### PR TITLE
feat(midi): extract shared UmpSysex7Reassembler from AUv3 + CoreMIDI (item 8.2)

### DIFF
--- a/.agents/skills/auv3/SKILL.md
+++ b/.agents/skills/auv3/SKILL.md
@@ -507,18 +507,41 @@ status == 0x2  → continue
 status == 0x3  → end
 ```
 
-`au_adapter.mm` accumulates start → continue → end spans into one
-`add_sysex` call (`#292` / `#288`). Two hard-learned P1 lessons:
+As of macOS plan item 8.2, the sysex7 reassembly state machine no
+longer lives inline in `au_adapter.mm` — it now delegates to the
+shared `pulp::midi::UmpSysex7Reassembler`
+(`core/midi/include/pulp/midi/ump_sysex7_reassembler.hpp`) so the
+same battle-tested implementation backs every UMP-aware Pulp backend
+(AUv3, CoreMIDI device input, and any future Win/Linux UMP path).
+`au_adapter.mm` only owns the AURenderEventMIDIEventList walk, the
+word-cursor advance, and the per-MIDIEventList `EmitCtx` that tags
+the assembled sysex with `event->head.eventSampleTime`.
+
+When touching the AUv3 sysex path: prefer fixes inside the shared
+reassembler (and `test/test_ump_sysex7_reassembler.cpp`) over
+adapter-local patches. Two P1 invariants the adapter still owns
+itself remain unchanged and important:
 
 1. **Advance the word cursor by `ump_words`, not by 1.** A type-3
    message is 2 UMP words long; advancing by 1 makes the second
