### PR TITLE
test(local-ci): cover scheduler execution edges

### DIFF
--- a/tools/local-ci/test_local_ci_extra.py
+++ b/tools/local-ci/test_local_ci_extra.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import os
 import pathlib
@@ -12,6 +13,7 @@ import sys
 import tempfile
 import unittest
 from argparse import Namespace
+from contextlib import redirect_stdout
 from datetime import datetime, timezone
 from unittest import mock
 
@@ -1621,6 +1623,156 @@ class LocalCiPureHelperTests(unittest.TestCase):
         ):
             self.assertIsNone(self.mod.git_origin_http_url(self.root))
             self.assertIsNone(self.mod.git_origin_clone_url(self.root))
+
+    def test_scheduler_submission_and_target_resolution_edges(self) -> None:
+        config = {"targets": {}, "defaults": {}}
+        self.assertIs(self.mod.config_for_job_execution({"submission": {}}, config), config)
+
+        missing_config = self.root / "missing.json"
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.assertIs(
+                self.mod.config_for_job_execution({"submission": {"config_path": str(missing_config)}}, config),
+                config,
+            )
+        self.assertIn("failed to load submission config", buf.getvalue())
+
+        submitted_config = self.root / "submitted.json"
+        submitted_config.write_text(json.dumps({"targets": {"mac": {"enabled": True}}, "defaults": {"targets": "mac"}}))
+        loaded = self.mod.config_for_job_execution({"submission": {"config_path": str(submitted_config)}}, config)
+        self.assertEqual(loaded["defaults"]["targets"], "mac")
+        self.assertEqual(loaded["targets"]["mac"]["enabled"], True)
+
+        self.assertEqual(self.mod.submission_target_state({"submission": {"target_hosts": {"mac": "bad"}}}, "mac"), {})
+        self.assertEqual(
+            self.mod.submission_target_state({"submission": {"target_hosts": {"mac": {"status": "primary-up"}}}}, "mac"),
+            {"status": "primary-up"},
+        )
+
+        with mock.patch.object(self.mod, "ensure_host_reachable", return_value="live-host") as ensure:
+            self.assertEqual(
+                self.mod.resolve_ssh_target_execution(
+                    {"submission": {"target_hosts": {"ubuntu": {"status": "primary-up", "resolved_host": "u1"}}}},
+                    "ubuntu",
+                    {"host": "u0", "repo_path": "/repo"},
+                    {},
+                ),
+                ("u1", "/repo"),
+            )
+            self.assertEqual(
+                self.mod.resolve_ssh_target_execution(
+                    {"submission": {"target_hosts": {"ubuntu": {"status": "unreachable", "repo_path": "/submitted"}}}},
+                    "ubuntu",
+                    {"host": "u0", "repo_path": "/repo"},
+                    {},
+                ),
+                (None, "/submitted"),
+            )
+            self.assertEqual(
+                self.mod.resolve_ssh_target_execution(
+                    {"submission": {"target_hosts": {"ubuntu": {"status": "utm-fallback-pending", "configured_host": "fallback"}}}},
+                    "ubuntu",
+                    {"host": "u0", "repo_path": "/repo"},
+                    {"ssh_timeout": 3},
+                ),
+                ("live-host", "/repo"),
+            )
+            self.assertEqual(ensure.call_args.args[1]["host"], "fallback")
+            self.assertEqual(
+                self.mod.resolve_ssh_target_execution({}, "ubuntu", {"host": "u0", "repo_path": "/repo"}, {}),
+                ("live-host", "/repo"),
+            )
+
+    def test_scheduler_builds_unreachable_and_no_target_results(self) -> None:
+        config = {
+            "targets": {
+                "mac": {"enabled": False},
+                "ubuntu": {"enabled": True, "host": "ubuntu", "repo_path": "/repo"},
+                "windows": {"enabled": True, "host": "win", "repo_path": r"C:\Repo"},
+            },
+            "defaults": {},
+        }
+        job = self.mod.make_job("feature/offline", "d" * 40, "normal", ["mac", "ubuntu", "windows"], "run", "full")
+
+        reporters: dict[str, object] = {}
+        with mock.patch.object(self.mod, "resolve_ssh_target_execution", return_value=(None, "/repo")):
+            tasks = self.mod._build_target_tasks(job, config, progress_factory=lambda name: reporters.setdefault(name, name))
+
+        self.assertEqual([name for name, _fn in tasks], ["ubuntu", "windows"])
+        ubuntu_result = tasks[0][1]()
+        windows_result = tasks[1][1]()
+        self.assertEqual(ubuntu_result["status"], "unreachable")
+        self.assertEqual(ubuntu_result["stderr_tail"], "Host unreachable")
+        self.assertEqual(windows_result["target"], "windows")
+        self.assertEqual(windows_result["exit_code"], -1)
+        self.assertEqual(reporters, {})
+
+        no_targets_job = self.mod.make_job("feature/none", "e" * 40, "low", ["mac"], "run", "smoke")
+        result = self.mod.process_job(no_targets_job, {"targets": {"mac": {"enabled": False}}, "defaults": {}})
+        self.assertEqual(result["overall"], "pass")
+        self.assertEqual(result["results"], [])
+        self.assertNotIn("validation", result)
+        self.assertEqual(result["targets"], ["mac"])
+        self.assertIsInstance(result["provenance"], dict)
+
+    def test_scheduler_process_job_and_drain_failure_edges(self) -> None:
+        job = self.mod.make_job("feature/error", "f" * 40, "normal", ["mac"], "run", "full")
+        failing_task = [("mac", lambda: (_ for _ in ()).throw(RuntimeError("boom")))]
+        progress_snapshots = []
+
+        with mock.patch.object(self.mod, "_build_target_tasks", return_value=failing_task), \
+             mock.patch.object(self.mod, "update_runner_active_targets", side_effect=lambda _job_id, state: progress_snapshots.append(state)), \
+             mock.patch.object(self.mod, "update_job_active_targets"):
+            result = self.mod.process_job(job, {"targets": {"mac": {"enabled": True}}, "defaults": {}})
+
+        self.assertEqual(result["overall"], "fail")
+        self.assertEqual(result["results"][0]["target"], "mac")
+        self.assertEqual(result["results"][0]["status"], "error")
+        self.assertIn("boom", result["results"][0]["stderr_tail"])
+        self.assertEqual(progress_snapshots[0]["mac"]["phase"], "starting")
+        self.assertEqual(progress_snapshots[-1]["mac"]["status"], "error")
+
+        with mock.patch.object(self.mod, "file_lock", side_effect=self.mod.LockBusyError("busy")):
+            self.assertEqual(self.mod.drain_pending_jobs({"targets": {}}, blocking=False), (False, False))
+
+        queue = [self.mod.make_job("feature/boom", "a" * 40, "normal", ["mac"], "run", "full")]
+        queue[0]["id"] = "job-boom"
+        saved_results = []
+        with mock.patch.object(self.mod, "claim_next_job", side_effect=[queue[0], None]), \
+             mock.patch.object(self.mod, "process_job", side_effect=RuntimeError("explode")), \
+             mock.patch.object(self.mod, "save_result", side_effect=lambda result: saved_results.append(result) or (self.root / "result.json")), \
+             mock.patch.object(self.mod, "finalize_job") as finalize, \
+             mock.patch.object(self.mod, "write_runner_info"), \
+             mock.patch.object(self.mod, "clear_runner_info"), \
+             mock.patch.object(self.mod, "reclaim_stale_remote_validators"), \
+             mock.patch.object(self.mod, "print_result"):
+            self.assertEqual(self.mod.drain_pending_jobs({"targets": {}}, blocking=True), (True, True))
+
+        self.assertEqual(saved_results[0]["overall"], "fail")
+        self.assertEqual(saved_results[0]["results"][0]["target"], "scheduler")
+        self.assertIn("explode", saved_results[0]["results"][0]["stderr_tail"])
+        self.assertEqual(finalize.call_args.args[0], "job-boom")
+
+    def test_scheduler_cli_error_paths_report_context(self) -> None:
+        with mock.patch.object(self.mod, "load_config", side_effect=FileNotFoundError("missing config")):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                self.assertEqual(self.mod.cmd_drain(Namespace()), 1)
+        self.assertIn("missing config", buf.getvalue())
+
+        with mock.patch.object(self.mod, "load_config", return_value={"targets": {}}), \
+             mock.patch.object(self.mod, "drain_pending_jobs", return_value=(False, False)), \
+             mock.patch.object(self.mod, "current_runner_info", return_value={"active_job_id": "abc123", "active_branch": "feature/live"}):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                self.assertEqual(self.mod.cmd_drain(Namespace()), 0)
+        self.assertIn("[abc123] feature/live", buf.getvalue())
+
+        with mock.patch.object(self.mod, "load_config", side_effect=ValueError("bad targets")):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                self.assertEqual(self.mod.cmd_enqueue(Namespace(branch=None, sha=None, targets=None, priority=None, smoke=False)), 1)
+        self.assertIn("bad targets", buf.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Coverage target

- Area: `tools/local-ci/local_ci.py` scheduler / target execution helpers.
- Batch size: 41 assertion-style additions, within the requested 36-48 range.
- Base: `27724368e3e4700ae6ed643d18cf913aa8da05e0` (`origin/main` when branched and before push).
- Head: `4e58c37853d097ad164a606a479692a362420ad2`.

## Local coverage evidence

Fresh-main Python coverage showed `tools/local-ci/local_ci.py` at 72% before this batch.

After this batch:

```text
/tmp/pulp-pycoverage-venv/bin/python tools/scripts/run_python_coverage.py \
  --pattern 'tools/local-ci/test_local_ci.py' \
  --pattern 'tools/local-ci/test_local_ci_extra.py'
```

Result for the target file:

```text
tools/local-ci/local_ci.py  4347 Stmts, 1030 Miss, 1702 Branch, 329 BrPart, 73%
```

The new assertions cover existing behavior for:

- submitted config loading and fallback warnings
- submission target state normalization
- SSH target resolution for primary, unreachable, fallback-pending, and default host checks
- unreachable Ubuntu/Windows target task generation
- no-target `process_job` results
- task exception capture and progress-state flushing
- drain lock-busy and scheduler exception paths
- `cmd_drain` / `cmd_enqueue` error reporting

## Validation

```text
/tmp/pulp-pycoverage-venv/bin/python tools/local-ci/test_local_ci_extra.py
/tmp/pulp-pycoverage-venv/bin/python tools/scripts/run_python_coverage.py --pattern 'tools/local-ci/test_local_ci.py' --pattern 'tools/local-ci/test_local_ci_extra.py'
diff-cover build-coverage/python/coverage.python.xml --compare-branch=origin/main --fail-under=75 --markdown-report /tmp/pulp-local-ci-scheduler-diff-cover.md
git diff --check
source "$(git rev-parse --show-toplevel)/tools/scripts/cli_version_check.sh" && pulp_cli_version_check
git fetch origin main --prune && git rev-parse HEAD && git rev-parse origin/main
```

Diff-cover reported no uncovered changed coverable lines. CLI skew check passed silently. `HEAD` and `origin/main` matched at branch point before push.

Skill-Update: skip skill=ci reason="tests-only coverage for existing local-ci scheduler behavior"
