### PR TITLE
test(tools): cover local ci helper modules

### DIFF
--- a/tools/local-ci/test_git_helpers.py
+++ b/tools/local-ci/test_git_helpers.py
@@ -50,6 +50,9 @@ class GitHelpersTests(unittest.TestCase):
         self.assertEqual(run.call_count, 2)
         self.assertEqual(run.call_args_list[0].kwargs["cwd"], self.mod.ROOT)
         self.assertTrue(run.call_args_list[0].kwargs["check"])
+        self.assertEqual(run.call_args_list[0].args[0], ["git", "rev-parse", "--abbrev-ref", "HEAD"])
+        self.assertEqual(run.call_args_list[1].args[0], ["git", "rev-parse", "HEAD"])
+        self.assertTrue(run.call_args_list[1].kwargs["check"])
 
     def test_git_root_for_returns_resolved_path_or_none(self) -> None:
         with mock.patch.object(
@@ -63,8 +66,11 @@ class GitHelpersTests(unittest.TestCase):
             self.mod.subprocess,
             "run",
             return_value=subprocess.CompletedProcess(["git"], 128, stdout="", stderr="fatal"),
-        ):
+        ) as run:
             self.assertIsNone(self.mod.git_root_for(self.root))
+        self.assertEqual(run.call_args.args[0], ["git", "rev-parse", "--show-toplevel"])
+        self.assertEqual(run.call_args.kwargs["cwd"], self.root)
+        self.assertFalse(run.call_args.kwargs.get("check", False))
 
     def test_resolve_git_ref_sha_returns_commit_or_raises_detail(self) -> None:
         sha = "b" * 40
@@ -72,8 +78,18 @@ class GitHelpersTests(unittest.TestCase):
             self.mod.subprocess,
             "run",
             return_value=subprocess.CompletedProcess(["git"], 0, stdout=f"{sha}\n", stderr=""),
-        ):
+        ) as run:
             self.assertEqual(self.mod.resolve_git_ref_sha("HEAD"), sha)
