### PR TITLE
test(import): expand design import benchmark coverage

### DIFF
--- a/test/test_design_import_benchmark.cpp
+++ b/test/test_design_import_benchmark.cpp
@@ -145,3 +145,65 @@ TEST_CASE("design-import benchmark emits live and baked-native lane JSON",
         fs::remove(out);
     }
 }
+
+TEST_CASE("design-import benchmark CLI rejects invalid arguments before running fixtures",
+          "[design-import][benchmark]") {
+    set_no_launch_env();
+    const auto bin = bench_binary();
+    REQUIRE(fs::exists(bin));
+
+    for (const auto& args : std::vector<std::vector<std::string>>{
+             {"--lane=nope"},
+             {"--idle-ms=abc"},
+             {"--interactive-ms", "abc"},
+             {"--target-fps=1x"},
+             {"--output"},
+         }) {
+        auto r = exec(bin.string(), args, /*timeout_ms=*/10000);
+        REQUIRE_FALSE(r.timed_out);
+        REQUIRE(r.exit_code == 2);
+        REQUIRE(r.stderr_output.find("usage: pulp-design-import-bench") != std::string::npos);
+        REQUIRE(r.stdout_output.empty());
+    }
+}
+
+TEST_CASE("design-import benchmark help exits successfully without stderr",
+          "[design-import][benchmark]") {
+    set_no_launch_env();
+    const auto bin = bench_binary();
+    REQUIRE(fs::exists(bin));
+
+    auto r = exec(bin.string(), {"--help"}, /*timeout_ms=*/10000);
+
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code == 0);
+    REQUIRE(r.stdout_output.find("usage: pulp-design-import-bench") != std::string::npos);
+    REQUIRE(r.stderr_output.empty());
+}
+
+TEST_CASE("design-import benchmark writes stdout JSON and clamps nonpositive timing",
+          "[design-import][benchmark]") {
+    set_no_launch_env();
+    const auto bin = bench_binary();
+    REQUIRE(fs::exists(bin));
+
+    auto r = exec(bin.string(),
+                  {
+                      "--lane=baked-native",
+                      "--idle-ms=-10",
+                      "--interactive-ms=-20",
+                      "--target-fps=0",
+                  },
+                  /*timeout_ms=*/30000);
+
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code == 0);
+    REQUIRE(r.stderr_output.empty());
+    REQUIRE(r.stdout_output.find("\"lane\": \"baked-native\"") != std::string::npos);
+    REQUIRE(contains_key(r.stdout_output, "startup"));
+    REQUIRE(contains_key(r.stdout_output, "idle"));
+    REQUIRE(contains_key(r.stdout_output, "interactive"));
+    REQUIRE(extract_number(r.stdout_output, "target_fps") == 1.0);
+    REQUIRE(extract_number(r.stdout_output, "duration_ms") == 0.0);
+    REQUIRE(extract_number(r.stdout_output, "samples") == 0.0);
+}

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -15,14 +15,12 @@
 #include <pulp/runtime/range.hpp>
 #include <pulp/runtime/scope_guard.hpp>
 #include <pulp/runtime/scoped_no_alloc.hpp>
-#include <pulp/runtime/socket.hpp>
 #include <pulp/runtime/stream.hpp>
 #include <pulp/runtime/text_diff.hpp>
 #include "../external/cpp-httplib/httplib.h"
 #include <catch2/catch_approx.hpp>
 #include <algorithm>
 #include <atomic>
-#include <array>
 #include <chrono>
 #include <cmath>
 #include <fstream>
@@ -72,55 +70,56 @@ struct OneShotHttpResponse {
     bool downloaded = false;
 };
 
