### PR TITLE
feat(cli): pulp identity record + build --check-identity (item 3.12)

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -1198,3 +1198,49 @@ Notes for CLI maintenance:
 - Companion runtime signal: `decide_gpu_host` (core/format/gpu_host_select.hpp)
   logs `build=debug|release` on the `[plugin-gpu-host]` adapter line and warns
   once on Debug, so a host log immediately shows which build was loaded.
+
+## `pulp identity` — committed plugin identity lockfile
+
+Track 3.12 (macOS plugin-authoring plan) introduced a Rust-side surface
+for managing `.pulp/identity.lock`, the committed pin of each plugin's
+host-visible identity (AU 4CC + manufacturer code, AAX product code,
+optional VST3 FUID, optional CLAP id, version). Lives in
+`experimental/pulp-rs/src/cmd/identity.rs`; schema doc at
+`docs/reference/identity-lock.md`.
+
+Surface:
+
+- `pulp identity record [--allow-identity-change] [--dry-run]` —
+  refresh the lockfile. Refuses to overwrite drifted entries without
+  `--allow-identity-change` (the audit-trail flag a reviewer can grep
+  in the commit message).
+- `pulp identity check [--allow-identity-change]` — pure read; exit
+  1 on drift, 0 with `--allow-identity-change`. CI-friendly.
+- `pulp build --check-identity [--allow-identity-change]` — runs the
+  check before the configure step so a drifted PR fails the whole
+  build, not just a downstream gate. Wired in
+  `cmd::orchestrate::build_with`.
+
+Gotchas (lessons from the slice):
+
+- **Empty recorded fields are NOT drift.** `vst3_fuid` and
+  `clap_plugin_id` are optional today because the recorder doesn't yet
+  scrape `Steinberg::FUID(...)` literals out of source files. The diff
+  treats `recorded == ""` as "not yet pinned" — only non-empty
+  recorded values that no longer match the current source trigger a
+  failure. A future slice can teach `parse_plugins_from_text` to walk
+  source-side identity declarations once the regex shape is locked in.
+- **Single-file CMake scan.** `parse_plugins_from_cmake` reads the
+  project's top-level `CMakeLists.txt`. Nested `pulp_add_plugin(...)`
+  invocations under `add_subdirectory(...)` are out of scope today —
+  add a CMake-tree-walker if real projects start hiding plugin
+  declarations in nested files.
+- **Lock file is reviewable.** TOML output is sorted by `target` and
+  uses `to_string_pretty`, so `git diff .pulp/identity.lock` is
+  always linear. Don't switch to `to_string` (compact) — the on-disk
+  layout being readable is the whole point.
+- **Two flag sites, same semantics.** `--allow-identity-change` works
+  on both `pulp identity {record,check}` and `pulp build
+  --check-identity`. Keep them in lockstep — the orchestrate path
+  re-uses `cmd::identity::run(Check)` rather than re-implementing the
+  comparison.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.227.0
+    VERSION 0.228.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -89,9 +89,13 @@ pulp build -j8                # Parallel jobs
 pulp build --watch            # Build and watch for changes
 pulp build --watch --test     # Build, watch, run tests on change
 pulp build --allow-unsupported-sdk # Bypass the CLI-vs-project SDK guard (unsupported)
