### PR TITLE
feat(host): ExtensionsVisitor + SignalGraph automation slew + sidechain (items 4.5/4.6/4.7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.233.0
+    VERSION 0.234.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/host/include/pulp/host/extensions_visitor.hpp
+++ b/core/host/include/pulp/host/extensions_visitor.hpp
@@ -1,0 +1,150 @@
+#pragma once
+
+// ExtensionsVisitor — typed plugin introspection (item 4.5).
+//
+// PluginSlot intentionally abstracts the format (VST3, AU, CLAP, LV2) so that
+// host code can drive any plugin through a single interface. Sometimes,
+// though, host code needs the underlying format-specific handle: a panel
+// might want to surface the `clap_plugin_id`, a debugger might want the
+// VST3 `IComponent*`, a CoreAudio-aware UI might want the `AudioComponent`.
+// Punching that out with a `void*` getter would leak the abstraction and
+// invite undefined behaviour the moment a caller cast the wrong way.
+//
+// Inspiration: JUCE's `ExtensionsVisitor` family. The pattern is a
+// double-dispatch visitor — host code subclasses `ExtensionsVisitor`,
+// overrides the format-specific `visit*` methods it cares about, and calls
+// `slot.accept(visitor)`. Slots that know about a format call back into the
+// matching `visit*`; slots compiled without a given format SDK can simply
+// not call its visitor method, so the visitor never sees a stale handle.
+//
+// The format-specific handle structs deliberately avoid pulling in the
+// format SDK headers — handles are exposed as `void*` typedefs so that
+// callers that *do* link against the SDK can `static_cast<>` them back to
+// the concrete type (e.g. `static_cast<const clap_plugin_t*>(handle)`)
+// while non-SDK call sites can still link the header.
+//
+// Default `visit_*` implementations fall through to `visit_unknown(slot)`,
+// letting hosts opt-in to specific format dispatches without overriding
+// every method.
+
+#include <string>
+#include <string_view>
+
+namespace pulp::host {
+
+class PluginSlot;
+
+// Tag struct identifying the underlying plugin format. Mirrors the
+// PluginFormat enum but stays in this header to avoid pulling scanner.hpp
+// for callers that only want the visitor pattern.
+enum class ExtensionFormat {
+    Unknown,
+    VST3,
+    AudioUnit,
+    AudioUnitV3,
+    CLAP,
+    LV2,
+};
+
+// ── Per-format handle descriptors ───────────────────────────────────────
+//
+// All native handles are exposed as `void*` so this header is SDK-free.
+// Callers reinterpret_cast back to the documented concrete type. Each
+// struct carries a small handful of identifying metadata so that visitor
+// code can perform a sanity check (format / IID / category) before
+// reaching into the handle.
+
+struct Vst3Extension {
+    /// `Steinberg::Vst::IComponent*` — the audio-processing side of the
+    /// plugin. Lifetime is tied to the owning PluginSlot.
+    void* component = nullptr;
+    /// `Steinberg::Vst::IAudioProcessor*` — non-null when the plugin
+    /// implements the audio-processor interface (every effect/instrument).
+    void* audio_processor = nullptr;
+    /// `Steinberg::Vst::IEditController*` — non-null for plugins that
+    /// expose a controller. May alias `component` on combined plugins.
+    void* edit_controller = nullptr;
+    /// FUID string of the plugin's processor class, e.g.
+    /// "ABCDEF01-2345-6789-ABCD-EF0123456789".
+    std::string class_id;
+};
+
+struct AudioUnitExtension {
+    /// `AudioComponentInstance` (a.k.a. `AudioUnit`). Owned by the slot.
+    void* component_instance = nullptr;
+    /// AU component description fields, populated at load time.
+    unsigned int type = 0;           ///< OSType (kAudioUnitType_*).
+    unsigned int subtype = 0;        ///< OSType (manufacturer-defined).
+    unsigned int manufacturer = 0;   ///< OSType (manufacturer code).
+};
+
+struct AudioUnitV3Extension {
+    /// `AUAudioUnit*`. Bridged-Objective-C pointer, owned by the slot.
+    void* audio_unit = nullptr;
+};
+
+struct ClapExtension {
+    /// `const clap_plugin_t*` — the plugin instance. Owned by the slot.
+    void* plugin = nullptr;
+    /// `const clap_host_t*` — host-side struct the plugin was created
+    /// against. Owned by the slot; do not free.
+    void* host = nullptr;
+    /// CLAP plugin id, e.g. "com.pulp.gain".
+    std::string plugin_id;
+};
+
+struct Lv2Extension {
+    /// `LilvInstance*` if the loader uses lilv; otherwise opaque to the
+    /// host (loader-specific).
+    void* instance = nullptr;
+    /// LV2 plugin URI, e.g. "https://example.com/plugins/gain".
+    std::string uri;
+};
+
+// ── Visitor base class ──────────────────────────────────────────────────
+//
+// Subclass and override only the visit_* methods relevant to your work.
+// The default fallthrough to `visit_unknown` means a visitor that only
+// cares about CLAP can ignore every other adapter without explicit
+// no-ops.
+class ExtensionsVisitor {
+public:
+    virtual ~ExtensionsVisitor() = default;
+
+    /// Called when the slot represents a format the visitor did not
+    /// override, or when the slot itself does not know its own format
+    /// (placeholder / unresolved slots). The slot is non-null.
+    virtual void visit_unknown(const PluginSlot& /*slot*/,
+                               ExtensionFormat /*format*/) {}
+
+    virtual void visit_vst3(const PluginSlot& slot,
+                            const Vst3Extension& /*ext*/) {
+        visit_unknown(slot, ExtensionFormat::VST3);
+    }
+    virtual void visit_audio_unit(const PluginSlot& slot,
+                                  const AudioUnitExtension& /*ext*/) {
+        visit_unknown(slot, ExtensionFormat::AudioUnit);
+    }
+    virtual void visit_audio_unit_v3(const PluginSlot& slot,
+                                     const AudioUnitV3Extension& /*ext*/) {
+        visit_unknown(slot, ExtensionFormat::AudioUnitV3);
+    }
+    virtual void visit_clap(const PluginSlot& slot,
+                            const ClapExtension& /*ext*/) {
+        visit_unknown(slot, ExtensionFormat::CLAP);
+    }
+    virtual void visit_lv2(const PluginSlot& slot,
+                           const Lv2Extension& /*ext*/) {
+        visit_unknown(slot, ExtensionFormat::LV2);
+    }
+};
+
+// ── Default no-op accept_ helpers ───────────────────────────────────────
+//
+// PluginSlot::accept(visitor) is the canonical entry point — its default
+// implementation in plugin_slot.hpp calls visit_unknown so unknown slots
+// behave sensibly. Each format-specific slot overrides accept() to
+// dispatch into the matching visit_* method with a populated
+// `*Extension` struct.
+
+} // namespace pulp::host

--- a/core/host/include/pulp/host/plugin_slot.hpp
+++ b/core/host/include/pulp/host/plugin_slot.hpp
@@ -12,6 +12,7 @@
 
 #include <pulp/host/scanner.hpp>
 #include <pulp/host/parameter_event_queue.hpp>
+#include <pulp/host/extensions_visitor.hpp>
 #include <pulp/runtime/node_abi.hpp>
 #include <pulp/state/parameter.hpp>
 #include <pulp/audio/buffer.hpp>
@@ -152,6 +153,20 @@ public:
     // Latency
     virtual int latency_samples() const = 0;
     virtual int tail_samples() const = 0;
+
+    // ── Extensions visitor (item 4.5) ───────────────────────────────────
+    //
+    // Typed plugin introspection: subclass ExtensionsVisitor, override
+    // the visit_* methods you care about, then call
+    //   slot.accept(visitor)
+    // The slot dispatches to the matching visit_* overload (visit_clap,
+    // visit_vst3, ...) with a populated handle struct. The default
+    // implementation here calls visit_unknown so placeholder/unresolved
+    // slots and slots whose format adapter was not compiled in degrade
+    // gracefully without leaking a stale handle.
+    virtual void accept(ExtensionsVisitor& visitor) const {
+        visitor.visit_unknown(*this, ExtensionFormat::Unknown);
+    }
 };
 
 } // namespace pulp::host

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -75,13 +75,18 @@ struct Connection {
     bool automation = false;  // automation-edge: source audio drives a param on
                               // the dest plugin.
     bool audio_rate_modulation = false; // dense CV edge into an AudioRate param.
+    bool sidechain = false;   // sidechain-edge: like a normal audio edge, but
+                              // routes into one of the destination plugin's
+                              // sidechain-bus input ports (item 4.7). The
+                              // topological-sort + PDC treat sidechain as a
+                              // hard edge — it is not a back-edge.
 
     // Parameter-modulation fields (valid when automation or
     // audio_rate_modulation is true).
     uint32_t automation_param_id  = 0;
     float automation_range_lo     = 0.0f;  // plain param domain
     float automation_range_hi     = 1.0f;  // plain param domain
-    float automation_smoothing_ms = 0.0f;  // per-source pre-mix slew
+    float automation_smoothing_ms = 0.0f;  // per-source pre-mix slew (item 4.6)
     AutomationMix automation_mix  = AutomationMix::Replace;
 
     bool operator==(const Connection& o) const {
@@ -89,6 +94,7 @@ struct Connection {
             && dest_node == o.dest_node && dest_port == o.dest_port
             && automation == o.automation
             && audio_rate_modulation == o.audio_rate_modulation
+            && sidechain == o.sidechain
             && ((automation || audio_rate_modulation)
                 ? automation_param_id == o.automation_param_id : true);
     }
@@ -186,6 +192,23 @@ public:
     // Participates in cycle detection and topological sort the same way as
     // audio connections.
     bool connect_midi(NodeId source, NodeId dest);
+
+    // Sidechain connection (item 4.7): routes a source's audio output port
+    // into the destination plugin's sidechain bus port. The destination
+    // port is `dest_sidechain_port` — the caller supplies the absolute
+    // port index on the destination node (the host knows how many main
+    // input ports a plugin exposes via PluginInfo::num_inputs; sidechain
+    // ports follow main inputs). The flag does NOT change topological
+    // ordering — sidechain participates in cycle detection and PDC the
+    // same as a normal audio edge — but it is tagged so UIs, serializers,
+    // and per-format adapters can recognise the role.
+    //
+    // Tagging is metadata: the actual routing still uses (source, source
+    // port) → (dest, dest sidechain port). Calling this is equivalent to
+    // connect() with an extra flag, plus a guard that the destination is
+    // a Plugin node (sidechain only makes sense on plugins).
+    bool connect_sidechain(NodeId source, PortIndex source_port,
+                           NodeId dest, PortIndex dest_sidechain_port);
 
     // Automation connection: the audio samples on `src`'s output port drive
     // `dest`'s parameter `dest_param_id`. Two control points per block (first
@@ -328,6 +351,15 @@ private:
         // Feedback edges hold the previous block's source-port audio so the
         // destination can read it before the source writes the current block.
         std::vector<float> feedback_prev;  // size = max_block_size_
+
+        // Item 4.6 — per-source automation slew state. Holds the value
+        // we last delivered to the destination (post-slew, post range-
+        // map) so the next block can resume ramping toward a new target
+        // instead of snapping. `primed` tracks whether `last_value` has
+        // been seeded yet; on the first block of a freshly-prepared graph
+        // we snap to the source value to avoid a glide from zero.
+        float slew_last_value = 0.0f;
+        bool slew_primed = false;
     };
 
     // CompiledGraph — immutable audio-thread-safe snapshot of the graph
@@ -360,6 +392,8 @@ private:
         };
         std::unordered_map<NodeId, NodeShape> shapes;
         int max_block_size = 0;
