### PR TITLE
test(scan-worker): cover JSON worker edge contracts

### DIFF
--- a/tools/scan-worker/test_scan_worker.cpp
+++ b/tools/scan-worker/test_scan_worker.cpp
@@ -48,6 +48,25 @@ void write_file(const fs::path& path, const std::string& body) {
     out << body;
 }
 
+std::string json_escaped(std::string text) {
+    std::string escaped;
+    for (unsigned char c : text) {
+        switch (c) {
+            case '"': escaped += "\\\""; break;
+            case '\\': escaped += "\\\\"; break;
+            case '\n': escaped += "\\n"; break;
+            case '\r': escaped += "\\r"; break;
+            case '\t': escaped += "\\t"; break;
+            default: escaped += static_cast<char>(c); break;
+        }
+    }
+    return escaped;
+}
+
+std::string json_field(const std::string& key, const std::string& value) {
+    return "\"" + key + "\":\"" + json_escaped(value) + "\"";
+}
+
 pulp::platform::ProcessResult run_worker(const std::vector<std::string>& args) {
     return pulp::platform::exec(PULP_SCAN_WORKER_PATH, args, 5000);
 }
@@ -59,6 +78,7 @@ TEST_CASE("pulp-scan-worker reports usage when bundle path is missing",
     auto result = run_worker({});
     REQUIRE(result.exit_code == 2);
     REQUIRE_THAT(result.stderr_output, ContainsSubstring("usage: pulp-scan-worker"));
+    REQUIRE(result.stdout_output.empty());
 }
 
 TEST_CASE("pulp-scan-worker rejects unsupported bundle extensions",
@@ -70,6 +90,7 @@ TEST_CASE("pulp-scan-worker rejects unsupported bundle extensions",
     auto result = run_worker({path.string()});
     REQUIRE(result.exit_code == 3);
     REQUIRE_THAT(result.stderr_output, ContainsSubstring("unsupported bundle extension"));
+    REQUIRE(result.stdout_output.empty());
 }
 
 TEST_CASE("pulp-scan-worker emits JSON for a manifest-free VST3 bundle",
@@ -83,7 +104,7 @@ TEST_CASE("pulp-scan-worker emits JSON for a manifest-free VST3 bundle",
     REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"name\":\"Probe\""));
     REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"unique_id\":\"Probe\""));
     REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"format\":\"vst3\""));
-    REQUIRE_THAT(result.stdout_output, ContainsSubstring(bundle.string()));
+    REQUIRE_THAT(result.stdout_output, ContainsSubstring(json_field("path", bundle.string())));
 }
 
 TEST_CASE("pulp-scan-worker reports VST3 moduleinfo identity and booleans",
@@ -113,7 +134,7 @@ TEST_CASE("pulp-scan-worker reports VST3 moduleinfo identity and booleans",
     REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"is_instrument\":false"));
     REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"is_effect\":true"));
     REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"format\":\"vst3\""));
-    REQUIRE_THAT(result.stdout_output, ContainsSubstring(bundle.string()));
+    REQUIRE_THAT(result.stdout_output, ContainsSubstring(json_field("path", bundle.string())));
 }
 
 TEST_CASE("pulp-scan-worker filters sibling bundles from the same directory",
@@ -131,9 +152,9 @@ TEST_CASE("pulp-scan-worker filters sibling bundles from the same directory",
     REQUIRE(result.stdout_output.find('\n') == result.stdout_output.size() - 1);
     REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"name\":\"Target\""));
     REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"unique_id\":\"Target\""));
-    REQUIRE_THAT(result.stdout_output, ContainsSubstring(target.string()));
+    REQUIRE_THAT(result.stdout_output, ContainsSubstring(json_field("path", target.string())));
     REQUIRE(result.stdout_output.find("Sibling") == std::string::npos);
-    REQUIRE(result.stdout_output.find(sibling.string()) == std::string::npos);
+    REQUIRE(result.stdout_output.find(json_escaped(sibling.string())) == std::string::npos);
 }
 
 TEST_CASE("pulp-scan-worker emits fallback JSON for unreadable CLAP bundles",
@@ -152,14 +173,11 @@ TEST_CASE("pulp-scan-worker emits fallback JSON for unreadable CLAP bundles",
     REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"format\":\"clap\""));
     REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"is_instrument\":false"));
     REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"is_effect\":true"));
-    REQUIRE_THAT(result.stdout_output, ContainsSubstring(bundle.string()));
+    REQUIRE_THAT(result.stdout_output, ContainsSubstring(json_field("path", bundle.string())));
 }
 
 TEST_CASE("pulp-scan-worker preserves fallback JSON fields for spaced CLAP paths",
           "[host][scan-worker][coverage][phase3]") {
-#ifdef _WIN32
-    SUCCEED("Windows path normalization is covered by the generic CLAP fallback case");
-#else
     ScratchDir scratch("spaced-clap");
     auto bundle = scratch.path / "Space Name.clap";
     write_file(bundle, "not a dynamic library");
@@ -171,8 +189,83 @@ TEST_CASE("pulp-scan-worker preserves fallback JSON fields for spaced CLAP paths
     REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"unique_id\":\"Space Name\""));
     REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"format\":\"clap\""));
     REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"path\":\""));
