### PR TITLE
fix(signal): ConvolverIrSwapper retired ring keeps frees off audio thread (Codex P1 on #2881)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.231.0
+    VERSION 0.233.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/signal/CMakeLists.txt
+++ b/core/signal/CMakeLists.txt
@@ -7,6 +7,11 @@ target_include_directories(pulp-signal
         $<INSTALL_INTERFACE:include>
 )
 
+# pulp/signal/convolver_messages.hpp transitively includes
+# pulp::runtime's SpscQueue (lock-free retired-IR ring). Propagate
+# the dependency so consumers of pulp::signal don't have to know.
+target_link_libraries(pulp-signal INTERFACE pulp::runtime)
+
 # Link Accelerate framework on Apple for vDSP FFT optimization
 if(APPLE)
     target_link_libraries(pulp-signal INTERFACE "-framework Accelerate")

--- a/core/signal/include/pulp/signal/convolver.hpp
+++ b/core/signal/include/pulp/signal/convolver.hpp
@@ -64,28 +64,36 @@ public:
     /// Must be called at a block boundary (between `process()` calls)
     /// so the in-flight overlap buffers don't pick up midway through.
     bool try_swap_ir(ConvolverIrSwapper& swapper) {
+        // Gate the swap on retire-ring capacity FIRST so the audio
+        // thread never has to free the displaced IR inline if the
+        // ring is saturated (Codex P1 on #2881 — single-slot retired_
+        // would let the audio thread deallocate when 2+ swaps
+        // happened between drain_old() calls). Refusing the swap
+        // when the ring is full is RT-safe: pending stays in the
+        // swapper for the next try_swap_ir attempt; in-flight state_
+        // continues uninterrupted; worker thread catches up on its
+        // next drain tick.
+        if (state_ && !swapper.has_retire_capacity()) {
+            return false;
+        }
+
         auto next = swapper.try_consume();
         if (!next)
             return false;
 
-        // Hand off the displaced IR to the swapper for off-thread
-        // teardown. If the swapper's retired slot was already full,
-        // the swapper returns the previous occupant so we can fall
-        // back to in-line deletion — this should be vanishingly rare
-        // in practice (UI thread drains faster than IRs swap), but
-        // the fallback prevents a leak.
         auto previous = std::move(state_);
         state_ = std::move(next);
         partition_index_ = 0;
 
         if (previous) {
-            auto bumped = swapper.retire(std::move(previous));
-            // bumped is freed here (off audio thread? no — but only
-            // ever in the pathological "swap faster than drain" case;
-            // free counts as a soft RT violation we accept over a
-            // leak). drain_old() on the worker thread keeps this
-            // bumped pointer null in normal operation.
-            (void)bumped;
+            // We pre-checked capacity above (single-producer ring +
+            // single audio-thread consumer here, so no race between
+            // the check and this push). The unreachable false branch
+            // is defence-in-depth — leaks `previous` rather than
+            // freeing on RT.
+            const bool ok = swapper.retire(previous);
+            (void)ok;
+            (void)previous.release(); // ownership transferred on ok==true
         }
         return true;
     }

--- a/core/signal/include/pulp/signal/convolver_messages.hpp
+++ b/core/signal/include/pulp/signal/convolver_messages.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <pulp/runtime/spsc_queue.hpp>
 #include <pulp/signal/fft.hpp>
 
 #include <algorithm>
@@ -110,11 +111,11 @@ public:
     ConvolverIrSwapper& operator=(const ConvolverIrSwapper&) = delete;
 
     ~ConvolverIrSwapper() {
-        // Reclaim anything still parked in either slot so we don't
-        // leak memory at teardown. Safe because both producer and
-        // consumer threads must have stopped by destruction.
+        // Reclaim anything still parked so we don't leak memory at
+        // teardown. Safe because both producer and consumer threads
+        // must have stopped by destruction.
         delete pending_.exchange(nullptr, std::memory_order_acquire);
-        delete retired_.exchange(nullptr, std::memory_order_acquire);
+        while (auto* p = pop_retired_raw()) delete p;
     }
 
     /// Build a fresh IR state off the audio thread and publish it for
@@ -154,26 +155,50 @@ public:
     }
 
     /// Audio-thread-callable: park the IR that the audio thread is
