### PR TITLE
feat(render+view): VBlank-locked safe-repaint pattern across all platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.186.0
+    VERSION 0.187.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/render/CMakeLists.txt
+++ b/core/render/CMakeLists.txt
@@ -23,6 +23,15 @@ if(NOT ANDROID)
     target_sources(pulp-render PRIVATE src/sdl3_surface.cpp)
 endif()
 
+# Slice 16 — VBlank-locked RenderLoop platform backends.
+# iOS uses CADisplayLink; Android uses AChoreographer. macOS (CVDisplayLink),
+# Windows (DwmFlush) and the Linux/timer fallback all live in render_loop.cpp.
+if(PULP_IOS)
+    target_sources(pulp-render PRIVATE src/render_loop_apple.mm)
+elseif(ANDROID)
+    target_sources(pulp-render PRIVATE src/render_loop_android.cpp)
+endif()
+
 # DRACO mesh decompression (optional)
 if(PULP_HAS_DRACO)
     target_link_libraries(pulp-render PRIVATE draco)
@@ -61,9 +70,15 @@ if(PULP_HAS_SDL3)
     target_compile_definitions(pulp-render PRIVATE PULP_HAS_SDL3=1)
 endif()
 
-# CVDisplayLink for macOS render loop
+# RenderLoop vblank sources (Slice 16):
+#   macOS — CVDisplayLink (CoreVideo)
+#   iOS   — CADisplayLink (QuartzCore, already linked above for Metal)
+#   Win   — DwmFlush (dwmapi)
 if(APPLE AND NOT PULP_IOS)
     target_link_libraries(pulp-render PRIVATE "-framework CoreVideo")
+endif()
+if(WIN32)
+    target_link_libraries(pulp-render PRIVATE dwmapi)
 endif()
 
 # Link WebGPU if available

--- a/core/render/include/pulp/render/render_loop.hpp
+++ b/core/render/include/pulp/render/render_loop.hpp
@@ -1,41 +1,90 @@
 #pragma once
 
-// RenderLoop abstraction for frame-paced GPU rendering
-// Platform-specific implementations drive the render callback at display refresh rate.
+// RenderLoop abstraction for frame-paced GPU rendering.
 //
-// macOS: CVDisplayLink
-// Windows: DwmFlush or present-paced via D3D12 swap chain
-// Linux: SDL3 event loop with vsync via Vulkan present
-// WASM: requestAnimationFrame
+// Platform-specific implementations drive the render callback at the
+// display's refresh rate (vblank). The canonical pattern is *"set a dirty
+// flag, repaint on the next frame"* rather than periodic polling — call
+// request_frame() to mark dirty and the loop fires the callback exactly
+// once on the next vblank, coalescing any number of intervening requests.
+//
+//   macOS   : CVDisplayLink                       (real vblank)
+//   iOS     : CADisplayLink                       (real vblank)
+//   Android : AChoreographer                      (real vblank)
+//   Windows : DwmFlush (DWM-composed vblank wait)  (real vblank)
+//   Linux   : timer fallback                      (conscious fallback —
+//             a real X11/Wayland present-sync source drops in behind the
+//             same factory seam when available; see render_loop.cpp)
+//   Other   : timer fallback                      (~60 Hz)
+//
+// Slice 16 (planning/2026-05-18-rt-safety-and-debug-dx.md) — the VBlank-
+// locked safe-repaint pattern. The dirty-flag coalescer itself lives in
+// RenderLoopState (render_loop_state.hpp) and is platform-agnostic and
+// unit-tested; each platform subclass only owns the native vsync source.
 
 #include <functional>
 #include <memory>
-#include <atomic>
 
 namespace pulp::render {
 
 using FrameCallback = std::function<void()>;
 
+/// Which concrete backend RenderLoop::create() selected. Exposed so callers
+/// (and tests) can introspect whether a real vblank source or the timer
+/// fallback is in use without depending on platform defines.
+enum class RenderLoopBackend {
+    cv_display_link,   ///< macOS — real vblank.
+    ca_display_link,   ///< iOS — real vblank.
+    choreographer,     ///< Android — real vblank.
+    dwm_flush,         ///< Windows — DWM-composed vblank wait.
+    timer,             ///< Conscious ~60 Hz timer fallback (Linux/other).
+};
+
+/// Human-readable name for a backend (for logs / diagnostics).
+const char* render_loop_backend_name(RenderLoopBackend backend);
+
+/// True if the backend is locked to a real hardware/compositor vblank
+/// signal (as opposed to the conscious timer fallback).
+constexpr bool render_loop_backend_is_vsync(RenderLoopBackend backend) {
+    return backend != RenderLoopBackend::timer;
+}
+
 class RenderLoop {
 public:
-    // Create a platform-appropriate render loop
-    // native_handle: window/view handle (NSView*, HWND, SDL_Window*)
+    // Create a platform-appropriate render loop.
+    // native_handle: optional window/view handle (NSView*, HWND, SDL_Window*).
+    // Defining PULP_RENDER_LOOP_FORCE_TIMER forces the timer fallback on
+    // every platform — used by headless unit tests.
     static std::unique_ptr<RenderLoop> create(void* native_handle = nullptr);
+
+    // Create the conscious ~60 Hz timer-backed render loop explicitly, on
+    // any platform. Unlike create(), the result drives its callback from a
+    // worker thread and never depends on a native run loop / compositor, so
+    // it is deterministic in headless contexts. Intended for unit tests and
+    // for callers that deliberately want the no-vsync fallback.
+    static std::unique_ptr<RenderLoop> create_timer_loop();
 
     virtual ~RenderLoop() = default;
 
-    // Start the render loop with a frame callback
-    // The callback is invoked at (approximately) display refresh rate
+    // Start the render loop with a frame callback. The callback is invoked
+    // at (approximately) display refresh rate, but only on frames where a
+    // request_frame() has been posted since the last callback — the loop is
+    // demand-driven, not free-running, so an idle UI costs nothing.
     virtual void start(FrameCallback on_frame) = 0;
 
-    // Stop the render loop
+    // Stop the render loop. Idempotent; safe to call before start().
     virtual void stop() = 0;
 
-    // Request a frame be rendered (marks dirty, callback fires on next vsync)
+    // Request a frame be rendered. Marks the loop dirty; the callback fires
+    // once on the next vsync. Any number of calls between two vsyncs
+    // coalesce into a single callback invocation. RT-safe (lock-free).
     virtual void request_frame() = 0;
 
     // Is the loop currently running?
     virtual bool is_running() const = 0;
+
+    // Which backend this instance is. Lets callers detect a timer fallback.
+    virtual RenderLoopBackend backend() const = 0;
 };
 
 } // namespace pulp::render

