### PR TITLE
fix(audio): harden file and buffering edge cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.183.6
+    VERSION 0.184.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/audio/include/pulp/audio/buffering_reader.hpp
+++ b/core/audio/include/pulp/audio/buffering_reader.hpp
@@ -11,6 +11,7 @@
 #include <functional>
 #include <cstring>
 #include <algorithm>
+#include <limits>
 
 namespace pulp::audio {
 
@@ -56,6 +57,19 @@ public:
     void start(int num_channels, int buffer_frames = 44100) {
         stop();
 
+        if (num_channels <= 0 || buffer_frames <= 0 ||
+            num_channels > std::numeric_limits<int>::max() / buffer_frames ||
+            num_channels > std::numeric_limits<int>::max() / kChunkFrames) {
+            num_channels_ = 0;
+            buffer_size_ = 0;
+            write_pos_ = 0;
+            read_pos_ = 0;
+            available_.store(0);
+            finished_.store(false);
+            running_.store(false);
+            return;
+        }
+
         num_channels_ = num_channels;
         buffer_size_ = buffer_frames * num_channels;
         buffer_.resize(static_cast<size_t>(buffer_size_), 0.0f);
@@ -84,6 +98,8 @@ public:
     int read(float* dest, int num_frames, int num_channels) {
         if (dest == nullptr || num_frames <= 0) return 0;
         if (num_channels != num_channels_ || buffer_.empty()) return 0;
+        if (num_channels <= 0 ||
+            num_frames > std::numeric_limits<int>::max() / num_channels) return 0;
 
         int samples_requested = num_frames * num_channels;
         int avail = available_.load(std::memory_order_acquire);
@@ -145,10 +161,10 @@ private:
     std::thread thread_;
     std::mutex mutex_;
     std::condition_variable cv_;
+    static constexpr int kChunkFrames = 1024;
 
     void background_loop() {
-        constexpr int chunk_frames = 1024;
-        std::vector<float> temp(static_cast<size_t>(chunk_frames * num_channels_));
+        std::vector<float> temp(static_cast<size_t>(kChunkFrames * num_channels_));
 
         while (running_.load()) {
             // Wait until there's space in the buffer
@@ -156,14 +172,14 @@ private:
                 std::unique_lock<std::mutex> lock(mutex_);
                 cv_.wait_for(lock, std::chrono::milliseconds(10), [this] {
                     return !running_.load() ||
-                           available_.load() < buffer_size_ - chunk_frames * num_channels_;
+                           available_.load() < buffer_size_;
                 });
             }
 
             if (!running_.load()) break;
 
             int space = buffer_size_ - available_.load(std::memory_order_acquire);
-            int frames_to_read = std::min(chunk_frames, space / std::max(1, num_channels_));
+            int frames_to_read = std::min(kChunkFrames, space / std::max(1, num_channels_));
 
             if (frames_to_read <= 0) continue;
 
@@ -174,8 +190,11 @@ private:
 
             if (frames_got <= 0) {
                 finished_.store(true);
+                running_.store(false);
+                cv_.notify_all();
                 return;
             }
+            if (frames_got > frames_to_read) frames_got = frames_to_read;
 
             int samples = frames_got * num_channels_;
             int first_chunk = std::min(samples, buffer_size_ - write_pos_);

--- a/core/audio/src/aiff_reader.cpp
+++ b/core/audio/src/aiff_reader.cpp
@@ -7,6 +7,8 @@
 #include <cstring>
 #include <cmath>
 #include <algorithm>
+#include <cstddef>
+#include <limits>
 
 namespace pulp::audio {
 
@@ -62,6 +64,32 @@ static void double_to_extended(double val, uint8_t* p) {
     p[1] = static_cast<uint8_t>(exponent & 0xFF);
     for (int i = 0; i < 8; ++i)
         p[2 + i] = static_cast<uint8_t>((m >> (56 - i * 8)) & 0xFF);
+}
+
+static bool has_consistent_channel_lengths(const AudioFileData& data) {
+    if (data.empty()) return false;
+
+    const auto expected_frames = data.num_frames();
+    return std::all_of(data.channels.begin(), data.channels.end(),
+                       [expected_frames](const auto& channel) {
+                           return channel.size() == expected_frames;
+                       });
+}
+
+static bool can_write_aiff_pcm16(const AudioFileData& data) {
+    if (data.sample_rate == 0 || !has_consistent_channel_lengths(data))
+        return false;
+
+    const uint32_t channels = data.num_channels();
+    const uint64_t frames = data.num_frames();
+    if (channels == 0 || channels > std::numeric_limits<uint16_t>::max() ||
+        frames > std::numeric_limits<uint32_t>::max())
+        return false;
+
+    constexpr uint32_t bytes_per_sample = 2;
+    const uint64_t bytes_per_frame = static_cast<uint64_t>(channels) * bytes_per_sample;
+    return frames <=
+        (static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) - 8u) / bytes_per_frame;
 }
 
 // ── AIFF Reader ─────────────────────────────────────────────────────────
@@ -162,11 +190,16 @@ public:
                 uint8_t ssnd_header[8];
                 file.read(reinterpret_cast<char*>(ssnd_header), 8);
                 if (file.gcount() != 8) return std::nullopt;
+                uint32_t offset = read_be32(ssnd_header);
                 size_t data_size = chunk_size - 8;
                 ssnd_data.resize(data_size);
                 file.read(reinterpret_cast<char*>(ssnd_data.data()), static_cast<std::streamsize>(data_size));
                 if (file.gcount() != static_cast<std::streamsize>(data_size))
                     return std::nullopt;
+                if (offset > ssnd_data.size())
+                    return std::nullopt;
+                if (offset > 0)
+                    ssnd_data.erase(ssnd_data.begin(), ssnd_data.begin() + static_cast<std::ptrdiff_t>(offset));
                 if (chunk_size & 1) file.seekg(1, std::ios::cur);
             } else {
                 file.seekg(chunk_size + (chunk_size & 1), std::ios::cur);
@@ -233,7 +266,7 @@ public:
 class AiffWriter : public FormatWriter {
 public:
     bool write(const std::string& path, const AudioFileData& data) override {
-        if (data.empty()) return false;
+        if (!can_write_aiff_pcm16(data)) return false;
 
         std::ofstream file(path, std::ios::binary);
         if (!file) return false;

--- a/core/audio/src/audio_file.cpp
+++ b/core/audio/src/audio_file.cpp
@@ -11,6 +11,10 @@ namespace pulp::audio {
 
 // ── Sample format conversion ─────────────────────────────────────────────────
 
+static float finite_or_zero(float value) {
+    return std::isfinite(value) ? value : 0.0f;
+}
+
 void int16_to_float(const int16_t* src, float* dst, size_t count) {
     constexpr float scale = 1.0f / 32768.0f;
     for (size_t i = 0; i < count; ++i)
@@ -36,14 +40,14 @@ void int32_to_float(const int32_t* src, float* dst, size_t count) {
 
 void float_to_int16(const float* src, int16_t* dst, size_t count) {
     for (size_t i = 0; i < count; ++i) {
-        float clamped = std::clamp(src[i], -1.0f, 1.0f);
+        float clamped = std::clamp(finite_or_zero(src[i]), -1.0f, 1.0f);
         dst[i] = static_cast<int16_t>(clamped * 32767.0f);
     }
 }
 
 void float_to_int32(const float* src, int32_t* dst, size_t count) {
     for (size_t i = 0; i < count; ++i) {
-        float clamped = std::clamp(src[i], -1.0f, 1.0f);
+        float clamped = std::clamp(finite_or_zero(src[i]), -1.0f, 1.0f);
         if (clamped >= 1.0f) {
             dst[i] = std::numeric_limits<int32_t>::max();
         } else if (clamped <= -1.0f) {
@@ -79,6 +83,9 @@ std::optional<AudioFileInfo> read_audio_file_info(const std::string& path) {
         if (!reader) return std::nullopt;
 
         auto props = reader->getProperties();
+        if (!(props.sampleRate > 0) || props.numChannels == 0)
+            return std::nullopt;
+
         AudioFileInfo info;
         info.sample_rate = static_cast<uint32_t>(props.sampleRate);
         info.num_channels = props.numChannels;
@@ -100,7 +107,9 @@ std::optional<AudioFileData> read_audio_file(const std::string& path) {
         if (!reader) return std::nullopt;
 
         auto props = reader->getProperties();
-        if (props.numFrames == 0 || props.numChannels == 0) return std::nullopt;
+        if (!(props.sampleRate > 0) || props.numFrames == 0 || props.numChannels == 0 ||
+            props.numFrames > std::numeric_limits<uint32_t>::max())
+            return std::nullopt;
 
         uint32_t frames = static_cast<uint32_t>(props.numFrames);
 
@@ -126,7 +135,10 @@ std::optional<AudioFileData> read_audio_file(const std::string& path) {
 }
 
 bool write_wav_file(const std::string& path, const AudioFileData& data) {
+    if (data.sample_rate == 0) return false;
     if (!has_consistent_channel_lengths(data)) return false;
+    if (data.num_channels() > std::numeric_limits<uint16_t>::max()) return false;
+    if (data.num_frames() > std::numeric_limits<uint32_t>::max()) return false;
 
     try {
         choc::audio::WAVAudioFileFormat<true> wav;

--- a/core/audio/src/audio_focus.cpp
+++ b/core/audio/src/audio_focus.cpp
@@ -58,7 +58,6 @@ void AudioFocusRegistry::publish(AudioFocusState state) {
 void AudioFocusRegistry::reset_for_test() {
     std::lock_guard<std::mutex> lock(mtx_);
     cbs_.clear();
-    next_id_ = 1;
     current_.store(static_cast<std::uint8_t>(AudioFocusState::gained),
                    std::memory_order_release);
 }

--- a/core/audio/src/format_registry.cpp
+++ b/core/audio/src/format_registry.cpp
@@ -245,10 +245,12 @@ FormatRegistry::FormatRegistry() {
 }
 
 void FormatRegistry::register_reader(std::unique_ptr<FormatReader> reader) {
+    if (!reader) return;
     readers_.push_back(std::move(reader));
 }
 
 void FormatRegistry::register_writer(std::unique_ptr<FormatWriter> writer) {
+    if (!writer) return;
     writers_.push_back(std::move(writer));
 }
 

--- a/core/audio/src/mmap_reader.cpp
+++ b/core/audio/src/mmap_reader.cpp
@@ -30,6 +30,8 @@ void MemoryMappedAudioReader::close() {
 bool MemoryMappedAudioReader::read_frames(float** dest_channels, uint32_t num_channels,
                                            uint64_t start_frame, uint64_t num_frames) {
     if (!is_open()) return false;
+    if (num_channels == 0 || num_frames == 0) return true;
+    if (dest_channels == nullptr) return false;
 
     // For now, read the full file and extract the range
     // A more optimized version would decode only the requested range
@@ -37,6 +39,9 @@ bool MemoryMappedAudioReader::read_frames(float** dest_channels, uint32_t num_ch
     if (!data) return false;
 
     uint32_t ch_count = std::min(num_channels, data->num_channels());
+    for (uint32_t c = 0; c < ch_count; ++c)
+        if (dest_channels[c] == nullptr) return false;
+
     uint64_t avail = data->num_frames();
     uint64_t start = std::min(start_frame, avail);
     uint64_t count = std::min(num_frames, avail - start);

--- a/core/audio/src/streaming_writer.cpp
+++ b/core/audio/src/streaming_writer.cpp
@@ -1,6 +1,7 @@
 #include <pulp/audio/streaming_writer.hpp>
 #include <cstring>
 #include <algorithm>
+#include <limits>
 
 namespace pulp::audio {
 
@@ -29,6 +30,14 @@ bool StreamingWriter::open(std::string_view path, uint32_t sample_rate,
         return false;
     if (num_channels == 0 || sample_rate == 0)
         return false;
+    const uint32_t bytes_per_sample = bits_per_sample / 8;
+    if (num_channels > std::numeric_limits<uint16_t>::max() ||
+        num_channels > std::numeric_limits<uint16_t>::max() / bytes_per_sample)
+        return false;
+
+    uint16_t block_align = static_cast<uint16_t>(bytes_per_sample * num_channels);
+    if (sample_rate > std::numeric_limits<uint32_t>::max() / block_align)
+        return false;
 
     sample_rate_ = sample_rate;
     num_channels_ = num_channels;
@@ -40,7 +49,6 @@ bool StreamingWriter::open(std::string_view path, uint32_t sample_rate,
     if (!file_) return false;
 
     // Write WAV header with placeholder sizes (updated in close())
-    uint16_t block_align = static_cast<uint16_t>((bits_per_sample / 8) * num_channels);
     uint32_t byte_rate = sample_rate * block_align;
 
     file_.write("RIFF", 4);
@@ -67,6 +75,8 @@ bool StreamingWriter::open(std::string_view path, uint32_t sample_rate,
 
 int StreamingWriter::write_frames(const float* interleaved_data, int num_frames) {
     if (!file_.is_open() || interleaved_data == nullptr || num_frames <= 0) return 0;
+    if (num_channels_ > static_cast<uint32_t>(std::numeric_limits<int>::max() / num_frames))
+        return 0;
 
     int total_samples = num_frames * static_cast<int>(num_channels_);
 
@@ -97,6 +107,7 @@ int StreamingWriter::write_frames(const float* interleaved_data, int num_frames)
 int StreamingWriter::write_frames(const float* const* channels, int num_channels, int num_frames) {
     if (!file_.is_open() || channels == nullptr
         || num_channels != static_cast<int>(num_channels_) || num_frames <= 0) return 0;
+    if (num_channels > std::numeric_limits<int>::max() / num_frames) return 0;
     for (int c = 0; c < num_channels; ++c)
         if (channels[c] == nullptr) return 0;
 

--- a/core/platform/platform/win/child_process_win.cpp
+++ b/core/platform/platform/win/child_process_win.cpp
@@ -67,6 +67,37 @@ size_t drain_pipe(HANDLE fd, std::string& buffer, size_t max_bytes,
     return total;
 }
 
+std::string quote_windows_arg(const std::string& arg) {
+    if (arg.empty()) return "\"\"";
+
+    const bool needs_quotes =
+        arg.find_first_of(" \t\n\v\"") != std::string::npos;
+    if (!needs_quotes) return arg;
+
+    std::string quoted;
+    quoted.reserve(arg.size() + 2);
+    quoted.push_back('"');
+
+    size_t backslashes = 0;
+    for (char c : arg) {
+        if (c == '\\') {
+            ++backslashes;
+        } else if (c == '"') {
+            quoted.append(backslashes * 2 + 1, '\\');
+            quoted.push_back('"');
+            backslashes = 0;
+        } else {
+            quoted.append(backslashes, '\\');
+            backslashes = 0;
+            quoted.push_back(c);
+        }
+    }
+
+    quoted.append(backslashes * 2, '\\');
+    quoted.push_back('"');
+    return quoted;
+}
+
 }  // namespace
 
 struct ChildProcess::Impl {
@@ -107,18 +138,14 @@ bool ChildProcess::start(const std::string& command,
     bool is_cmd_c = (command == "cmd" || command == "cmd.exe") &&
                     !args.empty() && (args[0] == "/c" || args[0] == "/C");
 
-    std::string cmdline = "\"" + command + "\"";
+    std::string cmdline = quote_windows_arg(command);
     for (size_t i = 0; i < args.size(); ++i) {
         auto& a = args[i];
-        if (a.empty()) {
-            cmdline += " \"\"";  // preserve empty args
-        } else if (is_cmd_c && i == args.size() - 1) {
+        if (is_cmd_c && i == args.size() - 1) {
             // Last arg to cmd /c is the shell command — pass through raw
             cmdline += " " + a;
-        } else if (a.find(' ') != std::string::npos && a.find('"') == std::string::npos) {
-            cmdline += " \"" + a + "\"";
         } else {
-            cmdline += " " + a;
+            cmdline += " " + quote_windows_arg(a);
         }
     }
 

--- a/test/test_audio_file.cpp
+++ b/test/test_audio_file.cpp
@@ -225,12 +225,19 @@ static std::vector<unsigned char> make_comm_chunk(uint16_t channels,
     return comm;
 }
 
-static std::vector<unsigned char> make_ssnd_chunk(const std::vector<unsigned char>& sample_bytes) {
+static std::vector<unsigned char> make_ssnd_chunk_with_offset(
+    const std::vector<unsigned char>& offset_bytes,
+    const std::vector<unsigned char>& sample_bytes) {
     std::vector<unsigned char> ssnd;
+    append_be32(ssnd, static_cast<uint32_t>(offset_bytes.size()));
     append_be32(ssnd, 0);
-    append_be32(ssnd, 0);
+    ssnd.insert(ssnd.end(), offset_bytes.begin(), offset_bytes.end());
     ssnd.insert(ssnd.end(), sample_bytes.begin(), sample_bytes.end());
     return ssnd;
+}
+
+static std::vector<unsigned char> make_ssnd_chunk(const std::vector<unsigned char>& sample_bytes) {
+    return make_ssnd_chunk_with_offset({}, sample_bytes);
 }
 
 static void write_aiff_fixture(const std::filesystem::path& path,
@@ -407,6 +414,30 @@ TEST_CASE("float to int32 scales fractional values symmetrically",
     REQUIRE(std::abs(dst[3] - static_cast<int32_t>(0.75 * 2147483647.0)) <= 1);
 }
 
+TEST_CASE("float to integer conversion maps non-finite samples to silence",
+          "[audio][convert][coverage][phase3]") {
+    const float src[] = {
+        std::numeric_limits<float>::quiet_NaN(),
+        std::numeric_limits<float>::infinity(),
+        -std::numeric_limits<float>::infinity(),
+        0.25f,
+    };
+    int16_t dst16[4] = {};
+    int32_t dst32[4] = {};
+
+    float_to_int16(src, dst16, 4);
+    float_to_int32(src, dst32, 4);
+
+    REQUIRE(dst16[0] == 0);
+    REQUIRE(dst16[1] == 0);
+    REQUIRE(dst16[2] == 0);
+    REQUIRE(dst16[3] == 8191);
+    REQUIRE(dst32[0] == 0);
+    REQUIRE(dst32[1] == 0);
+    REQUIRE(dst32[2] == 0);
+    REQUIRE(std::abs(dst32[3] - static_cast<int32_t>(0.25 * 2147483647.0)) <= 1);
+}
+
 // ── WAV file I/O ─────────────────────────────────────────────────────────────
 
 TEST_CASE("Write and read WAV file", "[audio][file]") {
@@ -493,6 +524,38 @@ TEST_CASE("WAV reader reports zero-frame metadata but rejects loading data",
     std::filesystem::remove(path);
 }
 
+TEST_CASE("WAV reader rejects zero sample-rate metadata",
+          "[audio][file][coverage][phase3]") {
+    auto path = unique_temp_audio_path("_read_zero_rate.wav");
+    std::filesystem::remove(path);
+
+    const std::vector<uint8_t> wav = {
+        'R', 'I', 'F', 'F',
+        38, 0, 0, 0,
+        'W', 'A', 'V', 'E',
+        'f', 'm', 't', ' ',
+        16, 0, 0, 0,
+        1, 0,
+        1, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        2, 0,
+        16, 0,
+        'd', 'a', 't', 'a',
+        2, 0, 0, 0,
+        0, 0,
+    };
+    {
+        std::ofstream f(path, std::ios::binary);
+        f.write(reinterpret_cast<const char*>(wav.data()),
+                static_cast<std::streamsize>(wav.size()));
+    }
+
+    REQUIRE_FALSE(read_audio_file_info(path.string()).has_value());
+    REQUIRE_FALSE(read_audio_file(path.string()).has_value());
+    std::filesystem::remove(path);
+}
+
 TEST_CASE("AudioFileData shape helpers and WAV writer reject first-channel empties",
           "[audio][file][issue-640]") {
     AudioFileData data;
@@ -517,6 +580,39 @@ TEST_CASE("AudioFileData shape helpers and WAV writer reject first-channel empti
     REQUIRE_FALSE(data.empty());
     REQUIRE_FALSE(write_wav_file(path.string(), data));
     REQUIRE_FALSE(std::filesystem::exists(path));
+}
+
+TEST_CASE("WAV writer rejects zero sample-rate data without creating a file",
+          "[audio][file][coverage][phase3]") {
+    AudioFileData data;
+    data.sample_rate = 0;
+    data.channels = {{0.0f, 0.5f}};
+
+    auto path = unique_temp_audio_path("_zero_rate.wav");
+    std::filesystem::remove(path);
+
+    REQUIRE_FALSE(write_wav_file(path.string(), data));
+    REQUIRE_FALSE(std::filesystem::exists(path));
+}
+
+TEST_CASE("WAV and AIFF writers reject channel counts that cannot fit file headers",
+          "[audio][file][coverage][phase3]") {
+    AudioFileData data;
+    data.sample_rate = 44100;
+    data.channels.resize(static_cast<size_t>(std::numeric_limits<uint16_t>::max()) + 1u);
+    for (auto& channel : data.channels) {
+        channel.push_back(0.0f);
+    }
+
+    auto wav_path = unique_temp_audio_path("_too_many_channels.wav");
+    auto aiff_path = unique_temp_audio_path("_too_many_channels.aiff");
+    std::filesystem::remove(wav_path);
+    std::filesystem::remove(aiff_path);
+
+    REQUIRE_FALSE(write_wav_file(wav_path.string(), data));
+    REQUIRE_FALSE(FormatRegistry::instance().write(aiff_path.string(), data));
+    REQUIRE_FALSE(std::filesystem::exists(wav_path));
+    REQUIRE_FALSE(std::filesystem::exists(aiff_path));
 }
 
 TEST_CASE("WAV helpers write deinterleaved channel data and reject malformed input",
@@ -702,6 +798,36 @@ TEST_CASE("MemoryMappedAudioReader leaves destinations untouched past EOF",
     std::filesystem::remove(path);
 }
 
+TEST_CASE("MemoryMappedAudioReader rejects invalid destinations before decoding",
+          "[audio][file][mmap][coverage][phase3]") {
+    auto path = unique_temp_audio_path("_mmap_destinations.wav");
+    std::filesystem::remove(path);
+
+    AudioFileData data;
+    data.sample_rate = 44100;
+    data.channels = {
+        {0.0f, 0.25f, 0.5f},
+        {1.0f, 0.75f, 0.5f},
+    };
+    REQUIRE(write_wav_file(path.string(), data));
+
+    MemoryMappedAudioReader reader;
+    REQUIRE(reader.open(path.string()));
+
+    float left[2] = {-1.0f, -1.0f};
+    float* missing_channels[] = {left, nullptr};
+    REQUIRE_FALSE(reader.read_frames(nullptr, 2, 0, 1));
+    REQUIRE_FALSE(reader.read_frames(missing_channels, 2, 0, 1));
+    REQUIRE(left[0] == -1.0f);
+    REQUIRE(left[1] == -1.0f);
+
+    REQUIRE(reader.read_frames(nullptr, 0, 0, 1));
+    REQUIRE(reader.read_frames(missing_channels, 2, 0, 0));
+
+    reader.close();
+    std::filesystem::remove(path);
+}
+
 TEST_CASE("offline processing handles guards, block tails, and file dispatch",
           "[audio][file][offline][issue-640]") {
     AudioFileData input;
@@ -798,18 +924,25 @@ TEST_CASE("StreamingWriter rejects invalid opens and closed writes",
     REQUIRE_FALSE(writer.open(path.string(), 44100, 2, 12));
     REQUIRE_FALSE(writer.open(path.string(), 0, 2, 16));
     REQUIRE_FALSE(writer.open(path.string(), 44100, 0, 16));
+    REQUIRE_FALSE(writer.open(
+        path.string(), 44100, static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1, 16));
+    REQUIRE_FALSE(writer.open(
+        path.string(), std::numeric_limits<uint32_t>::max(), std::numeric_limits<uint16_t>::max(), 32));
     REQUIRE_FALSE(writer.is_open());
 
     REQUIRE(writer.open(path.string(), 44100, 2, 16));
     REQUIRE(writer.write_frames(static_cast<const float*>(nullptr), 1) == 0);
     REQUIRE(writer.write_frames(&sample, 0) == 0);
     REQUIRE(writer.write_frames(&sample, -1) == 0);
+    REQUIRE(writer.write_frames(&sample, std::numeric_limits<int>::max()) == 0);
 
     const float* invalid_channels[] = {&sample, nullptr};
     REQUIRE(writer.write_frames(static_cast<const float* const*>(nullptr), 2, 1) == 0);
     REQUIRE(writer.write_frames(invalid_channels, 2, 1) == 0);
     REQUIRE(writer.write_frames(invalid_channels, 2, 0) == 0);
     REQUIRE(writer.write_frames(invalid_channels, 2, -1) == 0);
+    const float* valid_channels[] = {&sample, &sample};
+    REQUIRE(writer.write_frames(valid_channels, 2, std::numeric_limits<int>::max()) == 0);
     REQUIRE(writer.frames_written() == 0);
 
     writer.close();
@@ -960,6 +1093,22 @@ TEST_CASE("FormatRegistry exposes built-in audio codecs", "[audio][file][registr
     REQUIRE(contains_extension(write_extensions, ".wave"));
     REQUIRE(contains_extension(write_extensions, ".aiff"));
     REQUIRE(contains_extension(write_extensions, ".aif"));
+}
+
+TEST_CASE("FormatRegistry ignores null custom handlers",
+          "[audio][file][registry][coverage][phase3]") {
+    auto& registry = FormatRegistry::instance();
+
+    const auto read_before = registry.supported_read_extensions();
+    const auto write_before = registry.supported_write_extensions();
+
+    registry.register_reader(nullptr);
+    registry.register_writer(nullptr);
+
+    REQUIRE(registry.supported_read_extensions() == read_before);
+    REQUIRE(registry.supported_write_extensions() == write_before);
+    REQUIRE(registry.find_reader(".wav") != nullptr);
+    REQUIRE(registry.find_writer(".wav") != nullptr);
 }
 
 TEST_CASE("FormatRegistry rejects missing and extension-only paths",
@@ -1188,6 +1337,35 @@ TEST_CASE("FormatRegistry writes and reads AIFF files", "[audio][file][registry]
     std::filesystem::remove(tmp_path);
 }
 
+TEST_CASE("AIFF writer rejects invalid source data without creating files",
+          "[audio][file][registry][aiff][coverage][phase3]") {
+    auto& registry = FormatRegistry::instance();
+
+    SECTION("zero sample rate") {
+        auto tmp_path = unique_temp_audio_path("_aiff_writer_zero_rate.aiff");
+        std::filesystem::remove(tmp_path);
+
+        AudioFileData data;
+        data.sample_rate = 0;
+        data.channels = {{0.0f, 0.5f}};
+
+        REQUIRE_FALSE(registry.write(tmp_path.string(), data));
+        REQUIRE_FALSE(std::filesystem::exists(tmp_path));
+    }
+
+    SECTION("ragged channel lengths") {
+        auto tmp_path = unique_temp_audio_path("_aiff_writer_ragged.aiff");
+        std::filesystem::remove(tmp_path);
+
+        AudioFileData data;
+        data.sample_rate = 44100;
+        data.channels = {{0.0f, 0.5f}, {1.0f}};
+
+        REQUIRE_FALSE(registry.write(tmp_path.string(), data));
+        REQUIRE_FALSE(std::filesystem::exists(tmp_path));
+    }
+}
+
 TEST_CASE("AIFF reader rejects malformed files", "[audio][file][registry][aiff]") {
     auto tmp_path = std::filesystem::temp_directory_path() / "pulp_test_audio_malformed.aiff";
     std::filesystem::remove(tmp_path);
@@ -1302,6 +1480,47 @@ TEST_CASE("AIFF reader skips malformed SSND chunks before valid data", "[audio][
     REQUIRE_THAT(data->channels[0][0], WithinAbs(0.5f, 0.001f));
 
     std::filesystem::remove(tmp_path);
+}
+
+TEST_CASE("AIFF reader honors SSND offsets and rejects invalid offsets",
+          "[audio][file][registry][aiff][coverage][phase3]") {
+    auto& registry = FormatRegistry::instance();
+
+    SECTION("valid offset skips pad bytes before PCM") {
+        auto tmp_path = unique_temp_audio_path("_aiff_ssnd_offset.aiff");
+
+        write_aiff_fixture(tmp_path,
+                           "AIFF",
+                           {
+                               {"COMM", make_comm_chunk(1, 1, 16)},
+                               {"SSND", make_ssnd_chunk_with_offset({0x7F, 0x7F}, {0x40, 0x00})},
+                           });
+
+        auto data = registry.read(tmp_path.string());
+        REQUIRE(data.has_value());
+        REQUIRE(data->num_channels() == 1);
+        REQUIRE(data->num_frames() == 1);
+        REQUIRE_THAT(data->channels[0][0], WithinAbs(0.5f, 0.001f));
+        std::filesystem::remove(tmp_path);
+    }
+
+    SECTION("offset beyond payload is malformed") {
+        auto tmp_path = unique_temp_audio_path("_aiff_bad_ssnd_offset.aiff");
+        std::vector<unsigned char> ssnd;
+        append_be32(ssnd, 4);
+        append_be32(ssnd, 0);
+        ssnd.insert(ssnd.end(), {0x40, 0x00});
+
+        write_aiff_fixture(tmp_path,
+                           "AIFF",
+                           {
+                               {"COMM", make_comm_chunk(1, 1, 16)},
+                               {"SSND", ssnd},
+                           });
+
+        REQUIRE_FALSE(registry.read(tmp_path.string()).has_value());
+        std::filesystem::remove(tmp_path);
+    }
 }
 
 TEST_CASE("AIFF reader rejects truncated PCM payloads", "[audio][file][registry][aiff]") {

--- a/test/test_audio_focus.cpp
+++ b/test/test_audio_focus.cpp
@@ -285,6 +285,28 @@ TEST_CASE("AudioFocusRegistry: reset_for_test clears subscribers and state",
     SUCCEED("no crash on stale token reset");
 }
 
+TEST_CASE("AudioFocusRegistry: stale tokens cannot unsubscribe post-reset subscribers",
+          "[audio][focus][coverage][phase3]") {
+    AudioFocusRegistry::instance().reset_for_test();
+
+    int stale_count = 0;
+    auto stale = AudioFocusRegistry::instance().subscribe(
+        [&](AudioFocusState) { ++stale_count; });
+
+    AudioFocusRegistry::instance().reset_for_test();
+
+    int fresh_count = 0;
+    auto fresh = AudioFocusRegistry::instance().subscribe(
+        [&](AudioFocusState) { ++fresh_count; });
+
+    stale.reset();
+    AudioFocusRegistry::instance().publish(AudioFocusState::duck);
+
+    REQUIRE(stale_count == 0);
+    REQUIRE(fresh_count == 1);
+    REQUIRE(fresh.id() != 0);
+}
+
 TEST_CASE("AudioFocusRegistry: publish with no subscribers still updates state",
           "[audio][focus][issue-640]") {
     AudioFocusRegistry::instance().reset_for_test();

--- a/test/test_buffering_reader.cpp
+++ b/test/test_buffering_reader.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <thread>
 #include <chrono>
+#include <limits>
 #include <vector>
 
 using namespace pulp::audio;
@@ -265,6 +266,41 @@ TEST_CASE("BufferingReader signals finished when source ends", "[audio][bufferin
     }
 
     REQUIRE(reader.is_finished());
+    REQUIRE_FALSE(reader.is_running());
+    reader.stop();
+}
+
+TEST_CASE("BufferingReader preserves buffered tail after worker reaches EOF",
+          "[audio][buffering][coverage][phase3]") {
+    BufferingReader reader;
+
+    std::atomic<int> emitted{0};
+    reader.set_read_callback([&](float* dest, int frames, int channels) {
+        const int start = emitted.load();
+        const int frames_to_emit = std::min(frames, 3 - start);
+        for (int frame = 0; frame < frames_to_emit; ++frame) {
+            for (int ch = 0; ch < channels; ++ch) {
+                dest[frame * channels + ch] = static_cast<float>(start + frame + 1);
+            }
+        }
+        emitted.fetch_add(frames_to_emit);
+        return frames_to_emit;
+    });
+
+    reader.start(1, 8);
+    REQUIRE(wait_until_finished_with_frames(reader, 3));
+    REQUIRE_FALSE(reader.is_running());
+    REQUIRE(reader.frames_available() == 3);
+
+    std::array<float, 5> buf;
+    buf.fill(-1.0f);
+    REQUIRE(reader.read(buf.data(), 5, 1) == 3);
+    REQUIRE(buf[0] == 1.0f);
+    REQUIRE(buf[1] == 2.0f);
+    REQUIRE(buf[2] == 3.0f);
+    REQUIRE(buf[3] == 0.0f);
+    REQUIRE(buf[4] == 0.0f);
+
     reader.stop();
 }
 
@@ -381,5 +417,101 @@ TEST_CASE("BufferingReader invalid read destinations are no-ops",
     });
     reader.start(1, 1024);
     REQUIRE(reader.read(nullptr, 16, 1) == 0);
+    reader.stop();
+}
+
+TEST_CASE("BufferingReader invalid start parameters do not launch a worker",
+          "[audio][buffering][coverage][phase3]") {
+    BufferingReader reader;
+
+    reader.start(0, 1024);
+    REQUIRE_FALSE(reader.is_running());
+    REQUIRE(reader.frames_available() == 0);
+
+    reader.start(2, 0);
+    REQUIRE_FALSE(reader.is_running());
+    REQUIRE(reader.frames_available() == 0);
+
+    reader.start(-1, 1024);
+    REQUIRE_FALSE(reader.is_running());
+
+    reader.start(2, -1);
+    REQUIRE_FALSE(reader.is_running());
+
+    reader.start(std::numeric_limits<int>::max(), 2);
+    REQUIRE_FALSE(reader.is_running());
+}
+
+TEST_CASE("BufferingReader read rejects overflowing frame-channel requests",
+          "[audio][buffering][coverage][phase3]") {
+    BufferingReader reader;
+    reader.set_read_callback([](float* dest, int frames, int channels) {
+        for (int i = 0; i < frames * channels; ++i) dest[i] = 1.0f;
+        return frames;
+    });
+    reader.start(2, 1024);
+
+    float sentinel[2] = {-1.0f, -2.0f};
+    REQUIRE(reader.read(sentinel, std::numeric_limits<int>::max(), 2) == 0);
+    REQUIRE(sentinel[0] == -1.0f);
+    REQUIRE(sentinel[1] == -2.0f);
+
+    reader.stop();
+}
+
+TEST_CASE("BufferingReader clamps over-reported callback frame counts",
+          "[audio][buffering][coverage][phase3]") {
+    BufferingReader reader;
+    std::atomic<int> next{0};
+    reader.set_read_callback([&](float* dest, int frames, int channels) {
+        const int start = next.fetch_add(frames);
+        for (int frame = 0; frame < frames; ++frame) {
+            for (int ch = 0; ch < channels; ++ch) {
+                dest[frame * channels + ch] = static_cast<float>(start + frame);
+            }
+        }
+        return frames + 64;
+    });
+
+    reader.start(1, 1024);
+    REQUIRE(wait_for_frames(reader, 1024));
+    REQUIRE(reader.frames_available() == 1024);
+
+    std::array<float, 4> buf{};
+    REQUIRE(reader.read(buf.data(), 4, 1) == 4);
+    REQUIRE(buf[0] == 0.0f);
+    REQUIRE(buf[1] == 1.0f);
+    REQUIRE(buf[2] == 2.0f);
+    REQUIRE(buf[3] == 3.0f);
+
+    reader.stop();
+}
+
+TEST_CASE("BufferingReader fills ring buffers smaller than the worker chunk",
+          "[audio][buffering][coverage][phase3]") {
+    BufferingReader reader;
+    std::atomic<int> emitted{0};
+    reader.set_read_callback([&](float* dest, int frames, int channels) {
+        const int start = emitted.load();
+        const int frames_to_emit = std::min(frames, 4 - start);
+        for (int frame = 0; frame < frames_to_emit; ++frame) {
+            for (int ch = 0; ch < channels; ++ch) {
+                dest[frame * channels + ch] = static_cast<float>(start + frame);
+            }
+        }
+        emitted.fetch_add(frames_to_emit);
+        return frames_to_emit;
+    });
+
+    reader.start(1, 4);
+    REQUIRE(wait_for_frames(reader, 4));
+
+    std::array<float, 4> buf{};
+    REQUIRE(reader.read(buf.data(), 4, 1) == 4);
+    REQUIRE(buf[0] == 0.0f);
+    REQUIRE(buf[1] == 1.0f);
+    REQUIRE(buf[2] == 2.0f);
+    REQUIRE(buf[3] == 3.0f);
+
     reader.stop();
 }

--- a/test/test_child_process.cpp
+++ b/test/test_child_process.cpp
@@ -133,6 +133,31 @@ TEST_CASE("run with empty command fails gracefully", "[child_process]") {
     REQUIRE(r.exit_code != 0);
 }
 
+#ifdef _WIN32
+TEST_CASE("exec preserves embedded quotes and trailing backslashes on Windows",
+          "[child_process][win][issue-493]") {
+    auto powershell = find_on_path("powershell.exe");
+    if (!powershell) {
+        SUCCEED("skipped: powershell.exe not found");
+        return;
+    }
+
+    const std::string expected = "say \"hi\" C:\\tmp\\";
+    ProcessOptions opts;
+    opts.timeout_ms = 5000;
+    auto r = ChildProcess::run(
+        powershell->string(),
+        {"-NoProfile",
+         "-Command",
+         "param([string]$x) [Console]::Out.Write($x)",
+         expected},
+        opts);
+
+    REQUIRE(r.exit_code == 0);
+    REQUIRE(r.stdout_output == expected);
+}
+#endif
+
 TEST_CASE("stderr is captured separately", "[child_process]") {
     ProcessOptions opts;
     opts.timeout_ms = 5000;


### PR DESCRIPTION
## Summary
- harden WAV/AIFF readers and writers around invalid metadata, non-finite samples, ragged channel data, and size overflows
- make buffering reader handle invalid dimensions, small rings, EOF, and over-reported callbacks more robustly
- guard mmap destinations, streaming writer overflow paths, null format handlers, and stale audio-focus tokens

## Tests
- cmake --build build --target pulp-test-audio-file pulp-test-buffering-reader pulp-test-audio-focus --parallel
- ./build/test/pulp-test-audio-file --reporter compact
- ./build/test/pulp-test-buffering-reader --reporter compact
- ./build/test/pulp-test-audio-focus --reporter compact
- git diff --check origin/main...HEAD
- python3 tools/import-validation/check-source-contracts.py --strict
- python3 tools/import-validation/test_source_contracts.py
- python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main --config tools/scripts/versioning.json
- python3 tools/scripts/version_bump_check.py --mode=report --base origin/main --config tools/scripts/versioning.json