### PR TITLE
feat(view): port WindowHost::set_design_viewport + aspect-lock to PluginViewHost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.201.0
+    VERSION 0.202.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/plugin_view_host.hpp
+++ b/core/view/include/pulp/view/plugin_view_host.hpp
@@ -130,6 +130,40 @@ public:
     virtual void detach_native_child_view(NativeViewHandle child_view) {
         (void) child_view;
     }
+
+    // ── Design viewport (mirrors WindowHost::set_design_viewport) ────────
+    //
+    // Constrain editor resize to a fixed aspect ratio. Plugin hosts do not
+    // own the OS window — the DAW does — so the host does not enforce the
+    // aspect itself. Per-format resize-hint paths drive enforcement (CLAP
+    // `gui_get_resize_hints.preserve_aspect_ratio`, VST3
+    // `checkSizeConstraint`). Stored here purely for API parity with
+    // `WindowHost` and so adapters can query it. Default no-op.
+    virtual void set_fixed_aspect_ratio(float ratio) { (void)ratio; }
+
+    // Set a fixed "design viewport". When set, the root view's bounds are
+    // pinned to (design_w x design_h) and paint applies an aspect-correct
+    // scale + letterbox translate to fit the current host size. Mouse
+    // coordinates receive the inverse transform before hit-test. Pass
+    // (0, 0) to disable.
+    //
+    // This mirrors `WindowHost::set_design_viewport` (see that method's
+    // docs for the design rationale, pulp #59/#63/#64/#65) so that an
+    // editor that already paints correctly in the standalone window host
+    // paints identically when embedded by a DAW. Default no-op for hosts
+    // that do not implement design-viewport scaling.
+    virtual void set_design_viewport(float design_w, float design_h) {
+        (void)design_w;
+        (void)design_h;
+    }
+
+    // Inverse-map a host-space point (e.g. mouse coords in host logical
+    // pixels) into root-view space using the active design-viewport
+    // transform. Identity when no design viewport is set. Exposed so
+    // native event handlers AND unit tests can exercise the same
+    // inverse-transform path without needing AppKit / UIKit event
+    // delivery.
+    virtual Point window_to_root_point(Point pt) const { return pt; }
 };
 
 } // namespace pulp::view

--- a/core/view/platform/mac/plugin_view_host_mac.mm
+++ b/core/view/platform/mac/plugin_view_host_mac.mm
@@ -7,6 +7,7 @@
 #include <pulp/view/input_events.hpp>
 #include <pulp/view/widgets.hpp>
 #include <pulp/view/ui_components.hpp>
+#include <pulp/view/window_host.hpp>  // compute_design_viewport_transform
 #import <Cocoa/Cocoa.h>
 #include <algorithm>
 #include <atomic>
@@ -45,6 +46,16 @@ NSArray* pulp_text_accessibility_all_elements_macos();
 @interface PulpPluginView : NSView
 @property (nonatomic, assign) pulp::view::View* rootView;
 @property (nonatomic, copy) void (^onResize)(uint32_t, uint32_t);
+// Inverse-design-viewport transform applied to every host-space input point
+// before hit_test, mirroring the standalone PulpView. nil = identity. Set
+// by MacPluginViewHost::set_design_viewport.
+@property (nonatomic, copy) pulp::view::Point (^pointTransform)(pulp::view::Point);
+// Design viewport size. (0, 0) = identity (paint at host bounds, no
+// scale/letterbox). When set, drawRect pins root to (designW, designH),
+// fills letterbox bars at host bounds, then translate+scale before
+// paint_all so the rendered surface matches the standalone host.
+@property (nonatomic, assign) float designW;
+@property (nonatomic, assign) float designH;
 @end
 
 // ── Accessibility element wrapping a Pulp View ──────────────────────────────
