### PR TITLE
feat(format): host quirks — Cubase 10/9, Live, Wavelab (items 5.2/5.3/5.4/5.6)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.234.0
+    VERSION 0.235.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/host_quirks/ableton_live.hpp
+++ b/core/format/include/pulp/format/host_quirks/ableton_live.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+/// @file host_quirks/ableton_live.hpp
+/// Per-host quirks for Ableton Live (macOS plan item 5.4).
+///
+/// DAW-quirks rows 5 + 6 (VST3):
+///   * row 5: Live calls `checkSizeConstraint()` even when the plugin
+///     advertises `canResize() == false`. The adapter must always
+///     return valid bounds (fall back to current size) rather than
+///     failing, otherwise Live silently refuses to display the editor.
+///   * row 6: on Windows with per-monitor-V2 DPI, Live's host window
+///     may not be ready when the plugin attempts to attach. The
+///     adapter must defer view creation until the system-window
+///     handle is non-null and retry on the next vsync. **No-op on
+///     macOS / Linux** — the flag is set unconditionally because the
+///     Windows VST3 adapter is the only call site that consults it.
+///   * row 7 (VST2) is in Pulp's Deferred-by-design list and intentionally
+///     not wired here.
+///
+/// Version handling: both quirks have been present in every Live VST3
+/// host vintage Pulp encounters, so `apply_ableton_live` fires them
+/// regardless of `HostVersion`. If a future Live release fixes either,
+/// add an `is_before(major)` guard at that point.
+///
+/// **Reference-Lineage**: cleanroom reproducer=macos-plan-item-5.4
+/// docs=https://help.ableton.com/hc/en-us/articles/4419010492444-Working-with-VST-Plug-Ins
+
+#include <pulp/format/host_quirks.hpp>
+#include <pulp/format/host_version.hpp>
+
+namespace pulp::format::host_quirks {
+
+/// Populate Ableton Live host-gated flags onto `q`. `v` is unused
+/// today (both rows are version-invariant) but kept for signature
+/// uniformity with other per-host modules.
+inline void apply_ableton_live(HostQuirks& q, HostVersion /*v*/) {
+    // Row 5 — VST3 always-return-valid-bounds from checkSizeConstraint.
+    q.live_vst3_canresize_ignore = true;
+    // Row 6 — VST3 Windows per-monitor-DPI defer. No-op off Windows
+    // at the adapter call site; the flag is unconditional here so
+    // the Windows path picks it up automatically.
+    q.live_vst3_windows_dpi_defer = true;
+}
+
+}  // namespace pulp::format::host_quirks

