### PR TITLE
ci: centralize react Codecov uploads on main

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1000,6 +1000,15 @@ Consequences when touching `coverage.yml` or `coverage-diff-gate`:
   breaks on every leg that resolved to a single scalar label. `tojson`
   always emits valid JSON: a string stays quoted, an array stays an
   array, an object stays an object.
+- **@pulp/react Codecov uploads are split by event.** PRs that touch
+  `packages/pulp-react/**` still build, test, and upload through the
+  path-filtered `pulp-react-build.yml` workflow. Push-to-main and manual
+  Codecov uploads for `@pulp/react` live in `coverage.yml` as
+  `pulp-react-coverage`. Do not move the main upload back to
+  `pulp-react-build.yml`: if the native Coverage run for a SHA is
+  superseded before any OS legs upload, an independent React upload would
+  advance Codecov's `main` branch record to a mixed React + stale-native
+  snapshot.
 
 ## Prerequisites Check
 
@@ -1733,10 +1742,12 @@ would make CI flakier than it needs to be.
 
 ## Coverage workflow (`#566` Phase 1)
 
-`.github/workflows/coverage.yml` has three jobs:
+`.github/workflows/coverage.yml`'s major jobs include:
 
 - `resolve-runners` — shared-helper resolver (`tools/scripts/resolve_runs_on.py`) that picks per-OS runs-on labels in priority order: workflow_dispatch input → `PULP_COVERAGE_<OS>_RUNS_ON_JSON` repo variable → hard-coded default (`ubuntu-latest` / `macos-latest` / `windows-latest`). Same pattern as `sanitizers.yml`. Change runner for one OS by setting the repo variable — no workflow edit required.
-- `coverage` — matrix over {linux, macos, windows}. Every leg builds with Clang source-based coverage, runs the native test suite, uploads HTML + summary + Cobertura artifacts, and pushes to Codecov with exactly one per-OS flag (`os-linux`, `os-macos`, `os-windows`). The Linux leg also installs `coverage.py >= 7.10`, runs `tools/scripts/run_python_coverage.py` for `tools/scripts/**`, `tools/deps/**`, and `tools/local-ci/**`, uploads the Python HTML + summary + Cobertura artifacts, and includes `build-coverage/python/coverage.python.xml` in the same Codecov upload. The macOS leg additionally runs `tools/scripts/run_swift_coverage.py`, stages `build-coverage/apple/coverage.apple.json`, uploads the Apple summary artifact, and includes that JSON in the same Codecov upload. Subsystem / platform / surface slicing comes from `codecov.yml`'s `component_management` path globs, not from a multi-flag CSV on the upload step. Has `continue-on-error: true` on the heavy coverage steps and `fail-fast: false` on the matrix — a flake on any one OS never cancels the others and never blocks a merge.
+- `coverage` — event-conditional matrix over {macos} on PRs and {linux, macos, windows} on push-to-main / workflow_dispatch. Every leg builds with Clang source-based coverage, runs the native test suite, uploads HTML + summary + Cobertura artifacts, and pushes to Codecov with exactly one per-OS flag (`os-linux`, `os-macos`, `os-windows`). The Linux leg also installs `coverage.py >= 7.10`, runs `tools/scripts/run_python_coverage.py` for `tools/scripts/**`, `tools/deps/**`, and `tools/local-ci/**`, uploads the Python HTML + summary + Cobertura artifacts, and includes `build-coverage/python/coverage.python.xml` in the same Codecov upload. The macOS leg additionally runs `tools/scripts/run_swift_coverage.py`, stages `build-coverage/apple/coverage.apple.lcov`, uploads the Apple summary artifact, and includes that LCOV in the same Codecov upload when present. Subsystem / platform / surface slicing comes from `codecov.yml`'s `component_management` path globs, not from a multi-flag CSV on the upload step. Has `fail-fast: false` on the matrix — a flake on any one OS never cancels the others and never blocks a merge.
+- `android-kotlin-coverage` — Gradle/JaCoCo coverage for `android/app/src/main/kotlin/**`, uploaded to Codecov from the canonical Coverage workflow so main snapshots keep Android JVM coverage fresh.
+- `pulp-react-coverage` — Vitest/Cobertura coverage for `packages/pulp-react/**` on push-to-main and workflow_dispatch. PR upload remains in `pulp-react-build.yml`; main upload is centralized here so side coverage cannot advance Codecov when native Coverage for the same SHA was cancelled before upload.
 - `coverage-diff-gate` — downloads all three OS Cobertura artifacts (`coverage-cobertura-${sha}` for Linux, `coverage-cobertura-macos-${sha}`, `coverage-cobertura-windows-${sha}`), merges them with `tools/scripts/merge_cobertura.py` (taking `max(hits)` per `(filename, line)`), then runs `diff-cover --fail-under=75` against `origin/<base>` on the merged XML. Hard-fails the PR when the global diff-coverage floor is missed. The job still renders and upserts the diff-coverage PR comment via `tools/scripts/coverage_diff_comment.py` even on failure, and it also runs the per-tier gate (`tools/scripts/coverage_tier_check.py`) in advisory mode against the same merged XML.
 
 Gotchas:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1031,6 +1031,78 @@ jobs:
           fail_ci_if_error: false
           verbose: true
 
