### PR TITLE
feat(view): clarify native child embedding support contract

### DIFF
--- a/.agents/skills/webview-ui/SKILL.md
+++ b/.agents/skills/webview-ui/SKILL.md
@@ -116,6 +116,21 @@ Important notes from the working proof:
 
 ## Window Embedding
 
+WebView backend availability and host embedding availability are separate. A
+`WebViewPanel` can exist even when the surrounding `WindowHost` or
+`PluginViewHost` cannot accept a native child surface. Always check:
+- the panel's `native_handle()`
+- the host's native content/view handle where applicable
+- the boolean returned by `attach_native_child_view(...)`
+
+Current host truth:
+- standalone `WindowHost` child embedding is built in on macOS
+- built-in iOS `WindowHost` does not expose standalone child-view embedding
+  handles yet
+- `PluginViewHost` child embedding is built in on macOS and iOS
+- Windows/Linux/Android embedding is factory-backed through
+  `WindowHost::Factory` or `PluginViewHost::Factory`
+
 For palette / inspector style UI:
 - create the parent `WindowHost`
 - create the child/palette `WindowHost`

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.121.0",
+      "version": "0.122.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.121.0"
+  "version": "0.122.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.121.0",
+  "version": "0.122.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.253.0
+    VERSION 0.254.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/inspector_window.hpp
+++ b/core/view/include/pulp/view/inspector_window.hpp
@@ -12,6 +12,7 @@
 #include <pulp/view/split_view.hpp>
 #include <pulp/view/window_host.hpp>
 #include <pulp/view/window_manager.hpp>
