### PR TITLE
feat(midi): MpeVoiceTracker consumes UMP per-note management + assignable PNC (item 8.5b)

### DIFF
--- a/.agents/skills/mpe/SKILL.md
+++ b/.agents/skills/mpe/SKILL.md
@@ -137,6 +137,33 @@ responsible for incrementing on note-on and decrementing on note-off,
 **including the steal path** — see the test "MpeVoiceAllocator steal
 path decrements glide refcount" for the invariant.
 
+### UMP per-note management + assignable PNC (post #2860)
+
+`MpeVoiceTracker` consumes the full MIDI 2.0 per-note expression
+surface:
+
+- **Status 0xF0 — Per-Note Management**: `kPerNoteResetControllers`
+  bit returns per-note expression (pitch bend / pressure / timbre) to
+  spec defaults (0); `kPerNoteDetachControllers` bit sets
+  `MpeNoteState::detached`, after which channel-level controllers
+  (status 0xE0 / 0xD0 / 0xB0) skip that note. Per-note targeted
+  messages (0x60 per-note pitch bend, 0x00 registered PNC, 0x10
+  assignable PNC) still apply to detached notes.
+- **Status 0x10 — Assignable Per-Note CC**: the index is host-defined
+  per the UMP spec, so the tracker only routes when the plugin binds
+  one via `set_assignable_timbre_index(uint8_t)`. Unbound by default —
+  unbound assignable PNC is silently ignored. Registered PNC 74
+  (status 0x00) still routes to timbre regardless.
+- **Retrigger semantics**: a note-on while the slot is still active
+  clears `detached` (re-attaches the slot to channel-level controllers).
+
+If you're routing UMP into the tracker, use the factories on
+`UmpPacket`: `per_note_management(group, channel, note, flags)`,
+`assignable_per_note_cc(...)`, `registered_per_note_cc(...)`,
+`per_note_pitch_bend(...)`. Channel-level cache stays updated even
+for detached notes so freshly-added notes on the same channel still
+inherit running state via `add_note`.
+
 ### Format adapter coverage
 
 As of the MPE Phase 1–3 merge (PR #135, #138), the CLAP adapter

--- a/.agents/skills/mpe/SKILL.md
+++ b/.agents/skills/mpe/SKILL.md
@@ -156,6 +156,15 @@ surface:
   (status 0x00) still routes to timbre regardless.
 - **Retrigger semantics**: a note-on while the slot is still active
   clears `detached` (re-attaches the slot to channel-level controllers).
+- **D+S flag combination**: when detach and reset bits arrive in the
+  same management packet, detach takes effect on the currently
+  sounding note (state preserved for its lifecycle); reset is *armed*
+  for the next note-on at the same (channel, note) index. Pulp does
+  not yet maintain the armed-reset memory — D+S currently degrades to
+  detach-only on the live note (matches spec for the sounding note,
+  Codex P1 on #2860). The armed-future-reset slice is deferred
+  follow-up work; if you need the full D+S note-rotation flow, file
+  an issue with a controller reproducer.
 
 If you're routing UMP into the tracker, use the factories on
 `UmpPacket`: `per_note_management(group, channel, note, flags)`,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.220.0
+    VERSION 0.221.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/midi/include/pulp/midi/mpe_voice_tracker.hpp
+++ b/core/midi/include/pulp/midi/mpe_voice_tracker.hpp
@@ -27,6 +27,7 @@
 #include <array>
 #include <cstdint>
 #include <functional>
+#include <optional>
 
 namespace pulp::midi {
 
@@ -46,6 +47,13 @@ struct MpeNoteState {
     float timbre = 0.0f;           ///< CC 74 (0..1); same value as `slide`
     uint32_t note_id = 0;          ///< Monotonic id assigned on note-on (never 0)
     bool is_upper_zone = false;    ///< true if this note lives in the upper zone
+    /// True after a UMP Per-Note Management message with the "detach
+    /// controllers" flag landed on this note: subsequent channel-level
+    /// controller updates (pitch bend, pressure, CC74 on the member
+    /// channel) no longer write into this note. Per-note targeted
+    /// messages (status 0x60 / 0x00 / 0x10) still apply. Cleared when
+    /// the slot is reused for a fresh note-on (retrigger included).
+    bool detached = false;
 };
 
 /// Tracks MPE voice state across channels.
@@ -76,6 +84,21 @@ public:
     void set_manager_bend_range(float semitones);
     float member_bend_range() const { return member_bend_semi_; }
     float manager_bend_range() const { return manager_bend_semi_; }
+
+    /// Bind a MIDI 2.0 Assignable Per-Note Controller index (status
+    /// 0x10) to per-note timbre. The assignable PNC space is host-
+    /// configured per the UMP spec; this hook lets a Pulp plugin
+    /// advertise which assignable index it accepts as timbre. Pass
+    /// `std::nullopt` to disable assignable-PNC routing entirely
+    /// (registered PNC 74, status 0x00, continues to route to timbre
+    /// regardless). Range: 0-127.
+    void set_assignable_timbre_index(std::optional<uint8_t> cc_index) {
+        if (cc_index) assignable_timbre_index_ = static_cast<uint8_t>(*cc_index & 0x7F);
+        else assignable_timbre_index_.reset();
+    }
+    std::optional<uint8_t> assignable_timbre_index() const {
+        return assignable_timbre_index_;
+    }
 
     // ── Event ingestion ────────────────────────────────────────────────────
 
@@ -148,6 +171,10 @@ private:
     // member-channel cache, so they only update that one note.
     void apply_per_note_pitch_bend(uint8_t ch, uint8_t note, float semitones);
     void apply_per_note_timbre(uint8_t ch, uint8_t note, float timbre);
+    // UMP Per-Note Management (status 0xF0): `flags` bit-0 resets per-note
+    // controllers to their defaults, bit-1 detaches channel-level
+    // controllers from the note (`MpeNoteState::detached`).
+    void apply_per_note_management(uint8_t ch, uint8_t note, uint8_t flags);
 
     static float ump_bend_normalised(uint32_t v32);
 
@@ -161,6 +188,7 @@ private:
     float member_bend_semi_ = kDefaultMemberBendSemitones;
     float manager_bend_semi_ = kDefaultManagerBendSemitones;
     uint32_t next_note_id_ = 1;
+    std::optional<uint8_t> assignable_timbre_index_;
 };
 
 } // namespace pulp::midi

--- a/core/midi/src/mpe_voice_tracker.cpp
+++ b/core/midi/src/mpe_voice_tracker.cpp
@@ -346,16 +346,31 @@ void MpeVoiceTracker::apply_per_note_timbre(uint8_t ch, uint8_t note, float timb
 
 void MpeVoiceTracker::apply_per_note_management(uint8_t ch, uint8_t note, uint8_t flags) {
     // UMP Per-Note Management has two bit flags:
-    //   bit 0 (kPerNoteResetControllers) — return per-note expression
-    //     values to spec defaults (0 for pitch bend, pressure, timbre).
-    //   bit 1 (kPerNoteDetachControllers) — channel-level controller
-    //     updates no longer propagate to this note; per-note targeted
-    //     messages (status 0x60 / 0x00 / 0x10) still apply.
+    //   bit 0 (kPerNoteResetControllers, S) — reset per-note expression.
+    //   bit 1 (kPerNoteDetachControllers, D) — detach channel-level
+    //     controllers from the currently sounding note (its expression
+    //     state is frozen for the rest of its lifecycle).
+    //
+    // The flag-combination semantics per the UMP spec
+    // (Codex P1 on #2860, MIDI 2.0 spec § Per-Note Management):
+    //   S alone   → reset the currently sounding note immediately
+    //   D alone   → detach, leave expression untouched
+    //   D + S     → detach takes effect on the currently sounding note
+    //               (its state is preserved for its remaining lifecycle);
+    //               reset arms for FUTURE notes at the same (channel,
+    //               note) index. Pulp does not yet maintain the
+    //               armed-for-future-note memory — D+S degrades to
+    //               detach-only on the live note here, which matches
+    //               the spec for the sounding note. The "arm reset for
+    //               future" slice is tracked as a deferred follow-up
+    //               in the macOS plan; see SKILL.md "UMP per-note
+    //               management" gotchas.
     const bool reset_controllers = (flags & UmpPacket::kPerNoteResetControllers) != 0;
     const bool detach_controllers = (flags & UmpPacket::kPerNoteDetachControllers) != 0;
+    const bool reset_live_note = reset_controllers && !detach_controllers;
     for (auto& s : notes_) {
         if (!s.active || s.channel != ch || s.note != note) continue;
-        if (reset_controllers) {
+        if (reset_live_note) {
             s.pitch_bend_semitones = 0.0f;
             s.pressure = 0.0f;
             s.timbre = 0.0f;

--- a/core/midi/src/mpe_voice_tracker.cpp
+++ b/core/midi/src/mpe_voice_tracker.cpp
@@ -151,6 +151,24 @@ bool MpeVoiceTracker::process(const UmpPacket& p) {
             }
             return true;
         }
+        case 0x10: {  // Assignable per-note CC
+            // The assignable PNC controller index is host-defined; only
+            // route to timbre when the plugin has bound an index via
+            // set_assignable_timbre_index().
+            if (assignable_timbre_index_.has_value()) {
+                const uint8_t cc = static_cast<uint8_t>(p.words[0] & 0x7F);
+                if (cc == *assignable_timbre_index_) {
+                    apply_per_note_timbre(ch, p.note_number(),
+                                          static_cast<float>(p.data_32()) / 4294967295.0f);
+                }
+            }
+            return true;
+        }
+        case 0xF0: {  // Per-note management — reset + detach flags
+            const uint8_t flags = static_cast<uint8_t>(p.words[0] & 0xFF);
+            apply_per_note_management(ch, p.note_number(), flags);
+            return true;
+        }
         default:
             return true;  // belongs to zone but we don't map this status
     }
@@ -200,12 +218,14 @@ void MpeVoiceTracker::reset() {
 // ── Private helpers ────────────────────────────────────────────────────────
 
 void MpeVoiceTracker::add_note(uint8_t ch, uint8_t note, uint8_t velocity, bool upper) {
-    // Reuse existing slot if one matches (retrigger).
+    // Reuse existing slot if one matches (retrigger). Re-attach the
+    // slot so channel-level controllers resume affecting it.
     for (auto& s : notes_) {
         if (s.active && s.channel == ch && s.note == note) {
             s.velocity = velocity;
             s.note_id = next_note_id_++;
             s.is_upper_zone = upper;
+            s.detached = false;
             if (on_note_on) on_note_on(s);
             return;
         }
@@ -246,9 +266,12 @@ void MpeVoiceTracker::remove_note(uint8_t ch, uint8_t note) {
 }
 
 void MpeVoiceTracker::update_channel_pitch_bend(uint8_t ch, float semitones, bool upper) {
+    // The per-channel cache is updated regardless of detach so that
+    // *fresh* notes added to the same channel after a detach still
+    // inherit the running channel state (add_note seeds from it).
     channel_pitch_bend_[ch] = semitones;
     for (auto& s : notes_) {
-        if (!s.active || s.channel != ch) continue;
+        if (!s.active || s.channel != ch || s.detached) continue;
         s.pitch_bend_semitones = semitones;
         if (on_pitch_bend) on_pitch_bend(s);
     }
@@ -258,7 +281,7 @@ void MpeVoiceTracker::update_channel_pitch_bend(uint8_t ch, float semitones, boo
 void MpeVoiceTracker::update_channel_pressure(uint8_t ch, float pressure, bool upper) {
     channel_pressure_[ch] = pressure;
     for (auto& s : notes_) {
-        if (!s.active || s.channel != ch) continue;
+        if (!s.active || s.channel != ch || s.detached) continue;
         s.pressure = pressure;
         if (on_pressure) on_pressure(s);
     }
@@ -268,7 +291,7 @@ void MpeVoiceTracker::update_channel_pressure(uint8_t ch, float pressure, bool u
 void MpeVoiceTracker::update_channel_timbre(uint8_t ch, float timbre, bool upper) {
     channel_timbre_[ch] = timbre;
     for (auto& s : notes_) {
-        if (!s.active || s.channel != ch) continue;
+        if (!s.active || s.channel != ch || s.detached) continue;
         s.timbre = timbre;
         if (on_timbre) on_timbre(s);
     }
@@ -318,6 +341,31 @@ void MpeVoiceTracker::apply_per_note_timbre(uint8_t ch, uint8_t note, float timb
         if (!s.active || s.channel != ch || s.note != note) continue;
         s.timbre = timbre;
         if (on_timbre) on_timbre(s);
+    }
+}
+
+void MpeVoiceTracker::apply_per_note_management(uint8_t ch, uint8_t note, uint8_t flags) {
+    // UMP Per-Note Management has two bit flags:
+    //   bit 0 (kPerNoteResetControllers) — return per-note expression
+    //     values to spec defaults (0 for pitch bend, pressure, timbre).
+    //   bit 1 (kPerNoteDetachControllers) — channel-level controller
+    //     updates no longer propagate to this note; per-note targeted
+    //     messages (status 0x60 / 0x00 / 0x10) still apply.
+    const bool reset_controllers = (flags & UmpPacket::kPerNoteResetControllers) != 0;
+    const bool detach_controllers = (flags & UmpPacket::kPerNoteDetachControllers) != 0;
+    for (auto& s : notes_) {
+        if (!s.active || s.channel != ch || s.note != note) continue;
+        if (reset_controllers) {
+            s.pitch_bend_semitones = 0.0f;
+            s.pressure = 0.0f;
+            s.timbre = 0.0f;
+            if (on_pitch_bend) on_pitch_bend(s);
+            if (on_pressure) on_pressure(s);
+            if (on_timbre) on_timbre(s);
+        }
+        if (detach_controllers) {
+            s.detached = true;
+        }
     }
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2166,6 +2166,10 @@ pulp_add_test_suite(pulp-test-midi1-backend-audit LIBRARIES pulp::midi)
 # macOS plan Batch C — BufferOps SIMD helpers (item 1.6)
 pulp_add_test_suite(pulp-test-buffer-ops LIBRARIES pulp::audio pulp::runtime)
 
+# macOS plan Batch E remainder — MpeVoiceTracker per-note management +
+# assignable PNC consumption (item 8.5b)
+pulp_add_test_suite(pulp-test-mpe-tracker-per-note-management LIBRARIES pulp::midi)
+
 # macOS plan Batch A — Foundations
 pulp_add_test_suite(pulp-test-dc-blocker LIBRARIES pulp::signal)
 pulp_add_test_suite(pulp-test-denormal LIBRARIES pulp::signal)

--- a/test/test_mpe_tracker_per_note_management.cpp
+++ b/test/test_mpe_tracker_per_note_management.cpp
@@ -152,13 +152,20 @@ TEST_CASE("MpeVoiceTracker note-on retrigger clears detach state (item 8.5b)",
     REQUIRE(tracker.find(1, 60)->pitch_bend_semitones > 0.0f);
 }
 
-TEST_CASE("MpeVoiceTracker per-note management reset+detach in one message (item 8.5b)",
-          "[midi][mpe][per-note-management]") {
+TEST_CASE("MpeVoiceTracker D+S per-note management preserves live note state (Codex #2860 P1)",
+          "[midi][mpe][per-note-management][regression]") {
+    // Per the MIDI 2.0 UMP spec § Per-Note Management, when both detach
+    // and reset bits are set, detach takes effect on the currently
+    // sounding note (its controller state is preserved for the rest of
+    // its lifecycle) and reset arms for future note-ons at this index.
+    // Earlier impl zeroed expression on the live note, breaking the
+    // expressive playback the D+S note-rotation flow depends on.
     MpeVoiceTracker tracker{MpeConfig::standard_lower(4)};
     REQUIRE(tracker.process(note_on(/*ch=*/2, /*note=*/64)));
     REQUIRE(tracker.process(UmpPacket::per_note_pitch_bend(
         /*group=*/0, /*channel=*/2, /*note=*/64, /*value=*/0xFFFFFFFFu)));
-    REQUIRE(tracker.find(2, 64)->pitch_bend_semitones > 0.0f);
+    const float live_pitch_bend = tracker.find(2, 64)->pitch_bend_semitones;
+    REQUIRE(live_pitch_bend > 0.0f);
 
     auto combo = UmpPacket::per_note_management(
         /*group=*/0, /*channel=*/2, /*note=*/64,
@@ -169,8 +176,14 @@ TEST_CASE("MpeVoiceTracker per-note management reset+detach in one message (item
 
     const auto* n = tracker.find(2, 64);
     REQUIRE(n != nullptr);
-    REQUIRE(n->pitch_bend_semitones == 0.0f);
+    // D+S: live note state PRESERVED + detach applied.
+    REQUIRE(n->pitch_bend_semitones == live_pitch_bend);
     REQUIRE(n->detached);
+
+    // Channel-level pitch bend updates still skip the detached note.
+    REQUIRE(tracker.process(UmpPacket::pitch_bend_2(
+        /*group=*/0, /*channel=*/2, /*value=*/0u))); // bend toward 0
+    REQUIRE(tracker.find(2, 64)->pitch_bend_semitones == live_pitch_bend);
 }
 
 TEST_CASE("MpeVoiceTracker per-note management only targets the matching note (item 8.5b)",

--- a/test/test_mpe_tracker_per_note_management.cpp
+++ b/test/test_mpe_tracker_per_note_management.cpp
@@ -1,0 +1,205 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/midi/mpe_voice_tracker.hpp>
+#include <pulp/midi/ump.hpp>
+
+using namespace pulp::midi;
+
+// ────────────────────────────────────────────────────────────────────────
+// macOS plan item 8.5b — MpeVoiceTracker consumes UMP per-note
+// management (status 0xF0) and assignable per-note CC (status 0x10),
+// using the factories that landed in #2836.
+// ────────────────────────────────────────────────────────────────────────
+
+namespace {
+
+UmpPacket note_on(uint8_t channel, uint8_t note, uint16_t velocity = 0x8000) {
+    return UmpPacket::note_on_2(/*group=*/0, channel, note, velocity);
+}
+
+} // namespace
+
+TEST_CASE("MpeVoiceTracker assignable PNC is ignored without a configured index (item 8.5b)",
+          "[midi][mpe][per-note-management]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(4)};
+    REQUIRE_FALSE(tracker.assignable_timbre_index().has_value());
+
+    REQUIRE(tracker.process(note_on(/*ch=*/1, /*note=*/60)));
+    REQUIRE(tracker.active_count() == 1);
+
+    // Send assignable per-note CC index 17 with half-scale value.
+    auto pkt = UmpPacket::assignable_per_note_cc(
+        /*group=*/0, /*channel=*/1, /*note=*/60,
+        /*cc_index=*/17, /*value=*/0x80000000u);
+    REQUIRE(tracker.process(pkt));
+
+    const auto* n = tracker.find(1, 60);
+    REQUIRE(n != nullptr);
+    REQUIRE(n->timbre == 0.0f); // tracker has no index bound → ignored
+}
+
+TEST_CASE("MpeVoiceTracker assignable PNC routes to timbre when index is bound (item 8.5b)",
+          "[midi][mpe][per-note-management]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(4)};
+    tracker.set_assignable_timbre_index(uint8_t{17});
+    REQUIRE(tracker.assignable_timbre_index() == uint8_t{17});
+
+    REQUIRE(tracker.process(note_on(/*ch=*/1, /*note=*/60)));
+
+    // Wrong index — must NOT affect timbre.
+    auto wrong = UmpPacket::assignable_per_note_cc(
+        /*group=*/0, /*channel=*/1, /*note=*/60,
+        /*cc_index=*/4, /*value=*/0xFFFFFFFFu);
+    REQUIRE(tracker.process(wrong));
+    REQUIRE(tracker.find(1, 60)->timbre == 0.0f);
+
+    // Right index — applies to timbre.
+    auto right = UmpPacket::assignable_per_note_cc(
+        /*group=*/0, /*channel=*/1, /*note=*/60,
+        /*cc_index=*/17, /*value=*/0x80000000u);
+    REQUIRE(tracker.process(right));
+    const auto* n = tracker.find(1, 60);
+    REQUIRE(n != nullptr);
+    // 0x80000000 / 0xFFFFFFFF ≈ 0.5
+    REQUIRE(n->timbre > 0.4999f);
+    REQUIRE(n->timbre < 0.5001f);
+}
+
+TEST_CASE("MpeVoiceTracker per-note management reset returns expression to defaults (item 8.5b)",
+          "[midi][mpe][per-note-management]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(4)};
+    REQUIRE(tracker.process(note_on(/*ch=*/2, /*note=*/64)));
+
+    // Apply some per-note expression first.
+    REQUIRE(tracker.process(UmpPacket::per_note_pitch_bend(
+        /*group=*/0, /*channel=*/2, /*note=*/64, /*value=*/0xFFFFFFFFu)));
+    REQUIRE(tracker.process(UmpPacket::registered_per_note_cc(
+        /*group=*/0, /*channel=*/2, /*note=*/64,
+        /*cc_index=*/74, /*value=*/0xFFFFFFFFu)));
+
+    const auto* n_before = tracker.find(2, 64);
+    REQUIRE(n_before != nullptr);
+    REQUIRE(n_before->pitch_bend_semitones > 0.0f);
+    REQUIRE(n_before->timbre > 0.99f);
+
+    // Per-note management with reset flag.
+    auto mgmt = UmpPacket::per_note_management(
+        /*group=*/0, /*channel=*/2, /*note=*/64,
+        /*flags=*/UmpPacket::kPerNoteResetControllers);
+    REQUIRE(tracker.process(mgmt));
+
+    const auto* n_after = tracker.find(2, 64);
+    REQUIRE(n_after != nullptr);
+    REQUIRE(n_after->pitch_bend_semitones == 0.0f);
+    REQUIRE(n_after->pressure == 0.0f);
+    REQUIRE(n_after->timbre == 0.0f);
+    REQUIRE_FALSE(n_after->detached); // reset alone does not detach
+}
+
+TEST_CASE("MpeVoiceTracker per-note management detach blocks channel-level updates (item 8.5b)",
+          "[midi][mpe][per-note-management]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(4)};
+    REQUIRE(tracker.process(note_on(/*ch=*/3, /*note=*/72)));
+
+    // Detach the note from channel-level controllers.
+    auto detach = UmpPacket::per_note_management(
+        /*group=*/0, /*channel=*/3, /*note=*/72,
+        /*flags=*/UmpPacket::kPerNoteDetachControllers);
+    REQUIRE(tracker.process(detach));
+    REQUIRE(tracker.find(3, 72)->detached);
+
+    // Channel-level pitch bend (status 0xE0) — must NOT propagate to the
+    // detached note.
+    REQUIRE(tracker.process(UmpPacket::pitch_bend_2(
+        /*group=*/0, /*channel=*/3, /*value=*/0xFFFFFFFFu)));
+    REQUIRE(tracker.find(3, 72)->pitch_bend_semitones == 0.0f);
+
+    // Channel-level pressure (status 0xD0) — must NOT propagate.
+    UmpPacket pressure;
+    pressure.word_count = 2;
+    pressure.words[0] = (0x4u << 28) | (uint32_t{0xD0u | 3u} << 16);
+    pressure.words[1] = 0xFFFFFFFFu;
+    REQUIRE(tracker.process(pressure));
+    REQUIRE(tracker.find(3, 72)->pressure == 0.0f);
+
+    // Channel-level CC74 (status 0xB0) — must NOT propagate.
+    REQUIRE(tracker.process(UmpPacket::cc_2(
+        /*group=*/0, /*channel=*/3, /*controller=*/74, /*value=*/0xFFFFFFFFu)));
+    REQUIRE(tracker.find(3, 72)->timbre == 0.0f);
+
+    // Per-note targeted message — DOES apply even on a detached note.
+    REQUIRE(tracker.process(UmpPacket::per_note_pitch_bend(
+        /*group=*/0, /*channel=*/3, /*note=*/72, /*value=*/0xFFFFFFFFu)));
+    REQUIRE(tracker.find(3, 72)->pitch_bend_semitones > 0.0f);
+}
+
+TEST_CASE("MpeVoiceTracker note-on retrigger clears detach state (item 8.5b)",
+          "[midi][mpe][per-note-management]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(4)};
+    REQUIRE(tracker.process(note_on(/*ch=*/1, /*note=*/60)));
+
+    REQUIRE(tracker.process(UmpPacket::per_note_management(
+        /*group=*/0, /*channel=*/1, /*note=*/60,
+        /*flags=*/UmpPacket::kPerNoteDetachControllers)));
+    REQUIRE(tracker.find(1, 60)->detached);
+
+    // Retrigger note-on without an intervening note-off.
+    REQUIRE(tracker.process(note_on(/*ch=*/1, /*note=*/60, /*velocity=*/0x4000)));
+    REQUIRE_FALSE(tracker.find(1, 60)->detached);
+
+    // Channel-level pitch bend now propagates again.
+    REQUIRE(tracker.process(UmpPacket::pitch_bend_2(
+        /*group=*/0, /*channel=*/1, /*value=*/0xFFFFFFFFu)));
+    REQUIRE(tracker.find(1, 60)->pitch_bend_semitones > 0.0f);
+}
+
+TEST_CASE("MpeVoiceTracker per-note management reset+detach in one message (item 8.5b)",
+          "[midi][mpe][per-note-management]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(4)};
+    REQUIRE(tracker.process(note_on(/*ch=*/2, /*note=*/64)));
+    REQUIRE(tracker.process(UmpPacket::per_note_pitch_bend(
+        /*group=*/0, /*channel=*/2, /*note=*/64, /*value=*/0xFFFFFFFFu)));
+    REQUIRE(tracker.find(2, 64)->pitch_bend_semitones > 0.0f);
+
+    auto combo = UmpPacket::per_note_management(
+        /*group=*/0, /*channel=*/2, /*note=*/64,
+        /*flags=*/static_cast<uint8_t>(
+            UmpPacket::kPerNoteResetControllers
+            | UmpPacket::kPerNoteDetachControllers));
+    REQUIRE(tracker.process(combo));
+
+    const auto* n = tracker.find(2, 64);
+    REQUIRE(n != nullptr);
+    REQUIRE(n->pitch_bend_semitones == 0.0f);
+    REQUIRE(n->detached);
+}
+
+TEST_CASE("MpeVoiceTracker per-note management only targets the matching note (item 8.5b)",
+          "[midi][mpe][per-note-management]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(4)};
+    REQUIRE(tracker.process(note_on(/*ch=*/1, /*note=*/60)));
+    REQUIRE(tracker.process(note_on(/*ch=*/1, /*note=*/64)));
+
+    REQUIRE(tracker.process(UmpPacket::per_note_management(
+        /*group=*/0, /*channel=*/1, /*note=*/60,
+        /*flags=*/UmpPacket::kPerNoteDetachControllers)));
+
+    REQUIRE(tracker.find(1, 60)->detached);
+    REQUIRE_FALSE(tracker.find(1, 64)->detached);
+
+    // Channel-level pitch bend reaches note 64 (not detached) but
+    // skips note 60.
+    REQUIRE(tracker.process(UmpPacket::pitch_bend_2(
+        /*group=*/0, /*channel=*/1, /*value=*/0xFFFFFFFFu)));
+    REQUIRE(tracker.find(1, 60)->pitch_bend_semitones == 0.0f);
+    REQUIRE(tracker.find(1, 64)->pitch_bend_semitones > 0.0f);
+}
+
+TEST_CASE("MpeVoiceTracker set_assignable_timbre_index masks to 7-bit range (item 8.5b)",
+          "[midi][mpe][per-note-management]") {
+    MpeVoiceTracker tracker;
+    tracker.set_assignable_timbre_index(uint8_t{0xFF}); // out of 7-bit range
+    REQUIRE(tracker.assignable_timbre_index() == uint8_t{0x7F}); // masked
+
+    tracker.set_assignable_timbre_index(std::nullopt);
+    REQUIRE_FALSE(tracker.assignable_timbre_index().has_value());
+}


### PR DESCRIPTION
## Summary

macOS plan **Batch E remainder — item 8.5b**: wire the UMP factories from #2836 through `MpeVoiceTracker` so plugin authors get the full MIDI 2.0 per-note expression surface.

| What | Status |
|---|---|
| Per-Note Management (status 0xF0) — reset + detach | ✅ |
| Assignable Per-Note CC (status 0x10) — host-bindable timbre route | ✅ |
| Detach blocks channel-level controllers, per-note targeted messages still apply | ✅ |
| Retrigger note-on clears detach | ✅ |
| Channel-level cache updated regardless of detach (fresh notes still inherit) | ✅ |

### New public API

- `MpeVoiceTracker::set_assignable_timbre_index(std::optional<uint8_t>)` — bind a host-defined PNC index to per-note timbre. Default unbound = assignable PNC ignored.
- `MpeVoiceTracker::assignable_timbre_index()` accessor.
- `MpeNoteState::detached` field on snapshots / `find()` results.

## Test plan

- [x] `pulp-test-mpe-tracker-per-note-management` — 61 assertions / 8 cases ✓ (new file)
  - assignable PNC ignored without configured index
  - assignable PNC routes when bound (correct + wrong index)
  - reset returns expression to defaults
  - detach blocks channel updates (pitch bend / pressure / CC74) but lets per-note targeted messages through
  - retrigger clears detach
  - reset+detach combined
  - per-note management targets only matching note
  - assignable index masks to 7-bit range
- [x] `pulp-test-mpe-voice-tracker` — 361 assertions / 36 cases ✓ (existing, no regression)

## Notes

- Minor version bump (0.219.0 → 0.220.0) for the new public API.
- All factories used (`per_note_management`, `assignable_per_note_cc`, `kPerNoteResetControllers`, `kPerNoteDetachControllers`) were already in main from #2836 — this PR is purely the consumer side.
- Detach semantics follow the UMP spec: per-note targeted messages (status 0x60 / 0x00 / 0x10) bypass the detach gate, but channel-level pitch bend / pressure / CC74 skip detached notes.
- Channel-level controller cache is still maintained for detached notes' channel so fresh notes added afterward inherit the running channel state on note-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)