### PR TITLE
test(signal): cover matrix and window edge paths

### DIFF
--- a/test/test_dsp_enhancements.cpp
+++ b/test/test_dsp_enhancements.cpp
@@ -457,6 +457,54 @@ TEST_CASE("Matrix4 scale and rotations transform vectors",
     REQUIRE_THAT(around_z.z, WithinAbs(0.0f, 1e-5));
 }
 
+TEST_CASE("Matrix affine helpers compose transforms and preserve row-major layout",
+          "[dsp][matrix][coverage][phase3]") {
+    auto translate = translation_matrix(2.0f, -3.0f, 4.0f);
+    auto scale = scale_matrix(3.0f, 4.0f, 5.0f);
+    auto composed = translate * scale;
+
+    REQUIRE_THAT(composed(0, 0), WithinAbs(3.0f, 1e-6f));
+    REQUIRE_THAT(composed(1, 1), WithinAbs(4.0f, 1e-6f));
+    REQUIRE_THAT(composed(2, 2), WithinAbs(5.0f, 1e-6f));
+    REQUIRE_THAT(composed(0, 3), WithinAbs(2.0f, 1e-6f));
+    REQUIRE_THAT(composed(1, 3), WithinAbs(-3.0f, 1e-6f));
+    REQUIRE_THAT(composed(2, 3), WithinAbs(4.0f, 1e-6f));
+
+    auto transformed = transform(composed, Vec3{1.0f, 2.0f, -1.0f});
+    REQUIRE_THAT(transformed.x, WithinAbs(5.0f, 1e-6f));
+    REQUIRE_THAT(transformed.y, WithinAbs(5.0f, 1e-6f));
+    REQUIRE_THAT(transformed.z, WithinAbs(-1.0f, 1e-6f));
+
+    auto transposed = composed.transposed();
+    REQUIRE_THAT(transposed(3, 0), WithinAbs(2.0f, 1e-6f));
+    REQUIRE_THAT(transposed(3, 1), WithinAbs(-3.0f, 1e-6f));
+    REQUIRE_THAT(transposed(3, 2), WithinAbs(4.0f, 1e-6f));
+    REQUIRE_THAT(transposed(0, 3), WithinAbs(0.0f, 1e-6f));
+}
+
+TEST_CASE("Matrix arithmetic covers cancellation, determinant signs, and inequality",
+          "[dsp][matrix][coverage][phase3]") {
+    Matrix2 a;
+    a(0, 0) = 2.0f;  a(0, 1) = -3.0f;
+    a(1, 0) = 4.0f;  a(1, 1) = 5.0f;
+
+    Matrix2 b;
+    b(0, 0) = -2.0f; b(0, 1) = 3.0f;
+    b(1, 0) = -4.0f; b(1, 1) = -5.0f;
+
+    auto cancelled = a + b;
+    REQUIRE(cancelled == Matrix2::zero());
+    REQUIRE_FALSE(a == b);
+    REQUIRE_THAT(determinant(a), WithinAbs(22.0f, 1e-6f));
+    REQUIRE_THAT(determinant(b), WithinAbs(22.0f, 1e-6f));
+
+    auto product = a * b;
+    REQUIRE_THAT(product(0, 0), WithinAbs(8.0f, 1e-6f));
+    REQUIRE_THAT(product(0, 1), WithinAbs(21.0f, 1e-6f));
+    REQUIRE_THAT(product(1, 0), WithinAbs(-28.0f, 1e-6f));
+    REQUIRE_THAT(product(1, 1), WithinAbs(-13.0f, 1e-6f));
+}
+
 // ── SpecialFunctions ────────────────────────────────────────────────────
 
 TEST_CASE("sinc function", "[dsp][special]") {

--- a/test/test_signal.cpp
+++ b/test/test_signal.cpp
@@ -1208,6 +1208,60 @@ TEST_CASE("Signal target covers window families and bounded application",
     REQUIRE_THAT(buffer[2], WithinAbs(4.0f, 1e-6f));
 }
 
+TEST_CASE("WindowFunction edge sizes and symmetry stay deterministic",
+          "[signal][window][coverage][phase3]") {
+    REQUIRE(WindowFunction::generate(-3, WindowFunction::Type::blackman).empty());
+
+    for (auto type : {WindowFunction::Type::hann,
+                      WindowFunction::Type::hamming,
+                      WindowFunction::Type::blackman,
+                      WindowFunction::Type::flat_top,
+                      WindowFunction::Type::kaiser}) {
+        auto one = WindowFunction::generate(1, type, 5.0f);
+        REQUIRE(one.size() == 1);
+        REQUIRE_THAT(one[0], WithinAbs(1.0f, 1e-6f));
+    }
+
+    const auto hann = WindowFunction::generate(8, WindowFunction::Type::hann);
+    REQUIRE_THAT(hann.front(), WithinAbs(hann.back(), 1e-6f));
+    REQUIRE_THAT(hann[1], WithinAbs(hann[6], 1e-6f));
+    REQUIRE(hann[3] > hann[2]);
+
+    const auto blackman = WindowFunction::generate(8, WindowFunction::Type::blackman);
+    REQUIRE_THAT(blackman[0], WithinAbs(blackman[7], 1e-6f));
+    REQUIRE_THAT(blackman[2], WithinAbs(blackman[5], 1e-6f));
+    REQUIRE(blackman[3] > blackman[1]);
+
+    const auto flat_top = WindowFunction::generate(9, WindowFunction::Type::flat_top);
+    REQUIRE(flat_top[4] > 0.99f);
+    REQUIRE(flat_top[4] > flat_top[3]);
+}
+
+TEST_CASE("WindowFunction applies only provided coefficients and honors Kaiser alpha",
+          "[signal][window][coverage][phase3]") {
+    float partial[] = {2.0f, 4.0f, 8.0f, 16.0f};
+    WindowFunction::apply(partial, {0.25f, 0.5f});
+    REQUIRE_THAT(partial[0], WithinAbs(0.5f, 1e-6f));
+    REQUIRE_THAT(partial[1], WithinAbs(2.0f, 1e-6f));
+    REQUIRE_THAT(partial[2], WithinAbs(8.0f, 1e-6f));
+    REQUIRE_THAT(partial[3], WithinAbs(16.0f, 1e-6f));
+
+    float unchanged[] = {3.0f, 6.0f};
+    WindowFunction::apply(unchanged, {});
+    REQUIRE_THAT(unchanged[0], WithinAbs(3.0f, 1e-6f));
+    REQUIRE_THAT(unchanged[1], WithinAbs(6.0f, 1e-6f));
+
+    const auto default_alpha = WindowFunction::generate(7, WindowFunction::Type::kaiser, 0.0f);
+    const auto negative_alpha = WindowFunction::generate(7, WindowFunction::Type::kaiser, -2.0f);
+    const auto high_alpha = WindowFunction::generate(7, WindowFunction::Type::kaiser, 9.0f);
+
+    REQUIRE_THAT(default_alpha.front(), WithinAbs(negative_alpha.front(), 1e-6f));
+    REQUIRE_THAT(default_alpha[3], WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(high_alpha[3], WithinAbs(1.0f, 1e-6f));
+    REQUIRE(high_alpha.front() < default_alpha.front());
+    REQUIRE_THAT(high_alpha[1], WithinAbs(high_alpha[5], 1e-6f));
+}
+
 TEST_CASE("Signal target covers spectrogram ramps axes and scrolling columns",
           "[signal][spectrogram][coverage]") {
     ColorMapper inferno(ColorRamp::inferno);


### PR DESCRIPTION
## Summary
- Adds a 43-assertion signal coverage batch focused on matrix helpers and window edge behavior.
- Covers matrix composition/transposition/determinant paths and deterministic window sizing/application/Kaiser alpha branches.
- Based on latest `origin/main` at `2775c58cb1fbef18fe29581f39751339f62ff14c`.

## Coverage context
- Current Codecov component evidence before this PR: `signal` is about 60.77%, below the 75% priority threshold.
- `core/signal/include/pulp/signal/windowing.hpp` was a low signal file at about 20.33% line coverage.
- This PR is intentionally batched at 43 assertions to stay in the requested 36-48 fixes/assertions range and reduce extra CI runs.

## Validation
- `git diff --check origin/main...HEAD`
- `source tools/scripts/cli_version_check.sh && pulp_cli_version_check`
- `python3 tools/scripts/skill_sync_check.py --help`
- `python3 tools/scripts/version_bump_check.py --help`

Focused build/test and Codecov validation are delegated to Shipyard/GitHub runners per project workflow and current no-local-build constraint.