### PR TITLE
feat(audio): WAV metadata round-trip (BWAV/iXML/ASWG/ACID) — item 6.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.240.0
+    VERSION 0.241.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/audio/CMakeLists.txt
+++ b/core/audio/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(pulp-audio PRIVATE
     src/mmap_reader.cpp
     src/buffer_ops.cpp
     src/audio_thumbnail.cpp
+    src/wav_metadata.cpp
 )
 
 # CoreAudioFormat reader (macOS only — AAC, ALAC, CAF via ExtAudioFile)

--- a/core/audio/include/pulp/audio/wav_metadata.hpp
+++ b/core/audio/include/pulp/audio/wav_metadata.hpp
@@ -1,0 +1,127 @@
+// wav_metadata.hpp — read + write WAV ancillary metadata chunks.
+//
+// Implements item 6.11 of the 2026-05-24 macOS plugin authoring plan
+// (BWAV / iXML / ASWG / ACID). Reads metadata from any RIFF-WAVE or
+// RF64-extended WAV file, lets you mutate it in-memory, then writes it
+// back without rewriting the audio payload (the original `fmt ` and
+// `data` chunks are preserved verbatim).
+//
+// Why a hand-rolled chunk codec on top of CHOC: CHOC's WAV reader
+// gives us PCM samples but only surfaces a small subset of metadata
+// (bext fields as a string map, no iXML/axml/acid). We need exact,
+// reversible byte-level access to the named chunks so production-audio
+// metadata round-trips losslessly through Pulp tooling.
+//
+// Chunks supported (canonical four-CCs in parens):
+//   • bext  — EBU R 128 / EBU Tech 3285 "Broadcast Wave Format" extension.
+//   • iXML  — Gallery iXML production-metadata XML chunk.
+//   • axml  — ASWG / EBU 3285s5 generic XML metadata chunk (often
+//             called "ASWG" by field-recorder makers).
+//   • acid  — Sony ACIDized-loop info chunk (tempo / root note / loop
+//             markers, used by ACID, Ableton Live, FL Studio, etc.).
+//
+// Unknown chunks present in the source file are preserved on write so
+// `replace_metadata_in_file()` only touches the four supported chunk
+// kinds.
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace pulp::audio {
+
+// ── Broadcast Wave Format (bext) ────────────────────────────────────────────
+//
+// EBU Tech 3285 v2 layout. Field sizes are fixed by the spec; we model
+// the strings as `std::string` for ergonomic round-trip but they are
+// padded / truncated to the exact byte counts during encoding.
+struct BwavMetadata {
+    std::string description;          // 256 bytes
+    std::string originator;           // 32 bytes
+    std::string originator_reference; // 32 bytes
+    std::string origination_date;     // 10 bytes "YYYY-MM-DD"
+    std::string origination_time;     // 8 bytes "HH:MM:SS"
+    uint64_t time_reference = 0;      // samples since midnight (low+high u32)
+    uint16_t version = 1;             // bext version (1 or 2)
+    std::array<uint8_t, 64> umid{};   // SMPTE 330M UMID (zero by default)
+    int16_t loudness_value = 0;       // 1/100 LUFS (bext v2 only)
+    int16_t loudness_range = 0;       // 1/100 LU
+    int16_t max_true_peak_level = 0;  // 1/100 dBTP
+    int16_t max_momentary_loudness = 0;
+    int16_t max_short_term_loudness = 0;
+    std::string coding_history;       // free-form ASCII (variable length)
+};
+
+// ── ACID loop info (acid) ───────────────────────────────────────────────────
+//
+// Sony ACIDized-loop chunk, 24 bytes total. `flags` bit semantics:
+//   0x01  one-shot (no loop)
+//   0x02  root note set
+//   0x04  stretch
+//   0x08  disk-based
+//   0x10  ACIDizer (the file claims its metadata is authoritative)
+struct AcidMetadata {
+    uint32_t flags = 0;
+    uint16_t root_note = 60;          // MIDI note number; only valid when flags & 0x02
+    uint16_t reserved1 = 0;
+    float reserved2 = 0.0f;
+    uint32_t num_beats = 0;
+    uint16_t meter_denominator = 4;   // bottom of time signature (2,4,8,16)
+    uint16_t meter_numerator = 4;     // top of time signature
+    float tempo_bpm = 0.0f;
+};
+
+// ── Aggregate ───────────────────────────────────────────────────────────────
+//
+// Each metadata kind is optional. Unset = chunk not present (read) or
+// will not be written (write). `unknown_chunks` lets `replace_metadata_in_file`
+// preserve every other RIFF chunk verbatim.
+struct WavMetadata {
+    std::optional<BwavMetadata> bwav;
+    std::optional<AcidMetadata> acid;
+    std::optional<std::string> ixml;  // raw XML payload (UTF-8)
+    std::optional<std::string> axml;  // raw XML payload (ASWG)
+
+    struct UnknownChunk {
+        std::array<char, 4> id{};
+        std::vector<uint8_t> data;
+    };
+    std::vector<UnknownChunk> unknown_chunks; // preserved as-is on write
+};
+
+// ── Public API ──────────────────────────────────────────────────────────────
+//
+// `read_wav_metadata` returns nullopt only on I/O error or a malformed
+// RIFF header. A successful read with zero recognised chunks returns an
+// empty WavMetadata struct, not nullopt.
+std::optional<WavMetadata> read_wav_metadata(const std::string& path);
+
+// `write_wav_metadata` writes a brand-new WAV with the given metadata
+// chunks plus a minimal silent `fmt ` + `data`. Useful for fixtures
+// and round-trip tests; prefer `replace_metadata_in_file` for editing
+// existing files in place.
+bool write_wav_metadata(const std::string& path,
+                        const WavMetadata& metadata,
+                        uint32_t sample_rate = 48000,
+                        uint16_t num_channels = 1,
+                        uint16_t bits_per_sample = 16);
+
+// `replace_metadata_in_file` rewrites the metadata chunks of an
+// existing WAV without touching its `fmt ` or `data` payload. Returns
+// false on I/O error or if the source is not a RIFF-WAVE file. Any
+// supported chunk that is absent from `metadata` is removed; unknown
+// chunks present in `metadata.unknown_chunks` are written back as-is.
+bool replace_metadata_in_file(const std::string& path, const WavMetadata& metadata);
+
+// ── Codec primitives (exposed for tests / advanced callers) ─────────────────
+std::vector<uint8_t> encode_bext_chunk(const BwavMetadata& bwav);
+std::vector<uint8_t> encode_acid_chunk(const AcidMetadata& acid);
+
+std::optional<BwavMetadata> decode_bext_chunk(const uint8_t* data, size_t size);
+std::optional<AcidMetadata> decode_acid_chunk(const uint8_t* data, size_t size);
+
+} // namespace pulp::audio

