### PR TITLE
test(tools): cover version gate guard edges

### DIFF
--- a/tools/scripts/test_gates.py
+++ b/tools/scripts/test_gates.py
@@ -17,6 +17,7 @@ Run the whole suite:
     python3 tools/scripts/test_gates.py
 
 Or run a single cluster module directly:
+    python3 tools/scripts/test_gate_common.py
     python3 tools/scripts/test_version_bump_surfaces.py
     python3 tools/scripts/test_version_bump_heuristics.py
     python3 tools/scripts/test_version_bump_apply.py
@@ -37,6 +38,10 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # Re-export the cluster TestCase subclasses. `unittest`'s default loader
 # discovers every `TestCase` in this module's namespace, so importing the
 # classes here is sufficient to run all of them under `test_gates.py`.
+from test_gate_common import GlobToRegexTests  # noqa: E402,F401
+from test_gate_common import GitHelperTests  # noqa: E402,F401
+from test_gate_common import StripMetaTests  # noqa: E402,F401
+from test_gate_common import TrailerParseTests  # noqa: E402,F401
 from test_version_bump_surfaces import VersionBumpSurfacesTests  # noqa: E402,F401
 from test_version_bump_heuristics import VersionBumpHeuristicsTests  # noqa: E402,F401
 from test_version_bump_apply import VersionBumpApplyTests  # noqa: E402,F401

--- a/tools/scripts/test_skill_sync.py
+++ b/tools/scripts/test_skill_sync.py
@@ -12,6 +12,8 @@ of the aggregate suite via `test_gates.py`.
 
 from __future__ import annotations
 
+from pathlib import Path
+import sys
 import unittest
 
 from gate_test_support import GateFixtureTestCase, _git
@@ -128,6 +130,18 @@ class SkillSyncTests(GateFixtureTestCase):
         )
         self.assertEqual(len(bypassed), 1)
         self.assertEqual(bypassed[0].bypass_reason, "generated rename")
+
+    def test_import_gate_module_inserts_scripts_path_when_missing(self) -> None:
+        scripts = str(Path(__file__).resolve().parent)
+        original_path = list(sys.path)
+
+        try:
+            sys.path[:] = [p for p in sys.path if p != scripts]
+            module = self._import_gate_module("gate_common")
+            self.assertIs(module, __import__("gate_common"))
+            self.assertEqual(sys.path[0], scripts)
+        finally:
+            sys.path[:] = original_path
 
 
 if __name__ == "__main__":

--- a/tools/scripts/test_version_bump_apply.py
+++ b/tools/scripts/test_version_bump_apply.py
@@ -18,12 +18,25 @@ import os
 import subprocess
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from gate_test_support import GateFixtureTestCase, _git
 
 
 class VersionBumpApplyTests(GateFixtureTestCase):
     """version_bump_check apply + render cluster fixtures."""