--- a/core/render/src/render_loop.cpp
+++ b/core/render/src/render_loop.cpp
@@ -1,5 +1,17 @@
-// RenderLoop platform implementations
-// Each platform uses its native vsync mechanism for frame-paced rendering.
+// RenderLoop platform implementations.
+//
+// Each platform uses its native vsync mechanism for frame-paced rendering;
+// the shared RenderLoopState (render_loop_state.hpp) is the platform-
+// agnostic dirty-flag coalescer that turns N request_frame() calls between
+// two vblanks into exactly one callback invocation.
+//
+//   macOS   — MacRenderLoop      : CVDisplayLink           (this file)
+//   iOS     — IOSRenderLoop      : CADisplayLink           (render_loop_apple.mm)
+//   Android — AndroidRenderLoop  : AChoreographer          (render_loop_android.cpp)
+//   Windows — WindowsRenderLoop  : DwmFlush vblank wait    (this file)
+//   Linux   — TimerRenderLoop    : conscious timer fallback (this file)
+//
+// Slice 16, planning/2026-05-18-rt-safety-and-debug-dx.md.
 
 #include <pulp/render/render_loop.hpp>
 #include <pulp/runtime/log.hpp>
@@ -15,7 +27,23 @@
 #endif
 #endif
 
+#if defined(_WIN32) && !defined(PULP_RENDER_LOOP_FORCE_TIMER)
+#include <windows.h>
+#include <dwmapi.h>
+#endif
+
 namespace pulp::render {
+
+const char* render_loop_backend_name(RenderLoopBackend backend) {
+    switch (backend) {
+        case RenderLoopBackend::cv_display_link: return "CVDisplayLink";
+        case RenderLoopBackend::ca_display_link: return "CADisplayLink";
+        case RenderLoopBackend::choreographer:   return "AChoreographer";
+        case RenderLoopBackend::dwm_flush:       return "DwmFlush";
+        case RenderLoopBackend::timer:           return "timer";
+    }
+    return "unknown";
+}
 
 // ── macOS: CVDisplayLink ────────────────────────────────────────────────
 
@@ -51,6 +79,10 @@ public:
 
     bool is_running() const override { return state_.is_running(); }
 
+    RenderLoopBackend backend() const override {
+        return RenderLoopBackend::cv_display_link;
+    }
+
 private:
     CVDisplayLinkRef display_link_ = nullptr;
     FrameCallback callback_;
@@ -72,7 +104,78 @@ private:
 
 #endif // macOS
 
-// ── Generic: Timer-based fallback (Windows, Linux, or no-vsync) ─────────
+// ── Windows: DwmFlush (DWM-composed vblank wait) ────────────────────────
+//
+// DwmFlush() blocks until the DWM compositor's next composition pass,
+// which is paced to the display's vblank. Unlike a present-paced waitable
+// swapchain it needs no swapchain/window handle, so it works from the
+// RenderLoop factory seam without a native_handle. If DwmFlush() fails
+// (no DWM — Server Core, remote session, or a future headless config) the
+// loop transparently degrades to the ~60 Hz timer cadence for that frame.
+
+#if defined(_WIN32) && !defined(PULP_RENDER_LOOP_FORCE_TIMER)
+
+class WindowsRenderLoop : public RenderLoop {
+public:
+    ~WindowsRenderLoop() override { stop(); }
+
+    void start(FrameCallback on_frame) override {
+        if (!state_.start()) {
+            return;
+        }
+        callback_ = std::move(on_frame);
+
+        thread_ = std::thread([this]() {
+            using namespace std::chrono;
+            const auto fallback_interval = microseconds(16667); // ~60Hz
+            while (state_.is_running()) {
+                // Block until the next DWM composition (vblank-paced).
+                // S_OK means we waited on a real vblank; any failure
+                // (DWM disabled / unavailable) falls back to a timed
+                // sleep so the loop still makes forward progress.
+                const HRESULT hr = DwmFlush();
+                if (hr != S_OK && state_.is_running()) {
+                    std::this_thread::sleep_for(fallback_interval);
+                }
+                if (state_.consume_frame_request() && state_.is_running()) {
+                    if (callback_) callback_();
+                }
+            }
+        });
+    }
+
+    void stop() override {
+        state_.stop();
+        if (thread_.joinable()) thread_.join();
+    }
+
+    void request_frame() override {
+        state_.request_frame();
+    }
+
+    bool is_running() const override { return state_.is_running(); }
+
+    RenderLoopBackend backend() const override {
+        return RenderLoopBackend::dwm_flush;
+    }
+
+private:
+    std::thread thread_;
+    FrameCallback callback_;
+    RenderLoopState state_;
+};
+
+#endif // Windows
+
+// ── Generic: Timer-based fallback ───────────────────────────────────────
+//
+// Used on Linux and any other platform without a wired vblank source, and
+// by headless unit tests via PULP_RENDER_LOOP_FORCE_TIMER. This is a
+// CONSCIOUS fallback, not a real vblank lock: Linux real pacing needs an
+// X11 (GLX_OML_sync_control / DRM vblank) or Wayland (frame-callback)
+// presentation object that the RenderLoop factory does not own today. The
+// factory seam below is the single point where a real LinuxRenderLoop
+// drops in once that surface exists — no consumer code changes.
 
 class TimerRenderLoop : public RenderLoop {
 public:
@@ -112,6 +215,10 @@ public:
 
     bool is_running() const override { return state_.is_running(); }
 
+    RenderLoopBackend backend() const override {
+        return RenderLoopBackend::timer;
+    }
+
 private:
     std::thread thread_;
     FrameCallback callback_;
@@ -119,14 +226,43 @@ private:
 };
 
 // ── Factory ─────────────────────────────────────────────────────────────
+//
+// Single seam for backend selection. Platform subclasses defined in their
+// own translation units (iOS / Android) are constructed via the forward-
+// declared factory helpers below so this file stays C++-only.
+
+#if defined(__APPLE__) && !defined(PULP_RENDER_LOOP_FORCE_TIMER) && TARGET_OS_IPHONE
+// Defined in render_loop_apple.mm — owns a CADisplayLink.
+std::unique_ptr<RenderLoop> make_ios_render_loop();
+#endif
+
+#if defined(__ANDROID__) && !defined(PULP_RENDER_LOOP_FORCE_TIMER)
+// Defined in render_loop_android.cpp — owns an AChoreographer registration.
+std::unique_ptr<RenderLoop> make_android_render_loop();
+#endif
 
 std::unique_ptr<RenderLoop> RenderLoop::create(void* native_handle) {
     (void)native_handle;
-#if defined(__APPLE__) && !defined(PULP_RENDER_LOOP_FORCE_TIMER) && TARGET_OS_OSX
+#if defined(PULP_RENDER_LOOP_FORCE_TIMER)
+    return std::make_unique<TimerRenderLoop>();
+#elif defined(__APPLE__) && TARGET_OS_OSX
     return std::make_unique<MacRenderLoop>();
+#elif defined(__APPLE__) && TARGET_OS_IPHONE
+    return make_ios_render_loop();
+#elif defined(__ANDROID__)
+    return make_android_render_loop();
+#elif defined(_WIN32)
+    return std::make_unique<WindowsRenderLoop>();
 #else
+    // Linux and any other platform: conscious timer fallback.
     return std::make_unique<TimerRenderLoop>();
 #endif
+}
+
+std::unique_ptr<RenderLoop> RenderLoop::create_timer_loop() {
+    // TimerRenderLoop is compiled on every platform — no native run loop
+    // needed, so this is the deterministic choice for headless tests.
+    return std::make_unique<TimerRenderLoop>();
 }
 
 } // namespace pulp::render

