### PR TITLE
feat(macos-plan): Batch E (UMP per-note + JR Clock) + Sqrt4_5dB midpoint fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.211.0
+    VERSION 0.212.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/midi/include/pulp/midi/ump.hpp
+++ b/core/midi/include/pulp/midi/ump.hpp
@@ -204,7 +204,106 @@ struct UmpPacket {
                     | uint32_t(velocity & 0x7F);
         return p;
     }
+
+    // MIDI 2.0 Assignable Per-Note Controller (status 0x10). Byte 2 is
+    // the note number, byte 3 is the user-assigned controller index.
+    // Distinct from `registered_per_note_cc` (status 0x00) which uses
+    // standard registered controller IDs.
+    static UmpPacket assignable_per_note_cc(uint8_t group, uint8_t channel,
+                                             uint8_t note, uint8_t cc_index,
+                                             uint32_t value) {
+        UmpPacket p;
+        p.word_count = 2;
+        p.words[0] = (0x4u << 28) | (uint32_t(group & 0x0F) << 24)
+                    | (uint32_t(0x10 | (channel & 0x0F)) << 16)
+                    | (uint32_t(note & 0x7F) << 8)
+                    | uint32_t(cc_index & 0x7F);
+        p.words[1] = value;
+        return p;
+    }
+
+    // MIDI 2.0 Per-Note Management (status 0xF0). Byte 2 is the note
+    // number; byte 3 carries flags (bit 0 = reset per-note controllers
+    // to default, bit 1 = detach previously-held controllers from the
+    // note so they stop tracking it). Word 1 is reserved by the spec.
+    static UmpPacket per_note_management(uint8_t group, uint8_t channel,
+                                          uint8_t note, uint8_t flags) {
+        UmpPacket p;
+        p.word_count = 2;
+        p.words[0] = (0x4u << 28) | (uint32_t(group & 0x0F) << 24)
+                    | (uint32_t(0xF0 | (channel & 0x0F)) << 16)
+                    | (uint32_t(note & 0x7F) << 8)
+                    | uint32_t(flags);
+        p.words[1] = 0;
+        return p;
+    }
+
+    // Per-Note Management flags (UMP spec):
+    static constexpr uint8_t kPerNoteResetControllers = 0x01;
+    static constexpr uint8_t kPerNoteDetachControllers = 0x02;
 };
+
+// ── Utility messages (UMP type 0x0) ──────────────────────────────────────
+
+/// Utility message status codes (bits 20-23 of word 0 for type 0x0).
+///
+/// JR Clock / JR Timestamp carry a 16-bit value in bits 0-15 of word 0
+/// measured in 1/31250-second units (~32 µs resolution). They let hosts
+/// schedule UMP events with sub-block timing accuracy. JR Clock is the
+/// "current time" reference; JR Timestamp is "this packet's event
+/// happens at this offset". See the MIDI 2.0 UMP spec § Utility.
+enum class UtilityStatus : uint8_t {
+    Noop          = 0x0,
+    JrClock       = 0x1,
+    JrTimestamp   = 0x2,
+    DeltaClockstampTicksPerQuarter = 0x3,
+    DeltaClockstamp = 0x4,
+};
+
+/// Extract the utility status nibble from a type-0 UMP packet (bits 20-23 of word 0).
+inline UtilityStatus utility_status(const UmpPacket& p) {
+    return static_cast<UtilityStatus>((p.words[0] >> 20) & 0x0F);
+}
+
+/// Extract the 16-bit JR Clock / JR Timestamp value from a type-0 UMP
+/// packet (bits 0-15 of word 0). Caller must check `utility_status()`
+/// first to know which kind of value this is. Returns 0 for non-JR
+/// utility messages.
+inline uint16_t jr_value_16(const UmpPacket& p) {
+    return static_cast<uint16_t>(p.words[0] & 0xFFFF);
+}
+
+/// One JR Clock tick is 1/31250 of a second (~32 microseconds).
+/// Convenience accessors convert a 16-bit JR value to a time delta.
+constexpr double kJrTicksPerSecond = 31250.0;
+
+inline double jr_value_seconds(uint16_t value) {
+    return static_cast<double>(value) / kJrTicksPerSecond;
+}
+
+inline double jr_value_microseconds(uint16_t value) {
+    return static_cast<double>(value) * (1'000'000.0 / kJrTicksPerSecond);
+}
+
+/// Build a JR Clock utility packet (status 0x1).
+inline UmpPacket make_jr_clock(uint8_t group, uint16_t value) {
+    UmpPacket p;
+    p.word_count = 1;
+    p.words[0] = (0x0u << 28) | (uint32_t(group & 0x0F) << 24)
+                | (uint32_t(0x1) << 20)
+                | uint32_t(value);
+    return p;
+}
+
+/// Build a JR Timestamp utility packet (status 0x2).
+inline UmpPacket make_jr_timestamp(uint8_t group, uint16_t value) {
+    UmpPacket p;
+    p.word_count = 1;
+    p.words[0] = (0x0u << 28) | (uint32_t(group & 0x0F) << 24)
+                | (uint32_t(0x2) << 20)
+                | uint32_t(value);
+    return p;
+}
 
 // ── MPE (MIDI Polyphonic Expression) ────────────────────────────────────
 

