### PR TITLE
feat(format): host quirks — Bitwig, FL Studio, Logic AU, AU v3 cross-host, cross-format defaults (items 5.5/5.7/5.10/5.11/5.12)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.235.0
+    VERSION 0.236.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/host_quirks/auv3_cross_host.hpp
+++ b/core/format/include/pulp/format/host_quirks/auv3_cross_host.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+/// @file host_quirks/auv3_cross_host.hpp
+/// AU v3 cross-host quirks (macOS plan item 5.11).
+///
+/// DAW-quirks rows 21 + 22 — these are not specific to any single AU v3
+/// host; they're contract-level accommodations every AU v3 wrapper
+/// surface needs. The dispatch table layers this helper on top of the
+/// per-host helpers for any host that exposes an AU v3 plug-in surface
+/// (today: Logic Pro + GarageBand on macOS; the same flags also apply
+/// when Pulp's AU v3 plug-in extension runs as a child process of an
+/// iOS / macOS host that exposes the AU v3 wrapper surface — those
+/// hosts are currently reported as `HostType::Unknown` and the AU v3
+/// adapter is responsible for re-applying this helper when it detects
+/// the wrapper-provided host identifier at runtime).
+///
+///   * row 21: AU v3 expects the bypass parameter to be tracked on two
+///     surfaces — the plugin-provided bypass param and the platform's
+///     `AUValue` for `getShouldBypassEffect`. One-sided updates cause
+///     stale UI (if only the platform side updates) or stale audio (if
+///     only the plugin side updates). The AU v3 adapter must register a
+///     single bypass parameter that proxies both ways.
+///   * row 22: AU v3 plug-ins run in a sandboxed extension; the host
+///     executable name is not visible to the bundle. Host detection
+///     must consume the wrapper-provided host identifier (e.g.
+///     `AUHostingService`-reported value) instead of the executable-
+///     path heuristic. The flag tells the host-detection layer to
+///     prefer the wrapper-reported identifier when set.
+///
+/// Version handling: both rows are AU v3 contract behavior, not host-
+/// version-keyed. The helper fires both flags unconditionally for any
+/// host that exposes an AU v3 surface.
+///
+/// **Reference-Lineage**: cleanroom reproducer=macos-plan-item-5.11
+/// docs=https://developer.apple.com/documentation/audiotoolbox/auaudiounit
+
+#include <pulp/format/host_quirks.hpp>
+#include <pulp/format/host_version.hpp>
+
+namespace pulp::format::host_quirks {
+
+/// Populate AU v3 cross-host flags onto `q`. Layered on top of the
+/// per-host helper for any host with an AU v3 surface. Version-invariant
+/// — the flags reflect AU v3 contract requirements rather than per-host
+/// version bands.
+inline void apply_auv3_cross_host(HostQuirks& q, HostVersion /*v*/) {
+    // Row 21 — dual-track bypass (plugin param ↔ AU v3 platform AUValue).
+    q.au_v3_bypass_dual_tracking = true;
+    // Row 22 — prefer wrapper-reported host ID over executable-path
+    // heuristic at the host-detection layer.
+    q.au_v3_host_id_from_wrapper = true;
+}
+
+}  // namespace pulp::format::host_quirks

--- a/core/format/include/pulp/format/host_quirks/bitwig.hpp
+++ b/core/format/include/pulp/format/host_quirks/bitwig.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+/// @file host_quirks/bitwig.hpp
+/// Per-host quirks for Bitwig Studio (macOS plan item 5.5).
+///
+/// DAW-quirks rows 8 + 9 (VST3):
+///   * row 8: on Linux / BSD, Bitwig does not auto-invalidate after a
+///     host-initiated editor resize. The adapter must force a full-view
+///     `View::invalidate()` after `IPlugView::onSize()` returns so the
+///     plugin's UI actually repaints. **No-op off Linux** — the flag is
+///     set unconditionally because the Linux VST3 adapter is the only
+///     call site that consults it.
+///   * row 9: older Bitwig versions (< 6.0) call `setBusArrangements()`
+///     while the plugin is active, in violation of the VST3 spec. The
+///     adapter must treat that call as advisory — either silently ignore
+///     when the new arrangement matches the current one, or transparently
+///     deactivate / reconfigure / reactivate. Modern Bitwig (6.0+) honors
+///     the spec, so the workaround stays off there.
+///
+/// Version handling: row 8 is platform-keyed (Linux), not version-keyed,
+/// so it fires unconditionally and the adapter no-ops off Linux. Row 9
+/// only fires on `major < 6.0`. `HostVersion{0,0,0}` (unknown) is treated
+/// as legacy — the conservative workaround stays on so a misdetected
+/// older Bitwig still survives.
+///
+/// **Reference-Lineage**: cleanroom reproducer=macos-plan-item-5.5
+/// docs=https://www.bitwig.com/userguide/latest/
+
+#include <pulp/format/host_quirks.hpp>
+#include <pulp/format/host_version.hpp>
+
+namespace pulp::format::host_quirks {
+
+/// Populate Bitwig host-gated flags onto `q` based on `v`.
+inline void apply_bitwig(HostQuirks& q, HostVersion v) {
+    // Row 8 — Linux-only repaint workaround. No-op off Linux at the
+    // adapter call site; flag is unconditional here.
+    q.bitwig_vst3_linux_repaint_after_resize = true;
+    // Row 9 — setBusArrangements-while-active workaround. Fixed in
+    // Bitwig 6.0; conservative for unknown versions (treated as legacy).
+    if (v.is_before(6, 0)) {
+        q.bitwig_vst3_setbusarrangements_while_active = true;
+    }
+}
+
+}  // namespace pulp::format::host_quirks

