### PR TITLE
docs(skills): AU v2 Cocoa view advertisement + embedded-view input gotchas

### DIFF
--- a/.agents/skills/auv2/SKILL.md
+++ b/.agents/skills/auv2/SKILL.md
@@ -166,6 +166,36 @@ NSView directly, so native frame changes are forwarded to `bridge->resize()`
 through that seam. Full contract: the `view-bridge` skill's "GPU view host
 auto-selection" section. (GPU-plugin-view-host work, 2026-05.)
 
+### AU v2 MUST advertise its Cocoa view, or the host shows its generic UI
+
+Selecting the GPU host (above) is necessary but NOT sufficient. The host only
+loads the Pulp editor if the AU advertises `kAudioUnitProperty_CocoaUI`. For a
+long time NO Pulp AU v2 did — `fill_cocoa_view_info()` existed but was never
+wired into `GetProperty`, so Logic/auval saw `Cocoa Views Available: 0` and fell
+back to a generic param view (the symptom: a plain "Level" slider instead of the
+real editor). Both `PulpAUEffect` and `PulpAUInstrument` now serve
+`kAudioUnitProperty_CocoaUI` in `GetProperty`/`GetPropertyInfo`. Watch-outs:
+
+- The adapters compile into the shared `pulp-format` lib **without** `PULP_AU_GUI`,
+  while the Cocoa view module (`au_v2_cocoa_view.mm`) is added per-`*_AU` target
+  **with** it. So an `#ifdef PULP_AU_GUI` in the adapter is always off. The view
+  is reached via a runtime hook `g_cocoa_view_info_filler` (hidden visibility,
+  defined in `au_v2_adapter.cpp`) that the view module's static-init registers.
+  Query it ungated; null → delegate to base (no view).
+- The **instrument** (`PulpAUInstrument`, `MusicDeviceBase`) must ALSO serve
+  `kPulpEditorContextProperty` — the Cocoa view factory reads it to reach the
+  Processor + StateStore. It originally overrode no `GetProperty` at all.
+- **`CFBundleCopyBundleURL` PAC-crashes** (`__CFCheckCFInfoPACSignature`,
+  PAC_EXCEPTION/SIGKILL) inside pointer-auth-hardened sandboxed hosts (Logic's
+  `AUHostingServiceXPC`, auval) the instant the view is queried — a hardware trap
+  a `@try` cannot catch. Use `-[NSBundle bundleURL]` instead. This was the actual
+  reason the editor never loaded even in code paths that tried.
+- The factory ObjC class name MUST be **per-plugin-unique** (`PULP_AU_COCOA_VIEW_CLASS`,
+  injected per `*_AU` target from MFR+CODE 4ccs). ObjC class names are
+  process-global; two Pulp AUs in one host would collide on a fixed name.
+- Validate with `auval -v` → expect `Cocoa Views Available: 1`. Covered by
+  `test/test_au_v2_cocoa_ui.mm`.
+
 ### `auval` automation must disable editor creation
 
 `auval` can instantiate AU editor surfaces during validation, which is

--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -613,6 +613,16 @@ Rules when touching an adapter's editor-attach path:
 - AU v2 has no host resize callback — use `host->set_resize_callback(...)` to
   forward native-NSView frame changes to `bridge->resize()`. VST3/CLAP drive
   resize through their own host size callbacks and don't need it.
+- **Embedded plugin views route their own mouse input.** The mac plugin views
+  (`PulpGpuPluginView` GPU + `PulpPluginView` CPU, in `plugin_view_host_mac.mm`)
+  implement `mouseDown/Dragged/Up/scrollWheel` → `hit_test` → `on_mouse_event` +
+  `on_mouse_down/drag/up` with W3C pointer/drag bubbling to ancestors and
+  drag-target liveness, reusing the standalone window host's `mac_geometry`
+  helpers. Without these the editor paints but swallows every click. They also
+  set flexible `autoresizingMask` so they follow host editor-container resizes.
+- **AU specifically also needs the Cocoa view advertised** (`kAudioUnitProperty_CocoaUI`)
+  or the host shows its own generic param view regardless of the host wiring —
+  see the `auv2` skill's "AU v2 MUST advertise its Cocoa view" gotcha.
 
 See `planning/2026-05-22-gpu-view-host-in-plugins.md` and its `qa/` doc.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.198.0
+    VERSION 0.199.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/au_v2_adapter.hpp
+++ b/core/format/include/pulp/format/au_v2_adapter.hpp
@@ -24,6 +24,30 @@ struct PulpEditorContext {
     pulp::state::StateStore* store;
 };
 