--- a/core/format/include/pulp/format/host_quirks/cubase.hpp
+++ b/core/format/include/pulp/format/host_quirks/cubase.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+/// @file host_quirks/cubase.hpp
+/// Per-host quirks for Steinberg Cubase + Nuendo (treated identically).
+///
+/// Cubase 10 vintage — DAW-quirks rows 1, 2, 3 (macOS plan item 5.2):
+///   * row 1: async window resize after `IPlugView::onSize()` returns.
+///   * row 2: parameter automation ordering — value-set must precede
+///     gesture-edit notification within the same dispatch cycle.
+///   * row 3: integer-rounded `setContentScaleFactor()` requires
+///     plugin-side residual correction on fractional-DPI displays.
+///
+/// Cubase 9 vintage — DAW-quirks row 4 (macOS plan item 5.3):
+///   * row 4: state-blob stream reports the wrong size; the adapter
+///     must validate the actual read count rather than trusting the
+///     host-reported size.
+///
+/// Version dispatch: Cubase 10 quirks fire on `major >= 10`; the
+/// Cubase 9 state-blob quirk only fires on the 9.x line (NOT on
+/// Cubase 10+) since 10 fixed the underlying stream bug. Cubase
+/// `HostVersion{0,0,0}` (unknown) intentionally leaves both bands
+/// off — the adapter falls back to spec-compliant defaults.
+///
+/// Nuendo is treated as Cubase in the dispatch table
+/// (`make_quirks_for` maps `HostType::Nuendo` here) — Nuendo 10
+/// inherits the Cubase 10 row, Nuendo 8/9 inherits Cubase 9's row.
+///
+/// **Reference-Lineage**: cleanroom reproducer=macos-plan-item-5.2/5.3
+/// docs=https://steinbergmedia.github.io/vst3_dev_portal/pages/Technical+Documentation/Technical+Documentation.html
+
+#include <pulp/format/host_quirks.hpp>
+#include <pulp/format/host_version.hpp>
+
+namespace pulp::format::host_quirks {
+
+/// Populate Cubase-specific (and Nuendo-as-Cubase) host-gated flags
+/// onto `q` based on `v`. No-op when `v` is unknown.
+inline void apply_cubase(HostQuirks& q, HostVersion v) {
+    // Row 1, 2, 3 — Cubase 10+ (and Nuendo 10+) async-resize +
+    // gesture-ordering + fractional-DPI correction.
+    if (v.is_at_least(10, 0)) {
+        q.cubase10_async_view_resize_queue = true;
+        q.cubase10_param_gesture_ordering = true;
+        q.cubase10_fractional_scale_correction = true;
+    }
+    // Row 4 — Cubase 9 (9.0 ≤ v < 10.0) state-blob size validation.
+    // Cubase 10 fixed the underlying stream-size bug, so the validation
+    // path stays off there.
+    if (v.is_at_least(9, 0) && v.is_before(10, 0)) {
+        q.cubase9_state_blob_size_validation = true;
+    }
+}
+
+}  // namespace pulp::format::host_quirks

--- a/core/format/include/pulp/format/host_quirks/wavelab.hpp
+++ b/core/format/include/pulp/format/host_quirks/wavelab.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+/// @file host_quirks/wavelab.hpp
+/// Per-host quirks for Steinberg Wavelab (macOS plan item 5.6).
+///
+/// DAW-quirks rows 10 + 11 (VST3):
+///   * row 10: Wavelab 11.1+ calls `setBusArrangements()` re-entrantly
+///     from inside the `prepareToPlay` stack when the plugin invokes
+///     `setLatencySamples()`. Without a deferral, the plugin can
+///     deadlock or corrupt its activation state. The adapter must
+///     defer activation-side effects (layout commit, latency report)
+///     until the current stack unwinds.
+///   * row 11: Wavelab's state-blob format diverges from standard VST3
+///     enough that strict error reporting on a `MemoryStream` read
+///     failure causes Wavelab to drop the session's parameter set.
+///     The adapter must return success with a logged warning rather
+///     than propagating the error — let the host believe the load
+///     worked and present a clean parameter set.
+///   * row 12 (VST2 editor-thread dispatch) is in Pulp's Deferred list.
+///
+/// Version handling: row 10 is documented as Wavelab 11.1+. We fire
+/// it on `major >= 11` (the underlying re-entrancy was observed
+/// throughout the 11.x line; minor 11.0 is also affected per the
+/// reproducer). Row 11 is version-invariant — Wavelab's state-blob
+/// divergence predates the 11.x window and remains in the latest
+/// release as of the macOS plan, so we fire it unconditionally.
+///
+/// **Reference-Lineage**: cleanroom reproducer=macos-plan-item-5.6
+/// docs=https://steinbergmedia.github.io/vst3_dev_portal/pages/Technical+Documentation/Bus+Arrangement+Setup.html
+
+#include <pulp/format/host_quirks.hpp>
+#include <pulp/format/host_version.hpp>
+
+namespace pulp::format::host_quirks {
+
+/// Populate Wavelab host-gated flags onto `q` based on `v`.
+inline void apply_wavelab(HostQuirks& q, HostVersion v) {
+    // Row 10 — Wavelab 11+ re-entrant setBusArrangements during
+    // prepareToPlay. Adapter must defer activation-side effects.
+    if (v.is_at_least(11, 0)) {
+        q.wavelab_vst3_defer_activation = true;
+    }
+    // Row 11 — Wavelab state-blob graceful-restore fallback. Version-
+    // invariant: the divergence exists across the Wavelab versions
+    // Pulp targets and there's no fixed release on the horizon.
+    q.wavelab_state_blob_fallback = true;
+}
+
+}  // namespace pulp::format::host_quirks

