### PR TITLE
docs(skills): rewrite issue/PR cite-phrases as stable rationale (docs-noise-lint)

### DIFF
--- a/.agents/skills/auv2/SKILL.md
+++ b/.agents/skills/auv2/SKILL.md
@@ -155,6 +155,17 @@ The attribute is a static-analysis hint only — dropping it from derived-class 
 
 Calling `_ownership->bridge->close()` HERE explicitly (BEFORE `delete _ownership`) reverses that order: the View dies first, then `~PluginViewHost` dereferences a dangling `root_` reference and crashes the AU v2 editor close path. Codex P1 review on PR #653 caught this — the fix is to remove the explicit close, NOT to add it. Same rule applies to any future Cocoa-View ownership wrapper that mixes a `ViewBridge` and a `PluginViewHost` in the same C++ scope.
 
+### Editor GPU host is auto-selected — don't hardcode `use_gpu`
+
+`au_v2_cocoa_view.mm` no longer sets `Options::use_gpu` by hand; it calls
+`pulp::format::decide_gpu_host(*bridge)` so a Skia/Dawn/scripted editor gets the
+GPU `PluginViewHost` automatically (hardcoding `use_gpu=false` was the bug that
+made it fall back to AutoUi/CPU). It also wires `host->set_resize_callback(...)`
+because AU v2 has **no host size callback** — the DAW resizes the returned
+NSView directly, so native frame changes are forwarded to `bridge->resize()`
+through that seam. Full contract: the `view-bridge` skill's "GPU view host
+auto-selection" section. (GPU-plugin-view-host work, 2026-05.)
+
 ### `auval` automation must disable editor creation
 
 `auval` can instantiate AU editor surfaces during validation, which is

--- a/.agents/skills/auv3/SKILL.md
+++ b/.agents/skills/auv3/SKILL.md
@@ -381,8 +381,8 @@ a freed View (GPU-plugin-view-host work, 2026-05; Codex P1).
 Calling `_bridge->close()` HERE explicitly (before `[super dealloc]`)
 reverses that order: the View dies first, then `~PluginViewHost`
 dereferences a dangling `root_` reference and crashes AUv3 editor
-close. Codex P1 review on PR #653 caught the original variant — the fix
-is to remove the explicit close, NOT to add it.
+close. An earlier variant explicitly closed the bridge here and shipped
+that crash; the fix is to remove the explicit close, NOT to add it.
 
 The AUv3 editor now also auto-selects the GPU host via the shared
 `decide_gpu_host()` helper (Options overload) — see the `view-bridge`

--- a/.agents/skills/auv3/SKILL.md
+++ b/.agents/skills/auv3/SKILL.md
@@ -356,25 +356,37 @@ class name fails silently.
 ### `PulpAUViewController::dealloc` — never call `_bridge->close()` explicitly
 
 The view controller declares its ivars `_bridge` (ViewBridge), then
