### PR TITLE
fix(cli): select build config at build time for multi-config generators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.192.1
+    VERSION 0.192.2
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/test/test_cli_create_targets.cpp
+++ b/test/test_cli_create_targets.cpp
@@ -4,6 +4,7 @@
 
 #include <vector>
 
+using pulp::cli::create_build_config;
 using pulp::cli::create_default_build_targets;
 
 TEST_CASE("CLI create targets use format suffixes for plugin projects", "[cli][create]") {
@@ -95,4 +96,20 @@ TEST_CASE("CLI create targets match complete format tokens only",
     CHECK(standalone_prefix == std::vector<std::string>{
         "PulpPlugin-test",
     });
+}
+
+TEST_CASE("CLI create selects build config at build/test time for multi-config generators",
+          "[cli][create][issue-2133]") {
+    // Codex P1 on PR #2133: `pulp create` set only the configure-time
+    // CMAKE_BUILD_TYPE, so on Visual Studio / Xcode multi-config generators
+    // `cmake --build` and `ctest` defaulted to Debug regardless of --debug.
+    // The config name must flow into `cmake --build --config <cfg>` and
+    // `ctest -C <cfg>`.
+    CHECK(create_build_config(false) == "Release");
+    CHECK(create_build_config(true) == "Debug");
+
+    // The fragments appended to the build/test commands resolve to the
+    // multi-config selectors the generators require.
+    CHECK((" --config " + create_build_config(false)) == " --config Release");
+    CHECK((" -C " + create_build_config(true)) == " -C Debug");
 }

--- a/tools/cli/cmd_create.cpp
+++ b/tools/cli/cmd_create.cpp
@@ -661,6 +661,7 @@ int cmd_create(const std::vector<std::string>& args) {
 
         std::string build_cmd = "cmake --build " + shell_quote(out_dir / "build");
         append_build_targets(build_cmd);
+        build_cmd += " --config " + pulp::cli::create_build_config(debug_build);
         rc = run_with_spinner(build_cmd, "Building");
         if (rc != 0) {
             std::cerr << "Build failed.\n";
@@ -668,7 +669,9 @@ int cmd_create(const std::vector<std::string>& args) {
         }
 
         log("\nRunning tests...\n");
-        rc = run("ctest --test-dir " + (out_dir / "build").string() + " --output-on-failure");
+        rc = run("ctest --test-dir " + (out_dir / "build").string()
+                 + " -C " + pulp::cli::create_build_config(debug_build)
+                 + " --output-on-failure");
         if (rc != 0) {
             std::cerr << "Tests failed.\n";
             return rc;
@@ -688,6 +691,7 @@ int cmd_create(const std::vector<std::string>& args) {
 
         std::string build_cmd = "cmake --build " + shell_quote(root / "build");
         append_build_targets(build_cmd);
+        build_cmd += " --config " + pulp::cli::create_build_config(debug_build);
         rc = run_with_spinner(build_cmd, "Building");
         if (rc != 0) {
             std::cerr << "Build failed.\n";
@@ -699,7 +703,9 @@ int cmd_create(const std::vector<std::string>& args) {
         if (fs::exists(test_binary)) {
             rc = run(test_binary.string());
         } else {
-            rc = run("ctest --test-dir " + (root / "build").string() + " -R \"" + name + "\" --output-on-failure");
+            rc = run("ctest --test-dir " + (root / "build").string()
+                     + " -C " + pulp::cli::create_build_config(debug_build)
+                     + " -R \"" + name + "\" --output-on-failure");
         }
         if (rc != 0) {
             std::cerr << "Tests failed.\n";

--- a/tools/cli/create_targets.cpp
+++ b/tools/cli/create_targets.cpp
@@ -74,4 +74,8 @@ std::vector<std::string> create_default_build_targets(const std::string& class_n
     return targets;
 }
 
+std::string create_build_config(bool debug) {
+    return debug ? "Debug" : "Release";
+}
+
 }  // namespace pulp::cli

--- a/tools/cli/create_targets.hpp
+++ b/tools/cli/create_targets.hpp
@@ -9,4 +9,17 @@ std::vector<std::string> create_default_build_targets(const std::string& class_n
                                                       const std::string& type,
                                                       const std::string& formats);
 
+// Returns the CMake build configuration name ("Release" by default, "Debug"
+// when debug is true).
+//
+// Multi-config generators (Visual Studio, Xcode) ignore the configure-time
+// CMAKE_BUILD_TYPE and require the configuration to be chosen at BUILD time via
+// `cmake --build --config <cfg>` and at TEST time via `ctest -C <cfg>`.
+// Single-config generators (Ninja, Unix Makefiles) honor CMAKE_BUILD_TYPE and
+// safely ignore these flags, so emitting `--config`/`-C` unconditionally is
+// correct on every generator. Codex P1 on PR #2133: setting only the
+// configure-time CMAKE_BUILD_TYPE left `pulp create` building Debug on Visual
+// Studio (and made `--debug` a no-op there).
+std::string create_build_config(bool debug);
+
 }  // namespace pulp::cli


### PR DESCRIPTION
## What

`pulp create` set only the configure-time `-DCMAKE_BUILD_TYPE`, but multi-config generators (Visual Studio, Xcode) ignore `CMAKE_BUILD_TYPE` — the configuration must be chosen at **build** time (`cmake --build --config <cfg>`) and **test** time (`ctest -C <cfg>`). Without those flags `pulp create` built Debug on Visual Studio regardless of the new default-Release behavior, and `--debug` was a no-op there.

## Fix

- New `pulp::cli::create_build_config(debug)` helper (sibling of `create_default_build_targets`).
- Threads `--config <cfg>` into both `cmake --build` invocations and `-C <cfg>` into both `ctest` invocations (standalone + example paths).
- Single-config generators (Ninja, Unix Makefiles) ignore these flags, so emitting them unconditionally is correct on every generator.

## Test

- New `[cli][create][issue-2133]` case in `test_cli_create_targets.cpp` asserting the config name + the appended `--config`/`-C` fragments.
- `pulp-test-cli-create-targets`: 12 assertions / 8 cases pass.
- `cmd_create.cpp` syntax-checked with the real GPU build flags.

## Why now

Addresses the only **unaddressed Codex P1** found by the refactor-roadmap final audit (originally raised on PR #2133, never resolved on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)