### PR TITLE
feat(inspect): add Phase 6.2 texture atlas viewer to the inspector overlay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.178.2
+    VERSION 0.179.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/render/include/pulp/render/atlas_inventory.hpp
+++ b/core/render/include/pulp/render/atlas_inventory.hpp
@@ -1,0 +1,203 @@
+#pragma once
+
+// atlas_inventory.hpp — read-only GPU texture-atlas inventory.
+//
+// Phase 6.2 of the inspector GPU-perf roadmap
+// (planning/2026-05-19-inspector-phase6-gpu-perf-spike.md § Phase 6.2).
+//
+// The render layer owns several shelf-packed texture atlases — the
+// glyph atlas (SDF text), the image atlas, the gradient ramp atlas,
+// and the path atlas (texture_atlas.hpp). Each one is a GPU texture
+// page that small bitmaps are packed into; when an atlas fills up,
+// rendering either thrashes (evict + re-pack churn) or spills to a
+// fresh page. "Is my SDF atlas thrashing?" is a real perf question.
+//
+// `AtlasInventory` is the answer surface: a small, render-layer-owned
+// collection of `AtlasInfo` snapshots that the inspector overlay's
+// atlas viewer renders. It deliberately holds *value snapshots*, not
+// pointers to live atlases — the inspector reads it on the UI thread
+// while the render thread keeps mutating the real atlases, so a
+// snapshot taken at a known point is the safe contract.
+//
+// What it surfaces is exactly what the Pulp-owned atlas classes can
+// honestly report: per-atlas pixel dimensions, a shelf-packer
+// occupancy estimate, the live entry (packed-region) count, and a
+// page count. Skia manages its own internal SkStrike glyph cache
+// separately and does not expose page-level introspection through a
+// stable public API; this inventory does NOT fabricate numbers for
+// it — it reports the atlases Pulp itself packs.
+
+#include <pulp/render/texture_atlas.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace pulp::render {
+
+/// Which kind of atlas an AtlasInfo describes. Mirrors the atlas
+/// classes in texture_atlas.hpp so the inspector can label rows and
+/// (later) pick per-kind colors.
+enum class AtlasKind {
+    glyph,     ///< GlyphAtlas — SDF / custom-text glyph cache.
+    image,     ///< ImageAtlas — packed small images.
+    gradient,  ///< GradientAtlas — evaluated gradient ramps (row-packed).
+    path,      ///< PathAtlas — rasterized vector paths.
+};
+
+/// Human-readable name for an AtlasKind — used by the inspector panel
+/// and by tests.
+inline const char* atlas_kind_name(AtlasKind kind) {
+    switch (kind) {
+        case AtlasKind::glyph:    return "glyph";
+        case AtlasKind::image:    return "image";
+        case AtlasKind::gradient: return "gradient";
+        case AtlasKind::path:     return "path";
+    }
+    return "unknown";
+}
+
+/// A value-snapshot of one texture atlas's state, taken at a known
+/// point. Everything here is a plain copy — safe to read on the UI
+/// thread after the render thread has moved on.
+struct AtlasInfo {
+    AtlasKind kind = AtlasKind::image;
+    std::string label;       ///< Display label (defaults to the kind name).
+    int width = 0;           ///< Atlas page width in texels.
+    int height = 0;          ///< Atlas page height in texels.
+    int pages = 1;           ///< Number of GPU texture pages.
+    std::size_t entries = 0; ///< Live packed regions (glyphs/images/etc).
+    float occupancy = 0.0f;  ///< Shelf-packer fill fraction, [0, 1].
+
+    /// Total addressable texels across every page.
+    std::size_t texel_capacity() const {
+        return static_cast<std::size_t>(width) *
+               static_cast<std::size_t>(height) *
+               static_cast<std::size_t>(pages < 1 ? 1 : pages);
+    }
+
+    /// Occupancy clamped to [0, 1] and expressed as a 0-100 percentage,
+    /// rounded to the nearest integer — the form the panel prints.
+    int occupancy_percent() const {
+        float clamped = occupancy;
+        if (clamped < 0.0f) clamped = 0.0f;
+        if (clamped > 1.0f) clamped = 1.0f;
+        return static_cast<int>(clamped * 100.0f + 0.5f);
+    }
+};
+
+/// A read-only collection of atlas snapshots for the inspector.
+///
+/// The render layer (or a test) builds an inventory by calling
+/// `snapshot()` on each live atlas; the inspector overlay is then
+/// handed a pointer to the inventory and renders one row per entry.
+/// The inventory invents no data — every field of every AtlasInfo
+/// comes straight from an atlas's own introspection accessors.
+class AtlasInventory {
+public:
+    /// Capture a snapshot of an ImageAtlas / GlyphAtlas / PathAtlas —
+    /// any atlas type exposing width()/height()/occupancy()/
+    /// entry_count(). `pages` defaults to 1 (Pulp's atlas classes are
+    /// single-page today); a caller that spills across pages can pass
+    /// the real count.
+    template <typename Atlas>
+    static AtlasInfo snapshot(const Atlas& atlas, AtlasKind kind,
+                              std::string label = {}, int pages = 1) {
+        AtlasInfo info;
+        info.kind = kind;
+        info.label = label.empty() ? atlas_kind_name(kind)
+                                    : std::move(label);
+        info.width = atlas.width();
+        info.height = atlas.height();
+        info.pages = pages < 1 ? 1 : pages;
+        info.entries = atlas.entry_count();
+        info.occupancy = atlas.occupancy();
+        return info;
+    }
+
+    /// GradientAtlas is row-packed (no width/height) — give it an
+    /// explicit dedicated snapshot. The ramp width is a caller-supplied
+    /// convention (gradient ramps are typically 256 texels wide); the
+    /// page height is the row budget.
+    static AtlasInfo snapshot_gradient(const GradientAtlas& atlas,
+                                       std::string label = {},
+                                       int ramp_width = 256) {
+        AtlasInfo info;
+        info.kind = AtlasKind::gradient;
+        info.label = label.empty() ? atlas_kind_name(AtlasKind::gradient)
+                                    : std::move(label);
+        info.width = ramp_width;
+        info.height = atlas.row_capacity();
+        info.pages = 1;
+        info.entries = atlas.entry_count();
+        info.occupancy = atlas.occupancy();
+        return info;
+    }
+
+    /// Append a pre-built AtlasInfo snapshot.
+    void add(AtlasInfo info) { atlases_.push_back(std::move(info)); }
+
+    /// Snapshot any width/height/occupancy atlas straight into the
+    /// inventory.
+    template <typename Atlas>
+    void add_atlas(const Atlas& atlas, AtlasKind kind,
+                   std::string label = {}, int pages = 1) {
+        atlases_.push_back(snapshot(atlas, kind, std::move(label), pages));
+    }
+
+    /// Snapshot a GradientAtlas straight into the inventory.
+    void add_gradient(const GradientAtlas& atlas, std::string label = {},
+                      int ramp_width = 256) {
+        atlases_.push_back(
+            snapshot_gradient(atlas, std::move(label), ramp_width));
+    }
+
+    /// Drop every snapshot — call before re-populating each frame the
+    /// inspector refreshes.
+    void clear() { atlases_.clear(); }
+
+    /// All atlas snapshots, in insertion order.
+    const std::vector<AtlasInfo>& atlases() const { return atlases_; }
+
+    /// Number of atlas snapshots held.
+    std::size_t size() const { return atlases_.size(); }
+
+    /// True when no atlas has been registered — the inspector renders
+    /// the "GPU atlas unavailable" empty state in this case.
+    bool empty() const { return atlases_.empty(); }
+
+    /// Total GPU texture pages across every registered atlas.
+    int total_pages() const {
+        int total = 0;
+        for (const auto& a : atlases_)
+            total += (a.pages < 1 ? 1 : a.pages);
+        return total;
+    }
+
+    /// Total live packed regions (glyphs / images / ramps / paths)
+    /// across every atlas.
+    std::size_t total_entries() const {
+        std::size_t total = 0;
+        for (const auto& a : atlases_) total += a.entries;
+        return total;
+    }
+
+    /// Mean occupancy across all atlases, in [0, 1]; 0 when empty.
+    float average_occupancy() const {
+        if (atlases_.empty()) return 0.0f;
+        float sum = 0.0f;
+        for (const auto& a : atlases_) {
+            float o = a.occupancy;
+            if (o < 0.0f) o = 0.0f;
+            if (o > 1.0f) o = 1.0f;
+            sum += o;
+        }
+        return sum / static_cast<float>(atlases_.size());
+    }
+
+private:
+    std::vector<AtlasInfo> atlases_;
+};
+
+} // namespace pulp::render

