### PR TITLE
fix(midi+test): collector continue-drain + 64-slot pending ring; audit test uses in-range port id

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.218.0
+    VERSION 0.219.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/midi/include/pulp/midi/message_collector.hpp
+++ b/core/midi/include/pulp/midi/message_collector.hpp
@@ -32,6 +32,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cmath>
 #include <cstddef>
 #include <optional>
@@ -115,27 +116,21 @@ public:
             }
         }
 
-        // Drain the queue without losing future events. Events that
-        // fit the current block are delivered immediately; future events
-        // are stashed in the pending ring. When the ring is full, the
-        // popped future event is parked in a single consumer-side
-        // lookahead slot (`overflow_`) and the drain stops — so the
-        // *remaining* queue items stay in the SPSC FIFO untouched and
-        // get retried on the next drain when the ring has room.
-        // Zero data loss; no consumer-side write to the SPSC queue
-        // (Codex P1 on #2843, #2845, #2853).
+        // Drain the queue. Events that fit the current block are
+        // delivered immediately; future events are stashed in the
+        // consumer-owned pending ring. We KEEP draining even after a
+        // future event lands so later in-block events still get
+        // delivered this block (Codex P1 on #2856 — earlier
+        // break-after-stash starved out-of-order in-block items).
         //
-        // The next-event source is either the consumer-side overflow
-        // slot (carried from the previous drain) or a fresh pop.
-        while (true) {
-            std::optional<TimestampedShortMessage> next;
-            if (overflow_.has_value()) {
-                next = std::move(overflow_);
-                overflow_.reset();
-            } else {
-                next = queue_.try_pop();
-            }
-            if (!next.has_value()) break;
+        // The pending ring is sized (`kPendingSlots`) to absorb the
+        // realistic Pulp workloads in one drain: UI clicks, scripting
+        // schedulers with look-ahead, MIDI file playback. When the
+        // ring is genuinely saturated, additional FUTURE events have
+        // nowhere to live and are dropped — observable via the atomic
+        // `dropped_future_` counter so callers can detect pathological
+        // back-pressure.
+        while (auto next = queue_.try_pop()) {
             const auto& entry = *next;
             if (entry.timestamp_seconds < block_end_seconds) {
                 deliver(entry);
@@ -144,15 +139,23 @@ public:
             }
             // Future event: try to stash in the pending ring.
             if (stash_pending(entry)) {
-                continue; // ring had room — keep draining
+                continue;
             }
-            // Ring full: park in the consumer-side overflow slot and
-            // stop draining so the remaining queue items survive to
-            // the next drain.
-            overflow_ = entry;
-            break;
+            // Ring genuinely saturated. Drop with atomic counter.
+            dropped_future_.fetch_add(1, std::memory_order_relaxed);
         }
         return drained;
+    }
+
+    /// Number of FUTURE events the consumer dropped because the pending
+    /// ring was saturated at the moment they were popped. Monotonic,
+    /// atomic, never reset. A non-zero value means producers buffered
+    /// more events than `pending_capacity()` can carry across drains;
+    /// either reduce producer-side look-ahead or pick a larger
+    /// `Capacity` so the producer SPSC queue itself absorbs more
+    /// in-flight events.
+    std::size_t dropped_future() const {
+        return dropped_future_.load(std::memory_order_relaxed);
     }
 
     /// Approximate number of events currently queued (does NOT count
@@ -163,25 +166,24 @@ public:
     /// Compile-time capacity of the producer queue.
     static constexpr std::size_t capacity() { return Capacity; }
 
-    /// Compile-time size of the consumer-owned pending ring. Large
-    /// enough to absorb out-of-order producer bursts in practical
-    /// usage (UI + scripting timing). If a workload routinely fills
-    /// the ring, picking a larger value reduces per-drain overhead
-    /// (extra ring slots get scanned first instead of going through
-    /// the overflow lookahead path).
+    /// Compile-time size of the consumer-owned pending ring. Sized to
+    /// absorb realistic Pulp producer bursts (UI input + scripting
+    /// look-ahead + MIDI file playback) within a single drain. A
+    /// workload that exceeds this in one drain will see drops counted
+    /// via `dropped_future()`; raising `Capacity` lets the producer
+    /// queue itself absorb more in-flight events before they reach the
+    /// consumer ring.
     static constexpr std::size_t pending_capacity() { return kPendingSlots; }
 
 private:
-    static constexpr std::size_t kPendingSlots = 8;
+    static constexpr std::size_t kPendingSlots = 64;
 
     pulp::runtime::SpscQueue<TimestampedShortMessage, Capacity> queue_;
-    /// Consumer-owned pending ring for popped-but-future events.
-    /// Linear scan; N=8 keeps the per-drain overhead negligible.
+    /// Consumer-owned pending ring for popped-but-future events. Linear
+    /// scan; N=64 keeps the per-drain overhead small while absorbing
+    /// realistic scripting / playback bursts without consumer-side drops.
     std::array<std::optional<TimestampedShortMessage>, kPendingSlots> pending_{};