+bool wait_until_http_ready(int port, std::chrono::milliseconds timeout);
+
 OneShotHttpResponse serve_one_http_response(std::string_view method,
                                             std::string_view path,
                                             std::string_view body = {}) {
-    Socket server;
-    REQUIRE(server.create(SocketType::TCP));
-    REQUIRE(server.bind("127.0.0.1", 0));
-    REQUIRE(server.listen(1));
-    const auto port = server.local_port();
-    REQUIRE(port != 0);
+    httplib::Server server;
+
+    auto route_path = std::string(path);
+    if (const auto query = route_path.find('?'); query != std::string::npos)
+        route_path.resize(query);
 
     OneShotHttpResponse exchange;
-    std::thread worker([&] {
-        auto client = server.accept();
-        if (!client) return;
-
+    const auto capture_request = [&](const httplib::Request& request) {
         exchange.accepted = true;
-        std::array<std::uint8_t, 2048> buffer{};
-        while (true) {
-            const auto received = client->receive(buffer.data(), buffer.size());
-            if (received <= 0) break;
-            exchange.request.append(reinterpret_cast<const char*>(buffer.data()),
-                                    static_cast<std::size_t>(received));
-
-            const auto header_end = exchange.request.find("\r\n\r\n");
-            if (header_end == std::string::npos) continue;
-
-            std::size_t expected_body_size = 0;
-            const auto length_key = std::string("Content-Length: ");
-            const auto length_pos = exchange.request.find(length_key);
-            if (length_pos != std::string::npos) {
-                const auto start = length_pos + length_key.size();
-                const auto end = exchange.request.find("\r\n", start);
-                expected_body_size =
-                    static_cast<std::size_t>(std::stoul(exchange.request.substr(start, end - start)));
-            }
-
-            const auto body_size = exchange.request.size() - (header_end + 4);
-            if (body_size >= expected_body_size) break;
+        exchange.request = request.method + " " + request.target + " HTTP/1.1\r\n";
+        if (request.has_header("Content-Type")) {
+            exchange.request +=
+                "Content-Type: " + request.get_header_value("Content-Type") + "\r\n";
         }
+        for (const auto& [key, value] : request.headers) {
+            if (key != "Content-Type")
+                exchange.request += key + ": " + value + "\r\n";
+        }
+        exchange.request += "\r\n";
+        exchange.request += request.body;
+    };
+    const auto send_ok = [&](const httplib::Request& request, httplib::Response& response) {
+        capture_request(request);
+        response.set_header("X-Pulp-Test", "loopback");
+        response.set_content("ok-response", "text/plain");
+    };
 
-        const std::string payload = "ok-response";
-        const std::string wire_response =
-            "HTTP/1.1 200 OK\r\n"
-            "Content-Type: text/plain\r\n"
-            "X-Pulp-Test: loopback\r\n"
-            "Content-Length: " + std::to_string(payload.size()) + "\r\n"
-            "Connection: close\r\n\r\n" + payload;
-        (void)client->send(wire_response);
+    server.Get("/__ready", [](const httplib::Request&, httplib::Response& response) {
+        response.status = 204;
     });
+    if (method == "POST")
+        server.Post(route_path, send_ok);
+    else
+        server.Get(route_path, send_ok);
+
+    const auto port = server.bind_to_any_port("127.0.0.1");
+    REQUIRE(port != 0);
+
+    std::thread worker([&] { server.listen_after_bind(); });
+    auto stop_server = make_scope_guard([&] {
+        server.stop();
+        if (worker.joinable())
+            worker.join();
+    });
+    REQUIRE(wait_until_http_ready(port, std::chrono::seconds(10)));
 
     const auto url = "http://127.0.0.1:" + std::to_string(port) + std::string(path);
     if (method == "POST") {
@@ -131,7 +130,6 @@ OneShotHttpResponse serve_one_http_response(std::string_view method,
         exchange.response = http_get(url, 2);
     }
 
-    worker.join();
     return exchange;
 }
 

--- a/tools/scripts/test_design_import_benchmark.py
+++ b/tools/scripts/test_design_import_benchmark.py
@@ -3,7 +3,11 @@
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
+import json
+import os
 import pathlib
 import sys
 import tempfile
@@ -24,6 +28,118 @@ def write_sized(path: pathlib.Path, size: int) -> None:
 
 
 class BinarySizeTests(unittest.TestCase):
+    def test_default_paths_prefer_existing_build_outputs(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            build = pathlib.Path(td) / "build"
+            exe_name = "pulp-design-import-bench.exe" if os.name == "nt" else "pulp-design-import-bench"
+            debug_exe = build / "tools" / "import-design" / "Debug" / exe_name
+            primary_exe = build / "tools" / "import-design" / exe_name
+            write_sized(debug_exe, 1)
+
+            self.assertEqual(dib.default_bench_exe(build), debug_exe)
+
+            write_sized(primary_exe, 1)
+            self.assertEqual(dib.default_bench_exe(build), primary_exe)
+
+            release_archive = build / "core" / "view" / "Release" / "pulp-view.lib"
+            primary_archive = build / "core" / "view" / "libpulp-view.a"
+            write_sized(release_archive, 1)
+            self.assertEqual(dib.default_pulp_view_archive(build), release_archive)
+
+            write_sized(primary_archive, 1)
+            self.assertEqual(dib.default_pulp_view_archive(build), primary_archive)
+
+    def test_object_lookup_prefers_pulp_view_obj_variant(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            build = pathlib.Path(td) / "build"
+            preferred = build / "core" / "view" / "CMakeFiles" / "pulp-view.dir" / "src" / "widget_bridge.cpp.obj"
+            fallback = build / "other" / "widget_bridge.cpp.obj"
+            direct = build / "direct" / "object.obj"
+            write_sized(fallback, 10)
+            write_sized(preferred, 20)
+            write_sized(direct, 30)
+
+            variants = dib.object_name_variants("core/view/CMakeFiles/pulp-view.dir/src/widget_bridge.cpp.o")
+            obj_variants = dib.object_name_variants("core/view/CMakeFiles/pulp-view.dir/src/widget_bridge.cpp.obj")
+            found = dib.find_build_object(build, "core/view/CMakeFiles/pulp-view.dir/src/widget_bridge.cpp.o")
+            direct_found = dib.find_build_object(build, "direct/object.obj")
+            missing = dib.find_build_object(build, "missing-object.o")
+
+        self.assertIn("widget_bridge.cpp.o", variants)
+        self.assertIn("widget_bridge.cpp.obj", variants)
+        self.assertIn("widget_bridge.cpp.o", obj_variants)
+        self.assertEqual(found, preferred)
+        self.assertEqual(direct_found, direct)
+        self.assertIsNone(missing)
+
+    def test_parse_size_output_ignores_headers_and_non_numeric_rows(self) -> None:
+        output = """\
+   text    data     bss     dec     hex filename
+     10      20       1      31      1f object-a.o
+not-a-row
+      5       7       2      14       e object-b.o
+      4    nope       0       4       4 object-c.o
+"""
+        self.assertEqual(dib.parse_size_output(output), 42)
+
+    def test_linked_size_falls_back_to_stat_when_size_tool_is_missing(self) -> None:
+        old_tool = os.environ.get("PULP_SIZE_TOOL")
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                path = pathlib.Path(td) / "object.o"
+                write_sized(path, 1234)
+                os.environ["PULP_SIZE_TOOL"] = str(pathlib.Path(td) / "missing-size-tool")
+
+                self.assertEqual(dib.linked_size_bytes(path), 1234)
+        finally:
+            if old_tool is None:
+                os.environ.pop("PULP_SIZE_TOOL", None)
+            else:
+                os.environ["PULP_SIZE_TOOL"] = old_tool
+
+    def test_linked_size_uses_parsed_text_and_data_when_size_tool_succeeds(self) -> None:
+        old_tool = os.environ.get("PULP_SIZE_TOOL")
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                root = pathlib.Path(td)
+                path = root / "object.o"
+                tool = root / "fake-size"
+                write_sized(path, 1234)
+                tool.write_text(
+                    "#!/bin/sh\n"
+                    "printf '   text    data     bss filename\\n'\n"
+                    "printf '     12      34       0 %s\\n' \"$1\"\n",
+                    encoding="utf-8",
+                )
+                tool.chmod(0o755)
+                os.environ["PULP_SIZE_TOOL"] = str(tool)
+
+                self.assertEqual(dib.linked_size_bytes(path), 46)
+        finally:
+            if old_tool is None:
+                os.environ.pop("PULP_SIZE_TOOL", None)
+            else:
+                os.environ["PULP_SIZE_TOOL"] = old_tool
+
+    def test_linked_size_falls_back_when_size_tool_output_has_no_sections(self) -> None:
+        old_tool = os.environ.get("PULP_SIZE_TOOL")
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                root = pathlib.Path(td)
+                path = root / "object.o"
+                tool = root / "fake-size-empty"
+                write_sized(path, 321)
+                tool.write_text("#!/bin/sh\nprintf 'not numeric\\n'\n", encoding="utf-8")
+                tool.chmod(0o755)
+                os.environ["PULP_SIZE_TOOL"] = str(tool)
+
+                self.assertEqual(dib.linked_size_bytes(path), 321)
+        finally:
+            if old_tool is None:
+                os.environ.pop("PULP_SIZE_TOOL", None)
+            else:
+                os.environ["PULP_SIZE_TOOL"] = old_tool
+
     def test_measure_binary_sizes_sums_live_runtime_objects_and_gate(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = pathlib.Path(td)
@@ -70,6 +186,59 @@ class BinarySizeTests(unittest.TestCase):
 
 
 class ReportTests(unittest.TestCase):
+    def test_no_launch_env_sets_headless_flags_and_preserves_existing_env(self) -> None:
+        old_value = os.environ.get("PULP_BENCH_EXISTING")
+        try:
+            os.environ["PULP_BENCH_EXISTING"] = "keep-me"
+            env = dib.no_launch_env()
+        finally:
+            if old_value is None:
+                os.environ.pop("PULP_BENCH_EXISTING", None)
+            else:
+                os.environ["PULP_BENCH_EXISTING"] = old_value
+
+        self.assertEqual(env["PULP_DISABLE_PLUGIN_EDITOR"], "1")
+        self.assertEqual(env["PULP_HEADLESS"], "1")
+        self.assertEqual(env["PULP_TEST_MODE"], "1")
+        self.assertEqual(env["PULP_INSPECTOR_NO_LAUNCH"], "1")
+        self.assertEqual(env["PULP_BENCH_EXISTING"], "keep-me")
+
+    def test_delta_ratio_handles_missing_or_zero_baseline(self) -> None:
+        self.assertIsNone(dib.delta_ratio(1, 0))
+        self.assertIsNone(dib.delta_ratio(1, None))
+        self.assertIsNone(dib.delta_ratio(None, 1))
+        self.assertEqual(dib.delta_ratio(75, 100), -0.25)
+
+    def test_run_lane_builds_command_and_reads_json_output(self) -> None:
+        calls: list[dict[str, object]] = []
+        old_run = dib.subprocess.run
+
+        def fake_run(cmd: list[str], **kwargs: object) -> object:
+            calls.append({"cmd": cmd, **kwargs})
+            out_arg = next(arg for arg in cmd if arg.startswith("--output="))
+            out_path = pathlib.Path(out_arg.split("=", 1)[1])
+            out_path.write_text('{"lane": "live", "samples": 7}\n', encoding="utf-8")
+            return object()
+
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                dib.subprocess.run = fake_run  # type: ignore[assignment]
+                result = dib.run_lane(pathlib.Path("/tmp/fake-bench"), "live", 10, 20, 30, pathlib.Path(td))
+        finally:
+            dib.subprocess.run = old_run
+
+        self.assertEqual(result["lane"], "live")
+        self.assertEqual(result["samples"], 7)
+        self.assertEqual(calls[0]["cmd"][1:5], [
+            "--lane=live",
+            "--idle-ms=10",
+            "--interactive-ms=20",
+            "--target-fps=30",
+        ])
+        self.assertEqual(calls[0]["check"], True)
+        self.assertEqual(calls[0]["timeout"], 30)
+        self.assertEqual(calls[0]["env"]["PULP_HEADLESS"], "1")  # type: ignore[index]
+
     def test_comparison_and_markdown_record_phase9_gate_inputs(self) -> None:
         live = {
             "fixture": "fixture",
@@ -163,6 +332,93 @@ class ReportTests(unittest.TestCase):
         self.assertEqual(dib.format_bytes(3 * 1024 * 1024), "3.00 MiB")
         self.assertEqual(dib.format_pct(0.125), "12.50%")
         self.assertEqual(dib.format_ms(1.234), "1.23 ms")
+
+    def test_main_skip_run_writes_json_and_markdown_without_benchmark(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            output_json = root / "out" / "report.json"
+            output_md = root / "out" / "report.md"
+
+            rc = dib.main([
+                "--build-dir", str(root / "build"),
+                "--bench-exe", str(root / "missing-bench"),
+                "--skip-run",
+                "--target-fps", "144",
+                "--output-json", str(output_json),
+                "--output-md", str(output_md),
+                "--object", "missing-object.o",
+            ])
+
+            report = json.loads(output_json.read_text(encoding="utf-8"))
+            markdown = output_md.read_text(encoding="utf-8")
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(report["schema"], "pulp-design-import-benchmark-summary-v1")
+        self.assertEqual(report["lanes"]["live"]["fixture"], "not-run")
+        self.assertEqual(report["lanes"]["baked-native"]["target_fps"], 144)
+        self.assertEqual(report["binary_size"]["benchmark_app_bytes"], 0)
+        self.assertEqual(report["binary_size"]["objects"][0]["path"], "missing-object.o")
+        self.assertIn("Phase 9 gate: **NOT MET**", markdown)
+
+    def test_main_reports_missing_benchmark_without_skip_run(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            err = io.StringIO()
+            missing = pathlib.Path(td) / "missing-bench"
+            with contextlib.redirect_stderr(err):
+                rc = dib.main([
+                    "--build-dir", str(pathlib.Path(td) / "build"),
+                    "--bench-exe", str(missing),
+                ])
+
+        self.assertEqual(rc, 1)
+        self.assertIn("benchmark executable not found", err.getvalue())
+
+    def test_main_runs_lanes_and_prints_markdown_when_no_outputs_are_requested(self) -> None:
+        old_run_lane = dib.run_lane
+
+        def fake_run_lane(
+            bench_exe: pathlib.Path,
+            lane: str,
+            idle_ms: int,
+            interactive_ms: int,
+            target_fps: int,
+            output_dir: pathlib.Path,
+        ) -> dict[str, object]:
+            self.assertTrue(bench_exe.exists())
+            self.assertEqual(idle_ms, 3)
+            self.assertEqual(interactive_ms, 4)
+            self.assertEqual(target_fps, 5)
+            self.assertTrue(output_dir.exists())
+            return {
+                "lane": lane,
+                "fixture": "fake",
+                "target_fps": target_fps,
+                "startup": {"first_frame_ms": 1.0},
+                "idle": {"samples": 0},
+                "interactive": {"samples": 0, "js_evaluations_total": 0},
+            }
+
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                root = pathlib.Path(td)
+                bench = root / "bench"
+                write_sized(bench, 1)
+                out = io.StringIO()
+                dib.run_lane = fake_run_lane
+                with contextlib.redirect_stdout(out):
+                    rc = dib.main([
+                        "--build-dir", str(root / "build"),
+                        "--bench-exe", str(bench),
+                        "--idle-ms", "3",
+                        "--interactive-ms", "4",
+                        "--target-fps", "5",
+                    ])
+        finally:
+            dib.run_lane = old_run_lane
+
+        self.assertEqual(rc, 0)
+        self.assertIn("# Design-Import Benchmark Results", out.getvalue())
+        self.assertIn("Fixture: `fake`", out.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expand Python coverage for `tools/scripts/design_import_benchmark.py` across path discovery, object lookup, size-tool parsing/fallback, headless env setup, lane running, skip-run reporting, and missing-benchmark errors
- add C++ shell-out coverage for `pulp-design-import-bench` help, invalid CLI arguments, stdout JSON, and clamped nonpositive duration/FPS inputs

## Validation
- `python3 tools/scripts/test_design_import_benchmark.py` (16 tests)
- `/tmp/pulp-pycoverage-venv/bin/python tools/scripts/run_python_coverage.py --pattern 'tools/scripts/test_design_import_benchmark.py'` (`tools/scripts/design_import_benchmark.py` 99%)
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF`
- `cmake --build build --target pulp-test-design-import-benchmark -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-design-import-benchmark --reporter compact` (4 cases, 90 assertions)
- `git diff --check origin/main...HEAD`
- `python3 tools/import-validation/check-source-contracts.py --strict`
- `python3 tools/import-validation/test_source_contracts.py`
- `python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main`
- `python3 tools/scripts/version_bump_check.py --mode=report --base origin/main`

Note: local pre-push diff-cover was demoted with `PULP_DISABLE_PREPUSH_DIFF_COVER=1` after the known pinned mbedTLS FetchContent checkout failure (`107ea89daaefb9867ea9121002fbbdf926780e98`). CI remains authoritative.