--- a/core/render/include/pulp/render/texture_atlas.hpp
+++ b/core/render/include/pulp/render/texture_atlas.hpp
@@ -25,6 +25,37 @@ public:
     int width() const { return width_; }
     int height() const { return height_; }
 
+    /// Area of the atlas surface (width × height), in texels.
+    /// Read-only introspection — used by the inspector's atlas viewer.
+    std::size_t capacity() const {
+        return static_cast<std::size_t>(width_) *
+               static_cast<std::size_t>(height_);
+    }
+
+    /// Texels consumed by the shelf allocator so far. This is the
+    /// shelf-packed *footprint* — every completed shelf counts its full
+    /// height across the atlas width, plus the in-progress shelf counts
+    /// up to its current write cursor. It is an upper bound on the live
+    /// pixel area (shelf packing leaves gaps), which is exactly the
+    /// number that answers "how close is this atlas to full?".
+    std::size_t used_area() const {
+        const std::size_t completed =
+            static_cast<std::size_t>(shelf_y_) *
+            static_cast<std::size_t>(width_);
+        const std::size_t in_progress =
+            static_cast<std::size_t>(shelf_x_) *
+            static_cast<std::size_t>(shelf_h_);
+        return completed + in_progress;
+    }
+
+    /// Fraction of the atlas the shelf allocator has consumed, in
+    /// [0, 1]. Returns 0 for a degenerate (zero-area) atlas.
+    float occupancy() const {
+        const std::size_t cap = capacity();
+        if (cap == 0) return 0.0f;
+        return static_cast<float>(used_area()) / static_cast<float>(cap);
+    }
+
 private:
     int width_, height_;
     int shelf_y_, shelf_h_, shelf_x_;
@@ -54,6 +85,11 @@ public:
 
     size_t entry_count() const { return entries_.size(); }
 
+    /// Read-only introspection for the inspector's atlas viewer.
+    int width() const { return packer_.width(); }
+    int height() const { return packer_.height(); }
+    float occupancy() const { return packer_.occupancy(); }
+
 private:
     AtlasPacker packer_;
     std::unordered_map<uint64_t, Entry> entries_;
@@ -77,6 +113,17 @@ public:
     size_t evict_stale(uint64_t current_frame, uint64_t max_age = 120);
 
     size_t entry_count() const { return entries_.size(); }
+
+    /// Read-only introspection for the inspector's atlas viewer. A
+    /// GradientAtlas is row-packed (one ramp per row) rather than
+    /// shelf-packed, so occupancy is simply allocated rows over the
+    /// row budget.
+    int row_capacity() const { return max_rows_; }
+    int rows_used() const { return next_row_; }
+    float occupancy() const {
+        if (max_rows_ <= 0) return 0.0f;
+        return static_cast<float>(next_row_) / static_cast<float>(max_rows_);
+    }
 
 private:
     std::unordered_map<uint64_t, Entry> entries_;
