### PR TITLE
fix: Codex P1/P2 round 3 — MidiMessageCollector zero-loss overflow slot + ARA SDK-ON assert non-null

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.217.0
+    VERSION 0.218.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/midi/include/pulp/midi/message_collector.hpp
+++ b/core/midi/include/pulp/midi/message_collector.hpp
@@ -115,46 +115,60 @@ public:
             }
         }
 
-        // Always drain the queue regardless of whether pending events
-        // remain in the future — the queue may hold *earlier-than-pending*
-        // events when the producer pushes out of timestamp order, and
-        // those must not be starved (Codex P1 on #2845).
+        // Drain the queue without losing future events. Events that
+        // fit the current block are delivered immediately; future events
+        // are stashed in the pending ring. When the ring is full, the
+        // popped future event is parked in a single consumer-side
+        // lookahead slot (`overflow_`) and the drain stops — so the
+        // *remaining* queue items stay in the SPSC FIFO untouched and
+        // get retried on the next drain when the ring has room.
+        // Zero data loss; no consumer-side write to the SPSC queue
+        // (Codex P1 on #2843, #2845, #2853).
+        //
+        // The next-event source is either the consumer-side overflow
+        // slot (carried from the previous drain) or a fresh pop.
         while (true) {
-            auto popped = queue_.try_pop();
-            if (!popped) break;
-            const auto& entry = *popped;
+            std::optional<TimestampedShortMessage> next;
+            if (overflow_.has_value()) {
+                next = std::move(overflow_);
+                overflow_.reset();
+            } else {
+                next = queue_.try_pop();
+            }
+            if (!next.has_value()) break;
+            const auto& entry = *next;
             if (entry.timestamp_seconds < block_end_seconds) {
                 deliver(entry);
                 ++drained;
                 continue;
             }
-            // Future event: stash in the consumer-owned pending ring.
-            if (!stash_pending(entry)) {
-                // Ring overflow — record + drop. Producer should slow
-                // down or grow the pending ring.
-                ++dropped_overflow_;
+            // Future event: try to stash in the pending ring.
+            if (stash_pending(entry)) {
+                continue; // ring had room — keep draining
             }
+            // Ring full: park in the consumer-side overflow slot and
+            // stop draining so the remaining queue items survive to
+            // the next drain.
+            overflow_ = entry;
+            break;
         }
         return drained;
     }
 
     /// Approximate number of events currently queued (does NOT count
-    /// the deferred-future entries in the pending ring).
+    /// the deferred-future entries in the pending ring or the
+    /// consumer-side overflow slot).
     std::size_t size_approx() const { return queue_.size_approx(); }
-
-    /// Number of future events the consumer has dropped because the
-    /// pending ring overflowed. Monotonically increasing; useful as
-    /// a diagnostic counter. Reset to 0 only by `reset_dropped_overflow()`.
-    std::size_t dropped_overflow() const { return dropped_overflow_; }
-    void reset_dropped_overflow() { dropped_overflow_ = 0; }
 
     /// Compile-time capacity of the producer queue.
     static constexpr std::size_t capacity() { return Capacity; }
 
     /// Compile-time size of the consumer-owned pending ring. Large
     /// enough to absorb out-of-order producer bursts in practical
-    /// usage (UI + scripting timing). If a workload routinely overflows,
-    /// pick a larger value at instantiation.
+    /// usage (UI + scripting timing). If a workload routinely fills
+    /// the ring, picking a larger value reduces per-drain overhead
+    /// (extra ring slots get scanned first instead of going through
+    /// the overflow lookahead path).
     static constexpr std::size_t pending_capacity() { return kPendingSlots; }
 
 private:
@@ -164,37 +178,24 @@ private:
     /// Consumer-owned pending ring for popped-but-future events.
     /// Linear scan; N=8 keeps the per-drain overhead negligible.
     std::array<std::optional<TimestampedShortMessage>, kPendingSlots> pending_{};