--- a/core/format/include/pulp/format/host_quirks/fl_studio.hpp
+++ b/core/format/include/pulp/format/host_quirks/fl_studio.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+/// @file host_quirks/fl_studio.hpp
+/// Per-host quirks for Image-Line FL Studio (macOS plan item 5.7).
+///
+/// DAW-quirks rows 13 + 14 (VST3):
+///   * row 13: FL's Patcher routing layer violates the VST3 activation
+///     contract — it can call `process()` before `setActive(true)` and
+///     can call `setBusArrangements()` concurrently with `process()`.
+///     The adapter must wrap `setActive` / `process` / `setBusArrangements`
+///     in a mutex when FL Studio is detected to prevent state races and
+///     undefined-behavior overlap. Cheaper than diagnosing the data race
+///     after the fact.
+///   * row 14: FL's state-blob format diverges enough from reference VST3
+///     that the `MemoryStream`-shaped reader path fails outright. The
+///     adapter must skip that reader and fall through to a tolerant
+///     unknown-format reader so FL sessions deserialize cleanly.
+///
+/// Version handling: both quirks have been present across every FL
+/// Studio VST3 vintage Pulp encounters (the Patcher contract issue is
+/// architectural; the state-blob divergence predates the 20.x window
+/// and is still present). `apply_fl_studio` fires both flags regardless
+/// of `HostVersion`. If a future FL release fixes either, add an
+/// `is_before(major)` guard at that point.
+///
+/// **Reference-Lineage**: cleanroom reproducer=macos-plan-item-5.7
+/// docs=https://www.image-line.com/fl-studio-learning/fl-studio-online-manual/html/plugins/wrapper.htm
+
+#include <pulp/format/host_quirks.hpp>
+#include <pulp/format/host_version.hpp>
+
+namespace pulp::format::host_quirks {
+
+/// Populate FL Studio host-gated flags onto `q`. `v` is unused today
+/// (both rows are version-invariant) but kept for signature uniformity
+/// with other per-host modules.
+inline void apply_fl_studio(HostQuirks& q, HostVersion /*v*/) {
+    // Row 13 — mutex around setActive / process / setBusArrangements
+    // to survive FL Patcher's concurrent / out-of-order dispatch.
+    q.fl_studio_setactive_process_mutex = true;
+    // Row 14 — skip MemoryStream-shaped reader; fall through to a
+    // tolerant unknown-format reader for FL state blobs.
+    q.fl_studio_state_reader_skip = true;
+}
+
+}  // namespace pulp::format::host_quirks

