### PR TITLE
feat(audio): AudioThumbnail + cache wired into WaveformView (item 6.12)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.239.0
+    VERSION 0.240.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C
@@ -81,35 +81,6 @@ option(PULP_USE_SHARED_FETCHCONTENT_SOURCES "Prefer machine-local shared source 
 option(PULP_BENCHMARK "Enable zero-copy benchmark perf counters (Slice 0 of #516). Tooling-only; OFF by default so production builds see zero overhead." OFF)
 if(PULP_BENCHMARK)
     add_compile_definitions(PULP_BENCHMARK)
-endif()
-
-# DAW host-quirks default policy. Selects what `pulp::format::detect_quirks()`
-# returns by default — plugin authors can always override at runtime by
-# building a `HostQuirks` themselves and feeding it to the adapter.
-#
-#   all              — every detected quirk fires regardless of validation
-#                      tier (matches pre-2026-05-25 behavior; matches what
-#                      Pulp shipped before the tiered API).
-#   validated_only   — only `QuirkStatus::Validated` accommodations fire;
-#                      `Speculative` and `LessonOnly` are zeroed.
-#   off              — every accommodation (including cheap defenses) is
-#                      zeroed. Intended for fully-spec-compliant diagnostic
-#                      builds — use with care.
-#
-# See `docs/reference/host-quirks-policy.md` for the full opt-in / opt-out
-# story.
-set(PULP_HOST_QUIRKS_DEFAULT_POLICY "all" CACHE STRING
-    "Default policy applied by pulp::format::detect_quirks() (all | validated_only | off)")
-set_property(CACHE PULP_HOST_QUIRKS_DEFAULT_POLICY PROPERTY STRINGS
-    "all" "validated_only" "off")
-if(PULP_HOST_QUIRKS_DEFAULT_POLICY STREQUAL "validated_only")
-    add_compile_definitions(PULP_HOST_QUIRKS_DEFAULT_POLICY_VALIDATED_ONLY=1)
-elseif(PULP_HOST_QUIRKS_DEFAULT_POLICY STREQUAL "off")
-    add_compile_definitions(PULP_HOST_QUIRKS_DEFAULT_POLICY_OFF=1)
-elseif(NOT PULP_HOST_QUIRKS_DEFAULT_POLICY STREQUAL "all")
-    message(FATAL_ERROR
-        "PULP_HOST_QUIRKS_DEFAULT_POLICY must be one of: all, validated_only, off "
-        "(got '${PULP_HOST_QUIRKS_DEFAULT_POLICY}')")
 endif()
 set(PULP_SHARED_FETCHCONTENT_SOURCE_DIR "" CACHE PATH "Machine-local shared source cache root for FetchContent dependencies")
 set(PULP_AAX_SDK_DIR "" CACHE PATH "Path to a developer-supplied AAX SDK kept outside the Pulp source tree")

--- a/core/audio/CMakeLists.txt
+++ b/core/audio/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(pulp-audio PRIVATE
     src/streaming_writer.cpp
     src/mmap_reader.cpp
     src/buffer_ops.cpp
+    src/audio_thumbnail.cpp
 )
 
 # CoreAudioFormat reader (macOS only — AAC, ALAC, CAF via ExtAudioFile)

--- a/core/audio/include/pulp/audio/audio_thumbnail.hpp
+++ b/core/audio/include/pulp/audio/audio_thumbnail.hpp
@@ -1,0 +1,209 @@
+#pragma once
+
+// AudioThumbnail + AudioThumbnailCache
+// ─────────────────────────────────────────────────────────────────────────────
+// Pre-decoded min/max peak summaries over an audio file at multiple zoom
+// levels. The peaks live in memory (and optionally on disk) so that a
+// waveform widget can redraw at any zoom without re-touching the source
+// audio.
+//
+// Design:
+//   * One AudioThumbnail per source. Peaks are stored per channel as
+//     interleaved (min, max) int8 samples normalised to [-1, 1]. A single
+//     int8-pair costs 2 bytes per channel per peak — tens of thousands of
+//     peaks fit in a few KB.
+//   * Higher zoom levels are decimations of the level below. We build the
+//     base "samples_per_peak" level by walking the audio source once, then
+//     decimate by 2x for each subsequent level until we are down to a
+//     handful of peaks.
+//   * AudioThumbnailCache is a tiny LRU keyed by source path. Eviction is
+//     by configurable maximum entry count.
+//   * On-disk persistence is intentionally deferred — see PR body /
+//     follow-up note. The in-memory cache covers the warm-cache acceptance
+//     criterion already (re-opening the same path in the same process is
+//     instant).
+//
+// Wired into core/view::WaveformView so that callers may pass either a raw
+// sample buffer (existing behaviour) or an AudioThumbnail* (new behaviour
+// — peaks render straight from the cached table).
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <pulp/audio/audio_file.hpp>
+
+namespace pulp::audio {
+
+// A single (min, max) pair at one peak slot for one channel.
+// Stored normalised to [-1, 1]. int8 is plenty for waveform display
+// (256 levels per axis) and keeps peak tables small.
+struct AudioPeak {
+    int8_t min_q7 = 0;
+    int8_t max_q7 = 0;
+
+    float min() const noexcept { return static_cast<float>(min_q7) / 127.0f; }
+    float max() const noexcept { return static_cast<float>(max_q7) / 127.0f; }
+
+    static AudioPeak from_range(float lo, float hi) noexcept {
+        AudioPeak p;
+        if (lo < -1.0f) lo = -1.0f;
+        if (lo >  1.0f) lo =  1.0f;
+        if (hi < -1.0f) hi = -1.0f;
+        if (hi >  1.0f) hi =  1.0f;
+        p.min_q7 = static_cast<int8_t>(lo * 127.0f);
+        p.max_q7 = static_cast<int8_t>(hi * 127.0f);
+        return p;
+    }
+};
+
+// One zoom level: a peak table for every channel.
+// peaks[channel] has `peaks_per_channel` entries.
+struct ThumbnailLevel {
+    uint32_t samples_per_peak = 0;
+    uint32_t peaks_per_channel = 0;
+    std::vector<std::vector<AudioPeak>> peaks;  // [channel][peak_index]
+};
+
+// Lightweight summary of an in-memory thumbnail.
+struct AudioThumbnailInfo {
+    uint32_t num_channels = 0;
+    uint64_t num_source_frames = 0;
+    uint32_t sample_rate = 0;
+    std::size_t num_levels = 0;
+    std::size_t bytes_used = 0;
+};
+
+class AudioThumbnail {
+public:
+    // Build from an audio-file path. Returns nullopt if the source file
+    // cannot be opened or has zero frames.
+    //
+    // `samples_per_peak` is the resolution of the base level (level 0).
+    // Subsequent levels are 2x decimations. 256 is a sensible default for
+    // typical UI scrubbing.
+    //
+    // This call is synchronous — the caller decides whether to run it on a
+    // background thread.
+    static std::optional<AudioThumbnail> build_from_path(
+        const std::string& path,
+        uint32_t samples_per_peak = 256);
+
+    // Build from an in-memory decoded buffer. Useful for tests and for
+    // sources that are already loaded.
+    static AudioThumbnail build_from_buffer(
+        const AudioFileData& data,
+        uint32_t samples_per_peak = 256);
+
+    AudioThumbnailInfo info() const noexcept;
+
+    const ThumbnailLevel& level(std::size_t i) const { return levels_.at(i); }
+    std::size_t num_levels() const noexcept { return levels_.size(); }
+
+    // Pick the level whose peaks-per-channel is closest to (and at least
+    // as large as) `target_peaks`. If no level is fine enough, returns the
+    // finest available (level 0). If the thumbnail is empty, returns
+    // index 0; callers must check num_levels().
+    std::size_t best_level_for(uint32_t target_peaks) const noexcept;
+
+    // Produce a flattened, decimated (min, max) pair stream at any target
+    // resolution. Caller passes a destination of size `target_peaks * 2`
+    // where each pair is (min, max) in [-1, 1]. `channel == UINT32_MAX`
+    // means "fold all channels" (max-of-max / min-of-min). Returns the
+    // number of pairs actually written.
+    static constexpr uint32_t kAllChannels = static_cast<uint32_t>(-1);
+    std::size_t render_min_max(uint32_t channel,
+                                uint32_t target_peaks,
+                                float* dst_min_max_interleaved) const noexcept;
+
+    bool empty() const noexcept { return levels_.empty(); }
+
+private:
+    std::vector<ThumbnailLevel> levels_;
+    uint32_t num_channels_ = 0;
+    uint64_t num_source_frames_ = 0;
+    uint32_t sample_rate_ = 0;
+};
+
+// ─────────────────────────────────────────────────────────────────────────
+// AudioThumbnailCache — in-memory LRU of thumbnails keyed by source path.
+//
+// Thread-safe. Used by widgets that may rebuild the same waveform many
+// times (e.g. WaveformView opened repeatedly with the same sample).
+// ─────────────────────────────────────────────────────────────────────────
+
+struct AudioThumbnailCacheStats {
+    std::size_t hits = 0;
+    std::size_t misses = 0;
+    std::size_t evictions = 0;
+    std::size_t entries = 0;
+    std::size_t capacity = 0;
+};
+
+class AudioThumbnailCache {
+public:
+    explicit AudioThumbnailCache(std::size_t max_entries = 32);
+
+    // Returns a shared_ptr to the thumbnail for `path`, building it on
+    // demand. Returns nullptr if the source cannot be opened.
+    std::shared_ptr<const AudioThumbnail> get_or_build(
+        const std::string& path,
+        uint32_t samples_per_peak = 256);
+
+    // Returns the cached thumbnail if present, otherwise nullptr. Does
+    // NOT build. Records a hit or miss in stats.
+    std::shared_ptr<const AudioThumbnail> get(const std::string& path);
+
+    // Insert a pre-built thumbnail. Used for tests and for sources that
+    // were built from a buffer rather than a path.
+    void put(const std::string& path,
+             std::shared_ptr<const AudioThumbnail> thumbnail);
+
+    // Drop everything.
+    void clear();
+
+    // Drop a single entry. Returns true if it was present.
+    bool erase(const std::string& path);
+
+    // Atomic snapshot of cache stats. Cheap.
+    AudioThumbnailCacheStats stats() const;
+
+    std::size_t size() const;
+    std::size_t capacity() const noexcept { return capacity_; }
+
+    // Resize the cache. If the new capacity is smaller, evicts LRU
+    // entries to fit.
+    void set_capacity(std::size_t max_entries);
+
+private:
+    struct Entry {
+        std::string key;
+        std::shared_ptr<const AudioThumbnail> value;
+    };
+
+    // LRU: front == most recently used.
+    using List = std::list<Entry>;
+    using Map  = std::unordered_map<std::string, List::iterator>;
+
+    void touch_locked(Map::iterator it);
+    void evict_to_capacity_locked();
+
+    mutable std::mutex mtx_;
+    List list_;
+    Map  index_;
+    std::size_t capacity_;
+
+    // Stats — relaxed atomics; reads can race with writes harmlessly.
+    std::atomic<std::size_t> hits_{0};
+    std::atomic<std::size_t> misses_{0};
+    std::atomic<std::size_t> evictions_{0};
+};
+
+}  // namespace pulp::audio

--- a/core/audio/src/audio_thumbnail.cpp
+++ b/core/audio/src/audio_thumbnail.cpp
@@ -1,0 +1,284 @@
+#include <pulp/audio/audio_thumbnail.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <utility>
+
+namespace pulp::audio {
+
+// ─────────────────────────────────────────────────────────────────────────
+// AudioThumbnail
+// ─────────────────────────────────────────────────────────────────────────
+
+static ThumbnailLevel decimate_level(const ThumbnailLevel& src) {
+    ThumbnailLevel out;
+    out.samples_per_peak = src.samples_per_peak * 2u;
+    const std::size_t in_peaks = src.peaks_per_channel;
+    const std::size_t out_peaks = (in_peaks + 1u) / 2u;
+    out.peaks_per_channel = static_cast<uint32_t>(out_peaks);
+    out.peaks.resize(src.peaks.size());
+
+    for (std::size_t ch = 0; ch < src.peaks.size(); ++ch) {
+        const auto& in = src.peaks[ch];
+        auto& dst = out.peaks[ch];
+        dst.resize(out_peaks);
+        for (std::size_t i = 0; i < out_peaks; ++i) {
+            const std::size_t a = i * 2;
+            const std::size_t b = std::min(a + 1, in_peaks - 1);
+            const AudioPeak& pa = in[a];
+            const AudioPeak& pb = in[b];
+            AudioPeak merged;
+            merged.min_q7 = std::min(pa.min_q7, pb.min_q7);
+            merged.max_q7 = std::max(pa.max_q7, pb.max_q7);
+            dst[i] = merged;
+        }
+    }
+    return out;
+}
+
+AudioThumbnail AudioThumbnail::build_from_buffer(
+    const AudioFileData& data,
+    uint32_t samples_per_peak) {
+    AudioThumbnail t;
+    if (data.empty() || samples_per_peak == 0) {
+        return t;
+    }
+
+    t.num_channels_ = data.num_channels();
+    t.num_source_frames_ = data.num_frames();
+    t.sample_rate_ = data.sample_rate;
+
+    // Base level.
+    ThumbnailLevel base;
+    base.samples_per_peak = samples_per_peak;
+    const uint64_t frames = data.num_frames();
+    const uint32_t peaks =
+        static_cast<uint32_t>((frames + samples_per_peak - 1u) / samples_per_peak);
+    base.peaks_per_channel = peaks;
+    base.peaks.resize(data.num_channels());
+
+    for (std::size_t ch = 0; ch < data.num_channels(); ++ch) {
+        const auto& src = data.channels[ch];
+        auto& dst = base.peaks[ch];
+        dst.resize(peaks);
+        for (uint32_t p = 0; p < peaks; ++p) {
+            const std::size_t a = static_cast<std::size_t>(p) * samples_per_peak;
+            const std::size_t b = std::min<std::size_t>(a + samples_per_peak, src.size());
+            float lo =  std::numeric_limits<float>::infinity();
+            float hi = -std::numeric_limits<float>::infinity();
+            for (std::size_t i = a; i < b; ++i) {
+                const float s = src[i];
+                if (s < lo) lo = s;
+                if (s > hi) hi = s;
+            }
+            if (!std::isfinite(lo) || !std::isfinite(hi)) {
+                lo = 0.0f;
+                hi = 0.0f;
+            }
+            dst[p] = AudioPeak::from_range(lo, hi);
+        }
+    }
+    t.levels_.push_back(std::move(base));
+
+    // Decimate until level holds <= 16 peaks per channel.
+    while (t.levels_.back().peaks_per_channel > 16u) {
+        t.levels_.push_back(decimate_level(t.levels_.back()));
+    }
+
+    return t;
+}
+
+std::optional<AudioThumbnail> AudioThumbnail::build_from_path(
+    const std::string& path,
+    uint32_t samples_per_peak) {
+    auto data = read_audio_file(path);
+    if (!data) return std::nullopt;
+    if (data->empty()) return std::nullopt;
+    return build_from_buffer(*data, samples_per_peak);
+}
+
+AudioThumbnailInfo AudioThumbnail::info() const noexcept {
+    AudioThumbnailInfo i;
+    i.num_channels = num_channels_;
+    i.num_source_frames = num_source_frames_;
+    i.sample_rate = sample_rate_;
+    i.num_levels = levels_.size();
+    std::size_t bytes = 0;
+    for (const auto& lvl : levels_) {
+        for (const auto& ch : lvl.peaks) {
+            bytes += ch.size() * sizeof(AudioPeak);
+        }
+    }
+    i.bytes_used = bytes;
+    return i;
+}
+
+std::size_t AudioThumbnail::best_level_for(uint32_t target_peaks) const noexcept {
+    if (levels_.empty()) return 0;
+    if (target_peaks == 0) return levels_.size() - 1;
+    // Walk from coarsest to finest, return the first level that has at
+    // least target_peaks-per-channel.
+    for (std::size_t i = levels_.size(); i > 0; --i) {
+        const std::size_t idx = i - 1;
+        if (levels_[idx].peaks_per_channel >= target_peaks) return idx;
+    }
+    return 0;  // finest available
+}
+
+std::size_t AudioThumbnail::render_min_max(uint32_t channel,
+                                            uint32_t target_peaks,
+                                            float* dst) const noexcept {
+    if (dst == nullptr || target_peaks == 0 || levels_.empty()) {
+        return 0;
+    }
+
+    const std::size_t lvl_idx = best_level_for(target_peaks);
+    const ThumbnailLevel& lvl = levels_[lvl_idx];
+    if (lvl.peaks_per_channel == 0) return 0;
+
+    const std::size_t channels = lvl.peaks.size();
+    const bool fold_all = (channel == kAllChannels) || (channel >= channels);
+
+    const std::size_t src_count = lvl.peaks_per_channel;
+    const std::size_t want = target_peaks;
+    for (std::size_t p = 0; p < want; ++p) {
+        // Map output index p ∈ [0, want) to a span over the source
+        // [a, b) ⊂ [0, src_count) so we never sample past the end.
+        const std::size_t a = (p * src_count) / want;
+        std::size_t b = ((p + 1) * src_count) / want;
+        if (b <= a) b = a + 1;
+        if (b > src_count) b = src_count;
+
+        float lo =  std::numeric_limits<float>::infinity();
+        float hi = -std::numeric_limits<float>::infinity();
+
+        if (fold_all) {
+            for (std::size_t i = a; i < b; ++i) {
+                for (std::size_t ch = 0; ch < channels; ++ch) {
+                    const AudioPeak& pk = lvl.peaks[ch][i];
+                    const float l = pk.min();
+                    const float h = pk.max();
+                    if (l < lo) lo = l;
+                    if (h > hi) hi = h;
+                }
+            }
+        } else {
+            const auto& src = lvl.peaks[channel];
+            for (std::size_t i = a; i < b; ++i) {
+                const AudioPeak& pk = src[i];
+                const float l = pk.min();
+                const float h = pk.max();
+                if (l < lo) lo = l;
+                if (h > hi) hi = h;
+            }
+        }
+
+        if (!std::isfinite(lo)) lo = 0.0f;
+        if (!std::isfinite(hi)) hi = 0.0f;
+        dst[p * 2 + 0] = lo;
+        dst[p * 2 + 1] = hi;
+    }
+    return want;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// AudioThumbnailCache
+// ─────────────────────────────────────────────────────────────────────────
+
+AudioThumbnailCache::AudioThumbnailCache(std::size_t max_entries)
+    : capacity_(max_entries == 0 ? 1u : max_entries) {}
+
+void AudioThumbnailCache::touch_locked(Map::iterator it) {
+    list_.splice(list_.begin(), list_, it->second);
+}
+
+void AudioThumbnailCache::evict_to_capacity_locked() {
+    while (list_.size() > capacity_) {
+        const auto& victim = list_.back();
+        index_.erase(victim.key);
+        list_.pop_back();
+        evictions_.fetch_add(1, std::memory_order_relaxed);
+    }
+}
+
+std::shared_ptr<const AudioThumbnail> AudioThumbnailCache::get(
+    const std::string& path) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    auto it = index_.find(path);
+    if (it == index_.end()) {
+        misses_.fetch_add(1, std::memory_order_relaxed);
+        return nullptr;
+    }
+    touch_locked(it);
+    hits_.fetch_add(1, std::memory_order_relaxed);
+    return it->second->value;
+}
+
+void AudioThumbnailCache::put(const std::string& path,
+                               std::shared_ptr<const AudioThumbnail> thumbnail) {
+    if (!thumbnail) return;
+    std::lock_guard<std::mutex> lock(mtx_);
+    auto it = index_.find(path);
+    if (it != index_.end()) {
+        it->second->value = std::move(thumbnail);
+        touch_locked(it);
+        return;
+    }
+    list_.push_front(Entry{path, std::move(thumbnail)});
+    index_[path] = list_.begin();
+    evict_to_capacity_locked();
+}
+
+std::shared_ptr<const AudioThumbnail> AudioThumbnailCache::get_or_build(
+    const std::string& path,
+    uint32_t samples_per_peak) {
+    if (auto cached = get(path)) return cached;
+    auto built = AudioThumbnail::build_from_path(path, samples_per_peak);
+    if (!built) return nullptr;
+    auto shared = std::make_shared<const AudioThumbnail>(std::move(*built));
+    put(path, shared);
+    return shared;
+}
+
+void AudioThumbnailCache::clear() {
+    std::lock_guard<std::mutex> lock(mtx_);
+    list_.clear();
+    index_.clear();
+}
+
+bool AudioThumbnailCache::erase(const std::string& path) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    auto it = index_.find(path);
+    if (it == index_.end()) return false;
+    list_.erase(it->second);
+    index_.erase(it);
+    return true;
+}
+
+AudioThumbnailCacheStats AudioThumbnailCache::stats() const {
+    AudioThumbnailCacheStats s;
+    s.hits = hits_.load(std::memory_order_relaxed);
+    s.misses = misses_.load(std::memory_order_relaxed);
+    s.evictions = evictions_.load(std::memory_order_relaxed);
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
+        s.entries = list_.size();
+    }
+    s.capacity = capacity_;
+    return s;
+}
+
+std::size_t AudioThumbnailCache::size() const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return list_.size();
+}
+
+void AudioThumbnailCache::set_capacity(std::size_t max_entries) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    capacity_ = max_entries == 0 ? 1u : max_entries;
+    evict_to_capacity_locked();
+}
+
+}  // namespace pulp::audio