@@ -239,22 +250,30 @@ void pulp_plugin_wheel(pulp::view::View* root, pulp::view::Point pt, NSEvent* ev
 
 - (BOOL)isFlipped { return NO; }
 - (BOOL)acceptsFirstResponder { return YES; }
+// Resolve a window-space event into root-view coords, applying the inverse
+// design-viewport transform when set so hit_test runs against design-space
+// coords. Identity when pointTransform is nil.
+- (pulp::view::Point)localPoint:(NSEvent*)event {
+    auto pt = pulp_plugin_local_point(self, event);
+    if (self.pointTransform) pt = self.pointTransform(pt);
+    return pt;
+}
 - (void)mouseDown:(NSEvent*)event {
     if (!self.rootView) return;
-    pulp_plugin_mouse_down(self.rootView, event, pulp_plugin_local_point(self, event), &_dragTarget);
+    pulp_plugin_mouse_down(self.rootView, event, [self localPoint:event], &_dragTarget);
     [self setNeedsDisplay:YES];
 }
 - (void)mouseDragged:(NSEvent*)event {
-    pulp_plugin_mouse_drag(self.rootView, pulp_plugin_local_point(self, event), &_dragTarget);
+    pulp_plugin_mouse_drag(self.rootView, [self localPoint:event], &_dragTarget);
     [self setNeedsDisplay:YES];
 }
 - (void)mouseUp:(NSEvent*)event {
-    pulp_plugin_mouse_up(self.rootView, event, pulp_plugin_local_point(self, event), &_dragTarget);
+    pulp_plugin_mouse_up(self.rootView, event, [self localPoint:event], &_dragTarget);
     [self setNeedsDisplay:YES];
 }
 - (void)scrollWheel:(NSEvent*)event {
     if (!self.rootView) return;
-    pulp_plugin_wheel(self.rootView, pulp_plugin_local_point(self, event), event);
+    pulp_plugin_wheel(self.rootView, [self localPoint:event], event);
     [self setNeedsDisplay:YES];
 }
 - (BOOL)isAccessibilityElement { return YES; }
@@ -298,21 +317,38 @@ void pulp_plugin_wheel(pulp::view::View* root, pulp::view::Point pt, NSEvent* ev
 - (void)drawRect:(NSRect)dirtyRect {
     CGContextRef ctx = [[NSGraphicsContext currentContext] CGContext];
     NSRect bounds = self.bounds;
+    const float bw = static_cast<float>(bounds.size.width);
+    const float bh = static_cast<float>(bounds.size.height);
 
-    pulp::canvas::CoreGraphicsCanvas canvas(ctx,
-        static_cast<float>(bounds.size.width),
-        static_cast<float>(bounds.size.height));
+    pulp::canvas::CoreGraphicsCanvas canvas(ctx, bw, bh);
 
-    // Clear with theme background
+    // Clear at host bounds so the letterbox bars (visible only when the
+    // OS aspect-lock briefly diverges during user drag) share the design
+    // background color — same approach as the standalone host.
     canvas.set_fill_color(pulp::canvas::Color::rgba8(30, 30, 46));
-    canvas.fill_rect(0, 0,
-        static_cast<float>(bounds.size.width),
-        static_cast<float>(bounds.size.height));
+    canvas.fill_rect(0, 0, bw, bh);
 
-    if (self.rootView) {
-        self.rootView->set_bounds({0, 0,
-            static_cast<float>(bounds.size.width),
-            static_cast<float>(bounds.size.height)});
+    if (!self.rootView) return;
+
+    // Design viewport: pin root at design size, apply translate+scale
+    // before paint_all so content renders proportionally. Otherwise lay
+    // out at host bounds. Mirrors WindowHost paint_scene.
+    float sx, sy, tx, ty;
+    const bool has_viewport = self.designW > 0.0f && self.designH > 0.0f &&
+        pulp::view::WindowHost::compute_design_viewport_transform(
+            bw, bh, self.designW, self.designH, sx, sy, tx, ty);
+
+    if (has_viewport) {
+        self.rootView->set_bounds({0, 0, self.designW, self.designH});
+        self.rootView->layout_children();
+        const int saved = canvas.save_count();
+        canvas.save();
+        canvas.translate(tx, ty);
+        canvas.scale(sx, sy);
+        self.rootView->paint_all(canvas);
+        canvas.restore_to_count(saved);
+    } else {
+        self.rootView->set_bounds({0, 0, bw, bh});
         self.rootView->layout_children();
         self.rootView->paint_all(canvas);
     }
@@ -499,6 +535,43 @@ public:
         detach_child_view_from_host(view_, child_view);
     }
 
+    void set_fixed_aspect_ratio(float ratio) override {
+        // Plugin hosts don't own the OS window — DAW enforces the aspect
+        // via the per-format resize-hint path. Stored for API parity.
+        fixed_aspect_ratio_ = ratio;
+    }
+
+    void set_design_viewport(float design_w, float design_h) override {
+        design_viewport_w_ = design_w;
+        design_viewport_h_ = design_h;
+        @autoreleasepool {
+            view_.designW = design_w;
+            view_.designH = design_h;
+            if (design_w > 0.0f && design_h > 0.0f) {
+                __block MacPluginViewHost* host = this;
+                view_.pointTransform = ^pulp::view::Point(pulp::view::Point pt) {
+                    return host->window_to_root_point(pt);
+                };
+            } else {
+                view_.pointTransform = nil;
+            }
+            [view_ setNeedsDisplay:YES];
+        }
+    }
+
+    Point window_to_root_point(Point pt) const override {
+        float sx, sy, tx, ty;
+        if (!WindowHost::compute_design_viewport_transform(
+                static_cast<float>(size_.width),
+                static_cast<float>(size_.height),
+                design_viewport_w_, design_viewport_h_,
+                sx, sy, tx, ty)) {
+            return pt;
+        }
+        if (sx <= 0.0f || sy <= 0.0f) return pt;
+        return { (pt.x - tx) / sx, (pt.y - ty) / sy };
+    }
+
     void on_native_frame_changed(uint32_t w, uint32_t h) {
         if (w == size_.width && h == size_.height) return;
         if (w == 0 || h == 0) return;
@@ -511,6 +584,12 @@ private:
     Size size_;
     PulpPluginView* view_ = nil;
     std::function<void(uint32_t, uint32_t)> resize_cb_;
+    // Design viewport: when (>0, >0) root paints at design size and the
+    // canvas applies translate+scale to fit the host bounds. Mouse coords
+    // are inverse-mapped via window_to_root_point().
+    float design_viewport_w_ = 0.0f;
+    float design_viewport_h_ = 0.0f;
+    float fixed_aspect_ratio_ = 0.0f;
 };
 
 } // namespace pulp::view (close for ObjC declarations)
@@ -535,6 +614,10 @@ private:
 @property (nonatomic, copy) void (^onWindowChange)(void);
 @property (nonatomic, copy) void (^onBackingChange)(void);
 @property (nonatomic, copy) void (^onResize)(uint32_t, uint32_t);
+// Inverse-design-viewport transform applied to every host-space input point
+// before hit_test. Mirrors PulpPluginView + the standalone host. nil =
+// identity. Set by MacGpuPluginViewHost::set_design_viewport.
+@property (nonatomic, copy) pulp::view::Point (^pointTransform)(pulp::view::Point);
 @end
 
 @implementation PulpGpuPluginView {
@@ -542,22 +625,29 @@ private:
 }
 
 - (BOOL)acceptsFirstResponder { return YES; }
+// Resolve a window-space event into root-view coords, applying the inverse
+// design-viewport transform when set.
+- (pulp::view::Point)localPoint:(NSEvent*)event {
+    auto pt = pulp_plugin_local_point(self, event);
+    if (self.pointTransform) pt = self.pointTransform(pt);
+    return pt;
+}
 - (void)mouseDown:(NSEvent*)event {
     if (!self.rootView) return;
-    pulp_plugin_mouse_down(self.rootView, event, pulp_plugin_local_point(self, event), &_dragTarget);
+    pulp_plugin_mouse_down(self.rootView, event, [self localPoint:event], &_dragTarget);
     if (self.rootView) self.rootView->request_repaint();
 }
 - (void)mouseDragged:(NSEvent*)event {
-    pulp_plugin_mouse_drag(self.rootView, pulp_plugin_local_point(self, event), &_dragTarget);
+    pulp_plugin_mouse_drag(self.rootView, [self localPoint:event], &_dragTarget);
     if (self.rootView) self.rootView->request_repaint();
 }
 - (void)mouseUp:(NSEvent*)event {
-    pulp_plugin_mouse_up(self.rootView, event, pulp_plugin_local_point(self, event), &_dragTarget);
+    pulp_plugin_mouse_up(self.rootView, event, [self localPoint:event], &_dragTarget);
     if (self.rootView) self.rootView->request_repaint();
 }
 - (void)scrollWheel:(NSEvent*)event {
     if (!self.rootView) return;
-    pulp_plugin_wheel(self.rootView, pulp_plugin_local_point(self, event), event);
+    pulp_plugin_wheel(self.rootView, [self localPoint:event], event);
     if (self.rootView) self.rootView->request_repaint();
 }
 
@@ -774,6 +864,41 @@ public:
         detach_child_view_from_host(metal_view_, child_view);
     }
 
+    void set_fixed_aspect_ratio(float ratio) override {
+        // Plugin hosts don't own the OS window — DAW enforces via the
+        // per-format resize-hint path. Stored for API parity.
+        fixed_aspect_ratio_ = ratio;
+    }
+
+    void set_design_viewport(float design_w, float design_h) override {
+        design_viewport_w_ = design_w;
+        design_viewport_h_ = design_h;
+        @autoreleasepool {
+            if (design_w > 0.0f && design_h > 0.0f) {
+                __block MacGpuPluginViewHost* host = this;
+                metal_view_.pointTransform = ^pulp::view::Point(pulp::view::Point pt) {
+                    return host->window_to_root_point(pt);
+                };
+            } else {
+                metal_view_.pointTransform = nil;
+            }
+        }
+        needs_repaint_.store(true, std::memory_order_relaxed);
+    }
+
+    Point window_to_root_point(Point pt) const override {
+        float sx, sy, tx, ty;
+        if (!WindowHost::compute_design_viewport_transform(
+                static_cast<float>(size_.width),
+                static_cast<float>(size_.height),
+                design_viewport_w_, design_viewport_h_,
+                sx, sy, tx, ty)) {
+            return pt;
+        }
+        if (sx <= 0.0f || sy <= 0.0f) return pt;
+        return { (pt.x - tx) / sx, (pt.y - ty) / sy };
+    }
+
 private:
     View& root_;
     Size size_;
@@ -794,6 +919,12 @@ private:
     // teardown is a no-op (DAW teardown order is not under our control).
     std::shared_ptr<std::atomic<bool>> alive_;
     int frame_ok_count_ = 0;
+    // Design viewport: when (>0, >0) root paints at design size and the
+    // Skia canvas applies translate+scale to fit the host bounds. Mouse
+    // coords are inverse-mapped via window_to_root_point().
+    float design_viewport_w_ = 0.0f;
+    float design_viewport_h_ = 0.0f;
+    float fixed_aspect_ratio_ = 0.0f;
 
     void init_gpu(float width, float height) {
         gpu_surface_ = render::GpuSurface::create_dawn();
@@ -838,13 +969,34 @@ private:
     }
 
     void paint_scene(canvas::Canvas& canvas) {
-        float w = static_cast<float>(size_.width);
-        float h = static_cast<float>(size_.height);
-        root_.set_bounds({0, 0, w, h});
-        root_.layout_children();
+        const float w = static_cast<float>(size_.width);
+        const float h = static_cast<float>(size_.height);
+
+        // Letterbox bg first at host bounds so the bars (visible only when
+        // the OS aspect-lock briefly diverges during user drag) share the
+        // design background color. Matches the standalone host.
         canvas.set_fill_color(pulp::canvas::Color::rgba8(30, 30, 46));
         canvas.fill_rect(0, 0, w, h);
-        root_.paint_all(canvas);
+
+        float sx, sy, tx, ty;
+        const bool has_viewport = design_viewport_w_ > 0.0f && design_viewport_h_ > 0.0f &&
+            WindowHost::compute_design_viewport_transform(
+                w, h, design_viewport_w_, design_viewport_h_, sx, sy, tx, ty);
+
+        if (has_viewport) {
+            root_.set_bounds({0, 0, design_viewport_w_, design_viewport_h_});
+            root_.layout_children();
+            const int saved = canvas.save_count();
+            canvas.save();
+            canvas.translate(tx, ty);
+            canvas.scale(sx, sy);
+            root_.paint_all(canvas);
+            canvas.restore_to_count(saved);
+        } else {
+            root_.set_bounds({0, 0, w, h});
+            root_.layout_children();
+            root_.paint_all(canvas);
+        }
     }
 
     // Render one frame. When capture buffers are supplied, the rendered

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -865,6 +865,29 @@ pulp_add_test_suite(pulp-test-view-size-aspect LIBRARIES pulp::format)
 # fixed-design content into the current window.
 pulp_add_test_suite(pulp-test-view-design-viewport LIBRARIES pulp::view)
 
+# PluginViewHost design-viewport wiring (mac CPU + GPU). The pure
+# math is already pinned by `pulp-test-view-design-viewport`; this
+# target covers the new PluginViewHost virtuals (set_design_viewport,
+# set_fixed_aspect_ratio, window_to_root_point) and that the mac CPU
+# host inverse-maps mouse coords before hit_test. GPU section soft-
+# skips without Dawn / a window server. Foundation for CLAP
+# gui_get_resize_hints + VST3 checkSizeConstraint resize negotiation.
+if(APPLE AND NOT PULP_IOS)
+    add_executable(pulp-test-plugin-view-host-design-viewport
+        test_plugin_view_host_design_viewport.mm)
+    target_link_libraries(pulp-test-plugin-view-host-design-viewport PRIVATE
+        pulp::view pulp::canvas Catch2::Catch2WithMain "-framework AppKit")
+    if(PULP_HAS_SKIA)
+        target_link_libraries(pulp-test-plugin-view-host-design-viewport
+            PRIVATE pulp::render skia::skia)
+        target_compile_definitions(pulp-test-plugin-view-host-design-viewport
+            PRIVATE PULP_HAS_SKIA=1)
+        target_include_directories(pulp-test-plugin-view-host-design-viewport
+            PRIVATE ${SKIA_INCLUDE_DIRS})
+    endif()
+    catch_discover_tests(pulp-test-plugin-view-host-design-viewport)
+endif()
+
 # pulp-internal #70 — design-tool viewport resolver probe-layout
 # pattern. Locks in the yoga-measured-height path that the design-tool
 # example uses to auto-size its window for grid + row trees where

--- a/test/test_plugin_view_host_design_viewport.mm
+++ b/test/test_plugin_view_host_design_viewport.mm
@@ -1,0 +1,199 @@
+// test_plugin_view_host_design_viewport.mm — port of WindowHost's
+// set_design_viewport + aspect-lock contract onto PluginViewHost.
+//
+// pulp #59/#63/#64/#65 originated this on the standalone WindowHost; the
+// math is already pinned by test_view_design_viewport.cpp. This file
+// covers the PluginViewHost wiring: the new virtuals (set_design_viewport,
+// set_fixed_aspect_ratio, window_to_root_point) and that the mac CPU and
+// GPU hosts apply the inverse transform to host-space input points before
+// hit-test. Without these, CLAP gui_get_resize_hints / VST3
+// checkSizeConstraint can request a proportional resize and the editor
+// still mis-routes clicks at the new size — the kind of silent failure
+// that only surfaces inside a DAW.
+//
+// Tag [plugin-view-host][design-viewport]. Mac-only (the implementations
+// being tested live in plugin_view_host_mac.mm). GPU section soft-skips
+// when Dawn / a window server is unavailable.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <pulp/canvas/canvas.hpp>
+#include <pulp/view/plugin_view_host.hpp>
+#include <pulp/view/view.hpp>
+#include <pulp/view/window_host.hpp>
+
+#if defined(__APPLE__)
+#import <Cocoa/Cocoa.h>
+#endif
+
+using namespace pulp::view;
+using Catch::Approx;
+
+#if defined(__APPLE__)
+
+namespace {
+
+// Pumps the Cocoa run loop a few ticks so -viewDidMoveToWindow fires +
+// the GPU host's display link drives a first frame. Mirrors the helper
+// in test_plugin_editor_host_smoke_mac.mm.
+void pump_run_loop(int frames) {
+    for (int i = 0; i < frames; ++i) {
+        @autoreleasepool {
+            [[NSRunLoop currentRunLoop]
+                runMode:NSDefaultRunLoopMode
+                beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.02]];
+        }
+    }
+}
+
+bool looks_like_png(const std::vector<uint8_t>& d) {
+    return d.size() > 8 && d[0] == 0x89 && d[1] == 'P' && d[2] == 'N' && d[3] == 'G';
+}
+
+}  // namespace
+
+TEST_CASE("PluginViewHost (mac CPU) — set_design_viewport + inverse hit-test",
+          "[plugin-view-host][design-viewport][mac][cpu]") {
+    @autoreleasepool {
+        View root;
+        PluginViewHost::Options opts;
+        opts.size = {1800u, 1040u};
+        opts.use_gpu = false;
+        auto host = PluginViewHost::create(root, opts);
+        REQUIRE(host != nullptr);
+
+        SECTION("default — window_to_root_point is identity") {
+            pulp::view::Point in{500.0f, 300.0f};
+            pulp::view::Point out = host->window_to_root_point(in);
+            REQUIRE(out.x == Approx(in.x));
+            REQUIRE(out.y == Approx(in.y));
+        }
+
+        SECTION("matching aspect (1800x1040 host, 900x520 design) — scale 2") {
+            host->set_design_viewport(900.0f, 520.0f);
+
+            // Window-space origin → design-space origin.
+            pulp::view::Point at_origin = host->window_to_root_point({0.0f, 0.0f});
+            REQUIRE(at_origin.x == Approx(0.0f).margin(0.01f));
+            REQUIRE(at_origin.y == Approx(0.0f).margin(0.01f));
+
+            // Window-space center → design-space center.
+            pulp::view::Point at_center = host->window_to_root_point({900.0f, 520.0f});
+            REQUIRE(at_center.x == Approx(450.0f).margin(0.01f));
+            REQUIRE(at_center.y == Approx(260.0f).margin(0.01f));
+
+            // Arbitrary: window-space (200, 200) at scale=2 → design (100, 100).
+            pulp::view::Point arbitrary = host->window_to_root_point({200.0f, 200.0f});
+            REQUIRE(arbitrary.x == Approx(100.0f).margin(0.01f));
+            REQUIRE(arbitrary.y == Approx(100.0f).margin(0.01f));
+        }
+
+        SECTION("host wider than design — letterbox tx > 0") {
+            host->set_size(1800, 900);
+            host->set_design_viewport(900.0f, 520.0f);
+            const float s = 900.0f / 520.0f;             // height-limited
+            const float tx = (1800.0f - 900.0f * s) * 0.5f;
+
+            // The left edge of the design surface lives at window-x = tx, so
+            // window (tx, 0) → design (0, 0). A point inside the letterbox
+            // bar maps to a NEGATIVE design-x.
+            pulp::view::Point edge = host->window_to_root_point({tx, 0.0f});
+            REQUIRE(edge.x == Approx(0.0f).margin(0.05f));
+            REQUIRE(edge.y == Approx(0.0f).margin(0.05f));
+
+            pulp::view::Point bar = host->window_to_root_point({tx * 0.5f, 0.0f});
+            REQUIRE(bar.x < 0.0f);
+        }
+
+        SECTION("reset (0, 0) restores identity") {
+            host->set_design_viewport(900.0f, 520.0f);
+            host->set_design_viewport(0.0f, 0.0f);
+            pulp::view::Point identity = host->window_to_root_point({500.0f, 300.0f});
+            REQUIRE(identity.x == Approx(500.0f));
+            REQUIRE(identity.y == Approx(300.0f));
+        }
+
+        SECTION("set_fixed_aspect_ratio is API-parity no-op (no enforcement)") {
+            // The plugin host doesn't own the OS window; aspect enforcement
+            // is the per-format resize-hint path's job. Make sure the call
+            // doesn't crash and doesn't affect window_to_root_point.
+            host->set_fixed_aspect_ratio(900.0f / 520.0f);
+            host->set_design_viewport(900.0f, 520.0f);
+            pulp::view::Point at_center = host->window_to_root_point({900.0f, 520.0f});
+            REQUIRE(at_center.x == Approx(450.0f).margin(0.01f));
+            REQUIRE(at_center.y == Approx(260.0f).margin(0.01f));
+        }
+    }
+}
+
+#if defined(PULP_HAS_SKIA)
+
+TEST_CASE("PluginViewHost (mac GPU) — set_design_viewport renders + inverse-maps",
+          "[plugin-view-host][design-viewport][mac][gpu][skia]") {
+    @autoreleasepool {
+        // Hidden NSWindow so the GPU host's CAMetalLayer can acquire a
+        // drawable for capture_back_buffer_png. Soft-skip if no window
+        // server is available (e.g. CI lane without a desktop session).
+        NSWindow* window =
+            [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 1800, 1040)
+                                        styleMask:NSWindowStyleMaskBorderless
+                                          backing:NSBackingStoreBuffered
+                                            defer:NO];
+        if (!window || !window.contentView) {
+            SUCCEED("No Cocoa window — GPU design-viewport smoke skipped.");
+            return;
+        }
+
+        View root;
+        root.set_requires_gpu_host(true);
+        root.set_background_color(pulp::canvas::Color::rgba8(200, 50, 50));
+
+        PluginViewHost::Options opts;
+        opts.size = {1800u, 1040u};
+        opts.use_gpu = true;
+        auto host = PluginViewHost::create(root, opts);
+        REQUIRE(host != nullptr);
+
+        if (!host->is_gpu_backed()) {
+            // Dawn/Metal adapter not available — host fell back to CPU.
+            SUCCEED("No Dawn/Metal adapter — GPU design-viewport smoke skipped.");
+            [window close];
+            return;
+        }
+
+        // Set the design viewport BEFORE attach so the first paint already
+        // uses the transform — this is what CLAP gui_set_size will need to
+        // do before -viewDidMoveToWindow fires for first paint.
+        host->set_design_viewport(900.0f, 520.0f);
+        host->attach_to_parent((__bridge void*)window.contentView);
+        pump_run_loop(5);
+
+        auto png = host->capture_back_buffer_png();
+        INFO("captured PNG bytes: " << png.size());
+        REQUIRE_FALSE(png.empty());
+        REQUIRE(looks_like_png(png));
+
+        // Inverse mapping consistent with the math (and identical to the
+        // CPU host — proves both hosts share the formula).
+        pulp::view::Point at_center = host->window_to_root_point({900.0f, 520.0f});
+        REQUIRE(at_center.x == Approx(450.0f).margin(0.01f));
+        REQUIRE(at_center.y == Approx(260.0f).margin(0.01f));
+
+        // Resize the host — window_to_root_point must use the NEW size when
+        // re-computing the inverse transform (CLAP gui_set_size path).
+        host->set_size(900, 520);
+        pump_run_loop(3);
+        pulp::view::Point identity_after_resize = host->window_to_root_point({450.0f, 260.0f});
+        REQUIRE(identity_after_resize.x == Approx(450.0f).margin(0.01f));
+        REQUIRE(identity_after_resize.y == Approx(260.0f).margin(0.01f));
+
+        host->detach();
+        host.reset();
+        [window close];
+    }
+}
+
+#endif  // PULP_HAS_SKIA
+
+#endif  // __APPLE__