-   word's header nibble look like a new message header (P1).
-2. **Sysex7 size is 0..6 bytes per 2-word packet.** Extract bytes
-   from word0 bits 15..0 + word1 bits 31..0, clamped to `size` and to
-   6 (#292 P2 — preserve message boundaries).
+   word's header nibble look like a new message header (`#292` P1).
+   This lives in the `switch (mt)` block above the call to
+   `reassembler.feed_packet`.
+2. **`reassembler.feed_packet` expects an already-type-3 packet** —
+   the adapter checks `mt == 0x3` before calling. Don't push the
+   type check into the reassembler; both call sites already need the
+   nibble for cursor advance and re-checking would be redundant in
+   the hot path.
 
-Both are tested by `test/test_ump_*.cpp`. Touch the accumulator → add
-a test that exercises the boundary.
+Sysex7 size is still 0..6 bytes per 2-word packet (#292 P2 —
+preserve message boundaries); the reassembler clamps to 6
+defensively.
+
+Both invariants are tested by
+`test/test_ump_sysex7_reassembler.cpp` (the `#292 P1` test feeds a
+contrived packet whose word1 begins with a nibble matching sysex7
+to prove word1 is never reparsed as a fresh word0). Touch the
+reassembler → add a test that exercises the boundary.
 
 ### Short-MIDI length must be validated
 

--- a/.agents/skills/mpe/SKILL.md
+++ b/.agents/skills/mpe/SKILL.md
@@ -203,6 +203,30 @@ still works if you extract per-note data from `MidiBuffer` yourself.
 - Hosting MPE plugins (MPE output, dispatching MPE into a loaded
   plugin) — covered by the SignalGraph hosting work, not this skill.
 
+### UMP sysex7 reassembly (post macOS-plan 8.2)
+
+UMP type-0x3 sysex7 reassembly is **not part of MpeVoiceTracker** —
+it's a separate per-stream state machine shared across every Pulp
+UMP backend, exposed as `pulp::midi::UmpSysex7Reassembler` in
+`core/midi/include/pulp/midi/ump_sysex7_reassembler.hpp`. Each
+input port / source owns one instance (the reassembler is not
+thread-safe; that's by design, since CoreMIDI / AUv3 callbacks are
+already single-threaded per port).
+
+Touching anything in `core/midi/include/**/*ump*` triggers this
+skill via `tools/scripts/skill_path_map.json`. When you add a new
+UMP-aware backend (WinRT MIDI 2.0, ALSA UMP, iOS CoreMIDI 2.0),
+delegate sysex7 reassembly to `UmpSysex7Reassembler` rather than
+re-implementing the start / continue / end state machine inline —
+the AUv3 and macOS CoreMIDI backends do exactly that, and any drift
+between the two backends used to cause the `#239` / `#292` family
+of bugs.
+
+The reassembler's `feed_packet` is a function-pointer-callback
+API so it stays RT-safe in the audio render block; the
+`feed_collect` convenience wrapper allocates and is meant for
+tests / cold paths only.
+
 ## Implementation note: where MpeVoiceTracker bodies live
 
 As of companion-track U-9 (2026-05-19), `MpeVoiceTracker`'s method bodies live in `core/midi/src/mpe_voice_tracker.cpp`, not inline in `core/midi/include/pulp/midi/mpe_voice_tracker.hpp`. The header keeps the class declaration + trivial inline getters; non-trivial methods (`process`, `set_config`, `reset`, `add_note`, `remove_note`, etc.) link from the .cpp.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.233.0
+    VERSION 0.234.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/src/au_adapter.mm
+++ b/core/format/src/au_adapter.mm
@@ -9,6 +9,7 @@
 #include <pulp/format/plugin_state_io.hpp>
 #include <pulp/format/registry.hpp>
 #include <pulp/format/ara.hpp>
+#include <pulp/midi/ump_sysex7_reassembler.hpp>
 #include <pulp/runtime/log.hpp>
 #include <pulp/state/parameter_event_queue.hpp>
 #include <cmath>
@@ -463,47 +464,37 @@ static int32_t block_relative_sample_offset(AUEventSampleTime event_sample_time,
                     midi_in.add(me);
                 }
             } else if (event->head.eventType == AURenderEventMIDIEventList) {
-                // AUMIDIEventList delivers UMP-encoded events. For
-                // sysex the UMP type-3 (7-bit Data Messages) stream
-                // carries the F0..F7 payload spread across 8-byte
-                // (2-word) packets. Each word's top nibble identifies
-                // the UMP message type; nibble 0x3 = sysex7.
+                // AUMIDIEventList delivers UMP-encoded events. The
+                // UMP message-type nibble (bits 28-31 of word 0)
+                // identifies the message class; nibble 0x3 is sysex7
+                // and reassembly is delegated to the shared
+                // UmpSysex7Reassembler in core/midi (macOS plan 8.2 —
+                // extracts the previously inline #292 fix to a
+                // single, tested implementation shared with the
+                // CoreMIDI device backend).
                 //
-                // Each sysex7 UMP also carries a 4-bit status in
-                // bits 20-23 of word 0:
-                //   0x0 = complete (single-packet sysex)
-                //   0x1 = start
-                //   0x2 = continue
-                //   0x3 = end
-                //
-                // We accumulate start→continue→end spans into one
-                // payload and emit a single add_sysex per logical
-                // sysex message (#292 P2 — preserve boundaries).
-                //
-                // Each type-3 message is 2 UMP words, so the cursor
-                // must advance by 2 per message — not 1 — otherwise
-                // the second word's payload nibble can masquerade as
-                // a new message header (#292 P1 — advance by size).
+                // The reassembler emits each completed logical sysex
+                // exactly once; we tag the resulting payload with the
+                // surrounding MIDIEventList's event sample time.
                 const auto& elist = event->MIDIEventsList;
                 const MIDIEventList* packets = &elist.eventList;
                 if (packets) {
-                    std::vector<uint8_t> payload;
-                    bool in_progress = false;
-                    const MIDIEventPacket* pkt = &packets->packet[0];
-
-                    auto extract_bytes = [&](uint32_t w0, uint32_t w1,
-                                             uint32_t size, std::vector<uint8_t>& out) {
-                        const uint8_t buf[6] = {
-                            static_cast<uint8_t>((w0 >>  8) & 0xFF),
-                            static_cast<uint8_t>((w0 >>  0) & 0xFF),
-                            static_cast<uint8_t>((w1 >> 24) & 0xFF),
-                            static_cast<uint8_t>((w1 >> 16) & 0xFF),
-                            static_cast<uint8_t>((w1 >>  8) & 0xFF),
-                            static_cast<uint8_t>((w1 >>  0) & 0xFF),
-                        };
-                        for (uint32_t e = 0; e < size && e < 6; ++e)
-                            out.push_back(buf[e]);
+                    struct EmitCtx {
+                        pulp::midi::MidiBuffer* sink;
+                        int32_t sample_offset;
                     };
+                    EmitCtx ctx{
+                        &midi_in,
+                        static_cast<int32_t>(event->head.eventSampleTime),
+                    };
+                    auto emit = [](const std::vector<uint8_t>& payload,
+                                   void* user) {
+                        auto* c = static_cast<EmitCtx*>(user);
+                        c->sink->add_sysex(payload, c->sample_offset, 0.0);
+                    };
+
+                    pulp::midi::UmpSysex7Reassembler reassembler;
+                    const MIDIEventPacket* pkt = &packets->packet[0];
 
                     for (UInt32 i = 0; i < packets->numPackets; ++i) {
                         UInt32 w = 0;
@@ -514,6 +505,10 @@ static int32_t block_relative_sample_offset(AUEventSampleTime event_sample_time,
                             // UMP message word length by type. Types
                             // not listed default to 1 so we still
                             // advance past unknown messages safely.
+                            // Each type-3 message is 2 UMP words; the
+                            // cursor advances by `ump_words`, not 1,
+                            // so word1 cannot masquerade as a fresh
+                            // message header (#292 P1).
                             UInt32 ump_words = 1;
                             switch (mt) {
                                 case 0x0: case 0x1: case 0x2:
@@ -531,41 +526,8 @@ static int32_t block_relative_sample_offset(AUEventSampleTime event_sample_time,
                             if (w + ump_words > pkt->wordCount) break;
 
                             if (mt == 0x3) {
-                                const uint8_t status = (word0 >> 20) & 0x0F;
-                                const uint32_t size   = (word0 >> 16) & 0x0F;
                                 const uint32_t word1 = pkt->words[w + 1];
-
-                                if (status == 0x0) {
-                                    // Complete single-packet sysex
-                                    std::vector<uint8_t> p;
-                                    extract_bytes(word0, word1, size, p);
-                                    if (!p.empty()) {
-                                        midi_in.add_sysex(std::move(p),
-                                            static_cast<int32_t>(event->head.eventSampleTime),
-                                            0.0);
-                                    }
-                                } else if (status == 0x1) {
-                                    // Start — reset accumulator
-                                    payload.clear();
-                                    extract_bytes(word0, word1, size, payload);
-                                    in_progress = true;
-                                } else if (status == 0x2 && in_progress) {
-                                    extract_bytes(word0, word1, size, payload);
-                                } else if (status == 0x3 && in_progress) {
-                                    extract_bytes(word0, word1, size, payload);
-                                    if (!payload.empty()) {
-                                        midi_in.add_sysex(std::move(payload),
-                                            static_cast<int32_t>(event->head.eventSampleTime),
-                                            0.0);
-                                    }
-                                    payload.clear();
-                                    in_progress = false;
-                                }
-                                // status 0x2/0x3 without in_progress
-                                // arriving first means we missed a
-                                // start; drop silently — corrupting
-                                // the Processor's view is worse than
-                                // dropping one malformed sysex.
+                                reassembler.feed_packet(word0, word1, emit, &ctx);
                             }
 
                             w += ump_words;

--- a/core/midi/include/pulp/midi/ump_sysex7_reassembler.hpp
+++ b/core/midi/include/pulp/midi/ump_sysex7_reassembler.hpp
@@ -1,0 +1,265 @@
+#pragma once
+
+// UmpSysex7Reassembler — shared reassembler for UMP Type-0x3 (sysex7)
+// packet streams.
+//
+// Background
+// ==========
+//
+// MIDI 2.0 UMP delivers sysex via "Data Messages — sysex7" (UMP message
+// type 0x3), which is a 64-bit / 2-word packet carrying up to 6 bytes
+// of sysex payload at a time. A logical sysex (F0 .. F7) longer than
+// 6 bytes is split across multiple type-0x3 packets using a 4-bit
+// status nibble (bits 20-23 of word 0):
+//
+//     0x0  complete   — single-packet sysex (size <= 6 bytes)
+//     0x1  start      — first packet, more to follow
+//     0x2  continue   — middle packet
+//     0x3  end        — final packet
+//
+// The 4-bit "size" field (bits 16-19 of word 0) is the number of valid
+// payload bytes in this packet (0..6). The payload bytes themselves are
+// packed into bits 0..15 of word 0 and bits 0..31 of word 1, in that
+// order:
+//
+//     byte 0 = (word0 >>  8) & 0xFF
+//     byte 1 = (word0 >>  0) & 0xFF
+//     byte 2 = (word1 >> 24) & 0xFF
+//     byte 3 = (word1 >> 16) & 0xFF
+//     byte 4 = (word1 >>  8) & 0xFF
+//     byte 5 = (word1 >>  0) & 0xFF
+//
+// Reference: MIDI 2.0 UMP specification §4.7 "Data Messages — System
+// Exclusive 7-bit (sysex7)".
+//
+// Why a shared reassembler
+// ========================
+//
+// Pulp historically open-coded the same state machine inline in both
+// `core/format/src/au_adapter.mm` (AUv3 MIDIEventList path) and
+// `core/midi/platform/mac/coremidi_device.mm` (CoreMIDI 2.0 input
+// callback). Both implementations carry the same regression notes
+// (#239 / #292) and the same edge-case handling for orphaned
+// continue/end packets. Extracting the state machine here:
+//
+//   1. Eliminates duplicated state and bit-twiddling.
+//   2. Centralises the regression test for the #292 P1 bug ("second
+//      word's top nibble can masquerade as a new message header") and
+//      the #292 P2 boundary-preservation property.
+//   3. Gives future UMP-aware backends (WinRT MIDI 2.0, ALSA UMP,
+//      iOS CoreMIDI 2.0) a drop-in dependency.
+//
+// Thread-safety
+// =============
+//
+// The reassembler holds per-stream state (`payload_` + `in_progress_`).
+// It is **not** thread-safe — each input port / source should own its
+// own instance. The CoreMIDI input callback is single-threaded per
+// port, and AUv3 render blocks are single-threaded per audio bus, so
+// the per-stream model fits both call sites.
+//
+// RT-safety
+// =========
+//
+// `feed_packet()` may allocate inside the internal `std::vector` as
+// the payload grows past its current capacity. Callers that want
+// strict RT-safety should `reserve()` the worst-case sysex length up
+// front via `reserve(N)`. AU adapter render-thread use is already
+// allocating in this path today (pre-extraction), so this extraction
+// does not regress that property.
+//
+// Unit tests live in `test/test_ump_sysex7_reassembler.cpp`.
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace pulp::midi {
+
+/// Callback shape: receives the complete sysex payload (the F0..F7
+/// inner bytes — i.e. the payload bytes carried by the type-0x3
+/// stream, with no synthesised F0/F7 framing). UMP sysex7 packets do
+/// not carry F0/F7 framing bytes by design (the framing is implicit
+/// in the start/continue/end status nibble), so the emitted payload
+/// matches what every downstream Pulp MIDI sink expects from
+/// `MidiBuffer::add_sysex()` / `MidiInput::sysex_callback_`.
+///
+/// The reassembler invokes this callback exactly once per logical
+/// sysex (either a single complete packet, or a start → continue* →
+/// end span). Orphaned continue/end packets (i.e. arrival without a
+/// preceding start) are dropped silently — corrupting the downstream
+/// sink with a partial payload is worse than dropping one malformed
+/// sysex (#292 P2).
+using Sysex7EmitFn = void(*)(const std::vector<std::uint8_t>& payload,
+                             void* user);
+
+/// Reassembler state machine for UMP Type-0x3 sysex7 packet streams.
+///
+/// Per-stream — see "Thread-safety" in the file header.
+class UmpSysex7Reassembler {
+public:
+    /// Classification of the most recently consumed packet.
+    enum class Status {
+        /// Single-packet sysex (status nibble 0x0). The emit callback
+        /// fired with the complete payload.
+        single_packet,
+        /// Start packet (status nibble 0x1). Accumulator is now armed;
+        /// the emit callback has NOT fired yet.
+        start,
+        /// Continue packet (status nibble 0x2) appended to an armed
+        /// accumulator. The emit callback has NOT fired yet.
+        continued,
+        /// End packet (status nibble 0x3) closed an armed accumulator.
+        /// The emit callback fired with the complete payload.
+        ended,
+        /// Continue / end without a preceding start, OR a packet whose
+        /// status nibble is neither 0x0/0x1/0x2/0x3. The accumulator is
+        /// untouched; the callback did NOT fire.
+        dropped,
+    };
+
+    UmpSysex7Reassembler() = default;
+
+    /// Feed a single 2-word UMP packet through the state machine.
+    ///
+    /// Caller must ensure the packet is actually a Type-0x3 (sysex7)
+    /// packet — i.e. `(word0 >> 28) & 0x0F == 0x3`. Passing a non-0x3
+    /// packet is a programmer error; the reassembler does not validate
+    /// the message type itself because callers already need that
+    /// nibble for dispatch / cursor-advance and re-checking it here
+    /// would be redundant work in the hot path.
+    ///
+    /// `emit` is invoked at most once per call, only when this packet
+    /// completes a logical sysex (status 0x0 or 0x3). `user` is passed
+    /// through verbatim — keep it lightweight to preserve RT-safety.
+    Status feed_packet(std::uint32_t word0, std::uint32_t word1,
+                       Sysex7EmitFn emit, void* user) noexcept {
+        const std::uint8_t status =
+            static_cast<std::uint8_t>((word0 >> 20) & 0x0F);
+        const std::uint32_t size =
+            static_cast<std::uint32_t>((word0 >> 16) & 0x0F);
+
+        switch (status) {
+        case 0x0: {
+            // Complete single-packet sysex. Use a scratch vector so
+            // the call doesn't disturb any partial in-progress state
+            // (per #292 P2 — an interleaved single-packet sysex must
+            // not eat a separate in-progress accumulator). This is
+            // genuinely possible: the UMP spec permits independent
+            // sysex streams on different groups to interleave through
+            // a single endpoint.
+            std::vector<std::uint8_t> scratch;
+            extract_bytes(word0, word1, size, scratch);
+            if (!scratch.empty() && emit) {
+                emit(scratch, user);
+            }
+            return Status::single_packet;
+        }
+        case 0x1: {
+            // Start — reset the accumulator and begin capture. If a
+            // previous in-progress sysex was never closed, it is
+            // silently dropped: the spec doesn't allow nested sysex,
+            // and resetting is the only sane recovery.
+            payload_.clear();
+            extract_bytes(word0, word1, size, payload_);
+            in_progress_ = true;
+            return Status::start;
+        }
+        case 0x2:
+            if (in_progress_) {
+                extract_bytes(word0, word1, size, payload_);
+                return Status::continued;
+            }
+            // Orphan continue — drop. See #292 P2.
+            return Status::dropped;
+        case 0x3:
+            if (in_progress_) {
+                extract_bytes(word0, word1, size, payload_);
+                if (!payload_.empty() && emit) {
+                    emit(payload_, user);
+                }
+                payload_.clear();
+                in_progress_ = false;
+                return Status::ended;
+            }
+            // Orphan end — drop. See #292 P2.
+            return Status::dropped;
+        default:
+            // Reserved / unknown status nibble. Per the spec, type-0x3
+            // status values 0x4..0xF are reserved; the only sane
+            // behaviour for forward compatibility is to drop the
+            // packet without disturbing accumulator state.
+            return Status::dropped;
+        }
+    }
+
+    /// True when an in-progress sysex is open (a 0x1 start packet has
+    /// been seen and no 0x3 end packet has closed it yet).
+    bool in_progress() const noexcept { return in_progress_; }
+
+    /// Current accumulated payload size in bytes (0 when idle).
+    std::size_t partial_size() const noexcept { return payload_.size(); }
+
+    /// Reserve worst-case payload capacity to avoid allocations in the
+    /// hot path. Safe to call at port-open / prepare() time.
+    void reserve(std::size_t worst_case_bytes) {
+        payload_.reserve(worst_case_bytes);
+    }
+
+    /// Drop any in-progress sysex without emitting. Use on port-close
+    /// or when a transport-level reset is observed (e.g. CoreMIDI
+    /// endpoint reconnect).
+    void reset() noexcept {
+        payload_.clear();
+        in_progress_ = false;
+    }
+
+private:
+    static void extract_bytes(std::uint32_t w0, std::uint32_t w1,
+                              std::uint32_t size,
+                              std::vector<std::uint8_t>& out) {
+        // Per the UMP spec, payload bytes are packed:
+        //   byte 0 = (w0 >>  8) & 0xFF
+        //   byte 1 = (w0 >>  0) & 0xFF
+        //   byte 2 = (w1 >> 24) & 0xFF
+        //   byte 3 = (w1 >> 16) & 0xFF
+        //   byte 4 = (w1 >>  8) & 0xFF
+        //   byte 5 = (w1 >>  0) & 0xFF
+        // `size` is the 4-bit field from bits 16-19 of w0 and is in
+        // 0..6. We clamp at 6 defensively.
+        const std::uint8_t buf[6] = {
+            static_cast<std::uint8_t>((w0 >>  8) & 0xFF),
+            static_cast<std::uint8_t>((w0 >>  0) & 0xFF),
+            static_cast<std::uint8_t>((w1 >> 24) & 0xFF),
+            static_cast<std::uint8_t>((w1 >> 16) & 0xFF),
+            static_cast<std::uint8_t>((w1 >>  8) & 0xFF),
+            static_cast<std::uint8_t>((w1 >>  0) & 0xFF),
+        };
+        const std::uint32_t n = (size > 6) ? 6 : size;
+        for (std::uint32_t i = 0; i < n; ++i) out.push_back(buf[i]);
+    }
+
+    std::vector<std::uint8_t> payload_;
+    bool in_progress_ = false;
+};
+
+/// Convenience: feed a packet and collect the emitted payload (if any)
+/// into `out`. Returns the same `Status` as `feed_packet`. Useful for
+/// hosts that want a value-returning API rather than a callback. Not
+/// RT-safe (the lambda capture allocates) — for hot-path use, prefer
+/// the function-pointer `feed_packet` overload.
+inline UmpSysex7Reassembler::Status feed_collect(
+    UmpSysex7Reassembler& r, std::uint32_t word0, std::uint32_t word1,
+    std::vector<std::uint8_t>& out) {
+    struct Box { std::vector<std::uint8_t>* sink; };
+    Box box{&out};
+    return r.feed_packet(word0, word1,
+        [](const std::vector<std::uint8_t>& payload, void* user) {
+            auto* b = static_cast<Box*>(user);
+            *b->sink = payload;
+        },
+        &box);
+}
+
+} // namespace pulp::midi

--- a/core/midi/platform/mac/coremidi_device.mm
+++ b/core/midi/platform/mac/coremidi_device.mm
@@ -1,6 +1,7 @@
 #include <pulp/midi/device.hpp>
 #include <pulp/midi/ump.hpp>
 #include <pulp/midi/ump_conversion.hpp>
+#include <pulp/midi/ump_sysex7_reassembler.hpp>
 #include <pulp/runtime/log.hpp>
 #include <CoreMIDI/CoreMIDI.h>
 
@@ -61,73 +62,29 @@ public:
                             }
                         } else if (type == 0x03) {
                             // SysEx7 (UMP type 3) — reassemble multi-
-                            // packet payloads into a single sysex
-                            // callback. Status nibble (bits 20-23 of
-                            // word 0) indicates which packet of the
-                            // logical message this is:
-                            //   0x0 = complete single-packet sysex
-                            //   0x1 = start
-                            //   0x2 = continue
-                            //   0x3 = end
-                            // Mirrors the AU adapter's in-process
-                            // reassembler (#239 / #292). Without this,
-                            // sysex from a CoreMIDI device source
-                            // (Pulp standalone or DAW host on macOS)
-                            // would be silently dropped.
+                            // packet payloads via the shared
+                            // UmpSysex7Reassembler. macOS plan 8.2
+                            // extracted the previously inline #292 fix
+                            // to a single, tested class shared with
+                            // the AUv3 adapter; reassembler state
+                            // lives on this CoreMidiInput so a
+                            // multi-packet sysex spanning callback
+                            // invocations accumulates correctly.
                             const uint32_t word1 =
                                 packet->words[wordIdx + 1];
-                            const uint8_t status =
-                                static_cast<uint8_t>((word >> 20) & 0x0F);
-                            const uint32_t size  =
-                                static_cast<uint32_t>((word >> 16) & 0x0F);
-                            const double ts_sec =
-                                static_cast<double>(packet->timeStamp) / 1e9;
-
-                            auto extract = [](uint32_t w0, uint32_t w1,
-                                              uint32_t sz,
-                                              std::vector<uint8_t>& out) {
-                                const uint8_t buf[6] = {
-                                    static_cast<uint8_t>((w0 >>  8) & 0xFF),
-                                    static_cast<uint8_t>((w0 >>  0) & 0xFF),
-                                    static_cast<uint8_t>((w1 >> 24) & 0xFF),
-                                    static_cast<uint8_t>((w1 >> 16) & 0xFF),
-                                    static_cast<uint8_t>((w1 >>  8) & 0xFF),
-                                    static_cast<uint8_t>((w1 >>  0) & 0xFF),
-                                };
-                                for (uint32_t e = 0; e < sz && e < 6; ++e)
-                                    out.push_back(buf[e]);
+                            struct EmitCtx {
+                                MidiSysexCallback* cb;
+                                double ts_sec;
                             };
-
-                            if (status == 0x0) {
-                                std::vector<uint8_t> p;
-                                extract(word, word1, size, p);
-                                if (!p.empty() && this->sysex_callback_) {
-                                    this->sysex_callback_(p, ts_sec);
-                                }
-                            } else if (status == 0x1) {
-                                this->sysex_payload_.clear();
-                                extract(word, word1, size,
-                                        this->sysex_payload_);
-                                this->sysex_in_progress_ = true;
-                            } else if (status == 0x2
-                                       && this->sysex_in_progress_) {
-                                extract(word, word1, size,
-                                        this->sysex_payload_);
-                            } else if (status == 0x3
-                                       && this->sysex_in_progress_) {
-                                extract(word, word1, size,
-                                        this->sysex_payload_);
-                                if (!this->sysex_payload_.empty()
-                                    && this->sysex_callback_) {
-                                    this->sysex_callback_(
-                                        this->sysex_payload_, ts_sec);
-                                }
-                                this->sysex_payload_.clear();
-                                this->sysex_in_progress_ = false;
-                            }
-                            // 0x2 / 0x3 without an earlier 0x1 means we
-                            // missed the start; drop silently rather
-                            // than emit a corrupt sysex (#292 P2).
+                            EmitCtx ctx{&this->sysex_callback_,
+                                        static_cast<double>(packet->timeStamp) / 1e9};
+                            auto emit = [](const std::vector<uint8_t>& p,
+                                           void* user) {
+                                auto* c = static_cast<EmitCtx*>(user);
+                                if (*c->cb) (*c->cb)(p, c->ts_sec);
+                            };
+                            this->sysex_reassembler_.feed_packet(
+                                word, word1, emit, &ctx);
                         }
                         // Other UMP types (utility, system, SysEx8,
                         // stream, flex) intentionally skipped this slice.
@@ -172,6 +129,9 @@ public:
     void close() override {
         if (port_) { MIDIPortDispose(port_); port_ = 0; }
         if (client_) { MIDIClientDispose(client_); client_ = 0; }
+        // Drop any in-progress sysex so a reopened port starts fresh
+        // and never emits a stale partial payload.
+        sysex_reassembler_.reset();
         is_open_ = false;
     }
 
@@ -186,12 +146,12 @@ private:
     MIDIPortRef port_ = 0;
     MidiInputCallback callback_;
     MidiSysexCallback sysex_callback_;
-    // SysEx7 (UMP type 0x03) reassembly state. The OS callback fires
-    // once per MIDIEventList delivery, so a multi-packet sysex (start
-    // → continue* → end) spans callback invocations and accumulates
-    // here.
-    std::vector<uint8_t> sysex_payload_;
-    bool sysex_in_progress_ = false;
+    // SysEx7 (UMP type 0x03) reassembly state — shared implementation
+    // in core/midi/include/pulp/midi/ump_sysex7_reassembler.hpp. The
+    // OS callback fires once per MIDIEventList delivery, so a multi-
+    // packet sysex (start → continue* → end) spans callback invocations
+    // and the reassembler keeps the partial payload between deliveries.
+    UmpSysex7Reassembler sysex_reassembler_;
     bool is_open_ = false;
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -716,6 +716,10 @@ pulp_add_test_suite(pulp-test-frame-fill LIBRARIES pulp::audio)
 # machine shared by Android/ALSA/Windows/iOS MIDI backends. Header-only.
 pulp_add_test_suite(pulp-test-sysex-accumulator LIBRARIES pulp::midi)
 
+# macOS plan 8.2: UmpSysex7Reassembler — shared UMP type-0x3 reassembler
+# extracted from the inline AUv3 / CoreMIDI state machines. Header-only.
+pulp_add_test_suite(pulp-test-ump-sysex7-reassembler LIBRARIES pulp::midi)
+
 # AsyncStream tests (Phase 2)
 pulp_add_test_suite(pulp-test-async-stream LIBRARIES pulp::runtime)
 

--- a/test/test_ump_sysex7_reassembler.cpp
+++ b/test/test_ump_sysex7_reassembler.cpp
@@ -1,0 +1,326 @@
+// Tests for UmpSysex7Reassembler — shared UMP Type-0x3 sysex7
+// reassembler extracted from the AUv3 / CoreMIDI inline state machines
+// (macOS plugin authoring plan item 8.2).
+//
+// Pinned regressions:
+//   - #239 / #292 P1: per-packet word cursor must advance correctly;
+//     the second word's top nibble can match a continuation packet's
+//     payload byte. Tested by feeding contrived packet pairs where
+//     word1 begins with what looks like a status byte.
+//   - #292 P2: orphaned continue/end packets are dropped silently;
+//     they must not corrupt an unrelated in-progress accumulator or
+//     emit a partial payload.
+//   - Interleaved single-packet sysex (status 0x0) on top of an open
+//     start (status 0x1) accumulator must not consume the open state.
+//   - Reserved status nibbles (0x4..0xF) drop without disturbing the
+//     accumulator.
+
+#include <pulp/midi/ump_sysex7_reassembler.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <vector>
+
+using pulp::midi::UmpSysex7Reassembler;
+using pulp::midi::feed_collect;
+using Status = UmpSysex7Reassembler::Status;
+
+namespace {
+
+// Build a UMP type-0x3 word0 given status nibble, payload size, and up
+// to two payload bytes packed into word0's low 16 bits. Group is 0.
+constexpr std::uint32_t make_word0(std::uint8_t status,
+                                   std::uint8_t size,
+                                   std::uint8_t b0 = 0,
+                                   std::uint8_t b1 = 0) {
+    const std::uint32_t type    = 0x3u << 28;
+    const std::uint32_t group   = 0u   << 24;
+    const std::uint32_t s_field = static_cast<std::uint32_t>(status & 0x0F) << 20;
+    const std::uint32_t z_field = static_cast<std::uint32_t>(size   & 0x0F) << 16;
+    return type | group | s_field | z_field |
+           (static_cast<std::uint32_t>(b0) << 8) |
+            static_cast<std::uint32_t>(b1);
+}
+
+// Build word1 from up to four payload bytes.
+constexpr std::uint32_t make_word1(std::uint8_t b2 = 0,
+                                   std::uint8_t b3 = 0,
+                                   std::uint8_t b4 = 0,
+                                   std::uint8_t b5 = 0) {
+    return (static_cast<std::uint32_t>(b2) << 24)
+         | (static_cast<std::uint32_t>(b3) << 16)
+         | (static_cast<std::uint32_t>(b4) <<  8)
+         |  static_cast<std::uint32_t>(b5);
+}
+
+struct EmitSink {
+    std::vector<std::vector<std::uint8_t>> sysex;
+};
+
+void capture(const std::vector<std::uint8_t>& payload, void* user) {
+    static_cast<EmitSink*>(user)->sysex.push_back(payload);
+}
+
+} // namespace
+
+TEST_CASE("UmpSysex7Reassembler: single-packet sysex (status 0x0)",
+          "[midi][ump][sysex7][issue-292]") {
+    UmpSysex7Reassembler r;
+    EmitSink sink;
+
+    // Universal Device Inquiry payload bytes (no F0/F7 framing in UMP).
+    const std::uint8_t bytes[6] = {0x7E, 0x7F, 0x06, 0x01, 0x02, 0x03};
+    const std::uint32_t w0 = make_word0(0x0, 6, bytes[0], bytes[1]);
+    const std::uint32_t w1 = make_word1(bytes[2], bytes[3], bytes[4], bytes[5]);
+
+    auto status = r.feed_packet(w0, w1, capture, &sink);
+    REQUIRE(status == Status::single_packet);
+    REQUIRE_FALSE(r.in_progress());
+    REQUIRE(sink.sysex.size() == 1);
+    REQUIRE(sink.sysex[0] == std::vector<std::uint8_t>{
+        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5]});
+}
+
+TEST_CASE("UmpSysex7Reassembler: start → end multi-packet sysex",
+          "[midi][ump][sysex7]") {
+    UmpSysex7Reassembler r;
+    EmitSink sink;
+
+    // First packet: start, 6 bytes.
+    auto s1 = r.feed_packet(make_word0(0x1, 6, 0x10, 0x11),
+                            make_word1(0x12, 0x13, 0x14, 0x15),
+                            capture, &sink);
+    REQUIRE(s1 == Status::start);
+    REQUIRE(r.in_progress());
+    REQUIRE(r.partial_size() == 6);
+    REQUIRE(sink.sysex.empty());
+
+    // End packet: 4 bytes.
+    auto s2 = r.feed_packet(make_word0(0x3, 4, 0x20, 0x21),
+                            make_word1(0x22, 0x23, 0x00, 0x00),
+                            capture, &sink);
+    REQUIRE(s2 == Status::ended);
+    REQUIRE_FALSE(r.in_progress());
+    REQUIRE(sink.sysex.size() == 1);
+    REQUIRE(sink.sysex[0] == std::vector<std::uint8_t>{
+        0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+        0x20, 0x21, 0x22, 0x23});
+}
+
+TEST_CASE("UmpSysex7Reassembler: start → continue* → end span",
+          "[midi][ump][sysex7]") {
+    UmpSysex7Reassembler r;
+    EmitSink sink;
+
+    REQUIRE(r.feed_packet(make_word0(0x1, 6, 0x01, 0x02),
+                          make_word1(0x03, 0x04, 0x05, 0x06),
+                          capture, &sink) == Status::start);
+    REQUIRE(r.feed_packet(make_word0(0x2, 6, 0x07, 0x08),
+                          make_word1(0x09, 0x0A, 0x0B, 0x0C),
+                          capture, &sink) == Status::continued);
+    REQUIRE(r.feed_packet(make_word0(0x2, 3, 0x0D, 0x0E),
+                          make_word1(0x0F, 0x00, 0x00, 0x00),
+                          capture, &sink) == Status::continued);
+    REQUIRE(r.feed_packet(make_word0(0x3, 2, 0x10, 0x11),
+                          make_word1(0x00, 0x00, 0x00, 0x00),
+                          capture, &sink) == Status::ended);
+
+    REQUIRE(sink.sysex.size() == 1);
+    REQUIRE(sink.sysex[0].size() == 6 + 6 + 3 + 2);
+    REQUIRE(sink.sysex[0].front() == 0x01);
+    REQUIRE(sink.sysex[0].back() == 0x11);
+}
+
+TEST_CASE("UmpSysex7Reassembler: orphan continue is dropped silently (#292 P2)",
+          "[midi][ump][sysex7][issue-292]") {
+    UmpSysex7Reassembler r;
+    EmitSink sink;
+
+    auto s = r.feed_packet(make_word0(0x2, 4, 0xAA, 0xBB),
+                           make_word1(0xCC, 0xDD, 0, 0),
+                           capture, &sink);
+    REQUIRE(s == Status::dropped);
+    REQUIRE_FALSE(r.in_progress());
+    REQUIRE(sink.sysex.empty());
+}
+
+TEST_CASE("UmpSysex7Reassembler: orphan end is dropped silently (#292 P2)",
+          "[midi][ump][sysex7][issue-292]") {
+    UmpSysex7Reassembler r;
+    EmitSink sink;
+
+    auto s = r.feed_packet(make_word0(0x3, 4, 0xAA, 0xBB),
+                           make_word1(0xCC, 0xDD, 0, 0),
+                           capture, &sink);
+    REQUIRE(s == Status::dropped);
+    REQUIRE_FALSE(r.in_progress());
+    REQUIRE(sink.sysex.empty());
+}
+
+TEST_CASE("UmpSysex7Reassembler: interleaved single-packet preserves open accumulator",
+          "[midi][ump][sysex7][issue-292]") {
+    UmpSysex7Reassembler r;
+    EmitSink sink;
+
+    // Open an in-progress sysex.
+    REQUIRE(r.feed_packet(make_word0(0x1, 4, 0xAA, 0xBB),
+                          make_word1(0xCC, 0xDD, 0, 0),
+                          capture, &sink) == Status::start);
+    REQUIRE(r.in_progress());
+    REQUIRE(r.partial_size() == 4);
+
+    // Interleave a complete single-packet sysex (different logical
+    // stream, e.g. different UMP group). The single-packet path must
+    // not consume our open accumulator.
+    REQUIRE(r.feed_packet(make_word0(0x0, 2, 0x55, 0x66),
+                          make_word1(0, 0, 0, 0),
+                          capture, &sink) == Status::single_packet);
+    REQUIRE(r.in_progress());
+    REQUIRE(r.partial_size() == 4);  // unchanged
+    REQUIRE(sink.sysex.size() == 1);
+    REQUIRE(sink.sysex[0] == std::vector<std::uint8_t>{0x55, 0x66});
+
+    // Close the original accumulator.
+    REQUIRE(r.feed_packet(make_word0(0x3, 2, 0xEE, 0xFF),
+                          make_word1(0, 0, 0, 0),
+                          capture, &sink) == Status::ended);
+    REQUIRE(sink.sysex.size() == 2);
+    REQUIRE(sink.sysex[1] == std::vector<std::uint8_t>{
+        0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF});
+}
+
+TEST_CASE("UmpSysex7Reassembler: nested start resets accumulator (no nest)",
+          "[midi][ump][sysex7]") {
+    UmpSysex7Reassembler r;
+    EmitSink sink;
+
+    REQUIRE(r.feed_packet(make_word0(0x1, 4, 0x01, 0x02),
+                          make_word1(0x03, 0x04, 0, 0),
+                          capture, &sink) == Status::start);
+    // Another start before end — drop the half-built sysex, begin again.
+    REQUIRE(r.feed_packet(make_word0(0x1, 3, 0xAA, 0xBB),
+                          make_word1(0xCC, 0, 0, 0),
+                          capture, &sink) == Status::start);
+    REQUIRE(r.partial_size() == 3);
+    REQUIRE(sink.sysex.empty());
+
+    REQUIRE(r.feed_packet(make_word0(0x3, 1, 0xDD, 0x00),
+                          make_word1(0, 0, 0, 0),
+                          capture, &sink) == Status::ended);
+    REQUIRE(sink.sysex.size() == 1);
+    REQUIRE(sink.sysex[0] == std::vector<std::uint8_t>{
+        0xAA, 0xBB, 0xCC, 0xDD});
+}
+
+TEST_CASE("UmpSysex7Reassembler: reset() drops in-progress state",
+          "[midi][ump][sysex7]") {
+    UmpSysex7Reassembler r;
+    EmitSink sink;
+
+    REQUIRE(r.feed_packet(make_word0(0x1, 3, 0x01, 0x02),
+                          make_word1(0x03, 0, 0, 0),
+                          capture, &sink) == Status::start);
+    REQUIRE(r.in_progress());
+    r.reset();
+    REQUIRE_FALSE(r.in_progress());
+    REQUIRE(r.partial_size() == 0);
+
+    // After reset, a continue packet must be treated as orphan.
+    REQUIRE(r.feed_packet(make_word0(0x2, 1, 0xFF, 0),
+                          make_word1(0, 0, 0, 0),
+                          capture, &sink) == Status::dropped);
+    REQUIRE(sink.sysex.empty());
+}
+
+TEST_CASE("UmpSysex7Reassembler: reserved status nibble drops cleanly",
+          "[midi][ump][sysex7]") {
+    UmpSysex7Reassembler r;
+    EmitSink sink;
+
+    // Open a real sysex so we can prove reserved-status doesn't touch it.
+    REQUIRE(r.feed_packet(make_word0(0x1, 3, 0x01, 0x02),
+                          make_word1(0x03, 0, 0, 0),
+                          capture, &sink) == Status::start);
+
+    // status nibble 0x7 — reserved per the UMP spec.
+    REQUIRE(r.feed_packet(make_word0(0x7, 6, 0x99, 0x99),
+                          make_word1(0x99, 0x99, 0x99, 0x99),
+                          capture, &sink) == Status::dropped);
+    REQUIRE(r.in_progress());
+    REQUIRE(r.partial_size() == 3);
+
+    // Original sysex still closes cleanly.
+    REQUIRE(r.feed_packet(make_word0(0x3, 1, 0x04, 0),
+                          make_word1(0, 0, 0, 0),
+                          capture, &sink) == Status::ended);
+    REQUIRE(sink.sysex.size() == 1);
+    REQUIRE(sink.sysex[0] == std::vector<std::uint8_t>{
+        0x01, 0x02, 0x03, 0x04});
+}
+
+TEST_CASE("UmpSysex7Reassembler: #292 P1 — word1's top nibble must not be reparsed",
+          "[midi][ump][sysex7][issue-292]") {
+    // Regression for the #292 P1 bug: a multi-word UMP message must be
+    // consumed in full, never re-entered word-by-word. We verify the
+    // reassembler does not look at word1 as if it were a fresh word0
+    // by constructing a continue packet whose word1's top nibble is
+    // 0x3 (matching a sysex7 message-type) and whose status-nibble bits
+    // would name "start". The reassembler must treat the whole 2-word
+    // packet as ONE continue, appending all 6 bytes verbatim.
+    UmpSysex7Reassembler r;
+    EmitSink sink;
+
+    REQUIRE(r.feed_packet(make_word0(0x1, 6, 0xAA, 0xBB),
+                          make_word1(0xCC, 0xDD, 0xEE, 0xFF),
+                          capture, &sink) == Status::start);
+
+    // word1 = 0x31_60_00_00 — top nibble looks like a sysex7 type,
+    // status-bits would look like a start. The reassembler must ignore
+    // that and treat the whole packet as a single continue.
+    const std::uint32_t w0 = make_word0(0x2, 6, 0x11, 0x22);
+    const std::uint32_t w1 = 0x31'60'00'00u;
+    REQUIRE(r.feed_packet(w0, w1, capture, &sink) == Status::continued);
+    REQUIRE(r.partial_size() == 6 + 6);
+    REQUIRE(sink.sysex.empty());
+
+    REQUIRE(r.feed_packet(make_word0(0x3, 0, 0, 0),
+                          make_word1(0, 0, 0, 0),
+                          capture, &sink) == Status::ended);
+    REQUIRE(sink.sysex.size() == 1);
+    REQUIRE(sink.sysex[0] == std::vector<std::uint8_t>{
+        0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
+        0x11, 0x22, 0x31, 0x60, 0x00, 0x00});
+}
+
+TEST_CASE("UmpSysex7Reassembler: size > 6 is clamped defensively",
+          "[midi][ump][sysex7]") {
+    UmpSysex7Reassembler r;
+    EmitSink sink;
+    std::vector<std::uint8_t> out;
+    // size = 0xF (15) — spec only allows 0..6. We clamp to 6.
+    auto s = feed_collect(r,
+        make_word0(0x0, 0xF, 0x01, 0x02),
+        make_word1(0x03, 0x04, 0x05, 0x06), out);
+    REQUIRE(s == Status::single_packet);
+    REQUIRE(out.size() == 6);
+}
+
+TEST_CASE("UmpSysex7Reassembler: feed_collect convenience returns the payload",
+          "[midi][ump][sysex7]") {
+    UmpSysex7Reassembler r;
+    std::vector<std::uint8_t> out;
+    auto s = feed_collect(r,
+        make_word0(0x0, 3, 0x7E, 0x7F),
+        make_word1(0x06, 0, 0, 0), out);
+    REQUIRE(s == Status::single_packet);
+    REQUIRE(out == std::vector<std::uint8_t>{0x7E, 0x7F, 0x06});
+}
+
+TEST_CASE("UmpSysex7Reassembler: reserve() does not change state",
+          "[midi][ump][sysex7]") {
+    UmpSysex7Reassembler r;
+    r.reserve(1024);
+    REQUIRE_FALSE(r.in_progress());
+    REQUIRE(r.partial_size() == 0);
+}


### PR DESCRIPTION
## Summary

Extract the UMP type-0x3 sysex7 reassembly state machine — previously open-coded in both `core/format/src/au_adapter.mm` (AUv3 adapter) and `core/midi/platform/mac/coremidi_device.mm` (CoreMIDI device input) — into a single shared `pulp::midi::UmpSysex7Reassembler` in `core/midi/include/pulp/midi/ump_sysex7_reassembler.hpp`.

Both inline impls carried the same `#239` / `#292` regression notes (word-cursor advance must be 2 for type-3, orphaned continue/end must drop, etc.). The new shared class is the single tested home for that state machine and will be reused by future UMP backends (WinRT MIDI 2.0, ALSA UMP, iOS CoreMIDI 2.0).

Closes macOS plan item 8.2.

## What changed

- **New** `core/midi/include/pulp/midi/ump_sysex7_reassembler.hpp` — header-only state machine + `feed_collect` convenience.
- **AUv3 adapter** (`core/format/src/au_adapter.mm`) — sysex7 inline block replaced with a `reassembler.feed_packet(word0, word1, emit, &ctx)` call. The adapter still owns the AURenderEventMIDIEventList walk + `ump_words` cursor advance (the `#292` P1 invariant lives there).
- **CoreMIDI device** (`core/midi/platform/mac/coremidi_device.mm`) — sysex7 inline block replaced with same. Adds `sysex_reassembler_.reset()` to `close()` so a reopened port never emits a stale partial sysex.
- **13 new test cases / 70 assertions** in `test/test_ump_sysex7_reassembler.cpp` cover the original inline behaviour plus regression pins for `#292` P1 (word1's top nibble must not be reparsed) and `#292` P2 (orphaned continue/end + interleaved single-packet sysex on top of an open accumulator do not corrupt state), plus spec edge cases (reserved status nibbles, nested start, size > 6 defensive clamp).
- **Skill updates** — `auv3` now points at the shared reassembler; `mpe` calls out that UMP sysex7 is per-stream side state, not MpeVoiceTracker-owned, and tells future UMP backends to delegate rather than re-implement.

## Test plan

- [x] `pulp-test-ump-sysex7-reassembler` — 70 assertions / 13 cases pass locally
- [x] `pulp-test-midi`, `pulp-test-midi-buffer-ump`, `pulp-test-midi-buffer-sysex`, `pulp-test-sysex-accumulator`, `pulp-test-ump-buffer-conversion`, `pulp-test-midi-expansion`, `pulp-test-ump-mpe` — all still green (no MIDI/UMP regression)
- [x] `pulp::format` library still builds (verified: AUv3 adapter `.mm` direct-compile + linked `pulp-format`)
- [ ] CI macOS lane (Shipyard primary gate)