-    /// displacing so a non-RT thread can free it. If a previous retire
-    /// has not been drained yet, the new and old swap and the older
-    /// pointer is returned for the caller to either re-retire later
-    /// (rare) or in-line free (fallback). The intent is that the UI
-    /// thread calls `drain_old()` faster than IRs swap.
-    [[nodiscard]] std::unique_ptr<ConvolverIrState>
-    retire(std::unique_ptr<ConvolverIrState> displaced) {
-        if (!displaced)
-            return nullptr;
-        auto* raw = displaced.release();
-        auto* prev = retired_.exchange(raw, std::memory_order_acq_rel);
-        return std::unique_ptr<ConvolverIrState>(prev);
+    /// displacing so a non-RT thread can free it. Returns `true` if
+    /// the IR was queued for drain; `false` if the retire ring is
+    /// already full. On `false` the displaced state is returned to
+    /// the caller via the moved-in `unique_ptr` being LEFT INTACT
+    /// (caller still owns it). The audio-thread caller (see
+    /// `PartitionedConvolver::try_swap_ir`) should gate the swap on
+    /// `has_retire_capacity()` first so this path is never hit in
+    /// well-paced operation.
+    ///
+    /// RT contract: never allocates, never blocks, never frees.
+    [[nodiscard]] bool retire(std::unique_ptr<ConvolverIrState>& displaced) {
+        if (!displaced) return true; // nothing to park
+        auto* raw = displaced.get();
+        if (!retired_queue_.try_push(raw)) return false;
+        (void)displaced.release(); // ownership transferred to queue
+        return true;
     }
 
-    /// UI / worker thread: reclaim any retired IR that the audio
-    /// thread parked here. Call periodically (e.g. once per UI tick).
-    /// Returns the freed state for inspection in tests; the unique_ptr
-    /// destructor performs the actual deallocation.
-    std::unique_ptr<ConvolverIrState> drain_old() {
-        auto* raw = retired_.exchange(nullptr, std::memory_order_acquire);
+    /// True if there's room in the retire ring for one more displaced
+    /// IR. Audio thread checks this before consuming pending so a
+    /// swap never strands a displaced IR without an off-thread free
+    /// path (Codex P1 on #2881).
+    bool has_retire_capacity() const {
+        return retired_queue_.size_approx() < kRetireRingCapacity;
+    }
+
+    /// UI / worker thread: reclaim ALL retired IRs the audio thread
+    /// has parked. Returns the count freed; the actual deallocation
+    /// runs through `unique_ptr` destructors in this scope (off-RT).
+    /// Test callers can use the single-pop overload below if they
+    /// want to inspect each freed state.
+    std::size_t drain_old() {
+        std::size_t freed = 0;
+        while (auto* raw = pop_retired_raw()) {
+            std::unique_ptr<ConvolverIrState> state(raw);
+            ++freed;
+        }
+        return freed;
+    }
+
+    /// UI / worker thread: pop ONE retired IR for test inspection.
+    /// Returns nullptr if none queued.
+    std::unique_ptr<ConvolverIrState> drain_old_one() {
+        auto* raw = pop_retired_raw();
         return std::unique_ptr<ConvolverIrState>(raw);
     }
 
@@ -182,17 +207,33 @@ public:
         return pending_.load(std::memory_order_acquire) != nullptr;
     }
 
-    /// True if a retired IR is awaiting drain.
+    /// True if any retired IR is awaiting drain.
     bool has_retired() const {
-        return retired_.load(std::memory_order_acquire) != nullptr;
+        return retired_queue_.size_approx() > 0;
+    }
+
+    /// Compile-time capacity of the retired-IR ring. Sized so a few
+    /// back-to-back swaps survive a single missed drain tick — past
+    /// this point, swaps refuse until a drain runs.
+    static constexpr std::size_t retire_capacity() {
+        return kRetireRingCapacity;
     }
 
 private:
+    static constexpr std::size_t kRetireRingCapacity = 8;
+
     // Producer → consumer: latest IR awaiting pickup.
     std::atomic<ConvolverIrState*> pending_{nullptr};
-    // Consumer → producer: IR displaced from the audio thread,
-    // waiting to be freed off-thread.
-    std::atomic<ConvolverIrState*> retired_{nullptr};
+    // Consumer → producer: ring of displaced IRs awaiting off-thread
+    // deletion. Replaces the single-slot atomic the original impl used
+    // (Codex P1 #2881 — single slot starved on rapid IR automation,
+    // forcing audio-thread frees when the slot was full).
+    pulp::runtime::SpscQueue<ConvolverIrState*, kRetireRingCapacity> retired_queue_;
+
+    ConvolverIrState* pop_retired_raw() {
+        auto popped = retired_queue_.try_pop();
+        return popped ? *popped : nullptr;
+    }
 };
 
 } // namespace pulp::signal

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1343,7 +1343,7 @@ pulp_add_test_suite(pulp-test-convolver LIBRARIES pulp::signal)
 # Background-IR-swap tests for PartitionedConvolver (macOS plugin authoring
 # plan item 2.3, Slice A). Lock-free pointer-shuttle hand-off from worker
 # thread → audio thread, including a concurrent stage/swap hammer test.