--- a/core/render/src/render_loop.cpp
+++ b/core/render/src/render_loop.cpp
@@ -134,6 +134,7 @@ public:
                 // (DWM disabled / unavailable) falls back to a timed
                 // sleep so the loop still makes forward progress.
                 const HRESULT hr = DwmFlush();
+                backend_tracker_.note_wait_result(hr == S_OK);
                 if (hr != S_OK && state_.is_running()) {
                     std::this_thread::sleep_for(fallback_interval);
                 }
@@ -155,14 +156,17 @@ public:
 
     bool is_running() const override { return state_.is_running(); }
 
+    // Reports timer once DwmFlush() has failed, so callers using
+    // render_loop_backend_is_vsync() can detect the fallback (Codex P2 #2580).
     RenderLoopBackend backend() const override {
-        return RenderLoopBackend::dwm_flush;
+        return backend_tracker_.effective_backend();
     }
 
 private:
     std::thread thread_;
     FrameCallback callback_;
     RenderLoopState state_;
+    DwmBackendTracker backend_tracker_;
 };
 
 #endif // Windows

--- a/core/render/src/render_loop_android.cpp
+++ b/core/render/src/render_loop_android.cpp
@@ -1,0 +1,135 @@
+// Android RenderLoop — AChoreographer-backed vblank source.
+//
+// Slice 16, planning/2026-05-18-rt-safety-and-debug-dx.md. AChoreographer
+// is Android's native vsync callback (API 24+); it pumps cleanly on
+// 60/90/120 Hz and VRR displays. The existing standalone Choreographer
+// pacer lives in core/render/platform/android/choreographer_android.cpp;
+// this is the RenderLoop-shaped wrapper wired into RenderLoop::create().
+//
+// AChoreographer_getInstance() is thread/looper-sensitive: it must be
+// called from a thread with an ALooper attached (the Android UI / render
+// thread). RenderLoop::create() is therefore expected to be called from
+// that thread on Android. If no Choreographer is available start() stops
+// the loop immediately so is_running() reports false (rather than a loop
+// that claims to run but can never tick).
+//
+// LIFETIME — AChoreographer_postFrameCallback cannot be cancelled, so a
+// callback posted before stop() can still fire after the AndroidRenderLoop
+// object is destroyed. The callback therefore must NOT capture a raw
+// `this`. Instead the loop's mutable state lives in a heap ControlBlock
+// owned by a std::shared_ptr; each posted callback carries a heap token
+// holding a std::weak_ptr to it. When the callback fires it locks the
+// weak_ptr — if the loop is gone, lock() fails and the callback is a safe
+// no-op. No leak (the token is freed at callback entry), no UAF, and no
+// undocumented "must outlive one vsync" contract.
+//
+// RenderLoopState is the shared platform-agnostic dirty-flag coalescer.
+
+#include <pulp/render/render_loop.hpp>
+#include "render_loop_state.hpp"
+
+#if defined(__ANDROID__) && !defined(PULP_RENDER_LOOP_FORCE_TIMER)
+
+#include <android/choreographer.h>
+#include <android/looper.h>
+
+#include <memory>
+
+namespace pulp::render {
+
+namespace {
+
+// Heap-owned mutable state, kept alive independently of the RenderLoop
+// object so a trailing AChoreographer callback can safely observe it.
+struct AndroidLoopControl {
+    RenderLoopState state;
+    FrameCallback   callback;
+    AChoreographer* choreographer = nullptr;
+};
+
+// Forward decl — the static vsync callback re-posts itself.
+void post_next_frame(const std::shared_ptr<AndroidLoopControl>& control);
+
+// AChoreographer_postFrameCallback uses `long` for the timestamp and a
+// `void*` payload. The payload is a heap token holding a weak_ptr to the
+// control block; it is deleted as soon as the callback fires.
+void on_vsync(long /*frame_time_nanos*/, void* data) {
+    std::unique_ptr<std::weak_ptr<AndroidLoopControl>> token(
+        static_cast<std::weak_ptr<AndroidLoopControl>*>(data));
+
+    auto control = token->lock();
+    if (!control) {
+        return;  // RenderLoop was destroyed — safe no-op.
+    }
+    if (!control->state.is_running()) {
+        return;  // Stopped — do not re-post.
+    }
+    if (control->state.consume_frame_request()) {
+        if (control->callback) control->callback();
+    }
+    if (control->state.is_running()) {
+        post_next_frame(control);  // Continuous demand-driven loop.
+    }
+}
+
+void post_next_frame(const std::shared_ptr<AndroidLoopControl>& control) {
+    if (!control->choreographer) {
+        return;
+    }
+    auto* token = new std::weak_ptr<AndroidLoopControl>(control);
+    AChoreographer_postFrameCallback(control->choreographer, &on_vsync, token);
+}
+
+} // namespace
+
+class AndroidRenderLoop : public RenderLoop {
+public:
+    AndroidRenderLoop() : control_(std::make_shared<AndroidLoopControl>()) {}
+    ~AndroidRenderLoop() override { stop(); }
+
+    void start(FrameCallback on_frame) override {
+        if (!control_->state.start()) {
+            return;
+        }
+        control_->callback = std::move(on_frame);
+
+        // AChoreographer_getInstance() requires an ALooper on this thread.
+        control_->choreographer = AChoreographer_getInstance();
+        if (!control_->choreographer) {
+            // No vsync source — report not-running rather than a loop that
+            // claims to run but can never tick.
+            control_->state.stop();
+            return;
+        }
+        post_next_frame(control_);
+    }
+
+    void stop() override {
+        control_->state.stop();
+        // A callback already posted to AChoreographer cannot be cancelled,
+        // but it observes state.is_running()==false (or, after this object
+        // is destroyed, a dead weak_ptr) and will not re-post.
+        control_->choreographer = nullptr;
+    }
+
+    void request_frame() override {
+        control_->state.request_frame();
+    }
+
+    bool is_running() const override { return control_->state.is_running(); }
+
+    RenderLoopBackend backend() const override {
+        return RenderLoopBackend::choreographer;
+    }
+
+private:
+    std::shared_ptr<AndroidLoopControl> control_;
+};
+
+std::unique_ptr<RenderLoop> make_android_render_loop() {
+    return std::make_unique<AndroidRenderLoop>();
+}
+
+} // namespace pulp::render
+
+#endif // __ANDROID__

