### PR TITLE
fix(import-design): close review followups

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -71,6 +71,35 @@ Do not push empty commits just to churn queued macOS checks. Cancel
 superseded SHAs, rebase or push only when a PR needs current `main`, and
 wait unless a check has actually failed.
 
+## PR Review Thread Hygiene
+
+Before opening a follow-up PR or declaring a phase complete, sweep review
+threads for the PRs touched by that phase:
+
+```bash
+gh api graphql -f query='
+query($owner:String!, $repo:String!, $number:Int!) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$number) {
+      reviewThreads(first:100) {
+        nodes {
+          isResolved
+          isOutdated
+          comments(first:20) {
+            nodes { url body author { login } }
+          }
+        }
+      }
+    }
+  }
+}' -F owner=danielraffel -F repo=pulp -F number=<PR>
+```
+
+For every unresolved thread, either fix it in the follow-up branch or verify
+that current `main` already fixed it. Leave a reply on the original thread with
+the fixing commit/PR and the validation that proved it, so future sweeps can
+distinguish addressed-but-unresolved GitHub state from actual pending work.
+
 ## Shipping a PR: route through `shipyard pr`
 
 When the user says any of: **"push to main"**, **"ship this"**, **"ship it"**,

--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -172,8 +172,11 @@ asset reference points at HTTP(S).
 
 `--mode baked` is implemented for `--emit ir-json` and `--emit cpp`; `cpp`
 requires baked mode. `--mode live` remains the default and `--from jsx --mode
-live --emit js` writes the precompiled bundle verbatim. When changing this
-lane, keep the CLI help, `docs/status/cli-commands.yaml`,
+live --emit js` writes the precompiled bundle verbatim. Because that path does
+not parse or render the bundle, it must reject `--validate`, `--reference`,
+`--diff`, and `--debug` with a clear usage error rather than silently bypassing
+shared post-processing. When changing this lane, keep the CLI help,
+`docs/status/cli-commands.yaml`,
 `docs/reference/cli.md`, `docs/reference/design-import.md`, and the
 import-design skill aligned. The JSX baked snapshot policy is
 `--snapshot-semantics {fail|warn|accept}`: `fail` rejects dynamic APIs by

--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -105,9 +105,12 @@ const CppExportOptions&)`. CLI usage is `pulp import-design --mode baked --emit
 cpp --output imported_ui.cpp`; the tool writes the sibling `.hpp` by default.
 Generated code should contain direct widget construction, stable anchor IDs,
 token/asset constants, `bake_asset_manifest()`, and TODO comments for unresolved
-audio parameter or meter bindings. Preserve duplicate token names even when
-their values alias, and emit non-hex semantic color tokens as strings rather
-than trying to parse them as colors.
+audio parameter or meter bindings. Knob current value and reset default are
+distinct: emitted `set_value(...)` may come from the normalized `value`
+attribute, while `set_default_value(...)` must come from normalized
+`audio_default`. Preserve duplicate token names even when their values alias,
+and emit non-hex semantic color tokens as strings rather than trying to parse
+them as colors.
 
 The Phase 5/7/9 benchmark harness lives at `pulp-design-import-bench` and is driven
 by `tools/scripts/design_import_benchmark.py`. Run it under no-launch env
@@ -176,8 +179,9 @@ Ask the user or detect from context:
 - Representative fixtures live under `planning/fixtures/stitch/`; the primary one is `transport-bar.tsx` (transport controls + range sliders + canvas VU meter). Run `tools/import-validation/stitch-roundtrip.sh --parser-only` for the parser/dispatch gate.
 
 **JSX-instrument runtime-import (experiment slice, 2026-05-17, planning/2026-05-17-jsx-instrument-import.md)**:
-- Unlike v0/figma/stitch, the `jsx` source is NOT a synthetic shape-counter — it executes the user's real React tree. `parse_jsx_react(bundle_js, component_name)` wraps a pre-compiled IIFE bundle (esbuild output of React + ReactDOM + user JSX + nav/document sandbox shims) as a synthetic `ClaudeBundle`, then the existing `parse_claude_html_with_runtime` harness materializes it into a `DesignIR` via the live React reconciler + web-compat DOM shim. **Per Codex/RepoPrompt review:** custom inline-defined components (knobs, faders, etc.) materialize as their underlying SVG primitives — DO NOT widget-promote them to native `<Knob>`/`<Fader>`, which would lose visual parity with the source JSX.
-- The JSX→JS compile happens in Node, not in the C++ runtime. Run `tools/import-design/jsx-runtime/jsx-transform.mjs --in <file>.jsx --out <out>.js` to produce the IIFE bundle. The script ships its own `node_modules` (React 18.3.1 + ReactDOM 18.3.1 + esbuild 0.24.0) at `tools/import-design/jsx-runtime/node_modules/`. First-run `npm install` is required.
+- Unlike v0/figma/stitch, the `jsx` source is NOT a synthetic shape-counter — it executes the user's real React tree. `parse_jsx_react(bundle_js, component_name)` wraps a pre-compiled IIFE bundle (esbuild output of React plus either ReactDOM or the @pulp/react native bridge + user JSX + nav/document sandbox shims) as a synthetic `ClaudeBundle`, then the existing `parse_claude_html_with_runtime` harness materializes it into a `DesignIR` via DOM walking or the native `WidgetBridge` snapshot fallback. **Per Codex/RepoPrompt review:** custom inline-defined components (knobs, faders, etc.) materialize as their underlying SVG primitives — DO NOT widget-promote them to native `<Knob>`/`<Fader>`, which would lose visual parity with the source JSX.
+- The JSX→JS compile happens in Node, not in the C++ runtime. Run `tools/import-design/jsx-runtime/jsx-transform.mjs --in <file>.jsx --out <out>.js` to produce the IIFE bundle. The script ships its own `node_modules` (React 18.3.1 + ReactDOM 18.3.1 + react-reconciler 0.29.2 + scheduler 0.23.2 + esbuild 0.24.0) at `tools/import-design/jsx-runtime/node_modules/`. First-run `npm install` is required.
+- Current Chainer/native bundles route `react-dom` through `pulp-react-dom-shim.mjs` and `@pulp/react`. The live lane writes that bundle verbatim. The baked lane first tries the DOM walker; when the bundle renders native views instead of DOM nodes, it freezes the `WidgetBridge` tree into DesignIR with `capture_method = runtime_native_snapshot` and `snapshotSource = native-view`, then can emit baked C++ from that IR.
 - Supported input today: single-file `.jsx` or `.tsx`, default-exported React function component, hooks from `react` only, inline `style={{...}}` objects, SVG primitives (`svg/path/circle/line`), `<input>`/`<button>` form elements (text-input editing is degraded — plain text inputs fall back to a non-editable View per Codex review), `setInterval`/`requestAnimationFrame`/`getBoundingClientRect`. The TypeScript path strips TSX through the Node/esbuild transform before the C++ runtime parser sees the bundle.
 - Out of scope until follow-up PRs: window-level `mousemove`/`mouseup` global fan-out (the canonical 2-week gotcha; static render works, interactive drag does not), viewport resize signaling (`window.innerWidth/innerHeight` hard-coded), screenshot-similarity acceptance gate (timers/random would need freezing for determinism), Babel-standalone embedding (replaces the Node shell-out).
 - End-to-end harness: `tools/import-validation/jsx-roundtrip.sh` runs the transform + builds + runs the smoke test (`pulp-test-design-import-jsx-runtime` — asserts >9 IR nodes + Chainer-shaped text materializes) + optionally renders a `pulp-screenshot` PNG. Primary fixtures: `planning/fixtures/jsx/chainer-instrument.jsx` (762-line Chainer instrument with 9 inline custom components, SVG, drag, setInterval) and `planning/fixtures/jsx/typed-control.tsx` for TSX stripping.
@@ -796,7 +800,8 @@ pulp import-design --from claude --file design.html --no-emit-classnames
 Import artifact flag vocabulary:
 - `--output <path>` is the destination for the primary artifact. JS defaults to `ui.js`; `--emit cpp` defaults to `imported_ui.cpp` and writes the sibling header.
 - `--emit js`, `--emit ir-json`, and `--emit cpp` are implemented. `cpp` requires `--mode baked`. Legacy `--emit classnames` remains accepted for the Claude classnames sidecar.
-- `--mode live` is the default. Static sources emit generated JS in live mode; `--from jsx --mode live --emit js` writes the precompiled JSX bundle verbatim. `--mode baked` emits canonical IR or baked C++ via `--emit ir-json|cpp`.
+- `--mode live` is the default. Static sources emit generated JS in live mode; `--from jsx --mode live --emit js` writes the precompiled JSX bundle verbatim for runtime import and rejects `--validate`, `--reference`, `--diff`, and `--debug`. `--mode baked` emits canonical IR or baked C++ via `--emit ir-json|cpp`.
+- JSX baked snapshots accept both DOM-walked bundles and live/native bundles. Native bundles freeze through the `WidgetBridge` tree and record `snapshotSource=native-view`; generated baked C++ still constructs direct `View`/`Label` trees and should only require `pulp::view-core`.
 - `--snapshot-semantics fail|warn|accept` is honored for JSX baked IR snapshots. `fail` rejects dynamic APIs by default, `warn` proceeds with a structured diagnostic, and `accept` proceeds silently. The scan covers timers, animation frames, clock/random APIs, and fetch while ignoring comments and string literals.
 - URL imports fetch through argv-safe `curl` into a unique temporary file; literal `--file` paths are read directly and may contain normal filesystem punctuation, while `--url` rejects shell metacharacters before fetching.
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.110.0",
+      "version": "0.111.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.110.0"
+  "version": "0.111.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.110.0",
+  "version": "0.111.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/.claude/commands/import-design.md
+++ b/.claude/commands/import-design.md
@@ -51,8 +51,8 @@ Ask the user or detect from context:
 
 **React JSX runtime bundle**:
 - Compile the JSX/TSX first with `tools/import-design/jsx-runtime/jsx-transform.mjs`.
-- `--mode live --emit js` writes the precompiled bundle verbatim.
-- `--mode baked --emit ir-json|cpp` captures a runtime snapshot; use `--snapshot-semantics accept` only when accepting dynamic APIs is intentional.
+- `--mode live --emit js` writes the precompiled bundle verbatim for runtime import and rejects `--validate`, `--reference`, `--diff`, and `--debug`.
+- `--mode baked --emit ir-json|cpp` captures a runtime snapshot. DOM bundles are walked as DOM; live/native bundles that render through `@pulp/react` freeze the native `WidgetBridge` tree and record `snapshotSource: native-view`. Use `--snapshot-semantics accept` only when accepting dynamic APIs is intentional.
 
 **File-based fallback**:
 - Read the file and parse based on --from source type
@@ -171,7 +171,7 @@ pulp import-design --from v0 --file component.tsx
 pulp import-design --from pencil --file design.json
 pulp import-design --from claude --file design.html   # writes ui.js + tokens.json + classnames.json + bridge_handlers.cpp
 pulp import-design --from designmd --file DESIGN.md --tokens tokens.json
-pulp import-design --from jsx --file bundle.js --mode live --emit js
+pulp import-design --from jsx --file bundle.js --mode live --emit js --output live-ui.js
 pulp import-design --from jsx --file bundle.js --mode baked --emit cpp --snapshot-semantics accept --output imported_ui.cpp
 
 # With validation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.195.3
