### PR TITLE
test(events): cover timer and discovery edge paths

### DIFF
--- a/test/test_events_timer_helpers.cpp
+++ b/test/test_events_timer_helpers.cpp
@@ -101,3 +101,49 @@ TEST_CASE("Timer with empty callback still tracks one-shot lifecycle",
     REQUIRE(timer.is_active());
     REQUIRE(wait_until([&] { return !timer.is_active(); }, 500ms));
 }
+
+TEST_CASE("Timer restart invalidates stale queued dispatches",
+          "[events][timer][coverage][issue-687]") {
+    EventLoop loop;
+    std::atomic<int> calls{0};
+    Timer timer(loop, 75ms, [&] { calls.fetch_add(1); }, false);
+
+    REQUIRE_FALSE(timer.is_active());
+    timer.start();
+    REQUIRE(timer.is_active());
+
+    timer.stop();
+    REQUIRE_FALSE(timer.is_active());
+    timer.set_interval(5ms);
+    REQUIRE(timer.interval() == 5ms);
+
+    timer.start();
+    REQUIRE(timer.is_active());
+    REQUIRE(wait_until([&] { return calls.load() == 1; }, 500ms));
+    REQUIRE_FALSE(timer.is_active());
+
+    std::this_thread::sleep_for(100ms);
+    REQUIRE(calls.load() == 1);
+}
+
+TEST_CASE("Repeating timer can stop itself from its callback",
+          "[events][timer][coverage]") {
+    EventLoop loop;
+    std::atomic<int> calls{0};
+    Timer* self = nullptr;
+    Timer timer(loop, 5ms, [&] {
+        calls.fetch_add(1);
+        self->stop();
+    }, true);
+    self = &timer;
+
+    REQUIRE_FALSE(timer.is_active());
+    timer.start();
+    REQUIRE(timer.is_active());
+
+    REQUIRE(wait_until([&] { return calls.load() == 1; }, 500ms));
+    REQUIRE_FALSE(timer.is_active());
+
+    std::this_thread::sleep_for(30ms);
+    REQUIRE(calls.load() == 1);
+}

--- a/test/test_ipc_endpoints.cpp
+++ b/test/test_ipc_endpoints.cpp
@@ -123,3 +123,25 @@ TEST_CASE("IPC socket endpoint failure can be reset with disconnect",
     connection.disconnect();
     REQUIRE(connection.state() == IpcState::Disconnected);
 }
+
+TEST_CASE("IPC socket client rejects hostless numeric endpoints",
+          "[events][ipc][endpoint][codecov]") {
+    const std::vector<std::string_view> endpoints = {
+        "0",
+        "1",
+        ":12345",
+        "12345",
+        "65535",
+    };
+
+    for (auto endpoint : endpoints) {
+        InterprocessConnection client;
+        REQUIRE_FALSE(client.connect(endpoint, IpcTransport::Socket));
+        REQUIRE(client.state() == IpcState::Error);
+        REQUIRE_FALSE(client.is_connected());
+
+        client.disconnect();
+        REQUIRE(client.state() == IpcState::Disconnected);
+        REQUIRE_FALSE(client.is_connected());
+    }
+}

--- a/test/test_network_service_discovery.cpp
+++ b/test/test_network_service_discovery.cpp
@@ -519,6 +519,71 @@ TEST_CASE("NSD keys discoveries and loss by service name plus type",
     REQUIRE(nsd.discovered().front().type == "_pulp._tcp");
 }
 