+pulp build --check-identity    # Verify .pulp/identity.lock before configure (Track 3.12)
+pulp build --check-identity --allow-identity-change  # Treat identity drift as a warning
 ```
 
 Extra arguments are passed through to `cmake --build`.
+
+`--check-identity` runs the same comparison as `pulp identity check` before the configure step, so a PR that changes an AU 4CC / VST3 FUID / CLAP id / AAX product code without re-recording the lock fails the build with a per-field diff. See `docs/reference/identity-lock.md`.
 
 The `--watch` flag enters a file-watching loop after the initial build. It polls source files every 500ms and rebuilds on changes. Combine with `--test` to run tests after each successful rebuild and `--validate` to run quick dlopen checks.
 
@@ -1204,6 +1208,22 @@ Flags:
 | `--id <unique-id>` | Select a specific plug-in descriptor by URI / unique-id (used for LV2 and multi-plugin CLAP bundles) |
 
 Prints plug-in metadata (name, vendor, version, format, parameter count) and the peak output level from a 256-sample synthetic block at 48 kHz. Exit code 0 on success, 1 if the bundle could not be loaded, 2 if `prepare()` failed.
+
+### identity
+
+**Status**: experimental
+
+Manage `.pulp/identity.lock` — the committed pin of each plugin's AU 4CC, manufacturer code, AAX product code, optional VST3 FUID, and optional CLAP plugin id. The lock is the audit trail that "this plugin's host-visible identity has not silently changed". See [docs/reference/identity-lock.md](identity-lock.md) for the schema and Track 3.12 of the macOS plugin-authoring plan for the rationale.
+
+```bash
+pulp identity record                              # Write/refresh .pulp/identity.lock
+pulp identity record --allow-identity-change      # Accept drift and overwrite the lock
+pulp identity record --dry-run                    # Print what would be written
+pulp identity check                               # Compare lock vs project, exit 1 on drift
+pulp identity check --allow-identity-change       # Treat drift as success
+```
+
+The same check is wired into `pulp build --check-identity` so CI can fail any PR that changes a host-visible identity field without an explicit `pulp identity record --allow-identity-change` step.
 
 ### tool
 

--- a/docs/reference/identity-lock.md
+++ b/docs/reference/identity-lock.md
@@ -1,0 +1,154 @@
+# `.pulp/identity.lock` — plugin identity pin
+
+`.pulp/identity.lock` is a committed lockfile that records the
+**stable identity** of every plugin in a Pulp project: AU four-character
+component subtype + manufacturer code, AAX product code, optional
+VST3 FUID, optional CLAP plugin id, and the project version those
+fields are released against. The lock travels with the source so
+unintended drift in any of these fields surfaces at review time
+instead of after a release — a changed AU 4CC or VST3 FUID silently
+invalidates every saved DAW session that referenced the previous
+identity.
+
+This document describes the file format. The CLI surface that
+reads and writes it is `pulp identity record` /
+`pulp identity check`, with the same checks wired into
+`pulp build --check-identity` (see Track 3.12 of
+`planning/2026-05-24-macos-plugin-authoring-plan.md`).
+
+## Where it lives
+
+```
+<project-root>/.pulp/identity.lock
+```
+
+`.pulp/` is created automatically by `pulp identity record` when
+needed. The directory is reserved for committed CLI-managed state;
+do not put scratch files there.
+
+## Format (schema = 1)
+
+The lockfile is TOML. The on-disk shape is intentionally narrow so a
+human reviewer can read a `git diff` and immediately tell whether a
+change is a typo, a rename, or a deliberate identity flip.
+
+```toml
+schema = 1
+
+[[plugins]]
+target               = "PulpGain"      # CMake target name
+plugin_name          = "PulpGain"      # PLUGIN_NAME or target
+manufacturer         = "Pulp"
+bundle_id            = "com.pulp.gain"
+version              = "1.0.0"
+au_plugin_code       = "PGan"          # 4 chars, PLUGIN_CODE
+au_manufacturer_code = "Pulp"          # 4 chars, MANUFACTURER_CODE
+aax_product_code     = "PGaP"          # 4 chars, AAX_PRODUCT_CODE
+# Optional — empty strings are omitted on write.
+# vst3_fuid          = "Steinberg::FUID(0x..., 0x..., 0x..., 0x...)"
+# clap_plugin_id     = "com.pulp.gain"
+```
+
+### Field reference
+
+| Field                  | Required | Source                                   | Drift = lost compat in |
+|------------------------|----------|------------------------------------------|------------------------|
+| `target`               | yes      | `pulp_add_plugin(<target> ...)`          | n/a — lookup key       |
+| `plugin_name`          | yes      | `PLUGIN_NAME` (default = `target`)       | Display name only      |
+| `manufacturer`         | yes      | `MANUFACTURER`                           | All formats            |
+| `bundle_id`            | yes      | `BUNDLE_ID`                              | macOS bundle id, AU    |
+| `version`              | yes      | `VERSION`                                | Host upgrade banners   |
+| `au_plugin_code`       | optional | `PLUGIN_CODE` (4-char ASCII)             | **AU saved sessions**  |
+| `au_manufacturer_code` | optional | `MANUFACTURER_CODE` (4-char ASCII)       | **AU saved sessions**  |
+| `aax_product_code`     | optional | `AAX_PRODUCT_CODE` (4-char ASCII)        | AAX saved sessions     |
+| `vst3_fuid`            | optional | `Steinberg::FUID(...)` literal in source | **VST3 saved sessions**|
+| `clap_plugin_id`       | optional | CLAP plugin descriptor (reverse-DNS)     | **CLAP saved sessions**|
+
+"Optional" means the field is permitted to be the empty string in the
+lock — typically because the project hasn't pinned that identity
+surface yet. An empty recorded value is treated as **"not yet pinned"**
+and never triggers drift; the recorder fills it in on the next
+`pulp identity record` run. A non-empty recorded value that no longer
+matches the current source **is** drift and blocks the build unless
+the developer explicitly accepts the change.
+
+### Schema versioning
+
+`schema` is an integer. The current schema is `1`. The CLI refuses
+to parse a lock whose `schema` exceeds the version it understands; a
+schema bump is reserved for required-field additions or layout
+changes that would otherwise silently lose information.
+
+## Workflows
+
+### First-time setup
+
+```bash
+cd <project>
+pulp identity record
+git add .pulp/identity.lock
+git commit -m "chore: pin plugin identity"
+```
+
+### Continuous integration
+
+Add `pulp build --check-identity` to the CI build step. Any PR that
+changes an AU 4CC, VST3 FUID, CLAP id, or AAX product code without
+also re-running `pulp identity record --allow-identity-change` fails
+the build with a per-field diff:
+
+```
+pulp identity check: drift detected:
+  - PulpGain.au_plugin_code: lock="PGan" vs current="PGn2"
+pulp identity check: run `pulp identity record --allow-identity-change`
+to accept the change, or revert the source to match the lock.
+```
+
+### Deliberately changing an identity
+
+A deliberate identity change is rare — it loses host compatibility
+with every saved session that referenced the previous identity. When
+it does happen, accept the change explicitly:
+
+```bash
+pulp identity record --allow-identity-change
+git diff .pulp/identity.lock        # review the change
+git commit .pulp/identity.lock
+```
+
+The diff against the previous lock is the audit trail. Reviewers
+should treat any non-trivial change to this file the same way they
+treat a public API rename — it's a breaking change that needs an
+explicit decision.
+
+## CLI reference
+
+| Command                                              | Effect                                                                                     | Exit code |
+|------------------------------------------------------|--------------------------------------------------------------------------------------------|-----------|
+| `pulp identity record`                               | Refresh the lockfile from the project's current state. Refuses to overwrite drifted entries. | 0 ok / 1 drift refused |
+| `pulp identity record --allow-identity-change`       | As above but accepts drift and writes anyway.                                              | 0         |
+| `pulp identity record --dry-run`                     | Print the would-be lock without writing it.                                                | 0         |
+| `pulp identity check`                                | Compare current state against the lock. No writes.                                         | 0 ok / 1 drift |
+| `pulp identity check --allow-identity-change`        | As above but treats drift as success (still prints the diff).                              | 0         |
+| `pulp build --check-identity`                        | Run `identity check` before configuring; abort the build on drift.                         | 0 ok / 1 drift |
+| `pulp build --check-identity --allow-identity-change`| As above but treats drift as a warning, not a build break.                                 | 0         |
+
+## Implementation notes
+
+- The recorder parses `pulp_add_plugin(...)` blocks out of the
+  project's top-level `CMakeLists.txt`. A follow-up slice can teach
+  it to follow `add_subdirectory` / `include` directives if real
+  projects start hiding plugin declarations in nested files.
+- `vst3_fuid` and `clap_plugin_id` are present in the schema today
+  but the recorder leaves them blank pending a regex shape for the
+  source-side scrape. They can be edited by hand in the lock without
+  breaking the check — the comparison only fires when both sides
+  carry a non-empty value.
+- The lockfile sort order is stable (`plugins` sorted by `target`)
+  so review diffs stay readable across recordings.
+
+## See also
+
+- `planning/2026-05-24-macos-plugin-authoring-plan.md` § 3.12
+- `core/format/include/pulp/format/processor.hpp` — `PluginDescriptor`
+- `tools/cmake/PulpUtils.cmake` — `pulp_add_plugin(...)` definition

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -12,6 +12,12 @@ commands:
       - name: --allow-unsupported-sdk
         kind: flag
         description: Bypass the CLI-vs-project SDK compatibility guard and continue anyway (unsupported)
+      - name: --check-identity
+        kind: flag
+        description: Verify `.pulp/identity.lock` matches the current plugin identity before configuring. Aborts the build on drift. See `docs/reference/identity-lock.md`.
+      - name: --allow-identity-change
+        kind: flag
+        description: Paired with `--check-identity`, treats drift as a warning instead of a build break.
       - name: extra_args
         kind: passthrough
         description: Passed through to cmake --build (e.g., --target, -j)
@@ -1084,6 +1090,24 @@ commands:
         kind: flag
         description: Verify package license compatibility
     docs: reference/cli.md#audit-package-extensions
+
+  - name: identity
+    status: experimental
+    summary: Manage `.pulp/identity.lock` — the committed pin of each plugin's AU 4CC, manufacturer code, AAX product code, optional VST3 FUID, and optional CLAP plugin id. Implements Track 3.12 of the macOS plugin-authoring plan.
+    args:
+      - name: record
+        kind: subcommand
+        description: Refresh `.pulp/identity.lock` from the project's current `pulp_add_plugin(...)` declarations. Refuses to overwrite drifted entries without `--allow-identity-change`.
+      - name: check
+        kind: subcommand
+        description: Compare `.pulp/identity.lock` against the project's current state. Exit 1 on drift, 0 with `--allow-identity-change`.
+      - name: --allow-identity-change
+        kind: flag
+        description: Treat identity drift as success (still prints the diff). Pairs with `record` and `check`.
+      - name: --dry-run
+        kind: flag
+        description: With `record`, print the would-be lock without touching disk.
+    docs: reference/identity-lock.md
 
   - name: help
     status: usable

--- a/experimental/pulp-rs/src/cmd/identity.rs
+++ b/experimental/pulp-rs/src/cmd/identity.rs
@@ -1,0 +1,951 @@
+//! `pulp identity record` + identity-lock comparison helpers.
+//!
+//! Implements Track 3.12 of the macOS plugin-authoring plan
+//! (`planning/2026-05-24-macos-plugin-authoring-plan.md`): a committed
+//! `.pulp/identity.lock` records the canonical AU 4CC, manufacturer
+//! code, VST3 FUID, CLAP plugin ID, AAX product ID, and version of
+//! each plugin in a Pulp project. The lock travels with the source so
+//! that drift in any of those identity fields surfaces at build /
+//! review time instead of as a "my DAW lost its preset" mystery
+//! months later.
+//!
+//! # Why a lockfile, not a derived value?
+//!
+//! Hosts (DAWs) cache plugin identity. Changing the AU 4CC, the
+//! VST3 FUID, or the CLAP plugin ID after a release silently breaks
+//! every saved session that referenced the previous identity. The
+//! lock makes "this identity is permanent" an explicit, reviewable
+//! commit — and `pulp build --check-identity` (see
+//! [`crate::cmd::orchestrate`]) refuses to build when the developer
+//! has changed the identity without consciously bumping the lock.
+//!
+//! # Schema
+//!
+//! See `docs/reference/identity-lock.md`. The TOML shape is:
+//!
+//! ```toml
+//! schema = 1
+//!
+//! [[plugins]]
+//! target = "PulpGain"
+//! plugin_name = "PulpGain"
+//! manufacturer = "Pulp"
+//! bundle_id = "com.pulp.gain"
+//! version = "1.0.0"
+//! au_plugin_code = "PGan"
+//! au_manufacturer_code = "Pulp"
+//! aax_product_code = "PGaP"
+//! vst3_fuid = ""              # optional — empty when not declared yet
+//! clap_plugin_id = ""         # optional
+//! ```
+//!
+//! `vst3_fuid` and `clap_plugin_id` are optional because they're
+//! typically declared in the plugin's C++ source, not in
+//! `pulp_add_plugin(...)`. The Rust port reads what's present in
+//! `CMakeLists.txt` today; a follow-up slice can teach the recorder
+//! to scrape `Steinberg::FUID(...)` literals out of source files
+//! once a regex shape is locked in.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{CliError, Result};
+
+/// One plugin entry inside `.pulp/identity.lock`.
+///
+/// Field order matches the on-disk TOML so `toml::to_string_pretty`
+/// emits a stable, review-friendly layout.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PluginIdentity {
+    /// CMake target name passed to `pulp_add_plugin(<target> ...)`.
+    pub target: String,
+    /// Human-readable plugin name (PLUGIN_NAME, falls back to target).
+    pub plugin_name: String,
+    /// Manufacturer / vendor string.
+    pub manufacturer: String,
+    /// Reverse-DNS bundle identifier.
+    pub bundle_id: String,
+    /// Semver string driving format-side version metadata.
+    pub version: String,
+    /// 4-char AU component subtype (`PLUGIN_CODE`).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub au_plugin_code: String,
+    /// 4-char AU manufacturer code (`MANUFACTURER_CODE`).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub au_manufacturer_code: String,
+    /// 4-char AAX product code (`AAX_PRODUCT_CODE`).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub aax_product_code: String,
+    /// VST3 FUID literal (e.g. `Steinberg::FUID(0x..., 0x..., 0x..., 0x...)`).
+    /// Optional — empty until a recorder slice scrapes it from source.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub vst3_fuid: String,
+    /// CLAP plugin id (reverse-DNS, e.g. `com.pulp.gain`).
+    /// Optional — defaults to `bundle_id` when not explicitly recorded.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub clap_plugin_id: String,
+}
+
+/// Top-level `.pulp/identity.lock` document.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityLock {
+    /// Lockfile schema version. `1` today.
+    pub schema: u32,
+    /// One entry per `pulp_add_plugin(...)` invocation found in the
+    /// project. Sorted by `target` so the on-disk order is stable.
+    #[serde(default)]
+    pub plugins: Vec<PluginIdentity>,
+}
+
+impl IdentityLock {
+    /// Current schema version. Bump when adding required fields.
+    pub const CURRENT_SCHEMA: u32 = 1;
+
+    /// Default empty document at the current schema.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            schema: Self::CURRENT_SCHEMA,
+            plugins: Vec::new(),
+        }
+    }
+
+    /// Path of `.pulp/identity.lock` under a project root.
+    #[must_use]
+    pub fn path_for(project_root: &Path) -> PathBuf {
+        project_root.join(".pulp").join("identity.lock")
+    }
+
+    /// Serialize to TOML in a stable, review-friendly form.
+    ///
+    /// # Errors
+    ///
+    /// [`CliError::Other`] if TOML serialization fails (should not
+    /// happen for the schema above).
+    pub fn to_toml(&self) -> Result<String> {
+        toml::to_string_pretty(self).map_err(|e| CliError::Other(format!("toml encode: {e}")))
+    }
+
+    /// Parse from TOML.
+    ///
+    /// # Errors
+    ///
+    /// [`CliError::Other`] on TOML parse failure.
+    pub fn from_toml(body: &str) -> Result<Self> {
+        toml::from_str(body).map_err(|e| CliError::Other(format!("identity.lock parse: {e}")))
+    }
+
+    /// Read from `<root>/.pulp/identity.lock`, returning `Ok(None)`
+    /// when the file is absent so callers can distinguish "no lock
+    /// yet" from "lock present but mismatched".
+    ///
+    /// # Errors
+    ///
+    /// [`CliError::Other`] on IO failure other than `NotFound`, or
+    /// TOML parse failure.
+    pub fn load(project_root: &Path) -> Result<Option<Self>> {
+        let path = Self::path_for(project_root);
+        match std::fs::read_to_string(&path) {
+            Ok(body) => Self::from_toml(&body).map(Some),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(CliError::Other(format!(
+                "read {}: {e}",
+                path.display()
+            ))),
+        }
+    }
+
+    /// Write to `<root>/.pulp/identity.lock`, creating `.pulp/` if it
+    /// doesn't exist yet.
+    ///
+    /// # Errors
+    ///
+    /// [`CliError::Other`] on IO failure or TOML encoding failure.
+    pub fn save(&self, project_root: &Path) -> Result<PathBuf> {
+        let dir = project_root.join(".pulp");
+        if let Err(e) = std::fs::create_dir_all(&dir) {
+            return Err(CliError::Other(format!(
+                "mkdir {}: {e}",
+                dir.display()
+            )));
+        }
+        let path = Self::path_for(project_root);
+        let body = self.to_toml()?;
+        std::fs::write(&path, body)
+            .map_err(|e| CliError::Other(format!("write {}: {e}", path.display())))?;
+        Ok(path)
+    }
+
+    /// Find a plugin entry by `target`. `None` when not recorded.
+    #[must_use]
+    pub fn find(&self, target: &str) -> Option<&PluginIdentity> {
+        self.plugins.iter().find(|p| p.target == target)
+    }
+
+    /// Replace-or-insert by `target` and re-sort so the on-disk
+    /// order stays stable across edits.
+    pub fn upsert(&mut self, entry: PluginIdentity) {
+        if let Some(slot) = self.plugins.iter_mut().find(|p| p.target == entry.target) {
+            *slot = entry;
+        } else {
+            self.plugins.push(entry);
+        }
+        self.plugins.sort_by(|a, b| a.target.cmp(&b.target));
+    }
+}
+
+/// A single identity-drift finding produced by [`diff_lock`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DriftFinding {
+    /// Target whose identity has drifted.
+    pub target: String,
+    /// Field name (`au_plugin_code`, `vst3_fuid`, …).
+    pub field: &'static str,
+    /// Recorded value from `.pulp/identity.lock`.
+    pub recorded: String,
+    /// Current value parsed from the project source.
+    pub current: String,
+}
+
+impl std::fmt::Display for DriftFinding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{target}.{field}: lock={recorded:?} vs current={current:?}",
+            target = self.target,
+            field = self.field,
+            recorded = self.recorded,
+            current = self.current,
+        )
+    }
+}
+
+/// Compare two identity sets keyed by target. Findings cover:
+///
+/// - Missing targets on either side (lock-only or current-only entries).
+/// - Per-field drift for matching targets.
+///
+/// Empty `recorded` lock fields are treated as "not pinned yet" and
+/// never produce a drift finding — the recorder fills them in on the
+/// next `pulp identity record` rather than failing the build.
+#[must_use]
+pub fn diff_lock(
+    recorded: &IdentityLock,
+    current: &[PluginIdentity],
+) -> Vec<DriftFinding> {
+    let mut out = Vec::new();
+    let recorded_by_target: BTreeMap<&str, &PluginIdentity> = recorded
+        .plugins
+        .iter()
+        .map(|p| (p.target.as_str(), p))
+        .collect();
+    let current_by_target: BTreeMap<&str, &PluginIdentity> = current
+        .iter()
+        .map(|p| (p.target.as_str(), p))
+        .collect();
+
+    for (target, cur) in &current_by_target {
+        let Some(rec) = recorded_by_target.get(target) else {
+            out.push(DriftFinding {
+                target: (*target).to_owned(),
+                field: "<plugin>",
+                recorded: "<absent>".to_owned(),
+                current: "<present>".to_owned(),
+            });
+            continue;
+        };
+        diff_field(target, "plugin_name", &rec.plugin_name, &cur.plugin_name, &mut out);
+        diff_field(target, "manufacturer", &rec.manufacturer, &cur.manufacturer, &mut out);
+        diff_field(target, "bundle_id", &rec.bundle_id, &cur.bundle_id, &mut out);
+        diff_field(target, "version", &rec.version, &cur.version, &mut out);
+        diff_field(target, "au_plugin_code", &rec.au_plugin_code, &cur.au_plugin_code, &mut out);
+        diff_field(
+            target,
+            "au_manufacturer_code",
+            &rec.au_manufacturer_code,
+            &cur.au_manufacturer_code,
+            &mut out,
+        );
+        diff_field(target, "aax_product_code", &rec.aax_product_code, &cur.aax_product_code, &mut out);
+        diff_field(target, "vst3_fuid", &rec.vst3_fuid, &cur.vst3_fuid, &mut out);
+        diff_field(target, "clap_plugin_id", &rec.clap_plugin_id, &cur.clap_plugin_id, &mut out);
+    }
+
+    for (target, rec) in &recorded_by_target {
+        if !current_by_target.contains_key(target) {
+            out.push(DriftFinding {
+                target: (*target).to_owned(),
+                field: "<plugin>",
+                recorded: "<present>".to_owned(),
+                current: "<absent>".to_owned(),
+            });
+            let _ = rec; // silence unused binding warning on the borrow.
+        }
+    }
+
+    out
+}
+
+fn diff_field(
+    target: &str,
+    field: &'static str,
+    recorded: &str,
+    current: &str,
+    out: &mut Vec<DriftFinding>,
+) {
+    // Treat empty recorded slots as "not yet pinned" — the recorder
+    // fills them in on the next run rather than failing the build.
+    if recorded.is_empty() {
+        return;
+    }
+    if recorded != current {
+        out.push(DriftFinding {
+            target: target.to_owned(),
+            field,
+            recorded: recorded.to_owned(),
+            current: current.to_owned(),
+        });
+    }
+}
+
+// ── CMakeLists.txt → PluginIdentity parser ───────────────────────────
+
+/// Scan a project's `CMakeLists.txt` (and any included files) for
+/// `pulp_add_plugin(<target> ...)` blocks and lift their identity
+/// fields into [`PluginIdentity`] structs.
+///
+/// This is intentionally a single-file regex scan today — the same
+/// shape Pulp uses elsewhere (see `cmd::version::plugin_re`). A
+/// follow-up slice can teach it to follow `add_subdirectory` /
+/// `include` directives if real projects start hiding plugin
+/// declarations in nested files.
+///
+/// # Errors
+///
+/// [`CliError::Other`] when the file cannot be read.
+pub fn parse_plugins_from_cmake(cmake_path: &Path) -> Result<Vec<PluginIdentity>> {
+    let body = std::fs::read_to_string(cmake_path).map_err(|e| {
+        CliError::Other(format!("read {}: {e}", cmake_path.display()))
+    })?;
+    Ok(parse_plugins_from_text(&body))
+}
+
+/// Parse `pulp_add_plugin(...)` blocks out of an in-memory CMake
+/// source body. Exposed so tests can exercise the parser without
+/// touching the filesystem.
+#[must_use]
+pub fn parse_plugins_from_text(body: &str) -> Vec<PluginIdentity> {
+    static_block_re()
+        .captures_iter(body)
+        .filter_map(|caps| {
+            let target = caps.get(1)?.as_str().trim().to_owned();
+            let inner = caps.get(2)?.as_str();
+            Some(extract_identity(target, inner))
+        })
+        .collect()
+}
+
+fn extract_identity(target: String, body: &str) -> PluginIdentity {
+    let plugin_name = arg_value(body, "PLUGIN_NAME").unwrap_or_else(|| target.clone());
+    let manufacturer = arg_value(body, "MANUFACTURER").unwrap_or_default();
+    let bundle_id = arg_value(body, "BUNDLE_ID").unwrap_or_default();
+    let version = arg_value(body, "VERSION").unwrap_or_default();
+    let au_plugin_code = arg_value(body, "PLUGIN_CODE").unwrap_or_default();
+    let au_manufacturer_code = arg_value(body, "MANUFACTURER_CODE").unwrap_or_default();
+    let aax_product_code = arg_value(body, "AAX_PRODUCT_CODE").unwrap_or_default();
+    PluginIdentity {
+        target,
+        plugin_name,
+        manufacturer,
+        bundle_id,
+        version,
+        au_plugin_code,
+        au_manufacturer_code,
+        aax_product_code,
+        vst3_fuid: String::new(),
+        clap_plugin_id: String::new(),
+    }
+}
+
+fn static_block_re() -> &'static Regex {
+    static RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+    RE.get_or_init(|| {
+        // Match `pulp_add_plugin(<target> <body>)`. The body is
+        // captured up to the next unescaped closing paren — Pulp's
+        // CMake conventions don't nest parens inside the call.
+        Regex::new(r"(?s)pulp_add_plugin\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*([^)]*)\)")
+            .expect("valid regex")
+    })
+}
+
+/// Pull a single `KEY "value"` (or `KEY value`) out of a CMake
+/// argument body. Returns `None` when the key is absent or the value
+/// is missing / blank.
+fn arg_value(body: &str, key: &str) -> Option<String> {
+    // We look for `\bKEY\s+(value)` where `value` is either
+    // double-quoted or a bare token. Stop at the next CMake keyword
+    // so a malformed entry doesn't gobble the whole argument list.
+    let pattern = format!(
+        r#"(?m)\b{key}\s+(?:"([^"]*)"|([A-Za-z0-9_./@:+\-]+))"#,
+        key = regex::escape(key),
+    );
+    let re = Regex::new(&pattern).ok()?;
+    let caps = re.captures(body)?;
+    let val = caps
+        .get(1)
+        .or_else(|| caps.get(2))
+        .map(|m| m.as_str().trim().to_owned())
+        .filter(|s| !s.is_empty())?;
+    Some(val)
+}
+
+// ── `pulp identity record` subcommand ────────────────────────────────
+
+/// Parsed `pulp identity ...` invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IdentityCmd {
+    /// Refresh `.pulp/identity.lock` from the project's current state.
+    Record {
+        /// Allow overwriting drifted entries without bailing out.
+        /// `pulp identity record` always writes; the flag exists as
+        /// a deliberate mirror of `pulp build --check-identity
+        /// --allow-identity-change` so the same intent reads the
+        /// same way at both call sites.
+        allow_change: bool,
+        /// Don't touch the lockfile — just print what would be
+        /// written. Useful for review-style invocations.
+        dry_run: bool,
+    },
+    /// Compare `.pulp/identity.lock` against the project's current
+    /// state without modifying anything. Equivalent to the read-side
+    /// of `pulp build --check-identity`. Provided as its own
+    /// subcommand so CI can run it independently of a full build.
+    Check {
+        /// Treat changed identities as success (exit 0) rather than
+        /// failure (exit 1).
+        allow_change: bool,
+    },
+    /// Print a short usage block.
+    Help,
+}
+
+/// Parse `pulp identity <tail>`.
+///
+/// # Errors
+///
+/// [`CliError::BadUsage`] when the subcommand is unrecognised.
+pub fn parse(tail: &[String]) -> Result<IdentityCmd> {
+    let sub = tail.first().map(String::as_str).unwrap_or("");
+    match sub {
+        "" | "help" | "-h" | "--help" => Ok(IdentityCmd::Help),
+        "record" => {
+            let (allow_change, dry_run) = parse_record_flags(&tail[1..])?;
+            Ok(IdentityCmd::Record {
+                allow_change,
+                dry_run,
+            })
+        }
+        "check" => {
+            let allow_change = tail[1..]
+                .iter()
+                .any(|a| a == "--allow-identity-change" || a == "--allow-change");
+            Ok(IdentityCmd::Check { allow_change })
+        }
+        other => Err(CliError::BadUsage(format!(
+            "pulp identity: unknown subcommand: {other}\n  supported: record, check, help"
+        ))),
+    }
+}
+
+fn parse_record_flags(rest: &[String]) -> Result<(bool, bool)> {
+    let mut allow_change = false;
+    let mut dry_run = false;
+    for a in rest {
+        match a.as_str() {
+            "--allow-identity-change" | "--allow-change" => allow_change = true,
+            "--dry-run" => dry_run = true,
+            other => {
+                return Err(CliError::BadUsage(format!(
+                    "pulp identity record: unknown flag: {other}\n  supported: \
+                     --allow-identity-change, --dry-run"
+                )))
+            }
+        }
+    }
+    Ok((allow_change, dry_run))
+}
+
+/// Run `pulp identity <sub>` against a project root. Returns the
+/// process exit code (0 on success, 1 on drift / file errors, 2 on
+/// usage error).
+///
+/// # Errors
+///
+/// [`CliError::Other`] when the project root is missing or the lock
+/// file can't be read / written.
+pub fn run(
+    project_root: &Path,
+    cmake_path: &Path,
+    cmd: &IdentityCmd,
+    out: &mut impl Write,
+) -> Result<i32> {
+    match cmd {
+        IdentityCmd::Help => {
+            write_usage(out)?;
+            Ok(0)
+        }
+        IdentityCmd::Record {
+            allow_change,
+            dry_run,
+        } => run_record(project_root, cmake_path, *allow_change, *dry_run, out),
+        IdentityCmd::Check { allow_change } => {
+            run_check(project_root, cmake_path, *allow_change, out)
+        }
+    }
+}
+
+fn run_record(
+    project_root: &Path,
+    cmake_path: &Path,
+    allow_change: bool,
+    dry_run: bool,
+    out: &mut impl Write,
+) -> Result<i32> {
+    let current = parse_plugins_from_cmake(cmake_path)?;
+    if current.is_empty() {
+        writeln!(
+            out,
+            "pulp identity record: no pulp_add_plugin(...) blocks found in {}",
+            cmake_path.display()
+        )
+        .map_err(io_err)?;
+        return Ok(1);
+    }
+
+    let existing = IdentityLock::load(project_root)?;
+    let mut lock = existing.clone().unwrap_or_else(IdentityLock::empty);
+    let drift = if let Some(ref rec) = existing {
+        diff_lock(rec, &current)
+    } else {
+        Vec::new()
+    };
+
+    if !drift.is_empty() && !allow_change {
+        writeln!(
+            out,
+            "pulp identity record: refusing to overwrite existing identity \
+             without --allow-identity-change. Drift detected:"
+        )
+        .map_err(io_err)?;
+        for d in &drift {
+            writeln!(out, "  - {d}").map_err(io_err)?;
+        }
+        return Ok(1);
+    }
+
+    for entry in current {
+        lock.upsert(entry);
+    }
+
+    if dry_run {
+        writeln!(out, "# .pulp/identity.lock (dry-run)").map_err(io_err)?;
+        writeln!(out, "{}", lock.to_toml()?).map_err(io_err)?;
+        return Ok(0);
+    }
+
+    let path = lock.save(project_root)?;
+    writeln!(
+        out,
+        "pulp identity record: wrote {} ({} plugin{})",
+        path.display(),
+        lock.plugins.len(),
+        if lock.plugins.len() == 1 { "" } else { "s" }
+    )
+    .map_err(io_err)?;
+    Ok(0)
+}
+
+fn run_check(
+    project_root: &Path,
+    cmake_path: &Path,
+    allow_change: bool,
+    out: &mut impl Write,
+) -> Result<i32> {
+    let current = parse_plugins_from_cmake(cmake_path)?;
+    let Some(lock) = IdentityLock::load(project_root)? else {
+        writeln!(
+            out,
+            "pulp identity check: no .pulp/identity.lock found. \
+             Run `pulp identity record` to create one."
+        )
+        .map_err(io_err)?;
+        return Ok(1);
+    };
+    let drift = diff_lock(&lock, &current);
+    if drift.is_empty() {
+        writeln!(
+            out,
+            "pulp identity check: OK ({} plugin{})",
+            lock.plugins.len(),
+            if lock.plugins.len() == 1 { "" } else { "s" }
+        )
+        .map_err(io_err)?;
+        return Ok(0);
+    }
+    writeln!(out, "pulp identity check: drift detected:").map_err(io_err)?;
+    for d in &drift {
+        writeln!(out, "  - {d}").map_err(io_err)?;
+    }
+    if allow_change {
+        writeln!(
+            out,
+            "pulp identity check: --allow-identity-change set; treating drift as success."
+        )
+        .map_err(io_err)?;
+        return Ok(0);
+    }
+    writeln!(
+        out,
+        "pulp identity check: run `pulp identity record --allow-identity-change` \
+         to accept the change, or revert the source to match the lock."
+    )
+    .map_err(io_err)?;
+    Ok(1)
+}
+
+fn write_usage(out: &mut impl Write) -> Result<()> {
+    let usage = concat!(
+        "Usage: pulp identity <subcommand>\n",
+        "\n",
+        "Subcommands:\n",
+        "  record [--allow-identity-change] [--dry-run]\n",
+        "      Refresh .pulp/identity.lock from the project's current\n",
+        "      pulp_add_plugin(...) declarations. Refuses to overwrite a\n",
+        "      drifted entry unless --allow-identity-change is passed.\n",
+        "      --dry-run prints the would-be lock without touching disk.\n",
+        "  check [--allow-identity-change]\n",
+        "      Compare .pulp/identity.lock against the project's current\n",
+        "      state without writing. Exit 1 on drift, 0 with\n",
+        "      --allow-identity-change.\n",
+        "  help\n",
+        "      Print this usage block.\n",
+    );
+    out.write_all(usage.as_bytes()).map_err(io_err)
+}
+
+fn io_err(e: std::io::Error) -> CliError {
+    CliError::Other(e.to_string())
+}
+
+// ── tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn sample_cmake() -> &'static str {
+        r#"
+cmake_minimum_required(VERSION 3.24)
+project(MyProj VERSION 1.2.3)
+
+pulp_add_plugin(MyGain
+    FORMATS         VST3 AU CLAP Standalone
+    PLUGIN_NAME     "My Gain"
+    BUNDLE_ID       "com.example.mygain"
+    MANUFACTURER    "Example"
+    VERSION         "1.2.3"
+    CATEGORY        Effect
+    PLUGIN_CODE     "MGan"
+    MANUFACTURER_CODE "Exmp"
+    AAX_PRODUCT_CODE "MGaP"
+)
+
+pulp_add_plugin(MySynth
+    FORMATS         VST3 CLAP
+    BUNDLE_ID       "com.example.mysynth"
+    MANUFACTURER    "Example"
+    VERSION         "1.2.3"
+    CATEGORY        Instrument
+    PLUGIN_CODE     "MSyn"
+    MANUFACTURER_CODE "Exmp"
+)
+"#
+    }
+
+    #[test]
+    fn parser_extracts_two_plugins_with_canonical_fields() {
+        let plugins = parse_plugins_from_text(sample_cmake());
+        assert_eq!(plugins.len(), 2);
+
+        let gain = plugins.iter().find(|p| p.target == "MyGain").unwrap();
+        assert_eq!(gain.plugin_name, "My Gain");
+        assert_eq!(gain.bundle_id, "com.example.mygain");
+        assert_eq!(gain.manufacturer, "Example");
+        assert_eq!(gain.version, "1.2.3");
+        assert_eq!(gain.au_plugin_code, "MGan");
+        assert_eq!(gain.au_manufacturer_code, "Exmp");
+        assert_eq!(gain.aax_product_code, "MGaP");
+
+        let synth = plugins.iter().find(|p| p.target == "MySynth").unwrap();
+        // PLUGIN_NAME falls back to target when absent.
+        assert_eq!(synth.plugin_name, "MySynth");
+        assert_eq!(synth.aax_product_code, ""); // AAX_PRODUCT_CODE not set.
+    }
+
+    #[test]
+    fn parse_subcommand_accepts_record_and_check() {
+        let cmd = parse(&["record".to_owned()]).unwrap();
+        assert_eq!(
+            cmd,
+            IdentityCmd::Record {
+                allow_change: false,
+                dry_run: false
+            }
+        );
+
+        let cmd = parse(&[
+            "record".to_owned(),
+            "--allow-identity-change".to_owned(),
+            "--dry-run".to_owned(),
+        ])
+        .unwrap();
+        assert_eq!(
+            cmd,
+            IdentityCmd::Record {
+                allow_change: true,
+                dry_run: true
+            }
+        );
+
+        let cmd = parse(&[
+            "check".to_owned(),
+            "--allow-identity-change".to_owned(),
+        ])
+        .unwrap();
+        assert_eq!(cmd, IdentityCmd::Check { allow_change: true });
+
+        assert!(parse(&[]).is_ok());
+        assert!(parse(&["help".to_owned()]).is_ok());
+        assert!(matches!(
+            parse(&["bogus".to_owned()]),
+            Err(CliError::BadUsage(_))
+        ));
+    }
+
+    #[test]
+    fn record_round_trips_through_toml() {
+        let td = TempDir::new().unwrap();
+        let root = td.path();
+        let cmake = root.join("CMakeLists.txt");
+        std::fs::write(&cmake, sample_cmake()).unwrap();
+
+        let mut sink = Vec::new();
+        let rc = run(
+            root,
+            &cmake,
+            &IdentityCmd::Record {
+                allow_change: false,
+                dry_run: false,
+            },
+            &mut sink,
+        )
+        .unwrap();
+        assert_eq!(rc, 0);
+
+        // Lockfile exists with both plugins, sorted by target.
+        let lock = IdentityLock::load(root).unwrap().unwrap();
+        assert_eq!(lock.schema, IdentityLock::CURRENT_SCHEMA);
+        assert_eq!(lock.plugins.len(), 2);
+        assert_eq!(lock.plugins[0].target, "MyGain");
+        assert_eq!(lock.plugins[1].target, "MySynth");
+
+        // Re-recording is a no-op (no drift, still succeeds).
+        let mut sink = Vec::new();
+        let rc = run(
+            root,
+            &cmake,
+            &IdentityCmd::Record {
+                allow_change: false,
+                dry_run: false,
+            },
+            &mut sink,
+        )
+        .unwrap();
+        assert_eq!(rc, 0);
+
+        // Check is happy.
+        let mut sink = Vec::new();
+        let rc = run(
+            root,
+            &cmake,
+            &IdentityCmd::Check { allow_change: false },
+            &mut sink,
+        )
+        .unwrap();
+        assert_eq!(rc, 0);
+    }
+
+    #[test]
+    fn drift_is_caught_and_blocks_overwrite() {
+        let td = TempDir::new().unwrap();
+        let root = td.path();
+        let cmake = root.join("CMakeLists.txt");
+        std::fs::write(&cmake, sample_cmake()).unwrap();
+
+        // Record initial state.
+        let mut sink = Vec::new();
+        run(
+            root,
+            &cmake,
+            &IdentityCmd::Record {
+                allow_change: false,
+                dry_run: false,
+            },
+            &mut sink,
+        )
+        .unwrap();
+
+        // Drift: change the AU 4CC of MyGain.
+        let drifted = sample_cmake().replace("PLUGIN_CODE     \"MGan\"", "PLUGIN_CODE     \"MGn2\"");
+        std::fs::write(&cmake, drifted).unwrap();
+
+        let mut sink = Vec::new();
+        let rc = run(
+            root,
+            &cmake,
+            &IdentityCmd::Check { allow_change: false },
+            &mut sink,
+        )
+        .unwrap();
+        assert_eq!(rc, 1, "check must fail on AU 4CC drift");
+        let report = String::from_utf8(sink).unwrap();
+        assert!(report.contains("au_plugin_code"), "{report}");
+        assert!(report.contains("MyGain"), "{report}");
+
+        // record without --allow-identity-change must refuse.
+        let mut sink = Vec::new();
+        let rc = run(
+            root,
+            &cmake,
+            &IdentityCmd::Record {
+                allow_change: false,
+                dry_run: false,
+            },
+            &mut sink,
+        )
+        .unwrap();
+        assert_eq!(rc, 1);
+        let report = String::from_utf8(sink).unwrap();
+        assert!(
+            report.contains("--allow-identity-change"),
+            "expected guidance pointer, got: {report}"
+        );
+
+        // With --allow-identity-change, recording succeeds and the
+        // new lock matches the new source.
+        let mut sink = Vec::new();
+        let rc = run(
+            root,
+            &cmake,
+            &IdentityCmd::Record {
+                allow_change: true,
+                dry_run: false,
+            },
+            &mut sink,
+        )
+        .unwrap();
+        assert_eq!(rc, 0);
+        let lock = IdentityLock::load(root).unwrap().unwrap();
+        let gain = lock.find("MyGain").unwrap();
+        assert_eq!(gain.au_plugin_code, "MGn2");
+    }
+
+    #[test]
+    fn dry_run_does_not_create_lockfile() {
+        let td = TempDir::new().unwrap();
+        let root = td.path();
+        let cmake = root.join("CMakeLists.txt");
+        std::fs::write(&cmake, sample_cmake()).unwrap();
+
+        let mut sink = Vec::new();
+        let rc = run(
+            root,
+            &cmake,
+            &IdentityCmd::Record {
+                allow_change: false,
+                dry_run: true,
+            },
+            &mut sink,
+        )
+        .unwrap();
+        assert_eq!(rc, 0);
+        assert!(!IdentityLock::path_for(root).exists());
+
+        let body = String::from_utf8(sink).unwrap();
+        assert!(body.contains("dry-run"));
+        assert!(body.contains("MyGain"));
+        assert!(body.contains("MySynth"));
+    }
+
+    #[test]
+    fn empty_recorded_fields_dont_trigger_drift() {
+        // A lock with vst3_fuid="" should not fail check when the
+        // current state also has "" — the field is "not yet pinned".
+        let lock = IdentityLock {
+            schema: 1,
+            plugins: vec![PluginIdentity {
+                target: "X".into(),
+                plugin_name: "X".into(),
+                manufacturer: "Y".into(),
+                bundle_id: "com.y.x".into(),
+                version: "1.0.0".into(),
+                au_plugin_code: "Xxxx".into(),
+                au_manufacturer_code: "Yyyy".into(),
+                aax_product_code: "XxxP".into(),
+                vst3_fuid: String::new(),
+                clap_plugin_id: String::new(),
+            }],
+        };
+        let current = vec![PluginIdentity {
+            target: "X".into(),
+            plugin_name: "X".into(),
+            manufacturer: "Y".into(),
+            bundle_id: "com.y.x".into(),
+            version: "1.0.0".into(),
+            au_plugin_code: "Xxxx".into(),
+            au_manufacturer_code: "Yyyy".into(),
+            aax_product_code: "XxxP".into(),
+            vst3_fuid: String::new(),
+            clap_plugin_id: String::new(),
+        }];
+        assert!(diff_lock(&lock, &current).is_empty());
+    }
+
+    #[test]
+    fn missing_target_in_current_is_drift() {
+        let lock = IdentityLock {
+            schema: 1,
+            plugins: vec![PluginIdentity {
+                target: "Gone".into(),
+                plugin_name: "Gone".into(),
+                manufacturer: "Z".into(),
+                bundle_id: "com.z.gone".into(),
+                version: "1.0.0".into(),
+                au_plugin_code: "Gone".into(),
+                au_manufacturer_code: "Zzzz".into(),
+                aax_product_code: "GoneP".into(),
+                vst3_fuid: String::new(),
+                clap_plugin_id: String::new(),
+            }],
+        };
+        let drift = diff_lock(&lock, &[]);
+        assert_eq!(drift.len(), 1);
+        assert_eq!(drift[0].field, "<plugin>");
+        assert_eq!(drift[0].target, "Gone");
+    }
+}