+
+    def test_cluster_helper_fallbacks_cover_isolated_imports(self) -> None:
+        vba = self._import_gate_module("version_bump_apply")
+        vbr = self._import_gate_module("version_bump_render")
+        vbh = self._import_gate_module("version_bump_heuristics")
+
+        with mock.patch.object(vba, "_vbc", return_value=object()):
+            self.assertIs(vba._h("bump_version"), vba.bump_version)
+        with mock.patch.object(vbr, "_vbc", return_value=object()):
+            self.assertIs(vbr._h("already_bumped"), vbr.already_bumped)
+        with mock.patch.object(vbh, "_vbc", return_value=object()):
+            self.assertIs(vbh._h("git_range_trailers"), vbh.git_range_trailers)
 
     def test_partial_multi_file_bump_fails(self) -> None:
         """Plugin surface with two version files: bumping only ONE used to

--- a/tools/scripts/test_version_bump_check_extra.py
+++ b/tools/scripts/test_version_bump_check_extra.py
@@ -209,6 +209,7 @@ class VersionFileIoTests(unittest.TestCase):
             ("FIX: capital not matched", 1),  # case-sensitive per the spec
         ]
         for subject, expected in cases:
+            self.assertEqual(vbc.main(["classify-subject", subject]), expected)
             r = sp.run(
                 ["python3", str(script), "classify-subject", subject],
                 capture_output=True, text=True, check=False,

--- a/tools/scripts/test_version_bump_surfaces.py
+++ b/tools/scripts/test_version_bump_surfaces.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import unittest
+from unittest import mock
 
 from gate_test_support import GateFixtureTestCase, VBC, _run
 
@@ -79,6 +80,135 @@ class VersionBumpSurfacesTests(GateFixtureTestCase):
                 "1.0.0",
             )
         )
+
+    def test_json_path_read_write_and_walk_guards(self) -> None:
+        vbc = self._import_gate_module("version_bump_check")
+
+        self.f.write(
+            "manifest.json",
+            json.dumps({
+                "plugins": [
+                    {"name": "alpha", "version": "1.0.0"},
+                    {"name": "beta", "version": "2.0.0"},
+                ],
+                "metadata": {"tool": {"version": "3.0.0"}},
+            }, indent=2) + "\n",
+        )
+
+        plugin_vf = vbc.VersionFile("manifest.json", "json_path", "plugins.1.version")
+        self.assertEqual(vbc.read_version(self.tmp, plugin_vf), "2.0.0")
+        self.assertTrue(vbc.write_version(self.tmp, plugin_vf, "2.1.0"))
+        manifest = json.loads((self.tmp / "manifest.json").read_text())
+        self.assertEqual(manifest["plugins"][1]["version"], "2.1.0")
+        self.assertTrue((self.tmp / "manifest.json").read_text().endswith("\n"))
+
+        nested_vf = vbc.VersionFile("manifest.json", "json_path", "metadata.tool.version")
+        self.assertEqual(vbc.read_version(self.tmp, nested_vf), "3.0.0")
+
+        self.assertIsNone(vbc._json_walk_get(manifest, ""))
+        self.assertIsNone(vbc._json_walk_get(manifest, "plugins..version"))
+        self.assertIsNone(vbc._json_walk_get(manifest, "metadata.missing.version"))
+        self.assertIsNone(vbc._json_walk_get(manifest, "plugins.nope.version"))
+        self.assertIsNone(vbc._json_walk_get(manifest, "plugins.4.version"))
+        self.assertIsNone(vbc._json_walk_get(manifest, "metadata.tool.version.patch"))
+
+        self.assertFalse(vbc._json_walk_set(manifest, "", "x"))
+        self.assertFalse(vbc._json_walk_set(manifest, "plugins..version", "x"))
+        self.assertFalse(vbc._json_walk_set(manifest, "plugins.nope.version", "x"))
+        self.assertFalse(vbc._json_walk_set(manifest, "plugins.4.version", "x"))
+        self.assertFalse(vbc._json_walk_set(manifest, "metadata.tool.version.patch", "x"))
+        self.assertFalse(vbc._json_walk_set(manifest, "plugins.0.missing.0", "x"))
+        self.assertFalse(vbc._json_walk_set(manifest, "plugins.0.version.patch", "x"))
+        self.assertFalse(vbc._json_walk_set(manifest, "plugins.0.version.patch.leaf", "x"))
+
+        root_list = [{"version": "1.0.0"}]
+        self.assertTrue(vbc._json_walk_set(root_list, "0", {"version": "1.1.0"}))
+        self.assertEqual(root_list[0]["version"], "1.1.0")
+        self.assertFalse(vbc._json_walk_set(root_list, "nope", "x"))
+        self.assertFalse(vbc._json_walk_set(root_list, "4", "x"))
+
+    def test_version_file_failure_modes_are_fail_closed(self) -> None:
+        vbc = self._import_gate_module("version_bump_check")
+        vbs = self._import_gate_module("version_bump_surfaces")
+
+        self.assertIsNone(
+            vbc.read_version(self.tmp, vbc.VersionFile("missing.json", "json_field", "version"))
+        )
+        with mock.patch.object(vbs, "_vbc", return_value=object()):
+            self.assertIs(vbs._h("already_bumped"), vbs.already_bumped)
+        self.assertIsNone(
+            vbc._extract_version_from_text(
+                "{not json}\n",
+                vbc.VersionFile("manifest.json", "json_path", "plugins.0.version"),
+            )
+        )
+
+        self.f.write("bad-field.json", "{not json}\n")
+        self.f.write("bad-path.json", "{not json}\n")
+        self.f.write("plain.txt", "no version here\n")
+
+        self.assertIsNone(
+            vbc.read_version(self.tmp, vbc.VersionFile("bad-path.json", "json_path", "a.b"))
+        )
+        self.assertFalse(
+            vbc.write_version(
+                self.tmp,
+                vbc.VersionFile("bad-field.json", "json_field", "version"),
+                "1.0.0",
+            )
+        )
+        self.assertFalse(
+            vbc.write_version(
+                self.tmp,
+                vbc.VersionFile("bad-path.json", "json_path", "a.b"),
+                "1.0.0",
+            )
+        )
+        self.assertFalse(
+            vbc.write_version(
+                self.tmp,
+                vbc.VersionFile("plain.txt", "regex", pattern=r"missing=(\d+\.\d+\.\d+)"),
+                "1.0.0",
+            )
+        )
+        self.assertFalse(
+            vbc.write_version(
+                self.tmp,
+                vbc.VersionFile("plain.txt", "unknown_kind"),
+                "1.0.0",
+            )
+        )
+
+    def test_base_version_helpers_cover_missing_and_equal_paths(self) -> None:
+        vbc = self._import_gate_module("version_bump_check")
+
+        vf = vbc.VersionFile("CMakeLists.txt", "cmake_project_version")
+        with mock.patch.object(vbc, "version_at_base", return_value="0.1.0"):
+            self.assertFalse(vbc.already_bumped("origin/main", vf, self.tmp))
+        self.assertIsNone(
+            vbc.version_at_base(
+                "origin/main",
+                vbc.VersionFile("missing.json", "json_field", "version"),
+            )
+        )
+
+        self.assertTrue(vbc.write_version(self.tmp, vf, "0.2.0"))
+        with mock.patch.object(vbc, "version_at_base", return_value="0.1.0"):
+            self.assertTrue(vbc.already_bumped("origin/main", vf, self.tmp))
+        with mock.patch.object(vbc, "version_at_base", return_value="0.2.0"):
+            self.assertFalse(vbc.already_bumped("origin/main", vf, self.tmp))
+        with mock.patch.object(vbc, "version_at_base", return_value=None):
+            self.assertFalse(vbc.already_bumped("origin/main", vf, self.tmp))
+
+        self.f.write("broken.json", "{not json}\n")
+        with mock.patch.object(vbc, "version_at_base", return_value="1.0.0"):
+            self.assertFalse(
+                vbc.already_bumped(
+                    "origin/main",
+                    vbc.VersionFile("broken.json", "json_field", "version"),
+                    self.tmp,
+                )
+            )
 
     def test_version_config_loader_strips_metadata(self) -> None:
         vbc = self._import_gate_module("version_bump_check")

--- a/tools/scripts/test_version_consistency_check_extra.py
+++ b/tools/scripts/test_version_consistency_check_extra.py
@@ -7,6 +7,8 @@ import importlib.util
 import io
 import json
 import pathlib
+import runpy
+import shutil
 import tempfile
 import textwrap
 import unittest
@@ -144,6 +146,27 @@ class VersionConsistencyDirectTests(unittest.TestCase):
 
         self.assertEqual(rc, 0)
         self.assertIn("SDK 1.2.4", output)
+
+    def test_script_entrypoint_exits_with_main_return_code(self) -> None:
+        write_layout(self.root)
+        script = self.root / "tools" / "scripts" / "version_consistency_check.py"
+        script.parent.mkdir(parents=True)
+        shutil.copyfile(MODULE_PATH, script)
+
+        with redirect_stdout(io.StringIO()) as output:
+            with self.assertRaises(SystemExit) as ctx:
+                runpy.run_path(str(script), run_name="__main__")
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("version consistency OK", output.getvalue())
+
+    def test_repo_script_entrypoint_is_covered_in_process(self) -> None:
+        with redirect_stdout(io.StringIO()) as output:
+            with self.assertRaises(SystemExit) as ctx:
+                runpy.run_path(str(MODULE_PATH), run_name="__main__")
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("version consistency OK", output.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- cover JSON path, fail-closed, fallback, and base-version guard paths in the version-bump tooling
- cover the version-consistency script entrypoint in process
- include gate_common tests in the aggregate gate suite and cover gate module import path insertion

## Validation
- python3 tools/scripts/test_gates.py
- python3 tools/scripts/test_gate_common.py
- python3 tools/scripts/test_version_consistency_check.py
- python3 tools/scripts/test_version_consistency_check_extra.py
- /tmp/pulp-pycoverage-venv/bin/python tools/scripts/run_python_coverage.py --pattern tools/scripts/test_gates.py --pattern tools/scripts/test_gate_common.py --pattern tools/scripts/test_version_bump*.py --pattern tools/scripts/test_version_consistency_check*.py
- python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report
- GITHUB_PR_TITLE="test(tools): cover version gate guard edges" python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat
- python3 tools/import-validation/check-source-contracts.py --strict
- python3 tools/import-validation/test_source_contracts.py
- git diff --check origin/main..HEAD