### PR TITLE
test(audio,midi,runtime): expand phase3 coverage batch

### DIFF
--- a/test/test_async_stream.cpp
+++ b/test/test_async_stream.cpp
@@ -449,6 +449,23 @@ TEST_CASE("CancellationToken sharing and idempotent cancel", "[async_stream]") {
     REQUIRE_FALSE(other.is_cancelled());
 }
 
+TEST_CASE("AsyncStream cancellation token mirrors stream cancellation",
+          "[async_stream][coverage][phase3]") {
+    auto backing = std::make_unique<TestStream>();
+    AsyncStream::Options opts;
+    opts.auto_read = false;
+    AsyncStream stream(std::move(backing), opts);
+
+    auto before = stream.cancellation_token();
+    auto again = stream.cancellation_token();
+    REQUIRE(before.shares(again));
+    REQUIRE_FALSE(before.is_cancelled());
+
+    stream.cancel();
+    REQUIRE(before.is_cancelled());
+    REQUIRE(stream.cancellation_token().is_cancelled());
+}
+
 TEST_CASE("AsyncStream executor routes callbacks off worker", "[async_stream]") {
     auto backing = std::make_unique<TestStream>();
     auto* raw = backing.get();

--- a/test/test_audio.cpp
+++ b/test/test_audio.cpp
@@ -575,6 +575,57 @@ TEST_CASE("CallbackContext defaults and sample position remain explicit",
     REQUIRE(block.sample_position == 4096);
 }
 
+TEST_CASE("AudioCallback receives stable context and writable output views",
+          "[audio][device][codecov]") {
+    CallbackContext defaults;
+    REQUIRE(defaults.sample_rate == 0.0);
+    REQUIRE(defaults.buffer_size == 0);
+    REQUIRE(defaults.sample_position == 0);
+
+    float in_left[3] = {0.25f, -0.5f, 1.0f};
+    float in_right[3] = {1.0f, 0.5f, -0.25f};
+    const float* input_channels[2] = {in_left, in_right};
+    float out_left[3] = {};
+    float out_right[3] = {};
+    float* output_channels[2] = {out_left, out_right};
+
+    BufferView<const float> input(input_channels, 2, 3);
+    BufferView<float> output(output_channels, 2, 3);
+    CallbackContext context;
+    context.sample_rate = 96000.0;
+    context.buffer_size = 3;
+    context.sample_position = 1024;
+
+    bool called = false;
+    AudioCallback callback = [&](const BufferView<const float>& in,
+                                 BufferView<float>& out,
+                                 const CallbackContext& ctx) {
+        called = true;
+        REQUIRE(ctx.sample_rate == 96000.0);
+        REQUIRE(ctx.buffer_size == 3);
+        REQUIRE(ctx.sample_position == 1024);
+        REQUIRE(in.num_channels() == 2);
+        REQUIRE(out.num_channels() == 2);
+        REQUIRE(in.num_samples() == 3);
+        REQUIRE(out.num_samples() == 3);
+
+        for (std::size_t sample = 0; sample < out.num_samples(); ++sample) {
+            out.channel(0)[sample] = in.channel(0)[sample] + in.channel(1)[sample];
+            out.channel(1)[sample] = in.channel(0)[sample] - in.channel(1)[sample];
+        }
+    };
+
+    callback(input, output, context);
+
+    REQUIRE(called);
+    REQUIRE(out_left[0] == 1.25f);
+    REQUIRE(out_left[1] == 0.0f);
+    REQUIRE(out_left[2] == 0.75f);
+    REQUIRE(out_right[0] == -0.75f);
+    REQUIRE(out_right[1] == -1.0f);
+    REQUIRE(out_right[2] == 1.25f);
+}
+
 TEST_CASE("ChannelSet maps standard layouts by count and name",
           "[audio][channel-set][issue-640]") {
     REQUIRE(ChannelSet::from_channel_count(0).name == "Discrete 0");

--- a/test/test_audio_edge_cases.cpp
+++ b/test/test_audio_edge_cases.cpp
@@ -27,6 +27,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <pulp/audio/frame_fill.hpp>
 #include <pulp/format/headless.hpp>
 
 #include <cmath>
@@ -65,6 +66,41 @@ void process_once(pulp::format::HeadlessHost& host,
 }
 
 }  // namespace
+
+TEST_CASE("Audio frame fill clamps partial reads and preserves valid samples",
+          "[audio][edges][frame-fill][codecov]") {
+    float buffer[] = {
+        1.0f, 2.0f,
+        3.0f, 4.0f,
+        5.0f, 6.0f,
+    };
+
+    pulp::audio::zero_fill_short_read(buffer, 2, 3, 2);
+
+    REQUIRE(buffer[0] == 1.0f);
+    REQUIRE(buffer[1] == 2.0f);
+    REQUIRE(buffer[2] == 3.0f);
+    REQUIRE(buffer[3] == 4.0f);
+    REQUIRE(buffer[4] == 0.0f);
+    REQUIRE(buffer[5] == 0.0f);
+
+    float negative_read[] = {7.0f, 8.0f, 9.0f, 10.0f};
+    pulp::audio::zero_fill_short_read(negative_read, -4, 2, 2);
+    REQUIRE(negative_read[0] == 0.0f);
+    REQUIRE(negative_read[1] == 0.0f);
+    REQUIRE(negative_read[2] == 0.0f);
+    REQUIRE(negative_read[3] == 0.0f);
+
+    float overfull_read[] = {11.0f, 12.0f};
+    pulp::audio::zero_fill_short_read(overfull_read, 8, 1, 2);
+    REQUIRE(overfull_read[0] == 11.0f);
+    REQUIRE(overfull_read[1] == 12.0f);
+
+    pulp::audio::zero_fill_short_read(nullptr, 0, 2, 2);
+    pulp::audio::zero_fill_short_read(overfull_read, 0, 2, 0);
+    REQUIRE(overfull_read[0] == 11.0f);
+    REQUIRE(overfull_read[1] == 12.0f);
+}
 
 // ── 1. Zero-length block is a safe no-op ─────────────────────────────
 

--- a/test/test_audio_focus.cpp
+++ b/test/test_audio_focus.cpp
@@ -17,6 +17,14 @@
 using pulp::audio::AudioFocusRegistry;
 using pulp::audio::AudioFocusState;
 
+namespace {
+
+AudioFocusRegistry::Token&& token_rvalue(AudioFocusRegistry::Token& token) {
+    return static_cast<AudioFocusRegistry::Token&&>(token);
+}
+
+} // namespace
+
 TEST_CASE("AudioFocusRegistry: default state is gained",
           "[audio][focus][issue-334]") {
     AudioFocusRegistry::instance().reset_for_test();
@@ -128,11 +136,14 @@ TEST_CASE("AudioFocusRegistry: token self move assignment preserves subscription
         [&](AudioFocusState) { ++count; });
     const int id = token.id();
 
-    auto& ref = token;
-    token = std::move(ref);
+    token = token_rvalue(token);
     REQUIRE(token.id() == id);
 
     AudioFocusRegistry::instance().publish(AudioFocusState::duck);
+    REQUIRE(count == 1);
+
+    token.reset();
+    AudioFocusRegistry::instance().publish(AudioFocusState::gained);
     REQUIRE(count == 1);
 }
 

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -114,6 +114,42 @@ LoopbackHttpExchange serve_loopback_http_response(std::string response_body) {
     return exchange;
 }
 
+LoopbackHttpExchange serve_loopback_http_status(int status_code, std::string response_body = {}) {
+    Socket server;
+    REQUIRE(server.create(SocketType::TCP));
+    REQUIRE(server.bind("127.0.0.1", 0));
+    REQUIRE(server.listen(1));
+    const auto port = server.local_port();
+    REQUIRE(port != 0);
+
+    LoopbackHttpExchange exchange;
+    exchange.base_url = "http://127.0.0.1:" + std::to_string(port);
+    auto request = exchange.request;
+    exchange.worker = std::thread([server = std::move(server),
+                                   status_code,
+                                   response_body = std::move(response_body),
+                                   request = std::move(request)]() mutable {
+        auto client = server.accept();
+        if (!client) return;
+
+        std::array<std::uint8_t, 2048> buffer{};
+        const auto received = client->receive(buffer.data(), buffer.size());
+        if (received > 0) {
+            request->assign(reinterpret_cast<const char*>(buffer.data()),
+                            static_cast<std::size_t>(received));
+        }
+
+        const auto reason = status_code >= 200 && status_code < 300 ? "OK" : "Rejected";
+        const std::string wire_response =
+            "HTTP/1.1 " + std::to_string(status_code) + " " + reason + "\r\n"
+            "Content-Type: application/json\r\n"
+            "Content-Length: " + std::to_string(response_body.size()) + "\r\n"
+            "Connection: close\r\n\r\n" + response_body;
+        (void) client->send(wire_response);
+    });
+    return exchange;
+}
+
 }  // namespace
 
 // ── BigInteger ──────────────────────────────────────────────────────────
