### PR TITLE
feat(runtime): add node ABI capability gate

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1629,7 +1629,7 @@ use `CMAKE_CURRENT_LIST_DIR`. The two existing helpers paths
 
 `pulp pr` orchestrates the full shipping flow. CI enforces three gates on every PR to `main`:
 
-- `.github/workflows/version-skill-check.yml` — runs `tools/scripts/version_bump_check.py`, `tools/scripts/skill_sync_check.py`, `tools/scripts/compat_sync_check.py`, and `tools/scripts/node_abi_gate.py` in `--mode=report`. Failure blocks merge. No bypass except the commit trailers documented in `docs/guides/versioning.md` and `docs/guides/compat-sync.md`; the node ABI gate is fixed by preserving virtual-method order or appending new virtuals at the tail.
+- `.github/workflows/version-skill-check.yml` — runs `tools/scripts/version_bump_check.py`, `tools/scripts/skill_sync_check.py`, `tools/scripts/compat_sync_check.py`, and `tools/scripts/node_abi_gate.py` in `--mode=report`. Failure blocks merge. No bypass except the commit trailers documented in `docs/guides/versioning.md` and `docs/guides/compat-sync.md`; the node ABI gate is fixed by preserving existing virtual declarations or appending new virtuals at the tail.
 - `.shipyard/config.toml` → `[validation.gates]` pipeline — same scripts via `shipyard run --pipeline gates`. Runs with `PULP_ENFORCE_PREPUSH=1` so warnings become errors.
 
 Locally:

--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1629,13 +1629,13 @@ use `CMAKE_CURRENT_LIST_DIR`. The two existing helpers paths
 
 `pulp pr` orchestrates the full shipping flow. CI enforces three gates on every PR to `main`:
 
-- `.github/workflows/version-skill-check.yml` — runs `tools/scripts/version_bump_check.py`, `tools/scripts/skill_sync_check.py`, and (since #1029) `tools/scripts/compat_sync_check.py` in `--mode=report`. Failure blocks merge. No bypass except the commit trailers documented in `docs/guides/versioning.md` and `docs/guides/compat-sync.md`.
+- `.github/workflows/version-skill-check.yml` — runs `tools/scripts/version_bump_check.py`, `tools/scripts/skill_sync_check.py`, `tools/scripts/compat_sync_check.py`, and `tools/scripts/node_abi_gate.py` in `--mode=report`. Failure blocks merge. No bypass except the commit trailers documented in `docs/guides/versioning.md` and `docs/guides/compat-sync.md`; the node ABI gate is fixed by preserving virtual-method order or appending new virtuals at the tail.
 - `.shipyard/config.toml` → `[validation.gates]` pipeline — same scripts via `shipyard run --pipeline gates`. Runs with `PULP_ENFORCE_PREPUSH=1` so warnings become errors.
 
 Locally:
 
-- `.githooks/pre-push` (install via `tools/scripts/install-githooks.sh`) runs all three scripts advisory-by-default. `PULP_ENFORCE_PREPUSH=1` upgrades to hard fail; `PULP_SKIP_PREPUSH=1` is the single-push emergency bypass.
-- `tools/scripts/gates.sh` — on-demand runner for JUST the cheap gates (skill-sync + version-bump + compat-sync + deps-audit). Runs in ~1 second, exits non-zero on any failure with a one-liner pointing at the right surgical bypass. Use it before `git push` when you've made changes that might touch mapped paths but you don't want to wait for the pre-push hook OR the 20-minute CI roundtrip. Independent of the git hook (no install step needed). Named to align with Shipyard's planned `shipyard gates` subcommand (see `planning/2026-05-19-shipyard-preflight-upstream-proposal.md`); avoids collision with Shipyard's existing `preflight` namespace (SSH backend reachability probes).
+- `.githooks/pre-push` (install via `tools/scripts/install-githooks.sh`) runs the same fast scripts, including the node ABI gate, advisory-by-default. `PULP_ENFORCE_PREPUSH=1` upgrades to hard fail; `PULP_SKIP_PREPUSH=1` is the single-push emergency bypass.
+- `tools/scripts/gates.sh` — on-demand runner for JUST the cheap gates (skill-sync + version-bump + compat-sync + node-ABI + deps-audit). Runs in ~1 second, exits non-zero on any failure with a one-liner pointing at the right surgical bypass. Use it before `git push` when you've made changes that might touch mapped paths but you don't want to wait for the pre-push hook OR the 20-minute CI roundtrip. Independent of the git hook (no install step needed). Named to align with Shipyard's planned `shipyard gates` subcommand (see `planning/2026-05-19-shipyard-preflight-upstream-proposal.md`); avoids collision with Shipyard's existing `preflight` namespace (SSH backend reachability probes).
 
 **Bypass-priority cheat sheet** — reach for the surgical knob first; the nuclear one masks fast checks too:
 

--- a/.agents/skills/clap/SKILL.md
+++ b/.agents/skills/clap/SKILL.md
@@ -71,7 +71,9 @@ struct. It owns:
   automation point with `header.time` before the StateStore dual-write
   lands the last value for ordinary parameter reads.
 - `mpe_tracker` + `mpe_buffer` + `mpe_enabled` — MPE sidecar populated
-  only if `PluginDescriptor::supports_mpe` is true.
+  only if `PluginDescriptor::effective_capabilities().supports_mpe`
+  is true. The effective value ORs the legacy descriptor flag with the
+  node ABI capability field.
 - `ump_buffer` + `ump_enabled` — UMP sidecar. Cleared at the top of
   every block, then filled from BOTH sources every block: native
   `CLAP_EVENT_MIDI2` packets append directly during the event loop,

--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -180,6 +180,12 @@ rules:
   format and graph code can share the event ABI without depending on
   `core/host`. Phase 1 loaders consume it; Phase 0 loaders accept and
   ignore. Use it — not `set_parameter` — for per-block automation.
+- **Node ABI surface.** `PluginSlot` includes
+  `pulp/runtime/node_abi.hpp` and participates in the node ABI
+  virtual-order gate. Existing virtual methods may not be inserted,
+  removed, or reordered; add new virtual methods only after the current
+  tail and let `tools/scripts/node_abi_gate.py --mode=report` verify
+  the diff against the PR base.
 - **Thread rules doc.** `docs/reference/host-thread-rules.md` is the
   canonical reference.
 

--- a/.agents/skills/mpe/SKILL.md
+++ b/.agents/skills/mpe/SKILL.md
@@ -26,7 +26,7 @@ If you only need monophonic aftertouch or a global mod wheel, plain
 | You're writing... | Use |
 |--|--|
 | An MPE synth voice | Subclass `midi::MpeSynthVoice`, render your oscillator using `state().pitch_bend_semitones`, `state().pressure`, `state().timbre` |
-| An MPE synth plugin | `MpeVoiceAllocator<YourVoice>` inside the processor, dispatch `MpeBuffer` in `process()`, set `supports_mpe = true` in the descriptor |
+| An MPE synth plugin | `MpeVoiceAllocator<YourVoice>` inside the processor, dispatch `MpeBuffer` in `process()`, set `supports_mpe = true` or `node_capabilities.supports_mpe = true` in the descriptor |
 | A host that loads MPE plugins | Build an `MpeBuffer` from inbound MIDI (zone-aware) and hand it to `Processor::mpe_input()` — the CLAP adapter already does this |
 | Pure MIDI 2.0 UMP work | Out of scope — Phase 4 is deferred, see `planning/next-features-plan.md` |
 
@@ -39,7 +39,7 @@ If you only need monophonic aftertouch or a global mod wheel, plain
 ```
 
 The CLI post-processes the generated descriptor to add
-`.supports_mpe = true` and includes `<pulp/midi/mpe_buffer.hpp>`. No
+`.supports_mpe = true` or `.node_capabilities.supports_mpe = true` and includes `<pulp/midi/mpe_buffer.hpp>`. No
 manual wiring required.
 
 ### 2. Declare the voice

--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -23,6 +23,12 @@ times to be worth remembering.
 | Hand the built view to an external container (TabPanel, WindowHost) | Yes — call `ViewBridge::release_view()` |
 | Ship a paint-only overlay (inspector) | No — but `attach_secondary_view(…, ViewRole::Inspector)` is the primitive you'll eventually use |
 
+`Processor`'s editor hooks (`create_view`, `view_size`, `on_view_*`) are
+part of the node ABI surface. When adding a new view lifecycle hook, append
+the virtual at the tail of `Processor`; never insert, remove, reorder, or
+re-signature existing virtuals. `tools/scripts/node_abi_gate.py --mode=report`
+is the fast check before pushing.
+
 ## Lifecycle protocol — adapter author side
 
 ```

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.101.0",
+      "version": "0.102.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.101.0"
+  "version": "0.102.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -11,7 +11,7 @@
 #   git config core.hooksPath .githooks
 #
 # Bypass knobs (use sparingly — CI runs the same gates):
-#   PULP_DISABLE_PREPUSH_GATES=1   # demote ALL gates to advisory (skill/version/compat/docs-noise/source-contract/deps)
+#   PULP_DISABLE_PREPUSH_GATES=1   # demote ALL gates to advisory (skill/version/compat/node-ABI/docs-noise/source-contract/deps)
 #   PULP_DISABLE_PREPUSH_DIFF_COVER=1  # demote diff-cover gate only
 #   PULP_SKIP_PREPUSH=1            # skip ALL gates entirely (true emergencies)
 #
@@ -84,6 +84,7 @@ VBC="$ROOT/tools/scripts/version_bump_check.py"
 SSC="$ROOT/tools/scripts/skill_sync_check.py"
 CSC="$ROOT/tools/scripts/compat_sync_check.py"
 DNL="$ROOT/tools/scripts/docs_noise_lint.py"
+NAG="$ROOT/tools/scripts/node_abi_gate.py"
 SCC="$ROOT/tools/import-validation/check-source-contracts.py"
 SCT="$ROOT/tools/import-validation/test_source_contracts.py"
 CFG="$ROOT/tools/scripts/versioning.json"
@@ -156,6 +157,17 @@ if [ -f "$DNL" ]; then
         0) ;;
         1) fail=1 ;;
         *) echo "[pre-push] docs_noise_lint: internal error" >&2 ;;
