### PR TITLE
ci: fix resolve-provider busy-probe over-counting (M1 runners starved during deep queues)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -344,6 +344,48 @@ macOS matrix leg by name, then exit as soon as that leg reports. Otherwise
 advisory Linux/Windows jobs can keep a green macOS leg from satisfying branch
 protection.
 
+### Gotcha: the macOS overflow busy-probe must count only *running* M1 legs (#2467)
+
+`build.yml`'s `resolve-provider` job has an inline-Python "busy probe"
+(`_count_busy_local_mac_runners`) that decides whether a PR's macOS leg
+runs on the local M1s or overflows to github-hosted `macos-15`. The rule:
+`BUSY >= LOCAL_MAC_OVERFLOW_THRESHOLD` (default 2) → overflow.
+
+**The probe must count only macOS Build-and-Test jobs that are RIGHT NOW
+`status == "in_progress"` on a local M1** — a job whose `status` is
+`in_progress` *and* whose `labels` array contains the local self-hosted
+label (`PULP_LOCAL_MAC_RUNNER_LABEL`, default `sanitizer`). Everything
+else counts 0:
+
+- A `queued` Build-and-Test run has dispatched nothing — never enumerate
+  queued runs at all; the probe lists only `status=in_progress` runs.
+- A run that is `in_progress` but whose macOS matrix job is not yet
+  registered (matrix not expanded) or is still `queued` is NOT holding an
+  M1 → count 0.
+- An API blip on a per-run `/jobs` call → count 0 (under-count).
+
+**Why err toward "use local":** an earlier cut enumerated `in_progress`
++ `queued` runs and *pessimistically* counted a not-yet-registered macOS
+job as local-busy. During a deep Actions queue (~250 runs) that
+over-counts catastrophically — hundreds of undispatched queued runs read
+as local-busy, BUSY blows past the threshold, every new macOS leg routes
+to github-hosted overflow, and the local M1s sit 100% idle while macOS
+work — the CI long-pole — starves on the contended hosted pool. Merges
+stalled ~80 minutes on 2026-05-20. Slightly oversubscribing the M1s (a
+3rd leg briefly queues behind 2 running ones) is far less harmful, so the
+probe under-counts, never over-counts.
+
+The probe uses the default workflow `GITHUB_TOKEN` — `repos/.../actions/
+runs/<id>/jobs` exposes per-job `status` + `labels` without an
+`Administration: Read` scope. Do NOT switch the probe to the
+`actions/runners` endpoint (needs admin scope; the first cut did and fell
+back to BUSY=0 every run). Regression coverage:
+`tools/scripts/test_resolve_provider_busy_probe.py`, wired into
+`workflow-lint.yml`; it extracts the inline probe from `build.yml` and
+asserts a 50-run deep queue with 2 real local legs reports BUSY=2 (not
+50). Cooperates with `macos_reroute_watcher.py` — the probe makes the
+initial dispatch call, the watcher catches near-misses after the fact.
+
 ### Release workflows: runner routing
 
 Release workflows should follow the same post-cutover rule: do not add

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,30 +154,55 @@ jobs:
           # too. Local participation drops to zero during deep queues
           # (user feedback, pulp task #24).
           #
-          # This probe (pulp task #24) is smarter: it counts only BAT
-          # runs whose macOS job is RUNNING-ON-LOCAL. We enumerate
-          # in_progress + queued BAT runs and for each one inspect its
-          # macOS job's `labels` array. If the labels include
-          # "self-hosted", the run is occupying the local Mac. If the
-          # job hasn't been dispatched yet (resolve-provider still
-          # running for that run), we conservatively count it as BUSY
-          # since we can't yet tell where its macOS leg will land.
+          # This probe (pulp #2467 class) counts only the macOS legs
+          # ACTUALLY OCCUPYING a local M1 right now: a Build-and-Test
+          # macOS job whose `status == "in_progress"` AND whose `labels`
+          # include the local self-hosted label. Everything else counts
+          # as 0:
+          #   - A `queued` Build-and-Test run has dispatched nothing, so
+          #     it cannot be holding an M1. We do NOT enumerate queued
+          #     runs at all.
+          #   - A run that is `in_progress` but whose macOS matrix job is
+          #     not yet registered (matrix not expanded) or is still
+          #     `queued` is NOT occupying an M1 — count 0.
           #
