### PR TITLE
test(macos-plan): Batch R — ARA scaffold validation (item 3.6)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2157,6 +2157,9 @@ pulp_add_test_suite(pulp-test-midi-message-collector LIBRARIES pulp::midi)
 # macOS plan Batch G (partial) — Compressor sidechain HPF + lookahead
 pulp_add_test_suite(pulp-test-compressor-sidechain LIBRARIES pulp::signal)
 
+# macOS plan Batch R — ARA scaffold validation
+pulp_add_test_suite(pulp-test-ara-scaffold LIBRARIES pulp::format)
+
 # macOS plan Batch A — Foundations
 pulp_add_test_suite(pulp-test-dc-blocker LIBRARIES pulp::signal)
 pulp_add_test_suite(pulp-test-denormal LIBRARIES pulp::signal)

--- a/test/test_ara_scaffold.cpp
+++ b/test/test_ara_scaffold.cpp
@@ -1,0 +1,119 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/format/ara.hpp>
+
+#include <cstring>
+#include <string_view>
+
+using namespace pulp::format;
+
+// ────────────────────────────────────────────────────────────────────────
+// Scaffold validation (macOS plan item 3.6) — Pulp's ARA stub must
+// compile + return documented defaults when PULP_ENABLE_ARA=OFF (the
+// default). With PULP_ENABLE_ARA=ON + a developer-supplied Celemony
+// SDK, ara_sdk_compiled_in() flips to true and ara_sdk_generation()
+// returns the SDK's API generation number. The latter is a manual
+// smoke (requires Celemony license + checkout) and is documented in
+// CLAUDE.md rather than exercised in CI.
+// ────────────────────────────────────────────────────────────────────────
+
+TEST_CASE("ARA scaffold reports SDK-not-compiled-in by default",
+          "[format][ara][scaffold]") {
+    // Default Pulp build (PULP_ENABLE_ARA=OFF) must report false here.
+    // When a developer builds with PULP_ENABLE_ARA=ON + a valid
+    // PULP_ARA_SDK_DIR, this returns true — switch the assertion to
+    // verify the SDK path locally and document the procedure in
+    // CLAUDE.md.
+#ifdef PULP_HAS_ARA
+    REQUIRE(ara_sdk_compiled_in() == true);
+    REQUIRE(ara_sdk_generation() > 0);
+#else
+    REQUIRE(ara_sdk_compiled_in() == false);
+    REQUIRE(ara_sdk_generation() == 0);
+#endif
+}
+
+TEST_CASE("ARA host_supports_ara starts false (host query lives in adapters)",
+          "[format][ara][scaffold]") {
+    // The cross-format `host_supports_ara()` returns false until per-
+    // format companion factories (VST3 / AU v3 / CLAP) land — see the
+    // workstream 06 slices referenced in ara.hpp. Default behavior is
+    // deterministic: false regardless of the SDK build-flag, because
+    // *runtime* host-availability is independent of compile-time
+    // SDK-inclusion.
+    REQUIRE(host_supports_ara() == false);
+}
+
+TEST_CASE("AraDocumentController defaults are conservative",
+          "[format][ara][scaffold]") {
+    struct DefaultController : AraDocumentController {};
+    DefaultController c;
+    REQUIRE(c.is_ara_supported() == false);
+    REQUIRE(c.supported_roles() == 0);
+    REQUIRE(c.ara_factory_name() == "");
+
+    // Virtual no-op methods must not crash and must not require ARA SDK
+    // headers — Pulp plugins that don't declare ARA shouldn't pay any
+    // setup cost.
+    c.begin_editing();
+    c.notify_audio_source_content_changed(42);
+    c.end_editing();
+}
+
+TEST_CASE("AraDocumentController subclass can advertise roles",
+          "[format][ara][scaffold]") {
+    struct EditorController : AraDocumentController {
+        int supported_roles() const override {
+            return static_cast<int>(AraRole::EditorRenderer)
+                 | static_cast<int>(AraRole::EditorView);
+        }
+        bool is_ara_supported() const override { return true; }
+        std::string ara_factory_name() const override { return "PulpEditor"; }
+    };
+    EditorController c;
+    REQUIRE(c.is_ara_supported() == true);
+    const int roles = c.supported_roles();
+    REQUIRE((roles & static_cast<int>(AraRole::EditorRenderer)) != 0);
+    REQUIRE((roles & static_cast<int>(AraRole::EditorView)) != 0);
+    REQUIRE((roles & static_cast<int>(AraRole::PlaybackRenderer)) == 0);
+    REQUIRE(c.ara_factory_name() == "PulpEditor");
+}
+
+TEST_CASE("Companion-factory accessor returns nullptr without SDK",
+          "[format][ara][scaffold]") {
+    struct DummyController : AraDocumentController {
+        bool is_ara_supported() const override { return true; }
+    };
+    DummyController c;
+    const void* factory = ara_companion_factory_for(&c);
+#ifdef PULP_HAS_ARA
+    // With the SDK linked in, a real factory should be returned (or
+    // nullptr if the controller doesn't advertise an ARA-aware role —
+    // implementation choice; this test loosens to "either is valid").
+    (void) factory;
+#else
+    // Without the SDK, no factory can exist.
+    REQUIRE(factory == nullptr);
+#endif
+}
+
+TEST_CASE("Adapter factory keys match Celemony conventions",
+          "[format][ara][scaffold]") {
+    // CLAP-side companion extension id.
+    REQUIRE(std::string_view(kClapAraFactoryExtension)
+            == "com.celemony.ara/clap-factory-v1");
+    // VST3 host-context attribute key.
+    REQUIRE(std::string_view(kVst3AraFactoryContextKey)
+            == "com.celemony.ara/vst3-host-factory-v1");
+    // AU v3 property key — Logic Pro expects this exact name.
+    REQUIRE(std::string_view(kAuAraFactoryPropertyKey)
+            == "audioUnitARAFactory");
+}
+
+TEST_CASE("AraRole enum values are stable single-bit flags",
+          "[format][ara][scaffold]") {
+    // PluginDescriptor / adapter code combines roles with bitwise OR.
+    REQUIRE(static_cast<int>(AraRole::None) == 0);
+    REQUIRE(static_cast<int>(AraRole::PlaybackRenderer) == 1);
+    REQUIRE(static_cast<int>(AraRole::EditorRenderer) == 2);
+    REQUIRE(static_cast<int>(AraRole::EditorView) == 4);
+}


