### PR TITLE
fix(host): complete custom node registry behavior

### DIFF
--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -146,10 +146,11 @@ predictable output, no MIDI.
   (`type_id`, `version`, port counts, default name, optional process
   callback), then instantiated with `add_custom_node(type_id)` or
   `add_custom_node(type_id, version)`. `GraphSerializer` resolves exact
-  `(type_id, version)` matches, preserves unresolved custom identities as
-  placeholder `NodeType::Custom` nodes, and reports them in
+  `(type_id, version)` matches with the saved port shape, preserves unresolved
+  custom identities as placeholder `NodeType::Custom` nodes, and reports them in
   `LoadResult::missing_custom_node_types`, so do not coerce unknown node
-  strings to a built-in type.
+  strings to a built-in type. Runtime callbacks are attached only when the
+  registered version and shape match the node.
 
 ## Common tripwires
 

--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -143,9 +143,11 @@ predictable output, no MIDI.
   `HostParamInfo::rate == AudioRate` params; do not route dense CV into
   stepped/read-only/control-rate parameters.
 - Custom graph nodes are registered per `SignalGraph` with `CustomNodeType`
-  (`type_id`, `version`, port counts, default name), then instantiated with
-  `add_custom_node(type_id)`. `GraphSerializer` preserves unresolved custom
-  identities as placeholder `NodeType::Custom` nodes and reports them in
+  (`type_id`, `version`, port counts, default name, optional process
+  callback), then instantiated with `add_custom_node(type_id)` or
+  `add_custom_node(type_id, version)`. `GraphSerializer` resolves exact
+  `(type_id, version)` matches, preserves unresolved custom identities as
+  placeholder `NodeType::Custom` nodes, and reports them in
   `LoadResult::missing_custom_node_types`, so do not coerce unknown node
   strings to a built-in type.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.182.0
+    VERSION 0.183.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -148,6 +148,10 @@ public:
     NodeId add_gain_node(const std::string& name = "Gain");
     NodeId add_midi_input_node(const std::string& name = "MIDI In");
     NodeId add_midi_output_node(const std::string& name = "MIDI Out");
