### PR TITLE
fix(view,host): honor 0% dimensions, fix grid-template:none throw, cap CLAP scan count (#2703 #2704)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.197.3
+    VERSION 0.197.4
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/host/include/pulp/host/scanner.hpp
+++ b/core/host/include/pulp/host/scanner.hpp
@@ -125,4 +125,9 @@ private:
 #endif
 };
 
+// Clamp an untrusted CLAP plugin count — a malformed bundle's factory can
+// return an absurd value that would make reserve()/iteration throw and abort
+// the whole scan (#2703). Exposed for testing.
+uint32_t cap_clap_plugin_count(uint32_t count) noexcept;
+
 } // namespace pulp::host

--- a/core/host/src/scanner_clap.cpp
+++ b/core/host/src/scanner_clap.cpp
@@ -38,6 +38,13 @@ std::string resolve_clap_binary(const std::string& path) {
 
 }  // namespace
 
+uint32_t cap_clap_plugin_count(uint32_t count) noexcept {
+    // No real CLAP bundle exposes thousands of plugins; clamp an untrusted
+    // count so a malformed factory can't drive an absurd allocation (#2703).
+    constexpr uint32_t kMaxClapPluginsPerBundle = 1024;
+    return count > kMaxClapPluginsPerBundle ? kMaxClapPluginsPerBundle : count;
+}
+
 // Filename-only fallback used when descriptor enumeration fails for
 // any reason (missing entry, init failure, exception thrown across
 // the dlopen boundary). The user sees the bundle in scan output but
@@ -171,6 +178,14 @@ std::vector<PluginInfo> scan_clap_bundle_descriptors(const std::string& path) {
         runtime::log_warn("CLAP scan: get_plugin_count threw unknown exception for '{}' (#812 guard)",
                           path);
     } // LCOV_EXCL_STOP
