### PR TITLE
fix(view): address Codex P1/P2 findings on lock-to-source + token-lock

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -468,7 +468,12 @@ token export) are separate phases and are NOT in this engine.
   name) onto the camelCase `el.style.<name>` surface. Hyphen/snake
   fragments camelCase. The allow-list is exactly the set of properties
   `generate_node()` emits — an unknown / mistyped path reports
-  `unsupported_property` instead of writing a bogus assignment.
+  `unsupported_property` instead of writing a bogus assignment. A few
+  leaves *alias* onto a different `el.style.<name>` than their camelCase
+  spelling: `backgroundGradient` maps to `background` because web-compat
+  codegen represents gradient fills as `el.style.background`. If you add
+  a token leaf whose camelCase spelling differs from the codegen
+  property, add an alias line next to the `backgroundGradient` mapping.
 - **Status semantics** — `rewritten` / `inserted` mutate the text;
   `already_current` is the idempotent re-lock no-op; `anchor_not_found`
   and `unsupported_property` are graceful failures that leave the
@@ -487,6 +492,15 @@ token export) are separate phases and are NOT in this engine.
 If you add a codegen property to `design_codegen.cpp`'s `generate_node`,
 add it to the `kKnown` allow-list in `lock_property_to_style_name()` too
 — otherwise that property can never be locked to source.
+
+**Control-char escaping in the rewritten literal:** `escape_js_single()`
+escapes the value before it is spliced into the `'<value>'` literal. It
+must handle more than `\` and `'` — a pasted multi-line CSS value (e.g. a
+`background` shorthand split over lines) carries `\n` / `\r` / `\t` and
+other C0 control chars that would otherwise terminate the string literal
+and produce syntactically invalid generated JS. The helper escapes
+`\n`/`\r`/`\t` by name and any remaining char `< 0x20` as `\xNN`. Same
+rule as the `js_single_quote_escape()` requirement for emitted user text.
 
 ### Phase 4c — token lock-to-source (`DESIGN.md` rewrite)
 

--- a/core/view/src/lock_to_source.cpp
+++ b/core/view/src/lock_to_source.cpp
@@ -114,15 +114,33 @@ std::string lower(const std::string& s) {
     return out;
 }
 