@@ -104,6 +151,11 @@ public:
 
     size_t entry_count() const { return entries_.size(); }
 
+    /// Read-only introspection for the inspector's atlas viewer.
+    int width() const { return packer_.width(); }
+    int height() const { return packer_.height(); }
+    float occupancy() const { return packer_.occupancy(); }
+
 private:
     AtlasPacker packer_;
     std::unordered_map<uint64_t, Entry> entries_;
@@ -127,6 +179,11 @@ public:
     size_t evict_stale(uint64_t current_frame, uint64_t max_age = 600);
 
     size_t entry_count() const { return entries_.size(); }
+
+    /// Read-only introspection for the inspector's atlas viewer.
+    int width() const { return packer_.width(); }
+    int height() const { return packer_.height(); }
+    float occupancy() const { return packer_.occupancy(); }
 
 private:
     AtlasPacker packer_;

--- a/inspect/include/pulp/inspect/inspector_overlay.hpp
+++ b/inspect/include/pulp/inspect/inspector_overlay.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 namespace pulp::render { class RenderPassManager; }
+namespace pulp::render { class AtlasInventory; }
 
 namespace pulp::inspect {
 
@@ -49,6 +50,20 @@ public:
 
     // ── Data sources ────────────────────────────────────────────────
     void set_render_pass_manager(render::RenderPassManager* rpm) { rpm_ = rpm; }
+
+    /// Phase 6.2 — attach the render layer's texture-atlas inventory so
+    /// the atlas viewer tab (`A` hotkey) can report per-atlas
+    /// dimensions, page count, and occupancy. The inventory is a
+    /// value-snapshot collection owned by the render/host layer; the
+    /// overlay only reads it. Passing nullptr (the default) makes the
+    /// atlas tab render its "GPU atlas unavailable" empty state — the
+    /// inspector never crashes when no GPU atlas is wired.
+    void set_atlas_inventory(const render::AtlasInventory* inv) {
+        atlas_inventory_ = inv;
+    }
+    const render::AtlasInventory* atlas_inventory() const {
+        return atlas_inventory_;
+    }
 
     /// Phase 0b PR-C-1 — connect the inspector overlay to the in-process
     /// TweakStore so gesture detectors can persist direct-manipulation
@@ -397,6 +412,47 @@ public:
         return reconcile_rows_.size();
     }
 
+    // ── Phase 6.2 — texture atlas viewer ────────────────────────────
+    //
+    // Spec: planning/2026-05-19-inspector-phase6-gpu-perf-spike.md
+    // § Phase 6.2. The render layer packs small bitmaps into a handful
+    // of shelf-packed GPU texture atlases — the glyph atlas (SDF text),
+    // the image atlas, the gradient ramp atlas, the path atlas. When an
+    // atlas fills, rendering thrashes (evict + re-pack churn). The
+    // atlas viewer answers "is my SDF atlas thrashing?" without leaving
+    // the inspector.
+    //
+    // It is a *read-only* report over a render::AtlasInventory — a
+    // value-snapshot collection the host wires in via
+    // set_atlas_inventory(). The tab invents no parallel data model:
+    // every per-atlas figure (dimensions, page count, occupancy, entry
+    // count) comes straight from the Pulp-owned atlas classes'
+    // introspection accessors. When no inventory is attached the tab
+    // renders a graceful "GPU atlas unavailable" empty state.
+    //
+    // The tab toggles with the `A` key (atlas) and, when on, takes over
+    // the property-panel region exactly like the Phase 6.1 pass viewer
+    // and Phase 5.2 reconciliation tab — the tree section above stays
+    // put so the user keeps navigation context.
+
+    /// Toggle the texture-atlas viewer tab. Off by default so the
+    /// inspector panel layout is unchanged until the user opts in
+    /// (`A` key in handle_key_event). When on, the tab replaces the
+    /// property section, mirroring the Phase 6.1 pass viewer.
+    void set_atlas_viewer_visible(bool visible) {
+        atlas_viewer_visible_ = visible;
+    }
+    bool atlas_viewer_visible() const { return atlas_viewer_visible_; }
+    void toggle_atlas_viewer() {
+        atlas_viewer_visible_ = !atlas_viewer_visible_;
+    }
+
+    /// Number of atlas rows the viewer laid out on the most recent
+    /// paint() while it was visible. Visible for tests so they can
+    /// assert the tab rendered the expected rows without scraping
+    /// pixels. Zero when the tab is hidden or no inventory is wired.
+    std::size_t atlas_row_count() const { return atlas_row_count_; }
+
     // ── Phase 3e — 20× zoom loupe ───────────────────────────────────
     //
     // A magnified-pixel preview panel ("loupe") that shows the region
@@ -567,6 +623,20 @@ private:
     float reconcile_scroll_y_ = 0.0f;
     std::vector<ReconcileRow> reconcile_rows_;
 
+    // ── Phase 6.2 — texture-atlas-viewer state ──────────────────────
+    //
+    // atlas_viewer_visible_ tracks the `A`-key toggle; off by default
+    // so the panel layout is unchanged until the user opts in.
+    // atlas_inventory_ is a non-owning pointer to the render layer's
+    // snapshot collection (nullptr → graceful empty state).
+    // atlas_scroll_y_ keeps the row list stable across frames;
+    // atlas_row_count_ caches how many rows the last paint laid out so
+    // atlas_row_count() can report it to tests without scraping pixels.
+    bool atlas_viewer_visible_ = false;
+    const render::AtlasInventory* atlas_inventory_ = nullptr;
+    float atlas_scroll_y_ = 0.0f;
+    std::size_t atlas_row_count_ = 0;
+
     // Phase 3a — drag-handles state. Off by default so the inspector
     // behaves identically to the pre-3a build until the user opts in
     // (D-key toggle in handle_key_event).
