### PR TITLE
feat(format): extend ProcessContext with AudioPlayHead transport surface (item 1.3 struct-only slice)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.230.0
+    VERSION 0.231.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/processor.hpp
+++ b/core/format/include/pulp/format/processor.hpp
@@ -198,10 +198,61 @@ struct PrepareContext {
     int output_channels = 2;
 };
 
+/// SMPTE video frame rate (item 1.3 macOS plan).
+///
+/// Used by `ProcessContext::frame_rate` so plugins that drive video sync
+/// or display SMPTE timecode can format positions correctly. `unknown` is
+/// the documented sentinel for hosts that do not provide a frame rate
+/// (e.g. CLAP `clap_event_transport` has no frame-rate field; AU
+/// `kAudioUnitProperty_HostCallbacks` only exposes it inside
+/// `HostCallback_GetTransportState2`'s `outCurrentSampleInTimeLine`
+/// indirectly via the project session — adapters report `unknown` if
+/// the host does not surface it).
+enum class FrameRate {
+    unknown = 0,
+    fps_24,           ///< Film. VST3 `kFrameRate24fps`.
+    fps_25,           ///< PAL. VST3 `kFrameRate25fps`.
+    fps_29_97,        ///< NTSC non-drop. VST3 `kFrameRate2997fps`.
+    fps_29_97_drop,   ///< NTSC drop-frame. VST3 `kFrameRate2997DropFps`.
+    fps_30,           ///< NTSC integer. VST3 `kFrameRate30fps`.
+    fps_30_drop,      ///< 30 drop-frame. VST3 `kFrameRate30DropFps`.
+    fps_60,           ///< High-rate. VST3 `kFrameRate60fps`.
+};
+
 /// Process context — passed every audio callback with transport state.
 ///
 /// Fields are populated by the host. Not all hosts provide all fields —
 /// check is_playing before using position data.