+    esac
+fi
+
+# Node ABI virtual-order gate. Processor and PluginSlot are public
+# polymorphic surfaces; virtual methods may only be appended within ABI v1.
+if [ -f "$NAG" ]; then
+    "$PYTHON" "$NAG" --base "$BASE" --mode=report
+    case $? in
+        0) ;;
+        1) fail=1 ;;
+        *) echo "[pre-push] node_abi_gate: internal error" >&2 ;;
     esac
 fi
 
@@ -272,7 +284,7 @@ if [ "$compat_flip_failed" = "1" ] && [ "$disable_main" = "1" ]; then
 fi
 
 if [ "$fail" = "1" ] && [ "$disable_main" = "1" ]; then
-    echo "[pre-push] PULP_DISABLE_PREPUSH_GATES=1 — skill/version/compat/docs-noise/deps gate failures DEMOTED to advisory." >&2
+    echo "[pre-push] PULP_DISABLE_PREPUSH_GATES=1 — skill/version/compat/node-ABI/docs-noise/deps gate failures DEMOTED to advisory." >&2
     fail=0
 fi
 
@@ -283,7 +295,7 @@ fi
 
 echo "[pre-push] gate failure(s) above; blocking push." >&2
 echo "[pre-push] To bypass (use sparingly; CI still runs the same gates):" >&2
-echo "[pre-push]   PULP_DISABLE_PREPUSH_GATES=1 git push          # demote skill/version/compat/docs-noise/deps/flip" >&2
+echo "[pre-push]   PULP_DISABLE_PREPUSH_GATES=1 git push          # demote skill/version/compat/node-ABI/docs-noise/deps/flip" >&2
 echo "[pre-push]   PULP_DISABLE_PREPUSH_DIFF_COVER=1 git push     # demote diff-cover only" >&2
 echo "[pre-push]   PULP_SKIP_PREPUSH=1 git push                   # skip ALL gates (emergencies)" >&2
 exit 1

--- a/.github/workflows/version-skill-check.yml
+++ b/.github/workflows/version-skill-check.yml
@@ -115,6 +115,12 @@ jobs:
               --base "${{ steps.base.outputs.ref }}" \
               --mode=report --enforce
 
+      - name: Node ABI virtual-order check
+        run: |
+          python3 tools/scripts/node_abi_gate.py \
+              --base "${{ steps.base.outputs.ref }}" \
+              --mode=report
+
       - name: Source-contract registry check
         # Lightweight import-provider contract gate. The registry linter is
         # intentionally no-build and treats optional planning-submodule paths
@@ -137,6 +143,7 @@ jobs:
       - name: Gate-script fixture tests
         run: |
           python3 tools/scripts/test_gates.py
+          python3 tools/scripts/test_node_abi_gate.py
           python3 tools/scripts/test_docs_sync_check.py
           python3 tools/scripts/test_compat_sync_check.py
           python3 tools/scripts/test_check_cli_mcp_parity.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.180.4