-          # API cost: 1 list-call + N per-run-jobs calls. With typical
-          # N <= ~30 (open PRs cap), the cost is bounded. Probe failure
-          # still falls back to BUSY=0 (safer to under-count than to
-          # always overflow).
+          # The earlier cut (pulp #1942) enumerated in_progress + queued
+          # runs and PESSIMISTICALLY counted a not-yet-registered macOS
+          # job as local-busy. During a deep Actions queue (~250 runs)
+          # that over-counts catastrophically: hundreds of undispatched
+          # queued runs all read as "local-busy", BUSY blows past the
+          # threshold, EVERY new macOS leg routes to github-hosted
+          # overflow, and the local M1 runners sit 100% idle while macOS
+          # work — the CI long-pole — starves on the contended
+          # github-hosted pool. Merges stalled ~80 minutes on 2026-05-20.
+          #
+          # The fix deliberately INVERTS the old pessimism: an
+          # unregistered / queued / API-blip macOS job counts 0, not 1.
+          # The probe errs toward "use local". Slightly oversubscribing
+          # the M1s (a 3rd macOS leg briefly queues behind 2 running
+          # ones) is FAR less harmful than the failure it replaces (M1s
+          # 100% idle while everything piles onto a jammed github-hosted
+          # pool). Under-count, never over-count.
+          #
+          # API cost: 1 list-call + N per-run-jobs calls, N bounded by
+          # the count of in_progress Build-and-Test runs (small — the
+          # `concurrency` group cancels superseded runs). Probe failure
+          # still falls back to BUSY=0 (consistent with "err toward
+          # local").
           def _count_busy_local_mac_runners() -> int:
               if not REPOSITORY:
                   return 0
               current_run_id = os.environ.get("GITHUB_RUN_ID", "")
               local_label = (os.environ.get("LOCAL_MAC_RUNNER_LABEL") or "self-hosted").strip()
 