+/// Cross-TU Cocoa-view hook. The AU adapter classes (`PulpAUEffect`,
+/// `PulpAUInstrument`) are compiled into the shared `pulp-format` library
+/// WITHOUT `PULP_AU_GUI`, while the Cocoa view factory + its
+/// `AudioUnitCocoaViewInfo` filler live in `au_v2_cocoa_view.mm`, added
+/// per-plugin to the `*_AU` target WITH `PULP_AU_GUI`. A compile-time
+/// `#ifdef` in the adapters would therefore always be off. Instead, the GUI
+/// module registers its filler here at static-init, and the adapters read it
+/// (ungated) from `GetProperty(kAudioUnitProperty_CocoaUI)`.
+///
+/// Null when no GUI module is linked (CLAP / Standalone / headless tests) —
+/// the adapters then report no Cocoa view and the host uses its generic view.
+/// Without this hook the host is NEVER told the plugin has a custom editor —
+/// the bug ChainerSynth surfaced (the editor never showed in Logic regardless
+/// of the GPU-host wiring; only AU effects had ANY editor-context property and
+/// none advertised the Cocoa view at all).
+using CocoaViewInfoFiller = bool (*)(void*);
+extern CocoaViewInfoFiller g_cocoa_view_info_filler;
+
+/// Fills an `AudioUnitCocoaViewInfo` with the Pulp Cocoa view factory's bundle
+/// URL + class name. Defined in `au_v2_cocoa_view.mm` (PULP_AU_GUI); installed
+/// into `g_cocoa_view_info_filler` at static-init. Returns false if the factory
+/// class isn't available. `outData` must point to an `AudioUnitCocoaViewInfo`.
+bool fill_cocoa_view_info(void* outData);
+
 /// Decode a short MIDI status byte and two data bytes into a
 /// ``midi::MidiEvent``. Exposed at namespace scope so the AU-MIDI routing
 /// can be unit tested without constructing a real ``AudioComponentInstance``.

--- a/core/format/include/pulp/format/au_v2_instrument.hpp
+++ b/core/format/include/pulp/format/au_v2_instrument.hpp
@@ -21,6 +21,17 @@ public:
                               AudioUnitParameterID inParameterID,
                               AudioUnitParameterInfo& outParameterInfo) override;
 
+    // Serve the Pulp editor-context property (so the Cocoa view factory can
+    // reach this instance's Processor + StateStore) and advertise the Cocoa
+    // view to the host (kAudioUnitProperty_CocoaUI). Without these the host
+    // never loads the Pulp editor and shows its own generic param view —
+    // the AU-instrument editor gap ChainerSynth surfaced.
+    OSStatus GetPropertyInfo(AudioUnitPropertyID inID, AudioUnitScope inScope,
+                             AudioUnitElement inElement, UInt32& outDataSize,
+                             bool& outWritable) override;
+    OSStatus GetProperty(AudioUnitPropertyID inID, AudioUnitScope inScope,
+                         AudioUnitElement inElement, void* outData) override;
+
     OSStatus Initialize() override;
     void Cleanup() override;
 

--- a/core/format/src/au_v2_adapter.cpp
+++ b/core/format/src/au_v2_adapter.cpp
@@ -4,6 +4,7 @@
 
 #include <AudioUnitSDK/AUPlugInDispatch.h>
 #include <AudioToolbox/AudioUnitUtilities.h>
+#include <AudioToolbox/AudioToolbox.h>  // kAudioUnitProperty_CocoaUI, AudioUnitCocoaViewInfo
 
 #include <pulp/format/au_v2_adapter.hpp>
 #include <pulp/format/plugin_state_io.hpp>
@@ -14,6 +15,15 @@
 #include <limits>
 
 namespace pulp::format::au {
+
+// Cross-TU Cocoa-view hook (see au_v2_adapter.hpp). Hidden visibility keeps it
+// per-loaded-image so two Pulp AU components in one host don't share state.
+// Installed by au_v2_cocoa_view.mm's static-init when a *_AU target links it
+// (PULP_AU_GUI); null for CLAP / Standalone / headless builds of pulp-format.
+#if defined(__clang__) || defined(__GNUC__)
+__attribute__((visibility("hidden")))
+#endif
+CocoaViewInfoFiller g_cocoa_view_info_filler = nullptr;
 
 // Parameter IDs for the AU system map 1:1 from Pulp ParamIDs
 // AU uses AudioUnitParameterID (UInt32) which matches our state::ParamID
@@ -192,6 +202,12 @@ OSStatus PulpAUEffect::GetPropertyInfo(AudioUnitPropertyID inID, AudioUnitScope 
         outWritable = false;
         return noErr;
     }
+    if (inID == kAudioUnitProperty_CocoaUI && g_cocoa_view_info_filler) {
+        if (inScope != kAudioUnitScope_Global) return kAudioUnitErr_InvalidScope;
+        outDataSize = sizeof(AudioUnitCocoaViewInfo);
+        outWritable = false;
+        return noErr;
+    }
     return AUMIDIEffectBase::GetPropertyInfo(inID, inScope, inElement, outDataSize, outWritable);
 }
 
