### PR TITLE
feat(macos-plan): Batch D (partial) — HMAC + AES-256-GCM AEAD + constant_time_equal (item 7.1a)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.212.0
+    VERSION 0.213.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/runtime/include/pulp/runtime/crypto.hpp
+++ b/core/runtime/include/pulp/runtime/crypto.hpp
@@ -46,6 +46,58 @@ std::optional<std::vector<uint8_t>> aes_decrypt(
     const uint8_t* ciphertext, size_t size,
     const uint8_t* key_32, const uint8_t* iv_16);
 
+// ── HMAC (RFC 2104 / RFC 2202 / RFC 4231) ───────────────────────────────
+
+/// Compute HMAC-SHA256(key, data). Returns 32-byte tag.
+/// Vectors: RFC 4231 (HMAC-SHA-256).
+std::vector<uint8_t> hmac_sha256(
+    const uint8_t* key, size_t key_size,
+    const uint8_t* data, size_t data_size);
+std::vector<uint8_t> hmac_sha256(std::string_view key, std::string_view data);
+
+/// Compute HMAC-SHA1(key, data). Returns 20-byte tag.
+/// Vectors: RFC 2202 (HMAC-SHA-1). Legacy use (e.g., AWS Signature v2).
+std::vector<uint8_t> hmac_sha1(
+    const uint8_t* key, size_t key_size,
+    const uint8_t* data, size_t data_size);
+
+// ── AES-GCM (AEAD, NIST SP 800-38D) ─────────────────────────────────────
+
+/// Output of AES-GCM encryption: ciphertext + 16-byte authentication tag.
+struct GcmOutput {
+    std::vector<uint8_t> ciphertext;
+    std::vector<uint8_t> tag; ///< 16 bytes
+};
+
+/// AES-256-GCM encrypt with optional Additional Authenticated Data (AAD).
+/// IV/nonce should be 12 bytes (96 bits) per NIST SP 800-38D §8.2.1.
+/// Returns ciphertext (same length as plaintext) + 16-byte authentication tag.
+/// Returns std::nullopt on internal mbedTLS failure (rare; mostly OOM).
+std::optional<GcmOutput> aes_gcm_encrypt(
+    const uint8_t* plaintext, size_t plaintext_size,
+    const uint8_t* key_32,
+    const uint8_t* iv_12, size_t iv_size,
+    const uint8_t* aad, size_t aad_size);
+
+/// AES-256-GCM decrypt + verify the 16-byte tag.
+/// Returns plaintext on success; std::nullopt if the tag fails to verify
+/// (caller must treat that as a hard failure — *do not* surface partial
+/// plaintext on tag mismatch; the buffer is overwritten regardless but
+/// the contract is "verified or null").
+std::optional<std::vector<uint8_t>> aes_gcm_decrypt(
+    const uint8_t* ciphertext, size_t ciphertext_size,
+    const uint8_t* key_32,
+    const uint8_t* iv_12, size_t iv_size,
+    const uint8_t* aad, size_t aad_size,
+    const uint8_t* tag_16);
+
+// ── Constant-time comparison ────────────────────────────────────────────
+
+/// Constant-time byte comparison. Returns true iff @p a and @p b match.
+/// Use whenever comparing MAC tags, key material, or other secret bytes
+/// — `std::memcmp` short-circuits and leaks timing information.
+bool constant_time_equal(const uint8_t* a, const uint8_t* b, size_t size);
+
 // ── Machine ID ──────────────────────────────────────────────────────────
 
 /// Generate a machine-specific fingerprint (deterministic per machine).

--- a/core/runtime/src/crypto.cpp
+++ b/core/runtime/src/crypto.cpp
@@ -6,6 +6,8 @@
 #include <mbedtls/sha1.h>
 #include <mbedtls/md5.h>
 #include <mbedtls/aes.h>
+#include <mbedtls/gcm.h>
+#include <mbedtls/md.h>
 
 #include <sstream>
 #include <iomanip>
@@ -139,6 +141,113 @@ std::optional<std::vector<uint8_t>> aes_decrypt(
     }
     result.resize(size - pad_val);
     return result;