-pulp_add_test_suite(pulp-test-convolver-bg-swap LIBRARIES pulp::signal)
+pulp_add_test_suite(pulp-test-convolver-bg-swap LIBRARIES pulp::signal pulp::runtime)
 
 # Test signal source (sine tone, file playback)
 pulp_add_test_suite(pulp-test-test-signal LIBRARIES pulp::standalone)

--- a/test/test_convolver_bg_swap.cpp
+++ b/test/test_convolver_bg_swap.cpp
@@ -120,7 +120,7 @@ TEST_CASE("PartitionedConvolver::try_swap_ir picks up a staged IR",
 
     // The retired slot now holds the previously-loaded identity IR.
     REQUIRE(swapper.has_retired());
-    auto reclaimed = swapper.drain_old();
+    auto reclaimed = swapper.drain_old_one();
     REQUIRE(reclaimed != nullptr);
     REQUIRE_FALSE(swapper.has_retired());
 }
@@ -157,7 +157,7 @@ TEST_CASE("PartitionedConvolver swap changes processing output without xrun",
         REQUIRE_THAT(out_half[i], WithinAbs(input[i] * 0.5f, 1e-3f));
 
     // Worker thread drains the retired IR.
-    auto reclaimed = swapper.drain_old();
+    auto reclaimed = swapper.drain_old_one();
     REQUIRE(reclaimed != nullptr);
 }
 
