### PR TITLE
feat(render): GPU render time via Skia Graphite GpuStats (#2611)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.192.2
+    VERSION 0.193.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/render/include/pulp/render/gpu_render_time.hpp
+++ b/core/render/include/pulp/render/gpu_render_time.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <optional>
+
+namespace pulp::render {
+
+/// Phase 6.5 (re-scoped) — whole-recording GPU *render* time.
+///
+/// True per-pass GPU timing tied to Pulp's logical render passes is
+/// architecturally blocked: Skia Graphite owns the Dawn command encoder and
+/// every render-pass descriptor, so Pulp cannot inject per-pass
+/// `timestampWrites`, and the encoder-level `WriteTimestamp` is gated behind
+/// Dawn's `allow_unsafe_apis` toggle and disabled by Skia's `DawnCaps` on
+/// Metal/Apple-silicon (Pulp's primary platform). See
+/// `planning/2026-05-21-gpu-timestamp-readback-proposal.md`.
+///
+/// What IS available — and correct on every backend — is Skia Graphite's own
+/// GPU-stats API: `InsertRecordingInfo::fGpuStatsFlags = kElapsedTime` plus a
+/// finished-with-stats callback that hands back a `GpuStats{elapsedTime}` in
+/// nanoseconds once the GPU finishes the recording. `SkiaSurface` wires that
+/// callback; this header carries the *pure*, Dawn-free seam — the ns→ms
+/// conversion + the cross-thread latest-sample holder — so it can be unit
+/// tested without a live GPU device.
+///
+/// Naming note: it is "GPU render time", not total frame time. On the Metal
+/// fallback Skia measures first-pass-begin → last-pass-end of the recording
+/// and excludes non-pass work (texture uploads/copies) and present.
+
+/// Nanoseconds per millisecond. WebGPU timestamps resolve in nanoseconds and
+/// Skia reports `results[1] - results[0]` directly, so no per-device period.
+inline constexpr double kGpuRenderNanosecondsPerMillisecond = 1.0e6;
+
+/// Convert a Graphite `GpuStats::elapsedTime` sample into a millisecond
+/// duration. Returns `std::nullopt` — meaning "no usable sample this frame" —
+/// when the finished-with-stats callback did not succeed, or when the elapsed
+/// time is zero (Skia surfaces 0 when no pass was timestamped, the timer setup
+/// failed, or the work was effectively zero/quantized — never a real sample).
+[[nodiscard]] inline std::optional<double>
+gpu_render_ns_to_ms(std::uint64_t elapsed_ns, bool callback_ok) {
+    if (!callback_ok || elapsed_ns == 0) {
+        return std::nullopt;
+    }
+    return static_cast<double>(elapsed_ns) / kGpuRenderNanosecondsPerMillisecond;
+}
+
+/// Thread-safe holder for the latest GPU render-time sample.
+///
+/// The Graphite finished-with-stats callback fires on whatever thread pumps
+/// GPU completion (the render thread, via `Context::submit`), while the
+/// inspector reads from the UI thread. A scalar duration + a "have a sample
+/// yet" flag are independent atomics; a stale read across the pair is
+/// harmless (it only ever shows a slightly older valid duration). Relaxed
+/// ordering is sufficient — there is no other state these guard.
+class GpuRenderTimeTracker {
+public:
+    /// Store a sample from the finished-with-stats callback. Ignored when the
+    /// callback failed or the elapsed time is zero (so the last good sample is
+    /// retained rather than being clobbered by a "no sample" frame).
+    void store(std::uint64_t elapsed_ns, bool callback_ok) {
+        if (auto ms = gpu_render_ns_to_ms(elapsed_ns, callback_ok)) {
+            last_ms_.store(*ms, std::memory_order_relaxed);
+            have_sample_.store(true, std::memory_order_relaxed);
+        }
+    }
+
+    /// True once at least one valid sample has landed. Lets the inspector
+    /// distinguish "supported, waiting for the first sample" from "0 ms".
+    [[nodiscard]] bool have_sample() const {
+        return have_sample_.load(std::memory_order_relaxed);
+    }
+
+    /// The most recent valid GPU render duration in milliseconds (0 until the
+    /// first sample lands).
+    [[nodiscard]] double last_ms() const {
+        return last_ms_.load(std::memory_order_relaxed);
+    }
+
+private:
+    std::atomic<double> last_ms_{0.0};
+    std::atomic<bool> have_sample_{false};
+};
+
+} // namespace pulp::render

--- a/core/render/include/pulp/render/skia_surface.hpp
+++ b/core/render/include/pulp/render/skia_surface.hpp
@@ -67,6 +67,20 @@ public:
     /// read back any GPU-texture-backed embedded images instead of
     /// silently dropping them. The pointer is owned by the SkiaSurface.
     virtual skgpu::graphite::Context* graphite_context() const = 0;
+
+    /// Phase 6.5 (re-scoped) — most recent whole-recording GPU *render* time
+    /// in milliseconds, sampled from Skia Graphite's GpuStats(kElapsedTime)
+    /// finished-with-stats callback. Returns 0 until the first sample lands or
+    /// when timing is unavailable. This is render-recording time, not total
+    /// frame time (on the Metal fallback it excludes non-pass uploads/copies
+    /// and present). See `gpu_render_time.hpp` and
+    /// `planning/2026-05-21-gpu-timestamp-readback-proposal.md`.
+    virtual double gpu_render_time_ms() const = 0;
+
+    /// Whether GPU render timing is available this run — the adapter offered
+    /// `timestamp-query` AND Graphite advertises `kElapsedTime`. When false the
+    /// inspector should show the honest "GPU timing unavailable".
+    virtual bool gpu_render_timing_available() const = 0;
 };
 
 } // namespace pulp::render

