### PR TITLE
test(osc): cover UDP and channel branch edges

### DIFF
--- a/test/test_osc.cpp
+++ b/test/test_osc.cpp
@@ -357,6 +357,44 @@ TEST_CASE("OSC Sender rejects invalid hostnames", "[osc][udp][sender]") {
     REQUIRE_FALSE(tx.is_connected());
 }
 
+TEST_CASE("OSC Sender sends caller-owned raw packets over loopback",
+          "[osc][udp][sender][coverage]") {
+    std::atomic<int> handled{0};
+    Message received;
+    std::mutex received_mutex;
+
+    Receiver rx;
+    REQUIRE(rx.listen(0, [&](const Message& msg) {
+        std::lock_guard<std::mutex> lock(received_mutex);
+        received = msg;
+        handled.fetch_add(1, std::memory_order_release);
+    }));
+    REQUIRE(rx.local_port() != 0);
+
+    Sender tx;
+    REQUIRE(tx.connect("127.0.0.1", rx.local_port()));
+
+    Message msg("/raw/sender");
+    msg.add(321);
+    const auto data = encode(msg);
+    for (int i = 0; i < 100 && handled.load(std::memory_order_acquire) == 0; ++i) {
+        REQUIRE(tx.send_raw(data.data(), data.size()));
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+
+    REQUIRE(handled.load(std::memory_order_acquire) > 0);
+    {
+        std::lock_guard<std::mutex> lock(received_mutex);
+        REQUIRE(received.address == "/raw/sender");
+        REQUIRE(received.get_int(0) == 321);
+    }
+
+    tx.disconnect();
+    rx.stop();
+    REQUIRE_FALSE(tx.is_connected());
+    REQUIRE_FALSE(rx.is_listening());
+}
+
 TEST_CASE("OSC Sender disconnects idempotently and reconnects to loopback",
           "[osc][udp][sender][codecov]") {
     std::atomic<int> handled{0};
@@ -783,6 +821,23 @@ TEST_CASE("OSC Receiver accepts an empty handler and stops cleanly",
     REQUIRE_FALSE(rx.is_listening());
 }
 
+TEST_CASE("OSC Receiver rejects binding to an already-used UDP port",
+          "[osc][udp][receiver][coverage]") {
+    Receiver first;
+    REQUIRE(first.listen(0, [](const Message&) {}));
+    const auto port = first.local_port();
+    REQUIRE(port != 0);
+
+    Receiver second;
+    REQUIRE_FALSE(second.listen(port, [](const Message&) {}));
+    REQUIRE_FALSE(second.is_listening());
+    REQUIRE(second.local_port() == 0);
+    REQUIRE(first.is_listening());
+
+    first.stop();
+    REQUIRE_FALSE(first.is_listening());
+}
+
 // ── Bundles and address patterns ────────────────────────────────────────────
 
 TEST_CASE("OSC bundle serializes and restores nested messages and bundles",
@@ -849,4 +904,22 @@ TEST_CASE("OSC address pattern rejects incomplete classes and alternatives",
 
     REQUIRE(address_matches("/track/?", "/track/A"));
     REQUIRE_FALSE(address_matches("/track/?", "/track//"));
+}
+
+TEST_CASE("OSC address pattern covers boundary backtracking failures",
+          "[osc][pattern][coverage]") {
+    REQUIRE(address_matches("/mix/*/tail", "/mix//tail"));
+    REQUIRE_FALSE(address_matches("/mix/*/tail", "/mix/a/b/tail"));
+    REQUIRE_FALSE(address_matches("/mix/*tail", "/mix/a/tail"));
+    REQUIRE_FALSE(address_matches("/mix/*tail", "/mix/tail/extra"));
+
+    REQUIRE_FALSE(address_matches("/note/[abc]", "/note/"));
+    REQUIRE_FALSE(address_matches("/note/[!abc]", "/note/a"));
+    REQUIRE(address_matches("/note/[!abc]", "/note/z"));
+    REQUIRE_FALSE(address_matches("/note/[z-a]", "/note/m"));
+
+    REQUIRE(address_matches("/{alpha,beta,gamma}/1", "/alpha/1"));
+    REQUIRE(address_matches("/{alpha,beta,gamma}/1", "/gamma/1"));
+    REQUIRE_FALSE(address_matches("/{alpha,beta,gamma}/1", "/gamma/2"));
+    REQUIRE_FALSE(address_matches("/{alpha,,gamma}/1", "/gamma/1"));
 }

--- a/test/test_osc_channel.cpp
+++ b/test/test_osc_channel.cpp
@@ -169,6 +169,21 @@ TEST_CASE("OscChannel open rejects invalid remote hosts",
     REQUIRE_FALSE(channel);
 }
 
+TEST_CASE("OscChannel open fails cleanly when requested local port is occupied",
+          "[osc_channel][lifecycle][coverage]") {
+    Receiver occupied;
+    REQUIRE(occupied.listen(0, [](const Message&) {}));
+    const auto local_port = occupied.local_port();
+    REQUIRE(local_port != 0);
+
+    auto channel = OscChannel::open("127.0.0.1", 29876, local_port);
+    REQUIRE_FALSE(channel);
+    REQUIRE(occupied.is_listening());
+
+    occupied.stop();
+    REQUIRE_FALSE(occupied.is_listening());
+}
+
 TEST_CASE("OscChannel send after close is rejected", "[osc_channel][lifecycle]") {
     auto a = open_loopback_endpoint();
     if (!a) {
@@ -185,6 +200,27 @@ TEST_CASE("OscChannel send after close is rejected", "[osc_channel][lifecycle]")
 
     const uint8_t bytes[] = {0, 0, 0, 0};
     REQUIRE_FALSE(a->send(bytes, sizeof(bytes)));
+}
+
+TEST_CASE("OscChannel accepts error callback replacement without changing state",
+          "[osc_channel][lifecycle][coverage]") {
+    auto a = open_loopback_endpoint();
+    if (!a) {
+        SUCCEED("could not open loopback UDP pair; skipping");
+        return;
+    }
+
+    int first_count = 0;
+    int second_count = 0;
+    a->on_error([&](std::string_view) { ++first_count; });
+    a->on_error([&](std::string_view) { ++second_count; });
+
+    REQUIRE(a->is_open());
+    REQUIRE(first_count == 0);
+    REQUIRE(second_count == 0);
+
+    a->close();
+    REQUIRE_FALSE(a->is_open());
 }
 
 TEST_CASE("OscChannel close is idempotent and on_closed fires exactly once",
@@ -294,6 +330,31 @@ TEST_CASE("OscChannel delivers raw send() bytes verbatim to the peer",
 
     a->close();
     b->close();
+}
+
+TEST_CASE("OscChannel leaves unhandled incoming messages as no-op deliveries",
+          "[osc_channel][raw][coverage]") {
+    auto pair = open_loopback_pair();
+    if (!pair) {
+        SUCCEED("could not open loopback UDP pair; skipping");
+        return;
+    }
+    auto& a = pair.first;
+    auto& b = pair.second;
+
+    Message msg("/no/callback");
+    msg.add(int32_t{12});
+    const auto encoded = encode(msg);
+
+    REQUIRE(a->send(encoded.data(), encoded.size()));
+    std::this_thread::sleep_for(150ms);
+    REQUIRE(a->is_open());
+    REQUIRE(b->is_open());
+
+    a->close();
+    b->close();
+    REQUIRE_FALSE(a->is_open());
+    REQUIRE_FALSE(b->is_open());
 }
 
 TEST_CASE("OscChannel message callback replacement uses latest callback",


### PR DESCRIPTION
## Summary
- Add OSC UDP sender/receiver coverage for raw packet loopback and bind-failure handling.
- Add OscChannel lifecycle coverage for occupied local ports, error callback replacement, and no-op unhandled deliveries.
- Add OSC address-pattern boundary/backtracking coverage for star, class, negation, invalid range, and alternatives.
- Batch size: 42 new Catch2 assertion/check lines, within the requested 36-48 coverage-fix range.

## Coverage Evidence
Before this batch, targeted local coverage over the OSC tests showed:
- `core/osc/src/osc_channel.cpp`: 93.75% lines, 78.57% branches.
- `core/osc/src/osc_udp.cpp`: 90.84% lines, 73.53% branches.

After this batch, the same instrumented run reports:
- `core/osc/src/osc_channel.cpp`: 97.92% lines, 85.71% branches.
- `core/osc/src/osc_udp.cpp`: 91.60% lines, 75.00% branches.

## Validation
- `cmake --build build-cov --target pulp-test-osc pulp-test-osc-bundle pulp-test-osc-channel -j$(sysctl -n hw.ncpu)`
- `./build-cov/test/pulp-test-osc`
- `./build-cov/test/pulp-test-osc-bundle`
- `./build-cov/test/pulp-test-osc-channel`
- Instrumented local coverage run for the three OSC test binaries.
- Manual local diff-cover equivalent against `origin/main` at the repo 75% threshold: success; this test-only diff has no source lines with coverage information.
- `git diff --check`
- `pulp_cli_version_check`
- Rebased onto latest `origin/main`, reran focused OSC build/tests, and pushed refreshed head so Codecov reports against the current branch SHA.

## Base
- Based on `origin/main` `89777727df2d5bdc3cd6723a5c641c104c0c4187`.
- Current head: `5ddf2f57537dbdd1c0f1c85c145ff3c1b7096b9e`.
