### PR TITLE
feat(view): FileChooser builder wraps native FileDialog (macOS plan 6.2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.228.0
+    VERSION 0.229.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -331,6 +331,7 @@ target_sources(pulp-view-core PRIVATE
     src/breadcrumb.cpp
     src/buttons.cpp
     src/file_browser.cpp
+    src/file_chooser.cpp
     src/code_editor.cpp
     src/table.cpp
     src/toolbar.cpp

--- a/core/view/include/pulp/view/file_chooser.hpp
+++ b/core/view/include/pulp/view/file_chooser.hpp
@@ -1,0 +1,115 @@
+#pragma once
+
+/// @file file_chooser.hpp
+/// @brief Pulp-shaped builder for native open/save/folder dialogs.
+///
+/// macOS plan item 6.2 (planning/2026-05-24-macos-plugin-authoring-plan.md):
+/// wraps `pulp::platform::FileDialog::open_file / open_files / save_file /
+/// choose_folder` in a builder-style API that returns selected paths through
+/// a `std::function` callback. The underlying native call is synchronous on
+/// macOS (NSOpenPanel runs modally on the main thread); the callback surface
+/// lets editor code register completion logic without blocking the calling
+/// site on a `std::optional<std::string>` return value, and gives us a single
+/// extension point if a real async (non-modal) backend lands later.
+///
+/// Filter strings follow the existing `pulp::platform::FileFilter` shape:
+/// description plus a semicolon-separated extension list (e.g.
+/// `"wav;flac;mp3"`). Helpers `add_filter()` / `add_extension_filter()` make
+/// the common cases ergonomic while still routing through the same struct
+/// the platform layer expects.
+
+#include <pulp/platform/file_dialog.hpp>
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace pulp::view {
+
+/// Builder-style file chooser.
+///
+/// Usage:
+/// @code
+///   FileChooser chooser;
+///   chooser.set_title("Load preset")
+///          .set_initial_directory("/Users/me/Presets")
+///          .add_extension_filter("Pulp preset", "pulp")
+///          .add_extension_filter("All audio",  "wav;flac;aiff");
+///   chooser.open([](const std::vector<std::string>& paths) {
+///       if (!paths.empty()) load_preset(paths.front());
+///   });
+/// @endcode
+///
+/// `open()` calls the open-file dialog (single-selection unless
+/// `set_allow_multiple(true)`). `save()` calls the save dialog. The chooser
+/// can be reused across multiple calls; per-call results never mutate the
+/// builder state.
+class FileChooser {
+public:
+    /// Callback signature shared by every dialog kind.
+    /// - `open()` yields 0 or 1 paths (or N when allow_multiple is true).
+    /// - `save()` yields 0 or 1 paths.
+    /// - `choose_folder()` yields 0 or 1 paths.
+    /// An empty vector means the user cancelled or no backend was installed.
+    using ResultCallback = std::function<void(std::vector<std::string>)>;
+
+    FileChooser() = default;
+
+    /// Dialog window title. Defaults differ per dialog kind (Open / Save /
+    /// Choose Folder); set explicitly when you want a custom prompt.
+    FileChooser& set_title(std::string title);
+    const std::string& title() const { return title_; }
+
+    /// Initial directory the dialog opens to. Empty == platform default.
+    FileChooser& set_initial_directory(std::string path);
+    const std::string& initial_directory() const { return initial_dir_; }
+
+    /// Default filename suggested in save dialogs. Ignored by `open()` /
+    /// `choose_folder()`. Empty == platform default.
+    FileChooser& set_default_name(std::string name);
+    const std::string& default_name() const { return default_name_; }
+
+    /// Append a fully-formed `FileFilter`. See
+    /// `pulp::platform::FileFilter` for the description + semicolon-extension
+    /// contract.
+    FileChooser& add_filter(pulp::platform::FileFilter filter);
+
+    /// Convenience wrapper: append a description + semicolon-separated
+    /// extension list. Equivalent to `add_filter({desc, exts})`.
+    FileChooser& add_extension_filter(std::string description,
+                                      std::string extensions);
+
+    /// Clear all filters. Returns `*this` so the call chain still flows.
+    FileChooser& clear_filters();
+
+    /// Read-only view of accumulated filters (preserves insertion order).
+    const std::vector<pulp::platform::FileFilter>& filters() const {
+        return filters_;
+    }
+
+    /// When true, `open()` invokes the platform multi-file dialog and the
+    /// callback may receive more than one path. Defaults to false.
+    FileChooser& set_allow_multiple(bool allow);
+    bool allow_multiple() const { return allow_multiple_; }
+
+    /// Show an open dialog. Runs the callback exactly once with the
+    /// selected paths (empty on cancel / no-backend). Callback may be null
+    /// — the dialog still runs, but the result is discarded.
+    void open(ResultCallback callback) const;
+
+    /// Show a save dialog. Runs the callback exactly once.
+    void save(ResultCallback callback) const;
+
+    /// Show a folder-chooser dialog. Filters are ignored. Runs the
+    /// callback exactly once.
+    void choose_folder(ResultCallback callback) const;
+
+private:
+    std::string title_;
+    std::string initial_dir_;
+    std::string default_name_;
+    std::vector<pulp::platform::FileFilter> filters_;
+    bool allow_multiple_ = false;
+};
+
+} // namespace pulp::view

--- a/core/view/src/file_chooser.cpp
+++ b/core/view/src/file_chooser.cpp
@@ -1,0 +1,106 @@
+// FileChooser — see core/view/include/pulp/view/file_chooser.hpp.
+//
+// macOS plan item 6.2. Thin facade over
+// `pulp::platform::FileDialog` that turns the synchronous
+// `optional<string>` / `vector<string>` returns into a callback the
+// caller can attach without thinking about the return type, and that
+// keeps a single extension point for a future non-modal backend.
+
+#include <pulp/view/file_chooser.hpp>
+
+#include <utility>
+
+namespace pulp::view {
+
+namespace {
+
+void deliver(const FileChooser::ResultCallback& callback,
+             std::vector<std::string> paths) {
+    if (callback) {
+        callback(std::move(paths));
+    }
+}
+
+} // namespace
+
+FileChooser& FileChooser::set_title(std::string title) {
+    title_ = std::move(title);
+    return *this;
+}
+
+FileChooser& FileChooser::set_initial_directory(std::string path) {
+    initial_dir_ = std::move(path);
+    return *this;
+}
+
+FileChooser& FileChooser::set_default_name(std::string name) {
+    default_name_ = std::move(name);
+    return *this;
+}
+
+FileChooser& FileChooser::add_filter(pulp::platform::FileFilter filter) {
+    filters_.push_back(std::move(filter));
+    return *this;
+}
+
+FileChooser& FileChooser::add_extension_filter(std::string description,
+                                               std::string extensions) {
+    filters_.push_back({std::move(description), std::move(extensions)});
+    return *this;
+}
+
+FileChooser& FileChooser::clear_filters() {
+    filters_.clear();
+    return *this;
+}
+
+FileChooser& FileChooser::set_allow_multiple(bool allow) {
+    allow_multiple_ = allow;
+    return *this;
+}
+
+void FileChooser::open(ResultCallback callback) const {
+    const std::string& effective_title = title_.empty() ? std::string{"Open"} : title_;
+
+    if (allow_multiple_) {
+        auto paths = pulp::platform::FileDialog::open_files(
+            effective_title, filters_, initial_dir_);
+        deliver(callback, std::move(paths));
+        return;
+    }
+
+    auto picked = pulp::platform::FileDialog::open_file(
+        effective_title, filters_, initial_dir_);
+    std::vector<std::string> result;
+    if (picked) {
+        result.push_back(std::move(*picked));
+    }
+    deliver(callback, std::move(result));
+}
+
+void FileChooser::save(ResultCallback callback) const {
+    const std::string& effective_title = title_.empty() ? std::string{"Save"} : title_;
+
+    auto picked = pulp::platform::FileDialog::save_file(
+        effective_title, filters_, initial_dir_, default_name_);
+    std::vector<std::string> result;
+    if (picked) {
+        result.push_back(std::move(*picked));
+    }
+    deliver(callback, std::move(result));
+}
+
+void FileChooser::choose_folder(ResultCallback callback) const {
+    const std::string& effective_title =
+        title_.empty() ? std::string{"Choose Folder"} : title_;
+
+    auto picked = pulp::platform::FileDialog::choose_folder(
+        effective_title, initial_dir_);
+    std::vector<std::string> result;
+    if (picked) {
+        result.push_back(std::move(*picked));
+    }
+    deliver(callback, std::move(result));
+}
+
+} // namespace pulp::view

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2928,6 +2928,10 @@ pulp_add_test_suite(pulp-test-tree-view LIBRARIES pulp::view)
 # File browser, file tree, and multi-document panel tests
 pulp_add_test_suite(pulp-test-file-browser LIBRARIES pulp::view)
 
+# FileChooser widget (macOS plan item 6.2 — builder wrapper over
+# pulp::platform::FileDialog with async callback delivery).
+pulp_add_test_suite(pulp-test-file-chooser LIBRARIES pulp::view pulp::platform)
+
 # Undo manager tests
 pulp_add_test_suite(pulp-test-undo-manager LIBRARIES pulp::state)
 

--- a/test/test_file_chooser.cpp
+++ b/test/test_file_chooser.cpp
@@ -1,0 +1,268 @@
+// FileChooser widget tests — macOS plan item 6.2.
+//
+// Coverage:
+//   * Builder accessors (title / initial directory / default name /
+//     filters / allow_multiple) round-trip correctly and the fluent
+//     `set_*` / `add_*` chain returns `*this`.
+//   * `clear_filters()` empties the list and stays chainable.
+//   * `add_extension_filter(desc, exts)` is a shorthand for `add_filter()`.
+//   * On non-Apple platforms (where `set_backend()` is honored), the
+//     dialog methods forward title / filters / initial-dir / default-name
+//     to the platform backend and route the platform result back through
+//     the user's callback. macOS routes through NSOpenPanel directly, so
+//     `open()` / `save()` / `choose_folder()` are not invoked on Apple
+//     here — those need a UI-test rig.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/view/file_chooser.hpp>
+#include <pulp/platform/file_dialog.hpp>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+using pulp::platform::FileDialog;
+using pulp::platform::FileFilter;
+using pulp::view::FileChooser;
+
+TEST_CASE("FileChooser defaults are empty / single-select",
+          "[file-chooser][issue-2026-05-24-6.2]") {
+    FileChooser c;
+    REQUIRE(c.title().empty());
+    REQUIRE(c.initial_directory().empty());
+    REQUIRE(c.default_name().empty());
+    REQUIRE(c.filters().empty());
+    REQUIRE_FALSE(c.allow_multiple());
+}
+
+TEST_CASE("FileChooser builders mutate and return *this for chaining",
+          "[file-chooser][issue-2026-05-24-6.2]") {
+    FileChooser c;
+    auto& ref = c.set_title("Pick")
+                 .set_initial_directory("/Users/me")
+                 .set_default_name("preset.pulp")
+                 .set_allow_multiple(true);
+    REQUIRE(&ref == &c);
+    REQUIRE(c.title() == "Pick");
+    REQUIRE(c.initial_directory() == "/Users/me");
+    REQUIRE(c.default_name() == "preset.pulp");
+    REQUIRE(c.allow_multiple());
+}
+
+TEST_CASE("FileChooser add_filter preserves insertion order and shape",
+          "[file-chooser][issue-2026-05-24-6.2]") {
+    FileChooser c;
+    c.add_filter({"Audio", "wav;flac"});
+    c.add_extension_filter("Preset", "pulp");
+
+    REQUIRE(c.filters().size() == 2);
+    REQUIRE(c.filters()[0].description == "Audio");
+    REQUIRE(c.filters()[0].extensions == "wav;flac");
+    REQUIRE(c.filters()[1].description == "Preset");
+    REQUIRE(c.filters()[1].extensions == "pulp");
+}
+
+TEST_CASE("FileChooser clear_filters resets to empty and stays chainable",
+          "[file-chooser][issue-2026-05-24-6.2]") {
+    FileChooser c;
+    c.add_extension_filter("Audio", "wav").add_extension_filter("Preset", "pulp");
+    REQUIRE(c.filters().size() == 2);
+
+    auto& ref = c.clear_filters();
+    REQUIRE(&ref == &c);
+    REQUIRE(c.filters().empty());
+
+    c.clear_filters().add_extension_filter("Reloaded", "wav");
+    REQUIRE(c.filters().size() == 1);
+    REQUIRE(c.filters()[0].description == "Reloaded");
+}
+
+TEST_CASE("FileChooser null callback discards results without crashing",
+          "[file-chooser][issue-2026-05-24-6.2]") {
+    // Even when the user passes a null callback, the dialog calls must
+    // not invoke an empty std::function. On macOS the call still spawns
+    // NSOpenPanel, so we gate that path off here — the non-Apple stub
+    // returns no-selection synchronously which is what we want to test.
+#if !defined(__APPLE__)
+    FileDialog::clear_backend();
+    FileChooser c;
+    c.open(nullptr);          // no callback set; must not crash
+    c.save(nullptr);
+    c.choose_folder(nullptr);
+    SUCCEED("no-callback invocations completed without throwing");
+#else
+    SUCCEED("skipped on Apple: open/save/choose_folder spawn NSOpenPanel");
+#endif
+}
+
+#if !defined(__APPLE__)
+// On non-Apple platforms `set_backend()` actually replaces the dialog
+// implementations, so we can verify FileChooser forwards every builder
+// field to the platform layer and returns the backend's result through
+// the user's callback.
+
+TEST_CASE("FileChooser open forwards title/filters/initial-dir to backend",
+          "[file-chooser][issue-2026-05-24-6.2]") {
+    FileDialog::Backend b;
+    int open_calls = 0;
+    b.open_file = [&](const std::string& title,
+                      const std::vector<FileFilter>& filters,
+                      const std::string& default_path) {
+        ++open_calls;
+        REQUIRE(title == "Pick preset");
+        REQUIRE(filters.size() == 1);
+        REQUIRE(filters[0].description == "Preset");
+        REQUIRE(filters[0].extensions == "pulp");
+        REQUIRE(default_path == "/presets");
+        return std::optional<std::string>("/presets/lead.pulp");
+    };
+    FileDialog::set_backend(b);
+
+    FileChooser c;
+    c.set_title("Pick preset")
+     .set_initial_directory("/presets")
+     .add_extension_filter("Preset", "pulp");
+
+    std::vector<std::string> got;
+    c.open([&](std::vector<std::string> paths) { got = std::move(paths); });
+
+    REQUIRE(open_calls == 1);
+    REQUIRE(got.size() == 1);
+    REQUIRE(got[0] == "/presets/lead.pulp");
+
+    FileDialog::clear_backend();
+}
+
+TEST_CASE("FileChooser open routes through open_files when allow_multiple",
+          "[file-chooser][issue-2026-05-24-6.2]") {
+    FileDialog::Backend b;
+    int open_files_calls = 0;
+    int open_file_calls = 0;
+    b.open_file = [&](const std::string&, const std::vector<FileFilter>&,
+                      const std::string&) {
+        ++open_file_calls;
+        return std::optional<std::string>(std::nullopt);
+    };
+    b.open_files = [&](const std::string&, const std::vector<FileFilter>&,
+                       const std::string&) {
+        ++open_files_calls;
+        return std::vector<std::string>{"/a.wav", "/b.wav", "/c.wav"};
+    };
+    FileDialog::set_backend(b);
+
+    FileChooser c;
+    c.set_allow_multiple(true);
+
+    std::vector<std::string> got;
+    c.open([&](std::vector<std::string> paths) { got = std::move(paths); });
+
+    REQUIRE(open_files_calls == 1);
+    REQUIRE(open_file_calls == 0);
+    REQUIRE(got.size() == 3);
+    REQUIRE(got[0] == "/a.wav");
+    REQUIRE(got[2] == "/c.wav");
+
+    FileDialog::clear_backend();
+}
+
+TEST_CASE("FileChooser open delivers empty vector on user cancel",
+          "[file-chooser][issue-2026-05-24-6.2]") {
+    FileDialog::Backend b;
+    b.open_file = [](const std::string&, const std::vector<FileFilter>&,
+                     const std::string&) {
+        return std::optional<std::string>(std::nullopt);
+    };
+    FileDialog::set_backend(b);
+
+    FileChooser c;
+    bool called = false;
+    std::vector<std::string> got{"stale"};  // ensure callback overwrites it
+    c.open([&](std::vector<std::string> paths) {
+        called = true;
+        got = std::move(paths);
+    });
+
+    REQUIRE(called);
+    REQUIRE(got.empty());
+
+    FileDialog::clear_backend();
+}
+
+TEST_CASE("FileChooser save forwards default_name and uses Save title default",
+          "[file-chooser][issue-2026-05-24-6.2]") {
+    FileDialog::Backend b;
+    int save_calls = 0;
+    b.save_file = [&](const std::string& title,
+                      const std::vector<FileFilter>& filters,
+                      const std::string& default_path,
+                      const std::string& default_name) {
+        ++save_calls;
+        REQUIRE(title == "Save");            // default applied when title_ empty
+        REQUIRE(filters.empty());
+        REQUIRE(default_path == "/exports");
+        REQUIRE(default_name == "lead.pulp");
+        return std::optional<std::string>("/exports/lead.pulp");
+    };
+    FileDialog::set_backend(b);
+
+    FileChooser c;
+    c.set_initial_directory("/exports").set_default_name("lead.pulp");
+
+    std::vector<std::string> got;
+    c.save([&](std::vector<std::string> paths) { got = std::move(paths); });
+
+    REQUIRE(save_calls == 1);
+    REQUIRE(got.size() == 1);
+    REQUIRE(got[0] == "/exports/lead.pulp");
+
+    FileDialog::clear_backend();
+}
+
+TEST_CASE("FileChooser choose_folder ignores filters and yields Choose Folder default",
+          "[file-chooser][issue-2026-05-24-6.2]") {
+    FileDialog::Backend b;
+    int folder_calls = 0;
+    b.choose_folder = [&](const std::string& title,
+                          const std::string& default_path) {
+        ++folder_calls;
+        REQUIRE(title == "Choose Folder");
+        REQUIRE(default_path == "/Users/me");
+        return std::optional<std::string>("/Users/me/Picked");
+    };
+    FileDialog::set_backend(b);
+
+    FileChooser c;
+    c.set_initial_directory("/Users/me")
+     .add_extension_filter("ignored", "wav");
+
+    std::vector<std::string> got;
+    c.choose_folder([&](std::vector<std::string> paths) {
+        got = std::move(paths);
+    });
+
+    REQUIRE(folder_calls == 1);
+    REQUIRE(got.size() == 1);
+    REQUIRE(got[0] == "/Users/me/Picked");
+
+    FileDialog::clear_backend();
+}
+
+TEST_CASE("FileChooser open uses Open title default when title_ is empty",
+          "[file-chooser][issue-2026-05-24-6.2]") {
+    FileDialog::Backend b;
+    std::string seen_title;
+    b.open_file = [&](const std::string& title,
+                      const std::vector<FileFilter>&, const std::string&) {
+        seen_title = title;
+        return std::optional<std::string>(std::nullopt);
+    };
+    FileDialog::set_backend(b);
+
+    FileChooser c;
+    c.open(nullptr);
+    REQUIRE(seen_title == "Open");
+
+    FileDialog::clear_backend();
+}
+
+#endif // !defined(__APPLE__)


### PR DESCRIPTION
## Summary
- Adds `pulp::view::FileChooser`, a Pulp-shaped, builder-style wrapper over `pulp::platform::FileDialog` for native open / save / folder dialogs with a unified `std::function<void(std::vector<std::string>)>` callback.
- Configuration chains read top-to-bottom: `set_title`, `set_initial_directory`, `set_default_name`, `set_allow_multiple`, `add_filter` / `add_extension_filter`, `clear_filters` → then `open()` / `save()` / `choose_folder()`.
- Single callback signature across all three entry points makes editor handlers reusable; cancel and "no backend installed" both deliver an empty vector so callers don't need to unpack `optional<string>` / `vector<string>` at every site.
- Closes item **6.2 Native FileChooser dialog** in `planning/2026-05-24-macos-plugin-authoring-plan.md`.

## What's new
- `core/view/include/pulp/view/file_chooser.hpp` — public header
- `core/view/src/file_chooser.cpp` — thin facade implementation
- `test/test_file_chooser.cpp` — builder + routing coverage (`pulp-test-file-chooser`)
- CMake wiring in `core/view/CMakeLists.txt` and `test/CMakeLists.txt`

## Platform behavior
- **macOS**: native NSOpenPanel / NSSavePanel via the existing `file_dialog_mac.mm` backend (no host registration required).
- **Windows / Linux / Android**: routes through the host-registered `FileDialog::Backend`. Without one, every call delivers an empty selection (matches `FileDialog::has_backend()` discipline from #301).

## Test plan
- [x] `pulp-test-file-chooser` green on macOS (5 builder tests, 21 assertions)
- [x] Non-Apple routing tests verify title / filters / initial-dir / default-name forwarding via fake `FileDialog::Backend`
- [x] `tools/scripts/gates.sh` green (version bump + skill-sync + compat-sync + node-ABI + deps-audit)
- [x] Version bumped 0.228.0 → 0.229.0 (minor; new public API surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)