--- a/experimental/pulp-rs/src/cmd/mod.rs
+++ b/experimental/pulp-rs/src/cmd/mod.rs
@@ -15,6 +15,7 @@ pub mod dev;
 pub mod docs;
 pub mod doctor;
 pub mod help;
+pub mod identity;
 pub mod motion;
 pub mod orchestrate;
 pub mod pkg;

--- a/experimental/pulp-rs/src/cmd/orchestrate.rs
+++ b/experimental/pulp-rs/src/cmd/orchestrate.rs
@@ -68,6 +68,14 @@ pub struct BuildArgs {
     /// `--validate` — run plugin validators after a successful build
     /// (also deferred; needs `cmd::validate` port).
     pub validate: bool,
+    /// `--check-identity` — verify `.pulp/identity.lock` matches the
+    /// current plugin identity before configuring. Implements Track
+    /// 3.12 of the macOS plugin-authoring plan.
+    pub check_identity: bool,
+    /// `--allow-identity-change` — paired with `--check-identity`,
+    /// treats drift as a soft warning instead of failing the build.
+    /// Mirrors `pulp identity check --allow-identity-change`.
+    pub allow_identity_change: bool,
 }
 
 /// Parse `pulp-rs build` flags.
@@ -79,6 +87,8 @@ pub fn parse_build_args(args: &[String]) -> BuildArgs {
             "--watch" | "-w" => out.watch = true,
             "--test" | "-t" => out.test = true,
             "--validate" => out.validate = true,
+            "--check-identity" => out.check_identity = true,
+            "--allow-identity-change" => out.allow_identity_change = true,
             _ if a.starts_with("--js-engine=") => {
                 out.js_engine = Some(a.trim_start_matches("--js-engine=").to_owned());
             }
@@ -120,6 +130,21 @@ pub fn build_with<S: Spawner>(
     spawner: &S,
     out: &mut impl Write,
 ) -> Result<i32> {
+    if args.check_identity {
+        // Track 3.12: refuse to configure / build when the project's
+        // current plugin identity has drifted from `.pulp/identity.lock`
+        // without `--allow-identity-change`. Runs early so a doomed
+        // build doesn't waste a configure step.
+        let cmake = proj.root.join("CMakeLists.txt");
+        let sub = crate::cmd::identity::IdentityCmd::Check {
+            allow_change: args.allow_identity_change,
+        };
+        let rc = crate::cmd::identity::run(&proj.root, &cmake, &sub, out)?;
+        if rc != 0 {
+            return Ok(rc);
+        }
+    }
+
     if args.watch {
         // Phase 7: route --watch through the C++ binary if it's on
         // PATH, otherwise fall back to the "not ported" stub so
@@ -1055,13 +1080,44 @@ mod tests {
             "--watch".to_owned(),
             "--test".to_owned(),
             "--validate".to_owned(),
+            "--check-identity".to_owned(),
+            "--allow-identity-change".to_owned(),
             "--js-engine=v8".to_owned(),
             "--target".to_owned(),
             "pulp-gain".to_owned(),
         ]);
         assert!(a.watch && a.test && a.validate);
+        assert!(a.check_identity && a.allow_identity_change);
         assert_eq!(a.js_engine.as_deref(), Some("v8"));
         assert_eq!(a.passthrough, vec!["--target", "pulp-gain"]);
+    }
+
+    #[test]
+    fn build_check_identity_blocks_when_lock_missing() {
+        let td = tempfile::tempdir().unwrap();
+        let proj = standalone_project(td.path());
+        std::fs::write(
+            proj.root.join("CMakeLists.txt"),
+            r#"pulp_add_plugin(X PLUGIN_NAME "X" BUNDLE_ID "com.x.x" MANUFACTURER "X" VERSION "1.0.0" PLUGIN_CODE "Xxxx" MANUFACTURER_CODE "Xxxx")"#,
+        )
+        .unwrap();
+        let spawner = RecordingSpawner::ok();
+        let mut out = Vec::new();
+        let rc = build_with(
+            &proj,
+            &BuildArgs {
+                check_identity: true,
+                ..Default::default()
+            },
+            &spawner,
+            &mut out,
+        )
+        .unwrap();
+        // Lock missing → exit 1, no cmake invocations made.
+        assert_eq!(rc, 1);
+        assert!(spawner.calls.borrow().is_empty());
+        let report = String::from_utf8(out).unwrap();
+        assert!(report.contains("identity"), "{report}");
     }
 
     #[test]

--- a/experimental/pulp-rs/src/main.rs
+++ b/experimental/pulp-rs/src/main.rs
@@ -139,6 +139,13 @@ enum Command {
     /// (PULP_MOTION_SERVER=1).
     #[command(name = "motion")]
     Motion(PkgTailArgs),
+
+    /// Manage `.pulp/identity.lock` — the committed pin of each
+    /// plugin's AU 4CC, manufacturer code, AAX product code,
+    /// optional VST3 FUID, and optional CLAP plugin id. See
+    /// `docs/reference/identity-lock.md` and Track 3.12 of the
+    /// macOS plugin-authoring plan.
+    Identity(PkgTailArgs),
 }
 
 #[derive(clap::Args, Debug)]
@@ -613,6 +620,25 @@ fn real_main() -> Result<(), ExitCode> {
             })?;
             let spawner = pulp_rs::proc::SystemSpawner;
             map_exit(cmd::tool::run(&sub, &spawner, &mut out))
