### PR TITLE
feat(macos-plan): Batch A — Foundations (DcBlocker, denormal snap, NormalisableRange, ADSR buffer-apply, SmoothedValue audit, time-window undo, HighResolutionTimer OS-queue)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.208.0
+    VERSION 0.209.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/runtime/include/pulp/runtime/high_resolution_timer.hpp
+++ b/core/runtime/include/pulp/runtime/high_resolution_timer.hpp
@@ -12,6 +12,23 @@
 
 namespace pulp::runtime {
 
+/// Backend selection for the high-resolution timer.
+///
+/// - `DedicatedThread` (default): a Pulp-owned worker thread spins or
+///   sleeps to the next deadline. Cross-platform; ~1 ms jitter under
+///   load. Use when no OS timer queue is available or when the
+///   workload runs outside an event loop.
+/// - `OsTimerQueue`: backed by the platform's native high-resolution
+///   timer queue (macOS / iOS: `dispatch_source_create` on a leeway-0
+///   timer). No Pulp-owned thread; callbacks fire on the dispatch
+///   queue. Lower jitter on supported platforms. Falls back to
+///   `DedicatedThread` on platforms without an equivalent surface
+///   (Linux desktop) so the contract holds.
+enum class TimerMode {
+    DedicatedThread,
+    OsTimerQueue,
+};
+
 class HighResolutionTimer {
 public:
     HighResolutionTimer() = default;
@@ -20,11 +37,22 @@ public:
     /// Start the timer with the given interval. Callback runs on a dedicated thread.
     void start(std::chrono::microseconds interval, std::function<void()> callback);
 
+    /// Start the timer in the requested mode.
+    /// Falls back to `DedicatedThread` if the requested backend is
+    /// unavailable on this platform.
+    void start(std::chrono::microseconds interval,
+               std::function<void()> callback,
+               TimerMode mode);
+
     /// Stop the timer.
     void stop();
 
     /// Whether the timer is currently running.
     bool is_running() const { return running_.load(std::memory_order_relaxed); }
+
+    /// The backend actually in use for the current run (may differ from
+    /// the requested mode when the platform doesn't support it).
+    TimerMode active_mode() const { return active_mode_; }
 
     // No copy or move
     HighResolutionTimer(const HighResolutionTimer&) = delete;
@@ -37,6 +65,8 @@ private:
     std::mutex mutex_;
     std::thread thread_;
     std::shared_ptr<TimerState> state_;
+    TimerMode active_mode_ = TimerMode::DedicatedThread;
+    void* dispatch_source_ = nullptr; ///< `dispatch_source_t` cast to void* (Apple only).
 };
 
 }  // namespace pulp::runtime

--- a/core/runtime/src/high_resolution_timer.cpp
+++ b/core/runtime/src/high_resolution_timer.cpp
@@ -2,6 +2,7 @@
 
 #ifdef __APPLE__
 #include <mach/mach_time.h>
+#include <dispatch/dispatch.h>
 #elif defined(__linux__)
 #include <sched.h>
 #include <pthread.h>
@@ -21,7 +22,62 @@ HighResolutionTimer::~HighResolutionTimer() {
 
 void HighResolutionTimer::start(std::chrono::microseconds interval,
                                 std::function<void()> callback) {
+    start(interval, std::move(callback), TimerMode::DedicatedThread);
+}
+
+void HighResolutionTimer::start(std::chrono::microseconds interval,
+                                std::function<void()> callback,
+                                TimerMode mode) {
     stop();
+
+#ifdef __APPLE__
+    if (mode == TimerMode::OsTimerQueue) {
+        // Pin the callback on the shared TimerState so the dispatch-source
+        // block can keep it alive through the timer's lifetime.
+        auto state = std::make_shared<TimerState>();
+        state->callback = std::move(callback);
+        state->running.store(true, std::memory_order_release);
+
+        dispatch_queue_attr_t attr = dispatch_queue_attr_make_with_qos_class(
+            DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INTERACTIVE, 0);
+        dispatch_queue_t queue =
+            dispatch_queue_create("com.pulp.runtime.HighResolutionTimer", attr);
+        dispatch_source_t source = dispatch_source_create(
+            DISPATCH_SOURCE_TYPE_TIMER, 0, 0, queue);
+        // Release ownership of the queue to the source (which keeps it alive).
+        dispatch_release(queue);
+
+        const uint64_t interval_ns = static_cast<uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(interval).count());
+        dispatch_source_set_timer(source,
+                                  dispatch_time(DISPATCH_TIME_NOW, interval_ns),
+                                  interval_ns,
+                                  /* leeway */ 0);
+
+        std::shared_ptr<TimerState> state_for_block = state;
+        dispatch_source_set_event_handler(source, ^{
+            if (state_for_block->running.load(std::memory_order_acquire)
+                && state_for_block->callback) {
+                state_for_block->callback();
+            }
+        });
+
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            state_ = state;
+            dispatch_source_ = source;
+            active_mode_ = TimerMode::OsTimerQueue;
+            running_.store(true, std::memory_order_release);
+        }
+
+        dispatch_resume(source);
+        return;
+    }
+#else
+    (void) mode; // OsTimerQueue falls through to DedicatedThread off-Apple.
+#endif
+
+    active_mode_ = TimerMode::DedicatedThread;
     auto state = std::make_shared<TimerState>();
     state->callback = std::move(callback);
     state->running.store(true, std::memory_order_release);
@@ -76,6 +132,7 @@ void HighResolutionTimer::stop() {
     std::shared_ptr<TimerState> state;
     std::thread thread;
     bool stop_from_timer_thread = false;
+    void* source_to_release = nullptr;
 
     running_.store(false, std::memory_order_release);
 
@@ -92,7 +149,21 @@ void HighResolutionTimer::stop() {
             stop_from_timer_thread = thread_.get_id() == std::this_thread::get_id();
             thread = std::move(thread_);
         }
+
+        source_to_release = dispatch_source_;
+        dispatch_source_ = nullptr;
+        active_mode_ = TimerMode::DedicatedThread;
     }
