### PR TITLE
ci: harden pages and release watchdog

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -40,6 +40,18 @@ skill for the full banner contract and override knobs
 (`PULP_SKEW_CHECK_DISABLE`, `PULP_SKEW_CHECK_CACHE`). Release-discovery
 Slice 6 (#551).
 
+## GitHub workflow gotchas
+
+- Keep watchdog/issue-maintenance workflows on REST `gh api` calls. Avoid
+  `gh issue list` / `gh pr *` helpers in those paths because they can use the
+  shared GraphQL quota; a watchdog must not fail while reporting that the
+  watched workflow already recovered.
+- Pulp's docs site is deployed by `.github/workflows/docs-deploy.yml`. If
+  GitHub Pages is set to legacy `main`/`docs` builds, the generated Pages
+  checkout tries to clone the private `planning` submodule with the default
+  token and fails before docs deploys. Fix that at the Pages configuration
+  layer (`build_type=workflow`), not by weakening normal submodule checkout.
+
 ## Current Build-and-Test routing
 
 As of the 2026-05-20 classify gate, `build.yml` runs a cheap

--- a/.github/workflows/auto-release-watchdog.yml
+++ b/.github/workflows/auto-release-watchdog.yml
@@ -91,23 +91,25 @@ jobs:
 
           # Look up in both OPEN and CLOSED state; only close OPEN trackers
           # when we return to green (mirror of #475 close-path pattern).
-          existing_json=$(
-              gh issue list \
-                  --repo "$repo" \
-                  --state all \
-                  --search "in:title \"${title}\"" \
-                  --json number,title,state \
-                  --jq "[.[] | select(.title == \"${title}\")] | first // {}"
+          # Use REST here; the shared GraphQL quota is often exhausted by
+          # agent PR polling, and a watchdog must not fail when the watched
+          # workflow has already returned to green.
+          search_json=$(
+              gh api --method GET "/search/issues" \
+                  -f q="repo:${repo} is:issue in:title ${title}"
           )
+          existing_json=$(printf '%s' "$search_json" | TRACKING_TITLE="$title" python3 -c 'import json, os, sys; title = os.environ["TRACKING_TITLE"]; data = json.load(sys.stdin); match = next((item for item in data.get("items", []) if item.get("title") == title), None); print(json.dumps({"number": match.get("number", ""), "state": str(match.get("state", "")).upper()}) if match else "{}")')
           existing=$(echo "$existing_json" | python3 -c "import json, sys; d=json.load(sys.stdin); print(d.get('number','') or '')")
           existing_state=$(echo "$existing_json" | python3 -c "import json, sys; d=json.load(sys.stdin); print(d.get('state','') or '')")
 
           if [ "$KIND" = "success" ]; then
               if [ -n "${existing:-}" ] && [ "$existing_state" = "OPEN" ]; then
                   echo "Auto-release recovered — closing tracker #${existing}."
-                  gh issue comment "$existing" --repo "$repo" \
-                      --body "Auto-release returned to success on run ${RUN_URL}. Closing. (sha ${RUN_SHA})"
-                  gh issue close "$existing" --repo "$repo" --reason completed
+                  gh api -X POST "/repos/${repo}/issues/${existing}/comments" \
+                      -f body="Auto-release returned to success on run ${RUN_URL}. Closing. (sha ${RUN_SHA})"
+                  gh api -X PATCH "/repos/${repo}/issues/${existing}" \
+                      -f state=closed \
+                      -f state_reason=completed
               else
                   echo "Auto-release succeeded and no open tracker — nothing to do."
               fi
@@ -147,10 +149,13 @@ jobs:
 
           if [ -z "${existing:-}" ]; then
               echo "Creating tracking issue."
-              gh issue create --repo "$repo" --title "$title" --body-file body.md --label bug,ci,blocks-release 2>&1 || \
-                  gh issue create --repo "$repo" --title "$title" --body-file body.md
+              TRACKING_TITLE="$title" python3 -c 'import json, os; body = open("body.md", encoding="utf-8").read(); print(json.dumps({"title": os.environ["TRACKING_TITLE"], "body": body, "labels": ["bug", "ci", "blocks-release"]}))' > issue.json
+              gh api -X POST "/repos/${repo}/issues" --input issue.json 2>&1 || {
+                  TRACKING_TITLE="$title" python3 -c 'import json, os; body = open("body.md", encoding="utf-8").read(); print(json.dumps({"title": os.environ["TRACKING_TITLE"], "body": body}))' > issue.json
+                  gh api -X POST "/repos/${repo}/issues" --input issue.json
+              }
           else
               echo "Updating tracking issue #${existing}."
-              gh issue edit "$existing" --repo "$repo" --body-file body.md
-              gh issue reopen "$existing" --repo "$repo" 2>/dev/null || true
+              gh api -X PATCH "/repos/${repo}/issues/${existing}" -F body=@body.md
+              gh api -X PATCH "/repos/${repo}/issues/${existing}" -f state=open 2>/dev/null || true
           fi

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -720,7 +720,9 @@ pulp_add_test_suite(pulp-test-sysex-accumulator LIBRARIES pulp::midi)
 pulp_add_test_suite(pulp-test-async-stream LIBRARIES pulp::runtime)
 
 # Network Stream tests (Phase 3)
-pulp_add_test_suite(pulp-test-network-stream LIBRARIES pulp::runtime)
+pulp_add_test_suite(pulp-test-network-stream
+    LIBRARIES pulp::runtime
+    PROPERTIES RESOURCE_LOCK network-stream)
 
 # MessageChannel tests (Phase 4)
 pulp_add_test_suite(pulp-test-memory-message-channel LIBRARIES pulp::runtime)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -104,7 +104,7 @@ if(Python3_Interpreter_FOUND)
         COMMAND ${Python3_EXECUTABLE}
                 ${CMAKE_CURRENT_SOURCE_DIR}/test_pulp_mcp_binary_smoke.py
                 $<TARGET_FILE:pulp-mcp>)
-    set_tests_properties(pulp-mcp-binary-smoke PROPERTIES TIMEOUT 30)
+    set_tests_properties(pulp-mcp-binary-smoke PROPERTIES TIMEOUT 90)
 endif()
 
 # Setup-hook unit test — verifies hooks/scripts/check-pulp-cli.sh
@@ -2383,7 +2383,13 @@ add_executable(pulp-test-design-import test_design_import.cpp)
 target_link_libraries(pulp-test-design-import PRIVATE pulp::view Catch2::Catch2WithMain)
 target_compile_definitions(pulp-test-design-import PRIVATE PULP_REPO_ROOT="${CMAKE_SOURCE_DIR}")
 catch_discover_tests(pulp-test-design-import
+    TEST_SPEC "~[network]"
     PROPERTIES LABELS "parser-import")
+catch_discover_tests(pulp-test-design-import
+    TEST_SPEC "[network]"
+    PROPERTIES
+        LABELS "parser-import"
+        RESOURCE_LOCK "design-import-network")
 
 # P5-3 follow-up — W3C Design Tokens cluster extracted from
 # test_design_import.cpp. Covers parse_w3c_tokens, export_w3c_tokens,
@@ -2558,7 +2564,13 @@ target_compile_definitions(pulp-test-import-design-tool PRIVATE
     PULP_IMPORT_DESIGN_TOOL_PATH="$<TARGET_FILE:pulp-import-design>")
 add_dependencies(pulp-test-import-design-tool pulp-import-design)
 catch_discover_tests(pulp-test-import-design-tool
+    TEST_SPEC "~[network]"
     PROPERTIES LABELS "parser-import")
+catch_discover_tests(pulp-test-import-design-tool
+    TEST_SPEC "[network]"
+    PROPERTIES
+        LABELS "parser-import"
+        RESOURCE_LOCK "design-import-network")
 
 # pulp #468 — `--execute-bundle` harness end-to-end. Boots the
 # ScriptEngine + WidgetBridge, builds a synthetic React-like bundle on

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -1052,11 +1052,9 @@ TEST_CASE("JSX snapshot dynamic API scanner detects non-deterministic APIs",
     REQUIRE_FALSE(detect_jsx_snapshot_dynamic_apis(
         R"JS(const label = `${"Date.now()"} ${/* Math.random() */ 1}`;)JS").has_dynamic_apis());
     REQUIRE_FALSE(detect_jsx_snapshot_dynamic_apis(
-        R"JS(
-            const single = 'escaped \' Date.now()';
-            const double_quote = "escaped \" Math.random()";
-            const template = `escaped \` fetch("/state")`;
-        )JS").has_dynamic_apis());
+        "const single = 'escaped \\' Date.now()';\n"
+        "const double_quote = \"escaped \\\" Math.random()\";\n"
+        "const template = `escaped \\` fetch(\"/state\")`;\n").has_dynamic_apis());
     REQUIRE_FALSE(detect_jsx_snapshot_dynamic_apis("const x = 1;").has_dynamic_apis());
 }
 

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -1091,7 +1091,7 @@ TEST_CASE("DesignIR asset manifest fetches network assets through cache and veri
 
     DesignIrAssetOptions options;
     options.allow_network_fetch = true;
-    options.network_timeout_ms = 5000;
+    options.network_timeout_ms = 30000;
     options.cache_directory = tmp.path / "asset-cache";
     options.expected_hash_by_uri[url] = "not-the-actual-hash";
 
@@ -1159,7 +1159,7 @@ TEST_CASE("DesignIR asset manifest reports network fetch failures and timeouts",
     DesignIrAssetOptions options;
     options.allow_network_fetch = true;
     options.cache_directory = tmp.path / "asset-cache";
-    options.network_timeout_ms = 5000;
+    options.network_timeout_ms = 30000;
 
     DesignIR failed_ir;
     failed_ir.root.type = "frame";
@@ -1191,7 +1191,7 @@ TEST_CASE("DesignIR asset manifest reports missing fetcher and empty network dow
     DesignIrAssetOptions options;
     options.allow_network_fetch = true;
     options.cache_directory = tmp.path / "asset-cache";
-    options.network_timeout_ms = 1000;
+    options.network_timeout_ms = 10000;
 
     DesignIR missing_fetcher_ir;
     missing_fetcher_ir.root.type = "frame";

--- a/test/test_import_design_tool.cpp
+++ b/test/test_import_design_tool.cpp
@@ -166,7 +166,7 @@ TEST_CASE("pulp-import-design reports help and argument diagnostics",
 }
 
 TEST_CASE("pulp-import-design validates phase 0.5 import vocabulary",
-          "[cli][import-design][tool][issue-493]") {
+          "[cli][import-design][tool][issue-493][network]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp-import-design not built"); return; }
 
     TempDir tmp("pulp-import-design-tool-flags");
@@ -274,8 +274,9 @@ TEST_CASE("pulp-import-design validates phase 0.5 import vocabulary",
                                           "--output", ir_output.string(),
                                           "--allow-network-fetch",
                                           "--asset-cache", cache_dir.string(),
-                                          "--asset-timeout-ms", "5000",
-                                          "--asset-hash", url + "=" + expected_hash});
+                                          "--asset-timeout-ms", "30000",
+                                          "--asset-hash", url + "=" + expected_hash},
+                                         60000);
         REQUIRE_FALSE(fetched.timed_out);
         REQUIRE(fetched.exit_code == 0);
         const auto fetched_json = read_text(ir_output);
