### PR TITLE
feat(render): HeadlessSurface CI wrapper for offscreen Dawn/Skia (item 6.7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.238.0
+    VERSION 0.239.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/render/CMakeLists.txt
+++ b/core/render/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(pulp-render PRIVATE
     src/gpu_surface_dawn.cpp
     src/gpu_compute.cpp
     src/gpu_timestamps.cpp
+    src/headless_surface.cpp
     src/skia_surface.cpp
     src/skp_capture.cpp
     src/render_loop.cpp

--- a/core/render/include/pulp/render/headless_surface.hpp
+++ b/core/render/include/pulp/render/headless_surface.hpp
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <pulp/render/gpu_surface.hpp>
+#include <pulp/render/skia_surface.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace pulp::canvas { class Canvas; }
+
+namespace pulp::render {
+
+/// One-call wrapper for the existing offscreen Dawn + Skia path
+/// (`GpuSurface::create_dawn() + native_surface_handle=nullptr` +
+/// `SkiaSurface::create`). Intended for CI golden tests and any other
+/// callsite that wants "render this scene to an RGBA / PNG buffer with
+/// no window". Spec: planning/2026-05-24-macos-plugin-authoring-plan.md §6.7.
+///
+/// The wrapper does NOT introduce a new render path — it just hides
+/// the begin_frame/end_frame ceremony and the GPU readback dance so a
+/// test can do:
+///
+///   auto h = HeadlessSurface::create({640, 360});
+///   if (!h || !h->is_ready()) {
+///       SUCCEED("Dawn/Graphite unavailable — golden skipped.");
+///       return;
+///   }
+///   auto rgba = h->render_rgba([&](canvas::Canvas& c) {
+///       paint_my_scene(c);
+///   });
+///   auto png = HeadlessSurface::encode_png(rgba);
+///
+/// When Skia/Dawn isn't linked (the `PULP_HAS_SKIA=0` build), the
+/// factory returns nullptr and `last_error()` carries the reason so
+/// the caller can soft-skip. The header is always safe to include —
+/// no Skia/Dawn types leak into it.
+class HeadlessSurface {
+public:
+    struct Config {
+        uint32_t width = 800;
+        uint32_t height = 600;
+        /// HiDPI scale factor handed to SkiaSurface::Config.
+        float scale_factor = 1.0f;
+        /// Background fill applied before the user paint callback runs.
+        /// Defaults to opaque black so a no-op paint still produces a
+        /// deterministic frame (read-back uninitialized GPU memory is
+        /// not reproducible — see plan §6.7 acceptance).
+        uint8_t clear_r = 0;
+        uint8_t clear_g = 0;
+        uint8_t clear_b = 0;
+        uint8_t clear_a = 255;
+    };
+
+    struct Rgba {
+        std::vector<uint8_t> pixels;  ///< RGBA, 4 bytes/pixel, row-major top→bottom
+        uint32_t width = 0;
+        uint32_t height = 0;
+
+        bool empty() const { return pixels.empty() || width == 0 || height == 0; }
+        size_t pixel_count() const { return static_cast<size_t>(width) * height; }
+    };
+
+    /// Caller-supplied paint callback. The Canvas is the live Skia
+    /// canvas for the current offscreen frame. The wrapper applies the
+    /// background fill BEFORE invoking this callback.
+    using PaintFn = std::function<void(canvas::Canvas&)>;
+
+    /// Create a headless offscreen surface, or `nullptr` if Skia/Dawn
+    /// aren't available or the underlying GpuSurface/SkiaSurface
+    /// initialization failed. `last_error_out` (if non-null) is filled
+    /// with a human-readable reason in the failure case.
+    static std::unique_ptr<HeadlessSurface> create(
+        const Config& config,
+        std::string* last_error_out = nullptr);
+
+    virtual ~HeadlessSurface() = default;
+
+    /// True when the underlying GpuSurface + SkiaSurface are live and
+    /// ready to accept paint callbacks. False after a failed init or
+    /// when the device was lost.
+    virtual bool is_ready() const = 0;
+
+    /// Run one offscreen frame: begin_frame → fill → user paint → read
+    /// pixels → end_frame. Returns an empty `Rgba` on failure (callers
+    /// should soft-skip when `is_ready()` was true but readback failed
+    /// — the GPU adapter may be too constrained for readback).
+    virtual Rgba render_rgba(const PaintFn& paint) = 0;
+
+    /// Convenience: render and PNG-encode in one call. Returns empty
+    /// bytes on failure (same semantics as `render_rgba`).
+    virtual std::vector<uint8_t> render_png(const PaintFn& paint) = 0;
+
+    /// Last error message recorded by the wrapper. Empty when no error.
+    virtual std::string last_error() const = 0;
+
+    /// PNG-encode an already-captured RGBA buffer. Returns empty on
+    /// failure. Available even on builds where the runtime surface
+    /// itself isn't (e.g. host-side post-processing of a fixture
+    /// snapshot). When `PULP_HAS_SKIA` is off the implementation
+    /// returns empty bytes and records a reason in `error_out`.
+    static std::vector<uint8_t> encode_png(const Rgba& rgba,
+                                           std::string* error_out = nullptr);
+
+    /// Cheap deterministic fingerprint of an RGBA buffer — FNV-1a 64.
+    /// Useful for golden-bytes assertions where storing the full PNG
+    /// in-tree is overkill but the test still wants drift detection.
+    /// Independent of Skia, always available.
+    static uint64_t rgba_fingerprint(const Rgba& rgba);
+};
+
+} // namespace pulp::render

--- a/core/render/src/headless_surface.cpp
+++ b/core/render/src/headless_surface.cpp
@@ -1,0 +1,278 @@
+// headless_surface.cpp — CI-friendly wrapper around the existing
+// offscreen Dawn/Skia path. Spec: planning/2026-05-24-macos-plugin-
+// authoring-plan.md §6.7 ("upgrade Headless GpuSurface from Partial →
+// Full — capability already exists; this is wrapping").
+//
+// We deliberately do NOT introduce a new render path here. All of the
+// real GPU work continues to live in `GpuSurface::create_dawn()` +
+// `SkiaSurface::create()`. This translation unit:
+//
+//   1. Stitches the two together with `native_surface_handle=nullptr`
+//      (Dawn's documented offscreen mode).
+//   2. Brackets the user paint callback with begin_frame/end_frame
+//      and a deterministic background clear.
+//   3. Pulls pixels off the GPU via `SkiaSurface::read_current_rgba`
+//      and (optionally) PNG-encodes them with `SkPngEncoder`.
+//   4. When `PULP_HAS_SKIA` is OFF, returns a sentinel "unavailable"
+//      surface — callers soft-skip via `is_ready()`/`last_error()`.
+//
+// PNG encoding goes through Skia's `SkPngEncoder` rather than the
+// macOS-only `mac_capture::encode_rgba_to_png` helper so the same
+// wrapper produces deterministic bytes on Linux runners too.
+
+#include <pulp/render/headless_surface.hpp>
+
+#include <pulp/canvas/canvas.hpp>
+
+#if defined(PULP_HAS_SKIA)
+#include "include/core/SkData.h"
+#include "include/core/SkImage.h"
+#include "include/core/SkImageInfo.h"
+#include "include/core/SkPixmap.h"
+#include "include/encode/SkPngEncoder.h"
+#endif
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace pulp::render {
+
+namespace {
+
+#if defined(PULP_HAS_SKIA)
+
+class HeadlessSurfaceImpl final : public HeadlessSurface {
+public:
+    HeadlessSurfaceImpl(std::unique_ptr<GpuSurface> gpu,
+                        std::unique_ptr<SkiaSurface> skia,
+                        Config config)
+        : gpu_(std::move(gpu)),
+          skia_(std::move(skia)),
+          config_(config) {}
+
+    bool is_ready() const override {
+        return gpu_ && skia_ && skia_->is_available();
+    }
+
+    Rgba render_rgba(const PaintFn& paint) override {
+        last_error_.clear();
+        Rgba out;
+        if (!is_ready()) {
+            last_error_ = "HeadlessSurface: not ready (GpuSurface or SkiaSurface unavailable)";
+            return out;
+        }
+        if (!gpu_->begin_frame()) {
+            last_error_ = "HeadlessSurface: GpuSurface::begin_frame() failed";
+            return out;
+        }
+        auto* canvas = skia_->begin_frame();
+        if (canvas == nullptr) {
+            last_error_ = "HeadlessSurface: SkiaSurface::begin_frame() returned null canvas";
+            // Still end the gpu frame so the device queue isn't left mid-frame.
+            gpu_->end_frame();
+            return out;
+        }
+
+        // Deterministic background fill. Without this the GPU texture
+        // we read back may contain uninitialized memory and the PNG
+        // bytes won't be reproducible across reruns (plan §6.7 acceptance).
+        canvas->set_fill_color(canvas::Color::rgba8(
+            config_.clear_r, config_.clear_g, config_.clear_b, config_.clear_a));
+        canvas->fill_rect(0.0f, 0.0f,
+                          static_cast<float>(config_.width),
+                          static_cast<float>(config_.height));
+
+        if (paint) {
+            paint(*canvas);
+        }
+
+        // Submit the recorded GPU work BEFORE reading pixels back.
+        // `SkiaSurface::end_frame()` is what calls `recorder_->snap()` +
+        // `context_->insertRecording()` + `context_->submit()`. If we
+        // tried to `read_current_rgba` before that, the readback would
+        // sample whatever was in the offscreen render target on the
+        // previous frame (or uninitialized memory on the very first
+        // frame) — which is exactly the determinism bug this wrapper
+        // is supposed to make impossible.
+        //
+        // `end_frame()` only resets the per-frame `frame_surface_` (the
+        // wrapped swapchain texture); the offscreen `offscreen_surface_`
+        // we render into here survives, so `read_current_rgba` still
+        // has a valid source after the submit.
+        skia_->end_frame();
+
+        std::vector<uint8_t> pixels;
+        uint32_t pw = 0, ph = 0;
+        const bool read = skia_->read_current_rgba(pixels, pw, ph);
+
+        gpu_->end_frame();
+
+        if (!read) {
+            last_error_ = "HeadlessSurface: SkiaSurface::read_current_rgba() failed (GPU readback unsupported on this adapter?)";
+            return out;
+        }
+        out.pixels = std::move(pixels);
+        out.width = pw;
+        out.height = ph;
+        return out;
+    }
+
+    std::vector<uint8_t> render_png(const PaintFn& paint) override {
+        auto rgba = render_rgba(paint);
+        if (rgba.empty()) return {};
+        std::string enc_err;
+        auto png = HeadlessSurface::encode_png(rgba, &enc_err);
+        if (png.empty() && !enc_err.empty() && last_error_.empty()) {
+            last_error_ = enc_err;
+        }
+        return png;
+    }
+
+    std::string last_error() const override { return last_error_; }
+
+private:
+    std::unique_ptr<GpuSurface> gpu_;
+    std::unique_ptr<SkiaSurface> skia_;
+    Config config_;
+    mutable std::string last_error_;
+};
+
+#else  // !PULP_HAS_SKIA
+
+// Sentinel: callers can always construct a HeadlessSurface for type
+// reasons but `is_ready()` returns false and `last_error()` carries
+// a clear "skia not linked" reason so tests soft-skip rather than
+// fail compilation.
+class HeadlessSurfaceImpl final : public HeadlessSurface {
+public:
+    HeadlessSurfaceImpl() = default;
+    bool is_ready() const override { return false; }
+    Rgba render_rgba(const PaintFn&) override {
+        last_error_ = "HeadlessSurface: built without PULP_HAS_SKIA — offscreen GPU path is unavailable";
+        return {};
+    }
+    std::vector<uint8_t> render_png(const PaintFn&) override {
+        last_error_ = "HeadlessSurface: built without PULP_HAS_SKIA — PNG encode requires Skia";
+        return {};
+    }
+    std::string last_error() const override { return last_error_; }
+
+private:
+    mutable std::string last_error_;
+};
+
+#endif  // PULP_HAS_SKIA
+
+} // namespace
+
+std::unique_ptr<HeadlessSurface> HeadlessSurface::create(
+    const Config& config,
+    std::string* last_error_out) {
+    auto set_err = [&](const char* msg) {
+        if (last_error_out) *last_error_out = msg;
+    };
+
+#if defined(PULP_HAS_SKIA)
+    if (config.width == 0 || config.height == 0) {
+        set_err("HeadlessSurface::create: width and height must be > 0");
+        return nullptr;
+    }
+
+    auto gpu = GpuSurface::create_dawn();
+    if (!gpu) {
+        set_err("HeadlessSurface::create: GpuSurface::create_dawn() returned null (no Dawn backend)");
+        return nullptr;
+    }
+    GpuSurface::Config gpu_config{};
+    gpu_config.width = config.width;
+    gpu_config.height = config.height;
+    gpu_config.vsync = false;
+    gpu_config.native_surface_handle = nullptr;  // offscreen / no presentation
+    if (!gpu->initialize(gpu_config)) {
+        set_err("HeadlessSurface::create: GpuSurface::initialize() failed (no native adapter?)");
+        return nullptr;
+    }
+
+    SkiaSurface::Config skia_config{};
+    skia_config.width = config.width;
+    skia_config.height = config.height;
+    skia_config.scale_factor = config.scale_factor;
+    auto skia = SkiaSurface::create(*gpu, skia_config);
+    if (!skia || !skia->is_available()) {
+        set_err("HeadlessSurface::create: SkiaSurface::create() failed or reported unavailable");
+        return nullptr;
+    }
+
+    if (last_error_out) last_error_out->clear();
+    return std::make_unique<HeadlessSurfaceImpl>(std::move(gpu), std::move(skia), config);
+#else
+    (void)config;
+    set_err("HeadlessSurface::create: build was configured without PULP_HAS_SKIA");
+    return nullptr;
+#endif
+}
+
+std::vector<uint8_t> HeadlessSurface::encode_png(const Rgba& rgba,
+                                                 std::string* error_out) {
+    auto set_err = [&](const char* msg) {
+        if (error_out) *error_out = msg;
+    };
+    if (rgba.empty()) {
+        set_err("HeadlessSurface::encode_png: empty RGBA input");
+        return {};
+    }
+    const size_t need = static_cast<size_t>(rgba.width) * rgba.height * 4u;
+    if (rgba.pixels.size() < need) {
+        set_err("HeadlessSurface::encode_png: pixel buffer smaller than width*height*4");
+        return {};
+    }
+
+#if defined(PULP_HAS_SKIA)
+    auto info = SkImageInfo::Make(static_cast<int>(rgba.width),
+                                  static_cast<int>(rgba.height),
+                                  kRGBA_8888_SkColorType,
+                                  kUnpremul_SkAlphaType);
+    SkPixmap pixmap(info, rgba.pixels.data(),
+                    static_cast<size_t>(rgba.width) * 4u);
+    // SkPngEncoder offers a 2-arg pixmap overload that returns
+    // `sk_sp<SkData>` (the 3-arg form takes an SkWStream* and returns
+    // bool — we want the buffer back, so use the 2-arg form).
+    sk_sp<SkData> png = SkPngEncoder::Encode(pixmap, SkPngEncoder::Options{});
+    if (!png || png->size() == 0) {
+        set_err("HeadlessSurface::encode_png: SkPngEncoder::Encode returned empty");
+        return {};
+    }
+    std::vector<uint8_t> out(png->size());
+    std::memcpy(out.data(), png->data(), png->size());
+    if (error_out) error_out->clear();
+    return out;
+#else
+    set_err("HeadlessSurface::encode_png: build was configured without PULP_HAS_SKIA");
+    return {};
+#endif
+}
+
+uint64_t HeadlessSurface::rgba_fingerprint(const Rgba& rgba) {
+    // FNV-1a 64. Deterministic, no deps, fine for goldens-by-fingerprint.
+    constexpr uint64_t kOffset = 1469598103934665603ULL;
+    constexpr uint64_t kPrime  = 1099511628211ULL;
+    uint64_t h = kOffset;
+    // Hash dimensions first so e.g. (10x20 = all-zero) and (20x10 = all-
+    // zero) get different fingerprints.
+    const uint32_t dims[2] = {rgba.width, rgba.height};
+    const auto* dim_bytes = reinterpret_cast<const uint8_t*>(dims);
+    for (size_t i = 0; i < sizeof(dims); ++i) {
+        h ^= static_cast<uint64_t>(dim_bytes[i]);
+        h *= kPrime;
+    }
+    for (uint8_t b : rgba.pixels) {
+        h ^= static_cast<uint64_t>(b);
+        h *= kPrime;
+    }
+    return h;
+}
+
+} // namespace pulp::render

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1668,6 +1668,24 @@ if(PULP_ENABLE_GPU)
     endif()
     catch_discover_tests(pulp-test-skia-surface ${PULP_GPU_TEST_DISCOVERY_ARGS})
 
+    # HeadlessSurface CI wrapper (plan §6.7) — one-call offscreen
+    # Dawn/Skia helper for golden-test fixtures. Compiles on every
+    # build; runtime cases gate on PULP_HAS_SKIA && __APPLE__ at the
+    # source level and otherwise soft-skip when no Dawn adapter is
+    # available. Needs Skia headers directly for the SkPngEncoder /
+    # SkPixmap symbols the wrapper uses to PNG-encode the readback.
+    add_executable(pulp-test-headless-surface test_headless_surface.cpp)
+    target_link_libraries(pulp-test-headless-surface PRIVATE
+        pulp::render pulp::canvas Catch2::Catch2WithMain)
+    if(PULP_HAS_SKIA)
+        target_compile_definitions(pulp-test-headless-surface PRIVATE
+            PULP_HAS_SKIA=1)
+        target_include_directories(pulp-test-headless-surface PRIVATE
+            ${SKIA_INCLUDE_DIRS})
+    endif()
+    catch_discover_tests(pulp-test-headless-surface
+        ${PULP_GPU_TEST_DISCOVERY_ARGS})
+
     # GPU compute tests (Phase 11 feasibility)
     add_executable(pulp-test-gpu-compute test_gpu_compute.cpp)
     target_link_libraries(pulp-test-gpu-compute PRIVATE pulp::render pulp::signal Catch2::Catch2WithMain)

--- a/test/test_headless_surface.cpp
+++ b/test/test_headless_surface.cpp
@@ -1,0 +1,241 @@
+// test_headless_surface.cpp — HeadlessSurface wrapper
+//
+// Plan: planning/2026-05-24-macos-plugin-authoring-plan.md §6.7.
+// Confirms the one-call CI wrapper that hides the existing
+// `GpuSurface::create_dawn() + native_surface_handle=nullptr` +
+// `SkiaSurface::create()` ceremony behind a `render_rgba` / `render_png`
+// API. The runtime cases gate on `PULP_HAS_SKIA && __APPLE__` —
+// otherwise the wrapper's create() returns nullptr (compile-time
+// safe) and we exercise only the pure-function `encode_png` /
+// `rgba_fingerprint` paths.
+//
+// Tag: [gpu][skia][headless-surface][item-6-7]
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/render/headless_surface.hpp>
+#include <pulp/canvas/canvas.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+using pulp::render::HeadlessSurface;
+
+namespace {
+
+constexpr uint32_t kW = 256;
+constexpr uint32_t kH = 128;
+
+// Sentinel background — distinctive enough that
+// `count_non_background` won't mistake noise for the user's paint.
+constexpr uint8_t kBgR = 20, kBgG = 40, kBgB = 80;
+
+uint32_t count_non_background(const HeadlessSurface::Rgba& rgba) {
+    const size_t n = rgba.pixel_count();
+    if (n == 0 || rgba.pixels.size() < n * 4u) return 0;
+    uint32_t count = 0;
+    for (size_t i = 0; i < n; ++i) {
+        const uint8_t r = rgba.pixels[i * 4 + 0];
+        const uint8_t g = rgba.pixels[i * 4 + 1];
+        const uint8_t b = rgba.pixels[i * 4 + 2];
+        const int dr = std::abs(static_cast<int>(r) - kBgR);
+        const int dg = std::abs(static_cast<int>(g) - kBgG);
+        const int db = std::abs(static_cast<int>(b) - kBgB);
+        if (dr + dg + db > 24) ++count;
+    }
+    return count;
+}
+
+} // namespace
+
+// ── Always-on cases (independent of GPU availability) ────────────────────
+
+TEST_CASE("HeadlessSurface::encode_png rejects empty / undersized input",
+          "[gpu][headless-surface][item-6-7]") {
+    HeadlessSurface::Rgba empty;
+    std::string err;
+    auto png = HeadlessSurface::encode_png(empty, &err);
+    REQUIRE(png.empty());
+    REQUIRE_FALSE(err.empty());
+
+    HeadlessSurface::Rgba bad;
+    bad.width = 4;
+    bad.height = 4;
+    bad.pixels.assign(8, 0);  // need 64 bytes, give 8
+    err.clear();
+    png = HeadlessSurface::encode_png(bad, &err);
+    REQUIRE(png.empty());
+    REQUIRE_FALSE(err.empty());
+}
+
+TEST_CASE("HeadlessSurface::rgba_fingerprint is deterministic and dim-sensitive",
+          "[gpu][headless-surface][item-6-7]") {
+    HeadlessSurface::Rgba a;
+    a.width = 2;
+    a.height = 3;
+    a.pixels = {1,2,3,4, 5,6,7,8, 9,10,11,12,
+                13,14,15,16, 17,18,19,20, 21,22,23,24};
+
+    HeadlessSurface::Rgba b = a;  // same content + dims
+    REQUIRE(HeadlessSurface::rgba_fingerprint(a) ==
+            HeadlessSurface::rgba_fingerprint(b));
+
+    HeadlessSurface::Rgba c = a;  // mutate one byte → different fingerprint
+    c.pixels[0] ^= 0xFF;
+    REQUIRE(HeadlessSurface::rgba_fingerprint(a) !=
+            HeadlessSurface::rgba_fingerprint(c));
+
+    HeadlessSurface::Rgba d;      // swap dims → different fingerprint
+    d.width = 3;
+    d.height = 2;
+    d.pixels = a.pixels;
+    REQUIRE(HeadlessSurface::rgba_fingerprint(a) !=
+            HeadlessSurface::rgba_fingerprint(d));
+}
+
+#if defined(PULP_HAS_SKIA) && defined(__APPLE__)
+
+TEST_CASE("HeadlessSurface::create soft-fails when Dawn unavailable",
+          "[gpu][skia][headless-surface][item-6-7]") {
+    HeadlessSurface::Config cfg;
+    cfg.width = 0;  // intentionally invalid → wrapper rejects without touching Dawn
+    cfg.height = 0;
+    std::string err;
+    auto surface = HeadlessSurface::create(cfg, &err);
+    REQUIRE(surface == nullptr);
+    REQUIRE_FALSE(err.empty());
+}
+
+TEST_CASE("HeadlessSurface renders a deterministic clear-only frame",
+          "[gpu][skia][headless-surface][item-6-7]") {
+    HeadlessSurface::Config cfg;
+    cfg.width = kW;
+    cfg.height = kH;
+    cfg.clear_r = kBgR;
+    cfg.clear_g = kBgG;
+    cfg.clear_b = kBgB;
+    cfg.clear_a = 255;
+
+    std::string err;
+    auto surface = HeadlessSurface::create(cfg, &err);
+    if (!surface) {
+        // No Dawn/Graphite on this host — that's the documented
+        // soft-skip path the CI lane uses when the runner lacks a GPU.
+        SUCCEED("HeadlessSurface unavailable: " + err);
+        return;
+    }
+    REQUIRE(surface->is_ready());
+
+    auto frame_a = surface->render_rgba(nullptr);
+    if (frame_a.empty()) {
+        SUCCEED("GPU readback failed: " + surface->last_error());
+        return;
+    }
+    REQUIRE(frame_a.width == kW);
+    REQUIRE(frame_a.height == kH);
+
+    // Same surface, same paint (none) → reproducible within tolerance.
+    // GPU async readback can produce sub-LSB jitter on a small number
+    // of pixels even on the same machine (plan §6.7: "reproducible
+    // within a documented tolerance"). The wrapper guarantees that the
+    // *vast majority* of pixels match exactly — we assert that floor
+    // rather than bit-exact fingerprint equality.
+    auto frame_b = surface->render_rgba(nullptr);
+    REQUIRE_FALSE(frame_b.empty());
+    REQUIRE(frame_a.width == frame_b.width);
+    REQUIRE(frame_a.height == frame_b.height);
+    REQUIRE(frame_a.pixels.size() == frame_b.pixels.size());
+    size_t diff_bytes = 0;
+    for (size_t i = 0; i < frame_a.pixels.size(); ++i) {
+        if (frame_a.pixels[i] != frame_b.pixels[i]) ++diff_bytes;
+    }
+    INFO("byte-diff between consecutive renders: " << diff_bytes
+         << " of " << frame_a.pixels.size());
+    // Tolerance: at most 1% of bytes may differ across consecutive
+    // renders. In practice the fully-cleared frames we render here
+    // match bit-exactly on Apple Silicon — the budget exists for
+    // adapter-jitter on other lanes.
+    REQUIRE(diff_bytes * 100u < frame_a.pixels.size());
+
+    // Clear-only frame: count_non_background must be ~0 (cleared with
+    // the background color). Allow a tiny tolerance for any GPU sampler
+    // dither at the edges.
+    const uint32_t painted = count_non_background(frame_a);
+    INFO("non-background pixels on a clear-only frame: " << painted);
+    REQUIRE(painted < (frame_a.pixel_count() / 100u));  // < 1%
+}
+
+TEST_CASE("HeadlessSurface renders a paint callback then encodes PNG",
+          "[gpu][skia][headless-surface][item-6-7]") {
+    HeadlessSurface::Config cfg;
+    cfg.width = kW;
+    cfg.height = kH;
+    cfg.clear_r = kBgR;
+    cfg.clear_g = kBgG;
+    cfg.clear_b = kBgB;
+    cfg.clear_a = 255;
+
+    std::string err;
+    auto surface = HeadlessSurface::create(cfg, &err);
+    if (!surface) {
+        SUCCEED("HeadlessSurface unavailable: " + err);
+        return;
+    }
+
+    auto paint_red_band = [](pulp::canvas::Canvas& c) {
+        c.set_fill_color(pulp::canvas::Color::rgba8(220, 30, 30, 255));
+        c.fill_rect(16.0f, 16.0f,
+                    static_cast<float>(kW) - 32.0f,
+                    static_cast<float>(kH) - 32.0f);
+    };
+
+    auto rgba = surface->render_rgba(paint_red_band);
+    if (rgba.empty()) {
+        SUCCEED("GPU readback failed: " + surface->last_error());
+        return;
+    }
+    REQUIRE(rgba.width == kW);
+    REQUIRE(rgba.height == kH);
+
+    // The paint callback should have produced many non-background pixels.
+    const uint32_t painted = count_non_background(rgba);
+    INFO("non-background pixels after paint: " << painted);
+    REQUIRE(painted > 1000u);
+
+    // PNG round-trip via the convenience entry point.
+    auto png = surface->render_png(paint_red_band);
+    if (png.empty()) {
+        SUCCEED("PNG encode failed: " + surface->last_error());
+        return;
+    }
+    REQUIRE(png.size() >= 8u);
+    // PNG magic: 89 50 4E 47 0D 0A 1A 0A
+    static constexpr uint8_t kMagic[8] = {0x89, 0x50, 0x4E, 0x47,
+                                          0x0D, 0x0A, 0x1A, 0x0A};
+    REQUIRE(std::memcmp(png.data(), kMagic, sizeof(kMagic)) == 0);
+}
+
+#else  // !(PULP_HAS_SKIA && __APPLE__)
+
+TEST_CASE("HeadlessSurface skips runtime cases when Skia/Apple unavailable",
+          "[gpu][skia][headless-surface][item-6-7]") {
+    HeadlessSurface::Config cfg;
+    cfg.width = kW;
+    cfg.height = kH;
+    std::string err;
+    auto surface = HeadlessSurface::create(cfg, &err);
+    // Without Skia, create() returns null; with Skia on non-Apple, the
+    // platform GpuSurface path may not init. Either way: no crash, and
+    // err is populated so callers can soft-skip.
+    if (!surface) {
+        REQUIRE_FALSE(err.empty());
+        SUCCEED("HeadlessSurface unavailable on this build: " + err);
+        return;
+    }
+    SUCCEED("HeadlessSurface available on a non-Apple Skia build — runtime cases skipped");
+}
+
+#endif  // PULP_HAS_SKIA && __APPLE__


### PR DESCRIPTION
## Summary

- Plan: `planning/2026-05-24-macos-plugin-authoring-plan.md` §6.7. Upgrades the Headless GpuSurface line from `Partial` → `Full` — the capability already existed via `GpuSurface::create_dawn() + native_surface_handle=nullptr` + `SkiaSurface`; this is the one-call CI wrapper around it.
- New `core/render::HeadlessSurface` returns RGBA / PNG in one call, with a deterministic background clear + Skia-based PNG encoding so the same scene produces reproducible bytes across reruns on the same machine.
- The submit-before-readback ordering inside `render_rgba` is load-bearing — without `SkiaSurface::end_frame()` first, the offscreen path samples stale GPU memory and produces drift between consecutive frames. Surfaced + fixed during bring-up.

## Files

- `core/render/include/pulp/render/headless_surface.hpp` (new public API; no Skia/Dawn types leak in the header)
- `core/render/src/headless_surface.cpp`
- `test/test_headless_surface.cpp` — 5 cases / 23 assertions; always-on cases (`encode_png` rejection, `rgba_fingerprint`); runtime cases gated on `PULP_HAS_SKIA && __APPLE__` with soft-skip when no Dawn adapter is available
- CMake wiring in `core/render/CMakeLists.txt` + `test/CMakeLists.txt`
- Planning tracker row 6.7 → 🟡 (planning submodule)

## Test plan

- [x] `cmake --build build --target pulp-test-headless-surface` → green
- [x] `./build/test/pulp-test-headless-surface` → 23/23 assertions pass on Apple Silicon
- [x] Existing sibling tests still pass: `pulp-test-skia-surface` (131/131), `pulp-test-gpu-surface` (41/41), `pulp-test-plugin-editor-headless-gpu` (25/25)
- [x] PNG output begins with PNG magic (`89 50 4E 47 0D 0A 1A 0A`)
- [x] Clear-only frame: byte-diff between consecutive renders well under the 1% tolerance budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)