-    std::size_t dropped_overflow_ = 0;
+    /// One-slot lookahead for a future event the ring couldn't store —
+    /// carried into the next drain so no event is ever silently dropped
+    /// on the consumer side.
+    std::optional<TimestampedShortMessage> overflow_;
 
-    /// Place @p entry in an empty pending slot. If all slots are
-    /// occupied, evict the slot with the LARGEST timestamp (latest
-    /// future event) so the ring keeps the soonest-due events. Returns
-    /// true if @p entry was stored; false if the ring already held
-    /// only earlier-due events and @p entry was rejected.
+    /// Place @p entry in an empty pending slot. Returns true if
+    /// @p entry was stored, false if all slots are occupied. Eviction
+    /// is deliberately not performed here — overflow events stay in
+    /// the consumer-side `overflow_` slot or the producer queue so
+    /// the contract is zero data loss.
     bool stash_pending(const TimestampedShortMessage& entry) {
-        // First pass: empty slot.
         for (auto& slot : pending_) {
             if (!slot.has_value()) {
                 slot = entry;
                 return true;
             }
         }
-        // All occupied — find the latest-due slot.
-        std::size_t latest_idx = 0;
-        double latest_ts = pending_[0]->timestamp_seconds;
-        for (std::size_t i = 1; i < pending_.size(); ++i) {
-            if (pending_[i]->timestamp_seconds > latest_ts) {
-                latest_ts = pending_[i]->timestamp_seconds;
-                latest_idx = i;
-            }
-        }
-        // If the new entry is sooner than the latest pending, evict.
-        if (entry.timestamp_seconds < latest_ts) {
-            pending_[latest_idx] = entry;
-            // The evicted (later) entry is the one we lose.
-            return false; // signals an overflow drop
-        }
-        return false; // new entry rejected entirely (it's the latest)
+        return false; // all slots full
     }
 };
 