@@ -351,7 +352,9 @@ TEST_CASE("pulp-import-design validates phase 0.5 import vocabulary",
                                           "--emit", "ir-json",
                                           "--output", ir_output.string(),
                                           "--allow-network-fetch",
-                                          "--asset-cache", cache_dir.string()});
+                                          "--asset-cache", cache_dir.string(),
+                                          "--asset-timeout-ms", "30000"},
+                                         60000);
         REQUIRE_FALSE(fetched.timed_out);
         REQUIRE(fetched.exit_code == 0);
         const auto ir_json = read_text(ir_output);
@@ -646,7 +649,7 @@ TEST_CASE("pulp-import-design handles literal file paths and rejects unsafe URLs
 
 #ifndef _WIN32
 TEST_CASE("pulp-import-design URL fetch uses a unique temp file and argv-safe curl",
-          "[cli][import-design][tool][issue-493]") {
+          "[cli][import-design][tool][issue-493][network]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp-import-design not built"); return; }
 
     TempDir tmp("pulp-import-design-tool-url-fetch");
@@ -675,7 +678,8 @@ TEST_CASE("pulp-import-design URL fetch uses a unique temp file and argv-safe cu
                                 "--url", "https://example.test/screen.html?node-id=1&mode=dev",
                                 "--output", output.string(),
                                 "--no-comments",
-                                "--no-tokens"});
+                                "--no-tokens"},
+                               60000);
 
     REQUIRE_FALSE(r.timed_out);
     REQUIRE(r.exit_code == 0);

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -57,12 +57,12 @@ struct HttpServerRunner {
     std::thread thread;
 };
 