--- a/core/render/src/gpu_surface_dawn.cpp
+++ b/core/render/src/gpu_surface_dawn.cpp
@@ -109,6 +109,22 @@ public:
         // Request device
         wgpu::DeviceDescriptor device_desc{};
         device_desc.label = "Pulp GPU Device";
+
+        // Phase 6.5 — opt the device into `timestamp-query` when the adapter
+        // offers it, so Skia Graphite can report per-recording GPU render time
+        // via its GpuStats(kElapsedTime) path (see SkiaSurface). Strictly
+        // gated: requesting a feature the adapter lacks fails RequestDevice, so
+        // only add it when advertised. Absent the feature, GPU render time is
+        // reported unavailable and CPU timing stands alone. `ts_feature` must
+        // outlive the synchronous RequestDevice call below — it does (same
+        // scope).
+        wgpu::FeatureName ts_feature = wgpu::FeatureName::TimestampQuery;
+        if (adapter_.HasFeature(wgpu::FeatureName::TimestampQuery)) {
+            device_desc.requiredFeatureCount = 1;
+            device_desc.requiredFeatures = &ts_feature;
+            runtime::log_info("GpuSurface: enabling timestamp-query (GPU render time gated on Graphite supportedGpuStats)");
+        }
+
         device_desc.SetUncapturedErrorCallback(
             [](const wgpu::Device&, wgpu::ErrorType type, wgpu::StringView message) {
                 runtime::log_error("GpuSurface: WebGPU error ({}): {}",

--- a/core/render/src/skia_surface.cpp
+++ b/core/render/src/skia_surface.cpp
@@ -3,12 +3,14 @@
 #ifdef PULP_HAS_SKIA
 
 #include <pulp/canvas/skia_canvas.hpp>
+#include <pulp/render/gpu_render_time.hpp>
 #include <pulp/runtime/log.hpp>
 
 // Dawn C++ API (from Skia's bundled Dawn)
 #include "webgpu/webgpu_cpp.h"
 
 // Skia Graphite headers
+#include "include/gpu/GpuTypes.h"            // GpuStats, GpuStatsFlags
 #include "include/gpu/graphite/Context.h"
 #include "include/gpu/graphite/ContextOptions.h"
 #include "include/gpu/graphite/Recorder.h"
@@ -33,7 +35,13 @@ public:
 
     ~SkiaSurfaceImpl() override {
         if (context_) {
-            context_->submit({});
+            // Drain any outstanding GpuStats finished-with-stats callbacks
+            // before `this` dies — they capture `this` as their context, so a
+            // pending callback firing after destruction would be a
+            // use-after-free. A sync submit + completion check flushes them
+            // while the object is still alive.
+            context_->submit(skgpu::graphite::SyncToCpu::kYes);
+            context_->checkAsyncWorkCompletion();
         }
     }
 
@@ -69,11 +77,22 @@ public:
             return false;
         }
 
+        // Phase 6.5 (re-scoped) — probe whether Graphite can report
+        // per-recording GPU render time on this device. Graphite backs
+        // kElapsedTime with Dawn timestamp queries, so it only advertises the
+        // stat when the shared device enabled `timestamp-query` (GpuSurface
+        // requests it when the adapter offers it). GpuStatsFlags has no
+        // bitmask operators, so test via the underlying uint32_t.
+        gpu_elapsed_supported_ =
+            (static_cast<std::uint32_t>(context_->supportedGpuStats()) &
+             static_cast<std::uint32_t>(skgpu::GpuStatsFlags::kElapsedTime)) != 0;
+
         // Create offscreen fallback target (used when no presentable surface)
         create_offscreen_target();
 
-        runtime::log_info("SkiaSurface: Graphite initialized on shared Dawn device (presentable: {})",
-            gpu_.has_surface() ? "yes" : "no");
+        runtime::log_info("SkiaSurface: Graphite initialized on shared Dawn device (presentable: {}, gpu-render-time: {})",
+            gpu_.has_surface() ? "yes" : "no",
+            gpu_elapsed_supported_ ? "available" : "unavailable");
         return true;
     }
 
@@ -147,6 +166,18 @@ public:
         if (recording) {
             skgpu::graphite::InsertRecordingInfo info;
             info.fRecording = recording.get();
+
+            // Phase 6.5 (re-scoped) — request GPU render time for this
+            // recording. The callback fires on a later submit/completion (so
+            // the value lags ~1 frame); it captures `this`, which is kept
+            // alive by the destructor drain. Only request when supported so
+            // unsupported devices pay nothing.
+            if (gpu_elapsed_supported_) {
+                info.fGpuStatsFlags = skgpu::GpuStatsFlags::kElapsedTime;
+                info.fFinishedContext = this;
+                info.fFinishedWithStatsProc = &SkiaSurfaceImpl::on_gpu_stats;
+            }
+
             context_->insertRecording(info);
             context_->submit({});
         }
@@ -239,10 +270,36 @@ public:
         return context_.get();
     }
 