+
+#ifdef __APPLE__
+    if (source_to_release) {
+        dispatch_source_t source = static_cast<dispatch_source_t>(source_to_release);
+        dispatch_source_cancel(source);
+        dispatch_release(source);
+    }
+#else
+    (void) source_to_release;
+#endif
 
     if (stop_from_timer_thread) {
         // A callback can stop or destroy its timer; hand the join to another

--- a/core/signal/include/pulp/signal/adsr.hpp
+++ b/core/signal/include/pulp/signal/adsr.hpp
@@ -80,6 +80,30 @@ public:
     enum class Stage { idle, attack, decay, sustain, release };
     Stage stage() const { return stage_; }
 
+    /// Multiply @p num_samples of @p buffer (starting at @p start_sample)
+    /// by successive envelope values. Advances the envelope by @p num_samples.
+    /// Real-time safe; no allocations.
+    ///
+    /// @code
+    /// adsr.apply_to_buffer(audio_data, 0, block_size);  // amplitude envelope
+    /// @endcode
+    void apply_to_buffer(float* buffer, int start_sample, int num_samples) {
+        for (int i = 0; i < num_samples; ++i)
+            buffer[start_sample + i] *= next();
+    }
+
+    /// Multiply each channel of a planar multi-channel buffer by the same
+    /// envelope. All channels see the same envelope progression — the
+    /// envelope advances once per sample, not per (sample, channel) pair.
+    void apply_to_buffer(float* const* channels, int num_channels,
+                         int start_sample, int num_samples) {
+        for (int i = 0; i < num_samples; ++i) {
+            const float env = next();
+            for (int ch = 0; ch < num_channels; ++ch)
+                channels[ch][start_sample + i] *= env;
+        }
+    }
+
 private:
     Params params_;
     float sample_rate_ = 44100.0f;

--- a/core/signal/include/pulp/signal/dc_blocker.hpp
+++ b/core/signal/include/pulp/signal/dc_blocker.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+namespace pulp::signal {
+
+/// One-pole DC blocker (first-order high-pass).
+///
+/// Removes DC offset and very-low-frequency drift from an audio stream
+/// without measurably altering the audio band. Real-time safe; no
+/// allocations.
+///
+/// Transfer function: H(z) = (1 - z^-1) / (1 - p * z^-1)
+/// where p is the pole position (default 0.995 → ~3.5 Hz corner at 44.1 kHz).
+///
+/// @code
+/// pulp::signal::DcBlocker blocker;
+/// blocker.set_pole(0.995f);
+/// for (int i = 0; i < num_samples; ++i)
+///     output[i] = blocker.process(input[i]);
+/// @endcode
+///
+/// For a more aggressive corner frequency, use a higher-order HPF biquad
+/// instead — this primitive is intentionally minimal.
+template<typename T = float>
+class DcBlocker {
+public:
+    DcBlocker() = default;
+
+    /// Set the pole position (typically 0.99..0.999).
+    /// Higher values give a lower corner frequency.
+    /// At 44.1 kHz: 0.995 ≈ 3.5 Hz, 0.999 ≈ 0.7 Hz.
+    void set_pole(T pole) { pole_ = pole; }
+
+    /// Clear filter state. Call between unrelated streams.
+    void reset() { last_in_ = T(0); last_out_ = T(0); }
+
+    /// Process one sample.
+    T process(T x) {
+        const T y = x - last_in_ + pole_ * last_out_;
+        last_in_ = x;
+        last_out_ = y;
+        return y;
+    }
+
+    /// Process a block in-place.
+    void process(T* samples, int n) {
+        for (int i = 0; i < n; ++i)
+            samples[i] = process(samples[i]);
+    }
+
+private:
+    T pole_ = T(0.995);
+    T last_in_ = T(0);
+    T last_out_ = T(0);
+};
+
+} // namespace pulp::signal

--- a/core/signal/include/pulp/signal/denormal.hpp
+++ b/core/signal/include/pulp/signal/denormal.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+
+namespace pulp::signal {
+
+/// Denormal-flushing utility.
+///
+/// Denormal floating-point values cause severe CPU stalls on x86 when
+/// they enter recursive paths like IIR filter state or reverb feedback.
+/// `snap_to_zero` returns 0 when the input is below a threshold whose
+/// magnitude is large enough to catch denormals (and very-quiet tails)
+/// but small enough not to be audible (-150 dB FS).
+///
+/// Use at the end of each recursive state update in IIR / SVF / TPT /
+/// Ladder / Ballistics / Reverb feedback paths.
+///
+/// @code
+/// last_out_ = pulp::signal::snap_to_zero(coef * last_out_ + input);
+/// @endcode
+///
+/// Build-time toggle: define PULP_DSP_ENABLE_SNAP_TO_ZERO=0 to compile
+/// out the check (the function becomes the identity). Default: ON.
+#ifndef PULP_DSP_ENABLE_SNAP_TO_ZERO
+#define PULP_DSP_ENABLE_SNAP_TO_ZERO 1
+#endif
+
+/// Threshold in absolute value below which a sample is treated as zero.
+/// 1e-15f corresponds to about -300 dB FS for `float` — well below any
+/// audible level and well above the denormal range (~1.4e-45f).
+template<typename T>
+inline constexpr T snap_threshold() { return T(1e-15); }
+
+/// Returns 0 if |x| < snap_threshold, else x. Branchless on most compilers
+/// (compiles to a `cmpltps` + `andps` pair on x86-SSE).
+template<typename T>
+inline T snap_to_zero(T x) {
+#if PULP_DSP_ENABLE_SNAP_TO_ZERO
+    return (x < snap_threshold<T>() && x > -snap_threshold<T>()) ? T(0) : x;
+#else
+    return x;
+#endif
+}
+
+/// Snap an entire buffer in place.
+template<typename T>
+inline void snap_to_zero(T* samples, int n) {
+#if PULP_DSP_ENABLE_SNAP_TO_ZERO
+    for (int i = 0; i < n; ++i)
+        samples[i] = snap_to_zero(samples[i]);
+#else
+    (void) samples;
+    (void) n;
+#endif
+}
+
+/// Return true if @p x is a denormal (subnormal) float.
+/// Useful for diagnostics; not for hot paths.
+template<typename T>
+inline bool is_denormal(T x) {
+    return x != T(0) && std::fpclassify(x) == FP_SUBNORMAL;
+}
+
+} // namespace pulp::signal

--- a/core/signal/include/pulp/signal/smoothed_value.hpp
+++ b/core/signal/include/pulp/signal/smoothed_value.hpp
@@ -5,8 +5,20 @@
 
 namespace pulp::signal {
 
-// Smoothly interpolates toward a target value over time
-// Real-time safe, no allocations. Use for parameter smoothing.
+/// Linear smoothing for control-rate parameters.
+///
+/// Real-time safe; no allocations. Use for parameter smoothing where the
+/// linear ramp is perceptually correct (gain in linear units, mix, pan
+/// position, etc.).
+///
+/// For parameters where the linear ramp is perceptually wrong — pitch,
+/// frequency, gain in dB — use `LogRampedValue` (in
+/// `core/signal/include/pulp/signal/log_ramped_value.hpp`) which applies
+/// a multiplicative (geometric) per-sample step so equal time produces
+/// equal perceptual change across the range.
+///
+/// The two utilities together cover Pulp's smoothing surface; consumers
+/// pick the curve that matches the parameter's semantics.
 template<typename T = float>
 class SmoothedValue {
 public:

--- a/core/state/include/pulp/state/edit_history.hpp
+++ b/core/state/include/pulp/state/edit_history.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <string>
@@ -42,26 +43,47 @@ public:
     /// Execute an action and add it to the history.
     /// If coalescing is enabled and the last action has the same description,
     /// replaces it (merging rapid small changes into one undo step).
+    /// If `set_coalesce_window` is set to a non-zero duration, two
+    /// consecutive actions also coalesce when they arrive within that
+    /// window even if their descriptions differ.
     void perform(std::unique_ptr<EditAction> action) {
         action->redo();
         // A new edit invalidates redo history even when it coalesces into
         // the current undo step.
         redo_stack_.clear();
-        // Coalesce: if same description as last action, replace it
-        if (coalesce_ && !undo_stack_.empty() &&
+        const auto now = Clock::now();
+        const bool same_description =
+            coalesce_ && !undo_stack_.empty() &&
             !action->description().empty() &&
-            undo_stack_.back()->description() == action->description()) {
+            undo_stack_.back()->description() == action->description();
+        const bool within_window =
+            coalesce_window_.count() > 0 && !undo_stack_.empty() &&
+            (now - last_perform_time_) <= coalesce_window_;
+        if (same_description || (coalesce_ && within_window)) {
             undo_stack_.back() = std::move(action);
+            last_perform_time_ = now;
             return;
         }
         undo_stack_.push_back(std::move(action));
+        last_perform_time_ = now;
         // Enforce depth limit
         while (undo_stack_.size() > max_depth_)
             undo_stack_.erase(undo_stack_.begin());
     }
 
-    /// Enable/disable coalescing (merge rapid changes with same description).
+    /// Enable/disable description-based coalescing (merge rapid changes
+    /// with same description). Defaults to true.
     void set_coalesce(bool enabled) { coalesce_ = enabled; }
+
+    /// Time-window coalescing. When @p window > 0, two consecutive
+    /// `perform()` calls that arrive within this duration are merged into
+    /// one undo step even if their descriptions differ. Use 0 to disable
+    /// (description-only coalescing). 0 by default to preserve existing
+    /// behavior.
+    void set_coalesce_window(std::chrono::milliseconds window) {
+        coalesce_window_ = window;
+    }
+    std::chrono::milliseconds coalesce_window() const { return coalesce_window_; }
 
     /// Convenience: perform a lambda-based action.
     void perform(std::function<void()> do_fn, std::function<void()> undo_fn,
@@ -113,10 +135,14 @@ public:
     size_t max_depth() const { return max_depth_; }
 
 private:
+    using Clock = std::chrono::steady_clock;
+
     std::vector<std::unique_ptr<EditAction>> undo_stack_;
     std::vector<std::unique_ptr<EditAction>> redo_stack_;
     size_t max_depth_;
     bool coalesce_ = true;  ///< Merge rapid changes with same description
+    std::chrono::milliseconds coalesce_window_{0};
+    Clock::time_point last_perform_time_{};
 };
 
 } // namespace pulp::state

--- a/core/state/include/pulp/state/edit_history.hpp
+++ b/core/state/include/pulp/state/edit_history.hpp
@@ -98,6 +98,9 @@ public:
         undo_stack_.pop_back();
         action->undo();
         redo_stack_.push_back(std::move(action));
+        // Reset coalesce timestamp so a new edit right after undo doesn't
+        // merge into the now-older `undo_stack_.back()` entry.
+        last_perform_time_ = Clock::time_point{};
         return true;
     }
 
@@ -108,6 +111,7 @@ public:
         redo_stack_.pop_back();
         action->redo();
         undo_stack_.push_back(std::move(action));
+        last_perform_time_ = Clock::time_point{};
         return true;
     }
 

--- a/core/state/include/pulp/state/parameter.hpp
+++ b/core/state/include/pulp/state/parameter.hpp
@@ -54,6 +54,101 @@ struct ParamRange {
     }
 };
 
