### PR TITLE
fix(render): survive GPU-backed images + write .skp atomically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.181.0
+    VERSION 0.182.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/include/pulp/canvas/skia_canvas.hpp
+++ b/core/canvas/include/pulp/canvas/skia_canvas.hpp
@@ -9,6 +9,7 @@
 class SkCanvas;
 class SkSurface;
 class SkFont;
+class SkImage;
 class SkPaint;
 class SkPathBuilder;
 
@@ -132,6 +133,15 @@ public:
                                     float dx, float dy, float dw, float dh) override;
     bool measure_image_from_file(const std::string& path,
                                   float& out_width, float& out_height) override;
+
+    // Skia-specific: draw an already-constructed SkImage (e.g. a GPU
+    // surface snapshot or atlas texture) into the active rect. The
+    // decode-from-bytes paths above always yield raster images; this
+    // overload is the seam for drawing a GPU-texture-backed image, which
+    // is the case the `.skp` capture's image proc must handle. Returns
+    // false when the canvas or image is null.
+    bool draw_skia_image(const sk_sp<SkImage>& image,
+                         float x, float y, float w, float h);
 
     // ── Line dash / pixel manipulation (issue-916) ─────────────────────
     void set_line_dash(const float* intervals, int count, float phase) override;

--- a/core/canvas/src/skia_canvas.cpp
+++ b/core/canvas/src/skia_canvas.cpp
@@ -1266,6 +1266,14 @@ bool SkiaCanvas::draw_image_from_file(const std::string& path,
     return true;
 }
 
+bool SkiaCanvas::draw_skia_image(const sk_sp<SkImage>& image,
+                                  float x, float y, float w, float h) {
+    if (!canvas_ || !image) return false;
+    canvas_->drawImageRect(image, SkRect::MakeXYWH(x, y, w, h),
+                           sampling_options_for_image_smoothing());
+    return true;
+}
+
 // pulp #1737 — 9-arg drawImage source-rect form. Skia's drawImageRect has
 // a four-rect overload that maps `src` (in image coords) onto `dst` (in
 // canvas coords) with the active sampling. Used by sprite-sheet slicing.

--- a/core/render/include/pulp/render/skia_surface.hpp
+++ b/core/render/include/pulp/render/skia_surface.hpp
@@ -6,6 +6,10 @@
 #include <functional>
 #include <vector>
 
+namespace skgpu::graphite {
+class Context;
+}
+
 namespace pulp::render {
 
 /// Skia Graphite rendering surface.
@@ -56,6 +60,13 @@ public:
 
     /// Check if Skia rendering is available
     virtual bool is_available() const = 0;
+
+    /// The live Graphite `Context` backing this surface, or `nullptr`
+    /// when Skia/Graphite is unavailable. Hand this to a `SkpFrameCapture`
+    /// (or `capture_skp_to_file`) so a `.skp` of this surface's frame can
+    /// read back any GPU-texture-backed embedded images instead of
+    /// silently dropping them. The pointer is owned by the SkiaSurface.
+    virtual skgpu::graphite::Context* graphite_context() const = 0;
 };
 
 } // namespace pulp::render

--- a/core/render/include/pulp/render/skp_capture.hpp
+++ b/core/render/include/pulp/render/skp_capture.hpp
@@ -36,6 +36,17 @@
 //     `SkDeserialProcs::fImageProc` that decodes the PNG payload back to
 //     an `SkImage`.
 //
+//   * GPU-texture-backed embedded images. A raster `SkImage` PNG-encodes
+//     with no GPU context. A texture-backed image (atlas / surface
+//     snapshot) cannot — Skia's PNG encoder needs the owning context to
+//     read the pixels off the GPU first. Pulp renders on Graphite, whose
+//     pixel readback is `skgpu::graphite::Context::asyncRescaleAndReadPixels`.
+//     So a capture that may embed GPU images must be handed the Graphite
+//     `Context` (see `capture_skp_to_file` / `SkpFrameCapture` ctor): the
+//     image proc then rasterizes texture-backed images before encoding.
+//     If a texture-backed image is met with no `Context`, the proc fails
+//     loudly (logged) rather than silently dropping the image.
+//
 // Graceful degradation: when Skia is not compiled in, `SkpFrameCapture`
 // reports `available() == false`, `canvas()` returns `nullptr`, and the
 // capture functions return a failed `SkpCaptureResult` with a reason