@@ -206,6 +222,11 @@ OSStatus PulpAUEffect::GetProperty(AudioUnitPropertyID inID, AudioUnitScope inSc
         ctx->processor = processor_.get();
         ctx->store = &store_;
         return noErr;
+    }
+    if (inID == kAudioUnitProperty_CocoaUI && g_cocoa_view_info_filler) {
+        if (inScope != kAudioUnitScope_Global) return kAudioUnitErr_InvalidScope;
+        if (!outData) return kAudioUnitErr_InvalidProperty;
+        return g_cocoa_view_info_filler(outData) ? noErr : kAudioUnitErr_InvalidProperty;
     }
     return AUMIDIEffectBase::GetProperty(inID, inScope, inElement, outData);
 }

--- a/core/format/src/au_v2_cocoa_view.mm
+++ b/core/format/src/au_v2_cocoa_view.mm
@@ -20,6 +20,19 @@
 #include <pulp/view/plugin_view_host.hpp>
 #include <pulp/runtime/log.hpp>
 
+// Per-plugin-unique Cocoa view factory class name. ObjC class names are
+// process-global, so a fixed name would collide when two Pulp AU components
+// load into one host. PulpPluginFormats.cmake injects PULP_AU_COCOA_VIEW_CLASS
+// = PulpAUCocoaViewFactory_<MFR>_<CODE> per *_AU target; the @interface, the
+// @implementation, and the name returned in AudioUnitCocoaViewInfo all derive
+// from it so the registered class and the advertised name always match.
+#ifndef PULP_AU_COCOA_VIEW_CLASS
+#define PULP_AU_COCOA_VIEW_CLASS PulpAUCocoaViewFactory
+#endif
+#define PULP_STRINGIFY_IMPL(x) #x
+#define PULP_STRINGIFY(x) PULP_STRINGIFY_IMPL(x)
+static const char* const kPulpAUCocoaViewClassName = PULP_STRINGIFY(PULP_AU_COCOA_VIEW_CLASS);
+
 // ── Ownership wrapper ──────────────────────────────────────────────────
 // Wraps C++ ownership objects in an ObjC class so they share the NSView's
 // lifetime via an associated object.
@@ -80,10 +93,10 @@ static const char kOwnershipKey = 0;
 
 // ── Cocoa View Factory ─────────────────────────────────────────────────
 
-@interface PulpAUCocoaViewFactory : NSObject <AUCocoaUIBase>
+@interface PULP_AU_COCOA_VIEW_CLASS : NSObject <AUCocoaUIBase>
 @end
 
-@implementation PulpAUCocoaViewFactory
+@implementation PULP_AU_COCOA_VIEW_CLASS
 
 - (unsigned)interfaceVersion {
     return 0;
@@ -187,32 +200,57 @@ bool fill_cocoa_view_info(void* outData) {
         if (!outData) return false;
         auto* info = static_cast<AudioUnitCocoaViewInfo*>(outData);
 
-        // Get the bundle containing the PulpAUCocoaViewFactory class
-        Class factoryClass = NSClassFromString(@"PulpAUCocoaViewFactory");
+        // Get the bundle containing the (per-plugin-unique) factory class.
+        Class factoryClass = [PULP_AU_COCOA_VIEW_CLASS class];
         if (!factoryClass) return false;
 
         NSBundle* classBundle = [NSBundle bundleForClass:factoryClass];
         if (!classBundle) return false;
 
-        // Defensive: CFBundleCopyBundleURL can crash in sandboxed XPC hosts
-        // (Logic Pro's AUHostingServiceXPC) due to PAC signature validation.
-        // Wrap in @try to prevent taking down the host process.
+        // Get the bundle URL via NSBundle's ObjC accessor, NOT
+        // CFBundleCopyBundleURL. The raw CFBundle path runs
+        // __CFCheckCFInfoPACSignature, which raises a PAC_EXCEPTION /
+        // SIGKILL in pointer-authentication-hardened, sandboxed hosts
+        // (Logic Pro's AUHostingServiceXPC, and auval). That SIGKILL is a
+        // hardware trap, NOT an NSException, so a @try can't catch it — it
+        // takes down the whole host process. `-[NSBundle bundleURL]` returns
+        // the same URL without the PAC-sensitive CFBundle access. This was
+        // the actual crash that kept the Pulp AU editor from ever loading.
         @try {
-            CFBundleRef bundle = (__bridge CFBundleRef)classBundle;
-            if (!bundle) return false;
+            NSURL* bundleURL = [classBundle bundleURL];
+            if (!bundleURL) return false;
 
-            CFURLRef url = CFBundleCopyBundleURL(bundle);
-            if (!url) return false;
+            // The class name advertised here MUST equal the @implementation's
+            // class (both derive from PULP_AU_COCOA_VIEW_CLASS) or the host
+            // can't NSClassFromString() it. Ownership: AU CF view-info
+            // properties are returned to the host, which releases them — so
+            // hand over +1-retained CF objects.
+            CFStringRef className = CFStringCreateWithCString(
+                kCFAllocatorDefault, kPulpAUCocoaViewClassName, kCFStringEncodingUTF8);
+            if (!className) return false;
 
-            info->mCocoaAUViewBundleLocation = url;
-            info->mCocoaAUViewClass[0] = CFStringCreateCopy(kCFAllocatorDefault,
-                CFSTR("PulpAUCocoaViewFactory"));
+            info->mCocoaAUViewBundleLocation = (CFURLRef)CFBridgingRetain(bundleURL);
+            info->mCocoaAUViewClass[0] = className;
             return true;
         } @catch (NSException*) {
             return false;
         }
     }
 }