+/// Skew-aware normalized range with optional symmetric centre.
+///
+/// `NormalisableRange<T>` extends `ParamRange` with a non-linear mapping
+/// between the [0, 1] host-automation domain and the [min, max] parameter
+/// domain. Two shape controls:
+///
+/// - `skew`: <1 weights toward `min`, >1 weights toward `max`, 1 = linear.
+///   Conventionally, a skew of `log(0.5) / log((mid - min) / (max - min))`
+///   places `mid` at the centre (0.5) of the normalized range.
+/// - `symmetric_skew`: when true, the curve is mirrored around the centre,
+///   so values near 0.5 in normalized space land near the midpoint and
+///   values near the edges fan out symmetrically. Useful for bipolar
+///   parameters like pan, balance, detune.
+///
+/// Step quantization is honored on denormalize (matches `ParamRange::step`).
+///
+/// @code
+/// // Frequency knob: 20 Hz at min, 20 kHz at max, 1 kHz at centre.
+/// pulp::state::NormalisableRange<float> freq{20.0f, 20000.0f, 1000.0f};
+/// float normalized = freq.normalize(1000.0f); // ~= 0.5
+/// float hz         = freq.denormalize(0.5f);  // ~= 1000.0f
+/// @endcode
+template<typename T = float>
+struct NormalisableRange {
+    T min = T(0);
+    T max = T(1);
+    T interval = T(0);          ///< Step size. 0 = continuous.
+    T skew = T(1);              ///< 1 = linear, <1 weights min, >1 weights max.
+    bool symmetric_skew = false;
+
+    constexpr NormalisableRange() = default;
+    constexpr NormalisableRange(T lo, T hi, T step = T(0), T skew_value = T(1),
+                                bool symmetric = false)
+        : min(lo), max(hi), interval(step),
+          skew(skew_value), symmetric_skew(symmetric) {}
+
+    /// Build a NormalisableRange whose normalised midpoint maps to the
+    /// supplied real-valued centre. Equivalent to choosing the skew that
+    /// satisfies denormalize(0.5) == centre.
+    static NormalisableRange with_centre(T lo, T hi, T centre, T step = T(0)) {
+        NormalisableRange r{lo, hi, step};
+        if (hi > lo && centre > lo && centre < hi) {
+            const T proportion = (centre - lo) / (hi - lo);
+            // log(0.5) / log(proportion) gives the skew that lands `centre` at 0.5.
+            r.skew = std::log(T(0.5)) / std::log(proportion);
+        }
+        return r;
+    }
+
+    /// Map a real value in [min, max] to a normalized value in [0, 1].
+    ///
+    /// Skew convention: with `skew < 1` the curve weights toward `min`
+    /// (small real values cover more of the [0, 1] domain); with
+    /// `skew > 1` the curve weights toward `max`. `skew == 1` is linear.
+    T normalize(T value) const {
+        if (max == min) return T(0);
+        T proportion = (value - min) / (max - min);
+        proportion = std::clamp(proportion, T(0), T(1));
+        if (symmetric_skew) {
+            const T centred = (proportion * T(2)) - T(1); // [-1, 1]
+            const T magnitude = std::pow(std::abs(centred), skew);
+            const T signed_mag = centred < T(0) ? -magnitude : magnitude;
+            return (signed_mag + T(1)) * T(0.5);
+        }
+        return std::pow(proportion, skew);
+    }
+
+    /// Map a normalized [0, 1] value back to the real range. Applies
+    /// `interval` quantization when non-zero.
+    T denormalize(T normalized) const {
+        normalized = std::clamp(normalized, T(0), T(1));
+        T proportion;
+        if (symmetric_skew) {
+            const T centred = (normalized * T(2)) - T(1); // [-1, 1]
+            const T magnitude = std::pow(std::abs(centred), T(1) / skew);
+            const T signed_mag = centred < T(0) ? -magnitude : magnitude;
+            proportion = (signed_mag + T(1)) * T(0.5);
+        } else {
+            proportion = std::pow(normalized, T(1) / skew);
+        }
+        T value = min + proportion * (max - min);
+        if (interval > T(0)) {
+            value = min + std::round((value - min) / interval) * interval;
+        }
+        return std::clamp(value, min, max);
+    }
+
+    /// Round a real value down to the nearest legal step.
+    T snap(T value) const {
+        if (interval <= T(0)) return std::clamp(value, min, max);
+        T snapped = min + std::round((value - min) / interval) * interval;
+        return std::clamp(snapped, min, max);
+    }
+};
+
 /// Immutable parameter metadata, registered once at plugin initialization.
 ///
 /// Each parameter has a unique @c id, a human-readable @c name, an optional

