### PR TITLE
feat(inspect): add selection-mode toggle (FOLLOWS_MOUSE / FOLLOWS_FOCUS)

### DIFF
--- a/inspect/include/pulp/inspect/inspector_overlay.hpp
+++ b/inspect/include/pulp/inspect/inspector_overlay.hpp
@@ -222,6 +222,31 @@ public:
     View* selected_view() const { return selected_; }
     View* hovered_view() const { return hovered_; }
 
+    // ── Phase 3 — selection-mode toggle ─────────────────────────────
+    /// How the selected node is chosen as the pointer moves.
+    ///   - follows_focus: selection stays pinned to the focused element
+    ///     and does NOT chase the pointer — only an explicit click (or
+    ///     panel-tree pick) changes it. This is the inspector's
+    ///     historical behavior and the default, so the toggle is opt-in.
+    ///   - follows_mouse: selection tracks whatever View the pointer is
+    ///     over — every hover / pointer-move re-selects the hovered node,
+    ///     a Figma-style "select on hover" mode for fast scrubbing.
+    enum class SelectionMode : std::uint8_t { follows_focus, follows_mouse };
+
+    /// Current selection mode. Defaults to `follows_focus` (click-to-
+    /// select), so existing hosts and tests are unaffected until the
+    /// user opts in via the `M` hotkey.
+    SelectionMode selection_mode() const { return selection_mode_; }
+    void set_selection_mode(SelectionMode mode) { selection_mode_ = mode; }
+    /// Flip between follows_focus and follows_mouse. Bound to the `M`
+    /// ("mode") hotkey in handle_key_event() — D/E/P/T/J/Z/R/A are all
+    /// taken, so M is the natural free letter for "selection mode".
+    void toggle_selection_mode() {
+        selection_mode_ = (selection_mode_ == SelectionMode::follows_focus)
+                              ? SelectionMode::follows_mouse
+                              : SelectionMode::follows_focus;
+    }
+
     // ── Phase 5.1 — source-jump ─────────────────────────────────────
     /// The editor-URL config used to format source-jump URLs. The host
     /// sets this once (mirroring the DomainHandler's config); the `J`
@@ -501,6 +526,11 @@ private:
 
     // Distance measurement mode
     View* distance_anchor_ = nullptr;
+
+    // Phase 3 — selection-mode toggle. follows_focus (default) keeps the
+    // selection pinned until an explicit click; follows_mouse re-selects
+    // the hovered View on every pointer-move. Toggled via the `M` hotkey.
+    SelectionMode selection_mode_ = SelectionMode::follows_focus;
 
     // Phase 3f — Alt-hover sibling distance (Figma-style spacing reveal).
     // Tracks the View under the cursor while Alt is held; cleared as soon

--- a/inspect/src/inspector_overlay.cpp
+++ b/inspect/src/inspector_overlay.cpp
@@ -803,8 +803,15 @@ bool InspectorOverlay::handle_mouse_event(const MouseEvent& event) {
         // only changed by an explicit click (handled below). The Alt
         // modifier is excluded so Alt-hover sibling-distance and
         // Alt+click distance-anchor modes keep their pinned selection.
+        //
+        // A field edit in progress also pins the selection: begin_field_edit()
+        // snapshots the edit target, but write_field_value() /
+        // commit_field_edit() still operate on the *current* selected_. If a
+        // mid-edit hover were allowed to move selected_, the edit would commit
+        // to the wrong node (or a no-longer-valid target). follows_focus mode
+        // is already safe here because it never chases the pointer.
         if (selection_mode_ == SelectionMode::follows_mouse &&
-            !event.is_down && !event.isAltDown()) {
+            !event.is_down && !event.isAltDown() && !is_editing()) {
             selected_ = hit;
         }
     }

--- a/inspect/src/inspector_overlay.cpp
+++ b/inspect/src/inspector_overlay.cpp
@@ -501,6 +501,18 @@ bool InspectorOverlay::handle_key_event(const KeyEvent& event) {
         return true;
     }
 
+    // Phase 3 — M toggles the selection mode between follows_focus
+    // (click-to-select; the default) and follows_mouse (selection
+    // tracks the pointer). No modifier; inspector-active only, and
+    // guarded behind not-editing so typing an 'm' into a field-edit
+    // buffer can't flip the mode. D/E/T/J/P/Z/R/A are already claimed,
+    // so M ("mode") is the natural free letter.
+    if (active_ && editing_field_.empty() && event.key == KeyCode::m &&
+        event.is_down && event.modifiers == 0) {
+        toggle_selection_mode();
+        return true;
+    }
+
     return false;
 }
 
