### PR TITLE
test(runtime): expand Phase 3 state/runtime coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.185.0
+    VERSION 0.186.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/render/include/pulp/render/gpu_timestamps.hpp
+++ b/core/render/include/pulp/render/gpu_timestamps.hpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <optional>
 #include <vector>
 
@@ -36,6 +37,34 @@ inline constexpr std::uint32_t kTimestampsPerPass = 2;
 /// normalizes Metal/Vulkan/D3D12 hardware counters to ns for us, so
 /// unlike raw Vulkan there is no per-device `timestampPeriod` to apply.)
 inline constexpr double kNanosecondsPerMillisecond = 1.0e6;
+
+/// Decode a map-read timestamp buffer into a vector of raw `uint64_t`
+/// GPU-clock ticks.
+///
+/// `ResolveQuerySet` writes each timestamp as a little-endian `uint64_t`;
+/// after the resolve buffer is copied to a `MapRead` buffer and mapped,
+/// `wgpu::Buffer::GetConstMappedRange` hands back exactly those bytes.
+/// This helper is the *pure* seam between Dawn's mapped memory and the
+/// tick→ms math: it has no Dawn dependency, so a unit test can feed it a
+/// synthetic byte blob — exactly the bytes a real mapped buffer would
+/// carry — and assert that `read_back()` then surfaces populated,
+/// correctly-decoded ticks instead of an empty vector.
+///
+/// `byte_count` that is not a whole multiple of 8 is truncated to the
+/// last complete `uint64_t`; a null pointer or zero length yields an
+/// empty vector. The decode uses `std::memcpy` rather than a reinterpret
+/// cast so it is alignment-safe on every platform.
+[[nodiscard]] inline std::vector<std::uint64_t>
+decode_resolved_ticks(const std::byte* mapped_bytes, std::size_t byte_count) {
+    std::vector<std::uint64_t> ticks;
+    if (mapped_bytes == nullptr || byte_count < sizeof(std::uint64_t)) {
+        return ticks;
+    }
+    const std::size_t count = byte_count / sizeof(std::uint64_t);
+    ticks.resize(count);
+    std::memcpy(ticks.data(), mapped_bytes, count * sizeof(std::uint64_t));
+    return ticks;
+}
 
 /// Convert a raw begin/end GPU-timestamp pair (nanosecond ticks) into a
 /// pass duration in milliseconds.