--- a/test/test_ara_scaffold.cpp
+++ b/test/test_ara_scaffold.cpp
@@ -86,10 +86,10 @@ TEST_CASE("Companion-factory accessor returns nullptr without SDK",
     DummyController c;
     const void* factory = ara_companion_factory_for(&c);
 #ifdef PULP_HAS_ARA
-    // With the SDK linked in, a real factory should be returned (or
-    // nullptr if the controller doesn't advertise an ARA-aware role —
-    // implementation choice; this test loosens to "either is valid").
-    (void) factory;
+    // With the SDK linked in, ara_factory.cpp builds and returns a
+    // real ARAFactory struct — never nullptr (Codex P2 on #2854 noted
+    // the prior assertion was a no-op).
+    REQUIRE(factory != nullptr);
 #else
     // Without the SDK, no factory can exist.
     REQUIRE(factory == nullptr);

--- a/test/test_midi_message_collector.cpp
+++ b/test/test_midi_message_collector.cpp
@@ -200,7 +200,6 @@ TEST_CASE("MidiMessageCollector pending ring handles multiple out-of-order futur
     MidiBuffer b1;
     REQUIRE(collector.drain_into(b1, /*start=*/0.0,
                                        /*samples=*/256, /*sr=*/48000.0) == 0);
-    REQUIRE(collector.dropped_overflow() == 0);
 
     // Drain at t=3.0: only the ts=3.0 event fits.
     MidiBuffer b2;
@@ -219,6 +218,40 @@ TEST_CASE("MidiMessageCollector pending ring handles multiple out-of-order futur
     REQUIRE(collector.drain_into(b4, /*start=*/5.0,
                                        /*samples=*/256, /*sr=*/48000.0) == 1);
     REQUIRE(b4[0].message.getNoteNumber() == 60);
+}
+
+TEST_CASE("MidiMessageCollector survives >ring-capacity future bursts without loss (Codex #2853 P1)",
+          "[midi][collector][regression]") {
+    MidiMessageCollector<128> collector;
+    // Push 24 events all in the future — more than the 8-slot pending
+    // ring + the 1-slot consumer overflow can hold. Earlier impl would
+    // silently drop the late entries; new impl keeps the unstashable
+    // events in the producer SPSC queue until the ring has room.
+    constexpr int kEvents = 24;
+    for (int i = 0; i < kEvents; ++i) {
+        REQUIRE(collector.push_now(note_on(0, static_cast<uint8_t>(60 + i), 100),
+                                    /*ts=*/10.0 + double(i) * 0.001));
+    }
+
+    // First drain at t=0: nothing fits the block. 8 in ring, 1 parked
+    // in overflow, remaining 15 stay in the SPSC queue. Critically: no
+    // event is lost — they're all preserved across the producer queue
+    // + pending ring + overflow slot.
+    MidiBuffer b1;
+    REQUIRE(collector.drain_into(b1, /*start=*/0.0,
+                                       /*samples=*/256, /*sr=*/48000.0) == 0);
+
+    // Drain across multiple subsequent blocks until everything lands.
+    int total_delivered = 0;
+    for (int i = 0; i < 8 && total_delivered < kEvents; ++i) {
+        MidiBuffer extra;
+        total_delivered += static_cast<int>(
+            collector.drain_into(extra, /*start=*/10.0,
+                                         /*samples=*/static_cast<int>(0.5 * 48000),
+                                         /*sr=*/48000.0));
+    }
+    // Zero loss — all events eventually delivered.
+    REQUIRE(total_delivered == kEvents);
 }
 
 TEST_CASE("MidiMessageCollector returns false when queue is full",


### PR DESCRIPTION
## Summary

Third round of post-merge Codex findings, bundled in one PR. The collector area has now stabilized on a zero-data-loss design; the ARA scaffold test asserts the SDK-ON contract for real instead of `(void) factory`.

| Source | Fix |
|---|---|
| #2853 Codex P1 | Previous fix funneled ALL future events into the 8-slot pending ring, dropping the rest. New design: pop one at a time; if pending ring is full, park the popped event in a single consumer-side `overflow_` slot and **stop draining the queue** so remaining items survive in the SPSC FIFO untouched. The next drain picks up overflow first, then the queue. Zero data loss; consumer thread still never writes to the SPSC queue. |
| #2853 P2 (dropped_overflow_ not atomic) | Resolved by removing the counter — the new design has no consumer-side drops, so there's nothing to count. `reset_dropped_overflow()` and `dropped_overflow()` are removed from the public API. |
| #2854 Codex P2 | `PULP_HAS_ARA` branch was `(void) factory` — silent pass on regression. `ara_factory.cpp` always returns a non-null `ARAFactory` pointer when the SDK is compiled in, so the branch now asserts `REQUIRE(factory != nullptr)`. |

## Test plan

- [x] `pulp-test-midi-message-collector` — 81 assertions / 9 cases (up from 56/8). Added "survives > ring-capacity future bursts without loss" regression: pushes 24 future events, drains repeatedly, asserts all 24 eventually delivered. The dropped_overflow assertions removed from the older multi-out-of-order test.
- [x] `pulp-test-ara-scaffold` — 19 assertions / 7 cases unchanged in count; default-OFF still green. The PULP_HAS_ARA path now asserts non-null factory (couldn't be exercised in CI without a Celemony SDK, but the assertion is real on developer machines).

## Notes

- Removing `dropped_overflow()` is a 1-PR-old API break (introduced in #2853 + #2845); acceptable as minor since no released consumers.
- Version bumped to 0.218.0 (minor; behavior fix + API surface change in 1-PR-old code).
- Collector contract finalized: producer queue can fill (`push_now` returns false) but consumer side never drops; pending-ring + overflow slot together preserve unbounded out-of-order future events as long as the producer queue has room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)