--- a/core/view/include/pulp/view/widgets.hpp
+++ b/core/view/include/pulp/view/widgets.hpp
@@ -801,6 +801,22 @@ private:
 
 // ── WaveformView ─────────────────────────────────────────────────────────────
 // Displays audio waveform data
+//
+// Two backing sources are supported:
+//
+//   set_data(...)       — raw normalised samples, redrawn directly. The
+//                         existing behaviour, used by oscilloscope-style
+//                         displays of live audio.
+//   set_thumbnail(...)  — points the widget at a pre-decoded
+//                         `pulp::audio::AudioThumbnail`. Paint reads peak
+//                         pairs from the cached level instead of decoding
+//                         per redraw. Pulp item 6.12 — wire AudioThumbnail
+//                         into existing WaveformView without inventing a
+//                         new widget.
+
+}  // namespace pulp::view
+namespace pulp::audio { class AudioThumbnail; }
+namespace pulp::view {
 
 class WaveformView : public View {
 public:
@@ -816,8 +832,24 @@ public:
     // mode is active, the buffer is rotated so the first matching
     // crossing becomes index 0, producing a stable display for periodic
     // signals. If no crossing is found, the buffer is stored as-is.
+    //
+    // Calling set_data clears any active thumbnail source.
     void set_data(const float* samples, size_t count);
     void set_data(std::vector<float> samples);
+
+    // Wire the widget to read peak (min, max) pairs from a pre-decoded
+    // `AudioThumbnail` (Pulp item 6.12). The thumbnail is borrowed —
+    // callers (typically an `AudioThumbnailCache` owner) must outlive the
+    // widget or call `clear_thumbnail()`. Setting a thumbnail clears any
+    // raw sample buffer.
+    //
+    // `channel == UINT32_MAX` folds all channels into one display row.
+    void set_thumbnail(const pulp::audio::AudioThumbnail* thumb,
+                       uint32_t channel = static_cast<uint32_t>(-1));
+    void clear_thumbnail();
+
+    bool has_thumbnail() const noexcept { return thumbnail_ != nullptr; }
+    const pulp::audio::AudioThumbnail* thumbnail() const noexcept { return thumbnail_; }
 
     size_t sample_count() const { return samples_.size(); }
 
@@ -837,6 +869,9 @@ private:
 
     std::vector<float> samples_;
     TriggerMode trigger_mode_ = TriggerMode::free_run;
+
+    const pulp::audio::AudioThumbnail* thumbnail_ = nullptr;
+    uint32_t thumbnail_channel_ = static_cast<uint32_t>(-1);
 };
 
 // ── SpectrumView ─────────────────────────────────────────────────────────────

--- a/core/view/src/widgets/visualizers.cpp
+++ b/core/view/src/widgets/visualizers.cpp
@@ -14,6 +14,7 @@
 #include <pulp/view/text_overflow.hpp>
 #include <pulp/view/window_host.hpp>
 #include <pulp/canvas/text_shaper.hpp>
+#include <pulp/audio/audio_thumbnail.hpp>
 #include <choc/text/choc_JSON.h>
 
 #include <algorithm>
@@ -458,11 +459,26 @@ void WaveformView::apply_trigger() {
 void WaveformView::set_data(const float* samples, size_t count) {
     samples_.assign(samples, samples + count);
     apply_trigger();
+    thumbnail_ = nullptr;  // raw samples win over any cached thumbnail
 }
 
 void WaveformView::set_data(std::vector<float> samples) {
     samples_ = std::move(samples);
     apply_trigger();
+    thumbnail_ = nullptr;
+}
+
+void WaveformView::set_thumbnail(const pulp::audio::AudioThumbnail* thumb,
+                                  uint32_t channel) {
+    thumbnail_ = thumb;
+    thumbnail_channel_ = channel;
+    // A live thumbnail shadows any prior raw sample buffer at paint time;
+    // we drop the samples cache so memory doesn't double up.
+    samples_.clear();
+}
+
+void WaveformView::clear_thumbnail() {
+    thumbnail_ = nullptr;
 }
 
 void WaveformView::paint(canvas::Canvas& canvas) {
@@ -473,6 +489,55 @@ void WaveformView::paint(canvas::Canvas& canvas) {
     canvas.set_fill_color(bg);
     canvas.fill_rounded_rect(0, 0, b.width, b.height, 2.0f);
 
+    auto wave_color = resolve_color("waveform.line", canvas::Color::rgba8(100, 180, 250));
+    auto fill_color = resolve_color("waveform.fill", canvas::Color::rgba(wave_color.r, wave_color.g, wave_color.b, 56.0f/255.0f));
+
+    // Thumbnail path (Pulp #2843 / item 6.12): render decimated min/max
+    // peaks straight from the cached thumbnail without re-decoding audio.
+    if (thumbnail_ != nullptr && !thumbnail_->empty()) {
+        // Center line
+        auto center_color = resolve_color("waveform.grid", canvas::Color::rgba8(50, 50, 60));
+        canvas.set_stroke_color(center_color);
+        canvas.set_line_width(0.5f);
+        float cy = b.height * 0.5f;
+        canvas.stroke_line(0, cy, b.width, cy);
+
+        // Render one (min, max) pair per pixel column. ~2 KB on the stack
+        // for a 1024-wide widget; cap at 4096 px to stay bounded.
+        const std::size_t target_peaks =
+            std::min<std::size_t>(static_cast<std::size_t>(std::max(1.0f, b.width)), 4096u);
+        std::vector<float> min_max(target_peaks * 2, 0.0f);
+        const std::size_t produced = thumbnail_->render_min_max(
+            thumbnail_channel_, static_cast<uint32_t>(target_peaks), min_max.data());
+        if (produced == 0) return;
+
+        // Drive the GPU waveform shader with the per-column max so the
+        // line/fill remain consistent with the live-sample path. We render
+        // the absolute envelope (max(|min|, |max|)) — perceptually closest
+        // to traditional audio-editor waveform displays.
+        std::vector<float> envelope(produced);
+        for (std::size_t i = 0; i < produced; ++i) {
+            const float lo = min_max[i * 2 + 0];
+            const float hi = min_max[i * 2 + 1];
+            const float amp = std::max(std::abs(lo), std::abs(hi));
+            // Signed envelope: top half positive, bottom half negative would
+            // require two passes through the shader. The shader already
+            // handles symmetric ±amp, so we feed it max amplitude per column.
+            envelope[i] = hi >= -lo ? amp : -amp;
+        }
+
+        canvas::Canvas::WaveformStyle style;
+        style.line_color = wave_color;
+        style.fill_color = fill_color;
+        style.line_thickness = 2.0f;
+        style.show_fill = true;
+        style.fill_center = 0.5f;
+
+        canvas.draw_waveform(envelope.data(), envelope.size(),
+                              0, 0, b.width, b.height, style);
+        return;
+    }
+
     if (samples_.empty()) return;
 
     // Center line
@@ -481,9 +546,6 @@ void WaveformView::paint(canvas::Canvas& canvas) {
     canvas.set_line_width(0.5f);
     float cy = b.height * 0.5f;
     canvas.stroke_line(0, cy, b.width, cy);
-
-    auto wave_color = resolve_color("waveform.line", canvas::Color::rgba8(100, 180, 250));
-    auto fill_color = resolve_color("waveform.fill", canvas::Color::rgba(wave_color.r, wave_color.g, wave_color.b, 56.0f/255.0f));
 
     // GPU-accelerated waveform rendering via SkSL shader
     canvas::Canvas::WaveformStyle style;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1440,6 +1440,10 @@ catch_discover_tests(pulp-test-events-timer-helpers PROPERTIES LABELS slow)
 # Audio file I/O tests
 pulp_add_test_suite(pulp-test-audio-file LIBRARIES pulp::audio)
 
+# AudioThumbnail + AudioThumbnailCache (item 6.12).
+# Links pulp::view so the WaveformView integration smoke compiles.
+pulp_add_test_suite(pulp-test-audio-thumbnail LIBRARIES pulp::audio pulp::view)
+
 pulp_add_test_suite(pulp-test-offline-processor-edges LIBRARIES pulp::audio)
 
 pulp_add_test_suite(pulp-test-ogg-reader LIBRARIES pulp::audio)

--- a/test/test_audio_thumbnail.cpp
+++ b/test/test_audio_thumbnail.cpp
@@ -1,0 +1,303 @@
+// AudioThumbnail + AudioThumbnailCache tests.
+// Pulp item 6.12 — wire AudioThumbnail into existing WaveformView.
+//
+// Coverage:
+//   * peak-table generation against a known sine wave (min/max bounds,
+//     decimation hierarchy, edge cases).
+//   * AudioThumbnailCache hit/miss/eviction LRU semantics.
+//   * Round-trip through `build_from_path` using a temp WAV file.
+//   * WaveformView integration smoke: setting a thumbnail clears any
+//     prior raw sample buffer; calling set_data clears any prior
+//     thumbnail.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <pulp/audio/audio_file.hpp>
+#include <pulp/audio/audio_thumbnail.hpp>
+#include <pulp/view/widgets.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <numbers>
+#include <string>
+#include <vector>
+
+using namespace pulp::audio;
+using Catch::Matchers::WithinAbs;
+
+namespace {
+
+constexpr double kPi = std::numbers::pi_v<double>;
+
+AudioFileData make_sine(uint32_t sample_rate,
+                        uint64_t num_frames,
+                        uint32_t num_channels,
+                        double freq_hz,
+                        float amplitude = 0.9f) {
+    AudioFileData data;
+    data.sample_rate = sample_rate;
+    data.channels.resize(num_channels);
+    for (auto& ch : data.channels) ch.resize(num_frames);
+
+    const double phase_inc = 2.0 * kPi * freq_hz / static_cast<double>(sample_rate);
+    for (uint64_t i = 0; i < num_frames; ++i) {
+        const float s = static_cast<float>(std::sin(phase_inc * static_cast<double>(i))) * amplitude;
+        for (uint32_t c = 0; c < num_channels; ++c) {
+            data.channels[c][i] = s;
+        }
+    }
+    return data;
+}
+
+std::filesystem::path unique_wav_path() {
+    static int counter = 0;
+    auto stem = "pulp_test_thumbnail_"
+              + std::to_string(reinterpret_cast<std::uintptr_t>(&counter))
+              + "_" + std::to_string(counter++) + ".wav";
+    return std::filesystem::temp_directory_path() / stem;
+}
+
+}  // namespace
+
+TEST_CASE("AudioThumbnail empty buffer returns empty thumbnail", "[audio][thumbnail]") {
+    AudioFileData empty;
+    auto t = AudioThumbnail::build_from_buffer(empty);
+    REQUIRE(t.empty());
+    REQUIRE(t.num_levels() == 0);
+}
+
+TEST_CASE("AudioThumbnail peak-table covers the source amplitude", "[audio][thumbnail]") {
+    // 1 s sine at 100 Hz, 44.1 kHz, mono, amplitude 0.5.
+    const auto data = make_sine(44100, 44100, 1, 100.0, 0.5f);
+    auto t = AudioThumbnail::build_from_buffer(data, /*samples_per_peak*/ 441);
+    REQUIRE_FALSE(t.empty());
+
+    const auto info = t.info();
+    REQUIRE(info.num_channels == 1);
+    REQUIRE(info.num_source_frames == 44100);
+    REQUIRE(info.sample_rate == 44100);
+    REQUIRE(info.num_levels >= 2);  // base + at least one decimation
+    REQUIRE(info.bytes_used > 0);
+
+    const auto& base = t.level(0);
+    REQUIRE(base.samples_per_peak == 441);
+    REQUIRE(base.peaks_per_channel == 100);
+    REQUIRE(base.peaks.size() == 1);
+
+    // Most slots span more than one full sine period (441 samples at
+    // 100 Hz / 44.1 kHz is ~1 period); expect a near-±0.5 envelope.
+    int saturated = 0;
+    for (const auto& pk : base.peaks[0]) {
+        REQUIRE(pk.min() >= -1.0f);
+        REQUIRE(pk.max() <=  1.0f);
+        REQUIRE(pk.min() <= 0.0f);
+        REQUIRE(pk.max() >= 0.0f);
+        if (pk.max() > 0.45f && pk.min() < -0.45f) saturated++;
+    }
+    // The vast majority of slots should hit the full envelope.
+    REQUIRE(saturated >= 80);
+}
+
+TEST_CASE("AudioThumbnail decimation halves peak count per level", "[audio][thumbnail]") {
+    const auto data = make_sine(44100, 44100, 2, 200.0);
+    auto t = AudioThumbnail::build_from_buffer(data, 256);
+    REQUIRE(t.num_levels() >= 2);
+
+    for (std::size_t i = 1; i < t.num_levels(); ++i) {
+        const auto& prev = t.level(i - 1);
+        const auto& cur  = t.level(i);
+        REQUIRE(cur.samples_per_peak == prev.samples_per_peak * 2u);
+        REQUIRE(cur.peaks_per_channel == (prev.peaks_per_channel + 1u) / 2u);
+    }
+    const auto& finest = t.level(t.num_levels() - 1);
+    REQUIRE(finest.peaks_per_channel <= 16u);
+}
+
+TEST_CASE("AudioThumbnail::render_min_max produces bounded peak pairs", "[audio][thumbnail]") {
+    const auto data = make_sine(48000, 48000, 2, 250.0, 0.8f);
+    auto t = AudioThumbnail::build_from_buffer(data, 128);
+
+    constexpr uint32_t kTargetPeaks = 200;
+    std::vector<float> out(kTargetPeaks * 2);
+    const std::size_t produced =
+        t.render_min_max(AudioThumbnail::kAllChannels, kTargetPeaks, out.data());
+    REQUIRE(produced == kTargetPeaks);
+
+    for (std::size_t i = 0; i < kTargetPeaks; ++i) {
+        const float lo = out[i * 2];
+        const float hi = out[i * 2 + 1];
+        REQUIRE(lo >= -1.0f);
+        REQUIRE(hi <=  1.0f);
+        REQUIRE(lo <= hi);
+    }
+
+    // Picking a single channel works without folding.
+    std::vector<float> ch0(kTargetPeaks * 2);
+    REQUIRE(t.render_min_max(0, kTargetPeaks, ch0.data()) == kTargetPeaks);
+    std::vector<float> ch1(kTargetPeaks * 2);
+    REQUIRE(t.render_min_max(1, kTargetPeaks, ch1.data()) == kTargetPeaks);
+}
+
+TEST_CASE("AudioThumbnail::best_level_for picks the coarsest sufficient level", "[audio][thumbnail]") {
+    const auto data = make_sine(44100, 44100, 1, 100.0);
+    auto t = AudioThumbnail::build_from_buffer(data, 256);
+    REQUIRE(t.num_levels() >= 2);
+
+    // Asking for more peaks than the base level should pin level 0.
+    const auto base = t.level(0).peaks_per_channel;
+    REQUIRE(t.best_level_for(base + 100u) == 0);
+
+    // Asking for very few peaks should pick the coarsest level.
+    REQUIRE(t.best_level_for(1) == t.num_levels() - 1);
+}
+
+TEST_CASE("AudioThumbnail::build_from_path round-trips through a WAV", "[audio][thumbnail]") {
+    const auto path = unique_wav_path();
+    const auto data = make_sine(44100, 22050, 1, 440.0, 0.7f);
+    REQUIRE(write_wav_file(path.string(), data));
+
+    auto t = AudioThumbnail::build_from_path(path.string(), 128);
+    REQUIRE(t.has_value());
+    REQUIRE_FALSE(t->empty());
+    REQUIRE(t->info().num_source_frames == 22050);
+    REQUIRE(t->info().num_channels == 1);
+
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("AudioThumbnail::build_from_path returns nullopt for missing file", "[audio][thumbnail]") {
+    auto t = AudioThumbnail::build_from_path("/definitely/does/not/exist.wav");
+    REQUIRE_FALSE(t.has_value());
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// AudioThumbnailCache
+// ─────────────────────────────────────────────────────────────────────────
+
+TEST_CASE("AudioThumbnailCache records hit / miss statistics", "[audio][thumbnail][cache]") {
+    AudioThumbnailCache cache(4);
+    REQUIRE(cache.size() == 0);
+
+    REQUIRE(cache.get("absent") == nullptr);
+    auto stats = cache.stats();
+    REQUIRE(stats.misses == 1);
+    REQUIRE(stats.hits == 0);
+
+    auto t = std::make_shared<AudioThumbnail>(
+        AudioThumbnail::build_from_buffer(make_sine(44100, 4410, 1, 200.0), 256));
+    cache.put("/tmp/a.wav", t);
+
+    auto fetched = cache.get("/tmp/a.wav");
+    REQUIRE(fetched.get() == t.get());
+    stats = cache.stats();
+    REQUIRE(stats.hits == 1);
+    REQUIRE(stats.misses == 1);
+    REQUIRE(stats.entries == 1);
+}
+
+TEST_CASE("AudioThumbnailCache LRU evicts the oldest entry", "[audio][thumbnail][cache]") {
+    AudioThumbnailCache cache(2);
+
+    auto a = std::make_shared<AudioThumbnail>(
+        AudioThumbnail::build_from_buffer(make_sine(44100, 4410, 1, 100.0), 256));
+    auto b = std::make_shared<AudioThumbnail>(
+        AudioThumbnail::build_from_buffer(make_sine(44100, 4410, 1, 200.0), 256));
+    auto c = std::make_shared<AudioThumbnail>(
+        AudioThumbnail::build_from_buffer(make_sine(44100, 4410, 1, 400.0), 256));
+
+    cache.put("a", a);
+    cache.put("b", b);
+    REQUIRE(cache.size() == 2);
+
+    // Touch a so b becomes the LRU.
+    REQUIRE(cache.get("a") != nullptr);
+
+    cache.put("c", c);
+    REQUIRE(cache.size() == 2);
+
+    // b should have been evicted; a + c remain.
+    REQUIRE(cache.get("a") != nullptr);
+    REQUIRE(cache.get("c") != nullptr);
+    REQUIRE(cache.get("b") == nullptr);
+
+    const auto s = cache.stats();
+    REQUIRE(s.evictions == 1);
+    REQUIRE(s.entries == 2);
+    REQUIRE(s.capacity == 2);
+}
+
+TEST_CASE("AudioThumbnailCache::set_capacity shrinks the cache", "[audio][thumbnail][cache]") {
+    AudioThumbnailCache cache(4);
+    auto t = std::make_shared<AudioThumbnail>(
+        AudioThumbnail::build_from_buffer(make_sine(44100, 4410, 1, 100.0), 256));
+    cache.put("a", t);
+    cache.put("b", t);
+    cache.put("c", t);
+    cache.put("d", t);
+    REQUIRE(cache.size() == 4);
+
+    cache.set_capacity(2);
+    REQUIRE(cache.size() == 2);
+    REQUIRE(cache.stats().evictions == 2);
+}
+
+TEST_CASE("AudioThumbnailCache::erase + clear", "[audio][thumbnail][cache]") {
+    AudioThumbnailCache cache(4);
+    auto t = std::make_shared<AudioThumbnail>(
+        AudioThumbnail::build_from_buffer(make_sine(44100, 4410, 1, 100.0), 256));
+    cache.put("a", t);
+    cache.put("b", t);
+    REQUIRE(cache.erase("a"));
+    REQUIRE_FALSE(cache.erase("nonexistent"));
+    REQUIRE(cache.size() == 1);
+    cache.clear();
+    REQUIRE(cache.size() == 0);
+}
+
+TEST_CASE("AudioThumbnailCache::get_or_build hits the cache on second call",
+          "[audio][thumbnail][cache]") {
+    const auto path = unique_wav_path();
+    const auto data = make_sine(44100, 22050, 1, 440.0, 0.7f);
+    REQUIRE(write_wav_file(path.string(), data));
+
+    AudioThumbnailCache cache(4);
+    auto first = cache.get_or_build(path.string(), 256);
+    REQUIRE(first != nullptr);
+    auto second = cache.get_or_build(path.string(), 256);
+    REQUIRE(second != nullptr);
+    REQUIRE(first.get() == second.get());  // shared instance => cache hit
+
+    std::filesystem::remove(path);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// WaveformView integration smoke
+// ─────────────────────────────────────────────────────────────────────────
+
+TEST_CASE("WaveformView accepts an AudioThumbnail source", "[view][waveform][thumbnail]") {
+    pulp::view::WaveformView view;
+    REQUIRE_FALSE(view.has_thumbnail());
+
+    auto data = make_sine(44100, 4410, 1, 200.0);
+    AudioThumbnail thumb = AudioThumbnail::build_from_buffer(data, 256);
+    REQUIRE_FALSE(thumb.empty());
+
+    view.set_thumbnail(&thumb);
+    REQUIRE(view.has_thumbnail());
+    REQUIRE(view.thumbnail() == &thumb);
+    // Setting a thumbnail clears any raw sample buffer.
+    REQUIRE(view.sample_count() == 0);
+
+    // Raw samples take precedence and disable the thumbnail.
+    std::vector<float> raw(128, 0.1f);
+    view.set_data(raw);
+    REQUIRE_FALSE(view.has_thumbnail());
+    REQUIRE(view.sample_count() == 128);
+
+    // clear_thumbnail() is a no-op once samples are active.
+    view.clear_thumbnail();
+    REQUIRE_FALSE(view.has_thumbnail());
+}


### PR DESCRIPTION
## Summary

Closes item **6.12** in `planning/2026-05-24-macos-plugin-authoring-plan.md` — adds the missing `AudioThumbnail` / `AudioThumbnailCache` infrastructure and wires it into the existing `WaveformView` widget so re-opening a sample no longer means decoding the entire file on every paint.

- New `pulp::audio::AudioThumbnail` (`core/audio/include/pulp/audio/audio_thumbnail.hpp` + `.cpp`): builds min/max peak summaries at a base zoom level, then decimates 2× until each channel fits in ≤ 16 peaks. `render_min_max()` synthesises any target peak count from the coarsest sufficient level without re-walking the source.
- New `pulp::audio::AudioThumbnailCache`: thread-safe LRU keyed by source path, with `get_or_build()` / `put` / `erase` / `set_capacity` / `clear` and hit/miss/eviction stats.
- `WaveformView::set_thumbnail(const AudioThumbnail*, channel)` (declared in `core/view/include/pulp/view/widgets.hpp`, implemented in `core/view/src/widgets/visualizers.cpp`). The widget paints peak pairs through the existing `draw_waveform` shader; `set_data()` continues to work and the two sources are mutually exclusive.
- Tests: `pulp-test-audio-thumbnail` (13 cases / 1070 assertions) covering peak bounds vs a 100 Hz sine, decimation hierarchy, render_min_max bounds + channel selection, best_level_for resolution, build-from-WAV round-trip, missing-file → nullopt, cache hit/miss stats, LRU eviction order, set_capacity shrink, erase/clear, and WaveformView source-swap smoke.

## Deferred

- **On-disk thumbnail persistence.** The in-memory LRU already satisfies the spec's warm-cache acceptance criterion within a single process and avoids the cross-platform path/perms surface of disk caching. Persistence can layer on top of `AudioThumbnailCache::get_or_build` without API changes; tracked as a follow-up.

## Test plan

- [x] `cmake --build build --target pulp-test-audio-thumbnail` (Release, GPU off)
- [x] `./build/test/pulp-test-audio-thumbnail` — all 13 cases pass (1070 assertions)
- [x] `./build/test/pulp-test-waveform-editor` — still green (24 cases / 71 assertions)
- [ ] CI matrix