### PR TITLE
ci: fix Codex P1s on coverage matrix encoding + watchdog scope

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -876,6 +876,17 @@ Fix pattern (applies to any GH-Actions job, not just coverage):
   `queued_at`, and `created_at` is when every leg — including the queued
   one — was created. The watchdog must exclude its own job name from the
   scan or it will reap itself.
+  - **Scope the watchdog's job-name match to the REQUIRED legs only.**
+    `coverage-queue-watchdog` matches a name that starts with `Coverage
+    report (` AND ends with `, Clang)` — i.e. only the native `(macOS,
+    Clang)` / `(Linux, Clang)` / `(Windows, Clang)` legs the required
+    `Diff coverage required` gate depends on. A bare `Coverage report (`
+    prefix match also catches `Coverage report (Android, Kotlin)`, the
+    **advisory** Android lane. Reaping cancels the *whole run* (there is
+    no single-leg cancel API), so matching an advisory leg would cancel
+    the required gate too — even when native coverage would have
+    succeeded. Match on a suffix that only the required legs carry
+    (`, Clang)` here; the Android lane ends `, Kotlin)`).
   - **Tune the grace window from measured queue-wait data, not a
     guess.** `coverage-queue-watchdog`'s `QUEUED_GRACE_MINUTES` is
     **150** (was 25). Measured coverage-leg queue waits: median ~30 min,
@@ -980,6 +991,15 @@ Consequences when touching `coverage.yml` or `coverage-diff-gate`:
 - `Diff coverage required` keeps its exact name and pass/fail semantics
   for macOS-reachable code — it is still the REQUIRED branch-protection
   check.
+- **The `matrix-config` job MUST encode `runs_on_json` with `jq`'s
+  `tojson`, never `tostring`.** The downstream `coverage` job consumes
+  it via `runs-on: ${{ fromJSON(matrix.runs_on_json) }}`, so the field
+  must hold valid JSON. `tostring` on a JSON *string* scalar (the
+  default fallback, e.g. `"macos-latest"`) strips the quotes and emits a
+  bare `macos-latest`, which `fromJSON` rejects — matrix expansion then
+  breaks on every leg that resolved to a single scalar label. `tojson`
+  always emits valid JSON: a string stays quoted, an array stays an
+  array, an object stays an object.
 
 ## Prerequisites Check
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -270,9 +270,17 @@ jobs:
           set -euo pipefail
           # One include entry per OS leg. macOS is always present; Linux
           # and Windows are appended only for non-pull_request events.
+          #
+          # `runs_on_json` MUST be encoded with `tojson`, never `tostring`.
+          # The downstream `coverage` job consumes it via
+          # `fromJSON(matrix.runs_on_json)`, which requires valid JSON.
+          # `tostring` on a JSON string scalar (e.g. "macos-latest") strips
+          # the quotes and emits a bare `macos-latest`, which `fromJSON`
+          # rejects. `tojson` always emits valid JSON — a string stays
+          # quoted, an array stays an array, an object stays an object.
           macos=$(jq -nc \
             --argjson runs_on "${MACOS_RUNS_ON_JSON}" \
-            '{os:"macos", label:"macOS", flag:"os-macos", runs_on_json:($runs_on|tostring)}')
+            '{os:"macos", label:"macOS", flag:"os-macos", runs_on_json:($runs_on|tojson)}')
           if [ "${EVENT_NAME}" = "pull_request" ]; then
             # Per-PR coverage is macOS-only — Linux/Windows coverage is
             # provided by the nightly cross-platform-check.yml lane.
