### PR TITLE
ci: skip Android Kotlin coverage on PRs

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -933,10 +933,10 @@ the correct fix; they bound runs regardless of `cancel-in-progress`.
 `tools/scripts/classify_changes.py --mode=diff`, outputs
 `native_build_required`). Skip-safe PRs (docs / planning `*.md` only —
 classifier fails *closed*, any uncertainty → `true`) skip the
-`coverage` matrix (150 min/leg) and `android-kotlin-coverage` entirely:
-both have `needs: [..., classify]` + `if:
-needs.classify.outputs.native_build_required == 'true'`. No runner is
-allocated on a docs PR.
+`coverage` matrix (150 min/leg); docs-only PRs also skip
+`android-kotlin-coverage`. The Android Kotlin lane is additionally
+guarded with `github.event_name != 'pull_request'`, so it never allocates
+a runner on PRs. No coverage runner is allocated on a docs PR.
 
 `coverage-diff-gate` is a **REQUIRED branch-protection check** — break it
 and docs PRs get blocked OR coverage silently passes when it shouldn't.
@@ -1002,6 +1002,13 @@ Consequences when touching `coverage.yml` or `coverage-diff-gate`:
 - `Diff coverage required` keeps its exact name and pass/fail semantics
   for macOS-reachable code — it is still the REQUIRED branch-protection
   check.
+- **`android-kotlin-coverage` must stay off PRs.** It is a separate
+  Gradle/JaCoCo job, not part of the `matrix-config` native coverage
+  matrix, so macOS-only PR coverage requires its own event guard:
+  `github.event_name != 'pull_request' && native_build_required == 'true'`.
+  A classify-only guard accidentally queues Android coverage on every
+  code PR even though Linux/Windows/Android PR coverage moved to the
+  nightly lane.
 - **The `matrix-config` job MUST encode `runs_on_json` with `jq`'s
   `tojson`, never `tostring`.** The downstream `coverage` job consumes
   it via `runs-on: ${{ fromJSON(matrix.runs_on_json) }}`, so the field
@@ -1757,7 +1764,7 @@ would make CI flakier than it needs to be.
 
 - `resolve-runners` — shared-helper resolver (`tools/scripts/resolve_runs_on.py`) that picks per-OS runs-on labels in priority order: workflow_dispatch input → `PULP_COVERAGE_<OS>_RUNS_ON_JSON` repo variable → hard-coded default (`ubuntu-latest` / `macos-latest` / `windows-latest`). Same pattern as `sanitizers.yml`. Change runner for one OS by setting the repo variable — no workflow edit required.
 - `coverage` — event-conditional matrix over {macos} on PRs and {linux, macos, windows} on push-to-main / workflow_dispatch. Every leg builds with Clang source-based coverage, runs the native test suite, uploads HTML + summary + Cobertura artifacts, and pushes to Codecov with exactly one per-OS flag (`os-linux`, `os-macos`, `os-windows`). The Linux leg also installs `coverage.py >= 7.10`, runs `tools/scripts/run_python_coverage.py` for `tools/scripts/**`, `tools/deps/**`, and `tools/local-ci/**`, uploads the Python HTML + summary + Cobertura artifacts, and includes `build-coverage/python/coverage.python.xml` in the same Codecov upload. The macOS leg additionally runs `tools/scripts/run_swift_coverage.py`, stages `build-coverage/apple/coverage.apple.lcov`, uploads the Apple summary artifact, and includes that LCOV in the same Codecov upload when present. Subsystem / platform / surface slicing comes from `codecov.yml`'s `component_management` path globs, not from a multi-flag CSV on the upload step. Has `fail-fast: false` on the matrix — a flake on any one OS never cancels the others and never blocks a merge.
-- `android-kotlin-coverage` — Gradle/JaCoCo coverage for `android/app/src/main/kotlin/**`, uploaded to Codecov from the canonical Coverage workflow so main snapshots keep Android JVM coverage fresh.
+- `android-kotlin-coverage` — Gradle/JaCoCo coverage for `android/app/src/main/kotlin/**`, uploaded to Codecov from the canonical Coverage workflow on push-to-main / workflow_dispatch so main snapshots keep Android JVM coverage fresh without spending a PR runner.
 - `pulp-react-coverage` — Vitest/Cobertura coverage for `packages/pulp-react/**` on push-to-main and workflow_dispatch. PR upload remains in `pulp-react-build.yml`; main upload is centralized here so side coverage cannot advance Codecov when native Coverage for the same SHA was cancelled before upload.
 - `coverage-diff-gate` — downloads all three OS Cobertura artifacts (`coverage-cobertura-${sha}` for Linux, `coverage-cobertura-macos-${sha}`, `coverage-cobertura-windows-${sha}`), merges them with `tools/scripts/merge_cobertura.py` (taking `max(hits)` per `(filename, line)`), then runs `diff-cover --fail-under=75` against `origin/<base>` on the merged XML. Hard-fails the PR when the global diff-coverage floor is missed. The job still renders and upserts the diff-coverage PR comment via `tools/scripts/coverage_diff_comment.py` even on failure, and it also runs the per-tier gate (`tools/scripts/coverage_tier_check.py`) in advisory mode against the same merged XML.
 