### PR DESCRIPTION
## Summary

macOS plan **Batch R** — verifies Pulp's existing ARA scaffold (`core/format::AraDocumentController` + companion factory accessors) reports documented defaults when `PULP_ENABLE_ARA=OFF` (the default) and lays groundwork to flip the assertions to the SDK-ON path when a developer supplies the Celemony SDK.

Per the macOS plan + Batch-3 reviewer decision (ARA = scaffold-only; full hosting deferred), the goal is "confirm Pulp's ARA stub compiles when `PULP_ENABLE_ARA=ON` + Celemony SDK supplied" — codified here as test coverage rather than code.

| Item | What ships |
|---|---|
| 3.6 ARA scaffold validation | New `pulp-test-ara-scaffold` test binary. Asserts: `ara_sdk_compiled_in() == false` when OFF / `true` when ON; `ara_sdk_generation()` is 0 when OFF / >0 when ON; `host_supports_ara() == false` (runtime query — independent of build flag); default `AraDocumentController` returns conservative defaults (not supported, 0 roles, empty factory name); subclasses can OR `AraRole` flags; `ara_companion_factory_for()` is nullptr without the SDK; the three adapter factory keys (CLAP / VST3 / AU v3) match Celemony's documented conventions exactly; `AraRole` values are stable single-bit flags. |

## Test plan

`pulp-test-ara-scaffold` — 19 assertions / 7 cases, all green on default build (PULP_ENABLE_ARA=OFF). Tests are `#ifdef PULP_HAS_ARA`-aware: on a developer machine with the Celemony SDK + `PULP_ENABLE_ARA=ON` build, the SDK-ON branch fires instead. Both branches are exercised by source, just guarded.

## Notes

- No source changes; this is pure test scaffolding around an existing scaffold (the actual ARA SDK integration is much larger work tracked separately in the workstream-06 slices already referenced in `ara.hpp`).
- The manual SDK-ON smoke ("plugin loads as ARA-capable in Logic / Studio One") still needs to be done by a developer with Celemony SDK access; this test ensures the code path doesn't bit-rot in the meantime.
- No version bump — test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)