--- a/core/render/src/render_loop_apple.mm
+++ b/core/render/src/render_loop_apple.mm
@@ -1,0 +1,123 @@
+// iOS RenderLoop — CADisplayLink-backed vblank source.
+//
+// Slice 16, planning/2026-05-18-rt-safety-and-debug-dx.md. Mirrors the
+// macOS CVDisplayLink path in render_loop.cpp but uses CADisplayLink,
+// which is the iOS-native vsync callback (CVDisplayLink is macOS-only).
+//
+// The CADisplayLink is added to the main run loop in NSRunLoopCommonModes
+// so it keeps ticking during scroll/track tracking. Its target fires on
+// the main thread, so the frame callback runs on the main thread directly
+// (no dispatch_async needed, unlike the macOS path whose callback fires on
+// a CV thread). RenderLoopState is the shared dirty-flag coalescer.
+//
+// LIFETIME — IOSRenderLoop MUST be created, stopped, and destroyed on the
+// main thread. The CADisplayLink fires its selector on [NSRunLoop
+// mainRunLoop], so as long as start()/stop()/the destructor also run on
+// the main thread the selector can never be mid-flight while the C++
+// object is being torn down — there is no concurrency window. stop()
+// clears the ObjC target's back-pointer BEFORE invalidating the link, so
+// even a same-runloop re-entrant tick is a safe no-op.
+
+#include <pulp/render/render_loop.hpp>
+#include "render_loop_state.hpp"
+
+#import <TargetConditionals.h>
+
+#if defined(__APPLE__) && TARGET_OS_IPHONE && !defined(PULP_RENDER_LOOP_FORCE_TIMER)
+
+#import <QuartzCore/QuartzCore.h>
+#import <Foundation/Foundation.h>
+
+namespace pulp::render {
+class IOSRenderLoop;
+}
+
+// ObjC target for the CADisplayLink selector. CADisplayLink retains its
+// target, so this holds only a raw back-pointer to the C++ loop; the C++
+// loop clears it in stop()/dtor before the link is invalidated.
+@interface PulpRenderLoopDisplayLinkTarget : NSObject {
+@public
+    pulp::render::IOSRenderLoop* loop;
+}
+- (void)tick:(CADisplayLink*)link;
+@end
+
+namespace pulp::render {
+
+class IOSRenderLoop : public RenderLoop {
+public:
+    ~IOSRenderLoop() override { stop(); }
+
+    void start(FrameCallback on_frame) override {
+        if (!state_.start()) {
+            return;
+        }
+        callback_ = std::move(on_frame);
+
+        @autoreleasepool {
+            target_ = [[PulpRenderLoopDisplayLinkTarget alloc] init];
+            target_->loop = this;
+            display_link_ = [CADisplayLink displayLinkWithTarget:target_
+                                                        selector:@selector(tick:)];
+            [display_link_ addToRunLoop:[NSRunLoop mainRunLoop]
+                                forMode:NSRunLoopCommonModes];
+        }
+    }
+
+    void stop() override {
+        state_.stop();
+        @autoreleasepool {
+            // Clear the target's back-pointer FIRST so any selector that
+            // somehow runs between here and invalidate observes a nil loop
+            // and no-ops, then invalidate and drop the link + target.
+            if (target_) {
+                target_->loop = nullptr;
+            }
+            if (display_link_) {
+                [display_link_ invalidate];
+                display_link_ = nil;
+            }
+            target_ = nil;
+        }
+    }
+
+    void request_frame() override {
+        state_.request_frame();
+    }
+
+    bool is_running() const override { return state_.is_running(); }
+
+    RenderLoopBackend backend() const override {
+        return RenderLoopBackend::ca_display_link;
+    }
+
+    // Invoked from the CADisplayLink target on the main thread.
+    void on_vsync() {
+        if (state_.consume_frame_request() && state_.is_running()) {
+            if (callback_) callback_();
+        }
+    }
+
+private:
+    CADisplayLink* display_link_ = nil;
+    PulpRenderLoopDisplayLinkTarget* target_ = nil;
+    FrameCallback callback_;
+    RenderLoopState state_;
+};
+
+std::unique_ptr<RenderLoop> make_ios_render_loop() {
+    return std::make_unique<IOSRenderLoop>();
+}
+
+} // namespace pulp::render
+
+@implementation PulpRenderLoopDisplayLinkTarget
+- (void)tick:(CADisplayLink*)link {
+    (void)link;
+    if (loop) {
+        loop->on_vsync();
+    }
+}
+@end
+
+#endif // iOS

--- a/core/render/src/render_loop_state.hpp
+++ b/core/render/src/render_loop_state.hpp
@@ -2,7 +2,44 @@
 
 #include <atomic>
 
