### PR TITLE
test(runtime): expand phase3 runtime coverage batch

### DIFF
--- a/test/test_async_stream.cpp
+++ b/test/test_async_stream.cpp
@@ -231,6 +231,33 @@ TEST_CASE("AsyncStream cancel drains pending writes with Closed", "[async_stream
     REQUIRE(last_err.load() == StreamError::Closed);
 }
 
+TEST_CASE("AsyncStream write on pre-closed stream completes without queuing",
+          "[async_stream][coverage][phase3]") {
+    auto backing = std::make_unique<TestStream>();
+    backing->close();
+
+    AsyncStream::Options opts;
+    opts.auto_read = false;
+    AsyncStream stream(std::move(backing), opts);
+
+    std::atomic<int> completions{0};
+    std::atomic<std::size_t> bytes{99};
+    std::atomic<StreamError> error{StreamError::Ok};
+
+    const std::uint8_t payload[] = {'c', 'l', 'o', 's', 'e', 'd'};
+    REQUIRE(stream.write_async(payload, sizeof(payload),
+                               [&](std::size_t n, StreamError err) {
+                                   bytes.store(n);
+                                   error.store(err);
+                                   completions.fetch_add(1);
+                               }));
+
+    REQUIRE(wait_until([&] { return completions.load() == 1; }));
+    REQUIRE(bytes.load() == 0);
+    REQUIRE(error.load() == StreamError::Closed);
+    REQUIRE(stream.pending_write_bytes() == 0);
+}
+
 TEST_CASE("AsyncStream cancel drains queue even before worker starts", "[async_stream]") {
     auto backing = std::make_unique<TestStream>();
     AsyncStream::Options opts;

--- a/test/test_child_process.cpp
+++ b/test/test_child_process.cpp
@@ -259,6 +259,38 @@ TEST_CASE("output capture respects max byte limits",
     REQUIRE(r.stderr_output == "123");
 }
 
+TEST_CASE("zero max output bytes drains without capturing lines",
+          "[child_process][edge][coverage][phase3]") {
+    std::vector<std::string> stdout_lines;
+    std::vector<std::string> stderr_lines;
+
+    ProcessOptions opts;
+    opts.timeout_ms = 5000;
+    opts.max_output_bytes = 0;
+    opts.on_stdout_line = [&](std::string_view line) {
+        stdout_lines.emplace_back(line);
+    };
+    opts.on_stderr_line = [&](std::string_view line) {
+        stderr_lines.emplace_back(line);
+    };
+
+#ifdef _WIN32
+    auto r = ChildProcess::run("cmd",
+        {"/c", "echo out-line& echo err-line 1>&2"},
+        opts);
+#else
+    auto r = ChildProcess::run("/bin/sh",
+        {"-c", "printf 'out-line\\n'; printf 'err-line\\n' >&2"},
+        opts);
+#endif
+
+    REQUIRE(r.exit_code == 0);
+    REQUIRE(r.stdout_output.empty());
+    REQUIRE(r.stderr_output.empty());
+    REQUIRE(stdout_lines.empty());
+    REQUIRE(stderr_lines.empty());
+}
+
 TEST_CASE("stderr line callback fires independently",
           "[child_process][edge][issue-640]") {
     std::vector<std::string> stdout_lines;

--- a/test/test_child_process.cpp
+++ b/test/test_child_process.cpp
@@ -336,6 +336,30 @@ TEST_CASE("line callback buffers partial stderr without trailing newline",
     REQUIRE(stderr_lines.empty());
 }
 
+TEST_CASE("move assignment transfers a running child process",
+          "[child_process][edge][coverage][phase3]") {
+    ChildProcess cp;
+
+#ifdef _WIN32
+    REQUIRE(cp.start("cmd", {"/c", "<nul set /p dummy=moved & exit /b 0"}));
+#else
+    REQUIRE(cp.start("/bin/sh", {"-c", "printf moved"}));
+#endif
+
+    ChildProcess moved;
+    moved = std::move(cp);
+
+    auto r = moved.wait();
+    REQUIRE(r.exit_code == 0);
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE_FALSE(r.was_cancelled);
+#ifdef _WIN32
+    REQUIRE(r.stdout_output.find("moved") != std::string::npos);
+#else
+    REQUIRE(r.stdout_output == "moved");
+#endif
+}
+
 TEST_CASE("wait is idempotent after process completion",
           "[child_process][edge][issue-640]") {
     ChildProcess cp;

--- a/test/test_child_process.cpp
+++ b/test/test_child_process.cpp
@@ -314,6 +314,28 @@ TEST_CASE("line callback buffers partial stdout without trailing newline",
     REQUIRE(stdout_lines.empty());
 }
 
+TEST_CASE("line callback buffers partial stderr without trailing newline",
+          "[child_process][edge][coverage][phase3]") {
+    std::vector<std::string> stderr_lines;
+    ProcessOptions opts;
+    opts.timeout_ms = 5000;
+    opts.on_stderr_line = [&](std::string_view line) {
+        stderr_lines.emplace_back(line);
+    };
+
+#ifdef _WIN32
+    auto r = ChildProcess::run("cmd",
+        {"/c", "<nul set /p dummy=partialerr 1>&2"},
+        opts);
+#else
+    auto r = ChildProcess::run("/bin/sh", {"-c", "printf partialerr >&2"}, opts);
+#endif
+
+    REQUIRE(r.exit_code == 0);
+    REQUIRE(r.stderr_output == "partialerr");
+    REQUIRE(stderr_lines.empty());
+}
+
 TEST_CASE("wait is idempotent after process completion",
           "[child_process][edge][issue-640]") {
     ChildProcess cp;

--- a/test/test_child_process.cpp
+++ b/test/test_child_process.cpp
@@ -360,6 +360,29 @@ TEST_CASE("move assignment transfers a running child process",
 #endif
 }
 
+TEST_CASE("move constructor transfers a running child process",
+          "[child_process][edge][coverage][phase3]") {
+    ChildProcess cp;
+
+#ifdef _WIN32
+    REQUIRE(cp.start("cmd", {"/c", "<nul set /p dummy=move-ctor & exit /b 0"}));
+#else
+    REQUIRE(cp.start("/bin/sh", {"-c", "printf move-ctor"}));
+#endif
+
+    ChildProcess moved(std::move(cp));
+
+    auto r = moved.wait();
+    REQUIRE(r.exit_code == 0);
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE_FALSE(r.was_cancelled);
+#ifdef _WIN32
+    REQUIRE(r.stdout_output.find("move-ctor") != std::string::npos);
+#else
+    REQUIRE(r.stdout_output == "move-ctor");
+#endif
+}
+
 TEST_CASE("wait is idempotent after process completion",
           "[child_process][edge][issue-640]") {
     ChildProcess cp;

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -1099,7 +1099,7 @@ TEST_CASE("pulp build allows explicit unsupported SDK bypass",
     const auto bin = fs::absolute(pulp_binary());
     auto cwd_saver = fs::current_path();
     fs::current_path(tmp);
-    auto r = exec(bin.string(), {"build", "--allow-unsupported-sdk"}, 10000);
+    auto r = exec(bin.string(), {"build", "--allow-unsupported-sdk"}, 30000);
     fs::current_path(cwd_saver);
     fs::remove_all(tmp);
 
@@ -1916,4 +1916,3 @@ TEST_CASE("PULP_DEBUG=1 surfaces phase markers to stderr (#682)",
 
     pulp_unsetenv("PULP_UPDATE_CHECK_DISABLED");
 }
-

--- a/test/test_ipc.cpp
+++ b/test/test_ipc.cpp
@@ -27,6 +27,18 @@ std::optional<uint16_t> start_socket_server_on_loopback(InterprocessConnectionSe
     return std::nullopt;
 }
 
+std::optional<uint16_t> start_socket_server_on_any_interface(InterprocessConnectionServer& server) {
+    const auto seed = static_cast<uint16_t>(
+        std::chrono::steady_clock::now().time_since_epoch().count() % 20000);
+    for (uint16_t i = 0; i < 200; ++i) {
+        const uint16_t port = static_cast<uint16_t>(20000 + ((seed + i) % 20000));
+        if (server.start(std::to_string(port), IpcTransport::Socket)) {
+            return port;
+        }
+    }
+    return std::nullopt;
+}
+
 struct CapturingServer : InterprocessConnectionServer {
     void client_connected(std::unique_ptr<InterprocessConnection> conn) override {
         conn->on_message = [this](const void*, size_t size) {
@@ -161,6 +173,21 @@ TEST_CASE("IPC socket server stops while waiting for a client",
     REQUIRE(port.has_value());
     REQUIRE(server.is_running());
 
+    server.stop();
+    REQUIRE_FALSE(server.is_running());
+}
+
+TEST_CASE("IPC socket server default callback owns accepted clients",
+          "[events][ipc][socket][codecov][phase3]") {
+    InterprocessConnectionServer server;
+    auto port = start_socket_server_on_any_interface(server);
+    REQUIRE(port.has_value());
+    REQUIRE(server.is_running());
+
+    InterprocessConnection client;
+    REQUIRE(client.connect("127.0.0.1:" + std::to_string(*port), IpcTransport::Socket));
+
+    client.disconnect();
     server.stop();
     REQUIRE_FALSE(server.is_running());
 }

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -946,3 +946,37 @@ TEST_CASE("JsonRpcPeer consumes responses for requests without callbacks",
     REQUIRE(wait_until([&] { return callbacks.load() == 1; }));
     REQUIRE(result == R"("ok")");
 }
+
+TEST_CASE("JsonRpcPeer escapes outbound method and notification names",
+          "[json_rpc][coverage][phase3]") {
+    auto pair = MemoryMessageChannel::make_pair();
+    JsonRpcPeer client(*pair.first);
+    JsonRpcPeer server(*pair.second);
+
+    const std::string request_name = R"(quote"slash\method)";
+    const std::string notification_name = R"(notify"slash\event)";
+
+    server.register_method(request_name, [](std::string_view params) {
+        REQUIRE(params.find(R"("ok")") != std::string_view::npos);
+        REQUIRE(params.find("true") != std::string_view::npos);
+        return JsonRpcResult::ok(R"("escaped")");
+    });
+
+    std::string notification_params = "unset";
+    server.on_notification(notification_name, [&](std::string_view params) {
+        notification_params = std::string(params);
+    });
+
+    std::atomic<int> callbacks{0};
+    std::string result;
+    REQUIRE(client.send_request(request_name, R"({"ok":true})",
+                                [&](const JsonRpcResult& response) {
+        result = response.result_json;
+        callbacks.fetch_add(1);
+    }));
+    REQUIRE(wait_until([&] { return callbacks.load() == 1; }));
+    REQUIRE(result == R"("escaped")");
+
+    REQUIRE(client.notify(notification_name, R"([1])"));
+    REQUIRE(wait_until([&] { return notification_params == "[1]"; }));
+}

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -269,6 +269,32 @@ TEST_CASE("JsonRpcPeer preserves string request ids and omits missing params",
     REQUIRE(captured_params.empty());
 }
 
+TEST_CASE("JsonRpcPeer destruction clears the channel message callback",
+          "[json_rpc][coverage][phase3]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    std::string reply;
+    pair.first->on_message([&](const Message& message) {
+        reply.assign(message.as_text());
+    });
+
+    {
+        JsonRpcPeer server(*pair.second);
+        server.register_method("ping", [](std::string_view) {
+            return JsonRpcResult::ok(R"("pong")");
+        });
+
+        REQUIRE(pair.first->send_text(
+            R"json({"jsonrpc":"2.0","id":1,"method":"ping"})json"));
+        REQUIRE(reply.find("pong") != std::string::npos);
+    }
+
+    reply.clear();
+    REQUIRE(pair.first->send_text(
+        R"json({"jsonrpc":"2.0","id":2,"method":"ping"})json"));
+    REQUIRE(reply.empty());
+}
+
 TEST_CASE("JsonRpcPeer serializes handler errors and exceptions", "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
     JsonRpcPeer client(*pair.first);

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -499,6 +499,34 @@ TEST_CASE("JsonRpcPeer dispatches incoming error responses with data",
     REQUIRE(error->data_json.find("false") != std::string::npos);
 }
 
+TEST_CASE("JsonRpcPeer defaults missing incoming error fields",
+          "[json_rpc][coverage][phase3]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    std::string outbound_request;
+    pair.second->on_message([&](const Message& message) {
+        outbound_request.assign(message.as_text());
+    });
+
+    JsonRpcPeer client(*pair.first);
+    std::atomic<bool> done{false};
+    std::optional<JsonRpcError> error;
+
+    REQUIRE(client.send_request("willFail", "[]", [&](const JsonRpcResult& response) {
+        error = response.error;
+        done.store(true);
+    }));
+    REQUIRE(outbound_request.find(R"("id":1)") != std::string::npos);
+
+    pair.second->send_text(R"json({"jsonrpc":"2.0","id":1,"error":{}})json");
+
+    REQUIRE(wait_until([&] { return done.load(); }));
+    REQUIRE(error.has_value());
+    REQUIRE(error->code == 0);
+    REQUIRE(error->message.empty());
+    REQUIRE(error->data_json.empty());
+}
+
 TEST_CASE("JsonRpcPeer replies to null id requests and notification gaps",
           "[json_rpc][coverage][phase3]") {
     auto pair = MemoryMessageChannel::make_pair();

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -888,3 +888,33 @@ TEST_CASE("JsonRpcPeer accepts binary JSON and default error envelopes",
     REQUIRE(default_error->message.empty());
     REQUIRE(default_error->data_json.empty());
 }
+
+TEST_CASE("JsonRpcPeer consumes responses for requests without callbacks",
+          "[json_rpc][coverage][phase3]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    std::vector<std::string> outbound;
+    pair.second->on_message([&](const Message& message) {
+        outbound.emplace_back(message.as_text());
+    });
+
+    JsonRpcPeer client(*pair.first);
+    REQUIRE(client.send_request("fireAndForget", "", {}));
+    REQUIRE(outbound.size() == 1);
+    REQUIRE(outbound.back().find(R"("id":1)") != std::string::npos);
+
+    pair.second->send_text(R"json({"jsonrpc":"2.0","id":1,"result":true})json");
+
+    std::atomic<int> callbacks{0};
+    std::string result;
+    REQUIRE(client.send_request("followup", "", [&](const JsonRpcResult& response) {
+        result = response.result_json;
+        callbacks.fetch_add(1);
+    }));
+    REQUIRE(outbound.size() == 2);
+    REQUIRE(outbound.back().find(R"("id":2)") != std::string::npos);
+
+    pair.second->send_text(R"json({"jsonrpc":"2.0","id":2,"result":"ok"})json");
+    REQUIRE(wait_until([&] { return callbacks.load() == 1; }));
+    REQUIRE(result == R"("ok")");
+}

--- a/test/test_memory_message_channel.cpp
+++ b/test/test_memory_message_channel.cpp
@@ -8,6 +8,40 @@
 
 using namespace pulp::runtime;
 
+namespace {
+
+class BinaryOnlyMessageChannel final : public MessageChannel {
+public:
+    bool send(const std::uint8_t* data, std::size_t size) override {
+        payload.assign(data, data + size);
+        return accepted;
+    }
+    void on_message(MessageCallback) override {}
+    void on_closed(ChannelClosedCallback) override {}
+    void on_error(ChannelErrorCallback) override {}
+    void close() override { open = false; }
+    bool is_open() const override { return open; }
+
+    std::vector<std::uint8_t> payload;
+    bool accepted = true;
+    bool open = true;
+};
+
+} // namespace
+
+TEST_CASE("MessageChannel default text send uses binary send",
+          "[runtime][message_channel][coverage][phase3]") {
+    BinaryOnlyMessageChannel channel;
+    MessageChannel& base = channel;
+
+    REQUIRE(base.send(std::string_view("plain-text")));
+    REQUIRE(channel.payload == std::vector<std::uint8_t>(
+                                   {'p', 'l', 'a', 'i', 'n', '-', 't', 'e', 'x', 't'}));
+
+    channel.accepted = false;
+    REQUIRE_FALSE(base.send(std::string_view("rejected")));
+}
+
 TEST_CASE("MemoryMessageChannel delivers binary payloads synchronously",
           "[runtime][message_channel]") {
     auto [left, right] = MemoryMessageChannel::make_pair();

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -883,6 +883,48 @@ TEST_CASE("HttpStream reads a successful local response body in chunks",
     REQUIRE(served.load());
 }
 
+TEST_CASE("http_get defaults missing URL path to slash",
+          "[network_stream][http][coverage][phase3]") {
+    Socket listener;
+    REQUIRE(listener.create(SocketType::TCP));
+    auto port = try_bind_loopback_ephemeral(listener);
+    REQUIRE(port);
+
+    std::atomic<bool> server_ready{false};
+    std::atomic<bool> saw_root_path{false};
+    std::thread server_thread([&] {
+        server_ready.store(true);
+        auto accepted = listener.accept();
+        if (!accepted) return;
+
+        std::array<std::uint8_t, 512> request{};
+        const int received = accepted->receive(request.data(), request.size());
+        if (received > 0) {
+            const std::string request_text(reinterpret_cast<const char*>(request.data()),
+                                           static_cast<std::size_t>(received));
+            saw_root_path.store(request_text.find("GET / HTTP/1.1") != std::string::npos);
+        }
+
+        const std::string response =
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Length: 4\r\n"
+            "\r\n"
+            "root";
+        accepted->send(reinterpret_cast<const std::uint8_t*>(response.data()),
+                       response.size());
+        accepted->close();
+    });
+    ThreadJoiner join_server{server_thread};
+    while (!server_ready.load()) std::this_thread::sleep_for(1ms);
+
+    const auto response = http_get("http://127.0.0.1:" + std::to_string(*port), 2);
+    REQUIRE(response.status_code == 200);
+    REQUIRE(response.body == "root");
+
+    join_server.join();
+    REQUIRE(saw_root_path.load());
+}
+
 TEST_CASE("HttpStream post factory reads a successful local response",
           "[network_stream][http][coverage][phase3]") {
     Socket listener;

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -881,6 +881,57 @@ TEST_CASE("HttpStream reads a successful local response body in chunks",
     REQUIRE(served.load());
 }
 
+TEST_CASE("HttpStream post factory reads a successful local response",
+          "[network_stream][http][coverage][phase3]") {
+    Socket listener;
+    REQUIRE(listener.create(SocketType::TCP));
+    auto port = try_bind_loopback_ephemeral(listener);
+    REQUIRE(port);
+
+    std::atomic<bool> server_ready{false};
+    std::atomic<bool> saw_post{false};
+    std::thread server_thread([&] {
+        server_ready.store(true);
+        auto accepted = listener.accept();
+        if (!accepted) return;
+
+        std::array<std::uint8_t, 1024> request{};
+        const int received = accepted->receive(request.data(), request.size());
+        if (received > 0) {
+            const std::string request_text(reinterpret_cast<const char*>(request.data()),
+                                           static_cast<std::size_t>(received));
+            saw_post.store(request_text.find("POST /submit HTTP/1.1") != std::string::npos &&
+                           request_text.find("application/json") != std::string::npos);
+        }
+        const std::string response =
+            "HTTP/1.1 201 Created\r\n"
+            "Content-Length: 6\r\n"
+            "\r\n"
+            "stored";
+        accepted->send(reinterpret_cast<const std::uint8_t*>(response.data()),
+                       response.size());
+        accepted->close();
+    });
+    ThreadJoiner join_server{server_thread};
+    while (!server_ready.load()) std::this_thread::sleep_for(1ms);
+
+    auto stream = HttpStream::post("http://127.0.0.1:" + std::to_string(*port) + "/submit",
+                                   R"({"ok":true})", "application/json", 2);
+    REQUIRE(stream);
+    REQUIRE(stream->status_code() == 201);
+    REQUIRE(stream->transport_error().empty());
+
+    std::array<std::uint8_t, 8> buffer{};
+    auto read = stream->read(buffer.data(), buffer.size());
+    REQUIRE(read.ok());
+    REQUIRE(read.bytes == 6);
+    REQUIRE(std::string(reinterpret_cast<const char*>(buffer.data()), read.bytes) == "stored");
+    REQUIRE(stream->eof());
+
+    join_server.join();
+    REQUIRE(saw_post.load());
+}
+
 TEST_CASE("HttpStream default state supports zero reads and idempotent close",
           "[network_stream][http][coverage][phase3]") {
     HttpStream stream;

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -822,6 +822,65 @@ TEST_CASE("HttpStream status_code is 0 before fetch",
     REQUIRE(stream.status_code() == 0);
 }
 
+TEST_CASE("HttpStream reads a successful local response body in chunks",
+          "[network_stream][http][coverage][phase3]") {
+    Socket listener;
+    REQUIRE(listener.create(SocketType::TCP));
+    auto port = try_bind_loopback_ephemeral(listener);
+    REQUIRE(port);
+
+    std::atomic<bool> server_ready{false};
+    std::atomic<bool> served{false};
+    std::thread server_thread([&] {
+        server_ready.store(true);
+        auto accepted = listener.accept();
+        if (!accepted) return;
+
+        std::array<std::uint8_t, 512> request{};
+        accepted->receive(request.data(), request.size());
+        const std::string response =
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Length: 5\r\n"
+            "X-Pulp-Test: yes\r\n"
+            "\r\n"
+            "hello";
+        accepted->send(reinterpret_cast<const std::uint8_t*>(response.data()),
+                       response.size());
+        accepted->close();
+        served.store(true);
+    });
+    ThreadJoiner join_server{server_thread};
+    while (!server_ready.load()) std::this_thread::sleep_for(1ms);
+
+    auto stream = HttpStream::get("http://127.0.0.1:" + std::to_string(*port) + "/ok", 2);
+    REQUIRE(stream);
+    REQUIRE(stream->status_code() == 200);
+    REQUIRE(stream->transport_error().empty());
+    REQUIRE(stream->headers().find("X-Pulp-Test") != stream->headers().end());
+    REQUIRE(stream->is_open());
+
+    std::array<std::uint8_t, 8> buffer{};
+    auto first = stream->read(buffer.data(), 2);
+    REQUIRE(first.ok());
+    REQUIRE(first.bytes == 2);
+    REQUIRE(std::string(reinterpret_cast<const char*>(buffer.data()), first.bytes) == "he");
+    REQUIRE(stream->is_open());
+
+    auto second = stream->read(buffer.data(), 8);
+    REQUIRE(second.ok());
+    REQUIRE(second.bytes == 3);
+    REQUIRE(std::string(reinterpret_cast<const char*>(buffer.data()), second.bytes) == "llo");
+    REQUIRE(stream->eof());
+    REQUIRE_FALSE(stream->is_open());
+
+    auto eof = stream->read(buffer.data(), buffer.size());
+    REQUIRE_FALSE(eof.ok());
+    REQUIRE(eof.closed());
+
+    join_server.join();
+    REQUIRE(served.load());
+}
+
 TEST_CASE("HttpStream default state supports zero reads and idempotent close",
           "[network_stream][http][coverage][phase3]") {
     HttpStream stream;

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -10,6 +10,8 @@
 #include <atomic>
 #include <chrono>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
 #include <optional>
 #include <string>
 #include <thread>
@@ -930,6 +932,51 @@ TEST_CASE("HttpStream post factory reads a successful local response",
 
     join_server.join();
     REQUIRE(saw_post.load());
+}
+
+TEST_CASE("http_download writes a successful local response to disk",
+          "[network_stream][http][coverage][phase3]") {
+    Socket listener;
+    REQUIRE(listener.create(SocketType::TCP));
+    auto port = try_bind_loopback_ephemeral(listener);
+    REQUIRE(port);
+
+    std::atomic<bool> server_ready{false};
+    std::thread server_thread([&] {
+        server_ready.store(true);
+        auto accepted = listener.accept();
+        if (!accepted) return;
+
+        std::array<std::uint8_t, 512> request{};
+        accepted->receive(request.data(), request.size());
+        const std::string response =
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Length: 10\r\n"
+            "\r\n"
+            "downloaded";
+        accepted->send(reinterpret_cast<const std::uint8_t*>(response.data()),
+                       response.size());
+        accepted->close();
+    });
+    ThreadJoiner join_server{server_thread};
+    while (!server_ready.load()) std::this_thread::sleep_for(1ms);
+
+    const auto output_path = std::filesystem::temp_directory_path() /
+        ("pulp-http-download-" + std::to_string(*port) + ".bin");
+    std::filesystem::remove(output_path);
+
+    REQUIRE(http_download("http://127.0.0.1:" + std::to_string(*port) + "/artifact",
+                          output_path.string(), 2));
+    REQUIRE(std::filesystem::exists(output_path));
+
+    std::ifstream file(output_path, std::ios::binary);
+    const std::string contents((std::istreambuf_iterator<char>(file)),
+                               std::istreambuf_iterator<char>());
+    file.close();
+    REQUIRE(contents == "downloaded");
+    std::filesystem::remove(output_path);
+
+    join_server.join();
 }
 
 TEST_CASE("HttpStream default state supports zero reads and idempotent close",

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -106,6 +106,19 @@ std::optional<std::uint16_t> try_bind_udp(Socket& socket,
     return std::nullopt;
 }
 
+std::string receive_http_headers(Socket& socket) {
+    std::string request;
+    std::array<std::uint8_t, 256> buffer{};
+    while (request.size() < 16 * 1024) {
+        const int received = socket.receive(buffer.data(), buffer.size());
+        if (received <= 0) break;
+        request.append(reinterpret_cast<const char*>(buffer.data()),
+                       static_cast<std::size_t>(received));
+        if (request.find("\r\n\r\n") != std::string::npos) break;
+    }
+    return request;
+}
+
 }  // namespace
 
 // ── IP address helpers ──────────────────────────────────────────────────
@@ -897,13 +910,8 @@ TEST_CASE("http_get defaults missing URL path to slash",
         auto accepted = listener.accept();
         if (!accepted) return;
 
-        std::array<std::uint8_t, 512> request{};
-        const int received = accepted->receive(request.data(), request.size());
-        if (received > 0) {
-            const std::string request_text(reinterpret_cast<const char*>(request.data()),
-                                           static_cast<std::size_t>(received));
-            saw_root_path.store(request_text.find("GET /") != std::string::npos);
-        }
+        const auto request_text = receive_http_headers(*accepted);
+        saw_root_path.store(request_text.find("GET /") != std::string::npos);
 
         const std::string response =
             "HTTP/1.1 200 OK\r\n"
@@ -939,14 +947,9 @@ TEST_CASE("HttpStream post factory reads a successful local response",
         auto accepted = listener.accept();
         if (!accepted) return;
 
-        std::array<std::uint8_t, 1024> request{};
-        const int received = accepted->receive(request.data(), request.size());
-        if (received > 0) {
-            const std::string request_text(reinterpret_cast<const char*>(request.data()),
-                                           static_cast<std::size_t>(received));
-            saw_post.store(request_text.find("POST /submit") != std::string::npos &&
-                           request_text.find("application/json") != std::string::npos);
-        }
+        const auto request_text = receive_http_headers(*accepted);
+        saw_post.store(request_text.find("POST /submit") != std::string::npos &&
+                       request_text.find("application/json") != std::string::npos);
         const std::string response =
             "HTTP/1.1 201 Created\r\n"
             "Content-Length: 6\r\n"

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -902,7 +902,7 @@ TEST_CASE("http_get defaults missing URL path to slash",
         if (received > 0) {
             const std::string request_text(reinterpret_cast<const char*>(request.data()),
                                            static_cast<std::size_t>(received));
-            saw_root_path.store(request_text.find("GET / HTTP/1.1") != std::string::npos);
+            saw_root_path.store(request_text.find("GET /") != std::string::npos);
         }
 
         const std::string response =
@@ -944,7 +944,7 @@ TEST_CASE("HttpStream post factory reads a successful local response",
         if (received > 0) {
             const std::string request_text(reinterpret_cast<const char*>(request.data()),
                                            static_cast<std::size_t>(received));
-            saw_post.store(request_text.find("POST /submit HTTP/1.1") != std::string::npos &&
+            saw_post.store(request_text.find("POST /submit") != std::string::npos &&
                            request_text.find("application/json") != std::string::npos);
         }
         const std::string response =

--- a/test/test_runtime.cpp
+++ b/test/test_runtime.cpp
@@ -498,6 +498,23 @@ TEST_CASE("TemporaryFile move assignment cleans previous file", "[runtime][tempo
     REQUIRE_FALSE(std::filesystem::exists(new_path));
 }
 
+TEST_CASE("TemporaryFile self move assignment leaves file ownership intact",
+          "[runtime][temporary_file][coverage][phase3]") {
+    std::filesystem::path path;
+    {
+        TemporaryFile file(".self");
+        path = file.path();
+        REQUIRE(std::filesystem::exists(path));
+
+        TemporaryFile* same_file = &file;
+        file = std::move(*same_file);
+
+        REQUIRE(file.path() == path);
+        REQUIRE(std::filesystem::exists(path));
+    }
+    REQUIRE_FALSE(std::filesystem::exists(path));
+}
+
 TEST_CASE("DynamicLibrary reports closed and failed lookup paths", "[runtime][dynamic_library]") {
     DynamicLibrary library;
     REQUIRE_FALSE(library.is_open());

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -1333,6 +1333,17 @@ TEST_CASE("Expression evaluator treats chained powers as right associative",
     REQUIRE(*negative_exponent == Catch::Approx(4.0));
 }
 
+TEST_CASE("Expression evaluator handles unary plus and division by zero",
+          "[runtime][expression][coverage][phase3]") {
+    auto positive = evaluate(" \t +e + +2 ");
+    REQUIRE(positive.has_value());
+    REQUIRE(*positive == Catch::Approx(4.718281828459045));
+
+    auto divided = evaluate("10 / (3 - 3)");
+    REQUIRE(divided.has_value());
+    REQUIRE(*divided == Catch::Approx(0.0));
+}
+
 // ── HTTP URL parsing ───────────────────────────────────────────────────
 
 TEST_CASE("HTTP helpers reject malformed URLs without transport work",

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -738,6 +738,22 @@ TEST_CASE("run_process captures stderr separately",
     REQUIRE(result->stderr_output.find("bad-news") != std::string::npos);
 }
 
+TEST_CASE("run_process captures stdout and stderr from one child",
+          "[runtime][child_process][coverage][phase3]") {
+#ifdef _WIN32
+    auto result = run_process("powershell",
+        {"-NoProfile", "-Command",
+         "Write-Output 'out-line'; [Console]::Error.WriteLine('err-line'); exit 3"});
+#else
+    auto result = run_process("/bin/sh",
+        {"-c", "printf out-line; printf err-line >&2; exit 3"});
+#endif
+    REQUIRE(result.has_value());
+    REQUIRE(result->exit_code == 3);
+    REQUIRE(result->stdout_output.find("out-line") != std::string::npos);
+    REQUIRE(result->stderr_output.find("err-line") != std::string::npos);
+}
+
 TEST_CASE("run_process honors working directory and preserves spaced arguments",
           "[runtime][child_process][coverage][phase3]") {
     const auto dir = std::filesystem::temp_directory_path()

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -30,6 +30,12 @@
 #include <unistd.h>
 #endif
 
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
 using namespace pulp::runtime;
 
 namespace {
@@ -824,6 +830,17 @@ TEST_CASE("launch_process reports failed starts and missing pids",
     SUCCEED("Android reports exec failures via child exit status, not launch failure");
 #endif
     REQUIRE_FALSE(is_process_running(99999999));
+}
+
+TEST_CASE("is_process_running recognizes the current process",
+          "[runtime][child_process][coverage][phase3]") {
+#ifdef _WIN32
+    const int pid = _getpid();
+#else
+    const int pid = static_cast<int>(getpid());
+#endif
+    REQUIRE(pid > 0);
+    REQUIRE(is_process_running(pid));
 }
 
 // ── Base64 ──────────────────────────────────────────────────────────────

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -924,6 +924,56 @@ TEST_CASE("NamedPipe POSIX FIFO round-trips bytes and unlinks on close",
     REQUIRE_FALSE(std::filesystem::exists(path));
 }
 
+TEST_CASE("PipeStream forwards reads and writes over a connected POSIX FIFO",
+          "[stream][pipe][coverage][phase3]") {
+    auto path = make_temp_path("pulp_pipe_stream_roundtrip");
+    std::filesystem::remove(path);
+
+    auto server = std::make_unique<NamedPipe>();
+    REQUIRE(server->create_server(path.string()));
+
+    auto client = std::make_unique<NamedPipe>();
+    REQUIRE(client->connect_client(path.string()));
+
+    PipeStream server_stream(std::move(server));
+    PipeStream client_stream(std::move(client));
+    REQUIRE(server_stream.is_open());
+    REQUIRE(client_stream.is_open());
+    REQUIRE(server_stream.pipe() != nullptr);
+
+    std::uint8_t zero = 0;
+    REQUIRE(server_stream.write(&zero, 0).ok());
+    REQUIRE(client_stream.read(&zero, 0).ok());
+
+    const std::uint8_t outbound[] = {'p', 'i', 'p', 'e'};
+    auto wrote = server_stream.write(outbound, sizeof(outbound));
+    REQUIRE(wrote.ok());
+    REQUIRE(wrote.bytes == sizeof(outbound));
+
+    std::array<std::uint8_t, sizeof(outbound)> inbound{};
+    auto read = client_stream.read(inbound.data(), inbound.size());
+    REQUIRE(read.ok());
+    REQUIRE(read.bytes == inbound.size());
+    REQUIRE(std::memcmp(inbound.data(), outbound, inbound.size()) == 0);
+
+    const std::uint8_t reply[] = {'o', 'k'};
+    REQUIRE(client_stream.write(reply, sizeof(reply)).bytes == sizeof(reply));
+
+    std::array<std::uint8_t, sizeof(reply)> reply_in{};
+    auto reply_read = server_stream.read(reply_in.data(), reply_in.size());
+    REQUIRE(reply_read.ok());
+    REQUIRE(reply_read.bytes == reply_in.size());
+    REQUIRE(std::memcmp(reply_in.data(), reply, reply_in.size()) == 0);
+
+    client_stream.close();
+    REQUIRE_FALSE(client_stream.is_open());
+    REQUIRE(server_stream.is_open());
+
+    server_stream.close();
+    REQUIRE_FALSE(server_stream.is_open());
+    REQUIRE_FALSE(std::filesystem::exists(path));
+}
+
 TEST_CASE("NamedPipe POSIX move transfers FIFO cleanup ownership",
           "[stream][named_pipe][issue-641]") {
     auto first = make_temp_path("pulp_named_pipe_move_first");

--- a/test/test_sync_primitives.cpp
+++ b/test/test_sync_primitives.cpp
@@ -45,6 +45,18 @@ TEST_CASE("SeqLock basic read/write", "[runtime][seqlock]") {
     REQUIRE(result.time_sig_den == 8);
 }
 
+TEST_CASE("SeqLock default value is readable before first write",
+          "[runtime][seqlock][coverage][phase3]") {
+    SeqLock<TransportState> lock;
+
+    auto result = lock.read();
+
+    REQUIRE(result.tempo == 120.0);
+    REQUIRE(result.beat_position == 0.0);
+    REQUIRE(result.time_sig_num == 4);
+    REQUIRE(result.time_sig_den == 4);
+}
+
 TEST_CASE("SeqLock explicit initial value is readable before first write",
           "[runtime][seqlock][coverage][phase3]") {
     TransportState init;

--- a/test/test_websocket_channel.cpp
+++ b/test/test_websocket_channel.cpp
@@ -15,6 +15,7 @@
 #include <optional>
 #include <string>
 #include <thread>
+#include <vector>
 
 #if defined(__APPLE__) || defined(__linux__)
 #include <csignal>
@@ -66,6 +67,26 @@ std::string receive_http_headers(Socket& socket) {
         }
     }
     return out;
+}
+
+bool send_masked_client_frame(Socket& socket,
+                              bool fin,
+                              std::uint8_t opcode,
+                              std::string_view payload) {
+    if (payload.size() >= 126) return false;
+
+    const std::array<std::uint8_t, 4> mask{0x11, 0x22, 0x33, 0x44};
+    std::vector<std::uint8_t> frame;
+    frame.reserve(2 + mask.size() + payload.size());
+    frame.push_back(static_cast<std::uint8_t>((fin ? 0x80 : 0x00) | opcode));
+    frame.push_back(static_cast<std::uint8_t>(0x80 | payload.size()));
+    frame.insert(frame.end(), mask.begin(), mask.end());
+    for (std::size_t i = 0; i < payload.size(); ++i) {
+        frame.push_back(static_cast<std::uint8_t>(
+            static_cast<std::uint8_t>(payload[i]) ^ mask[i & 0x3]));
+    }
+
+    return socket.send(frame.data(), frame.size()) == static_cast<int>(frame.size());
 }
 
 }  // namespace
@@ -418,6 +439,69 @@ TEST_CASE("WebSocketChannel delivers binary send as binary message",
     }
 
     client->close();
+    if (server_ws) server_ws->close();
+    server_thread.join();
+}
+
+TEST_CASE("WebSocketChannel assembles fragmented text frames",
+          "[websocket][frame-kind][coverage][phase3]") {
+    Socket listener;
+    REQUIRE(listener.create(SocketType::TCP));
+    auto port = bind_loopback(listener, 47701);
+    if (!port) { SUCCEED("could not bind loopback; skipping"); return; }
+
+    std::atomic<bool> ready{false};
+    std::atomic<bool> server_accept_done{false};
+    std::unique_ptr<WebSocketChannel> server_ws;
+    std::mutex mu;
+    std::vector<std::string> seen;
+
+    std::thread server_thread([&] {
+        ready.store(true);
+        auto accepted = listener.accept();
+        if (!accepted) return;
+        auto server_tcp = std::make_unique<TcpStream>(std::move(*accepted));
+        server_ws = WebSocketChannel::accept(std::move(server_tcp));
+        if (!server_ws) return;
+        server_ws->on_message([&](const Message& m) {
+            std::lock_guard<std::mutex> lock(mu);
+            seen.emplace_back(m.as_text());
+        });
+        server_accept_done.store(true);
+    });
+    while (!ready.load()) std::this_thread::sleep_for(1ms);
+
+    Socket client;
+    REQUIRE(client.create(SocketType::TCP));
+    REQUIRE(client.connect("127.0.0.1", *port));
+    const std::string key = "dGhlIHNhbXBsZSBub25jZQ==";
+    const std::string request =
+        "GET /fragmented HTTP/1.1\r\n"
+        "Host: 127.0.0.1\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        "Sec-WebSocket-Key: " + key + "\r\n"
+        "Sec-WebSocket-Version: 13\r\n\r\n";
+    REQUIRE(client.send(request) == static_cast<int>(request.size()));
+    auto response = receive_http_headers(client);
+    REQUIRE(response.find("101") != std::string::npos);
+    REQUIRE(response.find(WebSocketChannel::compute_accept_key(key)) != std::string::npos);
+    REQUIRE(wait_until([&] { return server_accept_done.load(); }));
+
+    REQUIRE(send_masked_client_frame(client, false, 0x1, "frag"));
+    REQUIRE(send_masked_client_frame(client, true, 0x0, "ment"));
+
+    REQUIRE(wait_until([&] {
+        std::lock_guard<std::mutex> lock(mu);
+        return !seen.empty();
+    }));
+
+    {
+        std::lock_guard<std::mutex> lock(mu);
+        REQUIRE(seen == std::vector<std::string>{"fragment"});
+    }
+
+    client.close();
     if (server_ws) server_ws->close();
     server_thread.join();
 }

--- a/test/test_websocket_channel.cpp
+++ b/test/test_websocket_channel.cpp
@@ -89,6 +89,32 @@ bool send_masked_client_frame(Socket& socket,
     return socket.send(frame.data(), frame.size()) == static_cast<int>(frame.size());
 }
 
+std::optional<std::vector<std::uint8_t>> receive_unmasked_server_frame(Socket& socket,
+                                                                       std::uint8_t& opcode) {
+    std::uint8_t hdr[2]{};
+    if (socket.receive(hdr, 2) != 2) return std::nullopt;
+    opcode = hdr[0] & 0x0f;
+    if ((hdr[1] & 0x80) != 0) return std::nullopt;
+
+    std::uint64_t len = hdr[1] & 0x7f;
+    if (len == 126) {
+        std::uint8_t ext[2]{};
+        if (socket.receive(ext, 2) != 2) return std::nullopt;
+        len = (std::uint64_t(ext[0]) << 8) | ext[1];
+    } else if (len == 127) {
+        return std::nullopt;
+    }
+
+    std::vector<std::uint8_t> payload(static_cast<std::size_t>(len));
+    std::size_t off = 0;
+    while (off < payload.size()) {
+        auto n = socket.receive(payload.data() + off, payload.size() - off);
+        if (n <= 0) return std::nullopt;
+        off += static_cast<std::size_t>(n);
+    }
+    return payload;
+}
+
 }  // namespace
 
 TEST_CASE("WebSocket accept_key follows RFC 6455 section 4.2.2", "[websocket]") {
@@ -557,6 +583,55 @@ TEST_CASE("WebSocketChannel reports unknown frame opcodes",
         std::lock_guard<std::mutex> lock(mu);
         return error == "unknown opcode" && closed.load();
     }));
+
+    client.close();
+    if (server_ws) server_ws->close();
+    server_thread.join();
+}
+
+TEST_CASE("WebSocketChannel replies to ping frames with pong",
+          "[websocket][frame-kind][coverage][phase3]") {
+    Socket listener;
+    REQUIRE(listener.create(SocketType::TCP));
+    auto port = bind_loopback(listener, 47901);
+    if (!port) { SUCCEED("could not bind loopback; skipping"); return; }
+
+    std::atomic<bool> ready{false};
+    std::atomic<bool> server_accept_done{false};
+    std::unique_ptr<WebSocketChannel> server_ws;
+
+    std::thread server_thread([&] {
+        ready.store(true);
+        auto accepted = listener.accept();
+        if (!accepted) return;
+        auto server_tcp = std::make_unique<TcpStream>(std::move(*accepted));
+        server_ws = WebSocketChannel::accept(std::move(server_tcp));
+        server_accept_done.store(server_ws != nullptr);
+    });
+    while (!ready.load()) std::this_thread::sleep_for(1ms);
+
+    Socket client;
+    REQUIRE(client.create(SocketType::TCP));
+    REQUIRE(client.connect("127.0.0.1", *port));
+    const std::string key = "dGhlIHNhbXBsZSBub25jZQ==";
+    const std::string request =
+        "GET /ping HTTP/1.1\r\n"
+        "Host: 127.0.0.1\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        "Sec-WebSocket-Key: " + key + "\r\n"
+        "Sec-WebSocket-Version: 13\r\n\r\n";
+    REQUIRE(client.send(request) == static_cast<int>(request.size()));
+    auto response = receive_http_headers(client);
+    REQUIRE(response.find("101") != std::string::npos);
+    REQUIRE(wait_until([&] { return server_accept_done.load(); }));
+
+    REQUIRE(send_masked_client_frame(client, true, 0x9, "ok"));
+    std::uint8_t opcode = 0;
+    auto payload = receive_unmasked_server_frame(client, opcode);
+    REQUIRE(payload.has_value());
+    REQUIRE(opcode == 0xA);
+    REQUIRE(*payload == std::vector<std::uint8_t>{'o', 'k'});
 
     client.close();
     if (server_ws) server_ws->close();

--- a/test/test_websocket_channel.cpp
+++ b/test/test_websocket_channel.cpp
@@ -506,6 +506,63 @@ TEST_CASE("WebSocketChannel assembles fragmented text frames",
     server_thread.join();
 }
 
+TEST_CASE("WebSocketChannel reports unknown frame opcodes",
+          "[websocket][frame-kind][coverage][phase3]") {
+    Socket listener;
+    REQUIRE(listener.create(SocketType::TCP));
+    auto port = bind_loopback(listener, 47801);
+    if (!port) { SUCCEED("could not bind loopback; skipping"); return; }
+
+    std::atomic<bool> ready{false};
+    std::atomic<bool> server_accept_done{false};
+    std::atomic<bool> closed{false};
+    std::unique_ptr<WebSocketChannel> server_ws;
+    std::mutex mu;
+    std::string error;
+
+    std::thread server_thread([&] {
+        ready.store(true);
+        auto accepted = listener.accept();
+        if (!accepted) return;
+        auto server_tcp = std::make_unique<TcpStream>(std::move(*accepted));
+        server_ws = WebSocketChannel::accept(std::move(server_tcp));
+        if (!server_ws) return;
+        server_ws->on_error([&](std::string_view reason) {
+            std::lock_guard<std::mutex> lock(mu);
+            error = std::string(reason);
+        });
+        server_ws->on_closed([&] { closed.store(true); });
+        server_accept_done.store(true);
+    });
+    while (!ready.load()) std::this_thread::sleep_for(1ms);
+
+    Socket client;
+    REQUIRE(client.create(SocketType::TCP));
+    REQUIRE(client.connect("127.0.0.1", *port));
+    const std::string key = "dGhlIHNhbXBsZSBub25jZQ==";
+    const std::string request =
+        "GET /unknown-opcode HTTP/1.1\r\n"
+        "Host: 127.0.0.1\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        "Sec-WebSocket-Key: " + key + "\r\n"
+        "Sec-WebSocket-Version: 13\r\n\r\n";
+    REQUIRE(client.send(request) == static_cast<int>(request.size()));
+    auto response = receive_http_headers(client);
+    REQUIRE(response.find("101") != std::string::npos);
+    REQUIRE(wait_until([&] { return server_accept_done.load(); }));
+
+    REQUIRE(send_masked_client_frame(client, true, 0x3, "reserved"));
+    REQUIRE(wait_until([&] {
+        std::lock_guard<std::mutex> lock(mu);
+        return error == "unknown opcode" && closed.load();
+    }));
+
+    client.close();
+    if (server_ws) server_ws->close();
+    server_thread.join();
+}
+
 TEST_CASE("WebSocketChannel receives 64-bit payload length frames",
           "[websocket][frame-length][issue-641]") {
     Socket listener;

--- a/test/test_websocket_channel.cpp
+++ b/test/test_websocket_channel.cpp
@@ -638,6 +638,61 @@ TEST_CASE("WebSocketChannel replies to ping frames with pong",
     server_thread.join();
 }
 
+TEST_CASE("WebSocketChannel echoes close frames and closes",
+          "[websocket][frame-kind][coverage][phase3]") {
+    Socket listener;
+    REQUIRE(listener.create(SocketType::TCP));
+    auto port = bind_loopback(listener, 48001);
+    if (!port) { SUCCEED("could not bind loopback; skipping"); return; }
+
+    std::atomic<bool> ready{false};
+    std::atomic<bool> server_accept_done{false};
+    std::atomic<bool> closed{false};
+    std::unique_ptr<WebSocketChannel> server_ws;
+
+    std::thread server_thread([&] {
+        ready.store(true);
+        auto accepted = listener.accept();
+        if (!accepted) return;
+        auto server_tcp = std::make_unique<TcpStream>(std::move(*accepted));
+        server_ws = WebSocketChannel::accept(std::move(server_tcp));
+        if (!server_ws) return;
+        server_ws->on_closed([&] { closed.store(true); });
+        server_accept_done.store(true);
+    });
+    while (!ready.load()) std::this_thread::sleep_for(1ms);
+
+    Socket client;
+    REQUIRE(client.create(SocketType::TCP));
+    REQUIRE(client.connect("127.0.0.1", *port));
+    const std::string key = "dGhlIHNhbXBsZSBub25jZQ==";
+    const std::string request =
+        "GET /close HTTP/1.1\r\n"
+        "Host: 127.0.0.1\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        "Sec-WebSocket-Key: " + key + "\r\n"
+        "Sec-WebSocket-Version: 13\r\n\r\n";
+    REQUIRE(client.send(request) == static_cast<int>(request.size()));
+    auto response = receive_http_headers(client);
+    REQUIRE(response.find("101") != std::string::npos);
+    REQUIRE(wait_until([&] { return server_accept_done.load(); }));
+
+    const std::string close_payload{"\x03\xe8", 2};
+    REQUIRE(send_masked_client_frame(client, true, 0x8, close_payload));
+    std::uint8_t opcode = 0;
+    auto payload = receive_unmasked_server_frame(client, opcode);
+    REQUIRE(payload.has_value());
+    REQUIRE(opcode == 0x8);
+    REQUIRE(*payload == std::vector<std::uint8_t>{0x03, 0xe8});
+    REQUIRE(wait_until([&] { return closed.load(); }));
+    REQUIRE_FALSE(server_ws->is_open());
+
+    client.close();
+    if (server_ws) server_ws->close();
+    server_thread.join();
+}
+
 TEST_CASE("WebSocketChannel receives 64-bit payload length frames",
           "[websocket][frame-length][issue-641]") {
     Socket listener;

--- a/test/test_websocket_channel.cpp
+++ b/test/test_websocket_channel.cpp
@@ -69,6 +69,16 @@ std::string receive_http_headers(Socket& socket) {
     return out;
 }
 
+bool receive_exact(Socket& socket, std::uint8_t* data, std::size_t bytes) {
+    std::size_t off = 0;
+    while (off < bytes) {
+        auto n = socket.receive(data + off, bytes - off);
+        if (n <= 0) return false;
+        off += static_cast<std::size_t>(n);
+    }
+    return true;
+}
+
 bool send_masked_client_frame(Socket& socket,
                               bool fin,
                               std::uint8_t opcode,
@@ -92,25 +102,23 @@ bool send_masked_client_frame(Socket& socket,
 std::optional<std::vector<std::uint8_t>> receive_unmasked_server_frame(Socket& socket,
                                                                        std::uint8_t& opcode) {
     std::uint8_t hdr[2]{};
-    if (socket.receive(hdr, 2) != 2) return std::nullopt;
+    if (!receive_exact(socket, hdr, 2)) return std::nullopt;
     opcode = hdr[0] & 0x0f;
     if ((hdr[1] & 0x80) != 0) return std::nullopt;
 
     std::uint64_t len = hdr[1] & 0x7f;
     if (len == 126) {
         std::uint8_t ext[2]{};
-        if (socket.receive(ext, 2) != 2) return std::nullopt;
+        if (!receive_exact(socket, ext, 2)) return std::nullopt;
         len = (std::uint64_t(ext[0]) << 8) | ext[1];
     } else if (len == 127) {
         return std::nullopt;
     }
 
     std::vector<std::uint8_t> payload(static_cast<std::size_t>(len));
-    std::size_t off = 0;
-    while (off < payload.size()) {
-        auto n = socket.receive(payload.data() + off, payload.size() - off);
-        if (n <= 0) return std::nullopt;
-        off += static_cast<std::size_t>(n);
+    if (!payload.empty() &&
+        !receive_exact(socket, payload.data(), payload.size())) {
+        return std::nullopt;
     }
     return payload;
 }

--- a/test/test_websocket_channel.cpp
+++ b/test/test_websocket_channel.cpp
@@ -194,6 +194,20 @@ TEST_CASE("WebSocket accept_key rejects empty input gracefully",
     REQUIRE(result == WebSocketChannel::compute_accept_key(""));
 }
 
+TEST_CASE("WebSocketChannel rejects null and closed streams before handshake",
+          "[websocket][handshake][coverage][phase3]") {
+    REQUIRE(WebSocketChannel::connect(nullptr, "127.0.0.1", "/") == nullptr);
+    REQUIRE(WebSocketChannel::accept(nullptr) == nullptr);
+
+    auto closed_client = std::make_unique<TcpStream>();
+    REQUIRE_FALSE(closed_client->is_open());
+    REQUIRE(WebSocketChannel::connect(std::move(closed_client), "127.0.0.1", "/") == nullptr);
+
+    auto closed_server = std::make_unique<TcpStream>();
+    REQUIRE_FALSE(closed_server->is_open());
+    REQUIRE(WebSocketChannel::accept(std::move(closed_server)) == nullptr);
+}
+
 TEST_CASE("WebSocketChannel connect fails gracefully on non-WS peer",
           "[websocket][handshake]") {
     // A peer that accepts the TCP connection but never sends a valid


### PR DESCRIPTION
## Summary
- add runtime/event/network coverage for JSON-RPC, child process, IPC, streams, HTTP, WebSocket, temporary files, and sync primitives
- harden local HTTP/WebSocket tests against TCP short reads and request protocol-version variance
- relax the unsupported-SDK bypass shellout timeout to avoid false failures on busy self-hosted macOS runners
- batch 29 focused test/coverage commits on top of current main

## Local validation
- cmake -S . -B build-gpu-off -DPULP_ENABLE_GPU=OFF -DCMAKE_BUILD_TYPE=Debug
- cmake --build build-gpu-off --target pulp-test-async-stream pulp-test-child-process pulp-test-ipc pulp-test-json-rpc pulp-test-memory-message-channel pulp-test-network-stream pulp-test-runtime pulp-test-runtime-utils pulp-test-stream pulp-test-sync pulp-test-websocket-channel
- affected runtime test binaries passed directly
- cmake --build build-gpu-off --target pulp-test-cli-shellout
- ./pulp-test-cli-shellout "pulp build allows explicit unsupported SDK bypass"
- cmake --build build-gpu-off --target pulp-test-network-stream pulp-test-websocket-channel
- affected network/WebSocket test binaries passed directly
- git diff --check origin/main...HEAD
- python3 tools/import-validation/check-source-contracts.py --strict
- python3 tools/import-validation/test_source_contracts.py
- python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main
- python3 tools/scripts/version_bump_check.py --mode=report --base origin/main