-    REQUIRE_THAT(result.stdout_output, ContainsSubstring("Space Name.clap"));
+    REQUIRE_THAT(result.stdout_output, ContainsSubstring(json_field("path", bundle.string())));
     REQUIRE(result.stdout_output.find("Space%20Name") == std::string::npos);
     REQUIRE(result.stdout_output.back() == '\n');
-#endif
+}
+
+TEST_CASE("pulp-scan-worker rejects known but unsupported plugin suffixes",
+          "[host][scan-worker][coverage]") {
+    ScratchDir scratch("unsupported-formats");
+    auto component = scratch.path / "Legacy.component";
+    auto lv2 = scratch.path / "Graph.lv2";
+    fs::create_directories(component / "Contents" / "MacOS");
+    fs::create_directories(lv2);
+
+    auto component_result = run_worker({component.string()});
+    REQUIRE(component_result.exit_code == 3);
+    REQUIRE_THAT(component_result.stderr_output,
+                 ContainsSubstring("unsupported bundle extension"));
+    REQUIRE_THAT(component_result.stderr_output, ContainsSubstring("Legacy.component"));
+    REQUIRE(component_result.stdout_output.empty());
+
+    auto lv2_result = run_worker({lv2.string()});
+    REQUIRE(lv2_result.exit_code == 3);
+    REQUIRE_THAT(lv2_result.stderr_output, ContainsSubstring("Graph.lv2"));
+    REQUIRE(lv2_result.stdout_output.empty());
+}
+
+TEST_CASE("pulp-scan-worker falls back cleanly for malformed VST3 moduleinfo",
+          "[host][scan-worker][coverage]") {
+    ScratchDir scratch("bad-vst3-moduleinfo");
+    auto bundle = scratch.path / "Bad Metadata.vst3";
+    fs::create_directories(bundle / "Contents" / "Resources");
+    write_file(bundle / "Contents" / "Resources" / "moduleinfo.json",
+               R"({"Classes":[{"Category":"Audio Module Class","CID":"not-a-cid"}]})");
+
+    auto result = run_worker({bundle.string()});
+    REQUIRE(result.exit_code == 0);
+    REQUIRE_FALSE(result.stdout_output.empty());
+    REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"name\":\"Bad Metadata\""));
+    REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"unique_id\":\"Bad Metadata\""));
+    REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"format\":\"vst3\""));
+    REQUIRE_THAT(result.stdout_output, ContainsSubstring(json_field("path", bundle.string())));
+    REQUIRE(result.stdout_output.find("not-a-cid") == std::string::npos);
+    REQUIRE(result.stdout_output.back() == '\n');
+}
+
+TEST_CASE("pulp-scan-worker keeps CLAP fallback JSON scoped to the requested bundle",
+          "[host][scan-worker][coverage]") {
+    ScratchDir scratch("clap-siblings");
+    auto target = scratch.path / "Target Clap.clap";
+    auto sibling = scratch.path / "Sibling Clap.clap";
+    write_file(target, "not a dynamic library");
+    write_file(sibling, "not a dynamic library");
+
+    auto result = run_worker({target.string()});
+    REQUIRE(result.exit_code == 0);
+    REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"name\":\"Target Clap\""));
+    REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"unique_id\":\"Target Clap\""));
+    REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"format\":\"clap\""));
+    REQUIRE_THAT(result.stdout_output, ContainsSubstring(json_field("path", target.string())));
+    REQUIRE(result.stdout_output.find("Sibling Clap") == std::string::npos);
+    REQUIRE(result.stdout_output.find(json_escaped(sibling.string())) == std::string::npos);
+}
+
+TEST_CASE("pulp-scan-worker reports one JSON object per target scan",
+          "[host][scan-worker][coverage]") {
+    ScratchDir scratch("single-object");
+    auto bundle = scratch.path / "Single.vst3";
+    fs::create_directories(bundle / "Contents" / "Resources");
+
+    auto result = run_worker({bundle.string()});
+    REQUIRE(result.exit_code == 0);
+    REQUIRE_FALSE(result.stdout_output.empty());
+    REQUIRE(result.stdout_output.front() == '{');
+    REQUIRE(result.stdout_output.back() == '\n');
+    const auto closing_brace = result.stdout_output.find_last_of('}');
+    REQUIRE(closing_brace != std::string::npos);
+    REQUIRE(result.stdout_output.find_first_not_of("\r\n", closing_brace + 1)
+            == std::string::npos);
+    REQUIRE(result.stdout_output.find("\n{") == std::string::npos);
 }


### PR DESCRIPTION
## Summary
- Expands `tools/scan-worker/` coverage around JSON worker contracts, including unsupported suffixes, malformed VST3 moduleinfo fallback, CLAP fallback scope, and single-object output.
- Hardens existing assertions to check JSON-escaped paths, which keeps the tests meaningful on Windows path separators instead of matching raw filesystem strings.
- Keeps the batch scoped to one requested low-coverage area.

## Coverage Batch
- Batch size: 36 meaningful assertions/checks.
- Requested area coverage: `tools/scan-worker/`.
- Branch rebased on latest `origin/main` before submission.

## Validation
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/skill_sync_check.py`
- `python3 tools/scripts/version_bump_check.py --mode=report --accept-intent-trailers`
- Submitted through `shipyard pr --no-apply-bumps --skip-target ubuntu --skip-target windows` because the configured local Ubuntu SSH target is down and local Windows/Ubuntu SSH validation was explicitly skipped for this effort.