-`_viewHost` (PluginViewHost), then `_fallbackView`. When `[super
+`_fallbackView` (View), then `_viewHost` (PluginViewHost). When `[super
 dealloc]` runs, the runtime destroys C++-typed ivars in REVERSE
-declaration order: `_fallbackView`, `_viewHost`, `_bridge`. That
+declaration order: `_viewHost`, `_fallbackView`, `_bridge`. That
 ordering is load-bearing:
 
-1. `~PluginViewHost` runs second. It calls
-   `root_.set_plugin_view_host(nullptr)` — the View `root_`
-   references is still alive (still owned by `_bridge->view_`), so
-   the call is safe and clears the back-pointer.
-2. `~ViewBridge` runs last. Its destructor calls `close()` →
-   `Processor::on_view_closed` → `view_.reset()` destroys the View.
-   The back-pointer was already cleared in step 1, so the View's
-   own teardown can't reach a dead host.
+1. `~PluginViewHost` runs FIRST. It calls
+   `root_.set_plugin_view_host(nullptr)` (and `set_frame_clock(nullptr)`
+   on the GPU host). `root_` references either `_bridge->view_` OR
+   `_fallbackView` — BOTH are still alive at this point, so clearing
+   the back-pointers is safe on either path.
+2. `~View` (`_fallbackView`) runs next — no-op on the bridge-success
+   path; on the fallback path the back-pointer was cleared in step 1.
+3. `~ViewBridge` runs last. Its destructor calls `close()` →
+   `Processor::on_view_closed` → `view_.reset()`. The back-pointer was
+   already cleared in step 1.
+
+**`_viewHost` MUST be declared last (destroy first).** The original order
+`_bridge, _viewHost, _fallbackView` destroyed `_fallbackView` before
+`_viewHost`; on the no-`audioUnit` preview path `_fallbackView` *is* the
+View `_viewHost->root_` references, so the host cleared a back-pointer into
+a freed View (GPU-plugin-view-host work, 2026-05; Codex P1).
 
 Calling `_bridge->close()` HERE explicitly (before `[super dealloc]`)
 reverses that order: the View dies first, then `~PluginViewHost`
 dereferences a dangling `root_` reference and crashes AUv3 editor
-close. Codex P1 review on PR #653 caught this — the fix is to remove
-the explicit close, NOT to add it.
+close. Codex P1 review on PR #653 caught the original variant — the fix
+is to remove the explicit close, NOT to add it.
+
+The AUv3 editor now also auto-selects the GPU host via the shared
+`decide_gpu_host()` helper (Options overload) — see the `view-bridge`
+skill's "GPU view host auto-selection" section.
 
 ### Headless automation must not create fallback AUv3 UI
 

--- a/.agents/skills/clap/SKILL.md
+++ b/.agents/skills/clap/SKILL.md
@@ -213,6 +213,15 @@ Window API negotiation is compile-time platform-switched to Cocoa /
 Win32 / X11. `gui_can_resize` returns false today — resize negotiation
 has not been wired.
 
+`gui_create` no longer hardcodes `Options::use_gpu`; it calls
+`pulp::format::decide_gpu_host(*bridge)` so a Skia/Dawn/scripted editor
+auto-selects the GPU `PluginViewHost`, wires the per-vsync scripted idle pump
+(`make_scripted_idle_pump`), and screams via `warn_if_unexpected_cpu_fallback`
+on a silent CPU fallback. CLAP's `gui_set_size` already resizes the bridge +
+host, so no extra resize seam is needed (unlike AU v2). Full contract: the
+`view-bridge` skill's "GPU view host auto-selection" section.
+(GPU-plugin-view-host work, 2026-05.)
+
 ### ARA companion factory
 
 `clap_get_extension(kClapAraFactoryExtension)` lazily creates the

--- a/.agents/skills/ios/SKILL.md
+++ b/.agents/skills/ios/SKILL.md
@@ -295,7 +295,7 @@ Builds the `.appex` only. The App Store container host-app target is authored se
 
 ### `PulpAUViewController::dealloc` — never call `_bridge->close()` explicitly
 
-Touched here because `core/format/src/au_view_controller_ios.mm` is dual-owned by `ios` + `auv3` + `view-bridge`. The view controller's ivars are declared `_bridge`, `_fallbackView`, `_viewHost` (the GPU-plugin-view-host work reordered them — see below) and destroyed in REVERSE declaration order, so `_viewHost` is destroyed FIRST. That makes `root_.set_plugin_view_host(nullptr)` / `set_frame_clock(nullptr)` in `~PluginViewHost` safe on BOTH paths (the bridge's view and the `_fallbackView` are still alive). Calling `_bridge->close()` explicitly in `dealloc` reverses that order, frees the View first, and the host's destructor then dereferences a dangling reference — crashes AUv3 editor close. Codex P1 review on PR #653. Full rationale lives in the `auv3` skill under "PulpAUViewController::dealloc — never call `_bridge->close()` explicitly".
+Touched here because `core/format/src/au_view_controller_ios.mm` is dual-owned by `ios` + `auv3` + `view-bridge`. The view controller's ivars are declared `_bridge`, `_fallbackView`, `_viewHost` (the GPU-plugin-view-host work reordered them — see below) and destroyed in REVERSE declaration order, so `_viewHost` is destroyed FIRST. That makes `root_.set_plugin_view_host(nullptr)` / `set_frame_clock(nullptr)` in `~PluginViewHost` safe on BOTH paths (the bridge's view and the `_fallbackView` are still alive). Calling `_bridge->close()` explicitly in `dealloc` reverses that order, frees the View first, and the host's destructor then dereferences a dangling reference — crashes AUv3 editor close. Full rationale lives in the `auv3` skill under "PulpAUViewController::dealloc — never call `_bridge->close()` explicitly".
 
 **Ivar order is load-bearing (2026-05 fallback-UAF fix):** the old order
 `_bridge, _viewHost, _fallbackView` destroyed `_fallbackView` BEFORE `_viewHost`.
@@ -337,7 +337,7 @@ GPU-plugin-view-host work):
   on a device/simulator.
 - **Embeddability matches mac:** display link starts on `-didMoveToWindow`
   (not `attach_to_parent`); `-layoutSubviews` re-syncs size/scale; `tick()`
-  pumps `idle_callback_` first (the #1402 contract — keep it), then frame clock
+  pumps `idle_callback_` first (the idle-pump-in-tick contract — keep it), then frame clock
   + CSS animations; liveness token; GpuSurface resized PHYSICAL, SkiaSurface
   LOGICAL+scale; CPU fallback in the factory when `is_gpu_backed()` is false.
 

--- a/.agents/skills/ios/SKILL.md
+++ b/.agents/skills/ios/SKILL.md
@@ -295,7 +295,13 @@ Builds the `.appex` only. The App Store container host-app target is authored se
 
 ### `PulpAUViewController::dealloc` — never call `_bridge->close()` explicitly
 
-Touched here because `core/format/src/au_view_controller_ios.mm` is dual-owned by `ios` + `auv3` + `view-bridge`. The view controller's ivars `_bridge`, `_viewHost`, `_fallbackView` are destroyed in REVERSE declaration order by the runtime; the resulting sequence (host destroyed before bridge) is what makes the `root_.set_plugin_view_host(nullptr)` call in `~PluginViewHost` safe. Calling `_bridge->close()` explicitly in `dealloc` reverses that order, frees the View first, and the host's destructor then dereferences a dangling reference — crashes AUv3 editor close. Codex P1 review on PR #653. Full rationale lives in the `auv3` skill under "PulpAUViewController::dealloc — never call `_bridge->close()` explicitly".
+Touched here because `core/format/src/au_view_controller_ios.mm` is dual-owned by `ios` + `auv3` + `view-bridge`. The view controller's ivars are declared `_bridge`, `_fallbackView`, `_viewHost` (the GPU-plugin-view-host work reordered them — see below) and destroyed in REVERSE declaration order, so `_viewHost` is destroyed FIRST. That makes `root_.set_plugin_view_host(nullptr)` / `set_frame_clock(nullptr)` in `~PluginViewHost` safe on BOTH paths (the bridge's view and the `_fallbackView` are still alive). Calling `_bridge->close()` explicitly in `dealloc` reverses that order, frees the View first, and the host's destructor then dereferences a dangling reference — crashes AUv3 editor close. Codex P1 review on PR #653. Full rationale lives in the `auv3` skill under "PulpAUViewController::dealloc — never call `_bridge->close()` explicitly".
+
+**Ivar order is load-bearing (2026-05 fallback-UAF fix):** the old order
+`_bridge, _viewHost, _fallbackView` destroyed `_fallbackView` BEFORE `_viewHost`.
+On the no-`audioUnit` preview path `_fallbackView` *is* the View `_viewHost->root_`
+references, so the host then cleared a back-pointer into a freed View. Declaring
+`_viewHost` LAST (so it destroys first) fixes both paths. Don't reorder back.
 
 ### AUv3 headless guard must not create a fallback host
 
@@ -314,6 +320,26 @@ The fix is two pieces:
 2. In `tick()`, run `idle_callback_()` first; the callback can `request_repaint`, which arms `needs_repaint_` and triggers `render_frame()` in the same tick.
 
 CPU iOS host (`IOSWindowHost`) has the same gap but no display link; `repaint()` just calls `[root_view_ setNeedsDisplay]` and UIKit drives `drawRect:` only on user interaction. A separate CADisplayLink-on-CPU-path fix is owed; not blocking AUv3 use cases since AUv3 host apps go through the GPU path.
+
+### Embeddable iOS GPU *plugin* host (`IOSGpuPluginViewHost`) — distinct from the window host
+
+`core/view/platform/ios/plugin_view_host_ios.mm` is the AUv3 plugin embed
+host (vs `IOSGpuWindowHost` for standalone). Two things to know (2026-05
+GPU-plugin-view-host work):
+
+- **It was dead code on a stale render API.** The prior version did
+  `std::make_unique<render::GpuSurface>()` (abstract!) and
+  `SkiaSurface::initialize` with `dawn_device`/`dawn_queue` Config fields that
+  no longer exist. It compiled never because **no `ios-gpu` Skia libs are
+  fetched**, so `PULP_HAS_SKIA` is OFF for iOS and the block is `#ifdef`'d out.
+  It now uses the current API (`GpuSurface::create_dawn()` + `SkiaSurface::create()`).
+  **This whole path is CI-unvalidated** until iOS Skia is fetched/built — verify
+  on a device/simulator.
+- **Embeddability matches mac:** display link starts on `-didMoveToWindow`
+  (not `attach_to_parent`); `-layoutSubviews` re-syncs size/scale; `tick()`
+  pumps `idle_callback_` first (the #1402 contract — keep it), then frame clock
+  + CSS animations; liveness token; GpuSurface resized PHYSICAL, SkiaSurface
+  LOGICAL+scale; CPU fallback in the factory when `is_gpu_backed()` is false.
 
 ## See Also
 

--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -586,9 +586,40 @@ AUv3 avoids constructing `PluginViewHost`. Do not replace this with
 post-hoc window cleanup; the contract is that no native editor host is
 created in the first place.
 
+## GPU view host auto-selection — never hardcode `use_gpu=false`
+
+The format adapters (AU v2 / VST3 / CLAP / iOS AUv3) must NOT hand-set
+`PluginViewHost::Options::use_gpu`. They call the shared decision helper
+`pulp::format::decide_gpu_host(bridge)` (`core/format/include/pulp/format/gpu_host_select.hpp`),
+which returns `use_gpu` = `bridge.uses_script_ui() || bridge.view()->requires_gpu_host()`,
+honoring the `PULP_DISABLE_PLUGIN_GPU` runtime opt-out. Hardcoding
+`use_gpu=false` is the exact trap that made a Skia/Dawn editor silently fall
+back to the AutoUi CPU path (the GPU-plugin-view-host work, 2026-05).
+
+Rules when touching an adapter's editor-attach path:
+- A custom `Processor::create_view()` that paints via the GPU (scripted React
+  UI, WebGPU/Three.js canvas) MUST call `view->set_requires_gpu_host(true)` on
+  its root, or `decide_gpu_host` returns `mode=autoui` and it gets CPU. The
+  framework scripted-UI root (`editor_ui.hpp`) already sets it.
+- After `PluginViewHost::create(...)`, call
+  `format::warn_if_unexpected_cpu_fallback(decision, host.get())` — it screams
+  (`runtime::log_error`) if GPU was requested but the host fell back to CPU.
+- Wire the per-vsync scripted pump: `host->set_idle_callback(make_scripted_idle_pump(bridge))`.
+  Without it a JS UI paints its first frame but `requestAnimationFrame` /
+  timers / async results never fire.
+- `make_scripted_idle_pump` captures the `ViewBridge` by raw pointer, so the
+  host MUST be destroyed before the bridge. In AU/VST3/CLAP the bridge is
+  declared before the host (reverse-destruction → host first); keep that order.
+- AU v2 has no host resize callback — use `host->set_resize_callback(...)` to
+  forward native-NSView frame changes to `bridge->resize()`. VST3/CLAP drive
+  resize through their own host size callbacks and don't need it.
+
+See `planning/2026-05-22-gpu-view-host-in-plugins.md` and its `qa/` doc.
+
 ## References
 
 - `core/format/include/pulp/format/view_bridge.hpp` — public API
+- `core/format/include/pulp/format/gpu_host_select.hpp` — GPU host auto-select helper
 - `core/format/src/view_bridge.cpp` — implementation
 - `core/format/include/pulp/format/processor.hpp` — `create_view`,
   `view_size`, `on_view_*`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.197.4
+    VERSION 0.198.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/clap_entry.hpp
+++ b/core/format/include/pulp/format/clap_entry.hpp
@@ -16,6 +16,7 @@
 #include <pulp/format/clap_adapter.hpp>
 #ifdef PULP_CLAP_GUI
 #include <pulp/format/editor_ui.hpp>
+#include <pulp/format/gpu_host_select.hpp>
 #endif
 #include <pulp/runtime/log.hpp>
 #include <pulp/runtime/system.hpp>
@@ -314,15 +315,19 @@ inline bool gui_create(const clap_plugin_t* plugin, const char*, bool) {
     }
 
     const auto& hints = p->bridge->size_hints();
+    const auto gpu = decide_gpu_host(*p->bridge);
     view::PluginViewHost::Options opts;
     opts.size = {hints.preferred_width, hints.preferred_height};
-    opts.use_gpu = false;  // Start with CoreGraphics; GPU opt-in later
+    opts.use_gpu = gpu.use_gpu;
 
     p->editor_host = view::PluginViewHost::create(*p->bridge->view(), opts);
     if (p->editor_host) {
-        runtime::log_info("CLAP editor: created ({}x{}, mode={})",
+        warn_if_unexpected_cpu_fallback(gpu, p->editor_host.get());
+        // Pump the scripted UI session (async results, timers, rAF) per vsync.
+        p->editor_host->set_idle_callback(make_scripted_idle_pump(*p->bridge));
+        runtime::log_info("CLAP editor: created ({}x{}, mode={}, gpu={})",
                           hints.preferred_width, hints.preferred_height,
-                          p->bridge->uses_script_ui() ? "scripted" : "autoui");
+                          gpu.mode, p->editor_host->is_gpu_backed());
     } else {
         runtime::log_error("CLAP editor: failed to create host");
         p->bridge->close();

--- a/core/format/include/pulp/format/editor_ui.hpp
+++ b/core/format/include/pulp/format/editor_ui.hpp
@@ -33,6 +33,11 @@ inline EditorUiInstance build_editor_ui(state::StateStore& store,
         auto root = std::make_unique<view::View>();
         root->set_theme(view::Theme::dark());
         root->flex().direction = view::FlexDirection::column;
+        // The scripted UI paints through the Skia/Dawn pipeline; tag the
+        // root so adapters auto-select the GPU PluginViewHost. (Adapters
+        // also check ViewBridge::uses_script_ui(); this keeps the flag
+        // correct when the view is inspected outside a bridge.)
+        root->set_requires_gpu_host(true);
 
         view::ScriptedUiOptions options;
         options.script_path = *script_path;

--- a/core/format/include/pulp/format/gpu_host_select.hpp
+++ b/core/format/include/pulp/format/gpu_host_select.hpp
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <pulp/format/view_bridge.hpp>
+#include <pulp/runtime/log.hpp>
+#include <pulp/view/plugin_view_host.hpp>
+#include <pulp/view/scripted_ui.hpp>
+
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+
+// Shared GPU PluginViewHost auto-selection for every plugin format adapter
+// (AU v2 / VST3 / CLAP / iOS AUv3). The renderer, JS runtime, Yoga layout,
+// and surface management are identical across formats — only the per-format
+// shell/lifecycle glue differs — so the *decision* of whether to request the
+// GPU host belongs in one place.
+//
+// A developer building a Skia/Dawn/scripted editor gets the GPU host
+// automatically; they never hand-set a flag. Hardcoding `use_gpu=false` is
+// exactly the trap that made the ChainerSynth AU fall back to AutoUi/CPU.
+//
+// See `planning/2026-05-22-gpu-view-host-in-plugins.md`.
+
+namespace pulp::format {
+
+/// Runtime opt-out: `PULP_DISABLE_PLUGIN_GPU=1` forces the CoreGraphics CPU
+/// path. DAW/plugin host processes vary; a GPU failure must never make an
+/// editor vanish, so the operator can always force CPU.
+inline bool plugin_gpu_disabled_by_env() {
+    const char* v = std::getenv("PULP_DISABLE_PLUGIN_GPU");
+    return v != nullptr && v[0] != '\0' && std::strcmp(v, "0") != 0;
+}
+
+struct GpuHostDecision {
+    bool use_gpu = false;          ///< final request passed to PluginViewHost::Options
+    const char* mode = "autoui";   ///< "scripted" | "custom" | "autoui"
+    bool wants_gpu = false;        ///< capability signal, before env opt-out
+    bool create_view_null = false; ///< bridge has no view (open failed)
+};
+
+/// Decide whether the GPU host should be requested for `bridge`, and emit the
+/// `[plugin-gpu-host]` debug-parity adapter log (mirrors `[gpu-host]`).
+///
+/// GPU is wanted when the editor renders through the Skia/Dawn pipeline:
+///   - the framework scripted-UI path (`PULP_UI_SCRIPT_PATH`), detected via
+///     `ViewBridge::uses_script_ui()`, or
+///   - a custom `Processor::create_view()` whose view set
+///     `View::set_requires_gpu_host(true)` (e.g. ChainerSynth).
+inline GpuHostDecision decide_gpu_host(const ViewBridge& bridge) {
+    GpuHostDecision d;
+    const view::View* v = bridge.view();
+    d.create_view_null = (v == nullptr);
+
+    const bool scripted = bridge.uses_script_ui();
+    const bool view_wants = (v != nullptr) && v->requires_gpu_host();
+    d.wants_gpu = scripted || view_wants;
+
+    if (scripted) {
+        d.mode = "scripted";
+    } else if (view_wants) {
+        d.mode = "custom";
+    } else {
+        d.mode = "autoui";
+    }
+
+    const bool env_off = plugin_gpu_disabled_by_env();
+    d.use_gpu = d.wants_gpu && !env_off;
+
+    runtime::log_info(
+        "[plugin-gpu-host] adapter mode={} use_gpu={} wants_gpu={} "
+        "env_disabled={} scripted={} requires_gpu_host={} create_view_null={}",
+        d.mode, d.use_gpu, d.wants_gpu, env_off, scripted, view_wants,
+        d.create_view_null);
+
+    return d;
+}
+
+/// Build the per-vsync idle pump for a bridge. GPU hosts invoke it once per
+/// display-link tick so the scripted UI session keeps polling async results,
+/// timers, and `requestAnimationFrame` while the editor is embedded. Captures
+/// the bridge by pointer; the host MUST drop this callback (via `detach()` /
+/// destruction) before the bridge is destroyed — every adapter resets its
+/// host before `bridge.close()`.
+inline std::function<void()> make_scripted_idle_pump(ViewBridge& bridge) {
+    auto* bridge_ptr = &bridge;
+    return [bridge_ptr]() {
+        if (auto* session = bridge_ptr->scripted_ui()) {
+            session->poll();
+        }
+    };
+}
+
+/// Scream-guard (runtime): after the host is created, verify the GPU path
+/// actually took. If GPU was expected (requested + Skia compiled in) but the
+/// host fell back to CoreGraphics, log LOUDLY — the same "expected-but-not-used
+/// → scream" philosophy as the build-time Skia-not-linked guard (c6da9c4da).
+/// On a no-Skia build the request is moot, so no scream fires.
+inline void warn_if_unexpected_cpu_fallback(const GpuHostDecision& d,
+                                            const view::PluginViewHost* host) {
+#ifdef PULP_HAS_SKIA
+    if (d.use_gpu && host != nullptr && !host->is_gpu_backed()) {
+        runtime::log_error(
+            "[plugin-gpu-host] gpu-init-failed falling_back=cpu mode={} "
+            "use_gpu=true host=cpu — a GPU/scripted editor view silently "
+            "fell back to CoreGraphics. Check Dawn/Metal availability in the "
+            "host process (or set PULP_DISABLE_PLUGIN_GPU=1 intentionally).",
+            d.mode);
+    }
+#else
+    (void) d;
+    (void) host;
+#endif
+}
+
+} // namespace pulp::format

--- a/core/format/src/au_v2_cocoa_view.mm
+++ b/core/format/src/au_v2_cocoa_view.mm
@@ -148,6 +148,14 @@ static const char kOwnershipKey = 0;
     // below); the wrapper destroys host (stops the display link) before bridge.
     host->set_idle_callback(format::make_scripted_idle_pump(*bridge));
 
+    // AU v2 has no host size callback — the DAW resizes the returned NSView
+    // directly. Forward native frame changes to the bridge so the surfaces
+    // resize and Processor::on_view_resized fires.
+    format::ViewBridge* bridge_ptr = bridge.get();
+    host->set_resize_callback([bridge_ptr](uint32_t w, uint32_t h) {
+        bridge_ptr->resize(w, h);
+    });
+
     bridge->notify_attached();
 
     runtime::log_info("AU v2 editor: created view ({}x{}, mode={}, gpu={})",

--- a/core/format/src/au_v2_cocoa_view.mm
+++ b/core/format/src/au_v2_cocoa_view.mm
@@ -14,6 +14,7 @@
 
 #include <pulp/format/detail/editor_environment.hpp>
 #include <pulp/format/au_v2_adapter.hpp>
+#include <pulp/format/gpu_host_select.hpp>
 #include <pulp/format/processor.hpp>
 #include <pulp/format/view_bridge.hpp>
 #include <pulp/view/plugin_view_host.hpp>
@@ -129,9 +130,10 @@ static const char kOwnershipKey = 0;
     const uint32_t w = bridge->size_hints().preferred_width;
     const uint32_t h = bridge->size_hints().preferred_height;
 
+    const auto gpu = format::decide_gpu_host(*bridge);
     view::PluginViewHost::Options opts;
     opts.size = {w, h};
-    opts.use_gpu = false;
+    opts.use_gpu = gpu.use_gpu;
 
     auto host = view::PluginViewHost::create(*bridge->view(), opts);
     if (!host) {
@@ -139,11 +141,17 @@ static const char kOwnershipKey = 0;
         bridge->close();
         return nil;
     }
+    format::warn_if_unexpected_cpu_fallback(gpu, host.get());
+
+    // Pump the scripted UI session per vsync. Captures the ViewBridge object
+    // by address (stable across the unique_ptr move into the ownership wrapper
+    // below); the wrapper destroys host (stops the display link) before bridge.
+    host->set_idle_callback(format::make_scripted_idle_pump(*bridge));
 
     bridge->notify_attached();
 
-    runtime::log_info("AU v2 editor: created view ({}x{}, mode={})",
-                      w, h, bridge->uses_script_ui() ? "scripted" : "autoui");
+    runtime::log_info("AU v2 editor: created view ({}x{}, mode={}, gpu={})",
+                      w, h, gpu.mode, host->is_gpu_backed());
 
     NSView* editorView = (__bridge NSView*)host->native_handle();
     [editorView setFrame:NSMakeRect(0, 0, w, h)];

--- a/core/format/src/au_view_controller_ios.mm
+++ b/core/format/src/au_view_controller_ios.mm
@@ -11,6 +11,7 @@
 #import <AudioToolbox/AudioToolbox.h>
 #import <CoreAudioKit/CoreAudioKit.h>
 #include <pulp/format/detail/editor_environment.hpp>
+#include <pulp/format/gpu_host_select.hpp>
 #include <pulp/format/processor.hpp>
 #include <pulp/format/view_bridge.hpp>
 #include <pulp/view/plugin_view_host.hpp>
@@ -84,16 +85,32 @@
     }
 
     self.preferredContentSize = CGSizeMake(w, h);
-    auto size = pulp::view::PluginViewHost::Size{w, h};
-    _viewHost = pulp::view::PluginViewHost::create(*root, size);
+
+    // Auto-select the GPU host for a scripted / GPU-backed editor (P5) via the
+    // shared decision helper, using the Options overload. The preview/fallback
+    // case (no bridge) stays on the default CPU host.
+    pulp::view::PluginViewHost::Options opts;
+    opts.size = {w, h};
+    const char* mode = "fallback";
+    if (_bridge) {
+        const auto gpu = pulp::format::decide_gpu_host(*_bridge);
+        opts.use_gpu = gpu.use_gpu;
+        mode = gpu.mode;
+        _viewHost = pulp::view::PluginViewHost::create(*root, opts);
+        if (_viewHost) {
+            pulp::format::warn_if_unexpected_cpu_fallback(gpu, _viewHost.get());
+            _viewHost->set_idle_callback(pulp::format::make_scripted_idle_pump(*_bridge));
+        }
+    } else {
+        _viewHost = pulp::view::PluginViewHost::create(*root, opts);
+    }
 
     if (_viewHost) {
         _viewHost->attach_to_parent((__bridge void*)self.view);
         if (_bridge) _bridge->notify_attached();
-        pulp::runtime::log_info("AU iOS: view controller loaded, {}x{}, mode={}",
-                                size.width, size.height,
-                                _bridge ? (_bridge->uses_script_ui() ? "scripted" : "autoui")
-                                        : "fallback");
+        pulp::runtime::log_info("AU iOS: view controller loaded, {}x{}, mode={}, gpu={}",
+                                opts.size.width, opts.size.height, mode,
+                                _viewHost->is_gpu_backed());
     }
 }
 

--- a/core/format/src/au_view_controller_ios.mm
+++ b/core/format/src/au_view_controller_ios.mm
@@ -36,9 +36,14 @@
 @end
 
 @implementation PulpAUViewController {
+    // Declaration order is load-bearing — see -dealloc. _viewHost holds a
+    // `View& root_`; it MUST be destroyed before whichever object owns that
+    // View (the bridge's view, OR _fallbackView in the no-bridge preview
+    // path). Declaring _viewHost LAST makes it destroy FIRST (reverse order),
+    // which is safe for both paths.
     std::unique_ptr<pulp::format::ViewBridge> _bridge;
-    std::unique_ptr<pulp::view::PluginViewHost> _viewHost;
     std::unique_ptr<pulp::view::View> _fallbackView;
+    std::unique_ptr<pulp::view::PluginViewHost> _viewHost;
 }
 
 - (void)viewDidLoad {
@@ -127,33 +132,36 @@
 }
 
 - (void)dealloc {
-    // Destruction-order contract (Codex P1 review on PR #653):
+    // Destruction-order contract (Codex P1 review on PR #653; fallback-path
+    // UAF fix, GPU-plugin-view-host):
     //
     // PulpAUViewController declares its ivars in order:
-    //     _bridge       (ViewBridge — owns the View tree)
+    //     _bridge       (ViewBridge — owns the View tree on the success path)
+    //     _fallbackView (the View on the no-bridge preview path)
     //     _viewHost     (PluginViewHost — holds `View& root_`)
-    //     _fallbackView (only used when bridge fails)
     //
     // After [super dealloc] the runtime destroys C++-typed ivars in
-    // REVERSE declaration order: _fallbackView, then _viewHost, then
+    // REVERSE declaration order: _viewHost, then _fallbackView, then
     // _bridge. That ordering is load-bearing:
-    //   1. ~_fallbackView runs (no-op when bridge succeeded).
-    //   2. ~unique_ptr<PluginViewHost> runs. Its destructor calls
-    //      `root_.set_plugin_view_host(nullptr)` — the View that
-    //      `root_` references is still alive (still owned by
-    //      `_bridge->view_`), so the call is safe and clears the
-    //      back-pointer.
-    //   3. ~unique_ptr<ViewBridge> runs. Its destructor calls
-    //      `close()` which fires `Processor::on_view_closed`,
-    //      releases the scripted UI, and resets the View. The
-    //      back-pointer was already cleared in step 2, so the
-    //      View's own teardown can't reach a dead host.
+    //   1. ~unique_ptr<PluginViewHost> runs FIRST. Its destructor calls
+    //      `root_.set_plugin_view_host(nullptr)` (and, for the GPU host,
+    //      `root_.set_frame_clock(nullptr)`). `root_` references either
+    //      `_bridge->view_` or `_fallbackView` — BOTH are still alive at
+    //      this point, so the back-pointer clear is safe on either path.
+    //      (Previously _viewHost was declared before _fallbackView, so on
+    //      the fallback path the View died first and ~PluginViewHost
+    //      dereferenced a dangling `root_`.)
+    //   2. ~unique_ptr<View> (_fallbackView) runs (no-op when bridge
+    //      succeeded; on the fallback path the back-pointer was cleared
+    //      in step 1).
+    //   3. ~unique_ptr<ViewBridge> runs. Its destructor calls `close()`
+    //      which fires `Processor::on_view_closed`, releases the scripted
+    //      UI, and resets the View. The back-pointer was already cleared
+    //      in step 1, so the View's own teardown can't reach a dead host.
     //
-    // Calling `_bridge->close()` HERE explicitly (before [super
-    // dealloc]) reverses that order — the View dies first, then
-    // ~PluginViewHost dereferences a dangling `root_` reference and
-    // crashes AUv3 editor close. Don't reintroduce the explicit
-    // close in this dealloc path.
+    // Calling `_bridge->close()` HERE explicitly (before [super dealloc])
+    // reverses that order — the View dies first, then ~PluginViewHost
+    // dereferences a dangling `root_`. Don't reintroduce the explicit close.
     [super dealloc];
 }
 

--- a/core/format/src/vst3_plug_view.cpp
+++ b/core/format/src/vst3_plug_view.cpp
@@ -5,6 +5,7 @@
 #ifdef PULP_VST3_GUI
 
 #include <pulp/format/vst3_plug_view.hpp>
+#include <pulp/format/gpu_host_select.hpp>
 #include <pulp/runtime/log.hpp>
 #include <cstring>
 
@@ -43,9 +44,10 @@ tresult PLUGIN_API PulpPlugView::attached(void* parent, FIDString type) {
     }
 
     const auto& hints = bridge_.size_hints();
+    const auto gpu = decide_gpu_host(bridge_);
     view::PluginViewHost::Options opts;
     opts.size = {hints.preferred_width, hints.preferred_height};
-    opts.use_gpu = false;  // CoreGraphics for now; GPU opt-in later
+    opts.use_gpu = gpu.use_gpu;
 
     editor_host_ = view::PluginViewHost::create(*bridge_.view(), opts);
     if (!editor_host_) {
@@ -53,6 +55,10 @@ tresult PLUGIN_API PulpPlugView::attached(void* parent, FIDString type) {
         bridge_.close();
         return kResultFalse;
     }
+    warn_if_unexpected_cpu_fallback(gpu, editor_host_.get());
+
+    // Pump the scripted UI session (async results, timers, rAF) per vsync.
+    editor_host_->set_idle_callback(make_scripted_idle_pump(bridge_));
 
     editor_host_->attach_to_parent(parent);
     auto result = CPluginView::attached(parent, type);
@@ -66,9 +72,9 @@ tresult PLUGIN_API PulpPlugView::attached(void* parent, FIDString type) {
     // Attach succeeded — now fire Processor::on_view_opened.
     bridge_.notify_attached();
 
-    runtime::log_info("VST3 editor: attached ({}x{}, mode={})",
+    runtime::log_info("VST3 editor: attached ({}x{}, mode={}, gpu={})",
                       hints.preferred_width, hints.preferred_height,
-                      bridge_.uses_script_ui() ? "scripted" : "autoui");
+                      gpu.mode, editor_host_->is_gpu_backed());
     return result;
 }
 

--- a/core/view/include/pulp/view/plugin_view_host.hpp
+++ b/core/view/include/pulp/view/plugin_view_host.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <cstdint>
 #include <functional>
+#include <vector>
 
 namespace pulp::view {
 
@@ -66,6 +67,29 @@ public:
     // Resize
     virtual void set_size(uint32_t width, uint32_t height) = 0;
     virtual Size get_size() const = 0;
+
+    // True only when this host is rendering through the GPU (Dawn/Skia
+    // Graphite) pipeline AND GPU initialization succeeded. CoreGraphics
+    // CPU hosts return false, and a GPU host that failed to initialize
+    // Dawn/Skia and fell back to CPU also returns false. Adapters read
+    // this after create() to scream when a GPU/scripted editor view
+    // silently took the CPU path (see `format/gpu_host_select.hpp`).
+    virtual bool is_gpu_backed() const { return false; }
+
+    // Per-vsync idle pump. GPU hosts invoke this callback once per display
+    // link tick (before rendering) so a scripted UI's `ScriptedUiSession::poll()`
+    // — async results, timers, requestAnimationFrame — keeps running while
+    // the editor is embedded. CPU hosts ignore it. Default no-op.
+    virtual void set_idle_callback(std::function<void()> callback) {
+        (void) callback;
+    }
+
+    // Capture the host's current back buffer as a PNG (mirrors
+    // `WindowHost::capture_back_buffer_png`, issue #2001). GPU hosts read
+    // back the rendered Skia frame via `SkiaSurface::read_current_rgba`;
+    // hosts that cannot capture return an empty vector. Used by the
+    // embedded-editor host smoke tests.
+    virtual std::vector<uint8_t> capture_back_buffer_png() { return {}; }
 
     // Attach/detach a native child view inside the plugin editor host.
     // Coordinates use Pulp's top-left origin convention, matching WindowHost.

--- a/core/view/include/pulp/view/plugin_view_host.hpp
+++ b/core/view/include/pulp/view/plugin_view_host.hpp
@@ -76,6 +76,16 @@ public:
     // silently took the CPU path (see `format/gpu_host_select.hpp`).
     virtual bool is_gpu_backed() const { return false; }
 
+    // Native-frame resize notification. AU v2 has no host size callback — the
+    // DAW resizes the returned NSView directly. Hosts invoke this callback
+    // when their native view's frame changes (after they have already resized
+    // their own surfaces) so the adapter can forward to `ViewBridge::resize`
+    // (fires Processor::on_view_resized). VST3/CLAP drive resize through their
+    // own host size callbacks and don't need this. Default no-op.
+    virtual void set_resize_callback(std::function<void(uint32_t, uint32_t)> cb) {
+        (void) cb;
+    }
+
     // Per-vsync idle pump. GPU hosts invoke this callback once per display
     // link tick (before rendering) so a scripted UI's `ScriptedUiSession::poll()`
     // — async results, timers, requestAnimationFrame — keeps running while

--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -285,6 +285,22 @@ public:
     bool backface_visible() const { return backface_visible_; }
     void set_backface_visible(bool v) { backface_visible_ = v; }
 
+    /// GPU-host capability signal (pulp #2700-followup, GPU-plugin-view-host).
+    /// A view that is rendered through the Skia/Dawn/Yoga scripted-UI path —
+    /// or any custom `Processor::create_view()` that paints via GPU-backed
+    /// widgets (e.g. WebGPU/Three.js canvases, the scripted React UI) — sets
+    /// this true so plugin format adapters auto-select the GPU
+    /// `PluginViewHost` instead of the CoreGraphics CPU fallback. Default
+    /// false: a plain widget tree renders fine on CPU and a Processor that
+    /// returns `nullptr` from `create_view()` intentionally selects AutoUi.
+    ///
+    /// This lives on the View (not the Processor) because `create_view()` can
+    /// return a different view per editor instance and the flag must not touch
+    /// the node ABI. Adapters read it via `ViewBridge::view()` after
+    /// `ViewBridge::open()`. See `planning/2026-05-22-gpu-view-host-in-plugins.md`.
+    bool requires_gpu_host() const { return requires_gpu_host_; }
+    void set_requires_gpu_host(bool v) { requires_gpu_host_ = v; }
+
     /// Mark layout as needing recalculation (auto-invalidation)
     void invalidate_layout() { layout_dirty_ = true; }
     bool layout_dirty() const { return layout_dirty_; }
@@ -1334,6 +1350,7 @@ private:
     bool hit_testable_ = true;
     PointerEvents pointer_events_ = PointerEvents::auto_;
     bool backface_visible_ = true;
+    bool requires_gpu_host_ = false;
     FrameClock* frame_clock_ = nullptr;
 
     // Visual properties

--- a/core/view/platform/ios/plugin_view_host_ios.mm
+++ b/core/view/platform/ios/plugin_view_host_ios.mm
@@ -311,6 +311,9 @@ private:
 #ifdef PULP_HAS_SKIA
 #include <pulp/render/gpu_surface.hpp>
 #include <pulp/render/skia_surface.hpp>
+#include <pulp/view/frame_clock.hpp>
+#include <functional>
+#include <memory>
 #import <QuartzCore/CAMetalLayer.h>
 #import <Metal/Metal.h>
 
@@ -318,13 +321,28 @@ class IOSGpuPluginViewHost;
 
 }  // namespace pulp::view
 
-// Metal-backed UIView for GPU rendering in AUv3 hosts
+// Metal-backed UIView for GPU rendering in AUv3 hosts.
+//
+// Like the mac embedded view, the display link is driven by window-attach,
+// not by attach_to_parent — the AUv3 controller adds this view to its own
+// hierarchy, so the host wires `onWindowChange` / `onLayout` to start/stop
+// the link and re-sync surfaces at the right times.
 @interface PulpMetalPluginView : UIView
+@property (nonatomic, copy) void (^onWindowChange)(void);
+@property (nonatomic, copy) void (^onLayout)(void);
 @end
 
 @implementation PulpMetalPluginView
 + (Class)layerClass { return [CAMetalLayer class]; }
 - (CAMetalLayer *)metalLayer { return (CAMetalLayer *)self.layer; }
+- (void)didMoveToWindow {
+    [super didMoveToWindow];
+    if (self.onWindowChange) self.onWindowChange();
+}
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    if (self.onLayout) self.onLayout();
+}
 @end
 
 // CADisplayLink target — relays the vsync tick to the C++ host.
@@ -338,52 +356,63 @@ namespace pulp::view {
 class IOSGpuPluginViewHost : public PluginViewHost {
 public:
     IOSGpuPluginViewHost(View& root, const Options& opts)
-        : root_(root), size_(opts.size) {
+        : root_(root), size_(opts.size),
+          alive_(std::make_shared<std::atomic<bool>>(true)) {
         @autoreleasepool {
+            root_.set_frame_clock(&frame_clock_);
             CGRect frame = CGRectMake(0, 0, opts.size.width, opts.size.height);
             metal_view_ = [[PulpMetalPluginView alloc] initWithFrame:frame];
             metal_view_.multipleTouchEnabled = YES;
             metal_view_.autoresizingMask =
                 UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+            metal_view_.onWindowChange = ^{ this->handle_window_change(); };
+            metal_view_.onLayout = ^{ this->handle_layout(); };
 
-            CGFloat scale = UIScreen.mainScreen.scale;
-            uint32_t pw = static_cast<uint32_t>(opts.size.width * scale);
-            uint32_t ph = static_cast<uint32_t>(opts.size.height * scale);
+            scale_ = current_scale();
+            uint32_t pw = static_cast<uint32_t>(opts.size.width * scale_);
+            uint32_t ph = static_cast<uint32_t>(opts.size.height * scale_);
 
             CAMetalLayer* layer = [metal_view_ metalLayer];
             layer.device = MTLCreateSystemDefaultDevice();
             layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+            layer.framebufferOnly = NO;
             layer.drawableSize = CGSizeMake(pw, ph);
-            layer.contentsScale = scale;
+            layer.contentsScale = scale_;
 
-            render::GpuSurface::Config gpu_cfg;
-            gpu_cfg.width = pw;
-            gpu_cfg.height = ph;
-            gpu_cfg.native_surface_handle = (__bridge void*)layer;
-
-            gpu_surface_ = std::make_unique<render::GpuSurface>();
-            if (gpu_surface_->initialize(gpu_cfg)) {
-                render::SkiaSurface::Config skia_cfg;
-                skia_cfg.width = pw;
-                skia_cfg.height = ph;
-                skia_cfg.dawn_device = gpu_surface_->dawn_device_handle();
-                skia_cfg.dawn_queue = gpu_surface_->dawn_queue_handle();
-                skia_cfg.dawn_instance = gpu_surface_->dawn_instance_handle();
-
-                skia_surface_ = std::make_unique<render::SkiaSurface>();
-                if (!skia_surface_->initialize(skia_cfg)) {
-                    skia_surface_.reset();
+            // Current render API: create the Dawn surface, then build the
+            // Skia Graphite surface from it (mirrors the mac host). GpuSurface
+            // gets PHYSICAL pixels; SkiaSurface gets LOGICAL size + scale.
+            gpu_surface_ = render::GpuSurface::create_dawn();
+            if (gpu_surface_) {
+                render::GpuSurface::Config gpu_cfg{};
+                gpu_cfg.width = pw;
+                gpu_cfg.height = ph;
+                gpu_cfg.native_surface_handle = (__bridge void*)layer;
+                if (gpu_surface_->initialize(gpu_cfg)) {
+                    render::SkiaSurface::Config skia_cfg{};
+                    skia_cfg.width = opts.size.width;
+                    skia_cfg.height = opts.size.height;
+                    skia_cfg.scale_factor = static_cast<float>(scale_);
+                    skia_surface_ = render::SkiaSurface::create(*gpu_surface_, skia_cfg);
+                    if (!skia_surface_) gpu_surface_.reset();
+                } else {
                     gpu_surface_.reset();
                 }
-            } else {
-                gpu_surface_.reset();
             }
         }
     }
 
     ~IOSGpuPluginViewHost() override {
+        alive_->store(false, std::memory_order_release);
         root_.set_plugin_view_host(nullptr);
         stop_display_link();
+        @autoreleasepool {
+            metal_view_.onWindowChange = nil;
+            metal_view_.onLayout = nil;
+        }
+        skia_surface_.reset();
+        gpu_surface_.reset();
+        root_.set_frame_clock(nullptr);
     }
 
     NativeViewHandle native_handle() override { return (__bridge void*)metal_view_; }
@@ -393,7 +422,7 @@ public:
             UIView* pv = (__bridge UIView*)parent;
             if (pv && metal_view_) {
                 [pv addSubview:metal_view_];
-                start_display_link();
+                // Display link starts via -didMoveToWindow → handle_window_change().
                 needs_repaint_.store(true, std::memory_order_relaxed);
             }
         }
@@ -411,6 +440,18 @@ public:
     }
 
     void tick() {
+        if (!alive_->load(std::memory_order_acquire)) return;
+        // Pump idle (scripted poll: async results, timers, rAF) FIRST so any
+        // request_repaint they trigger is seen below.
+        if (idle_callback_) idle_callback_();
+
+        const bool tick_subscribers = frame_clock_.has_active_subscribers();
+        const bool animate = tree_has_active_css_animation(&root_);
+        if (tick_subscribers || animate) {
+            frame_clock_.tick(1.0f / 60.0f);
+            root_.tick_animations(1.0f / 60.0f);
+            needs_repaint_.store(true, std::memory_order_relaxed);
+        }
         if (needs_repaint_.exchange(false, std::memory_order_relaxed)) {
             render_frame();
         }
@@ -420,18 +461,31 @@ public:
         size_ = {w, h};
         @autoreleasepool {
             metal_view_.frame = CGRectMake(0, 0, w, h);
-            CGFloat scale = UIScreen.mainScreen.scale;
-            [metal_view_ metalLayer].drawableSize = CGSizeMake(w * scale, h * scale);
+            scale_ = current_scale();
+            [metal_view_ metalLayer].contentsScale = scale_;
+            [metal_view_ metalLayer].drawableSize = CGSizeMake(w * scale_, h * scale_);
+            // Resize parity: GpuSurface PHYSICAL, SkiaSurface LOGICAL + scale.
+            if (gpu_surface_) {
+                gpu_surface_->resize(static_cast<uint32_t>(w * scale_),
+                                     static_cast<uint32_t>(h * scale_));
+            }
             if (skia_surface_) {
-                skia_surface_->resize(static_cast<uint32_t>(w * scale),
-                                      static_cast<uint32_t>(h * scale),
-                                      static_cast<float>(scale));
+                skia_surface_->resize(w, h, static_cast<float>(scale_));
             }
         }
         needs_repaint_.store(true, std::memory_order_relaxed);
     }
 
     Size get_size() const override { return size_; }
+
+    bool is_gpu_backed() const override {
+        return gpu_surface_ != nullptr && skia_surface_ != nullptr &&
+               skia_surface_->is_available();
+    }
+
+    void set_idle_callback(std::function<void()> callback) override {
+        idle_callback_ = std::move(callback);
+    }
 
     bool attach_native_child_view(NativeViewHandle child_view,
                                   float x,
@@ -459,9 +513,59 @@ private:
     PulpMetalPluginView* metal_view_ = nil;
     std::unique_ptr<render::GpuSurface> gpu_surface_;
     std::unique_ptr<render::SkiaSurface> skia_surface_;
+    FrameClock frame_clock_;
     std::atomic<bool> needs_repaint_{false};
     CADisplayLink* display_link_ = nil;
     PulpIOSPluginDisplayLinkTarget* display_link_target_ = nil;
+    std::function<void()> idle_callback_;
+    CGFloat scale_ = 1.0;
+    // Liveness token (parity with the mac host). CADisplayLink ticks run on
+    // the main run loop and stop on -invalidate, but the token makes a racing
+    // teardown safe and matches the cross-platform contract.
+    std::shared_ptr<std::atomic<bool>> alive_;
+
+    // Prefer the view's window-screen scale; fall back to the view's own
+    // content scale, then the main screen. Updated on layout / window change.
+    CGFloat current_scale() const {
+        if (metal_view_.window && metal_view_.window.screen)
+            return metal_view_.window.screen.scale;
+        if (metal_view_)
+            return metal_view_.contentScaleFactor;
+        return UIScreen.mainScreen.scale;
+    }
+
+    static bool tree_has_active_css_animation(View* view) {
+        if (!view) return false;
+        if (view->animation_play_state() != "paused") {
+            for (const auto& a : view->active_animations()) {
+                if (a.active) return true;
+            }
+        }
+        for (size_t i = 0; i < view->child_count(); ++i) {
+            if (tree_has_active_css_animation(view->child_at(i))) return true;
+        }
+        return false;
+    }
+
+    void handle_window_change() {
+        if (metal_view_.window) {
+            scale_ = current_scale();
+            start_display_link();
+            needs_repaint_.store(true, std::memory_order_relaxed);
+        } else {
+            stop_display_link();
+        }
+    }
+
+    void handle_layout() {
+        const CGFloat new_scale = current_scale();
+        const CGSize bounds = metal_view_.bounds.size;
+        const uint32_t w = static_cast<uint32_t>(bounds.width);
+        const uint32_t h = static_cast<uint32_t>(bounds.height);
+        if (new_scale != scale_ || w != size_.width || h != size_.height) {
+            if (w > 0 && h > 0) set_size(w, h);
+        }
+    }
 
     void start_display_link() {
         if (display_link_) return;
@@ -481,7 +585,10 @@ private:
                 [display_link_ invalidate];
                 display_link_ = nil;
             }
-            display_link_target_ = nil;
+            if (display_link_target_) {
+                display_link_target_.host = nullptr;
+                display_link_target_ = nil;
+            }
         }
     }
 
@@ -532,8 +639,14 @@ std::unique_ptr<PluginViewHost> PluginViewHost::create(View& root, const Options
 #ifdef PULP_HAS_SKIA
     if (options.use_gpu) {
         auto host = std::make_unique<IOSGpuPluginViewHost>(root, options);
-        root.set_plugin_view_host(host.get());
-        return host;
+        if (host->is_gpu_backed()) {
+            root.set_plugin_view_host(host.get());
+            return host;
+        }
+        // GPU init failed — fall back to the CoreGraphics host so the editor
+        // never disappears (item 9). The runtime scream-guard in the adapter
+        // (`warn_if_unexpected_cpu_fallback`) logs the mismatch loudly.
+        host.reset();
     }
 #endif
     auto host = std::make_unique<IOSPluginViewHost>(root, options.size);

--- a/core/view/platform/mac/plugin_view_host_mac.mm
+++ b/core/view/platform/mac/plugin_view_host_mac.mm
@@ -8,9 +8,16 @@
 #include <algorithm>
 #include <atomic>
 
+#include <functional>
+#include <memory>
+
 #ifdef PULP_HAS_SKIA
 #include <pulp/render/gpu_surface.hpp>
 #include <pulp/render/skia_surface.hpp>
+#include <pulp/view/frame_clock.hpp>
+#include <pulp/view/widgets.hpp>
+#include <pulp/view/ui_components.hpp>
+#include "window_host_mac_capture.h"  // mac_capture::encode_rgba_to_png
 #import <QuartzCore/CAMetalLayer.h>
 #import <CoreVideo/CVDisplayLink.h>
 #import <Metal/Metal.h>
@@ -311,10 +318,21 @@ private:
 
 #ifdef PULP_HAS_SKIA
 
-// CAMetalLayer-backed NSView for DAW-embedded GPU rendering
+// CAMetalLayer-backed NSView for DAW-embedded GPU rendering.
+//
+// Unlike the standalone window host (which owns its NSWindow and starts the
+// CVDisplayLink in its constructor), an embedded plugin view is handed a
+// parent view by the host and only becomes live once it joins a window. So
+// this view exposes window-attach / backing-change callbacks the host wires
+// up to start/stop the display link and reconfigure surfaces at the right
+// moments. The wrapper paths (AU returns the NSView directly; VST3/CLAP call
+// attach_to_parent) never drive `attach_to_parent`-time rendering — they all
+// funnel through `-viewDidMoveToWindow`.
 @interface PulpGpuPluginView : NSView
 @property (nonatomic, readonly) CAMetalLayer* metalLayer;
 @property (nonatomic, assign) pulp::view::View* rootView;
+@property (nonatomic, copy) void (^onWindowChange)(void);
+@property (nonatomic, copy) void (^onBackingChange)(void);
 @end
 
 @implementation PulpGpuPluginView
@@ -326,11 +344,16 @@ private:
         CAMetalLayer* layer = [CAMetalLayer layer];
         layer.device = MTLCreateSystemDefaultDevice();
         layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
-        layer.framebufferOnly = YES;
+        // framebufferOnly = NO so the embedded back buffer can be read back
+        // for headless capture (`capture_back_buffer_png`) — matches the
+        // standalone MacGpuWindowHost. (Plugin host previously set YES,
+        // which blocked readback.)
+        layer.framebufferOnly = NO;
         CGFloat scale = self.window ? self.window.backingScaleFactor
                                     : [NSScreen mainScreen].backingScaleFactor;
         layer.contentsScale = scale;
         layer.drawableSize = CGSizeMake(frame.size.width * scale, frame.size.height * scale);
+        layer.opaque = YES;
         self.layer = layer;
         _metalLayer = layer;
     }
@@ -347,6 +370,14 @@ private:
     self.metalLayer.drawableSize = CGSizeMake(newSize.width * scale, newSize.height * scale);
 }
 
+// Start/stop the display link when the view joins or leaves a window. This is
+// the embeddable equivalent of the standalone host starting its link in the
+// constructor — the wrapper attach paths don't render until this fires.
+- (void)viewDidMoveToWindow {
+    [super viewDidMoveToWindow];
+    if (self.onWindowChange) self.onWindowChange();
+}
+
 - (void)viewDidChangeBackingProperties {
     [super viewDidChangeBackingProperties];
     CGFloat scale = self.window ? self.window.backingScaleFactor
@@ -354,6 +385,7 @@ private:
     self.metalLayer.contentsScale = scale;
     self.metalLayer.drawableSize = CGSizeMake(self.bounds.size.width * scale,
                                               self.bounds.size.height * scale);
+    if (self.onBackingChange) self.onBackingChange();
 }
 
 // Accessibility
@@ -368,21 +400,42 @@ namespace pulp::view { // reopen for C++ classes
 class MacGpuPluginViewHost : public PluginViewHost {
 public:
     MacGpuPluginViewHost(View& root, Size size)
-        : root_(root), size_(size) {
+        : root_(root), size_(size),
+          alive_(std::make_shared<std::atomic<bool>>(true)) {
         @autoreleasepool {
+            root_.set_frame_clock(&frame_clock_);
             NSRect frame = NSMakeRect(0, 0, size.width, size.height);
             metal_view_ = [[PulpGpuPluginView alloc] initWithFrame:frame];
             metal_view_.rootView = &root_;
-            init_gpu(size.width, size.height);
+
+            // Wire the embeddable lifecycle hooks. The display link starts
+            // when the view joins a window and stops when it leaves; the
+            // surfaces re-sync on backing (HiDPI) changes. Captured `this`
+            // is safe: the view is owned by this host and torn down in the
+            // destructor before `this` dies, and the callbacks are cleared
+            // there too.
+            metal_view_.onWindowChange = ^{ this->handle_window_change(); };
+            metal_view_.onBackingChange = ^{ this->handle_backing_change(); };
+
+            init_gpu(static_cast<float>(size.width), static_cast<float>(size.height));
         }
     }
 
     ~MacGpuPluginViewHost() override {
+        // Flip the liveness token FIRST so any display-link block already
+        // queued on the main thread becomes a no-op before we free anything
+        // (mirrors the #2502 deferred-click token).
+        alive_->store(false, std::memory_order_release);
         root_.set_plugin_view_host(nullptr);
         stop_display_link();
+        @autoreleasepool {
+            metal_view_.onWindowChange = nil;
+            metal_view_.onBackingChange = nil;
+        }
         skia_surface_.reset();
         gpu_surface_.reset();
         metal_view_.rootView = nullptr;
+        root_.set_frame_clock(nullptr);
     }
 
     NativeViewHandle native_handle() override {
@@ -394,8 +447,8 @@ public:
             NSView* parent_view = (__bridge NSView*)parent;
             if (parent_view && metal_view_) {
                 [parent_view addSubview:metal_view_];
-                start_display_link();
-                needs_repaint_.store(true);
+                // Display link starts via -viewDidMoveToWindow → handle_window_change().
+                needs_repaint_.store(true, std::memory_order_relaxed);
             }
         }
     }
@@ -415,18 +468,48 @@ public:
         size_ = {width, height};
         @autoreleasepool {
             [metal_view_ setFrameSize:NSMakeSize(width, height)];
-        }
-        if (gpu_surface_) {
-            gpu_surface_->resize(width, height);
-        }
-        if (skia_surface_) {
+            // Resize parity with the standalone host: GpuSurface in PHYSICAL
+            // pixels (logical * scale, matches the CAMetalLayer drawableSize),
+            // SkiaSurface in LOGICAL size + scale factor.
             CGFloat scale = metal_view_.metalLayer.contentsScale;
-            skia_surface_->resize(width, height, static_cast<float>(scale));
+            if (gpu_surface_) {
+                gpu_surface_->resize(static_cast<uint32_t>(width * scale),
+                                     static_cast<uint32_t>(height * scale));
+            }
+            if (skia_surface_) {
+                skia_surface_->resize(width, height, static_cast<float>(scale));
+            }
         }
-        needs_repaint_.store(true);
+        needs_repaint_.store(true, std::memory_order_relaxed);
     }
 
     Size get_size() const override { return size_; }
+
+    bool is_gpu_backed() const override {
+        return gpu_surface_ != nullptr && skia_surface_ != nullptr &&
+               skia_surface_->is_available();
+    }
+
+    void set_idle_callback(std::function<void()> callback) override {
+        idle_callback_ = std::move(callback);
+        has_idle_callback_.store(static_cast<bool>(idle_callback_),
+                                 std::memory_order_release);
+    }
+
+    // Deterministic GPU back-buffer readback for hidden / headless test
+    // hosts (mirrors WindowHost::capture_back_buffer_png, issue #2001).
+    // Goes straight through render_frame()'s readback path; never shows a
+    // window or touches the compositor. Returns {} on failure.
+    std::vector<uint8_t> capture_back_buffer_png() override {
+        if (!gpu_surface_ || !skia_surface_) return {};
+        needs_repaint_.store(true, std::memory_order_relaxed);
+        std::vector<uint8_t> pixels;
+        uint32_t pixel_w = 0;
+        uint32_t pixel_h = 0;
+        if (!render_frame(&pixels, &pixel_w, &pixel_h)) return {};
+        return pulp::view::mac_capture::encode_rgba_to_png(
+            pixels.data(), pixel_w, pixel_h, static_cast<size_t>(pixel_w) * 4u);
+    }
 
     bool attach_native_child_view(NativeViewHandle child_view,
                                   float x,
@@ -456,51 +539,110 @@ private:
     std::unique_ptr<render::GpuSurface> gpu_surface_;
     std::unique_ptr<render::SkiaSurface> skia_surface_;
     CVDisplayLinkRef display_link_ = nullptr;
+    FrameClock frame_clock_;
     std::atomic<bool> needs_repaint_{true};
+    std::atomic<bool> continuous_frames_{false};
+    std::atomic<bool> render_dispatch_queued_{false};
+    std::function<void()> idle_callback_;
+    std::atomic<bool> has_idle_callback_{false};
+    // Liveness token captured by the display-link main-thread dispatch
+    // blocks. Flipped false in the destructor so a queued block after
+    // teardown is a no-op (DAW teardown order is not under our control).
+    std::shared_ptr<std::atomic<bool>> alive_;
+    int frame_ok_count_ = 0;
 
-    void init_gpu(uint32_t width, uint32_t height) {
+    void init_gpu(float width, float height) {
         gpu_surface_ = render::GpuSurface::create_dawn();
-        if (!gpu_surface_) return;
+        if (!gpu_surface_) {
+            fprintf(stderr, "[plugin-gpu-host] gpu init failed reason=create_dawn_null "
+                            "falling_back=cpu-paint\n");
+            return;
+        }
 
-        render::GpuSurface::Config config{};
-        config.width = width;
-        config.height = height;
-        config.native_surface_handle = (__bridge void*)metal_view_.metalLayer;
+        // Configure GpuSurface at PHYSICAL pixel dimensions to match the
+        // CAMetalLayer drawableSize (logical * scale).
+        CGFloat scale = metal_view_.metalLayer.contentsScale;
+        uint32_t phys_w = static_cast<uint32_t>(width * scale);
+        uint32_t phys_h = static_cast<uint32_t>(height * scale);
 
-        if (!gpu_surface_->initialize(config)) {
+        render::GpuSurface::Config gpu_config{};
+        gpu_config.width = phys_w;
+        gpu_config.height = phys_h;
+        gpu_config.native_surface_handle = (__bridge void*)metal_view_.metalLayer;
+
+        if (!gpu_surface_->initialize(gpu_config)) {
+            fprintf(stderr, "[plugin-gpu-host] gpu init failed reason=initialize "
+                            "falling_back=cpu-paint\n");
             gpu_surface_.reset();
             return;
         }
 
-        CGFloat scale = metal_view_.metalLayer.contentsScale;
+        // SkiaSurface uses LOGICAL dimensions + scale factor.
         render::SkiaSurface::Config skia_config{};
-        skia_config.width = width;
-        skia_config.height = height;
+        skia_config.width = static_cast<uint32_t>(width);
+        skia_config.height = static_cast<uint32_t>(height);
         skia_config.scale_factor = static_cast<float>(scale);
-
         skia_surface_ = render::SkiaSurface::create(*gpu_surface_, skia_config);
+        if (!skia_surface_) {
+            fprintf(stderr, "[plugin-gpu-host] gpu init failed reason=skia_create_null "
+                            "falling_back=cpu-paint\n");
+            gpu_surface_.reset();
+            return;
+        }
+        fprintf(stderr, "[plugin-gpu-host] init requested size=%.0fx%.0f scale=%.1f "
+                        "gpu=%ux%u\n", width, height, scale, phys_w, phys_h);
     }
 
-    void render_frame() {
-        if (!gpu_surface_ || !skia_surface_ || !needs_repaint_.load(std::memory_order_relaxed))
-            return;
+    void paint_scene(canvas::Canvas& canvas) {
+        float w = static_cast<float>(size_.width);
+        float h = static_cast<float>(size_.height);
+        root_.set_bounds({0, 0, w, h});
+        root_.layout_children();
+        canvas.set_fill_color(pulp::canvas::Color::rgba8(30, 30, 46));
+        canvas.fill_rect(0, 0, w, h);
+        root_.paint_all(canvas);
+    }
 
-        if (!gpu_surface_->begin_frame()) return;
+    // Render one frame. When capture buffers are supplied, the rendered
+    // RGBA back buffer is read back into them (for capture_back_buffer_png).
+    bool render_frame(std::vector<uint8_t>* capture_pixels = nullptr,
+                      uint32_t* capture_width = nullptr,
+                      uint32_t* capture_height = nullptr) {
+        if (!gpu_surface_ || !skia_surface_) return false;
+        if (!gpu_surface_->begin_frame()) return false;
 
-        if (auto* canvas = skia_surface_->begin_frame()) {
-            float w = static_cast<float>(size_.width);
-            float h = static_cast<float>(size_.height);
-            root_.set_bounds({0, 0, w, h});
-            root_.layout_children();
+        auto* canvas = skia_surface_->begin_frame();
+        if (!canvas) {
+            gpu_surface_->end_frame();
+            return false;
+        }
 
-            canvas->set_fill_color(pulp::canvas::Color::rgba8(30, 30, 46));
-            canvas->fill_rect(0, 0, w, h);
-            root_.paint_all(*canvas);
+        if (frame_ok_count_++ == 0) {
+            CGFloat scale = metal_view_.metalLayer.contentsScale;
+            fprintf(stderr, "[plugin-gpu-host] first frame logical=%ux%u gpu=%ux%u scale=%.1f\n",
+                    size_.width, size_.height, gpu_surface_->width(),
+                    gpu_surface_->height(), scale);
+        }
+
+        paint_scene(*canvas);
+
+        continuous_frames_.store(
+            view_needs_continuous_frames(&root_) || frame_clock_.has_active_subscribers(),
+            std::memory_order_relaxed);
+
+        bool captured = true;
+        if (capture_pixels && capture_width && capture_height) {
+            captured = skia_surface_->read_current_rgba(*capture_pixels,
+                                                        *capture_width,
+                                                        *capture_height);
         }
 
         skia_surface_->end_frame();
         gpu_surface_->end_frame();
-        needs_repaint_.store(false, std::memory_order_relaxed);
+
+        needs_repaint_.store(continuous_frames_.load(std::memory_order_relaxed),
+                             std::memory_order_relaxed);
+        return captured;
     }
 
     static CVReturn display_link_callback(
@@ -508,19 +650,88 @@ private:
         CVOptionFlags, CVOptionFlags*, void* context)
     {
         auto* self = static_cast<MacGpuPluginViewHost*>(context);
-        if (self->needs_repaint_.load(std::memory_order_relaxed)) {
+        // Copy the liveness token so the atomic outlives a teardown that
+        // races this callback.
+        auto alive = self->alive_;
+        if (!alive->load(std::memory_order_acquire)) return kCVReturnSuccess;
+
+        const bool has_idle = self->has_idle_callback_.load(std::memory_order_acquire);
+        if (self->needs_repaint_.load(std::memory_order_relaxed) ||
+            self->continuous_frames_.load(std::memory_order_relaxed) ||
+            has_idle) {
+            bool expected = false;
+            if (!self->render_dispatch_queued_.compare_exchange_strong(
+                    expected, true, std::memory_order_acq_rel,
+                    std::memory_order_relaxed)) {
+                return kCVReturnSuccess;  // a render is already queued this vsync
+            }
             dispatch_async(dispatch_get_main_queue(), ^{
-                self->render_frame();
+                @autoreleasepool {
+                    if (!alive->load(std::memory_order_acquire)) return;
+                    // Pump idle (scripted poll: async results, timers, rAF)
+                    // FIRST so any request_repaint they trigger is seen below.
+                    if (self->idle_callback_) self->idle_callback_();
+
+                    bool animate = view_needs_continuous_frames(&self->root_);
+                    bool tick_subscribers = self->frame_clock_.has_active_subscribers();
+                    if (!self->needs_repaint_.load(std::memory_order_relaxed) &&
+                        !animate && !tick_subscribers) {
+                        self->continuous_frames_.store(false, std::memory_order_relaxed);
+                        self->render_dispatch_queued_.store(false, std::memory_order_release);
+                        return;
+                    }
+                    self->frame_clock_.tick(1.0f / 60.0f);
+                    advance_widget_animations(&self->root_, 1.0f / 60.0f);
+                    if (animate || tick_subscribers) {
+                        self->needs_repaint_.store(true, std::memory_order_relaxed);
+                    }
+                    self->render_frame();
+                    self->render_dispatch_queued_.store(false, std::memory_order_release);
+                }
             });
         }
         return kCVReturnSuccess;
     }
 
+    void handle_window_change() {
+        if (metal_view_.window) {
+            start_display_link();
+            needs_repaint_.store(true, std::memory_order_relaxed);
+        } else {
+            stop_display_link();
+        }
+    }
+
+    void handle_backing_change() {
+        // The view already updated its layer's contentsScale/drawableSize;
+        // re-sync the surfaces at the new scale and re-arm a paint.
+        set_size(size_.width, size_.height);
+    }
+
     void start_display_link() {
-        if (display_link_) return;
+        if (display_link_) {
+            // Already running; just make sure it's bound to the current screen.
+            bind_to_window_screen();
+            return;
+        }
         CVDisplayLinkCreateWithActiveCGDisplays(&display_link_);
         CVDisplayLinkSetOutputCallback(display_link_, display_link_callback, this);
+        bind_to_window_screen();
         CVDisplayLinkStart(display_link_);
+    }
+
+    // Bind the display link to the screen the embedded view is actually on,
+    // so we render at that display's vsync (the host window may live on a
+    // secondary monitor).
+    void bind_to_window_screen() {
+        if (!display_link_) return;
+        NSScreen* screen = metal_view_.window ? metal_view_.window.screen : nil;
+        if (!screen) screen = [NSScreen mainScreen];
+        NSNumber* num = screen.deviceDescription[@"NSScreenNumber"];
+        if (num) {
+            CVDisplayLinkSetCurrentCGDisplay(
+                display_link_, (CGDirectDisplayID)num.unsignedIntValue);
+        }
     }
 
     void stop_display_link() {
@@ -529,6 +740,47 @@ private:
             CVDisplayLinkRelease(display_link_);
             display_link_ = nullptr;
         }
+    }
+
+    // ── Continuous-frame / animation drivers (parity with MacGpuWindowHost) ──
+    static bool view_needs_continuous_frames(View* view) {
+        if (!view) return false;
+        if (auto* k = dynamic_cast<Knob*>(view)) {
+            if ((k->hover_glow() > 0.01f && k->hover_glow() < 0.99f) || k->shader_uses_time())
+                return true;
+        }
+        if (auto* t = dynamic_cast<Toggle*>(view)) {
+            if ((t->thumb_position() > 0.01f && t->thumb_position() < 0.99f) || t->shader_uses_time())
+                return true;
+        }
+        if (auto* f = dynamic_cast<Fader*>(view)) {
+            if (f->hover_scale() > 1.01f || f->shader_uses_time())
+                return true;
+        }
+        if (auto* sv = dynamic_cast<ScrollView*>(view)) {
+            if (sv->scroll_animating()) return true;
+        }
+        if (view->animation_play_state() != "paused") {
+            for (const auto& a : view->active_animations()) {
+                if (a.active) return true;
+            }
+        }
+        for (size_t i = 0; i < view->child_count(); ++i) {
+            if (view_needs_continuous_frames(view->child_at(i))) return true;
+        }
+        return false;
+    }
+
+    static void advance_widget_animations(View* view, float dt) {
+        if (!view) return;
+        if (auto* k = dynamic_cast<Knob*>(view)) k->advance_animations(dt);
+        else if (auto* t = dynamic_cast<Toggle*>(view)) t->advance_animations(dt);
+        else if (auto* f = dynamic_cast<Fader*>(view)) f->advance_animations(dt);
+        else if (auto* sv = dynamic_cast<ScrollView*>(view)) sv->advance_animations(dt);
+        else if (auto* tip = dynamic_cast<Tooltip*>(view)) tip->advance_animations(dt);
+        view->tick_animations(dt);
+        for (size_t i = 0; i < view->child_count(); ++i)
+            advance_widget_animations(view->child_at(i), dt);
     }
 };
 
@@ -550,8 +802,14 @@ std::unique_ptr<PluginViewHost> PluginViewHost::create(View& root, const Options
 #ifdef PULP_HAS_SKIA
     if (options.use_gpu) {
         auto host = std::make_unique<MacGpuPluginViewHost>(root, options.size);
-        root.set_plugin_view_host(host.get());
-        return host;
+        if (host->is_gpu_backed()) {
+            root.set_plugin_view_host(host.get());
+            return host;
+        }
+        // GPU init failed (no Dawn/Metal adapter in this host process) — fall
+        // back to the CoreGraphics host so the editor never disappears (item 9).
+        // The adapter's runtime scream-guard logs the mismatch loudly.
+        host.reset();
     }
 #endif
     auto host = std::make_unique<MacPluginViewHost>(root, options.size);

--- a/core/view/platform/mac/plugin_view_host_mac.mm
+++ b/core/view/platform/mac/plugin_view_host_mac.mm
@@ -35,6 +35,7 @@ NSArray* pulp_text_accessibility_all_elements_macos();
 
 @interface PulpPluginView : NSView
 @property (nonatomic, assign) pulp::view::View* rootView;
+@property (nonatomic, copy) void (^onResize)(uint32_t, uint32_t);
 @end
 
 // ── Accessibility element wrapping a Pulp View ──────────────────────────────
@@ -147,6 +148,14 @@ NSArray* pulp_text_accessibility_all_elements_macos();
     [self setNeedsDisplay:YES];
 }
 
+- (void)setFrameSize:(NSSize)newSize {
+    [super setFrameSize:newSize];
+    if (self.onResize) {
+        self.onResize(static_cast<uint32_t>(newSize.width),
+                      static_cast<uint32_t>(newSize.height));
+    }
+}
+
 @end
 
 static NSRect child_view_frame_in_host(NSView* container,
@@ -238,11 +247,15 @@ public:
             NSRect frame = NSMakeRect(0, 0, size.width, size.height);
             view_ = [[PulpPluginView alloc] initWithFrame:frame];
             view_.rootView = &root_;
+            view_.onResize = ^(uint32_t w, uint32_t h) {
+                this->on_native_frame_changed(w, h);
+            };
         }
     }
 
     ~MacPluginViewHost() override {
         root_.set_plugin_view_host(nullptr);
+        @autoreleasepool { view_.onResize = nil; }
         detach();
     }
 
@@ -286,6 +299,10 @@ public:
         return size_;
     }
 
+    void set_resize_callback(std::function<void(uint32_t, uint32_t)> cb) override {
+        resize_cb_ = std::move(cb);
+    }
+
     bool attach_native_child_view(NativeViewHandle child_view,
                                   float x,
                                   float y,
@@ -306,10 +323,18 @@ public:
         detach_child_view_from_host(view_, child_view);
     }
 
+    void on_native_frame_changed(uint32_t w, uint32_t h) {
+        if (w == size_.width && h == size_.height) return;
+        if (w == 0 || h == 0) return;
+        set_size(w, h);
+        if (resize_cb_) resize_cb_(w, h);
+    }
+
 private:
     View& root_;
     Size size_;
     PulpPluginView* view_ = nil;
+    std::function<void(uint32_t, uint32_t)> resize_cb_;
 };
 
 } // namespace pulp::view (close for ObjC declarations)
@@ -333,6 +358,7 @@ private:
 @property (nonatomic, assign) pulp::view::View* rootView;
 @property (nonatomic, copy) void (^onWindowChange)(void);
 @property (nonatomic, copy) void (^onBackingChange)(void);
+@property (nonatomic, copy) void (^onResize)(uint32_t, uint32_t);
 @end
 
 @implementation PulpGpuPluginView
@@ -368,6 +394,13 @@ private:
                                 : [NSScreen mainScreen].backingScaleFactor;
     self.metalLayer.contentsScale = scale;
     self.metalLayer.drawableSize = CGSizeMake(newSize.width * scale, newSize.height * scale);
+    // AU v2 resizes this NSView directly (no host size callback). Notify the
+    // host; it resizes surfaces and forwards to ViewBridge::resize. The host
+    // guards against re-entrancy when *it* drove the frame change.
+    if (self.onResize) {
+        self.onResize(static_cast<uint32_t>(newSize.width),
+                      static_cast<uint32_t>(newSize.height));
+    }
 }
 
 // Start/stop the display link when the view joins or leaves a window. This is
@@ -416,6 +449,9 @@ public:
             // there too.
             metal_view_.onWindowChange = ^{ this->handle_window_change(); };
             metal_view_.onBackingChange = ^{ this->handle_backing_change(); };
+            metal_view_.onResize = ^(uint32_t w, uint32_t h) {
+                this->on_native_frame_changed(w, h);
+            };
 
             init_gpu(static_cast<float>(size.width), static_cast<float>(size.height));
         }
@@ -431,6 +467,7 @@ public:
         @autoreleasepool {
             metal_view_.onWindowChange = nil;
             metal_view_.onBackingChange = nil;
+            metal_view_.onResize = nil;
         }
         skia_surface_.reset();
         gpu_surface_.reset();
@@ -496,6 +533,10 @@ public:
                                  std::memory_order_release);
     }
 