+        }
+        Command::Identity(args) => {
+            let parsed = cmd::identity::parse(&args.tail).map_err(|e| match e {
+                CliError::BadUsage(msg) => {
+                    eprintln!("{msg}");
+                    ExitCode::from(2)
+                }
+                other => {
+                    eprintln!("pulp identity: {other}");
+                    ExitCode::from(2)
+                }
+            })?;
+            let cwd = read_cwd()?;
+            let Some(root) = pulp_rs::project::resolve(&cwd).map(|p| p.root) else {
+                eprintln!("pulp identity: not in a Pulp project directory");
+                return Err(ExitCode::from(1));
+            };
+            let cmake = root.join("CMakeLists.txt");
+            map_exit(cmd::identity::run(&root, &cmake, &parsed, &mut out))
         }
         Command::Motion(args) => {
             let (sub, flags) = cmd::motion::parse(&args.tail).map_err(|e| match e {

--- a/experimental/pulp-rs/tests/identity_smoke_test.rs
+++ b/experimental/pulp-rs/tests/identity_smoke_test.rs
@@ -1,0 +1,125 @@
+//! Integration smoke for `pulp identity record` / `pulp identity check`.
+//!
+//! Drives the real binary through `assert_cmd` so the CLI surface is
+//! exercised end-to-end: arg parsing, project-root discovery,
+//! CMakeLists.txt scan, lockfile write, and the drift-detection
+//! exit-code semantics that `pulp build --check-identity` and CI
+//! gates depend on. The unit tests in `cmd::identity::tests` cover
+//! the parser / diff machinery directly; this file pins the binary
+//! contract.
+
+use std::fs;
+
+use predicates::prelude::*;
+
+const SAMPLE_CMAKE: &str = r#"
+cmake_minimum_required(VERSION 3.24)
+project(SmokeProj VERSION 1.0.0)
+
+pulp_add_plugin(SmokeGain
+    FORMATS         VST3 AU CLAP
+    PLUGIN_NAME     "Smoke Gain"
+    BUNDLE_ID       "com.smoke.gain"
+    MANUFACTURER    "SmokeCo"
+    VERSION         "1.0.0"
+    PLUGIN_CODE     "Smkg"
+    MANUFACTURER_CODE "Smco"
+    AAX_PRODUCT_CODE "SmkP"
+)
+"#;
+
+fn setup_project() -> tempfile::TempDir {
+    let td = tempfile::tempdir().unwrap();
+    fs::write(td.path().join("pulp.toml"), "sdk_version = \"0.40.0\"\n").unwrap();
+    fs::write(td.path().join("CMakeLists.txt"), SAMPLE_CMAKE).unwrap();
+    td
+}
+
+#[test]
+fn identity_record_then_check_round_trip() {
+    let td = setup_project();
+
+    // record → exit 0, lockfile present.
+    assert_cmd::Command::cargo_bin("pulp")
+        .unwrap()
+        .current_dir(td.path())
+        .args(["identity", "record"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(".pulp/identity.lock"));
+    assert!(td.path().join(".pulp/identity.lock").is_file());
+
+    // check → exit 0, OK message.
+    assert_cmd::Command::cargo_bin("pulp")
+        .unwrap()
+        .current_dir(td.path())
+        .args(["identity", "check"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("OK"));
+}
+
+#[test]
+fn identity_check_fails_on_drifted_au_code() {
+    let td = setup_project();
+
+    // Record first.
+    assert_cmd::Command::cargo_bin("pulp")
+        .unwrap()
+        .current_dir(td.path())
+        .args(["identity", "record"])
+        .assert()
+        .success();
+
+    // Drift the AU 4CC.
+    let drifted = SAMPLE_CMAKE.replace("PLUGIN_CODE     \"Smkg\"", "PLUGIN_CODE     \"Smk2\"");
+    fs::write(td.path().join("CMakeLists.txt"), drifted).unwrap();
+
+    // check → exit 1, names the drifted field.
+    assert_cmd::Command::cargo_bin("pulp")
+        .unwrap()
+        .current_dir(td.path())
+        .args(["identity", "check"])
+        .assert()
+        .failure()
+        .code(1)
+        .stdout(predicate::str::contains("au_plugin_code"))
+        .stdout(predicate::str::contains("SmokeGain"));
+
+    // check --allow-identity-change → exit 0.
+    assert_cmd::Command::cargo_bin("pulp")
+        .unwrap()
+        .current_dir(td.path())
+        .args(["identity", "check", "--allow-identity-change"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn identity_record_dry_run_does_not_write_lock() {
+    let td = setup_project();
+
+    assert_cmd::Command::cargo_bin("pulp")
+        .unwrap()
+        .current_dir(td.path())
+        .args(["identity", "record", "--dry-run"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("SmokeGain"))
+        .stdout(predicate::str::contains("dry-run"));
+    assert!(!td.path().join(".pulp/identity.lock").exists());
+}
+
+#[test]
+fn identity_help_lists_subcommands() {
+    // No args = help (parity with `pulp identity help`).
+    let td = setup_project();
+    assert_cmd::Command::cargo_bin("pulp")
+        .unwrap()
+        .current_dir(td.path())
+        .args(["identity"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("record"))
+        .stdout(predicate::str::contains("check"));
+}


### PR DESCRIPTION
## Summary

Ships **item 3.12 — Bundle identity** of `planning/2026-05-24-macos-plugin-authoring-plan.md`: a committed `.pulp/identity.lock` plus the CLI surface that writes it and the build-time gate that defends it.

### What ships

- **`pulp identity record`** — refresh `.pulp/identity.lock` from the project's `pulp_add_plugin(...)` declarations. Refuses to overwrite drifted entries without `--allow-identity-change` (the audit-trail flag a reviewer can grep). `--dry-run` for review.
- **`pulp identity check`** — pure read. Exit 1 on drift, 0 with `--allow-identity-change`. CI-friendly.
- **`pulp build --check-identity`** — runs the check before the configure step so a drifted PR fails the whole build, not just a downstream gate.
- **Schema doc** at `docs/reference/identity-lock.md` covering field semantics, "empty = not yet pinned" rule, schema versioning, and the deliberate-change workflow.

The lockfile pins each plugin's host-visible identity (AU 4CC + manufacturer code, AAX product code, optional VST3 FUID, optional CLAP id, version). Changing any of those silently breaks every saved DAW session that referenced the previous identity — the lock makes drift a reviewable commit.

### Why this matters

A changed AU 4CC or VST3 FUID is the single most common "my plugin lost its preset" footgun in plug-in releases. Today nothing in the build pipeline catches a one-character typo in `PLUGIN_CODE`. This slice closes that gap with a one-screen file the reviewer can diff.

### Coverage

- 8 unit tests in `cmd::identity::tests` (parser, TOML round-trip, drift detection, dry-run, missing-target drift, empty-field semantics)
- 4 integration tests in `tests/identity_smoke_test.rs` (real binary via `assert_cmd` covering record → check round-trip, AU 4CC drift exit code, dry-run no-write, help)
- 1 new orchestrate test that `pulp build --check-identity` exits 1 + skips cmake when the lock is missing

### Deferred (called out in commit body, follow-up issue welcome)

- `vst3_fuid` / `clap_plugin_id` source-side scrape (schema slots reserved; hand-editable today, will be auto-filled once the source regex shape is locked in)
- `pulp version bump` cross-format sync (Slice C of the spec — version sync across AU plist / VST3 module / CLAP factory)
- Nested-CMake walk (today's scan reads the top-level `CMakeLists.txt` only; tracked for when a real project lands plugin declarations under `add_subdirectory`)

### Surface diff

| Surface                                        | Change                                          |
|------------------------------------------------|-------------------------------------------------|
| `experimental/pulp-rs/src/cmd/identity.rs`     | New 800+ LOC module — parser, lockfile, dispatch |
| `experimental/pulp-rs/src/cmd/orchestrate.rs`  | `BuildArgs::check_identity` + `allow_identity_change` + early-fail wire |
| `experimental/pulp-rs/src/main.rs`             | `Identity(...)` clap variant + dispatch arm     |
| `docs/reference/identity-lock.md`              | New schema + workflow + CLI reference doc       |
| `docs/reference/cli.md` + `docs/status/cli-commands.yaml` | `identity` command + `--check-identity` flag entries |
| `.agents/skills/cli-maintenance/SKILL.md`      | New section documenting the surface + gotchas   |

## Test plan

- [x] `cargo test --lib identity` (8/8 pass)
- [x] `cargo test --test identity_smoke_test` (4/4 pass)
- [x] `cargo test --lib cmd::orchestrate::tests::build_check_identity_blocks_when_lock_missing` (pass)
- [x] End-to-end smoke: `pulp identity record` → check OK → drift AU 4CC → check fails with named field → `--allow-identity-change` rescues
- [x] `tools/scripts/gates.sh` — skill-sync, version-bump, compat-sync, deps-audit all green
- [ ] CI on PR — Rust crate builds + tests on macOS / Linux / Windows

## Tracker

Updates `planning/2026-05-24-macos-plugin-authoring-plan.md` row 3.12 from 🚫 to ✅ on merge.