### PR TITLE
feat(view+host): PluginManagerPanel drag-add into SignalGraph (item 4.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.119.0",
+      "version": "0.120.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.119.0"
+  "version": "0.120.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.119.0",
+  "version": "0.120.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.242.0
+    VERSION 0.243.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -416,4 +416,26 @@ private:
                                        const std::vector<Connection>& connections);
 };
 
+// ── Drag-add helper (item 4.3) ──────────────────────────────────────────
+//
+// `add_plugin_node_from_drop` is the host-side companion to
+// `pulp::view::PluginManagerPanel::on_row_drag_start`. It attempts to
+// load the plugin in the supplied `PluginInfo`; if PluginSlot::load
+// returns null (plugin missing on this machine, ABI mismatch, scanner
+// gave us a stale path, etc.) it falls back to
+// `add_unresolved_plugin_node` so the topology survives a serialize +
+// reload pass and the user can resolve the plugin later.
+//
+// `loaded_out`, if non-null, is set to true when a live PluginSlot
+// attached or false when the node landed unresolved — useful for
+// driving the drop-target UI (e.g. ghost-vs-solid node rendering).
+//
+// The function takes the graph by reference; it is the caller's
+// responsibility to call `graph.prepare(...)` afterwards before the
+// next audio block. We do NOT do that here because real hosts batch
+// drops and prepare once at the end of the UI tick.
+NodeId add_plugin_node_from_drop(SignalGraph& graph,
+                                 const PluginInfo& info,
+                                 bool* loaded_out = nullptr);
+
 } // namespace pulp::host

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -1207,4 +1207,26 @@ float SignalGraph::node_gain(NodeId id) const {
     return n->gain;
 }
 
+// ── Drag-add helper (item 4.3) ──────────────────────────────────────────
+NodeId add_plugin_node_from_drop(SignalGraph& graph,
+                                 const PluginInfo& info,
+                                 bool* loaded_out)
+{
+    // Try the live-load path first. add_plugin_node calls PluginSlot::load,
+    // which may return null when the bundle is missing or refuses to load.
+    const NodeId id = graph.add_plugin_node(info);
+    if (auto* n = graph.node(id); n && n->plugin) {
+        if (loaded_out) *loaded_out = true;
+        return id;
+    }
+
+    // Live-load failed — remove the half-loaded node and create an
+    // unresolved placeholder so the graph still carries the user's intent.
+    graph.remove_node(id);
+    if (loaded_out) *loaded_out = false;
+    return graph.add_unresolved_plugin_node(
+        info, info.num_inputs, info.num_outputs,
+        info.name.empty() ? info.path : info.name);
+}
+
 } // namespace pulp::host

--- a/core/view/include/pulp/view/plugin_manager_panel.hpp
+++ b/core/view/include/pulp/view/plugin_manager_panel.hpp
@@ -38,6 +38,39 @@ struct PluginManagerRow {
     std::string path;                 ///< Absolute path to the plugin bundle/binary
     std::string reason;               ///< For failed/blacklisted rows: why
     std::int64_t last_scan_unix = 0;  ///< Seconds-since-epoch; 0 = "never"
+
+    // ── Item 4.3 — drag-add identity ─────────────────────────────────────
+    // The fields below are populated by the model so a drag-add into a
+    // SignalGraph can synthesize the PluginInfo without having to re-scan
+    // or look the row up by path. They are intentionally optional — older
+    // models that pre-date item 4.3 leave them at defaults and the
+    // resulting drop produces an "unresolved" graph node (PluginSlot::load
+    // is still attempted via `to_plugin_info`).
+    std::string manufacturer;
+    std::string version;
+    std::string unique_id;
+    int num_inputs = 2;
+    int num_outputs = 2;
+    bool is_instrument = false;
+    bool is_effect = true;
+
+    /// Convert this row back into a `pulp::host::PluginInfo` suitable for
+    /// SignalGraph::add_plugin_node(). Lossy by construction — only the
+    /// fields the manager panel tracks survive.
+    pulp::host::PluginInfo to_plugin_info() const {
+        pulp::host::PluginInfo info;
+        info.name = name;
+        info.manufacturer = manufacturer;
+        info.version = version;
+        info.path = path;
+        info.unique_id = unique_id;
+        info.format = format;
+        info.is_instrument = is_instrument;
+        info.is_effect = is_effect;
+        info.num_inputs = num_inputs;
+        info.num_outputs = num_outputs;
+        return info;
+    }
 };
 
 /// Which bucket a row belongs to.