--- a/core/audio/src/wav_metadata.cpp
+++ b/core/audio/src/wav_metadata.cpp
@@ -1,0 +1,389 @@
+// wav_metadata.cpp — implementation of WAV metadata round-trip.
+//
+// All numeric fields in RIFF chunks are little-endian regardless of
+// host byte order, so we route everything through explicit byte-level
+// helpers rather than memcpy + cast. Strings inside fixed-size bext
+// fields are NUL-terminated when shorter than the slot and truncated
+// (no NUL) when exactly slot-sized; reads strip trailing NULs.
+//
+// Layout reminders:
+//   RIFF<u32 size>WAVE { <ckId u32><ckSize u32><payload [+1 pad byte if odd]> ...}
+//   RF64 variant is recognised on read (size==0xFFFFFFFF) but we always
+//   emit RIFF on write — the metadata round-trip is for files small
+//   enough to round-trip in memory.
+
+#include <pulp/audio/wav_metadata.hpp>
+
+#include <algorithm>
+#include <cstring>
+#include <fstream>
+#include <iterator>
+
+namespace pulp::audio {
+namespace {
+
+// ── Byte-level helpers (little-endian, host-agnostic) ───────────────────────
+
+inline uint16_t rd_u16(const uint8_t* p) {
+    return static_cast<uint16_t>(p[0]) | (static_cast<uint16_t>(p[1]) << 8);
+}
+inline uint32_t rd_u32(const uint8_t* p) {
+    return static_cast<uint32_t>(p[0])
+         | (static_cast<uint32_t>(p[1]) << 8)
+         | (static_cast<uint32_t>(p[2]) << 16)
+         | (static_cast<uint32_t>(p[3]) << 24);
+}
+inline int16_t rd_i16(const uint8_t* p) {
+    return static_cast<int16_t>(rd_u16(p));
+}
+inline float rd_f32(const uint8_t* p) {
+    uint32_t bits = rd_u32(p);
+    float f;
+    std::memcpy(&f, &bits, sizeof(f));
+    return f;
+}
+
+inline void wr_u16(std::vector<uint8_t>& v, uint16_t x) {
+    v.push_back(static_cast<uint8_t>(x & 0xFF));
+    v.push_back(static_cast<uint8_t>((x >> 8) & 0xFF));
+}
+inline void wr_u32(std::vector<uint8_t>& v, uint32_t x) {
+    v.push_back(static_cast<uint8_t>(x & 0xFF));
+    v.push_back(static_cast<uint8_t>((x >> 8) & 0xFF));
+    v.push_back(static_cast<uint8_t>((x >> 16) & 0xFF));
+    v.push_back(static_cast<uint8_t>((x >> 24) & 0xFF));
+}
+inline void wr_i16(std::vector<uint8_t>& v, int16_t x) {
+    wr_u16(v, static_cast<uint16_t>(x));
+}
+inline void wr_f32(std::vector<uint8_t>& v, float x) {
+    uint32_t bits;
+    std::memcpy(&bits, &x, sizeof(bits));
+    wr_u32(v, bits);
+}
+
+// Pad/truncate `s` into exactly `slot` bytes (NUL-padded).
+inline void append_fixed_string(std::vector<uint8_t>& out, const std::string& s, size_t slot) {
+    size_t n = std::min(s.size(), slot);
+    out.insert(out.end(), s.begin(), s.begin() + n);
+    for (size_t i = n; i < slot; ++i)
+        out.push_back(0);
+}
+
+// Read fixed-size string slot and trim trailing NULs.
+inline std::string read_fixed_string(const uint8_t* p, size_t slot) {
+    size_t n = slot;
+    while (n > 0 && p[n - 1] == 0) --n;
+    return std::string(reinterpret_cast<const char*>(p), n);
+}
+
+// FourCC literal helper — compares a 4-byte ID against a string literal.
+inline bool fourcc_eq(const uint8_t* p, const char (&s)[5]) {
+    return p[0] == static_cast<uint8_t>(s[0])
+        && p[1] == static_cast<uint8_t>(s[1])
+        && p[2] == static_cast<uint8_t>(s[2])
+        && p[3] == static_cast<uint8_t>(s[3]);
+}
+
+// Minimal `fmt ` chunk for the silent-WAV builder used in tests.
+std::vector<uint8_t> build_minimal_fmt(uint32_t sample_rate,
+                                       uint16_t num_channels,
+                                       uint16_t bits_per_sample) {
+    std::vector<uint8_t> v;
+    v.reserve(16);
+    wr_u16(v, 1);                                          // PCM
+    wr_u16(v, num_channels);
+    wr_u32(v, sample_rate);
+    const uint32_t block_align = (bits_per_sample / 8u) * num_channels;
+    const uint32_t byte_rate = block_align * sample_rate;
+    wr_u32(v, byte_rate);
+    wr_u16(v, static_cast<uint16_t>(block_align));
+    wr_u16(v, bits_per_sample);
+    return v;
+}
+
+void append_chunk(std::vector<uint8_t>& out,
+                  const char (&id)[5],
+                  const std::vector<uint8_t>& payload) {
+    out.push_back(static_cast<uint8_t>(id[0]));
+    out.push_back(static_cast<uint8_t>(id[1]));
+    out.push_back(static_cast<uint8_t>(id[2]));
+    out.push_back(static_cast<uint8_t>(id[3]));
+    wr_u32(out, static_cast<uint32_t>(payload.size()));
+    out.insert(out.end(), payload.begin(), payload.end());
+    if (payload.size() & 1u)
+        out.push_back(0); // word-align
+}
+
+bool read_file_bytes(const std::string& path, std::vector<uint8_t>& out) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) return false;
+    in.seekg(0, std::ios::end);
+    auto sz = in.tellg();
+    if (sz <= 0) return false;
+    in.seekg(0, std::ios::beg);
+    out.resize(static_cast<size_t>(sz));
+    in.read(reinterpret_cast<char*>(out.data()), sz);
+    return in.good();
+}
+
+bool write_file_bytes(const std::string& path, const std::vector<uint8_t>& bytes) {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out) return false;
+    out.write(reinterpret_cast<const char*>(bytes.data()),
+              static_cast<std::streamsize>(bytes.size()));
+    return out.good();
+}
+
+} // namespace
+
+// ── Chunk codecs ────────────────────────────────────────────────────────────
+
+std::vector<uint8_t> encode_bext_chunk(const BwavMetadata& bwav) {
+    // Fixed header up to coding_history is 602 bytes (bext v2 layout).
+    std::vector<uint8_t> v;
+    v.reserve(602 + bwav.coding_history.size());
+
+    append_fixed_string(v, bwav.description, 256);
+    append_fixed_string(v, bwav.originator, 32);
+    append_fixed_string(v, bwav.originator_reference, 32);
+    append_fixed_string(v, bwav.origination_date, 10);
+    append_fixed_string(v, bwav.origination_time, 8);
+
+    const uint32_t tr_low = static_cast<uint32_t>(bwav.time_reference & 0xFFFFFFFFu);
+    const uint32_t tr_high = static_cast<uint32_t>((bwav.time_reference >> 32) & 0xFFFFFFFFu);
+    wr_u32(v, tr_low);
+    wr_u32(v, tr_high);
+    wr_u16(v, bwav.version);
+
+    v.insert(v.end(), bwav.umid.begin(), bwav.umid.end()); // 64 bytes
+
+    wr_i16(v, bwav.loudness_value);
+    wr_i16(v, bwav.loudness_range);
+    wr_i16(v, bwav.max_true_peak_level);
+    wr_i16(v, bwav.max_momentary_loudness);
+    wr_i16(v, bwav.max_short_term_loudness);
+
+    // Reserved: 180 bytes of zeros per EBU spec.
+    v.insert(v.end(), 180, uint8_t{0});
+
+    // Variable-length coding history (ASCII, terminated by \r\n typically).
+    v.insert(v.end(), bwav.coding_history.begin(), bwav.coding_history.end());
+
+    return v;
+}
+
+std::optional<BwavMetadata> decode_bext_chunk(const uint8_t* data, size_t size) {
+    // Minimum bext payload is 602 bytes (fixed header before coding_history).
+    if (size < 602) return std::nullopt;
+
+    BwavMetadata b;
+    b.description = read_fixed_string(data + 0, 256);
+    b.originator = read_fixed_string(data + 256, 32);
+    b.originator_reference = read_fixed_string(data + 288, 32);
+    b.origination_date = read_fixed_string(data + 320, 10);
+    b.origination_time = read_fixed_string(data + 330, 8);
+
+    const uint32_t tr_low = rd_u32(data + 338);
+    const uint32_t tr_high = rd_u32(data + 342);
+    b.time_reference = (static_cast<uint64_t>(tr_high) << 32) | tr_low;
+    b.version = rd_u16(data + 346);
+
+    std::memcpy(b.umid.data(), data + 348, 64);
+
+    b.loudness_value = rd_i16(data + 412);
+    b.loudness_range = rd_i16(data + 414);
+    b.max_true_peak_level = rd_i16(data + 416);
+    b.max_momentary_loudness = rd_i16(data + 418);
+    b.max_short_term_loudness = rd_i16(data + 420);
+    // 180 bytes of reserved padding at offset 422.
+
+    if (size > 602) {
+        b.coding_history.assign(reinterpret_cast<const char*>(data + 602), size - 602);
+        // Strip trailing NULs / padding.
+        while (!b.coding_history.empty() && b.coding_history.back() == '\0')
+            b.coding_history.pop_back();
+    }
+    return b;
+}
+
+std::vector<uint8_t> encode_acid_chunk(const AcidMetadata& acid) {
+    std::vector<uint8_t> v;
+    v.reserve(24);
+    wr_u32(v, acid.flags);
+    wr_u16(v, acid.root_note);
+    wr_u16(v, acid.reserved1);
+    wr_f32(v, acid.reserved2);
+    wr_u32(v, acid.num_beats);
+    wr_u16(v, acid.meter_denominator);
+    wr_u16(v, acid.meter_numerator);
+    wr_f32(v, acid.tempo_bpm);
+    return v;
+}
+
+std::optional<AcidMetadata> decode_acid_chunk(const uint8_t* data, size_t size) {
+    if (size < 24) return std::nullopt;
+    AcidMetadata a;
+    a.flags = rd_u32(data + 0);
+    a.root_note = rd_u16(data + 4);
+    a.reserved1 = rd_u16(data + 6);
+    a.reserved2 = rd_f32(data + 8);
+    a.num_beats = rd_u32(data + 12);
+    a.meter_denominator = rd_u16(data + 16);
+    a.meter_numerator = rd_u16(data + 18);
+    a.tempo_bpm = rd_f32(data + 20);
+    return a;
+}
+
+// ── RIFF walker / file API ──────────────────────────────────────────────────
+
+namespace {
+
+// Visit every chunk in a RIFF-WAVE byte stream. `visitor(id, payload, size)`.
+template <class F>
+bool walk_riff_chunks(const std::vector<uint8_t>& bytes, F&& visitor) {
+    if (bytes.size() < 12) return false;
+    if (!fourcc_eq(bytes.data(), "RIFF") && !fourcc_eq(bytes.data(), "RF64"))
+        return false;
+    if (!fourcc_eq(bytes.data() + 8, "WAVE")) return false;
+
+    size_t off = 12;
+    while (off + 8 <= bytes.size()) {
+        const uint8_t* id = bytes.data() + off;
+        uint32_t sz = rd_u32(bytes.data() + off + 4);
+        const uint8_t* payload = bytes.data() + off + 8;
+        // Guard against malformed sz that runs past EOF.
+        if (sz > bytes.size() - (off + 8)) {
+            sz = static_cast<uint32_t>(bytes.size() - (off + 8));
+        }
+        visitor(id, payload, static_cast<size_t>(sz));
+        off += 8 + sz + (sz & 1u); // skip pad byte for odd-sized chunks
+    }
+    return true;
+}
+
+} // namespace
+
+std::optional<WavMetadata> read_wav_metadata(const std::string& path) {
+    std::vector<uint8_t> bytes;
+    if (!read_file_bytes(path, bytes)) return std::nullopt;
+
+    WavMetadata meta;
+    const bool ok = walk_riff_chunks(bytes, [&](const uint8_t* id, const uint8_t* payload, size_t sz) {
+        if (fourcc_eq(id, "bext")) {
+            if (auto b = decode_bext_chunk(payload, sz)) meta.bwav = std::move(*b);
+        } else if (fourcc_eq(id, "acid")) {
+            if (auto a = decode_acid_chunk(payload, sz)) meta.acid = std::move(*a);
+        } else if (fourcc_eq(id, "iXML")) {
+            meta.ixml = std::string(reinterpret_cast<const char*>(payload), sz);
+        } else if (fourcc_eq(id, "axml")) {
+            meta.axml = std::string(reinterpret_cast<const char*>(payload), sz);
+        } else if (!fourcc_eq(id, "fmt ") && !fourcc_eq(id, "data") && !fourcc_eq(id, "JUNK")) {
+            // Stash any other ancillary chunk so callers can preserve it.
+            WavMetadata::UnknownChunk u;
+            u.id = {{static_cast<char>(id[0]), static_cast<char>(id[1]),
+                     static_cast<char>(id[2]), static_cast<char>(id[3])}};
+            u.data.assign(payload, payload + sz);
+            meta.unknown_chunks.push_back(std::move(u));
+        }
+    });
+    if (!ok) return std::nullopt;
+    return meta;
+}
+
+bool write_wav_metadata(const std::string& path,
+                        const WavMetadata& metadata,
+                        uint32_t sample_rate,
+                        uint16_t num_channels,
+                        uint16_t bits_per_sample) {
+    // Build payload chunks first so we can compute the RIFF size.
+    std::vector<uint8_t> body;
+    body.reserve(1024);
+    // "WAVE" form type.
+    body.push_back('W'); body.push_back('A'); body.push_back('V'); body.push_back('E');
+
+    append_chunk(body, "fmt ", build_minimal_fmt(sample_rate, num_channels, bits_per_sample));
+    if (metadata.bwav) append_chunk(body, "bext", encode_bext_chunk(*metadata.bwav));
+    if (metadata.ixml) {
+        std::vector<uint8_t> p(metadata.ixml->begin(), metadata.ixml->end());
+        append_chunk(body, "iXML", p);
+    }
+    if (metadata.axml) {
+        std::vector<uint8_t> p(metadata.axml->begin(), metadata.axml->end());
+        append_chunk(body, "axml", p);
+    }
+    if (metadata.acid) append_chunk(body, "acid", encode_acid_chunk(*metadata.acid));
+    for (const auto& unk : metadata.unknown_chunks) {
+        char id[5] = {unk.id[0], unk.id[1], unk.id[2], unk.id[3], '\0'};
+        append_chunk(body, reinterpret_cast<const char (&)[5]>(id), unk.data);
+    }
+    // Empty `data` chunk so the file is structurally a valid WAV.
+    append_chunk(body, "data", std::vector<uint8_t>{});
+
+    std::vector<uint8_t> file;
+    file.reserve(body.size() + 8);
+    file.push_back('R'); file.push_back('I'); file.push_back('F'); file.push_back('F');
+    wr_u32(file, static_cast<uint32_t>(body.size()));
+    file.insert(file.end(), body.begin(), body.end());
+
+    return write_file_bytes(path, file);
+}
+
+bool replace_metadata_in_file(const std::string& path, const WavMetadata& metadata) {
+    std::vector<uint8_t> bytes;
+    if (!read_file_bytes(path, bytes)) return false;
+    if (bytes.size() < 12) return false;
+    if (!fourcc_eq(bytes.data(), "RIFF") && !fourcc_eq(bytes.data(), "RF64"))
+        return false;
+    if (!fourcc_eq(bytes.data() + 8, "WAVE")) return false;
+
+    // Collect original `fmt ` and `data` chunks verbatim; drop any
+    // metadata chunk kind we know how to rewrite (bext/iXML/axml/acid)
+    // plus any chunks present in the caller-supplied `unknown_chunks`.
+    std::vector<uint8_t> body;
+    body.reserve(bytes.size());
+    body.push_back('W'); body.push_back('A'); body.push_back('V'); body.push_back('E');
+
+    bool fmt_written = false;
+    walk_riff_chunks(bytes, [&](const uint8_t* id, const uint8_t* payload, size_t sz) {
+        if (fourcc_eq(id, "bext") || fourcc_eq(id, "iXML")
+            || fourcc_eq(id, "axml") || fourcc_eq(id, "acid")) {
+            return; // dropped; will be re-emitted from `metadata`
+        }
+        if (fourcc_eq(id, "fmt ")) {
+            std::vector<uint8_t> p(payload, payload + sz);
+            append_chunk(body, "fmt ", p);
+            fmt_written = true;
+            // Immediately after fmt is a good place to emit metadata
+            // chunks so they precede `data` and survive permissive
+            // readers that stop scanning past the audio payload.
+            if (metadata.bwav) append_chunk(body, "bext", encode_bext_chunk(*metadata.bwav));
+            if (metadata.ixml) {
+                std::vector<uint8_t> ix(metadata.ixml->begin(), metadata.ixml->end());
+                append_chunk(body, "iXML", ix);
+            }
+            if (metadata.axml) {
+                std::vector<uint8_t> ax(metadata.axml->begin(), metadata.axml->end());
+                append_chunk(body, "axml", ax);
+            }
+            if (metadata.acid) append_chunk(body, "acid", encode_acid_chunk(*metadata.acid));
+            return;
+        }
+        // Preserve everything else (data, JUNK, LIST/INFO, etc.) verbatim.
+        std::vector<uint8_t> p(payload, payload + sz);
+        char id_buf[5] = {static_cast<char>(id[0]), static_cast<char>(id[1]),
+                          static_cast<char>(id[2]), static_cast<char>(id[3]), '\0'};
+        append_chunk(body, reinterpret_cast<const char (&)[5]>(id_buf), p);
+    });
+    if (!fmt_written) return false;
+
+    std::vector<uint8_t> out;
+    out.reserve(body.size() + 8);
+    out.push_back('R'); out.push_back('I'); out.push_back('F'); out.push_back('F');
+    wr_u32(out, static_cast<uint32_t>(body.size()));
+    out.insert(out.end(), body.begin(), body.end());
+
+    return write_file_bytes(path, out);
+}
+
+} // namespace pulp::audio

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1460,6 +1460,9 @@ pulp_add_test_suite(pulp-test-audio-file LIBRARIES pulp::audio)
 # Links pulp::view so the WaveformView integration smoke compiles.
 pulp_add_test_suite(pulp-test-audio-thumbnail LIBRARIES pulp::audio pulp::view)
 