@@ -161,12 +190,14 @@ enum class GpuTimestampSupport {
 ///
 /// Intended per-frame usage (driven by the GPU surface / render loop):
 ///   1. `begin_frame(pass_count)` — (re)size the QuerySet for the frame.
-///   2. For each pass, `timestamp_writes(i)` supplies the
-///      `timestampWrites` for that pass's render-pass descriptor.
-///   3. `resolve(encoder_handle)` — append `ResolveQuerySet` + copy.
-///   4. After the queue submits and the buffer maps, `read_back()`
-///      returns the resolved ticks; feed them through
-///      `resolve_pass_timings` + `apply_pass_timings`.
+///   2. Each pass's render-pass descriptor declares `timestampWrites`
+///      against this QuerySet (begin/end slots `2*i` and `2*i + 1`).
+///   3. `resolve(instance_handle)` — after the queue has submitted the
+///      frame's render passes, append a `ResolveQuerySet` + copy-to-
+///      readback command, submit it, and map-read the ticks into the
+///      internal buffer.
+///   4. `read_back()` returns the resolved ticks `resolve()` populated;
+///      feed them through `resolve_pass_timings` + `apply_pass_timings`.
 ///
 /// The 1-frame readback lag is inherent to GPU timestamp queries and is
 /// accepted by the spike spec (Phase 6.5, "1-frame lag is unavoidable").
@@ -198,9 +229,28 @@ public:
     /// when unsupported or when the size is unchanged.
     void begin_frame(std::size_t pass_count);
 
+    /// Resolve the frame's timestamp QuerySet and map-read the ticks.
+    ///
+    /// Encodes a `ResolveQuerySet` from the QuerySet into the resolve
+    /// buffer, copies that into a host-mappable buffer, submits the
+    /// command, and synchronously map-reads the `uint64_t` ticks into the
+    /// internal buffer that `read_back()` returns. `dawn_instance_handle`
+    /// is a `wgpu::Instance*` erased to `void*` (matching
+    /// `GpuSurface::dawn_instance_handle()`) — it is needed to pump
+    /// `ProcessEvents` while the asynchronous map completes.
+    ///
+    /// Returns true when a frame of ticks was resolved and is now
+    /// available via `read_back()`. Returns false — leaving the previous
+    /// `read_back()` result intact — when unsupported, when no QuerySet
+    /// has been sized yet, or when the map-read did not complete. Safe to
+    /// call with `nullptr` (then it just reports false). In a CPU-only
+    /// build this is a no-op that always returns false.
+    bool resolve(void* dawn_instance_handle);
+
     /// Read back the most recently resolved timestamp buffer as raw
     /// nanosecond ticks (`[begin0, end0, begin1, end1, ...]`). Empty
-    /// when unsupported or when no frame has resolved yet.
+    /// when unsupported or when no frame has resolved yet — populated by
+    /// the most recent successful `resolve()`.
     [[nodiscard]] std::vector<std::uint64_t> read_back() const;
 
 private:

--- a/core/render/include/pulp/render/render_pass.hpp
+++ b/core/render/include/pulp/render/render_pass.hpp
@@ -51,8 +51,10 @@ public:
     /// Begin a new frame. Resets all pass statistics.
     void begin_frame() {
         passes_.clear();
+        current_pass_ = RenderPassType::background;
         frame_count_++;
         total_time_ms_ = 0;
+        over_budget_ = false;
     }
 
     /// Begin a render pass of the given type.

--- a/core/render/src/gpu_timestamps.cpp
+++ b/core/render/src/gpu_timestamps.cpp
@@ -2,11 +2,19 @@
 
 #include <pulp/runtime/log.hpp>
 
+#include <chrono>
+#include <cstddef>
+#include <thread>
+
 // Phase 6.5 — Dawn GPU timestamp queries.
 //
 // The header (`gpu_timestamps.hpp`) carries the pure tick→ms conversion
-// math, which is unit-tested without a device. This file carries the
-// Dawn-specific QuerySet / resolve-buffer plumbing.
+// math and the `decode_resolved_ticks` byte-decode seam, both unit-
+// tested without a device. This file carries the Dawn-specific QuerySet
+// / resolve-buffer plumbing: `begin_frame` sizes the QuerySet, `resolve`
+// encodes `ResolveQuerySet` + a copy into a host-mappable buffer, maps
+// it, and decodes the ticks into `last_resolved` so `read_back` actually
+// returns live GPU numbers.
 //
 // The C++ WebGPU API (`webgpu/webgpu_cpp.h`, the `wgpu::` types) ships
 // inside Skia's bundled Dawn, so the real implementation gates on
@@ -119,6 +127,87 @@ void GpuTimestamps::begin_frame(std::size_t pass_count) {
     impl_->slot_capacity = slots;
 }
 
+bool GpuTimestamps::resolve(void* dawn_instance_handle) {
+    if (support_ != GpuTimestampSupport::supported || impl_ == nullptr) {
+        return false;
+    }
+    // begin_frame() must have created the QuerySet + buffers first. A
+    // zero-pass frame leaves them null; nothing to resolve.
+    if (impl_->query_set == nullptr || impl_->resolve_buffer == nullptr ||
+        impl_->readback_buffer == nullptr || impl_->slot_capacity == 0) {
+        return false;
+    }
+
+    // The instance is required to pump `ProcessEvents` while the async
+    // buffer map completes — Dawn never advances callbacks on its own.
+    if (dawn_instance_handle == nullptr) {
+        return false;
+    }
+    auto* instance = static_cast<wgpu::Instance*>(dawn_instance_handle);
+    if (instance == nullptr || *instance == nullptr) {
+        return false;
+    }
+
+    const std::uint64_t bytes =
+        static_cast<std::uint64_t>(impl_->slot_capacity) * sizeof(std::uint64_t);
+
+    // Encode: ResolveQuerySet writes the QuerySet's ticks into the
+    // resolve buffer; CopyBufferToBuffer stages them into the host-
+    // mappable readback buffer. One encoder, one submit.
+    wgpu::CommandEncoderDescriptor enc_desc{};
+    enc_desc.label = "Pulp Timestamp Resolve";
+    wgpu::CommandEncoder encoder = impl_->device.CreateCommandEncoder(&enc_desc);
+    encoder.ResolveQuerySet(impl_->query_set, 0, impl_->slot_capacity,
+                            impl_->resolve_buffer, 0);
+    encoder.CopyBufferToBuffer(impl_->resolve_buffer, 0,
+                               impl_->readback_buffer, 0, bytes);
+    wgpu::CommandBuffer cmd = encoder.Finish();
+    impl_->device.GetQueue().Submit(1, &cmd);
+
+    // Map the readback buffer for host reads. The map is asynchronous;
+    // pump `ProcessEvents` until the callback fires or a deadline trips.
+    // The deadline mirrors `gpu_compute.cpp`'s readback path so a wedged
+    // GPU degrades to "no sample this frame" instead of hanging.
+    bool mapped = false;
+    bool ok = false;
+    impl_->readback_buffer.MapAsync(
+        wgpu::MapMode::Read, 0, static_cast<std::size_t>(bytes),
+        wgpu::CallbackMode::AllowProcessEvents,
+        [&mapped, &ok](wgpu::MapAsyncStatus status, wgpu::StringView) {
+            mapped = true;
+            ok = (status == wgpu::MapAsyncStatus::Success);
+        });
+
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (!mapped && std::chrono::steady_clock::now() < deadline) {
+        instance->ProcessEvents();
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    if (!mapped || !ok) {
+        // On timeout the buffer may still be mid-map; leave it and keep
+        // the previous `last_resolved` so the inspector shows stale-but-
+        // honest numbers rather than flickering to empty.
+        runtime::log_info("GpuTimestamps: timestamp readback did not map");
+        return false;
+    }
+
+    const void* data = impl_->readback_buffer.GetConstMappedRange(
+        0, static_cast<std::size_t>(bytes));
+    if (data == nullptr) {
+        impl_->readback_buffer.Unmap();
+        return false;
+    }
+
+    // Decode the mapped bytes through the pure, Dawn-free helper — the
+    // same path the unit tests exercise with synthetic bytes.
+    impl_->last_resolved = decode_resolved_ticks(
+        static_cast<const std::byte*>(data), static_cast<std::size_t>(bytes));
+    impl_->readback_buffer.Unmap();
+    return !impl_->last_resolved.empty();
+}
+
 std::vector<std::uint64_t> GpuTimestamps::read_back() const {
     if (impl_ == nullptr) {
         return {};
@@ -144,6 +233,8 @@ bool GpuTimestamps::initialize(void* /*dawn_device_handle*/) {
 }
 
 void GpuTimestamps::begin_frame(std::size_t /*pass_count*/) {}
+
+bool GpuTimestamps::resolve(void* /*dawn_instance_handle*/) { return false; }
 
 std::vector<std::uint64_t> GpuTimestamps::read_back() const { return {}; }
 

--- a/core/render/src/gpu_timestamps.cpp
+++ b/core/render/src/gpu_timestamps.cpp
@@ -2,8 +2,10 @@
 
 #include <pulp/runtime/log.hpp>
 
+#include <atomic>
 #include <chrono>
 #include <cstddef>
+#include <memory>
 #include <thread>
 
 // Phase 6.5 — Dawn GPU timestamp queries.
@@ -45,6 +47,11 @@ struct GpuTimestamps::Impl {
 
     /// Last successfully map-read frame of ticks.
     std::vector<std::uint64_t> last_resolved;
+};
+
+struct MapReadbackState {
+    std::atomic_bool mapped{false};
+    std::atomic_bool ok{false};
 };
 
 GpuTimestamps::GpuTimestamps() = default;
@@ -168,27 +175,33 @@ bool GpuTimestamps::resolve(void* dawn_instance_handle) {
     // pump `ProcessEvents` until the callback fires or a deadline trips.
     // The deadline mirrors `gpu_compute.cpp`'s readback path so a wedged
     // GPU degrades to "no sample this frame" instead of hanging.
-    bool mapped = false;
-    bool ok = false;
+    auto map_state = std::make_shared<MapReadbackState>();
     impl_->readback_buffer.MapAsync(
         wgpu::MapMode::Read, 0, static_cast<std::size_t>(bytes),
         wgpu::CallbackMode::AllowProcessEvents,
-        [&mapped, &ok](wgpu::MapAsyncStatus status, wgpu::StringView) {
-            mapped = true;
-            ok = (status == wgpu::MapAsyncStatus::Success);
+        [map_state](wgpu::MapAsyncStatus status, wgpu::StringView) {
+            map_state->ok.store(status == wgpu::MapAsyncStatus::Success);
+            map_state->mapped.store(true);
         });
 
     const auto deadline =
         std::chrono::steady_clock::now() + std::chrono::seconds(2);
-    while (!mapped && std::chrono::steady_clock::now() < deadline) {
+    while (!map_state->mapped.load() &&
+           std::chrono::steady_clock::now() < deadline) {
         instance->ProcessEvents();
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 
-    if (!mapped || !ok) {
-        // On timeout the buffer may still be mid-map; leave it and keep
-        // the previous `last_resolved` so the inspector shows stale-but-
-        // honest numbers rather than flickering to empty.
+    if (!map_state->mapped.load()) {
+        // Cancel the pending map so the same readback buffer can be used
+        // by a later frame. The callback may still arrive after return,
+        // so it only touches the shared state above.
+        impl_->readback_buffer.Unmap();
+        runtime::log_info("GpuTimestamps: timestamp readback did not map");
+        return false;
+    }
+
+    if (!map_state->ok.load()) {
         runtime::log_info("GpuTimestamps: timestamp readback did not map");
         return false;
     }

--- a/core/runtime/src/analytics.cpp
+++ b/core/runtime/src/analytics.cpp
@@ -9,7 +9,9 @@ namespace {
 std::string json_escape(std::string_view value) {
     std::string escaped;
     escaped.reserve(value.size());
+    constexpr char kHex[] = "0123456789abcdef";
     for (char c : value) {
+        const auto uc = static_cast<unsigned char>(c);
         if (c == '\\') {
             escaped += "\\\\";
         } else if (c == '"') {
@@ -20,6 +22,14 @@ std::string json_escape(std::string_view value) {
             escaped += "\\r";
         } else if (c == '\t') {
             escaped += "\\t";
+        } else if (c == '\b') {
+            escaped += "\\b";
+        } else if (c == '\f') {
+            escaped += "\\f";
+        } else if (uc < 0x20) {
+            escaped += "\\u00";
+            escaped += kHex[(uc >> 4) & 0x0f];
+            escaped += kHex[uc & 0x0f];
         } else {
             escaped += c;
         }

--- a/core/runtime/src/child_process.cpp
+++ b/core/runtime/src/child_process.cpp
@@ -12,7 +12,9 @@
 #include <poll.h>
 #endif
 
+#include <algorithm>
 #include <array>
+#include <chrono>
 #include <cstring>
 
 extern "C" {
@@ -203,6 +205,11 @@ std::optional<ProcessResult> run_process(
 
     ProcessResult result;
     char buf[4096];
+    bool timed_out = false;
+    auto deadline = std::chrono::steady_clock::now();
+    if (timeout_ms > 0) {
+        deadline += std::chrono::milliseconds(timeout_ms);
+    }
 
     // Read stdout and stderr using poll
     struct pollfd fds[2] = {
@@ -212,8 +219,24 @@ std::optional<ProcessResult> run_process(
     int open_fds = 2;
 
     while (open_fds > 0) {
-        int ret = poll(fds, 2, timeout_ms > 0 ? timeout_ms : -1);
-        if (ret <= 0) break;
+        int poll_timeout = -1;
+        if (timeout_ms > 0) {
+            const auto now = std::chrono::steady_clock::now();
+            if (now >= deadline) {
+                timed_out = true;
+                break;
+            }
+            auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+                deadline - now).count();
+            poll_timeout = static_cast<int>(std::max<int64_t>(remaining, 1));
+        }
+
+        int ret = poll(fds, 2, poll_timeout);
+        if (ret == 0) {
+            timed_out = true;
+            break;
+        }
+        if (ret < 0) break;
 
         if (fds[0].revents & (POLLIN | POLLHUP)) {
             ssize_t n = read(stdout_pipe[0], buf, sizeof(buf));
@@ -227,12 +250,19 @@ std::optional<ProcessResult> run_process(
         }
     }
 
+    if (timed_out) {
+        kill(pid, SIGKILL);
+    }
+
     ::close(stdout_pipe[0]);
     ::close(stderr_pipe[0]);
 
     int wstatus;
-    waitpid(pid, &wstatus, 0);
-    result.exit_code = WIFEXITED(wstatus) ? WEXITSTATUS(wstatus) : -1;
+    if (waitpid(pid, &wstatus, 0) < 0 || timed_out) {
+        result.exit_code = -1;
+    } else {
+        result.exit_code = WIFEXITED(wstatus) ? WEXITSTATUS(wstatus) : -1;
+    }
 
     return result;
 }

--- a/core/runtime/src/i18n.cpp
+++ b/core/runtime/src/i18n.cpp
@@ -88,6 +88,9 @@ bool LocalisedStrings::load_json_file(std::string_view path) {
                 ++pos;
                 if (content[pos] == 'n') result += '\n';
                 else if (content[pos] == 't') result += '\t';
+                else if (content[pos] == 'r') result += '\r';
+                else if (content[pos] == 'b') result += '\b';
+                else if (content[pos] == 'f') result += '\f';
                 else result += content[pos];
             } else {
                 result += content[pos];

--- a/core/runtime/src/zip.cpp
+++ b/core/runtime/src/zip.cpp
@@ -62,6 +62,9 @@ std::optional<size_t> parse_gzip_header(const uint8_t* data, size_t size) {
 // Decompress a raw DEFLATE stream of unknown decompressed size into a vector.
 // Used for the gzip path (no zlib header) and as a building block.
 std::optional<std::vector<uint8_t>> inflate_raw(const uint8_t* data, size_t size) {
+    if (data == nullptr || size == 0)
+        return std::nullopt;
+
     std::vector<uint8_t> result;
     // Heuristic initial size; grows as needed.
     result.resize(size > 0 ? size * 4 : 64);
@@ -83,6 +86,10 @@ std::optional<std::vector<uint8_t>> inflate_raw(const uint8_t* data, size_t size
             return result;
         }
         if (status == MZ_BUF_ERROR) {
+            if (stream.avail_in == 0 && stream.avail_out > 0) {
+                mz_inflateEnd(&stream);
+                return std::nullopt;
+            }
             size_t old_size = result.size();
             result.resize(old_size * 2);
             stream.next_out = result.data() + stream.total_out;
@@ -105,6 +112,9 @@ std::optional<std::vector<uint8_t>> inflate_raw(const uint8_t* data, size_t size
 // concatenated RFC 1952 gzip members.
 std::optional<std::vector<uint8_t>> inflate_raw_consumed(
         const uint8_t* data, size_t size, size_t* consumed_in) {
+    if (data == nullptr || size == 0)
+        return std::nullopt;
+
     std::vector<uint8_t> result;
     result.resize(size > 0 ? size * 4 : 64);
 
@@ -129,6 +139,10 @@ std::optional<std::vector<uint8_t>> inflate_raw_consumed(
             return result;
         }
         if (status == MZ_BUF_ERROR || status == MZ_OK) {
+            if (stream.avail_in == 0 && stream.avail_out > 0) {
+                mz_inflateEnd(&stream);
+                return std::nullopt;
+            }
             // Need more output room (or we ran out of input prematurely).
             // Doubling output is the right move for MZ_BUF_ERROR; if
             // avail_in is already 0 we'll loop here briefly and the

--- a/test/test_analytics.cpp
+++ b/test/test_analytics.cpp
@@ -191,6 +191,31 @@ TEST_CASE("FileAnalyticsDestination escapes each special JSON character",
     }
 }
 
+TEST_CASE("FileAnalyticsDestination escapes non-printable JSON control bytes",
+          "[runtime][analytics][coverage][phase3]") {
+    TemporaryFile tmp(".jsonl");
+    FileAnalyticsDestination dest(tmp.path_string());
+
+    AnalyticsEvent event;
+    event.name = std::string("nul", 3) + '\0' + "unit";
+    event.timestamp = 1.0;
+    event.properties = {
+        {"backspace", std::string("a\b")},
+        {"formfeed", std::string("b\f")},
+        {"unit", std::string("c") + static_cast<char>(0x1f)},
+    };
+    dest.log_event(event);
+    dest.flush();
+
+    std::ifstream f(tmp.path());
+    std::string line;
+    REQUIRE(std::getline(f, line));
+    REQUIRE(line.find("\"event\":\"nul\\u0000unit\"") != std::string::npos);
+    REQUIRE(line.find("\"backspace\":\"a\\b\"") != std::string::npos);
+    REQUIRE(line.find("\"formfeed\":\"b\\f\"") != std::string::npos);
+    REQUIRE(line.find("\"unit\":\"c\\u001f\"") != std::string::npos);
+}
+
 TEST_CASE("FileAnalyticsDestination escapes special JSON property keys and values",
           "[runtime][analytics][coverage][issue-656]") {
     TemporaryFile tmp(".jsonl");

--- a/test/test_gpu_timestamps.cpp
+++ b/test/test_gpu_timestamps.cpp
@@ -1,14 +1,20 @@
 // Phase 6.5 — Dawn GPU timestamp queries.
 //
 // These tests cover the *pure* resolution layer of `gpu_timestamps.hpp`:
-// the nanosecond-tick -> millisecond conversion, the resolved-buffer ->
-// per-pass walk, and the RenderPassManager integration. They run without
-// a live GPU device by feeding synthetic resolved-buffer values, so they
+// the nanosecond-tick -> millisecond conversion, the `decode_resolved_
+// ticks` mapped-buffer byte decode, the resolved-buffer -> per-pass walk,
+// and the RenderPassManager integration. They run without a live GPU
+// device by feeding synthetic resolved-buffer bytes/values, so they
 // execute on every CI lane (including the no-GPU sanitizer matrix).
 //
+// `decode_resolved_ticks` is the seam `GpuTimestamps::resolve()` uses to
+// turn a mapped Dawn readback buffer into ticks — covering it here is
+// what proves `read_back()` surfaces populated, correctly-converted
+// numbers rather than the empty vector the Phase 6.5 P1 review flagged.
+//
 // Live-device smoke (a real `wgpu::QuerySet` resolved against Metal/
-// Vulkan) is deferred to CI's GPU matrix; the math asserted here is the
-// part that historically hides perf bugs.
+// Vulkan via `resolve()`) is deferred to CI's GPU matrix; the math and
+// decode asserted here are the parts that historically hide perf bugs.
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -16,10 +22,29 @@
 #include <pulp/render/gpu_timestamps.hpp>
 #include <pulp/render/render_pass.hpp>
 
+#include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <vector>
 
 using namespace pulp::render;
+
+namespace {
+
+// Pack a vector of ticks into the little-endian uint64 byte layout that
+// `wgpu::Buffer::GetConstMappedRange` hands back after a real
+// `ResolveQuerySet` + copy. This is the synthetic stand-in for a mapped
+// Dawn buffer — feeding it through `decode_resolved_ticks` exercises the
+// exact decode path `GpuTimestamps::resolve()` uses on a live device.
+std::vector<std::byte> pack_ticks(const std::vector<std::uint64_t>& ticks) {
+    std::vector<std::byte> bytes(ticks.size() * sizeof(std::uint64_t));
+    if (!ticks.empty()) {
+        std::memcpy(bytes.data(), ticks.data(), bytes.size());
+    }
+    return bytes;
+}
+
+}  // namespace
 
 // ── timestamp_pair_to_ms — nanosecond conversion ────────────────────────────
 
@@ -65,6 +90,78 @@ TEST_CASE("timestamp_pair_to_ms treats an equal pair as zero duration",
     auto ms = timestamp_pair_to_ms(7'777, 7'777);
     REQUIRE(ms.has_value());
     REQUIRE(*ms == Catch::Approx(0.0));
+}
+
+// ── decode_resolved_ticks — mapped-buffer byte decode ───────────────────────
+//
+// This is the seam the Phase 6.5 P1 review flagged: before this layer
+// existed, `GpuTimestamps::read_back()` returned an internal vector that
+// nothing ever populated, so GPU timings never surfaced even when the
+// device supported `timestamp-query`. `resolve()` now decodes the
+// mapped readback buffer through `decode_resolved_ticks`; these cases
+// pin that decode against the byte layout a real mapped buffer carries.
+
+TEST_CASE("decode_resolved_ticks decodes a mapped timestamp buffer",
+          "[render][gpu-timestamps]") {
+    // The bytes a real resolved + map-read buffer would hold for a
+    // two-pass frame: [begin0, end0, begin1, end1].
+    const std::vector<std::uint64_t> ticks = {
+        1'000, 1'000 + 2'000'000,
+        9'000, 9'000 + 500'000,
+    };
+    const auto bytes = pack_ticks(ticks);
+
+    const auto decoded = decode_resolved_ticks(bytes.data(), bytes.size());
+    REQUIRE(decoded == ticks);
+
+    // The decoded ticks feed straight into the existing per-pass walk —
+    // proving the resolve path produces a populated, usable result.
+    const auto timings = resolve_pass_timings(decoded, 2);
+    REQUIRE(timings.size() == 2);
+    REQUIRE(timings[0].valid);
+    REQUIRE(timings[0].gpu_time_ms == Catch::Approx(2.0));
+    REQUIRE(timings[1].valid);
+    REQUIRE(timings[1].gpu_time_ms == Catch::Approx(0.5));
+}
+
+TEST_CASE("decode_resolved_ticks round-trips large 64-bit tick values",
+          "[render][gpu-timestamps]") {
+    // GPU clocks are wide — make sure no value is truncated to 32 bits.
+    const std::vector<std::uint64_t> ticks = {
+        0x0000'0001'0000'0000ULL,             // 2^32 — would vanish if truncated
+        0xFFFF'FFFF'FFFF'FFFFULL,             // max uint64
+        0x0123'4567'89AB'CDEFULL,
+    };
+    const auto bytes = pack_ticks(ticks);
+    const auto decoded = decode_resolved_ticks(bytes.data(), bytes.size());
+    REQUIRE(decoded == ticks);
+}
+
+TEST_CASE("decode_resolved_ticks returns empty for a null or short buffer",
+          "[render][gpu-timestamps]") {
+    // A device that never mapped the buffer hands back null / nothing —
+    // the decode must yield an empty vector, never read out of bounds.
+    REQUIRE(decode_resolved_ticks(nullptr, 64).empty());
+    REQUIRE(decode_resolved_ticks(nullptr, 0).empty());
+
+    const std::vector<std::uint64_t> one = {42};
+    const auto bytes = pack_ticks(one);
+    REQUIRE(decode_resolved_ticks(bytes.data(), 0).empty());
+    // Fewer than 8 bytes — no whole uint64 to decode.
+    REQUIRE(decode_resolved_ticks(bytes.data(), 7).empty());
+}
+
+TEST_CASE("decode_resolved_ticks truncates a partial trailing tick",
+          "[render][gpu-timestamps]") {
+    // A short or partial readback (e.g. only 1.5 uint64s landed) decodes
+    // to the last *whole* tick; resolve_pass_timings then tolerates the
+    // truncated tail by marking missing passes invalid.
+    const std::vector<std::uint64_t> ticks = {111, 222};
+    const auto bytes = pack_ticks(ticks);
+    // 12 bytes = one whole uint64 + 4 trailing bytes.
+    const auto decoded = decode_resolved_ticks(bytes.data(), 12);
+    REQUIRE(decoded.size() == 1);
+    REQUIRE(decoded[0] == 111);
 }
 
 // ── resolve_pass_timings — resolved-buffer walk ─────────────────────────────
@@ -259,6 +356,11 @@ TEST_CASE("GpuTimestamps degrades gracefully with no device",
 
     // No-ops, no crash.
     ts.begin_frame(4);
+    REQUIRE(ts.read_back().empty());
+
+    // resolve() with no device (and a null instance) must report false
+    // and never crash — the same safe path the CPU-only build takes.
+    REQUIRE_FALSE(ts.resolve(nullptr));
     REQUIRE(ts.read_back().empty());
 }
 

--- a/test/test_gpu_timestamps.cpp
+++ b/test/test_gpu_timestamps.cpp
@@ -321,6 +321,30 @@ TEST_CASE("set_pass_gpu_time rejects a negative duration",
     REQUIRE_FALSE(rpm.passes()[0].gpu_time_valid);
 }
 
+TEST_CASE("RenderPassManager begin_frame clears stale frame state",
+          "[render][gpu-timestamps][coverage][phase3]") {
+    RenderPassManager rpm;
+    rpm.set_budget(1.0f);
+    rpm.begin_frame();
+    rpm.begin_pass(RenderPassType::overlay);
+    rpm.end_pass(2.0f, 3);
+    rpm.set_pass_gpu_time(0, 0.5f);
+    rpm.end_frame();
+
+    REQUIRE(rpm.over_budget());
+    REQUIRE(rpm.has_gpu_timing());
+    REQUIRE(rpm.current_pass() == RenderPassType::overlay);
+    REQUIRE(rpm.total_time_ms() == Catch::Approx(2.0f));
+
+    rpm.begin_frame();
+    REQUIRE(rpm.frame_count() == 2);
+    REQUIRE(rpm.passes().empty());
+    REQUIRE_FALSE(rpm.over_budget());
+    REQUIRE_FALSE(rpm.has_gpu_timing());
+    REQUIRE(rpm.current_pass() == RenderPassType::background);
+    REQUIRE(rpm.total_time_ms() == Catch::Approx(0.0f));
+}
+
 // ── GpuTimestampSupport — feature-availability state machine ─────────────────
 
 TEST_CASE("GpuTimestampSupport describe/is_usable cover every state",

--- a/test/test_i18n.cpp
+++ b/test/test_i18n.cpp
@@ -468,6 +468,25 @@ TEST_CASE("i18n JSON parser handles escapes and keyless entries", "[runtime][i18
     REQUIRE(strings.translate("slash") == "path\\file");
 }
 
+TEST_CASE("i18n JSON parser handles standard control escapes",
+          "[runtime][i18n][coverage][phase3]") {
+    TemporaryFile tmp(".json");
+    {
+        std::ofstream f(tmp.path());
+        f << "{";
+        f << "\"carriage\":\"left\\rright\",";
+        f << "\"backspace\":\"ab\\bc\",";
+        f << "\"formfeed\":\"page\\fbreak\"";
+        f << "}";
+    }
+
+    LocalisedStrings strings;
+    REQUIRE(strings.load_json_file(tmp.path_string()));
+    REQUIRE(strings.translate("carriage") == "left\rright");
+    REQUIRE(strings.translate("backspace") == "ab\bc");
+    REQUIRE(strings.translate("formfeed") == "page\fbreak");
+}
+
 TEST_CASE("i18n JSON parser accepts commas and duplicate keys", "[runtime][i18n][coverage][issue-656]") {
     TemporaryFile tmp(".json");
     {

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -3,12 +3,44 @@
 #include <pulp/runtime/big_integer.hpp>
 #include <pulp/runtime/base64.hpp>
 #include <pulp/runtime/temporary_file.hpp>
+#include "../external/cpp-httplib/httplib.h"
 
+#include <chrono>
 #include <fstream>
 #include <limits>
+#include <thread>
 #include <utility>
 
 using namespace pulp::runtime;
+using namespace std::chrono_literals;
+
+namespace {
+
+struct LicenseHttpServerRunner {
+    explicit LicenseHttpServerRunner(httplib::Server& s)
+        : server(s)
+        , thread([this] { server.listen_after_bind(); }) {}
+
+    ~LicenseHttpServerRunner() {
+        server.stop();
+        if (thread.joinable()) {
+            thread.join();
+        }
+    }
+
+    bool wait_until_running(std::chrono::milliseconds timeout = 2s) const {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (!server.is_running() && std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(5ms);
+        }
+        return server.is_running();
+    }
+
+    httplib::Server& server;
+    std::thread thread;
+};
+
+}  // namespace
 
 // ── BigInteger ──────────────────────────────────────────────────────────
 
@@ -556,4 +588,41 @@ TEST_CASE("OnlineActivation rejects malformed server URLs without network", "[cr
     REQUIRE_FALSE(OnlineActivation::activate("not-a-url", "serial", "product").has_value());
     REQUIRE_FALSE(OnlineActivation::deactivate("not-a-url", "license"));
     REQUIRE(OnlineActivation::check_status("not-a-url", "license") == LicenseStatus::NotFound);
+}
+
+TEST_CASE("OnlineActivation handles successful loopback activation flows",
+          "[crypto][license][coverage][phase3]") {
+    httplib::Server server;
+    server.Post("/activate", [](const httplib::Request&, httplib::Response& response) {
+        response.set_content("license-key", "text/plain");
+    });
+    server.Post("/deactivate", [](const httplib::Request&, httplib::Response& response) {
+        response.status = 204;
+    });
+    server.Get("/status", [](const httplib::Request& request, httplib::Response& response) {
+        const auto key = request.has_param("key") ? request.get_param_value("key") : "";
+        if (key == "license-key") {
+            response.set_content(R"({"valid":true})", "application/json");
+        } else if (key == "expired-key") {
+            response.set_content(R"({"expired":true})", "application/json");
+        } else {
+            response.set_content(R"({"status":"denied"})", "application/json");
+        }
+    });
+
+    const int port = server.bind_to_any_port("127.0.0.1");
+    REQUIRE(port > 0);
+    LicenseHttpServerRunner runner(server);
+    REQUIRE(runner.wait_until_running());
+
+    const std::string base_url = "http://127.0.0.1:" + std::to_string(port);
+    auto license = OnlineActivation::activate(base_url, "serial-1", "PulpSynth");
+    REQUIRE(license.has_value());
+    REQUIRE(*license == "license-key");
+
+    REQUIRE(OnlineActivation::deactivate(base_url, *license));
+    REQUIRE(OnlineActivation::check_status(base_url, *license) == LicenseStatus::Valid);
+    REQUIRE(OnlineActivation::check_status(base_url, "expired-key") == LicenseStatus::Expired);
+    REQUIRE(OnlineActivation::check_status(base_url, "unknown-key") ==
+            LicenseStatus::InvalidSignature);
 }

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -3,12 +3,14 @@
 #include <pulp/runtime/ip_address.hpp>
 #include <pulp/runtime/network_stream.hpp>
 #include <pulp/runtime/socket.hpp>
+#include "../external/cpp-httplib/httplib.h"
 
 #include <algorithm>
 #include <array>
 #include <atomic>
 #include <chrono>
 #include <cstring>
+#include <optional>
 #include <string>
 #include <thread>
 
@@ -29,6 +31,30 @@ struct ThreadJoiner {
             thread.join();
         }
     }
+};
+
+struct HttpServerRunner {
+    explicit HttpServerRunner(httplib::Server& s)
+        : server(s)
+        , thread([this] { server.listen_after_bind(); }) {}
+
+    ~HttpServerRunner() {
+        server.stop();
+        if (thread.joinable()) {
+            thread.join();
+        }
+    }
+
+    bool wait_until_running(std::chrono::milliseconds timeout = 2s) const {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (!server.is_running() && std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(5ms);
+        }
+        return server.is_running();
+    }
+
+    httplib::Server& server;
+    std::thread thread;
 };
 
 // Pick an ephemeral port and return the bound listener + its actual port.
@@ -849,4 +875,73 @@ TEST_CASE("HttpStream factories and refetch reset closed state to request result
     auto read = stream.read(&byte, sizeof(byte));
     REQUIRE_FALSE(read.ok());
     REQUIRE(read.error == StreamError::IoError);
+}
+
+TEST_CASE("HttpStream reads successful GET responses in chunks",
+          "[network_stream][http][coverage][phase3]") {
+    httplib::Server server;
+    server.Get("/body", [](const httplib::Request&, httplib::Response& response) {
+        response.set_header("X-Pulp-Stream", "ok");
+        response.set_content("chunked-body", "text/plain");
+    });
+
+    const int port = server.bind_to_any_port("127.0.0.1");
+    REQUIRE(port > 0);
+    HttpServerRunner runner(server);
+    REQUIRE(runner.wait_until_running());
+
+    auto stream = HttpStream::get("http://127.0.0.1:" + std::to_string(port) + "/body", 2);
+    REQUIRE(stream);
+    REQUIRE(stream->status_code() == 200);
+    REQUIRE(stream->headers().at("X-Pulp-Stream") == "ok");
+    REQUIRE(stream->is_open());
+    REQUIRE_FALSE(stream->eof());
+
+    std::array<std::uint8_t, 16> buffer{};
+    auto first = stream->read(buffer.data(), 7);
+    REQUIRE(first.ok());
+    REQUIRE(first.bytes == 7);
+    REQUIRE(std::string(reinterpret_cast<char*>(buffer.data()), first.bytes) == "chunked");
+    REQUIRE(stream->is_open());
+
+    auto second = stream->read(buffer.data(), buffer.size());
+    REQUIRE(second.ok());
+    REQUIRE(second.bytes == 5);
+    REQUIRE(std::string(reinterpret_cast<char*>(buffer.data()), second.bytes) == "-body");
+    REQUIRE_FALSE(stream->is_open());
+    REQUIRE(stream->eof());
+
+    auto eof = stream->read(buffer.data(), buffer.size());
+    REQUIRE_FALSE(eof.ok());
+    REQUIRE(eof.closed());
+}
+
+TEST_CASE("HttpStream POST factory exposes successful response bodies",
+          "[network_stream][http][coverage][phase3]") {
+    httplib::Server server;
+    server.Post("/echo", [](const httplib::Request& request, httplib::Response& response) {
+        response.set_header("X-Pulp-Method", request.method);
+        response.set_content(request.body, "text/plain");
+    });
+
+    const int port = server.bind_to_any_port("127.0.0.1");
+    REQUIRE(port > 0);
+    HttpServerRunner runner(server);
+    REQUIRE(runner.wait_until_running());
+
+    auto stream = HttpStream::post("http://127.0.0.1:" + std::to_string(port) + "/echo",
+                                   "payload=42",
+                                   "text/plain",
+                                   2);
+    REQUIRE(stream);
+    REQUIRE(stream->status_code() == 200);
+    REQUIRE(stream->headers().at("X-Pulp-Method") == "POST");
+    REQUIRE(stream->is_open());
+
+    std::array<std::uint8_t, 32> buffer{};
+    auto read = stream->read(buffer.data(), buffer.size());
+    REQUIRE(read.ok());
+    REQUIRE(read.bytes == 10);
+    REQUIRE(std::string(reinterpret_cast<char*>(buffer.data()), read.bytes) == "payload=42");
+    REQUIRE(stream->read(buffer.data(), buffer.size()).closed());
 }

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -17,6 +17,7 @@
 #include "../external/cpp-httplib/httplib.h"
 #include <catch2/catch_approx.hpp>
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <fstream>
 #include <filesystem>
@@ -761,6 +762,21 @@ TEST_CASE("run_process fails on nonexistent", "[runtime][child_process]") {
     auto result = run_process("/tmp/nonexistent_binary_12345");
 #endif
     REQUIRE_FALSE(result.has_value());
+}
+
+TEST_CASE("run_process terminates POSIX children on timeout",
+          "[runtime][child_process][coverage][phase3]") {
+#if defined(_WIN32) || defined(__ANDROID__)
+    SUCCEED("POSIX timeout termination is covered on macOS/Linux");
+#else
+    const auto start = std::chrono::steady_clock::now();
+    auto result = run_process("/bin/sh", {"-c", "sleep 2"}, "", 50);
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    REQUIRE(result.has_value());
+    REQUIRE(result->exit_code == -1);
+    REQUIRE(elapsed < std::chrono::milliseconds(1500));
+#endif
 }
 
 TEST_CASE("launch_process reports failed starts and missing pids",

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -24,6 +24,12 @@
 #include <iterator>
 #include <thread>
 
+#if !defined(_WIN32)
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
 using namespace pulp::runtime;
 
 namespace {
@@ -770,12 +776,41 @@ TEST_CASE("run_process terminates POSIX children on timeout",
     SUCCEED("POSIX timeout termination is covered on macOS/Linux");
 #else
     const auto start = std::chrono::steady_clock::now();
-    auto result = run_process("/bin/sh", {"-c", "sleep 2"}, "", 50);
+    auto result = run_process("/bin/sh", {"-c", "exec sleep 2"}, "", 50);
     const auto elapsed = std::chrono::steady_clock::now() - start;
 
     REQUIRE(result.has_value());
     REQUIRE(result->exit_code == -1);
     REQUIRE(elapsed < std::chrono::milliseconds(1500));
+#endif
+}
+
+TEST_CASE("run_process preserves POSIX output captured before timeout",
+          "[runtime][child_process][coverage][phase3]") {
+#if defined(_WIN32) || defined(__ANDROID__)
+    SUCCEED("POSIX timeout output preservation is covered on macOS/Linux");
+#else
+    auto result = run_process("/bin/sh", {"-c", "printf ready; exec sleep 2"}, "", 75);
+
+    REQUIRE(result.has_value());
+    REQUIRE(result->exit_code == -1);
+    REQUIRE(result->stdout_output == "ready");
+#endif
+}
+
+TEST_CASE("launch_process starts a POSIX child visible to is_process_running",
+          "[runtime][child_process][coverage][phase3]") {
+#if defined(_WIN32) || defined(__ANDROID__)
+    SUCCEED("POSIX process lifecycle is covered on macOS/Linux");
+#else
+    const int pid = launch_process("/bin/sleep", {"2"});
+    REQUIRE(pid > 0);
+    REQUIRE(is_process_running(pid));
+
+    REQUIRE(kill(static_cast<pid_t>(pid), SIGTERM) == 0);
+    int status = 0;
+    REQUIRE(waitpid(static_cast<pid_t>(pid), &status, 0) == pid);
+    REQUIRE_FALSE(is_process_running(pid));
 #endif
 }
 

--- a/test/test_state.cpp
+++ b/test/test_state.cpp
@@ -4,6 +4,7 @@
 #include <pulp/state/binding.hpp>
 #include <pulp/state/state.hpp>
 #include <pulp/state/state_migration.hpp>
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -11,6 +12,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <mutex>
+#include <optional>
 #include <thread>
 #include <vector>
 
@@ -130,6 +132,88 @@ TEST_CASE("ParameterEventQueue is available from state",
     REQUIRE(queue.events()[1].sample_offset == 32);
     REQUIRE(queue.events()[2].param_id == 3);
     REQUIRE(queue.events()[2].sample_offset == 64);
+}
+
+TEST_CASE("ParameterEventQueue enforces capacity and preserves stable sort order",
+          "[state][params][events][coverage][phase3]") {
+    ParameterEventQueue queue;
+
+    REQUIRE(queue.capacity() == ParameterEventQueue::kCapacity);
+    for (std::size_t i = 0; i < queue.capacity(); ++i) {
+        REQUIRE(queue.push(ParameterEvent{
+            .param_id = static_cast<ParamID>(i + 1),
+            .sample_offset = static_cast<int32_t>(queue.capacity() - i),
+            .value = static_cast<float>(i),
+        }));
+    }
+
+    REQUIRE_FALSE(queue.push(ParameterEvent{.param_id = 9999, .sample_offset = 0, .value = 1.0f}));
+    REQUIRE(queue.size() == queue.capacity());
+
+    queue.clear();
+    REQUIRE(queue.empty());
+    REQUIRE(queue.push(ParameterEvent{.param_id = 1, .sample_offset = 8, .value = 1.0f}));
+    REQUIRE(queue.push(ParameterEvent{.param_id = 2, .sample_offset = 8, .value = 2.0f}));
+    REQUIRE(queue.push(ParameterEvent{.param_id = 3, .sample_offset = 4, .value = 3.0f}));
+
+    queue.sort();
+    REQUIRE(queue.events()[0].param_id == 3);
+    REQUIRE(queue.events()[1].param_id == 1);
+    REQUIRE(queue.events()[2].param_id == 2);
+}
+
+TEST_CASE("ParamCursor ignores unregistered events but honors explicit snapshots",
+          "[state][params][cursor][coverage][phase3]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "Gain", "", {0.0f, 1.0f, 0.25f}));
+    store.set_value(1, 0.5f);
+
+    ParameterEventQueue events;
+    REQUIRE(events.push(ParameterEvent{.param_id = 99, .sample_offset = 0, .value = 9.0f}));
+    REQUIRE(events.push(ParameterEvent{.param_id = 1, .sample_offset = 4, .value = 2.0f}));
+    events.sort();
+
+    std::array<ParamSnapshotEntry, 1> snapshots{{{99, 7.0f}}};
+    ParamCursor cursor(store, &events, snapshots);
+
+    REQUIRE(cursor.is_tracked(99));
+    REQUIRE(cursor.value(99) == 7.0f);
+    REQUIRE(cursor.is_tracked(1));
+    REQUIRE(cursor.value(1) == 0.5f);
+
+    cursor.advance_to(0);
+    REQUIRE(cursor.value(99) == 7.0f);
+    REQUIRE(cursor.value(1) == 0.5f);
+
+    cursor.advance_to(4);
+    REQUIRE(cursor.value(1) == 1.0f);
+    REQUIRE(store.get_value(1) == 0.5f);
+}
+
+TEST_CASE("ParamCursor is monotonic and null event queues fall back to StateStore",
+          "[state][params][cursor][coverage][phase3]") {
+    StateStore store;
+    store.add_parameter(make_param_info(7, "Mix", "", {-1.0f, 1.0f, 0.0f}));
+    store.set_value(7, 0.25f);
+
+    ParamCursor no_events(store, nullptr);
+    REQUIRE(no_events.tracked_param_count() == 0);
+    REQUIRE(no_events.value(7) == 0.25f);
+    REQUIRE(no_events.value(1234) == 0.0f);
+
+    ParameterEventQueue events;
+    REQUIRE(events.push(ParameterEvent{.param_id = 7, .sample_offset = 2, .value = -0.5f}));
+    REQUIRE(events.push(ParameterEvent{.param_id = 7, .sample_offset = 5, .value = 0.75f}));
+    events.sort();
+
+    ParamCursor cursor(store, &events);
+    cursor.advance_to(5);
+    REQUIRE(cursor.position() == 5);
+    REQUIRE(cursor.value(7) == 0.75f);
+
+    cursor.advance_to(2);
+    REQUIRE(cursor.position() == 5);
+    REQUIRE(cursor.value(7) == 0.75f);
 }
 
 TEST_CASE("ParamRange with step", "[state][range]") {
@@ -1311,6 +1395,138 @@ TEST_CASE("StateStore rejects corrupt source blobs before migration callbacks",
     REQUIRE_FALSE(target.deserialize(data));
     REQUIRE_FALSE(migration_called);
     REQUIRE_THAT(target.get_value(42), WithinAbs(10.0, 0.001));
+}
+
+TEST_CASE("StateMigrationRegistry rejects invalid and duplicate registrations",
+          "[state][serialize][migration][coverage][phase3]") {
+    StateMigrationRegistry registry;
+    auto migration = [](std::span<const uint8_t>, std::vector<uint8_t>&) {
+        return true;
+    };
+
+    REQUIRE_FALSE(registry.register_migration(2, 2, migration));
+    REQUIRE_FALSE(registry.register_migration(3, 2, migration));
+    REQUIRE_FALSE(registry.register_migration(1, 2, {}));
+    REQUIRE(registry.register_migration(1, 2, migration));
+    REQUIRE_FALSE(registry.register_migration(1, 3, migration));
+    REQUIRE(registry.has_migration_from(1));
+    REQUIRE_FALSE(registry.has_migration_from(2));
+}
+
+TEST_CASE("StateMigrationRegistry copies current-version blobs and rejects bad sources",
+          "[state][serialize][migration][coverage][phase3]") {
+    StateStore source;
+    source.set_state_version(4);
+    source.add_parameter(make_param_info(42, "Answer", "", {0.0f, 100.0f, 10.0f}));
+    source.set_value(42, 64.0f);
+    auto data = source.serialize();
+
+    StateMigrationRegistry registry;
+    auto same = registry.migrate(data, 4);
+    REQUIRE(same.has_value());
+    REQUIRE(*same == data);
+
+    REQUIRE_FALSE(registry.migrate(data, 3).has_value());
+    REQUIRE_FALSE(serialized_state_version({}).has_value());
+
+    auto corrupt = data;
+    corrupt[0] = 'X';
+    REQUIRE_FALSE(serialized_state_version(corrupt).has_value());
+    REQUIRE_FALSE(registry.migrate(corrupt, 4).has_value());
+
+    auto bad_crc = data;
+    bad_crc.back() ^= 0x5au;
+    REQUIRE(serialized_state_version(bad_crc) == std::optional<uint32_t>{4});
+    REQUIRE_FALSE(registry.migrate(bad_crc, 4).has_value());
+}
+
+TEST_CASE("StateMigrationRegistry applies multi-hop migrations in order",
+          "[state][serialize][migration][coverage][phase3]") {
+    StateStore source;
+    source.set_state_version(1);
+    source.add_parameter(make_param_info(7, "Mix", "", {0.0f, 1.0f, 0.25f}));
+    source.set_value(7, 0.75f);
+    auto data = source.serialize();
+
+    std::vector<uint32_t> calls;
+    auto rewrite_version = [&calls](uint32_t to_version) {
+        return [&calls, to_version](std::span<const uint8_t> source_blob,
+                                    std::vector<uint8_t>& migrated) {
+            calls.push_back(to_version);
+            migrated.assign(source_blob.begin(), source_blob.end());
+            write_u32_le(migrated, 4, to_version);
+            const auto crc_offset = migrated.size() - 4;
+            write_u32_le(migrated, crc_offset,
+                         crc32_simple_for_test(migrated, crc_offset));
+            return true;
+        };
+    };
+
+    StateMigrationRegistry registry;
+    REQUIRE(registry.register_migration(1, 2, rewrite_version(2)));
+    REQUIRE(registry.register_migration(2, 4, rewrite_version(4)));
+
+    auto migrated = registry.migrate(data, 4);
+    REQUIRE(migrated.has_value());
+    REQUIRE(calls == std::vector<uint32_t>{2, 4});
+    REQUIRE(serialized_state_version(*migrated) == std::optional<uint32_t>{4});
+
+    StateStore target;
+    target.set_state_version(4);
+    target.add_parameter(make_param_info(7, "Mix", "", {0.0f, 1.0f, 0.25f}));
+    REQUIRE(target.deserialize(*migrated));
+    REQUIRE_THAT(target.get_value(7), WithinAbs(0.75f, 0.001f));
+}
+
+TEST_CASE("StateMigrationRegistry rejects broken migration callbacks",
+          "[state][serialize][migration][coverage][phase3]") {
+    StateStore source;
+    source.set_state_version(1);
+    source.add_parameter(make_param_info(3, "Drive", "", {0.0f, 1.0f, 0.5f}));
+    auto data = source.serialize();
+
+    StateMigrationRegistry missing_hop;
+    REQUIRE(missing_hop.register_migration(
+        1, 3,
+        [](std::span<const uint8_t> source_blob, std::vector<uint8_t>& migrated) {
+            migrated.assign(source_blob.begin(), source_blob.end());
+            write_u32_le(migrated, 4, 3);
+            const auto crc_offset = migrated.size() - 4;
+            write_u32_le(migrated, crc_offset,
+                         crc32_simple_for_test(migrated, crc_offset));
+            return true;
+        }));
+    REQUIRE_FALSE(missing_hop.migrate(data, 2).has_value());
+
+    StateMigrationRegistry returns_false;
+    REQUIRE(returns_false.register_migration(
+        1, 2,
+        [](std::span<const uint8_t>, std::vector<uint8_t>&) {
+            return false;
+        }));
+    REQUIRE_FALSE(returns_false.migrate(data, 2).has_value());
+
+    StateMigrationRegistry empty_output;
+    REQUIRE(empty_output.register_migration(
+        1, 2,
+        [](std::span<const uint8_t>, std::vector<uint8_t>& migrated) {
+            migrated.clear();
+            return true;
+        }));
+    REQUIRE_FALSE(empty_output.migrate(data, 2).has_value());
+
+    StateMigrationRegistry wrong_version;
+    REQUIRE(wrong_version.register_migration(
+        1, 2,
+        [](std::span<const uint8_t> source_blob, std::vector<uint8_t>& migrated) {
+            migrated.assign(source_blob.begin(), source_blob.end());
+            write_u32_le(migrated, 4, 99);
+            const auto crc_offset = migrated.size() - 4;
+            write_u32_le(migrated, crc_offset,
+                         crc32_simple_for_test(migrated, crc_offset));
+            return true;
+        }));
+    REQUIRE_FALSE(wrong_version.migrate(data, 2).has_value());
 }
 
 TEST_CASE("StateStore reset_all_to_defaults notifies in registration order",

--- a/test/test_state_tree.cpp
+++ b/test/test_state_tree.cpp
@@ -1370,6 +1370,21 @@ TEST_CASE("StateTreeSynchroniser decode rejects malformed delta framing",
     REQUIRE(decoded[0].value.index() == 0);
 }
 
+TEST_CASE("StateTreeSynchroniser decode keeps available deltas when count is too large",
+          "[state][sync][coverage][phase3]") {
+    SyncDelta delta{SyncDeltaType::PropertySet, "0", "gain", 0.75, -1};
+    auto encoded = StateTreeSynchroniser::encode({delta});
+    encoded[0] = 3;
+    encoded[1] = 0;
+
+    auto decoded = StateTreeSynchroniser::decode(encoded.data(), encoded.size());
+    REQUIRE(decoded.size() == 1);
+    REQUIRE(decoded[0].type == SyncDeltaType::PropertySet);
+    REQUIRE(decoded[0].path == "0");
+    REQUIRE(decoded[0].key == "gain");
+    REQUIRE_THAT(std::get<double>(decoded[0].value), WithinAbs(0.75, 1e-9));
+}
+
 TEST_CASE("StateTreeSynchroniser apply mutates properties and children", "[state][sync]") {
     auto tree = StateTree::create("root");
     tree->set("remove_me", std::string("bye"));
@@ -1395,6 +1410,84 @@ TEST_CASE("StateTreeSynchroniser apply mutates properties and children", "[state
     REQUIRE(tree->child_count() == 2);
     REQUIRE(tree->child(0)->type_name() == "inserted");
     REQUIRE(tree->child(1)->type_name() == "appended");
+}
+
+TEST_CASE("StateTreeSynchroniser apply skips malformed and unreachable paths",
+          "[state][sync][coverage][phase3]") {
+    auto root = StateTree::create("root");
+    auto child = StateTree::create("child");
+    root->add_child(child);
+
+    std::vector<SyncDelta> deltas = {
+        {SyncDeltaType::PropertySet, ".0", "bad_empty_prefix", std::string("x"), -1},
+        {SyncDeltaType::PropertySet, "0.", "bad_empty_suffix", std::string("x"), -1},
+        {SyncDeltaType::PropertySet, "x", "bad_alpha", std::string("x"), -1},
+        {SyncDeltaType::PropertySet, "2", "bad_index", std::string("x"), -1},
+        {SyncDeltaType::PropertySet, "0.1", "bad_nested_index", std::string("x"), -1},
+        {SyncDeltaType::PropertySet, "0", "valid", std::string("ok"), -1},
+    };
+
+    StateTreeSynchroniser::apply(*root, deltas);
+
+    REQUIRE_FALSE(root->has("bad_empty_prefix"));
+    REQUIRE_FALSE(root->has("bad_empty_suffix"));
+    REQUIRE_FALSE(root->has("bad_alpha"));
+    REQUIRE_FALSE(root->has("bad_index"));
+    REQUIRE_FALSE(root->has("bad_nested_index"));
+    REQUIRE_FALSE(child->has("bad_empty_prefix"));
+    REQUIRE_FALSE(child->has("bad_empty_suffix"));
+    REQUIRE_FALSE(child->has("bad_alpha"));
+    REQUIRE_FALSE(child->has("bad_index"));
+    REQUIRE_FALSE(child->has("bad_nested_index"));
+    REQUIRE(child->get_string("valid") == "ok");
+}
+
+TEST_CASE("StateTreeSynchroniser observes descendants of newly added subtrees",
+          "[state][sync][coverage][phase3]") {
+    auto root = StateTree::create("root");
+    auto bank = StateTree::create("bank");
+    auto voice = StateTree::create("voice");
+    bank->add_child(voice);
+
+    StateTreeSynchroniser sync;
+    sync.attach(root);
+    root->add_child(bank);
+
+    auto add_deltas = sync.take_deltas();
+    REQUIRE(add_deltas.size() == 1);
+    REQUIRE(add_deltas[0].type == SyncDeltaType::ChildAdd);
+    REQUIRE(add_deltas[0].path.empty());
+    REQUIRE(add_deltas[0].key == "bank");
+
+    voice->set("gain", 0.5);
+    auto nested_deltas = sync.take_deltas();
+    REQUIRE(nested_deltas.size() == 1);
+    REQUIRE(nested_deltas[0].type == SyncDeltaType::PropertySet);
+    REQUIRE(nested_deltas[0].path == "0.0");
+    REQUIRE(nested_deltas[0].key == "gain");
+    REQUIRE_THAT(std::get<double>(nested_deltas[0].value), WithinAbs(0.5, 1e-9));
+}
+
+TEST_CASE("StateTreeSynchroniser detaches removed subtrees before later mutations",
+          "[state][sync][coverage][phase3]") {
+    auto root = StateTree::create("root");
+    auto child = StateTree::create("child");
+    auto grandchild = StateTree::create("grandchild");
+    child->add_child(grandchild);
+    root->add_child(child);
+
+    StateTreeSynchroniser sync;
+    sync.attach(root);
+    root->remove_child(0);
+
+    auto remove_deltas = sync.take_deltas();
+    REQUIRE(remove_deltas.size() == 1);
+    REQUIRE(remove_deltas[0].type == SyncDeltaType::ChildRemove);
+    REQUIRE(remove_deltas[0].child_index == 0);
+
+    child->set("detached", true);
+    grandchild->set("detached", true);
+    REQUIRE(sync.take_deltas().empty());
 }
 
 // ── StateTreeSynchroniser nested-node routing (P7-3) ────────────────────

--- a/test/test_xml_zip.cpp
+++ b/test/test_xml_zip.cpp
@@ -373,6 +373,14 @@ TEST_CASE("deflate_decompress rejects truncated raw streams",
     REQUIRE_FALSE(deflate_decompress(compressed->data(), compressed->size()).has_value());
 }
 
+TEST_CASE("deflate_decompress rejects empty raw streams without growth",
+          "[runtime][zip][coverage][phase3]") {
+    REQUIRE_FALSE(deflate_decompress(nullptr, 0).has_value());
+
+    const uint8_t unused = 0;
+    REQUIRE_FALSE(deflate_decompress(&unused, 0).has_value());
+}
+
 // ── RFC 1952 gzip wire-format compliance (issue-468 follow-up) ──────────
 //
 // gzip_compress() must emit a real RFC 1952 stream — magic bytes, deflate
@@ -545,6 +553,28 @@ TEST_CASE("gzip_decompress rejects gzip input with corrupt trailer ISIZE", "[run
     (*compressed)[compressed->size() - 1] ^= 0x01;
     auto out = gzip_decompress(compressed->data(), compressed->size());
     REQUIRE_FALSE(out.has_value());
+}
+
+TEST_CASE("gzip_decompress rejects truncated member trailers and empty members",
+          "[runtime][zip][coverage][phase3]") {
+    const std::string original = "truncated gzip trailer payload";
+    auto compressed = gzip_compress(original);
+    REQUIRE(compressed.has_value());
+    REQUIRE(compressed->size() > 18);
+
+    auto missing_isize = *compressed;
+    missing_isize.resize(missing_isize.size() - 4);
+    REQUIRE_FALSE(gzip_decompress(missing_isize.data(), missing_isize.size()).has_value());
+
+    const std::vector<uint8_t> header_and_trailer_only = {
+        0x1f, 0x8b, 0x08, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0xff,
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+    };
+    REQUIRE_FALSE(gzip_decompress(header_and_trailer_only.data(),
+                                  header_and_trailer_only.size()).has_value());
 }
 
 // Codex P2 on PR #747: RFC 1952 §2.2 permits multiple gzip members


### PR DESCRIPTION
## Summary
- add Phase 3 coverage across state migration/cursors/synchroniser, runtime zip/process/i18n/analytics, lock-to-source escaping, render pass reset, GPU timestamp readback, HttpStream success bodies, and OnlineActivation loopback flows
- fix the covered runtime/render edges where tests exposed product behavior gaps
- apply the required SDK minor bump for the new public GpuTimestamps::resolve API

## Local validation
- cmake --build build --target pulp-test-state pulp-test-state-tree pulp-test-xml-zip pulp-test-runtime-utils pulp-test-analytics pulp-test-i18n pulp-test-lock-to-source pulp-test-gpu-timestamps pulp-test-network-stream pulp-test-license --parallel
- ./build/test/pulp-test-state --reporter compact
- ./build/test/pulp-test-state-tree --reporter compact
- ./build/test/pulp-test-xml-zip --reporter compact
- ./build/test/pulp-test-runtime-utils --reporter compact
- ./build/test/pulp-test-analytics --reporter compact
- ./build/test/pulp-test-i18n --reporter compact
- ./build/test/pulp-test-lock-to-source --reporter compact
- ./build/test/pulp-test-gpu-timestamps --reporter compact
- ./build/test/pulp-test-network-stream --reporter compact
- ./build/test/pulp-test-license --reporter compact
- python3 tools/import-validation/check-source-contracts.py --strict
- python3 tools/import-validation/test_source_contracts.py
- python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main
- python3 tools/scripts/version_bump_check.py --mode=report --base origin/main
- python3 tools/scripts/source_tree_pollution_check.py --mode=root-allowlist --rev HEAD
- git diff --check origin/main..HEAD