@@ -692,6 +728,30 @@ TEST_CASE("OnlineActivation check_status maps loopback response bodies",
                 LicenseStatus::InvalidSignature);
         exchange.worker.join();
         REQUIRE(exchange.request->find("GET /status?key=rejected-key&machine=") != std::string::npos);
+    }
+}
+
+TEST_CASE("OnlineActivation treats non-2xx loopback responses as activation failures",
+          "[crypto][license][coverage][phase3]") {
+    {
+        auto exchange = serve_loopback_http_status(403, R"({"error":"denied"})");
+        REQUIRE_FALSE(OnlineActivation::activate(exchange.base_url, "serial", "product"));
+        exchange.worker.join();
+        REQUIRE(exchange.request->find("POST /activate HTTP/1.1") != std::string::npos);
+    }
+
+    {
+        auto exchange = serve_loopback_http_status(500, R"({"error":"server"})");
+        REQUIRE_FALSE(OnlineActivation::deactivate(exchange.base_url, "license"));
+        exchange.worker.join();
+        REQUIRE(exchange.request->find("POST /deactivate HTTP/1.1") != std::string::npos);
+    }
+
+    {
+        auto exchange = serve_loopback_http_status(404, R"({"status":"valid"})");
+        REQUIRE(OnlineActivation::check_status(exchange.base_url, "license") == LicenseStatus::NotFound);
+        exchange.worker.join();
+        REQUIRE(exchange.request->find("GET /status?key=license&machine=") != std::string::npos);
     }
 }
 

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -2,12 +2,15 @@
 #include <pulp/runtime/license.hpp>
 #include <pulp/runtime/big_integer.hpp>
 #include <pulp/runtime/base64.hpp>
+#include <pulp/runtime/socket.hpp>
 #include <pulp/runtime/temporary_file.hpp>
 #include "../external/cpp-httplib/httplib.h"
 
+#include <array>
 #include <chrono>
 #include <fstream>
 #include <limits>
+#include <memory>
 #include <thread>
 #include <utility>
 
@@ -39,6 +42,77 @@ struct LicenseHttpServerRunner {
     httplib::Server& server;
     std::thread thread;
 };
+
+}  // namespace
+
+namespace {
+
+struct LoopbackHttpExchange {
+    std::string base_url;
+    std::shared_ptr<std::string> request = std::make_shared<std::string>();
+    std::thread worker;
+
+    LoopbackHttpExchange() = default;
+    LoopbackHttpExchange(const LoopbackHttpExchange&) = delete;
+    LoopbackHttpExchange& operator=(const LoopbackHttpExchange&) = delete;
+    LoopbackHttpExchange(LoopbackHttpExchange&&) noexcept = default;
+    LoopbackHttpExchange& operator=(LoopbackHttpExchange&&) noexcept = default;
+
+    ~LoopbackHttpExchange() {
+        if (worker.joinable()) worker.join();
+    }
+};
+
+LoopbackHttpExchange serve_loopback_http_response(std::string response_body) {
+    Socket server;
+    REQUIRE(server.create(SocketType::TCP));
+    REQUIRE(server.bind("127.0.0.1", 0));
+    REQUIRE(server.listen(1));
+    const auto port = server.local_port();
+    REQUIRE(port != 0);
+
+    LoopbackHttpExchange exchange;
+    exchange.base_url = "http://127.0.0.1:" + std::to_string(port);
+    auto request = exchange.request;
+    exchange.worker = std::thread([server = std::move(server),
+                                   response_body = std::move(response_body),
+                                   request = std::move(request)]() mutable {
+        auto client = server.accept();
+        if (!client) return;
+
+        std::array<std::uint8_t, 2048> buffer{};
+        while (true) {
+            const auto received = client->receive(buffer.data(), buffer.size());
+            if (received <= 0) break;
+            request->append(reinterpret_cast<const char*>(buffer.data()),
+                            static_cast<std::size_t>(received));
+
+            const auto header_end = request->find("\r\n\r\n");
+            if (header_end == std::string::npos) continue;
+
+            std::size_t expected_body_size = 0;
+            const auto length_key = std::string("Content-Length: ");
+            const auto length_pos = request->find(length_key);
+            if (length_pos != std::string::npos) {
+                const auto start = length_pos + length_key.size();
+                const auto end = request->find("\r\n", start);
+                expected_body_size =
+                    static_cast<std::size_t>(std::stoul(request->substr(start, end - start)));
+            }
+
+            const auto body_size = request->size() - (header_end + 4);
+            if (body_size >= expected_body_size) break;
+        }
+
+        const std::string wire_response =
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Type: application/json\r\n"
+            "Content-Length: " + std::to_string(response_body.size()) + "\r\n"
+            "Connection: close\r\n\r\n" + response_body;
+        (void) client->send(wire_response);
+    });
+    return exchange;
+}
 
 }  // namespace
 