--- a/core/format/include/pulp/format/host_quirks/logic_pro.hpp
+++ b/core/format/include/pulp/format/host_quirks/logic_pro.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+/// @file host_quirks/logic_pro.hpp
+/// Per-host quirks for Apple Logic Pro + GarageBand (macOS plan
+/// item 5.10).
+///
+/// DAW-quirks rows 19 + 20 (AU v1 / v2):
+///   * row 19: Logic hangs when the AU plugin probes for more than 8
+///     channels during channel-count enumeration. The AU v2 adapter
+///     hard-caps `maxChannelsToProbeFor` at 8 when Logic (or GarageBand,
+///     which inherits Logic's AU host stack) is detected; the default
+///     stays at 64 for other AU hosts.
+///   * row 20: `getTailLengthSeconds()` is documented as `NSTimeInterval`
+///     (seconds, wall-clock), not a pre-computed sample count. The AU
+///     v2 adapter keeps a cached sample rate fresh across
+///     `prepareToPlay` events and converts `Processor::tail_seconds()`
+///     into AU's expected wall-clock units on demand.
+///
+/// Version handling: both rows are present across every Logic /
+/// GarageBand vintage Pulp targets — the channel-probe hang has been
+/// observed from Logic 8 through Logic 11, and the tail-time unit
+/// convention is part of the AU v2 contract. `apply_logic_pro` fires
+/// both regardless of `HostVersion`. GarageBand is treated as Logic by
+/// the dispatch table (`make_quirks_for` maps `HostType::GarageBand`
+/// here) — same AU host stack, same accommodations.
+///
+/// **Reference-Lineage**: cleanroom reproducer=macos-plan-item-5.10
+/// docs=https://developer.apple.com/library/archive/documentation/MusicAudio/Conceptual/AudioUnitProgrammingGuide/Introduction/Introduction.html
+
+#include <pulp/format/host_quirks.hpp>
+#include <pulp/format/host_version.hpp>
+
+namespace pulp::format::host_quirks {
+
+/// Populate Logic Pro (and GarageBand-as-Logic) AU host-gated flags
+/// onto `q`. `v` is unused today (both rows are version-invariant) but
+/// kept for signature uniformity with other per-host modules.
+inline void apply_logic_pro(HostQuirks& q, HostVersion /*v*/) {
+    // Row 19 — Logic hangs above 8 probed channels. Hard-cap at 8.
+    q.logic_au_channel_probe_cap = 8;
+    // Row 20 — Tail-time samples-to-seconds conversion via cached
+    // sample rate (kept fresh in the AU v2 adapter's prepare path).
+    q.logic_au_tail_time_conversion = true;
+}
+
+}  // namespace pulp::format::host_quirks

--- a/core/format/src/host_quirks.cpp
+++ b/core/format/src/host_quirks.cpp
@@ -1,6 +1,7 @@
 #include <pulp/format/host_quirks.hpp>
 
 #include <pulp/format/host_quirks/ableton_live.hpp>
+#include <pulp/format/host_quirks/bitwig.hpp>
 #include <pulp/format/host_quirks/cubase.hpp>
 #include <pulp/format/host_quirks/wavelab.hpp>
 #include <pulp/format/host_version.hpp>
