### PR TITLE
refactor(compat): split compat.json into per-surface parts (P5-NEW-B)

### DIFF
--- a/compat/_meta.json
+++ b/compat/_meta.json
@@ -1,0 +1,60 @@
+{
+  "compat-schema-version": "0.3",
+  "_comment": "Compat matrix per #1027. This file is the spec-driven inventory of every prop / style / API surface Pulp's React + DOM-lite consumers might use, mapped to its current implementation status. Status values: supported | partial | missing | wontfix. The 'mapsTo' field names the bridge / Yoga / Skia path the prop lowers to. The 'tests' field records validation references; legacy free-form test paths may coexist with typed routes such as semantic:<fixture-id>, visual:<fixture-id>, dom:<fixture-id>, behavior:<fixture-id>, unit:<test-id>, or cannot-validate:<tracking-id>. The audit was generated 2026-04-30 by walking three reference specs (Yoga via React Native Layout Props, React Native View / Text / Transform Style Props, and the most-used MDN CSS reference) and cross-referencing against four implementation surfaces: packages/pulp-react/src/prop-applier.ts (the @pulp/react switch), core/view/js/web-compat-style-decl.js (the DOM-lite CSS adapter), core/view/src/widget_bridge.cpp (the C++ bridge \u2014 251 register_function entries), and core/view/include/pulp/view/{view,geometry}.hpp (the Flex / View widget surface).",
+  "_audit": {
+    "_evidence_grace_until": "2026-05-22",
+    "generated": "2026-05-04",
+    "main_sha": "a5f4f5ac",
+    "spec_sources": {
+      "yoga": "https://www.yogalayout.dev/docs/styling \u2014 list cross-checked against https://reactnative.dev/docs/layout-props which mirrors the upstream Yoga API",
+      "rn_view": "https://reactnative.dev/docs/view-style-props",
+      "rn_text": "https://reactnative.dev/docs/text-style-props",
+      "rn_transform": "https://reactnative.dev/docs/transforms",
+      "rn_layout": "https://reactnative.dev/docs/layout-props",
+      "css": "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties \u2014 top ~150 commonly-used properties across layout, box-model, typography, color, transforms, flex/grid, opacity. Print, paged-media, and CSS-fonts loading specifics are out of scope.",
+      "canvas2d": "https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D \u2014 HTML Living Standard CanvasRenderingContext2D",
+      "html_element": "https://developer.mozilla.org/en-US/docs/Web/API/Element + HTMLElement attribute coverage, ARIA attributes, dataset, classList, the DocumentFragment shim"
+    },
+    "implementation_surfaces": [
+      "packages/pulp-react/src/prop-applier.ts",
+      "packages/pulp-react/src/host-config.ts",
+      "packages/pulp-react/src/intrinsics.ts",
+      "core/view/js/web-compat-style-decl.js",
+      "core/view/js/web-compat-element.js",
+      "core/view/js/web-compat-canvas.js",
+      "core/view/js/web-compat-document.js",
+      "core/view/src/widget_bridge.cpp",
+      "core/view/include/pulp/view/view.hpp",
+      "core/view/include/pulp/view/geometry.hpp",
+      "core/canvas/src/skia_canvas.cpp",
+      "core/canvas/platform/mac/cg_canvas.mm"
+    ],
+    "_notes_on_consumer_surfaces": "The same prop can have different status across consumer surfaces. 'css/*' tracks what core/view/js/web-compat-style-decl.js (the DOM-lite el.style adapter) routes; 'rn/*' tracks what packages/pulp-react/src/prop-applier.ts (the React renderer for @pulp/react JSX intrinsics) routes; 'yoga/*' tracks the underlying Yoga-shaped layout surface in core/view/include/pulp/view/geometry.hpp::FlexStyle; 'canvas2d/*' tracks the Canvas2D shim in web-compat-canvas.js paired with the canvas* family in widget_bridge.cpp + the Skia/CG backends in core/canvas/; 'html/*' tracks the DOM-lite Element / HTMLElement surface in web-compat-element.js + web-compat-document.js. Where a prop is supported by one consumer but not another, both are noted explicitly in 'notes'.",
+    "_changelog": {
+      "2026-04-30": "Initial population \u2014 361 entries across css/, rn/, yoga/. react/, html/, canvas2d/ stubbed. PR #1166.",
+      "2026-05-04": "Refresh after PRs #1167, #1169, #1173, #1174, #1291, #1297, #1344, #1345, #1347, #1348, #1353. Populated canvas2d/ (~60 entries) and html/ (~30 entries). Added rn/d, rn/viewBox, rn/fill, rn/stroke, rn/strokeWidth, rn/overlay (SvgPath + overlay-routing). Updated css/border, css/borderRadius, css/borderColor, css/fontFamily status to reflect per-attribute setter routing. Added css/_hover_pseudo for :hover stylesheet support.",
+      "2026-05-05": "pulp #1434 batch 4: React Native shorthand aliases marginHorizontal / marginVertical / paddingHorizontal / paddingVertical now fan out at the JS-side translators (web-compat-style-decl.js + prop-applier.ts) to the existing per-edge bridge setters. Reclassified rn/* + yoga/* entries from missing -> supported and added new css/* entries (4 new keys; css count 195 -> 199).",
+      "2026-05-06": "pulp #1545: yoga catalog work. Promoted yoga/flexBasis from partial -> supported after re-verifying YGNodeStyleSetFlexBasisPercent fires for 'NN%' strings end-to-end through the bridge (test [issue-1545] in test_widget_bridge.cpp). The 'content' keyword stays in unsupportedValues (Yoga itself does not expose it). yoga/boxSizing was also added as a placeholder entry but kept at status `missing` \u2014 the FlexStyle::box_sizing field + YGNodeStyleSetBoxSizing dispatch is a forward dependency on pulp #1516 (PR #1538) and will flip to `supported` once #1538 merges (yoga count stays at 53 + 1 placeholder = 54 total entries).",
+      "2026-05-06_1551": "pulp #1551 (Phase A3 Bundle 3 inside pulp #1434 umbrella): pure catalog add of 13 already-implemented css/* meta entries \u2014 `__StyleSheet`, `__matchMedia`, `__pseudo_active` / `__pseudo_disabled` / `__pseudo_focus` / `__pseudo_hover`, `__selector_child` / `__selector_class` / `__selector_descendant` / `__selector_id` / `__selector_tag`, `__setProperty_var`, `__var`. Documents existing wiring in `core/view/js/web-compat-document.js`, `web-compat-style-decl.js`, `css-parser.js` and `web-compat.js`. No code changes; +13 instant supported entries. css count 199 -> 212.",
+      "2026-05-06_1544": "pulp #1544: Added yoga/flex and yoga/flexFlow catalog entries documenting the unsupported CSS shorthand surface on the Yoga side (yoga count 53 -> 55). PR #1563.",
+      "2026-05-07": "pulp #1434 A4 Bundles 2-7: css NOT-IMPL closure. 30 entries flipped missing -> partial / noop / wontfix across animations tail (animationPlayState), logical-edge fan-out (margin/padding Block/Inline Start/End -- 7 entries), overflow per-axis + 3D (overflowX, overflowY, overflowWrap, perspective, perspectiveOrigin), text rendering tail (textIndent, verticalAlign, wordBreak, writingMode, scroll* -- 8), isolation + clipPath + mask + direction + mixBlendMode (6), and resize + fontVariant (2). New bridge fns: setTextIndent, setVerticalAlign, setWordBreak, setFontVariant. Extended setAnimation with the \"play_state\" control token. Synthetic __pseudo_classes_note flipped wontfix. Catalog css count holds at 212; missing -> 0.",
+      "2026-05-07_B2": "Phase B.2 visual accounting: bumped compat-schema-version to 0.3 so tests can carry typed validation routes; backfilled semantic Yoga fixture refs for the checked-in layout goldens without changing support status counts.",
+      "2026-05-07_W3css3": "pulp #1434 Wave 3 css.3 + Codex P1 audit follow-through on #1508. css/animationPlayState flipped partial \u2192 supported by adding View::tick_animations(dt) which honors the `paused` keyword (no-op when paused, advance-each-CssAnimation otherwise) \u2014 the playback driver pause/resume gap the previous A4 Bundle 2 entry had explicitly deferred. Prop-applier `animationPlayState` case added (was missing; only the JS shim path existed). Verified the two Codex P1 fixes from #1508 hold in the final form: (1) setAnimation(id, \"name\"|\"duration\"|... , value) control-token ABI is implemented in the bridge alongside the positional ABI so the JS shim's per-longhand calls land on the staged_animation slot rather than missing the keyframes registry, (2) animationDuration in prop-applier.ts dispatches to setAnimation/duration, not setTransitionDuration. css count holds at 212."
+    },
+    "counts": {
+      "css": 217,
+      "rn": 120,
+      "yoga": 56,
+      "react": 0,
+      "html": 59,
+      "canvas2d": 63,
+      "imports": 5
+    },
+    "changelog": {
+      "2026-05-07_W4css": "pulp Wave 4 css extensive \u2014 DIVERGE sweep. Drove the css surface from 128 PASS / 49 DIVERGE (60.4%) to 177 PASS / 0 DIVERGE (83.5%) in a single pass \u2014 the 35 non-PASS remainder is fully architectural (10 noop intentional stubs + 25 wontfix). Per-entry reclassifications follow the Wave 1 backgroundAttachment precedent: paint-time / architectural value-coverage caveats moved out of unsupportedValues into notes; status flipped partial -> supported when value-coverage is complete; partial-deferred-* used when a real subsystem (image loader, HarfBuzz, paint pipeline) is the gating block. Border family (5) arch-solid-only-pen; border-radius (2) arch-skia-rrect-single-radius; background family (5) arch-deferred-image-loader / arch-skia-no-conic-gradient / arch-single-bg; mask family (2) arch-paint-deferred; layout-length (2) arch-yoga-no-intrinsic-sizing + arch-no-calc-eval + single-level-cascade for em/rem; outline family (4) arch-numeric-only + arch-no-cascade-color + arch-paint-px-only; overflow (3) arch-scroll-via-scrollview + arch-axis-tied-overflow; display (1) arch-flex-only; enum cleanups (8) cursor / pointerEvents / textDecoration / userSelect / visibility / whiteSpace / fontStyle label trimming + arch caveats. Drift count: 7 -> 0 on css. css count holds at 212."
+    }
+  },
+  "react": {
+    "_note": "The @pulp/react reconciler surface (host-config.ts, prop-applier.ts) is captured under rn/* above (prop-applier covers ~70 props). This section is reserved for React-specific features that aren't single-prop entries: Suspense, ConcurrentMode, Profiler, error boundaries, refs, portals, hooks edge cases (useTransition, useDeferredValue, useId, useSyncExternalStore). As of 2026-05-04 the renderer is built on react-reconciler@0.31 and supports the basic function-component + useState + useEffect + useRef + useMemo / useCallback set; concurrent features are not exercised. File-issue follow-up: enumerate observed React features end-to-end and populate per-feature entries. Currently empty pending that audit."
+  }
+}

--- a/compat/canvas2d.json
+++ b/compat/canvas2d.json
@@ -1,0 +1,931 @@
+{
+  "canvas2d": {
+    "_note": "Populated 2026-05-04 from web-compat-canvas.js (~36 prototype methods + 7 attrs) crossed against widget_bridge.cpp's canvas* register_function entries (~47 funcs) and the Skia/CG backends in core/canvas/. Spec source: HTML Living Standard CanvasRenderingContext2D / https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D. The bridge layer is consistent across Skia (Linux/Windows) and CG (mac); divergences are noted per-entry. Heavy expansion landed in PR #1348 (pulp #1346 / #1322): save, restore, setTransform, translate, scale, rotate, globalAlpha, globalCompositeOperation, createLinearGradient, createRadialGradient, arc, arcTo, bezierCurveTo, quadraticCurveTo, rect, roundRect, ellipse, clip, fillText, strokeText. Skia gradient shape fills landed in #1353; CG counterpart in #1360 (merged 2026-05-03).",
+    "canvas2d/fillRect": {
+      "status": "supported",
+      "mapsTo": "web-compat-canvas.js: ctx.fillRect(x,y,w,h) -> _syncGlobalState + _applyFillStyle + canvasRect(id,x,y,w,h). Bridge `canvasRect` honors the active fillStyle / gradient via the use_active_style path (#968).",
+      "supportedValues": [
+        "any rectangle"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "PR #1348 fixed a typo where the JS was calling canvasFillRect (which never existed) \u2014 now correctly calls canvasRect.",
+      "issue": "1346"
+    },
+    "canvas2d/strokeRect": {
+      "status": "supported",
+      "mapsTo": "ctx.strokeRect -> _syncGlobalState + _syncLineState + _applyStrokeStyle + canvasStrokeRect.",
+      "supportedValues": [
+        "any rectangle"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Stroke gradients fall back to first stop's color (bridge has no stroke-gradient setter today).",
+      "issue": ""
+    },
+    "canvas2d/clearRect": {
+      "status": "supported",
+      "mapsTo": "ctx.clearRect -> canvasClearRect.",
+      "supportedValues": [
+        "any rectangle"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/beginPath": {
+      "status": "supported",
+      "mapsTo": "ctx.beginPath -> canvasBeginPath.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/closePath": {
+      "status": "supported",
+      "mapsTo": "ctx.closePath -> canvasClosePath.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/moveTo": {
+      "status": "supported",
+      "mapsTo": "ctx.moveTo -> canvasMoveTo.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/lineTo": {
+      "status": "supported",
+      "mapsTo": "ctx.lineTo -> canvasLineTo.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/rect": {
+      "status": "supported",
+      "mapsTo": "ctx.rect(x,y,w,h) -> moveTo + 4\u00d7 lineTo back to start (composes a closed subpath).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Path-construction op (no fill/stroke). Honors fill()/stroke()/clip() afterward. PR #1348.",
+      "issue": "1346"
+    },
+    "canvas2d/roundRect": {
+      "status": "supported",
+      "mapsTo": "ctx.roundRect(x,y,w,h,radii) -> canvasPathRoundRect(id, x, y, w, h, tl_x, tl_y, tr_x, tr_y, br_x, br_y, bl_x, bl_y) -> SkRRect::setRectRadii (Skia) / per-corner CGPath layout (CG). All five spec radii forms (number / [r] / [r1,r2] / [r1,r2,r3] / [r1,r2,r3,r4]) and elliptical {x,y} corners are normalized to 8 floats in the JS shim.",
+      "supportedValues": [
+        "uniform radius (number, or array[1])",
+        "two-value [horizontal, vertical] (array[2])",
+        "three-value [tl, tr=bl, br] (array[3])",
+        "four-value [tl, tr, br, bl] (array[4])",
+        "elliptical {x, y} corner objects in any slot"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [wave2-canvas2d]"
+      ],
+      "notes": "PR #1348 + Wave 2 cheap wiring \u2014 confirmed all five radii forms thread through to SkRRect::setRectRadii with 4 distinct SkVector corners.",
+      "issue": "1346"
+    },
+    "canvas2d/arc": {
+      "status": "supported",
+      "mapsTo": "ctx.arc(cx,cy,r,start,end,anticlockwise) -> path-mode emit as cubic-bezier segments via canvasMoveTo + canvasCubicTo. Bridge has immediate-mode canvasArc but no path-mode arc primitive.",
+      "supportedValues": [
+        "any arc"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1526]"
+      ],
+      "notes": "PR #1348. The bezier approximation is per-quadrant (k = (4/3)\u00b7tan(\u03b8/4)); fidelity is visually exact for fill/stroke/clip use cases. Wave 1 drift cleanup \u2014 partial \u2192 supported (PR #1348 wired path-mode arc as cubic-bezier segments via canvasPathArc; bezier approximation is per-quadrant, visually exact for fill/stroke/clip use cases).",
+      "issue": "1346"
+    },
+    "canvas2d/arcTo": {
+      "status": "supported",
+      "mapsTo": "ctx.arcTo(x1,y1,x2,y2,r) -> canvasPathArcTo. Skia: SkPath::arcTo(p1, p2, radius) \u2014 closed-form tangent-arc geometry. CG: CGPathAddArcToPoint(p1, p2, radius). pulp #1521 replaced the conservative lineTo-only fallback with the spec-compliant radius-tangent computation.",
+      "supportedValues": [
+        "arcTo(x1, y1, x2, y2, radius) \u2014 geometrically correct on Skia + CG"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1521 \u2014 native SkPath::arcTo (Skia) / CGPathAddArcToPoint (CG). Wave 4 c2d cleanup: catalog reconciled to match wired implementation (prior PR #1348 lineTo fallback was replaced by #1521).",
+      "issue": ""
+    },
+    "canvas2d/bezierCurveTo": {
+      "status": "supported",
+      "mapsTo": "ctx.bezierCurveTo -> canvasCubicTo.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1526]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/quadraticCurveTo": {
+      "status": "supported",
+      "mapsTo": "ctx.quadraticCurveTo -> canvasQuadTo.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1526]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/ellipse": {
+      "status": "supported",
+      "mapsTo": "ctx.ellipse(cx,cy,rx,ry,rotation,start,end,anticlockwise) -> canvasPathEllipse(id, cx, cy, rx, ry, rotation, start, end, anticlockwise) -> SkPathBuilder::arcTo + SkMatrix::preRotate (Skia) / CGPathAddArc + CGAffineTransform (CG). PR #1521 wired native arc geometry; rotation is honoured via a temporary oval-aligned arc rotated through (cx, cy).",
+      "supportedValues": [
+        "axis-aligned ellipses",
+        "non-zero rotation",
+        "anticlockwise sweep"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [wave2-canvas2d]"
+      ],
+      "notes": "PR #1521 + Wave 2 cheap wiring \u2014 confirmed rotation threads through SkMatrix and CGAffineTransform.",
+      "issue": "1346"
+    },
+    "canvas2d/fill": {
+      "status": "supported",
+      "mapsTo": "ctx.fill(fillRule?) -> _syncGlobalState + _applyFillStyle + canvasFillPath(id, fillRule). The fillRule int (0 = nonzero, 1 = evenodd) threads through canvas_widget.cpp into Canvas::fill_current_path(FillRule) -> SkPath::setFillType (Skia) / CGContextEOFillPath vs CGContextFillPath (CG).",
+      "supportedValues": [
+        "default (nonzero) fill",
+        "evenodd fill rule"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [wave2-canvas2d]"
+      ],
+      "notes": "Wave 2 cheap wiring \u2014 added FillRule enum to canvas.hpp, plumbed cmd.int_val from widget_bridge through CanvasWidget::paint into both Skia (SkPathFillType::kEvenOdd) and CG (CGContextEOFillPath) backends. Pre-Wave-2 the rule was read by widget_bridge but discarded by canvas_widget.",
+      "issue": ""
+    },
+    "canvas2d/stroke": {
+      "status": "supported",
+      "mapsTo": "ctx.stroke -> _syncGlobalState + _syncLineState + _applyStrokeStyle + canvasStrokePath.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/clip": {
+      "status": "supported",
+      "mapsTo": "ctx.clip(fillRule?) -> canvasClip(id, fillRule). The fillRule int (0 = nonzero, 1 = evenodd) threads through canvas_widget.cpp into Canvas::clip(FillRule) -> SkPath::setFillType + SkCanvas::clipPath (Skia) / CGContextEOClip vs CGContextClip (CG).",
+      "supportedValues": [
+        "default (nonzero) clip",
+        "evenodd clip rule"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [wave2-canvas2d]"
+      ],
+      "notes": "Backed by SkCanvas::clipPath. (issue-896 added canvasClip; older canvasClipRect is the rect-only path.) Wave 2 cheap wiring \u2014 added FillRule enum to canvas.hpp, plumbed cmd.int_val from widget_bridge through CanvasWidget::paint into both Skia (SkPathFillType::kEvenOdd) and CG (CGContextEOClip) backends.",
+      "issue": ""
+    },
+    "canvas2d/isPointInPath": {
+      "status": "supported",
+      "mapsTo": "ctx.isPointInPath(x, y[, fillRule]) -> JS-side ray-cast against the path mirror. Each path-construction method (moveTo / lineTo / rect / roundRect / arc / arcTo / ellipse / bezierCurveTo / quadraticCurveTo / closePath) appends to `_pathSubpaths` in addition to forwarding to the bridge. Curve segments sample to ~16 line pieces \u2014 accurate enough for spec-compliant hit testing.",
+      "supportedValues": [
+        "isPointInPath(x, y) on rect / lineTo polygon / arc / curve paths",
+        "rolls back across save / restore via the path-mirror snapshot"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1527]"
+      ],
+      "notes": "pulp #1527 bridge-thin gap-fill. Synchronous return \u2014 no bridge round-trip; the bridge owns the canonical SkPath but it's not queryable from JS until paint time. Wave 1 paperwork \u2014 synchronous return; no bridge round-trip; bridge-thin gap-fill (pulp #1527). arch-path2d-deferred \u2014 Path2D-object first argument requires a separate JS shim object (pulp #1527) that maintains its own subpath mirror. The 2-arg form (x, y) using the canvas's current path is fully wired and matches the spec semantics for the most-used invocation pattern.",
+      "issue": "1527"
+    },
+    "canvas2d/isPointInStroke": {
+      "status": "supported",
+      "mapsTo": "ctx.isPointInStroke(x, y) -> JS-side closest-point-on-segment distance check against `_pathSubpaths`. Returns true when the test point's distance to any path segment is \u2264 lineWidth / 2.",
+      "supportedValues": [
+        "lineWidth-aware hit test on straight + curve segments",
+        "respects later assignments to ctx.lineWidth"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1527]"
+      ],
+      "notes": "pulp #1527 bridge-thin gap-fill. Pairs with isPointInPath; uses the same JS path mirror. Wave 1 paperwork \u2014 pairs with isPointInPath; same JS path mirror (pulp #1527). arch-cap-join-approximated \u2014 lineCap (square) / lineJoin (miter spikes) geometry are approximated as round caps in the JS-side polyline mirror. Spec-compliance for sub-pixel hit-testing on stroke join geometry would need a real path stroker. The common case (round caps + bevel/round joins) works correctly.",
+      "issue": "1527"
+    },
+    "canvas2d/save": {
+      "status": "supported",
+      "mapsTo": "ctx.save -> canvasSave (Skia/CG canvas state stack).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "PR #1348. Without save/restore, FilterBank's first ctx.save() threw TypeError and aborted the frame.",
+      "issue": "1346"
+    },
+    "canvas2d/restore": {
+      "status": "supported",
+      "mapsTo": "ctx.restore -> canvasRestore.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "PR #1348.",
+      "issue": "1346"
+    },
+    "canvas2d/translate": {
+      "status": "supported",
+      "mapsTo": "ctx.translate(x,y) -> canvasTranslate.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "PR #1348.",
+      "issue": "1346"
+    },
+    "canvas2d/scale": {
+      "status": "supported",
+      "mapsTo": "ctx.scale(sx,sy) -> canvasScale.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "PR #1348.",
+      "issue": "1346"
+    },
+    "canvas2d/rotate": {
+      "status": "supported",
+      "mapsTo": "ctx.rotate(radians) -> canvasRotate.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "PR #1348.",
+      "issue": "1346"
+    },
+    "canvas2d/setTransform": {
+      "status": "supported",
+      "mapsTo": "ctx.setTransform(a,b,c,d,e,f) \u2014 also accepts a single DOMMatrix-like arg, shim unpacks. -> canvasSetTransform.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "PR #1348. resetTransform aliases to setTransform(1,0,0,1,0,0).",
+      "issue": "1346"
+    },
+    "canvas2d/resetTransform": {
+      "status": "supported",
+      "mapsTo": "ctx.resetTransform -> canvasSetTransform(id, 1, 0, 0, 1, 0, 0). Also resets the JS-side _currentTransform mirror (pulp #1527) so getTransform reads back the identity.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "PR #1348. Mirror update added in pulp #1527.",
+      "issue": "1346"
+    },
+    "canvas2d/getTransform": {
+      "status": "supported",
+      "mapsTo": "ctx.getTransform() -> returns a DOMMatrix-shaped object reflecting the JS-mirrored 2D affine transform. The shim tracks `_currentTransform` via translate / scale / rotate / setTransform / transform / save / restore so the read is synchronous (no bridge round-trip; the bridge replays draws at paint time and has no queryable 'current matrix' from JS). Per HTML5 Canvas spec, getTransform() returns a NEW DOMMatrix per call (a snapshot \u2014 mutating it does not affect the live ctx). DOMMatrix mutation methods (multiplySelf, scaleSelf, etc.) on the returned object are not exposed because they would only mutate the snapshot, not the canvas \u2014 same outcome as on the standard browser surface.",
+      "supportedValues": [
+        "a, b, c, d, e, f (live)",
+        "m11/m12/m21/m22/m41/m42 DOMMatrix aliases",
+        "is2D, isIdentity flags",
+        "toFloat32Array / toFloat64Array readers",
+        "multiplySelf(other) \u2014 right-multiply + chain",
+        "scaleSelf(sx, sy?) \u2014 post-multiply scale",
+        "rotateSelf(angle) \u2014 post-multiply rotation (radians)",
+        "translateSelf(tx, ty) \u2014 post-multiply translation",
+        "inverse() \u2014 return inverted copy (throws on singular)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1527][dommatrix-mutators]"
+      ],
+      "notes": "DIVERGE\u2192PASS sweep \u2014 clarified that snapshot semantics are spec-compliant (HTML5 Canvas spec: getTransform() returns a NEW DOMMatrix); DOMMatrix mutation methods on a snapshot wouldn't affect the canvas anyway. pulp #1527 bridge-thin gap-fill. Wave-5 follow-up audit (post-PR #1616 sweep): walked back to partial. `_PulpCanvasMatrix` (web-compat-canvas.js) has `a/b/c/d/e/f` getters and `is2D`/`isIdentity` flags but does NOT implement DOMMatrix mutators like `multiplySelf` / `scaleSelf` / `inverse()`. Standard DOM code that does `ctx.getTransform().multiplySelf(other)` will throw at runtime. PR #1527 followup: DOMMatrix mutator methods (multiplySelf / scaleSelf / rotateSelf / translateSelf / inverse) now implemented on the snapshot. Snapshot semantics preserved per HTML5 spec \u2014 mutating the returned matrix does NOT affect the live ctx; mutators return `this` for chaining; inverse() returns a NEW matrix (throws TypeError on singular).",
+      "issue": "1527"
+    },
+    "canvas2d/transform": {
+      "status": "supported",
+      "mapsTo": "ctx.transform(a,b,c,d,e,f) \u2014 multiplies CURRENT transform; bridge only exposes replace (setTransform), not concat. Pure-translation matrices (a===1, b===0, c===0, d===1) fall through to canvasTranslate; everything else is a no-op.",
+      "supportedValues": [
+        "pure-translation matrices",
+        "arbitrary concat (rotate/scale/skew composed onto existing transform)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1348][codex-p1]"
+      ],
+      "notes": "PR #1348. File a follow-up if a plugin needs strict concat. Wave 1 paperwork \u2014 strict concat semantics deferred (PR #1348); pure-translation fast path covers the common case. Wired in PR #1701 \u2014 ctx.transform() forwards the composed matrix M' = M * given to canvasSetTransform; JS-side mirror and bridge state stay in sync. Verified via [view][canvas2d][issue-1348][codex-p1] tests.",
+      "issue": "1346"
+    },
+    "canvas2d/fillText": {
+      "status": "supported",
+      "mapsTo": "ctx.fillText(text,x,y,maxWidth) -> _syncGlobalState + _syncShadowState + _syncFilterState + _syncDirectionState + _syncTextState + _applyFillStyle + canvasFillText(id, text, x, y, size, color, maxWidth). pulp #1525 plumbed maxWidth end-to-end (Skia: SkMatrix::Scale around the origin; CG: CGContextScaleCTM). pulp Wave 3 c2d.6 routes gradient/pattern fillStyle through current_fill_paint() on Skia. pulp #1666 \u2014 CoreGraphicsCanvas::fill_text now switches to kCGTextClip on the glyph fills then calls fill_with_active_paint(), so the active gradient (set via set_fill_gradient_linear/_radial/_two_circles) paints the glyphs on the CG path too.",
+      "supportedValues": [
+        "fillText(text, x, y) \u2014 solid colour fillStyle",
+        "fillText(text, x, y, maxWidth) \u2014 squeezed via SkMatrix::Scale (Skia) / CGContextScaleCTM (CG)",
+        "gradient fillStyle on Skia (shader flows onto glyph paint via current_fill_paint)",
+        "gradient fillStyle on CoreGraphics (kCGTextClip + CGContextDrawLinearGradient/Radial inside the glyph clip)",
+        "CanvasPattern fillStyle on Skia (SkShader::MakeImage)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas.cpp [issue-1666]",
+        "test/test_widget_bridge.cpp [wave2-canvas2d]"
+      ],
+      "notes": "pulp #1525 \u2014 maxWidth plumbed end-to-end. pulp Wave 3 c2d.6 \u2014 gradient/pattern fillStyle routes through current_fill_paint() on Skia. pulp #1666 \u2014 CoreGraphics path now handles gradient fillStyle via kCGTextClip + fill_with_active_paint(). CG pattern fillStyle on glyphs is a separate sub-feature tracked under canvas2d/createPattern follow-ups.",
+      "issue": ""
+    },
+    "canvas2d/strokeText": {
+      "status": "supported",
+      "mapsTo": "ctx.strokeText(text, x, y, maxWidth?) -> canvasStrokeText -> SkiaCanvas::stroke_text builds an SkPaint via make_stroke_paint() (which sets SkPaint::kStroke_Style) and draws the SkShaper / per-glyph SkTextBlob with that paint. Honors line_width, lineJoin, lineCap, miterLimit, strokeStyle (incl. patterns/gradients), and shadow filter.",
+      "supportedValues": [
+        "true stroked-glyph rendering (kStroke_Style)",
+        "maxWidth squeeze",
+        "lineWidth, lineJoin, lineCap, miterLimit",
+        "stroke patterns / gradients via _applyStrokeStyle"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [wave2-canvas2d]"
+      ],
+      "notes": "PR #1525 + Codex P2 follow-up \u2014 make_stroke_paint() sets kStroke_Style and apply_stroke_state() propagates sticky stroke state. Wave 2 cheap wiring \u2014 confirmed end-to-end and bumped from partial -> supported.",
+      "issue": ""
+    },
+    "canvas2d/measureText": {
+      "status": "supported",
+      "mapsTo": "ctx.measureText(text) \u2014 when canvasMeasureText is available returns the bridge-side TextMetrics; else returns a coarse char-width estimate.",
+      "supportedValues": [
+        "width",
+        "actualBoundingBoxLeft/Right/Ascent/Descent",
+        "fontBoundingBoxAscent/Descent"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "issue-916. The shim guarantees a non-null TextMetrics object even on older hosts where canvasMeasureText isn't registered (returns zero-filled fields based on font px size).",
+      "issue": ""
+    },
+    "canvas2d/drawImage": {
+      "status": "supported",
+      "mapsTo": "ctx.drawImage(img, ...) -> canvasDrawImage(id, src, dx, dy, dw, dh [, sx, sy, sw, sh]). Supports the 3-arg, 5-arg, and 9-arg signatures. pulp #1737 \u2014 9-arg source-rect form (sprite-sheet slicing) is now plumbed end-to-end: JS shim passes sx/sy/sw/sh as args[6..9]; bridge sets has_source_rect on the CanvasDrawCmd; canvas widget routes through Canvas::draw_image_from_file_rect (Skia: SkCanvas::drawImageRect with src+dst).",
+      "supportedValues": [
+        "drawImage(img, dx, dy)",
+        "drawImage(img, dx, dy, dw, dh)",
+        "drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh) \u2014 sprite-sheet slicing"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1737]"
+      ],
+      "notes": "pulp #1737 \u2014 9-arg source-rect form wired: Canvas + Skia + RecordingCanvas got draw_image_from_*_rect overrides; CanvasDrawCmd gained has_source_rect + uses x2/y2/x3/y3 for sx/sy/sw/sh.",
+      "issue": ""
+    },
+    "canvas2d/getImageData": {
+      "status": "supported",
+      "mapsTo": "ctx.getImageData(x,y,w,h) -> canvasGetImageData (returns base64 RGBA blob, shim decodes to Uint8ClampedArray).",
+      "supportedValues": [
+        "any rect from a rasterized canvas"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-916]"
+      ],
+      "notes": "issue-916. The base64 round-trip avoids passing typed arrays across the JS bridge. Wave 1 paperwork \u2014 base64 round-trip avoids typed-array bridge cost (issue-916). arch-recordingcanvas-by-design \u2014 RecordingCanvas returns zero-filled pixels by design (it records draw commands; no rasterization). The Skia + CoreGraphics backends both return real pixel data.",
+      "issue": ""
+    },
+    "canvas2d/putImageData": {
+      "status": "supported",
+      "mapsTo": "ctx.putImageData(imgdata, dx, dy [, dirtyX, dirtyY, dirtyW, dirtyH]) -> base64-encodes and calls canvasPutImageData. pulp #1737 \u2014 7-arg sub-rect form is now plumbed: the JS shim slices the (dirtyX, dirtyY, dirtyW, dirtyH) sub-rect from imageData.data row-by-row, clamps the rect to source bounds (per HTML5 spec), short-circuits to no-op on empty rect, and calls the same canvasPutImageData bridge fn with the sliced buffer + smaller dimensions + adjusted dst (dx + dirtyX, dy + dirtyY).",
+      "supportedValues": [
+        "putImageData(img, dx, dy)",
+        "putImageData(img, dx, dy, dirtyX, dirtyY, dirtyW, dirtyH) \u2014 sub-rect form"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1737]"
+      ],
+      "notes": "pulp #1737 \u2014 sub-rect form sliced in JS shim (no bridge contract change). Empty dirty rect is a no-op per HTML5 spec; negative dirtyW/dirtyH are normalised; out-of-bounds dirty rect is clamped to source bounds.",
+      "issue": ""
+    },
+    "canvas2d/createLinearGradient": {
+      "status": "supported",
+      "mapsTo": "ctx.createLinearGradient(x0,y0,x1,y1) -> returns a JS-side CanvasGradient object with addColorStop(); the bridge picks it up on the next fill via canvasSetLinearGradient.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "PR #1348. CG (mac) gradient-shape fill landed in #1359/#1360 (merged 2026-05-03).",
+      "issue": "964"
+    },
+    "canvas2d/createRadialGradient": {
+      "status": "supported",
+      "mapsTo": "ctx.createRadialGradient(x0,y0,r0,x1,y1,r1) -> CanvasGradient with kind='radial'. Both circles are wired through to the backend: Skia routes through SkGradientShader::MakeTwoPointConical, CG routes through CGContextDrawRadialGradient(start_centre, start_radius, end_centre, end_radius). The bridge dispatches via canvasSetRadialGradientTwoCircles when both circles differ.",
+      "supportedValues": [
+        "centre-bloom (x0===x1, y0===y1, r0===0)",
+        "true two-circle radial with offset / sized inner circle"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas.cpp [canvas][cg][issue-1524]",
+        "test/test_canvas2d_shim.cpp [view][canvas2d][issue-1524]"
+      ],
+      "notes": "pulp #1524. Two-circle support: Skia MakeTwoPointConical, CG full CGContextDrawRadialGradient with both circles. Inner circle (x0,y0,r0) packed in CanvasDrawCmd as (x, y, extra), outer (x1,y1,r1) as (x2, y2, w).",
+      "issue": "1524"
+    },
+    "canvas2d/createConicGradient": {
+      "status": "supported",
+      "mapsTo": "ctx.createConicGradient(startAngle, x, y) -> CanvasGradient with _kind='conic'; flushed via canvasSetConicGradient when assigned to fillStyle. Skia routes through SkGradientShader::MakeSweep (real sweep). CG software-rasterises a CGImage of the active clip's bounding box (per-pixel atan2 sweep + colour-stop interpolation) and paints it via CGContextDrawImage.",
+      "supportedValues": [
+        "Skia backend: real conic sweep with multiple stops",
+        "CG backend: software-rasterised conic with multiple stops (atan2 sweep + linear interpolation between stops, premultiplied RGBA8)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas.cpp [canvas][cg][issue-1524]",
+        "test/test_canvas2d_shim.cpp [issue-1434][bridge-thin]"
+      ],
+      "notes": "pulp #1524. Skia uses MakeSweep; CG falls back to a software rasteriser that rebuilds the conic CGImage when the clip-bounding-box changes (caches across repeated fills with the same clip).",
+      "issue": "1524"
+    },
+    "canvas2d/createPattern": {
+      "status": "supported",
+      "mapsTo": "ctx.createPattern(image, repetition) -> CanvasPattern handle, flushed via canvasSetFillPattern / canvasSetStrokePattern. Skia routes through SkShader::MakeImage with SkTileMode per axis (real tiled fill); CG routes through CGPatternCreate + CGPatternCallbacks (image-tile draw callback) and CGContextSetFillPattern.",
+      "supportedValues": [
+        "repeat",
+        "repeat-x",
+        "repeat-y",
+        "no-repeat"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas.cpp [canvas][cg][issue-1524]",
+        "test/test_canvas2d_shim.cpp [issue-1434][bridge-thin]"
+      ],
+      "notes": "pulp #1524. Skia uses SkShader::MakeImage; CG uses CGPatternCreate with a draw callback that emits one tile via CGContextDrawImage. `no_repeat` axes blow up the tile step beyond the clip bbox so only the seed tile lands. Image source decoded via ImageIO (CGImageSourceCreateWithData / WithURL) for both file paths and `data:` URLs. Note: CG stroke patterns are still a no-op (strokes continue with stroke_color_) \u2014 file a follow-up if a CG-targeted plugin needs tiled stroke patterns; this entry is for the createPattern fill surface.",
+      "issue": "1524"
+    },
+    "canvas2d/addColorStop": {
+      "status": "supported",
+      "mapsTo": "CanvasGradient.addColorStop(offset, color) \u2014 accumulates stops on the JS-side gradient object; flushed to bridge via canvasSetLinearGradient / canvasSetRadialGradient when the gradient is assigned to fillStyle.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": "964"
+    },
+    "canvas2d/setLineDash": {
+      "status": "supported",
+      "mapsTo": "ctx.setLineDash(pattern) -> canvasSetLineDash(id, pattern, lineDashOffset). Bridge does the HTML5-spec odd-length array doubling (`[5, 10, 15]` \u2192 `[5, 10, 15, 5, 10, 15]`) in widget_bridge.cpp::canvasSetLineDash before recording the command. Negative / non-finite values drop the pattern (graceful solid-stroke fallback per spec's implementation-defined clause).",
+      "supportedValues": [
+        "even-length pattern arrays",
+        "odd-length pattern arrays (spec-doubled by the bridge)",
+        "lineDashOffset phase arg"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "DIVERGE\u2192PASS sweep \u2014 the catalog note about \"shim takes pattern verbatim; bridge handles the spec-doubling\" was describing the architecture, not a gap. The end-to-end behavior is spec-compliant. Wave 1 paperwork \u2014 see SKILL canvas2d gotchas; HTML5-spec odd-length doubling is performed internally by canvasSetLineDash before recording.",
+      "issue": ""
+    },
+    "canvas2d/getLineDash": {
+      "status": "supported",
+      "mapsTo": "Returns a copy of the current pattern (per spec).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/lineDashOffset": {
+      "status": "supported",
+      "mapsTo": "ctx.lineDashOffset getter/setter pair (Wave 4 c2d cleanup). Setting re-pushes the active dash pattern via canvasSetLineDash with the new phase, so mutating between draws shifts the stroke phase without requiring a redundant setLineDash call. Non-finite values (NaN, Infinity) are ignored per HTML5 spec.",
+      "supportedValues": [
+        "lineDashOffset assignment between draws (re-flushes the dash pattern with new phase)",
+        "lineDashOffset read (returns the most-recently-assigned value)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1526]"
+      ],
+      "notes": "Wave 4 c2d cleanup \u2014 defineProperty getter/setter pair re-flushes dash on assignment. Pre-Wave-4 the field tracked locally but only sent on the next setLineDash, so phase mutations between draws were silently dropped.",
+      "issue": ""
+    },
+    "canvas2d/fillStyle": {
+      "status": "supported",
+      "mapsTo": "Settable to a CSS-color string OR a CanvasGradient object OR a CanvasPattern object. Solid colors push via canvasSetFillColor; gradients push via canvasSetLinearGradient / canvasSetRadialGradient on the next draw; patterns push via canvasSetFillPattern (handled by `_applyFillStyle` in web-compat-canvas.js).",
+      "supportedValues": [
+        "CSS color strings",
+        "CanvasGradient (linear, radial, conic)",
+        "CanvasPattern (via createPattern)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "DIVERGE\u2192PASS sweep \u2014 pattern path was already wired (createPattern in PASS list, _applyFillStyle dispatches canvasSetFillPattern); the catalog had a stale gap entry from before pulp #1434's createPattern bridge work. Wave 1 paperwork \u2014 CanvasPattern wiring confirmed via createPattern + _applyFillStyle / canvasSetFillPattern (#1625 finding).",
+      "issue": ""
+    },
+    "canvas2d/strokeStyle": {
+      "status": "supported",
+      "mapsTo": "Settable to a CSS-color string OR a CanvasGradient OR a CanvasPattern. pulp Wave 3 c2d.7 \u2014 bridge exposes canvasSetStrokeLinearGradient / canvasSetStrokeRadialGradient / canvasSetStrokeRadialGradientTwoCircles / canvasSetStrokeConicGradient / canvasSetStrokePattern; the JS shim routes gradients per kind in _applyStrokeStyle. Skia populates stroke_shader_; apply_stroke_state attaches it to SkPaint via setShader. pulp #1666 \u2014 CoreGraphicsCanvas now implements set_stroke_gradient_linear/_radial/_two_circles/_conic + a stroke_with_active_paint() helper that builds CGGradientRef from the stops, calls CGContextReplacePathWithStrokedPath + CGContextClip, then CGContextDrawLinearGradient/Radial inside the clip. All stroke entry points (stroke_rect, stroke_rounded_rect, stroke_circle, stroke_arc, stroke_line, stroke_path, stroke_current_path, stroke_text via CTFontCreatePathForGlyph) route through that helper when has_stroke_gradient_ is set.",
+      "supportedValues": [
+        "CSS color strings",
+        "CanvasGradient (linear, radial, two-circle radial) on stroke (Skia + CoreGraphics)",
+        "CanvasGradient (conic) on stroke (Skia)",
+        "CanvasPattern on stroke (Skia)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas.cpp [issue-1666]"
+      ],
+      "notes": "pulp Wave 3 c2d.7 \u2014 stroke gradients wired through dedicated setters. Wave 4 c2d cleanup: catalog reconciled to match wired implementation. PR #1643 added gradient stroke shaders on Skia. pulp #1666 \u2014 added native CG stroke gradient implementation (linear/radial/two-circle) using CGContextReplacePathWithStrokedPath + CGContextDrawLinearGradient/Radial. CG conic stroke + CG pattern stroke fall back to first-stop solid; tracked as separate follow-ups under canvas2d/createConicGradient + canvas2d/createPattern.",
+      "issue": ""
+    },
+    "canvas2d/lineWidth": {
+      "status": "supported",
+      "mapsTo": "Tracked locally; pushed to bridge via canvasSetLineWidth on the next stroke().",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/lineCap": {
+      "status": "supported",
+      "mapsTo": "Locally tracked; flushed via canvasSetLineCap on next stroke (idempotent: only pushes when value changed).",
+      "supportedValues": [
+        "butt",
+        "round",
+        "square"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1526]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/lineJoin": {
+      "status": "supported",
+      "mapsTo": "Locally tracked; flushed via canvasSetLineJoin on next stroke.",
+      "supportedValues": [
+        "miter",
+        "round",
+        "bevel"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1526]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/miterLimit": {
+      "status": "supported",
+      "mapsTo": "ctx.miterLimit -> canvasSetMiterLimit (web-compat-canvas.js _syncLineState). Sticky stroke state. Skia honours via SkPaint::setStrokeMiter; CG via CGContextSetMiterLimit. Spec: assigning \u2264 0 / NaN / Infinity is silently ignored (validated at the shim level).",
+      "supportedValues": [
+        "any positive finite number",
+        "spec default = 10"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1434][bridge-thin]"
+      ],
+      "notes": "pulp #1434 bridge-thin gap-fill. Side note: this PR also wired SkPaint::setStrokeJoin + setStrokeCap from line_join_/line_cap_ \u2014 those were stored but never applied on Skia before.",
+      "issue": "1434"
+    },
+    "canvas2d/globalAlpha": {
+      "status": "supported",
+      "mapsTo": "Locally tracked; flushed via canvasSetGlobalAlpha on the next draw.",
+      "supportedValues": [
+        "[0, 1]"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1526]"
+      ],
+      "notes": "PR #1348.",
+      "issue": "1346"
+    },
+    "canvas2d/globalCompositeOperation": {
+      "status": "supported",
+      "mapsTo": "Locally tracked; flushed via canvasGlobalCompositeOperation OR canvasSetBlendMode on the next draw.",
+      "supportedValues": [
+        "source-over",
+        "source-in",
+        "source-out",
+        "source-atop",
+        "destination-over",
+        "destination-in",
+        "destination-out",
+        "destination-atop",
+        "lighter",
+        "copy",
+        "xor",
+        "multiply",
+        "screen",
+        "overlay",
+        "darken",
+        "lighten",
+        "color-dodge",
+        "color-burn",
+        "hard-light",
+        "soft-light",
+        "difference",
+        "exclusion",
+        "hue",
+        "saturation",
+        "color",
+        "luminosity"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1526]"
+      ],
+      "notes": "PR #1348. Both backends now honor every value: Skia handles them via SkBlendMode; CG via CGContextSetBlendMode (pulp #1371 fixed a silent no-op in CoreGraphicsCanvas::set_blend_mode and added pixel-level coverage in test_canvas.cpp).",
+      "issue": "1346"
+    },
+    "canvas2d/font": {
+      "status": "supported",
+      "mapsTo": "Locally tracked; the shim's _parseFontShorthand walks the full CSS font shorthand ([style] [variant] [weight] [stretch] <size>[/<lineHeight>] <family>) and dispatches canvasSetFontFull(id, family, size, weight, slant, letterSpacing) when the host registered it (post pulp #1434), falling back to canvasSetFont(id, family, size) otherwise. Skia honours weight + slant via SkFontStyle; CG falls through to family + size.",
+      "supportedValues": [
+        "'<size>px <family>'",
+        "'<weight> <size>px <family>' (e.g. 'bold 14px Inter')",
+        "'<style> <size>px <family>' (e.g. 'italic 14px Inter')",
+        "'<style> <weight> <size>px <family>'",
+        "'<style> <variant> <weight> <size>px/<lineHeight> <family>' (full shorthand)",
+        "weight keywords: normal/bold/bolder/lighter",
+        "weight numerics: 100..900 (3-digit)",
+        "style keywords: normal/italic/oblique",
+        "stretch keywords: ultra-condensed..ultra-expanded (parsed, dropped)",
+        "lineHeight: number / length / 'normal' (parsed, ignored per Canvas2D spec \u2014 canvas uses the font's own line metrics)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1434]"
+      ],
+      "notes": "pulp #1434 expanded shim parser to full CSS font shorthand. Family names quoted as 'Inter' or \"Inter\" are unwrapped; comma-separated lists are passed verbatim. font-variant 'small-caps' is the ONLY genuine gap and is architecturally tied: Canvas::set_font_full has no variant field and Skia/CG canvas font pipelines don't expose OpenType variation axes at this layer. Per #1657 discipline this stays as DIVERGE (honest signal of a real value-gap) rather than being moved to notes \u2014 the gap IS real and consumers should know. Reclassification would require either (a) extending Canvas::set_font to carry variant flags, or (b) adapter-level architectural-exclusion support. arch-skia-cg-no-small-caps \u2014 font-variant 'small-caps' is parsed and tracked but Skia/CG canvas pipeline doesn't honour it (Canvas::set_font_full has no variant field). Architectural \u2014 full small-caps rendering would need OpenType glyph substitution which neither backend exposes through the canvas API. The other shorthand fields (size, family, style, weight) all work.",
+      "issue": "1434"
+    },
+    "canvas2d/textAlign": {
+      "status": "supported",
+      "mapsTo": "Locally tracked; flushed via canvasSetTextAlign on next text draw.",
+      "supportedValues": [
+        "left",
+        "right",
+        "center",
+        "start",
+        "end"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1526]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/textBaseline": {
+      "status": "supported",
+      "mapsTo": "Locally tracked; flushed via canvasSetTextBaseline.",
+      "supportedValues": [
+        "top",
+        "hanging",
+        "middle",
+        "alphabetic",
+        "ideographic",
+        "bottom"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1526]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/imageSmoothingEnabled": {
+      "status": "supported",
+      "mapsTo": "ctx.imageSmoothingEnabled -> canvasSetImageSmoothing (web-compat-canvas.js _syncImageSmoothingState, flushed before drawImage). Skia translates to SkSamplingOptions(kLinear/kNearest); CG to CGContextSetInterpolationQuality(kCGInterpolationLow/None).",
+      "supportedValues": [
+        "true (smoothed bilinear/bicubic by default)",
+        "false (nearest-neighbour, pixel-art preservation)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1434][bridge-thin]"
+      ],
+      "notes": "pulp #1434 bridge-thin gap-fill. Spec defaults match Skia/CG defaults so unmodified callers see no change.",
+      "issue": "1434"
+    },
+    "canvas2d/imageSmoothingQuality": {
+      "status": "supported",
+      "mapsTo": "ctx.imageSmoothingQuality -> canvasSetImageSmoothing 3rd arg. Skia: low=kLinear, medium=kLinear+mipmap, high=Mitchell cubic. CG: low/medium/high -> kCGInterpolationLow/Medium/High. Unknown strings coerce to 'low'.",
+      "supportedValues": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1434][bridge-thin]"
+      ],
+      "notes": "pulp #1434 bridge-thin gap-fill.",
+      "issue": "1434"
+    },
+    "canvas2d/direction": {
+      "status": "supported",
+      "mapsTo": "ctx.direction -> canvasSetDirection (web-compat-canvas.js _syncDirectionState, flushed before fillText/strokeText). Skia: SkShaper leftToRight flag flipped per direction (RTL emits glyphs in visual order via HarfBuzz). Stored on the canvas state and consumed by both fill_text() and recording capture. inherit currently maps to ltr until per-View writing-direction lookup lands (#1506).",
+      "supportedValues": [
+        "ltr (default, leftToRight shaping)",
+        "rtl (HarfBuzz buffer direction RTL via SkShaper leftToRight=false)",
+        "inherit (treated as ltr; per-View resolution tracked under #1506)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1520]"
+      ],
+      "notes": "pulp #1520 \u2014 JS shim + bridge + SkShaper direction flag. Real bidi (mixed LTR/RTL paragraphs) shares plumbing with #1506. arch-skparagraph-bidi \u2014 Full Unicode Bidi Algorithm for mixed-script paragraphs is deferred to SkParagraph plumbing (pulp #1506); the ltr/rtl/inherit value set the catalog claims is fully wired via SkShaper direction flag.",
+      "issue": "1520"
+    },
+    "canvas2d/filter": {
+      "status": "supported",
+      "mapsTo": "ctx.filter -> canvasSetFilter (web-compat-canvas.js _syncFilterState, flushed before fill/stroke/text/image draws). Skia parses CSS <filter-function-list> into an SkImageFilter chain (Blur + ColorFilter::Matrix combinations) applied via SkPaint::setImageFilter. Distinct from CSS `filter` on the View element (#1503) \u2014 this is per-2D-context state and stacks with save()/restore().",
+      "supportedValues": [
+        "blur(<length>)",
+        "brightness(<num|%>)",
+        "contrast(<num|%>)",
+        "drop-shadow(<dx> <dy> <blur> <color>)",
+        "grayscale(<num|%>)",
+        "hue-rotate(<angle>)",
+        "invert(<num|%>)",
+        "opacity(<num|%>)",
+        "saturate(<num|%>)",
+        "sepia(<num|%>)",
+        "none (default; clears any active chain)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas.cpp [skia][filter-chain][drop-shadow]",
+        "test/test_canvas2d_shim.cpp [issue-1520]"
+      ],
+      "notes": "pulp #1520 \u2014 JS shim + bridge + Skia parser/chain. Parser is local to skia_canvas.cpp; #1503's CSS filter on View elements is a parallel parser to be unified in a follow-up. arch-no-svg-filter-refs \u2014 url(#filter-id) SVG filter references are not supported \u2014 Pulp doesn't have an SVG filter graph. The 9 filter functions (blur/brightness/contrast/grayscale/hue-rotate/invert/opacity/saturate/sepia) plus drop-shadow are all wired on the Skia (GPU) backend. CG canvas backend (the CPU fallback used when no GPU context is available \u2014 `core/canvas/platform/mac/cg_canvas.mm` inherits the base `Canvas::set_filter` no-op) silently drops ALL filter functions; promoting CG to honor the chain requires CGImage filter wiring + a CG color-matrix equivalent (follow-up, tracked alongside the parallel `css/filter` CG-degradation note). For now, ctx.filter is honest-supported only when a Skia context is active; the Skia tests cited above prove that path.",
+      "issue": "1520"
+    },
+    "canvas2d/shadowColor": {
+      "status": "supported",
+      "mapsTo": "ctx.shadowColor -> canvasSetShadowColor (web-compat-canvas.js _syncShadowState). Sticky state on the C++ canvas; backends apply via SkImageFilters::DropShadow (Skia) or CGContextSetShadowWithColor (CoreGraphics).",
+      "supportedValues": [
+        "CSS color string (#rgb, #rrggbb, rgba(...), hsl(...), named colors, transparent)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1434-batch-7]",
+        "test/test_canvas_widget.cpp [issue-1434-batch-7]"
+      ],
+      "notes": "issue-1434 batch 7. Box-shadow on the View widget remains the separate setBoxShadow primitive (#925).",
+      "issue": "1434"
+    },
+    "canvas2d/shadowBlur": {
+      "status": "supported",
+      "mapsTo": "ctx.shadowBlur -> canvasSetShadowBlur (web-compat-canvas.js _syncShadowState). Skia maps blur radius to Gaussian sigma via sigma = blur/2.0 (Chromium's mapping); CG passes blur radius through directly.",
+      "supportedValues": [
+        "non-negative finite Number (CSS pixels)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1434-batch-7]",
+        "test/test_canvas_widget.cpp [issue-1434-batch-7]"
+      ],
+      "notes": "issue-1434 batch 7. HTML5 spec: negative values are silently ignored at the shim/bridge boundary.",
+      "issue": "1434"
+    },
+    "canvas2d/shadowOffsetX": {
+      "status": "supported",
+      "mapsTo": "ctx.shadowOffsetX -> canvasSetShadowOffsetX (web-compat-canvas.js _syncShadowState). Combines with shadowOffsetY into the dx/dy components of the Skia DropShadow filter / CG shadow offset CGSize.",
+      "supportedValues": [
+        "finite Number (CSS pixels)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1434-batch-7]",
+        "test/test_canvas_widget.cpp [issue-1434-batch-7]"
+      ],
+      "notes": "issue-1434 batch 7. Non-finite values are silently ignored by the shim.",
+      "issue": "1434"
+    },
+    "canvas2d/shadowOffsetY": {
+      "status": "supported",
+      "mapsTo": "ctx.shadowOffsetY -> canvasSetShadowOffsetY (web-compat-canvas.js _syncShadowState). Combines with shadowOffsetX; same Skia / CG mapping.",
+      "supportedValues": [
+        "finite Number (CSS pixels)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1434-batch-7]",
+        "test/test_canvas_widget.cpp [issue-1434-batch-7]"
+      ],
+      "notes": "issue-1434 batch 7. Non-finite values are silently ignored by the shim.",
+      "issue": "1434"
+    },
+    "canvas2d/getContext_webgpu": {
+      "status": "supported",
+      "mapsTo": "HTMLCanvasElement.getContext('webgpu') -> __createGPUCanvasContext (web-compat-canvas.js). Returns a GPUCanvasContext with configure / getCurrentTexture / present that bridges to native WebGPU when the device is native.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Tracked in detail under canvas2d/* by convention even though WebGPU is not strictly Canvas2D \u2014 the shim co-locates them. See planning/research/three-js* for the Three.js end-to-end story.",
+      "issue": ""
+    },
+    "canvas2d/getContext_2d": {
+      "status": "supported",
+      "mapsTo": "HTMLCanvasElement.getContext('2d') -> CanvasRenderingContext2D singleton per-canvas (cached on _canvasContext2d).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/_native_canvasFillCircle": {
+      "status": "supported",
+      "mapsTo": "Pulp-specific bridge fn (canvasFillCircle). Used by some legacy widget renderers; NOT spec'd in HTML5 Canvas. Plugin code should prefer arc()+fill().",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Bridge convenience; not part of the standard Canvas2D API.",
+      "issue": ""
+    },
+    "canvas2d/_native_canvasFillRoundedRect": {
+      "status": "supported",
+      "mapsTo": "Pulp-specific bridge fn (canvasFillRoundedRect). Equivalent of roundRect()+fill() in one call.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Bridge convenience.",
+      "issue": ""
+    },
+    "canvas2d/_native_canvasStrokeLine": {
+      "status": "supported",
+      "mapsTo": "Pulp-specific bridge fn (canvasStrokeLine). Equivalent of moveTo()+lineTo()+stroke() in one call.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Bridge convenience.",
+      "issue": ""
+    }
+  }
+}

--- a/compat/css.json
+++ b/compat/css.json
@@ -1,0 +1,3572 @@
+{
+  "css": {
+    "css/__StyleSheet": {
+      "status": "supported",
+      "mapsTo": "core/view/js/web-compat-document.js StyleSheet class (lines 5-72): constructor parses `{ selector: { props } }` rule maps via `_parseSelector`, attach() registers the sheet in `__stylesheets__` and applies rules to every existing element via `_applyTo`, detach() removes it. Pseudo-classes (`:hover`, `:focus`, `:active`, `:disabled`) route to dedicated `_setupPseudo*` wirers; ordinary rules call `_applyStyles` to assign each property through the existing CSSStyleDeclaration setter trap so the bridge-routing path stays the same as inline `el.style.X = ...`.",
+      "supportedValues": [
+        "new StyleSheet({ '.box': { width: '100px' } }).attach()",
+        "sheet.detach()",
+        "rules with simple selectors (tag / id / class) plus optional pseudo-class suffix",
+        "<style> elements (translated via `_parseCssText` to a StyleSheet on appendChild)"
+      ],
+      "unsupportedValues": [
+        "@media / @keyframes / @supports / @import at-rules",
+        ":focus-within / :focus-visible / :checked / :nth-child / :not(...)",
+        "attribute selectors in rule keys (`[data-role='x']`)",
+        "rule reordering (StyleSheets layer in attach order \u2014 no specificity-based sort)"
+      ],
+      "tests": [
+        "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
+      ],
+      "notes": "pulp #1551 catalog add \u2014 already implemented (StyleSheet has been available since the DOM-lite shim landed and was extended for `:hover` support in pulp #1149 / #1345). The same engine drives both JS-API consumers (`new StyleSheet(...)`) and HTML-input consumers (parsed `<style>` tags via `_parseCssText`).",
+      "issue": "1551"
+    },
+    "css/__hover_pseudo": {
+      "status": "supported",
+      "mapsTo": "web-compat-document.js (#1345 / pulp #1149 part b): `:hover` rules are parsed out of the inline <style> element, stashed per-element, and the document installs mouseenter/mouseleave listeners that swap the styles on the fly.",
+      "supportedValues": [
+        ":hover (any element selector)"
+      ],
+      "unsupportedValues": [
+        ":focus-within",
+        ":focus-visible",
+        ":nth-child(...)",
+        ":not(...)",
+        ":hover combinators (e.g. .a:hover .b)"
+      ],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Pseudo-class support is intentionally narrow. `:hover` is the highest-impact CSS selector in interactive UIs and the most-requested by Spectr/FilterBank consumers. The other interactive pseudo-classes (`:focus`, `:active`) require additional bridge plumbing and are not yet wired. 2026-05-12 closure: `:focus` and `:active` reclassified as supported \u2014 web-compat-document.js:282 (_setupPseudoFocus, addEventListener focus/blur) and :297 (_setupPseudoActive, addEventListener mousedown/mouseup) are fully wired. The original notes referencing 'not yet wired' predate pulp #1149 part-b and #1345. Pinned by test.",
+      "issue": "1149"
+    },
+    "css/__matchMedia": {
+      "status": "supported",
+      "mapsTo": "core/view/js/css-parser.js `_matchMediaQuery` (lines 593-617) evaluates a media-query string against the current root size obtained from `getRootSize()`. Stylesheets and matched-media @rules consume this directly. The `window.matchMedia(query)` wrapper that returns a MediaQueryList shim lives in core/view/js/web-compat.js (lines 2101-2114) but that file is NOT loaded by the WidgetBridge prelude chain \u2014 the wrapper is reachable only when web-compat.js is loaded explicitly.",
+      "supportedValues": [
+        "(min-width: <px>)",
+        "(max-width: <px>)",
+        "(min-height: <px>)",
+        "(max-height: <px>)",
+        "(orientation: landscape | portrait)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
+      ],
+      "notes": "pulp #1551 catalog add \u2014 already implemented. Existing `WebCompat: matchMedia min-width` and `WebCompat: matchMedia orientation landscape` cases in test_web_compat_prelude.cpp exercise the parser; pulp #1551 adds an end-to-end case that walks through `window.matchMedia()` and asserts the returned MediaQueryList shape. Wave 4 css extensive \u2014 drift cleanup \u2014 value-coverage is complete (the parser handles the documented query forms; live re-evaluation on resize + extended @media features are paint/runtime-deferred follow-ups documented in mapsTo). Reclassified as runtime-side gap rather than value-coverage gap.",
+      "issue": "1551"
+    },
+    "css/__pseudo_active": {
+      "status": "supported",
+      "mapsTo": "core/view/js/web-compat-document.js _setupPseudoActive (lines 277-290): on `:active` rule match, registers `mousedown` (snapshot-current-style + apply rule props) and `mouseup` (restore snapshot) listeners. Idempotent via `el._activeSetup`.",
+      "supportedValues": [
+        "element:active { ... }",
+        "tag/id/class qualified `:active` selectors",
+        "ordinary CSS properties inside the `:active` rule body (anything the inline-setter trap routes)"
+      ],
+      "unsupportedValues": [
+        "`:active` combined with descendant / child combinators in the `<style>` text parser \u2014 TRACKED in pulp #1323 (text-parser parser-extension); not a per-row gap",
+        "keyboard activation of `:active` (synthesized only on mousedown/mouseup; no Enter/Space key handling) \u2014 INTENTIONAL (matches HTML default: `:active` is the pointer-pressed state; keyboard activation is a separate accessibility concern that consumers handle via keydown listeners)"
+      ],
+      "tests": [
+        "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
+      ],
+      "notes": "pulp #1551 catalog add \u2014 already implemented. Wiring is parallel to `:hover` but uses mousedown/mouseup edges instead of mouseenter/mouseleave. Closure: :active mousedown/mouseup wiring pinned by test/web-compat/test_web_compat_prelude.cpp [issue-1551] (existing test). Combinator gap is tracked in #1323; keyboard activation is INTENTIONAL design (matches HTML default; consumers handle key activation via keydown listeners).",
+      "issue": "1551"
+    },
+    "css/__pseudo_classes_note": {
+      "status": "wontfix",
+      "mapsTo": "no global CSS pseudo-class system today; per-pseudo-class catalog entries (css/__pseudo_hover, __pseudo_focus, __pseudo_active, __pseudo_disabled) hold the per-pseudo claim. This synthetic note is superseded.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        ":hover",
+        ":active",
+        ":focus",
+        ":focus-visible",
+        ":disabled",
+        ":checked",
+        ":first-child",
+        ":last-child",
+        ":nth-child",
+        "etc."
+      ],
+      "tests": [],
+      "notes": "Pulp routes hover/click/etc. through bridge event registrations (registerHover, registerClick) rather than through CSS pseudo-classes. JSX consumers wire interactivity via on* event props, not via CSS. Superseded by the per-pseudo-class catalog entries (`css/__pseudo_hover`, `css/__pseudo_focus`, `css/__pseudo_active`, `css/__pseudo_disabled`) added in pulp #1551. pulp #1434 A4 Bundle 6 closure: status flipped missing \u2192 wontfix (architectural \u2014 the per-pseudo entries are the canonical claim).",
+      "issue": ""
+    },
+    "css/__pseudo_disabled": {
+      "status": "supported",
+      "mapsTo": "core/view/js/web-compat-document.js StyleSheet._applyTo `:disabled` branch (lines 56-59): when a rule's parsed pseudo is `disabled` and `_matchesSelector(el, parsed) && el._disabled` both hold, the rule's properties are applied via `_applyStyles(el, props)`. The element's `disabled` getter/setter (web-compat-element.js lines 334-339) writes through to `el._disabled`.",
+      "supportedValues": [
+        "element:disabled { ... }",
+        "rules apply on attach / appendChild when `el.disabled === true`"
+      ],
+      "unsupportedValues": [
+        "live re-application when `disabled` is toggled at runtime \u2014 INTENTIONAL: Pulp's :disabled is an apply-time styling helper, not a live pseudo-class engine; StyleSheet._applyTo runs at attach / appendChild time only. Consumers should treat :disabled styling as one-way (set disabled before mount, or re-attach to re-apply).",
+        "snapshot-restore symmetry on re-enable \u2014 INTENTIONAL (same rationale): the disabled branch does not capture pre-disabled values; one-way styling avoids the storage / replay overhead a live pseudo-class engine would need."
+      ],
+      "tests": [
+        "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
+      ],
+      "notes": "pulp #1551 catalog add \u2014 already implemented. The pseudo branch is wired distinctly from `:hover` / `:focus` / `:active` because `:disabled` is not interaction-driven \u2014 it gates on element state. Closure: :disabled apply-time semantics pinned by [issue-1551] :disabled test; live re-apply + snapshot-restore are INTENTIONAL one-way design choices, not bounded edges of a live engine. Documented so consumers expecting browser-style live pseudo behaviour know to opt into re-mount instead.",
+      "issue": "1551"
+    },
+    "css/__pseudo_focus": {
+      "status": "supported",
+      "mapsTo": "core/view/js/web-compat-document.js _setupPseudoFocus (lines 262-275): on `:focus` rule match, registers `focus` (snapshot-current-style + apply rule props) and `blur` (restore snapshot) listeners. Idempotent via `el._focusSetup`.",
+      "supportedValues": [
+        "element:focus { ... }",
+        "tag/id/class qualified `:focus` selectors",
+        "ordinary CSS properties inside the `:focus` rule body"
+      ],
+      "unsupportedValues": [
+        "`:focus-within` (focus inside any descendant) \u2014 TRACKED in a separate :focus-engine extension (real CSS feature; implementable when a consumer files for it)",
+        "`:focus-visible` (keyboard-only focus) \u2014 TRACKED in the same :focus-engine extension (real CSS feature; needs distinction between keyboard and mouse focus)",
+        "rule selectors that combine `:focus` with combinators in the `<style>` text parser \u2014 TRACKED in pulp #1323"
+      ],
+      "tests": [
+        "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
+      ],
+      "notes": "pulp #1551 catalog add \u2014 already implemented. Wiring is parallel to `:hover` / `:active` and routes through the same `addEventListener` channel so it coexists with JSX `onFocus` / `onBlur` handlers. Closure: :focus focus/blur wiring pinned by test/web-compat/test_web_compat_prelude.cpp [issue-1551] (existing test). :focus-within and :focus-visible are real CSS features tracked in a follow-up :focus-engine extension; combinator gap is tracked in #1323. None are closeable on this row alone.",
+      "issue": "1551"
+    },
+    "css/__pseudo_hover": {
+      "status": "supported",
+      "mapsTo": "core/view/js/web-compat-document.js _setupPseudoHover (lines 74-145): on `:hover` rule match, registers `mouseenter` (snapshot-current-style for the union of properties across all hover rules + apply each rule's props in source order) and `mouseleave` (restore snapshot, drop snapshot map). Multi-rule layering tracked per-element via `el._hoverState.propsList`. Idempotent via `el._hoverState.wired` and per-rule object-identity checks. registerHover() is armed lazily on `_nativeCreated`.",
+      "supportedValues": [
+        "element:hover { ... }",
+        "multiple hover rules layered on the same element (last write wins per property)",
+        "tag/id/class qualified `:hover` selectors",
+        "ordinary CSS properties inside the `:hover` rule body"
+      ],
+      "unsupportedValues": [
+        "`:hover` combinators in the `<style>` text parser (e.g. `.a:hover .b`) \u2014 TRACKED in pulp #1323 (text-parser parser-extension follow-up); not a gap to close on this row",
+        "synthesized hover from touch / pen input \u2014 INTENTIONAL: Pulp does NOT synthesize mouse hover from touch (touch != mouseenter); consumers wanting touch-driven highlight behaviour should use a touch-specific class toggle or :active"
+      ],
+      "tests": [
+        "test/web-compat/test_web_compat_prelude.cpp [issue-1551]",
+        "test/web-compat/test_css_hover_translation.cpp"
+      ],
+      "notes": "pulp #1551 catalog add \u2014 already implemented. Companion to the original `css/__hover_pseudo` entry, with full multi-rule + idempotency + native-arming details captured. Hover rules originate either from the JS-API (`new StyleSheet({...})`) or from `<style>` text parsed via `_parseCssText`. Closure: :hover supported core pinned by [issue-1551] :hover test; combinator gap is tracked in #1323; touch-synth omission is intentional design (matches RN; documented for consumer expectations).",
+      "issue": "1551"
+    },
+    "css/__selector_child": {
+      "status": "supported",
+      "mapsTo": "core/view/js/web-compat-document.js _parseSelector (lines 296-335): splits on ` > ` and recurses with `direct=true`. _matchesSelector (lines 337-367): when `parsed.direct` is set, the element's immediate `_parentElement` must match the parent selector \u2014 descendant ancestors do NOT count.",
+      "supportedValues": [
+        "<parent> > <child> (chained: `div > section > .item` \u2014 left-associative reduction in `_parseSelector`)"
+      ],
+      "unsupportedValues": [
+        "adjacent-sibling combinator `+` (e.g. `.a + .b`) \u2014 TRACKED in a separate selector-parser extension (not in Tier-1 scope; implementable when a consumer files for it)",
+        "general-sibling combinator `~` (e.g. `.a ~ .b`) \u2014 TRACKED in the same selector-parser extension"
+      ],
+      "tests": [
+        "test/web-compat/test_selector_matching.cpp",
+        "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
+      ],
+      "notes": "pulp #1551 catalog add \u2014 already implemented. Existing `Selector: JS parser distinguishes child and descendant combinators` test exercises this; the issue-1551 case adds a structural-selector smoke that runs alongside the others. Closure: child combinator `>` pinned by test/web-compat/test_selector_matching.cpp [events][selector] (\"JS parser distinguishes child and descendant combinators\"). Sibling combinators (`+`, `~`) are real CSS features but require a separate selector-parser extension; tracked in a follow-up rather than closed as wontfix.",
+      "issue": "1551"
+    },
+    "css/__selector_class": {
+      "status": "supported",
+      "mapsTo": "core/view/js/web-compat-document.js _parseSelector (lines 296-335) tokenises `.foo.bar` into `parsed.classes = ['foo', 'bar']`. _matchesSelector (lines 344-347) requires every class to be present in `el.classList` (Element.classList is the standard contains/add/remove API).",
+      "supportedValues": [
+        ".foo",
+        ".foo.bar (compound \u2014 every listed class must match)",
+        "tag.class compounds (`button.primary`)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/web-compat/test_selector_matching.cpp",
+        "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
+      ],
+      "notes": "pulp #1551 catalog add \u2014 already implemented. Class selectors are the most common StyleSheet rule shape in Pulp consumers (Spectr's editor.js, FilterBank, react renderer's className-driven styling). 2026-05-12 closure (Codex P2-aware honest reclass): both originally-listed unsupportedValues are INTENTIONAL design \u2014 (a) namespace-qualified class selectors require XML namespace context that Pulp's HTML-only document model does not carry; (b) case-sensitive class matching IS the CSS spec for HTML standards mode (the listed \"case-insensitive\" behavior would be quirks-mode-only). Neither is a gap to close.",
+      "issue": "1551"
+    },
+    "css/__selector_descendant": {
+      "status": "supported",
+      "mapsTo": "core/view/js/web-compat-document.js _parseSelector (lines 296-335): splits on whitespace and recurses with `direct=false`. _matchesSelector (lines 350-363): when `parsed.parent` is set without `parsed.direct`, walks `_parentElement` chain looking for any ancestor that matches the parent selector.",
+      "supportedValues": [
+        "<ancestor> <descendant>",
+        "chained descendant combinators (`section .row .item`)"
+      ],
+      "unsupportedValues": [
+        "interleaved descendant + child combinators in the `<style>` text parser (the underlying `_parseSelector` handles them but the inline `<style>` text parser limits to flat selectors) \u2014 TRACKED in pulp #1323; not a gap to close on this row"
+      ],
+      "tests": [
+        "test/web-compat/test_selector_matching.cpp",
+        "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
+      ],
+      "notes": "pulp #1551 catalog add \u2014 already implemented. Closure: ordinary descendant matching pinned by test/web-compat/test_selector_matching.cpp [events][selector] (JS parser distinguishes child and descendant combinators); the text-parser flat-selector limit is honestly tracked in pulp #1323 and is not a per-row closure target.",
+      "issue": "1551"
+    },
+    "css/__selector_id": {
+      "status": "supported",
+      "mapsTo": "core/view/js/web-compat-document.js _parseSelector (lines 296-335) tokenises `#foo` into `parsed.id = 'foo'`. _matchesSelector (lines 341-342) compares against `el.getAttribute('id')`.",
+      "supportedValues": [
+        "#foo",
+        "tag#id and class#id compounds (`button#bypass.primary`)",
+        "[id='foo'] / [id=\"foo\"] / [id=foo] attribute-selector forms (route through the existing _matchesSelector attrs path, verified by [tier1-closure])"
+      ],
+      "unsupportedValues": [
+        "multiple `#id` tokens in one selector (a CSS spec edge case; the parser keeps only the last `#id` it sees \u2014 INTENTIONAL: real CSS spec allows multiple `#id` but matching is over the union, which Pulp's single-slot parser doesn't model; rarely emitted by design tools)."
+      ],
+      "tests": [
+        "test/web-compat/test_selector_matching.cpp",
+        "test/web-compat/test_web_compat_prelude.cpp [issue-1551]",
+        "test/web-compat/test_selector_matching.cpp [tier1-closure]"
+      ],
+      "notes": "pulp #1551 catalog add \u2014 already implemented. Note that `document.getElementById` uses a separate `#id`-prefixed lookup table in `__elements__` \u2014 the selector path here goes through `_findMatch` via `querySelector` / `querySelectorAll` and StyleSheet `_applyTo`. Closure: [id='foo'] attribute-selector form was already working via the existing _matchesSelector attrs path \u2014 confirmed by new test test/web-compat/test_selector_matching.cpp [tier1-closure] (5 assertions: single-quoted, double-quoted, unquoted, negative non-match, compound div[id=\u2026]). Catalog moves [id='foo'] from unsupportedValues to supportedValues to reflect what the code already does. Multiple-#id-in-one-selector is documented INTENTIONAL design (rare in practice).",
+      "issue": "1551"
+    },
+    "css/__selector_tag": {
+      "status": "supported",
+      "mapsTo": "core/view/js/web-compat-document.js _parseSelector (lines 296-335) tokenises a leading identifier into `parsed.tag` (lower-cased). _matchesSelector (lines 339) compares against `el.tagName.toLowerCase()`.",
+      "supportedValues": [
+        "button",
+        "div",
+        "span",
+        "h1 / h2 / ... / h6",
+        "any HTML element name the consumer creates via `document.createElement`",
+        "* (universal selector \u2014 matches any element via null-tag fall-through in _matchesSelector; verified by [tier1-closure])"
+      ],
+      "unsupportedValues": [
+        "namespace-qualified tag names (`svg|circle`) \u2014 INTENTIONAL (Pulp is HTML-only; XML namespace selectors are out of scope by design)",
+        "case-sensitive tag matching \u2014 INTENTIONAL (matching is case-insensitive on both sides; matches HTML quirks where `<DIV>` and `<div>` are the same element)"
+      ],
+      "tests": [
+        "test/web-compat/test_selector_matching.cpp",
+        "test/web-compat/test_web_compat_prelude.cpp [issue-1551]",
+        "test/web-compat/test_selector_matching.cpp [tier1-closure]"
+      ],
+      "notes": "pulp #1551 catalog add \u2014 already implemented. Closure: tag matching pinned by test/web-compat/test_selector_matching.cpp [events][selector] (compound + descendant tests) + new [tier1-closure] test verifying universal `*` matches via null-tag fall-through. Namespace + case-sensitive matching are documented INTENTIONAL (HTML-only by design; case-insensitive matches HTML quirks).",
+      "issue": "1551"
+    },
+    "css/__setProperty_var": {
+      "status": "supported",
+      "mapsTo": "core/view/js/web-compat-style-decl.js CSSStyleDeclaration.prototype.setProperty (lines 1259-1279): when `name` starts with `--`, slices the prefix and tries `parseCSSLength(value)` first \u2014 on success calls `setMotionToken(tokenName, parsed.value)` so the bridge motion-token system picks up the new value. On length-parse failure, tries `parseCSSColor(value)` and on success routes through `applyTokenDiff` as a theme color override. getPropertyValue routes back through `getMotionToken` for `--` names.",
+      "supportedValues": [
+        "el.style.setProperty('--accent', '12px')",
+        "el.style.setProperty('--accent', '#ff0000')",
+        "el.style.setProperty('--accent', 'cornflowerblue')",
+        "el.style.getPropertyValue('--accent')",
+        "el.style.removeProperty('--accent')"
+      ],
+      "unsupportedValues": [
+        "scoped (per-element) custom property cascading \u2014 the bridge motion-token namespace is shared across the document; `--name` is effectively a global token, not a CSS-cascade scoped variable",
+        "string / list / shadow / gradient values (only length and color tokens are routed)",
+        "the `!important` flag on the third argument"
+      ],
+      "tests": [
+        "test/web-compat/test_web_compat_prelude.cpp [issue-1551]"
+      ],
+      "notes": "pulp #1551 catalog add \u2014 already implemented. Pairs with `css/__var` \u2014 `setProperty('--name', value)` writes the token, `var(--name)` reads it back through `_resolveVar`. Both share the motion-token bridge so JS-driven token mutation immediately affects the next layout/paint pass.",
+      "issue": "1551"
+    },
+    "css/__var": {
+      "status": "supported",
+      "mapsTo": "core/view/js/css-parser.js _resolveVar (lines 433-441): regex-replaces every `var(--<name>[, <fallback>])` in a CSS value string with `getMotionToken(name)` when defined, falling back to the inline literal or `0`. Applied by web-compat-style-decl.js inline-setter routing on every property assignment (e.g. lines 51, 53, 82) so `el.style.X = 'var(--accent)'` resolves at the moment the bridge call is made.",
+      "supportedValues": [
+        "var(--name)",
+        "var(--name, <fallback>)",
+        "any CSS property assignment (`width`, `color`, `margin`, etc.) whose string value contains a `var(...)` call"
+      ],
+      "unsupportedValues": [
+        "scoped (per-element) cascading \u2014 see notes in css/__setProperty_var"
+      ],
+      "tests": [
+        "test/web-compat/test_web_compat_prelude.cpp [issue-1551]",
+        "test/web-compat/test_web_compat_prelude.cpp [nested-fallback]"
+      ],
+      "notes": "pulp #1551 catalog add \u2014 already implemented. `var(--name)` is the read side of the bridge motion-token system; `setProperty('--name', value)` is the write side. Together they let consumers parameterise inline styles with named tokens without going through the full CSS-cascade engine. Coverage-gap closure: nested-fallback (var(--a, var(--b, 0))) and var() inside other CSS functions (calc(var(--x) + 10px)) are now supported via the balanced-paren _resolveVar walker (pinned by [nested-fallback]).",
+      "issue": "1551"
+    },
+    "css/alignContent": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'align_content', value) -> FlexStyle.align_content + align_content_space -> YGNodeStyleSetAlignContent",
+      "supportedValues": [
+        "flex-start",
+        "flex-end",
+        "center",
+        "stretch",
+        "space-between",
+        "space-around",
+        "space-evenly"
+      ],
+      "unsupportedValues": [
+        "first baseline",
+        "last baseline",
+        "normal"
+      ],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 (sub-agent #12 follow-up): bridge gained 'align_content' setFlex case + FlexStyle.align_content/align_content_space fields. The CSS translator already routed via setFlex(id, 'align_content', _cssToFlex(resolved)) \u2014 just needed the bridge backend. Multi-line flex (`flexWrap: 'wrap'`) cross-axis distribution now works.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1434"
+    },
+    "css/alignItems": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'align_items', value)",
+      "supportedValues": [
+        "flex-start",
+        "flex-end",
+        "center",
+        "stretch",
+        "baseline",
+        "first baseline"
+      ],
+      "unsupportedValues": [
+        "last baseline (requires baseline-set tracking not supported by YGAlignBaseline; aliasing to plain baseline would silently misrender multi-line flex containers)"
+      ],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]",
+        "test/test_widget_bridge.cpp [issue-1434] (setFlex align_items: first baseline aliases to baseline; last baseline stays unsupported)"
+      ],
+      "notes": "FlexAlign enum has {start, center, end, stretch, auto_, baseline}. pulp #1434 rn batch B wired baseline via FlexAlign::baseline -> YGAlignBaseline. pulp #1434 Tier 1 (PR-B): 'first baseline' aliased to plain 'baseline' (the baseline-set 'first' selector is the default Yoga computes). Codex P1 on PR #1853: 'last baseline' is NOT aliased -- it requires last-baseline tracking that Yoga does not implement; documented unsupported, pinned by [issue-1434].",
+      "issue": ""
+    },
+    "css/alignSelf": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'align_self', value)",
+      "supportedValues": [
+        "auto",
+        "flex-start",
+        "flex-end",
+        "center",
+        "stretch",
+        "baseline"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Same enum as align-items. pulp #1434 rn batch B: baseline wired.",
+      "issue": ""
+    },
+    "css/all": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "initial",
+        "inherit",
+        "unset",
+        "revert"
+      ],
+      "tests": [],
+      "notes": "CSS-cascade reset not modeled.",
+      "issue": ""
+    },
+    "css/animation": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards animation-name to setAnimation. defineKeyframes populates the application-wide CssKeyframesRegistry; setAnimation looks up by name and seeds CssAnimation entries on the View. PR 2 of the ladder wires the playback driver to advance these.",
+      "supportedValues": [
+        "CssEasing keyword set",
+        "cubic-bezier(...)",
+        "steps(N, end|start)",
+        "animation-name resolution via the registry",
+        "duration in ms or s"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
+      "issue": ""
+    },
+    "css/animationDelay": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards animation-name to setAnimation. defineKeyframes populates the application-wide CssKeyframesRegistry; setAnimation looks up by name and seeds CssAnimation entries on the View. PR 2 of the ladder wires the playback driver to advance these.",
+      "supportedValues": [
+        "CssEasing keyword set",
+        "cubic-bezier(...)",
+        "steps(N, end|start)",
+        "animation-name resolution via the registry",
+        "duration in ms or s"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
+      "issue": ""
+    },
+    "css/animationDirection": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards animation-name to setAnimation. defineKeyframes populates the application-wide CssKeyframesRegistry; setAnimation looks up by name and seeds CssAnimation entries on the View. PR 2 of the ladder wires the playback driver to advance these.",
+      "supportedValues": [
+        "CssEasing keyword set",
+        "cubic-bezier(...)",
+        "steps(N, end|start)",
+        "animation-name resolution via the registry",
+        "duration in ms or s",
+        "normal",
+        "reverse",
+        "alternate",
+        "alternate-reverse"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes. Wave 1 drift cleanup \u2014 animation-name resolution + direction enum stored on CssAnimation entries (PR 1 of #1508 ladder); harness verifies all 4 spec values claimed.",
+      "issue": ""
+    },
+    "css/animationDuration": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards animation-name to setAnimation. defineKeyframes populates the application-wide CssKeyframesRegistry; setAnimation looks up by name and seeds CssAnimation entries on the View. PR 2 of the ladder wires the playback driver to advance these.",
+      "supportedValues": [
+        "CssEasing keyword set",
+        "cubic-bezier(...)",
+        "steps(N, end|start)",
+        "animation-name resolution via the registry",
+        "duration in ms or s"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
+      "issue": ""
+    },
+    "css/animationFillMode": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards animation-name to setAnimation. defineKeyframes populates the application-wide CssKeyframesRegistry; setAnimation looks up by name and seeds CssAnimation entries on the View. PR 2 of the ladder wires the playback driver to advance these.",
+      "supportedValues": [
+        "CssEasing keyword set",
+        "cubic-bezier(...)",
+        "steps(N, end|start)",
+        "animation-name resolution via the registry",
+        "duration in ms or s",
+        "none",
+        "forwards",
+        "backwards",
+        "both"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes. Wave 1 drift cleanup \u2014 fill-mode enum stored on CssAnimation entries (PR 1 of #1508 ladder); harness verifies all 4 spec values claimed.",
+      "issue": ""
+    },
+    "css/animationIterationCount": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards animation-name to setAnimation. defineKeyframes populates the application-wide CssKeyframesRegistry; setAnimation looks up by name and seeds CssAnimation entries on the View. PR 2 of the ladder wires the playback driver to advance these.",
+      "supportedValues": [
+        "CssEasing keyword set",
+        "cubic-bezier(...)",
+        "steps(N, end|start)",
+        "animation-name resolution via the registry",
+        "duration in ms or s"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
+      "issue": ""
+    },
+    "css/animationName": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards animation-name to setAnimation. defineKeyframes populates the application-wide CssKeyframesRegistry; setAnimation looks up by name and seeds CssAnimation entries on the View. PR 2 of the ladder wires the playback driver to advance these.",
+      "supportedValues": [
+        "CssEasing keyword set",
+        "cubic-bezier(...)",
+        "steps(N, end|start)",
+        "animation-name resolution via the registry",
+        "duration in ms or s"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
+      "issue": ""
+    },
+    "css/animationPlayState": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards `animation-play-state` through setAnimation(id, \"play_state\", value); the bridge stores the keyword on View::animation_play_state_. View::tick_animations(dt) honors the keyword by skipping the timeline advance when value is \"paused\" (web spec semantic) \u2014 animations resume on the next tick when the keyword flips back to \"running\".",
+      "supportedValues": [
+        "running",
+        "paused",
+        "paused (now wired \u2014 tick_animations is invoked per-frame on macOS + Android frame loops; honors paused keyword no-op)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"WidgetBridge setAnimation play_state stores on View\"",
+        "test/test_widget_bridge.cpp::\"View::tick_animations honors paused play_state\"",
+        "packages/pulp-react/test/prop-applier-animation.test.ts::\"animationPlayState routes to setAnimation/play_state\"",
+        "test/test_widget_bridge.cpp [issue-1668][animationplaystate-paused]"
+      ],
+      "notes": "pulp #1434 Wave 3 css.3: status flipped partial \u2192 supported. View::tick_animations(dt) advances active_animations_ entries in-place but is a no-op when animation_play_state_ == \"paused\", giving the play-state keyword its full pause/resume semantic without coupling the existing seed-only flow to a frame-driven dispatcher. The per-property tween-to-View commit step is the orthogonal PR-2-of-the-original-ladder follow-up; play-state pause/resume is independently testable today. Wave-5 follow-up audit (post-PR #1616 sweep): walked back to partial. `grep tick_animations` on `core/` shows zero non-test callers \u2014 production frame ticks never advance the timeline, so the keyword is stored on View::animation_play_state_ but has no observable effect. Wiring the dispatcher into View::on_frame is the unblock. pulp #1668 \u2014 frame-loop integration completed. macOS window_host_mac.mm advance_widget_animations and Android gpu_surface_android.cpp advance_view_animations now call View::tick_animations(dt) on every View in the tree per frame. The recursive walk honors animation_play_state_ (paused \u2192 no advance) and is a no-op for Views with no active CSS animations.",
+      "issue": ""
+    },
+    "css/animationTimingFunction": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards animation-name to setAnimation. defineKeyframes populates the application-wide CssKeyframesRegistry; setAnimation looks up by name and seeds CssAnimation entries on the View. PR 2 of the ladder wires the playback driver to advance these.",
+      "supportedValues": [
+        "CssEasing keyword set",
+        "cubic-bezier(...)",
+        "steps(N, end|start)",
+        "animation-name resolution via the registry",
+        "duration in ms or s"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"defineKeyframes populates the registry\"",
+        "test/test_widget_bridge.cpp::\"setAnimation seeds Animation from registry\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-1 \u2014 keyframes registry + animation-name resolver substrate landed. defineKeyframes(name, JSON-stringified stops) populates the application-wide CssKeyframesRegistry; setAnimation seeds CssAnimation entries on the View. Frame-driven playback that ticks the timeline lands in PR 2 of the ladder. Iterations + direction + fill-mode are stored on the seeded entry; PR 4 specializes.",
+      "issue": ""
+    },
+    "css/aspectRatio": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js parses '<n>', '<num>/<den>', and 'auto'; calls setFlex(id, 'aspect_ratio', ratio); widget_bridge writes FlexStyle.aspect_ratio; yoga_layout dispatches to YGNodeStyleSetAspectRatio",
+      "supportedValues": [
+        "number",
+        "ratio (n/d)",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/web-compat/test_layout_aspect_ratio.cpp"
+      ],
+      "notes": "pulp #1434 \u2014 three value forms accepted: plain number ('1.5'), 'width / height' ratio ('16/9' -> 1.778), and 'auto' (clears slot). Both 'aspectRatio' (camelCase) and 'aspect-ratio' (kebab-case) work; setProperty auto-converts kebab to camel.",
+      "issue": "1434"
+    },
+    "css/backdropFilter": {
+      "status": "supported",
+      "mapsTo": "parses blur(Npx) \u2192 setBackdropFilter(id, blur_px)",
+      "supportedValues": [
+        "blur(<px>)",
+        "none",
+        "other filter functions (parsed; only blur applies at paint time per arch-blur-only-backdrop)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/web-compat/test_css_translator_gaps_1434.cpp [issue-1434-batch-3]"
+      ],
+      "notes": "Blur-only. CSS shim parses the blur(Npx) substring; non-matching filter functions are ignored. None / empty clears the slot. Wave 4 css extensive \u2014 non-blur filter functions are arch-blur-only-backdrop (the bridge slot View::backdrop_filter_blur_ is scalar; the multi-function chain that the foreground filter chain uses is queued behind SkImageFilters compose-list parity). Authors who need brightness/saturate stack via the foreground filter property which IS chain-aware.",
+      "issue": "1434"
+    },
+    "css/backfaceVisibility": {
+      "status": "wontfix",
+      "mapsTo": "Architectural \u2014 Pulp's render is 2D-affine only; backface culling requires the same 3D pipeline as css/perspective + perspectiveOrigin. Same wontfix-arch class as css/perspective.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "pulp #1737 (CSS NO-OP audit) \u2014 reclassified noop \u2192 wontfix. Pre-fix flagged \"noop pending #1026 (3D pipeline)\" but #1026 isn't on the near-term roadmap. Treat consistently with css/perspective family which is already wontfix.",
+      "issue": "1026"
+    },
+    "css/background": {
+      "status": "supported",
+      "mapsTo": "if 'gradient' in value -> setBackgroundGradient; else parseCSSColor -> setBackground",
+      "supportedValues": [
+        "color",
+        "linear-gradient(...)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Background shorthand supports only color OR a gradient. Wave 1 architectural reclassification \u2014 url() / image / conic-gradient / multiple-bg are partial-deferred-image-loader (image src loader and viewport-relative paint not in Pulp's pipeline); color + linear-gradient round-trip end-to-end. Wave 4 css extensive \u2014 url() / image() / image-set() are arch-deferred-image-loader (no asset-fetch pipeline at the JS shim \u2014 image loading is the orthogonal follow-up). conic-gradient is arch-skia-no-conic-gradient (Skia's SkGradientShader doesn't natively support conical sweeps; angle-sweep emulation would require offscreen rasterization and is an explicit non-goal at this surface). multiple backgrounds + size-in-shorthand are arch-single-bg (the View::background_ slot stores a single background; mirrors the box-shadow single-shadow pattern). Reclassified value coverage out of unsupportedValues per the Wave 1 backgroundAttachment precedent.",
+      "issue": ""
+    },
+    "css/backgroundAttachment": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js -> setBackgroundAttachment(id, kw); bridge stores keyword on View::background_attachment_ slot. No paint impact today.",
+      "supportedValues": [
+        "scroll (conformant default \u2014 pulp's layout is non-scrolling so the spec behavior coincides with our render path)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1517]"
+      ],
+      "notes": "pulp #1517 \u2014 accepts the keyword without crashing; paint impact is exactly zero because pulp doesn't model scroll contexts. `scroll` is the spec-conformant default for our case. Status `noop` means the property is wired through but has no rendered effect. Wave 1 architectural reclassification \u2014 `fixed` / `local` are arch-no-scroll-context (Pulp's layout is non-scrolling so `scroll` is the spec-conformant default; viewport-relative paint origin and scroll-context coupling are not modeled). Wave 1 drift cleanup \u2014 noop status retained; cleared unsupportedValues since `fixed` / `local` are arch-no-scroll-context (Pulp doesn't model scroll contexts; the default `scroll` is the spec-conformant rendering).",
+      "issue": "1517"
+    },
+    "css/backgroundClip": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js -> setBackgroundClip(id, kw); bridge stores keyword on View::background_clip_ slot.",
+      "supportedValues": [
+        "border-box (default; pulp paints bg edge-to-edge \u2014 same as the spec default)",
+        "padding-box (no-op on solid bg; same visual as border-box)",
+        "content-box (no-op on solid bg; same visual as border-box)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1517]"
+      ],
+      "notes": "pulp #1517 \u2014 keyword stored on View; the box-flavor variants are visual no-ops on solid backgrounds (which is what pulp paints today). The `text` variant requires real paint-chain composition and is deferred. Wave 1 architectural reclassification \u2014 `text` keyword is partial-deferred-paint-composition (slot stored on View::background_clip_; paint-time SkBlendMode::kSrcIn against text glyphs requires paint-chain composition not in pipeline today). Wave 4 css extensive \u2014 text is arch-paint-deferred (paint-time SkBlendMode::kSrcIn against text glyphs is the follow-up; the slot stores the value so the wiring is ready). Reclassified as paint-side gap rather than value-coverage gap.",
+      "issue": "1517"
+    },
+    "css/backgroundColor": {
+      "status": "supported",
+      "mapsTo": "parseCSSColor -> setBackground(id, hex)",
+      "supportedValues": [
+        "#hex",
+        "#rgba",
+        "rgb()",
+        "rgba()",
+        "hsl()",
+        "hsla()",
+        "oklch()",
+        "oklab()",
+        "lch()",
+        "lab()",
+        "color(srgb|srgb-linear|display-p3)",
+        "transparent",
+        "named colors"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up. color-mix() and currentColor remain unsupported (deferred); wide-gamut HDR via Skia SkColor4f is a follow-up \u2014 current path converts to sRGB hex.",
+      "issue": ""
+    },
+    "css/backgroundImage": {
+      "status": "supported",
+      "mapsTo": "same path as background",
+      "supportedValues": [
+        "linear-gradient(...)",
+        "radial-gradient(...) (parsed)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "url() image backgrounds not implemented. Wave 1 architectural reclassification \u2014 url() / image-set() / conic-gradient / multiple-bg are partial-deferred-image-loader (image src loader not in Pulp's pipeline); linear-gradient + radial-gradient round-trip end-to-end. Wave 4 css extensive \u2014 url() / image-set() are arch-deferred-image-loader (no asset-fetch pipeline at the JS shim). conic-gradient is arch-skia-no-conic-gradient. multiple is arch-single-bg. Reclassified value coverage out of unsupportedValues per the Wave 1 backgroundAttachment precedent.",
+      "issue": ""
+    },
+    "css/backgroundOrigin": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js -> setBackgroundOrigin(id, kw); bridge stores keyword on View::background_origin_ slot. No paint impact today.",
+      "supportedValues": [
+        "border-box / padding-box / content-box \u2014 all accepted, all stored, all paint identically because pulp doesn't paint repeating gradient tiles (the only case where this would matter)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1517]"
+      ],
+      "notes": "pulp #1517 \u2014 value stored for round-tripping; paint impact is zero because the property only matters for repeating gradient tiles. When pulp adds gradient-tile paint, the slot is already populated. Wave 1 drift cleanup \u2014 noop \u2192 supported (wired through web-compat-style-decl.js; the box-flavor variants are visual no-ops on solid backgrounds, which is what Pulp paints today \u2014 matches CSS spec default behavior).",
+      "issue": "1517"
+    },
+    "css/backgroundPosition": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js:1418 forwards `background-position` to setBackgroundPosition(id, value); bridge function is registered (widget_bridge.cpp Wave 5 css.5) and stores the keyword on View::background_position_. Storage-only today: pulp's solid-bg paint path doesn't honor position offsets, which only matter for url() / image-set() raster backgrounds (deferred to image-loader slice \u2014 see backgroundImage).",
+      "supportedValues": [
+        "<keyword>",
+        "<percentage>",
+        "<length>"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 5 css.5 \u2014 registered the previously-missing setBackgroundPosition bridge fn so the JS shim no longer no-ops. Storage-only round-trip: keyword stored verbatim on View::background_position_ slot for a future raster-image paint pass to honor without a JS-side change. Solid-bg paint (which is what Pulp paints today) doesn't position because there's no raster image to position. Catalog stays `supported` since the value coverage (keyword / length / percentage) all parse and survive bridge round-trip; the architectural caveat is: with no raster background pipeline (arch-deferred-image-loader), the offsets have no visual effect.",
+      "issue": ""
+    },
+    "css/backgroundRepeat": {
+      "status": "supported",
+      "mapsTo": "setBackgroundRepeat(id, kw) \u2014 storage-only on the View; paint-time honoring deferred",
+      "supportedValues": [
+        "repeat",
+        "no-repeat",
+        "repeat-x",
+        "repeat-y",
+        "space",
+        "round"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::WidgetBridge setBackgroundRepeat round-trips keyword on View",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1552: bridge fn registered (widget_bridge.cpp). The keyword round-trips through View::set_background_repeat \u2014 the slot is preserved so future paint logic for `background-image: url(...)` / repeating gradients can honor it without an API break. For solid-color backgrounds (today's only painted case) repeat semantics are a no-op, which is why the status remains `partial` rather than `supported`. Mirrors the storage-only strategy used for text-decoration-style (pulp #1434 batch 3). Wave 1 drift cleanup \u2014 partial \u2192 supported (no unsupported values listed; wired through web-compat-style-decl.js).",
+      "issue": "1552"
+    },
+    "css/backgroundSize": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js:1413 forwards `background-size` to setBackgroundSize(id, value); bridge function is registered (widget_bridge.cpp Wave 5 css.5) and stores the keyword on View::background_size_. Storage-only today: same arch-deferred-image-loader caveat as backgroundPosition \u2014 `cover` / `contain` / `<length>` only sized-fit a raster image, and pulp paints solid bg / gradients (which auto-fit to the box).",
+      "supportedValues": [
+        "cover",
+        "contain",
+        "auto",
+        "<length>",
+        "<percentage>"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 5 css.5 \u2014 registered the previously-missing setBackgroundSize bridge fn so the JS shim no longer no-ops. Storage-only round-trip: keyword stored verbatim on View::background_size_ slot for a future raster-image paint pass. The `cover` / `contain` / `auto` / `<length>` / `<percentage>` value space all round-trip through bridge. Architectural caveat: arch-deferred-image-loader \u2014 without a raster bg pipeline these have no visual effect, but the catalog claim is honest because the value is captured and queryable.",
+      "issue": ""
+    },
+    "css/border": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js: 'border' shorthand parses '<width>px solid <color>' and routes to setBorderColor(id, color) + setBorderWidth(id, width) (per-attribute, NOT the unified setBorder, to preserve any prior borderRadius). 'borderColor' / 'borderWidth' / 'borderRadius' route to their respective per-attribute setters too \u2014 see pulp #1166/#1169.",
+      "supportedValues": [
+        "solid (only)",
+        "dashed (accepted; rendered as solid per arch-solid-only-pen)",
+        "dotted (accepted; rendered as solid per arch-solid-only-pen)",
+        "double (accepted; rendered as solid per arch-solid-only-pen)",
+        "groove (accepted; rendered as solid per arch-solid-only-pen)",
+        "ridge (accepted; rendered as solid per arch-solid-only-pen)",
+        "inset (accepted; rendered as solid per arch-solid-only-pen)",
+        "outset (accepted; rendered as solid per arch-solid-only-pen)",
+        "none (border-width 0)",
+        "hidden (border-width 0)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Fixed 2026-04-26 (#1169 / audit PR #1166 finding #4): per-attribute setters now preserve unset siblings, matching CSS semantics. Setting `borderColor` after `borderRadius` no longer zeros the radius. The unified setBorder(id, color, width, radius) is still available for the React `border` object-prop path. Border style ('solid', 'dashed', 'dotted', 'double') is parsed but only the default solid pen is rendered today. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen \u2014 JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
+      "issue": "1166"
+    },
+    "css/borderBottom": {
+      "status": "supported",
+      "mapsTo": "regex parse -> setBorderSide(id, 'bottom', width, color)",
+      "supportedValues": [
+        "solid",
+        "dashed (accepted; rendered as solid per arch-solid-only-pen)",
+        "dotted (accepted; rendered as solid per arch-solid-only-pen)",
+        "double (accepted; rendered as solid per arch-solid-only-pen)",
+        "none (border-width 0)",
+        "hidden (border-width 0)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 4 css extensive \u2014 border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen \u2014 JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
+      "issue": ""
+    },
+    "css/borderBottomColor": {
+      "status": "supported",
+      "mapsTo": "setBorderSide(id, 'bottom', 0, color)",
+      "supportedValues": [
+        "any css color"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderBottomLeftRadius": {
+      "status": "supported",
+      "mapsTo": "setCornerRadius(id, 'BottomLeft', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderBottomRightRadius": {
+      "status": "supported",
+      "mapsTo": "setCornerRadius(id, 'BottomRight', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderBottomWidth": {
+      "status": "supported",
+      "mapsTo": "setBorderSide(id, 'bottom', px, '')",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderCollapse": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "See tableLayout.",
+      "issue": ""
+    },
+    "css/borderColor": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js: 'borderColor' -> setBorderColor(id, color) \u2014 per-attribute, preserves width and radius.",
+      "supportedValues": [
+        "#hex",
+        "#rgba",
+        "rgb()",
+        "rgba()",
+        "hsl()",
+        "hsla()",
+        "oklch()",
+        "oklab()",
+        "lch()",
+        "lab()",
+        "color(srgb|srgb-linear|display-p3)",
+        "transparent",
+        "named colors"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Fixed 2026-04-26 (#1169). Previously routed onto the unified setBorder which clobbered radius. Now uses the dedicated setBorderColor bridge fn. pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up. color-mix() and currentColor remain unsupported (deferred); wide-gamut HDR via Skia SkColor4f is a follow-up \u2014 current path converts to sRGB hex.",
+      "issue": "1166"
+    },
+    "css/borderLeft": {
+      "status": "supported",
+      "mapsTo": "regex parse -> setBorderSide(id, 'left', width, color)",
+      "supportedValues": [
+        "solid",
+        "dashed (accepted; rendered as solid per arch-solid-only-pen)",
+        "dotted (accepted; rendered as solid per arch-solid-only-pen)",
+        "double (accepted; rendered as solid per arch-solid-only-pen)",
+        "none (border-width 0)",
+        "hidden (border-width 0)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 4 css extensive \u2014 border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen \u2014 JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
+      "issue": ""
+    },
+    "css/borderLeftColor": {
+      "status": "supported",
+      "mapsTo": "setBorderSide(id, 'left', 0, color)",
+      "supportedValues": [
+        "any css color"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderLeftWidth": {
+      "status": "supported",
+      "mapsTo": "setBorderSide(id, 'left', px, '')",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderRadius": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js: 'borderRadius' -> setBorderRadius(id, value); accepts px / %; bridge slot is scalar so % is treated as px-equivalent best-effort (no box-relative resolution today).",
+      "supportedValues": [
+        "px",
+        "%",
+        "<length> <length> shorthand (collapsed to the first value per arch-skia-rrect-single-radius)",
+        "1-value / 2-value with `/` separator (parser tolerant; first radius wins per arch-skia-rrect-single-radius)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.2 \u2014 % accepted (parseCSSLength returns the value, forwarded to scalar bridge slot; not box-relative). Fixed 2026-04-26 (#1169). Previously routed onto setBorder and lost color/width on a subsequent borderColor/Width assignment. Wave 1 architectural reclassification \u2014 two-value elliptical + `/` separator syntax are arch-skia-rrect-single-radius (Skia rounded-rect uses a single radius today; elliptical RRect requires SkRRect path). Wave 4 css extensive \u2014 two-value elliptical + `/` separator are arch-skia-rrect-single-radius (Skia's rounded-rect today uses a single scalar per corner; elliptical RRect with separate x/y radii would require SkRRect path-construction and is an explicit non-goal at this surface).",
+      "issue": "1166"
+    },
+    "css/borderRight": {
+      "status": "supported",
+      "mapsTo": "regex parse -> setBorderSide(id, 'right', width, color)",
+      "supportedValues": [
+        "solid",
+        "dashed (accepted; rendered as solid per arch-solid-only-pen)",
+        "dotted (accepted; rendered as solid per arch-solid-only-pen)",
+        "double (accepted; rendered as solid per arch-solid-only-pen)",
+        "none (border-width 0)",
+        "hidden (border-width 0)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 4 css extensive \u2014 border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen \u2014 JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
+      "issue": ""
+    },
+    "css/borderRightColor": {
+      "status": "supported",
+      "mapsTo": "setBorderSide(id, 'right', 0, color)",
+      "supportedValues": [
+        "any css color"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderRightWidth": {
+      "status": "supported",
+      "mapsTo": "setBorderSide(id, 'right', px, '')",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderSpacing": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "See tableLayout.",
+      "issue": ""
+    },
+    "css/borderStyle": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards the keyword verbatim to setBorderStyle (widget_bridge.cpp); View::BorderStyle stores the enum; view.cpp paint installs SkDashPathEffect via canvas.set_line_dash(...) for dashed/dotted at stroke time.",
+      "supportedValues": [
+        "solid",
+        "dashed",
+        "dotted",
+        "none",
+        "hidden",
+        "double (degrades to solid)",
+        "groove (degrades to solid)",
+        "ridge (degrades to solid)",
+        "inset (degrades to solid)",
+        "outset (degrades to solid)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setBorderStyle maps each keyword to the right enum\"",
+        "test/test_widget_bridge.cpp::\"dashed border emits set_line_dash command then clears it\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Triage #10 \u2014 Skia paint installs SkDashPathEffect for dashed/dotted (CG falls through to solid via the canvas-base no-op set_line_dash). View::BorderStyle enum stores the keyword; bridge maps strings; Skia honors at stroke time. Other named styles (double/groove/ridge/inset/outset) currently degrade to solid \u2014 paint-side compositions are a follow-up. none/hidden short-circuit the stroke entirely.",
+      "issue": ""
+    },
+    "css/borderTop": {
+      "status": "supported",
+      "mapsTo": "regex parse -> setBorderSide(id, 'top', width, color)",
+      "supportedValues": [
+        "solid",
+        "dashed (accepted; rendered as solid per arch-solid-only-pen)",
+        "dotted (accepted; rendered as solid per arch-solid-only-pen)",
+        "double (accepted; rendered as solid per arch-solid-only-pen)",
+        "none (border-width 0)",
+        "hidden (border-width 0)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 4 css extensive \u2014 border-style values dashed/dotted/double/groove/ridge/inset/outset/none/hidden are arch-solid-only-pen \u2014 JS+bridge accept the keyword (round-trip without crash) but the paint pipeline draws a single solid pen by design (see core/view/src/view.cpp paint_border). 'none'/'hidden' equate to border-width 0 which is the natural representation in Yoga.",
+      "issue": ""
+    },
+    "css/borderTopColor": {
+      "status": "supported",
+      "mapsTo": "setBorderSide(id, 'top', 0, color)",
+      "supportedValues": [
+        "any css color"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Sets width to 0 -- must combine with borderTopWidth. Quirk.",
+      "issue": ""
+    },
+    "css/borderTopLeftRadius": {
+      "status": "supported",
+      "mapsTo": "setCornerRadius(id, 'TopLeft', px); accepts % (forwarded as scalar best-effort, see borderRadius for the same caveat).",
+      "supportedValues": [
+        "px",
+        "%",
+        "elliptical x/y (collapsed to the x value per arch-skia-rrect-single-radius)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.2 \u2014 % accepted. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 elliptical x/y form is arch-skia-rrect-single-radius (single scalar slot per corner; elliptical paths require SkRRect rebuild and are an explicit non-goal at this surface).",
+      "issue": ""
+    },
+    "css/borderTopRightRadius": {
+      "status": "supported",
+      "mapsTo": "setCornerRadius(id, 'TopRight', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderTopWidth": {
+      "status": "supported",
+      "mapsTo": "setBorderSide(id, 'top', px, '')",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderWidth": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js: parseCSSLength + thin/medium/thick keyword expansion (1/2/4 px) -> setBorderWidth(id, px). % values forward the parsed value verbatim (scalar bridge slot, no box-relative resolution).",
+      "supportedValues": [
+        "px",
+        "thin (1px)",
+        "medium (2px)",
+        "thick (4px)",
+        "% (best-effort scalar)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.2 \u2014 thin/medium/thick keyword expansion + % acceptance. Per CSS Backgrounds & Borders L3, thin/medium/thick are author-named widths; canonical browser values are 1/3/5px but pulp picks 1/2/4 for a slightly thinner ladder at 1x DPI (authors who want exact browser parity pass numeric px).",
+      "issue": ""
+    },
+    "css/bottom": {
+      "status": "supported",
+      "mapsTo": "setBottom(id, px); JS shim resolves em/rem (\u00d7 14px default), vh/vw (\u00d7 600/800 default viewport), % flows verbatim through the 'NN%' bridge path -> YGNodeStyleSetPositionPercent.",
+      "supportedValues": [
+        "px",
+        "%",
+        "em",
+        "rem",
+        "vh",
+        "vw"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.2 \u2014 em/rem/vh/vw resolved in JS using the same default font-size (14px) and viewport (800x600) as resolveLength in css-parser.js. Single-level cascade; nested font-size cascade is the follow-up. pulp #1434 batch 6: percent values flow through the bridge via 'NN%'.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1434"
+    },
+    "css/boxShadow": {
+      "status": "supported",
+      "mapsTo": "regex parse -> setBoxShadow(id, dx, dy, blur, spread, color, inset)",
+      "supportedValues": [
+        "[inset] <dx>px <dy>px <blur>px [<spread>px] <color>",
+        "comma-separated multi-shadow (first shadow wins per arch-single-shadow)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Single-shadow only. Multiple comma-separated shadows are not split. pulp #1434 Triage #15: catalog status flipped supported\u2192partial \u2014 single-shadow with optional inset is wired (web-compat-style-decl.js:565); multi-shadow comma-separated lists are deferred. Wave 4 css extensive \u2014 multi-shadow comma-separated lists are arch-single-shadow (View::shadow_ stores a single ShadowSpec; stacking multiple drop-shadows would require a layered SkLayer paint pass and is an explicit non-goal \u2014 when authors need two shadows they use boxShadow + filter:drop-shadow).",
+      "issue": ""
+    },
+    "css/boxSizing": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js + prop-applier.ts -> setBoxSizing(id, kw) -> FlexStyle.box_sizing -> YGNodeStyleSetBoxSizing(YGBoxSizingBorderBox|ContentBox). Yoga 3.x honors the spec natively, so padding+border are subtracted from declared dimensions when border-box is set.",
+      "supportedValues": [
+        "content-box",
+        "border-box",
+        "border-box (pulp default; declared width/height includes padding+border \u2014 matches Yoga 3.x's own default and what virtually every modern web design expects)",
+        "content-box (CSS spec default; padding+border are outside declared dimensions, so a 100px-wide box with 10px padding has 120px outer width)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1516]"
+      ],
+      "notes": "pulp #1516 \u2014 Yoga 3.2.1's native YGNodeStyleSetBoxSizing does the spec-correct math; previously the JS shim silently no-op'd because the bridge didn't register setBoxSizing. The default is `border-box` (matches Yoga 3.x's default + pulp's implicit pre-#1516 behavior + the de-facto `* { box-sizing: border-box }` web reset). Consumers that explicitly want CSS-spec content-box semantics can opt in via `boxSizing: 'content-box'`. High-leverage change for design imports \u2014 Figma / v0 / Claude Design HTML exports often emit explicit boxSizing declarations that previously dropped silently.",
+      "issue": "1516"
+    },
+    "css/captionSide": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "See tableLayout.",
+      "issue": ""
+    },
+    "css/clear": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Float-companion property -- not relevant.",
+      "issue": ""
+    },
+    "css/clipPath": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js parses `clip-path` and forwards path(\"...\") to setClipPath(id, svg_d). Skia parses via SkPath::FromSVGString and the canvas installs the clip on paint (#1540). url() / circle() / inset() / polygon() / ellipse() are deferred \u2014 the bridge stores an empty path so previous values don't linger.",
+      "supportedValues": [
+        "path(\"...\")",
+        "none"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 A4 Bundle 6: status flipped missing \u2192 partial. Wiring landed in #1540 (clip_path_svg). Wave 1 architectural reclassification \u2014 Pulp wires only SVG `path()` by design (arch-path-only); url() / circle() / ellipse() / inset() / polygon() / box keywords are explicit non-goals (the Skia path is the universal primitive).",
+      "issue": ""
+    },
+    "css/color": {
+      "status": "supported",
+      "mapsTo": "parseCSSColor -> setTextColor(id, hex)",
+      "supportedValues": [
+        "#hex",
+        "#rgba",
+        "rgb()",
+        "rgba()",
+        "hsl()",
+        "hsla()",
+        "oklch()",
+        "oklab()",
+        "lch()",
+        "lab()",
+        "color(srgb|srgb-linear|display-p3)",
+        "transparent",
+        "named colors"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up. color-mix() and currentColor remain unsupported (deferred); wide-gamut HDR via Skia SkColor4f is a follow-up \u2014 current path converts to sRGB hex.",
+      "issue": ""
+    },
+    "css/columnCount": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "See columns.",
+      "issue": ""
+    },
+    "css/columnGap": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'column_gap', px) for numeric, 'NN%' string for percent (best-effort: stored on the scalar FlexStyle.column_gap slot since Yoga has no YGNodeStyleSetGapPercent API yet \u2014 treated as px until upstream Yoga ships percent-aware gap).",
+      "supportedValues": [
+        "px",
+        "% (best-effort scalar)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.2 \u2014 % accepted at the JS+bridge layer; honest stored-as-scalar caveat documented above. Status stays partial because Yoga doesn't yet honor percent gaps (px-equivalent only). Wave 4 css extensive \u2014 % is best-effort (stored on the scalar slot, treated as px-equivalent) until upstream Yoga ships YGNodeStyleSetGapPercent \u2014 tracked as deferred-yoga-percent-gap. Status flipped partial -> supported because every CSS-spec value (px / %) round-trips through the bridge today; the % honoring is the orthogonal Yoga upstream follow-up.",
+      "issue": ""
+    },
+    "css/columnRule": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "See columns.",
+      "issue": ""
+    },
+    "css/columnWidth": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "See columns.",
+      "issue": ""
+    },
+    "css/columns": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Multi-column layout out of scope; not aligned with Yoga or RN.",
+      "issue": ""
+    },
+    "css/contain": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Browser-only optimization hint.",
+      "issue": ""
+    },
+    "css/content": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "::before/::after not supported (no pseudo-element model).",
+      "issue": ""
+    },
+    "css/contentVisibility": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Browser-only optimization hint.",
+      "issue": ""
+    },
+    "css/counterIncrement": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not in scope.",
+      "issue": ""
+    },
+    "css/counterReset": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "CSS counters not in scope.",
+      "issue": ""
+    },
+    "css/cursor": {
+      "status": "supported",
+      "mapsTo": "setCursor(id, value) \u2014 widget_bridge.cpp maps the full CSS keyword set to View::CursorStyle. col-resize/ew-resize/e-resize/w-resize \u2192 horizontal_resize; row-resize/ns-resize/n-resize/s-resize \u2192 vertical_resize; nwse/nw/se \u2192 top_left_resize; nesw/ne/sw \u2192 top_right_resize; move/all-scroll \u2192 multi_directional_resize; none/hidden \u2192 invisible; pointer/crosshair/text/grab/grabbing/not-allowed/no-drop/vertical-text mapped 1:1.",
+      "supportedValues": [
+        "default",
+        "pointer",
+        "crosshair",
+        "text",
+        "vertical-text",
+        "grab",
+        "grabbing",
+        "not-allowed",
+        "no-drop",
+        "col-resize",
+        "row-resize",
+        "ew-resize",
+        "ns-resize",
+        "nwse-resize",
+        "nesw-resize",
+        "n-resize",
+        "s-resize",
+        "e-resize",
+        "w-resize",
+        "nw-resize",
+        "ne-resize",
+        "sw-resize",
+        "se-resize",
+        "move",
+        "all-scroll",
+        "none",
+        "hidden",
+        "auto",
+        "cell",
+        "context-menu",
+        "help",
+        "progress",
+        "wait",
+        "zoom-in",
+        "zoom-out"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setCursor maps the full CSS keyword set\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Triage #7 \u2014 cursor enum fan-out. Unknown keywords fall back to default. CSS values without a CursorStyle slot today (alias/copy/cell/zoom-in/zoom-out/help/wait/progress/context-menu) also fall back to default; tracked for a follow-up that adds dedicated CursorStyle slots + platform-specific glyphs. url() cursor images are not supported (browser-specific feature). Wave 1 architectural reclassification \u2014 auto/cell/context-menu/help/progress/wait/zoom-in/zoom-out fall back to default by design (arch-platform-cursor-set; Pulp uses pointer/text/grab/grabbing + the resize family by design \u2014 adding more requires platform-specific glyphs and is an explicit OOS). Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 auto / cell / context-menu / help / progress / wait / zoom-in / zoom-out are arch-platform-cursor-set (accepted at the bridge \u2014 setCursor falls back to the default cursor glyph for unknown keywords). Adding dedicated CursorStyle slots + platform-specific glyph dispatch is the follow-up.",
+      "issue": ""
+    },
+    "css/direction": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards `direction` to setDirection(id, value). The bridge maps to View::WritingDirection; Yoga honors at layout time and Skia paragraph_style at text shape time (#1506). Logical-edge mapping in the JS shim still uses the LTR fast path; direction-aware logical\u2192physical resolution is the follow-up.",
+      "supportedValues": [
+        "ltr",
+        "rtl"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 A4 Bundle 6: status flipped missing \u2192 partial. Bridge wiring landed in #1506; CSS surface gets the same setDirection routing. Wave 1 drift cleanup \u2014 logical-edge mapping verified via Bundle 3 fast-path (#1506).",
+      "issue": ""
+    },
+    "css/display": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js: 'display' -> setVisible(id, false) on 'none', setVisible(id, true) on 'flex'/'block'. 'grid' is acknowledged but only takes effect when gridTemplateColumns/Rows is also set. Yoga has no 'block', 'inline', 'inline-block', 'table', 'contents' modes -- Pulp is flex-only.",
+      "supportedValues": [
+        "flex",
+        "none",
+        "block",
+        "inline",
+        "inline-block",
+        "inline-flex",
+        "inline-grid",
+        "grid",
+        "contents",
+        "table",
+        "table-row",
+        "table-cell"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Yoga's underlying view model is exclusively flex. 'block' is silently aliased to 'flex'. RN's display enum is {none, flex, contents} which matches us better than CSS. The Display enum on the C++ View has no direct field -- visibility is implemented via View::set_visible. There is no 'partial' display rendering -- non-flex values render as flex with default direction. 2026-04-28 (#1167 / pulp #1147): `display: flex` now defaults flex-direction to 'row' to match CSS web compat (Pulp's underlying widgets default to 'col' / FlexDirection::column from RN convention, so the JS shim emits an explicit 'row' when the consumer didn't declare flexDirection / flex-direction / flex-flow with a direction token). Wave 1 architectural reclassification \u2014 non-flex display modes are arch-flex-only per CLAUDE.md design philosophy (Yoga's view model is exclusively flex; 'block' is silently aliased to 'flex'; grid/inline/inline-block/table/contents/inline-flex/inline-grid/list-item won't fix without violating the flex-only design). Wave 4 css extensive \u2014 non-flex display modes (inline / inline-block / inline-flex / inline-grid / grid / contents / table / table-row / table-cell) are arch-flex-only (Yoga's view model is exclusively flex; these values round-trip through the JS shim \u2014 `block` is silently aliased to `flex`, `none` hides via setVisible(id, false), the rest fall through to flex with default direction). Adding non-flex layout would violate the flex-only design (per CLAUDE.md). Reclassified value coverage out of unsupportedValues per the Wave 1 backgroundAttachment precedent.",
+      "issue": "1147"
+    },
+    "css/emptyCells": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "See tableLayout.",
+      "issue": ""
+    },
+    "css/filter": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards `filter` keyword string verbatim to setFilter (widget_bridge.cpp); bridge parses the function chain into View::FilterOp[]; view.cpp paint dispatches via canvas.save_layer_with_filters; Skia backend composes the chain via SkImageFilters::Compose + SkColorFilters::Matrix.",
+      "supportedValues": [
+        "blur(<px>)",
+        "brightness(<number>)",
+        "contrast(<number>)",
+        "grayscale(<number>)",
+        "hue-rotate(<deg|rad|turn|grad>)",
+        "invert(<number>)",
+        "opacity(<number>)",
+        "saturate(<number>)",
+        "sepia(<number>)",
+        "drop-shadow(<dx> <dy> <blur> <color>)",
+        "chained functions in source order",
+        "\"none\" clears the chain"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setFilter parses chained functions in source order\"",
+        "test/test_widget_bridge.cpp::\"setFilter parses brightness/contrast/grayscale/etc\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-4 \u2014 full CSS filter chain. setFilter parses the function-call sequence into View::FilterOp[]; view.cpp paint hands off to canvas.save_layer_with_filters; Skia composes via SkImageFilters::Compose + SkColorFilters::Matrix per filter. CG path falls back to blur-only collapse (no SkColorFilter equivalent yet). Full function set: blur / brightness / contrast / grayscale / hue-rotate / invert / opacity / saturate / sepia / drop-shadow. CG canvas backend currently degrades the chain to blur-only collapse (color-matrix filters silently no-op); SkColorFilter-equivalent for CG is a follow-up.",
+      "issue": ""
+    },
+    "css/flex": {
+      "status": "supported",
+      "mapsTo": "shorthand: setFlex(id, 'flex_grow'/'flex_shrink'/'flex_basis', ...)",
+      "supportedValues": [
+        "<grow>",
+        "<grow> <shrink>",
+        "<grow> <shrink> <basis>",
+        "'auto'",
+        "'none'",
+        "'initial'"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "The CSS shorthand keywords (auto/none/initial) parse as NaN and silently set flex_grow=0. Wave 1 drift cleanup \u2014 'auto'/'none'/'initial' keywords wired via yoga A4 (#1622); previously parsed as NaN and silently set flex_grow=0.",
+      "issue": ""
+    },
+    "css/flexBasis": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'flex_basis', px)",
+      "supportedValues": [
+        "px",
+        "%",
+        "auto",
+        "content (treated as auto per arch-yoga-no-content-basis)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Yoga supports 'auto' and percentages; Pulp accepts only px float. pulp #1434 rn batch C: % and auto wired via FlexStyle::dim_flex_basis. Wave 4 css extensive \u2014 `content` keyword is arch-yoga-no-content-basis (Yoga's flex-basis is a scalar / percent / auto; the `content` keyword would require intrinsic-size resolution which Yoga doesn't model today). Authors use `auto` for the equivalent fall-back behaviour.",
+      "issue": ""
+    },
+    "css/flexDirection": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'direction', 'row' | 'col')",
+      "supportedValues": [
+        "row",
+        "column",
+        "row-reverse",
+        "column-reverse"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "MAJOR GAP -- Pulp's FlexDirection enum (geometry.hpp:61) only has {row, column}. Reverse modes silently fall through to default 'col'. pulp #1434 rn batch B: row-reverse/column-reverse now route to YGFlexDirectionRowReverse/ColumnReverse via the CSS shim + bridge.",
+      "issue": ""
+    },
+    "css/flexFlow": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js shorthand parser fans out into setFlex(direction, ...) and setFlex(flex_wrap, ...) \u2014 supports row / column / row-reverse / column-reverse and wrap / nowrap / wrap-reverse.",
+      "supportedValues": [
+        "row|column|row-reverse|column-reverse",
+        "nowrap|no-wrap|wrap|wrap-reverse",
+        "combined two-token shorthand (e.g. \"row wrap-reverse\")"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"flex-flow shorthand recognizes wrap-reverse\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Triage #14 \u2014 extended shorthand parser to recognize -reverse modes.",
+      "issue": ""
+    },
+    "css/flexGrow": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'flex_grow', n)",
+      "supportedValues": [
+        "number"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "css/flexShrink": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'flex_shrink', n)",
+      "supportedValues": [
+        "number"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "css/flexWrap": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards the keyword verbatim to setFlex(flex_wrap, 'wrap'|'wrap-reverse'|'nowrap'); FlexStyle.flex_wrap is now a tri-state FlexWrap enum; yoga_layout.cpp dispatches via YGWrapWrap / YGWrapWrapReverse / YGWrapNoWrap.",
+      "supportedValues": [
+        "nowrap",
+        "no-wrap",
+        "wrap",
+        "wrap-reverse"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setFlex flex_wrap accepts wrap-reverse keyword\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Triage #14 \u2014 FlexStyle.flex_wrap converted from bool to tri-state enum; YGWrapWrapReverse is dispatched for wrap-reverse.",
+      "issue": ""
+    },
+    "css/float": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "left",
+        "right",
+        "none"
+      ],
+      "tests": [],
+      "notes": "CSS float not relevant under a flex-only layout model.",
+      "issue": ""
+    },
+    "css/fontFamily": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js + widget_bridge.cpp setFontFamily \u2014 both layers split CSS lists on commas, trim, strip outer quotes, and pick the first non-empty family. Bridge stores the value on Label or in the View's inheritable_font_family_ slot (cascade). PR #1174 + pulp #1434 Phase A2-5.",
+      "supportedValues": [
+        "single font name (quoted or not)",
+        "comma-separated font lists ('JetBrains Mono', ui-monospace, monospace) \u2014 first non-empty family wins"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1434-fontfamily]"
+      ],
+      "notes": "Wave 2 css.4 \u2014 reclassified partial -> partial-deferred-#932 (whole-list fallback is gated on Skia SkFontMgr font registration in pulp #932, not a JS-side gap). Phase A2-5 (pulp #1434) added @pulp/react JSX dispatch and a bridge-side list parser so direct setFontFamily('id', 'A, B, C') calls are now correct. The cascade slot on container Views means container-level fontFamily reaches descendant Labels via parent-walk (mirrors letter_spacing / font_weight). Wave 4 css extensive \u2014 drift cleanup \u2014 value-coverage is complete (single name + comma-separated list both round-trip; first family wins). The Skia SkFontMgr fallback-chain gating (pulp #932) is documented in mapsTo / notes; reclassified as paint-side architectural gap rather than a value-coverage gap.",
+      "issue": "1151"
+    },
+    "css/fontSize": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js: parseCSSLength + em/rem/% resolution (\u00d7 default 14px) + smaller/larger keyword expansion (0.83x/1.2x); -> setFontSize(id, px).",
+      "supportedValues": [
+        "px",
+        "em",
+        "rem",
+        "%",
+        "smaller (0.83x)",
+        "larger (1.2x)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.2 \u2014 em/rem/% resolved against the default 14px font-size (matches resolveLength fallback). smaller/larger expand to 0.83x and 1.2x per CSS spec. Multi-level cascade (resolving em against an actual ancestor font-size) is the follow-up; the single-level resolver covers the common case.",
+      "issue": ""
+    },
+    "css/fontStyle": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js: 'oblique' (and 'oblique <angle>') aliased to 'italic' before reaching setFontStyle (Skia distinguishes italic-vs-oblique only when the font has a `slnt` variation axis, which most bundled fonts don't ship); -> setFontStyle(id, 'italic'|'normal').",
+      "supportedValues": [
+        "normal",
+        "italic",
+        "oblique"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.4 \u2014 oblique alias upgrades a silent no-op (the bridge previously only honored 'italic') to the closest visual approximation. Real oblique requires SkFont variation axes which is the follow-up. Wave 4 css extensive \u2014 label cleanup \u2014 `oblique` claims the bare keyword (the bridge aliases to italic which is the closest visual approximation today). `oblique <angle>` is arch-paint-deferred (real oblique requires SkFont variation axes which is the documented follow-up).",
+      "issue": ""
+    },
+    "css/fontVariant": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards `font-variant` to setFontVariant(id, value); the bridge stores the value on View::font_variant_. HarfBuzz feature wiring is the follow-up; mirrors the rn surface choice on the same A4 sweep.",
+      "supportedValues": [
+        "<font-feature keyword set>"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 A4 Bundle 7: status flipped missing \u2192 partial. setFontVariant bridge fn now exists; mirrors rn/fontVariant. Wave 4 css extensive \u2014 HarfBuzz feature integration is arch-paint-deferred (the bridge stores the value on View::font_variant_; HarfBuzz line-break/feature wiring at paint time is the follow-up tracked in mapsTo). Reclassified as paint-side gap rather than value-coverage gap.",
+      "issue": ""
+    },
+    "css/fontWeight": {
+      "status": "supported",
+      "mapsTo": "translate keyword/numeric \u2192 setFontWeight(id, n)",
+      "supportedValues": [
+        "100..900 (numeric)",
+        "normal",
+        "bold",
+        "lighter",
+        "bolder"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/web-compat/test_css_translator_gaps_1434.cpp [issue-1434-batch-3]",
+        "packages/pulp-react/test/prop-applier-fontweight.test.ts"
+      ],
+      "notes": "Keyword-to-numeric: normal\u2192400, bold\u2192700, lighter\u2192300, bolder\u2192700. Numeric keywords parse unchanged. Mirrored in @pulp/react prop-applier (_normalizeFontWeight).",
+      "issue": "1434"
+    },
+    "css/gap": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js: single-token form -> setFlex(id, 'gap', px); two-token form 'row col' -> setFlex(row_gap) + setFlex(column_gap). % accepted (best-effort scalar \u2014 same caveat as rowGap/columnGap).",
+      "supportedValues": [
+        "px (number)",
+        "% (best-effort scalar)",
+        "two-value 'row col' syntax"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.2 \u2014 two-value form fans out to row_gap + column_gap; % accepted at JS+bridge (Yoga gap is scalar-only today, no YGNodeStyleSetGapPercent yet).",
+      "issue": ""
+    },
+    "css/gridArea": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards keyword/value verbatim to setGrid; bridge stores on GridStyle. layout_grid (view.cpp) honors template_columns/rows + per-child column/row spans + col/row gaps. PRs 2-3 of the A2-2 ladder add auto-flow dense-packing + named-area resolution.",
+      "supportedValues": [
+        "template_columns/rows: fixed-px / \"Nfr\" / \"auto\"",
+        "gap / column-gap / row-gap",
+        "gridColumn / gridRow shorthand",
+        "template_areas: named-area string",
+        "grid-area: named token or \"row / col / row / col\""
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "issue": ""
+    },
+    "css/gridAutoColumns": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards keyword/value verbatim to setGrid; bridge stores on GridStyle. layout_grid (view.cpp) honors template_columns/rows + per-child column/row spans + col/row gaps. PRs 2-3 of the A2-2 ladder add auto-flow dense-packing + named-area resolution.",
+      "supportedValues": [
+        "template_columns/rows: fixed-px / \"Nfr\" / \"auto\"",
+        "gap / column-gap / row-gap",
+        "gridColumn / gridRow shorthand",
+        "template_areas: named-area string",
+        "grid-area: named token or \"row / col / row / col\""
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "issue": ""
+    },
+    "css/gridAutoFlow": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards keyword/value verbatim to setGrid; bridge stores on GridStyle. layout_grid (view.cpp) honors template_columns/rows + per-child column/row spans + col/row gaps. PRs 2-3 of the A2-2 ladder add auto-flow dense-packing + named-area resolution.",
+      "supportedValues": [
+        "template_columns/rows: fixed-px / \"Nfr\" / \"auto\"",
+        "gap / column-gap / row-gap",
+        "gridColumn / gridRow shorthand",
+        "template_areas: named-area string",
+        "grid-area: named token or \"row / col / row / col\""
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "issue": ""
+    },
+    "css/gridAutoRows": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards keyword/value verbatim to setGrid; bridge stores on GridStyle. layout_grid (view.cpp) honors template_columns/rows + per-child column/row spans + col/row gaps. PRs 2-3 of the A2-2 ladder add auto-flow dense-packing + named-area resolution.",
+      "supportedValues": [
+        "template_columns/rows: fixed-px / \"Nfr\" / \"auto\"",
+        "gap / column-gap / row-gap",
+        "gridColumn / gridRow shorthand",
+        "template_areas: named-area string",
+        "grid-area: named token or \"row / col / row / col\""
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "issue": ""
+    },
+    "css/gridColumn": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards keyword/value verbatim to setGrid; bridge stores on GridStyle. layout_grid (view.cpp) honors template_columns/rows + per-child column/row spans + col/row gaps. PRs 2-3 of the A2-2 ladder add auto-flow dense-packing + named-area resolution.",
+      "supportedValues": [
+        "template_columns/rows: fixed-px / \"Nfr\" / \"auto\"",
+        "gap / column-gap / row-gap",
+        "gridColumn / gridRow shorthand",
+        "template_areas: named-area string",
+        "grid-area: named token or \"row / col / row / col\""
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "issue": ""
+    },
+    "css/gridRow": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards keyword/value verbatim to setGrid; bridge stores on GridStyle. layout_grid (view.cpp) honors template_columns/rows + per-child column/row spans + col/row gaps. PRs 2-3 of the A2-2 ladder add auto-flow dense-packing + named-area resolution.",
+      "supportedValues": [
+        "template_columns/rows: fixed-px / \"Nfr\" / \"auto\"",
+        "gap / column-gap / row-gap",
+        "gridColumn / gridRow shorthand",
+        "template_areas: named-area string",
+        "grid-area: named token or \"row / col / row / col\""
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "issue": ""
+    },
+    "css/gridTemplateAreas": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards keyword/value verbatim to setGrid; bridge stores on GridStyle. layout_grid (view.cpp) honors template_columns/rows + per-child column/row spans + col/row gaps. PRs 2-3 of the A2-2 ladder add auto-flow dense-packing + named-area resolution.",
+      "supportedValues": [
+        "template_columns/rows: fixed-px / \"Nfr\" / \"auto\"",
+        "gap / column-gap / row-gap",
+        "gridColumn / gridRow shorthand",
+        "template_areas: named-area string",
+        "grid-area: named token or \"row / col / row / col\""
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "issue": ""
+    },
+    "css/gridTemplateColumns": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards keyword/value verbatim to setGrid; bridge stores on GridStyle. layout_grid (view.cpp) honors template_columns/rows + per-child column/row spans + col/row gaps. PRs 2-3 of the A2-2 ladder add auto-flow dense-packing + named-area resolution.",
+      "supportedValues": [
+        "template_columns/rows: fixed-px / \"Nfr\" / \"auto\"",
+        "gap / column-gap / row-gap",
+        "gridColumn / gridRow shorthand",
+        "template_areas: named-area string",
+        "grid-area: named token or \"row / col / row / col\""
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "issue": ""
+    },
+    "css/gridTemplateRows": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards keyword/value verbatim to setGrid; bridge stores on GridStyle. layout_grid (view.cpp) honors template_columns/rows + per-child column/row spans + col/row gaps. PRs 2-3 of the A2-2 ladder add auto-flow dense-packing + named-area resolution.",
+      "supportedValues": [
+        "template_columns/rows: fixed-px / \"Nfr\" / \"auto\"",
+        "gap / column-gap / row-gap",
+        "gridColumn / gridRow shorthand",
+        "template_areas: named-area string",
+        "grid-area: named token or \"row / col / row / col\""
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setGrid auto_columns / auto_rows / auto_flow\"",
+        "test/test_widget_bridge.cpp::\"parse_template_areas: simple 3x3 grid\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-2 PR 1 \u2014 grid surface extension. New GridStyle fields: auto_columns / auto_rows / auto_flow / template_areas + per-child grid_area_name. parse_template_areas walks the CSS named-area string into a NamedArea[] map; setGrid('grid_area', ...) accepts both named-token and numeric forms. The existing layout_grid algorithm consumes template_columns/rows/gaps/per-child placement \u2014 multi-stop named-area resolution + auto-flow dense-packing land in PRs 2-3 of the ladder.",
+      "issue": ""
+    },
+    "css/height": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'height', px) for numeric, 'NN%' for percent, 'auto' for hug-contents (yoga/height path via FlexStyle.dim_height)",
+      "supportedValues": [
+        "px (number)",
+        "%",
+        "auto",
+        "em (resolved against default 14px per arch-single-level-cascade)",
+        "rem (resolved against default 14px per arch-single-level-cascade)",
+        "min-content (treated as auto per arch-yoga-no-intrinsic-sizing)",
+        "max-content (treated as auto per arch-yoga-no-intrinsic-sizing)",
+        "fit-content (treated as auto per arch-yoga-no-intrinsic-sizing)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1423 wired px + %; pulp #1434 (sub-agent #12 follow-up) wired 'auto' end-to-end (CSS translator forwards 'auto' verbatim; bridge populates FlexStyle.dim_height.unit = auto_; yoga_layout.cpp dispatches to YGNodeStyleSetHeightAuto). Relative units (em/rem/vh/vw) remain deferred. Wave 1 architectural reclassification \u2014 min-content / max-content / fit-content are arch-yoga-limit (Yoga doesn't compute content-sized boxes); em/rem are deferred (relative-unit resolver lands later). Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 min-content / max-content / fit-content are arch-yoga-no-intrinsic-sizing (Yoga's flex layout doesn't model intrinsic sizing; use flex / flex-basis for the equivalent shrink-to-fit behaviour). calc() is arch-no-calc-eval (no expression evaluator at the JS shim layer; authors precompute or use JS variables). em/rem resolve against the default 14px font-size at the JS layer (single-level cascade per Wave 2 css.2 fontSize precedent).",
+      "issue": "https://github.com/danielraffel/pulp/issues/1434"
+    },
+    "css/inset": {
+      "status": "supported",
+      "mapsTo": "expandShorthand -> setTop/setRight/setBottom/setLeft",
+      "supportedValues": [
+        "1-4 px tokens"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Shorthand expands correctly. Underlying setTop/etc. are px only.",
+      "issue": ""
+    },
+    "css/isolation": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js -> setIsolation(id, kw) -> View::set_isolation slot. Pulp's per-View save_layer_with_blend model (pulp #1549) is structurally isolated by default: each View with mix-blend-mode opens its own composition layer and composites back to its parent normally \u2014 no cross-stacking-context blend leakage. Z-index is paint-order scoped to siblings within a parent. Both author intents of `isolation: isolate` (blend-mode containment + stacking-context creation) happen by default.",
+      "supportedValues": [
+        "auto",
+        "isolate"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "unit:test_widget_bridge#issue-1737"
+      ],
+      "notes": "pulp #1434 A4 Bundle 6 (initial wontfix) + pulp #1737 RN-OOS-fixup final round (this slice): walked back from wontfix to supported as honest CSS-subset claim. The earlier wontfix was correct that Pulp has no explicit stacking-context engine, but the audit revealed that the per-View paint model already produces the `isolate` outcome by structural accident: each View with mix-blend-mode (via save_layer_with_blend, pulp #1549) has its own composition layer, so child blends cannot reach through their parent to blend against the parent's siblings. Z-index is paint-order scoped to siblings within a parent, so child z-index does not promote past the parent. Both author intents of `isolation: isolate` (blend-mode containment + stacking-context creation) are met by default in Pulp regardless of the keyword set. Same CSS-subset pattern as overscrollBehavior, includeFontPadding, scrollBehavior from earlier this session. Catalog claim: both keywords round-trip; single consistent behavior produced; author intent matches the `isolate` outcome.",
+      "issue": ""
+    },
+    "css/justifyContent": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'justify_content', value)",
+      "supportedValues": [
+        "flex-start",
+        "flex-end",
+        "center",
+        "space-between",
+        "space-around",
+        "space-evenly"
+      ],
+      "unsupportedValues": [
+        "left (direction-context-dependent: on a column container both 'left' and 'right' behave as 'start' per CSS Box Alignment; a direction-agnostic alias would silently misrender vertical flex containers)",
+        "right (same direction-context dependency; 'right' is flex-end only on row-LTR containers)",
+        "stretch (CSS spec grows AUTO-sized items equally; FlexJustify has no equivalent enum -- aliasing to flex-start would silently misrender stretching layouts)",
+        "normal (per spec behaves as 'stretch' on flex containers; inherits the same problem)"
+      ],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]",
+        "test/test_widget_bridge.cpp [issue-1434] (setFlex justify_content: left/right/stretch/normal stay unsupported (direction-dep + arch))"
+      ],
+      "notes": "FlexJustify enum: {start, center, end_, space_between, space_around, space_evenly}. pulp #1434 Tier 1 (PR-B): NO new direction-context-dependent aliases were added. Codex P1 on PR #1853 (two findings): 'left'/'right' are NOT aliased because their CSS semantics depend on flex-direction (column containers have both behave as 'start'); 'stretch' and 'normal' are NOT aliased because FlexJustify has no stretch equivalent. The dispatcher's default branch sets FlexJustify::start so unknown values fall through safely. All four are documented in unsupportedValues with rationale; pinned by [issue-1434].",
+      "issue": ""
+    },
+    "css/left": {
+      "status": "supported",
+      "mapsTo": "setLeft(id, px); JS shim resolves em/rem (\u00d7 14px default), vh/vw (\u00d7 600/800 default viewport), % flows verbatim through the 'NN%' bridge path -> YGNodeStyleSetPositionPercent.",
+      "supportedValues": [
+        "px",
+        "%",
+        "em",
+        "rem",
+        "vh",
+        "vw"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.2 \u2014 em/rem/vh/vw resolved in JS using the same default font-size (14px) and viewport (800x600) as resolveLength in css-parser.js. Single-level cascade; nested font-size cascade is the follow-up. pulp #1434 batch 6: percent values flow through the bridge via 'NN%'.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1434"
+    },
+    "css/letterSpacing": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js: parseCSSLength + em resolution (\u00d7 default 14px) + normal keyword (= 0); -> setLetterSpacing(id, px).",
+      "supportedValues": [
+        "px",
+        "em",
+        "rem",
+        "normal"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.2 \u2014 em/rem resolved against the default 14px font-size (same caveat as fontSize re: single-level cascade). normal -> 0 per CSS spec.",
+      "issue": ""
+    },
+    "css/lineClamp": {
+      "status": "supported",
+      "mapsTo": "parseInt -> setLineClamp(id, n) \u2014 Label paint emits at most N lines + U+2026 ellipsis on the last visible line if source lines were dropped",
+      "supportedValues": [
+        "integer"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::WidgetBridge setLineClamp stores count on Label",
+        "test/test_widget_bridge.cpp::WidgetBridge setLineClamp truncates multi-line text in paint",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1552: bridge fn registered. Setting a non-zero clamp implicitly enables `multi_line_` on the Label so paint takes the multi-line branch (without that, the single-line path runs and the clamp is a no-op). Last-visible line gets U+2026 appended if source lines were dropped. CSS spec uses `none` to disable; pulp accepts numeric `0` for the same effect. 2026-05-12 closure: `none` reclassified as supported \u2014 the JS dispatcher (web-compat-style-decl.js:1793) routes `setLineClamp(id, parseInt(resolved) || 0)`, so `none` (parseInt \u2192 NaN, NaN || 0 \u2192 0) takes the same disable path as numeric 0. Pinned by test.",
+      "issue": "1552"
+    },
+    "css/lineHeight": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js: detects bare-number unitless multiplier (\u00d7 default 14px font-size); resolves em/rem/% against same default; normal = 1.2 \u00d7 14; numeric px path unchanged. -> setLineHeight(id, px).",
+      "supportedValues": [
+        "px",
+        "unitless multiplier (e.g. 1.5)",
+        "em",
+        "rem",
+        "%",
+        "normal"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.2 \u2014 closes the major-gap unitless-multiplier hole. Resolved against the default 14px font-size (same single-level cascade caveat as fontSize). Multi-level cascade is the follow-up.",
+      "issue": ""
+    },
+    "css/listStyle": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js parses the shorthand into the 3 longhands (any order: type / position / image) and dispatches setListStyleType / setListStyleImage / setListStylePosition. Bridge stores values on View::ListStyleType / list_style_image_ / View::ListStylePosition slots. Paint-time marker rendering is deferred \u2014 values are stored but not yet drawn.",
+      "supportedValues": [
+        "shorthand parsing into 3 longhands"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setListStyleType maps each keyword to the right enum (issue-1514)\"",
+        "packages/pulp-react/test/prop-applier-list-style.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.4 \u2014 reclassified partial -> partial-deferred-paint-time (marker glyph painting is the architectural blocker, not a JS-side gap). pulp #1514 \u2014 list-style cluster. Pulp doesn't model <li>/<ul>/<ol> semantics; the bridge stores the values verbatim on the View so a future paint pass (or future semantic-list surface) can honor them. Wave 4 css extensive \u2014 drift cleanup \u2014 value-coverage is complete (the catalog's only 'unsupported' entry was the paint-time marker glyph rendering, which is an arch-paint-deferred follow-up \u2014 moved out of unsupportedValues per the Wave 1 backgroundAttachment precedent).",
+      "issue": "1514"
+    },
+    "css/listStyleImage": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards the resolved string to setListStyleImage; bridge stores on View::list_style_image_. URL fetch + image decode + bullet-image paint are deferred (same caveat as backgroundImage URLs).",
+      "supportedValues": [
+        "url(...) string stored",
+        "none clears the slot"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setListStyleImage stores url and clears on 'none' (issue-1514)\"",
+        "packages/pulp-react/test/prop-applier-list-style.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.4 \u2014 reclassified partial -> partial-deferred-paint-time (bullet image paint is the architectural blocker, not a JS-side gap). pulp #1514 \u2014 Bridge round-trips the URL string. Image fetch + decode + paint is the follow-up. Wave 4 css extensive \u2014 drift cleanup \u2014 value-coverage is complete (the catalog's only 'unsupported' entry was the paint-time marker glyph rendering, which is an arch-paint-deferred follow-up \u2014 moved out of unsupportedValues per the Wave 1 backgroundAttachment precedent).",
+      "issue": "1514"
+    },
+    "css/listStylePosition": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards the keyword to setListStylePosition; bridge stores View::ListStylePosition (inside / outside). Paint-time marker offset is deferred.",
+      "supportedValues": [
+        "inside",
+        "outside"
+      ],
+      "unsupportedValues": [
+        "marker offset rendering (stored-but-not-painted)"
+      ],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setListStylePosition maps each keyword to the right enum (issue-1514)\"",
+        "packages/pulp-react/test/prop-applier-list-style.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1514 \u2014 Bridge stores the position; marker rendering is the follow-up. Wave 1 drift cleanup \u2014 partial \u2192 supported (harness verifies all 2 spec values).",
+      "issue": "1514"
+    },
+    "css/listStyleType": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards the keyword to setListStyleType; bridge stores View::ListStyleType (none / disc / circle / square / decimal / decimal-leading-zero / lower-roman / upper-roman / lower-alpha / upper-alpha / lower-latin / upper-latin / lower-greek / armenian / georgian). Marker glyph paint is deferred — `decimal` additionally needs sibling-index resolution from the parent's children, and the counter-style keywords need glyph rendering before they become visually distinct from disc.",
+      "supportedValues": [
+        "none",
+        "disc",
+        "circle",
+        "square",
+        "decimal",
+        "decimal-leading-zero",
+        "lower-roman",
+        "upper-roman",
+        "lower-alpha",
+        "upper-alpha",
+        "lower-latin",
+        "upper-latin",
+        "lower-greek",
+        "armenian",
+        "georgian"
+      ],
+      "unsupportedValues": [
+        "cjk-decimal / hebrew / hiragana / katakana / etc. (other CSS Counter Styles Level 3 keywords — storage-only follow-up)"
+      ],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setListStyleType maps each keyword to the right enum (issue-1514)\"",
+        "test/test_widget_bridge.cpp::\"setListStyleType maps counter-style keywords to enum slots (issue-1514)\"",
+        "test/test_widget_bridge.cpp::\"listStyle shorthand routes counter-style keywords (issue-1514)\"",
+        "packages/pulp-react/test/prop-applier-list-style.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1514 — Bridge stores the type keyword on a View::ListStyleType enum slot; marker glyph rendering is the follow-up. Pulp doesn't model HTML <li> semantics yet. Wave 1 drift cleanup — decimal sibling-index + marker glyph paint shipped via #1551 catalog hygiene. Counter-style extension (lower-roman / upper-roman / lower-alpha / upper-alpha / lower-latin / upper-latin / lower-greek / armenian / georgian / decimal-leading-zero) is storage-only today; paint-side glyph rendering remains the follow-up.",
+      "issue": "1514"
+    },
+    "css/margin": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js: per-token shorthand re-tokenizer (1/2/3/4 forms) -> setFlex(margin_*) with per-token 'auto' / 'NN%' / numeric routing. Each edge uses the same string-aware setFlex pathway as the per-edge longhands.",
+      "supportedValues": [
+        "px (1-4 tokens)",
+        "%",
+        "auto",
+        "mixed per-token (e.g. 'auto 10%')"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.2 \u2014 auto + % now honored in the shorthand (parity with the per-edge longhands). Yoga's YGNodeStyleSetMarginAuto centers when both opposing margins are auto.",
+      "issue": ""
+    },
+    "css/marginBlock": {
+      "status": "supported",
+      "mapsTo": "expandShorthand -> setFlex(id, 'margin_top'/'margin_bottom', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Logical property; assumes horizontal writing mode.",
+      "issue": ""
+    },
+    "css/marginBlockEnd": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js maps `margin-block-end` \u2192 setFlex(margin_bottom) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges \u2014 direction-aware mapping is the follow-up.",
+      "supportedValues": [
+        "<length>",
+        "<percentage>",
+        "auto (margin only)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 A4 Bundle 3: status flipped missing \u2192 partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "issue": ""
+    },
+    "css/marginBlockStart": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js maps `margin-block-start` \u2192 setFlex(margin_top) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges \u2014 direction-aware mapping is the follow-up.",
+      "supportedValues": [
+        "<length>",
+        "<percentage>",
+        "auto (margin only)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 A4 Bundle 3: status flipped missing \u2192 partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "issue": ""
+    },
+    "css/marginBottom": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards \"NN%\" / \"auto\" / numeric verbatim to setFlex(margin_*); bridge routes via dim_margin_*.unit to Yoga (cross-surface mega-batch).",
+      "supportedValues": [
+        "px",
+        "%",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
+      "issue": ""
+    },
+    "css/marginHorizontal": {
+      "status": "supported",
+      "mapsTo": "marginHorizontal -> setFlex(margin_left, px) + setFlex(margin_right, px)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"5%\")",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "issue": ""
+    },
+    "css/marginInline": {
+      "status": "supported",
+      "mapsTo": "expandShorthand -> setFlex(id, 'margin_left'/'margin_right', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Logical property normalized to physical. No RTL awareness -- always treated as LTR (margin_left = inline-start).",
+      "issue": ""
+    },
+    "css/marginInlineEnd": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js maps `margin-inline-end` \u2192 setFlex(margin_right) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges \u2014 direction-aware mapping is the follow-up.",
+      "supportedValues": [
+        "<length>",
+        "<percentage>",
+        "auto (margin only)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 A4 Bundle 3: status flipped missing \u2192 partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "issue": ""
+    },
+    "css/marginInlineStart": {
+      "status": "supported",
+      "mapsTo": "case in switch is bare break (line 609); RTL untracked",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 batch 1: status flipped missing \u2192 partial. CSS translator at web-compat-style-decl.js:784 maps to setFlex(margin_left) under LTR assumption; RTL not yet wired. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "issue": ""
+    },
+    "css/marginLeft": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards \"NN%\" / \"auto\" / numeric verbatim to setFlex(margin_*); bridge routes via dim_margin_*.unit to Yoga (cross-surface mega-batch).",
+      "supportedValues": [
+        "px",
+        "%",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
+      "issue": ""
+    },
+    "css/marginRight": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards \"NN%\" / \"auto\" / numeric verbatim to setFlex(margin_*); bridge routes via dim_margin_*.unit to Yoga (cross-surface mega-batch).",
+      "supportedValues": [
+        "px",
+        "%",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
+      "issue": ""
+    },
+    "css/marginTop": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards \"NN%\" / \"auto\" / numeric verbatim to setFlex(margin_*); bridge routes via dim_margin_*.unit to Yoga (cross-surface mega-batch).",
+      "supportedValues": [
+        "px",
+        "%",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"CSSStyleDeclaration forwards marginTop percent + auto verbatim\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / % / auto. CSS-spec em/rem/vh/vw/calc() not wired (parseCSSLength is px-only); pass numeric values for those.",
+      "issue": ""
+    },
+    "css/marginVertical": {
+      "status": "supported",
+      "mapsTo": "marginVertical -> setFlex(margin_top, px) + setFlex(margin_bottom, px)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"5%\")",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "issue": ""
+    },
+    "css/mask": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards `mask` shorthand to setMask(id, value) AND extracts the mask-image substring (url() / linear-gradient() / radial-gradient()) to setMaskImage. Storage-only today; the saveLayer + SkBlendMode::kDstIn paint slice is the follow-up (#1540 mask storage).",
+      "supportedValues": [
+        "url(#ref)",
+        "linear-gradient(...)",
+        "radial-gradient(...)",
+        "solid color"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 A4 Bundle 6: status flipped missing \u2192 partial. Storage landed in #1515 / #1540. Wave 4 css extensive \u2014 mask sub-properties (mode/repeat/position/size/origin/clip/composite) are arch-paint-deferred \u2014 the shorthand parser routes mask-image to setMaskImage today; the orchestration of the other sub-properties at paint time is the follow-up. Reclassified as paint-side gap rather than value-coverage gap.",
+      "issue": ""
+    },
+    "css/maskImage": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards `mask-image` to setMaskImage(id, value) -> View::set_mask_image -> View::paint_all routes through Canvas::save_layer_with_mask -> SkiaCanvas's 2-saveLayer + SkBlendMode::kDstIn composite at restore time. Phase 1 paints linear-gradient masks fully; radial-gradient and url() image masks fall through safely (no mask applied \u2014 content unaffected).",
+      "supportedValues": [
+        "url(#ref)",
+        "linear-gradient(...)",
+        "radial-gradient(...)",
+        "none"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]",
+        "unit:test_view#issue-1515"
+      ],
+      "notes": "pulp #1434 A4 Bundle 6 (initial flip), pulp #1515 (storage landed), pulp #1737 PR-3 (this slice \u2014 paint integration via Canvas::save_layer_with_mask + SkiaCanvas's 2-saveLayer + SkBlendMode::kDstIn composite at restore time). The catalog claim at this entry is keyword-coverage: Pulp's mask-image surface accepts every spec value (url, linear-gradient, radial-gradient, none) and round-trips them through View::mask_image_. Paint-time coverage in Phase 1: `linear-gradient(...)` and `none` are honored end-to-end; `radial-gradient(...)` and `url(...)` shapes drop to a no-mask fall-through (the layer opens with content opacity, restore() sees no pending shader, layer closes plainly \u2014 matches pre-#1737 behavior, content is unaffected). Phase 2 followup will extend the parser to radial-gradient + url(file_path) via image_cache + url(#elementRef) via the SVG `<defs>` registry shared with rn/fill (#932). That parser-coverage extension does not require a new API surface \u2014 Canvas::save_layer_with_mask already accepts all these strings.",
+      "issue": ""
+    },
+    "css/maxHeight": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'max_height', px) for numeric, 'NN%' for percent. Wave 2 css.2 \u2014 calc() / min() / max() / clamp() now wired in the JS shim via resolveCSSLength (#1576).",
+      "supportedValues": [
+        "px (number)",
+        "%",
+        "calc()",
+        "min()",
+        "max()",
+        "clamp()"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.2 \u2014 calc() actually wired in the shim (catalog had previously claimed it shipped; verified + connected). pulp #1434 rn batch C: % values route through FlexStyle::dim_*.unit \u2192 Yoga percent API. min-content / max-content / fit-content remain architectural OOS (Yoga doesn't compute content-sized boxes).",
+      "issue": ""
+    },
+    "css/maxWidth": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'max_width', px) for numeric, 'NN%' for percent. Wave 2 css.2 \u2014 calc() / min() / max() / clamp() now wired in the JS shim via resolveCSSLength (#1576).",
+      "supportedValues": [
+        "px (number)",
+        "%",
+        "calc()",
+        "min()",
+        "max()",
+        "clamp()"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.2 \u2014 calc() actually wired in the shim. 0 = no maximum (semantic differs from CSS where unspecified = none). min-content / max-content / fit-content remain architectural OOS (Yoga doesn't compute content-sized boxes).",
+      "issue": ""
+    },
+    "css/minHeight": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'min_height', px) for numeric, 'NN%' for percent. Wave 2 css.2 \u2014 calc() / min() / max() / clamp() now wired in the JS shim via resolveCSSLength (#1576).",
+      "supportedValues": [
+        "px (number)",
+        "%",
+        "calc()",
+        "min()",
+        "max()",
+        "clamp()"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.2 \u2014 calc() actually wired in the shim. min-content / max-content / fit-content remain architectural OOS (Yoga doesn't compute content-sized boxes).",
+      "issue": ""
+    },
+    "css/minWidth": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'min_width', px) for numeric, 'NN%' for percent. Wave 2 css.2 \u2014 calc() / min() / max() / clamp() now wired in the JS shim via resolveCSSLength (#1576).",
+      "supportedValues": [
+        "px (number)",
+        "%",
+        "calc()",
+        "min()",
+        "max()",
+        "clamp()"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.2 \u2014 calc() actually wired in the shim. min-content / max-content / fit-content remain architectural OOS (Yoga doesn't compute content-sized boxes).",
+      "issue": ""
+    },
+    "css/mixBlendMode": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards `mix-blend-mode` to setMixBlendMode(id, value) (#1549). The bridge maps the W3C blend-mode keyword set + plus-lighter/plus-darker onto canvas::Canvas::BlendMode and the View paint path routes through save_layer_with_blend at compositing time.",
+      "supportedValues": [
+        "normal",
+        "multiply",
+        "screen",
+        "overlay",
+        "darken",
+        "lighten",
+        "color-dodge",
+        "color-burn",
+        "hard-light",
+        "soft-light",
+        "difference",
+        "exclusion",
+        "hue",
+        "saturation",
+        "color",
+        "luminosity",
+        "plus-lighter (additive \u2014 SkBlendMode::kPlus)",
+        "plus-darker (additive \u2014 SkBlendMode::kPlus)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::WidgetBridge setMixBlendMode keyword -> BlendMode mapping",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.9 \u2014 plus-lighter/plus-darker now map to BlendMode::lighter (Skia's SkBlendMode::kPlus). plus-darker is technically a multiplicative variant in the W3C draft but Skia/Chromium ship the additive kPlus for both; mirroring that is the closest match without a custom SkBlender. pulp #1434 A4 Bundle 6: original wiring (16 W3C modes).",
+      "issue": ""
+    },
+    "css/opacity": {
+      "status": "supported",
+      "mapsTo": "setOpacity(id, n)",
+      "supportedValues": [
+        "0..1 number",
+        "percentage strings (parsed to 0..1 numeric at the JS layer)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "parseFloat strips the % suffix silently. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 percentage strings are accepted at the JS layer (parsed as 0..1 from 'NN%') \u2014 the JS shim normalizes percent to numeric before calling setOpacity. The bridge slot is numeric only (arch-numeric-only-bridge); authors who pass numeric strings or numbers hit the same setOpacity path today.",
+      "issue": ""
+    },
+    "css/order": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'order', n)",
+      "supportedValues": [
+        "integer"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "css/outline": {
+      "status": "supported",
+      "mapsTo": "web-compat shorthand parser fans out to setOutlineWidth + setOutlineStyle + setOutlineColor (web-compat-style-decl.js:851 since pulp #1519).",
+      "supportedValues": [
+        "<width> <style> <color> shorthand",
+        "thin/medium/thick keyword for width (parses; currently falls through to numeric \u2014 keyword expansion deferred)",
+        "double/groove/ridge/inset/outset (accepted; rendered as solid per arch-solid-only-pen)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1519 \u2014 outline cluster now bridge-backed. Shorthand parses `<width>px <style> <color>` and dispatches to the per-attribute setters. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 outline-style values double/groove/ridge/inset/outset are arch-solid-only-pen (mirrors border-style \u2014 paint pipeline draws a single solid pen by design; outline-width thin/medium/thick are author-named widths and currently fall through to the numeric path \u2014 adding the keyword expansion is queued behind border parity but parses without crashing today).",
+      "issue": ""
+    },
+    "css/outlineColor": {
+      "status": "supported",
+      "mapsTo": "setOutlineColor(id, color) \u2014 registered in widget_bridge.cpp since pulp #1519. CSS translator at web-compat-style-decl.js:864 routes through it.",
+      "supportedValues": [
+        "#hex",
+        "#rgba",
+        "rgb()",
+        "rgba()",
+        "named colors",
+        "currentColor (resolves to bridge default per arch-no-cascade-color)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1519 \u2014 outline color now writes to View::outline_color_; Skia paint strokes the inflated rect with this color. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 currentColor keyword is arch-no-cascade-color (the JS shim has no ancestor color resolver; authors pass explicit colors per css/borderColor / css/color precedent \u2014 currentColor parses but resolves to the bridge default).",
+      "issue": ""
+    },
+    "css/outlineOffset": {
+      "status": "supported",
+      "mapsTo": "setOutlineOffset(id, px) \u2014 registered in widget_bridge.cpp since pulp #1519. CSS translator at web-compat-style-decl.js routes through it.",
+      "supportedValues": [
+        "<length>px",
+        "em/rem/% (resolved to px at the JS layer; falls back to the default 14px font-size for em/rem)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1519 \u2014 gap between border-box edge and outline. Skia inflates the stroke rect by (offset + width/2). Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 em/rem/% units are arch-paint-px-only (outline is paint-only; the bridge resolves length at the JS boundary and forwards a numeric px to setOutlineOffset \u2014 em/rem/% would require a paint-time resolver hook). Authors precompute at the JS layer.",
+      "issue": ""
+    },
+    "css/outlineStyle": {
+      "status": "supported",
+      "mapsTo": "setOutlineStyle(id, keyword) \u2014 registered in widget_bridge.cpp since pulp #1519. CSS translator at web-compat-style-decl.js routes through it; keyword set mirrors borderStyle.",
+      "supportedValues": [
+        "solid",
+        "dashed",
+        "dotted",
+        "none",
+        "hidden",
+        "double (degrades to solid)",
+        "groove (degrades to solid)",
+        "ridge (degrades to solid)",
+        "inset (degrades to solid)",
+        "outset (degrades to solid)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1519 \u2014 line-style enum reused from View::BorderStyle (CSS spec is identical). Skia installs SkDashPathEffect for dashed/dotted at outline-stroke time. Other named styles currently degrade to solid (paint-side gap, same as borderStyle).",
+      "issue": ""
+    },
+    "css/outlineWidth": {
+      "status": "supported",
+      "mapsTo": "setOutlineWidth(id, px) \u2014 registered in widget_bridge.cpp since pulp #1519. CSS translator at web-compat-style-decl.js:859 routes through it.",
+      "supportedValues": [
+        "<length>px",
+        "thin/medium/thick (parses; rendered as the numeric default per arch-numeric-only)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1519 \u2014 outline stroke thickness. width<=0 short-circuits the paint. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 thin/medium/thick keyword forms are arch-numeric-only (the bridge slot is numeric px; the JS shim does not yet expand the keyword set \u2014 authors pass numeric px today, mirrors border-width).",
+      "issue": ""
+    },
+    "css/overflow": {
+      "status": "supported",
+      "mapsTo": "setOverflow(id, 'visible'|'hidden')",
+      "supportedValues": [
+        "visible",
+        "hidden",
+        "scroll",
+        "auto",
+        "clip"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "View::Overflow enum has only {visible, hidden}. Scroll requires using the ScrollView intrinsic. Wave 4 css extensive \u2014 scroll / auto / clip are arch-scroll-via-scrollview (View::Overflow has only {visible, hidden}; the JS shim parses the keyword without crash and the bridge clamps to the closest behaviour \u2014 `scroll` / `auto` / `overlay` are routed to `hidden` clip, matching the no-scroll-context default). Authors who need true scrolling use the dedicated ScrollView intrinsic, mirrors React Native's split. Reclassified value coverage out of unsupportedValues per the Wave 1 backgroundAttachment precedent.",
+      "issue": ""
+    },
+    "css/overflowWrap": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards `overflow-wrap` (and the legacy `word-wrap` alias) to setWordBreak(id, value) -> View::set_word_break -> Label::paint reads View::word_break() -> maps to canvas::BreakMode (normal / break_word / anywhere) -> TextShaper::layout_with_lines applies in-segment splits when an over-wide word can't fit on the current line.",
+      "supportedValues": [
+        "normal",
+        "break-word",
+        "anywhere"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "unit:test_widgets#issue-1737"
+      ],
+      "notes": "pulp #1434 A4 Bundle 4 (initial flip), pulp #1616 (walked back to partial when audit confirmed paint-path didn't consume the value), pulp #1737 PR-1 (#1795 \u2014 added BreakMode + codepoint-break logic to TextShaper::layout_from_segments), pulp #1737 PR-2 (this slice \u2014 wired Label::paint multi_line path to TextShaper::layout_with_lines when word_break is break-word/anywhere AND bounds().width > 0). Default `normal` keeps the legacy \\n-only split for zero behavior change. Tested end-to-end in test_widgets [issue-1737]: 'Antidisestablishmentarianism' at width 60 with break-word produces multi-line wrapped output (lossless reconstruction), with line-clamp=2 the second line gets the U+2026 ellipsis, and bounds().width==0 falls through to the legacy path (no shaper invocation). The proportional-split heuristic (seg.width / utf8_codepoints per codepoint) trades pixel-perfect break positions for measure-once-reflow-forever cache reuse \u2014 CSS Text Module Level 3 \u00a76.1 doesn't require pixel-perfect break positions for soft-wrap.",
+      "issue": ""
+    },
+    "css/overflowX": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards `overflow-x` to setOverflow(id, value) (View::Overflow has only {visible, hidden} and is axis-tied). Last-write-wins across the two axes; `overflow-x: hidden` clips both axes.",
+      "supportedValues": [
+        "visible",
+        "hidden",
+        "per-axis clipping (axis-tied per arch-axis-tied-overflow)",
+        "scroll (arch-scroll-via-scrollview \u2014 use ScrollView)",
+        "auto (arch-scroll-via-scrollview \u2014 use ScrollView)",
+        "clip (arch-scroll-via-scrollview \u2014 clipped at View::overflow_=hidden)",
+        "overlay (arch-scroll-via-scrollview \u2014 use ScrollView)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 A4 Bundle 4: status flipped missing \u2192 partial. Pulp's View::Overflow enum doesn't model per-axis clipping; CSS overflow-x routes to the same single-axis setter as `overflow`. Wave 4 css extensive \u2014 per-axis clipping is arch-axis-tied-overflow (View::overflow_ is a single enum; both axes clip together \u2014 authors who need true per-axis behaviour use the ScrollView intrinsic). scroll/auto/clip/overlay are arch-scroll-via-scrollview (the CSS surface only models visible/hidden \u2014 scrollable containers go through the dedicated ScrollView widget, mirrors React Native's split).",
+      "issue": ""
+    },
+    "css/overflowY": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards `overflow-y` to setOverflow(id, value). Same axis-tied semantics as overflow-x.",
+      "supportedValues": [
+        "visible",
+        "hidden",
+        "per-axis clipping (axis-tied per arch-axis-tied-overflow)",
+        "scroll (arch-scroll-via-scrollview \u2014 use ScrollView)",
+        "auto (arch-scroll-via-scrollview \u2014 use ScrollView)",
+        "clip (arch-scroll-via-scrollview \u2014 clipped at View::overflow_=hidden)",
+        "overlay (arch-scroll-via-scrollview \u2014 use ScrollView)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 A4 Bundle 4: status flipped missing \u2192 partial. See overflowX note. Wave 4 css extensive \u2014 per-axis clipping is arch-axis-tied-overflow (View::overflow_ is a single enum; both axes clip together \u2014 authors who need true per-axis behaviour use the ScrollView intrinsic). scroll/auto/clip/overlay are arch-scroll-via-scrollview (the CSS surface only models visible/hidden \u2014 scrollable containers go through the dedicated ScrollView widget, mirrors React Native's split).",
+      "issue": ""
+    },
+    "css/overscrollBehavior": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js -> setOverscrollBehavior(id, value) -> View::overscroll_behavior_ slot. ScrollView::clamp_scroll_targets already clamps at content bounds and Pulp does not implement scroll-chaining, so all three keywords (auto / contain / none) behave as CSS contain in Pulp.",
+      "supportedValues": [
+        "auto",
+        "contain",
+        "none"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "unit:test_widget_bridge#issue-1737"
+      ],
+      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11): walked back from wontfix to supported. CSS spec distinguishes auto (chain to parent) vs contain (stop chain, no overscroll) vs none (same plus suppress glow). Pulp does not implement scroll-chaining and has no overscroll glow today, so all three keywords behave as CSS contain \u2014 a valid subset of the spec. Specifying contain or none matches CSS behavior exactly; specifying auto gets the stricter contain behavior, which is a no-op surprise but does not violate the spec.",
+      "issue": ""
+    },
+    "css/padding": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js: per-token shorthand re-tokenizer (1/2/3/4 forms) -> setFlex(padding_*) with per-token 'NN%' / numeric routing. Yoga's padding has no auto API (only margin does), so per-token 'auto' is silently dropped.",
+      "supportedValues": [
+        "px (1-4 tokens)",
+        "%"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.2 \u2014 % now honored in the shorthand (parity with the per-edge longhands). auto is intentionally dropped because Yoga padding doesn't support it. Wave 4 css extensive \u2014 auto is arch-yoga-no-padding-auto (Yoga's padding API is scalar / percent only; the spec-asymmetric margin-auto behavior doesn't apply to padding). Cleared from unsupportedValues \u2014 the spec-equivalent default is 0.",
+      "issue": ""
+    },
+    "css/paddingBlock": {
+      "status": "supported",
+      "mapsTo": "expandShorthand -> setFlex(id, 'padding_top/bottom', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "css/paddingBlockEnd": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js maps `padding-block-end` \u2192 setFlex(padding_bottom) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges \u2014 direction-aware mapping is the follow-up.",
+      "supportedValues": [
+        "<length>",
+        "<percentage>",
+        "auto (margin only)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 A4 Bundle 3: status flipped missing \u2192 partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "issue": ""
+    },
+    "css/paddingBlockStart": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js maps `padding-block-start` \u2192 setFlex(padding_top) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges \u2014 direction-aware mapping is the follow-up.",
+      "supportedValues": [
+        "<length>",
+        "<percentage>",
+        "auto (margin only)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 A4 Bundle 3: status flipped missing \u2192 partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "issue": ""
+    },
+    "css/paddingBottom": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards \"NN%\" / numeric verbatim to setFlex(padding_*); bridge routes via dim_padding_*.unit to Yoga.",
+      "supportedValues": [
+        "px",
+        "%"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
+      "issue": ""
+    },
+    "css/paddingHorizontal": {
+      "status": "supported",
+      "mapsTo": "paddingHorizontal -> setFlex(padding_left, px) + setFlex(padding_right, px)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"5%\")"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "issue": ""
+    },
+    "css/paddingInline": {
+      "status": "supported",
+      "mapsTo": "expandShorthand -> setFlex(id, 'padding_left/right', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Logical property mapped LTR-only.",
+      "issue": ""
+    },
+    "css/paddingInlineEnd": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js maps `padding-inline-end` \u2192 setFlex(padding_right) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges \u2014 direction-aware mapping is the follow-up.",
+      "supportedValues": [
+        "<length>",
+        "<percentage>",
+        "auto (margin only)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 A4 Bundle 3: status flipped missing \u2192 partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "issue": ""
+    },
+    "css/paddingInlineStart": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js maps `padding-inline-start` \u2192 setFlex(padding_left) under the LTR / horizontal-tb writing-mode fast path. RTL / vertical writing modes would swap inline edges \u2014 direction-aware mapping is the follow-up.",
+      "supportedValues": [
+        "<length>",
+        "<percentage>",
+        "auto (margin only)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 A4 Bundle 3: status flipped missing \u2192 partial. LTR fast path delegates to the existing per-edge bridge dispatch. Wave 1 drift cleanup \u2014 LTR + RTL via setDirection (#1506); writing-mode-aware mapping no longer deferred.",
+      "issue": ""
+    },
+    "css/paddingLeft": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards \"NN%\" / numeric verbatim to setFlex(padding_*); bridge routes via dim_padding_*.unit to Yoga.",
+      "supportedValues": [
+        "px",
+        "%"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
+      "issue": ""
+    },
+    "css/paddingRight": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards \"NN%\" / numeric verbatim to setFlex(padding_*); bridge routes via dim_padding_*.unit to Yoga.",
+      "supportedValues": [
+        "px",
+        "%"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
+      "issue": ""
+    },
+    "css/paddingTop": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards \"NN%\" / numeric verbatim to setFlex(padding_*); bridge routes via dim_padding_*.unit to Yoga.",
+      "supportedValues": [
+        "px",
+        "%"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts px / %. CSS-spec auto is inexpressible (Yoga has no padding-auto API); em/rem/vh/vw/calc() not wired.",
+      "issue": ""
+    },
+    "css/paddingVertical": {
+      "status": "supported",
+      "mapsTo": "paddingVertical -> setFlex(padding_top, px) + setFlex(padding_bottom, px)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"5%\")"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "issue": ""
+    },
+    "css/pageBreakAfter": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Print only.",
+      "issue": ""
+    },
+    "css/pageBreakBefore": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Print only.",
+      "issue": ""
+    },
+    "css/perspective": {
+      "status": "wontfix",
+      "mapsTo": "Architectural \u2014 no 3D transform stack. Pulp's View::setTransform is 2D-affine only (geometry.hpp). Adding 3D would be a major engine rewrite.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "pulp #1737 (CSS NO-OP audit) \u2014 reclassified noop \u2192 wontfix. Catalog notes already said \"Architecturally out of scope\"; the noop classification was misleading. Direct parallel to css/willChange (already wontfix).",
+      "issue": ""
+    },
+    "css/perspectiveOrigin": {
+      "status": "wontfix",
+      "mapsTo": "Architectural \u2014 companion to css/perspective. Same wontfix-arch class.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "pulp #1737 (CSS NO-OP audit) \u2014 reclassified noop \u2192 wontfix. Bundled with css/perspective.",
+      "issue": ""
+    },
+    "css/placeContent": {
+      "status": "supported",
+      "mapsTo": "setFlex 'align_content' + 'justify_content'",
+      "supportedValues": [
+        "<align-content> <justify-content> shorthand"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "align_content half is silently dropped (see css/alignContent). Wave 4 css extensive \u2014 shorthand parser fans out to setFlex 'align_content' + 'justify_content' (the only two CSS-spec axes that survive in pulp's flex-only layout). Removed the residual 'all' marker \u2014 not a CSS-spec value.",
+      "issue": ""
+    },
+    "css/placeItems": {
+      "status": "supported",
+      "mapsTo": "setFlex 'align_items' + 'justify_content'",
+      "supportedValues": [
+        "align-items justify-content shorthand"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Misnamed -- second token is mapped to justify_content rather than justify_items (which Yoga doesn't support). Wave 1 drift cleanup \u2014 partial \u2192 supported (non-enum, wired through web-compat-style-decl.js with no unsupported values listed).",
+      "issue": ""
+    },
+    "css/pointerEvents": {
+      "status": "supported",
+      "mapsTo": "setPointerEvents(id, mode)",
+      "supportedValues": [
+        "auto",
+        "none",
+        "box-only",
+        "box-none",
+        "all",
+        "visible",
+        "visible-painted",
+        "visible-fill",
+        "visible-stroke"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Triage #13 \u2014 catalog trim. CSS spec lists SVG-specific values (visible-painted / visible-fill / visible-stroke / painted / fill / stroke); pulp doesn't render SVG via the renderer surface (SVG is layout-leaf via SvgPath widgets), so those values would be no-ops. Trimmed from the catalog. Wave 4 css extensive \u2014 all / visible / visible-painted / visible-fill / visible-stroke are arch-non-svg-renderer (CSS spec defines these for SVG painted regions; pulp doesn't render SVG via the renderer surface \u2014 SVG paths go through the SvgPath layout-leaf widget). The bridge maps unknown keywords to View::PointerEvents::auto.",
+      "issue": ""
+    },
+    "css/position": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js: 'position' -> setPosition. View::Position enum has static_/relative/absolute/fixed/sticky.",
+      "supportedValues": [
+        "static",
+        "relative",
+        "absolute",
+        "fixed",
+        "sticky"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "All five CSS values are accepted by the bridge. 'fixed' and 'sticky' may render the same as 'absolute' in practice -- see #779 follow-ups for behavioral verification.",
+      "issue": ""
+    },
+    "css/printMargin": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Print media is out of scope for a GPU plugin renderer.",
+      "issue": ""
+    },
+    "css/quotes": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Generated content not in scope.",
+      "issue": ""
+    },
+    "css/resize": {
+      "status": "wontfix",
+      "mapsTo": "Architectural \u2014 no CSS-resize-handle paint primitive + no overflow:auto drag-router. Same class as the multi-column / table primitives already wontfix under \"non-Yoga layout\" per CLAUDE.md flex+grid layout-model contract.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "pulp #1737 (CSS NO-OP audit) \u2014 reclassified noop \u2192 wontfix. Resize handles fall outside the flex+grid layout primitives Pulp commits to.",
+      "issue": ""
+    },
+    "css/right": {
+      "status": "supported",
+      "mapsTo": "setRight(id, px); JS shim resolves em/rem (\u00d7 14px default), vh/vw (\u00d7 600/800 default viewport), % flows verbatim through the 'NN%' bridge path -> YGNodeStyleSetPositionPercent.",
+      "supportedValues": [
+        "px",
+        "%",
+        "em",
+        "rem",
+        "vh",
+        "vw"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.2 \u2014 em/rem/vh/vw resolved in JS using the same default font-size (14px) and viewport (800x600) as resolveLength in css-parser.js. Single-level cascade; nested font-size cascade is the follow-up. pulp #1434 batch 6: percent values flow through the bridge via 'NN%'.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1434"
+    },
+    "css/rowGap": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'row_gap', px) for numeric, 'NN%' string for percent (best-effort: stored on the scalar FlexStyle.row_gap slot since Yoga has no YGNodeStyleSetGapPercent API yet \u2014 treated as px until upstream Yoga ships percent-aware gap).",
+      "supportedValues": [
+        "px",
+        "% (best-effort scalar)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.2 \u2014 % accepted at the JS+bridge layer; honest stored-as-scalar caveat documented above. Status stays partial because Yoga doesn't yet honor percent gaps (px-equivalent only). Wave 4 css extensive \u2014 % is best-effort (stored on the scalar slot, treated as px-equivalent) until upstream Yoga ships YGNodeStyleSetGapPercent \u2014 tracked as deferred-yoga-percent-gap. Status flipped partial -> supported because every CSS-spec value (px / %) round-trips through the bridge today; the % honoring is the orthogonal Yoga upstream follow-up.",
+      "issue": ""
+    },
+    "css/scrollBehavior": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js -> setScrollBehavior(id, value) -> View::scroll_behavior_ slot. The ScrollView intrinsic reads the slot in scroll_by: auto triggers instant scroll (CSS default), anything else (empty / smooth / etc.) keeps the existing animated scroll (Pulp default). Non-ScrollView views round-trip the keyword but the paint pipeline does not consume it.",
+      "supportedValues": [
+        "auto",
+        "smooth"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "unit:test_widget_bridge#issue-1737"
+      ],
+      "notes": "pulp #1737 (CSS NO-OP audit) \u2014 reclassified noop \u2192 wontfix. Same \"scroll-via-ScrollView\" rationale as css/overflow scroll/auto/clip.",
+      "issue": ""
+    },
+    "css/scrollMargin": {
+      "status": "wontfix",
+      "mapsTo": "Architectural \u2014 needs CSS scroll-container model + scroll-snap engine. Multi-element coordination engine parallel to a CSS cascade engine.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "pulp #1737 (CSS NO-OP audit) \u2014 reclassified noop \u2192 wontfix. Bundled with the scroll-snap family.",
+      "issue": ""
+    },
+    "css/scrollPadding": {
+      "status": "wontfix",
+      "mapsTo": "Architectural \u2014 same scroll-snap engine prerequisite as css/scrollMargin.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "pulp #1737 (CSS NO-OP audit) \u2014 reclassified noop \u2192 wontfix. Bundled with the scroll-snap family.",
+      "issue": ""
+    },
+    "css/scrollSnapType": {
+      "status": "wontfix",
+      "mapsTo": "Architectural \u2014 scroll-snap engine is a multi-element coordination engine (snap-area resolution + snap-strictness state machine) parallel to a CSS cascade engine.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "pulp #1737 (CSS NO-OP audit) \u2014 reclassified noop \u2192 wontfix. Same shape as the stacking-context engine that justified rn/isolation as wontfix in PR #1785.",
+      "issue": ""
+    },
+    "css/tableLayout": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "No table primitives in Pulp.",
+      "issue": ""
+    },
+    "css/textAlign": {
+      "status": "supported",
+      "mapsTo": "setTextAlign(id, value)",
+      "supportedValues": [
+        "left",
+        "center",
+        "right",
+        "start",
+        "end",
+        "auto",
+        "justify",
+        "match-parent"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]",
+        "test/test_widget_bridge.cpp [issue-1434][coverage]"
+      ],
+      "notes": "RN supports auto/justify; we don't. pulp #1434 Triage #11: bridge accepts start/end (LTR-only aliases for left/right), auto (LTR fallback), and justify. pulp #1434 follow-up: match-parent resolves at paint time by walking the View parent chain via inheritable_text_align(); falls back to left when no ancestor set a value (CSS spec default for text-align).",
+      "issue": ""
+    },
+    "css/textDecoration": {
+      "status": "supported",
+      "mapsTo": "setTextDecoration(id, value)",
+      "supportedValues": [
+        "underline",
+        "line-through",
+        "overline",
+        "none",
+        "blink"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Single-keyword only. Cannot express 'underline dashed red'. Wave 4 css extensive \u2014 blink is arch-deprecated (CSS Text Decoration L3 explicitly deprecates the keyword; modern browsers no-op it for accessibility). The bridge accepts the keyword and applies no decoration \u2014 matches the spec deprecation path.",
+      "issue": ""
+    },
+    "css/textDecorationColor": {
+      "status": "supported",
+      "mapsTo": "setTextDecorationColor(id, color)",
+      "supportedValues": [
+        "any color"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/web-compat/test_css_translator_gaps_1434.cpp [issue-1434-batch-3]"
+      ],
+      "notes": "Bridge calls Label::set_text_decoration_color. Painted color falls back to the text color when unset.",
+      "issue": "1434"
+    },
+    "css/textDecorationLine": {
+      "status": "supported",
+      "mapsTo": "setTextDecoration(id, line)",
+      "supportedValues": [
+        "underline",
+        "line-through",
+        "overline",
+        "none"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/web-compat/test_css_translator_gaps_1434.cpp [issue-1434-batch-3]"
+      ],
+      "notes": "Routes to the same Label::TextDecoration setter as the shorthand. Per-attribute longhand preserves any previously-set sibling longhand (color/style). The deprecated 'blink' value is intentionally not supported (matches modern UA behavior).",
+      "issue": "1434"
+    },
+    "css/textDecorationStyle": {
+      "status": "supported",
+      "mapsTo": "setTextDecorationStyle(id, style)",
+      "supportedValues": [
+        "solid",
+        "double",
+        "dotted",
+        "dashed",
+        "wavy"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/web-compat/test_css_translator_gaps_1434.cpp [issue-1434-batch-3]"
+      ],
+      "notes": "CSS shim + bridge accept all 5 spec values and store them on Label. Paint path renders solid regardless today; non-solid styles fall back to solid (spec-allowed).",
+      "issue": "1434"
+    },
+    "css/textIndent": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js parses the length and forwards to setTextIndent(id, px); the bridge stores the value on View::text_indent_. SkParagraph::setTextIndent integration at paint time is the follow-up.",
+      "supportedValues": [
+        "<length>",
+        "<percentage> (parsed; resolved to px at the JS layer per arch-paint-deferred)",
+        "each-line (parsed; falls through to default first-line application per arch-paint-deferred)",
+        "hanging (parsed; falls through to default first-line application per arch-paint-deferred)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 A4 Bundle 5: status flipped missing \u2192 partial. Storage-only with a dedicated bridge fn. Wave 4 css extensive \u2014 <percentage> / each-line / hanging are arch-paint-deferred (SkParagraph::setTextIndent integration at paint time is queued \u2014 the bridge stores the keyword + length on View::text_indent_ today and the paint path applies the stored value as a leading inset, so arbitrary first-line / each-line semantics are pending). Authors can express the leading inset today; per-line dispatch is the follow-up.",
+      "issue": ""
+    },
+    "css/textOverflow": {
+      "status": "supported",
+      "mapsTo": "setTextOverflow(id, value)",
+      "supportedValues": [
+        "ellipsis",
+        "clip",
+        "<string> custom token (stored verbatim; paint-time substitution deferred)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 string custom token is accepted at the bridge \u2014 setTextOverflow stores the string verbatim; paint-time application of an arbitrary truncation string (in place of the ellipsis glyph) is queued behind SkParagraph support. The bridge round-trip is complete.",
+      "issue": ""
+    },
+    "css/textShadow": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js:1356 parses `<dx>px <dy>px <blur>px <color>` and calls setTextShadow(id, dx, dy, blur, color); bridge function is registered (widget_bridge.cpp Wave 5 css.5) and routes into the existing per-attribute slots (text_shadow_offset / text_shadow_radius / text_shadow_color) \u2014 same slots the React-style setTextShadow{Color,Offset,Radius} fan-out uses.",
+      "supportedValues": [
+        "[inset] <dx>px <dy>px <blur>px [<spread>px] <color> (parsed at the JS shim; bridge fn registration deferred to paint-time)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 5 css.5 \u2014 registered the previously-missing setTextShadow bridge fn so the JS shim no longer no-ops. Composes into the existing 3 per-attribute slots that already round-trip through bridge (color / offset / radius). Catalog stays `supported`: the round-trip is honest. Multi-shadow comma-separated lists are arch-single-shadow (Pulp's text-shadow model is one SkPaint::Looper per Label, matching box-shadow's single-shadow architecture). Inset is parsed but is invalid for text-shadow per CSS L3 (text-shadow has no inset variant) \u2014 the JS shim accepts it for shorthand parity but the bridge ignores.",
+      "issue": ""
+    },
+    "css/textTransform": {
+      "status": "supported",
+      "mapsTo": "setTextTransform(id, value)",
+      "supportedValues": [
+        "uppercase",
+        "lowercase",
+        "capitalize",
+        "none"
+      ],
+      "unsupportedValues": [
+        "full-width (ARCH-DEFERRED: requires ICU/Unicode width-transform support outside Pulp's current Skia text path; would need an ICU subsystem to land before this becomes implementable, not a closeable coverage gap on Pulp's intended surface)",
+        "full-size-kana (ARCH-DEFERRED: same \u2014 needs Unicode kana-width transform support outside the current text path)"
+      ],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]",
+        "test/test_widget_bridge.cpp [css-textTransform]"
+      ],
+      "notes": "Closure: 4 supported values pinned by test/test_widget_bridge.cpp [css-textTransform]; the two unsupported CJK-specific transforms are honestly reclassified as ARCH-DEFERRED (would require ICU Unicode-width data Pulp's Skia text path does not currently load).",
+      "issue": ""
+    },
+    "css/top": {
+      "status": "supported",
+      "mapsTo": "setTop(id, px); JS shim resolves em/rem (\u00d7 14px default), vh/vw (\u00d7 600/800 default viewport), % flows verbatim through the 'NN%' bridge path -> YGNodeStyleSetPositionPercent.",
+      "supportedValues": [
+        "px",
+        "%",
+        "em",
+        "rem",
+        "vh",
+        "vw"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 2 css.2 \u2014 em/rem/vh/vw resolved in JS using the same default font-size (14px) and viewport (800x600) as resolveLength in css-parser.js. Single-level cascade; nested font-size cascade is the follow-up. pulp #1434 batch 6: percent values flow through the bridge via 'NN%'.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1434"
+    },
+    "css/touchAction": {
+      "status": "wontfix",
+      "mapsTo": "architectural \u2014 Pulp's gesture model is platform-native (UIKit/AppKit/Android gesture recognizers, audio-plugin custom gesture handlers). touch-action would require a Web-style per-axis touch-router slice (CSS Pointer Events \u00a76) that splits a single touch stream into pan/zoom/scroll channels \u2014 Pulp does not have that pipeline.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "auto",
+        "none",
+        "manipulation",
+        "pan-x",
+        "pan-y",
+        "pan-left",
+        "pan-right",
+        "pan-up",
+        "pan-down",
+        "pinch-zoom"
+      ],
+      "tests": [],
+      "notes": "Architectural OOS per CLAUDE.md / Pulp input model. **Important clarification (Codex P2 on #1794):** `pointer-events` is NOT a drop-in equivalent for `touch-action`. `View::hit_test()` consulting `pointer-events: none` drops the node entirely from hit-testing \u2014 the element receives NO pointer events at all. `touch-action: none` is different: the element keeps receiving pointer events, but the user agent is told NOT to apply default touch behaviors (panning, pinch-zoom). So `pointer-events:none` and `touch-action:none` overlap only in the coarse 'this region is not pannable' read; they diverge when an interactive element wants to receive pointer events (drag, draw, custom gesture handling) while suppressing the user-agent's default scroll/zoom interpretation. Pulp expresses that pattern through platform gesture-recognizer APIs (UIKit `UIPanGestureRecognizer`, etc.) rather than CSS touch-action; the bridge accepts but does not honor the CSS keyword. The fine-grained per-axis modes (manipulation, pan-x, pan-y, pinch-zoom) require the Web-style per-axis touch-router that Pulp's input pipeline doesn't have. Same architectural-ceiling reclassification pattern as #1785 (rn/isolation \u2014 no stacking-context engine) and #1790 (9 css NO-OPs \u2014 no block-flow / table / multi-column / float / print primitives). Counts as OOS in achievable-ceiling math; closed the last css NO-OP entry. Originally `partial` (#1475 walked back to `noop` when audit confirmed no hit-test consumption); flipped to `wontfix` in #1794 with this entry recording the full architectural rationale.",
+      "issue": ""
+    },
+    "css/transform": {
+      "status": "supported",
+      "mapsTo": "parseTransform (css-parser.js) walks the function set; web-compat-style-decl.js dispatches via setTranslate / setRotation / setScale / setSkew. Walk-once accumulator merges axes (e.g. translateX(10) translateY(20) \u2192 ONE setTranslate(10,20)).",
+      "supportedValues": [
+        "translate(x,y)",
+        "translateX(x)",
+        "translateY(y)",
+        "rotate(deg)",
+        "rotateZ(deg)",
+        "scale(n)",
+        "scale(x,y)",
+        "scaleX(n)",
+        "scaleY(n)",
+        "skewX(deg)",
+        "skewY(deg)",
+        "matrix(a,b,c,d,tx,ty) \u2014 decomposed to translate+scale+rotate",
+        "angle units: deg / rad / turn / grad"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/web-compat/test_web_compat_prelude.cpp::\"WebCompat: parseTransform recognizes scaleX\"",
+        "test/web-compat/test_web_compat_prelude.cpp::\"WebCompat: setSkew bridge fn registered\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Triage #9 fan-out \u2014 full CSS transform-function set wired via parseTransform walk-once accumulator. setSkew bridge fn registered; scaleX/scaleY share uniform setScale slot (last-write-wins; bridge gap); matrix() decomposed to translate+scale+rotate. rotateX / rotateY / matrix3d / perspective silently drop (pulp's 2D View has no 3D model). Deferred: rotateX/rotateY/matrix3d/perspective (no 3D model on View \u2014 pulp follow-up).",
+      "issue": ""
+    },
+    "css/transformOrigin": {
+      "status": "supported",
+      "mapsTo": "parse keywords + percentages -> setTransformOrigin(id, x, y) (0..1)",
+      "supportedValues": [
+        "center",
+        "left",
+        "right",
+        "top",
+        "bottom",
+        "<percentage>",
+        "<keyword> <keyword>",
+        "<length> (px; resolved as scalar via parseCSSLength)",
+        "third value / z-axis (arch-2d-only; ignored at the bridge)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Px values are mishandled -- only % and keywords resolve correctly. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 px is supported via the parseCSSLength path (numeric forwards as scalar to setTransformOrigin). third value (z-axis) is arch-2d-only \u2014 pulp's transform pipeline is 2D (Skia matrix is 2D); 3D transforms render in the layer's 2D projection per arch-2d-only.",
+      "issue": ""
+    },
+    "css/transition": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards keyword/value verbatim to setTransition / setTransitionProperty / setTransitionDuration / setTransitionDelay / setTransitionTimingFunction. Bridge stores TransitionSpec[] on View::transitions_; PR 2 wires the playback driver.",
+      "supportedValues": [
+        "shorthand parsing",
+        "cubic-bezier(...)",
+        "steps(N, end|start)",
+        "linear / ease / ease-in / ease-out / ease-in-out",
+        "duration in ms or s",
+        "delay in ms or s",
+        "comma-separated entries",
+        "\"none\" clears the list"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setTransition stores TransitionSpecs on the View\"",
+        "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
+      "issue": "1323"
+    },
+    "css/transitionDelay": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards keyword/value verbatim to setTransition / setTransitionProperty / setTransitionDuration / setTransitionDelay / setTransitionTimingFunction. Bridge stores TransitionSpec[] on View::transitions_; PR 2 wires the playback driver.",
+      "supportedValues": [
+        "shorthand parsing",
+        "cubic-bezier(...)",
+        "steps(N, end|start)",
+        "linear / ease / ease-in / ease-out / ease-in-out",
+        "duration in ms or s",
+        "delay in ms or s",
+        "comma-separated entries",
+        "\"none\" clears the list"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setTransition stores TransitionSpecs on the View\"",
+        "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
+      "issue": ""
+    },
+    "css/transitionDuration": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards keyword/value verbatim to setTransition / setTransitionProperty / setTransitionDuration / setTransitionDelay / setTransitionTimingFunction. Bridge stores TransitionSpec[] on View::transitions_; PR 2 wires the playback driver.",
+      "supportedValues": [
+        "shorthand parsing",
+        "cubic-bezier(...)",
+        "steps(N, end|start)",
+        "linear / ease / ease-in / ease-out / ease-in-out",
+        "duration in ms or s",
+        "delay in ms or s",
+        "comma-separated entries",
+        "\"none\" clears the list"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setTransition stores TransitionSpecs on the View\"",
+        "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
+      "issue": ""
+    },
+    "css/transitionProperty": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards keyword/value verbatim to setTransition / setTransitionProperty / setTransitionDuration / setTransitionDelay / setTransitionTimingFunction. Bridge stores TransitionSpec[] on View::transitions_; PR 2 wires the playback driver.",
+      "supportedValues": [
+        "shorthand parsing",
+        "cubic-bezier(...)",
+        "steps(N, end|start)",
+        "linear / ease / ease-in / ease-out / ease-in-out",
+        "duration in ms or s",
+        "delay in ms or s",
+        "comma-separated entries",
+        "\"none\" clears the list"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setTransition stores TransitionSpecs on the View\"",
+        "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
+      "issue": ""
+    },
+    "css/transitionTimingFunction": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards keyword/value verbatim to setTransition / setTransitionProperty / setTransitionDuration / setTransitionDelay / setTransitionTimingFunction. Bridge stores TransitionSpec[] on View::transitions_; PR 2 wires the playback driver.",
+      "supportedValues": [
+        "shorthand parsing",
+        "cubic-bezier(...)",
+        "steps(N, end|start)",
+        "linear / ease / ease-in / ease-out / ease-in-out",
+        "duration in ms or s",
+        "delay in ms or s",
+        "comma-separated entries",
+        "\"none\" clears the list"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setTransition stores TransitionSpecs on the View\"",
+        "test/test_widget_bridge.cpp::\"parse_transition_shorthand: comma-separated entries\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-1 \u2014 transition shorthand parser + bridge wiring landed. setTransition parses the full CSS shorthand into TransitionSpec[]; longhand setters (setTransitionProperty/Duration/Delay/TimingFunction) apply uniformly across the parsed list. Frame-driven playback that consults the spec when a property changes lands in PR 2 of the ladder.",
+      "issue": ""
+    },
+    "css/userSelect": {
+      "status": "supported",
+      "mapsTo": "setUserSelect(id, value)",
+      "supportedValues": [
+        "auto",
+        "none",
+        "text",
+        "all",
+        "contain"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1656-tier2-userSelect]"
+      ],
+      "notes": "pulp #1538 / #1656 Tier-2 follow-up \u2014 bridge `setUserSelect` now actually stores the keyword on `View::user_select_` (storage slot for downstream widgets to read). Round-trip verified end-to-end through `CSSStyleDeclaration._applyProperty`. Selection-blocking behavior in TextEditor / Label is the next slice (storage exists; widgets need to read it before suppressing selection events).",
+      "issue": ""
+    },
+    "css/verticalAlign": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards the keyword to setVerticalAlign(id, value); the bridge maps to the existing canvas::TextVerticalAlign enum on Label widgets (top|middle|bottom|baseline). Widgets other than Label ignore the value silently (the field is per-widget).",
+      "supportedValues": [
+        "top",
+        "middle",
+        "bottom",
+        "baseline",
+        "sub (parsed; falls through to baseline per arch-paint-deferred)",
+        "super (parsed; falls through to baseline per arch-paint-deferred)",
+        "text-top (parsed; falls through to top per arch-paint-deferred)",
+        "text-bottom (parsed; falls through to bottom per arch-paint-deferred)",
+        "<length> (parsed; resolved to px at the JS layer; falls through to baseline per arch-paint-deferred)",
+        "<percentage> (parsed; resolved to px at the JS layer; falls through to baseline per arch-paint-deferred)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 A4 Bundle 5: status flipped missing \u2192 partial. Routes to the existing TextVerticalAlign enum on Label. Wave 4 css extensive \u2014 sub / super / text-top / text-bottom / <length> / <percentage> are arch-paint-deferred \u2014 the bridge stores the keyword on View::vertical_align_ and the paint pipeline today applies the four canonical canvas::TextBaseline values (top / middle / bottom / baseline); the extended set is queued behind SkParagraph baseline shift integration. Round-trip is complete.",
+      "issue": ""
+    },
+    "css/visibility": {
+      "status": "supported",
+      "mapsTo": "setVisibility(id, 'visible'|'hidden') if registered, else opacity fallback",
+      "supportedValues": [
+        "visible",
+        "hidden",
+        "collapse"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "setVisibility IS registered (widget_bridge.cpp:1814) so the primary path works. Wave 4 css extensive \u2014 collapse is arch-table-only \u2014 the CSS spec explicitly defines it as equivalent to `hidden` outside of table-row / table-column contexts; pulp's flex-only layout is non-table by design (arch-flex-only) so the spec-equivalent collapse->hidden mapping is the spec-conformant rendering.",
+      "issue": ""
+    },
+    "css/webkitLineClamp": {
+      "status": "supported",
+      "mapsTo": "same as lineClamp \u2014 both keys funnel through setLineClamp(id, n)",
+      "supportedValues": [
+        "integer"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::WidgetBridge setLineClamp stores count on Label",
+        "test/test_widget_bridge.cpp::WidgetBridge setLineClamp truncates multi-line text in paint",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1552: shares the lineClamp wiring. The CSS shim case routes both `line-clamp` and `-webkit-line-clamp` to the same setLineClamp bridge fn; the @pulp/react prop-applier dispatches both `lineClamp` and `webkitLineClamp` keys through the same branch. 2026-05-12 closure: `none` reclassified \u2014 shares lineClamp's dispatcher, same parseInt fallthrough.",
+      "issue": "1552"
+    },
+    "css/whiteSpace": {
+      "status": "supported",
+      "mapsTo": "setWhiteSpace(id, value) \u2014 bridge widget_bridge.cpp:2478 maps the keyword to View::WhiteSpaceMode enum (normal / nowrap / pre / pre_wrap / pre_line / break_spaces). The legacy white_space_nowrap() bool is maintained in lock-step (true for {nowrap, pre}) so existing TextShaper consumers keep working. Label.multi_line is toggled per spec semantics: pre/nowrap \u2192 no wrap; normal/pre-wrap/pre-line/break-spaces \u2192 wrap.",
+      "supportedValues": [
+        "normal",
+        "nowrap",
+        "pre",
+        "pre-wrap",
+        "pre-line",
+        "break-spaces"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1410]",
+        "test/test_widget_bridge.cpp [issue-1737]"
+      ],
+      "notes": "pulp #1737 \u2014 full WhiteSpaceMode enum wired end-to-end. Bridge maps all 6 CSS keywords to the matching enum value; Label.multi_line is toggled per spec (no wrap for nowrap/pre, wrap for the other 4). Whitespace preservation is consumed by the existing Label render path which splits on `\\n` for multi-line modes. break-spaces' extra-break-opportunity refinement degrades to pre-wrap rendering today \u2014 same render output, slightly different break behaviour at long-word boundaries \u2014 tracked as a paint-side follow-up but not a catalog-level gap because the supportedValues claim is keyword coverage + multi_line semantics. Each keyword has a regression test asserting both white_space_mode() and multi_line() reach the spec-correct values; unknown keywords fall back to normal per CSS forward-compat.",
+      "issue": ""
+    },
+    "css/width": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'width', px) for numeric, 'NN%' for percent, 'auto' for hug-contents (yoga/width path via FlexStyle.dim_width)",
+      "supportedValues": [
+        "px (number)",
+        "%",
+        "auto",
+        "em (resolved against default 14px per arch-single-level-cascade)",
+        "rem (resolved against default 14px per arch-single-level-cascade)",
+        "min-content (treated as auto per arch-yoga-no-intrinsic-sizing)",
+        "max-content (treated as auto per arch-yoga-no-intrinsic-sizing)",
+        "fit-content (treated as auto per arch-yoga-no-intrinsic-sizing)",
+        "calc() (treated as auto per arch-no-calc-eval; precompute at the JS layer)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1423 wired px + %; pulp #1434 (sub-agent #12 follow-up) wired 'auto' end-to-end (CSS translator forwards 'auto' verbatim; bridge populates FlexStyle.dim_width.unit = auto_; yoga_layout.cpp dispatches to YGNodeStyleSetWidthAuto). Relative units (em/rem/calc) remain deferred. Wave 1 architectural reclassification \u2014 min-content / max-content / fit-content are arch-yoga-limit (Yoga doesn't compute content-sized boxes); em/rem/calc() are deferred (relative-unit resolver lands later \u2014 calc() shipped via #1576 for min/max sides only). Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 min-content / max-content / fit-content are arch-yoga-no-intrinsic-sizing (Yoga's flex layout doesn't model intrinsic sizing; use flex / flex-basis for the equivalent shrink-to-fit behaviour). calc() is arch-no-calc-eval (no expression evaluator at the JS shim layer; authors precompute or use JS variables). em/rem resolve against the default 14px font-size at the JS layer (single-level cascade per Wave 2 css.2 fontSize precedent).",
+      "issue": "https://github.com/danielraffel/pulp/issues/1434"
+    },
+    "css/willChange": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Hint to compositor -- Pulp's renderer is GPU all the time.",
+      "issue": ""
+    },
+    "css/wordBreak": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards `word-break` to setWordBreak(id, value); the bridge stores the value on View::word_break_. HarfBuzz line-break feature integration is the paint-side follow-up.",
+      "supportedValues": [
+        "normal",
+        "break-all",
+        "keep-all",
+        "break-word"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 A4 Bundle 5: missing -> partial -> supported. Bridge fn setWordBreak stores the keyword on View::word_break_; all 4 CSS-spec values (normal | break-all | keep-all | break-word) round-trip through the bridge. HarfBuzz line-break feature integration at paint time is the behavior-fidelity follow-up; the catalog claim is keyword-coverage complete.",
+      "issue": ""
+    },
+    "css/wordWrap": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js forwards `word-wrap` (legacy alias) to setWordBreak(id, value); shared with wordBreak / overflowWrap. Bridge fn registered at widget_bridge.cpp:4983 (since pulp #1434 A4 Bundle 5).",
+      "supportedValues": [
+        "normal",
+        "break-word",
+        "anywhere"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 batch (catalog hygiene): status flipped missing -> partial. CSS translator at web-compat-style-decl.js:728-729 funnels `wordWrap`, `overflowWrap`, and `wordBreak` through the same setWordBreak case. Bridge function is not yet registered, so values are silently dropped at runtime. Legacy alias of overflow-wrap. Wave 4 css extensive \u2014 stale claim \u2014 break-word/normal/anywhere all reach setWordBreak via the same shared route as wordBreak/overflowWrap (web-compat-style-decl.js funnels three cases into the same call). The bridge fn IS registered (widget_bridge.cpp:4983); HarfBuzz line-break feature integration is the shared paint-side follow-up.",
+      "issue": ""
+    },
+    "css/writingMode": {
+      "status": "wontfix",
+      "mapsTo": "Architectural \u2014 Pulp's TextShaper is horizontal-tb only; vertical writing requires a separate text-layout pipeline in HarfBuzz/SkParagraph.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "pulp #1737 (CSS NO-OP audit) \u2014 reclassified noop \u2192 wontfix. Catalog text already said \"Architecturally out of scope\"; the noop classification was misleading.",
+      "issue": ""
+    },
+    "css/zIndex": {
+      "status": "supported",
+      "mapsTo": "setZIndex(id, int)",
+      "supportedValues": [
+        "integer",
+        "auto (resolved to 0 at the JS layer)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "'auto' parses as 0. Wave 1 drift cleanup \u2014 supported \u2192 partial (catalog had real unsupportedValues; honest claim is partial, not supported; gotchas are arch / deferred per entry-specific notes). Wave 4 css extensive \u2014 `auto` parses as 0 at the JS layer (the integer slot is 0 by default; auto matches the layout-natural ordering). Round-trip is complete.",
+      "issue": ""
+    },
+    "css/appearance": {
+      "status": "supported",
+      "mapsTo": "el.style.appearance -> setAppearance(id, value) -> View::appearance_ (storage-only). Pulp paints all widgets custom; appearance has no rendering impact in the architecture.",
+      "supportedValues": [
+        "auto",
+        "none",
+        "button",
+        "textfield",
+        "menulist",
+        "menulist-button",
+        "searchfield",
+        "textarea",
+        "checkbox",
+        "radio",
+        "menulist-text",
+        "menulist-textfield"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1707-followup-appearance]"
+      ],
+      "notes": "Pulp paints all widgets custom (no native form-widget rendering). `appearance: none` is the effective behavior for every Pulp View regardless of slot value. Slot exists so authors who set `appearance: none` for reset-style consistency see a no-op (not an unsupported drop) and the value round-trips through CSSStyleDeclaration. Includes WebKit/Moz-prefixed variants for compatibility with imported designs."
+    },
+    "css/maskSize": {
+      "status": "supported",
+      "mapsTo": "el.style.maskSize -> setMaskSize(id, value) -> View::mask_size_ -> View::paint_all routes via Canvas::save_layer_with_mask(...,mask_size) -> SkiaCanvas::save_layer_with_mask parses the value into width/height factors that scale the gradient endpoints before the saveLayer + SkBlendMode::kDstIn composite at restore time.",
+      "supportedValues": [
+        "auto",
+        "cover",
+        "contain",
+        "<percentage>",
+        "<percentage> <percentage>",
+        "<length>",
+        "<length> <length>"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1707-followup-maskSize]",
+        "unit:test_view#issue-1515"
+      ],
+      "notes": "pulp #1515 (storage), pulp #1737 PR-3 (paint slice). Bridge stores via setMaskSize; View::paint_all forwards the value to Canvas::save_layer_with_mask alongside mask_image. SkiaCanvas parses the value (auto/cover/contain \u2192 1.0 multiplier; <percentage> \u2192 /100; <length> in px \u2192 /bound) and applies the resulting (width_factor, height_factor) to the gradient endpoint span before building the SkShader. The 2-saveLayer + SkBlendMode::kDstIn composite at restore() time keeps only the alpha the mask permits \u2014 same architectural pattern Chromium uses for CSS Masking Module Level 1 \u00a75. Phase 1 paints linear-gradient masks fully; radial-gradient and url() image masks fall through to the no-mask path safely (matches pre-#1737 behavior \u2014 content paints unchanged, mask silently bypassed). Tested end-to-end in test_view [issue-1515]: the spy canvas verifies the API dispatch with the exact mask_image + mask_size strings.",
+      "issue": "1515"
+    },
+    "css/objectFit": {
+      "status": "supported",
+      "mapsTo": "el.style.objectFit -> setObjectFit(id, value) -> View::object_fit_. pulp #1737 \u2014 ImageView::paint now consumes the value: probes intrinsic image dimensions via Canvas::measure_image_from_file (Skia override consults SkImage header without forcing decode), computes a fit rect per spec, then routes through draw_image_from_file (full src) or draw_image_from_file_rect (cropped src for `none`/`cover` overflow). Backends without measure_image_from_file fall back to the pre-#1737 stretch-to-bounds path (object-fit: fill).",
+      "supportedValues": [
+        "fill",
+        "contain",
+        "cover",
+        "none",
+        "scale-down"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1707-followup-objectFit]",
+        "test/test_image_view_cache.cpp [object-fit][issue-1737]"
+      ],
+      "notes": "pulp #1737 \u2014 wired end-to-end: Canvas::measure_image_from_file API + ImageView::paint compute_fit lambda + Skia override using SkImages::DeferredFromEncodedData (peek SkImage header). Per CSS spec: `fill` stretches; `contain` letterboxes preserving AR; `cover` crops to fill the larger axis; `none` paints native size centred (with src-rect crop when image overflows the box); `scale-down` chooses `none` if smaller, else `contain`."
+    },
+    "css/objectPosition": {
+      "status": "supported",
+      "mapsTo": "el.style.objectPosition -> setObjectPosition(id, value) -> View::object_position_. pulp #1737 \u2014 ImageView::paint parses `<x> <y>` two-token strings (`%`, bare numbers, or px lengths) and offsets the centred dst rect within the box. CSS percentage form is implemented per spec: `0%` pins to the start, `100%` to the end (slack-relative).",
+      "supportedValues": [
+        "<percentage> <percentage>",
+        "<length> <length>",
+        "single-token shorthand (applied to both axes)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1707-followup-objectPosition]",
+        "test/test_image_view_cache.cpp [object-position][issue-1737]"
+      ],
+      "notes": "pulp #1737 \u2014 paired with object-fit, consumed by ImageView::paint after compute_fit. Slack-based percentage interpretation matches the spec; lengths are converted to a percentage of the slack so they compose with the centred-default fit rect."
+    },
+    "css/grid": {
+      "status": "supported",
+      "mapsTo": "el.style.grid -> JS-shim parses `<rows> / <cols>` form and fans out to setGrid(id, 'template_rows', ...) + setGrid(id, 'template_columns', ...). Full grid shorthand spec (auto-flow forms, embedded template-areas, dense packing) is deferred \u2014 authors can use the existing longhand grid-template-{rows,columns,areas} + grid-auto-{rows,columns,flow} entries directly.",
+      "supportedValues": [
+        "<rows> / <cols>",
+        "none",
+        "single-track value (treated as template_rows)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1707-followup-grid]"
+      ],
+      "notes": "Common `<rows> / <cols>` form parsed; longhand fan-out to existing grid-template-{rows,columns} entries which are already supported. Status `partial` is honest until full shorthand parser ships. Most imported designs use the simple form; complex auto-flow shorthands are rare in practice. arch-grid-ceiling \u2014 `auto-flow [dense]?`, embedded template-areas, and `subgrid` exceed Yoga 3.x grid feature set; they are deferred until Yoga adds the API. Authors needing those forms should use the longhand grid-template-{rows,columns,areas} and grid-auto-{rows,columns,flow} entries directly. The catalog claim of `supported` reflects the basic <rows> / <cols> form which is the common case."
+    }
+  }
+}

--- a/compat/html.json
+++ b/compat/html.json
@@ -1,0 +1,768 @@
+{
+  "html": {
+    "_note": "Populated 2026-05-04 from web-compat-element.js (~836 LOC) and web-compat-document.js (~1527 LOC). Tracks the DOM-lite consumer surface: createElement / setAttribute / appendChild / addEventListener / Element / HTMLElement attributes / dataset / classList / events / style sheet support. Spec source: https://developer.mozilla.org/en-US/docs/Web/API/Element + HTMLElement subclasses. Recent additions since 2026-04-30: html/svg width/height attribute replay (#1347 / pulp #1147), html/span/p/label widget mapping confirmed (Label widget, not View), html/style :hover stylesheet support (#1345 / pulp #1149 part b). 2026-05-05 hygiene (pulp #1434): html/ARIA flipped missing \u2192 partial \u2014 storage works (parallel to html/Element_disabled); platform-bridge routing tracked under #1476.",
+    "html/ARIA": {
+      "status": "supported",
+      "mapsTo": "Element.setAttribute('aria-label', ...) \u2192 bridge.setAccessibilityLabel \u2192 View::set_access_label(). Element.setAttribute('role', ...) \u2192 bridge.setAccessibilityRole \u2192 View::set_access_role() with ARIA\u2192AccessRole bucket mapping (slider/checkbox/switch/radio/img/progressbar/meter/heading/label collapse onto Pulp's enum; the long ARIA tail collapses to AccessRole::group). pulp #1737 \u2014 Element.setAttribute('aria-pressed' / 'aria-checked' / 'aria-disabled' / 'aria-hidden', ...) \u2192 bridge.setAccessibilityState \u2192 View::access_pressed_ / access_checked_ / access_disabled_ / access_hidden_ slots (tri-state per ARIA 1.2 \u2014 `true` / `false` / `mixed` / unset). Storage round-trips through getAttribute either way. macOS NSAccessibility bridge in core/view/platform/mac/accessibility_mac.mm reads all slots directly; AccessibilityTree snapshot picks them up cross-platform; removeAttribute clears the matching slot.",
+      "supportedValues": [
+        "aria-label \u2192 setAccessibilityLabel routing",
+        "role \u2192 setAccessibilityRole routing (full ARIA\u2192AccessRole bucket mapping)",
+        "aria-pressed / aria-checked / aria-disabled / aria-hidden state attributes (tri-state per ARIA 1.2)",
+        "removeAttribute resets the matching View slot (no stale state on detach)",
+        "aria-* attribute storage / read-back via setAttribute / getAttribute (forward-compat for the long ARIA tail)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [wave3-html] (HTML aria-label + role attributes route to View access slots)",
+        "test/test_widget_bridge.cpp [issue-1641-followup-aria-removeattribute]",
+        "test/test_widget_bridge.cpp [issue-1737] (aria-pressed / -checked / -disabled / -hidden routing to View::access_*_ slots; tri-state; removeAttribute resets)"
+      ],
+      "notes": "Wave 3 (PR #1641) wired aria-label + role + macOS NSAccessibility. pulp #1737 \u2014 added aria-pressed / -checked / -disabled / -hidden state attributes via new setAccessibilityState bridge fn + View::access_pressed_/_checked_/_disabled_/_hidden_ slots; JS shim setAttribute fast-paths the four state attrs and __replayAriaAttributes__ covers the React-pre-mount commit order; removeAttribute clears the matching slot (mirrors the #1641 followup pattern for aria-label / role). Linux AT-SPI bridge + Windows UIA bridge remain `arch-deferred-platform-at` (tracked under pulp #217 \u2014 multi-week platform integration scope; not a Pulp-side ARIA-attribute gap). The state slots are populated cross-platform; whichever platform AT bridge lands next will read them automatically.",
+      "issue": "1476"
+    },
+    "html/DocumentFragment": {
+      "status": "supported",
+      "mapsTo": "Minimal shim with appendChild / removeChild covering React's reconciler hot path (createDocumentFragment + batched-insert). Children are flushed onto the parent on appendChild(fragment).",
+      "supportedValues": [
+        "createDocumentFragment()",
+        "appendChild / removeChild",
+        "children flush onto parent on appendChild(fragment)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 1 architectural reclassification \u2014 full Range / Selection API is arch-text-editor-owns-selection (Pulp's text editor has its own selection model; the W3C Range/Selection API is not modeled by design). Wave 4 cleanup \u2014 status partial \u2192 supported + emptied unsupportedValues so the harness reflects the wired DocumentFragment surface (the React reconciler path); the Range/Selection API is an explicit arch non-goal, not a partial-deferred gap.",
+      "issue": ""
+    },
+    "html/Element_addEventListener": {
+      "status": "supported",
+      "mapsTo": "Element.addEventListener \u2014 registers click / mousedown / mouseup / mouseenter / mouseleave / pointerenter / pointerleave / pointerdown / pointermove / pointerup / pointercancel / gesturestart / gesturechange / gestureend / input / change / focus / blur / wheel / dragstart / drag / dragend / dragenter / dragover / dragleave / drop with the bridge. registerHover/registerClick/registerPointer/registerGesture/registerWheel/registerDrop are called lazily as needed; drop events synthesize a DragEvent-shaped object with `_dropData`.",
+      "supportedValues": [
+        "click",
+        "mousedown",
+        "mouseup",
+        "mouseenter",
+        "mouseleave",
+        "pointerenter",
+        "pointerleave",
+        "pointerdown",
+        "pointermove",
+        "pointerup",
+        "pointercancel",
+        "gesturestart",
+        "gesturechange",
+        "gestureend",
+        "input",
+        "change",
+        "focus",
+        "blur",
+        "wheel",
+        "dragstart",
+        "drag",
+        "dragend",
+        "dragenter",
+        "dragover",
+        "dragleave",
+        "drop",
+        "keydown / keyup / keypress (forwarded globally via __dispatch__)",
+        "close (dispatched by HTMLDialogElement.close())",
+        "toggle (dispatched by HTMLDetailsElement.open setter)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"addEventListener('wheel', fn) routes through registerWheel\"",
+        "test/test_widget_bridge.cpp::\"addEventListener('drop', fn) routes through registerDrop\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "DIVERGE\u2192PASS sweep \u2014 `wheel` and `drag*`/`drop` event types are now routed through `registerWheel` / `registerDrop` from inside `_registerNativeEvent`, so DOM consumers no longer need to call the platform-specific bridge fns directly. The full multi-stage drag lifecycle (native drag-image rendering, dragstart/drag/dragend on the source element) remains a roadmap item \u2014 the bridge fires a single `drop` callback at completion and we synthesize a DragEvent-shaped object for the target element. Hover events fixed earlier in PR #1173 (pulp #1149 part a).",
+      "issue": "1149"
+    },
+    "html/Element_appendChild": {
+      "status": "supported",
+      "mapsTo": "web-compat-dom-ops.js: appendChild reparents native widget if needed via _reparentNative + replays presentational attrs.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_classList": {
+      "status": "supported",
+      "mapsTo": "Element.classList \u2014 add/remove/toggle/contains/length/item, mirrors className. Triggers stylesheet re-application on change.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_cloneNode": {
+      "status": "supported",
+      "mapsTo": "Element.cloneNode(deep) \u2014 replicates className, textContent, type, value, style props; recursive when deep.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_dataset": {
+      "status": "supported",
+      "mapsTo": "Element.dataset \u2014 kebab-cased data-* attrs surface as camelCase JS properties. Includes the data-overlay='true' hint (#1148).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": "1148"
+    },
+    "html/Element_disabled": {
+      "status": "supported",
+      "mapsTo": "Element.disabled property accessor in web-compat-element.js \u2014 set re-applies stylesheets (so `:disabled` selectors react) AND calls bridge `setEnabled(id, !disabled)` so the underlying View flips its enabled flag and stops handling pointer events / dispatching change.",
+      "supportedValues": [
+        "true / false (round-trips through el.disabled getter; both stylesheet and native widget state stay in sync)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"Element.disabled wires to setEnabled\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "DIVERGE\u2192PASS sweep \u2014 previously the setter only flipped the stylesheet flag, leaving the native widget interactive even though `:disabled` styles applied. Now wired end-to-end via setEnabled.",
+      "issue": ""
+    },
+    "html/Element_dispatchEvent": {
+      "status": "supported",
+      "mapsTo": "Element.dispatchEvent \u2014 capture + target + bubble phases; honors stopPropagation / preventDefault / _noBubble.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_getAttribute": {
+      "status": "supported",
+      "mapsTo": "Element.getAttribute(name).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_getBoundingClientRect": {
+      "status": "supported",
+      "mapsTo": "Element.getBoundingClientRect -> getLayoutRect bridge fn. Returns {x,y,width,height,top,right,bottom,left}.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_hidden": {
+      "status": "supported",
+      "mapsTo": "Element.hidden -> setVisible(id, !hidden).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_insertBefore": {
+      "status": "supported",
+      "mapsTo": "web-compat-dom-ops.js.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_nodeName": {
+      "status": "supported",
+      "mapsTo": "Returns upper-case tagName per DOM spec.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_nodeType": {
+      "status": "supported",
+      "mapsTo": "Element.nodeType === 1 (ELEMENT_NODE). Constants exposed on the prototype for React's reconciler hot-path checks.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Pulp #468.",
+      "issue": "468"
+    },
+    "html/Element_offsetWidth": {
+      "status": "supported",
+      "mapsTo": "Maps to getBoundingClientRect().width.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Same for offsetHeight, clientWidth, clientHeight.",
+      "issue": ""
+    },
+    "html/Element_removeAttribute": {
+      "status": "supported",
+      "mapsTo": "Element.removeAttribute \u2014 also clears data-* dataset entries and re-evaluates overlay heuristic if data-overlay was set.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_removeChild": {
+      "status": "supported",
+      "mapsTo": "web-compat-dom-ops.js.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_replaceChild": {
+      "status": "supported",
+      "mapsTo": "web-compat-dom-ops.js.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_setAttribute": {
+      "status": "supported",
+      "mapsTo": "Element.setAttribute(name, value) \u2014 handles id, class, data-*, plus presentational width/height for media tags (replay path).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_setPointerCapture": {
+      "status": "supported",
+      "mapsTo": "Element.setPointerCapture / releasePointerCapture -> nativeSetPointerCapture / nativeReleasePointerCapture (P2b).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_textContent": {
+      "status": "supported",
+      "mapsTo": "Element.textContent \u2014 special-cased for <style>: routes through _processStyleElement instead of setText.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": "1323"
+    },
+    "html/Element_value": {
+      "status": "supported",
+      "mapsTo": "Element.value \u2014 type-aware (range -> normalized, checkbox -> 0/1, progress -> setProgress, default -> setText).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Event_constructor": {
+      "status": "supported",
+      "mapsTo": "Event(type, init) and CustomEvent(type, init) constructor functions in web-compat-element.js \u2014 produce objects shaped like the DOM Event interface (type / bubbles / cancelable / composed / target / currentTarget / timeStamp / defaultPrevented / stopPropagation / stopImmediatePropagation / preventDefault). Round-trips through Element.dispatchEvent. The bridge-synthesized `_makeEvent` factory remains the canonical path for native-originated events (it carries the position / pointer / gesture fields).",
+      "supportedValues": [
+        "new Event('foo')",
+        "new Event('foo', { bubbles, cancelable, composed })",
+        "new CustomEvent('foo', { detail })"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"new Event() round-trips through dispatchEvent\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "DIVERGE\u2192PASS sweep \u2014 userland `new Event(...)` previously was a TypeError because no Event class was exposed. Now exposed as a global constructor (plus CustomEvent for parity). Type-only events are sufficient for the harness gap; full DOM event class hierarchy (UIEvent / MouseEvent / KeyboardEvent etc.) remains a roadmap follow-up.",
+      "issue": ""
+    },
+    "html/StyleSheet_inline": {
+      "status": "supported",
+      "mapsTo": "Inline <style> elements parsed and applied to the document. Selectors: tag, .class, #id, [attr], descendant, child; :hover stylesheet support added in PR #1345. Properties routed through CSSStyleDeclaration._applyProperty (full css/* surface).",
+      "supportedValues": [
+        "tag, .class, #id selectors",
+        "[attr] / [attr=value] attribute selectors (Wave 3 PR #1641)",
+        "descendant (a b) / child (a > b) combinators (Wave 3 PR #1641)",
+        ":hover pseudo-class (PR #1345)",
+        "all css/* properties via CSSStyleDeclaration._applyProperty"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "PR #1345 added :hover; PR #1641 (Wave 3 html.3) extended selector engine with [attr] / descendant / child / compound. Wave 1 architectural reclassification \u2014 @media / @keyframes / @import / @font-face / @supports / complex selectors are arch-no-cascade-engine (Pulp doesn't model the CSS cascade by design; selector evaluation is single-pass tag/.class/#id/[attr]/combinator). Wave 4 cleanup \u2014 status partial \u2192 supported + emptied unsupportedValues; the inline-style surface that IS implemented is the supported claim, the at-rule + cascade-engine extensions are explicit arch non-goals (consumers reach for @pulp/react state-dependent components for media-query / keyframe needs).",
+      "issue": ""
+    },
+    "html/article": {
+      "status": "supported",
+      "mapsTo": "createCol \u2014 same as div.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/aside": {
+      "status": "supported",
+      "mapsTo": "createCol \u2014 same as div.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/button": {
+      "status": "supported",
+      "mapsTo": "createToggleButton(id, parent).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Inherits ToggleButton widget \u2014 toggleable by default.",
+      "issue": ""
+    },
+    "html/canvas": {
+      "status": "supported",
+      "mapsTo": "createCanvas(id, parent). 2D context via Element.getContext('2d'); WebGPU via getContext('webgpu').",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "See canvas2d/* for the rendering surface.",
+      "issue": ""
+    },
+    "html/details": {
+      "status": "supported",
+      "mapsTo": "createCol(id, parent). `el.open = true/false` setter (defined on Element.prototype as a tag-aware accessor in web-compat-element.js) toggles the `open` HTML attribute, re-applies stylesheets so `details[open]` selectors react, and dispatches a `toggle` event. The <summary> tag semantic (always visible while children hide under closed details) remains a paint-side roadmap item but the open-state vocabulary is now wired.",
+      "supportedValues": [
+        "el.open getter / setter",
+        "open HTML attribute reflection",
+        "'toggle' event on open-state change"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"<details> open setter dispatches toggle event\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "DIVERGE\u2192PASS sweep \u2014 open/closed toggle behavior wired through Element.open setter. <summary>-driven children hiding when closed is a paint-side concern that remains roadmap; the harness gap was about JS-side toggle semantics.",
+      "issue": ""
+    },
+    "html/dialog": {
+      "status": "supported",
+      "mapsTo": "createPanel(id, parent) + setVisible(false). Element.show() / showModal() / close() methods on Element.prototype (tag-guarded \u2014 return early on non-DIALOG elements) flip setVisible and the `open` HTML attribute, dispatch a `close` event, and round-trip `el.returnValue`. showModal() degrades to show() + an internal `_dialogModal` flag because Pulp doesn't yet have a native modal-input-trap layer; the ::backdrop pseudo-element remains a separate paint-side roadmap item.",
+      "supportedValues": [
+        "dialog as a hidden Panel",
+        "el.show() \u2014 non-modal open with `open` attribute reflection",
+        "el.showModal() (degrades to show() + _dialogModal flag \u2014 no native modal trap layer yet, tracked separately)",
+        "el.close(returnValue) + 'close' event dispatch",
+        "el.open getter / setter (reflects + drives `open` attribute)",
+        "el.returnValue round-trip"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::<dialog> show/close round-trips visibility and dispatches close"
+      ],
+      "notes": "DIVERGE\u2192PASS sweep \u2014 show/showModal/close methods exposed. pulp #1737: catalog flipped noop \u2192 supported to match the wired behavior. Wave 1 walked this back to noop conservatively because modal-input-trap + ::backdrop aren't wired, but the JS surface (show / showModal / close / open / returnValue) IS wired and the existing test [test/test_widget_bridge.cpp \"<dialog> show/close...\"] exercises the round-trip. Architectural follow-ups (native modal-input-trap layer, ::backdrop pseudo-element paint) are documented in supportedValues notes \u2014 same precedent as object-fit's degraded-but-honored claim. Closes the last html-surface NO-OP.",
+      "issue": ""
+    },
+    "html/div": {
+      "status": "supported",
+      "mapsTo": "Element('div')._ensureNative -> createCol(id, parent). Same for section/article/aside/header/footer/nav/main.",
+      "supportedValues": [
+        "all generic flow tags"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Generic container \u2014 Yoga column flex by default.",
+      "issue": ""
+    },
+    "html/document_addEventListener": {
+      "status": "supported",
+      "mapsTo": "Global key/mouse listener installation on document.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/document_createElement": {
+      "status": "supported",
+      "mapsTo": "document.createElement(tag) -> new Element(tag).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/document_createTextNode": {
+      "status": "supported",
+      "mapsTo": "document.createTextNode -> Text-like Element.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Used by React reconciler. Confirmed wired in web-compat-document.js (pulp #1434 batch 1).",
+      "issue": ""
+    },
+    "html/document_getElementById": {
+      "status": "supported",
+      "mapsTo": "document.getElementById -> __elements__['#'+id] lookup.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/document_querySelector": {
+      "status": "supported",
+      "mapsTo": "document.querySelector / querySelectorAll \u2014 _parseSelector + _matchesSelector in web-compat-document.js. Tokenizes the rightmost simple selector (tag / #id / .class / [attr] / [attr=value] / [attr^=v] / [attr$=v] / [attr*=v] / [attr|=v] / [attr~=v]) plus descendant (`a b`), child (`a > b`), and a curated set of pseudo-classes. Walks left to right with bracket-aware splitting.",
+      "supportedValues": [
+        "#id",
+        ".class",
+        "tagname",
+        "[attr]",
+        "[attr=value]",
+        "[attr^=value]",
+        "[attr$=value]",
+        "[attr*=value]",
+        "[attr|=value]",
+        "[attr~=value]",
+        "compound (tag.class, tag#id, tag[attr], #id.class[attr])",
+        "descendant (a b)",
+        "child (a > b)",
+        ":hover / :focus / :active / :disabled / :checked / :enabled (state-on-element pseudo-classes \u2014 read el._isHovered / _hasFocus / _isActive / _disabled / _checked)",
+        ":first-child / :last-child / :only-child / :empty (DOM-position pseudo-classes)",
+        ":root (matches the body element via _matchesPseudoClass \u2014 works for stylesheet `:root { ... }` rules via StyleSheet._applyTo; document.querySelector(':root') returns null because _findMatch starts traversal from root._children, which never includes the root itself)",
+        ":nth-child(N) / :nth-child(2n+1) / :nth-child(odd|even) / :nth-last-child(...) (formula + keyword forms)",
+        ":not(<simple>) (functional negation \u2014 recursively dispatches to _matchesSelector)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [wave3-html] (querySelector minimal selector engine)",
+        "test/test_widget_bridge.cpp [issue-1641-followup-querySelector-colon]",
+        "test/test_widget_bridge.cpp [issue-1737] (pseudo-class evaluation: :hover state, :disabled, :checked, :enabled, :not, :first/:last/:only-child, :nth-child, :empty)"
+      ],
+      "notes": "Wave 3 (PR #1641) wired tag/.class/#id/[attr]/[attr=value]/descendant/child. pulp #1641 followup fixed bracket-aware colon scanning. pulp #1737 \u2014 pseudo-class state matching now implemented end-to-end: state-on-element forms read the bridge-maintained el._isHovered/_hasFocus/_isActive/_disabled/_checked slots; DOM-position forms walk parent._children; :nth-child(...) supports both keyword (`odd`/`even`) and `An+B` formula syntax; :not(<simple>) recursively dispatches to _matchesSelector. Stylesheet `_applyTo` strips the pseudo before structural matching so the existing :hover/:focus/:active wire-up path keeps firing on style application (the live state evaluation happens via the event listener). Out of scope: `:has()`, `:is()`, `:where()`, attribute namespaces \u2014 these need the full CSS Selectors Level 4 cascade engine (arch-no-cascade-engine per CLAUDE.md; use @pulp/react components for state-dependent styling that goes beyond what's wired here).",
+      "issue": ""
+    },
+    "html/footer": {
+      "status": "supported",
+      "mapsTo": "createCol \u2014 same as div.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/h1": {
+      "status": "supported",
+      "mapsTo": "createLabel + setFontSize(32) + setFontWeight(700).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Heading levels h1-h6 each map to a Label with default size + weight.",
+      "issue": ""
+    },
+    "html/h2": {
+      "status": "supported",
+      "mapsTo": "createLabel + setFontSize(24) + setFontWeight(700).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/h3": {
+      "status": "supported",
+      "mapsTo": "createLabel + setFontSize(20) + setFontWeight(600).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/h4": {
+      "status": "supported",
+      "mapsTo": "createLabel + setFontSize(16) + setFontWeight(600).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/h5": {
+      "status": "supported",
+      "mapsTo": "createLabel + setFontSize(14) + setFontWeight(600).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/h6": {
+      "status": "supported",
+      "mapsTo": "createLabel + setFontSize(12) + setFontWeight(600).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/header": {
+      "status": "supported",
+      "mapsTo": "createCol \u2014 same as div.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/hr": {
+      "status": "supported",
+      "mapsTo": "createCol + setFlex(height=1) + setBackground('#666').",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Visual divider.",
+      "issue": ""
+    },
+    "html/img": {
+      "status": "supported",
+      "mapsTo": "createImage(id, parent) -> ImageView; setAttribute('src', ...) -> setImageSource(id, src) -> ImageView::set_image_path; ImageView::paint decodes via canvas.draw_image_from_file (Skia: SkData::MakeFromFileName + SkImages::DeferredFromEncodedData via SkCodec). <img width/height> attributes honored via __replayMediaAttributes__ (PR #1347).",
+      "supportedValues": [
+        "src as filesystem path (decoded via Skia SkCodec)",
+        "src as file:// URL (path stripped before decode)",
+        "width/height HTML attributes for layout",
+        "placeholder shown when src is empty or decode fails"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_image_view_cache.cpp"
+      ],
+      "notes": "Wired via pulp #1658: <img> creates an ImageView (was: createLabel placeholder), src attribute routes through setImageSource to ImageView::set_image_path, and ImageView::paint calls canvas.draw_image_from_file which Skia implements via SkImages::DeferredFromEncodedData (SkCodec under the hood). Both _ensureNative and the React/JSX setAttribute-before-mount path replay src through __replayMediaAttributes__. data: URLs and http(s) fetch are deferred follow-ups (file:// + bare paths cover the common static-asset case).",
+      "issue": ""
+    },
+    "html/input": {
+      "status": "supported",
+      "mapsTo": "createTextEditor by default; createFader for type=range, createCheckbox for type=checkbox. Other `type=` values fall through to text-editor \u2014 a deliberate design choice that matches how the same DOM element is rendered in environments without specialized native widgets (the value-bearing semantics are uniform, only the chrome differs).",
+      "supportedValues": [
+        "type=text / type=password / type=email / type=number / type=range / type=checkbox",
+        "type=date / type=time / type=datetime-local / type=month / type=week (fall through to text-editor \u2014 value typed as ISO-8601 string)",
+        "type=file / type=color (fall through to text-editor \u2014 placeholder; native pickers are a roadmap item)",
+        "type=url / type=search (fall through to text-editor)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "DIVERGE\u2192PASS sweep \u2014 fall-through to text-editor is the SUPPORTED behavior for these input types in Pulp's render surface; the catalog previously listed them as gaps but they accept input correctly (the value is just a string typed by the user). Specialized chrome \u2014 date pickers, color wheels, file pickers \u2014 remains a roadmap item; that's a separate UX concern from compat. Wave 1 drift cleanup \u2014 partial \u2192 supported (wired through _ensureNative -> bridge createTextEditor / createFader / createCheckbox).",
+      "issue": ""
+    },
+    "html/label": {
+      "status": "supported",
+      "mapsTo": "createLabel + lazy `_installLabelForRouting` in web-compat-element.js \u2014 clicking the label inspects the `for` attribute and, if it matches an Element id, routes activation to that target (focus via setFocus when wired; checkbox/radio toggle plus dispatched 'input' event always).",
+      "supportedValues": [
+        "createLabel rendering",
+        "for attribute \u2192 click activation routing (toggle on checkbox/radio; setFocus when bridge fn available)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"<label for=...> click toggles labeled checkbox\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "DIVERGE\u2192PASS sweep \u2014 `for` attribute click-routing wired in JS. Full focus-pull (currently bridge has no setFocus) remains a roadmap follow-up; the harness gap was about the wired vs. silently-dropped distinction.",
+      "issue": ""
+    },
+    "html/main": {
+      "status": "supported",
+      "mapsTo": "createCol \u2014 same as div.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/nav": {
+      "status": "supported",
+      "mapsTo": "createCol \u2014 same as div.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/p": {
+      "status": "supported",
+      "mapsTo": "createLabel \u2014 same as span.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Confirmed 2026-05-04. Block-level CSS semantics not modeled (no margin defaults).",
+      "issue": ""
+    },
+    "html/progress": {
+      "status": "supported",
+      "mapsTo": "createProgress(id, parent).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/section": {
+      "status": "supported",
+      "mapsTo": "createCol \u2014 same as div.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/select": {
+      "status": "supported",
+      "mapsTo": "createCombo(id, parent).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "html/span": {
+      "status": "supported",
+      "mapsTo": "createLabel(id, '', parent). Confirmed 2026-05-04: <span> maps to Label widget (not View). Same for <p>, <label>.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Confirmed in web-compat-element.js _ensureNative.",
+      "issue": ""
+    },
+    "html/style": {
+      "status": "supported",
+      "mapsTo": "Element('style')._ensureNative -> createCol + setVisible(false). textContent is routed through _processStyleElement (web-compat-document.js) which parses CSS rules incl. :hover and Wave 3 selector extensions ([attr] / descendant / child). Shares the StyleSheet_inline pipeline.",
+      "supportedValues": [
+        "inline <style> with class/id/element selectors",
+        ":hover pseudo-class",
+        "[attr] selectors + descendant / child combinators (Wave 3 PR #1641)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "PR #1345 / pulp #1149 part b added :hover; PR #1641 (Wave 3 html.3) extended selector engine. Wave 1 architectural reclassification \u2014 @media / @keyframes / complex selectors are arch-no-cascade-engine (Pulp's inline <style> parser is single-pass; the cascade engine is an explicit non-goal). Wave 4 cleanup \u2014 status partial \u2192 supported + emptied unsupportedValues so the harness reflects the wired surface; rides the StyleSheet_inline catalog claim.",
+      "issue": "1149"
+    },
+    "html/svg": {
+      "status": "supported",
+      "mapsTo": "createCol(id, parent) (PR #1347 confirmed). HTML width/height attributes reserve flex layout space. The supported surface is the layout-leaf shim; rendered SVG paths route through the @pulp/react SvgPath intrinsic (which is the canonical primitive).",
+      "supportedValues": [
+        "<svg> layout-leaf placeholder with width/height HTML attrs",
+        "createCol bridge wiring + width/height attribute replay (PR #1347)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "PR #1347 (pulp #1147): <svg> is a leaf container that reserves layout space. For rendered SVG paths use the @pulp/react SvgPath intrinsic. Wave 1 architectural reclassification \u2014 full SVG rasterization of children is arch-explicit-non-goal (createCol shim reserves layout space; @pulp/react SvgPath intrinsic is the canonical rendered-path API \u2014 the layout-shim surface IS the supported surface). Wave 4 cleanup \u2014 status partial \u2192 supported + emptied unsupportedValues; child path/rect/circle/text rasterization is arch-non-goal, not a partial-deferred gap.",
+      "issue": "1147"
+    },
+    "html/textarea": {
+      "status": "supported",
+      "mapsTo": "createTextEditor + setMultiLine(1).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    }
+  }
+}

--- a/compat/imports.json
+++ b/compat/imports.json
@@ -1,0 +1,97 @@
+{
+  "imports": {
+    "_note": "The 'imports' prefix tracks design-import format detection (see core/dsl/import-design / tools/cli/src/import_design.cpp / docs/reference/imports/*). Each top-level key is a recognized import source (claude, figma, pencil, stitch, v0); each entry carries 'parser-version' (the Pulp-side detector version) and 'detected-formats' (a list of {format-version, introduced, deprecated, fingerprint, notes} objects). The `fingerprint` field is the heuristic the parser uses to recognize the source format from a directory or file payload. When a new import source lands or an existing source's export format changes, add a detected-formats entry rather than mutating an existing one (so historical exports keep parsing). Tracked via PR #1047 (pulp #1031) for versioned import-design detection.",
+    "claude": {
+      "parser-version": "2.1",
+      "detected-formats": [
+        {
+          "format-version": "2024.10",
+          "introduced": "2024-10-01",
+          "deprecated": null,
+          "fingerprint": [
+            {
+              "kind": "html-script-type",
+              "value": "__bundler/template"
+            }
+          ],
+          "notes": "Anthropic Labs Claude Design \u2014 manually-exported standalone HTML. Detect via the inline bundler script tag inserted by the Claude Design export. Loader-shell HTML wraps the bundled React app; the static parser sees ~9 elements until the bundle is executed."
+        }
+      ]
+    },
+    "designmd": {
+      "parser-version": "0.1",
+      "detected-formats": [
+        {
+          "format-version": "alpha",
+          "introduced": "2026-05-13",
+          "deprecated": null,
+          "match": "all-of",
+          "min-confidence-pct": 95,
+          "fingerprint": [
+            {
+              "kind": "filename",
+              "regex": "(?i)^DESIGN\\.md$"
+            },
+            {
+              "kind": "frontmatter-fence",
+              "value": "---"
+            },
+            {
+              "kind": "frontmatter-key",
+              "required": "name"
+            },
+            {
+              "kind": "frontmatter-key",
+              "any-of": ["colors", "typography", "rounded", "spacing", "components"]
+            }
+          ],
+          "notes": "Google's DESIGN.md (Apache-2.0, https://github.com/google-labs-code/design.md). Upstream pin: tag 0.1.1. YAML frontmatter + Markdown body. Strict detection: filename + frontmatter fence + name: key + at least one canonical token-group key. The all-of match plus 95% confidence floor avoids false positives on generic Jekyll/Hugo Markdown frontmatter."
+        }
+      ]
+    },
+    "figma": {
+      "parser-version": "0.1",
+      "detected-formats": []
+    },
+    "pencil": {
+      "parser-version": "0.1",
+      "detected-formats": []
+    },
+    "stitch": {
+      "parser-version": "1.0",
+      "detected-formats": [
+        {
+          "format-version": "2025.04",
+          "introduced": "2025-04-15",
+          "deprecated": null,
+          "fingerprint": [
+            {
+              "kind": "directory-files",
+              "files": [
+                "code.html",
+                "DESIGN.md",
+                "screen.png"
+              ]
+            },
+            {
+              "kind": "html-script-src",
+              "regex": "cdn\\.tailwindcss\\.com\\?plugins=forms,container-queries"
+            },
+            {
+              "kind": "tailwind-config-token",
+              "any-of": [
+                "surface-container",
+                "on-primary"
+              ]
+            }
+          ],
+          "notes": "Material 3 token vocab. Stitch ZIP / directory exports include code.html, DESIGN.md, screen.png at the top level. Tailwind CDN configured with the forms + container-queries plugins is the strongest single signal."
+        }
+      ]
+    },
+    "v0": {
+      "parser-version": "0.1",
+      "detected-formats": []
+    }
+  }
+}

--- a/compat/rn.json
+++ b/compat/rn.json
@@ -1,0 +1,1970 @@
+{
+  "rn": {
+    "rn/alignContent": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setFlex(id, 'align_content', value) -> FlexStyle.align_content + align_content_space -> YGNodeStyleSetAlignContent",
+      "supportedValues": [
+        "flex-start",
+        "start",
+        "flex-end",
+        "end",
+        "center",
+        "stretch",
+        "space-between",
+        "space-around",
+        "space-evenly"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 (sub-agent #12 follow-up): @pulp/react FlexProps now exposes alignContent (FlexAlignContent type); prop-applier forwards verbatim to the bridge's new setFlex 'align_content' case. Yoga's YGNodeStyleSetAlignContent supports all RN values natively.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1434"
+    },
+    "rn/alignItems": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setFlex(id, 'align_items', value)",
+      "supportedValues": [
+        "flex-start",
+        "start",
+        "flex-end",
+        "end",
+        "center",
+        "stretch",
+        "baseline"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Pulp's FlexAlign type takes short forms only ({start, center, end, stretch}). RN documentation uses 'flex-start'/'flex-end' which prop-applier passes through verbatim -- these would not match the C++ enum names. Style decl converts 'flex-start'->'start' but @pulp/react does not. pulp #1434 rn batch B: bridge now accepts flex-start/flex-end/baseline; @pulp/react prop-applier passes through verbatim.",
+      "issue": ""
+    },
+    "rn/alignSelf": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setFlex(id, 'align_self', value)",
+      "supportedValues": [
+        "auto",
+        "flex-start",
+        "start",
+        "flex-end",
+        "end",
+        "center",
+        "stretch",
+        "baseline"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Same long-form/short-form mismatch as alignItems. pulp #1434 rn batch B: same alias support as alignItems.",
+      "issue": ""
+    },
+    "rn/aspectRatio": {
+      "status": "supported",
+      "mapsTo": "@pulp/react FlexProps.aspectRatio -> setFlex(id, 'aspect_ratio', value) -> FlexStyle.aspect_ratio -> YGNodeStyleSetAspectRatio",
+      "supportedValues": [
+        "number"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-aspect-ratio.test.ts",
+        "test/web-compat/test_layout_aspect_ratio.cpp"
+      ],
+      "notes": "pulp #1434 \u2014 JSX surface accepts numeric aspectRatio (RN parity per oracle 'kind: number'). String forms ('16/9', 'auto') reach FlexStyle through the CSS shim path (web-compat-style-decl.js), not the @pulp/react TS surface.",
+      "issue": "1434"
+    },
+    "rn/backfaceVisibility": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier forwards keyword to setBackfaceVisibility (widget_bridge.cpp:2133).",
+      "supportedValues": [
+        "visible",
+        "hidden"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-wires.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn bridge-wires bundle (sub-agent #27 finding) \u2014 bridge fn was registered in widget_bridge.cpp; @pulp/react prop-applier dispatch wired in this PR.",
+      "issue": ""
+    },
+    "rn/backgroundColor": {
+      "status": "supported",
+      "mapsTo": "background prop -> setBackground",
+      "supportedValues": [
+        "#hex",
+        "#rgba",
+        "rgb()",
+        "rgba()",
+        "hsl()",
+        "hsla()",
+        "oklch()",
+        "oklab()",
+        "lch()",
+        "lab()",
+        "color(srgb|srgb-linear|display-p3)",
+        "transparent",
+        "named colors"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
+      "issue": ""
+    },
+    "rn/borderBottomColor": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches `borderBottomColor` to `setBorderBottomColor(id, color)` (prop-applier.ts:310-313 since #1396).",
+      "supportedValues": [
+        "#hex",
+        "#rgba",
+        "rgb()",
+        "rgba()",
+        "hsl()",
+        "hsla()",
+        "oklch()",
+        "oklab()",
+        "lch()",
+        "lab()",
+        "color(srgb|srgb-linear|display-p3)",
+        "transparent",
+        "named colors"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
+      "issue": ""
+    },
+    "rn/borderBottomLeftRadius": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches `borderBottomLeftRadius` to `setBorderBottomLeftRadius(id, n)` (prop-applier.ts:318-321 since #1396).",
+      "supportedValues": [
+        "number (px)",
+        "% (resolved at paint time as pct * 0.01 * min(width, height))"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-wave2.test.ts",
+        "test/test_widget_bridge.cpp [issue-1663][borderradius-pct]"
+      ],
+      "notes": "Same. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues. pulp #1663 wired %: bridge accepts \"NN%\" string, View stores in corner_radius_pct_ slot, paint-time effective_corner_radius() resolves against current bounds. Test backing at [view][bridge][rn][issue-1663][borderradius-pct].",
+      "issue": ""
+    },
+    "rn/borderBottomRightRadius": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches `borderBottomRightRadius` to `setBorderBottomRightRadius(id, n)` (prop-applier.ts:318-321 since #1396).",
+      "supportedValues": [
+        "number (px)",
+        "% (resolved at paint time as pct * 0.01 * min(width, height))"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-wave2.test.ts",
+        "test/test_widget_bridge.cpp [issue-1663][borderradius-pct]"
+      ],
+      "notes": "Same. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues. pulp #1663 wired %: bridge accepts \"NN%\" string, View stores in corner_radius_pct_ slot, paint-time effective_corner_radius() resolves against current bounds. Test backing at [view][bridge][rn][issue-1663][borderradius-pct].",
+      "issue": ""
+    },
+    "rn/borderBottomWidth": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches `borderBottomWidth` to `setBorderBottomWidth(id, n)` (prop-applier.ts:314-317 since #1396).",
+      "supportedValues": [
+        "number (px)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "RN prop is flat top-level, Pulp uses object shape. Convert: <View style={{borderBottomWidth: 2}} /> -> <View borderBottom={{color:'#000', width:2}} />. Awkward for RN ports. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only \u2014 em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
+      "issue": ""
+    },
+    "rn/borderColor": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches `borderColor` to `setBorderColor(id, ...)` (prop-applier.ts:300-302).",
+      "supportedValues": [
+        "#hex",
+        "#rgba",
+        "rgb()",
+        "rgba()",
+        "hsl()",
+        "hsla()",
+        "oklch()",
+        "oklab()",
+        "lch()",
+        "lab()",
+        "color(srgb|srgb-linear|display-p3)",
+        "transparent",
+        "named colors"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
+      "issue": ""
+    },
+    "rn/borderCurve": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setBorderCurve(id, kw) -> View::set_border_curve(BorderCurve::continuous|circular). View::paint_all dispatches between build_per_corner_rounded_rect_path (circular \u2014 standard kappa 0.5522 quarter-circle bezier) and build_continuous_corner_rounded_rect_path (continuous \u2014 extension 1.528, flatter kappa 0.85 producing the iOS-style squircle approximation).",
+      "supportedValues": [
+        "circular",
+        "continuous"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "unit:test_widget_bridge#issue-1737"
+      ],
+      "notes": "pulp #1737 RN-OOS-fixup #1812: walked back from wontfix to supported. `circular` (default) uses Pulp's standard quarter-circle bezier rounded corner \u2014 bit-identical to pre-PR behavior. `continuous` switches to a super-ellipse path approximation that extends each corner curve to ~1.528R from the vertex with a flatter cubic profile (kappa 0.85 vs 0.5522 for circular). This is a single-cubic approximation of Apple's continuousCornerShape \u2014 Figma uses similar math for its \"smooth corners\" feature. Result is visually a recognizable iOS squircle on large-radius cards (24px+); subtle vs circular below 12px. Pixel-perfect Apple replication would need a multi-cubic path (or a quintic polynomial); the catalog claim is \"Apple-style continuous corner approximation\" not \"bit-identical to native iOS renderer\". When R approaches half-axis, the clamp tightens to half-axis/extension to prevent path self-intersection from the elongated curve.",
+      "issue": ""
+    },
+    "rn/borderEndWidth": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier \u2014 End \u2192 Right under LTR; routes to setBorderRightWidth.",
+      "supportedValues": [
+        "number (px)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "issue": ""
+    },
+    "rn/borderLeftColor": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches `borderLeftColor` to `setBorderLeftColor(id, color)` (prop-applier.ts:310-313 since #1396).",
+      "supportedValues": [
+        "#hex",
+        "#rgba",
+        "rgb()",
+        "rgba()",
+        "hsl()",
+        "hsla()",
+        "oklch()",
+        "oklab()",
+        "lch()",
+        "lab()",
+        "color(srgb|srgb-linear|display-p3)",
+        "transparent",
+        "named colors"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
+      "issue": ""
+    },
+    "rn/borderLeftWidth": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches `borderLeftWidth` to `setBorderLeftWidth(id, n)` (prop-applier.ts:314-317 since #1396).",
+      "supportedValues": [
+        "number (px)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Same as borderBottomWidth. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only \u2014 em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
+      "issue": ""
+    },
+    "rn/borderRadius": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches `borderRadius` to `setBorderRadius(id, ...)` (prop-applier.ts:300-302).",
+      "supportedValues": [
+        "number (px)",
+        "% (resolved at paint time as pct * 0.01 * min(width, height))"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-wave2.test.ts",
+        "test/test_widget_bridge.cpp [issue-1663][borderradius-pct]"
+      ],
+      "notes": "Workaround: <View border={{color:'transparent', width:0, radius:R}} />. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full elliptical rrect rendering is a deferred paint-side gap). pulp #1663 wired %: bridge accepts \"NN%\" string, View stores in corner_radius_pct_ slot, paint-time effective_corner_radius() resolves against current bounds. Test backing at [view][bridge][rn][issue-1663][borderradius-pct].",
+      "issue": ""
+    },
+    "rn/borderRightColor": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches `borderRightColor` to `setBorderRightColor(id, color)` (prop-applier.ts:310-313 since #1396).",
+      "supportedValues": [
+        "#hex",
+        "#rgba",
+        "rgb()",
+        "rgba()",
+        "hsl()",
+        "hsla()",
+        "oklch()",
+        "oklab()",
+        "lch()",
+        "lab()",
+        "color(srgb|srgb-linear|display-p3)",
+        "transparent",
+        "named colors"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
+      "issue": ""
+    },
+    "rn/borderRightWidth": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches `borderRightWidth` to `setBorderRightWidth(id, n)` (prop-applier.ts:314-317 since #1396).",
+      "supportedValues": [
+        "number (px)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Same. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only \u2014 em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
+      "issue": ""
+    },
+    "rn/borderStartWidth": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier \u2014 Start \u2192 Left under LTR; routes to setBorderLeftWidth.",
+      "supportedValues": [
+        "number (px)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "issue": ""
+    },
+    "rn/borderStyle": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches borderStyle to setBorderStyle. Bridge + Skia path same as css/borderStyle.",
+      "supportedValues": [
+        "solid",
+        "dashed",
+        "dotted",
+        "none",
+        "hidden",
+        "double (degrades to solid)",
+        "groove (degrades to solid)",
+        "ridge (degrades to solid)",
+        "inset (degrades to solid)",
+        "outset (degrades to solid)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-border-style.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Triage #10 \u2014 Skia paint installs SkDashPathEffect for dashed/dotted (CG falls through to solid via the canvas-base no-op set_line_dash). View::BorderStyle enum stores the keyword; bridge maps strings; Skia honors at stroke time. Other named styles (double/groove/ridge/inset/outset) currently degrade to solid \u2014 paint-side compositions are a follow-up. none/hidden short-circuit the stroke entirely.",
+      "issue": ""
+    },
+    "rn/borderTopColor": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches `borderTopColor` to `setBorderTopColor(id, color)` (prop-applier.ts:310-313 since #1396).",
+      "supportedValues": [
+        "#hex",
+        "#rgba",
+        "rgb()",
+        "rgba()",
+        "hsl()",
+        "hsla()",
+        "oklch()",
+        "oklab()",
+        "lch()",
+        "lab()",
+        "color(srgb|srgb-linear|display-p3)",
+        "transparent",
+        "named colors"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
+      "issue": ""
+    },
+    "rn/borderTopLeftRadius": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches `borderTopLeftRadius` to `setBorderTopLeftRadius(id, n)` (prop-applier.ts:318-321 since #1396).",
+      "supportedValues": [
+        "number (px)",
+        "% (resolved at paint time as pct * 0.01 * min(width, height))"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-wave2.test.ts",
+        "test/test_widget_bridge.cpp [issue-1663][borderradius-pct]"
+      ],
+      "notes": "Bridge has setBorderTopLeftRadius -- needs prop wiring. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues. pulp #1663 wired %: bridge accepts \"NN%\" string, View stores in corner_radius_pct_ slot, paint-time effective_corner_radius() resolves against current bounds. Test backing at [view][bridge][rn][issue-1663][borderradius-pct].",
+      "issue": ""
+    },
+    "rn/borderTopRightRadius": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches `borderTopRightRadius` to `setBorderTopRightRadius(id, n)` (prop-applier.ts:318-321 since #1396).",
+      "supportedValues": [
+        "number (px)",
+        "% (resolved at paint time as pct * 0.01 * min(width, height))"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-wave2.test.ts",
+        "test/test_widget_bridge.cpp [issue-1663][borderradius-pct]"
+      ],
+      "notes": "Same. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues. pulp #1663 wired %: bridge accepts \"NN%\" string, View stores in corner_radius_pct_ slot, paint-time effective_corner_radius() resolves against current bounds. Test backing at [view][bridge][rn][issue-1663][borderradius-pct].",
+      "issue": ""
+    },
+    "rn/borderTopWidth": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches `borderTopWidth` to `setBorderTopWidth(id, n)` (prop-applier.ts:314-317 since #1396).",
+      "supportedValues": [
+        "number (px)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Same as borderBottomWidth. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only \u2014 em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
+      "issue": ""
+    },
+    "rn/borderWidth": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches `borderWidth` to `setBorderWidth(id, ...)` (prop-applier.ts:300-302).",
+      "supportedValues": [
+        "number (px)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "User can call <View border={{color:'#000', width:N}} /> as workaround. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only \u2014 em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
+      "issue": ""
+    },
+    "rn/bottom": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setBottom(id, n | 'NN%')",
+      "supportedValues": [
+        "number",
+        "string '%'"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 batch 6: percent strings flow through prop-applier verbatim; the bridge routes them to YGNodeStyleSetPositionPercent via View::top_unit_/etc.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1434"
+    },
+    "rn/boxShadow": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches `boxShadow` (string OR object OR BoxShadowValue[] array) to clearBoxShadow + setBoxShadow per shadow (prop-applier.ts:865-915). String parser mirrors web-compat-style-decl.js.",
+      "supportedValues": [
+        "'none' (clears)",
+        "CSS-spec single-shadow string: [inset] <dx>px <dy>px <blur>px [<spread>px] <color>",
+        "multi-shadow comma-separated string (one setBoxShadow dispatch per parsed shadow; paren-depth-aware split)",
+        "object form { offsetX, offsetY, blur?, spread?, color, inset? }",
+        "BoxShadowValue array (RN Fabric: [{offsetX,offsetY,color,blurRadius?,spreadDistance?,inset?}])"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-wave2.test.ts",
+        "packages/pulp-react/test/prop-applier-box-shadow.test.ts",
+        "packages/pulp-react/test/prop-applier-wave4.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "All forms wired: 'none' (clears), CSS string (single + multi-shadow paren-aware split), object form { offsetX, offsetY, blur?, spread?, color, inset? }, AND RN Fabric BoxShadowValue[] array form (prop-applier.ts:877-894 \u2014 clears first, dispatches one setBoxShadow per shadow with blurRadius/spreadDistance preferred over blur/spread). All 4 forms tested in prop-applier-wave4.test.ts. Closes pulp #1664 \u2014 catalog was stale citing array form as gap when it was actually wired by Wave 4 #1651.",
+      "issue": ""
+    },
+    "rn/boxSizing": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setBoxSizing(id, 'border-box'|'content-box') -> FlexProps.box_sizing -> Yoga YGNodeStyleSetBoxSizing",
+      "supportedValues": [
+        "border-box",
+        "content-box"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-not-impl-bundle1.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1545 landed setBoxSizing on the bridge + Yoga 3.x YGNodeStyleSetBoxSizing wiring; the @pulp/react prop-applier dispatches verbatim. Default is content-box (Yoga's historical model); border-box matches the CSS reset most web designs ship with.",
+      "issue": "1545"
+    },
+    "rn/color": {
+      "status": "supported",
+      "mapsTo": "textColor prop -> setTextColor",
+      "supportedValues": [
+        "#hex",
+        "#rgba",
+        "rgb()",
+        "rgba()",
+        "hsl()",
+        "hsla()",
+        "oklch()",
+        "oklab()",
+        "lch()",
+        "lab()",
+        "color(srgb|srgb-linear|display-p3)",
+        "transparent",
+        "named colors"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Triage #8 \u2014 modern CSS color spaces (oklch, oklab, lch, lab, color() with srgb/srgb-linear/display-p3) now wired through parseCSSColor (css-parser.js). Spike-quality: converts to sRGB hex at parse time; deep wide-gamut path (Skia SkColor4f) is a follow-up.",
+      "issue": ""
+    },
+    "rn/columnGap": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'column_gap', n)",
+      "supportedValues": [
+        "number"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "rn/cursor": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier forwards keyword to setCursor (prop-applier.ts:749 \u2192 widget_bridge.cpp:4007); bridge maps CSS keywords onto View::CursorStyle slots.",
+      "supportedValues": [
+        "default",
+        "pointer",
+        "crosshair",
+        "text",
+        "vertical-text",
+        "grab",
+        "grabbing",
+        "not-allowed",
+        "no-drop",
+        "none",
+        "hidden",
+        "col-resize",
+        "row-resize",
+        "ew-resize",
+        "ns-resize",
+        "nwse-resize",
+        "nesw-resize",
+        "n-resize",
+        "s-resize",
+        "e-resize",
+        "w-resize",
+        "nw-resize",
+        "ne-resize",
+        "sw-resize",
+        "se-resize",
+        "move",
+        "all-scroll",
+        "auto"
+      ],
+      "unsupportedValues": [
+        "wait",
+        "help",
+        "progress",
+        "cell"
+      ],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-wires.test.ts",
+        "packages/pulp-react/test/prop-applier-wave2.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1550 catalog hygiene: flipped partial \u2192 supported. Triage #7 fan-out (#1434 small-wins bundle) wired the CSS cursor keyword set onto View::CursorStyle. RN's spec ViewStyle accepts only {auto, pointer}; Pulp accepts the full CSS cursor enum because the same prop-applier path serves both rn/cursor and css/cursor. Keywords without a dedicated visual (wait / help / progress / alias / copy / zoom-* / cell / context-menu) fall through to `default` \u2014 they're listed in unsupportedValues for catalog accuracy. Wave 1 drift cleanup \u2014 `auto` keyword falls back to default (View::CursorStyle::default_); arch-platform-cursor-set means we don't add a dedicated 'auto' slot. Wave 2 rn \u2014 added 'auto' regression coverage in the wave2 test bundle. 2026-05-12 macOS partial (pulp #1550): `alias` (NSCursor.dragLinkCursor), `copy` (NSCursor.dragCopyCursor), `zoom-in` / `zoom-out` (NSCursor.zoomInCursor / zoomOutCursor on macOS 10.15+ with defensive respondsToSelector), `context-menu` (NSCursor.contextualMenuCursor) now wire to real native cursors via View::CursorStyle slots and window_host_mac.mm dispatch. The remaining 4 (`wait`, `help`, `progress`, `cell`) have no native macOS cursor and stay catalog-unsupported \u2014 they fall through to default. Linux / Windows / web-platform-bridge implementations would add their own per-keyword mapping later.",
+      "issue": ""
+    },
+    "rn/d": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts: 'd' -> setSvgPath(id, value). Wired by SvgPath JSX intrinsic (pulp #994 / PR #1291).",
+      "supportedValues": [
+        "any SVG path-data string (e.g. 'M0,0 L10,10 Z')"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Only meaningful when the consumer renders <SvgPath> from @pulp/react. The bridge createSvgPath / setSvgPath / setSvgViewBox / setSvgFill / setSvgStroke / setSvgStrokeWidth surface lands on SvgPathWidget in core/view/.",
+      "issue": "994"
+    },
+    "rn/direction": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setDirection(id, value) -> View::set_direction (drives Yoga writing-direction + Skia paragraph text-direction at shape time)",
+      "supportedValues": [
+        "inherit",
+        "ltr",
+        "rtl",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-not-impl-bundle1.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1506 landed RTL bidi. The `direction` prop is value-disambiguated in @pulp/react: writing-direction keywords (ltr/rtl/inherit/auto) route to setDirection; flexDirection aliases ('row' / 'column' / 'row-reverse' / 'column-reverse') still fall through to setFlex(direction) for backward compat with older code. New code SHOULD use `writingDirection` (already wired) for clarity. Yoga honors writing direction for `flexDirection: 'row'` (visually reversed under rtl); Skia text-direction is consumed at shape time.",
+      "issue": "1506"
+    },
+    "rn/display": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches `display: 'flex'` to setVisible(true) and `display: 'none'` to setVisible(false) (pulp #1434 Triage #12, prop-applier.ts:323+).",
+      "supportedValues": [
+        "flex",
+        "none"
+      ],
+      "unsupportedValues": [
+        "contents"
+      ],
+      "tests": [
+        "test/test_widget_bridge.cpp [display-contents]",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "@pulp/react users opt out via the boolean `visible` prop. No 'contents' equivalent. pulp #1434 (Triage #12): the prop-applier now accepts display: flex / none, mirroring the yoga side wired in #1422. \"contents\" remains unsupported (Yoga has no equivalent). ARCH-DEFERRED: display: contents requires parallel block/inline-flow layout that CLAUDE.md's flex+grid-only policy (Yoga 3.0 ceiling) explicitly rules out \u2014 the dispatcher silently no-ops; pinned by test/test_widget_bridge.cpp [display-contents].",
+      "issue": ""
+    },
+    "rn/elevation": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setElevation(id, n) -> bridge translates the Material elevation value to a single-shadow approximation via View::set_box_shadow(0, max(1, n/2), n+1, 0, rgba(0,0,0, clamp(0.15+n*0.01, 0.15, 0.30))). Elevation 0 clears the shadow entirely.",
+      "supportedValues": [
+        "0..24 (Material Design dp scale)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "unit:test_widget_bridge#issue-1737"
+      ],
+      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11, final sweep): walked back from wontfix to supported. RN`s elevation prop is Android-only Material Design depth (0-24dp); upstream RN silently ignores it on iOS. Pulp shims it to a single-shadow approximation of Material`s dual-shadow spec so consumers shipping unchanged RN-Android styles render a visible shadow on every Pulp platform \u2014 a strict improvement over upstream RN`s iOS behavior. The catalog had already noted that Pulp uses boxShadow as the cross-platform equivalent; this PR adds the missing translation shim. Material`s exact spec uses umbra + penumbra dual shadows; Pulp`s BoxShadow is a single shadow, so the visual is recognizable Material but not pixel-identical to Android`s native renderer. Consumers needing exact dual-shadow rendering should use boxShadow directly (Pulp fully supports the CSS box-shadow syntax including multi-shadow lists).",
+      "issue": ""
+    },
+    "rn/end": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier \u2014 end \u2192 right under LTR; routes to setRight.",
+      "supportedValues": [
+        "number",
+        "percent string"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "issue": ""
+    },
+    "rn/experimental_backgroundImage": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setBackgroundGradient(id, value) (CSS gradient string only)",
+      "supportedValues": [
+        "linear-gradient(...)",
+        "radial-gradient(...)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-not-impl-bundle1.test.ts"
+      ],
+      "notes": "pulp #1434 (rn NOT-IMPL bundle 1): wired through to setBackgroundGradient so the same string format CSS consumers use is accepted from RN code. RN's New-Architecture-only array-of-objects gradient form is NOT supported (gradient strings only). url() raster images for background-image are also out of scope until SkImage lazy load lands. arch-rn-fabric-vendor-api \u2014 RN Fabric array-of-objects gradient API is a New Architecture vendor extension. Pulp's gradient surface is the standard `linearGradient`/`radialGradient` CSS-style API which works.",
+      "issue": ""
+    },
+    "rn/fill": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts: 'fill' -> setSvgFill(id, value) for CSS-color strings, OR setSvgFillGradient(id, css_linear_gradient_string) for gradient fills. SvgPathWidget stores either solid fill_color_ OR fill_gradient_ (the gradient slot wins when set). paint() parses the CSS linear-gradient string against local bounds and calls Canvas::set_fill_gradient_linear before fill_current_path; SkiaCanvas implements via SkGradientShader::MakeLinear.",
+      "supportedValues": [
+        "CSS color strings",
+        "url(#gradient) \u2014 when paired with a defining JSX <SvgLinearGradient> intrinsic OR a CSS linear-gradient(...) string forwarded directly via setSvgFillGradient"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "unit:test_svg_path_widget#issue-932",
+        "unit:test_svg_path_widget#issue-1737"
+      ],
+      "notes": "Only on @pulp/react SvgPath. Inline <svg> in DOM-lite still uses createCol (pulp #1147), which means CSS `fill` does NOT route to SVG fill \u2014 it falls into the unknown-prop default switch. pulp #932 (initial gradient slot deferred) + pulp #1737 PR-4 (this slice). SvgPathWidget gained a fill_gradient_ string slot + set_fill_gradient/clear_fill_gradient API. paint() parses the CSS linear-gradient at frame time against local bounds, builds endpoint coords + colors/positions arrays, and routes through Canvas::set_fill_gradient_linear (cross-backend \u2014 RecordingCanvas's default falls back to set_fill_color(stops[0]); SkiaCanvas implements via SkGradientShader::MakeLinear; CG falls back to its solid fill). New bridge fn setSvgFillGradient(id, css_value) accepts the linear-gradient string verbatim. JSX consumers (`<SvgLinearGradient id='g' stops={...}>` + `fill='url(#g)'`) work via the prop-applier resolving the JSX subtree's gradient defs into the CSS string before calling the bridge \u2014 direct C++ consumers can also call set_fill_gradient with a hand-built string. radial-gradient + url(file_path) image fills are followups (parser-only extension; no API change needed).",
+      "issue": "994"
+    },
+    "rn/filter": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier forwards CSS-string verbatim to setFilter (post sub-agent #27 wiring; widget_bridge.cpp parses the full function chain since this PR).",
+      "supportedValues": [
+        "blur(<px>)",
+        "brightness / contrast / grayscale / hue-rotate / invert / opacity / saturate / sepia (each with numeric or angle args)",
+        "drop-shadow(<dx> <dy> <blur> <color>)",
+        "chained functions in source order"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-wires.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Phase A2-4 \u2014 full CSS filter chain. setFilter parses the function-call sequence into View::FilterOp[]; view.cpp paint hands off to canvas.save_layer_with_filters; Skia composes via SkImageFilters::Compose + SkColorFilters::Matrix per filter. CG path falls back to blur-only collapse (no SkColorFilter equivalent yet). Full function set: blur / brightness / contrast / grayscale / hue-rotate / invert / opacity / saturate / sepia / drop-shadow.",
+      "issue": ""
+    },
+    "rn/flex": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts case 'flex': fans the numeric value out to setFlex(id, 'flex_grow', n) + setFlex(id, 'flex_shrink', 1) + setFlex(id, 'flex_basis', 0) for positive n; (0,0,'auto') for n=0; (0,1,'auto') for negative n. Matches RN's bare-number shorthand semantics.",
+      "supportedValues": [
+        "number"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-flex.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1518 closed the gap. Bare-number `flex={n}` is the canonical RN-flavored shorthand; `flex` as an object/string is not a thing in RN, so no further forms are needed. Underlying bridge wires were already stable (flex_grow / flex_shrink / flex_basis) \u2014 this is purely an adapter aliasing.",
+      "issue": "1518"
+    },
+    "rn/flexBasis": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'flex_basis', n)",
+      "supportedValues": [
+        "number (px)",
+        "string % (e.g. '40%')",
+        "'auto'"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1434-rn-batch-c]"
+      ],
+      "notes": "TS type is 'number' only. pulp #1434 rn batch C: bridge accepts number / \"NN%\" / \"auto\"; FlexStyle::dim_flex_basis.unit drives YGNodeStyleSetFlexBasis{,Percent,Auto}. Wave 1 architectural reclassification \u2014 `content` keyword is arch-yoga-limit (Yoga has no flex-basis content algorithm); status flipped partial \u2192 wontfix to match the actual ground-truth out-of-scope reason. number / percent / 'auto' all remain fully wired. Wave-5 follow-up audit (post-PR #1616 sweep): walked back wontfix\u2192partial. `wontfix` maps to OOS in the harness taxonomy and bypasses drift checking for the supported `number`/`%`/`auto` subset; partial preserves drift detection on the supported forms while keeping `content` listed as the real Yoga-architecture limit. arch-yoga-no-content-keyword \u2014 Yoga doesn't model the `content` keyword (it's a CSS Level 3 spec extension that maps to intrinsic-size resolution Yoga doesn't have). number, %, auto, and 0 are all supported.",
+      "issue": ""
+    },
+    "rn/flexDirection": {
+      "status": "supported",
+      "mapsTo": "prop-applier 'direction' -> setFlex(id, 'direction', value); but RN says 'row'|'row-reverse'|'column'|'column-reverse'",
+      "supportedValues": [
+        "row",
+        "column",
+        "row-reverse",
+        "column-reverse"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "ALSO MAJOR -- types.ts FlexDirection = 'row' | 'col'. Pulp uses 'col' instead of 'column' (RN convention) -- porting RN code requires renaming. And no reverse modes. pulp #1434 rn batch B: column added (RN canonical) alongside the legacy col shorthand; reverse modes route to Yoga.",
+      "issue": ""
+    },
+    "rn/flexGrow": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'flex_grow', n)",
+      "supportedValues": [
+        "number"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "rn/flexShrink": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'flex_shrink', n)",
+      "supportedValues": [
+        "number"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "rn/flexWrap": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier forwards string ('wrap' / 'wrap-reverse' / 'nowrap') verbatim to setFlex(flex_wrap, ...); legacy boolean still accepted (true \u2192 1, false \u2192 0).",
+      "supportedValues": [
+        "boolean (legacy)",
+        "nowrap",
+        "no-wrap",
+        "wrap",
+        "wrap-reverse"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-bundle.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Triage #14 \u2014 broadened flexWrap type to boolean | string (CSS keywords). RN spec accepts the same string vocabulary; routing same as css/flexWrap.",
+      "issue": ""
+    },
+    "rn/fontFamily": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts case 'fontFamily' -> setFontFamily(id, value). Bridge stores the CSS comma-separated list verbatim (Label::set_font_family or View::set_inheritable_font_family for cascade). pulp #1737 (#932 followup) \u2014 SkiaCanvas resolution walks the whole list at paint time: skia_canvas.cpp:get_cached_typeface splits on commas (split_font_family_list helper), strips outer quotes + whitespace, tries each family through the existing match cascade (registered \u2192 bundled \u2192 SkFontMgr matchFamilyStyle) until one resolves. Single-family inputs (no comma) still hit get_cached_typeface_single fast-path with identical pre-fix behavior.",
+      "supportedValues": [
+        "single family name (single-name fast path)",
+        "comma-separated CSS family list (e.g. `'SF Pro, system-ui, sans-serif'`) \u2014 walked in declaration order through the match cascade until a family resolves",
+        "quoted family names (e.g. `'\"My Font Name\"'`) \u2014 outer quotes stripped per CSS spec",
+        "extra whitespace tolerated between commas + around quoted names"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1434-fontfamily]",
+        "test/test_canvas.cpp [issue-1737] (comma-list fontFamily falls back through SkFontMgr; quotes + whitespace handling)"
+      ],
+      "notes": "pulp #1434 Phase A2-5 wired the @pulp/react JSX dispatch + bridge list parser. pulp #1737 (#932 followup) closed the whole-list fallback chain \u2014 SkiaCanvas resolves the comma-separated list at paint time via split_font_family_list + per-family matchFamilyStyle walk. Resolution accepts a family if SkFontMgr returns a typeface whose actual family name contains (or is contained by) the requested family \u2014 guards against SkFontMgr's null-fallback masking a missing family. Single-family inputs unchanged \u2014 fast-path delegates straight to get_cached_typeface_single.",
+      "issue": "1434"
+    },
+    "rn/fontSize": {
+      "status": "supported",
+      "mapsTo": "setFontSize",
+      "supportedValues": [
+        "number (px)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "rn/fontStyle": {
+      "status": "supported",
+      "mapsTo": "setFontStyle",
+      "supportedValues": [
+        "normal",
+        "italic"
+      ],
+      "unsupportedValues": [
+        "oblique"
+      ],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "rn/fontVariant": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setFontVariant(id, csv) -> View::set_font_variant -> Label::paint parses CSV -> Canvas::set_font_features({tnum|smcp|onum|lnum|pnum=1}) -> SkiaCanvas::shape_with_features -> SkShaper 8-arg shape() (font_runs/bidi/script/lang TrivialRunIterators) -> HarfBuzz GSUB/GPOS",
+      "supportedValues": [
+        "small-caps",
+        "oldstyle-nums",
+        "lining-nums",
+        "tabular-nums",
+        "proportional-nums"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-not-impl-bundle1.test.ts",
+        "unit:test_canvas#issue-1737"
+      ],
+      "notes": "pulp #1434 (rn NOT-IMPL bundle 1) + A4 Bundle 1 (#1611) landed the prop-applier + bridge fn + storage slot. pulp #1737 (this slice) wires the storage through Label::paint to Canvas::set_font_features and SkiaCanvas::shape_with_features (the 8-arg SkShaper::shape overload with TrivialFont/BiDi/Script/Language RunIterators) so HarfBuzz now honors the OpenType tags at shape time. tnum forces equal-advance digits via measure_text/fill_text; smcp/onum/lnum/pnum behave per CSS Fonts Module 4 \u00a77.3. Verified end-to-end via test_canvas \"set_font_features routes tnum through SkShaper\" (Inter '111' vs '999' advances converge under tnum, restore on clear_font_features). Fall-through: if SkShaper::Make() returns null on a host without text-shaping, the per-glyph builder runs without features (degraded but non-crashing).",
+      "issue": ""
+    },
+    "rn/fontWeight": {
+      "status": "supported",
+      "mapsTo": "setFontWeight (numeric)",
+      "supportedValues": [
+        "100..900",
+        "normal",
+        "bold",
+        "100",
+        "200",
+        "300",
+        "400",
+        "500",
+        "600",
+        "700",
+        "800",
+        "900",
+        "ultralight",
+        "thin",
+        "light",
+        "medium",
+        "regular",
+        "semibold",
+        "condensedBold",
+        "condensed",
+        "heavy",
+        "black"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-wave2.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Keyword aliasing not done in prop-applier. Wave 1 drift cleanup \u2014 populated supportedValues with the RN standard weight set (normal / bold / 100..900); wired through prop-applier 'fontWeight' case. Wave 2 rn \u2014 added regression coverage for numeric weights '100'..'900'.",
+      "issue": ""
+    },
+    "rn/gap": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'gap', n)",
+      "supportedValues": [
+        "number"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "rn/height": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'height', n) \u2014 number=px, '50%'=percent, 'auto'=hug-contents",
+      "supportedValues": [
+        "number (px)",
+        "string % (e.g. '50%')",
+        "string 'auto'"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1712][rn-height]"
+      ],
+      "notes": "pulp #1434 rn batch C wired number + %; pulp #1434 (sub-agent #12 follow-up) wired 'auto' end-to-end. TS type accepts `number | string`; prop-applier forwards verbatim; bridge dispatches via FlexStyle::dim_height.unit (px / percent / auto_) and yoga_layout.cpp routes to YGNodeStyleSetHeight{,Percent,Auto}. Wave 1 drift cleanup \u2014 supported \u2192 partial (`vh` string unit is a real deferred gap). arch-no-viewport \u2014 `vh`/`vw`/`vmin`/`vmax` units are deferred because Pulp has no global viewport context (Views can be embedded in plugin editors, standalone windows, or mobile screens with different sizing semantics; CSS viewport-unit semantics are undefined at the View level). Authors should use `%` units relative to the parent container instead. See pulp #1712.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1434"
+    },
+    "rn/includeFontPadding": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setIncludeFontPadding(id, bool) -> View::set_include_font_padding (storage-only slot). Pulp text-shaping pipeline uses tight baseline-relative positioning and does NOT add Android-vestigial vertical glyph padding regardless of this value \u2014 both keywords accepted, single consistent behavior produced (matches the `false` outcome that authors typically want).",
+      "supportedValues": [
+        true,
+        false
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "unit:test_widget_bridge#issue-1737"
+      ],
+      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11, final sweep): walked back from wontfix to supported. RN`s `includeFontPadding` is Android-only \u2014 Android TextView paints extra vertical padding around glyphs that this prop disables (`false`). Pulp`s text shaping (Skia/SkParagraph) uses tight baseline-relative positioning and never had Android`s vestigial padding to begin with, so the visible result matches the `false` intent that most authors want from this prop. Setting `true` is a silent no-op (Pulp can`t add padding it doesn`t model). Catalog claim is honest CSS-subset (same pattern as overscroll-behavior in PR #1805): all keywords round-trip; single consistent behavior produced; author intent for the common case (`false`) is met by default. Bridge fn stores the value on View::include_font_padding_ purely for round-trip reads (`el.style.includeFontPadding === false`).",
+      "issue": ""
+    },
+    "rn/inset": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier \u2014 CSS shorthand fan-out to top/right/bottom/left (1/2/3/4 token expansion).",
+      "supportedValues": [
+        "number",
+        "percent string",
+        "space-separated 2/3/4 token shorthand"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "issue": ""
+    },
+    "rn/insetBlock": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier \u2014 top + bottom fan-out.",
+      "supportedValues": [
+        "number",
+        "percent string"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "issue": ""
+    },
+    "rn/insetInline": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier \u2014 left + right fan-out under LTR.",
+      "supportedValues": [
+        "number",
+        "percent string"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "issue": ""
+    },
+    "rn/isolation": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setIsolation(id, kw) -> View::set_isolation slot. Mirrors css/isolation: Pulp's per-View paint model is structurally isolated by default (per-View save_layer_with_blend composition + paint-order-scoped z-index). RN authors get the `isolate` outcome regardless of the keyword set.",
+      "supportedValues": [
+        "auto",
+        "isolate"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "unit:test_widget_bridge#issue-1737"
+      ],
+      "notes": "pulp #1565 followup (initial wontfix) + pulp #1737 RN-OOS-fixup final round (this slice): walked back from wontfix to supported. Same architectural-by-default rationale as css/isolation \u2014 Pulp's per-View save_layer_with_blend model + paint-order-scoped z-index already produce the `isolate` outcome that RN authors want for blend-mode containment. Honest CSS-subset claim: both keywords round-trip; single consistent behavior produced.",
+      "issue": ""
+    },
+    "rn/justifyContent": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'justify_content', value)",
+      "supportedValues": [
+        "flex-start",
+        "start",
+        "flex-end",
+        "end",
+        "center",
+        "space-between",
+        "space-around",
+        "space-evenly"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Long-form RN names not auto-converted -- same trap as alignItems. pulp #1434 rn batch B: bridge accepts flex-start/flex-end CSS aliases via the same alias table.",
+      "issue": ""
+    },
+    "rn/left": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setLeft(id, n | 'NN%')",
+      "supportedValues": [
+        "number",
+        "string '%'"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 batch 6: percent strings flow through prop-applier verbatim; the bridge routes them to YGNodeStyleSetPositionPercent via View::top_unit_/etc.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1434"
+    },
+    "rn/letterSpacing": {
+      "status": "supported",
+      "mapsTo": "setLetterSpacing",
+      "supportedValues": [
+        "number"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "rn/lineHeight": {
+      "status": "supported",
+      "mapsTo": "setLineHeight",
+      "supportedValues": [
+        "number (px)",
+        "unitless multiplier"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-wave2.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 1 drift cleanup \u2014 supported \u2192 partial (unitless multiplier form is a real deferred gap; absolute-px works end-to-end). Wave 2 rn \u2014 unitless-multiplier semantics now resolved at dispatch time. Values <= 8 are treated as a multiplier of the live `fontSize` from props (default 14 if absent); larger values flow through as absolute pixels. Px-suffix strings strip the suffix and treat as absolute.",
+      "issue": ""
+    },
+    "rn/margin": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'margin', n)",
+      "supportedValues": [
+        "'auto' keyword",
+        "1-4 token shorthand string",
+        "number",
+        "percent string"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-wave2.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 1 drift cleanup \u2014 supported \u2192 partial (auto + string-form margins are real deferred gaps). Wave 2 rn \u2014 string margin shorthands (`'auto'`, `'5%'`, `'0 auto'`) now fan out to the per-edge bridge keys (which honor Yoga's YGNodeStyleSetMarginAuto for centering and the percent path).",
+      "issue": ""
+    },
+    "rn/marginBottom": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier passes number | string verbatim to setFlex(margin_*); bridge routes via dim_margin_*.unit. (cross-surface mega-batch)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"50%\")",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-edges.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
+      "issue": ""
+    },
+    "rn/marginEnd": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier \u2014 End \u2192 Right under LTR.",
+      "supportedValues": [
+        "number",
+        "percent string",
+        "\"auto\""
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "issue": ""
+    },
+    "rn/marginHorizontal": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts: marginHorizontal -> setFlex(margin_left) + setFlex(margin_right)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"5%\")",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "issue": ""
+    },
+    "rn/marginLeft": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier passes number | string verbatim to setFlex(margin_*); bridge routes via dim_margin_*.unit. (cross-surface mega-batch)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"50%\")",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-edges.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
+      "issue": ""
+    },
+    "rn/marginRight": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier passes number | string verbatim to setFlex(margin_*); bridge routes via dim_margin_*.unit. (cross-surface mega-batch)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"50%\")",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-edges.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
+      "issue": ""
+    },
+    "rn/marginStart": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier \u2014 Start \u2192 Left under LTR.",
+      "supportedValues": [
+        "number",
+        "percent string",
+        "\"auto\""
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "issue": ""
+    },
+    "rn/marginTop": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier passes number | string verbatim to setFlex(margin_*); bridge routes via dim_margin_*.unit. (cross-surface mega-batch)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"50%\")",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-edges.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
+      "issue": ""
+    },
+    "rn/marginVertical": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts: marginVertical -> setFlex(margin_top) + setFlex(margin_bottom)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"5%\")",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "issue": ""
+    },
+    "rn/maxHeight": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'max_height', n)",
+      "supportedValues": [
+        "number (px)",
+        "string % (e.g. '50%')"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_height.unit; yoga_layout.cpp routes to YGNodeStyleSetMaxHeightPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_height.unit \u2192 YGNodeStyleSetMaxHeightPercent.",
+      "issue": ""
+    },
+    "rn/maxWidth": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'max_width', n)",
+      "supportedValues": [
+        "number (px)",
+        "string % (e.g. '50%')"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_width.unit; yoga_layout.cpp routes to YGNodeStyleSetMaxWidthPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_width.unit \u2192 YGNodeStyleSetMaxWidthPercent.",
+      "issue": ""
+    },
+    "rn/minHeight": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'min_height', n)",
+      "supportedValues": [
+        "number (px)",
+        "string % (e.g. '50%')"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_height.unit; yoga_layout.cpp routes to YGNodeStyleSetMinHeightPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_height.unit \u2192 YGNodeStyleSetMinHeightPercent.",
+      "issue": ""
+    },
+    "rn/minWidth": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'min_width', n)",
+      "supportedValues": [
+        "number (px)",
+        "string % (e.g. '50%')"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_width.unit; yoga_layout.cpp routes to YGNodeStyleSetMinWidthPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_width.unit \u2192 YGNodeStyleSetMinWidthPercent.",
+      "issue": ""
+    },
+    "rn/mixBlendMode": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches mixBlendMode to setMixBlendMode (prop-applier.ts since pulp #1549). Bridge maps the W3C blend-mode keyword set to canvas::Canvas::BlendMode and writes to View::mix_blend_mode_; paint path forces a saveLayer via save_layer_with_blend so the subtree composites back through the requested mode. Tests: packages/pulp-react/test/prop-applier-mix-blend-mode.test.ts (JSX dispatch); test/test_widget_bridge.cpp::WidgetBridge setMixBlendMode keyword -> BlendMode mapping (bridge keyword table).",
+      "supportedValues": [
+        "normal",
+        "multiply",
+        "screen",
+        "overlay",
+        "darken",
+        "lighten",
+        "color-dodge",
+        "color-burn",
+        "hard-light",
+        "soft-light",
+        "difference",
+        "exclusion",
+        "hue",
+        "saturation",
+        "color",
+        "luminosity"
+      ],
+      "unsupportedValues": [
+        "plus-darker"
+      ],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wired through @pulp/react JSX (RN 0.76 New Architecture). Skia paint backend honors the keyword at saveLayer compositing time; CG / D2D backends fall through to plain save_layer (no-op blend) until those backends grow the same shim. 2026-05-12 closure: `plus-lighter` reclassified as supported (additive kPlus mapping is spec-correct); `plus-darker` stays unsupported \u2014 Pulp maps it to kPlus too (same as plus-lighter) but W3C draft defines plus-darker as MULTIPLICATIVE \u2014 widget_bridge.cpp:5473 maps both to canvas::Canvas::BlendMode::lighter (SkBlendMode::kPlus at the Skia layer, matching Chromium's mapping). Caveat: `plus-darker` is technically a multiplicative variant in the W3C draft but Skia/Chromium ship additive kPlus for both. Pinned by test.",
+      "issue": "1549"
+    },
+    "rn/opacity": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setOpacity(id, n)",
+      "supportedValues": [
+        "0..1 number"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "rn/outlineColor": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches outlineColor to setOutlineColor (prop-applier.ts since pulp #1519). Bridge writes to View::outline_color_.",
+      "supportedValues": [
+        "#hex",
+        "#rgba",
+        "rgb()",
+        "rgba()",
+        "named colors",
+        "currentColor (resolves to View::inheritable_text_color() with theme text fallback)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-outline.test.ts",
+        "test/test_widget_bridge.cpp [issue-1710][outline-currentcolor]"
+      ],
+      "notes": "pulp #1519 \u2014 RN outline cluster. Outline is paint-time only and does NOT affect Yoga layout (parent never reserves space). Skia paint inflates the box by (offset + width/2) and strokes with the parsed color. Wave 1 drift cleanup \u2014 supported \u2192 partial (currentColor keyword resolution deferred; CSS color strings round-trip). Wired in pulp #1710 \u2014 `currentColor` keyword resolves to the View's inheritable text color (walks parent chain via View::inheritable_text_color), falling back to theme `text.primary` token when no ancestor set the text color explicitly. Test [view][bridge][rn][issue-1710][outline-currentcolor] proves the resolution.",
+      "issue": ""
+    },
+    "rn/outlineOffset": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches outlineOffset to setOutlineOffset (prop-applier.ts since pulp #1519). Bridge writes to View::outline_offset_.",
+      "supportedValues": [
+        "number (px)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-outline.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1519 \u2014 gap between border-box edge and outline. Paint-only; no Yoga layout impact.",
+      "issue": ""
+    },
+    "rn/outlineStyle": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches outlineStyle to setOutlineStyle (prop-applier.ts since pulp #1519). Bridge maps the CSS keyword to View::BorderStyle (reused \u2014 CSS spec is identical for outline + border).",
+      "supportedValues": [
+        "solid",
+        "dashed",
+        "dotted",
+        "none",
+        "hidden",
+        "double (degrades to solid)",
+        "groove (degrades to solid)",
+        "ridge (degrades to solid)",
+        "inset (degrades to solid)",
+        "outset (degrades to solid)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-outline.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1519 \u2014 Skia installs SkDashPathEffect for dashed/dotted at outline-stroke time. Other named styles currently degrade to solid (paint-side gap, same as borderStyle). none/hidden/zero-width short-circuit the stroke.",
+      "issue": ""
+    },
+    "rn/outlineWidth": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches outlineWidth to setOutlineWidth (prop-applier.ts since pulp #1519). Bridge writes to View::outline_width_.",
+      "supportedValues": [
+        "number (px)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-outline.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1519 \u2014 outline stroke thickness. width<=0 short-circuits the paint. Paint-only; no Yoga layout impact.",
+      "issue": ""
+    },
+    "rn/overflow": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches `overflow` to `setOverflow(id, mode)` (prop-applier.ts:629 since #1388). Bridge accepts all 3 RN ViewStyle keywords (visible / hidden / scroll) at widget_bridge.cpp:3650-3663; `scroll` is recorded on View::Overflow::scroll and propagates through Yoga so the layout engine knows about the clipping context (no scrollbar layer yet \u2014 author wires a ScrollView intrinsic for true scrolling).",
+      "supportedValues": [
+        "visible",
+        "hidden",
+        "scroll"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-pointer.test.ts",
+        "test/test_widget_bridge.cpp [issue-1737][rn-overflow-scroll]"
+      ],
+      "notes": "pulp #1550 catalog hygiene: flipped partial \u2192 supported. pulp #1737 \u2014 keyword coverage reclassified to all 3 RN values to match the bridge implementation (widget_bridge.cpp:3650-3663) and the css/overflow precedent. `scroll` clips painted pixels like `hidden` but propagates through Yoga as a distinct overflow mode. Authors who need true scrollbars wire the ScrollView intrinsic; this mirrors React Native's split between style-level overflow and a dedicated ScrollView container.",
+      "issue": ""
+    },
+    "rn/overlay": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts: 'overlay' -> claimOverlay(id) / releaseOverlay(id) on flip. Bridge serializes onto a single View::active_overlay_ slot to fix React-popover click routing (pulp #1148, PRs #1297 + #1344).",
+      "supportedValues": [
+        "true",
+        "false"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Generalized overlay-click routing. The CSS-shim auto-claim heuristic (web-compat-style-decl.js _reevaluateOverlay) calls into the same bridge functions when position:absolute combines with z-index above a threshold (>= 10) OR the data-overlay='true' hint is set, so DOM-lite consumers don't need to rewire to the @pulp/react overlay prop.",
+      "issue": "1148"
+    },
+    "rn/padding": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'padding', n)",
+      "supportedValues": [
+        "1-4 token shorthand string",
+        "number",
+        "percent string"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-wave2.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Wave 1 drift cleanup \u2014 supported \u2192 partial (% form on padding edges is deferred). Wave 2 rn \u2014 string padding shorthands (`'5%'`, `'10px 20px'`, etc.) now fan out to the per-edge bridge keys (which already accept percent via Yoga's YGNodeStyleSetPaddingPercent). Numeric values still take the single-call shorthand path.",
+      "issue": ""
+    },
+    "rn/paddingBottom": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier passes number | string verbatim to setFlex(padding_*); bridge routes via dim_padding_*.unit.",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"50%\")"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-edges.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts number (px) or percent string. RN spec also lists `auto` for padding but it is inexpressible (Yoga has no padding-auto API).",
+      "issue": ""
+    },
+    "rn/paddingEnd": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier \u2014 End \u2192 Right under LTR.",
+      "supportedValues": [
+        "number",
+        "percent string"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "issue": ""
+    },
+    "rn/paddingHorizontal": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts: paddingHorizontal -> setFlex(padding_left) + setFlex(padding_right)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"5%\")"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "issue": ""
+    },
+    "rn/paddingLeft": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier passes number | string verbatim to setFlex(padding_*); bridge routes via dim_padding_*.unit.",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"50%\")"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-edges.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts number (px) or percent string. RN spec also lists `auto` for padding but it is inexpressible (Yoga has no padding-auto API).",
+      "issue": ""
+    },
+    "rn/paddingRight": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier passes number | string verbatim to setFlex(padding_*); bridge routes via dim_padding_*.unit.",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"50%\")"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-edges.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts number (px) or percent string. RN spec also lists `auto` for padding but it is inexpressible (Yoga has no padding-auto API).",
+      "issue": ""
+    },
+    "rn/paddingStart": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier \u2014 Start \u2192 Left under LTR.",
+      "supportedValues": [
+        "number",
+        "percent string"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "issue": ""
+    },
+    "rn/paddingTop": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier passes number | string verbatim to setFlex(padding_*); bridge routes via dim_padding_*.unit.",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"50%\")"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-edges.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 accepts number (px) or percent string. RN spec also lists `auto` for padding but it is inexpressible (Yoga has no padding-auto API).",
+      "issue": ""
+    },
+    "rn/paddingVertical": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts: paddingVertical -> setFlex(padding_top) + setFlex(padding_bottom)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"5%\")"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "issue": ""
+    },
+    "rn/pointerEvents": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier forwards keyword to setPointerEvents (widget_bridge.cpp:2107); bridge maps to View::PointerEvents enum.",
+      "supportedValues": [
+        "auto",
+        "none",
+        "box-only",
+        "box-none"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-wires.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn bridge-wires bundle (sub-agent #27 finding) \u2014 bridge fn was registered in widget_bridge.cpp; @pulp/react prop-applier dispatch wired in this PR.",
+      "issue": ""
+    },
+    "rn/position": {
+      "status": "supported",
+      "mapsTo": "setPosition(id, value)",
+      "supportedValues": [
+        "absolute",
+        "relative",
+        "static"
+      ],
+      "unsupportedValues": [
+        "fixed (RN omits)",
+        "sticky (RN omits)"
+      ],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "RN's enum is {absolute, relative, static}. Pulp accepts more (fixed, sticky) than RN.",
+      "issue": ""
+    },
+    "rn/right": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setRight(id, n | 'NN%')",
+      "supportedValues": [
+        "number",
+        "string '%'"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 batch 6: percent strings flow through prop-applier verbatim; the bridge routes them to YGNodeStyleSetPositionPercent via View::top_unit_/etc.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1434"
+    },
+    "rn/rowGap": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'row_gap', n)",
+      "supportedValues": [
+        "number"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "rn/shadowColor": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setShadowColor(id, color) -> View::set_box_shadow_color (widget_bridge.cpp). Mutates View::shadow_.color of the shared BoxShadow struct (mirrors the textShadow longhand pattern at widget_bridge.cpp:5368-5392).",
+      "supportedValues": [
+        "CSS color strings (#rgb / #rrggbb / rgb()/rgba() / named)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "unit:test_widget_bridge#issue-1737"
+      ],
+      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11): walked back from  to . The earlier wontfix cited \"iOS-only legacy; consumers on modern RN use boxShadow which pulp already supports\" \u2014 true but a 1-line shim makes the longhand work too (parallel to how text-shadow longhand was already wired). View::set_box_shadow_color mutates View::shadow_.color and activates has_shadow_; paint_all picks it up via the existing draw_box_shadow path. Bridge fn aliases hex colors through the same parseHexColor used by setSvgFill / setBackgroundColor / etc.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1546"
+    },
+    "rn/shadowOffset": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setShadowOffset(id, dx, dy) -> View::set_box_shadow_offset. Mutates View::shadow_.{offset_x, offset_y}.",
+      "supportedValues": [
+        "{ width: number, height: number }"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "unit:test_widget_bridge#issue-1737"
+      ],
+      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11): walked back from  to . RN spec uses  for offset; prop-applier destructures into (dx, dy) args before the bridge call (mirrors textShadowOffset). View::set_box_shadow_offset writes both offset fields and activates has_shadow_. Modern RN uses  shorthand; the longhand is here for legacy compat.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1546"
+    },
+    "rn/shadowOpacity": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setShadowOpacity(id, opacity) -> View::set_box_shadow_opacity. RN spec 0..1; Pulp Color stores alpha as 0..1 float so the value flows verbatim into View::shadow_.color.a.",
+      "supportedValues": [
+        "0..1 (RN spec range)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "unit:test_widget_bridge#issue-1737"
+      ],
+      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11): walked back from  to . RN spec: shadowOpacity is 0..1. View::set_box_shadow_opacity multiplies into the existing color alpha so an author can combine  +  and get half-opacity red. has_shadow_ flips on regardless so the shadow paints even if the author only set opacity without color.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1546"
+    },
+    "rn/shadowRadius": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setShadowRadius(id, radius_px) -> View::set_box_shadow_radius. Mutates View::shadow_.blur (Pulp uses CSS naming for the shadow-blur field).",
+      "supportedValues": [
+        "<length> in px"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "unit:test_widget_bridge#issue-1737"
+      ],
+      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11): walked back from  to . RN spec: shadowRadius is the blur radius in px (matches CSS box-shadow blur arg). View::shadow_.blur is the same field that boxShadow shorthand writes. Mutating it via setShadowRadius produces identical paint output to setBoxShadow with matching blur arg.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1546"
+    },
+    "rn/start": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier \u2014 start \u2192 left under LTR; routes to setLeft.",
+      "supportedValues": [
+        "number",
+        "percent string"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-logical-edges.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn logical-edge bundle (sub-agent #27 finding) \u2014 LTR-only fast path. @pulp/react prop-applier maps Start\u2192Left, End\u2192Right; inset shorthand fans out to top/right/bottom/left; insetBlock\u2192top+bottom; insetInline\u2192left+right. True RTL bidi requires a future direction system. RTL inheritance via setDirection \u2014 see #1506 (catalog flipped partial \u2192 supported, Wave 1 drift cleanup).",
+      "issue": ""
+    },
+    "rn/stroke": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts: 'stroke' -> setSvgStroke(id, value). Bridge accepts a CSS-color string.",
+      "supportedValues": [
+        "CSS color strings"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Only on @pulp/react SvgPath. See rn/fill caveat \u2014 no DOM-lite path-prop equivalent.",
+      "issue": "994"
+    },
+    "rn/strokeWidth": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts: 'strokeWidth' -> setSvgStrokeWidth(id, number).",
+      "supportedValues": [
+        "number (px)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Only on @pulp/react SvgPath.",
+      "issue": "994"
+    },
+    "rn/textAlign": {
+      "status": "supported",
+      "mapsTo": "setTextAlign",
+      "supportedValues": [
+        "left",
+        "center",
+        "right",
+        "auto",
+        "justify"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Triage #11: bridge accepts auto + justify; \"auto\" resolves to left under LTR (pulp doesn't model RTL yet); \"justify\" routes through canvas TextAlign::justify (full SkParagraph kJustify rendering follows up).",
+      "issue": ""
+    },
+    "rn/textAlignVertical": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setVerticalAlign(id, value) \u2014 RN-Android equivalent of  shares the same Label::vertical_align_ slot. Bridge fn at widget_bridge.cpp:5180 accepts top/middle/bottom/baseline (and Pulp's Label paints accordingly). Bridge fn aliases center\u2192VA::center, auto\u2192baseline.",
+      "supportedValues": [
+        "auto",
+        "top",
+        "bottom",
+        "center"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "unit:test_widget_bridge#setVerticalAlign"
+      ],
+      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11): walked back from  to . The earlier note \"could map to flex align\" was wrong \u2014 the canonical target is Label::vertical_align_ (text-vertical-align), not flex align-items. Reuses the same setVerticalAlign bridge fn rn/verticalAlign uses, since Pulp's Label models the union of CSS verticalAlign + RN-Android textAlignVertical semantics. Wired through prop-applier.ts in this PR.",
+      "issue": ""
+    },
+    "rn/textDecorationColor": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setTextDecorationColor(id, color) (widget_bridge.cpp:4271) -> Label::set_text_decoration_color. Mirrors css/textDecorationColor which is  on the same bridge fn.",
+      "supportedValues": [
+        "CSS color strings (#rgb / #rrggbb / rgb()/rgba() / named)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "unit:test_widget_bridge#setTextDecorationColor"
+      ],
+      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11): walked back from  to . The setTextDecorationColor bridge fn was already implemented (widget_bridge.cpp:4271) and css/textDecorationColor was already . Wired through prop-applier.ts in this PR.",
+      "issue": ""
+    },
+    "rn/textDecorationLine": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setTextDecoration(id, value) -> Label::set_text_decoration",
+      "supportedValues": [
+        "none",
+        "underline",
+        "line-through",
+        "overline",
+        "underline line-through"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-not-impl-bundle1.test.ts",
+        "packages/pulp-react/test/prop-applier-wave2.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 (rn NOT-IMPL bundle 1): the @pulp/react surface aliases RN's `textDecorationLine` to the existing setTextDecoration bridge fn. Single-keyword form is honored by Label::TextDecoration; the RN compound form `'underline line-through'` is forwarded verbatim but only the first keyword takes effect today (same partial gap noted on css/textDecoration). `overline` is a pulp extension over RN spec. Wave 1 drift cleanup \u2014 added 'underline line-through' combined keyword to supportedValues (the prop-applier passes the keyword to the bridge verbatim). Wave 2 rn \u2014 added 'underline line-through' compound regression coverage.",
+      "issue": ""
+    },
+    "rn/textDecorationStyle": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setTextDecorationStyle(id, value) (widget_bridge.cpp:4287) -> Label::set_text_decoration_style. Mirrors css/textDecorationStyle which is  on the same bridge fn.",
+      "supportedValues": [
+        "solid",
+        "double",
+        "dotted",
+        "dashed",
+        "wavy"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "unit:test_widget_bridge#setTextDecorationStyle"
+      ],
+      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11): walked back from  to . The setTextDecorationStyle bridge fn was already implemented (widget_bridge.cpp:4287) with all 5 spec values, and css/textDecorationStyle was already . Wired through prop-applier.ts in this PR.",
+      "issue": ""
+    },
+    "rn/textShadowColor": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setTextShadowColor(id, hex) -> widget_bridge.cpp:5010",
+      "supportedValues": [
+        "CSS color strings"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-not-impl-bundle1.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1548 work shipped: bridge fn registered (widget_bridge.cpp:5010-5017) and prop-applier wired (prop-applier.ts:1280). Earlier catalog note claimed deferred-to-#1548 \u2014 that work landed. CSS color strings flow through to View::set_text_shadow_color_."
+    },
+    "rn/textShadowOffset": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setTextShadowOffset(id, dx, dy) -> widget_bridge.cpp:5018",
+      "supportedValues": [
+        "{ width, height }"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-not-impl-bundle1.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1548 work shipped: bridge fn registered (widget_bridge.cpp:5018-5026) and prop-applier wired (prop-applier.ts:1281-1287). { width, height } shape per RN spec; prop-applier coerces missing axes to 0."
+    },
+    "rn/textShadowRadius": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setTextShadowRadius(id, px) -> widget_bridge.cpp:5027",
+      "supportedValues": [
+        "px (number)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-not-impl-bundle1.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1548 work shipped: bridge fn registered (widget_bridge.cpp:5027-5034) and prop-applier wired (prop-applier.ts:1288). Blur radius in px (number)."
+    },
+    "rn/textTransform": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier forwards keyword to setTextTransform (widget_bridge.cpp:3486); bridge maps to View::TextTransform.",
+      "supportedValues": [
+        "none",
+        "uppercase",
+        "lowercase",
+        "capitalize"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-wires.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn bridge-wires bundle (sub-agent #27 finding) \u2014 bridge fn was registered in widget_bridge.cpp; @pulp/react prop-applier dispatch wired in this PR.",
+      "issue": ""
+    },
+    "rn/top": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setTop(id, n | 'NN%')",
+      "supportedValues": [
+        "number",
+        "string '%'"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 batch 6: percent strings flow through prop-applier verbatim; the bridge routes them to YGNodeStyleSetPositionPercent via View::top_unit_/etc.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1434"
+    },
+    "rn/transform": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier walks the array and dispatches setTranslate / setRotation / setScale / setSkew per the within-array merged snapshot. setSkew newly registered (Triage #9 fan-out).",
+      "supportedValues": [
+        "array of {translateX|translateY}",
+        "array of {rotate|rotateZ}",
+        "array of {scale|scaleX|scaleY}",
+        "array of {skewX|skewY}",
+        "angle units: \"45deg\" / \"0.785rad\" / \"0.5turn\" / \"50grad\" / numeric",
+        "within-array axis merging: [{translateX:10},{translateY:20}] dispatches ONE setTranslate(10,20)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-transform.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Triage #9 fan-out \u2014 full CSS transform-function set wired via parseTransform walk-once accumulator. setSkew bridge fn registered; scaleX/scaleY share uniform setScale slot (last-write-wins; bridge gap); matrix() decomposed to translate+scale+rotate. rotateX / rotateY / matrix3d / perspective silently drop (pulp's 2D View has no 3D model). rn array surface does not include matrix() (RN spec omits it). independent scaleX != scaleY \u2014 last-write-wins on the uniform bridge.",
+      "issue": ""
+    },
+    "rn/transformOrigin": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier parses CSS string (\"NN% NN%\" / \"NNpx NNpx\" / keyword pairs) into two fractional 0..1 coordinates and dispatches to setTransformOrigin (widget_bridge.cpp:3703).",
+      "supportedValues": [
+        "\"NN% NN%\"",
+        "\"NNpx NNpx\"",
+        "\"center\"",
+        "\"left top\" / \"right bottom\" / etc. (keyword pairs)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-wires.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn bridge-wires bundle (sub-agent #27 finding) \u2014 bridge fn was registered in widget_bridge.cpp; @pulp/react prop-applier dispatch wired in this PR.",
+      "issue": ""
+    },
+    "rn/userSelect": {
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier forwards keyword to setUserSelect (prop-applier.ts:753). Bridge routes the keyword to View::UserSelect at widget_bridge.cpp:2474-2484 \u2014 `none` / `text` / `all` / `contain` map to the matching enum value; unknown values fall back to `auto`. Stored on View::user_select_ (view.hpp:1071) with a `view->user_select()` getter so widgets that participate in selection can read it.",
+      "supportedValues": [
+        "auto",
+        "none",
+        "text",
+        "all",
+        "contain"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-wires.test.ts",
+        "test/test_widget_bridge.cpp [issue-1656-tier2-userSelect]"
+      ],
+      "notes": "pulp #1737 \u2014 catalog flipped noop \u2192 supported to match the wired implementation. View::UserSelect enum + setter/getter landed under pulp #1538/#1656 follow-up; the bridge's setUserSelect (widget_bridge.cpp:2474-2484) already routes all 5 RN keywords with full evidence in test/test_widget_bridge.cpp [issue-1656-tier2-userSelect]. Native text-selection suppression on the input layer is the behaviour-fidelity follow-up; the keyword-coverage + storage round-trip is complete and matches the css/userSelect catalog precedent.",
+      "issue": ""
+    },
+    "rn/verticalAlign": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setVerticalAlign(id, value) (widget_bridge.cpp:5180) -> Label::set_vertical_align(canvas::TextVerticalAlign). Mirrors css/verticalAlign which is supported on the same bridge fn. Bridge fn aliases auto\u2192baseline (Pulp default).",
+      "supportedValues": [
+        "auto",
+        "top",
+        "bottom",
+        "middle"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "unit:test_widget_bridge#setVerticalAlign"
+      ],
+      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11): walked back from  to . The setVerticalAlign bridge fn was already implemented (widget_bridge.cpp:5180) and css/verticalAlign was already  on the same target. The wontfix entry pre-dated the bridge fn landing. Wired through prop-applier.ts in this PR.",
+      "issue": ""
+    },
+    "rn/viewBox": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts: 'viewBox' -> setSvgViewBox(id, w, h). Expected as [number, number] tuple.",
+      "supportedValues": [
+        "SVG-style 'min-x min-y w h' string (trailing w/h consumed; min-x/min-y origin offset is a paint-side gap)",
+        "[number, number] (width, height)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-wave2.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "RN doesn't have a native SVG surface; this is a Pulp-specific @pulp/react intrinsic. CSS-shim consumers don't see this prop today. Wave 1 drift cleanup \u2014 supported \u2192 partial (only the [w,h] tuple is consumed; min-x/min-y prefix is parsed but ignored). Wave 2 rn \u2014 SVG-spec string form `'min-x min-y w h'` (or `'w h'`) now parses at dispatch time. The bridge consumes the trailing two tokens as (width, height); the min-x / min-y origin offset is not yet honored by the SvgPathWidget paint side (separate paint-side follow-up).",
+      "issue": "994"
+    },
+    "rn/width": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'width', n) \u2014 number=px, '50%'=percent, 'auto'=hug-contents",
+      "supportedValues": [
+        "number (px)",
+        "string % (e.g. '50%')",
+        "string 'auto'"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn batch C wired number + %; pulp #1434 (sub-agent #12 follow-up) wired 'auto' end-to-end. TS type accepts `number | string`; bridge dispatches via FlexStyle::dim_width.unit (px / percent / auto_) and yoga_layout.cpp routes to YGNodeStyleSetWidth{,Percent,Auto}.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1434"
+    },
+    "rn/writingDirection": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts:952 \u2014  -> setDirection(id, value). RN ViewStyle uses ; CSS uses ; Pulp routes both through the same setDirection bridge fn (widget_bridge.cpp:4944-4953). pulp #1506 landed RTL bidi end-to-end.",
+      "supportedValues": [
+        "ltr",
+        "rtl",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "unit:test_widget_bridge#setDirection"
+      ],
+      "notes": "pulp #1737 RN-OOS-fixup (catalog audit 2026-05-11): walked back from  to . The earlier wontfix cited \"RTL not modeled\" but pulp #1506 had already landed RTL bidi via setDirection (the same bridge fn the css  prop uses, which is ). The prop-applier route at packages/pulp-react/src/prop-applier.ts:952 was already wired pre-audit; this is purely a stale catalog correction.",
+      "issue": ""
+    },
+    "rn/zIndex": {
+      "status": "supported",
+      "mapsTo": "setZIndex(id, n)",
+      "supportedValues": [
+        "number"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    }
+  }
+}

--- a/compat/yoga.json
+++ b/compat/yoga.json
@@ -1,0 +1,866 @@
+{
+  "yoga": {
+    "yoga/flexDirection": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.direction",
+      "supportedValues": [
+        "row",
+        "column",
+        "row-reverse",
+        "column-reverse"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn batch B: FlexDirection extended with row_reverse/column_reverse; yoga_layout.cpp dispatches to YGFlexDirectionRowReverse/ColumnReverse.",
+      "issue": ""
+    },
+    "yoga/flexWrap": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.flex_wrap (bool)",
+      "supportedValues": [
+        "nowrap",
+        "wrap",
+        "wrap-reverse"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 Triage #14 \u2014 FlexStyle.flex_wrap is now FlexWrap enum (no_wrap/wrap/wrap_reverse); yoga_layout.cpp dispatches all three through YGNodeStyleSetFlexWrap with YGWrapNoWrap / YGWrapWrap / YGWrapWrapReverse.",
+      "issue": ""
+    },
+    "yoga/flexGrow": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.flex_grow (float)",
+      "supportedValues": [
+        "non-negative number"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "semantic:yoga/flex-grow-shrink",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "yoga/flexShrink": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.flex_shrink (float)",
+      "supportedValues": [
+        "non-negative number"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "semantic:yoga/flex-grow-shrink",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "yoga/flexBasis": {
+      "status": "supported",
+      "mapsTo": "FlexStyle::dim_flex_basis (Dimension { unit, value }) \u2192 YGNodeStyleSetFlexBasis / YGNodeStyleSetFlexBasisPercent / YGNodeStyleSetFlexBasisAuto in build_yoga_subtree (core/view/src/yoga_layout.cpp).",
+      "supportedValues": [
+        "px",
+        "%",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "unit:test/test_widget_bridge.cpp [issue-1434-rn-batch-c]",
+        "unit:test/test_widget_bridge.cpp [issue-1545]",
+        "semantic:yoga/flex-grow-shrink",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "All three Yoga-native value forms route end-to-end. pulp #1434 rn batch C added bridge plumbing (number / 'NN%' / 'auto'); pulp #1545 promoted the entry to supported after re-verifying YGNodeStyleSetFlexBasisPercent is wired and exercised. The CSS-3 `content` keyword (intrinsic-size flex basis) is not modeled by Yoga itself, so it's treated as out-of-scope (parity with upstream Yoga / React Native) rather than as a tracked gap.",
+      "issue": ""
+    },
+    "yoga/justifyContent": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.justify_content (FlexJustify enum)",
+      "supportedValues": [
+        "flex-start",
+        "start",
+        "flex-end",
+        "end",
+        "center",
+        "space-between",
+        "space-around",
+        "space-evenly"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "All 6 modes covered. Bridge accepts both CSS spelling (flex-start/flex-end) and Yoga spelling (start/end) \u2014 CSS translator _cssToFlex maps the former to the latter. pulp #1434 rn batch B: confirmed bridge accepts flex-start/flex-end aliases too via @pulp/react prop-applier path.",
+      "issue": ""
+    },
+    "yoga/alignItems": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.align_items (FlexAlign enum)",
+      "supportedValues": [
+        "flex-start",
+        "start",
+        "flex-end",
+        "end",
+        "center",
+        "stretch",
+        "baseline"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn batch B: bridge accepts both CSS (flex-start/flex-end/baseline) and Yoga (start/end) spellings; FlexAlign extended with baseline \u2192 YGAlignBaseline.",
+      "issue": ""
+    },
+    "yoga/alignSelf": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.align_self (FlexAlign + auto_)",
+      "supportedValues": [
+        "auto",
+        "flex-start",
+        "start",
+        "flex-end",
+        "end",
+        "center",
+        "stretch",
+        "baseline"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn batch B: bridge accepts both CSS and Yoga spellings; FlexAlign::baseline added.",
+      "issue": ""
+    },
+    "yoga/alignContent": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.align_content (FlexAlign) + FlexStyle.align_content_space (AlignContentSpace) -> YGNodeStyleSetAlignContent",
+      "supportedValues": [
+        "flex-start",
+        "start",
+        "flex-end",
+        "end",
+        "center",
+        "stretch",
+        "space-between",
+        "space-around",
+        "space-evenly"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 (sub-agent #12 follow-up): multi-line flex cross-axis distribution. Yoga supports it natively via YGNodeStyleSetAlignContent; gap was a missing FlexStyle field + setter wiring. Bridge accepts both bare and prefixed CSS spellings plus the three space-* values. align_content_space encodes space-between / space-around / space-evenly because FlexAlign has no space variants (those don't make sense on align_items / align_self).",
+      "issue": "https://github.com/danielraffel/pulp/issues/1434"
+    },
+    "yoga/width": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.preferred_width (px) + FlexStyle.dim_width (percent / auto)",
+      "supportedValues": [
+        "px",
+        "%",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "semantic:yoga/percentage-sizing",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1423 wired px + %; pulp #1434 (sub-agent #12 follow-up) wired 'auto'. percent values route through FlexStyle.dim_width (DimensionUnit::percent) -> YGNodeStyleSetWidthPercent; 'auto' routes through DimensionUnit::auto_ -> YGNodeStyleSetWidthAuto (Figma hug-contents, v0 intrinsic-sizing, Claude Design responsive containers). CSS translator and @pulp/react prop-applier pass 'NN%' / 'auto' strings verbatim to the bridge.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1434"
+    },
+    "yoga/height": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.preferred_height (px) + FlexStyle.dim_height (percent / auto)",
+      "supportedValues": [
+        "px",
+        "%",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "semantic:yoga/percentage-sizing",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1423 wired px + %; pulp #1434 (sub-agent #12 follow-up) wired 'auto' (YGNodeStyleSetHeightAuto via FlexStyle.dim_height.unit == auto_). Same shape as width.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1434"
+    },
+    "yoga/minWidth": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.min_width",
+      "supportedValues": [
+        "px",
+        "%"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn batch C: bridge populates FlexStyle::dim_min_width.unit; yoga_layout.cpp dispatches to YGNodeStyleSetMinWidthPercent.",
+      "issue": ""
+    },
+    "yoga/minHeight": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.min_height",
+      "supportedValues": [
+        "px",
+        "%"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn batch C: bridge populates FlexStyle::dim_min_height.unit; yoga_layout.cpp dispatches to YGNodeStyleSetMinHeightPercent.",
+      "issue": ""
+    },
+    "yoga/maxWidth": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.max_width (0 = no max)",
+      "supportedValues": [
+        "px",
+        "%"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Semantic of 0 differs from CSS unspecified. pulp #1434 rn batch C: bridge populates FlexStyle::dim_max_width.unit; yoga_layout.cpp dispatches to YGNodeStyleSetMaxWidthPercent.",
+      "issue": ""
+    },
+    "yoga/maxHeight": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.max_height",
+      "supportedValues": [
+        "px",
+        "%"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 rn batch C: bridge populates FlexStyle::dim_max_height.unit; yoga_layout.cpp dispatches to YGNodeStyleSetMaxHeightPercent.",
+      "issue": ""
+    },
+    "yoga/aspectRatio": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.aspect_ratio (std::optional<float>) -> YGNodeStyleSetAspectRatio",
+      "supportedValues": [
+        "number"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "unit:test/web-compat/test_layout_aspect_ratio.cpp",
+        "semantic:yoga/aspect-ratio",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 \u2014 added FlexStyle.aspect_ratio + Yoga dispatch + bridge setFlex 'aspect_ratio' branch + @pulp/react aspectRatio prop. CSS shim accepts plain numbers ('1.5'), 'width/height' ratios ('16/9'), and 'auto' (clears slot).",
+      "issue": "1434"
+    },
+    "yoga/boxSizing": {
+      "status": "supported",
+      "mapsTo": "JS shim setBoxSizing \u2192 bridge widget_bridge.cpp:3666-3686 routes the keyword to FlexStyle::box_sizing (geometry.hpp:307); yoga_layout.cpp:123-128 calls YGNodeStyleSetBoxSizing with the matching YGBoxSizing enum. Default border-box matches the CSS spec.",
+      "supportedValues": [
+        "border-box",
+        "content-box"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1516]"
+      ],
+      "notes": "pulp #1516 (PR #1538) wired FlexStyle::box_sizing + YGNodeStyleSetBoxSizing. Mirrors css/boxSizing on the same view slot \u2014 the css side is also supported. pulp #1737 catalog hygiene: catalog drifted to `missing` after the wiring landed; flipped now that the wiring is verified end-to-end.",
+      "issue": "1516"
+    },
+    "yoga/margin": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.margin (float) for the uniform shorthand; per-edge `marginTop` / `marginRight` / `marginBottom` / `marginLeft` route through FlexStyle::dim_margin_* to YGNodeStyleSetMargin{,Percent,Auto}. The shorthand is uniform-px today; the per-edge entries already cover px / % / auto.",
+      "supportedValues": [
+        "px",
+        "auto (per-edge \u2014 see yoga/marginTop etc.)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Yoga's YGNodeStyleSetMarginAuto is wired through `apply_margin` and `apply_logical_margin` in yoga_layout.cpp \u2014 `auto` works on every edge (top/right/bottom/left/start/end). The uniform shorthand stays px-only because there's no spec-defined `margin: auto` per-edge expansion that requires the shorthand itself to carry the unit; consumers that want centering set the per-edge keys.",
+      "issue": ""
+    },
+    "yoga/marginTop": {
+      "status": "supported",
+      "mapsTo": "setFlex(margin_top, N|\"NN%\"|\"auto\") routed via FlexStyle::dim_margin_top to YGNodeStyleSetMargin{,Percent,Auto}. yoga_layout.cpp dispatches on dim.unit (cross-surface mega-batch).",
+      "supportedValues": [
+        "px",
+        "%",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setFlex margin edges accept percent strings\"",
+        "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
+      "issue": ""
+    },
+    "yoga/marginRight": {
+      "status": "supported",
+      "mapsTo": "setFlex(margin_right, N|\"NN%\"|\"auto\") routed via FlexStyle::dim_margin_right to YGNodeStyleSetMargin{,Percent,Auto}. yoga_layout.cpp dispatches on dim.unit (cross-surface mega-batch).",
+      "supportedValues": [
+        "px",
+        "%",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setFlex margin edges accept percent strings\"",
+        "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
+      "issue": ""
+    },
+    "yoga/marginBottom": {
+      "status": "supported",
+      "mapsTo": "setFlex(margin_bottom, N|\"NN%\"|\"auto\") routed via FlexStyle::dim_margin_bottom to YGNodeStyleSetMargin{,Percent,Auto}. yoga_layout.cpp dispatches on dim.unit (cross-surface mega-batch).",
+      "supportedValues": [
+        "px",
+        "%",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setFlex margin edges accept percent strings\"",
+        "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
+      "issue": ""
+    },
+    "yoga/marginLeft": {
+      "status": "supported",
+      "mapsTo": "setFlex(margin_left, N|\"NN%\"|\"auto\") routed via FlexStyle::dim_margin_left to YGNodeStyleSetMargin{,Percent,Auto}. yoga_layout.cpp dispatches on dim.unit (cross-surface mega-batch).",
+      "supportedValues": [
+        "px",
+        "%",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setFlex margin edges accept percent strings\"",
+        "test/test_widget_bridge.cpp::\"setFlex margin edges accept 'auto' keyword\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 per-edge accepts number, percent string, auto.",
+      "issue": ""
+    },
+    "yoga/marginStart": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.dim_margin_start (yoga_layout.cpp dispatches to YGNodeStyleSetMargin/Percent/Auto on YGEdgeStart)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"5%\")",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1542]"
+      ],
+      "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeStart resolves to the left edge in LTR and the right edge in RTL; the new FlexStyle::writing_direction field plus YGNodeStyleSetDirection drives the flip.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1542"
+    },
+    "yoga/marginEnd": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.dim_margin_end (yoga_layout.cpp dispatches to YGNodeStyleSetMargin/Percent/Auto on YGEdgeEnd)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"10%\")",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1542]"
+      ],
+      "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeEnd resolves to the right edge in LTR and the left edge in RTL.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1542"
+    },
+    "yoga/marginHorizontal": {
+      "status": "supported",
+      "mapsTo": "translator fan-out -> FlexStyle.margin_left + FlexStyle.margin_right (web-compat-style-decl.js + prop-applier.ts)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"5%\")",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "issue": ""
+    },
+    "yoga/marginVertical": {
+      "status": "supported",
+      "mapsTo": "translator fan-out -> FlexStyle.margin_top + FlexStyle.margin_bottom (web-compat-style-decl.js + prop-applier.ts)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"5%\")",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "issue": ""
+    },
+    "yoga/padding": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.padding (uniform shorthand, float) plus per-edge FlexStyle::dim_padding_* routing through `apply_padding` / `apply_logical_padding` in yoga_layout.cpp to YGNodeStyleSetPadding{,Percent}.",
+      "supportedValues": [
+        "px",
+        "% (per-edge \u2014 see yoga/paddingTop etc.)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "semantic:yoga/box-sizing",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "% values flow through the per-edge keys (paddingTop/Right/Bottom/Left/Start/End). The uniform `padding` shorthand is px-only by design \u2014 the bridge expands shorthands at the JS layer (web-compat-style-decl.js `padding` case) into per-edge calls that DO carry the unit. CSS spec rejects `padding: auto` (auto is invalid for padding), matching Yoga's lack of a YGNodeStyleSetPaddingAuto API.",
+      "issue": ""
+    },
+    "yoga/paddingTop": {
+      "status": "supported",
+      "mapsTo": "setFlex(padding_top, N|\"NN%\") routed via FlexStyle::dim_padding_top to YGNodeStyleSetPadding{,Percent}. Yoga has no padding-auto API.",
+      "supportedValues": [
+        "px",
+        "%"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
+      "issue": ""
+    },
+    "yoga/paddingRight": {
+      "status": "supported",
+      "mapsTo": "setFlex(padding_right, N|\"NN%\") routed via FlexStyle::dim_padding_right to YGNodeStyleSetPadding{,Percent}. Yoga has no padding-auto API.",
+      "supportedValues": [
+        "px",
+        "%"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
+      "issue": ""
+    },
+    "yoga/paddingBottom": {
+      "status": "supported",
+      "mapsTo": "setFlex(padding_bottom, N|\"NN%\") routed via FlexStyle::dim_padding_bottom to YGNodeStyleSetPadding{,Percent}. Yoga has no padding-auto API.",
+      "supportedValues": [
+        "px",
+        "%"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
+      "issue": ""
+    },
+    "yoga/paddingLeft": {
+      "status": "supported",
+      "mapsTo": "setFlex(padding_left, N|\"NN%\") routed via FlexStyle::dim_padding_left to YGNodeStyleSetPadding{,Percent}. Yoga has no padding-auto API.",
+      "supportedValues": [
+        "px",
+        "%"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setFlex padding edges accept percent strings\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 Yoga padding accepts px and percent. `auto` is a Yoga-side gap (Yoga has no YGNodeStyleSetPaddingAuto API).",
+      "issue": ""
+    },
+    "yoga/paddingStart": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.dim_padding_start (yoga_layout.cpp dispatches to YGNodeStyleSetPadding/Percent on YGEdgeStart)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"15%\")"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1542]"
+      ],
+      "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeStart resolves to the left edge in LTR and the right edge in RTL. `auto` is spec-invalid for padding (CSS rejects `padding: auto`), so it's not listed as a gap \u2014 Yoga matches the spec by not exposing a YGNodeStyleSetPaddingAuto API.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1542"
+    },
+    "yoga/paddingEnd": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.dim_padding_end (yoga_layout.cpp dispatches to YGNodeStyleSetPadding/Percent on YGEdgeEnd)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"25%\")"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1542]"
+      ],
+      "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeEnd resolves to the right edge in LTR and the left edge in RTL. `auto` is spec-invalid for padding so it's not listed as a gap.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1542"
+    },
+    "yoga/paddingHorizontal": {
+      "status": "supported",
+      "mapsTo": "translator fan-out -> FlexStyle.padding_left + FlexStyle.padding_right (web-compat-style-decl.js + prop-applier.ts)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"5%\")"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "issue": ""
+    },
+    "yoga/paddingVertical": {
+      "status": "supported",
+      "mapsTo": "translator fan-out -> FlexStyle.padding_top + FlexStyle.padding_bottom (web-compat-style-decl.js + prop-applier.ts)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"5%\")"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 cross-surface mega-batch \u2014 alias fans out to per-edge keys; same value coverage as the per-edge entries.",
+      "issue": ""
+    },
+    "yoga/borderWidth": {
+      "status": "supported",
+      "mapsTo": "yoga_layout.cpp::apply_border_widths -> YGNodeStyleSetBorder(node, YGEdge*, view.border_*_width). Per-side override (set_border_top/right/bottom/left, reached via setBorderTopWidth etc.) wins; otherwise the uniform View::border_width() is forwarded to all four edges. Couples with #1516 box-sizing so Yoga's content-box / border-box math gets accurate border insets (pulp #1543).",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "semantic:yoga/box-sizing",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Yoga's BORDER edges contribute to content-box sizing. Before #1543, Pulp's borders were paint-only (Skia stroke) and Yoga saw zero border insets, which made box-sizing math wrong when border-box was active. Wired now \u2014 borders affect both layout AND paint. % is intentionally not listed as an unsupported gap because the CSS spec rejects `border-width: <%>` (invalid value); Yoga matches the spec by not exposing a YGNodeStyleSetBorderPercent API.",
+      "issue": ""
+    },
+    "yoga/borderTopWidth": {
+      "status": "supported",
+      "mapsTo": "yoga_layout.cpp::apply_border_widths -> YGNodeStyleSetBorder(node, YGEdgeTop, ...). Per-side wins over the uniform border_width() (pulp #1543).",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Same as borderWidth \u2014 the per-edge variants share the same wiring. Reached from JS via setBorderTopWidth(id, w). % is spec-invalid for border-width so not listed as a gap.",
+      "issue": ""
+    },
+    "yoga/borderRightWidth": {
+      "status": "supported",
+      "mapsTo": "yoga_layout.cpp::apply_border_widths -> YGNodeStyleSetBorder(node, YGEdgeRight, ...). Per-side wins over the uniform border_width() (pulp #1543).",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Same. Reached via setBorderRightWidth(id, w). % is spec-invalid for border-width so not listed as a gap.",
+      "issue": ""
+    },
+    "yoga/borderBottomWidth": {
+      "status": "supported",
+      "mapsTo": "yoga_layout.cpp::apply_border_widths -> YGNodeStyleSetBorder(node, YGEdgeBottom, ...). Per-side wins over the uniform border_width() (pulp #1543).",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Same. Reached via setBorderBottomWidth(id, w). % is spec-invalid for border-width so not listed as a gap.",
+      "issue": ""
+    },
+    "yoga/borderLeftWidth": {
+      "status": "supported",
+      "mapsTo": "yoga_layout.cpp::apply_border_widths -> YGNodeStyleSetBorder(node, YGEdgeLeft, ...). Per-side wins over the uniform border_width() (pulp #1543).",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Same. Reached via setBorderLeftWidth(id, w). % is spec-invalid for border-width so not listed as a gap.",
+      "issue": ""
+    },
+    "yoga/position": {
+      "status": "supported",
+      "mapsTo": "View::Position enum (separate from FlexStyle)",
+      "supportedValues": [
+        "static",
+        "relative",
+        "absolute",
+        "fixed",
+        "sticky"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "semantic:yoga/position-absolute",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "Pulp's enum is a SUPERSET of Yoga's {static, relative, absolute}.",
+      "issue": ""
+    },
+    "yoga/top": {
+      "status": "supported",
+      "mapsTo": "View::set_top (px) + View::set_top(v, DimensionUnit::percent)",
+      "supportedValues": [
+        "px",
+        "%"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "semantic:yoga/position-absolute",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 batch 6: percent values route through View::set_top(v, DimensionUnit::percent); yoga_layout.cpp dispatches on top_unit_/right_unit_/bottom_unit_/left_unit_ to call YGNodeStyleSetPositionPercent. CSS translator passes 'NN%' strings verbatim to the bridge. Mirrors the FlexStyle::dim_width path from pulp #1423 (PR #1426) for the View positional fields.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1434"
+    },
+    "yoga/right": {
+      "status": "supported",
+      "mapsTo": "View::set_right (px) + View::set_right(v, DimensionUnit::percent)",
+      "supportedValues": [
+        "px",
+        "%"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 batch 6: percent values route through View::set_right(v, DimensionUnit::percent); yoga_layout.cpp dispatches on top_unit_/right_unit_/bottom_unit_/left_unit_ to call YGNodeStyleSetPositionPercent. CSS translator passes 'NN%' strings verbatim to the bridge. Mirrors the FlexStyle::dim_width path from pulp #1423 (PR #1426) for the View positional fields.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1434"
+    },
+    "yoga/bottom": {
+      "status": "supported",
+      "mapsTo": "View::set_bottom (px) + View::set_bottom(v, DimensionUnit::percent)",
+      "supportedValues": [
+        "px",
+        "%"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 batch 6: percent values route through View::set_bottom(v, DimensionUnit::percent); yoga_layout.cpp dispatches on top_unit_/right_unit_/bottom_unit_/left_unit_ to call YGNodeStyleSetPositionPercent. CSS translator passes 'NN%' strings verbatim to the bridge. Mirrors the FlexStyle::dim_width path from pulp #1423 (PR #1426) for the View positional fields.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1434"
+    },
+    "yoga/left": {
+      "status": "supported",
+      "mapsTo": "View::set_left (px) + View::set_left(v, DimensionUnit::percent)",
+      "supportedValues": [
+        "px",
+        "%"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "semantic:yoga/position-absolute",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1434 batch 6: percent values route through View::set_left(v, DimensionUnit::percent); yoga_layout.cpp dispatches on top_unit_/right_unit_/bottom_unit_/left_unit_ to call YGNodeStyleSetPositionPercent. CSS translator passes 'NN%' strings verbatim to the bridge. Mirrors the FlexStyle::dim_width path from pulp #1423 (PR #1426) for the View positional fields.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1434"
+    },
+    "yoga/start": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.dim_start (yoga_layout.cpp dispatches to YGNodeStyleSetPosition / SetPositionPercent / SetPositionAuto on YGEdgeStart based on dim.unit)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"12%\")",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1542]",
+        "test/test_widget_bridge.cpp::\"setFlex start/end accept 'auto' keyword\""
+      ],
+      "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeStart resolves to the left edge in LTR and the right edge in RTL. `auto` (the CSS default \u2014 \"don't anchor to this edge\") routes through Yoga's YGNodeStyleSetPositionAuto via FlexStyle::dim_start.unit = auto_; the bridge accepts `'auto'` verbatim. Wired DIVERGE\u2192PASS sweep.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1542"
+    },
+    "yoga/end": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.dim_end (yoga_layout.cpp dispatches to YGNodeStyleSetPosition / SetPositionPercent / SetPositionAuto on YGEdgeEnd based on dim.unit)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"8%\")",
+        "auto"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1542]",
+        "test/test_widget_bridge.cpp::\"setFlex start/end accept 'auto' keyword\""
+      ],
+      "notes": "pulp #1542 \u2014 yoga logical-edge fan-out. YGEdgeEnd resolves to the right edge in LTR and the left edge in RTL. `auto` routes through YGNodeStyleSetPositionAuto. Wired DIVERGE\u2192PASS sweep.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1542"
+    },
+    "yoga/gap": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.gap",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "yoga/rowGap": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.row_gap (-1 = use gap)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "yoga/columnGap": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.column_gap",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "yoga/order": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.order (int)",
+      "supportedValues": [
+        "integer"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "",
+      "issue": ""
+    },
+    "yoga/display": {
+      "status": "supported",
+      "mapsTo": "View::set_visible (display:none) + flex layout default (display:flex)",
+      "supportedValues": [
+        "flex",
+        "none"
+      ],
+      "unsupportedValues": [
+        "contents"
+      ],
+      "tests": [
+        "test/test_widget_bridge.cpp [display-contents]",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1420: claim flex+none as supported. CSS translator at web-compat-style-decl.js:86-118 routes display:none to setVisible(false) and display:flex to setVisible(true)+setFlex(direction). 'flex' is implicit in pulp's layout model; 'none' uses View visibility. Yoga has YGDisplay {flex, none, contents}; pulp doesn't model 'contents'. ARCH-DEFERRED: display: contents requires parallel block/inline-flow layout that CLAUDE.md's flex+grid-only policy (Yoga 3.0 ceiling) explicitly rules out \u2014 the dispatcher silently no-ops; pinned by test/test_widget_bridge.cpp [display-contents].",
+      "issue": "https://github.com/danielraffel/pulp/issues/1420"
+    },
+    "yoga/overflow": {
+      "status": "supported",
+      "mapsTo": "View::Overflow {visible, hidden, scroll} \u2014 set via setOverflow(id, 'visible'|'hidden'|'scroll') in widget_bridge.cpp; routed through to Yoga via YGNodeStyleSetOverflow in yoga_layout.cpp::build_yoga_subtree. Paint clipping in view.cpp treats `scroll` like `hidden` (no scrollbar UI yet).",
+      "supportedValues": [
+        "visible",
+        "hidden",
+        "scroll"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"setOverflow accepts scroll keyword\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "DIVERGE\u2192PASS sweep \u2014 `scroll` is now accepted as a third keyword and propagates through both the layout engine (Yoga's overflow:scroll affects descendant-overflow contribution) and the paint clip path (matches CSS spec where `scroll` clips the painted box like `hidden`). Scrollbar UI / actual scroll-position state remains a roadmap item; the harness gap was about *layout-side* keyword acceptance, which is now covered.",
+      "issue": ""
+    },
+    "yoga/direction": {
+      "status": "supported",
+      "mapsTo": "FlexStyle.writing_direction (yoga_layout.cpp dispatches to YGNodeStyleSetDirection / YGNodeCalculateLayout root direction)",
+      "supportedValues": [
+        "ltr",
+        "rtl",
+        "inherit"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1542]"
+      ],
+      "notes": "pulp #1542 \u2014 bridge accepts `direction_writing` sub-key on setFlex (distinct from `direction` for flex-direction). FlexStyle::writing_direction { inherit, ltr, rtl } drives both YGNodeStyleSetDirection on the per-node call and the root's YGNodeCalculateLayout direction argument. Required for yoga's logical-edge resolution (start/end, marginStart, etc.).",
+      "issue": "https://github.com/danielraffel/pulp/issues/1542"
+    },
+    "yoga/flex": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js case 'flex' shorthand parser splits on whitespace and dispatches setFlex(id, 'flex_grow', ...) + optional setFlex(id, 'flex_shrink', ...) + optional setFlex(id, 'flex_basis', ...) onto FlexStyle.flex_grow/flex_shrink/flex_basis. Keyword forms route through the same setFlex calls \u2014 see notes for spec expansions.",
+      "supportedValues": [
+        "<grow>",
+        "<grow> <shrink>",
+        "<grow> <shrink> <basis>",
+        "'auto' (\u2261 1 1 auto)",
+        "'none' (\u2261 0 0 auto)",
+        "'initial' (\u2261 0 1 auto)"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/web-compat/test_popover_row_template_1147.cpp",
+        "test/test_widget_bridge.cpp::\"flex shorthand keyword forms\""
+      ],
+      "notes": "pulp #1544 \u2014 catalog promotion. Already wired through `web-compat-style-decl.js` shorthand parser; mirrors `css/flex`. DIVERGE\u2192PASS sweep \u2014 keyword forms (`flex: auto`/`none`/`initial`) now expand per the CSS Flexible Box spec instead of silently zeroing flex_grow.",
+      "issue": ""
+    },
+    "yoga/flexFlow": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js case 'flexFlow' tokenizes the shorthand and dispatches setFlex(id, 'direction', ...) + setFlex(id, 'flex_wrap', ...) onto FlexStyle.direction / FlexStyle.flex_wrap.",
+      "supportedValues": [
+        "row|column|row-reverse|column-reverse",
+        "nowrap|no-wrap|wrap|wrap-reverse",
+        "combined two-token shorthand (e.g. \"row wrap-reverse\")"
+      ],
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp::\"flex-flow shorthand recognizes wrap-reverse\"",
+        "test/test_widget_bridge.cpp [issue-1711][evidence-backfill]"
+      ],
+      "notes": "pulp #1544 \u2014 catalog promotion. Already wired through `web-compat-style-decl.js` shorthand parser (pulp #1434 Triage #14 extended it to cover `-reverse` modes); mirrors `css/flexFlow`.",
+      "issue": ""
+    }
+  }
+}

--- a/tools/scripts/compat_aggregate.py
+++ b/tools/scripts/compat_aggregate.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""compat.json split / aggregate / sync tool (roadmap P5-NEW-B).
+
+The repo-root ``compat.json`` is a single ~8.2k-line web-compat
+inventory keyed by surface (css / rn / yoga / html / canvas2d /
+imports) plus non-surface metadata (``compat-schema-version``,
+``_comment``, ``_audit``, ``react``).
+
+That single file is awkward to edit and review. This tool splits it
+into per-surface parts under ``compat/`` while keeping the aggregate
+``compat.json`` byte-for-byte unchanged, so every existing consumer
+(the harness verifier, the compat-sync gate, the import validators,
+the C++ tests) sees zero difference.
+
+Why verbatim text slicing instead of ``json.loads`` / ``json.dumps``
+round-tripping: the aggregate was hand-edited inconsistently — some
+strings carry literal non-ASCII characters (e.g. an em-dash) and
+others carry the ``\\uXXXX`` escaped form. No single ``json.dumps``
+setting reproduces that mix, so re-serialization would NOT be
+byte-stable. Instead this tool slices the raw text at the top-level
+key boundaries: every part holds the exact bytes of its key block,
+and the aggregate is rebuilt by concatenating those bytes with the
+original ``{\\n`` prefix, ``,\\n`` separators, and ``\\n}`` suffix.
+
+Layout produced::
+
+    compat/
+      _meta.json     non-surface keys: compat-schema-version,
+                     _comment, _audit, react  (verbatim slices)
+      css.json       one verbatim slice per surface
+      rn.json
+      yoga.json
+      html.json
+      canvas2d.json
+      imports.json
+
+Each part file is a normal JSON object whose single top-level key is
+the surface name (``{"css": { ... }}``) — so a part is independently
+loadable / lintable. The value text inside is the EXACT bytes lifted
+from the aggregate (preserving its em-dash / escape inconsistencies),
+so concatenation is lossless.
+
+Commands::
+
+    compat_aggregate.py split    # (re)generate compat/ parts from compat.json
+    compat_aggregate.py build    # regenerate compat.json from compat/ parts
+    compat_aggregate.py check    # assert aggregate == regenerated-from-parts
+
+``check`` is the CI / pre-push gate: it fails loudly if compat.json
+and the compat/ parts have drifted apart.
+
+Zero third-party dependencies — stdlib only, PEP-668 safe.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Top-level keys, in the exact order they appear in compat.json.
+# Order is load-bearing for byte-stable reassembly.
+SURFACE_KEYS = ["css", "rn", "yoga", "html", "canvas2d", "imports"]
+META_KEYS = ["compat-schema-version", "_comment", "_audit", "react"]
+ALL_KEYS_ORDER = ["compat-schema-version", "_comment", "_audit",
+                  "css", "rn", "yoga", "react", "html", "canvas2d",
+                  "imports"]
+
+META_PART = "_meta.json"
+
+
+# ── repo layout ─────────────────────────────────────────────────────────
+
+
+def repo_root() -> Path:
+    """Locate the repo root (the dir holding compat.json + CMakeLists.txt)."""
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            check=True, capture_output=True, text=True,
+        )
+        return Path(out.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        cur = Path(__file__).resolve()
+        for parent in [cur, *cur.parents]:
+            if (parent / "compat.json").exists():
+                return parent
+        raise SystemExit("compat_aggregate: cannot locate repo root")
+
+
+# ── verbatim slicing ────────────────────────────────────────────────────
+
+
+def slice_aggregate(raw: str) -> dict[str, str]:
+    """Split the raw aggregate text into verbatim ``  "key": <value>``
+    blocks, keyed by top-level key.
+
+    The aggregate has the exact shape::
+
+        {\\n
+          "k0": <v0>,\\n
+          "k1": <v1>,\\n
+          ...
+          "kN": <vN>\\n
+        }
+
+    so block_i is the substring ``  "ki": <vi>`` with no surrounding
+    separators. Returns ``{key: block_text}``.
+    """
+    if not raw.startswith("{\n"):
+        raise ValueError("compat.json does not start with '{\\n' — "
+                          "structure assumption broken, refusing to slice")
+    if not raw.endswith("\n}"):
+        raise ValueError("compat.json does not end with '\\n}' — "
+                          "structure assumption broken, refusing to slice")
+
+    # Find the byte offset where each top-level key block begins.
+    starts: list[tuple[str, int]] = []
+    for key in ALL_KEYS_ORDER:
+        needle = '\n  "' + key + '":'
+        idx = raw.find(needle)
+        if idx == -1:
+            # First key has no leading '\n' (it follows the '{').
+            needle0 = '  "' + key + '":'
+            idx0 = raw.find(needle0)
+            if idx0 == -1:
+                raise ValueError(
+                    f"compat.json: top-level key {key!r} not found"
+                )
+            starts.append((key, idx0))
+        else:
+            starts.append((key, idx + 1))  # +1: skip the '\n', point at '  '
+
+    starts.sort(key=lambda kv: kv[1])
+    found_order = [k for k, _ in starts]
+    if found_order != ALL_KEYS_ORDER:
+        raise ValueError(
+            "compat.json: unexpected top-level key order "
+            f"{found_order!r} (expected {ALL_KEYS_ORDER!r})"
+        )
+
+    blocks: dict[str, str] = {}
+    for i, (key, start) in enumerate(starts):
+        if i + 1 < len(starts):
+            nxt = starts[i + 1][1]
+            sep = raw[nxt - 2:nxt]
+            if sep != ",\n":
+                raise ValueError(
+                    f"compat.json: expected ',\\n' before key after "
+                    f"{key!r}, got {sep!r}"
+                )
+            blocks[key] = raw[start:nxt - 2]
+        else:
+            blocks[key] = raw[start:-2]  # trim trailing '\n}'
+    return blocks
+
+
+def assemble_aggregate(blocks: dict[str, str]) -> str:
+    """Inverse of :func:`slice_aggregate` — concatenate verbatim blocks
+    back into the byte-identical aggregate text."""
+    missing = [k for k in ALL_KEYS_ORDER if k not in blocks]
+    if missing:
+        raise ValueError(f"missing key block(s): {missing}")
+    body = ",\n".join(blocks[k] for k in ALL_KEYS_ORDER)
+    return "{\n" + body + "\n}"
+
+
+def part_text_for(keys: list[str], blocks: dict[str, str]) -> str:
+    """Render a standalone part file for ``keys``.
+
+    A part is a valid JSON object whose body is the verbatim key
+    block(s) lifted from the aggregate, wrapped in ``{\\n ... \\n}``.
+    Because the inner bytes are verbatim, the part round-trips exactly.
+    """
+    body = ",\n".join(blocks[k] for k in keys)
+    return "{\n" + body + "\n}\n"
+
+
+def blocks_from_part(text: str, expected_keys: list[str]) -> dict[str, str]:
+    """Recover verbatim key blocks from a part file produced by
+    :func:`part_text_for`."""
+    stripped = text.rstrip("\n")
+    if not stripped.startswith("{\n") or not stripped.endswith("\n}"):
+        raise ValueError("part file: not a '{\\n ... \\n}' object")
+    # Re-use the aggregate slicer logic: the inner structure is identical.
+    starts: list[tuple[str, int]] = []
+    for key in expected_keys:
+        needle = '\n  "' + key + '":'
+        idx = stripped.find(needle)
+        if idx == -1:
+            needle0 = '  "' + key + '":'
+            idx0 = stripped.find(needle0)
+            if idx0 == -1:
+                raise ValueError(f"part file: key {key!r} not found")
+            starts.append((key, idx0))
+        else:
+            starts.append((key, idx + 1))
+    starts.sort(key=lambda kv: kv[1])
+    blocks: dict[str, str] = {}
+    for i, (key, start) in enumerate(starts):
+        if i + 1 < len(starts):
+            nxt = starts[i + 1][1]
+            blocks[key] = stripped[start:nxt - 2]
+        else:
+            blocks[key] = stripped[start:-2]
+    return blocks
+
+
+# ── commands ─────────────────────────────────────────────────────────────
+
+
+def cmd_split(root: Path) -> int:
+    """Regenerate compat/ parts from the authoritative compat.json."""
+    aggregate = root / "compat.json"
+    raw = aggregate.read_text(encoding="utf-8")
+    blocks = slice_aggregate(raw)
+
+    parts_dir = root / "compat"
+    parts_dir.mkdir(exist_ok=True)
+
+    # Per-surface parts.
+    for key in SURFACE_KEYS:
+        (parts_dir / f"{key}.json").write_text(
+            part_text_for([key], blocks), encoding="utf-8",
+        )
+    # Residual non-surface keys.
+    (parts_dir / META_PART).write_text(
+        part_text_for(META_KEYS, blocks), encoding="utf-8",
+    )
+
+    # Verify the round-trip immediately.
+    rebuilt = _aggregate_from_parts(parts_dir)
+    if rebuilt != raw:
+        print("compat_aggregate: split produced a non-byte-identical "
+              "round-trip — aborting (compat/ left in place for "
+              "inspection).", file=sys.stderr)
+        return 1
+    print(f"compat_aggregate: wrote {len(SURFACE_KEYS) + 1} part files "
+          f"under {parts_dir} (round-trip byte-identical).")
+    return 0
+
+
+def _aggregate_from_parts(parts_dir: Path) -> str:
+    """Read compat/ parts and reassemble the aggregate text."""
+    blocks: dict[str, str] = {}
+    for key in SURFACE_KEYS:
+        part = parts_dir / f"{key}.json"
+        if not part.exists():
+            raise FileNotFoundError(f"missing part: {part}")
+        blocks.update(blocks_from_part(
+            part.read_text(encoding="utf-8"), [key],
+        ))
+    meta = parts_dir / META_PART
+    if not meta.exists():
+        raise FileNotFoundError(f"missing part: {meta}")
+    blocks.update(blocks_from_part(
+        meta.read_text(encoding="utf-8"), META_KEYS,
+    ))
+    return assemble_aggregate(blocks)
+
+
+def cmd_build(root: Path) -> int:
+    """Regenerate compat.json from the compat/ parts."""
+    parts_dir = root / "compat"
+    if not parts_dir.is_dir():
+        print(f"compat_aggregate: no parts dir at {parts_dir} — run "
+              "`split` first.", file=sys.stderr)
+        return 1
+    rebuilt = _aggregate_from_parts(parts_dir)
+    (root / "compat.json").write_text(rebuilt, encoding="utf-8")
+    print(f"compat_aggregate: regenerated compat.json from {parts_dir}.")
+    return 0
+
+
+def cmd_check(root: Path) -> int:
+    """Assert compat.json == aggregate-regenerated-from-parts.
+
+    This is the CI / pre-push sync gate. Exit 0 when in sync, 1 when
+    drifted, 2 on a structural error.
+    """
+    aggregate = root / "compat.json"
+    parts_dir = root / "compat"
+    if not aggregate.exists():
+        print("compat_aggregate: compat.json missing", file=sys.stderr)
+        return 2
+    if not parts_dir.is_dir():
+        print(f"compat_aggregate: no parts dir at {parts_dir} — run "
+              "`split` to create it.", file=sys.stderr)
+        return 2
+
+    current = aggregate.read_text(encoding="utf-8")
+    try:
+        rebuilt = _aggregate_from_parts(parts_dir)
+    except (ValueError, FileNotFoundError) as exc:
+        print(f"compat_aggregate: cannot rebuild from parts: {exc}",
+              file=sys.stderr)
+        return 2
+
+    if current == rebuilt:
+        print("compat_aggregate: compat.json is byte-identical to the "
+              "compat/ parts.")
+        return 0
+
+    # Drift: report the first divergence to help the author.
+    n = min(len(current), len(rebuilt))
+    first = next((i for i in range(n) if current[i] != rebuilt[i]), n)
+    print("compat_aggregate: DRIFT — compat.json and compat/ parts "
+          "disagree.", file=sys.stderr)
+    print(f"  first difference at byte {first}", file=sys.stderr)
+    print(f"  compat.json : ...{current[max(0, first-40):first+40]!r}...",
+          file=sys.stderr)
+    print(f"  from parts  : ...{rebuilt[max(0, first-40):first+40]!r}...",
+          file=sys.stderr)
+    print("  Fix: edit the relevant compat/<surface>.json part, then run "
+          "`tools/scripts/compat_aggregate.py build` to regenerate "
+          "compat.json (or `split` to regenerate the parts from the "
+          "aggregate).", file=sys.stderr)
+    return 1
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="compat.json split / aggregate / sync (P5-NEW-B)",
+    )
+    parser.add_argument(
+        "command", choices=("split", "build", "check"),
+        help="split: compat.json -> compat/ parts; "
+             "build: compat/ parts -> compat.json; "
+             "check: assert the two are byte-identical",
+    )
+    parser.add_argument(
+        "--repo-root", default=None,
+        help="Override repo root (default: git toplevel / compat.json walk)",
+    )
+    args = parser.parse_args(argv)
+
+    root = Path(args.repo_root) if args.repo_root else repo_root()
+
+    if args.command == "split":
+        return cmd_split(root)
+    if args.command == "build":
+        return cmd_build(root)
+    return cmd_check(root)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/scripts/test_compat_aggregate.py
+++ b/tools/scripts/test_compat_aggregate.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Tests for compat_aggregate.py (roadmap P5-NEW-B).
+
+Covers:
+    1. Verbatim slice / assemble round-trip (byte-stable).
+    2. The real repo-root compat.json round-trips byte-identically
+       through split + build.
+    3. `check` passes when in sync and fails on drift.
+    4. The em-dash / \\uXXXX escape inconsistency that defeats
+       json.dumps re-serialization is preserved by verbatim slicing.
+
+Run:
+    python3 tools/scripts/test_compat_aggregate.py
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "tools" / "scripts" / "compat_aggregate.py"
+sys.path.insert(0, str(REPO_ROOT / "tools" / "scripts"))
+
+import compat_aggregate as ca  # noqa: E402
+
+
+# A minimal aggregate with the SAME structural shape as the real
+# compat.json: a non-surface metadata block, the six surfaces, and a
+# `react` block — in the canonical key order. Deliberately mixes a
+# literal em-dash and an escaped — so re-serialization would NOT
+# be byte-stable but verbatim slicing is.
+SAMPLE_AGGREGATE = (
+    "{\n"
+    '  "compat-schema-version": "0.3",\n'
+    '  "_comment": "literal em-dash — here",\n'
+    '  "_audit": {\n'
+    '    "generated": "2026-05-04"\n'
+    "  },\n"
+    '  "css": {\n'
+    '    "display": {\n'
+    '      "note": "escaped \\u2014 dash"\n'
+    "    }\n"
+    "  },\n"
+    '  "rn": {\n'
+    '    "View": {}\n'
+    "  },\n"
+    '  "yoga": {\n'
+    '    "flex": {}\n'
+    "  },\n"
+    '  "react": {\n'
+    '    "_note": "react surface"\n'
+    "  },\n"
+    '  "html": {\n'
+    '    "div": {}\n'
+    "  },\n"
+    '  "canvas2d": {\n'
+    '    "fillRect": {}\n'
+    "  },\n"
+    '  "imports": {\n'
+    '    "figma": {}\n'
+    "  }\n"
+    "}"
+)
+
+
+class SliceAssembleTests(unittest.TestCase):
+    def test_round_trip_is_byte_identical(self) -> None:
+        blocks = ca.slice_aggregate(SAMPLE_AGGREGATE)
+        self.assertEqual(ca.assemble_aggregate(blocks), SAMPLE_AGGREGATE)
+
+    def test_all_top_level_keys_present(self) -> None:
+        blocks = ca.slice_aggregate(SAMPLE_AGGREGATE)
+        self.assertEqual(set(blocks), set(ca.ALL_KEYS_ORDER))
+
+    def test_preserves_escape_inconsistency(self) -> None:
+        # The literal em-dash and the escaped — must both survive
+        # verbatim — this is exactly why we slice instead of json.dumps.
+        blocks = ca.slice_aggregate(SAMPLE_AGGREGATE)
+        self.assertIn("—", blocks["_comment"])
+        self.assertIn("\\u2014", blocks["css"])
+
+    def test_rejects_bad_prefix(self) -> None:
+        with self.assertRaises(ValueError):
+            ca.slice_aggregate('  "css": {}\n}')  # no '{\n' prefix
+
+    def test_part_round_trip(self) -> None:
+        blocks = ca.slice_aggregate(SAMPLE_AGGREGATE)
+        for key in ca.SURFACE_KEYS:
+            text = ca.part_text_for([key], blocks)
+            recovered = ca.blocks_from_part(text, [key])
+            self.assertEqual(recovered[key], blocks[key])
+        meta_text = ca.part_text_for(ca.META_KEYS, blocks)
+        recovered = ca.blocks_from_part(meta_text, ca.META_KEYS)
+        for key in ca.META_KEYS:
+            self.assertEqual(recovered[key], blocks[key])
+
+
+class CliRoundTripTests(unittest.TestCase):
+    def _run(self, command: str, root: Path) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), command, "--repo-root", str(root)],
+            capture_output=True, text=True,
+        )
+
+    def test_split_build_check_on_sample(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            agg = root / "compat.json"
+            agg.write_text(SAMPLE_AGGREGATE, encoding="utf-8")
+            original = agg.read_text(encoding="utf-8")
+
+            self.assertEqual(self._run("split", root).returncode, 0)
+            parts = sorted(p.name for p in (root / "compat").iterdir())
+            self.assertEqual(parts, [
+                "_meta.json", "canvas2d.json", "css.json", "html.json",
+                "imports.json", "rn.json", "yoga.json",
+            ])
+
+            self.assertEqual(self._run("build", root).returncode, 0)
+            self.assertEqual(
+                agg.read_text(encoding="utf-8"), original,
+                "build must regenerate a byte-identical compat.json",
+            )
+            self.assertEqual(self._run("check", root).returncode, 0)
+
+    def test_check_detects_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "compat.json").write_text(
+                SAMPLE_AGGREGATE, encoding="utf-8")
+            self.assertEqual(self._run("split", root).returncode, 0)
+            # Mutate a part so it no longer matches the aggregate.
+            css = root / "compat" / "css.json"
+            css.write_text(
+                css.read_text(encoding="utf-8").replace("display", "DISPLAY"),
+                encoding="utf-8",
+            )
+            res = self._run("check", root)
+            self.assertEqual(res.returncode, 1, res.stderr)
+            self.assertIn("DRIFT", res.stderr)
+
+    def test_check_missing_parts_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "compat.json").write_text(
+                SAMPLE_AGGREGATE, encoding="utf-8")
+            res = self._run("check", root)
+            self.assertEqual(res.returncode, 2, res.stderr)
+
+
+class RealCompatJsonTests(unittest.TestCase):
+    """Round-trip the actual repo compat.json byte-for-byte."""
+
+    def test_real_compat_json_is_byte_stable(self) -> None:
+        src = REPO_ROOT / "compat.json"
+        if not src.exists():
+            self.skipTest("compat.json not present")
+        original = src.read_text(encoding="utf-8")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            shutil.copy(src, root / "compat.json")
+            res = subprocess.run(
+                [sys.executable, str(SCRIPT), "split",
+                 "--repo-root", str(root)],
+                capture_output=True, text=True,
+            )
+            self.assertEqual(res.returncode, 0, res.stderr)
+            subprocess.run(
+                [sys.executable, str(SCRIPT), "build",
+                 "--repo-root", str(root)],
+                check=True, capture_output=True, text=True,
+            )
+            self.assertEqual(
+                (root / "compat.json").read_text(encoding="utf-8"),
+                original,
+                "real compat.json must survive split+build byte-identically",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Roadmap **P5-NEW-B**. The root `compat.json` (8,251 lines / 464 KB) is split into per-surface parts; the aggregate stays **byte-identical** so every consumer is unaffected.

`compat.json` has 10 top-level keys — the 6 surfaces plus `compat-schema-version`, `_comment`, `_audit`, `react`. It was hand-edited inconsistently (some strings carry a literal em-dash, others the `—` escape), so no `json.dumps` setting reproduces it — the aggregate is rebuilt by **verbatim text slicing**.

New files:
- `compat/{css,rn,yoga,html,canvas2d,imports}.json` — verbatim per-surface slices (each independently valid JSON)
- `compat/_meta.json` — the 4 non-surface keys, so nothing is lost
- `tools/scripts/compat_aggregate.py` — `split` / `build` / `check` (the sync gate)
- `tools/scripts/test_compat_aggregate.py` — 9 tests (round-trip, escape-inconsistency preservation, drift detection, real-file byte-stability)

## Test plan

- [x] `diff` of pre-refactor vs regenerated `compat.json` is empty — `git status` does not list `compat.json` (unmodified, byte-identical).
- [x] `test_compat_aggregate.py` — 9/9 pass.
- [x] `compat_sync_check.py` tests (61) pass; harness verifier loads cleanly; `check-source-contracts.py` exits 0.

No version bump (`compat/` + `tools/scripts/` are not versioned surfaces).

**Follow-up (out of scope here):** wire `compat_aggregate.py check` + `test_compat_aggregate.py` into a CI workflow that already runs `tools/scripts/test_*.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)