### PR TITLE
test(host): cover scanner and scan cache branch edges

### DIFF
--- a/test/test_plugin_info_metadata.cpp
+++ b/test/test_plugin_info_metadata.cpp
@@ -6,7 +6,48 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/host/scanner.hpp>
 
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
 using namespace pulp::host;
+namespace fs = std::filesystem;
+
+namespace {
+
+struct ScannerScratchDir {
+    fs::path path;
+
+    explicit ScannerScratchDir(const char* stem) {
+        path = fs::temp_directory_path()
+             / (std::string("pulp-scanner-metadata-") + stem + "-"
+                + std::to_string(std::chrono::steady_clock::now()
+                                     .time_since_epoch()
+                                     .count()));
+        std::error_code ec;
+        fs::remove_all(path, ec);
+        fs::create_directories(path);
+    }
+
+    ~ScannerScratchDir() {
+        std::error_code ec;
+        fs::remove_all(path, ec);
+    }
+
+    ScannerScratchDir(const ScannerScratchDir&) = delete;
+    ScannerScratchDir& operator=(const ScannerScratchDir&) = delete;
+};
+
+void write_text(const fs::path& path, const std::string& text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream out(path, std::ios::binary);
+    REQUIRE(out.good());
+    out << text;
+}
+
+} // namespace
 
 TEST_CASE("PluginInfo default-constructs with empty metadata",
           "[host][plugin-info]") {
@@ -202,4 +243,116 @@ TEST_CASE("PluginScanner identifies bundle suffixes for each host format",
                                                   PluginFormat::CLAP));
     REQUIRE_FALSE(PluginScanner::is_plugin_bundle("/tmp/Test.clap",
                                                   PluginFormat::LV2));
+}
+
+TEST_CASE("PluginScanner honors disabled format flags without progress callbacks",
+          "[host][scanner][coverage][phase3]") {
+    PluginScanner scanner;
+    ScanOptions opts;
+    opts.scan_vst3 = false;
+    opts.scan_au = false;
+    opts.scan_clap = false;
+    opts.scan_lv2 = false;
+    opts.only_extra_paths = true;
+    opts.extra_paths.push_back("/tmp/pulp-disabled-scan-should-not-be-read");
+
+    int progress_calls = 0;
+    opts.on_progress = [&](const std::string&, int, int) {
+        ++progress_calls;
+    };
+
+    const auto plugins = scanner.scan(opts);
+    REQUIRE(plugins.empty());
+    REQUIRE(progress_calls == 0);
+}
+
+TEST_CASE("PluginScanner only_extra_paths reports each enabled format path",
+          "[host][scanner][coverage][phase3]") {
+    ScannerScratchDir scratch("empty-extra-paths");
+
+    PluginScanner scanner;
+    ScanOptions opts;
+    opts.scan_vst3 = true;
+    opts.scan_au = false;
+    opts.scan_clap = true;
+    opts.scan_lv2 = true;
+    opts.only_extra_paths = true;
+    opts.extra_paths.push_back(scratch.path.string());
+
+    std::vector<std::string> paths;
+    std::vector<int> scanned;
+    opts.on_progress = [&](const std::string& current, int scanned_count, int) {
+        paths.push_back(current);
+        scanned.push_back(scanned_count);
+    };
+
+    const auto plugins = scanner.scan(opts);
+    REQUIRE(plugins.empty());
+    REQUIRE(paths.size() == 3);
+    REQUIRE(paths[0] == scratch.path.string());
+    REQUIRE(paths[1] == scratch.path.string());
+    REQUIRE(paths[2] == scratch.path.string());
+    REQUIRE(scanned == std::vector<int>{0, 1, 2});
+}
+
+TEST_CASE("PluginScanner scans only supplied hermetic VST3 and LV2 directories",
+          "[host][scanner][coverage][phase3]") {
+    ScannerScratchDir scratch("synthetic-bundles");
+    fs::create_directories(scratch.path / "BetaSynth.vst3" / "Contents" / "Resources");
+    fs::create_directories(scratch.path / "AlphaVerb.lv2");
+    fs::create_directories(scratch.path / "Ignored.clap");
+    fs::create_directories(scratch.path / "NotAPlugin");
+    write_text(scratch.path / "AlphaVerb.lv2" / "manifest.ttl",
+               "@prefix lv2: <http://lv2plug.in/ns/lv2core#> .\n"
+               "<http://example.com/pulp/AlphaVerb> a lv2:Plugin .\n");
+
+    PluginScanner scanner;
+    ScanOptions opts;
+    opts.scan_vst3 = true;
+    opts.scan_au = false;
+    opts.scan_clap = false;
+    opts.scan_lv2 = true;
+    opts.only_extra_paths = true;
+    opts.extra_paths.push_back(scratch.path.string());
+
+    const auto plugins = scanner.scan(opts);
+    REQUIRE(plugins.size() == 2);
+    REQUIRE(plugins[0].name == "AlphaVerb");
+    REQUIRE(plugins[0].format == PluginFormat::LV2);
+    REQUIRE(plugins[0].path == (scratch.path / "AlphaVerb.lv2").string());
+    REQUIRE(plugins[0].unique_id == "http://example.com/pulp/AlphaVerb");
+    REQUIRE(plugins[1].name == "BetaSynth");
+    REQUIRE(plugins[1].format == PluginFormat::VST3);
+    REQUIRE(plugins[1].path == (scratch.path / "BetaSynth.vst3").string());
+    REQUIRE(plugins[1].unique_id == "BetaSynth");
+}
+
+TEST_CASE("PluginScanner skips missing and non-directory extra paths",
+          "[host][scanner][coverage][phase3]") {
+    ScannerScratchDir scratch("bad-extra-paths");
+    const auto plain_file = scratch.path / "plain-file.vst3";
+    write_text(plain_file, "not a directory");
+
+    PluginScanner scanner;
+    ScanOptions opts;
+    opts.scan_vst3 = true;
+    opts.scan_au = false;
+    opts.scan_clap = false;
+    opts.scan_lv2 = false;
+    opts.only_extra_paths = true;
+    opts.extra_paths = {
+        (scratch.path / "missing").string(),
+        plain_file.string(),
+    };
+
+    std::vector<std::string> progressed;
+    opts.on_progress = [&](const std::string& current, int, int) {
+        progressed.push_back(current);
+    };
+
+    const auto plugins = scanner.scan(opts);
+    REQUIRE(plugins.empty());
+    REQUIRE(progressed.size() == 2);
+    REQUIRE(progressed[0] == (scratch.path / "missing").string());
+    REQUIRE(progressed[1] == plain_file.string());
 }