+    VERSION 0.196.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/design_import.hpp
+++ b/core/view/include/pulp/view/design_import.hpp
@@ -566,8 +566,9 @@ std::optional<ClaudeBundle> parse_react_native_export(const std::string& tsx);
 /// outside Pulp's supported runtime-import DOM/CSS/API subset.
 std::optional<ClaudeBundle> parse_pencil_react(const std::string& tsx);
 
-/// Wrap a pre-compiled JSX runtime bundle (esbuild IIFE of React + ReactDOM +
-/// the user's JSX component, produced by `tools/import-design/jsx-runtime/
+/// Wrap a pre-compiled JSX runtime bundle (esbuild IIFE of React plus either
+/// ReactDOM or the @pulp/react native bridge and the user's JSX component,
+/// produced by `tools/import-design/jsx-runtime/
 /// jsx-transform.mjs`) as a synthetic `ClaudeBundle` so the existing
 /// runtime-import harness (`parse_claude_html_with_runtime`) can materialize
 /// it. The C++ side does not compile JSX itself — the Node-side esbuild

--- a/core/view/include/pulp/view/widgets.hpp
+++ b/core/view/include/pulp/view/widgets.hpp
@@ -238,6 +238,7 @@ public:
     float value() const { return value_; }
 
     void set_default_value(float v) { default_value_ = std::clamp(v, 0.0f, 1.0f); }
+    float default_value() const { return default_value_; }
 
     void set_label(std::string text) {
         if (label_ == text) return;

--- a/core/view/src/claude_bundle.cpp
+++ b/core/view/src/claude_bundle.cpp
@@ -21,17 +21,21 @@
 
 #include <pulp/view/design_import.hpp>
 #include <pulp/view/anchor_strategy.hpp>
+#include <pulp/view/buttons.hpp>
 #include <pulp/view/input_events.hpp>
 #include <pulp/runtime/base64.hpp>
 #include <pulp/runtime/zip.hpp>
 #include <pulp/view/script_engine.hpp>
+#include <pulp/view/text_editor.hpp>
 #include <pulp/view/widget_bridge.hpp>
 #include <pulp/view/view.hpp>
+#include <pulp/view/widgets.hpp>
 #include <pulp/state/store.hpp>
 #include <choc/text/choc_JSON.h>
 #include <cstdio>
 #include <cstdlib>
 #include <sstream>
+#include <iomanip>
 #include <algorithm>
 #include <cctype>
 #include <functional>
@@ -519,6 +523,102 @@ size_t count_ir_nodes(const IRNode& n) {
     size_t total = 1;
     for (const auto& c : n.children) total += count_ir_nodes(c);
     return total;
+}
+
+std::string color_to_hex(Color color) {
+    std::ostringstream out;
+    out << '#'
+        << std::hex << std::setfill('0') << std::nouppercase
+        << std::setw(2) << static_cast<int>(color.r8())
+        << std::setw(2) << static_cast<int>(color.g8())
+        << std::setw(2) << static_cast<int>(color.b8());
+    if (color.a8() != 255)
+        out << std::setw(2) << static_cast<int>(color.a8());
+    return out.str();
+}
+
+LayoutDirection ir_direction(FlexDirection direction) {
+    return (direction == FlexDirection::row || direction == FlexDirection::row_reverse)
+        ? LayoutDirection::row
+        : LayoutDirection::column;
+}
+
+IRNode view_to_ir_node(const View& view, std::string_view path) {
+    IRNode node;
+    node.name = !view.id().empty() ? view.id() : std::string(path);
+    if (!view.id().empty()) {
+        node.stable_anchor_id = view.id();
+        node.anchor_strategy = "adapter";
+    }
+
+    if (const auto* label = dynamic_cast<const Label*>(&view)) {
+        node.type = "text";
+        node.text_content = label->text();
+        if (label->has_own_font_size()) node.style.font_size = label->font_size();
+        if (label->has_own_text_color()) node.style.color = color_to_hex(label->text_color());
+        if (!label->font_family().empty()) node.style.font_family = label->font_family();
+        if (label->has_own_font_weight()) node.style.font_weight = label->font_weight();
+    } else if (const auto* button = dynamic_cast<const TextButton*>(&view)) {
+        node.type = "button";
+        node.text_content = button->label();
+    } else if (const auto* editor = dynamic_cast<const TextEditor*>(&view)) {
+        node.type = "input";
+        node.attributes["value"] = editor->text();
+    } else if (const auto* checkbox = dynamic_cast<const Checkbox*>(&view)) {
+        node.type = "checkbox";
+        node.attributes["checked"] = checkbox->is_checked() ? "true" : "false";
+    } else if (const auto* knob = dynamic_cast<const Knob*>(&view)) {
+        node.type = "knob";
+        node.audio_widget = AudioWidgetType::knob;
+        node.audio_label = knob->label();
+        node.audio_default = knob->default_value();
+        node.attributes["value"] = std::to_string(knob->value());
+    } else if (const auto* fader = dynamic_cast<const Fader*>(&view)) {
+        node.type = "fader";
+        node.audio_widget = AudioWidgetType::fader;
+        node.audio_label = fader->label();
+        node.attributes["value"] = std::to_string(fader->value());
+        if (fader->orientation() == Fader::Orientation::horizontal)
+            node.attributes["orientation"] = "horizontal";
+    } else if (const auto* meter = dynamic_cast<const Meter*>(&view)) {
+        node.type = "meter";
+        node.audio_widget = AudioWidgetType::meter;
+        node.attributes["value"] = std::to_string(meter->display_rms());
+    } else if (const auto* xy = dynamic_cast<const XYPad*>(&view)) {
+        node.type = "xy_pad";
+        node.audio_widget = AudioWidgetType::xy_pad;
+        node.attributes["x"] = std::to_string(xy->x_value());
+        node.attributes["y"] = std::to_string(xy->y_value());
+    } else {
+        node.type = "frame";
+    }
+
+    const auto& flex = view.flex();
+    node.layout.direction = ir_direction(flex.direction);
+    node.layout.gap = flex.gap;
+    node.layout.padding_top = flex.padding_top >= 0 ? flex.padding_top : flex.padding;
+    node.layout.padding_right = flex.padding_right >= 0 ? flex.padding_right : flex.padding;
+    node.layout.padding_bottom = flex.padding_bottom >= 0 ? flex.padding_bottom : flex.padding;
+    node.layout.padding_left = flex.padding_left >= 0 ? flex.padding_left : flex.padding;
+    if (flex.flex_grow != 0.0f) node.layout.flex_grow = flex.flex_grow;
+    if (flex.flex_shrink != 1.0f) node.layout.flex_shrink = flex.flex_shrink;
+
+    if (flex.preferred_width > 0) node.style.width = flex.preferred_width;
+    else if (view.bounds().width > 0) node.style.width = view.bounds().width;
+    if (flex.preferred_height > 0) node.style.height = flex.preferred_height;
+    else if (view.bounds().height > 0) node.style.height = view.bounds().height;
+    if (flex.min_width > 0) node.style.min_width = flex.min_width;
+    if (flex.min_height > 0) node.style.min_height = flex.min_height;
+    if (flex.max_width > 0) node.style.max_width = flex.max_width;
+    if (flex.max_height > 0) node.style.max_height = flex.max_height;
+    if (view.has_background_color()) node.style.background_color = color_to_hex(view.background_color());
+
+    for (size_t i = 0; i < view.child_count(); ++i) {
+        const auto* child = view.child_at(i);
+        if (child == nullptr) continue;
+        node.children.push_back(view_to_ir_node(*child, std::string(path) + "/" + std::to_string(i)));
+    }
+    return node;
 }
 
 }  // namespace
