### PR TITLE
refactor(design-tool): wrap imperative build code in ordered functions (P8-NEW prep)

### DIFF
--- a/examples/design-tool/design-tool.js
+++ b/examples/design-tool/design-tool.js
@@ -2,16 +2,22 @@
 // Reference: ~/Code/ai-style-designer/Tools/theme-designer.html
 // Hot-reloadable: edit and save to see changes instantly.
 
-setTheme("dark");
+function bootstrapTheme() {
+    setTheme("dark");
+}
+bootstrapTheme();
 
 // Wrap __requestFrame__ to use the callback registry pattern
 // (C++ can't receive JS functions directly — use ID-based dispatch)
 var __origRequestFrame__ = __requestFrame__;
-__requestFrame__ = function(fn) {
-    var id = __frameNextId__++;
-    __frameCallbacks__[id] = fn;
-    return __origRequestFrame__(id);
-};
+function installFrameCallbackShim() {
+    __requestFrame__ = function(fn) {
+        var id = __frameNextId__++;
+        __frameCallbacks__[id] = fn;
+        return __origRequestFrame__(id);
+    };
+}
+installFrameCallbackShim();
 
 // ═══════════════════════════════════════════════════════════════════
 // Color/palette/app state
@@ -462,22 +468,25 @@ function refreshPreviewLayoutSection() {
 // ═══════════════════════════════════════════════════════════════════
 // Root: vertical column (toolbar → main → status bar)
 // ═══════════════════════════════════════════════════════════════════
-setFlex("", "direction", "col");
-setFlex("", "gap", 0);
-setBackground("", APP_BG);
+function buildRootShell() {
+    setFlex("", "direction", "col");
+    setFlex("", "gap", 0);
+    setBackground("", APP_BG);
 
-// ═══════════════════════════════════════════════════════════════════
-// TOOLBAR (44px, full width, space-between)
-// ═══════════════════════════════════════════════════════════════════
-createRow("toolbar");
-setFlex("toolbar", "height", 44);
-setFlex("toolbar", "flex_shrink", 0);
-setFlex("toolbar", "gap", 8);
-setFlex("toolbar", "padding_left", 12);
-setFlex("toolbar", "padding_right", 12);
-setFlex("toolbar", "align_items", "center");
-setBackground("toolbar", APP_SURFACE);
-setBorder("toolbar", APP_BORDER, 1, 0);
+    // ═══════════════════════════════════════════════════════════════════
+    // TOOLBAR (44px, full width, space-between)
+    // ═══════════════════════════════════════════════════════════════════
+    createRow("toolbar");
+    setFlex("toolbar", "height", 44);
+    setFlex("toolbar", "flex_shrink", 0);
+    setFlex("toolbar", "gap", 8);
+    setFlex("toolbar", "padding_left", 12);
+    setFlex("toolbar", "padding_right", 12);
+    setFlex("toolbar", "align_items", "center");
+    setBackground("toolbar", APP_SURFACE);
+    setBorder("toolbar", APP_BORDER, 1, 0);
+}
+buildRootShell();
 
 function createToolbarSeparator(id) {
     createCol(id, "toolbar");
@@ -487,93 +496,102 @@ function createToolbarSeparator(id) {
     setBackground(id, APP_BORDER);
 }
 
-createRow("toolbar-title-group", "toolbar");
-setFlex("toolbar-title-group", "height", 28);
-setFlex("toolbar-title-group", "align_items", "center");
-setFlex("toolbar-title-group", "flex_shrink", 0);
+function buildToolbarTitleAndPreset() {
+    createRow("toolbar-title-group", "toolbar");
+    setFlex("toolbar-title-group", "height", 28);
+    setFlex("toolbar-title-group", "align_items", "center");
+    setFlex("toolbar-title-group", "flex_shrink", 0);
 
-createLabel("theme-name-label", "Default Dark", "toolbar-title-group");
-setFontSize("theme-name-label", 12);
-setFlex("theme-name-label", "width", 132);
-setFlex("theme-name-label", "flex_shrink", 0);
-setFlex("theme-name-label", "height", 26);
-setTextOverflow("theme-name-label", "ellipsis");
+    createLabel("theme-name-label", "Default Dark", "toolbar-title-group");
+    setFontSize("theme-name-label", 12);
+    setFlex("theme-name-label", "width", 132);
+    setFlex("theme-name-label", "flex_shrink", 0);
+    setFlex("theme-name-label", "height", 26);
+    setTextOverflow("theme-name-label", "ellipsis");
 
-createToolbarSeparator("toolbar-sep-1");
+    createToolbarSeparator("toolbar-sep-1");
 
-createRow("toolbar-preset-group", "toolbar");
-setFlex("toolbar-preset-group", "height", 28);
-setFlex("toolbar-preset-group", "align_items", "center");
-setFlex("toolbar-preset-group", "gap", 6);
-setFlex("toolbar-preset-group", "flex_shrink", 0);
+    createRow("toolbar-preset-group", "toolbar");
+    setFlex("toolbar-preset-group", "height", 28);
+    setFlex("toolbar-preset-group", "align_items", "center");
+    setFlex("toolbar-preset-group", "gap", 6);
+    setFlex("toolbar-preset-group", "flex_shrink", 0);
 
-createLabel("toolbar-preset-label", "Preset", "toolbar-preset-group");
-setFontSize("toolbar-preset-label", 10);
-setTextColor("toolbar-preset-label", APP_TEXT_DIM);
-setFlex("toolbar-preset-label", "width", 34);
-setFlex("toolbar-preset-label", "height", 14);
-setFlex("toolbar-preset-label", "flex_shrink", 0);
+    createLabel("toolbar-preset-label", "Preset", "toolbar-preset-group");
+    setFontSize("toolbar-preset-label", 10);
+    setTextColor("toolbar-preset-label", APP_TEXT_DIM);
+    setFlex("toolbar-preset-label", "width", 34);
+    setFlex("toolbar-preset-label", "height", 14);
+    setFlex("toolbar-preset-label", "flex_shrink", 0);
 
-createCombo("preset-selector", "toolbar-preset-group");
-setItems("preset-selector", ["Default Dark", "Light", "Pro Audio", "Violet", "Amber", "Ocean", "Neon"]);
-setFlex("preset-selector", "width", 118);
-setFlex("preset-selector", "height", 26);
-setFlex("preset-selector", "flex_shrink", 0);
+    createCombo("preset-selector", "toolbar-preset-group");
+    setItems("preset-selector", ["Default Dark", "Light", "Pro Audio", "Violet", "Amber", "Ocean", "Neon"]);
+    setFlex("preset-selector", "width", 118);
+    setFlex("preset-selector", "height", 26);
+    setFlex("preset-selector", "flex_shrink", 0);
 
-createToolbarSeparator("toolbar-sep-2");
+    createToolbarSeparator("toolbar-sep-2");
+}
+buildToolbarTitleAndPreset();
 
 // State scrubber pills
 var stateNames = ["Default", "Hover", "Focus", "Disabled", "Error"];
 var activeState = 0;
-createRow("toolbar-state-group", "toolbar");
-setFlex("toolbar-state-group", "height", 28);
-setFlex("toolbar-state-group", "align_items", "center");
-setFlex("toolbar-state-group", "flex_shrink", 0);
+function buildToolbarStateGroup() {
+    createRow("toolbar-state-group", "toolbar");
+    setFlex("toolbar-state-group", "height", 28);
+    setFlex("toolbar-state-group", "align_items", "center");
+    setFlex("toolbar-state-group", "flex_shrink", 0);
 
-createRow("state-pills", "toolbar-state-group");
-setFlex("state-pills", "height", 26);
-setFlex("state-pills", "width", 316);
-setFlex("state-pills", "flex_shrink", 0);
-setFlex("state-pills", "gap", 2);
-setFlex("state-pills", "align_items", "center");
-setFlex("state-pills", "padding_left", 2);
-setFlex("state-pills", "padding_right", 2);
-setBackground("state-pills", APP_PANEL);
-setBorder("state-pills", APP_BORDER, 1, 6);
+    createRow("state-pills", "toolbar-state-group");
+    setFlex("state-pills", "height", 26);
+    setFlex("state-pills", "width", 316);
+    setFlex("state-pills", "flex_shrink", 0);
+    setFlex("state-pills", "gap", 2);
+    setFlex("state-pills", "align_items", "center");
+    setFlex("state-pills", "padding_left", 2);
+    setFlex("state-pills", "padding_right", 2);
+    setBackground("state-pills", APP_PANEL);
+    setBorder("state-pills", APP_BORDER, 1, 6);
+}
+buildToolbarStateGroup();
 
 var stateWidths = [64, 56, 56, 76, 54];
-for (var sp = 0; sp < stateNames.length; sp++) {
-    var spId = "state-pill-" + sp;
-    createCol(spId, "state-pills");
-    setFlex(spId, "height", 20);
-    setFlex(spId, "width", stateWidths[sp]);
-    setFlex(spId, "flex_shrink", 0);
-    setFlex(spId, "justify_content", "center");
-    setFlex(spId, "align_items", "center");
-    if (sp === 0) {
-        setBackground(spId, '#2a2040');
+function buildToolbarStatePills() {
+    for (var sp = 0; sp < stateNames.length; sp++) {
+        var spId = "state-pill-" + sp;
+        createCol(spId, "state-pills");
+        setFlex(spId, "height", 20);
+        setFlex(spId, "width", stateWidths[sp]);
+        setFlex(spId, "flex_shrink", 0);
+        setFlex(spId, "justify_content", "center");
+        setFlex(spId, "align_items", "center");
+        if (sp === 0) {
+            setBackground(spId, '#2a2040');
+        }
+        setBorder(spId, "transparent", 0, 4);
+        createLabel(spId + "-lbl", stateNames[sp], spId);
+        setFontSize(spId + "-lbl", 10);
+        setTextColor(spId + "-lbl", sp === 0 ? APP_ACCENT : APP_TEXT_DIM);
+        setPointerEvents(spId + "-lbl", "none");
+        registerClick(spId);
+        (function(idx) {
+            on("state-pill-" + idx, "click", function() {
+                // Update pill visuals
+                for (var si = 0; si < stateNames.length; si++) {
+                    setBackground("state-pill-" + si, si === idx ? '#2a2040' : 'transparent');
+                    setBorder("state-pill-" + si, "transparent", 0, 4);
+                    setTextColor("state-pill-" + si + "-lbl", si === idx ? APP_ACCENT : APP_TEXT_DIM);
+                }
+                activeState = idx;
+                setText("status-text", "State: " + stateNames[idx]);
+                // #50: Apply state overrides to preview components
+                applyStateToPreview(idx);
+            });
+        })(sp);
     }
-    setBorder(spId, "transparent", 0, 4);
-    createLabel(spId + "-lbl", stateNames[sp], spId);
-    setFontSize(spId + "-lbl", 10);
-    setTextColor(spId + "-lbl", sp === 0 ? APP_ACCENT : APP_TEXT_DIM);
-    setPointerEvents(spId + "-lbl", "none");
-    registerClick(spId);
-    (function(idx) {
-        on("state-pill-" + idx, "click", function() {
-            // Update pill visuals
-            for (var si = 0; si < stateNames.length; si++) {
-                setBackground("state-pill-" + si, si === idx ? '#2a2040' : 'transparent');
-                setBorder("state-pill-" + si, "transparent", 0, 4);
-                setTextColor("state-pill-" + si + "-lbl", si === idx ? APP_ACCENT : APP_TEXT_DIM);
-            }
-            activeState = idx;
-            setText("status-text", "State: " + stateNames[idx]);
-            // #50: Apply state overrides to preview components
-            applyStateToPreview(idx);
-        });
-    })(sp);
 }
+buildToolbarStatePills();
 
 // #50: Apply state overrides to preview components
 function applyStateToPreview(stateIdx) {
@@ -690,22 +708,25 @@ function applyStateToPreview(stateIdx) {
 }
 
 // Spacer
-createCol("toolbar-spacer", "toolbar");
-setFlex("toolbar-spacer", "flex_grow", 1);
+function buildToolbarSpacerAndGroups() {
+    createCol("toolbar-spacer", "toolbar");
+    setFlex("toolbar-spacer", "flex_grow", 1);
 
-createRow("toolbar-history-group", "toolbar");
-setFlex("toolbar-history-group", "height", 28);
-setFlex("toolbar-history-group", "align_items", "center");
-setFlex("toolbar-history-group", "gap", 8);
-setFlex("toolbar-history-group", "flex_shrink", 0);
+    createRow("toolbar-history-group", "toolbar");
+    setFlex("toolbar-history-group", "height", 28);
+    setFlex("toolbar-history-group", "align_items", "center");
+    setFlex("toolbar-history-group", "gap", 8);
+    setFlex("toolbar-history-group", "flex_shrink", 0);
 
-createToolbarSeparator("toolbar-sep-3");
+    createToolbarSeparator("toolbar-sep-3");
 
-createRow("toolbar-file-group", "toolbar");
-setFlex("toolbar-file-group", "height", 28);
-setFlex("toolbar-file-group", "align_items", "center");
-setFlex("toolbar-file-group", "gap", 8);
-setFlex("toolbar-file-group", "flex_shrink", 0);
+    createRow("toolbar-file-group", "toolbar");
+    setFlex("toolbar-file-group", "height", 28);
+    setFlex("toolbar-file-group", "align_items", "center");
+    setFlex("toolbar-file-group", "gap", 8);
+    setFlex("toolbar-file-group", "flex_shrink", 0);
+}
+buildToolbarSpacerAndGroups();
 
 // Toolbar action buttons with pill styling
 var toolbarBtns = [
@@ -714,227 +735,230 @@ var toolbarBtns = [
     { id: "import-btn", label: "Import", width: 88, group: "toolbar-file-group" },
     { id: "export-btn", label: "Export", width: 94, group: "toolbar-file-group", accent: true }
 ];
-for (var tb = 0; tb < toolbarBtns.length; tb++) {
-    var btn = toolbarBtns[tb];
-    createCol(btn.id + "-pill", btn.group);
-    setFlex(btn.id + "-pill", "width", btn.width);
-    setFlex(btn.id + "-pill", "height", 26);
-    setFlex(btn.id + "-pill", "flex_shrink", 0);
-    setFlex(btn.id + "-pill", "padding_left", 8);
-    setFlex(btn.id + "-pill", "padding_right", 8);
-    setFlex(btn.id + "-pill", "justify_content", "center");
-    setFlex(btn.id + "-pill", "align_items", "center");
-    setBackground(btn.id + "-pill", btn.accent ? APP_ACCENT : APP_PANEL);
-    setBorder(btn.id + "-pill", btn.accent ? APP_ACCENT : APP_BORDER, 1, 6);
+function buildToolbarActionsAndLeftPanelControls() {
+    for (var tb = 0; tb < toolbarBtns.length; tb++) {
+        var btn = toolbarBtns[tb];
+        createCol(btn.id + "-pill", btn.group);
+        setFlex(btn.id + "-pill", "width", btn.width);
+        setFlex(btn.id + "-pill", "height", 26);
+        setFlex(btn.id + "-pill", "flex_shrink", 0);
+        setFlex(btn.id + "-pill", "padding_left", 8);
+        setFlex(btn.id + "-pill", "padding_right", 8);
+        setFlex(btn.id + "-pill", "justify_content", "center");
+        setFlex(btn.id + "-pill", "align_items", "center");
+        setBackground(btn.id + "-pill", btn.accent ? APP_ACCENT : APP_PANEL);
+        setBorder(btn.id + "-pill", btn.accent ? APP_ACCENT : APP_BORDER, 1, 6);
 
-    createLabel(btn.id, btn.label, btn.id + "-pill");
-    setFontSize(btn.id, 10);
-    setTextColor(btn.id, btn.accent ? "#ffffff" : APP_TEXT_DIM);
-    setPointerEvents(btn.id, "none");
+        createLabel(btn.id, btn.label, btn.id + "-pill");
+        setFontSize(btn.id, 10);
+        setTextColor(btn.id, btn.accent ? "#ffffff" : APP_TEXT_DIM);
+        setPointerEvents(btn.id, "none");
+    }
+
+    registerHover("undo-btn-pill");
+    registerHover("redo-btn-pill");
+    registerHover("import-btn-pill");
+    registerHover("export-btn-pill");
+    on("undo-btn-pill", "mouseenter", function() { setBorder("undo-btn-pill", APP_ACCENT, 1, 6); setBackground("undo-btn-pill", APP_PANEL_RAISED); setTextColor("undo-btn", APP_TEXT); });
+    on("undo-btn-pill", "mouseleave", function() { setBorder("undo-btn-pill", APP_BORDER, 1, 6); setBackground("undo-btn-pill", APP_PANEL); setTextColor("undo-btn", APP_TEXT_DIM); });
+    on("redo-btn-pill", "mouseenter", function() { setBorder("redo-btn-pill", APP_ACCENT, 1, 6); setBackground("redo-btn-pill", APP_PANEL_RAISED); setTextColor("redo-btn", APP_TEXT); });
+    on("redo-btn-pill", "mouseleave", function() { setBorder("redo-btn-pill", APP_BORDER, 1, 6); setBackground("redo-btn-pill", APP_PANEL); setTextColor("redo-btn", APP_TEXT_DIM); });
+    on("import-btn-pill", "mouseenter", function() { setBorder("import-btn-pill", APP_ACCENT, 1, 6); setBackground("import-btn-pill", APP_PANEL_RAISED); setTextColor("import-btn", APP_TEXT); });
+    on("import-btn-pill", "mouseleave", function() { setBorder("import-btn-pill", APP_BORDER, 1, 6); setBackground("import-btn-pill", APP_PANEL); setTextColor("import-btn", APP_TEXT_DIM); });
+    on("export-btn-pill", "mouseenter", function() { setBorder("export-btn-pill", APP_ACCENT_HOVER, 1, 6); setBackground("export-btn-pill", APP_ACCENT_HOVER); });
+    on("export-btn-pill", "mouseleave", function() { setBorder("export-btn-pill", APP_ACCENT, 1, 6); setBackground("export-btn-pill", APP_ACCENT); });
+
+    // ═══════════════════════════════════════════════════════════════════
+    // MAIN AREA (3 columns: left 310px | center flex | right 272px)
+    // ═══════════════════════════════════════════════════════════════════
+    createRow("main-area");
+    setFlex("main-area", "flex_grow", 1);
+
+    // ── LEFT PANEL (Token Browser — scrollable) ─────────────────────
+    createScrollView("left-panel", "main-area");
+    setFlex("left-panel", "width", 310);
+    setFlex("left-panel", "min_width", 260);
+    setFlex("left-panel", "flex_shrink", 0);
+    setFlex("left-panel", "padding_right", 12);
+    setBackground("left-panel", APP_SURFACE);
+    setBorder("left-panel", APP_BORDER, 1, 0);
+    setScrollContentSize("left-panel", 310, 900);
+
+    // Issue 9: Color System section matching HTML reference
+    createCol("color-section", "left-panel");
+    setFlex("color-section", "padding", 10);
+    setFlex("color-section", "padding_right", 18);
+    setFlex("color-section", "gap", 6);
+    setFlex("color-section", "height", 386);
+    setFlex("color-section", "flex_shrink", 0);
+
+    createLabel("cs-title", "COLOR SYSTEM", "color-section");
+    setFontSize("cs-title", 10);
+    setTextColor("cs-title", APP_ACCENT);
+    setFlex("cs-title", "height", 14);
+
+    // #55: Template selector row
+    createRow("template-row", "color-section");
+    setFlex("template-row", "height", 22);
+    setFlex("template-row", "gap", 6);
+    setFlex("template-row", "align_items", "center");
+    createLabel("template-lbl", "Template", "template-row");
+    setFontSize("template-lbl", 9);
+    setTextColor("template-lbl", APP_TEXT_DIM);
+    setFlex("template-lbl", "width", 58);
+    setFlex("template-lbl", "flex_shrink", 0);
+    setTextOverflow("template-lbl", "ellipsis");
+    createCombo("template-selector", "template-row");
+    setItems("template-selector", ["Audio Studio", "Tailwind 4"]);
+    setFlex("template-selector", "width", 200);
+    setFlex("template-selector", "flex_grow", 1);
+    setFlex("template-selector", "height", 22);
+    setSelected("template-selector", 0);
+    // #56: ? info button
+    createLabel("template-help", "?", "template-row");
+    setFontSize("template-help", 10);
+    setTextColor("template-help", APP_TEXT_DIM);
+    setTextAlign("template-help", "center");
+    setFlex("template-help", "width", 18);
+    setFlex("template-help", "height", 18);
+    setFlex("template-help", "flex_shrink", 0);
+    setBackground("template-help", "#ffffff08");
+    setBorder("template-help", APP_BORDER, 1, 9);
+    setCursor("template-help", "pointer");
+    registerClick("template-help");
+    on("template-help", "click", function() {
+        showHelpModal("Template", "Choose the base palette preset the designer starts from. Audio Studio follows the native reference palette; Tailwind biases the ramps toward utility-style web tokens.");
+    });
+
+    on("template-selector", "select", function(idx) {
+        var templates = [
+            { title: "Audio Studio", theme: "dark", accent: "#89B4FA", harmony: "monochromatic", templateIndex: 0, snapshot: true },
+            { title: "Tailwind 4", theme: "light", accent: "#2563EB", harmony: "complementary", templateIndex: 1, snapshot: true }
+        ];
+        var config = templates[idx] || templates[0];
+        applyPaletteConfiguration(config);
+        showToast(config.title + " template applied");
+    });
+
+    // Harmony selector row
+    createRow("harmony-row", "color-section");
+    setFlex("harmony-row", "height", 22);
+    setFlex("harmony-row", "gap", 6);
+    setFlex("harmony-row", "align_items", "center");
+    createLabel("harmony-lbl", "Harmony", "harmony-row");
+    setFontSize("harmony-lbl", 9);
+    setTextColor("harmony-lbl", APP_TEXT_DIM);
+    setFlex("harmony-lbl", "width", 58);
+    setFlex("harmony-lbl", "flex_shrink", 0);
+    setTextOverflow("harmony-lbl", "ellipsis");
+    createCombo("harmony-selector", "harmony-row");
+    setItems("harmony-selector", ["Monochromatic", "Analogous", "Complementary", "Split Comp.", "None"]);
+    setFlex("harmony-selector", "width", 200);
+    setFlex("harmony-selector", "flex_grow", 1);
+    setFlex("harmony-selector", "height", 22);
+    createLabel("harmony-help", "?", "harmony-row");
+    setFontSize("harmony-help", 10);
+    setTextColor("harmony-help", APP_TEXT_DIM);
+    setTextAlign("harmony-help", "center");
+    setFlex("harmony-help", "width", 18);
+    setFlex("harmony-help", "height", 18);
+    setFlex("harmony-help", "flex_shrink", 0);
+    setBackground("harmony-help", "#ffffff08");
+    setBorder("harmony-help", APP_BORDER, 1, 9);
+    setCursor("harmony-help", "pointer");
+    registerClick("harmony-help");
+    on("harmony-help", "click", function() {
+        showHelpModal("Harmony", "Controls how the non-accent semantic ramps relate to the accent hue. Use this to keep warning, success, and error colors either tightly coordinated or intentionally separated.");
+    });
+
+    // Mode selector row
+    createRow("mode-row", "color-section");
+    setFlex("mode-row", "height", 22);
+    setFlex("mode-row", "gap", 6);
+    setFlex("mode-row", "align_items", "center");
+    createLabel("mode-lbl", "Mode", "mode-row");
+    setFontSize("mode-lbl", 9);
+    setTextColor("mode-lbl", APP_TEXT_DIM);
+    setFlex("mode-lbl", "width", 58);
+    setFlex("mode-lbl", "flex_shrink", 0);
+    createCombo("mode-selector", "mode-row");
+    setItems("mode-selector", ["Dark", "Light"]);
+    setFlex("mode-selector", "width", 200);
+    setFlex("mode-selector", "flex_grow", 1);
+    setFlex("mode-selector", "height", 22);
+    createLabel("mode-help", "?", "mode-row");
+    setFontSize("mode-help", 10);
+    setTextColor("mode-help", APP_TEXT_DIM);
+    setTextAlign("mode-help", "center");
+    setFlex("mode-help", "width", 18);
+    setFlex("mode-help", "height", 18);
+    setFlex("mode-help", "flex_shrink", 0);
+    setBackground("mode-help", "#ffffff08");
+    setBorder("mode-help", APP_BORDER, 1, 9);
+    setCursor("mode-help", "pointer");
+    registerClick("mode-help");
+    on("mode-help", "click", function() {
+        showHelpModal("Mode", "Dark mode maps lighter shades to text and surfaces over dark backgrounds. Light mode inverts the relationship so semantic ramps still read correctly.");
+    });
+
+    // Issue 9: 5 palette rows — each with base color dot + name + 11-shade mini ramp
+    // (shade ramps are built dynamically by buildShadeRamps below)
+
+    // Hue fader (compact)
+    createRow("hue-row", "color-section");
+    setFlex("hue-row", "gap", 6);
+    setFlex("hue-row", "align_items", "center");
+    setFlex("hue-row", "height", 22);
+
+    createLabel("hue-label", "Hue", "hue-row");
+    setFontSize("hue-label", 9);
+    setTextColor("hue-label", APP_TEXT_DIM);
+    setFlex("hue-label", "width", 26);
+
+    createFader("accent-hue", "horizontal", "hue-row");
+    setFlex("accent-hue", "flex_grow", 1);
+    setFlex("accent-hue", "height", 18);
+    setValue("accent-hue", 0.65);
+
+    // Token search field
+    createRow("token-search-row", "left-panel");
+    setFlex("token-search-row", "height", 32);
+    setFlex("token-search-row", "flex_shrink", 0);
+    setFlex("token-search-row", "padding_left", 10);
+    setFlex("token-search-row", "padding_right", 10);
+    setFlex("token-search-row", "padding_right", 18);
+    setFlex("token-search-row", "padding_top", 6);
+    setFlex("token-search-row", "align_items", "center");
+    setFlex("token-search-row", "gap", 0);
+
+    createIcon("search-icon", "search", "token-search-row");
+    setFlex("search-icon", "width", 24);
+    setFlex("search-icon", "height", 24);
+
+    createTextEditor("token-search", "token-search-row");
+    setPlaceholder("token-search", "Search tokens...");
+    setFlex("token-search", "flex_grow", 1);
+    setFlex("token-search", "height", 24);
+    setTextColor("token-search", APP_TEXT);
+
+    // Token browser header
+    createRow("token-header", "left-panel");
+    setFlex("token-header", "height", 24);
+    setFlex("token-header", "flex_shrink", 0);
+    setFlex("token-header", "padding_left", 10);
+    setFlex("token-header", "padding_right", 18);
+    setFlex("token-header", "align_items", "center");
+
+    createLabel("tokens-title", "TOKENS", "token-header");
+    setFontSize("tokens-title", 10);
+    setTextColor("tokens-title", APP_TEXT_DIM);
+
+    // Token list (inside left-panel scroll, no nested scroll needed)
+    createCol("token-list", "left-panel");
+    setFlex("token-list", "height", 0);
+    setFlex("token-list", "flex_shrink", 0);
 }
-
-registerHover("undo-btn-pill");
-registerHover("redo-btn-pill");
-registerHover("import-btn-pill");
-registerHover("export-btn-pill");
-on("undo-btn-pill", "mouseenter", function() { setBorder("undo-btn-pill", APP_ACCENT, 1, 6); setBackground("undo-btn-pill", APP_PANEL_RAISED); setTextColor("undo-btn", APP_TEXT); });
-on("undo-btn-pill", "mouseleave", function() { setBorder("undo-btn-pill", APP_BORDER, 1, 6); setBackground("undo-btn-pill", APP_PANEL); setTextColor("undo-btn", APP_TEXT_DIM); });
-on("redo-btn-pill", "mouseenter", function() { setBorder("redo-btn-pill", APP_ACCENT, 1, 6); setBackground("redo-btn-pill", APP_PANEL_RAISED); setTextColor("redo-btn", APP_TEXT); });
-on("redo-btn-pill", "mouseleave", function() { setBorder("redo-btn-pill", APP_BORDER, 1, 6); setBackground("redo-btn-pill", APP_PANEL); setTextColor("redo-btn", APP_TEXT_DIM); });
-on("import-btn-pill", "mouseenter", function() { setBorder("import-btn-pill", APP_ACCENT, 1, 6); setBackground("import-btn-pill", APP_PANEL_RAISED); setTextColor("import-btn", APP_TEXT); });
-on("import-btn-pill", "mouseleave", function() { setBorder("import-btn-pill", APP_BORDER, 1, 6); setBackground("import-btn-pill", APP_PANEL); setTextColor("import-btn", APP_TEXT_DIM); });
-on("export-btn-pill", "mouseenter", function() { setBorder("export-btn-pill", APP_ACCENT_HOVER, 1, 6); setBackground("export-btn-pill", APP_ACCENT_HOVER); });
-on("export-btn-pill", "mouseleave", function() { setBorder("export-btn-pill", APP_ACCENT, 1, 6); setBackground("export-btn-pill", APP_ACCENT); });
-
-// ═══════════════════════════════════════════════════════════════════
-// MAIN AREA (3 columns: left 310px | center flex | right 272px)
-// ═══════════════════════════════════════════════════════════════════
-createRow("main-area");
-setFlex("main-area", "flex_grow", 1);
-
-// ── LEFT PANEL (Token Browser — scrollable) ─────────────────────
-createScrollView("left-panel", "main-area");
-setFlex("left-panel", "width", 310);
-setFlex("left-panel", "min_width", 260);
-setFlex("left-panel", "flex_shrink", 0);
-setFlex("left-panel", "padding_right", 12);
-setBackground("left-panel", APP_SURFACE);
-setBorder("left-panel", APP_BORDER, 1, 0);
-setScrollContentSize("left-panel", 310, 900);
-
-// Issue 9: Color System section matching HTML reference
-createCol("color-section", "left-panel");
-setFlex("color-section", "padding", 10);
-setFlex("color-section", "padding_right", 18);
-setFlex("color-section", "gap", 6);
-setFlex("color-section", "height", 386);
-setFlex("color-section", "flex_shrink", 0);
-
-createLabel("cs-title", "COLOR SYSTEM", "color-section");
-setFontSize("cs-title", 10);
-setTextColor("cs-title", APP_ACCENT);
-setFlex("cs-title", "height", 14);
-
-// #55: Template selector row
-createRow("template-row", "color-section");
-setFlex("template-row", "height", 22);
-setFlex("template-row", "gap", 6);
-setFlex("template-row", "align_items", "center");
-createLabel("template-lbl", "Template", "template-row");
-setFontSize("template-lbl", 9);
-setTextColor("template-lbl", APP_TEXT_DIM);
-setFlex("template-lbl", "width", 58);
-setFlex("template-lbl", "flex_shrink", 0);
-setTextOverflow("template-lbl", "ellipsis");
-createCombo("template-selector", "template-row");
-setItems("template-selector", ["Audio Studio", "Tailwind 4"]);
-setFlex("template-selector", "width", 200);
-setFlex("template-selector", "flex_grow", 1);
-setFlex("template-selector", "height", 22);
-setSelected("template-selector", 0);
-// #56: ? info button
-createLabel("template-help", "?", "template-row");
-setFontSize("template-help", 10);
-setTextColor("template-help", APP_TEXT_DIM);
-setTextAlign("template-help", "center");
-setFlex("template-help", "width", 18);
-setFlex("template-help", "height", 18);
-setFlex("template-help", "flex_shrink", 0);
-setBackground("template-help", "#ffffff08");
-setBorder("template-help", APP_BORDER, 1, 9);
-setCursor("template-help", "pointer");
-registerClick("template-help");
-on("template-help", "click", function() {
-    showHelpModal("Template", "Choose the base palette preset the designer starts from. Audio Studio follows the native reference palette; Tailwind biases the ramps toward utility-style web tokens.");
-});
-
-on("template-selector", "select", function(idx) {
-    var templates = [
-        { title: "Audio Studio", theme: "dark", accent: "#89B4FA", harmony: "monochromatic", templateIndex: 0, snapshot: true },
-        { title: "Tailwind 4", theme: "light", accent: "#2563EB", harmony: "complementary", templateIndex: 1, snapshot: true }
-    ];
-    var config = templates[idx] || templates[0];
-    applyPaletteConfiguration(config);
-    showToast(config.title + " template applied");
-});
-
-// Harmony selector row
-createRow("harmony-row", "color-section");
-setFlex("harmony-row", "height", 22);
-setFlex("harmony-row", "gap", 6);
-setFlex("harmony-row", "align_items", "center");
-createLabel("harmony-lbl", "Harmony", "harmony-row");
-setFontSize("harmony-lbl", 9);
-setTextColor("harmony-lbl", APP_TEXT_DIM);
-setFlex("harmony-lbl", "width", 58);
-setFlex("harmony-lbl", "flex_shrink", 0);
-setTextOverflow("harmony-lbl", "ellipsis");
-createCombo("harmony-selector", "harmony-row");
-setItems("harmony-selector", ["Monochromatic", "Analogous", "Complementary", "Split Comp.", "None"]);
-setFlex("harmony-selector", "width", 200);
-setFlex("harmony-selector", "flex_grow", 1);
-setFlex("harmony-selector", "height", 22);
-createLabel("harmony-help", "?", "harmony-row");
-setFontSize("harmony-help", 10);
-setTextColor("harmony-help", APP_TEXT_DIM);
-setTextAlign("harmony-help", "center");
-setFlex("harmony-help", "width", 18);
-setFlex("harmony-help", "height", 18);
-setFlex("harmony-help", "flex_shrink", 0);
-setBackground("harmony-help", "#ffffff08");
-setBorder("harmony-help", APP_BORDER, 1, 9);
-setCursor("harmony-help", "pointer");
-registerClick("harmony-help");
-on("harmony-help", "click", function() {
-    showHelpModal("Harmony", "Controls how the non-accent semantic ramps relate to the accent hue. Use this to keep warning, success, and error colors either tightly coordinated or intentionally separated.");
-});
-
-// Mode selector row
-createRow("mode-row", "color-section");
-setFlex("mode-row", "height", 22);
-setFlex("mode-row", "gap", 6);
-setFlex("mode-row", "align_items", "center");
-createLabel("mode-lbl", "Mode", "mode-row");
-setFontSize("mode-lbl", 9);
-setTextColor("mode-lbl", APP_TEXT_DIM);
-setFlex("mode-lbl", "width", 58);
-setFlex("mode-lbl", "flex_shrink", 0);
-createCombo("mode-selector", "mode-row");
-setItems("mode-selector", ["Dark", "Light"]);
-setFlex("mode-selector", "width", 200);
-setFlex("mode-selector", "flex_grow", 1);
-setFlex("mode-selector", "height", 22);
-createLabel("mode-help", "?", "mode-row");
-setFontSize("mode-help", 10);
-setTextColor("mode-help", APP_TEXT_DIM);
-setTextAlign("mode-help", "center");
-setFlex("mode-help", "width", 18);
-setFlex("mode-help", "height", 18);
-setFlex("mode-help", "flex_shrink", 0);
-setBackground("mode-help", "#ffffff08");
-setBorder("mode-help", APP_BORDER, 1, 9);
-setCursor("mode-help", "pointer");
-registerClick("mode-help");
-on("mode-help", "click", function() {
-    showHelpModal("Mode", "Dark mode maps lighter shades to text and surfaces over dark backgrounds. Light mode inverts the relationship so semantic ramps still read correctly.");
-});
-
-// Issue 9: 5 palette rows — each with base color dot + name + 11-shade mini ramp
-// (shade ramps are built dynamically by buildShadeRamps below)
-
-// Hue fader (compact)
-createRow("hue-row", "color-section");
-setFlex("hue-row", "gap", 6);
-setFlex("hue-row", "align_items", "center");
-setFlex("hue-row", "height", 22);
-
-createLabel("hue-label", "Hue", "hue-row");
-setFontSize("hue-label", 9);
-setTextColor("hue-label", APP_TEXT_DIM);
-setFlex("hue-label", "width", 26);
-
-createFader("accent-hue", "horizontal", "hue-row");
-setFlex("accent-hue", "flex_grow", 1);
-setFlex("accent-hue", "height", 18);
-setValue("accent-hue", 0.65);
-
-// Token search field
-createRow("token-search-row", "left-panel");
-setFlex("token-search-row", "height", 32);
-setFlex("token-search-row", "flex_shrink", 0);
-setFlex("token-search-row", "padding_left", 10);
-setFlex("token-search-row", "padding_right", 10);
-setFlex("token-search-row", "padding_right", 18);
-setFlex("token-search-row", "padding_top", 6);
-setFlex("token-search-row", "align_items", "center");
-setFlex("token-search-row", "gap", 0);
-
-createIcon("search-icon", "search", "token-search-row");
-setFlex("search-icon", "width", 24);
-setFlex("search-icon", "height", 24);
-
-createTextEditor("token-search", "token-search-row");
-setPlaceholder("token-search", "Search tokens...");
-setFlex("token-search", "flex_grow", 1);
-setFlex("token-search", "height", 24);
-setTextColor("token-search", APP_TEXT);
-
-// Token browser header
-createRow("token-header", "left-panel");
-setFlex("token-header", "height", 24);
-setFlex("token-header", "flex_shrink", 0);
-setFlex("token-header", "padding_left", 10);
-setFlex("token-header", "padding_right", 18);
-setFlex("token-header", "align_items", "center");
-
-createLabel("tokens-title", "TOKENS", "token-header");
-setFontSize("tokens-title", 10);
-setTextColor("tokens-title", APP_TEXT_DIM);
-
-// Token list (inside left-panel scroll, no nested scroll needed)
-createCol("token-list", "left-panel");
-setFlex("token-list", "height", 0);
-setFlex("token-list", "flex_shrink", 0);
+buildToolbarActionsAndLeftPanelControls();
 
 // Token groups
 // D5: Expanded token registry (50+ semantic tokens matching HTML reference)
@@ -1082,121 +1106,124 @@ function updateTokenFilterLayout(query) {
     updateLeftPanelScrollMetrics();
 }
 
-for (var g = 0; g < tokenGroups.length; g++) {
-    var group = tokenGroups[g];
-    var gid = "tg-" + g;
-    // Yoga needs explicit height for each token group
-    var groupHeight = 18 + (group.tokens.length * 28) + 8;  // title + rows + padding
-    createCol(gid, "token-list");
-    setFlex(gid, "height", groupHeight);
-    setFlex(gid, "flex_shrink", 0);
-    setFlex(gid, "padding_left", 10);
-    setFlex(gid, "padding_right", 10);
-    setFlex(gid, "padding_top", 4);
-    setFlex(gid, "gap", 2);
+function buildTokenList() {
+    for (var g = 0; g < tokenGroups.length; g++) {
+        var group = tokenGroups[g];
+        var gid = "tg-" + g;
+        // Yoga needs explicit height for each token group
+        var groupHeight = 18 + (group.tokens.length * 28) + 8;  // title + rows + padding
+        createCol(gid, "token-list");
+        setFlex(gid, "height", groupHeight);
+        setFlex(gid, "flex_shrink", 0);
+        setFlex(gid, "padding_left", 10);
+        setFlex(gid, "padding_right", 10);
+        setFlex(gid, "padding_top", 4);
+        setFlex(gid, "gap", 2);
 
-    // D7: Styled group headers — uppercase, accent colored
-    createLabel(gid + "-title", group.name, gid);
-    setFontSize(gid + "-title", 9);
-    setTextColor(gid + "-title", APP_ACCENT);
-    setFlex(gid + "-title", "height", 18);
+        // D7: Styled group headers — uppercase, accent colored
+        createLabel(gid + "-title", group.name, gid);
+        setFontSize(gid + "-title", 9);
+        setTextColor(gid + "-title", APP_ACCENT);
+        setFlex(gid + "-title", "height", 18);
 
-    for (var t = 0; t < group.tokens.length; t++) {
-        var tid = "tok-" + g + "-" + t;
-        createRow(tid, gid);
-        setFlex(tid, "height", 24);
-        setFlex(tid, "flex_shrink", 0);
-        setFlex(tid, "gap", 6);
-        setFlex(tid, "align_items", "center");
+        for (var t = 0; t < group.tokens.length; t++) {
+            var tid = "tok-" + g + "-" + t;
+            createRow(tid, gid);
+            setFlex(tid, "height", 24);
+            setFlex(tid, "flex_shrink", 0);
+            setFlex(tid, "gap", 6);
+            setFlex(tid, "align_items", "center");
 
-        // Color swatch (small colored box)
-        var swatchId = tid + "-sw";
-        createCol(swatchId, tid);
-        setFlex(swatchId, "width", 18);
-        setFlex(swatchId, "height", 18);
-        setFlex(swatchId, "min_width", 18);
-        setFlex(swatchId, "min_height", 18);
-        setFlex(swatchId, "max_width", 18);
-        setFlex(swatchId, "max_height", 18);
-        setBorder(swatchId, APP_BORDER, 1, 4);
+            // Color swatch (small colored box)
+            var swatchId = tid + "-sw";
+            createCol(swatchId, tid);
+            setFlex(swatchId, "width", 18);
+            setFlex(swatchId, "height", 18);
+            setFlex(swatchId, "min_width", 18);
+            setFlex(swatchId, "min_height", 18);
+            setFlex(swatchId, "max_width", 18);
+            setFlex(swatchId, "max_height", 18);
+            setBorder(swatchId, APP_BORDER, 1, 4);
 
-        // Token name
-        createLabel(tid + "-name", group.tokens[t], tid);
-        setFontSize(tid + "-name", 11);
-        setFlex(tid + "-name", "flex_grow", 1);
+            // Token name
+            createLabel(tid + "-name", group.tokens[t], tid);
+            setFontSize(tid + "-name", 11);
+            setFlex(tid + "-name", "flex_grow", 1);
 
-        createLabel(tid + "-mod", "\u2022", tid);
-        setFontSize(tid + "-mod", 11);
-        setFlex(tid + "-mod", "width", 8);
-        setFlex(tid + "-mod", "height", 12);
-        setOpacity(tid + "-mod", 0.0);
+            createLabel(tid + "-mod", "\u2022", tid);
+            setFontSize(tid + "-mod", 11);
+            setFlex(tid + "-mod", "width", 8);
+            setFlex(tid + "-mod", "height", 12);
+            setOpacity(tid + "-mod", 0.0);
 
-        var resetId = tid + "-reset";
-        createCol(resetId, tid);
-        setFlex(resetId, "width", 34);
-        setFlex(resetId, "min_width", 34);
-        setFlex(resetId, "max_width", 34);
-        setFlex(resetId, "height", 18);
-        setFlex(resetId, "justify_content", "center");
-        setFlex(resetId, "align_items", "center");
-        setFlex(resetId, "flex_shrink", 0);
-        setBackground(resetId, APP_SURFACE);
-        setBorder(resetId, APP_BORDER, 1, 9);
-        setVisible(resetId, false);
-        registerClick(resetId);
-        createLabel(resetId + "-lbl", "Reset", resetId);
-        setFontSize(resetId + "-lbl", 8);
-        setTextColor(resetId + "-lbl", APP_TEXT_DIM);
-        setPointerEvents(resetId + "-lbl", "none");
+            var resetId = tid + "-reset";
+            createCol(resetId, tid);
+            setFlex(resetId, "width", 34);
+            setFlex(resetId, "min_width", 34);
+            setFlex(resetId, "max_width", 34);
+            setFlex(resetId, "height", 18);
+            setFlex(resetId, "justify_content", "center");
+            setFlex(resetId, "align_items", "center");
+            setFlex(resetId, "flex_shrink", 0);
+            setBackground(resetId, APP_SURFACE);
+            setBorder(resetId, APP_BORDER, 1, 9);
+            setVisible(resetId, false);
+            registerClick(resetId);
+            createLabel(resetId + "-lbl", "Reset", resetId);
+            setFontSize(resetId + "-lbl", 8);
+            setTextColor(resetId + "-lbl", APP_TEXT_DIM);
+            setPointerEvents(resetId + "-lbl", "none");
 
-        // D1: hex input field
-        var hexId = tid + "-hex";
-        createTextEditor(hexId, tid);
-        setPlaceholder(hexId, "#000000");
-        setFlex(hexId, "width", 72);
-        setFlex(hexId, "min_width", 72);
-        setFlex(hexId, "max_width", 72);
-        setFlex(hexId, "flex_shrink", 0);
-        setFlex(hexId, "height", 20);
-        setFontSize(hexId, 10);
+            // D1: hex input field
+            var hexId = tid + "-hex";
+            createTextEditor(hexId, tid);
+            setPlaceholder(hexId, "#000000");
+            setFlex(hexId, "width", 72);
+            setFlex(hexId, "min_width", 72);
+            setFlex(hexId, "max_width", 72);
+            setFlex(hexId, "flex_shrink", 0);
+            setFlex(hexId, "height", 20);
+            setFontSize(hexId, 10);
 
-        // D7: hover highlight on token row
-        registerHover(tid);
-        (function(rowId) {
-            on(rowId, 'mouseenter', function() { setBackground(rowId, '#ffffff08'); });
-            on(rowId, 'mouseleave', function() { setBackground(rowId, 'transparent'); });
-        })(tid);
+            // D7: hover highlight on token row
+            registerHover(tid);
+            (function(rowId) {
+                on(rowId, 'mouseenter', function() { setBackground(rowId, '#ffffff08'); });
+                on(rowId, 'mouseleave', function() { setBackground(rowId, 'transparent'); });
+            })(tid);
 
-        // D1: click swatch → open token popup
-        registerClick(swatchId);
-        (function(tokenName, sid, gi, ti) {
-            on(sid, 'click', function() {
-                openTokenPopup(tokenName, sid, gi, ti);
-            });
-        })(group.tokens[t], swatchId, g, t);
+            // D1: click swatch → open token popup
+            registerClick(swatchId);
+            (function(tokenName, sid, gi, ti) {
+                on(sid, 'click', function() {
+                    openTokenPopup(tokenName, sid, gi, ti);
+                });
+            })(group.tokens[t], swatchId, g, t);
 
-        (function(tokenName, rid) {
-            on(rid, 'click', function() {
-                resetTokenColor(tokenName);
-            });
-        })(group.tokens[t], resetId);
+            (function(tokenName, rid) {
+                on(rid, 'click', function() {
+                    resetTokenColor(tokenName);
+                });
+            })(group.tokens[t], resetId);
 
-        // D1: hex input → apply on Enter
-        (function(tokenName, hid) {
-            on(hid, 'return', function(text) {
-                var hex = text.trim();
-                if (!/^#[0-9a-fA-F]{6}$/.test(hex)) return;
-                applyTokenColor(tokenName, hex);
-            });
-        })(group.tokens[t], hexId);
+            // D1: hex input → apply on Enter
+            (function(tokenName, hid) {
+                on(hid, 'return', function(text) {
+                    var hex = text.trim();
+                    if (!/^#[0-9a-fA-F]{6}$/.test(hex)) return;
+                    applyTokenColor(tokenName, hex);
+                });
+            })(group.tokens[t], hexId);
+        }
     }
-}
 
-// Token search filtering
-on("token-search", "change", function(query) {
-    updateTokenFilterLayout(query);
-    layout();
-});
+    // Token search filtering
+    on("token-search", "change", function(query) {
+        updateTokenFilterLayout(query);
+        layout();
+    });
+}
+buildTokenList();
 
 // ── Apply token colors to swatches ───────────────────────────────
 function updateTokenSwatches(skipPreviewRefresh) {
@@ -2222,29 +2249,32 @@ function scheduleAccentHueApply(forceApply) {
 }
 
 // "Generate Opposite Mode" button below palette rows
-createCol("gen-opposite-btn", "color-section");
-setFlex("gen-opposite-btn", "height", 32);
-setFlex("gen-opposite-btn", "justify_content", "center");
-setFlex("gen-opposite-btn", "align_items", "center");
-setBackground("gen-opposite-btn", APP_ACCENT);
-setBorder("gen-opposite-btn", APP_ACCENT, 0, 6);
-createLabel("gen-opposite-lbl", "Generate Opposite Mode", "gen-opposite-btn");
-setFontSize("gen-opposite-lbl", 11);
-setTextColor("gen-opposite-lbl", "#ffffff");
-setPointerEvents("gen-opposite-lbl", "none");
-registerClick("gen-opposite-btn");
-on("gen-opposite-btn", "click", function() {
-    var sourceMode = resolvePaletteMode(currentPaletteMode);
-    var targetMode = resolvePaletteMode(sourceMode === "light" ? "dark" : "light");
-    switchPaletteMode(targetMode, {
-        generatedTitle: targetMode === "light" ? "Generated Light" : "Generated Dark"
+function buildOppositeModeButton() {
+    createCol("gen-opposite-btn", "color-section");
+    setFlex("gen-opposite-btn", "height", 32);
+    setFlex("gen-opposite-btn", "justify_content", "center");
+    setFlex("gen-opposite-btn", "align_items", "center");
+    setBackground("gen-opposite-btn", APP_ACCENT);
+    setBorder("gen-opposite-btn", APP_ACCENT, 0, 6);
+    createLabel("gen-opposite-lbl", "Generate Opposite Mode", "gen-opposite-btn");
+    setFontSize("gen-opposite-lbl", 11);
+    setTextColor("gen-opposite-lbl", "#ffffff");
+    setPointerEvents("gen-opposite-lbl", "none");
+    registerClick("gen-opposite-btn");
+    on("gen-opposite-btn", "click", function() {
+        var sourceMode = resolvePaletteMode(currentPaletteMode);
+        var targetMode = resolvePaletteMode(sourceMode === "light" ? "dark" : "light");
+        switchPaletteMode(targetMode, {
+            generatedTitle: targetMode === "light" ? "Generated Light" : "Generated Dark"
+        });
+        pushThemeSnapshot();
+        refreshOppositeModeButton();
+        layout();
+        showToast("Switched to " + (targetMode === "light" ? "Light" : "Dark") + " mode");
     });
-    pushThemeSnapshot();
     refreshOppositeModeButton();
-    layout();
-    showToast("Switched to " + (targetMode === "light" ? "Light" : "Dark") + " mode");
-});
-refreshOppositeModeButton();
+}
+buildOppositeModeButton();
 
 // #60: Save/Load palette buttons
 function serializePaletteConfiguration() {
@@ -2289,138 +2319,144 @@ function readTextFile(path) {
     return exec("cat " + shellQuote(path) + " 2>/dev/null");
 }
 
-createRow("palette-io-row", "color-section");
-setFlex("palette-io-row", "height", 26);
-setFlex("palette-io-row", "gap", 6);
+function buildPaletteSaveLoadRow() {
+    createRow("palette-io-row", "color-section");
+    setFlex("palette-io-row", "height", 26);
+    setFlex("palette-io-row", "gap", 6);
 
-createCol("palette-save-btn", "palette-io-row");
-setFlex("palette-save-btn", "flex_grow", 1);
-setFlex("palette-save-btn", "height", 26);
-setFlex("palette-save-btn", "justify_content", "center");
-setFlex("palette-save-btn", "align_items", "center");
-setBorder("palette-save-btn", APP_BORDER, 1, 4);
-createLabel("palette-save-lbl", "Save", "palette-save-btn");
-setFontSize("palette-save-lbl", 10);
-setPointerEvents("palette-save-lbl", "none");
-registerClick("palette-save-btn");
-on("palette-save-btn", "click", function() {
-    var path = normalizePaletteSavePath(showSaveDialog("Save Palette", "Color System JSON", "json"));
-    writeTextFile(path, serializePaletteConfiguration());
-    showToast("Palette saved to " + path);
-});
+    createCol("palette-save-btn", "palette-io-row");
+    setFlex("palette-save-btn", "flex_grow", 1);
+    setFlex("palette-save-btn", "height", 26);
+    setFlex("palette-save-btn", "justify_content", "center");
+    setFlex("palette-save-btn", "align_items", "center");
+    setBorder("palette-save-btn", APP_BORDER, 1, 4);
+    createLabel("palette-save-lbl", "Save", "palette-save-btn");
+    setFontSize("palette-save-lbl", 10);
+    setPointerEvents("palette-save-lbl", "none");
+    registerClick("palette-save-btn");
+    on("palette-save-btn", "click", function() {
+        var path = normalizePaletteSavePath(showSaveDialog("Save Palette", "Color System JSON", "json"));
+        writeTextFile(path, serializePaletteConfiguration());
+        showToast("Palette saved to " + path);
+    });
 
-createCol("palette-load-btn", "palette-io-row");
-setFlex("palette-load-btn", "flex_grow", 1);
-setFlex("palette-load-btn", "height", 26);
-setFlex("palette-load-btn", "justify_content", "center");
-setFlex("palette-load-btn", "align_items", "center");
-setBorder("palette-load-btn", APP_BORDER, 1, 4);
-createLabel("palette-load-lbl", "Load", "palette-load-btn");
-setFontSize("palette-load-lbl", 10);
-setPointerEvents("palette-load-lbl", "none");
-registerClick("palette-load-btn");
-on("palette-load-btn", "click", function() {
-    var path = showOpenDialog("Load Palette", "Color System JSON", "json");
-    if (!path || path.length === 0) path = "/tmp/pulp-palette.colorsystem.json";
-    var json = readTextFile(path);
-    if (json && json.length > 10) {
-        if (applySerializedPaletteConfiguration(json)) {
-            showToast("Palette loaded from " + path);
+    createCol("palette-load-btn", "palette-io-row");
+    setFlex("palette-load-btn", "flex_grow", 1);
+    setFlex("palette-load-btn", "height", 26);
+    setFlex("palette-load-btn", "justify_content", "center");
+    setFlex("palette-load-btn", "align_items", "center");
+    setBorder("palette-load-btn", APP_BORDER, 1, 4);
+    createLabel("palette-load-lbl", "Load", "palette-load-btn");
+    setFontSize("palette-load-lbl", 10);
+    setPointerEvents("palette-load-lbl", "none");
+    registerClick("palette-load-btn");
+    on("palette-load-btn", "click", function() {
+        var path = showOpenDialog("Load Palette", "Color System JSON", "json");
+        if (!path || path.length === 0) path = "/tmp/pulp-palette.colorsystem.json";
+        var json = readTextFile(path);
+        if (json && json.length > 10) {
+            if (applySerializedPaletteConfiguration(json)) {
+                showToast("Palette loaded from " + path);
+            }
+        } else {
+            showToast("No palette file found");
         }
-    } else {
-        showToast("No palette file found");
-    }
-});
+    });
 
-updateTokenFilterLayout("");
-updateLeftPanelScrollMetrics();
+    updateTokenFilterLayout("");
+    updateLeftPanelScrollMetrics();
+}
+buildPaletteSaveLoadRow();
 
 // ── Color Picker (legacy — hidden, replaced by inline palette editor)
 var pickerVisible = false;
 var pickerColor = { L: 0, C: 0, H: 0, hex: '#000000' };
 
-createCol("color-picker", "");
-setFlex("color-picker", "width", 280);
-setFlex("color-picker", "height", 200);
-setFlex("color-picker", "padding", 12);
-setFlex("color-picker", "gap", 8);
-setBackground("color-picker", APP_PANEL);
-setBorder("color-picker", APP_BORDER, 1, 8);
-setBoxShadow("color-picker", 0, 4, 12, 0, "#00000060");
-setVisible("color-picker", false);
+function buildLegacyColorPicker() {
+    createCol("color-picker", "");
+    setFlex("color-picker", "width", 280);
+    setFlex("color-picker", "height", 200);
+    setFlex("color-picker", "padding", 12);
+    setFlex("color-picker", "gap", 8);
+    setBackground("color-picker", APP_PANEL);
+    setBorder("color-picker", APP_BORDER, 1, 8);
+    setBoxShadow("color-picker", 0, 4, 12, 0, "#00000060");
+    setVisible("color-picker", false);
 
-// Color preview swatch
-createCol("picker-preview", "color-picker");
-setFlex("picker-preview", "height", 40);
-setBorder("picker-preview", APP_BORDER, 1, 6);
+    // Color preview swatch
+    createCol("picker-preview", "color-picker");
+    setFlex("picker-preview", "height", 40);
+    setBorder("picker-preview", APP_BORDER, 1, 6);
 
-// OKLCH values row
-createRow("picker-values", "color-picker");
-setFlex("picker-values", "height", 16);
-setFlex("picker-values", "gap", 12);
-setFlex("picker-values", "align_items", "center");
+    // OKLCH values row
+    createRow("picker-values", "color-picker");
+    setFlex("picker-values", "height", 16);
+    setFlex("picker-values", "gap", 12);
+    setFlex("picker-values", "align_items", "center");
 
-createLabel("picker-l-label", "L: 0.00", "picker-values");
-setFontSize("picker-l-label", 10);
-setFlex("picker-l-label", "width", 60);
+    createLabel("picker-l-label", "L: 0.00", "picker-values");
+    setFontSize("picker-l-label", 10);
+    setFlex("picker-l-label", "width", 60);
 
-createLabel("picker-c-label", "C: 0.000", "picker-values");
-setFontSize("picker-c-label", 10);
-setFlex("picker-c-label", "width", 70);
+    createLabel("picker-c-label", "C: 0.000", "picker-values");
+    setFontSize("picker-c-label", 10);
+    setFlex("picker-c-label", "width", 70);
 
-createLabel("picker-h-label", "H: 0.0", "picker-values");
-setFontSize("picker-h-label", 10);
-setFlex("picker-h-label", "width", 60);
+    createLabel("picker-h-label", "H: 0.0", "picker-values");
+    setFontSize("picker-h-label", 10);
+    setFlex("picker-h-label", "width", 60);
 
-// Hex value
-createRow("picker-hex-row", "color-picker");
-setFlex("picker-hex-row", "height", 20);
-setFlex("picker-hex-row", "align_items", "center");
+    // Hex value
+    createRow("picker-hex-row", "color-picker");
+    setFlex("picker-hex-row", "height", 20);
+    setFlex("picker-hex-row", "align_items", "center");
 
-createLabel("picker-hex", "#000000", "picker-hex-row");
-setFontSize("picker-hex", 12);
+    createLabel("picker-hex", "#000000", "picker-hex-row");
+    setFontSize("picker-hex", 12);
 
-// H slider
-createRow("picker-h-row", "color-picker");
-setFlex("picker-h-row", "height", 20);
-setFlex("picker-h-row", "gap", 6);
-setFlex("picker-h-row", "align_items", "center");
+    // H slider
+    createRow("picker-h-row", "color-picker");
+    setFlex("picker-h-row", "height", 20);
+    setFlex("picker-h-row", "gap", 6);
+    setFlex("picker-h-row", "align_items", "center");
 
-createLabel("picker-h-lbl", "H", "picker-h-row");
-setFontSize("picker-h-lbl", 10);
-setFlex("picker-h-lbl", "width", 14);
+    createLabel("picker-h-lbl", "H", "picker-h-row");
+    setFontSize("picker-h-lbl", 10);
+    setFlex("picker-h-lbl", "width", 14);
 
-createFader("picker-h-fader", "horizontal", "picker-h-row");
-setFlex("picker-h-fader", "flex_grow", 1);
-setFlex("picker-h-fader", "height", 16);
+    createFader("picker-h-fader", "horizontal", "picker-h-row");
+    setFlex("picker-h-fader", "flex_grow", 1);
+    setFlex("picker-h-fader", "height", 16);
 
-// C slider
-createRow("picker-c-row", "color-picker");
-setFlex("picker-c-row", "height", 20);
-setFlex("picker-c-row", "gap", 6);
-setFlex("picker-c-row", "align_items", "center");
+    // C slider
+    createRow("picker-c-row", "color-picker");
+    setFlex("picker-c-row", "height", 20);
+    setFlex("picker-c-row", "gap", 6);
+    setFlex("picker-c-row", "align_items", "center");
 
-createLabel("picker-c-lbl", "C", "picker-c-row");
-setFontSize("picker-c-lbl", 10);
-setFlex("picker-c-lbl", "width", 14);
+    createLabel("picker-c-lbl", "C", "picker-c-row");
+    setFontSize("picker-c-lbl", 10);
+    setFlex("picker-c-lbl", "width", 14);
 
-createFader("picker-c-fader", "horizontal", "picker-c-row");
-setFlex("picker-c-fader", "flex_grow", 1);
-setFlex("picker-c-fader", "height", 16);
+    createFader("picker-c-fader", "horizontal", "picker-c-row");
+    setFlex("picker-c-fader", "flex_grow", 1);
+    setFlex("picker-c-fader", "height", 16);
 
-// L slider
-createRow("picker-l-row", "color-picker");
-setFlex("picker-l-row", "height", 20);
-setFlex("picker-l-row", "gap", 6);
-setFlex("picker-l-row", "align_items", "center");
+    // L slider
+    createRow("picker-l-row", "color-picker");
+    setFlex("picker-l-row", "height", 20);
+    setFlex("picker-l-row", "gap", 6);
+    setFlex("picker-l-row", "align_items", "center");
 
-createLabel("picker-l-lbl", "L", "picker-l-row");
-setFontSize("picker-l-lbl", 10);
-setFlex("picker-l-lbl", "width", 14);
+    createLabel("picker-l-lbl", "L", "picker-l-row");
+    setFontSize("picker-l-lbl", 10);
+    setFlex("picker-l-lbl", "width", 14);
 
-createFader("picker-l-fader", "horizontal", "picker-l-row");
-setFlex("picker-l-fader", "flex_grow", 1);
-setFlex("picker-l-fader", "height", 16);
+    createFader("picker-l-fader", "horizontal", "picker-l-row");
+    setFlex("picker-l-fader", "flex_grow", 1);
+    setFlex("picker-l-fader", "height", 16);
+}
+buildLegacyColorPicker();
 
 function showColorPicker(hex) {
     var oklch = OklchEngine.hexToOklch(hex);
@@ -2461,9 +2497,12 @@ function updatePickerFromSliders() {
     setText("picker-hex", hex);
 }
 
-on("picker-h-fader", "change", function() { updatePickerFromSliders(); });
-on("picker-c-fader", "change", function() { updatePickerFromSliders(); });
-on("picker-l-fader", "change", function() { updatePickerFromSliders(); });
+function wireLegacyColorPicker() {
+    on("picker-h-fader", "change", function() { updatePickerFromSliders(); });
+    on("picker-c-fader", "change", function() { updatePickerFromSliders(); });
+    on("picker-l-fader", "change", function() { updatePickerFromSliders(); });
+}
+wireLegacyColorPicker();
 
 // ═══════════════════════════════════════════════════════════════════
 // D1: Token Palette Picker Popup
@@ -2471,233 +2510,242 @@ on("picker-l-fader", "change", function() { updatePickerFromSliders(); });
 var TOKEN_POPUP_W = 280;
 
 // Click-outside backdrop
-createCol("tp-backdrop", "");
-setPosition("tp-backdrop", "absolute");
-setTop("tp-backdrop", 0);
-setLeft("tp-backdrop", 0);
-setFlex("tp-backdrop", "width", 9999);
-setFlex("tp-backdrop", "height", 9999);
-setZIndex("tp-backdrop", 99);
-setVisible("tp-backdrop", false);
-registerClick("tp-backdrop");
-on("tp-backdrop", "click", function() { closeTokenPopup(); });
+function buildTokenPopupShell() {
+    createCol("tp-backdrop", "");
+    setPosition("tp-backdrop", "absolute");
+    setTop("tp-backdrop", 0);
+    setLeft("tp-backdrop", 0);
+    setFlex("tp-backdrop", "width", 9999);
+    setFlex("tp-backdrop", "height", 9999);
+    setZIndex("tp-backdrop", 99);
+    setVisible("tp-backdrop", false);
+    registerClick("tp-backdrop");
+    on("tp-backdrop", "click", function() { closeTokenPopup(); });
 
-// Popup container
-createCol("token-popup", "");
-setPosition("token-popup", "absolute");
-setFlex("token-popup", "width", TOKEN_POPUP_W);
-setFlex("token-popup", "padding", 12);
-setFlex("token-popup", "gap", 8);
-setBackground("token-popup", APP_PANEL);
-setBorder("token-popup", APP_BORDER, 1, 8);
-setBoxShadow("token-popup", 0, 8, 24, 0, "#000000a0");
-setZIndex("token-popup", 100);
-setVisible("token-popup", false);
+    // Popup container
+    createCol("token-popup", "");
+    setPosition("token-popup", "absolute");
+    setFlex("token-popup", "width", TOKEN_POPUP_W);
+    setFlex("token-popup", "padding", 12);
+    setFlex("token-popup", "gap", 8);
+    setBackground("token-popup", APP_PANEL);
+    setBorder("token-popup", APP_BORDER, 1, 8);
+    setBoxShadow("token-popup", 0, 8, 24, 0, "#000000a0");
+    setZIndex("token-popup", 100);
+    setVisible("token-popup", false);
 
-// Header row: token name + close
-createRow("tp-header", "token-popup");
-setFlex("tp-header", "height", 22);
-setFlex("tp-header", "align_items", "center");
-createLabel("tp-token-name", "—", "tp-header");
-setFontSize("tp-token-name", 11);
-setTextColor("tp-token-name", APP_ACCENT);
-setFlex("tp-token-name", "flex_grow", 1);
-createLabel("tp-token-modified", "*", "tp-header");
-setFontSize("tp-token-modified", 12);
-setTextColor("tp-token-modified", APP_ACCENT_HOVER);
-setFlex("tp-token-modified", "width", 10);
-setFlex("tp-token-modified", "height", 14);
-setOpacity("tp-token-modified", 0.0);
+    // Header row: token name + close
+    createRow("tp-header", "token-popup");
+    setFlex("tp-header", "height", 22);
+    setFlex("tp-header", "align_items", "center");
+    createLabel("tp-token-name", "—", "tp-header");
+    setFontSize("tp-token-name", 11);
+    setTextColor("tp-token-name", APP_ACCENT);
+    setFlex("tp-token-name", "flex_grow", 1);
+    createLabel("tp-token-modified", "*", "tp-header");
+    setFontSize("tp-token-modified", 12);
+    setTextColor("tp-token-modified", APP_ACCENT_HOVER);
+    setFlex("tp-token-modified", "width", 10);
+    setFlex("tp-token-modified", "height", 14);
+    setOpacity("tp-token-modified", 0.0);
 
-createCol("tp-close", "tp-header");
-setFlex("tp-close", "width", 26);
-setFlex("tp-close", "height", 26);
-setFlex("tp-close", "justify_content", "center");
-setFlex("tp-close", "align_items", "center");
-setBackground("tp-close", APP_SURFACE);
-setBorder("tp-close", APP_BORDER, 1, 13);
-setCursor("tp-close", "pointer");
-createLabel("tp-close-lbl", "\u00d7", "tp-close");
-setFontSize("tp-close-lbl", 12);
-setPointerEvents("tp-close-lbl", "none");
-registerClick("tp-close");
-registerPointer("tp-close");
-on("tp-close", "pointerdown", function() { closeTokenPopup(); });
-on("tp-close", "click", function() { closeTokenPopup(); });
+    createCol("tp-close", "tp-header");
+    setFlex("tp-close", "width", 26);
+    setFlex("tp-close", "height", 26);
+    setFlex("tp-close", "justify_content", "center");
+    setFlex("tp-close", "align_items", "center");
+    setBackground("tp-close", APP_SURFACE);
+    setBorder("tp-close", APP_BORDER, 1, 13);
+    setCursor("tp-close", "pointer");
+    createLabel("tp-close-lbl", "\u00d7", "tp-close");
+    setFontSize("tp-close-lbl", 12);
+    setPointerEvents("tp-close-lbl", "none");
+    registerClick("tp-close");
+    registerPointer("tp-close");
+    on("tp-close", "pointerdown", function() { closeTokenPopup(); });
+    on("tp-close", "click", function() { closeTokenPopup(); });
 
-// Undo / Redo / Reset row
-createRow("tp-undo-row", "token-popup");
-setFlex("tp-undo-row", "height", 22);
-setFlex("tp-undo-row", "gap", 4);
-setFlex("tp-undo-row", "align_items", "center");
+    // Undo / Redo / Reset row
+    createRow("tp-undo-row", "token-popup");
+    setFlex("tp-undo-row", "height", 22);
+    setFlex("tp-undo-row", "gap", 4);
+    setFlex("tp-undo-row", "align_items", "center");
+}
+buildTokenPopupShell();
 
 var tpUndoBtns = ["Undo", "Redo", "Reset"];
-for (var ub = 0; ub < tpUndoBtns.length; ub++) {
-    var ubId = "tp-btn-" + ub;
-    createCol(ubId, "tp-undo-row");
-    setFlex(ubId, "width", ub === 2 ? 44 : 48);
-    setFlex(ubId, "min_width", ub === 2 ? 44 : 48);
-    setFlex(ubId, "max_width", ub === 2 ? 44 : 48);
-    setFlex(ubId, "flex_shrink", 0);
-    setFlex(ubId, "height", 22);
-    setFlex(ubId, "justify_content", "center");
-    setFlex(ubId, "align_items", "center");
-    setBackground(ubId, APP_SURFACE);
-    setBorder(ubId, APP_BORDER, 1, 4);
-    createLabel(ubId + "-lbl", tpUndoBtns[ub], ubId);
-    setFontSize(ubId + "-lbl", 9);
-    setPointerEvents(ubId + "-lbl", "none");
-    registerClick(ubId);
+function buildTokenPopupControls() {
+    for (var ub = 0; ub < tpUndoBtns.length; ub++) {
+        var ubId = "tp-btn-" + ub;
+        createCol(ubId, "tp-undo-row");
+        setFlex(ubId, "width", ub === 2 ? 44 : 48);
+        setFlex(ubId, "min_width", ub === 2 ? 44 : 48);
+        setFlex(ubId, "max_width", ub === 2 ? 44 : 48);
+        setFlex(ubId, "flex_shrink", 0);
+        setFlex(ubId, "height", 22);
+        setFlex(ubId, "justify_content", "center");
+        setFlex(ubId, "align_items", "center");
+        setBackground(ubId, APP_SURFACE);
+        setBorder(ubId, APP_BORDER, 1, 4);
+        createLabel(ubId + "-lbl", tpUndoBtns[ub], ubId);
+        setFontSize(ubId + "-lbl", 9);
+        setPointerEvents(ubId + "-lbl", "none");
+        registerClick(ubId);
+    }
+
+    on("tp-btn-0", "click", function() { // Undo
+        if (!tokenEditState.activeToken) return;
+        var h = tokenHistory(tokenEditState.activeToken);
+        if (h.cursor > 0) {
+            h.cursor--;
+            var hex = h.stack[h.cursor];
+            var obj = { colors: {} };
+            obj.colors[tokenEditState.activeToken] = hex;
+            applyTokenDiff(JSON.stringify(obj));
+            pushThemeSnapshot();
+            tokenEditState.modified[tokenEditState.activeToken] = (hex !== h.original);
+            if (!tokenEditState.modified[tokenEditState.activeToken])
+                delete tokenEditState.modified[tokenEditState.activeToken];
+            updateTokenSwatches();
+            updateModifiedCount();
+            updateAllTokenNameDisplays();
+            updatePopupState(tokenEditState.activeToken);
+            layout();
+        }
+    });
+
+    on("tp-btn-1", "click", function() { // Redo
+        if (!tokenEditState.activeToken) return;
+        var h = tokenHistory(tokenEditState.activeToken);
+        if (h.cursor < h.stack.length - 1) {
+            h.cursor++;
+            var hex = h.stack[h.cursor];
+            var obj = { colors: {} };
+            obj.colors[tokenEditState.activeToken] = hex;
+            applyTokenDiff(JSON.stringify(obj));
+            pushThemeSnapshot();
+            tokenEditState.modified[tokenEditState.activeToken] = (hex !== h.original);
+            if (!tokenEditState.modified[tokenEditState.activeToken])
+                delete tokenEditState.modified[tokenEditState.activeToken];
+            updateTokenSwatches();
+            updateModifiedCount();
+            updateAllTokenNameDisplays();
+            updatePopupState(tokenEditState.activeToken);
+            layout();
+        }
+    });
+
+    on("tp-btn-2", "click", function() { // Reset
+        if (!tokenEditState.activeToken) return;
+        resetTokenColor(tokenEditState.activeToken);
+    });
+
+    // Hex input in popup
+    createRow("tp-hex-row", "token-popup");
+    setFlex("tp-hex-row", "height", 24);
+    setFlex("tp-hex-row", "gap", 6);
+    setFlex("tp-hex-row", "align_items", "center");
+    createLabel("tp-hex-lbl", "Hex", "tp-hex-row");
+    setFontSize("tp-hex-lbl", 10);
+    setTextColor("tp-hex-lbl", APP_TEXT_DIM);
+    createTextEditor("tp-hex-input", "tp-hex-row");
+    setFlex("tp-hex-input", "flex_grow", 1);
+    setFlex("tp-hex-input", "height", 22);
+    setFontSize("tp-hex-input", 11);
+    on("tp-hex-input", "return", function(text) {
+        var hex = text.trim();
+        if (!tokenEditState.activeToken) return;
+        if (!/^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/.test(hex)) return;
+        if (hex.length === 7) hex = applyHexAlpha(hex, getValue("tp-alpha-fdr"));
+        applyTokenColor(tokenEditState.activeToken, hex);
+    });
+    on("tp-hex-input", "escape", function() {
+        closeTokenPopup();
+    });
+
+    // #62: Token alpha (opacity) fader
+    createRow("tp-alpha-row", "token-popup");
+    setFlex("tp-alpha-row", "height", 20);
+    setFlex("tp-alpha-row", "gap", 6);
+    setFlex("tp-alpha-row", "align_items", "center");
+    createLabel("tp-alpha-lbl", "Alpha", "tp-alpha-row");
+    setFontSize("tp-alpha-lbl", 9);
+    setTextColor("tp-alpha-lbl", APP_TEXT_DIM);
+    setFlex("tp-alpha-lbl", "width", 30);
+    createFader("tp-alpha-fdr", "horizontal", "tp-alpha-row");
+    setFlex("tp-alpha-fdr", "flex_grow", 1);
+    setFlex("tp-alpha-fdr", "height", 14);
+    setValue("tp-alpha-fdr", 1.0);
+    createLabel("tp-alpha-val", "1.0", "tp-alpha-row");
+    setFontSize("tp-alpha-val", 9);
+    setFlex("tp-alpha-val", "width", 24);
+    on("tp-alpha-fdr", "change", function() {
+        var alpha = getValue("tp-alpha-fdr");
+        setText("tp-alpha-val", alpha.toFixed(1));
+        if (tokenEditState.activeToken) {
+            var themeColors = JSON.parse(getThemeJson()).colors || {};
+            var currentHex = themeColors[tokenEditState.activeToken] || '#000000';
+            applyTokenColor(tokenEditState.activeToken, applyHexAlpha(currentHex, alpha), { flash: false });
+        }
+    });
+
+    // 5 palette shade grids
+    createCol("tp-palettes", "token-popup");
+    setFlex("tp-palettes", "gap", 6);
+
+    for (var pp = 0; pp < paletteNames.length; pp++) {
+        var ppId = "tp-pal-" + pp;
+        createCol(ppId, "tp-palettes");
+        setFlex(ppId, "gap", 2);
+
+        createLabel(ppId + "-title", paletteNames[pp].toUpperCase(), ppId);
+        setFontSize(ppId + "-title", 9);
+        setTextColor(ppId + "-title", APP_TEXT_DIM);
+        setFlex(ppId + "-title", "height", 14);
+
+        createRow(ppId + "-row", ppId);
+        setFlex(ppId + "-row", "gap", 2);
+        setFlex(ppId + "-row", "height", 20);
+
+        for (var ps = 0; ps < ShadeGenerator.STEPS.length; ps++) {
+            var psId = ppId + "-s" + ps;
+            createCol(psId, ppId + "-row");
+            setFlex(psId, "flex_grow", 1);
+            setFlex(psId, "height", 20);
+            setBorder(psId, APP_BORDER, 0, 2);
+            registerClick(psId);
+            (function(palIdx, shadeIdx) {
+                on("tp-pal-" + palIdx + "-s" + shadeIdx, "click", function() {
+                    if (!tokenEditState.activeToken) return;
+                    var palette = PaletteSystem.create(currentAccent, currentHarmony);
+                    var pKey = paletteKeys[palIdx];
+                    var hex = palette[pKey][ShadeGenerator.STEPS[shadeIdx]].hex;
+                    hex = applyHexAlpha(hex, getValue("tp-alpha-fdr"));
+                    applyTokenColor(tokenEditState.activeToken, hex);
+                });
+            })(pp, ps);
+        }
+    }
 }
-
-on("tp-btn-0", "click", function() { // Undo
-    if (!tokenEditState.activeToken) return;
-    var h = tokenHistory(tokenEditState.activeToken);
-    if (h.cursor > 0) {
-        h.cursor--;
-        var hex = h.stack[h.cursor];
-        var obj = { colors: {} };
-        obj.colors[tokenEditState.activeToken] = hex;
-        applyTokenDiff(JSON.stringify(obj));
-        pushThemeSnapshot();
-        tokenEditState.modified[tokenEditState.activeToken] = (hex !== h.original);
-        if (!tokenEditState.modified[tokenEditState.activeToken])
-            delete tokenEditState.modified[tokenEditState.activeToken];
-        updateTokenSwatches();
-        updateModifiedCount();
-        updateAllTokenNameDisplays();
-        updatePopupState(tokenEditState.activeToken);
-        layout();
-    }
-});
-
-on("tp-btn-1", "click", function() { // Redo
-    if (!tokenEditState.activeToken) return;
-    var h = tokenHistory(tokenEditState.activeToken);
-    if (h.cursor < h.stack.length - 1) {
-        h.cursor++;
-        var hex = h.stack[h.cursor];
-        var obj = { colors: {} };
-        obj.colors[tokenEditState.activeToken] = hex;
-        applyTokenDiff(JSON.stringify(obj));
-        pushThemeSnapshot();
-        tokenEditState.modified[tokenEditState.activeToken] = (hex !== h.original);
-        if (!tokenEditState.modified[tokenEditState.activeToken])
-            delete tokenEditState.modified[tokenEditState.activeToken];
-        updateTokenSwatches();
-        updateModifiedCount();
-        updateAllTokenNameDisplays();
-        updatePopupState(tokenEditState.activeToken);
-        layout();
-    }
-});
-
-on("tp-btn-2", "click", function() { // Reset
-    if (!tokenEditState.activeToken) return;
-    resetTokenColor(tokenEditState.activeToken);
-});
-
-// Hex input in popup
-createRow("tp-hex-row", "token-popup");
-setFlex("tp-hex-row", "height", 24);
-setFlex("tp-hex-row", "gap", 6);
-setFlex("tp-hex-row", "align_items", "center");
-createLabel("tp-hex-lbl", "Hex", "tp-hex-row");
-setFontSize("tp-hex-lbl", 10);
-setTextColor("tp-hex-lbl", APP_TEXT_DIM);
-createTextEditor("tp-hex-input", "tp-hex-row");
-setFlex("tp-hex-input", "flex_grow", 1);
-setFlex("tp-hex-input", "height", 22);
-setFontSize("tp-hex-input", 11);
-on("tp-hex-input", "return", function(text) {
-    var hex = text.trim();
-    if (!tokenEditState.activeToken) return;
-    if (!/^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/.test(hex)) return;
-    if (hex.length === 7) hex = applyHexAlpha(hex, getValue("tp-alpha-fdr"));
-    applyTokenColor(tokenEditState.activeToken, hex);
-});
-on("tp-hex-input", "escape", function() {
-    closeTokenPopup();
-});
-
-// #62: Token alpha (opacity) fader
-createRow("tp-alpha-row", "token-popup");
-setFlex("tp-alpha-row", "height", 20);
-setFlex("tp-alpha-row", "gap", 6);
-setFlex("tp-alpha-row", "align_items", "center");
-createLabel("tp-alpha-lbl", "Alpha", "tp-alpha-row");
-setFontSize("tp-alpha-lbl", 9);
-setTextColor("tp-alpha-lbl", APP_TEXT_DIM);
-setFlex("tp-alpha-lbl", "width", 30);
-createFader("tp-alpha-fdr", "horizontal", "tp-alpha-row");
-setFlex("tp-alpha-fdr", "flex_grow", 1);
-setFlex("tp-alpha-fdr", "height", 14);
-setValue("tp-alpha-fdr", 1.0);
-createLabel("tp-alpha-val", "1.0", "tp-alpha-row");
-setFontSize("tp-alpha-val", 9);
-setFlex("tp-alpha-val", "width", 24);
-on("tp-alpha-fdr", "change", function() {
-    var alpha = getValue("tp-alpha-fdr");
-    setText("tp-alpha-val", alpha.toFixed(1));
-    if (tokenEditState.activeToken) {
-        var themeColors = JSON.parse(getThemeJson()).colors || {};
-        var currentHex = themeColors[tokenEditState.activeToken] || '#000000';
-        applyTokenColor(tokenEditState.activeToken, applyHexAlpha(currentHex, alpha), { flash: false });
-    }
-});
-
-// 5 palette shade grids
-createCol("tp-palettes", "token-popup");
-setFlex("tp-palettes", "gap", 6);
-
-for (var pp = 0; pp < paletteNames.length; pp++) {
-    var ppId = "tp-pal-" + pp;
-    createCol(ppId, "tp-palettes");
-    setFlex(ppId, "gap", 2);
-
-    createLabel(ppId + "-title", paletteNames[pp].toUpperCase(), ppId);
-    setFontSize(ppId + "-title", 9);
-    setTextColor(ppId + "-title", APP_TEXT_DIM);
-    setFlex(ppId + "-title", "height", 14);
-
-    createRow(ppId + "-row", ppId);
-    setFlex(ppId + "-row", "gap", 2);
-    setFlex(ppId + "-row", "height", 20);
-
-    for (var ps = 0; ps < ShadeGenerator.STEPS.length; ps++) {
-        var psId = ppId + "-s" + ps;
-        createCol(psId, ppId + "-row");
-        setFlex(psId, "flex_grow", 1);
-        setFlex(psId, "height", 20);
-        setBorder(psId, APP_BORDER, 0, 2);
-        registerClick(psId);
-        (function(palIdx, shadeIdx) {
-            on("tp-pal-" + palIdx + "-s" + shadeIdx, "click", function() {
-                if (!tokenEditState.activeToken) return;
-                var palette = PaletteSystem.create(currentAccent, currentHarmony);
-                var pKey = paletteKeys[palIdx];
-                var hex = palette[pKey][ShadeGenerator.STEPS[shadeIdx]].hex;
-                hex = applyHexAlpha(hex, getValue("tp-alpha-fdr"));
-                applyTokenColor(tokenEditState.activeToken, hex);
-            });
-        })(pp, ps);
-    }
-}
+buildTokenPopupControls();
 
 // Custom HCL section (expandable)
 var tpCustomOpen = false;
-createRow("tp-custom-toggle", "token-popup");
-setFlex("tp-custom-toggle", "height", 22);
-setFlex("tp-custom-toggle", "align_items", "center");
-registerClick("tp-custom-toggle");
-createLabel("tp-custom-lbl", "\u25b6 Custom color picker", "tp-custom-toggle");
-setFontSize("tp-custom-lbl", 10);
-setTextColor("tp-custom-lbl", APP_TEXT_DIM);
-setPointerEvents("tp-custom-lbl", "none");
+function buildTokenPopupCustomToggle() {
+    createRow("tp-custom-toggle", "token-popup");
+    setFlex("tp-custom-toggle", "height", 22);
+    setFlex("tp-custom-toggle", "align_items", "center");
+    registerClick("tp-custom-toggle");
+    createLabel("tp-custom-lbl", "\u25b6 Custom color picker", "tp-custom-toggle");
+    setFontSize("tp-custom-lbl", 10);
+    setTextColor("tp-custom-lbl", APP_TEXT_DIM);
+    setPointerEvents("tp-custom-lbl", "none");
 
-createCol("tp-custom", "token-popup");
-setFlex("tp-custom", "gap", 4);
-setVisible("tp-custom", false);
+    createCol("tp-custom", "token-popup");
+    setFlex("tp-custom", "gap", 4);
+    setVisible("tp-custom", false);
+}
+buildTokenPopupCustomToggle();
 
 // D2: Gamut triangle canvas — rendered as grid of colored rectangles
 var GAMUT_W = 50;  // columns (lightness steps)
@@ -2714,25 +2762,28 @@ var tpPopupShaderHueBucket = -1;
 var tpPopupSliderApplyFrame = 0;
 var tpPopupSliderPending = null;
 
-createCol("tp-gamut-wrap", "tp-custom");
-setPosition("tp-gamut-wrap", "relative");
-setFlex("tp-gamut-wrap", "width", 250);
-setFlex("tp-gamut-wrap", "height", 120);
-setFlex("tp-gamut-wrap", "flex_shrink", 0);
+function buildTokenPopupGamut() {
+    createCol("tp-gamut-wrap", "tp-custom");
+    setPosition("tp-gamut-wrap", "relative");
+    setFlex("tp-gamut-wrap", "width", 250);
+    setFlex("tp-gamut-wrap", "height", 120);
+    setFlex("tp-gamut-wrap", "flex_shrink", 0);
 
-createCanvas("tp-gamut", "tp-gamut-wrap");
-setFlex("tp-gamut", "width", 250);
-setFlex("tp-gamut", "height", 120);
-setBackground("tp-gamut", APP_SURFACE);
-setPointerEvents("tp-gamut", "none");
+    createCanvas("tp-gamut", "tp-gamut-wrap");
+    setFlex("tp-gamut", "width", 250);
+    setFlex("tp-gamut", "height", 120);
+    setBackground("tp-gamut", APP_SURFACE);
+    setPointerEvents("tp-gamut", "none");
 
-createCanvas("tp-gamut-overlay", "tp-gamut-wrap");
-setPosition("tp-gamut-overlay", "absolute");
-setTop("tp-gamut-overlay", 0);
-setLeft("tp-gamut-overlay", 0);
-setFlex("tp-gamut-overlay", "width", 250);
-setFlex("tp-gamut-overlay", "height", 120);
-registerPointer("tp-gamut-overlay");
+    createCanvas("tp-gamut-overlay", "tp-gamut-wrap");
+    setPosition("tp-gamut-overlay", "absolute");
+    setTop("tp-gamut-overlay", 0);
+    setLeft("tp-gamut-overlay", 0);
+    setFlex("tp-gamut-overlay", "width", 250);
+    setFlex("tp-gamut-overlay", "height", 120);
+    registerPointer("tp-gamut-overlay");
+}
+buildTokenPopupGamut();
 
 function renderTokenPopupGamutOverlay(renderHue, dotL, dotC, dotHex) {
     var overlayId = "tp-gamut-overlay";
@@ -2880,71 +2931,74 @@ function handleTokenPopupGamutPointer(evt, commit) {
     applyTokenPopupGamutPoint(evt.offsetX, evt.offsetY, commit);
 }
 
-on("tp-gamut-overlay", "pointerdown", function(evt) {
-    tpPopupGamutDragActive = true;
-    nativeSetPointerCapture("tp-gamut-overlay", evt && evt.pointerId ? evt.pointerId : 0);
-    handleTokenPopupGamutPointer(evt, false);
-});
-on("tp-gamut-overlay", "pointermove", function(evt) {
-    if (!tpPopupGamutDragActive) return;
-    handleTokenPopupGamutPointer(evt, false);
-});
-on("tp-gamut-overlay", "pointerup", function(evt) {
-    if (!tpPopupGamutDragActive) return;
-    tpPopupGamutDragActive = false;
-    handleTokenPopupGamutPointer(evt, true);
-    nativeReleasePointerCapture("tp-gamut-overlay", evt && evt.pointerId ? evt.pointerId : 0);
-    updatePopupState(tokenEditState.activeToken);
-});
-on("tp-gamut-overlay", "pointercancel", function(evt) {
-    tpPopupGamutDragActive = false;
-    nativeReleasePointerCapture("tp-gamut-overlay", evt && evt.pointerId ? evt.pointerId : 0);
-    if (tokenEditState.activeToken) updatePopupState(tokenEditState.activeToken);
-});
+function wireTokenPopupGamut() {
+    on("tp-gamut-overlay", "pointerdown", function(evt) {
+        tpPopupGamutDragActive = true;
+        nativeSetPointerCapture("tp-gamut-overlay", evt && evt.pointerId ? evt.pointerId : 0);
+        handleTokenPopupGamutPointer(evt, false);
+    });
+    on("tp-gamut-overlay", "pointermove", function(evt) {
+        if (!tpPopupGamutDragActive) return;
+        handleTokenPopupGamutPointer(evt, false);
+    });
+    on("tp-gamut-overlay", "pointerup", function(evt) {
+        if (!tpPopupGamutDragActive) return;
+        tpPopupGamutDragActive = false;
+        handleTokenPopupGamutPointer(evt, true);
+        nativeReleasePointerCapture("tp-gamut-overlay", evt && evt.pointerId ? evt.pointerId : 0);
+        updatePopupState(tokenEditState.activeToken);
+    });
+    on("tp-gamut-overlay", "pointercancel", function(evt) {
+        tpPopupGamutDragActive = false;
+        nativeReleasePointerCapture("tp-gamut-overlay", evt && evt.pointerId ? evt.pointerId : 0);
+        if (tokenEditState.activeToken) updatePopupState(tokenEditState.activeToken);
+    });
 
-// H (hue) fader
-createRow("tp-hue-row", "tp-custom");
-setFlex("tp-hue-row", "height", 24);
-setFlex("tp-hue-row", "gap", 6);
-setFlex("tp-hue-row", "align_items", "center");
-createLabel("tp-h-fader-lbl", "H", "tp-hue-row");
-setFontSize("tp-h-fader-lbl", 10);
-setFlex("tp-h-fader-lbl", "width", 14);
-createFader("tp-h-fader", "horizontal", "tp-hue-row");
-setFlex("tp-h-fader", "flex_grow", 1);
-setFlex("tp-h-fader", "height", 20);
+    // H (hue) fader
+    createRow("tp-hue-row", "tp-custom");
+    setFlex("tp-hue-row", "height", 24);
+    setFlex("tp-hue-row", "gap", 6);
+    setFlex("tp-hue-row", "align_items", "center");
+    createLabel("tp-h-fader-lbl", "H", "tp-hue-row");
+    setFontSize("tp-h-fader-lbl", 10);
+    setFlex("tp-h-fader-lbl", "width", 14);
+    createFader("tp-h-fader", "horizontal", "tp-hue-row");
+    setFlex("tp-h-fader", "flex_grow", 1);
+    setFlex("tp-h-fader", "height", 20);
 
-// C (chroma) fader
-createRow("tp-chroma-row", "tp-custom");
-setFlex("tp-chroma-row", "height", 24);
-setFlex("tp-chroma-row", "gap", 6);
-setFlex("tp-chroma-row", "align_items", "center");
-createLabel("tp-c-fader-lbl", "C", "tp-chroma-row");
-setFontSize("tp-c-fader-lbl", 10);
-setFlex("tp-c-fader-lbl", "width", 14);
-createFader("tp-c-fader", "horizontal", "tp-chroma-row");
-setFlex("tp-c-fader", "flex_grow", 1);
-setFlex("tp-c-fader", "height", 20);
+    // C (chroma) fader
+    createRow("tp-chroma-row", "tp-custom");
+    setFlex("tp-chroma-row", "height", 24);
+    setFlex("tp-chroma-row", "gap", 6);
+    setFlex("tp-chroma-row", "align_items", "center");
+    createLabel("tp-c-fader-lbl", "C", "tp-chroma-row");
+    setFontSize("tp-c-fader-lbl", 10);
+    setFlex("tp-c-fader-lbl", "width", 14);
+    createFader("tp-c-fader", "horizontal", "tp-chroma-row");
+    setFlex("tp-c-fader", "flex_grow", 1);
+    setFlex("tp-c-fader", "height", 20);
 
-// L (lightness) fader
-createRow("tp-light-row", "tp-custom");
-setFlex("tp-light-row", "height", 24);
-setFlex("tp-light-row", "gap", 6);
-setFlex("tp-light-row", "align_items", "center");
-createLabel("tp-l-fader-lbl", "L", "tp-light-row");
-setFontSize("tp-l-fader-lbl", 10);
-setFlex("tp-l-fader-lbl", "width", 14);
-createFader("tp-l-fader", "horizontal", "tp-light-row");
-setFlex("tp-l-fader", "flex_grow", 1);
-setFlex("tp-l-fader", "height", 20);
+    // L (lightness) fader
+    createRow("tp-light-row", "tp-custom");
+    setFlex("tp-light-row", "height", 24);
+    setFlex("tp-light-row", "gap", 6);
+    setFlex("tp-light-row", "align_items", "center");
+    createLabel("tp-l-fader-lbl", "L", "tp-light-row");
+    setFontSize("tp-l-fader-lbl", 10);
+    setFlex("tp-l-fader-lbl", "width", 14);
+    createFader("tp-l-fader", "horizontal", "tp-light-row");
+    setFlex("tp-l-fader", "flex_grow", 1);
+    setFlex("tp-l-fader", "height", 20);
 
-// OKLCH value display
-createRow("tp-oklch-vals", "tp-custom");
-setFlex("tp-oklch-vals", "height", 16);
-setFlex("tp-oklch-vals", "gap", 8);
-createLabel("tp-oklch-display", "L: 0.50  C: 0.100  H: 180", "tp-oklch-vals");
-setFontSize("tp-oklch-display", 9);
-setTextColor("tp-oklch-display", APP_TEXT_DIM);
+    // OKLCH value display
+    createRow("tp-oklch-vals", "tp-custom");
+    setFlex("tp-oklch-vals", "height", 16);
+    setFlex("tp-oklch-vals", "gap", 8);
+    createLabel("tp-oklch-display", "L: 0.50  C: 0.100  H: 180", "tp-oklch-vals");
+    setFontSize("tp-oklch-display", 9);
+    setTextColor("tp-oklch-display", APP_TEXT_DIM);
+}
+wireTokenPopupGamut();
 
 function onTpHclChange(hueChanged, forceApply) {
     if (tpPopupHclSyncActive || !tokenEditState.activeToken) return;
@@ -2995,33 +3049,36 @@ function endTokenPopupSliderDrag(hueChanged) {
     onTpHclChange(!!hueChanged, true);
 }
 
-on("tp-h-fader", "pointerdown", function() { beginTokenPopupSliderDrag("h"); });
-on("tp-h-fader", "pointerup", function() { endTokenPopupSliderDrag(true); });
-on("tp-h-fader", "pointercancel", function() { endTokenPopupSliderDrag(true); });
-on("tp-c-fader", "pointerdown", function() { beginTokenPopupSliderDrag("c"); });
-on("tp-c-fader", "pointerup", function() { endTokenPopupSliderDrag(false); });
-on("tp-c-fader", "pointercancel", function() { endTokenPopupSliderDrag(false); });
-on("tp-l-fader", "pointerdown", function() { beginTokenPopupSliderDrag("l"); });
-on("tp-l-fader", "pointerup", function() { endTokenPopupSliderDrag(false); });
-on("tp-l-fader", "pointercancel", function() { endTokenPopupSliderDrag(false); });
-on("tp-h-fader", "change", function() { onTpHclChange(true, false); });
-on("tp-c-fader", "change", function() { onTpHclChange(false, false); });
-on("tp-l-fader", "change", function() { onTpHclChange(false, false); });
+function wireTokenPopupSliders() {
+    on("tp-h-fader", "pointerdown", function() { beginTokenPopupSliderDrag("h"); });
+    on("tp-h-fader", "pointerup", function() { endTokenPopupSliderDrag(true); });
+    on("tp-h-fader", "pointercancel", function() { endTokenPopupSliderDrag(true); });
+    on("tp-c-fader", "pointerdown", function() { beginTokenPopupSliderDrag("c"); });
+    on("tp-c-fader", "pointerup", function() { endTokenPopupSliderDrag(false); });
+    on("tp-c-fader", "pointercancel", function() { endTokenPopupSliderDrag(false); });
+    on("tp-l-fader", "pointerdown", function() { beginTokenPopupSliderDrag("l"); });
+    on("tp-l-fader", "pointerup", function() { endTokenPopupSliderDrag(false); });
+    on("tp-l-fader", "pointercancel", function() { endTokenPopupSliderDrag(false); });
+    on("tp-h-fader", "change", function() { onTpHclChange(true, false); });
+    on("tp-c-fader", "change", function() { onTpHclChange(false, false); });
+    on("tp-l-fader", "change", function() { onTpHclChange(false, false); });
 
-on("tp-custom-toggle", "click", function() {
-    tpCustomOpen = !tpCustomOpen;
-    setVisible("tp-custom", tpCustomOpen);
-    setText("tp-custom-lbl", tpCustomOpen ? "\u25bc Custom color picker" : "\u25b6 Custom color picker");
-    if (tpCustomOpen && tokenEditState.activeToken) {
-        var hex = (JSON.parse(getThemeJson()).colors || {})[tokenEditState.activeToken] || '#808080';
-        var oklch = OklchEngine.hexToOklch(hex);
-        applyTokenPopupSliderShaders(oklch.H);
-        updateTokenPopupCustomUi(oklch, oklch.H, true, true);
-    }
-    layout();
-    if (tokenEditState.activeSwatchId) positionTokenPopup(tokenEditState.activeSwatchId);
-    layout();
-});
+    on("tp-custom-toggle", "click", function() {
+        tpCustomOpen = !tpCustomOpen;
+        setVisible("tp-custom", tpCustomOpen);
+        setText("tp-custom-lbl", tpCustomOpen ? "\u25bc Custom color picker" : "\u25b6 Custom color picker");
+        if (tpCustomOpen && tokenEditState.activeToken) {
+            var hex = (JSON.parse(getThemeJson()).colors || {})[tokenEditState.activeToken] || '#808080';
+            var oklch = OklchEngine.hexToOklch(hex);
+            applyTokenPopupSliderShaders(oklch.H);
+            updateTokenPopupCustomUi(oklch, oklch.H, true, true);
+        }
+        layout();
+        if (tokenEditState.activeSwatchId) positionTokenPopup(tokenEditState.activeSwatchId);
+        layout();
+    });
+}
+wireTokenPopupSliders();
 
 // ── Popup open/close/update functions ───────────────────────────
 function rebuildPopupPalette() {
@@ -3113,106 +3170,112 @@ function closeTokenPopup() {
 }
 
 // ── Accent hue slider handler ────────────────────────────────────
-on("accent-hue", "pointerdown", function() {
-    var accent = OklchEngine.hexToOklch(currentAccent);
-    accentHueBaseL = accent.L;
-    accentHueBaseC = accent.C;
-    accentHuePreviewCache = {};
-    accentHueDragActive = true;
-});
-on("accent-hue", "pointerup", function() {
-    accentHueDragActive = false;
-    scheduleAccentHueApply(true);
-});
-on("accent-hue", "pointercancel", function() {
-    accentHueDragActive = false;
-    scheduleAccentHueApply(true);
-});
-on("accent-hue", "change", function(val) {
-    accentHuePendingHue = val * 360;
-    scheduleAccentHueApply(false);
-});
+function wireAccentHueAndSelectors() {
+    on("accent-hue", "pointerdown", function() {
+        var accent = OklchEngine.hexToOklch(currentAccent);
+        accentHueBaseL = accent.L;
+        accentHueBaseC = accent.C;
+        accentHuePreviewCache = {};
+        accentHueDragActive = true;
+    });
+    on("accent-hue", "pointerup", function() {
+        accentHueDragActive = false;
+        scheduleAccentHueApply(true);
+    });
+    on("accent-hue", "pointercancel", function() {
+        accentHueDragActive = false;
+        scheduleAccentHueApply(true);
+    });
+    on("accent-hue", "change", function(val) {
+        accentHuePendingHue = val * 360;
+        scheduleAccentHueApply(false);
+    });
 
-// Harmony selector handler
-// Harmony change: update palette colors in-place (no widget tree mutation)
-on("harmony-selector", "select", function(idx) {
-    var modes = ["monochromatic", "analogous", "complementary", "splitComplementary", "none"];
-    if (idx >= 0 && idx < modes.length) {
-        currentHarmony = modes[idx];
-        setSelected("harmony-selector", idx);
-        // Just update colors — don't rebuild widget tree during mouse event
-        var palette = PaletteSystem.create(currentAccent, currentHarmony);
-        applyPaletteThemeDiff(palette, currentPaletteMode);
-        updateTokenSwatches();
-        refreshPaletteEditorsFromPalette(palette, true, true);
-        markCurrentModeDirty();
+    // Harmony selector handler
+    // Harmony change: update palette colors in-place (no widget tree mutation)
+    on("harmony-selector", "select", function(idx) {
+        var modes = ["monochromatic", "analogous", "complementary", "splitComplementary", "none"];
+        if (idx >= 0 && idx < modes.length) {
+            currentHarmony = modes[idx];
+            setSelected("harmony-selector", idx);
+            // Just update colors — don't rebuild widget tree during mouse event
+            var palette = PaletteSystem.create(currentAccent, currentHarmony);
+            applyPaletteThemeDiff(palette, currentPaletteMode);
+            updateTokenSwatches();
+            refreshPaletteEditorsFromPalette(palette, true, true);
+            markCurrentModeDirty();
+            layout();
+        }
+    });
+
+    // Dark/Light mode handler
+    on("mode-selector", "select", function(idx) {
+        switchPaletteMode(idx === 0 ? "dark" : "light");
+        refreshPaletteEditorsFromPalette(PaletteSystem.create(currentAccent, currentHarmony), true, true);
+        pushThemeSnapshot();
         layout();
-    }
-});
+    });
 
-// Dark/Light mode handler
-on("mode-selector", "select", function(idx) {
-    switchPaletteMode(idx === 0 ? "dark" : "light");
-    refreshPaletteEditorsFromPalette(PaletteSystem.create(currentAccent, currentHarmony), true, true);
-    pushThemeSnapshot();
-    layout();
-});
+    // ── CENTER PANEL (Preview) ───────────────────────────────────────
+    createCol("center-panel", "main-area");
+    setFlex("center-panel", "flex_grow", 1);
+    setFlex("center-panel", "flex_shrink", 1);
+    setFlex("center-panel", "min_width", 420);  // Issue 5: prevent scrollbar behind content
+    setFlex("center-panel", "padding", 16);
+    setFlex("center-panel", "gap", 8);
+    setBackground("center-panel", APP_BG);
 
-// ── CENTER PANEL (Preview) ───────────────────────────────────────
-createCol("center-panel", "main-area");
-setFlex("center-panel", "flex_grow", 1);
-setFlex("center-panel", "flex_shrink", 1);
-setFlex("center-panel", "min_width", 420);  // Issue 5: prevent scrollbar behind content
-setFlex("center-panel", "padding", 16);
-setFlex("center-panel", "gap", 8);
-setBackground("center-panel", APP_BG);
+    createCol("preview-shell", "center-panel");
+    setFlex("preview-shell", "flex_grow", 1);
+    setFlex("preview-shell", "gap", 0);
+    setBackground("preview-shell", APP_PANEL);
+    setBorder("preview-shell", APP_BORDER, 1, 12);
 
-createCol("preview-shell", "center-panel");
-setFlex("preview-shell", "flex_grow", 1);
-setFlex("preview-shell", "gap", 0);
-setBackground("preview-shell", APP_PANEL);
-setBorder("preview-shell", APP_BORDER, 1, 12);
-
-createRow("preview-chrome", "preview-shell");
-setFlex("preview-chrome", "height", 26);
-setFlex("preview-chrome", "padding_left", 10);
-setFlex("preview-chrome", "padding_right", 10);
-setFlex("preview-chrome", "gap", 6);
-setFlex("preview-chrome", "align_items", "center");
-setBackground("preview-chrome", APP_PANEL_RAISED);
+    createRow("preview-chrome", "preview-shell");
+    setFlex("preview-chrome", "height", 26);
+    setFlex("preview-chrome", "padding_left", 10);
+    setFlex("preview-chrome", "padding_right", 10);
+    setFlex("preview-chrome", "gap", 6);
+    setFlex("preview-chrome", "align_items", "center");
+    setBackground("preview-chrome", APP_PANEL_RAISED);
+}
+wireAccentHueAndSelectors();
 
 var previewChromeDots = ["#ff5f57", "#febc2e", "#28c840"];
-for (var pcd = 0; pcd < previewChromeDots.length; pcd++) {
-    var dotId = "preview-chrome-dot-" + pcd;
-    createCol(dotId, "preview-chrome");
-    setFlex(dotId, "width", 8);
-    setFlex(dotId, "height", 8);
-    setBackground(dotId, previewChromeDots[pcd]);
-    setBorder(dotId, previewChromeDots[pcd], 0, 4);
+function buildPreviewChrome() {
+    for (var pcd = 0; pcd < previewChromeDots.length; pcd++) {
+        var dotId = "preview-chrome-dot-" + pcd;
+        createCol(dotId, "preview-chrome");
+        setFlex(dotId, "width", 8);
+        setFlex(dotId, "height", 8);
+        setBackground(dotId, previewChromeDots[pcd]);
+        setBorder(dotId, previewChromeDots[pcd], 0, 4);
+    }
+
+    createLabel("preview-chrome-title", "Plugin Preview", "preview-chrome");
+    setFontSize("preview-chrome-title", 10);
+    setTextColor("preview-chrome-title", APP_TEXT_DIM);
+    setFlex("preview-chrome-title", "padding_left", 4);
+
+    createCol("preview-chrome-divider", "preview-shell");
+    setFlex("preview-chrome-divider", "height", 1);
+    setBackground("preview-chrome-divider", APP_BORDER);
+
+    // Preview content area (scrollable, inside a plugin-style shell)
+    createScrollView("preview-scroll", "preview-shell");
+    setFlex("preview-scroll", "flex_grow", 1);
+    setBackground("preview-scroll", APP_BG);
+    setBorder("preview-scroll", APP_BORDER, 0, 0);
+    setScrollContentSize("preview-scroll", 500, 1900);
+
+    createCol("preview-area", "preview-scroll");
+    setFlex("preview-area", "height", 1900);
+    setFlex("preview-area", "flex_shrink", 0);
+    setFlex("preview-area", "padding", 14);
+    setFlex("preview-area", "padding_right", 28);  // extra space for scrollbar
+    setFlex("preview-area", "gap", 10);
 }
-
-createLabel("preview-chrome-title", "Plugin Preview", "preview-chrome");
-setFontSize("preview-chrome-title", 10);
-setTextColor("preview-chrome-title", APP_TEXT_DIM);
-setFlex("preview-chrome-title", "padding_left", 4);
-
-createCol("preview-chrome-divider", "preview-shell");
-setFlex("preview-chrome-divider", "height", 1);
-setBackground("preview-chrome-divider", APP_BORDER);
-
-// Preview content area (scrollable, inside a plugin-style shell)
-createScrollView("preview-scroll", "preview-shell");
-setFlex("preview-scroll", "flex_grow", 1);
-setBackground("preview-scroll", APP_BG);
-setBorder("preview-scroll", APP_BORDER, 0, 0);
-setScrollContentSize("preview-scroll", 500, 1900);
-
-createCol("preview-area", "preview-scroll");
-setFlex("preview-area", "height", 1900);
-setFlex("preview-area", "flex_shrink", 0);
-setFlex("preview-area", "padding", 14);
-setFlex("preview-area", "padding_right", 28);  // extra space for scrollbar
-setFlex("preview-area", "gap", 10);
+buildPreviewChrome();
 
 function stylePreviewSectionHeader(id) {
     setFontSize(id, 10);
@@ -3222,279 +3285,288 @@ function stylePreviewSectionHeader(id) {
 }
 
 // Foundations section: bg swatches + text hierarchy
-createLabel("foundations-header", "FOUNDATIONS", "preview-area");
-stylePreviewSectionHeader("foundations-header");
+function buildPreviewFoundationsHeader() {
+    createLabel("foundations-header", "FOUNDATIONS", "preview-area");
+    stylePreviewSectionHeader("foundations-header");
 
-// Background swatches row
-createRow("bg-swatches", "preview-area");
-setFlex("bg-swatches", "gap", 6);
-setFlex("bg-swatches", "height", 32);
-setFlex("bg-swatches", "align_items", "center");
+    // Background swatches row
+    createRow("bg-swatches", "preview-area");
+    setFlex("bg-swatches", "gap", 6);
+    setFlex("bg-swatches", "height", 32);
+    setFlex("bg-swatches", "align_items", "center");
+}
+buildPreviewFoundationsHeader();
 
 var bgTokens = ["bg.primary", "bg.secondary", "bg.surface", "bg.elevated"];
 var bgLabels = ["Primary", "Secondary", "Surface", "Elevated"];
-for (var bi = 0; bi < bgTokens.length; bi++) {
-    var bsId = "bg-sw-" + bi;
-    createCol(bsId, "bg-swatches");
-    setFlex(bsId, "flex_grow", 1);
-    setFlex(bsId, "height", 28);
-    setBorder(bsId, APP_BORDER, 1, 4);
-    setFlex(bsId, "padding", 4);
-    setFlex(bsId, "justify_content", "center");
-    // Color from theme
-    var themeColors = JSON.parse(getThemeJson()).colors || {};
-    if (themeColors[bgTokens[bi]]) setBackground(bsId, themeColors[bgTokens[bi]]);
-    createLabel(bsId + "-l", bgLabels[bi], bsId);
-    setFontSize(bsId + "-l", 8);
-    setFlex(bsId + "-l", "height", 10);
+function buildPreviewControls() {
+    for (var bi = 0; bi < bgTokens.length; bi++) {
+        var bsId = "bg-sw-" + bi;
+        createCol(bsId, "bg-swatches");
+        setFlex(bsId, "flex_grow", 1);
+        setFlex(bsId, "height", 28);
+        setBorder(bsId, APP_BORDER, 1, 4);
+        setFlex(bsId, "padding", 4);
+        setFlex(bsId, "justify_content", "center");
+        // Color from theme
+        var themeColors = JSON.parse(getThemeJson()).colors || {};
+        if (themeColors[bgTokens[bi]]) setBackground(bsId, themeColors[bgTokens[bi]]);
+        createLabel(bsId + "-l", bgLabels[bi], bsId);
+        setFontSize(bsId + "-l", 8);
+        setFlex(bsId + "-l", "height", 10);
+    }
+
+    // Text hierarchy row
+    createRow("text-hierarchy", "preview-area");
+    setFlex("text-hierarchy", "gap", 16);
+    setFlex("text-hierarchy", "height", 24);
+    setFlex("text-hierarchy", "align_items", "center");
+
+    createLabel("th-heading", "Heading", "text-hierarchy");
+    setFontSize("th-heading", 16);
+    setFlex("th-heading", "width", 80);
+
+    createLabel("th-body", "Body text", "text-hierarchy");
+    setFontSize("th-body", 12);
+    setFlex("th-body", "width", 80);
+
+    createLabel("th-caption", "Caption", "text-hierarchy");
+    setFontSize("th-caption", 9);
+    setTextColor("th-caption", APP_TEXT_DIM);
+    setFlex("th-caption", "width", 60);
+
+    // Controls section: knobs
+    createLabel("controls-header", "CONTROLS", "preview-area");
+    stylePreviewSectionHeader("controls-header");
+
+    createRow("knob-row", "preview-area");
+    setFlex("knob-row", "gap", 16);
+    setFlex("knob-row", "height", 64);
+    setFlex("knob-row", "align_items", "center");
+
+    createKnob("k1", "knob-row");
+    setLabel("k1", "Gain");
+    setFlex("k1", "width", 56);
+    setFlex("k1", "height", 64);
+    setValue("k1", 0.4);
+
+    createKnob("k2", "knob-row");
+    setLabel("k2", "Freq");
+    setFlex("k2", "width", 56);
+    setFlex("k2", "height", 64);
+    setValue("k2", 0.6);
+
+    createKnob("k3", "knob-row");
+    setLabel("k3", "Res");
+    setFlex("k3", "width", 56);
+    setFlex("k3", "height", 64);
+    setValue("k3", 0.8);
+
+    createKnob("k4", "knob-row");
+    setLabel("k4", "Mix");
+    setFlex("k4", "width", 56);
+    setFlex("k4", "height", 64);
+    setValue("k4", 1.0);
+
+    // Fader
+    createFader("slider1", "horizontal", "preview-area");
+    setFlex("slider1", "height", 24);
+    setValue("slider1", 0.65);
+
+    // Buttons row (Normal, Hover, Action, Disabled)
+    createRow("btn-row", "preview-area");
+    setFlex("btn-row", "gap", 8);
+    setFlex("btn-row", "height", 32);
+    setFlex("btn-row", "align_items", "center");
+
+    createCol("btn-normal", "btn-row");
+    setFlex("btn-normal", "flex_grow", 1);
+    setFlex("btn-normal", "height", 28);
+    setBackground("btn-normal", "#3a3a4c");
+    setBorder("btn-normal", APP_BORDER, 1, 6);
+    setFlex("btn-normal", "justify_content", "center");
+    setFlex("btn-normal", "align_items", "center");
+    createLabel("btn-normal-label", "Normal", "btn-normal");
+    setFontSize("btn-normal-label", 11);
+    setFlex("btn-normal-label", "height", 16);
+
+    createCol("btn-hover", "btn-row");
+    setFlex("btn-hover", "flex_grow", 1);
+    setFlex("btn-hover", "height", 28);
+    setBackground("btn-hover", "#4a4a5c");
+    setBorder("btn-hover", APP_BORDER, 1, 6);
+    setFlex("btn-hover", "justify_content", "center");
+    setFlex("btn-hover", "align_items", "center");
+    createLabel("btn-hover-label", "Hover", "btn-hover");
+    setFontSize("btn-hover-label", 11);
+    setFlex("btn-hover-label", "height", 16);
+
+    createCol("btn-action", "btn-row");
+    setFlex("btn-action", "flex_grow", 1);
+    setFlex("btn-action", "height", 28);
+    setBackground("btn-action", APP_ACCENT);
+    setBorder("btn-action", APP_ACCENT, 0, 6);
+    setFlex("btn-action", "justify_content", "center");
+    setFlex("btn-action", "align_items", "center");
+    createLabel("btn-action-label", "Action", "btn-action");
+    setFontSize("btn-action-label", 11);
+    setFlex("btn-action-label", "height", 16);
+
+    createCol("btn-disabled", "btn-row");
+    setFlex("btn-disabled", "flex_grow", 1);
+    setFlex("btn-disabled", "height", 28);
+    setBackground("btn-disabled", "#2a2a36");
+    setBorder("btn-disabled", APP_BORDER, 1, 6);
+    setOpacity("btn-disabled", 0.5);
+    setFlex("btn-disabled", "justify_content", "center");
+    setFlex("btn-disabled", "align_items", "center");
+    createLabel("btn-disabled-label", "Disabled", "btn-disabled");
+    setFontSize("btn-disabled-label", 11);
+    setFlex("btn-disabled-label", "height", 16);
+    setTextColor("btn-disabled-label", APP_TEXT_DIM);
+
+    // Toggles + checkbox row
+    createRow("toggle-row", "preview-area");
+    setFlex("toggle-row", "gap", 10);
+    setFlex("toggle-row", "height", 28);
+    setFlex("toggle-row", "align_items", "center");
+
+    createToggle("t1", "toggle-row");
+    setFlex("t1", "width", 36);
+    setFlex("t1", "height", 20);
+    setValue("t1", 1);
+
+    createLabel("toggle-on-label", "Enabled", "toggle-row");
+    setFontSize("toggle-on-label", 11);
+    setFlex("toggle-on-label", "width", 50);
+
+    createToggle("t2", "toggle-row");
+    setFlex("t2", "width", 36);
+    setFlex("t2", "height", 20);
+
+    createLabel("toggle-off-label", "Disabled", "toggle-row");
+    setFontSize("toggle-off-label", 11);
+    setFlex("toggle-off-label", "width", 52);
+
+    // Checkbox
+    createCheckbox("cb1", "toggle-row");
+    setFlex("cb1", "width", 22);
+    setFlex("cb1", "height", 22);
+    setValue("cb1", 1);
+
+    // Toggle button row
+    createRow("toggle-btn-row", "preview-area");
+    setFlex("toggle-btn-row", "height", 32);
+    setFlex("toggle-btn-row", "gap", 8);
+
+    createToggleButton("tb1", "toggle-btn-row");
+    setLabel("tb1", "Toggle");
+    setFlex("tb1", "flex_grow", 1);
+    setFlex("tb1", "height", 28);
+
+    // Text input + Placeholder + Combo preview
+    createRow("input-row", "preview-area");
+    setFlex("input-row", "gap", 8);
+    setFlex("input-row", "height", 30);
+    setFlex("input-row", "align_items", "center");
+
+    createTextEditor("sample-input", "input-row");
+    setPlaceholder("sample-input", "Some text");
+    setText("sample-input", "Some text");
+    setFlex("sample-input", "width", 120);
+    setFlex("sample-input", "height", 26);
+    setTextColor("sample-input", APP_TEXT);
+
+    createTextEditor("sample-placeholder", "input-row");
+    setPlaceholder("sample-placeholder", "Placeholder...");
+    setFlex("sample-placeholder", "width", 120);
+    setFlex("sample-placeholder", "height", 26);
+    setTextColor("sample-placeholder", APP_TEXT);
+
+    createRow("sample-combo", "input-row");
+    setFlex("sample-combo", "width", 148);
+    setFlex("sample-combo", "height", 26);
+    setFlex("sample-combo", "padding_left", 8);
+    setFlex("sample-combo", "padding_right", 8);
+    setFlex("sample-combo", "align_items", "center");
+    setFlex("sample-combo", "gap", 8);
+    setBackground("sample-combo", APP_PANEL);
+    setBorder("sample-combo", APP_BORDER, 1, 6);
+    createLabel("sample-combo-label", "Select preset...", "sample-combo");
+    setFontSize("sample-combo-label", 10);
+    setFlex("sample-combo-label", "flex_grow", 1);
+    setTextColor("sample-combo-label", APP_TEXT);
+    setPointerEvents("sample-combo-label", "none");
+    createLabel("sample-combo-caret", "\u25be", "sample-combo");
+    setFontSize("sample-combo-caret", 10);
+    setTextColor("sample-combo-caret", APP_TEXT_DIM);
+    setPointerEvents("sample-combo-caret", "none");
+
+    // Data display: Waveform
+    createLabel("data-header", "DATA DISPLAY", "preview-area");
+    stylePreviewSectionHeader("data-header");
+
+    createWaveform("waveform", "preview-area");
+    setFlex("waveform", "height", 60);
 }
-
-// Text hierarchy row
-createRow("text-hierarchy", "preview-area");
-setFlex("text-hierarchy", "gap", 16);
-setFlex("text-hierarchy", "height", 24);
-setFlex("text-hierarchy", "align_items", "center");
-
-createLabel("th-heading", "Heading", "text-hierarchy");
-setFontSize("th-heading", 16);
-setFlex("th-heading", "width", 80);
-
-createLabel("th-body", "Body text", "text-hierarchy");
-setFontSize("th-body", 12);
-setFlex("th-body", "width", 80);
-
-createLabel("th-caption", "Caption", "text-hierarchy");
-setFontSize("th-caption", 9);
-setTextColor("th-caption", APP_TEXT_DIM);
-setFlex("th-caption", "width", 60);
-
-// Controls section: knobs
-createLabel("controls-header", "CONTROLS", "preview-area");
-stylePreviewSectionHeader("controls-header");
-
-createRow("knob-row", "preview-area");
-setFlex("knob-row", "gap", 16);
-setFlex("knob-row", "height", 64);
-setFlex("knob-row", "align_items", "center");
-
-createKnob("k1", "knob-row");
-setLabel("k1", "Gain");
-setFlex("k1", "width", 56);
-setFlex("k1", "height", 64);
-setValue("k1", 0.4);
-
-createKnob("k2", "knob-row");
-setLabel("k2", "Freq");
-setFlex("k2", "width", 56);
-setFlex("k2", "height", 64);
-setValue("k2", 0.6);
-
-createKnob("k3", "knob-row");
-setLabel("k3", "Res");
-setFlex("k3", "width", 56);
-setFlex("k3", "height", 64);
-setValue("k3", 0.8);
-
-createKnob("k4", "knob-row");
-setLabel("k4", "Mix");
-setFlex("k4", "width", 56);
-setFlex("k4", "height", 64);
-setValue("k4", 1.0);
-
-// Fader
-createFader("slider1", "horizontal", "preview-area");
-setFlex("slider1", "height", 24);
-setValue("slider1", 0.65);
-
-// Buttons row (Normal, Hover, Action, Disabled)
-createRow("btn-row", "preview-area");
-setFlex("btn-row", "gap", 8);
-setFlex("btn-row", "height", 32);
-setFlex("btn-row", "align_items", "center");
-
-createCol("btn-normal", "btn-row");
-setFlex("btn-normal", "flex_grow", 1);
-setFlex("btn-normal", "height", 28);
-setBackground("btn-normal", "#3a3a4c");
-setBorder("btn-normal", APP_BORDER, 1, 6);
-setFlex("btn-normal", "justify_content", "center");
-setFlex("btn-normal", "align_items", "center");
-createLabel("btn-normal-label", "Normal", "btn-normal");
-setFontSize("btn-normal-label", 11);
-setFlex("btn-normal-label", "height", 16);
-
-createCol("btn-hover", "btn-row");
-setFlex("btn-hover", "flex_grow", 1);
-setFlex("btn-hover", "height", 28);
-setBackground("btn-hover", "#4a4a5c");
-setBorder("btn-hover", APP_BORDER, 1, 6);
-setFlex("btn-hover", "justify_content", "center");
-setFlex("btn-hover", "align_items", "center");
-createLabel("btn-hover-label", "Hover", "btn-hover");
-setFontSize("btn-hover-label", 11);
-setFlex("btn-hover-label", "height", 16);
-
-createCol("btn-action", "btn-row");
-setFlex("btn-action", "flex_grow", 1);
-setFlex("btn-action", "height", 28);
-setBackground("btn-action", APP_ACCENT);
-setBorder("btn-action", APP_ACCENT, 0, 6);
-setFlex("btn-action", "justify_content", "center");
-setFlex("btn-action", "align_items", "center");
-createLabel("btn-action-label", "Action", "btn-action");
-setFontSize("btn-action-label", 11);
-setFlex("btn-action-label", "height", 16);
-
-createCol("btn-disabled", "btn-row");
-setFlex("btn-disabled", "flex_grow", 1);
-setFlex("btn-disabled", "height", 28);
-setBackground("btn-disabled", "#2a2a36");
-setBorder("btn-disabled", APP_BORDER, 1, 6);
-setOpacity("btn-disabled", 0.5);
-setFlex("btn-disabled", "justify_content", "center");
-setFlex("btn-disabled", "align_items", "center");
-createLabel("btn-disabled-label", "Disabled", "btn-disabled");
-setFontSize("btn-disabled-label", 11);
-setFlex("btn-disabled-label", "height", 16);
-setTextColor("btn-disabled-label", APP_TEXT_DIM);
-
-// Toggles + checkbox row
-createRow("toggle-row", "preview-area");
-setFlex("toggle-row", "gap", 10);
-setFlex("toggle-row", "height", 28);
-setFlex("toggle-row", "align_items", "center");
-
-createToggle("t1", "toggle-row");
-setFlex("t1", "width", 36);
-setFlex("t1", "height", 20);
-setValue("t1", 1);
-
-createLabel("toggle-on-label", "Enabled", "toggle-row");
-setFontSize("toggle-on-label", 11);
-setFlex("toggle-on-label", "width", 50);
-
-createToggle("t2", "toggle-row");
-setFlex("t2", "width", 36);
-setFlex("t2", "height", 20);
-
-createLabel("toggle-off-label", "Disabled", "toggle-row");
-setFontSize("toggle-off-label", 11);
-setFlex("toggle-off-label", "width", 52);
-
-// Checkbox
-createCheckbox("cb1", "toggle-row");
-setFlex("cb1", "width", 22);
-setFlex("cb1", "height", 22);
-setValue("cb1", 1);
-
-// Toggle button row
-createRow("toggle-btn-row", "preview-area");
-setFlex("toggle-btn-row", "height", 32);
-setFlex("toggle-btn-row", "gap", 8);
-
-createToggleButton("tb1", "toggle-btn-row");
-setLabel("tb1", "Toggle");
-setFlex("tb1", "flex_grow", 1);
-setFlex("tb1", "height", 28);
-
-// Text input + Placeholder + Combo preview
-createRow("input-row", "preview-area");
-setFlex("input-row", "gap", 8);
-setFlex("input-row", "height", 30);
-setFlex("input-row", "align_items", "center");
-
-createTextEditor("sample-input", "input-row");
-setPlaceholder("sample-input", "Some text");
-setText("sample-input", "Some text");
-setFlex("sample-input", "width", 120);
-setFlex("sample-input", "height", 26);
-setTextColor("sample-input", APP_TEXT);
-
-createTextEditor("sample-placeholder", "input-row");
-setPlaceholder("sample-placeholder", "Placeholder...");
-setFlex("sample-placeholder", "width", 120);
-setFlex("sample-placeholder", "height", 26);
-setTextColor("sample-placeholder", APP_TEXT);
-
-createRow("sample-combo", "input-row");
-setFlex("sample-combo", "width", 148);
-setFlex("sample-combo", "height", 26);
-setFlex("sample-combo", "padding_left", 8);
-setFlex("sample-combo", "padding_right", 8);
-setFlex("sample-combo", "align_items", "center");
-setFlex("sample-combo", "gap", 8);
-setBackground("sample-combo", APP_PANEL);
-setBorder("sample-combo", APP_BORDER, 1, 6);
-createLabel("sample-combo-label", "Select preset...", "sample-combo");
-setFontSize("sample-combo-label", 10);
-setFlex("sample-combo-label", "flex_grow", 1);
-setTextColor("sample-combo-label", APP_TEXT);
-setPointerEvents("sample-combo-label", "none");
-createLabel("sample-combo-caret", "\u25be", "sample-combo");
-setFontSize("sample-combo-caret", 10);
-setTextColor("sample-combo-caret", APP_TEXT_DIM);
-setPointerEvents("sample-combo-caret", "none");
-
-// Data display: Waveform
-createLabel("data-header", "DATA DISPLAY", "preview-area");
-stylePreviewSectionHeader("data-header");
-
-createWaveform("waveform", "preview-area");
-setFlex("waveform", "height", 60);
+buildPreviewControls();
 
 var waveData = [];
-for (var i = 0; i < 512; i++) {
-    var phase = i / 512;
-    var envelope = 0.74 + Math.sin(phase * Math.PI * 6) * 0.08;
-    waveData.push((Math.sin(2 * Math.PI * 3 * phase) * 0.48 +
-                   Math.sin(2 * Math.PI * 9 * phase) * 0.20 +
-                   Math.sin(2 * Math.PI * 17 * phase) * 0.08) * envelope);
+function buildPreviewWaveformAndMeters() {
+    for (var i = 0; i < 512; i++) {
+        var phase = i / 512;
+        var envelope = 0.74 + Math.sin(phase * Math.PI * 6) * 0.08;
+        waveData.push((Math.sin(2 * Math.PI * 3 * phase) * 0.48 +
+                       Math.sin(2 * Math.PI * 9 * phase) * 0.20 +
+                       Math.sin(2 * Math.PI * 17 * phase) * 0.08) * envelope);
+    }
+    setWaveformData("waveform", waveData);
+
+    // Meters
+    createRow("meter-row", "preview-area");
+    setFlex("meter-row", "gap", 4);
+    setFlex("meter-row", "height", 52);
+
+    createMeter("m1", "vertical", "meter-row");
+    setFlex("m1", "width", 14);
+    setWidgetStyle("m1", "minimal");
+    setMeterLevel("m1", 0.75, 0.88);
+
+    createMeter("m2", "vertical", "meter-row");
+    setFlex("m2", "width", 14);
+    setWidgetStyle("m2", "minimal");
+    setMeterLevel("m2", 0.55, 0.72);
+
+    createMeter("m3", "vertical", "meter-row");
+    setFlex("m3", "width", 14);
+    setWidgetStyle("m3", "minimal");
+    setMeterLevel("m3", 0.3, 0.45);
+
+    createMeter("m4", "vertical", "meter-row");
+    setFlex("m4", "width", 14);
+    setWidgetStyle("m4", "minimal");
+    setMeterLevel("m4", 0.85, 0.95);
+
+    // Layout section: single-row status cards matching the HTML reference
+    createRow("layout-header-row", "preview-area");
+    setFlex("layout-header-row", "height", 16);
+    setFlex("layout-header-row", "gap", 8);
+    setFlex("layout-header-row", "align_items", "center");
+
+    createLabel("layout-header", "LAYOUT", "layout-header-row");
+    setFontSize("layout-header", 10);
+    setLetterSpacing("layout-header", 1.2);
+    setTextColor("layout-header", APP_TEXT_DIM);
+    setFlex("layout-header", "height", 14);
+    setFlex("layout-header", "width", 52);
+    setFlex("layout-header", "flex_shrink", 0);
+
+    createCol("layout-header-line", "layout-header-row");
+    setFlex("layout-header-line", "height", 1);
+    setFlex("layout-header-line", "flex_grow", 1);
+    setBackground("layout-header-line", previewThemeColor("divider", APP_BORDER));
 }
-setWaveformData("waveform", waveData);
-
-// Meters
-createRow("meter-row", "preview-area");
-setFlex("meter-row", "gap", 4);
-setFlex("meter-row", "height", 52);
-
-createMeter("m1", "vertical", "meter-row");
-setFlex("m1", "width", 14);
-setWidgetStyle("m1", "minimal");
-setMeterLevel("m1", 0.75, 0.88);
-
-createMeter("m2", "vertical", "meter-row");
-setFlex("m2", "width", 14);
-setWidgetStyle("m2", "minimal");
-setMeterLevel("m2", 0.55, 0.72);
-
-createMeter("m3", "vertical", "meter-row");
-setFlex("m3", "width", 14);
-setWidgetStyle("m3", "minimal");
-setMeterLevel("m3", 0.3, 0.45);
-
-createMeter("m4", "vertical", "meter-row");
-setFlex("m4", "width", 14);
-setWidgetStyle("m4", "minimal");
-setMeterLevel("m4", 0.85, 0.95);
-
-// Layout section: single-row status cards matching the HTML reference
-createRow("layout-header-row", "preview-area");
-setFlex("layout-header-row", "height", 16);
-setFlex("layout-header-row", "gap", 8);
-setFlex("layout-header-row", "align_items", "center");
-
-createLabel("layout-header", "LAYOUT", "layout-header-row");
-setFontSize("layout-header", 10);
-setLetterSpacing("layout-header", 1.2);
-setTextColor("layout-header", APP_TEXT_DIM);
-setFlex("layout-header", "height", 14);
-setFlex("layout-header", "width", 52);
-setFlex("layout-header", "flex_shrink", 0);
-
-createCol("layout-header-line", "layout-header-row");
-setFlex("layout-header-line", "height", 1);
-setFlex("layout-header-line", "flex_grow", 1);
-setBackground("layout-header-line", previewThemeColor("divider", APP_BORDER));
+buildPreviewWaveformAndMeters();
 
 // D3: Card grid matching HTML reference — Empty, Loading, Ready (OK badge), Error (! badge)
 var cardDefs = [
@@ -3503,85 +3575,88 @@ var cardDefs = [
     { id: "card-3", label: "Ready", bg: APP_PANEL, border: '#4CAF50', badge: "OK", badgeColor: '#4CAF50' },
     { id: "card-4", label: "Error", bg: '#3a2020', border: '#e94560', badge: "!", badgeColor: '#e94560' }
 ];
-createRow("card-grid-row", "preview-area");
-setFlex("card-grid-row", "gap", 6);
-setFlex("card-grid-row", "height", 56);
-setFlex("card-grid-row", "align_items", "stretch");
-setFlex("card-grid-row", "flex_wrap", 0);
+function buildPreviewLayoutCards() {
+    createRow("card-grid-row", "preview-area");
+    setFlex("card-grid-row", "gap", 6);
+    setFlex("card-grid-row", "height", 56);
+    setFlex("card-grid-row", "align_items", "stretch");
+    setFlex("card-grid-row", "flex_wrap", 0);
 
-for (var ci = 0; ci < cardDefs.length; ci++) {
-    var cd = cardDefs[ci];
-    createCol(cd.id, "card-grid-row");
-    setPosition(cd.id, "relative");
-    setFlex(cd.id, "flex_grow", 1);
-    setFlex(cd.id, "flex_basis", 0);
-    setFlex(cd.id, "min_width", 0);
-    setBackground(cd.id, cd.bg);
-    setBorder(cd.id, cd.border, 1, 8);
-    setFlex(cd.id, "padding", 6);
-    setFlex(cd.id, "justify_content", "center");
-    setFlex(cd.id, "align_items", "center");
+    for (var ci = 0; ci < cardDefs.length; ci++) {
+        var cd = cardDefs[ci];
+        createCol(cd.id, "card-grid-row");
+        setPosition(cd.id, "relative");
+        setFlex(cd.id, "flex_grow", 1);
+        setFlex(cd.id, "flex_basis", 0);
+        setFlex(cd.id, "min_width", 0);
+        setBackground(cd.id, cd.bg);
+        setBorder(cd.id, cd.border, 1, 8);
+        setFlex(cd.id, "padding", 6);
+        setFlex(cd.id, "justify_content", "center");
+        setFlex(cd.id, "align_items", "center");
 
-    if (cd.loading) {
-        createLabel(cd.id + "-label", cd.label, cd.id);
-        setPosition(cd.id + "-label", "absolute");
-        setTop(cd.id + "-label", 8);
-        setLeft(cd.id + "-label", 10);
-        setFontSize(cd.id + "-label", 9);
-        setTextColor(cd.id + "-label", APP_TEXT_DIM);
+        if (cd.loading) {
+            createLabel(cd.id + "-label", cd.label, cd.id);
+            setPosition(cd.id + "-label", "absolute");
+            setTop(cd.id + "-label", 8);
+            setLeft(cd.id + "-label", 10);
+            setFontSize(cd.id + "-label", 9);
+            setTextColor(cd.id + "-label", APP_TEXT_DIM);
 
-        createLabel(cd.id + "-spinner", "\u25DC", cd.id);
-        setFontSize(cd.id + "-spinner", 15);
-        setTextColor(cd.id + "-spinner", APP_ACCENT);
-    } else {
-        createLabel(cd.id + "-label", cd.label, cd.id);
-        setFontSize(cd.id + "-label", 11);
-        setTextColor(cd.id + "-label", cd.id === "card-4" ? "#F44336" : APP_TEXT_DIM);
+            createLabel(cd.id + "-spinner", "\u25DC", cd.id);
+            setFontSize(cd.id + "-spinner", 15);
+            setTextColor(cd.id + "-spinner", APP_ACCENT);
+        } else {
+            createLabel(cd.id + "-label", cd.label, cd.id);
+            setFontSize(cd.id + "-label", 11);
+            setTextColor(cd.id + "-label", cd.id === "card-4" ? "#F44336" : APP_TEXT_DIM);
+        }
+
+        if (cd.badge) {
+            createCol(cd.id + "-badge", cd.id);
+            setPosition(cd.id + "-badge", "absolute");
+            setTop(cd.id + "-badge", 6);
+            setRight(cd.id + "-badge", 6);
+            setFlex(cd.id + "-badge", "height", 14);
+            setFlex(cd.id + "-badge", "min_width", cd.badge === "OK" ? 18 : 14);
+            setFlex(cd.id + "-badge", "max_width", cd.badge === "OK" ? 18 : 14);
+            setFlex(cd.id + "-badge", "justify_content", "center");
+            setFlex(cd.id + "-badge", "align_items", "center");
+            setBackground(cd.id + "-badge", cd.badgeColor);
+            setBorder(cd.id + "-badge", cd.badgeColor, 0, 3);
+            createLabel(cd.id + "-badge-lbl", cd.badge, cd.id + "-badge");
+            setFontSize(cd.id + "-badge-lbl", 7);
+            setTextColor(cd.id + "-badge-lbl", "#ffffff");
+        }
     }
 
-    if (cd.badge) {
-        createCol(cd.id + "-badge", cd.id);
-        setPosition(cd.id + "-badge", "absolute");
-        setTop(cd.id + "-badge", 6);
-        setRight(cd.id + "-badge", 6);
-        setFlex(cd.id + "-badge", "height", 14);
-        setFlex(cd.id + "-badge", "min_width", cd.badge === "OK" ? 18 : 14);
-        setFlex(cd.id + "-badge", "max_width", cd.badge === "OK" ? 18 : 14);
-        setFlex(cd.id + "-badge", "justify_content", "center");
-        setFlex(cd.id + "-badge", "align_items", "center");
-        setBackground(cd.id + "-badge", cd.badgeColor);
-        setBorder(cd.id + "-badge", cd.badgeColor, 0, 3);
-        createLabel(cd.id + "-badge-lbl", cd.badge, cd.id + "-badge");
-        setFontSize(cd.id + "-badge-lbl", 7);
-        setTextColor(cd.id + "-badge-lbl", "#ffffff");
-    }
+    // ── Progress + Spinner ───────────────────────────────────────────
+    createRow("progress-row", "preview-area");
+    setFlex("progress-row", "gap", 12);
+    setFlex("progress-row", "height", 24);
+    setFlex("progress-row", "align_items", "center");
+
+    createProgress("prog1", "progress-row");
+    setFlex("prog1", "flex_grow", 1);
+    setFlex("prog1", "height", 6);
+    setProgress("prog1", 0.65);
+
+    createRow("spinner-row", "progress-row");
+    setFlex("spinner-row", "gap", 8);
+    setFlex("spinner-row", "align_items", "center");
+    setFlex("spinner-row", "height", 16);
+
+    createLabel("spinner-icon", "\u25E0", "spinner-row");
+    setFontSize("spinner-icon", 11);
+    setTextColor("spinner-icon", APP_ACCENT);
+    setFlex("spinner-icon", "width", 12);
+
+    createLabel("spinner-text", "Loading...", "spinner-row");
+    setFontSize("spinner-text", 10);
+    setTextColor("spinner-text", APP_TEXT_DIM);
+    setFlex("spinner-text", "width", 54);
 }
-
-// ── Progress + Spinner ───────────────────────────────────────────
-createRow("progress-row", "preview-area");
-setFlex("progress-row", "gap", 12);
-setFlex("progress-row", "height", 24);
-setFlex("progress-row", "align_items", "center");
-
-createProgress("prog1", "progress-row");
-setFlex("prog1", "flex_grow", 1);
-setFlex("prog1", "height", 6);
-setProgress("prog1", 0.65);
-
-createRow("spinner-row", "progress-row");
-setFlex("spinner-row", "gap", 8);
-setFlex("spinner-row", "align_items", "center");
-setFlex("spinner-row", "height", 16);
-
-createLabel("spinner-icon", "\u25E0", "spinner-row");
-setFontSize("spinner-icon", 11);
-setTextColor("spinner-icon", APP_ACCENT);
-setFlex("spinner-icon", "width", 12);
-
-createLabel("spinner-text", "Loading...", "spinner-row");
-setFontSize("spinner-text", 10);
-setTextColor("spinner-text", APP_TEXT_DIM);
-setFlex("spinner-text", "width", 54);
+buildPreviewLayoutCards();
 
 // Animate spinner character rotation
 var spinnerFrames = ["\u25DC", "\u25DD", "\u25DE", "\u25DF"];
@@ -3592,435 +3667,456 @@ function tickSpinner() {
     setText("card-2-spinner", spinnerFrames[spinnerIdx]);
     __requestFrame__(tickSpinner);
 }
-__requestFrame__(tickSpinner);
+function buildPreviewSpinnerAndTabsHeader() {
+    __requestFrame__(tickSpinner);
 
-// ── Tab Bar (General / Audio / MIDI / About) ─────────────────────
-createLabel("tabs-header", "TABS", "preview-area");
-stylePreviewSectionHeader("tabs-header");
+    // ── Tab Bar (General / Audio / MIDI / About) ─────────────────────
+    createLabel("tabs-header", "TABS", "preview-area");
+    stylePreviewSectionHeader("tabs-header");
 
-createRow("tab-bar-preview", "preview-area");
-setFlex("tab-bar-preview", "height", 30);
-setFlex("tab-bar-preview", "gap", 0);
-setFlex("tab-bar-preview", "align_items", "stretch");
-setBorder("tab-bar-preview", APP_BORDER, 0, 0);
-createCol("tab-bar-preview-line", "tab-bar-preview");
-setPosition("tab-bar-preview-line", "absolute");
-setLeft("tab-bar-preview-line", 0);
-setRight("tab-bar-preview-line", 0);
-setBottom("tab-bar-preview-line", 0);
-setFlex("tab-bar-preview-line", "height", 1);
-setBackground("tab-bar-preview-line", "transparent");
+    createRow("tab-bar-preview", "preview-area");
+    setFlex("tab-bar-preview", "height", 30);
+    setFlex("tab-bar-preview", "gap", 0);
+    setFlex("tab-bar-preview", "align_items", "stretch");
+    setBorder("tab-bar-preview", APP_BORDER, 0, 0);
+    createCol("tab-bar-preview-line", "tab-bar-preview");
+    setPosition("tab-bar-preview-line", "absolute");
+    setLeft("tab-bar-preview-line", 0);
+    setRight("tab-bar-preview-line", 0);
+    setBottom("tab-bar-preview-line", 0);
+    setFlex("tab-bar-preview-line", "height", 1);
+    setBackground("tab-bar-preview-line", "transparent");
+}
+buildPreviewSpinnerAndTabsHeader();
 
 var tabNames = ["General", "Audio", "MIDI", "About"];
-for (var ti = 0; ti < tabNames.length; ti++) {
-    var tabId = "ptab-" + ti;
-    createCol(tabId, "tab-bar-preview");
-    setPosition(tabId, "relative");
-    setFlex(tabId, "height", 30);
-    setFlex(tabId, "padding_left", 14);
-    setFlex(tabId, "padding_right", 14);
-    setFlex(tabId, "justify_content", "center");
-    setFlex(tabId, "align_items", "center");
-    registerClick(tabId);
-    registerHover(tabId);
+function buildPreviewTabBarAndPanel() {
+    for (var ti = 0; ti < tabNames.length; ti++) {
+        var tabId = "ptab-" + ti;
+        createCol(tabId, "tab-bar-preview");
+        setPosition(tabId, "relative");
+        setFlex(tabId, "height", 30);
+        setFlex(tabId, "padding_left", 14);
+        setFlex(tabId, "padding_right", 14);
+        setFlex(tabId, "justify_content", "center");
+        setFlex(tabId, "align_items", "center");
+        registerClick(tabId);
+        registerHover(tabId);
 
-    createLabel(tabId + "-l", tabNames[ti], tabId);
-    setFontSize(tabId + "-l", 12);
-    setTextColor(tabId + "-l", ti === 0 ? APP_TEXT : APP_TEXT_DIM);
-    setPointerEvents(tabId + "-l", "none");
+        createLabel(tabId + "-l", tabNames[ti], tabId);
+        setFontSize(tabId + "-l", 12);
+        setTextColor(tabId + "-l", ti === 0 ? APP_TEXT : APP_TEXT_DIM);
+        setPointerEvents(tabId + "-l", "none");
 
-    createCol(tabId + "-line", tabId);
-    setPosition(tabId + "-line", "absolute");
-    setLeft(tabId + "-line", 10);
-    setRight(tabId + "-line", 10);
-    setBottom(tabId + "-line", 0);
-    setFlex(tabId + "-line", "height", 2);
-    setBackground(tabId + "-line", ti === 0 ? APP_ACCENT : "transparent");
+        createCol(tabId + "-line", tabId);
+        setPosition(tabId + "-line", "absolute");
+        setLeft(tabId + "-line", 10);
+        setRight(tabId + "-line", 10);
+        setBottom(tabId + "-line", 0);
+        setFlex(tabId + "-line", "height", 2);
+        setBackground(tabId + "-line", ti === 0 ? APP_ACCENT : "transparent");
 
-    (function(idx) {
-        on("ptab-" + idx, "mouseenter", function() {
-            previewTabHoverIndex = idx;
-            refreshPreviewTabs(false);
-        });
-        on("ptab-" + idx, "mouseleave", function() {
-            if (previewTabHoverIndex === idx) previewTabHoverIndex = -1;
-            refreshPreviewTabs(false);
-        });
-        on("ptab-" + idx, "click", function() { setPreviewActiveTab(idx); });
-    })(ti);
+        (function(idx) {
+            on("ptab-" + idx, "mouseenter", function() {
+                previewTabHoverIndex = idx;
+                refreshPreviewTabs(false);
+            });
+            on("ptab-" + idx, "mouseleave", function() {
+                if (previewTabHoverIndex === idx) previewTabHoverIndex = -1;
+                refreshPreviewTabs(false);
+            });
+            on("ptab-" + idx, "click", function() { setPreviewActiveTab(idx); });
+        })(ti);
+    }
+
+    // Panel content area with divider
+    createCol("panel-content", "preview-area");
+    setFlex("panel-content", "height", 56);
+    setFlex("panel-content", "padding", 8);
+    setFlex("panel-content", "gap", 4);
+    setBackground("panel-content", APP_PANEL);
+    setBorder("panel-content", APP_BORDER, 1, 6);
+
+    createLabel("panel-title", "Panel content area", "panel-content");
+    setFontSize("panel-title", 11);
+
+    createCol("panel-divider", "panel-content");
+    setFlex("panel-divider", "height", 1);
+    setBackground("panel-divider", APP_BORDER);
+
+    createLabel("panel-sub", "With divider and secondary text", "panel-content");
+    setFontSize("panel-sub", 10);
+    setTextColor("panel-sub", APP_TEXT_DIM);
+
+    previewReady = true;
+    applyStateToPreview(activeState);
+
+    // ── Overlays (Static Preview) ────────────────────────────────────
+    createLabel("overlays-header", "OVERLAYS (STATIC PREVIEW)", "preview-area");
+    stylePreviewSectionHeader("overlays-header");
+
+    createRow("overlay-row", "preview-area");
+    setFlex("overlay-row", "gap", 8);
+    setFlex("overlay-row", "height", 96);
+    setBackground("overlay-row", applyHexAlpha(APP_PANEL_RAISED, 0.82));
+    setBorder("overlay-row", APP_BORDER, 1, 8);
+
+    // Confirm Action dialog card
+    createCol("dialog-card", "overlay-row");
+    setFlex("dialog-card", "flex_grow", 1);
+    setFlex("dialog-card", "padding", 8);
+    setFlex("dialog-card", "gap", 4);
+    setBackground("dialog-card", APP_PANEL);
+    setBorder("dialog-card", APP_BORDER, 1, 8);
+
+    createLabel("dialog-title", "Confirm Action", "dialog-card");
+    setFontSize("dialog-title", 11);
+
+    createLabel("dialog-msg", "Are you sure you want to delete this preset? This cannot be undone.", "dialog-card");
+    setFontSize("dialog-msg", 9);
+    setTextColor("dialog-msg", APP_TEXT_DIM);
+
+    createRow("dialog-btns", "dialog-card");
+    setFlex("dialog-btns", "gap", 6);
+    setFlex("dialog-btns", "height", 22);
+    setFlex("dialog-btns", "align_items", "center");
+    setFlex("dialog-btns", "justify_content", "flex-end");
+
+    createCol("dialog-cancel", "dialog-btns");
+    setFlex("dialog-cancel", "width", 50);
+    setFlex("dialog-cancel", "height", 20);
+    setBorder("dialog-cancel", APP_BORDER, 1, 4);
+    setFlex("dialog-cancel", "justify_content", "center");
+    setFlex("dialog-cancel", "align_items", "center");
+    createLabel("dialog-cancel-l", "Cancel", "dialog-cancel");
+    setFontSize("dialog-cancel-l", 9);
+
+    createCol("dialog-accept", "dialog-btns");
+    setFlex("dialog-accept", "width", 50);
+    setFlex("dialog-accept", "height", 20);
+    setBackground("dialog-accept", APP_ACCENT);
+    setBorder("dialog-accept", APP_ACCENT, 0, 4);
+    setFlex("dialog-accept", "justify_content", "center");
+    setFlex("dialog-accept", "align_items", "center");
+    createLabel("dialog-accept-l", "Accept", "dialog-accept");
+    setFontSize("dialog-accept-l", 9);
+
+    // Context menu card
+    createCol("ctx-menu", "overlay-row");
+    setFlex("ctx-menu", "width", 120);
+    setFlex("ctx-menu", "padding", 4);
+    setFlex("ctx-menu", "gap", 0);
+    setBackground("ctx-menu", APP_PANEL);
+    setBorder("ctx-menu", APP_BORDER, 1, 6);
 }
-
-// Panel content area with divider
-createCol("panel-content", "preview-area");
-setFlex("panel-content", "height", 56);
-setFlex("panel-content", "padding", 8);
-setFlex("panel-content", "gap", 4);
-setBackground("panel-content", APP_PANEL);
-setBorder("panel-content", APP_BORDER, 1, 6);
-
-createLabel("panel-title", "Panel content area", "panel-content");
-setFontSize("panel-title", 11);
-
-createCol("panel-divider", "panel-content");
-setFlex("panel-divider", "height", 1);
-setBackground("panel-divider", APP_BORDER);
-
-createLabel("panel-sub", "With divider and secondary text", "panel-content");
-setFontSize("panel-sub", 10);
-setTextColor("panel-sub", APP_TEXT_DIM);
-
-previewReady = true;
-applyStateToPreview(activeState);
-
-// ── Overlays (Static Preview) ────────────────────────────────────
-createLabel("overlays-header", "OVERLAYS (STATIC PREVIEW)", "preview-area");
-stylePreviewSectionHeader("overlays-header");
-
-createRow("overlay-row", "preview-area");
-setFlex("overlay-row", "gap", 8);
-setFlex("overlay-row", "height", 96);
-setBackground("overlay-row", applyHexAlpha(APP_PANEL_RAISED, 0.82));
-setBorder("overlay-row", APP_BORDER, 1, 8);
-
-// Confirm Action dialog card
-createCol("dialog-card", "overlay-row");
-setFlex("dialog-card", "flex_grow", 1);
-setFlex("dialog-card", "padding", 8);
-setFlex("dialog-card", "gap", 4);
-setBackground("dialog-card", APP_PANEL);
-setBorder("dialog-card", APP_BORDER, 1, 8);
-
-createLabel("dialog-title", "Confirm Action", "dialog-card");
-setFontSize("dialog-title", 11);
-
-createLabel("dialog-msg", "Are you sure you want to delete this preset? This cannot be undone.", "dialog-card");
-setFontSize("dialog-msg", 9);
-setTextColor("dialog-msg", APP_TEXT_DIM);
-
-createRow("dialog-btns", "dialog-card");
-setFlex("dialog-btns", "gap", 6);
-setFlex("dialog-btns", "height", 22);
-setFlex("dialog-btns", "align_items", "center");
-setFlex("dialog-btns", "justify_content", "flex-end");
-
-createCol("dialog-cancel", "dialog-btns");
-setFlex("dialog-cancel", "width", 50);
-setFlex("dialog-cancel", "height", 20);
-setBorder("dialog-cancel", APP_BORDER, 1, 4);
-setFlex("dialog-cancel", "justify_content", "center");
-setFlex("dialog-cancel", "align_items", "center");
-createLabel("dialog-cancel-l", "Cancel", "dialog-cancel");
-setFontSize("dialog-cancel-l", 9);
-
-createCol("dialog-accept", "dialog-btns");
-setFlex("dialog-accept", "width", 50);
-setFlex("dialog-accept", "height", 20);
-setBackground("dialog-accept", APP_ACCENT);
-setBorder("dialog-accept", APP_ACCENT, 0, 4);
-setFlex("dialog-accept", "justify_content", "center");
-setFlex("dialog-accept", "align_items", "center");
-createLabel("dialog-accept-l", "Accept", "dialog-accept");
-setFontSize("dialog-accept-l", 9);
-
-// Context menu card
-createCol("ctx-menu", "overlay-row");
-setFlex("ctx-menu", "width", 120);
-setFlex("ctx-menu", "padding", 4);
-setFlex("ctx-menu", "gap", 0);
-setBackground("ctx-menu", APP_PANEL);
-setBorder("ctx-menu", APP_BORDER, 1, 6);
+buildPreviewTabBarAndPanel();
 
 var ctxItems = ["Copy", "Paste", "---", "Rename", "Delete"];
-for (var ci = 0; ci < ctxItems.length; ci++) {
-    if (ctxItems[ci] === "---") {
-        createCol("ctx-sep-" + ci, "ctx-menu");
-        setFlex("ctx-sep-" + ci, "height", 1);
-        setBackground("ctx-sep-" + ci, APP_BORDER);
-    } else {
-        var cid = "ctx-" + ci;
-        createRow(cid, "ctx-menu");
-        setFlex(cid, "height", 22);
-        setFlex(cid, "padding_left", 8);
-        setFlex(cid, "align_items", "center");
-        createLabel(cid + "-l", ctxItems[ci], cid);
-        setFontSize(cid + "-l", 11);
-        registerHover(cid);
-        if (ctxItems[ci] === "Paste") {
-            setBackground(cid, APP_ACCENT + "22");
-            setTextColor(cid + "-l", APP_ACCENT);
-            (function(id, labelId) {
-                on(id, "mouseenter", function() {
-                    setBackground(id, APP_ACCENT + "32");
-                    setTextColor(labelId, APP_ACCENT_HOVER);
-                });
-                on(id, "mouseleave", function() {
-                    setBackground(id, APP_ACCENT + "22");
-                    setTextColor(labelId, APP_ACCENT);
-                });
-            })(cid, cid + "-l");
+function buildPreviewContextMenu() {
+    for (var ci = 0; ci < ctxItems.length; ci++) {
+        if (ctxItems[ci] === "---") {
+            createCol("ctx-sep-" + ci, "ctx-menu");
+            setFlex("ctx-sep-" + ci, "height", 1);
+            setBackground("ctx-sep-" + ci, APP_BORDER);
         } else {
-            (function(id, labelId, isDelete) {
-                on(id, "mouseenter", function() {
-                    setBackground(id, "#ffffff10");
-                    if (!isDelete) setTextColor(labelId, APP_TEXT);
-                });
-                on(id, "mouseleave", function() {
-                    setBackground(id, "transparent");
-                    if (!isDelete) setTextColor(labelId, APP_TEXT_DIM);
-                });
-            })(cid, cid + "-l", ctxItems[ci] === "Delete");
+            var cid = "ctx-" + ci;
+            createRow(cid, "ctx-menu");
+            setFlex(cid, "height", 22);
+            setFlex(cid, "padding_left", 8);
+            setFlex(cid, "align_items", "center");
+            createLabel(cid + "-l", ctxItems[ci], cid);
+            setFontSize(cid + "-l", 11);
+            registerHover(cid);
+            if (ctxItems[ci] === "Paste") {
+                setBackground(cid, APP_ACCENT + "22");
+                setTextColor(cid + "-l", APP_ACCENT);
+                (function(id, labelId) {
+                    on(id, "mouseenter", function() {
+                        setBackground(id, APP_ACCENT + "32");
+                        setTextColor(labelId, APP_ACCENT_HOVER);
+                    });
+                    on(id, "mouseleave", function() {
+                        setBackground(id, APP_ACCENT + "22");
+                        setTextColor(labelId, APP_ACCENT);
+                    });
+                })(cid, cid + "-l");
+            } else {
+                (function(id, labelId, isDelete) {
+                    on(id, "mouseenter", function() {
+                        setBackground(id, "#ffffff10");
+                        if (!isDelete) setTextColor(labelId, APP_TEXT);
+                    });
+                    on(id, "mouseleave", function() {
+                        setBackground(id, "transparent");
+                        if (!isDelete) setTextColor(labelId, APP_TEXT_DIM);
+                    });
+                })(cid, cid + "-l", ctxItems[ci] === "Delete");
+            }
+            if (ctxItems[ci] === "Delete") setTextColor(cid + "-l", "#f38ba8");
         }
-        if (ctxItems[ci] === "Delete") setTextColor(cid + "-l", "#f38ba8");
     }
+
+    // ── States ───────────────────────────────────────────────────────
+    createLabel("states-header", "STATES", "preview-area");
+    stylePreviewSectionHeader("states-header");
+
+    createRow("states-row", "preview-area");
+    setFlex("states-row", "gap", 6);
+    setFlex("states-row", "height", 26);
+    setFlex("states-row", "align_items", "center");
 }
-
-// ── States ───────────────────────────────────────────────────────
-createLabel("states-header", "STATES", "preview-area");
-stylePreviewSectionHeader("states-header");
-
-createRow("states-row", "preview-area");
-setFlex("states-row", "gap", 6);
-setFlex("states-row", "height", 26);
-setFlex("states-row", "align_items", "center");
+buildPreviewContextMenu();
 
 var stateNames = ["Normal", "Hover", "Active", "Focus", "Disabled"];
 var stateBgs   = ["#3a3a4c", "#4a4a5c", APP_ACCENT, "#3a3a4c", "#2a2a36"];
-for (var si = 0; si < stateNames.length; si++) {
-    var sid = "state-" + si;
-    createCol(sid, "states-row");
-    setFlex(sid, "flex_grow", 1);
-    setFlex(sid, "height", 24);
-    setBackground(sid, stateBgs[si]);
-    setBorder(sid, si === 3 ? APP_ACCENT : APP_BORDER, 1, 4);
-    if (si === 4) setOpacity(sid, 0.5);
-    setFlex(sid, "justify_content", "center");
-    setFlex(sid, "align_items", "center");
-    createLabel(sid + "-l", stateNames[si], sid);
-    setFontSize(sid + "-l", 9);
-}
-
-// ── Effects ──────────────────────────────────────────────────────
-createLabel("effects-header", "EFFECTS", "preview-area");
-stylePreviewSectionHeader("effects-header");
-
-createRow("effects-row", "preview-area");
-setFlex("effects-row", "gap", 8);
-setFlex("effects-row", "height", 44);
-setFlex("effects-row", "align_items", "center");
-
-var effectNames = ["Shadow", "Glow", "Blur", "Gradient"];
-for (var ei = 0; ei < effectNames.length; ei++) {
-    var eid = "effect-" + ei;
-    createCol(eid, "effects-row");
-    setFlex(eid, "flex_grow", 1);
-    setFlex(eid, "height", 40);
-    setFlex(eid, "padding_top", 5);
-    setFlex(eid, "padding_bottom", 5);
-    setFlex(eid, "gap", 4);
-    setBackground(eid, APP_PANEL);
-    setBorder(eid, APP_BORDER, 1, 6);
-    setFlex(eid, "align_items", "center");
-    setFlex(eid, "justify_content", "center");
-
-    createRow(eid + "-viz", eid);
-    setFlex(eid + "-viz", "height", 10);
-    setFlex(eid + "-viz", "gap", 3);
-    setFlex(eid + "-viz", "align_items", "center");
-
-    if (ei === 0) {
-        createCol(eid + "-chip", eid + "-viz");
-        setFlex(eid + "-chip", "width", 22);
-        setFlex(eid + "-chip", "height", 8);
-        setBackground(eid + "-chip", APP_PANEL_RAISED);
-        setBorder(eid + "-chip", APP_BORDER, 1, 4);
-    } else if (ei === 1) {
-        createCol(eid + "-chip", eid + "-viz");
-        setFlex(eid + "-chip", "width", 18);
-        setFlex(eid + "-chip", "height", 8);
-        setBackground(eid + "-chip", APP_ACCENT);
-        setBorder(eid + "-chip", APP_ACCENT, 0, 4);
-    } else if (ei === 2) {
-        for (var blurStep = 0; blurStep < 3; blurStep++) {
-            createCol(eid + "-chip-" + blurStep, eid + "-viz");
-            setFlex(eid + "-chip-" + blurStep, "width", 8 + blurStep * 4);
-            setFlex(eid + "-chip-" + blurStep, "height", 8);
-            setBackground(eid + "-chip-" + blurStep, APP_ACCENT);
-            setBorder(eid + "-chip-" + blurStep, "transparent", 0, 4);
-            setOpacity(eid + "-chip-" + blurStep, 0.35 + blurStep * 0.2);
-        }
-    } else {
-        for (var gradStep = 0; gradStep < 3; gradStep++) {
-            createCol(eid + "-chip-" + gradStep, eid + "-viz");
-            setFlex(eid + "-chip-" + gradStep, "width", 8);
-            setFlex(eid + "-chip-" + gradStep, "height", 8);
-            setBorder(eid + "-chip-" + gradStep, "transparent", 0, 4);
-        }
+function buildPreviewStates() {
+    for (var si = 0; si < stateNames.length; si++) {
+        var sid = "state-" + si;
+        createCol(sid, "states-row");
+        setFlex(sid, "flex_grow", 1);
+        setFlex(sid, "height", 24);
+        setBackground(sid, stateBgs[si]);
+        setBorder(sid, si === 3 ? APP_ACCENT : APP_BORDER, 1, 4);
+        if (si === 4) setOpacity(sid, 0.5);
+        setFlex(sid, "justify_content", "center");
+        setFlex(sid, "align_items", "center");
+        createLabel(sid + "-l", stateNames[si], sid);
+        setFontSize(sid + "-l", 9);
     }
 
-    createLabel(eid + "-l", effectNames[ei], eid);
-    setFontSize(eid + "-l", 9);
+    // ── Effects ──────────────────────────────────────────────────────
+    createLabel("effects-header", "EFFECTS", "preview-area");
+    stylePreviewSectionHeader("effects-header");
+
+    createRow("effects-row", "preview-area");
+    setFlex("effects-row", "gap", 8);
+    setFlex("effects-row", "height", 44);
+    setFlex("effects-row", "align_items", "center");
 }
+buildPreviewStates();
 
-// ── GPU Showcase ─────────────────────────────────────────────────
-createLabel("showcase-header", "GPU SHOWCASE", "preview-area");
-stylePreviewSectionHeader("showcase-header");
+var effectNames = ["Shadow", "Glow", "Blur", "Gradient"];
+function buildPreviewEffects() {
+    for (var ei = 0; ei < effectNames.length; ei++) {
+        var eid = "effect-" + ei;
+        createCol(eid, "effects-row");
+        setFlex(eid, "flex_grow", 1);
+        setFlex(eid, "height", 40);
+        setFlex(eid, "padding_top", 5);
+        setFlex(eid, "padding_bottom", 5);
+        setFlex(eid, "gap", 4);
+        setBackground(eid, APP_PANEL);
+        setBorder(eid, APP_BORDER, 1, 6);
+        setFlex(eid, "align_items", "center");
+        setFlex(eid, "justify_content", "center");
 
-// XY Pad for touch/mouse interaction demo
-createRow("showcase-row", "preview-area");
-setFlex("showcase-row", "gap", 8);
-setFlex("showcase-row", "height", 84);
+        createRow(eid + "-viz", eid);
+        setFlex(eid + "-viz", "height", 10);
+        setFlex(eid + "-viz", "gap", 3);
+        setFlex(eid + "-viz", "align_items", "center");
 
-createXYPad("xy-demo", "showcase-row");
-setFlex("xy-demo", "width", 80);
-setFlex("xy-demo", "height", 84);
-setXY("xy-demo", 0.38, 0.67);
+        if (ei === 0) {
+            createCol(eid + "-chip", eid + "-viz");
+            setFlex(eid + "-chip", "width", 22);
+            setFlex(eid + "-chip", "height", 8);
+            setBackground(eid + "-chip", APP_PANEL_RAISED);
+            setBorder(eid + "-chip", APP_BORDER, 1, 4);
+        } else if (ei === 1) {
+            createCol(eid + "-chip", eid + "-viz");
+            setFlex(eid + "-chip", "width", 18);
+            setFlex(eid + "-chip", "height", 8);
+            setBackground(eid + "-chip", APP_ACCENT);
+            setBorder(eid + "-chip", APP_ACCENT, 0, 4);
+        } else if (ei === 2) {
+            for (var blurStep = 0; blurStep < 3; blurStep++) {
+                createCol(eid + "-chip-" + blurStep, eid + "-viz");
+                setFlex(eid + "-chip-" + blurStep, "width", 8 + blurStep * 4);
+                setFlex(eid + "-chip-" + blurStep, "height", 8);
+                setBackground(eid + "-chip-" + blurStep, APP_ACCENT);
+                setBorder(eid + "-chip-" + blurStep, "transparent", 0, 4);
+                setOpacity(eid + "-chip-" + blurStep, 0.35 + blurStep * 0.2);
+            }
+        } else {
+            for (var gradStep = 0; gradStep < 3; gradStep++) {
+                createCol(eid + "-chip-" + gradStep, eid + "-viz");
+                setFlex(eid + "-chip-" + gradStep, "width", 8);
+                setFlex(eid + "-chip-" + gradStep, "height", 8);
+                setBorder(eid + "-chip-" + gradStep, "transparent", 0, 4);
+            }
+        }
 
-// Spectrum analyzer
-createSpectrum("spectrum-demo", "showcase-row");
-setFlex("spectrum-demo", "flex_grow", 1);
-setFlex("spectrum-demo", "height", 84);
+        createLabel(eid + "-l", effectNames[ei], eid);
+        setFontSize(eid + "-l", 9);
+    }
+
+    // ── GPU Showcase ─────────────────────────────────────────────────
+    createLabel("showcase-header", "GPU SHOWCASE", "preview-area");
+    stylePreviewSectionHeader("showcase-header");
+
+    // XY Pad for touch/mouse interaction demo
+    createRow("showcase-row", "preview-area");
+    setFlex("showcase-row", "gap", 8);
+    setFlex("showcase-row", "height", 84);
+
+    createXYPad("xy-demo", "showcase-row");
+    setFlex("xy-demo", "width", 80);
+    setFlex("xy-demo", "height", 84);
+    setXY("xy-demo", 0.38, 0.67);
+
+    // Spectrum analyzer
+    createSpectrum("spectrum-demo", "showcase-row");
+    setFlex("spectrum-demo", "flex_grow", 1);
+    setFlex("spectrum-demo", "height", 84);
+}
+buildPreviewEffects();
 
 // Generate some spectrum data
 var specData = [];
-for (var si = 0; si < 72; si++) {
-    var freq = si / 71;
-    var lowPeak = 26 * Math.exp(-Math.pow((freq - 0.14) / 0.08, 2));
-    var midPeak = 18 * Math.exp(-Math.pow((freq - 0.46) / 0.10, 2));
-    var airPeak = 22 * Math.exp(-Math.pow((freq - 0.78) / 0.06, 2));
-    var ripple = Math.sin(freq * 26.0) * 2.2 + Math.cos(freq * 13.0) * 1.1;
-    var floor = -74 + Math.sin(freq * 5.0) * 1.5;
-    specData.push(Math.max(-78, Math.min(-8, floor + lowPeak + midPeak + airPeak + ripple)));
+function buildPreviewSpectrum() {
+    for (var si = 0; si < 72; si++) {
+        var freq = si / 71;
+        var lowPeak = 26 * Math.exp(-Math.pow((freq - 0.14) / 0.08, 2));
+        var midPeak = 18 * Math.exp(-Math.pow((freq - 0.46) / 0.10, 2));
+        var airPeak = 22 * Math.exp(-Math.pow((freq - 0.78) / 0.06, 2));
+        var ripple = Math.sin(freq * 26.0) * 2.2 + Math.cos(freq * 13.0) * 1.1;
+        var floor = -74 + Math.sin(freq * 5.0) * 1.5;
+        specData.push(Math.max(-78, Math.min(-8, floor + lowPeak + midPeak + airPeak + ripple)));
+    }
+    setSpectrumData("spectrum-demo", specData);
+
+    // Second waveform with different data
+    createLabel("waveform2-header", "AUDIO WAVEFORM", "preview-area");
+    stylePreviewSectionHeader("waveform2-header");
+
+    createWaveform("waveform2", "preview-area");
+    setFlex("waveform2", "height", 60);
 }
-setSpectrumData("spectrum-demo", specData);
-
-// Second waveform with different data
-createLabel("waveform2-header", "AUDIO WAVEFORM", "preview-area");
-stylePreviewSectionHeader("waveform2-header");
-
-createWaveform("waveform2", "preview-area");
-setFlex("waveform2", "height", 60);
+buildPreviewSpectrum();
 
 var wave2 = [];
-for (var w2 = 0; w2 < 512; w2++) {
-    var phase2 = w2 / 512;
-    var envelope2 = 0.58 + 0.18 * Math.sin(phase2 * Math.PI * 4.0);
-    wave2.push((Math.sin(2 * Math.PI * 5 * phase2) * 0.42 +
-                Math.sin(2 * Math.PI * 13 * phase2) * 0.18 +
-                Math.sin(2 * Math.PI * 27 * phase2) * 0.09) * envelope2);
+function buildPreviewWaveform2AndRightPanel() {
+    for (var w2 = 0; w2 < 512; w2++) {
+        var phase2 = w2 / 512;
+        var envelope2 = 0.58 + 0.18 * Math.sin(phase2 * Math.PI * 4.0);
+        wave2.push((Math.sin(2 * Math.PI * 5 * phase2) * 0.42 +
+                    Math.sin(2 * Math.PI * 13 * phase2) * 0.18 +
+                    Math.sin(2 * Math.PI * 27 * phase2) * 0.09) * envelope2);
+    }
+    setWaveformData("waveform2", wave2);
+
+    // ── RIGHT PANEL (Inspector + Chat) ──────────────────────────────
+    createCol("right-panel", "main-area");
+    setFlex("right-panel", "width", 272);
+    setFlex("right-panel", "min_width", 272);
+    setFlex("right-panel", "max_width", 272);
+    setFlex("right-panel", "flex_grow", 0);
+    setFlex("right-panel", "flex_shrink", 0);
+    setBackground("right-panel", APP_SURFACE);
+    setBorder("right-panel", APP_BORDER, 1, 0);
+
+    // Tab bar
+    createRow("right-tabs", "right-panel");
+    setFlex("right-tabs", "height", 36);
+    setFlex("right-tabs", "flex_shrink", 0);
+    setFlex("right-tabs", "align_items", "center");
+    setFlex("right-tabs", "justify_content", "center");
+    setFlex("right-tabs", "gap", 0);
+    setFlex("right-tabs", "padding_left", 10);
+    setFlex("right-tabs", "padding_right", 10);
+    setBackground("right-tabs", APP_PANEL);
+    setBorder("right-tabs", APP_BORDER, 1, 0);
+
+    // Tab columns (label + underline indicator)
+    createCol("tab-inspector-col", "right-tabs");
+    setFlex("tab-inspector-col", "flex_grow", 1);
+    setFlex("tab-inspector-col", "height", 36);
+    setFlex("tab-inspector-col", "align_items", "center");
+    setFlex("tab-inspector-col", "justify_content", "center");
+    setFlex("tab-inspector-col", "gap", 0);
+
+    createLabel("tab-inspector", "INSPECTOR", "tab-inspector-col");
+    setFontSize("tab-inspector", 11);
+    setFlex("tab-inspector", "height", 28);
+    setTextAlign("tab-inspector", "center");
+    setTextColor("tab-inspector", APP_TEXT_DIM);
+
+    // Underline indicator — use width not flex_grow to avoid vertical expansion
+    createCol("tab-inspector-line", "tab-inspector-col");
+    setFlex("tab-inspector-line", "height", 2);
+    setFlex("tab-inspector-line", "width", 120);
+    setFlex("tab-inspector-line", "flex_shrink", 0);
+
+    createCol("tab-chat-col", "right-tabs");
+    setFlex("tab-chat-col", "flex_grow", 1);
+    setFlex("tab-chat-col", "height", 36);
+    setFlex("tab-chat-col", "align_items", "center");
+    setFlex("tab-chat-col", "justify_content", "center");
+    setFlex("tab-chat-col", "gap", 0);
+
+    createLabel("tab-chat", "CHAT", "tab-chat-col");
+    setFontSize("tab-chat", 11);
+    setFlex("tab-chat", "height", 28);
+    setTextAlign("tab-chat", "center");
+    setTextColor("tab-chat", APP_ACCENT);
+
+    createCol("tab-chat-line", "tab-chat-col");
+    setFlex("tab-chat-line", "height", 2);
+    setFlex("tab-chat-line", "width", 120);
+    setFlex("tab-chat-line", "flex_shrink", 0);
+    setBackground("tab-chat-line", APP_ACCENT);
+
+    // Inspector content area (hidden by default)
+    createCol("inspector-area", "right-panel");
+    setFlex("inspector-area", "flex_grow", 1);
+    setFlex("inspector-area", "padding", 10);
+    setFlex("inspector-area", "gap", 6);
+    setVisible("inspector-area", false);
+
+    createLabel("insp-title", "ELEMENT INSPECTOR", "inspector-area");
+    setFontSize("insp-title", 10);
+    setTextColor("insp-title", APP_TEXT_DIM);
+    setFlex("insp-title", "height", 14);
+
+    createLabel("insp-hint", "Cmd+click any element in the preview to inspect its properties.", "inspector-area");
+    setFontSize("insp-hint", 10);
+    setTextColor("insp-hint", APP_TEXT_DIM);
+    setFlex("insp-hint", "height", 28);
+
+    // Inspector property rows (placeholder)
+    createRow("insp-row-type", "inspector-area");
+    setFlex("insp-row-type", "height", 20);
+    setFlex("insp-row-type", "align_items", "center");
+    createLabel("insp-type-k", "Type:", "insp-row-type");
+    setFontSize("insp-type-k", 10);
+    setTextColor("insp-type-k", APP_TEXT_DIM);
+    setFlex("insp-type-k", "width", 60);
+    createLabel("insp-type-v", "—", "insp-row-type");
+    setFontSize("insp-type-v", 10);
+    setFlex("insp-type-v", "flex_grow", 1);
+
+    createRow("insp-row-id", "inspector-area");
+    setFlex("insp-row-id", "height", 20);
+    setFlex("insp-row-id", "align_items", "center");
+    createLabel("insp-id-k", "ID:", "insp-row-id");
+    setFontSize("insp-id-k", 10);
+    setTextColor("insp-id-k", APP_TEXT_DIM);
+    setFlex("insp-id-k", "width", 60);
+    createLabel("insp-id-v", "—", "insp-row-id");
+    setFontSize("insp-id-v", 10);
+    setFlex("insp-id-v", "flex_grow", 1);
+
+    createRow("insp-row-bounds", "inspector-area");
+    setFlex("insp-row-bounds", "height", 20);
+    setFlex("insp-row-bounds", "align_items", "center");
+    createLabel("insp-bounds-k", "Bounds:", "insp-row-bounds");
+    setFontSize("insp-bounds-k", 10);
+    setTextColor("insp-bounds-k", APP_TEXT_DIM);
+    setFlex("insp-bounds-k", "width", 60);
+    createLabel("insp-bounds-v", "—", "insp-row-bounds");
+    setFontSize("insp-bounds-v", 10);
+    setFlex("insp-bounds-v", "flex_grow", 1);
 }
-setWaveformData("waveform2", wave2);
-
-// ── RIGHT PANEL (Inspector + Chat) ──────────────────────────────
-createCol("right-panel", "main-area");
-setFlex("right-panel", "width", 272);
-setFlex("right-panel", "min_width", 272);
-setFlex("right-panel", "max_width", 272);
-setFlex("right-panel", "flex_grow", 0);
-setFlex("right-panel", "flex_shrink", 0);
-setBackground("right-panel", APP_SURFACE);
-setBorder("right-panel", APP_BORDER, 1, 0);
-
-// Tab bar
-createRow("right-tabs", "right-panel");
-setFlex("right-tabs", "height", 36);
-setFlex("right-tabs", "flex_shrink", 0);
-setFlex("right-tabs", "align_items", "center");
-setFlex("right-tabs", "justify_content", "center");
-setFlex("right-tabs", "gap", 0);
-setFlex("right-tabs", "padding_left", 10);
-setFlex("right-tabs", "padding_right", 10);
-setBackground("right-tabs", APP_PANEL);
-setBorder("right-tabs", APP_BORDER, 1, 0);
-
-// Tab columns (label + underline indicator)
-createCol("tab-inspector-col", "right-tabs");
-setFlex("tab-inspector-col", "flex_grow", 1);
-setFlex("tab-inspector-col", "height", 36);
-setFlex("tab-inspector-col", "align_items", "center");
-setFlex("tab-inspector-col", "justify_content", "center");
-setFlex("tab-inspector-col", "gap", 0);
-
-createLabel("tab-inspector", "INSPECTOR", "tab-inspector-col");
-setFontSize("tab-inspector", 11);
-setFlex("tab-inspector", "height", 28);
-setTextAlign("tab-inspector", "center");
-setTextColor("tab-inspector", APP_TEXT_DIM);
-
-// Underline indicator — use width not flex_grow to avoid vertical expansion
-createCol("tab-inspector-line", "tab-inspector-col");
-setFlex("tab-inspector-line", "height", 2);
-setFlex("tab-inspector-line", "width", 120);
-setFlex("tab-inspector-line", "flex_shrink", 0);
-
-createCol("tab-chat-col", "right-tabs");
-setFlex("tab-chat-col", "flex_grow", 1);
-setFlex("tab-chat-col", "height", 36);
-setFlex("tab-chat-col", "align_items", "center");
-setFlex("tab-chat-col", "justify_content", "center");
-setFlex("tab-chat-col", "gap", 0);
-
-createLabel("tab-chat", "CHAT", "tab-chat-col");
-setFontSize("tab-chat", 11);
-setFlex("tab-chat", "height", 28);
-setTextAlign("tab-chat", "center");
-setTextColor("tab-chat", APP_ACCENT);
-
-createCol("tab-chat-line", "tab-chat-col");
-setFlex("tab-chat-line", "height", 2);
-setFlex("tab-chat-line", "width", 120);
-setFlex("tab-chat-line", "flex_shrink", 0);
-setBackground("tab-chat-line", APP_ACCENT);
-
-// Inspector content area (hidden by default)
-createCol("inspector-area", "right-panel");
-setFlex("inspector-area", "flex_grow", 1);
-setFlex("inspector-area", "padding", 10);
-setFlex("inspector-area", "gap", 6);
-setVisible("inspector-area", false);
-
-createLabel("insp-title", "ELEMENT INSPECTOR", "inspector-area");
-setFontSize("insp-title", 10);
-setTextColor("insp-title", APP_TEXT_DIM);
-setFlex("insp-title", "height", 14);
-
-createLabel("insp-hint", "Cmd+click any element in the preview to inspect its properties.", "inspector-area");
-setFontSize("insp-hint", 10);
-setTextColor("insp-hint", APP_TEXT_DIM);
-setFlex("insp-hint", "height", 28);
-
-// Inspector property rows (placeholder)
-createRow("insp-row-type", "inspector-area");
-setFlex("insp-row-type", "height", 20);
-setFlex("insp-row-type", "align_items", "center");
-createLabel("insp-type-k", "Type:", "insp-row-type");
-setFontSize("insp-type-k", 10);
-setTextColor("insp-type-k", APP_TEXT_DIM);
-setFlex("insp-type-k", "width", 60);
-createLabel("insp-type-v", "—", "insp-row-type");
-setFontSize("insp-type-v", 10);
-setFlex("insp-type-v", "flex_grow", 1);
-
-createRow("insp-row-id", "inspector-area");
-setFlex("insp-row-id", "height", 20);
-setFlex("insp-row-id", "align_items", "center");
-createLabel("insp-id-k", "ID:", "insp-row-id");
-setFontSize("insp-id-k", 10);
-setTextColor("insp-id-k", APP_TEXT_DIM);
-setFlex("insp-id-k", "width", 60);
-createLabel("insp-id-v", "—", "insp-row-id");
-setFontSize("insp-id-v", 10);
-setFlex("insp-id-v", "flex_grow", 1);
-
-createRow("insp-row-bounds", "inspector-area");
-setFlex("insp-row-bounds", "height", 20);
-setFlex("insp-row-bounds", "align_items", "center");
-createLabel("insp-bounds-k", "Bounds:", "insp-row-bounds");
-setFontSize("insp-bounds-k", 10);
-setTextColor("insp-bounds-k", APP_TEXT_DIM);
-setFlex("insp-bounds-k", "width", 60);
-createLabel("insp-bounds-v", "—", "insp-row-bounds");
-setFontSize("insp-bounds-v", 10);
-setFlex("insp-bounds-v", "flex_grow", 1);
+buildPreviewWaveform2AndRightPanel();
 
 // Tab switching logic
 var activeTab = "chat";
@@ -4045,185 +4141,188 @@ function switchTab(tab) {
 }
 
 // Tab switching via registerClick + on() click events
-registerClick("tab-inspector-col");
-registerClick("tab-chat-col");
-registerClick("tab-inspector");
-registerClick("tab-chat");
-on("tab-inspector-col", "click", function() { switchTab("inspector"); });
-on("tab-chat-col", "click", function() { switchTab("chat"); });
-on("tab-inspector", "click", function() { switchTab("inspector"); });
-on("tab-chat", "click", function() { switchTab("chat"); });
+function buildRightPanelChat() {
+    registerClick("tab-inspector-col");
+    registerClick("tab-chat-col");
+    registerClick("tab-inspector");
+    registerClick("tab-chat");
+    on("tab-inspector-col", "click", function() { switchTab("inspector"); });
+    on("tab-chat-col", "click", function() { switchTab("chat"); });
+    on("tab-inspector", "click", function() { switchTab("inspector"); });
+    on("tab-chat", "click", function() { switchTab("chat"); });
 
-// Chat content area
-createCol("chat-area", "right-panel");
-setFlex("chat-area", "flex_grow", 1);
-setFlex("chat-area", "padding", 10);
-setFlex("chat-area", "gap", 8);
+    // Chat content area
+    createCol("chat-area", "right-panel");
+    setFlex("chat-area", "flex_grow", 1);
+    setFlex("chat-area", "padding", 10);
+    setFlex("chat-area", "gap", 8);
 
-// AI provider / model selector
-createCol("model-row", "chat-area");
-setFlex("model-row", "height", 48);
-setFlex("model-row", "flex_shrink", 0);
-setFlex("model-row", "gap", 4);
+    // AI provider / model selector
+    createCol("model-row", "chat-area");
+    setFlex("model-row", "height", 48);
+    setFlex("model-row", "flex_shrink", 0);
+    setFlex("model-row", "gap", 4);
 
-createRow("model-top-row", "model-row");
-setFlex("model-top-row", "height", 22);
-setFlex("model-top-row", "align_items", "center");
-setFlex("model-top-row", "justify_content", "space-between");
+    createRow("model-top-row", "model-row");
+    setFlex("model-top-row", "height", 22);
+    setFlex("model-top-row", "align_items", "center");
+    setFlex("model-top-row", "justify_content", "space-between");
 
-// #51: Context badge with accent styling
-// Chat context badge
-createRow("context-badge", "model-top-row");
-setFlex("context-badge", "height", 22);
-setFlex("context-badge", "width", 136);
-setFlex("context-badge", "flex_shrink", 0);
-setFlex("context-badge", "padding_left", 8);
-setFlex("context-badge", "padding_right", 6);
-setFlex("context-badge", "align_items", "center");
-setFlex("context-badge", "gap", 6);
-setBackground("context-badge", '#2a2040');
-setBorder("context-badge", '#9f7aea', 1, 11);
-createLabel("context-label", "Editing: All", "context-badge");
-setFontSize("context-label", 9);
-setTextColor("context-label", APP_ACCENT);
-setFlex("context-label", "flex_grow", 1);
-setFlex("context-label", "height", 14);
-setTextOverflow("context-label", "ellipsis");
-createCol("context-clear", "context-badge");
-setFlex("context-clear", "width", 14);
-setFlex("context-clear", "height", 14);
-setFlex("context-clear", "justify_content", "center");
-setFlex("context-clear", "align_items", "center");
-setBackground("context-clear", "#ffffff0c");
-setBorder("context-clear", "#ffffff12", 1, 7);
-createIcon("context-clear-icon", "close", "context-clear");
-setFlex("context-clear-icon", "width", 9);
-setFlex("context-clear-icon", "height", 9);
-setPointerEvents("context-clear-icon", "none");
-setVisible("context-clear", false);
-registerClick("context-clear");
-registerClick("context-badge");
+    // #51: Context badge with accent styling
+    // Chat context badge
+    createRow("context-badge", "model-top-row");
+    setFlex("context-badge", "height", 22);
+    setFlex("context-badge", "width", 136);
+    setFlex("context-badge", "flex_shrink", 0);
+    setFlex("context-badge", "padding_left", 8);
+    setFlex("context-badge", "padding_right", 6);
+    setFlex("context-badge", "align_items", "center");
+    setFlex("context-badge", "gap", 6);
+    setBackground("context-badge", '#2a2040');
+    setBorder("context-badge", '#9f7aea', 1, 11);
+    createLabel("context-label", "Editing: All", "context-badge");
+    setFontSize("context-label", 9);
+    setTextColor("context-label", APP_ACCENT);
+    setFlex("context-label", "flex_grow", 1);
+    setFlex("context-label", "height", 14);
+    setTextOverflow("context-label", "ellipsis");
+    createCol("context-clear", "context-badge");
+    setFlex("context-clear", "width", 14);
+    setFlex("context-clear", "height", 14);
+    setFlex("context-clear", "justify_content", "center");
+    setFlex("context-clear", "align_items", "center");
+    setBackground("context-clear", "#ffffff0c");
+    setBorder("context-clear", "#ffffff12", 1, 7);
+    createIcon("context-clear-icon", "close", "context-clear");
+    setFlex("context-clear-icon", "width", 9);
+    setFlex("context-clear-icon", "height", 9);
+    setPointerEvents("context-clear-icon", "none");
+    setVisible("context-clear", false);
+    registerClick("context-clear");
+    registerClick("context-badge");
 
-createCombo("provider-selector", "model-top-row");
-setItems("provider-selector", ["Claude", "Codex"]);
-setFlex("provider-selector", "width", 84);
-setFlex("provider-selector", "height", 22);
+    createCombo("provider-selector", "model-top-row");
+    setItems("provider-selector", ["Claude", "Codex"]);
+    setFlex("provider-selector", "width", 84);
+    setFlex("provider-selector", "height", 22);
 
-createRow("model-bottom-row", "model-row");
-setFlex("model-bottom-row", "height", 22);
-setFlex("model-bottom-row", "align_items", "center");
-setFlex("model-bottom-row", "gap", 6);
+    createRow("model-bottom-row", "model-row");
+    setFlex("model-bottom-row", "height", 22);
+    setFlex("model-bottom-row", "align_items", "center");
+    setFlex("model-bottom-row", "gap", 6);
 
-createCombo("model-selector", "model-bottom-row");
-setItems("model-selector", ["Sonnet 4.6", "Opus 4.6"]);
-setFlex("model-selector", "flex_grow", 1);
-setFlex("model-selector", "height", 22);
+    createCombo("model-selector", "model-bottom-row");
+    setItems("model-selector", ["Sonnet 4.6", "Opus 4.6"]);
+    setFlex("model-selector", "flex_grow", 1);
+    setFlex("model-selector", "height", 22);
 
-createCombo("effort-selector", "model-bottom-row");
-setItems("effort-selector", ["Default", "Low", "Medium", "High", "xHigh"]);
-setFlex("effort-selector", "width", 74);
-setFlex("effort-selector", "height", 22);
-setVisible("effort-selector", false);
+    createCombo("effort-selector", "model-bottom-row");
+    setItems("effort-selector", ["Default", "Low", "Medium", "High", "xHigh"]);
+    setFlex("effort-selector", "width", 74);
+    setFlex("effort-selector", "height", 22);
+    setVisible("effort-selector", false);
 
-createCol("chat-export-btn", "model-bottom-row");
-setFlex("chat-export-btn", "width", 52);
-setFlex("chat-export-btn", "height", 22);
-setFlex("chat-export-btn", "justify_content", "center");
-setFlex("chat-export-btn", "align_items", "center");
-setBorder("chat-export-btn", APP_BORDER, 1, 6);
-createLabel("chat-export-label", "Export", "chat-export-btn");
-setFontSize("chat-export-label", 9);
-setTextColor("chat-export-label", APP_TEXT_DIM);
-setPointerEvents("chat-export-label", "none");
-registerClick("chat-export-btn");
+    createCol("chat-export-btn", "model-bottom-row");
+    setFlex("chat-export-btn", "width", 52);
+    setFlex("chat-export-btn", "height", 22);
+    setFlex("chat-export-btn", "justify_content", "center");
+    setFlex("chat-export-btn", "align_items", "center");
+    setBorder("chat-export-btn", APP_BORDER, 1, 6);
+    createLabel("chat-export-label", "Export", "chat-export-btn");
+    setFontSize("chat-export-label", 9);
+    setTextColor("chat-export-label", APP_TEXT_DIM);
+    setPointerEvents("chat-export-label", "none");
+    registerClick("chat-export-btn");
 
-// Chat messages (scrollable)
-createScrollView("chat-messages", "chat-area");
-setFlex("chat-messages", "flex_grow", 1);
-setFlex("chat-messages", "padding_right", 10);
-setScrollContentSize("chat-messages", 224, 400);  // keep content clear of scrollbar
+    // Chat messages (scrollable)
+    createScrollView("chat-messages", "chat-area");
+    setFlex("chat-messages", "flex_grow", 1);
+    setFlex("chat-messages", "padding_right", 10);
+    setScrollContentSize("chat-messages", 224, 400);  // keep content clear of scrollbar
 
-createCol("chat-thread", "chat-messages");
-setFlex("chat-thread", "gap", 8);
-setFlex("chat-thread", "padding_right", 14);
-setFlex("chat-thread", "flex_shrink", 0);
+    createCol("chat-thread", "chat-messages");
+    setFlex("chat-thread", "gap", 8);
+    setFlex("chat-thread", "padding_right", 14);
+    setFlex("chat-thread", "flex_shrink", 0);
 
-createLabel("welcome-msg", "Describe a visual style and the preview will update live.", "chat-thread");
-setFontSize("welcome-msg", 11);
-setFlex("welcome-msg", "height", 30);
+    createLabel("welcome-msg", "Describe a visual style and the preview will update live.", "chat-thread");
+    setFontSize("welcome-msg", 11);
+    setFlex("welcome-msg", "height", 30);
 
-createLabel("hint-msg", 'Try: "warm vintage" or "neon cyberpunk"', "chat-thread");
-setFontSize("hint-msg", 10);
-setTextColor("hint-msg", APP_TEXT_DIM);
-setFlex("hint-msg", "height", 16);
+    createLabel("hint-msg", 'Try: "warm vintage" or "neon cyberpunk"', "chat-thread");
+    setFontSize("hint-msg", 10);
+    setTextColor("hint-msg", APP_TEXT_DIM);
+    setFlex("hint-msg", "height", 16);
 
-createRow("chat-typing-row", "chat-area");
-setFlex("chat-typing-row", "height", 0);
-setFlex("chat-typing-row", "align_items", "center");
-setFlex("chat-typing-row", "gap", 6);
-setFlex("chat-typing-row", "padding_left", 6);
-setFlex("chat-typing-row", "padding_right", 6);
-setFlex("chat-typing-row", "flex_shrink", 0);
-setBackground("chat-typing-row", APP_PANEL);
-setBorder("chat-typing-row", APP_BORDER, 1, 6);
-setVisible("chat-typing-row", false);
+    createRow("chat-typing-row", "chat-area");
+    setFlex("chat-typing-row", "height", 0);
+    setFlex("chat-typing-row", "align_items", "center");
+    setFlex("chat-typing-row", "gap", 6);
+    setFlex("chat-typing-row", "padding_left", 6);
+    setFlex("chat-typing-row", "padding_right", 6);
+    setFlex("chat-typing-row", "flex_shrink", 0);
+    setBackground("chat-typing-row", APP_PANEL);
+    setBorder("chat-typing-row", APP_BORDER, 1, 6);
+    setVisible("chat-typing-row", false);
 
-createLabel("chat-typing-label", "", "chat-typing-row");
-setFontSize("chat-typing-label", 9);
-setTextColor("chat-typing-label", APP_TEXT_DIM);
+    createLabel("chat-typing-label", "", "chat-typing-row");
+    setFontSize("chat-typing-label", 9);
+    setTextColor("chat-typing-label", APP_TEXT_DIM);
 
-// Chat input area
-createRow("chat-attachment-row", "chat-area");
-setFlex("chat-attachment-row", "height", 0);
-setFlex("chat-attachment-row", "gap", 6);
-setFlex("chat-attachment-row", "align_items", "center");
-setFlex("chat-attachment-row", "padding_left", 6);
-setFlex("chat-attachment-row", "padding_right", 6);
-setFlex("chat-attachment-row", "flex_shrink", 0);
-setBackground("chat-attachment-row", APP_PANEL);
-setBorder("chat-attachment-row", APP_BORDER, 1, 6);
-setVisible("chat-attachment-row", false);
+    // Chat input area
+    createRow("chat-attachment-row", "chat-area");
+    setFlex("chat-attachment-row", "height", 0);
+    setFlex("chat-attachment-row", "gap", 6);
+    setFlex("chat-attachment-row", "align_items", "center");
+    setFlex("chat-attachment-row", "padding_left", 6);
+    setFlex("chat-attachment-row", "padding_right", 6);
+    setFlex("chat-attachment-row", "flex_shrink", 0);
+    setBackground("chat-attachment-row", APP_PANEL);
+    setBorder("chat-attachment-row", APP_BORDER, 1, 6);
+    setVisible("chat-attachment-row", false);
 
-createLabel("chat-attachment-label", "", "chat-attachment-row");
-setFontSize("chat-attachment-label", 9);
-setTextColor("chat-attachment-label", APP_TEXT_DIM);
-setFlex("chat-attachment-label", "flex_grow", 1);
-setTextOverflow("chat-attachment-label", "ellipsis");
+    createLabel("chat-attachment-label", "", "chat-attachment-row");
+    setFontSize("chat-attachment-label", 9);
+    setTextColor("chat-attachment-label", APP_TEXT_DIM);
+    setFlex("chat-attachment-label", "flex_grow", 1);
+    setTextOverflow("chat-attachment-label", "ellipsis");
 
-createCol("chat-attachment-clear", "chat-attachment-row");
-setFlex("chat-attachment-clear", "width", 16);
-setFlex("chat-attachment-clear", "height", 16);
-setFlex("chat-attachment-clear", "justify_content", "center");
-setFlex("chat-attachment-clear", "align_items", "center");
-setBorder("chat-attachment-clear", APP_BORDER, 1, 8);
-createLabel("chat-attachment-clear-label", "x", "chat-attachment-clear");
-setFontSize("chat-attachment-clear-label", 9);
-setTextColor("chat-attachment-clear-label", APP_TEXT_DIM);
-setPointerEvents("chat-attachment-clear-label", "none");
-registerClick("chat-attachment-clear");
+    createCol("chat-attachment-clear", "chat-attachment-row");
+    setFlex("chat-attachment-clear", "width", 16);
+    setFlex("chat-attachment-clear", "height", 16);
+    setFlex("chat-attachment-clear", "justify_content", "center");
+    setFlex("chat-attachment-clear", "align_items", "center");
+    setBorder("chat-attachment-clear", APP_BORDER, 1, 8);
+    createLabel("chat-attachment-clear-label", "x", "chat-attachment-clear");
+    setFontSize("chat-attachment-clear-label", 9);
+    setTextColor("chat-attachment-clear-label", APP_TEXT_DIM);
+    setPointerEvents("chat-attachment-clear-label", "none");
+    registerClick("chat-attachment-clear");
 
-createRow("chat-input-row", "chat-area");
-setFlex("chat-input-row", "height", 36);
-setFlex("chat-input-row", "align_items", "center");
-setFlex("chat-input-row", "flex_shrink", 0);
-setFlex("chat-input-row", "gap", 6);
+    createRow("chat-input-row", "chat-area");
+    setFlex("chat-input-row", "height", 36);
+    setFlex("chat-input-row", "align_items", "center");
+    setFlex("chat-input-row", "flex_shrink", 0);
+    setFlex("chat-input-row", "gap", 6);
 
-// Upload button with hover state (Issue 3)
-// #49: Upload button with proper icon sizing
-createCol("upload-btn", "chat-input-row");
-setFlex("upload-btn", "width", 32);
-setFlex("upload-btn", "height", 32);
-setBackground("upload-btn", APP_PANEL);
-setBorder("upload-btn", APP_BORDER, 1, 6);
-setFlex("upload-btn", "justify_content", "center");
-setFlex("upload-btn", "align_items", "center");
-createIcon("upload-icon", "image_upload", "upload-btn");
-setFlex("upload-icon", "width", 16);
-setFlex("upload-icon", "height", 16);
-setPointerEvents("upload-icon", "none");
-registerHover("upload-btn");
-on("upload-btn", "mouseenter", function() { setBorder("upload-btn", APP_ACCENT, 1, 6); setBackground("upload-btn", APP_PANEL_RAISED); });
-on("upload-btn", "mouseleave", function() { setBorder("upload-btn", APP_BORDER, 1, 6); setBackground("upload-btn", APP_PANEL); });
+    // Upload button with hover state (Issue 3)
+    // #49: Upload button with proper icon sizing
+    createCol("upload-btn", "chat-input-row");
+    setFlex("upload-btn", "width", 32);
+    setFlex("upload-btn", "height", 32);
+    setBackground("upload-btn", APP_PANEL);
+    setBorder("upload-btn", APP_BORDER, 1, 6);
+    setFlex("upload-btn", "justify_content", "center");
+    setFlex("upload-btn", "align_items", "center");
+    createIcon("upload-icon", "image_upload", "upload-btn");
+    setFlex("upload-icon", "width", 16);
+    setFlex("upload-icon", "height", 16);
+    setPointerEvents("upload-icon", "none");
+    registerHover("upload-btn");
+    on("upload-btn", "mouseenter", function() { setBorder("upload-btn", APP_ACCENT, 1, 6); setBackground("upload-btn", APP_PANEL_RAISED); });
+    on("upload-btn", "mouseleave", function() { setBorder("upload-btn", APP_BORDER, 1, 6); setBackground("upload-btn", APP_PANEL); });
+}
+buildRightPanelChat();
 // Issue 2: image upload via file dialog
 var uploadedImagePath = "";
 var uploadedImageName = "";
@@ -4367,9 +4466,12 @@ function getReferenceImageDialogExtensions() {
     return REFERENCE_IMAGE_EXTENSIONS;
 }
 
-on("chat-attachment-clear", "click", function() {
-    clearUploadedImage();
-});
+function wireChatAttachmentClear() {
+    on("chat-attachment-clear", "click", function() {
+        clearUploadedImage();
+    });
+}
+wireChatAttachmentClear();
 
 function updateChatInputSizing(text) {
     var value = text || "";
@@ -4401,252 +4503,255 @@ function setChatPendingUi(pending) {
     refreshSendButtonPresentation(pending);
 }
 
-registerClick("upload-btn");
-on("upload-btn", "click", function() {
-    var path = showOpenDialog("Select Reference Image", "Image Files", getReferenceImageDialogExtensions());
-    if (path && path.length > 0) {
-        if (!isSupportedReferenceImage(path)) {
-            showToast("Unsupported image type");
-            return;
+function buildChatControlsAndToast() {
+    registerClick("upload-btn");
+    on("upload-btn", "click", function() {
+        var path = showOpenDialog("Select Reference Image", "Image Files", getReferenceImageDialogExtensions());
+        if (path && path.length > 0) {
+            if (!isSupportedReferenceImage(path)) {
+                showToast("Unsupported image type");
+                return;
+            }
+            setUploadedImage(path);
+            showToast("Attached " + uploadedImageName);
         }
-        setUploadedImage(path);
-        showToast("Attached " + uploadedImageName);
-    }
-});
+    });
 
-createTextEditor("chat-input", "chat-input-row");
-setPlaceholder("chat-input", "Describe a style...");
-setMultiLine("chat-input", 1);
-setFlex("chat-input", "flex_grow", 1);
-setFlex("chat-input", "height", 32);
-setTextColor("chat-input", APP_TEXT);
-on("chat-input", "change", function(text) {
-    updateChatInputSizing(text);
-});
+    createTextEditor("chat-input", "chat-input-row");
+    setPlaceholder("chat-input", "Describe a style...");
+    setMultiLine("chat-input", 1);
+    setFlex("chat-input", "flex_grow", 1);
+    setFlex("chat-input", "height", 32);
+    setTextColor("chat-input", APP_TEXT);
+    on("chat-input", "change", function(text) {
+        updateChatInputSizing(text);
+    });
 
-// #49: Send button with proper icon sizing
-createCol("send-btn", "chat-input-row");
-setFlex("send-btn", "width", 32);
-setFlex("send-btn", "height", 32);
-setBackground("send-btn", APP_ACCENT);
-setBorder("send-btn", APP_ACCENT, 1, 6);
-setFlex("send-btn", "justify_content", "center");
-setFlex("send-btn", "align_items", "center");
-createIcon("send-icon", "send", "send-btn");
-setFlex("send-icon", "width", 16);
-setFlex("send-icon", "height", 16);
-setPointerEvents("send-icon", "none");
-createIcon("send-cancel-icon", "close", "send-btn");
-setFlex("send-cancel-icon", "width", 14);
-setFlex("send-cancel-icon", "height", 14);
-setPointerEvents("send-cancel-icon", "none");
-setVisible("send-cancel-icon", false);
-// Issue 3: hover state for send button
-registerHover("send-btn");
-on("send-btn", "mouseenter", function() {
-    if (chatRequestPending) {
-        setBackground("send-btn", APP_SURFACE);
-        setBorder("send-btn", APP_TEXT_DIM, 1, 6);
-    } else {
-        setBackground("send-btn", APP_ACCENT_HOVER);
-        setBorder("send-btn", APP_ACCENT_HOVER, 1, 6);
-    }
-});
-on("send-btn", "mouseleave", function() { refreshSendButtonPresentation(); });
+    // #49: Send button with proper icon sizing
+    createCol("send-btn", "chat-input-row");
+    setFlex("send-btn", "width", 32);
+    setFlex("send-btn", "height", 32);
+    setBackground("send-btn", APP_ACCENT);
+    setBorder("send-btn", APP_ACCENT, 1, 6);
+    setFlex("send-btn", "justify_content", "center");
+    setFlex("send-btn", "align_items", "center");
+    createIcon("send-icon", "send", "send-btn");
+    setFlex("send-icon", "width", 16);
+    setFlex("send-icon", "height", 16);
+    setPointerEvents("send-icon", "none");
+    createIcon("send-cancel-icon", "close", "send-btn");
+    setFlex("send-cancel-icon", "width", 14);
+    setFlex("send-cancel-icon", "height", 14);
+    setPointerEvents("send-cancel-icon", "none");
+    setVisible("send-cancel-icon", false);
+    // Issue 3: hover state for send button
+    registerHover("send-btn");
+    on("send-btn", "mouseenter", function() {
+        if (chatRequestPending) {
+            setBackground("send-btn", APP_SURFACE);
+            setBorder("send-btn", APP_TEXT_DIM, 1, 6);
+        } else {
+            setBackground("send-btn", APP_ACCENT_HOVER);
+            setBorder("send-btn", APP_ACCENT_HOVER, 1, 6);
+        }
+    });
+    on("send-btn", "mouseleave", function() { refreshSendButtonPresentation(); });
 
-// ═══════════════════════════════════════════════════════════════════
-// STATUS BAR (28px, full width)
-// ═══════════════════════════════════════════════════════════════════
-createRow("status-bar");
-setFlex("status-bar", "height", 28);
-setFlex("status-bar", "flex_shrink", 0);
-setFlex("status-bar", "padding_left", 12);
-setFlex("status-bar", "padding_right", 12);
-setFlex("status-bar", "align_items", "center");
-setFlex("status-bar", "justify_content", "space-between");
-setBackground("status-bar", APP_SURFACE);
-setBorder("status-bar", APP_BORDER, 1, 0);
+    // ═══════════════════════════════════════════════════════════════════
+    // STATUS BAR (28px, full width)
+    // ═══════════════════════════════════════════════════════════════════
+    createRow("status-bar");
+    setFlex("status-bar", "height", 28);
+    setFlex("status-bar", "flex_shrink", 0);
+    setFlex("status-bar", "padding_left", 12);
+    setFlex("status-bar", "padding_right", 12);
+    setFlex("status-bar", "align_items", "center");
+    setFlex("status-bar", "justify_content", "space-between");
+    setBackground("status-bar", APP_SURFACE);
+    setBorder("status-bar", APP_BORDER, 1, 0);
 
-createLabel("status-text", "0 tokens modified", "status-bar");
-setFontSize("status-text", 10);
-setTextColor("status-text", APP_TEXT_DIM);
+    createLabel("status-text", "0 tokens modified", "status-bar");
+    setFontSize("status-text", 10);
+    setTextColor("status-text", APP_TEXT_DIM);
 
-createLabel("status-schema", "pulp-theme/v1", "status-bar");
+    createLabel("status-schema", "pulp-theme/v1", "status-bar");
 
-// ═══════════════════════════════════════════════════════════════════
-// D7: Toast notification system
-// ═══════════════════════════════════════════════════════════════════
-createCol("toast-overlay", "");
-setPosition("toast-overlay", "absolute");
-setFlex("toast-overlay", "width", 200);
-setFlex("toast-overlay", "height", 30);
-setFlex("toast-overlay", "justify_content", "center");
-setFlex("toast-overlay", "align_items", "center");
-setBackground("toast-overlay", APP_PANEL);
-setBorder("toast-overlay", APP_BORDER, 1, 6);
-setBoxShadow("toast-overlay", 0, 4, 16, 0, "#00000060");
-setZIndex("toast-overlay", 200);
-setOpacity("toast-overlay", 0);
-setVisible("toast-overlay", false);
+    // ═══════════════════════════════════════════════════════════════════
+    // D7: Toast notification system
+    // ═══════════════════════════════════════════════════════════════════
+    createCol("toast-overlay", "");
+    setPosition("toast-overlay", "absolute");
+    setFlex("toast-overlay", "width", 200);
+    setFlex("toast-overlay", "height", 30);
+    setFlex("toast-overlay", "justify_content", "center");
+    setFlex("toast-overlay", "align_items", "center");
+    setBackground("toast-overlay", APP_PANEL);
+    setBorder("toast-overlay", APP_BORDER, 1, 6);
+    setBoxShadow("toast-overlay", 0, 4, 16, 0, "#00000060");
+    setZIndex("toast-overlay", 200);
+    setOpacity("toast-overlay", 0);
+    setVisible("toast-overlay", false);
 
-createLabel("toast-text", "", "toast-overlay");
-setFontSize("toast-text", 10);
+    createLabel("toast-text", "", "toast-overlay");
+    setFontSize("toast-text", 10);
 
-createModal("help-modal", "");
-setPosition("help-modal", "absolute");
-setFlex("help-modal", "width", 1100);
-setFlex("help-modal", "height", 700);
-setFlex("help-modal", "justify_content", "center");
-setFlex("help-modal", "align_items", "center");
-setBackground("help-modal", "#00000088");
-setZIndex("help-modal", 210);
-setOpacity("help-modal", 0);
-setVisible("help-modal", false);
-setPointerEvents("help-modal", "none");
-registerClick("help-modal");
+    createModal("help-modal", "");
+    setPosition("help-modal", "absolute");
+    setFlex("help-modal", "width", 1100);
+    setFlex("help-modal", "height", 700);
+    setFlex("help-modal", "justify_content", "center");
+    setFlex("help-modal", "align_items", "center");
+    setBackground("help-modal", "#00000088");
+    setZIndex("help-modal", 210);
+    setOpacity("help-modal", 0);
+    setVisible("help-modal", false);
+    setPointerEvents("help-modal", "none");
+    registerClick("help-modal");
 
-createCol("help-card", "help-modal");
-setFlex("help-card", "width", 340);
-setFlex("help-card", "min_height", 144);
-setFlex("help-card", "padding", 16);
-setFlex("help-card", "gap", 10);
-setBackground("help-card", APP_PANEL);
-setBorder("help-card", APP_BORDER, 1, 12);
-setBoxShadow("help-card", 0, 12, 32, 0, "#00000088");
+    createCol("help-card", "help-modal");
+    setFlex("help-card", "width", 340);
+    setFlex("help-card", "min_height", 144);
+    setFlex("help-card", "padding", 16);
+    setFlex("help-card", "gap", 10);
+    setBackground("help-card", APP_PANEL);
+    setBorder("help-card", APP_BORDER, 1, 12);
+    setBoxShadow("help-card", 0, 12, 32, 0, "#00000088");
 
-createRow("help-card-header", "help-card");
-setFlex("help-card-header", "height", 26);
-setFlex("help-card-header", "align_items", "center");
-setFlex("help-card-header", "justify_content", "space-between");
-setFlex("help-card-header", "gap", 8);
+    createRow("help-card-header", "help-card");
+    setFlex("help-card-header", "height", 26);
+    setFlex("help-card-header", "align_items", "center");
+    setFlex("help-card-header", "justify_content", "space-between");
+    setFlex("help-card-header", "gap", 8);
 
-createLabel("help-modal-title", "Help", "help-card-header");
-setFontSize("help-modal-title", 14);
-setTextColor("help-modal-title", APP_TEXT);
-setFlex("help-modal-title", "flex_grow", 1);
-setTextOverflow("help-modal-title", "ellipsis");
+    createLabel("help-modal-title", "Help", "help-card-header");
+    setFontSize("help-modal-title", 14);
+    setTextColor("help-modal-title", APP_TEXT);
+    setFlex("help-modal-title", "flex_grow", 1);
+    setTextOverflow("help-modal-title", "ellipsis");
 
-createCol("help-modal-close-btn", "help-card-header");
-setFlex("help-modal-close-btn", "width", 60);
-setFlex("help-modal-close-btn", "height", 26);
-setFlex("help-modal-close-btn", "padding_left", 6);
-setFlex("help-modal-close-btn", "padding_right", 6);
-setFlex("help-modal-close-btn", "justify_content", "center");
-setFlex("help-modal-close-btn", "align_items", "center");
-setBackground("help-modal-close-btn", APP_SURFACE);
-setBorder("help-modal-close-btn", APP_BORDER, 1, 8);
-registerClick("help-modal-close-btn");
+    createCol("help-modal-close-btn", "help-card-header");
+    setFlex("help-modal-close-btn", "width", 60);
+    setFlex("help-modal-close-btn", "height", 26);
+    setFlex("help-modal-close-btn", "padding_left", 6);
+    setFlex("help-modal-close-btn", "padding_right", 6);
+    setFlex("help-modal-close-btn", "justify_content", "center");
+    setFlex("help-modal-close-btn", "align_items", "center");
+    setBackground("help-modal-close-btn", APP_SURFACE);
+    setBorder("help-modal-close-btn", APP_BORDER, 1, 8);
+    registerClick("help-modal-close-btn");
 
-createLabel("help-modal-close-label", "Close", "help-modal-close-btn");
-setFontSize("help-modal-close-label", 10);
-setTextColor("help-modal-close-label", APP_TEXT_DIM);
-setPointerEvents("help-modal-close-label", "none");
+    createLabel("help-modal-close-label", "Close", "help-modal-close-btn");
+    setFontSize("help-modal-close-label", 10);
+    setTextColor("help-modal-close-label", APP_TEXT_DIM);
+    setPointerEvents("help-modal-close-label", "none");
 
-createLabel("help-modal-body", "", "help-card");
-setFontSize("help-modal-body", 11);
-setTextColor("help-modal-body", APP_TEXT_DIM);
-setMultiLine("help-modal-body", 1);
-setFlex("help-modal-body", "flex_grow", 1);
+    createLabel("help-modal-body", "", "help-card");
+    setFontSize("help-modal-body", 11);
+    setTextColor("help-modal-body", APP_TEXT_DIM);
+    setMultiLine("help-modal-body", 1);
+    setFlex("help-modal-body", "flex_grow", 1);
 
-on("help-modal", "click", function() { hideHelpModal(); });
-on("help-modal", "dismiss", function() { hideHelpModal(); });
-on("help-modal-close-btn", "click", function() { hideHelpModal(); });
+    on("help-modal", "click", function() { hideHelpModal(); });
+    on("help-modal", "dismiss", function() { hideHelpModal(); });
+    on("help-modal-close-btn", "click", function() { hideHelpModal(); });
 
-createModal("contrast-modal", "");
-setPosition("contrast-modal", "absolute");
-setFlex("contrast-modal", "width", 1100);
-setFlex("contrast-modal", "height", 700);
-setFlex("contrast-modal", "justify_content", "center");
-setFlex("contrast-modal", "align_items", "center");
-setBackground("contrast-modal", "#00000088");
-setZIndex("contrast-modal", 211);
-setOpacity("contrast-modal", 0);
-setVisible("contrast-modal", false);
-setPointerEvents("contrast-modal", "none");
-registerClick("contrast-modal");
+    createModal("contrast-modal", "");
+    setPosition("contrast-modal", "absolute");
+    setFlex("contrast-modal", "width", 1100);
+    setFlex("contrast-modal", "height", 700);
+    setFlex("contrast-modal", "justify_content", "center");
+    setFlex("contrast-modal", "align_items", "center");
+    setBackground("contrast-modal", "#00000088");
+    setZIndex("contrast-modal", 211);
+    setOpacity("contrast-modal", 0);
+    setVisible("contrast-modal", false);
+    setPointerEvents("contrast-modal", "none");
+    registerClick("contrast-modal");
 
-createCol("contrast-card", "contrast-modal");
-setFlex("contrast-card", "width", 360);
-setFlex("contrast-card", "min_height", 214);
-setFlex("contrast-card", "padding", 16);
-setFlex("contrast-card", "gap", 10);
-setBackground("contrast-card", APP_PANEL);
-setBorder("contrast-card", APP_BORDER, 1, 12);
-setBoxShadow("contrast-card", 0, 12, 32, 0, "#00000088");
+    createCol("contrast-card", "contrast-modal");
+    setFlex("contrast-card", "width", 360);
+    setFlex("contrast-card", "min_height", 214);
+    setFlex("contrast-card", "padding", 16);
+    setFlex("contrast-card", "gap", 10);
+    setBackground("contrast-card", APP_PANEL);
+    setBorder("contrast-card", APP_BORDER, 1, 12);
+    setBoxShadow("contrast-card", 0, 12, 32, 0, "#00000088");
 
-createRow("contrast-card-header", "contrast-card");
-setFlex("contrast-card-header", "height", 26);
-setFlex("contrast-card-header", "align_items", "center");
-setFlex("contrast-card-header", "justify_content", "space-between");
-setFlex("contrast-card-header", "gap", 8);
+    createRow("contrast-card-header", "contrast-card");
+    setFlex("contrast-card-header", "height", 26);
+    setFlex("contrast-card-header", "align_items", "center");
+    setFlex("contrast-card-header", "justify_content", "space-between");
+    setFlex("contrast-card-header", "gap", 8);
 
-createLabel("contrast-title", "Contrast", "contrast-card-header");
-setFontSize("contrast-title", 14);
-setTextColor("contrast-title", APP_TEXT);
-setFlex("contrast-title", "flex_grow", 1);
-setTextOverflow("contrast-title", "ellipsis");
+    createLabel("contrast-title", "Contrast", "contrast-card-header");
+    setFontSize("contrast-title", 14);
+    setTextColor("contrast-title", APP_TEXT);
+    setFlex("contrast-title", "flex_grow", 1);
+    setTextOverflow("contrast-title", "ellipsis");
 
-createCol("contrast-close-btn", "contrast-card-header");
-setFlex("contrast-close-btn", "width", 60);
-setFlex("contrast-close-btn", "height", 26);
-setFlex("contrast-close-btn", "padding_left", 6);
-setFlex("contrast-close-btn", "padding_right", 6);
-setFlex("contrast-close-btn", "justify_content", "center");
-setFlex("contrast-close-btn", "align_items", "center");
-setBackground("contrast-close-btn", APP_SURFACE);
-setBorder("contrast-close-btn", APP_BORDER, 1, 8);
-registerClick("contrast-close-btn");
+    createCol("contrast-close-btn", "contrast-card-header");
+    setFlex("contrast-close-btn", "width", 60);
+    setFlex("contrast-close-btn", "height", 26);
+    setFlex("contrast-close-btn", "padding_left", 6);
+    setFlex("contrast-close-btn", "padding_right", 6);
+    setFlex("contrast-close-btn", "justify_content", "center");
+    setFlex("contrast-close-btn", "align_items", "center");
+    setBackground("contrast-close-btn", APP_SURFACE);
+    setBorder("contrast-close-btn", APP_BORDER, 1, 8);
+    registerClick("contrast-close-btn");
 
-createLabel("contrast-close-label", "Close", "contrast-close-btn");
-setFontSize("contrast-close-label", 10);
-setTextColor("contrast-close-label", APP_TEXT_DIM);
-setPointerEvents("contrast-close-label", "none");
+    createLabel("contrast-close-label", "Close", "contrast-close-btn");
+    setFontSize("contrast-close-label", 10);
+    setTextColor("contrast-close-label", APP_TEXT_DIM);
+    setPointerEvents("contrast-close-label", "none");
 
-createLabel("contrast-hex", "#000000", "contrast-card");
-setFontSize("contrast-hex", 11);
-setTextColor("contrast-hex", APP_TEXT_DIM);
+    createLabel("contrast-hex", "#000000", "contrast-card");
+    setFontSize("contrast-hex", 11);
+    setTextColor("contrast-hex", APP_TEXT_DIM);
 
-createRow("contrast-sample-row", "contrast-card");
-setFlex("contrast-sample-row", "height", 92);
-setFlex("contrast-sample-row", "gap", 10);
+    createRow("contrast-sample-row", "contrast-card");
+    setFlex("contrast-sample-row", "height", 92);
+    setFlex("contrast-sample-row", "gap", 10);
 
-createCol("contrast-white-card", "contrast-sample-row");
-setFlex("contrast-white-card", "flex_grow", 1);
-setFlex("contrast-white-card", "height", 92);
-setFlex("contrast-white-card", "padding", 10);
-setFlex("contrast-white-card", "justify_content", "space-between");
-setBackground("contrast-white-card", "#FFFFFF");
-setBorder("contrast-white-card", "#D8D8E4", 1, 10);
+    createCol("contrast-white-card", "contrast-sample-row");
+    setFlex("contrast-white-card", "flex_grow", 1);
+    setFlex("contrast-white-card", "height", 92);
+    setFlex("contrast-white-card", "padding", 10);
+    setFlex("contrast-white-card", "justify_content", "space-between");
+    setBackground("contrast-white-card", "#FFFFFF");
+    setBorder("contrast-white-card", "#D8D8E4", 1, 10);
 
-createLabel("contrast-white-aa", "Aa", "contrast-white-card");
-setFontSize("contrast-white-aa", 24);
-createLabel("contrast-white-ratio", "", "contrast-white-card");
-setFontSize("contrast-white-ratio", 10);
-setTextColor("contrast-white-ratio", "#444444");
+    createLabel("contrast-white-aa", "Aa", "contrast-white-card");
+    setFontSize("contrast-white-aa", 24);
+    createLabel("contrast-white-ratio", "", "contrast-white-card");
+    setFontSize("contrast-white-ratio", 10);
+    setTextColor("contrast-white-ratio", "#444444");
 
-createCol("contrast-black-card", "contrast-sample-row");
-setFlex("contrast-black-card", "flex_grow", 1);
-setFlex("contrast-black-card", "height", 92);
-setFlex("contrast-black-card", "padding", 10);
-setFlex("contrast-black-card", "justify_content", "space-between");
-setBackground("contrast-black-card", "#111111");
-setBorder("contrast-black-card", "#1f1f28", 1, 10);
+    createCol("contrast-black-card", "contrast-sample-row");
+    setFlex("contrast-black-card", "flex_grow", 1);
+    setFlex("contrast-black-card", "height", 92);
+    setFlex("contrast-black-card", "padding", 10);
+    setFlex("contrast-black-card", "justify_content", "space-between");
+    setBackground("contrast-black-card", "#111111");
+    setBorder("contrast-black-card", "#1f1f28", 1, 10);
 
-createLabel("contrast-black-aa", "Aa", "contrast-black-card");
-setFontSize("contrast-black-aa", 24);
-createLabel("contrast-black-ratio", "", "contrast-black-card");
-setFontSize("contrast-black-ratio", 10);
-setTextColor("contrast-black-ratio", "#CFCFE0");
+    createLabel("contrast-black-aa", "Aa", "contrast-black-card");
+    setFontSize("contrast-black-aa", 24);
+    createLabel("contrast-black-ratio", "", "contrast-black-card");
+    setFontSize("contrast-black-ratio", 10);
+    setTextColor("contrast-black-ratio", "#CFCFE0");
 
-createLabel("contrast-note", "", "contrast-card");
-setFontSize("contrast-note", 10);
-setTextColor("contrast-note", APP_TEXT_DIM);
-setMultiLine("contrast-note", 1);
-setFlex("contrast-note", "flex_grow", 1);
+    createLabel("contrast-note", "", "contrast-card");
+    setFontSize("contrast-note", 10);
+    setTextColor("contrast-note", APP_TEXT_DIM);
+    setMultiLine("contrast-note", 1);
+    setFlex("contrast-note", "flex_grow", 1);
 
-on("contrast-modal", "click", function() { hideContrastModal(); });
-on("contrast-modal", "dismiss", function() { hideContrastModal(); });
-on("contrast-close-btn", "click", function() { hideContrastModal(); });
+    on("contrast-modal", "click", function() { hideContrastModal(); });
+    on("contrast-modal", "dismiss", function() { hideContrastModal(); });
+    on("contrast-close-btn", "click", function() { hideContrastModal(); });
+}
+buildChatControlsAndToast();
 
 var toastTimer = 0;
 function showToast(msg) {
@@ -4670,8 +4775,11 @@ function showToast(msg) {
     }
     __requestFrame__(fadeToast);
 }
-setFontSize("status-schema", 10);
-setTextColor("status-schema", APP_TEXT_DIM);
+function styleStatusSchema() {
+    setFontSize("status-schema", 10);
+    setTextColor("status-schema", APP_TEXT_DIM);
+}
+styleStatusSchema();
 
 // ═══════════════════════════════════════════════════════════════════
 // Inspector: Cmd+click detection
@@ -4731,75 +4839,78 @@ function getDesignDebugStateJson() {
     return JSON.stringify(lastDesignDebugState);
 }
 
-enableInspectClick();
-on("__inspect__", "click", function(widgetId) {
-    setDesignDebugTarget(widgetId || null);
-    if (activeTab === "inspector") {
-        switchTab("inspector");
-    }
-});
+function wireInspectorAndGlobalKeys() {
+    enableInspectClick();
+    on("__inspect__", "click", function(widgetId) {
+        setDesignDebugTarget(widgetId || null);
+        if (activeTab === "inspector") {
+            switchTab("inspector");
+        }
+    });
 
-// Clear context — click x or the badge itself
-on("context-clear", "click", function() {
-    clearInspectedComponent();
-});
-on("context-badge", "click", function() {
-    if (inspectedComponent) {
+    // Clear context — click x or the badge itself
+    on("context-clear", "click", function() {
         clearInspectedComponent();
-    }
-});
+    });
+    on("context-badge", "click", function() {
+        if (inspectedComponent) {
+            clearInspectedComponent();
+        }
+    });
 
-// ═══════════════════════════════════════════════════════════════════
-// Global keyboard shortcuts (Cmd+Z undo, Cmd+Shift+Z redo)
-// ═══════════════════════════════════════════════════════════════════
-on("__global__", "keydown", function(evt) {
-    if (!evt) return;
-    if ((evt.key === 274 || evt.key === 27) && chatRequestPending) {
-        cancelPendingChat("Chat canceled");
-        return;
-    }
-    if ((evt.key === 274 || evt.key === 27) && tokenEditState.activeToken) {
-        closeTokenPopup();
-        layout();
-        return;
-    }
-    if ((evt.key === 274 || evt.key === 27) && helpModalOpen) {
-        hideHelpModal();
-        return;
-    }
-    if ((evt.key === 274 || evt.key === 27) && contrastModalOpen) {
-        hideContrastModal();
-        return;
-    }
-    if ((evt.key === 274 || evt.key === 27) && exportPopupOpen) {
-        hideExportPopup();
-        return;
-    }
-    var cmd = (evt.mods & 0x18) !== 0;  // kModMeta | kModCmd
-    var shift = (evt.mods & 0x01) !== 0;
-    // 'z' key = 122 ASCII or platform key code
-    if (cmd && evt.key === 122) {
-        if (shift) {
-            // Redo
-            if (historyIndex < themeHistory.length - 1) {
-                historyIndex++;
-                applyTokenDiff(themeHistory[historyIndex]);
-                updateTokenSwatches();
-                setText("status-text", "Redo (" + historyIndex + "/" + (themeHistory.length - 1) + ")");
-                layout();
-            }
-        } else {
-            // Undo
-            if (historyIndex > 0) {
-                historyIndex--;
-                applyTokenDiff(themeHistory[historyIndex]);
-                updateTokenSwatches();
-                setText("status-text", "Undo (" + historyIndex + "/" + (themeHistory.length - 1) + ")");
-                layout();
+    // ═══════════════════════════════════════════════════════════════════
+    // Global keyboard shortcuts (Cmd+Z undo, Cmd+Shift+Z redo)
+    // ═══════════════════════════════════════════════════════════════════
+    on("__global__", "keydown", function(evt) {
+        if (!evt) return;
+        if ((evt.key === 274 || evt.key === 27) && chatRequestPending) {
+            cancelPendingChat("Chat canceled");
+            return;
+        }
+        if ((evt.key === 274 || evt.key === 27) && tokenEditState.activeToken) {
+            closeTokenPopup();
+            layout();
+            return;
+        }
+        if ((evt.key === 274 || evt.key === 27) && helpModalOpen) {
+            hideHelpModal();
+            return;
+        }
+        if ((evt.key === 274 || evt.key === 27) && contrastModalOpen) {
+            hideContrastModal();
+            return;
+        }
+        if ((evt.key === 274 || evt.key === 27) && exportPopupOpen) {
+            hideExportPopup();
+            return;
+        }
+        var cmd = (evt.mods & 0x18) !== 0;  // kModMeta | kModCmd
+        var shift = (evt.mods & 0x01) !== 0;
+        // 'z' key = 122 ASCII or platform key code
+        if (cmd && evt.key === 122) {
+            if (shift) {
+                // Redo
+                if (historyIndex < themeHistory.length - 1) {
+                    historyIndex++;
+                    applyTokenDiff(themeHistory[historyIndex]);
+                    updateTokenSwatches();
+                    setText("status-text", "Redo (" + historyIndex + "/" + (themeHistory.length - 1) + ")");
+                    layout();
+                }
+            } else {
+                // Undo
+                if (historyIndex > 0) {
+                    historyIndex--;
+                    applyTokenDiff(themeHistory[historyIndex]);
+                    updateTokenSwatches();
+                    setText("status-text", "Undo (" + historyIndex + "/" + (themeHistory.length - 1) + ")");
+                    layout();
+                }
             }
         }
-    }
-});
+    });
+}
+wireInspectorAndGlobalKeys();
 
 // ═══════════════════════════════════════════════════════════════════
 // Chat logic
@@ -4992,9 +5103,12 @@ function addChatMessage(role, text) {
     layout();
 }
 
-on("chat-export-btn", "click", function() {
-    exportChatHistory();
-});
+function wireChatExportButton() {
+    on("chat-export-btn", "click", function() {
+        exportChatHistory();
+    });
+}
+wireChatExportButton();
 
 var chatRequestPending = false;
 var chatRequestCounter = 0;
@@ -5110,24 +5224,27 @@ function setDesignDebugAIConfig(providerId, modelId, reasoningEffort) {
     refreshAISelectors();
 }
 
-on("provider-selector", "select", function(idx) {
-    aiProviderIndex = Math.max(0, Math.min(aiProviderOptions.length - 1, Math.round(idx)));
+function wireAISelectors() {
+    on("provider-selector", "select", function(idx) {
+        aiProviderIndex = Math.max(0, Math.min(aiProviderOptions.length - 1, Math.round(idx)));
+        refreshAISelectors();
+        layout();
+    });
+
+    on("model-selector", "select", function(idx) {
+        var provider = getSelectedAIProvider();
+        aiModelIndexByProvider[provider] = Math.max(0, Math.round(idx));
+        lastDesignDebugState.model = getSelectedAIModel();
+    });
+
+    on("effort-selector", "select", function(idx) {
+        aiReasoningEffortIndex = Math.max(0, Math.min(aiReasoningEffortValues.length - 1, Math.round(idx)));
+        lastDesignDebugState.reasoningEffort = getSelectedAIReasoningEffort();
+    });
+
     refreshAISelectors();
-    layout();
-});
-
-on("model-selector", "select", function(idx) {
-    var provider = getSelectedAIProvider();
-    aiModelIndexByProvider[provider] = Math.max(0, Math.round(idx));
-    lastDesignDebugState.model = getSelectedAIModel();
-});
-
-on("effort-selector", "select", function(idx) {
-    aiReasoningEffortIndex = Math.max(0, Math.min(aiReasoningEffortValues.length - 1, Math.round(idx)));
-    lastDesignDebugState.reasoningEffort = getSelectedAIReasoningEffort();
-});
-
-refreshAISelectors();
+}
+wireAISelectors();
 
 function numericParam(params, key, fallback, minValue, maxValue) {
     var raw = params && params[key] !== undefined ? Number(params[key]) : fallback;
@@ -6169,36 +6286,39 @@ function submitChat(text) {
     updateChatInputSizing("");
 }
 
-on("chat-input", "return", function(text) {
-    submitChat(text);
-});
+function wireChatInputAndPresetSelector() {
+    on("chat-input", "return", function(text) {
+        submitChat(text);
+    });
 
-// Send button triggers same as return key
-registerClick("send-btn");
-on("send-btn", "click", function() {
-    if (chatRequestPending) {
-        cancelPendingChat("Chat canceled");
-        return;
-    }
-    var text = getText("chat-input");
-    submitChat(text);
-});
+    // Send button triggers same as return key
+    registerClick("send-btn");
+    on("send-btn", "click", function() {
+        if (chatRequestPending) {
+            cancelPendingChat("Chat canceled");
+            return;
+        }
+        var text = getText("chat-input");
+        submitChat(text);
+    });
 
-setChatPendingUi(false);
+    setChatPendingUi(false);
 
-// Preset handler
-on("preset-selector", "select", function(idx) {
-    var presets = [
-        { title: "Default Dark", theme: "dark", accent: "#89B4FA", harmony: "monochromatic", presetIndex: 0 },
-        { title: "Light", theme: "light", accent: "#2563EB", harmony: "complementary", presetIndex: 1 },
-        { title: "Pro Audio", theme: "pro_audio", accent: "#89B4FA", harmony: "monochromatic", presetIndex: 2 },
-        { title: "Violet", theme: "dark", accent: "#AA88FF", harmony: "monochromatic", presetIndex: 3 },
-        { title: "Amber", theme: "dark", accent: "#D4A017", harmony: "monochromatic", presetIndex: 4 },
-        { title: "Ocean", theme: "dark", accent: "#0EA5E9", harmony: "analogous", presetIndex: 5 },
-        { title: "Neon", theme: "dark", accent: "#FF00FF", harmony: "complementary", presetIndex: 6 }
-    ];
-    applyPaletteConfiguration(presets[idx] || presets[0]);
-});
+    // Preset handler
+    on("preset-selector", "select", function(idx) {
+        var presets = [
+            { title: "Default Dark", theme: "dark", accent: "#89B4FA", harmony: "monochromatic", presetIndex: 0 },
+            { title: "Light", theme: "light", accent: "#2563EB", harmony: "complementary", presetIndex: 1 },
+            { title: "Pro Audio", theme: "pro_audio", accent: "#89B4FA", harmony: "monochromatic", presetIndex: 2 },
+            { title: "Violet", theme: "dark", accent: "#AA88FF", harmony: "monochromatic", presetIndex: 3 },
+            { title: "Amber", theme: "dark", accent: "#D4A017", harmony: "monochromatic", presetIndex: 4 },
+            { title: "Ocean", theme: "dark", accent: "#0EA5E9", harmony: "analogous", presetIndex: 5 },
+            { title: "Neon", theme: "dark", accent: "#FF00FF", harmony: "complementary", presetIndex: 6 }
+        ];
+        applyPaletteConfiguration(presets[idx] || presets[0]);
+    });
+}
+wireChatInputAndPresetSelector();
 
 // ═══════════════════════════════════════════════════════════════════
 // Export/Import buttons
@@ -6323,148 +6443,151 @@ function showExportPopup() {
     layout();
 }
 
-createCol("export-backdrop", "");
-setPosition("export-backdrop", "absolute");
-setFlex("export-backdrop", "width", 1100);
-setFlex("export-backdrop", "height", 700);
-setTop("export-backdrop", 0);
-setLeft("export-backdrop", 0);
-setBackground("export-backdrop", "#00000088");
-setZIndex("export-backdrop", 149);
-setVisible("export-backdrop", false);
-setPointerEvents("export-backdrop", "none");
-registerClick("export-backdrop");
-on("export-backdrop", "click", function() { hideExportPopup(); });
+function buildExportPopup() {
+    createCol("export-backdrop", "");
+    setPosition("export-backdrop", "absolute");
+    setFlex("export-backdrop", "width", 1100);
+    setFlex("export-backdrop", "height", 700);
+    setTop("export-backdrop", 0);
+    setLeft("export-backdrop", 0);
+    setBackground("export-backdrop", "#00000088");
+    setZIndex("export-backdrop", 149);
+    setVisible("export-backdrop", false);
+    setPointerEvents("export-backdrop", "none");
+    registerClick("export-backdrop");
+    on("export-backdrop", "click", function() { hideExportPopup(); });
 
-// Export popup overlay
-createCol("export-popup", "");
-setPosition("export-popup", "absolute");
-setFlex("export-popup", "width", 480);
-setFlex("export-popup", "height", 400);
-setFlex("export-popup", "padding", 16);
-setFlex("export-popup", "gap", 10);
-setBackground("export-popup", APP_PANEL);
-setBorder("export-popup", APP_BORDER, 1, 10);
-setBoxShadow("export-popup", 0, 16, 48, 0, "#000000c0");
-setZIndex("export-popup", 150);
-setVisible("export-popup", false);
+    // Export popup overlay
+    createCol("export-popup", "");
+    setPosition("export-popup", "absolute");
+    setFlex("export-popup", "width", 480);
+    setFlex("export-popup", "height", 400);
+    setFlex("export-popup", "padding", 16);
+    setFlex("export-popup", "gap", 10);
+    setBackground("export-popup", APP_PANEL);
+    setBorder("export-popup", APP_BORDER, 1, 10);
+    setBoxShadow("export-popup", 0, 16, 48, 0, "#000000c0");
+    setZIndex("export-popup", 150);
+    setVisible("export-popup", false);
 
-// Export header
-createRow("exp-header", "export-popup");
-setFlex("exp-header", "height", 24);
-setFlex("exp-header", "align_items", "center");
-createLabel("exp-title", "Export Theme", "exp-header");
-setFontSize("exp-title", 14);
-setFlex("exp-title", "flex_grow", 1);
+    // Export header
+    createRow("exp-header", "export-popup");
+    setFlex("exp-header", "height", 24);
+    setFlex("exp-header", "align_items", "center");
+    createLabel("exp-title", "Export Theme", "exp-header");
+    setFontSize("exp-title", 14);
+    setFlex("exp-title", "flex_grow", 1);
 
-createCol("exp-close", "exp-header");
-setFlex("exp-close", "width", 22);
-setFlex("exp-close", "height", 22);
-setFlex("exp-close", "justify_content", "center");
-setFlex("exp-close", "align_items", "center");
-createLabel("exp-close-lbl", "x", "exp-close");
-setFontSize("exp-close-lbl", 12);
-registerClick("exp-close");
-on("exp-close", "click", function() { hideExportPopup(); });
+    createCol("exp-close", "exp-header");
+    setFlex("exp-close", "width", 22);
+    setFlex("exp-close", "height", 22);
+    setFlex("exp-close", "justify_content", "center");
+    setFlex("exp-close", "align_items", "center");
+    createLabel("exp-close-lbl", "x", "exp-close");
+    setFontSize("exp-close-lbl", 12);
+    registerClick("exp-close");
+    on("exp-close", "click", function() { hideExportPopup(); });
 
-// Format tabs
-createRow("exp-tabs", "export-popup");
-setFlex("exp-tabs", "height", 26);
-setFlex("exp-tabs", "gap", 2);
-for (var ef = 0; ef < exportFormats.length; ef++) {
-    var efId = "exp-tab-" + ef;
-    createCol(efId, "exp-tabs");
-    setFlex(efId, "flex_grow", 1);
-    setFlex(efId, "height", 26);
-    setFlex(efId, "justify_content", "center");
-    setFlex(efId, "align_items", "center");
-    setBorder(efId, ef === 0 ? APP_ACCENT : APP_BORDER, 1, 4);
-    createLabel(efId + "-lbl", exportFormats[ef], efId);
-    setFontSize(efId + "-lbl", 10);
-    setTextColor(efId + "-lbl", ef === 0 ? APP_ACCENT : APP_TEXT_DIM);
-    registerClick(efId);
-    (function(idx) {
-        on("exp-tab-" + idx, "click", function() {
-            activeExportFormat = idx;
-            for (var i = 0; i < exportFormats.length; i++) {
-                setBorder("exp-tab-" + i, i === idx ? APP_ACCENT : APP_BORDER, 1, 4);
-                setTextColor("exp-tab-" + i + "-lbl", i === idx ? APP_ACCENT : APP_TEXT_DIM);
-            }
-            setText("exp-code", generateExport(idx));
-        });
-    })(ef);
-}
-
-// Code preview (scrollable text)
-createScrollView("exp-code-scroll", "export-popup");
-setFlex("exp-code-scroll", "flex_grow", 1);
-setBackground("exp-code-scroll", APP_BG);
-setBorder("exp-code-scroll", APP_BORDER, 1, 4);
-setScrollContentSize("exp-code-scroll", 440, 1200);
-
-createLabel("exp-code", "", "exp-code-scroll");
-setFontSize("exp-code", 10);
-setFlex("exp-code", "padding", 8);
-setFlex("exp-code", "width", 440);
-
-// Action buttons
-createRow("exp-actions", "export-popup");
-setFlex("exp-actions", "height", 28);
-setFlex("exp-actions", "gap", 8);
-setFlex("exp-actions", "justify_content", "flex-end");
-
-createCol("exp-copy-btn", "exp-actions");
-setFlex("exp-copy-btn", "width", 80);
-setFlex("exp-copy-btn", "height", 28);
-setFlex("exp-copy-btn", "justify_content", "center");
-setFlex("exp-copy-btn", "align_items", "center");
-setBorder("exp-copy-btn", APP_BORDER, 1, 4);
-createLabel("exp-copy-lbl", "Copy", "exp-copy-btn");
-setFontSize("exp-copy-lbl", 10);
-registerClick("exp-copy-btn");
-on("exp-copy-btn", "click", function() {
-    var code = generateExport(activeExportFormat);
-    writeClipboard(code);
-    showToast("Copied to clipboard");
-});
-
-createCol("exp-save-btn", "exp-actions");
-setFlex("exp-save-btn", "width", 80);
-setFlex("exp-save-btn", "height", 28);
-setFlex("exp-save-btn", "justify_content", "center");
-setFlex("exp-save-btn", "align_items", "center");
-setBackground("exp-save-btn", APP_ACCENT);
-setBorder("exp-save-btn", APP_ACCENT, 0, 4);
-createLabel("exp-save-lbl", "Save", "exp-save-btn");
-setFontSize("exp-save-lbl", 10);
-registerClick("exp-save-btn");
-on("exp-save-btn", "click", function() {
-    var code = generateExport(activeExportFormat);
-    var ext = getExportFileExtension(activeExportFormat);
-    var path = "/tmp/pulp-theme" + ext;
-    exec("cat > " + path + " << 'PULPEOF'\n" + code + "\nPULPEOF");
-    showToast("Saved to " + path);
-});
-
-registerClick("export-btn-pill");
-on("export-btn-pill", "click", function() {
-    setText("exp-code", generateExport(activeExportFormat));
-    showExportPopup();
-});
-
-registerClick("import-btn-pill");
-on("import-btn-pill", "click", function() {
-    var path = "/tmp/pulp-theme-export.json";
-    var json = exec("cat " + path + " 2>/dev/null");
-    if (json && json.length > 10) {
-        applyTokenDiff(json);
-        updateTokenSwatches();
-        setText("status-text", "Imported from " + path);
-    } else {
-        setText("status-text", "No theme file found");
+    // Format tabs
+    createRow("exp-tabs", "export-popup");
+    setFlex("exp-tabs", "height", 26);
+    setFlex("exp-tabs", "gap", 2);
+    for (var ef = 0; ef < exportFormats.length; ef++) {
+        var efId = "exp-tab-" + ef;
+        createCol(efId, "exp-tabs");
+        setFlex(efId, "flex_grow", 1);
+        setFlex(efId, "height", 26);
+        setFlex(efId, "justify_content", "center");
+        setFlex(efId, "align_items", "center");
+        setBorder(efId, ef === 0 ? APP_ACCENT : APP_BORDER, 1, 4);
+        createLabel(efId + "-lbl", exportFormats[ef], efId);
+        setFontSize(efId + "-lbl", 10);
+        setTextColor(efId + "-lbl", ef === 0 ? APP_ACCENT : APP_TEXT_DIM);
+        registerClick(efId);
+        (function(idx) {
+            on("exp-tab-" + idx, "click", function() {
+                activeExportFormat = idx;
+                for (var i = 0; i < exportFormats.length; i++) {
+                    setBorder("exp-tab-" + i, i === idx ? APP_ACCENT : APP_BORDER, 1, 4);
+                    setTextColor("exp-tab-" + i + "-lbl", i === idx ? APP_ACCENT : APP_TEXT_DIM);
+                }
+                setText("exp-code", generateExport(idx));
+            });
+        })(ef);
     }
-    layout();
-});
+
+    // Code preview (scrollable text)
+    createScrollView("exp-code-scroll", "export-popup");
+    setFlex("exp-code-scroll", "flex_grow", 1);
+    setBackground("exp-code-scroll", APP_BG);
+    setBorder("exp-code-scroll", APP_BORDER, 1, 4);
+    setScrollContentSize("exp-code-scroll", 440, 1200);
+
+    createLabel("exp-code", "", "exp-code-scroll");
+    setFontSize("exp-code", 10);
+    setFlex("exp-code", "padding", 8);
+    setFlex("exp-code", "width", 440);
+
+    // Action buttons
+    createRow("exp-actions", "export-popup");
+    setFlex("exp-actions", "height", 28);
+    setFlex("exp-actions", "gap", 8);
+    setFlex("exp-actions", "justify_content", "flex-end");
+
+    createCol("exp-copy-btn", "exp-actions");
+    setFlex("exp-copy-btn", "width", 80);
+    setFlex("exp-copy-btn", "height", 28);
+    setFlex("exp-copy-btn", "justify_content", "center");
+    setFlex("exp-copy-btn", "align_items", "center");
+    setBorder("exp-copy-btn", APP_BORDER, 1, 4);
+    createLabel("exp-copy-lbl", "Copy", "exp-copy-btn");
+    setFontSize("exp-copy-lbl", 10);
+    registerClick("exp-copy-btn");
+    on("exp-copy-btn", "click", function() {
+        var code = generateExport(activeExportFormat);
+        writeClipboard(code);
+        showToast("Copied to clipboard");
+    });
+
+    createCol("exp-save-btn", "exp-actions");
+    setFlex("exp-save-btn", "width", 80);
+    setFlex("exp-save-btn", "height", 28);
+    setFlex("exp-save-btn", "justify_content", "center");
+    setFlex("exp-save-btn", "align_items", "center");
+    setBackground("exp-save-btn", APP_ACCENT);
+    setBorder("exp-save-btn", APP_ACCENT, 0, 4);
+    createLabel("exp-save-lbl", "Save", "exp-save-btn");
+    setFontSize("exp-save-lbl", 10);
+    registerClick("exp-save-btn");
+    on("exp-save-btn", "click", function() {
+        var code = generateExport(activeExportFormat);
+        var ext = getExportFileExtension(activeExportFormat);
+        var path = "/tmp/pulp-theme" + ext;
+        exec("cat > " + path + " << 'PULPEOF'\n" + code + "\nPULPEOF");
+        showToast("Saved to " + path);
+    });
+
+    registerClick("export-btn-pill");
+    on("export-btn-pill", "click", function() {
+        setText("exp-code", generateExport(activeExportFormat));
+        showExportPopup();
+    });
+
+    registerClick("import-btn-pill");
+    on("import-btn-pill", "click", function() {
+        var path = "/tmp/pulp-theme-export.json";
+        var json = exec("cat " + path + " 2>/dev/null");
+        if (json && json.length > 10) {
+            applyTokenDiff(json);
+            updateTokenSwatches();
+            setText("status-text", "Imported from " + path);
+        } else {
+            setText("status-text", "No theme file found");
+        }
+        layout();
+    });
+}
+buildExportPopup();
 
 // Undo/Redo (snapshot-based)
 var themeHistory = [];
@@ -6478,28 +6601,31 @@ function pushThemeSnapshot() {
     themeHistory.push(snap);
     historyIndex = themeHistory.length - 1;
 }
-pushThemeSnapshot();
+function buildUndoRedoWiring() {
+    pushThemeSnapshot();
 
-registerClick("undo-btn-pill");
-on("undo-btn-pill", "click", function() {
-    if (historyIndex > 0) {
-        historyIndex--;
-        applyTokenDiff(themeHistory[historyIndex]);
-        updateTokenSwatches();
-        setText("status-text", "Undo (" + historyIndex + "/" + (themeHistory.length - 1) + ")");
-        layout();
-    }
-});
+    registerClick("undo-btn-pill");
+    on("undo-btn-pill", "click", function() {
+        if (historyIndex > 0) {
+            historyIndex--;
+            applyTokenDiff(themeHistory[historyIndex]);
+            updateTokenSwatches();
+            setText("status-text", "Undo (" + historyIndex + "/" + (themeHistory.length - 1) + ")");
+            layout();
+        }
+    });
 
-registerClick("redo-btn-pill");
-on("redo-btn-pill", "click", function() {
-    if (historyIndex < themeHistory.length - 1) {
-        historyIndex++;
-        applyTokenDiff(themeHistory[historyIndex]);
-        updateTokenSwatches();
-        setText("status-text", "Redo (" + historyIndex + "/" + (themeHistory.length - 1) + ")");
-        layout();
-    }
-});
+    registerClick("redo-btn-pill");
+    on("redo-btn-pill", "click", function() {
+        if (historyIndex < themeHistory.length - 1) {
+            historyIndex++;
+            applyTokenDiff(themeHistory[historyIndex]);
+            updateTokenSwatches();
+            setText("status-text", "Redo (" + historyIndex + "/" + (themeHistory.length - 1) + ")");
+            layout();
+        }
+    });
 
-layout();
+    layout();
+}
+buildUndoRedoWiring();


### PR DESCRIPTION
## Summary

**Preparatory refactor that unblocks roadmap P8-NEW** (the design-tool.js "by concern" split). The split couldn't proceed because `examples/design-tool/design-tool.js` (6,505 lines) interleaved top-level imperative widget construction across 44 regions with `var`/`function` declarations — execution-order-sensitive, so a concern-split would scatter the imperative blocks.

This wraps 42 contiguous imperative regions into named, ordered build/wire functions — `buildRootShell`, `buildToolbarTitleAndPreset`, `buildTokenList`, `buildTokenPopupShell/Controls/Gamut`, `buildPreviewControls`, `buildPreviewTabBarAndPanel`, `buildRightPanelChat`, `buildExportPopup`, `wireInspectorAndGlobalKeys`, `wireAISelectors`, … — each **invoked immediately at its original source location** (define-then-call-inline, not deferred-to-EOF). The file stays one file; no `var`/`function` declaration moved.

## Test plan

- [x] **Byte-exact proof:** un-wrapping the refactored file (remove each wrapper triple, dedent bodies 4 spaces) reproduces the original `design-tool.js` byte-for-byte — execution order provably unchanged.
- [x] `pulp-test-design-tool-layout` (loads the real `design-tool.js` through WidgetBridge + ScriptEngine, asserts the full widget tree + interactive paths): baseline 533 assertions / 45 cases → post-refactor **533 / 45**, identical.
- [x] `pulp-test-design-tool-viewport-resolver` (4) + `pulp-test-widget-bridge-dispatch-global-key` (3) pass; `node -c` clean.
- [x] All harness globals (`currentHarmony`, `tokenEditState`, `generateExport`, `openTokenPopup`, …) stay top-level — wrapped regions held only loop iterators / ephemeral builder locals.

Zero behavior change. No version bump (`examples/` is not a versioned surface). A follow-up PR can now split `design-tool.js` by concern cleanly (P8-NEW proper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)