### PR TITLE
test(tools): cover import reference diff helpers

### DIFF
--- a/tools/import-validation/diff_against_reference.py
+++ b/tools/import-validation/diff_against_reference.py
@@ -31,17 +31,20 @@ import argparse
 import sys
 from pathlib import Path
 
-try:
-    from PIL import Image
-except ImportError:
-    print("error: PIL/Pillow required (pip install Pillow)", file=sys.stderr)
-    sys.exit(2)
-
 import warnings
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 
+def _image_module():
+    try:
+        from PIL import Image
+    except ImportError as exc:
+        raise RuntimeError("PIL/Pillow required (pip install Pillow)") from exc
+    return Image
+
+
 def load_normalized(path: Path, target_size: tuple[int, int]) -> Image.Image:
+    Image = _image_module()
     img = Image.open(path).convert("RGB")
     if img.size != target_size:
         img = img.resize(target_size, Image.Resampling.LANCZOS)
@@ -123,7 +126,11 @@ def main() -> int:
             print(f"error: file not found: {p}", file=sys.stderr)
             return 2
 
-    w, h = (int(x) for x in args.size.split("x"))
+    try:
+        w, h = (int(x) for x in args.size.split("x"))
+    except ValueError:
+        print(f"error: malformed --size {args.size}", file=sys.stderr)
+        return 2
     target = (w, h)
 
     try:

--- a/tools/import-validation/diff_against_reference_regions.py
+++ b/tools/import-validation/diff_against_reference_regions.py
@@ -38,12 +38,6 @@ import json
 import sys
 from pathlib import Path
 
-try:
-    from PIL import Image
-except ImportError:
-    print("error: PIL/Pillow required (pip install Pillow)", file=sys.stderr)
-    sys.exit(2)
-
 import warnings
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
@@ -83,7 +77,16 @@ SPECTR_REGIONS = {
 }
 
 
+def _image_module():
+    try:
+        from PIL import Image
+    except ImportError as exc:
+        raise RuntimeError("PIL/Pillow required (pip install Pillow)") from exc
+    return Image
+
+
 def load_normalized(path: Path, target_size: tuple[int, int]) -> Image.Image:
+    Image = _image_module()
     img = Image.open(path).convert("RGB")
     if img.size != target_size:
         img = img.resize(target_size, Image.Resampling.LANCZOS)
@@ -114,6 +117,7 @@ def histogram_similarity(a: Image.Image, b: Image.Image) -> float:
 def mean_pixel_distance(a: Image.Image, b: Image.Image) -> float:
     if a.size != b.size:
         # Resize candidate region to reference region; cheap.
+        Image = _image_module()
         b = b.resize(a.size, Image.Resampling.LANCZOS)
     pa = list(a.getdata())
     pb = list(b.getdata())