-bool wait_until_http_ready(int port, std::chrono::milliseconds timeout = 10s) {
+bool wait_until_http_ready(int port, std::chrono::milliseconds timeout = 30s) {
     const auto deadline = std::chrono::steady_clock::now() + timeout;
     while (std::chrono::steady_clock::now() < deadline) {
         httplib::Client client("127.0.0.1", port);
-        client.set_connection_timeout(0, 200000);
-        client.set_read_timeout(0, 200000);
+        client.set_connection_timeout(0, 500000);
+        client.set_read_timeout(0, 500000);
         if (auto response = client.Get("/__ready");
             response && response->status == 204) {
             return true;

--- a/test/test_pulp_mcp_binary_smoke.py
+++ b/test/test_pulp_mcp_binary_smoke.py
@@ -32,7 +32,7 @@ def main() -> int:
             text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            timeout=10,
+            timeout=30,
         )
     except OSError as exc:
         return fail(f"could not execute {binary}: {exc}")
@@ -59,7 +59,7 @@ def main() -> int:
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        timeout=10,
+        timeout=30,
     )
     if rpc.returncode != 0:
         return fail(

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -790,7 +790,7 @@ TEST_CASE("run_process preserves POSIX output captured before timeout",
 #if defined(_WIN32) || defined(__ANDROID__)
     SUCCEED("POSIX timeout output preservation is covered on macOS/Linux");
 #else
-    auto result = run_process("/bin/sh", {"-c", "printf ready; exec sleep 2"}, "", 75);
+    auto result = run_process("/bin/sh", {"-c", "printf ready; exec sleep 2"}, "", 500);
 
     REQUIRE(result.has_value());
     REQUIRE(result->exit_code == -1);

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -1394,7 +1394,12 @@ TEST_CASE("HTTP helpers expose error responses without downloading bodies",
     REQUIRE(server.is_running());
 
     const auto base = std::string("http://127.0.0.1:") + std::to_string(port);
-    const auto response = http_get(base + "/missing", 2);
+    auto response = http_get(base + "/missing", 2);
+    const auto get_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (response.status_code == 0 && std::chrono::steady_clock::now() < get_deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(25));
+        response = http_get(base + "/missing", 2);
+    }
     REQUIRE(response.status_code == 404);
     REQUIRE_FALSE(response.ok());
     REQUIRE(response.body == "missing");

--- a/tools/cmake/PulpTestSuite.cmake
+++ b/tools/cmake/PulpTestSuite.cmake
@@ -29,13 +29,14 @@ include_guard(GLOBAL)
 #     [LIBRARIES lib1 lib2 ...]          # additional Pulp / system libraries (Catch2WithMain is always linked)
 #     [LABELS "label1;label2"]           # catch_discover_tests PROPERTIES LABELS
 #     [TIMEOUT seconds]                  # catch_discover_tests PROPERTIES TIMEOUT
+#     [PROPERTIES name value ...]        # additional catch_discover_tests PROPERTIES
 #     [INCLUDE_DIRS dir1 dir2 ...]       # extra include directories
 #     [COMPILE_DEFINITIONS def1 ...]     # extra compile definitions
 # )
 function(pulp_add_test_suite NAME)
     set(options "")
     set(oneValueArgs LABELS TIMEOUT)
-    set(multiValueArgs SOURCES LIBRARIES INCLUDE_DIRS COMPILE_DEFINITIONS)
+    set(multiValueArgs SOURCES LIBRARIES INCLUDE_DIRS COMPILE_DEFINITIONS PROPERTIES)
     cmake_parse_arguments(P "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     # Default source file: strip the conventional "pulp-test-" prefix and
@@ -57,16 +58,20 @@ function(pulp_add_test_suite NAME)
         target_compile_definitions(${NAME} PRIVATE ${P_COMPILE_DEFINITIONS})
     endif()
 
-    # Discover Catch2 cases. Pass LABELS / TIMEOUT through if set so
-    # downstream `ctest -L <label>` and per-suite timeouts keep working.
+    # Discover Catch2 cases. Pass LABELS / TIMEOUT / additional properties
+    # through if set so downstream `ctest -L <label>` and per-suite timeouts
+    # keep working.
     set(_discover_args "")
-    if(P_LABELS OR P_TIMEOUT)
+    if(P_LABELS OR P_TIMEOUT OR P_PROPERTIES)
         list(APPEND _discover_args PROPERTIES)
         if(P_LABELS)
             list(APPEND _discover_args LABELS "${P_LABELS}")
         endif()
         if(P_TIMEOUT)
             list(APPEND _discover_args TIMEOUT "${P_TIMEOUT}")
+        endif()
+        if(P_PROPERTIES)
+            list(APPEND _discover_args ${P_PROPERTIES})
         endif()
     endif()
     catch_discover_tests(${NAME} ${_discover_args})


### PR DESCRIPTION
## Summary
- move auto-release watchdog issue lookup/update paths from gh issue helpers to REST gh api calls
- fix the MSVC string-literal compile failure from #2626 in test_design_import.cpp
- serialize the network stream CTest cases and give the local HTTP readiness probe more scheduler slack after the macOS runner flaked waiting for /__ready
- document the CI gotchas in the ci skill
- switched GitHub Pages repo config from legacy main/docs to workflow deploy via REST so generated Pages checkout no longer clones the private planning submodule

## Local validation
- yamllint --no-warnings -d relaxed .github/workflows/auto-release-watchdog.yml .github/workflows/docs-deploy.yml
- python3 tools/import-validation/check-source-contracts.py --strict
- python3 tools/import-validation/test_source_contracts.py
- python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main
- python3 tools/scripts/version_bump_check.py --mode=report --base origin/main
- git diff --check origin/main..HEAD
- cmake -S . -B /tmp/pulp-cmake-check-2629 -DPULP_ENABLE_GPU=OFF -DPULP_TEXT_SHAPING=OFF -DPULP_BUILD_EXAMPLES=OFF -DPULP_ENABLE_SWIFT=OFF
- cmake --build /tmp/pulp-cmake-check-2629 --target pulp-test-network-stream -j$(sysctl -n hw.ncpu)
- ctest --test-dir /tmp/pulp-cmake-check-2629 -R "HttpStream reads successful GET responses in chunks|HttpStream POST factory exposes successful response bodies" --output-on-failure
- /tmp/pulp-cmake-check-2629/test/pulp-test-network-stream

Note: Shipyard local mac validation fails in this worktree because the local Skia payload is absent; GitHub CI is the authoritative workflow validation for this PR.