+    double gpu_render_time_ms() const override {
+        return gpu_render_tracker_.last_ms();
+    }
+
+    bool gpu_render_timing_available() const override {
+        return gpu_elapsed_supported_;
+    }
+
 private:
+    // Graphite finished-with-stats callback (Phase 6.5 re-scoped). Fires on
+    // the thread pumping GPU completion (render thread, via Context::submit)
+    // once the GPU finishes the recording. Stores the elapsed time (ns) into
+    // the cross-thread tracker; treats a failed callback or zero elapsed as
+    // "no sample" so the last good value is retained.
+    static void on_gpu_stats(skgpu::graphite::GpuFinishedContext ctx,
+                             skgpu::CallbackResult result,
+                             const skgpu::GpuStats& stats) {
+        auto* self = static_cast<SkiaSurfaceImpl*>(ctx);
+        if (!self) return;
+        self->gpu_render_tracker_.store(
+            stats.elapsedTime, result == skgpu::CallbackResult::kSuccess);
+    }
+
     GpuSurface& gpu_;
     uint32_t width_ = 0, height_ = 0;
     float scale_ = 1.0f;
+
+    // Phase 6.5 (re-scoped) — GPU render time via Graphite GpuStats.
+    bool gpu_elapsed_supported_ = false;  ///< Set once in init() from supportedGpuStats().
+    GpuRenderTimeTracker gpu_render_tracker_;  ///< Latest sample; written by on_gpu_stats().
 
     std::unique_ptr<skgpu::graphite::Context> context_;
     std::unique_ptr<skgpu::graphite::Recorder> recorder_;

