### PR TITLE
feat(host): crash-isolated plugin scanner (item 4.1)

### DIFF
--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -304,6 +304,48 @@ created with null slots so connection ids stay stable. `GraphNode`
 gained a `plugin_info` member that survives a failed slot load so
 re-saving an unresolved-plugin node preserves its identity.
 
+## Crash-isolated scanning (`IsolatedPluginScanner`, item 4.1)
+
+`pulp::host::IsolatedPluginScanner` (in
+`core/host/include/pulp/host/isolated_scanner.hpp`) is the high-level
+wrapper around the long-standing `pulp-scan-worker` binary. Construct
+it with a path to the worker, then call `scan(bundle_path, timeout_ms)`
+to scan a single bundle in a child process via
+`pulp::platform::ChildProcess::run()`. A crash, hang, or malformed
+descriptor is reported as a `ScanResult { status, descriptor,
+exit_code, error_message }` instead of taking down the host.
+
+`ScanStatus` classifications:
+
+| Status          | Trigger                                          | Caller action                |
+|-----------------|--------------------------------------------------|------------------------------|
+| `Ok`            | exit 0 + parseable JSON descriptor on stdout     | use `result.descriptor`      |
+| `Crash`         | exit ≠ 0,2,3 OR exit 0 with unparseable stdout   | `ScanBlacklist::blacklist()` |
+| `Timeout`       | worker exceeded `timeout_ms`                      | blacklist as soft crash      |
+| `FormatError`   | worker exit 3 (unsupported bundle extension)     | skip (not a plugin format)   |
+| `NotPlugin`     | worker exit 0 with empty stdout                  | skip                          |
+| `WorkerMissing` | configured `worker_path` doesn't exist           | operational error — surface  |
+
+Gotchas:
+
+- The worker's exit-code surface is frozen: 0 = success, 2 = usage
+  error, 3 = unsupported extension. Anything else is treated as a
+  crash. If you grow the worker's exit semantics, update the parent's
+  classifier in `core/host/src/isolated_scanner.cpp` AND the test
+  matrix in `test/test_isolated_scanner.cpp` in the same commit.
+- The descriptor parser is a flat string-search, not a full JSON
+  parser — it relies on the worker's `write_json_descriptor()` schema
+  being stable. If you add nested objects to the worker output, swap
+  to `choc::json` here instead of extending the string search.
+- `ChildProcess::exec_code` is `-1` for any signal-kill on POSIX (the
+  Crash branch covers this) and an OS exception code on Windows
+  (also Crash). Don't try to disambiguate further; the only signal
+  the parent has is "did the worker exit 0 with valid JSON or not".
+- Tests use a small `fixtures/isolated_scanner_crash_helper.cpp`
+  binary that segfaults / hangs / emits garbage on demand. Pattern is
+  reusable for any future ChildProcess-based isolation work — give
+  the helper a mode argv and exec it from the parent.
+
 ## Scanner identity rules (issue #491 P2)
 
 `PluginScanner` produces `PluginInfo::unique_id` values that

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.116.0",
+      "version": "0.117.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.116.0"
+  "version": "0.117.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.116.0",
+  "version": "0.117.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.237.0
+    VERSION 0.238.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/host/CMakeLists.txt
+++ b/core/host/CMakeLists.txt
@@ -15,9 +15,11 @@ target_sources(pulp-host PRIVATE
     src/scan_blacklist.cpp
     src/scan_cache.cpp
     src/background_scanner.cpp
+    src/isolated_scanner.cpp
 )
 
 target_link_libraries(pulp-host PUBLIC pulp::audio pulp::midi pulp::runtime pulp::state)
+target_link_libraries(pulp-host PRIVATE pulp::platform)
 
 # CLAP plugin loader + scanner (requires CLAP SDK)
 if(PULP_HAS_CLAP)

