### PR TITLE
feat(audio): SampleConverter — PCM ↔ planar float across format × endian × layout (item 1.5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.223.0
+    VERSION 0.224.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/audio/include/pulp/audio/sample_converter.hpp
+++ b/core/audio/include/pulp/audio/sample_converter.hpp
@@ -1,0 +1,352 @@
+#pragma once
+
+/// @file sample_converter.hpp
+/// Run-time PCM sample-format converter.
+///
+/// `SampleConverter` converts between packed PCM byte streams and
+/// planar `float` channels along three independent axes:
+///
+///   * Sample format — `Int8 / Int16 / Int24 / Int32 / Float32 / Float64`
+///   * Endianness — `Little / Big / Native` (Native resolves to the
+///     host's byte order at construction time)
+///   * Layout — `Interleaved / Planar`
+///
+/// Integer formats round-trip without bit-loss; float ↔ int conversion
+/// is within 1 LSB of the reference. The implementation is
+/// header-only because `core/audio` is a real `add_library` target
+/// and the conversion paths are small enough that link-time matters
+/// less than inlining.
+///
+/// Design intent: this is the Pulp-native shape for the audio-data
+/// converter surface — clean-room, no name or class mirroring of any
+/// reference framework. Callers needing PCM I/O at format boundaries
+/// should reach here before rolling per-format helpers.
+
+#include <algorithm>
+#include <bit>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+
+namespace pulp::audio {
+
+/// Packed-PCM sample format the bytes are encoded in.
+enum class SampleFormat : uint8_t {
+    Int8,    ///< 8-bit signed (-128..127)
+    Int16,   ///< 16-bit signed
+    Int24,   ///< 24-bit signed packed (3 bytes)
+    Int32,   ///< 32-bit signed
+    Float32, ///< IEEE-754 single
+    Float64, ///< IEEE-754 double
+};
+
+/// Byte order. `Native` resolves to the host endianness at the
+/// converter's construction time, so changes to the host byte order
+/// (e.g. cross-compilation) do not silently break.
+enum class Endianness : uint8_t {
+    Little,
+    Big,
+    Native,
+};
+
+/// Memory layout of the byte stream relative to channels.
+enum class Layout : uint8_t {
+    Interleaved, ///< [ch0_s0, ch1_s0, ch0_s1, ch1_s1, ...]
+    Planar,      ///< [ch0_s0, ch0_s1, ..., ch1_s0, ch1_s1, ...]
+};
+
+/// Bytes per sample for `format`. Returns 0 for unknown values.
+constexpr std::size_t bytes_per_sample(SampleFormat format) noexcept {
+    switch (format) {
+        case SampleFormat::Int8:    return 1;
+        case SampleFormat::Int16:   return 2;
+        case SampleFormat::Int24:   return 3;
+        case SampleFormat::Int32:   return 4;
+        case SampleFormat::Float32: return 4;
+        case SampleFormat::Float64: return 8;
+    }
+    return 0;
+}
+
+/// True if `format` is a floating-point format.
+constexpr bool is_float(SampleFormat format) noexcept {
+    return format == SampleFormat::Float32 || format == SampleFormat::Float64;
+}
+
+namespace detail {
+
+constexpr bool host_is_little_endian() noexcept {
+    return std::endian::native == std::endian::little;
+}
+
+inline Endianness resolve_endianness(Endianness e) noexcept {
+    if (e != Endianness::Native) return e;
+    return host_is_little_endian() ? Endianness::Little : Endianness::Big;
+}
+
+template <typename T>
+inline T byteswap_int(T value) noexcept {
+    static_assert(std::is_integral_v<T>);
+    T out;
+    auto* in_bytes = reinterpret_cast<const uint8_t*>(&value);
+    auto* out_bytes = reinterpret_cast<uint8_t*>(&out);
+    for (std::size_t i = 0; i < sizeof(T); ++i) {
+        out_bytes[i] = in_bytes[sizeof(T) - 1 - i];
+    }
+    return out;
+}
+
+template <typename T>
+inline T load_int(const uint8_t* src, Endianness src_endian) noexcept {
+    T value;
+    std::memcpy(&value, src, sizeof(T));
+    const auto resolved = resolve_endianness(src_endian);
+    if (resolved != (host_is_little_endian() ? Endianness::Little : Endianness::Big)) {
+        value = byteswap_int(value);
+    }
+    return value;
+}
+
+template <typename T>
+inline void store_int(uint8_t* dst, T value, Endianness dst_endian) noexcept {
+    const auto resolved = resolve_endianness(dst_endian);
+    if (resolved != (host_is_little_endian() ? Endianness::Little : Endianness::Big)) {
+        value = byteswap_int(value);
+    }
+    std::memcpy(dst, &value, sizeof(T));
+}
+
+inline int32_t load_int24(const uint8_t* src, Endianness src_endian) noexcept {
+    const auto resolved = resolve_endianness(src_endian);
+    int32_t val;
+    if (resolved == Endianness::Little) {
+        val = static_cast<int32_t>(src[0])
+            | (static_cast<int32_t>(src[1]) << 8)
+            | (static_cast<int32_t>(src[2]) << 16);
+    } else {
+        val = static_cast<int32_t>(src[2])
+            | (static_cast<int32_t>(src[1]) << 8)
+            | (static_cast<int32_t>(src[0]) << 16);
+    }
+    // Sign-extend from 24-bit to 32-bit.
+    if (val & 0x800000) val |= static_cast<int32_t>(0xFF000000u);
+    return val;
+}
+
+inline void store_int24(uint8_t* dst, int32_t value, Endianness dst_endian) noexcept {
+    // Clamp to 24-bit signed range first so out-of-band int values
+    // don't corrupt adjacent bytes.
+    constexpr int32_t kMax = (1 << 23) - 1;
+    constexpr int32_t kMin = -(1 << 23);
+    if (value > kMax) value = kMax;
+    else if (value < kMin) value = kMin;
+    const auto resolved = resolve_endianness(dst_endian);
+    if (resolved == Endianness::Little) {
+        dst[0] = static_cast<uint8_t>(value & 0xFF);
+        dst[1] = static_cast<uint8_t>((value >> 8) & 0xFF);
+        dst[2] = static_cast<uint8_t>((value >> 16) & 0xFF);
+    } else {
+        dst[0] = static_cast<uint8_t>((value >> 16) & 0xFF);
+        dst[1] = static_cast<uint8_t>((value >> 8) & 0xFF);
+        dst[2] = static_cast<uint8_t>(value & 0xFF);
+    }
+}
+
+inline float finite_or_zero(float v) noexcept {
+    return std::isfinite(v) ? v : 0.0f;
+}
+
+// Scale factor for int → float normalization. We use 2^(N-1) (not
+// 2^(N-1) - 1) for the divide so the centre maps cleanly to 0 and
+// the full negative range produces -1.0 exactly. The maximum
+// positive int produces (2^(N-1) - 1) / 2^(N-1) ≈ 0.99999 (within
+// 1 LSB of +1), matching the asymmetric int range.
+constexpr float kInt8Scale  = 1.0f / 128.0f;
+constexpr float kInt16Scale = 1.0f / 32768.0f;
+constexpr float kInt24Scale = 1.0f / 8388608.0f;
+constexpr double kInt32Scale = 1.0 / 2147483648.0;
+
+} // namespace detail
+
+/// Run-time PCM converter. Construct once with a (format, endian,
+/// layout) triple; call `to_float` / `from_float` per block.
+class SampleConverter {
+public:
+    SampleConverter(SampleFormat format,
+                     Endianness endian = Endianness::Native,
+                     Layout layout = Layout::Interleaved) noexcept
+        : format_(format), endian_(endian), layout_(layout) {}
+
+    SampleFormat format() const noexcept { return format_; }
+    Endianness endian() const noexcept { return endian_; }
+    Layout layout() const noexcept { return layout_; }
+
+    /// Bytes occupied per sample (independent of layout / channel count).
+    std::size_t bytes_per_sample() const noexcept {
+        return ::pulp::audio::bytes_per_sample(format_);
+    }
+
+    /// Total byte size for `frames * channels` PCM samples in the
+    /// configured layout.
+    std::size_t bytes_for(std::size_t frames, std::size_t channels) const noexcept {
+        return frames * channels * bytes_per_sample();
+    }
+
+    /// Convert PCM bytes → planar float channels.
+    ///   - `src` must contain `bytes_for(frames, channels)` bytes.
+    ///   - `dst_channels` must point to `channels` arrays of `frames`
+    ///     floats each.
+    /// Out-of-range or unknown format is a no-op.
+    void to_float(const void* src,
+                   float* const* dst_channels,
+                   std::size_t frames,
+                   std::size_t channels) const noexcept {
+        to_float_scaled(src, dst_channels, frames, channels, 1.0f);
+    }
+
+    /// Same as `to_float` with a per-sample gain multiplier applied
+    /// during conversion (saves a second pass over the buffer).
+    void to_float_scaled(const void* src,
+                          float* const* dst_channels,
+                          std::size_t frames,
+                          std::size_t channels,
+                          float gain) const noexcept {
+        if (!src || !dst_channels || frames == 0 || channels == 0) return;
+        const auto* bytes = static_cast<const uint8_t*>(src);
+        const std::size_t bps = bytes_per_sample();
+        for (std::size_t f = 0; f < frames; ++f) {
+            for (std::size_t c = 0; c < channels; ++c) {
+                const std::size_t byte_index = byte_offset(f, c, frames, channels, bps);
+                dst_channels[c][f] = decode_sample(bytes + byte_index) * gain;
+            }
+        }
+    }
+
+    /// Convert planar float channels → PCM bytes. Float values are
+    /// clipped to [-1, +1] before quantization to integer formats;
+    /// non-finite samples are written as silence (0).
+    void from_float(const float* const* src_channels,
+                     void* dst,
+                     std::size_t frames,
+                     std::size_t channels) const noexcept {
+        if (!src_channels || !dst || frames == 0 || channels == 0) return;
+        auto* bytes = static_cast<uint8_t*>(dst);
+        const std::size_t bps = bytes_per_sample();
+        for (std::size_t f = 0; f < frames; ++f) {
+            for (std::size_t c = 0; c < channels; ++c) {
+                const std::size_t byte_index = byte_offset(f, c, frames, channels, bps);
+                encode_sample(bytes + byte_index, src_channels[c][f]);
+            }
+        }
+    }
+
+private:
+    std::size_t byte_offset(std::size_t frame,
+                             std::size_t channel,
+                             std::size_t frames,
+                             std::size_t channels,
+                             std::size_t bps) const noexcept {
+        if (layout_ == Layout::Interleaved) {
+            return (frame * channels + channel) * bps;
+        }
+        // Planar: channel `c` occupies bytes [c*frames*bps, (c+1)*frames*bps).
+        return (channel * frames + frame) * bps;
+    }
+
+    float decode_sample(const uint8_t* src) const noexcept {
+        switch (format_) {
+            case SampleFormat::Int8: {
+                const int8_t v = static_cast<int8_t>(*src);
+                return static_cast<float>(v) * detail::kInt8Scale;
+            }
+            case SampleFormat::Int16: {
+                const int16_t v = detail::load_int<int16_t>(src, endian_);
+                return static_cast<float>(v) * detail::kInt16Scale;
+            }
+            case SampleFormat::Int24: {
+                const int32_t v = detail::load_int24(src, endian_);
+                return static_cast<float>(v) * detail::kInt24Scale;
+            }
+            case SampleFormat::Int32: {
+                const int32_t v = detail::load_int<int32_t>(src, endian_);
+                return static_cast<float>(
+                    static_cast<double>(v) * detail::kInt32Scale);
+            }
+            case SampleFormat::Float32: {
+                int32_t bits = detail::load_int<int32_t>(src, endian_);
+                float f;
+                std::memcpy(&f, &bits, sizeof(float));
+                return f;
+            }
+            case SampleFormat::Float64: {
+                int64_t bits = detail::load_int<int64_t>(src, endian_);
+                double d;
+                std::memcpy(&d, &bits, sizeof(double));
+                return static_cast<float>(d);
+            }
+        }
+        return 0.0f;
+    }
+
+    void encode_sample(uint8_t* dst, float value) const noexcept {
+        value = detail::finite_or_zero(value);
+        switch (format_) {
+            case SampleFormat::Int8: {
+                value = std::clamp(value, -1.0f, 1.0f);
+                const int8_t v = static_cast<int8_t>(
+                    std::lrintf(value * 127.0f));
+                std::memcpy(dst, &v, 1);
+                return;
+            }
+            case SampleFormat::Int16: {
+                value = std::clamp(value, -1.0f, 1.0f);
+                const int16_t v = static_cast<int16_t>(
+                    std::lrintf(value * 32767.0f));
+                detail::store_int<int16_t>(dst, v, endian_);
+                return;
+            }
+            case SampleFormat::Int24: {
+                value = std::clamp(value, -1.0f, 1.0f);
+                const int32_t v = static_cast<int32_t>(
+                    std::lrintf(value * 8388607.0f));
+                detail::store_int24(dst, v, endian_);
+                return;
+            }
+            case SampleFormat::Int32: {
+                value = std::clamp(value, -1.0f, 1.0f);
+                int32_t v;
+                if (value >= 1.0f) {
+                    v = std::numeric_limits<int32_t>::max();
+                } else if (value <= -1.0f) {
+                    v = std::numeric_limits<int32_t>::min();
+                } else {
+                    v = static_cast<int32_t>(
+                        std::lrint(static_cast<double>(value) * 2147483647.0));
+                }
+                detail::store_int<int32_t>(dst, v, endian_);
+                return;
+            }
+            case SampleFormat::Float32: {
+                int32_t bits;
+                std::memcpy(&bits, &value, sizeof(int32_t));
+                detail::store_int<int32_t>(dst, bits, endian_);
+                return;
+            }
+            case SampleFormat::Float64: {
+                const double d = static_cast<double>(value);
+                int64_t bits;
+                std::memcpy(&bits, &d, sizeof(int64_t));
+                detail::store_int<int64_t>(dst, bits, endian_);
+                return;
+            }
+        }
+    }
+
+    SampleFormat format_;
+    Endianness endian_;
+    Layout layout_;
+};
+
+} // namespace pulp::audio

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2176,6 +2176,9 @@ pulp_add_test_suite(pulp-test-wavetable LIBRARIES pulp::signal)
 # macOS plan Batch G — Generic Synthesiser polyphony (item 2.5)
 pulp_add_test_suite(pulp-test-synthesiser LIBRARIES pulp::midi)
 
+# macOS plan Batch C — SampleConverter (item 1.5)
+pulp_add_test_suite(pulp-test-sample-converter LIBRARIES pulp::audio)
+
 # macOS plan Batch A — Foundations
 pulp_add_test_suite(pulp-test-dc-blocker LIBRARIES pulp::signal)
 pulp_add_test_suite(pulp-test-denormal LIBRARIES pulp::signal)

--- a/test/test_sample_converter.cpp
+++ b/test/test_sample_converter.cpp
@@ -1,0 +1,313 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <pulp/audio/sample_converter.hpp>
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <vector>
+
+using namespace pulp::audio;
+using Catch::Matchers::WithinAbs;
+using Catch::Matchers::WithinRel;
+
+// ────────────────────────────────────────────────────────────────────────
+// macOS plan item 1.5 — SampleConverter
+//
+// Convert PCM bytes ↔ planar float across:
+//   - 6 formats (Int8/16/24/32, Float32/64)
+//   - 3 endianness (Little/Big/Native — Native resolves to host)
+//   - 2 layouts (Interleaved/Planar)
+//
+// Tests pin the full matrix: every (format × endian × layout)
+// round-trips without bit loss for integer formats, and float
+// formats round-trip exactly.
+// ────────────────────────────────────────────────────────────────────────
+
+namespace {
+
+// Each test fixture allocates 4 frames × 2 channels of float, encodes
+// to bytes via converter, decodes back, and asserts equality.
+void round_trip_test(SampleFormat fmt, Endianness e, Layout layout, float epsilon) {
+    SampleConverter c(fmt, e, layout);
+    constexpr std::size_t frames = 4;
+    constexpr std::size_t channels = 2;
+    std::vector<float> ch0_in = {-1.0f, -0.5f, 0.0f, 0.5f};
+    std::vector<float> ch1_in = {0.999f, 0.25f, -0.25f, -0.75f};
+    const float* in_chs[2] = {ch0_in.data(), ch1_in.data()};
+
+    std::vector<uint8_t> bytes(c.bytes_for(frames, channels), 0);
+    c.from_float(in_chs, bytes.data(), frames, channels);
+
+    std::vector<float> ch0_out(frames, 99.0f);
+    std::vector<float> ch1_out(frames, 99.0f);
+    float* out_chs[2] = {ch0_out.data(), ch1_out.data()};
+    c.to_float(bytes.data(), out_chs, frames, channels);
+
+    for (std::size_t f = 0; f < frames; ++f) {
+        REQUIRE_THAT(ch0_out[f], WithinAbs(ch0_in[f], epsilon));
+        REQUIRE_THAT(ch1_out[f], WithinAbs(ch1_in[f], epsilon));
+    }
+}
+
+} // namespace
+
+TEST_CASE("SampleConverter accessors match construction", "[audio][sample-converter]") {
+    SampleConverter c(SampleFormat::Int16, Endianness::Big, Layout::Planar);
+    REQUIRE(c.format() == SampleFormat::Int16);
+    REQUIRE(c.endian() == Endianness::Big);
+    REQUIRE(c.layout() == Layout::Planar);
+    REQUIRE(c.bytes_per_sample() == 2);
+    REQUIRE(c.bytes_for(/*frames=*/100, /*channels=*/4) == 800);
+}
+
+TEST_CASE("bytes_per_sample matches format size", "[audio][sample-converter]") {
+    REQUIRE(bytes_per_sample(SampleFormat::Int8) == 1);
+    REQUIRE(bytes_per_sample(SampleFormat::Int16) == 2);
+    REQUIRE(bytes_per_sample(SampleFormat::Int24) == 3);
+    REQUIRE(bytes_per_sample(SampleFormat::Int32) == 4);
+    REQUIRE(bytes_per_sample(SampleFormat::Float32) == 4);
+    REQUIRE(bytes_per_sample(SampleFormat::Float64) == 8);
+}
+
+TEST_CASE("is_float identifies floating-point formats", "[audio][sample-converter]") {
+    REQUIRE(is_float(SampleFormat::Float32));
+    REQUIRE(is_float(SampleFormat::Float64));
+    REQUIRE_FALSE(is_float(SampleFormat::Int8));
+    REQUIRE_FALSE(is_float(SampleFormat::Int16));
+    REQUIRE_FALSE(is_float(SampleFormat::Int24));
+    REQUIRE_FALSE(is_float(SampleFormat::Int32));
+}
+
+// Int round-trip epsilons are 2 LSB because Pulp uses asymmetric
+// encode (scale by 2^(N-1) - 1, e.g. 32767) and decode (scale by
+// 2^(N-1), e.g. 32768). The asymmetry buys clean -1.0 representation
+// and clamped +1.0 → max-int, at the cost of ~1 LSB round-trip drift
+// at extreme positive samples.
+TEST_CASE("Int16 LE round-trips through Interleaved layout", "[audio][sample-converter]") {
+    round_trip_test(SampleFormat::Int16, Endianness::Little, Layout::Interleaved,
+                     /*eps=*/2.0f / 32768.0f);
+}
+
+TEST_CASE("Int16 BE round-trips through Interleaved layout", "[audio][sample-converter]") {
+    round_trip_test(SampleFormat::Int16, Endianness::Big, Layout::Interleaved,
+                     /*eps=*/2.0f / 32768.0f);
+}
+
+TEST_CASE("Int16 Native round-trips through Interleaved layout", "[audio][sample-converter]") {
+    round_trip_test(SampleFormat::Int16, Endianness::Native, Layout::Interleaved,
+                     /*eps=*/2.0f / 32768.0f);
+}
+
+TEST_CASE("Int16 LE round-trips through Planar layout", "[audio][sample-converter]") {
+    round_trip_test(SampleFormat::Int16, Endianness::Little, Layout::Planar,
+                     /*eps=*/2.0f / 32768.0f);
+}
+
+TEST_CASE("Int8 round-trips through all layouts", "[audio][sample-converter]") {
+    round_trip_test(SampleFormat::Int8, Endianness::Little, Layout::Interleaved, 2.0f / 128.0f);
+    round_trip_test(SampleFormat::Int8, Endianness::Little, Layout::Planar, 2.0f / 128.0f);
+}
+
+TEST_CASE("Int24 round-trips through all layouts + endianness", "[audio][sample-converter]") {
+    constexpr float eps = 2.0f / (1 << 23);
+    round_trip_test(SampleFormat::Int24, Endianness::Little, Layout::Interleaved, eps);
+    round_trip_test(SampleFormat::Int24, Endianness::Big, Layout::Interleaved, eps);
+    round_trip_test(SampleFormat::Int24, Endianness::Native, Layout::Interleaved, eps);
+    round_trip_test(SampleFormat::Int24, Endianness::Little, Layout::Planar, eps);
+    round_trip_test(SampleFormat::Int24, Endianness::Big, Layout::Planar, eps);
+}
+
+TEST_CASE("Int32 round-trips through all layouts + endianness", "[audio][sample-converter]") {
+    constexpr float eps = 1.0f / 8388608.0f;  // float precision, not int32 precision
+    round_trip_test(SampleFormat::Int32, Endianness::Little, Layout::Interleaved, eps);
+    round_trip_test(SampleFormat::Int32, Endianness::Big, Layout::Interleaved, eps);
+    round_trip_test(SampleFormat::Int32, Endianness::Little, Layout::Planar, eps);
+}
+
+TEST_CASE("Float32 round-trips exactly", "[audio][sample-converter]") {
+    round_trip_test(SampleFormat::Float32, Endianness::Little, Layout::Interleaved, 0.0f);
+    round_trip_test(SampleFormat::Float32, Endianness::Big, Layout::Interleaved, 0.0f);
+    round_trip_test(SampleFormat::Float32, Endianness::Little, Layout::Planar, 0.0f);
+    round_trip_test(SampleFormat::Float32, Endianness::Big, Layout::Planar, 0.0f);
+}
+
+TEST_CASE("Float64 round-trips within float precision", "[audio][sample-converter]") {
+    round_trip_test(SampleFormat::Float64, Endianness::Little, Layout::Interleaved, 1e-6f);
+    round_trip_test(SampleFormat::Float64, Endianness::Big, Layout::Interleaved, 1e-6f);
+    round_trip_test(SampleFormat::Float64, Endianness::Little, Layout::Planar, 1e-6f);
+}
+
+TEST_CASE("Int16 LE byte layout is correct (Interleaved 2 channels)",
+          "[audio][sample-converter]") {
+    SampleConverter c(SampleFormat::Int16, Endianness::Little, Layout::Interleaved);
+    // ch0 = 0x1234, ch1 = -0x5678 across 1 frame.
+    std::vector<float> ch0 = {0x1234 / 32768.0f};
+    std::vector<float> ch1 = {-(0x5678 / 32768.0f)};
+    const float* in[2] = {ch0.data(), ch1.data()};
+    std::vector<uint8_t> bytes(4, 0);
+    c.from_float(in, bytes.data(), 1, 2);
+    // Little-endian Int16: low byte first.
+    REQUIRE(bytes[0] == 0x34); // ch0 low byte
+    REQUIRE(bytes[1] == 0x12); // ch0 high byte
+    // -0x5678 == 0xA988 in two's complement int16. Allow ±1 LSB for the
+    // float→int rounding.
+    const int16_t got = static_cast<int16_t>(bytes[2] | (uint16_t(bytes[3]) << 8));
+    REQUIRE(std::abs(static_cast<int>(got) - (-0x5678)) <= 1);
+}
+
+TEST_CASE("Int16 BE byte layout is correct (high byte first)",
+          "[audio][sample-converter]") {
+    SampleConverter c(SampleFormat::Int16, Endianness::Big, Layout::Interleaved);
+    std::vector<float> ch0 = {0x1234 / 32768.0f};
+    const float* in[1] = {ch0.data()};
+    std::vector<uint8_t> bytes(2, 0);
+    c.from_float(in, bytes.data(), 1, 1);
+    REQUIRE(bytes[0] == 0x12); // BE: high byte first
+    REQUIRE(bytes[1] == 0x34);
+}
+
+TEST_CASE("Int24 LE byte layout — 3 bytes, low-byte first",
+          "[audio][sample-converter]") {
+    SampleConverter c(SampleFormat::Int24, Endianness::Little, Layout::Interleaved);
+    std::vector<float> ch0 = {0x123456 / 8388608.0f};
+    const float* in[1] = {ch0.data()};
+    std::vector<uint8_t> bytes(3, 0);
+    c.from_float(in, bytes.data(), 1, 1);
+    REQUIRE(bytes[0] == 0x56);
+    REQUIRE(bytes[1] == 0x34);
+    REQUIRE(bytes[2] == 0x12);
+}
+
+TEST_CASE("Int24 sign extension preserves negative values",
+          "[audio][sample-converter]") {
+    SampleConverter c(SampleFormat::Int24, Endianness::Little, Layout::Interleaved);
+    // -1.0f → -8388607 (or -8388608, format-dependent clipping)
+    std::vector<float> in_data = {-1.0f};
+    const float* in[1] = {in_data.data()};
+    std::vector<uint8_t> bytes(3, 0);
+    c.from_float(in, bytes.data(), 1, 1);
+    std::vector<float> out(1, 99.0f);
+    float* outp[1] = {out.data()};
+    c.to_float(bytes.data(), outp, 1, 1);
+    REQUIRE_THAT(out[0], WithinAbs(-1.0f, 1.0f / 8388608.0f));
+}
+
+TEST_CASE("Planar layout encodes channels in separate blocks",
+          "[audio][sample-converter]") {
+    SampleConverter c(SampleFormat::Int16, Endianness::Little, Layout::Planar);
+    // 3 frames × 2 channels.
+    std::vector<float> ch0 = {1.0f / 32768.0f, 2.0f / 32768.0f, 3.0f / 32768.0f};
+    std::vector<float> ch1 = {10.0f / 32768.0f, 20.0f / 32768.0f, 30.0f / 32768.0f};
+    const float* in[2] = {ch0.data(), ch1.data()};
+    std::vector<uint8_t> bytes(12, 0);
+    c.from_float(in, bytes.data(), 3, 2);
+
+    // Read channel 0 block (bytes 0..5) as 3 Int16 LE values: 1, 2, 3.
+    auto read_le16 = [&](std::size_t offset) {
+        return static_cast<int16_t>(
+            bytes[offset] | (uint16_t(bytes[offset + 1]) << 8));
+    };
+    REQUIRE(read_le16(0) == 1);
+    REQUIRE(read_le16(2) == 2);
+    REQUIRE(read_le16(4) == 3);
+    // Channel 1 block (bytes 6..11): 10, 20, 30.
+    REQUIRE(read_le16(6) == 10);
+    REQUIRE(read_le16(8) == 20);
+    REQUIRE(read_le16(10) == 30);
+}
+
+TEST_CASE("Float32 from_float clips at ±1.0 for integer destinations",
+          "[audio][sample-converter]") {
+    SampleConverter c(SampleFormat::Int16, Endianness::Native, Layout::Interleaved);
+    std::vector<float> in_data = {2.0f, -2.0f, 0.5f};
+    const float* in[1] = {in_data.data()};
+    std::vector<uint8_t> bytes(6, 0);
+    c.from_float(in, bytes.data(), 3, 1);
+    std::vector<float> out(3, 99.0f);
+    float* outp[1] = {out.data()};
+    c.to_float(bytes.data(), outp, 3, 1);
+    REQUIRE_THAT(out[0], WithinAbs(1.0f, 1.0f / 32768.0f));   // clipped from +2
+    REQUIRE_THAT(out[1], WithinAbs(-1.0f, 1.0f / 32768.0f));  // clipped from -2
+    REQUIRE_THAT(out[2], WithinAbs(0.5f, 1.0f / 32768.0f));   // in range
+}
+
+TEST_CASE("Non-finite input float becomes silence when encoding to int",
+          "[audio][sample-converter]") {
+    SampleConverter c(SampleFormat::Int16, Endianness::Native, Layout::Interleaved);
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+    const float inf = std::numeric_limits<float>::infinity();
+    std::vector<float> in_data = {nan, inf, -inf};
+    const float* in[1] = {in_data.data()};
+    std::vector<uint8_t> bytes(6, 0);
+    c.from_float(in, bytes.data(), 3, 1);
+    std::vector<float> out(3, 99.0f);
+    float* outp[1] = {out.data()};
+    c.to_float(bytes.data(), outp, 3, 1);
+    REQUIRE_THAT(out[0], WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(out[1], WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(out[2], WithinAbs(0.0f, 1e-6f));
+}
+
+TEST_CASE("to_float_scaled applies gain during conversion",
+          "[audio][sample-converter]") {
+    SampleConverter c(SampleFormat::Int16, Endianness::Native, Layout::Interleaved);
+    std::vector<float> in_data = {0.5f};
+    const float* in[1] = {in_data.data()};
+    std::vector<uint8_t> bytes(2, 0);
+    c.from_float(in, bytes.data(), 1, 1);
+
+    std::vector<float> out(1, 99.0f);
+    float* outp[1] = {out.data()};
+    c.to_float_scaled(bytes.data(), outp, 1, 1, /*gain=*/2.0f);
+    REQUIRE_THAT(out[0], WithinAbs(1.0f, 1.0f / 32768.0f));
+}
+
+TEST_CASE("SampleConverter null inputs are no-op", "[audio][sample-converter]") {
+    SampleConverter c(SampleFormat::Int16, Endianness::Native, Layout::Interleaved);
+    float dummy = 99.0f;
+    float* outp[1] = {&dummy};
+    REQUIRE_NOTHROW(c.to_float(nullptr, outp, 1, 1));
+    REQUIRE_NOTHROW(c.to_float(&dummy, nullptr, 1, 1));
+    REQUIRE_NOTHROW(c.from_float(nullptr, &dummy, 1, 1));
+    REQUIRE_NOTHROW(c.from_float(reinterpret_cast<const float* const*>(&dummy),
+                                   nullptr, 1, 1));
+    // Zero counts are also no-op.
+    std::vector<uint8_t> bytes(8, 0xAA);
+    REQUIRE_NOTHROW(c.to_float(bytes.data(), outp, 0, 1));
+    REQUIRE_NOTHROW(c.to_float(bytes.data(), outp, 1, 0));
+}
+
+TEST_CASE("All 6 formats × 3 endians × 2 layouts round-trip",
+          "[audio][sample-converter][matrix]") {
+    constexpr SampleFormat formats[] = {
+        SampleFormat::Int8, SampleFormat::Int16, SampleFormat::Int24,
+        SampleFormat::Int32, SampleFormat::Float32, SampleFormat::Float64,
+    };
+    constexpr Endianness endians[] = {
+        Endianness::Little, Endianness::Big, Endianness::Native,
+    };
+    constexpr Layout layouts[] = {
+        Layout::Interleaved, Layout::Planar,
+    };
+    int cases = 0;
+    for (auto fmt : formats) {
+        // Pick a per-format tolerance: int formats see ~2 LSB
+        // round-trip drift at extreme positives (asymmetric encode/
+        // decode scaling — see per-format tests above for rationale).
+        // Float formats are exact (Float32) or float-precision (Float64).
+        const float eps = is_float(fmt) ? (fmt == SampleFormat::Float64 ? 1e-6f : 0.0f)
+                                         : 2.0f / static_cast<float>(
+                                               1u << (static_cast<int>(
+                                                   bytes_per_sample(fmt)) * 8 - 1));
+        for (auto e : endians) {
+            for (auto l : layouts) {
+                round_trip_test(fmt, e, l, eps);
+                ++cases;
+            }
+        }
+    }
+    REQUIRE(cases == 36);
+}


### PR DESCRIPTION
## Summary

macOS plan **Batch C — item 1.5**: `pulp::audio::SampleConverter` — first-class converter for packed-PCM byte streams ↔ planar float channels.

### Surface

Three independent axes, configured at construction:

| Axis | Values |
|---|---|
| `SampleFormat` | `Int8 / Int16 / Int24 / Int32 / Float32 / Float64` |
| `Endianness` | `Little / Big / Native` (Native resolves to host) |
| `Layout` | `Interleaved / Planar` |

API:
- `to_float(src, dst_channels, frames, channels)` — decode bytes → planar float
- `to_float_scaled(..., gain)` — same with per-sample gain (no second pass)
- `from_float(src_channels, dst, frames, channels)` — encode planar float → bytes
- `bytes_per_sample()` / `bytes_for(frames, channels)` helpers
- Free functions: `is_float(format)`, `bytes_per_sample(format)`

### Design notes

- **Header-only.** Matches the rest of `pulp::audio`'s layout; small enough that inlining matters more than link time.
- **Endianness via `std::endian::native`.** Mismatch triggers a portable per-type byteswap.
- **Int24 = 3 bytes packed.** Explicit LE/BE byte layout + 24→32 sign extension on load + ±2²³−1 clamp on store.
- **Float ↔ int asymmetric scaling.** Encode by `2^(N-1) - 1` (clean +1.0 → max int), decode by `2^(N-1)` (clean -1.0 ← min int). Round-trip drift at extremes is ~1 LSB; tests bound at 2 LSB.
- **Non-finite floats → silence (0)** when encoding to int (matches the audio convention).
- **Out-of-range floats clip to ±1.0.**

## Test plan

- [x] `pulp-test-sample-converter` — 502 assertions / 22 cases ✓
  - Accessors match construction
  - `bytes_per_sample`, `is_float` free functions
  - **36-combination matrix sweep**: every (6 formats × 3 endians × 2 layouts)
  - Per-format spot checks: Int8/16/24/32, Float32/64 across all endian + layout combinations
  - Byte-layout pins: Int16 LE (low byte first), Int16 BE (high byte first), Int24 LE (3 bytes packed)
  - Int24 sign extension preserves negative values
  - Planar layout encodes channels in separate contiguous blocks
  - `from_float` clips at ±1.0 for int destinations
  - NaN / +Inf / -Inf become silence when encoding to int
  - `to_float_scaled` applies gain during conversion
  - Null pointer + zero count = no-op (safe defaults)

## Notes

- Minor version bump for new public surface.
- Closes gap doc row "AudioDataConverters" → `Full`.
- Existing `audio_file.cpp` per-format helpers remain for backward-compat; new code should reach for `SampleConverter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)