+
+// Install the filler into the shared adapter hook at image load. Only *_AU
+// targets compile this TU (PULP_AU_GUI), so non-GUI builds of pulp-format
+// leave g_cocoa_view_info_filler null and report no Cocoa view.
+namespace {
+struct CocoaViewInfoFillerRegistration {
+    CocoaViewInfoFillerRegistration() { g_cocoa_view_info_filler = &fill_cocoa_view_info; }
+    ~CocoaViewInfoFillerRegistration() {
+        if (g_cocoa_view_info_filler == &fill_cocoa_view_info)
+            g_cocoa_view_info_filler = nullptr;
+    }
+};
+CocoaViewInfoFillerRegistration g_register_cocoa_view_info_filler;
+} // namespace
 
 } // namespace pulp::format::au
 

--- a/core/format/src/au_v2_instrument.cpp
+++ b/core/format/src/au_v2_instrument.cpp
@@ -4,8 +4,10 @@
 
 #include <AudioUnitSDK/AUPlugInDispatch.h>
 #include <AudioUnitSDK/AUOutputElement.h>
+#include <AudioToolbox/AudioToolbox.h>  // kAudioUnitProperty_CocoaUI, AudioUnitCocoaViewInfo
 
 #include <pulp/format/au_v2_instrument.hpp>
+#include <pulp/format/au_v2_adapter.hpp>  // kPulpEditorContextProperty, PulpEditorContext, fill_cocoa_view_info
 #include <pulp/format/plugin_state_io.hpp>
 #include <pulp/format/registry.hpp>
 #include <pulp/runtime/log.hpp>
@@ -82,6 +84,46 @@ OSStatus PulpAUInstrument::GetParameterInfo(AudioUnitScope inScope,
         outParameterInfo.unit = kAudioUnitParameterUnit_Generic;
 
     return noErr;
+}
+
+OSStatus PulpAUInstrument::GetPropertyInfo(AudioUnitPropertyID inID, AudioUnitScope inScope,
+                                           AudioUnitElement inElement, UInt32& outDataSize,
+                                           bool& outWritable)
+{
+    if (inID == kPulpEditorContextProperty) {
+        if (inScope != kAudioUnitScope_Global) return kAudioUnitErr_InvalidScope;
+        if (inElement != 0) return kAudioUnitErr_InvalidElement;
+        outDataSize = sizeof(PulpEditorContext);
+        outWritable = false;
+        return noErr;
+    }
+    if (inID == kAudioUnitProperty_CocoaUI && g_cocoa_view_info_filler) {
+        if (inScope != kAudioUnitScope_Global) return kAudioUnitErr_InvalidScope;
+        outDataSize = sizeof(AudioUnitCocoaViewInfo);
+        outWritable = false;
+        return noErr;
+    }
+    return MusicDeviceBase::GetPropertyInfo(inID, inScope, inElement, outDataSize, outWritable);
+}
+
+OSStatus PulpAUInstrument::GetProperty(AudioUnitPropertyID inID, AudioUnitScope inScope,
+                                       AudioUnitElement inElement, void* outData)
+{
+    if (inID == kPulpEditorContextProperty) {
+        if (inScope != kAudioUnitScope_Global) return kAudioUnitErr_InvalidScope;
+        if (inElement != 0) return kAudioUnitErr_InvalidElement;
+        if (!outData) return kAudioUnitErr_InvalidProperty;
+        auto* ctx = static_cast<PulpEditorContext*>(outData);
+        ctx->processor = processor_.get();
+        ctx->store = &store_;
+        return noErr;
+    }
+    if (inID == kAudioUnitProperty_CocoaUI && g_cocoa_view_info_filler) {
+        if (inScope != kAudioUnitScope_Global) return kAudioUnitErr_InvalidScope;
+        if (!outData) return kAudioUnitErr_InvalidProperty;
+        return g_cocoa_view_info_filler(outData) ? noErr : kAudioUnitErr_InvalidProperty;
+    }
+    return MusicDeviceBase::GetProperty(inID, inScope, inElement, outData);
 }
 
 OSStatus PulpAUInstrument::Initialize()

