### PR TITLE
test(state): cover properties and migration copy edges

### DIFF
--- a/test/test_properties_file.cpp
+++ b/test/test_properties_file.cpp
@@ -2,13 +2,54 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/state/properties_file.hpp>
 #include <pulp/runtime/temporary_file.hpp>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <optional>
 #include <random>
 
 using namespace pulp::state;
 using namespace pulp::runtime;
 using Catch::Matchers::WithinAbs;
+
+class ScopedEnvVar {
+public:
+    ScopedEnvVar(const char* name, const std::string& value)
+        : name_(name) {
+        if (const char* existing = std::getenv(name)) {
+            old_value_ = existing;
+        }
+        set(name, value);
+    }
+
+    ~ScopedEnvVar() {
+        if (old_value_.has_value()) {
+            set(name_.c_str(), *old_value_);
+        } else {
+            unset(name_.c_str());
+        }
+    }
+
+private:
+    static void set(const char* name, const std::string& value) {
+#ifdef _WIN32
+        _putenv_s(name, value.c_str());
+#else
+        setenv(name, value.c_str(), 1);
+#endif
+    }
+
+    static void unset(const char* name) {
+#ifdef _WIN32
+        _putenv_s(name, "");
+#else
+        unsetenv(name);
+#endif
+    }
+
+    std::string name_;
+    std::optional<std::string> old_value_;
+};
 
 // ── PropertiesFile basic operations ─────────────────────────────────────
 
@@ -536,6 +577,42 @@ TEST_CASE("PropertiesFile successful load replaces stale values",
     REQUIRE(props.get_int("count").value_or(0) == 3);
 }
 
