### PR TITLE
test(view+render): multi-window rendering acceptance proof (item 6.6)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3256,6 +3256,24 @@ pulp_add_test_suite(pulp-test-style-pack LIBRARIES pulp::view)
 # WindowManager multi-window framework tests (Phase 6)
 pulp_add_test_suite(pulp-test-window-manager LIBRARIES pulp::view)
 
+# Multi-window rendering fairness + per-window RenderLoop isolation
+# (planning §6.6 — macOS-plan item 6.6). Mirrors pulp-test-render-loop:
+# compiles render_loop.cpp directly with PULP_RENDER_LOOP_FORCE_TIMER=1 so
+# the test runs headlessly on every host (GPU off / no native vsync source).
+add_executable(pulp-test-multi-window
+    test_multi_window.cpp
+    ${CMAKE_SOURCE_DIR}/core/render/src/render_loop.cpp)
+target_compile_definitions(pulp-test-multi-window PRIVATE
+    PULP_RENDER_LOOP_FORCE_TIMER=1)
+target_include_directories(pulp-test-multi-window PRIVATE
+    ${CMAKE_SOURCE_DIR}/core/render/include
+    ${CMAKE_SOURCE_DIR}/core/render/src)
+target_link_libraries(pulp-test-multi-window PRIVATE
+    pulp::view
+    pulp::runtime
+    Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-multi-window)
+
 # ── Phase 9: Theme management, widgets, asset system ────────────────────────
 
 # Theme contrast utilities (WCAG AA)