+    void set_resize_callback(std::function<void(uint32_t, uint32_t)> cb) override {
+        resize_cb_ = std::move(cb);
+    }
+
     // Deterministic GPU back-buffer readback for hidden / headless test
     // hosts (mirrors WindowHost::capture_back_buffer_png, issue #2001).
     // Goes straight through render_frame()'s readback path; never shows a
@@ -545,6 +586,7 @@ private:
     std::atomic<bool> render_dispatch_queued_{false};
     std::function<void()> idle_callback_;
     std::atomic<bool> has_idle_callback_{false};
+    std::function<void(uint32_t, uint32_t)> resize_cb_;
     // Liveness token captured by the display-link main-thread dispatch
     // blocks. Flipped false in the destructor so a queued block after
     // teardown is a no-op (DAW teardown order is not under our control).
@@ -691,6 +733,17 @@ private:
             });
         }
         return kCVReturnSuccess;
+    }
+
+    // Called when the native NSView frame changed (e.g. AU host resize).
+    // Guards re-entrancy: when *we* drove the change via set_size(), size_
+    // already matches, so this is a no-op and never recurses through
+    // set_size()'s own [metal_view_ setFrameSize:] call.
+    void on_native_frame_changed(uint32_t w, uint32_t h) {
+        if (w == size_.width && h == size_.height) return;
+        if (w == 0 || h == 0) return;
+        set_size(w, h);
+        if (resize_cb_) resize_cb_(w, h);
     }
 
     void handle_window_change() {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1088,6 +1088,39 @@ if(PULP_HAS_SKIA AND APPLE AND PULP_ENABLE_GPU)
     # APPLE-gated, so the Windows webgpu DL_PATHS dance from the
     # PULP_GPU_TEST_DISCOVERY_ARGS block below isn't needed here.
     catch_discover_tests(pulp-test-font-rendering-goldens-gpu)
+
+    # GPU view-host-in-plugins (P1) — proves a Processor::create_view() editor
+    # that sets requires_gpu_host() auto-selects the GPU host, mounts a real
+    # (non-AutoUi) tree, and paints a nonblank offscreen Dawn/Skia frame.
+    # Soft-skips on Dawn-init failure.
+    add_executable(pulp-test-plugin-editor-headless-gpu
+        test_plugin_editor_headless_gpu.cpp)
+    target_link_libraries(pulp-test-plugin-editor-headless-gpu PRIVATE
+        pulp::format pulp::view pulp::state pulp::canvas pulp::render
+        Catch2::Catch2WithMain skia::skia)
+    target_compile_definitions(pulp-test-plugin-editor-headless-gpu PRIVATE
+        PULP_HAS_SKIA=1)
+    target_include_directories(pulp-test-plugin-editor-headless-gpu PRIVATE
+        ${SKIA_INCLUDE_DIRS})
+    catch_discover_tests(pulp-test-plugin-editor-headless-gpu)
+
+    # Embedded-host smoke (mac GPU lane): attaches the GPU host to a hidden
+    # NSWindow and proves a nonblank first-frame capture, plus drives the CLAP
+    # gui_create/set_parent adapter path. Needs CLAP for the PULP_CLAP_PLUGIN
+    # entry. Soft-skips without a Dawn adapter / window server.
+    if(PULP_HAS_CLAP)
+        add_executable(pulp-test-plugin-editor-host-smoke-mac
+            test_plugin_editor_host_smoke_mac.mm
+            ${CMAKE_SOURCE_DIR}/core/format/src/clap_adapter.cpp)
+        target_link_libraries(pulp-test-plugin-editor-host-smoke-mac PRIVATE
+            pulp::format pulp::view pulp::state pulp::canvas pulp::render
+            clap Catch2::Catch2WithMain skia::skia "-framework AppKit")
+        target_compile_definitions(pulp-test-plugin-editor-host-smoke-mac PRIVATE
+            PULP_HAS_SKIA=1 PULP_CLAP_GUI=1)
+        target_include_directories(pulp-test-plugin-editor-host-smoke-mac PRIVATE
+            ${SKIA_INCLUDE_DIRS})
+        catch_discover_tests(pulp-test-plugin-editor-host-smoke-mac)
+    endif()
 endif()
 
 # Font v2 Slice 3.4 — Skia GPU Vulkan lane (SCAFFOLD).

--- a/test/test_plugin_editor_headless_gpu.cpp
+++ b/test/test_plugin_editor_headless_gpu.cpp
@@ -1,0 +1,275 @@
+// test_plugin_editor_headless_gpu.cpp — GPU view-host-in-plugins (P1 proof)
+//
+// Proves the plugin-editor GPU path end to end WITHOUT a DAW or a window:
+//
+//   1. Capability selection (decide_gpu_host): a Processor whose
+//      create_view() returns a view with set_requires_gpu_host(true) makes
+//      the adapters auto-select the GPU host (mode="custom", use_gpu=true);
+//      an AutoUi fallback (create_view()==nullptr) does NOT (mode="autoui",
+//      use_gpu=false); and PULP_DISABLE_PLUGIN_GPU forces CPU. This is the
+//      scream-guard's selection logic — it's what prevents the silent
+//      AutoUi/CPU fallback that triggered this work.
+//
+//   2. Structural assertion (ViewInspector::to_json): the mounted tree has
+//      the editor's own labels and is NOT the AutoUi "Parameters" grid.
+//
+//   3. Nonblank GPU digest: render the editor view through an offscreen
+//      Dawn+Skia surface (native_surface_handle=nullptr) and read it back via
+//      SkiaSurface::read_current_rgba — assert pixels were painted beyond the
+//      cleared background. Mirrors test_font_rendering_goldens_gpu.cpp; soft-
+//      skips when no Dawn adapter is present (CI lane without a GPU).
+//
+// Gated PULP_HAS_SKIA && APPLE && PULP_ENABLE_GPU at compile time (CMake);
+// soft-skips on Dawn-init failure at run time.
+//
+// Tag: [gpu][skia][plugin-gpu-host][issue-2700-followup]
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/canvas/canvas.hpp>
+#include <pulp/format/gpu_host_select.hpp>
+#include <pulp/format/processor.hpp>
+#include <pulp/format/view_bridge.hpp>
+#include <pulp/state/store.hpp>
+#include <pulp/view/inspector.hpp>
+#include <pulp/view/view.hpp>
+#include <pulp/view/widgets.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <vector>
+
+#if defined(PULP_HAS_SKIA) && defined(__APPLE__)
+#include <pulp/render/gpu_surface.hpp>
+#include <pulp/render/skia_surface.hpp>
+#endif
+
+using namespace pulp;
+
+namespace {
+
+// Distinctive labels — the structural assertion looks for these and the
+// absence of the AutoUi "Parameters" title to prove the real editor mounted.
+constexpr const char* kEditorLabels[] = {"CHAINER", "OSC", "X-OVER", "LIMIT"};
+
+constexpr uint32_t kW = 480;
+constexpr uint32_t kH = 320;
+// The editor view paints this background; non-background pixels = painted UI.
+constexpr uint8_t kBgR = 30, kBgG = 30, kBgB = 46;
+
+// A Processor whose create_view() returns a GPU-backed scripted-style editor.
+class GpuEditorProcessor : public format::Processor {
+public:
+    bool return_view = true;  // false → exercise the AutoUi fallback path
+
+    format::PluginDescriptor descriptor() const override {
+        return {"GpuEditor", "Acme", "com.acme.gpueditor", "1.0.0",
+                format::PluginCategory::Effect};
+    }
+    void define_parameters(state::StateStore& s) override {
+        s.add_parameter({1, "Level", "dB", {-60.0f, 12.0f, 0.0f}});
+    }
+    void prepare(const format::PrepareContext&) override {}
+    void process(audio::BufferView<float>&, const audio::BufferView<const float>&,
+                 midi::MidiBuffer&, midi::MidiBuffer&,
+                 const format::ProcessContext&) override {}
+
+    format::ViewSize view_size() const override {
+        return {kW, kH, 320, 240, 1024, 768};
+    }
+
+    std::unique_ptr<view::View> create_view() override {
+        if (!return_view) return nullptr;  // → ViewBridge builds AutoUi
+        auto root = std::make_unique<view::View>();
+        root->set_requires_gpu_host(true);
+        root->set_background_color(canvas::Color::rgba8(kBgR, kBgG, kBgB));
+        root->flex().direction = view::FlexDirection::column;
+        root->flex().padding = 16;
+        root->flex().gap = 10;
+        for (const char* text : kEditorLabels) {
+            auto label = std::make_unique<view::Label>(text);
+            label->set_font_size(20.0f);
+            label->flex().preferred_height = 28;
+            root->add_child(std::move(label));
+        }
+        return root;
+    }
+};
+
+bool contains(const std::string& haystack, const std::string& needle) {
+    return haystack.find(needle) != std::string::npos;
+}
+
+} // namespace
+
+TEST_CASE("plugin-gpu-host: a requires_gpu_host editor auto-selects GPU",
+          "[gpu][plugin-gpu-host]") {
+    GpuEditorProcessor p;
+    state::StateStore store;
+    p.set_state_store(&store);
+    p.define_parameters(store);
+
+    format::ViewBridge bridge(p, store);
+    std::string err;
+    REQUIRE(bridge.open(&err));
+    bridge.notify_attached();
+    REQUIRE(bridge.view() != nullptr);
+    REQUIRE(bridge.view()->requires_gpu_host());
+
+    // Make sure the env opt-out isn't set from the environment.
+    ::unsetenv("PULP_DISABLE_PLUGIN_GPU");
+    auto decision = format::decide_gpu_host(bridge);
+    REQUIRE(decision.wants_gpu);
+    REQUIRE(decision.use_gpu);
+    REQUIRE(std::string(decision.mode) == "custom");
+
+    SECTION("PULP_DISABLE_PLUGIN_GPU forces CPU but still records intent") {
+        ::setenv("PULP_DISABLE_PLUGIN_GPU", "1", 1);
+        auto off = format::decide_gpu_host(bridge);
+        CHECK(off.wants_gpu);       // capability unchanged
+        CHECK_FALSE(off.use_gpu);   // request suppressed
+        ::unsetenv("PULP_DISABLE_PLUGIN_GPU");
+    }
+}
+
+TEST_CASE("plugin-gpu-host: AutoUi fallback does NOT request GPU",
+          "[gpu][plugin-gpu-host]") {
+    // This is the scream-guard's core invariant: an editor that genuinely
+    // wants AutoUi/CPU must NOT request the GPU host (and vice-versa).
+    GpuEditorProcessor p;
+    p.return_view = false;  // create_view() → nullptr → AutoUi
+    state::StateStore store;
+    p.set_state_store(&store);
+    p.define_parameters(store);
+
+    format::ViewBridge bridge(p, store);
+    std::string err;
+    REQUIRE(bridge.open(&err));
+    REQUIRE(bridge.view() != nullptr);
+    REQUIRE_FALSE(bridge.view()->requires_gpu_host());
+
+    ::unsetenv("PULP_DISABLE_PLUGIN_GPU");
+    auto decision = format::decide_gpu_host(bridge);
+    REQUIRE_FALSE(decision.wants_gpu);
+    REQUIRE_FALSE(decision.use_gpu);
+    REQUIRE(std::string(decision.mode) == "autoui");
+}
+
+TEST_CASE("plugin-gpu-host: editor tree is structurally not AutoUi",
+          "[gpu][plugin-gpu-host]") {
+    GpuEditorProcessor p;
+    state::StateStore store;
+    p.set_state_store(&store);
+    p.define_parameters(store);
+
+    format::ViewBridge bridge(p, store);
+    std::string err;
+    REQUIRE(bridge.open(&err));
+
+    const std::string json = view::ViewInspector::to_json(*bridge.view());
+    for (const char* label : kEditorLabels) {
+        INFO("expected editor label: " << label);
+        REQUIRE(contains(json, label));
+    }
+    // AutoUi's root title is the "Parameters" label — the real editor has none.
+    REQUIRE_FALSE(contains(json, "Parameters"));
+}
+
+#if defined(PULP_HAS_SKIA) && defined(__APPLE__)
+
+namespace {
+
+struct GpuFixture {
+    std::unique_ptr<render::GpuSurface> gpu;
+    std::unique_ptr<render::SkiaSurface> skia;
+    bool ready() const { return gpu && skia && skia->is_available(); }
+};
+
+GpuFixture make_offscreen_fixture(uint32_t w, uint32_t h) {
+    GpuFixture f;
+    f.gpu = render::GpuSurface::create_dawn();
+    if (!f.gpu) return f;
+    render::GpuSurface::Config gpu_config{};
+    gpu_config.width = w;
+    gpu_config.height = h;
+    gpu_config.native_surface_handle = nullptr;  // headless / offscreen
+    if (!f.gpu->initialize(gpu_config)) {
+        f.gpu.reset();
+        return f;
+    }
+    render::SkiaSurface::Config skia_config{};
+    skia_config.width = w;
+    skia_config.height = h;
+    skia_config.scale_factor = 1.0f;
+    f.skia = render::SkiaSurface::create(*f.gpu, skia_config);
+    return f;
+}
+
+// Count pixels that differ from the editor's known background — i.e. pixels
+// the UI actually painted (labels). A blank/failed frame returns ~0.
+uint32_t count_non_background(const std::vector<uint8_t>& px, uint32_t w, uint32_t h) {
+    const size_t need = static_cast<size_t>(w) * h * 4u;
+    if (px.size() < need) return 0;
+    uint32_t n = 0;
+    for (uint32_t i = 0; i < w * h; ++i) {
+        const uint8_t r = px[i * 4 + 0];
+        const uint8_t g = px[i * 4 + 1];
+        const uint8_t b = px[i * 4 + 2];
+        const int dr = std::abs(static_cast<int>(r) - kBgR);
+        const int dg = std::abs(static_cast<int>(g) - kBgG);
+        const int db = std::abs(static_cast<int>(b) - kBgB);
+        if (dr + dg + db > 24) ++n;
+    }
+    return n;
+}
+
+} // namespace
+
+TEST_CASE("plugin-gpu-host: editor view paints nonblank GPU frame (offscreen)",
+          "[gpu][skia][plugin-gpu-host]") {
+    auto f = make_offscreen_fixture(kW, kH);
+    if (!f.ready()) {
+        SUCCEED("Dawn/Graphite unavailable on this host — offscreen GPU proof skipped.");
+        return;
+    }
+
+    GpuEditorProcessor p;
+    state::StateStore store;
+    p.set_state_store(&store);
+    p.define_parameters(store);
+    format::ViewBridge bridge(p, store);
+    std::string err;
+    REQUIRE(bridge.open(&err));
+    view::View* root = bridge.view();
+    REQUIRE(root != nullptr);
+
+    REQUIRE(f.gpu->begin_frame());
+    auto* canvas = f.skia->begin_frame();
+    REQUIRE(canvas != nullptr);
+    root->set_bounds({0, 0, static_cast<float>(kW), static_cast<float>(kH)});
+    root->layout_children();
+    canvas->set_fill_color(canvas::Color::rgba8(kBgR, kBgG, kBgB));
+    canvas->fill_rect(0, 0, static_cast<float>(kW), static_cast<float>(kH));
+    root->paint_all(*canvas);
+
+    std::vector<uint8_t> pixels;
+    uint32_t pw = 0, ph = 0;
+    const bool read = f.skia->read_current_rgba(pixels, pw, ph);
+    f.skia->end_frame();
+    f.gpu->end_frame();
+
+    if (!read) {
+        SUCCEED("GPU readback failed (no adapter) — nonblank proof skipped.");
+        return;
+    }
+    const uint32_t painted = count_non_background(pixels, pw, ph);
+    INFO("non-background pixels: " << painted << " of " << (pw * ph));
+    // Four labels at 20px over a 480x320 surface paint thousands of glyph
+    // pixels; require a conservative floor well above readback noise.
+    REQUIRE(painted > 200u);
+}
+
+#endif // PULP_HAS_SKIA && __APPLE__

--- a/test/test_plugin_editor_host_smoke_mac.mm
+++ b/test/test_plugin_editor_host_smoke_mac.mm
@@ -1,0 +1,241 @@
+// test_plugin_editor_host_smoke_mac.mm — GPU view-host-in-plugins smoke (mac)
+//
+// Proves the *embedded* GPU plugin host actually attaches to a host-provided
+// parent NSView and paints a first frame — the thing the headless offscreen
+// test can't cover (offscreen has no window/attach lifecycle). Two layers:
+//
+//   1. PluginViewHost level (deterministic, we own the host): build a GPU
+//      host for a requires_gpu_host() editor, attach it to a HIDDEN NSWindow's
+//      content view, pump the run loop so -viewDidMoveToWindow starts the
+//      display link, then capture_back_buffer_png() and assert a nonblank PNG.
+//      Also resizes and re-captures (HiDPI surface-resize path).
+//
+//   2. CLAP adapter level (no DAW): drive gui_create / set_parent / set_size
+//      through the generated CLAP entry against the same hidden window, which
+//      exercises the adapter's decide_gpu_host() auto-selection + attach path.
+//
+// Must run with a real window server (self-hosted mac GPU lane). Clears the
+// no-editor env guards in-process. Soft-skips when no Dawn/Metal adapter or
+// Cocoa window is available, so a GitHub-hosted mac without a GPU stays green.
+//
+// Tag: [gpu][skia][plugin-gpu-host][mac][issue-2700-followup]
+
+#include <catch2/catch_test_macros.hpp>
+
+#if defined(PULP_HAS_SKIA) && defined(__APPLE__)
+
+#import <Cocoa/Cocoa.h>
+
+#include <pulp/format/clap_entry.hpp>
+#include <pulp/format/gpu_host_select.hpp>
+#include <pulp/format/processor.hpp>
+#include <pulp/format/view_bridge.hpp>
+#include <pulp/state/store.hpp>
+#include <pulp/view/plugin_view_host.hpp>
+#include <pulp/view/view.hpp>
+#include <pulp/view/widgets.hpp>
+#include <pulp/canvas/canvas.hpp>
+
+#include <cstdlib>
+#include <memory>
+#include <string>
+
+using namespace pulp;
+
+namespace smoke {
+
+constexpr uint32_t kW = 480;
+constexpr uint32_t kH = 320;
+
+class GpuEditorProcessor : public format::Processor {
+public:
+    format::PluginDescriptor descriptor() const override {
+        return {"GpuEditorSmoke", "Acme", "com.acme.gpueditor.smoke", "1.0.0",
+                format::PluginCategory::Effect};
+    }
+    void define_parameters(state::StateStore& s) override {
+        s.add_parameter({1, "Level", "dB", {-60.0f, 12.0f, 0.0f}});
+    }
+    void prepare(const format::PrepareContext&) override {}
+    void process(audio::BufferView<float>&, const audio::BufferView<const float>&,
+                 midi::MidiBuffer&, midi::MidiBuffer&,
+                 const format::ProcessContext&) override {}
+    format::ViewSize view_size() const override { return {kW, kH, 320, 240, 1024, 768}; }
+    std::unique_ptr<view::View> create_view() override {
+        auto root = std::make_unique<view::View>();
+        root->set_requires_gpu_host(true);
+        root->set_background_color(canvas::Color::rgba8(30, 30, 46));
+        root->flex().direction = view::FlexDirection::column;
+        root->flex().padding = 16;
+        for (const char* t : {"CHAINER", "OSC", "X-OVER", "LIMIT"}) {
+            auto l = std::make_unique<view::Label>(t);
+            l->set_font_size(20.0f);
+            l->flex().preferred_height = 28;
+            root->add_child(std::move(l));
+        }
+        return root;
+    }
+};
+
+inline std::unique_ptr<format::Processor> create_smoke_processor() {
+    return std::make_unique<GpuEditorProcessor>();
+}
+
+inline void pump_run_loop(int frames) {
+    for (int i = 0; i < frames; ++i) {
+        @autoreleasepool {
+            [[NSRunLoop currentRunLoop]
+                runMode:NSDefaultRunLoopMode
+                beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.02]];
+        }
+    }
+}
+
+inline void clear_no_editor_env() {
+    ::unsetenv("CI");
+    ::unsetenv("PULP_TEST_MODE");
+    ::unsetenv("PULP_HEADLESS");
+    ::unsetenv("PULP_DISABLE_PLUGIN_EDITOR");
+    ::unsetenv("PULP_DISABLE_PLUGIN_GPU");
+}
+
+inline bool looks_like_png(const std::vector<uint8_t>& d) {
+    return d.size() > 8 && d[0] == 0x89 && d[1] == 'P' && d[2] == 'N' && d[3] == 'G';
+}
+
+} // namespace smoke
+
+// Generate a CLAP entry backed by the smoke processor (file-scope global).
+PULP_CLAP_PLUGIN(smoke::create_smoke_processor)
+
+TEST_CASE("embedded GPU plugin host attaches + paints first frame (mac)",
+          "[gpu][skia][plugin-gpu-host][mac]") {
+    smoke::clear_no_editor_env();
+    @autoreleasepool {
+        NSWindow* window =
+            [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, smoke::kW, smoke::kH)
+                                        styleMask:NSWindowStyleMaskTitled
+                                          backing:NSBackingStoreBuffered
+                                            defer:NO];
+        if (!window || !window.contentView) {
+            SUCCEED("No Cocoa window available — embedded host smoke skipped.");
+            return;
+        }
+
+        smoke::GpuEditorProcessor p;
+        state::StateStore store;
+        p.set_state_store(&store);
+        p.define_parameters(store);
+        format::ViewBridge bridge(p, store);
+        std::string err;
+        REQUIRE(bridge.open(&err));
+
+        auto decision = format::decide_gpu_host(bridge);
+        REQUIRE(decision.use_gpu);
+        REQUIRE(std::string(decision.mode) == "custom");
+
+        view::PluginViewHost::Options opts;
+        opts.size = {smoke::kW, smoke::kH};
+        opts.use_gpu = decision.use_gpu;
+        auto host = view::PluginViewHost::create(*bridge.view(), opts);
+        REQUIRE(host != nullptr);
+
+        if (!host->is_gpu_backed()) {
+            // GPU host fell back to CPU — no Dawn/Metal adapter on this host.
+            SUCCEED("No GPU adapter — embedded GPU host smoke skipped (CPU fallback).");
+            bridge.close();
+            [window close];
+            return;
+        }
+
+        host->set_idle_callback(format::make_scripted_idle_pump(bridge));
+        host->attach_to_parent((__bridge void*)window.contentView);
+        bridge.notify_attached();
+        smoke::pump_run_loop(5);
+
+        auto png = host->capture_back_buffer_png();
+        INFO("captured PNG bytes: " << png.size());
+        REQUIRE_FALSE(png.empty());
+        REQUIRE(smoke::looks_like_png(png));
+
+        // Resize (exercises the GpuSurface PHYSICAL / SkiaSurface LOGICAL+scale
+        // resize path) and re-capture.
+        host->set_size(smoke::kW + 40, smoke::kH + 20);
+        smoke::pump_run_loop(3);
+        auto png2 = host->capture_back_buffer_png();
+        REQUIRE_FALSE(png2.empty());
+        REQUIRE(smoke::looks_like_png(png2));
+
+        host->detach();
+        host.reset();
+        bridge.close();
+        [window close];
+    }
+}
+
+TEST_CASE("CLAP gui_create/set_parent attaches the embedded editor (mac)",
+          "[gpu][skia][plugin-gpu-host][mac][clap]") {
+    smoke::clear_no_editor_env();
+    @autoreleasepool {
+        REQUIRE(clap_entry.init("test"));
+        auto* factory = static_cast<const clap_plugin_factory_t*>(
+            clap_entry.get_factory(CLAP_PLUGIN_FACTORY_ID));
+        REQUIRE(factory != nullptr);
+        auto* desc = factory->get_plugin_descriptor(factory, 0);
+        REQUIRE(desc != nullptr);
+        const clap_plugin_t* plugin = factory->create_plugin(factory, nullptr, desc->id);
+        REQUIRE(plugin != nullptr);
+        REQUIRE(plugin->init(plugin));
+
+        auto* gui = static_cast<const clap_plugin_gui_t*>(
+            plugin->get_extension(plugin, CLAP_EXT_GUI));
+        REQUIRE(gui != nullptr);
+
+        if (!gui->is_api_supported(plugin, CLAP_WINDOW_API_COCOA, false)) {
+            SUCCEED("Cocoa GUI API not supported on this host — CLAP smoke skipped.");
+            plugin->destroy(plugin);
+            clap_entry.deinit();
+            return;
+        }
+
+        if (!gui->create(plugin, CLAP_WINDOW_API_COCOA, false)) {
+            // Editor still env-blocked (no window server) — soft skip.
+            SUCCEED("CLAP gui_create returned false (no window server) — skipped.");
+            plugin->destroy(plugin);
+            clap_entry.deinit();
+            return;
+        }
+
+        NSWindow* window =
+            [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, smoke::kW, smoke::kH)
+                                        styleMask:NSWindowStyleMaskTitled
+                                          backing:NSBackingStoreBuffered
+                                            defer:NO];
+        REQUIRE(window.contentView != nil);
+
+        clap_window_t cw{};
+        cw.api = CLAP_WINDOW_API_COCOA;
+        cw.cocoa = (__bridge void*)window.contentView;
+        REQUIRE(gui->set_parent(plugin, &cw));
+
+        uint32_t w = 0, h = 0;
+        if (gui->get_size(plugin, &w, &h)) {
+            REQUIRE(w > 0);
+            REQUIRE(h > 0);
+        }
+        smoke::pump_run_loop(5);
+
+        gui->destroy(plugin);
+        plugin->destroy(plugin);
+        clap_entry.deinit();
+        [window close];
+    }
+}
+
+#else  // !(PULP_HAS_SKIA && __APPLE__)
+
+TEST_CASE("embedded GPU plugin host smoke is mac+Skia only", "[gpu][plugin-gpu-host][mac]") {
+    SUCCEED("Built without PULP_HAS_SKIA / not Apple — embedded host smoke is a no-op.");
+}
+
+#endif


### PR DESCRIPTION
The pre-push docs-noise gate flagged transient workflow breadcrumbs added in
the prior skill update: a 'review on PR #653 caught' cite-phrase (auv3, ios)
and a bare '#1402 contract' parenthetical (ios). Rewrite them as evergreen
rationale without the PR/issue citations.