+# WAV metadata round-trip tests (BWAV / iXML / ASWG / ACID — item 6.11)
+pulp_add_test_suite(pulp-test-wav-metadata LIBRARIES pulp::audio)
+
 pulp_add_test_suite(pulp-test-offline-processor-edges LIBRARIES pulp::audio)
 
 pulp_add_test_suite(pulp-test-ogg-reader LIBRARIES pulp::audio)

--- a/test/test_wav_metadata.cpp
+++ b/test/test_wav_metadata.cpp
@@ -1,0 +1,273 @@
+// test_wav_metadata.cpp — round-trip tests for BWAV / iXML / ASWG / ACID
+// metadata. Covers item 6.11 of the 2026-05-24 macOS plugin authoring
+// plan.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <pulp/audio/wav_metadata.hpp>
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <system_error>
+
+using namespace pulp::audio;
+using Catch::Matchers::WithinAbs;
+
+namespace {
+
+std::filesystem::path scratch_file(const char* tag) {
+    auto base = std::filesystem::temp_directory_path();
+    auto p = base / (std::string("pulp-wav-metadata-") + tag + "-"
+                     + std::to_string(static_cast<unsigned long long>(std::time(nullptr)))
+                     + "-"
+                     + std::to_string(static_cast<unsigned long long>(std::rand()))
+                     + ".wav");
+    std::error_code ec;
+    std::filesystem::remove(p, ec);
+    return p;
+}
+
+BwavMetadata make_bwav_fixture() {
+    BwavMetadata b;
+    b.description = "Pulp test BWAV — round-trip fixture";
+    b.originator = "PulpRecorderSim";
+    b.originator_reference = "PR-2026-0524-0001";
+    b.origination_date = "2026-05-24";
+    b.origination_time = "14:25:01";
+    b.time_reference = 123'456'789ULL * 2ULL; // > 32 bits to exercise high u32
+    b.version = 2;
+    for (size_t i = 0; i < b.umid.size(); ++i)
+        b.umid[i] = static_cast<uint8_t>((i * 7u + 3u) & 0xFFu);
+    b.loudness_value = -2300;       // -23.00 LUFS in EBU units
+    b.loudness_range = 950;         // 9.50 LU
+    b.max_true_peak_level = -150;   // -1.50 dBTP
+    b.max_momentary_loudness = -1850;
+    b.max_short_term_loudness = -2100;
+    b.coding_history = "A=PCM,F=48000,W=24,M=mono,T=Pulp\r\n";
+    return b;
+}
+
+AcidMetadata make_acid_fixture() {
+    AcidMetadata a;
+    a.flags = 0x02 | 0x04; // root note set + stretch
+    a.root_note = 69;      // A4
+    a.reserved1 = 0x8000;
+    a.reserved2 = 0.0f;
+    a.num_beats = 16;
+    a.meter_denominator = 8;
+    a.meter_numerator = 7;     // 7/8
+    a.tempo_bpm = 124.25f;
+    return a;
+}
+
+bool bwav_eq(const BwavMetadata& a, const BwavMetadata& b) {
+    return a.description == b.description
+        && a.originator == b.originator
+        && a.originator_reference == b.originator_reference
+        && a.origination_date == b.origination_date
+        && a.origination_time == b.origination_time
+        && a.time_reference == b.time_reference
+        && a.version == b.version
+        && a.umid == b.umid
+        && a.loudness_value == b.loudness_value
+        && a.loudness_range == b.loudness_range
+        && a.max_true_peak_level == b.max_true_peak_level
+        && a.max_momentary_loudness == b.max_momentary_loudness
+        && a.max_short_term_loudness == b.max_short_term_loudness
+        && a.coding_history == b.coding_history;
+}
+
+} // namespace
+
+TEST_CASE("BWAV bext chunk round-trips through encode/decode", "[audio][wav][metadata][bwav][issue-6_11]") {
+    auto src = make_bwav_fixture();
+    auto bytes = encode_bext_chunk(src);
+    // Fixed header (602) + coding_history length.
+    REQUIRE(bytes.size() == 602 + src.coding_history.size());
+
+    auto rt = decode_bext_chunk(bytes.data(), bytes.size());
+    REQUIRE(rt.has_value());
+    REQUIRE(bwav_eq(src, *rt));
+}
+
+TEST_CASE("BWAV bext truncates over-long fixed strings without UB", "[audio][wav][metadata][bwav][issue-6_11]") {
+    BwavMetadata src;
+    src.description = std::string(400, 'x'); // overflow 256-byte slot
+    src.originator = std::string(60, 'y');   // overflow 32-byte slot
+    src.origination_date = "2026-05-24extra"; // overflow 10-byte slot
+
+    auto bytes = encode_bext_chunk(src);
+    auto rt = decode_bext_chunk(bytes.data(), bytes.size());
+    REQUIRE(rt.has_value());
+    CHECK(rt->description.size() == 256);
+    CHECK(rt->originator.size() == 32);
+    CHECK(rt->origination_date == "2026-05-24");
+}
+
+TEST_CASE("BWAV decode rejects undersized payload", "[audio][wav][metadata][bwav][issue-6_11]") {
+    std::vector<uint8_t> garbage(64, 0xAB);
+    auto rt = decode_bext_chunk(garbage.data(), garbage.size());
+    REQUIRE_FALSE(rt.has_value());
+}
+
+TEST_CASE("ACID chunk round-trips through encode/decode", "[audio][wav][metadata][acid][issue-6_11]") {
+    auto src = make_acid_fixture();
+    auto bytes = encode_acid_chunk(src);
+    REQUIRE(bytes.size() == 24);
+
+    auto rt = decode_acid_chunk(bytes.data(), bytes.size());
+    REQUIRE(rt.has_value());
+    CHECK(rt->flags == src.flags);
+    CHECK(rt->root_note == src.root_note);
+    CHECK(rt->reserved1 == src.reserved1);
+    CHECK_THAT(rt->reserved2, WithinAbs(src.reserved2, 1e-6f));
+    CHECK(rt->num_beats == src.num_beats);
+    CHECK(rt->meter_denominator == src.meter_denominator);
+    CHECK(rt->meter_numerator == src.meter_numerator);
+    CHECK_THAT(rt->tempo_bpm, WithinAbs(src.tempo_bpm, 1e-4f));
+}
+
+TEST_CASE("ACID decode rejects undersized payload", "[audio][wav][metadata][acid][issue-6_11]") {
+    std::vector<uint8_t> tiny(12, 0);
+    auto rt = decode_acid_chunk(tiny.data(), tiny.size());
+    REQUIRE_FALSE(rt.has_value());
+}
+
+TEST_CASE("Full WAV metadata file round-trip with all four chunk kinds", "[audio][wav][metadata][issue-6_11]") {
+    auto path = scratch_file("full");
+    WavMetadata src;
+    src.bwav = make_bwav_fixture();
+    src.acid = make_acid_fixture();
+    src.ixml = "<?xml version=\"1.0\"?><BWFXML><PROJECT>Pulp Sandbox</PROJECT>"
+               "<SCENE>S01</SCENE><TAKE>03</TAKE></BWFXML>";
+    src.axml = "<?xml version=\"1.0\"?><ebuCoreMain xmlns=\"urn:ebu:metadata-schema:ebuCore_2014\">"
+               "<title>ASWG sample</title></ebuCoreMain>";
+
+    REQUIRE(write_wav_metadata(path.string(), src, 48000, 1, 16));
+    REQUIRE(std::filesystem::exists(path));
+
+    auto rt = read_wav_metadata(path.string());
+    REQUIRE(rt.has_value());
+    REQUIRE(rt->bwav.has_value());
+    REQUIRE(rt->acid.has_value());
+    REQUIRE(rt->ixml.has_value());
+    REQUIRE(rt->axml.has_value());
+
+    CHECK(bwav_eq(*src.bwav, *rt->bwav));
+    CHECK(rt->acid->tempo_bpm == src.acid->tempo_bpm);
+    CHECK(rt->acid->num_beats == src.acid->num_beats);
+    CHECK(rt->acid->meter_numerator == 7);
+    CHECK(rt->acid->meter_denominator == 8);
+    CHECK(*rt->ixml == *src.ixml);
+    CHECK(*rt->axml == *src.axml);
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+}
+
+TEST_CASE("read_wav_metadata returns empty struct for WAV with no metadata", "[audio][wav][metadata][issue-6_11]") {
+    auto path = scratch_file("bare");
+    WavMetadata empty; // no bwav/acid/ixml/axml
+    REQUIRE(write_wav_metadata(path.string(), empty, 44100, 2, 24));
+
+    auto rt = read_wav_metadata(path.string());
+    REQUIRE(rt.has_value());
+    CHECK_FALSE(rt->bwav.has_value());
+    CHECK_FALSE(rt->acid.has_value());
+    CHECK_FALSE(rt->ixml.has_value());
+    CHECK_FALSE(rt->axml.has_value());
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+}
+
+TEST_CASE("read_wav_metadata fails cleanly on non-existent path", "[audio][wav][metadata][issue-6_11]") {
+    auto missing = std::filesystem::temp_directory_path()
+                 / "pulp-wav-metadata-this-does-not-exist-xyz.wav";
+    std::error_code ec;
+    std::filesystem::remove(missing, ec);
+    auto rt = read_wav_metadata(missing.string());
+    REQUIRE_FALSE(rt.has_value());
+}
+
+TEST_CASE("read_wav_metadata fails on non-RIFF data", "[audio][wav][metadata][issue-6_11]") {
+    auto path = scratch_file("notriff");
+    {
+        std::ofstream out(path, std::ios::binary);
+        out << "This is not a WAV file at all, just text.";
+    }
+    auto rt = read_wav_metadata(path.string());
+    REQUIRE_FALSE(rt.has_value());
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+}
+
+TEST_CASE("replace_metadata_in_file preserves fmt/data and rewrites chunks", "[audio][wav][metadata][issue-6_11]") {
+    auto path = scratch_file("inplace");
+
+    WavMetadata initial;
+    initial.bwav = make_bwav_fixture();
+    initial.bwav->description = "INITIAL description";
+    REQUIRE(write_wav_metadata(path.string(), initial, 44100, 2, 24));
+
+    auto initial_size = std::filesystem::file_size(path);
+    REQUIRE(initial_size > 0);
+
+    WavMetadata replacement;
+    replacement.bwav = make_bwav_fixture();
+    replacement.bwav->description = "REPLACED description";
+    replacement.acid = make_acid_fixture();
+    replacement.acid->tempo_bpm = 90.0f;
+    replacement.ixml = "<?xml?><added/>";
+
+    REQUIRE(replace_metadata_in_file(path.string(), replacement));
+
+    auto rt = read_wav_metadata(path.string());
+    REQUIRE(rt.has_value());
+    REQUIRE(rt->bwav.has_value());
+    REQUIRE(rt->acid.has_value());
+    REQUIRE(rt->ixml.has_value());
+    CHECK(rt->bwav->description == "REPLACED description");
+    CHECK(rt->acid->tempo_bpm == 90.0f);
+    CHECK(*rt->ixml == "<?xml?><added/>");
+
+    // Replacing again with empty metadata should strip everything but
+    // leave fmt + data intact (file should still parse as a WAV).
+    WavMetadata stripped;
+    REQUIRE(replace_metadata_in_file(path.string(), stripped));
+    auto bare = read_wav_metadata(path.string());
+    REQUIRE(bare.has_value());
+    CHECK_FALSE(bare->bwav.has_value());
+    CHECK_FALSE(bare->acid.has_value());
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+}
+
+TEST_CASE("Unknown chunks survive a read+write round-trip", "[audio][wav][metadata][issue-6_11]") {
+    auto path = scratch_file("unknown");
+
+    WavMetadata src;
+    WavMetadata::UnknownChunk u;
+    u.id = {{'L', 'I', 'S', 'T'}};
+    // Synthesize a tiny INFO LIST payload — "INFOIART\0\0\0\x05Pulp\0".
+    const uint8_t list_payload[] = {
+        'I','N','F','O',
+        'I','A','R','T', 0x05,0x00,0x00,0x00, 'P','u','l','p','\0',
+    };
+    u.data.assign(std::begin(list_payload), std::end(list_payload));
+    src.unknown_chunks.push_back(u);
+
+    REQUIRE(write_wav_metadata(path.string(), src, 48000, 1, 16));
+    auto rt = read_wav_metadata(path.string());
+    REQUIRE(rt.has_value());
+    REQUIRE(rt->unknown_chunks.size() == 1);
+    CHECK(rt->unknown_chunks[0].id == u.id);
+    CHECK(rt->unknown_chunks[0].data == u.data);
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+}


