### PR TITLE
test(signal): cover noise gate guard contracts

### DIFF
--- a/core/signal/include/pulp/signal/noise_gate.hpp
+++ b/core/signal/include/pulp/signal/noise_gate.hpp
@@ -17,8 +17,21 @@ public:
         float range_db = -80.0f;       // Max attenuation
     };
 
-    void set_params(const Params& p) { params_ = p; }
-    void set_sample_rate(float sr) { sample_rate_ = sr; }
+    void set_params(const Params& p) {
+        params_.threshold_db =
+            std::isfinite(p.threshold_db) ? p.threshold_db : -40.0f;
+        params_.ratio = std::isfinite(p.ratio) ? std::max(1.0f, p.ratio) : 1.0f;
+        params_.attack_ms =
+            std::isfinite(p.attack_ms) ? std::max(0.0f, p.attack_ms) : 0.0f;
+        params_.release_ms =
+            std::isfinite(p.release_ms) ? std::max(0.0f, p.release_ms) : 0.0f;
+        params_.range_db =
+            std::isfinite(p.range_db) ? std::min(0.0f, p.range_db) : -80.0f;
+    }
+
+    void set_sample_rate(float sr) {
+        sample_rate_ = (std::isfinite(sr) && sr > 0.0f) ? sr : 44100.0f;
+    }
 
     float process(float input) {
         float abs_in = std::abs(input);
@@ -52,6 +65,9 @@ public:
     }
 
     void process(float* buffer, int num_samples) {
+        if (buffer == nullptr || num_samples <= 0)
+            return;
+
         for (int i = 0; i < num_samples; ++i)
             buffer[i] = process(buffer[i]);
     }

--- a/test/test_signal.cpp
+++ b/test/test_signal.cpp
@@ -943,6 +943,131 @@ TEST_CASE("NoiseGate ignores nonpositive buffer lengths",
     REQUIRE_THAT(samples[2], WithinAbs(-0.001f, 1e-6f));
 }
 
