### PR TITLE
fix(midi): preserve raw parser state across chunks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.183.4
+    VERSION 0.184.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/midi/include/pulp/midi/raw_midi_parser.hpp
+++ b/core/midi/include/pulp/midi/raw_midi_parser.hpp
@@ -42,6 +42,11 @@ inline constexpr std::size_t kRawMidiSysexLimit = 64 * 1024;
 struct RawMidiParserState {
     std::vector<uint8_t> sysex_buffer;
     bool sysex_in_progress = false;
+    uint8_t running_status = 0;
+    uint8_t pending_status = 0;
+    uint8_t pending_data[2] = {};
+    std::size_t pending_count = 0;
+    std::size_t pending_expected = 0;
 };
 
 // Short message = status byte + 0..2 data bytes (channel voice /
@@ -63,6 +68,69 @@ inline void parse_raw_midi_bytes(const uint8_t* buf,
                                  RawMidiParserState& state,
                                  const RawMidiShortCallback& on_short,
                                  const RawMidiSysexCallback& on_sysex) {
+    auto clear_pending = [&state] {
+        state.pending_status = 0;
+        state.pending_data[0] = 0;
+        state.pending_data[1] = 0;
+        state.pending_count = 0;
+        state.pending_expected = 0;
+    };
+
+    auto short_data_len = [](uint8_t status) -> std::size_t {
+        if ((status & 0xF0) >= 0x80 && (status & 0xF0) <= 0xE0) {
+            return ((status & 0xF0) == 0xC0 || (status & 0xF0) == 0xD0) ? 1u : 2u;
+        }
+        if (status == 0xF1 || status == 0xF3) return 1;
+        if (status == 0xF2) return 2;
+        if (status == 0xF6 || status == 0xF7) return 0;
+        return static_cast<std::size_t>(-1);
+    };
+
+    auto is_channel_status = [](uint8_t status) {
+        return (status & 0xF0) >= 0x80 && (status & 0xF0) <= 0xE0;
+    };
+
+    auto emit_pending = [&] {
+        if (on_short) {
+            on_short(state.pending_status,
+                     state.pending_expected > 0 ? state.pending_data[0] : 0,
+                     state.pending_expected > 1 ? state.pending_data[1] : 0);
+        }
+        const uint8_t completed_status = state.pending_status;
+        clear_pending();
+        if (is_channel_status(completed_status)) state.running_status = completed_status;
+    };
+
+    auto start_pending = [&](uint8_t status) {
+        clear_pending();
+        const auto data_len = short_data_len(status);
+        if (data_len == static_cast<std::size_t>(-1)) {
+            state.running_status = 0;
+            return;
+        }
+        if (is_channel_status(status)) {
+            state.running_status = status;
+        } else {
+            state.running_status = 0;
+        }
+        if (data_len == 0) {
+            if (on_short) on_short(status, 0, 0);
+            return;
+        }
+        state.pending_status = status;
+        state.pending_expected = data_len;
+    };
+
+    auto consume_data = [&](uint8_t data) {
+        if (state.pending_status == 0) {
+            if (state.running_status == 0) return;
+            start_pending(state.running_status);
+        }
+        if (state.pending_status == 0 || state.pending_count >= 2) return;
+        state.pending_data[state.pending_count++] = data;
+        if (state.pending_count >= state.pending_expected) emit_pending();
+    };
+
     for (std::size_t i = 0; i < n; ++i) {
         const uint8_t b = buf[i];
 
@@ -102,40 +170,17 @@ inline void parse_raw_midi_bytes(const uint8_t* buf,
             state.sysex_buffer.clear();
             state.sysex_buffer.push_back(b);
             state.sysex_in_progress = true;
+            state.running_status = 0;
+            clear_pending();
             continue;
         }
 
-        if ((b & 0x80) == 0) continue; // stray data byte
-
-        std::size_t msg_len = 3;
-        if ((b & 0xF0) == 0xC0 || (b & 0xF0) == 0xD0) {
-            msg_len = 2; // Program Change, Channel Pressure
-        } else if (b == 0xF1 || b == 0xF3) {
-            msg_len = 2; // MTC Quarter Frame, Song Select
-        } else if (b == 0xF2) {
-            msg_len = 3; // Song Position Pointer
-        } else if (b == 0xF6 || b == 0xF7) {
-            msg_len = 1; // Tune Request, stray End-of-Exclusive
+        if ((b & 0x80) != 0) {
+            start_pending(b);
+            continue;
         }
 
-        if (i + msg_len <= n) {
-            bool has_valid_data = true;
-            for (std::size_t data_index = 1; data_index < msg_len; ++data_index) {
-                if ((buf[i + data_index] & 0x80) != 0) {
-                    has_valid_data = false;
-                    break;
-                }
-            }
-
-            if (!has_valid_data) continue;
-
-            if (on_short) {
-                on_short(b,
-                         msg_len > 1 ? buf[i + 1] : 0,
-                         msg_len > 2 ? buf[i + 2] : 0);
-            }
-            i += msg_len - 1; // outer ++i advances past the last byte
-        }
+        consume_data(b);
     }
 }
 

--- a/core/midi/include/pulp/midi/rpn_parser.hpp
+++ b/core/midi/include/pulp/midi/rpn_parser.hpp
@@ -146,7 +146,6 @@ private:
             state.param_msb_set = false;
             state.param_lsb_set = false;
             state.param_set = false;
-            state.value_msb = 0;
         } else if (is_msb && state.param_set) {
             state.param_lsb_set = false;
             state.param_set = false;

--- a/core/midi/include/pulp/midi/rpn_parser.hpp
+++ b/core/midi/include/pulp/midi/rpn_parser.hpp
@@ -59,27 +59,19 @@ public:
 
         switch (cc) {
             case 101: // RPN MSB
-                state.param_msb = val;
-                state.is_rpn = true;
-                state.param_set = false;
+                set_parameter_byte(state, true, true, val);
                 break;
 
             case 100: // RPN LSB
-                state.param_lsb = val;
-                state.is_rpn = true;
-                state.param_set = true;
+                set_parameter_byte(state, true, false, val);
                 break;
 
             case 99: // NRPN MSB
-                state.param_msb = val;
-                state.is_rpn = false;
-                state.param_set = false;
+                set_parameter_byte(state, false, true, val);
                 break;
 
             case 98: // NRPN LSB
-                state.param_lsb = val;
-                state.is_rpn = false;
-                state.param_set = true;
+                set_parameter_byte(state, false, false, val);
                 break;
 
             case 6: // Data Entry MSB
@@ -128,6 +120,8 @@ private:
         uint8_t param_lsb = 0;
         uint8_t value_msb = 0;
         bool is_rpn = true;
+        bool param_msb_set = false;
+        bool param_lsb_set = false;
         bool param_set = false;
     };
 
@@ -135,6 +129,38 @@ private:
 
     static uint16_t combine(uint8_t msb, uint8_t lsb) {
         return static_cast<uint16_t>((msb << 7) | lsb);
+    }
+
+    static void update_parameter_state(ChannelState& state) {
+        state.param_set = state.param_msb_set && state.param_lsb_set
+                       && !(state.param_msb == 0x7F && state.param_lsb == 0x7F);
+    }
+
+    static void set_parameter_byte(ChannelState& state,
+                                   bool is_rpn,
+                                   bool is_msb,
+                                   uint8_t value) {
+        if (state.is_rpn != is_rpn) {
+            state.param_msb = 0;
+            state.param_lsb = 0;
+            state.param_msb_set = false;
+            state.param_lsb_set = false;
+            state.param_set = false;
+            state.value_msb = 0;
+        } else if (is_msb && state.param_set) {
+            state.param_lsb_set = false;
+            state.param_set = false;
+        }
+
+        state.is_rpn = is_rpn;
+        if (is_msb) {
+            state.param_msb = value;
+            state.param_msb_set = true;
+        } else {
+            state.param_lsb = value;
+            state.param_lsb_set = true;
+        }
+        update_parameter_state(state);
     }
 };
 