+  pulp-react-coverage:
+    # Keep @pulp/react's main-branch Codecov upload in the canonical
+    # Coverage workflow. The path-filtered pulp-react build workflow still
+    # validates PRs, but it must not be the only main upload for a SHA whose
+    # native Coverage run was superseded before any OS legs uploaded.
+    name: Coverage report (@pulp/react, Vitest)
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: false
+          lfs: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: packages/pulp-react/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: packages/pulp-react
+
+      - name: Build
+        run: npm run build
+        working-directory: packages/pulp-react
+
+      - name: Test (with coverage)
+        run: npm run test:coverage
+        working-directory: packages/pulp-react
+
+      - name: Verify Cobertura XML exists
+        shell: bash
+        run: |
+          xml=packages/pulp-react/coverage/cobertura-coverage.xml
+          test -s "$xml" || {
+            echo "::error::cobertura-coverage.xml is missing or empty."
+            echo "::error::Vitest coverage step likely failed — check the 'Test (with coverage)' step above."
+            exit 1
+          }
+          size=$(wc -c < "$xml")
+          echo "cobertura-coverage.xml size: ${size} bytes"
+          lines_valid=$(python3 -c "import xml.etree.ElementTree as E; print(E.parse('$xml').getroot().attrib.get('lines-valid', '0'))")
+          if [ "${lines_valid}" = "0" ]; then
+            echo "::error::cobertura-coverage.xml is structurally empty (lines-valid=0)."
+            exit 1
+          fi
+          echo "cobertura-coverage.xml has lines-valid=${lines_valid}"
+
+      - name: Upload pulp-react coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: pulp-react-coverage-${{ github.sha }}
+          path: packages/pulp-react/coverage/cobertura-coverage.xml
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Upload pulp-react coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: packages/pulp-react/coverage/cobertura-coverage.xml
+          flags: pulp-react
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          verbose: true
+
   coverage-diff-gate:
     # Per-PR diff-coverage gate. REQUIRED — sub-threshold diff coverage
     # hard-fails the PR. The job still posts a summary comment so

--- a/.github/workflows/pulp-react-build.yml
+++ b/.github/workflows/pulp-react-build.yml
@@ -79,12 +79,12 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload pulp-react coverage to Codecov
-        # pulp #1886 Phase 1 — measure-only. Flag `pulp-react` lets
-        # Codecov slice the dashboard by SDK surface without changing
-        # the existing per-OS flag semantics on coverage.yml. No
-        # threshold enforcement here; Phase 2 will layer per-tier
-        # enforcement once a baseline is observed.
-        if: always()
+        # PR-only upload. Push-to-main uploads live in coverage.yml so
+        # Codecov's main branch record advances only from the canonical
+        # Coverage workflow, not from this independent path-filtered
+        # workflow when a native Coverage run was superseded before it
+        # could upload its OS legs.
+        if: always() && github.event_name == 'pull_request'
         uses: codecov/codecov-action@v5
         with:
           files: packages/pulp-react/coverage/cobertura-coverage.xml

