### PR TITLE
test(signal): cover biquad response contracts

### DIFF
--- a/test/test_biquad.cpp
+++ b/test/test_biquad.cpp
@@ -35,6 +35,11 @@ struct BiquadCase {
     float gain_db;
 };
 
+struct BiquadImpulseCase {
+    BiquadCase config;
+    std::array<float, 3> expected;
+};
+
 }  // namespace
 
 TEST_CASE("Biquad default coefficients are an identity bypass",
@@ -65,6 +70,55 @@ TEST_CASE("Biquad zero and negative block lengths are no-ops",
     filter.process(buffer.data(), -4);
 
     require_buffer_matches(buffer, expected);
+}
+
+TEST_CASE("Biquad impulse responses stay pinned for representative filters",
+          "[signal][biquad][coverage][phase3]") {
+    const std::array<BiquadImpulseCase, 8> cases{{
+        {{Biquad::Type::lowpass, 600.0f, 0.707f, 0.0f}, {0.00146030f, 0.00567915f, 0.01088156f}},
+        {{Biquad::Type::highpass, 4000.0f, 0.707f, 0.0f}, {0.68927898f, -0.49656902f, -0.27527589f}},
+        {{Biquad::Type::bandpass, 1200.0f, 1.25f, 0.0f}, {0.05888889f, 0.10947732f, 0.09268173f}},
+        {{Biquad::Type::notch, 1800.0f, 0.9f, 0.0f}, {0.88519713f, -0.19763063f, -0.13697046f}},
+        {{Biquad::Type::allpass, 2500.0f, 0.8f, 0.0f}, {0.66541807f, -0.52764727f, -0.27489917f}},
+        {{Biquad::Type::peaking, 1200.0f, 0.75f, 6.0f}, {1.06842939f, 0.12587992f, 0.10411456f}},
+        {{Biquad::Type::low_shelf, 250.0f, 0.707f, 6.0f}, {1.00806409f, 0.01618423f, 0.01628813f}},
+        {{Biquad::Type::high_shelf, 8000.0f, 0.707f, -6.0f}, {0.63626967f, 0.22975227f, 0.13133734f}},
+    }};
+
+    for (const auto& c : cases) {
+        Biquad filter;
+        filter.set_coefficients(c.config.type, c.config.freq_hz, c.config.q,
+                                kSampleRate, c.config.gain_db);
+
+        std::array<float, 4> impulse{{1.0f, 0.0f, 0.0f, 0.0f}};
+        filter.process(impulse.data(), static_cast<int>(impulse.size()));
+        require_buffer_matches(std::array<float, 3>{{impulse[0], impulse[1], impulse[2]}},
+                               c.expected,
+                               1e-5f);
+    }
+}
+
+TEST_CASE("Biquad extreme valid controls still produce finite sample output",
+          "[signal][biquad][coverage][phase3]") {
+    const std::array<BiquadCase, 8> cases{{
+        {Biquad::Type::lowpass, 20.0f, 0.01f, 0.0f},
+        {Biquad::Type::highpass, 20000.0f, 25.0f, 0.0f},
+        {Biquad::Type::bandpass, 40.0f, 50.0f, 0.0f},
+        {Biquad::Type::notch, 19000.0f, 0.02f, 0.0f},
+        {Biquad::Type::allpass, 12000.0f, 100.0f, 0.0f},
+        {Biquad::Type::peaking, 80.0f, 0.05f, 24.0f},
+        {Biquad::Type::low_shelf, 30.0f, 0.1f, -24.0f},
+        {Biquad::Type::high_shelf, 18000.0f, 0.1f, 24.0f},
+    }};
+
+    for (const auto& c : cases) {
+        Biquad filter;
+        filter.set_coefficients(c.type, c.freq_hz, c.q, kSampleRate, c.gain_db);
+
+        REQUIRE(std::isfinite(filter.process(1.0f)));
+        REQUIRE(std::isfinite(filter.process(-0.5f)));
+        REQUIRE(std::isfinite(filter.process(0.25f)));
+    }
 }
 
 TEST_CASE("Biquad sample and block processing paths match",


### PR DESCRIPTION
## Summary
- add Biquad impulse-response regression anchors across lowpass, highpass, bandpass, notch, allpass, peaking, low-shelf, and high-shelf modes
- add valid-extreme control checks for low/high frequency, high/low Q, and shelf/peaking gain cases
- keep the PR test-only after Codecov did not reliably credit inline header guard branches
- batch size: 48 meaningful response/finite checks in the signal/Biquad area

## Validation
- `git diff --check origin/main...HEAD`
- `pulp_cli_version_check`
- confirmed branch is based on latest `origin/main` (`81533b63a`)
- no local build/test run; follow-up validation is running through GitHub checks

Version-Bump: sdk=skip reason="coverage-focused Biquad regression tests with no API/version surface change"