+    VERSION 0.181.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/clap_adapter.hpp
+++ b/core/format/include/pulp/format/clap_adapter.hpp
@@ -44,15 +44,15 @@ struct PulpClapPlugin {
     state::ParameterEventQueue param_events;
 
     // MPE sidecar — populated from midi_in before each process() call when
-    // the Processor declares supports_mpe in its PluginDescriptor.
+    // the Processor declares MPE in its effective PluginDescriptor capabilities.
     midi::MpeVoiceTracker mpe_tracker;
     midi::MpeBuffer mpe_buffer;
     int32_t mpe_current_sample_offset = 0;
     bool mpe_enabled = false;
 
     // UMP sidecar — populated by converting midi_in to MIDI 2.0 UMP packets
-    // when the Processor declares supports_ump. In the future, CLAP hosts
-    // that deliver CLAP_EVENT_MIDI2 can populate this buffer directly.
+    // when the Processor declares UMP in its effective PluginDescriptor
+    // capabilities. Native CLAP_EVENT_MIDI2 packets also append directly.
     midi::UmpBuffer ump_buffer;
     bool ump_enabled = false;
 

--- a/core/format/include/pulp/format/processor.hpp
+++ b/core/format/include/pulp/format/processor.hpp
@@ -4,6 +4,7 @@
 #include <pulp/midi/buffer.hpp>
 #include <pulp/midi/mpe_buffer.hpp>
 #include <pulp/midi/ump_buffer.hpp>
+#include <pulp/runtime/node_abi.hpp>
 #include <pulp/state/parameter_event_queue.hpp>
 #include <pulp/state/store.hpp>
 #include <pulp/view/view.hpp>
@@ -49,6 +50,14 @@ struct BusInfo {
     std::string name;
     int default_channels = 2;
     bool optional = false;  ///< true for sidechain buses that can be deactivated
+};
+
+/// Capability sidecar for the node ABI. New capability bits should be
+/// appended here with false defaults so descriptor aggregate initializers
+/// remain source-compatible.
+struct NodeCapabilities {
+    bool supports_mpe = false;
+    bool supports_ump = false;
 };
 
 /// Plugin metadata — declared once, immutable.
@@ -121,6 +130,18 @@ struct PluginDescriptor {
     /// AU kAudioUnitProperty_URL. Leave empty to skip.
     std::string vendor_url;
     std::string vendor_email;
+
+    /// Node ABI capability bits. This is the forward-compatible capability
+    /// model; legacy supports_mpe/supports_ump remain accepted and are OR'd
+    /// into effective_capabilities().
+    NodeCapabilities node_capabilities;
+
+    NodeCapabilities effective_capabilities() const {
+        return {
+            .supports_mpe = supports_mpe || node_capabilities.supports_mpe,
+            .supports_ump = supports_ump || node_capabilities.supports_ump,
+        };
+    }
 
     /// Channel count of the first (main) input bus.
     int default_input_channels() const {
@@ -387,13 +408,13 @@ public:
     const audio::BufferView<const float>* sidechain_input() const { return sidechain_; }
 
     /// Access the per-note MPE expression buffer for this block. Returns
-    /// nullptr unless the plugin declared PluginDescriptor::supports_mpe = true
-    /// and the host/format adapter populated it.
+    /// nullptr unless the plugin declared MPE via PluginDescriptor legacy
+    /// flags or node capabilities and the host/format adapter populated it.
     const midi::MpeBuffer* mpe_input() const { return mpe_input_; }
 
     /// Access the MIDI 2.0 UMP buffer for this block. Returns nullptr
-    /// unless the plugin declared PluginDescriptor::supports_ump = true
-    /// and the host/format adapter populated it.
+    /// unless the plugin declared UMP via PluginDescriptor legacy flags or
+    /// node capabilities and the host/format adapter populated it.
     const midi::UmpBuffer* ump_input() const { return ump_input_; }
 
     /// Access sample-accurate parameter automation for this block. Returns

--- a/core/format/src/clap_adapter.cpp
+++ b/core/format/src/clap_adapter.cpp
@@ -45,8 +45,10 @@ bool clap_init(const clap_plugin_t* plugin) {
     self->preset_manager = std::make_unique<state::PresetManager>(
         self->store, desc.manufacturer, desc.name);
 
+    const auto caps = desc.effective_capabilities();
+
     // Wire MPE sidecar when the plugin opts in.
-    self->mpe_enabled = desc.supports_mpe;
+    self->mpe_enabled = caps.supports_mpe;
     if (self->mpe_enabled) {
         midi::bind_tracker_to_buffer(
             self->mpe_tracker, self->mpe_buffer, self->mpe_current_sample_offset);
@@ -54,7 +56,7 @@ bool clap_init(const clap_plugin_t* plugin) {
     }
 
     // Wire UMP sidecar when the plugin opts in.
-    self->ump_enabled = desc.supports_ump;
+    self->ump_enabled = caps.supports_ump;
     if (self->ump_enabled) {
         runtime::log_info("CLAP: UMP sidecar enabled for '{}'", desc.name);
     }

--- a/core/format/src/descriptor_validation.cpp
+++ b/core/format/src/descriptor_validation.cpp
@@ -90,7 +90,8 @@ std::vector<DescriptorIssue> validate_descriptor(const PluginDescriptor& d) {
                           "— the plugin will receive no MIDI input"});
     }
 
-    if ((d.supports_mpe || d.supports_ump) && !d.accepts_midi) {
+    const auto caps = d.effective_capabilities();
+    if ((caps.supports_mpe || caps.supports_ump) && !d.accepts_midi) {
         issues.push_back({DescriptorIssueSeverity::Warning,
                           "accepts_midi",
                           "supports_mpe / supports_ump are set but "

--- a/core/host/include/pulp/host/plugin_slot.hpp
+++ b/core/host/include/pulp/host/plugin_slot.hpp
@@ -12,6 +12,7 @@
 
 #include <pulp/host/scanner.hpp>
 #include <pulp/host/parameter_event_queue.hpp>
+#include <pulp/runtime/node_abi.hpp>
 #include <pulp/state/parameter.hpp>
 #include <pulp/audio/buffer.hpp>
 #include <pulp/midi/buffer.hpp>

--- a/core/runtime/include/pulp/runtime/node_abi.hpp
+++ b/core/runtime/include/pulp/runtime/node_abi.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstdint>
+
+namespace pulp {
+
+inline constexpr std::uint32_t PULP_NODE_ABI_VERSION = 1;
+
+inline constexpr std::uint32_t pulp_node_abi_version() noexcept {
+    return PULP_NODE_ABI_VERSION;
+}
+
+} // namespace pulp

--- a/core/runtime/include/pulp/runtime/runtime.hpp
+++ b/core/runtime/include/pulp/runtime/runtime.hpp
@@ -26,6 +26,7 @@
 
 #include <pulp/runtime/assert.hpp>
 #include <pulp/runtime/log.hpp>
+#include <pulp/runtime/node_abi.hpp>
 #include <pulp/runtime/scope_guard.hpp>
 #include <pulp/runtime/spsc_queue.hpp>
 #include <pulp/runtime/system.hpp>

--- a/docs/guides/mpe.md
+++ b/docs/guides/mpe.md
@@ -35,10 +35,13 @@ public:
 };
 ```
 
-When `supports_mpe` is `true`, a Pulp format adapter that recognises MPE
-(currently: CLAP) runs the inbound `MidiBuffer` through an
-`MpeVoiceTracker` each block, populates an `MpeBuffer`, and attaches it
-via `Processor::set_mpe_input()` before calling `process()`.
+When `supports_mpe` is `true`, or when
+`node_capabilities.supports_mpe` is true, a Pulp format adapter that
+recognises MPE (currently: CLAP) runs the inbound `MidiBuffer` through
+an `MpeVoiceTracker` each block, populates an `MpeBuffer`, and attaches
+it via `Processor::set_mpe_input()` before calling `process()`. Adapters
+read `PluginDescriptor::effective_capabilities()`, which ORs the legacy
+flags with the node ABI capability field.
 
 ## Components
 
@@ -123,10 +126,12 @@ void process(...) override {
 ```
 
 `supports_mpe` and `supports_ump` are independent and can both be set.
-The CLAP adapter populates the UMP sidecar by converting the inbound
-MIDI 1.0 stream with `midi1_to_ump()`; when CLAP ships
-`CLAP_EVENT_MIDI2` the adapter will feed the host's native packets
-directly with no code change on the plugin side.
+New code may also set `node_capabilities.supports_mpe` and
+`node_capabilities.supports_ump`; `effective_capabilities()` makes the
+two declaration styles equivalent. The CLAP adapter populates the UMP
+sidecar by converting the inbound MIDI 1.0 stream with `midi1_to_ump()`
+and by appending native `CLAP_EVENT_MIDI2` packets when the host sends
+them.
 
 `MpeVoiceTracker::process(UmpPacket)` accepts UMP input in addition to
 `MidiEvent`, routing MIDI 2.0 per-note pitch bend (status `0x60`) and

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -611,6 +611,11 @@ This single class automatically works as VST3, AU, CLAP, LV2, AAX, Standalone, W
 | Settings Panel | `settings_panel.hpp` | Audio/MIDI device selector with test signal and meters |
 | ViewBridge | `view_bridge.hpp` | Editor-view lifecycle: `create_view()`, `on_view_{opened,closed,resized}`, multi-view attach (editor + inspector + remote). See `docs/guides/view-bridge.md`. |
 
+The SDK-facing `Processor` and host-side `PluginSlot` surfaces share the
+[node ABI policy](./node-abi.md): virtual methods are append-only within a node
+ABI generation, and new optional behavior should prefer additive descriptor
+capabilities over new virtual methods.
+
 ---
 
 ## host

--- a/docs/reference/node-abi.md
+++ b/docs/reference/node-abi.md
@@ -31,8 +31,8 @@ are append-only:
 - add new virtual methods only after the current virtual-method tail
 
 `tools/scripts/node_abi_gate.py` enforces this in CI by comparing the current
-virtual declaration order against the PR base. A middle insert, removal, or
-reorder fails; appending at the tail passes.
+virtual declarations against the PR base. A middle insert, removal, reorder, or
+signature change fails; appending at the tail passes.
 
 ## Optional Capabilities
 

--- a/docs/reference/node-abi.md
+++ b/docs/reference/node-abi.md
@@ -1,0 +1,46 @@
+# Node ABI
+
+Pulp exposes two SDK-facing C++ node surfaces:
+
+- `pulp::format::Processor`, implemented by plug-ins
+- `pulp::host::PluginSlot`, implemented by host-side format loaders
+
+Both surfaces include `pulp/runtime/node_abi.hpp`, which defines
+`PULP_NODE_ABI_VERSION` and `pulp_node_abi_version()`. Version `1` is the
+current node ABI generation.
+
+## Compatibility Contract
+
+Pulp's node ABI is a source-compatibility contract. Plug-ins and host nodes are
+expected to be recompiled with the Pulp SDK they ship against. The version
+constant lets code, tests, and generated artifacts state the node interface
+generation they were built for.
+
+This is not a claim of stable C++ binary ABI across arbitrary compilers,
+standard libraries, compiler flags, or struct layouts. A truly stable binary
+node ABI would need a dedicated C shim. Pulp does not expose that shim today.
+
+## Virtual Method Policy
+
+Within a node ABI generation, virtual methods on `Processor` and `PluginSlot`
+are append-only:
+
+- do not reorder existing virtual methods
+- do not remove existing virtual methods
+- do not change an existing virtual method signature
+- add new virtual methods only after the current virtual-method tail
+
+`tools/scripts/node_abi_gate.py` enforces this in CI by comparing the current
+virtual declaration order against the PR base. A middle insert, removal, or
+reorder fails; appending at the tail passes.
+
+## Optional Capabilities
+
+New optional node behavior should prefer additive capability bits over new
+virtual methods. `PluginDescriptor::node_capabilities` carries the forward
+compatible capability field, while legacy `supports_mpe` and `supports_ump`
+remain valid for source compatibility.
+
+Use `PluginDescriptor::effective_capabilities()` when adapter or host code
+needs the effective value. It ORs the legacy flags with the node capability
+field so both declaration styles behave the same.

--- a/docs/status/docs-index.yaml
+++ b/docs/status/docs-index.yaml
@@ -334,6 +334,11 @@ docs:
     kind: reference
     summary: All subsystems with status and key headers
 
+  - slug: node-abi
+    path: reference/node-abi.md
+    kind: reference
+    summary: Source-ABI policy for Processor and PluginSlot node interfaces
+
   # Policies
   - slug: code-style
     path: policies/code-style.md

--- a/test/test_clap_midi_events.cpp
+++ b/test/test_clap_midi_events.cpp
@@ -155,6 +155,8 @@ public:
 
     bool opts_mpe = false;
     bool opts_ump = false;
+    bool opts_node_mpe = false;
+    bool opts_node_ump = false;
 
     // Mutable state captured each time process() runs.
     mutable midi::MidiBuffer captured_midi;
@@ -173,6 +175,8 @@ public:
         d.accepts_midi = true;
         d.supports_mpe = opts_mpe;
         d.supports_ump = opts_ump;
+        d.node_capabilities.supports_mpe = opts_node_mpe;
+        d.node_capabilities.supports_ump = opts_node_ump;
         return d;
     }
     void define_parameters(state::StateStore& store) override {
@@ -244,6 +248,8 @@ CapturingProcessor* g_capturing = nullptr;
 EmittingProcessor*  g_emitting  = nullptr;
 bool g_pending_opts_mpe = false;
 bool g_pending_opts_ump = false;
+bool g_pending_opts_node_mpe = false;
+bool g_pending_opts_node_ump = false;
 std::vector<midi::MidiEvent> g_pending_emit;
 std::vector<midi::MidiBuffer::SysexEvent> g_pending_sysex;
 
@@ -252,6 +258,12 @@ std::unique_ptr<Processor> make_capturing() {
     g_capturing = up.get();
     if (g_pending_opts_mpe) up->opts_mpe = true;
     if (g_pending_opts_ump) up->opts_ump = true;
+    if (g_pending_opts_node_mpe) up->opts_node_mpe = true;
+    if (g_pending_opts_node_ump) up->opts_node_ump = true;
+    g_pending_opts_mpe = false;
+    g_pending_opts_ump = false;
+    g_pending_opts_node_mpe = false;
+    g_pending_opts_node_ump = false;
     return up;
 }
 
@@ -812,6 +824,40 @@ TEST_CASE("CLAP_EVENT_MIDI_SYSEX with empty payload is dropped",
 // ── Inbound: CLAP_EVENT_MIDI2 ───────────────────────────────────────────
 
 #if defined(CLAP_VERSION_GE) && CLAP_VERSION_GE(1, 1, 0)
+TEST_CASE("CLAP enables sidecars from node capabilities",
+          "[clap][midi][node-abi]") {
+    g_pending_opts_mpe = false;
+    g_pending_opts_ump = false;
+    g_pending_opts_node_mpe = true;
+    g_pending_opts_node_ump = true;
+    Harness h(make_capturing);
+
+    InputEventList events;
+    auto packet = midi::UmpPacket::note_on_2(/*group*/0, /*channel*/1,
+                                              /*note*/61, /*vel16*/0x8000);
+    clap_event_midi2_t midi2{};
+    midi2.header = make_header(sizeof(midi2), CLAP_EVENT_MIDI2, 7);
+    midi2.port_index = 0;
+    midi2.data[0] = packet.words[0];
+    midi2.data[1] = packet.words[1];
+    events.push(midi2);
+
+    clap_event_note_expression_t expr{};
+    expr.header = make_header(sizeof(expr), CLAP_EVENT_NOTE_EXPRESSION, 9);
+    expr.expression_id = CLAP_NOTE_EXPRESSION_PRESSURE;
+    expr.note_id = -1;
+    expr.port_index = 0;
+    expr.channel = 2;
+    expr.key = 72;
+    expr.value = 0.75;
+    events.push(expr);
+
+    REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+    REQUIRE(g_capturing->had_mpe_input);
+    REQUIRE(g_capturing->had_ump_input);
+    REQUIRE_FALSE(g_capturing->captured_ump.empty());
+}
+
 TEST_CASE("CLAP_EVENT_MIDI2 routed straight to UMP sidecar when opted in",
           "[clap][midi][issue-pending]") {
     g_pending_opts_mpe = false;

--- a/test/test_descriptor_validation.cpp
+++ b/test/test_descriptor_validation.cpp
@@ -243,6 +243,18 @@ TEST_CASE("DescriptorValidation: MPE and UMP sidecars share one warning on audio
     REQUIRE(descriptor_is_valid(issues));
 }
 
+TEST_CASE("DescriptorValidation: node capabilities use sidecar MIDI warning contract",
+          "[format][descriptor-validation][node-abi]") {
+    auto d = well_formed_effect();
+    d.node_capabilities.supports_mpe = true;
+    d.node_capabilities.supports_ump = true;
+    d.accepts_midi = false;
+
+    auto issues = validate_descriptor(d);
+    REQUIRE(warning_count_on(issues, "accepts_midi") == 1);
+    REQUIRE(descriptor_is_valid(issues));
+}
+
 TEST_CASE("DescriptorValidation: supports_ump follows the accepts_midi sidecar warning contract",
           "[format][descriptor-validation][coverage][issue-493]") {
     SECTION("UMP without MIDI input warns") {

--- a/test/test_hosted_editor.cpp
+++ b/test/test_hosted_editor.cpp
@@ -87,6 +87,12 @@ public:
 
 } // namespace
 
+TEST_CASE("Node ABI version is visible through PluginSlot surface",
+          "[host][hosted-editor][node-abi]") {
+    REQUIRE(pulp::PULP_NODE_ABI_VERSION == 1);
+    REQUIRE(pulp::pulp_node_abi_version() == pulp::PULP_NODE_ABI_VERSION);
+}
+
 TEST_CASE("no-editor slot returns nullptr from create_hosted_editor",
           "[host][hosted-editor]") {
     NoEditorSlot s;

--- a/test/test_processor_defaults.cpp
+++ b/test/test_processor_defaults.cpp
@@ -87,8 +87,18 @@ TEST_CASE("PluginDescriptor defaults to conservative stereo effect metadata",
     REQUIRE_FALSE(d.produces_midi);
     REQUIRE_FALSE(d.supports_mpe);
     REQUIRE_FALSE(d.supports_ump);
+    REQUIRE_FALSE(d.node_capabilities.supports_mpe);
+    REQUIRE_FALSE(d.node_capabilities.supports_ump);
+    REQUIRE_FALSE(d.effective_capabilities().supports_mpe);
+    REQUIRE_FALSE(d.effective_capabilities().supports_ump);
     REQUIRE_FALSE(d.ios_requires_background_audio);
     REQUIRE(d.tail_samples == 0);
+}
+
+TEST_CASE("Node ABI version is visible through Processor surface",
+          "[format][processor-defaults][node-abi]") {
+    REQUIRE(pulp::PULP_NODE_ABI_VERSION == 1);
+    REQUIRE(pulp::pulp_node_abi_version() == pulp::PULP_NODE_ABI_VERSION);
 }
 
 TEST_CASE("PluginDescriptor bus helpers return zero when main buses are absent",
@@ -138,6 +148,29 @@ TEST_CASE("PluginDescriptor carries MIDI, MPE, UMP, and mobile flags independent
     REQUIRE(d.supports_ump);
     REQUIRE(d.ios_requires_background_audio);
     REQUIRE(d.tail_samples == -1);
+}
+
+TEST_CASE("PluginDescriptor effective_capabilities ORs legacy and node fields",
+          "[format][processor-defaults][node-abi]") {
+    PluginDescriptor d;
+
+    SECTION("legacy MPE plus node UMP") {
+        d.supports_mpe = true;
+        d.node_capabilities.supports_ump = true;
+
+        const auto caps = d.effective_capabilities();
+        REQUIRE(caps.supports_mpe);
+        REQUIRE(caps.supports_ump);
+    }
+
+    SECTION("node MPE plus legacy UMP") {
+        d.node_capabilities.supports_mpe = true;
+        d.supports_ump = true;
+
+        const auto caps = d.effective_capabilities();
+        REQUIRE(caps.supports_mpe);
+        REQUIRE(caps.supports_ump);
+    }
 }
 
 TEST_CASE("PluginDescriptor preserves optional vendor contact metadata",

--- a/tools/cmake/PulpDependencies.cmake
+++ b/tools/cmake/PulpDependencies.cmake
@@ -342,9 +342,9 @@ set(PULP_HAS_HIGHWAY TRUE)
 message(STATUS "Pulp: Highway SIMD library enabled")
 
 # Mbed TLS (Apache 2.0) — cryptographic primitives (SHA-256, RSA, AES)
-# Pinned to the exact SHA for v3.6.2. CMake's shallow FetchContent clone can
-# intermittently fail to resolve annotated tag names during fresh coverage
-# configures; the commit pin keeps the release fixed while avoiding tag lookup.
+# Pinned to the exact SHA for v3.6.2. Keep this as a full clone: CMake's shallow
+# FetchContent path can fetch only the remote tip and then fail to checkout this
+# non-tip commit during fresh coverage configures.
 set(ENABLE_TESTING OFF CACHE BOOL "" FORCE)
 set(ENABLE_PROGRAMS OFF CACHE BOOL "" FORCE)
 set(MBEDTLS_FATAL_WARNINGS OFF CACHE BOOL "" FORCE)
@@ -352,7 +352,6 @@ FetchContent_Declare(
     mbedtls
     GIT_REPOSITORY https://github.com/Mbed-TLS/mbedtls.git
     GIT_TAG 107ea89daaefb9867ea9121002fbbdf926780e98
-    GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(mbedtls)
 set(PULP_HAS_MBEDTLS TRUE)

--- a/tools/scripts/gates.sh
+++ b/tools/scripts/gates.sh
@@ -11,6 +11,7 @@
 #   - skill-sync (catches missing SKILL.md updates for mapped paths)
 #   - version-bump (catches feat:/fix: PRs without a chore: bump versions commit)
 #   - compat-sync (when compat.json is touched, requires matching test coverage)
+#   - node-ABI (Processor/PluginSlot virtual methods are append-only)
 #   - deps-audit (catches DEPENDENCIES.md / NOTICE.md drift)
 #
 # Does NOT run:
@@ -54,6 +55,7 @@ BASE="${1:-${PULP_GATES_BASE:-origin/main}}"
 VBC="$ROOT/tools/scripts/version_bump_check.py"
 SSC="$ROOT/tools/scripts/skill_sync_check.py"
 CSC="$ROOT/tools/scripts/compat_sync_check.py"
+NAG="$ROOT/tools/scripts/node_abi_gate.py"
 CFG="$ROOT/tools/scripts/versioning.json"
 DEPS_AUDIT="$ROOT/tools/deps/audit.py"
 
@@ -110,7 +112,16 @@ if [ -f "$CSC" ] && [ -f "$COMPAT_MAP" ]; then
     fi
 fi
 
-# ── 4. deps-audit ──────────────────────────────────────────────────────────
+# ── 4. node ABI virtual-order gate ─────────────────────────────────────────
+if [ -f "$NAG" ]; then
+    echo "" >&2
+    echo "▸ node-ABI virtual-order check" >&2
+    if ! "$PYTHON" "$NAG" --base "$BASE" --mode=report; then
+        fail=1
+    fi
+fi
+
+# ── 5. deps-audit ──────────────────────────────────────────────────────────
 if [ -f "$DEPS_AUDIT" ]; then
     echo "" >&2
     echo "▸ deps-audit (attribution drift)" >&2

--- a/tools/scripts/node_abi_gate.py
+++ b/tools/scripts/node_abi_gate.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
-"""Node ABI virtual-order gate.
+"""Node ABI virtual declaration gate.
 
 Processor and PluginSlot are SDK-facing polymorphic surfaces. Within a major
 node ABI version, new virtual methods must be appended at the end of the class
-vtable. Inserting, removing, or reordering existing virtuals changes already
-compiled consumer binaries.
+vtable. Inserting, removing, reordering, or re-signaturing existing virtuals
+changes the node contract.
 
 The gate compares the current working tree against a git base and requires the
-base virtual-method order to remain a prefix of the current order.
+base virtual-method declarations to remain a prefix of the current order.
 """
 
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 import re
 import subprocess
 import sys
@@ -29,6 +30,12 @@ SURFACES = (
         "core/host/include/pulp/host/plugin_slot.hpp",
     ),
 )
+
+
+@dataclass(frozen=True)
+class VirtualDecl:
+    name: str
+    signature: str
 
 
 def repo_root() -> Path | None:
@@ -77,31 +84,136 @@ def class_body(text: str, class_name: str) -> str:
     return text[start:i - 1]
 
 
-def virtual_order(text: str, class_name: str) -> list[str]:
-    body = strip_comments(class_body(text, class_name))
-    names: list[str] = []
-    for match in re.finditer(r"\bvirtual\b(?P<decl>[^;{]*?)\(", body, re.DOTALL):
-        before_paren = match.group("decl").strip()
-        name_match = re.search(r"([~A-Za-z_]\w*)\s*$", before_paren)
-        if not name_match:
+def _matching_paren(text: str, open_index: int) -> int:
+    depth = 1
+    i = open_index + 1
+    while i < len(text) and depth > 0:
+        if text[i] == "(":
+            depth += 1
+        elif text[i] == ")":
+            depth -= 1
+        i += 1
+    if depth != 0:
+        raise ValueError("virtual method declaration has unbalanced parentheses")
+    return i - 1
+
+
+def _split_params(params: str) -> list[str]:
+    if not params.strip():
+        return []
+    out: list[str] = []
+    start = 0
+    angle_depth = 0
+    paren_depth = 0
+    for i, ch in enumerate(params):
+        if ch == "<":
+            angle_depth += 1
+        elif ch == ">" and angle_depth > 0:
+            angle_depth -= 1
+        elif ch == "(":
+            paren_depth += 1
+        elif ch == ")" and paren_depth > 0:
+            paren_depth -= 1
+        elif ch == "," and angle_depth == 0 and paren_depth == 0:
+            out.append(params[start:i])
+            start = i + 1
+    out.append(params[start:])
+    return out
+
+
+def _strip_default_arg(param: str) -> str:
+    angle_depth = 0
+    paren_depth = 0
+    for i, ch in enumerate(param):
+        if ch == "<":
+            angle_depth += 1
+        elif ch == ">" and angle_depth > 0:
+            angle_depth -= 1
+        elif ch == "(":
+            paren_depth += 1
+        elif ch == ")" and paren_depth > 0:
+            paren_depth -= 1
+        elif ch == "=" and angle_depth == 0 and paren_depth == 0:
+            return param[:i]
+    return param
+
+
+def _normalize_type(text: str) -> str:
+    text = re.sub(r"\s+", " ", text).strip()
+    text = re.sub(r"\s*([<>,()&*])\s*", r"\1", text)
+    text = re.sub(r"\s*=\s*", "=", text)
+    return text
+
+
+def _normalize_param(param: str) -> str:
+    param = _strip_default_arg(param)
+    param = re.sub(r"\s+", " ", param).strip()
+    # Parameter names are not part of the ABI signature; remove the common
+    # named-parameter shape while preserving unnamed type-only declarations.
+    name_match = re.match(r"(?P<type>.+\S)\s+[A-Za-z_]\w*$", param)
+    if name_match:
+        param = name_match.group("type")
+    return _normalize_type(param)
+
+
+def _canonical_virtual_signature(raw_decl: str) -> tuple[str, str]:
+    decl = re.sub(r"^\s*virtual\b", "", raw_decl, count=1).strip()
+    open_paren = decl.find("(")
+    if open_paren < 0:
+        raise ValueError("virtual method declaration missing parameter list")
+    close_paren = _matching_paren(decl, open_paren)
+
+    before_paren = decl[:open_paren].strip()
+    params = decl[open_paren + 1:close_paren]
+    after_paren = decl[close_paren + 1:].strip()
+
+    name_match = re.search(r"([~A-Za-z_]\w*)\s*$", before_paren)
+    if not name_match:
+        raise ValueError("virtual method declaration missing method name")
+    name = name_match.group(1)
+
+    canonical_params = ",".join(_normalize_param(p) for p in _split_params(params))
+    signature = (
+        f"{_normalize_type(before_paren)}"
+        f"({canonical_params})"
+        f"{_normalize_type(after_paren)}"
+    )
+    return name, signature
+
+
+def virtual_order(text: str, class_name: str) -> list[VirtualDecl]:
+    body = class_body(strip_comments(text), class_name)
+    decls: list[VirtualDecl] = []
+    for match in re.finditer(r"\bvirtual\b(?P<decl>.*?)(?:;|{)", body, re.DOTALL):
+        raw_decl = match.group("decl").strip()
+        try:
+            name, signature = _canonical_virtual_signature(f"virtual {raw_decl}")
+        except ValueError:
             continue
-        names.append(name_match.group(1))
-    return names
+        decls.append(VirtualDecl(name=name, signature=signature))
+    return decls
 
 
-def render_mismatch(surface: str, old: list[str], new: list[str]) -> str:
+def render_mismatch(surface: str, old: list[VirtualDecl], new: list[VirtualDecl]) -> str:
     lines = [f"{surface}: virtual order is not additive-only"]
     common = min(len(old), len(new))
-    first_bad = next((i for i in range(common) if old[i] != new[i]), common)
+    first_bad = next(
+        (i for i in range(common) if old[i].signature != new[i].signature),
+        common,
+    )
     if first_bad < len(old):
         lines.append(f"  first mismatch at index {first_bad}:")
-        lines.append(f"    base:    {old[first_bad]}")
+        lines.append(f"    base:    {old[first_bad].signature}")
         lines.append(
-            f"    current: {new[first_bad] if first_bad < len(new) else '<missing>'}"
+            "    current: "
+            f"{new[first_bad].signature if first_bad < len(new) else '<missing>'}"
         )
     if len(new) < len(old):
         lines.append("  current order removed virtual method(s)")
-    lines.append("  allowed change: append new virtual methods after all existing ones")
+    lines.append(
+        "  allowed change: append new virtual methods after all existing ones; "
+        "do not re-signature existing virtuals"
+    )
     return "\n".join(lines)
 
 
@@ -120,7 +232,7 @@ def check_surface(root: Path, base: str, class_name: str, rel_path: str) -> str 
     except ValueError as exc:
         return f"{class_name}: {exc}"
 
-    if new[:len(old)] != old:
+    if [v.signature for v in new[:len(old)]] != [v.signature for v in old]:
         return render_mismatch(class_name, old, new)
     return None
 

--- a/tools/scripts/node_abi_gate.py
+++ b/tools/scripts/node_abi_gate.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Node ABI virtual-order gate.
+
+Processor and PluginSlot are SDK-facing polymorphic surfaces. Within a major
+node ABI version, new virtual methods must be appended at the end of the class
+vtable. Inserting, removing, or reordering existing virtuals changes already
+compiled consumer binaries.
+
+The gate compares the current working tree against a git base and requires the
+base virtual-method order to remain a prefix of the current order.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+SURFACES = (
+    (
+        "Processor",
+        "core/format/include/pulp/format/processor.hpp",
+    ),
+    (
+        "PluginSlot",
+        "core/host/include/pulp/host/plugin_slot.hpp",
+    ),
+)
+
+
+def repo_root() -> Path | None:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def git_show(base: str, rel_path: str) -> str | None:
+    result = subprocess.run(
+        ["git", "show", f"{base}:{rel_path}"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def strip_comments(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    return re.sub(r"//.*", "", text)
+
+
+def class_body(text: str, class_name: str) -> str:
+    match = re.search(rf"\bclass\s+{re.escape(class_name)}\b[^{{]*{{", text)
+    if not match:
+        raise ValueError(f"class {class_name} not found")
+
+    start = match.end()
+    depth = 1
+    i = start
+    while i < len(text) and depth > 0:
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+        i += 1
+    if depth != 0:
+        raise ValueError(f"class {class_name} body is unbalanced")
+    return text[start:i - 1]
+
+
+def virtual_order(text: str, class_name: str) -> list[str]:
+    body = strip_comments(class_body(text, class_name))
+    names: list[str] = []
+    for match in re.finditer(r"\bvirtual\b(?P<decl>[^;{]*?)\(", body, re.DOTALL):
+        before_paren = match.group("decl").strip()
+        name_match = re.search(r"([~A-Za-z_]\w*)\s*$", before_paren)
+        if not name_match:
+            continue
+        names.append(name_match.group(1))
+    return names
+
+
+def render_mismatch(surface: str, old: list[str], new: list[str]) -> str:
+    lines = [f"{surface}: virtual order is not additive-only"]
+    common = min(len(old), len(new))
+    first_bad = next((i for i in range(common) if old[i] != new[i]), common)
+    if first_bad < len(old):
+        lines.append(f"  first mismatch at index {first_bad}:")
+        lines.append(f"    base:    {old[first_bad]}")
+        lines.append(
+            f"    current: {new[first_bad] if first_bad < len(new) else '<missing>'}"
+        )
+    if len(new) < len(old):
+        lines.append("  current order removed virtual method(s)")
+    lines.append("  allowed change: append new virtual methods after all existing ones")
+    return "\n".join(lines)
+
+
+def check_surface(root: Path, base: str, class_name: str, rel_path: str) -> str | None:
+    old_text = git_show(base, rel_path)
+    if old_text is None:
+        return f"{class_name}: could not read {rel_path} at {base}"
+
+    current_path = root / rel_path
+    if not current_path.exists():
+        return f"{class_name}: current file missing: {rel_path}"
+
+    try:
+        old = virtual_order(old_text, class_name)
+        new = virtual_order(current_path.read_text(), class_name)
+    except ValueError as exc:
+        return f"{class_name}: {exc}"
+
+    if new[:len(old)] != old:
+        return render_mismatch(class_name, old, new)
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", default="origin/main")
+    parser.add_argument("--mode", choices=("hint", "report"), default="report")
+    args = parser.parse_args(argv)
+
+    root = repo_root()
+    if root is None:
+        print("node_abi_gate: not in a git working tree", file=sys.stderr)
+        return 0 if args.mode == "hint" else 2
+
+    findings = [
+        finding
+        for class_name, rel_path in SURFACES
+        if (finding := check_surface(root, args.base, class_name, rel_path))
+    ]
+
+    if not findings:
+        print("node_abi_gate: Processor and PluginSlot virtual order is additive-only")
+        return 0
+
+    print("\n\n".join(findings), file=sys.stderr)
+    return 0 if args.mode == "hint" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/scripts/skill_path_map.json
+++ b/tools/scripts/skill_path_map.json
@@ -76,6 +76,8 @@
         "tools/scripts/validation_profile_select.py",
         "tools/scripts/test_validation_profile_select.py",
         "tools/scripts/macos_reroute_watcher.py",
+        "tools/scripts/node_abi_gate.py",
+        "tools/scripts/test_node_abi_gate.py",
         "tools/scripts/gates.sh",
         "tools/launchd/**",
         ".githooks/**"

--- a/tools/scripts/test_node_abi_gate.py
+++ b/tools/scripts/test_node_abi_gate.py
@@ -63,7 +63,9 @@ class NodeAbiGateTests(unittest.TestCase):
     def header(class_name: str, methods: list[str]) -> str:
         decls: list[str] = []
         for method in methods:
-            if method.startswith("~"):
+            if method.startswith("virtual "):
+                decls.append(f"    {method}")
+            elif method.startswith("~"):
                 decls.append(f"    virtual {method}() = default;")
             else:
                 decls.append(f"    virtual void {method}() {{}}")
@@ -97,6 +99,33 @@ class NodeAbiGateTests(unittest.TestCase):
         code, out = self.gate()
         self.assertEqual(code, 1)
         self.assertIn("current order removed virtual method", out)
+
+    def test_signature_change_fails(self) -> None:
+        self.write_headers(
+            ["~Processor", "descriptor", "virtual void prepare(double samples) {}"],
+            ["~PluginSlot", "info", "process"],
+        )
+        code, out = self.gate()
+        self.assertEqual(code, 1)
+        self.assertIn("do not re-signature existing virtuals", out)
+        self.assertIn("void prepare()", out)
+        self.assertIn("void prepare(double)", out)
+
+    def test_parameter_name_only_change_passes(self) -> None:
+        self.write_headers(
+            ["~Processor", "descriptor", "virtual void prepare(int samples) {}"],
+            ["~PluginSlot", "info", "process"],
+        )
+        git(self.tmp, "add", ".")
+        git(self.tmp, "commit", "-q", "-m", "named parameter baseline")
+        git(self.tmp, "update-ref", "refs/remotes/origin/main", "HEAD")
+
+        self.write_headers(
+            ["~Processor", "descriptor", "virtual void prepare(int block_size) {}"],
+            ["~PluginSlot", "info", "process"],
+        )
+        code, out = self.gate()
+        self.assertEqual(code, 0, out)
 
 
 if __name__ == "__main__":

--- a/tools/scripts/test_node_abi_gate.py
+++ b/tools/scripts/test_node_abi_gate.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+GATE = REPO_ROOT / "tools" / "scripts" / "node_abi_gate.py"
+
+
+def run(cmd: list[str], cwd: Path) -> tuple[int, str]:
+    result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    return result.returncode, result.stdout + result.stderr
+
+
+def git(cwd: Path, *args: str) -> None:
+    env = os.environ.copy()
+    subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+class NodeAbiGateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="pulp-node-abi-gate-"))
+        git(self.tmp, "init", "-q", "-b", "main")
+        git(self.tmp, "config", "user.email", "test@example.com")
+        git(self.tmp, "config", "user.name", "Test")
+        git(self.tmp, "config", "commit.gpgsign", "false")
+        self.processor = (
+            self.tmp / "core" / "format" / "include" / "pulp" / "format" / "processor.hpp"
+        )
+        self.plugin_slot = (
+            self.tmp / "core" / "host" / "include" / "pulp" / "host" / "plugin_slot.hpp"
+        )
+        self.write_headers(["~Processor", "descriptor", "prepare"],
+                           ["~PluginSlot", "info", "process"])
+        git(self.tmp, "add", ".")
+        git(self.tmp, "commit", "-q", "-m", "initial")
+        git(self.tmp, "update-ref", "refs/remotes/origin/main", "HEAD")
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def write_headers(self, processor_methods: list[str], slot_methods: list[str]) -> None:
+        self.processor.parent.mkdir(parents=True, exist_ok=True)
+        self.plugin_slot.parent.mkdir(parents=True, exist_ok=True)
+        self.processor.write_text(self.header("Processor", processor_methods))
+        self.plugin_slot.write_text(self.header("PluginSlot", slot_methods))
+
+    @staticmethod
+    def header(class_name: str, methods: list[str]) -> str:
+        decls: list[str] = []
+        for method in methods:
+            if method.startswith("~"):
+                decls.append(f"    virtual {method}() = default;")
+            else:
+                decls.append(f"    virtual void {method}() {{}}")
+        return textwrap.dedent(f"""\
+            #pragma once
+            class {class_name} {{
+            public:
+            {chr(10).join(decls)}
+            }};
+            """)
+
+    def gate(self) -> tuple[int, str]:
+        return run(["python3", str(GATE), "--base", "origin/main"], self.tmp)
+
+    def test_appended_virtuals_pass(self) -> None:
+        self.write_headers(["~Processor", "descriptor", "prepare", "release"],
+                           ["~PluginSlot", "info", "process", "parameters"])
+        code, out = self.gate()
+        self.assertEqual(code, 0, out)
+
+    def test_inserted_virtual_fails(self) -> None:
+        self.write_headers(["~Processor", "descriptor", "inserted", "prepare"],
+                           ["~PluginSlot", "info", "process"])
+        code, out = self.gate()
+        self.assertEqual(code, 1)
+        self.assertIn("Processor: virtual order is not additive-only", out)
+
+    def test_removed_virtual_fails(self) -> None:
+        self.write_headers(["~Processor", "descriptor"],
+                           ["~PluginSlot", "info", "process"])
+        code, out = self.gate()
+        self.assertEqual(code, 1)
+        self.assertIn("current order removed virtual method", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the Phase 5 node ABI version/capability gate
- enforce additive-only node vtable changes through the node ABI checker
- wire the compatibility corpus and root allowlist fixes needed by the current CI baseline

## Local validation
- python3 tools/scripts/test_node_abi_gate.py
- python3 tools/scripts/node_abi_gate.py --base origin/main --mode=report
- python3 tools/import-validation/check-source-contracts.py --strict
- python3 tools/import-validation/test_source_contracts.py
- python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main
- python3 tools/scripts/version_bump_check.py --mode=report --base origin/main
- python3 tools/scripts/source_tree_pollution_check.py --mode=root-allowlist --rev HEAD
- python3 tools/scripts/test_source_tree_pollution_check.py
- cmake --build build --target pulp-test-processor-defaults pulp-test-clap-midi-events pulp-test-descriptor-validation pulp-test-hosted-editor -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-processor-defaults
- ./build/test/pulp-test-clap-midi-events
- ./build/test/pulp-test-descriptor-validation
- ./build/test/pulp-test-hosted-editor