### PR TITLE
test(coverage): omit CI bootstrap tests from Python surface

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -108,6 +108,9 @@ ignore:
   # Targeted top-level Python helper tests live next to the tools they
   # validate, but remain test code rather than product coverage surface.
   - "tools/test_*.py"
+  # CI bootstrap tests live beside the shell scripts they validate, but
+  # remain test code and must not appear as uncovered Python source.
+  - "tools/ci/test_*.py"
   # Motion visual self-check scripts are executable test harnesses. The
   # Python coverage lane runs a pure helper unit test for the analyzer
   # instead of counting those dependency-gated scripts as product code.

--- a/tools/scripts/run_python_coverage.py
+++ b/tools/scripts/run_python_coverage.py
@@ -109,6 +109,7 @@ COVERAGE_SURFACES = (
             "tools/scripts/test_*.py",
             "tools/deps/test_*.py",
             "tools/local-ci/test_*.py",
+            "tools/ci/test_*.py",
             "tools/import-validation/test_*.py",
             "tools/packages/test_*.py",
             "tools/scripts/_*.py",

--- a/tools/scripts/test_codecov_config.py
+++ b/tools/scripts/test_codecov_config.py
@@ -125,6 +125,8 @@ class CodecovYamlStructure(unittest.TestCase):
         self.assertIn("tools/harness/visual/tests/**", set(self.doc["ignore"]))
         self.assertIn("tools/test_*.py", python_omits)
         self.assertIn("tools/test_*.py", set(self.doc["ignore"]))
+        self.assertIn("tools/ci/test_*.py", python_omits)
+        self.assertIn("tools/ci/test_*.py", set(self.doc["ignore"]))
         self.assertIn("tools/motion/visual/test_*.py", python_omits)
         self.assertIn("tools/motion/visual/test_*.py", set(self.doc["ignore"]))
 

--- a/tools/scripts/test_run_python_coverage.py
+++ b/tools/scripts/test_run_python_coverage.py
@@ -57,6 +57,7 @@ class CoveragercTests(unittest.TestCase):
                         "tools/scripts/test_*.py",
                         "tools/deps/test_*.py",
                         "tools/local-ci/test_*.py",
+                        "tools/ci/test_*.py",
                         "tools/packages/test_*.py",
                     ),
                     always_include=True,
@@ -77,6 +78,7 @@ class CoveragercTests(unittest.TestCase):
             self.assertIn("tools/test_*.py", text)
             self.assertIn("tools/scripts/test_*.py", text)
             self.assertIn("tools/local-ci/test_*.py", text)
+            self.assertIn("tools/ci/test_*.py", text)
             self.assertIn("tools/deps/_*.py", text)
             self.assertIn("tools/packages/test_*.py", text)
             self.assertIn("core/view/js/_*.py", text)