--- a/docs/reference/rendering.md
+++ b/docs/reference/rendering.md
@@ -98,6 +98,49 @@ style.line_thickness = 2.0f;
 canvas.draw_waveform(samples, count, x, y, w, h, style);
 ```
 
+## GPU Render Time
+
+Pulp can report **true GPU-side render time** alongside the CPU wall-time the
+inspector has always shown. It is exposed on the Skia surface:
+
+```cpp
+auto* skia = /* pulp::render::SkiaSurface* */;
+if (skia->gpu_render_timing_available()) {
+    double ms = skia->gpu_render_time_ms();  // 0 until the first sample lands
+}
+```
+
+**This is whole-recording GPU render time, not per-pass attribution.** That
+distinction is deliberate and load-bearing:
+
+- The number comes from Skia Graphite's own GPU-stats API
+  (`InsertRecordingInfo::fGpuStatsFlags = kElapsedTime`), which measures the GPU
+  elapsed time of the *recording Pulp submits each frame* — not Pulp's logical
+  render passes (background / content / effects / overlay / post). Skia Graphite
+  owns the Dawn command encoder and every render-pass descriptor, so Pulp cannot
+  inject per-pass `timestampWrites`. True per-pass GPU attribution would require
+  Skia to expose that granularity (or Pulp to own more of the render graph).
+- WebGPU timestamp queries *can* measure command timing, but the API in use here
+  surfaces recording-level elapsed time, not detailed per-pass attribution. See
+  the WebGPU/Chromium discussion of this exact distinction:
+  <https://groups.google.com/a/chromium.org/g/blink-dev/c/dtYJ0MQYMlU>.
+- On the **Metal** backend (Apple platforms) Skia disables Dawn command-buffer
+  timestamps and falls back to render/compute-pass timestamp writes, so the
+  measurement spans first-pass-begin → last-pass-end of the recording and
+  **excludes** non-pass work (texture uploads/copies) and `Present()`.
+
+**Availability and honesty rules:**
+
+- Requires the Dawn `timestamp-query` feature. Pulp requests it only when the
+  adapter advertises it; otherwise GPU render time is reported **unavailable**.
+- `gpu_render_timing_available()` reflects device/feature support; an
+  unsupported platform reports unavailable rather than a fake `0`.
+- A failed sample or a zero elapsed time is treated as "no sample" — the last
+  good value is retained, never overwritten with a misleading `0`.
+
+Design rationale and the per-pass feasibility analysis live in
+`planning/2026-05-21-gpu-timestamp-readback-proposal.md`.
+
 ## Gradients
 
 ```cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1957,6 +1957,16 @@ catch_discover_tests(pulp-test-gpu-timestamps
     PROPERTIES
         LABELS coverage)
 
+add_executable(pulp-test-gpu-render-time
+    test_gpu_render_time.cpp)
+target_include_directories(pulp-test-gpu-render-time PRIVATE
+    ${CMAKE_SOURCE_DIR}/core/render/include)
+target_link_libraries(pulp-test-gpu-render-time PRIVATE
+    Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-gpu-render-time
+    PROPERTIES
+        LABELS coverage)
+
 add_executable(pulp-test-render-loop
     test_render_loop.cpp
     ${CMAKE_SOURCE_DIR}/core/render/src/render_loop.cpp)

--- a/test/test_gpu_render_time.cpp
+++ b/test/test_gpu_render_time.cpp
@@ -1,0 +1,72 @@
+// Phase 6.5 (re-scoped) — GPU render time pure-logic tests.
+//
+// The Dawn/Graphite plumbing (SkiaSurface's GpuStats callback) needs a live
+// GPU device + window and is exercised by the on-device smoke / CI macOS lane.
+// The pure seam — ns→ms conversion + the "0 or failed callback == no sample"
+// rule + the cross-thread latest-sample holder — is Dawn-free and tested here
+// with synthetic samples, the same way DwmBackendTracker / the old per-pass
+// timestamp math are unit-tested without a GPU.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/render/gpu_render_time.hpp>
+
+using namespace pulp::render;
+
+TEST_CASE("gpu_render_ns_to_ms converts a successful sample",
+          "[render][gpu-render-time][issue-2611]") {
+    // 1 ms == 1e6 ns.
+    auto ms = gpu_render_ns_to_ms(1'000'000, /*callback_ok=*/true);
+    REQUIRE(ms.has_value());
+    REQUIRE(*ms == 1.0);
+
+    // 16.667 ms ≈ a 60 Hz frame.
+    auto frame = gpu_render_ns_to_ms(16'667'000, true);
+    REQUIRE(frame.has_value());
+    REQUIRE(*frame > 16.6);
+    REQUIRE(*frame < 16.7);
+}
+
+TEST_CASE("gpu_render_ns_to_ms reports no sample for zero or failed callbacks",
+          "[render][gpu-render-time][issue-2611]") {
+    // Zero elapsed is Skia's "no pass timestamped / timer failed" sentinel.
+    REQUIRE_FALSE(gpu_render_ns_to_ms(0, true).has_value());
+    // A failed callback is never a usable duration, even with non-zero ns.
+    REQUIRE_FALSE(gpu_render_ns_to_ms(5'000'000, false).has_value());
+    REQUIRE_FALSE(gpu_render_ns_to_ms(0, false).has_value());
+}
+
+TEST_CASE("GpuRenderTimeTracker starts with no sample",
+          "[render][gpu-render-time][issue-2611]") {
+    GpuRenderTimeTracker t;
+    REQUIRE_FALSE(t.have_sample());
+    REQUIRE(t.last_ms() == 0.0);
+}
+
+TEST_CASE("GpuRenderTimeTracker stores a valid sample",
+          "[render][gpu-render-time][issue-2611]") {
+    GpuRenderTimeTracker t;
+    t.store(2'000'000, /*callback_ok=*/true);  // 2 ms
+    REQUIRE(t.have_sample());
+    REQUIRE(t.last_ms() == 2.0);
+}
+
+TEST_CASE("GpuRenderTimeTracker retains the last good sample across no-sample frames",
+          "[render][gpu-render-time][issue-2611]") {
+    GpuRenderTimeTracker t;
+    t.store(3'000'000, true);            // 3 ms — good
+    REQUIRE(t.last_ms() == 3.0);
+
+    // A failed callback or zero-elapsed frame must NOT clobber the last good
+    // value to 0 — the inspector keeps showing the most recent real duration.
+    t.store(0, true);
+    REQUIRE(t.have_sample());
+    REQUIRE(t.last_ms() == 3.0);
+
+    t.store(9'000'000, false);
+    REQUIRE(t.last_ms() == 3.0);
+
+    // A new valid sample updates it.
+    t.store(5'000'000, true);            // 5 ms
+    REQUIRE(t.last_ms() == 5.0);
+}


