### PR TITLE
ci: document leftover CI-watch Monitor cleanup in the ci skill

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1491,6 +1491,12 @@ Minimum incident response once a failure is visible:
 4. Queue the narrowest truthful rerun needed after the fix.
 5. Close the loop with a short status update that says what failed, what is being tried now, and what still remains.
 
+### Gotcha: stop a leftover CI-watch Monitor by the Monitor's task id, not the agent's
+
+When an agent spawns a background Monitor (or a poll loop) to watch a PR's check-runs, that Monitor is a **separate task** from the agent. After the agent's work finishes, the Monitor keeps running — re-emitting "agent completed" events and burning shared REST quota polling `commits/<sha>/check-runs` — until its until-condition is met or it is explicitly stopped.
+
+To stop a leftover Monitor: `TaskStop` **the Monitor's own task id** (the still-running poll-loop task — visible in the task list as a `local_bash` task). Do NOT `TaskStop` the agent's id: once the agent has finished it is already `completed`, so `TaskStop <agent-id>` fails with `not running (status: completed)` and the Monitor keeps going. The agent id and the Monitor id are different — target the Monitor.
+
 ### `cloud run [branch]` — Trigger GitHub Actions
 
 Trigger cloud CI only when cloud CI is actually needed, for example


### PR DESCRIPTION
## Summary

Adds one gotcha section to `.agents/skills/ci/SKILL.md` documenting how to stop a leftover CI-watch Monitor.

A background Monitor (or poll loop) spawned to watch a PR's check-runs is a **separate task** from the agent that spawned it. After the agent's work finishes, the Monitor keeps running — re-emitting "agent completed" events and burning shared REST quota polling `commits/<sha>/check-runs` — until its until-condition is met or it is explicitly stopped.

The fix: `TaskStop` the Monitor's **own** task id (the still-running `local_bash` poll-loop task), not the agent's id. The agent is already `completed`, so `TaskStop <agent-id>` fails with `not running (status: completed)` and the Monitor keeps going.

The new `### Gotcha:` subsection sits right after the **Active CI Incident Loop** section, which is the existing home for CI-monitoring guidance.

## Test plan

- [x] `.agents/skills/ci/SKILL.md` is the only file changed (`git diff --stat` confirms 1 file, 6 insertions)
- [x] `python3 tools/scripts/skill_sync_check.py --mode=report` passes (no mapped source paths touched)
- [x] Markdown structure intact — new section matches existing `### Gotcha:` heading style

🤖 Generated with [Claude Code](https://claude.com/claude-code)