### PR TITLE
test(format): cover screenshot capture edge cases

### DIFF
--- a/test/test_screenshot_capture.cpp
+++ b/test/test_screenshot_capture.cpp
@@ -11,6 +11,7 @@
 
 #include <cstdio>
 #include <filesystem>
+#include <functional>
 #include <fstream>
 #include <string>
 #include <vector>
@@ -134,4 +135,134 @@ TEST_CASE("ScreenshotCapture default delay (30) honored when caller leaves field
     // matches (so an unset config doesn't fire on the first tick).
     ScreenshotCapture cap;
     REQUIRE(cap.delay == 30);
+}
+
+TEST_CASE("ScreenshotCapture handles missing capture callback as empty bytes",
+          "[issue-468][screenshot][coverage][phase3]") {
+    CaptureHarness h;
+    auto path = tmp_screenshot_path("missing_capture");
+    std::filesystem::remove(path);
+    auto cap = h.make(path, 1);
+    cap.capture_fn = {};
+
+    cap();
+    REQUIRE(h.capture_calls == 0);
+    REQUIRE(h.close_calls == 1);
+    REQUIRE(h.errors.size() == 1);
+    REQUIRE(h.errors[0].find("empty") != std::string::npos);
+    REQUIRE_FALSE(std::filesystem::exists(path));
+    REQUIRE(*cap.captured);
+
+    cap();
+    REQUIRE(h.close_calls == 1);
+}
+
+TEST_CASE("ScreenshotCapture reports empty screenshot path before writing",
+          "[issue-468][screenshot][coverage][phase3]") {
+    CaptureHarness h;
+    auto cap = h.make("", 1);
+
+    cap();
+    REQUIRE(h.capture_calls == 1);
+    REQUIRE(h.close_calls == 1);
+    REQUIRE(h.errors.size() == 1);
+    REQUIRE(h.errors[0].find("path is empty") != std::string::npos);
+    REQUIRE(*cap.captured);
+}
+
+TEST_CASE("ScreenshotCapture tolerates missing error callback for bad inputs",
+          "[issue-468][screenshot][coverage][phase3]") {
+    CaptureHarness h;
+    auto cap = h.make("", 1);
+    cap.on_error = {};
+
+    cap();
+    REQUIRE(h.capture_calls == 1);
+    REQUIRE(h.close_calls == 1);
+    REQUIRE(h.errors.empty());
+    REQUIRE(*cap.captured);
+}
+
+TEST_CASE("ScreenshotCapture reports failed file writes and still closes",
+          "[issue-468][screenshot][coverage][phase3]") {
+    CaptureHarness h;
+    auto missing_dir = std::filesystem::temp_directory_path() /
+                       "pulp_test_screenshot_missing_dir" /
+                       "capture.png";
+    std::filesystem::remove_all(missing_dir.parent_path());
+    auto cap = h.make(missing_dir.string(), 1);
+
+    cap();
+    REQUIRE(h.capture_calls == 1);
+    REQUIRE(h.close_calls == 1);
+    REQUIRE(h.errors.size() == 1);
+    REQUIRE(h.errors[0].find("failed to write") != std::string::npos);
+    REQUIRE_FALSE(std::filesystem::exists(missing_dir));
+    REQUIRE(*cap.captured);
+}
+
+TEST_CASE("ScreenshotCapture skips write error reporting when no handler is set",
+          "[issue-468][screenshot][coverage][phase3]") {
+    CaptureHarness h;
+    auto missing_dir = std::filesystem::temp_directory_path() /
+                       "pulp_test_screenshot_missing_dir_no_error" /
+                       "capture.png";
+    std::filesystem::remove_all(missing_dir.parent_path());
+    auto cap = h.make(missing_dir.string(), 1);
+    cap.on_error = {};
+
+    cap();
+    REQUIRE(h.capture_calls == 1);
+    REQUIRE(h.close_calls == 1);
+    REQUIRE(h.errors.empty());
+    REQUIRE_FALSE(std::filesystem::exists(missing_dir));
+}
+
+TEST_CASE("ScreenshotCapture permits missing close callback after a successful write",
+          "[issue-468][screenshot][coverage][phase3]") {
+    CaptureHarness h;
+    auto path = tmp_screenshot_path("missing_close");
+    std::filesystem::remove(path);
+    auto cap = h.make(path, 1);
+    cap.close_fn = {};
+
+    cap();
+    REQUIRE(h.capture_calls == 1);
+    REQUIRE(h.close_calls == 0);
+    REQUIRE(h.errors.empty());
+    REQUIRE(std::filesystem::exists(path));
+    REQUIRE(read_file_bytes(path) == h.bytes_to_return);
+    REQUIRE(*cap.captured);
+
+    cap();
+    REQUIRE(h.capture_calls == 1);
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("ScreenshotCapture captures immediately for non-positive delays",
+          "[issue-468][screenshot][coverage][phase3]") {
+    CaptureHarness zero_delay;
+    auto zero_path = tmp_screenshot_path("zero_delay");
+    std::filesystem::remove(zero_path);
+    auto zero = zero_delay.make(zero_path, 0);
+
+    zero();
+    REQUIRE(zero_delay.capture_calls == 1);
+    REQUIRE(zero_delay.close_calls == 1);
+    REQUIRE(*zero.frame == 1);
+    REQUIRE(read_file_bytes(zero_path) == zero_delay.bytes_to_return);
+
+    CaptureHarness negative_delay;
+    auto negative_path = tmp_screenshot_path("negative_delay");
+    std::filesystem::remove(negative_path);
+    auto negative = negative_delay.make(negative_path, -4);
+
+    negative();
+    REQUIRE(negative_delay.capture_calls == 1);
+    REQUIRE(negative_delay.close_calls == 1);
+    REQUIRE(*negative.frame == 1);
+    REQUIRE(read_file_bytes(negative_path) == negative_delay.bytes_to_return);
+
+    std::filesystem::remove(zero_path);
+    std::filesystem::remove(negative_path);
 }


### PR DESCRIPTION
## Summary
- add a 38-assertion format/screenshot batch for ScreenshotCapture edge contracts
- cover empty capture bytes, empty paths, missing callbacks, write failures, one-shot behavior, and non-positive delays
- keep the PR test-only and scoped to test/test_screenshot_capture.cpp

## Validation
- git diff --check origin/main...HEAD
- PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/version_bump_check.py --base origin/main --mode=report
- python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report
- Shipyard opened/tracked the PR; local mac configure still reported the known local Skia/Dawn validation gap, while GitHub/Shipyard runner checks are in progress.

## Coverage
- 38 added assertions
- Codecov branch totals are pending for head daf756a897c53ca755191510c38917c2c59e5b57