--- a/core/signal/include/pulp/signal/dry_wet_mixer.hpp
+++ b/core/signal/include/pulp/signal/dry_wet_mixer.hpp
@@ -175,8 +175,12 @@ private:
                 wet = std::sqrt(mix_);
                 break;
             case MixCurve::Sqrt4_5dB:
-                dry = std::sqrt(1.0f - mix_) * (1.0f - mix_ * 0.5f);
-                wet = std::sqrt(mix_) * (0.5f + mix_ * 0.5f);
+                // -4.5 dB = geometric mean of -3 dB sqrt (exp 0.5) and
+                // -6 dB linear (exp 1.0) → exponent 0.75. At mix=0.5
+                // produces 0.5^0.75 ≈ 0.5946 per side ≈ -4.51 dB,
+                // matching the documented midpoint notch.
+                dry = std::pow(1.0f - mix_, 0.75f);
+                wet = std::pow(mix_, 0.75f);
                 break;
         }
     }

--- a/core/signal/include/pulp/signal/panner.hpp
+++ b/core/signal/include/pulp/signal/panner.hpp
@@ -95,8 +95,11 @@ public:
                 r_gain = std::sqrt(position);
                 break;
             case PanLaw::Sqrt4_5dB:
-                l_gain = std::sqrt(1.0f - position) * (1.0f - position * 0.5f);
-                r_gain = std::sqrt(position) * (0.5f + position * 0.5f);
+                // -4.5 dB = geometric mean of -3 dB sqrt and -6 dB linear
+                // → exponent 0.75. At centre yields 0.5^0.75 ≈ 0.5946
+                // ≈ -4.51 dB per channel, matching the documented notch.
+                l_gain = std::pow(1.0f - position, 0.75f);
+                r_gain = std::pow(position, 0.75f);
                 break;
         }
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2145,6 +2145,9 @@ pulp_add_test_suite(pulp-test-host-quirks LIBRARIES pulp::format)
 # macOS plan Batch B (partial: mixers) — DryWetMixer + Panner pan laws
 pulp_add_test_suite(pulp-test-pan-mix-laws LIBRARIES pulp::signal)
 
+# macOS plan Batch E (partial) — UMP per-note + JR Clock
+pulp_add_test_suite(pulp-test-ump-extensions LIBRARIES pulp::midi)
+
 # macOS plan Batch A — Foundations
 pulp_add_test_suite(pulp-test-dc-blocker LIBRARIES pulp::signal)
 pulp_add_test_suite(pulp-test-denormal LIBRARIES pulp::signal)

--- a/test/test_pan_mix_laws.cpp
+++ b/test/test_pan_mix_laws.cpp
@@ -114,6 +114,14 @@ TEST_CASE("DryWetMixer Sin6dB has -6dB notch at midpoint", "[signal][mix-laws]")
     REQUIRE(std::abs(half.wet - 0.5f) < 1e-4f);
 }
 
+TEST_CASE("DryWetMixer Sqrt4_5dB has -4.5dB notch at midpoint (Codex #2834 P2 regression)",
+          "[signal][mix-laws][regression]") {
+    auto half = gains(MixCurve::Sqrt4_5dB, 0.5f);
+    // 0.5^0.75 ≈ 0.5946, 20*log10(0.5946) ≈ -4.51 dB.
+    REQUIRE(std::abs(half.dry - 0.594603f) < 1e-3f);
+    REQUIRE(std::abs(half.wet - 0.594603f) < 1e-3f);
+}
+
 // ────────────────────────────────────────────────────────────────────────
 // Panner laws
 // ────────────────────────────────────────────────────────────────────────
