### PR TITLE
feat(macos-plan): Batch P — HostQuirks scaffolding + HostVersion detection + Reference-Lineage trailer doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -636,6 +636,21 @@ Shipyard is pinned in `tools/shipyard.toml` and auto-discovers Pulp's `tools/scr
 | Skill update   | `Skill-Update: skip skill=<name> reason="..."`                  |
 | Auto-release   | `Release: skip reason="..."`                                     |
 
+**Reference-Lineage trailer** (required on any commit touching
+`core/format/host_quirks.cpp` or `core/format/include/pulp/format/host_quirks/`):
+
+| Trailer                                                                                  |
+|------------------------------------------------------------------------------------------|
+| `Reference-Lineage: cleanroom reproducer=#<issue> docs=<url>`                           |
+
+DAW-quirk fixes must be reached independently from host vendor docs + a
+reproducer Pulp issue — never by transcribing the reference framework's
+workaround. The trailer is the audit trail that proves the
+implementation is clean-room. See
+`planning/2026-05-24-daw-host-quirks-inheritance.md` for the
+license-hygiene contract and the catalog of accommodations the
+HostQuirks struct dispatches.
+
 Codex picks this policy up via the existing `AGENTS.md → CLAUDE.md` pointer; `AGENTS.md` intentionally stays a thin redirect so the two never drift. Full design: [docs/guides/versioning.md](docs/guides/versioning.md).
 
 ### Release Watchdog

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.209.0
+    VERSION 0.210.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/CMakeLists.txt
+++ b/core/format/CMakeLists.txt
@@ -15,6 +15,10 @@ target_sources(pulp-format PRIVATE
     src/validation_harness.cpp
     src/aax_model.cpp
     src/host_type.cpp
+    src/host_version.cpp
+    $<$<PLATFORM_ID:Darwin>:src/host_version_mac.mm>
+    $<$<PLATFORM_ID:Windows>:src/host_version_win.cpp>
+    src/host_quirks.cpp
     src/ara.cpp
     src/ara_factory.cpp
     src/ios_audio_session.cpp

--- a/core/format/include/pulp/format/host_quirks.hpp
+++ b/core/format/include/pulp/format/host_quirks.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+/// @file host_quirks.hpp
+/// Per-host accommodation flags consumed by format adapters.
+///
+/// Pulp's format adapters (VST3, AU v2, AU v3, CLAP, AAX) consult a
+/// `HostQuirks` struct at init time to switch between defensive defaults
+/// (always-on) and host-gated behaviors (only when a specific DAW /
+/// version is detected). The full catalog of accommodations lives in
+/// `planning/2026-05-24-daw-host-quirks-inheritance.md`.
+///
+/// Reviewer decision (2026-05-25): cheap defenses are always-on, expensive
+/// defenses are host-gated. Always-on defaults are seeded by the
+/// default-constructed `HostQuirks`; host-gated flags are turned on by
+/// the per-host factory headers under `host_quirks/<host>.hpp`.
+///
+/// **License-hygiene contract**: every fix that flips a host-gated flag
+/// must cite a host vendor doc + a reproducer Pulp issue. The commit
+/// trailer `Reference-Lineage: cleanroom reproducer=#NNNN docs=<url>`
+/// is required (advisory pre-push warning hint will catch missing
+/// trailers on commits touching `core/format/host_quirks/`).
+
+#include <pulp/format/host_type.hpp>
+#include <pulp/format/host_version.hpp>
+
+namespace pulp::format {
+
+/// Always-on / host-gated defensive behaviors that the adapters consult.
+///
+/// Cheap defenses (default-true) apply to every host — they cover spec
+/// compliance and obvious safety nets. Expensive defenses (default-false)
+/// only fire when a specific host is detected; the per-host module
+/// factories under `host_quirks/<host>.hpp` populate the relevant flags.
+struct HostQuirks {
+    // ── Cheap defenses (always-on by default; rows 23–28 of the
+    //    DAW-quirks catalog cross-format defaults) ──
+    /// Synthesize a bypass parameter when the plugin doesn't declare one.
+    bool synthesize_bypass_parameter = true;
+    /// Clamp `Processor::latency_samples()` to non-negative when
+    /// reporting to the host (VST3 requires unsigned).
+    bool clamp_latency_to_nonneg = true;
+    /// When a host-requested bus arrangement isn't supported, accept it
+    /// and emit silence on the extra channels rather than failing.
+    bool silence_unsupported_bus_arrangements = true;
+
+    // ── Host-gated cheap-ish (default off, single host) ──
+
+    // Cubase 10
+    bool cubase10_async_view_resize_queue = false;     ///< row 1
+    bool cubase10_param_gesture_ordering = false;      ///< row 2
+    bool cubase10_fractional_scale_correction = false; ///< row 3
+
+    // Cubase 9
+    bool cubase9_state_blob_size_validation = false;   ///< row 4
+
+    // Ableton Live
+    bool live_vst3_canresize_ignore = false;           ///< row 5
+    bool live_vst3_windows_dpi_defer = false;          ///< row 6 (Windows-only)
+
+    // Bitwig
+    bool bitwig_vst3_linux_repaint_after_resize = false; ///< row 8 (Linux-only)
+    bool bitwig_vst3_setbusarrangements_while_active = false; ///< row 9
+
+    // Wavelab
+    bool wavelab_vst3_defer_activation = false;        ///< row 10
+    bool wavelab_state_blob_fallback = false;          ///< row 11
+
+    // FL Studio
+    bool fl_studio_setactive_process_mutex = false;    ///< row 13
+    bool fl_studio_state_reader_skip = false;          ///< row 14
+
+    // Reaper (rows 15 + R1–R7)
+    bool reaper_vst3_gesture_ordering = false;         ///< row 15
+    bool reaper_process_while_bypassed = false;        ///< row R1
+    bool reaper_keyboard_passthrough = false;          ///< row R2
+    bool reaper_permissive_bus_arrangements = false;   ///< row R3
+    bool reaper_anticipative_fx_buffer_variability = false; ///< row R4
+    bool reaper_midsession_setstate = false;           ///< row R6
+
+    // Pro Tools (AAX, opt-in)
+    bool pro_tools_aax_sidechain_negotiation = false;  ///< row 16
+    bool pro_tools_aax_latency_callback_push = false;  ///< row 17
+    bool pro_tools_aax_mono_second_bus = false;        ///< row 18
+
+    // Logic Pro AU
+    int logic_au_channel_probe_cap = 64;               ///< row 19 (Logic = 8)
+    bool logic_au_tail_time_conversion = false;        ///< row 20
+
+    // AU v3 cross-host
+    bool au_v3_bypass_dual_tracking = false;           ///< row 21
+    bool au_v3_host_id_from_wrapper = false;           ///< row 22
+};
+
+/// Build a `HostQuirks` populated for the given host + version.
+///
+/// Default-constructed `HostQuirks` already turns on the cheap
+/// always-on defenses. This factory layers the host-gated flags on top
+/// based on the detected host (and version where the quirk is
+/// version-keyed).
+HostQuirks make_quirks_for(HostType type, HostVersion version);
+
+/// Convenience: detect host + version, return the corresponding quirks.
+HostQuirks detect_quirks();
+
+}  // namespace pulp::format

--- a/core/format/include/pulp/format/host_version.hpp
+++ b/core/format/include/pulp/format/host_version.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+/// @file host_version.hpp
+/// Host major/minor/patch version detection on top of `HostType`.
+///
+/// Some DAW accommodations are version-keyed (Cubase 9 state-blob size
+/// quirk differs from Cubase 10 async-resize quirk). `HostVersion`
+/// captures the host's reported version string in a comparable form so
+/// `host_quirks::make_quirks_for(HostType, HostVersion)` can branch.
+
+#include <pulp/format/host_type.hpp>
+
+#include <optional>
+#include <string_view>
+
+namespace pulp::format {
+
+/// Semver-ish host version.
+///
+/// Pulp doesn't try to parse every DAW's idiosyncratic version string —
+/// just enough to distinguish major/minor releases for quirk dispatch.
+/// `patch` is best-effort; missing components default to 0.
+struct HostVersion {
+    int major = 0;
+    int minor = 0;
+    int patch = 0;
+
+    constexpr HostVersion() = default;
+    constexpr HostVersion(int maj, int min = 0, int pat = 0)
+        : major(maj), minor(min), patch(pat) {}
+
+    /// True when this version is >= the comparison target.
+    constexpr bool is_at_least(int maj, int min = 0, int pat = 0) const {
+        if (major != maj) return major > maj;
+        if (minor != min) return minor > min;
+        return patch >= pat;
+    }
+
+    /// True when this version is strictly less than the comparison target.
+    constexpr bool is_before(int maj, int min = 0, int pat = 0) const {
+        return !is_at_least(maj, min, pat);
+    }
+
+    /// Returns true if all components are zero (unknown / undetected).
+    constexpr bool is_unknown() const {
+        return major == 0 && minor == 0 && patch == 0;
+    }
+};
+
+/// Best-effort parse of a version string like "10.0.50", "12.0", or
+/// "Pro Tools 2024.6". Returns `std::nullopt` if no leading numeric
+/// component is found.
+std::optional<HostVersion> parse_host_version(std::string_view version_string);
+
+/// Detect the running host's major/minor version, best-effort.
+///
+/// On macOS, attempts to read the host process's `Info.plist`
+/// (`CFBundleShortVersionString`). On Windows / Linux, attempts the
+/// platform's version-resource / `--version` introspection. Returns
+/// an empty (zero-valued) `HostVersion` when detection fails — callers
+/// should treat that as "unknown" and avoid version-gated quirks.
+HostVersion detect_host_version(HostType type);
+
+/// Combined accessor: detect both type and version in one call.
+struct HostInfo {
+    HostType type = HostType::Unknown;
+    HostVersion version;
+};
+
+HostInfo detect_host_info();
+
+}  // namespace pulp::format

--- a/core/format/src/host_quirks.cpp
+++ b/core/format/src/host_quirks.cpp
@@ -1,0 +1,90 @@
+#include <pulp/format/host_quirks.hpp>
+
+#include <pulp/format/host_version.hpp>
+
+namespace pulp::format {
+
+namespace {
+
+// Per-host quirk-population helpers. Each function consumes the current
+// HostQuirks and the detected version, then flips the host-gated flags
+// that apply. License-hygiene: every flag flipped here must be backed
+// by a host vendor doc + a reproducer Pulp issue. See the catalog at
+// `planning/2026-05-24-daw-host-quirks-inheritance.md`.
+//
+// As each per-host accommodation lands (batches J–N), the
+// implementation flips the corresponding flag here and an adapter
+// reads it in its hot path. The factory functions below are
+// intentionally tiny so per-host detail can move into
+// `core/format/include/pulp/format/host_quirks/<host>.hpp` headers
+// later without churn.
+
+void apply_cubase_quirks(HostQuirks& q, HostVersion v) {
+    if (v.is_at_least(10, 0)) {
+        q.cubase10_async_view_resize_queue = true;
+        q.cubase10_param_gesture_ordering = true;
+        q.cubase10_fractional_scale_correction = true;
+    }
+    if (v.is_at_least(9, 0) && v.is_before(10, 0)) {
+        q.cubase9_state_blob_size_validation = true;
+    }
+}
+
+void apply_ableton_live_quirks(HostQuirks& q, HostVersion /*v*/) {
+    q.live_vst3_canresize_ignore = true;
+    q.live_vst3_windows_dpi_defer = true; // No-op on macOS/Linux.
+}
+
+void apply_bitwig_quirks(HostQuirks& q, HostVersion v) {
+    q.bitwig_vst3_linux_repaint_after_resize = true; // No-op off Linux.
+    if (v.is_before(6, 0)) {
+        q.bitwig_vst3_setbusarrangements_while_active = true;
+    }
+}
+
+void apply_reaper_quirks(HostQuirks& q, HostVersion /*v*/) {
+    q.reaper_vst3_gesture_ordering = true;
+    q.reaper_process_while_bypassed = true;
+    q.reaper_keyboard_passthrough = true;
+    q.reaper_permissive_bus_arrangements = true;
+    q.reaper_anticipative_fx_buffer_variability = true;
+    q.reaper_midsession_setstate = true;
+}
+
+void apply_logic_pro_quirks(HostQuirks& q, HostVersion /*v*/) {
+    q.logic_au_channel_probe_cap = 8; // row 19 — Logic hangs above 8.
+    q.logic_au_tail_time_conversion = true;
+}
+
+void apply_pro_tools_quirks(HostQuirks& q, HostVersion /*v*/) {
+    q.pro_tools_aax_sidechain_negotiation = true;
+    q.pro_tools_aax_latency_callback_push = true;
+    q.pro_tools_aax_mono_second_bus = true;
+}
+
+} // namespace
+
+HostQuirks make_quirks_for(HostType type, HostVersion version) {
+    HostQuirks q; // cheap defenses on by default
+    switch (type) {
+        case HostType::Cubase:
+        case HostType::Nuendo:        apply_cubase_quirks(q, version); break;
+        case HostType::AbletonLive:   apply_ableton_live_quirks(q, version); break;
+        case HostType::Bitwig:        apply_bitwig_quirks(q, version); break;
+        case HostType::Reaper:        apply_reaper_quirks(q, version); break;
+        case HostType::LogicPro:
+        case HostType::GarageBand:    apply_logic_pro_quirks(q, version); break;
+        case HostType::ProTools:      apply_pro_tools_quirks(q, version); break;
+        // Wavelab / FL Studio / StudioOne / DigitalPerformer / etc. land
+        // their flags here when the per-host fixes ship in batches L/N.
+        default: break;
+    }
+    return q;
+}
+
+HostQuirks detect_quirks() {
+    const auto info = detect_host_info();
+    return make_quirks_for(info.type, info.version);
+}
+
+}  // namespace pulp::format

--- a/core/format/src/host_version.cpp
+++ b/core/format/src/host_version.cpp
@@ -1,0 +1,51 @@
+#include <pulp/format/host_version.hpp>
+
+#include <cctype>
+#include <charconv>
+#include <string_view>
+
+namespace pulp::format {
+
+std::optional<HostVersion> parse_host_version(std::string_view s) {
+    // Skip leading non-digit text (e.g., "Pro Tools 2024.6").
+    size_t i = 0;
+    while (i < s.size() && !std::isdigit(static_cast<unsigned char>(s[i]))) ++i;
+    if (i == s.size()) return std::nullopt;
+
+    HostVersion v;
+    int* parts[3] = {&v.major, &v.minor, &v.patch};
+    int part_idx = 0;
+
+    while (i < s.size() && part_idx < 3) {
+        size_t start = i;
+        while (i < s.size() && std::isdigit(static_cast<unsigned char>(s[i]))) ++i;
+        if (start == i) break;
+        int value = 0;
+        auto [ptr, ec] = std::from_chars(s.data() + start, s.data() + i, value);
+        if (ec != std::errc{}) return std::nullopt;
+        *parts[part_idx++] = value;
+        if (i < s.size() && s[i] == '.') ++i; // skip separator
+        else break;
+    }
+    if (part_idx == 0) return std::nullopt;
+    return v;
+}
+
+// Platform-specific version detection lives in
+// `core/format/src/host_version_<platform>.{mm,cpp}`. The cross-platform
+// fallback returns an unknown version — adapters must treat that as
+// "version-gated quirks off".
+#if !defined(__APPLE__) && !defined(_WIN32)
+HostVersion detect_host_version(HostType /*type*/) {
+    return {};
+}
+#endif
+
+HostInfo detect_host_info() {
+    HostInfo info;
+    info.type = detect_host_type();
+    info.version = detect_host_version(info.type);
+    return info;
+}
+
+}  // namespace pulp::format

--- a/core/format/src/host_version_mac.mm
+++ b/core/format/src/host_version_mac.mm
@@ -1,0 +1,28 @@
+// Apple-only `detect_host_version` impl.
+//
+// Reads the host process's main bundle `CFBundleShortVersionString`,
+// parses it via `parse_host_version`, and returns the result. Falls
+// back to an empty `HostVersion` if the bundle isn't readable or has
+// no version string — adapters treat that as "version-gated quirks off".
+
+#include <pulp/format/host_version.hpp>
+
+#import <Foundation/Foundation.h>
+
+namespace pulp::format {
+
+HostVersion detect_host_version(HostType /*type*/) {
+    @autoreleasepool {
+        NSBundle* bundle = [NSBundle mainBundle];
+        if (bundle == nil) return {};
+        id raw = [bundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+        if (![raw isKindOfClass:[NSString class]]) return {};
+        NSString* version = (NSString*) raw;
+        const char* utf8 = [version UTF8String];
+        if (utf8 == nullptr) return {};
+        const auto parsed = parse_host_version(std::string_view(utf8));
+        return parsed.value_or(HostVersion{});
+    }
+}
+
+}  // namespace pulp::format

--- a/core/format/src/host_version_win.cpp
+++ b/core/format/src/host_version_win.cpp
@@ -1,0 +1,50 @@
+// Windows-only `detect_host_version` impl.
+//
+// Reads the host executable's VS_FIXEDFILEINFO via GetFileVersionInfoW
+// and converts the packed dwFileVersionMS/LS into a `HostVersion`.
+// Returns an empty `HostVersion` if the version resource is unavailable
+// — adapters treat that as "version-gated quirks off".
+
+#ifdef _WIN32
+
+#include <pulp/format/host_version.hpp>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#pragma comment(lib, "version.lib")
+
+#include <vector>
+
+namespace pulp::format {
+
+HostVersion detect_host_version(HostType /*type*/) {
+    wchar_t path[MAX_PATH] = {};
+    DWORD path_len = GetModuleFileNameW(nullptr, path, MAX_PATH);
+    if (path_len == 0 || path_len >= MAX_PATH) return {};
+
+    DWORD handle = 0;
+    DWORD size = GetFileVersionInfoSizeW(path, &handle);
+    if (size == 0) return {};
+
+    std::vector<unsigned char> buffer(size);
+    if (!GetFileVersionInfoW(path, handle, size, buffer.data())) return {};
+
+    VS_FIXEDFILEINFO* info = nullptr;
+    UINT info_len = 0;
+    if (!VerQueryValueW(buffer.data(), L"\\",
+                        reinterpret_cast<LPVOID*>(&info), &info_len)) {
+        return {};
+    }
+    if (info == nullptr) return {};
+
+    HostVersion v;
+    v.major = static_cast<int>(HIWORD(info->dwFileVersionMS));
+    v.minor = static_cast<int>(LOWORD(info->dwFileVersionMS));
+    v.patch = static_cast<int>(HIWORD(info->dwFileVersionLS));
+    return v;
+}
+
+}  // namespace pulp::format
+
+#endif // _WIN32

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2138,6 +2138,10 @@ pulp_add_test_suite(pulp-test-sprite-strip LIBRARIES pulp::view)
 # Edit history (global undo) tests
 pulp_add_test_suite(pulp-test-edit-history LIBRARIES pulp::state)
 
+# macOS plan Batch P — HostQuirks scaffolding + HostVersion detection
+pulp_add_test_suite(pulp-test-host-version LIBRARIES pulp::format)
+pulp_add_test_suite(pulp-test-host-quirks LIBRARIES pulp::format)
+
 # macOS plan Batch A — Foundations
 pulp_add_test_suite(pulp-test-dc-blocker LIBRARIES pulp::signal)
 pulp_add_test_suite(pulp-test-denormal LIBRARIES pulp::signal)

--- a/test/test_host_quirks.cpp
+++ b/test/test_host_quirks.cpp
@@ -1,0 +1,94 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/format/host_quirks.hpp>
+
+using namespace pulp::format;
+
+TEST_CASE("HostQuirks default-construct enables cheap defenses",
+          "[format][host-quirks]") {
+    HostQuirks q;
+    REQUIRE(q.synthesize_bypass_parameter == true);
+    REQUIRE(q.clamp_latency_to_nonneg == true);
+    REQUIRE(q.silence_unsupported_bus_arrangements == true);
+    // Expensive defenses default off.
+    REQUIRE(q.fl_studio_setactive_process_mutex == false);
+    REQUIRE(q.cubase10_async_view_resize_queue == false);
+    REQUIRE(q.reaper_process_while_bypassed == false);
+    REQUIRE(q.logic_au_channel_probe_cap == 64);
+}
+
+TEST_CASE("make_quirks_for unknown host returns cheap-defense defaults",
+          "[format][host-quirks]") {
+    auto q = make_quirks_for(HostType::Unknown, {});
+    REQUIRE(q.synthesize_bypass_parameter == true);
+    REQUIRE(q.logic_au_channel_probe_cap == 64);
+    REQUIRE(q.cubase10_async_view_resize_queue == false);
+}
+
+TEST_CASE("make_quirks_for Cubase 10 flips Cubase-10 flags",
+          "[format][host-quirks]") {
+    auto q = make_quirks_for(HostType::Cubase, HostVersion{10, 0});
+    REQUIRE(q.cubase10_async_view_resize_queue == true);
+    REQUIRE(q.cubase10_param_gesture_ordering == true);
+    REQUIRE(q.cubase10_fractional_scale_correction == true);
+    // Cubase 9 row should NOT fire on Cubase 10.
+    REQUIRE(q.cubase9_state_blob_size_validation == false);
+}
+
+TEST_CASE("make_quirks_for Cubase 9 fires the 9-only state-blob quirk",
+          "[format][host-quirks]") {
+    auto q = make_quirks_for(HostType::Cubase, HostVersion{9, 5});
+    REQUIRE(q.cubase9_state_blob_size_validation == true);
+    REQUIRE(q.cubase10_async_view_resize_queue == false);
+}
+
+TEST_CASE("make_quirks_for Logic caps channel probe at 8",
+          "[format][host-quirks]") {
+    auto q = make_quirks_for(HostType::LogicPro, HostVersion{11, 0});
+    REQUIRE(q.logic_au_channel_probe_cap == 8);
+    REQUIRE(q.logic_au_tail_time_conversion == true);
+    // GarageBand shares the same Logic quirks.
+    auto gb = make_quirks_for(HostType::GarageBand, HostVersion{});
+    REQUIRE(gb.logic_au_channel_probe_cap == 8);
+}
+
+TEST_CASE("make_quirks_for Reaper flips all 6 Reaper flags",
+          "[format][host-quirks]") {
+    auto q = make_quirks_for(HostType::Reaper, HostVersion{7, 20});
+    REQUIRE(q.reaper_vst3_gesture_ordering == true);
+    REQUIRE(q.reaper_process_while_bypassed == true);
+    REQUIRE(q.reaper_keyboard_passthrough == true);
+    REQUIRE(q.reaper_permissive_bus_arrangements == true);
+    REQUIRE(q.reaper_anticipative_fx_buffer_variability == true);
+    REQUIRE(q.reaper_midsession_setstate == true);
+}
+
+TEST_CASE("make_quirks_for Bitwig < 6 enables setBusArrangements-while-active workaround",
+          "[format][host-quirks]") {
+    auto old = make_quirks_for(HostType::Bitwig, HostVersion{5, 2});
+    REQUIRE(old.bitwig_vst3_setbusarrangements_while_active == true);
+    auto modern = make_quirks_for(HostType::Bitwig, HostVersion{6, 0});
+    REQUIRE(modern.bitwig_vst3_setbusarrangements_while_active == false);
+    // Linux-repaint always-on (no-op off Linux at adapter call site).
+    REQUIRE(old.bitwig_vst3_linux_repaint_after_resize == true);
+}
+
+TEST_CASE("make_quirks_for Pro Tools flips all 3 AAX flags",
+          "[format][host-quirks]") {
+    auto q = make_quirks_for(HostType::ProTools, HostVersion{2024, 6});
+    REQUIRE(q.pro_tools_aax_sidechain_negotiation == true);
+    REQUIRE(q.pro_tools_aax_latency_callback_push == true);
+    REQUIRE(q.pro_tools_aax_mono_second_bus == true);
+}
+
+TEST_CASE("make_quirks_for Ableton Live enables canResize workaround",
+          "[format][host-quirks]") {
+    auto q = make_quirks_for(HostType::AbletonLive, HostVersion{12, 0});
+    REQUIRE(q.live_vst3_canresize_ignore == true);
+    REQUIRE(q.live_vst3_windows_dpi_defer == true);
+}
+
+TEST_CASE("Nuendo treats as Cubase for quirk purposes",
+          "[format][host-quirks]") {
+    auto q = make_quirks_for(HostType::Nuendo, HostVersion{13, 0});
+    REQUIRE(q.cubase10_async_view_resize_queue == true);
+}

--- a/test/test_host_version.cpp
+++ b/test/test_host_version.cpp
@@ -1,0 +1,64 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/format/host_version.hpp>
+
+using namespace pulp::format;
+
+TEST_CASE("HostVersion default is unknown", "[format][host-version]") {
+    HostVersion v;
+    REQUIRE(v.is_unknown());
+    REQUIRE_FALSE(v.is_at_least(1, 0));
+}
+
+TEST_CASE("HostVersion comparison ordering", "[format][host-version]") {
+    HostVersion v{10, 0, 50};
+    REQUIRE(v.is_at_least(10, 0));
+    REQUIRE(v.is_at_least(10, 0, 49));
+    REQUIRE(v.is_at_least(9, 9, 99));
+    REQUIRE_FALSE(v.is_at_least(10, 1));
+    REQUIRE_FALSE(v.is_at_least(11, 0));
+    REQUIRE(v.is_before(10, 0, 51));
+    REQUIRE(v.is_before(11, 0));
+}
+
+TEST_CASE("parse_host_version handles common formats", "[format][host-version]") {
+    auto v = parse_host_version("10.0.50");
+    REQUIRE(v.has_value());
+    REQUIRE(v->major == 10);
+    REQUIRE(v->minor == 0);
+    REQUIRE(v->patch == 50);
+
+    auto v2 = parse_host_version("12.0");
+    REQUIRE(v2.has_value());
+    REQUIRE(v2->major == 12);
+    REQUIRE(v2->minor == 0);
+    REQUIRE(v2->patch == 0);
+
+    // Leading non-digit text (e.g., "Pro Tools 2024.6") should be skipped.
+    auto v3 = parse_host_version("Pro Tools 2024.6");
+    REQUIRE(v3.has_value());
+    REQUIRE(v3->major == 2024);
+    REQUIRE(v3->minor == 6);
+
+    auto v4 = parse_host_version("5");
+    REQUIRE(v4.has_value());
+    REQUIRE(v4->major == 5);
+}
+
+TEST_CASE("parse_host_version returns nullopt on no numeric component",
+          "[format][host-version]") {
+    REQUIRE_FALSE(parse_host_version("no version here").has_value());
+    REQUIRE_FALSE(parse_host_version("").has_value());
+}
+
+TEST_CASE("detect_host_info returns coherent HostType + HostVersion",
+          "[format][host-version]") {
+    HostInfo info = detect_host_info();
+    // We don't know which host is "running" in the test environment, so we
+    // only assert the shape: type is a valid enum value and version is
+    // either unknown or has sensible non-negative components.
+    REQUIRE((info.type == HostType::Unknown || info.type == HostType::Other
+             || info.type == HostType::Standalone || true));
+    REQUIRE(info.version.major >= 0);
+    REQUIRE(info.version.minor >= 0);
+    REQUIRE(info.version.patch >= 0);
+}


### PR DESCRIPTION
## Summary

macOS plan **Batch P — HostQuirks scaffolding** (in-scope subset).
3 items from `planning/2026-05-24-macos-plugin-authoring-plan.md`,
batched per the plan's PR batching policy to reduce CI cost.

This batch unblocks the format-adapter batches (J–N) by giving each
adapter a `HostQuirks` struct to consult instead of re-inventing the
per-host dispatch. Cheap defenses (synthesize bypass param, clamp
latency, silence unsupported bus arrangements) are always-on; expensive
ones (FL Studio mutex, Cubase 10 async resize, Logic AU channel cap,
Reaper-specific quirks, etc.) are host-gated and turn on only when the
detected host + version says they should.

| Item | What ships |
|---|---|
| 3.9 HostType host-version detection | `core/format::HostVersion` struct (major/minor/patch + `is_at_least` / `is_before` / `is_unknown`); `parse_host_version()`; per-platform `detect_host_version()` (macOS via `CFBundleShortVersionString`; Windows via `VS_FIXEDFILEINFO`; Linux returns unknown). `HostInfo` + `detect_host_info()` for one-shot type + version. |
| 5.1 HostQuirks struct + scaffolding | `core/format::HostQuirks` with ~25 boolean flags grouped by host (Cubase 9/10, Live, Bitwig, Wavelab, FL Studio, Reaper, Pro Tools, Logic Pro, AU v3 cross-host) + always-on defenses; `make_quirks_for(HostType, HostVersion)` factory; `detect_quirks()` convenience. Per-host headers under `core/format/include/pulp/format/host_quirks/<host>.hpp` will land as J–N implementations need them. |
| 5.13 Reference-Lineage trailer | New section in `CLAUDE.md` documenting the required `Reference-Lineage: cleanroom reproducer=#NNNN docs=<url>` commit trailer for every change under `core/format/host_quirks*`. License-hygiene audit trail per the DAW-quirks doc. |
| 5.14 host-quirks-log.md | Initialized in the planning submodule (separate commit). |

**Deferred to a follow-up PR** (Batch P2):
- **3.12 Bundle identity** — `.pulp/identity.lock` schema + `pulp build --check-identity` flag + `pulp identity record` subcommand. Substantial work; clean split.
- **5.13 advisory pre-push hint** — `.githooks/pre-push` warning when commits touch `core/format/host_quirks/` without the trailer. The CLAUDE.md doc is enough to start; the hook can ride with 3.12 when we touch `tools/cli/cmd_build.cpp`.

## Test plan

Two new test binaries, all green locally:

- [x] `pulp-test-host-version` — 28 assertions / 5 cases (default-unknown, comparison ordering across major/minor/patch, parse common formats incl. leading-text "Pro Tools 2024.6", nullopt on non-numeric, `detect_host_info` shape)
- [x] `pulp-test-host-quirks` — 34 assertions / 10 cases (default cheap-defense-on; Unknown host = cheap-defaults only; Cubase 10 fires all 3 Cubase-10 flags but **not** the Cubase 9 one; Cubase 9 fires the 9-only flag; Logic caps channel probe at 8 and shares with GarageBand; Reaper fires all 6 flags; Bitwig < 6 enables the spec-violation workaround, modern Bitwig does not; Pro Tools fires all 3 AAX flags; Live enables canResize workaround; Nuendo treats as Cubase)

Library link sanity: `pulp-format` rebuilds clean.

## Notes

- Per Pulp-native naming: `HostQuirks` / `HostVersion` / `HostInfo` / `make_quirks_for` are clean-room names reached from the public concepts — no reference-framework class shape mirrored.
- macOS / Windows version detection is platform-specific via separate `host_version_mac.mm` / `host_version_win.cpp` translation units; Linux falls back to the cross-platform stub that returns unknown.
- `Nuendo` is treated as `Cubase` for quirk-dispatch purposes since Steinberg ships them on the same VST3 host code.
- Version bumped to 0.210.0 (minor; new feature surface).
- Companion planning-submodule commit initializes `planning/host-quirks-log.md` (item 5.14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)