@@ -668,6 +738,13 @@ private:
     /// reconciliation-status badge (locked / drift / unresolvable).
     /// Repopulates reconcile_rows_ with this frame's classified rows.
     void paint_reconcile_tab(Canvas& canvas, float x, float y, float w, float h);
+
+    /// Phase 6.2 — render the texture-atlas viewer into the panel
+    /// region normally occupied by the property section. Each
+    /// registered atlas gets a row showing its kind label, pixel
+    /// dimensions, page count, live entry count, and an occupancy bar.
+    /// Updates atlas_row_count_ with the number of rows laid out.
+    void paint_atlas_tab(Canvas& canvas, float x, float y, float w, float h);
 
     // ── Panel hit testing ───────────────────────────────────────────
     bool point_in_panel(Point p) const;

--- a/inspect/src/inspector_overlay.cpp
+++ b/inspect/src/inspector_overlay.cpp
@@ -4,6 +4,7 @@
 #include <pulp/inspect/tweak_store.hpp>
 #include <pulp/view/inspector.hpp>
 #include <pulp/render/render_pass.hpp>
+#include <pulp/render/atlas_inventory.hpp>
 
 #include <choc/text/choc_JSON.h>
 
@@ -115,6 +116,11 @@ void InspectorOverlay::set_active(bool active) {
         // The R-key toggle state itself is left intact (mirrors how
         // the tweaks panel keeps tweaks_panel_visible_ across opens).
         reconcile_rows_.clear();
+        // Phase 6.2 — reset the atlas viewer's laid-out row count so
+        // atlas_row_count() reports 0 while the inspector is shut. As
+        // with the reconciliation tab the `A`-key toggle state is left
+        // intact so re-opening the inspector restores the same tab.
+        atlas_row_count_ = 0;
     }
 }
 
