### PR TITLE
refactor(view): embed JS preludes as an extern-linked TU (P8-5, #2641)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.193.0
+    VERSION 0.193.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -65,11 +65,12 @@ set(PULP_JS_PRELUDES
     ${CMAKE_CURRENT_SOURCE_DIR}/js/import-runtime.js
 )
 set(PULP_JS_EMBEDDED_HEADER ${CMAKE_CURRENT_BINARY_DIR}/web_compat_preludes_gen.hpp)
+set(PULP_JS_EMBEDDED_SOURCE ${CMAKE_CURRENT_BINARY_DIR}/web_compat_preludes_gen.cpp)
 
 # pulp #1382 — embed_js.cmake's `string(SUBSTRING)` chunker operates on
 # BYTES, so a 12000-byte chunk boundary that lands inside a UTF-8
 # multi-byte codepoint splits the codepoint mid-sequence. The result
-# is a generated header with invalid UTF-8 at chunk boundaries; MSVC
+# is a generated file with invalid UTF-8 at chunk boundaries; MSVC
 # then mis-parses the trailing `)__JS__"` delimiter, walks past it
 # into the next R"__JS__()__JS__" header, and reports C2026 ("string
 # too big") on the runaway literal. Used to be a non-issue when the
@@ -82,47 +83,60 @@ set(PULP_JS_EMBEDDED_HEADER ${CMAKE_CURRENT_BINARY_DIR}/web_compat_preludes_gen.
 # Switch to that.
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
+# P8-5 (#2641) — split the embedded preludes into an extern-linked TU so a
+# JS-prelude edit no longer recompiles the 9.7k-line widget_bridge.cpp.
+#
+# * The DECLARATION header is generated here at *configure* time from the
+#   prelude file list, written only-if-changed. Its content depends only on
+#   the file *names* (not their contents), so editing a .js prelude never
+#   bumps its mtime — and thus never recompiles widget_bridge.cpp, which
+#   includes only this header. (Mirrors tools/cmake/PulpEmbedData.cmake.)
+# * The DEFINITION .cpp is generated at *build* time by embed_js.py and
+#   compiled as its own translation unit; a .js edit rebuilds only this .cpp
+#   + relink.
+#
+# The var-name derivation (stem with '-' -> '_') MUST match embed_js.py.
+set(_pulp_prelude_decls
+    "#pragma once\n// Auto-generated from the JS prelude file list — do not edit\n\nnamespace pulp::view::preludes {\n\n")
+foreach(_prelude ${PULP_JS_PRELUDES})
+    get_filename_component(_prelude_stem "${_prelude}" NAME_WE)
+    string(REPLACE "-" "_" _prelude_var "${_prelude_stem}")
+    string(APPEND _pulp_prelude_decls "extern const char* const ${_prelude_var};\n")
+endforeach()
+string(APPEND _pulp_prelude_decls "\n}  // namespace pulp::view::preludes\n")
+
+set(_pulp_existing_decls "")
+if(EXISTS "${PULP_JS_EMBEDDED_HEADER}")
+    file(READ "${PULP_JS_EMBEDDED_HEADER}" _pulp_existing_decls)
+endif()
+if(NOT "${_pulp_existing_decls}" STREQUAL "${_pulp_prelude_decls}")
+    file(WRITE "${PULP_JS_EMBEDDED_HEADER}" "${_pulp_prelude_decls}")
+endif()
+
 add_custom_command(
-    OUTPUT ${PULP_JS_EMBEDDED_HEADER}
+    OUTPUT ${PULP_JS_EMBEDDED_SOURCE}
     COMMAND ${Python3_EXECUTABLE}
         ${CMAKE_CURRENT_SOURCE_DIR}/js/embed_js.py
-        ${PULP_JS_EMBEDDED_HEADER}
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/css-colors.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/css-parser.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/web-compat-element.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/web-compat-element-events.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/web-compat-canvas.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/web-compat-canvas-gpu.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/web-compat-canvas-matrix.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/web-compat-canvas-image.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/web-compat-style-decl.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/web-compat-style-decl-layout.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/web-compat-style-decl-paint.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/web-compat-style-decl-typography.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/web-compat-style-decl-transform.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/web-compat-style-decl-misc.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/web-compat-style-decl-helpers.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/web-compat-document.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/web-compat-document-selectors.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/web-compat-document-gpu-mock.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/web-compat-dom-ops.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/web-compat-gpu-buffered.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/web-compat-observers.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/web-compat-scheduler.js
-        ${CMAKE_CURRENT_SOURCE_DIR}/js/import-runtime.js
+        ${PULP_JS_EMBEDDED_SOURCE}
+        ${PULP_JS_PRELUDES}
     DEPENDS
         ${PULP_JS_PRELUDES}
         ${CMAKE_CURRENT_SOURCE_DIR}/js/embed_js.py
-    COMMENT "Embedding JS preludes into C++ header (UTF-8-safe Python chunker)"
+    COMMENT "Embedding JS preludes into C++ source (UTF-8-safe Python chunker)"
+    VERBATIM
 )
-add_custom_target(pulp-view-js-preludes DEPENDS ${PULP_JS_EMBEDDED_HEADER})
+
+# The generated .cpp is a real pulp-view source: CMake wires the
+# custom-command dependency automatically, so no separate aggregator target
+# is needed. widget_bridge.cpp includes only the (stable) declaration header.
+target_sources(pulp-view PRIVATE ${PULP_JS_EMBEDDED_SOURCE})
 
 target_include_directories(pulp-view
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
     PRIVATE
-        ${CMAKE_CURRENT_BINARY_DIR}  # For generated web_compat_preludes_gen.hpp
+        ${CMAKE_CURRENT_BINARY_DIR}  # For generated web_compat_preludes_gen.{hpp,cpp}
 )
 
 # ── JS engine backend selection ──────────────────────────────────────────────
@@ -361,8 +375,6 @@ target_include_directories(pulp-view PUBLIC
     $<BUILD_INTERFACE:${choc_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include>
 )
-
-add_dependencies(pulp-view pulp-view-js-preludes)
 
 target_link_libraries(pulp-view PUBLIC pulp::canvas pulp::events pulp::state pulp::signal pulp::platform pulp::host)
 # pulp #468 — design_import.cpp uses pulp::runtime::base64_decode +

--- a/core/view/js/embed_js.py
+++ b/core/view/js/embed_js.py
@@ -1,5 +1,21 @@
 #!/usr/bin/env python3
-"""Generate a C++ header that embeds JS preludes as concatenated raw strings."""
+"""Generate a C++ source file that DEFINES the JS preludes as externally
+linkable string constants.
+
+P8-5 (#2641): the preludes used to be emitted as `static const char*`
+definitions inside `web_compat_preludes_gen.hpp`, which was `#include`d
+directly by the 9,792-line widget_bridge.cpp. Every JS-prelude edit therefore
+recompiled widget_bridge.cpp (and re-tokenized ~458 KB of raw-string literals).
+
+Now the definitions live in this generated `.cpp` (its own translation unit)
+and the matching `extern const char* const` declarations live in
+`web_compat_preludes_gen.hpp`, which is generated at CMake *configure* time
+from the same prelude file list (see core/view/CMakeLists.txt). Editing a
+prelude rebuilds only this generated `.cpp` + relink — not widget_bridge.cpp.
+
+The variable-name derivation here (file stem with '-' -> '_') MUST stay in
+sync with the header generator in core/view/CMakeLists.txt.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +24,9 @@ import sys
 
 # Keep raw string chunks comfortably below MSVC's per-literal limit.
 # The generator preserves exact JS bytes, so smaller chunks are safe.
+# (pulp #1382: slice on Python str — char-aware — so chunk boundaries never
+# split a UTF-8 multi-byte codepoint, which would corrupt the R"__JS__(...)"
+# delimiter and trip MSVC C2026.)
 CHUNK_SIZE = 4000
 
 
@@ -21,28 +40,28 @@ def chunk_text(text: str, chunk_size: int) -> list[str]:
 
 def main(argv: list[str]) -> int:
     if len(argv) < 3:
-        print("usage: embed_js.py <output.hpp> <input1.js> [input2.js ...]", file=sys.stderr)
+        print("usage: embed_js.py <output.cpp> <input1.js> [input2.js ...]", file=sys.stderr)
         return 1
 
     output_path = pathlib.Path(argv[1])
     input_paths = [pathlib.Path(arg) for arg in argv[2:]]
 
     parts = [
-        "#pragma once\n",
         "// Auto-generated from JS prelude files — do not edit\n",
+        '#include "web_compat_preludes_gen.hpp"\n\n',
         "namespace pulp::view::preludes {\n\n",
     ]
 
     for input_path in input_paths:
         text = input_path.read_text(encoding="utf-8")
-        parts.append(f"static const char* {var_name_for(input_path)} =\n")
+        parts.append(f"const char* const {var_name_for(input_path)} =\n")
         for chunk in chunk_text(text, CHUNK_SIZE):
             parts.append('R"__JS__(')
             parts.append(chunk)
             parts.append(')__JS__"\n')
         parts.append(";\n\n")
 
-    parts.append("} // namespace pulp::view::preludes\n")
+    parts.append("}  // namespace pulp::view::preludes\n")
     output_path.write_text("".join(parts), encoding="utf-8")
     return 0
 


### PR DESCRIPTION
## What

The generated web-compat preludes (~458KB of raw-string literals across 23 .js files) were emitted as `static const char*` definitions in `web_compat_preludes_gen.hpp`, `#include`d directly by the 9.7k-line `widget_bridge.cpp`. Every JS-prelude edit recompiled widget_bridge.cpp (and re-tokenized all 458KB).

## Fix (mirrors `tools/cmake/PulpEmbedData.cmake`)

- **Declaration header** (`extern const char* const …;`) is generated at CMake **configure** time from the prelude file *list*, written **only-if-changed** — its content depends only on file *names*, so editing a .js prelude never bumps its mtime and never recompiles widget_bridge.cpp (which includes only this header).
- **Definition .cpp** (`const char* const … = R"__JS__(…)__JS__"`) is emitted by `embed_js.py` and compiled as its own pulp-view TU; a prelude edit rebuilds only that .cpp + relink.
- UTF-8-safe chunker (CHUNK_SIZE=4000, pulp #1382) and `pulp::view::preludes::` symbol surface unchanged; widget_bridge.cpp untouched.

## Incremental-build proof (validation criterion)

arm64, GPU off. Touched `core/view/js/css-colors.js`, rebuilt `pulp-view --verbose`:
- ✅ Only `web_compat_preludes_gen.cpp.o` recompiled (mtime bumped), then `ar` re-archived `libpulp-view.a`.
- ✅ `widget_bridge.cpp.o` **mtime unchanged** — NOT recompiled. No `Building CXX … widget_bridge.cpp.o` line in verbose output.

## Test

`pulp-test-widget-bridge-runtime-import`: 36 assertions / 12 cases pass (preludes load + evaluate correctly via the extern TU).

Closes #2641.

🤖 Generated with [Claude Code](https://claude.com/claude-code)