@@ -569,6 +643,56 @@ TEST_CASE("OnlineActivation treats empty server URL as failed request",
     REQUIRE_FALSE(OnlineActivation::activate("", "serial", "product"));
     REQUIRE_FALSE(OnlineActivation::deactivate("", "license"));
     REQUIRE(OnlineActivation::check_status("", "license") == LicenseStatus::NotFound);
+}
+
+TEST_CASE("OnlineActivation activate returns loopback license response",
+          "[crypto][license][coverage][phase3]") {
+    auto exchange = serve_loopback_http_response("license-key");
+
+    auto license = OnlineActivation::activate(exchange.base_url, "serial-123", "PulpSynth");
+    exchange.worker.join();
+
+    REQUIRE(license.has_value());
+    REQUIRE(*license == "license-key");
+    REQUIRE(exchange.request->find("POST /activate HTTP/1.1") != std::string::npos);
+    REQUIRE(exchange.request->find(R"("serial":"serial-123")") != std::string::npos);
+    REQUIRE(exchange.request->find(R"("product":"PulpSynth")") != std::string::npos);
+}
+
+TEST_CASE("OnlineActivation deactivate accepts successful loopback response",
+          "[crypto][license][coverage][phase3]") {
+    auto exchange = serve_loopback_http_response(R"({"ok":true})");
+
+    REQUIRE(OnlineActivation::deactivate(exchange.base_url, "license-key"));
+    exchange.worker.join();
+
+    REQUIRE(exchange.request->find("POST /deactivate HTTP/1.1") != std::string::npos);
+    REQUIRE(exchange.request->find(R"("key":"license-key")") != std::string::npos);
+}
+
+TEST_CASE("OnlineActivation check_status maps loopback response bodies",
+          "[crypto][license][coverage][phase3]") {
+    {
+        auto exchange = serve_loopback_http_response(R"({"status":"valid"})");
+        REQUIRE(OnlineActivation::check_status(exchange.base_url, "valid-key") == LicenseStatus::Valid);
+        exchange.worker.join();
+        REQUIRE(exchange.request->find("GET /status?key=valid-key&machine=") != std::string::npos);
+    }
+
+    {
+        auto exchange = serve_loopback_http_response(R"({"status":"expired"})");
+        REQUIRE(OnlineActivation::check_status(exchange.base_url, "expired-key") == LicenseStatus::Expired);
+        exchange.worker.join();
+        REQUIRE(exchange.request->find("GET /status?key=expired-key&machine=") != std::string::npos);
+    }
+
+    {
+        auto exchange = serve_loopback_http_response(R"({"status":"rejected"})");
+        REQUIRE(OnlineActivation::check_status(exchange.base_url, "rejected-key") ==
+                LicenseStatus::InvalidSignature);
+        exchange.worker.join();
+        REQUIRE(exchange.request->find("GET /status?key=rejected-key&machine=") != std::string::npos);
+    }
 }
 
 TEST_CASE("LicenseGenerator requires a usable private key", "[crypto][license]") {

--- a/test/test_memory_message_channel.cpp
+++ b/test/test_memory_message_channel.cpp
@@ -188,6 +188,9 @@ TEST_CASE("MemoryMessageChannel accepts empty null binary sends",
     REQUIRE(received.size() == 1);
     REQUIRE(received.front().kind == MessageKind::Binary);
     REQUIRE(received.front().payload.empty());
+    REQUIRE(received.front().as_text().empty());
+    REQUIRE(left->is_open());
+    REQUIRE(right->is_open());
 }
 
 TEST_CASE("MemoryMessageChannel can clear callbacks while remaining open",

--- a/test/test_midi.cpp
+++ b/test/test_midi.cpp
@@ -312,6 +312,22 @@ TEST_CASE("MidiBuffer stores independent SysEx sidecar events",
     REQUIRE(buffer.empty());
 }
 
+TEST_CASE("MidiBuffer clear preserves SysEx sidecar until explicit clear",
+          "[midi][buffer][sysex][coverage][phase3]") {
+    MidiBuffer buffer;
+    buffer.add(MidiEvent::note_on(0, 60, 100));
+    buffer.add_sysex({0xF0, 0x7D, 0x02, 0xF7}, 32, 1.0);
+
+    buffer.clear();
+
+    REQUIRE(buffer.empty());
+    REQUIRE(buffer.sysex_size() == 1);
+    REQUIRE(buffer.sysex()[0].sample_offset == 32);
+
+    buffer.clear_sysex();
+    REQUIRE(buffer.sysex_size() == 0);
+}
+
 TEST_CASE("MidiKeyboardState tracks notes and releases with callbacks",
           "[midi][keyboard][codecov]") {
     MidiKeyboardState keys;

--- a/test/test_midi.cpp
+++ b/test/test_midi.cpp
@@ -2,6 +2,7 @@
 #include <catch2/catch_approx.hpp>
 #include <pulp/midi/midi.hpp>
 #include <pulp/midi/mpe_buffer.hpp>
+#include <pulp/midi/device.hpp>
 #include <pulp/midi/midi_file.hpp>
 #include <pulp/midi/midi_message_sequence.hpp>
 #include <pulp/midi/ump_buffer.hpp>
@@ -30,6 +31,33 @@ struct TempDir {
     ~TempDir() {
         std::error_code ec;
         fs::remove_all(path, ec);
+    }
+};
+
+class NoopMidiInput final : public MidiInput {
+public:
+    bool open(const std::string&, MidiInputCallback) override { return false; }
+    void close() override {}
+    bool is_open() const override { return false; }
+};
+
+class NoopMidiOutput final : public MidiOutput {
+public:
+    bool open(const std::string&) override { return false; }
+    void close() override {}
+    bool is_open() const override { return false; }
+    void send(const MidiEvent&) override {}
+};
+
+class DefaultHookMidiSystem final : public MidiSystem {
+public:
+    std::vector<MidiPortInfo> enumerate_inputs() override { return {}; }
+    std::vector<MidiPortInfo> enumerate_outputs() override { return {}; }
+    std::unique_ptr<MidiInput> create_input() override {
+        return std::make_unique<NoopMidiInput>();
+    }
+    std::unique_ptr<MidiOutput> create_output() override {
+        return std::make_unique<NoopMidiOutput>();
     }
 };
 
@@ -183,6 +211,32 @@ TEST_CASE("MidiEvent factory methods mask MIDI data-byte boundaries",
         auto evt = MidiEvent::pitch_bend(4, 0xFFFF);
         require_bytes(evt, 0xE4, 0x7F, 0x7F);
     }
+}
+
+TEST_CASE("MIDI device defaults expose safe no-op extension hooks",
+          "[midi][device][codecov]") {
+    MidiPortInfo info;
+    REQUIRE(info.id.empty());
+    REQUIRE(info.name.empty());
+    REQUIRE_FALSE(info.is_input);
+    REQUIRE_FALSE(info.is_output);
+
+    NoopMidiInput input;
+    input.set_sysex_callback([](const std::vector<uint8_t>&, double) {
+        FAIL("base MidiInput sysex hook should not invoke callbacks");
+    });
+    input.set_sysex_callback({});
+    REQUIRE_FALSE(input.is_open());
+
+    DefaultHookMidiSystem system;
+    int callbacks = 0;
+    system.set_port_change_callback([&] { ++callbacks; });
+    system.set_port_change_callback({});
+    REQUIRE(callbacks == 0);
+    REQUIRE(system.enumerate_inputs().empty());
+    REQUIRE(system.enumerate_outputs().empty());
+    REQUIRE(system.create_input() != nullptr);
+    REQUIRE(system.create_output() != nullptr);
 }
 
 TEST_CASE("MidiBuffer operations", "[midi][buffer]") {

--- a/test/test_midi_ci.cpp
+++ b/test/test_midi_ci.cpp
@@ -515,3 +515,40 @@ TEST_CASE("CiDiscovery profile reply lists enabled and disabled profiles",
     REQUIRE(reply[27] == disabled.reserved);
     REQUIRE(reply[28] == 0xF7);
 }
+
+TEST_CASE("CiDiscovery profile reply encodes multi-byte profile counts",
+          "[midi][ci][codecov]") {
+    CiDiscovery responder;
+    for (int i = 0; i < 130; ++i) {
+        responder.add_profile({
+            ProfileId{0x01, static_cast<uint8_t>(i & 0x7F), 0x00, 0x00, 0x00},
+            true,
+            0,
+        });
+    }
+    for (int i = 0; i < 129; ++i) {
+        responder.add_profile({
+            ProfileId{0x02, static_cast<uint8_t>(i & 0x7F), 0x00, 0x00, 0x00},
+            false,
+            0,
+        });
+    }
+
+    auto inquiry = make_ci_header(CiMessageType::ProfileInquiry,
+                                  MUID{0x00013579}, responder.local_muid());
+    inquiry.push_back(0xF7);
+
+    auto reply = responder.process_message(inquiry.data(), inquiry.size());
+
+    constexpr std::size_t enabled_count_offset = 14;
+    constexpr std::size_t enabled_profile_bytes = 130 * 5;
+    constexpr std::size_t disabled_count_offset =
+        enabled_count_offset + 2 + enabled_profile_bytes;
+
+    REQUIRE(reply.size() == disabled_count_offset + 2 + 129 * 5 + 1);
+    REQUIRE(reply[enabled_count_offset] == 2);
+    REQUIRE(reply[enabled_count_offset + 1] == 1);
+    REQUIRE(reply[disabled_count_offset] == 1);
+    REQUIRE(reply[disabled_count_offset + 1] == 1);
+    REQUIRE(reply.back() == 0xF7);
+}

--- a/test/test_mpe_buffer.cpp
+++ b/test/test_mpe_buffer.cpp
@@ -146,6 +146,23 @@ TEST_CASE("MpeConfig identifies lower and upper zone member boundaries",
     REQUIRE(cfg.zone_for_channel(12) == nullptr);
 }
 
+TEST_CASE("MpeZone rejects disabled and non-standard manager layouts",
+          "[midi][mpe][codecov]") {
+    MpeZone disabled_lower{0, 0};
+    REQUIRE(disabled_lower.is_lower());
+    REQUIRE_FALSE(disabled_lower.contains_channel(1));
+
+    MpeZone disabled_upper{15, 0};
+    REQUIRE(disabled_upper.is_upper());
+    REQUIRE_FALSE(disabled_upper.contains_channel(14));
+
+    MpeZone custom_manager{7, 4};
+    REQUIRE_FALSE(custom_manager.is_lower());
+    REQUIRE_FALSE(custom_manager.is_upper());
+    REQUIRE_FALSE(custom_manager.contains_channel(7));
+    REQUIRE_FALSE(custom_manager.contains_channel(8));
+}
+
 TEST_CASE("MpeVoiceTracker seeds new notes from cached member expression",
           "[midi][mpe][issue-645]") {
     MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};

--- a/test/test_mpe_synth_voice.cpp
+++ b/test/test_mpe_synth_voice.cpp
@@ -286,6 +286,25 @@ TEST_CASE("MpeGlideDetector flags overlap on same channel", "[midi][mpe]") {
     REQUIRE_FALSE(glide.channel_held(1));
 }
 
+TEST_CASE("MpeGlideDetector ignores unmatched releases and reset clears channels",
+          "[midi][mpe][codecov]") {
+    MpeGlideDetector glide;
+    MpeNoteState note;
+    note.channel = 9;
+    note.note = 72;
+    note.note_id = 90;
+
+    glide.observe_note_off(note);
+    REQUIRE_FALSE(glide.channel_held(9));
+
+    REQUIRE_FALSE(glide.observe_note_on(note));
+    REQUIRE(glide.channel_held(9));
+
+    glide.reset();
+    REQUIRE_FALSE(glide.channel_held(9));
+    REQUIRE_FALSE(glide.observe_note_on(note));
+}
+
 TEST_CASE("MpeVoiceAllocator reports last_was_glide", "[midi][mpe]") {
     MpeVoiceAllocator<TestVoice> alloc{4};
     alloc.dispatch(note_on_event(1, 60, 100, 1));

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -106,7 +106,26 @@ std::optional<std::uint16_t> try_bind_udp(Socket& socket,
     return std::nullopt;
 }
 
-std::string receive_http_headers(Socket& socket) {
+std::size_t content_length_from_headers(const std::string& request) {
+    const auto header_end = request.find("\r\n\r\n");
+    const auto length_key = std::string("Content-Length: ");
+    const auto length_pos = request.find(length_key);
+    if (header_end == std::string::npos || length_pos == std::string::npos)
+        return 0;
+
+    const auto start = length_pos + length_key.size();
+    const auto end = request.find("\r\n", start);
+    if (end == std::string::npos || end > header_end)
+        return 0;
+
+    try {
+        return static_cast<std::size_t>(std::stoul(request.substr(start, end - start)));
+    } catch (...) {
+        return 0;
+    }
+}
+
+std::string receive_http_request(Socket& socket) {
     std::string request;
     std::array<std::uint8_t, 256> buffer{};
     while (request.size() < 16 * 1024) {
@@ -114,7 +133,11 @@ std::string receive_http_headers(Socket& socket) {
         if (received <= 0) break;
         request.append(reinterpret_cast<const char*>(buffer.data()),
                        static_cast<std::size_t>(received));
-        if (request.find("\r\n\r\n") != std::string::npos) break;
+        const auto header_end = request.find("\r\n\r\n");
+        if (header_end == std::string::npos) continue;
+
+        const auto body_size = request.size() - (header_end + 4);
+        if (body_size >= content_length_from_headers(request)) break;
     }
     return request;
 }
@@ -926,7 +949,7 @@ TEST_CASE("http_get defaults missing URL path to slash",
         auto accepted = listener.accept();
         if (!accepted) return;
 
-        const auto request_text = receive_http_headers(*accepted);
+        const auto request_text = receive_http_request(*accepted);
         saw_root_path.store(request_text.find("GET /") != std::string::npos);
 
         const std::string response =
@@ -963,7 +986,7 @@ TEST_CASE("HttpStream post factory reads a successful local response",
         auto accepted = listener.accept();
         if (!accepted) return;
 
-        const auto request_text = receive_http_headers(*accepted);
+        const auto request_text = receive_http_request(*accepted);
         saw_post.store(request_text.find("POST /submit") != std::string::npos &&
                        request_text.find("application/json") != std::string::npos);
         const std::string response =
@@ -979,7 +1002,7 @@ TEST_CASE("HttpStream post factory reads a successful local response",
     while (!server_ready.load()) std::this_thread::sleep_for(1ms);
 
     auto stream = HttpStream::post("http://127.0.0.1:" + std::to_string(*port) + "/submit",
-                                   R"({"ok":true})", "application/json", 2);
+                                   R"({"ok":true})", "application/json", 10);
     REQUIRE(stream);
     REQUIRE(stream->status_code() == 201);
     REQUIRE(stream->transport_error().empty());

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -158,6 +158,22 @@ TEST_CASE("IPv4 validation accepts private network examples",
     REQUIRE(is_valid_ipv4("169.254.10.20"));
 }
 
+TEST_CASE("IPv4 validation rejects non-canonical numeric address forms",
+          "[network_stream][ip-address][coverage][phase3]") {
+    REQUIRE_FALSE(is_valid_ipv4("127.1"));
+    REQUIRE_FALSE(is_valid_ipv4("127.0.1"));
+    REQUIRE_FALSE(is_valid_ipv4("0300.0250.0001.0001"));
+    REQUIRE_FALSE(is_valid_ipv4("0xc0.0xa8.0x01.0x01"));
+    REQUIRE_FALSE(is_valid_ipv4("3232235777"));
+}
+
+TEST_CASE("IPv4 validation accepts canonical public resolver examples",
+          "[network_stream][ip-address][coverage][phase3]") {
+    REQUIRE(is_valid_ipv4("1.1.1.1"));
+    REQUIRE(is_valid_ipv4("8.8.8.8"));
+    REQUIRE(is_valid_ipv4("9.9.9.9"));
+}
+
 TEST_CASE("local IPv4 helpers return valid fallback or interface addresses",
           "[network_stream][ip-address][issue-641]") {
     auto addresses = local_ipv4_addresses();

--- a/test/test_preset_manager.cpp
+++ b/test/test_preset_manager.cpp
@@ -603,10 +603,12 @@ TEST_CASE("PresetManager import of duplicate destination preserves existing pres
     setup_test_store(store);
     PresetManager pm(store, "TestCo", "TestPlugin");
 
+    store.set_value(1, -6.0f);
+    store.set_value(2, 80.0f);
     REQUIRE(pm.save("Imported"));
 
     const auto external = sandbox.root / "external" / "Imported.json";
-    write_text_file(external, R"json({"parameters":{"Gain":-9}})json");
+    write_text_file(external, R"json({"parameters":{"Gain":-30,"Mix":20}})json");
 
     int list_changes = 0;
     pm.on_list_changed = [&] { ++list_changes; };
@@ -615,13 +617,15 @@ TEST_CASE("PresetManager import of duplicate destination preserves existing pres
 
     REQUIRE(imported.has_value());
     REQUIRE(imported->name == "Imported");
+    REQUIRE(imported->path == pm.user_presets_dir() / "Imported.json");
     REQUIRE(list_changes == 1);
     REQUIRE(pm.user_presets().size() == 1);
 
     store.set_value(1, 0.0f);
-    auto listed = require_user_preset(pm, "Imported");
-    REQUIRE(pm.load(listed));
-    REQUIRE(store.get_value(1) == Catch::Approx(0.0f));
+    store.set_value(2, 0.0f);
+    REQUIRE(pm.load(*imported));
+    REQUIRE(store.get_value(1) == Catch::Approx(-6.0f));
+    REQUIRE(store.get_value(2) == Catch::Approx(80.0f));
 }
 
 TEST_CASE("PresetManager rename failure leaves current preset unchanged",

--- a/test/test_properties_file.cpp
+++ b/test/test_properties_file.cpp
@@ -160,6 +160,21 @@ TEST_CASE("PropertiesFile bool getter accepts true and numeric-one strings",
     REQUIRE_FALSE(props.get_bool("other_text").value_or(true));
 }
 
+TEST_CASE("PropertiesFile bool getter requires exact true tokens",
+          "[state][properties][coverage][phase3-large]") {
+    PropertiesFile props;
+    props.set_string("upper_true", "TRUE");
+    props.set_string("title_true", "True");
+    props.set_string("spaced_true", " true");
+    props.set_string("spaced_one", "1 ");
+
+    REQUIRE(props.get_bool("upper_true").has_value());
+    REQUIRE_FALSE(props.get_bool("upper_true").value_or(true));
+    REQUIRE_FALSE(props.get_bool("title_true").value_or(true));
+    REQUIRE_FALSE(props.get_bool("spaced_true").value_or(true));
+    REQUIRE_FALSE(props.get_bool("spaced_one").value_or(true));
+}
+
 TEST_CASE("PropertiesFile remove", "[state][properties]") {
     PropertiesFile props;
     props.set_string("key", "value");

--- a/test/test_raw_midi_parser.cpp
+++ b/test/test_raw_midi_parser.cpp
@@ -453,6 +453,18 @@ TEST_CASE("raw_midi_parser recovers from aborted sysex (#406 codex P2)",
     REQUIRE(c.sysex[0] == std::vector<uint8_t>{0xF0, 0x01, 0xF7});
 }
 
+TEST_CASE("raw_midi_parser restarts sysex on nested start byte",
+          "[midi][raw_midi_parser][coverage][phase3]") {
+    auto c = parse({
+        0xF0, 0x7E, 0x00,  // abandoned sysex prefix
+        0xF0, 0x01, 0xF7,  // fresh complete sysex
+    });
+
+    REQUIRE(c.shorts.empty());
+    REQUIRE(c.sysex.size() == 1);
+    REQUIRE(c.sysex[0] == std::vector<uint8_t>{0xF0, 0x01, 0xF7});
+}
+
 TEST_CASE("raw_midi_parser aborted sysex handles system-common too",
           "[midi][raw_midi_parser][issue-406]") {
     // 0xF1 (MTC Quarter Frame) is a 2-byte system-common status that

--- a/test/test_running_status.cpp
+++ b/test/test_running_status.cpp
@@ -248,6 +248,29 @@ TEST_CASE("all realtime status bytes emit immediately",
     REQUIRE(v[7].status == 0xFF);
 }
 
+TEST_CASE("reserved real-time bytes preserve running status",
+          "[midi][running-status][codecov]") {
+    auto v = parse({
+        0x90, 0x3C, 0x7F,
+        0xF9,
+        0x3D, 0x40,
+        0xFD,
+        0x3E, 0x41,
+    });
+
+    REQUIRE(v.size() == 5);
+    REQUIRE(v[0].status == 0x90);
+    REQUIRE(v[0].d1 == 0x3C);
+    REQUIRE(v[1].status == 0xF9);
+    REQUIRE(v[2].status == 0x90);
+    REQUIRE(v[2].d1 == 0x3D);
+    REQUIRE(v[2].d2 == 0x40);
+    REQUIRE(v[3].status == 0xFD);
+    REQUIRE(v[4].status == 0x90);
+    REQUIRE(v[4].d1 == 0x3E);
+    REQUIRE(v[4].d2 == 0x41);
+}
+
 TEST_CASE("sysex is delivered separately; cancels running status",
           "[midi][running-status]") {
     RunningStatusParser p;

--- a/test/test_running_status.cpp
+++ b/test/test_running_status.cpp
@@ -553,6 +553,35 @@ TEST_CASE("reset() clears pending system-common state",
     REQUIRE(shorts.empty());
 }
 
+TEST_CASE("reset clears pending sysex payload",
+          "[midi][running-status][coverage][phase3]") {
+    RunningStatusParser p;
+    int sysex_count = 0;
+    std::vector<Captured> shorts;
+    p.on_sysex([&](const uint8_t*, std::size_t) {
+        ++sysex_count;
+    });
+    p.on_short_message([&](const MidiEvent& e) {
+        const auto& m = e.message;
+        shorts.push_back({m.data()[0],
+                          m.length() > 1 ? m.data()[1] : uint8_t(0),
+                          m.length() > 2 ? m.data()[2] : uint8_t(0)});
+    });
+
+    const uint8_t start_sysex[] = {0xF0, 0x7E, 0x7F};
+    p.feed(start_sysex, sizeof(start_sysex));
+    p.reset();
+
+    const uint8_t tail_and_note[] = {0x06, 0x01, 0xF7, 0x90, 0x3C, 0x7F};
+    p.feed(tail_and_note, sizeof(tail_and_note));
+
+    REQUIRE(sysex_count == 0);
+    REQUIRE(shorts.size() == 1);
+    REQUIRE(shorts[0].status == 0x90);
+    REQUIRE(shorts[0].d1 == 0x3C);
+    REQUIRE(shorts[0].d2 == 0x7F);
+}
+
 TEST_CASE("feed preserves partial channel message across calls",
           "[midi][running-status][coverage]") {
     RunningStatusParser p;

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -869,9 +869,12 @@ TEST_CASE("run_process honors working directory and preserves spaced arguments",
 TEST_CASE("run_process rejects missing working directories",
           "[runtime][child_process][coverage][phase3]") {
 #if defined(_WIN32) || defined(__APPLE__) || defined(__linux__)
-    const auto missing_dir =
-        (std::filesystem::temp_directory_path()
-         / "pulp-run-process-missing-working-dir").string();
+    TemporaryFile marker(".missing-working-dir");
+    const auto missing_path = marker.path();
+    marker.release();
+    std::filesystem::remove(missing_path);
+
+    const auto missing_dir = missing_path.string();
     REQUIRE_FALSE(std::filesystem::exists(missing_dir));
 
 #ifdef _WIN32
@@ -1682,10 +1685,18 @@ TEST_CASE("HTTP download writes successful response bodies",
 
 TEST_CASE("HTTP download reports unwritable output paths after successful fetch",
           "[runtime][http][coverage][phase3]") {
-    const auto missing_dir_output =
-        (std::filesystem::temp_directory_path()
-         / "pulp-http-download-missing-dir"
-         / "artifact.bin").string();
+    TemporaryFile marker(".missing-http-dir");
+    const auto missing_dir = marker.path();
+    marker.release();
+    std::filesystem::remove(missing_dir);
+    auto cleanup = make_scope_guard([&] {
+        std::error_code ec;
+        std::filesystem::remove_all(missing_dir, ec);
+    });
+
+    const auto missing_dir_output = (missing_dir / "artifact.bin").string();
+    REQUIRE_FALSE(std::filesystem::exists(missing_dir));
+
     auto exchange = serve_one_http_response("DOWNLOAD", "/unwritable.bin", missing_dir_output);
 
     REQUIRE(exchange.accepted);

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -130,6 +130,21 @@ OneShotHttpResponse serve_one_http_response(std::string_view method,
     return exchange;
 }
 
+bool wait_until_http_ready(int port, std::chrono::milliseconds timeout = std::chrono::seconds(10)) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        httplib::Client client("127.0.0.1", port);
+        client.set_connection_timeout(0, 500000);
+        client.set_read_timeout(0, 500000);
+        if (auto response = client.Get("/__ready");
+            response && response->status == 204) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return false;
+}
+
 }  // namespace
 
 // ── ScopeGuard ─────────────────────────────────────────────────────────
@@ -1582,6 +1597,9 @@ TEST_CASE("HTTP helpers round-trip against a loopback server",
         response.set_header("X-Content-Type", request.get_header_value("Content-Type"));
         response.set_content(request.body, "text/plain");
     });
+    server.Get("/__ready", [](const httplib::Request&, httplib::Response& response) {
+        response.status = 204;
+    });
     server.Get("/download", [](const httplib::Request&, httplib::Response& response) {
         response.set_content(std::string("payload\0bytes", 13), "application/octet-stream");
     });
@@ -1601,30 +1619,31 @@ TEST_CASE("HTTP helpers round-trip against a loopback server",
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
     }
     REQUIRE(server.is_running());
+    REQUIRE(wait_until_http_ready(port));
 
     const auto base = std::string("http://127.0.0.1:") + std::to_string(port);
-    auto get_response = http_get(base + "/hello?name=agent", 2);
-    const auto get_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    auto get_response = http_get(base + "/hello?name=agent", 10);
+    const auto get_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(15);
     while (!get_response.ok() && std::chrono::steady_clock::now() < get_deadline) {
         std::this_thread::sleep_for(std::chrono::milliseconds(25));
-        get_response = http_get(base + "/hello?name=agent", 2);
+        get_response = http_get(base + "/hello?name=agent", 10);
     }
     REQUIRE(get_response.ok());
     REQUIRE(get_response.status_code == 200);
     REQUIRE(get_response.body == "hello");
     REQUIRE(get_response.headers.at("X-Pulp-Test") == "agent");
 
-    const auto root_response = http_get(base, 2);
+    const auto root_response = http_get(base, 10);
     REQUIRE(root_response.ok());
     REQUIRE(root_response.body == "root");
 
-    const auto post_response = http_post(base + "/echo", "body=42", "text/custom", 2);
+    const auto post_response = http_post(base + "/echo", "body=42", "text/custom", 10);
     REQUIRE(post_response.ok());
     REQUIRE(post_response.body == "body=42");
     REQUIRE(post_response.headers.at("X-Content-Type").find("text/custom") != std::string::npos);
 
     TemporaryFile downloaded(".bin");
-    REQUIRE(http_download(base + "/download", downloaded.path_string(), 2));
+    REQUIRE(http_download(base + "/download", downloaded.path_string(), 10));
     std::ifstream file(downloaded.path(), std::ios::binary);
     std::string bytes((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
     REQUIRE(bytes == std::string("payload\0bytes", 13));
@@ -1637,7 +1656,7 @@ TEST_CASE("HTTP helpers round-trip against a loopback server",
     auto cleanup_blocked_output = make_scope_guard([&] {
         std::filesystem::remove_all(blocked_path);
     });
-    REQUIRE_FALSE(http_download(base + "/download", blocked_path.string(), 2));
+    REQUIRE_FALSE(http_download(base + "/download", blocked_path.string(), 10));
 }
 
 TEST_CASE("HTTP helpers copy successful GET status body and headers",

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -836,9 +836,15 @@ TEST_CASE("run_process captures stdout and stderr from one child",
 
 TEST_CASE("run_process honors working directory and preserves spaced arguments",
           "[runtime][child_process][coverage][phase3]") {
-    const auto dir = std::filesystem::temp_directory_path()
-        / "pulp-runtime-run-process-working-dir";
-    std::filesystem::create_directories(dir);
+    TemporaryFile marker(".cwd");
+    const auto dir = marker.path();
+    marker.release();
+    std::filesystem::remove(dir);
+    REQUIRE(std::filesystem::create_directory(dir));
+    auto cleanup = make_scope_guard([&] {
+        std::error_code ec;
+        std::filesystem::remove_all(dir, ec);
+    });
 
 #ifdef _WIN32
     auto result = run_process(
@@ -858,9 +864,6 @@ TEST_CASE("run_process honors working directory and preserves spaced arguments",
     REQUIRE(result->exit_code == 0);
     REQUIRE(std::filesystem::exists(dir / "marker.txt"));
     REQUIRE(result->stdout_output.find("value with spaces") != std::string::npos);
-
-    std::error_code ec;
-    std::filesystem::remove(dir, ec);
 }
 
 TEST_CASE("run_process fails on nonexistent", "[runtime][child_process]") {

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -1642,7 +1642,7 @@ TEST_CASE("HTTP helpers copy successful GET status body and headers",
     auto exchange = serve_one_http_response("GET", "/status?ok=1");
 
     REQUIRE(exchange.accepted);
-    REQUIRE(exchange.request.find("GET /status?ok=1 HTTP/1.1") != std::string::npos);
+    REQUIRE(exchange.request.find("GET /status?ok=1") != std::string::npos);
     REQUIRE(exchange.response.error.empty());
     REQUIRE(exchange.response.status_code == 200);
     REQUIRE(exchange.response.ok());
@@ -1656,7 +1656,7 @@ TEST_CASE("HTTP helpers copy successful POST request bodies",
     auto exchange = serve_one_http_response("POST", "/submit", R"({"value":7})");
 
     REQUIRE(exchange.accepted);
-    REQUIRE(exchange.request.find("POST /submit HTTP/1.1") != std::string::npos);
+    REQUIRE(exchange.request.find("POST /submit") != std::string::npos);
     REQUIRE(exchange.request.find("Content-Type: application/json") != std::string::npos);
     REQUIRE(exchange.request.find(R"({"value":7})") != std::string::npos);
     REQUIRE(exchange.response.error.empty());
@@ -1671,7 +1671,7 @@ TEST_CASE("HTTP download writes successful response bodies",
 
     REQUIRE(exchange.accepted);
     REQUIRE(exchange.downloaded);
-    REQUIRE(exchange.request.find("GET /artifact.bin HTTP/1.1") != std::string::npos);
+    REQUIRE(exchange.request.find("GET /artifact.bin") != std::string::npos);
 
     std::ifstream file(output.path(), std::ios::binary);
     REQUIRE(file.good());
@@ -1690,7 +1690,7 @@ TEST_CASE("HTTP download reports unwritable output paths after successful fetch"
 
     REQUIRE(exchange.accepted);
     REQUIRE_FALSE(exchange.downloaded);
-    REQUIRE(exchange.request.find("GET /unwritable.bin HTTP/1.1") != std::string::npos);
+    REQUIRE(exchange.request.find("GET /unwritable.bin") != std::string::npos);
 }
 
 TEST_CASE("local IPv4 helpers return usable fallback values",

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -866,6 +866,27 @@ TEST_CASE("run_process honors working directory and preserves spaced arguments",
     REQUIRE(result->stdout_output.find("value with spaces") != std::string::npos);
 }
 
+TEST_CASE("run_process rejects missing working directories",
+          "[runtime][child_process][coverage][phase3]") {
+#if defined(_WIN32) || defined(__APPLE__) || defined(__linux__)
+    const auto missing_dir =
+        (std::filesystem::temp_directory_path()
+         / "pulp-run-process-missing-working-dir").string();
+    REQUIRE_FALSE(std::filesystem::exists(missing_dir));
+
+#ifdef _WIN32
+    auto result = run_process("powershell",
+                              {"-NoProfile", "-Command", "Write-Output ignored"},
+                              missing_dir);
+#else
+    auto result = run_process("/bin/pwd", {}, missing_dir);
+#endif
+    REQUIRE_FALSE(result.has_value());
+#else
+    SUCCEED("This platform ignores run_process working_dir in the runtime helper.");
+#endif
+}
+
 TEST_CASE("run_process fails on nonexistent", "[runtime][child_process]") {
 #ifdef _WIN32
     auto result = run_process("C:\\nonexistent_binary_12345.exe");

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -13,10 +13,12 @@
 #include <pulp/runtime/range.hpp>
 #include <pulp/runtime/scope_guard.hpp>
 #include <pulp/runtime/scoped_no_alloc.hpp>
+#include <pulp/runtime/socket.hpp>
 #include <pulp/runtime/text_diff.hpp>
 #include "../external/cpp-httplib/httplib.h"
 #include <catch2/catch_approx.hpp>
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
 #include <fstream>
@@ -56,6 +58,73 @@ const char* system_library_symbol() {
 #else
     return "malloc";
 #endif
+}
+
+struct OneShotHttpResponse {
+    HttpResponse response;
+    std::string request;
+    bool accepted = false;
+};
+
+OneShotHttpResponse serve_one_http_response(std::string_view method,
+                                            std::string_view path,
+                                            std::string_view body = {}) {
+    Socket server;
+    REQUIRE(server.create(SocketType::TCP));
+    REQUIRE(server.bind("127.0.0.1", 0));
+    REQUIRE(server.listen(1));
+    const auto port = server.local_port();
+    REQUIRE(port != 0);
+
+    OneShotHttpResponse exchange;
+    std::thread worker([&] {
+        auto client = server.accept();
+        if (!client) return;
+
+        exchange.accepted = true;
+        std::array<std::uint8_t, 2048> buffer{};
+        while (true) {
+            const auto received = client->receive(buffer.data(), buffer.size());
+            if (received <= 0) break;
+            exchange.request.append(reinterpret_cast<const char*>(buffer.data()),
+                                    static_cast<std::size_t>(received));
+
+            const auto header_end = exchange.request.find("\r\n\r\n");
+            if (header_end == std::string::npos) continue;
+
+            std::size_t expected_body_size = 0;
+            const auto length_key = std::string("Content-Length: ");
+            const auto length_pos = exchange.request.find(length_key);
+            if (length_pos != std::string::npos) {
+                const auto start = length_pos + length_key.size();
+                const auto end = exchange.request.find("\r\n", start);
+                expected_body_size =
+                    static_cast<std::size_t>(std::stoul(exchange.request.substr(start, end - start)));
+            }
+
+            const auto body_size = exchange.request.size() - (header_end + 4);
+            if (body_size >= expected_body_size) break;
+        }
+
+        const std::string payload = "ok-response";
+        const std::string wire_response =
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Type: text/plain\r\n"
+            "X-Pulp-Test: loopback\r\n"
+            "Content-Length: " + std::to_string(payload.size()) + "\r\n"
+            "Connection: close\r\n\r\n" + payload;
+        (void)client->send(wire_response);
+    });
+
+    const auto url = "http://127.0.0.1:" + std::to_string(port) + std::string(path);
+    if (method == "POST") {
+        exchange.response = http_post(url, body, "application/json", 2);
+    } else {
+        exchange.response = http_get(url, 2);
+    }
+
+    worker.join();
+    return exchange;
 }
 
 }  // namespace
@@ -1539,6 +1608,33 @@ TEST_CASE("HTTP helpers round-trip against a loopback server",
         std::filesystem::remove_all(blocked_path);
     });
     REQUIRE_FALSE(http_download(base + "/download", blocked_path.string(), 2));
+}
+
+TEST_CASE("HTTP helpers copy successful GET status body and headers",
+          "[runtime][http][coverage][phase3]") {
+    auto exchange = serve_one_http_response("GET", "/status?ok=1");
+
+    REQUIRE(exchange.accepted);
+    REQUIRE(exchange.request.find("GET /status?ok=1 HTTP/1.1") != std::string::npos);
+    REQUIRE(exchange.response.error.empty());
+    REQUIRE(exchange.response.status_code == 200);
+    REQUIRE(exchange.response.ok());
+    REQUIRE(exchange.response.body == "ok-response");
+    REQUIRE(exchange.response.headers.at("Content-Type") == "text/plain");
+    REQUIRE(exchange.response.headers.at("X-Pulp-Test") == "loopback");
+}
+
+TEST_CASE("HTTP helpers copy successful POST request bodies",
+          "[runtime][http][coverage][phase3]") {
+    auto exchange = serve_one_http_response("POST", "/submit", R"({"value":7})");
+
+    REQUIRE(exchange.accepted);
+    REQUIRE(exchange.request.find("POST /submit HTTP/1.1") != std::string::npos);
+    REQUIRE(exchange.request.find("Content-Type: application/json") != std::string::npos);
+    REQUIRE(exchange.request.find(R"({"value":7})") != std::string::npos);
+    REQUIRE(exchange.response.error.empty());
+    REQUIRE(exchange.response.status_code == 200);
+    REQUIRE(exchange.response.body == "ok-response");
 }
 
 TEST_CASE("local IPv4 helpers return usable fallback values",

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -64,6 +64,7 @@ struct OneShotHttpResponse {
     HttpResponse response;
     std::string request;
     bool accepted = false;
+    bool downloaded = false;
 };
 
 OneShotHttpResponse serve_one_http_response(std::string_view method,
@@ -119,6 +120,8 @@ OneShotHttpResponse serve_one_http_response(std::string_view method,
     const auto url = "http://127.0.0.1:" + std::to_string(port) + std::string(path);
     if (method == "POST") {
         exchange.response = http_post(url, body, "application/json", 2);
+    } else if (method == "DOWNLOAD") {
+        exchange.downloaded = http_download(url, body, 2);
     } else {
         exchange.response = http_get(url, 2);
     }
@@ -1635,6 +1638,22 @@ TEST_CASE("HTTP helpers copy successful POST request bodies",
     REQUIRE(exchange.response.error.empty());
     REQUIRE(exchange.response.status_code == 200);
     REQUIRE(exchange.response.body == "ok-response");
+}
+
+TEST_CASE("HTTP download writes successful response bodies",
+          "[runtime][http][coverage][phase3]") {
+    TemporaryFile output(".http-body");
+    auto exchange = serve_one_http_response("DOWNLOAD", "/artifact.bin", output.path_string());
+
+    REQUIRE(exchange.accepted);
+    REQUIRE(exchange.downloaded);
+    REQUIRE(exchange.request.find("GET /artifact.bin HTTP/1.1") != std::string::npos);
+
+    std::ifstream file(output.path(), std::ios::binary);
+    REQUIRE(file.good());
+    const std::string contents((std::istreambuf_iterator<char>(file)),
+                               std::istreambuf_iterator<char>());
+    REQUIRE(contents == "ok-response");
 }
 
 TEST_CASE("local IPv4 helpers return usable fallback values",

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -1656,6 +1656,19 @@ TEST_CASE("HTTP download writes successful response bodies",
     REQUIRE(contents == "ok-response");
 }
 
+TEST_CASE("HTTP download reports unwritable output paths after successful fetch",
+          "[runtime][http][coverage][phase3]") {
+    const auto missing_dir_output =
+        (std::filesystem::temp_directory_path()
+         / "pulp-http-download-missing-dir"
+         / "artifact.bin").string();
+    auto exchange = serve_one_http_response("DOWNLOAD", "/unwritable.bin", missing_dir_output);
+
+    REQUIRE(exchange.accepted);
+    REQUIRE_FALSE(exchange.downloaded);
+    REQUIRE(exchange.request.find("GET /unwritable.bin HTTP/1.1") != std::string::npos);
+}
+
 TEST_CASE("local IPv4 helpers return usable fallback values",
           "[runtime][ip][coverage]") {
     const auto primary = local_ipv4_address();

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -173,17 +173,25 @@ TEST_CASE("ScopedNoAlloc state is thread-local",
     bool worker_initial_in_scope = true;
     int worker_nested_depth = -1;
     bool worker_nested_in_scope = false;
+    int worker_final_depth = -1;
+    bool worker_final_in_scope = true;
     std::thread worker([&] {
         worker_initial_depth = no_alloc_scope_depth();
         worker_initial_in_scope = is_in_no_alloc_scope();
-        ScopedNoAlloc worker_scope;
-        worker_nested_depth = no_alloc_scope_depth();
-        worker_nested_in_scope = is_in_no_alloc_scope();
+        {
+            ScopedNoAlloc worker_scope;
+            worker_nested_depth = no_alloc_scope_depth();
+            worker_nested_in_scope = is_in_no_alloc_scope();
+        }
+        worker_final_depth = no_alloc_scope_depth();
+        worker_final_in_scope = is_in_no_alloc_scope();
     });
     worker.join();
 
     REQUIRE(worker_initial_depth == 0);
     REQUIRE_FALSE(worker_initial_in_scope);
+    REQUIRE(worker_final_depth == 0);
+    REQUIRE_FALSE(worker_final_in_scope);
 #ifndef NDEBUG
     REQUIRE(no_alloc_scope_depth() == 1);
     REQUIRE(is_in_no_alloc_scope());

--- a/test/test_simd.cpp
+++ b/test/test_simd.cpp
@@ -160,6 +160,13 @@ TEST_CASE("simd operations handle empty input", "[simd]") {
     REQUIRE(simd_reduce_add(&dummy, 0) == 0.0f);
 }
 
+TEST_CASE("simd reductions return zero for empty max and min",
+          "[simd][coverage][phase3]") {
+    float dummy = 42.0f;
+    REQUIRE(simd_reduce_max(&dummy, 0) == 0.0f);
+    REQUIRE(simd_reduce_min(&dummy, 0) == 0.0f);
+}
+
 TEST_CASE("simd operations handle count=1", "[simd]") {
     float a = 3.0f, b = 4.0f, dst = 0.0f;
     simd_add(&a, &b, &dst, 1);

--- a/test/test_state.cpp
+++ b/test/test_state.cpp
@@ -960,6 +960,28 @@ TEST_CASE("StateStore empty serialization round-trips as a minimum frame",
                                                               data.size() - 1}));
 }
 
+TEST_CASE("StateStore deserialize ignores valid trailing payload extensions",
+          "[state][serialize][coverage][phase3-large]") {
+    StateStore source;
+    auto p1 = make_param_info(1, "One", "", {0.0f, 1.0f, 0.0f});
+    source.add_parameter(p1);
+    source.set_value(1, 0.5f);
+
+    auto data = source.serialize();
+    const auto old_crc_offset = data.size() - 4;
+    data.insert(data.begin() + static_cast<std::ptrdiff_t>(old_crc_offset),
+                {0xde, 0xad, 0xbe, 0xef});
+    const auto payload_size = data.size() - 4;
+    write_le_u32(data, payload_size, test_crc32(data.data(), payload_size));
+
+    StateStore target;
+    target.add_parameter(p1);
+    target.set_value(1, 0.25f);
+
+    REQUIRE(target.deserialize(data));
+    REQUIRE_THAT(target.get_value(1), WithinAbs(0.5, 0.001));
+}
+
 // ─── ListenerToken / thread routing (Slice 1) ───────────────────────────────
 
 TEST_CASE("ListenerToken removes its listener on destruction",

--- a/test/test_sync_primitives.cpp
+++ b/test/test_sync_primitives.cpp
@@ -112,6 +112,25 @@ TEST_CASE("SeqLock concurrent stress test", "[runtime][seqlock]") {
     REQUIRE(torn_reads.load() == 0);
 }
 
+TEST_CASE("SpscQueue failed push preserves queued item",
+          "[runtime][spsc][coverage][phase3]") {
+    SpscQueue<int, 1> q;
+
+    REQUIRE(q.empty());
+    REQUIRE(q.try_push(42));
+    REQUIRE_FALSE(q.empty());
+    REQUIRE(q.size_approx() == 1);
+
+    REQUIRE_FALSE(q.try_push(99));
+    REQUIRE(q.size_approx() == 1);
+
+    auto value = q.try_pop();
+    REQUIRE(value.has_value());
+    REQUIRE(*value == 42);
+    REQUIRE(q.empty());
+    REQUIRE_FALSE(q.try_pop().has_value());
+}
+
 // ── TripleBuffer tests ────────────────────────────────────────────────────
 
 TEST_CASE("TripleBuffer default constructor exposes value-initialized front buffer",

--- a/test/test_ump_buffer_conversion.cpp
+++ b/test/test_ump_buffer_conversion.cpp
@@ -25,6 +25,36 @@ TEST_CASE("UmpBuffer sort + clear", "[midi][ump]") {
     REQUIRE(buf.empty());
 }
 
+TEST_CASE("UmpBuffer accepts moved events and exposes const iteration",
+          "[midi][ump][coverage][phase3]") {
+    UmpBuffer buf;
+    UmpEvent event{UmpPacket::note_on_2(2, 3, 60, 0x4000), 48};
+    buf.add(std::move(event));
+
+    const UmpBuffer& view = buf;
+    int visited = 0;
+    for (const auto& item : view) {
+        REQUIRE(item.sample_offset == 48);
+        REQUIRE(item.packet.group() == 2);
+        REQUIRE(item.packet.channel() == 3);
+        ++visited;
+    }
+
+    REQUIRE(visited == 1);
+    REQUIRE(view[0].packet.note_number() == 60);
+}
+
+TEST_CASE("UmpPacket size_for_type covers supported packet classes",
+          "[midi][ump][coverage][phase3]") {
+    REQUIRE(UmpPacket::size_for_type(UmpMessageType::Utility) == 1);
+    REQUIRE(UmpPacket::size_for_type(UmpMessageType::System) == 1);
+    REQUIRE(UmpPacket::size_for_type(UmpMessageType::Midi1ChannelVoice) == 1);
+    REQUIRE(UmpPacket::size_for_type(UmpMessageType::DataSysEx) == 2);
+    REQUIRE(UmpPacket::size_for_type(UmpMessageType::Midi2ChannelVoice) == 2);
+    REQUIRE(UmpPacket::size_for_type(UmpMessageType::Data128) == 4);
+    REQUIRE(UmpPacket::size_for_type(static_cast<UmpMessageType>(0x0F)) == 1);
+}
+
 TEST_CASE("UmpPacket helper factories mask groups channels and data fields",
           "[midi][ump][helpers]") {
     auto note = UmpPacket::note_on_2(0x2F, 0x1E, 0xFF, 0x1234, 0x8F, 0xABCD);

--- a/test/test_xml_zip.cpp
+++ b/test/test_xml_zip.cpp
@@ -347,7 +347,9 @@ TEST_CASE("deflate compression levels round-trip edge settings",
 TEST_CASE("zip helpers reject malformed deflate and zlib input",
           "[runtime][zip][coverage][phase3-large]") {
     const uint8_t malformed[] = {0xde, 0xad, 0xbe, 0xef};
+    const std::vector<uint8_t> malformed_raw = {0xff, 0x00, 0x7a, 0x13, 0x42};
     REQUIRE_FALSE(deflate_decompress(malformed, sizeof(malformed)).has_value());
+    REQUIRE_FALSE(deflate_decompress(malformed_raw.data(), malformed_raw.size()).has_value());
     REQUIRE_FALSE(gzip_decompress(malformed, sizeof(malformed)).has_value());
 }
 


### PR DESCRIPTION
## Summary
- add audio, MIDI, state, runtime, HTTP, SIMD, sync, and parser coverage across 31 focused commits
- isolate temp-path failure cases flagged by review using unique TemporaryFile-derived paths
- rebase onto current main after #2635 so this run includes the latest CI/test hardening

## Local validation
- cmake --build build-gpu-off --target pulp-test-async-stream pulp-test-audio pulp-test-audio-edge-cases pulp-test-audio-focus pulp-test-license pulp-test-memory-message-channel pulp-test-midi pulp-test-midi-ci pulp-test-mpe-buffer pulp-test-mpe-synth-voice pulp-test-network-stream pulp-test-preset-manager pulp-test-properties pulp-test-raw-midi-parser pulp-test-running-status pulp-test-runtime-utils pulp-test-simd pulp-test-state pulp-test-sync pulp-test-ump-buffer-conversion pulp-test-xml-zip
- affected test binaries passed directly
- git diff --check origin/main...HEAD
- python3 tools/import-validation/check-source-contracts.py --strict
- python3 tools/import-validation/test_source_contracts.py
- python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main
- python3 tools/scripts/version_bump_check.py --mode=report --base origin/main