@@ -18,13 +19,6 @@ namespace {
 // header) must be backed by a host vendor doc + a reproducer Pulp
 // issue. See the catalog at
 // `planning/2026-05-24-daw-host-quirks-inheritance.md`.
-
-void apply_bitwig_quirks(HostQuirks& q, HostVersion v) {
-    q.bitwig_vst3_linux_repaint_after_resize = true; // No-op off Linux.
-    if (v.is_before(6, 0)) {
-        q.bitwig_vst3_setbusarrangements_while_active = true;
-    }
-}
 
 void apply_reaper_quirks(HostQuirks& q, HostVersion /*v*/) {
     q.reaper_vst3_gesture_ordering = true;
@@ -55,7 +49,7 @@ HostQuirks make_quirks_for(HostType type, HostVersion version) {
         case HostType::Nuendo:        host_quirks::apply_cubase(q, version); break;
         case HostType::AbletonLive:   host_quirks::apply_ableton_live(q, version); break;
         case HostType::Wavelab:       host_quirks::apply_wavelab(q, version); break;
-        case HostType::Bitwig:        apply_bitwig_quirks(q, version); break;
+        case HostType::Bitwig:        host_quirks::apply_bitwig(q, version); break;
         case HostType::Reaper:        apply_reaper_quirks(q, version); break;
         case HostType::LogicPro:
         case HostType::GarageBand:    apply_logic_pro_quirks(q, version); break;

--- a/core/format/src/host_quirks.cpp
+++ b/core/format/src/host_quirks.cpp
@@ -4,6 +4,7 @@
 #include <pulp/format/host_quirks/bitwig.hpp>
 #include <pulp/format/host_quirks/cubase.hpp>
 #include <pulp/format/host_quirks/fl_studio.hpp>
+#include <pulp/format/host_quirks/logic_pro.hpp>
 #include <pulp/format/host_quirks/wavelab.hpp>
 #include <pulp/format/host_version.hpp>
 
@@ -30,11 +31,6 @@ void apply_reaper_quirks(HostQuirks& q, HostVersion /*v*/) {
     q.reaper_midsession_setstate = true;
 }
 
-void apply_logic_pro_quirks(HostQuirks& q, HostVersion /*v*/) {
-    q.logic_au_channel_probe_cap = 8; // row 19 — Logic hangs above 8.
-    q.logic_au_tail_time_conversion = true;
-}
-
 void apply_pro_tools_quirks(HostQuirks& q, HostVersion /*v*/) {
     q.pro_tools_aax_sidechain_negotiation = true;
     q.pro_tools_aax_latency_callback_push = true;
@@ -54,7 +50,7 @@ HostQuirks make_quirks_for(HostType type, HostVersion version) {
         case HostType::FLStudio:      host_quirks::apply_fl_studio(q, version); break;
         case HostType::Reaper:        apply_reaper_quirks(q, version); break;
         case HostType::LogicPro:
-        case HostType::GarageBand:    apply_logic_pro_quirks(q, version); break;
+        case HostType::GarageBand:    host_quirks::apply_logic_pro(q, version); break;
         case HostType::ProTools:      apply_pro_tools_quirks(q, version); break;
         // StudioOne / DigitalPerformer / etc. land their flags here
         // when the per-host fixes ship in later batches.

--- a/core/format/src/host_quirks.cpp
+++ b/core/format/src/host_quirks.cpp
@@ -1,6 +1,7 @@
 #include <pulp/format/host_quirks.hpp>
 
 #include <pulp/format/host_quirks/ableton_live.hpp>
+#include <pulp/format/host_quirks/auv3_cross_host.hpp>
 #include <pulp/format/host_quirks/bitwig.hpp>
 #include <pulp/format/host_quirks/cubase.hpp>
 #include <pulp/format/host_quirks/fl_studio.hpp>
@@ -50,7 +51,15 @@ HostQuirks make_quirks_for(HostType type, HostVersion version) {
         case HostType::FLStudio:      host_quirks::apply_fl_studio(q, version); break;
         case HostType::Reaper:        apply_reaper_quirks(q, version); break;
         case HostType::LogicPro:
-        case HostType::GarageBand:    host_quirks::apply_logic_pro(q, version); break;
+        case HostType::GarageBand:
+            // Logic + GarageBand share the AU v2 host stack (rows 19,
+            // 20) and also expose an AU v3 surface (rows 21, 22). Apply
+            // the per-host Logic helper first, then layer the AU v3
+            // cross-host flags on top so adapters consulting either
+            // surface see consistent state.
+            host_quirks::apply_logic_pro(q, version);
+            host_quirks::apply_auv3_cross_host(q, version);
+            break;
         case HostType::ProTools:      apply_pro_tools_quirks(q, version); break;
         // StudioOne / DigitalPerformer / etc. land their flags here
         // when the per-host fixes ship in later batches.

--- a/core/format/src/host_quirks.cpp
+++ b/core/format/src/host_quirks.cpp
@@ -3,6 +3,7 @@
 #include <pulp/format/host_quirks/ableton_live.hpp>
 #include <pulp/format/host_quirks/bitwig.hpp>
 #include <pulp/format/host_quirks/cubase.hpp>
+#include <pulp/format/host_quirks/fl_studio.hpp>
 #include <pulp/format/host_quirks/wavelab.hpp>
 #include <pulp/format/host_version.hpp>
 
@@ -50,12 +51,13 @@ HostQuirks make_quirks_for(HostType type, HostVersion version) {
         case HostType::AbletonLive:   host_quirks::apply_ableton_live(q, version); break;
         case HostType::Wavelab:       host_quirks::apply_wavelab(q, version); break;
         case HostType::Bitwig:        host_quirks::apply_bitwig(q, version); break;
+        case HostType::FLStudio:      host_quirks::apply_fl_studio(q, version); break;
         case HostType::Reaper:        apply_reaper_quirks(q, version); break;
         case HostType::LogicPro:
         case HostType::GarageBand:    apply_logic_pro_quirks(q, version); break;
         case HostType::ProTools:      apply_pro_tools_quirks(q, version); break;
-        // FL Studio / StudioOne / DigitalPerformer / etc. land their
-        // flags here when the per-host fixes ship in batches L/N.
+        // StudioOne / DigitalPerformer / etc. land their flags here
+        // when the per-host fixes ship in later batches.
         default: break;
     }
     return q;

--- a/test/test_host_quirks.cpp
+++ b/test/test_host_quirks.cpp
@@ -242,3 +242,39 @@ TEST_CASE("make_quirks_for FL Studio leaves other hosts' flags off",
     REQUIRE(q.logic_au_channel_probe_cap == 64);
     REQUIRE(q.au_v3_bypass_dual_tracking == false);
 }
+
+// ── macOS plan item 5.10 — Logic Pro AU dispatch (DAW-quirks rows
+//    19 + 20). Factory extracted to
+//    `core/format/include/pulp/format/host_quirks/logic_pro.hpp`. ──
+
+TEST_CASE("make_quirks_for Logic Pro keeps channel cap + tail-time conversion on",
+          "[format][host-quirks][logic]") {
+    // Pre-existing "Logic caps channel probe at 8" already covers the
+    // happy path; this case pins that the extracted header keeps the
+    // same flags on across the modern Logic releases.
+    auto q = make_quirks_for(HostType::LogicPro, HostVersion{11, 0});
+    REQUIRE(q.logic_au_channel_probe_cap == 8);
+    REQUIRE(q.logic_au_tail_time_conversion == true);
+    auto modern = make_quirks_for(HostType::LogicPro, HostVersion{12, 0});
+    REQUIRE(modern.logic_au_channel_probe_cap == 8);
+    REQUIRE(modern.logic_au_tail_time_conversion == true);
+}
+
+TEST_CASE("make_quirks_for GarageBand inherits Logic AU quirks via shared header",
+          "[format][host-quirks][logic]") {
+    auto q = make_quirks_for(HostType::GarageBand, HostVersion{10, 4});
+    REQUIRE(q.logic_au_channel_probe_cap == 8);
+    REQUIRE(q.logic_au_tail_time_conversion == true);
+}
+
+TEST_CASE("make_quirks_for Logic Pro leaves other hosts' flags off",
+          "[format][host-quirks][logic][isolation]") {
+    auto q = make_quirks_for(HostType::LogicPro, HostVersion{11, 0});
+    REQUIRE(q.logic_au_channel_probe_cap == 8);
+    REQUIRE(q.cubase10_async_view_resize_queue == false);
+    REQUIRE(q.live_vst3_canresize_ignore == false);
+    REQUIRE(q.wavelab_state_blob_fallback == false);
+    REQUIRE(q.bitwig_vst3_linux_repaint_after_resize == false);
+    REQUIRE(q.fl_studio_setactive_process_mutex == false);
+    REQUIRE(q.reaper_process_while_bypassed == false);
+}

--- a/test/test_host_quirks.cpp
+++ b/test/test_host_quirks.cpp
@@ -182,3 +182,33 @@ TEST_CASE("make_quirks_for Wavelab unknown version keeps state-blob fallback on,
     REQUIRE(q.wavelab_state_blob_fallback == true);
     REQUIRE(q.wavelab_vst3_defer_activation == false);
 }
+
+// ── macOS plan item 5.5 — Bitwig dispatch (DAW-quirks rows 8 + 9).
+//    Factory extracted to `core/format/include/pulp/format/host_quirks/bitwig.hpp`. ──
+
+TEST_CASE("make_quirks_for Bitwig unknown version treats as legacy (workaround on)",
+          "[format][host-quirks][bitwig]") {
+    // HostVersion{} defaults to {0,0,0}, which is_before(6,0) → true,
+    // so the conservative workaround stays on for a misdetected older
+    // Bitwig. Linux-repaint flag is always on (no-op off Linux).
+    auto q = make_quirks_for(HostType::Bitwig, HostVersion{});
+    REQUIRE(q.bitwig_vst3_linux_repaint_after_resize == true);
+    REQUIRE(q.bitwig_vst3_setbusarrangements_while_active == true);
+}
+
+TEST_CASE("make_quirks_for Bitwig 6+ drops setBusArrangements workaround",
+          "[format][host-quirks][bitwig]") {
+    auto q = make_quirks_for(HostType::Bitwig, HostVersion{6, 5});
+    REQUIRE(q.bitwig_vst3_setbusarrangements_while_active == false);
+    REQUIRE(q.bitwig_vst3_linux_repaint_after_resize == true);
+}
+
+TEST_CASE("make_quirks_for Bitwig leaves Cubase / Live / FL flags off",
+          "[format][host-quirks][bitwig][isolation]") {
+    auto q = make_quirks_for(HostType::Bitwig, HostVersion{5, 2});
+    REQUIRE(q.bitwig_vst3_setbusarrangements_while_active == true);
+    REQUIRE(q.cubase10_async_view_resize_queue == false);
+    REQUIRE(q.live_vst3_canresize_ignore == false);
+    REQUIRE(q.fl_studio_setactive_process_mutex == false);
+    REQUIRE(q.logic_au_channel_probe_cap == 64);
+}

--- a/test/test_host_quirks.cpp
+++ b/test/test_host_quirks.cpp
@@ -278,3 +278,49 @@ TEST_CASE("make_quirks_for Logic Pro leaves other hosts' flags off",
     REQUIRE(q.fl_studio_setactive_process_mutex == false);
     REQUIRE(q.reaper_process_while_bypassed == false);
 }
+
+// ── macOS plan item 5.11 — AU v3 cross-host dispatch (DAW-quirks rows
+//    21 + 22). Helper at
+//    `core/format/include/pulp/format/host_quirks/auv3_cross_host.hpp`,
+//    layered on Logic + GarageBand which expose an AU v3 surface. ──
+
+TEST_CASE("make_quirks_for Logic Pro layers AU v3 cross-host flags on top",
+          "[format][host-quirks][auv3]") {
+    auto q = make_quirks_for(HostType::LogicPro, HostVersion{11, 0});
+    REQUIRE(q.au_v3_bypass_dual_tracking == true);
+    REQUIRE(q.au_v3_host_id_from_wrapper == true);
+    // Logic AU quirks still on (layering doesn't clobber the per-host
+    // flags).
+    REQUIRE(q.logic_au_channel_probe_cap == 8);
+    REQUIRE(q.logic_au_tail_time_conversion == true);
+}
+
+TEST_CASE("make_quirks_for GarageBand layers AU v3 cross-host flags on top",
+          "[format][host-quirks][auv3]") {
+    auto q = make_quirks_for(HostType::GarageBand, HostVersion{10, 4});
+    REQUIRE(q.au_v3_bypass_dual_tracking == true);
+    REQUIRE(q.au_v3_host_id_from_wrapper == true);
+}
+
+TEST_CASE("AU v3 cross-host flags stay off for non-AU-v3 hosts",
+          "[format][host-quirks][auv3][isolation]") {
+    auto cubase = make_quirks_for(HostType::Cubase, HostVersion{12, 0});
+    REQUIRE(cubase.au_v3_bypass_dual_tracking == false);
+    REQUIRE(cubase.au_v3_host_id_from_wrapper == false);
+
+    auto live = make_quirks_for(HostType::AbletonLive, HostVersion{12, 0});
+    REQUIRE(live.au_v3_bypass_dual_tracking == false);
+    REQUIRE(live.au_v3_host_id_from_wrapper == false);
+
+    auto bitwig = make_quirks_for(HostType::Bitwig, HostVersion{5, 0});
+    REQUIRE(bitwig.au_v3_bypass_dual_tracking == false);
+    REQUIRE(bitwig.au_v3_host_id_from_wrapper == false);
+
+    auto reaper = make_quirks_for(HostType::Reaper, HostVersion{7, 20});
+    REQUIRE(reaper.au_v3_bypass_dual_tracking == false);
+    REQUIRE(reaper.au_v3_host_id_from_wrapper == false);
+
+    auto fl = make_quirks_for(HostType::FLStudio, HostVersion{21, 0});
+    REQUIRE(fl.au_v3_bypass_dual_tracking == false);
+    REQUIRE(fl.au_v3_host_id_from_wrapper == false);
+}

--- a/test/test_host_quirks.cpp
+++ b/test/test_host_quirks.cpp
@@ -212,3 +212,33 @@ TEST_CASE("make_quirks_for Bitwig leaves Cubase / Live / FL flags off",
     REQUIRE(q.fl_studio_setactive_process_mutex == false);
     REQUIRE(q.logic_au_channel_probe_cap == 64);
 }
+
+// ── macOS plan item 5.7 — FL Studio dispatch (DAW-quirks rows 13 + 14).
+//    Factory at `core/format/include/pulp/format/host_quirks/fl_studio.hpp`. ──
+
+TEST_CASE("make_quirks_for FL Studio fires mutex + state-reader-skip flags",
+          "[format][host-quirks][fl-studio]") {
+    auto q = make_quirks_for(HostType::FLStudio, HostVersion{21, 0});
+    REQUIRE(q.fl_studio_setactive_process_mutex == true);
+    REQUIRE(q.fl_studio_state_reader_skip == true);
+}
+
+TEST_CASE("make_quirks_for FL Studio unknown version still fires both flags",
+          "[format][host-quirks][fl-studio]") {
+    // Both rows are version-invariant.
+    auto q = make_quirks_for(HostType::FLStudio, HostVersion{});
+    REQUIRE(q.fl_studio_setactive_process_mutex == true);
+    REQUIRE(q.fl_studio_state_reader_skip == true);
+}
+
+TEST_CASE("make_quirks_for FL Studio leaves other hosts' flags off",
+          "[format][host-quirks][fl-studio][isolation]") {
+    auto q = make_quirks_for(HostType::FLStudio, HostVersion{20, 9});
+    REQUIRE(q.fl_studio_setactive_process_mutex == true);
+    REQUIRE(q.cubase10_async_view_resize_queue == false);
+    REQUIRE(q.live_vst3_canresize_ignore == false);
+    REQUIRE(q.wavelab_state_blob_fallback == false);
+    REQUIRE(q.bitwig_vst3_linux_repaint_after_resize == false);
+    REQUIRE(q.logic_au_channel_probe_cap == 64);
+    REQUIRE(q.au_v3_bypass_dual_tracking == false);
+}

--- a/test/test_host_quirks.cpp
+++ b/test/test_host_quirks.cpp
@@ -1,5 +1,9 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/format/host_quirks.hpp>
+#include <pulp/format/host_type.hpp>
+
+#include <array>
+#include <utility>
 
 using namespace pulp::format;
 
@@ -323,4 +327,94 @@ TEST_CASE("AU v3 cross-host flags stay off for non-AU-v3 hosts",
     auto fl = make_quirks_for(HostType::FLStudio, HostVersion{21, 0});
     REQUIRE(fl.au_v3_bypass_dual_tracking == false);
     REQUIRE(fl.au_v3_host_id_from_wrapper == false);
+}
+
+// ── macOS plan item 5.12 — Cross-format defensive defaults (DAW-quirks
+//    rows 23-30). The cheap always-on defenses are seeded by the
+//    default-constructed `HostQuirks`; this group of tests pins that
+//    every host dispatch path (including the unknown / default lane)
+//    leaves them on, and that `detect_quirks()` preserves them too. ──
+
+TEST_CASE("cross-format defensive defaults are on for every host",
+          "[format][host-quirks][defaults]") {
+    // Sample one host per category — Cubase / Nuendo (version-keyed),
+    // Live + Wavelab (version-invariant), Bitwig (legacy with
+    // workaround), FL Studio (just-shipped lane), Logic + GarageBand
+    // (Apple AU lane with AU v3 layering), Reaper (workaround-heavy),
+    // Pro Tools (AAX lane), and Unknown / Standalone / Other (default
+    // lane). Every entry must keep the cheap defenses on.
+    const auto cases = std::array{
+        std::pair{HostType::Cubase,      HostVersion{12, 0}},
+        std::pair{HostType::Nuendo,      HostVersion{13, 0}},
+        std::pair{HostType::AbletonLive, HostVersion{11, 0}},
+        std::pair{HostType::Wavelab,     HostVersion{11, 1}},
+        std::pair{HostType::Bitwig,      HostVersion{5, 2}},
+        std::pair{HostType::FLStudio,    HostVersion{21, 0}},
+        std::pair{HostType::LogicPro,    HostVersion{11, 0}},
+        std::pair{HostType::GarageBand,  HostVersion{10, 4}},
+        std::pair{HostType::Reaper,      HostVersion{7, 20}},
+        std::pair{HostType::ProTools,    HostVersion{2024, 6}},
+        std::pair{HostType::Unknown,     HostVersion{}},
+        std::pair{HostType::Standalone,  HostVersion{}},
+        std::pair{HostType::Other,       HostVersion{}},
+    };
+    for (auto [host, version] : cases) {
+        auto q = make_quirks_for(host, version);
+        INFO("host=" << host_type_name(host)
+             << " version=" << version.major << "." << version.minor);
+        // Row 23 — bypass synthesis.
+        REQUIRE(q.synthesize_bypass_parameter == true);
+        // Row 24 — latency clamp to non-negative.
+        REQUIRE(q.clamp_latency_to_nonneg == true);
+        // Rows 25-26 — silence unsupported bus arrangements.
+        REQUIRE(q.silence_unsupported_bus_arrangements == true);
+    }
+}
+
+TEST_CASE("cross-format defensive defaults survive detect_quirks()",
+          "[format][host-quirks][defaults]") {
+    // detect_quirks() shells through detect_host_info() → the same
+    // make_quirks_for() pipeline. Cheap defenses must be on no matter
+    // which host (or no host) the runtime detects.
+    auto q = detect_quirks();
+    REQUIRE(q.synthesize_bypass_parameter == true);
+    REQUIRE(q.clamp_latency_to_nonneg == true);
+    REQUIRE(q.silence_unsupported_bus_arrangements == true);
+}
+
+TEST_CASE("cross-format defensive defaults are the only flags on for Unknown host",
+          "[format][host-quirks][defaults]") {
+    // The default lane must not flip any host-gated flag — only the
+    // cheap defenses should be on.
+    auto q = make_quirks_for(HostType::Unknown, HostVersion{});
+    // Cheap defenses on.
+    REQUIRE(q.synthesize_bypass_parameter == true);
+    REQUIRE(q.clamp_latency_to_nonneg == true);
+    REQUIRE(q.silence_unsupported_bus_arrangements == true);
+    // Every host-gated flag stays off.
+    REQUIRE(q.cubase10_async_view_resize_queue == false);
+    REQUIRE(q.cubase10_param_gesture_ordering == false);
+    REQUIRE(q.cubase10_fractional_scale_correction == false);
+    REQUIRE(q.cubase9_state_blob_size_validation == false);
+    REQUIRE(q.live_vst3_canresize_ignore == false);
+    REQUIRE(q.live_vst3_windows_dpi_defer == false);
+    REQUIRE(q.bitwig_vst3_linux_repaint_after_resize == false);
+    REQUIRE(q.bitwig_vst3_setbusarrangements_while_active == false);
+    REQUIRE(q.wavelab_vst3_defer_activation == false);
+    REQUIRE(q.wavelab_state_blob_fallback == false);
+    REQUIRE(q.fl_studio_setactive_process_mutex == false);
+    REQUIRE(q.fl_studio_state_reader_skip == false);
+    REQUIRE(q.reaper_vst3_gesture_ordering == false);
+    REQUIRE(q.reaper_process_while_bypassed == false);
+    REQUIRE(q.reaper_keyboard_passthrough == false);
+    REQUIRE(q.reaper_permissive_bus_arrangements == false);
+    REQUIRE(q.reaper_anticipative_fx_buffer_variability == false);
+    REQUIRE(q.reaper_midsession_setstate == false);
+    REQUIRE(q.pro_tools_aax_sidechain_negotiation == false);
+    REQUIRE(q.pro_tools_aax_latency_callback_push == false);
+    REQUIRE(q.pro_tools_aax_mono_second_bus == false);
+    REQUIRE(q.logic_au_channel_probe_cap == 64); // Default cap, not Logic's 8.
+    REQUIRE(q.logic_au_tail_time_conversion == false);
+    REQUIRE(q.au_v3_bypass_dual_tracking == false);
+    REQUIRE(q.au_v3_host_id_from_wrapper == false);
 }


### PR DESCRIPTION
## Summary

Batch 2 of the macOS plan's per-host quirk extraction (Batch P #2833 +
Batch from #2893 are the prior slices). Lands five items end-to-end:

- **5.5 Bitwig** — extract `apply_bitwig_quirks` inline helper into
  `core/format/include/pulp/format/host_quirks/bitwig.hpp`; same
  behavior (row 8 Linux-repaint always-on, row 9 setBusArrangements
  workaround for HostVersion < 6.0).
- **5.7 FL Studio** — new
  `core/format/include/pulp/format/host_quirks/fl_studio.hpp`; wires
  `HostType::FLStudio` into the dispatch; both flags
  (`fl_studio_setactive_process_mutex`, `fl_studio_state_reader_skip`)
  fire unconditionally (rows 13 + 14 are version-invariant).
- **5.10 Logic Pro AU** — extract `apply_logic_pro_quirks` into
  `core/format/include/pulp/format/host_quirks/logic_pro.hpp`; same
  behavior (row 19 channel-probe cap at 8, row 20 tail-time wall-
  clock conversion). GarageBand continues to share the dispatch case.
- **5.11 AU v3 cross-host** — new
  `core/format/include/pulp/format/host_quirks/auv3_cross_host.hpp`;
  layered on Logic + GarageBand by the dispatch (rows 21 + 22:
  bypass dual-tracking + wrapper-reported host ID).
- **5.12 Cross-format defensive defaults** — flag state was already
  correct from Batch P. Three new fixtures pin the contract: every
  host dispatch lane (incl. Unknown) leaves the cheap defenses on,
  `detect_quirks()` preserves them, and the Unknown lane doesn't bleed
  any host-gated flag.

## Test plan

- [x] `pulp-test-host-quirks` — 184 assertions in 33 test cases pass
  (was 65 in 18 before this PR).
- [x] `pulp-test-host-version` — 28 assertions in 5 test cases pass
  (unchanged).
- [x] No adapter wiring changes — flags are still flag-only; per-host
  adapter consumption is left to the format-adapter wiring batches per
  the macOS plan's phase ordering.
- [x] License-hygiene contract satisfied: every commit under
  `core/format/host_quirks*` includes a `Reference-Lineage: cleanroom
  reproducer=macos-plan-item-5.X docs=<host-vendor-url>` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)