@@ -145,6 +147,8 @@ class CoveragercTests(unittest.TestCase):
             for rel_path in (
                 "tools/audit.py",
                 "tools/test_audit.py",
+                "tools/ci/bootstrap_macos_host.py",
+                "tools/ci/test_bootstrap_macos_host.py",
                 "tools/packages/freshness_check.py",
                 "tools/packages/validate_registry.py",
                 "tools/packages/_private.py",
@@ -159,6 +163,7 @@ class CoveragercTests(unittest.TestCase):
                     ["tools", "core/view/js"],
                     [
                         "tools/test_*.py",
+                        "tools/ci/test_*.py",
                         "tools/packages/_*.py",
                         "core/view/js/_*.py",
                     ],
@@ -168,6 +173,7 @@ class CoveragercTests(unittest.TestCase):
                 [path.relative_to(root).as_posix() for path in files],
                 [
                     "tools/audit.py",
+                    "tools/ci/bootstrap_macos_host.py",
                     "tools/packages/freshness_check.py",
                     "tools/packages/validate_registry.py",
                     "core/view/js/embed_js.py",

--- a/tools/scripts/test_run_python_coverage_extra.py
+++ b/tools/scripts/test_run_python_coverage_extra.py
@@ -170,6 +170,79 @@ class SurfaceExtraTests(unittest.TestCase):
         self.assertIn("source =\n    tools/scripts", text)
         self.assertIn("omit =\n    tools/scripts/test_*.py", text)
 
+    def test_broader_tools_surface_omits_first_party_test_harness_files(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            paths = [
+                "tools/audit.py",
+                "tools/check_status_ladder.py",
+                "tools/test_check_status_ladder.py",
+                "tools/ci/bootstrap_macos_host.py",
+                "tools/ci/test_bootstrap_macos_host.py",
+                "tools/scripts/run_python_coverage.py",
+                "tools/scripts/test_run_python_coverage.py",
+                "tools/deps/audit.py",
+                "tools/deps/test_audit.py",
+                "tools/local-ci/local_ci.py",
+                "tools/local-ci/test_local_ci.py",
+                "tools/import-validation/diff_against_reference.py",
+                "tools/import-validation/test_diff_against_reference.py",
+                "tools/packages/freshness_check.py",
+                "tools/packages/test_freshness_check.py",
+                "tools/sandbox-e2e/fixture.py",
+                "tools/sandbox-e2e/nested/fixture.py",
+                "tools/harness/visual/runner.py",
+                "tools/harness/visual/tests/test_runner.py",
+                "tools/motion/visual/analyze_sequence.py",
+                "tools/motion/visual/test_analyze_sequence.py",
+            ]
+            for rel_path in paths:
+                path = root / rel_path
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("print('fixture')\n", encoding="utf-8")
+
+            broader_surface = next(surface for surface in rpc.COVERAGE_SURFACES if surface.always_include)
+            omit_globs = broader_surface.resolved_omit_globs()
+            with mock.patch.object(rpc, "REPO_ROOT", root):
+                files = {
+                    path.relative_to(root).as_posix()
+                    for path in rpc._report_source_files(["tools"], list(omit_globs))
+                }
+
+        self.assertIn("tools/test_*.py", omit_globs)
+        self.assertIn("tools/ci/test_*.py", omit_globs)
+        self.assertIn("tools/scripts/test_*.py", omit_globs)
+        self.assertIn("tools/deps/test_*.py", omit_globs)
+        self.assertIn("tools/local-ci/test_*.py", omit_globs)
+        self.assertIn("tools/import-validation/test_*.py", omit_globs)
+        self.assertIn("tools/packages/test_*.py", omit_globs)
+        self.assertIn("tools/sandbox-e2e/*.py", omit_globs)
+        self.assertIn("tools/sandbox-e2e/**/*.py", omit_globs)
+        self.assertIn("tools/harness/visual/tests/*.py", omit_globs)
+        self.assertIn("tools/harness/visual/tests/**/*.py", omit_globs)
+        self.assertIn("tools/motion/visual/test_*.py", omit_globs)
+        self.assertIn("tools/audit.py", files)
+        self.assertIn("tools/check_status_ladder.py", files)
+        self.assertIn("tools/ci/bootstrap_macos_host.py", files)
+        self.assertIn("tools/scripts/run_python_coverage.py", files)
+        self.assertIn("tools/deps/audit.py", files)
+        self.assertIn("tools/local-ci/local_ci.py", files)
+        self.assertIn("tools/import-validation/diff_against_reference.py", files)
+        self.assertIn("tools/packages/freshness_check.py", files)
+        self.assertIn("tools/harness/visual/runner.py", files)
+        self.assertIn("tools/motion/visual/analyze_sequence.py", files)
+        self.assertNotIn("tools/test_check_status_ladder.py", files)
+        self.assertNotIn("tools/ci/test_bootstrap_macos_host.py", files)
+        self.assertNotIn("tools/scripts/test_run_python_coverage.py", files)
+        self.assertNotIn("tools/deps/test_audit.py", files)
+        self.assertNotIn("tools/local-ci/test_local_ci.py", files)
+        self.assertNotIn("tools/import-validation/test_diff_against_reference.py", files)
+        self.assertNotIn("tools/packages/test_freshness_check.py", files)
+        self.assertNotIn("tools/sandbox-e2e/fixture.py", files)
+        self.assertNotIn("tools/sandbox-e2e/nested/fixture.py", files)
+        self.assertNotIn("tools/harness/visual/tests/test_runner.py", files)
+        self.assertNotIn("tools/motion/visual/test_analyze_sequence.py", files)
+
 
 class CoberturaPathExtraTests(unittest.TestCase):
     def test_repo_relative_xml_filename_normalizes_backslashes_and_dot_source(self) -> None:


### PR DESCRIPTION
## Summary
- Keep `tools/ci/test_*.py` out of both Codecov and local Python coverage source surfaces.
- Preserve real `tools/ci/*.py` helper discovery so implementation files beside CI scripts still count.
- Add contract coverage for the broad tools source surface so first-party test harnesses do not reappear as uncovered product code.

## Coverage Evidence
- Base: `80164eac265addb082f3b1a72e36a116c2b04c96` (`origin/main` after #2734)
- Head: `85ed3667ff5db6f5a2a921d36228c37a2fd75cd1`
- Batch size: 36 meaningful assertion additions
- Before: `tools/ci/test_bootstrap_macos_host.py` appeared in the full Python summary as `0%`, even though it is a test harness for `tools/ci/bootstrap-macos-host.sh`.
- After: full Python coverage omits that test harness path; total remains `92%` (`15374` statements, `1022` missed, `6060` branches, `540` partial branches).
- Lowest remaining real implementation row after this batch: `tools/local-ci/local_ci.py` at `80%`.

## Validation
- `/tmp/pulp-pycoverage-venv/bin/python tools/scripts/test_run_python_coverage.py`
- `/tmp/pulp-pycoverage-venv/bin/python tools/scripts/test_run_python_coverage_extra.py`
- `/tmp/pulp-pycoverage-venv/bin/python tools/scripts/test_codecov_config.py`
- `/tmp/pulp-pycoverage-venv/bin/python tools/scripts/test_codecov_components.py`
- `/tmp/pulp-pycoverage-venv/bin/python tools/scripts/run_python_coverage.py`
- `git diff --check`
- `/Users/danielraffel/.local/bin/diff-cover build-coverage/python/coverage.python.xml --compare-branch=origin/main --fail-under=75 --markdown-report /tmp/pulp-python-coverage-perimeter-diff.md`
  - Result: no coverable source lines in this config/test-only diff.
- `source "$(git rev-parse --show-toplevel)/tools/scripts/cli_version_check.sh" && pulp_cli_version_check`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD --mode report`
  - Result: no mapped paths touched.
- Confirmed `origin/main` is an ancestor of `HEAD` after `git fetch origin main`.