--- a/core/host/include/pulp/host/isolated_scanner.hpp
+++ b/core/host/include/pulp/host/isolated_scanner.hpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+// Crash-isolated plugin scanner (macOS plan item 4.1).
+//
+// Loads a single plugin bundle in a CHILD PROCESS via the canonical
+// `pulp::platform::ChildProcess` API + the pre-existing
+// `pulp-scan-worker` helper binary (tools/scan-worker/). A crash, hang,
+// or format error in the worker is reported back to the parent as a
+// `ScanResult` with a structured `ScanStatus` instead of taking down
+// the host.
+//
+// Builds on PR #2815 (ChildProcess) and workstream 03 slice 3.3b
+// (`pulp-scan-worker` binary).
+//
+// Usage:
+//   pulp::host::IsolatedPluginScanner s{worker_path};
+//   auto result = s.scan(bundle_path, /*timeout_ms=*/5000);
+//   if (result.status == ScanStatus::Ok) {
+//       use(result.descriptor);
+//   } else if (result.status == ScanStatus::Crash) {
+//       blacklist.blacklist(bundle_path, result.error_message);
+//   }
+
+#include <pulp/host/scanner.hpp>
+
+#include <optional>
+#include <string>
+
+namespace pulp::host {
+
+/// Outcome of an isolated scan attempt. Anything non-`Ok` means the
+/// parent did NOT trust the worker's stdout — `descriptor` is only
+/// meaningful when `status == Ok`.
+enum class ScanStatus {
+    Ok,           ///< Worker exited 0 and emitted a parseable descriptor.
+    Crash,        ///< Worker terminated abnormally (signal / non-zero
+                  ///< code with no JSON). The bundle is suspect — caller
+                  ///< should blacklist it.
+    Timeout,      ///< Worker exceeded the per-scan timeout. Treated as a
+                  ///< soft crash for blacklist purposes.
+    FormatError,  ///< Worker rejected the bundle (exit code 3 — extension
+                  ///< not recognized). Not a crash; just unsupported.
+    NotPlugin,    ///< Worker ran cleanly but emitted no descriptor (the
+                  ///< file at `path` was not a plugin we can scan).
+    WorkerMissing ///< The configured `worker_path` doesn't exist or
+                  ///< can't be exec'd. Operational error, not a bundle
+                  ///< problem.
+};
+
+struct ScanResult {
+    ScanStatus status = ScanStatus::Crash;
+    /// Populated only when `status == Ok`. The worker can produce more
+    /// than one descriptor per bundle (CLAP factories can list several);
+    /// the isolated scanner reports the first and the caller can re-scan
+    /// for the full set in the same child if needed. Keep this simple
+    /// for now — multi-descriptor bundles are rare in the wild and the
+    /// host calls one-bundle-at-a-time.
+    std::optional<PluginInfo> descriptor;
+    /// Worker exit status (raw OS exit code, or -1 if it never started /
+    /// was signal-killed). Useful for diagnostics in the result log.
+    int exit_code = -1;
+    /// Human-readable error explanation (stderr tail, "timeout", or
+    /// "worker not found"). Stored verbatim so the parent can write it
+    /// straight into `ScanBlacklist::blacklist(..., reason)`.
+    std::string error_message;
+};
+
+class IsolatedPluginScanner {
+public:
+    /// Construct with the path to the `pulp-scan-worker` binary that
+    /// will be exec'd for each scan. Resolution policy is intentionally
+    /// caller-controlled — Pulp ships the worker next to the CLI at
+    /// install time, but tests inject `$<TARGET_FILE:pulp-scan-worker>`
+    /// directly, and an embedded host may keep it elsewhere.
+    explicit IsolatedPluginScanner(std::string worker_path)
+        : worker_path_(std::move(worker_path)) {}
+
+    /// Scan a single bundle in a child process. Always returns; never
+    /// propagates a crash from the worker back into the caller.
+    ScanResult scan(const std::string& bundle_path, int timeout_ms = 5000) const;
+
+    /// Accessor for the resolved worker path (mostly for diagnostics).
+    const std::string& worker_path() const noexcept { return worker_path_; }
+
+private:
+    std::string worker_path_;
+};
+
+}  // namespace pulp::host