+#include "pulp/render/render_loop.hpp"
+
 namespace pulp::render {
+
+// Slice 16 — tracks whether a compositor-vblank wait (Windows DwmFlush) has
+// degraded to the timer fallback so backend() reports the effective backend.
+//
+// The Windows loop waits on DwmFlush() for vblank pacing; when DWM is
+// unavailable (Server Core, remote session, headless) DwmFlush() fails and
+// the loop transparently sleeps on a ~60 Hz timer instead. Without this
+// tracker, backend() would keep claiming dwm_flush (a real vblank) while the
+// loop is actually on the timer — defeating the very introspection API that
+// render_loop_backend_is_vsync() callers rely on to detect a non-vsync path.
+//
+// The latch is sticky: once DwmFlush() fails we report timer for the rest of
+// the loop's life. DWM availability does not flip back mid-session in the
+// failure cases this guards (DWM disabled / no compositor), and a sticky flag
+// is race-free and conservative — a caller that has seen any vblank miss
+// should not be told it is back on a reliable vblank.
+class DwmBackendTracker {
+public:
+    // Record the outcome of one DwmFlush() wait (true == S_OK / real vblank).
+    void note_wait_result(bool ok) {
+        if (!ok) {
+            on_timer_fallback_.store(true, std::memory_order_relaxed);
+        }
+    }
+
+    // The effective backend given everything observed so far.
+    RenderLoopBackend effective_backend() const {
+        return on_timer_fallback_.load(std::memory_order_relaxed)
+                   ? RenderLoopBackend::timer
+                   : RenderLoopBackend::dwm_flush;
+    }
+
+private:
+    std::atomic<bool> on_timer_fallback_{false};
+};
 
 class RenderLoopState {
 public:

--- a/core/state/include/pulp/state/binding.hpp
+++ b/core/state/include/pulp/state/binding.hpp
@@ -128,6 +128,16 @@ public:
     /// Call this periodically from the UI thread. Fires change callbacks if the
     /// value differs from the last polled value.
     /// @return True if the value changed since the last poll.
+    ///
+    /// @note Soft-deprecated (Slice 16, RT-Safety + Debug DX roadmap). The
+    ///       canonical pattern is no longer periodic polling: a parameter
+    ///       change should *set a dirty flag* and the UI should *repaint on
+    ///       the next vblank* via `WindowHost::mark_dirty()` —
+    ///       see `pulp::render::RenderLoop` and `WindowHost::mark_dirty()`.
+    ///       `poll()` stays supported for existing callers and for hosts
+    ///       without a vblank-driven loop, but new code should prefer the
+    ///       dirty-flag / next-frame path. It is intentionally NOT marked
+    ///       `[[deprecated]]` to avoid breaking `-Werror` builds.
     bool poll() {
         if (!store_) return false;
         float current = store_->get_value(param_id_);

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -512,4 +512,9 @@ endif()
 # NOT need to link pulp::render when PULP_BENCHMARK is enabled.
 if(TARGET pulp-render)
     target_link_libraries(pulp-view PRIVATE pulp::render)
+    # Slice 16 — when pulp-render is linked, WindowHost::mark_dirty() can
+    # route dirty marks through a vblank-paced RenderLoop. GPU-off builds
+    # (sanitizer matrix) have no pulp-render target, so mark_dirty() there
+    # degrades to a direct repaint(); the define gates that cleanly.
+    target_compile_definitions(pulp-view PRIVATE PULP_VIEW_HAS_RENDER_LOOP=1)
 endif()

--- a/core/view/include/pulp/view/param_attachment.hpp
+++ b/core/view/include/pulp/view/param_attachment.hpp
@@ -117,6 +117,12 @@ attach_combo(state::StateStore& store, state::ParamID id,
 }
 
 /// Poll all bindings in a vector to sync with host automation.
+///
+/// @note Soft-deprecated (Slice 16) alongside `Binding::poll()`. Prefer the
+///       VBlank-locked dirty-flag pattern: have parameter changes call
+///       `WindowHost::mark_dirty()` so the UI repaints once on the next
+///       vsync instead of polling every binding on a timer. This helper
+///       remains for hosts without a vblank-driven `RenderLoop`.
 inline void poll_bindings(std::vector<state::Binding>& bindings) {
     for (auto& b : bindings) b.poll();
 }

--- a/core/view/include/pulp/view/window_host.hpp
+++ b/core/view/include/pulp/view/window_host.hpp
@@ -9,6 +9,7 @@
 
 namespace pulp::render {
 class GpuSurface;
+class RenderLoop;
 }
 
 namespace pulp::view {
@@ -81,8 +82,36 @@ public:
     virtual void hide() = 0;
     virtual bool is_visible() const = 0;
 
-    // Request a repaint
+    // Request a repaint immediately. Platform impls translate this to the
+    // native invalidation call (setNeedsDisplay, InvalidateRect, …).
     virtual void repaint() = 0;
+
+    // ── Slice 16: VBlank-locked safe-repaint ────────────────────────────
+    //
+    // The canonical pattern for "something changed, the UI needs to redraw"
+    // is *"set a dirty flag, repaint on the next frame"* rather than the
+    // legacy periodic-polling pattern (Binding::poll() on a timer).
+    //
+    // mark_dirty() is the consumer entry point. When a RenderLoop has been
+    // attached via attach_render_loop(), it coalesces every call between
+    // two vblanks into exactly one request_frame() — so N state changes in
+    // one frame cost one repaint, locked to the display refresh. When no
+    // RenderLoop is attached it falls through to repaint() so existing
+    // callers keep working unchanged.
+    //
+    // Non-virtual on purpose: the coalescing policy is platform-agnostic
+    // and lives here so every platform host shares one implementation.
+    void mark_dirty();
+
+    // Attach (or detach, with nullptr) a vblank-paced RenderLoop that
+    // mark_dirty() should drive. Ownership stays with the caller; the loop
+    // must outlive the host or be detached first. Optional — hosts that
+    // already run their own native display-link loop can leave this unset
+    // and mark_dirty() degrades to a direct repaint().
+    void attach_render_loop(render::RenderLoop* loop) { render_loop_ = loop; }
+
+    // The attached RenderLoop, or nullptr.
+    render::RenderLoop* render_loop() const { return render_loop_; }
 
     // Native host/window handles for embedding child platform views such as
     // WebViews. Default implementations return nullptr on platforms that do
@@ -274,6 +303,10 @@ public:
     // ── D.4 Mouse relative mode ─────────────────────────────────────────
     /// Hide cursor and report relative deltas (infinite drag for knobs).
     virtual void set_mouse_relative_mode(bool enabled) { (void)enabled; }
+
+private:
+    // Slice 16 — optional vblank-paced RenderLoop driven by mark_dirty().
+    render::RenderLoop* render_loop_ = nullptr;
 };
 
 } // namespace pulp::view

--- a/core/view/src/view.cpp
+++ b/core/view/src/view.cpp
@@ -1113,8 +1113,14 @@ void View::request_repaint() {
     // never need to walk the parent chain. No host attached: silent
     // no-op — paint is already on the way for the initial mount, or
     // there's no surface to paint to yet.
+    //
+    // Slice 16 — route through WindowHost::mark_dirty(), the canonical
+    // "set a dirty flag, repaint on the next vblank" path. When a
+    // RenderLoop is attached this coalesces N change notifications in one
+    // frame into a single vsync-paced repaint; otherwise mark_dirty()
+    // degrades to a direct repaint() (unchanged behavior).
     if (window_host_) {
-        window_host_->repaint();
+        window_host_->mark_dirty();
     } else if (plugin_view_host_) {
         plugin_view_host_->repaint();
     }

--- a/core/view/src/window_host_stub.cpp
+++ b/core/view/src/window_host_stub.cpp
@@ -49,17 +49,23 @@ void WindowHost::set_resize_callback(ResizeCallback cb) {
     (void) cb;
 }
 
-// Slice 16 — VBlank-locked safe-repaint. When a RenderLoop is attached,
-// route the dirty mark through request_frame() so every call between two
-// vblanks coalesces into a single vsync-paced repaint. Otherwise fall
-// through to the platform repaint() — existing behavior, no regression.
+// Slice 16 — VBlank-locked safe-repaint. When a RenderLoop is attached AND
+// running, route the dirty mark through request_frame() so every call
+// between two vblanks coalesces into a single vsync-paced repaint. Otherwise
+// fall through to the platform repaint() — existing behavior, no regression.
+//
+// The is_running() guard matters: a loop attached but not yet started (or
+// already stopped while still attached) has a no-op request_frame(), so
+// without the guard the dirty update would be silently dropped and the UI
+// could appear frozen until some other repaint trigger. Falling through to
+// repaint() keeps an attached-but-idle loop correct.
 //
 // In GPU-off builds (no pulp-render target) RenderLoop is incomplete, so
 // render_loop_ can never be non-null there and mark_dirty() is always a
 // plain repaint(); the PULP_VIEW_HAS_RENDER_LOOP guard keeps it buildable.
 void WindowHost::mark_dirty() {
 #if defined(PULP_VIEW_HAS_RENDER_LOOP)
-    if (render_loop_) {
+    if (render_loop_ && render_loop_->is_running()) {
         render_loop_->request_frame();
         return;
     }

--- a/core/view/src/window_host_stub.cpp
+++ b/core/view/src/window_host_stub.cpp
@@ -10,6 +10,10 @@
 
 #include <pulp/view/window_host.hpp>
 
+#if defined(PULP_VIEW_HAS_RENDER_LOOP)
+#include <pulp/render/render_loop.hpp>
+#endif
+
 #include <mutex>
 
 namespace pulp::view {
@@ -43,6 +47,24 @@ WindowHost::ContentSize WindowHost::get_content_size() const {
 
 void WindowHost::set_resize_callback(ResizeCallback cb) {
     (void) cb;
+}
+
+// Slice 16 — VBlank-locked safe-repaint. When a RenderLoop is attached,
+// route the dirty mark through request_frame() so every call between two
+// vblanks coalesces into a single vsync-paced repaint. Otherwise fall
+// through to the platform repaint() — existing behavior, no regression.
+//
+// In GPU-off builds (no pulp-render target) RenderLoop is incomplete, so
+// render_loop_ can never be non-null there and mark_dirty() is always a
+// plain repaint(); the PULP_VIEW_HAS_RENDER_LOOP guard keeps it buildable.
+void WindowHost::mark_dirty() {
+#if defined(PULP_VIEW_HAS_RENDER_LOOP)
+    if (render_loop_) {
+        render_loop_->request_frame();
+        return;
+    }
+#endif
+    repaint();
 }
 
 #if !defined(__APPLE__)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1998,6 +1998,14 @@ if(PULP_ENABLE_GPU)
     target_link_libraries(pulp-test-rendering-integration PRIVATE pulp::view pulp::render pulp::state Catch2::Catch2WithMain)
     catch_discover_tests(pulp-test-rendering-integration)
 
+    # Slice 16 — WindowHost::mark_dirty() VBlank-locked safe-repaint routing.
+    # Needs both pulp::view (mark_dirty / attach_render_loop) and
+    # pulp::render (RenderLoop factory), so it gates on PULP_ENABLE_GPU.
+    add_executable(pulp-test-window-host-repaint test_window_host_repaint.cpp)
+    target_link_libraries(pulp-test-window-host-repaint PRIVATE
+        pulp::view pulp::render Catch2::Catch2WithMain)
+    catch_discover_tests(pulp-test-window-host-repaint)
+
 endif()
 
 # Texture atlas helpers compile cleanly without GPU deps; keep this pure

--- a/test/test_render_loop.cpp
+++ b/test/test_render_loop.cpp
@@ -195,6 +195,32 @@ TEST_CASE("render_loop_backend_name covers every backend",
           == "timer");
 }
 
+TEST_CASE("DwmBackendTracker latches to the timer fallback once a vblank wait fails",
+          "[render][loop][vblank][slice-16][issue-2580]") {
+    // Codex P2 #2580: the Windows loop sleeps on a ~60 Hz timer when
+    // DwmFlush() fails, but backend() must then stop claiming dwm_flush so
+    // render_loop_backend_is_vsync() callers can detect the fallback.
+    DwmBackendTracker tracker;
+
+    // Fresh tracker is optimistic: the real vblank backend.
+    REQUIRE(tracker.effective_backend() == RenderLoopBackend::dwm_flush);
+    REQUIRE(render_loop_backend_is_vsync(tracker.effective_backend()));
+
+    // Successful waits keep it on the vblank backend.
+    tracker.note_wait_result(true);
+    tracker.note_wait_result(true);
+    REQUIRE(tracker.effective_backend() == RenderLoopBackend::dwm_flush);
+
+    // A single failure latches the timer fallback.
+    tracker.note_wait_result(false);
+    REQUIRE(tracker.effective_backend() == RenderLoopBackend::timer);
+    REQUIRE_FALSE(render_loop_backend_is_vsync(tracker.effective_backend()));
+
+    // The latch is sticky: a later successful wait does not flip it back.
+    tracker.note_wait_result(true);
+    REQUIRE(tracker.effective_backend() == RenderLoopBackend::timer);
+}
+
 TEST_CASE("RenderLoop coalesces a burst of frame requests into one callback",
           "[render][loop][vblank][slice-16]") {
     // The canonical safe-repaint contract: any number of request_frame()

--- a/test/test_render_loop.cpp
+++ b/test/test_render_loop.cpp
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <string>
 #include <thread>
 
 using namespace pulp::render;
@@ -153,4 +154,132 @@ TEST_CASE("RenderLoop timer backend can restart with a new callback",
 
     REQUIRE(first.load(std::memory_order_relaxed) == 1);
     REQUIRE(second.load(std::memory_order_relaxed) == 1);
+}
+
+// ── Slice 16 — VBlank-locked safe-repaint additions ─────────────────────
+
+TEST_CASE("RenderLoop factory selects the timer backend under force-timer",
+          "[render][loop][vblank][slice-16]") {
+    // This test target is compiled with PULP_RENDER_LOOP_FORCE_TIMER=1, so
+    // the factory must select the conscious timer fallback on every host.
+    auto loop = RenderLoop::create();
+    REQUIRE(loop != nullptr);
+    REQUIRE(loop->backend() == RenderLoopBackend::timer);
+}
+
+TEST_CASE("render_loop_backend_is_vsync distinguishes real vblank sources",
+          "[render][loop][vblank][slice-16]") {
+    // The four native backends are real vblank sources; only the timer
+    // fallback is not. constexpr so the classification is compile-checked.
+    static_assert(render_loop_backend_is_vsync(RenderLoopBackend::cv_display_link));
+    static_assert(render_loop_backend_is_vsync(RenderLoopBackend::ca_display_link));
+    static_assert(render_loop_backend_is_vsync(RenderLoopBackend::choreographer));
+    static_assert(render_loop_backend_is_vsync(RenderLoopBackend::dwm_flush));
+    static_assert(!render_loop_backend_is_vsync(RenderLoopBackend::timer));
+
+    REQUIRE(render_loop_backend_is_vsync(RenderLoopBackend::dwm_flush));
+    REQUIRE_FALSE(render_loop_backend_is_vsync(RenderLoopBackend::timer));
+}
+
+TEST_CASE("render_loop_backend_name covers every backend",
+          "[render][loop][vblank][slice-16]") {
+    CHECK(std::string(render_loop_backend_name(RenderLoopBackend::cv_display_link))
+          == "CVDisplayLink");
+    CHECK(std::string(render_loop_backend_name(RenderLoopBackend::ca_display_link))
+          == "CADisplayLink");
+    CHECK(std::string(render_loop_backend_name(RenderLoopBackend::choreographer))
+          == "AChoreographer");
+    CHECK(std::string(render_loop_backend_name(RenderLoopBackend::dwm_flush))
+          == "DwmFlush");
+    CHECK(std::string(render_loop_backend_name(RenderLoopBackend::timer))
+          == "timer");
+}
+
+TEST_CASE("RenderLoop coalesces a burst of frame requests into one callback",
+          "[render][loop][vblank][slice-16]") {
+    // The canonical safe-repaint contract: any number of request_frame()
+    // calls between two vblanks fire the callback exactly once. This is the
+    // platform-agnostic coalescing the native vsync subclasses inherit via
+    // RenderLoopState — exercised here through the timer backend.
+    auto loop = RenderLoop::create();
+    REQUIRE(loop != nullptr);
+
+    std::atomic<int> frames{0};
+    loop->start([&]() { frames.fetch_add(1, std::memory_order_relaxed); });
+
+    // start() arms the initial frame.
+    REQUIRE(wait_for_count(frames, 1));
+
+    // Burst of dirty marks before the next frame interval elapses.
+    for (int i = 0; i < 32; ++i) {
+        loop->request_frame();
+    }
+
+    // The burst coalesces: exactly one more callback, not 32.
+    REQUIRE(wait_for_count(frames, 2));
+    std::this_thread::sleep_for(std::chrono::milliseconds(60));
+    REQUIRE(frames.load(std::memory_order_relaxed) == 2);
+
+    loop->stop();
+}
+
+TEST_CASE("RenderLoop stays idle with no frame request",
+          "[render][loop][vblank][slice-16]") {
+    // Demand-driven: after the initial start() frame, an untouched loop
+    // must not free-run. This is what makes vblank-locked repaint cheap
+    // for an idle UI versus the legacy periodic-poll pattern.
+    auto loop = RenderLoop::create();
+    REQUIRE(loop != nullptr);
+
+    std::atomic<int> frames{0};
+    loop->start([&]() { frames.fetch_add(1, std::memory_order_relaxed); });
+
+    REQUIRE(wait_for_count(frames, 1));      // initial frame only
+    std::this_thread::sleep_for(std::chrono::milliseconds(80));
+    REQUIRE(frames.load(std::memory_order_relaxed) == 1);
+
+    loop->stop();
+}
+
+TEST_CASE("RenderLoop request_frame from inside the callback arms the next frame",
+          "[render][loop][vblank][slice-16]") {
+    // A callback that re-arms (e.g. an animating widget) drives a steady
+    // one-callback-per-vblank cadence — the next-frame scheduling path —
+    // without ever recursing within the same frame.
+    auto loop = RenderLoop::create();
+    REQUIRE(loop != nullptr);
+
+    std::atomic<int> frames{0};
+    loop->start([&]() {
+        if (frames.fetch_add(1, std::memory_order_relaxed) < 4) {
+            loop->request_frame();  // schedule the next frame, not a recursion
+        }
+    });
+
+    REQUIRE(wait_for_count(frames, 5));
+    std::this_thread::sleep_for(std::chrono::milliseconds(60));
+    // The callback stopped re-arming after frame 5 — the loop goes idle.
+    REQUIRE(frames.load(std::memory_order_relaxed) == 5);
+
+    loop->stop();
+}
+
+TEST_CASE("RenderLoop stop suppresses callbacks for a pending request",
+          "[render][loop][vblank][slice-16]") {
+    auto loop = RenderLoop::create();
+    REQUIRE(loop != nullptr);
+
+    std::atomic<int> frames{0};
+    loop->start([&]() { frames.fetch_add(1, std::memory_order_relaxed); });
+    REQUIRE(wait_for_count(frames, 1));
+
+    // Arm a request and immediately stop — the pending dirty flag must be
+    // cleared by stop() so no further callback fires.
+    loop->request_frame();
+    loop->stop();
+    REQUIRE_FALSE(loop->is_running());
+
+    const int after_stop = frames.load(std::memory_order_relaxed);
+    std::this_thread::sleep_for(std::chrono::milliseconds(60));
+    REQUIRE(frames.load(std::memory_order_relaxed) == after_stop);
 }

--- a/test/test_window_host_repaint.cpp
+++ b/test/test_window_host_repaint.cpp
@@ -1,0 +1,157 @@
+// Slice 16 — WindowHost::mark_dirty() VBlank-locked safe-repaint routing.
+//
+// mark_dirty() is the consumer entry point for "something changed, redraw".
+// When a RenderLoop is attached it must coalesce every call between two
+// vblanks into a single request_frame(); with no loop attached it must
+// degrade to a direct repaint() so existing callers keep working.
+//
+// These tests use a headless WindowHost subclass and the explicit
+// timer-backed RenderLoop (RenderLoop::create_timer_loop()), which drives
+// its callback from a worker thread and needs no native run loop — so the
+// platform-agnostic routing is exercised deterministically without a
+// window. (RenderLoop::create() on macOS returns the CVDisplayLink backend
+// whose callback dispatches to the main run loop; that never pumps in a
+// headless Catch2 process, hence the explicit timer factory here.)
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/view/window_host.hpp>
+#include <pulp/view/view.hpp>
+#include <pulp/render/render_loop.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace pulp::view;
+
+namespace {
+
+// Minimal concrete WindowHost — counts direct repaint() calls.
+class CountingWindowHost : public WindowHost {
+public:
+    void show() override {}
+    void hide() override {}
+    bool is_visible() const override { return false; }
+    void repaint() override {
+        repaints_.fetch_add(1, std::memory_order_relaxed);
+    }
+    void set_close_callback(std::function<void()>) override {}
+    void run_event_loop() override {}
+
+    int repaint_count() const {
+        return repaints_.load(std::memory_order_relaxed);
+    }
+
+private:
+    std::atomic<int> repaints_{0};
+};
+
+bool wait_for(std::atomic<int>& v, int target) {
+    for (int i = 0; i < 200; ++i) {
+        if (v.load(std::memory_order_relaxed) >= target) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    return v.load(std::memory_order_relaxed) >= target;
+}
+
+} // namespace
+
+TEST_CASE("WindowHost::mark_dirty falls through to repaint with no RenderLoop",
+          "[view][window-host][vblank][slice-16]") {
+    CountingWindowHost host;
+    REQUIRE(host.render_loop() == nullptr);
+
+    host.mark_dirty();
+    host.mark_dirty();
+    host.mark_dirty();
+
+    // No vblank loop attached — each mark_dirty() is a direct repaint().
+    REQUIRE(host.repaint_count() == 3);
+}
+
+TEST_CASE("WindowHost::mark_dirty routes through an attached RenderLoop",
+          "[view][window-host][vblank][slice-16]") {
+    CountingWindowHost host;
+    auto loop = pulp::render::RenderLoop::create_timer_loop();
+    REQUIRE(loop != nullptr);
+
+    std::atomic<int> frames{0};
+    loop->start([&]() { frames.fetch_add(1, std::memory_order_relaxed); });
+
+    host.attach_render_loop(loop.get());
+    REQUIRE(host.render_loop() == loop.get());
+
+    // Let the initial start() frame land first — otherwise it coalesces
+    // with the burst below into a single pending request (which is itself
+    // correct coalescing, just not what this case is measuring).
+    REQUIRE(wait_for(frames, 1));
+
+    // A burst of mark_dirty() calls in one frame must coalesce to a single
+    // vsync-paced repaint — they are NOT direct repaint() calls anymore.
+    for (int i = 0; i < 16; ++i) {
+        host.mark_dirty();
+    }
+
+    REQUIRE(wait_for(frames, 2));  // the 16-call burst → exactly one frame
+    std::this_thread::sleep_for(std::chrono::milliseconds(60));
+    CHECK(frames.load(std::memory_order_relaxed) == 2);
+
+    // mark_dirty() went through the loop, not the host's direct repaint().
+    CHECK(host.repaint_count() == 0);
+
+    loop->stop();
+    host.attach_render_loop(nullptr);
+}
+
+TEST_CASE("WindowHost::mark_dirty reverts to repaint after the loop detaches",
+          "[view][window-host][vblank][slice-16]") {
+    CountingWindowHost host;
+    auto loop = pulp::render::RenderLoop::create_timer_loop();
+    REQUIRE(loop != nullptr);
+    loop->start([]() {});
+
+    host.attach_render_loop(loop.get());
+    host.mark_dirty();                 // → loop->request_frame()
+    CHECK(host.repaint_count() == 0);
+
+    host.attach_render_loop(nullptr);  // detach
+    host.mark_dirty();                 // → direct repaint() again
+    host.mark_dirty();
+    CHECK(host.repaint_count() == 2);
+
+    loop->stop();
+}
+
+TEST_CASE("View::request_repaint drives the host's vblank dirty path",
+          "[view][window-host][vblank][slice-16]") {
+    // request_repaint() is the in-tree consumer of the safe-repaint
+    // pattern: a widget marks itself dirty and the host coalesces to one
+    // repaint on the next vsync instead of the legacy poll-on-a-timer.
+    CountingWindowHost host;
+    auto loop = pulp::render::RenderLoop::create_timer_loop();
+    REQUIRE(loop != nullptr);
+
+    std::atomic<int> frames{0};
+    loop->start([&]() { frames.fetch_add(1, std::memory_order_relaxed); });
+    host.attach_render_loop(loop.get());
+
+    pulp::view::View root;
+    root.set_window_host(&host);
+
+    // Drain the initial start() frame before measuring the burst.
+    REQUIRE(wait_for(frames, 1));
+
+    for (int i = 0; i < 10; ++i) {
+        root.request_repaint();
+    }
+
+    REQUIRE(wait_for(frames, 2));  // 10 request_repaint() → one coalesced frame
+    std::this_thread::sleep_for(std::chrono::milliseconds(60));
+    CHECK(frames.load(std::memory_order_relaxed) == 2);
+    CHECK(host.repaint_count() == 0);
+
+    root.set_window_host(nullptr);
+    loop->stop();
+    host.attach_render_loop(nullptr);
+}

--- a/test/test_window_host_repaint.cpp
+++ b/test/test_window_host_repaint.cpp
@@ -104,6 +104,40 @@ TEST_CASE("WindowHost::mark_dirty routes through an attached RenderLoop",
     host.attach_render_loop(nullptr);
 }
 
+TEST_CASE("WindowHost::mark_dirty falls through to repaint when the attached loop is not running",
+          "[view][window-host][vblank][slice-16][issue-2580]") {
+    // Codex P1 #2580: a loop attached but not running has a no-op
+    // request_frame(), so routing through it would silently drop the dirty
+    // update and freeze the UI. mark_dirty() must guard on is_running().
+    CountingWindowHost host;
+    auto loop = pulp::render::RenderLoop::create_timer_loop();
+    REQUIRE(loop != nullptr);
+    REQUIRE_FALSE(loop->is_running());     // attached below, never started
+
+    host.attach_render_loop(loop.get());
+    REQUIRE(host.render_loop() == loop.get());
+
+    // Attached but NOT running → must fall through to direct repaint().
+    host.mark_dirty();
+    host.mark_dirty();
+    CHECK(host.repaint_count() == 2);
+
+    // Once started, routing switches to the loop — no new direct repaints.
+    std::atomic<int> frames{0};
+    loop->start([&]() { frames.fetch_add(1, std::memory_order_relaxed); });
+    REQUIRE(wait_for(frames, 1));          // initial start() frame
+    host.mark_dirty();
+    REQUIRE(wait_for(frames, 2));
+    CHECK(host.repaint_count() == 2);      // still 2 — went through the loop
+
+    // Stopping the loop while still attached reverts to direct repaint().
+    loop->stop();
+    host.mark_dirty();
+    CHECK(host.repaint_count() == 3);
+
+    host.attach_render_loop(nullptr);
+}
+
 TEST_CASE("WindowHost::mark_dirty reverts to repaint after the loop detaches",
           "[view][window-host][vblank][slice-16]") {
     CountingWindowHost host;


### PR DESCRIPTION
Slice 16 of the RT-Safety + Debug DX roadmap. Replaces the periodic
Binding::poll() pattern with the canonical "set a dirty flag, repaint on
the next vblank" pattern, locked to a real vsync source on every platform.

RenderLoop gains a per-platform vblank backend behind one factory seam:
  - macOS:   CVDisplayLink (already present) — verified, reused.
  - iOS:     new IOSRenderLoop (CADisplayLink) in render_loop_apple.mm.
  - Android: new AndroidRenderLoop (AChoreographer) in render_loop_android.cpp,
             with a shared_ptr/weak_ptr control block so an uncancellable
             trailing vsync callback can never UAF a destroyed loop.
  - Windows: WindowsRenderLoop using DwmFlush — a real DWM-composed vblank
             wait (not a timer), with a timed degrade when DWM is absent.
  - Linux:   conscious timer fallback; the factory seam is the single drop-in
             point for a future X11/Wayland present-sync source.

Consumer-side API: WindowHost::mark_dirty() + attach_render_loop() coalesce
N dirty marks per frame into one vsync-paced repaint when a RenderLoop is
attached, and degrade to a direct repaint() otherwise. View::request_repaint()
routes through mark_dirty(). Binding::poll() / poll_bindings() are
soft-deprecated in docs (not [[deprecated]], to keep -Werror callers green).

RenderLoop exposes backend()/RenderLoopBackend so callers can tell a real
vsync source from the timer fallback. RenderLoop::create_timer_loop() forces
the timer backend for deterministic headless tests.

Tests: 13 new Catch2 cases — burst coalescing (N marks -> 1 frame), idle
loop, request-from-callback next-frame scheduling, stop-suppression, factory
backend selection, and WindowHost::mark_dirty routing with/without a loop.
All 20 render_loop|repaint|vblank tests pass; pulp-test-view and
pulp-test-state confirm no ripple regression.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>