+TEST_CASE("NoiseGate sanitizes invalid params without amplifying quiet input",
+          "[signal][gate][coverage][phase3]") {
+    NoiseGate gate;
+    gate.set_sample_rate(1000.0f);
+    gate.set_params({
+        std::numeric_limits<float>::quiet_NaN(),
+        -4.0f,
+        std::numeric_limits<float>::quiet_NaN(),
+        std::numeric_limits<float>::quiet_NaN(),
+        12.0f,
+    });
+
+    const float positive = gate.process(0.001f);
+    const float negative = gate.process(-0.001f);
+    const float zero = gate.process(0.0f);
+
+    REQUIRE(std::isfinite(positive));
+    REQUIRE(std::isfinite(negative));
+    REQUIRE_THAT(positive, WithinAbs(0.001f, 1e-7f));
+    REQUIRE_THAT(negative, WithinAbs(-0.001f, 1e-7f));
+    REQUIRE_THAT(zero, WithinAbs(0.0f, 1e-9f));
+}
+
+TEST_CASE("NoiseGate clamps timing and ratio to stable instantaneous behavior",
+          "[signal][gate][coverage][phase3]") {
+    NoiseGate gate;
+    gate.set_sample_rate(1000.0f);
+    gate.set_params({-20.0f, 0.25f, -1.0f, -10.0f, -48.0f});
+
+    const float quiet = 0.01f;
+    const float loud = 0.5f;
+
+    REQUIRE_THAT(gate.process(quiet), WithinAbs(quiet, 1e-7f));
+    REQUIRE_THAT(gate.process(-quiet), WithinAbs(-quiet, 1e-7f));
+    REQUIRE_THAT(gate.process(loud), WithinAbs(loud, 1e-6f));
+    REQUIRE_THAT(gate.process(-loud), WithinAbs(-loud, 1e-6f));
+}
+
+TEST_CASE("NoiseGate invalid sample rates fall back to finite coefficients",
+          "[signal][gate][coverage][phase3]") {
+    NoiseGate gate;
+    gate.set_sample_rate(-1.0f);
+    gate.set_params({-20.0f, 20.0f, 0.5f, 50.0f, -24.0f});
+
+    const auto first = gate.process(0.001f);
+    const auto second = gate.process(0.001f);
+    const auto loud = gate.process(1.0f);
+
+    REQUIRE(std::isfinite(first));
+    REQUIRE(std::isfinite(second));
+    REQUIRE(std::isfinite(loud));
+    REQUIRE(first >= 0.0f);
+    REQUIRE(second >= 0.0f);
+    REQUIRE(loud > 0.0f);
+}
+
+TEST_CASE("NoiseGate null buffers and valid buffers preserve callback safety",
+          "[signal][gate][coverage][phase3]") {
+    NoiseGate gate;
+    gate.set_sample_rate(1000.0f);
+    gate.set_params({-20.0f, 20.0f, 0.0f, 0.0f, -24.0f});
+
+    gate.process(nullptr, 3);
+
+    float samples[] = {0.001f, -0.001f, 1.0f};
+    gate.process(samples, 0);
+    gate.process(samples, -3);
+
+    REQUIRE_THAT(samples[0], WithinAbs(0.001f, 1e-6f));
+    REQUIRE_THAT(samples[1], WithinAbs(-0.001f, 1e-6f));
+    REQUIRE_THAT(samples[2], WithinAbs(1.0f, 1e-6f));
+
+    gate.process(samples, 3);
+    REQUIRE(std::abs(samples[0]) < 0.001f);
+    REQUIRE(std::abs(samples[1]) < 0.001f);
+    REQUIRE_THAT(samples[2], WithinAbs(1.0f, 1e-6f));
+}
+
+TEST_CASE("NoiseGate reset releases held attenuation after sanitized params",
+          "[signal][gate][coverage][phase3]") {
+    NoiseGate gate;
+    gate.set_sample_rate(std::numeric_limits<float>::infinity());
+    gate.set_params({-20.0f, 20.0f, 0.0f, 1000.0f, -18.0f});
+
+    const float quiet = gate.process(0.001f);
+    const float held_loud = gate.process(1.0f);
+    gate.reset();
+    const float reset_loud = gate.process(1.0f);
+
+    REQUIRE(std::abs(quiet) < 0.001f);
+    REQUIRE(held_loud > 0.0f);
+    REQUIRE(held_loud < 1.0f);
+    REQUIRE_THAT(reset_loud, WithinAbs(1.0f, 1e-6f));
+}
+
+TEST_CASE("NoiseGate non-finite range falls back to bounded attenuation",
+          "[signal][gate][coverage][phase3]") {
+    NoiseGate gate;
+    gate.set_sample_rate(std::numeric_limits<float>::quiet_NaN());
+    gate.set_params({
+        std::numeric_limits<float>::quiet_NaN(),
+        20.0f,
+        0.0f,
+        0.0f,
+        std::numeric_limits<float>::quiet_NaN(),
+    });
+
+    const float quiet = gate.process(0.001f);
+    const float negative_quiet = gate.process(-0.001f);
+    const float silence = gate.process(0.0f);
+    const float loud = gate.process(1.0f);
+
+    REQUIRE(std::isfinite(quiet));
+    REQUIRE(std::isfinite(negative_quiet));
+    REQUIRE(std::abs(quiet) < 0.001f);
+    REQUIRE(std::abs(negative_quiet) < 0.001f);
+    REQUIRE(quiet > 0.0f);
+    REQUIRE(negative_quiet < 0.0f);
+    REQUIRE_THAT(quiet, WithinAbs(0.001f * 0.0001f, 1e-9f));
+    REQUIRE_THAT(negative_quiet, WithinAbs(-0.001f * 0.0001f, 1e-9f));
+    REQUIRE_THAT(silence, WithinAbs(0.0f, 1e-9f));
+    REQUIRE_THAT(loud, WithinAbs(1.0f, 1e-6f));
+    REQUIRE(loud > std::abs(quiet));
+}
+
 // ── Panner ───────────────────────────────────────────────────────────────────
 
 TEST_CASE("Panner center", "[signal][panner]") {


### PR DESCRIPTION
## Summary
- Add a focused NoiseGate coverage batch for parameter sanitization, invalid sample-rate fallback, null/nonpositive buffer safety, sign preservation, bounded attenuation, and reset release behavior.
- Harden NoiseGate against unsafe host/plugin inputs: non-finite params fall back to sane defaults, ratio/timing/range are clamped to non-amplifying callback behavior, invalid sample rates fall back to 44.1 kHz, and null/nonpositive buffer processing is a no-op.
- Keep the batch deterministic and in-memory: small stack buffers only, no sleeps, no filesystem, no device/network dependencies.

## Behavioral value
- Protects audio-callback behavior from invalid automation/configuration values producing non-finite coefficients or unintended gain.
- Verifies quiet signals remain attenuated or unity-bounded rather than amplified when params are malformed.
- Verifies reset clears held attenuation after release smoothing.
- Adds 36 meaningful assertions in one coherent signal component to keep CI runs batched.

## Validation
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report`
- Local manual builds/tests intentionally not run; validation is delegated to Shipyard/GitHub runners per repo workflow.

Version-Bump: sdk=skip reason="coverage-focused NoiseGate guard with no API/version surface change"