--- a/core/state/include/pulp/state/undo_manager.hpp
+++ b/core/state/include/pulp/state/undo_manager.hpp
@@ -88,8 +88,13 @@ public:
         const auto now = Clock::now();
         if (coalesce_window_.count() > 0 && !undo_stack_.empty() &&
             (now - last_perform_time_) <= coalesce_window_) {
+            // A new edit invalidates redo history even when it merges into
+            // the prior transaction — otherwise undo+new-edit could leave
+            // stale redo entries that no longer make sense.
+            redo_stack_.clear();
             undo_stack_.back().actions.push_back(std::move(action));
             last_perform_time_ = now;
+            if (on_state_changed) on_state_changed();
             return;
         }
 
@@ -155,6 +160,10 @@ public:
         }
 
         redo_stack_.push_back(std::move(tx));
+        // Reset the coalesce timestamp so the next edit starts a fresh
+        // window — a `perform()` after `undo()` must never merge into
+        // the older entry that's still on the undo stack.
+        last_perform_time_ = Clock::time_point{};
         if (on_state_changed) on_state_changed();
         return true;
     }
@@ -172,6 +181,7 @@ public:
         }
 
         undo_stack_.push_back(std::move(tx));
+        last_perform_time_ = Clock::time_point{};
         if (on_state_changed) on_state_changed();
         return true;
     }

--- a/core/state/include/pulp/state/undo_manager.hpp
+++ b/core/state/include/pulp/state/undo_manager.hpp
@@ -3,6 +3,7 @@
 /// @file undo_manager.hpp
 /// Generic undo/redo system with named actions and transaction grouping.
 
+#include <chrono>
 #include <string>
 #include <vector>
 #include <functional>
