### PR TITLE
test(local-ci): cover CLI scheduler branch edges

### DIFF
--- a/tools/local-ci/test_local_ci_extra.py
+++ b/tools/local-ci/test_local_ci_extra.py
@@ -131,6 +131,141 @@ class LocalCiPureHelperTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Invalid boolean value"):
             self.mod.parse_config_bool("maybe")
 
+    def test_main_dispatches_top_level_and_cloud_subcommands(self) -> None:
+        top_level_cases = [
+            (["enqueue", "feature/a", "--sha", "a" * 40, "--smoke"], "cmd_enqueue", 11),
+            (["drain"], "cmd_drain", 12),
+            (["run", "feature/a", "--targets", "mac", "--smoke"], "cmd_run", 13),
+            (["ship", "feature/a", "--base", "main"], "cmd_ship", 14),
+            (["check", "2752", "--smoke"], "cmd_check", 15),
+            (["list"], "cmd_list", 16),
+            (["bump", "job-1", "high"], "cmd_bump", 17),
+            (["cancel", "job-1"], "cmd_cancel", 18),
+            (["logs", "job-1", "--target", "mac", "--lines", "5"], "cmd_logs", 19),
+            (["cleanup", "--dry-run", "--include-prepared"], "cmd_cleanup", 20),
+            (["evidence", "feature/a", "--sha", "a" * 40], "cmd_evidence", 21),
+            (["status"], "cmd_status", 22),
+            (["desktop", "status", "mac", "--json"], "cmd_desktop", 23),
+        ]
+        for argv_tail, handler_name, expected in top_level_cases:
+            with self.subTest(handler=handler_name):
+                with mock.patch.object(sys, "argv", ["local_ci.py", *argv_tail]), \
+                     mock.patch.object(self.mod, handler_name, return_value=expected) as handler:
+                    self.assertEqual(self.mod.main(), expected)
+                    handler.assert_called_once()
+
+        cloud_cases = [
+            (["cloud", "workflows"], "cmd_cloud_workflows", 31),
+            (["cloud", "defaults"], "cmd_cloud_defaults", 32),
+            (["cloud", "history", "--workflow", "build", "--provider", "namespace"], "cmd_cloud_history", 33),
+            (["cloud", "compare", "build"], "cmd_cloud_compare", 34),
+            (["cloud", "recommend", "build"], "cmd_cloud_recommend", 35),
+            (["cloud", "run", "build", "feature/a", "--wait"], "cmd_cloud_run", 36),
+            (["cloud", "status", "latest", "--refresh"], "cmd_cloud_status", 37),
+            (["cloud", "namespace", "doctor"], "cmd_cloud_namespace_doctor", 38),
+            (["cloud", "namespace", "setup"], "cmd_cloud_namespace_setup", 39),
+        ]
+        for argv_tail, handler_name, expected in cloud_cases:
+            with self.subTest(handler=handler_name):
+                with mock.patch.object(sys, "argv", ["local_ci.py", *argv_tail]), \
+                     mock.patch.object(self.mod, handler_name, return_value=expected) as handler:
+                    self.assertEqual(self.mod.main(), expected)
+                    handler.assert_called_once()
+
+        with mock.patch.object(sys, "argv", ["local_ci.py", "cloud"]), \
+             redirect_stdout(io.StringIO()) as buf:
+            self.assertEqual(self.mod.main(), 1)
+        self.assertIn("missing cloud subcommand", buf.getvalue())
+
+        with mock.patch.object(sys, "argv", ["local_ci.py", "cloud", "namespace"]), \
+             redirect_stdout(io.StringIO()) as buf:
+            self.assertEqual(self.mod.main(), 1)
+        self.assertIn("missing cloud namespace subcommand", buf.getvalue())
+
+        with mock.patch.object(sys, "argv", ["local_ci.py"]), redirect_stdout(io.StringIO()) as buf:
+            self.assertEqual(self.mod.main(), 1)
+        self.assertIn("Local CI runner for Pulp", buf.getvalue())
+
+    def test_parser_desktop_action_source_contracts_and_defaults(self) -> None:
+        parser = self.mod.build_parser()
+
+        smoke = parser.parse_args([
+            "desktop",
+            "smoke",
+            "mac",
+            "--command",
+            "open Pulp.app",
+            "--source-mode",
+            "exact-sha",
+            "--branch",
+            "feature/a",
+            "--sha",
+            "a" * 40,
+            "--prepare-command",
+            "cmake --build build",
+            "--prepare-timeout",
+            "12.5",
+            "--capture-ui-snapshot",
+            "--click-view-id",
+            "root",
+            "--capture-before",
+            "--settle-secs",
+            "0.25",
+            "--timeout",
+            "2.5",
+            "--json",
+        ])
+        self.assertEqual(smoke.command, "desktop")
+        self.assertEqual(smoke.desktop_command, "smoke")
+        self.assertEqual(smoke.target, "mac")
+        self.assertEqual(smoke.launch_command, "open Pulp.app")
+        self.assertEqual(smoke.source_mode, "exact-sha")
+        self.assertEqual(smoke.branch, "feature/a")
+        self.assertEqual(smoke.sha, "a" * 40)
+        self.assertEqual(smoke.prepare_command, "cmake --build build")
+        self.assertEqual(smoke.prepare_timeout, 12.5)
+        self.assertTrue(smoke.capture_ui_snapshot)
+        self.assertEqual(smoke.click_view_id, "root")
+        self.assertTrue(smoke.capture_before)
+        self.assertEqual(smoke.settle_secs, 0.25)
+        self.assertEqual(smoke.timeout, 2.5)
+        self.assertTrue(smoke.json)
+
+        click = parser.parse_args(["desktop", "click", "windows", "--bundle-id", "com.pulp.App", "--click", "12,34"])
+        self.assertEqual(click.desktop_command, "click")
+        self.assertEqual(click.target, "windows")
+        self.assertEqual(click.bundle_id, "com.pulp.App")
+        self.assertEqual(click.click, "12,34")
+        self.assertEqual(click.source_mode, "live")
+        self.assertEqual(click.prepare_timeout, 900.0)
+        self.assertFalse(click.capture_ui_snapshot)
+        self.assertFalse(click.pulp_app_automation)
+
+        inspect_args = parser.parse_args([
+            "desktop",
+            "inspect",
+            "ubuntu",
+            "--bundle-id",
+            "com.pulp.Tool",
+            "--pulp-app-automation",
+            "--json",
+        ])
+        self.assertEqual(inspect_args.desktop_command, "inspect")
+        self.assertEqual(inspect_args.target, "ubuntu")
+        self.assertEqual(inspect_args.bundle_id, "com.pulp.Tool")
+        self.assertTrue(inspect_args.pulp_app_automation)
+        self.assertTrue(inspect_args.json)
+        self.assertEqual(inspect_args.source_mode, "live")
+        self.assertIsNone(inspect_args.prepare_command)
+
+        cleanup = parser.parse_args(["cleanup", "--apply", "--keep-results", "3", "--keep-logs", "4", "--keep-bundles", "5"])
+        self.assertEqual(cleanup.command, "cleanup")
+        self.assertTrue(cleanup.apply)
+        self.assertEqual(cleanup.keep_results, 3)
+        self.assertEqual(cleanup.keep_logs, 4)
+        self.assertEqual(cleanup.keep_bundles, 5)
+        self.assertFalse(cleanup.include_prepared)
+
     def test_desktop_adapter_defaults_cover_fallbacks(self) -> None:
         self.assertEqual(self.mod.infer_desktop_adapter("mac", {"type": "local"}), "macos-local")
         self.assertEqual(self.mod.infer_desktop_adapter("custom", {"type": "local"}), "local-window")