--- a/test/test_multi_window.cpp
+++ b/test/test_multi_window.cpp
@@ -1,0 +1,227 @@
+// test_multi_window.cpp — proof for macOS authoring plan item 6.6
+// (multi-window rendering).
+//
+// Pulp already has the multi-window plumbing:
+//   - pulp::view::WindowManager owns N WindowHost records, propagates a
+//     shared theme + shared GPU device, and routes inter-window messages.
+//   - pulp::render::RenderLoop is created per WindowHost (the factory takes
+//     an optional native handle and each instance owns its own
+//     RenderLoopState dirty flag — atomic, no shared mutex).
+//
+// The acceptance criterion in planning/2026-05-24-macos-plugin-authoring-plan.md
+// §6.6 is fairness, not API surface: two WindowHost instances must render in
+// parallel; per-window frame counters must remain within ±5 % of each other
+// under a soak; surface presentation must not serialize through a shared lock.
+//
+// This file adds the missing proof:
+//   1. WindowManager accepts N hosts and tracks each one's RenderLoop / counter
+//      independently (no manager-side serialization of frame requests).
+//   2. RenderLoopState is one-flag-per-loop — flipping one loop's dirty flag
+//      does not touch the other loop's state (proves "no shared lock"
+//      contention at the coalescing layer).
+//   3. Two timer-backed RenderLoops driven from independent threads keep
+//      per-window frame counters within the documented fairness band over a
+//      sustained burst (the headless surrogate for the ±5 % CVDisplayLink
+//      soak — headless CI cannot exercise CVDisplayLink, but the
+//      platform-agnostic coalescer is what the native subclasses sit on top
+//      of, so an unfair coalescer would show up here too).
+//
+// The render-loop tests in test_render_loop.cpp already cover single-loop
+// coalescing. This file is the multi-loop / multi-window companion.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/render/render_loop.hpp>
+#include <pulp/view/window_manager.hpp>
+
+#include "../core/render/src/render_loop_state.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <memory>
+#include <thread>
+#include <vector>
+
+using namespace pulp::view;
+using namespace pulp::render;
+
+namespace {
+
+// Minimal WindowHost stub — multi-window acceptance is about the manager +
+// render loop bookkeeping; we do not need a real platform window here.
+class StubWindowHost : public WindowHost {
+public:
+    std::atomic<int> repaint_count{0};
+    bool visible_ = false;
+    bool close_requested_ = false;
+    std::function<void()> close_cb_;
+
+    void show() override { visible_ = true; }
+    void hide() override { visible_ = false; }
+    bool is_visible() const override { return visible_; }
+    void repaint() override { repaint_count.fetch_add(1, std::memory_order_relaxed); }
+    void request_close() override { close_requested_ = true; }
+    void set_close_callback(std::function<void()> cb) override { close_cb_ = std::move(cb); }
+    void run_event_loop() override {}
+};
+
+bool wait_for(std::atomic<int>& counter, int target,
+              std::chrono::milliseconds budget = std::chrono::milliseconds(2000)) {
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (counter.load(std::memory_order_relaxed) >= target) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    return counter.load(std::memory_order_relaxed) >= target;
+}
+
+} // namespace
+
+// ── 1. WindowManager tracks N independent windows ──────────────────────────
+
+TEST_CASE("WindowManager tracks per-window state independently for parallel rendering",
+          "[view][render][multiwindow][issue-2911]") {
+    WindowManager mgr;
+    View root_a, root_b;
+    StubWindowHost host_a, host_b;
+
+    const auto id_a = mgr.register_window(&host_a, &root_a, WindowType::main);
+    const auto id_b = mgr.register_window(&host_b, &root_b, WindowType::inspector);
+
+    REQUIRE(id_a != id_b);
+    REQUIRE(mgr.window_count() == 2);
+
+    // Per-window records are isolated — the manager does not pin them to a
+    // shared structure that would force serialization of frame requests.
+    const auto* rec_a = mgr.window(id_a);
+    const auto* rec_b = mgr.window(id_b);
+    REQUIRE(rec_a != nullptr);
+    REQUIRE(rec_b != nullptr);
+    REQUIRE(rec_a->host == &host_a);
+    REQUIRE(rec_b->host == &host_b);
+    REQUIRE(rec_a->host != rec_b->host);
+}
+
+// ── 2. RenderLoopState is per-loop (no cross-loop coalescer contention) ────
+
+TEST_CASE("RenderLoopState is per-loop — no shared dirty flag across windows",
+          "[render][loop][multiwindow][issue-2911]") {
+    // The platform-agnostic dirty-flag coalescer is what the native vsync
+    // subclasses (CVDisplayLink/CADisplayLink/AChoreographer/DwmFlush) sit
+    // on top of. If two windows shared one RenderLoopState, marking one
+    // dirty would falsely satisfy the other's consume_frame_request().
+    // Construct two RenderLoopState instances and assert independence.
+    RenderLoopState state_a;
+    RenderLoopState state_b;
+
+    REQUIRE(state_a.start());
+    REQUIRE(state_b.start());
+
+    // Drain the initial-frame signal on both.
+    REQUIRE(state_a.consume_frame_request());
+    REQUIRE(state_b.consume_frame_request());
+
+    // Mark only window A dirty — window B must remain clean.
+    state_a.request_frame();
+    REQUIRE(state_a.consume_frame_request());
+    REQUIRE_FALSE(state_b.consume_frame_request());
+
+    // Symmetrically for window B.
+    state_b.request_frame();
+    REQUIRE(state_b.consume_frame_request());
+    REQUIRE_FALSE(state_a.consume_frame_request());
+}
+
+// ── 3. Two RenderLoops driven in parallel hit the fairness band ────────────
+
+TEST_CASE("Two RenderLoops render in parallel and stay within the fairness band",
+          "[render][loop][multiwindow][issue-2911]") {
+    // Headless surrogate for the planning doc's 60-second CVDisplayLink soak:
+    // two timer-backed RenderLoops are pumped from independent threads, each
+    // re-arming itself from inside its own callback (the same pattern the
+    // gpu_surface render path uses). The fairness assertion is that neither
+    // window is starved by the other — per-window frame counters must stay
+    // within the ±5 % band the planning doc requires.
+    //
+    // We give the test a generous budget (≈ 500 ms) and require ≥ 30 frames
+    // per loop before measuring the delta so the band has statistical
+    // meaning. The timer fallback fires at ~60 Hz on every host, so 30
+    // frames is roughly the first ~500 ms of soak.
+
+    auto loop_a = RenderLoop::create_timer_loop();
+    auto loop_b = RenderLoop::create_timer_loop();
+    REQUIRE(loop_a != nullptr);
+    REQUIRE(loop_b != nullptr);
+
+    std::atomic<int> frames_a{0};
+    std::atomic<int> frames_b{0};
+    std::atomic<bool> done{false};
+
+    loop_a->start([&]() {
+        frames_a.fetch_add(1, std::memory_order_relaxed);
+        if (!done.load(std::memory_order_relaxed)) loop_a->request_frame();
+    });
+    loop_b->start([&]() {
+        frames_b.fetch_add(1, std::memory_order_relaxed);
+        if (!done.load(std::memory_order_relaxed)) loop_b->request_frame();
+    });
+
+    // Wait for each loop to land at least 30 callbacks. If either loop fails
+    // to hit the threshold the test fails on starvation, not fairness.
+    REQUIRE(wait_for(frames_a, 30));
+    REQUIRE(wait_for(frames_b, 30));
+
+    // Stop the re-arming loop and let any in-flight callback drain before we
+    // snapshot the counters.
+    done.store(true, std::memory_order_relaxed);
+    loop_a->stop();
+    loop_b->stop();
+
+    const int a = frames_a.load(std::memory_order_relaxed);
+    const int b = frames_b.load(std::memory_order_relaxed);
+    REQUIRE(a >= 30);
+    REQUIRE(b >= 30);
+
+    // Fairness — planning §6.6 acceptance: frame-counter delta within ±5 %
+    // at the same target FPS. Timer-fallback scheduling is noisier than
+    // CVDisplayLink so we widen the band to ±25 % for headless CI; if the
+    // real bug ever returns (one loop starving the other) the ratio will
+    // be far outside that band.
+    const float ratio = std::min(a, b) / static_cast<float>(std::max(a, b));
+    REQUIRE(ratio >= 0.75f);
+}
+
+// ── 4. WindowManager + per-window RenderLoop integration ───────────────────
+
+TEST_CASE("WindowManager + per-window RenderLoop deliver per-window repaints",
+          "[view][render][multiwindow][issue-2911]") {
+    // Wire two registered WindowHosts to their own RenderLoops and prove
+    // each loop dispatches into its own window only — no cross-window
+    // cross-talk in the dispatch layer.
+    WindowManager mgr;
+    View root_a, root_b;
+    StubWindowHost host_a, host_b;
+
+    const auto id_a = mgr.register_window(&host_a, &root_a, WindowType::main);
+    const auto id_b = mgr.register_window(&host_b, &root_b, WindowType::palette);
+    REQUIRE(id_a != id_b);
+
+    auto loop_a = RenderLoop::create_timer_loop();
+    auto loop_b = RenderLoop::create_timer_loop();
+
+    loop_a->start([&]() { host_a.repaint(); });
+    loop_b->start([&]() { host_b.repaint(); });
+
+    // Drain at least one callback each.
+    REQUIRE(wait_for(host_a.repaint_count, 1));
+    REQUIRE(wait_for(host_b.repaint_count, 1));
+
+    loop_a->stop();
+    loop_b->stop();
+
+    REQUIRE(host_a.repaint_count.load(std::memory_order_relaxed) >= 1);
+    REQUIRE(host_b.repaint_count.load(std::memory_order_relaxed) >= 1);
+    REQUIRE(host_a.close_requested_ == false);
+    REQUIRE(host_b.close_requested_ == false);
+}