@@ -280,10 +288,10 @@ jobs:
           else
             linux=$(jq -nc \
               --argjson runs_on "${LINUX_RUNS_ON_JSON}" \
-              '{os:"linux", label:"Linux", flag:"os-linux", runs_on_json:($runs_on|tostring)}')
+              '{os:"linux", label:"Linux", flag:"os-linux", runs_on_json:($runs_on|tojson)}')
             windows=$(jq -nc \
               --argjson runs_on "${WINDOWS_RUNS_ON_JSON}" \
-              '{os:"windows", label:"Windows", flag:"os-windows", runs_on_json:($runs_on|tostring)}')
+              '{os:"windows", label:"Windows", flag:"os-windows", runs_on_json:($runs_on|tojson)}')
             include=$(jq -nc \
               --argjson l "${linux}" \
               --argjson m "${macos}" \
@@ -857,12 +865,20 @@ jobs:
             while IFS=$'\t' read -r job_name job_status; do
               [ -z "${job_name}" ] && continue
               [ "${job_name}" = "${SELF_JOB_NAME}" ] && continue
-              # Only the native + Kotlin coverage legs — every one is a
-              # `Coverage report (...)` job and every one can route to a
-              # self-hosted / Namespace pool. The watchdog itself is
-              # already excluded by the SELF_JOB_NAME check above.
+              # Only the REQUIRED native coverage legs — `Coverage report
+              # (macOS, Clang)` / `(Linux, Clang)` / `(Windows, Clang)`.
+              # These are the legs the required `Diff coverage required`
+              # gate depends on and the ones that route to a saturated
+              # self-hosted / Namespace pool. Match a name that both
+              # starts with `Coverage report (` AND ends with `, Clang)`.
+              #
+              # `Coverage report (Android, Kotlin)` ends `, Kotlin)` and
+              # is deliberately NOT reaped: the Android lane is advisory,
+              # is not part of the required diff-coverage dependency
+              # chain, and reaping it would cancel the whole run —
+              # including the required native gate — for an advisory leg.
               case "${job_name}" in
-                "Coverage report ("*) ;;
+                "Coverage report ("*", Clang)") ;;
                 *) continue ;;
               esac
               [ "${job_status}" != "queued" ] && continue


### PR DESCRIPTION
Follow-up fix PR for two P1 Codex review findings on already-merged coverage.yml PRs #2540 and #2541.

## FIX 1 — `matrix-config` job (Codex P1 on #2540)

**Preserve JSON encoding for matrix runs-on values.**

The `matrix-config` job built the `coverage` matrix `include` list with `jq`, encoding the `runs_on_json` field via `($runs_on|tostring)`. `tostring` on a JSON *string* scalar (e.g. `"macos-latest"`) strips the quotes and emits a bare `macos-latest`, which is **not** valid JSON. The downstream `coverage` job consumes it via `runs-on: ${{ fromJSON(matrix.runs_on_json) }}`, which rejects invalid JSON — so matrix expansion broke whenever a leg resolved to a single scalar label (the default fallback path).

Fix: all three include entries (macOS / Linux / Windows) now use `($runs_on|tojson)`, which always emits valid JSON — a string stays quoted, an array stays an array, an object stays an object. Nearby comment updated to state the encoding requirement.

## FIX 2 — `coverage-queue-watchdog` job (Codex P1 on #2541)

**Limit watchdog matching to required coverage matrix legs.**

The watchdog matched every job named `Coverage report (...)` via a bare `case "Coverage report ("*)` shell pattern, which also matched `Coverage report (Android, Kotlin)` — the **advisory** Android lane, which is not part of the required diff-coverage dependency chain. If the Android lane sat queued past the grace window, the watchdog cancelled the *whole run* (there is no single-leg cancel API) — including the required `Diff coverage required` gate — even when native coverage would have succeeded.

Fix: the watchdog now requires the job name to both start with `Coverage report (` AND end with `, Clang)` — the three native legs `(macOS, Clang)` / `(Linux, Clang)` / `(Windows, Clang)`. `Coverage report (Android, Kotlin)` ends `, Kotlin)` and is deliberately not reaped. Watchdog comment updated to state the Android lane is advisory.

## Validation

- `yamllint --no-warnings -d relaxed` — clean
- `actionlint -shellcheck=` (lint-only) — clean
- `shellcheck` on both changed `run:` blocks (with `${{ }}` placeholdered) — clean
- `python3 yaml.safe_load` on coverage.yml — valid
- `case`-match behavior verified: the three `, Clang)` legs match (reaped); `(Android, Kotlin)` and the watchdog job itself do not match
- `tools/scripts/test_workflow_build_dirs.py` (parses coverage.yml) — 7 tests pass

`ci:`-prefixed — no version-bump marker required. `.agents/skills/ci/SKILL.md` updated with both gotchas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)