### PR TITLE
test(signal): cover chorus edge contracts

### DIFF
--- a/core/signal/include/pulp/signal/chorus.hpp
+++ b/core/signal/include/pulp/signal/chorus.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <pulp/signal/delay_line.hpp>
+#include <algorithm>
 #include <cmath>
 
 namespace pulp::signal {
@@ -9,20 +10,36 @@ namespace pulp::signal {
 class Chorus {
 public:
     void prepare(float sample_rate) {
+        if (!std::isfinite(sample_rate) || sample_rate <= 0.0f)
+            sample_rate = 44100.0f;
+
         sample_rate_ = sample_rate;
-        int max_delay = static_cast<int>(sample_rate * 0.05f); // 50ms max
+        int max_delay =
+            std::max(1, static_cast<int>(sample_rate * max_delay_ms * 0.001f));
         delay_l_.prepare(max_delay);
         delay_r_.prepare(max_delay);
+        prepared_ = true;
     }
 
-    void set_rate(float hz) { rate_ = hz; }      // LFO rate (0.1-5 Hz typical)
-    void set_depth(float d) { depth_ = d; }       // Modulation depth (0-1)
-    void set_mix(float m) { mix_ = m; }           // Dry/wet mix (0-1)
-    void set_delay_ms(float ms) { delay_ms_ = ms; } // Center delay (5-30ms typical)
+    void set_rate(float hz) {
+        rate_ = std::isfinite(hz) ? std::max(0.0f, hz) : 0.0f;
+    } // LFO rate (0.1-5 Hz typical)
+    void set_depth(float d) {
+        depth_ = std::isfinite(d) ? std::clamp(d, 0.0f, 1.0f) : 0.0f;
+    } // Modulation depth (0-1)
+    void set_mix(float m) {
+        mix_ = std::isfinite(m) ? std::clamp(m, 0.0f, 1.0f) : 0.0f;
+    } // Dry/wet mix (0-1)
+    void set_delay_ms(float ms) {
+        delay_ms_ = std::isfinite(ms) ? std::clamp(ms, 0.0f, max_delay_ms) : 0.0f;
+    } // Center delay (5-30ms typical)
 
     struct StereoSample { float left, right; };
 
     StereoSample process(float input) {
+        if (!prepared_)
+            return {input, input};
+
         float lfo_l = std::sin(2.0f * pi * phase_);
         float lfo_r = std::sin(2.0f * pi * phase_ + pi * 0.5f); // 90° offset
 
@@ -37,7 +54,8 @@ public:
         float wet_r = delay_r_.read(mod_r);
 
         phase_ += rate_ / sample_rate_;
-        if (phase_ >= 1.0f) phase_ -= 1.0f;
+        if (phase_ >= 1.0f)
+            phase_ = std::fmod(phase_, 1.0f);
 
         float dry = 1.0f - mix_;
         return {input * dry + wet_l * mix_,
@@ -52,6 +70,7 @@ public:
 
 private:
     static constexpr float pi = 3.14159265358979323846f;
+    static constexpr float max_delay_ms = 50.0f;
     DelayLine delay_l_, delay_r_;
     float sample_rate_ = 44100.0f;
     float rate_ = 1.0f;
@@ -59,6 +78,7 @@ private:
     float mix_ = 0.5f;
     float delay_ms_ = 15.0f;
     float phase_ = 0;
+    bool prepared_ = false;
 };
 
 } // namespace pulp::signal

--- a/test/test_signal.cpp
+++ b/test/test_signal.cpp
@@ -1074,6 +1074,180 @@ TEST_CASE("Chorus dry mix, phase wrap, and reset are deterministic",
     }
 }
 
+TEST_CASE("Chorus is safe before prepare and rejects non-finite mix",
+          "[signal][chorus][coverage][phase3]") {
+    Chorus unprepared;
+    unprepared.set_mix(1.0f);
+    unprepared.set_depth(1.0f);
+
+    for (float input : {1.0f, -0.25f}) {
+        auto out = unprepared.process(input);
+        REQUIRE_THAT(out.left, WithinAbs(input, 1e-6f));
+        REQUIRE_THAT(out.right, WithinAbs(input, 1e-6f));
+    }
+
+    Chorus chorus;
+    chorus.prepare(1000.0f);
+    chorus.set_mix(std::numeric_limits<float>::quiet_NaN());
+    chorus.set_depth(1.0f);
+    chorus.set_delay_ms(2.0f);
+
+    for (float input : {0.5f, -0.75f}) {
+        auto out = chorus.process(input);
+        REQUIRE_THAT(out.left, WithinAbs(input, 1e-6f));
+        REQUIRE_THAT(out.right, WithinAbs(input, 1e-6f));
+    }
+}
+
+TEST_CASE("Chorus wet zero-depth delay is centered and mono-compatible",
+          "[signal][chorus][coverage][phase3]") {
+    Chorus chorus;
+    chorus.prepare(1000.0f);
+    chorus.set_rate(0.0f);
+    chorus.set_depth(0.0f);
+    chorus.set_delay_ms(2.0f);
+    chorus.set_mix(1.0f);
+
+    const std::array<float, 5> input{{1.0f, 0.0f, 0.0f, -0.5f, 0.0f}};
+    std::array<Chorus::StereoSample, input.size()> out{};
+    for (size_t i = 0; i < input.size(); ++i)
+        out[i] = chorus.process(input[i]);
+
+    REQUIRE_THAT(out[0].left, WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(out[0].right, WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(out[1].left, WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(out[1].right, WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(out[2].left, WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(out[2].right, WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(out[4].left, WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(out[4].right, WithinAbs(0.0f, 1e-6f));
+}
+
+TEST_CASE("Chorus clamps mix and delay to safe callback ranges",
+          "[signal][chorus][coverage][phase3]") {
+    Chorus dry;
+    dry.prepare(1000.0f);
+    dry.set_mix(-1.0f);
+    dry.set_depth(1.0f);
+    dry.set_delay_ms(2.0f);
+
+    for (float input : {0.25f, -0.5f, 0.75f}) {
+        auto out = dry.process(input);
+        REQUIRE_THAT(out.left, WithinAbs(input, 1e-6f));
+        REQUIRE_THAT(out.right, WithinAbs(input, 1e-6f));
+    }
+
+    Chorus immediate_wet;
+    immediate_wet.prepare(1000.0f);
+    immediate_wet.set_mix(2.0f);
+    immediate_wet.set_depth(1.0f);
+    immediate_wet.set_delay_ms(-10.0f);
+
+    auto positive = immediate_wet.process(0.375f);
+    auto negative = immediate_wet.process(-0.625f);
+    REQUIRE_THAT(positive.left, WithinAbs(0.375f, 1e-6f));
+    REQUIRE_THAT(positive.right, WithinAbs(0.375f, 1e-6f));
+    REQUIRE_THAT(negative.left, WithinAbs(-0.625f, 1e-6f));
+    REQUIRE_THAT(negative.right, WithinAbs(-0.625f, 1e-6f));
+}
+
+TEST_CASE("Chorus depth clamps preserve modulation timing bounds",
+          "[signal][chorus][coverage][phase3]") {
+    Chorus limited_depth;
+    limited_depth.prepare(1000.0f);
+    limited_depth.set_rate(0.0f);
+    limited_depth.set_depth(2.0f);
+    limited_depth.set_delay_ms(2.0f);
+    limited_depth.set_mix(1.0f);
+
+    std::array<Chorus::StereoSample, 5> limited{};
+    for (size_t i = 0; i < limited.size(); ++i)
+        limited[i] = limited_depth.process(i == 0 ? 1.0f : 0.0f);
+
+    REQUIRE_THAT(limited[2].left, WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(limited[2].right, WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(limited[3].left, WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(limited[3].right, WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(limited[4].right, WithinAbs(0.0f, 1e-6f));
+
+    Chorus no_depth;
+    no_depth.prepare(1000.0f);
+    no_depth.set_rate(0.0f);
+    no_depth.set_depth(-1.0f);
+    no_depth.set_delay_ms(2.0f);
+    no_depth.set_mix(1.0f);
+
+    std::array<Chorus::StereoSample, 3> centered{};
+    for (size_t i = 0; i < centered.size(); ++i)
+        centered[i] = no_depth.process(i == 0 ? -0.5f : 0.0f);
+
+    REQUIRE_THAT(centered[0].left, WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(centered[0].right, WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(centered[2].left, WithinAbs(-0.5f, 1e-6f));
+    REQUIRE_THAT(centered[2].right, WithinAbs(-0.5f, 1e-6f));
+}
+
+TEST_CASE("Chorus reset clears delayed audio and restarts the same response",
+          "[signal][chorus][coverage][phase3]") {
+    Chorus chorus;
+    chorus.prepare(1000.0f);
+    chorus.set_rate(0.0f);
+    chorus.set_depth(0.0f);
+    chorus.set_delay_ms(2.0f);
+    chorus.set_mix(1.0f);
+
+    const std::array<float, 4> impulse{{1.0f, 0.0f, 0.0f, 0.0f}};
+    std::array<Chorus::StereoSample, impulse.size()> first{};
+    std::array<Chorus::StereoSample, impulse.size()> second{};
+    for (size_t i = 0; i < impulse.size(); ++i)
+        first[i] = chorus.process(impulse[i]);
+
+    chorus.reset();
+    auto cleared = chorus.process(0.0f);
+    REQUIRE_THAT(cleared.left, WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(cleared.right, WithinAbs(0.0f, 1e-6f));
+
+    chorus.reset();
+    for (size_t i = 0; i < impulse.size(); ++i)
+        second[i] = chorus.process(impulse[i]);
+
+    REQUIRE_THAT(second[0].left, WithinAbs(first[0].left, 1e-6f));
+    REQUIRE_THAT(second[0].right, WithinAbs(first[0].right, 1e-6f));
+    REQUIRE_THAT(second[2].left, WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(second[2].right, WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(second[3].left, WithinAbs(first[3].left, 1e-6f));
+    REQUIRE_THAT(second[3].right, WithinAbs(first[3].right, 1e-6f));
+}
+
+TEST_CASE("Chorus invalid sample rates and fast modulation stay finite",
+          "[signal][chorus][coverage][phase3]") {
+    Chorus chorus;
+    chorus.prepare(0.0f);
+    chorus.set_rate(std::numeric_limits<float>::infinity());
+    chorus.set_depth(std::numeric_limits<float>::infinity());
+    chorus.set_delay_ms(std::numeric_limits<float>::infinity());
+    chorus.set_mix(1.0f);
+
+    for (float input : {0.25f, -0.25f}) {
+        auto out = chorus.process(input);
+        REQUIRE(std::isfinite(out.left));
+        REQUIRE(std::isfinite(out.right));
+    }
+
+    Chorus fast;
+    fast.prepare(1000.0f);
+    fast.set_rate(3500.0f);
+    fast.set_depth(1.0f);
+    fast.set_delay_ms(1.0f);
+    fast.set_mix(1.0f);
+
+    for (float input : {1.0f, 0.0f}) {
+        auto out = fast.process(input);
+        REQUIRE(std::isfinite(out.left));
+        REQUIRE(std::isfinite(out.right));
+    }
+}
+
 // ── Phaser ───────────────────────────────────────────────────────────────────
 
 TEST_CASE("Phaser modifies signal", "[signal][phaser]") {


### PR DESCRIPTION
## Summary
- Add a focused Chorus coverage batch for unprepared safety, parameter clamping, dry/wet behavior, centered delay timing, depth modulation bounds, reset clearing, and finite fast-modulation behavior.
- Harden Chorus against unsafe callback inputs: unprepared processing now passes through, invalid sample rates fall back to a sane default, mix/depth/delay/rate setters clamp or sanitize inputs, and phase wrapping handles high rates robustly.
- Keep the batch deterministic and in-memory: small stack/std::array sample sequences only, no sleeps, no filesystem, no device/network dependencies.

## Behavioral value
- Protects a real crash surface where `process()` could push into an unprepared empty delay line.
- Verifies the DSP contract for zero-depth mono-compatible delay output instead of repeating the existing stereo-energy smoke test.
- Verifies clamps produce stable, observable callback behavior for invalid host/plugin parameter values.
- Adds 39 meaningful assertions in one coherent signal component to keep CI runs batched.

## Validation
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report`
- Local manual builds/tests intentionally not run; validation is delegated to Shipyard/GitHub runners per repo workflow.

Version-Bump: sdk=skip reason="coverage-focused Chorus guard with no API/version surface change"