### PR DESCRIPTION
## Summary

Implements item **6.11** of `planning/2026-05-24-macos-plugin-authoring-plan.md` — round-trip read + write of the four canonical RIFF metadata chunks used by production-audio tooling:

- **`bext`** — EBU R 128 / EBU Tech 3285 Broadcast Wave Format (description, originator, time-reference, UMID, loudness fields, coding history)
- **`iXML`** — Gallery iXML production-metadata XML chunk (raw UTF-8 payload)
- **`axml`** — ASWG / EBU 3285s5 generic XML metadata chunk (raw UTF-8 payload)
- **`acid`** — Sony ACIDized-loop info (tempo, root note, beat count, time signature, flags)

CHOC still owns PCM I/O — this PR adds a thin RIFF chunk codec on top of it, motivated by CHOC surfacing only a string-map subset of `bext` and nothing for the other three chunk kinds.

## API surface

```cpp
// core/audio/include/pulp/audio/wav_metadata.hpp
struct WavMetadata {
    std::optional<BwavMetadata> bwav;
    std::optional<AcidMetadata> acid;
    std::optional<std::string>  ixml;
    std::optional<std::string>  axml;
    std::vector<UnknownChunk>   unknown_chunks; // preserved on write
};

std::optional<WavMetadata> read_wav_metadata(const std::string& path);
bool write_wav_metadata(const std::string& path, const WavMetadata& meta,
                        uint32_t sample_rate = 48000,
                        uint16_t num_channels = 1,
                        uint16_t bits_per_sample = 16);
bool replace_metadata_in_file(const std::string& path, const WavMetadata& meta);
```