+}
+
+// ── HMAC ────────────────────────────────────────────────────────────────
+
+namespace {
+std::vector<uint8_t> hmac_with_md(mbedtls_md_type_t md_type, size_t out_size,
+                                    const uint8_t* key, size_t key_size,
+                                    const uint8_t* data, size_t data_size) {
+    std::vector<uint8_t> tag(out_size, 0);
+    const mbedtls_md_info_t* md = mbedtls_md_info_from_type(md_type);
+    if (md == nullptr) return tag; // never happens for SHA-1/256 in mbedTLS
+    mbedtls_md_context_t ctx;
+    mbedtls_md_init(&ctx);
+    if (mbedtls_md_setup(&ctx, md, /*hmac=*/1) != 0) {
+        mbedtls_md_free(&ctx);
+        return tag;
+    }
+    mbedtls_md_hmac_starts(&ctx, key, key_size);
+    mbedtls_md_hmac_update(&ctx, data, data_size);
+    mbedtls_md_hmac_finish(&ctx, tag.data());
+    mbedtls_md_free(&ctx);
+    return tag;
+}
+} // namespace
+
+std::vector<uint8_t> hmac_sha256(const uint8_t* key, size_t key_size,
+                                   const uint8_t* data, size_t data_size) {
+    return hmac_with_md(MBEDTLS_MD_SHA256, 32, key, key_size, data, data_size);
+}
+std::vector<uint8_t> hmac_sha256(std::string_view key, std::string_view data) {
+    return hmac_sha256(reinterpret_cast<const uint8_t*>(key.data()), key.size(),
+                       reinterpret_cast<const uint8_t*>(data.data()), data.size());
+}
+
+std::vector<uint8_t> hmac_sha1(const uint8_t* key, size_t key_size,
+                                 const uint8_t* data, size_t data_size) {
+    return hmac_with_md(MBEDTLS_MD_SHA1, 20, key, key_size, data, data_size);
+}
+
+// ── AES-256-GCM ─────────────────────────────────────────────────────────
+
+std::optional<GcmOutput> aes_gcm_encrypt(
+    const uint8_t* plaintext, size_t plaintext_size,
+    const uint8_t* key_32,
+    const uint8_t* iv, size_t iv_size,
+    const uint8_t* aad, size_t aad_size) {
+    GcmOutput out;
+    out.ciphertext.resize(plaintext_size);
+    out.tag.resize(16);
+
+    mbedtls_gcm_context ctx;
+    mbedtls_gcm_init(&ctx);
+    if (mbedtls_gcm_setkey(&ctx, MBEDTLS_CIPHER_ID_AES, key_32, 256) != 0) {
+        mbedtls_gcm_free(&ctx);
+        return std::nullopt;
+    }
+    int rc = mbedtls_gcm_crypt_and_tag(
+        &ctx, MBEDTLS_GCM_ENCRYPT, plaintext_size,
+        iv, iv_size, aad, aad_size,
+        plaintext,
+        out.ciphertext.empty() ? nullptr : out.ciphertext.data(),
+        out.tag.size(), out.tag.data());
+    mbedtls_gcm_free(&ctx);
+    if (rc != 0) return std::nullopt;
+    return out;
+}
+
+std::optional<std::vector<uint8_t>> aes_gcm_decrypt(
+    const uint8_t* ciphertext, size_t ciphertext_size,
+    const uint8_t* key_32,
+    const uint8_t* iv, size_t iv_size,
+    const uint8_t* aad, size_t aad_size,
+    const uint8_t* tag_16) {
+    std::vector<uint8_t> plaintext(ciphertext_size);
+
+    mbedtls_gcm_context ctx;
+    mbedtls_gcm_init(&ctx);
+    if (mbedtls_gcm_setkey(&ctx, MBEDTLS_CIPHER_ID_AES, key_32, 256) != 0) {
+        mbedtls_gcm_free(&ctx);
+        return std::nullopt;
+    }
+    int rc = mbedtls_gcm_auth_decrypt(
+        &ctx, ciphertext_size,
+        iv, iv_size, aad, aad_size,
+        tag_16, 16,
+        ciphertext,
+        plaintext.empty() ? nullptr : plaintext.data());
+    mbedtls_gcm_free(&ctx);
+    if (rc != 0) {
+        // Tag mismatch (MBEDTLS_ERR_GCM_AUTH_FAILED) or other failure;
+        // overwrite the plaintext buffer so partial decryption doesn't
+        // escape (mbedTLS already zeroes it on auth failure, but be
+        // explicit here in case of build-config differences).
+        std::fill(plaintext.begin(), plaintext.end(), uint8_t{0});
+        return std::nullopt;
+    }
+    return plaintext;
+}
+
+// ── Constant-time compare ───────────────────────────────────────────────
+
+bool constant_time_equal(const uint8_t* a, const uint8_t* b, size_t size) {
+    // Branchless XOR + accumulate.
+    uint8_t diff = 0;
+    for (size_t i = 0; i < size; ++i)
+        diff = static_cast<uint8_t>(diff | (a[i] ^ b[i]));
+    return diff == 0;
 }
 
 // ── Machine ID ──────────────────────────────────────────────────────────

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2148,6 +2148,9 @@ pulp_add_test_suite(pulp-test-pan-mix-laws LIBRARIES pulp::signal)
 # macOS plan Batch E (partial) — UMP per-note + JR Clock
 pulp_add_test_suite(pulp-test-ump-extensions LIBRARIES pulp::midi)
 