@@ -47,6 +58,10 @@
 #include <functional>
 #include <memory>
 #include <string>
+
+namespace skgpu::graphite {
+class Context;
+}
 
 namespace pulp::render {
 
@@ -81,7 +96,15 @@ class SkpFrameCapture {
 public:
     /// Begin a capture sized to `width` x `height` logical pixels.
     /// The cull rect of the recorded `SkPicture` is `[0,0,width,height]`.
-    SkpFrameCapture(int width, int height);
+    ///
+    /// `graphite_context` is optional. Pass the live Graphite `Context`
+    /// (e.g. from the `SkiaSurface` the frame is rendered on) when the
+    /// frame may embed GPU-texture-backed images — atlas glyphs, surface
+    /// snapshots. The capture uses it to read those images off the GPU so
+    /// they PNG-encode into the `.skp`. A purely vector / raster-image
+    /// frame needs no context and `nullptr` is fine.
+    explicit SkpFrameCapture(int width, int height,
+                             skgpu::graphite::Context* graphite_context = nullptr);
     ~SkpFrameCapture();
 
     SkpFrameCapture(const SkpFrameCapture&) = delete;
@@ -117,9 +140,14 @@ private:
 /// The callback paints whatever should appear in the frame. When Skia
 /// is unavailable, or `width`/`height` are non-positive, this returns a
 /// failed `SkpCaptureResult` with a reason and writes nothing.
+///
+/// `graphite_context` is forwarded to `SkpFrameCapture` — supply it when
+/// the painted frame may embed GPU-texture-backed images so they survive
+/// serialization (see the `SkpFrameCapture` constructor).
 SkpCaptureResult capture_skp_to_file(
     int width, int height, const std::string& path,
-    const std::function<void(canvas::Canvas&)>& paint);
+    const std::function<void(canvas::Canvas&)>& paint,
+    skgpu::graphite::Context* graphite_context = nullptr);
 
 /// `true` when this build can produce `.skp` captures (Skia compiled
 /// in). Lets callers (inspector / CLI) report an honest "unavailable"

--- a/core/render/src/skia_surface.cpp
+++ b/core/render/src/skia_surface.cpp
@@ -235,6 +235,10 @@ public:
         return context_ != nullptr && recorder_ != nullptr;
     }
 
+    skgpu::graphite::Context* graphite_context() const override {
+        return context_.get();
+    }
+
 private:
     GpuSurface& gpu_;
     uint32_t width_ = 0, height_ = 0;

--- a/core/render/src/skp_capture.cpp
+++ b/core/render/src/skp_capture.cpp
@@ -5,34 +5,130 @@
 #include <pulp/canvas/skia_canvas.hpp>
 #include <pulp/runtime/log.hpp>
 
+#include <cstdio>
+#include <memory>
+#include <vector>
+
 #include "include/core/SkCanvas.h"
+#include "include/core/SkColorSpace.h"
 #include "include/core/SkData.h"
 #include "include/core/SkImage.h"
+#include "include/core/SkImageInfo.h"
 #include "include/core/SkPicture.h"
 #include "include/core/SkPictureRecorder.h"
+#include "include/core/SkPixmap.h"
 #include "include/core/SkRect.h"
 #include "include/core/SkRefCnt.h"
 #include "include/core/SkSerialProcs.h"
 #include "include/core/SkStream.h"
 #include "include/encode/SkPngEncoder.h"