@@ -1908,13 +1915,13 @@ Gotchas surfaced while landing the four-phase SignalGraph follow-up:
   `python3 tools/scripts/version_bump_check.py --mode=apply` to update
   `CMakeLists.txt` + `CHANGELOG.md`. The gate reports "SDK X.Y.Z ✓
   bumped" when satisfied.
-- **Android/Kotlin coverage lives in `android.yml`, not `coverage.yml`.**
+- **Android/Kotlin coverage is a separate Gradle lane, not the native coverage matrix.**
   The dedicated `android-kotlin-coverage` job provisions Java + the
   Android SDK/NDK, runs `:app:testDebugUnitTest` plus
   `:app:jacocoDebugUnitTestReport`, uploads the JaCoCo artifacts, and
-  sends the XML to Codecov. Keep it separate from the Clang-based
-  `coverage.yml` matrix — Android coverage is a Gradle/SDK lane, not a
-  native profraw lane.
+  sends the XML to Codecov on main/manual coverage runs. Keep it separate
+  from the Clang-based `coverage.yml` matrix, and keep it skipped on PRs:
+  Android coverage is a Gradle/SDK lane, not a native profraw lane.
 
 - **Release-time workflows must declare `permissions: contents: write`.**
   Both `release-cli.yml` and `sign-and-release.yml` write to the

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -932,11 +932,11 @@ jobs:
     # emulator/device smoke remain in android.yml.
     name: Coverage report (Android, Kotlin)
     needs: [resolve-runners, classify]
-    # Skip-safe (docs/planning-only) PRs can't move the Kotlin coverage
-    # number either, so gate this lane on the same classifier output as the
-    # native coverage matrix.
-    # follow-up: a finer android-path gate would skip this on C++-only PRs too
-    if: needs.classify.outputs.native_build_required == 'true'
+    # PR coverage is macOS-only; Linux / Windows / Android coverage is
+    # supplied by the nightly cross-platform lane. Keep this Kotlin upload
+    # for canonical main/manual runs only so PRs do not allocate an Android
+    # coverage runner after the native matrix has already been narrowed.
+    if: github.event_name != 'pull_request' && needs.classify.outputs.native_build_required == 'true'
     runs-on: ${{ fromJSON(needs.resolve-runners.outputs.android_kotlin_runs_on) }}
     timeout-minutes: 30
     steps:

--- a/codecov.yml
+++ b/codecov.yml
@@ -22,14 +22,12 @@
 # workflow's `cancel-in-progress: true` concurrency policy that wipes
 # in-flight runs on force-push).
 #
-# `after_n_builds: 2` because per-PR coverage is now macOS-only (PR
-# #2540): a PR uploads roughly 2 coverage legs - macOS native (Cobertura
-# XML) + Android Kotlin (jacoco) - not 4. With `after_n_builds: 4` from
-# the old Linux/macOS/Windows/Android matrix, Codecov would wait forever
-# for two uploads that never arrive and never post its PR comment.
-# `2` posts correctly for PRs and does not harm push-to-main: on main
-# Codecov posts after the first 2 legs and updates the report as the
-# remaining legs arrive.
+# `after_n_builds: 1` because per-PR coverage is now macOS-only (PR
+# #2540): a normal PR uploads one native Cobertura report. Android
+# Kotlin, Linux, and Windows coverage are main/manual/nightly lanes, not
+# PR uploads. React PRs can still add a second upload, and Codecov will
+# update the report after that upload arrives. Waiting for 2 on ordinary
+# PRs would leave Codecov waiting for an upload that never arrives.
 #
 # If you add or remove a coverage uploader, bump this number to match
 # or Codecov will silently wait forever for the missing one and never
@@ -37,7 +35,7 @@
 # PR has long since merged with a stale report.
 codecov:
   notify:
-    after_n_builds: 2
+    after_n_builds: 1
 
 coverage:
   status:

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -57,12 +57,12 @@ struct HttpServerRunner {
     std::thread thread;
 };
 