+        self.assertEqual(run.call_args.args[0], ["git", "rev-parse", "--verify", "HEAD^{commit}"])
+        self.assertEqual(run.call_args.kwargs["cwd"], self.mod.ROOT)
+
+        with mock.patch.object(
+            self.mod.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(["git"], 1, stdout="stdout detail\n", stderr=""),
+        ):
+            with self.assertRaisesRegex(ValueError, "stdout detail"):
+                self.mod.resolve_git_ref_sha("missing")
 
         with mock.patch.object(
             self.mod.subprocess,
@@ -94,6 +110,8 @@ class GitHelpersTests(unittest.TestCase):
 
     def test_short_sha_handles_empty_and_long_values(self) -> None:
         self.assertEqual(self.mod.short_sha(""), "?")
+        self.assertEqual(self.mod.short_sha(None), "?")
+        self.assertEqual(self.mod.short_sha("123"), "123")
         self.assertEqual(self.mod.short_sha("1234567890abcdef"), "1234567890ab")
 
 

--- a/tools/local-ci/test_job_queue.py
+++ b/tools/local-ci/test_job_queue.py
@@ -140,16 +140,23 @@ class JobQueueTests(unittest.TestCase):
 
         normalized = self.mod.normalize_job(legacy_job)
         self.assertEqual(len(normalized["id"]), 12)
+        self.assertEqual(normalized["branch"], "feature/local-ci")
+        self.assertEqual(normalized["sha"], "abc123")
         self.assertEqual(normalized["priority"], "high")
         self.assertEqual(normalized["targets"], ["mac", "windows"])
         self.assertEqual(normalized["validation"], "smoke")
         self.assertEqual(normalized["status"], "pending")
         self.assertEqual(normalized["provenance"]["execution_kind"], "hosted")
+        self.assertEqual(normalized["submission"]["provenance"]["execution_kind"], "hosted")
 
         preserved = self.mod.normalize_job({"id": "manual-id", "targets": []})
         self.assertEqual(preserved["id"], "manual-id")
         self.assertEqual(preserved["priority"], "normal")
         self.assertEqual(preserved["validation"], "full")
+        self.assertEqual(preserved["targets"], [])
+        self.assertEqual(preserved["status"], "pending")
+        self.assertEqual(preserved["submission"]["provenance"]["execution_kind"], "direct")
+        self.assertEqual(preserved["provenance"]["execution_kind"], "direct")
 
         queue_file = self.mod.queue_path()
         self.assertEqual(self.mod.load_queue_unlocked(), [])
@@ -163,6 +170,43 @@ class JobQueueTests(unittest.TestCase):
 
         self.mod.save_queue_unlocked([normalized])
         self.assertEqual(json.loads(queue_file.read_text())[0]["id"], normalized["id"])
+        self.assertTrue(queue_file.read_text().endswith("\n"))
+
+    def test_normalize_job_prefers_top_level_provenance_and_validates_fields(self):
+        job = {
+            "id": "explicit",
+            "priority": "low",
+            "targets": ["ubuntu", "ubuntu", "mac"],
+            "status": "running",
+            "validation": "full",
+            "submission": {
+                "provenance": {
+                    "execution_kind": "hosted",
+                    "hosted_orchestrator": "github-actions",
+                    "runner_provider": "github-hosted",
+                }
+            },
+            "provenance": {
+                "execution_kind": "local",
+                "host": "dev-mac",
+            },
+        }
+
+        normalized = self.mod.normalize_job(job)
+
+        self.assertEqual(normalized["id"], "explicit")
+        self.assertEqual(normalized["priority"], "low")
+        self.assertEqual(normalized["targets"], ["mac", "ubuntu"])
+        self.assertEqual(normalized["status"], "running")
+        self.assertEqual(normalized["validation"], "full")
+        self.assertEqual(normalized["submission"]["provenance"]["execution_kind"], "hosted")
+        self.assertEqual(normalized["provenance"]["execution_kind"], "local")
+        self.assertEqual(normalized["provenance"]["host"], "dev-mac")
+
+        with self.assertRaisesRegex(ValueError, "Invalid priority"):
+            self.mod.normalize_job({"priority": "urgent"})
+        with self.assertRaisesRegex(ValueError, "Invalid validation mode"):
+            self.mod.normalize_job({"validation": "quick"})
 
 
 

--- a/tools/local-ci/test_state_paths.py
+++ b/tools/local-ci/test_state_paths.py
@@ -151,12 +151,17 @@ class StatePathsTests(unittest.TestCase):
     def test_state_paths_all_use_the_state_root(self):
         with mock.patch.dict(os.environ, {"PULP_LOCAL_CI_HOME": str(self.state_dir)}, clear=True):
             self.assertEqual(self.mod.queue_path(), self.state_dir / "queue.json")
+            self.assertEqual(self.mod.results_dir(), self.state_dir / "results")
+            self.assertEqual(self.mod.cloud_runs_dir(), self.state_dir / "cloud-runs")
             self.assertEqual(self.mod.evidence_path(), self.state_dir / "evidence.json")
+            self.assertEqual(self.mod.logs_dir(), self.state_dir / "logs")
+            self.assertEqual(self.mod.bundles_dir(), self.state_dir / "bundles")
             self.assertEqual(self.mod.prepared_dir(), self.state_dir / "prepared")
             self.assertEqual(self.mod.queue_lock_path(), self.state_dir / "queue.lock")
             self.assertEqual(self.mod.evidence_lock_path(), self.state_dir / "evidence.lock")
             self.assertEqual(self.mod.drain_lock_path(), self.state_dir / "drain.lock")
             self.assertEqual(self.mod.runner_info_path(), self.state_dir / "runner.json")
+            self.assertEqual(self.mod.job_logs_dir("job789"), self.state_dir / "logs" / "job789")
             self.assertEqual(self.mod.desktop_state_dir(), self.state_dir / "desktop-automation")
             self.assertEqual(
                 self.mod.desktop_receipts_dir(),
@@ -165,6 +170,9 @@ class StatePathsTests(unittest.TestCase):
 
     def test_state_dir_uses_platform_defaults_when_no_override_is_set(self):
         state_paths_mod = sys.modules["state_paths"]
+        with mock.patch.dict(os.environ, {"HOME": "/Users/pulp", "PULP_LOCAL_CI_HOME": "~/ci-state"}, clear=True):
+            self.assertEqual(self.mod.state_dir(), Path("/Users/pulp/ci-state"))
+
         with mock.patch.dict(os.environ, {}, clear=True), mock.patch.object(
             state_paths_mod.Path,
             "home",
@@ -214,6 +222,8 @@ class StatePathsTests(unittest.TestCase):
 
             self.assertEqual(prepared, path)
             self.assertEqual(prepared.read_text(), "")
+            self.assertTrue(prepared.parent.is_dir())
+            self.assertEqual(prepared.name, "mac.log")
 
 
 


### PR DESCRIPTION
## Coverage batch

- Adds 37 meaningful assertions across the extracted local-ci helper tests for git helpers, queue normalization, and state path/log helpers.
- Focused local coverage after rebase: `tools/local-ci/git_helpers.py` 100%, `tools/local-ci/job_queue.py` 100%, `tools/local-ci/state_paths.py` 100%.
- Branch head: `a8f37084718b2a2bf4926486b704c2eb6e4db5cf`; base: `71c5b9ce1c93377be79683dab4aa9f22cd0c3772`.

## Validation

- `python3 tools/local-ci/test_git_helpers.py`
- `python3 tools/local-ci/test_job_queue.py`
- `python3 tools/local-ci/test_state_paths.py`
- `/tmp/pulp-pycoverage-venv/bin/python tools/scripts/run_python_coverage.py --pattern 'tools/local-ci/test_git_helpers.py' --pattern 'tools/local-ci/test_job_queue.py' --pattern 'tools/local-ci/test_state_paths.py'`\n- `python3 tools/scripts/verify_cobertura_xml.py build-coverage/python/coverage.python.xml --label coverage.python.xml --hint 'python coverage lane'`\n- `diff-cover build-coverage/python/coverage.python.xml --compare-branch origin/main --fail-under 75`\n- `git diff --check`\n- `python3 tools/scripts/skill_sync_check.py`\n- `python3 tools/scripts/version_bump_check.py --mode=report`\n- CLI skew check\n\nSkill-Update: skip skill=ci reason="test-only coverage for existing local CI helpers"