@@ -231,4 +231,52 @@ TEST_CASE("PartitionedConvolver: try_swap_ir on an unloaded convolver",
     REQUIRE(conv.is_loaded());
     // Nothing to retire — convolver was empty before the swap.
     REQUIRE_FALSE(swapper.has_retired());
+}
+
+TEST_CASE("PartitionedConvolver: rapid swaps without drain refuse cleanly (Codex #2881 P1)",
+          "[signal][convolver][bg-swap][regression]") {
+    // The earlier impl used a single-slot retired_ atomic. Two swaps
+    // between drain_old() calls meant the displaced IR fell back to
+    // an inline delete on the audio thread — soft RT violation.
+    // The fix:
+    //   1. retired_ is now a fixed-size SPSC ring (kRetireRingCapacity).
+    //   2. try_swap_ir gates on has_retire_capacity() BEFORE consuming
+    //      pending. If the ring is full, the swap refuses cleanly;
+    //      pending IR stays in the swapper for the next attempt; the
+    //      in-flight IR continues; no audio-thread free, no leak.
+    constexpr std::size_t block = 64;
+    PartitionedConvolver conv;
+    const auto first = make_identity_ir(block);
+    conv.load_ir(first.data(), first.size(), block);
+
+    ConvolverIrSwapper swapper;
+    const std::size_t cap = ConvolverIrSwapper::retire_capacity();
+    REQUIRE(cap >= 2);
+
+    // Fire `cap` back-to-back swaps without draining; each must
+    // succeed and park its displaced IR.
+    for (std::size_t i = 0; i < cap; ++i) {
+        const auto ir = make_identity_ir(block);
+        REQUIRE(swapper.stage_ir(ir.data(), ir.size(), block));
+        REQUIRE(conv.try_swap_ir(swapper));
+    }
+    // Ring should now be full.
+    REQUIRE_FALSE(swapper.has_retire_capacity());
+
+    // One more swap MUST refuse. Pending stays staged, in-flight IR
+    // unchanged.
+    const auto extra = make_identity_ir(block);
+    REQUIRE(swapper.stage_ir(extra.data(), extra.size(), block));
+    REQUIRE_FALSE(conv.try_swap_ir(swapper));
+    REQUIRE(swapper.has_pending()); // pending still there for retry
+    REQUIRE_FALSE(swapper.has_retire_capacity());
+
+    // Worker drains; capacity returns.
+    const std::size_t freed = swapper.drain_old();
+    REQUIRE(freed == cap);
+    REQUIRE(swapper.has_retire_capacity());
+
+    // Retry the refused swap — now it succeeds.
+    REQUIRE(conv.try_swap_ir(swapper));
+    REQUIRE_FALSE(swapper.has_pending());
 }


### PR DESCRIPTION
## Summary

Codex P1 follow-up on **#2881** (item 2.3 Slice A — Convolver background IR swap). The earlier impl used a single-slot `std::atomic<ConvolverIrState*> retired_` for displaced IRs. When 2+ swaps happened between `drain_old()` calls (realistic during rapid IR automation), the second swap's `retire()` returned the previously-retired pointer and its destructor ran inline on the audio thread — a soft RT violation despite the API contract.

## Fix

- **`ConvolverIrSwapper::retired_` is now a fixed-size SPSC ring** (`kRetireRingCapacity = 8`). Up to N back-to-back swaps survive a single missed drain.
- **`retire(unique_ptr&)` returns `bool`**: `true` = parked in ring, `false` = ring full (displaced still owned by caller). The audio thread NEVER allocates or frees on this path.
- **`PartitionedConvolver::try_swap_ir` gates on `has_retire_capacity()` BEFORE consuming pending.** If the ring is full, the swap refuses cleanly; pending stays staged; the in-flight IR continues; worker thread catches up next drain tick.

### API touch-up

- `drain_old()` now returns the COUNT of IRs freed (was: returned the single popped unique_ptr).
- `drain_old_one()` added for test inspection paths that want a handle.

### CMake

`pulp-signal` now links `pulp::runtime` transitively because `convolver_messages.hpp` pulls in `SpscQueue`. Test target gains the same dep.

## Test plan

- [x] `pulp-test-convolver-bg-swap` — **8 cases / 512318 assertions** ✓ (was 7/512292)
  - New regression: "rapid swaps without drain refuse cleanly (Codex #2881 P1)" — fires `cap` back-to-back swaps, asserts ring fills + next refuses + pending stays + drain restores capacity + retry succeeds
  - Existing 7 tests updated for the new `drain_old_one()` API; all still pass

## Notes

- Minor version bump 0.231.0 → 0.232.0 (new public surface on the swapper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)