### PR TITLE
test(local-ci): cover desktop doctor edge paths

### DIFF
--- a/tools/local-ci/test_local_ci_extra.py
+++ b/tools/local-ci/test_local_ci_extra.py
@@ -1091,6 +1091,160 @@ class LocalCiPureHelperTests(unittest.TestCase):
         self.assertEqual(config["targets"]["windows"]["repo_path"], r"C:\Pulp")
         self.assertEqual(config["desktop_automation"]["targets"]["windows"]["repo_path"], r"C:\Pulp")
 
+    def test_desktop_doctor_macos_local_optional_edges(self) -> None:
+        config = {
+            "desktop_automation": {
+                "artifact_root": str(self.root / "artifacts"),
+                "targets": {
+                    "mac": {
+                        "adapter": "macos-local",
+                        "target_type": "local",
+                        "optional": {
+                            "webview_driver": True,
+                            "debug_attach": True,
+                            "video_capture": True,
+                            "frame_stats": True,
+                        },
+                    }
+                },
+            }
+        }
+        which_values = {"screencapture": None, "osascript": "/usr/bin/osascript", "lldb": "/usr/bin/lldb", "ffmpeg": None}
+
+        with mock.patch.object(self.mod.sys, "platform", "linux"):
+            with mock.patch.object(self.mod, "desktop_receipt_for", return_value=None):
+                with mock.patch.object(self.mod.shutil, "which", side_effect=lambda name: which_values.get(name)):
+                    with mock.patch.object(self.mod, "macos_accessibility_trusted", side_effect=json.JSONDecodeError("bad", "", 0)):
+                        checks = {check["name"]: check for check in self.mod.desktop_doctor_checks(config, "mac")}
+
+        self.assertTrue(checks["artifact_root"]["ok"])
+        self.assertFalse(checks["receipt"]["ok"])
+        self.assertIn("desktop install mac", checks["receipt"]["detail"])
+        self.assertFalse(checks["platform"]["ok"])
+        self.assertEqual(checks["platform"]["detail"], "running on linux")
+        self.assertFalse(checks["screencapture"]["ok"])
+        self.assertEqual(checks["screencapture"]["detail"], "missing")
+        self.assertTrue(checks["osascript"]["ok"])
+        self.assertFalse(checks["accessibility"]["ok"])
+        self.assertFalse(checks["accessibility"]["required"])
+        self.assertFalse(checks["webview_driver"]["ok"])
+        self.assertIn("webdriver_url is not set", checks["webview_driver"]["detail"])
+        self.assertTrue(checks["debug_attach"]["ok"])
+        self.assertEqual(checks["debug_attach"]["detail"], "/usr/bin/lldb")
+        self.assertFalse(checks["video_capture"]["ok"])
+        self.assertIn("ffmpeg not found", checks["video_capture"]["detail"])
+        self.assertTrue(checks["frame_stats"]["ok"])
+
+    def test_desktop_doctor_remote_linux_and_windows_edges(self) -> None:
+        config = {
+            "desktop_automation": {
+                "artifact_root": str(self.root / "artifacts"),
+                "targets": {
+                    "ubuntu": {
+                        "adapter": "linux-xvfb",
+                        "target_type": "ssh",
+                        "host": "ubuntu.example",
+                        "bootstrap": "xvfb-run",
+                    },
+                    "windows": {
+                        "adapter": "windows-session-agent",
+                        "target_type": "ssh",
+                        "host": "win.example",
+                        "repo_path": r"C:\Users\dev",
+                        "bootstrap": "scheduled-task",
+                    },
+                },
+            }
+        }
+        linux_tooling = {
+            "git_found": True,
+            "git_path": "/usr/bin/git",
+            "git_lfs_found": False,
+            "xvfb_run_found": True,
+            "xvfb_run_path": "/usr/bin/xvfb-run",
+            "xauth_found": True,
+            "xdotool_found": True,
+            "xwininfo_found": True,
+            "import_found": True,
+            "wmctrl_found": False,
+        }
+        windows_probe = {
+            "task_present": True,
+            "task_name": "PulpDesktopAutomationAgent-windows",
+            "task_state": "Ready",
+            "logged_on_user": " DEV\\alice ",
+            "session_state": " Active ",
+            "agent_root_exists": True,
+            "remote_root": r"C:\agent",
+            "jobs_dir_exists": False,
+            "jobs_dir": r"C:\agent\jobs",
+            "results_dir_exists": True,
+            "results_dir": r"C:\agent\results",
+            "script_exists": True,
+            "script_path": r"C:\agent\agent.ps1",
+        }
+        windows_tooling = {
+            "git_found": True,
+            "git_path": r"C:\Program Files\Git\cmd\git.exe",
+            "winget_found": False,
+            "gh_found": True,
+            "gh_path": r"C:\Program Files\GitHub CLI\gh.exe",
+            "gh_auth_ready": False,
+            "gh_auth_detail": "not logged in",
+        }
+        repo_probe = {
+            "repo_path": r"C:\Users\dev",
+            "repo_path_unsafe": True,
+            "repo_exists": True,
+            "git_dir_exists": True,
+            "head_exists": True,
+            "setup_exists": True,
+        }
+
+        with mock.patch.object(self.mod, "desktop_receipt_for", side_effect=[None, {"remote_bootstrap_ready": True}]):
+            with mock.patch.object(self.mod, "ssh_reachable", return_value=True):
+                with mock.patch.object(self.mod, "ssh_failure_detail", return_value="unused"):
+                    with mock.patch.object(self.mod, "probe_linux_launch_backend", return_value={"mode": "display", "display": ":99"}):
+                        with mock.patch.object(self.mod, "probe_linux_remote_tooling", return_value=linux_tooling):
+                            linux_checks = {
+                                check["name"]: check for check in self.mod.desktop_doctor_checks(config, "ubuntu")
+                            }
+                    with mock.patch.object(self.mod, "probe_windows_session_agent", return_value=windows_probe):
+                        with mock.patch.object(self.mod, "probe_windows_remote_tooling", return_value=windows_tooling):
+                            with mock.patch.object(self.mod, "probe_windows_repo_checkout", return_value=repo_probe):
+                                windows_checks = {
+                                    check["name"]: check for check in self.mod.desktop_doctor_checks(config, "windows")
+                                }
+
+        self.assertTrue(linux_checks["host"]["ok"])
+        self.assertEqual(linux_checks["host"]["detail"], "ubuntu.example")
+        self.assertTrue(linux_checks["ssh"]["ok"])
+        self.assertTrue(linux_checks["launch_backend"]["ok"])
+        self.assertIn("existing display :99", linux_checks["launch_backend"]["detail"])
+        self.assertTrue(linux_checks["git"]["ok"])
+        self.assertFalse(linux_checks["git-lfs"]["ok"])
+        self.assertIn("sudo apt-get install -y git-lfs", linux_checks["git-lfs"]["detail"])
+        self.assertFalse(linux_checks["wmctrl"]["required"])
+        self.assertTrue(linux_checks["bootstrap"]["ok"])
+        self.assertEqual(linux_checks["bootstrap"]["detail"], "xvfb-run")
+
+        self.assertTrue(windows_checks["scheduled_task"]["ok"])
+        self.assertTrue(windows_checks["scheduled_task"]["required"])
+        self.assertEqual(windows_checks["interactive_user"]["detail"], r"DEV\alice (Active)")
+        self.assertTrue(windows_checks["agent_root"]["ok"])
+        self.assertFalse(windows_checks["jobs_dir"]["ok"])
+        self.assertTrue(windows_checks["results_dir"]["ok"])
+        self.assertTrue(windows_checks["script_path"]["ok"])
+        self.assertTrue(windows_checks["git"]["ok"])
+        self.assertFalse(windows_checks["winget"]["ok"])
+        self.assertFalse(windows_checks["winget"]["required"])
+        self.assertTrue(windows_checks["gh"]["ok"])
+        self.assertFalse(windows_checks["gh_auth"]["ok"])
+        self.assertEqual(windows_checks["gh_auth"]["detail"], "not logged in")
+        self.assertFalse(windows_checks["repo_checkout"]["ok"])
+        self.assertIn("unsafe repo root", windows_checks["repo_checkout"]["detail"])
+        self.assertEqual(windows_checks["bootstrap"]["detail"], "scheduled-task")
+
     def test_desktop_source_request_manifest_and_command_edges(self) -> None:
         args = Namespace(
             source_mode="exact_sha",


### PR DESCRIPTION
## Summary
- Add focused desktop doctor coverage for macOS local, Linux SSH, and Windows session-agent targets.
- Verify diagnostic output for missing local tools, optional capabilities, Linux remote tooling, Windows agent state, GitHub CLI auth, and unsafe repo checkout remediation.
- Keep the batch scoped to `tools/local-ci/local_ci.py` doctor behavior.

## Coverage Evidence
- Base: `2b31f9f8e444917ef15121bf4f040601853f61a2` (`origin/main` after #2735)
- Head: `b8a33f6f0c6993105344b08f41140c265797fee5`
- Batch size: 44 meaningful assertion additions
- Full Python total: `92%` (`15374` statements, `1013` missed, `6060` branches, `536` partial branches)
- `tools/local-ci/local_ci.py`: remains rounded at `80%`, but misses dropped from `729` to `720` and partial branches from `347` to `343` versus the prior full Python summary.
- Lowest remaining real implementation rows: `tools/local-ci/local_ci.py` `80%`, `tools/import-validation/diff_against_reference_regions.py` `84%`, `tools/import-validation/check-source-contracts.py` `85%`, `tools/local-ci/cloud.py` `85%`.

## Validation
- `/tmp/pulp-pycoverage-venv/bin/python tools/local-ci/test_local_ci_extra.py`
- `/tmp/pulp-pycoverage-venv/bin/python tools/scripts/run_python_coverage.py`
- `git diff --check`
- `/Users/danielraffel/.local/bin/diff-cover build-coverage/python/coverage.python.xml --compare-branch=origin/main --fail-under=75 --markdown-report /tmp/pulp-python-local-ci-doctor-diff.md`
  - Result: no coverable source lines in this test-only diff.
- `source "$(git rev-parse --show-toplevel)/tools/scripts/cli_version_check.sh" && pulp_cli_version_check`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD --mode report`
  - Initial report mapped `tools/local-ci/test_local_ci_extra.py` to `ci`; commit carries `Skill-Update: skip skill=ci reason="test-only coverage for existing desktop doctor behavior"`.
- Confirmed `origin/main` is an ancestor of `HEAD` after `git fetch origin main`.