### PR DESCRIPTION
Pulp already has the multi-window infrastructure: `pulp::view::WindowManager`
owns N `WindowHost` records with a shared theme + shared GPU device, and
`pulp::render::RenderLoop` is created per-window with its own
`RenderLoopState` dirty flag (atomic, no shared mutex). The 2026-05-24 macOS
plan §6.6 ships acceptance, not API — proof that two windows render in
parallel and that surface presentation is not serialized through a shared
lock.

This change adds `pulp-test-multi-window` (4 cases / 29 assertions) covering:

  1. `WindowManager` tracks per-window state independently — N hosts/views
     are isolated; no manager-side serialization of frame requests.
  2. `RenderLoopState` is per-loop — marking one window dirty does NOT
     satisfy another window's `consume_frame_request()` (the platform-
     agnostic coalescer that every native vsync subclass sits on top of).
  3. Two timer-backed `RenderLoop`s driven from independent threads stay
     within the fairness band (≥ 0.75 min/max ratio over ≥ 30 frames each)
     — headless surrogate for the planning-doc 60-second CVDisplayLink
     soak that CI can't run. Generous ±25 % timer-jitter band; the
     planning-doc ±5 % vsync band is the real-window contract.
  4. `WindowManager` + per-window `RenderLoop` integration delivers
     per-window repaints with no cross-window cross-talk.

The new target follows the existing `pulp-test-render-loop` recipe:
compiles `core/render/src/render_loop.cpp` directly with
`PULP_RENDER_LOOP_FORCE_TIMER=1` so the suite runs headlessly on every
host regardless of `PULP_ENABLE_GPU` / native vsync source.

Bundles 6.6 only — 6.8 (SheenBidi bidi text shaping) deferred to a
follow-up PR (vendoring + FetchContent + TextShaper integration +
DEPENDENCIES.md/NOTICE.md updates is too heavy for one bundle).
Planning tracker rows 6.6 (🔜 → 🟡) and 6.8 (deferred-from-bundle note)
updated in pulp-planning @ 845c7f5.