-    /// One-slot lookahead for a future event the ring couldn't store —
-    /// carried into the next drain so no event is ever silently dropped
-    /// on the consumer side.
-    std::optional<TimestampedShortMessage> overflow_;
+    std::atomic<std::size_t> dropped_future_{0};
 
     /// Place @p entry in an empty pending slot. Returns true if
     /// @p entry was stored, false if all slots are occupied. Eviction

--- a/test/test_midi1_backend_audit.cpp
+++ b/test/test_midi1_backend_audit.cpp
@@ -74,16 +74,21 @@ TEST_CASE("MIDI 1.0 backend: open() with bogus port id fails gracefully",
 
     auto input = system->create_input();
     REQUIRE(input != nullptr);
+    // Codex P1 on #2857 — the Windows backend parses port_id via
+    // std::stoul into a UINT (uint32_t). Use a value that is numeric,
+    // in-range for uint32_t, and very unlikely to match a real device
+    // id so all backends reject it cleanly (CoreMIDI / ALSA do string
+    // compares against enumerate output; mmeapi looks up by UINT).
     // No callback is required to fail-open, but registering one
     // exercises the std::function move path in the backend.
-    const bool ok = input->open("99999999999999",
+    const bool ok = input->open("987654321",
                                   [](const MidiEvent&) {});
     REQUIRE(ok == false);
     REQUIRE(input->is_open() == false);
 
     auto output = system->create_output();
     REQUIRE(output != nullptr);
-    const bool ok2 = output->open("99999999999999");
+    const bool ok2 = output->open("987654321");
     REQUIRE(ok2 == false);
     REQUIRE(output->is_open() == false);
 }

--- a/test/test_midi_message_collector.cpp
+++ b/test/test_midi_message_collector.cpp
@@ -220,26 +220,25 @@ TEST_CASE("MidiMessageCollector pending ring handles multiple out-of-order futur
     REQUIRE(b4[0].message.getNoteNumber() == 60);
 }
 
-TEST_CASE("MidiMessageCollector survives >ring-capacity future bursts without loss (Codex #2853 P1)",
+TEST_CASE("MidiMessageCollector absorbs realistic future bursts within pending ring (Codex #2853 P1)",
           "[midi][collector][regression]") {
     MidiMessageCollector<128> collector;
-    // Push 24 events all in the future — more than the 8-slot pending
-    // ring + the 1-slot consumer overflow can hold. Earlier impl would
-    // silently drop the late entries; new impl keeps the unstashable
-    // events in the producer SPSC queue until the ring has room.
+    // Push 24 events all in the future — well within the 64-slot
+    // pending ring. Earlier impl variants either silently dropped late
+    // entries or starved later in-block events; current impl stashes
+    // every future event in the consumer-owned ring with zero loss.
     constexpr int kEvents = 24;
     for (int i = 0; i < kEvents; ++i) {
         REQUIRE(collector.push_now(note_on(0, static_cast<uint8_t>(60 + i), 100),
                                     /*ts=*/10.0 + double(i) * 0.001));
     }
 
-    // First drain at t=0: nothing fits the block. 8 in ring, 1 parked
-    // in overflow, remaining 15 stay in the SPSC queue. Critically: no
-    // event is lost — they're all preserved across the producer queue
-    // + pending ring + overflow slot.
+    // First drain at t=0: nothing fits. All 24 events land in the
+    // pending ring with no loss because 24 <= pending_capacity() (64).
     MidiBuffer b1;
     REQUIRE(collector.drain_into(b1, /*start=*/0.0,
                                        /*samples=*/256, /*sr=*/48000.0) == 0);
+    REQUIRE(collector.dropped_future() == 0);
 
     // Drain across multiple subsequent blocks until everything lands.
     int total_delivered = 0;
@@ -252,6 +251,74 @@ TEST_CASE("MidiMessageCollector survives >ring-capacity future bursts without lo
     }
     // Zero loss — all events eventually delivered.
     REQUIRE(total_delivered == kEvents);
+    REQUIRE(collector.dropped_future() == 0);
+}
+
+TEST_CASE("MidiMessageCollector keeps draining queue for in-block events even after a stash (Codex #2856 P1)",
+          "[midi][collector][regression]") {
+    MidiMessageCollector<128> collector;
+
+    // Push 10 FUTURE events first, then 1 IN-BLOCK event behind them in
+    // FIFO order. Earlier impl `break`-ed after a stash failure (which
+    // was easy to hit with the 8-slot ring), starving the in-block
+    // event. With the larger ring AND continue-drain semantics, every
+    // future event stashes cleanly and the in-block event still gets
+    // delivered in the SAME block.
+    for (int i = 0; i < 10; ++i) {
+        REQUIRE(collector.push_now(note_on(0, static_cast<uint8_t>(60 + i), 100),
+                                    /*ts=*/10.0 + double(i) * 0.001));
+    }
+    REQUIRE(collector.push_now(note_on(0, 42, 100), /*ts=*/0.001));
+
+    MidiBuffer b;
+    auto drained = collector.drain_into(b, /*start=*/0.0,
+                                          /*samples=*/256, /*sr=*/48000.0);
+    REQUIRE(drained == 1);
+    REQUIRE(b.size() == 1);
+    REQUIRE(b[0].message.getNoteNumber() == 42);
+    REQUIRE(b[0].sample_offset == 48); // (0.001 - 0.0) * 48000
+    REQUIRE(collector.dropped_future() == 0);
+
+    // Drain later blocks — all 10 future events should land.
+    int delivered = 0;
+    for (int i = 0; i < 8 && delivered < 10; ++i) {
+        MidiBuffer extra;
+        delivered += static_cast<int>(
+            collector.drain_into(extra, /*start=*/10.0,
+                                         /*samples=*/static_cast<int>(0.5 * 48000),
+                                         /*sr=*/48000.0));
+    }
+    REQUIRE(delivered == 10);
+    REQUIRE(collector.dropped_future() == 0);
+}
+
+TEST_CASE("MidiMessageCollector drops surplus future events when pending ring is genuinely saturated",
+          "[midi][collector][regression]") {
+    MidiMessageCollector<256> collector;
+    // Push enough future events to overflow the 64-slot pending ring.
+    constexpr int kRingPlusOne = 65;
+    for (int i = 0; i < kRingPlusOne; ++i) {
+        REQUIRE(collector.push_now(note_on(0, static_cast<uint8_t>(i & 0x7F), 100),
+                                    /*ts=*/10.0 + double(i) * 0.001));
+    }
+
+    MidiBuffer b;
+    REQUIRE(collector.drain_into(b, /*start=*/0.0,
+                                       /*samples=*/256, /*sr=*/48000.0) == 0);
+    REQUIRE(b.size() == 0);
+    REQUIRE(collector.dropped_future() == 1); // exactly one beyond ring capacity
+
+    // The 64 events that fit the ring should be deliverable.
+    int delivered = 0;
+    for (int i = 0; i < 8 && delivered < 64; ++i) {
+        MidiBuffer extra;
+        delivered += static_cast<int>(
+            collector.drain_into(extra, /*start=*/10.0,
+                                         /*samples=*/static_cast<int>(0.5 * 48000),
+                                         /*sr=*/48000.0));
+    }
+    REQUIRE(delivered == 64);
+    REQUIRE(collector.dropped_future() == 1); // counter monotonic
 }
 
 TEST_CASE("MidiMessageCollector returns false when queue is full",


### PR DESCRIPTION
## Summary

Codex round 4 follow-up — two P1 findings from #2856 and #2857.

### #2856 P1 — MidiMessageCollector starves out-of-order in-block events

Earlier impl `break`-ed the drain loop on stash failure (pending ring full + overflow occupied), which left in-block events behind the saturation point stuck in the SPSC queue until the next block. Codex correctly flagged that this is a real correctness regression for out-of-order producers: in-block events should land in their block, period.

**Fix:** drop the carried/overflow concept entirely. The pending ring is bumped 8 → 64 slots, and the drain loop always continues popping from the SPSC queue. The new contract:

- in-block events are ALWAYS delivered this block (no starvation)
- up to `pending_capacity()` future events stash with zero loss
- surplus future events drop with an atomic counter

A new public accessor `MidiMessageCollector::dropped_future()` exposes the drop count so callers can observe pathological back-pressure instead of having events disappear silently.

### #2857 P1 — backend audit test used out-of-range port id

`"99999999999999"` is 14 digits, which overflows `uint32_t` on Windows where the mmeapi backend parses via `std::stoul` into a `UINT`. The `std::out_of_range` exception escaped the test instead of exercising the "no such device" path.

**Fix:** use `"987654321"` (numeric, in-range for uint32_t, very unlikely to match a real device id) with a comment explaining the per-backend parsing contract.

## Test plan

- [x] `pulp-test-midi-message-collector` — 171 assertions in 11 cases ✓
  - existing #2843, #2845, #2853 regressions still pass against the new contract
  - new "keeps draining queue for in-block events even after a stash" (Codex #2856 P1)
  - new "drops surplus future events when pending ring is genuinely saturated"
  - existing #2853 regression updated to assert `dropped_future() == 0` for the realistic 24-event burst (24 < 64-slot ring)
- [x] `pulp-test-midi1-backend-audit` — 21 assertions in 7 cases ✓

## Notes

- Minor version bump (0.218.0 → 0.219.0) for the new public `dropped_future()` accessor.
- This is the 3rd P1 round on `MidiMessageCollector` — each round exposed a more subtle case (consumer-side SPSC write → early-return pending starvation → break-after-stash in-block starvation). The simplified ring-only design closes the design space: there is exactly one storage tier, and the only loss path is well-defined ring saturation with atomic observability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)