--- a/core/view/platform/mac/plugin_view_host_mac.mm
+++ b/core/view/platform/mac/plugin_view_host_mac.mm
@@ -4,12 +4,19 @@
 #if TARGET_OS_OSX
 
 #include <pulp/canvas/cg_canvas.hpp>
+#include <pulp/view/input_events.hpp>
+#include <pulp/view/widgets.hpp>
+#include <pulp/view/ui_components.hpp>
 #import <Cocoa/Cocoa.h>
 #include <algorithm>
 #include <atomic>
 
 #include <functional>
 #include <memory>
+
+// Reuse the standalone window host's coordinate/event helpers (to_local,
+// view_is_in_tree, modifiers_from_ns_flags) — same pulp-view-core lib.
+#include "window_host_mac_internal.hpp"
 
 #ifdef PULP_HAS_SKIA
 #include <pulp/render/gpu_surface.hpp>
@@ -79,9 +86,143 @@ NSArray* pulp_text_accessibility_all_elements_macos();
 - (BOOL)isAccessibilityElement { return YES; }
 @end
 
-@implementation PulpPluginView
+// ── Shared mouse-input dispatch for embedded plugin views ────────────────────
+//
+// Both PulpPluginView (CPU) and PulpGpuPluginView (GPU) embed a Pulp View tree
+// in a DAW editor window and must route native mouse events into it. This is
+// the same hit_test → on_mouse_event + on_mouse_down/drag/up + W3C pointer/drag
+// bubbling that the standalone MacGpuWindowHost's PulpView does — without it the
+// editor paints but swallows every click (the bug seen in Logic). Kept as free
+// functions so the two ObjC view classes share one implementation.
+namespace {
+
+pulp::view::Point pulp_plugin_local_point(NSView* self, NSEvent* event) {
+    NSPoint p = [self convertPoint:event.locationInWindow fromView:nil];
+    // NSView is not flipped (both plugin views return isFlipped NO): Y=0 is the
+    // bottom, so flip into the view tree's top-down space.
+    const float h = static_cast<float>(self.bounds.size.height);
+    return pulp::view::Point{static_cast<float>(p.x), h - static_cast<float>(p.y)};
+}
+
+void pulp_plugin_mouse_down(pulp::view::View* root, NSEvent* event,
+                            pulp::view::Point pt, pulp::view::View** drag_target) {
+    if (!root) return;
+    *drag_target = root->hit_test(pt);
+    pulp::view::ComboBox::notify_global_click(*drag_target);
+    if (!*drag_target) return;
+    using namespace pulp::view::mac_geometry;
+    auto local = to_local(pt, *drag_target, root);
+    if ((*drag_target)->focusable()) (*drag_target)->claim_input_focus();
+
+    pulp::view::MouseEvent me;
+    me.position = local;
+    me.window_position = pt;
+    me.button = pulp::view::MouseButton::left;
+    me.modifiers = modifiers_from_ns_flags(event.modifierFlags);
+    me.is_down = true;
+    me.click_count = static_cast<int>(event.clickCount);
+    (*drag_target)->on_mouse_event(me);
+    (*drag_target)->on_mouse_down(local);
+    // Bubble pointerdown to ancestors that registered on_pointer_event (React).
+    for (auto* b = (*drag_target)->parent(); b; b = b->parent()) {
+        if (!b->on_pointer_event) continue;
+        pulp::view::MouseEvent bme = me;
+        bme.position = to_local(pt, b, root);
+        b->on_pointer_event(bme);
+    }
+}
+
+void pulp_plugin_mouse_drag(pulp::view::View* root, pulp::view::Point pt,
+                            pulp::view::View** drag_target) {
+    using namespace pulp::view::mac_geometry;
+    if (!*drag_target || !root) return;
+    if (!view_is_in_tree(*drag_target, root)) { *drag_target = nullptr; return; }
+    auto local = to_local(pt, *drag_target, root);
+    (*drag_target)->on_mouse_drag(local);
+    if ((*drag_target)->on_drag) (*drag_target)->on_drag(local);
+    for (auto* b = (*drag_target)->parent(); b; b = b->parent()) {
+        if (!b->on_drag) continue;
+        (*b).on_drag(to_local(pt, b, root));
+    }
+}
+
+void pulp_plugin_mouse_up(pulp::view::View* root, NSEvent* event,
+                          pulp::view::Point pt, pulp::view::View** drag_target) {
+    using namespace pulp::view::mac_geometry;
+    if (!*drag_target || !root) return;
+    if (!view_is_in_tree(*drag_target, root)) { *drag_target = nullptr; return; }
+    auto local = to_local(pt, *drag_target, root);
+    auto* released = root->hit_test(pt);
+    pulp::view::View* click_target = *drag_target;
+    while (click_target && !click_target->on_click) click_target = click_target->parent();
+    auto click_handler = click_target ? click_target->on_click : std::function<void()>{};
+
+    (*drag_target)->on_mouse_up(local);
+    pulp::view::MouseEvent up;
+    up.position = local;
+    up.window_position = pt;
+    up.button = pulp::view::MouseButton::left;
+    up.modifiers = modifiers_from_ns_flags(event.modifierFlags);
+    up.is_down = false;
+    up.click_count = static_cast<int>(event.clickCount);
+    (*drag_target)->on_mouse_event(up);
+    for (auto* b = (*drag_target)->parent(); b; b = b->parent()) {
+        if (!b->on_pointer_event) continue;
+        pulp::view::MouseEvent bme = up;
+        bme.position = to_local(pt, b, root);
+        b->on_pointer_event(bme);
+    }
+    if (released == *drag_target && click_handler) click_handler();
+    *drag_target = nullptr;
+}
+
+void pulp_plugin_wheel(pulp::view::View* root, pulp::view::Point pt, NSEvent* event) {
+    if (!root) return;
+    auto* target = root->hit_test(pt);
+    if (!target) return;
+    pulp::view::MouseEvent me;
+    me.position = pt;
+    me.window_position = pt;
+    me.is_wheel = true;
+    me.scroll_delta_x = static_cast<float>(event.scrollingDeltaX);
+    me.scroll_delta_y = static_cast<float>(-event.scrollingDeltaY);
+    for (auto* v = target; v; v = v->parent()) {
+        if (auto* sv = dynamic_cast<pulp::view::ScrollView*>(v)) {
+            sv->on_mouse_event(me);
+            sv->layout_children();
+            return;
+        }
+        if (v->on_pointer_event) v->on_mouse_event(me);
+    }
+    target->on_mouse_event(me);
+}
+
+} // namespace
+
+@implementation PulpPluginView {
+    pulp::view::View* _dragTarget;  // captured at mouseDown, re-validated each event
+}
 
 - (BOOL)isFlipped { return NO; }