--- a/test/test_midi_expansion.cpp
+++ b/test/test_midi_expansion.cpp
@@ -197,6 +197,39 @@ TEST_CASE("RpnParser does not mix RPN and NRPN selector halves",
     REQUIRE(nrpn_calls == 1);
 }
 
+TEST_CASE("RpnParser preserves Data Entry MSB across RPN NRPN mode switches",
+          "[midi][rpn][issue-645]") {
+    RpnParser rpn;
+    std::vector<uint16_t> rpn_values;
+    std::vector<uint16_t> nrpn_values;
+
+    rpn.on_rpn = [&](uint8_t, uint16_t, uint16_t value) {
+        rpn_values.push_back(value);
+    };
+    rpn.on_nrpn = [&](uint8_t, uint16_t, uint16_t value) {
+        nrpn_values.push_back(value);
+    };
+
+    rpn.process(MidiEvent::cc(0, 101, 0));  // RPN MSB
+    rpn.process(MidiEvent::cc(0, 100, 1));  // RPN LSB
+    rpn.process(MidiEvent::cc(0, 6, 12));   // Data Entry MSB
+
+    rpn.process(MidiEvent::cc(0, 99, 2));   // switch to NRPN MSB
+    rpn.process(MidiEvent::cc(0, 98, 3));   // NRPN LSB
+    rpn.process(MidiEvent::cc(0, 38, 4));   // Data Entry LSB
+
+    REQUIRE(rpn_values.empty());
+    REQUIRE(nrpn_values == std::vector<uint16_t>{static_cast<uint16_t>((12 << 7) | 4)});
+
+    rpn.process(MidiEvent::cc(0, 6, 5));    // Data Entry MSB
+    rpn.process(MidiEvent::cc(0, 101, 6));  // switch back to RPN MSB
+    rpn.process(MidiEvent::cc(0, 100, 7));  // RPN LSB
+    rpn.process(MidiEvent::cc(0, 38, 8));   // Data Entry LSB
+
+    REQUIRE(nrpn_values.size() == 1);
+    REQUIRE(rpn_values == std::vector<uint16_t>{static_cast<uint16_t>((5 << 7) | 8)});
+}
+
 TEST_CASE("RpnParser does not reuse stale LSB after a new RPN MSB",
           "[midi][rpn][issue-645]") {
     RpnParser rpn;

--- a/test/test_midi_expansion.cpp
+++ b/test/test_midi_expansion.cpp
@@ -130,6 +130,153 @@ TEST_CASE("RpnParser ignores incomplete selections and unrelated CCs",
     REQUIRE(calls == 0);
 }
 
+TEST_CASE("RpnParser accepts selector bytes in either order",
+          "[midi][rpn][issue-645]") {
+    RpnParser rpn;
+    std::vector<uint16_t> params;
+    std::vector<uint16_t> values;
+
+    rpn.on_rpn = [&](uint8_t, uint16_t param, uint16_t value) {
+        params.push_back(param);
+        values.push_back(value);
+    };
+
+    rpn.process(MidiEvent::cc(0, 100, 5));  // RPN LSB first
+    rpn.process(MidiEvent::cc(0, 6, 9));
+    rpn.process(MidiEvent::cc(0, 38, 1));
+    REQUIRE(params.empty());
+
+    rpn.process(MidiEvent::cc(0, 101, 2));  // RPN MSB completes selection
+    rpn.process(MidiEvent::cc(0, 38, 3));
+
+    REQUIRE(params == std::vector<uint16_t>{static_cast<uint16_t>((2 << 7) | 5)});
+    REQUIRE(values == std::vector<uint16_t>{static_cast<uint16_t>((9 << 7) | 3)});
+}
+
+TEST_CASE("RpnParser accepts NRPN selector bytes in either order",
+          "[midi][rpn][issue-645]") {
+    RpnParser rpn;
+    uint16_t received_param = 0;
+    uint16_t received_value = 0;
+
+    rpn.on_nrpn = [&](uint8_t, uint16_t param, uint16_t value) {
+        received_param = param;
+        received_value = value;
+    };
+
+    rpn.process(MidiEvent::cc(1, 98, 12));  // NRPN LSB first
+    rpn.process(MidiEvent::cc(1, 6, 7));
+    rpn.process(MidiEvent::cc(1, 38, 4));
+    REQUIRE(received_param == 0);
+
+    rpn.process(MidiEvent::cc(1, 99, 3));   // NRPN MSB completes selection
+    rpn.process(MidiEvent::cc(1, 38, 5));
+
+    REQUIRE(received_param == static_cast<uint16_t>((3 << 7) | 12));
+    REQUIRE(received_value == static_cast<uint16_t>((7 << 7) | 5));
+}
+
+TEST_CASE("RpnParser does not mix RPN and NRPN selector halves",
+          "[midi][rpn][issue-645]") {
+    RpnParser rpn;
+    int rpn_calls = 0;
+    int nrpn_calls = 0;
+    rpn.on_rpn = [&](uint8_t, uint16_t, uint16_t) { ++rpn_calls; };
+    rpn.on_nrpn = [&](uint8_t, uint16_t, uint16_t) { ++nrpn_calls; };
+
+    rpn.process(MidiEvent::cc(0, 101, 4));  // RPN MSB
+    rpn.process(MidiEvent::cc(0, 98, 9));   // NRPN LSB should start a fresh selector
+    rpn.process(MidiEvent::cc(0, 6, 1));
+    rpn.process(MidiEvent::cc(0, 38, 2));
+    REQUIRE(rpn_calls == 0);
+    REQUIRE(nrpn_calls == 0);
+
+    rpn.process(MidiEvent::cc(0, 99, 1));   // Complete the NRPN selector
+    rpn.process(MidiEvent::cc(0, 38, 3));
+    REQUIRE(rpn_calls == 0);
+    REQUIRE(nrpn_calls == 1);
+}
+
+TEST_CASE("RpnParser does not reuse stale LSB after a new RPN MSB",
+          "[midi][rpn][issue-645]") {
+    RpnParser rpn;
+    std::vector<uint16_t> params;
+    rpn.on_rpn = [&](uint8_t, uint16_t param, uint16_t) {
+        params.push_back(param);
+    };
+
+    rpn.process(MidiEvent::cc(0, 101, 1));
+    rpn.process(MidiEvent::cc(0, 100, 2));
+    rpn.process(MidiEvent::cc(0, 6, 3));
+    rpn.process(MidiEvent::cc(0, 38, 4));
+    REQUIRE(params == std::vector<uint16_t>{static_cast<uint16_t>((1 << 7) | 2)});
+
+    rpn.process(MidiEvent::cc(0, 101, 5));
+    rpn.process(MidiEvent::cc(0, 38, 6));
+    REQUIRE(params.size() == 1);
+
+    rpn.process(MidiEvent::cc(0, 100, 7));
+    rpn.process(MidiEvent::cc(0, 38, 8));
+    REQUIRE(params == std::vector<uint16_t>{
+        static_cast<uint16_t>((1 << 7) | 2),
+        static_cast<uint16_t>((5 << 7) | 7),
+    });
+}
+
+TEST_CASE("RpnParser RPN null selector disables data and step callbacks",
+          "[midi][rpn][issue-645]") {
+    RpnParser rpn;
+    int value_calls = 0;
+    int increment_calls = 0;
+    int decrement_calls = 0;
+
+    rpn.on_rpn = [&](uint8_t, uint16_t, uint16_t) { ++value_calls; };
+    rpn.on_increment = [&](uint8_t, uint16_t, bool) { ++increment_calls; };
+    rpn.on_decrement = [&](uint8_t, uint16_t, bool) { ++decrement_calls; };
+
+    rpn.process(MidiEvent::cc(0, 101, 0));
+    rpn.process(MidiEvent::cc(0, 100, 0));
+    rpn.process(MidiEvent::cc(0, 6, 2));
+    rpn.process(MidiEvent::cc(0, 38, 0));
+    REQUIRE(value_calls == 1);
+
+    rpn.process(MidiEvent::cc(0, 101, 0x7F));
+    rpn.process(MidiEvent::cc(0, 100, 0x7F));
+    rpn.process(MidiEvent::cc(0, 6, 3));
+    rpn.process(MidiEvent::cc(0, 38, 4));
+    rpn.process(MidiEvent::cc(0, 96, 0));
+    rpn.process(MidiEvent::cc(0, 97, 0));
+
+    REQUIRE(value_calls == 1);
+    REQUIRE(increment_calls == 0);
+    REQUIRE(decrement_calls == 0);
+}
+
+TEST_CASE("RpnParser NRPN null selector disables only that channel",
+          "[midi][rpn][issue-645]") {
+    RpnParser rpn;
+    std::vector<uint8_t> channels;
+
+    rpn.on_nrpn = [&](uint8_t ch, uint16_t, uint16_t) {
+        channels.push_back(ch);
+    };
+
+    rpn.process(MidiEvent::cc(2, 99, 1));
+    rpn.process(MidiEvent::cc(2, 98, 2));
+    rpn.process(MidiEvent::cc(3, 99, 3));
+    rpn.process(MidiEvent::cc(3, 98, 4));
+
+    rpn.process(MidiEvent::cc(2, 99, 0x7F));
+    rpn.process(MidiEvent::cc(2, 98, 0x7F));
+
+    rpn.process(MidiEvent::cc(2, 6, 8));
+    rpn.process(MidiEvent::cc(2, 38, 9));
+    rpn.process(MidiEvent::cc(3, 6, 10));
+    rpn.process(MidiEvent::cc(3, 38, 11));
+
+    REQUIRE(channels == std::vector<uint8_t>{3});
+}
+
 TEST_CASE("RpnParser tolerates omitted callbacks",
           "[midi][rpn][issue-645]") {
     RpnParser rpn;
@@ -176,7 +323,7 @@ TEST_CASE("RpnParser reports NRPN increment and decrement metadata",
     REQUIRE(is_rpn_flags == std::vector<bool>{false, false});
 }
 
-TEST_CASE("RpnParser reports maximum 14-bit RPN parameter and value",
+TEST_CASE("RpnParser reports highest non-null RPN parameter and maximum value",
           "[midi][rpn][coverage]") {
     RpnParser rpn;
     uint8_t received_ch = 255;
@@ -189,13 +336,13 @@ TEST_CASE("RpnParser reports maximum 14-bit RPN parameter and value",
         received_value = value;
     };
 
-    rpn.process(MidiEvent::cc(15, 101, 127));
+    rpn.process(MidiEvent::cc(15, 101, 126));
     rpn.process(MidiEvent::cc(15, 100, 127));
     rpn.process(MidiEvent::cc(15, 6, 127));
     rpn.process(MidiEvent::cc(15, 38, 127));
 
     REQUIRE(received_ch == 15);
-    REQUIRE(received_param == 0x3fff);
+    REQUIRE(received_param == 0x3f7f);
     REQUIRE(received_value == 0x3fff);
 }
 

--- a/test/test_raw_midi_parser.cpp
+++ b/test/test_raw_midi_parser.cpp
@@ -90,6 +90,164 @@ TEST_CASE("raw_midi_parser drops stray data and incomplete short messages",
     REQUIRE(c.sysex.empty());
 }
 
+TEST_CASE("raw_midi_parser completes short messages split across calls",
+          "[midi][raw_midi_parser][issue-645]") {
+    RawMidiParserState state;
+    Captured c;
+    auto on_short = [&c](uint8_t s, uint8_t d1, uint8_t d2) {
+        c.shorts.push_back({s, d1, d2});
+    };
+    auto on_sysex = [&c](const std::vector<uint8_t>& sx) {
+        c.sysex.push_back(sx);
+    };
+
+    uint8_t chunk1[] = {0x90, 0x40};
+    uint8_t chunk2[] = {0x7F};
+    parse_raw_midi_bytes(chunk1, sizeof(chunk1), state, on_short, on_sysex);
+    REQUIRE(c.shorts.empty());
+
+    parse_raw_midi_bytes(chunk2, sizeof(chunk2), state, on_short, on_sysex);
+    REQUIRE(c.shorts.size() == 1);
+    REQUIRE(c.shorts[0].status == 0x90);
+    REQUIRE(c.shorts[0].d1 == 0x40);
+    REQUIRE(c.shorts[0].d2 == 0x7F);
+}
+
+TEST_CASE("raw_midi_parser preserves running status across chunks",
+          "[midi][raw_midi_parser][issue-645]") {
+    RawMidiParserState state;
+    Captured c;
+    auto on_short = [&c](uint8_t s, uint8_t d1, uint8_t d2) {
+        c.shorts.push_back({s, d1, d2});
+    };
+
+    uint8_t first[] = {0x90, 0x3C, 0x64, 0x3D};
+    uint8_t second[] = {0x65, 0x3E, 0x66};
+    parse_raw_midi_bytes(first, sizeof(first), state, on_short, {});
+    REQUIRE(c.shorts.size() == 1);
+
+    parse_raw_midi_bytes(second, sizeof(second), state, on_short, {});
+    REQUIRE(c.shorts.size() == 3);
+    REQUIRE(c.shorts[1].status == 0x90);
+    REQUIRE(c.shorts[1].d1 == 0x3D);
+    REQUIRE(c.shorts[1].d2 == 0x65);
+    REQUIRE(c.shorts[2].d1 == 0x3E);
+    REQUIRE(c.shorts[2].d2 == 0x66);
+}
+
+TEST_CASE("raw_midi_parser handles one-byte running status messages",
+          "[midi][raw_midi_parser][issue-645]") {
+    RawMidiParserState state;
+    Captured c;
+    auto on_short = [&c](uint8_t s, uint8_t d1, uint8_t d2) {
+        c.shorts.push_back({s, d1, d2});
+    };
+
+    uint8_t bytes[] = {0xC2, 0x05, 0x06, 0xD3, 0x40, 0x41};
+    parse_raw_midi_bytes(bytes, sizeof(bytes), state, on_short, {});
+
+    REQUIRE(c.shorts.size() == 4);
+    REQUIRE(c.shorts[0].status == 0xC2);
+    REQUIRE(c.shorts[0].d1 == 0x05);
+    REQUIRE(c.shorts[1].status == 0xC2);
+    REQUIRE(c.shorts[1].d1 == 0x06);
+    REQUIRE(c.shorts[2].status == 0xD3);
+    REQUIRE(c.shorts[2].d1 == 0x40);
+    REQUIRE(c.shorts[3].status == 0xD3);
+    REQUIRE(c.shorts[3].d1 == 0x41);
+}
+
+TEST_CASE("raw_midi_parser realtime bytes do not disturb pending data",
+          "[midi][raw_midi_parser][issue-645]") {
+    auto c = parse({0x90, 0x40, 0xF8, 0x7F,
+                    0x41, 0xF9, 0x70});
+
+    REQUIRE(c.shorts.size() == 4);
+    REQUIRE(c.shorts[0].status == 0xF8);
+    REQUIRE(c.shorts[1].status == 0x90);
+    REQUIRE(c.shorts[1].d1 == 0x40);
+    REQUIRE(c.shorts[1].d2 == 0x7F);
+    REQUIRE(c.shorts[2].status == 0xF9);
+    REQUIRE(c.shorts[3].status == 0x90);
+    REQUIRE(c.shorts[3].d1 == 0x41);
+    REQUIRE(c.shorts[3].d2 == 0x70);
+}
+
+TEST_CASE("raw_midi_parser reprocesses status that interrupts pending data",
+          "[midi][raw_midi_parser][issue-645]") {
+    auto c = parse({0x90, 0x40,       // partial note-on
+                    0xF1, 0x55,       // system-common status interrupts it
+                    0x90, 0x41, 0x7F});
+
+    REQUIRE(c.shorts.size() == 2);
+    REQUIRE(c.shorts[0].status == 0xF1);
+    REQUIRE(c.shorts[0].d1 == 0x55);
+    REQUIRE(c.shorts[1].status == 0x90);
+    REQUIRE(c.shorts[1].d1 == 0x41);
+    REQUIRE(c.shorts[1].d2 == 0x7F);
+}
+
+TEST_CASE("raw_midi_parser splits system-common messages across calls",
+          "[midi][raw_midi_parser][issue-645]") {
+    RawMidiParserState state;
+    Captured c;
+    auto on_short = [&c](uint8_t s, uint8_t d1, uint8_t d2) {
+        c.shorts.push_back({s, d1, d2});
+    };
+
+    uint8_t first[] = {0xF2, 0x10};
+    uint8_t second[] = {0x20, 0x90, 0x40};
+    uint8_t third[] = {0x7F};
+    parse_raw_midi_bytes(first, sizeof(first), state, on_short, {});
+    REQUIRE(c.shorts.empty());
+    parse_raw_midi_bytes(second, sizeof(second), state, on_short, {});
+    REQUIRE(c.shorts.size() == 1);
+    parse_raw_midi_bytes(third, sizeof(third), state, on_short, {});
+
+    REQUIRE(c.shorts.size() == 2);
+    REQUIRE(c.shorts[0].status == 0xF2);
+    REQUIRE(c.shorts[0].d1 == 0x10);
+    REQUIRE(c.shorts[0].d2 == 0x20);
+    REQUIRE(c.shorts[1].status == 0x90);
+    REQUIRE(c.shorts[1].d1 == 0x40);
+    REQUIRE(c.shorts[1].d2 == 0x7F);
+}
+
+TEST_CASE("raw_midi_parser sysex start clears pending short state",
+          "[midi][raw_midi_parser][issue-645]") {
+    RawMidiParserState state;
+    Captured c;
+    auto on_short = [&c](uint8_t s, uint8_t d1, uint8_t d2) {
+        c.shorts.push_back({s, d1, d2});
+    };
+    auto on_sysex = [&c](const std::vector<uint8_t>& sx) {
+        c.sysex.push_back(sx);
+    };
+
+    uint8_t bytes[] = {0x90, 0x40, 0xF0, 0x7D, 0xF7, 0x41, 0x7F,
+                       0x90, 0x42, 0x7F};
+    parse_raw_midi_bytes(bytes, sizeof(bytes), state, on_short, on_sysex);
+
+    REQUIRE(c.sysex.size() == 1);
+    REQUIRE(c.sysex[0] == std::vector<uint8_t>{0xF0, 0x7D, 0xF7});
+    REQUIRE(c.shorts.size() == 1);
+    REQUIRE(c.shorts[0].status == 0x90);
+    REQUIRE(c.shorts[0].d1 == 0x42);
+    REQUIRE(c.shorts[0].d2 == 0x7F);
+}
+
+TEST_CASE("raw_midi_parser undefined system statuses clear running state",
+          "[midi][raw_midi_parser][issue-645]") {
+    auto c = parse({0x90, 0x3C, 0x7F,
+                    0xF4,              // undefined status cancels running status
+                    0x3D, 0x7F,        // must be ignored
+                    0x90, 0x40, 0x7F});
+
+    REQUIRE(c.shorts.size() == 2);
+    REQUIRE(c.shorts[0].d1 == 0x3C);
+    REQUIRE(c.shorts[1].d1 == 0x40);
+}
+
 TEST_CASE("raw_midi_parser recovers when short-message data is another status",
           "[midi][raw_midi_parser][codecov]") {
     auto c = parse({0x90, 0x40,       // malformed Note On: next byte is status
@@ -110,22 +268,25 @@ TEST_CASE("raw_midi_parser recovers when short-message data is another status",
 TEST_CASE("raw_midi_parser recovers after status interrupts short data",
           "[midi][raw_midi_parser][coverage][phase3-large]") {
     auto c = parse({
-        0x90, 0x40, 0xF8,  // realtime byte interrupts incomplete Note On
-        0x41, 0x7F,        // stray data bytes must not finish stale 0x90
+        0x90, 0x40, 0xF8,  // realtime byte does not interrupt pending Note On
+        0x41, 0x7F,        // first byte completes the Note On; second starts running status
         0x80, 0x40, 0x00,  // fresh Note Off still parses normally
         0xF2, 0x10, 0xF6,  // Tune Request interrupts incomplete Song Position
         0x20,              // stray data must not finish stale 0xF2
         0xF3, 0x05,        // Song Select still parses normally
     });
 
-    REQUIRE(c.shorts.size() == 4);
+    REQUIRE(c.shorts.size() == 5);
     REQUIRE(c.shorts[0].status == 0xF8);
-    REQUIRE(c.shorts[1].status == 0x80);
+    REQUIRE(c.shorts[1].status == 0x90);
     REQUIRE(c.shorts[1].d1 == 0x40);
-    REQUIRE(c.shorts[1].d2 == 0x00);
-    REQUIRE(c.shorts[2].status == 0xF6);
-    REQUIRE(c.shorts[3].status == 0xF3);
-    REQUIRE(c.shorts[3].d1 == 0x05);
+    REQUIRE(c.shorts[1].d2 == 0x41);
+    REQUIRE(c.shorts[2].status == 0x80);
+    REQUIRE(c.shorts[2].d1 == 0x40);
+    REQUIRE(c.shorts[2].d2 == 0x00);
+    REQUIRE(c.shorts[3].status == 0xF6);
+    REQUIRE(c.shorts[4].status == 0xF3);
+    REQUIRE(c.shorts[4].d1 == 0x05);
     REQUIRE(c.sysex.empty());
 }
 
@@ -154,7 +315,7 @@ TEST_CASE("raw_midi_parser accumulates sysex across calls",
     REQUIRE_FALSE(state.sysex_in_progress);
 }
 
-TEST_CASE("raw_midi_parser does not carry partial short messages across calls",
+TEST_CASE("raw_midi_parser carries partial short messages across calls",
           "[midi][raw_midi_parser][coverage]") {
     RawMidiParserState state;
     Captured c;
@@ -170,10 +331,13 @@ TEST_CASE("raw_midi_parser does not carry partial short messages across calls",
     parse_raw_midi_bytes(chunk1, sizeof(chunk1), state, on_short, on_sysex);
     parse_raw_midi_bytes(chunk2, sizeof(chunk2), state, on_short, on_sysex);
 
-    REQUIRE(c.shorts.size() == 1);
-    REQUIRE(c.shorts[0].status == 0x80);
+    REQUIRE(c.shorts.size() == 2);
+    REQUIRE(c.shorts[0].status == 0x90);
     REQUIRE(c.shorts[0].d1 == 0x40);
-    REQUIRE(c.shorts[0].d2 == 0x00);
+    REQUIRE(c.shorts[0].d2 == 0x7F);
+    REQUIRE(c.shorts[1].status == 0x80);
+    REQUIRE(c.shorts[1].d1 == 0x40);
+    REQUIRE(c.shorts[1].d2 == 0x00);
     REQUIRE(c.sysex.empty());
     REQUIRE_FALSE(state.sysex_in_progress);
 }


### PR DESCRIPTION
## Summary
- preserve raw MIDI short-message state and running status across transport chunks
- keep realtime bytes transparent while pending short messages and SysEx are in flight
- tighten RPN/NRPN selection handling, including null-selector and mixed-selector edge cases

## Tests
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF
- cmake --build build --target pulp-test-raw-midi-parser pulp-test-midi-expansion --parallel
- ./build/test/pulp-test-raw-midi-parser --reporter compact
- ./build/test/pulp-test-midi-expansion --reporter compact
- git diff --check origin/main...HEAD
- python3 tools/import-validation/check-source-contracts.py --strict
- python3 tools/import-validation/test_source_contracts.py
- python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main --config tools/scripts/versioning.json
- python3 tools/scripts/version_bump_check.py --mode=report