### PR TITLE
feat(osc): route bundles through public receiver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.252.0
+    VERSION 0.253.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/osc/include/pulp/osc/osc.hpp
+++ b/core/osc/include/pulp/osc/osc.hpp
@@ -6,6 +6,8 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <string_view>
+#include <utility>
 
 namespace pulp::osc {
 
@@ -34,13 +36,15 @@ struct Message {
     std::string get_string(size_t i, const std::string& def = "") const;
 };
 
+struct Bundle;
+
 // ── OSC Encoding/Decoding ────────────────────────────────────────────────────
 
 // Encode a message to OSC binary format
 std::vector<uint8_t> encode(const Message& msg);
 
 // Decode an OSC binary packet into a message
-// Returns nullopt if the data is malformed
+// Returns an empty-address message if the data is malformed.
 Message decode(const uint8_t* data, size_t size);
 
 // ── OSC Sender ───────────────────────────────────────────────────────────────
@@ -56,6 +60,9 @@ public:
 
     // Send a message
     bool send(const Message& msg);
+
+    // Send a bundle
+    bool send(const Bundle& bundle);
 
     // Send a raw, already-encoded OSC datagram (e.g., a #bundle or any
     // byte-exact payload the caller has pre-built). Returns true if the
@@ -76,14 +83,40 @@ private:
 
 // Receives OSC messages over UDP
 using MessageHandler = std::function<void(const Message&)>;
+using BundleHandler = std::function<void(const Bundle&)>;
+using FormatErrorHandler = std::function<void(std::string_view)>;
+
+struct ReceiverRoute {
+    std::string address_pattern;
+    MessageHandler handler;
+};
+
+struct ReceiverOptions {
+    MessageHandler on_message;
+    BundleHandler on_bundle;
+    FormatErrorHandler on_error;
+    std::vector<ReceiverRoute> routes;
+};
 
 class Receiver {
 public:
     Receiver();
     ~Receiver();
 
+    Receiver(const Receiver&) = delete;
+    Receiver& operator=(const Receiver&) = delete;
+    Receiver(Receiver&&) = delete;
+    Receiver& operator=(Receiver&&) = delete;
+
     // Start listening on a port
     bool listen(uint16_t port, MessageHandler handler);
+
+    // Start listening with bundle, error, and address-route callbacks.
+    // Receiver callbacks may call stop(); shutdown short-circuits remaining
+    // callbacks for the current datagram. Destroying a Receiver from its own
+    // callback is supported; worker state stays alive until the callback and
+    // receive thread finish unwinding.
+    bool listen_with_options(uint16_t port, ReceiverOptions options);
 
     // Stop listening
     void stop();
@@ -92,8 +125,10 @@ public:
     uint16_t local_port() const;
 
 private:
+    void stop_impl(bool destroying);
+
     struct Impl;
-    std::unique_ptr<Impl> impl_;
+    std::shared_ptr<Impl> impl_;
 };
 
 } // namespace pulp::osc

--- a/core/osc/src/bundle.cpp
+++ b/core/osc/src/bundle.cpp
@@ -39,10 +39,6 @@ static void write_bytes(std::vector<uint8_t>& buf, const void* data, size_t n) {
     buf.insert(buf.end(), p, p + n);
 }
 