@@ -481,6 +487,17 @@ bool InspectorOverlay::handle_key_event(const KeyEvent& event) {
     if (active_ && editing_field_.empty() && event.key == KeyCode::r &&
         event.is_down && event.modifiers == 0) {
         toggle_reconcile_tab();
+        return true;
+    }
+
+    // Phase 6.2 — A toggles the texture-atlas viewer tab (no modifier;
+    // only while the inspector is active, same opt-in discipline as the
+    // D / E / P / Z / R toggles). Guarded behind not-editing so typing
+    // an 'a' into a field-edit buffer can't flip the tab. D/E/T/J/P/Z/R
+    // are already claimed, so A ("atlas") is the natural free letter.
+    if (active_ && editing_field_.empty() && event.key == KeyCode::a &&
+        event.is_down && event.modifiers == 0) {
+        toggle_atlas_viewer();
         return true;
     }
 
@@ -1088,17 +1105,26 @@ void InspectorOverlay::paint_panel(Canvas& canvas) {
     // this region instead of the property panel; the tree section above
     // is untouched so the user keeps navigation context. Phase 5.2 —
     // the reconciliation tab (R-key) takes over the same region with
-    // the same discipline. The pass viewer wins when both are toggled
-    // (it is the older surface), and reconcile_rows_ is cleared so
-    // reconcile_row_count() never reports a stale layout.
+    // the same discipline. Phase 6.2 — the texture-atlas viewer (A-key)
+    // is the third tab to claim this region. Precedence when multiple
+    // are toggled, oldest surface wins: pass viewer > reconciliation >
+    // atlas viewer > props. The losers' cached row counts are reset so
+    // reconcile_row_count() / atlas_row_count() never report a stale
+    // layout for a tab that did not paint this frame.
     auto paint_middle = [&](float x, float y, float w, float h) {
         if (pass_viewer_enabled_) {
             reconcile_rows_.clear();
+            atlas_row_count_ = 0;
             paint_pass_attribution(canvas, x, y, w, h);
         } else if (reconcile_tab_visible_) {
+            atlas_row_count_ = 0;
             paint_reconcile_tab(canvas, x, y, w, h);
+        } else if (atlas_viewer_visible_) {
+            reconcile_rows_.clear();
+            paint_atlas_tab(canvas, x, y, w, h);
         } else {
             reconcile_rows_.clear();
+            atlas_row_count_ = 0;
             paint_props_section(canvas, x, y, w, h);
         }
     };
@@ -2051,6 +2077,113 @@ void InspectorOverlay::paint_reconcile_tab(Canvas& canvas, float x, float y,
                              row_y + 14);
         }
         row_y += kRowHeight;
+    }
+
+    canvas.restore();
+}
+
+// ── Phase 6.2 — Texture atlas viewer ────────────────────────────────────────
+//
+// A read-only GPU-perf observability tab that answers "is my SDF atlas
+// thrashing?". It renders the render layer's texture-atlas inventory —
+// per-atlas dimensions, page count, live entry count, and a shelf-packer
+// occupancy bar. Like the Phase 6.1 pass viewer and Phase 5.2
+// reconciliation tab it takes over the property-panel region; it has no
+// interactive controls (purely informational), so there are no hit-rects
+// to record. Degrades gracefully to a "GPU atlas unavailable" line when
+// no inventory is wired (headless / GPU-off builds).
+
+void InspectorOverlay::paint_atlas_tab(Canvas& canvas, float x, float y,
+                                       float w, float h) {
+    // Occupancy bar colors: green when there's headroom, amber when the
+    // atlas is filling, red when nearly full (thrash risk). The amber/red
+    // pair matches the drift drawer + reconciliation tab so the GPU-perf
+    // surfaces read consistently.
+    const Color kBarTrack = Color::rgba(0.20f, 0.20f, 0.24f, 1.0f);
+    const Color kBarLow   = Color::rgba(0.35f, 0.85f, 0.45f, 1.0f);
+    const Color kBarMid   = Color::rgba(0.95f, 0.65f, 0.25f, 1.0f);
+    const Color kBarHigh  = Color::rgba(0.95f, 0.40f, 0.38f, 1.0f);
+
+    canvas.set_font("monospace", kFontSize);
+
+    // Section heading.
+    canvas.set_fill_color(kHighlightStroke);
+    canvas.fill_text("Texture Atlases (A)", x, y + 11);
+
+    // No inventory wired — graceful empty state. This is the headless /
+    // GPU-off path; the tab must never crash here.
+    if (!atlas_inventory_ || atlas_inventory_->empty()) {
+        atlas_row_count_ = 0;
+        canvas.set_fill_color(kPanelDim);
+        canvas.fill_text("GPU atlas unavailable", x, y + 11 + kRowHeight);
+        return;
+    }
+
+    const auto& atlases = atlas_inventory_->atlases();
+    atlas_row_count_ = atlases.size();
+
+    // Summary line: total pages + total packed entries, right-aligned in
+    // the header — mirrors the reconciliation tab's per-status summary.
+    {
+        std::ostringstream summary;
+        summary << atlas_inventory_->total_pages() << " pages  "
+                << atlas_inventory_->total_entries() << " entries";
+        canvas.set_fill_color(kPanelDim);
+        float sw = canvas.measure_text(summary.str());
+        canvas.fill_text(summary.str(), x + w - sw, y + 11);
+    }
+
+    // Each atlas occupies a two-line row: a label/dimensions/entries
+    // line, then an occupancy bar with a percentage readout.
+    constexpr float kAtlasRowH = kRowHeight * 2.0f + 6.0f;
+
+    canvas.save();
+    float list_top = y + kRowHeight;
+    canvas.clip_rect(x, list_top, w, h - kRowHeight);
+
+    float row_y = list_top - atlas_scroll_y_;
+    for (const auto& a : atlases) {
+        const bool visible = row_y > list_top - kAtlasRowH && row_y < y + h;
+        if (visible) {
+            // Line 1: "<label>  <W>x<H>" left, "<N> entries" right.
+            std::ostringstream dims;
+            dims << a.label << "  " << a.width << "x" << a.height;
+            if (a.pages > 1) dims << " x" << a.pages << "p";
+            canvas.set_fill_color(kPanelText);
+            canvas.fill_text(dims.str(), x, row_y + 12);
+
+            std::ostringstream ent;
+            ent << a.entries << " entries";
+            canvas.set_fill_color(kPanelDim);
+            float ew = canvas.measure_text(ent.str());
+            canvas.fill_text(ent.str(), x + w - ew, row_y + 12);
+
+            // Line 2: occupancy bar + percent readout.
+            const int pct = a.occupancy_percent();
+            const Color& fill = pct >= 85 ? kBarHigh
+                              : pct >= 60 ? kBarMid
+                                          : kBarLow;
+            const float bar_y = row_y + kRowHeight;
+            const float bar_h = 8.0f;
+            std::ostringstream pctstr;
+            pctstr << pct << "%";
+            const float pct_w = canvas.measure_text(pctstr.str()) + 6.0f;
+            const float bar_w = w - pct_w;
+
+            canvas.set_fill_color(kBarTrack);
+            canvas.fill_rounded_rect(x, bar_y, bar_w, bar_h, 2.0f);
+            float frac = static_cast<float>(pct) / 100.0f;
+            if (frac > 0.0f) {
+                canvas.set_fill_color(fill);
+                canvas.fill_rounded_rect(x, bar_y,
+                                         std::max(2.0f, bar_w * frac),
+                                         bar_h, 2.0f);
+            }
+            canvas.set_fill_color(fill);
+            canvas.fill_text(pctstr.str(), x + w - pct_w + 6.0f,
+                             bar_y + bar_h);
+        }
+        row_y += kAtlasRowH;
     }
 
     canvas.restore();

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -2,6 +2,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/inspect/inspector_window.hpp>
+#include <pulp/render/atlas_inventory.hpp>
 #include <pulp/view/inspector.hpp>
 #include <pulp/view/widgets.hpp>
 
@@ -3892,4 +3893,178 @@ TEST_CASE("InspectorOverlay Phase 5.2: locking a tweak moves it out of drift",
     REQUIRE(after.locked_count == 1);
     REQUIRE(after.drifted_count == 1);
     REQUIRE(after.unresolvable_count == 1);  // figma:5:gone unchanged
+}
+
+// ── Phase 6.2 — texture atlas viewer ────────────────────────────────────────
+//
+// Spec: planning/2026-05-19-inspector-phase6-gpu-perf-spike.md § Phase 6.2.
+// The atlas viewer is a read-only GPU-perf observability tab over the
+// render layer's AtlasInventory. These headless tests drive it through
+// the RecordingCanvas — the tab toggles via the `A` hotkey, renders one
+// row per registered atlas, and degrades gracefully when no inventory is
+// attached (GPU-off / headless builds). It invents no data: every figure
+// comes from the Pulp-owned atlas classes' introspection accessors.
+
+namespace {
+
+using pulp::render::AtlasInfo;
+using pulp::render::AtlasInventory;
+using pulp::render::AtlasKind;
+using pulp::render::GlyphAtlas;
+using pulp::render::ImageAtlas;
+
+// Build a small inventory snapshotting two real, partially-packed atlases
+// so the viewer has honest dimensions + occupancy to render.
+AtlasInventory make_atlas_inventory() {
+    static ImageAtlas images(256);
+    static GlyphAtlas glyphs(512);
+    pulp::render::AtlasPacker::Region r{};
+    images.allocate(1, 128, 256, r);   // 50% of the image atlas.
+    glyphs.allocate(2, 512, 256, r);   // 50% of the glyph atlas.
+
+    AtlasInventory inv;
+    inv.add_atlas(images, AtlasKind::image, "images");
+    inv.add_atlas(glyphs, AtlasKind::glyph);
+    return inv;
+}
+
+} // namespace
+
+TEST_CASE("InspectorOverlay Phase 6.2: A key toggles the atlas viewer",
+          "[inspect][overlay][atlas][phase6.2]") {
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+
+    REQUIRE_FALSE(overlay.atlas_viewer_visible());
+
+    KeyEvent a;
+    a.key = KeyCode::a;
+    a.is_down = true;
+    a.modifiers = 0;
+    REQUIRE(overlay.handle_key_event(a));
+    REQUIRE(overlay.atlas_viewer_visible());
+
+    REQUIRE(overlay.handle_key_event(a));
+    REQUIRE_FALSE(overlay.atlas_viewer_visible());
+}
+
+TEST_CASE("InspectorOverlay Phase 6.2: A key ignored when inspector inactive",
+          "[inspect][overlay][atlas][phase6.2]") {
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    InspectorOverlay overlay(root);
+    // Not active — the A hotkey must not fire so it can't collide with
+    // a plain text field in the host UI.
+
+    KeyEvent a;
+    a.key = KeyCode::a;
+    a.is_down = true;
+    a.modifiers = 0;
+    REQUIRE_FALSE(overlay.handle_key_event(a));
+    REQUIRE_FALSE(overlay.atlas_viewer_visible());
+}
+
+TEST_CASE("InspectorOverlay Phase 6.2: viewer renders a row per atlas",
+          "[inspect][overlay][atlas][phase6.2]") {
+    View root;
+    root.set_id("root");
+    // Tall enough that the panel's lower section fits both atlas rows.
+    root.set_bounds({0, 0, 500, 720});
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+
+    AtlasInventory inv = make_atlas_inventory();
+    overlay.set_atlas_inventory(&inv);
+    overlay.set_atlas_viewer_visible(true);
+
+    pulp::canvas::RecordingCanvas canvas;
+    overlay.paint(canvas);
+    REQUIRE(canvas.command_count() > 0);
+
+    // The viewer heading and both atlas labels must appear.
+    REQUIRE(count_text_containing(canvas, "Texture Atlases") >= 1);
+    REQUIRE(count_text_containing(canvas, "images") >= 1);
+    REQUIRE(count_text_containing(canvas, "glyph") >= 1);
+    // Each atlas printed an occupancy percentage — both atlases are at
+    // 50% so a "50%" readout is present.
+    REQUIRE(count_text_containing(canvas, "50%") >= 1);
+    // Two atlases were registered → two laid-out rows.
+    REQUIRE(overlay.atlas_row_count() == 2);
+}
+
+TEST_CASE("InspectorOverlay Phase 6.2: viewer degrades gracefully with no inventory",
+          "[inspect][overlay][atlas][phase6.2]") {
+    View root;
+    root.set_bounds({0, 0, 500, 320});
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    overlay.set_atlas_viewer_visible(true);
+    // No AtlasInventory attached — the GPU-off / headless path.
+
+    pulp::canvas::RecordingCanvas canvas;
+    overlay.paint(canvas);  // must not crash.
+    REQUIRE(count_text_containing(canvas, "GPU atlas unavailable") >= 1);
+    REQUIRE(overlay.atlas_row_count() == 0);
+}
+
+TEST_CASE("InspectorOverlay Phase 6.2: empty inventory shows the unavailable state",
+          "[inspect][overlay][atlas][phase6.2]") {
+    View root;
+    root.set_bounds({0, 0, 500, 320});
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    overlay.set_atlas_viewer_visible(true);
+
+    AtlasInventory empty;  // attached but holds no atlases.
+    overlay.set_atlas_inventory(&empty);
+
+    pulp::canvas::RecordingCanvas canvas;
+    overlay.paint(canvas);
+    REQUIRE(count_text_containing(canvas, "GPU atlas unavailable") >= 1);
+    REQUIRE(overlay.atlas_row_count() == 0);
+}
+
+TEST_CASE("InspectorOverlay Phase 6.2: dismissing the inspector clears atlas rows",
+          "[inspect][overlay][atlas][phase6.2]") {
+    View root;
+    root.set_bounds({0, 0, 500, 720});
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+
+    AtlasInventory inv = make_atlas_inventory();
+    overlay.set_atlas_inventory(&inv);
+    overlay.set_atlas_viewer_visible(true);
+
+    pulp::canvas::RecordingCanvas canvas;
+    overlay.paint(canvas);
+    REQUIRE(overlay.atlas_row_count() == 2);
+
+    // Closing the inspector resets the laid-out row count but leaves the
+    // A-key toggle intact so re-opening restores the same tab.
+    overlay.set_active(false);
+    REQUIRE(overlay.atlas_row_count() == 0);
+    REQUIRE(overlay.atlas_viewer_visible());
+}
+
+TEST_CASE("InspectorOverlay Phase 6.2: pass viewer takes precedence over atlas tab",
+          "[inspect][overlay][atlas][phase6.2]") {
+    View root;
+    root.set_bounds({0, 0, 500, 720});
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+
+    AtlasInventory inv = make_atlas_inventory();
+    overlay.set_atlas_inventory(&inv);
+    // Both tabs toggled on — the pass viewer is the older surface and
+    // wins; the atlas tab must not paint, and its row count resets.
+    overlay.set_atlas_viewer_visible(true);
+    overlay.set_pass_viewer_enabled(true);
+
+    pulp::canvas::RecordingCanvas canvas;
+    overlay.paint(canvas);
+    REQUIRE(count_text_containing(canvas, "Render Passes") >= 1);
+    REQUIRE(count_text_containing(canvas, "Texture Atlases") == 0);
+    REQUIRE(overlay.atlas_row_count() == 0);
 }

--- a/test/test_texture_atlas.cpp
+++ b/test/test_texture_atlas.cpp
@@ -1,5 +1,9 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 #include <pulp/render/texture_atlas.hpp>
+#include <pulp/render/atlas_inventory.hpp>
+
+#include <string>
 
 using namespace pulp::render;
 
@@ -430,4 +434,185 @@ TEST_CASE("BufferPool caps retained buffers at max_pool_size - issue-646",
         ++drained;
     }
     REQUIRE(drained == 32);
+}
+
+// ── Phase 6.2 — atlas introspection accessors ───────────────────────────────
+//
+// Spec: planning/2026-05-19-inspector-phase6-gpu-perf-spike.md § Phase 6.2.
+// The inspector's texture-atlas viewer reads per-atlas dimensions and a
+// shelf-packer occupancy estimate. These tests pin the read-only accessors
+// added to AtlasPacker / ImageAtlas / GlyphAtlas / GradientAtlas / PathAtlas.
+
+TEST_CASE("AtlasPacker reports capacity and occupancy - phase6.2",
+          "[render][atlas][phase6.2]") {
+    AtlasPacker p(64, 64);
+    REQUIRE(p.capacity() == 64u * 64u);
+    REQUIRE(p.used_area() == 0u);
+    REQUIRE(p.occupancy() == Catch::Approx(0.0f));
+
+    AtlasPacker::Region r{};
+    // Pack a 32×64 column on the first shelf: the in-progress shelf is
+    // 32 wide × 64 tall → 2048 texels of a 4096-texel atlas.
+    REQUIRE(p.allocate(32, 64, r));
+    REQUIRE(p.used_area() == 32u * 64u);
+    REQUIRE(p.occupancy() == Catch::Approx(0.5f));
+
+    // Fill the rest of the shelf — atlas is now fully occupied.
+    REQUIRE(p.allocate(32, 64, r));
+    REQUIRE(p.occupancy() == Catch::Approx(1.0f));
+}
+
+TEST_CASE("AtlasPacker occupancy is zero for a degenerate atlas - phase6.2",
+          "[render][atlas][phase6.2]") {
+    AtlasPacker p(0, 0);
+    REQUIRE(p.capacity() == 0u);
+    REQUIRE(p.occupancy() == Catch::Approx(0.0f));  // no divide-by-zero.
+}
+
+TEST_CASE("ImageAtlas exposes dimensions and occupancy - phase6.2",
+          "[render][atlas][phase6.2]") {
+    ImageAtlas atlas(128);
+    REQUIRE(atlas.width() == 128);
+    REQUIRE(atlas.height() == 128);
+    REQUIRE(atlas.occupancy() == Catch::Approx(0.0f));
+
+    AtlasPacker::Region r{};
+    REQUIRE(atlas.allocate(1, 64, 128, r));  // half the page width.
+    REQUIRE(atlas.occupancy() == Catch::Approx(0.5f));
+    REQUIRE(atlas.entry_count() == 1);
+}
+
+TEST_CASE("GlyphAtlas and PathAtlas expose dimensions - phase6.2",
+          "[render][atlas][phase6.2]") {
+    GlyphAtlas glyphs(256);
+    REQUIRE(glyphs.width() == 256);
+    REQUIRE(glyphs.height() == 256);
+    REQUIRE(glyphs.occupancy() == Catch::Approx(0.0f));
+
+    PathAtlas paths(512);
+    REQUIRE(paths.width() == 512);
+    REQUIRE(paths.height() == 512);
+    REQUIRE(paths.occupancy() == Catch::Approx(0.0f));
+}
+
+TEST_CASE("GradientAtlas exposes row capacity and occupancy - phase6.2",
+          "[render][atlas][phase6.2]") {
+    GradientAtlas ga;
+    REQUIRE(ga.row_capacity() == 512);
+    REQUIRE(ga.rows_used() == 0);
+    REQUIRE(ga.occupancy() == Catch::Approx(0.0f));
+
+    int row = -1;
+    for (int i = 0; i < 256; ++i)
+        REQUIRE(ga.allocate(static_cast<uint64_t>(i), row));
+    REQUIRE(ga.rows_used() == 256);
+    REQUIRE(ga.occupancy() == Catch::Approx(0.5f));  // 256 / 512.
+}
+
+// ── Phase 6.2 — AtlasInventory aggregator ───────────────────────────────────
+
+TEST_CASE("AtlasInventory starts empty - phase6.2",
+          "[render][atlas][phase6.2]") {
+    AtlasInventory inv;
+    REQUIRE(inv.empty());
+    REQUIRE(inv.size() == 0);
+    REQUIRE(inv.total_pages() == 0);
+    REQUIRE(inv.total_entries() == 0u);
+    REQUIRE(inv.average_occupancy() == Catch::Approx(0.0f));
+}
+
+TEST_CASE("AtlasInventory snapshots a packed atlas - phase6.2",
+          "[render][atlas][phase6.2]") {
+    GlyphAtlas glyphs(256);
+    AtlasPacker::Region r{};
+    REQUIRE(glyphs.allocate(7, 128, 256, r));  // half-page → 50% occupancy.
+
+    AtlasInventory inv;
+    inv.add_atlas(glyphs, AtlasKind::glyph);
+    REQUIRE_FALSE(inv.empty());
+    REQUIRE(inv.size() == 1);
+
+    const AtlasInfo& info = inv.atlases().front();
+    REQUIRE(info.kind == AtlasKind::glyph);
+    REQUIRE(info.label == "glyph");          // defaults to the kind name.
+    REQUIRE(info.width == 256);
+    REQUIRE(info.height == 256);
+    REQUIRE(info.pages == 1);
+    REQUIRE(info.entries == 1u);
+    REQUIRE(info.occupancy == Catch::Approx(0.5f));
+    REQUIRE(info.occupancy_percent() == 50);
+    REQUIRE(info.texel_capacity() == 256u * 256u);
+}
+
+TEST_CASE("AtlasInventory snapshot_gradient uses row capacity as height - phase6.2",
+          "[render][atlas][phase6.2]") {
+    GradientAtlas ga;
+    int row = -1;
+    for (int i = 0; i < 128; ++i)
+        REQUIRE(ga.allocate(static_cast<uint64_t>(i), row));
+
+    AtlasInventory inv;
+    inv.add_gradient(ga);
+    const AtlasInfo& info = inv.atlases().front();
+    REQUIRE(info.kind == AtlasKind::gradient);
+    REQUIRE(info.width == 256);             // default ramp width.
+    REQUIRE(info.height == 512);            // GradientAtlas row budget.
+    REQUIRE(info.entries == 128u);
+    REQUIRE(info.occupancy == Catch::Approx(0.25f));  // 128 / 512.
+}
+
+TEST_CASE("AtlasInventory aggregates across multiple atlases - phase6.2",
+          "[render][atlas][phase6.2]") {
+    ImageAtlas images(128);
+    GlyphAtlas glyphs(256);
+    AtlasPacker::Region r{};
+    REQUIRE(images.allocate(1, 64, 128, r));   // 50% of the image atlas.
+    REQUIRE(glyphs.allocate(2, 256, 256, r));  // 100% of the glyph atlas.
+
+    AtlasInventory inv;
+    inv.add_atlas(images, AtlasKind::image, "images", /*pages=*/2);
+    inv.add_atlas(glyphs, AtlasKind::glyph);
+
+    REQUIRE(inv.size() == 2);
+    REQUIRE(inv.total_pages() == 3);          // 2 + 1.
+    REQUIRE(inv.total_entries() == 2u);       // one entry per atlas.
+    // average occupancy = (0.5 + 1.0) / 2 = 0.75.
+    REQUIRE(inv.average_occupancy() == Catch::Approx(0.75f));
+    // The custom label survives; the default falls back to the kind name.
+    REQUIRE(inv.atlases()[0].label == "images");
+    REQUIRE(inv.atlases()[1].label == "glyph");
+}
+
+TEST_CASE("AtlasInventory clear empties the collection - phase6.2",
+          "[render][atlas][phase6.2]") {
+    ImageAtlas images(64);
+    AtlasInventory inv;
+    inv.add_atlas(images, AtlasKind::image);
+    REQUIRE(inv.size() == 1);
+    inv.clear();
+    REQUIRE(inv.empty());
+    REQUIRE(inv.total_pages() == 0);
+}
+
+TEST_CASE("AtlasInfo occupancy_percent clamps out-of-range values - phase6.2",
+          "[render][atlas][phase6.2]") {
+    AtlasInfo over;
+    over.occupancy = 1.7f;
+    REQUIRE(over.occupancy_percent() == 100);  // clamped high.
+
+    AtlasInfo under;
+    under.occupancy = -0.3f;
+    REQUIRE(under.occupancy_percent() == 0);   // clamped low.
+
+    AtlasInfo mid;
+    mid.occupancy = 0.333f;
+    REQUIRE(mid.occupancy_percent() == 33);    // rounds to nearest.
+}
+
+TEST_CASE("atlas_kind_name covers every AtlasKind - phase6.2",
+          "[render][atlas][phase6.2]") {
+    REQUIRE(std::string(atlas_kind_name(AtlasKind::glyph))    == "glyph");
+    REQUIRE(std::string(atlas_kind_name(AtlasKind::image))    == "image");
+    REQUIRE(std::string(atlas_kind_name(AtlasKind::gradient)) == "gradient");
+    REQUIRE(std::string(atlas_kind_name(AtlasKind::path))     == "path");
 }