@@ -783,6 +795,18 @@ bool InspectorOverlay::handle_mouse_event(const MouseEvent& event) {
     auto* hit = root_.hit_test(pos);
     if (hit) {
         hovered_ = hit;
+
+        // Phase 3 — selection-mode toggle. In follows_mouse mode the
+        // selection chases the pointer: every pointer-move re-selects
+        // the hovered View (Figma-style "select on hover"). In the
+        // default follows_focus mode the selection stays pinned and is
+        // only changed by an explicit click (handled below). The Alt
+        // modifier is excluded so Alt-hover sibling-distance and
+        // Alt+click distance-anchor modes keep their pinned selection.
+        if (selection_mode_ == SelectionMode::follows_mouse &&
+            !event.is_down && !event.isAltDown()) {
+            selected_ = hit;
+        }
     }
 
     // Phase 3f — Alt-hover sibling distance (Figma-style). Tracks the

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -657,6 +657,81 @@ TEST_CASE("InspectorOverlay: follows_mouse re-selects the hovered view",
     REQUIRE(overlay.selected_view() == a_ptr);  // pinned despite follows_mouse
 }
 
+// Codex P1 follow-up on #2556: in follows_mouse mode a hover must NOT
+// chase the pointer while a numeric field edit is in progress.
+// begin_field_edit() snapshots the edit target, but write_field_value()
+// / commit_field_edit() operate on the *current* selected_. If a
+// mid-edit hover were allowed to move selected_, the edit would commit
+// to the wrong (or no-longer-valid) node. follows_focus mode is already
+// safe because it never chases the pointer; this guards follows_mouse.
+TEST_CASE("InspectorOverlay: follows_mouse hover does not move selection "
+          "during a field edit (codex P1 #2556 regression)",
+          "[inspect][overlay][phase3][regression]") {
+    View root;
+    root.set_id("root");
+    root.set_bounds({0, 0, 500, 300});
+
+    auto a = std::make_unique<View>();
+    a->set_id("a");
+    a->set_anchor_id("figma:edit-target");
+    a->set_bounds({10, 10, 60, 60});
+    a->flex().padding = 8;
+    auto* a_ptr = a.get();
+    root.add_child(std::move(a));
+
+    auto b = std::make_unique<View>();
+    b->set_id("b");
+    b->set_bounds({100, 10, 60, 60});
+    b->flex().padding = 99;
+    auto* b_ptr = b.get();
+    root.add_child(std::move(b));
+
+    TweakStore store;
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    overlay.set_tweak_store(&store);
+    overlay.set_selection_mode(InspectorOverlay::SelectionMode::follows_mouse);
+
+    // Click to select a, then start a numeric field edit on it.
+    MouseEvent click_a;
+    click_a.position = {20, 20};
+    click_a.is_down = true;
+    REQUIRE(overlay.handle_mouse_event(click_a));
+    REQUIRE(overlay.selected_view() == a_ptr);
+
+    REQUIRE(overlay.begin_field_edit("layout.padding", 8.0f));
+    REQUIRE(overlay.is_editing());
+
+    // Move the mouse over b mid-edit. In follows_mouse mode this would
+    // normally re-select b — but a field edit is in progress, so the
+    // selection must stay pinned to the edit target a.
+    MouseEvent hover_b;
+    hover_b.position = {130, 30};
+    hover_b.is_down = false;
+    REQUIRE_FALSE(overlay.handle_mouse_event(hover_b));
+    REQUIRE(overlay.hovered_view() == b_ptr);    // hover tracking still works
+    REQUIRE(overlay.selected_view() == a_ptr);   // selection NOT chased
+
+    // Type a new value and commit — the edit must land on a, not b.
+    KeyEvent num5;
+    num5.key = KeyCode::num5;
+    num5.is_down = true;
+    REQUIRE(overlay.handle_key_event(num5));  // "8" → "85"
+    REQUIRE(overlay.commit_field_edit());
+    REQUIRE_FALSE(overlay.is_editing());
+
+    REQUIRE(a_ptr->flex().padding == 85.0f);  // edit committed to a
+    REQUIRE(b_ptr->flex().padding == 99.0f);  // b untouched
+    REQUIRE(store.count() == 1);              // exactly one tweak emitted
+
+    // After the edit ends, follows_mouse resumes chasing the pointer.
+    MouseEvent hover_b2;
+    hover_b2.position = {130, 30};
+    hover_b2.is_down = false;
+    REQUIRE_FALSE(overlay.handle_mouse_event(hover_b2));
+    REQUIRE(overlay.selected_view() == b_ptr);  // chasing resumes post-edit
+}
+
 // Codex P2 follow-up on #2328: Alt-hover state must clear when the
 // cursor enters the inspector panel. Otherwise the live distance line
 // keeps drawing from selected_ to a view that's no longer under the

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -516,6 +516,147 @@ TEST_CASE("InspectorOverlay: Alt-hover does nothing without a selection",
     REQUIRE(after_alt_hover.command_count() == baseline_count);
 }
 
+// Phase 3 — selection-mode toggle. The `M` hotkey flips between
+// follows_focus (click-to-select; the default) and follows_mouse
+// (selection chases the pointer). The default must be follows_focus so
+// the inspector's historical behavior is unchanged until the user opts
+// in.
+TEST_CASE("InspectorOverlay: M hotkey toggles selection mode",
+          "[inspect][overlay][phase3]") {
+    View root;
+    root.set_bounds({0, 0, 200, 200});
+    InspectorOverlay overlay(root);
+
+    // Default is follows_focus — historical click-to-select behavior.
+    REQUIRE(overlay.selection_mode() ==
+            InspectorOverlay::SelectionMode::follows_focus);
+
+    overlay.set_active(true);
+
+    KeyEvent m;
+    m.key = KeyCode::m;
+    m.is_down = true;
+    m.modifiers = 0;
+
+    // First M press → follows_mouse.
+    REQUIRE(overlay.handle_key_event(m));
+    REQUIRE(overlay.selection_mode() ==
+            InspectorOverlay::SelectionMode::follows_mouse);
+
+    // Second M press → back to follows_focus.
+    REQUIRE(overlay.handle_key_event(m));
+    REQUIRE(overlay.selection_mode() ==
+            InspectorOverlay::SelectionMode::follows_focus);
+
+    // The M hotkey only fires while the inspector is active — a press
+    // with the overlay closed must not flip the mode.
+    overlay.set_active(false);
+    REQUIRE_FALSE(overlay.handle_key_event(m));
+    REQUIRE(overlay.selection_mode() ==
+            InspectorOverlay::SelectionMode::follows_focus);
+}
+
+// In follows_focus mode a pointer-move must NOT change the selection —
+// only an explicit click does. This is the conservative default that
+// preserves the inspector's historical behavior.
+TEST_CASE("InspectorOverlay: follows_focus keeps selection pinned on hover",
+          "[inspect][overlay][phase3]") {
+    View root;
+    root.set_id("root");
+    root.set_bounds({0, 0, 500, 300});
+
+    auto a = std::make_unique<View>();
+    a->set_id("a");
+    a->set_bounds({10, 10, 60, 60});
+    auto* a_ptr = a.get();
+    root.add_child(std::move(a));
+
+    auto b = std::make_unique<View>();
+    b->set_id("b");
+    b->set_bounds({100, 10, 60, 60});
+    auto* b_ptr = b.get();
+    root.add_child(std::move(b));
+
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    REQUIRE(overlay.selection_mode() ==
+            InspectorOverlay::SelectionMode::follows_focus);
+
+    // Click to select a.
+    MouseEvent click_a;
+    click_a.position = {20, 20};
+    click_a.is_down = true;
+    REQUIRE(overlay.handle_mouse_event(click_a));
+    REQUIRE(overlay.selected_view() == a_ptr);
+
+    // Hover over b (pointer-move, no button) — hovered_ tracks b but the
+    // selection stays pinned to a.
+    MouseEvent hover_b;
+    hover_b.position = {130, 30};
+    hover_b.is_down = false;
+    REQUIRE_FALSE(overlay.handle_mouse_event(hover_b));
+    REQUIRE(overlay.hovered_view() == b_ptr);
+    REQUIRE(overlay.selected_view() == a_ptr);  // unchanged by hover
+}
+
+// In follows_mouse mode a pointer-move DOES re-select the hovered View
+// (Figma-style "select on hover"). An explicit click still works the
+// same way.
+TEST_CASE("InspectorOverlay: follows_mouse re-selects the hovered view",
+          "[inspect][overlay][phase3]") {
+    View root;
+    root.set_id("root");
+    root.set_bounds({0, 0, 500, 300});
+
+    auto a = std::make_unique<View>();
+    a->set_id("a");
+    a->set_bounds({10, 10, 60, 60});
+    auto* a_ptr = a.get();
+    root.add_child(std::move(a));
+
+    auto b = std::make_unique<View>();
+    b->set_id("b");
+    b->set_bounds({100, 10, 60, 60});
+    auto* b_ptr = b.get();
+    root.add_child(std::move(b));
+
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    overlay.set_selection_mode(InspectorOverlay::SelectionMode::follows_mouse);
+
+    // Click to select a.
+    MouseEvent click_a;
+    click_a.position = {20, 20};
+    click_a.is_down = true;
+    REQUIRE(overlay.handle_mouse_event(click_a));
+    REQUIRE(overlay.selected_view() == a_ptr);
+
+    // Hover over b (pointer-move, no button) — selection follows the
+    // pointer onto b.
+    MouseEvent hover_b;
+    hover_b.position = {130, 30};
+    hover_b.is_down = false;
+    REQUIRE_FALSE(overlay.handle_mouse_event(hover_b));
+    REQUIRE(overlay.hovered_view() == b_ptr);
+    REQUIRE(overlay.selected_view() == b_ptr);  // selection chased pointer
+
+    // Hover back over a — selection follows again.
+    MouseEvent hover_a;
+    hover_a.position = {30, 30};
+    hover_a.is_down = false;
+    REQUIRE_FALSE(overlay.handle_mouse_event(hover_a));
+    REQUIRE(overlay.selected_view() == a_ptr);
+
+    // Alt-hover must NOT chase the pointer — Alt-hover sibling-distance
+    // mode relies on a pinned selection.
+    MouseEvent alt_hover_b;
+    alt_hover_b.position = {130, 30};
+    alt_hover_b.modifiers = kModAlt;
+    alt_hover_b.is_down = false;
+    REQUIRE_FALSE(overlay.handle_mouse_event(alt_hover_b));
+    REQUIRE(overlay.selected_view() == a_ptr);  // pinned despite follows_mouse
+}
+
 // Codex P2 follow-up on #2328: Alt-hover state must clear when the
 // cursor enters the inspector panel. Otherwise the live distance line
 // keeps drawing from selected_ to a view that's no longer under the

--- a/tools/scripts/source_tree_pollution_check.py
+++ b/tools/scripts/source_tree_pollution_check.py
@@ -102,6 +102,7 @@ ALLOWED_ROOT_PATHS = frozenset({
     "apple",
     "bindings",
     "ci",
+    "compat",
     "core",
     "docs",
     "examples",


### PR DESCRIPTION
Phase 3 item 6 of the inspector direct-manipulation roadmap. Adds an
`M` hotkey that flips how the inspected node is chosen as the pointer
moves:

  - follows_focus (default) — selection stays pinned to the focused
    element; only an explicit click or panel-tree pick changes it.
    This is the inspector's historical behavior, so the default is a
    no-op for existing hosts and tests.
  - follows_mouse — selection chases the pointer; every hover /
    pointer-move re-selects the hovered View (Figma-style scrubbing).

The hover->selection update is gated on the mode and excludes the Alt
modifier so Alt-hover sibling-distance and Alt+click distance-anchor
modes keep their pinned selection. `M` is the natural free letter for
"mode" — D/E/P/T/J/Z/R/A are all already claimed by other toggles.

Adds 3 headless Catch2 cases: M-hotkey toggles the enum (and is a
no-op while the inspector is inactive), follows_focus keeps selection
pinned on hover, follows_mouse re-selects the hovered view.

Also adds the `compat/` directory to ALLOWED_ROOT_PATHS in
source_tree_pollution_check.py — PR #2531 split compat.json into a
per-surface compat/ directory but never updated the allowlist, so the
pre-push pollution gate was blocking every PR. The gate's own error
message instructs adding legitimate top-level paths to that set.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Version-Bump: skip reason="inspect/ is not a release surface"