### PR TITLE
fix(audio,signal,clap): harden 4 confirmed edge-case defects from the P7 audit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.197.0
+    VERSION 0.197.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/audio/src/aiff_reader.cpp
+++ b/core/audio/src/aiff_reader.cpp
@@ -240,9 +240,12 @@ public:
                     int16_t v = static_cast<int16_t>((p[0] << 8) | p[1]);
                     sample = static_cast<float>(v) / 32768.0f;
                 } else if (bits_per_sample == 24) {
-                    int32_t v = (static_cast<int32_t>(p[0]) << 24) |
-                                (static_cast<int32_t>(p[1]) << 16) |
-                                (static_cast<int32_t>(p[2]) << 8);
+                    // Build the 24-bit word with unsigned arithmetic; a signed
+                    // left-shift of a byte >= 0x80 into bit 31 is UB (#2694).
+                    uint32_t raw = (static_cast<uint32_t>(p[0]) << 24) |
+                                   (static_cast<uint32_t>(p[1]) << 16) |
+                                   (static_cast<uint32_t>(p[2]) << 8);
+                    int32_t v = static_cast<int32_t>(raw);
                     sample = static_cast<float>(v) / 2147483648.0f;
                 } else if (bits_per_sample == 32) {
                     int32_t v = static_cast<int32_t>(read_be32(p));

--- a/core/format/include/pulp/format/standalone.hpp
+++ b/core/format/include/pulp/format/standalone.hpp
@@ -64,6 +64,11 @@ public:
     midi::MidiSystem* midi_system() { return midi_system_.get(); }
 
 private:
+    // Tear down the audio + MIDI devices but KEEP the processor instance alive.
+    // apply_config() uses this so a settings change does not recreate the
+    // Processor out from under an editor ViewBridge holding a Processor& (#2693).
+    void stop_audio_keep_processor();
+
     ProcessorFactory factory_;
     std::unique_ptr<Processor> processor_;
     state::StateStore store_;

--- a/core/format/src/clap_adapter.cpp
+++ b/core/format/src/clap_adapter.cpp
@@ -28,8 +28,12 @@ static PulpClapPlugin* get_self(const clap_plugin_t* plugin) {
 // See #688. memcpy into a stack local guarantees proper alignment.
 template <typename T>
 static T load_event(const clap_event_header_t* hdr) {
-    T out;
-    std::memcpy(&out, hdr, sizeof(T));
+    // Guard against a short/malformed host event: copying sizeof(T) bytes when
+    // hdr->size < sizeof(T) reads past the event (OOB / UB on the audio thread,
+    // #2691). Copy only the bytes the host actually provided; the rest stay
+    // zero-initialised. (memcpy-into-a-stack-local also fixes alignment, #688.)
+    T out{};
+    std::memcpy(&out, hdr, std::min(static_cast<std::size_t>(hdr->size), sizeof(T)));
     return out;
 }
 

--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -23,14 +23,19 @@ StandaloneApp::~StandaloneApp() {
 }
 
 bool StandaloneApp::start() {
-    // Create processor
-    processor_ = factory_();
+    // Create the processor once and reuse it across audio reconfigurations
+    // (apply_config soft-restart). Recreating it on every settings change would
+    // dangle an editor ViewBridge holding a Processor& (#2693); parameters are
+    // defined a single time so the StateStore isn't re-registered on restart.
     if (!processor_) {
-        runtime::log_error("Standalone: failed to create processor");
-        return false;
+        processor_ = factory_();
+        if (!processor_) {
+            runtime::log_error("Standalone: failed to create processor");
+            return false;
+        }
+        processor_->set_state_store(&store_);
+        processor_->define_parameters(store_);
     }
-    processor_->set_state_store(&store_);
-    processor_->define_parameters(store_);
 
     auto desc = processor_->descriptor();
     runtime::log_info("Standalone: starting '{}'", desc.name);
@@ -168,7 +173,11 @@ bool StandaloneApp::start() {
 
 bool StandaloneApp::apply_config(const StandaloneConfig& new_config) {
     bool was_running = running_.load();
-    if (was_running) stop();
+    // Soft restart: tear down only the audio/MIDI devices and rebuild them for
+    // the new config, KEEPING the processor instance (start() reuses it and
+    // re-prepare()s it). A full stop()+start() would recreate the processor and
+    // dangle an editor ViewBridge holding a Processor& (#2693).
+    if (was_running) stop_audio_keep_processor();
     config_ = new_config;
     if (was_running) return start();
     return true;
@@ -374,7 +383,7 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
     return true;
 }
 
-void StandaloneApp::stop() {
+void StandaloneApp::stop_audio_keep_processor() {
     running_.store(false);
     if (midi_input_) {
         midi_input_->close();
@@ -385,6 +394,10 @@ void StandaloneApp::stop() {
         audio_device_->close();
         audio_device_.reset();
     }
+}
+
+void StandaloneApp::stop() {
+    stop_audio_keep_processor();
     if (processor_) {
         processor_->release();
         processor_.reset();

--- a/core/signal/include/pulp/signal/multi_channel_meter.hpp
+++ b/core/signal/include/pulp/signal/multi_channel_meter.hpp
@@ -163,6 +163,9 @@ public:
         for (int i = 0; i < num_samples; ++i) {
             for (int ch = 0; ch < num_channels; ++ch) {
                 float s = channels[ch][i];
+                // Non-finite samples (NaN/Inf) would poison RMS/LUFS/integrated
+                // accumulators irrecoverably (#2695). Treat them as silence.
+                if (!std::isfinite(s)) s = 0.0f;
                 float abs_s = std::abs(s);
 
                 if (abs_s > block_peak_[ch]) block_peak_[ch] = abs_s;
@@ -176,6 +179,8 @@ public:
             if (num_channels >= 2) {
                 float l = channels[0][i];
                 float r = channels[1][i];
+                if (!std::isfinite(l)) l = 0.0f;
+                if (!std::isfinite(r)) r = 0.0f;
                 correlation_sum_xy_ += static_cast<double>(l) * r;
                 correlation_sum_xx_ += static_cast<double>(l) * l;
                 correlation_sum_yy_ += static_cast<double>(r) * r;

--- a/core/signal/include/pulp/signal/spectrogram.hpp
+++ b/core/signal/include/pulp/signal/spectrogram.hpp
@@ -26,6 +26,10 @@ public:
 
     /// Map a normalized value (0 = minimum, 1 = maximum) to a color.
     SpectrogramColor map(float t) const {
+        // std::clamp(NaN, …) returns NaN, which the ramps then cast to uint8_t
+        // (undefined behavior, #2695). Sanitize NaN to 0 first; ±Inf clamp
+        // safely to 1.0 / 0.0 below.
+        if (std::isnan(t)) t = 0.0f;
         t = std::clamp(t, 0.0f, 1.0f);
 
         switch (ramp_) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1255,6 +1255,7 @@ pulp_add_test_suite(pulp-test-test-signal LIBRARIES pulp::standalone)
 
 # Standalone editor chrome helpers
 pulp_add_test_suite(pulp-test-standalone-editor-chrome LIBRARIES pulp::standalone)
+pulp_add_test_suite(pulp-test-standalone-apply-config LIBRARIES pulp::standalone)
 
 # Headless screenshot capture state machine (pulp #468)
 pulp_add_test_suite(pulp-test-screenshot-capture LIBRARIES pulp::standalone)

--- a/test/test_multi_channel_meter.cpp
+++ b/test/test_multi_channel_meter.cpp
@@ -273,3 +273,32 @@ TEST_CASE("MultiChannelBallistics clamps channel count and clears clip holds", "
     REQUIRE_FALSE(ballistics.channels[0].clip_indicator);
     REQUIRE_THAT(ballistics.channels[0].clip_hold_counter, WithinAbs(0.0f, 1e-6f));
 }
+
+TEST_CASE("MultiChannelMeter treats non-finite samples as silence (no NaN poisoning)",
+          "[signal][meter][issue-2695]") {
+    MultiChannelMeter meter;
+    meter.prepare(100.0f, 1);  // ~1-sample blocks so snapshots emit quickly
+
+    const float nan_s = std::numeric_limits<float>::quiet_NaN();
+    const float inf_s = std::numeric_limits<float>::infinity();
+    float nan_buf[] = {nan_s};
+    float inf_buf[] = {inf_s};
+    float good[]    = {0.5f};
+    const float* ch_nan[]  = {nan_buf};
+    const float* ch_inf[]  = {inf_buf};
+    const float* ch_good[] = {good};
+
+    // A NaN/Inf sample must not irrecoverably poison the RMS/LUFS/integrated
+    // accumulators (#2695): subsequent valid audio must still read finite.
+    meter.process(ch_nan, 1, 1);
+    meter.process(ch_inf, 1, 1);
+    for (int i = 0; i < 64; ++i) meter.process(ch_good, 1, 1);
+
+    const auto& snap = meter.snapshot();
+    REQUIRE(std::isfinite(snap.channels[0].peak));
+    REQUIRE(std::isfinite(snap.channels[0].rms));
+    REQUIRE_FALSE(std::isnan(snap.lufs_integrated));
+    REQUIRE_FALSE(std::isnan(snap.channels[0].lufs_momentary));
+    // The valid 0.5 samples should register a real RMS, not 0/NaN.
+    REQUIRE(snap.channels[0].rms > 0.0f);
+}

--- a/test/test_standalone_apply_config.cpp
+++ b/test/test_standalone_apply_config.cpp
@@ -1,0 +1,74 @@
+// Regression: StandaloneApp::apply_config must NOT recreate the processor while
+// the editor is open, or an editor ViewBridge holding a Processor& dangles
+// (use-after-free, #2693). apply_config now does a soft restart that tears down
+// only the audio/MIDI device and re-prepare()s the *same* processor instance.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/format/standalone.hpp>
+#include <pulp/format/processor.hpp>
+
+#include <memory>
+
+using namespace pulp::format;
+
+namespace {
+
+class ApplyConfigProc : public Processor {
+public:
+    PluginDescriptor descriptor() const override {
+        PluginDescriptor d;
+        d.name = "ApplyConfigProc";
+        d.manufacturer = "Pulp";
+        return d;
+    }
+    void define_parameters(pulp::state::StateStore&) override {}
+    void prepare(const PrepareContext&) override {}
+    void process(pulp::audio::BufferView<float>&,
+                 const pulp::audio::BufferView<const float>&,
+                 pulp::midi::MidiBuffer&,
+                 pulp::midi::MidiBuffer&,
+                 const ProcessContext&) override {}
+};
+
+int g_factory_calls = 0;
+std::unique_ptr<Processor> make_apply_config_proc() {
+    ++g_factory_calls;
+    return std::make_unique<ApplyConfigProc>();
+}
+
+}  // namespace
+
+TEST_CASE("StandaloneApp::apply_config preserves the processor instance",
+          "[format][standalone][issue-2693]") {
+    g_factory_calls = 0;
+    StandaloneApp app(&make_apply_config_proc);
+
+    StandaloneConfig cfg;
+    cfg.headless = true;
+    cfg.output_channels = 2;
+    cfg.buffer_size = 256;
+    app.set_config(cfg);
+
+    if (!app.start()) {
+        // No usable audio device (e.g. headless Linux CI). The running-path
+        // soft-restart is exercised on hosts with an audio device (macOS CI).
+        SUCCEED("no audio device available — running-path check skipped");
+        return;
+    }
+
+    Processor* before = app.processor();
+    REQUIRE(before != nullptr);
+    const int calls_after_start = g_factory_calls;
+
+    StandaloneConfig cfg2 = cfg;
+    cfg2.buffer_size = 512;  // a device-level change that triggers a restart
+    REQUIRE(app.apply_config(cfg2));
+
+    // The same Processor instance must survive the settings-apply: a recreate
+    // would dangle an editor ViewBridge's Processor& (#2693).
+    REQUIRE(app.processor() == before);
+    REQUIRE(g_factory_calls == calls_after_start);
+
+    app.stop();
+}

--- a/test/test_stft.cpp
+++ b/test/test_stft.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <vector>
 #include <numeric>
+#include <limits>
 
 using namespace pulp::signal;
 using Catch::Matchers::WithinAbs;
@@ -613,4 +614,26 @@ TEST_CASE("MultiChannelBallistics clear_clips", "[signal][meter]") {
     ballistics.clear_clips();
     REQUIRE_FALSE(ballistics.channels[0].clip_indicator);
     REQUIRE_FALSE(ballistics.channels[1].clip_indicator);
+}
+
+TEST_CASE("ColorMapper sanitizes NaN input (no NaN->uint8 UB)",
+          "[signal][spectrogram][issue-2695]") {
+    const float nan_t = std::numeric_limits<float>::quiet_NaN();
+    const float pinf  = std::numeric_limits<float>::infinity();
+    for (auto ramp : {ColorRamp::grayscale, ColorRamp::inferno,
+                      ColorRamp::viridis, ColorRamp::heat}) {
+        ColorMapper mapper(ramp);
+        // NaN must not reach the uint8_t cast (UB); map() sanitizes NaN to 0,
+        // so map(NaN) == map(0). +/-Inf clamp safely to 1.0 / 0.0.
+        auto at_zero = mapper.map(0.0f);
+        auto at_one  = mapper.map(1.0f);
+        auto at_nan  = mapper.map(nan_t);
+        REQUIRE(at_nan.r == at_zero.r);
+        REQUIRE(at_nan.g == at_zero.g);
+        REQUIRE(at_nan.b == at_zero.b);
+        auto at_pinf = mapper.map(pinf);   // clamps to 1.0
+        REQUIRE(at_pinf.r == at_one.r);
+        REQUIRE(at_pinf.g == at_one.g);
+        REQUIRE(at_pinf.b == at_one.b);
+    }
 }


### PR DESCRIPTION
## What

The P7 proactive-Codex audits (#2643/#2644) flagged 22 candidates. **Verifying each against current code, most were already guarded** (false positives — this codebase is well-hardened). This PR batches the **5 genuinely-real, locally-verified** defects (one PR, to minimize CI):

| Issue | Defect | Fix |
|-------|--------|-----|
| #2691 | `clap_adapter load_event<T>` — `memcpy(sizeof(T))` with no `hdr->size` check → **OOB read/UB on the audio thread** | copy `min(hdr->size, sizeof(T))` into a zero-init local |
| #2694 | `aiff_reader` 24-bit — signed-shift UB for bytes ≥ 0x80 | build with unsigned arithmetic (output bit-identical) |
| #2695 | `multi_channel_meter` — NaN/Inf samples **irrecoverably poison** RMS/LUFS | treat non-finite samples as silence |
| #2695 | `spectrogram ColorMapper::map` — `clamp(NaN)`→`uint8_t` (**UB**) | sanitize NaN→0; ±Inf clamp |
| **#2693** | `standalone apply_config` recreated the Processor under an open editor → **use-after-free** of the ViewBridge's `Processor&` | **soft restart**: keep the processor instance stable (reuse + re-prepare; tear down audio/MIDI only) |

## Tests (all run locally, GPU-off)

New `[issue-2695]` cases (meter NaN-no-poison, ColorMapper NaN sanitize) + `[issue-2693]` `test_standalone_apply_config` (processor instance stable across apply_config; ran the real path — start() succeeded on the local audio device). **meter 64/14 · stft 414/31 · audio-file 702/49 · clap-midi-events 330/38 · standalone-apply-config 4/1 — all pass.**

## Scope note

The other ~17 scan candidates were **false positives** (already-guarded: audio_file ragged/NaN/truncation, buffering_reader overflow, aiff SSND-offset/AIFC/huge-alloc, spectrogram dims, CLAP RT-safe-param-via-SPSC) or **unverifiable** (AUv3 #2692 — scan line numbers didn't match current code). Triaged in the #2691–#2695 closeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)