### PR DESCRIPTION
Adds a read-only GPU-perf observability tab to the inspector overlay
that visualizes the texture atlases the render layer packs: per-atlas
pixel dimensions, GPU page count, live entry count, and a shelf-packer
occupancy bar. It answers "is my SDF atlas thrashing?" without leaving
the inspector.

The tab toggles with the `A` hotkey, mirroring the Phase 6.1 per-pass
attribution viewer (`P`) and the Phase 5.2 reconciliation tab (`R`):
state field + hotkey handler + paint block + deactivation cleanup. When
multiple lower-section tabs are toggled, the oldest surface wins
(pass viewer > reconciliation > atlas viewer > props).

Data comes from a real render-layer accessor, not a parallel model:

  * texture_atlas.hpp gains read-only introspection accessors —
    AtlasPacker::capacity()/used_area()/occupancy(), and width()/
    height()/occupancy() on ImageAtlas/GlyphAtlas/PathAtlas plus
    row_capacity()/rows_used()/occupancy() on the row-packed
    GradientAtlas. All trivial inline getters, matching the existing
    width()/entry_count() style.
  * New core/render/include/pulp/render/atlas_inventory.hpp —
    AtlasInfo value-snapshot struct + AtlasInventory collection the
    host wires into the overlay via set_atlas_inventory(). It holds
    value snapshots (UI thread reads while the render thread mutates),
    invents no metrics, and reports only what the Pulp-owned atlas
    classes can honestly expose. Skia's internal SkStrike glyph cache
    is deliberately not fabricated.

Degrades gracefully: no inventory (or an empty one) renders a
"GPU atlas unavailable" line, never a crash — the headless / GPU-off
path.

Tests (inspect/ is under coverage hardening, #290):
  * test_texture_atlas.cpp — 12 new cases (451 assertions): the new
    introspection accessors + the AtlasInventory aggregator. Header-only,
    runs in GPU-off builds.
  * test_inspector.cpp — 7 new headless cases: the `A` hotkey toggles
    the tab, the tab lays out a row per atlas, the GPU-unavailable and
    empty-inventory states, deactivation clears the row count, and the
    pass-viewer-precedence path.
  All 125 inspector ctests and 40 texture-atlas cases pass.

Spec: planning/2026-05-19-inspector-phase6-gpu-perf-spike.md § Phase 6.2.

Version-Bump: skip reason="inspect/ is not a release surface"
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>