+TEST_CASE("PropertiesFile load coerces false and numeric JSON scalars",
+          "[state][properties][coverage][phase3-large]") {
+    TemporaryFile tmp(".json");
+    {
+        std::ofstream f(tmp.path());
+        f << R"json({"enabled":false,"voices":16,"gain":1.25,"label":"main"})json";
+    }
+
+    PropertiesFile props;
+    REQUIRE(props.load(tmp.path_string()));
+    REQUIRE(props.contains("enabled"));
+    REQUIRE(props.get_bool("enabled").has_value());
+    REQUIRE_FALSE(props.get_bool("enabled").value());
+    REQUIRE(props.get_int("voices").value_or(0) == 16);
+    REQUIRE_THAT(props.get_double("gain").value_or(0.0), WithinAbs(1.25, 0.000001));
+    REQUIRE(props.get_string("label").value_or("") == "main");
+}
+
+TEST_CASE("PropertiesFile can save to a path without a parent directory",
+          "[state][properties][coverage][phase3-large]") {
+    const std::filesystem::path path("properties_file_parentless_unit.json");
+    std::filesystem::remove(path);
+
+    PropertiesFile props;
+    props.set_string("mode", "local");
+    REQUIRE(props.save(path.string()));
+    REQUIRE(props.path() == path.string());
+    REQUIRE(std::filesystem::exists(path));
+
+    PropertiesFile reloaded;
+    REQUIRE(reloaded.load(path.string()));
+    REQUIRE(reloaded.get_string("mode").value_or("") == "local");
+
+    std::filesystem::remove(path);
+}
+
 TEST_CASE("PropertiesFile setters copy string-view keys and values",
           "[state][properties][coverage][phase3-large]") {
     std::string key = "dynamic_key";
@@ -624,4 +701,44 @@ TEST_CASE("ApplicationProperties paths are platform-appropriate", "[state][prope
 #elif defined(__linux__)
     REQUIRE(user_dir.find(".config") != std::string::npos);
 #endif
+}
+
+TEST_CASE("ApplicationProperties load reads user settings from the platform path",
+          "[state][properties][coverage][phase3-large]") {
+    TemporaryFile home_marker(".home");
+    const auto home_dir = std::filesystem::path(home_marker.path_string() + "_dir");
+    std::filesystem::create_directories(home_dir);
+#ifdef _WIN32
+    ScopedEnvVar scoped_appdata("APPDATA", home_dir.string());
+#else
+    ScopedEnvVar scoped_home("HOME", home_dir.string());
+#endif
+
+    const std::string app_name = "PulpUnitLoad";
+    const auto user_dir = std::filesystem::path(ApplicationProperties::user_settings_dir(app_name));
+    std::filesystem::create_directories(user_dir);
+    {
+        std::ofstream f(user_dir / "settings.json");
+        f << R"json({"theme":"dark","enabled":true,"voices":8,"gain":0.75})json";
+    }
+
+    ApplicationProperties app(app_name);
+    app.user_settings().set_string("stale", "old");
+    app.common_settings().set_string("scope", "common");
+
+    app.load();
+
+    REQUIRE(app.app_name() == app_name);
+    REQUIRE(app.user_settings().path().find(app_name) != std::string::npos);
+    REQUIRE(app.user_settings().path().find("settings.json") != std::string::npos);
+    REQUIRE_FALSE(app.user_settings().contains("stale"));
+    REQUIRE(app.user_settings().contains("theme"));
+    REQUIRE(app.user_settings().get_string("theme").value_or("") == "dark");
+    REQUIRE(app.user_settings().get_bool("enabled").value_or(false));
+    REQUIRE(app.user_settings().get_int("voices").value_or(0) == 8);
+    REQUIRE_THAT(app.user_settings().get_double("gain").value_or(0.0),
+                 WithinAbs(0.75, 0.000001));
+    REQUIRE(app.common_settings().get_string("scope").value_or("") == "common");
+    REQUIRE(app.common_settings().path().find(app_name) != std::string::npos);
+    REQUIRE(app.common_settings().path().find("settings.json") != std::string::npos);
 }

--- a/test/test_state.cpp
+++ b/test/test_state.cpp
@@ -1405,6 +1405,60 @@ TEST_CASE("StateStore migrations are scoped to each store instance",
     REQUIRE(second_called);
 }
 
+TEST_CASE("StateStore can copy registered migrations to a restore probe",
+          "[state][serialize][migration][coverage][phase3-large]") {
+    StateStore saved;
+    saved.set_state_version(8);
+    saved.add_parameter(make_param_info(42, "Answer", "", {0.0f, 100.0f, 10.0f}));
+    saved.set_value(42, 73.0f);
+    auto data = saved.serialize();
+
+    int source_calls = 0;
+    StateStore source_schema;
+    source_schema.set_state_version(9);
+    source_schema.add_parameter(make_param_info(42, "Answer", "", {0.0f, 100.0f, 10.0f}));
+    REQUIRE(source_schema.register_state_migration(
+        8, 9,
+        [&source_calls](std::span<const uint8_t> source_blob,
+                        std::vector<uint8_t>& migrated) {
+            ++source_calls;
+            migrated.assign(source_blob.begin(), source_blob.end());
+            write_u32_le(migrated, 4, 9);
+            const auto crc_offset = migrated.size() - 4;
+            write_u32_le(migrated, crc_offset,
+                         crc32_simple_for_test(migrated, crc_offset));
+            return true;
+        }));
+
+    StateStore probe;
+    probe.set_state_version(9);
+    probe.add_parameter(make_param_info(42, "Answer", "", {0.0f, 100.0f, 10.0f}));
+    int probe_calls = 0;
+    REQUIRE(probe.register_state_migration(
+        8, 9,
+        [&probe_calls](std::span<const uint8_t>, std::vector<uint8_t>&) {
+            ++probe_calls;
+            return false;
+        }));
+    REQUIRE_FALSE(probe.deserialize(data));
+    REQUIRE(probe_calls == 1);
+    REQUIRE(source_calls == 0);
+    REQUIRE_THAT(probe.get_value(42), WithinAbs(10.0, 0.001));
+
+    probe.copy_state_migrations_from(source_schema);
+    REQUIRE(probe.deserialize(data));
+    REQUIRE(source_calls == 1);
+    REQUIRE_THAT(probe.get_value(42), WithinAbs(73.0, 0.001));
+
+    StateStore live;
+    live.set_state_version(9);
+    live.add_parameter(make_param_info(42, "Answer", "", {0.0f, 100.0f, 10.0f}));
+    live.copy_state_migrations_from(probe);
+    REQUIRE(live.deserialize(data));
+    REQUIRE(source_calls == 2);
+    REQUIRE_THAT(live.get_value(42), WithinAbs(73.0, 0.001));
+}
+
 TEST_CASE("StateStore rejects corrupt source blobs before migration callbacks",
           "[state][serialize][migration]") {
     StateStore source;


### PR DESCRIPTION
## Summary
- Adds state/properties coverage for JSON false and numeric scalar coercion, parentless `PropertiesFile::save`, and platform-path `ApplicationProperties::load`.
- Covers `StateStore::copy_state_migrations_from` replacing a bad probe migration and reusing copied migrations for a live restore path.
- Batch size: 36 added Catch2 assertion/check lines.

## Coverage evidence
Focused state coverage on head `ee5a2e719bab763f585e3f5aaec15eb968903039` based on `origin/main` `bb87fa19655ae5ef8dab1e05bd0ecd198bbdf65d`:
- `core/state/src/properties_file.cpp`: 96.00% lines, 94.44% branches
- `core/state/src/state_migration.cpp`: 97.50% lines, 84.48% branches
- `core/state/src/store.cpp`: 96.07% lines, 82.43% branches
- Focused state suite total: 75.03% lines

## Validation
- `git diff --check`
- Pulp CLI version/skew check
- Focused tests: `pulp-test-state`, `pulp-test-properties`, `pulp-test-preset-manager`, `pulp-test-binding`, `pulp-test-state-tree`, `pulp-test-undo-manager`
- Local focused llvm-cov report over the state test binaries
- Local Shipyard mac validation rerun passed: `sy-20260523-7009d7`

## Notes
- The initial local Shipyard run failed at configure because the worktree-local ignored Shipyard override did not match the local executor key. I fixed the ignored local override and reran validation successfully; no PR files changed for that local-only setup fix.
- Codecov branch coverage is running against head `ee5a2e719bab763f585e3f5aaec15eb968903039`.