### PR TITLE
test(render): cover CPU render edge paths

### DIFF
--- a/test/test_dirty_tracker.cpp
+++ b/test/test_dirty_tracker.cpp
@@ -173,6 +173,19 @@ TEST_CASE("DirtyTracker ignores invalid viewport dimensions for promotion",
     REQUIRE(dt.dirty_rects().size() == 1);
 }
 
+TEST_CASE("DirtyTracker invalid viewport height disables promotion",
+          "[render][dirty][coverage][phase3-large]") {
+    DirtyTracker dt;
+    dt.set_viewport(100, 0, 0.01f);
+    dt.clear();
+    dt.invalidate(0, 0, 1000, 1000);
+
+    REQUIRE(dt.is_dirty());
+    REQUIRE_FALSE(dt.needs_full_repaint());
+    REQUIRE(dt.dirty_rects().size() == 1);
+    REQUIRE(dt.bounds().w == Catch::Approx(1000.0f));
+}
+
 TEST_CASE("DirtyTracker does not promote to full repaint without viewport", "[render][dirty][issue-646]") {
     DirtyTracker dt;
     dt.clear();
@@ -198,12 +211,46 @@ TEST_CASE("DirtyTracker coalesces nearby non-overlapping rects", "[render][dirty
     REQUIRE(b.h == Catch::Approx(10.0f));
 }
 
+TEST_CASE("DirtyTracker coalesces sparse overlaps through the intersects path",
+          "[render][dirty][coverage][phase3-large]") {
+    DirtyTracker dt;
+    dt.clear();
+
+    for (int i = 0; i < 15; ++i) {
+        dt.invalidate(static_cast<float>(i * 1000), 0, 1, 1);
+    }
+    dt.invalidate(0, 50, 1000, 1);
+    REQUIRE(dt.dirty_rects().size() == 16);
+
+    dt.invalidate(500, 0, 1, 1000);
+
+    REQUIRE(dt.dirty_rects().size() < 16);
+    auto b = dt.bounds();
+    REQUIRE(b.x == Catch::Approx(0.0f));
+    REQUIRE(b.y == Catch::Approx(0.0f));
+    REQUIRE(b.w >= 14001.0f);
+    REQUIRE(b.h == Catch::Approx(1000.0f));
+}
+
 TEST_CASE("Rect intersection", "[render][dirty]") {
     DirtyTracker::Rect a{0, 0, 10, 10};
     DirtyTracker::Rect b{5, 5, 10, 10};
     DirtyTracker::Rect c{20, 20, 10, 10};
     REQUIRE(a.intersects(b));
     REQUIRE_FALSE(a.intersects(c));
+}
+
+TEST_CASE("Rect intersection rejects each separating axis independently",
+          "[render][dirty][coverage][phase3-large]") {
+    DirtyTracker::Rect a{10, 10, 10, 10};
+    DirtyTracker::Rect left{0, 12, 5, 5};
+    DirtyTracker::Rect above{12, 0, 5, 5};
+    DirtyTracker::Rect below{12, 25, 5, 5};
+
+    REQUIRE_FALSE(a.intersects(left));
+    REQUIRE_FALSE(a.intersects(above));
+    REQUIRE_FALSE(a.intersects(below));
+    REQUIRE(a.area() == Catch::Approx(100.0f));
 }
 
 TEST_CASE("Rect merge returns bounding box", "[render][dirty][issue-646]") {

--- a/test/test_gpu_render_time.cpp
+++ b/test/test_gpu_render_time.cpp
@@ -151,3 +151,33 @@ TEST_CASE("RenderPassManager frame GPU time is independent of per-pass GPU time"
     REQUIRE(rpm.gpu_render_time_ms() == 8.0f);
     REQUIRE_FALSE(rpm.has_gpu_timing());
 }
+
+TEST_CASE("RenderPassManager handles empty pass endings and disabled budgets",
+          "[render][gpu-render-time][render-pass][coverage][phase3-large]") {
+    RenderPassManager rpm;
+    REQUIRE(rpm.budget() == 16.67f);
+    REQUIRE(rpm.frame_count() == 0);
+    REQUIRE(rpm.current_pass() == RenderPassType::background);
+
+    rpm.end_pass(12.0f, 4);
+    rpm.end_frame();
+    REQUIRE(rpm.passes().empty());
+    REQUIRE(rpm.total_time_ms() == 0.0f);
+    REQUIRE_FALSE(rpm.over_budget());
+
+    rpm.set_budget(0.0f);
+    REQUIRE(rpm.budget() == 0.0f);
+    rpm.begin_frame();
+    rpm.begin_pass(RenderPassType::post_effects);
+    rpm.end_pass(100.0f, 7);
+    rpm.end_frame();
+
+    REQUIRE(rpm.frame_count() == 1);
+    REQUIRE(rpm.current_pass() == RenderPassType::post_effects);
+    REQUIRE(rpm.passes().size() == 1);
+    REQUIRE(rpm.passes().front().type == RenderPassType::post_effects);
+    REQUIRE(rpm.passes().front().draw_calls == 7);
+    REQUIRE(rpm.passes().front().cpu_time_ms() == 100.0f);
+    REQUIRE(rpm.total_time_ms() == 100.0f);
+    REQUIRE_FALSE(rpm.over_budget());
+}

--- a/test/test_gpu_timestamps.cpp
+++ b/test/test_gpu_timestamps.cpp
@@ -377,9 +377,11 @@ TEST_CASE("GpuTimestamps degrades gracefully with no device",
     REQUIRE_FALSE(ok);
     REQUIRE(ts.support() == GpuTimestampSupport::unsupported);
     REQUIRE_FALSE(ts.available());
+    REQUIRE(ts.pass_capacity() == 0);
 
     // No-ops, no crash.
     ts.begin_frame(4);
+    REQUIRE(ts.pass_capacity() == 0);
     REQUIRE(ts.read_back().empty());
 
     // resolve() with no device (and a null instance) must report false

--- a/test/test_render_loop.cpp
+++ b/test/test_render_loop.cpp
@@ -167,6 +167,20 @@ TEST_CASE("RenderLoop factory selects the timer backend under force-timer",
     REQUIRE(loop->backend() == RenderLoopBackend::timer);
 }
 
+TEST_CASE("RenderLoop explicit timer factory is deterministic",
+          "[render][loop][coverage][phase3-large]") {
+    auto loop = RenderLoop::create_timer_loop();
+    REQUIRE(loop != nullptr);
+    REQUIRE_FALSE(loop->is_running());
+    REQUIRE(loop->backend() == RenderLoopBackend::timer);
+
+    std::atomic<int> frames{0};
+    loop->start([&]() { frames.fetch_add(1, std::memory_order_relaxed); });
+    REQUIRE(wait_for_count(frames, 1));
+    loop->stop();
+    REQUIRE_FALSE(loop->is_running());
+}
+
 TEST_CASE("render_loop_backend_is_vsync distinguishes real vblank sources",
           "[render][loop][vblank][slice-16]") {
     // The four native backends are real vblank sources; only the timer


### PR DESCRIPTION
## Summary
- Add render CPU edge coverage for dirty tracking, render-loop timer construction, render pass accounting, and GPU timestamp CPU stubs.
- Batch size: 36 new assertion/check lines.
- Scope: render-only tests; no production behavior changes.

## Coverage evidence
Focused llvm-cov render suite after this branch:
- core/render/include/pulp/render/dirty_tracker.hpp: 100.00% lines, 100.00% branches
- core/render/include/pulp/render/gpu_graph.hpp: 100.00% lines, 100.00% branches
- core/render/include/pulp/render/gpu_render_time.hpp: 100.00% lines, 100.00% branches
- core/render/include/pulp/render/gpu_timestamps.hpp: 97.22% lines, 96.43% branches
- core/render/include/pulp/render/render_pass.hpp: 100.00% lines, 100.00% branches
- core/render/include/pulp/render/texture_atlas.hpp: 97.96% lines, 87.50% branches
- core/render/src/gpu_timestamps.cpp: 100.00% lines
- core/render/src/render_loop.cpp: 96.77% lines, 88.46% branches
- core/render/src/texture_atlas.cpp: 100.00% lines, 95.83% branches
- Focused total: 91.05% lines, 91.85% branches

## Validation
- `git diff --check`
- `source tools/scripts/cli_version_check.sh && pulp_cli_version_check`
- `cmake -S . -B build-cov -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_TESTS=ON -DCMAKE_CXX_FLAGS="-fprofile-instr-generate -fcoverage-mapping" -DCMAKE_C_FLAGS="-fprofile-instr-generate -fcoverage-mapping"`
- Focused tests passed: `pulp-test-dirty-tracker`, `pulp-test-partial-rendering-poc`, `pulp-test-gpu-graph`, `pulp-test-render-loop`, `pulp-test-texture-atlas`, `pulp-test-gpu-render-time`, `pulp-test-gpu-timestamps`

## Branch freshness
- Base: `a8aa47fdc68b18a471e8ef47588bc4f8ef0bd98a` (`origin/main`)
- Head: `1520feba7d759069cac3fe46fd66780916206d42`
- Confirmed branch is based on latest `origin/main` before opening.