--- a/docs/guides/coverage.md
+++ b/docs/guides/coverage.md
@@ -443,6 +443,11 @@ Today the intended represented surface is:
   `bindings/python/bindings.cpp` through the Linux coverage lane.
 - **Kotlin/Android** coverage for `android/app/src/main/kotlin/**`
   via the Coverage workflow's JaCoCo upload.
+- **@pulp/react** TypeScript/JS coverage for `packages/pulp-react/**`
+  via Vitest's Cobertura output. PR uploads come from
+  `pulp-react-build.yml`; push-to-main uploads are centralized in
+  `coverage.yml` so Codecov's `main` branch record advances with the
+  canonical Coverage workflow rather than a side upload.
 
 Still out of scope today:
 
@@ -485,6 +490,14 @@ workflow. It emits JaCoCo XML from Gradle and uploads that XML directly
 to Codecov so the `android` component sees JVM-only Kotlin coverage
 even though the native coverage matrix is Clang-specific. APK builds
 and emulator smoke stay in `.github/workflows/android.yml`.
+
+`@pulp/react` coverage also uploads from the Coverage workflow on
+push-to-main and manual dispatches. The path-filtered
+`.github/workflows/pulp-react-build.yml` workflow still builds, tests,
+and uploads Codecov data for PRs that touch `packages/pulp-react/**`;
+it deliberately does not upload to Codecov on `main`, so a cancelled or
+superseded native Coverage run cannot leave the public branch snapshot
+at a React-only commit with stale carried-forward native flags.
 
 Per-OS flags let the dashboard answer "what's covered on a specific
 OS." Per-subsystem components answer "how's a specific piece of the

--- a/tools/scripts/test_codecov_config.py
+++ b/tools/scripts/test_codecov_config.py
@@ -32,6 +32,8 @@ import yaml
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
 CODECOV = REPO_ROOT / "codecov.yml"
 CORE_DIR = REPO_ROOT / "core"
+COVERAGE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "coverage.yml"
+PULP_REACT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pulp-react-build.yml"
 
 
 EXPECTED_NON_CORE_COMPONENT_IDS = {
@@ -244,6 +246,24 @@ class CodecovYamlStructure(unittest.TestCase):
                     flag,
                     f"{flag_name} upload flag must not be path-scoped",
                 )
+
+    def test_pulp_react_main_upload_is_centralized_in_coverage_workflow(self):
+        coverage = COVERAGE_WORKFLOW.read_text(encoding="utf-8")
+        react = PULP_REACT_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("pulp-react-coverage:", coverage)
+        self.assertIn("name: Coverage report (@pulp/react, Vitest)", coverage)
+        self.assertIn("if: github.event_name != 'pull_request'", coverage)
+        self.assertIn("packages/pulp-react/coverage/cobertura-coverage.xml", coverage)
+        self.assertIn("flags: pulp-react", coverage)
+
+        self.assertIn(
+            "if: always() && github.event_name == 'pull_request'",
+            react,
+            "pulp-react-build.yml must not upload Codecov data on push/main; "
+            "main uploads belong to coverage.yml so cancelled native Coverage "
+            "runs cannot leave Codecov on a mixed React+stale-native snapshot.",
+        )
 
     def test_core_axes_use_canonical_directory_mappings(self):
         # Core subsystem ids come directly from core/* and should map to


### PR DESCRIPTION
## Summary
- move push-to-main @pulp/react Codecov upload into the canonical Coverage workflow
- keep pulp-react-build.yml Codecov uploads PR-only so side uploads cannot advance main when native Coverage is cancelled
- document the coverage shape and add a structural regression test

## Validation
- python3 tools/scripts/test_codecov_config.py
- python3 tools/scripts/docs_sync_check.py --mode=report --base origin/main
- python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main
- python3 tools/scripts/version_bump_check.py --mode=report --base origin/main --require-bump-for-fix-feat
- yamllint --no-warnings -d relaxed .github/workflows/coverage.yml .github/workflows/pulp-react-build.yml codecov.yml
- actionlint -shellcheck= .github/workflows/coverage.yml .github/workflows/pulp-react-build.yml
- npm ci && npm run build && npm run test:coverage (packages/pulp-react)