### PR TITLE
feat(midi): MIDI-CI Property Exchange spec compliance (item 8.4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.236.0
+    VERSION 0.237.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/midi/CMakeLists.txt
+++ b/core/midi/CMakeLists.txt
@@ -19,6 +19,8 @@ target_include_directories(pulp-midi PUBLIC
 target_sources(pulp-midi PRIVATE
     src/midi_file.cpp
     src/midi_ci.cpp
+    src/midi_ci_pe.cpp
+    src/mcoded7.cpp
     src/mpe_voice_tracker.cpp
     src/running_status.cpp
 )

--- a/core/midi/include/pulp/midi/mcoded7.hpp
+++ b/core/midi/include/pulp/midi/mcoded7.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+// Mcoded7 — MIDI 2.0 Capability Inquiry property-exchange byte-packing.
+// Packs 7 arbitrary 8-bit bytes into 8 MIDI bytes (a leading high-bit byte
+// followed by seven low-7-bit bytes), so binary payloads can travel inside a
+// SysEx envelope without ever setting bit 7.
+//
+// Reference: MIDI 2.0 / MIDI-CI v1.2 spec, "Mcoded7 Data Encoding".
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace pulp::midi {
+
+/// Encode raw 8-bit bytes into Mcoded7. Output is `ceil(input/7) * 8 - extra`
+/// where `extra` trims trailing slots when the final group is short.
+/// The encoded stream contains only values <= 0x7F and is safe to embed in
+/// MIDI SysEx.
+std::vector<uint8_t> mcoded7_encode(const uint8_t* data, std::size_t size);
+
+inline std::vector<uint8_t> mcoded7_encode(const std::vector<uint8_t>& data) {
+    return mcoded7_encode(data.data(), data.size());
+}
+
+/// Decode an Mcoded7-encoded stream back to raw 8-bit bytes.
+/// Returns an empty vector if the input is malformed (contains a byte
+/// with bit 7 set anywhere it must not, or a final group's high-bit
+/// byte references more low bytes than were actually transmitted).
+std::vector<uint8_t> mcoded7_decode(const uint8_t* data, std::size_t size);
+
+inline std::vector<uint8_t> mcoded7_decode(const std::vector<uint8_t>& data) {
+    return mcoded7_decode(data.data(), data.size());
+}
+
+}  // namespace pulp::midi

--- a/core/midi/include/pulp/midi/midi_ci_pe.hpp
+++ b/core/midi/include/pulp/midi/midi_ci_pe.hpp
@@ -1,0 +1,192 @@
+#pragma once
+
+// MIDI-CI Property Exchange (PE) — multipart Get/Set messaging plus
+// Subscribe/Notify management on top of the discovery layer.
+//
+// The PE wire format wraps every Get/Set/Subscribe Inquiry and Reply in
+// SysEx envelopes whose body looks like:
+//
+//   request_id        : 1 byte (1..0x7F; 0 reserved)
+//   header_length     : 2 bytes 7-bit LE
+//   header_data       : N bytes Mcoded7-encoded JSON UTF-8
+//   total_chunks      : 2 bytes 7-bit LE
+//   chunk_number      : 2 bytes 7-bit LE  (1-indexed)
+//   payload_length    : 2 bytes 7-bit LE
+//   payload_data      : N bytes Mcoded7-encoded resource bytes
+//
+// Pulp implements the framing + Mcoded7 + JSON-header construction here.
+// zlib payload encoding (MIDI-CI v1.2 §6.3) is out-of-scope for this slice
+// and is tracked in the follow-up note in the spec doc.
+//
+// This file is intentionally header-only-ish: it owns no I/O. The caller
+// drives SysEx in/out around it.
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include <pulp/midi/midi_ci.hpp>
+
+namespace pulp::midi {
+
+/// PE sub-IDs (MIDI-CI sub-ID #2 byte). Mirrors `CiMessageType` for PE.
+enum class PeMessageType : uint8_t {
+    GetInquiry      = 0x34,
+    GetReply        = 0x35,
+    SetInquiry      = 0x36,
+    SetReply        = 0x37,
+    SubscribeInquiry = 0x38,
+    SubscribeReply   = 0x39,
+    Notify           = 0x3F,
+};
+
+/// A single PE chunk, after Mcoded7 decode of header + payload.
+/// Caller-owned UTF-8 strings; decoded JSON header is a string the caller
+/// can parse with `choc::json` (already vendored).
+struct PeChunk {
+    uint8_t request_id = 0;
+    uint16_t total_chunks = 0;
+    uint16_t chunk_number = 0;       ///< 1-indexed
+    std::string header_json;         ///< Decoded JSON UTF-8
+    std::vector<uint8_t> payload;    ///< Decoded resource bytes
+};
+
+/// Builder for PE message wire bytes. `pe_type` is one of the PE
+/// `CiMessageType` sub-IDs. `header_json` is plain UTF-8 JSON — the
+/// caller owns its schema (resource/, command/, status/, etc.).
+///
+/// Returns a complete SysEx envelope: F0 7E 7F 0D <sub-id> version
+/// src(4) dst(4) request_id hdr_len(2) hdr(Mcoded7) total(2)
+/// chunk_num(2) pay_len(2) pay(Mcoded7) F7.
+std::vector<uint8_t> pe_build_message(PeMessageType pe_type,
+                                      uint8_t ci_version,
+                                      MUID source,
+                                      MUID destination,
+                                      uint8_t request_id,
+                                      std::string_view header_json,
+                                      uint16_t total_chunks,
+                                      uint16_t chunk_number,
+                                      const uint8_t* payload,
+                                      std::size_t payload_size);
+
+inline std::vector<uint8_t> pe_build_message(PeMessageType pe_type,
+                                             uint8_t ci_version,
+                                             MUID source,
+                                             MUID destination,
+                                             uint8_t request_id,
+                                             std::string_view header_json,
+                                             uint16_t total_chunks,
+                                             uint16_t chunk_number,
+                                             const std::vector<uint8_t>& payload) {
+    return pe_build_message(pe_type, ci_version, source, destination,
+                            request_id, header_json, total_chunks,
+                            chunk_number, payload.data(), payload.size());
+}
+
+/// Parse a single PE SysEx envelope into a `PeChunk`. Returns `nullopt` if
+/// the buffer is not a well-formed PE message or fails Mcoded7 decode.
+/// Caller is responsible for matching `request_id` and reassembling chunks.
+std::optional<PeChunk> pe_parse_message(const uint8_t* data, std::size_t size);
+
+/// Split a logical PE Get/Set into wire-ready chunks bounded by
+/// `max_payload_bytes` of decoded resource per chunk. The header is
+/// repeated verbatim in each chunk per the spec.
+std::vector<std::vector<uint8_t>>
+pe_split_into_chunks(PeMessageType pe_type,
+                     uint8_t ci_version,
+                     MUID source,
+                     MUID destination,
+                     uint8_t request_id,
+                     std::string_view header_json,
+                     const uint8_t* payload,
+                     std::size_t payload_size,
+                     std::size_t max_payload_bytes);
+
+/// Reassemble a stream of incoming `PeChunk`s for the same `request_id`.
+/// Holds chunks until `total_chunks` have all been observed, then returns
+/// the concatenated payload and the (first) header.
+class PeReassembler {
+public:
+    /// Feed one chunk. Returns the fully reassembled chunk if this chunk
+    /// completes the transfer; otherwise `nullopt`.
+    std::optional<PeChunk> push(PeChunk chunk);
+
+    /// Drop any in-progress transfer for `request_id`.
+    void cancel(uint8_t request_id);
+
+    /// Number of in-flight transfers (test introspection).
+    std::size_t pending_transfers() const { return slots_.size(); }
+
+private:
+    struct Slot {
+        uint16_t total = 0;
+        uint16_t received = 0;
+        std::string header_json;
+        std::vector<std::vector<uint8_t>> chunks;  ///< chunk-num-1 -> bytes
+        std::vector<bool> seen;                    ///< per-chunk dup guard
+    };
+    std::unordered_map<uint8_t, Slot> slots_;
+};
+
+/// Builds a minimal PE JSON header. Plenty of producers will want to
+/// build their own, but this covers the common "resource + status" case
+/// and keeps tests from depending on a JSON library at the surface.
+///
+/// `command` is one of "start" / "end" / "partial" / "full" / "notify".
+/// Empty `command` is omitted.
+std::string pe_header_make(std::string_view resource,
+                           std::string_view command = {},
+                           int status = 200);
+
+/// Parse a PE JSON header. Returns true on success and fills the out
+/// params; returns false if the header is not valid JSON. Only the
+/// fields used by the PE framing are extracted; everything else is
+/// considered application data and ignored here.
+bool pe_header_parse(std::string_view json,
+                     std::string* resource,
+                     std::string* command,
+                     int* status);
+
+// ── Subscription management ─────────────────────────────────────────────
+
+/// One active subscription state — owned by `PeSubscriptionManager`.
+struct PeSubscription {
+    std::string subscription_id;   ///< Server-allocated, opaque to client
+    std::string resource;
+    MUID subscriber;
+};
+
+/// Authoritative subscription registry on the responder side.
+///
+/// Lifecycle:
+///   - `subscribe(resource, peer)` returns a new subscription id and
+///     records the binding.
+///   - `unsubscribe(id)` removes it.
+///   - `subscribers_of(resource)` is used by the responder when a
+///     resource changes to fan out Notify messages.
+class PeSubscriptionManager {
+public:
+    /// Allocate a subscription. `subscription_id` is generated
+    /// deterministically and is unique within this manager instance.
+    std::string subscribe(std::string_view resource, MUID subscriber);
+
+    /// Remove a subscription. Returns true if it existed.
+    bool unsubscribe(std::string_view subscription_id);
+
+    /// Returns all subscribers (MUID + id) currently bound to `resource`.
+    std::vector<PeSubscription> subscribers_of(std::string_view resource) const;
+
+    /// All known subscriptions (test introspection).
+    const std::vector<PeSubscription>& all() const { return subs_; }
+
+private:
+    std::vector<PeSubscription> subs_;
+    uint64_t next_id_ = 1;
+};
+
+}  // namespace pulp::midi

--- a/core/midi/src/mcoded7.cpp
+++ b/core/midi/src/mcoded7.cpp
@@ -1,0 +1,66 @@
+#include <pulp/midi/mcoded7.hpp>
+
+namespace pulp::midi {
+
+std::vector<uint8_t> mcoded7_encode(const uint8_t* data, std::size_t size) {
+    std::vector<uint8_t> out;
+    if (data == nullptr || size == 0) return out;
+
+    // Worst-case: one extra "high-bit" byte for every group of 7 input bytes.
+    out.reserve(((size + 6) / 7) * 8);
+
+    std::size_t i = 0;
+    while (i < size) {
+        const std::size_t group = (size - i < 7) ? (size - i) : 7;
+
+        // High-bit byte: bit (group-1) = high bit of the first body byte,
+        // down to bit 0 = high bit of the last body byte. Bits beyond
+        // `group` are zero.
+        uint8_t hi = 0;
+        for (std::size_t k = 0; k < group; ++k) {
+            const uint8_t in_byte = data[i + k];
+            if (in_byte & 0x80) {
+                hi |= static_cast<uint8_t>(1u << (group - 1 - k));
+            }
+        }
+        out.push_back(hi);
+        for (std::size_t k = 0; k < group; ++k) {
+            out.push_back(static_cast<uint8_t>(data[i + k] & 0x7F));
+        }
+        i += group;
+    }
+    return out;
+}
+
+std::vector<uint8_t> mcoded7_decode(const uint8_t* data, std::size_t size) {
+    std::vector<uint8_t> out;
+    if (data == nullptr || size == 0) return out;
+
+    out.reserve((size / 8) * 7 + 7);
+
+    std::size_t i = 0;
+    while (i < size) {
+        const uint8_t hi = data[i];
+        if (hi & 0x80) {
+            // Reserved: high-bit byte must itself have bit 7 clear.
+            return {};
+        }
+        const std::size_t remaining = size - i - 1;
+        const std::size_t group = (remaining < 7) ? remaining : 7;
+        if (group == 0) {
+            // Lone high-bit byte at end: malformed.
+            return {};
+        }
+        for (std::size_t k = 0; k < group; ++k) {
+            const uint8_t lo = data[i + 1 + k];
+            if (lo & 0x80) return {};
+            const uint8_t bit = static_cast<uint8_t>(
+                (hi >> (group - 1 - k)) & 0x1u);
+            out.push_back(static_cast<uint8_t>(lo | (bit ? 0x80 : 0)));
+        }
+        i += 1 + group;
+    }
+    return out;
+}
+
+}  // namespace pulp::midi

--- a/core/midi/src/midi_ci_pe.cpp
+++ b/core/midi/src/midi_ci_pe.cpp
@@ -1,0 +1,381 @@
+#include <pulp/midi/midi_ci_pe.hpp>
+#include <pulp/midi/mcoded7.hpp>
+
+#include <algorithm>
+#include <cstring>
+#include <sstream>
+
+namespace pulp::midi {
+
+// ── Wire helpers ────────────────────────────────────────────────────────
+
+namespace {
+
+void push_muid(std::vector<uint8_t>& buf, MUID muid) {
+    buf.push_back(muid.value & 0x7F);
+    buf.push_back((muid.value >> 7) & 0x7F);
+    buf.push_back((muid.value >> 14) & 0x7F);
+    buf.push_back((muid.value >> 21) & 0x7F);
+}
+
+void push_u16_le7(std::vector<uint8_t>& buf, uint16_t v) {
+    buf.push_back(v & 0x7F);
+    buf.push_back((v >> 7) & 0x7F);
+}
+
+uint16_t load_u16_le7(const uint8_t* p) {
+    return static_cast<uint16_t>(p[0])
+         | static_cast<uint16_t>(p[1] << 7);
+}
+
+bool is_pe_message(uint8_t sub_id) {
+    switch (static_cast<PeMessageType>(sub_id)) {
+        case PeMessageType::GetInquiry:
+        case PeMessageType::GetReply:
+        case PeMessageType::SetInquiry:
+        case PeMessageType::SetReply:
+        case PeMessageType::SubscribeInquiry:
+        case PeMessageType::SubscribeReply:
+        case PeMessageType::Notify:
+            return true;
+    }
+    return false;
+}
+
+} // namespace
+
+// ── pe_build_message / pe_parse_message ─────────────────────────────────
+
+std::vector<uint8_t> pe_build_message(PeMessageType pe_type,
+                                      uint8_t ci_version,
+                                      MUID source,
+                                      MUID destination,
+                                      uint8_t request_id,
+                                      std::string_view header_json,
+                                      uint16_t total_chunks,
+                                      uint16_t chunk_number,
+                                      const uint8_t* payload,
+                                      std::size_t payload_size) {
+    std::vector<uint8_t> msg;
+    msg.reserve(32 + header_json.size() * 2 + payload_size * 2);
+
+    // Universal SysEx + CI header.
+    msg.push_back(0xF0);
+    msg.push_back(0x7E);
+    msg.push_back(0x7F);
+    msg.push_back(0x0D);
+    msg.push_back(static_cast<uint8_t>(pe_type));
+    msg.push_back(ci_version);
+    push_muid(msg, source);
+    push_muid(msg, destination);
+
+    // PE body.
+    msg.push_back(request_id & 0x7F);
+
+    auto enc_header = mcoded7_encode(
+        reinterpret_cast<const uint8_t*>(header_json.data()),
+        header_json.size());
+    push_u16_le7(msg, static_cast<uint16_t>(enc_header.size()));
+    msg.insert(msg.end(), enc_header.begin(), enc_header.end());
+
+    push_u16_le7(msg, total_chunks);
+    push_u16_le7(msg, chunk_number);
+
+    auto enc_payload = (payload_size == 0)
+        ? std::vector<uint8_t>{}
+        : mcoded7_encode(payload, payload_size);
+    push_u16_le7(msg, static_cast<uint16_t>(enc_payload.size()));
+    msg.insert(msg.end(), enc_payload.begin(), enc_payload.end());
+
+    msg.push_back(0xF7);
+    return msg;
+}
+
+std::optional<PeChunk> pe_parse_message(const uint8_t* data, std::size_t size) {
+    if (data == nullptr) return std::nullopt;
+    // Min: F0 7E 7F 0D sub-id ver src(4) dst(4) req hdr_len(2)
+    //      total(2) chunk(2) pay_len(2) F7 = 22 bytes.
+    if (size < 22) return std::nullopt;
+    if (data[0] != 0xF0 || data[1] != 0x7E || data[3] != 0x0D) return std::nullopt;
+    if (!is_pe_message(data[4])) return std::nullopt;
+    if (data[size - 1] != 0xF7) return std::nullopt;
+
+    std::size_t p = 14;  // start of PE body
+    PeChunk chunk;
+    chunk.request_id = data[p++] & 0x7F;
+
+    if (p + 2 > size - 1) return std::nullopt;
+    uint16_t hdr_len = load_u16_le7(data + p);
+    p += 2;
+    if (p + hdr_len > size - 1) return std::nullopt;
+    auto hdr_dec = mcoded7_decode(data + p, hdr_len);
+    // hdr_dec.empty() with hdr_len > 0 means malformed Mcoded7.
+    if (hdr_len > 0 && hdr_dec.empty()) return std::nullopt;
+    chunk.header_json.assign(hdr_dec.begin(), hdr_dec.end());
+    p += hdr_len;
+
+    if (p + 6 > size - 1) return std::nullopt;
+    chunk.total_chunks = load_u16_le7(data + p);
+    p += 2;
+    chunk.chunk_number = load_u16_le7(data + p);
+    p += 2;
+    uint16_t pay_len = load_u16_le7(data + p);
+    p += 2;
+    if (p + pay_len > size - 1) return std::nullopt;
+    if (pay_len > 0) {
+        chunk.payload = mcoded7_decode(data + p, pay_len);
+        if (chunk.payload.empty()) return std::nullopt;
+    }
+    p += pay_len;
+
+    if (p != size - 1) return std::nullopt;  // junk before F7
+    return chunk;
+}
+
+std::vector<std::vector<uint8_t>>
+pe_split_into_chunks(PeMessageType pe_type,
+                     uint8_t ci_version,
+                     MUID source,
+                     MUID destination,
+                     uint8_t request_id,
+                     std::string_view header_json,
+                     const uint8_t* payload,
+                     std::size_t payload_size,
+                     std::size_t max_payload_bytes) {
+    if (max_payload_bytes == 0) max_payload_bytes = 1;
+    std::vector<std::vector<uint8_t>> chunks;
+
+    if (payload_size == 0) {
+        chunks.push_back(pe_build_message(
+            pe_type, ci_version, source, destination,
+            request_id, header_json,
+            /*total*/ 1, /*num*/ 1,
+            nullptr, 0));
+        return chunks;
+    }
+
+    std::size_t total = (payload_size + max_payload_bytes - 1) / max_payload_bytes;
+    if (total > 0x3FFF) total = 0x3FFF;  // 14-bit ceiling
+
+    for (std::size_t i = 0; i < total; ++i) {
+        std::size_t off = i * max_payload_bytes;
+        std::size_t len = std::min(max_payload_bytes, payload_size - off);
+        chunks.push_back(pe_build_message(
+            pe_type, ci_version, source, destination,
+            request_id, header_json,
+            static_cast<uint16_t>(total),
+            static_cast<uint16_t>(i + 1),
+            payload + off, len));
+    }
+    return chunks;
+}
+
+// ── PeReassembler ───────────────────────────────────────────────────────
+
+std::optional<PeChunk> PeReassembler::push(PeChunk chunk) {
+    if (chunk.total_chunks == 0 || chunk.chunk_number == 0) return std::nullopt;
+    if (chunk.chunk_number > chunk.total_chunks) return std::nullopt;
+
+    auto& slot = slots_[chunk.request_id];
+    if (slot.total == 0) {
+        slot.total = chunk.total_chunks;
+        slot.header_json = chunk.header_json;
+        slot.seen.assign(chunk.total_chunks, false);
+        slot.chunks.assign(chunk.total_chunks, std::vector<uint8_t>{});
+    } else if (slot.total != chunk.total_chunks) {
+        // Sender changed its mind mid-transfer — abort.
+        slots_.erase(chunk.request_id);
+        return std::nullopt;
+    }
+
+    const std::size_t idx = chunk.chunk_number - 1;
+    if (slot.seen[idx]) {
+        // Duplicate chunk: ignore but don't error.
+        return std::nullopt;
+    }
+    slot.seen[idx] = true;
+    slot.received++;
+    slot.chunks[idx] = std::move(chunk.payload);
+
+    if (slot.received != slot.total) return std::nullopt;
+
+    // Completion: stitch chunks in order.
+    PeChunk out;
+    out.request_id = chunk.request_id;
+    out.total_chunks = slot.total;
+    out.chunk_number = slot.total;
+    out.header_json = slot.header_json;
+    for (auto& part : slot.chunks) {
+        out.payload.insert(out.payload.end(), part.begin(), part.end());
+    }
+    slots_.erase(chunk.request_id);
+    return out;
+}
+
+void PeReassembler::cancel(uint8_t request_id) {
+    slots_.erase(request_id);
+}
+
+// ── PE JSON header (resource/command/status only) ───────────────────────
+
+namespace {
+
+void json_escape(std::ostringstream& os, std::string_view s) {
+    for (char c : s) {
+        switch (c) {
+            case '"':  os << "\\\""; break;
+            case '\\': os << "\\\\"; break;
+            case '\b': os << "\\b"; break;
+            case '\f': os << "\\f"; break;
+            case '\n': os << "\\n"; break;
+            case '\r': os << "\\r"; break;
+            case '\t': os << "\\t"; break;
+            default:
+                if (static_cast<unsigned char>(c) < 0x20) {
+                    char buf[8];
+                    std::snprintf(buf, sizeof(buf), "\\u%04x",
+                                  static_cast<unsigned>(c));
+                    os << buf;
+                } else {
+                    os << c;
+                }
+        }
+    }
+}
+
+// Tiny PE-header JSON value extractor. Handles only flat string and number
+// fields at the top level — which is all the framing layer needs.
+// Returns empty optional on missing key or parse failure.
+std::optional<std::string> json_get_string(std::string_view json,
+                                           std::string_view key) {
+    std::string needle = "\"";
+    needle += std::string(key);
+    needle += "\"";
+    auto pos = json.find(needle);
+    if (pos == std::string_view::npos) return std::nullopt;
+    pos += needle.size();
+    // skip ws + colon
+    while (pos < json.size() && (json[pos] == ' ' || json[pos] == ':' ||
+                                  json[pos] == '\t')) ++pos;
+    if (pos >= json.size() || json[pos] != '"') return std::nullopt;
+    ++pos;
+    std::string out;
+    while (pos < json.size() && json[pos] != '"') {
+        if (json[pos] == '\\' && pos + 1 < json.size()) {
+            char esc = json[pos + 1];
+            switch (esc) {
+                case '"': out += '"'; break;
+                case '\\': out += '\\'; break;
+                case '/': out += '/'; break;
+                case 'n': out += '\n'; break;
+                case 'r': out += '\r'; break;
+                case 't': out += '\t'; break;
+                case 'b': out += '\b'; break;
+                case 'f': out += '\f'; break;
+                default: return std::nullopt;
+            }
+            pos += 2;
+        } else {
+            out += json[pos++];
+        }
+    }
+    if (pos >= json.size()) return std::nullopt;
+    return out;
+}
+
+std::optional<int> json_get_int(std::string_view json, std::string_view key) {
+    std::string needle = "\"";
+    needle += std::string(key);
+    needle += "\"";
+    auto pos = json.find(needle);
+    if (pos == std::string_view::npos) return std::nullopt;
+    pos += needle.size();
+    while (pos < json.size() && (json[pos] == ' ' || json[pos] == ':' ||
+                                  json[pos] == '\t')) ++pos;
+    if (pos >= json.size()) return std::nullopt;
+    bool neg = false;
+    if (json[pos] == '-') { neg = true; ++pos; }
+    if (pos >= json.size() || json[pos] < '0' || json[pos] > '9')
+        return std::nullopt;
+    int v = 0;
+    while (pos < json.size() && json[pos] >= '0' && json[pos] <= '9') {
+        v = v * 10 + (json[pos] - '0');
+        ++pos;
+    }
+    return neg ? -v : v;
+}
+
+} // namespace
+
+std::string pe_header_make(std::string_view resource,
+                           std::string_view command,
+                           int status) {
+    std::ostringstream os;
+    os << "{\"resource\":\"";
+    json_escape(os, resource);
+    os << "\"";
+    if (!command.empty()) {
+        os << ",\"command\":\"";
+        json_escape(os, command);
+        os << "\"";
+    }
+    os << ",\"status\":" << status << "}";
+    return os.str();
+}
+
+bool pe_header_parse(std::string_view json,
+                     std::string* resource,
+                     std::string* command,
+                     int* status) {
+    if (json.empty()) return false;
+    // Cheap structural check — full JSON validation is the application's
+    // concern; we only need to pull the framing-relevant keys.
+    auto r = json_get_string(json, "resource");
+    if (resource) {
+        if (r) *resource = *r;
+        else resource->clear();
+    }
+    auto c = json_get_string(json, "command");
+    if (command) {
+        if (c) *command = *c;
+        else command->clear();
+    }
+    auto s = json_get_int(json, "status");
+    if (status) {
+        *status = s.value_or(200);
+    }
+    return r.has_value() || c.has_value() || s.has_value();
+}
+
+// ── PeSubscriptionManager ───────────────────────────────────────────────
+
+std::string PeSubscriptionManager::subscribe(std::string_view resource,
+                                             MUID subscriber) {
+    PeSubscription s;
+    s.resource = std::string(resource);
+    s.subscriber = subscriber;
+    s.subscription_id = "sub-" + std::to_string(next_id_++);
+    subs_.push_back(s);
+    return s.subscription_id;
+}
+
+bool PeSubscriptionManager::unsubscribe(std::string_view subscription_id) {
+    auto it = std::find_if(subs_.begin(), subs_.end(),
+        [&](const PeSubscription& s) {
+            return s.subscription_id == subscription_id;
+        });
+    if (it == subs_.end()) return false;
+    subs_.erase(it);
+    return true;
+}
+
+std::vector<PeSubscription>
+PeSubscriptionManager::subscribers_of(std::string_view resource) const {
+    std::vector<PeSubscription> out;
+    for (const auto& s : subs_) {
+        if (s.resource == resource) out.push_back(s);
+    }
+    return out;
+}
+
+}  // namespace pulp::midi

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -779,6 +779,9 @@ pulp_add_test_suite(pulp-test-license LIBRARIES pulp::runtime)
 # MIDI CI tests
 pulp_add_test_suite(pulp-test-midi-ci LIBRARIES pulp::midi)
 
+# MIDI CI Property Exchange (PE) tests — issue-84, plan item 8.4
+pulp_add_test_suite(pulp-test-midi-ci-pe LIBRARIES pulp::midi)
+
 # AU v2 effect adapter MIDI-input tests — guards the 2026-04-22 fix that
 # wired HandleMIDIEvent / HandleSysEx into `PulpAUEffect` and flipped the
 # component type from aufx to aumf for descriptor.accepts_midi=true.

--- a/test/test_midi_ci_pe.cpp
+++ b/test/test_midi_ci_pe.cpp
@@ -1,0 +1,397 @@
+// MIDI-CI Property Exchange (PE) — framing, Mcoded7, chunker, reassembly,
+// JSON header, subscription manager. Targets the spec-compliance gap from
+// macOS plugin authoring plan item 8.4.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/midi/mcoded7.hpp>
+#include <pulp/midi/midi_ci_pe.hpp>
+
+#include <numeric>
+#include <random>
+#include <string>
+#include <vector>
+
+using namespace pulp::midi;
+
+// ── Mcoded7 ─────────────────────────────────────────────────────────────
+
+TEST_CASE("Mcoded7 round-trips empty input",
+          "[midi][ci][pe][mcoded7][issue-84]") {
+    auto enc = mcoded7_encode(nullptr, 0);
+    REQUIRE(enc.empty());
+    auto dec = mcoded7_decode(nullptr, 0);
+    REQUIRE(dec.empty());
+}
+
+TEST_CASE("Mcoded7 round-trips full groups",
+          "[midi][ci][pe][mcoded7][issue-84]") {
+    std::vector<uint8_t> input;
+    for (int i = 0; i < 14; ++i) input.push_back(static_cast<uint8_t>(0x80 + i));
+    auto enc = mcoded7_encode(input);
+    // 14 bytes -> 2 groups of (1 hi + 7 lo) = 16 bytes.
+    REQUIRE(enc.size() == 16);
+    for (auto b : enc) REQUIRE((b & 0x80) == 0);  // all <= 0x7F
+    auto dec = mcoded7_decode(enc);
+    REQUIRE(dec == input);
+}
+
+TEST_CASE("Mcoded7 round-trips short final group",
+          "[midi][ci][pe][mcoded7][issue-84]") {
+    std::vector<uint8_t> input{0xFF, 0x80, 0x01, 0x02};  // 4 bytes
+    auto enc = mcoded7_encode(input);
+    REQUIRE(enc.size() == 5);  // 1 hi + 4 lo
+    // Top two bits of hi byte mark the two 0x80+ inputs.
+    REQUIRE(enc[0] == 0b00001100);
+    auto dec = mcoded7_decode(enc);
+    REQUIRE(dec == input);
+}
+
+TEST_CASE("Mcoded7 round-trips arbitrary binary payload",
+          "[midi][ci][pe][mcoded7][issue-84]") {
+    std::vector<uint8_t> payload(1000);
+    std::mt19937 rng(42);
+    for (auto& b : payload) b = static_cast<uint8_t>(rng() & 0xFF);
+    auto enc = mcoded7_encode(payload);
+    for (auto b : enc) REQUIRE((b & 0x80) == 0);
+    auto dec = mcoded7_decode(enc);
+    REQUIRE(dec == payload);
+}
+
+TEST_CASE("Mcoded7 rejects high-bit byte in stream",
+          "[midi][ci][pe][mcoded7][issue-84]") {
+    std::vector<uint8_t> bad{0x00, 0x80};  // body byte has bit-7 set
+    REQUIRE(mcoded7_decode(bad).empty());
+
+    std::vector<uint8_t> bad_hi{0x81, 0x00};  // hi byte itself has bit-7 set
+    REQUIRE(mcoded7_decode(bad_hi).empty());
+}
+
+TEST_CASE("Mcoded7 rejects lone trailing high-bit byte",
+          "[midi][ci][pe][mcoded7][issue-84]") {
+    std::vector<uint8_t> bad{0x10};  // hi byte with no body
+    REQUIRE(mcoded7_decode(bad).empty());
+}
+
+// ── PE message build/parse ──────────────────────────────────────────────
+
+TEST_CASE("PE build/parse round-trips a single chunk",
+          "[midi][ci][pe][issue-84]") {
+    MUID src{0x01234567};
+    MUID dst{0x07654321};
+    std::vector<uint8_t> payload{0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0xFF};
+    auto header = pe_header_make("/DeviceInfo", "full", 200);
+
+    auto msg = pe_build_message(PeMessageType::GetReply, 2, src, dst,
+                                /*request_id*/ 0x12, header,
+                                /*total*/ 1, /*num*/ 1, payload);
+
+    REQUIRE(msg.front() == 0xF0);
+    REQUIRE(msg.back() == 0xF7);
+    REQUIRE(msg[4] == static_cast<uint8_t>(PeMessageType::GetReply));
+    for (std::size_t i = 1; i + 1 < msg.size(); ++i) {
+        REQUIRE((msg[i] & 0x80) == 0);  // body must be 7-bit clean
+    }
+
+    auto parsed = pe_parse_message(msg.data(), msg.size());
+    REQUIRE(parsed.has_value());
+    REQUIRE(parsed->request_id == 0x12);
+    REQUIRE(parsed->total_chunks == 1);
+    REQUIRE(parsed->chunk_number == 1);
+    REQUIRE(parsed->header_json == header);
+    REQUIRE(parsed->payload == payload);
+}
+
+TEST_CASE("PE parse rejects malformed envelopes",
+          "[midi][ci][pe][issue-84]") {
+    std::vector<uint8_t> too_short{0xF0, 0x7E};
+    REQUIRE_FALSE(pe_parse_message(too_short.data(), too_short.size()).has_value());
+
+    REQUIRE_FALSE(pe_parse_message(nullptr, 0).has_value());
+
+    // Build then corrupt sub-ID.
+    auto good = pe_build_message(PeMessageType::GetInquiry, 2,
+                                 MUID{1}, MUID{2}, 1, "{\"resource\":\"x\"}",
+                                 1, 1, nullptr, 0);
+    auto wrong_subid = good;
+    wrong_subid[4] = 0x70;  // discovery, not PE
+    REQUIRE_FALSE(pe_parse_message(wrong_subid.data(),
+                                   wrong_subid.size()).has_value());
+
+    auto truncated = good;
+    truncated.pop_back();  // drop F7
+    REQUIRE_FALSE(pe_parse_message(truncated.data(),
+                                   truncated.size()).has_value());
+}
+
+// ── Chunker ─────────────────────────────────────────────────────────────
+
+TEST_CASE("PE chunker splits payload into bounded chunks",
+          "[midi][ci][pe][issue-84]") {
+    std::vector<uint8_t> payload(250);
+    std::iota(payload.begin(), payload.end(), uint8_t{0});
+
+    auto chunks = pe_split_into_chunks(PeMessageType::GetReply, 2,
+                                       MUID{1}, MUID{2}, /*req*/ 7,
+                                       pe_header_make("/Big", "partial"),
+                                       payload.data(), payload.size(),
+                                       /*max_payload_bytes*/ 64);
+    REQUIRE(chunks.size() == 4);  // ceil(250/64) = 4
+
+    PeReassembler ra;
+    std::optional<PeChunk> done;
+    for (auto& wire : chunks) {
+        auto p = pe_parse_message(wire.data(), wire.size());
+        REQUIRE(p.has_value());
+        REQUIRE(p->request_id == 7);
+        REQUIRE(p->total_chunks == 4);
+        done = ra.push(*p);
+    }
+    REQUIRE(done.has_value());
+    REQUIRE(done->payload == payload);
+}
+
+TEST_CASE("PE chunker emits one chunk for empty payload",
+          "[midi][ci][pe][issue-84]") {
+    auto chunks = pe_split_into_chunks(PeMessageType::SubscribeInquiry, 2,
+                                       MUID{1}, MUID{2}, 5,
+                                       pe_header_make("/Stub", "start"),
+                                       nullptr, 0, 32);
+    REQUIRE(chunks.size() == 1);
+    auto p = pe_parse_message(chunks[0].data(), chunks[0].size());
+    REQUIRE(p.has_value());
+    REQUIRE(p->total_chunks == 1);
+    REQUIRE(p->chunk_number == 1);
+    REQUIRE(p->payload.empty());
+}
+
+TEST_CASE("PeReassembler handles out-of-order chunks",
+          "[midi][ci][pe][issue-84]") {
+    std::vector<uint8_t> payload{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    auto chunks = pe_split_into_chunks(PeMessageType::GetReply, 2,
+                                       MUID{1}, MUID{2}, 9,
+                                       pe_header_make("/X"),
+                                       payload.data(), payload.size(),
+                                       /*max*/ 3);
+    REQUIRE(chunks.size() == 4);
+
+    PeReassembler ra;
+    // Feed in reverse.
+    std::optional<PeChunk> done;
+    for (std::size_t i = chunks.size(); i-- > 0;) {
+        auto p = pe_parse_message(chunks[i].data(), chunks[i].size());
+        REQUIRE(p.has_value());
+        done = ra.push(*p);
+    }
+    REQUIRE(done.has_value());
+    REQUIRE(done->payload == payload);
+}
+
+TEST_CASE("PeReassembler ignores duplicate chunks",
+          "[midi][ci][pe][issue-84]") {
+    std::vector<uint8_t> payload{42, 43, 44};
+    auto chunks = pe_split_into_chunks(PeMessageType::GetReply, 2,
+                                       MUID{1}, MUID{2}, 4,
+                                       pe_header_make("/Y"),
+                                       payload.data(), payload.size(), 1);
+    REQUIRE(chunks.size() == 3);
+
+    PeReassembler ra;
+    auto p0 = pe_parse_message(chunks[0].data(), chunks[0].size());
+    auto p1 = pe_parse_message(chunks[1].data(), chunks[1].size());
+    auto p2 = pe_parse_message(chunks[2].data(), chunks[2].size());
+
+    REQUIRE_FALSE(ra.push(*p0).has_value());
+    REQUIRE_FALSE(ra.push(*p0).has_value());  // dup
+    REQUIRE_FALSE(ra.push(*p1).has_value());
+    auto done = ra.push(*p2);
+    REQUIRE(done.has_value());
+    REQUIRE(done->payload == payload);
+    REQUIRE(ra.pending_transfers() == 0);
+}
+
+TEST_CASE("PeReassembler cancels in-flight transfers",
+          "[midi][ci][pe][issue-84]") {
+    PeReassembler ra;
+    auto chunks = pe_split_into_chunks(PeMessageType::GetReply, 2,
+                                       MUID{1}, MUID{2}, 11,
+                                       pe_header_make("/Z"),
+                                       reinterpret_cast<const uint8_t*>("hi"),
+                                       2, 1);
+    auto p0 = pe_parse_message(chunks[0].data(), chunks[0].size());
+    ra.push(*p0);
+    REQUIRE(ra.pending_transfers() == 1);
+    ra.cancel(11);
+    REQUIRE(ra.pending_transfers() == 0);
+}
+
+TEST_CASE("PeReassembler rejects mismatched total_chunks mid-transfer",
+          "[midi][ci][pe][issue-84]") {
+    PeReassembler ra;
+    PeChunk a{};
+    a.request_id = 1;
+    a.total_chunks = 3;
+    a.chunk_number = 1;
+    a.payload = {1};
+    PeChunk b = a;
+    b.total_chunks = 5;
+    b.chunk_number = 2;
+    b.payload = {2};
+
+    REQUIRE_FALSE(ra.push(a).has_value());
+    REQUIRE_FALSE(ra.push(b).has_value());  // abort
+    REQUIRE(ra.pending_transfers() == 0);
+}
+
+// ── JSON header ─────────────────────────────────────────────────────────
+
+TEST_CASE("PE header build is parseable",
+          "[midi][ci][pe][header][issue-84]") {
+    auto h = pe_header_make("/DeviceInfo", "full", 200);
+    std::string r, c;
+    int s = 0;
+    REQUIRE(pe_header_parse(h, &r, &c, &s));
+    REQUIRE(r == "/DeviceInfo");
+    REQUIRE(c == "full");
+    REQUIRE(s == 200);
+}
+
+TEST_CASE("PE header omits empty command",
+          "[midi][ci][pe][header][issue-84]") {
+    auto h = pe_header_make("/X");
+    REQUIRE(h.find("command") == std::string::npos);
+    std::string r, c;
+    int s = 0;
+    REQUIRE(pe_header_parse(h, &r, &c, &s));
+    REQUIRE(r == "/X");
+    REQUIRE(c.empty());
+    REQUIRE(s == 200);
+}
+
+TEST_CASE("PE header escapes special chars in resource",
+          "[midi][ci][pe][header][issue-84]") {
+    auto h = pe_header_make("/with\"quote\\and\nnewline", "set", 404);
+    // Build->parse must round-trip the escaped string verbatim.
+    std::string r, c;
+    int s = 0;
+    REQUIRE(pe_header_parse(h, &r, &c, &s));
+    REQUIRE(r == "/with\"quote\\and\nnewline");
+    REQUIRE(c == "set");
+    REQUIRE(s == 404);
+}
+
+TEST_CASE("PE header parser handles negative status",
+          "[midi][ci][pe][header][issue-84]") {
+    std::string json = "{\"resource\":\"/x\",\"status\":-1}";
+    std::string r, c;
+    int s = 0;
+    REQUIRE(pe_header_parse(json, &r, &c, &s));
+    REQUIRE(r == "/x");
+    REQUIRE(s == -1);
+}
+
+TEST_CASE("PE header parser returns false on empty input",
+          "[midi][ci][pe][header][issue-84]") {
+    std::string r, c;
+    int s = 0;
+    REQUIRE_FALSE(pe_header_parse("", &r, &c, &s));
+}
+
+// ── Subscription manager ────────────────────────────────────────────────
+
+TEST_CASE("PeSubscriptionManager tracks resource subscribers",
+          "[midi][ci][pe][subscribe][issue-84]") {
+    PeSubscriptionManager mgr;
+    auto id1 = mgr.subscribe("/Mix/Gain", MUID{0x11});
+    auto id2 = mgr.subscribe("/Mix/Gain", MUID{0x22});
+    auto id3 = mgr.subscribe("/Mix/Pan",  MUID{0x33});
+
+    REQUIRE(id1 != id2);
+    REQUIRE(id2 != id3);
+
+    auto gain_subs = mgr.subscribers_of("/Mix/Gain");
+    REQUIRE(gain_subs.size() == 2);
+
+    auto pan_subs = mgr.subscribers_of("/Mix/Pan");
+    REQUIRE(pan_subs.size() == 1);
+    REQUIRE(pan_subs[0].subscriber == MUID{0x33});
+
+    REQUIRE(mgr.unsubscribe(id2));
+    REQUIRE(mgr.subscribers_of("/Mix/Gain").size() == 1);
+    REQUIRE_FALSE(mgr.unsubscribe("nonexistent-id"));
+}
+
+TEST_CASE("PeSubscriptionManager fans out notify payload",
+          "[midi][ci][pe][subscribe][issue-84]") {
+    PeSubscriptionManager mgr;
+    auto id_a = mgr.subscribe("/Param/1", MUID{0xA});
+    (void)id_a;
+    mgr.subscribe("/Param/1", MUID{0xB});
+
+    // Caller builds Notify messages addressed to each subscriber.
+    auto subs = mgr.subscribers_of("/Param/1");
+    REQUIRE(subs.size() == 2);
+
+    std::vector<std::vector<uint8_t>> outbox;
+    std::vector<uint8_t> payload{0x77};
+    for (const auto& s : subs) {
+        outbox.push_back(pe_build_message(
+            PeMessageType::Notify, 2, MUID{0xFFFE}, s.subscriber,
+            1, pe_header_make(s.resource, "notify"),
+            1, 1, payload));
+    }
+    REQUIRE(outbox.size() == 2);
+    auto parsed = pe_parse_message(outbox[0].data(), outbox[0].size());
+    REQUIRE(parsed.has_value());
+    REQUIRE(parsed->payload == payload);
+}
+
+// ── End-to-end: virtual responder ──────────────────────────────────────
+
+TEST_CASE("PE chunked Get round-trips against an in-process virtual responder",
+          "[midi][ci][pe][e2e][issue-84]") {
+    // Simulate a Get/Reply where the responder's resource is bigger than
+    // a single chunk (this is what the spec calls out as the gap).
+    std::vector<uint8_t> resource_bytes(500);
+    std::mt19937 rng(7);
+    for (auto& b : resource_bytes) b = static_cast<uint8_t>(rng() & 0xFF);
+
+    const MUID client{0xC1};
+    const MUID server{0x5E};
+    const uint8_t req_id = 0x21;
+
+    // 1. Client sends GetInquiry (empty payload, header carries resource path).
+    auto get_msgs = pe_split_into_chunks(
+        PeMessageType::GetInquiry, 2, client, server, req_id,
+        pe_header_make("/Patch/Current", "full"),
+        nullptr, 0, 64);
+    REQUIRE(get_msgs.size() == 1);
+
+    auto get_parsed = pe_parse_message(get_msgs[0].data(), get_msgs[0].size());
+    REQUIRE(get_parsed.has_value());
+
+    // 2. Server fans out a multi-chunk GetReply with the resource bytes.
+    auto reply_msgs = pe_split_into_chunks(
+        PeMessageType::GetReply, 2, server, client, req_id,
+        pe_header_make("/Patch/Current", "full", 200),
+        resource_bytes.data(), resource_bytes.size(), 128);
+    REQUIRE(reply_msgs.size() == 4);  // ceil(500/128)
+
+    // 3. Client reassembles.
+    PeReassembler ra;
+    std::optional<PeChunk> done;
+    for (auto& m : reply_msgs) {
+        auto p = pe_parse_message(m.data(), m.size());
+        REQUIRE(p.has_value());
+        done = ra.push(*p);
+    }
+    REQUIRE(done.has_value());
+    REQUIRE(done->request_id == req_id);
+    REQUIRE(done->payload == resource_bytes);
+
+    std::string r, c;
+    int status = 0;
+    REQUIRE(pe_header_parse(done->header_json, &r, &c, &status));
+    REQUIRE(r == "/Patch/Current");
+    REQUIRE(status == 200);
+}


### PR DESCRIPTION
## Summary

Closes part of `planning/2026-05-24-macos-plugin-authoring-plan.md` **item 8.4** (PE spec compliance).

Adds the MIDI 2.0 Capability Inquiry Property Exchange framing, encoding, and reassembly layers:

- **Mcoded7 encoder/decoder** (`mcoded7.{hpp,cpp}`) — packs 8-bit binary into 7-bit-safe SysEx bytes; round-trips full groups, short trailing groups, and 1000-byte random payloads.
- **PE message build / parse** (`midi_ci_pe.{hpp,cpp}`) — full `F0 7E 7F 0D <pe-sub-id> ver src(4) dst(4) req hdr_len(2) hdr(Mcoded7) total(2) chunk(2) pay_len(2) pay(Mcoded7) F7` envelope; rejects malformed input, wrong sub-ID, truncation.
- **Multipart chunker + `PeReassembler`** — splits payloads to bounded chunks, reassembles in any order, deduplicates resends, aborts on `total_chunks` mismatch mid-transfer.
- **JSON header builder/parser** — resource/command/status surface (the bits the framing layer needs to route), with escape support, no external JSON dep.
- **`PeSubscriptionManager`** — tracks (resource → subscribers), supports unsubscribe by id, exposes `subscribers_of(resource)` for Notify fan-out.

## Tests

`test/test_midi_ci_pe.cpp` — 22 cases / 1357 assertions covering Mcoded7, message round-trip, chunker bounds, reassembly ordering, duplicate handling, cancel, header escape/parse, subscription lifecycle, plus an end-to-end virtual-responder PE Get/Reply with a 500-byte resource split into 4 chunks.

Local Release build (`-DPULP_ENABLE_GPU=OFF`) green: `pulp-test-midi-ci-pe` (1357/1357 ✓), `pulp-test-midi-ci` (185/185 ✓, no regression).

## Deferred (follow-ups under item 8.4)

- zlib payload encoding (MIDI-CI v1.2 §6.3) — needs a zlib dep, out-of-scope for this slice.
- Wire-level Subscribe/Notify dispatch inside `CiDiscovery::process_message` — builder + manager land here; dispatch wiring is the next slice.
- RT-safety annotation sweep on every CI entry point.

## Test plan

- [x] `pulp-test-midi-ci-pe` passes locally (Release, GPU off)
- [x] `pulp-test-midi-ci` still passes (no regression on existing PE storage layer)
- [ ] CI macOS lane green