### PR TITLE
test(harness): lint visual-harness Dockerfile against canonical Skia pin (P9-4)

### DIFF
--- a/tools/harness/visual/check_skia_pin.py
+++ b/tools/harness/visual/check_skia_pin.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Lint: the visual-harness Dockerfile must match the canonical Skia pin.
+
+Roadmap P9-4. The visual harness builds a deterministic raster image inside
+``ci/visual-harness.Dockerfile``, which downloads a pinned ``linux/amd64`` Skia
+archive via ``ARG`` lines. The canonical, machine-readable Skia pin lives in
+``tools/deps/manifest.json`` under the ``Skia`` dependency's ``determinism``
+block (per CLAUDE.md, the manifest is the dependency inventory source of truth).
+
+Nothing previously cross-checked the two, so the Dockerfile's baked-in Skia
+release tag, archive URL, SHA-256, and skia-python version could silently drift
+from the manifest. This script reads both ends and exits non-zero with a clear
+diff message on any mismatch.
+
+Usage::
+
+    python3 tools/harness/visual/check_skia_pin.py
+
+Exit codes:
+    0 — Dockerfile Skia pin matches the canonical manifest pin.
+    1 — drift detected (mismatch printed to stderr).
+    2 — could not parse one of the inputs (treated as a hard failure).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[2]
+MANIFEST_PATH = REPO_ROOT / "tools/deps/manifest.json"
+DOCKERFILE_PATH = REPO_ROOT / "ci/visual-harness.Dockerfile"
+
+# The Dockerfile builds the Linux x64 image, so it is checked against the
+# manifest's ``linux-x64`` release asset.
+DOCKER_PLATFORM = "linux-x64"
+
+
+class CheckError(Exception):
+    """Raised when an input cannot be parsed (exit code 2)."""
+
+
+def _parse_dockerfile_args(text: str) -> Dict[str, str]:
+    """Return the ``ARG name=value`` defaults declared in the Dockerfile."""
+    args: Dict[str, str] = {}
+    arg_re = re.compile(r"^\s*ARG\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+?)\s*$")
+    for line in text.splitlines():
+        match = arg_re.match(line)
+        if match:
+            args[match.group(1)] = match.group(2).strip().strip('"').strip("'")
+    return args
+
+
+def read_dockerfile_pin(path: Path = DOCKERFILE_PATH) -> Dict[str, str]:
+    """Extract the Skia pin baked into the visual-harness Dockerfile."""
+    if not path.is_file():
+        raise CheckError(f"Dockerfile not found: {path}")
+    args = _parse_dockerfile_args(path.read_text(encoding="utf-8"))
+
+    required = (
+        "SKIA_RELEASE_TAG",
+        "SKIA_LINUX_X64_SHA256",
+        "SKIA_LINUX_X64_URL",
+        "SKIA_PYTHON_VERSION",
+    )
+    missing = [name for name in required if name not in args]
+    if missing:
+        raise CheckError(
+            f"{path} is missing required ARG line(s): {', '.join(missing)}"
+        )
+
+    return {
+        "release_tag": args["SKIA_RELEASE_TAG"],
+        "sha256": args["SKIA_LINUX_X64_SHA256"],
+        "url": args["SKIA_LINUX_X64_URL"],
+        "python_version": args["SKIA_PYTHON_VERSION"],
+    }
+
+
+def read_manifest_pin(path: Path = MANIFEST_PATH) -> Dict[str, str]:
+    """Extract the canonical Skia pin from tools/deps/manifest.json."""
+    if not path.is_file():
+        raise CheckError(f"manifest not found: {path}")
+    try:
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        raise CheckError(f"{path} is not valid JSON: {exc}") from exc
+
+    skia = None
+    for dep in manifest.get("dependencies", []):
+        if dep.get("name") == "Skia":
+            skia = dep
+            break
+    if skia is None:
+        raise CheckError(f"{path} has no 'Skia' dependency entry")
+
+    determinism = skia.get("determinism")
+    if not isinstance(determinism, dict):
+        raise CheckError(f"{path} Skia entry has no 'determinism' block")
+
+    assets = determinism.get("release_assets", {})
+    asset = assets.get(DOCKER_PLATFORM)
+    if not isinstance(asset, dict):
+        raise CheckError(
+            f"{path} Skia determinism block has no "
+            f"release_assets['{DOCKER_PLATFORM}']"
+        )
+
+    for key in ("skia_branch", "skia_python_smoke_version"):
+        if key not in determinism:
+            raise CheckError(f"{path} Skia determinism block missing '{key}'")
+    for key in ("url", "sha256"):
+        if key not in asset:
+            raise CheckError(
+                f"{path} release_assets['{DOCKER_PLATFORM}'] missing '{key}'"
+            )
+
+    return {
+        "release_tag": determinism["skia_branch"],
+        "sha256": asset["sha256"],
+        "url": asset["url"],
+        "python_version": determinism["skia_python_smoke_version"],
+    }
+
+
+# Human-readable label per compared field.
+_FIELD_LABELS = {
+    "release_tag": "Skia release tag",
+    "sha256": "Linux x64 archive SHA-256",
+    "url": "Linux x64 archive URL",
+    "python_version": "skia-python version",
+}
+
+
+def compare(dockerfile: Dict[str, str], manifest: Dict[str, str]) -> list[str]:
+    """Return a list of human-readable drift messages (empty == in sync)."""
+    drift: list[str] = []
+    for field, label in _FIELD_LABELS.items():
+        if dockerfile[field] != manifest[field]:
+            drift.append(
+                f"  {label}:\n"
+                f"    Dockerfile (ci/visual-harness.Dockerfile): {dockerfile[field]}\n"
+                f"    manifest   (tools/deps/manifest.json):     {manifest[field]}"
+            )
+    return drift
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        dockerfile = read_dockerfile_pin()
+        manifest = read_manifest_pin()
+    except CheckError as exc:
+        print(f"check_skia_pin: ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    drift = compare(dockerfile, manifest)
+    if drift:
+        print(
+            "check_skia_pin: visual-harness Dockerfile Skia pin has drifted "
+            "from the canonical manifest pin:",
+            file=sys.stderr,
+        )
+        for entry in drift:
+            print(entry, file=sys.stderr)
+        print(
+            "\nUpdate ci/visual-harness.Dockerfile ARG lines and "
+            "tools/deps/manifest.json together so they stay in sync.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        "check_skia_pin: OK — visual-harness Dockerfile Skia pin matches "
+        f"tools/deps/manifest.json (release {manifest['release_tag']})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/harness/visual/check_skia_pin.py
+++ b/tools/harness/visual/check_skia_pin.py
@@ -103,6 +103,10 @@ def read_manifest_pin(path: Path = MANIFEST_PATH) -> Dict[str, str]:
         raise CheckError(f"{path} Skia entry has no 'determinism' block")
 
     assets = determinism.get("release_assets", {})
+    if not isinstance(assets, dict):
+        raise CheckError(
+            f"{path} Skia determinism 'release_assets' is not an object"
+        )
     asset = assets.get(DOCKER_PLATFORM)
     if not isinstance(asset, dict):
         raise CheckError(

--- a/tools/harness/visual/tests/test_check_skia_pin.py
+++ b/tools/harness/visual/tests/test_check_skia_pin.py
@@ -134,6 +134,20 @@ class CheckSkiaPinTests(unittest.TestCase):
         with self.assertRaises(check_skia_pin.CheckError):
             check_skia_pin.read_manifest_pin(manifest_path)
 
+    def test_non_dict_release_assets_raises_check_error(self) -> None:
+        # A manifest where determinism.release_assets is accidentally a
+        # non-object (e.g. a list) must surface as a CheckError → exit 2,
+        # not an uncaught AttributeError from calling .get on it.
+        import copy
+
+        manifest = copy.deepcopy(_MANIFEST_TEMPLATE)
+        manifest["dependencies"][0]["determinism"]["release_assets"] = []
+        manifest_path = _write_manifest(
+            Path(self._tmpdir.name) / "manifest.json", manifest
+        )
+        with self.assertRaises(check_skia_pin.CheckError):
+            check_skia_pin.read_manifest_pin(manifest_path)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/harness/visual/tests/test_check_skia_pin.py
+++ b/tools/harness/visual/tests/test_check_skia_pin.py
@@ -1,0 +1,139 @@
+"""Tests for the visual-harness Dockerfile / manifest Skia-pin lint (P9-4)."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.harness.visual import check_skia_pin  # noqa: E402
+
+_DOCKERFILE = """\
+# syntax=docker/dockerfile:1.7
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG SKIA_RELEASE_TAG=chrome/m144
+ARG SKIA_LINUX_X64_SHA256=aaaa
+ARG SKIA_LINUX_X64_URL=https://example.test/skia.zip
+ARG SKIA_PYTHON_VERSION=144.0.post2
+"""
+
+_MANIFEST_TEMPLATE = {
+    "dependencies": [
+        {
+            "name": "Skia",
+            "determinism": {
+                "skia_branch": "chrome/m144",
+                "skia_python_smoke_version": "144.0.post2",
+                "release_assets": {
+                    "linux-x64": {
+                        "url": "https://example.test/skia.zip",
+                        "sha256": "aaaa",
+                    }
+                },
+            },
+        }
+    ]
+}
+
+
+def _write_manifest(path: Path, manifest: dict) -> Path:
+    import json
+
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+    return path
+
+
+class CheckSkiaPinTests(unittest.TestCase):
+    def _dockerfile(self, body: str = _DOCKERFILE) -> Path:
+        path = Path(self._tmpdir.name) / "visual-harness.Dockerfile"
+        path.write_text(body, encoding="utf-8")
+        return path
+
+    def setUp(self) -> None:
+        import tempfile
+
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+
+    # --- repo-state guard: the live repo must currently be in sync ----------
+
+    def test_live_repo_pin_is_in_sync(self) -> None:
+        """The lint must pass against the current checked-in files."""
+        self.assertEqual(check_skia_pin.main([]), 0)
+
+    # --- match --------------------------------------------------------------
+
+    def test_compare_returns_no_drift_when_pins_match(self) -> None:
+        docker = check_skia_pin.read_dockerfile_pin(self._dockerfile())
+        manifest_path = _write_manifest(
+            Path(self._tmpdir.name) / "manifest.json", _MANIFEST_TEMPLATE
+        )
+        manifest = check_skia_pin.read_manifest_pin(manifest_path)
+        self.assertEqual(check_skia_pin.compare(docker, manifest), [])
+
+    # --- mismatch -----------------------------------------------------------
+
+    def test_compare_reports_release_tag_drift(self) -> None:
+        docker = check_skia_pin.read_dockerfile_pin(self._dockerfile())
+        import copy
+
+        drifted = copy.deepcopy(_MANIFEST_TEMPLATE)
+        drifted["dependencies"][0]["determinism"]["skia_branch"] = "chrome/m145"
+        manifest_path = _write_manifest(
+            Path(self._tmpdir.name) / "manifest.json", drifted
+        )
+        manifest = check_skia_pin.read_manifest_pin(manifest_path)
+
+        drift = check_skia_pin.compare(docker, manifest)
+        self.assertEqual(len(drift), 1)
+        self.assertIn("Skia release tag", drift[0])
+        self.assertIn("chrome/m144", drift[0])
+        self.assertIn("chrome/m145", drift[0])
+
+    def test_compare_reports_sha_and_url_drift(self) -> None:
+        docker = check_skia_pin.read_dockerfile_pin(self._dockerfile())
+        import copy
+
+        drifted = copy.deepcopy(_MANIFEST_TEMPLATE)
+        asset = drifted["dependencies"][0]["determinism"]["release_assets"][
+            "linux-x64"
+        ]
+        asset["sha256"] = "bbbb"
+        asset["url"] = "https://example.test/other.zip"
+        manifest_path = _write_manifest(
+            Path(self._tmpdir.name) / "manifest.json", drifted
+        )
+        manifest = check_skia_pin.read_manifest_pin(manifest_path)
+
+        drift = check_skia_pin.compare(docker, manifest)
+        self.assertEqual(len(drift), 2)
+        joined = "\n".join(drift)
+        self.assertIn("SHA-256", joined)
+        self.assertIn("URL", joined)
+
+    def test_missing_arg_line_raises_check_error(self) -> None:
+        body = "\n".join(
+            line
+            for line in _DOCKERFILE.splitlines()
+            if "SKIA_PYTHON_VERSION" not in line
+        )
+        with self.assertRaises(check_skia_pin.CheckError):
+            check_skia_pin.read_dockerfile_pin(self._dockerfile(body))
+
+    def test_manifest_without_skia_raises_check_error(self) -> None:
+        manifest_path = _write_manifest(
+            Path(self._tmpdir.name) / "manifest.json", {"dependencies": []}
+        )
+        with self.assertRaises(check_skia_pin.CheckError):
+            check_skia_pin.read_manifest_pin(manifest_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Roadmap **P9-4**. The visual-harness Dockerfile bakes a pinned Skia release, but nothing checked it stays in sync with the repo's canonical Skia pin — so they could silently drift. This adds the missing lint.

**The two pin ends:**
- Consumer: `ci/visual-harness.Dockerfile` — `ARG SKIA_RELEASE_TAG` / `SKIA_LINUX_X64_URL` / `SKIA_LINUX_X64_SHA256` / `SKIA_PYTHON_VERSION`.
- Canonical (source of truth): `tools/deps/manifest.json` — the `Skia` dependency's `determinism` block.
- Pre-existing `test_skia_determinism.py` covers `pins.py` ↔ manifest but **not** the Dockerfile — that was the gap.

**Added:**
- `tools/harness/visual/check_skia_pin.py` — parses the Dockerfile `ARG` defaults, reads `manifest.json` `Skia.determinism`, compares release tag / URL / SHA-256 / skia-python version. Exit 0 in sync, 1 with a field-by-field diff on drift, 2 on unparseable input.
- `tools/harness/visual/tests/test_check_skia_pin.py` — 6 cases (match, release-tag drift, SHA+URL drift, malformed Dockerfile, manifest-without-Skia, live-repo guard).

## Test plan

- [x] Lint against current repo — exit 0, pin **currently in sync** (`chrome/m144`).
- [x] Tests 6/6 pass; drift path verified end-to-end (temp drifted manifest → exit 1 + expected diff).

No version bump (`tools/harness/visual/` is not a versioned surface).

**Follow-up (out of scope):** wire `python3 tools/harness/visual/check_skia_pin.py` into a CI workflow (visual-harness or deps-audit job) so drift fails CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)