### PR TITLE
fix(render): populate resolved GPU timestamps in read_back() (Codex P1)

### DIFF
--- a/core/render/include/pulp/render/gpu_timestamps.hpp
+++ b/core/render/include/pulp/render/gpu_timestamps.hpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <optional>
 #include <vector>
 
@@ -37,6 +38,34 @@ inline constexpr std::uint32_t kTimestampsPerPass = 2;
 /// normalizes Metal/Vulkan/D3D12 hardware counters to ns for us, so
 /// unlike raw Vulkan there is no per-device `timestampPeriod` to apply.)
 inline constexpr double kNanosecondsPerMillisecond = 1.0e6;
+
+/// Decode a map-read timestamp buffer into a vector of raw `uint64_t`
+/// GPU-clock ticks.
+///
+/// `ResolveQuerySet` writes each timestamp as a little-endian `uint64_t`;
+/// after the resolve buffer is copied to a `MapRead` buffer and mapped,
+/// `wgpu::Buffer::GetConstMappedRange` hands back exactly those bytes.
+/// This helper is the *pure* seam between Dawn's mapped memory and the
+/// tick→ms math: it has no Dawn dependency, so a unit test can feed it a
+/// synthetic byte blob — exactly the bytes a real mapped buffer would
+/// carry — and assert that `read_back()` then surfaces populated,
+/// correctly-decoded ticks instead of an empty vector.
+///
+/// `byte_count` that is not a whole multiple of 8 is truncated to the
+/// last complete `uint64_t`; a null pointer or zero length yields an
+/// empty vector. The decode uses `std::memcpy` rather than a reinterpret
+/// cast so it is alignment-safe on every platform.
+[[nodiscard]] inline std::vector<std::uint64_t>
+decode_resolved_ticks(const std::byte* mapped_bytes, std::size_t byte_count) {
+    std::vector<std::uint64_t> ticks;
+    if (mapped_bytes == nullptr || byte_count < sizeof(std::uint64_t)) {
+        return ticks;
+    }
+    const std::size_t count = byte_count / sizeof(std::uint64_t);
+    ticks.resize(count);
+    std::memcpy(ticks.data(), mapped_bytes, count * sizeof(std::uint64_t));
+    return ticks;
+}
 
 /// Convert a raw begin/end GPU-timestamp pair (nanosecond ticks) into a
 /// pass duration in milliseconds.