@@ -1090,6 +1225,72 @@ class LocalCiPureHelperTests(unittest.TestCase):
         self.mod.update_target_repo_path(config, "windows", r"C:\Pulp")
         self.assertEqual(config["targets"]["windows"]["repo_path"], r"C:\Pulp")
         self.assertEqual(config["desktop_automation"]["targets"]["windows"]["repo_path"], r"C:\Pulp")
+
+    def test_wait_for_job_and_ssh_reachability_cover_scheduler_edges(self) -> None:
+        with mock.patch.object(self.mod, "load_job", return_value=None), redirect_stdout(io.StringIO()) as buf:
+            self.assertEqual(self.mod.wait_for_job("missing", {}), (None, 1))
+        self.assertIn("Job not found", buf.getvalue())
+
+        with mock.patch.object(self.mod, "load_job", return_value={"status": "completed"}), \
+             redirect_stdout(io.StringIO()) as buf:
+            self.assertEqual(self.mod.wait_for_job("done", {}), (None, 1))
+        self.assertIn("without a result file", buf.getvalue())
+
+        completed_job = {"status": "completed", "result_file": str(self.root / "result.json")}
+        failed_result = {"overall": "fail"}
+        with mock.patch.object(self.mod, "load_job", return_value=completed_job), \
+             mock.patch.object(self.mod, "load_result", return_value=failed_result):
+            self.assertEqual(self.mod.wait_for_job("done", {}), (failed_result, 1))
+
+        queued_job = {"status": "running"}
+        passed_job = {"status": "completed", "result_file": str(self.root / "pass.json")}
+        passed_result = {"overall": "pass"}
+        with mock.patch.object(self.mod, "load_job", side_effect=[queued_job, passed_job]), \
+             mock.patch.object(self.mod, "drain_pending_jobs", return_value=(False, False)), \
+             mock.patch.object(self.mod, "current_runner_info", return_value={"active_job_id": "abc123", "active_branch": "feature/a"}), \
+             mock.patch.object(self.mod, "load_result", return_value=passed_result), \
+             mock.patch.object(self.mod.time, "sleep") as sleep, \
+             redirect_stdout(io.StringIO()) as buf:
+            self.assertEqual(self.mod.wait_for_job("queued", {}), (passed_result, 0))
+        self.assertIn("[abc123] feature/a", buf.getvalue())
+        sleep.assert_called_once_with(self.mod.WAIT_POLL_SECS)
+
+        with mock.patch.object(self.mod, "ssh_reachable", return_value=True):
+            self.assertEqual(self.mod.ensure_host_reachable("ubuntu", {"host": "primary"}, {}), "primary")
+        with mock.patch.object(self.mod, "ssh_reachable", side_effect=[False, True]):
+            self.assertEqual(
+                self.mod.ensure_host_reachable("ubuntu", {"host": "primary", "fallback_host": "fallback"}, {}),
+                "fallback",
+            )
+        with mock.patch.object(self.mod, "ssh_reachable", return_value=False), redirect_stdout(io.StringIO()) as buf:
+            self.assertIsNone(self.mod.ensure_host_reachable("ubuntu", {"host": "primary"}, {}))
+        self.assertIn("no UTM fallback", buf.getvalue())
+
+        fallback = {"vm_name": "Ubuntu", "boot_wait_secs": 0, "ssh_retry_secs": 10}
+        with mock.patch.object(self.mod, "ssh_reachable", side_effect=[False, True]), \
+             mock.patch.object(self.mod, "utmctl_vm_status", return_value="stopped"), \
+             mock.patch.object(self.mod, "utmctl_start", return_value=True), \
+             mock.patch.object(self.mod.time, "sleep"), \
+             mock.patch.object(self.mod.time, "time", side_effect=[0, 1]):
+            self.assertEqual(self.mod.ensure_host_reachable("ubuntu", {"host": "primary", "utm_fallback": fallback}, {}), "primary")
+
+        with mock.patch.object(self.mod, "ssh_reachable", return_value=False), \
+             mock.patch.object(self.mod, "utmctl_vm_status", return_value=None):
+            self.assertIsNone(self.mod.ensure_host_reachable("ubuntu", {"host": "primary", "utm_fallback": fallback}, {}))
+        with mock.patch.object(self.mod, "ssh_reachable", return_value=False), \
+             mock.patch.object(self.mod, "utmctl_vm_status", return_value="stopped"), \
+             mock.patch.object(self.mod, "utmctl_start", return_value=False):
+            self.assertIsNone(self.mod.ensure_host_reachable("ubuntu", {"host": "primary", "utm_fallback": fallback}, {}))
+        with mock.patch.object(self.mod, "ssh_reachable", return_value=False), \
+             mock.patch.object(self.mod, "utmctl_vm_status", return_value="started"), \
+             mock.patch.object(self.mod.time, "time", return_value=0):
+            self.assertIsNone(
+                self.mod.ensure_host_reachable(
+                    "ubuntu",
+                    {"host": "primary", "utm_fallback": {"vm_name": "Ubuntu", "ssh_retry_secs": 0}},
+                    {},
+                )
+            )
 
     def test_desktop_doctor_macos_local_optional_edges(self) -> None:
         config = {


### PR DESCRIPTION
## Summary
- add local_ci CLI dispatch coverage for every top-level and cloud subcommand path, including missing cloud namespace/default error handling
- add desktop parser contract coverage for source-mode, exact-SHA preparation, interaction, JSON, and cleanup options
- add scheduler/SSH coverage for wait_for_job result paths plus primary, fallback, UTM start, and UTM failure reachability paths

## Batch size
- 62 assertion/check lines in one coherent local-ci batch; slightly above the 36-48 target because the first slice left local_ci.py at 74.1% branch, and the added scheduler/reachability coverage pushes it above the 75% floor

## Validation
- focused: `/tmp/pulp-pycoverage-venv/bin/python tools/local-ci/test_local_ci_extra.py` (49 tests)
- full Python coverage: `/tmp/pulp-pycoverage-venv/bin/python tools/scripts/run_python_coverage.py`
- diff-cover: `/Users/danielraffel/.local/bin/diff-cover build-coverage/python/coverage.python.xml --compare-branch=origin/main --fail-under=75 --exclude '*/test_*' --exclude 'tools/local-ci/test_local_ci_extra.py'`
- diff whitespace: `git diff --check`
- CLI skew check: `pulp_cli_version_check`
- latest main confirmed before PR: branch rebased onto `origin/main` b9302852392d7a9be99e9b4d241c0bad5209565a

## Coverage evidence
- `tools/local-ci/local_ci.py`: line 86.7%, branch 75.6%
- `tools/local-ci/cloud.py`: line 91.0%, branch 83.0%
- total Python: line 94.9%, branch 90.3%

## Notes
- Shipyard local mac handoff reported the known local configure failure; GitHub/Codecov checks are being swept here for the authoritative branch coverage refresh.