--- a/test/test_scan_cache.cpp
+++ b/test/test_scan_cache.cpp
@@ -610,3 +610,85 @@ TEST_CASE("ScanCache save_to creates nested parent directories",
     std::error_code ec;
     fs::remove_all(root, ec);
 }
+
+TEST_CASE("ScanCache from_json loads entries without optional metadata",
+          "[scan_cache][codecov][phase3]") {
+    HostScanCache cache;
+    REQUIRE(cache.from_json(R"({
+        "schema_version": 1,
+        "entries": [{
+            "path": "/tmp/minimal.lv2",
+            "mtime": 11,
+            "size": 22,
+            "name": "Minimal",
+            "manufacturer": "Pulp",
+            "version": "1.0",
+            "plugin_path": "/tmp/minimal.lv2",
+            "unique_id": "http://example.com/minimal",
+            "format": "lv2"
+        }]
+    })"));
+
+    REQUIRE(cache.size() == 1);
+    const auto& entry = cache.entries().at("/tmp/minimal.lv2");
+    REQUIRE(entry.mtime == 11);
+    REQUIRE(entry.size == 22);
+    REQUIRE(entry.info.name == "Minimal");
+    REQUIRE(entry.info.format == PluginFormat::LV2);
+    REQUIRE(entry.info.is_effect);
+    REQUIRE_FALSE(entry.info.is_instrument);
+    REQUIRE(entry.info.num_inputs == 2);
+    REQUIRE(entry.info.num_outputs == 2);
+    REQUIRE(entry.info.category.empty());
+    REQUIRE(entry.info.features.empty());
+}
+
+TEST_CASE("ScanCache from_json keeps valid siblings around malformed records",
+          "[scan_cache][codecov][phase3]") {
+    HostScanCache cache;
+    REQUIRE(cache.from_json(R"({
+        "schema_version": 1,
+        "entries": [
+            {
+                "path": "/tmp/first.vst3",
+                "mtime": 1,
+                "size": 2,
+                "name": "First",
+                "manufacturer": "Pulp",
+                "version": "1.0",
+                "plugin_path": "/tmp/first.vst3",
+                "unique_id": "first-id",
+                "format": "vst3"
+            },
+            {
+                "path": "/tmp/bad-format.clap",
+                "mtime": 3,
+                "size": 4,
+                "name": "Bad",
+                "manufacturer": "Pulp",
+                "version": "1.0",
+                "plugin_path": "/tmp/bad-format.clap",
+                "unique_id": "bad-id",
+                "format": "unknown-format"
+            },
+            {
+                "path": "/tmp/second.clap",
+                "mtime": 5,
+                "size": 6,
+                "name": "Second",
+                "manufacturer": "Pulp",
+                "version": "1.0",
+                "plugin_path": "/tmp/second.clap",
+                "unique_id": "second-id",
+                "format": "clap"
+            }
+        ]
+    })"));
+
+    REQUIRE(cache.size() == 2);
+    REQUIRE(cache.entries().count("/tmp/first.vst3") == 1);
+    REQUIRE(cache.entries().count("/tmp/bad-format.clap") == 0);
+    REQUIRE(cache.entries().count("/tmp/second.clap") == 1);
+    REQUIRE(cache.entries().at("/tmp/first.vst3").info.format == PluginFormat::VST3);
+    REQUIRE(cache.entries().at("/tmp/second.clap").info.format == PluginFormat::CLAP);
+}


### PR DESCRIPTION
## Summary
- Add host scanner coverage for disabled format flags, only-extra-path reporting, hermetic VST3/LV2 discovery, and missing/non-directory extra paths.
- Add scan cache JSON coverage for entries with omitted optional metadata and malformed-record sibling preservation.
- Batch size: 41 new Catch2 assertion/check lines, within the requested 36-48 coverage-fix range.

## Validation
- `cmake --build build --target pulp-test-plugin-info-metadata pulp-test-scan-cache -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-plugin-info-metadata`
- `./build/test/pulp-test-scan-cache`
- Instrumented coverage build with `PULP_ENABLE_COVERAGE=ON` and `PULP_ENABLE_GPU=OFF` for both targets.
- Manual local diff-cover equivalent against `origin/main` at the repo 75% threshold: success; this test-only diff has no source lines with coverage information.
- `git diff --check`
- `pulp_cli_version_check`

## Base
- Based on `origin/main` `c7cf4a2265220ff78721f19b3f35086f1884d511`.