--- a/core/format/include/pulp/format/host_type.hpp
+++ b/core/format/include/pulp/format/host_type.hpp
@@ -17,6 +17,7 @@ enum class HostType {
     ProTools,
     Cubase,
     Nuendo,
+    Wavelab,
     StudioOne,
     FLStudio,
     Bitwig,

--- a/core/format/src/host_quirks.cpp
+++ b/core/format/src/host_quirks.cpp
@@ -1,5 +1,6 @@
 #include <pulp/format/host_quirks.hpp>
 
+#include <pulp/format/host_quirks/ableton_live.hpp>
 #include <pulp/format/host_quirks/cubase.hpp>
 #include <pulp/format/host_version.hpp>
 
@@ -16,11 +17,6 @@ namespace {
 // header) must be backed by a host vendor doc + a reproducer Pulp
 // issue. See the catalog at
 // `planning/2026-05-24-daw-host-quirks-inheritance.md`.
-
-void apply_ableton_live_quirks(HostQuirks& q, HostVersion /*v*/) {
-    q.live_vst3_canresize_ignore = true;
-    q.live_vst3_windows_dpi_defer = true; // No-op on macOS/Linux.
-}
 
 void apply_bitwig_quirks(HostQuirks& q, HostVersion v) {
     q.bitwig_vst3_linux_repaint_after_resize = true; // No-op off Linux.
@@ -56,7 +52,7 @@ HostQuirks make_quirks_for(HostType type, HostVersion version) {
     switch (type) {
         case HostType::Cubase:
         case HostType::Nuendo:        host_quirks::apply_cubase(q, version); break;
-        case HostType::AbletonLive:   apply_ableton_live_quirks(q, version); break;
+        case HostType::AbletonLive:   host_quirks::apply_ableton_live(q, version); break;
         case HostType::Bitwig:        apply_bitwig_quirks(q, version); break;
         case HostType::Reaper:        apply_reaper_quirks(q, version); break;
         case HostType::LogicPro:

--- a/core/format/src/host_quirks.cpp
+++ b/core/format/src/host_quirks.cpp
@@ -2,6 +2,7 @@
 
 #include <pulp/format/host_quirks/ableton_live.hpp>
 #include <pulp/format/host_quirks/cubase.hpp>
+#include <pulp/format/host_quirks/wavelab.hpp>
 #include <pulp/format/host_version.hpp>
 
 namespace pulp::format {
@@ -53,13 +54,14 @@ HostQuirks make_quirks_for(HostType type, HostVersion version) {
         case HostType::Cubase:
         case HostType::Nuendo:        host_quirks::apply_cubase(q, version); break;
         case HostType::AbletonLive:   host_quirks::apply_ableton_live(q, version); break;
+        case HostType::Wavelab:       host_quirks::apply_wavelab(q, version); break;
         case HostType::Bitwig:        apply_bitwig_quirks(q, version); break;
         case HostType::Reaper:        apply_reaper_quirks(q, version); break;
         case HostType::LogicPro:
         case HostType::GarageBand:    apply_logic_pro_quirks(q, version); break;
         case HostType::ProTools:      apply_pro_tools_quirks(q, version); break;
-        // Wavelab / FL Studio / StudioOne / DigitalPerformer / etc. land
-        // their flags here when the per-host fixes ship in batches L/N.
+        // FL Studio / StudioOne / DigitalPerformer / etc. land their
+        // flags here when the per-host fixes ship in batches L/N.
         default: break;
     }
     return q;

--- a/core/format/src/host_quirks.cpp
+++ b/core/format/src/host_quirks.cpp
@@ -1,34 +1,21 @@
 #include <pulp/format/host_quirks.hpp>
 
+#include <pulp/format/host_quirks/cubase.hpp>
 #include <pulp/format/host_version.hpp>
 
 namespace pulp::format {
 
 namespace {
 
-// Per-host quirk-population helpers. Each function consumes the current
-// HostQuirks and the detected version, then flips the host-gated flags
-// that apply. License-hygiene: every flag flipped here must be backed
-// by a host vendor doc + a reproducer Pulp issue. See the catalog at
+// Per-host quirk-population helpers. Extracted per-host modules under
+// `core/format/include/pulp/format/host_quirks/<host>.hpp` expose an
+// inline `host_quirks::apply_<host>(HostQuirks&, HostVersion)` that
+// the dispatch table below routes to. Hosts without a dedicated header
+// still live here as private helpers until the next batch extracts
+// them. License-hygiene: every flag flipped here (or in a per-host
+// header) must be backed by a host vendor doc + a reproducer Pulp
+// issue. See the catalog at
 // `planning/2026-05-24-daw-host-quirks-inheritance.md`.
-//
-// As each per-host accommodation lands (batches J–N), the
-// implementation flips the corresponding flag here and an adapter
-// reads it in its hot path. The factory functions below are
-// intentionally tiny so per-host detail can move into
-// `core/format/include/pulp/format/host_quirks/<host>.hpp` headers
-// later without churn.
-
-void apply_cubase_quirks(HostQuirks& q, HostVersion v) {
-    if (v.is_at_least(10, 0)) {
-        q.cubase10_async_view_resize_queue = true;
-        q.cubase10_param_gesture_ordering = true;
-        q.cubase10_fractional_scale_correction = true;
-    }
-    if (v.is_at_least(9, 0) && v.is_before(10, 0)) {
-        q.cubase9_state_blob_size_validation = true;
-    }
-}
 
 void apply_ableton_live_quirks(HostQuirks& q, HostVersion /*v*/) {
     q.live_vst3_canresize_ignore = true;
@@ -68,7 +55,7 @@ HostQuirks make_quirks_for(HostType type, HostVersion version) {
     HostQuirks q; // cheap defenses on by default
     switch (type) {
         case HostType::Cubase:
-        case HostType::Nuendo:        apply_cubase_quirks(q, version); break;
+        case HostType::Nuendo:        host_quirks::apply_cubase(q, version); break;
         case HostType::AbletonLive:   apply_ableton_live_quirks(q, version); break;
         case HostType::Bitwig:        apply_bitwig_quirks(q, version); break;
         case HostType::Reaper:        apply_reaper_quirks(q, version); break;

--- a/core/format/src/host_type.cpp
+++ b/core/format/src/host_type.cpp
@@ -48,6 +48,11 @@ HostType host_type_from_process_name(std::string_view process_name) {
     if (name.find("ableton") != std::string::npos || name.find("live") != std::string::npos) return HostType::AbletonLive;
     if (name.find("reaper") != std::string::npos) return HostType::Reaper;
     if (name.find("protools") != std::string::npos || name.find("pro tools") != std::string::npos) return HostType::ProTools;
+    // Wavelab must be checked before Cubase / Nuendo because the
+    // Steinberg Wavelab executable does NOT contain "cubase" but the
+    // overlap-check still keeps Wavelab as its own classifier rather
+    // than folding it into the Cubase family — its quirks diverge.
+    if (name.find("wavelab") != std::string::npos) return HostType::Wavelab;
     if (name.find("cubase") != std::string::npos) return HostType::Cubase;
     if (name.find("nuendo") != std::string::npos) return HostType::Nuendo;
     if (name.find("studio one") != std::string::npos || name.find("studioone") != std::string::npos) return HostType::StudioOne;
@@ -74,6 +79,7 @@ std::string host_type_name(HostType type) {
         case HostType::ProTools: return "Pro Tools";
         case HostType::Cubase: return "Cubase";
         case HostType::Nuendo: return "Nuendo";
+        case HostType::Wavelab: return "WaveLab";
         case HostType::StudioOne: return "Studio One";
         case HostType::FLStudio: return "FL Studio";
         case HostType::Bitwig: return "Bitwig Studio";

--- a/test/test_diagnostic_reporter.cpp
+++ b/test/test_diagnostic_reporter.cpp
@@ -271,6 +271,7 @@ TEST_CASE("HostType names cover every declared host enum",
     REQUIRE(host_type_name(HostType::ProTools) == "Pro Tools");
     REQUIRE(host_type_name(HostType::Cubase) == "Cubase");
     REQUIRE(host_type_name(HostType::Nuendo) == "Nuendo");
+    REQUIRE(host_type_name(HostType::Wavelab) == "WaveLab");
     REQUIRE(host_type_name(HostType::StudioOne) == "Studio One");
     REQUIRE(host_type_name(HostType::FLStudio) == "FL Studio");
     REQUIRE(host_type_name(HostType::Bitwig) == "Bitwig Studio");
@@ -287,6 +288,7 @@ TEST_CASE("HostType feature heuristics default permissive for modern hosts",
                       HostType::Reaper,
                       HostType::Cubase,
                       HostType::Nuendo,
+                      HostType::Wavelab,
                       HostType::StudioOne,
                       HostType::FLStudio,
                       HostType::Bitwig,
@@ -309,6 +311,8 @@ TEST_CASE("HostType process-name classifier covers DAW executable aliases",
     REQUIRE(host_type_from_process_name("protools") == HostType::ProTools);
     REQUIRE(host_type_from_process_name("Cubase 14") == HostType::Cubase);
     REQUIRE(host_type_from_process_name("Nuendo") == HostType::Nuendo);
+    REQUIRE(host_type_from_process_name("WaveLab 12") == HostType::Wavelab);
+    REQUIRE(host_type_from_process_name("wavelab") == HostType::Wavelab);
     REQUIRE(host_type_from_process_name("Studio One") == HostType::StudioOne);
     REQUIRE(host_type_from_process_name("studioone") == HostType::StudioOne);
     REQUIRE(host_type_from_process_name("FL Studio") == HostType::FLStudio);

--- a/test/test_host_quirks.cpp
+++ b/test/test_host_quirks.cpp
@@ -129,3 +129,18 @@ TEST_CASE("make_quirks_for Cubase with unknown version stays defensive-default",
     REQUIRE(q.synthesize_bypass_parameter == true);
     REQUIRE(q.clamp_latency_to_nonneg == true);
 }
+
+// ── macOS plan item 5.4 — Ableton Live header extraction. Factory at
+//    `core/format/include/pulp/format/host_quirks/ableton_live.hpp`. ──
+
+TEST_CASE("make_quirks_for Ableton Live leaves Cubase / Wavelab flags off",
+          "[format][host-quirks][isolation]") {
+    auto q = make_quirks_for(HostType::AbletonLive, HostVersion{11, 0});
+    REQUIRE(q.live_vst3_canresize_ignore == true);
+    REQUIRE(q.live_vst3_windows_dpi_defer == true);
+    REQUIRE(q.cubase10_async_view_resize_queue == false);
+    REQUIRE(q.cubase9_state_blob_size_validation == false);
+    REQUIRE(q.wavelab_vst3_defer_activation == false);
+    REQUIRE(q.wavelab_state_blob_fallback == false);
+    REQUIRE(q.reaper_process_while_bypassed == false);
+}

--- a/test/test_host_quirks.cpp
+++ b/test/test_host_quirks.cpp
@@ -144,3 +144,41 @@ TEST_CASE("make_quirks_for Ableton Live leaves Cubase / Wavelab flags off",
     REQUIRE(q.wavelab_state_blob_fallback == false);
     REQUIRE(q.reaper_process_while_bypassed == false);
 }
+
+// ── macOS plan item 5.6 — Wavelab dispatch (DAW-quirks rows 10 + 11).
+//    New `HostType::Wavelab` + per-host header at
+//    `core/format/include/pulp/format/host_quirks/wavelab.hpp`. ──
+
+TEST_CASE("make_quirks_for Wavelab 11.1 fires both Wavelab flags",
+          "[format][host-quirks][wavelab]") {
+    auto q = make_quirks_for(HostType::Wavelab, HostVersion{11, 1});
+    REQUIRE(q.wavelab_vst3_defer_activation == true);
+    REQUIRE(q.wavelab_state_blob_fallback == true);
+    // No cross-host bleed.
+    REQUIRE(q.cubase10_async_view_resize_queue == false);
+    REQUIRE(q.live_vst3_canresize_ignore == false);
+}
+
+TEST_CASE("make_quirks_for Wavelab 12 keeps both flags on (regression coverage)",
+          "[format][host-quirks][wavelab]") {
+    auto q = make_quirks_for(HostType::Wavelab, HostVersion{12, 0});
+    REQUIRE(q.wavelab_vst3_defer_activation == true);
+    REQUIRE(q.wavelab_state_blob_fallback == true);
+}
+
+TEST_CASE("make_quirks_for Wavelab 10 keeps activation-deferral OFF but state-blob fallback ON",
+          "[format][host-quirks][wavelab]") {
+    // Row 10 is documented as Wavelab 11+; row 11 is version-invariant.
+    auto q = make_quirks_for(HostType::Wavelab, HostVersion{10, 5});
+    REQUIRE(q.wavelab_vst3_defer_activation == false);
+    REQUIRE(q.wavelab_state_blob_fallback == true);
+}
+
+TEST_CASE("make_quirks_for Wavelab unknown version keeps state-blob fallback on, defer off",
+          "[format][host-quirks][wavelab]") {
+    // Version-invariant state-blob row fires even when version is
+    // undetected; activation-deferral stays off without 11+ evidence.
+    auto q = make_quirks_for(HostType::Wavelab, HostVersion{});
+    REQUIRE(q.wavelab_state_blob_fallback == true);
+    REQUIRE(q.wavelab_vst3_defer_activation == false);
+}

--- a/test/test_host_quirks.cpp
+++ b/test/test_host_quirks.cpp
@@ -92,3 +92,40 @@ TEST_CASE("Nuendo treats as Cubase for quirk purposes",
     auto q = make_quirks_for(HostType::Nuendo, HostVersion{13, 0});
     REQUIRE(q.cubase10_async_view_resize_queue == true);
 }
+
+// ── macOS plan items 5.2 / 5.3 — Cubase header extraction. The Cubase
+//    factory lives at `core/format/include/pulp/format/host_quirks/cubase.hpp`;
+//    these isolation tests pin that Cubase doesn't fire other hosts'
+//    flags, and that the version bands behave as documented. ──
+
+TEST_CASE("make_quirks_for Cubase 10 does not fire Live / Wavelab / Bitwig flags",
+          "[format][host-quirks][isolation]") {
+    auto q = make_quirks_for(HostType::Cubase, HostVersion{12, 0});
+    REQUIRE(q.cubase10_async_view_resize_queue == true);
+    // Live / Wavelab / Bitwig flags must stay default-false.
+    REQUIRE(q.live_vst3_canresize_ignore == false);
+    REQUIRE(q.live_vst3_windows_dpi_defer == false);
+    REQUIRE(q.wavelab_vst3_defer_activation == false);
+    REQUIRE(q.wavelab_state_blob_fallback == false);
+    REQUIRE(q.bitwig_vst3_linux_repaint_after_resize == false);
+}
+
+TEST_CASE("make_quirks_for Cubase 9 leaves Cubase 10 flags off",
+          "[format][host-quirks][isolation]") {
+    auto q = make_quirks_for(HostType::Cubase, HostVersion{9, 0});
+    REQUIRE(q.cubase9_state_blob_size_validation == true);
+    REQUIRE(q.cubase10_async_view_resize_queue == false);
+    REQUIRE(q.cubase10_param_gesture_ordering == false);
+    REQUIRE(q.cubase10_fractional_scale_correction == false);
+}
+
+TEST_CASE("make_quirks_for Cubase with unknown version stays defensive-default",
+          "[format][host-quirks][isolation]") {
+    // Unknown HostVersion (all zeros) — no version-keyed quirk should fire.
+    auto q = make_quirks_for(HostType::Cubase, HostVersion{});
+    REQUIRE(q.cubase10_async_view_resize_queue == false);
+    REQUIRE(q.cubase9_state_blob_size_validation == false);
+    // Cheap defenses still on.
+    REQUIRE(q.synthesize_bypass_parameter == true);
+    REQUIRE(q.clamp_latency_to_nonneg == true);
+}


### PR DESCRIPTION
## Summary

Ships the first wave of DAW host-quirk per-host extraction on top of the macOS plan Batch P scaffolding (#2833):

- **5.2 Cubase 10** — extracts `apply_cubase()` into `core/format/include/pulp/format/host_quirks/cubase.hpp`; rows 1/2/3 fire on `HostVersion >= 10.0`.
- **5.3 Cubase 9** — same header; row 4 (state-blob stream-size validation) fires on `9.0 <= HostVersion < 10.0` and stays OFF on Cubase 10+ (fixed upstream).
- **5.4 Ableton Live** — extracts `apply_ableton_live()` into `ableton_live.hpp`; rows 5 + 6 fire unconditionally (row 6 is a no-op off Windows at the adapter call site). VST2 row 7 stays in Pulp's Deferred-by-design list.
- **5.6 Wavelab** — new `HostType::Wavelab` (Steinberg sibling-but-not-Cubase), classifier alias, name-table entry, dispatch entry, plus `wavelab.hpp` with `apply_wavelab()`. Row 10 (`wavelab_vst3_defer_activation`) fires on `HostVersion >= 11.0`; row 11 (`wavelab_state_blob_fallback`) is version-invariant.

Each per-host header carries the **License-hygiene contract**: clean-room sourcing, vendor docs URL, and the macOS plan item ID as the reproducer in the `Reference-Lineage:` trailer of every commit under `core/format/host_quirks*`.

Bitwig (5.5) and FL Studio (5.7) are intentionally out of scope — they remain `🔜` in the tracker for follow-up PRs.

## Test plan

- [x] `pulp-test-host-quirks` — 65 assertions in 18 test cases (was 26 in 10) — covers per-host isolation (Cubase 10 doesn't bleed Live/Wavelab/Bitwig flags, etc.) + every Wavelab version band (11.1 / 12 / 10 / unknown).
- [x] `pulp-test-host-version` — 28 assertions in 5 test cases — unchanged behavior.
- [x] `pulp-test-diagnostic` — 139 assertions in 20 test cases — exercises the new `HostType::Wavelab` enum value through `host_type_name` / `host_supports_resize` / `host_supports_sidechain` / `host_type_from_process_name`.
- [x] Release no-GPU configure + build (`-DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF`) clean.
- [x] `planning/host-quirks-log.md` appended with 8 entries (3 Cubase 10 rows, 1 Cubase 9 row, 2 Live rows, 2 Wavelab rows).
- [x] `planning/2026-05-24-macos-plugin-authoring-plan.md` tracker rows 5.2 / 5.3 / 5.4 / 5.6 flipped to ✅.

Generated with [Claude Code](https://claude.com/claude-code)
