### PR TITLE
ci: keep coverage watchdog alive until legs exist

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -864,8 +864,9 @@ Fix pattern (applies to any GH-Actions job, not just coverage):
 - **For the queued-hang mode, add an explicit queued-job watchdog.**
   `coverage.yml`'s `coverage-queue-watchdog` job is the reference: it
   runs on `ubuntu-latest` (never self-hosted, so it itself can never be
-  the stuck thing), starts immediately (no `needs:` on the matrix), and
-  polls this run's own jobs via `gh api
+  the stuck thing), starts after `classify` says native coverage is
+  required (still no `needs:` on the matrix), and polls this run's own
+  jobs via `gh api
   repos/{repo}/actions/runs/{run_id}/jobs`. If a `Coverage report (...)`
   leg has been `status==queued` past a grace window it cancels the whole
   run via `POST runs/{run_id}/cancel` (`permissions: actions: write`).
@@ -876,6 +877,15 @@ Fix pattern (applies to any GH-Actions job, not just coverage):
   `queued_at`, and `created_at` is when every leg — including the queued
   one — was created. The watchdog must exclude its own job name from the
   scan or it will reap itself.
+  - **Do not exit before native coverage legs exist.** The watchdog can
+    start before `matrix-config` has materialized the `coverage` matrix.
+    In that window the jobs API returns zero matching `Coverage report
+    (..., Clang)` jobs; that means "not created yet", not "all coverage
+    legs left queued". Track whether at least one required native leg has
+    ever been observed, and only use `queued_legs == 0` as an early-exit
+    condition after that observation. This exact bug left a later macOS
+    coverage leg queued while newer main Coverage runs piled up behind
+    the workflow concurrency group, keeping Codecov's main record stale.
   - **Scope the watchdog's job-name match to the REQUIRED legs only.**
     `coverage-queue-watchdog` matches a name that starts with `Coverage
     report (` AND ends with `, Clang)` — i.e. only the native `(macOS,
@@ -898,8 +908,9 @@ Fix pattern (applies to any GH-Actions job, not just coverage):
     pool. The poll window (`POLL_SECONDS` 60 × `MAX_POLLS` 160 = 160
     min) must exceed the grace, and the job's `timeout-minutes` (165)
     must exceed the poll window. A long grace is cheap: the watchdog
-    still exits EARLY (the `queued_legs == 0` branch) the moment the leg
-    starts, so in the common case it never runs the full window.
+    still exits EARLY after it has observed a required native coverage
+    leg and none remain queued, so in the common case it never runs the
+    full window.
 - **Pin a pure gate/aggregation job to a GitHub-hosted runner**
   (`ubuntu-latest` / `ubuntu-24.04`). A job that only downloads
   artifacts and runs a check must never queue behind a saturated

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -740,9 +740,12 @@ jobs:
   #
   # This watchdog is the explicit queued-job reaper. It runs on a
   # GitHub-hosted runner (NEVER self-hosted, so it can never itself be
-  # the thing that's stuck), starts immediately (no `needs:`), and polls
-  # THIS run's own jobs. If any coverage leg has been `queued` longer
-  # than QUEUED_GRACE_MINUTES, it cancels the whole run via the
+  # the thing that's stuck), starts as soon as the classifier says native
+  # coverage is required, and polls THIS run's own jobs. Because it can
+  # start before the coverage matrix has been materialized, "no coverage
+  # legs observed yet" must NOT be treated as "nothing queued". If any
+  # coverage leg has been `queued` longer than QUEUED_GRACE_MINUTES, it
+  # cancels the whole run via the
   # `runs/{id}/cancel` API — there is no public API to cancel a single
   # matrix leg, and cancelling the run is what the required gate needs
   # anyway: `coverage-diff-gate`'s `if: always()` precondition step then
@@ -762,9 +765,9 @@ jobs:
     # QUEUED_GRACE_MINUTES window plus the margin MAX_POLLS provides, then
     # exits. This bound must exceed the POLL_SECONDS * MAX_POLLS poll
     # window (60s * 160 = 160 min) so the loop is never killed mid-window.
-    # In the common case the watchdog still exits EARLY — the moment every
-    # coverage leg has left `queued` (the `queued_legs == 0` branch) — so
-    # it almost never runs the full window.
+    # In the common case the watchdog still exits EARLY — after it has
+    # observed at least one native coverage leg and every observed leg has
+    # left `queued` — so it almost never runs the full window.
     timeout-minutes: 165
     permissions:
       # actions: write is required to POST runs/{id}/cancel.
@@ -792,9 +795,9 @@ jobs:
           # out a deep but healthy queue.
           #
           # This long grace does NOT mean the watchdog usually runs for
-          # 150 min: it still exits EARLY (the `queued_legs == 0` branch)
-          # the moment the leg starts, which in the common case is well
-          # inside the window.
+          # 150 min: it still exits EARLY after native coverage legs have
+          # been created and none remain queued, which in the common case
+          # is well inside the window.
           QUEUED_GRACE_MINUTES: '150'
           # Poll cadence + total watch window. POLL_SECONDS * MAX_POLLS
           # (60s * 160 = 160 min) must comfortably exceed
@@ -842,6 +845,7 @@ jobs:
           echo "Poll cadence:       ${POLL_SECONDS}s x ${MAX_POLLS}"
 
           poll=0
+          observed_coverage_legs=0
           while [ "${poll}" -lt "${MAX_POLLS}" ]; do
             poll=$((poll + 1))
             now_epoch=$(date -u +%s)
@@ -860,6 +864,7 @@ jobs:
             )
 
             queued_legs=0
+            coverage_legs_this_poll=0
             stuck_leg=""
             stuck_age_min=0
             while IFS=$'\t' read -r job_name job_status; do
@@ -881,6 +886,8 @@ jobs:
                 "Coverage report ("*", Clang)") ;;
                 *) continue ;;
               esac
+              coverage_legs_this_poll=$((coverage_legs_this_poll + 1))
+              observed_coverage_legs=1
               [ "${job_status}" != "queued" ] && continue
 
               queued_legs=$((queued_legs + 1))
@@ -905,14 +912,17 @@ jobs:
             fi
 
             if [ "${queued_legs}" -eq 0 ]; then
-              echo "  poll ${poll}: no coverage leg is queued — every leg has a runner or has finished. Watchdog done."
-              exit 0
+              if [ "${observed_coverage_legs}" -eq 1 ]; then
+                echo "  poll ${poll}: observed ${coverage_legs_this_poll} native coverage leg(s); none are queued — every leg has a runner or has finished. Watchdog done."
+                exit 0
+              fi
+              echo "  poll ${poll}: no native coverage legs observed yet — waiting for matrix-config/coverage job creation."
             fi
 
             sleep "${POLL_SECONDS}"
           done
 
-          echo "Watchdog window elapsed (${MAX_POLLS} polls) with no leg past the ${QUEUED_GRACE_MINUTES}-min grace — nothing reaped."
+          echo "Watchdog window elapsed (${MAX_POLLS} polls) with no native coverage leg past the ${QUEUED_GRACE_MINUTES}-min grace — nothing reaped."
 
   android-kotlin-coverage:
     # Keep Android JVM coverage on the always-on Coverage workflow so

--- a/docs/guides/coverage.md
+++ b/docs/guides/coverage.md
@@ -294,6 +294,13 @@ at a **75%** floor. Sub-threshold diff coverage hard-fails this check
 and blocks the merge — adding untested code means either adding tests
 or splitting the untested portion into its own PR.
 
+On pull requests the native coverage matrix is intentionally macOS-only.
+Linux and Windows native coverage are collected on push-to-main,
+workflow dispatch, and the nightly cross-platform lane. A docs/planning
+PR that the classifier marks skip-safe does not allocate native coverage
+runners at all; the required diff-coverage gate reports a fast green
+skip instead.
+
 For local pre-submit checks, run `tools/scripts/local_diff_cover.sh`.
 Pass test targets to limit the build, and set
 `PULP_DIFF_COVER_CTEST_REGEX` when the PR has a focused test subset so
@@ -337,9 +344,9 @@ before starting each tranche, watch them again after pushing it, debug
 new failures as soon as they appear, and manually merge PRs once they
 are green.
 
-Use Namespace-backed GitHub checks and Codecov comments as the default
-evidence path. Local VMs are a fallback for reproducing or isolating
-failures, not the normal proof that a tranche is ready.
+Use GitHub checks and Codecov comments as the default evidence path.
+Local VMs are a fallback for reproducing or isolating failures, not the
+normal proof that a tranche is ready.
 
 ## How the collection works
 
@@ -471,9 +478,13 @@ Still out of scope today:
 
 ## Cross-platform matrix
 
-The coverage workflow runs on
-`{ubuntu-latest, macos-latest, windows-latest}` for the native lane.
-Each OS produces its own `coverage.cobertura.xml` and uploads to
+The native coverage matrix is event-conditional. On pull requests, it
+runs only the macOS leg when `tools/scripts/classify_changes.py` says
+native coverage is required. On push-to-main and workflow dispatch, it
+runs `{ubuntu-latest, macos-latest, windows-latest}` so the Codecov
+branch record receives the full cross-OS picture.
+
+Each OS leg produces its own `coverage.cobertura.xml` and uploads to
 Codecov with an OS-tag flag. The Linux leg also uploads the Python
 tools XML for `tools/scripts/**`, `tools/deps/**`,
 `tools/local-ci/**`, top-level `tools/*.py`, `tools/packages/**`, and
@@ -514,9 +525,10 @@ is not already on PATH).
 
 The per-OS legs do NOT fail-fast: a flake on one OS does not cancel
 the others, so the Codecov dashboard still gets partial cross-OS
-coverage when one leg hits a transient toolchain issue. The
-`coverage-diff-gate` job downstream consumes a **merged Cobertura
-XML** built from all three OS artifacts via
+coverage when one leg hits a transient toolchain issue. On pull
+requests there is normally only a macOS native XML. On push-to-main and
+manual dispatches, the `coverage-diff-gate` job downstream consumes a
+**merged Cobertura XML** built from all available OS artifacts via
 `tools/scripts/merge_cobertura.py` (#635). Earlier the gate was
 pinned to the Linux artifact only, which silently skipped Apple-only
 (`au_adapter.mm`, `au_v2_*`) and Windows-only files — diff-cover
@@ -525,6 +537,15 @@ specific change. Merging takes `max(hits)` per `(filename, line)`
 across the inputs, so a line covered on any OS counts as covered
 overall. diff-cover stays a single-XML tool (one PR comment, one
 number) but the silent-skip is closed.
+
+The Coverage workflow also has a `Coverage queue watchdog` job for PRs
+that need native coverage. It runs on GitHub-hosted Ubuntu and polls the
+current workflow run's own jobs. The watchdog may start before GitHub
+has materialized the native coverage matrix, so it must wait until it
+has observed at least one `Coverage report (..., Clang)` leg before
+concluding that there are no queued native legs left. That distinction
+prevents a later macOS coverage leg from sitting queued indefinitely
+while Codecov's branch record remains stale.
 
 **Local equivalent caveat.** `scripts/run_coverage.sh` produces only
 the host-OS Cobertura XML. A local `diff-cover` invocation against

--- a/tools/scripts/test_codecov_config.py
+++ b/tools/scripts/test_codecov_config.py
@@ -265,6 +265,22 @@ class CodecovYamlStructure(unittest.TestCase):
             "runs cannot leave Codecov on a mixed React+stale-native snapshot.",
         )
 
+    def test_coverage_watchdog_waits_until_native_legs_exist(self):
+        # Regression: the watchdog can start after `classify` but before
+        # `matrix-config` has materialized the native coverage matrix.
+        # Seeing zero coverage legs in that window must not be treated as
+        # "all coverage legs have left queued", or a later macOS leg can
+        # sit queued forever while main Codecov records stay stale.
+        coverage = COVERAGE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("observed_coverage_legs=0", coverage)
+        self.assertIn("coverage_legs_this_poll=0", coverage)
+        self.assertIn("observed_coverage_legs=1", coverage)
+        self.assertIn("no native coverage legs observed yet", coverage)
+        self.assertIn(
+            'if [ "${observed_coverage_legs}" -eq 1 ]; then',
+            coverage,
+        )
+
     def test_core_axes_use_canonical_directory_mappings(self):
         # Core subsystem ids come directly from core/* and should map to
         # exactly that directory in both flag and component declarations.


### PR DESCRIPTION
## Summary
- keep the Coverage queue watchdog polling until it has observed at least one native Coverage leg
- prevent the early no-leg poll from exiting before matrix-config materializes coverage jobs
- document the gotcha in the CI skill and add a structural regression test

## Validation
- python3 tools/scripts/test_codecov_config.py
- yamllint --no-warnings -d relaxed .github/workflows/coverage.yml
- actionlint -shellcheck= .github/workflows/coverage.yml
- python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main
- python3 tools/scripts/version_bump_check.py --mode=report --base origin/main
- python3 tools/import-validation/check-source-contracts.py --strict
- git diff --check origin/main..HEAD

Local diff-cover was demoted with PULP_DISABLE_PREPUSH_DIFF_COVER=1 because the local coverage build cannot fetch the pinned mbedtls tree 107ea89daaefb9867ea9121002fbbdf926780e98.