--- a/core/host/src/isolated_scanner.cpp
+++ b/core/host/src/isolated_scanner.cpp
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: MIT
+//
+// Crash-isolated plugin scanner — macOS plan item 4.1.
+//
+// Spawns `pulp-scan-worker` per bundle via `pulp::platform::ChildProcess`
+// and classifies the worker's outcome into a `ScanStatus`. The worker's
+// stdout is the JSON line(s) it emits per descriptor (see
+// tools/scan-worker/scan_worker_main.cpp); we keep the parser deliberately
+// small — flat, double-quoted-only, no escapes-with-unicode reassembly —
+// because the worker is the only producer and we control its format.
+
+#include <pulp/host/isolated_scanner.hpp>
+
+#include <pulp/platform/child_process.hpp>
+
+#include <algorithm>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <string_view>
+
+namespace fs = std::filesystem;
+
+namespace pulp::host {
+
+namespace {
+
+// Strip surrounding whitespace.
+std::string_view trim(std::string_view s) {
+    while (!s.empty() && (s.front() == ' ' || s.front() == '\t' ||
+                          s.front() == '\r' || s.front() == '\n')) {
+        s.remove_prefix(1);
+    }
+    while (!s.empty() && (s.back() == ' ' || s.back() == '\t' ||
+                          s.back() == '\r' || s.back() == '\n')) {
+        s.remove_suffix(1);
+    }
+    return s;
+}
+
+// Unescape the small set of escapes the worker emits (json_escape in
+// scan_worker_main.cpp). Anything else is passed through unchanged —
+// good enough for worker-controlled output.
+std::string json_unescape(std::string_view raw) {
+    std::string out;
+    out.reserve(raw.size());
+    for (std::size_t i = 0; i < raw.size(); ++i) {
+        char c = raw[i];
+        if (c == '\\' && i + 1 < raw.size()) {
+            char n = raw[i + 1];
+            switch (n) {
+                case '"':  out += '"';  ++i; continue;
+                case '\\': out += '\\'; ++i; continue;
+                case 'b':  out += '\b'; ++i; continue;
+                case 'f':  out += '\f'; ++i; continue;
+                case 'n':  out += '\n'; ++i; continue;
+                case 'r':  out += '\r'; ++i; continue;
+                case 't':  out += '\t'; ++i; continue;
+                default: break;
+            }
+        }
+        out += c;
+    }
+    return out;
+}
+
+// Locate `"key":"value"` and return value. Returns std::nullopt when the
+// key isn't present in `line`. Deliberately string-search rather than a
+// real JSON parser — keeps this TU tiny and the worker output schema is
+// frozen by us.
+std::optional<std::string> find_string(std::string_view line, std::string_view key) {
+    std::string needle = "\"";
+    needle += std::string(key);
+    needle += "\":\"";
+    auto k = line.find(needle);
+    if (k == std::string_view::npos) return std::nullopt;
+    auto value_start = k + needle.size();
+    // Find the closing quote, honouring a single level of backslash escape.
+    auto i = value_start;
+    while (i < line.size()) {
+        if (line[i] == '\\' && i + 1 < line.size()) {
+            i += 2;
+            continue;
+        }
+        if (line[i] == '"') break;
+        ++i;
+    }
+    if (i >= line.size()) return std::nullopt;
+    return json_unescape(line.substr(value_start, i - value_start));
+}
+
+// Locate `"key":true|false` and return the bool. Defaults to `dflt`.
+bool find_bool(std::string_view line, std::string_view key, bool dflt) {
+    std::string needle = "\"";
+    needle += std::string(key);
+    needle += "\":";
+    auto k = line.find(needle);
+    if (k == std::string_view::npos) return dflt;
+    auto v = k + needle.size();
+    if (v + 4 <= line.size() && line.compare(v, 4, "true") == 0) return true;
+    if (v + 5 <= line.size() && line.compare(v, 5, "false") == 0) return false;
+    return dflt;
+}
+
+PluginFormat parse_format(std::string_view s) {
+    if (s == "clap") return PluginFormat::CLAP;
+    if (s == "vst3") return PluginFormat::VST3;
+    if (s == "au")   return PluginFormat::AudioUnit;
+    if (s == "auv3") return PluginFormat::AudioUnitV3;
+    if (s == "lv2")  return PluginFormat::LV2;
+    return PluginFormat::VST3;  // arbitrary default; caller checks status==Ok first
+}
+
+std::optional<PluginInfo> parse_descriptor_line(std::string_view line) {
+    line = trim(line);
+    if (line.empty() || line.front() != '{') return std::nullopt;
+
+    PluginInfo info;
+    info.name = find_string(line, "name").value_or("");
+    info.manufacturer = find_string(line, "manufacturer").value_or("");
+    info.version = find_string(line, "version").value_or("");
+    info.unique_id = find_string(line, "unique_id").value_or("");
+    info.path = find_string(line, "path").value_or("");
+    info.is_instrument = find_bool(line, "is_instrument", false);
+    info.is_effect = find_bool(line, "is_effect", true);
+    info.format = parse_format(find_string(line, "format").value_or(""));
+
+    // A well-formed worker descriptor always has at least a name+path.
+    if (info.name.empty() && info.path.empty()) return std::nullopt;
+    return info;
+}
+
+// Tail of stderr, capped so the error_message stays small (the parent
+// often serializes it into ScanBlacklist's reason field).
+std::string short_stderr(const std::string& s) {
+    constexpr std::size_t kCap = 256;
+    if (s.size() <= kCap) return s;
+    std::string out = "...";
+    out.append(s, s.size() - kCap, kCap);
+    return out;
+}
+
+}  // namespace
+
+ScanResult IsolatedPluginScanner::scan(const std::string& bundle_path,
+                                       int timeout_ms) const {
+    ScanResult result;
+
+    // Operational preflight — the worker has to exist and be a regular
+    // file. We don't try to chmod/exec-test; ChildProcess will surface
+    // exec failures via exit_code = -1 with empty stdout if we get past
+    // this guard.
+    std::error_code ec;
+    if (worker_path_.empty() || !fs::exists(worker_path_, ec) ||
+        !fs::is_regular_file(worker_path_, ec)) {
+        result.status = ScanStatus::WorkerMissing;
+        result.error_message = "pulp-scan-worker not found at: " + worker_path_;
+        return result;
+    }
+
+    pulp::platform::ProcessOptions opts;
+    opts.timeout_ms = timeout_ms;
+    opts.capture_stdout = true;
+    opts.capture_stderr = true;
+    // Cap the captured output. The default 1 MB is plenty; a worker
+    // that floods stdout is itself a sign of corruption and we'd
+    // rather classify it as Crash than allocate forever.
+    opts.max_output_bytes = 64 * 1024;
+
+    auto proc = pulp::platform::ChildProcess::run(
+        worker_path_, {bundle_path}, opts);
+
+    result.exit_code = proc.exit_code;
+
+    if (proc.timed_out) {
+        result.status = ScanStatus::Timeout;
+        result.error_message = "scan timed out after " +
+                               std::to_string(timeout_ms) + " ms: " +
+                               short_stderr(proc.stderr_output);
+        return result;
+    }
+
+    // exit_code 2 = usage error from worker (we always pass argv[1], so
+    // this would mean the worker is older than expected); exit_code 3 =
+    // unsupported bundle extension. Both are non-crash conditions.
+    if (proc.exit_code == 3) {
+        result.status = ScanStatus::FormatError;
+        result.error_message = short_stderr(proc.stderr_output);
+        return result;
+    }
+    if (proc.exit_code == 2) {
+        result.status = ScanStatus::FormatError;  // operationally same — caller can't recover
+        result.error_message = "scan-worker usage error: " +
+                               short_stderr(proc.stderr_output);
+        return result;
+    }
+
+    // Anything else non-zero (signal kill -> -1 on POSIX, or an OS
+    // exception code on Windows) is a crash. The worker only ever
+    // exits 0 / 2 / 3 deliberately.
+    if (proc.exit_code != 0) {
+        result.status = ScanStatus::Crash;
+        result.error_message = "worker exited abnormally (code " +
+                               std::to_string(proc.exit_code) + "): " +
+                               short_stderr(proc.stderr_output);
+        return result;
+    }
+
+    // exit_code 0 and stdout is empty → the worker ran cleanly but the
+    // bundle produced no descriptor (e.g., the format scanner couldn't
+    // pull anything sensible out of it). Treat as NotPlugin.
+    std::string_view out{proc.stdout_output};
+    out = trim(out);
+    if (out.empty()) {
+        result.status = ScanStatus::NotPlugin;
+        result.error_message = "worker emitted no descriptor for " + bundle_path;
+        return result;
+    }
+
+    // Parse the first line. The worker emits one JSON object per line;
+    // we report the first descriptor and ignore the rest (multi-class
+    // CLAPs are rare and the bundle-level identity is what matters for
+    // the host-side blacklist + cache).
+    auto nl = out.find('\n');
+    std::string_view first = (nl == std::string_view::npos) ? out : out.substr(0, nl);
+    auto parsed = parse_descriptor_line(first);
+    if (!parsed) {
+        // exit 0 but unparseable output — treat as crash so the bundle
+        // is blacklisted; a malformed descriptor is a worker-level
+        // contract violation we shouldn't trust.
+        result.status = ScanStatus::Crash;
+        result.error_message = "worker stdout not parseable: " +
+                               short_stderr(proc.stdout_output);
+        return result;
+    }
+    result.status = ScanStatus::Ok;
+    result.descriptor = std::move(parsed);
+    return result;
+}
+
+}  // namespace pulp::host

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -922,6 +922,30 @@ target_link_libraries(pulp-test-scan-blacklist PRIVATE pulp::host Catch2::Catch2
 # `slow` (#1589): file-mtime sleep loops (rebuilt-plugin-not-blacklisted
 # flow waits on filesystem timestamp resolution). Each test ~1s.
 catch_discover_tests(pulp-test-scan-blacklist PROPERTIES LABELS slow)
+# Crash-isolated scanner (macOS plan item 4.1). Skipped on iOS/Android
+# where pulp-scan-worker isn't built (sandboxed platforms can't fork).
+if(NOT IOS AND NOT ANDROID)
+    add_executable(pulp-isolated-scanner-crash-helper
+        fixtures/isolated_scanner_crash_helper.cpp)
+    set_target_properties(pulp-isolated-scanner-crash-helper PROPERTIES
+        OUTPUT_NAME "pulp-isolated-scanner-crash-helper")
+
+    add_executable(pulp-test-isolated-scanner test_isolated_scanner.cpp)
+    # pulp::platform comes transitively via pulp::host (it's a PRIVATE
+    # dep there, but the static-archive link still pulls in the symbols
+    # the test needs through pulp::host's USAGE side). We only have to
+    # list Catch2 + the public dep.
+    target_link_libraries(pulp-test-isolated-scanner PRIVATE
+        pulp::host
+        Catch2::Catch2WithMain)
+    target_compile_definitions(pulp-test-isolated-scanner PRIVATE
+        PULP_ISOLATED_SCANNER_REAL_WORKER="$<TARGET_FILE:pulp-scan-worker>"
+        PULP_ISOLATED_SCANNER_CRASH_HELPER="$<TARGET_FILE:pulp-isolated-scanner-crash-helper>")
+    add_dependencies(pulp-test-isolated-scanner
+        pulp-scan-worker
+        pulp-isolated-scanner-crash-helper)
+    catch_discover_tests(pulp-test-isolated-scanner)
+endif()
 # Hosted editor API (workstream 03 slice 3.4)
 pulp_add_test_suite(pulp-test-hosted-editor LIBRARIES pulp::host)
 # Accessibility announcements (workstream 04 slice 4.3)

--- a/test/fixtures/isolated_scanner_crash_helper.cpp
+++ b/test/fixtures/isolated_scanner_crash_helper.cpp
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+//
+// Tiny helper binary for `pulp-test-isolated-scanner`. Used in place of
+// `pulp-scan-worker` to exercise the parent's classification of an
+// abnormal worker exit. Triggered ONLY by the test (no install
+// rule). Three modes via argv[1]:
+//
+//   crash    — deref a null pointer (SIGSEGV / Windows AV exception)
+//   timeout  — sleep for 60s so the parent's 1s timeout fires
+//   garbage  — exit 0 with non-JSON stdout (worker contract violation)
+//
+// Anything else exits 0 silently (mimics the NotPlugin path the real
+// worker takes when it can't extract a descriptor).
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <thread>
+
+int main(int argc, char** argv) {
+    // Allow either `helper <mode>` (test for worker contract) or
+    // `helper <bundle> <mode>` (matches real-worker signature where
+    // argv[1] is the bundle path). The test uses the latter form.
+    std::string mode;
+    if (argc >= 3) {
+        mode = argv[2];
+    } else if (argc == 2) {
+        mode = argv[1];
+    }
+
+    if (mode == "crash") {
+        // Volatile to defeat the optimizer collapsing this away.
+        volatile int* p = nullptr;
+        *p = 42;  // boom
+        return 99;  // unreachable
+    }
+    if (mode == "timeout") {
+        std::this_thread::sleep_for(std::chrono::seconds(60));
+        return 0;
+    }
+    if (mode == "garbage") {
+        std::printf("this is not json\n");
+        return 0;
+    }
+    if (mode == "unsupported") {
+        // Mimic the real worker's "unsupported bundle extension" exit.
+        std::fprintf(stderr, "test helper: unsupported bundle extension\n");
+        return 3;
+    }
+    // Default — silent clean exit.
+    return 0;
+}

--- a/test/test_isolated_scanner.cpp
+++ b/test/test_isolated_scanner.cpp
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+//
+// Crash-isolated plugin scanner (macOS plan item 4.1) — unit tests.
+//
+// Two binaries are exercised:
+//   PULP_ISOLATED_SCANNER_REAL_WORKER  → the actual pulp-scan-worker
+//     (validates the happy-path Ok / NotPlugin / FormatError flows).
+//   PULP_ISOLATED_SCANNER_CRASH_HELPER → a tiny test helper that can
+//     crash / hang / emit garbage on demand (validates the Crash,
+//     Timeout, and "unparseable worker output" classifications).
+
+#include <pulp/host/isolated_scanner.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#ifndef PULP_ISOLATED_SCANNER_REAL_WORKER
+#error "PULP_ISOLATED_SCANNER_REAL_WORKER must point at the pulp-scan-worker binary"
+#endif
+#ifndef PULP_ISOLATED_SCANNER_CRASH_HELPER
+#error "PULP_ISOLATED_SCANNER_CRASH_HELPER must point at the crash helper binary"
+#endif
+
+namespace fs = std::filesystem;
+using Catch::Matchers::ContainsSubstring;
+using pulp::host::IsolatedPluginScanner;
+using pulp::host::ScanStatus;
+
+namespace {
+
+struct ScratchDir {
+    fs::path path;
+
+    explicit ScratchDir(const char* stem) {
+        const auto counter =
+            std::chrono::steady_clock::now().time_since_epoch().count();
+        path = fs::temp_directory_path()
+             / (std::string("pulp-isolated-scanner-test-") + stem + "-"
+                + std::to_string(counter));
+        std::error_code ec;
+        fs::remove_all(path, ec);
+        fs::create_directories(path);
+    }
+
+    ~ScratchDir() {
+        std::error_code ec;
+        fs::remove_all(path, ec);
+    }
+
+    ScratchDir(const ScratchDir&) = delete;
+    ScratchDir& operator=(const ScratchDir&) = delete;
+};
+
+void write_file(const fs::path& path, const std::string& body) {
+    fs::create_directories(path.parent_path());
+    std::ofstream out(path, std::ios::binary);
+    REQUIRE(out.good());
+    out << body;
+}
+
+}  // namespace
+
+// ── Happy path: real worker, real bundle ───────────────────────────────
+
+TEST_CASE("IsolatedPluginScanner returns Ok for a parseable VST3 bundle",
+          "[host][isolated-scanner][item-4.1]") {
+    ScratchDir scratch("ok-vst3");
+    auto bundle = scratch.path / "Probe.vst3";
+    fs::create_directories(bundle / "Contents" / "Resources");
+
+    IsolatedPluginScanner scanner{PULP_ISOLATED_SCANNER_REAL_WORKER};
+    auto result = scanner.scan(bundle.string(), /*timeout_ms=*/5000);
+
+    REQUIRE(result.status == ScanStatus::Ok);
+    REQUIRE(result.descriptor.has_value());
+    REQUIRE(result.descriptor->name == "Probe");
+    REQUIRE(result.descriptor->path == bundle.string());
+    REQUIRE(result.descriptor->format == pulp::host::PluginFormat::VST3);
+    REQUIRE(result.exit_code == 0);
+}
+
+TEST_CASE("IsolatedPluginScanner returns FormatError for an unknown extension",
+          "[host][isolated-scanner][item-4.1]") {
+    ScratchDir scratch("not-plugin");
+    auto file = scratch.path / "random-file.txt";
+    write_file(file, "this is not a plugin");
+
+    IsolatedPluginScanner scanner{PULP_ISOLATED_SCANNER_REAL_WORKER};
+    auto result = scanner.scan(file.string(), /*timeout_ms=*/5000);
+
+    REQUIRE(result.status == ScanStatus::FormatError);
+    REQUIRE(result.exit_code == 3);
+    REQUIRE_THAT(result.error_message, ContainsSubstring("unsupported"));
+}
+
+// ── Crash path: deliberate-crash helper ────────────────────────────────
+
+TEST_CASE("IsolatedPluginScanner classifies a worker SIGSEGV as Crash",
+          "[host][isolated-scanner][item-4.1][crash]") {
+    IsolatedPluginScanner scanner{PULP_ISOLATED_SCANNER_CRASH_HELPER};
+    auto result = scanner.scan("crash", /*timeout_ms=*/5000);
+
+    REQUIRE(result.status == ScanStatus::Crash);
+    REQUIRE_FALSE(result.descriptor.has_value());
+    // POSIX signal-kill → exit_code -1; Windows crash → large non-zero
+    // exception code. Either way it's not 0.
+    REQUIRE(result.exit_code != 0);
+    REQUIRE_FALSE(result.error_message.empty());
+}
+
+TEST_CASE("IsolatedPluginScanner classifies a hung worker as Timeout",
+          "[host][isolated-scanner][item-4.1][crash]") {
+    IsolatedPluginScanner scanner{PULP_ISOLATED_SCANNER_CRASH_HELPER};
+    auto result = scanner.scan("timeout", /*timeout_ms=*/250);
+
+    REQUIRE(result.status == ScanStatus::Timeout);
+    REQUIRE_FALSE(result.descriptor.has_value());
+    REQUIRE_THAT(result.error_message, ContainsSubstring("timed out"));
+}
+
+TEST_CASE("IsolatedPluginScanner classifies unparseable worker output as Crash",
+          "[host][isolated-scanner][item-4.1][crash]") {
+    IsolatedPluginScanner scanner{PULP_ISOLATED_SCANNER_CRASH_HELPER};
+    auto result = scanner.scan("garbage", /*timeout_ms=*/5000);
+
+    // exit 0 + non-JSON stdout — we don't trust that and report Crash.
+    REQUIRE(result.status == ScanStatus::Crash);
+    REQUIRE_FALSE(result.descriptor.has_value());
+    REQUIRE_THAT(result.error_message, ContainsSubstring("not parseable"));
+}
+
+TEST_CASE("IsolatedPluginScanner returns NotPlugin when worker exits clean with no output",
+          "[host][isolated-scanner][item-4.1]") {
+    IsolatedPluginScanner scanner{PULP_ISOLATED_SCANNER_CRASH_HELPER};
+    auto result = scanner.scan("silent", /*timeout_ms=*/5000);
+
+    REQUIRE(result.status == ScanStatus::NotPlugin);
+    REQUIRE_FALSE(result.descriptor.has_value());
+    REQUIRE(result.exit_code == 0);
+}
+
+// ── Operational error path ─────────────────────────────────────────────
+
+TEST_CASE("IsolatedPluginScanner reports WorkerMissing when worker_path is absent",
+          "[host][isolated-scanner][item-4.1]") {
+    ScratchDir scratch("missing");
+    auto missing = scratch.path / "no-such-worker";
+
+    IsolatedPluginScanner scanner{missing.string()};
+    auto result = scanner.scan("any-path", /*timeout_ms=*/1000);
+
+    REQUIRE(result.status == ScanStatus::WorkerMissing);
+    REQUIRE_THAT(result.error_message, ContainsSubstring("not found"));
+}


### PR DESCRIPTION
Adds IsolatedPluginScanner — a high-level wrapper around the existing
pulp-scan-worker binary that loads a single plugin bundle in a child
process via pulp::platform::ChildProcess. A worker crash (SIGSEGV /
abort / Windows AV), a hang, or a malformed descriptor is reported back
to the parent as a structured ScanResult with a ScanStatus
{ Ok, Crash, Timeout, FormatError, NotPlugin, WorkerMissing } instead
of taking down the host. Builds on PR #2815 (canonical ChildProcess)
and workstream 03 slice 3.3b (pulp-scan-worker).

Tests use the real pulp-scan-worker for Ok / FormatError plus a small
test helper that segfaults / hangs / emits garbage on demand to
exercise the Crash, Timeout, unparseable-output, NotPlugin, and
WorkerMissing classifications. 25 assertions across 7 cases.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>