+- (BOOL)acceptsFirstResponder { return YES; }
+- (void)mouseDown:(NSEvent*)event {
+    if (!self.rootView) return;
+    pulp_plugin_mouse_down(self.rootView, event, pulp_plugin_local_point(self, event), &_dragTarget);
+    [self setNeedsDisplay:YES];
+}
+- (void)mouseDragged:(NSEvent*)event {
+    pulp_plugin_mouse_drag(self.rootView, pulp_plugin_local_point(self, event), &_dragTarget);
+    [self setNeedsDisplay:YES];
+}
+- (void)mouseUp:(NSEvent*)event {
+    pulp_plugin_mouse_up(self.rootView, event, pulp_plugin_local_point(self, event), &_dragTarget);
+    [self setNeedsDisplay:YES];
+}
+- (void)scrollWheel:(NSEvent*)event {
+    if (!self.rootView) return;
+    pulp_plugin_wheel(self.rootView, pulp_plugin_local_point(self, event), event);
+    [self setNeedsDisplay:YES];
+}
 - (BOOL)isAccessibilityElement { return YES; }
 - (NSAccessibilityRole)accessibilityRole { return NSAccessibilityGroupRole; }
 - (NSString*)accessibilityLabel { return @"Plugin UI"; }
@@ -247,6 +388,7 @@ public:
             NSRect frame = NSMakeRect(0, 0, size.width, size.height);
             view_ = [[PulpPluginView alloc] initWithFrame:frame];
             view_.rootView = &root_;
+            view_.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
             view_.onResize = ^(uint32_t w, uint32_t h) {
                 this->on_native_frame_changed(w, h);
             };
@@ -361,12 +503,38 @@ private:
 @property (nonatomic, copy) void (^onResize)(uint32_t, uint32_t);
 @end
 
