### PR TITLE
feat(view): CommandRegistry + KeyMappingEditor (item 6.4, Pulp-native)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.240.0
+    VERSION 0.241.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -340,6 +340,8 @@ target_sources(pulp-view-core PRIVATE
     src/splash_screen.cpp
     src/live_constant_editor.cpp
     src/inspector_window.cpp
+    src/command_registry.cpp
+    src/key_mapping_editor.cpp
 )
 
 target_sources(pulp-view-script PRIVATE

--- a/core/view/include/pulp/view/command_registry.hpp
+++ b/core/view/include/pulp/view/command_registry.hpp
@@ -1,0 +1,231 @@
+#pragma once
+
+/// @file command_registry.hpp
+/// CommandRegistry + CommandHandler + CommandInfo + ShortcutMap — Pulp-native
+/// command dispatch and keyboard-shortcut routing.
+///
+/// Pulp-native naming per the license-lineage note in
+/// `planning/2026-05-24-macos-plugin-authoring-plan.md` section 6.4: the
+/// primitives are deliberately *not* named after any reference framework's
+/// classes. The behavior contract is "a key event finds the topmost focused
+/// handler that claims a command and dispatches to it".
+///
+/// ## Architecture
+///
+/// - `CommandID` — opaque 32-bit ID. Apps define their own constants.
+/// - `CommandInfo` — metadata for one command (display name, category,
+///   default shortcut, enabled state). Used by the `KeyMappingEditor`.
+/// - `CommandHandler` — interface implemented by any object that knows how
+///   to perform commands. Typically a View subclass, but doesn't have to
+///   be — anything with command knowledge can register. The handler
+///   reports which commands it can perform and runs them on demand.
+/// - `CommandRegistry` — central per-app dispatcher. Owns:
+///     * the set of known `CommandInfo` records;
+///     * the chain of registered `CommandHandler` pointers (front of the
+///       chain = highest priority);
+///     * the `ShortcutMap` (key + modifier → command id).
+///   `dispatch(id)` walks the handler chain top-to-bottom and invokes the
+///   first handler that claims the command.
+/// - `ShortcutMap` — pure data: associates a `(KeyCode, modifiers)` pair
+///   with a `CommandID`. The registry uses it for routing; the editor UI
+///   uses it for rebinding. Persists via `pulp::state::PropertiesFile`.
+///
+/// ## Routing through the existing focus chain
+///
+/// The registry exposes `dispatch_key_event(const KeyEvent&)` which:
+///   1. Looks up the (key, modifiers) tuple in the `ShortcutMap`.
+///   2. If no command matches, returns false (host can fall through to
+///      its existing per-View `on_key_event` delivery).
+///   3. If a command matches, walks the registered handler chain and
+///      invokes the first one that claims the command. Returns true
+///      iff a handler ran.
+///
+/// The contract intentionally lets the host integrate two ways:
+///   (a) call `dispatch_key_event` BEFORE the normal `on_key_event`
+///       delivery — global shortcuts win;
+///   (b) call it AFTER — focused widget wins, with the registry as a
+///       fall-through (the macOS-MVP plan's default).
+///
+/// ## Persistence
+///
+/// `ShortcutMap::save_to(PropertiesFile&)` and `load_from(PropertiesFile&)`
+/// round-trip the user's rebindings through Pulp's
+/// `pulp::state::ApplicationProperties` (user settings file). The editor UI
+/// calls save() on every commit so changes survive a restart.
+
+#include <pulp/view/input_events.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace pulp::state { class PropertiesFile; }
+
+namespace pulp::view {
+
+/// Opaque 32-bit command identifier. Apps define their own enum-style
+/// constants (e.g. `constexpr CommandID kFileOpen = 0x1001`). Zero is
+/// reserved for "no command".
+using CommandID = std::uint32_t;
+
+inline constexpr CommandID kInvalidCommandID = 0;
+
+/// Metadata for one command. Used by `KeyMappingEditor` to render the
+/// list of rebindable actions and by the registry for display/debug.
+struct CommandInfo {
+    CommandID id = kInvalidCommandID;
+    std::string name;          ///< User-facing display name ("Open File…")
+    std::string category;      ///< Group ("File", "Edit", "View") for the editor.
+    KeyCode default_key = KeyCode::unknown;
+    std::uint16_t default_modifiers = 0;
+    bool enabled = true;       ///< False = greyed out / not dispatched.
+};
+
+/// Interface implemented by any object that can perform commands.
+///
+/// A handler is typically a View subclass but doesn't have to be — the
+/// registry holds raw `CommandHandler*` and the owner is responsible for
+/// removing the handler before destruction (see
+/// `CommandRegistry::remove_handler`). This mirrors how Pulp's other
+/// listener APIs (timer, async-update) work.
+class CommandHandler {
+public:
+    virtual ~CommandHandler() = default;
+
+    /// Report which commands this handler can perform. Called by the
+    /// registry when dispatching; an empty result means "I don't know
+    /// about that command — try the next handler". The default
+    /// implementation returns the static `commands()` set, which makes
+    /// per-instance overrides cheap.
+    virtual std::vector<CommandID> commands() const = 0;
+
+    /// Perform a command. Return true if handled (stops the dispatch
+    /// walk), false to let the next handler in the chain try.
+    virtual bool perform_command(CommandID id) = 0;
+};
+
+/// (KeyCode, modifiers) → CommandID lookup table. Pure data; safe to
+/// copy. Persists through `save_to` / `load_from`.
+class ShortcutMap {
+public:
+    /// Associate a (key, modifier) chord with a command. If a different
+    /// command was previously bound to the same chord, it is replaced.
+    void bind(KeyCode key, std::uint16_t modifiers, CommandID id);
+
+    /// Remove any binding for the given chord. No-op if unbound.
+    void unbind(KeyCode key, std::uint16_t modifiers);
+
+    /// Remove every chord that points to the given command.
+    void unbind_command(CommandID id);
+
+    /// Look up a chord. Returns `kInvalidCommandID` if unbound.
+    CommandID find(KeyCode key, std::uint16_t modifiers) const;
+
+    /// All chords currently bound to the given command. Useful for the
+    /// editor UI to show "command X is bound to Cmd-O, F2".
+    struct Chord {
+        KeyCode key = KeyCode::unknown;
+        std::uint16_t modifiers = 0;
+    };
+    std::vector<Chord> chords_for(CommandID id) const;
+
+    /// Number of bound chords.
+    std::size_t size() const { return bindings_.size(); }
+
+    /// Clear all bindings.
+    void clear() { bindings_.clear(); }
+
+    /// Serialize / restore through a `pulp::state::PropertiesFile`.
+    /// Round-trip is lossless. The key namespace inside the properties
+    /// file is `"shortcuts.<key>.<mods>"` → `<command-id>` so different
+    /// subsystems can share one file without colliding (callers can
+    /// pass a custom `key_prefix` to use their own namespace).
+    void save_to(pulp::state::PropertiesFile& props,
+                 std::string_view key_prefix = "shortcuts") const;
+    bool load_from(const pulp::state::PropertiesFile& props,
+                   std::string_view key_prefix = "shortcuts");
+
+private:
+    // Composite key: key code in low 32 bits, modifiers in high 16 bits.
+    using ChordKey = std::uint64_t;
+    static ChordKey make_key(KeyCode k, std::uint16_t m) {
+        return (static_cast<ChordKey>(m) << 32) |
+               static_cast<ChordKey>(static_cast<std::uint32_t>(k));
+    }
+    std::unordered_map<ChordKey, CommandID> bindings_;
+};
+
+/// Central command dispatcher. One per application (or per window, if you
+/// want per-window scopes). Owns the `ShortcutMap` and a chain of
+/// registered `CommandHandler` pointers.
+class CommandRegistry {
+public:
+    CommandRegistry() = default;
+    ~CommandRegistry() = default;
+
+    // Non-copyable, non-movable — handlers register by raw pointer.
+    CommandRegistry(const CommandRegistry&) = delete;
+    CommandRegistry& operator=(const CommandRegistry&) = delete;
+
+    // ── Command metadata ────────────────────────────────────────────
+
+    /// Register a command. If the info's `default_key` is non-unknown,
+    /// the registry also binds the default chord in the `ShortcutMap`
+    /// (unless that chord is already bound — user-loaded rebindings
+    /// take priority, which is why apps should `load` the shortcut map
+    /// from disk BEFORE calling `register_command`).
+    void register_command(const CommandInfo& info);
+
+    /// Look up a command by id. Returns nullopt if unknown.
+    std::optional<CommandInfo> command_info(CommandID id) const;
+
+    /// All registered commands, in registration order.
+    const std::vector<CommandInfo>& commands() const { return commands_; }
+
+    /// Mutate a command's `enabled` flag (e.g. greys out "Undo" when
+    /// the stack is empty). Does not change shortcut bindings.
+    void set_enabled(CommandID id, bool enabled);
+
+    // ── Handler chain ───────────────────────────────────────────────
+
+    /// Add a handler to the front of the dispatch chain (highest
+    /// priority). Caller retains ownership; must call `remove_handler`
+    /// before the handler is destroyed.
+    void add_handler(CommandHandler* handler);
+
+    /// Remove a handler from the chain. Safe to call with an unknown
+    /// pointer (no-op).
+    void remove_handler(CommandHandler* handler);
+
+    /// Number of handlers currently in the chain.
+    std::size_t handler_count() const { return handlers_.size(); }
+
+    // ── Dispatch ────────────────────────────────────────────────────
+
+    /// Dispatch a command id through the handler chain. Returns true if
+    /// some handler claimed it. Commands marked `enabled=false` are not
+    /// dispatched and the call returns false.
+    bool dispatch(CommandID id);
+
+    /// Dispatch a key event: look up the chord in the `ShortcutMap`,
+    /// then dispatch the resulting command (if any). Returns true iff
+    /// a command was found AND a handler claimed it.
+    bool dispatch_key_event(const KeyEvent& event);
+
+    // ── ShortcutMap access ──────────────────────────────────────────
+
+    ShortcutMap& shortcuts() { return shortcuts_; }
+    const ShortcutMap& shortcuts() const { return shortcuts_; }
+
+private:
+    std::vector<CommandInfo> commands_;
+    std::unordered_map<CommandID, std::size_t> command_index_;
+    std::vector<CommandHandler*> handlers_;
+    ShortcutMap shortcuts_;
+};
+
+} // namespace pulp::view

--- a/core/view/include/pulp/view/key_mapping_editor.hpp
+++ b/core/view/include/pulp/view/key_mapping_editor.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+/// @file key_mapping_editor.hpp
+/// KeyMappingEditor — Pulp-native UI for rebinding command shortcuts.
+///
+/// Pulp-native naming per planning/2026-05-24-macos-plugin-authoring-plan.md
+/// section 6.4. The editor is a `View` that lists every command registered
+/// with a `CommandRegistry`, shows each command's current chord, and lets
+/// the user pick a row + press a new chord to rebind. Changes are committed
+/// to the registry's `ShortcutMap` and persisted through
+/// `pulp::state::ApplicationProperties::user_settings()` (or any caller-
+/// supplied `PropertiesFile`).
+///
+/// The widget is deliberately small — it relies on the parent shell to
+/// scroll it. Rows use `Theme` tokens (`background.surface`,
+/// `text.primary`, `border.subtle`, `accent.primary`) where available and
+/// fall back to a neutral palette otherwise.
+
+#include <pulp/view/command_registry.hpp>
+#include <pulp/view/view.hpp>
+
+#include <functional>
+#include <string>
+
+namespace pulp::state { class PropertiesFile; }
+
+namespace pulp::view {
+
+class KeyMappingEditor : public View {
+public:
+    /// Construct an editor bound to a `CommandRegistry`. The registry must
+    /// outlive the editor.
+    explicit KeyMappingEditor(CommandRegistry& registry);
+
+    /// Optional: a `PropertiesFile` to persist rebindings to. Each commit
+    /// calls `ShortcutMap::save_to(props)` and (if `auto_save_path` is
+    /// non-empty) `props.save(auto_save_path)`. Without a file the editor
+    /// just mutates the in-memory ShortcutMap.
+    void set_persistence(pulp::state::PropertiesFile* props,
+                         std::string auto_save_path = {});
+
+    /// Optional: prefix to use inside the PropertiesFile (defaults to
+    /// "shortcuts"). Lets multiple editors share one settings file
+    /// without colliding.
+    void set_persistence_prefix(std::string prefix);
+
+    // ── Selection / capture state ───────────────────────────────────
+
+    /// Select a row (by command id) and begin chord capture. Subsequent
+    /// `on_key_event` calls will commit the next non-modifier-only key
+    /// as the new binding for `id`.
+    void begin_capture(CommandID id);
+
+    /// Cancel any in-progress chord capture.
+    void cancel_capture();
+
+    /// True when waiting for the user to press a chord.
+    bool is_capturing() const { return capture_id_ != kInvalidCommandID; }
+
+    /// The command id currently being captured (kInvalidCommandID when
+    /// not capturing).
+    CommandID capturing_command() const { return capture_id_; }
+
+    /// Force-rebind a command's chord, bypassing capture. Persists if
+    /// persistence is configured. Pass `KeyCode::unknown` to unbind.
+    void rebind(CommandID id, KeyCode key, std::uint16_t modifiers);
+
+    // ── Optional callbacks ──────────────────────────────────────────
+
+    /// Fires after a successful commit (capture or `rebind`).
+    std::function<void(CommandID, KeyCode, std::uint16_t)> on_rebound;
+
+    // ── View overrides ──────────────────────────────────────────────
+
+    void paint(canvas::Canvas& canvas) override;
+    void on_mouse_down(Point pos) override;
+    bool on_key_event(const KeyEvent& event) override;
+    bool accepts_text_input() const override { return is_capturing(); }
+
+    /// Row height in points. Public for parent-shell layout math.
+    float row_height() const { return row_height_; }
+    void set_row_height(float h) { row_height_ = h > 4.0f ? h : 4.0f; }
+
+    /// Total intrinsic height = row_height * (1 + registered command count).
+    float intrinsic_height() const override;
+
+private:
+    void commit(CommandID id, KeyCode key, std::uint16_t modifiers);
+    int row_at(float y) const;
+
+    CommandRegistry& registry_;
+    pulp::state::PropertiesFile* props_ = nullptr;
+    std::string auto_save_path_;
+    std::string persistence_prefix_ = "shortcuts";
+
+    CommandID capture_id_ = kInvalidCommandID;
+    float row_height_ = 28.0f;
+};
+
+/// Render a (key + modifiers) chord as a user-facing string, e.g.
+/// "Cmd+Shift+O" or "F5". Exposed so the editor and other UIs share one
+/// formatter. Modifier order is canonical (Ctrl, Alt, Shift, Cmd/Meta).
+std::string format_chord(KeyCode key, std::uint16_t modifiers);
+
+} // namespace pulp::view

--- a/core/view/src/command_registry.cpp
+++ b/core/view/src/command_registry.cpp
@@ -1,0 +1,179 @@
+// command_registry.cpp — Pulp-native command dispatch + shortcut routing.
+//
+// See `core/view/include/pulp/view/command_registry.hpp` for the contract.
+// Pulp-native names per planning/2026-05-24-macos-plugin-authoring-plan.md
+// section 6.4 (license-lineage note).
+
+#include <pulp/view/command_registry.hpp>
+#include <pulp/state/properties_file.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+
+namespace pulp::view {
+
+// ── ShortcutMap ─────────────────────────────────────────────────────────
+
+void ShortcutMap::bind(KeyCode key, std::uint16_t modifiers, CommandID id) {
+    if (id == kInvalidCommandID) {
+        unbind(key, modifiers);
+        return;
+    }
+    bindings_[make_key(key, modifiers)] = id;
+}
+
+void ShortcutMap::unbind(KeyCode key, std::uint16_t modifiers) {
+    bindings_.erase(make_key(key, modifiers));
+}
+
+void ShortcutMap::unbind_command(CommandID id) {
+    for (auto it = bindings_.begin(); it != bindings_.end();) {
+        if (it->second == id) it = bindings_.erase(it);
+        else ++it;
+    }
+}
+
+CommandID ShortcutMap::find(KeyCode key, std::uint16_t modifiers) const {
+    auto it = bindings_.find(make_key(key, modifiers));
+    return (it == bindings_.end()) ? kInvalidCommandID : it->second;
+}
+
+std::vector<ShortcutMap::Chord> ShortcutMap::chords_for(CommandID id) const {
+    std::vector<Chord> result;
+    for (auto& [k, v] : bindings_) {
+        if (v != id) continue;
+        Chord c;
+        c.key = static_cast<KeyCode>(static_cast<std::uint32_t>(k & 0xFFFFFFFFu));
+        c.modifiers = static_cast<std::uint16_t>((k >> 32) & 0xFFFFu);
+        result.push_back(c);
+    }
+    return result;
+}
+
+void ShortcutMap::save_to(pulp::state::PropertiesFile& props,
+                          std::string_view key_prefix) const {
+    // Build a "<prefix>.<key>.<mods>" → "<command-id>" key for each
+    // binding. Strip the existing keys for this prefix first so removed
+    // bindings don't linger in the persisted file.
+    const std::string prefix = std::string(key_prefix) + ".";
+    {
+        // PropertiesFile doesn't expose a prefix-remove, so iterate keys
+        // and remove anything under our prefix. `keys()` returns a copy
+        // so it's safe to mutate during the walk.
+        for (const auto& k : props.keys()) {
+            if (k.size() > prefix.size() &&
+                std::equal(prefix.begin(), prefix.end(), k.begin())) {
+                props.remove(k);
+            }
+        }
+    }
+    for (const auto& [chord_key, cmd] : bindings_) {
+        auto key_code = static_cast<std::uint32_t>(chord_key & 0xFFFFFFFFu);
+        auto mods = static_cast<std::uint16_t>((chord_key >> 32) & 0xFFFFu);
+        std::string k = prefix + std::to_string(key_code) + "." +
+                        std::to_string(static_cast<unsigned>(mods));
+        props.set_int(k, static_cast<std::int64_t>(cmd));
+    }
+}
+
+bool ShortcutMap::load_from(const pulp::state::PropertiesFile& props,
+                            std::string_view key_prefix) {
+    const std::string prefix = std::string(key_prefix) + ".";
+    bool any = false;
+    for (const auto& k : props.keys()) {
+        if (k.size() <= prefix.size()) continue;
+        if (!std::equal(prefix.begin(), prefix.end(), k.begin())) continue;
+        // "<prefix>.<key>.<mods>" — find the two dots after prefix.
+        auto dot1 = k.find('.', prefix.size());
+        if (dot1 == std::string::npos) continue;
+        std::string key_part = k.substr(prefix.size(), dot1 - prefix.size());
+        std::string mods_part = k.substr(dot1 + 1);
+        try {
+            auto key_code = static_cast<std::uint32_t>(std::stoul(key_part));
+            auto mods = static_cast<std::uint16_t>(std::stoul(mods_part));
+            auto cmd = props.get_int(k);
+            if (!cmd) continue;
+            bindings_[make_key(static_cast<KeyCode>(key_code), mods)] =
+                static_cast<CommandID>(*cmd);
+            any = true;
+        } catch (...) {
+            // Malformed key — skip rather than reject the whole file.
+            continue;
+        }
+    }
+    return any;
+}
+
+// ── CommandRegistry ─────────────────────────────────────────────────────
+
+void CommandRegistry::register_command(const CommandInfo& info) {
+    if (info.id == kInvalidCommandID) return;
+    auto it = command_index_.find(info.id);
+    if (it != command_index_.end()) {
+        commands_[it->second] = info;
+    } else {
+        command_index_[info.id] = commands_.size();
+        commands_.push_back(info);
+    }
+    // Bind the default chord only if (a) nothing else already owns it AND
+    // (b) this command has no existing binding. (a) protects another
+    // command's chord; (b) lets apps load() the user's saved ShortcutMap
+    // BEFORE register_command and keep the user's rebind even when the
+    // default chord is free.
+    if (info.default_key != KeyCode::unknown &&
+        shortcuts_.find(info.default_key, info.default_modifiers) ==
+            kInvalidCommandID &&
+        shortcuts_.chords_for(info.id).empty()) {
+        shortcuts_.bind(info.default_key, info.default_modifiers, info.id);
+    }
+}
+
+std::optional<CommandInfo> CommandRegistry::command_info(CommandID id) const {
+    auto it = command_index_.find(id);
+    if (it == command_index_.end()) return std::nullopt;
+    return commands_[it->second];
+}
+
+void CommandRegistry::set_enabled(CommandID id, bool enabled) {
+    auto it = command_index_.find(id);
+    if (it == command_index_.end()) return;
+    commands_[it->second].enabled = enabled;
+}
+
+void CommandRegistry::add_handler(CommandHandler* handler) {
+    if (!handler) return;
+    // Push to the front: most-recently-added wins, matching how a
+    // newly-opened modal/panel grabs shortcut priority.
+    handlers_.insert(handlers_.begin(), handler);
+}
+
+void CommandRegistry::remove_handler(CommandHandler* handler) {
+    if (!handler) return;
+    handlers_.erase(std::remove(handlers_.begin(), handlers_.end(), handler),
+                    handlers_.end());
+}
+
+bool CommandRegistry::dispatch(CommandID id) {
+    if (id == kInvalidCommandID) return false;
+    auto idx = command_index_.find(id);
+    if (idx != command_index_.end() && !commands_[idx->second].enabled) {
+        return false;
+    }
+    for (auto* handler : handlers_) {
+        if (!handler) continue;
+        auto known = handler->commands();
+        if (std::find(known.begin(), known.end(), id) == known.end()) continue;
+        if (handler->perform_command(id)) return true;
+    }
+    return false;
+}
+
+bool CommandRegistry::dispatch_key_event(const KeyEvent& event) {
+    if (!event.is_down) return false; // commands fire on key-down only
+    CommandID id = shortcuts_.find(event.key, event.modifiers);
+    if (id == kInvalidCommandID) return false;
+    return dispatch(id);
+}
+
+} // namespace pulp::view

--- a/core/view/src/key_mapping_editor.cpp
+++ b/core/view/src/key_mapping_editor.cpp
@@ -1,0 +1,227 @@
+// key_mapping_editor.cpp — Pulp-native UI for rebinding command shortcuts.
+//
+// See `core/view/include/pulp/view/key_mapping_editor.hpp` for the contract.
+
+#include <pulp/view/key_mapping_editor.hpp>
+#include <pulp/state/properties_file.hpp>
+
+#include <cmath>
+#include <utility>
+
+namespace pulp::view {
+
+namespace {
+
+const char* keycode_label(KeyCode k) {
+    using K = KeyCode;
+    switch (k) {
+        case K::left: return "Left";
+        case K::right: return "Right";
+        case K::up: return "Up";
+        case K::down: return "Down";
+        case K::home: return "Home";
+        case K::end_: return "End";
+        case K::page_up: return "PageUp";
+        case K::page_down: return "PageDown";
+        case K::backspace: return "Backspace";
+        case K::delete_: return "Delete";
+        case K::tab: return "Tab";
+        case K::enter: return "Enter";
+        case K::escape: return "Escape";
+        case K::space: return "Space";
+        case K::f1: return "F1"; case K::f2: return "F2";
+        case K::f3: return "F3"; case K::f4: return "F4";
+        case K::f5: return "F5"; case K::f6: return "F6";
+        case K::f7: return "F7"; case K::f8: return "F8";
+        case K::f9: return "F9"; case K::f10: return "F10";
+        case K::f11: return "F11"; case K::f12: return "F12";
+        case K::unknown: return "—";
+        default: break;
+    }
+    return nullptr;
+}
+
+bool is_modifier_only_keycode(KeyCode k) {
+    // No dedicated modifier-key enum values in input_events.hpp yet, so
+    // capture commits on the first non-unknown key. This matches the
+    // contract documented in the header (commit the next non-modifier
+    // chord) without requiring new enum surface.
+    return k == KeyCode::unknown;
+}
+
+} // namespace
+
+std::string format_chord(KeyCode key, std::uint16_t modifiers) {
+    if (key == KeyCode::unknown && modifiers == 0) return "—";
+    std::string out;
+    auto add = [&](const char* s) {
+        if (!out.empty()) out += "+";
+        out += s;
+    };
+    if (modifiers & kModCtrl)  add("Ctrl");
+    if (modifiers & kModAlt)   add("Alt");
+    if (modifiers & kModShift) add("Shift");
+    if (modifiers & kModCmd)   add("Cmd");
+    else if (modifiers & kModMeta) add("Meta");
+
+    // Key portion.
+    if (key != KeyCode::unknown) {
+        if (const char* lbl = keycode_label(key)) {
+            add(lbl);
+        } else {
+            // Printable ASCII — uppercase for display.
+            int code = static_cast<int>(key);
+            if (code >= 'a' && code <= 'z') code -= 32;
+            char buf[2] = {static_cast<char>(code), 0};
+            add(buf);
+        }
+    }
+    return out;
+}
+
+// ── KeyMappingEditor ────────────────────────────────────────────────────
+
+KeyMappingEditor::KeyMappingEditor(CommandRegistry& registry)
+    : registry_(registry) {
+    set_focusable(true);
+}
+
+void KeyMappingEditor::set_persistence(pulp::state::PropertiesFile* props,
+                                       std::string auto_save_path) {
+    props_ = props;
+    auto_save_path_ = std::move(auto_save_path);
+}
+
+void KeyMappingEditor::set_persistence_prefix(std::string prefix) {
+    persistence_prefix_ = std::move(prefix);
+}
+
+void KeyMappingEditor::begin_capture(CommandID id) {
+    if (!registry_.command_info(id)) return;
+    capture_id_ = id;
+}
+
+void KeyMappingEditor::cancel_capture() {
+    capture_id_ = kInvalidCommandID;
+}
+
+void KeyMappingEditor::rebind(CommandID id, KeyCode key,
+                              std::uint16_t modifiers) {
+    if (!registry_.command_info(id)) return;
+    commit(id, key, modifiers);
+}
+
+void KeyMappingEditor::commit(CommandID id, KeyCode key,
+                              std::uint16_t modifiers) {
+    auto& map = registry_.shortcuts();
+    // Drop any other chord previously pointing at this command so each
+    // command has at most one binding (matches the editor's one-row-per-
+    // command UI).
+    map.unbind_command(id);
+    if (key != KeyCode::unknown) {
+        // If another command already owns this chord, replace it (the
+        // user's intent is "give this chord to me now").
+        map.bind(key, modifiers, id);
+    }
+    capture_id_ = kInvalidCommandID;
+
+    if (props_) {
+        map.save_to(*props_, persistence_prefix_);
+        if (!auto_save_path_.empty()) {
+            props_->save(auto_save_path_);
+        }
+    }
+    if (on_rebound) on_rebound(id, key, modifiers);
+}
+
+int KeyMappingEditor::row_at(float y) const {
+    if (row_height_ <= 0.0f) return -1;
+    // Row 0 is the header.
+    int idx = static_cast<int>(std::floor(y / row_height_)) - 1;
+    if (idx < 0 || idx >= static_cast<int>(registry_.commands().size())) {
+        return -1;
+    }
+    return idx;
+}
+
+void KeyMappingEditor::on_mouse_down(Point pos) {
+    int idx = row_at(pos.y);
+    if (idx < 0) {
+        cancel_capture();
+        return;
+    }
+    auto cmd = registry_.commands()[static_cast<std::size_t>(idx)];
+    begin_capture(cmd.id);
+}
+
+bool KeyMappingEditor::on_key_event(const KeyEvent& event) {
+    if (!is_capturing()) return false;
+    if (!event.is_down) return true; // consume key-up while capturing
+
+    // Escape cancels capture without rebinding.
+    if (event.key == KeyCode::escape && event.modifiers == 0) {
+        cancel_capture();
+        return true;
+    }
+    if (is_modifier_only_keycode(event.key)) return true;
+
+    commit(capture_id_, event.key, event.modifiers);
+    return true;
+}
+
+float KeyMappingEditor::intrinsic_height() const {
+    return row_height_ * (1.0f + static_cast<float>(registry_.commands().size()));
+}
+
+void KeyMappingEditor::paint(canvas::Canvas& canvas) {
+    const auto r = local_bounds();
+    const Color bg       = resolve_color("background.surface",
+                                         Color::rgba(0.10f, 0.10f, 0.11f, 1.0f));
+    const Color text     = resolve_color("text.primary",
+                                         Color::rgba(0.92f, 0.92f, 0.95f, 1.0f));
+    const Color text_dim = resolve_color("text.secondary",
+                                         Color::rgba(0.62f, 0.62f, 0.66f, 1.0f));
+    const Color sel      = resolve_color("accent.primary",
+                                         Color::rgba(0.20f, 0.45f, 0.85f, 1.0f));
+    const Color border   = resolve_color("border.subtle",
+                                         Color::rgba(0.20f, 0.20f, 0.22f, 1.0f));
+
+    canvas.set_fill_color(bg);
+    canvas.fill_rect(r.x, r.y, r.width, r.height);
+
+    const float pad = 8.0f;
+    const float name_x = r.x + pad;
+    const float chord_x = r.x + r.width * 0.55f;
+
+    // Header row.
+    canvas.set_fill_color(text_dim);
+    canvas.fill_text("Command", name_x, r.y + row_height_ * 0.7f);
+    canvas.fill_text("Shortcut", chord_x, r.y + row_height_ * 0.7f);
+
+    canvas.set_fill_color(border);
+    canvas.fill_rect(r.x, r.y + row_height_ - 1.0f, r.width, 1.0f);
+
+    // One row per command.
+    const auto& cmds = registry_.commands();
+    for (std::size_t i = 0; i < cmds.size(); ++i) {
+        const float row_y = r.y + row_height_ * (1.0f + static_cast<float>(i));
+        const bool is_capturing_row = (cmds[i].id == capture_id_);
+
+        if (is_capturing_row) {
+            canvas.set_fill_color(sel);
+            canvas.fill_rect(r.x, row_y, r.width, row_height_);
+        }
+
+        canvas.set_fill_color(is_capturing_row ? bg : text);
+        canvas.fill_text(cmds[i].name, name_x, row_y + row_height_ * 0.7f);
+
+        auto chords = registry_.shortcuts().chords_for(cmds[i].id);
+        std::string chord_text =
+            is_capturing_row ? std::string("Press a key…")
+            : chords.empty() ? std::string("—")
+            : format_chord(chords.front().key, chords.front().modifiers);
+        canvas.fill_text(chord_text, chord_x, row_y + row_height_ * 0.7f);
+    }
+}
+
+} // namespace pulp::view

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -850,6 +850,8 @@ pulp_add_test_suite(pulp-test-modulation-matrix-widget LIBRARIES pulp::view)
 pulp_add_test_suite(pulp-test-lasso LIBRARIES pulp::view)
 # Split pane layout widget
 pulp_add_test_suite(pulp-test-split-view LIBRARIES pulp::view)
+# CommandRegistry + KeyMappingEditor (Pulp-native names — planning slice 6.4)
+pulp_add_test_suite(pulp-test-command-registry LIBRARIES pulp::view pulp::state)
 # PluginDescriptor vendor_url + vendor_email (workstream 01 slice 1.8)
 pulp_add_test_suite(pulp-test-vendor-url LIBRARIES pulp::format)
 # Image cache (workstream 07 slice 7.4)

--- a/test/test_command_registry.cpp
+++ b/test/test_command_registry.cpp
@@ -1,0 +1,337 @@
+// test_command_registry.cpp — coverage for the Pulp-native CommandRegistry,
+// CommandHandler, CommandInfo, ShortcutMap, and KeyMappingEditor primitives.
+//
+// Section 6.4 of planning/2026-05-24-macos-plugin-authoring-plan.md:
+//   "a Pulp app registers commands + key bindings; keypress routes to the
+//    focused command handler; rebind UI persists via
+//    pulp::state::ApplicationProperties."
+//
+// Each test below pins one row of that contract.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/state/properties_file.hpp>
+#include <pulp/view/command_registry.hpp>
+#include <pulp/view/input_events.hpp>
+#include <pulp/view/key_mapping_editor.hpp>
+
+#include <algorithm>
+#include <cstdio>
+#include <filesystem>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+using namespace pulp::view;
+
+namespace {
+
+constexpr CommandID kCmdOpen = 0x1001;
+constexpr CommandID kCmdSave = 0x1002;
+constexpr CommandID kCmdUndo = 0x1003;
+
+class CountingHandler : public CommandHandler {
+public:
+    CountingHandler(std::vector<CommandID> known, bool claim = true)
+        : known_(std::move(known)), claim_(claim) {}
+
+    std::vector<CommandID> commands() const override { return known_; }
+
+    bool perform_command(CommandID id) override {
+        last_id_ = id;
+        ++calls_;
+        return claim_;
+    }
+
+    int calls_ = 0;
+    CommandID last_id_ = kInvalidCommandID;
+private:
+    std::vector<CommandID> known_;
+    bool claim_;
+};
+
+std::string temp_props_path(const char* suffix) {
+    auto dir = std::filesystem::temp_directory_path();
+    auto p = dir / (std::string("pulp-cmdregistry-") + suffix + "-" +
+                    std::to_string(std::rand()) + ".json");
+    return p.string();
+}
+
+} // namespace
+
+TEST_CASE("CommandRegistry registers commands and binds default chords",
+          "[view][command_registry][issue-6.4]") {
+    CommandRegistry reg;
+
+    CommandInfo open{kCmdOpen, "Open File", "File", KeyCode::o, kModCmd};
+    CommandInfo save{kCmdSave, "Save",      "File", KeyCode::s, kModCmd};
+    reg.register_command(open);
+    reg.register_command(save);
+
+    REQUIRE(reg.commands().size() == 2);
+    REQUIRE(reg.command_info(kCmdOpen)->name == "Open File");
+    REQUIRE(reg.command_info(kCmdSave)->category == "File");
+    REQUIRE_FALSE(reg.command_info(0x9999).has_value());
+
+    // Default chords got bound automatically.
+    REQUIRE(reg.shortcuts().find(KeyCode::o, kModCmd) == kCmdOpen);
+    REQUIRE(reg.shortcuts().find(KeyCode::s, kModCmd) == kCmdSave);
+}
+
+TEST_CASE("CommandRegistry re-registration replaces existing info",
+          "[view][command_registry][issue-6.4]") {
+    CommandRegistry reg;
+    reg.register_command({kCmdOpen, "Open", "File"});
+    reg.register_command({kCmdOpen, "Open File…", "File"});
+    REQUIRE(reg.commands().size() == 1);
+    REQUIRE(reg.command_info(kCmdOpen)->name == "Open File…");
+}
+
+TEST_CASE("CommandRegistry dispatch walks handler chain top-to-bottom",
+          "[view][command_registry][issue-6.4]") {
+    CommandRegistry reg;
+    reg.register_command({kCmdOpen, "Open", "File"});
+
+    CountingHandler first({kCmdOpen}, /*claim=*/false);
+    CountingHandler second({kCmdOpen}, /*claim=*/true);
+
+    reg.add_handler(&second);   // added first → ends up behind…
+    reg.add_handler(&first);    // …the handler added last (priority front).
+    REQUIRE(reg.handler_count() == 2);
+
+    REQUIRE(reg.dispatch(kCmdOpen));
+    REQUIRE(first.calls_ == 1);   // got it first, declined to claim
+    REQUIRE(second.calls_ == 1);  // chain fell through and second claimed
+    REQUIRE(second.last_id_ == kCmdOpen);
+
+    // Disabled commands don't dispatch.
+    reg.set_enabled(kCmdOpen, false);
+    REQUIRE_FALSE(reg.dispatch(kCmdOpen));
+    REQUIRE(first.calls_ == 1);
+    REQUIRE(second.calls_ == 1);
+}
+
+TEST_CASE("CommandRegistry::dispatch_key_event routes through ShortcutMap",
+          "[view][command_registry][issue-6.4]") {
+    CommandRegistry reg;
+    reg.register_command({kCmdOpen, "Open", "File", KeyCode::o, kModCmd});
+
+    CountingHandler handler({kCmdOpen, kCmdSave});
+    reg.add_handler(&handler);
+
+    KeyEvent press_open;
+    press_open.key = KeyCode::o;
+    press_open.modifiers = kModCmd;
+    press_open.is_down = true;
+    REQUIRE(reg.dispatch_key_event(press_open));
+    REQUIRE(handler.calls_ == 1);
+
+    KeyEvent press_release = press_open;
+    press_release.is_down = false;
+    REQUIRE_FALSE(reg.dispatch_key_event(press_release));  // key-up ignored
+
+    KeyEvent press_unbound;
+    press_unbound.key = KeyCode::z;
+    press_unbound.modifiers = 0;
+    press_unbound.is_down = true;
+    REQUIRE_FALSE(reg.dispatch_key_event(press_unbound));
+    REQUIRE(handler.calls_ == 1);
+}
+
+TEST_CASE("CommandRegistry remove_handler stops dispatching to it",
+          "[view][command_registry][issue-6.4]") {
+    CommandRegistry reg;
+    reg.register_command({kCmdOpen, "Open", "File"});
+
+    CountingHandler handler({kCmdOpen});
+    reg.add_handler(&handler);
+    REQUIRE(reg.dispatch(kCmdOpen));
+    REQUIRE(handler.calls_ == 1);
+
+    reg.remove_handler(&handler);
+    REQUIRE(reg.handler_count() == 0);
+    REQUIRE_FALSE(reg.dispatch(kCmdOpen));
+    REQUIRE(handler.calls_ == 1);
+
+    // remove_handler with unknown pointer is a no-op.
+    reg.remove_handler(&handler);
+    reg.remove_handler(nullptr);
+}
+
+TEST_CASE("ShortcutMap binds, unbinds, and lists chords",
+          "[view][command_registry][issue-6.4]") {
+    ShortcutMap map;
+    map.bind(KeyCode::o, kModCmd, kCmdOpen);
+    map.bind(KeyCode::f5, 0, kCmdOpen);   // two chords → same command
+    map.bind(KeyCode::s, kModCmd, kCmdSave);
+
+    REQUIRE(map.find(KeyCode::o, kModCmd) == kCmdOpen);
+    REQUIRE(map.find(KeyCode::f5, 0) == kCmdOpen);
+    REQUIRE(map.find(KeyCode::s, kModCmd) == kCmdSave);
+    REQUIRE(map.find(KeyCode::z, 0) == kInvalidCommandID);
+
+    auto open_chords = map.chords_for(kCmdOpen);
+    REQUIRE(open_chords.size() == 2);
+    std::unordered_set<int> keys;
+    for (auto c : open_chords) keys.insert(static_cast<int>(c.key));
+    REQUIRE(keys.count(static_cast<int>(KeyCode::o)) == 1);
+    REQUIRE(keys.count(static_cast<int>(KeyCode::f5)) == 1);
+
+    map.unbind(KeyCode::o, kModCmd);
+    REQUIRE(map.find(KeyCode::o, kModCmd) == kInvalidCommandID);
+    REQUIRE(map.chords_for(kCmdOpen).size() == 1);
+
+    map.unbind_command(kCmdOpen);
+    REQUIRE(map.chords_for(kCmdOpen).empty());
+    REQUIRE(map.find(KeyCode::s, kModCmd) == kCmdSave);
+
+    // Binding to kInvalidCommandID is an unbind.
+    map.bind(KeyCode::s, kModCmd, kInvalidCommandID);
+    REQUIRE(map.find(KeyCode::s, kModCmd) == kInvalidCommandID);
+}
+
+TEST_CASE("ShortcutMap rebinding replaces the previous owner",
+          "[view][command_registry][issue-6.4]") {
+    ShortcutMap map;
+    map.bind(KeyCode::o, kModCmd, kCmdOpen);
+    map.bind(KeyCode::o, kModCmd, kCmdSave);   // steal the chord
+    REQUIRE(map.find(KeyCode::o, kModCmd) == kCmdSave);
+}
+
+TEST_CASE("ShortcutMap persists through PropertiesFile round-trip",
+          "[view][command_registry][issue-6.4]") {
+    ShortcutMap map;
+    map.bind(KeyCode::o, kModCmd, kCmdOpen);
+    map.bind(KeyCode::s, kModCmd, kCmdSave);
+    map.bind(KeyCode::f5, 0, kCmdUndo);
+
+    pulp::state::PropertiesFile props;
+    map.save_to(props, "shortcuts");
+    // Independent reading round-trip — props is the only carrier.
+
+    ShortcutMap restored;
+    REQUIRE(restored.load_from(props, "shortcuts"));
+    REQUIRE(restored.find(KeyCode::o, kModCmd) == kCmdOpen);
+    REQUIRE(restored.find(KeyCode::s, kModCmd) == kCmdSave);
+    REQUIRE(restored.find(KeyCode::f5, 0) == kCmdUndo);
+    REQUIRE(restored.size() == 3);
+
+    // Round-trip with explicit save/load through a temp JSON file too.
+    const auto path = temp_props_path("roundtrip");
+    REQUIRE(props.save(path));
+    pulp::state::PropertiesFile loaded;
+    REQUIRE(loaded.load(path));
+    ShortcutMap restored_from_disk;
+    REQUIRE(restored_from_disk.load_from(loaded, "shortcuts"));
+    REQUIRE(restored_from_disk.find(KeyCode::s, kModCmd) == kCmdSave);
+    std::remove(path.c_str());
+}
+
+TEST_CASE("CommandRegistry loaded ShortcutMap takes priority over defaults",
+          "[view][command_registry][issue-6.4]") {
+    // The header documents: "load() before register_command so user
+    // rebindings take priority." This pins that ordering.
+    pulp::state::PropertiesFile props;
+    ShortcutMap saved;
+    saved.bind(KeyCode::p, kModCmd, kCmdOpen);   // user rebound Open → Cmd-P
+    saved.save_to(props);
+
+    CommandRegistry reg;
+    REQUIRE(reg.shortcuts().load_from(props));
+
+    // Register with a *different* default chord — the loaded user binding
+    // should be honoured and the default chord should not get bound.
+    reg.register_command({kCmdOpen, "Open", "File", KeyCode::o, kModCmd});
+
+    REQUIRE(reg.shortcuts().find(KeyCode::p, kModCmd) == kCmdOpen);
+    REQUIRE(reg.shortcuts().find(KeyCode::o, kModCmd) == kInvalidCommandID);
+}
+
+TEST_CASE("KeyMappingEditor: click row + press chord rebinds and persists",
+          "[view][command_registry][issue-6.4]") {
+    CommandRegistry reg;
+    reg.register_command({kCmdOpen, "Open", "File", KeyCode::o, kModCmd});
+    reg.register_command({kCmdSave, "Save", "File", KeyCode::s, kModCmd});
+
+    pulp::state::PropertiesFile props;
+    KeyMappingEditor editor(reg);
+    editor.set_persistence(&props);
+    editor.set_bounds({0, 0, 400, 200});
+
+    // Row 0 is the header; row 1 = first command (Open).
+    pulp::view::Point click{50.0f, editor.row_height() * 1.5f};
+    editor.on_mouse_down(click);
+    REQUIRE(editor.is_capturing());
+    REQUIRE(editor.capturing_command() == kCmdOpen);
+
+    KeyEvent press;
+    press.key = KeyCode::p;
+    press.modifiers = kModCmd | kModShift;
+    press.is_down = true;
+    REQUIRE(editor.on_key_event(press));
+    REQUIRE_FALSE(editor.is_capturing());
+
+    REQUIRE(reg.shortcuts().find(KeyCode::p, kModCmd | kModShift) == kCmdOpen);
+    REQUIRE(reg.shortcuts().find(KeyCode::o, kModCmd) == kInvalidCommandID);
+
+    // Persistence flushed straight into the PropertiesFile.
+    ShortcutMap restored;
+    REQUIRE(restored.load_from(props));
+    REQUIRE(restored.find(KeyCode::p, kModCmd | kModShift) == kCmdOpen);
+
+    // ESC during capture cancels without rebinding.
+    editor.begin_capture(kCmdSave);
+    REQUIRE(editor.is_capturing());
+    KeyEvent esc;
+    esc.key = KeyCode::escape;
+    esc.modifiers = 0;
+    esc.is_down = true;
+    REQUIRE(editor.on_key_event(esc));
+    REQUIRE_FALSE(editor.is_capturing());
+    REQUIRE(reg.shortcuts().find(KeyCode::s, kModCmd) == kCmdSave);
+}
+
+TEST_CASE("KeyMappingEditor::rebind() bypasses capture",
+          "[view][command_registry][issue-6.4]") {
+    CommandRegistry reg;
+    reg.register_command({kCmdOpen, "Open", "File", KeyCode::o, kModCmd});
+    KeyMappingEditor editor(reg);
+    std::vector<std::tuple<CommandID, KeyCode, std::uint16_t>> events;
+    editor.on_rebound = [&](CommandID id, KeyCode k, std::uint16_t m) {
+        events.emplace_back(id, k, m);
+    };
+    editor.rebind(kCmdOpen, KeyCode::f9, 0);
+    REQUIRE(reg.shortcuts().find(KeyCode::f9, 0) == kCmdOpen);
+    REQUIRE(events.size() == 1);
+    REQUIRE(std::get<0>(events.back()) == kCmdOpen);
+    REQUIRE(std::get<1>(events.back()) == KeyCode::f9);
+    REQUIRE(std::get<2>(events.back()) == 0);
+
+    // Unbind by passing KeyCode::unknown.
+    editor.rebind(kCmdOpen, KeyCode::unknown, 0);
+    REQUIRE(reg.shortcuts().chords_for(kCmdOpen).empty());
+    REQUIRE(events.size() == 2);
+    REQUIRE(std::get<1>(events.back()) == KeyCode::unknown);
+}
+
+TEST_CASE("KeyMappingEditor accepts_text_input toggles with capture",
+          "[view][command_registry][issue-6.4]") {
+    CommandRegistry reg;
+    reg.register_command({kCmdOpen, "Open", "File"});
+    KeyMappingEditor editor(reg);
+    REQUIRE_FALSE(editor.accepts_text_input());
+    editor.begin_capture(kCmdOpen);
+    REQUIRE(editor.accepts_text_input());
+    editor.cancel_capture();
+    REQUIRE_FALSE(editor.accepts_text_input());
+}
+
+TEST_CASE("format_chord renders modifiers in canonical order",
+          "[view][command_registry][issue-6.4]") {
+    REQUIRE(format_chord(KeyCode::s, kModCmd) == "Cmd+S");
+    REQUIRE(format_chord(KeyCode::o, kModCmd | kModShift) == "Shift+Cmd+O");
+    REQUIRE(format_chord(KeyCode::f5, 0) == "F5");
+    REQUIRE(format_chord(KeyCode::escape, kModCtrl | kModAlt) ==
+            "Ctrl+Alt+Escape");
+    REQUIRE(format_chord(KeyCode::unknown, 0) == "—");
+}


### PR DESCRIPTION
## Summary

Item 6.4 from `planning/2026-05-24-macos-plugin-authoring-plan.md` — Pulp-native command dispatch + keyboard-shortcut routing + a UI for rebinding.

- **New public API** in `core/view`:
  - `CommandRegistry` (central dispatcher), `CommandHandler` (interface), `CommandInfo` (metadata), `ShortcutMap` ((key, modifiers) → command id), `KeyMappingEditor` (rebind UI), `format_chord()` helper.
- **Routing** reuses the existing focus chain via the new `CommandRegistry::dispatch_key_event(KeyEvent)` — hosts call it before or after their per-View `on_key_event` delivery. Returns true iff a chord matched AND a handler claimed the command.
- **Persistence** rides `pulp::state::PropertiesFile::save_to/load_from` with a configurable prefix so multiple registries can share one settings file; the editor flushes after every commit.
- **Default chord precedence**: `register_command` only binds the default chord if (a) it's free AND (b) the command has no existing binding — so apps can `load()` a saved `ShortcutMap` BEFORE registration and keep user rebindings.

Naming is Pulp-native per the section 6.4 license-lineage note — behavior contract first, not class-name parity with any reference framework.

## Tests

`test/test_command_registry.cpp` — 13 cases / 79 assertions covering register/dispatch/handler-chain/disabled-skip/key-event routing/bind+unbind+lookup/persistence round-trip/loaded-priority/editor click-to-rebind+ESC-cancel/editor rebind() bypass/accepts_text_input toggle/format_chord canonical-order. Linked as `pulp-test-command-registry` against `pulp::view` + `pulp::state`.

## Tracker

`planning/2026-05-24-macos-plugin-authoring-plan.md` row 6.4 flipped to 🟡 with the shipped-surface summary; PR # + merge SHA will be backfilled post-merge.

## Test plan

- [x] `cmake --build build --target pulp-test-command-registry`
- [x] `./build/test/pulp-test-command-registry` — 79 assertions across 13 cases pass
- [x] `ctest -R "CommandRegistry|KeyMappingEditor|ShortcutMap|format_chord"` — 13/13 pass
- [ ] CI macOS / Linux / Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)