+#include "include/gpu/graphite/Context.h"
+#include "include/gpu/graphite/GraphiteTypes.h"
 
 namespace pulp::render {
 
 namespace {
 
+// State carried through SkSerialProcs::fImageCtx — the optional Graphite
+// Context the capture was constructed with. nullptr when the caller
+// promised the frame is raster/vector-only.
+struct SerialImageContext {
+    skgpu::graphite::Context* graphite_context = nullptr;
+};
+
+// Receives the result of Context::asyncRescaleAndReadPixels.
+struct ReadbackState {
+    bool done = false;
+    std::unique_ptr<const SkImage::AsyncReadResult> result;
+};
+
+// Rasterize a GPU-texture-backed image into CPU pixels via the Graphite
+// Context's async readback, driven synchronously. Returns a raster
+// SkImage on success, nullptr on failure. `.skp` capture is a
+// user-triggered, off-the-audio-thread action, so the synchronous GPU
+// flush here is acceptable (never call this from a realtime path).
+sk_sp<SkImage> rasterize_texture_image(SkImage* image,
+                                       skgpu::graphite::Context* ctx) {
+    if (!image || !ctx) return nullptr;
+
+    const SkImageInfo info = SkImageInfo::Make(
+        image->width(), image->height(), kRGBA_8888_SkColorType,
+        kPremul_SkAlphaType,
+        image->refColorSpace() ? image->refColorSpace()
+                               : SkColorSpace::MakeSRGB());
+
+    ReadbackState state;
+    ctx->asyncRescaleAndReadPixels(
+        image, info, SkIRect::MakeWH(image->width(), image->height()),
+        SkImage::RescaleGamma::kSrc, SkImage::RescaleMode::kNearest,
+        [](SkImage::ReadPixelsContext c,
+           std::unique_ptr<const SkImage::AsyncReadResult> r) {
+            auto* s = static_cast<ReadbackState*>(c);
+            s->result = std::move(r);
+            s->done = true;
+        },
+        &state);
+
+    // Drive the readback to completion on the CPU.
+    ctx->submit(skgpu::graphite::SyncToCpu::kYes);
+    while (!state.done) {
+        ctx->checkAsyncWorkCompletion();
+    }
+
+    if (!state.result || state.result->count() < 1 ||
+        !state.result->data(0)) {
+        runtime::log_error(
+            "SkpFrameCapture: GPU image readback failed — embedded image "
+            "dropped from .skp");
+        return nullptr;
+    }
+
+    // The AsyncReadResult owns the pixels only for its own lifetime, so
+    // copy them into an SkData-backed raster image before it is freed.
+    const SkPixmap pixmap(info, state.result->data(0),
+                          state.result->rowBytes(0));
+    return SkImages::RasterFromPixmapCopy(pixmap);
+}
+
 // Serialize-side image proc. SkPicture::serialize() drops embedded
 // SkImages to nullptr by default (documented in SkPicture.h); this
 // PNG-encodes them so atlas/image draws survive into the .skp. This is
 // the contract the Phase 6.4 spike pinned in test_skia_surface.cpp.
-sk_sp<SkData> encode_embedded_image(SkImage* image, void* /*ctx*/) {
+//
+// Raster images PNG-encode directly. A GPU-texture-backed image cannot:
+// SkPngEncoder must read its pixels off the GPU first. We rasterize it
+// via the Graphite Context threaded through fImageCtx. If a texture
+// image arrives with no Context, the proc fails loudly (logged) instead
+// of silently dropping it from the artifact.
+sk_sp<SkData> encode_embedded_image(SkImage* image, void* ctx) {
     if (!image) return nullptr;
+
+    if (image->isTextureBacked()) {
+        auto* sctx = static_cast<SerialImageContext*>(ctx);
+        skgpu::graphite::Context* gctx =
+            sctx ? sctx->graphite_context : nullptr;
+        if (!gctx) {
+            runtime::log_error(
+                "SkpFrameCapture: embedded image is GPU-texture-backed but "
+                "no Graphite Context was supplied — pass the Context to "
+                "SkpFrameCapture/capture_skp_to_file so it survives the .skp");
+            return nullptr;
+        }
+        sk_sp<SkImage> raster = rasterize_texture_image(image, gctx);
+        if (!raster) return nullptr;
+        return SkPngEncoder::Encode(nullptr, raster.get(),
+                                    SkPngEncoder::Options{});
+    }
+
     return SkPngEncoder::Encode(nullptr, image, SkPngEncoder::Options{});
 }
 
-// Build the SkSerialProcs every Pulp .skp capture uses.
-SkSerialProcs pulp_serial_procs() {
+// Build the SkSerialProcs every Pulp .skp capture uses. `image_ctx`
+// outlives the serialize() call it is passed to.
+SkSerialProcs pulp_serial_procs(SerialImageContext* image_ctx) {
     SkSerialProcs procs;
     procs.fImageProc = &encode_embedded_image;
+    procs.fImageCtx = image_ctx;
     return procs;
 }
 
@@ -44,12 +140,15 @@ struct SkpFrameCapture::Impl {
     bool consumed = false;
     int width = 0;
     int height = 0;
+    skgpu::graphite::Context* graphite_context = nullptr;
 };
 
-SkpFrameCapture::SkpFrameCapture(int width, int height)
+SkpFrameCapture::SkpFrameCapture(int width, int height,
+                                 skgpu::graphite::Context* graphite_context)
     : impl_(std::make_unique<Impl>()) {
     impl_->width = width;
     impl_->height = height;
+    impl_->graphite_context = graphite_context;
 
     if (width <= 0 || height <= 0) {
         runtime::log_warn(
@@ -106,7 +205,9 @@ SkpCaptureResult SkpFrameCapture::finish_to_memory(std::string& out_blob) {
         return result;
     }
 
-    SkSerialProcs procs = pulp_serial_procs();
+    SerialImageContext image_ctx;
+    image_ctx.graphite_context = impl_->graphite_context;
+    SkSerialProcs procs = pulp_serial_procs(&image_ctx);
     sk_sp<SkData> blob = picture->serialize(&procs);
     if (!blob || blob->size() == 0) {
         result.reason = "SkPicture::serialize produced no data";
@@ -138,16 +239,35 @@ SkpCaptureResult SkpFrameCapture::finish_to_file(const std::string& path) {
         return result;
     }
 
-    SkFILEWStream out(path.c_str());
-    if (!out.isValid()) {
-        result.reason = "could not open .skp output file: " + path;
+    // Atomic write: serialize to a sibling temp file, then rename it onto
+    // the destination only after the bytes are fully on disk. A failed
+    // write therefore never leaves a truncated `.skp` and never clobbers
+    // a previously-valid capture — the header's "never a half-written
+    // file" guarantee.
+    const std::string tmp_path = path + ".tmp";
+    std::remove(tmp_path.c_str());
+
+    {
+        SkFILEWStream out(tmp_path.c_str());
+        if (!out.isValid()) {
+            result.reason = "could not open .skp temp file: " + tmp_path;
+            return result;
+        }
+        if (!out.write(blob.data(), blob.size())) {
+            result.reason = "failed writing .skp bytes to: " + tmp_path;
+            // SkFILEWStream closes on scope exit; drop the partial temp
+            // so the destination path is never touched.
+            std::remove(tmp_path.c_str());
+            return result;
+        }
+        out.fsync();
+    } // SkFILEWStream destructor closes the file before the rename.
+
+    if (std::rename(tmp_path.c_str(), path.c_str()) != 0) {
+        result.reason = "failed renaming .skp temp file onto: " + path;
+        std::remove(tmp_path.c_str());
         return result;
     }
-    if (!out.write(blob.data(), blob.size())) {
-        result.reason = "failed writing .skp bytes to: " + path;
-        return result;
-    }
-    out.flush();
 
     result.ok = true;
     result.bytes_written = mem.bytes_written;
@@ -159,8 +279,9 @@ SkpCaptureResult SkpFrameCapture::finish_to_file(const std::string& path) {
 
 SkpCaptureResult capture_skp_to_file(
     int width, int height, const std::string& path,
-    const std::function<void(canvas::Canvas&)>& paint) {
-    SkpFrameCapture capture(width, height);
+    const std::function<void(canvas::Canvas&)>& paint,
+    skgpu::graphite::Context* graphite_context) {
+    SkpFrameCapture capture(width, height, graphite_context);
     if (!capture.available()) {
         SkpCaptureResult result;
         result.path = path;
@@ -189,7 +310,9 @@ namespace pulp::render {
 
 struct SkpFrameCapture::Impl {};
 
-SkpFrameCapture::SkpFrameCapture(int /*width*/, int /*height*/) : impl_(nullptr) {}
+SkpFrameCapture::SkpFrameCapture(int /*width*/, int /*height*/,
+                                 skgpu::graphite::Context* /*graphite_context*/)
+    : impl_(nullptr) {}
 SkpFrameCapture::~SkpFrameCapture() = default;
 
 bool SkpFrameCapture::available() const { return false; }
@@ -212,7 +335,8 @@ SkpCaptureResult SkpFrameCapture::finish_to_memory(std::string& out_blob) {
 
 SkpCaptureResult capture_skp_to_file(
     int /*width*/, int /*height*/, const std::string& path,
-    const std::function<void(canvas::Canvas&)>& /*paint*/) {
+    const std::function<void(canvas::Canvas&)>& /*paint*/,
+    skgpu::graphite::Context* /*graphite_context*/) {
     SkpCaptureResult result;
     result.path = path;
     result.reason = "skp capture unavailable: this build has no Skia support";

--- a/test/test_skia_surface.cpp
+++ b/test/test_skia_surface.cpp
@@ -4,8 +4,12 @@
 #include <pulp/render/skp_capture.hpp>
 
 #ifdef PULP_HAS_SKIA
+#include <pulp/canvas/skia_canvas.hpp>
+
 #include <cstring>
 #include <filesystem>
+#include <fstream>
+#include <memory>
 
 #include "include/core/SkBitmap.h"
 #include "include/core/SkCanvas.h"
@@ -18,6 +22,11 @@
 #include "include/core/SkStream.h"
 #include "include/core/SkSurface.h"
 #include "include/encode/SkPngEncoder.h"
+#include "include/gpu/graphite/Context.h"
+#include "include/gpu/graphite/GraphiteTypes.h"
+#include "include/gpu/graphite/Recorder.h"
+#include "include/gpu/graphite/Recording.h"
+#include "include/gpu/graphite/Surface.h"
 #endif
 
 using namespace pulp::render;
@@ -502,6 +511,147 @@ TEST_CASE("SkpFrameCapture preserves embedded-image pixels via fImageProc",
 
     SkImageInfo info = SkImageInfo::MakeN32Premul(8, 8);
     REQUIRE(replay_top_left(restored, info) == SK_ColorGREEN);
+}
+
+TEST_CASE("SkpFrameCapture round-trips a GPU-texture-backed embedded image",
+          "[render][skia][skp]") {
+    // Codex P1: SkPicture::serialize()'s image proc must not silently drop
+    // GPU-texture-backed embedded images. SkpFrameCapture rasterizes them
+    // via the Graphite Context threaded through the capture, so a frame
+    // that embeds a GPU image survives the .skp round trip with pixels
+    // intact. Requires a live GPU adapter — skips cleanly without one.
+    auto gpu = GpuSurface::create_dawn();
+    if (!gpu) return;
+    GpuSurface::Config gpu_config{};
+    gpu_config.width = 16;
+    gpu_config.height = 16;
+    if (!gpu->initialize(gpu_config)) return;  // no GPU adapter
+
+    auto skia = SkiaSurface::create(*gpu, {.width = 16, .height = 16});
+    if (!skia || !skia->is_available()) return;
+
+    skgpu::graphite::Context* ctx = skia->graphite_context();
+    REQUIRE(ctx != nullptr);
+
+    // Build a GPU-texture-backed image: render solid green into an
+    // offscreen Graphite render target and snapshot it. A Graphite
+    // surface snapshot is a texture-backed SkImage — exactly the
+    // atlas/snapshot case the fix targets. The recording must be
+    // inserted + submitted so the texture actually holds the pixels.
+    std::unique_ptr<skgpu::graphite::Recorder> recorder = ctx->makeRecorder();
+    REQUIRE(recorder != nullptr);
+    SkImageInfo info = SkImageInfo::MakeN32Premul(8, 8);
+    sk_sp<SkSurface> gpu_surface =
+        SkSurfaces::RenderTarget(recorder.get(), info);
+    if (!gpu_surface) return;  // offscreen GPU target unavailable
+    gpu_surface->getCanvas()->clear(SK_ColorGREEN);
+    sk_sp<SkImage> gpu_image = gpu_surface->makeImageSnapshot();
+    REQUIRE(gpu_image != nullptr);
+    REQUIRE(gpu_image->isTextureBacked());
+    {
+        std::unique_ptr<skgpu::graphite::Recording> rec = recorder->snap();
+        skgpu::graphite::InsertRecordingInfo rec_info{};
+        rec_info.fRecording = rec.get();
+        REQUIRE(ctx->insertRecording(rec_info) ==
+                skgpu::graphite::InsertStatus::kSuccess);
+        ctx->submit(skgpu::graphite::SyncToCpu::kYes);
+    }
+
+    pulp::render::SkpFrameCapture capture(8, 8, ctx);
+    REQUIRE(capture.available());
+    // Draw the texture-backed image into the capture canvas.
+    auto* skia_canvas =
+        static_cast<pulp::canvas::SkiaCanvas*>(capture.canvas());
+    REQUIRE(skia_canvas != nullptr);
+    REQUIRE(skia_canvas->draw_skia_image(gpu_image, 0.0f, 0.0f, 8.0f, 8.0f));
+
+    std::string blob;
+    auto result = capture.finish_to_memory(blob);
+    REQUIRE(result.ok);
+    REQUIRE(result.op_count > 0);
+
+    // Deserialize with the matching image proc and replay. If the texture
+    // image had been dropped, the replay would be black, not green.
+    SkDeserialProcs dprocs = skp_deserial_procs();
+    sk_sp<SkPicture> restored =
+        SkPicture::MakeFromData(blob.data(), blob.size(), &dprocs);
+    REQUIRE(restored != nullptr);
+    REQUIRE(replay_top_left(restored, info) == SK_ColorGREEN);
+}
+
+TEST_CASE("SkpFrameCapture writes atomically — a failed write leaves no file",
+          "[render][skia][skp]") {
+    // Codex P2: the .skp must never land half-written and must never
+    // clobber a previously-valid capture. The write goes to a sibling
+    // <dest>.tmp and is renamed onto the destination only on full
+    // success.
+
+    SECTION("failed write does not create the destination file") {
+        // A path inside a directory that does not exist: opening the
+        // sibling temp file fails, so nothing is written.
+        const std::string bad_dir =
+            (std::filesystem::temp_directory_path() /
+             "pulp-skp-no-such-dir-xyz").string();
+        std::filesystem::remove_all(bad_dir);
+        const std::string dest = bad_dir + "/frame.skp";
+
+        auto result = pulp::render::capture_skp_to_file(
+            16, 16, dest, [](pulp::canvas::Canvas& c) {
+                c.set_fill_color(pulp::canvas::Color::rgba8(255, 0, 0));
+                c.fill_rect(0.0f, 0.0f, 16.0f, 16.0f);
+            });
+        REQUIRE_FALSE(result.ok);
+        REQUIRE_FALSE(result.reason.empty());
+        REQUIRE_FALSE(std::filesystem::exists(dest));
+        REQUIRE_FALSE(std::filesystem::exists(dest + ".tmp"));
+    }
+
+    SECTION("a failed write leaves a prior valid capture intact") {
+        const std::string path =
+            (std::filesystem::temp_directory_path() /
+             "pulp-skp-atomic-prior.skp").string();
+        std::filesystem::remove(path);
+
+        // First capture succeeds and writes a valid .skp.
+        auto first = pulp::render::capture_skp_to_file(
+            16, 16, path, [](pulp::canvas::Canvas& c) {
+                c.set_fill_color(pulp::canvas::Color::rgba8(0, 255, 0));
+                c.fill_rect(0.0f, 0.0f, 16.0f, 16.0f);
+            });
+        REQUIRE(first.ok);
+        REQUIRE(std::filesystem::exists(path));
+        const auto original_size = std::filesystem::file_size(path);
+        REQUIRE(original_size > 0);
+
+        // A second capture aimed at the same path but with a temp file
+        // that cannot be created: pre-create the <dest>.tmp path as a
+        // NON-EMPTY directory. SkFILEWStream cannot open a directory as a
+        // file, and the non-empty directory also survives the unlink
+        // attempt — so the write fails and the destination is untouched.
+        const std::string tmp_as_dir = path + ".tmp";
+        std::filesystem::remove_all(tmp_as_dir);
+        std::filesystem::create_directory(tmp_as_dir);
+        { std::ofstream guard(tmp_as_dir + "/keep"); guard << "x"; }
+
+        auto second = pulp::render::capture_skp_to_file(
+            16, 16, path, [](pulp::canvas::Canvas& c) {
+                c.set_fill_color(pulp::canvas::Color::rgba8(0, 0, 255));
+                c.fill_rect(0.0f, 0.0f, 16.0f, 16.0f);
+            });
+        REQUIRE_FALSE(second.ok);
+        REQUIRE_FALSE(second.reason.empty());
+
+        // The prior capture is untouched — same file, same bytes.
+        REQUIRE(std::filesystem::exists(path));
+        REQUIRE(std::filesystem::file_size(path) == original_size);
+        SkFILEStream in(path.c_str());
+        REQUIRE(in.isValid());
+        sk_sp<SkPicture> restored = SkPicture::MakeFromStream(&in);
+        REQUIRE(restored != nullptr);
+
+        std::filesystem::remove_all(tmp_as_dir);
+        std::filesystem::remove(path);
+    }
 }
 
 TEST_CASE("SkpFrameCapture degrades gracefully on invalid input",


### PR DESCRIPTION
## Summary

Two Codex review findings on the Phase 6.4 `.skp` frame capture (PR #2548, now merged). They land here as a follow-up because #2548 merged before the fixes were ready.

- **P1 — embedded GPU-texture-backed images were silently dropped.** `encode_embedded_image()` called `SkPngEncoder::Encode(nullptr, ...)`, which cannot read a texture-backed `SkImage`'s pixels off the GPU — so atlas / surface-snapshot images vanished from the serialized `.skp`. `SkpFrameCapture` and `capture_skp_to_file` now take an optional Graphite `Context`; the serialize image proc rasterizes texture-backed images via `Context::asyncRescaleAndReadPixels` (synchronous flush — capture is a user-triggered, off-audio-thread action) before PNG-encoding. A texture image met with no `Context` fails loudly (logged) instead of dropping silently. `SkiaSurface::graphite_context()` lets the production caller supply it; `SkiaCanvas::draw_skia_image()` is the seam for drawing a pre-constructed (GPU) `SkImage`.
- **P2 — `.skp` was written non-atomically.** `finish_to_file()` wrote straight to the destination, so a failed write left a truncated artifact and could clobber a previous valid capture. It now serializes to a sibling `<dest>.tmp`, `fsync`s, and `rename()`s onto the destination only on full success; any failure unlinks the temp and leaves the destination untouched.

## Test plan

- [x] `test_skia_surface.cpp [skp]`: GPU-texture-backed embedded image round-trips with pixels intact (replay + pixel sample) — exercised against a live Graphite adapter
- [x] `[skp]`: a failed write creates no destination file; a failed write leaves a prior valid capture byte-intact
- [x] `ctest -R "skp|skia_surface"` — all 10 `[skp]` / 16 `[skia]` cases pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)