-@implementation PulpGpuPluginView
+@implementation PulpGpuPluginView {
+    pulp::view::View* _dragTarget;  // captured at mouseDown, re-validated each event
+}
+
+- (BOOL)acceptsFirstResponder { return YES; }
+- (void)mouseDown:(NSEvent*)event {
+    if (!self.rootView) return;
+    pulp_plugin_mouse_down(self.rootView, event, pulp_plugin_local_point(self, event), &_dragTarget);
+    if (self.rootView) self.rootView->request_repaint();
+}
+- (void)mouseDragged:(NSEvent*)event {
+    pulp_plugin_mouse_drag(self.rootView, pulp_plugin_local_point(self, event), &_dragTarget);
+    if (self.rootView) self.rootView->request_repaint();
+}
+- (void)mouseUp:(NSEvent*)event {
+    pulp_plugin_mouse_up(self.rootView, event, pulp_plugin_local_point(self, event), &_dragTarget);
+    if (self.rootView) self.rootView->request_repaint();
+}
+- (void)scrollWheel:(NSEvent*)event {
+    if (!self.rootView) return;
+    pulp_plugin_wheel(self.rootView, pulp_plugin_local_point(self, event), event);
+    if (self.rootView) self.rootView->request_repaint();
+}
 
 - (instancetype)initWithFrame:(NSRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
         self.wantsLayer = YES;
+        // Follow the host's editor-container resize. AU v2 hosts (and VST3/CLAP
+        // when they resize the parent) move our frame; flexible autoresizing
+        // makes -setFrameSize: fire, which resizes the surfaces + relays out.
+        self.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
         CAMetalLayer* layer = [CAMetalLayer layer];
         layer.device = MTLCreateSystemDefaultDevice();
         layer.pixelFormat = MTLPixelFormatBGRA8Unorm;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -780,6 +780,25 @@ if(APPLE AND NOT PULP_IOS AND PULP_HAS_AUSDK)
     # std::expected). Match it here so the adapter header parses.
     set_target_properties(pulp-test-au-v2-effect PROPERTIES CXX_STANDARD 23)
     catch_discover_tests(pulp-test-au-v2-effect)
+
+    # AU v2 Cocoa editor-view advertisement (kAudioUnitProperty_CocoaUI). Compiles
+    # the Cocoa view module with PULP_AU_GUI + a test-unique factory class name and
+    # asserts the cross-TU filler registers + advertises the right, resolvable class.
+    add_executable(pulp-test-au-v2-cocoa-ui
+        test_au_v2_cocoa_ui.mm
+        ${CMAKE_SOURCE_DIR}/core/format/src/au_v2_cocoa_view.mm)
+    target_link_libraries(pulp-test-au-v2-cocoa-ui PRIVATE
+        pulp::format pulp::view Catch2::Catch2WithMain
+        "-framework AppKit" "-framework AudioToolbox" "-framework QuartzCore")
+    target_compile_definitions(pulp-test-au-v2-cocoa-ui PRIVATE
+        PULP_AU_GUI=1 PULP_AU_COCOA_VIEW_CLASS=PulpAUCocoaViewFactory_Test)
+    set_target_properties(pulp-test-au-v2-cocoa-ui PROPERTIES CXX_STANDARD 23)
+    # AudioUnitSDK 1.4 headers use std::expected (C++23). The root sets
+    # CMAKE_CXX_STANDARD=20 which wins for ObjC++ over the target CXX_STANDARD,
+    # so force C++23 explicitly on the OBJCXX sources (both .mm here).
+    target_compile_options(pulp-test-au-v2-cocoa-ui PRIVATE
+        $<$<COMPILE_LANGUAGE:OBJCXX>:-std=gnu++23>)
+    catch_discover_tests(pulp-test-au-v2-cocoa-ui)
 endif()
 
 # iOS AVAudioSession bridge (workstream 05 slice 5.2)

--- a/test/test_au_v2_cocoa_ui.mm
+++ b/test/test_au_v2_cocoa_ui.mm
@@ -1,0 +1,62 @@
+// test_au_v2_cocoa_ui.mm — AU v2 Cocoa editor-view advertisement.
+//
+// Regression test for the bug ChainerSynth surfaced: no AU v2 adapter
+// advertised kAudioUnitProperty_CocoaUI, so hosts (Logic, auval) never learned
+// the plugin had a custom editor and showed their own generic param view. The
+// fix wires a cross-TU filler hook (g_cocoa_view_info_filler) that the
+// per-target Cocoa view module registers at static-init, and gives the factory
+// class a per-plugin-unique name (PULP_AU_COCOA_VIEW_CLASS) so two Pulp AUs in
+// one host don't collide on a process-global ObjC class name.
+//
+// This test compiles au_v2_cocoa_view.mm with PULP_AU_GUI + a test-unique
+// class name and asserts the registration + the advertised view info, without
+// constructing a real AudioComponentInstance.
+
+#include <catch2/catch_test_macros.hpp>
+
+#if defined(__APPLE__) && !TARGET_OS_IPHONE
+
+#import <Foundation/Foundation.h>
+#import <AudioToolbox/AudioToolbox.h>
+#import <AudioUnit/AUCocoaUIView.h>
+
+#include <pulp/format/au_v2_adapter.hpp>
+
+TEST_CASE("AU v2 advertises a unique, resolvable Cocoa view factory",
+          "[auv2][cocoa][editor]") {
+    using namespace pulp::format::au;
+
+    // The Cocoa view module's static-init registrar installs the filler when
+    // linked (it's compiled into this test target with PULP_AU_GUI).
+    REQUIRE(g_cocoa_view_info_filler != nullptr);
+
+    AudioUnitCocoaViewInfo info{};
+    REQUIRE(g_cocoa_view_info_filler(&info));
+
+    // Bundle URL handed to the host (+1 retained; host owns/releases).
+    REQUIRE(info.mCocoaAUViewBundleLocation != nullptr);
+
+    // Advertised class name == the per-target unique name (set via the
+    // PULP_AU_COCOA_VIEW_CLASS define on this test target below).
+    REQUIRE(info.mCocoaAUViewClass[0] != nullptr);
+    NSString* className = (__bridge NSString*)info.mCocoaAUViewClass[0];
+    REQUIRE([className isEqualToString:@"PulpAUCocoaViewFactory_Test"]);
+
+    // The advertised class resolves and conforms to AUCocoaUIBase — i.e. the
+    // name we hand the host is the class we actually registered.
+    Class cls = NSClassFromString(className);
+    REQUIRE(cls != nil);
+    REQUIRE([cls conformsToProtocol:@protocol(AUCocoaUIBase)]);
+
+    // Release the +1 CF objects the filler handed us (the host would).
+    CFRelease(info.mCocoaAUViewBundleLocation);
+    CFRelease(info.mCocoaAUViewClass[0]);
+}
+
+#else
+
+TEST_CASE("AU v2 Cocoa view advertisement is mac-only", "[auv2][cocoa]") {
+    SUCCEED("Not macOS — AU v2 Cocoa view test is a no-op.");
+}
+
+#endif

--- a/tools/cmake/PulpPluginFormats.cmake
+++ b/tools/cmake/PulpPluginFormats.cmake
@@ -307,7 +307,18 @@ function(_pulp_add_au target name bundle_id version manufacturer category plugin
         "-framework CoreAudio"
         "-framework Cocoa"
     )
-    target_compile_definitions(${target}_AU PRIVATE PULP_AU_GUI=1)
+    # Per-plugin-unique Cocoa view factory class name. ObjC class names are
+    # process-global, so two Pulp AU components in one host would otherwise
+    # collide on a fixed `PulpAUCocoaViewFactory`. Derive a unique name from
+    # the manufacturer + plugin 4ccs (sanitized to a valid identifier). The
+    # @interface/@implementation in au_v2_cocoa_view.mm and the class name
+    # returned in AudioUnitCocoaViewInfo both use this define.
+    set(_pulp_au_cocoa_class_suffix "${manufacturer_code}_${plugin_code}")
+    string(REGEX REPLACE "[^A-Za-z0-9_]" "_" _pulp_au_cocoa_class_suffix
+        "${_pulp_au_cocoa_class_suffix}")
+    target_compile_definitions(${target}_AU PRIVATE
+        PULP_AU_GUI=1
+        PULP_AU_COCOA_VIEW_CLASS=PulpAUCocoaViewFactory_${_pulp_au_cocoa_class_suffix})
     # AudioUnitSDK 1.4 headers use std::expected (C++23). CMAKE_CXX_STANDARD=20
     # at the repo root is authoritative under CMake 3.24's policy — target
     # compile_features are ignored when a lower CXX_STANDARD is already set.


### PR DESCRIPTION
auv2: new 'AU v2 MUST advertise its Cocoa view' gotcha — the kAudioUnitProperty_CocoaUI
wiring (cross-TU g_cocoa_view_info_filler hook, instrument editor-context, the
CFBundleCopyBundleURL PAC crash → -[NSBundle bundleURL], per-plugin-unique factory
class name, auval 'Cocoa Views Available: 1' check).
view-bridge: embedded plugin views route their own mouse input + autoresize; AU
additionally needs the Cocoa view advertised.