### PR DESCRIPTION
## What

Ships **whole-recording GPU render time** for the inspector via Skia Graphite's own GPU-stats API (`InsertRecordingInfo::fGpuStatsFlags = kElapsedTime`), resolving the actionable part of #2611 / Phase 6.5.

## Why this scope (not per-pass)

True per-pass GPU timing tied to Pulp's logical passes is **architecturally blocked**: Skia Graphite owns the Dawn command encoder and every render-pass descriptor, so Pulp cannot inject per-pass `timestampWrites`; and the encoder-level `WriteTimestamp` is gated behind Dawn's `allow_unsafe_apis` toggle and **disabled by Skia's `DawnCaps` on Metal/Apple-silicon** (Pulp's primary platform). This is "whole-recording GPU render time", explicitly **not** per-pass attribution — see the design + 3-cycle review (incl. codex-consult) in `planning/2026-05-21-gpu-timestamp-readback-proposal.md`.

## Changes

- **`gpu_surface_dawn.cpp`** — request the `timestamp-query` device feature, strictly gated on `adapter.HasFeature` (requesting an unsupported feature fails `RequestDevice`).
- **`gpu_render_time.hpp`** (new) — pure, Dawn-free, unit-tested seam: ns→ms conversion + a cross-thread latest-sample holder. `0`/failed-callback = "no sample" (keeps the last good value; never reports a fake `0`).
- **`skia_surface.{hpp,cpp}`** — gate on `Context::supportedGpuStats() & kElapsedTime`; request `kElapsedTime` + a finished-with-stats callback per recording; store elapsed ns into the tracker; **drain pending callbacks in the destructor** (sync submit + `checkAsyncWorkCompletion`) to avoid a use-after-free of the captured `this`. New accessors `gpu_render_time_ms()` / `gpu_render_timing_available()`.
- The dead per-pass `GpuTimestamps` QuerySet path is left untouched here (retired in a follow-up); this does **not** fake a single pass into `RenderPassManager`.

## Semantics

Labeled **GPU render time**, gated on `timestamp-query`/device support; unsupported platforms report **unavailable, not zero** (the tracker distinguishes "no sample yet" from a real `0`). On the Metal fallback it measures the recording's render passes (first-pass-begin → last-pass-end), excluding non-pass uploads/copies and present — documented in the header.

## Validation (before this PR)

Built a **GPU release** locally and ran the **Chainer** UI on Apple-silicon via `ui-preview`:
- Compiles clean in a real Skia/Dawn build; Chainer renders unchanged.
- `timestamp-query` enabled → `available=true` → real ~3–4 ms/frame GPU render time (varying frame-to-frame, quantized to the Metal timer resolution).
- Unit test `pulp-test-gpu-render-time` passes (17 assertions / 5 cases).
- codex-consult review of the diff: no P1/P2 correctness/safety findings.

## Follow-up (tracked)

Surfacing "GPU render time" beside CPU time in the inspector overlay + retiring the dead per-pass QuerySet code — separate PR (the inspector↔render wiring is diffuse). Tracked under #2611.

🤖 Generated with [Claude Code](https://claude.com/claude-code)