+# macOS plan Batch D (partial) — HMAC + AEAD primitives
+pulp_add_test_suite(pulp-test-hmac-aead LIBRARIES pulp::runtime)
+
 # macOS plan Batch A — Foundations
 pulp_add_test_suite(pulp-test-dc-blocker LIBRARIES pulp::signal)
 pulp_add_test_suite(pulp-test-denormal LIBRARIES pulp::signal)

--- a/test/test_hmac_aead.cpp
+++ b/test/test_hmac_aead.cpp
@@ -1,0 +1,205 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/runtime/crypto.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+using namespace pulp::runtime;
+
+namespace {
+
+std::string to_hex(const std::vector<uint8_t>& v) {
+    static const char* hex = "0123456789abcdef";
+    std::string out;
+    out.reserve(v.size() * 2);
+    for (uint8_t b : v) { out.push_back(hex[b >> 4]); out.push_back(hex[b & 0x0F]); }
+    return out;
+}
+
+std::vector<uint8_t> from_hex(std::string_view h) {
+    std::vector<uint8_t> out;
+    out.reserve(h.size() / 2);
+    auto val = [](char c) -> int {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return 10 + c - 'a';
+        if (c >= 'A' && c <= 'F') return 10 + c - 'A';
+        return 0;
+    };
+    for (size_t i = 0; i + 1 < h.size(); i += 2) {
+        out.push_back(static_cast<uint8_t>((val(h[i]) << 4) | val(h[i + 1])));
+    }
+    return out;
+}
+
+} // namespace
+
+// ────────────────────────────────────────────────────────────────────────
+// HMAC-SHA256 — RFC 4231 test vectors (subset)
+// ────────────────────────────────────────────────────────────────────────
+
+TEST_CASE("HMAC-SHA256 RFC 4231 test case 1", "[runtime][crypto][hmac][rfc]") {
+    auto key = from_hex("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+    auto tag = hmac_sha256(key.data(), key.size(),
+                            reinterpret_cast<const uint8_t*>("Hi There"), 8);
+    REQUIRE(to_hex(tag) ==
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7");
+}
+
+TEST_CASE("HMAC-SHA256 RFC 4231 test case 2 ('Jefe')",
+          "[runtime][crypto][hmac][rfc]") {
+    auto tag = hmac_sha256(
+        reinterpret_cast<const uint8_t*>("Jefe"), 4,
+        reinterpret_cast<const uint8_t*>("what do ya want for nothing?"), 28);
+    REQUIRE(to_hex(tag) ==
+            "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843");
+}
+
+TEST_CASE("HMAC-SHA256 RFC 4231 test case 3 (long data + 0xaa key)",
+          "[runtime][crypto][hmac][rfc]") {
+    std::array<uint8_t, 20> key; key.fill(0xaa);
+    std::array<uint8_t, 50> data; data.fill(0xdd);
+    auto tag = hmac_sha256(key.data(), key.size(), data.data(), data.size());
+    REQUIRE(to_hex(tag) ==
+            "773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe");
+}
+
+TEST_CASE("HMAC-SHA256 string_view overload", "[runtime][crypto][hmac]") {
+    auto tag = hmac_sha256(std::string_view("Jefe"),
+                            std::string_view("what do ya want for nothing?"));
+    REQUIRE(to_hex(tag) ==
+            "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843");
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// HMAC-SHA1 — RFC 2202 test vectors (subset)
+// ────────────────────────────────────────────────────────────────────────
+
+TEST_CASE("HMAC-SHA1 RFC 2202 test case 1", "[runtime][crypto][hmac][rfc]") {
+    auto key = from_hex("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+    auto tag = hmac_sha1(key.data(), key.size(),
+                          reinterpret_cast<const uint8_t*>("Hi There"), 8);
+    REQUIRE(to_hex(tag) == "b617318655057264e28bc0b6fb378c8ef146be00");
+}
+
+TEST_CASE("HMAC-SHA1 RFC 2202 test case 2 ('Jefe')",
+          "[runtime][crypto][hmac][rfc]") {
+    auto tag = hmac_sha1(
+        reinterpret_cast<const uint8_t*>("Jefe"), 4,
+        reinterpret_cast<const uint8_t*>("what do ya want for nothing?"), 28);
+    REQUIRE(to_hex(tag) == "effcdf6ae5eb2fa2d27416d5f184df9c259a7c79");
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// AES-256-GCM — NIST SP 800-38D test vector
+// ────────────────────────────────────────────────────────────────────────
+
+TEST_CASE("AES-256-GCM NIST Test Case 13 (256-bit key, empty plaintext)",
+          "[runtime][crypto][gcm][rfc]") {
+    auto key = from_hex(
+        "0000000000000000000000000000000000000000000000000000000000000000");
+    auto iv = from_hex("000000000000000000000000");
+    auto out = aes_gcm_encrypt(nullptr, 0, key.data(),
+                                iv.data(), iv.size(),
+                                nullptr, 0);
+    REQUIRE(out.has_value());
+    REQUIRE(out->ciphertext.empty());
+    REQUIRE(to_hex(out->tag) == "530f8afbc74536b9a963b4f1c4cb738b");
+}
+
+TEST_CASE("AES-256-GCM round-trip recovers plaintext + verifies tag",
+          "[runtime][crypto][gcm]") {
+    std::array<uint8_t, 32> key; for (size_t i = 0; i < 32; ++i) key[i] = static_cast<uint8_t>(i);
+    std::array<uint8_t, 12> iv;  for (size_t i = 0; i < 12; ++i) iv[i] = static_cast<uint8_t>(0x10 + i);
+    const std::string plain = "Pulp macOS plan Batch D — AEAD via mbedTLS";
+    const std::string aad = "header-context";
+
+    auto enc = aes_gcm_encrypt(
+        reinterpret_cast<const uint8_t*>(plain.data()), plain.size(),
+        key.data(), iv.data(), iv.size(),
+        reinterpret_cast<const uint8_t*>(aad.data()), aad.size());
+    REQUIRE(enc.has_value());
+    REQUIRE(enc->ciphertext.size() == plain.size());
+    REQUIRE(enc->tag.size() == 16);
+
+    auto dec = aes_gcm_decrypt(
+        enc->ciphertext.data(), enc->ciphertext.size(),
+        key.data(), iv.data(), iv.size(),
+        reinterpret_cast<const uint8_t*>(aad.data()), aad.size(),
+        enc->tag.data());
+    REQUIRE(dec.has_value());
+    REQUIRE(std::string(dec->begin(), dec->end()) == plain);
+}
+
+TEST_CASE("AES-256-GCM rejects tampered ciphertext", "[runtime][crypto][gcm]") {
+    std::array<uint8_t, 32> key{};
+    std::array<uint8_t, 12> iv{};
+    const std::string plain = "secret payload";
+    auto enc = aes_gcm_encrypt(
+        reinterpret_cast<const uint8_t*>(plain.data()), plain.size(),
+        key.data(), iv.data(), iv.size(),
+        nullptr, 0);
+    REQUIRE(enc.has_value());
+    // Flip one byte of ciphertext.
+    enc->ciphertext[0] ^= 0x01;
+    auto dec = aes_gcm_decrypt(
+        enc->ciphertext.data(), enc->ciphertext.size(),
+        key.data(), iv.data(), iv.size(),
+        nullptr, 0, enc->tag.data());
+    REQUIRE_FALSE(dec.has_value()); // tag verify failed
+}
+
+TEST_CASE("AES-256-GCM rejects tampered tag", "[runtime][crypto][gcm]") {
+    std::array<uint8_t, 32> key{};
+    std::array<uint8_t, 12> iv{};
+    const std::string plain = "secret payload";
+    auto enc = aes_gcm_encrypt(
+        reinterpret_cast<const uint8_t*>(plain.data()), plain.size(),
+        key.data(), iv.data(), iv.size(),
+        nullptr, 0);
+    REQUIRE(enc.has_value());
+    enc->tag[5] ^= 0xFF;
+    auto dec = aes_gcm_decrypt(
+        enc->ciphertext.data(), enc->ciphertext.size(),
+        key.data(), iv.data(), iv.size(),
+        nullptr, 0, enc->tag.data());
+    REQUIRE_FALSE(dec.has_value());
+}
+
+TEST_CASE("AES-256-GCM rejects mismatched AAD", "[runtime][crypto][gcm]") {
+    std::array<uint8_t, 32> key{};
+    std::array<uint8_t, 12> iv{};
+    const std::string plain = "payload";
+    const std::string aad_a = "context-A";
+    const std::string aad_b = "context-B";
+    auto enc = aes_gcm_encrypt(
+        reinterpret_cast<const uint8_t*>(plain.data()), plain.size(),
+        key.data(), iv.data(), iv.size(),
+        reinterpret_cast<const uint8_t*>(aad_a.data()), aad_a.size());
+    REQUIRE(enc.has_value());
+    auto dec = aes_gcm_decrypt(
+        enc->ciphertext.data(), enc->ciphertext.size(),
+        key.data(), iv.data(), iv.size(),
+        reinterpret_cast<const uint8_t*>(aad_b.data()), aad_b.size(),
+        enc->tag.data());
+    REQUIRE_FALSE(dec.has_value());
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Constant-time compare
+// ────────────────────────────────────────────────────────────────────────
+
+TEST_CASE("constant_time_equal matches std::memcmp behavior on equality",
+          "[runtime][crypto][ct-compare]") {
+    std::array<uint8_t, 32> a{}; for (auto& b : a) b = 0xA5;
+    std::array<uint8_t, 32> b = a;
+    REQUIRE(constant_time_equal(a.data(), b.data(), a.size()));
+
+    b[15] ^= 0x01;
+    REQUIRE_FALSE(constant_time_equal(a.data(), b.data(), a.size()));
+}
+
+TEST_CASE("constant_time_equal handles zero-length", "[runtime][crypto][ct-compare]") {
+    REQUIRE(constant_time_equal(nullptr, nullptr, 0));
+}


### PR DESCRIPTION
## Summary

macOS plan **Batch D (partial)** — three crypto primitives + RFC vectors. Scoped to mbedTLS-backed primitives only; Ed25519, license-format migration (7.2), and Sparkle wiring (7.3) follow in their own focused PRs.

| Item | What ships |
|---|---|
| 7.1a HMAC | `hmac_sha256(key,data)` + `hmac_sha1(key,data)` via `mbedtls_md_hmac_*`. Returns 32 / 20-byte tags. String-view overload for ergonomics. |
| 7.1a AES-256-GCM (AEAD) | `aes_gcm_encrypt(plaintext, key32, iv, aad)` returning `{ciphertext, tag}` + `aes_gcm_decrypt(...)` returning `std::optional<plaintext>` (nullopt on tag mismatch). 12-byte IV per NIST SP 800-38D §8.2.1. Explicit-zero on auth failure as defense-in-depth. |
| 7.1a constant_time_equal | Branchless XOR + accumulate. For tag / key-material comparison — never use `std::memcmp` for those. |

**Deferred to follow-up PRs** (recorded in tracker):
- **7.1b Ed25519** — needs library decision: mbedTLS EdDSA support is gated/optional in older builds; alternatives are libsodium or ed25519-donna. Better to pick + audit in its own PR than rush it into a crypto bundle.
- **7.2 License signing migration** — touches existing license code; needs LicenseFormatVersion bump strategy + back-compat reader for one release.
- **7.3 Sparkle Ed25519 wiring** — depends on 7.1b landing first.

## Test plan

`pulp-test-hmac-aead` — 23 assertions / 13 cases. All green locally:

- HMAC-SHA256 RFC 4231 test cases 1, 2, 3 (incl. long-data + 0xaa key path) + string_view overload regression
- HMAC-SHA1 RFC 2202 test cases 1 + 2 ('Jefe' classic vector)
- AES-256-GCM NIST Test Case 13 (256-bit key, empty plaintext, zero IV, expected tag `530f8a...`)
- AES-256-GCM round-trip with AAD recovers plaintext exactly
- AES-256-GCM rejects tampered ciphertext, tampered tag, mismatched AAD (3 separate cases)
- constant_time_equal matches behavior on equal/unequal + handles zero-length

Broader runtime sanity: `pulp-test-runtime` — 261 assertions / 39 cases, no regressions.

## Notes

- New surface lives under `pulp::runtime` per CHOC-first / mbedTLS-backed crypto policy in CLAUDE.md.
- Version bumped to 0.213.0 (minor; new public API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)