### PR TITLE
feat(macos-plan): Batch G (partial) — Compressor sidechain HPF + lookahead (item 2.4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.215.0
+    VERSION 0.216.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/signal/include/pulp/signal/compressor.hpp
+++ b/core/signal/include/pulp/signal/compressor.hpp
@@ -1,12 +1,29 @@
 #pragma once
 
+#include <pulp/signal/biquad.hpp>
+#include <pulp/signal/delay_line.hpp>
+
 #include <cmath>
 #include <algorithm>
 
 namespace pulp::signal {
 
-// Feed-forward compressor with adjustable attack/release
+// Feed-forward compressor with adjustable attack/release.
 // Real-time safe. Operates on single samples.
+//
+// Sidechain HPF (item 2.4 of macOS plan): when `set_sidechain_hpf_hz`
+// is non-zero, the level-detection path runs the sidechain signal
+// through a high-pass biquad before envelope-following. This makes
+// the compressor less reactive to bass content — useful for
+// preventing pumping on a bass-heavy mix or for sidechain-from-kick
+// patterns where the kick's fundamental shouldn't trigger
+// compression on top of the snare.
+//
+// Lookahead (item 2.4): when `set_lookahead_ms` is non-zero, the
+// dry signal is delayed by that many ms so the envelope follower
+// "sees the future" — peak transients are caught before they hit
+// the output. Round-trip latency increases by the lookahead amount;
+// callers should report it via Processor::latency_samples().
 class Compressor {
 public:
     struct Params {
@@ -19,24 +36,73 @@ public:
     };
 
     void set_params(const Params& p) { params_ = p; }
-    void set_sample_rate(float sr) { sample_rate_ = sr; }
+    void set_sample_rate(float sr) {
+        sample_rate_ = sr;
+        configure_sidechain_filter();
+        configure_lookahead_buffer();
+    }
 
+    /// Set the sidechain high-pass cutoff (Hz). 0 disables the HPF
+    /// and the sidechain detector sees the raw signal. Typical values:
+    /// 80–200 Hz for "duck on bass" prevention. The filter is a
+    /// second-order Butterworth biquad (Q ≈ 0.707).
+    void set_sidechain_hpf_hz(float hz) {
+        sidechain_hpf_hz_ = std::max(0.0f, hz);
+        configure_sidechain_filter();
+    }
+    float sidechain_hpf_hz() const { return sidechain_hpf_hz_; }
+
+    /// Set the lookahead in milliseconds. The dry input is delayed by
+    /// this amount so the envelope follower can react before the
+    /// transient arrives. 0 disables lookahead (default).
+    /// Maximum supported lookahead is 50 ms — beyond that the
+    /// internal ring buffer is too large for low-latency contexts.
+    void set_lookahead_ms(float ms) {
+        lookahead_ms_ = std::clamp(ms, 0.0f, 50.0f);
+        configure_lookahead_buffer();
+    }
+    float lookahead_ms() const { return lookahead_ms_; }
+
+    /// Latency reported to the host = lookahead in samples (0 when off).
+    int latency_samples() const {
+        return static_cast<int>(std::round(lookahead_ms_ * 0.001f * sample_rate_));
+    }
+
+    /// Process one sample. The sidechain signal defaults to @p input,
+    /// matching the original non-sidechain behavior.
     float process(float input) {
-        float input_db = 20.0f * std::log10(std::max(std::abs(input), 1e-10f));
+        return process_with_sidechain(input, input);
+    }
 
-        // Compute gain reduction
-        float gain_db = compute_gain(input_db);
+    /// Process one sample with an explicit sidechain detector input.
+    /// `sidechain` is the signal that drives the envelope follower;
+    /// `input` is the signal that gets the gain applied.
+    float process_with_sidechain(float input, float sidechain) {
+        // Apply sidechain HPF if configured.
+        const float detector = sidechain_hpf_active_
+            ? sidechain_hpf_.process(sidechain)
+            : sidechain;
 
-        // Envelope follower (smooth the gain)
-        float target = gain_db;
-        float coeff = (target < envelope_db_)
+        const float input_db = 20.0f * std::log10(std::max(std::abs(detector), 1e-10f));
+        const float gain_db = compute_gain(input_db);
+
+        const float coeff = (gain_db < envelope_db_)
             ? attack_coeff()
             : release_coeff();
+        envelope_db_ = envelope_db_ + coeff * (gain_db - envelope_db_);
 
-        envelope_db_ = envelope_db_ + coeff * (target - envelope_db_);
+        const float gain_linear =
+            std::pow(10.0f, (envelope_db_ + params_.makeup_db) / 20.0f);
 
-        // Apply gain
-        float gain_linear = std::pow(10.0f, (envelope_db_ + params_.makeup_db) / 20.0f);
+        // Lookahead: push input into the delay, read out the
+        // sample-from-the-past, apply the gain that the envelope
+        // followed off the un-delayed sidechain.
+        if (lookahead_samples_ > 0) {
+            lookahead_buffer_.push(input);
+            const float delayed = lookahead_buffer_.read(
+                static_cast<float>(lookahead_samples_));
+            return delayed * gain_linear;
+        }
         return input * gain_linear;
     }
 
@@ -45,14 +111,53 @@ public:
             buffer[i] = process(buffer[i]);
     }
 
+    /// Process a block with a separate sidechain input. Both buffers
+    /// must be at least @p num_samples long.
+    void process_with_sidechain(float* buffer, const float* sidechain,
+                                  int num_samples) {
+        for (int i = 0; i < num_samples; ++i)
+            buffer[i] = process_with_sidechain(buffer[i], sidechain[i]);
+    }
+
     float gain_reduction_db() const { return envelope_db_; }
 
-    void reset() { envelope_db_ = 0.0f; }
+    void reset() {
+        envelope_db_ = 0.0f;
+        sidechain_hpf_.reset();
+        lookahead_buffer_.reset();
+    }
 
 private:
     Params params_;
     float sample_rate_ = 44100.0f;
     float envelope_db_ = 0.0f;
+
+    float sidechain_hpf_hz_ = 0.0f;
+    bool sidechain_hpf_active_ = false;
+    Biquad sidechain_hpf_{};
+
+    float lookahead_ms_ = 0.0f;
+    int lookahead_samples_ = 0;
+    DelayLine lookahead_buffer_{};
+
+    void configure_sidechain_filter() {
+        sidechain_hpf_active_ = sidechain_hpf_hz_ > 0.0f && sample_rate_ > 0.0f;
+        if (sidechain_hpf_active_) {
+            sidechain_hpf_.set_coefficients(
+                Biquad::Type::highpass,
+                sidechain_hpf_hz_, /*Q=*/0.7071068f, sample_rate_);
+            sidechain_hpf_.reset();
+        }
+    }
+    void configure_lookahead_buffer() {
+        lookahead_samples_ = static_cast<int>(
+            std::round(lookahead_ms_ * 0.001f * sample_rate_));
+        if (lookahead_samples_ > 0) {
+            // DelayLine wants a buffer length >= max delay + 1.
+            lookahead_buffer_.prepare(lookahead_samples_ + 1);
+            lookahead_buffer_.reset();
+        }
+    }
 
     float compute_gain(float input_db) const {
         float knee = params_.knee_db;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2154,6 +2154,9 @@ pulp_add_test_suite(pulp-test-hmac-aead LIBRARIES pulp::runtime)
 # macOS plan Batch C (partial) — MidiMessageCollector (UI→audio MIDI hub)
 pulp_add_test_suite(pulp-test-midi-message-collector LIBRARIES pulp::midi)
 
+# macOS plan Batch G (partial) — Compressor sidechain HPF + lookahead
+pulp_add_test_suite(pulp-test-compressor-sidechain LIBRARIES pulp::signal)
+
 # macOS plan Batch A — Foundations
 pulp_add_test_suite(pulp-test-dc-blocker LIBRARIES pulp::signal)
 pulp_add_test_suite(pulp-test-denormal LIBRARIES pulp::signal)

--- a/test/test_compressor_sidechain.cpp
+++ b/test/test_compressor_sidechain.cpp
@@ -1,0 +1,170 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/signal/compressor.hpp>
+
+#include <cmath>
+#include <vector>
+
+using namespace pulp::signal;
+
+namespace {
+
+float db_to_lin(float db) { return std::pow(10.0f, db / 20.0f); }
+
+float rms(const std::vector<float>& v, int start, int end) {
+    double acc = 0.0;
+    const int n = end - start;
+    for (int i = start; i < end; ++i) acc += double(v[i]) * double(v[i]);
+    return static_cast<float>(std::sqrt(acc / n));
+}
+
+} // namespace
+
+TEST_CASE("Compressor latency_samples reflects lookahead",
+          "[signal][compressor]") {
+    Compressor c;
+    c.set_sample_rate(48000.0f);
+    REQUIRE(c.latency_samples() == 0);
+
+    c.set_lookahead_ms(1.0f);
+    REQUIRE(c.latency_samples() == 48);
+
+    c.set_lookahead_ms(5.0f);
+    REQUIRE(c.latency_samples() == 240);
+
+    // Clamp at 50 ms max.
+    c.set_lookahead_ms(1000.0f);
+    REQUIRE(c.lookahead_ms() == 50.0f);
+    REQUIRE(c.latency_samples() == 2400);
+}
+
+TEST_CASE("Compressor with lookahead delays the dry signal by the same amount",
+          "[signal][compressor]") {
+    Compressor c;
+    c.set_sample_rate(48000.0f);
+    c.set_lookahead_ms(1.0f); // 48 samples
+    Compressor::Params p; p.threshold_db = 0.0f; // no actual compression
+    c.set_params(p);
+
+    // Drive with an impulse at sample 0.
+    std::vector<float> buf(256, 0.0f);
+    buf[0] = 1.0f;
+    c.process(buf.data(), 256);
+
+    // With lookahead = 48 samples, the impulse should now appear at
+    // sample ~48 in the output (the dry signal was delayed by the
+    // lookahead amount).
+    int found = -1;
+    for (int i = 0; i < 256; ++i) {
+        if (std::abs(buf[i]) > 0.5f) { found = i; break; }
+    }
+    REQUIRE(found == 48);
+}
+
+TEST_CASE("Compressor sidechain HPF attenuates bass-driven triggering",
+          "[signal][compressor]") {
+    // A loud sub-bass sidechain signal should NOT cause gain reduction
+    // when the HPF is set above the sub-bass.
+    Compressor c;
+    c.set_sample_rate(48000.0f);
+    c.set_sidechain_hpf_hz(200.0f);
+    Compressor::Params p;
+    p.threshold_db = -20.0f;
+    p.ratio = 8.0f;
+    p.attack_ms = 0.1f;
+    p.release_ms = 50.0f;
+    c.set_params(p);
+
+    const int n = 4096;
+    constexpr float kTwoPi = 6.28318530717958647692f;
+    constexpr float kSub = 60.0f; // well below the 200 Hz HPF corner
+
+    // Build a hot 60 Hz sidechain.
+    std::vector<float> sidechain(n);
+    for (int i = 0; i < n; ++i)
+        sidechain[i] = 0.8f * std::sin(kTwoPi * kSub * float(i) / 48000.0f);
+
+    // Process a constant 0.5 input against the bass sidechain.
+    std::vector<float> input(n, 0.5f);
+    c.process_with_sidechain(input.data(), sidechain.data(), n);
+
+    // With HPF on, the sidechain detector sees a much-attenuated bass,
+    // so envelope_db should hover close to 0 → almost no gain reduction
+    // → output ≈ 0.5.
+    const float tail_rms = rms(input, n / 2, n);
+    REQUIRE(tail_rms > 0.45f); // very little compression
+    REQUIRE(c.gain_reduction_db() > -3.0f); // shallow at worst
+}
+
+TEST_CASE("Compressor sidechain WITHOUT HPF clearly compresses bass-driven input",
+          "[signal][compressor]") {
+    Compressor c;
+    c.set_sample_rate(48000.0f);
+    c.set_sidechain_hpf_hz(0.0f); // HPF disabled
+    Compressor::Params p;
+    p.threshold_db = -20.0f;
+    p.ratio = 8.0f;
+    p.attack_ms = 0.1f;
+    p.release_ms = 50.0f;
+    c.set_params(p);
+
+    const int n = 4096;
+    constexpr float kTwoPi = 6.28318530717958647692f;
+    constexpr float kSub = 60.0f;
+
+    std::vector<float> sidechain(n);
+    for (int i = 0; i < n; ++i)
+        sidechain[i] = 0.8f * std::sin(kTwoPi * kSub * float(i) / 48000.0f);
+
+    std::vector<float> input(n, 0.5f);
+    c.process_with_sidechain(input.data(), sidechain.data(), n);
+
+    // Without HPF the bass triggers compression → audible gain reduction.
+    REQUIRE(c.gain_reduction_db() < -3.0f);
+}
+
+TEST_CASE("Compressor process(input) still works as a self-sidechain compressor",
+          "[signal][compressor]") {
+    // Regression test: the original single-arg `process(input)` API
+    // must keep working with input acting as its own sidechain detector.
+    Compressor c;
+    c.set_sample_rate(48000.0f);
+    Compressor::Params p;
+    p.threshold_db = -20.0f;
+    p.ratio = 4.0f;
+    p.attack_ms = 5.0f;
+    p.release_ms = 50.0f;
+    c.set_params(p);
+
+    // Drive with a -10 dBFS sine (above threshold) and assert gain
+    // reduction kicks in.
+    constexpr float kTwoPi = 6.28318530717958647692f;
+    const float amp = db_to_lin(-10.0f);
+    std::vector<float> buf(4096);
+    for (size_t i = 0; i < buf.size(); ++i)
+        buf[i] = amp * std::sin(kTwoPi * 1000.0f * float(i) / 48000.0f);
+    c.process(buf.data(), static_cast<int>(buf.size()));
+
+    REQUIRE(c.gain_reduction_db() < -1.0f);
+}
+
+TEST_CASE("Compressor reset clears sidechain HPF + lookahead state",
+          "[signal][compressor]") {
+    Compressor c;
+    c.set_sample_rate(48000.0f);
+    c.set_sidechain_hpf_hz(150.0f);
+    c.set_lookahead_ms(2.0f);
+    Compressor::Params p; p.threshold_db = -20.0f;
+    c.set_params(p);
+
+    // Pump some signal through to populate the delay + filter state.
+    for (int i = 0; i < 512; ++i) (void) c.process(0.5f);
+
+    c.reset();
+    // After reset, processing a zero impulse stream should produce
+    // zeros for at least the lookahead window (delay line cleared).
+    bool all_zero = true;
+    for (int i = 0; i < c.latency_samples(); ++i) {
+        if (std::abs(c.process(0.0f)) > 1e-9f) { all_zero = false; break; }
+    }
+    REQUIRE(all_zero);
+}


### PR DESCRIPTION
## Summary

macOS plan **Batch G (partial)** — single item from the DSP-advanced cluster. Two well-known compressor features bundled into the existing `core/signal::Compressor`, RT-safe and back-compat with the existing one-arg API.

| Item | What ships |
|---|---|
| 2.4 Sidechain HPF | `set_sidechain_hpf_hz(hz)` enables an internal 2nd-order Butterworth biquad HPF on the level-detector path. Typical use: 80–200 Hz to stop bass content from triggering pumping. 0 disables (default). |
| 2.4 Lookahead | `set_lookahead_ms(ms)` adds a dry-signal delay (0–50 ms) so the envelope follower sees transients before they hit the output. `latency_samples()` reports the delay so adapters can compensate. 0 disables (default). |
| 2.4 Explicit-sidechain process | `process_with_sidechain(input, sidechain)` — single-sample and block variants. Existing `process(input)` keeps working (input acts as its own sidechain detector). |

## Test plan

`pulp-test-compressor-sidechain` — 11 assertions / 6 cases, all green:

- `latency_samples()` reflects lookahead at 48 kHz; 50 ms cap honored
- Lookahead delays a dry impulse by exactly the lookahead sample count
- Sidechain HPF at 200 Hz attenuates 60 Hz sidechain → gain reduction stays shallow (> -3 dB), tail RMS stays near 0.5
- Same setup WITHOUT HPF → bass clearly triggers compression (gain reduction < -3 dB)
- Original `process(input)` regression: -10 dBFS sine above threshold still triggers compression
- `reset()` clears both HPF + lookahead state

Broader signal sanity: `pulp-test-signal` — 751 assertions / 87 cases, no regressions.

## Notes

- Built on existing `pulp::signal::Biquad` + `pulp::signal::DelayLine` — no new lock-free machinery.
- Sidechain HPF uses 2nd-order Butterworth (Q ≈ 0.707) — phase-flat enough for ducking workflows.
- Version bumped to 0.216.0 (minor; new public API on existing class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)