### PR TITLE
feat(midi): generic Synthesiser polyphony framework (item 2.5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.222.1
+    VERSION 0.223.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/midi/include/pulp/midi/synthesiser.hpp
+++ b/core/midi/include/pulp/midi/synthesiser.hpp
@@ -1,0 +1,379 @@
+#pragma once
+
+/// @file synthesiser.hpp
+/// Generic MIDI-1 polyphonic synth framework.
+///
+/// `Synthesiser<Voice>` owns a fixed-size pool of `Voice` instances
+/// (subclasses of `SynthesiserVoice`) and routes MIDI events into
+/// them, with a configurable voice-stealing strategy when the pool
+/// is exhausted.
+///
+/// Relationship to MPE: `MpeVoiceAllocator` (in
+/// `mpe_synth_voice.hpp`) is the MPE-aware counterpart that routes
+/// per-note expression across MPE member channels. `Synthesiser`
+/// is the plain-MIDI alternative — one note per channel/note pair,
+/// channel-level pitch bend / aftertouch / CC apply to every active
+/// note on that channel.
+///
+/// Use `Synthesiser` when the descriptor sets `supports_mpe = false`
+/// (the default for non-expressive synths).
+
+#include <pulp/midi/buffer.hpp>
+#include <pulp/midi/message.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#include <vector>
+
+namespace pulp::midi {
+
+/// Per-note metadata maintained by the Synthesiser when a voice is
+/// activated. Subclasses read this via `voice.note()`.
+struct SynthesiserNote {
+    uint8_t channel = 0;          ///< MIDI channel (0–15)
+    uint8_t note = 0;             ///< MIDI note number (0–127)
+    uint8_t velocity = 0;         ///< Note-on velocity (1–127; 0 → note off)
+    int8_t priority = 0;          ///< User-supplied priority for `Priority` steal
+    uint32_t note_id = 0;         ///< Monotonic id; younger > older
+    bool active = false;          ///< Voice is sounding (held or releasing)
+    bool releasing = false;       ///< Note-off received; voice in release tail
+};
+
+/// Voice-stealing strategy applied when `note_on` fires and no free
+/// voice is available.
+enum class VoiceStealStrategy : uint8_t {
+    /// Steal the oldest active voice (smallest `note_id`).
+    Oldest,
+    /// Steal the voice currently reporting the lowest `peak_level()`.
+    /// Voices that don't override `peak_level()` all report 0, so this
+    /// degrades to a deterministic earliest-found scan — useful for
+    /// quiet-tail envelopes.
+    Quietest,
+    /// Steal the voice with the lowest MIDI note number.
+    Lowest,
+    /// Steal the voice with the highest MIDI note number.
+    Highest,
+    /// Steal the voice with the lowest `priority`. Ties broken by
+    /// oldest-first.
+    Priority,
+};
+
+/// Abstract base for one synth voice. Subclasses implement `render`
+/// and may override `on_pitch_bend` / `on_aftertouch` / `on_cc` /
+/// `peak_level` to participate in channel-level controllers and
+/// voice-stealing.
+class SynthesiserVoice {
+public:
+    virtual ~SynthesiserVoice() = default;
+
+    /// Activate this voice for `note`. Called by the synth when the
+    /// pool finds (or steals) a slot. Subclasses can override to
+    /// schedule envelope attack etc.; the base records the note and
+    /// sets `active_ = true`.
+    virtual void on_note_on(const SynthesiserNote& note) {
+        note_ = note;
+        active_ = true;
+        releasing_ = false;
+    }
+
+    /// Begin release. Subclasses typically schedule envelope release
+    /// here; when the envelope tail completes they should call
+    /// `mark_inactive()` so the synth's free-voice scan can reclaim
+    /// the slot.
+    virtual void on_note_off() { releasing_ = true; }
+
+    /// Channel-level pitch bend (semitones, already scaled by the
+    /// configured bend range). Default no-op — override to apply.
+    virtual void on_pitch_bend(float bend_semitones) { (void)bend_semitones; }
+
+    /// Channel-level aftertouch (0..1). Default no-op.
+    virtual void on_aftertouch(float pressure) { (void)pressure; }
+
+    /// Channel-level CC (raw 0–127 value). Default no-op.
+    virtual void on_cc(uint8_t cc_number, uint8_t value) {
+        (void)cc_number; (void)value;
+    }
+
+    /// Render `num_samples` of audio into `out`. The synth calls
+    /// `render` ADDITIVELY — voices sum into the existing buffer
+    /// contents — so the caller should zero `out` before calling
+    /// `Synthesiser::process` if they want a fresh block.
+    virtual void render(float* out, int num_samples) = 0;
+
+    /// Reported by the voice for the `Quietest` steal strategy and
+    /// for caller-side metering. Default 0 (matches "no audio level
+    /// info available"); subclasses with an envelope should return
+    /// the envelope's current level.
+    virtual float peak_level() const { return 0.0f; }
+
+    /// Hard-reset (clear state, drop note). Called when a voice is
+    /// stolen and reused.
+    virtual void reset() {
+        note_ = {};
+        active_ = false;
+        releasing_ = false;
+    }
+
+    bool active() const { return active_; }
+    bool releasing() const { return releasing_; }
+    const SynthesiserNote& note() const { return note_; }
+
+protected:
+    /// Subclasses call this from `render()` once their release tail
+    /// finishes so the synth can reclaim the voice on the next
+    /// `note_on`.
+    void mark_inactive() { active_ = false; releasing_ = false; }
+
+    SynthesiserNote note_{};
+    bool active_ = false;
+    bool releasing_ = false;
+};
+
+/// Polyphonic synth that routes plain-MIDI events into a pool of
+/// `Voice` instances. `Voice` must derive from `SynthesiserVoice`.
+template <typename Voice>
+class Synthesiser {
+    static_assert(std::is_base_of<SynthesiserVoice, Voice>::value,
+                  "Voice must derive from SynthesiserVoice");
+
+public:
+    /// Construct with a fixed polyphony. Voices are
+    /// default-constructed.
+    explicit Synthesiser(std::size_t polyphony = 16)
+        : voices_(polyphony) {}
+
+    void set_steal_strategy(VoiceStealStrategy s) { strategy_ = s; }
+    VoiceStealStrategy steal_strategy() const { return strategy_; }
+
+    /// Pitch-bend range applied to channel-level pitch-bend messages.
+    /// Default is ±2 semitones (MIDI 1.0 RPN 0 default). Override
+    /// with `set_pitch_bend_range_semitones` to match the host's
+    /// expected range (typically ±2, ±12, or ±24).
+    void set_pitch_bend_range_semitones(float r) {
+        if (r > 0.0f) bend_range_semi_ = r;
+    }
+    float pitch_bend_range_semitones() const { return bend_range_semi_; }
+
+    /// Direct event entry points — usable when the caller wants to
+    /// build a Synthesiser pipeline without a full MidiBuffer.
+    void note_on(uint8_t channel, uint8_t note, uint8_t velocity,
+                 int8_t priority = 0) {
+        if (velocity == 0) { note_off(channel, note); return; }
+        Voice* v = find_free_voice();
+        if (!v) v = steal_voice();
+        if (!v) return;
+        SynthesiserNote n;
+        n.channel = static_cast<uint8_t>(channel & 0x0F);
+        n.note = static_cast<uint8_t>(note & 0x7F);
+        n.velocity = static_cast<uint8_t>(velocity & 0x7F);
+        n.priority = priority;
+        n.note_id = ++next_id_;
+        n.active = true;
+        n.releasing = false;
+        v->on_note_on(n);
+    }
+
+    void note_off(uint8_t channel, uint8_t note) {
+        for (auto& v : voices_) {
+            if (v.active() && !v.releasing()
+                && v.note().channel == (channel & 0x0F)
+                && v.note().note == (note & 0x7F)) {
+                v.on_note_off();
+            }
+        }
+    }
+
+    void pitch_bend(uint8_t channel, float bend_semitones) {
+        for (auto& v : voices_) {
+            if (v.active() && v.note().channel == (channel & 0x0F)) {
+                v.on_pitch_bend(bend_semitones);
+            }
+        }
+    }
+
+    void aftertouch(uint8_t channel, float pressure) {
+        for (auto& v : voices_) {
+            if (v.active() && v.note().channel == (channel & 0x0F)) {
+                v.on_aftertouch(pressure);
+            }
+        }
+    }
+
+    void cc(uint8_t channel, uint8_t cc_number, uint8_t value) {
+        for (auto& v : voices_) {
+            if (v.active() && v.note().channel == (channel & 0x0F)) {
+                v.on_cc(cc_number, value);
+            }
+        }
+    }
+
+    /// Drive the synth across one audio block. Events are dispatched
+    /// at their sample offsets within the block; voices render the
+    /// sub-segments between events. The output buffer is NOT zeroed
+    /// — voices render additively, so the caller must clear it (or
+    /// pass a buffer that already holds the desired pre-mix).
+    void process(const MidiBuffer& events, float* out, int num_samples) {
+        if (num_samples <= 0) return;
+        int sample_index = 0;
+        for (std::size_t i = 0; i < events.size(); ++i) {
+            const auto& e = events[i];
+            int target = static_cast<int>(e.sample_offset);
+            if (target < sample_index) target = sample_index;
+            if (target > num_samples) target = num_samples;
+            if (target > sample_index) {
+                render_active(out + sample_index, target - sample_index);
+                sample_index = target;
+            }
+            dispatch_event(e);
+        }
+        if (sample_index < num_samples) {
+            render_active(out + sample_index, num_samples - sample_index);
+        }
+    }
+
+    std::size_t polyphony() const { return voices_.size(); }
+    Voice& voice(std::size_t i) { return voices_[i]; }
+    const Voice& voice(std::size_t i) const { return voices_[i]; }
+
+    std::size_t active_count() const {
+        std::size_t n = 0;
+        for (const auto& v : voices_) if (v.active()) ++n;
+        return n;
+    }
+
+    void reset() {
+        for (auto& v : voices_) v.reset();
+        next_id_ = 0;
+    }
+
+private:
+    Voice* find_free_voice() {
+        for (auto& v : voices_) if (!v.active()) return &v;
+        return nullptr;
+    }
+
+    Voice* steal_voice() {
+        if (voices_.empty()) return nullptr;
+        Voice* chosen = nullptr;
+        switch (strategy_) {
+            case VoiceStealStrategy::Oldest: {
+                uint32_t oldest_id = std::numeric_limits<uint32_t>::max();
+                for (auto& v : voices_) {
+                    if (v.active() && v.note().note_id < oldest_id) {
+                        chosen = &v;
+                        oldest_id = v.note().note_id;
+                    }
+                }
+                break;
+            }
+            case VoiceStealStrategy::Quietest: {
+                float min_level = std::numeric_limits<float>::infinity();
+                uint32_t tie_id = std::numeric_limits<uint32_t>::max();
+                for (auto& v : voices_) {
+                    if (!v.active()) continue;
+                    const float lvl = v.peak_level();
+                    if (lvl < min_level
+                        || (lvl == min_level && v.note().note_id < tie_id)) {
+                        chosen = &v;
+                        min_level = lvl;
+                        tie_id = v.note().note_id;
+                    }
+                }
+                break;
+            }
+            case VoiceStealStrategy::Lowest: {
+                uint8_t lowest = 127;
+                uint32_t tie_id = std::numeric_limits<uint32_t>::max();
+                for (auto& v : voices_) {
+                    if (!v.active()) continue;
+                    const uint8_t n = v.note().note;
+                    if (n < lowest || (n == lowest && v.note().note_id < tie_id)) {
+                        chosen = &v;
+                        lowest = n;
+                        tie_id = v.note().note_id;
+                    }
+                }
+                break;
+            }
+            case VoiceStealStrategy::Highest: {
+                int highest = -1;
+                uint32_t tie_id = std::numeric_limits<uint32_t>::max();
+                for (auto& v : voices_) {
+                    if (!v.active()) continue;
+                    const int n = v.note().note;
+                    if (n > highest
+                        || (n == highest && v.note().note_id < tie_id)) {
+                        chosen = &v;
+                        highest = n;
+                        tie_id = v.note().note_id;
+                    }
+                }
+                break;
+            }
+            case VoiceStealStrategy::Priority: {
+                int lowest_prio = std::numeric_limits<int>::max();
+                uint32_t tie_id = std::numeric_limits<uint32_t>::max();
+                for (auto& v : voices_) {
+                    if (!v.active()) continue;
+                    const int p = v.note().priority;
+                    if (p < lowest_prio
+                        || (p == lowest_prio && v.note().note_id < tie_id)) {
+                        chosen = &v;
+                        lowest_prio = p;
+                        tie_id = v.note().note_id;
+                    }
+                }
+                break;
+            }
+        }
+        if (chosen) chosen->reset();
+        return chosen;
+    }
+
+    void dispatch_event(const MidiEvent& e) {
+        const uint8_t status_top = static_cast<uint8_t>(e.data()[0] & 0xF0);
+        const uint8_t channel = e.channel();
+        if (e.is_note_on() && e.velocity() > 0) {
+            note_on(channel, e.note(), e.velocity());
+            return;
+        }
+        if (e.is_note_off() || (e.is_note_on() && e.velocity() == 0)) {
+            note_off(channel, e.note());
+            return;
+        }
+        if (e.is_pitch_bend()) {
+            const uint16_t raw = static_cast<uint16_t>(
+                e.data()[1] | (uint16_t(e.data()[2]) << 7));
+            const float norm = (static_cast<float>(raw) - 8192.0f) / 8192.0f;
+            pitch_bend(channel, norm * bend_range_semi_);
+            return;
+        }
+        if (status_top == 0xD0) {
+            aftertouch(channel, e.data()[1] / 127.0f);
+            return;
+        }
+        if (e.is_cc()) {
+            cc(channel, e.cc_number(), e.cc_value());
+            return;
+        }
+        // PolyAftertouch (0xA0), ProgramChange (0xC0), system messages
+        // are ignored at this layer — subclasses can route them via
+        // direct event taps if needed.
+    }
+
+    void render_active(float* out, int n) {
+        for (auto& v : voices_) {
+            if (v.active()) v.render(out, n);
+        }
+    }
+
+    std::vector<Voice> voices_;
+    VoiceStealStrategy strategy_ = VoiceStealStrategy::Oldest;
+    float bend_range_semi_ = 2.0f;
+    uint32_t next_id_ = 0;
+};
+
+} // namespace pulp::midi

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2173,6 +2173,9 @@ pulp_add_test_suite(pulp-test-mpe-tracker-per-note-management LIBRARIES pulp::mi
 # macOS plan Batch G — Wavetable oscillator (item 2.6)
 pulp_add_test_suite(pulp-test-wavetable LIBRARIES pulp::signal)
 
+# macOS plan Batch G — Generic Synthesiser polyphony (item 2.5)
+pulp_add_test_suite(pulp-test-synthesiser LIBRARIES pulp::midi)
+
 # macOS plan Batch A — Foundations
 pulp_add_test_suite(pulp-test-dc-blocker LIBRARIES pulp::signal)
 pulp_add_test_suite(pulp-test-denormal LIBRARIES pulp::signal)

--- a/test/test_synthesiser.cpp
+++ b/test/test_synthesiser.cpp
@@ -1,0 +1,385 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <pulp/midi/synthesiser.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+using namespace pulp::midi;
+using Catch::Matchers::WithinAbs;
+
+// ────────────────────────────────────────────────────────────────────────
+// macOS plan item 2.5 — Generic Synthesiser polyphony framework
+//
+// Plain-MIDI (non-MPE) synth with voice-stealing strategies and
+// per-block event dispatch into a fixed pool of voices.
+// ────────────────────────────────────────────────────────────────────────
+
+namespace {
+
+/// Test voice that records lifecycle + accumulates sample counts so
+/// tests can verify dispatch + render scheduling.
+class TestVoice : public SynthesiserVoice {
+public:
+    void on_note_on(const SynthesiserNote& n) override {
+        SynthesiserVoice::on_note_on(n);
+        ++note_on_calls;
+        last_velocity = n.velocity;
+    }
+    void on_note_off() override {
+        SynthesiserVoice::on_note_off();
+        ++note_off_calls;
+    }
+    void on_pitch_bend(float semis) override {
+        ++pitch_bend_calls;
+        last_pitch_bend = semis;
+    }
+    void on_aftertouch(float p) override {
+        ++aftertouch_calls;
+        last_aftertouch = p;
+    }
+    void on_cc(uint8_t cc, uint8_t value) override {
+        ++cc_calls;
+        last_cc_number = cc;
+        last_cc_value = value;
+    }
+    void render(float* out, int n) override {
+        rendered_samples += n;
+        // Add a constant 0.5 per active voice so output sums reveal
+        // how many voices ran across the block.
+        for (int i = 0; i < n; ++i) out[i] += 0.5f;
+    }
+    float peak_level() const override { return peak_; }
+    void reset() override {
+        SynthesiserVoice::reset();
+        peak_ = 0.0f;
+        // Lifecycle counters are intentionally NOT reset — they accumulate
+        // across the voice's life so tests can read steal-path behavior.
+    }
+
+    void set_peak(float p) { peak_ = p; }
+
+    int note_on_calls = 0;
+    int note_off_calls = 0;
+    int pitch_bend_calls = 0;
+    int aftertouch_calls = 0;
+    int cc_calls = 0;
+    int rendered_samples = 0;
+    uint8_t last_velocity = 0;
+    float last_pitch_bend = 0.0f;
+    float last_aftertouch = 0.0f;
+    uint8_t last_cc_number = 0;
+    uint8_t last_cc_value = 0;
+
+private:
+    float peak_ = 0.0f;
+};
+
+MidiEvent note_on_ev(uint8_t ch, uint8_t note, uint8_t vel, int sample_offset = 0) {
+    return MidiEvent{
+        choc::midi::ShortMessage(
+            static_cast<uint8_t>(0x90 | (ch & 0x0F)), note, vel),
+        sample_offset,
+        0.0
+    };
+}
+
+MidiEvent note_off_ev(uint8_t ch, uint8_t note, int sample_offset = 0) {
+    return MidiEvent{
+        choc::midi::ShortMessage(
+            static_cast<uint8_t>(0x80 | (ch & 0x0F)), note, 0),
+        sample_offset,
+        0.0
+    };
+}
+
+MidiEvent cc_ev(uint8_t ch, uint8_t cc, uint8_t value) {
+    return MidiEvent{
+        choc::midi::ShortMessage(
+            static_cast<uint8_t>(0xB0 | (ch & 0x0F)), cc, value),
+        0, 0.0
+    };
+}
+
+MidiEvent pitch_bend_ev(uint8_t ch, uint16_t value14) {
+    return MidiEvent{
+        choc::midi::ShortMessage(
+            static_cast<uint8_t>(0xE0 | (ch & 0x0F)),
+            static_cast<uint8_t>(value14 & 0x7F),
+            static_cast<uint8_t>((value14 >> 7) & 0x7F)),
+        0, 0.0
+    };
+}
+
+MidiEvent aftertouch_ev(uint8_t ch, uint8_t pressure) {
+    return MidiEvent{
+        choc::midi::ShortMessage(
+            static_cast<uint8_t>(0xD0 | (ch & 0x0F)), pressure, 0),
+        0, 0.0
+    };
+}
+
+} // namespace
+
+TEST_CASE("Synthesiser allocates a free voice on note_on", "[midi][synth]") {
+    Synthesiser<TestVoice> synth(4);
+    REQUIRE(synth.active_count() == 0);
+    synth.note_on(0, 60, 100);
+    REQUIRE(synth.active_count() == 1);
+    REQUIRE(synth.voice(0).note().note == 60);
+    REQUIRE(synth.voice(0).note().velocity == 100);
+}
+
+TEST_CASE("Synthesiser note_off marks the matching voice as releasing",
+          "[midi][synth]") {
+    Synthesiser<TestVoice> synth(4);
+    synth.note_on(0, 60, 100);
+    synth.note_off(0, 60);
+    REQUIRE(synth.voice(0).releasing());
+    // Still active until the subclass calls mark_inactive().
+    REQUIRE(synth.voice(0).active());
+}
+
+TEST_CASE("Synthesiser note_on velocity 0 is a note-off", "[midi][synth]") {
+    Synthesiser<TestVoice> synth(4);
+    synth.note_on(0, 60, 100);
+    synth.note_on(0, 60, 0); // velocity 0 → note off
+    REQUIRE(synth.voice(0).releasing());
+}
+
+TEST_CASE("Synthesiser allocates separate voices for distinct notes",
+          "[midi][synth]") {
+    Synthesiser<TestVoice> synth(4);
+    synth.note_on(0, 60, 100);
+    synth.note_on(0, 64, 90);
+    synth.note_on(0, 67, 80);
+    REQUIRE(synth.active_count() == 3);
+}
+
+TEST_CASE("Synthesiser Oldest steal evicts the smallest note_id",
+          "[midi][synth][steal]") {
+    Synthesiser<TestVoice> synth(2);
+    synth.set_steal_strategy(VoiceStealStrategy::Oldest);
+    synth.note_on(0, 60, 100); // note_id = 1 (oldest)
+    synth.note_on(0, 64, 90);  // note_id = 2
+    synth.note_on(0, 67, 80);  // steals → oldest (note 60)
+    REQUIRE(synth.active_count() == 2);
+    // No voice holds note 60 anymore.
+    for (std::size_t i = 0; i < synth.polyphony(); ++i) {
+        REQUIRE(synth.voice(i).note().note != 60);
+    }
+}
+
+TEST_CASE("Synthesiser Lowest steal evicts the lowest pitch",
+          "[midi][synth][steal]") {
+    Synthesiser<TestVoice> synth(2);
+    synth.set_steal_strategy(VoiceStealStrategy::Lowest);
+    synth.note_on(0, 60, 100);
+    synth.note_on(0, 72, 90);
+    synth.note_on(0, 80, 80); // steals lowest (60)
+    REQUIRE(synth.active_count() == 2);
+    for (std::size_t i = 0; i < synth.polyphony(); ++i) {
+        REQUIRE(synth.voice(i).note().note != 60);
+    }
+}
+
+TEST_CASE("Synthesiser Highest steal evicts the highest pitch",
+          "[midi][synth][steal]") {
+    Synthesiser<TestVoice> synth(2);
+    synth.set_steal_strategy(VoiceStealStrategy::Highest);
+    synth.note_on(0, 60, 100);
+    synth.note_on(0, 80, 90);
+    synth.note_on(0, 64, 80); // steals highest (80)
+    REQUIRE(synth.active_count() == 2);
+    for (std::size_t i = 0; i < synth.polyphony(); ++i) {
+        REQUIRE(synth.voice(i).note().note != 80);
+    }
+}
+
+TEST_CASE("Synthesiser Priority steal evicts the lowest priority",
+          "[midi][synth][steal]") {
+    Synthesiser<TestVoice> synth(2);
+    synth.set_steal_strategy(VoiceStealStrategy::Priority);
+    synth.note_on(0, 60, 100, /*priority=*/5);
+    synth.note_on(0, 64, 90, /*priority=*/1); // lowest priority
+    synth.note_on(0, 67, 80, /*priority=*/3); // steals priority-1 voice
+    REQUIRE(synth.active_count() == 2);
+    for (std::size_t i = 0; i < synth.polyphony(); ++i) {
+        REQUIRE(synth.voice(i).note().note != 64);
+    }
+}
+
+TEST_CASE("Synthesiser Quietest steal evicts the lowest peak_level",
+          "[midi][synth][steal]") {
+    Synthesiser<TestVoice> synth(2);
+    synth.set_steal_strategy(VoiceStealStrategy::Quietest);
+    synth.note_on(0, 60, 100);
+    synth.note_on(0, 64, 90);
+    synth.voice(0).set_peak(0.8f);
+    synth.voice(1).set_peak(0.2f);
+    synth.note_on(0, 67, 80); // steals voice(1) (quieter)
+    REQUIRE(synth.voice(1).note().note == 67);
+    REQUIRE(synth.voice(0).note().note == 60);
+}
+
+TEST_CASE("Synthesiser channel-level pitch bend reaches every voice on that channel",
+          "[midi][synth][controllers]") {
+    Synthesiser<TestVoice> synth(4);
+    synth.note_on(0, 60, 100);
+    synth.note_on(0, 64, 100);
+    synth.note_on(1, 72, 100); // different channel — must NOT receive
+
+    synth.pitch_bend(0, 1.5f);
+    REQUIRE(synth.voice(0).pitch_bend_calls == 1);
+    REQUIRE(synth.voice(1).pitch_bend_calls == 1);
+    REQUIRE(synth.voice(2).pitch_bend_calls == 0);
+    REQUIRE_THAT(synth.voice(0).last_pitch_bend, WithinAbs(1.5f, 1e-6f));
+}
+
+TEST_CASE("Synthesiser channel-level aftertouch routes to channel voices",
+          "[midi][synth][controllers]") {
+    Synthesiser<TestVoice> synth(4);
+    synth.note_on(0, 60, 100);
+    synth.note_on(1, 64, 100);
+    synth.aftertouch(0, 0.75f);
+    REQUIRE(synth.voice(0).aftertouch_calls == 1);
+    REQUIRE_THAT(synth.voice(0).last_aftertouch, WithinAbs(0.75f, 1e-6f));
+    REQUIRE(synth.voice(1).aftertouch_calls == 0);
+}
+
+TEST_CASE("Synthesiser channel-level CC routes to channel voices",
+          "[midi][synth][controllers]") {
+    Synthesiser<TestVoice> synth(2);
+    synth.note_on(0, 60, 100);
+    synth.cc(0, 1, 42); // mod wheel
+    REQUIRE(synth.voice(0).cc_calls == 1);
+    REQUIRE(synth.voice(0).last_cc_number == 1);
+    REQUIRE(synth.voice(0).last_cc_value == 42);
+}
+
+TEST_CASE("Synthesiser MidiBuffer process dispatches events at sample offsets",
+          "[midi][synth][process]") {
+    Synthesiser<TestVoice> synth(2);
+    MidiBuffer buf;
+    buf.add(note_on_ev(0, 60, 100, /*offset=*/0));
+    buf.add(note_on_ev(0, 64, 90, /*offset=*/100));
+    buf.add(note_off_ev(0, 60, /*offset=*/200));
+
+    std::vector<float> out(256, 0.0f);
+    synth.process(buf, out.data(), static_cast<int>(out.size()));
+
+    // Voice 0 (note 60) was active samples 0..200 → 200 samples rendered
+    // before note_off (which moves it to releasing but still rendering).
+    // After note_off it keeps rendering through the rest of the block
+    // (releasing = true, active = true) → another 56 samples.
+    REQUIRE(synth.voice(0).note().note == 60);
+    REQUIRE(synth.voice(0).releasing());
+    REQUIRE(synth.voice(0).rendered_samples == 256);
+
+    // Voice 1 (note 64) activated at sample 100 → renders samples
+    // 100..256 → 156 samples.
+    REQUIRE(synth.voice(1).note().note == 64);
+    REQUIRE_FALSE(synth.voice(1).releasing());
+    REQUIRE(synth.voice(1).rendered_samples == 156);
+}
+
+TEST_CASE("Synthesiser MidiBuffer process handles pitch-bend events",
+          "[midi][synth][process]") {
+    Synthesiser<TestVoice> synth(2);
+    synth.set_pitch_bend_range_semitones(12.0f);
+    MidiBuffer buf;
+    buf.add(note_on_ev(0, 60, 100, 0));
+    buf.add(pitch_bend_ev(0, 16383)); // full positive
+    std::vector<float> out(128, 0.0f);
+    synth.process(buf, out.data(), 128);
+    REQUIRE(synth.voice(0).pitch_bend_calls == 1);
+    // (16383 - 8192) / 8192 ≈ 1.0 → 1.0 * 12 = 12 semitones (within 1 LSB)
+    REQUIRE_THAT(synth.voice(0).last_pitch_bend, WithinAbs(12.0f, 0.01f));
+}
+
+TEST_CASE("Synthesiser MidiBuffer process handles aftertouch + CC events",
+          "[midi][synth][process]") {
+    Synthesiser<TestVoice> synth(2);
+    MidiBuffer buf;
+    buf.add(note_on_ev(0, 60, 100, 0));
+    buf.add(aftertouch_ev(0, 127));
+    buf.add(cc_ev(0, 74, 64));
+    std::vector<float> out(64, 0.0f);
+    synth.process(buf, out.data(), 64);
+    REQUIRE(synth.voice(0).aftertouch_calls == 1);
+    REQUIRE_THAT(synth.voice(0).last_aftertouch, WithinAbs(1.0f, 1e-6f));
+    REQUIRE(synth.voice(0).cc_calls == 1);
+    REQUIRE(synth.voice(0).last_cc_number == 74);
+    REQUIRE(synth.voice(0).last_cc_value == 64);
+}
+
+TEST_CASE("Synthesiser 32-voice polyphony stress without dropouts",
+          "[midi][synth][stress]") {
+    Synthesiser<TestVoice> synth(32);
+    for (uint8_t n = 36; n < 68; ++n) {
+        synth.note_on(0, n, 100);
+    }
+    REQUIRE(synth.active_count() == 32);
+    // No voice was dropped — every requested note ended up in a slot.
+    std::vector<uint8_t> notes_observed;
+    notes_observed.reserve(32);
+    for (std::size_t i = 0; i < synth.polyphony(); ++i) {
+        if (synth.voice(i).active()) notes_observed.push_back(synth.voice(i).note().note);
+    }
+    std::sort(notes_observed.begin(), notes_observed.end());
+    for (uint8_t n = 36; n < 68; ++n) {
+        REQUIRE(std::binary_search(notes_observed.begin(), notes_observed.end(), n));
+    }
+
+    // Drive a single 512-sample block — every voice renders its full
+    // share, output sum is 32 voices × 512 samples × 0.5 per voice.
+    std::vector<float> out(512, 0.0f);
+    MidiBuffer empty;
+    synth.process(empty, out.data(), 512);
+    for (float s : out) REQUIRE_THAT(s, WithinAbs(16.0f, 1e-3f));
+}
+
+TEST_CASE("Synthesiser reset clears every voice", "[midi][synth]") {
+    Synthesiser<TestVoice> synth(4);
+    synth.note_on(0, 60, 100);
+    synth.note_on(0, 64, 100);
+    synth.reset();
+    REQUIRE(synth.active_count() == 0);
+}
+
+TEST_CASE("Synthesiser process with empty MidiBuffer renders active voices full block",
+          "[midi][synth][process]") {
+    Synthesiser<TestVoice> synth(2);
+    synth.note_on(0, 60, 100);
+    MidiBuffer empty;
+    std::vector<float> out(256, 0.0f);
+    synth.process(empty, out.data(), 256);
+    REQUIRE(synth.voice(0).rendered_samples == 256);
+}
+
+TEST_CASE("Synthesiser process with num_samples <= 0 is a no-op",
+          "[midi][synth][process]") {
+    Synthesiser<TestVoice> synth(2);
+    synth.note_on(0, 60, 100);
+    MidiBuffer empty;
+    std::vector<float> out(16, 0.0f);
+    synth.process(empty, out.data(), 0);
+    synth.process(empty, out.data(), -5);
+    REQUIRE(synth.voice(0).rendered_samples == 0);
+}
+
+TEST_CASE("Synthesiser process clamps event sample_offset above block size",
+          "[midi][synth][process]") {
+    Synthesiser<TestVoice> synth(2);
+    MidiBuffer buf;
+    buf.add(note_on_ev(0, 60, 100, /*offset=*/0));
+    // Out-of-range offset (host emitted late) — clamped to block end,
+    // so render fills the whole block first then dispatches.
+    buf.add(note_off_ev(0, 60, /*offset=*/9999));
+    std::vector<float> out(128, 0.0f);
+    synth.process(buf, out.data(), 128);
+    REQUIRE(synth.voice(0).rendered_samples == 128);
+    REQUIRE(synth.voice(0).releasing());
+}


### PR DESCRIPTION
## Summary

macOS plan **Batch G — item 2.5**: `pulp::midi::Synthesiser<Voice>` — non-MPE polyphony framework. Plain-MIDI (channel-routed) synth that owns a fixed pool of `SynthesiserVoice` subclasses, dispatches per-block MIDI events at sample-accurate offsets, and falls back to a configurable voice-stealing strategy when the pool is exhausted.

### Surface

| Class / enum | Purpose |
|---|---|
| `SynthesiserVoice` | Abstract base — note lifecycle + channel controllers (pitch bend / aftertouch / CC) + `peak_level()` for Quietest steal + `mark_inactive()` so subclasses reclaim voices when envelope tail completes. |
| `VoiceStealStrategy` | `Oldest / Quietest / Lowest / Highest / Priority` (ties broken by oldest `note_id`). |
| `Synthesiser<Voice>` | Direct event entry points + `process(MidiBuffer, out, num_samples)` with sample-accurate event dispatch. |

### Design

- **Additive render.** Voices `render()` ADDITIVELY into the output buffer (matching the `MpeVoiceAllocator` convention). Caller is responsible for zeroing `out`.
- **Pitch-bend range default ±2 semitones.** Matches the MIDI 1.0 RPN 0 default. Override per-host via `set_pitch_bend_range_semitones`.
- **Static-asserted Voice base.** `std::is_base_of<SynthesiserVoice, Voice>` so misuse fails at compile time.

### Relationship to MPE

`MpeVoiceAllocator` (in `mpe_synth_voice.hpp`) is the MPE-aware counterpart that routes per-note expression across MPE member channels. `Synthesiser` is the choice when the descriptor sets `supports_mpe = false` (default for non-expressive synths).

## Test plan

- [x] `pulp-test-synthesiser` — 595 assertions / 20 cases ✓
  - Free-voice allocation + per-note distinct slots
  - note_on(vel=0) is a note_off
  - **All five voice-stealing strategies** (Oldest / Quietest / Lowest / Highest / Priority)
  - Channel-level pitch bend / aftertouch / CC reach only matching channel's voices
  - `MidiBuffer process` dispatches at sample offsets; pre-event samples render to first voice; post-event samples render to second voice
  - Pitch-bend range applied through MidiBuffer (full positive 14-bit → ±range scaling)
  - **32-voice polyphony stress** — every requested note in a slot; 512-sample block additive sum = 16.0 (32 voices × 0.5)
  - `reset()` clears every voice
  - `num_samples <= 0` no-op + out-of-range event sample_offset clamps to block end

## Notes

- Minor version bump for new public surface.
- Closes gap doc row "Generic Synthesiser polyphony framework" → `Full`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)