--- a/tools/import-validation/test_diff_against_reference.py
+++ b/tools/import-validation/test_diff_against_reference.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Unit tests for diff_against_reference.py helper scoring and CLI flow."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).with_name("diff_against_reference.py")
+SPEC = importlib.util.spec_from_file_location("diff_against_reference", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+diff = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = diff
+SPEC.loader.exec_module(diff)
+
+
+class FakeImage:
+    def __init__(
+        self,
+        pixels: list[tuple[int, int, int]],
+        size: tuple[int, int] | None = None,
+        histogram: list[int] | None = None,
+    ) -> None:
+        self._pixels = pixels
+        self.size = size or (len(pixels), 1)
+        self._histogram = histogram
+        self.resized_to: tuple[int, int] | None = None
+        self.converted_to: str | None = None
+
+    def getdata(self) -> list[tuple[int, int, int]]:
+        return self._pixels
+
+    def histogram(self) -> list[int]:
+        if self._histogram is not None:
+            return self._histogram
+        hist = [0] * 768
+        for r, g, b in self._pixels:
+            hist[r] += 1
+            hist[256 + g] += 1
+            hist[512 + b] += 1
+        return hist
+
+    def convert(self, mode: str) -> "FakeImage":
+        self.converted_to = mode
+        return self
+
+    def resize(self, target: tuple[int, int], _resampling: object = None) -> "FakeImage":
+        self.resized_to = target
+        self.size = target
+        return self
+
+
+class HelperScoringTests(unittest.TestCase):
+    def test_image_module_imports_pillow_or_reports_install_hint(self) -> None:
+        def fake_import(name: str, *args: object, **kwargs: object) -> object:
+            if name == "PIL":
+                return mock.Mock(Image="fake-image-module")
+            return __import__(name, *args, **kwargs)
+
+        with mock.patch("builtins.__import__", side_effect=fake_import):
+            self.assertEqual(diff._image_module(), "fake-image-module")
+        with mock.patch("builtins.__import__", side_effect=ImportError):
+            with self.assertRaisesRegex(RuntimeError, "PIL/Pillow required"):
+                diff._image_module()
+
+    def test_histogram_similarity_handles_identity_and_empty_norm(self) -> None:
+        a = FakeImage([(0, 0, 0)], histogram=[1, 2, 3])
+        self.assertAlmostEqual(diff.histogram_similarity(a, a), 1.0)
+        self.assertEqual(diff.histogram_similarity(FakeImage([], histogram=[]), a), 0.0)
+
+    def test_mean_pixel_distance_scores_identical_different_and_mismatched_lengths(self) -> None:
+        white = FakeImage([(255, 255, 255)])
+        black = FakeImage([(0, 0, 0)])
+        self.assertEqual(diff.mean_pixel_distance(white, white), 1.0)
+        self.assertLess(diff.mean_pixel_distance(white, black), 0.001)
+        self.assertEqual(diff.mean_pixel_distance(white, FakeImage([])), 0.0)
+        self.assertGreater(diff.mean_pixel_distance(white, FakeImage([(128, 128, 128)])), 0.49)
+        self.assertLess(diff.mean_pixel_distance(white, FakeImage([(128, 128, 128)])), 0.51)
+
+    def test_blank_detection_uses_near_black_ratio(self) -> None:
+        self.assertTrue(diff.is_blank(FakeImage([(0, 0, 0)] * 96 + [(255, 255, 255)] * 4)))
+        self.assertFalse(diff.is_blank(FakeImage([(0, 0, 0)] * 94 + [(255, 255, 255)] * 6)))
+
+    def test_dominant_colors_are_quantized_and_sorted(self) -> None:
+        img = FakeImage([(33, 63, 95), (34, 64, 96), (250, 250, 250)])
+        colors = diff.dominant_colors(img, k=2)
+        self.assertEqual(colors, [(32, 32, 64), (32, 64, 96)])
+        self.assertEqual(len(colors), 2)
+        self.assertNotIn((224, 224, 224), colors)
+
+    def test_load_normalized_converts_and_resizes_when_needed(self) -> None:
+        opened = FakeImage([(1, 2, 3)], size=(4, 4))
+        fake_module = mock.Mock()
+        fake_module.open.return_value = opened
+        fake_module.Resampling.LANCZOS = object()
+        with mock.patch.object(diff, "_image_module", return_value=fake_module):
+            result = diff.load_normalized(Path("image.png"), (8, 8))
+        self.assertIs(result, opened)
+        self.assertEqual(opened.converted_to, "RGB")
+        self.assertEqual(opened.resized_to, (8, 8))
+        fake_module.open.assert_called_once_with(Path("image.png"))
+        self.assertEqual(result.size, (8, 8))
+
+    def test_load_normalized_skips_resize_when_size_matches(self) -> None:
+        opened = FakeImage([(1, 2, 3)], size=(8, 8))
+        fake_module = mock.Mock()
+        fake_module.open.return_value = opened
+        with mock.patch.object(diff, "_image_module", return_value=fake_module):
+            result = diff.load_normalized(Path("image.png"), (8, 8))
+        self.assertIs(result, opened)
+        self.assertIsNone(opened.resized_to)
+        self.assertEqual(opened.converted_to, "RGB")
+
+
+class MainFlowTests(unittest.TestCase):
+    def _run_main(
+        self,
+        argv: list[str],
+        *,
+        ref: FakeImage | None = None,
+        cand: FakeImage | None = None,
+    ) -> tuple[int, str, str]:
+        ref_img = ref or FakeImage([(255, 255, 255)])
+        cand_img = cand or FakeImage([(255, 255, 255)])
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with tempfile.TemporaryDirectory() as tdir:
+            root = Path(tdir)
+            ref_path = root / "ref.png"
+            cand_path = root / "cand.png"
+            ref_path.write_text("ref", encoding="utf-8")
+            cand_path.write_text("cand", encoding="utf-8")
+            args = [str(ref_path), str(cand_path), *argv]
+            with mock.patch.object(sys, "argv", [str(SCRIPT), *args]), \
+                 mock.patch.object(diff, "load_normalized", side_effect=[ref_img, cand_img]), \
+                 contextlib.redirect_stdout(stdout), \
+                 contextlib.redirect_stderr(stderr):
+                rc = diff.main()
+        return rc, stdout.getvalue(), stderr.getvalue()
+
+    def test_main_prints_pass_verdict_for_matching_images(self) -> None:
+        rc, stdout, stderr = self._run_main(["--threshold", "0.5"])
+        self.assertEqual(rc, 0)
+        self.assertIn("PASS", stdout)
+        self.assertEqual(stderr, "")
+
+    def test_main_fails_blank_candidate_even_when_pixels_match(self) -> None:
+        blank = FakeImage([(0, 0, 0)] * 100)
+        rc, stdout, _stderr = self._run_main([], ref=blank, cand=blank)
+        self.assertEqual(rc, 1)
+        self.assertIn("tier=blank", stdout)
+        self.assertIn("candidate is essentially blank", stdout)
+        self.assertIn("FAIL", stdout)
+        self.assertIn("ref dominant colors", stdout)
+
+    def test_main_json_output_contains_metrics_and_diagnosis(self) -> None:
+        rc, stdout, _stderr = self._run_main(["--json", "--threshold", "0.99"])
+        payload = json.loads(stdout)
+        self.assertEqual(rc, 0)
+        self.assertTrue(payload["passed"])
+        self.assertEqual(payload["tier"], "pass")
+        self.assertEqual(payload["score"], 1.0)
+        self.assertEqual(payload["threshold"], 0.99)
+        self.assertFalse(payload["blank_candidate"])
+
+    def test_main_reports_missing_file_before_loading_images(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with mock.patch.object(sys, "argv", [str(SCRIPT), "missing-ref.png", "missing-cand.png"]), \
+             mock.patch.object(diff, "load_normalized") as load_normalized, \
+             contextlib.redirect_stdout(stdout), \
+             contextlib.redirect_stderr(stderr):
+            rc = diff.main()
+        self.assertEqual(rc, 2)
+        self.assertIn("file not found", stderr.getvalue())
+        self.assertEqual(stdout.getvalue(), "")
+        load_normalized.assert_not_called()
+
+    def test_main_rejects_malformed_size(self) -> None:
+        rc, _stdout, stderr = self._run_main(["--size", "12-by-8"])
+        self.assertEqual(rc, 2)
+        self.assertIn("malformed --size", stderr)
+
+    def test_main_reports_load_errors_as_compare_errors(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with tempfile.TemporaryDirectory() as tdir:
+            root = Path(tdir)
+            ref_path = root / "ref.png"
+            cand_path = root / "cand.png"
+            ref_path.write_text("ref", encoding="utf-8")
+            cand_path.write_text("cand", encoding="utf-8")
+            with mock.patch.object(sys, "argv", [str(SCRIPT), str(ref_path), str(cand_path)]), \
+                 mock.patch.object(diff, "load_normalized", side_effect=RuntimeError("bad image")), \
+                 contextlib.redirect_stdout(stdout), \
+                 contextlib.redirect_stderr(stderr):
+                rc = diff.main()
+        self.assertEqual(rc, 2)
+        self.assertIn("failed to load images", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/import-validation/test_diff_against_reference_regions.py
+++ b/tools/import-validation/test_diff_against_reference_regions.py
@@ -11,15 +11,24 @@ Pins the Codex P2 contract on PR #1871:
 
 from __future__ import annotations
 
+import contextlib
+import importlib.util
+import io
 import json
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 THIS_DIR = Path(__file__).resolve().parent
 SCRIPT = THIS_DIR / "diff_against_reference_regions.py"
+SPEC = importlib.util.spec_from_file_location("diff_against_reference_regions", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+regions_mod = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = regions_mod
+SPEC.loader.exec_module(regions_mod)
 
 
 def _run(args: list[str]) -> subprocess.CompletedProcess:
@@ -191,6 +200,200 @@ class TestStrictFlag(unittest.TestCase):
                 f"expected exit 1 with --strict; got {result.returncode}\n"
                 f"stdout={result.stdout}\nstderr={result.stderr}",
             )
+
+
+class FakeImage:
+    def __init__(
+        self,
+        pixels: list[tuple[int, int, int]],
+        size: tuple[int, int] = (10, 10),
+        histogram: list[int] | None = None,
+    ) -> None:
+        self._pixels = pixels
+        self.size = size
+        self._histogram = histogram
+        self.crop_box: tuple[int, int, int, int] | None = None
+        self.resized_to: tuple[int, int] | None = None
+
+    def getdata(self) -> list[tuple[int, int, int]]:
+        return self._pixels
+
+    def histogram(self) -> list[int]:
+        if self._histogram is not None:
+            return self._histogram
+        hist = [0] * 768
+        for r, g, b in self._pixels:
+            hist[r] += 1
+            hist[256 + g] += 1
+            hist[512 + b] += 1
+        return hist
+
+    def crop(self, box: tuple[int, int, int, int]) -> "FakeImage":
+        cropped = FakeImage(self._pixels, size=(box[2] - box[0], box[3] - box[1]))
+        cropped.crop_box = box
+        return cropped
+
+    def resize(self, target: tuple[int, int], _resampling: object = None) -> "FakeImage":
+        self.resized_to = target
+        self.size = target
+        return self
+
+
+class TestRegionHelpers(unittest.TestCase):
+    def test_image_module_imports_pillow_or_reports_install_hint(self) -> None:
+        def fake_import(name: str, *args: object, **kwargs: object) -> object:
+            if name == "PIL":
+                return mock.Mock(Image="fake-image-module")
+            return __import__(name, *args, **kwargs)
+
+        with mock.patch("builtins.__import__", side_effect=fake_import):
+            self.assertEqual(regions_mod._image_module(), "fake-image-module")
+        with mock.patch("builtins.__import__", side_effect=ImportError):
+            with self.assertRaisesRegex(RuntimeError, "PIL/Pillow required"):
+                regions_mod._image_module()
+
+    def test_crop_region_maps_percent_rects_to_pixel_bounds(self) -> None:
+        img = FakeImage([(1, 2, 3)], size=(200, 100))
+        cropped = regions_mod.crop_region(img, {"x": 0.25, "y": 0.10, "w": 0.50, "h": 0.20})
+        self.assertEqual(cropped.crop_box, (50, 10, 150, 30))
+        self.assertEqual(cropped.size, (100, 20))
+
+    def test_crop_region_clamps_empty_percent_dimensions_to_one_pixel(self) -> None:
+        img = FakeImage([(1, 2, 3)], size=(200, 100))
+        cropped = regions_mod.crop_region(img, {"x": 0.0, "y": 0.0, "w": 0.0, "h": 0.0})
+        self.assertEqual(cropped.crop_box, (0, 0, 1, 1))
+
+    def test_mean_pixel_distance_resizes_candidate_region_before_compare(self) -> None:
+        ref = FakeImage([(255, 255, 255)], size=(2, 2))
+        cand = FakeImage([(255, 255, 255)], size=(1, 1))
+        fake_module = mock.Mock()
+        fake_module.Resampling.LANCZOS = object()
+        with mock.patch.object(regions_mod, "_image_module", return_value=fake_module):
+            self.assertEqual(regions_mod.mean_pixel_distance(ref, cand), 1.0)
+        self.assertEqual(cand.resized_to, (2, 2))
+
+    def test_histogram_and_pixel_distance_zero_guards(self) -> None:
+        empty = FakeImage([], histogram=[])
+        full = FakeImage([(255, 255, 255)], histogram=[1])
+        self.assertEqual(regions_mod.histogram_similarity(empty, full), 0.0)
+        self.assertEqual(regions_mod.mean_pixel_distance(full, FakeImage([])), 0.0)
+
+    def test_is_blank_treats_empty_or_mostly_black_regions_as_blank(self) -> None:
+        self.assertTrue(regions_mod.is_blank(FakeImage([])))
+        self.assertTrue(regions_mod.is_blank(FakeImage([(0, 0, 0)] * 96 + [(255, 255, 255)] * 4)))
+        self.assertFalse(regions_mod.is_blank(FakeImage([(0, 0, 0)] * 94 + [(255, 255, 255)] * 6)))
+
+    def test_region_score_uses_default_threshold_and_blank_candidate_gate(self) -> None:
+        ref = FakeImage([(0, 0, 0)] * 100)
+        cand = FakeImage([(0, 0, 0)] * 100)
+        result = regions_mod.region_score(ref, cand, {"x": 0.0, "y": 0.0, "w": 1.0, "h": 1.0})
+        self.assertEqual(result["threshold"], 0.75)
+        self.assertFalse(result["passed"])
+        self.assertEqual(result["score"], 1.0)
+        self.assertTrue(result["blank_candidate"])
+        self.assertTrue(result["blank_reference"])
+        self.assertEqual(result["rect_pct"], {"x": 0.0, "y": 0.0, "w": 1.0, "h": 1.0})
+
+    def test_region_score_passes_non_blank_matching_region_with_notes(self) -> None:
+        img = FakeImage([(255, 255, 255)] * 100)
+        result = regions_mod.region_score(
+            img,
+            img,
+            {"x": 0.0, "y": 0.0, "w": 1.0, "h": 1.0, "threshold": 0.99, "notes": "full"},
+        )
+        self.assertTrue(result["passed"])
+        self.assertEqual(result["score"], 1.0)
+        self.assertEqual(result["notes"], "full")
+        self.assertFalse(result["blank_candidate"])
+        self.assertFalse(result["blank_reference"])
+
+    def test_load_regions_defaults_to_spectr_regions(self) -> None:
+        self.assertIs(regions_mod.load_regions(None), regions_mod.SPECTR_REGIONS)
+        self.assertIn("central_canvas", regions_mod.load_regions(None))
+
+    def test_load_regions_reports_missing_malformed_and_empty_files(self) -> None:
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr), self.assertRaises(SystemExit) as missing:
+            regions_mod.load_regions(Path("missing-regions.json"))
+        self.assertIn("regions JSON not found", stderr.getvalue())
+
+        with tempfile.TemporaryDirectory() as tdir:
+            tmp = Path(tdir)
+            malformed = tmp / "bad.json"
+            malformed.write_text("{", encoding="utf-8")
+            empty = tmp / "empty.json"
+            empty.write_text("{}", encoding="utf-8")
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr), self.assertRaises(SystemExit) as bad_json:
+                regions_mod.load_regions(malformed)
+            self.assertIn("malformed regions JSON", stderr.getvalue())
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr), self.assertRaises(SystemExit) as empty_json:
+                regions_mod.load_regions(empty)
+            self.assertEqual(empty_json.exception.code, 2)
+            self.assertIn("non-empty object", stderr.getvalue())
+
+    def test_load_normalized_uses_pillow_module_and_skips_matching_resize(self) -> None:
+        opened = mock.Mock()
+        opened.size = (16, 8)
+        opened.convert.return_value = opened
+        fake_module = mock.Mock()
+        fake_module.open.return_value = opened
+        with mock.patch.object(regions_mod, "_image_module", return_value=fake_module):
+            result = regions_mod.load_normalized(Path("ref.png"), (16, 8))
+        self.assertIs(result, opened)
+        opened.convert.assert_called_once_with("RGB")
+        opened.resize.assert_not_called()
+
+    def test_main_rejects_malformed_size_before_image_loading(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with tempfile.TemporaryDirectory() as tdir:
+            tmp = Path(tdir)
+            ref_path = tmp / "ref.png"
+            cand_path = tmp / "cand.png"
+            ref_path.write_text("ref", encoding="utf-8")
+            cand_path.write_text("cand", encoding="utf-8")
+            with mock.patch.object(sys, "argv", [str(SCRIPT), str(ref_path), str(cand_path), "--size", "bad"]), \
+                 mock.patch.object(regions_mod, "load_normalized") as load_normalized, \
+                 contextlib.redirect_stdout(stdout), \
+                 contextlib.redirect_stderr(stderr):
+                rc = regions_mod.main()
+        self.assertEqual(rc, 2)
+        self.assertIn("malformed --size", stderr.getvalue())
+        self.assertEqual(stdout.getvalue(), "")
+        load_normalized.assert_not_called()
+
+    def test_main_json_without_strict_reports_failures_but_exits_zero(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with tempfile.TemporaryDirectory() as tdir:
+            tmp = Path(tdir)
+            ref_path = tmp / "ref.png"
+            cand_path = tmp / "cand.png"
+            region_path = tmp / "regions.json"
+            ref_path.write_text("ref", encoding="utf-8")
+            cand_path.write_text("cand", encoding="utf-8")
+            region_path.write_text(
+                json.dumps({"full": {"x": 0.0, "y": 0.0, "w": 1.0, "h": 1.0, "threshold": 0.99}}),
+                encoding="utf-8",
+            )
+            with mock.patch.object(sys, "argv", [str(SCRIPT), str(ref_path), str(cand_path), "--regions", str(region_path), "--json"]), \
+                 mock.patch.object(regions_mod, "load_normalized", side_effect=[
+                     FakeImage([(255, 255, 255)] * 100),
+                     FakeImage([(0, 0, 0)] * 100),
+                 ]), \
+                 contextlib.redirect_stdout(stdout), \
+                 contextlib.redirect_stderr(stderr):
+                rc = regions_mod.main()
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(rc, 0)
+        self.assertFalse(payload["all_passed"])
+        self.assertEqual(payload["failed_regions"], ["full"])
+        self.assertEqual(payload["size_normalized_to"], "1320x860")
+        self.assertEqual(stderr.getvalue(), "")
+        self.assertIn("full", payload["regions"])
+        self.assertTrue(payload["regions"]["full"]["blank_candidate"])
 
 
 if __name__ == "__main__":

--- a/tools/scripts/run_python_coverage.py
+++ b/tools/scripts/run_python_coverage.py
@@ -83,7 +83,11 @@ COVERAGE_SURFACES = (
     ),
     CoverageSurface(
         ("tools/import-validation",),
-        ("tools/import-validation/test_source_contracts.py",),
+        (
+            "tools/import-validation/test_diff_against_reference.py",
+            "tools/import-validation/test_diff_against_reference_regions.py",
+            "tools/import-validation/test_source_contracts.py",
+        ),
     ),
     # Keep the broader first-party tooling roots represented while the
     # executed test set stays on the established tooling roots plus

--- a/tools/scripts/test_run_python_coverage.py
+++ b/tools/scripts/test_run_python_coverage.py
@@ -104,6 +104,14 @@ class CoveragercTests(unittest.TestCase):
             rpc.DEFAULT_TEST_GLOBS,
         )
         self.assertIn(
+            "tools/import-validation/test_diff_against_reference.py",
+            rpc.DEFAULT_TEST_GLOBS,
+        )
+        self.assertIn(
+            "tools/import-validation/test_diff_against_reference_regions.py",
+            rpc.DEFAULT_TEST_GLOBS,
+        )
+        self.assertIn(
             "tools/import-validation/test_source_contracts.py",
             rpc.DEFAULT_TEST_GLOBS,
         )


### PR DESCRIPTION
Skill-Update: skip skill=import-design reason="coverage-only tests for existing import validation helpers; no import workflow change"