### PR TITLE
feat(state): add serialized state migrations

### DIFF
--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -134,6 +134,10 @@ predictable output, no MIDI.
   thread, don't recompute per block.
 - Removing a node invalidates its `NodeId`. Connections referencing a
   removed node are pruned automatically.
+- `.pulpgraph` schema changes must go through the graph serializer migration
+  path. Bump the graph format version, add a deterministic migrator for older
+  fixtures, and keep future-version loads fail-closed instead of silently
+  accepting fields the current reader does not understand.
 
 ## Common tripwires
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.100.0",
+      "version": "0.101.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.100.0"
+  "version": "0.101.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.179.0
+    VERSION 0.180.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/plugin_state_io.hpp
+++ b/core/format/include/pulp/format/plugin_state_io.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <span>
 #include <vector>
 
@@ -12,6 +13,16 @@ namespace pulp::format {
 class Processor;
 
 namespace plugin_state_io {
+
+using EnvelopeMigrationFn =
+    std::function<bool(std::span<const uint8_t> source,
+                       std::vector<uint8_t>& destination)>;
+
+uint32_t current_envelope_version();
+
+bool register_envelope_migration(uint32_t from_version,
+                                 uint32_t to_version,
+                                 EnvelopeMigrationFn migration);
 
 /// Serialize the host-facing plugin state blob for a Processor.
 ///

--- a/core/format/src/plugin_state_io.cpp
+++ b/core/format/src/plugin_state_io.cpp
@@ -7,7 +7,9 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <span>
+#include <utility>
 #include <vector>
 
 namespace pulp::format::plugin_state_io {
@@ -53,6 +55,7 @@ void clone_schema(const state::StateStore& source, state::StateStore& dest) {
     for (const auto& param : source.all_params()) {
         dest.add_parameter(param);
     }
+    dest.copy_state_migrations_from(source);
 }
 
 struct ParsedBlob {
@@ -60,7 +63,108 @@ struct ParsedBlob {
     std::span<const uint8_t> plugin_blob;
 };
 
-bool parse_blob(std::span<const uint8_t> bytes, ParsedBlob& parsed) {
+struct EnvelopeMigrationEntry {
+    uint32_t from_version = 0;
+    uint32_t to_version = 0;
+    EnvelopeMigrationFn migration;
+};
+
+std::vector<EnvelopeMigrationEntry>& envelope_migrations() {
+    static std::vector<EnvelopeMigrationEntry> migrations;
+    return migrations;
+}
+
+const EnvelopeMigrationEntry* find_envelope_migration(uint32_t from_version) {
+    for (const auto& entry : envelope_migrations()) {
+        if (entry.from_version == from_version) {
+            return &entry;
+        }
+    }
+    return nullptr;
+}
+
+std::optional<uint32_t> envelope_version(std::span<const uint8_t> bytes) {
+    if (!has_magic(bytes, kEnvelopeMagic)
+        || bytes.size() < (kEnvelopeHeaderSize + kEnvelopeFooterSize)) {
+        return std::nullopt;
+    }
+    return choc::memory::readLittleEndian<uint32_t>(bytes.data() + 4);
+}
+
+bool has_valid_envelope_crc(std::span<const uint8_t> bytes) {
+    if (!has_magic(bytes, kEnvelopeMagic)
+        || bytes.size() < (kEnvelopeHeaderSize + kEnvelopeFooterSize)) {
+        return false;
+    }
+
+    const uint32_t store_size =
+        choc::memory::readLittleEndian<uint32_t>(bytes.data() + 8);
+    const uint32_t plugin_size =
+        choc::memory::readLittleEndian<uint32_t>(bytes.data() + 12);
+    const std::size_t payload_size =
+        static_cast<std::size_t>(store_size) + static_cast<std::size_t>(plugin_size);
+
+    if (payload_size > (bytes.size() - kEnvelopeHeaderSize - kEnvelopeFooterSize)) {
+        return false;
+    }
+
+    const std::size_t expected_size =
+        kEnvelopeHeaderSize + payload_size + kEnvelopeFooterSize;
+    if (bytes.size() != expected_size) {
+        return false;
+    }
+
+    const std::size_t crc_offset = kEnvelopeHeaderSize + payload_size;
+    const uint32_t stored_crc =
+        choc::memory::readLittleEndian<uint32_t>(bytes.data() + crc_offset);
+    const uint32_t computed_crc = crc32_simple(bytes.data(), crc_offset);
+    return stored_crc == computed_crc;
+}
+
+bool migrate_envelope_to_current(std::span<const uint8_t> bytes,
+                                 std::vector<uint8_t>& migrated_storage) {
+    auto version = envelope_version(bytes);
+    if (!version.has_value() || *version > kEnvelopeVersion) {
+        return false;
+    }
+    if (!has_valid_envelope_crc(bytes)) {
+        return false;
+    }
+    if (*version == kEnvelopeVersion) {
+        migrated_storage.assign(bytes.begin(), bytes.end());
+        return true;
+    }
+
+    std::vector<uint8_t> current(bytes.begin(), bytes.end());
+    while (*version != kEnvelopeVersion) {
+        const auto* migration = find_envelope_migration(*version);
+        if (migration == nullptr
+            || migration->to_version <= *version
+            || migration->to_version > kEnvelopeVersion) {
+            return false;
+        }
+
+        std::vector<uint8_t> next;
+        if (!migration->migration(current, next) || next.empty()) {
+            return false;
+        }
+
+        auto next_version = envelope_version(next);
+        if (!next_version.has_value() || *next_version != migration->to_version) {
+            return false;
+        }
+
+        current = std::move(next);
+        version = next_version;
+    }
+
+    migrated_storage = std::move(current);
+    return true;
+}
+
+bool parse_blob(std::span<const uint8_t> bytes,
+                ParsedBlob& parsed,
+                std::vector<uint8_t>& migrated_storage) {
     if (has_magic(bytes, kStateStoreMagic)) {
         parsed.store_blob = bytes;
         parsed.plugin_blob = {};
@@ -77,7 +181,19 @@ bool parse_blob(std::span<const uint8_t> bytes, ParsedBlob& parsed) {
 
     const uint32_t version =
         choc::memory::readLittleEndian<uint32_t>(bytes.data() + 4);
-    if (version != kEnvelopeVersion) {
+    if (version > kEnvelopeVersion) {
+        return false;
+    }
+    if (version < kEnvelopeVersion) {
+        if (!migrate_envelope_to_current(bytes, migrated_storage)) {
+            return false;
+        }
+        bytes = migrated_storage;
+    }
+
+    const uint32_t readable_version =
+        choc::memory::readLittleEndian<uint32_t>(bytes.data() + 4);
+    if (readable_version != kEnvelopeVersion) {
         return false;
     }
 
@@ -128,6 +244,26 @@ bool restore_previous_state(const std::vector<uint8_t>& store_blob,
 
 } // namespace
 
+uint32_t current_envelope_version() {
+    return kEnvelopeVersion;
+}
+
+bool register_envelope_migration(uint32_t from_version,
+                                 uint32_t to_version,
+                                 EnvelopeMigrationFn migration) {
+    if (from_version >= to_version
+        || to_version > kEnvelopeVersion
+        || !migration) {
+        return false;
+    }
+    if (find_envelope_migration(from_version) != nullptr) {
+        return false;
+    }
+
+    envelope_migrations().push_back({from_version, to_version, std::move(migration)});
+    return true;
+}
+
 std::vector<uint8_t> serialize(const state::StateStore& store,
                                const Processor& processor) {
     auto store_blob = store.serialize();
@@ -154,7 +290,8 @@ bool deserialize(std::span<const uint8_t> bytes,
                  state::StateStore& store,
                  Processor& processor) {
     ParsedBlob parsed{};
-    if (!parse_blob(bytes, parsed)) {
+    std::vector<uint8_t> migrated_storage;
+    if (!parse_blob(bytes, parsed, migrated_storage)) {
         return false;
     }
 

--- a/core/host/include/pulp/host/graph_serializer.hpp
+++ b/core/host/include/pulp/host/graph_serializer.hpp
@@ -15,6 +15,7 @@
 // Phase 3 of planning/signal-graph-followups-plan.md.
 
 #include <pulp/host/signal_graph.hpp>
+#include <functional>
 #include <string>
 #include <unordered_map>
 
@@ -22,6 +23,15 @@ namespace pulp::host {
 
 class GraphSerializer {
 public:
+    using MigrationFn =
+        std::function<bool(const std::string& source_json,
+                           std::string& destination_json)>;
+
+    static int current_format_version();
+    static bool register_migration(int from_version,
+                                   int to_version,
+                                   MigrationFn migration);
+
     // Encode the entire graph as JSON. The `editor_layout` map (NodeId →
     // (x,y)) is optional — pass an empty map if the graph has no UI.
     static std::string to_json(const SignalGraph& graph,

--- a/core/host/src/graph_serializer.cpp
+++ b/core/host/src/graph_serializer.cpp
@@ -8,6 +8,9 @@
 #include <sstream>
 #include <unordered_map>
 #include <cstdint>
+#include <limits>
+#include <optional>
+#include <vector>
 
 namespace pulp::host {
 namespace {
@@ -24,6 +27,118 @@ inline double get_double(const V& v) {
 }
 
 constexpr int kFormatVersion = 1;
+
+struct GraphMigrationEntry {
+    int from_version = 0;
+    int to_version = 0;
+    GraphSerializer::MigrationFn migration;
+};
+
+std::vector<GraphMigrationEntry>& graph_migrations() {
+    static std::vector<GraphMigrationEntry> migrations;
+    return migrations;
+}
+
+std::optional<int> graph_format_version(const choc::value::Value& root) {
+    const auto& value = root["format_version"];
+    if (value.isInt32() || value.isInt64()) {
+        const auto raw = value.getInt64();
+        if (raw < std::numeric_limits<int>::min()
+            || raw > std::numeric_limits<int>::max()) {
+            return std::nullopt;
+        }
+        return static_cast<int>(raw);
+    }
+
+    return std::nullopt;
+}
+
+const GraphMigrationEntry* find_graph_migration(int from_version) {
+    for (const auto& entry : graph_migrations()) {
+        if (entry.from_version == from_version) {
+            return &entry;
+        }
+    }
+    return nullptr;
+}
+
+bool migrate_graph_json(std::string& json, std::string& error) {
+    for (;;) {
+        choc::value::Value root;
+        try {
+            root = choc::json::parse(json);
+        } catch (const std::exception& e) {
+            error = std::string("JSON parse failed: ") + e.what();
+            return false;
+        }
+
+        if (!root.isObject()) {
+            error = "root is not an object";
+            return false;
+        }
+        if (!root.hasObjectMember("format_version")) {
+            error = "missing graph format_version";
+            return false;
+        }
+
+        auto version = graph_format_version(root);
+        if (!version.has_value()) {
+            error = "format_version is not an integer";
+            return false;
+        }
+
+        if (*version == kFormatVersion) {
+            return true;
+        }
+        if (*version > kFormatVersion) {
+            error = "unsupported graph format_version "
+                    + std::to_string(*version);
+            return false;
+        }
+
+        const auto* migration = find_graph_migration(*version);
+        if (migration == nullptr) {
+            error = "unsupported graph format_version "
+                    + std::to_string(*version);
+            return false;
+        }
+
+        if (migration->to_version <= *version
+            || migration->to_version > kFormatVersion) {
+            error = "graph migration does not move toward current format_version";
+            return false;
+        }
+
+        std::string migrated;
+        if (!migration->migration(json, migrated) || migrated.empty()) {
+            error = "graph migration failed";
+            return false;
+        }
+
+        choc::value::Value migrated_root;
+        try {
+            migrated_root = choc::json::parse(migrated);
+        } catch (const std::exception& e) {
+            error = std::string("graph migration produced invalid JSON: ") + e.what();
+            return false;
+        }
+
+        if (!migrated_root.isObject()
+            || !migrated_root.hasObjectMember("format_version")) {
+            error = "graph migration did not produce expected format_version";
+            return false;
+        }
+
+        auto migrated_version = graph_format_version(migrated_root);
+        if (!migrated_version.has_value()
+            || *migrated_version != migration->to_version) {
+            error = "graph migration did not produce expected format_version";
+            return false;
+        }
+
+        json = std::move(migrated);
+    }
+}
 
 const char* node_type_str(NodeType t) {
     switch (t) {
@@ -119,6 +234,27 @@ std::vector<uint8_t> b64_decode(std::string_view s) {
 
 } // namespace
 
+int GraphSerializer::current_format_version() {
+    return kFormatVersion;
+}
+
+bool GraphSerializer::register_migration(int from_version,
+                                         int to_version,
+                                         MigrationFn migration) {
+    if (from_version >= to_version
+        || to_version > kFormatVersion
+        || !migration) {
+        return false;
+    }
+
+    if (find_graph_migration(from_version) != nullptr) {
+        return false;
+    }
+
+    graph_migrations().push_back({from_version, to_version, std::move(migration)});
+    return true;
+}
+
 std::string GraphSerializer::to_json(
     const SignalGraph& graph,
     const std::unordered_map<NodeId, std::pair<float,float>>& editor_layout) {
@@ -192,9 +328,14 @@ GraphSerializer::LoadResult GraphSerializer::from_json(SignalGraph& graph, const
     LoadResult result;
     graph.clear();
 
+    std::string readable_json = json;
+    if (!migrate_graph_json(readable_json, result.error)) {
+        return result;
+    }
+
     choc::value::Value root;
     try {
-        root = choc::json::parse(json);
+        root = choc::json::parse(readable_json);
     } catch (const std::exception& e) {
         result.error = std::string("JSON parse failed: ") + e.what();
         return result;

--- a/core/state/CMakeLists.txt
+++ b/core/state/CMakeLists.txt
@@ -9,6 +9,7 @@ target_include_directories(pulp-state
 
 target_sources(pulp-state PRIVATE
     src/store.cpp
+    src/state_migration.cpp
     src/preset_manager.cpp
     src/state_tree.cpp
     src/state_tree_sync.cpp

--- a/core/state/include/pulp/state/state_migration.hpp
+++ b/core/state/include/pulp/state/state_migration.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <span>
+#include <vector>
+
+namespace pulp::state {
+
+/// Offline migration support for serialized StateStore payloads.
+///
+/// Migration callbacks run on load/save infrastructure, never on the audio
+/// thread. A callback receives the complete source blob and must write a
+/// complete destination blob, including any format header/footer checksums.
+class StateMigrationRegistry {
+public:
+    using MigrationFn =
+        std::function<bool(std::span<const uint8_t> source,
+                           std::vector<uint8_t>& destination)>;
+
+    bool register_migration(uint32_t from_version,
+                            uint32_t to_version,
+                            MigrationFn migration);
+
+    [[nodiscard]] bool has_migration_from(uint32_t from_version) const;
+
+    [[nodiscard]] std::optional<std::vector<uint8_t>>
+    migrate(std::span<const uint8_t> source, uint32_t target_version) const;
+
+private:
+    struct Entry {
+        uint32_t from_version = 0;
+        uint32_t to_version = 0;
+        MigrationFn migration;
+    };
+
+    const Entry* find(uint32_t from_version) const;
+
+    std::vector<Entry> migrations_;
+};
+
+[[nodiscard]] std::optional<uint32_t>
+serialized_state_version(std::span<const uint8_t> source);
+
+} // namespace pulp::state

--- a/core/state/include/pulp/state/store.hpp
+++ b/core/state/include/pulp/state/store.hpp
@@ -2,6 +2,7 @@
 
 #include <pulp/state/listener_token.hpp>
 #include <pulp/state/parameter.hpp>
+#include <pulp/state/state_migration.hpp>
 #include <array>
 #include <vector>
 #include <unordered_map>
@@ -246,6 +247,20 @@ public:
     /// Get the current state schema version.
     uint32_t state_version() const { return state_version_; }
 
+    /// Register a load-time migration for this store's parameter schema.
+    ///
+    /// Migrations are scoped to the StateStore instance because state schema
+    /// versions are plugin-defined; two plugins may both need a different
+    /// migration from version 1 to 2.
+    bool register_state_migration(uint32_t from_version,
+                                  uint32_t to_version,
+                                  StateMigrationRegistry::MigrationFn migration);
+
+    /// Copy schema migrations from another store with the same registered
+    /// parameters. Used by restore probes that validate before touching live
+    /// state.
+    void copy_state_migrations_from(const StateStore& source);
+
 private:
     std::vector<ParamInfo> params_;
     std::vector<ParamGroup> groups_;
@@ -253,6 +268,7 @@ private:
     std::vector<ParamValue> values_;
     std::shared_ptr<detail::ListenerRegistry> registry_;
     std::vector<ListenerToken> permanent_listener_tokens_;
+    StateMigrationRegistry migrations_;
     uint32_t state_version_ = 1;
 
     std::function<void(ParamID)> on_begin_gesture_;

--- a/core/state/src/state_migration.cpp
+++ b/core/state/src/state_migration.cpp
@@ -1,0 +1,129 @@
+#include <pulp/state/state_migration.hpp>
+
+#include <choc/memory/choc_Endianness.h>
+
+#include <cstddef>
+#include <utility>
+
+namespace pulp::state {
+namespace {
+
+bool has_state_magic(std::span<const uint8_t> source) {
+    return source.size() >= 4
+        && source[0] == 'P'
+        && source[1] == 'U'
+        && source[2] == 'L'
+        && source[3] == 'P';
+}
+
+uint32_t crc32_simple(const uint8_t* data, std::size_t len) {
+    uint32_t crc = 0xFFFFFFFFu;
+    for (std::size_t i = 0; i < len; ++i) {
+        crc ^= data[i];
+        for (int j = 0; j < 8; ++j) {
+            const uint32_t mask = (crc & 1u) ? 0xFFFFFFFFu : 0u;
+            crc = (crc >> 1) ^ (0xEDB88320u & mask);
+        }
+    }
+    return ~crc;
+}
+
+bool has_valid_state_crc(std::span<const uint8_t> source) {
+    if (source.size() < 16 || !has_state_magic(source)) {
+        return false;
+    }
+
+    const auto crc_offset = source.size() - 4;
+    const uint32_t stored_crc =
+        choc::memory::readLittleEndian<uint32_t>(source.data() + crc_offset);
+    const uint32_t computed_crc = crc32_simple(source.data(), crc_offset);
+    return stored_crc == computed_crc;
+}
+
+} // namespace
+
+bool StateMigrationRegistry::register_migration(uint32_t from_version,
+                                                uint32_t to_version,
+                                                MigrationFn migration) {
+    if (from_version >= to_version || !migration) {
+        return false;
+    }
+
+    if (find(from_version) != nullptr) {
+        return false;
+    }
+
+    migrations_.push_back({from_version, to_version, std::move(migration)});
+    return true;
+}
+
+bool StateMigrationRegistry::has_migration_from(uint32_t from_version) const {
+    return find(from_version) != nullptr;
+}
+
+std::optional<std::vector<uint8_t>>
+StateMigrationRegistry::migrate(std::span<const uint8_t> source,
+                                uint32_t target_version) const {
+    auto version = serialized_state_version(source);
+    if (!version.has_value()) {
+        return std::nullopt;
+    }
+    if (!has_valid_state_crc(source)) {
+        return std::nullopt;
+    }
+
+    if (*version == target_version) {
+        return std::vector<uint8_t>(source.begin(), source.end());
+    }
+    if (*version > target_version) {
+        return std::nullopt;
+    }
+
+    std::vector<uint8_t> current(source.begin(), source.end());
+    while (*version != target_version) {
+        const Entry* entry = find(*version);
+        if (entry == nullptr) {
+            return std::nullopt;
+        }
+
+        if (entry->to_version <= *version || entry->to_version > target_version) {
+            return std::nullopt;
+        }
+
+        std::vector<uint8_t> next;
+        if (!entry->migration(current, next) || next.empty()) {
+            return std::nullopt;
+        }
+
+        auto next_version = serialized_state_version(next);
+        if (!next_version.has_value() || *next_version != entry->to_version) {
+            return std::nullopt;
+        }
+
+        current = std::move(next);
+        version = next_version;
+    }
+
+    return current;
+}
+
+const StateMigrationRegistry::Entry*
+StateMigrationRegistry::find(uint32_t from_version) const {
+    for (const auto& entry : migrations_) {
+        if (entry.from_version == from_version) {
+            return &entry;
+        }
+    }
+    return nullptr;
+}
+
+std::optional<uint32_t>
+serialized_state_version(std::span<const uint8_t> source) {
+    if (source.size() < 12 || !has_state_magic(source)) {
+        return std::nullopt;
+    }
+
+    return choc::memory::readLittleEndian<uint32_t>(source.data() + 4);
+}
+
+} // namespace pulp::state

--- a/core/state/src/store.cpp
+++ b/core/state/src/store.cpp
@@ -4,6 +4,7 @@
 #include <pulp/events/event_loop.hpp>
 #include <pulp/runtime/spsc_queue.hpp>
 #include <pulp/state/store.hpp>
+#include <pulp/state/state_migration.hpp>
 #include <pulp/runtime/assert.hpp>
 #include <choc/memory/choc_Endianness.h>
 
@@ -323,6 +324,18 @@ void StateStore::add_listener(ParamChangeCallback callback) {
     permanent_listener_tokens_.push_back(std::move(token));
 }
 
+bool StateStore::register_state_migration(
+    uint32_t from_version,
+    uint32_t to_version,
+    StateMigrationRegistry::MigrationFn migration) {
+    return migrations_.register_migration(from_version, to_version,
+                                          std::move(migration));
+}
+
+void StateStore::copy_state_migrations_from(const StateStore& source) {
+    migrations_ = source.migrations_;
+}
+
 // ─── ListenerToken ──────────────────────────────────────────────────────────
 
 ListenerToken::ListenerToken(std::weak_ptr<detail::ListenerRegistry> registry,
@@ -415,6 +428,22 @@ std::vector<uint8_t> StateStore::serialize() const {
 
 bool StateStore::deserialize(std::span<const uint8_t> data) {
     if (data.size() < 16) return false; // Minimum: header(4) + version(4) + count(4) + crc(4)
+
+    std::vector<uint8_t> migrated_storage;
+    if (auto serialized_version = serialized_state_version(data);
+        serialized_version.has_value() && *serialized_version != state_version_) {
+        if (*serialized_version > state_version_) {
+            return false;
+        }
+
+        auto migrated = migrations_.migrate(data, state_version_);
+        if (migrated.has_value()) {
+            migrated_storage = std::move(*migrated);
+            data = migrated_storage;
+        } else if (migrations_.has_migration_from(*serialized_version)) {
+            return false;
+        }
+    }
 
     // Check magic
     if (data[0] != 'P' || data[1] != 'U' || data[2] != 'L' || data[3] != 'P')

--- a/docs/guides/parameters.md
+++ b/docs/guides/parameters.md
@@ -245,10 +245,17 @@ bool ok = store.deserialize(data);
 The format includes a version number and CRC32 checksum:
 
 ```
-[4 bytes: version] [4 bytes: param count] [per param: 4 bytes id + 4 bytes value] [4 bytes: CRC32]
+[4 bytes: magic] [4 bytes: version] [4 bytes: param count] [per param: 4 bytes id + 4 bytes value] [4 bytes: CRC32]
 ```
 
 Use `set_state_version()` for forward compatibility when adding parameters in new plugin versions.
+If an old saved state needs a structural upgrade before the current reader can
+load it, call `StateStore::register_state_migration()` on that store to add a
+step from the old version to the next version. Migration is a load-time/offline
+operation; the audio thread never runs it. Pulp reads registered older state
+versions forward to the current version, writes the current version, and fails
+closed on unreadable or future versions rather than silently dropping parameter
+values.
 
 ## Processor-Owned Plugin State
 
@@ -271,6 +278,9 @@ Format adapters, `HeadlessHost`, and `ValidationHarness` save an outer
 host-facing blob. The inner `StateStore` payload remains the same parameter-only
 binary format shown above. If `serialize_plugin_state()` returns an empty blob,
 Pulp preserves the legacy raw `StateStore` format for backward compatibility.
+The outer envelope has its own version and migration registry so envelope
+changes can be read from older versions before the inner `StateStore` and
+plugin-owned payloads are restored.
 
 `deserialize_plugin_state()` receives an empty span when loading an older blob
 that contains only `StateStore` data. Override implementations should treat

--- a/docs/reference/signal-graph.md
+++ b/docs/reference/signal-graph.md
@@ -71,6 +71,14 @@ reads back. Full automation-curve routing (one node's output driving
 another node's parameter over a block) is not yet available — track via
 the plan.
 
+## Persistence
+
+`GraphSerializer` writes `.pulpgraph` JSON with a `format_version` field.
+Loaders read that field before materializing nodes. Older graph versions can
+register `GraphSerializer::register_migration()` steps to upgrade JSON to the
+current format; newer or unreadable versions fail closed instead of being
+silently interpreted as current data.
+
 ## Thread model
 
 - **Build & edit** (add / connect / remove) runs on the UI thread.

--- a/test/test_graph_serializer.cpp
+++ b/test/test_graph_serializer.cpp
@@ -246,6 +246,109 @@ TEST_CASE("GraphSerializer rejects non-object roots and malformed field types",
     REQUIRE(field_dst.nodes().empty());
 }
 
+TEST_CASE("GraphSerializer fails closed before loading missing or future graph versions",
+          "[host][serializer][migration]") {
+    SignalGraph missing_version;
+    auto missing_result = GraphSerializer::from_json(missing_version, R"({
+  "nodes": [
+    {
+      "id": 1,
+      "type": "gain",
+      "name": "Missing Version",
+      "num_input_ports": 2,
+      "num_output_ports": 2
+    }
+  ],
+  "connections": []
+})");
+    REQUIRE_FALSE(missing_result.ok);
+    REQUIRE(missing_result.error.find("missing graph format_version")
+            != std::string::npos);
+    REQUIRE(missing_version.nodes().empty());
+
+    SignalGraph future_version;
+    auto future_result = GraphSerializer::from_json(future_version, R"({
+  "format_version": 2,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "gain",
+      "name": "Future Version",
+      "num_input_ports": 2,
+      "num_output_ports": 2
+    }
+  ],
+  "connections": []
+})");
+    REQUIRE_FALSE(future_result.ok);
+    REQUIRE(future_result.error.find("unsupported graph format_version 2")
+            != std::string::npos);
+    REQUIRE(future_version.nodes().empty());
+}
+
+TEST_CASE("GraphSerializer dispatches graph format migrations before materializing nodes",
+          "[host][serializer][migration]") {
+    const std::string versioned_json = R"({
+  "format_version": 0,
+  "nodes": [
+    {
+      "id": 7,
+      "type": "gain",
+      "name": "Migrated Gain",
+      "num_input_ports": 2,
+      "num_output_ports": 2,
+      "gain": 0.5
+    }
+  ],
+  "connections": []
+})";
+
+    SignalGraph rejected;
+    auto rejected_result = GraphSerializer::from_json(rejected, versioned_json);
+    REQUIRE_FALSE(rejected_result.ok);
+    REQUIRE(rejected_result.error.find("unsupported graph format_version 0")
+            != std::string::npos);
+    REQUIRE(rejected.nodes().empty());
+
+    REQUIRE(GraphSerializer::register_migration(
+        0, GraphSerializer::current_format_version(),
+        [](const std::string& source_json, std::string& migrated_json) {
+            migrated_json = source_json;
+            const auto pos = migrated_json.find("\"format_version\": 0");
+            if (pos == std::string::npos) return false;
+            migrated_json.replace(pos, std::string("\"format_version\": 0").size(),
+                                  "\"format_version\": 1");
+            return true;
+        }));
+
+    SignalGraph migrated;
+    auto result = GraphSerializer::from_json(migrated, versioned_json);
+    REQUIRE(result.ok);
+    REQUIRE(migrated.nodes().size() == 1);
+    REQUIRE(migrated.nodes().front().name == "Migrated Gain");
+}
+
+TEST_CASE("GraphSerializer rejects graph migrations that do not advance versions",
+          "[host][serializer][migration]") {
+    const std::string versioned_json = R"({
+  "format_version": -1,
+  "nodes": [],
+  "connections": []
+})";
+
+    REQUIRE(GraphSerializer::register_migration(
+        -1, GraphSerializer::current_format_version(),
+        [](const std::string& source_json, std::string& migrated_json) {
+            migrated_json = source_json;
+            return true;
+        }));
+
+    SignalGraph graph;
+    auto result = GraphSerializer::from_json(graph, versioned_json);
+    REQUIRE_FALSE(result.ok);
+    REQUIRE(result.error.find("expected format_version") != std::string::npos);
+}
+
 TEST_CASE("GraphSerializer clears partially loaded graphs after connection field errors",
           "[host][serializer][issue-493]") {
     SignalGraph dst;

--- a/test/test_plugin_state_io.cpp
+++ b/test/test_plugin_state_io.cpp
@@ -3,6 +3,7 @@
 #include <choc/memory/choc_Endianness.h>
 #include <pulp/format/plugin_state_io.hpp>
 #include <pulp/format/processor.hpp>
+#include <pulp/state/state_migration.hpp>
 
 #include <array>
 #include <cstdint>
@@ -254,6 +255,89 @@ TEST_CASE("plugin_state_io envelope with empty plugin payload resets plugin stat
     REQUIRE(restored.processor.plugin_state.empty());
     REQUIRE(restored.processor.deserialize_calls == 1);
     REQUIRE(restored.processor.last_payload.empty());
+}
+
+TEST_CASE("plugin_state_io migrates versioned StateStore payloads on read",
+          "[format][plugin-state][migration]") {
+    TestRig source;
+    source.store.set_state_version(1);
+    source.store.set_value(1, -6.0f);
+    source.processor.plugin_state = "view=compact";
+    auto store_blob = source.store.serialize();
+    auto plugin_blob = source.processor.serialize_plugin_state();
+    auto envelope = make_envelope(store_blob, plugin_blob);
+
+    TestRig restored;
+    restored.store.set_state_version(2);
+    restored.store.set_value(1, 9.0f);
+    restored.processor.plugin_state = "stale";
+
+    REQUIRE(restored.store.register_state_migration(
+        1, 2,
+        [](std::span<const uint8_t> source_blob, std::vector<uint8_t>& migrated) {
+            migrated.assign(source_blob.begin(), source_blob.end());
+            write_u32(migrated, 4, 2);
+            const auto crc_offset = migrated.size() - 4;
+            write_u32(migrated, crc_offset,
+                      crc32_simple(migrated.data(), crc_offset));
+            return true;
+        }));
+
+    REQUIRE(pulp::format::plugin_state_io::deserialize(envelope,
+                                                       restored.store,
+                                                       restored.processor));
+    REQUIRE_THAT(restored.store.get_value(1), WithinAbs(-6.0, 0.01));
+    REQUIRE(restored.processor.plugin_state == "view=compact");
+}
+
+TEST_CASE("plugin_state_io migrates old envelopes before parsing payloads",
+          "[format][plugin-state][migration]") {
+    TestRig source;
+    source.store.set_value(1, -8.0f);
+    source.processor.plugin_state = "view=legacy";
+    auto envelope = make_envelope(source.store.serialize(),
+                                  source.processor.serialize_plugin_state(),
+                                  0);
+
+    int migration_calls = 0;
+    REQUIRE(pulp::format::plugin_state_io::register_envelope_migration(
+        0, pulp::format::plugin_state_io::current_envelope_version(),
+        [&migration_calls](std::span<const uint8_t> source_blob,
+                           std::vector<uint8_t>& migrated) {
+            ++migration_calls;
+            migrated.assign(source_blob.begin(), source_blob.end());
+            write_u32(migrated, 4,
+                      pulp::format::plugin_state_io::current_envelope_version());
+            const auto crc_offset = migrated.size() - 4;
+            write_u32(migrated, crc_offset,
+                      crc32_simple(migrated.data(), crc_offset));
+            return true;
+        }));
+
+    TestRig restored;
+    restored.store.set_value(1, 3.0f);
+    restored.processor.plugin_state = "stale";
+
+    REQUIRE(pulp::format::plugin_state_io::deserialize(envelope,
+                                                       restored.store,
+                                                       restored.processor));
+    REQUIRE_THAT(restored.store.get_value(1), WithinAbs(-8.0, 0.01));
+    REQUIRE(restored.processor.plugin_state == "view=legacy");
+    REQUIRE(migration_calls == 1);
+
+    auto corrupt_legacy_envelope = envelope;
+    corrupt_legacy_envelope.back() ^= 0x55u;
+
+    TestRig untouched;
+    untouched.store.set_value(1, 4.0f);
+    untouched.processor.plugin_state = "keep";
+
+    REQUIRE_FALSE(pulp::format::plugin_state_io::deserialize(corrupt_legacy_envelope,
+                                                             untouched.store,
+                                                             untouched.processor));
+    REQUIRE_THAT(untouched.store.get_value(1), WithinAbs(4.0, 0.01));
+    REQUIRE(untouched.processor.plugin_state == "keep");
+    REQUIRE(migration_calls == 1);
 }
 
 TEST_CASE("plugin_state_io serialize falls back to raw StateStore blobs when plugin payload is empty",

--- a/test/test_state.cpp
+++ b/test/test_state.cpp
@@ -3,6 +3,7 @@
 #include <pulp/events/event_loop.hpp>
 #include <pulp/state/binding.hpp>
 #include <pulp/state/state.hpp>
+#include <pulp/state/state_migration.hpp>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -1200,6 +1201,116 @@ TEST_CASE("StateStore serializes custom state version",
 
     REQUIRE(target.deserialize(data));
     REQUIRE_THAT(target.get_value(42), WithinAbs(64.0, 0.001));
+}
+
+TEST_CASE("StateStore deserializes through registered version migrations",
+          "[state][serialize][migration]") {
+    StateStore source;
+    source.set_state_version(2);
+    source.add_parameter(make_param_info(42, "Answer", "", {0.0f, 100.0f, 10.0f}));
+    source.set_value(42, 88.0f);
+    auto data = source.serialize();
+
+    StateStore target;
+    target.set_state_version(3);
+    target.add_parameter(make_param_info(42, "Answer", "", {0.0f, 100.0f, 10.0f}));
+
+    REQUIRE(target.register_state_migration(
+        2, 3,
+        [](std::span<const uint8_t> source_blob, std::vector<uint8_t>& migrated) {
+            migrated.assign(source_blob.begin(), source_blob.end());
+            write_u32_le(migrated, 4, 3);
+            const auto crc_offset = migrated.size() - 4;
+            write_u32_le(migrated, crc_offset,
+                         crc32_simple_for_test(migrated, crc_offset));
+            return true;
+        }));
+
+    REQUIRE(target.deserialize(data));
+    REQUIRE_THAT(target.get_value(42), WithinAbs(88.0, 0.001));
+}
+
+TEST_CASE("StateStore migrations are scoped to each store instance",
+          "[state][serialize][migration]") {
+    StateStore source;
+    source.set_state_version(6);
+    source.add_parameter(make_param_info(42, "Answer", "", {0.0f, 100.0f, 10.0f}));
+    source.set_value(42, 88.0f);
+    auto data = source.serialize();
+
+    bool first_called = false;
+    bool second_called = false;
+
+    StateStore first;
+    first.set_state_version(7);
+    first.add_parameter(make_param_info(42, "Answer", "", {0.0f, 100.0f, 10.0f}));
+    REQUIRE(first.register_state_migration(
+        6, 7,
+        [&first_called](std::span<const uint8_t> source_blob,
+                        std::vector<uint8_t>& migrated) {
+            first_called = true;
+            migrated.assign(source_blob.begin(), source_blob.end());
+            write_u32_le(migrated, 4, 7);
+            const auto crc_offset = migrated.size() - 4;
+            write_u32_le(migrated, crc_offset,
+                         crc32_simple_for_test(migrated, crc_offset));
+            return true;
+        }));
+
+    StateStore second;
+    second.set_state_version(7);
+    second.add_parameter(make_param_info(42, "Answer", "", {0.0f, 100.0f, 10.0f}));
+    REQUIRE(second.register_state_migration(
+        6, 7,
+        [&second_called](std::span<const uint8_t> source_blob,
+                         std::vector<uint8_t>& migrated) {
+            second_called = true;
+            migrated.assign(source_blob.begin(), source_blob.end());
+            write_u32_le(migrated, 4, 7);
+            const auto crc_offset = migrated.size() - 4;
+            write_u32_le(migrated, crc_offset,
+                         crc32_simple_for_test(migrated, crc_offset));
+            return true;
+        }));
+
+    REQUIRE(first.deserialize(data));
+    REQUIRE(first_called);
+    REQUIRE_FALSE(second_called);
+
+    REQUIRE(second.deserialize(data));
+    REQUIRE(second_called);
+}
+
+TEST_CASE("StateStore rejects corrupt source blobs before migration callbacks",
+          "[state][serialize][migration]") {
+    StateStore source;
+    source.set_state_version(4);
+    source.add_parameter(make_param_info(42, "Answer", "", {0.0f, 100.0f, 10.0f}));
+    source.set_value(42, 88.0f);
+    auto data = source.serialize();
+    data.back() ^= 0x55u;
+
+    bool migration_called = false;
+    StateStore target;
+    target.set_state_version(5);
+    target.add_parameter(make_param_info(42, "Answer", "", {0.0f, 100.0f, 10.0f}));
+
+    REQUIRE(target.register_state_migration(
+        4, 5,
+        [&migration_called](std::span<const uint8_t> source_blob,
+                            std::vector<uint8_t>& migrated) {
+            migration_called = true;
+            migrated.assign(source_blob.begin(), source_blob.end());
+            write_u32_le(migrated, 4, 5);
+            const auto crc_offset = migrated.size() - 4;
+            write_u32_le(migrated, crc_offset,
+                         crc32_simple_for_test(migrated, crc_offset));
+            return true;
+        }));
+
+    REQUIRE_FALSE(target.deserialize(data));
+    REQUIRE_FALSE(migration_called);
+    REQUIRE_THAT(target.get_value(42), WithinAbs(10.0, 0.001));
 }
 
 TEST_CASE("StateStore reset_all_to_defaults notifies in registration order",


### PR DESCRIPTION
Add migration callbacks for serialized plugin and graph state payloads so older schema versions can be upgraded before restore.

Thread the migration path through StateStore, PluginStateIO, and GraphSerializer, with tests covering successful upgrades, rejected versions, and failed migrations.