+    // A malformed bundle can RETURN (not throw) an absurd count; reserve(count)
+    // would then throw bad_alloc/length_error outside the per-bundle fallback
+    // and abort the whole scan (#2703). Cap it before use.
+    if (uint32_t capped = cap_clap_plugin_count(count); capped != count) {
+        runtime::log_warn("CLAP scan: '{}' reported {} plugins; capping at {} (#2703 guard)",
+                          path, count, capped);
+        count = capped;
+    }
     results.reserve(count);
     for (uint32_t i = 0; i < count; ++i) {
         const clap_plugin_descriptor_t* desc = nullptr;

--- a/core/view/src/view.cpp
+++ b/core/view/src/view.cpp
@@ -1153,17 +1153,34 @@ std::vector<GridTrack> GridStyle::parse_template(const std::string& tmpl) {
     std::vector<GridTrack> tracks;
     std::istringstream ss(tmpl);
     std::string token;
+    // Parse a numeric prefix without throwing; std::stof on a non-numeric
+    // token (e.g. the CSS initial value `none`) used to throw out of
+    // WidgetBridge::load_script (#2704). Returns false for unparseable tokens.
+    auto try_parse = [](const std::string& s, float& out) -> bool {
+        try {
+            size_t consumed = 0;
+            out = std::stof(s, &consumed);
+            return consumed > 0;
+        } catch (...) {
+            return false;
+        }
+    };
     while (ss >> token) {
+        // `none` is the CSS initial value for grid-template-* — no explicit
+        // tracks. Skip it (and any other non-track keyword) rather than throw.
+        if (token == "none") continue;
         if (token.back() == 'r' && token.size() > 2 && token[token.size()-2] == 'f') {
             // "1fr", "2.5fr"
-            float val = std::stof(token.substr(0, token.size() - 2));
-            tracks.push_back(GridTrack::fractional(val));
+            float val = 0.0f;
+            if (try_parse(token.substr(0, token.size() - 2), val))
+                tracks.push_back(GridTrack::fractional(val));
         } else if (token == "auto") {
             tracks.push_back(GridTrack::auto_size());
         } else {
-            // "100px" or "100" — treat as fixed pixels
-            float val = std::stof(token);
-            tracks.push_back(GridTrack::fixed_px(val));
+            // "100px" or "100" — treat as fixed pixels; skip unparseable tokens.
+            float val = 0.0f;
+            if (try_parse(token, val))
+                tracks.push_back(GridTrack::fixed_px(val));
         }
     }
     return tracks;

--- a/core/view/src/yoga_layout.cpp
+++ b/core/view/src/yoga_layout.cpp
@@ -130,7 +130,7 @@ static void apply_flex_style(YGNodeRef node, const FlexStyle& f, bool is_absolut
         // YGNodeStyleSetFlexBasisPercent; numeric → existing px API.
         if (f.dim_flex_basis.unit == DimensionUnit::auto_) {
             YGNodeStyleSetFlexBasisAuto(node);
-        } else if (f.dim_flex_basis.unit == DimensionUnit::percent && f.dim_flex_basis.value > 0) {
+        } else if (f.dim_flex_basis.unit == DimensionUnit::percent && f.dim_flex_basis.value >= 0) {
             YGNodeStyleSetFlexBasisPercent(node, f.dim_flex_basis.value);
         } else if (f.flex_basis >= 0) {
             YGNodeStyleSetFlexBasis(node, f.flex_basis);
@@ -297,30 +297,30 @@ static void apply_flex_style(YGNodeRef node, const FlexStyle& f, bool is_absolut
     // gets cleared.
     if (f.dim_width.unit == DimensionUnit::auto_) {
         YGNodeStyleSetWidthAuto(node);
-    } else if (f.dim_width.unit == DimensionUnit::percent && f.dim_width.value > 0) {
+    } else if (f.dim_width.unit == DimensionUnit::percent && f.dim_width.value >= 0) {
         YGNodeStyleSetWidthPercent(node, f.dim_width.value);
     } else if (f.preferred_width > 0) {
         YGNodeStyleSetWidth(node, f.preferred_width);
     }
     if (f.dim_height.unit == DimensionUnit::auto_) {
         YGNodeStyleSetHeightAuto(node);
-    } else if (f.dim_height.unit == DimensionUnit::percent && f.dim_height.value > 0) {
+    } else if (f.dim_height.unit == DimensionUnit::percent && f.dim_height.value >= 0) {
         YGNodeStyleSetHeightPercent(node, f.dim_height.value);
     } else if (f.preferred_height > 0) {
         YGNodeStyleSetHeight(node, f.preferred_height);
     }
     // pulp #1434 (rn batch C) — min/max width/height dispatch on dim_*.unit
     // for the percent path; existing px path stays for numeric values.
-    if (f.dim_min_width.unit == DimensionUnit::percent && f.dim_min_width.value > 0) {
+    if (f.dim_min_width.unit == DimensionUnit::percent && f.dim_min_width.value >= 0) {
         YGNodeStyleSetMinWidthPercent(node, f.dim_min_width.value);
     } else if (f.min_width > 0) YGNodeStyleSetMinWidth(node, f.min_width);
-    if (f.dim_min_height.unit == DimensionUnit::percent && f.dim_min_height.value > 0) {
+    if (f.dim_min_height.unit == DimensionUnit::percent && f.dim_min_height.value >= 0) {
         YGNodeStyleSetMinHeightPercent(node, f.dim_min_height.value);
     } else if (f.min_height > 0) YGNodeStyleSetMinHeight(node, f.min_height);
-    if (f.dim_max_width.unit == DimensionUnit::percent && f.dim_max_width.value > 0) {
+    if (f.dim_max_width.unit == DimensionUnit::percent && f.dim_max_width.value >= 0) {
         YGNodeStyleSetMaxWidthPercent(node, f.dim_max_width.value);
     } else if (f.max_width > 0) YGNodeStyleSetMaxWidth(node, f.max_width);
-    if (f.dim_max_height.unit == DimensionUnit::percent && f.dim_max_height.value > 0) {
+    if (f.dim_max_height.unit == DimensionUnit::percent && f.dim_max_height.value >= 0) {
         YGNodeStyleSetMaxHeightPercent(node, f.dim_max_height.value);
     } else if (f.max_height > 0) YGNodeStyleSetMaxHeight(node, f.max_height);
 

--- a/test/test_host.cpp
+++ b/test/test_host.cpp
@@ -117,6 +117,21 @@ TEST_CASE("PluginScanner scan runs without crash", "[host][scanner]") {
 // Pin: scan a malformed `.clap` bundle and assert (a) it doesn't crash
 // and (b) the filename-fallback path produces a single PluginInfo so
 // users see SOMETHING in the catalog instead of a silent drop.
+TEST_CASE("cap_clap_plugin_count clamps an untrusted bundle count (issue-2703)",
+          "[host][scanner][issue-2703]") {
+    using pulp::host::cap_clap_plugin_count;
+    // Sane counts pass through unchanged.
+    REQUIRE(cap_clap_plugin_count(0) == 0);
+    REQUIRE(cap_clap_plugin_count(1) == 1);
+    REQUIRE(cap_clap_plugin_count(64) == 64);
+    REQUIRE(cap_clap_plugin_count(1024) == 1024);
+    // An absurd count from a malformed factory is clamped before it can drive
+    // an allocation that would throw and abort the whole scan.
+    REQUIRE(cap_clap_plugin_count(1025) == 1024);
+    REQUIRE(cap_clap_plugin_count(1000000) == 1024);
+    REQUIRE(cap_clap_plugin_count(0xFFFFFFFFu) == 1024);
+}
+
 TEST_CASE("scan_clap_bundle_descriptors survives malformed bundle (dlopen-fail path)",
           "[host][scanner][issue-1862][coverage]") {
     namespace fs = std::filesystem;

--- a/test/test_layout_w3c.cpp
+++ b/test/test_layout_w3c.cpp
@@ -467,6 +467,69 @@ TEST_CASE("KeyframeAnimation: multi-step keyframes", "[animation]") {
 // CSS Grid Layout Level 1
 // ═══════════════════════════════════════════════════════════════════
 
+TEST_CASE("Layout: max-width 0% clamps a growing child to zero (issue-2704)",
+          "[layout][w3c][issue-2704]") {
+    // A flex-grow child with max-width:0% must be clamped to 0 — the percent
+    // max path also used the >0 guard that dropped 0%.
+    View root;
+    root.set_bounds({0, 0, 400, 50});
+    root.flex().direction = FlexDirection::row;
+    auto child = std::make_unique<View>();
+    child->flex().flex_grow = 1;
+    child->flex().dim_max_width = Dimension{0.0f, DimensionUnit::percent};
+    root.add_child(std::move(child));
+    root.layout_children();
+    REQUIRE(root.child_at(0)->bounds().width == 0.0f);
+}
+
+TEST_CASE("Grid: parse_template 'none' is empty and never throws (issue-2704)",
+          "[layout][grid][issue-2704]") {
+    // `none` is the CSS initial value for grid-template-* — std::stof("none")
+    // used to throw out of WidgetBridge::load_script. It must yield no tracks.
+    REQUIRE_NOTHROW(GridStyle::parse_template("none"));
+    REQUIRE(GridStyle::parse_template("none").empty());
+    // Unparseable tokens are skipped, not thrown; valid tracks still parse.
+    REQUIRE_NOTHROW(GridStyle::parse_template("none auto 1fr garbage"));
+    auto mixed = GridStyle::parse_template("none auto 1fr garbage");
+    REQUIRE(mixed.size() == 2);
+    REQUIRE(mixed[0].type == GridTrack::Type::auto_);
+    REQUIRE(mixed[1].type == GridTrack::Type::fr);
+}
+
+TEST_CASE("Layout: width 0% lays out at zero, not intrinsic (issue-2704)",
+          "[layout][w3c][issue-2704]") {
+    View root;
+    root.set_bounds({0, 0, 300, 50});
+    root.flex().direction = FlexDirection::row;
+    auto child = std::make_unique<View>();
+    child->flex().preferred_width = 100;  // intrinsic fallback
+    child->flex().dim_width = Dimension{0.0f, DimensionUnit::percent};  // width: 0%
+    root.add_child(std::move(child));
+    root.layout_children();
+    // 0% must win over the intrinsic 100 (previously the >0 guard dropped 0%).
+    REQUIRE(root.child_at(0)->bounds().width == 0.0f);
+}
+
+TEST_CASE("Layout: flex-basis 0% is honored, not treated as auto (issue-2704)",
+          "[layout][w3c][issue-2704]") {
+    // Two flex:1 children with different intrinsic widths but flex-basis:0%
+    // should split the row EQUALLY (the classic `flex: 1` behavior). With the
+    // old >0 guard, 0% basis was dropped and the unequal intrinsics leaked in.
+    View root;
+    root.set_bounds({0, 0, 300, 50});
+    root.flex().direction = FlexDirection::row;
+    for (int i = 0; i < 2; ++i) {
+        auto c = std::make_unique<View>();
+        c->flex().preferred_width = 40.0f + static_cast<float>(i) * 80.0f;
+        c->flex().flex_grow = 1;
+        c->flex().dim_flex_basis = Dimension{0.0f, DimensionUnit::percent};
+        root.add_child(std::move(c));
+    }
+    root.layout_children();
+    REQUIRE(root.child_at(0)->bounds().width == root.child_at(1)->bounds().width);
+    REQUIRE(root.child_at(0)->bounds().width > 0.0f);
+}
+
 TEST_CASE("Grid: parse_template '1fr 2fr auto 100px'", "[layout][grid]") {
     auto tracks = GridStyle::parse_template("1fr 2fr auto 100");
     REQUIRE(tracks.size() == 4);


### PR DESCRIPTION
## What

Fixes the **clear, fully-tested** findings from the Codex bug-hunt on `view` + `host` (#2703, #2704), combined into one PR to keep it to a single CI run.

| Issue | Fix | Test |
|-------|-----|------|
| #2704 | `yoga_layout`: percent dims guarded `value > 0` → **`width/height/min/max/flex-basis: 0%` silently ignored** (laid out at intrinsic). Changed 7 guards to `>= 0`. | `[issue-2704]` width 0%, **flex-basis 0%** (equal split), max-width 0% clamp |
| #2704 | `GridStyle::parse_template`: `grid-template-columns: none` hit `std::stof("none")` → **threw out of `load_script`**. Now `none`→empty, unparseable tokens skipped. | parse_template none/garbage |
| #2703 | `scanner_clap`: guarded `get_plugin_count` *throwing* but not a malformed bundle *returning* an absurd count → `reserve(count)` aborts the scan. Extracted `cap_clap_plugin_count()` (≤1024). | `[issue-2703]` sane counts pass, absurd→1024 |

## Test rigor

The view tests are **gold-standard**: verified they **FAIL without the fix** (flex-basis split 110/190 instead of equal) and pass with it. **Full suites green, no regression: test_layout_w3c 88/38, test_host 675/18.**

## Deferred (kept open in #2703)

The two host **P1 RT-lifecycle** findings — live-gain plain-`float` data race (atomic breaks the runtime-node move-into-map) and `prepare()` re-entry vs an in-flight old snapshot — are genuine **design** changes, not quick guards. Out of scope for this batch; #2703 stays open for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)