-static void pad_to_4(std::vector<uint8_t>& buf) {
-    while (buf.size() % 4 != 0) buf.push_back(0);
-}
-
 std::vector<uint8_t> Bundle::serialize() const {
     std::vector<uint8_t> buf;
 
@@ -75,6 +71,7 @@ std::vector<uint8_t> Bundle::serialize() const {
 }
 
 std::optional<Bundle> Bundle::deserialize(const uint8_t* data, size_t size) {
+    if (data == nullptr) return std::nullopt;
     if (size < 16) return std::nullopt;  // minimum: header(8) + timetag(8)
 
     // Verify "#bundle\0" header
@@ -143,9 +140,11 @@ bool address_matches(std::string_view pattern, std::string_view address) {
                 ++pi;
                 bool negate = pi < pattern.size() && pattern[pi] == '!';
                 if (negate) ++pi;
+                bool saw_member = false;
                 bool matched = false;
                 bool closed = false;
                 while (pi < pattern.size() && pattern[pi] != ']') {
+                    saw_member = true;
                     if (pi + 2 < pattern.size() && pattern[pi + 1] == '-') {
                         if (address[ai] >= pattern[pi] && address[ai] <= pattern[pi + 2])
                             matched = true;
@@ -160,6 +159,7 @@ bool address_matches(std::string_view pattern, std::string_view address) {
                     ++pi;  // skip ']'
                 }
                 if (!closed) return false;
+                if (!saw_member) return false;
                 if (matched == negate) return false;
                 ++ai;
             } else if (pc == '{') {
@@ -169,12 +169,17 @@ bool address_matches(std::string_view pattern, std::string_view address) {
                 while (close < pattern.size() && pattern[close] != '}') ++close;
                 if (close == pattern.size()) return false;
 
+                if (pi == close) return false;
+
                 size_t scan = pi;
                 while (scan < close) {
                     size_t start = scan;
                     while (scan < close && pattern[scan] != ',') ++scan;
                     if (scan == start) return false;
-                    if (scan < close && pattern[scan] == ',') ++scan;
+                    if (scan < close && pattern[scan] == ',') {
+                        ++scan;
+                        if (scan == close) return false;
+                    }
                 }
 
                 while (pi < pattern.size() && pattern[pi] != '}') {

--- a/core/osc/src/osc_udp.cpp
+++ b/core/osc/src/osc_udp.cpp
@@ -198,6 +198,9 @@ bool Receiver::listen(uint16_t port, MessageHandler handler) {
     addr.sin_addr.s_addr = INADDR_ANY;
     addr.sin_port = htons(port);
 
+    // Keep receivers exclusive. Linux permits multiple UDP binds when all
+    // participants opt into SO_REUSEADDR, which makes packet delivery
+    // ambiguous for this one-handler Receiver API.
     if (bind(impl_->sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
         close_socket(impl_->sock);
         impl_->sock = kInvalidSocket;

--- a/core/osc/src/osc_udp.cpp
+++ b/core/osc/src/osc_udp.cpp
@@ -190,14 +190,15 @@ bool Sender::is_connected() const { return impl_->connected; }
 // ── Receiver ─────────────────────────────────────────────────────────────────
 
 struct Receiver::Impl {
-    SocketHandle sock = kInvalidSocket;
+    std::atomic<SocketHandle> sock{kInvalidSocket};
     std::thread thread;
     std::atomic<bool> running{false};
     ReceiverOptions options;
     std::atomic<uint16_t> local_port{0};
 
     ~Impl() {
-        if (sock != kInvalidSocket) close_socket(sock);
+        const auto old_sock = sock.exchange(kInvalidSocket, std::memory_order_acq_rel);
+        if (old_sock != kInvalidSocket) close_socket(old_sock);
     }
 
     bool is_running() const {
@@ -267,8 +268,8 @@ bool Receiver::listen_with_options(uint16_t port, ReceiverOptions options) {
         stop();
     }
     impl->local_port.store(0, std::memory_order_relaxed);
-    impl->sock = socket(AF_INET, SOCK_DGRAM, 0);
-    if (impl->sock == kInvalidSocket) return false;
+    auto sock = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sock == kInvalidSocket) return false;
 
     sockaddr_in addr{};
     addr.sin_family = AF_INET;
@@ -280,27 +281,24 @@ bool Receiver::listen_with_options(uint16_t port, ReceiverOptions options) {
     // ambiguous for this one-handler Receiver API.
 #if defined(_WIN32)
     BOOL exclusive_addr = TRUE;
-    if (setsockopt(impl->sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE,
+    if (setsockopt(sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE,
                    reinterpret_cast<const char*>(&exclusive_addr),
                    sizeof(exclusive_addr)) < 0) {
-        close_socket(impl->sock);
-        impl->sock = kInvalidSocket;
+        close_socket(sock);
         return false;
     }
 #endif
-    if (bind(impl->sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
-        close_socket(impl->sock);
-        impl->sock = kInvalidSocket;
+    if (bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+        close_socket(sock);
         return false;
     }
 
     sockaddr_in bound_addr{};
     SockLen bound_len = static_cast<SockLen>(sizeof(bound_addr));
-    if (getsockname(impl->sock,
+    if (getsockname(sock,
                     reinterpret_cast<sockaddr*>(&bound_addr),
                     &bound_len) < 0) {
-        close_socket(impl->sock);
-        impl->sock = kInvalidSocket;
+        close_socket(sock);
         return false;
     }
     impl->local_port.store(ntohs(bound_addr.sin_port), std::memory_order_relaxed);
@@ -308,31 +306,33 @@ bool Receiver::listen_with_options(uint16_t port, ReceiverOptions options) {
     // Set receive timeout so we can check running_ flag
 #if defined(_WIN32)
     DWORD timeout_ms = 100;
-    if (setsockopt(impl->sock, SOL_SOCKET, SO_RCVTIMEO,
+    if (setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO,
                    reinterpret_cast<const char*>(&timeout_ms), sizeof(timeout_ms)) < 0) {
-        close_socket(impl->sock);
-        impl->sock = kInvalidSocket;
+        close_socket(sock);
         impl->local_port.store(0, std::memory_order_relaxed);
         return false;
     }
 #else
     timeval tv{0, 100000}; // 100ms
-    if (setsockopt(impl->sock, SOL_SOCKET, SO_RCVTIMEO,
+    if (setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO,
                    reinterpret_cast<const char*>(&tv), sizeof(tv)) < 0) {
-        close_socket(impl->sock);
-        impl->sock = kInvalidSocket;
+        close_socket(sock);
         impl->local_port.store(0, std::memory_order_relaxed);
         return false;
     }
 #endif
 
     impl->options = std::move(options);
+    impl->sock.store(sock, std::memory_order_release);
     impl->running = true;
 
     impl->thread = std::thread([impl] {
         std::vector<uint8_t> buf(kMaxUdpDatagramSize);
         while (impl->running) {
-            auto n = recv(impl->sock,
+            const auto sock = impl->sock.load(std::memory_order_acquire);
+            if (sock == kInvalidSocket)
+                break;
+            auto n = recv(sock,
                           reinterpret_cast<char*>(buf.data()),
                           static_cast<int>(buf.size()),
                           0);
@@ -396,9 +396,10 @@ void Receiver::stop_impl(bool destroying) {
     //      valid, so there's no race window.
     //   3. Join the thread — guaranteed to see running=false and exit.
     //   4. Only then close the FD. No one else holds it anymore.
-    // If a callback calls stop() on the receiver thread itself, requesting
-    // shutdown is enough. The next outside stop()/destructor call owns join
-    // and close; joining here would self-join and terminate.
+    // If a callback calls stop() on the receiver thread itself, close the
+    // socket now so the port is released immediately, but leave thread join to
+    // the next outside stop()/destructor call. Joining here would self-join and
+    // terminate.
     auto impl = impl_;
     if (!impl) return;
 
@@ -407,23 +408,22 @@ void Receiver::stop_impl(bool destroying) {
         && impl->thread.get_id() == std::this_thread::get_id();
 
     impl->running = false;
-    if (impl->sock != kInvalidSocket) {
+    const auto sock = impl->sock.exchange(kInvalidSocket, std::memory_order_acq_rel);
+    if (sock != kInvalidSocket) {
 #if defined(_WIN32)
-        ::shutdown(impl->sock, SD_BOTH);
+        ::shutdown(sock, SD_BOTH);
 #else
-        ::shutdown(impl->sock, SHUT_RDWR);
+        ::shutdown(sock, SHUT_RDWR);
 #endif
     }
     if (called_from_receiver_thread) {
         impl->local_port.store(0, std::memory_order_relaxed);
+        if (sock != kInvalidSocket) close_socket(sock);
         if (destroying && impl->thread.joinable()) impl->thread.detach();
         return;
     }
     if (impl->thread.joinable()) impl->thread.join();
-    if (impl->sock != kInvalidSocket) {
-        close_socket(impl->sock);
-        impl->sock = kInvalidSocket;
-    }
+    if (sock != kInvalidSocket) close_socket(sock);
     impl->local_port.store(0, std::memory_order_relaxed);
     impl->options = {};
 }

--- a/core/osc/src/osc_udp.cpp
+++ b/core/osc/src/osc_udp.cpp
@@ -1,8 +1,11 @@
 #include <pulp/osc/osc.hpp>
+#include <pulp/osc/bundle.hpp>
 
 #include <thread>
 #include <atomic>
 #include <cerrno>
+#include <cstring>
+#include <utility>
 
 #if defined(_WIN32)
 #ifndef NOMINMAX
@@ -22,6 +25,12 @@
 #endif
 
 namespace pulp::osc {
+
+namespace {
+
+constexpr size_t kMaxUdpDatagramSize = 65536;
+
+} // namespace
 
 #if defined(_WIN32)
 using SocketHandle = SOCKET;
@@ -98,13 +107,14 @@ bool Sender::connect(const std::string& host, uint16_t port) {
     #if defined(_WIN32)
     if (!ensure_winsock()) return false;
     #endif
-    impl_->sock = socket(AF_INET, SOCK_DGRAM, 0);
-    if (impl_->sock == kInvalidSocket) return false;
+    auto sock = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sock == kInvalidSocket) return false;
 
-    impl_->dest.sin_family = AF_INET;
-    impl_->dest.sin_port = htons(port);
+    sockaddr_in dest{};
+    dest.sin_family = AF_INET;
+    dest.sin_port = htons(port);
 
-    if (inet_pton(AF_INET, host.c_str(), &impl_->dest.sin_addr) <= 0) {
+    if (inet_pton(AF_INET, host.c_str(), &dest.sin_addr) <= 0) {
         addrinfo hints{};
         hints.ai_family = AF_INET;
         hints.ai_socktype = SOCK_DGRAM;
@@ -113,8 +123,7 @@ bool Sender::connect(const std::string& host, uint16_t port) {
         const std::string port_string = std::to_string(port);
         if (getaddrinfo(host.c_str(), port_string.c_str(), &hints, &results) != 0
             || results == nullptr) {
-            close_socket(impl_->sock);
-            impl_->sock = kInvalidSocket;
+            close_socket(sock);
             return false;
         }
 
@@ -127,7 +136,7 @@ bool Sender::connect(const std::string& host, uint16_t port) {
             }
 
             const auto* addr = reinterpret_cast<const sockaddr_in*>(result->ai_addr);
-            impl_->dest.sin_addr = addr->sin_addr;
+            dest.sin_addr = addr->sin_addr;
             resolved = true;
             break;
         }
@@ -135,18 +144,25 @@ bool Sender::connect(const std::string& host, uint16_t port) {
         freeaddrinfo(results);
 
         if (!resolved) {
-            close_socket(impl_->sock);
-            impl_->sock = kInvalidSocket;
+            close_socket(sock);
             return false;
         }
     }
 
+    if (impl_->sock != kInvalidSocket) close_socket(impl_->sock);
+    impl_->sock = sock;
+    impl_->dest = dest;
     impl_->connected = true;
     return true;
 }
 
 bool Sender::send(const Message& msg) {
     auto data = encode(msg);
+    return send_raw(data.data(), data.size());
+}
+
+bool Sender::send(const Bundle& bundle) {
+    auto data = bundle.serialize();
     return send_raw(data.data(), data.size());
 }
 
@@ -177,21 +193,82 @@ struct Receiver::Impl {
     SocketHandle sock = kInvalidSocket;
     std::thread thread;
     std::atomic<bool> running{false};
-    MessageHandler handler;
+    ReceiverOptions options;
     std::atomic<uint16_t> local_port{0};
+
+    ~Impl() {
+        if (sock != kInvalidSocket) close_socket(sock);
+    }
+
+    bool is_running() const {
+        return running.load(std::memory_order_acquire);
+    }
+
+    void dispatch_error(std::string_view reason) {
+        if (!is_running()) return;
+        if (options.on_error) options.on_error(reason);
+    }
+
+    void dispatch_message(const Message& msg) {
+        if (!is_running()) return;
+        if (options.on_message) {
+            options.on_message(msg);
+            if (!is_running()) return;
+        }
+        for (const auto& route : options.routes) {
+            if (!is_running()) return;
+            if (!route.handler) continue;
+            if (route.address_pattern.empty()
+                || address_matches(route.address_pattern, msg.address)) {
+                route.handler(msg);
+            }
+        }
+    }
+
+    void dispatch_bundle_messages(const Bundle& bundle) {
+        for (const auto& element : bundle.elements) {
+            if (!is_running()) return;
+            if (element.is_message()) {
+                dispatch_message(element.message());
+            } else if (element.is_bundle()) {
+                dispatch_bundle_messages(element.bundle());
+            }
+        }
+    }
+
+    void dispatch_bundle(const Bundle& bundle) {
+        if (!is_running()) return;
+        if (options.on_bundle) {
+            options.on_bundle(bundle);
+            if (!is_running()) return;
+        }
+        dispatch_bundle_messages(bundle);
+    }
 };
 
-Receiver::Receiver() : impl_(std::make_unique<Impl>()) {}
+Receiver::Receiver() : impl_(std::make_shared<Impl>()) {}
 
-Receiver::~Receiver() { stop(); }
+Receiver::~Receiver() { stop_impl(true); }
 
 bool Receiver::listen(uint16_t port, MessageHandler handler) {
+    ReceiverOptions options;
+    options.on_message = std::move(handler);
+    return listen_with_options(port, std::move(options));
+}
+
+bool Receiver::listen_with_options(uint16_t port, ReceiverOptions options) {
     #if defined(_WIN32)
     if (!ensure_winsock()) return false;
     #endif
-    impl_->local_port.store(0, std::memory_order_relaxed);
-    impl_->sock = socket(AF_INET, SOCK_DGRAM, 0);
-    if (impl_->sock == kInvalidSocket) return false;
+    auto impl = impl_;
+    if (impl->running.load(std::memory_order_acquire)) return false;
+    if (impl->thread.joinable()) {
+        if (impl->thread.get_id() == std::this_thread::get_id()) return false;
+        stop();
+    }
+    impl->local_port.store(0, std::memory_order_relaxed);
+    impl->sock = socket(AF_INET, SOCK_DGRAM, 0);
+    if (impl->sock == kInvalidSocket) return false;
 
     sockaddr_in addr{};
     addr.sin_family = AF_INET;
@@ -201,55 +278,91 @@ bool Receiver::listen(uint16_t port, MessageHandler handler) {
     // Keep receivers exclusive. Linux permits multiple UDP binds when all
     // participants opt into SO_REUSEADDR, which makes packet delivery
     // ambiguous for this one-handler Receiver API.
-    if (bind(impl_->sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
-        close_socket(impl_->sock);
-        impl_->sock = kInvalidSocket;
+#if defined(_WIN32)
+    BOOL exclusive_addr = TRUE;
+    if (setsockopt(impl->sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE,
+                   reinterpret_cast<const char*>(&exclusive_addr),
+                   sizeof(exclusive_addr)) < 0) {
+        close_socket(impl->sock);
+        impl->sock = kInvalidSocket;
+        return false;
+    }
+#endif
+    if (bind(impl->sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+        close_socket(impl->sock);
+        impl->sock = kInvalidSocket;
         return false;
     }
 
     sockaddr_in bound_addr{};
     SockLen bound_len = static_cast<SockLen>(sizeof(bound_addr));
-    if (getsockname(impl_->sock,
+    if (getsockname(impl->sock,
                     reinterpret_cast<sockaddr*>(&bound_addr),
                     &bound_len) < 0) {
-        close_socket(impl_->sock);
-        impl_->sock = kInvalidSocket;
+        close_socket(impl->sock);
+        impl->sock = kInvalidSocket;
         return false;
     }
-    impl_->local_port.store(ntohs(bound_addr.sin_port), std::memory_order_relaxed);
+    impl->local_port.store(ntohs(bound_addr.sin_port), std::memory_order_relaxed);
 
     // Set receive timeout so we can check running_ flag
 #if defined(_WIN32)
     DWORD timeout_ms = 100;
-    setsockopt(impl_->sock, SOL_SOCKET, SO_RCVTIMEO,
-               reinterpret_cast<const char*>(&timeout_ms), sizeof(timeout_ms));
+    if (setsockopt(impl->sock, SOL_SOCKET, SO_RCVTIMEO,
+                   reinterpret_cast<const char*>(&timeout_ms), sizeof(timeout_ms)) < 0) {
+        close_socket(impl->sock);
+        impl->sock = kInvalidSocket;
+        impl->local_port.store(0, std::memory_order_relaxed);
+        return false;
+    }
 #else
     timeval tv{0, 100000}; // 100ms
-    setsockopt(impl_->sock, SOL_SOCKET, SO_RCVTIMEO,
-               reinterpret_cast<const char*>(&tv), sizeof(tv));
+    if (setsockopt(impl->sock, SOL_SOCKET, SO_RCVTIMEO,
+                   reinterpret_cast<const char*>(&tv), sizeof(tv)) < 0) {
+        close_socket(impl->sock);
+        impl->sock = kInvalidSocket;
+        impl->local_port.store(0, std::memory_order_relaxed);
+        return false;
+    }
 #endif
 
-    impl_->handler = std::move(handler);
-    impl_->running = true;
+    impl->options = std::move(options);
+    impl->running = true;
 
-    impl_->thread = std::thread([this] {
-        uint8_t buf[4096];
-        while (impl_->running) {
-            auto n = recv(impl_->sock, reinterpret_cast<char*>(buf), sizeof(buf), 0);
-            if (n > 0 && impl_->handler) {
-                auto msg = decode(buf, static_cast<size_t>(n));
-                if (!msg.address.empty()) {
-                    impl_->handler(msg);
+    impl->thread = std::thread([impl] {
+        std::vector<uint8_t> buf(kMaxUdpDatagramSize);
+        while (impl->running) {
+            auto n = recv(impl->sock,
+                          reinterpret_cast<char*>(buf.data()),
+                          static_cast<int>(buf.size()),
+                          0);
+            if (n > 0) {
+                const auto packet_size = static_cast<size_t>(n);
+                if (packet_size >= 8 && std::memcmp(buf.data(), "#bundle", 8) == 0) {
+                    auto bundle = Bundle::deserialize(buf.data(), packet_size);
+                    if (bundle) {
+                        impl->dispatch_bundle(*bundle);
+                    } else {
+                        impl->dispatch_error("malformed OSC bundle");
+                    }
+                } else {
+                    auto msg = decode(buf.data(), packet_size);
+                    if (!msg.address.empty()) {
+                        impl->dispatch_message(msg);
+                    } else {
+                        impl->dispatch_error("malformed OSC message");
+                    }
                 }
                 continue;
             }
 
             if (n == 0) {
+                impl->dispatch_error("malformed OSC message");
                 continue;
             }
 
             const int error = socket_last_error();
-            if (!impl_->running) {
+            if (!impl->running) {
                 break;
             }
             if (is_recv_timeout(error)) {
@@ -265,13 +378,17 @@ bool Receiver::listen(uint16_t port, MessageHandler handler) {
 }
 
 void Receiver::stop() {
+    stop_impl(false);
+}
+
+void Receiver::stop_impl(bool destroying) {
     // Shutdown ordering matters (#490). The receive thread may be
     // blocked inside recv() on this FD right now. If we close the FD
     // before joining, POSIX kernels are free to recycle that FD number
     // for an unrelated file/socket immediately — the receive thread's
     // NEXT iteration would then read from the wrong FD. That's UB.
     //
-    // Correct order:
+    // Correct order for callers outside the receiver thread:
     //   1. Flip `running` so the thread exits its loop after any
     //      current recv() returns.
     //   2. shutdown() the socket to wake recv() with the sentinel
@@ -279,23 +396,41 @@ void Receiver::stop() {
     //      valid, so there's no race window.
     //   3. Join the thread — guaranteed to see running=false and exit.
     //   4. Only then close the FD. No one else holds it anymore.
-    impl_->running = false;
-    if (impl_->sock != kInvalidSocket) {
+    // If a callback calls stop() on the receiver thread itself, requesting
+    // shutdown is enough. The next outside stop()/destructor call owns join
+    // and close; joining here would self-join and terminate.
+    auto impl = impl_;
+    if (!impl) return;
+
+    const bool called_from_receiver_thread =
+        impl->thread.joinable()
+        && impl->thread.get_id() == std::this_thread::get_id();
+
+    impl->running = false;
+    if (impl->sock != kInvalidSocket) {
 #if defined(_WIN32)
-        ::shutdown(impl_->sock, SD_BOTH);
+        ::shutdown(impl->sock, SD_BOTH);
 #else
-        ::shutdown(impl_->sock, SHUT_RDWR);
+        ::shutdown(impl->sock, SHUT_RDWR);
 #endif
     }
-    if (impl_->thread.joinable()) impl_->thread.join();
-    if (impl_->sock != kInvalidSocket) {
-        close_socket(impl_->sock);
-        impl_->sock = kInvalidSocket;
+    if (called_from_receiver_thread) {
+        impl->local_port.store(0, std::memory_order_relaxed);
+        if (destroying && impl->thread.joinable()) impl->thread.detach();
+        return;
     }
-    impl_->local_port.store(0, std::memory_order_relaxed);
+    if (impl->thread.joinable()) impl->thread.join();
+    if (impl->sock != kInvalidSocket) {
+        close_socket(impl->sock);
+        impl->sock = kInvalidSocket;
+    }
+    impl->local_port.store(0, std::memory_order_relaxed);
+    impl->options = {};
 }
 
-bool Receiver::is_listening() const { return impl_->running; }
+bool Receiver::is_listening() const {
+    return impl_->running.load(std::memory_order_acquire);
+}
 
 uint16_t Receiver::local_port() const {
     return impl_->local_port.load(std::memory_order_relaxed);

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `2d8f004a`; local post-rebase validation passing; SDK version is `0.241.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `0d934d4c`; local post-rebase validation passing; SDK version is `0.241.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased/validated; final SDK bump and push pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -523,9 +523,9 @@ PR2 implementation scope:
 
 PR2 validation and PR state:
 - PR #2822: https://github.com/danielraffel/pulp/pull/2822
-- The branch is rebased onto `origin/main` at `2d8f004a` after #2825, #2905,
-  #2900, #2909, #2906, #2914, #2908, and #2898 landed. The fresh required SDK
-  bump is `0.241.0`.
+- The branch is rebased onto `origin/main` at `0d934d4c` after #2825, #2905,
+  #2900, #2909, #2906, #2914, #2908, #2898, and #2913 landed. The fresh
+  required SDK bump is `0.241.0`.
 - Initial PR review-comment and issue-comment sweep found no comments to
   address. The first CI failure was the version-bump commit-shape guard; it was
   fixed by splitting the `0.209.0` API bump into the canonical
@@ -585,6 +585,15 @@ PR2 validation and PR state:
   --accept-intent-trailers` passes for SDK `0.240.0`, and `git diff --check`
   passes.
 - After the `2d8f004a` rebase, local post-rebase validation passed:
+  `cmake --build build --target pulp-test-osc pulp-test-osc-channel
+  pulp-test-events pulp-test-ipc -j8` and
+  `ctest --test-dir build --output-on-failure -R
+  'OSC|OscChannel|EventLoop|MainThread|main-thread|dispatcher|IPC|Interprocess'`
+  154/154. `python3 tools/scripts/version_bump_check.py --base origin/main
+  --config tools/scripts/versioning.json --mode=report
+  --require-bump-for-fix-feat --accept-intent-trailers` passes for SDK
+  `0.241.0`, and `git diff --check` passes.
+- After the `0d934d4c` rebase, local post-rebase validation passed:
   `cmake --build build --target pulp-test-osc pulp-test-osc-channel
   pulp-test-events pulp-test-ipc -j8` and
   `ctest --test-dir build --output-on-failure -R

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased and locally validated on `origin/main` `e68b1cbd` after main consumed SDK `0.249.0`; SDK version is `0.250.0`; hosted Ubuntu install-consumer smoke passed on the SheenBidi install fix | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased and locally validated on `origin/main` `a7e223f8` after main consumed SDK `0.250.0`; SDK version is `0.251.0`; hosted Ubuntu install-consumer smoke passed on the SheenBidi install fix | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased/validated; final SDK bump and push pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -769,6 +769,22 @@ PR2 validation and PR state:
   --mode report`, `python3 tools/scripts/version_bump_check.py --base
   origin/main --config tools/scripts/versioning.json --mode=report
   --require-bump-for-fix-feat --accept-intent-trailers` for SDK `0.250.0`,
+  Release/GPU-off configure and build of `pulp-test-osc`,
+  `pulp-test-osc-channel`, `pulp-test-events`, and `pulp-test-ipc`,
+  `ctest --test-dir build -R '^(OscChannel|OSC|IPC|EventLoop)'
+  --output-on-failure` 132/132, Release flag verification for
+  `pulp-test-osc`, `tools/check-docs.sh` with the existing 76 warnings, and
+  diff hygiene.
+- While the refreshed `27bacda5c` checks were running, `main` advanced through
+  #2966/#2967 and consumed SDK `0.250.0`. The branch was rebased again onto
+  `origin/main` at `a7e223f8`; the now-upstream `0.250.0` bump was dropped
+  during rebase, and a fresh SDK bump to `0.251.0` was applied. Local
+  validation passed again: `python3 tools/scripts/test_audit_top_level.py`
+  10/10, `python3 tools/audit.py --`, `python3
+  tools/scripts/skill_sync_check.py --base origin/main --head HEAD --mode
+  report`, `python3 tools/scripts/version_bump_check.py --base origin/main
+  --config tools/scripts/versioning.json --mode=report
+  --require-bump-for-fix-feat --accept-intent-trailers` for SDK `0.251.0`,
   Release/GPU-off configure and build of `pulp-test-osc`,
   `pulp-test-osc-channel`, `pulp-test-events`, and `pulp-test-ipc`,
   `ctest --test-dir build -R '^(OscChannel|OSC|IPC|EventLoop)'

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased and locally validated on `origin/main` `df0c82622` after a stale-base skill-sync range failure; SDK version remains `0.251.0`; hosted Ubuntu install-consumer smoke passed on the SheenBidi install fix | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased and locally validated on `origin/main` `e276edd17` after #2970 consumed SDK `0.252.0`; SDK version is now `0.253.0`; hosted Ubuntu install-consumer smoke passed on the SheenBidi install fix | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased/validated; final SDK bump and push pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -807,6 +807,20 @@ PR2 validation and PR state:
   '^(OscChannel|OSC|IPC|EventLoop)' --output-on-failure` 132/132, Release flag
   verification for `pulp-test-osc`, `tools/check-docs.sh` with the existing 76
   warnings, and diff hygiene.
+- While the refreshed `da604cf7c` checks were running, `main` advanced through
+  #2970 and consumed SDK `0.252.0`. The branch was rebased again onto
+  `origin/main` at `e276edd17`; the now-upstream Pro Tools audit allowlist
+  commit and stale `0.251.0` bump were skipped during rebase, and a fresh SDK
+  bump to `0.253.0` was applied. Local validation passed again: `python3
+  tools/scripts/test_audit_top_level.py` 11/11, `python3 tools/audit.py --`,
+  `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD
+  --mode report`, `python3 tools/scripts/version_bump_check.py --base
+  origin/main --config tools/scripts/versioning.json --mode=report
+  --require-bump-for-fix-feat --accept-intent-trailers` for SDK `0.253.0`,
+  Release/GPU-off configure and build of `pulp-test-osc`,
+  `pulp-test-osc-channel`, `pulp-test-events`, and `pulp-test-ipc`, and
+  `ctest --test-dir build -R '^(OscChannel|OSC|IPC|EventLoop)'
+  --output-on-failure` 132/132.
 - `tools/scripts/local_diff_cover.sh` hits the local GPU/Skia configure gate in
   this worktree, so the same coverage pipeline was run manually in
   `build-cov` with `PULP_ENABLE_COVERAGE=ON`, `PULP_ENABLE_GPU=OFF`, the OSC

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `ebf75ab`; local post-rebase/audit validation passing; SDK version is `0.246.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; locally rebased onto `origin/main` at `1a11c516`; local post-rebase/audit validation passing; SDK version is `0.247.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased/validated; final SDK bump and push pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -679,6 +679,23 @@ PR2 validation and PR state:
   `ctest --test-dir build -R '^(OscChannel|OSC|IPC|EventLoop)'
   --output-on-failure` 132/132, version-bump report for SDK `0.246.0`,
   `tools/check-docs.sh` with 76 existing warnings, and `git diff --check`.
+- Hosted CI on the `7e5c401a3` head then failed `Enforce version & skill sync`
+  because `main` advanced through #2935, #2936, #2937, and the v0.245.0
+  changelog while the checks were running. The resulting PR comparison included
+  unrelated main-side audio/format adapter paths, so the skill-sync failure was
+  a stale-base range race rather than an OSC implementation failure. The branch
+  was rebased onto `origin/main` at `1a11c516`; the stale `0.246.0` bump was
+  skipped as already upstream, and a fresh required SDK bump to `0.247.0` was
+  applied. Local validation passed again: `python3
+  tools/scripts/test_audit_top_level.py` 10/10, `python3 tools/audit.py --`,
+  `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD
+  --mode report`, `python3 tools/scripts/version_bump_check.py --base
+  origin/main --config tools/scripts/versioning.json --mode=report
+  --require-bump-for-fix-feat --accept-intent-trailers` for SDK `0.247.0`,
+  `cmake --build build --target pulp-test-osc pulp-test-osc-channel
+  pulp-test-events pulp-test-ipc -j8`, `ctest --test-dir build -R
+  '^(OscChannel|OSC|IPC|EventLoop)' --output-on-failure` 132/132, and
+  `tools/check-docs.sh` with 76 existing warnings.
 - `tools/scripts/local_diff_cover.sh` hits the local GPU/Skia configure gate in
   this worktree, so the same coverage pipeline was run manually in
   `build-cov` with `PULP_ENABLE_COVERAGE=ON`, `PULP_ENABLE_GPU=OFF`, the OSC

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `e8e6586f6`; local post-rebase validation passing; SDK version is `0.239.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `67a9266b0`; local post-rebase validation passing; SDK version is `0.240.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; rebase/validation pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -523,8 +523,9 @@ PR2 implementation scope:
 
 PR2 validation and PR state:
 - PR #2822: https://github.com/danielraffel/pulp/pull/2822
-- The branch is rebased onto `origin/main` at `e8e6586f6` after #2825, #2905,
-  #2900, #2909, and #2906 landed. The fresh required SDK bump is `0.239.0`.
+- The branch is rebased onto `origin/main` at `67a9266b0` after #2825, #2905,
+  #2900, #2909, #2906, and #2914 landed. The fresh required SDK bump is
+  `0.240.0`.
 - Initial PR review-comment and issue-comment sweep found no comments to
   address. The first CI failure was the version-bump commit-shape guard; it was
   fixed by splitting the `0.209.0` API bump into the canonical
@@ -573,7 +574,7 @@ PR2 validation and PR state:
   `cmake --build build --target pulp-test-osc pulp-test-osc-channel -j8` and
   `ctest --test-dir build --output-on-failure -R 'OSC|OscChannel'` passed
   100/100.
-- After the `e8e6586f6` rebase, local post-rebase validation passed:
+- After the `67a9266b0` rebase, local post-rebase validation passed:
   `cmake --build build --target pulp-test-osc pulp-test-osc-channel
   pulp-test-events pulp-test-ipc -j8`,
   `ctest --test-dir build --output-on-failure -R 'OSC|OscChannel'` 100/100,
@@ -581,7 +582,7 @@ PR2 validation and PR state:
   `ctest --test-dir build --output-on-failure -R
   'OSC|OscChannel|EventLoop|MainThread|main-thread|dispatcher|IPC|Interprocess'`
   154/154. `python3 tools/scripts/version_bump_check.py --mode=report
-  --accept-intent-trailers` passes for SDK `0.239.0`, and `git diff --check`
+  --accept-intent-trailers` passes for SDK `0.240.0`, and `git diff --check`
   passes.
 - `tools/scripts/local_diff_cover.sh` hits the local GPU/Skia configure gate in
   this worktree, so the same coverage pipeline was run manually in

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; locally rebased onto `origin/main` at `7be39f4a`; local post-rebase/audit validation passing; SDK version is `0.248.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; pushed at `8a8ddd3ad` after a GitHub Actions rerun-state reset; SDK version is `0.248.0`; local validation and hosted Ubuntu install-consumer smoke passed | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased/validated; final SDK bump and push pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -719,6 +719,15 @@ PR2 validation and PR state:
   SheenBidi package files are present, and configured a downstream
   `find_package(Pulp)` + `pulp_add_plugin(... FORMATS CLAP ...)` consumer that
   explicitly checks `TARGET SheenBidi::SheenBidi`.
+- The refreshed hosted Ubuntu install-consumer smoke then passed on the
+  SheenBidi fix, covering the downstream `find_package(Pulp)` + install-prefix
+  path in CI. The same hosted check wave hit GitHub Actions infrastructure
+  failures unrelated to branch code: multiple jobs failed before checkout with
+  `remote: Your account is suspended`/HTTP 403, coverage failed while
+  downloading actions from `codeload.github.com`, and rescue/rerun left several
+  workflows queued without jobs or cancelled before steps ran. An empty
+  `chore: retrigger OSC CI` commit was pushed at `8a8ddd3ad`, followed by this
+  living-doc update, to force a clean PR check set without changing OSC code.
 - `tools/scripts/local_diff_cover.sh` hits the local GPU/Skia configure gate in
   this worktree, so the same coverage pipeline was run manually in
   `build-cov` with `PULP_ENABLE_COVERAGE=ON`, `PULP_ENABLE_GPU=OFF`, the OSC

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; pushed at `8a8ddd3ad` after a GitHub Actions rerun-state reset; SDK version is `0.248.0`; local validation and hosted Ubuntu install-consumer smoke passed | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased and locally validated on `origin/main` `bae205c3` after GitHub Actions recovered; SDK version is `0.248.0`; hosted Ubuntu install-consumer smoke passed on the SheenBidi install fix | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased/validated; final SDK bump and push pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -728,6 +728,21 @@ PR2 validation and PR state:
   workflows queued without jobs or cancelled before steps ran. An empty
   `chore: retrigger OSC CI` commit was pushed at `8a8ddd3ad`, followed by this
   living-doc update, to force a clean PR check set without changing OSC code.
+- GitHub resolved the Actions/Pages incident at 2026-05-26 13:18 UTC and
+  Actions returned to operational status. The branch was then rebased cleanly
+  onto `origin/main` at `bae205c3` after `main` advanced through the coverage
+  PR stack without consuming SDK `0.248.0`. Post-rebase local validation
+  passed: `python3 tools/scripts/test_audit_top_level.py` 10/10,
+  `python3 tools/audit.py --`, `python3 tools/scripts/skill_sync_check.py
+  --base origin/main --head HEAD --mode report`,
+  `python3 tools/scripts/version_bump_check.py --base origin/main --config
+  tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat
+  --accept-intent-trailers` for SDK `0.248.0`, Release/GPU-off configure and
+  build of `pulp-test-osc`, `pulp-test-osc-channel`, `pulp-test-events`, and
+  `pulp-test-ipc`, `ctest --test-dir build -R '^(OscChannel|OSC|IPC|EventLoop)'
+  --output-on-failure` 132/132, Release flag verification for
+  `pulp-test-osc`, `tools/check-docs.sh` with the existing 76 warnings, and
+  diff hygiene.
 - `tools/scripts/local_diff_cover.sh` hits the local GPU/Skia configure gate in
   this worktree, so the same coverage pipeline was run manually in
   `build-cov` with `PULP_ENABLE_COVERAGE=ON`, `PULP_ENABLE_GPU=OFF`, the OSC

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `90a21146f`; local post-rebase validation passing; SDK version is `0.242.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `ad72d830`; local post-rebase validation passing; SDK version is `0.242.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased/validated; final SDK bump and push pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -523,9 +523,10 @@ PR2 implementation scope:
 
 PR2 validation and PR state:
 - PR #2822: https://github.com/danielraffel/pulp/pull/2822
-- The branch is rebased onto `origin/main` at `90a21146f` after #2825, #2905,
+- The branch is rebased onto `origin/main` at `ad72d830` after #2825, #2905,
   #2900, #2909, #2906, #2914, #2908, #2898, #2913, the regenerated v0.238.0
-  changelog, and #2901 landed. The fresh required SDK bump is `0.242.0`.
+  changelog, #2901, and #2902 landed. The fresh required SDK bump is
+  `0.242.0`.
 - Initial PR review-comment and issue-comment sweep found no comments to
   address. The first CI failure was the version-bump commit-shape guard; it was
   fixed by splitting the `0.209.0` API bump into the canonical
@@ -613,6 +614,16 @@ PR2 validation and PR state:
   `0.241.0`, `tools/check-docs.sh` passes with 76 existing warnings, and
   `git diff --check` passes.
 - After the `90a21146f` rebase, local post-rebase validation passed:
+  `cmake --build build --target pulp-test-osc pulp-test-osc-channel
+  pulp-test-events pulp-test-ipc -j8` and
+  `ctest --test-dir build --output-on-failure -R
+  'OSC|OscChannel|EventLoop|MainThread|main-thread|dispatcher|IPC|Interprocess'`
+  154/154. `python3 tools/scripts/version_bump_check.py --base origin/main
+  --config tools/scripts/versioning.json --mode=report
+  --require-bump-for-fix-feat --accept-intent-trailers` passes for SDK
+  `0.242.0`, `tools/check-docs.sh` passes with 76 existing warnings, and
+  `git diff --check` passes.
+- After the `ad72d830` rebase, local post-rebase validation passed:
   `cmake --build build --target pulp-test-osc pulp-test-osc-channel
   pulp-test-events pulp-test-ipc -j8` and
   `ctest --test-dir build --output-on-failure -R

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,8 +27,8 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `6125c235a`; local post-rebase validation passing; SDK version is `0.240.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
-| Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; rebase/validation pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `2d8f004a`; local post-rebase validation passing; SDK version is `0.241.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased/validated; final SDK bump and push pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
 - Add or update focused unit tests for every new public behavior.
@@ -523,9 +523,9 @@ PR2 implementation scope:
 
 PR2 validation and PR state:
 - PR #2822: https://github.com/danielraffel/pulp/pull/2822
-- The branch is rebased onto `origin/main` at `6125c235a` after #2825, #2905,
-  #2900, #2909, #2906, #2914, and #2908 landed. The fresh required SDK bump is
-  `0.240.0`.
+- The branch is rebased onto `origin/main` at `2d8f004a` after #2825, #2905,
+  #2900, #2909, #2906, #2914, #2908, and #2898 landed. The fresh required SDK
+  bump is `0.241.0`.
 - Initial PR review-comment and issue-comment sweep found no comments to
   address. The first CI failure was the version-bump commit-shape guard; it was
   fixed by splitting the `0.209.0` API bump into the canonical
@@ -584,6 +584,15 @@ PR2 validation and PR state:
   154/154. `python3 tools/scripts/version_bump_check.py --mode=report
   --accept-intent-trailers` passes for SDK `0.240.0`, and `git diff --check`
   passes.
+- After the `2d8f004a` rebase, local post-rebase validation passed:
+  `cmake --build build --target pulp-test-osc pulp-test-osc-channel
+  pulp-test-events pulp-test-ipc -j8` and
+  `ctest --test-dir build --output-on-failure -R
+  'OSC|OscChannel|EventLoop|MainThread|main-thread|dispatcher|IPC|Interprocess'`
+  154/154. `python3 tools/scripts/version_bump_check.py --base origin/main
+  --config tools/scripts/versioning.json --mode=report
+  --require-bump-for-fix-feat --accept-intent-trailers` passes for SDK
+  `0.241.0`, and `git diff --check` passes.
 - `tools/scripts/local_diff_cover.sh` hits the local GPU/Skia configure gate in
   this worktree, so the same coverage pipeline was run manually in
   `build-cov` with `PULP_ENABLE_COVERAGE=ON`, `PULP_ENABLE_GPU=OFF`, the OSC

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `acf025a`; local post-rebase/audit validation passing; SDK version is `0.245.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `ebf75ab`; local post-rebase/audit validation passing; SDK version is `0.246.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased/validated; final SDK bump and push pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -670,6 +670,15 @@ PR2 validation and PR state:
   build -R '^(OscChannel|OSC|IPC|EventLoop)' --output-on-failure` 132/132,
   version-bump report for SDK `0.245.0`, `tools/check-docs.sh` with 76 existing
   warnings, and `git diff --check`.
+- `main` advanced again to `ebf75ab` through #2934 and consumed SDK `0.245.0`
+  while #2822 hosted checks were starting. The stale bump was dropped during
+  rebase and a fresh required SDK bump to `0.246.0` was applied. Local
+  validation passed again: `python3 tools/scripts/test_audit_top_level.py`
+  10/10, `python3 tools/audit.py --`, `cmake --build build --target
+  pulp-test-osc pulp-test-osc-channel pulp-test-events pulp-test-ipc -j8`,
+  `ctest --test-dir build -R '^(OscChannel|OSC|IPC|EventLoop)'
+  --output-on-failure` 132/132, version-bump report for SDK `0.246.0`,
+  `tools/check-docs.sh` with 76 existing warnings, and `git diff --check`.
 - `tools/scripts/local_diff_cover.sh` hits the local GPU/Skia configure gate in
   this worktree, so the same coverage pipeline was run manually in
   `build-cov` with `PULP_ENABLE_COVERAGE=ON`, `PULP_ENABLE_GPU=OFF`, the OSC

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `ad72d830`; local post-rebase validation passing; SDK version is `0.242.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `24f1eba`; local post-rebase validation passing; SDK version is `0.244.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased/validated; final SDK bump and push pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -632,6 +632,19 @@ PR2 validation and PR state:
   --config tools/scripts/versioning.json --mode=report
   --require-bump-for-fix-feat --accept-intent-trailers` passes for SDK
   `0.242.0`, `tools/check-docs.sh` passes with 76 existing warnings, and
+  `git diff --check` passes.
+- After `main` advanced to `24f1eba` through #2929 and consumed SDK
+  `0.243.0`, the stale `0.242.0` bump commit was skipped during rebase and a
+  fresh required SDK bump to `0.244.0` was applied. Local post-rebase
+  validation passed:
+  `cmake --build build --target pulp-test-osc pulp-test-osc-channel
+  pulp-test-events pulp-test-ipc -j8` and
+  `ctest --test-dir build --output-on-failure -R
+  'OSC|OscChannel|EventLoop|MainThread|main-thread|dispatcher|IPC|Interprocess'`
+  154/154. `python3 tools/scripts/version_bump_check.py --base origin/main
+  --config tools/scripts/versioning.json --mode=report
+  --require-bump-for-fix-feat --accept-intent-trailers` passes for SDK
+  `0.244.0`, `tools/check-docs.sh` passes with 76 existing warnings, and
   `git diff --check` passes.
 - `tools/scripts/local_diff_cover.sh` hits the local GPU/Skia configure gate in
   this worktree, so the same coverage pipeline was run manually in

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -709,6 +709,16 @@ PR2 validation and PR state:
   pulp-test-events pulp-test-ipc -j8`, `ctest --test-dir build -R
   '^(OscChannel|OSC|IPC|EventLoop)' --output-on-failure` 132/132,
   `tools/check-docs.sh` with 76 existing warnings, and `git diff --check`.
+- Hosted install-consumer smoke then exposed an installed-SDK packaging gap:
+  `PulpConfig.cmake` loaded `PulpTargets.cmake` before defining the private
+  static dependency target `SheenBidi::SheenBidi`, so downstream
+  `find_package(Pulp)` consumers failed while validating exported targets. The
+  branch now loads SheenBidi through `find_dependency(SheenBidi CONFIG)` before
+  `PulpTargets.cmake`. Local validation rebuilt and installed a clean
+  Release/GPU-off SDK to `/tmp/pulp-install-check`, verified the installed
+  SheenBidi package files are present, and configured a downstream
+  `find_package(Pulp)` + `pulp_add_plugin(... FORMATS CLAP ...)` consumer that
+  explicitly checks `TARGET SheenBidi::SheenBidi`.
 - `tools/scripts/local_diff_cover.sh` hits the local GPU/Skia configure gate in
   this worktree, so the same coverage pipeline was run manually in
   `build-cov` with `PULP_ENABLE_COVERAGE=ON`, `PULP_ENABLE_GPU=OFF`, the OSC

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `60f0a0f3`; local post-rebase validation passing; SDK version is `0.238.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `e8e6586f6`; local post-rebase validation passing; SDK version is `0.239.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; rebase/validation pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -523,8 +523,8 @@ PR2 implementation scope:
 
 PR2 validation and PR state:
 - PR #2822: https://github.com/danielraffel/pulp/pull/2822
-- The branch is rebased onto `origin/main` at `60f0a0f3` after #2825, #2905,
-  and #2900 landed. The fresh required SDK bump is `0.238.0`.
+- The branch is rebased onto `origin/main` at `e8e6586f6` after #2825, #2905,
+  #2900, #2909, and #2906 landed. The fresh required SDK bump is `0.239.0`.
 - Initial PR review-comment and issue-comment sweep found no comments to
   address. The first CI failure was the version-bump commit-shape guard; it was
   fixed by splitting the `0.209.0` API bump into the canonical
@@ -573,7 +573,7 @@ PR2 validation and PR state:
   `cmake --build build --target pulp-test-osc pulp-test-osc-channel -j8` and
   `ctest --test-dir build --output-on-failure -R 'OSC|OscChannel'` passed
   100/100.
-- After the `60f0a0f3` rebase, local post-rebase validation passed:
+- After the `e8e6586f6` rebase, local post-rebase validation passed:
   `cmake --build build --target pulp-test-osc pulp-test-osc-channel
   pulp-test-events pulp-test-ipc -j8`,
   `ctest --test-dir build --output-on-failure -R 'OSC|OscChannel'` 100/100,
@@ -581,7 +581,7 @@ PR2 validation and PR state:
   `ctest --test-dir build --output-on-failure -R
   'OSC|OscChannel|EventLoop|MainThread|main-thread|dispatcher|IPC|Interprocess'`
   154/154. `python3 tools/scripts/version_bump_check.py --mode=report
-  --accept-intent-trailers` passes for SDK `0.238.0`, and `git diff --check`
+  --accept-intent-trailers` passes for SDK `0.239.0`, and `git diff --check`
   passes.
 - `tools/scripts/local_diff_cover.sh` hits the local GPU/Skia configure gate in
   this worktree, so the same coverage pipeline was run manually in

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `4cd4bdb`; local post-rebase validation passing; SDK version is `0.241.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `90a21146f`; local post-rebase validation passing; SDK version is `0.242.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased/validated; final SDK bump and push pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -523,9 +523,9 @@ PR2 implementation scope:
 
 PR2 validation and PR state:
 - PR #2822: https://github.com/danielraffel/pulp/pull/2822
-- The branch is rebased onto `origin/main` at `4cd4bdb` after #2825, #2905,
-  #2900, #2909, #2906, #2914, #2908, #2898, #2913, and the regenerated
-  v0.238.0 changelog landed. The fresh required SDK bump is `0.241.0`.
+- The branch is rebased onto `origin/main` at `90a21146f` after #2825, #2905,
+  #2900, #2909, #2906, #2914, #2908, #2898, #2913, the regenerated v0.238.0
+  changelog, and #2901 landed. The fresh required SDK bump is `0.242.0`.
 - Initial PR review-comment and issue-comment sweep found no comments to
   address. The first CI failure was the version-bump commit-shape guard; it was
   fixed by splitting the `0.209.0` API bump into the canonical
@@ -611,6 +611,16 @@ PR2 validation and PR state:
   --config tools/scripts/versioning.json --mode=report
   --require-bump-for-fix-feat --accept-intent-trailers` passes for SDK
   `0.241.0`, `tools/check-docs.sh` passes with 76 existing warnings, and
+  `git diff --check` passes.
+- After the `90a21146f` rebase, local post-rebase validation passed:
+  `cmake --build build --target pulp-test-osc pulp-test-osc-channel
+  pulp-test-events pulp-test-ipc -j8` and
+  `ctest --test-dir build --output-on-failure -R
+  'OSC|OscChannel|EventLoop|MainThread|main-thread|dispatcher|IPC|Interprocess'`
+  154/154. `python3 tools/scripts/version_bump_check.py --base origin/main
+  --config tools/scripts/versioning.json --mode=report
+  --require-bump-for-fix-feat --accept-intent-trailers` passes for SDK
+  `0.242.0`, `tools/check-docs.sh` passes with 76 existing warnings, and
   `git diff --check` passes.
 - `tools/scripts/local_diff_cover.sh` hits the local GPU/Skia configure gate in
   this worktree, so the same coverage pipeline was run manually in

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `95d8532`; local post-rebase validation passing; SDK version is `0.245.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `acf025a`; local post-rebase/audit validation passing; SDK version is `0.245.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased/validated; final SDK bump and push pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -659,6 +659,17 @@ PR2 validation and PR state:
   --require-bump-for-fix-feat --accept-intent-trailers` passes for SDK
   `0.245.0`, `tools/check-docs.sh` passes with 76 existing warnings, and
   `git diff --check` passes.
+- Hosted CI then surfaced a repo-audit false positive after `main` introduced
+  the first-party host-quirk header `core/format/include/pulp/format/host_quirks/pro_tools.hpp`.
+  The audit scanner still correctly blocks vendor-shaped files elsewhere, but
+  now allowlists that Pulp-owned header. The branch was rebased again onto
+  `origin/main` at `acf025a` after #2932, clearing the skill-sync range race.
+  Local validation passed: `python3 tools/scripts/test_audit_top_level.py` 10/10,
+  `python3 tools/audit.py --`, `cmake --build build --target pulp-test-osc
+  pulp-test-osc-channel pulp-test-events pulp-test-ipc -j8`, `ctest --test-dir
+  build -R '^(OscChannel|OSC|IPC|EventLoop)' --output-on-failure` 132/132,
+  version-bump report for SDK `0.245.0`, `tools/check-docs.sh` with 76 existing
+  warnings, and `git diff --check`.
 - `tools/scripts/local_diff_cover.sh` hits the local GPU/Skia configure gate in
   this worktree, so the same coverage pipeline was run manually in
   `build-cov` with `PULP_ENABLE_COVERAGE=ON`, `PULP_ENABLE_GPU=OFF`, the OSC

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -527,17 +527,20 @@ PR2 validation and PR state:
   address. The first CI failure was the version-bump commit-shape guard; it was
   fixed by splitting the `0.209.0` API bump into the canonical
   `chore: bump versions` commit. The refreshed version/skill check is passing.
-- At the latest sweep, docs, source pollution, header self-containment,
-  version/skill, dependency audit, Linux release-path, macOS build/test, and
-  advisory include-what-you-use checks were passing. Longer GitHub-hosted
-  platform, sanitizer, install-smoke, Android, and macOS release-path checks
-  were still queued or running; no refreshed check failure was present.
+- A later PR sweep found no human review threads. The stale pre-rebase hosted
+  matrix had unrelated Linux inspector failures and Windows process/IPC/
+  inspector/import-design failures; no SSH Windows/Ubuntu validation is part of
+  this focused pass. The stale Codecov bot report had patch coverage below the
+  advisory 75% target, so this branch was rebased onto current `main` and the
+  OSC coverage tests were tightened before pushing a refreshed head.
 - `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF`
 - `cmake --build build --target pulp-test-osc pulp-test-osc-bundle
   pulp-test-osc-channel`
 - Focused CTest coverage for route matching, typed bundle send/receive,
   malformed message/bundle callbacks, exclusive receiver binding, receiver
-  restart rejection, and occupied local-port channel failure passed.
+  restart rejection, occupied local-port channel failure, successful sender
+  reconnect over an existing socket, empty route handlers, and receiver-thread
+  listen rejection after callback-requested stop passed.
 - `ctest --test-dir build --output-on-failure -j4 --timeout 120 -R
   'OSC|OscChannel|osc|Bundle::deserialize rejects null data with bundle-sized
   length'` passed 100/100 after the final unconnected bundle-send,
@@ -549,13 +552,22 @@ PR2 validation and PR state:
   covered as a lifecycle regression. Malformed-input coverage includes real
   zero-length UDP datagrams and trailing-empty address-pattern alternatives.
   Bundle transport coverage includes disconnect/reconnect sends and empty bundle
-  receive.
+  receive. A fresh focused release run after the rebase passed
+  `ctest --test-dir build --output-on-failure -R 'OSC|OscChannel'` 100/100.
 - `tools/scripts/local_diff_cover.sh` hits the local GPU/Skia configure gate in
   this worktree, so the same coverage pipeline was run manually in
-  `build-cov-osc` with `PULP_ENABLE_GPU=OFF`, the OSC targets, and the same
-  75% diff-coverage floor. Result: 94% total diff coverage
-  (`core/osc/src/bundle.cpp` 100%, `core/osc/src/osc_udp.cpp` 94.3%). GitHub
-  Codecov remains the authoritative PR-side coverage result.
+  `build-cov` with `PULP_ENABLE_COVERAGE=ON`, `PULP_ENABLE_GPU=OFF`, the OSC
+  targets, `LLVM_PROFILE_FILE`, and the same 75% diff-coverage floor. The
+  focused coverage CTest run passed 100/100. Result: 94% total diff coverage
+  (`core/osc/src/bundle.cpp` 100%, `core/osc/src/osc_udp.cpp` 94.3%). The
+  remaining uncovered diff lines are defensive socket cleanup paths for
+  unresolved addrinfo, `getsockname()` failure, and receive-timeout
+  `setsockopt()` failure that are not deterministic to force through the public
+  API; GitHub Codecov remains the authoritative PR-side coverage result after
+  the refreshed push.
+- Final RepoPrompt and Claude blocker reviews after the rebase and coverage
+  sweep found no P0/P1 correctness issues in the branch implementation or the
+  pending OSC test/docs updates.
 
 ## Suggested Order
 

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased and locally validated on `origin/main` `e7cc41b0` after main consumed SDK `0.248.0`; SDK version is `0.249.0`; hosted Ubuntu install-consumer smoke passed on the SheenBidi install fix | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased and locally validated on `origin/main` `e68b1cbd` after main consumed SDK `0.249.0`; SDK version is `0.250.0`; hosted Ubuntu install-consumer smoke passed on the SheenBidi install fix | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased/validated; final SDK bump and push pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -753,6 +753,22 @@ PR2 validation and PR state:
   --mode report`, `python3 tools/scripts/version_bump_check.py --base
   origin/main --config tools/scripts/versioning.json --mode=report
   --require-bump-for-fix-feat --accept-intent-trailers` for SDK `0.249.0`,
+  Release/GPU-off configure and build of `pulp-test-osc`,
+  `pulp-test-osc-channel`, `pulp-test-events`, and `pulp-test-ipc`,
+  `ctest --test-dir build -R '^(OscChannel|OSC|IPC|EventLoop)'
+  --output-on-failure` 132/132, Release flag verification for
+  `pulp-test-osc`, `tools/check-docs.sh` with the existing 76 warnings, and
+  diff hygiene.
+- While the refreshed `0bae9c202` checks were running, `main` advanced through
+  #2963, regenerated the v0.249.0 changelog, and consumed SDK `0.249.0`. The
+  branch was rebased again onto `origin/main` at `e68b1cbd`; the now-upstream
+  `0.249.0` bump was dropped during rebase, and a fresh SDK bump to `0.250.0`
+  was applied. Local validation passed again: `python3
+  tools/scripts/test_audit_top_level.py` 10/10, `python3 tools/audit.py --`,
+  `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD
+  --mode report`, `python3 tools/scripts/version_bump_check.py --base
+  origin/main --config tools/scripts/versioning.json --mode=report
+  --require-bump-for-fix-feat --accept-intent-trailers` for SDK `0.250.0`,
   Release/GPU-off configure and build of `pulp-test-osc`,
   `pulp-test-osc-channel`, `pulp-test-events`, and `pulp-test-ipc`,
   `ctest --test-dir build -R '^(OscChannel|OSC|IPC|EventLoop)'

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased and locally validated on `origin/main` `bae205c3` after GitHub Actions recovered; SDK version is `0.248.0`; hosted Ubuntu install-consumer smoke passed on the SheenBidi install fix | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased and locally validated on `origin/main` `e7cc41b0` after main consumed SDK `0.248.0`; SDK version is `0.249.0`; hosted Ubuntu install-consumer smoke passed on the SheenBidi install fix | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased/validated; final SDK bump and push pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -740,6 +740,22 @@ PR2 validation and PR state:
   --accept-intent-trailers` for SDK `0.248.0`, Release/GPU-off configure and
   build of `pulp-test-osc`, `pulp-test-osc-channel`, `pulp-test-events`, and
   `pulp-test-ipc`, `ctest --test-dir build -R '^(OscChannel|OSC|IPC|EventLoop)'
+  --output-on-failure` 132/132, Release flag verification for
+  `pulp-test-osc`, `tools/check-docs.sh` with the existing 76 warnings, and
+  diff hygiene.
+- While the refreshed `c77a22d79` checks were running, `main` advanced through
+  #2958/#2959, regenerated the v0.248.0 changelog, and consumed SDK
+  `0.248.0`. The branch was rebased again onto `origin/main` at `e7cc41b0`;
+  the now-upstream `0.248.0` bump was dropped during rebase, and a fresh SDK
+  bump to `0.249.0` was applied. Local validation passed again: `python3
+  tools/scripts/test_audit_top_level.py` 10/10, `python3 tools/audit.py --`,
+  `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD
+  --mode report`, `python3 tools/scripts/version_bump_check.py --base
+  origin/main --config tools/scripts/versioning.json --mode=report
+  --require-bump-for-fix-feat --accept-intent-trailers` for SDK `0.249.0`,
+  Release/GPU-off configure and build of `pulp-test-osc`,
+  `pulp-test-osc-channel`, `pulp-test-events`, and `pulp-test-ipc`,
+  `ctest --test-dir build -R '^(OscChannel|OSC|IPC|EventLoop)'
   --output-on-failure` 132/132, Release flag verification for
   `pulp-test-osc`, `tools/check-docs.sh` with the existing 76 warnings, and
   diff hygiene.

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased and locally validated on `origin/main` `e276edd17` after #2970 consumed SDK `0.252.0`; SDK version is now `0.253.0`; hosted Ubuntu install-consumer smoke passed on the SheenBidi install fix | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased and locally validated on `origin/main` `b2a5b3f78` after #2970 consumed SDK `0.252.0` and #2939 upstreamed the audit allowlist; SDK version is now `0.253.0`; hosted Ubuntu install-consumer smoke passed on the SheenBidi install fix | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased/validated; final SDK bump and push pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -808,10 +808,11 @@ PR2 validation and PR state:
   verification for `pulp-test-osc`, `tools/check-docs.sh` with the existing 76
   warnings, and diff hygiene.
 - While the refreshed `da604cf7c` checks were running, `main` advanced through
-  #2970 and consumed SDK `0.252.0`. The branch was rebased again onto
-  `origin/main` at `e276edd17`; the now-upstream Pro Tools audit allowlist
-  commit and stale `0.251.0` bump were skipped during rebase, and a fresh SDK
-  bump to `0.253.0` was applied. Local validation passed again: `python3
+  #2970 and consumed SDK `0.252.0`, then #2939 upstreamed the Pro Tools audit
+  allowlist. The branch was rebased again onto `origin/main` at `b2a5b3f78`;
+  the now-upstream audit allowlist commit and stale `0.251.0` bump were skipped
+  during rebase, and a fresh SDK bump to `0.253.0` was applied. Local
+  validation passed again: `python3
   tools/scripts/test_audit_top_level.py` 11/11, `python3 tools/audit.py --`,
   `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD
   --mode report`, `python3 tools/scripts/version_bump_check.py --base

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -521,7 +521,17 @@ PR2 implementation scope:
 - Address-pattern validation now fails closed for trailing empty alternatives
   such as `{foo,}` and `{foo,bar,}`.
 
-PR2 local validation so far:
+PR2 validation and PR state:
+- Draft PR #2822: https://github.com/danielraffel/pulp/pull/2822
+- Initial PR review-comment and issue-comment sweep found no comments to
+  address. The first CI failure was the version-bump commit-shape guard; it was
+  fixed by splitting the `0.209.0` API bump into the canonical
+  `chore: bump versions` commit. The refreshed version/skill check is passing.
+- At the latest sweep, docs, source pollution, header self-containment,
+  version/skill, dependency audit, Linux release-path, macOS build/test, and
+  advisory include-what-you-use checks were passing. Longer GitHub-hosted
+  platform, sanitizer, install-smoke, Android, and macOS release-path checks
+  were still queued or running; no refreshed check failure was present.
 - `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF`
 - `cmake --build build --target pulp-test-osc pulp-test-osc-bundle
   pulp-test-osc-channel`

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `24f1eba`; local post-rebase validation passing; SDK version is `0.244.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `95d8532`; local post-rebase validation passing; SDK version is `0.245.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased/validated; final SDK bump and push pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -645,6 +645,19 @@ PR2 validation and PR state:
   --config tools/scripts/versioning.json --mode=report
   --require-bump-for-fix-feat --accept-intent-trailers` passes for SDK
   `0.244.0`, `tools/check-docs.sh` passes with 76 existing warnings, and
+  `git diff --check` passes.
+- After `main` advanced again to `95d8532` through #2931 and consumed SDK
+  `0.244.0`, Git dropped the stale `0.244.0` bump as already upstream during
+  rebase and a fresh required SDK bump to `0.245.0` was applied. Local
+  post-rebase validation passed:
+  `cmake --build build --target pulp-test-osc pulp-test-osc-channel
+  pulp-test-events pulp-test-ipc -j8` and
+  `ctest --test-dir build --output-on-failure -R
+  'OSC|OscChannel|EventLoop|MainThread|main-thread|dispatcher|IPC|Interprocess'`
+  154/154. `python3 tools/scripts/version_bump_check.py --base origin/main
+  --config tools/scripts/versioning.json --mode=report
+  --require-bump-for-fix-feat --accept-intent-trailers` passes for SDK
+  `0.245.0`, `tools/check-docs.sh` passes with 76 existing warnings, and
   `git diff --check` passes.
 - `tools/scripts/local_diff_cover.sh` hits the local GPU/Skia configure gate in
   this worktree, so the same coverage pipeline was run manually in

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `67a9266b0`; local post-rebase validation passing; SDK version is `0.240.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `6125c235a`; local post-rebase validation passing; SDK version is `0.240.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; rebase/validation pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -523,8 +523,8 @@ PR2 implementation scope:
 
 PR2 validation and PR state:
 - PR #2822: https://github.com/danielraffel/pulp/pull/2822
-- The branch is rebased onto `origin/main` at `67a9266b0` after #2825, #2905,
-  #2900, #2909, #2906, and #2914 landed. The fresh required SDK bump is
+- The branch is rebased onto `origin/main` at `6125c235a` after #2825, #2905,
+  #2900, #2909, #2906, #2914, and #2908 landed. The fresh required SDK bump is
   `0.240.0`.
 - Initial PR review-comment and issue-comment sweep found no comments to
   address. The first CI failure was the version-bump commit-shape guard; it was
@@ -574,7 +574,7 @@ PR2 validation and PR state:
   `cmake --build build --target pulp-test-osc pulp-test-osc-channel -j8` and
   `ctest --test-dir build --output-on-failure -R 'OSC|OscChannel'` passed
   100/100.
-- After the `67a9266b0` rebase, local post-rebase validation passed:
+- After the `6125c235a` rebase, local post-rebase validation passed:
   `cmake --build build --target pulp-test-osc pulp-test-osc-channel
   pulp-test-events pulp-test-ipc -j8`,
   `ctest --test-dir build --output-on-failure -R 'OSC|OscChannel'` 100/100,

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -26,9 +26,9 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | Track | Branch target | Worktree target | Status | Done means |
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
-| Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | PR [#2825](https://github.com/danielraffel/pulp/pull/2825) open; rebased onto current `origin/main` at `66428b24`; focused dispatcher/IPC/OSC, inspector, and design-debug validation passing; shared hosted CI portability fixes added for inspector/design-debug/OSC Linux failures found during the PR sweep; SDK version is `0.236.0` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open, ready for review; rebased onto current `main`; local OSC suite and manual GPU-off diff coverage passing | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, focused UDP and pure parser tests |
-| Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | Queued | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
+| Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebasing onto current `origin/main` after #2825 merge; local post-rebase validation pending | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; rebase/validation pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
 - Add or update focused unit tests for every new public behavior.
@@ -39,9 +39,10 @@ Validation expectations for each PR:
 - Sweep the full local diff for correctness, lifecycle, cross-platform, and
   docs issues before opening the PR; use Claude as an independent review pass
   and fix actionable findings before submitting.
-- Use the normal Shipyard PR flow so required checks and Codecov comments are
-  recorded before merge. For this focused pass, do not run SSH Windows/Ubuntu
-  validation lanes; use local/macOS evidence and GitHub-hosted checks.
+- Use the normal Shipyard/GitHub PR flow so required checks and Codecov
+  comments are recorded before merge. For this focused pass, do not run SSH
+  Windows/Ubuntu validation lanes; use local/macOS evidence and GitHub-hosted
+  checks.
 - After each PR opens, sweep Shipyard/GitHub review and CI comments, address
   actionable feedback on the same branch, and re-run focused validation before
   moving to the next feature.
@@ -57,7 +58,7 @@ Validation expectations for each PR:
 | Audio file formats | Partially implemented | `core/audio/src/format_registry.cpp`, `core/audio/src/audio_file.cpp`, `core/audio/src/aiff_reader.cpp`, `core/audio/src/ogg_reader.cpp`, `core/audio/src/flac_writer.cpp`, `core/audio/src/mp3_writer.cpp`, `core/audio/CMakeLists.txt` |
 | Audio devices and multichannel audio | Partially implemented | `core/audio/include/pulp/audio/device.hpp`, `core/audio/include/pulp/audio/channel_set.hpp`, `core/audio/platform/mac/coreaudio_device.mm`, `core/audio/platform/win/wasapi_device.cpp`, `core/audio/platform/linux/alsa_device.cpp`, `core/audio/platform/linux/jack_device.cpp` |
 | Native window embedding | Partially implemented | `core/view/include/pulp/view/window_host.hpp`, `core/view/include/pulp/view/plugin_view_host.hpp`, `core/view/src/window_host_stub.cpp`, `core/view/src/plugin_view_host_stub.cpp`, `core/host/include/pulp/host/plugin_slot.hpp` |
-| OSC | Partially implemented | `core/osc/include/pulp/osc/osc.hpp`, `core/osc/include/pulp/osc/bundle.hpp`, `core/osc/src/osc.cpp`, `core/osc/src/osc_udp.cpp`, `core/osc/src/bundle.cpp`, `core/osc/src/osc_channel.cpp`, `test/test_osc_channel.cpp` |
+| OSC | In closure | `core/osc/include/pulp/osc/osc.hpp`, `core/osc/include/pulp/osc/bundle.hpp`, `core/osc/src/osc.cpp`, `core/osc/src/osc_udp.cpp`, `core/osc/src/bundle.cpp`, `core/osc/src/osc_channel.cpp`, `test/test_osc.cpp`, `test/test_osc_channel.cpp` |
 
 ## Gaps Worth Closing
 
@@ -205,11 +206,11 @@ PR1 submit and review sweep:
   translation unit without UBSan instrumentation while keeping Pulp's script and
   view code instrumented. The previously failing Figma, Stitch, Pencil, and
   baked-native materialization cases now pass locally under UBSan.
-- GitHub-hosted Linux CI surfaced a latent OSC UDP portability gap: `Receiver`
-  enabled `SO_REUSEADDR`, which lets Linux bind multiple receivers to the same
-  UDP port and breaks the existing exclusive-listener contract. `Receiver` now
-  binds exclusively; the public API can add an explicit shared-port mode later
-  if a real use case needs it.
+- PR #2815 was squash-merged into `main` on 2026-05-25.
+- GitHub-hosted Linux CI surfaced a latent OSC UDP portability gap after PR1:
+  `Receiver` enabled `SO_REUSEADDR`, which lets Linux bind multiple receivers
+  to the same UDP port and breaks the existing exclusive-listener contract. That
+  fix is carried in PR2 because PR1 had already merged.
 
 ### 2. Main-Thread Dispatch and Native Event Loop
 
@@ -477,15 +478,85 @@ Recommended work:
 - Extend tests to cover nested bundles, bundle receive paths, address filtering,
   and invalid-packet handling.
 
+PR2 implementation scope:
+- `Sender::send(const Bundle&)` serializes typed bundles through the existing UDP
+  datagram primitive and preserves the existing connected-state rejection path.
+  Reconnect behavior is covered for bundle sends after `disconnect()` and a new
+  target `connect()`.
+- `Receiver::listen_with_options()` adds a non-ambiguous options-based API while
+  preserving the existing `listen(port, handler)` source contract, including
+  `listen(port, {})`.
+- `ReceiverOptions` exposes top-level `on_bundle`, `on_message`, `on_error`, and
+  address-pattern `ReceiverRoute` callbacks. Direct messages and messages inside
+  nested bundles are routed through the existing `address_matches()` matcher.
+- The receiver detects `#bundle` datagrams, deserializes typed bundles, reports
+  malformed bundles through `on_error`, and reports malformed message datagrams
+  through `on_error` instead of silently dropping them when rich receiver options
+  are used, including valid zero-length UDP datagrams that are malformed OSC
+  packets. Empty bundles dispatch through `on_bundle` without synthetic message
+  callbacks.
+- The UDP receive path now sizes its packet buffer for full UDP datagrams, so
+  valid bundles larger than the old 4 KiB stack buffer are delivered instead of
+  being parsed as truncated malformed packets.
+- UDP receivers now bind exclusively so the one-receiver-per-port contract is
+  consistent on Linux and macOS; an explicit shared-port mode can be added later
+  if a real API need appears. The Windows path sets `SO_EXCLUSIVEADDRUSE`
+  before `bind()` to preserve the same contract against sockets that opt into
+  shared address use.
+- `Receiver::listen_with_options()` now treats receive-timeout setup failure as
+  a listen failure instead of starting a receiver that may not stop promptly.
+- Receiver callbacks can request `stop()` from the receiver thread without
+  self-joining; cleanup is completed by the next outside `stop()` or
+  destructor call, the receiver can be reused without requiring a manual cleanup
+  call first, and callback fanout for the current datagram stops immediately
+  once shutdown has been requested. Receiver worker state is ref-counted so
+  destroying a receiver-owned object from inside a callback cannot free the
+  socket/thread state before the receive thread unwinds.
+- `Sender::connect()` now commits a new UDP socket and destination only after
+  host resolution succeeds, so a failed reconnect cannot leak the previous
+  socket or leave the sender disconnected from its existing destination.
+- `Bundle::deserialize()` now rejects null data even when the caller provides a
+  bundle-sized length, matching the rest of the malformed-packet rejection
+  behavior.
+- Address-pattern validation now fails closed for trailing empty alternatives
+  such as `{foo,}` and `{foo,bar,}`.
+
+PR2 local validation so far:
+- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF`
+- `cmake --build build --target pulp-test-osc pulp-test-osc-bundle
+  pulp-test-osc-channel`
+- Focused CTest coverage for route matching, typed bundle send/receive,
+  malformed message/bundle callbacks, exclusive receiver binding, receiver
+  restart rejection, and occupied local-port channel failure passed.
+- `ctest --test-dir build --output-on-failure -j4 --timeout 120 -R
+  'OSC|OscChannel|osc|Bundle::deserialize rejects null data with bundle-sized
+  length'` passed 100/100 after the final unconnected bundle-send,
+  failed-reconnect, large-bundle receive, callback self-stop, and null
+  bundle-deserialize assertions were added. The callback self-stop coverage also
+  verifies that a receiver can restart after the callback-requested stop and
+  that stop short-circuits bundle, message, route, and nested bundle callback
+  fanout for the current datagram. Callback-time receiver-owner destruction is
+  covered as a lifecycle regression. Malformed-input coverage includes real
+  zero-length UDP datagrams and trailing-empty address-pattern alternatives.
+  Bundle transport coverage includes disconnect/reconnect sends and empty bundle
+  receive.
+- `tools/scripts/local_diff_cover.sh` hits the local GPU/Skia configure gate in
+  this worktree, so the same coverage pipeline was run manually in
+  `build-cov-osc` with `PULP_ENABLE_GPU=OFF`, the OSC targets, and the same
+  75% diff-coverage floor. Result: 94% total diff coverage
+  (`core/osc/src/bundle.cpp` 100%, `core/osc/src/osc_udp.cpp` 94.3%). GitHub
+  Codecov remains the authoritative PR-side coverage result.
+
 ## Suggested Order
 
-1. JACK `DeviceInfo` reconciliation and AIFC compression whitelist.
-2. Audio format capability reporting and tests.
-3. OSC bundle-aware send/receive and format-error callbacks.
-4. Process API cleanup, including the `ConnectedChildProcess` layering decision.
-5. Audio device manager MVP.
-6. Main-thread dispatcher.
-7. Non-Apple native embedding implementations.
+1. Threads/processes closure in PR #2815. Complete.
+2. OSC bundle-aware send/receive, listener filtering, and format-error
+   callbacks. Active.
+3. Main-thread dispatcher.
+4. Non-Apple native embedding implementations or explicit supported-platform
+   contracts.
+5. Larger follow-up audit for audio formats, audio device management, and any
+   remaining platform capability claims.
 
 The first three are relatively contained and can turn partial support into
 clear, testable guarantees. The latter work touches broader platform contracts

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebasing onto current `origin/main` after #2825 merge; local post-rebase validation pending | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `60f0a0f3`; local post-rebase validation passing; SDK version is `0.238.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; rebase/validation pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -522,7 +522,9 @@ PR2 implementation scope:
   such as `{foo,}` and `{foo,bar,}`.
 
 PR2 validation and PR state:
-- Draft PR #2822: https://github.com/danielraffel/pulp/pull/2822
+- PR #2822: https://github.com/danielraffel/pulp/pull/2822
+- The branch is rebased onto `origin/main` at `60f0a0f3` after #2825, #2905,
+  and #2900 landed. The fresh required SDK bump is `0.238.0`.
 - Initial PR review-comment and issue-comment sweep found no comments to
   address. The first CI failure was the version-bump commit-shape guard; it was
   fixed by splitting the `0.209.0` API bump into the canonical
@@ -571,6 +573,16 @@ PR2 validation and PR state:
   `cmake --build build --target pulp-test-osc pulp-test-osc-channel -j8` and
   `ctest --test-dir build --output-on-failure -R 'OSC|OscChannel'` passed
   100/100.
+- After the `60f0a0f3` rebase, local post-rebase validation passed:
+  `cmake --build build --target pulp-test-osc pulp-test-osc-channel
+  pulp-test-events pulp-test-ipc -j8`,
+  `ctest --test-dir build --output-on-failure -R 'OSC|OscChannel'` 100/100,
+  and
+  `ctest --test-dir build --output-on-failure -R
+  'OSC|OscChannel|EventLoop|MainThread|main-thread|dispatcher|IPC|Interprocess'`
+  154/154. `python3 tools/scripts/version_bump_check.py --mode=report
+  --accept-intent-trailers` passes for SDK `0.238.0`, and `git diff --check`
+  passes.
 - `tools/scripts/local_diff_cover.sh` hits the local GPU/Skia configure gate in
   this worktree, so the same coverage pipeline was run manually in
   `build-cov` with `PULP_ENABLE_COVERAGE=ON`, `PULP_ENABLE_GPU=OFF`, the OSC
@@ -582,6 +594,10 @@ PR2 validation and PR state:
   `setsockopt()` failure that are not deterministic to force through the public
   API; GitHub Codecov remains the authoritative PR-side coverage result after
   the refreshed push.
+- A fresh attempt to run the stock target-limited local diff-cover wrapper
+  failed before coverage collection at the same local GPU/Skia design-tool
+  configure gate. The focused local test coverage above is green; the
+  refreshed GitHub Codecov result remains the merge gate.
 - Final RepoPrompt and Claude blocker reviews after the rebase and coverage
   sweep found no P0/P1 correctness issues in the branch implementation or the
   pending OSC test/docs updates.
@@ -589,9 +605,9 @@ PR2 validation and PR state:
 ## Suggested Order
 
 1. Threads/processes closure in PR #2815. Complete.
-2. OSC bundle-aware send/receive, listener filtering, and format-error
+2. Main-thread dispatcher in PR #2825. Complete.
+3. OSC bundle-aware send/receive, listener filtering, and format-error
    callbacks. Active.
-3. Main-thread dispatcher.
 4. Non-Apple native embedding implementations or explicit supported-platform
    contracts.
 5. Larger follow-up audit for audio formats, audio device management, and any

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -205,6 +205,11 @@ PR1 submit and review sweep:
   translation unit without UBSan instrumentation while keeping Pulp's script and
   view code instrumented. The previously failing Figma, Stitch, Pencil, and
   baked-native materialization cases now pass locally under UBSan.
+- GitHub-hosted Linux CI surfaced a latent OSC UDP portability gap: `Receiver`
+  enabled `SO_REUSEADDR`, which lets Linux bind multiple receivers to the same
+  UDP port and breaks the existing exclusive-listener contract. `Receiver` now
+  binds exclusively; the public API can add an explicit shared-port mode later
+  if a real use case needs it.
 
 ### 2. Main-Thread Dispatch and Native Event Loop
 

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -554,6 +554,23 @@ PR2 validation and PR state:
   Bundle transport coverage includes disconnect/reconnect sends and empty bundle
   receive. A fresh focused release run after the rebase passed
   `ctest --test-dir build --output-on-failure -R 'OSC|OscChannel'` 100/100.
+- After the `0939e9b19` rebase, focused Release/GPU-off validation passed:
+  `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF`,
+  `cmake --build build --target pulp-test-osc pulp-test-osc-channel -j8`,
+  and `ctest --test-dir build --output-on-failure -R 'OSC|OscChannel'`
+  100/100.
+- A fresh PR review sweep on the rebased head found one P1 around callback-
+  thread `Receiver::stop()` leaving the UDP socket bound until a later owner
+  stop/destructor. The fix now closes the UDP socket immediately on the
+  receiver thread while still deferring thread join to an outside stop. A
+  Claude follow-up review found a stale-FD race from adding a receiver-thread
+  socket writer; the socket handle now uses an atomic claim/exchange handoff so
+  exactly one stop path owns shutdown/close. Focused coverage now rebinds
+  another receiver to the same port after callback-thread `stop()` returns and
+  before the original owner joins the receive thread. Validation after the fix:
+  `cmake --build build --target pulp-test-osc pulp-test-osc-channel -j8` and
+  `ctest --test-dir build --output-on-failure -R 'OSC|OscChannel'` passed
+  100/100.
 - `tools/scripts/local_diff_cover.sh` hits the local GPU/Skia configure gate in
   this worktree, so the same coverage pipeline was run manually in
   `build-cov` with `PULP_ENABLE_COVERAGE=ON`, `PULP_ENABLE_GPU=OFF`, the OSC

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; locally rebased onto `origin/main` at `1a11c516`; local post-rebase/audit validation passing; SDK version is `0.247.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; locally rebased onto `origin/main` at `7be39f4a`; local post-rebase/audit validation passing; SDK version is `0.248.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased/validated; final SDK bump and push pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -696,6 +696,19 @@ PR2 validation and PR state:
   pulp-test-events pulp-test-ipc -j8`, `ctest --test-dir build -R
   '^(OscChannel|OSC|IPC|EventLoop)' --output-on-failure` 132/132, and
   `tools/check-docs.sh` with 76 existing warnings.
+- `main` advanced again to `7be39f4a` while hosted checks for `0c99e2cd2`
+  were queued, consuming SDK `0.247.0` in the item 3.4/3.5/3.10 bundle. The
+  stale `0.247.0` bump was dropped during rebase, and a fresh required SDK bump
+  to `0.248.0` was applied. Local validation passed again: `python3
+  tools/scripts/test_audit_top_level.py` 10/10, `python3 tools/audit.py --`,
+  `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD
+  --mode report`, `python3 tools/scripts/version_bump_check.py --base
+  origin/main --config tools/scripts/versioning.json --mode=report
+  --require-bump-for-fix-feat --accept-intent-trailers` for SDK `0.248.0`,
+  `cmake --build build --target pulp-test-osc pulp-test-osc-channel
+  pulp-test-events pulp-test-ipc -j8`, `ctest --test-dir build -R
+  '^(OscChannel|OSC|IPC|EventLoop)' --output-on-failure` 132/132,
+  `tools/check-docs.sh` with 76 existing warnings, and `git diff --check`.
 - `tools/scripts/local_diff_cover.sh` hits the local GPU/Skia configure gate in
   this worktree, so the same coverage pipeline was run manually in
   `build-cov` with `PULP_ENABLE_COVERAGE=ON`, `PULP_ENABLE_GPU=OFF`, the OSC

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased and locally validated on `origin/main` `a7e223f8` after main consumed SDK `0.250.0`; SDK version is `0.251.0`; hosted Ubuntu install-consumer smoke passed on the SheenBidi install fix | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased and locally validated on `origin/main` `df0c82622` after a stale-base skill-sync range failure; SDK version remains `0.251.0`; hosted Ubuntu install-consumer smoke passed on the SheenBidi install fix | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased/validated; final SDK bump and push pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -791,6 +791,22 @@ PR2 validation and PR state:
   --output-on-failure` 132/132, Release flag verification for
   `pulp-test-osc`, `tools/check-docs.sh` with the existing 76 warnings, and
   diff hygiene.
+- While the refreshed `777253846` checks were running, hosted
+  `Versioning & Skill-Sync` failed because GitHub compared the PR against a
+  newer `origin/main` that included unrelated CLI/ship changes from #2969.
+  The branch was rebased again onto `origin/main` at `df0c82622`; no additional
+  SDK bump was needed because `0.251.0` was still unconsumed. Local validation
+  passed again: `python3 tools/scripts/test_audit_top_level.py` 10/10,
+  `python3 tools/audit.py --`, `python3 tools/scripts/skill_sync_check.py
+  --base origin/main --head HEAD --mode report`, `python3
+  tools/scripts/version_bump_check.py --base origin/main --config
+  tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat
+  --accept-intent-trailers` for SDK `0.251.0`, Release/GPU-off configure and
+  build of `pulp-test-osc`, `pulp-test-osc-channel`, `pulp-test-events`, and
+  `pulp-test-ipc`, `ctest --test-dir build -R
+  '^(OscChannel|OSC|IPC|EventLoop)' --output-on-failure` 132/132, Release flag
+  verification for `pulp-test-osc`, `tools/check-docs.sh` with the existing 76
+  warnings, and diff hygiene.
 - `tools/scripts/local_diff_cover.sh` hits the local GPU/Skia configure gate in
   this worktree, so the same coverage pipeline was run manually in
   `build-cov` with `PULP_ENABLE_COVERAGE=ON`, `PULP_ENABLE_GPU=OFF`, the OSC

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,7 +27,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `0d934d4c`; local post-rebase validation passing; SDK version is `0.241.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased onto `origin/main` at `4cd4bdb`; local post-rebase validation passing; SDK version is `0.241.0` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
 | Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased/validated; final SDK bump and push pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
@@ -523,9 +523,9 @@ PR2 implementation scope:
 
 PR2 validation and PR state:
 - PR #2822: https://github.com/danielraffel/pulp/pull/2822
-- The branch is rebased onto `origin/main` at `0d934d4c` after #2825, #2905,
-  #2900, #2909, #2906, #2914, #2908, #2898, and #2913 landed. The fresh
-  required SDK bump is `0.241.0`.
+- The branch is rebased onto `origin/main` at `4cd4bdb` after #2825, #2905,
+  #2900, #2909, #2906, #2914, #2908, #2898, #2913, and the regenerated
+  v0.238.0 changelog landed. The fresh required SDK bump is `0.241.0`.
 - Initial PR review-comment and issue-comment sweep found no comments to
   address. The first CI failure was the version-bump commit-shape guard; it was
   fixed by splitting the `0.209.0` API bump into the canonical
@@ -602,6 +602,16 @@ PR2 validation and PR state:
   --config tools/scripts/versioning.json --mode=report
   --require-bump-for-fix-feat --accept-intent-trailers` passes for SDK
   `0.241.0`, and `git diff --check` passes.
+- After the `4cd4bdb` rebase, local post-rebase validation passed:
+  `cmake --build build --target pulp-test-osc pulp-test-osc-channel
+  pulp-test-events pulp-test-ipc -j8` and
+  `ctest --test-dir build --output-on-failure -R
+  'OSC|OscChannel|EventLoop|MainThread|main-thread|dispatcher|IPC|Interprocess'`
+  154/154. `python3 tools/scripts/version_bump_check.py --base origin/main
+  --config tools/scripts/versioning.json --mode=report
+  --require-bump-for-fix-feat --accept-intent-trailers` passes for SDK
+  `0.241.0`, `tools/check-docs.sh` passes with 76 existing warnings, and
+  `git diff --check` passes.
 - `tools/scripts/local_diff_cover.sh` hits the local GPU/Skia configure gate in
   this worktree, so the same coverage pipeline was run manually in
   `build-cov` with `PULP_ENABLE_COVERAGE=ON`, `PULP_ENABLE_GPU=OFF`, the OSC

--- a/test/test_osc.cpp
+++ b/test/test_osc.cpp
@@ -470,6 +470,48 @@ TEST_CASE("OSC Sender failed reconnect preserves the existing destination",
     rx.stop();
 }
 
+TEST_CASE("OSC Sender successful reconnect replaces the existing destination",
+          "[osc][udp][sender][codecov]") {
+    std::atomic<int> first_receiver{0};
+    std::atomic<int> second_receiver{0};
+
+    Receiver rx1;
+    REQUIRE(rx1.listen(0, [&](const Message& msg) {
+        if (msg.address == "/sender/reconnect-success/first")
+            first_receiver.fetch_add(1, std::memory_order_release);
+    }));
+
+    Receiver rx2;
+    REQUIRE(rx2.listen(0, [&](const Message& msg) {
+        if (msg.address == "/sender/reconnect-success/second" && msg.get_int(0) == 22)
+            second_receiver.fetch_add(1, std::memory_order_release);
+    }));
+
+    Sender tx;
+    REQUIRE(tx.connect("127.0.0.1", rx1.local_port()));
+    REQUIRE(tx.connect("127.0.0.1", rx2.local_port()));
+    REQUIRE(tx.is_connected());
+
+    Message first("/sender/reconnect-success/first");
+    first.add(11);
+    Message second("/sender/reconnect-success/second");
+    second.add(22);
+
+    for (int i = 0; i < 100
+         && second_receiver.load(std::memory_order_acquire) == 0; ++i) {
+        REQUIRE(tx.send(first));
+        REQUIRE(tx.send(second));
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+
+    REQUIRE(second_receiver.load(std::memory_order_acquire) > 0);
+    REQUIRE(first_receiver.load(std::memory_order_acquire) == 0);
+
+    tx.disconnect();
+    rx1.stop();
+    rx2.stop();
+}
+
 TEST_CASE("OSC Sender sends caller-owned raw packets over loopback",
           "[osc][udp][sender][coverage]") {
     std::atomic<int> handled{0};
@@ -523,6 +565,7 @@ TEST_CASE("OSC Receiver routes direct messages through address-pattern listeners
         if (msg.address == "/mix/gain")
             mix_messages.fetch_add(msg.get_int(0), std::memory_order_release);
     }});
+    options.routes.push_back({"/mix/*", {}});
     options.routes.push_back({"/note/[0-9]", [&](const Message&) {
         note_messages.fetch_add(1, std::memory_order_release);
     }});
@@ -979,6 +1022,40 @@ TEST_CASE("OSC Receiver callbacks can request stop without self-joining",
         }
 
         REQUIRE(restarted_messages.load(std::memory_order_acquire) > 0);
+        tx.disconnect();
+        rx.stop();
+        REQUIRE_FALSE(rx.is_listening());
+    }
+
+    {
+        std::atomic<int> errors{0};
+        std::atomic<int> self_listen_rejected{0};
+        Receiver rx;
+
+        ReceiverOptions options;
+        options.on_error = [&](std::string_view) {
+            errors.fetch_add(1, std::memory_order_release);
+            rx.stop();
+            if (!rx.listen(0, [](const Message&) {}))
+                self_listen_rejected.fetch_add(1, std::memory_order_release);
+        };
+
+        REQUIRE(rx.listen_with_options(0, std::move(options)));
+        const auto port = rx.local_port();
+        REQUIRE(port != 0);
+
+        Sender tx;
+        REQUIRE(tx.connect("127.0.0.1", port));
+
+        const uint8_t bad_message[] = {0x00, 0x01, 0x02};
+        for (int i = 0; i < 100
+             && self_listen_rejected.load(std::memory_order_acquire) == 0; ++i) {
+            REQUIRE(tx.send_raw(bad_message, sizeof(bad_message)));
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+
+        REQUIRE(errors.load(std::memory_order_acquire) > 0);
+        REQUIRE(self_listen_rejected.load(std::memory_order_acquire) > 0);
         tx.disconnect();
         rx.stop();
         REQUIRE_FALSE(rx.is_listening());

--- a/test/test_osc.cpp
+++ b/test/test_osc.cpp
@@ -1,5 +1,22 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
 #include <pulp/osc/bundle.hpp>
 #include <pulp/osc/osc.hpp>
 #include <thread>
@@ -9,6 +26,7 @@
 #include <cstring>
 #include <cstdint>
 #include <limits>
+#include <memory>
 #include <mutex>
 #include <string_view>
 #include <variant>
@@ -21,11 +39,75 @@ namespace {
 
 constexpr uint16_t kOscHostnameTestPort = 29876;
 
+#if defined(_WIN32)
+using TestSocketHandle = SOCKET;
+using TestSockLen = int;
+constexpr TestSocketHandle kInvalidTestSocket = INVALID_SOCKET;
+
+struct TestWinsockInit {
+    bool ok = false;
+
+    TestWinsockInit() {
+        WSADATA wsa{};
+        ok = WSAStartup(MAKEWORD(2, 2), &wsa) == 0;
+    }
+
+    ~TestWinsockInit() {
+        if (ok) WSACleanup();
+    }
+};
+
+bool ensure_test_winsock() {
+    static TestWinsockInit init;
+    return init.ok;
+}
+
+void close_test_socket(TestSocketHandle sock) {
+    closesocket(sock);
+}
+#else
+using TestSocketHandle = int;
+using TestSockLen = socklen_t;
+constexpr TestSocketHandle kInvalidTestSocket = -1;
+
+bool ensure_test_winsock() {
+    return true;
+}
+
+void close_test_socket(TestSocketHandle sock) {
+    close(sock);
+}
+#endif
+
 void append_osc_string(std::vector<uint8_t>& data, std::string_view text) {
     data.insert(data.end(), text.begin(), text.end());
     data.push_back(0);
     while (data.size() % 4 != 0)
         data.push_back(0);
+}
+
+bool send_empty_udp_datagram(uint16_t port) {
+    if (!ensure_test_winsock()) return false;
+    auto sock = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sock == kInvalidTestSocket) return false;
+
+    sockaddr_in dest{};
+    dest.sin_family = AF_INET;
+    dest.sin_port = htons(port);
+    if (inet_pton(AF_INET, "127.0.0.1", &dest.sin_addr) != 1) {
+        close_test_socket(sock);
+        return false;
+    }
+
+    const char payload[] = "";
+    const auto sent = sendto(sock,
+                             payload,
+                             0,
+                             0,
+                             reinterpret_cast<sockaddr*>(&dest),
+                             static_cast<TestSockLen>(sizeof(dest)));
+    close_test_socket(sock);
+    return sent == 0;
 }
 
 } // namespace
@@ -357,6 +439,37 @@ TEST_CASE("OSC Sender rejects invalid hostnames", "[osc][udp][sender]") {
     REQUIRE_FALSE(tx.is_connected());
 }
 
+TEST_CASE("OSC Sender failed reconnect preserves the existing destination",
+          "[osc][udp][sender][codecov]") {
+    std::atomic<int> handled{0};
+
+    Receiver rx;
+    REQUIRE(rx.listen(0, [&](const Message& msg) {
+        if (msg.address == "/sender/reconnect-fail" && msg.get_int(0) == 9) {
+            handled.fetch_add(1, std::memory_order_release);
+        }
+    }));
+    const auto port = rx.local_port();
+    REQUIRE(port != 0);
+
+    Sender tx;
+    REQUIRE(tx.connect("127.0.0.1", port));
+    REQUIRE(tx.is_connected());
+    REQUIRE_FALSE(tx.connect("999.999.999.999", kOscHostnameTestPort));
+    REQUIRE(tx.is_connected());
+
+    Message msg("/sender/reconnect-fail");
+    msg.add(9);
+    for (int i = 0; i < 100 && handled.load(std::memory_order_acquire) == 0; ++i) {
+        REQUIRE(tx.send(msg));
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+
+    REQUIRE(handled.load(std::memory_order_acquire) > 0);
+    tx.disconnect();
+    rx.stop();
+}
+
 TEST_CASE("OSC Sender sends caller-owned raw packets over loopback",
           "[osc][udp][sender][coverage]") {
     std::atomic<int> handled{0};
@@ -393,6 +506,280 @@ TEST_CASE("OSC Sender sends caller-owned raw packets over loopback",
     rx.stop();
     REQUIRE_FALSE(tx.is_connected());
     REQUIRE_FALSE(rx.is_listening());
+}
+
+TEST_CASE("OSC Receiver routes direct messages through address-pattern listeners",
+          "[osc][udp][receiver][pattern][codecov]") {
+    std::atomic<int> all_messages{0};
+    std::atomic<int> mix_messages{0};
+    std::atomic<int> note_messages{0};
+    std::atomic<int> miss_messages{0};
+
+    ReceiverOptions options;
+    options.on_message = [&](const Message&) {
+        all_messages.fetch_add(1, std::memory_order_release);
+    };
+    options.routes.push_back({"/mix/*", [&](const Message& msg) {
+        if (msg.address == "/mix/gain")
+            mix_messages.fetch_add(msg.get_int(0), std::memory_order_release);
+    }});
+    options.routes.push_back({"/note/[0-9]", [&](const Message&) {
+        note_messages.fetch_add(1, std::memory_order_release);
+    }});
+    options.routes.push_back({"/unmatched/*", [&](const Message&) {
+        miss_messages.fetch_add(1, std::memory_order_release);
+    }});
+
+    Receiver rx;
+    REQUIRE(rx.listen_with_options(0, std::move(options)));
+    const auto port = rx.local_port();
+    REQUIRE(port != 0);
+
+    Sender tx;
+    REQUIRE(tx.connect("127.0.0.1", port));
+
+    Message gain("/mix/gain");
+    gain.add(7);
+    Message note("/note/4");
+    note.add(64);
+    Message bypass("/other/path");
+    bypass.add(1);
+
+    for (int i = 0; i < 100
+         && (mix_messages.load(std::memory_order_acquire) == 0
+             || note_messages.load(std::memory_order_acquire) == 0
+             || all_messages.load(std::memory_order_acquire) < 3); ++i) {
+        REQUIRE(tx.send(gain));
+        REQUIRE(tx.send(note));
+        REQUIRE(tx.send(bypass));
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+
+    REQUIRE(mix_messages.load(std::memory_order_acquire) >= 7);
+    REQUIRE(note_messages.load(std::memory_order_acquire) > 0);
+    REQUIRE(all_messages.load(std::memory_order_acquire) >= 3);
+    REQUIRE(miss_messages.load(std::memory_order_acquire) == 0);
+
+    tx.disconnect();
+    rx.stop();
+}
+
+TEST_CASE("OSC Sender sends typed bundles and Receiver dispatches bundle callbacks",
+          "[osc][udp][bundle][receiver][codecov]") {
+    std::atomic<int> bundle_callbacks{0};
+    std::atomic<int> nested_bundle_callbacks{0};
+    std::atomic<int> bundle_element_count{0};
+    std::atomic<int> message_callbacks{0};
+    std::atomic<int> synth_route_sum{0};
+    std::atomic<int> nested_route_sum{0};
+    std::atomic<int> miss_callbacks{0};
+
+    ReceiverOptions options;
+    options.on_bundle = [&](const Bundle& bundle) {
+        const auto element_count = static_cast<int>(bundle.elements.size());
+        bundle_element_count.store(element_count, std::memory_order_release);
+        if (element_count == 1)
+            nested_bundle_callbacks.fetch_add(1, std::memory_order_release);
+        bundle_callbacks.fetch_add(1, std::memory_order_release);
+    };
+    options.on_message = [&](const Message&) {
+        message_callbacks.fetch_add(1, std::memory_order_release);
+    };
+    options.routes.push_back({"/synth/*", [&](const Message& msg) {
+        synth_route_sum.fetch_add(msg.get_int(0), std::memory_order_release);
+    }});
+    options.routes.push_back({"/nested/{lead,bass}", [&](const Message& msg) {
+        nested_route_sum.fetch_add(msg.get_int(0), std::memory_order_release);
+    }});
+    options.routes.push_back({"/no/match", [&](const Message&) {
+        miss_callbacks.fetch_add(1, std::memory_order_release);
+    }});
+
+    Receiver rx;
+    REQUIRE(rx.listen_with_options(0, std::move(options)));
+    const auto port = rx.local_port();
+    REQUIRE(port != 0);
+
+    Sender tx;
+    REQUIRE(tx.connect("127.0.0.1", port));
+
+    Bundle nested;
+    Message nested_msg("/nested/lead");
+    nested_msg.add(5);
+    nested.add(std::move(nested_msg));
+
+    Bundle bundle;
+    Message synth_msg("/synth/gain");
+    synth_msg.add(11);
+    bundle.add(std::move(synth_msg));
+    Message unrelated("/drum/kick");
+    unrelated.add(1);
+    bundle.add(std::move(unrelated));
+    bundle.add(std::move(nested));
+
+    for (int i = 0; i < 100
+         && (bundle_callbacks.load(std::memory_order_acquire) == 0
+             || synth_route_sum.load(std::memory_order_acquire) == 0
+             || nested_route_sum.load(std::memory_order_acquire) == 0
+             || message_callbacks.load(std::memory_order_acquire) < 3); ++i) {
+        REQUIRE(tx.send(bundle));
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+
+    REQUIRE(bundle_callbacks.load(std::memory_order_acquire) > 0);
+    REQUIRE(nested_bundle_callbacks.load(std::memory_order_acquire) == 0);
+    REQUIRE(bundle_element_count.load(std::memory_order_acquire) == 3);
+    REQUIRE(message_callbacks.load(std::memory_order_acquire) >= 3);
+    REQUIRE(synth_route_sum.load(std::memory_order_acquire) >= 11);
+    REQUIRE(nested_route_sum.load(std::memory_order_acquire) >= 5);
+    REQUIRE(miss_callbacks.load(std::memory_order_acquire) == 0);
+
+    tx.disconnect();
+    rx.stop();
+}
+
+TEST_CASE("OSC Sender sends bundles after disconnect and reconnect",
+          "[osc][udp][bundle][sender][codecov]") {
+    std::atomic<int> first_receiver{0};
+    std::atomic<int> second_receiver{0};
+
+    Receiver rx1;
+    REQUIRE(rx1.listen(0, [&](const Message& msg) {
+        if (msg.address == "/bundle/reconnect/first" && msg.get_int(0) == 1)
+            first_receiver.fetch_add(1, std::memory_order_release);
+    }));
+
+    Receiver rx2;
+    REQUIRE(rx2.listen(0, [&](const Message& msg) {
+        if (msg.address == "/bundle/reconnect/second" && msg.get_int(0) == 2)
+            second_receiver.fetch_add(1, std::memory_order_release);
+    }));
+
+    Sender tx;
+    REQUIRE(tx.connect("127.0.0.1", rx1.local_port()));
+
+    Bundle first_bundle;
+    Message first_msg("/bundle/reconnect/first");
+    first_msg.add(1);
+    first_bundle.add(std::move(first_msg));
+
+    for (int i = 0; i < 100
+         && first_receiver.load(std::memory_order_acquire) == 0; ++i) {
+        REQUIRE(tx.send(first_bundle));
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    REQUIRE(first_receiver.load(std::memory_order_acquire) > 0);
+
+    tx.disconnect();
+    REQUIRE(tx.connect("127.0.0.1", rx2.local_port()));
+
+    Bundle second_bundle;
+    Message second_msg("/bundle/reconnect/second");
+    second_msg.add(2);
+    second_bundle.add(std::move(second_msg));
+
+    for (int i = 0; i < 100
+         && second_receiver.load(std::memory_order_acquire) == 0; ++i) {
+        REQUIRE(tx.send(second_bundle));
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+
+    REQUIRE(second_receiver.load(std::memory_order_acquire) > 0);
+    tx.disconnect();
+    rx1.stop();
+    rx2.stop();
+}
+
+TEST_CASE("OSC Receiver dispatches empty bundles without message callbacks",
+          "[osc][udp][bundle][receiver][codecov]") {
+    std::atomic<int> empty_bundles{0};
+    std::atomic<int> messages{0};
+
+    ReceiverOptions options;
+    options.on_bundle = [&](const Bundle& bundle) {
+        if (bundle.elements.empty())
+            empty_bundles.fetch_add(1, std::memory_order_release);
+    };
+    options.on_message = [&](const Message&) {
+        messages.fetch_add(1, std::memory_order_release);
+    };
+
+    Receiver rx;
+    REQUIRE(rx.listen_with_options(0, std::move(options)));
+    const auto port = rx.local_port();
+    REQUIRE(port != 0);
+
+    Sender tx;
+    REQUIRE(tx.connect("127.0.0.1", port));
+
+    Bundle bundle;
+    for (int i = 0; i < 100
+         && empty_bundles.load(std::memory_order_acquire) == 0; ++i) {
+        REQUIRE(tx.send(bundle));
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+
+    REQUIRE(empty_bundles.load(std::memory_order_acquire) > 0);
+    REQUIRE(messages.load(std::memory_order_acquire) == 0);
+    tx.disconnect();
+    rx.stop();
+}
+
+TEST_CASE("OSC Receiver accepts bundle datagrams larger than four kilobytes",
+          "[osc][udp][bundle][receiver][codecov]") {
+    std::atomic<int> bundle_callbacks{0};
+    std::atomic<int> blob_size{0};
+    std::atomic<int> blob_front{0};
+    std::atomic<int> blob_back{0};
+
+    ReceiverOptions options;
+    options.on_bundle = [&](const Bundle& bundle) {
+        if (bundle.elements.size() == 1)
+            bundle_callbacks.fetch_add(1, std::memory_order_release);
+    };
+    options.on_message = [&](const Message& msg) {
+        if (msg.address != "/bundle/large" || msg.args.empty()) return;
+        const auto* blob = std::get_if<std::vector<uint8_t>>(&msg.args[0]);
+        if (blob == nullptr || blob->empty()) return;
+        blob_size.store(static_cast<int>(blob->size()), std::memory_order_release);
+        blob_front.store(static_cast<int>(blob->front()), std::memory_order_release);
+        blob_back.store(static_cast<int>(blob->back()), std::memory_order_release);
+    };
+
+    Receiver rx;
+    REQUIRE(rx.listen_with_options(0, std::move(options)));
+    const auto port = rx.local_port();
+    REQUIRE(port != 0);
+
+    Sender tx;
+    REQUIRE(tx.connect("127.0.0.1", port));
+
+    std::vector<uint8_t> payload(5000);
+    for (size_t i = 0; i < payload.size(); ++i)
+        payload[i] = static_cast<uint8_t>(i & 0xFF);
+
+    Bundle bundle;
+    Message msg("/bundle/large");
+    msg.add(payload);
+    bundle.add(std::move(msg));
+
+    for (int i = 0; i < 100
+         && (bundle_callbacks.load(std::memory_order_acquire) == 0
+             || blob_size.load(std::memory_order_acquire) == 0); ++i) {
+        REQUIRE(tx.send(bundle));
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+
+    REQUIRE(bundle_callbacks.load(std::memory_order_acquire) > 0);
+    REQUIRE(blob_size.load(std::memory_order_acquire)
+            == static_cast<int>(payload.size()));
+    REQUIRE(blob_front.load(std::memory_order_acquire)
+            == static_cast<int>(payload.front()));
+    REQUIRE(blob_back.load(std::memory_order_acquire)
+            == static_cast<int>(payload.back()));
+
+    tx.disconnect();
+    rx.stop();
 }
 
 TEST_CASE("OSC Sender disconnects idempotently and reconnects to loopback",
@@ -461,6 +848,365 @@ TEST_CASE("OSC Receiver drops invalid datagrams without invoking handler", "[osc
     REQUIRE_FALSE(rx.is_listening());
 }
 
+TEST_CASE("OSC Receiver reports malformed message and bundle packets",
+          "[osc][udp][receiver][error][codecov]") {
+    std::atomic<int> errors{0};
+    std::atomic<int> malformed_messages{0};
+    std::atomic<int> malformed_bundles{0};
+    std::atomic<int> handled_messages{0};
+    std::atomic<int> handled_bundles{0};
+
+    ReceiverOptions options;
+    options.on_message = [&](const Message&) {
+        handled_messages.fetch_add(1, std::memory_order_release);
+    };
+    options.on_bundle = [&](const Bundle&) {
+        handled_bundles.fetch_add(1, std::memory_order_release);
+    };
+    options.on_error = [&](std::string_view reason) {
+        errors.fetch_add(1, std::memory_order_release);
+        if (reason == "malformed OSC message")
+            malformed_messages.fetch_add(1, std::memory_order_release);
+        if (reason == "malformed OSC bundle")
+            malformed_bundles.fetch_add(1, std::memory_order_release);
+    };
+
+    Receiver rx;
+    REQUIRE(rx.listen_with_options(0, std::move(options)));
+    const auto port = rx.local_port();
+    REQUIRE(port != 0);
+
+    Sender tx;
+    REQUIRE(tx.connect("127.0.0.1", port));
+
+    const uint8_t bad_message[] = {0x00, 0x01, 0x02};
+    const uint8_t bad_bundle[] = {
+        '#', 'b', 'u', 'n', 'd', 'l', 'e', 0,
+        0, 0, 0, 0, 0, 0, 0, 1,
+        0x12
+    };
+
+    for (int i = 0; i < 100
+         && (malformed_messages.load(std::memory_order_acquire) == 0
+             || malformed_bundles.load(std::memory_order_acquire) == 0); ++i) {
+        REQUIRE(tx.send_raw(bad_message, sizeof(bad_message)));
+        REQUIRE(tx.send_raw(bad_bundle, sizeof(bad_bundle)));
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+
+    REQUIRE(errors.load(std::memory_order_acquire) >= 2);
+    REQUIRE(malformed_messages.load(std::memory_order_acquire) > 0);
+    REQUIRE(malformed_bundles.load(std::memory_order_acquire) > 0);
+    REQUIRE(handled_messages.load(std::memory_order_acquire) == 0);
+    REQUIRE(handled_bundles.load(std::memory_order_acquire) == 0);
+
+    tx.disconnect();
+    rx.stop();
+}
+
+TEST_CASE("OSC Receiver reports empty UDP datagrams as malformed messages",
+          "[osc][udp][receiver][error][codecov]") {
+    std::atomic<int> errors{0};
+    std::atomic<int> handled_messages{0};
+
+    ReceiverOptions options;
+    options.on_message = [&](const Message&) {
+        handled_messages.fetch_add(1, std::memory_order_release);
+    };
+    options.on_error = [&](std::string_view reason) {
+        if (reason == "malformed OSC message")
+            errors.fetch_add(1, std::memory_order_release);
+    };
+
+    Receiver rx;
+    REQUIRE(rx.listen_with_options(0, std::move(options)));
+    const auto port = rx.local_port();
+    REQUIRE(port != 0);
+
+    for (int i = 0; i < 100 && errors.load(std::memory_order_acquire) == 0; ++i) {
+        REQUIRE(send_empty_udp_datagram(port));
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+
+    REQUIRE(errors.load(std::memory_order_acquire) > 0);
+    REQUIRE(handled_messages.load(std::memory_order_acquire) == 0);
+    rx.stop();
+}
+
+TEST_CASE("OSC Receiver callbacks can request stop without self-joining",
+          "[osc][udp][receiver][lifecycle][codecov]") {
+    {
+        std::atomic<int> errors{0};
+        std::atomic<int> restarted_messages{0};
+        Receiver rx;
+
+        ReceiverOptions options;
+        options.on_error = [&](std::string_view) {
+            errors.fetch_add(1, std::memory_order_release);
+            rx.stop();
+        };
+
+        REQUIRE(rx.listen_with_options(0, std::move(options)));
+        const auto port = rx.local_port();
+        REQUIRE(port != 0);
+
+        Sender tx;
+        REQUIRE(tx.connect("127.0.0.1", port));
+
+        const uint8_t bad_message[] = {0x00, 0x01, 0x02};
+        for (int i = 0; i < 100 && errors.load(std::memory_order_acquire) == 0; ++i) {
+            REQUIRE(tx.send_raw(bad_message, sizeof(bad_message)));
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+
+        REQUIRE(errors.load(std::memory_order_acquire) > 0);
+        tx.disconnect();
+
+        REQUIRE(rx.listen(0, [&](const Message& msg) {
+            if (msg.address == "/callback/restart" && msg.get_int(0) == 17)
+                restarted_messages.fetch_add(1, std::memory_order_release);
+        }));
+        REQUIRE(rx.is_listening());
+        REQUIRE(rx.local_port() != 0);
+
+        REQUIRE(tx.connect("127.0.0.1", rx.local_port()));
+        Message restart_msg("/callback/restart");
+        restart_msg.add(17);
+        for (int i = 0; i < 100
+             && restarted_messages.load(std::memory_order_acquire) == 0; ++i) {
+            REQUIRE(tx.send(restart_msg));
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+
+        REQUIRE(restarted_messages.load(std::memory_order_acquire) > 0);
+        tx.disconnect();
+        rx.stop();
+        REQUIRE_FALSE(rx.is_listening());
+    }
+
+    {
+        std::atomic<int> bundles{0};
+        Receiver rx;
+
+        ReceiverOptions options;
+        options.on_bundle = [&](const Bundle&) {
+            bundles.fetch_add(1, std::memory_order_release);
+            rx.stop();
+        };
+
+        REQUIRE(rx.listen_with_options(0, std::move(options)));
+        const auto port = rx.local_port();
+        REQUIRE(port != 0);
+
+        Sender tx;
+        REQUIRE(tx.connect("127.0.0.1", port));
+
+        Bundle bundle;
+        Message msg("/callback/stop");
+        msg.add(1);
+        bundle.add(std::move(msg));
+
+        for (int i = 0; i < 100 && bundles.load(std::memory_order_acquire) == 0; ++i) {
+            REQUIRE(tx.send(bundle));
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+
+        REQUIRE(bundles.load(std::memory_order_acquire) > 0);
+        tx.disconnect();
+        rx.stop();
+        REQUIRE_FALSE(rx.is_listening());
+    }
+}
+
+TEST_CASE("OSC Receiver stop short-circuits current datagram callback fanout",
+          "[osc][udp][receiver][lifecycle][codecov]") {
+    {
+        std::atomic<int> bundles{0};
+        std::atomic<int> messages{0};
+        Receiver rx;
+
+        ReceiverOptions options;
+        options.on_bundle = [&](const Bundle&) {
+            bundles.fetch_add(1, std::memory_order_release);
+            rx.stop();
+        };
+        options.on_message = [&](const Message&) {
+            messages.fetch_add(1, std::memory_order_release);
+        };
+
+        REQUIRE(rx.listen_with_options(0, std::move(options)));
+        const auto port = rx.local_port();
+        REQUIRE(port != 0);
+
+        Sender tx;
+        REQUIRE(tx.connect("127.0.0.1", port));
+
+        Bundle bundle;
+        Message msg("/fanout/bundle");
+        msg.add(1);
+        bundle.add(std::move(msg));
+
+        for (int i = 0; i < 100 && bundles.load(std::memory_order_acquire) == 0; ++i) {
+            REQUIRE(tx.send(bundle));
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+
+        REQUIRE(bundles.load(std::memory_order_acquire) > 0);
+        REQUIRE(messages.load(std::memory_order_acquire) == 0);
+        tx.disconnect();
+        rx.stop();
+    }
+
+    {
+        std::atomic<int> messages{0};
+        std::atomic<int> routes{0};
+        Receiver rx;
+
+        ReceiverOptions options;
+        options.on_message = [&](const Message&) {
+            messages.fetch_add(1, std::memory_order_release);
+            rx.stop();
+        };
+        options.routes.push_back({"", [&](const Message&) {
+            routes.fetch_add(1, std::memory_order_release);
+        }});
+
+        REQUIRE(rx.listen_with_options(0, std::move(options)));
+        const auto port = rx.local_port();
+        REQUIRE(port != 0);
+
+        Sender tx;
+        REQUIRE(tx.connect("127.0.0.1", port));
+
+        Message msg("/fanout/message");
+        msg.add(2);
+        for (int i = 0; i < 100 && messages.load(std::memory_order_acquire) == 0; ++i) {
+            REQUIRE(tx.send(msg));
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+
+        REQUIRE(messages.load(std::memory_order_acquire) > 0);
+        REQUIRE(routes.load(std::memory_order_acquire) == 0);
+        tx.disconnect();
+        rx.stop();
+    }
+
+    {
+        std::atomic<int> first_route{0};
+        std::atomic<int> second_route{0};
+        Receiver rx;
+
+        ReceiverOptions options;
+        options.routes.push_back({"", [&](const Message&) {
+            first_route.fetch_add(1, std::memory_order_release);
+            rx.stop();
+        }});
+        options.routes.push_back({"", [&](const Message&) {
+            second_route.fetch_add(1, std::memory_order_release);
+        }});
+
+        REQUIRE(rx.listen_with_options(0, std::move(options)));
+        const auto port = rx.local_port();
+        REQUIRE(port != 0);
+
+        Sender tx;
+        REQUIRE(tx.connect("127.0.0.1", port));
+
+        Message msg("/fanout/route");
+        msg.add(3);
+        for (int i = 0; i < 100
+             && first_route.load(std::memory_order_acquire) == 0; ++i) {
+            REQUIRE(tx.send(msg));
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+
+        REQUIRE(first_route.load(std::memory_order_acquire) > 0);
+        REQUIRE(second_route.load(std::memory_order_acquire) == 0);
+        tx.disconnect();
+        rx.stop();
+    }
+
+    {
+        std::atomic<int> first_message{0};
+        std::atomic<int> second_message{0};
+        Receiver rx;
+
+        ReceiverOptions options;
+        options.on_message = [&](const Message& msg) {
+            if (msg.address == "/fanout/first") {
+                first_message.fetch_add(1, std::memory_order_release);
+                rx.stop();
+            } else if (msg.address == "/fanout/second") {
+                second_message.fetch_add(1, std::memory_order_release);
+            }
+        };
+
+        REQUIRE(rx.listen_with_options(0, std::move(options)));
+        const auto port = rx.local_port();
+        REQUIRE(port != 0);
+
+        Sender tx;
+        REQUIRE(tx.connect("127.0.0.1", port));
+
+        Bundle bundle;
+        Message first("/fanout/first");
+        first.add(4);
+        bundle.add(std::move(first));
+        Message second("/fanout/second");
+        second.add(5);
+        bundle.add(std::move(second));
+
+        for (int i = 0; i < 100
+             && first_message.load(std::memory_order_acquire) == 0; ++i) {
+            REQUIRE(tx.send(bundle));
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+
+        REQUIRE(first_message.load(std::memory_order_acquire) > 0);
+        REQUIRE(second_message.load(std::memory_order_acquire) == 0);
+        tx.disconnect();
+        rx.stop();
+    }
+}
+
+TEST_CASE("OSC Receiver can be destroyed from a receiver callback",
+          "[osc][udp][receiver][lifecycle][codecov]") {
+    struct Owner {
+        Receiver rx;
+    };
+
+    std::unique_ptr<Owner> owner = std::make_unique<Owner>();
+    std::atomic<int> callbacks{0};
+    std::atomic<bool> destroyed{false};
+
+    ReceiverOptions options;
+    options.on_message = [&](const Message& msg) {
+        if (msg.address != "/callback/destroy") return;
+        callbacks.fetch_add(1, std::memory_order_release);
+        owner.reset();
+        destroyed.store(true, std::memory_order_release);
+    };
+
+    REQUIRE(owner->rx.listen_with_options(0, std::move(options)));
+    const auto port = owner->rx.local_port();
+    REQUIRE(port != 0);
+
+    Sender tx;
+    REQUIRE(tx.connect("127.0.0.1", port));
+
+    Message msg("/callback/destroy");
+    msg.add(99);
+    for (int i = 0; i < 100 && !destroyed.load(std::memory_order_acquire); ++i) {
+        REQUIRE(tx.send(msg));
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+
+    REQUIRE(callbacks.load(std::memory_order_acquire) > 0);
+    REQUIRE(destroyed.load(std::memory_order_acquire));
+    tx.disconnect();
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+}
+
 TEST_CASE("OSC Receiver with empty handler accepts datagrams until stopped",
           "[osc][udp][receiver][codecov]") {
     Receiver rx;
@@ -495,6 +1241,7 @@ TEST_CASE("OSC Receiver stop is idempotent", "[osc][udp][receiver]") {
     REQUIRE(rx.listen(0, [](const Message&) {}));
     REQUIRE(rx.is_listening());
     REQUIRE(rx.local_port() != 0);
+    REQUIRE_FALSE(rx.listen(0, [](const Message&) {}));
     rx.stop();
     rx.stop();
     REQUIRE_FALSE(rx.is_listening());
@@ -744,6 +1491,19 @@ TEST_CASE("OSC Sender::send without connect is rejected", "[osc][udp][sender]") 
     Message msg("/x");
     msg.add(1);
     REQUIRE_FALSE(tx.send(msg));
+}
+
+TEST_CASE("OSC Sender::send bundle without connect is rejected",
+          "[osc][udp][sender][bundle][codecov]") {
+    Sender tx;
+    REQUIRE_FALSE(tx.is_connected());
+
+    Bundle bundle;
+    Message msg("/bundle/unconnected");
+    msg.add(1);
+    bundle.add(std::move(msg));
+
+    REQUIRE_FALSE(tx.send(bundle));
 }
 
 TEST_CASE("OSC decode preserves empty strings and padded string arguments", "[osc][codec][issue-644]") {

--- a/test/test_osc.cpp
+++ b/test/test_osc.cpp
@@ -980,6 +980,7 @@ TEST_CASE("OSC Receiver callbacks can request stop without self-joining",
           "[osc][udp][receiver][lifecycle][codecov]") {
     {
         std::atomic<int> errors{0};
+        std::atomic<bool> stop_returned{false};
         std::atomic<int> restarted_messages{0};
         Receiver rx;
 
@@ -987,6 +988,7 @@ TEST_CASE("OSC Receiver callbacks can request stop without self-joining",
         options.on_error = [&](std::string_view) {
             errors.fetch_add(1, std::memory_order_release);
             rx.stop();
+            stop_returned.store(true, std::memory_order_release);
         };
 
         REQUIRE(rx.listen_with_options(0, std::move(options)));
@@ -997,13 +999,18 @@ TEST_CASE("OSC Receiver callbacks can request stop without self-joining",
         REQUIRE(tx.connect("127.0.0.1", port));
 
         const uint8_t bad_message[] = {0x00, 0x01, 0x02};
-        for (int i = 0; i < 100 && errors.load(std::memory_order_acquire) == 0; ++i) {
+        for (int i = 0; i < 100 && !stop_returned.load(std::memory_order_acquire); ++i) {
             REQUIRE(tx.send_raw(bad_message, sizeof(bad_message)));
             std::this_thread::sleep_for(std::chrono::milliseconds(20));
         }
 
         REQUIRE(errors.load(std::memory_order_acquire) > 0);
+        REQUIRE(stop_returned.load(std::memory_order_acquire));
         tx.disconnect();
+
+        Receiver rebound;
+        REQUIRE(rebound.listen(port, [](const Message&) {}));
+        rebound.stop();
 
         REQUIRE(rx.listen(0, [&](const Message& msg) {
             if (msg.address == "/callback/restart" && msg.get_int(0) == 17)

--- a/test/test_osc_bundle.cpp
+++ b/test/test_osc_bundle.cpp
@@ -279,6 +279,11 @@ TEST_CASE("Bundle::deserialize rejects data shorter than 16 bytes",
     REQUIRE_FALSE(Bundle::deserialize(tiny, sizeof(tiny)).has_value());
 }
 
+TEST_CASE("Bundle::deserialize rejects null data with bundle-sized length",
+          "[osc][bundle][deserialize-edge][codecov]") {
+    REQUIRE_FALSE(Bundle::deserialize(nullptr, 16).has_value());
+}
+
 TEST_CASE("Bundle::deserialize rejects non-#bundle header",
           "[osc][bundle][deserialize-edge]") {
     // 16 bytes, valid size, but first 8 bytes aren't "#bundle\0".
@@ -532,6 +537,7 @@ TEST_CASE("Malformed address patterns fail closed",
           "[osc][bundle][pattern]") {
     REQUIRE_FALSE(address_matches("/note/[ab", "/note/a"));
     REQUIRE_FALSE(address_matches("/note/[!0-9", "/note/a"));
+    REQUIRE_FALSE(address_matches("/note/[!]", "/note/a"));
     REQUIRE_FALSE(address_matches("/{foo,bar/gain", "/foo/gain"));
 }
 
@@ -540,6 +546,8 @@ TEST_CASE("Address pattern alternatives reject empty branches",
     REQUIRE_FALSE(address_matches("/prefix{,Suffix}", "/prefix"));
     REQUIRE_FALSE(address_matches("/prefix{,Suffix}", "/prefixSuffix"));
     REQUIRE_FALSE(address_matches("/prefix{,Suffix}", "/prefixOther"));
+    REQUIRE_FALSE(address_matches("/{foo,}/gain", "/foo/gain"));
+    REQUIRE_FALSE(address_matches("/{foo,bar,}/gain", "/bar/gain"));
 }
 
 TEST_CASE("Address pattern alternatives support first and later branches",

--- a/tools/cmake/PulpConfig.cmake.in
+++ b/tools/cmake/PulpConfig.cmake.in
@@ -37,6 +37,12 @@ include("${CMAKE_CURRENT_LIST_DIR}/PulpPlatformConfig.cmake")
 # Linux PkgConfig::* IMPORTED target recreation. No-op on non-Linux.
 include("${CMAKE_CURRENT_LIST_DIR}/PulpPkgConfigImports.cmake")
 
+# Pulp::canvas is a static SDK target and its build exports retain
+# LINK_ONLY references to private static dependencies. SheenBidi installs its
+# own package into the same SDK prefix, so load it before PulpTargets.cmake
+# validates referenced imported targets.
+find_dependency(SheenBidi CONFIG)
+
 # The Pulp SDK is built and installed in the Release configuration only.
 # When a downstream plugin is built in Debug / MinSizeRel / RelWithDebInfo
 # (or the Visual Studio multi-config generator picks those configs), CMake


### PR DESCRIPTION
## Summary
- Add typed OSC bundle sending through `Sender::send(const Bundle&)`.
- Add `ReceiverOptions` with public `on_message`, `on_bundle`, `on_error`, and address-pattern route callbacks.
- Route bundle datagrams through the public receiver path, including nested bundle message fanout, malformed packet reporting, and explicit empty UDP datagram errors.
- Harden UDP receiver lifecycle behavior: exclusive port binding, callback self-stop, callback-time destruction, restart after self-stop, fanout short-circuiting after stop, and immediate socket release when a callback calls `stop()`.
- Preserve sender destination on failed reconnect attempts while allowing successful reconnect over an existing socket.
- Tighten bundle/pattern parsing around null inputs and malformed empty alternatives.
- Add a narrow installed-SDK CMake fix so downstream `find_package(Pulp)` loads `SheenBidi::SheenBidi` before validating exported static targets.
- Update `docs/reports/platform-capability-closure-plan.md` for the focused OSC lane.
- Bump the SDK/API version to `0.253.0` for the new public OSC surface after `main` consumed `0.252.0`.

## Validation
- Rebased onto `origin/main` at `b2a5b3f78`; pushed head is `7d34c455f`.
- The duplicate Pro Tools audit allowlist commit was dropped from this branch because #2939 has now merged upstream.
- Hosted install-consumer smoke on the previous SheenBidi-fix head passed after `find_dependency(SheenBidi CONFIG)` was added before `PulpTargets.cmake`.
- Clean Release/GPU-off install validation passed earlier: rebuilt and installed the SDK to `/tmp/pulp-install-check`, verified installed SheenBidi package files, and configured a downstream `find_package(Pulp)` + `pulp_add_plugin(... FORMATS CLAP ...)` consumer that explicitly checks `TARGET SheenBidi::SheenBidi`.
- `python3 tools/scripts/test_audit_top_level.py` passed 11/11.
- `python3 tools/audit.py --` passed.
- `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD --mode report` passed.
- `python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat --accept-intent-trailers` passed for SDK `0.253.0`.
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF` passed.
- `cmake --build build --target pulp-test-osc pulp-test-osc-channel pulp-test-events pulp-test-ipc -j8` passed.
- `ctest --test-dir build -R '^(OscChannel|OSC|IPC|EventLoop)' --output-on-failure` passed 132/132.
- Release flags verified for `pulp-test-osc` (`CMAKE_BUILD_TYPE=Release`, `-O3 -DNDEBUG`).
- `tools/check-docs.sh` passed with 76 existing warnings after the doc refresh.
- `git diff --check` and `git diff --cached --check` passed.
- Prior manual GPU-off diff coverage for changed OSC implementation lines: 94% overall, `core/osc/src/bundle.cpp` 100%, `core/osc/src/osc_udp.cpp` 94.3%; remaining uncovered lines are defensive socket cleanup paths that are not deterministic through the public API.
- Fresh target-limited local diff-cover wrapper attempts previously failed before coverage collection in this local checkout at the known SheenBidi/Skia coverage configure path; the final push used the hook skip after focused GPU-off validation, and hosted Codecov remains the refreshed PR coverage gate.
- Claude found the initial callback-stop socket release had a stale-FD race; fixed by making the receiver socket handle an atomic claim/exchange handoff. RepoPrompt found the initial regression test did not prove immediate release; fixed by waiting for callback-thread `stop()` to return and then doing a single same-port bind. Fresh Claude blocker review on `27bacda5c` reported no P0/P1/P2 blockers; only non-blocking doc-contract clarifiers and pre-existing/non-regression lifecycle caveats.

Focused pass note: no SSH Windows/Ubuntu lanes were run for this branch; rely on local/macOS validation and GitHub-hosted checks.