+    // Registers or replaces a custom type. If existing nodes use the same
+    // `(type_id, version)`, the live snapshot is invalidated so prepare()
+    // can rebuild with the matching process callback. Shape mismatches keep
+    // placeholder passthrough semantics instead of attaching the callback.
     bool register_custom_node_type(CustomNodeType type);
     const CustomNodeType* custom_node_type(std::string_view type_id) const;
     const CustomNodeType* custom_node_type(std::string_view type_id,

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -18,6 +18,7 @@
 #include <pulp/audio/buffer.hpp>
 #include <pulp/midi/buffer.hpp>
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <vector>
 #include <unordered_map>
@@ -42,12 +43,17 @@ enum class NodeType {
 using NodeId = uint32_t;
 using PortIndex = uint32_t;
 
+using CustomNodeProcessFn = std::function<void(audio::BufferView<float>& output,
+                                              const audio::BufferView<const float>& input,
+                                              int num_samples)>;
+
 struct CustomNodeType {
     std::string type_id;
     int version = 1;
     int num_input_ports = 0;
     int num_output_ports = 0;
     std::string default_name;
+    CustomNodeProcessFn process;
 };
 
 // ── Connection ──────────────────────────────────────────────────────────
@@ -144,7 +150,12 @@ public:
     NodeId add_midi_output_node(const std::string& name = "MIDI Out");
     bool register_custom_node_type(CustomNodeType type);
     const CustomNodeType* custom_node_type(std::string_view type_id) const;
+    const CustomNodeType* custom_node_type(std::string_view type_id,
+                                           int version) const;
     NodeId add_custom_node(std::string_view type_id,
+                           const std::string& name = {});
+    NodeId add_custom_node(std::string_view type_id,
+                           int version,
                            const std::string& name = {});
     NodeId add_unresolved_custom_node(std::string_view type_id,
                                       int version,
@@ -271,6 +282,7 @@ private:
         // node processes, then zero before the next block.
         std::vector<float> input_data;
         std::vector<float*> input_ptrs;
+        std::vector<const float*> input_const_ptrs;
         float gain = 1.0f;
 
         // PDC: cumulative samples of latency from AudioInput to this node's
@@ -336,6 +348,7 @@ private:
         // pointers into an outer container.
         std::unordered_map<NodeId, NodeRuntime> runtime;
         std::unordered_map<NodeId, std::shared_ptr<PluginSlot>> plugins;
+        std::unordered_map<NodeId, CustomNodeProcessFn> custom_processors;
         struct NodeShape {
             NodeType type;
             int num_input_ports;

--- a/core/host/src/graph_serializer.cpp
+++ b/core/host/src/graph_serializer.cpp
@@ -464,12 +464,11 @@ GraphSerializer::LoadResult GraphSerializer::from_json(SignalGraph& graph, const
                             version = (int)cv["version"].getInt64();
                         }
                     }
-                    const auto* registered = graph.custom_node_type(type_id);
+                    const auto* registered = graph.custom_node_type(type_id, version);
                     if (registered
-                        && registered->version == version
                         && registered->num_input_ports == in_ch
                         && registered->num_output_ports == out_ch) {
-                        new_id = graph.add_custom_node(type_id, name);
+                        new_id = graph.add_custom_node(type_id, version, name);
                     } else {
                         result.missing_custom_node_types.push_back(
                             custom_type_label(type_id, version));

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -54,6 +54,13 @@ bool is_valid_custom_node_type(const CustomNodeType& type) {
         && type.num_output_ports >= 0;
 }
 
+std::string custom_node_key(std::string_view type_id, int version) {
+    std::string key(type_id);
+    key.push_back('\x1f');
+    key += std::to_string(version);
+    return key;
+}
+
 } // namespace
 
 NodeId SignalGraph::add_input_node(int channels, const std::string& name) {
@@ -169,13 +176,24 @@ NodeId SignalGraph::add_midi_output_node(const std::string& name) {
 bool SignalGraph::register_custom_node_type(CustomNodeType type) {
     if (!is_valid_custom_node_type(type)) return false;
     if (type.default_name.empty()) type.default_name = type.type_id;
-    const auto key = type.type_id;
+    const auto key = custom_node_key(type.type_id, type.version);
     custom_node_types_[key] = std::move(type);
     return true;
 }
 
 const CustomNodeType* SignalGraph::custom_node_type(std::string_view type_id) const {
-    auto it = custom_node_types_.find(std::string(type_id));
+    const CustomNodeType* latest = nullptr;
+    const std::string wanted(type_id);
+    for (const auto& [_, type] : custom_node_types_) {
+        if (type.type_id != wanted) continue;
+        if (!latest || type.version > latest->version) latest = &type;
+    }
+    return latest;
+}
+
+const CustomNodeType* SignalGraph::custom_node_type(std::string_view type_id,
+                                                    int version) const {
+    auto it = custom_node_types_.find(custom_node_key(type_id, version));
     if (it == custom_node_types_.end()) return nullptr;
     return &it->second;
 }
@@ -183,6 +201,14 @@ const CustomNodeType* SignalGraph::custom_node_type(std::string_view type_id) co
 NodeId SignalGraph::add_custom_node(std::string_view type_id,
                                     const std::string& name) {
     const auto* type = custom_node_type(type_id);
+    if (!type) return 0;
+    return add_custom_node(type_id, type->version, name);
+}
+
+NodeId SignalGraph::add_custom_node(std::string_view type_id,
+                                    int version,
+                                    const std::string& name) {
+    const auto* type = custom_node_type(type_id, version);
     if (!type) return 0;
     return add_unresolved_custom_node(
         type->type_id,
@@ -554,10 +580,13 @@ SignalGraph::compile_(double /*sample_rate*/, int max_block_size) {
         rt.input_data.assign(static_cast<size_t>(in_ch) * max_block_size, 0.f);
         rt.output_ptrs.resize(out_ch);
         rt.input_ptrs.resize(in_ch);
+        rt.input_const_ptrs.resize(in_ch);
         for (int c = 0; c < out_ch; ++c)
             rt.output_ptrs[c] = rt.output_data.data() + static_cast<size_t>(c) * max_block_size;
-        for (int c = 0; c < in_ch; ++c)
+        for (int c = 0; c < in_ch; ++c) {
             rt.input_ptrs[c] = rt.input_data.data() + static_cast<size_t>(c) * max_block_size;
+            rt.input_const_ptrs[c] = rt.input_ptrs[c];
+        }
         rt.gain = n.gain;  // copy UI-thread scalar into per-snapshot runtime
         if (n.plugin) {
             for (const auto& p : n.plugin->parameters()) {
@@ -574,6 +603,13 @@ SignalGraph::compile_(double /*sample_rate*/, int max_block_size) {
         cg->shapes[n.id] = shape;
 
         if (n.plugin) cg->plugins[n.id] = n.plugin;
+        if (n.type == NodeType::Custom) {
+            if (const auto* type = custom_node_type(n.custom_type_id,
+                                                    n.custom_type_version);
+                type && type->process) {
+                cg->custom_processors[n.id] = type->process;
+            }
+        }
     }
 
     for (const auto& c : cg->connections) {
@@ -994,7 +1030,18 @@ void SignalGraph::process(audio::BufferView<float>& output,
             case NodeType::MidiOutput:
                 break;
             case NodeType::Custom:
-                pass_through_or_zero(rt);
+                if (auto custom_it = cg->custom_processors.find(id);
+                    custom_it != cg->custom_processors.end()) {
+                    audio::BufferView<float> out_view(
+                        rt.output_ptrs.data(), rt.output_ptrs.size(),
+                        static_cast<std::size_t>(num_samples));
+                    audio::BufferView<const float> in_view(
+                        rt.input_const_ptrs.data(), rt.input_const_ptrs.size(),
+                        static_cast<std::size_t>(num_samples));
+                    custom_it->second(out_view, in_view, num_samples);
+                } else {
+                    pass_through_or_zero(rt);
+                }
                 break;
         }
     }

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -54,6 +54,12 @@ bool is_valid_custom_node_type(const CustomNodeType& type) {
         && type.num_output_ports >= 0;
 }
 
+bool custom_type_matches_node_shape(const CustomNodeType& type,
+                                    const GraphNode& node) {
+    return type.num_input_ports == node.num_input_ports
+        && type.num_output_ports == node.num_output_ports;
+}
+
 std::string custom_node_key(std::string_view type_id, int version) {
     std::string key(type_id);
     key.push_back('\x1f');
@@ -175,9 +181,16 @@ NodeId SignalGraph::add_midi_output_node(const std::string& name) {
 
 bool SignalGraph::register_custom_node_type(CustomNodeType type) {
     if (!is_valid_custom_node_type(type)) return false;
+    const bool affects_existing_nodes = std::any_of(
+        nodes_.begin(), nodes_.end(), [&](const GraphNode& node) {
+            return node.type == NodeType::Custom
+                && node.custom_type_id == type.type_id
+                && node.custom_type_version == type.version;
+        });
     if (type.default_name.empty()) type.default_name = type.type_id;
     const auto key = custom_node_key(type.type_id, type.version);
     custom_node_types_[key] = std::move(type);
+    if (affects_existing_nodes) invalidate_live_();
     return true;
 }
 
@@ -606,7 +619,8 @@ SignalGraph::compile_(double /*sample_rate*/, int max_block_size) {
         if (n.type == NodeType::Custom) {
             if (const auto* type = custom_node_type(n.custom_type_id,
                                                     n.custom_type_version);
-                type && type->process) {
+                type && type->process
+                && custom_type_matches_node_shape(*type, n)) {
                 cg->custom_processors[n.id] = type->process;
             }
         }

--- a/docs/reference/node-abi.md
+++ b/docs/reference/node-abi.md
@@ -51,7 +51,9 @@ field so both declaration styles behave the same.
 `CustomNodeType`. Register a type on the graph with a stable `type_id`, a
 positive integer `version`, its input/output port shape, and an optional
 process callback, then instantiate it with `add_custom_node(type_id)` or
-`add_custom_node(type_id, version)`.
+`add_custom_node(type_id, version)`. A callback is attached only when the
+registered `(type_id, version)` and port shape match the node; mismatched or
+unresolved nodes use placeholder passthrough behavior.
 
 The node type enum only appends `NodeType::Custom`; built-in enum values stay
 stable. Serialized graphs store the custom `type_id` and `version`, and loads

--- a/docs/reference/node-abi.md
+++ b/docs/reference/node-abi.md
@@ -49,10 +49,12 @@ field so both declaration styles behave the same.
 
 `SignalGraph` supports string-keyed custom host nodes through
 `CustomNodeType`. Register a type on the graph with a stable `type_id`, a
-positive integer `version`, and its input/output port shape, then instantiate
-it with `add_custom_node(type_id)`.
+positive integer `version`, its input/output port shape, and an optional
+process callback, then instantiate it with `add_custom_node(type_id)` or
+`add_custom_node(type_id, version)`.
 
 The node type enum only appends `NodeType::Custom`; built-in enum values stay
 stable. Serialized graphs store the custom `type_id` and `version`, and loads
 preserve that identity even when the target graph has not registered a matching
-factory.
+factory. Multiple versions of the same custom `type_id` can be registered at
+once; deserialization resolves by exact `(type_id, version)`.

--- a/docs/reference/signal-graph.md
+++ b/docs/reference/signal-graph.md
@@ -24,9 +24,9 @@ Custom node types are registered per graph with `CustomNodeType`
 process callback) before calling `add_custom_node(type_id)` or
 `add_custom_node(type_id, version)`. Graph serialization stores the custom
 `type_id` and `version` so a topology can be reloaded on another machine.
-If the target graph has not registered the exact matching version, the loader
-still creates a placeholder `Custom` node with the saved identity and port
-shape and reports the unresolved type in
+If the target graph has not registered the exact matching version and shape,
+the loader still creates a placeholder `Custom` node with the saved identity
+and port shape and reports the unresolved type in
 `LoadResult::missing_custom_node_types`.
 
 ## Connections
@@ -65,7 +65,8 @@ walks this vector once per block:
 1. Input nodes copy from the host buffer to their output port.
 2. Plugin nodes call `PluginSlot::process()` with their gathered inputs.
 3. Gain nodes multiply in place.
-4. Custom nodes run their registered process callback; unresolved nodes or
+4. Custom nodes run their registered process callback when the registered
+   version and shape match the node; unresolved, shape-mismatched, or
    metadata-only registrations pass audio inputs through to matching outputs.
 5. MIDI nodes route events the same way audio flows.
 6. Output nodes copy to the host buffer.

--- a/docs/reference/signal-graph.md
+++ b/docs/reference/signal-graph.md
@@ -20,12 +20,14 @@ Each node has a stable `NodeId` that survives connection edits. The graph
 owns the nodes; removing a node invalidates its id.
 
 Custom node types are registered per graph with `CustomNodeType`
-(`type_id`, `version`, input ports, output ports, default name) before
-calling `add_custom_node(type_id)`. Graph serialization stores the custom
+(`type_id`, `version`, input ports, output ports, default name, optional
+process callback) before calling `add_custom_node(type_id)` or
+`add_custom_node(type_id, version)`. Graph serialization stores the custom
 `type_id` and `version` so a topology can be reloaded on another machine.
-If the target graph has not registered the matching factory, the loader still
-creates a placeholder `Custom` node with the saved identity and port shape and
-reports the unresolved type in `LoadResult::missing_custom_node_types`.
+If the target graph has not registered the exact matching version, the loader
+still creates a placeholder `Custom` node with the saved identity and port
+shape and reports the unresolved type in
+`LoadResult::missing_custom_node_types`.
 
 ## Connections
 
@@ -63,8 +65,8 @@ walks this vector once per block:
 1. Input nodes copy from the host buffer to their output port.
 2. Plugin nodes call `PluginSlot::process()` with their gathered inputs.
 3. Gain nodes multiply in place.
-4. Custom nodes pass audio inputs through to matching output ports unless a
-   future registered implementation gives them behavior.
+4. Custom nodes run their registered process callback; unresolved nodes or
+   metadata-only registrations pass audio inputs through to matching outputs.
 5. MIDI nodes route events the same way audio flows.
 6. Output nodes copy to the host buffer.
 

--- a/test/test_graph_serializer.cpp
+++ b/test/test_graph_serializer.cpp
@@ -111,6 +111,20 @@ bool missing_custom_types_contain(const GraphSerializer::LoadResult& result,
     return false;
 }
 
+CustomNodeType make_custom_node_type(std::string type_id,
+                                     int version,
+                                     int inputs,
+                                     int outputs,
+                                     std::string name) {
+    CustomNodeType type;
+    type.type_id = std::move(type_id);
+    type.version = version;
+    type.num_input_ports = inputs;
+    type.num_output_ports = outputs;
+    type.default_name = std::move(name);
+    return type;
+}
+
 } // namespace
 
 TEST_CASE("GraphSerializer round-trips an empty graph", "[host][serializer]") {
@@ -571,8 +585,8 @@ TEST_CASE("GraphSerializer decodes fallback wire values deterministically",
 TEST_CASE("GraphSerializer round-trips registered custom node identity",
           "[host][serializer][node-abi]") {
     SignalGraph src;
-    REQUIRE(src.register_custom_node_type(
-        {"pulp.test.custom-filter", 2, 1, 1, "Custom Filter"}));
+    REQUIRE(src.register_custom_node_type(make_custom_node_type(
+        "pulp.test.custom-filter", 2, 1, 1, "Custom Filter")));
     auto input = src.add_input_node(1, "Input");
     auto custom = src.add_custom_node("pulp.test.custom-filter", "Filter A");
     auto output = src.add_output_node(1, "Output");
@@ -587,8 +601,8 @@ TEST_CASE("GraphSerializer round-trips registered custom node identity",
     REQUIRE(json.find("\"version\": 2") != std::string::npos);
 
     SignalGraph dst;
-    REQUIRE(dst.register_custom_node_type(
-        {"pulp.test.custom-filter", 2, 1, 1, "Custom Filter"}));
+    REQUIRE(dst.register_custom_node_type(make_custom_node_type(
+        "pulp.test.custom-filter", 2, 1, 1, "Custom Filter")));
     auto result = GraphSerializer::from_json(dst, json);
     REQUIRE(result.ok);
     REQUIRE(result.missing_custom_node_types.empty());
@@ -611,28 +625,75 @@ TEST_CASE("GraphSerializer round-trips registered custom node identity",
 TEST_CASE("GraphSerializer preserves unresolved custom node identity",
           "[host][serializer][node-abi]") {
     SignalGraph src;
+    auto input = src.add_input_node(1, "Input");
     auto custom = src.add_unresolved_custom_node(
         "pulp.test.future-node", 4, 2, 1, "Future Node");
+    auto output = src.add_output_node(1, "Output");
+    REQUIRE(input != 0);
     REQUIRE(custom != 0);
+    REQUIRE(output != 0);
+    REQUIRE(src.connect(input, 0, custom, 0));
+    REQUIRE(src.connect(custom, 0, output, 0));
 
     const auto json = GraphSerializer::to_json(src);
     SignalGraph dst;
     auto result = GraphSerializer::from_json(dst, json);
     REQUIRE(result.ok);
     REQUIRE(missing_custom_types_contain(result, "pulp.test.future-node@4"));
-    REQUIRE(dst.nodes().size() == 1);
+    REQUIRE(dst.nodes().size() == 3);
+    REQUIRE(dst.connections().size() == 2);
 
-    const auto& node = dst.nodes().front();
-    REQUIRE(node.type == NodeType::Custom);
-    REQUIRE(node.custom_type_id == "pulp.test.future-node");
-    REQUIRE(node.custom_type_version == 4);
-    REQUIRE(node.num_input_ports == 2);
-    REQUIRE(node.num_output_ports == 1);
+    bool saw_custom = false;
+    for (const auto& node : dst.nodes()) {
+        if (node.type != NodeType::Custom) continue;
+        saw_custom = true;
+        REQUIRE(node.custom_type_id == "pulp.test.future-node");
+        REQUIRE(node.custom_type_version == 4);
+        REQUIRE(node.num_input_ports == 2);
+        REQUIRE(node.num_output_ports == 1);
+    }
+    REQUIRE(saw_custom);
+
+    REQUIRE(dst.prepare(48000.0, 4));
+    float in_samples[4] = {0.25f, 0.5f, 0.75f, 1.0f};
+    float out_samples[4] = {-1.0f, -1.0f, -1.0f, -1.0f};
+    const float* in_ptrs[1] = {in_samples};
+    float* out_ptrs[1] = {out_samples};
+    pulp::audio::BufferView<const float> in_view(in_ptrs, 1, 4);
+    pulp::audio::BufferView<float> out_view(out_ptrs, 1, 4);
+    dst.process(out_view, in_view, 4);
+    for (int i = 0; i < 4; ++i) REQUIRE(out_samples[i] == in_samples[i]);
 
     const auto second_json = GraphSerializer::to_json(dst);
     REQUIRE(second_json.find("\"type_id\": \"pulp.test.future-node\"") !=
             std::string::npos);
     REQUIRE(second_json.find("\"version\": 4") != std::string::npos);
+    REQUIRE(second_json.find("\"source_node\"") != std::string::npos);
+}
+
+TEST_CASE("GraphSerializer resolves custom nodes by exact registry version",
+          "[host][serializer][node-abi]") {
+    SignalGraph src;
+    REQUIRE(src.register_custom_node_type(make_custom_node_type(
+        "pulp.test.versioned-node", 1, 1, 1, "Version 1")));
+    auto custom = src.add_custom_node("pulp.test.versioned-node", 1, "Old Node");
+    REQUIRE(custom != 0);
+
+    const auto json = GraphSerializer::to_json(src);
+
+    SignalGraph dst;
+    REQUIRE(dst.register_custom_node_type(make_custom_node_type(
+        "pulp.test.versioned-node", 1, 1, 1, "Version 1")));
+    REQUIRE(dst.register_custom_node_type(make_custom_node_type(
+        "pulp.test.versioned-node", 2, 2, 2, "Version 2")));
+    auto result = GraphSerializer::from_json(dst, json);
+    REQUIRE(result.ok);
+    REQUIRE(result.missing_custom_node_types.empty());
+    REQUIRE(dst.nodes().size() == 1);
+    REQUIRE(dst.nodes().front().type == NodeType::Custom);
+    REQUIRE(dst.nodes().front().custom_type_version == 1);
+    REQUIRE(dst.nodes().front().num_input_ports == 1);
+    REQUIRE(dst.nodes().front().num_output_ports == 1);
 }
 
 TEST_CASE("GraphSerializer serializes plugin formats and state blobs",

--- a/test/test_host.cpp
+++ b/test/test_host.cpp
@@ -593,6 +593,95 @@ TEST_CASE("SignalGraph custom node registry keeps versions distinct",
     REQUIRE(graph.node(node_v2)->num_input_ports == 2);
 }
 
+TEST_CASE("SignalGraph custom node processors require matching shapes",
+          "[host][graph][node-abi]") {
+    SignalGraph graph;
+    auto input = graph.add_input_node(1, "Input");
+    auto custom = graph.add_unresolved_custom_node(
+        "pulp.test.shape-guard", 1, 1, 1, "Shape Guard");
+    auto output = graph.add_output_node(1, "Output");
+    REQUIRE(custom != 0);
+    REQUIRE(graph.connect(input, 0, custom, 0));
+    REQUIRE(graph.connect(custom, 0, output, 0));
+
+    bool callback_called = false;
+    CustomNodeType mismatched_type;
+    mismatched_type.type_id = "pulp.test.shape-guard";
+    mismatched_type.version = 1;
+    mismatched_type.num_input_ports = 2;
+    mismatched_type.num_output_ports = 1;
+    mismatched_type.default_name = "Shape Guard";
+    mismatched_type.process =
+        [&callback_called](pulp::audio::BufferView<float>& output,
+                           const pulp::audio::BufferView<const float>&,
+                           int num_samples) {
+            callback_called = true;
+            for (int i = 0; i < num_samples; ++i) {
+                output.channel_ptr(0)[i] = 99.0f;
+            }
+        };
+    REQUIRE(graph.register_custom_node_type(std::move(mismatched_type)));
+    REQUIRE(graph.prepare(48000.0, 4));
+
+    float in_samples[4] = {0.25f, 0.5f, 0.75f, 1.0f};
+    float out_samples[4] = {-1.0f, -1.0f, -1.0f, -1.0f};
+    const float* in_ptrs[1] = {in_samples};
+    float* out_ptrs[1] = {out_samples};
+    pulp::audio::BufferView<const float> in_view(in_ptrs, 1, 4);
+    pulp::audio::BufferView<float> out_view(out_ptrs, 1, 4);
+    graph.process(out_view, in_view, 4);
+
+    REQUIRE_FALSE(callback_called);
+    for (int i = 0; i < 4; ++i) REQUIRE(out_samples[i] == in_samples[i]);
+}
+
+TEST_CASE("SignalGraph custom node registrations invalidate matching snapshots",
+          "[host][graph][node-abi]") {
+    SignalGraph graph;
+    auto input = graph.add_input_node(1, "Input");
+    auto custom = graph.add_unresolved_custom_node(
+        "pulp.test.live-registration", 1, 1, 1, "Live Registration");
+    auto output = graph.add_output_node(1, "Output");
+    REQUIRE(custom != 0);
+    REQUIRE(graph.connect(input, 0, custom, 0));
+    REQUIRE(graph.connect(custom, 0, output, 0));
+    REQUIRE(graph.prepare(48000.0, 4));
+
+    float in_samples[4] = {0.25f, 0.5f, 0.75f, 1.0f};
+    float out_samples[4] = {-1.0f, -1.0f, -1.0f, -1.0f};
+    const float* in_ptrs[1] = {in_samples};
+    float* out_ptrs[1] = {out_samples};
+    pulp::audio::BufferView<const float> in_view(in_ptrs, 1, 4);
+    pulp::audio::BufferView<float> out_view(out_ptrs, 1, 4);
+
+    graph.process(out_view, in_view, 4);
+    for (int i = 0; i < 4; ++i) REQUIRE(out_samples[i] == in_samples[i]);
+
+    CustomNodeType registered_type;
+    registered_type.type_id = "pulp.test.live-registration";
+    registered_type.version = 1;
+    registered_type.num_input_ports = 1;
+    registered_type.num_output_ports = 1;
+    registered_type.default_name = "Live Registration";
+    registered_type.process = [](pulp::audio::BufferView<float>& output,
+                                 const pulp::audio::BufferView<const float>& input,
+                                 int num_samples) {
+        for (int i = 0; i < num_samples; ++i) {
+            output.channel_ptr(0)[i] = input.channel_ptr(0)[i] * 3.0f;
+        }
+    };
+    REQUIRE(graph.register_custom_node_type(std::move(registered_type)));
+
+    std::fill(out_samples, out_samples + 4, -1.0f);
+    graph.process(out_view, in_view, 4);
+    for (float sample : out_samples) REQUIRE(sample == 0.0f);
+
+    REQUIRE(graph.prepare(48000.0, 4));
+    std::fill(out_samples, out_samples + 4, -1.0f);
+    graph.process(out_view, in_view, 4);
+    for (int i = 0; i < 4; ++i) REQUIRE(out_samples[i] == in_samples[i] * 3.0f);
+}
+
 TEST_CASE("SignalGraph remove_node prunes edges and invalidates live graph",
           "[host][graph][coverage][phase3]") {
     SignalGraph graph;

--- a/test/test_host.cpp
+++ b/test/test_host.cpp
@@ -12,6 +12,7 @@
 #include <future>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 using namespace pulp::host;
@@ -495,12 +496,36 @@ TEST_CASE("SignalGraph add and remove nodes", "[host][graph]") {
 TEST_CASE("SignalGraph registers and processes custom nodes",
           "[host][graph][node-abi]") {
     SignalGraph graph;
-    REQUIRE_FALSE(graph.register_custom_node_type({"", 1, 1, 1, "Bad"}));
-    REQUIRE_FALSE(graph.register_custom_node_type({"pulp.test.bad", 0, 1, 1, "Bad"}));
+    CustomNodeType empty_type;
+    empty_type.version = 1;
+    empty_type.num_input_ports = 1;
+    empty_type.num_output_ports = 1;
+    empty_type.default_name = "Bad";
+    REQUIRE_FALSE(graph.register_custom_node_type(empty_type));
+
+    CustomNodeType zero_version_type;
+    zero_version_type.type_id = "pulp.test.bad";
+    zero_version_type.version = 0;
+    zero_version_type.num_input_ports = 1;
+    zero_version_type.num_output_ports = 1;
+    zero_version_type.default_name = "Bad";
+    REQUIRE_FALSE(graph.register_custom_node_type(zero_version_type));
     REQUIRE_FALSE(graph.add_custom_node("pulp.test.custom"));
 
-    REQUIRE(graph.register_custom_node_type(
-        {"pulp.test.custom", 3, 1, 1, "Custom"}));
+    CustomNodeType custom_type;
+    custom_type.type_id = "pulp.test.custom";
+    custom_type.version = 3;
+    custom_type.num_input_ports = 1;
+    custom_type.num_output_ports = 1;
+    custom_type.default_name = "Custom";
+    custom_type.process = [](pulp::audio::BufferView<float>& output,
+                             const pulp::audio::BufferView<const float>& input,
+                             int num_samples) {
+        for (int i = 0; i < num_samples; ++i) {
+            output.channel_ptr(0)[i] = input.channel_ptr(0)[i] * 2.0f;
+        }
+    };
+    REQUIRE(graph.register_custom_node_type(std::move(custom_type)));
     auto input = graph.add_input_node(1, "Input");
     auto custom = graph.add_custom_node("pulp.test.custom", "Custom A");
     auto output = graph.add_output_node(1, "Output");
@@ -525,7 +550,47 @@ TEST_CASE("SignalGraph registers and processes custom nodes",
     pulp::audio::BufferView<const float> in_view(in_ptrs, 1, 4);
     pulp::audio::BufferView<float> out_view(out_ptrs, 1, 4);
     graph.process(out_view, in_view, 4);
-    for (int i = 0; i < 4; ++i) REQUIRE(out_samples[i] == in_samples[i]);
+    for (int i = 0; i < 4; ++i) REQUIRE(out_samples[i] == in_samples[i] * 2.0f);
+}
+
+TEST_CASE("SignalGraph custom node registry keeps versions distinct",
+          "[host][graph][node-abi]") {
+    SignalGraph graph;
+
+    CustomNodeType v1_type;
+    v1_type.type_id = "pulp.test.versioned";
+    v1_type.version = 1;
+    v1_type.num_input_ports = 1;
+    v1_type.num_output_ports = 1;
+    v1_type.default_name = "Version 1";
+    REQUIRE(graph.register_custom_node_type(v1_type));
+
+    CustomNodeType v2_type;
+    v2_type.type_id = "pulp.test.versioned";
+    v2_type.version = 2;
+    v2_type.num_input_ports = 2;
+    v2_type.num_output_ports = 2;
+    v2_type.default_name = "Version 2";
+    REQUIRE(graph.register_custom_node_type(v2_type));
+
+    const auto* v1 = graph.custom_node_type("pulp.test.versioned", 1);
+    const auto* v2 = graph.custom_node_type("pulp.test.versioned", 2);
+    const auto* latest = graph.custom_node_type("pulp.test.versioned");
+    REQUIRE(v1 != nullptr);
+    REQUIRE(v2 != nullptr);
+    REQUIRE(latest != nullptr);
+    REQUIRE(v1->version == 1);
+    REQUIRE(v2->version == 2);
+    REQUIRE(latest->version == 2);
+
+    auto node_v1 = graph.add_custom_node("pulp.test.versioned", 1, "Old Shape");
+    auto node_v2 = graph.add_custom_node("pulp.test.versioned", 2, "New Shape");
+    REQUIRE(node_v1 != 0);
+    REQUIRE(node_v2 != 0);
+    REQUIRE(graph.node(node_v1)->custom_type_version == 1);
+    REQUIRE(graph.node(node_v1)->num_input_ports == 1);
+    REQUIRE(graph.node(node_v2)->custom_type_version == 2);
+    REQUIRE(graph.node(node_v2)->num_input_ports == 2);
 }
 
 TEST_CASE("SignalGraph remove_node prunes edges and invalidates live graph",


### PR DESCRIPTION
Follow-up to #2566 for Phase 6 node-type extensibility. Adds actual custom-node process callbacks, exact (type_id, version) registry lookup, and tests that unresolved custom-node topology round-trips without losing connections.