+TEST_CASE("NSD routes register and unregister to the current backend after swaps",
+          "[events][service-discovery][codecov]") {
+    NetworkServiceDiscovery nsd;
+    auto first = std::make_unique<FakeBackend>();
+    auto first_log = first->log;
+    auto second = std::make_unique<FakeBackend>();
+    auto second_log = second->log;
+
+    nsd.install_backend(std::move(first));
+    REQUIRE(nsd.has_backend());
+    REQUIRE(nsd.register_service("first", "_pulp._tcp", 1111));
+    REQUIRE(first_log->registered.size() == 1);
+    REQUIRE(std::get<0>(first_log->registered.front()) == "first");
+
+    nsd.install_backend(std::move(second));
+    REQUIRE(first_log->stopped == 1);
+    REQUIRE(nsd.has_backend());
+    REQUIRE(nsd.register_service("second", "_pulp._tcp", 2222));
+    REQUIRE(first_log->registered.size() == 1);
+    REQUIRE(second_log->registered.size() == 1);
+    REQUIRE(std::get<0>(second_log->registered.front()) == "second");
+
+    nsd.unregister_service();
+    REQUIRE(first_log->unregistered == 0);
+    REQUIRE(second_log->unregistered == 1);
+}
+
+TEST_CASE("NSD loss matching ignores services with the same type but different name",
+          "[events][service-discovery][codecov]") {
+    NetworkServiceDiscovery nsd;
+    nsd.install_backend(std::make_unique<FakeBackend>());
+
+    NetworkServiceDiscovery::Service alpha;
+    alpha.name = "alpha";
+    alpha.type = "_pulp._tcp";
+    alpha.hostname = "alpha.local";
+    alpha.port = 1;
+
+    NetworkServiceDiscovery::Service beta = alpha;
+    beta.name = "beta";
+    beta.hostname = "beta.local";
+    beta.port = 2;
+
+    nsd.notify_service_found(alpha);
+    nsd.notify_service_found(beta);
+    REQUIRE(nsd.discovered().size() == 2);
+
+    std::vector<std::string> lost;
+    nsd.on_service_lost = [&](const NetworkServiceDiscovery::Service& svc) {
+        lost.push_back(svc.name);
+    };
+
+    NetworkServiceDiscovery::Service missing = alpha;
+    missing.name = "missing";
+    nsd.notify_service_lost(missing);
+    REQUIRE(lost.empty());
+    REQUIRE(nsd.discovered().size() == 2);
+
+    nsd.notify_service_lost(alpha);
+    REQUIRE(lost == std::vector<std::string>{"alpha"});
+    REQUIRE(nsd.discovered().size() == 1);
+    REQUIRE(nsd.discovered().front().name == "beta");
+    REQUIRE(nsd.discovered().front().hostname == "beta.local");
+}
+
 TEST_CASE("MountedVolumeListChangeDetector returns a sorted platform snapshot",
           "[events][volume][lifecycle]") {
 #ifdef _WIN32


### PR DESCRIPTION
## Summary
- Add events coverage for timer stale-dispatch/restart and self-stopping repeating timer paths.
- Add IPC socket endpoint coverage for hostless numeric client endpoints.
- Add NetworkServiceDiscovery backend-swap and loss-matching lifecycle coverage.

## Coverage / Validation
- Branch: `feature/phase3-codecov-events-batch20-20260523`
- Base: `origin/main` at `da860fcb87e4f8063fce5681be1852b2a043a5b3`
- Head: `85cb5fbdb1c02e40dd55149cbd7f061d2f65b548`
- Merge commit: `f7d549be183594cc81f8ea788a6b9d2553122eea`
- Batch size: 37 added assertion/check source lines.

Focused local validation:
- `pulp-test-events`: 125 assertions / 36 test cases
- `pulp-test-events-async-helpers`: 61 assertions / 16 test cases
- `pulp-test-events-timer-helpers`: 33 assertions / 7 test cases
- `pulp-test-ipc`: 63 assertions / 15 test cases
- `pulp-test-ipc-endpoints`: 134 assertions / 7 test cases
- `pulp-test-network-service-discovery`: 116 assertions / 26 test cases

Focused local events coverage after rebase:
- Total: 81.82% lines, 73.15% branches
- `core/events/src/timer.cpp`: 96.92% lines, 87.50% branches
- `core/events/src/interprocess_connection.cpp`: 88.41% lines, 70.97% branches
- `core/events/src/volume_detector.cpp`: 95.61% lines, 89.29% branches

Diff-cover:
- Stock `tools/scripts/local_diff_cover.sh` hit the local Skia-less GPU configure guard.
- Equivalent temporary local wrapper with `-DPULP_ENABLE_GPU=OFF`, same threshold/config and targeted CTest regex `(Timer|IPC socket|NSD)`, passed: diff coverage at or above 75%.

Shipyard:
- `shipyard pr` preflight passed skill-sync and version-bump checks.
- Ubuntu and Windows SSH targets were unreachable from this machine and were deliberately skipped for Shipyard local validation; GitHub checks were triggered after merge.