### PR TITLE
feat(render): add Skia .skp frame capture (inspector Phase 6.4)

### DIFF
--- a/core/render/CMakeLists.txt
+++ b/core/render/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(pulp-render PRIVATE
     src/gpu_compute.cpp
     src/gpu_timestamps.cpp
     src/skia_surface.cpp
+    src/skp_capture.cpp
     src/render_loop.cpp
     src/draco_decoder.cpp
     src/ktx2_decoder.cpp

--- a/core/render/include/pulp/render/skp_capture.hpp
+++ b/core/render/include/pulp/render/skp_capture.hpp
@@ -1,0 +1,129 @@
+#pragma once
+
+// skp_capture.hpp — Skia `.skp` (SkPicture) frame capture.
+//
+// Phase 6.4 of the inspector GPU-perf roadmap
+// (planning/2026-05-19-inspector-phase6-gpu-perf-spike.md § Phase 6.4).
+//
+// The capture writes a rendered frame as a Skia `.skp` artifact that
+// Skia's own `skiadebugger` can replay op-by-op. This is the bridge
+// from "a frame looked weird in Pulp" to the best-in-class external
+// frame-debugging tool — for free, because Skia ships the format.
+//
+// Design (from the Phase 6.4 spike, which de-risked this in PR #2506):
+//
+//   * `.skp` is the legacy `SkPicture` serialization format. It is
+//     fully backend-independent — an `SkPictureRecorder` records draw
+//     ops into a backend-agnostic `SkRecord`, and nothing in the
+//     Graphite headers references `SkPicture`. So a capture works
+//     regardless of which GPU backend (Graphite/Dawn) the process runs
+//     and even with no live GPU context at all. We do NOT serialize a
+//     `skgpu::graphite::Recording` (that is the GPU command bundle, not
+//     a `.skp`).
+//
+//   * Capture re-runs the frame's draw ops into a fresh recording
+//     canvas. `SkpFrameCapture` owns an `SkPictureRecorder` and exposes
+//     a `pulp::canvas::Canvas` over its recording `SkCanvas`, so
+//     existing view-paint code paints into the capture exactly as it
+//     paints a live frame. Capture is a user-triggered action, never a
+//     per-frame cost.
+//
+//   * The one caveat the spike pinned: `SkPicture::serialize()` drops
+//     embedded `SkImage`s to `nullptr` by default. `SkpFrameCapture`
+//     always supplies `SkSerialProcs::fImageProc` (PNG-encode) so
+//     atlas/image draws survive the round trip. A replayer (skiadebugger,
+//     or a test) reads the artifact with the matching
+//     `SkDeserialProcs::fImageProc` that decodes the PNG payload back to
+//     an `SkImage`.
+//
+// Graceful degradation: when Skia is not compiled in, `SkpFrameCapture`
+// reports `available() == false`, `canvas()` returns `nullptr`, and the
+// capture functions return a failed `SkpCaptureResult` with a reason
+// string — no crash, no partial file.
+
+#include <pulp/canvas/canvas.hpp>
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace pulp::render {
+
+/// Outcome of a `.skp` capture attempt. A capture either produces a
+/// valid `.skp` artifact (`ok == true`, `bytes_written > 0`) or fails
+/// with a human-readable `reason` — never a half-written file.
+struct SkpCaptureResult {
+    bool ok = false;             ///< True when a `.skp` artifact was produced.
+    std::string path;            ///< Filesystem path of the written `.skp`, when ok.
+    std::size_t bytes_written = 0; ///< Size of the serialized `.skp` blob.
+    std::size_t op_count = 0;    ///< Approximate recorded draw-op count.
+    std::string reason;          ///< Failure explanation when `!ok`.
+
+    explicit operator bool() const { return ok; }
+};
+
+/// Records a single frame's draw ops into an `SkPicture` and serializes
+/// it to a `.skp` artifact.
+///
+/// Usage:
+///   SkpFrameCapture capture(width, height);
+///   if (capture.available()) {
+///       root_view.paint_all(*capture.canvas());   // re-run the paint
+///       auto result = capture.finish_to_file(path);
+///   }
+///
+/// The capture canvas is a normal `pulp::canvas::Canvas`, so any code
+/// that paints a live frame paints a capture frame unchanged. After
+/// `finish_to_file` / `finish_to_memory` the capture is consumed and
+/// `canvas()` returns `nullptr`.
+class SkpFrameCapture {
+public:
+    /// Begin a capture sized to `width` x `height` logical pixels.
+    /// The cull rect of the recorded `SkPicture` is `[0,0,width,height]`.
+    SkpFrameCapture(int width, int height);
+    ~SkpFrameCapture();
+
+    SkpFrameCapture(const SkpFrameCapture&) = delete;
+    SkpFrameCapture& operator=(const SkpFrameCapture&) = delete;
+
+    /// True when Skia is compiled in and the recording canvas exists.
+    /// False builds degrade gracefully — `canvas()` is `nullptr` and
+    /// `finish_*` return a failed result.
+    bool available() const;
+
+    /// The canvas to paint the frame into. Valid until `finish_*` is
+    /// called or the capture is destroyed; `nullptr` when unavailable.
+    canvas::Canvas* canvas();
+
+    /// Finish recording and write the `.skp` to `path`.
+    /// Embedded images are PNG-encoded via `SkSerialProcs::fImageProc`.
+    /// Consumes the capture: a second call returns a failed result.
+    SkpCaptureResult finish_to_file(const std::string& path);
+
+    /// Finish recording and serialize the `.skp` into `out_blob`
+    /// (raw `.skp` bytes). Useful for tests and in-memory transport.
+    /// Consumes the capture.
+    SkpCaptureResult finish_to_memory(std::string& out_blob);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+/// One-shot helper: capture a frame by handing a paint callback the
+/// capture canvas, then writing the `.skp` to `path`.
+///
+/// The callback paints whatever should appear in the frame. When Skia
+/// is unavailable, or `width`/`height` are non-positive, this returns a
+/// failed `SkpCaptureResult` with a reason and writes nothing.
+SkpCaptureResult capture_skp_to_file(
+    int width, int height, const std::string& path,
+    const std::function<void(canvas::Canvas&)>& paint);
+
+/// `true` when this build can produce `.skp` captures (Skia compiled
+/// in). Lets callers (inspector / CLI) report an honest "unavailable"
+/// instead of attempting a doomed capture.
+bool skp_capture_supported();
+
+} // namespace pulp::render

--- a/core/render/src/skp_capture.cpp
+++ b/core/render/src/skp_capture.cpp
@@ -1,0 +1,226 @@
+#include <pulp/render/skp_capture.hpp>
+
+#ifdef PULP_HAS_SKIA
+
+#include <pulp/canvas/skia_canvas.hpp>
+#include <pulp/runtime/log.hpp>
+
+#include "include/core/SkCanvas.h"
+#include "include/core/SkData.h"
+#include "include/core/SkImage.h"
+#include "include/core/SkPicture.h"
+#include "include/core/SkPictureRecorder.h"
+#include "include/core/SkRect.h"
+#include "include/core/SkRefCnt.h"
+#include "include/core/SkSerialProcs.h"
+#include "include/core/SkStream.h"
+#include "include/encode/SkPngEncoder.h"
+
+namespace pulp::render {
+
+namespace {
+
+// Serialize-side image proc. SkPicture::serialize() drops embedded
+// SkImages to nullptr by default (documented in SkPicture.h); this
+// PNG-encodes them so atlas/image draws survive into the .skp. This is
+// the contract the Phase 6.4 spike pinned in test_skia_surface.cpp.
+sk_sp<SkData> encode_embedded_image(SkImage* image, void* /*ctx*/) {
+    if (!image) return nullptr;
+    return SkPngEncoder::Encode(nullptr, image, SkPngEncoder::Options{});
+}
+
+// Build the SkSerialProcs every Pulp .skp capture uses.
+SkSerialProcs pulp_serial_procs() {
+    SkSerialProcs procs;
+    procs.fImageProc = &encode_embedded_image;
+    return procs;
+}
+
+} // namespace
+
+struct SkpFrameCapture::Impl {
+    SkPictureRecorder recorder;
+    std::unique_ptr<canvas::SkiaCanvas> canvas;
+    bool consumed = false;
+    int width = 0;
+    int height = 0;
+};
+
+SkpFrameCapture::SkpFrameCapture(int width, int height)
+    : impl_(std::make_unique<Impl>()) {
+    impl_->width = width;
+    impl_->height = height;
+
+    if (width <= 0 || height <= 0) {
+        runtime::log_warn(
+            "SkpFrameCapture: non-positive dimensions ({}x{}) — capture unavailable",
+            width, height);
+        return;
+    }
+
+    SkCanvas* rec = impl_->recorder.beginRecording(
+        SkRect::MakeWH(static_cast<float>(width), static_cast<float>(height)));
+    if (!rec) {
+        runtime::log_error("SkpFrameCapture: beginRecording returned null");
+        return;
+    }
+
+    // Wrap the recording canvas as a pulp::canvas::Canvas. No Graphite
+    // recorder is passed: picture recording is GPU-backend-agnostic and
+    // never touches the live GPU device.
+    impl_->canvas = std::make_unique<canvas::SkiaCanvas>(rec);
+}
+
+SkpFrameCapture::~SkpFrameCapture() = default;
+
+bool SkpFrameCapture::available() const {
+    return impl_ && impl_->canvas != nullptr && !impl_->consumed;
+}
+
+canvas::Canvas* SkpFrameCapture::canvas() {
+    if (!available()) return nullptr;
+    return impl_->canvas.get();
+}
+
+SkpCaptureResult SkpFrameCapture::finish_to_memory(std::string& out_blob) {
+    SkpCaptureResult result;
+    out_blob.clear();
+
+    if (!impl_ || !impl_->canvas) {
+        result.reason = "skp capture unavailable (Skia missing or invalid size)";
+        return result;
+    }
+    if (impl_->consumed) {
+        result.reason = "skp capture already finished";
+        return result;
+    }
+    impl_->consumed = true;
+
+    // Drop the Canvas wrapper before finishing — finishRecordingAsPicture
+    // invalidates the recording SkCanvas the wrapper points at.
+    impl_->canvas.reset();
+
+    sk_sp<SkPicture> picture = impl_->recorder.finishRecordingAsPicture();
+    if (!picture) {
+        result.reason = "finishRecordingAsPicture returned null";
+        return result;
+    }
+
+    SkSerialProcs procs = pulp_serial_procs();
+    sk_sp<SkData> blob = picture->serialize(&procs);
+    if (!blob || blob->size() == 0) {
+        result.reason = "SkPicture::serialize produced no data";
+        return result;
+    }
+
+    out_blob.assign(static_cast<const char*>(blob->data()), blob->size());
+    result.ok = true;
+    result.bytes_written = blob->size();
+    result.op_count = static_cast<std::size_t>(picture->approximateOpCount());
+    return result;
+}
+
+SkpCaptureResult SkpFrameCapture::finish_to_file(const std::string& path) {
+    SkpCaptureResult result;
+    result.path = path;
+
+    if (path.empty()) {
+        result.reason = "skp capture: empty output path";
+        // Still mark the capture consumed so a retry is honest.
+        if (impl_) impl_->consumed = true;
+        return result;
+    }
+
+    std::string blob;
+    SkpCaptureResult mem = finish_to_memory(blob);
+    if (!mem.ok) {
+        result.reason = mem.reason;
+        return result;
+    }
+
+    SkFILEWStream out(path.c_str());
+    if (!out.isValid()) {
+        result.reason = "could not open .skp output file: " + path;
+        return result;
+    }
+    if (!out.write(blob.data(), blob.size())) {
+        result.reason = "failed writing .skp bytes to: " + path;
+        return result;
+    }
+    out.flush();
+
+    result.ok = true;
+    result.bytes_written = mem.bytes_written;
+    result.op_count = mem.op_count;
+    runtime::log_info("SkpFrameCapture: wrote {} byte .skp ({} ops) to {}",
+                      result.bytes_written, result.op_count, path);
+    return result;
+}
+
+SkpCaptureResult capture_skp_to_file(
+    int width, int height, const std::string& path,
+    const std::function<void(canvas::Canvas&)>& paint) {
+    SkpFrameCapture capture(width, height);
+    if (!capture.available()) {
+        SkpCaptureResult result;
+        result.path = path;
+        result.reason = "skp capture unavailable (Skia missing or invalid size)";
+        return result;
+    }
+    if (paint) {
+        paint(*capture.canvas());
+    }
+    return capture.finish_to_file(path);
+}
+
+bool skp_capture_supported() { return true; }
+
+} // namespace pulp::render
+
+#else // !PULP_HAS_SKIA
+
+#include <pulp/runtime/log.hpp>
+
+namespace pulp::render {
+
+// Skia-absent fallbacks. Every entry point degrades gracefully: no
+// canvas, no file, a clear reason string — never a crash or a partial
+// .skp artifact.
+
+struct SkpFrameCapture::Impl {};
+
+SkpFrameCapture::SkpFrameCapture(int /*width*/, int /*height*/) : impl_(nullptr) {}
+SkpFrameCapture::~SkpFrameCapture() = default;
+
+bool SkpFrameCapture::available() const { return false; }
+
+canvas::Canvas* SkpFrameCapture::canvas() { return nullptr; }
+
+SkpCaptureResult SkpFrameCapture::finish_to_file(const std::string& path) {
+    SkpCaptureResult result;
+    result.path = path;
+    result.reason = "skp capture unavailable: this build has no Skia support";
+    return result;
+}
+
+SkpCaptureResult SkpFrameCapture::finish_to_memory(std::string& out_blob) {
+    out_blob.clear();
+    SkpCaptureResult result;
+    result.reason = "skp capture unavailable: this build has no Skia support";
+    return result;
+}
+
+SkpCaptureResult capture_skp_to_file(
+    int /*width*/, int /*height*/, const std::string& path,
+    const std::function<void(canvas::Canvas&)>& /*paint*/) {
+    SkpCaptureResult result;
+    result.path = path;
+    result.reason = "skp capture unavailable: this build has no Skia support";
+    return result;
+}
+
+bool skp_capture_supported() { return false; }
+
+} // namespace pulp::render
+
+#endif // PULP_HAS_SKIA

--- a/test/test_skia_surface.cpp
+++ b/test/test_skia_surface.cpp
@@ -1,9 +1,11 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/render/skia_surface.hpp>
 #include <pulp/render/gpu_surface.hpp>
+#include <pulp/render/skp_capture.hpp>
 
 #ifdef PULP_HAS_SKIA
 #include <cstring>
+#include <filesystem>
 
 #include "include/core/SkBitmap.h"
 #include "include/core/SkCanvas.h"
@@ -356,6 +358,200 @@ TEST_CASE("SkPicture with embedded image needs fImageProc to round-trip pixels",
         // actually proves fImageProc preserved the pixels.
         REQUIRE(replay_top_left(restored, info) == SK_ColorGREEN);
     }
+}
+
+#endif  // PULP_HAS_SKIA
+
+// ---------------------------------------------------------------------------
+// SkpFrameCapture — Phase 6.4 `.skp` frame-capture API (core/render)
+//
+// These exercise the public capture surface in
+// core/render/include/pulp/render/skp_capture.hpp: record a frame's
+// draw ops through the capture's pulp::canvas::Canvas, serialize a
+// `.skp` artifact, and prove the round trip — including the load-bearing
+// embedded-image-pixel assertion the spike pinned (cullRect equality
+// alone is insufficient). The capture path is GPU-backend-agnostic and
+// needs no live GPU context, so these run on the CI matrix even without
+// a GPU adapter.
+// ---------------------------------------------------------------------------
+
+#ifdef PULP_HAS_SKIA
+
+namespace {
+
+// Deserialize-side image proc — the replay-side half of the contract
+// SkpFrameCapture's fImageProc establishes. Decodes the PNG payload
+// SkpFrameCapture wrote back into an SkImage.
+SkDeserialProcs skp_deserial_procs() {
+    SkDeserialProcs procs;
+    procs.fImageProc = [](const void* data, size_t length,
+                          void*) -> sk_sp<SkImage> {
+        return SkImages::DeferredFromEncodedData(
+            SkData::MakeWithCopy(data, length));
+    };
+    return procs;
+}
+
+// A tiny solid-color PNG, the kind a real frame embeds via the image
+// atlas. Encoded here so draw_image_from_data() has a decodable source.
+sk_sp<SkData> solid_png(int size, SkColor color) {
+    SkImageInfo info = SkImageInfo::MakeN32Premul(size, size);
+    sk_sp<SkSurface> raster = SkSurfaces::Raster(info);
+    REQUIRE(raster != nullptr);
+    raster->getCanvas()->clear(color);
+    sk_sp<SkImage> image = raster->makeImageSnapshot();
+    REQUIRE(image != nullptr);
+    return SkPngEncoder::Encode(nullptr, image.get(), SkPngEncoder::Options{});
+}
+
+}  // namespace
+
+TEST_CASE("SkpFrameCapture records vector ops into a round-tripping .skp",
+          "[render][skia][skp]") {
+    pulp::render::SkpFrameCapture capture(64, 48);
+    REQUIRE(capture.available());
+    REQUIRE(pulp::render::skp_capture_supported());
+
+    pulp::canvas::Canvas* c = capture.canvas();
+    REQUIRE(c != nullptr);
+    c->set_fill_color(pulp::canvas::Color::rgba8(255, 0, 0));
+    c->fill_rect(4.0f, 4.0f, 40.0f, 24.0f);
+    c->set_fill_color(pulp::canvas::Color::rgba8(0, 0, 255));
+    c->fill_rect(20.0f, 20.0f, 24.0f, 16.0f);
+
+    std::string blob;
+    auto result = capture.finish_to_memory(blob);
+    REQUIRE(result.ok);
+    REQUIRE(result.bytes_written == blob.size());
+    REQUIRE(result.op_count > 0);
+
+    // The blob carries the documented .skp "skiapict" signature.
+    REQUIRE(blob.size() >= 8);
+    REQUIRE(std::memcmp(blob.data(), "skiapict", 8) == 0);
+
+    // Deserialize and assert the recording survived.
+    sk_sp<SkPicture> restored =
+        SkPicture::MakeFromData(blob.data(), blob.size());
+    REQUIRE(restored != nullptr);
+    REQUIRE(restored->cullRect() == SkRect::MakeWH(64.0f, 48.0f));
+    REQUIRE(restored->approximateOpCount() > 0);
+
+    // The capture is consumed: canvas() is null, a second finish fails.
+    REQUIRE(capture.canvas() == nullptr);
+    REQUIRE_FALSE(capture.available());
+    std::string second;
+    REQUIRE_FALSE(capture.finish_to_memory(second).ok);
+}
+
+TEST_CASE("SkpFrameCapture writes a loadable .skp file", "[render][skia][skp]") {
+    const std::string path =
+        (std::filesystem::temp_directory_path() /
+         "pulp-skp-capture-test.skp").string();
+    std::filesystem::remove(path);
+
+    auto result = pulp::render::capture_skp_to_file(
+        32, 32, path, [](pulp::canvas::Canvas& c) {
+            c.set_fill_color(pulp::canvas::Color::rgba8(0, 255, 0));
+            c.fill_rect(0.0f, 0.0f, 32.0f, 32.0f);
+        });
+    REQUIRE(result.ok);
+    REQUIRE(result.path == path);
+    REQUIRE(result.bytes_written > 0);
+    REQUIRE(std::filesystem::exists(path));
+    REQUIRE(std::filesystem::file_size(path) == result.bytes_written);
+
+    // Re-read the file off disk and confirm skiadebugger could load it.
+    SkFILEStream in(path.c_str());
+    REQUIRE(in.isValid());
+    sk_sp<SkPicture> restored = SkPicture::MakeFromStream(&in);
+    REQUIRE(restored != nullptr);
+    REQUIRE(restored->cullRect() == SkRect::MakeWH(32.0f, 32.0f));
+
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("SkpFrameCapture preserves embedded-image pixels via fImageProc",
+          "[render][skia][skp]") {
+    // The load-bearing Phase 6.4 assertion: a frame that embeds an image
+    // must survive the .skp round trip with its pixels intact.
+    // SkpFrameCapture sets SkSerialProcs::fImageProc (PNG encode); if it
+    // did not, the embedded image would deserialize to null and the
+    // replay would be blank. Replay + pixel-sample is what proves the
+    // payload survived — cullRect equality alone would still pass.
+    sk_sp<SkData> png = solid_png(8, SK_ColorGREEN);
+    REQUIRE(png != nullptr);
+
+    pulp::render::SkpFrameCapture capture(8, 8);
+    REQUIRE(capture.available());
+    REQUIRE(capture.canvas()->draw_image_from_data(
+        static_cast<const uint8_t*>(png->data()), png->size(),
+        0.0f, 0.0f, 8.0f, 8.0f));
+
+    std::string blob;
+    auto result = capture.finish_to_memory(blob);
+    REQUIRE(result.ok);
+    REQUIRE(result.op_count > 0);
+
+    // Deserialize WITH the matching fImageProc and replay into a fresh
+    // raster surface pre-cleared to black; sample the top-left pixel.
+    SkDeserialProcs dprocs = skp_deserial_procs();
+    sk_sp<SkPicture> restored =
+        SkPicture::MakeFromData(blob.data(), blob.size(), &dprocs);
+    REQUIRE(restored != nullptr);
+    REQUIRE(restored->cullRect() == SkRect::MakeWH(8.0f, 8.0f));
+
+    SkImageInfo info = SkImageInfo::MakeN32Premul(8, 8);
+    REQUIRE(replay_top_left(restored, info) == SK_ColorGREEN);
+}
+
+TEST_CASE("SkpFrameCapture degrades gracefully on invalid input",
+          "[render][skia][skp]") {
+    // Non-positive dimensions yield an unavailable capture — no canvas,
+    // no file, a clear reason. Never a crash or a partial .skp.
+    pulp::render::SkpFrameCapture bad(0, 32);
+    REQUIRE_FALSE(bad.available());
+    REQUIRE(bad.canvas() == nullptr);
+
+    std::string blob;
+    auto mem = bad.finish_to_memory(blob);
+    REQUIRE_FALSE(mem.ok);
+    REQUIRE_FALSE(mem.reason.empty());
+    REQUIRE(blob.empty());
+
+    auto file = pulp::render::capture_skp_to_file(
+        -1, -1, "/tmp/should-not-be-written.skp",
+        [](pulp::canvas::Canvas&) {});
+    REQUIRE_FALSE(file.ok);
+    REQUIRE_FALSE(file.reason.empty());
+
+    // Empty output path is rejected without writing.
+    pulp::render::SkpFrameCapture ok(16, 16);
+    REQUIRE(ok.available());
+    auto empty_path = ok.finish_to_file("");
+    REQUIRE_FALSE(empty_path.ok);
+    REQUIRE_FALSE(empty_path.reason.empty());
+}
+
+#else  // !PULP_HAS_SKIA
+
+TEST_CASE("SkpFrameCapture is unavailable without Skia", "[render][skia][skp]") {
+    // The Skia-absent build must still link and degrade gracefully:
+    // unavailable capture, null canvas, failed result with a reason.
+    REQUIRE_FALSE(pulp::render::skp_capture_supported());
+
+    pulp::render::SkpFrameCapture capture(64, 48);
+    REQUIRE_FALSE(capture.available());
+    REQUIRE(capture.canvas() == nullptr);
+
+    std::string blob;
+    auto mem = capture.finish_to_memory(blob);
+    REQUIRE_FALSE(mem.ok);
+    REQUIRE_FALSE(mem.reason.empty());
+
+    auto file = pulp::render::capture_skp_to_file(
+        64, 48, "/tmp/unused.skp", [](pulp::canvas::Canvas&) {});
+    REQUIRE_FALSE(file.ok);
+    REQUIRE_FALSE(file.reason.empty());
 }
 
 #endif  // PULP_HAS_SKIA

--- a/tools/scripts/source_tree_pollution_check.py
+++ b/tools/scripts/source_tree_pollution_check.py
@@ -102,6 +102,7 @@ ALLOWED_ROOT_PATHS = frozenset({
     "apple",
     "bindings",
     "ci",
+    "compat",
     "core",
     "docs",
     "examples",


### PR DESCRIPTION
PR #2531 split the single `compat.json` into a per-surface `compat/`
directory but did not add `compat` to `ALLOWED_ROOT_PATHS` in the
source-tree pollution check. The stale allowlist still lists only the
old `compat.json` file, so the pre-push and CI pollution gates flag the
legitimate, already-merged `compat/` directory as an unexpected
top-level path — blocking every PR.

Add `compat` to the top-level subsystem-dir allowlist. The gate's own
remediation message points here for exactly this case.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>