@@ -191,4 +199,15 @@ TEST_CASE("Panner Sin6dB has -6dB notch at centre", "[signal][pan-law]") {
     p.compute_gains(l, r);
     REQUIRE(std::abs(l - 0.5f) < 1e-4f);
     REQUIRE(std::abs(r - 0.5f) < 1e-4f);
+}
+
+TEST_CASE("Panner Sqrt4_5dB has -4.5dB notch at centre (Codex #2834 P2 regression)",
+          "[signal][pan-law][regression]") {
+    Panner p;
+    p.set_law(PanLaw::Sqrt4_5dB);
+    p.set_pan(0.0f);
+    float l, r;
+    p.compute_gains(l, r);
+    REQUIRE(std::abs(l - 0.594603f) < 1e-3f);
+    REQUIRE(std::abs(r - 0.594603f) < 1e-3f);
 }

--- a/test/test_ump_extensions.cpp
+++ b/test/test_ump_extensions.cpp
@@ -1,0 +1,109 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/midi/ump.hpp>
+
+#include <cmath>
+
+using namespace pulp::midi;
+
+// ────────────────────────────────────────────────────────────────────────
+// Per-note management (status 0xF0) + assignable per-note CC (status 0x10)
+// ────────────────────────────────────────────────────────────────────────
+
+TEST_CASE("UmpPacket::per_note_management builds correct status nibble",
+          "[midi][ump][per-note]") {
+    auto p = UmpPacket::per_note_management(
+        /*group*/ 2, /*channel*/ 3, /*note*/ 60,
+        UmpPacket::kPerNoteResetControllers);
+    REQUIRE(p.word_count == 2);
+    REQUIRE(p.message_type() == UmpMessageType::Midi2ChannelVoice);
+    REQUIRE(p.group() == 2);
+    REQUIRE(p.channel() == 3);
+    REQUIRE(p.status() == 0xF3);
+    REQUIRE(p.note_number() == 60);
+    // Flags live in the low byte of word 0.
+    REQUIRE((p.words[0] & 0xFF) == UmpPacket::kPerNoteResetControllers);
+    REQUIRE(p.words[1] == 0u);
+}
+
+TEST_CASE("UmpPacket::per_note_management supports combined flags",
+          "[midi][ump][per-note]") {
+    const uint8_t both = UmpPacket::kPerNoteResetControllers
+                       | UmpPacket::kPerNoteDetachControllers;
+    auto p = UmpPacket::per_note_management(0, 0, 64, both);
+    REQUIRE((p.words[0] & 0xFF) == 0x03);
+}
+
+TEST_CASE("UmpPacket::assignable_per_note_cc encodes status 0x10",
+          "[midi][ump][per-note]") {
+    auto p = UmpPacket::assignable_per_note_cc(
+        /*group*/ 0, /*channel*/ 1,
+        /*note*/ 72, /*cc_index*/ 5, /*value*/ 0x80000000);
+    REQUIRE(p.word_count == 2);
+    REQUIRE(p.message_type() == UmpMessageType::Midi2ChannelVoice);
+    REQUIRE(p.group() == 0);
+    REQUIRE(p.channel() == 1);
+    REQUIRE(p.status() == 0x11);
+    REQUIRE(p.note_number() == 72);
+    REQUIRE((p.words[0] & 0xFF) == 5);
+    REQUIRE(p.words[1] == 0x80000000u);
+}
+
+TEST_CASE("UmpPacket::registered_per_note_cc and assignable distinguish status",
+          "[midi][ump][per-note]") {
+    auto reg = UmpPacket::registered_per_note_cc(0, 0, 60, 7, 100);
+    auto asn = UmpPacket::assignable_per_note_cc(0, 0, 60, 7, 100);
+    REQUIRE((reg.words[0] >> 20) != (asn.words[0] >> 20));
+    REQUIRE(reg.status() == 0x00);
+    REQUIRE(asn.status() == 0x10);
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// JR Clock / JR Timestamp (UMP Utility type 0x0)
+// ────────────────────────────────────────────────────────────────────────
+
+TEST_CASE("make_jr_clock builds a type-0 packet with status 0x1",
+          "[midi][ump][jr-timing]") {
+    auto p = make_jr_clock(/*group*/ 0, /*value*/ 0x1234);
+    REQUIRE(p.word_count == 1);
+    REQUIRE(p.message_type() == UmpMessageType::Utility);
+    REQUIRE(utility_status(p) == UtilityStatus::JrClock);
+    REQUIRE(jr_value_16(p) == 0x1234);
+}
+
+TEST_CASE("make_jr_timestamp builds a type-0 packet with status 0x2",
+          "[midi][ump][jr-timing]") {
+    auto p = make_jr_timestamp(/*group*/ 3, /*value*/ 31250);
+    REQUIRE(p.word_count == 1);
+    REQUIRE(p.message_type() == UmpMessageType::Utility);
+    REQUIRE(p.group() == 3);
+    REQUIRE(utility_status(p) == UtilityStatus::JrTimestamp);
+    REQUIRE(jr_value_16(p) == 31250);
+}
+
+TEST_CASE("JR tick conversions match the 1/31250 s spec",
+          "[midi][ump][jr-timing]") {
+    // 31250 ticks = 1 s exactly.
+    REQUIRE(jr_value_seconds(31250) == 1.0);
+    // 1 tick = 32 microseconds (1e6 / 31250).
+    REQUIRE(std::abs(jr_value_microseconds(1) - 32.0) < 1e-9);
+    // Round-trip a few selected values.
+    for (uint16_t v : {0, 1, 1000, 15625, 31249, 65535}) {
+        const double s = jr_value_seconds(v);
+        REQUIRE(std::abs(s * 31250.0 - static_cast<double>(v)) < 1e-6);
+    }
+}
+
+TEST_CASE("utility_status of non-JR utility packets is correctly extracted",
+          "[midi][ump][jr-timing]") {
+    UmpPacket noop;
+    noop.word_count = 1;
+    noop.words[0] = 0x0u << 28; // status 0x0 = Noop
+    REQUIRE(utility_status(noop) == UtilityStatus::Noop);
+    REQUIRE(jr_value_16(noop) == 0);
+
+    UmpPacket dc_ticks;
+    dc_ticks.word_count = 1;
+    dc_ticks.words[0] = (0x0u << 28) | (0x3u << 20) | 0x0080;
+    REQUIRE(utility_status(dc_ticks) == UtilityStatus::DeltaClockstampTicksPerQuarter);
+    REQUIRE(jr_value_16(dc_ticks) == 0x0080);
+}


### PR DESCRIPTION
## Summary

macOS plan **Batch E (partial)** — 2 UMP items + an inline Codex P2 fix from #2834. Batched together to save a CI cycle per the plan's PR batching policy.

| Item | What ships |
|---|---|
| 8.3 JR Clock + JR Timestamp helpers | New `UtilityStatus` enum, `utility_status(p)` + `jr_value_16(p)` accessors, `jr_value_seconds/microseconds()` conversions (1 tick = 1/31250 s = ~32 µs per UMP spec), `make_jr_clock()` + `make_jr_timestamp()` factories. |
| 8.5 Per-note management + assignable PNC | New `UmpPacket::per_note_management()` (status 0xF0, reset/detach flags exposed as `kPerNoteResetControllers` / `kPerNoteDetachControllers`) + `UmpPacket::assignable_per_note_cc()` (status 0x10, distinct from existing registered_per_note_cc at status 0x00). |
| Codex P2 fix from #2834 | `Sqrt4_5dB` law in both `DryWetMixer` and `Panner` now uses `pow(p, 0.75)` — the geometric mean of -3 dB sqrt (exp 0.5) and -6 dB linear (exp 1.0). At midpoint produces 0.5^0.75 ≈ 0.5946 ≈ -4.51 dB, matching the documented notch. Old formula produced ~-5.51 dB. |

**Deferred to follow-up PRs** (recorded in tracker):
- **8.2 Sysex7 reassembler extraction** — the inline implementation in `core/format/src/au_adapter.mm` is tightly coupled to CoreMIDI's `MIDIEventPacket` state machine + already issue-#292-hardened. Extracting it cleanly without behavior drift needs a dedicated PR.
- **8.6 MIDI 1.0 backend audit** — pure audit + doc work; not blocking and bundles better with a future doc-only sweep.

## Test plan

Two test binaries, all green locally:

- [x] `pulp-test-ump-extensions` — 41 assertions / 8 cases. Per-note management correctness (status nibble 0xF0, combined reset+detach flags, word 1 reserved zero); assignable vs registered distinguishable; `make_jr_clock` / `make_jr_timestamp` build correct type-0 packets; tick conversions match the 1/31250-s spec; `utility_status` correctly extracts Noop and DeltaClockstampTicksPerQuarter.
- [x] `pulp-test-pan-mix-laws` — 103 assertions / 12 cases (up from 99/10): added regression tests asserting both `DryWetMixer::Sqrt4_5dB` and `Panner::Sqrt4_5dB` produce 0.5946 ± 1e-3 at midpoint (i.e., -4.51 dB notch).

## Notes

- Pulp-native naming throughout — no reference framework class shapes mirrored.
- Version bumped to 0.212.0 (minor; new factory methods + enum values).
- Cross-references the Codex review on #2834 directly in the fix commit + test names so the audit trail is traceable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)