@@ -162,12 +191,14 @@ enum class GpuTimestampSupport {
 ///
 /// Intended per-frame usage (driven by the GPU surface / render loop):
 ///   1. `begin_frame(pass_count)` — (re)size the QuerySet for the frame.
-///   2. For each pass, `timestamp_writes(i)` supplies the
-///      `timestampWrites` for that pass's render-pass descriptor.
-///   3. `resolve(encoder_handle)` — append `ResolveQuerySet` + copy.
-///   4. After the queue submits and the buffer maps, `read_back()`
-///      returns the resolved ticks; feed them through
-///      `resolve_pass_timings` + `apply_pass_timings`.
+///   2. Each pass's render-pass descriptor declares `timestampWrites`
+///      against this QuerySet (begin/end slots `2*i` and `2*i + 1`).
+///   3. `resolve(instance_handle)` — after the queue has submitted the
+///      frame's render passes, append a `ResolveQuerySet` + copy-to-
+///      readback command, submit it, and map-read the ticks into the
+///      internal buffer.
+///   4. `read_back()` returns the resolved ticks `resolve()` populated;
+///      feed them through `resolve_pass_timings` + `apply_pass_timings`.
 ///
 /// The 1-frame readback lag is inherent to GPU timestamp queries and is
 /// accepted by the spike spec (Phase 6.5, "1-frame lag is unavoidable").
@@ -199,9 +230,28 @@ public:
     /// when unsupported or when the size is unchanged.
     void begin_frame(std::size_t pass_count);
 
+    /// Resolve the frame's timestamp QuerySet and map-read the ticks.
+    ///
+    /// Encodes a `ResolveQuerySet` from the QuerySet into the resolve
+    /// buffer, copies that into a host-mappable buffer, submits the
+    /// command, and synchronously map-reads the `uint64_t` ticks into the
+    /// internal buffer that `read_back()` returns. `dawn_instance_handle`
+    /// is a `wgpu::Instance*` erased to `void*` (matching
+    /// `GpuSurface::dawn_instance_handle()`) — it is needed to pump
+    /// `ProcessEvents` while the asynchronous map completes.
+    ///
+    /// Returns true when a frame of ticks was resolved and is now
+    /// available via `read_back()`. Returns false — leaving the previous
+    /// `read_back()` result intact — when unsupported, when no QuerySet
+    /// has been sized yet, or when the map-read did not complete. Safe to
+    /// call with `nullptr` (then it just reports false). In a CPU-only
+    /// build this is a no-op that always returns false.
+    bool resolve(void* dawn_instance_handle);
+
     /// Read back the most recently resolved timestamp buffer as raw
     /// nanosecond ticks (`[begin0, end0, begin1, end1, ...]`). Empty
-    /// when unsupported or when no frame has resolved yet.
+    /// when unsupported or when no frame has resolved yet — populated by
+    /// the most recent successful `resolve()`.
     [[nodiscard]] std::vector<std::uint64_t> read_back() const;
 
 private:

--- a/core/render/src/gpu_timestamps.cpp
+++ b/core/render/src/gpu_timestamps.cpp
@@ -2,11 +2,19 @@
 
 #include <pulp/runtime/log.hpp>
 
+#include <chrono>
+#include <cstddef>
+#include <thread>
+
 // Phase 6.5 — Dawn GPU timestamp queries.
 //
 // The header (`gpu_timestamps.hpp`) carries the pure tick→ms conversion
-// math, which is unit-tested without a device. This file carries the
-// Dawn-specific QuerySet / resolve-buffer plumbing.
+// math and the `decode_resolved_ticks` byte-decode seam, both unit-
+// tested without a device. This file carries the Dawn-specific QuerySet
+// / resolve-buffer plumbing: `begin_frame` sizes the QuerySet, `resolve`
+// encodes `ResolveQuerySet` + a copy into a host-mappable buffer, maps
+// it, and decodes the ticks into `last_resolved` so `read_back` actually
+// returns live GPU numbers.
 //
 // The C++ WebGPU API (`webgpu/webgpu_cpp.h`, the `wgpu::` types) ships
 // inside Skia's bundled Dawn, so the real implementation gates on
@@ -120,6 +128,87 @@ void GpuTimestamps::begin_frame(std::size_t pass_count) {
     impl_->slot_capacity = slots;
 }
 
+bool GpuTimestamps::resolve(void* dawn_instance_handle) {
+    if (support_ != GpuTimestampSupport::supported || impl_ == nullptr) {
+        return false;
+    }
+    // begin_frame() must have created the QuerySet + buffers first. A
+    // zero-pass frame leaves them null; nothing to resolve.
+    if (impl_->query_set == nullptr || impl_->resolve_buffer == nullptr ||
+        impl_->readback_buffer == nullptr || impl_->slot_capacity == 0) {
+        return false;
+    }
+
+    // The instance is required to pump `ProcessEvents` while the async
+    // buffer map completes — Dawn never advances callbacks on its own.
+    if (dawn_instance_handle == nullptr) {
+        return false;
+    }
+    auto* instance = static_cast<wgpu::Instance*>(dawn_instance_handle);
+    if (instance == nullptr || *instance == nullptr) {
+        return false;
+    }
+
+    const std::uint64_t bytes =
+        static_cast<std::uint64_t>(impl_->slot_capacity) * sizeof(std::uint64_t);
+
+    // Encode: ResolveQuerySet writes the QuerySet's ticks into the
+    // resolve buffer; CopyBufferToBuffer stages them into the host-
+    // mappable readback buffer. One encoder, one submit.
+    wgpu::CommandEncoderDescriptor enc_desc{};
+    enc_desc.label = "Pulp Timestamp Resolve";
+    wgpu::CommandEncoder encoder = impl_->device.CreateCommandEncoder(&enc_desc);
+    encoder.ResolveQuerySet(impl_->query_set, 0, impl_->slot_capacity,
+                            impl_->resolve_buffer, 0);
+    encoder.CopyBufferToBuffer(impl_->resolve_buffer, 0,
+                               impl_->readback_buffer, 0, bytes);
+    wgpu::CommandBuffer cmd = encoder.Finish();
+    impl_->device.GetQueue().Submit(1, &cmd);
+
+    // Map the readback buffer for host reads. The map is asynchronous;
+    // pump `ProcessEvents` until the callback fires or a deadline trips.
+    // The deadline mirrors `gpu_compute.cpp`'s readback path so a wedged
+    // GPU degrades to "no sample this frame" instead of hanging.
+    bool mapped = false;
+    bool ok = false;
+    impl_->readback_buffer.MapAsync(
+        wgpu::MapMode::Read, 0, static_cast<std::size_t>(bytes),
+        wgpu::CallbackMode::AllowProcessEvents,
+        [&mapped, &ok](wgpu::MapAsyncStatus status, wgpu::StringView) {
+            mapped = true;
+            ok = (status == wgpu::MapAsyncStatus::Success);
+        });
+
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (!mapped && std::chrono::steady_clock::now() < deadline) {
+        instance->ProcessEvents();
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    if (!mapped || !ok) {
+        // On timeout the buffer may still be mid-map; leave it and keep
+        // the previous `last_resolved` so the inspector shows stale-but-
+        // honest numbers rather than flickering to empty.
+        runtime::log_info("GpuTimestamps: timestamp readback did not map");
+        return false;
+    }
+
+    const void* data = impl_->readback_buffer.GetConstMappedRange(
+        0, static_cast<std::size_t>(bytes));
+    if (data == nullptr) {
+        impl_->readback_buffer.Unmap();
+        return false;
+    }
+
+    // Decode the mapped bytes through the pure, Dawn-free helper — the
+    // same path the unit tests exercise with synthetic bytes.
+    impl_->last_resolved = decode_resolved_ticks(
+        static_cast<const std::byte*>(data), static_cast<std::size_t>(bytes));
+    impl_->readback_buffer.Unmap();
+    return !impl_->last_resolved.empty();
+}
+
 std::vector<std::uint64_t> GpuTimestamps::read_back() const {
     if (impl_ == nullptr) {
         return {};
@@ -145,6 +234,8 @@ bool GpuTimestamps::initialize(void* /*dawn_device_handle*/) {
 }
 
 void GpuTimestamps::begin_frame(std::size_t /*pass_count*/) {}
+
+bool GpuTimestamps::resolve(void* /*dawn_instance_handle*/) { return false; }
 
 std::vector<std::uint64_t> GpuTimestamps::read_back() const { return {}; }
 

--- a/test/test_gpu_timestamps.cpp
+++ b/test/test_gpu_timestamps.cpp
@@ -1,14 +1,20 @@
 // Phase 6.5 — Dawn GPU timestamp queries.
 //
 // These tests cover the *pure* resolution layer of `gpu_timestamps.hpp`:
-// the nanosecond-tick -> millisecond conversion, the resolved-buffer ->
-// per-pass walk, and the RenderPassManager integration. They run without
-// a live GPU device by feeding synthetic resolved-buffer values, so they
+// the nanosecond-tick -> millisecond conversion, the `decode_resolved_
+// ticks` mapped-buffer byte decode, the resolved-buffer -> per-pass walk,
+// and the RenderPassManager integration. They run without a live GPU
+// device by feeding synthetic resolved-buffer bytes/values, so they
 // execute on every CI lane (including the no-GPU sanitizer matrix).
 //
+// `decode_resolved_ticks` is the seam `GpuTimestamps::resolve()` uses to
+// turn a mapped Dawn readback buffer into ticks — covering it here is
+// what proves `read_back()` surfaces populated, correctly-converted
+// numbers rather than the empty vector the Phase 6.5 P1 review flagged.
+//
 // Live-device smoke (a real `wgpu::QuerySet` resolved against Metal/
-// Vulkan) is deferred to CI's GPU matrix; the math asserted here is the
-// part that historically hides perf bugs.
+// Vulkan via `resolve()`) is deferred to CI's GPU matrix; the math and
+// decode asserted here are the parts that historically hide perf bugs.
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -16,10 +22,29 @@
 #include <pulp/render/gpu_timestamps.hpp>
 #include <pulp/render/render_pass.hpp>
 
+#include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <vector>
 
 using namespace pulp::render;
+
+namespace {
+
+// Pack a vector of ticks into the little-endian uint64 byte layout that
+// `wgpu::Buffer::GetConstMappedRange` hands back after a real
+// `ResolveQuerySet` + copy. This is the synthetic stand-in for a mapped
+// Dawn buffer — feeding it through `decode_resolved_ticks` exercises the
+// exact decode path `GpuTimestamps::resolve()` uses on a live device.
+std::vector<std::byte> pack_ticks(const std::vector<std::uint64_t>& ticks) {
+    std::vector<std::byte> bytes(ticks.size() * sizeof(std::uint64_t));
+    if (!ticks.empty()) {
+        std::memcpy(bytes.data(), ticks.data(), bytes.size());
+    }
+    return bytes;
+}
+
+}  // namespace
 
 // ── timestamp_pair_to_ms — nanosecond conversion ────────────────────────────
 
@@ -65,6 +90,78 @@ TEST_CASE("timestamp_pair_to_ms treats an equal pair as zero duration",
     auto ms = timestamp_pair_to_ms(7'777, 7'777);
     REQUIRE(ms.has_value());
     REQUIRE(*ms == Catch::Approx(0.0));
+}
+
+// ── decode_resolved_ticks — mapped-buffer byte decode ───────────────────────
+//
+// This is the seam the Phase 6.5 P1 review flagged: before this layer
+// existed, `GpuTimestamps::read_back()` returned an internal vector that
+// nothing ever populated, so GPU timings never surfaced even when the
+// device supported `timestamp-query`. `resolve()` now decodes the
+// mapped readback buffer through `decode_resolved_ticks`; these cases
+// pin that decode against the byte layout a real mapped buffer carries.
+
+TEST_CASE("decode_resolved_ticks decodes a mapped timestamp buffer",
+          "[render][gpu-timestamps]") {
+    // The bytes a real resolved + map-read buffer would hold for a
+    // two-pass frame: [begin0, end0, begin1, end1].
+    const std::vector<std::uint64_t> ticks = {
+        1'000, 1'000 + 2'000'000,
+        9'000, 9'000 + 500'000,
+    };
+    const auto bytes = pack_ticks(ticks);
+
+    const auto decoded = decode_resolved_ticks(bytes.data(), bytes.size());
+    REQUIRE(decoded == ticks);
+
+    // The decoded ticks feed straight into the existing per-pass walk —
+    // proving the resolve path produces a populated, usable result.
+    const auto timings = resolve_pass_timings(decoded, 2);
+    REQUIRE(timings.size() == 2);
+    REQUIRE(timings[0].valid);
+    REQUIRE(timings[0].gpu_time_ms == Catch::Approx(2.0));
+    REQUIRE(timings[1].valid);
+    REQUIRE(timings[1].gpu_time_ms == Catch::Approx(0.5));
+}
+
+TEST_CASE("decode_resolved_ticks round-trips large 64-bit tick values",
+          "[render][gpu-timestamps]") {
+    // GPU clocks are wide — make sure no value is truncated to 32 bits.
+    const std::vector<std::uint64_t> ticks = {
+        0x0000'0001'0000'0000ULL,             // 2^32 — would vanish if truncated
+        0xFFFF'FFFF'FFFF'FFFFULL,             // max uint64
+        0x0123'4567'89AB'CDEFULL,
+    };
+    const auto bytes = pack_ticks(ticks);
+    const auto decoded = decode_resolved_ticks(bytes.data(), bytes.size());
+    REQUIRE(decoded == ticks);
+}
+
+TEST_CASE("decode_resolved_ticks returns empty for a null or short buffer",
+          "[render][gpu-timestamps]") {
+    // A device that never mapped the buffer hands back null / nothing —
+    // the decode must yield an empty vector, never read out of bounds.
+    REQUIRE(decode_resolved_ticks(nullptr, 64).empty());
+    REQUIRE(decode_resolved_ticks(nullptr, 0).empty());
+
+    const std::vector<std::uint64_t> one = {42};
+    const auto bytes = pack_ticks(one);
+    REQUIRE(decode_resolved_ticks(bytes.data(), 0).empty());
+    // Fewer than 8 bytes — no whole uint64 to decode.
+    REQUIRE(decode_resolved_ticks(bytes.data(), 7).empty());
+}
+
+TEST_CASE("decode_resolved_ticks truncates a partial trailing tick",
+          "[render][gpu-timestamps]") {
+    // A short or partial readback (e.g. only 1.5 uint64s landed) decodes
+    // to the last *whole* tick; resolve_pass_timings then tolerates the
+    // truncated tail by marking missing passes invalid.
+    const std::vector<std::uint64_t> ticks = {111, 222};
+    const auto bytes = pack_ticks(ticks);
+    // 12 bytes = one whole uint64 + 4 trailing bytes.
+    const auto decoded = decode_resolved_ticks(bytes.data(), 12);
+    REQUIRE(decoded.size() == 1);
+    REQUIRE(decoded[0] == 111);
 }
 
 // ── resolve_pass_timings — resolved-buffer walk ─────────────────────────────
@@ -259,6 +356,11 @@ TEST_CASE("GpuTimestamps degrades gracefully with no device",
 
     // No-ops, no crash.
     ts.begin_frame(4);
+    REQUIRE(ts.read_back().empty());
+
+    // resolve() with no device (and a null instance) must report false
+    // and never crash — the same safe path the CPU-only build takes.
+    REQUIRE_FALSE(ts.resolve(nullptr));
     REQUIRE(ts.read_back().empty());
 }
 


### PR DESCRIPTION
Follow-up to #2516 (Codex P1 review finding).

The Dawn GpuTimestamps implementation created the QuerySet and the
resolve/readback buffers in begin_frame(), but nothing ever ran the
ResolveQuerySet + buffer-map path that fills impl_->last_resolved. So
read_back() always returned an empty vector even when timestamp-query
was supported and init succeeded — GPU timings never surfaced.

Wire the missing path:

- Add GpuTimestamps::resolve(void* dawn_instance_handle): encodes
  ResolveQuerySet from the timestamp QuerySet into the resolve buffer,
  copies it into the host-mappable readback buffer, submits, then
  synchronously map-reads the uint64 ticks (pumping ProcessEvents with
  the same 2s deadline gpu_compute.cpp's readback uses).
- Add decode_resolved_ticks(): a pure, Dawn-free helper in the header
  that turns mapped buffer bytes into a tick vector via alignment-safe
  memcpy. resolve() decodes through it; this is the unit-testable seam.
- read_back() now returns the vector resolve() populated. The CPU-only
  stub resolve() is a no-op returning false; degrades gracefully when
  timestamp-query is unsupported or the device/instance is absent.

Tests: extend test_gpu_timestamps.cpp with decode_resolved_ticks cases
(full decode -> resolve_pass_timings round-trip, 64-bit values, null/
short buffers, partial-tail truncation) and a CPU-only resolve(nullptr)
degradation assertion — the exact gap the P1 calls out. Live-device
QuerySet resolution stays deferred to CI's GPU matrix.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>