+#include <functional>
 #include <memory>
 
 namespace pulp::view {
@@ -39,12 +40,18 @@ private:
 /// of a target view tree in a separate OS window.
 class InspectorWindow {
 public:
+    using HostFactory = std::function<std::unique_ptr<WindowHost>(
+        View& root, const WindowOptions& options)>;
+
     /// Construct an inspector targeting the given root view.
     /// @param target_root  The root of the view tree to inspect.
     /// @param mgr          Optional WindowManager for registration.
     /// @param parent        Optional parent WindowHost (positions relative to it).
+    /// @param host_factory Optional host creation override for tests or embedders
+    ///                     that route inspector windows through a custom host.
     InspectorWindow(View& target_root, WindowManager* mgr = nullptr,
-                    WindowHost* parent = nullptr);
+                    WindowHost* parent = nullptr,
+                    HostFactory host_factory = {});
     ~InspectorWindow();
 
     InspectorWindow(const InspectorWindow&) = delete;
@@ -75,6 +82,7 @@ private:
     View& target_root_;
     WindowManager* manager_ = nullptr;
     WindowHost* parent_host_ = nullptr;
+    HostFactory host_factory_;
 
     // Inspector window's own view tree
     std::unique_ptr<View> inspector_root_;

--- a/core/view/include/pulp/view/plugin_view_host.hpp
+++ b/core/view/include/pulp/view/plugin_view_host.hpp
@@ -34,11 +34,13 @@ public:
     // Create a plugin view host for the given view tree.
     //
     // Platform support (#299):
-    //   - macOS: NSView-backed impl in plugin_view_host_mac.mm.
-    //   - iOS: UIView-backed impl in plugin_view_host_ios.mm.
-    //   - Windows/Linux/Android: no built-in impl — host app
-    //     registers a factory via set_factory(). Without a
-    //     factory, create() returns nullptr explicitly.
+    //   - macOS: NSView-backed impl in plugin_view_host_mac.mm, including
+    //     native child-view attach/bounds/detach.
+    //   - iOS: UIView-backed impl in plugin_view_host_ios.mm, including
+    //     native child-view attach/bounds/detach.
+    //   - Windows/Linux/Android: no built-in impl — host app registers a
+    //     factory via set_factory(). Without a factory, create() returns
+    //     nullptr explicitly.
     static std::unique_ptr<PluginViewHost> create(View& root, Size size);
     static std::unique_ptr<PluginViewHost> create(View& root, const Options& options);
 
@@ -52,7 +54,9 @@ public:
 
     virtual ~PluginViewHost() = default;
 
-    // Get the native view handle to pass to the DAW host
+    // Get the native view handle to pass to the DAW host. A non-null host view
+    // does not by itself guarantee that this host can also embed other native
+    // child views; callers must branch on attach_native_child_view().
     virtual NativeViewHandle native_handle() = 0;
 
     // Attach this view to a parent native view (the DAW's editor window)
@@ -103,6 +107,9 @@ public:
 
     // Attach/detach a native child view inside the plugin editor host.
     // Coordinates use Pulp's top-left origin convention, matching WindowHost.
+    // Returning false is the canonical unsupported/rejected signal. Non-Apple
+    // factory-backed hosts that support native child embedding must override
+    // all three methods and should keep attachment state in the concrete host.
     virtual bool attach_native_child_view(NativeViewHandle child_view,
                                           float x,
                                           float y,

--- a/core/view/include/pulp/view/web_view.hpp
+++ b/core/view/include/pulp/view/web_view.hpp
@@ -122,9 +122,12 @@ WebViewOptions::FetchResource make_webview_directory_resource_fetcher(
     std::filesystem::path root_directory,
     std::string index_filename = "index.html");
 
-// Embedded web view component
-// Create with WebViewPanel::create(), then attach to a parent view or
-// use native_handle() to embed in a native window hierarchy.
+// Embedded web view component.
+// Create with WebViewPanel::create(), then use native_handle() to embed the
+// platform WebView in a WindowHost/PluginViewHost that actually exposes and
+// accepts native child views. WebView backend availability and host embedding
+// availability are separate capabilities; callers must check the host handle
+// and attach_native_child_view() result.
 class WebViewPanel {
 public:
     using JsCallback = std::function<std::string(const std::string& args_json)>;
@@ -146,7 +149,9 @@ public:
     // immediately.
     virtual void set_ready_handler(ReadyHandler handler) = 0;
 
-    // Get the native view handle for embedding (NSView*, HWND, etc.)
+    // Get the native view handle for embedding (NSView*, HWND, etc.). This is
+    // the child surface handle only; successful embedding also requires a host
+    // whose native child-view attach contract returns true.
     virtual NativeViewHandle native_handle() = 0;
 
     // Navigate to a URL

--- a/core/view/include/pulp/view/window_host.hpp
+++ b/core/view/include/pulp/view/window_host.hpp
@@ -58,13 +58,14 @@ struct WindowOptions {
 // Native window that hosts a View tree and renders it.
 //
 // Platform support (#299):
-//   - macOS: native NSWindow-backed impl in window_host_mac.mm.
-//   - iOS: native UIWindow-backed impl in window_host_ios.mm.
-//   - Windows/Linux/Android: no built-in impl — the host app or a
-//     future platform module registers a factory via
-//     set_factory(). Without a factory, create() returns nullptr
-//     so callers can surface "platform unsupported" through
-//     has_factory() rather than a silent null.
+//   - macOS: native NSWindow-backed impl in window_host_mac.mm, including
+//     native content handles and child-view attach/bounds/detach.
+//   - iOS: native UIWindow-backed impl in window_host_ios.mm. The standalone
+//     iOS host does not currently expose native child-view embedding.
+//   - Windows/Linux/Android: no built-in impl — the host app or a future
+//     platform module registers a factory via set_factory(). Without a
+//     factory, create() returns nullptr so callers can surface "platform
+//     unsupported" through has_factory() rather than a silent null.
 class WindowHost {
 public:
     struct ContentSize {
@@ -125,8 +126,10 @@ public:
     render::RenderLoop* render_loop() const { return render_loop_; }
 
     // Native host/window handles for embedding child platform views such as
-    // WebViews. Default implementations return nullptr on platforms that do
-    // not expose these seams yet.
+    // WebViews. These are instance capabilities, not platform guarantees:
+    // callers must check for non-null handles before attempting native child
+    // embedding. Default implementations return nullptr on hosts that do not
+    // expose native handles.
     /// Position this window alongside another window.
     /// Places to the right if there's screen space, otherwise to the left.
     virtual void position_beside(WindowHost* other) { (void)other; }
@@ -159,7 +162,10 @@ public:
     virtual ContentSize get_content_size() const;
 
     // Attach/detach a platform-native child view inside this host. Coordinates
-    // use Pulp's top-left origin convention.
+    // use Pulp's top-left origin convention. Returning false is the canonical
+    // unsupported/rejected signal. Non-Apple factory-backed hosts that support
+    // native child embedding must override all three methods and should keep
+    // attachment state in the concrete host.
     virtual bool attach_native_child_view(void* child_view,
                                           float x,
                                           float y,

--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -767,34 +767,25 @@ static void install_app_menu(NSString* appName) {
                     // `_deferredClickAlive` liveness token (a
                     // `shared_ptr<atomic<bool>>`). The copy keeps the
                     // `atomic<bool>` alive even after the PulpView itself is
-                    // gone. `-prepareForTeardown` — called from the host
-                    // destructor before the bridge/engine can be freed, and
-                    // again from -dealloc — flips the token to false. The
-                    // teardown runs synchronously with no run-loop pump
-                    // between the bridge's destruction and the flip, so every
-                    // still-queued block is defused. A block that drains after
-                    // teardown sees `false` and no-ops WITHOUT touching `self`
-                    // or invoking the captured handlers. `self` is captured
-                    // unretained (this file is compiled MRC); that is safe
-                    // because every `self` deref is gated behind the
-                    // token-is-alive check.
+                    // gone. `-prepareForTeardown` flips the token to false. A
+                    // block that drains after teardown sees `false` and no-ops.
+                    // Do not capture or dereference `self` from this block:
+                    // this file is compiled MRC, and hidden test windows can be
+                    // torn down before AppKit drains every main-queue callback.
+                    // The copied handlers have their own WidgetBridge /
+                    // ScriptEngine liveness guards, and mouseUp already marks
+                    // the view dirty immediately after scheduling the block.
                     std::shared_ptr<std::atomic<bool>> aliveToken = _deferredClickAlive;
                     dispatch_async(dispatch_get_main_queue(), ^{
-                        // Defused after teardown: do not touch `self` or the
-                        // captured `std::function`s — their backing
-                        // WidgetBridge / ScriptEngine may already be freed.
+                        // Defused after teardown: do not invoke handlers whose
+                        // backing WidgetBridge / ScriptEngine may already be
+                        // freed.
                         if (!aliveToken || !aliveToken->load())
                             return;
                         @try {
                             try {
-                                // Token still alive ⇒ the host (and therefore
-                                // this view) has not been torn down. The extra
-                                // rootView guard rejects a detached view tree.
-                                if (self.rootView) {
-                                    if (click_handler) click_handler();
-                                    if (global_click) global_click(clicked_id, modifiers);
-                                    [self setNeedsDisplay:YES];
-                                }
+                                if (click_handler) click_handler();
+                                if (global_click) global_click(clicked_id, modifiers);
                             } catch (const std::exception& e) {
                                 std::cerr << "MacWindowHost deferred click error: " << e.what() << "\n";
                             } catch (...) {

--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -772,9 +772,10 @@ static void install_app_menu(NSString* appName) {
                     // Do not capture or dereference `self` from this block:
                     // this file is compiled MRC, and hidden test windows can be
                     // torn down before AppKit drains every main-queue callback.
-                    // The copied handlers have their own WidgetBridge /
-                    // ScriptEngine liveness guards, and mouseUp already marks
-                    // the view dirty immediately after scheduling the block.
+                    // The copied handlers must keep their own WidgetBridge /
+                    // ScriptEngine liveness guards; this block intentionally
+                    // owns only the teardown token, and mouseUp already marks
+                    // the view dirty immediately after scheduling it.
                     std::shared_ptr<std::atomic<bool>> aliveToken = _deferredClickAlive;
                     dispatch_async(dispatch_get_main_queue(), ^{
                         // Defused after teardown: do not invoke handlers whose

--- a/core/view/src/inspector_window.cpp
+++ b/core/view/src/inspector_window.cpp
@@ -1,5 +1,8 @@
 #include <pulp/view/inspector_window.hpp>
 #include <pulp/view/input_events.hpp>
+#include <pulp/runtime/log.hpp>
+
+#include <utility>
 
 namespace pulp::view {
 
@@ -38,10 +41,12 @@ void InspectorHighlight::paint(canvas::Canvas& canvas) {
 // ── InspectorWindow ────────────────────────────────────────────────────────
 
 InspectorWindow::InspectorWindow(View& target_root, WindowManager* mgr,
-                                 WindowHost* parent)
+                                 WindowHost* parent,
+                                 HostFactory host_factory)
     : target_root_(target_root)
     , manager_(mgr)
     , parent_host_(parent)
+    , host_factory_(std::move(host_factory))
 {
     build_ui();
 
@@ -144,7 +149,18 @@ void InspectorWindow::show() {
         if (parent_host_)
             opts.parent_native_handle = parent_host_->native_window_handle();
 
-        window_host_ = WindowHost::create(*inspector_root_, opts);
+        window_host_ = host_factory_
+            ? host_factory_(*inspector_root_, opts)
+            : WindowHost::create(*inspector_root_, opts);
+        if (!window_host_) {
+            runtime::log_warn(
+                "InspectorWindow: WindowHost::create returned nullptr; "
+                "inspector windows require a supported WindowHost implementation");
+            if (highlight_ptr_)
+                highlight_ptr_->set_visible(false);
+            return;
+        }
+
         window_host_->set_close_callback([this]() {
             if (highlight_ptr_)
                 highlight_ptr_->set_visible(false);

--- a/docs/guides/view-bridge.md
+++ b/docs/guides/view-bridge.md
@@ -114,28 +114,37 @@ void MyPlugin::on_view_closed(view::View&) {
 detach API, and `View::plugin_view_host()` is populated across the whole
 editor subtree before `on_view_opened()` fires. That means a nested custom
 view can embed a `WebViewPanel` (or any other native child surface) without
-singletons or format-specific hooks:
+singletons or format-specific hooks when the concrete host supports native
+child embedding:
 
 ```cpp
 class WebViewSlot : public view::View {
 public:
   void attach_if_needed() {
     if (attached_ || !plugin_view_host() || !panel_) return;
+    auto child = panel_->native_handle();
+    if (!child) return;
+
     auto size = plugin_view_host()->get_size();
     attached_ = plugin_view_host()->attach_native_child_view(
-        panel_->native_handle(), 0, 0, size.width, size.height);
+        child, 0, 0, size.width, size.height);
   }
 
   void sync_to_host() {
     if (!attached_ || !plugin_view_host() || !panel_) return;
+    auto child = panel_->native_handle();
+    if (!child) return;
+
     auto size = plugin_view_host()->get_size();
     plugin_view_host()->set_native_child_view_bounds(
-        panel_->native_handle(), 0, 0, size.width, size.height);
+        child, 0, 0, size.width, size.height);
   }
 
   void detach_if_needed() {
     if (!attached_ || !plugin_view_host() || !panel_) return;
-    plugin_view_host()->detach_native_child_view(panel_->native_handle());
+    if (auto child = panel_->native_handle()) {
+      plugin_view_host()->detach_native_child_view(child);
+    }
     attached_ = false;
   }
 
@@ -161,6 +170,14 @@ Views added before the host exists still inherit the final
 `PluginViewHost*` when the editor opens, so deeply nested children can call
 `plugin_view_host()` just like children added later. See
 `examples/webview-plugin/` for a complete runnable example.
+
+`plugin_view_host()` being non-null only proves that the editor has a host.
+Native child embedding is an instance capability: the child surface must expose
+a non-null native handle and `attach_native_child_view()` must return true. The
+built-in plugin hosts support that contract on macOS and iOS. On
+Windows/Linux/Android, applications or format hosts provide it by registering a
+`PluginViewHost::Factory`; the default factory/stub path returns false rather
+than pretending native child embedding exists.
 
 ### Multiple views for one processor
 

--- a/docs/guides/webview.md
+++ b/docs/guides/webview.md
@@ -40,6 +40,19 @@ This is enough to claim native backend availability behind
 installed. It is not yet a claim that every higher-level WebView workflow has
 identical runtime polish on all three platforms.
 
+Native WebView backend availability is separate from host embedding
+availability. A `WebViewPanel` can exist while the surrounding `WindowHost` or
+`PluginViewHost` cannot accept a native child surface. The current host truth
+is:
+
+- standalone `WindowHost` child embedding is built in on macOS
+- standalone iOS `WindowHost` exists but does not currently expose native
+  child-view embedding handles
+- `PluginViewHost` child embedding is built in on macOS and iOS
+- Windows/Linux/Android embedding is factory-backed: the application or format
+  host registers a concrete `WindowHost::Factory` or `PluginViewHost::Factory`
+  that returns non-null handles and implements attach / resize / detach
+
 ## Build
 
 Enable the optional WebView layer:
@@ -93,6 +106,22 @@ That seam is the current bridge from Pulp's multi-window host layer into an
 embedded native WebView. It is intentionally small: enough to prove palette /
 inspector style embedding without pretending that Phase 7 is already a full
 window-docking system.
+
+Treat those calls as an instance capability, not a platform guarantee. Check
+the host handle, check the WebView child handle, and branch on the boolean
+returned by `attach_native_child_view(...)`:
+
+```cpp
+auto panel = WebViewPanel::create();
+auto host = WindowHost::create(root, options);
+
+if (!panel || !host || !panel->native_handle()
+    || !host->native_content_view_handle()
+    || !host->attach_native_child_view(panel->native_handle(), 0, 0, width, height)) {
+    // Fall back to a native Pulp view, a separate window, or an explicit
+    // unsupported-platform message.
+}
+```
 
 ## Simple HTML
 
@@ -309,8 +338,8 @@ The WebView test target currently proves:
 On some local/headless environments, the live callback readiness probe may skip rather than fail. That is treated as an environment limitation, not a blanket pass for the runtime.
 
 That is the current bar for claiming cross-platform backend availability. Do
-not overstate this as full runtime parity until the platform-specific host
-polish work is actually landed.
+not overstate this as full runtime parity or first-party non-Apple native host
+embedding until the platform-specific host work is actually landed.
 
 ## Future Skill
 

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -283,8 +283,9 @@ Key headers: `pulp/state/parameter.hpp`, `pulp/state/store.hpp`, `pulp/state/bin
 | Keyboard shortcuts | usable | all | registerShortcut bridge |
 | File dialogs (open, save, folder) | usable | macOS | NSOpenPanel/NSSavePanel |
 | Drag and drop | usable | macOS | File + text drop targets |
-| Plugin view hosting | usable | macOS/iOS | Native NSView/UIView + Metal. Windows/Linux/Android require a host-registered `PluginViewHost::Factory` (#299). |
-| SDL window host | partial | all | Cross-platform windowing via SDL3. Non-Apple platforms require a host-registered `WindowHost::Factory` for native presentation (#299); recording-canvas-only for now. |
+| Plugin view hosting | usable | macOS/iOS | Native NSView/UIView + Metal, including native child attach/bounds/detach. Windows/Linux/Android require a host-registered `PluginViewHost::Factory` (#299). |
+| Native child view embedding (WindowHost) | partial | macOS + factory-backed non-Apple | Built-in standalone support is macOS-only. Built-in iOS `WindowHost` does not expose the embedding handles. Windows/Linux/Android require a host-registered `WindowHost::Factory` that implements attach/bounds/detach (#299). |
+| SDL window host | partial | all | Cross-platform windowing via SDL3. SDL does not provide first-party native child embedding; non-Apple platforms require a host-registered `WindowHost::Factory` for native presentation (#299). Recording-canvas-only for now. |
 
 Key headers: `pulp/view/view.hpp`, `pulp/view/widgets.hpp`, `pulp/view/theme.hpp`, `pulp/view/script_engine.hpp`, `pulp/view/widget_bridge.hpp`
 

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -283,9 +283,9 @@ Key headers: `pulp/state/parameter.hpp`, `pulp/state/store.hpp`, `pulp/state/bin
 | Keyboard shortcuts | usable | all | registerShortcut bridge |
 | File dialogs (open, save, folder) | usable | macOS | NSOpenPanel/NSSavePanel |
 | Drag and drop | usable | macOS | File + text drop targets |
-| Plugin view hosting | usable | macOS/iOS | Native NSView/UIView + Metal, including native child attach/bounds/detach. Windows/Linux/Android require a host-registered `PluginViewHost::Factory` (#299). |
-| Native child view embedding (WindowHost) | partial | macOS + factory-backed non-Apple | Built-in standalone support is macOS-only. Built-in iOS `WindowHost` does not expose the embedding handles. Windows/Linux/Android require a host-registered `WindowHost::Factory` that implements attach/bounds/detach (#299). |
-| SDL window host | partial | all | Cross-platform windowing via SDL3. SDL does not provide first-party native child embedding; non-Apple platforms require a host-registered `WindowHost::Factory` for native presentation (#299). Recording-canvas-only for now. |
+| Plugin view hosting | usable | macOS/iOS | Native NSView/UIView + Metal, including native child attach/bounds/detach. Windows/Linux/Android require a host-registered `PluginViewHost::Factory`. |
+| Native child view embedding (WindowHost) | partial | macOS + factory-backed non-Apple | Built-in standalone support is macOS-only. Built-in iOS `WindowHost` does not expose the embedding handles. Windows/Linux/Android require a host-registered `WindowHost::Factory` that implements attach/bounds/detach. |
+| SDL window host | partial | all | Cross-platform windowing via SDL3. SDL does not provide first-party native child embedding; non-Apple platforms require a host-registered `WindowHost::Factory` for native presentation. Recording-canvas-only for now. |
 
 Key headers: `pulp/view/view.hpp`, `pulp/view/widgets.hpp`, `pulp/view/theme.hpp`, `pulp/view/script_engine.hpp`, `pulp/view/widget_bridge.hpp`
 

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -473,8 +473,8 @@ Closure slice:
   public docs do not imply first-party non-Apple embedding exists today.
 
 Native-window local validation:
-- Rebased onto `origin/main` at `1b12541ae` and refreshed the required SDK
-  minor bump to `0.215.0`.
+- Rebased onto `origin/main` at `65b48dfa6` and refreshed the required SDK
+  minor bump to `0.217.0`.
 - Configured Release with WebView enabled and GPU off:
   `cmake -S . -B build-native-window -DCMAKE_BUILD_TYPE=Release
   -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=ON
@@ -482,18 +482,25 @@ Native-window local validation:
 - Built the focused targets: `pulp-test-view-host-bridge`,
   `pulp-test-webview`, `pulp-webview-palette`, and
   `PulpWebViewPlugin_Standalone`.
+- A rebase sweep exposed an intermittent macOS deferred-click crash in the
+  view-host bridge tests. The queued click block no longer captures/derefs the
+  MRC `PulpView` object after teardown, and the early-teardown regression test
+  now uses a hidden host like the neighboring headless event tests.
+- `./build-native-window/test/pulp-test-view-host-bridge --reporter compact`
+  passed 81/81 assertions across 9 cases; a stress sweep passed 30/30 repeated
+  runs after the deferred-click hardening.
 - `./build-native-window/test/pulp-test-webview --reporter compact` passed
   5/7 test cases, with 2 local WebView readiness skips where the host
   environment never reached callback-ready state, and 84/84 assertions passed.
-- Focused CTest passes covered view-host, native-child, macOS/PulpView, and
-  WebView cases: 14 passed and 2 skipped for local WebView readiness/content
-  limitations.
+- Focused CTest over WebView/native-child attach cases passed 7/7 after
+  excluding generated `_NOT_BUILT` placeholders; 2 live WebView readiness cases
+  skipped in this local environment.
 - `tools/check-docs.sh` passed with existing repository warnings.
 - `git diff --check` passed.
 - `tools/scripts/gates.sh origin/main` passed skill-sync, version-bump,
   compat-sync, node-ABI, and deps-audit gates.
 - `version_bump_check.py --base origin/main --head HEAD --mode apply` applied
-  the required SDK minor bump to `0.215.0` after the inspector host-factory
+  the required SDK minor bump to `0.217.0` after the inspector host-factory
   override made the patch a public header/API change.
 - Coverage note: the stock `tools/scripts/local_diff_cover.sh` wrapper still
   configures the GPU examples path and fails locally without Skia. The same

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -27,8 +27,8 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | --- | --- | --- | --- | --- |
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
-| OSC | `feature/platform-osc` | `pulp-platform-osc` | PR [#2822](https://github.com/danielraffel/pulp/pull/2822) open; rebased and locally validated on `origin/main` `b2a5b3f78` after #2970 consumed SDK `0.252.0` and #2939 upstreamed the audit allowlist; SDK version is now `0.253.0`; hosted Ubuntu install-consumer smoke passed on the SheenBidi install fix | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
-| Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased/validated; final SDK bump and push pending after #2822 | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
+| OSC | `feature/platform-osc` | `pulp-platform-osc` | Merged via PR [#2822](https://github.com/danielraffel/pulp/pull/2822) as `bbc1506ed` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
+| Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; local rebase/validation in progress after #2822 merge | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
 - Add or update focused unit tests for every new public behavior.
@@ -452,13 +452,64 @@ The embedding API is present in `WindowHost` and `PluginViewHost`, but built-in
 concrete support is Apple-first. Non-Apple paths rely on host-registered
 factories, and default child-view attachment returns `false`.
 
-Recommended work:
-- Ship first-party Windows and Linux `WindowHost` implementations.
-- Ship first-party Windows and Linux `PluginViewHost` implementations.
-- Implement child-view attach, resize, and detach for platform-native handles.
-- Standardize the plugin editor lifecycle around `HostedEditor`.
-- Add smoke tests for native child attach/detach and bounds updates on each
-  supported desktop platform.
+Closure slice:
+- Make the current support contract explicit in public headers: native child
+  embedding is an instance capability, `attach_native_child_view()` returning
+  `false` is the canonical unsupported/rejected signal, and non-Apple support is
+  supplied by host-registered factories until first-party platform hosts land.
+- Keep the existing Apple built-ins in place: standalone `WindowHost` embedding
+  is built in on macOS; `PluginViewHost` child embedding is built in on macOS
+  and iOS; built-in iOS `WindowHost` does not currently expose the standalone
+  child-view embedding handles.
+- Add all-platform contract tests proving concrete hosts can implement
+  attach/bounds/detach correctly.
+- Add non-Apple factory tests proving `WindowHost::Factory` and
+  `PluginViewHost::Factory` can provide native child embedding and that the
+  default stub/factory path honestly rejects child attachment.
+- Update WebView examples and tests so failures distinguish backend absence,
+  missing host handles, and host rejection of native child attachment.
+- Update `docs/guides/view-bridge.md`, `docs/guides/webview.md`,
+  `docs/reference/capabilities.md`, and `docs/status/support-matrix.yaml` so
+  public docs do not imply first-party non-Apple embedding exists today.
+
+Native-window local validation:
+- Configured Release with WebView enabled and GPU off:
+  `cmake -S . -B build-native-window -DCMAKE_BUILD_TYPE=Release
+  -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=ON
+  -DPULP_BUILD_WEBVIEW=ON`.
+- Built the focused targets: `pulp-test-view-host-bridge`,
+  `pulp-test-webview`, `pulp-webview-palette`, and
+  `PulpWebViewPlugin_Standalone`.
+- `./build-native-window/test/pulp-test-webview --reporter compact` passed
+  with local WebView readiness skips where the host environment never reached
+  callback-ready state.
+- Focused CTest passes covered view-host, native-child, macOS/PulpView, and
+  WebView cases: 13 passed and 2 skipped for local WebView readiness/content
+  limitations.
+- `tools/check-docs.sh` passed with existing repository warnings.
+- `git diff --check` passed.
+- `version_bump_check.py --base origin/main --head HEAD --mode apply` applied
+  the required SDK minor bump to `0.212.0` after the inspector host-factory
+  override made the patch a public header/API change.
+- Coverage note: the behavior-bearing production change is the
+  `InspectorWindow::show()` null-host guard, covered locally through the
+  inspector host-factory override and on hosted non-Apple checks through the
+  no-factory regression test. Other production header changes are contract
+  comments, and examples/docs are excluded by the repo coverage filters.
+- Claude review reported no correctness blockers. RepoPrompt review found a
+  null-host crash in `InspectorWindow::show()`, an overstrict live WebView
+  attach assertion, and a silent plugin-example WebView-backend failure path;
+  all three were fixed and the focused build/test/docs checks were rerun.
+- SSH-backed Windows/Ubuntu testing is intentionally out of scope for this
+  focused closure pass; rely on GitHub-hosted platform checks after PR
+  submission.
+
+Deferred work:
+- First-party Windows/Linux/Android `WindowHost` and `PluginViewHost`
+  implementations remain future platform work. That slice needs real platform
+  handle ownership, child reparenting, resize, focus, lifetime, and runtime
+  smoke validation; it should not be represented as complete by this contract
+  clarification PR.
 
 ### 6. OSC Bundle and Routing Support
 

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -473,6 +473,8 @@ Closure slice:
   public docs do not imply first-party non-Apple embedding exists today.
 
 Native-window local validation:
+- Rebased onto `origin/main` at `1b12541ae` and refreshed the required SDK
+  minor bump to `0.215.0`.
 - Configured Release with WebView enabled and GPU off:
   `cmake -S . -B build-native-window -DCMAKE_BUILD_TYPE=Release
   -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=ON
@@ -481,17 +483,25 @@ Native-window local validation:
   `pulp-test-webview`, `pulp-webview-palette`, and
   `PulpWebViewPlugin_Standalone`.
 - `./build-native-window/test/pulp-test-webview --reporter compact` passed
-  with local WebView readiness skips where the host environment never reached
-  callback-ready state.
+  5/7 test cases, with 2 local WebView readiness skips where the host
+  environment never reached callback-ready state, and 84/84 assertions passed.
 - Focused CTest passes covered view-host, native-child, macOS/PulpView, and
-  WebView cases: 13 passed and 2 skipped for local WebView readiness/content
+  WebView cases: 14 passed and 2 skipped for local WebView readiness/content
   limitations.
 - `tools/check-docs.sh` passed with existing repository warnings.
 - `git diff --check` passed.
+- `tools/scripts/gates.sh origin/main` passed skill-sync, version-bump,
+  compat-sync, node-ABI, and deps-audit gates.
 - `version_bump_check.py --base origin/main --head HEAD --mode apply` applied
-  the required SDK minor bump to `0.212.0` after the inspector host-factory
+  the required SDK minor bump to `0.215.0` after the inspector host-factory
   override made the patch a public header/API change.
-- Coverage note: the behavior-bearing production change is the
+- Coverage note: the stock `tools/scripts/local_diff_cover.sh` wrapper still
+  configures the GPU examples path and fails locally without Skia. The same
+  coverage pipeline was run manually with `PULP_ENABLE_COVERAGE=ON` and
+  `PULP_ENABLE_GPU=OFF` in `build-cov-native-window`; focused coverage CTest
+  passed the three native-window contract tests and diff-cover reports 100%
+  for `core/view/src/inspector_window.cpp` against `origin/main` (12 changed
+  production lines, 0 missing). The behavior-bearing production change is the
   `InspectorWindow::show()` null-host guard, covered locally through the
   inspector host-factory override and on hosted non-Apple checks through the
   no-factory regression test. Other production header changes are contract

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -28,7 +28,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
 | OSC | `feature/platform-osc` | `pulp-platform-osc` | Merged via PR [#2822](https://github.com/danielraffel/pulp/pull/2822) as `bbc1506ed` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
-| Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased and validated on `origin/main` `c72ad330b` after #2822 merged; SDK `0.254.0`; Claude plugin `0.122.0` | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
+| Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased and validated on `origin/main` `f10a6e32e` after #2822 and #2971 merged; SDK `0.254.0`; Claude plugin `0.122.0` | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
 - Add or update focused unit tests for every new public behavior.
@@ -473,9 +473,10 @@ Closure slice:
   public docs do not imply first-party non-Apple embedding exists today.
 
 Native-window local validation:
-- Rebased onto `origin/main` at `c72ad330b` after #2822 merged and the v0.253.0
-  changelog landed. Historical status-only report commits were dropped during
-  rebase; this section is the current source of validation truth for #2844.
+- Rebased onto `origin/main` at `f10a6e32e` after #2822 merged, the v0.253.0
+  changelog landed, and #2971 added the DAW-bench harness package. Historical
+  status-only report commits were dropped during rebase; this section is the
+  current source of validation truth for #2844.
 - `version_bump_check.py --base origin/main --config
   tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat
   --accept-intent-trailers` passes with SDK `0.254.0` and Claude plugin

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -506,13 +506,14 @@ Native-window local validation:
   configures the GPU examples path and fails locally without Skia. The same
   coverage pipeline was run manually with `PULP_ENABLE_COVERAGE=ON` and
   `PULP_ENABLE_GPU=OFF` in `build-cov-native-window`; focused coverage CTest
-  passed the three native-window contract tests and diff-cover reports 100%
-  for `core/view/src/inspector_window.cpp` against `origin/main` (12 changed
-  production lines, 0 missing). The behavior-bearing production change is the
-  `InspectorWindow::show()` null-host guard, covered locally through the
-  inspector host-factory override and on hosted non-Apple checks through the
-  no-factory regression test. Other production header changes are contract
-  comments, and examples/docs are excluded by the repo coverage filters.
+  passed the three native-window contract tests after the `2d8f004a` rebase
+  and diff-cover reports 85% total diff coverage against `origin/main`
+  (`core/view/src/inspector_window.cpp` 100%;
+  `core/view/platform/mac/window_host_mac.mm` has 2 defensive teardown lines
+  not covered by the focused local coverage path). The behavior-bearing
+  `InspectorWindow::show()` null-host guard is covered locally through the
+  inspector host-factory override; hosted Codecov remains the final PR-side
+  coverage gate after the final push.
 - Claude review reported no correctness blockers. RepoPrompt review found a
   null-host crash in `InspectorWindow::show()`, an overstrict live WebView
   attach assertion, and a silent plugin-example WebView-backend failure path;

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -473,8 +473,8 @@ Closure slice:
   public docs do not imply first-party non-Apple embedding exists today.
 
 Native-window local validation:
-- Rebased onto `origin/main` at `65b48dfa6` and refreshed the required SDK
-  minor bump to `0.217.0`.
+- Rebased onto `origin/main` at `0939e9b19` and refreshed the required SDK
+  minor bump to `0.218.0`.
 - Configured Release with WebView enabled and GPU off:
   `cmake -S . -B build-native-window -DCMAKE_BUILD_TYPE=Release
   -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=ON
@@ -500,7 +500,7 @@ Native-window local validation:
 - `tools/scripts/gates.sh origin/main` passed skill-sync, version-bump,
   compat-sync, node-ABI, and deps-audit gates.
 - `version_bump_check.py --base origin/main --head HEAD --mode apply` applied
-  the required SDK minor bump to `0.217.0` after the inspector host-factory
+  the required SDK minor bump to `0.218.0` after the inspector host-factory
   override made the patch a public header/API change.
 - Coverage note: the stock `tools/scripts/local_diff_cover.sh` wrapper still
   configures the GPU examples path and fails locally without Skia. The same

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -28,7 +28,7 @@ implementation notes, tests, coverage proof, and PR link before shipping.
 | Threads and processes | `feature/platform-threads-processes` | `pulp-platform-threads-processes` | Merged via PR #2815 | Canonical platform process surface, runtime blocking wrapper, tested launch/wait/cancel/output/IPC behavior, no unneeded current-process or timer additions |
 | Native event loop | `feature/platform-main-thread-dispatch` | `pulp-platform-main-thread-dispatch` | Merged via PR [#2825](https://github.com/danielraffel/pulp/pull/2825) as `9c96f3dfa` | Cross-platform main-thread dispatcher contract, platform registrations where available, sync/async dispatch tests, EventLoop thread-id race fixed |
 | OSC | `feature/platform-osc` | `pulp-platform-osc` | Merged via PR [#2822](https://github.com/danielraffel/pulp/pull/2822) as `bbc1506ed` | Typed bundle send/receive, listener filtering using existing address matching, invalid-packet error callback, exclusive UDP receiver binding, focused UDP and pure parser tests |
-| Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; local rebase/validation in progress after #2822 merge | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
+| Native windows | `feature/platform-native-window-embedding` | `pulp-platform-native-window-embedding` | PR [#2844](https://github.com/danielraffel/pulp/pull/2844) open; locally rebased and validated on `origin/main` `c72ad330b` after #2822 merged; SDK `0.254.0`; Claude plugin `0.122.0` | First-party non-Apple host/plugin embedding path or explicit supported-platform contract, child attach/bounds/detach tests, docs updated to avoid overclaiming |
 
 Validation expectations for each PR:
 - Add or update focused unit tests for every new public behavior.
@@ -473,56 +473,46 @@ Closure slice:
   public docs do not imply first-party non-Apple embedding exists today.
 
 Native-window local validation:
-- Rebased onto `origin/main` at `0939e9b19` and refreshed the required SDK
-  minor bump to `0.218.0`.
+- Rebased onto `origin/main` at `c72ad330b` after #2822 merged and the v0.253.0
+  changelog landed. Historical status-only report commits were dropped during
+  rebase; this section is the current source of validation truth for #2844.
+- `version_bump_check.py --base origin/main --config
+  tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat
+  --accept-intent-trailers` passes with SDK `0.254.0` and Claude plugin
+  `0.122.0`.
+- `skill_sync_check.py --base origin/main --head HEAD --mode report` passes
+  with the `webview-ui` skill update.
+- `python3 tools/scripts/test_audit_top_level.py` passed 11/11 and
+  `python3 tools/audit.py --` passed.
 - Configured Release with WebView enabled and GPU off:
   `cmake -S . -B build-native-window -DCMAKE_BUILD_TYPE=Release
-  -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=ON
-  -DPULP_BUILD_WEBVIEW=ON`.
+  -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_WEBVIEW=ON -DPULP_BUILD_TESTS=ON
+  -DPULP_BUILD_EXAMPLES=ON`.
 - Built the focused targets: `pulp-test-view-host-bridge`,
   `pulp-test-webview`, `pulp-webview-palette`, and
   `PulpWebViewPlugin_Standalone`.
-- A rebase sweep exposed an intermittent macOS deferred-click crash in the
-  view-host bridge tests. The queued click block no longer captures/derefs the
-  MRC `PulpView` object after teardown, and the early-teardown regression test
-  now uses a hidden host like the neighboring headless event tests.
 - `./build-native-window/test/pulp-test-view-host-bridge --reporter compact`
-  passed 81/81 assertions across 9 cases; a stress sweep passed 30/30 repeated
-  runs after the deferred-click hardening.
+  passed 81/81 assertions across 9 cases.
 - `./build-native-window/test/pulp-test-webview --reporter compact` passed
   5/7 test cases, with 2 local WebView readiness skips where the host
   environment never reached callback-ready state, and 84/84 assertions passed.
 - Focused CTest over WebView/native-child attach cases passed 7/7 after
   excluding generated `_NOT_BUILT` placeholders; 2 live WebView readiness cases
   skipped in this local environment.
-- `tools/check-docs.sh` passed with existing repository warnings.
-- `git diff --check` passed.
-- `tools/scripts/gates.sh origin/main` passed skill-sync, version-bump,
-  compat-sync, node-ABI, and deps-audit gates.
-- `version_bump_check.py --base origin/main --head HEAD --mode apply` applied
-  the required SDK minor bump to `0.218.0` after the inspector host-factory
-  override made the patch a public header/API change.
-- Coverage note: the stock `tools/scripts/local_diff_cover.sh` wrapper still
-  configures the GPU examples path and fails locally without Skia. The same
-  coverage pipeline was run manually with `PULP_ENABLE_COVERAGE=ON` and
-  `PULP_ENABLE_GPU=OFF` in `build-cov-native-window`; focused coverage CTest
-  passed the three native-window contract tests after the `2d8f004a` rebase
-  and diff-cover reports 85% total diff coverage against `origin/main`
-  (`core/view/src/inspector_window.cpp` 100%;
-  `core/view/platform/mac/window_host_mac.mm` has 2 defensive teardown lines
-  not covered by the focused local coverage path). The behavior-bearing
-  `InspectorWindow::show()` null-host guard is covered locally through the
-  inspector host-factory override; hosted Codecov remains the final PR-side
-  coverage gate after the final push.
-- Claude review on the `2d8f004a` rebase reported no P0/P1/P2 correctness
+- A prior coverage refresh on this branch used the same coverage pipeline with
+  `PULP_ENABLE_COVERAGE=ON` and `PULP_ENABLE_GPU=OFF` in
+  `build-cov-native-window`; focused coverage CTest passed the native-window
+  contract tests and diff-cover reported 85% total diff coverage. The stock
+  local wrapper still enters broad GPU/example coverage paths that are not
+  reliable in this checkout; hosted Codecov remains the PR-side coverage gate.
+- Claude review on the earlier rebased branch reported no P0/P1/P2 correctness
   blockers. Two non-blocking hardening notes were addressed before final push:
   the mac deferred-click handler invariant is documented in code, and native
-  child test fake handles are per-instance instead of static sentinels. Focused
-  `pulp-test-view-host-bridge` build and direct test reran after those changes.
-  Earlier RepoPrompt review found a null-host crash in
-  `InspectorWindow::show()`, an overstrict live WebView attach assertion, and a
-  silent plugin-example WebView-backend failure path; all three were fixed and
-  the focused build/test/docs checks were rerun.
+  child test fake handles are per-instance instead of static sentinels. Earlier
+  RepoPrompt review found a null-host crash in `InspectorWindow::show()`, an
+  overstrict live WebView attach assertion, and a silent plugin-example
+  WebView-backend failure path; all three were fixed and the focused
+  build/test/docs checks were rerun.
 - SSH-backed Windows/Ubuntu testing is intentionally out of scope for this
   focused closure pass; rely on GitHub-hosted platform checks after PR
   submission.

--- a/docs/reports/platform-capability-closure-plan.md
+++ b/docs/reports/platform-capability-closure-plan.md
@@ -514,10 +514,15 @@ Native-window local validation:
   `InspectorWindow::show()` null-host guard is covered locally through the
   inspector host-factory override; hosted Codecov remains the final PR-side
   coverage gate after the final push.
-- Claude review reported no correctness blockers. RepoPrompt review found a
-  null-host crash in `InspectorWindow::show()`, an overstrict live WebView
-  attach assertion, and a silent plugin-example WebView-backend failure path;
-  all three were fixed and the focused build/test/docs checks were rerun.
+- Claude review on the `2d8f004a` rebase reported no P0/P1/P2 correctness
+  blockers. Two non-blocking hardening notes were addressed before final push:
+  the mac deferred-click handler invariant is documented in code, and native
+  child test fake handles are per-instance instead of static sentinels. Focused
+  `pulp-test-view-host-bridge` build and direct test reran after those changes.
+  Earlier RepoPrompt review found a null-host crash in
+  `InspectorWindow::show()`, an overstrict live WebView attach assertion, and a
+  silent plugin-example WebView-backend failure path; all three were fixed and
+  the focused build/test/docs checks were rerun.
 - SSH-backed Windows/Ubuntu testing is intentionally out of scope for this
   focused closure pass; rely on GitHub-hosted platform checks after PR
   submission.

--- a/docs/status/support-matrix.yaml
+++ b/docs/status/support-matrix.yaml
@@ -531,6 +531,35 @@ platform_maturity:
       has_backend(). No native provider ships yet for
       Windows/Linux/Android; callers register their own backend or
       receive explicit no-selection.
+  native_child_view_embedding_window_host:
+    status: partial
+    notes: >-
+      Standalone native child-view embedding is an instance capability, not a
+      blanket platform guarantee. Built-in `WindowHost` embedding is macOS
+      only; built-in iOS `WindowHost` does not currently expose child-view
+      handles. Windows/Linux/Android require a host-registered
+      `WindowHost::Factory` that returns non-null native handles and implements
+      attach/bounds/detach.
+    platforms:
+      macos: usable
+      ios: unsupported
+      windows: partial
+      linux: partial
+      android: partial
+  native_child_view_embedding_plugin_view_host:
+    status: partial
+    notes: >-
+      Plugin editor native child-view embedding is built in on macOS and iOS.
+      Windows/Linux/Android require a host-registered
+      `PluginViewHost::Factory` that returns non-null native handles and
+      implements attach/bounds/detach; no first-party host implementation ships
+      yet for those platforms.
+    platforms:
+      macos: usable
+      ios: usable
+      windows: partial
+      linux: partial
+      android: partial
 
 input:
   pointer_events:

--- a/examples/webview-monaco/main.cpp
+++ b/examples/webview-monaco/main.cpp
@@ -38,8 +38,19 @@ int main() {
   window_options.height = kWindowHeight;
 
   auto window = WindowHost::create(root, window_options);
-  if (!window || !window->native_content_view_handle()) {
-    std::cerr << "Failed to create Monaco host window\n";
+  if (!window) {
+    if (!WindowHost::has_factory()) {
+      std::cerr << "Failed to create Monaco host window: WindowHost::create "
+                   "returned nullptr and no WindowHost::Factory is registered\n";
+    } else {
+      std::cerr << "Failed to create Monaco host window: registered "
+                   "WindowHost::Factory returned nullptr\n";
+    }
+    return 1;
+  }
+  if (!window->native_content_view_handle()) {
+    std::cerr << "Failed to create Monaco host window: WindowHost does not expose "
+                 "a native content-view handle for child embedding\n";
     return 1;
   }
 
@@ -85,7 +96,9 @@ int main() {
                                                        : static_cast<float>(kWindowHeight);
   if (!window->attach_native_child_view(
           panel->native_handle(), 0, 0, initial_width, initial_height)) {
-    std::cerr << "Failed to attach Monaco WebView\n";
+    std::cerr << "Failed to attach Monaco WebView: WindowHost rejected native "
+                 "child embedding; the concrete host must override "
+                 "attach/bounds/detach for this example\n";
     return 1;
   }
 

--- a/examples/webview-palette/main.cpp
+++ b/examples/webview-palette/main.cpp
@@ -46,8 +46,19 @@ int main() {
   main_opts.width = 520;
   main_opts.height = 320;
   auto main_window = WindowHost::create(main_root, main_opts);
-  if (!main_window || !main_window->native_window_handle()) {
-    std::cerr << "Failed to create main host window\n";
+  if (!main_window) {
+    if (!WindowHost::has_factory()) {
+      std::cerr << "Failed to create main host window: WindowHost::create "
+                   "returned nullptr and no WindowHost::Factory is registered\n";
+    } else {
+      std::cerr << "Failed to create main host window: registered "
+                   "WindowHost::Factory returned nullptr\n";
+    }
+    return 1;
+  }
+  if (!main_window->native_window_handle()) {
+    std::cerr << "Failed to create main host window: WindowHost does not expose "
+                 "a native window handle for parented palette creation\n";
     return 1;
   }
 
@@ -63,8 +74,19 @@ int main() {
   palette_opts.window_type = &palette_type;
   palette_opts.parent_native_handle = main_window->native_window_handle();
   auto palette_window = WindowHost::create(palette_root, palette_opts);
-  if (!palette_window || !palette_window->native_content_view_handle()) {
-    std::cerr << "Failed to create palette host window\n";
+  if (!palette_window) {
+    if (!WindowHost::has_factory()) {
+      std::cerr << "Failed to create palette host window: WindowHost::create "
+                   "returned nullptr and no WindowHost::Factory is registered\n";
+    } else {
+      std::cerr << "Failed to create palette host window: registered "
+                   "WindowHost::Factory returned nullptr\n";
+    }
+    return 1;
+  }
+  if (!palette_window->native_content_view_handle()) {
+    std::cerr << "Failed to create palette host window: WindowHost does not expose "
+                 "a native content-view handle for child embedding\n";
     return 1;
   }
 
@@ -100,7 +122,9 @@ int main() {
 
   if (!palette_window->attach_native_child_view(
           palette_panel->native_handle(), 0, 0, palette_opts.width, palette_opts.height)) {
-    std::cerr << "Failed to attach WebView into palette host\n";
+    std::cerr << "Failed to attach WebView into palette host: WindowHost rejected "
+                 "native child embedding; the concrete host must override "
+                 "attach/bounds/detach for this example\n";
     return 1;
   }
 

--- a/examples/webview-plugin/webview_plugin.hpp
+++ b/examples/webview-plugin/webview_plugin.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <pulp/format/processor.hpp>
+#include <pulp/runtime/log.hpp>
 #include <pulp/view/plugin_view_host.hpp>
 #include <pulp/view/theme.hpp>
 #include <pulp/view/view.hpp>
@@ -138,6 +139,9 @@ public:
         options.initial_html = kWebViewLoadingHtml;
         panel_ = view::WebViewPanel::create(options);
         if (!panel_) {
+            runtime::log_warn(
+                "PulpWebViewPlugin: native WebView backend unavailable; "
+                "editor will use the fallback native background");
             return;
         }
 
@@ -173,6 +177,12 @@ public:
             static_cast<float>(size.height));
         if (attached_) {
             sync_to_host();
+        } else if (!warned_attach_failure_) {
+            warned_attach_failure_ = true;
+            runtime::log_warn(
+                "PulpWebViewPlugin: PluginViewHost rejected native child "
+                "embedding; this platform host must provide attach/bounds/"
+                "detach support for embedded WebViews");
         }
     }
 
@@ -205,6 +215,7 @@ public:
 private:
     std::unique_ptr<view::WebViewPanel> panel_;
     bool attached_ = false;
+    bool warned_attach_failure_ = false;
 };
 
 class WebViewEditorRoot final : public view::View {

--- a/test/test_view_host_bridge.cpp
+++ b/test/test_view_host_bridge.cpp
@@ -10,12 +10,141 @@
 // safe.
 
 #include <catch2/catch_test_macros.hpp>
+#include <pulp/view/inspector_window.hpp>
 #include <pulp/view/plugin_view_host.hpp>
 #include <pulp/view/screenshot.hpp>
 #include <pulp/view/view.hpp>
 #include <pulp/view/window_host.hpp>
 
+#include <utility>
+
 using namespace pulp::view;
+
+namespace {
+
+struct EmbeddedBounds {
+    float x = 0.0f;
+    float y = 0.0f;
+    float width = 0.0f;
+    float height = 0.0f;
+};
+
+class EmbeddingWindowHost final : public WindowHost {
+public:
+    void show() override { visible_ = true; }
+    void hide() override { visible_ = false; }
+    bool is_visible() const override { return visible_; }
+    void repaint() override { ++repaint_count_; }
+    void set_close_callback(std::function<void()> cb) override {
+        close_callback_ = std::move(cb);
+    }
+    void run_event_loop() override {}
+
+    void* native_window_handle() const override { return window_handle_; }
+    void* native_content_view_handle() const override { return content_handle_; }
+
+    bool attach_native_child_view(void* child_view,
+                                  float x,
+                                  float y,
+                                  float width,
+                                  float height) override {
+        if (!child_view) return false;
+        child_ = child_view;
+        bounds_ = {x, y, width, height};
+        attached_ = true;
+        return true;
+    }
+
+    bool set_native_child_view_bounds(void* child_view,
+                                      float x,
+                                      float y,
+                                      float width,
+                                      float height) override {
+        if (!attached_ || child_view != child_) return false;
+        bounds_ = {x, y, width, height};
+        return true;
+    }
+
+    void detach_native_child_view(void* child_view) override {
+        if (child_view == child_) {
+            child_ = nullptr;
+            attached_ = false;
+        }
+    }
+
+    bool attached() const { return attached_; }
+    void* child() const { return child_; }
+    const EmbeddedBounds& bounds() const { return bounds_; }
+
+private:
+    inline static int window_sentinel_;
+    inline static int content_sentinel_;
+
+    void* window_handle_ = &window_sentinel_;
+    void* content_handle_ = &content_sentinel_;
+    void* child_ = nullptr;
+    EmbeddedBounds bounds_{};
+    std::function<void()> close_callback_;
+    int repaint_count_ = 0;
+    bool visible_ = false;
+    bool attached_ = false;
+};
+
+class EmbeddingPluginViewHost final : public PluginViewHost {
+public:
+    NativeViewHandle native_handle() override { return host_handle_; }
+    void attach_to_parent(NativeViewHandle parent) override { parent_ = parent; }
+    void detach() override { parent_ = nullptr; attached_ = false; child_ = nullptr; }
+    void repaint() override { ++repaint_count_; }
+    void set_size(uint32_t width, uint32_t height) override { size_ = {width, height}; }
+    Size get_size() const override { return size_; }
+
+    bool attach_native_child_view(NativeViewHandle child_view,
+                                  float x,
+                                  float y,
+                                  float width,
+                                  float height) override {
+        if (!child_view) return false;
+        child_ = child_view;
+        bounds_ = {x, y, width, height};
+        attached_ = true;
+        return true;
+    }
+
+    bool set_native_child_view_bounds(NativeViewHandle child_view,
+                                      float x,
+                                      float y,
+                                      float width,
+                                      float height) override {
+        if (!attached_ || child_view != child_) return false;
+        bounds_ = {x, y, width, height};
+        return true;
+    }
+
+    void detach_native_child_view(NativeViewHandle child_view) override {
+        if (child_view == child_) {
+            child_ = nullptr;
+            attached_ = false;
+        }
+    }
+
+    bool attached() const { return attached_; }
+    NativeViewHandle child() const { return child_; }
+    const EmbeddedBounds& bounds() const { return bounds_; }
+
+private:
+    inline static int host_sentinel_;
+
+    NativeViewHandle host_handle_ = &host_sentinel_;
+    NativeViewHandle parent_ = nullptr;
+    NativeViewHandle child_ = nullptr;
+    EmbeddedBounds bounds_{};
+    Size size_{400, 300};
+    int repaint_count_ = 0;
+    bool attached_ = false;
+};
+
+} // namespace
 
 TEST_CASE("View host bridges: registration APIs are safe on all platforms",
           "[view][hosts][issue-299]") {
@@ -26,6 +155,78 @@ TEST_CASE("View host bridges: registration APIs are safe on all platforms",
     REQUIRE_FALSE(has_screenshot_provider());
     REQUIRE_FALSE(WindowHost::has_factory());
     REQUIRE_FALSE(PluginViewHost::has_factory());
+}
+
+TEST_CASE("Host child embedding contract is implementable by concrete hosts",
+          "[view][hosts][native-child]") {
+    EmbeddingWindowHost window_host;
+    int window_child_sentinel = 0;
+    auto child = static_cast<void*>(&window_child_sentinel);
+    REQUIRE(window_host.native_window_handle() != nullptr);
+    REQUIRE(window_host.native_content_view_handle() != nullptr);
+    REQUIRE_FALSE(window_host.attach_native_child_view(nullptr, 1.0f, 2.0f, 3.0f, 4.0f));
+    REQUIRE(window_host.attach_native_child_view(child, 1.0f, 2.0f, 3.0f, 4.0f));
+    REQUIRE(window_host.attached());
+    REQUIRE(window_host.child() == child);
+    REQUIRE(window_host.bounds().x == 1.0f);
+    REQUIRE(window_host.bounds().y == 2.0f);
+    REQUIRE(window_host.bounds().width == 3.0f);
+    REQUIRE(window_host.bounds().height == 4.0f);
+    int wrong_window_child_sentinel = 0;
+    REQUIRE_FALSE(window_host.set_native_child_view_bounds(
+        static_cast<void*>(&wrong_window_child_sentinel), 5.0f, 6.0f, 7.0f, 8.0f));
+    REQUIRE(window_host.set_native_child_view_bounds(child, 5.0f, 6.0f, 7.0f, 8.0f));
+    REQUIRE(window_host.bounds().x == 5.0f);
+    REQUIRE(window_host.bounds().y == 6.0f);
+    REQUIRE(window_host.bounds().width == 7.0f);
+    REQUIRE(window_host.bounds().height == 8.0f);
+    window_host.detach_native_child_view(child);
+    REQUIRE_FALSE(window_host.attached());
+
+    EmbeddingPluginViewHost plugin_host;
+    int plugin_child_sentinel = 0;
+    auto plugin_child = static_cast<NativeViewHandle>(&plugin_child_sentinel);
+    REQUIRE(plugin_host.native_handle() != nullptr);
+    REQUIRE_FALSE(plugin_host.attach_native_child_view(
+        nullptr, 9.0f, 10.0f, 11.0f, 12.0f));
+    REQUIRE(plugin_host.attach_native_child_view(plugin_child, 9.0f, 10.0f, 11.0f, 12.0f));
+    REQUIRE(plugin_host.attached());
+    REQUIRE(plugin_host.child() == plugin_child);
+    REQUIRE(plugin_host.bounds().x == 9.0f);
+    REQUIRE(plugin_host.bounds().y == 10.0f);
+    REQUIRE(plugin_host.bounds().width == 11.0f);
+    REQUIRE(plugin_host.bounds().height == 12.0f);
+    int wrong_plugin_child_sentinel = 0;
+    REQUIRE_FALSE(plugin_host.set_native_child_view_bounds(
+        static_cast<NativeViewHandle>(&wrong_plugin_child_sentinel), 13.0f, 14.0f, 15.0f, 16.0f));
+    REQUIRE(plugin_host.set_native_child_view_bounds(plugin_child, 13.0f, 14.0f, 15.0f, 16.0f));
+    REQUIRE(plugin_host.bounds().x == 13.0f);
+    REQUIRE(plugin_host.bounds().y == 14.0f);
+    REQUIRE(plugin_host.bounds().width == 15.0f);
+    REQUIRE(plugin_host.bounds().height == 16.0f);
+    plugin_host.detach_native_child_view(plugin_child);
+    REQUIRE_FALSE(plugin_host.attached());
+}
+
+TEST_CASE("InspectorWindow show is safe when host creation returns nullptr",
+          "[view][hosts][native-child]") {
+    View inspected_root;
+    bool factory_called = false;
+    InspectorWindow inspector(
+        inspected_root,
+        nullptr,
+        nullptr,
+        [&](View& root, const WindowOptions& options) -> std::unique_ptr<WindowHost> {
+            factory_called = true;
+            REQUIRE(&root != &inspected_root);
+            REQUIRE(options.title == "Inspector");
+            return nullptr;
+        });
+
+    inspector.show();
+
+    REQUIRE(factory_called);
+    REQUIRE_FALSE(inspector.is_visible());
 }
 
 #if !defined(__APPLE__)
@@ -104,6 +305,17 @@ TEST_CASE("Non-Apple PluginViewHost::create: no factory -> nullptr",
     REQUIRE(PluginViewHost::create(root, opts) == nullptr);
 }
 
+TEST_CASE("Non-Apple InspectorWindow show is safe without WindowHost factory",
+          "[view][hosts][native-child]") {
+    WindowHost::clear_factory();
+    View inspected_root;
+    InspectorWindow inspector(inspected_root);
+
+    inspector.show();
+
+    REQUIRE_FALSE(inspector.is_visible());
+}
+
 TEST_CASE("Non-Apple host factories propagate root host references",
           "[view][hosts][issue-651]") {
     WindowHost::clear_factory();
@@ -116,6 +328,11 @@ TEST_CASE("Non-Apple host factories propagate root host references",
     auto window_host = WindowHost::create(window_root, WindowOptions{});
     REQUIRE(window_host != nullptr);
     REQUIRE(window_root.window_host() == window_host.get());
+    int child_sentinel = 0;
+    auto child = static_cast<void*>(&child_sentinel);
+    REQUIRE_FALSE(window_host->attach_native_child_view(child, 1.0f, 2.0f, 3.0f, 4.0f));
+    REQUIRE_FALSE(window_host->set_native_child_view_bounds(child, 5.0f, 6.0f, 7.0f, 8.0f));
+    window_host->detach_native_child_view(child);
 
     View plugin_root;
     PluginViewHost::set_factory([](View&, const PluginViewHost::Options&) {
@@ -125,10 +342,67 @@ TEST_CASE("Non-Apple host factories propagate root host references",
     REQUIRE(plugin_host != nullptr);
     REQUIRE(plugin_root.plugin_view_host() == plugin_host.get());
 
-    auto child = reinterpret_cast<NativeViewHandle>(0x1);
-    REQUIRE_FALSE(plugin_host->attach_native_child_view(child, 1.0f, 2.0f, 3.0f, 4.0f));
-    REQUIRE_FALSE(plugin_host->set_native_child_view_bounds(child, 5.0f, 6.0f, 7.0f, 8.0f));
-    plugin_host->detach_native_child_view(child);
+    int plugin_child_sentinel = 0;
+    auto plugin_child = static_cast<NativeViewHandle>(&plugin_child_sentinel);
+    REQUIRE_FALSE(plugin_host->attach_native_child_view(plugin_child, 1.0f, 2.0f, 3.0f, 4.0f));
+    REQUIRE_FALSE(plugin_host->set_native_child_view_bounds(plugin_child, 5.0f, 6.0f, 7.0f, 8.0f));
+    plugin_host->detach_native_child_view(plugin_child);
+
+    PluginViewHost::clear_factory();
+    WindowHost::clear_factory();
+}
+
+TEST_CASE("Non-Apple host factories can supply native child embedding",
+          "[view][hosts][native-child]") {
+    WindowHost::clear_factory();
+    PluginViewHost::clear_factory();
+
+    View window_root;
+    WindowHost::set_factory([](View&, const WindowOptions&) {
+        return std::make_unique<EmbeddingWindowHost>();
+    });
+    auto window_host = WindowHost::create(window_root, WindowOptions{});
+    REQUIRE(window_host != nullptr);
+    REQUIRE(window_root.window_host() == window_host.get());
+    auto* embedding_window = dynamic_cast<EmbeddingWindowHost*>(window_host.get());
+    REQUIRE(embedding_window != nullptr);
+    REQUIRE(embedding_window->native_window_handle() != nullptr);
+    REQUIRE(embedding_window->native_content_view_handle() != nullptr);
+
+    int child_sentinel = 0;
+    auto child = static_cast<void*>(&child_sentinel);
+    REQUIRE(window_host->attach_native_child_view(child, 1.0f, 2.0f, 3.0f, 4.0f));
+    REQUIRE(embedding_window->attached());
+    REQUIRE(window_host->set_native_child_view_bounds(child, 5.0f, 6.0f, 7.0f, 8.0f));
+    REQUIRE(embedding_window->bounds().x == 5.0f);
+    REQUIRE(embedding_window->bounds().y == 6.0f);
+    REQUIRE(embedding_window->bounds().width == 7.0f);
+    REQUIRE(embedding_window->bounds().height == 8.0f);
+    window_host->detach_native_child_view(child);
+    REQUIRE_FALSE(embedding_window->attached());
+
+    View plugin_root;
+    PluginViewHost::set_factory([](View&, const PluginViewHost::Options&) {
+        return std::make_unique<EmbeddingPluginViewHost>();
+    });
+    auto plugin_host = PluginViewHost::create(plugin_root, PluginViewHost::Size{640, 360});
+    REQUIRE(plugin_host != nullptr);
+    REQUIRE(plugin_root.plugin_view_host() == plugin_host.get());
+    auto* embedding_plugin = dynamic_cast<EmbeddingPluginViewHost*>(plugin_host.get());
+    REQUIRE(embedding_plugin != nullptr);
+    REQUIRE(embedding_plugin->native_handle() != nullptr);
+
+    int plugin_child_sentinel = 0;
+    auto plugin_child = static_cast<NativeViewHandle>(&plugin_child_sentinel);
+    REQUIRE(plugin_host->attach_native_child_view(plugin_child, 9.0f, 10.0f, 11.0f, 12.0f));
+    REQUIRE(embedding_plugin->attached());
+    REQUIRE(plugin_host->set_native_child_view_bounds(plugin_child, 13.0f, 14.0f, 15.0f, 16.0f));
+    REQUIRE(embedding_plugin->bounds().x == 13.0f);
+    REQUIRE(embedding_plugin->bounds().y == 14.0f);
+    REQUIRE(embedding_plugin->bounds().width == 15.0f);
+    REQUIRE(embedding_plugin->bounds().height == 16.0f);
+    plugin_host->detach_native_child_view(plugin_child);
+    REQUIRE_FALSE(embedding_plugin->attached());
 
     PluginViewHost::clear_factory();
     WindowHost::clear_factory();

--- a/test/test_view_host_bridge.cpp
+++ b/test/test_view_host_bridge.cpp
@@ -77,9 +77,8 @@ public:
     const EmbeddedBounds& bounds() const { return bounds_; }
 
 private:
-    inline static int window_sentinel_;
-    inline static int content_sentinel_;
-
+    int window_sentinel_ = 0;
+    int content_sentinel_ = 0;
     void* window_handle_ = &window_sentinel_;
     void* content_handle_ = &content_sentinel_;
     void* child_ = nullptr;
@@ -133,8 +132,7 @@ public:
     const EmbeddedBounds& bounds() const { return bounds_; }
 
 private:
-    inline static int host_sentinel_;
-
+    int host_sentinel_ = 0;
     NativeViewHandle host_handle_ = &host_sentinel_;
     NativeViewHandle parent_ = nullptr;
     NativeViewHandle child_ = nullptr;

--- a/test/test_view_host_bridge_mac.mm
+++ b/test/test_view_host_bridge_mac.mm
@@ -487,6 +487,7 @@ TEST_CASE("PulpView deferred click is cancelled when bridge/engine are torn down
             opts.height = 100.0f;
             opts.resizable = false;
             opts.use_gpu = false;
+            opts.initially_hidden = true;
 
             auto host = WindowHost::create(root, opts);
             REQUIRE(host != nullptr);
@@ -508,7 +509,6 @@ TEST_CASE("PulpView deferred click is cancelled when bridge/engine are torn down
             )");
             REQUIRE(bridge.widget("clear") != nullptr);
 
-            host->show();
             auto* nswindow = (__bridge NSWindow*)host->native_window_handle();
             REQUIRE(nswindow != nil);
             auto* contentView = nswindow.contentView;

--- a/test/test_web_view.cpp
+++ b/test/test_web_view.cpp
@@ -454,7 +454,10 @@ TEST_CASE("WebViewPanel can attach to a WindowHost native content view", "[view]
 
     auto host = WindowHost::create(root, window_options);
     if (!host) {
-        SKIP("WindowHost is not available on this platform");
+        if (!WindowHost::has_factory()) {
+            SKIP("WindowHost unavailable: create() returned nullptr and no WindowHost::Factory is registered");
+        }
+        SKIP("WindowHost unavailable: registered WindowHost::Factory returned nullptr");
     }
 
     auto panel = WebViewPanel::create();
@@ -466,12 +469,24 @@ TEST_CASE("WebViewPanel can attach to a WindowHost native content view", "[view]
         SKIP("WebView never became ready in this environment");
     }
 
-    if (!host->native_window_handle() || !host->native_content_view_handle()) {
-        SKIP("WindowHost does not expose native embedding handles on this platform");
+    if (!panel->native_handle()) {
+        SKIP("WebViewPanel exists but does not expose a native child-view handle in this environment");
     }
 
-    REQUIRE(host->attach_native_child_view(panel->native_handle(), 0, 0, 320, 200));
-    REQUIRE(host->set_native_child_view_bounds(panel->native_handle(), 16, 12, 300, 180));
+    if (!host->native_window_handle() || !host->native_content_view_handle()) {
+        SKIP("WindowHost exists but does not expose native child-view handles; WebView backend availability is separate from host embedding support");
+    }
+
+    auto child_handle = panel->native_handle();
+    const bool attached = host->attach_native_child_view(child_handle, 0, 0, 320, 200);
+#if defined(__APPLE__)
+    REQUIRE(attached);
+#else
+    if (!attached) {
+        SKIP("WindowHost exposes native handles but rejected native child embedding in this environment");
+    }
+#endif
+    REQUIRE(host->set_native_child_view_bounds(child_handle, 16, 12, 300, 180));
 
     std::string last_message_type;
     panel->set_message_handler([&](const WebViewMessage& message) -> std::string {


### PR DESCRIPTION
## Summary
- Clarify native child embedding support boundaries across `WindowHost`, `PluginViewHost`, and WebView.
- Add an `InspectorWindow` host factory seam and null-host guard.
- Add contract tests for native child embedding and safer WebView/example failure handling.
- Harden macOS deferred-click teardown so callback dispatch does not capture or dereference the Objective-C view after early teardown.

## Validation
- Rebased onto `origin/main` at `f10a6e32e`; pushed head is `305c5a0e4`.
- Version surfaces pass with SDK `0.254.0` and Claude plugin `0.122.0`.
- `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD --mode report`
- `python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat --accept-intent-trailers`
- `python3 tools/scripts/test_audit_top_level.py` passed 11/11.
- `python3 tools/audit.py --` passed.
- Focused Release/GPU-off configure: `cmake -S . -B build-native-window -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_WEBVIEW=ON -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=ON`.
- Focused Release build passed for `pulp-test-view-host-bridge`, `pulp-test-webview`, `pulp-webview-palette`, and `PulpWebViewPlugin_Standalone`.
- Direct `pulp-test-view-host-bridge --reporter compact` passed: 9 test cases, 81/81 assertions.
- Direct `pulp-test-webview --reporter compact` passed 5/7 test cases with 2 readiness skips and 84/84 assertions.
- Focused CTest passed 7/7 after excluding generated `NOT_BUILT` placeholders: `ctest --test-dir build-native-window --output-on-failure -R 'ViewHost|view-host|native.child|Native child|WebView|webview' -E 'NOT_BUILT'`.
- `tools/check-docs.sh` passed on the post-#2971 base with the current warning set.
- Release flags verified for `pulp-test-view-host-bridge` and `pulp-test-webview`: `-O3 -DNDEBUG -std=c++20 -arch arm64 -fPIE`.
- `git diff --check` and `git diff --cached --check` passed.
- Pre-push gates passed; local broad diff-cover was deliberately skipped with `PULP_DISABLE_PREPUSH_DIFF_COVER=1` because hosted Codecov remains the merge gate.

Focused pass note: no SSH Windows/Ubuntu lanes were run manually, per project direction; rely on local macOS validation and GitHub-hosted checks.

<!-- whence {"labels": ["1·codex", "2·m3", "3·SYLF · Delivery", "4·vgpu analysis", "5·unresolved"], "prov": {"agent": "codex", "host": "m3", "workspace": "SYLF · Delivery", "tab": "vgpu analysis", "launcher": "unresolved", "terminal": "cmux", "terminal_address": "B475CC68-FE29-4940-919B-5F16E60811EF", "route": "unresolved", "origin_state": "known", "path": "/Volumes/Workshop/Code/pulp", "session": "01a044c8-8f81-7911-86d3-3d02ef5f829c", "resume": "codex resume 01a044c8-8f81-7911-86d3-3d02ef5f829c", "jump": "cmux surface focus B475CC68-FE29-4940-919B-5F16E60811EF", "relaunch": "cmux surface resume get \u002d\u002dsurface B475CC68-FE29-4940-919B-5F16E60811EF"}} -->

---
### 🔎 Provenance

|  |  |
|:--|:--|
| **Agent** | `codex` |
| **Machine** | `m3` |
| **Workspace** | `SYLF · Delivery` |
| **Tab** | vgpu analysis |
| **Launcher** | `unresolved` |
| **Route** | `unresolved` |
| **Terminal** | `cmux` |
| **Terminal address** | `B475CC68-FE29-4940-919B-5F16E60811EF` |
| **Origin state** | `known` |
| **Directory** | `/Volumes/Workshop/Code/pulp` |
| **Session** | `01a044c8-8f81-7911-86d3-3d02ef5f829c` |

**Resume**
```
codex resume 01a044c8-8f81-7911-86d3-3d02ef5f829c
```
**Jump to this tab**
```
cmux surface focus B475CC68-FE29-4940-919B-5F16E60811EF
```
**Relaunch (any agent)**
```
cmux surface resume get --surface B475CC68-FE29-4940-919B-5F16E60811EF
```

<sub>stamped 2026-08-29 18:47 UTC</sub>
<!-- /whence -->