@@ -1290,6 +1390,30 @@ DesignIR parse_claude_html_with_runtime(const std::string& html, ClaudeRuntimeOp
         // so the caller never gets worse than the current behavior.
         size_t nodes = count_ir_nodes(ir.root);
         if (nodes <= 9) {
+            // Native JSX live bundles route ReactDOM through @pulp/react, so
+            // there may be no expanded DOM for walkDomJson() to harvest. In
+            // that case the WidgetBridge root is the materialized tree; freeze
+            // that native tree into DesignIR so the same bundle can still emit
+            // baked IR/C++.
+            if (root.child_count() > 0) {
+                DesignIR native_ir;
+                native_ir.source = DesignSource::claude;
+                native_ir.root = view_to_ir_node(root, "root");
+                native_ir.root.type = "frame";
+                if (native_ir.root.name.empty()) native_ir.root.name = "ClaudeImport";
+                const size_t native_nodes = count_ir_nodes(native_ir.root);
+                if (native_nodes > 9) {
+                    if (opts.error_out) opts.error_out->clear();
+                    native_ir.root.provenance = IRProvenance{"claude-native-view", "1", {}};
+                    native_ir.root.confidence = IRConfidence::pass;
+                    assign_anchors(native_ir.root, AnchorStrategy::content_hash);
+                    native_ir.capture_method = "runtime_native_snapshot";
+                    native_ir.settle_rounds = 4;
+                    native_ir.source_adapter = "claude-native-view";
+                    native_ir.source_version = "1";
+                    return native_ir;
+                }
+            }
             std::ostringstream ss;
             ss << "runtime walker produced only " << nodes
                << " nodes (<= loader-shell floor of 9); falling back to static parser";

--- a/core/view/src/design_cpp_codegen.cpp
+++ b/core/view/src/design_cpp_codegen.cpp
@@ -211,15 +211,19 @@ bool attr_bool(const IRNode& node, std::string_view key) {
     return lower == "true" || lower == "1" || lower == "yes" || lower == "on";
 }
 
-float normalized_audio_value(const IRNode& node) {
-    if (auto value = attr_float(node, "value"))
-        return std::clamp(*value, 0.0f, 1.0f);
+float normalized_audio_default(const IRNode& node) {
     if (node.audio_max > node.audio_min)
         return std::clamp((node.audio_default - node.audio_min) /
                               (node.audio_max - node.audio_min),
                           0.0f,
                           1.0f);
     return std::clamp(node.audio_default, 0.0f, 1.0f);
+}
+
+float normalized_audio_value(const IRNode& node) {
+    if (auto value = attr_float(node, "value"))
+        return std::clamp(*value, 0.0f, 1.0f);
+    return normalized_audio_default(node);
 }
 
 std::optional<std::string> first_asset_id(const IRNode& node) {
@@ -841,8 +845,9 @@ void emit_widget_specific(std::ostringstream& out,
             if (!text.empty())
                 emit_line(out, depth, opts.indent_spaces, std::string(var) + "->set_label(" + cpp_string_literal(text) + ");");
             const auto value = float_expr(ctx, normalized_audio_value(node));
+            const auto default_value = float_expr(ctx, normalized_audio_default(node));
             emit_line(out, depth, opts.indent_spaces, std::string(var) + "->set_value(/* TODO: bind to param */ " + value + ");");
-            emit_line(out, depth, opts.indent_spaces, std::string(var) + "->set_default_value(" + value + ");");
+            emit_line(out, depth, opts.indent_spaces, std::string(var) + "->set_default_value(" + default_value + ");");
             break;
         }
         case NativeWidgetKind::fader: {

--- a/core/view/src/design_import_native_common.cpp
+++ b/core/view/src/design_import_native_common.cpp
@@ -418,14 +418,18 @@ LabelAlign parse_label_align(std::string_view value) {
     return LabelAlign::left;
 }
 
-float normalized_audio_value(const IRNode& node) {
-    if (auto value = attr_float(node, "value")) return std::clamp(*value, 0.0f, 1.0f);
+float normalized_audio_default(const IRNode& node) {
     if (node.audio_max > node.audio_min)
         return std::clamp((node.audio_default - node.audio_min) /
                               (node.audio_max - node.audio_min),
                           0.0f,
                           1.0f);
     return std::clamp(node.audio_default, 0.0f, 1.0f);
+}
+
+float normalized_audio_value(const IRNode& node) {
+    if (auto value = attr_float(node, "value")) return std::clamp(*value, 0.0f, 1.0f);
+    return normalized_audio_default(node);
 }
 
 void append_resolved_diagnostics(const ResolvedNativeNode& node,
@@ -757,7 +761,7 @@ std::unique_ptr<View> make_widget(const IRNode& node,
             auto knob = std::make_unique<Knob>();
             if (!text.empty()) knob->set_label(text);
             knob->set_value(normalized_audio_value(node));
-            knob->set_default_value(normalized_audio_value(node));
+            knob->set_default_value(normalized_audio_default(node));
             if (options.preview_mode) knob->set_render_style(WidgetRenderStyle::minimal);
             return knob;
         }

--- a/docs/guides/claude-code-plugin.md
+++ b/docs/guides/claude-code-plugin.md
@@ -62,7 +62,7 @@ This is not yet available because the Pulp repository is currently private. Thes
 | `/validate` | Run plugin format validators (auval, clap-validator) |
 | `/design [style]` | AI-driven design session with natural language |
 | `/ship` | Sign, notarize, and package for distribution |
-| `/import-design` | Import from Figma, Stitch, v0, or Pencil |
+| `/import-design` | Import from Figma, Stitch, v0, Pencil, Claude Design, DESIGN.md, or React JSX |
 | `/version` | Show, bump, or check version consistency |
 
 ### Skills

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -966,6 +966,7 @@ pulp import-design --from pencil --file ui.json --output ui.js --tokens tokens.j
 pulp import-design --from v0 --file card.tsx --dry-run
 pulp import-design --from claude --file design.html --classnames classnames.json
 pulp import-design --from designmd --file DESIGN.md --tokens out.json
+pulp import-design --from jsx --file bundle.js --mode live --emit js --output live-ui.js
 pulp import-design --from jsx --file bundle.js --mode baked --emit cpp --output imported_ui.cpp
 ```
 
@@ -1000,8 +1001,13 @@ against the source URL. The manifest keeps the authored relative URI and also
 records the resolved `source_url` used for HTTP(S) fetching.
 
 With `--from jsx --mode live --emit js`, the CLI writes the precompiled JSX
-runtime bundle verbatim. With `--from jsx --mode baked --emit ir-json|cpp`, the
-CLI captures a runtime snapshot into DesignIR and records snapshot provenance.
+runtime bundle verbatim for runtime import. That pass-through path rejects
+`--validate`, `--reference`, `--diff`, and `--debug` because it does not parse or
+render the bundle. With `--from jsx --mode baked --emit ir-json|cpp`, the CLI
+captures a runtime snapshot into DesignIR and records snapshot provenance. DOM
+bundles are captured through the DOM walker; live/native bundles that render
+through `@pulp/react` are frozen from the native `WidgetBridge` tree and record
+`runtime_native_snapshot` plus `snapshotSource: native-view`.
 Dynamic APIs such as `setInterval`, `setTimeout`, `requestAnimationFrame`,
 `Date.now`, `new Date`, `performance.now`, `Math.random`, and `fetch` fail by
 default under `--snapshot-semantics fail`; comments and string literals are

--- a/docs/reference/design-import.md
+++ b/docs/reference/design-import.md
@@ -63,7 +63,14 @@ shared normalized form: interactive `frame` nodes are promoted through the
 library normalization pass before code generation or IR serialization.
 
 For `--from jsx --mode live --emit js`, Pulp writes the precompiled bundle
-verbatim. For JSX baked IR/C++ snapshots, Pulp scans the precompiled bundle for
+verbatim for runtime import. That pass-through path does not parse or render
+the bundle, so `--validate`, `--reference`, `--diff`, and `--debug` are rejected;
+use baked IR or baked C++ when an import report or native snapshot validation is
+needed. For JSX baked IR/C++ snapshots, Pulp first runs the runtime harness and
+walks the materialized DOM; when a live/native bundle routes React through
+`@pulp/react` and leaves no expanded DOM, the harness freezes the native
+`WidgetBridge` tree instead (`capture_method: runtime_native_snapshot`,
+`snapshotSource: native-view`). Pulp scans the precompiled bundle for
 dynamic APIs that make a frozen snapshot non-deterministic (`setInterval`,
 `setTimeout`, `requestAnimationFrame`, `Date.now`, `new Date`,
 `performance.now`, `Math.random`, and `fetch`). Comments and string literals

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -618,7 +618,7 @@ commands:
         description: "Runtime model: live (default) or baked for canonical IR / baked C++ artifacts"
       - name: --snapshot-semantics
         kind: option
-        description: "JSX baked snapshot policy: fail rejects dynamic APIs, warn proceeds with diagnostics, accept proceeds silently"
+        description: "JSX baked snapshot policy: fail rejects dynamic APIs, warn proceeds with diagnostics, accept proceeds silently; JSX live JS pass-through rejects validation/debug flags"
       - name: --allow-network-fetch
         kind: flag
         description: "Allow DesignIR asset-manifest HTTP(S) fetches at import time"

--- a/test/test_design_import_cpp_codegen.cpp
+++ b/test/test_design_import_cpp_codegen.cpp
@@ -107,9 +107,10 @@ DesignIR build_codegen_fixture_ir() {
     auto drive = frame_node("drive", "Drive", 72.0f, 72.0f, LayoutDirection::column);
     drive.audio_widget = AudioWidgetType::knob;
     drive.audio_label = "Drive";
-    drive.audio_min = 0.0f;
-    drive.audio_max = 1.0f;
-    drive.audio_default = 0.5f;
+    drive.audio_min = -60.0f;
+    drive.audio_max = 0.0f;
+    drive.audio_default = -15.0f;
+    drive.attributes["value"] = "0.2";
     ir.root.children.push_back(std::move(drive));
 
     IRAssetRef asset;
@@ -211,6 +212,8 @@ TEST_CASE("baked C++ exporter emits ownable C++ source artifacts",
     REQUIRE(result.source.find("// auto-extracted: structural name \"Header\"") != std::string::npos);
     REQUIRE(result.source.find("std::unique_ptr<pulp::view::View> build_header()") != std::string::npos);
     REQUIRE(result.source.find("/* TODO: bind to param */") != std::string::npos);
+    REQUIRE(result.source.find("->set_value(/* TODO: bind to param */ 0.2f);") != std::string::npos);
+    REQUIRE(result.source.find("->set_default_value(0.75f);") != std::string::npos);
     REQUIRE(result.source.find("std::make_unique<pulp::view::Knob>()") != std::string::npos);
     REQUIRE(result.source.find("build_native_view_tree") == std::string::npos);
     REQUIRE(result.source.find("serialize_design_ir") == std::string::npos);

--- a/test/test_design_import_jsx_runtime.cpp
+++ b/test/test_design_import_jsx_runtime.cpp
@@ -3,9 +3,9 @@
 // pulp jsx-instrument-import experiment slice (2026-05-17).
 //
 // Validates that a pre-compiled JSX bundle (esbuild IIFE wrapping
-// React + ReactDOM + the user's JSX) can be wrapped as a Claude-style
-// envelope and executed through the existing runtime-import harness
-// (`parse_claude_html_with_runtime`). If the materialized DesignIR
+// React + either ReactDOM or the @pulp/react native bridge + the user's JSX)
+// can be wrapped as a Claude-style envelope and executed through the existing
+// runtime-import harness (`parse_claude_html_with_runtime`). If the materialized DesignIR
 // contains the named control panels Chainer ships (e.g. "generator",
 // "envelope"), the renderer-integration path is validated and the
 // follow-up work — `--from jsx` CLI wiring, drag, animation, parity
@@ -183,6 +183,35 @@ TEST_CASE("[jsx-experiment] Chainer JSX bundle materializes through Claude runti
         ir_contains_text(ir.root, "polywave");
     INFO("Chainer-shaped text found in IR: " << (found_chainer_text ? "yes" : "no"));
     REQUIRE(found_chainer_text);
+}
+
+TEST_CASE("[jsx-experiment] native live bundle can freeze through baked snapshot fallback",
+          "[view][import][jsx]") {
+    std::string native_bundle =
+        "(function(){\n"
+        "  createCol('native-panel', '');\n"
+        "  for (var i = 0; i < 12; ++i) {\n"
+        "    createLabel('native-label-' + i, i === 0 ? 'CHAINER native snapshot' : ('native row ' + i), 'native-panel');\n"
+        "  }\n"
+        "})();\n";
+    native_bundle.append(256, ' ');
+
+    auto bundle = parse_jsx_react(native_bundle, "NativeBridgeSmoke");
+    REQUIRE(bundle.has_value());
+
+    std::string err;
+    ClaudeRuntimeOptions opts;
+    opts.error_out = &err;
+    auto ir = parse_claude_html_with_runtime(synthesize_runtime_envelope(*bundle), opts);
+
+    INFO("runtime error_out: " << err);
+    INFO("capture_method: " << ir.capture_method);
+    INFO("materialized native IR node count: " << count_ir_nodes(ir.root));
+    REQUIRE(err.empty());
+    REQUIRE(ir.capture_method == "runtime_native_snapshot");
+    REQUIRE(ir.source_adapter == "claude-native-view");
+    REQUIRE(count_ir_nodes(ir.root) > 9);
+    REQUIRE(ir_contains_text(ir.root, "CHAINER native snapshot"));
 }
 
 TEST_CASE("[jsx-experiment] TypeScript .tsx bundle materializes through Claude runtime harness",

--- a/test/test_design_import_native_materializer.cpp
+++ b/test/test_design_import_native_materializer.cpp
@@ -423,6 +423,7 @@ TEST_CASE("baked native materializer preserves audio widget attributes",
     knob_node.audio_min = -60.0f;
     knob_node.audio_max = 0.0f;
     knob_node.audio_default = -15.0f;
+    knob_node.attributes["value"] = "0.2";
 
     auto fader_node = frame("mix", 96.0f, 32.0f, LayoutDirection::column);
     fader_node.audio_widget = AudioWidgetType::fader;
@@ -452,7 +453,8 @@ TEST_CASE("baked native materializer preserves audio widget attributes",
     auto* knob = dynamic_cast<Knob*>(root->child_at(0));
     REQUIRE(knob != nullptr);
     REQUIRE(knob->label() == "Drive");
-    REQUIRE(knob->value() == 0.75f);
+    REQUIRE(knob->value() == 0.2f);
+    REQUIRE(knob->default_value() == 0.75f);
     REQUIRE(knob->render_style() == WidgetRenderStyle::minimal);
 
     auto* fader = dynamic_cast<Fader*>(root->child_at(1));

--- a/test/test_import_design_tool.cpp
+++ b/test/test_import_design_tool.cpp
@@ -472,6 +472,25 @@ TEST_CASE("pulp-import-design validates phase 0.5 import vocabulary",
         REQUIRE(live.exit_code == 0);
         REQUIRE(read_text(output) == bundle);
         REQUIRE(live.stdout_output.find("JSX live bundle") != std::string::npos);
+
+        auto validate = run_import_design({"--from", "jsx",
+                                           "--file", jsx.string(),
+                                           "--output", (tmp.path / "validate-live-ui.js").string(),
+                                           "--validate"});
+        REQUIRE_FALSE(validate.timed_out);
+        REQUIRE(validate.exit_code == 2);
+        REQUIRE(validate.stderr_output.find("writes the precompiled bundle verbatim") != std::string::npos);
+        REQUIRE(validate.stderr_output.find("--mode baked --emit ir-json|cpp") != std::string::npos);
+
+        const auto debug_output = tmp.path / "live-debug.json";
+        auto debug = run_import_design({"--from", "jsx",
+                                        "--file", jsx.string(),
+                                        "--output", (tmp.path / "debug-live-ui.js").string(),
+                                        "--debug-output", debug_output.string()});
+        REQUIRE_FALSE(debug.timed_out);
+        REQUIRE(debug.exit_code == 2);
+        REQUIRE_FALSE(fs::exists(debug_output));
+        REQUIRE(debug.stderr_output.find("does not support --validate, --reference, --diff, or --debug") != std::string::npos);
     }
 
     SECTION("jsx baked snapshots fail by default on dynamic APIs and can warn or accept") {

--- a/tools/import-design/jsx-runtime/README.md
+++ b/tools/import-design/jsx-runtime/README.md
@@ -13,9 +13,12 @@ cd tools/import-design/jsx-runtime
 npm install
 ```
 
-Pulls React 18.3.1, ReactDOM 18.3.1, and esbuild 0.24.0 into the local
-`node_modules/`. Not committed (see `.gitignore`); `package-lock.json` IS
-committed for reproducible installs.
+Pulls React 18.3.1, ReactDOM 18.3.1, react-reconciler 0.29.2, scheduler
+0.23.2, and esbuild 0.24.0 into the local `node_modules/`. Not committed (see
+`.gitignore`); `package-lock.json` IS committed for reproducible installs.
+The transform aliases `@pulp/react` to the repo's `packages/pulp-react/src`
+entrypoint so a fresh checkout can bundle the native React host without
+publishing or linking the package first.
 
 ## Usage
 
@@ -27,7 +30,7 @@ node jsx-transform.mjs \
 ```
 
 Produces:
-- `<out>` — the IIFE bundle (~1 MB, React + ReactDOM + user JSX + nav shims)
+- `<out>` — the IIFE bundle (~1 MB, React + @pulp/react native bridge + user JSX + nav shims)
 - `<out>.manifest.json` — `{ componentName, sourceFile, outputBytes, ... }`
 
 The bundle is then consumable by:
@@ -36,6 +39,12 @@ The bundle is then consumable by:
 - `pulp import-design --from jsx --file <out> --mode baked --emit cpp --snapshot-semantics accept`
 - `pulp-screenshot --script <out> --output render.png` (works today)
 - `parse_jsx_react()` in C++ via the test harness
+
+The default bundle routes `react-dom` through `pulp-react-dom-shim.mjs`, which
+renders through `@pulp/react` into the native bridge. Baked snapshots first try
+the DOM walker, then freeze the native `WidgetBridge` tree when the bundle has
+no expanded DOM; those IR envelopes record `runtime_native_snapshot` and
+`root.attributes.snapshotSource = "native-view"`.
 
 ## End-to-end smoke
 

--- a/tools/import-design/jsx-runtime/jsx-transform.mjs
+++ b/tools/import-design/jsx-runtime/jsx-transform.mjs
@@ -303,6 +303,7 @@ async function main() {
                 'react':                       resolve(__dirname, 'node_modules/react'),
                 'react/jsx-runtime':           resolve(__dirname, 'node_modules/react/jsx-runtime.js'),
                 'react/jsx-dev-runtime':       resolve(__dirname, 'node_modules/react/jsx-dev-runtime.js'),
+                '@pulp/react':                  resolve(__dirname, '..', '..', '..', 'packages', 'pulp-react', 'src', 'index.ts'),
                 'react-reconciler':            resolve(__dirname, 'node_modules/react-reconciler'),
                 'react-reconciler/constants.js': resolve(__dirname, 'node_modules/react-reconciler/constants.js'),
                 'scheduler':                   resolve(__dirname, 'node_modules/scheduler'),

--- a/tools/import-design/jsx-runtime/package-lock.json
+++ b/tools/import-design/jsx-runtime/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "esbuild": "0.24.0",
         "react": "18.3.1",
-        "react-dom": "18.3.1"
+        "react-dom": "18.3.1",
+        "react-reconciler": "0.29.2",
+        "scheduler": "0.23.2"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -474,6 +476,22 @@
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
+      "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       },
       "peerDependencies": {
         "react": "^18.3.1"

--- a/tools/import-design/pulp_import_design.cpp
+++ b/tools/import-design/pulp_import_design.cpp
@@ -383,7 +383,7 @@ static void print_usage() {
     std::cout << "  pencil   Pencil/OpenPencil node JSON or .pen export\n";
     std::cout << "  claude   Anthropic Claude Design — manually-exported standalone HTML\n";
     std::cout << "  designmd Google DESIGN.md design-system spec (tokens only)\n";
-    std::cout << "  jsx      Precompiled React JSX runtime bundle for baked IR snapshots\n\n";
+    std::cout << "  jsx      Precompiled React JSX runtime bundle for live pass-through or baked snapshots\n\n";
     std::cout << "Options:\n";
     std::cout << "  --from <source>   Design source (required)\n";
     std::cout << "  --file <path>     Input file path\n";
@@ -445,7 +445,8 @@ static void print_usage() {
     std::cout << "  pulp import-design --from pencil --file design.json --dry-run\n";
     std::cout << "  pulp import-design --from pencil --file design.json --validate --reference source.png\n";
     std::cout << "  pulp import-design --from claude --file design.html\n";
-    std::cout << "  pulp import-design --from stitch --file screen.json --mode baked --emit cpp --output imported_ui.cpp\n";
+    std::cout << "  pulp import-design --from jsx --file bundle.js --mode live --emit js --output live-ui.js\n";
+    std::cout << "  pulp import-design --from jsx --file bundle.js --mode baked --emit cpp --output imported_ui.cpp\n";
 }
 
 // Bridge-handler scaffold body lives in core/view/src/design_import.cpp
@@ -889,6 +890,12 @@ int main(int argc, char* argv[]) {
     if (*source == DesignSource::jsx
         && runtime_mode == RuntimeMode::live
         && artifact_emit == ArtifactEmit::js) {
+        if (validate || debug_json || !diff_output.empty()) {
+            std::cerr << "Error: --from jsx --mode live --emit js writes the precompiled bundle verbatim "
+                         "and does not support --validate, --reference, --diff, or --debug; use "
+                         "--mode baked --emit ir-json|cpp for import validation or debug reports\n";
+            return 2;
+        }
         if (dry_run) {
             std::cout << content;
             return 0;
@@ -967,14 +974,18 @@ int main(int argc, char* argv[]) {
                     const auto fallback_reason = !runtime_error.empty()
                         ? runtime_error
                         : ir.fallback_reason;
-                    if (!fallback_reason.empty() || ir.capture_method != "runtime_snapshot") {
+                    const bool captured_runtime =
+                        ir.capture_method == "runtime_snapshot" ||
+                        ir.capture_method == "runtime_native_snapshot";
+                    if (!fallback_reason.empty() || !captured_runtime) {
                         std::cerr << "Error: JSX baked runtime snapshot failed";
                         if (!fallback_reason.empty()) std::cerr << ": " << fallback_reason;
                         std::cerr << "\n";
                         return 1;
                     }
+                    const bool native_snapshot = ir.capture_method == "runtime_native_snapshot";
                     ir.source = DesignSource::jsx;
-                    ir.capture_method = "runtime_snapshot";
+                    ir.capture_method = native_snapshot ? "runtime_native_snapshot" : "runtime_snapshot";
                     if (ir.settle_rounds <= 0) ir.settle_rounds = 4;
                     ir.source_adapter = "jsx-runtime";
                     ir.source_version = "1";
@@ -987,6 +998,8 @@ int main(int argc, char* argv[]) {
                     ir.root.confidence = IRConfidence::pass;
                     ir.root.source_adapter = "jsx-runtime";
                     ir.root.source_version = "1";
+                    if (native_snapshot)
+                        ir.root.attributes["snapshotSource"] = "native-view";
                     ir.root.attributes["snapshotSemantics"] = snapshot_semantics_name(snapshot_semantics);
                     if (dynamic_scan.has_dynamic_apis()
                         && snapshot_semantics == SnapshotSemantics::warn) {


### PR DESCRIPTION
## Summary
- Fixes review follow-up #2636: baked-native and baked C++ knobs now keep current value separate from reset default (`audio_default`).
- Fixes review follow-up #2665: JSX live JS pass-through now rejects validation/debug flags instead of bypassing shared post-processing.
- Adds native-view snapshot fallback so live/native `@pulp/react` bundles can be converted into baked DesignIR / baked C++.
- Updates CLI/plugin/docs/skills and codifies PR review-thread hygiene.

## Validation
- `build/test/pulp-test-design-import-native-materializer`
- `build/test/pulp-test-design-import-cpp-codegen`
- `build/test/pulp-test-import-design-tool`
- `build/test/pulp-test-design-import-jsx-runtime "[jsx]" --reporter compact`
- `PULP_JSX_BUNDLE=/tmp/pulp-chainer-validate/ChainerInstrument.bundle.js build/test/pulp-test-design-import-jsx-runtime "[jsx]" --reporter compact`
- `PULP_JSX_FIXTURE=/Users/danielraffel/Desktop/Chainer/ChainerInstrument.jsx PULP_JSX_BUNDLE_OUT=/tmp/pulp-chainer-validate/roundtrip.bundle.js PULP_BUILD_DIR=/private/tmp/pulp-design-import-phase9/build tools/import-validation/jsx-roundtrip.sh --skip-build --skip-screenshot`
- Chainer live pass-through was byte-identical: 945231-byte input bundle == output `chainer-live.js`.
- Chainer baked DesignIR emitted 306 nodes with `capture_method=runtime_native_snapshot`, `snapshotSource=native-view`, and Chainer text present.
- Chainer baked C++ emitted `chainer_ui.cpp/.hpp`, compiled to an object, and contains no `ScriptEngine`/`WidgetBridge`/JS runtime symbols.
- `pulp-test-view-core-link` passes and `otool -L` shows no JS-engine dylib.

## Notes
Ubuntu and Windows Shipyard targets were deliberately skipped for local UTM/SSH validation; GitHub-hosted checks for the PR are still running.