-bool wait_until_http_ready(int port, std::chrono::milliseconds timeout = 2s) {
+bool wait_until_http_ready(int port, std::chrono::milliseconds timeout = 10s) {
     const auto deadline = std::chrono::steady_clock::now() + timeout;
     while (std::chrono::steady_clock::now() < deadline) {
         httplib::Client client("127.0.0.1", port);
-        client.set_connection_timeout(1);
-        client.set_read_timeout(1);
+        client.set_connection_timeout(0, 200000);
+        client.set_read_timeout(0, 200000);
         if (auto response = client.Get("/__ready");
             response && response->status == 204) {
             return true;

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -57,6 +57,21 @@ struct HttpServerRunner {
     std::thread thread;
 };
 
+bool wait_until_http_ready(int port, std::chrono::milliseconds timeout = 2s) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        httplib::Client client("127.0.0.1", port);
+        client.set_connection_timeout(1);
+        client.set_read_timeout(1);
+        if (auto response = client.Get("/__ready");
+            response && response->status == 204) {
+            return true;
+        }
+        std::this_thread::sleep_for(10ms);
+    }
+    return false;
+}
+
 // Pick an ephemeral port and return the bound listener + its actual port.
 std::optional<std::uint16_t> try_bind_loopback(Socket& server, std::uint16_t port) {
     if (!server.bind("127.0.0.1", port)) return std::nullopt;
@@ -880,6 +895,9 @@ TEST_CASE("HttpStream factories and refetch reset closed state to request result
 TEST_CASE("HttpStream reads successful GET responses in chunks",
           "[network_stream][http][coverage][phase3]") {
     httplib::Server server;
+    server.Get("/__ready", [](const httplib::Request&, httplib::Response& response) {
+        response.status = 204;
+    });
     server.Get("/body", [](const httplib::Request&, httplib::Response& response) {
         response.set_header("X-Pulp-Stream", "ok");
         response.set_content("chunked-body", "text/plain");
@@ -889,9 +907,11 @@ TEST_CASE("HttpStream reads successful GET responses in chunks",
     REQUIRE(port > 0);
     HttpServerRunner runner(server);
     REQUIRE(runner.wait_until_running());
+    REQUIRE(wait_until_http_ready(port));
 
     auto stream = HttpStream::get("http://127.0.0.1:" + std::to_string(port) + "/body", 2);
     REQUIRE(stream);
+    INFO(stream->transport_error());
     REQUIRE(stream->status_code() == 200);
     REQUIRE(stream->headers().at("X-Pulp-Stream") == "ok");
     REQUIRE(stream->is_open());
@@ -919,6 +939,9 @@ TEST_CASE("HttpStream reads successful GET responses in chunks",
 TEST_CASE("HttpStream POST factory exposes successful response bodies",
           "[network_stream][http][coverage][phase3]") {
     httplib::Server server;
+    server.Get("/__ready", [](const httplib::Request&, httplib::Response& response) {
+        response.status = 204;
+    });
     server.Post("/echo", [](const httplib::Request& request, httplib::Response& response) {
         response.set_header("X-Pulp-Method", request.method);
         response.set_content(request.body, "text/plain");
@@ -928,12 +951,14 @@ TEST_CASE("HttpStream POST factory exposes successful response bodies",
     REQUIRE(port > 0);
     HttpServerRunner runner(server);
     REQUIRE(runner.wait_until_running());
+    REQUIRE(wait_until_http_ready(port));
 
     auto stream = HttpStream::post("http://127.0.0.1:" + std::to_string(port) + "/echo",
                                    "payload=42",
                                    "text/plain",
                                    2);
     REQUIRE(stream);
+    INFO(stream->transport_error());
     REQUIRE(stream->status_code() == 200);
     REQUIRE(stream->headers().at("X-Pulp-Method") == "POST");
     REQUIRE(stream->is_open());

--- a/tools/scripts/test_codecov_config.py
+++ b/tools/scripts/test_codecov_config.py
@@ -247,6 +247,17 @@ class CodecovYamlStructure(unittest.TestCase):
                     f"{flag_name} upload flag must not be path-scoped",
                 )
 
+    def test_notify_count_matches_pr_coverage_upload_contract(self):
+        # Ordinary PR coverage is macOS-only. Android Kotlin and other
+        # cross-platform uploads run on main/manual/nightly lanes, so the
+        # Codecov bot must not wait for a second PR upload that never comes.
+        self.assertEqual(self.doc["codecov"]["notify"]["after_n_builds"], 1)
+        coverage = COVERAGE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            "github.event_name != 'pull_request' && needs.classify.outputs.native_build_required == 'true'",
+            coverage,
+        )
+
     def test_pulp_react_main_upload_is_centralized_in_coverage_workflow(self):
         coverage = COVERAGE_WORKFLOW.read_text(encoding="utf-8")
         react = PULP_REACT_WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- keep the standalone Android Kotlin JaCoCo coverage job off pull_request events
- document the CI gotcha that Android Kotlin coverage is outside the native macOS-only matrix and needs its own PR event guard

## Validation
- yamllint --no-warnings -d relaxed .github/workflows/coverage.yml
- actionlint -shellcheck= .github/workflows/coverage.yml
- python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report
- GITHUB_PR_TITLE="ci: skip Android Kotlin coverage on PRs" python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat
- python3 tools/import-validation/check-source-contracts.py --strict
- python3 tools/import-validation/test_source_contracts.py
- git diff --check origin/main..HEAD