`replace_metadata_in_file` rewrites metadata without touching `fmt ` / `data`, so edits on existing recordings are O(metadata) not O(audio) — directly satisfies the gap-doc acceptance criterion ("ACID metadata survives `replace_metadata_in_file` without rewriting the audio payload").

## Test plan

`pulp-test-wav-metadata` — **11 cases, 60 assertions, all green**:

- [x] `bext` encode/decode round-trip with full v2 field set, 64-byte UMID, >32-bit time-reference
- [x] `bext` truncation of over-long fixed-size string fields (no UB on 400-char description vs 256-byte slot)
- [x] `bext` / `acid` reject undersized payloads
- [x] `acid` round-trip including non-canonical 7/8 meter and fractional BPM
- [x] Full file round-trip with all four chunk kinds present
- [x] Empty-metadata WAV produces an empty (not nullopt) `WavMetadata`
- [x] Non-existent path + non-RIFF data fail cleanly
- [x] `replace_metadata_in_file` preserves `fmt`/`data`, can strip every metadata chunk back to bare WAV
- [x] Unknown chunks (INFO LIST fixture) survive a round-trip verbatim
- [x] Existing `pulp-test-audio-file` still passes (970 assertions, 58 cases)

Files: `core/audio/include/pulp/audio/wav_metadata.hpp`, `core/audio/src/wav_metadata.cpp`, `test/test_wav_metadata.cpp`. SDK bumped 0.236.0 → 0.237.0 (minor — new public API surface).