### PR DESCRIPTION
Adds the design-viewport / aspect-lock API contract from WindowHost
(pulp #59/#63/#64/#65) onto PluginViewHost so the same fixed-design
scaling-and-letterboxing behavior that the standalone host uses is
available to DAW-embedded editors. Foundation for proportional+locked
resize negotiation through CLAP gui_get_resize_hints +
VST3 checkSizeConstraint (follow-up PRs).

New virtuals on PluginViewHost (no-op defaults so non-mac/iOS hosts
continue to work):
  * set_design_viewport(w, h)   — pin root at (w, h); paint scales +
                                  letterboxes to fit current host bounds.
  * set_fixed_aspect_ratio(r)   — API parity only; plugin hosts do NOT
                                  own the OS window so the DAW enforces
                                  aspect via per-format resize hints.
  * window_to_root_point(pt)    — inverse-map host-space coords into
                                  root-view space; called by native event
                                  handlers AND tests.

mac CPU + GPU hosts (plugin_view_host_mac.mm) implement all three:
  * pointTransform block on the ObjC view runs before hit_test so
    mouse coords inverse-map through the design transform.
  * paint paths (CPU drawRect / GPU paint_scene) layout root at design
    size and translate+scale before paint_all, with a host-bounds
    letterbox fill first so OS-aspect-drift bars share the design bg.

Test (test_plugin_view_host_design_viewport.mm) covers the wiring:
default identity, matching-aspect 2x scale, letterboxed case, reset,
set_fixed_aspect_ratio no-op, and a GPU host smoke that attaches to a
hidden NSWindow, sets the viewport, captures a real Skia/Dawn back
buffer, and verifies inverse-mapping consistency after resize. The
pure math is already pinned by test_view_design_viewport.cpp; this
file only covers PluginViewHost-side wiring.

Local: 27 assertions in 2 test cases pass (real Dawn/Metal init log
visible). Regression check on pulp-test-plugin-editor-host-smoke-mac
(18/2), pulp-test-plugin-editor-headless-gpu (25/4),
pulp-test-view-design-viewport (34/6), pulp-test-view-host-bridge
(44/7) — all green.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>