### PR TITLE
ci: add release-dry-run workflow to catch release-chain breakage pre-tag (P9-2, #2576)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -42,6 +42,14 @@ Slice 6 (#551).
 
 ## GitHub workflow gotchas
 
+- `.github/workflows/release-dry-run.yml` (P9-2, #2576) exercises the release
+  build → `package_cli.py` → `pulp ship appcast` chain on a synthetic version
+  (`0.0.0-dryrun`) WITHOUT publishing — no GitHub release, no signing/notarize,
+  no appcast upload; artifacts are throwaway. It's additive (does not touch
+  `release-cli.yml` / `sign-and-release.yml`) and runs weekly + on demand, so a
+  build/packaging/appcast-generation regression surfaces BEFORE a real tag.
+  Keep it credential-free (notarize/sign stay in the real path) so it can run
+  on a schedule without secrets.
 - Keep watchdog/issue-maintenance workflows on REST `gh api` calls. Avoid
   `gh issue list` / `gh pr *` helpers in those paths because they can use the
   shared GraphQL quota; a watchdog must not fail while reporting that the

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,0 +1,82 @@
+name: Release Dry-Run
+
+# P9-2 (#2576): exercise the release build → package → appcast chain on a
+# SYNTHETIC version WITHOUT publishing, so release-chain breakage (build /
+# packaging / appcast-generation regressions) is caught BEFORE a real tag is
+# cut — instead of manually, post-tag, after a failed release.
+#
+# This is intentionally additive: it does NOT touch the real release path
+# (release-cli.yml / sign-and-release.yml), creates NO GitHub release, does NO
+# code-signing or Apple notarization (those need production credentials), and
+# publishes NOTHING. Artifacts are uploaded only as throwaway workflow
+# artifacts. Runs weekly and on demand.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * 1'  # Mondays 12:00 UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-dry-run-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dry-run:
+    name: Release dry-run (darwin-arm64, no publish)
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Bootstrap dependencies
+        run: ./setup.sh --ci --deps-only
+        shell: bash
+
+      - name: Fetch Skia binaries
+        run: python3 tools/scripts/fetch_skia_for_release.py darwin-arm64
+        shell: bash
+
+      - name: Configure (mirrors release-cli.yml darwin-arm64)
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DPULP_BUILD_TESTS=OFF \
+            -DPULP_REQUIRE_GPU_FOR_SDK=ON \
+            -DPULP_BUILD_WEBVIEW=ON
+        shell: bash
+
+      - name: Build CLI
+        run: cmake --build build --config Release --target pulp pulp-cpp pulp-mcp
+        shell: bash
+
+      - name: Package CLI (dry-run — no upload)
+        run: |
+          python3 tools/scripts/package_cli.py \
+            --binary build/pulp \
+            --cpp-binary build/tools/cli/pulp-cpp \
+            --mcp-binary build/tools/mcp/pulp-mcp \
+            --build-dir build \
+            --platform darwin-arm64 \
+            --out pulp-darwin-arm64.tar.gz
+          test -s pulp-darwin-arm64.tar.gz || { echo "::error::package_cli produced no tarball"; exit 1; }
+        shell: bash
+
+      - name: Generate + validate appcast (synthetic version, no publish)
+        run: |
+          ./build/pulp ship appcast \
+            --version 0.0.0-dryrun \
+            --url https://example.invalid/pulp-0.0.0-dryrun.pkg \
+            --output appcast.xml
+          test -s appcast.xml || { echo "::error::appcast generation produced no file"; exit 1; }
+          xmllint --noout appcast.xml
+        shell: bash
+
+      - name: Upload dry-run artifacts (throwaway — NOT a release)
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-dry-run-darwin-arm64
+          path: |
+            pulp-darwin-arm64.tar.gz
+            appcast.xml
+          retention-days: 7


### PR DESCRIPTION
## What

A new, **additive** workflow (`.github/workflows/release-dry-run.yml`) that exercises the release **build → `package_cli.py` → `pulp ship appcast`** chain on a synthetic version (`0.0.0-dryrun`) **without publishing** — no GitHub release, no code-signing/notarization, no appcast upload; artifacts are throwaway (7-day retention). Runs **weekly + on `workflow_dispatch`**.

## Why (P9-2 of #2576)

Release breakage (build / packaging / appcast-generation regressions) was caught **manually, post-tag, after a failed release** — the roadmap's '7 `fix(release)`/90d' churn. This surfaces it **before a real tag is cut**.

Deliberately additive + safe:
- Does **not** touch the working release path (`release-cli.yml` / `sign-and-release.yml`) → **zero risk to real releases**.
- **Credential-free** (notarize/sign stay in the real path) → can run on a schedule without secrets.
- Configure/build/package steps **mirror** release-cli.yml's darwin-arm64 leg.

## Validation

`yamllint --no-warnings -d relaxed` (the `workflow-lint.yml` gate config) **clean**, `actionlint` **clean**, `yaml.safe_load` OK. ci SKILL.md updated (skill-sync).

## Scope note (P9-1 deferred)

The P9-1 half — extracting `release-cli.yml`'s inline bundle steps into `tools/scripts/release_*.py` — is deferred: packaging already lives in `package_cli.py`, and the remaining inline steps modify the **working release path** (only validatable on a real tag → higher risk, lower value than this dry-run). Tracked in #2576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)