### PR TITLE
ci: address Codex P1s on coverage + cross-platform workflows

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -812,23 +812,43 @@ Coverage run stayed `in_progress` for 4h+ until the reaper killed it.
 
 Fix pattern (applies to any GH-Actions job, not just coverage):
 
-- **Always set `timeout-minutes` on every job.** A healthy job's wall
-  time × ~2-2.5 is a safe backstop — it bounds both queued and running
-  time, so a starved self-hosted leg fails fast instead of squatting.
+- **`timeout-minutes` does NOT bound a QUEUED job — only a running one.**
+  This is the trap (codex P1 on pulp#2521). `timeout-minutes` starts
+  counting *after* a runner is assigned; a matrix leg routed to a
+  saturated self-hosted pool that never gets a runner sits `queued`
+  forever and the timeout never fires. Always set `timeout-minutes` on
+  every job anyway — it is the correct backstop for the *running*-hang
+  mode — but do not assume it covers the queued-hang mode.
+- **For the queued-hang mode, add an explicit queued-job watchdog.**
+  `coverage.yml`'s `coverage-queue-watchdog` job is the reference: it
+  runs on `ubuntu-latest` (never self-hosted, so it itself can never be
+  the stuck thing), starts immediately (no `needs:` on the matrix), and
+  polls this run's own jobs via `gh api
+  repos/{repo}/actions/runs/{run_id}/jobs`. If a `Coverage report (...)`
+  leg has been `status==queued` past a grace window it cancels the whole
+  run via `POST runs/{run_id}/cancel` (`permissions: actions: write`).
+  There is **no public API to cancel a single matrix leg** — cancelling
+  the whole run is the only option, and it is what the required gate
+  needs anyway. Age queued legs from the **run's `created_at`** (`gh api
+  repos/{repo}/actions/runs/{run_id}`): the jobs API exposes no per-job
+  `queued_at`, and `created_at` is when every leg — including the queued
+  one — was created. The watchdog must exclude its own job name from the
+  scan or it will reap itself.
 - **Pin a pure gate/aggregation job to a GitHub-hosted runner**
   (`ubuntu-latest` / `ubuntu-24.04`). A job that only downloads
   artifacts and runs a check must never queue behind a saturated
   self-hosted pool — if it does, `if: always()` cannot save it because
   the job still needs a runner to start.
 - A `needs:` + `if: always()` job only reaches a conclusion once every
-  upstream job is terminal; an upstream job with no timeout therefore
-  hangs the gate transitively.
+  upstream job is terminal; an upstream job stuck `queued` therefore
+  hangs the gate transitively until the watchdog (or the slower
+  repo-wide `stale-run-reaper.yml`) cancels the run.
 
 Do not flip a `concurrency` block's `cancel-in-progress` to `true` to
 "fix" a pile-up if `false` was a deliberate choice (e.g. coverage.yml
 keeps `false` for Codecov's `after_n_builds` upload completeness,
-pulp#1884). Per-job `timeout-minutes` is the correct fix; it bounds runs
-regardless of `cancel-in-progress`.
+pulp#1884). Per-job `timeout-minutes` plus the queued-job watchdog are
+the correct fix; they bound runs regardless of `cancel-in-progress`.
 
 ### Gotcha: `coverage.yml` is gated on `classify` — touch the gate carefully
 
@@ -1577,6 +1597,8 @@ gh workflow run release-cli.yml --ref main \
 The workflow file comes from main (fixed), the source tree comes from the tag (correct content), and the overlay step picks up post-tag script fixes automatically. `release-guard.yml` and `release-cli-watchdog.yml` will auto-close their trackers when the SDK assets land. This was the fix for the four-day stall on v0.95.0..v0.97.0 caused by a skia-builder chrome/m144 zip layout drift (`Release/<arch>/libskia.a` instead of `Release/libskia.a`). The fetch script flattens the arch subdir; regression coverage lives in `tools/scripts/test_fetch_skia_for_release.py`.
 
 **Nightly cross-platform check (`.github/workflows/cross-platform-check.yml`):** Pulp's team develops and tests on macOS; Linux, Windows, and Android are advisory "tell us if it breaks" signal, and per-PR CI has been slimmed so those legs no longer run on every PR. This scheduled workflow is the backstop. It runs nightly (`cron: '17 7 * * *'` — odd minute, off-peak; also `workflow_dispatch` for manual bisect) and builds + tests **Linux** (`ubuntu-latest`), **Windows** (`windows-latest`), and **Android** (NDK build on `ubuntu-latest`) as three independent jobs with `fail-fast: false` so one platform breaking never masks the others — catching ALL cross-platform breakage in one pass is the point. GitHub-hosted runners only: it must never consume the scarce self-hosted macOS capacity. A final `tracking-issues` job (`needs:` all three, `if: always()`) maintains **one tracking issue PER platform**, keyed by the EXACT titles `Cross-platform Linux check is broken` / `Cross-platform Windows check is broken` / `Cross-platform Android check is broken`. It reuses `auto-release-watchdog.yml`'s find-or-create / edit / reopen / close gh-api pattern: a failed platform job opens (or reopens + edits) its issue; a passing one closes its open issue. De-dup is by `gh issue list --search "in:title <title>" --state all` matching the exact title — never a fresh issue per night. Created issues carry `bug`, `ci`, `cross-platform`, and `platform:linux`/`platform:windows`/`platform:android` labels, and the body includes the run URL, tip SHA, per-job results, artifact name, and the commit range since the last green run (derived from the Actions API) so a regression can be bisected within a night's batch. Distinct from `nightly-full-build.yml`, which does the full macOS `make all` to catch test targets PR CI never compiles; this workflow is the *non-macOS* coverage PR CI no longer provides. If you slim or restore a per-PR advisory platform leg, keep this nightly in sync — it is the only thing keeping cross-platform debt visible.
+
+**Gotcha — `shell: cmd` step exit code is the LAST command's errorlevel.** Under `shell: cmd` GitHub Actions uses `cmd.exe` semantics: the step exit code is the errorlevel of the *last* program run, not the first failing one. The Windows ctest step writes to `test-windows.log` for artifact upload, then `type`s it into the run log — if `type` (always errorlevel 0) ran last, a real `ctest` failure was masked and the job went green, so the nightly tracking-issue logic never fired for genuine Windows breakage (codex P1 on pulp#2536). Fix: capture `set CTEST_RC=%ERRORLEVEL%` on the line *immediately* after `ctest` (before `type` overwrites `%ERRORLEVEL%`), then `exit /b %CTEST_RC%` as the final command. Same trap applies to any multi-command `shell: cmd` block where a non-final command is the one that can fail — capture-and-`exit /b`, or make the fallible command last. Note `build.yml`'s Windows test step is *not* affected: it runs `ctest` as the last command, so its errorlevel propagates naturally.
 
 **`RELEASE_BOT_TOKEN` is required for the auto-release chain to fire.** Without it, auto-release silently degrades — tags get created via `GITHUB_TOKEN` but GitHub doesn't trigger workflows on `GITHUB_TOKEN`-pushed tags, so `release-cli.yml` and `sign-and-release.yml` never run and no GitHub Release appears. Run `pulp doctor` to check; if missing, follow the "One-time setup" section in `docs/guides/versioning.md`. `pulp pr` will also print a heads-up before pushing the PR if the secret isn't present.
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -657,6 +657,175 @@ jobs:
           fail_ci_if_error: false
           verbose: true
 
+  # ── Queued-leg watchdog (codex P1 on pulp#2521) ────────────────────────
+  # `timeout-minutes` on the `coverage` matrix job ONLY bounds execution
+  # AFTER a runner is assigned — it does NOT expire a leg still sitting
+  # `queued` waiting for a runner. When the macOS coverage leg is routed
+  # to a self-hosted / Namespace pool (PULP_COVERAGE_MACOS_RUNS_ON_JSON)
+  # and that pool has no idle worker, the leg can squat in `queued` until
+  # GitHub's self-hosted queue timeout (up to 24h). While it does, the
+  # `coverage` job never reaches a terminal state, so the REQUIRED
+  # `coverage-diff-gate` (`needs: coverage`) stays blocked and the PR's
+  # required check is stuck for hours.
+  #
+  # The repo-wide `stale-run-reaper.yml` does NOT cover this: a run with
+  # one queued leg + other legs running shows as `in_progress`, so the
+  # reaper ages it from `run_started_at` against a 4h cutoff — far too
+  # slow, and not a per-leg signal at all.
+  #
+  # This watchdog is the explicit queued-job reaper. It runs on a
+  # GitHub-hosted runner (NEVER self-hosted, so it can never itself be
+  # the thing that's stuck), starts immediately (no `needs:`), and polls
+  # THIS run's own jobs. If any coverage leg has been `queued` longer
+  # than QUEUED_GRACE_MINUTES, it cancels the whole run via the
+  # `runs/{id}/cancel` API — there is no public API to cancel a single
+  # matrix leg, and cancelling the run is what the required gate needs
+  # anyway: `coverage-diff-gate`'s `if: always()` precondition step then
+  # reaches a real terminal `cancelled` conclusion instead of hanging.
+  coverage-queue-watchdog:
+    name: Coverage queue watchdog
+    # Gate on the same classifier output as the `coverage` matrix — when
+    # the matrix is skipped (skip-safe docs/planning PR) there are no
+    # coverage legs to reap and the watchdog has nothing to do.
+    needs: [classify]
+    if: needs.classify.outputs.native_build_required == 'true'
+    # GitHub-hosted on purpose: the watchdog must never queue behind the
+    # same saturated self-hosted pool it is meant to reap.
+    runs-on: ubuntu-latest
+    # Hard upper bound on the watchdog itself. A healthy coverage build
+    # takes ~1h; the watchdog only needs to catch a leg that NEVER gets a
+    # runner, so it polls for QUEUED_GRACE_MINUTES + a margin and exits.
+    # Once it cancels the run (or every leg has left `queued`) it stops
+    # early — this is just the backstop if neither happens.
+    timeout-minutes: 40
+    permissions:
+      # actions: write is required to POST runs/{id}/cancel.
+      actions: write
+      contents: read
+    steps:
+      - name: Reap a coverage leg stuck in the runner queue
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          SELF_JOB_NAME: Coverage queue watchdog
+          # A coverage leg that has not been assigned a runner this long
+          # is treated as orphaned by a saturated pool and reaped. A
+          # healthy leg picks up a runner in seconds-to-minutes; 25 min
+          # is generous headroom for a momentarily busy pool without
+          # letting a genuinely orphaned leg block the required gate for
+          # hours.
+          QUEUED_GRACE_MINUTES: '25'
+          # Poll cadence + total watch window. POLL_SECONDS * MAX_POLLS
+          # must comfortably exceed QUEUED_GRACE_MINUTES so a leg that
+          # queues at t=0 is still observed past the grace cutoff, while
+          # staying inside this job's timeout-minutes.
+          POLL_SECONDS: '60'
+          MAX_POLLS: '34'
+        run: |
+          set -euo pipefail
+
+          # The run's created_at is when EVERY job in this run — including
+          # any leg still sitting in `queued` — was created. Ageing a
+          # queued leg from this timestamp is correct and needs no
+          # per-job `queued_at` (the jobs API does not expose one). It
+          # also means a leg already orphaned before this watchdog's
+          # first poll is still aged correctly.
+          run_created_at=$(
+            gh api "repos/${REPO}/actions/runs/${RUN_ID}" \
+              --jq '.created_at' 2>/dev/null || echo ""
+          )
+          if [ -z "${run_created_at}" ]; then
+            echo "::warning::Could not read run created_at; watchdog cannot age queued legs. Exiting without action."
+            exit 0
+          fi
+
+          # timestamp -> epoch. GNU date first, Python fallback (mirrors
+          # stale-run-reaper.yml).
+          to_epoch() {
+            date -u -d "$1" +%s 2>/dev/null \
+              || python3 -c "import datetime,sys; print(int(datetime.datetime.fromisoformat(sys.argv[1].replace('Z','+00:00')).timestamp()))" "$1" \
+              2>/dev/null || echo ""
+          }
+
+          run_created_epoch=$(to_epoch "${run_created_at}")
+          if [ -z "${run_created_epoch}" ]; then
+            echo "::warning::Could not parse run created_at '${run_created_at}'; exiting without action."
+            exit 0
+          fi
+
+          echo "Repo:               ${REPO}"
+          echo "Run id:             ${RUN_ID}"
+          echo "Run created_at:     ${run_created_at}"
+          echo "Queued grace:       ${QUEUED_GRACE_MINUTES} min"
+          echo "Poll cadence:       ${POLL_SECONDS}s x ${MAX_POLLS}"
+
+          poll=0
+          while [ "${poll}" -lt "${MAX_POLLS}" ]; do
+            poll=$((poll + 1))
+            now_epoch=$(date -u +%s)
+
+            # Per-job: name <TAB> status. A coverage leg that has not
+            # been assigned a runner has status=queued. The jobs API has
+            # no per-job `queued_at`, so the leg is aged from the run's
+            # created_at (resolved once, above) — not a per-job field.
+            # Exclude the watchdog's own job so it can never reap itself.
+            jobs_tsv=$(
+              gh api --paginate \
+                -H "Accept: application/vnd.github+json" \
+                "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" \
+                --jq '.jobs[] | [.name, .status] | @tsv' \
+                2>/dev/null || true
+            )
+
+            queued_legs=0
+            stuck_leg=""
+            stuck_age_min=0
+            while IFS=$'\t' read -r job_name job_status; do
+              [ -z "${job_name}" ] && continue
+              [ "${job_name}" = "${SELF_JOB_NAME}" ] && continue
+              # Only the native + Kotlin coverage legs — every one is a
+              # `Coverage report (...)` job and every one can route to a
+              # self-hosted / Namespace pool. The watchdog itself is
+              # already excluded by the SELF_JOB_NAME check above.
+              case "${job_name}" in
+                "Coverage report ("*) ;;
+                *) continue ;;
+              esac
+              [ "${job_status}" != "queued" ] && continue
+
+              queued_legs=$((queued_legs + 1))
+              age_min=$(( (now_epoch - run_created_epoch) / 60 ))
+              echo "  poll ${poll}: '${job_name}' still queued (${age_min} min since run created)"
+              if [ "${age_min}" -ge "${QUEUED_GRACE_MINUTES}" ] && [ "${age_min}" -gt "${stuck_age_min}" ]; then
+                stuck_leg="${job_name}"
+                stuck_age_min="${age_min}"
+              fi
+            done <<< "${jobs_tsv}"
+
+            if [ -n "${stuck_leg}" ]; then
+              echo "::error::Coverage leg '${stuck_leg}' has been queued ${stuck_age_min} min (>= ${QUEUED_GRACE_MINUTES} min grace) — the runner pool is saturated and never assigned it a runner. Cancelling run ${RUN_ID} so the required 'Diff coverage required' gate reaches a terminal conclusion instead of hanging."
+              # POST cancel. Once GitHub accepts this (202) the run —
+              # including this watchdog job — is torn down; the cancel is
+              # already committed, so a mid-call kill is harmless.
+              gh api --method POST \
+                -H "Accept: application/vnd.github+json" \
+                "repos/${REPO}/actions/runs/${RUN_ID}/cancel" >/dev/null 2>&1 \
+                || echo "::warning::cancel POST failed (run may already be completing) — relying on stale-run-reaper.yml as the slower backstop."
+              exit 0
+            fi
+
+            if [ "${queued_legs}" -eq 0 ]; then
+              echo "  poll ${poll}: no coverage leg is queued — every leg has a runner or has finished. Watchdog done."
+              exit 0
+            fi
+
+            sleep "${POLL_SECONDS}"
+          done
+
+          echo "Watchdog window elapsed (${MAX_POLLS} polls) with no leg past the ${QUEUED_GRACE_MINUTES}-min grace — nothing reaped."
+
   android-kotlin-coverage:
     # Keep Android JVM coverage on the always-on Coverage workflow so
     # Codecov's main-branch head never drops back to `android: null`

--- a/.github/workflows/cross-platform-check.yml
+++ b/.github/workflows/cross-platform-check.yml
@@ -165,11 +165,26 @@ jobs:
         # without CP-1252 mangling — mirrors build.yml's Windows test
         # step. The `chcp 65001` must apply to the cmd subshell that
         # spawns the test binaries.
+        #
+        # Exit-status preservation (codex P1 on pulp#2536): under
+        # `shell: cmd` the step's exit code is the errorlevel of the
+        # LAST command. `ctest` writes to a log file we upload as an
+        # artifact, then `type` echoes it into the run log — but if
+        # `type` ran last its always-zero errorlevel would mask a real
+        # `ctest` failure, the job would go green on broken Windows
+        # tests, and the nightly tracking-issue logic would never fire
+        # for Windows. Capture `%ERRORLEVEL%` into CTEST_RC on the line
+        # IMMEDIATELY after `ctest` (before `type` overwrites it), then
+        # `exit /b` with that saved code so a Windows test failure
+        # correctly fails the step.
         shell: cmd
         run: |
           chcp 65001
           ctest --test-dir "%PULP_BUILD_DIR%" --output-on-failure -C Release -LE "validation|slow" -j8 --timeout 120 --exclude-regex "STFT|VisualizationBridge|Clipboard|Toolbar add items" > test-windows.log 2>&1
+          set CTEST_RC=%ERRORLEVEL%
           type test-windows.log
+          echo ctest exit code: %CTEST_RC%
+          exit /b %CTEST_RC%
 
       - name: Upload Windows build + test logs
         if: always()


### PR DESCRIPTION
Follow-up fix for two P1 Codex-review findings on CI workflows, both flagged on already-merged PRs.

## Finding 1 — `coverage.yml` queued-leg hang (Codex P1 on #2521)

> `timeout-minutes` only limits how long a job is allowed to run after it starts; it does not expire a job that is still queued waiting for a self-hosted runner. Under runner saturation (`PULP_COVERAGE_MACOS_RUNS_ON_JSON` with no idle macOS worker), this matrix leg can remain queued until GitHub's self-hosted queue timeout, so `coverage-diff-gate` (`needs: coverage`) can still stay blocked for hours and the required check remains stuck. [...] use an explicit queued-job reaper/fallback runner strategy instead of relying on `timeout-minutes` for queue control.

**Fix:** Added a `coverage-queue-watchdog` job. It:
- Runs on `ubuntu-latest` (never self-hosted, so it can never itself be the stuck thing) and starts immediately (no `needs:` on the matrix).
- Polls this run's own jobs via `gh api repos/{repo}/actions/runs/{run_id}/jobs`.
- If any `Coverage report (...)` leg has been `status==queued` past a 25-min grace window, cancels the whole run via `POST runs/{run_id}/cancel` (there is no public API to cancel a single matrix leg).
- Cancelling the run lets the required `Diff coverage required` gate reach a terminal `cancelled` conclusion instead of hanging indefinitely.
- Queued legs are aged from the run's `created_at` — the jobs API exposes no per-job `queued_at`, and `created_at` is when every leg (including the queued one) was created.
- Gated on the same `classify` output as the `coverage` matrix, bounded by its own `timeout-minutes`, and excludes its own job name from the scan.

This is complementary to the repo-wide `stale-run-reaper.yml`, which only fast-reaps whole runs after 8h `queued` / 4h `in_progress` and cannot reap a single queued matrix leg.

## Finding 2 — `cross-platform-check.yml` Windows ctest exit status (Codex P1 on #2536)

> This step can report success even when Windows tests fail: under `shell: cmd`, GitHub Actions uses `cmd.exe` semantics where the step exit code is from the **last** command, and here `type test-windows.log` runs after `ctest`. If `ctest` exits non-zero but `type` succeeds, the job is marked green, so the nightly tracker can miss real Windows regressions and incorrectly close/skip the Windows issue.

**Fix:** The Windows ctest step now captures `set CTEST_RC=%ERRORLEVEL%` on the line immediately after `ctest` (before `type` overwrites `%ERRORLEVEL%`), then `exit /b %CTEST_RC%` as the final command. A Windows test failure now correctly fails the step, so the nightly per-platform tracking-issue logic fires for Windows breakage. The UTF-8 `chcp 65001` behavior is unchanged.

## Skill update

`.agents/skills/ci/SKILL.md` (mapped to the `ci` skill):
- Corrected the existing queued-job gotcha, which incorrectly claimed `timeout-minutes` bounds queued time, and documented the watchdog as the fix for the queued-hang mode.
- Added a new gotcha on the `shell: cmd` last-command exit-code trap.

## Validation

- `yamllint --no-warnings -d relaxed` — clean on both files
- `actionlint -shellcheck=` — clean on both files
- `python3 -c "yaml.safe_load(...)"` — both files parse
- `shellcheck` on the watchdog `run:` block (with `${{ }}` expressions placeholdered) — clean
- `tools/scripts/gates.sh origin/main` — all gates pass

## Test plan

- [ ] CI green on this PR
- [ ] Next nightly `cross-platform-check.yml` run — Windows leg still runs and reports correctly
- [ ] Watchdog job appears in `coverage.yml` runs and exits cleanly when no leg is stuck

🤖 Generated with [Claude Code](https://claude.com/claude-code)