-              def _list_runs(status: str):
+              def _list_in_progress_runs():
+                  # Only `in_progress` runs can have a macOS job occupying
+                  # an M1. A `queued` run has dispatched nothing, so it is
+                  # never busy — we deliberately do not list it.
                   result = subprocess.run(
                       [
                           "gh", "api",
-                          f"repos/{REPOSITORY}/actions/runs?status={status}&per_page=100",
+                          f"repos/{REPOSITORY}/actions/runs?status=in_progress&per_page=100",
                           "--jq",
                           (
                               f'[.workflow_runs[] '
@@ -193,12 +218,16 @@ jobs:
                   )
                   return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
-              def _macos_job_targets_local(run_id: str) -> bool:
-                  # Returns True if the run's macOS job is dispatching to
-                  # the local self-hosted target. Returns True (pessimistic)
-                  # if the macOS job hasn't been registered yet — we can't
-                  # tell where it will land, so count it as potentially
-                  # local to avoid overcommitting.
+              def _macos_leg_running_on_local(run_id: str) -> bool:
+                  # True ONLY if this run has a macOS Build-and-Test job
+                  # that is RIGHT NOW `status == "in_progress"` AND whose
+                  # `labels` array contains the local self-hosted label
+                  # (exact membership, not substring). A queued macOS job
+                  # (not started), a not-yet-registered macOS job (matrix
+                  # not expanded), or a completed one is NOT occupying an
+                  # M1 → counts 0. This inverts the old pessimistic
+                  # not-yet-registered → BUSY fallback that starved the
+                  # local runners during deep queues.
                   try:
                       result = subprocess.run(
                           [
@@ -208,7 +237,10 @@ jobs:
                               (
                                   f'[.jobs[] '
                                   f'| select(.name | startswith("macOS")) '
-                                  f'| .labels] | flatten | join(",")'
+                                  f'| select(.status == "in_progress") '
+                                  f'| select((.labels // []) '
+                                  f'| index({json.dumps(local_label)})) '
+                                  f'| .id] | length'
                               ),
                           ],
                           check=True,
@@ -216,23 +248,21 @@ jobs:
                           text=True,
                           timeout=15,
                       )
-                      labels = (result.stdout or "").strip()
-                      if not labels:
-                          # macOS job not yet registered — pessimistic.
-                          return True
-                      return local_label in labels
+                      count_text = (result.stdout or "").strip()
+                      return int(count_text) > 0 if count_text else False
                   except (subprocess.SubprocessError, ValueError):
-                      # Defer to "potentially local" so a single API blip
-                      # doesn't accidentally let two local runs in flight.
-                      return True
+                      # API blip: under-count (count 0). Erring toward
+                      # "use local" is the safe failure mode — briefly
+                      # oversubscribing 2 M1s beats starving them idle.
+                      return False
 
               try:
-                  ids = _list_runs("in_progress") + _list_runs("queued")
-                  local_busy = sum(1 for rid in ids if _macos_job_targets_local(rid))
-                  total_other = len(ids)
+                  ids = _list_in_progress_runs()
+                  local_busy = sum(1 for rid in ids if _macos_leg_running_on_local(rid))
                   sys.stderr.write(
-                      f"resolve-provider: BAT runs other than self: "
-                      f"{total_other} total, {local_busy} targeting local\n"
+                      f"resolve-provider: in_progress BAT runs other than self: "
+                      f"{len(ids)} total, {local_busy} with a macOS leg "
+                      f"in_progress on a local M1\n"
                   )
                   return local_busy
               except (subprocess.SubprocessError, ValueError) as exc:

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -87,8 +87,8 @@ jobs:
           print(f"structural parse OK across {sum(1 for _ in pathlib.Path('.github/workflows').rglob('*.y*ml'))} files")
           PY
 
-      - name: Release-pipeline regression tests (#720, #1962)
-        # Regression coverage for two silent release-pipeline failures:
+      - name: Release-pipeline regression tests (#720, #1962, #2467)
+        # Regression coverage for silent CI-pipeline failures:
         #
         #   #720  — assert that release-side ctest invocations keep
         #           skipping the `validation` label so auval failures on
@@ -102,12 +102,20 @@ jobs:
         #           original script couldn't see — every release after
         #           v0.94.0 silently failed at the Skia fetch step and
         #           no GitHub Release was published.
+        #
+        #   #2467 — assert build.yml's resolve-provider macOS busy probe
+        #           counts only macOS legs actually in_progress on a
+        #           local M1. The earlier cut over-counted not-yet-
+        #           registered queued runs as local-busy, routed every
+        #           macOS leg to github-hosted overflow during deep
+        #           queues, and left the local M1s 100% idle.
         shell: bash
         run: |
           set -euo pipefail
           python3 tools/scripts/test_release_workflow_test_step.py
           python3 tools/scripts/test_workflow_build_dirs.py
           python3 tools/scripts/test_fetch_skia_for_release.py
+          python3 tools/scripts/test_resolve_provider_busy_probe.py
 
       - name: actionlint
         # Disable shellcheck + pyflakes — the Pulp repo has accumulated

--- a/tools/scripts/test_resolve_provider_busy_probe.py
+++ b/tools/scripts/test_resolve_provider_busy_probe.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Tests for build.yml's resolve-provider macOS busy probe.
+
+The probe (`_count_busy_local_mac_runners`) decides whether a PR's macOS
+Build-and-Test leg runs on the local self-hosted M1 runners or overflows
+to github-hosted `macos-15`. It must count ONLY macOS jobs that are
+actually occupying a local M1 right now — a job whose
+`status == "in_progress"` AND whose `labels` include the local
+self-hosted label.
+
+Regression covered (pulp #2467 class): an earlier cut enumerated
+`in_progress` + `queued` runs and PESSIMISTICALLY counted a
+not-yet-registered macOS job as local-busy. During a deep Actions queue
+(~250 runs) that over-counts catastrophically — hundreds of undispatched
+queued runs read as local-busy, BUSY blows past the threshold, every new
+macOS leg overflows, and the local M1s sit 100% idle while macOS work
+starves on the github-hosted pool.
+
+The probe is inline Python inside build.yml's resolve-provider step. This
+test extracts that heredoc, dedents it, execs ONLY the helper definitions
+in an isolated namespace with a mocked `subprocess`, and exercises
+`_count_busy_local_mac_runners` against deterministic `gh api` payloads.
+
+Run with:
+    python3 tools/scripts/test_resolve_provider_busy_probe.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import types
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BUILD_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "build.yml"
+
+# The local self-hosted label build.yml's probe defaults to when the repo
+# variable is unset (PULP_LOCAL_MAC_RUNNER_LABEL || 'sanitizer').
+LOCAL_LABEL = "sanitizer"
+
+
+def _assert(cond: bool, msg: str) -> None:
+    if not cond:
+        raise AssertionError(msg)
+
+
+def _extract_probe_source() -> str:
+    """Pull the inline Python heredoc out of build.yml and dedent it."""
+    text = BUILD_WORKFLOW.read_text(encoding="utf-8")
+    match = re.search(r"python3 - <<'PY'\n(?P<body>.*?)\n[ ]*PY\b", text, re.DOTALL)
+    _assert(match is not None, "build.yml missing the resolve-provider PY heredoc")
+    body = match.group("body")
+    # The run-block body is indented 10 spaces under the YAML `run: |`.
+    lines = body.split("\n")
+    dedented = [
+        line[10:] if line.startswith(" " * 10) else line
+        for line in lines
+    ]
+    return "\n".join(dedented)
+
+
+def _slice_probe_function(source: str) -> str:
+    """Return just the `_count_busy_local_mac_runners` def (+ nested helpers)."""
+    lines = source.split("\n")
+    start = None
+    for i, line in enumerate(lines):
+        if line.startswith("def _count_busy_local_mac_runners"):
+            start = i
+            break
+    _assert(start is not None, "probe function not found in build.yml heredoc")
+    end = len(lines)
+    for i in range(start + 1, len(lines)):
+        line = lines[i]
+        # First top-level (column-0, non-blank, non-comment) line after the
+        # def ends the function body.
+        if line and not line[0].isspace() and not line.startswith("#"):
+            end = i
+            break
+    return "\n".join(lines[start:end])
+
+
+class _FakeCompletedProcess:
+    def __init__(self, stdout: str) -> None:
+        self.stdout = stdout
+        self.returncode = 0
+
+
+def _build_fake_subprocess(in_progress_run_ids, jobs_by_run, *, raise_for=None):
+    """Construct a stand-in `subprocess` module for the probe.
+
+    `in_progress_run_ids` — list[str] of run IDs the runs list-call returns.
+    `jobs_by_run` — dict[run_id] -> list[job dict] for the per-run jobs call.
+    `raise_for` — optional set of run_ids whose jobs call raises (API blip).
+    """
+    raise_for = raise_for or set()
+
+    class _SubprocessError(Exception):
+        pass
+
+    def _run(args, **kwargs):  # noqa: ANN001
+        # args[0:2] == ["gh", "api"]; args[2] is the endpoint, args[4] the jq.
+        endpoint = args[2]
+        jq = args[4]
+        if "/actions/runs?status=in_progress" in endpoint:
+            return _FakeCompletedProcess(
+                "\n".join(str(r) for r in in_progress_run_ids) + "\n"
+            )
+        m = re.search(r"/actions/runs/([^/]+)/jobs", endpoint)
+        _assert(m is not None, f"unexpected endpoint: {endpoint}")
+        run_id = m.group(1)
+        if run_id in raise_for:
+            raise _SubprocessError("simulated gh api failure")
+        jobs = jobs_by_run.get(run_id, [])
+        # Apply the probe's jq: count macOS jobs in_progress carrying the
+        # local label. The jq embeds json.dumps(local_label); recover it.
+        label_match = re.search(r"index\((\"[^\"]+\")\)", jq)
+        _assert(label_match is not None, f"jq missing index(label): {jq}")
+        wanted = json.loads(label_match.group(1))
+        count = sum(
+            1
+            for j in jobs
+            if j.get("name", "").startswith("macOS")
+            and j.get("status") == "in_progress"
+            and wanted in (j.get("labels") or [])
+        )
+        return _FakeCompletedProcess(f"{count}\n")
+
+    mod = types.SimpleNamespace()
+    mod.run = _run
+    mod.SubprocessError = _SubprocessError
+    mod.CalledProcessError = _SubprocessError
+    return mod
+
+
+def _make_probe(in_progress_run_ids, jobs_by_run, *, raise_for=None,
+                repository="danielraffel/pulp", current_run_id="999"):
+    """Exec the extracted probe in an isolated namespace and return the fn."""
+    source = _slice_probe_function(_extract_probe_source())
+    ns: dict = {
+        "json": json,
+        "sys": sys,
+        "subprocess": _build_fake_subprocess(
+            in_progress_run_ids, jobs_by_run, raise_for=raise_for
+        ),
+        "os": types.SimpleNamespace(
+            environ={
+                "GITHUB_RUN_ID": current_run_id,
+                "LOCAL_MAC_RUNNER_LABEL": LOCAL_LABEL,
+            }
+        ),
+        "REPOSITORY": repository,
+    }
+    exec(compile(source, "<build.yml probe>", "exec"), ns)  # noqa: S102
+    return ns["_count_busy_local_mac_runners"]
+
+
+def _macos_job(status: str, *, local: bool = True, name: str = "macOS (ARM64) [local]"):
+    labels = [LOCAL_LABEL] if local else ["macos-15"]
+    return {"name": name, "status": status, "labels": labels}
+
+
+# ── tests ────────────────────────────────────────────────────────────────
+
+
+def test_counts_macos_leg_in_progress_on_local() -> None:
+    probe = _make_probe(["1"], {"1": [_macos_job("in_progress", local=True)]})
+    _assert(probe() == 1, "an in_progress macOS leg on a local M1 must count 1")
+
+
+def test_two_in_progress_local_legs_count_two() -> None:
+    probe = _make_probe(
+        ["1", "2"],
+        {
+            "1": [_macos_job("in_progress", local=True)],
+            "2": [_macos_job("in_progress", local=True)],
+        },
+    )
+    _assert(probe() == 2, "two busy local M1 legs must count 2 (threshold hit)")
+
+
+def test_overflow_leg_does_not_count_as_local() -> None:
+    # A macOS leg in_progress on github-hosted macos-15 is NOT on an M1.
+    probe = _make_probe(["1"], {"1": [_macos_job("in_progress", local=False)]})
+    _assert(probe() == 0, "an overflow (macos-15) leg must count 0")
+
+
+def test_queued_macos_leg_counts_zero() -> None:
+    # The core regression: a queued macOS job has not started — it is not
+    # occupying an M1, so it must count 0 (old probe wrongly counted it).
+    probe = _make_probe(["1"], {"1": [_macos_job("queued", local=True)]})
+    _assert(probe() == 0, "a queued macOS leg must count 0, not 1")
+
+
+def test_not_yet_registered_macos_leg_counts_zero() -> None:
+    # An in_progress run whose macOS matrix job is not yet registered:
+    # /jobs returns no macOS job. Old probe pessimistically counted 1;
+    # the fix counts 0. This is the deep-queue starvation regression.
+    probe = _make_probe(
+        ["1", "2", "3"],
+        {
+            "1": [{"name": "Linux (x64)", "status": "in_progress",
+                   "labels": ["ubuntu-latest"]}],
+            "2": [],
+            "3": [{"name": "resolve-provider", "status": "in_progress",
+                   "labels": ["ubuntu-latest"]}],
+        },
+    )
+    _assert(probe() == 0,
+            "in_progress runs with no registered macOS leg must count 0")
+
+
+def test_deep_queue_does_not_overcount() -> None:
+    # 50 in_progress runs, but only 2 have a macOS leg actually running on
+    # a local M1; the rest are mid-build on other legs / not-yet-expanded.
+    # The probe must report 2, not 50 — this is the exact failure mode.
+    ids = [str(i) for i in range(50)]
+    jobs = {i: [] for i in ids}
+    jobs["0"] = [_macos_job("in_progress", local=True)]
+    jobs["1"] = [_macos_job("in_progress", local=True)]
+    jobs["2"] = [_macos_job("queued", local=True)]          # queued → 0
+    jobs["3"] = [_macos_job("in_progress", local=False)]    # overflow → 0
+    probe = _make_probe(ids, jobs)
+    _assert(probe() == 2,
+            "deep queue with 2 real local legs must report BUSY=2, not 50")
+
+
+def test_completed_macos_leg_counts_zero() -> None:
+    # A completed macOS job has freed its M1.
+    probe = _make_probe(["1"], {"1": [_macos_job("completed", local=True)]})
+    _assert(probe() == 0, "a completed macOS leg must count 0")
+
+
+def test_api_blip_undercounts_to_zero() -> None:
+    # An exception from the per-run jobs call must under-count (return
+    # False for that run) — erring toward "use local", never overflow.
+    probe = _make_probe(
+        ["1", "2"],
+        {"1": [_macos_job("in_progress", local=True)]},
+        raise_for={"2"},
+    )
+    _assert(probe() == 1,
+            "an API blip on one run must not inflate the busy count")
+
+
+def test_empty_repository_returns_zero() -> None:
+    probe = _make_probe(["1"], {"1": [_macos_job("in_progress")]}, repository="")
+    _assert(probe() == 0, "no REPOSITORY → probe returns 0")
+
+
+def test_self_run_excluded_from_listing() -> None:
+    # The runs list jq excludes the current run id; confirm the jq filter
+    # text in build.yml still carries that select().
+    source = _extract_probe_source()
+    _assert('select((.id | tostring) != "{current_run_id}")' in source
+            or 'tostring) != "' in source,
+            "probe must still exclude the current run id from the runs list")
+
+
+def test_probe_does_not_enumerate_queued_runs() -> None:
+    # Guard: the fix must NOT list status=queued runs. If a future edit
+    # re-adds `_list_runs("queued")` the deep-queue regression returns.
+    source = _extract_probe_source()
+    probe_fn = _slice_probe_function(source)
+    _assert("status=queued" not in probe_fn,
+            "probe must not enumerate queued runs (deep-queue regression)")
+    _assert("status=in_progress" in probe_fn,
+            "probe must enumerate in_progress runs")
+
+
+def _all_tests() -> list:
+    return [
+        obj for name, obj in globals().items()
+        if name.startswith("test_") and callable(obj)
+    ]
+
+
+def main() -> int:
+    failures = 0
+    for fn in _all_tests():
+        try:
+            fn()
+            print(f"ok  {fn.__name__}")
+        except Exception as exc:  # noqa: BLE001
+            failures += 1
+            print(f"FAIL {fn.__name__}: {exc}")
+    if failures:
+        print(f"\n{failures} failing test(s)")
+        return 1
+    print(f"\nall {len(_all_tests())} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

`build.yml`'s `resolve-provider` job has an inline-Python "busy probe"
(`_count_busy_local_mac_runners`) that decides whether a PR's macOS
Build-and-Test leg runs on the **local M1 self-hosted runners** or
**overflows to github-hosted `macos-15`**. Rule: if busy-count `>=
LOCAL_MAC_OVERFLOW_THRESHOLD` (2) → overflow; else → local.

**The bug (`#2467` over-count class):** the probe enumerated both
`in_progress` *and* `queued` Build-and-Test runs, and a helper
PESSIMISTICALLY counted a macOS job that was **not yet registered** (run
dispatched, matrix job not created) as local-targeting. During a deep
Actions queue (~250 runs, observed live 2026-05-20) there are many
queued-but-undispatched runs — the probe counted them all as
"local-busy", busy-count blew past the threshold, every new macOS leg
routed to github-hosted overflow, and the local M1 runners sat 100% idle
(`busy=0`) for 30+ minutes while macOS work — the CI long-pole — starved
on the contended github-hosted pool. Merges stalled ~80 minutes.

## The fix

- Probe now lists only `status=in_progress` runs. A `queued` run has
  dispatched nothing — it cannot be holding an M1.
- `_macos_leg_running_on_local` counts a run iff it has a macOS
  Build-and-Test job that is **right now `status == "in_progress"`** AND
  whose `labels` array contains the local self-hosted label (exact jq
  `index()` membership, not substring — per Codex review).
- The old pessimistic "not-yet-registered → count as local" fallback is
  **inverted**: unregistered / queued / API-blip → counts 0. The probe
  under-counts, never over-counts, erring toward "use local".
- Rationale baked into the code comment: briefly oversubscribing the M1s
  (a 3rd leg queues behind 2 running ones) is far less harmful than the
  failure it replaces (M1s 100% idle while everything piles onto a
  jammed github-hosted pool).
- Uses the default workflow `GITHUB_TOKEN` — `actions/runs/<id>/jobs`
  exposes per-job `status` + `labels` with no new scope/secret.

## Test plan

- [x] `tools/scripts/test_resolve_provider_busy_probe.py` — 11 cases
      that extract the inline probe from `build.yml`, exec it in an
      isolated namespace against mocked `gh api` payloads, and assert
      the busy count. Includes a 50-run deep-queue case asserting
      `BUSY=2` (not 50) — the exact failure mode. Wired into
      `workflow-lint.yml`.
- [x] `yamllint --no-warnings -d relaxed` + `actionlint -shellcheck=` on
      both `build.yml` and `workflow-lint.yml` — clean.
- [x] `python3 -c "yaml.safe_load(...)"` on both workflows — clean.
- [x] Inline probe Python syntax-checked via `ast.parse` after dedent.
- [x] jq filter validated against mock job payloads (local in_progress →
      1; overflow `macos-15` → 0; queued → 0; not-registered → 0).
- [x] Existing `tools/scripts/test_resolve_runs_on.py` — 30/30 pass.
- [x] Probe logic sanity-checked with `/codex-consult` — confirmed jq +
      logic correct; adopted its exact-membership `index()` suggestion
      and `startswith("macOS")` safety note.

> [!NOTE]
> `build.yml` feeds the **required `macos` check** — do not merge without
> review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
