### PR TITLE
feat(format/host-quirks): extract REAPER + Pro Tools per-host headers (items 5.8 + 5.9)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.242.0
+    VERSION 0.243.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/host_quirks.hpp
+++ b/core/format/include/pulp/format/host_quirks.hpp
@@ -209,24 +209,30 @@ struct HostQuirksMeta {
     QuirkStatus fl_studio_setactive_process_mutex = QuirkStatus::Speculative;
     QuirkStatus fl_studio_state_reader_skip = QuirkStatus::Speculative;
 
-    // Reaper rows live in the dispatch table (host_quirks.cpp) but
-    // have NO per-host header yet and no isolation tests. LessonOnly
-    // until item 5.8 lands the header + per-symptom regression tests.
-    QuirkStatus reaper_vst3_gesture_ordering = QuirkStatus::LessonOnly;
-    QuirkStatus reaper_process_while_bypassed = QuirkStatus::LessonOnly;
-    QuirkStatus reaper_keyboard_passthrough = QuirkStatus::LessonOnly;
-    QuirkStatus reaper_permissive_bus_arrangements = QuirkStatus::LessonOnly;
-    QuirkStatus reaper_anticipative_fx_buffer_variability = QuirkStatus::LessonOnly;
-    QuirkStatus reaper_midsession_setstate = QuirkStatus::LessonOnly;
+    // Reaper rows now have a per-host header
+    // (`host_quirks/reaper.hpp`, item 5.8) + per-symptom isolation
+    // tests pinning the dispatch. In-DAW bench evidence is still
+    // pending → Speculative. Promote to Validated when REAPER 7.x
+    // bench rows ship.
+    QuirkStatus reaper_vst3_gesture_ordering = QuirkStatus::Speculative;
+    QuirkStatus reaper_process_while_bypassed = QuirkStatus::Speculative;
+    QuirkStatus reaper_keyboard_passthrough = QuirkStatus::Speculative;
+    QuirkStatus reaper_permissive_bus_arrangements = QuirkStatus::Speculative;
+    QuirkStatus reaper_anticipative_fx_buffer_variability = QuirkStatus::Speculative;
+    QuirkStatus reaper_midsession_setstate = QuirkStatus::Speculative;
     // iPlug2-audit lesson (2026-05-25): REAPER keyboard only-Space —
     // documented across 5.x–7.x line, no in-tree bench yet → LessonOnly.
     QuirkStatus reaper_keyboard_only_space = QuirkStatus::LessonOnly;
 
-    // Pro Tools AAX rows are gated on the developer-supplied Avid SDK
-    // (item 5.9). Catalog entries until the AAX lane lands a header.
-    QuirkStatus pro_tools_aax_sidechain_negotiation = QuirkStatus::LessonOnly;
-    QuirkStatus pro_tools_aax_latency_callback_push = QuirkStatus::LessonOnly;
-    QuirkStatus pro_tools_aax_mono_second_bus = QuirkStatus::LessonOnly;
+    // Pro Tools AAX rows now have a per-host header
+    // (`host_quirks/pro_tools.hpp`, item 5.9) + per-symptom isolation
+    // tests. AAX adapter use is gated on the developer-supplied Avid
+    // SDK (`PULP_AAX_SDK`); the quirk dispatch itself is unconditional
+    // so filter behavior matches across builds. In-DAW bench evidence
+    // requires the SDK → Speculative until those rows ship.
+    QuirkStatus pro_tools_aax_sidechain_negotiation = QuirkStatus::Speculative;
+    QuirkStatus pro_tools_aax_latency_callback_push = QuirkStatus::Speculative;
+    QuirkStatus pro_tools_aax_mono_second_bus = QuirkStatus::Speculative;
     // iPlug2-audit lesson (2026-05-25): Pro Tools AAX vendor-version
     // unreliability — documented via Avid AAX docs, no bench → LessonOnly.
     QuirkStatus aax_vendor_version_unknown = QuirkStatus::LessonOnly;

--- a/core/format/include/pulp/format/host_quirks/pro_tools.hpp
+++ b/core/format/include/pulp/format/host_quirks/pro_tools.hpp
@@ -1,0 +1,102 @@
+#pragma once
+
+/// @file host_quirks/pro_tools.hpp
+/// Per-host quirks for Avid Pro Tools (macOS plan item 5.9).
+///
+/// Pro Tools is the lone AAX host in Pulp's catalog, and AAX is a
+/// developer-supplied SDK lane (`PULP_AAX_SDK` is opt-in). The flags
+/// below are populated on `HostType::ProTools` detection regardless of
+/// whether the Avid SDK is wired up at build time — adapters that want
+/// to use them must themselves be guarded by the AAX SDK presence. This
+/// keeps the quirks dispatch table consistent across builds (so
+/// validated-only / off filtering behaves identically with or without
+/// the SDK), and lets non-AAX adapters consult the cross-host
+/// `aax_vendor_version_unknown` lesson without dragging in the AAX
+/// build dependency.
+///
+/// ## Rows covered
+///
+/// * row 16 (`pro_tools_aax_sidechain_negotiation`) — AAX's signal-graph
+///   model treats sidechain as an explicit edge: the host sends
+///   `connect` / `disconnect` events the plugin must handle and reflect
+///   in its bus state. Missing handlers leave the sidechain bus
+///   orphaned. The AAX adapter wires sidechain-connect / disconnect
+///   handlers that flip the sidechain-bus active flag and re-publish
+///   latency if it changes.
+/// * row 17 (`pro_tools_aax_latency_callback_push`) — Pro Tools' AAX
+///   wrapper uses an **active push** model for PDC: latency is
+///   reported via `Controller()->SetSignalLatency()`, not by passive
+///   query. The AAX adapter subscribes to the plugin's
+///   latency-changed signal and pushes to AAX's controller on change +
+///   once at `prepareToPlay`.
+/// * row 18 (`pro_tools_aax_mono_second_bus`) — historical AAX
+///   constraint: Pro Tools assumes a mono cue on the second input bus
+///   when declaring sidechain support. The AAX adapter presents only a
+///   mono variant in its descriptor when sidechain is declared.
+///
+/// Plus the iPlug2-audit lesson layered on top:
+///
+/// * `aax_vendor_version_unknown` — the AAX wrapper does not reliably
+///   surface its host vendor version through the AAX specification
+///   surface Pulp can query at runtime (the field can return zero or
+///   stale data depending on init order). Adapters and quirks must
+///   treat the Pro Tools version as unknown and avoid version-gated
+///   branching for this host.
+///
+/// ## Version handling
+///
+/// Pro Tools' AAX vendor version is unreliable by construction (per
+/// the `aax_vendor_version_unknown` lesson above), so there is no
+/// point in version-keying any of these rows: `apply_pro_tools` fires
+/// every flag unconditionally. Callers that want to gate by Pro Tools
+/// release should branch on `aax_vendor_version_unknown` and treat
+/// the version as opaque rather than calling `HostVersion::is_at_least`.
+///
+/// ## Tier status
+///
+/// All three AAX-quirk rows (16-18) are tagged `Speculative` in
+/// `HostQuirksMeta` as of this header extraction: they are documented
+/// from Avid AAX documentation + reproducer reports, with per-symptom
+/// isolation tests in `test/test_host_quirks.cpp` pinning the dispatch
+/// — but the in-DAW bench evidence (driving real Pro Tools sessions
+/// through Pulp's AAX adapter) is still pending and is itself gated on
+/// the Avid SDK being present. Promote to `Validated` when the bench
+/// rows ship under `PULP_AAX_SDK`. `aax_vendor_version_unknown`
+/// remains `LessonOnly` since it ships as a 2026-05-25 iPlug2-audit
+/// catalog lesson without an in-tree bench yet.
+///
+/// **Reference-Lineage**: cleanroom reproducer=macos-plan-item-5.9
+/// docs=Avid AAX SDK documentation (developer-supplied; opt-in lane)
+
+#include <pulp/format/host_quirks.hpp>
+#include <pulp/format/host_version.hpp>
+
+namespace pulp::format::host_quirks {
+
+/// Populate Pro Tools' main 3 AAX host-gated flags (rows 16-18) onto
+/// `q`. `v` is unused today (every row is version-invariant by design
+/// — see `aax_vendor_version_unknown`) but kept for signature
+/// uniformity with other per-host modules.
+inline void apply_pro_tools(HostQuirks& q, HostVersion /*v*/) {
+    // Row 16 — AAX sidechain is an explicit-edge model; wire the
+    // connect/disconnect handlers and re-publish latency on changes.
+    q.pro_tools_aax_sidechain_negotiation = true;
+    // Row 17 — Pro Tools needs an active push to
+    // Controller()->SetSignalLatency() on change + once at
+    // prepareToPlay; passive getLatencySamples() is not enough.
+    q.pro_tools_aax_latency_callback_push = true;
+    // Row 18 — historical AAX constraint: declare only a mono sidechain
+    // variant in the AAX descriptor.
+    q.pro_tools_aax_mono_second_bus = true;
+}
+
+/// Populate the AAX vendor-version-unknown lesson onto `q`. Layered on
+/// top of `apply_pro_tools(...)` so the iPlug2-audit lesson can stay
+/// at a different validation tier (LessonOnly today) without changing
+/// the rest of the Pro Tools dispatch (Speculative).
+inline void apply_pro_tools_aax_vendor_version_unknown(HostQuirks& q,
+                                                      HostVersion /*v*/) {
+    q.aax_vendor_version_unknown = true;
+}
+
+}  // namespace pulp::format::host_quirks

--- a/core/format/include/pulp/format/host_quirks/reaper.hpp
+++ b/core/format/include/pulp/format/host_quirks/reaper.hpp
@@ -1,29 +1,95 @@
 #pragma once
 
 /// @file host_quirks/reaper.hpp
-/// Per-host quirks for Cockos REAPER.
+/// Per-host quirks for Cockos REAPER (macOS plan item 5.8).
 ///
-/// REAPER's VST2 and VST3 host wrappers share the same keyboard event
-/// pipeline: `onKeyDown` / `onKeyUp` (or the equivalent VST2
-/// `effEditKeyDown` opcode) deliver a `keyMsg` payload that is only
-/// reliably populated for the Space key (`VKEY_SPACE`). Other keys
-/// arrive with malformed key state — virtual key code, modifier bits,
-/// and character payload can all be inconsistent or zero. Editors that
-/// route keyboard input through the format adapter must reject non-Space
-/// keys on REAPER rather than acting on the garbage payload.
+/// REAPER is a forgiving host — it absorbs many spec violations — but it
+/// also exposes more permissive configurations (e.g. arbitrary pin
+/// connectivity, mid-session FX-chain reloads, anticipative-FX rendering)
+/// than the typical VST3 / CLAP / AU host, so several quirks are
+/// REAPER-specific accommodations rather than spec bugs.
 ///
-/// The existing REAPER flags (gesture ordering, process-while-bypassed,
-/// keyboard passthrough, permissive bus arrangements, anticipative-FX
-/// buffer variability, mid-session setstate) are still set in the
-/// dispatch table in `host_quirks.cpp`; this header layers the
-/// keyboard-only-space flag on top so the per-host module can grow
-/// without expanding the dispatch table further.
+/// This header now owns the **full** REAPER quirk dispatch (DAW-quirks
+/// rows 15 + R1-R7), pulled out of `core/format/src/host_quirks.cpp`
+/// into a per-host module so the dispatch table doesn't grow further and
+/// REAPER-specific lessons live next to each other.
 ///
-/// Version handling: the keyboard quirk is documented across every
+/// ## Rows covered
+///
+/// * row 15 (`reaper_vst3_gesture_ordering`) — REAPER's VST3 automation
+///   reader expects parameter gesture-begin / value-change / gesture-end
+///   events in a particular order that differs from Cubase / Wavelab.
+///   Mis-ordered gestures produce spurious touch-automation lanes. The
+///   VST3 adapter consults this flag to switch to REAPER's ordering when
+///   the host is detected as REAPER.
+/// * row R1 (`reaper_process_while_bypassed`) — REAPER's "Run FX while
+///   bypassed" track option calls `process()` on the plugin even while
+///   bypassed (so tail state can settle cleanly). Adapters route bypass
+///   to `Processor::process_bypassed()` rather than assuming
+///   "bypassed = no process call".
+/// * row R2 (`reaper_keyboard_passthrough`) — REAPER's "send all
+///   keyboard input to plugin" track option routes raw key events into
+///   the plugin editor in addition to REAPER's own shortcut handling.
+///   `View::on_key_event` must distinguish "consumed" vs "not consumed"
+///   so the adapter can propagate unconsumed keys back to the host.
+/// * row R3 (`reaper_permissive_bus_arrangements`) — REAPER's FX-route
+///   pin matrix is more permissive than Cubase / Live; the VST3 adapter
+///   accepts any arrangement whose channel counts the plugin can handle
+///   (silence-out the rest) rather than rejecting non-standard layout
+///   names. Layers on top of the always-on
+///   `silence_unsupported_bus_arrangements` cheap defense.
+/// * row R4 (`reaper_anticipative_fx_buffer_variability`) — REAPER's
+///   anticipative-FX / offline render path calls `process()` from a
+///   non-realtime thread with buffer sizes that may differ from
+///   `prepare()`'s `max_buffer_size`. The contract is that
+///   `Processor::process()` honors per-block buffer-size variability
+///   without re-allocating.
+/// * row R5 (`reaper_vst3_gesture_ordering` covers the gesture half;
+///   the vendor/product-string identity contract for REAPER's
+///   compatibility-allow-list is handled by Track 3.12 — the
+///   `PluginDescriptor::manufacturer` string contract — and does not
+///   need a dedicated flag here. Documented for cross-reference.)
+/// * row R6 (`reaper_midsession_setstate`) — REAPER's per-track FX-state
+///   save/restore can fire `setState` at arbitrary times during a
+///   session, not just at project-load. `Processor::set_state` must
+///   stay safely callable mid-play; no resource re-allocation may
+///   require `prepare()` to be re-called.
+/// * row R7 (CLAP canary, no dedicated flag) — REAPER's CLAP host is
+///   among the most reference-correct in the wild and is used by
+///   Track 3.4 as the canary for any CLAP adapter regression. Carried
+///   here as documentation; the CLAP-side acceptance lives in the CLAP
+///   adapter test matrix.
+///
+/// Plus the iPlug2-audit lesson layered on top:
+///
+/// * `reaper_keyboard_only_space` — REAPER's VST2/VST3 `onKeyDown` /
+///   `effEditKeyDown` pipeline only delivers a well-formed `keyMsg`
+///   payload for the Space key (`VKEY_SPACE`); other keys arrive with
+///   malformed key state. Editors that route keyboard input through
+///   the format adapter must reject non-Space keys when this flag is
+///   set. Documented across REAPER 5.x through current 7.x.
+///
+/// ## Version handling
+///
+/// Every REAPER quirk Pulp tracks today is documented across every
 /// REAPER vintage Pulp encounters (5.x through current 7.x line), so
-/// `apply_reaper_keyboard` fires it unconditionally.
+/// `apply_reaper` fires every flag unconditionally. If a future REAPER
+/// release fixes a specific behavior, add an `is_before(major, minor)`
+/// guard at that point.
 ///
-/// **Reference-Lineage**: cleanroom reproducer=iplug2-quirks-audit-2026-05-25
+/// ## Tier status
+///
+/// All of these flags are tagged `Speculative` in `HostQuirksMeta` as
+/// of this header extraction: they are documented from REAPER vendor
+/// docs + reproducer reports, with per-symptom isolation tests in
+/// `test/test_host_quirks.cpp` pinning the dispatch — but the in-DAW
+/// bench evidence (driving real REAPER 7.x sessions through Pulp's
+/// adapters) is still pending. Promote to `Validated` when the bench
+/// rows ship. `reaper_keyboard_only_space` remains `LessonOnly` since
+/// it ships as a 2026-05-25 iPlug2-audit catalog lesson without an
+/// in-tree bench yet.
+///
+/// **Reference-Lineage**: cleanroom reproducer=macos-plan-item-5.8
 /// docs=https://www.reaper.fm/sdk/vst/vst_ext.php
 
 #include <pulp/format/host_quirks.hpp>
@@ -31,9 +97,38 @@
 
 namespace pulp::format::host_quirks {
 
+/// Populate REAPER's main 6 host-gated flags (rows 15 + R1-R4 + R6)
+/// onto `q`. `v` is unused today (every row is version-invariant) but
+/// kept for signature uniformity with other per-host modules.
+inline void apply_reaper(HostQuirks& q, HostVersion /*v*/) {
+    // Row 15 — REAPER-specific gesture/value ordering for the VST3
+    // automation reader; mis-ordered events otherwise produce spurious
+    // touch-automation lanes.
+    q.reaper_vst3_gesture_ordering = true;
+    // Row R1 — "Run FX while bypassed" routes process() calls to the
+    // plugin even when bypassed so tail state can drain cleanly.
+    q.reaper_process_while_bypassed = true;
+    // Row R2 — "send all keyboard input to plugin" passes keys to the
+    // editor in addition to REAPER's own shortcut handling; editors
+    // must distinguish consumed vs unconsumed.
+    q.reaper_keyboard_passthrough = true;
+    // Row R3 — REAPER's FX-route pin matrix is more permissive than
+    // typical VST3 hosts; accept channel-count-compatible arrangements
+    // even when the layout name doesn't match a standard one.
+    q.reaper_permissive_bus_arrangements = true;
+    // Row R4 — anticipative-FX renders call process() from a non-RT
+    // thread with variable buffer sizes; honor per-block variability
+    // without re-allocating.
+    q.reaper_anticipative_fx_buffer_variability = true;
+    // Row R6 — per-track FX-state save/restore can call setState
+    // mid-play; setState must stay RT-safe and callable at any time.
+    q.reaper_midsession_setstate = true;
+}
+
 /// Populate REAPER keyboard-only-space flag onto `q`. Layered on top of
-/// the existing REAPER quirks set in `apply_reaper_quirks` so the two
-/// can evolve independently.
+/// `apply_reaper(...)` so the iPlug2-audit lesson can stay at a
+/// different validation tier (LessonOnly today) without changing the
+/// rest of the REAPER dispatch (Speculative).
 inline void apply_reaper_keyboard(HostQuirks& q, HostVersion /*v*/) {
     q.reaper_keyboard_only_space = true;
 }

--- a/core/format/src/host_quirks.cpp
+++ b/core/format/src/host_quirks.cpp
@@ -7,6 +7,7 @@
 #include <pulp/format/host_quirks/cubase.hpp>
 #include <pulp/format/host_quirks/fl_studio.hpp>
 #include <pulp/format/host_quirks/logic_pro.hpp>
+#include <pulp/format/host_quirks/pro_tools.hpp>
 #include <pulp/format/host_quirks/reaper.hpp>
 #include <pulp/format/host_quirks/wavelab.hpp>
 #include <pulp/format/host_version.hpp>
@@ -26,27 +27,27 @@ namespace {
 // `planning/2026-05-24-daw-host-quirks-inheritance.md`.
 
 void apply_reaper_quirks(HostQuirks& q, HostVersion v) {
-    q.reaper_vst3_gesture_ordering = true;
-    q.reaper_process_while_bypassed = true;
-    q.reaper_keyboard_passthrough = true;
-    q.reaper_permissive_bus_arrangements = true;
-    q.reaper_anticipative_fx_buffer_variability = true;
-    q.reaper_midsession_setstate = true;
-    // Layer the keyboard-only-space flag on top via the per-host header
-    // so the dispatch table doesn't grow further.
+    // Main 6 REAPER rows (15 + R1-R4 + R6) — extracted to the per-host
+    // header so REAPER-specific lessons live in one place. Adapter
+    // surface unchanged; this is a pure header refactor for item 5.8.
+    host_quirks::apply_reaper(q, v);
+    // Layer the iPlug2-audit keyboard-only-space lesson on top via the
+    // separate factory so its LessonOnly tier can evolve independently
+    // of the rest of the REAPER dispatch (Speculative).
     host_quirks::apply_reaper_keyboard(q, v);
 }
 
-void apply_pro_tools_quirks(HostQuirks& q, HostVersion /*v*/) {
-    q.pro_tools_aax_sidechain_negotiation = true;
-    q.pro_tools_aax_latency_callback_push = true;
-    q.pro_tools_aax_mono_second_bus = true;
+void apply_pro_tools_quirks(HostQuirks& q, HostVersion v) {
+    // Main 3 AAX rows (16-18) — extracted to the per-host header for
+    // item 5.9 (opt-in lane gated on Avid SDK at the adapter level;
+    // the quirk dispatch itself is unconditional so filtering behaves
+    // identically across builds).
+    host_quirks::apply_pro_tools(q, v);
     // Pro Tools' AAX wrapper does not surface a reliable vendor version
     // through the AAX spec, so version-gated decisions for this host
-    // must be skipped entirely. Adapters should branch on this flag
-    // rather than `HostVersion` when deciding Pro Tools-specific
-    // behavior.
-    q.aax_vendor_version_unknown = true;
+    // must be skipped entirely. Layered via the separate factory so its
+    // LessonOnly tier can evolve independently of rows 16-18.
+    host_quirks::apply_pro_tools_aax_vendor_version_unknown(q, v);
 }
 
 // Tier filtering. A single helper reduces a (status-tag, current value)

--- a/test/test_host_quirks.cpp
+++ b/test/test_host_quirks.cpp
@@ -1,5 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/format/host_quirks.hpp>
+#include <pulp/format/host_quirks/pro_tools.hpp>
+#include <pulp/format/host_quirks/reaper.hpp>
 #include <pulp/format/host_type.hpp>
 
 #include <array>
@@ -547,6 +549,225 @@ TEST_CASE("make_quirks_for Pro Tools with unknown version still sets the version
     REQUIRE(q.aax_vendor_version_unknown == true);
 }
 
+// ── macOS plan item 5.8 — REAPER per-host header extraction (DAW-quirks
+//    rows 15 + R1-R7). Main dispatch moved to
+//    `core/format/include/pulp/format/host_quirks/reaper.hpp::apply_reaper`,
+//    with the iPlug2-audit `apply_reaper_keyboard` factory layered on
+//    top. These isolation tests pin each symptom row to its own assertion
+//    so a regression localizes to the exact REAPER quirk that broke. ──
+
+TEST_CASE("apply_reaper fires row 15 (VST3 gesture ordering) standalone",
+          "[format][host-quirks][reaper][isolation]") {
+    HostQuirks q;
+    host_quirks::apply_reaper(q, HostVersion{7, 20});
+    REQUIRE(q.reaper_vst3_gesture_ordering == true);
+}
+
+TEST_CASE("apply_reaper fires row R1 (process while bypassed) standalone",
+          "[format][host-quirks][reaper][isolation]") {
+    HostQuirks q;
+    host_quirks::apply_reaper(q, HostVersion{7, 20});
+    REQUIRE(q.reaper_process_while_bypassed == true);
+}
+
+TEST_CASE("apply_reaper fires row R2 (keyboard passthrough) standalone",
+          "[format][host-quirks][reaper][isolation]") {
+    HostQuirks q;
+    host_quirks::apply_reaper(q, HostVersion{7, 20});
+    REQUIRE(q.reaper_keyboard_passthrough == true);
+}
+
+TEST_CASE("apply_reaper fires row R3 (permissive bus arrangements) standalone",
+          "[format][host-quirks][reaper][isolation]") {
+    HostQuirks q;
+    host_quirks::apply_reaper(q, HostVersion{7, 20});
+    REQUIRE(q.reaper_permissive_bus_arrangements == true);
+}
+
+TEST_CASE("apply_reaper fires row R4 (anticipative-FX buffer variability) standalone",
+          "[format][host-quirks][reaper][isolation]") {
+    HostQuirks q;
+    host_quirks::apply_reaper(q, HostVersion{7, 20});
+    REQUIRE(q.reaper_anticipative_fx_buffer_variability == true);
+}
+
+TEST_CASE("apply_reaper fires row R6 (mid-session setState) standalone",
+          "[format][host-quirks][reaper][isolation]") {
+    HostQuirks q;
+    host_quirks::apply_reaper(q, HostVersion{7, 20});
+    REQUIRE(q.reaper_midsession_setstate == true);
+}
+
+TEST_CASE("apply_reaper does not flip the keyboard-only-space iPlug2 lesson",
+          "[format][host-quirks][reaper][isolation]") {
+    // The two REAPER factories must stay independently composable so
+    // their validation tiers can evolve separately (Speculative for the
+    // main 6 rows vs LessonOnly for the iPlug2-audit lesson). The main
+    // apply_reaper(...) must not silently include the keyboard lesson.
+    HostQuirks q;
+    host_quirks::apply_reaper(q, HostVersion{7, 20});
+    REQUIRE(q.reaper_keyboard_only_space == false);
+
+    // The keyboard factory called alone must not flip the main 6 rows.
+    HostQuirks kb;
+    host_quirks::apply_reaper_keyboard(kb, HostVersion{7, 20});
+    REQUIRE(kb.reaper_keyboard_only_space == true);
+    REQUIRE(kb.reaper_process_while_bypassed == false);
+    REQUIRE(kb.reaper_vst3_gesture_ordering == false);
+}
+
+TEST_CASE("apply_reaper leaves other hosts' flags off",
+          "[format][host-quirks][reaper][isolation]") {
+    HostQuirks q;
+    host_quirks::apply_reaper(q, HostVersion{7, 20});
+    REQUIRE(q.reaper_vst3_gesture_ordering == true);
+    // No cross-host bleed — every non-REAPER row must stay default.
+    REQUIRE(q.cubase10_async_view_resize_queue == false);
+    REQUIRE(q.cubase9_state_blob_size_validation == false);
+    REQUIRE(q.live_vst3_canresize_ignore == false);
+    REQUIRE(q.wavelab_state_blob_fallback == false);
+    REQUIRE(q.bitwig_vst3_linux_repaint_after_resize == false);
+    REQUIRE(q.fl_studio_setactive_process_mutex == false);
+    REQUIRE(q.logic_au_channel_probe_cap == 64);
+    REQUIRE(q.au_v3_bypass_dual_tracking == false);
+    REQUIRE(q.pro_tools_aax_sidechain_negotiation == false);
+    REQUIRE(q.pro_tools_aax_latency_callback_push == false);
+    REQUIRE(q.pro_tools_aax_mono_second_bus == false);
+    REQUIRE(q.aax_vendor_version_unknown == false);
+    REQUIRE(q.skip_bus_arrangement_call == false);
+}
+
+TEST_CASE("make_quirks_for Reaper routes through the extracted header",
+          "[format][host-quirks][reaper][isolation]") {
+    // Sanity: the dispatch table still produces the same struct after
+    // the extraction — every Reaper main row + the keyboard lesson + the
+    // cheap defenses must all be on. Mirrors the pre-extraction
+    // behavior pinned by the "flips all 6 Reaper flags" case above.
+    auto dispatched = make_quirks_for(HostType::Reaper, HostVersion{7, 20});
+    HostQuirks direct;
+    host_quirks::apply_reaper(direct, HostVersion{7, 20});
+    host_quirks::apply_reaper_keyboard(direct, HostVersion{7, 20});
+
+    REQUIRE(dispatched.reaper_vst3_gesture_ordering
+            == direct.reaper_vst3_gesture_ordering);
+    REQUIRE(dispatched.reaper_process_while_bypassed
+            == direct.reaper_process_while_bypassed);
+    REQUIRE(dispatched.reaper_keyboard_passthrough
+            == direct.reaper_keyboard_passthrough);
+    REQUIRE(dispatched.reaper_permissive_bus_arrangements
+            == direct.reaper_permissive_bus_arrangements);
+    REQUIRE(dispatched.reaper_anticipative_fx_buffer_variability
+            == direct.reaper_anticipative_fx_buffer_variability);
+    REQUIRE(dispatched.reaper_midsession_setstate
+            == direct.reaper_midsession_setstate);
+    REQUIRE(dispatched.reaper_keyboard_only_space
+            == direct.reaper_keyboard_only_space);
+    // Cheap defenses present in the dispatched struct but not on the
+    // hand-composed `direct` one (which started from default-ctor) —
+    // verify the dispatch keeps them on independently.
+    REQUIRE(dispatched.synthesize_bypass_parameter == true);
+}
+
+// ── macOS plan item 5.9 — Pro Tools / AAX per-host header extraction
+//    (DAW-quirks rows 16 + 17 + 18, gated on Avid SDK at the adapter
+//    surface). Main dispatch moved to
+//    `core/format/include/pulp/format/host_quirks/pro_tools.hpp::apply_pro_tools`
+//    with the iPlug2-audit `apply_pro_tools_aax_vendor_version_unknown`
+//    factory layered on top. Per-symptom isolation pins each row. ──
+
+TEST_CASE("apply_pro_tools fires row 16 (sidechain negotiation) standalone",
+          "[format][host-quirks][protools][isolation]") {
+    HostQuirks q;
+    host_quirks::apply_pro_tools(q, HostVersion{2024, 6});
+    REQUIRE(q.pro_tools_aax_sidechain_negotiation == true);
+}
+
+TEST_CASE("apply_pro_tools fires row 17 (latency callback push) standalone",
+          "[format][host-quirks][protools][isolation]") {
+    HostQuirks q;
+    host_quirks::apply_pro_tools(q, HostVersion{2024, 6});
+    REQUIRE(q.pro_tools_aax_latency_callback_push == true);
+}
+
+TEST_CASE("apply_pro_tools fires row 18 (mono second bus) standalone",
+          "[format][host-quirks][protools][isolation]") {
+    HostQuirks q;
+    host_quirks::apply_pro_tools(q, HostVersion{2024, 6});
+    REQUIRE(q.pro_tools_aax_mono_second_bus == true);
+}
+
+TEST_CASE("apply_pro_tools does not flip the aax-vendor-version-unknown iPlug2 lesson",
+          "[format][host-quirks][protools][isolation]") {
+    // The two Pro Tools factories must stay independently composable so
+    // their validation tiers can evolve separately (Speculative for the
+    // main 3 AAX rows vs LessonOnly for the iPlug2-audit lesson).
+    HostQuirks q;
+    host_quirks::apply_pro_tools(q, HostVersion{2024, 6});
+    REQUIRE(q.aax_vendor_version_unknown == false);
+
+    HostQuirks ver;
+    host_quirks::apply_pro_tools_aax_vendor_version_unknown(ver, HostVersion{2024, 6});
+    REQUIRE(ver.aax_vendor_version_unknown == true);
+    REQUIRE(ver.pro_tools_aax_sidechain_negotiation == false);
+    REQUIRE(ver.pro_tools_aax_latency_callback_push == false);
+    REQUIRE(ver.pro_tools_aax_mono_second_bus == false);
+}
+
+TEST_CASE("apply_pro_tools leaves other hosts' flags off",
+          "[format][host-quirks][protools][isolation]") {
+    HostQuirks q;
+    host_quirks::apply_pro_tools(q, HostVersion{2024, 6});
+    REQUIRE(q.pro_tools_aax_sidechain_negotiation == true);
+    // No cross-host bleed.
+    REQUIRE(q.cubase10_async_view_resize_queue == false);
+    REQUIRE(q.cubase9_state_blob_size_validation == false);
+    REQUIRE(q.live_vst3_canresize_ignore == false);
+    REQUIRE(q.wavelab_state_blob_fallback == false);
+    REQUIRE(q.bitwig_vst3_linux_repaint_after_resize == false);
+    REQUIRE(q.fl_studio_setactive_process_mutex == false);
+    REQUIRE(q.reaper_process_while_bypassed == false);
+    REQUIRE(q.reaper_keyboard_only_space == false);
+    REQUIRE(q.logic_au_channel_probe_cap == 64);
+    REQUIRE(q.au_v3_bypass_dual_tracking == false);
+    REQUIRE(q.skip_bus_arrangement_call == false);
+}
+
+TEST_CASE("make_quirks_for Pro Tools routes through the extracted header",
+          "[format][host-quirks][protools][isolation]") {
+    // Sanity: the dispatch table still produces the same struct after
+    // the extraction — every AAX main row + the version-unknown lesson
+    // + cheap defenses must all be on.
+    auto dispatched = make_quirks_for(HostType::ProTools, HostVersion{2024, 6});
+    HostQuirks direct;
+    host_quirks::apply_pro_tools(direct, HostVersion{2024, 6});
+    host_quirks::apply_pro_tools_aax_vendor_version_unknown(direct, HostVersion{2024, 6});
+
+    REQUIRE(dispatched.pro_tools_aax_sidechain_negotiation
+            == direct.pro_tools_aax_sidechain_negotiation);
+    REQUIRE(dispatched.pro_tools_aax_latency_callback_push
+            == direct.pro_tools_aax_latency_callback_push);
+    REQUIRE(dispatched.pro_tools_aax_mono_second_bus
+            == direct.pro_tools_aax_mono_second_bus);
+    REQUIRE(dispatched.aax_vendor_version_unknown
+            == direct.aax_vendor_version_unknown);
+    REQUIRE(dispatched.synthesize_bypass_parameter == true);
+}
+
+TEST_CASE("make_quirks_for_validated_only on Pro Tools leaves only cheap defenses",
+          "[format][host-quirks][protools][tiers]") {
+    // Every Pro Tools row is currently Speculative (AAX 16-18) or
+    // LessonOnly (vendor-version-unknown), so the validated-only filter
+    // should zero all of them and leave cheap defenses on.
+    auto q = make_quirks_for_validated_only(HostType::ProTools, HostVersion{2024, 6});
+    REQUIRE(q.synthesize_bypass_parameter == true);
+    REQUIRE(q.clamp_latency_to_nonneg == true);
+    REQUIRE(q.silence_unsupported_bus_arrangements == true);
+    REQUIRE(q.pro_tools_aax_sidechain_negotiation == false);
+    REQUIRE(q.pro_tools_aax_latency_callback_push == false);
+    REQUIRE(q.pro_tools_aax_mono_second_bus == false);
+    REQUIRE(q.aax_vendor_version_unknown == false);
+}
+
 // ── Validation-tier API (2026-05-25, item 5.15) ──
 //
 // Per-quirk validation tiers + the filter + the validated-only factory
@@ -596,20 +817,31 @@ TEST_CASE("kHostQuirksMeta tags every host-gated row as Speculative",
                    == QuirkStatus::Speculative);
 }
 
-TEST_CASE("kHostQuirksMeta tags Reaper / Pro Tools rows as LessonOnly",
+TEST_CASE("kHostQuirksMeta tags Reaper / Pro Tools main rows as Speculative",
           "[format][host-quirks][tiers]") {
-    // Reaper + Pro Tools live in the dispatch table but have no
-    // per-host header yet (see host_quirks.cpp). They're catalog
-    // entries Pulp uses as lessons until the headers + bench evidence
-    // ship.
+    // After items 5.8 (Reaper) + 5.9 (Pro Tools AAX) extracted the
+    // per-host headers + per-symptom isolation tests, the main rows
+    // graduate from LessonOnly to Speculative. They stay Speculative
+    // until the in-DAW bench evidence ships (Reaper 7.x for 5.8;
+    // PULP_AAX_SDK + Pro Tools session for 5.9).
     STATIC_REQUIRE(kHostQuirksMeta.reaper_process_while_bypassed
-                   == QuirkStatus::LessonOnly);
+                   == QuirkStatus::Speculative);
     STATIC_REQUIRE(kHostQuirksMeta.reaper_vst3_gesture_ordering
-                   == QuirkStatus::LessonOnly);
+                   == QuirkStatus::Speculative);
+    STATIC_REQUIRE(kHostQuirksMeta.reaper_keyboard_passthrough
+                   == QuirkStatus::Speculative);
+    STATIC_REQUIRE(kHostQuirksMeta.reaper_permissive_bus_arrangements
+                   == QuirkStatus::Speculative);
+    STATIC_REQUIRE(kHostQuirksMeta.reaper_anticipative_fx_buffer_variability
+                   == QuirkStatus::Speculative);
+    STATIC_REQUIRE(kHostQuirksMeta.reaper_midsession_setstate
+                   == QuirkStatus::Speculative);
     STATIC_REQUIRE(kHostQuirksMeta.pro_tools_aax_sidechain_negotiation
-                   == QuirkStatus::LessonOnly);
+                   == QuirkStatus::Speculative);
+    STATIC_REQUIRE(kHostQuirksMeta.pro_tools_aax_latency_callback_push
+                   == QuirkStatus::Speculative);
     STATIC_REQUIRE(kHostQuirksMeta.pro_tools_aax_mono_second_bus
-                   == QuirkStatus::LessonOnly);
+                   == QuirkStatus::Speculative);
 }
 
 TEST_CASE("kHostQuirksMeta tags iPlug2-audit 2026-05-25 rows as LessonOnly",
@@ -716,22 +948,37 @@ TEST_CASE("apply_filter is idempotent",
     REQUIRE(q.logic_au_channel_probe_cap == snapshot.logic_au_channel_probe_cap);
 }
 
-TEST_CASE("apply_filter custom: allow only LessonOnly keeps Reaper / Pro Tools flags",
+TEST_CASE("apply_filter custom: allow only LessonOnly keeps iPlug2-audit lessons",
           "[format][host-quirks][tiers]") {
-    // LessonOnly-only filter: lets the (currently un-bench-validated)
-    // Reaper rows ride while suppressing the validated cheap defenses
-    // and the speculative per-host rows.
-    auto q = make_quirks_for(HostType::Reaper, HostVersion{7, 20});
+    // LessonOnly-only filter: lets the iPlug2-audit catalog lessons
+    // (currently the only LessonOnly tier rows on these two hosts)
+    // ride while suppressing the validated cheap defenses and the
+    // speculative per-host rows that items 5.8 + 5.9 promoted.
+    auto reaper = make_quirks_for(HostType::Reaper, HostVersion{7, 20});
     QuirkFilter only_lesson{
         .allow_validated = false,
         .allow_speculative = false,
         .allow_lesson_only = true,
     };
-    apply_filter(q, only_lesson);
-    REQUIRE(q.reaper_process_while_bypassed == true);
-    REQUIRE(q.reaper_midsession_setstate == true);
+    apply_filter(reaper, only_lesson);
+    // LessonOnly REAPER row survives.
+    REQUIRE(reaper.reaper_keyboard_only_space == true);
+    // Speculative REAPER rows (post-5.8) zeroed.
+    REQUIRE(reaper.reaper_process_while_bypassed == false);
+    REQUIRE(reaper.reaper_midsession_setstate == false);
+    REQUIRE(reaper.reaper_vst3_gesture_ordering == false);
     // Validated cheap defenses zeroed.
-    REQUIRE(q.synthesize_bypass_parameter == false);
+    REQUIRE(reaper.synthesize_bypass_parameter == false);
+
+    auto pt = make_quirks_for(HostType::ProTools, HostVersion{2024, 6});
+    apply_filter(pt, only_lesson);
+    // LessonOnly Pro Tools row survives.
+    REQUIRE(pt.aax_vendor_version_unknown == true);
+    // Speculative Pro Tools AAX rows (post-5.9) zeroed.
+    REQUIRE(pt.pro_tools_aax_sidechain_negotiation == false);
+    REQUIRE(pt.pro_tools_aax_latency_callback_push == false);
+    REQUIRE(pt.pro_tools_aax_mono_second_bus == false);
+    REQUIRE(pt.synthesize_bypass_parameter == false);
 }
 
 TEST_CASE("make_quirks_for_validated_only matches make_quirks_for + filter",


### PR DESCRIPTION
## Summary

Macos plugin authoring plan items **5.8** (REAPER, 7 rows incl. R1–R7) + **5.9** (Pro Tools AAX, 3 rows; gated on Avid SDK at the adapter surface).

- **REAPER (item 5.8)** — extract the 6 main REAPER rows (15 + R1-R4 + R6) from `core/format/src/host_quirks.cpp` into `host_quirks::apply_reaper(...)` in the per-host header at `core/format/include/pulp/format/host_quirks/reaper.hpp`, mirroring the existing cubase/live/wavelab/bitwig/fl_studio/logic_pro pattern. The iPlug2-audit `apply_reaper_keyboard(...)` factory stays layered on top so its `LessonOnly` tier can evolve independently of the (now `Speculative`) main 6 rows. R5 is covered by Track 3.12 `PluginDescriptor::manufacturer` contract; R7 by Track 3.4 CLAP host matrix.
- **Pro Tools / AAX (item 5.9)** — new `core/format/include/pulp/format/host_quirks/pro_tools.hpp` exposing `host_quirks::apply_pro_tools(...)` for rows 16-18 (sidechain explicit connect/disconnect, latency callback-push, mono-second-bus). `aax_vendor_version_unknown` lesson layered on top via `host_quirks::apply_pro_tools_aax_vendor_version_unknown(...)`. Quirk dispatch unconditional; only the AAX **adapter** is gated on `PULP_AAX_SDK`.
- Promote `HostQuirksMeta` tags for the 6 REAPER rows + 3 AAX rows from `LessonOnly` to `Speculative`. Bench evidence (real REAPER 7.x / `PULP_AAX_SDK` + Pro Tools session) deferred — promotion to `Validated` is a follow-up.
- Adapter surface unchanged. Pure header-extraction + tier-graduation slice.

## Tests

`test/test_host_quirks.cpp` grows 56 → 74 cases (369 assertions, all green via `pulp-test-host-quirks` + `pulp-test-host-version`):

- 9 new isolation tests for REAPER (per-symptom for rows 15, R1, R2, R3, R4, R6 + tier-isolation between `apply_reaper` and `apply_reaper_keyboard` + cross-host bleed + dispatch parity)
- 7 new isolation tests for Pro Tools (per-symptom for rows 16-18 + tier-isolation between `apply_pro_tools` and `apply_pro_tools_aax_vendor_version_unknown` + cross-host bleed + dispatch parity + validated-only filter check)
- Two pre-existing tier tests updated: "tags Reaper / Pro Tools rows as LessonOnly" → "...as Speculative" (asserts the new tier + every newly-promoted field); LessonOnly-only filter test now exercises the two remaining LessonOnly rows (`reaper_keyboard_only_space` + `aax_vendor_version_unknown`).

## Planning

- `planning/2026-05-24-macos-plugin-authoring-plan.md`: tracker rows 5.8 + 5.9 flipped to 🟡.
- `planning/host-quirks-log.md`: two new entries documenting the extraction slices with clean-room sourcing (reaper.fm SDK + Avid AAX docs).

## Test plan

- [x] `cmake --build build --target pulp-test-host-quirks pulp-test-host-version -j8` (Release, GPU off)
- [x] `./build/test/pulp-test-host-quirks` — 369 assertions, 74 cases, all green
- [x] `ctest --test-dir build -R "HostQuirks|host-quirks|HostVersion|host-version"` — 9/9 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)