-// Escape a value for emission inside a JS single-quoted literal. Mirrors
-// the codegen's js_single_quote_escape for the characters a style value
-// can realistically contain (quotes, backslashes).
+// Escape a value for emission inside a JS single-quoted literal. Handles
+// quotes and backslashes, plus control characters: a pasted multi-line
+// CSS value can carry newlines / tabs that would otherwise terminate the
+// `'<value>'` literal and produce syntactically invalid generated JS.
 std::string escape_js_single(const std::string& s) {
     std::string out;
     out.reserve(s.size() + 2);
-    for (char c : s) {
-        if (c == '\\' || c == '\'') out += '\\';
-        out += c;
+    for (unsigned char c : s) {
+        switch (c) {
+            case '\\': out += "\\\\"; break;
+            case '\'': out += "\\'"; break;
+            case '\n': out += "\\n"; break;
+            case '\r': out += "\\r"; break;
+            case '\t': out += "\\t"; break;
+            default:
+                if (c < 0x20) {
+                    // Any remaining C0 control char as a `\xNN` escape so
+                    // the resulting string literal is always valid JS.
+                    static const char* kHex = "0123456789abcdef";
+                    out += "\\x";
+                    out += kHex[(c >> 4) & 0xF];
+                    out += kHex[c & 0xF];
+                } else {
+                    out += static_cast<char>(c);
+                }
+                break;
+        }
     }
     return out;
 }
@@ -150,7 +168,13 @@ lock_property_to_style_name(const std::string& property_path) {
     // flat `el.style.<name>` rewrite.
     if (leaf.find('.') != std::string::npos) return std::nullopt;
 
-    const std::string camel = to_camel(leaf);
+    std::string camel = to_camel(leaf);
+
+    // A few token-path leaves alias onto a different `el.style.<name>`
+    // surface than their camelCase spelling. The web-compat codegen
+    // represents gradient fills as `el.style.background`, so a
+    // `backgroundGradient` tweak path is valid and maps to `background`.
+    if (camel == "backgroundGradient") camel = "background";
 
     // Allow-list of style properties the web-compat codegen actually
     // emits as `el.style.<name>` (design_codegen.cpp generate_node()).

--- a/core/view/src/token_lock.cpp
+++ b/core/view/src/token_lock.cpp
@@ -113,26 +113,40 @@ LineIndex index_lines(const std::string& text) {
 // ── YAML scalar helpers ─────────────────────────────────────────────────
 
 // Render a YAML scalar value for embedding back into the frontmatter.
-// DESIGN.md colors and dimensions are conventionally double-quoted in
-// the upstream fixtures ("#855300", "1.5rem"); preserving that keeps the
-// rewritten file diff-clean. `quoted` controls whether to wrap the value
-// — callers pass the original token's quoting so a lock never changes
-// the quote style of a value that was already (un)quoted.
-std::string render_scalar(const std::string& value, bool quoted) {
-    if (!quoted) return value;
-    std::string out = "\"";
-    for (char c : value) {
-        if (c == '"' || c == '\\') out += '\\';
-        out += c;
+// DESIGN.md colors and dimensions are conventionally quoted in the
+// upstream fixtures ("#855300", "1.5rem"); preserving that keeps the
+// rewritten file diff-clean. `quote_char` is the ORIGINAL quote
+// character the token was written with (`"` or `'`), or `'\0'` when the
+// value was unquoted — so a lock never changes the quote style.
+std::string render_scalar(const std::string& value, char quote_char) {
+    if (quote_char == '\0') return value;
+    std::string out(1, quote_char);
+    if (quote_char == '"') {
+        // Double-quoted YAML supports backslash escapes.
+        for (char c : value) {
+            if (c == '"' || c == '\\') out += '\\';
+            out += c;
+        }
+    } else {
+        // Single-quoted YAML escapes a literal quote by doubling it and
+        // has no backslash escaping.
+        for (char c : value) {
+            if (c == '\'') out += '\'';
+            out += c;
+        }
     }
-    out += '"';
+    out += quote_char;
     return out;
 }
 
-// True when a value as written in YAML source begins with a quote.
-bool source_value_is_quoted(std::string_view trimmed_value) {
-    return !trimmed_value.empty() &&
-           (trimmed_value.front() == '"' || trimmed_value.front() == '\'');
+// The quote character a value was written with in YAML source — `"` or
+// `'` — or `'\0'` when the value is unquoted.
+char source_value_quote_char(std::string_view trimmed_value) {
+    if (!trimmed_value.empty() &&
+        (trimmed_value.front() == '"' || trimmed_value.front() == '\'')) {
+        return trimmed_value.front();
+    }
+    return '\0';
 }
 
 // Given a `key: value` source line, return the [start, end) byte range
@@ -405,7 +419,8 @@ TokenLockResult lock_token_in_designmd(const std::string& markdown,
     }
 
     std::string old_value_raw = line.substr(value_start, value_end - value_start);
-    const bool was_quoted = source_value_is_quoted(old_value_raw);
+    const char quote_char = source_value_quote_char(old_value_raw);
+    const bool was_quoted = quote_char != '\0';
 
     // Record the previous value with surrounding quotes stripped so the
     // caller sees the semantic value, not the YAML spelling.
@@ -414,7 +429,9 @@ TokenLockResult lock_token_in_designmd(const std::string& markdown,
         previous = previous.substr(1, previous.size() - 2);
     }
 
-    std::string rendered = render_scalar(new_value, was_quoted);
+    // Re-emit with the SAME quote character the token was written with,
+    // so a single-quoted token stays single-quoted after the rewrite.
+    std::string rendered = render_scalar(new_value, quote_char);
 
     // Splice the new value into the line, then the line back into the
     // file. Every byte outside [value_start, value_end) is preserved,

--- a/test/test_lock_to_source.cpp
+++ b/test/test_lock_to_source.cpp
@@ -440,3 +440,100 @@ TEST_CASE("lock-to-source round-trips a style-color tweak against re-codegen", "
 
     REQUIRE(locked.source == regen);
 }
+
+// ── Finding 1: control chars in a tweak value escape into valid JS ─────
+//
+// A pasted multi-line CSS value (e.g. a `background` shorthand split over
+// lines) carries newlines / tabs. The rewritten `'<value>'` literal must
+// stay syntactically valid JS — raw control characters would terminate
+// the string literal and break the generated artifact.
+
+TEST_CASE("lock-to-source escapes control chars in the tweak value",
+          "[lock-to-source][issue-1307]") {
+    CodeGenOptions opts;
+    opts.mode = CodeGenMode::web_compat;
+    opts.include_comments = true;
+
+    DesignIR original = make_panel_ir();
+    const std::string gen = generate_pulp_js(original, opts);
+    const std::string anchor = *original.root.children.front().stable_anchor_id;
+
+    // Value with embedded newline, carriage return, tab, and a vertical
+    // tab (0x0B — a remaining C0 control char). The vertical tab is
+    // spelled via octal (`\013`) so the following `e` is not swallowed
+    // into a `\xNN` escape.
+    LockToSourceTweak tweak{anchor, "paint.background",
+                            std::string("a\nb\rc\td\013e")};
+    LockResult locked = lock_tweak_into_source(gen, tweak);
+    REQUIRE((locked.status == LockStatus::rewritten ||
+             locked.status == LockStatus::inserted));
+
+    // The literal in the generated source is exactly the escaped form —
+    // no raw control byte survives.
+    REQUIRE(locked.source.find("'a\\nb\\rc\\td\\x0be'") !=
+            std::string::npos);
+    // No raw control character appears anywhere in the rewritten value
+    // (the un-escaped form is absent).
+    REQUIRE(locked.source.find("a\nb\rc\td\013e") == std::string::npos);
+}
+
+TEST_CASE("lock-to-source escapes a backslash and quote together",
+          "[lock-to-source][issue-1307]") {
+    CodeGenOptions opts;
+    opts.mode = CodeGenMode::web_compat;
+    opts.include_comments = true;
+
+    DesignIR original = make_panel_ir();
+    const std::string gen = generate_pulp_js(original, opts);
+    const std::string anchor = *original.root.children.front().stable_anchor_id;
+
+    LockToSourceTweak tweak{anchor, "paint.background",
+                            std::string("url('x\\y')")};
+    LockResult locked = lock_tweak_into_source(gen, tweak);
+    REQUIRE((locked.status == LockStatus::rewritten ||
+             locked.status == LockStatus::inserted));
+    // Backslash doubled, single quotes escaped.
+    REQUIRE(locked.source.find("'url(\\'x\\\\y\\')'") != std::string::npos);
+}
+
+// ── Finding 2: `backgroundGradient` tweak paths map to `background` ────
+//
+// Web-compat codegen represents gradient fills as `el.style.background`.
+// A `paint.backgroundGradient` / `style.backgroundGradient` tweak path is
+// therefore valid and must resolve to the `background` style property.
+
+TEST_CASE("backgroundGradient tweak path maps to the background property",
+          "[lock-to-source][issue-1307]") {
+    auto paint = lock_property_to_style_name("paint.backgroundGradient");
+    REQUIRE(paint.has_value());
+    CHECK(*paint == "background");
+
+    auto style = lock_property_to_style_name("style.backgroundGradient");
+    REQUIRE(style.has_value());
+    CHECK(*style == "background");
+
+    // Bare leaf (no namespace) resolves the same way.
+    auto bare = lock_property_to_style_name("backgroundGradient");
+    REQUIRE(bare.has_value());
+    CHECK(*bare == "background");
+}
+
+TEST_CASE("a backgroundGradient tweak rewrites the background style line",
+          "[lock-to-source][issue-1307]") {
+    CodeGenOptions opts;
+    opts.mode = CodeGenMode::web_compat;
+    opts.include_comments = true;
+
+    DesignIR original = make_panel_ir();
+    const std::string gen = generate_pulp_js(original, opts);
+    const std::string anchor = *original.root.children.front().stable_anchor_id;
+
+    LockToSourceTweak tweak{anchor, "paint.backgroundGradient",
+                            "linear-gradient(#000, #fff)"};
+    LockResult locked = lock_tweak_into_source(gen, tweak);
+    REQUIRE(locked.status != LockStatus::unsupported_property);
+    CHECK(locked.style_property == "background");
+    REQUIRE(locked.source.find(
+        ".style.background = 'linear-gradient(#000, #fff)';") !=
+            std::string::npos);
+}

--- a/test/test_token_lock.cpp
+++ b/test/test_token_lock.cpp
@@ -288,3 +288,44 @@ TEST_CASE("a locked DESIGN.md re-parses with the updated token",
     REQUIRE(it != parsed.ir.tokens.colors.end());
     CHECK(it->second == "#123456");
 }
+
+// ── Finding 3: a lock preserves the ORIGINAL quote character ──────────
+//
+// A token written with single quotes must stay single-quoted after a
+// rewrite; double stays double; unquoted stays unquoted. The locator
+// records the actual quote char, not just a bool, so render_scalar can
+// re-emit it verbatim.
+
+TEST_CASE("lock_token_in_designmd keeps a single-quoted value single-quoted",
+          "[view][token-lock][issue-1307]") {
+    std::string md =
+        "---\nname: Quotes\ncolors:\n  primary: '#855300'\n---\n";
+    auto result = lock_token_in_designmd(md, "", "colors.primary", "#123456");
+    REQUIRE(result.ok);
+    // Single quotes preserved, double quotes never introduced.
+    CHECK(result.updated_markdown.find("primary: '#123456'") !=
+          std::string::npos);
+    CHECK(result.updated_markdown.find("\"#123456\"") == std::string::npos);
+}
+
+TEST_CASE("lock_token_in_designmd keeps a double-quoted value double-quoted",
+          "[view][token-lock][issue-1307]") {
+    std::string md =
+        "---\nname: Quotes\ncolors:\n  primary: \"#855300\"\n---\n";
+    auto result = lock_token_in_designmd(md, "", "colors.primary", "#123456");
+    REQUIRE(result.ok);
+    CHECK(result.updated_markdown.find("primary: \"#123456\"") !=
+          std::string::npos);
+    CHECK(result.updated_markdown.find("'#123456'") == std::string::npos);
+}
+
+TEST_CASE("lock_token_in_designmd keeps an unquoted value unquoted",
+          "[view][token-lock][issue-1307]") {
+    std::string md =
+        "---\nname: Quotes\nspacing:\n  md: 24px\n---\n";
+    auto result = lock_token_in_designmd(md, "", "spacing.md", "30px");
+    REQUIRE(result.ok);
+    CHECK(result.updated_markdown.find("md: 30px") != std::string::npos);
+    CHECK(result.updated_markdown.find("\"30px\"") == std::string::npos);
+    CHECK(result.updated_markdown.find("'30px'") == std::string::npos);
+}

--- a/tools/scripts/source_tree_pollution_check.py
+++ b/tools/scripts/source_tree_pollution_check.py
@@ -102,6 +102,7 @@ ALLOWED_ROOT_PATHS = frozenset({
     "apple",
     "bindings",
     "ci",
+    "compat",
     "core",
     "docs",
     "examples",


### PR DESCRIPTION
Three review findings on the merged inspector-roadmap PRs:

- P1: escape_js_single() in lock_to_source.cpp only escaped backslash
  and single-quote, so a tweak value carrying newlines/tabs/other C0
  control chars produced syntactically invalid generated JS. Now
  escapes \n/\r/\t by name and any remaining char < 0x20 as \xNN.
- P2: lock_property_to_style_name() rejected backgroundGradient tweak
  paths. Web-compat codegen represents gradient fills as
  el.style.background, so backgroundGradient now aliases to background.
- P2: lock_token_in_designmd() tracked quoting as a bool and
  render_scalar always emitted double quotes, rewriting a
  single-quoted token as double-quoted. Quote tracking now records the
  actual original quote character and re-emits it verbatim.

Each fix ships with Catch2 coverage in test_lock_to_source.cpp /
test_token_lock.cpp. import-design SKILL.md gains the escaping and
property-alias gotchas.

Also adds the tracked `compat/` directory to ALLOWED_ROOT_PATHS in
source_tree_pollution_check.py — it was added by #2531 (compat.json
split into per-surface parts) without the companion allowlist update,
which blocks every push until corrected.

Follow-up to #2470 and #2508 (Codex review findings).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>