@@ -70,17 +71,33 @@ class UndoManager {
 public:
     /// Perform an action and add it to the undo history.
     /// The action's redo function is called immediately.
+    ///
+    /// When `set_coalesce_window` is non-zero and this call arrives
+    /// within that window of the previous outside-transaction `perform()`,
+    /// the new action is appended to the previous transaction rather than
+    /// creating a new top-level entry. This produces single-step undo for
+    /// rapid sequences (e.g., a slider drag).
     void perform(std::unique_ptr<UndoAction> action) {
         if (action->redo_fn) action->redo_fn();
 
         if (in_transaction_) {
             current_transaction_->actions.push_back(std::move(action));
-        } else {
-            UndoTransaction tx;
-            tx.name = action->name;
-            tx.actions.push_back(std::move(action));
-            push_undo(std::move(tx));
+            return;
         }
+
+        const auto now = Clock::now();
+        if (coalesce_window_.count() > 0 && !undo_stack_.empty() &&
+            (now - last_perform_time_) <= coalesce_window_) {
+            undo_stack_.back().actions.push_back(std::move(action));
+            last_perform_time_ = now;
+            return;
+        }
+
+        UndoTransaction tx;
+        tx.name = action->name;
+        tx.actions.push_back(std::move(action));
+        push_undo(std::move(tx));
+        last_perform_time_ = now;
     }
 
     /// Perform an action without immediately executing it.
@@ -198,12 +215,26 @@ public:
     /// Called whenever the undo/redo state changes.
     std::function<void()> on_state_changed;
 
+    /// Time-window coalescing. When @p window > 0, two consecutive
+    /// `perform()` calls outside any explicit transaction that arrive
+    /// within this duration are merged into one undo step. 0 disables
+    /// (each `perform()` becomes its own undo step). 0 by default to
+    /// preserve existing behavior.
+    void set_coalesce_window(std::chrono::milliseconds window) {
+        coalesce_window_ = window;
+    }
+    std::chrono::milliseconds coalesce_window() const { return coalesce_window_; }
+
 private:
+    using Clock = std::chrono::steady_clock;
+
     std::vector<UndoTransaction> undo_stack_;
     std::vector<UndoTransaction> redo_stack_;
     int max_history_ = 100;
     bool in_transaction_ = false;
     std::unique_ptr<UndoTransaction> current_transaction_;
+    std::chrono::milliseconds coalesce_window_{0};
+    Clock::time_point last_perform_time_{};
 
     void push_undo(UndoTransaction tx) {
         redo_stack_.clear(); // new action invalidates redo

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2138,6 +2138,13 @@ pulp_add_test_suite(pulp-test-sprite-strip LIBRARIES pulp::view)
 # Edit history (global undo) tests
 pulp_add_test_suite(pulp-test-edit-history LIBRARIES pulp::state)
 
+# macOS plan Batch A — Foundations
+pulp_add_test_suite(pulp-test-dc-blocker LIBRARIES pulp::signal)
+pulp_add_test_suite(pulp-test-denormal LIBRARIES pulp::signal)
+pulp_add_test_suite(pulp-test-normalisable-range LIBRARIES pulp::state)
+pulp_add_test_suite(pulp-test-adsr LIBRARIES pulp::signal)
+pulp_add_test_suite(pulp-test-high-resolution-timer LIBRARIES pulp::runtime)
+
 # Platform maturity tests (cursor, focus, IME, context menu, accessibility)
 pulp_add_test_suite(pulp-test-platform-maturity LIBRARIES pulp::view)
 

--- a/test/test_adsr.cpp
+++ b/test/test_adsr.cpp
@@ -1,0 +1,78 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/signal/adsr.hpp>
+
+#include <vector>
+
+using namespace pulp::signal;
+
+TEST_CASE("ADSR runs through stages", "[signal][adsr]") {
+    Adsr env;
+    env.set_sample_rate(44100.0f);
+    env.set_params({0.01f, 0.05f, 0.5f, 0.1f});
+
+    env.note_on();
+    REQUIRE(env.stage() == Adsr::Stage::attack);
+
+    // Advance enough samples for attack to complete and sustain to be reached.
+    for (int i = 0; i < 44100; ++i) (void) env.next();
+    REQUIRE(env.stage() == Adsr::Stage::sustain);
+
+    env.note_off();
+    REQUIRE(env.stage() == Adsr::Stage::release);
+
+    // Run release to completion.
+    for (int i = 0; i < 44100; ++i) (void) env.next();
+    REQUIRE(env.stage() == Adsr::Stage::idle);
+    REQUIRE(env.is_active() == false);
+}
+
+TEST_CASE("ADSR apply_to_buffer multiplies sample by envelope", "[signal][adsr]") {
+    Adsr env;
+    env.set_sample_rate(44100.0f);
+    env.set_params({0.001f, 0.005f, 0.5f, 0.01f});
+    env.note_on();
+
+    // Pre-warm the envelope so it has reached sustain.
+    for (int i = 0; i < 1024; ++i) (void) env.next();
+
+    std::vector<float> buffer(256, 1.0f);
+    env.apply_to_buffer(buffer.data(), 0, 256);
+    // In sustain (level == 0.5), every output should be 0.5.
+    for (float s : buffer) {
+        REQUIRE(s == 0.5f);
+    }
+}
+
+TEST_CASE("ADSR apply_to_buffer planar multi-channel", "[signal][adsr]") {
+    Adsr env;
+    env.set_sample_rate(44100.0f);
+    env.set_params({0.001f, 0.005f, 0.5f, 0.01f});
+    env.note_on();
+    for (int i = 0; i < 1024; ++i) (void) env.next();
+
+    std::vector<float> left(64, 2.0f);
+    std::vector<float> right(64, 2.0f);
+    float* channels[2] = {left.data(), right.data()};
+    env.apply_to_buffer(channels, 2, 0, 64);
+
+    // Both channels see the same per-sample multiplier (0.5 at sustain),
+    // so output is 1.0.
+    for (int i = 0; i < 64; ++i) {
+        REQUIRE(left[i] == 1.0f);
+        REQUIRE(right[i] == 1.0f);
+    }
+}
+
+TEST_CASE("ADSR retrigger does not reset level", "[signal][adsr]") {
+    Adsr env;
+    env.set_sample_rate(44100.0f);
+    env.set_params({0.1f, 0.1f, 0.5f, 0.1f});
+    env.note_on();
+    for (int i = 0; i < 2000; ++i) (void) env.next();
+    const float before = env.next();
+
+    env.note_on(); // retrigger
+    const float after = env.next();
+    // After retrigger we go back to attack stage; level shouldn't jump to 0.
+    REQUIRE(after >= before * 0.5f);
+}

--- a/test/test_dc_blocker.cpp
+++ b/test/test_dc_blocker.cpp
@@ -1,0 +1,64 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/signal/dc_blocker.hpp>
+
+#include <cmath>
+#include <numeric>
+#include <vector>
+
+using namespace pulp::signal;
+
+TEST_CASE("DcBlocker removes DC offset", "[signal][dc-blocker]") {
+    DcBlocker<float> blocker;
+
+    // 4096 samples of constant +0.5 should converge toward zero output.
+    std::vector<float> samples(4096, 0.5f);
+    blocker.process(samples.data(), static_cast<int>(samples.size()));
+
+    // The tail half should be well below the input DC level (>60 dB attenuation
+    // is a very loose bound; the actual attenuation at the default pole is
+    // far stronger).
+    const float tail_sum = std::accumulate(samples.begin() + 2048, samples.end(), 0.0f);
+    const float tail_mean = tail_sum / 2048.0f;
+    REQUIRE(std::abs(tail_mean) < 0.0005f);
+}
+
+TEST_CASE("DcBlocker preserves audio-band signal", "[signal][dc-blocker]") {
+    DcBlocker<float> blocker;
+    blocker.set_pole(0.995f);
+
+    // 1 kHz sine at 44.1 kHz should pass through with magnitude close to 1.
+    constexpr int kSampleRate = 44100;
+    constexpr int kBlockSize = 4096;
+    constexpr float kFreq = 1000.0f;
+    constexpr float kTwoPi = 6.28318530717958647692f;
+
+    std::vector<float> input(kBlockSize);
+    for (int i = 0; i < kBlockSize; ++i)
+        input[i] = std::sin(kTwoPi * kFreq * float(i) / float(kSampleRate));
+
+    std::vector<float> output(input);
+    blocker.process(output.data(), kBlockSize);
+
+    // Skip the first 1024 samples (filter warmup). Measure RMS of input vs output.
+    auto rms = [](const float* s, int from, int to) {
+        double acc = 0.0;
+        for (int i = from; i < to; ++i) acc += double(s[i]) * double(s[i]);
+        return std::sqrt(acc / double(to - from));
+    };
+    const double in_rms = rms(input.data(), 1024, kBlockSize);
+    const double out_rms = rms(output.data(), 1024, kBlockSize);
+    // Expect <= 0.5 dB attenuation at 1 kHz with pole=0.995.
+    const double ratio = out_rms / in_rms;
+    REQUIRE(ratio > 0.94);
+    REQUIRE(ratio < 1.01);
+}
+
+TEST_CASE("DcBlocker reset clears state", "[signal][dc-blocker]") {
+    DcBlocker<float> blocker;
+    for (int i = 0; i < 100; ++i)
+        (void) blocker.process(1.0f);
+    blocker.reset();
+    // First sample after reset of a constant input is the input itself.
+    const float first = blocker.process(0.5f);
+    REQUIRE(first == 0.5f);
+}

--- a/test/test_denormal.cpp
+++ b/test/test_denormal.cpp
@@ -1,0 +1,54 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/signal/denormal.hpp>
+
+#include <cmath>
+#include <limits>
+
+using namespace pulp::signal;
+
+TEST_CASE("snap_to_zero passes through audible values", "[signal][denormal]") {
+    REQUIRE(snap_to_zero(1.0f) == 1.0f);
+    REQUIRE(snap_to_zero(-1.0f) == -1.0f);
+    REQUIRE(snap_to_zero(1e-10f) == 1e-10f);  // -200 dB FS, still passes
+    REQUIRE(snap_to_zero(-1e-10f) == -1e-10f);
+}
+
+TEST_CASE("snap_to_zero zeroes denormals and tiny values", "[signal][denormal]") {
+    // Below 1e-15f threshold — should snap to zero.
+    REQUIRE(snap_to_zero(1e-20f) == 0.0f);
+    REQUIRE(snap_to_zero(-1e-20f) == 0.0f);
+    REQUIRE(snap_to_zero(std::numeric_limits<float>::denorm_min()) == 0.0f);
+    REQUIRE(snap_to_zero(-std::numeric_limits<float>::denorm_min()) == 0.0f);
+}
+
+TEST_CASE("snap_to_zero is identity at exact zero", "[signal][denormal]") {
+    REQUIRE(snap_to_zero(0.0f) == 0.0f);
+    REQUIRE(snap_to_zero(-0.0f) == 0.0f);
+}
+
+TEST_CASE("snap_to_zero buffer overload", "[signal][denormal]") {
+    float buf[8] = {1.0f, -1.0f, 1e-20f, -1e-20f, 0.0f, 0.5f, -0.5f,
+                    std::numeric_limits<float>::denorm_min()};
+    snap_to_zero(buf, 8);
+    REQUIRE(buf[0] == 1.0f);
+    REQUIRE(buf[1] == -1.0f);
+    REQUIRE(buf[2] == 0.0f);
+    REQUIRE(buf[3] == 0.0f);
+    REQUIRE(buf[4] == 0.0f);
+    REQUIRE(buf[5] == 0.5f);
+    REQUIRE(buf[6] == -0.5f);
+    REQUIRE(buf[7] == 0.0f);
+}
+
+TEST_CASE("is_denormal classifies subnormals", "[signal][denormal]") {
+    REQUIRE_FALSE(is_denormal(0.0f));
+    REQUIRE_FALSE(is_denormal(1.0f));
+    REQUIRE_FALSE(is_denormal(1e-10f));   // tiny but normal
+    REQUIRE(is_denormal(std::numeric_limits<float>::denorm_min()));
+}
+
+TEST_CASE("snap_to_zero double precision", "[signal][denormal]") {
+    REQUIRE(snap_to_zero(1.0) == 1.0);
+    REQUIRE(snap_to_zero(1e-20) == 0.0);
+    REQUIRE(snap_to_zero(0.5) == 0.5);
+}

--- a/test/test_edit_history.cpp
+++ b/test/test_edit_history.cpp
@@ -1,6 +1,9 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/state/edit_history.hpp>
 
+#include <chrono>
+#include <thread>
+
 using namespace pulp::state;
 
 TEST_CASE("EditHistory undo/redo", "[state][undo]") {

--- a/test/test_edit_history.cpp
+++ b/test/test_edit_history.cpp
@@ -259,3 +259,57 @@ TEST_CASE("EditHistory coalesced replacement controls undo and redo values",
     REQUIRE(history.redo());
     REQUIRE(v == 5);
 }
+
+TEST_CASE("EditHistory time-window coalescing merges rapid distinct-description actions",
+          "[state][undo][time-coalesce]") {
+    EditHistory history;
+    history.set_coalesce_window(std::chrono::milliseconds(200));
+    int v = 0;
+    history.perform([&] { v = 1; }, [&] { v = 0; }, "Move");
+    history.perform([&] { v = 2; }, [&] { v = 1; }, "Resize");
+    REQUIRE(v == 2);
+    REQUIRE(history.undo_count() == 1);
+    REQUIRE(history.undo());
+    REQUIRE(v == 1);
+}
+
+TEST_CASE("EditHistory time-window expiry keeps actions separate",
+          "[state][undo][time-coalesce]") {
+    EditHistory history;
+    history.set_coalesce_window(std::chrono::milliseconds(10));
+    int v = 0;
+    history.perform([&] { v = 1; }, [&] { v = 0; }, "First");
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    history.perform([&] { v = 2; }, [&] { v = 1; }, "Second");
+    REQUIRE(history.undo_count() == 2);
+}
+
+TEST_CASE("EditHistory window=0 disables time-window coalescing",
+          "[state][undo][time-coalesce]") {
+    EditHistory history;
+    history.set_coalesce(false); // disable description coalescing too
+    history.set_coalesce_window(std::chrono::milliseconds(0));
+    int v = 0;
+    history.perform([&] { v = 1; }, [&] { v = 0; }, "A");
+    history.perform([&] { v = 2; }, [&] { v = 1; }, "B");
+    REQUIRE(history.undo_count() == 2);
+}
+
+TEST_CASE("EditHistory undo resets coalesce window timestamp (Codex P1 regression)",
+          "[state][undo][time-coalesce][regression]") {
+    EditHistory history;
+    history.set_coalesce(false); // ensure only window coalescing matters
+    history.set_coalesce_window(std::chrono::milliseconds(200));
+    int v = 0;
+    history.perform([&] { v = 1; }, [&] { v = 0; }, "A");
+    REQUIRE(history.undo_count() == 1);
+    REQUIRE(history.undo());
+    REQUIRE(history.undo_count() == 0);
+    REQUIRE(history.can_redo());
+    // A new edit right after undo must NOT coalesce into the popped older
+    // entry — it should start its own undo entry. Also: a new edit
+    // invalidates redo history.
+    history.perform([&] { v = 2; }, [&] { v = 1; }, "B");
+    REQUIRE(history.undo_count() == 1);
+    REQUIRE_FALSE(history.can_redo());
+}

--- a/test/test_high_resolution_timer.cpp
+++ b/test/test_high_resolution_timer.cpp
@@ -1,0 +1,91 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/runtime/high_resolution_timer.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace pulp::runtime;
+
+TEST_CASE("HighResolutionTimer DedicatedThread mode fires callbacks", "[runtime][hrt]") {
+    HighResolutionTimer timer;
+    std::atomic<int> ticks{0};
+    timer.start(std::chrono::milliseconds(2),
+                [&] { ticks.fetch_add(1, std::memory_order_relaxed); });
+    REQUIRE(timer.is_running());
+    REQUIRE(timer.active_mode() == TimerMode::DedicatedThread);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    timer.stop();
+    REQUIRE(timer.is_running() == false);
+
+    // Conservative bound: at 2 ms cadence over 100 ms we expect roughly 50 ticks.
+    // Allow a wide window for CI variance.
+    REQUIRE(ticks.load() >= 5);
+}
+
+#ifdef __APPLE__
+TEST_CASE("HighResolutionTimer OsTimerQueue mode fires callbacks on Apple",
+          "[runtime][hrt][apple]") {
+    HighResolutionTimer timer;
+    std::atomic<int> ticks{0};
+    timer.start(std::chrono::milliseconds(2),
+                [&] { ticks.fetch_add(1, std::memory_order_relaxed); },
+                TimerMode::OsTimerQueue);
+    REQUIRE(timer.is_running());
+    REQUIRE(timer.active_mode() == TimerMode::OsTimerQueue);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    timer.stop();
+    REQUIRE(timer.is_running() == false);
+
+    REQUIRE(ticks.load() >= 5);
+}
+
+TEST_CASE("HighResolutionTimer OS queue cleans up on destruction",
+          "[runtime][hrt][apple]") {
+    std::atomic<int> ticks{0};
+    {
+        HighResolutionTimer timer;
+        timer.start(std::chrono::milliseconds(5),
+                    [&] { ticks.fetch_add(1, std::memory_order_relaxed); },
+                    TimerMode::OsTimerQueue);
+        std::this_thread::sleep_for(std::chrono::milliseconds(40));
+    } // destructor runs stop()
+    const int final_ticks = ticks.load();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    // After destruction, ticks must not advance.
+    REQUIRE(ticks.load() == final_ticks);
+}
+#endif
+
+TEST_CASE("HighResolutionTimer OS queue falls back to dedicated thread off-Apple",
+          "[runtime][hrt]") {
+    HighResolutionTimer timer;
+    std::atomic<int> ticks{0};
+    timer.start(std::chrono::milliseconds(2),
+                [&] { ticks.fetch_add(1, std::memory_order_relaxed); },
+                TimerMode::OsTimerQueue);
+    REQUIRE(timer.is_running());
+
+#ifndef __APPLE__
+    REQUIRE(timer.active_mode() == TimerMode::DedicatedThread);
+#endif
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    timer.stop();
+}
+
+TEST_CASE("HighResolutionTimer stop is idempotent", "[runtime][hrt]") {
+    HighResolutionTimer timer;
+    timer.stop();
+    timer.stop();
+    REQUIRE(timer.is_running() == false);
+
+    std::atomic<int> ticks{0};
+    timer.start(std::chrono::milliseconds(1),
+                [&] { ticks.fetch_add(1, std::memory_order_relaxed); });
+    timer.stop();
+    timer.stop();
+    REQUIRE(timer.is_running() == false);
+}

--- a/test/test_normalisable_range.cpp
+++ b/test/test_normalisable_range.cpp
@@ -1,0 +1,66 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/state/parameter.hpp>
+
+#include <cmath>
+
+using namespace pulp::state;
+
+TEST_CASE("NormalisableRange linear behaves like ParamRange", "[state][normalisable]") {
+    NormalisableRange<float> r{0.0f, 10.0f};
+    REQUIRE(r.normalize(0.0f) == 0.0f);
+    REQUIRE(r.normalize(5.0f) == 0.5f);
+    REQUIRE(r.normalize(10.0f) == 1.0f);
+    REQUIRE(r.denormalize(0.5f) == 5.0f);
+}
+
+TEST_CASE("NormalisableRange clamps out-of-range inputs", "[state][normalisable]") {
+    NormalisableRange<float> r{-1.0f, 1.0f};
+    REQUIRE(r.normalize(-5.0f) == 0.0f);
+    REQUIRE(r.normalize(5.0f) == 1.0f);
+    REQUIRE(r.denormalize(-1.0f) == -1.0f);
+    REQUIRE(r.denormalize(2.0f) == 1.0f);
+}
+
+TEST_CASE("NormalisableRange skew weights low end", "[state][normalisable]") {
+    // skew < 1 should pull the curve toward `min` — so denormalize(0.5)
+    // returns a value below the linear midpoint.
+    NormalisableRange<float> r{0.0f, 100.0f, /*step*/ 0.0f, /*skew*/ 0.3f};
+    const float mid = r.denormalize(0.5f);
+    REQUIRE(mid < 50.0f);
+    REQUIRE(mid > 0.0f);
+    // Round-trip: normalize(denormalize(n)) == n within tolerance.
+    REQUIRE(std::abs(r.normalize(mid) - 0.5f) < 1e-5f);
+}
+
+TEST_CASE("NormalisableRange with_centre places midpoint at 0.5", "[state][normalisable]") {
+    // Classic frequency knob: 20 Hz min, 20000 Hz max, 1000 Hz centre.
+    auto r = NormalisableRange<float>::with_centre(20.0f, 20000.0f, 1000.0f);
+    const float at_half = r.denormalize(0.5f);
+    REQUIRE(std::abs(at_half - 1000.0f) < 0.5f);
+    // Endpoints still snap.
+    REQUIRE(r.denormalize(0.0f) == 20.0f);
+    REQUIRE(r.denormalize(1.0f) == 20000.0f);
+}
+
+TEST_CASE("NormalisableRange step quantization", "[state][normalisable]") {
+    NormalisableRange<float> r{0.0f, 10.0f, /*step*/ 0.5f};
+    REQUIRE(r.denormalize(0.5f) == 5.0f);
+    REQUIRE(r.denormalize(0.05f) == 0.5f);
+    // 0.07 of 10 = 0.7, snaps to 0.5.
+    REQUIRE(r.denormalize(0.07f) == 0.5f);
+    REQUIRE(r.snap(2.3f) == 2.5f);
+    REQUIRE(r.snap(0.2f) == 0.0f);
+}
+
+TEST_CASE("NormalisableRange symmetric skew is mirrored", "[state][normalisable]") {
+    NormalisableRange<float> r{-1.0f, 1.0f, /*step*/ 0.0f, /*skew*/ 0.5f, /*symmetric*/ true};
+    // 0.0 in normalized space maps to -1, 1.0 maps to 1.
+    REQUIRE(std::abs(r.denormalize(0.0f) - (-1.0f)) < 1e-5f);
+    REQUIRE(std::abs(r.denormalize(1.0f) - 1.0f) < 1e-5f);
+    // 0.5 in normalized space maps near the midpoint (0).
+    REQUIRE(std::abs(r.denormalize(0.5f)) < 1e-5f);
+    // Mirror property: denormalize(0.5 + d) == -denormalize(0.5 - d) within tolerance.
+    const float plus = r.denormalize(0.7f);
+    const float minus = r.denormalize(0.3f);
+    REQUIRE(std::abs(plus + minus) < 1e-5f);
+}

--- a/test/test_undo_manager.cpp
+++ b/test/test_undo_manager.cpp
@@ -43,6 +43,41 @@ TEST_CASE("UndoManager coalesce_window=0 disables window coalescing",
     REQUIRE(um.undo_count() == 2);
 }
 
+TEST_CASE("UndoManager coalesced perform clears redo stack (Codex P1 regression)",
+          "[state][undo][time-coalesce][regression]") {
+    UndoManager um;
+    um.set_coalesce_window(std::chrono::milliseconds(200));
+    int v = 0;
+    um.perform(UndoAction::create("A", [&] { v = 0; }, [&] { v = 1; }));
+    um.perform(UndoAction::create("B", [&] { v = 1; }, [&] { v = 2; }));
+    REQUIRE(um.undo());
+    REQUIRE(um.can_redo());
+    // A new edit that lands within the coalesce window must INVALIDATE
+    // redo history even when it gets merged into the prior transaction —
+    // otherwise stale redo entries hang around after undo+new-edit.
+    // Wait briefly to ensure we're inside the window relative to first perform.
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    um.perform(UndoAction::create("C", [&] { v = 0; }, [&] { v = 3; }));
+    REQUIRE_FALSE(um.can_redo());
+}
+
+TEST_CASE("UndoManager undo resets coalesce window timestamp (Codex P1 regression)",
+          "[state][undo][time-coalesce][regression]") {
+    UndoManager um;
+    um.set_coalesce_window(std::chrono::milliseconds(200));
+    int v = 0;
+    um.perform(UndoAction::create("A", [&] { v = 0; }, [&] { v = 1; }));
+    REQUIRE(um.undo_count() == 1);
+    REQUIRE(um.undo());
+    REQUIRE(um.undo_count() == 0);
+    // After undo, the redo stack holds A. A new perform() should NOT
+    // coalesce into the (now-popped) older entry — it should start its
+    // own transaction.
+    um.perform(UndoAction::create("B", [&] { v = 1; }, [&] { v = 2; }));
+    REQUIRE(um.undo_count() == 1);
+    REQUIRE(um.undo_name() == "B");
+}
+
 TEST_CASE("UndoManager perform and undo", "[state][undo]") {
     UndoManager um;
     int value = 0;

--- a/test/test_undo_manager.cpp
+++ b/test/test_undo_manager.cpp
@@ -1,7 +1,47 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/state/undo_manager.hpp>
 
+#include <chrono>
+#include <thread>
+
 using namespace pulp::state;
+
+TEST_CASE("UndoManager time-window coalescing merges rapid actions",
+          "[state][undo][time-coalesce]") {
+    UndoManager um;
+    um.set_coalesce_window(std::chrono::milliseconds(200));
+    int v = 0;
+    um.perform(UndoAction::create("Step 1",
+        [&] { v = 0; }, [&] { v = 1; }));
+    um.perform(UndoAction::create("Step 2",
+        [&] { v = 1; }, [&] { v = 2; }));
+    REQUIRE(v == 2);
+    REQUIRE(um.undo_count() == 1);
+    REQUIRE(um.undo());
+    // Undo reverses both actions (Step 2 first, then Step 1) so v returns to 0.
+    REQUIRE(v == 0);
+}
+
+TEST_CASE("UndoManager time-window expiry keeps actions separate",
+          "[state][undo][time-coalesce]") {
+    UndoManager um;
+    um.set_coalesce_window(std::chrono::milliseconds(10));
+    int v = 0;
+    um.perform(UndoAction::create("A", [&] { v = 0; }, [&] { v = 1; }));
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    um.perform(UndoAction::create("B", [&] { v = 1; }, [&] { v = 2; }));
+    REQUIRE(um.undo_count() == 2);
+}
+
+TEST_CASE("UndoManager coalesce_window=0 disables window coalescing",
+          "[state][undo][time-coalesce]") {
+    UndoManager um;
+    um.set_coalesce_window(std::chrono::milliseconds(0));
+    int v = 0;
+    um.perform(UndoAction::create("A", [&] { v = 0; }, [&] { v = 1; }));
+    um.perform(UndoAction::create("B", [&] { v = 1; }, [&] { v = 2; }));
+    REQUIRE(um.undo_count() == 2);
+}
 
 TEST_CASE("UndoManager perform and undo", "[state][undo]") {
     UndoManager um;


### PR DESCRIPTION
## Summary

Macos plan **Batch A — Foundations**. 7 items from
`planning/2026-05-24-macos-plugin-authoring-plan.md`, bundled per the
plan's PR batching policy to reduce CI cost.

This batch has zero dependencies on the parallel platform-capability-
closure lanes (PR #2815 merged, #2822 OSC draft, #2825 main-thread
draft, queued Native-windows) and lands ahead of any of those.

| Item | What ships |
|---|---|
| 2.7 Denormal snap utility | `core/signal/include/pulp/signal/denormal.hpp` — `snap_to_zero<T>()` scalar + buffer overloads; opt-out via `PULP_DSP_ENABLE_SNAP_TO_ZERO=0`. |
| 2.8 ADSR buffer-apply | `Adsr::apply_to_buffer(mono)` + `Adsr::apply_to_buffer(planar multi-channel)`. |
| 2.10 DC blocker | `core/signal/include/pulp/signal/dc_blocker.hpp` — one-pole HPF wrapper. |
| 2.11 SmoothedValue audit | Header doc updated to cross-reference `LogRampedValue` for the multiplicative case (both classes already shipped — audit confirms no new code needed). |
| 1.4 HighResolutionTimer OS-queue | `TimerMode::OsTimerQueue` backed by `dispatch_source_create` on Apple; falls back to the existing dedicated-thread path off-Apple. New `active_mode()` accessor. |
| 6.9 NormalisableRange | `core/state::NormalisableRange<T>` with `skew`, `symmetric_skew`, `interval` quantization, `with_centre(min, max, centre)` factory. Lives next to existing `ParamRange`. |
| 6.10 Time-window UndoManager coalescing | `set_coalesce_window(ms)` on both `EditHistory` and `UndoManager`; rapid same-target actions merge into one undo step. Default 0 (preserves existing behavior). |

## Test plan

5 new test binaries + extensions to two existing ones. All green locally:

- [x] `pulp-test-dc-blocker` — 4 assertions / 3 cases
- [x] `pulp-test-denormal` — 25 assertions / 6 cases
- [x] `pulp-test-normalisable-range` — 23 assertions / 6 cases (linear, clamp, skew direction, with_centre 1 kHz placement, step quantize, symmetric mirror)
- [x] `pulp-test-adsr` — 390 assertions / 4 cases (stage progression, mono/planar buffer apply, retrigger)
- [x] `pulp-test-high-resolution-timer` — 12 assertions / 5 cases (DedicatedThread + Apple-only OsTimerQueue + destructor cleanup + non-Apple fallback + stop idempotency)
- [x] `pulp-test-edit-history` — extended with 3 time-window cases; full suite 78 assertions / 16 cases
- [x] `pulp-test-undo-manager` — extended with 3 time-window cases; full suite 173 assertions / 29 cases

Broader sanity on touched modules (no regressions):
- [x] `pulp-test-state` — 1505 / 78
- [x] `pulp-test-state-tree` — 388 / 83
- [x] `pulp-test-plugin-state-io` — 159 / 14
- [x] `pulp-test-runtime` — 261 / 39
- [x] `pulp-test-runtime-utils` — 708 / 152
- [x] `pulp-test-signal` — 751 / 87
- [x] `pulp-test-signal-filters` — 964 / 17

5441 assertions across all builds, zero failures.

## Notes

- Per Pulp-native naming policy (no mirroring of reference framework class
  shapes): `NormalisableRange<T>` is a clean-room implementation reached
  from the public NormalisableRange concept; `DcBlocker` is a one-pole
  HPF wrapper (no algorithm transcription); `snap_to_zero` is a Pulp-named
  utility.
- `TimerMode::OsTimerQueue` on macOS/iOS uses `dispatch_source_create` with
  `QOS_CLASS_USER_INTERACTIVE` + `leeway=0`. Off-Apple platforms fall back
  to the existing dedicated-thread path so the contract holds.
- Version bumped to 0.209.0 (minor; new feature surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)