@@ -473,6 +506,84 @@ public:
         }
     }
 
+    // ── Drag-add into a SignalGraph (item 4.3) ───────────────────────────
+    //
+    // The panel itself is rendering-only — it does not know what surface
+    // (graph editor, mixer column, etc.) the user is dropping onto. We
+    // emit a `on_row_drag_start` callback when the user presses on a
+    // scanned row and drags past `drag_threshold_px_`. The host is
+    // responsible for taking the row's `PluginInfo` and adding the node
+    // to whichever `SignalGraph` the drop landed on (see
+    // `pulp::host::add_plugin_node_from_row`).
+    //
+    // The drag callback fires only for rows in the `scanned` bucket —
+    // dragging a failed or blacklisted entry into the graph would create
+    // a node that can never load, so the panel suppresses it.
+
+    void on_mouse_down(Point pos) override {
+        drag_origin_ = pos;
+        drag_origin_set_ = true;
+        drag_started_ = false;
+        drag_row_ = identify_row_at(pos);
+    }
+    void on_mouse_drag(Point pos) override {
+        if (drag_origin_set_ && !drag_started_ && drag_row_.has_value()) {
+            const float dx = pos.x - drag_origin_.x;
+            const float dy = pos.y - drag_origin_.y;
+            if (dx * dx + dy * dy >= drag_threshold_px_ * drag_threshold_px_) {
+                drag_started_ = true;
+                if (on_row_drag_start && drag_row_->first == PluginManagerBucket::scanned) {
+                    on_row_drag_start(drag_row_->first, drag_row_->second, pos);
+                }
+            }
+        }
+    }
+    void on_mouse_up(Point pos) override {
+        if (drag_started_ && drag_row_.has_value() && on_row_drag_end) {
+            on_row_drag_end(drag_row_->first, drag_row_->second, pos);
+        }
+        drag_origin_set_ = false;
+        drag_started_ = false;
+        drag_row_.reset();
+    }
+
+    /// Programmatic drag — bypasses the per-frame mouse plumbing so a
+    /// host or test can fire the drag-add callback for a specific row
+    /// without synthesising motion events. The row is looked up by its
+    /// path. Returns true when a matching row was found and a non-empty
+    /// `on_row_drag_start` callback fired; false otherwise.
+    bool simulate_row_drag(PluginManagerBucket bucket,
+                           const std::string& path,
+                           Point drop_position = {0, 0})
+    {
+        const auto& rows_vec = visible(bucket);
+        for (const auto& r : rows_vec) {
+            if (r.path == path) {
+                if (bucket == PluginManagerBucket::scanned && on_row_drag_start) {
+                    on_row_drag_start(bucket, r, drop_position);
+                }
+                if (on_row_drag_end) {
+                    on_row_drag_end(bucket, r, drop_position);
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// Pixel threshold a drag must exceed before `on_row_drag_start` fires.
+    /// Defaults to 4 px to match common desktop conventions.
+    float drag_threshold_px() const { return drag_threshold_px_; }
+    void set_drag_threshold_px(float px) { drag_threshold_px_ = px; }
+
+    /// Fired once per drag, when the user has moved past
+    /// `drag_threshold_px()` after pressing on a scanned row.
+    std::function<void(PluginManagerBucket, const PluginManagerRow&, Point)> on_row_drag_start;
+
+    /// Fired on mouse-up after a drag started. Hosts that build a live
+    /// drop-target preview tear it down here.
+    std::function<void(PluginManagerBucket, const PluginManagerRow&, Point)> on_row_drag_end;
+
     bool on_key_event(const KeyEvent& event) override {
         if (!event.is_down) return false;
         // Type-to-filter: printable keys land in `on_text_input` on most
@@ -511,6 +622,37 @@ private:
     PluginManagerBucket context_menu_bucket_ = PluginManagerBucket::scanned;
 
     float row_height_ = 22.0f;
+
+    // Drag-add state (item 4.3)
+    Point drag_origin_{0, 0};
+    bool drag_origin_set_ = false;
+    bool drag_started_ = false;
+    std::optional<std::pair<PluginManagerBucket, PluginManagerRow>> drag_row_;
+    float drag_threshold_px_ = 4.0f;
+
+    std::optional<std::pair<PluginManagerBucket, PluginManagerRow>>
+    identify_row_at(Point pos) const {
+        const auto b = local_bounds();
+        const float toolbar_h = 28.0f;
+        if (pos.y < toolbar_h) return std::nullopt;
+
+        const float col_w = (b.width - 16.0f) / 3.0f;
+        const int col_idx = static_cast<int>((pos.x - 4.0f) / col_w);
+        const PluginManagerBucket bucket = col_idx <= 0
+            ? PluginManagerBucket::scanned
+            : col_idx == 1
+                ? PluginManagerBucket::failed
+                : PluginManagerBucket::blacklisted;
+
+        const float header_h = 20.0f;
+        const float row_y = pos.y - toolbar_h - 4.0f - header_h;
+        if (row_y < 0) return std::nullopt;
+
+        const auto& rows_vec = visible(bucket);
+        const int row = static_cast<int>(row_y / row_height_);
+        if (row < 0 || row >= static_cast<int>(rows_vec.size())) return std::nullopt;
+        return std::make_pair(bucket, rows_vec[static_cast<size_t>(row)]);
+    }
 
     const std::vector<PluginManagerRow>& visible(PluginManagerBucket b) const {
         switch (b) {

--- a/test/test_plugin_manager_panel.cpp
+++ b/test/test_plugin_manager_panel.cpp
@@ -10,6 +10,7 @@
 
 #include <pulp/host/scan_blacklist.hpp>
 #include <pulp/host/scanner.hpp>
+#include <pulp/host/signal_graph.hpp>
 #include <pulp/view/input_events.hpp>
 #include <pulp/view/plugin_manager_panel.hpp>
 
@@ -315,4 +316,182 @@ TEST_CASE("PluginManagerPanel text input appends to the filter "
     ke.is_down = true;
     REQUIRE(panel.on_key_event(ke));
     REQUIRE(panel.filter() == "gl");
+}
+
+// ── Item 4.3: drag-add into SignalGraph ──────────────────────────────────
+
+TEST_CASE("PluginManagerRow round-trips into a PluginInfo for the graph",
+          "[view][plugin_manager][issue-4-3]")
+{
+    PluginManagerRow row;
+    row.format = PluginFormat::CLAP;
+    row.name = "Solid Bass";
+    row.path = "/plugins/SolidBass.clap";
+    row.manufacturer = "Pulp Labs";
+    row.version = "1.2.3";
+    row.unique_id = "com.pulp.solidbass";
+    row.num_inputs = 0;
+    row.num_outputs = 2;
+    row.is_instrument = true;
+    row.is_effect = false;
+
+    const auto info = row.to_plugin_info();
+    REQUIRE(info.name == "Solid Bass");
+    REQUIRE(info.path == "/plugins/SolidBass.clap");
+    REQUIRE(info.manufacturer == "Pulp Labs");
+    REQUIRE(info.unique_id == "com.pulp.solidbass");
+    REQUIRE(info.num_inputs == 0);
+    REQUIRE(info.num_outputs == 2);
+    REQUIRE(info.is_instrument);
+    REQUIRE_FALSE(info.is_effect);
+    REQUIRE(info.format == PluginFormat::CLAP);
+}
+
+TEST_CASE("PluginManagerPanel fires on_row_drag_start when a scanned row "
+          "is dragged past the threshold",
+          "[view][plugin_manager][issue-4-3]")
+{
+    InMemoryPluginManagerModel model; populate_model(model);
+    PluginManagerPanel panel(model);
+    panel.set_bounds({0, 0, 900, 400});
+
+    int drag_start_count = 0;
+    int drag_end_count = 0;
+    PluginManagerRow captured_row;
+    PluginManagerBucket captured_bucket = PluginManagerBucket::failed;
+    panel.on_row_drag_start = [&](PluginManagerBucket b,
+                                  const PluginManagerRow& r,
+                                  pulp::view::Point) {
+        ++drag_start_count;
+        captured_row = r;
+        captured_bucket = b;
+    };
+    panel.on_row_drag_end = [&](PluginManagerBucket, const PluginManagerRow&,
+                                pulp::view::Point) {
+        ++drag_end_count;
+    };
+
+    // First scanned row sits just below the toolbar+header in column 0.
+    const pulp::view::Point press{40.0f, 28.0f + 4.0f + 20.0f + 4.0f};
+    panel.on_mouse_down(press);
+    // Below threshold — must not start a drag.
+    panel.on_mouse_drag({press.x + 1.0f, press.y + 1.0f});
+    REQUIRE(drag_start_count == 0);
+    // Past threshold (default 4 px) — drag starts.
+    panel.on_mouse_drag({press.x + 50.0f, press.y + 10.0f});
+    panel.on_mouse_up({press.x + 50.0f, press.y + 10.0f});
+    REQUIRE(drag_start_count == 1);
+    REQUIRE(drag_end_count == 1);
+    REQUIRE(captured_bucket == PluginManagerBucket::scanned);
+    REQUIRE(captured_row.path == "/plugins/SolidBass.clap");
+}
+
+TEST_CASE("PluginManagerPanel suppresses drag-add for failed and "
+          "blacklisted bucket rows",
+          "[view][plugin_manager][issue-4-3]")
+{
+    InMemoryPluginManagerModel model; populate_model(model);
+    PluginManagerPanel panel(model);
+    panel.set_bounds({0, 0, 900, 400});
+
+    int drag_starts = 0;
+    panel.on_row_drag_start = [&](PluginManagerBucket, const PluginManagerRow&,
+                                  pulp::view::Point) {
+        ++drag_starts;
+    };
+
+    // simulate_row_drag bypasses the geometry hit-test so the test
+    // doesn't have to know column coordinates.
+    REQUIRE(panel.simulate_row_drag(PluginManagerBucket::failed,
+                                    "/plugins/Broken.clap"));
+    REQUIRE(drag_starts == 0);
+
+    // Scanned row IS allowed.
+    REQUIRE(panel.simulate_row_drag(PluginManagerBucket::scanned,
+                                    "/plugins/SolidBass.clap"));
+    REQUIRE(drag_starts == 1);
+}
+
+TEST_CASE("Drag-emit from panel adds an unresolved plugin node to a "
+          "SignalGraph (item 4.3)",
+          "[view][plugin_manager][host][signal_graph][issue-4-3]")
+{
+    InMemoryPluginManagerModel model;
+    PluginManagerRow row;
+    row.format = PluginFormat::CLAP;
+    row.name = "Solid Bass";
+    row.path = "/nonexistent/plugins/SolidBass.clap";
+    row.unique_id = "com.pulp.solidbass";
+    row.num_inputs = 0;
+    row.num_outputs = 2;
+    row.is_instrument = true;
+    row.is_effect = false;
+    model.scanned_rows = {row};
+
+    PluginManagerPanel panel(model);
+    panel.set_bounds({0, 0, 900, 400});
+
+    pulp::host::SignalGraph graph;
+    pulp::host::NodeId last_added = 0;
+    bool last_loaded = true;
+    panel.on_row_drag_start = [&](PluginManagerBucket bucket,
+                                  const PluginManagerRow& r,
+                                  pulp::view::Point /*drop_pos*/) {
+        REQUIRE(bucket == PluginManagerBucket::scanned);
+        last_added = pulp::host::add_plugin_node_from_drop(
+            graph, r.to_plugin_info(), &last_loaded);
+    };
+
+    REQUIRE(panel.simulate_row_drag(PluginManagerBucket::scanned, row.path));
+
+    REQUIRE(last_added != 0);
+    // The path is bogus → PluginSlot::load returns null → unresolved fallback.
+    REQUIRE_FALSE(last_loaded);
+
+    const auto* n = graph.node(last_added);
+    REQUIRE(n != nullptr);
+    REQUIRE(n->type == pulp::host::NodeType::Plugin);
+    REQUIRE(n->plugin == nullptr);                 // unresolved
+    REQUIRE(n->plugin_info.path == row.path);      // identity preserved
+    REQUIRE(n->plugin_info.unique_id == "com.pulp.solidbass");
+    REQUIRE(n->num_input_ports == 0);
+    REQUIRE(n->num_output_ports == 2);
+
+    // Graph is now non-empty — drag-add really did integrate.
+    REQUIRE(graph.nodes().size() == 1);
+}
+
+TEST_CASE("Multiple drag-emits stack additional graph nodes "
+          "without disturbing earlier ones (item 4.3)",
+          "[view][plugin_manager][host][signal_graph][issue-4-3]")
+{
+    InMemoryPluginManagerModel model;
+    PluginManagerRow a;
+    a.format = PluginFormat::VST3; a.name = "Glacier"; a.path = "/p/Glacier.vst3";
+    a.unique_id = "glacier"; a.num_inputs = 2; a.num_outputs = 2;
+    PluginManagerRow b;
+    b.format = PluginFormat::CLAP; b.name = "Solid";    b.path = "/p/Solid.clap";
+    b.unique_id = "solid";    b.num_inputs = 2; b.num_outputs = 2;
+    model.scanned_rows = {a, b};
+
+    PluginManagerPanel panel(model);
+    panel.set_bounds({0, 0, 900, 400});
+    pulp::host::SignalGraph graph;
+
+    std::vector<pulp::host::NodeId> ids;
+    panel.on_row_drag_start = [&](PluginManagerBucket,
+                                  const PluginManagerRow& r,
+                                  pulp::view::Point) {
+        ids.push_back(pulp::host::add_plugin_node_from_drop(
+            graph, r.to_plugin_info(), nullptr));
+    };
+
+    REQUIRE(panel.simulate_row_drag(PluginManagerBucket::scanned, a.path));
+    REQUIRE(panel.simulate_row_drag(PluginManagerBucket::scanned, b.path));
+
+    REQUIRE(ids.size() == 2);
+    REQUIRE(ids[0] != ids[1]);
+    REQUIRE(graph.nodes().size() == 2);
+    REQUIRE(graph.node(ids[0])->plugin_info.unique_id == "glacier");
+    REQUIRE(graph.node(ids[1])->plugin_info.unique_id == "solid");
 }


### PR DESCRIPTION
## Summary

Wires the existing `pulp::view::PluginManagerPanel` widget into `pulp::host::SignalGraph` so the user can drag a scanned plugin row out of the panel and drop it onto a graph editor. The panel stays surface-agnostic — it emits `on_row_drag_start` / `on_row_drag_end` callbacks; hosts wire the drop into whichever graph the cursor lands on.

- `PluginManagerRow` gains identity fields (`manufacturer`, `version`, `unique_id`, `num_inputs`, `num_outputs`, `is_instrument`, `is_effect`) + a `to_plugin_info()` helper. Defaulted so older models keep working.
- `PluginManagerPanel` tracks press → drag-threshold → drag-start, suppresses drags on failed/blacklisted rows, and exposes `simulate_row_drag()` for tests and hosts.
- `pulp::host::add_plugin_node_from_drop(graph, info, &loaded)` tries the live `PluginSlot::load` path and falls back to `add_unresolved_plugin_node` when the bundle can't load — preserves user intent across save/reload.

Planning: `planning/2026-05-24-macos-plugin-authoring-plan.md` § 4.3.

## Test plan

- [x] `pulp-test-plugin-manager-panel` — 14/14 green (5 new drag-add cases incl. end-to-end drop into a `SignalGraph`)
- [x] `pulp-test-host-signal-graph` — 47/47 green (no regression)
- [x] `tools/scripts/gates.sh` — clean (skill-sync, version-bump, compat-sync, node-ABI, deps-audit)
- [x] Release build configured + targets compile clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)