+        double sample_rate = 0.0;  // item 4.6 — needed to convert
+                                   // automation_smoothing_ms into samples.
         int64_t total_latency_samples = 0;
     };
 

--- a/core/host/src/graph_serializer.cpp
+++ b/core/host/src/graph_serializer.cpp
@@ -388,6 +388,8 @@ std::string GraphSerializer::to_json(
         co.addMember("midi",        c.midi);
         co.addMember("automation",  c.automation);
         co.addMember("audio_rate_modulation", c.audio_rate_modulation);
+        // Item 4.7 — sidechain flag is additive; absent in older blobs.
+        co.addMember("sidechain",   c.sidechain);
         if (c.automation || c.audio_rate_modulation) {
             co.addMember("auto_param_id",  (int64_t)c.automation_param_id);
             co.addMember("auto_range_lo",  (double)c.automation_range_lo);
@@ -543,6 +545,9 @@ GraphSerializer::LoadResult GraphSerializer::from_json(SignalGraph& graph, const
             const bool ar   = cv.hasObjectMember("audio_rate_modulation")
                 ? cv["audio_rate_modulation"].getBool()
                 : false;
+            const bool sc   = cv.hasObjectMember("sidechain")
+                ? cv["sidechain"].getBool()
+                : false;
             if (ar) {
                 graph.connect_audio_rate_modulation(
                     src, sp, dst,
@@ -563,6 +568,8 @@ GraphSerializer::LoadResult GraphSerializer::from_json(SignalGraph& graph, const
                 graph.connect_feedback(src, sp, dst, dp);
             } else if (md) {
                 graph.connect_midi(src, dst);
+            } else if (sc) {
+                graph.connect_sidechain(src, sp, dst, dp);
             } else {
                 graph.connect(src, sp, dst, dp);
             }

--- a/core/host/src/plugin_slot_au.mm
+++ b/core/host/src/plugin_slot_au.mm
@@ -306,6 +306,23 @@ public:
         return 0;
     }
 
+    // Item 4.5 — typed plugin introspection. Surface the AudioUnit
+    // instance and its component description so callers can talk directly
+    // to AudioToolbox / use vendor-specific properties.
+    void accept(ExtensionsVisitor& visitor) const override {
+        AudioUnitExtension ext;
+        ext.component_instance = au_;
+        // Re-parse the 'TYPE:SUBT:MANU' triplet we stored at load time.
+        // parse_4cc_triplet lives in this file's anonymous namespace.
+        OSType t = 0, s = 0, m = 0;
+        if (parse_4cc_triplet(info_.unique_id, t, s, m)) {
+            ext.type = static_cast<unsigned int>(t);
+            ext.subtype = static_cast<unsigned int>(s);
+            ext.manufacturer = static_cast<unsigned int>(m);
+        }
+        visitor.visit_audio_unit(*this, ext);
+    }
+
 private:
     static OSStatus render_callback(
         void* refcon,

--- a/core/host/src/plugin_slot_clap.cpp
+++ b/core/host/src/plugin_slot_clap.cpp
@@ -393,6 +393,21 @@ public:
         return (int)ext->get(plugin_);
     }
 
+    // Item 4.5 — typed plugin introspection. Surface the underlying
+    // `const clap_plugin_t*` and host struct so callers can reach into
+    // CLAP-specific extensions without round-tripping through `void*`.
+    void accept(ExtensionsVisitor& visitor) const override {
+        ClapExtension ext;
+        ext.plugin = const_cast<clap_plugin_t*>(plugin_);
+        ext.host = const_cast<clap_host_t*>(&host_);
+        if (plugin_ && plugin_->desc && plugin_->desc->id) {
+            ext.plugin_id = plugin_->desc->id;
+        } else {
+            ext.plugin_id = info_.unique_id;
+        }
+        visitor.visit_clap(*this, ext);
+    }
+
 private:
     static const void* CLAP_ABI host_get_extension(const clap_host_t*, const char*) { return nullptr; }
     static void CLAP_ABI host_request_noop(const clap_host_t*) {}

--- a/core/host/src/plugin_slot_lv2.cpp
+++ b/core/host/src/plugin_slot_lv2.cpp
@@ -287,6 +287,15 @@ public:
     int latency_samples() const override { return 0; }
     int tail_samples() const override { return 0; }
 
+    // Item 4.5 — typed plugin introspection. Surface the LV2 instance
+    // handle and URI so callers can reach into LV2 vendor extensions.
+    void accept(ExtensionsVisitor& visitor) const override {
+        Lv2Extension ext;
+        ext.instance = reinterpret_cast<void*>(instance_);
+        ext.uri = info_.unique_id;
+        visitor.visit_lv2(*this, ext);
+    }
+
 private:
     PluginInfo info_;
     void* handle_ = nullptr;

--- a/core/host/src/plugin_slot_vst3.cpp
+++ b/core/host/src/plugin_slot_vst3.cpp
@@ -437,6 +437,18 @@ public:
         return (int)processor_->getTailSamples();
     }
 
+    // Item 4.5 — typed plugin introspection. Surface the IComponent and
+    // related VST3 interfaces so callers that link against the SDK can
+    // reach into vendor extensions without round-tripping through `void*`.
+    void accept(ExtensionsVisitor& visitor) const override {
+        Vst3Extension ext;
+        ext.component = component_;
+        ext.audio_processor = processor_;
+        ext.edit_controller = controller_;
+        ext.class_id = info_.unique_id;
+        visitor.visit_vst3(*this, ext);
+    }
+
     static HostApp& host_app() {
         static HostApp app;
         return app;

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -293,6 +293,32 @@ bool SignalGraph::connect_midi(NodeId source, NodeId dest) {
     return true;
 }
 
+bool SignalGraph::connect_sidechain(NodeId source, PortIndex source_port,
+                                    NodeId dest, PortIndex dest_sidechain_port) {
+    // Sidechain connections only make sense to Plugin nodes; everything
+    // else (Gain, Custom, AudioOutput, ...) has no notion of a sidechain
+    // bus. We reject other destinations early so callers fail loudly
+    // instead of silently routing into a regular audio port.
+    const GraphNode* src_n = node(source);
+    const GraphNode* dst_n = node(dest);
+    if (!src_n || !dst_n) return false;
+    if (dst_n->type != NodeType::Plugin) return false;
+    if ((int)source_port >= src_n->num_output_ports) return false;
+    if ((int)dest_sidechain_port >= dst_n->num_input_ports) return false;
+    if (would_create_cycle(source, dest)) return false;
+
+    Connection conn{};
+    conn.source_node = source;
+    conn.source_port = source_port;
+    conn.dest_node = dest;
+    conn.dest_port = dest_sidechain_port;
+    conn.sidechain = true;
+    for (auto& c : connections_) if (c == conn) return false;
+    connections_.push_back(conn);
+    invalidate_live_();
+    return true;
+}
+
 bool SignalGraph::connect_automation(NodeId src, PortIndex src_audio_port,
                                      NodeId dest, uint32_t dest_param_id,
                                      float range_lo, float range_hi,
@@ -579,9 +605,10 @@ void SignalGraph::compute_latencies_for_(CompiledGraph& cg,
 }
 
 std::shared_ptr<SignalGraph::CompiledGraph>
-SignalGraph::compile_(double /*sample_rate*/, int max_block_size) {
+SignalGraph::compile_(double sample_rate, int max_block_size) {
     auto cg = std::make_shared<CompiledGraph>();
     cg->max_block_size = max_block_size;
+    cg->sample_rate = sample_rate;
     cg->connections = connections_;
     cg->order = processing_order();
 
@@ -871,7 +898,8 @@ void SignalGraph::process(audio::BufferView<float>& output,
                     };
                     std::unordered_map<uint32_t, Accum> acc;
                     const int last = num_samples - 1;
-                    for (const auto& c : cg->connections) {
+                    for (size_t ci = 0; ci < cg->connections.size(); ++ci) {
+                        const auto& c = cg->connections[ci];
                         if (!c.automation || c.dest_node != id) continue;
                         auto src_it = cg->runtime.find(c.source_node);
                         if (src_it == cg->runtime.end()) continue;
@@ -880,10 +908,69 @@ void SignalGraph::process(audio::BufferView<float>& output,
                         const float* src = src_it->second.output_ptrs[sport];
                         const float s0 = std::clamp(src[0], 0.0f, 1.0f);
                         const float sN = std::clamp(src[last < 0 ? 0 : last], 0.0f, 1.0f);
-                        const float m0 = c.automation_range_lo
+                        float m0 = c.automation_range_lo
                             + s0 * (c.automation_range_hi - c.automation_range_lo);
-                        const float mN = c.automation_range_lo
+                        float mN = c.automation_range_lo
                             + sN * (c.automation_range_hi - c.automation_range_lo);
+
+                        // Item 4.6 — per-source linear slew. The user
+                        // declares automation_smoothing_ms; we limit how
+                        // far the delivered value can move per sample at
+                        // that ramp speed. State (last_value/primed)
+                        // lives on the parallel ConnectionDelay so it
+                        // survives the next block.
+                        if (c.automation_smoothing_ms > 0.0f
+                            && cg->sample_rate > 0.0
+                            && ci < cg->connection_delays.size()) {
+                            auto& dl = cg->connection_delays[ci];
+                            const float range = std::abs(
+                                c.automation_range_hi - c.automation_range_lo);
+                            const double slew_samples =
+                                (double)c.automation_smoothing_ms * 0.001
+                                * cg->sample_rate;
+                            // max move per sample, in the plugin's plain
+                            // parameter domain. We use the connection's
+                            // mapped range as the "full sweep" scale so
+                            // smoothing_ms behaves like "ms to traverse
+                            // the entire declared range".
+                            const float max_step = slew_samples > 0.0
+                                ? (range / (float)slew_samples)
+                                : range;
+                            if (!dl.slew_primed) {
+                                // First block — snap so we don't glide
+                                // up from 0.
+                                dl.slew_last_value = m0;
+                                dl.slew_primed = true;
+                            }
+                            auto ramp_to = [max_step](float from, float target) {
+                                const float delta = target - from;
+                                if (delta > max_step) return from + max_step;
+                                if (delta < -max_step) return from - max_step;
+                                return target;
+                            };
+                            // v0 lands at sample 0; vN lands at sample
+                            // `last`. Slew from the previous block's
+                            // post-slew value to m0 in one step, then
+                            // from there to mN over `last` steps.
+                            const float new_v0 = ramp_to(dl.slew_last_value, m0);
+                            float new_vN = new_v0;
+                            if (last > 0) {
+                                const float max_block_step =
+                                    max_step * (float)last;
+                                const float delta = mN - new_v0;
+                                if (delta > max_block_step) {
+                                    new_vN = new_v0 + max_block_step;
+                                } else if (delta < -max_block_step) {
+                                    new_vN = new_v0 - max_block_step;
+                                } else {
+                                    new_vN = mN;
+                                }
+                            }
+                            dl.slew_last_value = new_vN;
+                            m0 = new_v0;
+                            mN = new_vN;
+                        }
+
                         auto& a = acc[c.automation_param_id];
                         const auto bounds = bounds_for_param(c.automation_param_id,
                                                              c.automation_range_lo,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3076,6 +3076,12 @@ add_executable(pulp-test-host-signal-graph test_host_signal_graph.cpp)
 target_link_libraries(pulp-test-host-signal-graph PRIVATE pulp::host Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-host-signal-graph)
 
+# Item 4.5 — ExtensionsVisitor. Pure-header pattern test, no plugin
+# loading required; uses lightweight mock slots to exercise dispatch.
+add_executable(pulp-test-extensions-visitor test_extensions_visitor.cpp)
+target_link_libraries(pulp-test-extensions-visitor PRIVATE pulp::host Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-extensions-visitor)
+
 # Host regression coverage (#52) — end-to-end scan / load / process /
 # unload lifecycle, scanner failure modes (moduleinfo.json + manifest.ttl),
 # state round-trip, and hot-reload race-cleanliness. Separate binary so a

--- a/test/test_extensions_visitor.cpp
+++ b/test/test_extensions_visitor.cpp
@@ -1,0 +1,180 @@
+// Item 4.5 — typed plugin introspection.
+// Verifies ExtensionsVisitor double-dispatches into the correct visit_*
+// method and surfaces a populated *Extension struct for known formats.
+// Slots that the running build did not link an SDK against (e.g. AU on a
+// Linux CI lane) fall through to visit_unknown, which is exactly the
+// contract documented in extensions_visitor.hpp.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/host/extensions_visitor.hpp>
+#include <pulp/host/plugin_slot.hpp>
+
+using namespace pulp::host;
+
+namespace {
+
+// Minimal slot that does not override accept(); should fall through to
+// the base PluginSlot::accept which calls visit_unknown.
+class StubSlot final : public PluginSlot {
+public:
+    const PluginInfo& info() const override { return info_; }
+    bool is_loaded() const override { return true; }
+    bool prepare(double, int) override { return true; }
+    void release() override {}
+    void process(pulp::audio::BufferView<float>&,
+                 const pulp::audio::BufferView<const float>&,
+                 const pulp::midi::MidiBuffer&,
+                 pulp::midi::MidiBuffer&,
+                 const ParameterEventQueue&,
+                 int) override {}
+    std::vector<HostParamInfo> parameters() const override { return {}; }
+    float get_parameter(uint32_t) const override { return 0.f; }
+    void set_parameter(uint32_t, float) override {}
+    void set_bypass(bool) override {}
+    bool is_bypassed() const override { return false; }
+    std::vector<uint8_t> save_state() const override { return {}; }
+    bool restore_state(const std::vector<uint8_t>&) override { return false; }
+    bool has_editor() const override { return false; }
+    void* create_editor_view() override { return nullptr; }
+    void destroy_editor_view() override {}
+    int latency_samples() const override { return 0; }
+    int tail_samples() const override { return 0; }
+private:
+    PluginInfo info_{};
+};
+
+// Slot that pretends to be a CLAP plugin so the visitor sees a CLAP
+// dispatch path with a non-null handle.
+class FakeClapSlot final : public PluginSlot {
+public:
+    const PluginInfo& info() const override { return info_; }
+    bool is_loaded() const override { return true; }
+    bool prepare(double, int) override { return true; }
+    void release() override {}
+    void process(pulp::audio::BufferView<float>&,
+                 const pulp::audio::BufferView<const float>&,
+                 const pulp::midi::MidiBuffer&,
+                 pulp::midi::MidiBuffer&,
+                 const ParameterEventQueue&,
+                 int) override {}
+    std::vector<HostParamInfo> parameters() const override { return {}; }
+    float get_parameter(uint32_t) const override { return 0.f; }
+    void set_parameter(uint32_t, float) override {}
+    void set_bypass(bool) override {}
+    bool is_bypassed() const override { return false; }
+    std::vector<uint8_t> save_state() const override { return {}; }
+    bool restore_state(const std::vector<uint8_t>&) override { return false; }
+    bool has_editor() const override { return false; }
+    void* create_editor_view() override { return nullptr; }
+    void destroy_editor_view() override {}
+    int latency_samples() const override { return 0; }
+    int tail_samples() const override { return 0; }
+
+    void accept(ExtensionsVisitor& v) const override {
+        ClapExtension ext;
+        // Sentinel pointers — the test only checks they survive the
+        // dispatch unchanged. Real ClapSlot fills these with the
+        // `const clap_plugin_t*` / `const clap_host_t*` it owns.
+        ext.plugin = reinterpret_cast<void*>(0xC1ABDEAD);
+        ext.host = reinterpret_cast<void*>(0xC1ABCAFE);
+        ext.plugin_id = "com.pulp.test.clap";
+        v.visit_clap(*this, ext);
+    }
+
+private:
+    PluginInfo info_{};
+};
+
+struct CapturingVisitor : ExtensionsVisitor {
+    enum class Path { None, Unknown, Vst3, Au, AuV3, Clap, Lv2 };
+    Path path = Path::None;
+    ExtensionFormat unknown_format = ExtensionFormat::Unknown;
+    Vst3Extension vst3{};
+    AudioUnitExtension au{};
+    AudioUnitV3Extension auv3{};
+    ClapExtension clap{};
+    Lv2Extension lv2{};
+
+    void visit_unknown(const PluginSlot&, ExtensionFormat f) override {
+        path = Path::Unknown;
+        unknown_format = f;
+    }
+    void visit_vst3(const PluginSlot&, const Vst3Extension& e) override {
+        path = Path::Vst3;
+        vst3 = e;
+    }
+    void visit_audio_unit(const PluginSlot&, const AudioUnitExtension& e) override {
+        path = Path::Au;
+        au = e;
+    }
+    void visit_audio_unit_v3(const PluginSlot&, const AudioUnitV3Extension& e) override {
+        path = Path::AuV3;
+        auv3 = e;
+    }
+    void visit_clap(const PluginSlot&, const ClapExtension& e) override {
+        path = Path::Clap;
+        clap = e;
+    }
+    void visit_lv2(const PluginSlot&, const Lv2Extension& e) override {
+        path = Path::Lv2;
+        lv2 = e;
+    }
+};
+
+} // namespace
+
+TEST_CASE("ExtensionsVisitor base slot dispatches to visit_unknown",
+          "[host][extensions-visitor]") {
+    StubSlot slot;
+    CapturingVisitor v;
+    slot.accept(v);
+    REQUIRE(v.path == CapturingVisitor::Path::Unknown);
+    REQUIRE(v.unknown_format == ExtensionFormat::Unknown);
+}
+
+TEST_CASE("ExtensionsVisitor CLAP slot dispatches to visit_clap with handles",
+          "[host][extensions-visitor][clap]") {
+    FakeClapSlot slot;
+    CapturingVisitor v;
+    slot.accept(v);
+    REQUIRE(v.path == CapturingVisitor::Path::Clap);
+    REQUIRE(v.clap.plugin == reinterpret_cast<void*>(0xC1ABDEAD));
+    REQUIRE(v.clap.host == reinterpret_cast<void*>(0xC1ABCAFE));
+    REQUIRE(v.clap.plugin_id == "com.pulp.test.clap");
+}
+
+// A visitor that only overrides visit_unknown should still receive a
+// notification when a typed visit_* fires, because the default visit_*
+// fall through to visit_unknown.
+TEST_CASE("ExtensionsVisitor unhandled format paths fall through to visit_unknown",
+          "[host][extensions-visitor]") {
+    struct UnknownOnlyVisitor : ExtensionsVisitor {
+        ExtensionFormat seen = ExtensionFormat::Unknown;
+        int unknown_count = 0;
+        void visit_unknown(const PluginSlot&, ExtensionFormat f) override {
+            seen = f;
+            ++unknown_count;
+        }
+    };
+
+    FakeClapSlot slot;
+    UnknownOnlyVisitor v;
+    slot.accept(v);
+    REQUIRE(v.unknown_count == 1);
+    REQUIRE(v.seen == ExtensionFormat::CLAP);
+}
+
+// The ExtensionFormat enum exists so a visitor that overrides
+// visit_unknown can disambiguate which adapter type funneled in. Confirm
+// every documented enumerator survives a value round-trip; this acts as a
+// guard against accidental reorder/removal that would silently break
+// existing visitors.
+TEST_CASE("ExtensionsVisitor ExtensionFormat values are stable",
+          "[host][extensions-visitor]") {
+    REQUIRE(static_cast<int>(ExtensionFormat::Unknown) == 0);
+    REQUIRE(static_cast<int>(ExtensionFormat::VST3) == 1);
+    REQUIRE(static_cast<int>(ExtensionFormat::AudioUnit) == 2);
+    REQUIRE(static_cast<int>(ExtensionFormat::AudioUnitV3) == 3);
+    REQUIRE(static_cast<int>(ExtensionFormat::CLAP) == 4);
+    REQUIRE(static_cast<int>(ExtensionFormat::LV2) == 5);
+}

--- a/test/test_host_signal_graph.cpp
+++ b/test/test_host_signal_graph.cpp
@@ -1568,4 +1568,294 @@ TEST_CASE("SignalGraph audio-rate modulation fails closed when event capacity is
                                 static_cast<int>(ParameterEventQueue::kCapacity + 1)));
 }
 
+// ── Item 4.6 automation smoothing ──────────────────────────────────────
+
+TEST_CASE("SignalGraph automation smoothing slews step input over the declared time",
+          "[host][graph][automation][smoothing]") {
+    SignalGraph graph;
+    auto in_node = graph.add_input_node(1, "in");
+    auto slot = std::make_unique<MockAutomatable>();
+    auto* slot_ptr = slot.get();
+    auto plug = graph.add_plugin_node(std::move(slot), 0, 1, "auto");
+
+    // 100 ms slew across a [0, 1] range at 48 kHz = 4800 samples to
+    // traverse the full range. A 32-sample block can move at most
+    // 32 / 4800 = 0.00667 per block, so a step from 0 → 1 takes many
+    // blocks to land.
+    const double sr = 48000.0;
+    const int block = 32;
+    REQUIRE(graph.connect_automation(
+        in_node, 0, plug, MockAutomatable::kParamId, 0.0f, 1.0f,
+        100.0f /*ms*/, AutomationMix::Replace));
+    REQUIRE(graph.prepare(sr, block));
+
+    std::vector<float> in_buf(block, 1.0f);  // step to 1 immediately
+    std::vector<float> out_buf(block, 0.0f);
+    const float* in_ptrs[1] = {in_buf.data()};
+    float* out_ptrs[1] = {out_buf.data()};
+    pulp::audio::BufferView<const float> iv(in_ptrs, 1, block);
+    pulp::audio::BufferView<float> ov(out_ptrs, 1, block);
+
+    // Block 0: first block primes to source value (snap on first
+    // encounter), so v0 = 1.0 here. We assert that on the SECOND
+    // block — which represents a *new* step away from the previous
+    // post-slew value — the slew limits how far we can move.
+    graph.process(ov, iv, block);
+    REQUIRE(slot_ptr->received().size() == 2);
+
+    // Now step the source back to 0.0. The slew rate caps the per-
+    // sample delta at ~1/4800 ≈ 0.000208, so over `last = 31` samples
+    // we can only move ~0.00646 from the previous 1.0 — meaning vN
+    // should sit near 0.9935, NOT 0.0.
+    std::fill(in_buf.begin(), in_buf.end(), 0.0f);
+    graph.process(ov, iv, block);
+
+    const auto& events = slot_ptr->received();
+    REQUIRE(events.size() == 4);
+    // Event indexes 2 (v0) and 3 (vN) come from block 1.
+    // v0 was forced down by one sample of slew from 1.0 (≈ 0.999792).
+    REQUIRE(events[2].sample_offset == 0);
+    REQUIRE(events[2].value < 1.0f);  // moved down
+    REQUIRE(events[2].value > 0.95f); // but only by one sample's slew
+
+    // vN should still be near 1.0 (we can only move 31 samples-worth
+    // toward 0 in this block — far short of reaching it).
+    REQUIRE(events[3].sample_offset == block - 1);
+    REQUIRE(events[3].value > 0.99f);  // still far from 0
+    REQUIRE(events[3].value < events[2].value); // monotonically decreasing
+}
+
+TEST_CASE("SignalGraph automation smoothing is bypassed when smoothing_ms == 0",
+          "[host][graph][automation][smoothing]") {
+    SignalGraph graph;
+    auto in_node = graph.add_input_node(1, "in");
+    auto slot = std::make_unique<MockAutomatable>();
+    auto* slot_ptr = slot.get();
+    auto plug = graph.add_plugin_node(std::move(slot), 0, 1, "auto");
+
+    REQUIRE(graph.connect_automation(
+        in_node, 0, plug, MockAutomatable::kParamId, 0.0f, 1.0f,
+        0.0f, AutomationMix::Replace));
+    REQUIRE(graph.prepare(48000.0, 8));
+
+    // Step from 0 to 1 in one block — without smoothing, vN should
+    // land at exactly 1.0.
+    std::vector<float> in_buf(8, 0.0f);
+    in_buf[0] = 0.0f;
+    in_buf[7] = 1.0f;
+    std::vector<float> out_buf(8, 0.0f);
+    const float* in_ptrs[1] = {in_buf.data()};
+    float* out_ptrs[1] = {out_buf.data()};
+    pulp::audio::BufferView<const float> iv(in_ptrs, 1, 8);
+    pulp::audio::BufferView<float> ov(out_ptrs, 1, 8);
+
+    graph.process(ov, iv, 8);
+
+    const auto& events = slot_ptr->received();
+    REQUIRE(events.size() == 2);
+    REQUIRE(events[0].value == 0.0f);
+    REQUIRE(events[1].value == 1.0f);  // step delivered with no slew
+}
+
+TEST_CASE("SignalGraph automation smoothing eventually reaches the target",
+          "[host][graph][automation][smoothing]") {
+    SignalGraph graph;
+    auto in_node = graph.add_input_node(1, "in");
+    auto slot = std::make_unique<MockAutomatable>();
+    auto* slot_ptr = slot.get();
+    auto plug = graph.add_plugin_node(std::move(slot), 0, 1, "auto");
+
+    // 10 ms slew over [0,1] at 48 kHz = 480 samples. With a 64-sample
+    // block, the source rises by ~0.133 per block. ~8 blocks to land.
+    REQUIRE(graph.connect_automation(
+        in_node, 0, plug, MockAutomatable::kParamId, 0.0f, 1.0f,
+        10.0f, AutomationMix::Replace));
+    REQUIRE(graph.prepare(48000.0, 64));
+
+    std::vector<float> in_buf(64, 1.0f);
+    std::vector<float> out_buf(64, 0.0f);
+    const float* in_ptrs[1] = {in_buf.data()};
+    float* out_ptrs[1] = {out_buf.data()};
+    pulp::audio::BufferView<const float> iv(in_ptrs, 1, 64);
+    pulp::audio::BufferView<float> ov(out_ptrs, 1, 64);
+
+    // Block 0 primes to source value (snap) per the documented contract.
+    // After that, every step from 0 → 1 has to slew — but here the
+    // source is held at 1.0 continuously, so we should reach the target
+    // exactly in block 0 (snap-on-prime).
+    graph.process(ov, iv, 64);
+    REQUIRE_THAT(slot_ptr->received().back().value, WithinAbs(1.0f, 1e-6f));
+
+    // Now step the source back to 0 and watch the slew take ~8 blocks
+    // to reach it. We assert the value monotonically decreases and
+    // eventually crosses below epsilon.
+    std::fill(in_buf.begin(), in_buf.end(), 0.0f);
+    float last_value = 1.0f;
+    bool reached = false;
+    for (int b = 0; b < 32; ++b) {
+        graph.process(ov, iv, 64);
+        const float v = slot_ptr->received().back().value;
+        REQUIRE(v <= last_value + 1e-6f);  // non-increasing
+        last_value = v;
+        if (v < 1e-3f) { reached = true; break; }
+    }
+    REQUIRE(reached);
+}
+
+// ── Item 4.7 sidechain routing ────────────────────────────────────────
+
+namespace {
+// A simple "compressor": passes main input through unchanged, but copies
+// the average of its sidechain inputs into a public field so the test
+// can observe what arrived on the sidechain bus.
+class SidechainCompressor final : public PluginSlot {
+public:
+    int main_inputs = 2;
+    float last_sidechain_value = 0.0f;
+    int last_sidechain_count = 0;
+
+    const PluginInfo& info() const override { return info_; }
+    bool is_loaded() const override { return true; }
+    bool prepare(double, int) override { return true; }
+    void release() override {}
+    void process(pulp::audio::BufferView<float>& out,
+                 const pulp::audio::BufferView<const float>& in,
+                 const pulp::midi::MidiBuffer&, pulp::midi::MidiBuffer&,
+                 const pulp::host::ParameterEventQueue&,
+                 int n) override {
+        const int nc_in = static_cast<int>(in.num_channels());
+        const int nc_out = static_cast<int>(out.num_channels());
+
+        // Main input → main output (port-for-port).
+        for (int c = 0; c < std::min(main_inputs, nc_out); ++c) {
+            const float* s = c < nc_in ? in.channel_ptr(c) : nullptr;
+            float* d = out.channel_ptr(c);
+            for (int i = 0; i < n; ++i) d[i] = s ? s[i] : 0.f;
+        }
+
+        // Average everything beyond the main bus and stash it.
+        float accum = 0.f;
+        int count = 0;
+        for (int c = main_inputs; c < nc_in; ++c) {
+            const float* s = in.channel_ptr(c);
+            for (int i = 0; i < n; ++i) {
+                accum += s[i];
+                ++count;
+            }
+        }
+        last_sidechain_value = count > 0 ? accum / (float)count : 0.f;
+        last_sidechain_count = count;
+    }
+    std::vector<HostParamInfo> parameters() const override { return {}; }
+    float get_parameter(uint32_t) const override { return 0.f; }
+    void set_parameter(uint32_t, float) override {}
+    void set_bypass(bool) override {}
+    bool is_bypassed() const override { return false; }
+    std::vector<uint8_t> save_state() const override { return {}; }
+    bool restore_state(const std::vector<uint8_t>&) override { return false; }
+    bool has_editor() const override { return false; }
+    void* create_editor_view() override { return nullptr; }
+    void destroy_editor_view() override {}
+    int latency_samples() const override { return 0; }
+    int tail_samples() const override { return 0; }
+private:
+    PluginInfo info_ = make_plugin_info("Compressor", 4, 2);
+};
+} // namespace
+
+TEST_CASE("SignalGraph connect_sidechain tags the edge and routes to the named port",
+          "[host][graph][sidechain]") {
+    // Layout: kick (2 channels) — port 0 drives the compressor's main
+    // input, port 1 drives the compressor's sidechain. The compressor
+    // declares 2 input ports: 0 = main, 1 = sidechain.
+    //
+    // We use a single 2-channel AudioInput node because the graph
+    // dispatches `input[c]` into each AudioInput node's port `c`; using
+    // two 1-port AudioInput nodes would make both nodes see input[0],
+    // which collapses the test signal.
+    SignalGraph graph;
+    auto src = graph.add_input_node(2, "src");
+    auto comp_slot = std::make_unique<SidechainCompressor>();
+    comp_slot->main_inputs = 1;  // port 0 = main; port 1 = sidechain
+    auto* comp_ptr = comp_slot.get();
+    auto comp = graph.add_plugin_node(std::move(comp_slot), 2, 2, "compressor");
+    auto out = graph.add_output_node(2, "out");
+
+    REQUIRE(graph.connect(src, 0, comp, 0));            // main from input[0]
+    REQUIRE(graph.connect_sidechain(src, 1, comp, 1));  // sidechain from input[1]
+    REQUIRE(graph.connect(comp, 0, out, 0));
+    REQUIRE(graph.connect(comp, 1, out, 1));
+
+    // The sidechain edge should be present and tagged.
+    int sidechain_edges = 0;
+    for (const auto& c : graph.connections()) {
+        if (c.sidechain) ++sidechain_edges;
+    }
+    REQUIRE(sidechain_edges == 1);
+
+    REQUIRE(graph.prepare(48000.0, 16));
+
+    // input[0] = main signal (0.2), input[1] = kick (0.8).
+    std::vector<float> in_sig(16, 0.2f);
+    std::vector<float> in_kick(16, 0.8f);
+    std::vector<float> out_l(16, 0.f), out_r(16, 0.f);
+    const float* in_ptrs[2] = {in_sig.data(), in_kick.data()};
+    float* out_ptrs[2] = {out_l.data(), out_r.data()};
+    pulp::audio::BufferView<const float> iv(in_ptrs, 2, 16);
+    pulp::audio::BufferView<float> ov(out_ptrs, 2, 16);
+
+    graph.process(ov, iv, 16);
+
+    // Sidechain saw 16 frames of 0.8 → mean 0.8.
+    REQUIRE_THAT(comp_ptr->last_sidechain_value, WithinAbs(0.8f, 1e-6f));
+    REQUIRE(comp_ptr->last_sidechain_count == 16);
+
+    // Main signal pass-through delivered 0.2 to out[0]; out[1] stays at
+    // zero (plugin's port-2 output was untouched by the test fixture).
+    for (int i = 0; i < 16; ++i) {
+        REQUIRE_THAT(out_l[i], WithinAbs(0.2f, 1e-6f));
+        REQUIRE_THAT(out_r[i], WithinAbs(0.0f, 1e-6f));
+    }
+    graph.release();
+}
+
+TEST_CASE("SignalGraph connect_sidechain rejects non-Plugin destinations and bad ports",
+          "[host][graph][sidechain]") {
+    SignalGraph graph;
+    auto kick = graph.add_input_node(1, "kick");
+    auto gain = graph.add_gain_node("gain");
+    auto comp = graph.add_plugin_node(std::make_unique<SidechainCompressor>(),
+                                      4, 2, "comp");
+
+    // Non-Plugin destination: reject.
+    REQUIRE_FALSE(graph.connect_sidechain(kick, 0, gain, 0));
+    // Source port out of range: reject.
+    REQUIRE_FALSE(graph.connect_sidechain(kick, 4, comp, 2));
+    // Dest port out of range: reject.
+    REQUIRE_FALSE(graph.connect_sidechain(kick, 0, comp, 99));
+    // Unknown nodes: reject.
+    REQUIRE_FALSE(graph.connect_sidechain(999, 0, comp, 2));
+    REQUIRE_FALSE(graph.connect_sidechain(kick, 0, 999, 2));
+    REQUIRE(graph.connections().empty());
+
+    // Valid edge accepted; duplicate then rejected.
+    REQUIRE(graph.connect_sidechain(kick, 0, comp, 2));
+    REQUIRE_FALSE(graph.connect_sidechain(kick, 0, comp, 2));
+    REQUIRE(graph.connections().size() == 1);
+}
+
+TEST_CASE("SignalGraph sidechain edges participate in cycle detection",
+          "[host][graph][sidechain]") {
+    // comp -> follow (audio), follow -> comp.sidechain would close a cycle.
+    SignalGraph graph;
+    auto comp = graph.add_plugin_node(std::make_unique<SidechainCompressor>(),
+                                      3, 2, "comp");  // ports 0=main, 1,2=sidechain
+    auto follow = graph.add_plugin_node(std::make_unique<SidechainCompressor>(),
+                                        2, 2, "follow");
+
+    REQUIRE(graph.connect(comp, 0, follow, 0));
+    // Back-edge via sidechain would cycle — must be rejected.
+    REQUIRE_FALSE(graph.connect_sidechain(follow, 0, comp, 1));
+}
+
 // ── Phase 3 GraphSerializer round-trip ──────────────────────────────────


### PR DESCRIPTION
## Summary

Bundles three macOS-plugin-authoring slices from `planning/2026-05-24-macos-plugin-authoring-plan.md`:

- **Item 4.5 — ExtensionsVisitor**: double-dispatch visitor that surfaces format-specific plugin handles (VST3 IComponent, AU AudioComponentInstance, CLAP `clap_plugin_t`, LV2 instance) to host code without a leaky `void*` getter. Wired in all four format adapters; default `accept()` falls back to `visit_unknown` so placeholder slots degrade gracefully.
- **Item 4.6 — SignalGraph automation slew**: per-source linear slew on automation edges. The previously-TODO `automation_smoothing_ms` field now actually clamps the per-sample delta to `range / (ms * sr / 1000)`. 0 ms preserves snap behaviour exactly.
- **Item 4.7 — SignalGraph sidechain routing**: new `Connection.sidechain` flag + `connect_sidechain()` API. Sidechain edges route to the destination plugin's named sidechain port, participate in topological sort + PDC + cycle detection like normal audio edges, and round-trip through GraphSerializer (additive — older blobs load with `sidechain=false`).

## Test plan

- [x] `pulp-test-extensions-visitor` — 4 new cases (14 assertions)
- [x] `pulp-test-host-signal-graph` — 6 new cases for 4.6/4.7 on top of existing 40; all 46 pass (843 assertions total)
- [x] `pulp-test-host`, `pulp-test-host-regression`, `pulp-test-graph-serializer`, `pulp-test-matrix` — unchanged, all pass
- [x] Full host test label sweep: 115/115 pass
- [x] Whole-tree build (`cmake --build build -j`) — green on macOS

## Deferred / out of scope

- ExtensionsVisitor surfaces handles but does not yet add a higher-level "find extension by IID" helper — that's a follow-up on top of the visitor contract.
- Sidechain routing is metadata + routing; per-host quirks (e.g. Cubase's `setBusArrangements` re-negotiation for the dedicated sidechain bus) are tracked in track 5.
- Automation slew uses linear interpolation; an exponential / one-pole option can be added without breaking the wire format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)