+///
+/// Adapter sourcing (item 1.3 of the macOS plan; struct-only slice
+/// landed first, adapter wiring deferred to cross-cuts J / K / L / M):
+///
+/// - VST3 — `Vst::ProcessContext` (`SystemTime` →
+///   `host_time_ns`, `ProjectTimeMusic` → `position_beats`,
+///   `CycleStartMusic` / `CycleEndMusic` → `loop_start_beats` /
+///   `loop_end_beats`, `kCycleActive` → `is_looping`,
+///   `frameRate.framesPerSecond` → `frame_rate`).
+/// - AU v3 / v2 — `kAudioUnitProperty_HostCallbacks` (HostBeatAndTempo
+///   → `tempo_bpm` / `position_beats`; HostTransport →
+///   `is_playing` / `is_recording` / `is_looping` /
+///   `loop_start_beats` / `loop_end_beats`; MusicalTimeLocation →
+///   `time_sig_numerator` / `time_sig_denominator`; `mach_absolute_time`
+///   → `host_time_ns`). AU has no frame-rate field; `frame_rate`
+///   stays `FrameRate::unknown`.
+/// - CLAP — `clap_event_transport` (`flags` for is_playing /
+///   is_recording / is_looping; `loop_start_beats` /
+///   `loop_end_beats` directly; `tsig_num` / `tsig_denom` for time
+///   signature). CLAP does not provide frame rate; `frame_rate`
+///   stays `FrameRate::unknown`.
+/// - AAX (optional Avid SDK) — `IACFTransport` (`GetCurrentTickPosition`
+///   for beats; `GetCurrentLoopPosition` for loop range; transport
+///   state flags). Frame rate via `IACFTransport::GetTimeCodeInfo`
+///   when present, else `FrameRate::unknown`.
+///
+/// Change-flags (`tempo_changed`, `time_sig_changed`,
+/// `transport_changed`) are computed by the adapter once per block by
+/// diffing against the previous block's snapshot, so processors can
+/// branch on transitions only without re-reading every field.
 struct ProcessContext {
     double sample_rate = 0;
     int num_samples = 0;
@@ -212,6 +263,82 @@ struct ProcessContext {
     int64_t position_samples = 0;
     int time_sig_numerator = 4;
     int time_sig_denominator = 4;
+
+    // --- item 1.3 extensions (struct-only; adapter wiring deferred to
+    // J/K/L/M cross-cut). New fields default to "host did not provide"
+    // sentinels so existing adapters that don't populate them keep the
+    // pre-extension behaviour exactly. ---
+
+    /// Bar index derived from `position_beats` + the active time
+    /// signature. Hosts may already publish a precomputed bar (VST3
+    /// `Vst::ProcessContext::barPositionMusic`) — in that case the
+    /// adapter uses the host value directly. Otherwise the adapter
+    /// derives `bar = floor(position_beats * (time_sig_denominator /
+    /// 4) / time_sig_numerator)` and writes it here so processors that
+    /// just need "what bar am I in" do not recompute it per block.
+    /// Default 0 matches a stopped-at-origin playhead.
+    int64_t bar = 0;
+
+    /// True when the host's transport is in cycle/loop mode. VST3
+    /// exposes this as the `kCycleActive` flag on `ProcessContext`;
+    /// AU surfaces it via `HostTransport`'s `outIsCycling`; CLAP via
+    /// the `CLAP_TRANSPORT_IS_LOOP_ACTIVE` bit on
+    /// `clap_event_transport::flags`; AAX via `IACFTransport`'s loop
+    /// state. Default false (no loop).
+    bool is_looping = false;
+
+    /// Loop start in quarter notes, only meaningful when `is_looping`
+    /// is true. Mirrors `position_beats`'s PPQ convention. Sources:
+    /// VST3 `Vst::ProcessContext::cycleStartMusic`; AU
+    /// `HostTransport::outCycleStartBeat`; CLAP
+    /// `clap_event_transport::loop_start_beats` (converted from CLAP's
+    /// fixed-point `clap_beattime`); AAX
+    /// `IACFTransport::GetCurrentLoopPosition`. Default 0.
+    double loop_start_beats = 0.0;
+
+    /// Loop end in quarter notes, only meaningful when `is_looping`
+    /// is true. Same source list as `loop_start_beats`. Default 0
+    /// (loop_start == loop_end => no loop range yet).
+    double loop_end_beats = 0.0;
+
+    /// Host clock timestamp matching the start of this block, in
+    /// nanoseconds since an epoch the host chooses. Used for video
+    /// sync against the OS clock. Sources:
+    /// VST3 `Vst::ProcessContext::systemTime` (already nanoseconds on
+    /// Apple; otherwise host-defined); AU `mach_absolute_time()`
+    /// converted via `mach_timebase_info` (the AU adapter performs the
+    /// conversion before writing here); CLAP has no host-time field
+    /// today, so the adapter leaves the value at 0 (sentinel = "not
+    /// provided"); AAX `IACFTransport`'s sample-position only — host
+    /// time is unavailable, so leave at 0.
+    int64_t host_time_ns = 0;
+
+    /// SMPTE frame rate when the host exposes one. Default
+    /// `FrameRate::unknown` is the documented sentinel meaning "host
+    /// did not provide" — plugins must check before using.
+    FrameRate frame_rate = FrameRate::unknown;
+
+    /// True when the host's reported `tempo_bpm` differs from the
+    /// previous block. Lets processors recompute tempo-dependent
+    /// derived state (sample-domain envelope rates, delay-line beat
+    /// lengths) only on transitions instead of every block. Computed
+    /// by the adapter as `current.tempo_bpm != previous.tempo_bpm`.
+    /// Default false (no change relative to a hypothetical previous
+    /// block, which matches the initial-state contract).
+    bool tempo_changed = false;
+
+    /// True when the host's reported time signature
+    /// (`time_sig_numerator` or `time_sig_denominator`) differs from
+    /// the previous block. Lets processors rebuild bar-grid state on
+    /// transitions only. Default false.
+    bool time_sig_changed = false;
+
+    /// True when any transport state field (`is_playing`,
+    /// `is_recording`, `is_looping`) flipped since the previous
+    /// block. Lets processors reset playback-only DSP state (e.g.
+    /// flush a reverb tail when transport stops) on transitions only.
+    /// Default false.
+    bool transport_changed = false;
 };
 
 /// The plugin processor interface.

--- a/test/test_processor_defaults.cpp
+++ b/test/test_processor_defaults.cpp
@@ -206,6 +206,65 @@ TEST_CASE("ProcessContext defaults represent stopped 4/4 playback at 120 BPM",
     REQUIRE(c.position_samples == 0);
     REQUIRE(c.time_sig_numerator == 4);
     REQUIRE(c.time_sig_denominator == 4);
+
+    // Item 1.3 extensions — every new field defaults to the documented
+    // "host did not provide" sentinel so existing adapters that don't
+    // populate them keep their pre-extension behaviour.
+    REQUIRE(c.bar == 0);
+    REQUIRE_FALSE(c.is_looping);
+    REQUIRE(c.loop_start_beats == 0.0);
+    REQUIRE(c.loop_end_beats == 0.0);
+    REQUIRE(c.host_time_ns == 0);
+    REQUIRE(c.frame_rate == FrameRate::unknown);
+    REQUIRE_FALSE(c.tempo_changed);
+    REQUIRE_FALSE(c.time_sig_changed);
+    REQUIRE_FALSE(c.transport_changed);
+}
+
+TEST_CASE("ProcessContext carries item 1.3 playhead extensions independently",
+          "[format][processor-defaults][context][issue-1003][playhead]") {
+    ProcessContext c;
+
+    c.is_looping = true;
+    c.loop_start_beats = 16.0;
+    c.loop_end_beats = 32.5;
+    c.bar = 7;
+    c.host_time_ns = 1'234'567'890LL;
+    c.frame_rate = FrameRate::fps_29_97_drop;
+    c.tempo_changed = true;
+    c.time_sig_changed = true;
+    c.transport_changed = true;
+
+    REQUIRE(c.is_looping);
+    REQUIRE(c.loop_start_beats == 16.0);
+    REQUIRE(c.loop_end_beats == 32.5);
+    REQUIRE(c.bar == 7);
+    REQUIRE(c.host_time_ns == 1'234'567'890LL);
+    REQUIRE(c.frame_rate == FrameRate::fps_29_97_drop);
+    REQUIRE(c.tempo_changed);
+    REQUIRE(c.time_sig_changed);
+    REQUIRE(c.transport_changed);
+
+    // Defaulted legacy fields should not be disturbed when only the
+    // 1.3 extensions are touched.
+    REQUIRE(c.tempo_bpm == 120.0);
+    REQUIRE(c.time_sig_numerator == 4);
+    REQUIRE(c.time_sig_denominator == 4);
+    REQUIRE_FALSE(c.is_playing);
+    REQUIRE_FALSE(c.is_recording);
+}
+
+TEST_CASE("FrameRate enum exposes the SMPTE rates adapters must surface",
+          "[format][processor-defaults][context][playhead][frame-rate]") {
+    // Adapters map host frame-rate values onto this enum. The exact
+    // enumerators below are the contract; reordering them would silently
+    // break per-block transport push from VST3/AU/AAX.
+    REQUIRE(static_cast<int>(FrameRate::unknown) == 0);
+    REQUIRE(FrameRate::fps_24 != FrameRate::fps_25);
+    REQUIRE(FrameRate::fps_29_97 != FrameRate::fps_29_97_drop);
+    REQUIRE(FrameRate::fps_30 != FrameRate::fps_30_drop);
+    REQUIRE(FrameRate::fps_60 != FrameRate::fps_30);
+    REQUIRE(FrameRate::unknown != FrameRate::fps_24);
 }
 
 TEST_CASE("Processor default editor contract is auto UI with free-resize hints",
@@ -368,6 +427,16 @@ TEST_CASE("Processor process receives the exact transport context",
     context.position_samples = 123456;
     context.time_sig_numerator = 7;
     context.time_sig_denominator = 8;
+    // Item 1.3 extensions also round-trip through process() so adapters
+    // that populate the new fields land them at the plugin verbatim.
+    context.bar = 4;
+    context.is_looping = true;
+    context.loop_start_beats = 8.0;
+    context.loop_end_beats = 24.0;
+    context.host_time_ns = 9'876'543'210LL;
+    context.frame_rate = FrameRate::fps_24;
+    context.tempo_changed = true;
+    context.transport_changed = true;
 
     p.process(output, input, midi_in, midi_out, context);
 
@@ -381,6 +450,15 @@ TEST_CASE("Processor process receives the exact transport context",
     REQUIRE(p.last_process.position_samples == 123456);
     REQUIRE(p.last_process.time_sig_numerator == 7);
     REQUIRE(p.last_process.time_sig_denominator == 8);
+    REQUIRE(p.last_process.bar == 4);
+    REQUIRE(p.last_process.is_looping);
+    REQUIRE(p.last_process.loop_start_beats == 8.0);
+    REQUIRE(p.last_process.loop_end_beats == 24.0);
+    REQUIRE(p.last_process.host_time_ns == 9'876'543'210LL);
+    REQUIRE(p.last_process.frame_rate == FrameRate::fps_24);
+    REQUIRE(p.last_process.tempo_changed);
+    REQUIRE_FALSE(p.last_process.time_sig_changed);
+    REQUIRE(p.last_process.transport_changed);
 }
 
 TEST_CASE("Processor state-store pointer wiring exposes the exact store",


### PR DESCRIPTION
## Summary

Struct-only slice of macOS plan item **1.3 — AudioPlayHead transport extension on `ProcessContext`** (`planning/2026-05-24-macos-plugin-authoring-plan.md` §1.3).

Adds the missing transport fields plugin authors expect from a modern playhead:

- `bar` — precomputed bar index (host-supplied or adapter-derived).
- `is_looping` + `loop_start_beats` + `loop_end_beats` — host cycle/loop range.
- `host_time_ns` — host clock at block start (nanoseconds), for video sync against the OS clock.
- `frame_rate` — new `FrameRate` enum (24 / 25 / 29.97 / 29.97-drop / 30 / 30-drop / 60 / `unknown` sentinel).
- `tempo_changed` + `time_sig_changed` + `transport_changed` — per-block change flags so processors react only to transitions instead of re-reading every field.

Every new field defaults to a documented **"host did not provide" sentinel** so existing VST3 / AU / CLAP / AAX adapters that don't yet populate them stay bit-for-bit on their previous behaviour. The struct doc-comment lists the per-adapter sourcing (VST3 `Vst::ProcessContext::SystemTime`/`ProjectTimeMusic`/`CycleStart`, AU `kAudioUnitProperty_HostCallbacks`, CLAP `clap_event_transport`, AAX `IACFTransport`) so the J/K/L/M cross-cut that wires the adapters can land against this contract without re-deriving it.

## Deferred (next slice)

**Adapter wiring is intentionally NOT in this PR.** Per the plan: *"Extend struct first; adapter wiring happens in J/K/L/M."* That cross-cut will populate the new fields from `Vst::ProcessContext`, `HostCallbacks`, `clap_event_transport`, and `IACFTransport` and add per-adapter round-trip tests.

## Test plan

- [x] `pulp-test-processor-defaults` covers default sentinel values, independent field set/read, `FrameRate` enum ordering, and round-trip of new fields through `Processor::process()` — **243 assertions / 29 test cases, all green** in `cmake -B build -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF`.
- [x] `pulp-format` static-lib builds clean — no consumer regression on the existing `ProcessContext{}` use sites in VST3 / AU / CLAP / standalone / headless / host-slot / AAX runtime.