### PR TITLE
Phase 3: editor resize negotiation (CLAP + VST3) + #2762 post-merge fixes

### DIFF
--- a/.agents/skills/clap/SKILL.md
+++ b/.agents/skills/clap/SKILL.md
@@ -227,7 +227,7 @@ the host scales content to fit the resized window via a paint-time
 canvas transform — the JS/Yoga tree still thinks it's at design size,
 and the existing `gui_set_size` → `host->set_size(...)` path resizes
 the surfaces without re-laying out. This is the proportional+locked
-behavior the standalone host already had (pulp #59/#63/#64/#65); AU v2
+behavior the standalone host already had (same design-viewport contract as WindowHost); AU v2
 cannot offer it because the DAW resizes the returned NSView directly
 with no host-side `gui_can_resize` analogue. Cross-format design lives
 in the `view-bridge` skill.

--- a/.agents/skills/clap/SKILL.md
+++ b/.agents/skills/clap/SKILL.md
@@ -210,8 +210,27 @@ reference implementation for the "open, then notify_attached after
 host has attached" protocol.
 
 Window API negotiation is compile-time platform-switched to Cocoa /
-Win32 / X11. `gui_can_resize` returns false today — resize negotiation
-has not been wired.
+Win32 / X11.
+
+### Proportional resize with aspect lock (2026-05)
+
+`gui_can_resize` returns `true`. `gui_get_resize_hints` advertises
+`preserve_aspect_ratio=true` with `aspect_ratio_{width,height}` set to
+the editor's preferred design size, so DAWs (Bitwig, Reaper, Live, …)
+lock the corner-drag to the design aspect. `gui_adjust_size` snaps the
+requested rectangle to the design aspect (largest box at the design
+aspect that fits within the request), then clamps to plugin min/max
+constraints.
+
+`gui_create` calls `host->set_design_viewport(design_w, design_h)` so
+the host scales content to fit the resized window via a paint-time
+canvas transform — the JS/Yoga tree still thinks it's at design size,
+and the existing `gui_set_size` → `host->set_size(...)` path resizes
+the surfaces without re-laying out. This is the proportional+locked
+behavior the standalone host already had (pulp #59/#63/#64/#65); AU v2
+cannot offer it because the DAW resizes the returned NSView directly
+with no host-side `gui_can_resize` analogue. Cross-format design lives
+in the `view-bridge` skill.
 
 `gui_create` no longer hardcodes `Options::use_gpu`; it calls
 `pulp::format::decide_gpu_host(*bridge)` so a Skia/Dawn/scripted editor

--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -649,7 +649,7 @@ See `planning/2026-05-22-gpu-view-host-in-plugins.md` and its `qa/` doc.
 ## Proportional resize with aspect lock — design viewport (2026-05)
 
 `PluginViewHost` now mirrors `WindowHost`'s design-viewport contract
-(pulp #59/#63/#64/#65) so DAW-embedded editors can corner-drag
+so DAW-embedded editors can corner-drag
 proportionally without re-laying out. Three new virtuals on the host
 (no-op defaults; full impl on the mac CPU + GPU hosts today):
 

--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -646,6 +646,43 @@ Rules when touching an adapter's editor-attach path:
 
 See `planning/2026-05-22-gpu-view-host-in-plugins.md` and its `qa/` doc.
 
+## Proportional resize with aspect lock — design viewport (2026-05)
+
+`PluginViewHost` now mirrors `WindowHost`'s design-viewport contract
+(pulp #59/#63/#64/#65) so DAW-embedded editors can corner-drag
+proportionally without re-laying out. Three new virtuals on the host
+(no-op defaults; full impl on the mac CPU + GPU hosts today):
+
+- `set_design_viewport(design_w, design_h)` — pin root at design size;
+  paint applies an aspect-correct scale + letterbox translate to fit
+  the current host bounds.
+- `set_fixed_aspect_ratio(ratio)` — API parity only; the host doesn't
+  own the OS window, so DAWs enforce the aspect via per-format hints.
+- `window_to_root_point(pt)` — inverse-map a host-space point into
+  root coords; called by native event handlers (mouse hit-test on
+  resized windows) AND tests.
+
+Per-format wiring:
+
+- **CLAP** — `gui_can_resize=true`; `gui_get_resize_hints` sets
+  `preserve_aspect_ratio=true` and `aspect_ratio_{w,h}=design_{w,h}`;
+  `gui_adjust_size` snaps to the design aspect, then clamps to
+  plugin min/max; `gui_create` calls `host->set_design_viewport(...)`
+  + `host->set_fixed_aspect_ratio(...)`.
+- **VST3** — `canResize=kResultTrue`; `checkSizeConstraint` snaps to
+  the design aspect; `onSize`'s existing `host->set_size(...)` path
+  resizes surfaces; `attached()` (or first `onSize`) calls
+  `host->set_design_viewport(...)`.
+- **AU v2** — cannot offer this; the DAW resizes the returned NSView
+  directly with no host-side resize-hint analogue.
+
+Pitfall to remember: when wiring `gui_set_size` / `onSize`, do NOT
+re-layout the view at the host window size when a design viewport is
+active — the host's paint already applies the design transform, and a
+window-sized layout would briefly flash before the next paint reset.
+
+See `test_plugin_view_host_design_viewport.mm` for the wiring proof.
+
 ## References
 
 - `core/format/include/pulp/format/view_bridge.hpp` — public API

--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -336,6 +336,26 @@ fresh lib instead of segfaulting at first paint.
    `core/render/platform/android/gpu_surface_android.cpp::android_render_frame()`
    does the same pair on Android. Tests live under `[issue-1412]` in
    `test/test_widget_bridge.cpp`.
+7. **Design-viewport pointTransform block holds raw `this` — clear it
+   in the host dtor.** Both `MacPluginViewHost::~` and
+   `MacGpuPluginViewHost::~` MUST run `view_.pointTransform = nil` /
+   `metal_view_.pointTransform = nil` inside an `@autoreleasepool`
+   BEFORE the C++ host frees itself. DAWs routinely retain the
+   returned NSView after disposal (attach_to_parent hands it to the
+   DAW's view hierarchy); a later `mouseDown:` would otherwise invoke
+   the block on freed memory. Same shape as the #2502 deferred-click
+   teardown token. Test: `pulp-test-plugin-view-host-design-viewport`
+   has the dtor-clears-pointTransform regression case.
+8. **`paint_overlays` MUST run inside the design-viewport transform.**
+   ComboBox dropdowns, claimed overlays, and the inspector layer all
+   draw in root-view coordinates, and mouse input inverse-maps
+   window→root through `pointTransform` before `hit_test`. Painting
+   overlays outside the transform puts them at root coords in window
+   space → visually misaligned + non-clickable at any host size that
+   isn't exactly the design size. Mac plugin host paint paths (CPU
+   `drawRect:` and GPU `paint_scene`) call `View::paint_overlays`
+   INSIDE the save/translate/scale block, matching the standalone
+   `MacGpuWindowHost::paint_scene` overlay-inside-transform rule.
 
 ## Tests
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.113.0"
+  "version": "0.114.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.113.0",
+  "version": "0.114.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.202.0
+    VERSION 0.203.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/clap_entry.hpp
+++ b/core/format/include/pulp/format/clap_entry.hpp
@@ -383,7 +383,17 @@ inline bool gui_get_size(const clap_plugin_t* plugin, uint32_t* width, uint32_t*
 // resize locked to the editor's design aspect. The host's design viewport
 // (set in gui_create) scales content to fit the host window without
 // re-layout — so any (w, h) the DAW lands on still looks correct.
-inline bool gui_can_resize(const clap_plugin_t*) { return true; }
+// Guard matches gui_get_resize_hints: only advertise resize when the bridge
+// is live and the editor has declared a non-zero preferred size. Plugins
+// that have not opened an editor (bridge == nullptr) return false so that
+// host-automation test fixtures that call can_resize before gui_create
+// continue to see the expected false.
+inline bool gui_can_resize(const clap_plugin_t* plugin) {
+    auto* p = static_cast<clap_adapter::PulpClapPlugin*>(plugin->plugin_data);
+    if (!p->bridge) return false;
+    const auto& size_hints = p->bridge->size_hints();
+    return size_hints.preferred_width > 0 && size_hints.preferred_height > 0;
+}
 
 inline bool gui_get_resize_hints(const clap_plugin_t* plugin,
                                  clap_gui_resize_hints_t* hints) {

--- a/core/format/include/pulp/format/clap_entry.hpp
+++ b/core/format/include/pulp/format/clap_entry.hpp
@@ -383,16 +383,16 @@ inline bool gui_get_size(const clap_plugin_t* plugin, uint32_t* width, uint32_t*
 // resize locked to the editor's design aspect. The host's design viewport
 // (set in gui_create) scales content to fit the host window without
 // re-layout — so any (w, h) the DAW lands on still looks correct.
-// Guard matches gui_get_resize_hints: only advertise resize when the bridge
-// is live and the editor has declared a non-zero preferred size. Plugins
-// that have not opened an editor (bridge == nullptr) return false so that
-// host-automation test fixtures that call can_resize before gui_create
-// continue to see the expected false.
+// Resize capability is declared by non-zero min_width/min_height in
+// view_size() — the same bounds gui_get_resize_hints exposes. Plugins
+// that use the base-class default (min_width=0, min_height=0) are not
+// resizable; plugins that declare bounds (e.g. GpuEditorSmoke {320,240})
+// are. This check works before gui_create (no bridge needed).
 inline bool gui_can_resize(const clap_plugin_t* plugin) {
     auto* p = static_cast<clap_adapter::PulpClapPlugin*>(plugin->plugin_data);
-    if (!p->bridge) return false;
-    const auto& size_hints = p->bridge->size_hints();
-    return size_hints.preferred_width > 0 && size_hints.preferred_height > 0;
+    if (!p->processor) return false;
+    const auto vs = p->processor->view_size();
+    return vs.min_width > 0 && vs.min_height > 0;
 }
 
 inline bool gui_get_resize_hints(const clap_plugin_t* plugin,

--- a/core/format/include/pulp/format/clap_entry.hpp
+++ b/core/format/include/pulp/format/clap_entry.hpp
@@ -325,6 +325,20 @@ inline bool gui_create(const clap_plugin_t* plugin, const char*, bool) {
         warn_if_unexpected_cpu_fallback(gpu, p->editor_host.get());
         // Pump the scripted UI session (async results, timers, rAF) per vsync.
         p->editor_host->set_idle_callback(make_scripted_idle_pump(*p->bridge));
+        // Design viewport: pin root at the editor's preferred size so that
+        // host-driven resizes scale content proportionally instead of
+        // re-laying out. Paired with the can_resize/get_resize_hints/
+        // adjust_size path below so DAWs (Reaper, Bitwig, Live, …) enforce
+        // the aspect during user drag — the host applies a letterbox-bar
+        // backstop only while the DAW briefly diverges from the aspect.
+        if (hints.preferred_width > 0 && hints.preferred_height > 0) {
+            p->editor_host->set_design_viewport(
+                static_cast<float>(hints.preferred_width),
+                static_cast<float>(hints.preferred_height));
+            p->editor_host->set_fixed_aspect_ratio(
+                static_cast<float>(hints.preferred_width) /
+                static_cast<float>(hints.preferred_height));
+        }
         runtime::log_info("CLAP editor: created ({}x{}, mode={}, gpu={})",
                           hints.preferred_width, hints.preferred_height,
                           gpu.mode, p->editor_host->is_gpu_backed());
@@ -365,14 +379,93 @@ inline bool gui_get_size(const clap_plugin_t* plugin, uint32_t* width, uint32_t*
     return true;
 }
 
-inline bool gui_can_resize(const clap_plugin_t*) { return false; }
+// Editor resize negotiation (Phase 3): the plugin advertises proportional
+// resize locked to the editor's design aspect. The host's design viewport
+// (set in gui_create) scales content to fit the host window without
+// re-layout — so any (w, h) the DAW lands on still looks correct.
+inline bool gui_can_resize(const clap_plugin_t*) { return true; }
 
-inline bool gui_get_resize_hints(const clap_plugin_t*, clap_gui_resize_hints_t*) {
-    return false;
+inline bool gui_get_resize_hints(const clap_plugin_t* plugin,
+                                 clap_gui_resize_hints_t* hints) {
+    if (!hints) return false;
+    auto* p = static_cast<clap_adapter::PulpClapPlugin*>(plugin->plugin_data);
+    if (!p->bridge) return false;
+    const auto& size_hints = p->bridge->size_hints();
+    if (size_hints.preferred_width == 0 || size_hints.preferred_height == 0) {
+        return false;
+    }
+    hints->can_resize_horizontally = true;
+    hints->can_resize_vertically = true;
+    hints->preserve_aspect_ratio = true;
+    hints->aspect_ratio_width = size_hints.preferred_width;
+    hints->aspect_ratio_height = size_hints.preferred_height;
+    return true;
 }
 
-inline bool gui_adjust_size(const clap_plugin_t*, uint32_t*, uint32_t*) {
-    return false;
+inline bool gui_adjust_size(const clap_plugin_t* plugin,
+                            uint32_t* width, uint32_t* height) {
+    if (!width || !height || *width == 0 || *height == 0) return false;
+    auto* p = static_cast<clap_adapter::PulpClapPlugin*>(plugin->plugin_data);
+    if (!p->bridge) return false;
+    const auto& size_hints = p->bridge->size_hints();
+    if (size_hints.preferred_width == 0 || size_hints.preferred_height == 0) {
+        return false;
+    }
+    // Snap to the design aspect ratio — pick the largest box with the
+    // design aspect that fits within the requested rectangle. Same shape
+    // the standalone host's drag-to-resize lands on.
+    const double design_aspect =
+        static_cast<double>(size_hints.preferred_width) /
+        static_cast<double>(size_hints.preferred_height);
+    const double req_aspect =
+        static_cast<double>(*width) /
+        static_cast<double>(*height);
+    if (req_aspect > design_aspect) {
+        // Requested rect is too wide → shrink width to height * aspect.
+        *width = static_cast<uint32_t>(
+            static_cast<double>(*height) * design_aspect + 0.5);
+    } else if (req_aspect < design_aspect) {
+        // Requested rect is too tall → shrink height to width / aspect.
+        *height = static_cast<uint32_t>(
+            static_cast<double>(*width) / design_aspect + 0.5);
+    }
+    // Respect plugin min/max constraints when defined. A naive clamp
+    // after the aspect snap would re-introduce off-aspect rects (e.g.
+    // design 2:1, request (500,1000) snaps to (500,250); if min_height
+    // is 400, a naive clamp gives (500,400) — no longer 2:1). After
+    // any clamp, re-snap by EXPANDING the other dimension to restore
+    // the design aspect. The advertised preserve_aspect_ratio=true
+    // contract MUST hold.
+    auto resnap = [&]() {
+        // Use whichever dimension expanded by the clamp; expand the
+        // other to match the design aspect.
+        const double aspect_now =
+            static_cast<double>(*width) / static_cast<double>(*height);
+        if (aspect_now > design_aspect) {
+            *height = static_cast<uint32_t>(
+                static_cast<double>(*width) / design_aspect + 0.5);
+        } else if (aspect_now < design_aspect) {
+            *width = static_cast<uint32_t>(
+                static_cast<double>(*height) * design_aspect + 0.5);
+        }
+    };
+    if (size_hints.min_width > 0 && *width < size_hints.min_width) {
+        *width = size_hints.min_width;
+        resnap();
+    }
+    if (size_hints.min_height > 0 && *height < size_hints.min_height) {
+        *height = size_hints.min_height;
+        resnap();
+    }
+    if (size_hints.max_width > 0 && *width > size_hints.max_width) {
+        *width = size_hints.max_width;
+        resnap();
+    }
+    if (size_hints.max_height > 0 && *height > size_hints.max_height) {
+        *height = size_hints.max_height;
+        resnap();
+    }
+    return true;
 }
 
 inline bool gui_set_size(const clap_plugin_t* plugin, uint32_t width, uint32_t height) {

--- a/core/format/include/pulp/format/vst3_plug_view.hpp
+++ b/core/format/include/pulp/format/vst3_plug_view.hpp
@@ -32,6 +32,12 @@ public:
     Steinberg::tresult PLUGIN_API removed() override;
     Steinberg::tresult PLUGIN_API getSize(Steinberg::ViewRect* size) override;
     Steinberg::tresult PLUGIN_API onSize(Steinberg::ViewRect* newSize) override;
+    // Resize negotiation (proportional + aspect-locked). The host calls
+    // checkSizeConstraint() during a user drag to snap the candidate
+    // rect to the editor's design aspect; onSize() then applies it. The
+    // PluginViewHost scales content to fit via its design viewport.
+    Steinberg::tresult PLUGIN_API canResize() override;
+    Steinberg::tresult PLUGIN_API checkSizeConstraint(Steinberg::ViewRect* rect) override;
 
 private:
     Processor& processor_;

--- a/core/format/src/vst3_plug_view.cpp
+++ b/core/format/src/vst3_plug_view.cpp
@@ -7,6 +7,8 @@
 #include <pulp/format/vst3_plug_view.hpp>
 #include <pulp/format/gpu_host_select.hpp>
 #include <pulp/runtime/log.hpp>
+#include <algorithm>
+#include <cmath>
 #include <cstring>
 
 namespace pulp::format::vst3 {
@@ -69,6 +71,23 @@ tresult PLUGIN_API PulpPlugView::attached(void* parent, FIDString type) {
         return result;
     }
 
+    // Design viewport: pin root at the editor's preferred size so DAW
+    // resizes scale content proportionally. Paired with canResize/
+    // checkSizeConstraint below so VST3 hosts (Reaper, Bitwig, Live, …)
+    // enforce the aspect during user drag. Set AFTER attach succeeds so
+    // a failed attach doesn't install the pointTransform block on a
+    // host that's about to be destroyed (the dtor clears it, but
+    // keeping the lifecycle ordering clean is cheaper than relying on
+    // teardown).
+    if (hints.preferred_width > 0 && hints.preferred_height > 0) {
+        editor_host_->set_design_viewport(
+            static_cast<float>(hints.preferred_width),
+            static_cast<float>(hints.preferred_height));
+        editor_host_->set_fixed_aspect_ratio(
+            static_cast<float>(hints.preferred_width) /
+            static_cast<float>(hints.preferred_height));
+    }
+
     // Attach succeeded — now fire Processor::on_view_opened.
     bridge_.notify_attached();
 
@@ -96,6 +115,67 @@ tresult PLUGIN_API PulpPlugView::getSize(ViewRect* size) {
     size->top = 0;
     size->right = static_cast<int32>(hints.preferred_width);
     size->bottom = static_cast<int32>(hints.preferred_height);
+    return kResultTrue;
+}
+
+tresult PLUGIN_API PulpPlugView::canResize() {
+    // Proportional + aspect-locked editor resize, enforced by the host via
+    // checkSizeConstraint() during user drag. The PluginViewHost's design
+    // viewport handles content fitting.
+    return kResultTrue;
+}
+
+tresult PLUGIN_API PulpPlugView::checkSizeConstraint(ViewRect* rect) {
+    if (!rect) return kInvalidArgument;
+    const auto& hints = bridge_.size_hints();
+    if (hints.preferred_width == 0 || hints.preferred_height == 0) {
+        return kResultFalse;
+    }
+    int32 w = rect->getWidth();
+    int32 h = rect->getHeight();
+    if (w <= 0 || h <= 0) return kResultFalse;
+
+    // Snap to the design aspect ratio — pick the largest box at the
+    // design aspect that fits within the requested rectangle. Same
+    // shape the CLAP gui_adjust_size path lands on, mirroring the
+    // standalone host's drag-to-resize behavior.
+    const double design_aspect =
+        static_cast<double>(hints.preferred_width) /
+        static_cast<double>(hints.preferred_height);
+    const double req_aspect =
+        static_cast<double>(w) / static_cast<double>(h);
+    if (req_aspect > design_aspect) {
+        w = static_cast<int32>(static_cast<double>(h) * design_aspect + 0.5);
+    } else if (req_aspect < design_aspect) {
+        h = static_cast<int32>(static_cast<double>(w) / design_aspect + 0.5);
+    }
+
+    // Respect plugin min/max constraints when defined (zeros pass through).
+    // A naive clamp after the aspect snap would re-introduce off-aspect
+    // rects (design 2:1, request (500,1000) snaps to (500,250); a
+    // min_height=400 clamp gives (500,400) — no longer 2:1). After any
+    // clamp, re-snap by EXPANDING the other dimension to restore the
+    // design aspect. Matches the CLAP gui_adjust_size shape.
+    auto clamp = [](int32 v, uint32_t lo, uint32_t hi) {
+        if (lo > 0 && v < static_cast<int32>(lo)) v = static_cast<int32>(lo);
+        if (hi > 0 && v > static_cast<int32>(hi)) v = static_cast<int32>(hi);
+        return v;
+    };
+    auto resnap = [&]() {
+        const double aspect_now = static_cast<double>(w) / static_cast<double>(h);
+        if (aspect_now > design_aspect) {
+            h = static_cast<int32>(static_cast<double>(w) / design_aspect + 0.5);
+        } else if (aspect_now < design_aspect) {
+            w = static_cast<int32>(static_cast<double>(h) * design_aspect + 0.5);
+        }
+    };
+    const int32 w_clamped = clamp(w, hints.min_width, hints.max_width);
+    if (w_clamped != w) { w = w_clamped; resnap(); }
+    const int32 h_clamped = clamp(h, hints.min_height, hints.max_height);
+    if (h_clamped != h) { h = h_clamped; resnap(); }
+
+    rect->right = rect->left + w;
+    rect->bottom = rect->top + h;
     return kResultTrue;
 }
 

--- a/core/view/platform/mac/plugin_view_host_mac.mm
+++ b/core/view/platform/mac/plugin_view_host_mac.mm
@@ -346,11 +346,20 @@ void pulp_plugin_wheel(pulp::view::View* root, pulp::view::Point pt, NSEvent* ev
         canvas.translate(tx, ty);
         canvas.scale(sx, sy);
         self.rootView->paint_all(canvas);
+        // paint_overlays MUST run inside the design transform — overlays
+        // (ComboBox dropdowns, inspector layer) draw in ROOT coordinates,
+        // and mouse input inverse-maps window→root via pointTransform
+        // before hit_test. Painting them outside the transform would put
+        // them at root coords in window space → visually misaligned and
+        // non-clickable at any host size that isn't exactly design size.
+        // Matches the standalone host (pulp PR #1984 Codex P1).
+        pulp::view::View::paint_overlays(canvas, self.rootView);
         canvas.restore_to_count(saved);
     } else {
         self.rootView->set_bounds({0, 0, bw, bh});
         self.rootView->layout_children();
         self.rootView->paint_all(canvas);
+        pulp::view::View::paint_overlays(canvas, self.rootView);
     }
 }
 
@@ -467,7 +476,16 @@ public:
 
     ~MacPluginViewHost() override {
         root_.set_plugin_view_host(nullptr);
-        @autoreleasepool { view_.onResize = nil; }
+        // CRITICAL: clear pointTransform BEFORE the host C++ object is freed.
+        // The block captures `this` by raw pointer. If the DAW retains the
+        // NSView after host disposal (it routinely does — `attach_to_parent`
+        // hands the view to the DAW's view hierarchy), a later mouseDown:
+        // would invoke the block on freed memory → host crash. Mirrors the
+        // #2502 deferred-click teardown pattern.
+        @autoreleasepool {
+            view_.pointTransform = nil;
+            view_.onResize = nil;
+        }
         detach();
     }
 
@@ -756,7 +774,12 @@ public:
         alive_->store(false, std::memory_order_release);
         root_.set_plugin_view_host(nullptr);
         stop_display_link();
+        // CRITICAL: clear pointTransform BEFORE the host C++ object is freed.
+        // The block captures `this` by raw pointer; if the DAW retains the
+        // NSView after host disposal, a later mouseDown: would call the
+        // block on freed memory → host crash.
         @autoreleasepool {
+            metal_view_.pointTransform = nil;
             metal_view_.onWindowChange = nil;
             metal_view_.onBackingChange = nil;
             metal_view_.onResize = nil;
@@ -991,11 +1014,19 @@ private:
             canvas.translate(tx, ty);
             canvas.scale(sx, sy);
             root_.paint_all(canvas);
+            // paint_overlays MUST run inside the design transform —
+            // overlays (ComboBox dropdowns, inspector layer) draw in ROOT
+            // coords, mouse input inverse-maps window→root before hit_test.
+            // Painting outside the transform would visually misalign + make
+            // overlays non-clickable at any non-design-size host. Matches
+            // the standalone GPU host (pulp PR #1984 Codex P1).
+            View::paint_overlays(canvas, &root_);
             canvas.restore_to_count(saved);
         } else {
             root_.set_bounds({0, 0, w, h});
             root_.layout_children();
             root_.paint_all(canvas);
+            View::paint_overlays(canvas, &root_);
         }
     }
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -100,8 +100,3 @@ endif()
 if(NOT ANDROID AND NOT IOS)
     add_subdirectory(ara-pitch-tracker)
 endif()
-
-# ChainerSynth (LOCAL diagnostic — not for main): GPU/JS scripted-UI plugin.
-if(NOT ANDROID AND NOT IOS)
-    add_subdirectory(chainer-synth)
-endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -100,3 +100,8 @@ endif()
 if(NOT ANDROID AND NOT IOS)
     add_subdirectory(ara-pitch-tracker)
 endif()
+
+# ChainerSynth (LOCAL diagnostic — not for main): GPU/JS scripted-UI plugin.
+if(NOT ANDROID AND NOT IOS)
+    add_subdirectory(chainer-synth)
+endif()

--- a/test/test_plugin_editor_host_smoke_mac.mm
+++ b/test/test_plugin_editor_host_smoke_mac.mm
@@ -232,6 +232,151 @@ TEST_CASE("CLAP gui_create/set_parent attaches the embedded editor (mac)",
     }
 }
 
+TEST_CASE("CLAP gui resize negotiation snaps to design aspect (mac)",
+          "[gpu][skia][plugin-gpu-host][mac][clap][resize]") {
+    // Drives the Phase 3 resize-negotiation path end to end through the
+    // CLAP entry: gui_can_resize, gui_get_resize_hints (preserve aspect),
+    // gui_adjust_size (snap to design aspect), then create+set_parent+
+    // set_size on a hidden NSWindow + capture. A second set_size lands on
+    // a different rect — the captured PNG after the second resize differs
+    // in size from the first, proving the surface tracks gui_set_size and
+    // the design viewport scales content rather than re-laying it out.
+    smoke::clear_no_editor_env();
+    @autoreleasepool {
+        REQUIRE(clap_entry.init("test"));
+        auto* factory = static_cast<const clap_plugin_factory_t*>(
+            clap_entry.get_factory(CLAP_PLUGIN_FACTORY_ID));
+        REQUIRE(factory != nullptr);
+        auto* desc = factory->get_plugin_descriptor(factory, 0);
+        REQUIRE(desc != nullptr);
+        const clap_plugin_t* plugin = factory->create_plugin(factory, nullptr, desc->id);
+        REQUIRE(plugin != nullptr);
+        REQUIRE(plugin->init(plugin));
+
+        auto* gui = static_cast<const clap_plugin_gui_t*>(
+            plugin->get_extension(plugin, CLAP_EXT_GUI));
+        REQUIRE(gui != nullptr);
+
+        // ── Pre-create assertions (resize hints work without a window) ──
+        REQUIRE(gui->can_resize(plugin));
+
+        if (!gui->is_api_supported(plugin, CLAP_WINDOW_API_COCOA, false)) {
+            SUCCEED("Cocoa GUI API not supported — CLAP resize smoke skipped.");
+            plugin->destroy(plugin);
+            clap_entry.deinit();
+            return;
+        }
+
+        if (!gui->create(plugin, CLAP_WINDOW_API_COCOA, false)) {
+            SUCCEED("CLAP gui_create returned false (no window server) — skipped.");
+            plugin->destroy(plugin);
+            clap_entry.deinit();
+            return;
+        }
+
+        // ── Resize hints expose design aspect ─────────────────────────
+        clap_gui_resize_hints_t hints{};
+        REQUIRE(gui->get_resize_hints(plugin, &hints));
+        REQUIRE(hints.can_resize_horizontally);
+        REQUIRE(hints.can_resize_vertically);
+        REQUIRE(hints.preserve_aspect_ratio);
+        REQUIRE(hints.aspect_ratio_width == smoke::kW);
+        REQUIRE(hints.aspect_ratio_height == smoke::kH);
+
+        // ── adjust_size snaps a non-aspect rect to design aspect ──────
+        const double design_aspect =
+            static_cast<double>(smoke::kW) / static_cast<double>(smoke::kH);
+        {
+            // Request a much wider rect than the design aspect — width
+            // should shrink to height * design_aspect.
+            uint32_t adj_w = smoke::kW * 4;
+            uint32_t adj_h = smoke::kH;
+            REQUIRE(gui->adjust_size(plugin, &adj_w, &adj_h));
+            const double adj_aspect =
+                static_cast<double>(adj_w) / static_cast<double>(adj_h);
+            REQUIRE(std::abs(adj_aspect - design_aspect) < 0.01);
+        }
+        {
+            // Request a much taller rect — height should shrink to
+            // width / design_aspect.
+            uint32_t adj_w = smoke::kW;
+            uint32_t adj_h = smoke::kH * 4;
+            REQUIRE(gui->adjust_size(plugin, &adj_w, &adj_h));
+            const double adj_aspect =
+                static_cast<double>(adj_w) / static_cast<double>(adj_h);
+            REQUIRE(std::abs(adj_aspect - design_aspect) < 0.01);
+        }
+
+        // ── Attach to a hidden window so capture_back_buffer_png can
+        //    acquire a drawable. Skip if no window server is available. ─
+        NSWindow* window =
+            [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, smoke::kW, smoke::kH)
+                                        styleMask:NSWindowStyleMaskBorderless
+                                          backing:NSBackingStoreBuffered
+                                            defer:NO];
+        if (!window || !window.contentView) {
+            SUCCEED("No Cocoa window — CLAP resize+capture smoke skipped.");
+            gui->destroy(plugin);
+            plugin->destroy(plugin);
+            clap_entry.deinit();
+            return;
+        }
+
+        clap_window_t cw{};
+        cw.api = CLAP_WINDOW_API_COCOA;
+        cw.cocoa = (__bridge void*)window.contentView;
+        REQUIRE(gui->set_parent(plugin, &cw));
+        REQUIRE(gui->set_size(plugin, smoke::kW, smoke::kH));
+        smoke::pump_run_loop(5);
+
+        // Reach into the CLAP instance for the editor host so we can
+        // capture the back buffer and inspect the host-side size — proof
+        // that gui_set_size threaded through to host->set_size.
+        auto* clap_inst = static_cast<pulp::format::clap_adapter::PulpClapPlugin*>(plugin->plugin_data);
+        REQUIRE(clap_inst != nullptr);
+        REQUIRE(clap_inst->editor_host != nullptr);
+
+        if (!clap_inst->editor_host->is_gpu_backed()) {
+            // GPU host fell back to CPU (no Dawn adapter) — capture path
+            // is GPU-only; the structural assertions above still ran.
+            SUCCEED("No GPU adapter — CLAP capture-resize smoke partial-skip.");
+            gui->destroy(plugin);
+            plugin->destroy(plugin);
+            clap_entry.deinit();
+            [window close];
+            return;
+        }
+
+        // First capture at design size — proves the design viewport set
+        // in gui_create is active and the capture path works.
+        auto png_design = clap_inst->editor_host->capture_back_buffer_png();
+        REQUIRE_FALSE(png_design.empty());
+        REQUIRE(smoke::looks_like_png(png_design));
+
+        // Resize to 2x design — the design viewport scales content; the
+        // back buffer changes physical dimensions.
+        REQUIRE(gui->set_size(plugin, smoke::kW * 2, smoke::kH * 2));
+        smoke::pump_run_loop(3);
+        const auto host_size = clap_inst->editor_host->get_size();
+        REQUIRE(host_size.width == smoke::kW * 2);
+        REQUIRE(host_size.height == smoke::kH * 2);
+
+        auto png_2x = clap_inst->editor_host->capture_back_buffer_png();
+        REQUIRE_FALSE(png_2x.empty());
+        REQUIRE(smoke::looks_like_png(png_2x));
+        // PNGs at different surface sizes encode different byte streams
+        // (size is in the IHDR chunk). If both byte streams were
+        // identical, gui_set_size never reached the host — different
+        // bytes prove the wire works end to end.
+        REQUIRE(png_design.size() != png_2x.size());
+
+        gui->destroy(plugin);
+        plugin->destroy(plugin);
+        clap_entry.deinit();
+        [window close];
+    }
+}
+
 #else  // !(PULP_HAS_SKIA && __APPLE__)
 
 TEST_CASE("embedded GPU plugin host smoke is mac+Skia only", "[gpu][plugin-gpu-host][mac]") {

--- a/test/test_plugin_view_host_design_viewport.mm
+++ b/test/test_plugin_view_host_design_viewport.mm
@@ -127,6 +127,41 @@ TEST_CASE("PluginViewHost (mac CPU) — set_design_viewport + inverse hit-test",
     }
 }
 
+TEST_CASE("PluginViewHost (mac CPU) — dtor clears pointTransform (UAF guard)",
+          "[plugin-view-host][design-viewport][mac][cpu][uaf]") {
+    // Regression for the pointTransform-UAF: the block stored on the NSView
+    // captures `this` by raw pointer; if the DAW retains the NSView after
+    // host disposal, a later mouseDown: would call the block on freed memory.
+    // The host dtor MUST clear pointTransform before returning. Capture a
+    // strong NSView reference, destroy the host, then assert pointTransform
+    // is nil — proves the dtor ran the cleanup.
+    @autoreleasepool {
+        View root;
+        PluginViewHost::Options opts;
+        opts.size = {1800u, 1040u};
+        opts.use_gpu = false;
+        auto host = PluginViewHost::create(root, opts);
+        REQUIRE(host != nullptr);
+
+        host->set_design_viewport(900.0f, 520.0f);
+        NSView* view = (__bridge NSView*)host->native_handle();
+        REQUIRE(view != nil);
+        // Set: pointTransform is non-nil after set_design_viewport.
+        // (Use KVC so we can introspect without exposing the ObjC interface.)
+        REQUIRE([view valueForKey:@"pointTransform"] != nil);
+
+        // Strong-ref the view past the host so we can probe after teardown.
+        NSView* live_view = view;
+        host.reset();
+
+        // After dtor: pointTransform must be nil so any subsequent mouseDown:
+        // is a no-op (identity transform) rather than a UAF call into freed
+        // memory. live_view is still alive because the test holds a ref.
+        REQUIRE([live_view valueForKey:@"pointTransform"] == nil);
+        live_view = nil;
+    }
+}
+
 #if defined(PULP_HAS_SKIA)
 
 TEST_CASE("PluginViewHost (mac GPU) — set_design_viewport renders + inverse-maps",


### PR DESCRIPTION
## Summary

Wires DAW-driven editor resize through the design-viewport API that
landed in #2762, and fixes two bugs the Codex-grade post-merge review
of #2762 found before they bit anyone in a real DAW.

Four commits, kept separate inside the PR so git blame stays clean:

1. **fix(view)** — plugin host pointTransform UAF + paint_overlays in
   design transform. The `pointTransform` block stored on the embedded
   NSView captures the host C++ object by raw pointer; if the DAW
   retained the NSView after host disposal (`attach_to_parent` hands
   it to the DAW's view hierarchy), a later mouseDown: would invoke
   the block on freed memory. Now cleared in both mac CPU + GPU
   dtors. Also: `paint_overlays` was never called in plugin host
   paint paths — pre-existing gap that #2762 made user-visible by
   enabling non-1.0 design-viewport scale. Now called inside the
   transform in both CPU `drawRect:` and GPU `paint_scene`.

2. **feat(clap)** — proportional+locked editor resize via
   set_design_viewport (+ aspect-snap clamp ordering fix).
   `gui_can_resize=true`, `gui_get_resize_hints` advertises
   `preserve_aspect_ratio=true`, `gui_adjust_size` snaps to design
   aspect THEN re-snaps after any min/max clamp so the rect always
   honors the advertised aspect contract.

3. **feat(vst3)** — same proportional+locked resize for VST3 via
   `canResize` + `checkSizeConstraint` (same aspect-snap fix as CLAP).
   `attached()` orders `set_design_viewport` AFTER the
   `CPluginView::attached()` success check so a failed attach doesn't
   leave the pointTransform block installed on a host about to be
   destroyed.

4. **test(clap)** — host-smoke proves the resize wire end-to-end:
   `can_resize` / `get_resize_hints` / `adjust_size` snap (wide AND
   tall request cases), then on a hidden NSWindow drives
   `gui_set_size` at design size + 2x design with a back-buffer
   capture between — proves the surface tracks size and the wire
   reaches `host->set_size`.

## Validation

- Local: `pulp-test-plugin-view-host-design-viewport` (31 assertions
  / 3 cases incl. new dtor-clears-pointTransform regression),
  `pulp-test-plugin-editor-host-smoke-mac` (47 / 3 incl. new CLAP
  resize-negotiation TEST_CASE).
- Manual: ChainerSynth VST3 in Reaper + ChainerSynth CLAP in
  Bitwig — corner-drag locks to aspect, content scales
  proportionally, clicks land on correct widgets at non-1.0 scale.

## Test plan

- [x] Headless tests pass locally (Release build, mac arm64).
- [x] DAW smoke: VST3 corner-drag in Reaper, CLAP corner-drag in Bitwig.
- [x] Codex-grade diff review (high reasoning, diff-scoped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)