### PR TITLE
test(signal): cover processor duplicator edge contracts

### DIFF
--- a/core/signal/include/pulp/signal/processor_duplicator.hpp
+++ b/core/signal/include/pulp/signal/processor_duplicator.hpp
@@ -4,8 +4,9 @@
 // Template that wraps a mono DSP processor and applies it independently
 // to each channel of a multi-channel buffer.
 
+#include <algorithm>
+#include <cstddef>
 #include <vector>
-#include <memory>
 
 namespace pulp::signal {
 
@@ -22,7 +23,7 @@ public:
 
     /// Prepare for processing with the given number of channels
     void prepare(int num_channels, float sample_rate) {
-        processors_.resize(static_cast<size_t>(num_channels));
+        processors_.resize(static_cast<std::size_t>(std::max(0, num_channels)));
         for (auto& p : processors_) {
             p.set_sample_rate(sample_rate);
         }
@@ -33,8 +34,14 @@ public:
     /// num_channels: number of channels
     /// num_samples: samples per channel
     void process(float* const* channels, int num_channels, int num_samples) {
+        if (channels == nullptr || num_channels <= 0 || num_samples <= 0)
+            return;
+
         int count = std::min(num_channels, static_cast<int>(processors_.size()));
         for (int ch = 0; ch < count; ++ch) {
+            if (channels[ch] == nullptr)
+                continue;
+
             for (int i = 0; i < num_samples; ++i) {
                 channels[ch][i] = processors_[ch].process(channels[ch][i]);
             }
@@ -43,7 +50,9 @@ public:
 
     /// Process a single channel
     void process_channel(float* buffer, int channel, int num_samples) {
-        if (channel < 0 || channel >= static_cast<int>(processors_.size())) return;
+        if (buffer == nullptr || num_samples <= 0 ||
+            channel < 0 || channel >= static_cast<int>(processors_.size())) return;
+
         for (int i = 0; i < num_samples; ++i) {
             buffer[i] = processors_[channel].process(buffer[i]);
         }

--- a/test/test_dsp_enhancements.cpp
+++ b/test/test_dsp_enhancements.cpp
@@ -295,6 +295,23 @@ struct StatefulGain {
     void reset() { reset_called = true; }
 };
 
+struct CountingGain {
+    float gain = 1.0f;
+    float sample_rate = 0.0f;
+    int processed = 0;
+    int reset_count = 0;
+
+    void set_sample_rate(float sr) { sample_rate = sr; }
+    float process(float x) {
+        ++processed;
+        return x * gain;
+    }
+    void reset() {
+        ++reset_count;
+        processed = 0;
+    }
+};
+
 TEST_CASE("ProcessorDuplicator applies to all channels", "[dsp][duplicator]") {
     ProcessorDuplicator<TestGain> dup;
     dup.prepare(2, 44100.0f);
@@ -358,6 +375,140 @@ TEST_CASE("ProcessorDuplicator bounds channels and exposes channel state",
 
     dup.reset();
     REQUIRE(dup[0].reset_called);
+}
+
+TEST_CASE("ProcessorDuplicator treats nonpositive channel prepares as empty",
+          "[dsp][duplicator][coverage][phase3]") {
+    ProcessorDuplicator<CountingGain> dup;
+    dup.prepare(-2, 44100.0f);
+
+    float ch0[] = {1.0f, 2.0f};
+    float* channels[] = {ch0};
+    dup.process(channels, 1, 2);
+    dup.process_channel(ch0, 0, 2);
+
+    REQUIRE(dup.num_channels() == 0);
+    REQUIRE_THAT(ch0[0], WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(ch0[1], WithinAbs(2.0f, 1e-6f));
+
+    dup.prepare(0, 48000.0f);
+    ch0[0] = 3.0f;
+    ch0[1] = 4.0f;
+    dup.process(channels, 1, 2);
+
+    REQUIRE(dup.num_channels() == 0);
+    REQUIRE_THAT(ch0[0], WithinAbs(3.0f, 1e-6f));
+    REQUIRE_THAT(ch0[1], WithinAbs(4.0f, 1e-6f));
+}
+
+TEST_CASE("ProcessorDuplicator skips null channels without disturbing neighbors",
+          "[dsp][duplicator][coverage][phase3]") {
+    ProcessorDuplicator<CountingGain> dup;
+    dup.prepare(3, 44100.0f);
+    dup.for_each([](CountingGain& g) { g.gain = 2.0f; });
+
+    float ch0[] = {1.0f, -2.0f};
+    float ch2[] = {0.25f, -0.5f};
+    float extra[] = {9.0f, 10.0f};
+    float* channels[] = {ch0, nullptr, ch2, extra};
+
+    dup.process(channels, 4, 2);
+
+    REQUIRE_THAT(ch0[0], WithinAbs(2.0f, 1e-6f));
+    REQUIRE_THAT(ch0[1], WithinAbs(-4.0f, 1e-6f));
+    REQUIRE_THAT(ch2[0], WithinAbs(0.5f, 1e-6f));
+    REQUIRE_THAT(ch2[1], WithinAbs(-1.0f, 1e-6f));
+    REQUIRE_THAT(extra[0], WithinAbs(9.0f, 1e-6f));
+    REQUIRE_THAT(extra[1], WithinAbs(10.0f, 1e-6f));
+    REQUIRE(dup[0].processed == 2);
+    REQUIRE(dup[1].processed == 0);
+    REQUIRE(dup[2].processed == 2);
+}
+
+TEST_CASE("ProcessorDuplicator ignores null and nonpositive single-channel work",
+          "[dsp][duplicator][coverage][phase3]") {
+    ProcessorDuplicator<CountingGain> dup;
+    dup.prepare(2, 48000.0f);
+    dup[0].gain = 3.0f;
+    dup[1].gain = 4.0f;
+
+    float samples[] = {1.0f, -1.0f, 0.5f};
+    dup.process_channel(nullptr, 0, 3);
+    dup.process_channel(samples, 0, 0);
+    dup.process_channel(samples, 1, -8);
+
+    REQUIRE_THAT(samples[0], WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(samples[1], WithinAbs(-1.0f, 1e-6f));
+    REQUIRE_THAT(samples[2], WithinAbs(0.5f, 1e-6f));
+    REQUIRE(dup[1].processed == 0);
+
+    dup.process_channel(samples, 1, 3);
+
+    REQUIRE_THAT(samples[0], WithinAbs(4.0f, 1e-6f));
+    REQUIRE_THAT(samples[1], WithinAbs(-4.0f, 1e-6f));
+    REQUIRE_THAT(samples[2], WithinAbs(2.0f, 1e-6f));
+    REQUIRE(dup[1].processed == 3);
+}
+
+TEST_CASE("ProcessorDuplicator reapplies channel layout and sample rate on prepare",
+          "[dsp][duplicator][coverage][phase3]") {
+    ProcessorDuplicator<CountingGain> dup;
+    dup.prepare(2, 44100.0f);
+    dup[0].gain = 0.5f;
+    dup[1].gain = 0.25f;
+
+    REQUIRE(dup.num_channels() == 2);
+    REQUIRE_THAT(dup[0].sample_rate, WithinAbs(44100.0f, 1e-6f));
+    REQUIRE_THAT(dup[1].sample_rate, WithinAbs(44100.0f, 1e-6f));
+
+    dup.prepare(4, 96000.0f);
+
+    REQUIRE(dup.num_channels() == 4);
+    REQUIRE_THAT(dup[0].sample_rate, WithinAbs(96000.0f, 1e-6f));
+    REQUIRE_THAT(dup[1].sample_rate, WithinAbs(96000.0f, 1e-6f));
+    REQUIRE_THAT(dup[2].sample_rate, WithinAbs(96000.0f, 1e-6f));
+    REQUIRE_THAT(dup[3].sample_rate, WithinAbs(96000.0f, 1e-6f));
+
+    float ch0[] = {2.0f};
+    float ch1[] = {4.0f};
+    float ch2[] = {6.0f};
+    float ch3[] = {8.0f};
+    float* channels[] = {ch0, ch1, ch2, ch3};
+    dup.process(channels, 4, 1);
+
+    REQUIRE_THAT(ch0[0], WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(ch1[0], WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(ch2[0], WithinAbs(6.0f, 1e-6f));
+    REQUIRE_THAT(ch3[0], WithinAbs(8.0f, 1e-6f));
+    REQUIRE(dup[0].processed == 1);
+    REQUIRE(dup[1].processed == 1);
+    REQUIRE(dup[2].processed == 1);
+    REQUIRE(dup[3].processed == 1);
+}
+
+TEST_CASE("ProcessorDuplicator reset visits every prepared channel",
+          "[dsp][duplicator][coverage][phase3]") {
+    ProcessorDuplicator<CountingGain> dup;
+    dup.prepare(3, 48000.0f);
+
+    float ch0[] = {1.0f};
+    float ch1[] = {2.0f};
+    float ch2[] = {3.0f};
+    float* channels[] = {ch0, ch1, ch2};
+    dup.process(channels, 3, 1);
+
+    REQUIRE(dup[0].processed == 1);
+    REQUIRE(dup[1].processed == 1);
+    REQUIRE(dup[2].processed == 1);
+
+    dup.reset();
+
+    REQUIRE(dup[0].processed == 0);
+    REQUIRE(dup[1].processed == 0);
+    REQUIRE(dup[2].processed == 0);
+    REQUIRE(dup[0].reset_count == 1);
+    REQUIRE(dup[1].reset_count == 1);
+    REQUIRE(dup[2].reset_count == 1);
 }
 
 // ── Matrix ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add a focused ProcessorDuplicator coverage batch for channel-count, null-channel, single-channel, layout reprepare, and reset contracts.
- Harden ProcessorDuplicator so negative prepares become an empty layout and null/nonpositive processing work is a no-op instead of unsafe callback behavior.
- Keep the batch deterministic and in-memory: stack buffers only, no sleeps, no filesystem, no device/network dependencies.

## Behavioral value
- Protects audio-callback utility behavior when hosts provide zero/invalid channel layouts or sparse channel pointer arrays.
- Verifies prepared channel count limits processing so extra host channels are not touched.
- Verifies reprepare reapplies sample rate/channel layout and reset reaches every prepared per-channel processor.
- Adds 48 meaningful assertions in one coherent signal-helper area to keep CI runs batched.

## Validation
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report`
- Local manual builds/tests intentionally not run; validation is delegated to Shipyard/GitHub runners per repo workflow.

Version-Bump: sdk=skip reason="coverage-focused ProcessorDuplicator guard with no API/version surface change"
