### PR TITLE
fix(midi): SynthesiserVoice::on_note_off syncs note_.releasing (Codex P2 on #2870)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.224.0
+    VERSION 0.224.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/midi/include/pulp/midi/synthesiser.hpp
+++ b/core/midi/include/pulp/midi/synthesiser.hpp
@@ -82,8 +82,13 @@ public:
     /// Begin release. Subclasses typically schedule envelope release
     /// here; when the envelope tail completes they should call
     /// `mark_inactive()` so the synth's free-voice scan can reclaim
-    /// the slot.
-    virtual void on_note_off() { releasing_ = true; }
+    /// the slot. Keeps `note_.releasing` in sync with the `releasing_`
+    /// member so subclasses reading either path see the same state
+    /// (Codex P2 on #2870).
+    virtual void on_note_off() {
+        releasing_ = true;
+        note_.releasing = true;
+    }
 
     /// Channel-level pitch bend (semitones, already scaled by the
     /// configured bend range). Default no-op — override to apply.

--- a/test/test_synthesiser.cpp
+++ b/test/test_synthesiser.cpp
@@ -140,6 +140,10 @@ TEST_CASE("Synthesiser note_off marks the matching voice as releasing",
     REQUIRE(synth.voice(0).releasing());
     // Still active until the subclass calls mark_inactive().
     REQUIRE(synth.voice(0).active());
+    // Codex P2 on #2870 — `note().releasing` MUST stay in sync with
+    // the voice's `releasing_` flag so subclasses reading either
+    // path see the same state.
+    REQUIRE(synth.voice(0).note().releasing);
 }
 
 TEST_CASE("Synthesiser note_on velocity 0 is a note-off", "[midi][synth]") {


### PR DESCRIPTION
## Summary

Codex P2 follow-up on **#2870** — `SynthesiserVoice::on_note_off` only flipped the `releasing_` member without updating `note_.releasing`. Subclasses reading `note().releasing` for envelope or steal logic saw stale `false` even after note-off.

## Fix

Keep both fields in sync.

## Test plan

- [x] `pulp-test-synthesiser` — 596 assertions / 20 cases ✓ (was 595/20)
  - Existing "Synthesiser note_off marks the matching voice as releasing" now also asserts `voice(0).note().releasing == true`.

## Notes

- Patch version bump 0.224.0 → 0.224.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)