### PR TITLE
fix(audio): buffer_ops::clip sanitizes NaN before clamp (Codex P1 on #2864)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.222.0
+    VERSION 0.222.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/audio/src/buffer_ops.cpp
+++ b/core/audio/src/buffer_ops.cpp
@@ -42,11 +42,13 @@ void apply_gain_ramp(BufferView<float> buffer, float start_gain, float end_gain)
 
 void clip(std::span<float> samples, float lo, float hi) {
     if (samples.empty()) return;
-    // simd_clamp turns NaN into `lo` because std::min/std::max are
-    // ordered comparisons that return the second arg on NaN inputs in
-    // the Highway implementation Pulp uses. Scalar callers that hit
-    // this path through the buffer overload get the same semantics
-    // courtesy of `simd_clamp`'s scalar tail.
+    // Codex P1 on #2864 — `std::clamp` (Highway's clamp + simd_clamp's
+    // scalar tail) propagates NaN through the ordered comparisons, so
+    // delegating directly would leak NaN into downstream audio.
+    // Sanitize NaN → `lo` ourselves first, then delegate the clamp.
+    for (auto& s : samples) {
+        if (std::isnan(s)) s = lo;
+    }
     pulp::runtime::simd_clamp(samples.data(), lo, hi, samples.data(), samples.size());
 }
 

--- a/test/test_buffer_ops.cpp
+++ b/test/test_buffer_ops.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cmath>
+#include <limits>
 #include <vector>
 
 using namespace pulp::audio;
@@ -110,6 +111,37 @@ TEST_CASE("buffer_ops::clip on BufferView clips every channel", "[audio][buffer_
     REQUIRE_THAT(buf.channel(0)[1], WithinAbs(1.0f, 1e-6f));
     REQUIRE_THAT(buf.channel(1)[1], WithinAbs(1.0f, 1e-6f));
     REQUIRE_THAT(buf.channel(1)[0], WithinAbs(-1.0f, 1e-6f));
+}
+
+TEST_CASE("buffer_ops::clip sanitizes NaN to lo (Codex P1 on #2864)",
+          "[audio][buffer_ops][regression]") {
+    // The doc contract says NaN inputs become `lo`. The earlier impl
+    // delegated entirely to simd_clamp / std::clamp which propagate
+    // NaN through ordered comparisons, so NaN leaked into downstream
+    // audio. The post-fix impl converts NaN → lo before clamping.
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+
+    // SIMD-multiple length to exercise the vector path.
+    std::vector<float> simd_len(64);
+    for (std::size_t i = 0; i < simd_len.size(); ++i) {
+        simd_len[i] = (i % 7 == 0) ? nan : 0.0f;
+    }
+    ops::clip(std::span<float>{simd_len}, -0.5f, 0.5f);
+    for (std::size_t i = 0; i < simd_len.size(); ++i) {
+        REQUIRE_FALSE(std::isnan(simd_len[i]));
+        if (i % 7 == 0) REQUIRE_THAT(simd_len[i], WithinAbs(-0.5f, 1e-6f));
+    }
+
+    // Short tail (non-SIMD-multiple) — historically the scalar-tail
+    // path was what leaked NaN; pin that here too.
+    std::vector<float> short_tail = {nan, 0.0f, nan, 2.0f, nan};
+    ops::clip(std::span<float>{short_tail}, -1.0f, 1.0f);
+    REQUIRE_THAT(short_tail[0], WithinAbs(-1.0f, 1e-6f));
+    REQUIRE_THAT(short_tail[1], WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(short_tail[2], WithinAbs(-1.0f, 1e-6f));
+    REQUIRE_THAT(short_tail[3], WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(short_tail[4], WithinAbs(-1.0f, 1e-6f));
+    for (float v : short_tail) REQUIRE_FALSE(std::isnan(v));
 }
 
 TEST_CASE("buffer_ops::find_min_max scans a span", "[audio][buffer_ops]") {


### PR DESCRIPTION
## Summary

Codex P1 follow-up on **#2864** (item 1.6 — BufferOps). The `clip` doc contract says NaN inputs become `lo`, but the merged impl delegated entirely to `simd_clamp`, whose scalar tail is `std::clamp` and whose Highway path uses ordered comparisons that propagate NaN. Short buffers and the SIMD scalar tail could leak NaN into downstream audio.

## Fix

Explicit NaN → `lo` walk before delegating to `simd_clamp`. Patch is one loop in `buffer_ops::clip(span)`; the BufferView overload already delegates per-channel so it inherits the fix.

## Test plan

- [x] `pulp-test-buffer-ops` — 1782 assertions / 18 cases ✓ (was 1698/17)
  - New regression: "buffer_ops::clip sanitizes NaN to lo (Codex P1 on #2864)" covers both SIMD-multiple (64) and short non-SIMD-multiple (5) lengths so both the Highway path and the scalar tail are pinned.

## Notes

- Patch version bump 0.221.0 → 0.221.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)