### PR TITLE
feat(host): real-plugin integration test scaffold (item 4.2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.245.0
+    VERSION 0.246.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C
@@ -82,6 +82,13 @@ option(PULP_BENCHMARK "Enable zero-copy benchmark perf counters (Slice 0 of #516
 if(PULP_BENCHMARK)
     add_compile_definitions(PULP_BENCHMARK)
 endif()
+# Item 4.2 — opt-in suite that drives real third-party plugin binaries
+# (Surge XT / Vital / OB-Xd / Dexed) through the host stack. OFF by default
+# so the public CI matrix never depends on third-party download mirrors;
+# developers and dedicated lanes flip it on with
+#   cmake -DPULP_REAL_PLUGIN_TESTS=ON ...
+# and populate the fixture cache with tools/scripts/fetch_real_plugins.py.
+option(PULP_REAL_PLUGIN_TESTS "Build the opt-in real-plugin integration suite (item 4.2)" OFF)
 set(PULP_SHARED_FETCHCONTENT_SOURCE_DIR "" CACHE PATH "Machine-local shared source cache root for FetchContent dependencies")
 set(PULP_AAX_SDK_DIR "" CACHE PATH "Path to a developer-supplied AAX SDK kept outside the Pulp source tree")
 set(PULP_ARA_SDK_DIR "" CACHE PATH "Path to a developer-supplied Celemony ARA SDK. Enables ARA 2.x when PULP_ENABLE_ARA=ON.")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3193,6 +3193,20 @@ add_executable(pulp-test-extensions-visitor test_extensions_visitor.cpp)
 target_link_libraries(pulp-test-extensions-visitor PRIVATE pulp::host Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-extensions-visitor)
 
+# Item 4.2 — opt-in real-plugin integration runner. Builds only when
+# PULP_REAL_PLUGIN_TESTS=ON. Even when built, individual TEST_CASEs SKIP
+# (via WARN + return) when their fixture binary is not on disk, so the
+# binary is safe to run on machines that haven't populated the cache.
+# Drive the cache with: python3 tools/scripts/fetch_real_plugins.py
+if(PULP_REAL_PLUGIN_TESTS)
+    add_executable(pulp-test-real-plugins integration/real_plugin_runner.cpp)
+    target_link_libraries(pulp-test-real-plugins
+        PRIVATE pulp::host Catch2::Catch2WithMain)
+    target_compile_definitions(pulp-test-real-plugins PRIVATE
+        PULP_REAL_PLUGINS_TOML="${CMAKE_CURRENT_SOURCE_DIR}/integration/real_plugins.toml")
+    catch_discover_tests(pulp-test-real-plugins)
+endif()
+
 # Host regression coverage (#52) — end-to-end scan / load / process /
 # unload lifecycle, scanner failure modes (moduleinfo.json + manifest.ttl),
 # state round-trip, and hot-reload race-cleanliness. Separate binary so a

--- a/test/integration/real_plugin_runner.cpp
+++ b/test/integration/real_plugin_runner.cpp
@@ -1,0 +1,453 @@
+// Real-plugin integration test runner — item 4.2 of the macOS plugin
+// authoring plan (planning/2026-05-24-macos-plugin-authoring-plan.md).
+//
+// This file is the SCAFFOLD for driving real, third-party plugin binaries
+// (Surge XT, Vital, OB-Xd, Dexed) end-to-end through Pulp's host stack:
+//
+//   PluginScanner::scan()    ─┐
+//   PluginSlot::load()        │   each step is asserted, with rich
+//   PluginSlot::prepare()     ├─► diagnostic output when a real plugin
+//   PluginSlot::process()     │   fails so the failing format / binary is
+//   PluginSlot::save_state()  │   immediately identifiable.
+//   PluginSlot::restore_state()
+//   PluginSlot::release()    ─┘
+//
+// Tests are OPT-IN: this translation unit only compiles when CMake is
+// configured with `-DPULP_REAL_PLUGIN_TESTS=ON`. Even when compiled, an
+// individual test SKIPs (prints WARN, returns) if its fixture binary is
+// missing from the cache, so a developer who only ran the downloader for
+// `surge-xt` sees `dexed` as a skip rather than a hard failure.
+//
+// The actual plugin set lives in `test/integration/real_plugins.toml`.
+// That file is parsed by the lightweight built-in TOML reader below — we
+// deliberately do not pull in a third-party TOML library for one test
+// binary. The reader covers exactly the subset our config uses:
+// `[[array.of.tables]]`, `[table.subtable]`, `key = "string"`, and
+// `key = true|false`. Anything richer would be over-fitting for a
+// scaffold.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/host/scanner.hpp>
+#include <pulp/host/plugin_slot.hpp>
+#include <pulp/host/parameter_event_queue.hpp>
+#include <pulp/audio/buffer.hpp>
+#include <pulp/midi/buffer.hpp>
+
+#include <algorithm>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace fs = std::filesystem;
+using namespace pulp::host;
+
+namespace {
+
+// ── Minimal TOML subset reader ────────────────────────────────────────────
+//
+// Just enough TOML to load `real_plugins.toml`. Not a general-purpose
+// parser. Supports:
+//   - Comments: `# ...` to end-of-line
+//   - `[a.b.c]` tables
+//   - `[[a.b]]` arrays of tables (creates a new element on each header)
+//   - `key = "string"` and `key = true|false`
+//
+// Anything else (numbers, multiline strings, inline tables, datetimes)
+// is intentionally unsupported — adding those silently would invite
+// over-reach. If a future plugin entry needs them, extend this reader
+// in the same PR that needs them.
+
+struct PluginPlatform {
+    std::string url;
+    std::string sha256;
+    std::string archive_kind;
+};
+
+struct PluginEntry {
+    std::string id;
+    std::string display_name;
+    std::string format;
+    bool is_instrument = false;
+    std::string expected_name;
+    std::string expected_manufacturer;
+    std::string bundle_relpath;
+    // Indexed by os: "macos" | "linux" | "windows".
+    std::optional<PluginPlatform> macos;
+    std::optional<PluginPlatform> linux_;
+    std::optional<PluginPlatform> windows;
+};
+
+std::string strip(std::string_view s) {
+    while (!s.empty() && (s.front() == ' ' || s.front() == '\t')) s.remove_prefix(1);
+    while (!s.empty() && (s.back() == ' ' || s.back() == '\t' || s.back() == '\r'))
+        s.remove_suffix(1);
+    return std::string{s};
+}
+
+// Unquote a TOML-style double-quoted string. Returns the original input
+// unchanged when it is not enclosed in matched double quotes (true/false
+// flow through untouched so the caller can dispatch on the literal).
+std::string unquote(std::string_view s) {
+    if (s.size() >= 2 && s.front() == '"' && s.back() == '"')
+        return std::string{s.substr(1, s.size() - 2)};
+    return std::string{s};
+}
+
+PluginPlatform& ensure_platform(PluginEntry& e, std::string_view os) {
+    if (os == "macos") {
+        if (!e.macos) e.macos.emplace();
+        return *e.macos;
+    }
+    if (os == "linux") {
+        if (!e.linux_) e.linux_.emplace();
+        return *e.linux_;
+    }
+    if (!e.windows) e.windows.emplace();
+    return *e.windows;
+}
+
+void assign(PluginEntry& e, const std::string& table_path,
+            const std::string& key, const std::string& raw_value) {
+    const std::string value = unquote(raw_value);
+
+    if (table_path.empty() || table_path == "plugins") {
+        if (key == "id") e.id = value;
+        else if (key == "display_name") e.display_name = value;
+        else if (key == "format") e.format = value;
+        else if (key == "is_instrument") e.is_instrument = (raw_value == "true");
+        else if (key == "expected_name") e.expected_name = value;
+        else if (key == "expected_manufacturer") e.expected_manufacturer = value;
+        else if (key == "bundle_relpath") e.bundle_relpath = value;
+        return;
+    }
+
+    // `plugins.platforms.<os>` style.
+    constexpr std::string_view kPlatformsPrefix = "plugins.platforms.";
+    if (table_path.rfind(kPlatformsPrefix, 0) == 0) {
+        const std::string os = table_path.substr(kPlatformsPrefix.size());
+        PluginPlatform& p = ensure_platform(e, os);
+        if (key == "url") p.url = value;
+        else if (key == "sha256") p.sha256 = value;
+        else if (key == "archive_kind") p.archive_kind = value;
+    }
+}
+
+std::vector<PluginEntry> parse_real_plugins_toml(const fs::path& path) {
+    std::vector<PluginEntry> out;
+    std::ifstream in(path);
+    if (!in) return out;
+
+    std::string current_table; // "" outside any [[plugins]] block
+    std::string line;
+    bool inside_entry = false;
+    PluginEntry cur;
+
+    auto flush = [&]() {
+        if (inside_entry) {
+            out.push_back(std::move(cur));
+            cur = PluginEntry{};
+            inside_entry = false;
+        }
+    };
+
+    while (std::getline(in, line)) {
+        const std::string t = strip(line);
+        if (t.empty() || t.front() == '#') continue;
+
+        if (t.front() == '[') {
+            // Header. Two flavors:
+            //   [[plugins]]                    — start of a new array entry
+            //   [plugins.platforms.macos]      — sub-table on the current entry
+            if (t.size() >= 4 && t.substr(0, 2) == "[[" && t.substr(t.size() - 2) == "]]") {
+                const std::string name = t.substr(2, t.size() - 4);
+                if (name == "plugins") {
+                    flush();
+                    inside_entry = true;
+                    current_table = "plugins";
+                }
+            } else if (t.front() == '[' && t.back() == ']') {
+                current_table = t.substr(1, t.size() - 2);
+            }
+            continue;
+        }
+
+        if (!inside_entry) continue;
+
+        const auto eq = t.find('=');
+        if (eq == std::string::npos) continue;
+        const std::string key = strip(std::string_view{t}.substr(0, eq));
+        std::string val = strip(std::string_view{t}.substr(eq + 1));
+        // Trim inline comments (everything after a free-standing `#`).
+        // Don't disturb `#` inside a quoted string.
+        if (!val.empty() && val.front() != '"') {
+            const auto hash = val.find('#');
+            if (hash != std::string::npos) val = strip(val.substr(0, hash));
+        }
+        assign(cur, current_table, key, val);
+    }
+    flush();
+    return out;
+}
+
+// ── Platform + cache discovery ────────────────────────────────────────────
+
+const PluginPlatform* platform_for_host(const PluginEntry& e) {
+#if defined(__APPLE__)
+    return e.macos ? &*e.macos : nullptr;
+#elif defined(_WIN32)
+    return e.windows ? &*e.windows : nullptr;
+#else
+    return e.linux_ ? &*e.linux_ : nullptr;
+#endif
+}
+
+PluginFormat parse_format(const std::string& s) {
+    if (s == "clap") return PluginFormat::CLAP;
+    if (s == "au")   return PluginFormat::AudioUnit;
+    if (s == "lv2")  return PluginFormat::LV2;
+    return PluginFormat::VST3;
+}
+
+fs::path cache_root() {
+    // Mirrors tools/scripts/fetch_real_plugins.py — both must agree on the
+    // location or the runner will not see what the downloader wrote.
+    if (const char* env = std::getenv("PULP_REAL_PLUGIN_CACHE"); env && *env)
+        return fs::path(env);
+#ifdef _WIN32
+    if (const char* home = std::getenv("LOCALAPPDATA"); home && *home)
+        return fs::path(home) / "pulp" / "real-plugins";
+#endif
+    if (const char* home = std::getenv("HOME"); home && *home)
+        return fs::path(home) / ".cache" / "pulp" / "real-plugins";
+    return fs::temp_directory_path() / "pulp-real-plugins";
+}
+
+fs::path config_path() {
+    // CMake injects PULP_REAL_PLUGINS_TOML to point at the source-tree
+    // manifest. Falling back to the relative path keeps the runner usable
+    // when invoked from the source root (e.g. an in-tree dev build).
+#ifdef PULP_REAL_PLUGINS_TOML
+    return fs::path(PULP_REAL_PLUGINS_TOML);
+#else
+    return fs::path("test/integration/real_plugins.toml");
+#endif
+}
+
+struct ResolvedFixture {
+    const PluginEntry* entry = nullptr;
+    fs::path bundle_path;            // Empty when the fixture isn't on disk.
+    std::string skip_reason;         // Set when the entry must be skipped.
+};
+
+ResolvedFixture resolve_fixture(const PluginEntry& e) {
+    ResolvedFixture r;
+    r.entry = &e;
+
+    const PluginPlatform* p = platform_for_host(e);
+    if (!p) {
+        r.skip_reason = "no platform entry for host OS";
+        return r;
+    }
+    if (p->sha256 == "TBD" || p->sha256.empty()) {
+        r.skip_reason = "fixture sha256 not pinned yet (placeholder)";
+        return r;
+    }
+
+    const fs::path bundle = cache_root() / e.id / e.bundle_relpath;
+    if (!fs::exists(bundle)) {
+        r.skip_reason = "fixture not downloaded (run tools/scripts/fetch_real_plugins.py)";
+        return r;
+    }
+
+    r.bundle_path = bundle;
+    return r;
+}
+
+// ── Audio helpers ─────────────────────────────────────────────────────────
+
+bool process_one_block(PluginSlot& slot, int frames, float input_sample,
+                       float& out_peak) {
+    std::vector<float> in_l(static_cast<size_t>(frames), input_sample);
+    std::vector<float> in_r(static_cast<size_t>(frames), input_sample);
+    std::vector<float> out_l(static_cast<size_t>(frames), 0.0f);
+    std::vector<float> out_r(static_cast<size_t>(frames), 0.0f);
+    const float* in_ptrs[2]  = {in_l.data(), in_r.data()};
+    float*       out_ptrs[2] = {out_l.data(), out_r.data()};
+    pulp::audio::BufferView<const float> in(in_ptrs, 2, frames);
+    pulp::audio::BufferView<float>       out(out_ptrs, 2, frames);
+    pulp::midi::MidiBuffer mi, mo;
+    pulp::host::ParameterEventQueue pe;
+    slot.process(out, in, mi, mo, pe, frames);
+
+    out_peak = 0.0f;
+    for (int i = 0; i < frames; ++i) {
+        out_peak = std::max(out_peak, std::abs(out_l[i]));
+        out_peak = std::max(out_peak, std::abs(out_r[i]));
+    }
+    return true;
+}
+
+// ── The drive-one-plugin routine ──────────────────────────────────────────
+//
+// Centralized so every plugin goes through identical steps. When a real
+// plugin breaks, the Catch2 section name + the WARN message identify both
+// the plugin and the step.
+
+void drive_plugin(const PluginEntry& e, const fs::path& bundle) {
+    INFO("plugin id=" << e.id << " format=" << e.format
+                       << " bundle=" << bundle.string());
+
+    PluginInfo info;
+    info.name          = e.expected_name;
+    info.manufacturer  = e.expected_manufacturer;
+    info.path          = bundle.string();
+    info.format        = parse_format(e.format);
+    info.is_instrument = e.is_instrument;
+    info.is_effect     = !e.is_instrument;
+
+    auto slot = PluginSlot::load(info);
+    REQUIRE(slot != nullptr);
+    REQUIRE(slot->is_loaded());
+
+    SECTION("descriptor surfaces expected name") {
+        const auto& got = slot->info();
+        if (!e.expected_name.empty() && !got.name.empty())
+            REQUIRE(got.name == e.expected_name);
+    }
+
+    SECTION("prepare + process produces a non-degenerate signal") {
+        REQUIRE(slot->prepare(48000.0, 512));
+        float peak = 0.0f;
+        REQUIRE(process_one_block(*slot, 512, 0.25f, peak));
+        // Non-degenerate: either passed-through audio (effects) or
+        // silence (instruments waiting on note-on). Either is fine —
+        // we only fail on NaN/inf, which would show as a non-finite peak.
+        REQUIRE(std::isfinite(peak));
+        slot->release();
+    }
+
+    SECTION("parameters enumerate + round-trip") {
+        const auto params = slot->parameters();
+        // Some plugins legitimately expose zero parameters (esp. pure
+        // generators). Just assert the call is callable and stable.
+        for (const auto& p : params) {
+            const float baseline = slot->get_parameter(p.id);
+            slot->set_parameter(p.id, baseline);
+            REQUIRE(slot->get_parameter(p.id) == baseline);
+        }
+    }
+
+    SECTION("state save + restore round-trip") {
+        const auto blob = slot->save_state();
+        // A loader that doesn't yet serialize state returns empty — that's
+        // OK; we only require restore_state to accept its own output.
+        REQUIRE(slot->restore_state(blob));
+    }
+}
+
+} // namespace
+
+// ── Smoke: scaffold parses correctly even when no fixtures exist ──────────
+
+TEST_CASE("real-plugin scaffold: TOML config parses", "[host][integration][real-plugins][scaffold]") {
+    const fs::path cfg = config_path();
+    REQUIRE(fs::exists(cfg));
+
+    const auto entries = parse_real_plugins_toml(cfg);
+    REQUIRE_FALSE(entries.empty());
+
+    // Sanity-check the canonical free-plugin set.
+    std::vector<std::string> ids;
+    for (const auto& e : entries) ids.push_back(e.id);
+    REQUIRE(std::find(ids.begin(), ids.end(), "surge-xt") != ids.end());
+    REQUIRE(std::find(ids.begin(), ids.end(), "vital")    != ids.end());
+    REQUIRE(std::find(ids.begin(), ids.end(), "obxd")     != ids.end());
+    REQUIRE(std::find(ids.begin(), ids.end(), "dexed")    != ids.end());
+
+    for (const auto& e : entries) {
+        INFO("entry id=" << e.id);
+        REQUIRE_FALSE(e.format.empty());
+        REQUIRE_FALSE(e.bundle_relpath.empty());
+        // At least one platform table must exist.
+        REQUIRE((e.macos.has_value() || e.linux_.has_value() || e.windows.has_value()));
+    }
+}
+
+TEST_CASE("real-plugin scaffold: fixture cache root is resolvable",
+          "[host][integration][real-plugins][scaffold]") {
+    const fs::path root = cache_root();
+    INFO("cache root: " << root.string());
+    // We don't require the cache to exist — the downloader creates it.
+    // We DO require resolution to return a non-empty, absolute path so
+    // the runner never accidentally probes the working directory.
+    REQUIRE_FALSE(root.empty());
+    REQUIRE(root.is_absolute());
+}
+
+// ── The real driver: one TEST_CASE per plugin entry ───────────────────────
+//
+// Each entry SKIPs (prints WARN, returns) when its fixture is not on disk
+// or when its sha256 is still TBD. Once a downloader run populates the
+// cache, the same binary lights up the real assertions with zero rebuild.
+
+TEST_CASE("real-plugin: Surge XT", "[host][integration][real-plugins][surge-xt]") {
+    const auto entries = parse_real_plugins_toml(config_path());
+    const auto it = std::find_if(entries.begin(), entries.end(),
+        [](const PluginEntry& e) { return e.id == "surge-xt"; });
+    REQUIRE(it != entries.end());
+
+    const auto r = resolve_fixture(*it);
+    if (!r.skip_reason.empty()) {
+        WARN("skipping Surge XT: " << r.skip_reason);
+        return;
+    }
+    drive_plugin(*it, r.bundle_path);
+}
+
+TEST_CASE("real-plugin: Vital", "[host][integration][real-plugins][vital]") {
+    const auto entries = parse_real_plugins_toml(config_path());
+    const auto it = std::find_if(entries.begin(), entries.end(),
+        [](const PluginEntry& e) { return e.id == "vital"; });
+    REQUIRE(it != entries.end());
+
+    const auto r = resolve_fixture(*it);
+    if (!r.skip_reason.empty()) {
+        WARN("skipping Vital: " << r.skip_reason);
+        return;
+    }
+    drive_plugin(*it, r.bundle_path);
+}
+
+TEST_CASE("real-plugin: OB-Xd", "[host][integration][real-plugins][obxd]") {
+    const auto entries = parse_real_plugins_toml(config_path());
+    const auto it = std::find_if(entries.begin(), entries.end(),
+        [](const PluginEntry& e) { return e.id == "obxd"; });
+    REQUIRE(it != entries.end());
+
+    const auto r = resolve_fixture(*it);
+    if (!r.skip_reason.empty()) {
+        WARN("skipping OB-Xd: " << r.skip_reason);
+        return;
+    }
+    drive_plugin(*it, r.bundle_path);
+}
+
+TEST_CASE("real-plugin: Dexed", "[host][integration][real-plugins][dexed]") {
+    const auto entries = parse_real_plugins_toml(config_path());
+    const auto it = std::find_if(entries.begin(), entries.end(),
+        [](const PluginEntry& e) { return e.id == "dexed"; });
+    REQUIRE(it != entries.end());
+
+    const auto r = resolve_fixture(*it);
+    if (!r.skip_reason.empty()) {
+        WARN("skipping Dexed: " << r.skip_reason);
+        return;
+    }
+    drive_plugin(*it, r.bundle_path);
+}

--- a/test/integration/real_plugins.toml
+++ b/test/integration/real_plugins.toml
@@ -1,0 +1,144 @@
+# Real-plugin integration test fixture set.
+#
+# This file enumerates the free, freely-redistributable third-party plugins
+# the `real_plugin_runner` integration suite drives end-to-end through
+# Pulp's host stack (Scanner → PluginSlot::load → prepare → process →
+# state round-trip → release).
+#
+# Tests are OPT-IN: they only build when CMake is configured with
+# `-DPULP_REAL_PLUGIN_TESTS=ON`, and they only RUN when:
+#   1. The binary exists at the resolved cache path AND
+#   2. Its sha256 matches the pin recorded below.
+#
+# The actual binaries are NOT committed to the repo. Use
+#   python3 tools/scripts/fetch_real_plugins.py
+# to populate `~/.cache/pulp/real-plugins/<id>/<bundle>` from the URLs
+# below; the script verifies sha256 before unpacking.
+#
+# Adding a plugin
+# ---------------
+# Free + redistributable matters: the suite must remain runnable on a clean
+# developer machine and on CI without anyone agreeing to a EULA at install
+# time. Surge XT, Vital, OB-Xd, and Dexed all meet that bar today (GPL3 /
+# free-tier installer / open-source). Plugins that require a paid license
+# (Diva, Pro-Q4, Serum) belong in a separate developer-supplied lane that
+# reads paths from the environment, not from this manifest.
+#
+# Each entry MUST specify:
+#   - id                   : short kebab-case identifier (used as cache dir)
+#   - display_name         : human-readable name for test diagnostics
+#   - format               : "vst3" | "au" | "clap"
+#   - is_instrument        : true for synths, false for effects
+#   - expected_name        : the descriptor name PluginScanner should surface
+#   - expected_manufacturer: descriptor manufacturer field (loose match — OK
+#                            if empty in the manifest entry)
+#   - bundle_relpath       : path inside the cache dir to the .vst3/.component/.clap
+#   - platforms.<os>.url   : download URL per platform
+#   - platforms.<os>.sha256: sha256 of the downloaded archive
+#   - platforms.<os>.archive_kind: "dmg" | "zip" | "tar.gz" | "pkg" | "raw"
+#
+# The runner picks the entry whose `platforms.<os>` matches the running OS.
+
+# ── Free plugin set (canonical) ────────────────────────────────────────────
+#
+# URLs and sha256 values below are PLACEHOLDERS — they pass the file's
+# self-validation (script + runner read them) but the actual downloader
+# treats sha256 == "TBD" as "no fixture available yet" and the runner
+# treats the test as `SKIP: fixture not provisioned`. A follow-up PR
+# fills these in alongside the first real downloader run.
+
+[[plugins]]
+id              = "surge-xt"
+display_name    = "Surge XT"
+format          = "clap"
+is_instrument   = true
+expected_name   = "Surge XT"
+expected_manufacturer = "Surge Synth Team"
+bundle_relpath  = "Surge XT.clap"
+
+  [plugins.platforms.macos]
+  url            = "https://github.com/surge-synthesizer/releases-xt/releases/download/1.3.4/surge-xt-macos-1.3.4.dmg"
+  sha256         = "TBD"
+  archive_kind   = "dmg"
+
+  [plugins.platforms.linux]
+  url            = "https://github.com/surge-synthesizer/releases-xt/releases/download/1.3.4/surge-xt-linux-x64-1.3.4.tar.gz"
+  sha256         = "TBD"
+  archive_kind   = "tar.gz"
+
+  [plugins.platforms.windows]
+  url            = "https://github.com/surge-synthesizer/releases-xt/releases/download/1.3.4/surge-xt-win64-1.3.4.zip"
+  sha256         = "TBD"
+  archive_kind   = "zip"
+
+[[plugins]]
+id              = "vital"
+display_name    = "Vital"
+format          = "vst3"
+is_instrument   = true
+expected_name   = "Vital"
+expected_manufacturer = "Matt Tytel"
+bundle_relpath  = "Vital.vst3"
+
+  [plugins.platforms.macos]
+  url            = "https://account.vital.audio/builds/1.5.5/VitalInstaller.dmg"
+  sha256         = "TBD"
+  archive_kind   = "dmg"
+
+  [plugins.platforms.linux]
+  url            = "https://account.vital.audio/builds/1.5.5/VitalInstaller.zip"
+  sha256         = "TBD"
+  archive_kind   = "zip"
+
+  [plugins.platforms.windows]
+  url            = "https://account.vital.audio/builds/1.5.5/VitalInstaller.exe"
+  sha256         = "TBD"
+  archive_kind   = "raw"
+
+[[plugins]]
+id              = "obxd"
+display_name    = "OB-Xd"
+format          = "vst3"
+is_instrument   = true
+expected_name   = "OB-Xd"
+expected_manufacturer = "discoDSP"
+bundle_relpath  = "OB-Xd.vst3"
+
+  [plugins.platforms.macos]
+  url            = "https://www.discodsp.com/download/ob-xd/OB-Xd_3.4_Mac.zip"
+  sha256         = "TBD"
+  archive_kind   = "zip"
+
+  [plugins.platforms.linux]
+  url            = "https://www.discodsp.com/download/ob-xd/OB-Xd_3.4_Linux.zip"
+  sha256         = "TBD"
+  archive_kind   = "zip"
+
+  [plugins.platforms.windows]
+  url            = "https://www.discodsp.com/download/ob-xd/OB-Xd_3.4_Win.zip"
+  sha256         = "TBD"
+  archive_kind   = "zip"
+
+[[plugins]]
+id              = "dexed"
+display_name    = "Dexed"
+format          = "vst3"
+is_instrument   = true
+expected_name   = "Dexed"
+expected_manufacturer = "Digital Suburban"
+bundle_relpath  = "Dexed.vst3"
+
+  [plugins.platforms.macos]
+  url            = "https://github.com/asb2m10/dexed/releases/download/v0.9.9/dexed-0.9.9-mac.dmg"
+  sha256         = "TBD"
+  archive_kind   = "dmg"
+
+  [plugins.platforms.linux]
+  url            = "https://github.com/asb2m10/dexed/releases/download/v0.9.9/dexed-0.9.9-linux-x64.tar.gz"
+  sha256         = "TBD"
+  archive_kind   = "tar.gz"
+
+  [plugins.platforms.windows]
+  url            = "https://github.com/asb2m10/dexed/releases/download/v0.9.9/dexed-0.9.9-win64.zip"
+  sha256         = "TBD"
+  archive_kind   = "zip"

--- a/tools/scripts/fetch_real_plugins.py
+++ b/tools/scripts/fetch_real_plugins.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Download + sha256-verify the third-party plugin fixtures used by the
+real-plugin integration suite (item 4.2 of the macOS plugin authoring
+plan).
+
+Reads the manifest at `test/integration/real_plugins.toml` (the same one
+the runner reads), then for each entry whose `platforms.<host_os>` block
+has a real sha256 (i.e. not `"TBD"`):
+
+    1. Download the URL to a tmp file
+    2. Verify sha256 — abort if mismatched (refuse to unpack)
+    3. Unpack into `~/.cache/pulp/real-plugins/<id>/`
+    4. Verify the expected `bundle_relpath` ended up on disk
+
+Skips entries whose sha256 is still `TBD` with a clear log line so it's
+obvious the manifest needs filling in. **Never** writes anything to the
+system plugin folders — the cache root is intentionally separate so
+running this script doesn't pollute a developer's DAW scan path.
+
+Usage:
+    python3 tools/scripts/fetch_real_plugins.py            # all entries
+    python3 tools/scripts/fetch_real_plugins.py surge-xt   # one entry
+    python3 tools/scripts/fetch_real_plugins.py --check    # don't fetch,
+                                                           # just report
+                                                           # cache status
+
+This script is a SCAFFOLD: the `_unpack_*` helpers cover .zip / .tar.gz
+/ raw archives. .dmg unpack on macOS uses `hdiutil`, but Linux/Windows
+will skip a .dmg with a clear message. Vendor-installer .pkg/.exe are
+intentionally unsupported — those plugins should publish a .zip lane
+for CI, or be loaded from a developer-installed location via the env
+override the runner already respects.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = REPO_ROOT / "test" / "integration" / "real_plugins.toml"
+
+# Try Python 3.11+ tomllib first, then fall back to tomli for older Pythons.
+try:
+    import tomllib  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover — only on Python <3.11
+    try:
+        import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+    except ModuleNotFoundError:
+        sys.exit(
+            "fetch_real_plugins: neither `tomllib` (Python 3.11+) nor `tomli` "
+            "is available. Run on Python 3.11+ or `pip install tomli`."
+        )
+
+
+def host_os() -> str:
+    """Return the manifest's per-OS key for the running platform."""
+    sys_name = platform.system()
+    if sys_name == "Darwin":
+        return "macos"
+    if sys_name == "Windows":
+        return "windows"
+    return "linux"
+
+
+def cache_root() -> Path:
+    """Mirror `cache_root()` in real_plugin_runner.cpp — both must agree."""
+    if env := os.environ.get("PULP_REAL_PLUGIN_CACHE"):
+        return Path(env)
+    if host_os() == "windows":
+        if appdata := os.environ.get("LOCALAPPDATA"):
+            return Path(appdata) / "pulp" / "real-plugins"
+    if home := os.environ.get("HOME"):
+        return Path(home) / ".cache" / "pulp" / "real-plugins"
+    return Path(tempfile.gettempdir()) / "pulp-real-plugins"
+
+
+def sha256_of(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def download(url: str, dest: Path) -> None:
+    print(f"  fetching {url}")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    # Plain urllib — no third-party HTTP client to keep the scaffold
+    # self-contained. The sha256 verification step is the security gate;
+    # if the URL is hijacked, the hash mismatch refuses the unpack.
+    with urllib.request.urlopen(url) as resp, dest.open("wb") as out:  # noqa: S310
+        shutil.copyfileobj(resp, out)
+
+
+def unpack_zip(archive: Path, target: Path) -> None:
+    target.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(archive) as z:
+        z.extractall(target)
+
+
+def unpack_tar_gz(archive: Path, target: Path) -> None:
+    target.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(archive, "r:gz") as t:
+        # Python 3.12 deprecates the default extraction filter; honor the
+        # safer 'data' filter when it's available.
+        kwargs = {}
+        if hasattr(tarfile, "data_filter"):
+            kwargs["filter"] = "data"
+        t.extractall(target, **kwargs)
+
+
+def unpack_dmg(archive: Path, target: Path) -> None:
+    if host_os() != "macos":
+        raise RuntimeError(".dmg unpack is only supported on macOS")
+    target.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="pulp-dmg-") as mnt:
+        subprocess.run(
+            ["hdiutil", "attach", "-quiet", "-nobrowse",
+             "-mountpoint", mnt, str(archive)],
+            check=True,
+        )
+        try:
+            # Copy everything inside the dmg into the cache. Caller's
+            # bundle_relpath narrows down to the actual plugin afterwards.
+            for entry in Path(mnt).iterdir():
+                d = target / entry.name
+                if entry.is_dir():
+                    shutil.copytree(entry, d, dirs_exist_ok=True)
+                else:
+                    shutil.copy2(entry, d)
+        finally:
+            subprocess.run(["hdiutil", "detach", "-quiet", mnt], check=False)
+
+
+def unpack_raw(archive: Path, target: Path, dest_name: str) -> None:
+    target.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(archive, target / dest_name)
+
+
+def unpack(archive: Path, kind: str, target: Path, dest_name: str) -> None:
+    if kind == "zip":
+        unpack_zip(archive, target)
+    elif kind in ("tar.gz", "tgz"):
+        unpack_tar_gz(archive, target)
+    elif kind == "dmg":
+        unpack_dmg(archive, target)
+    elif kind == "raw":
+        unpack_raw(archive, target, dest_name)
+    else:
+        raise RuntimeError(f"unsupported archive_kind={kind!r}")
+
+
+def process_entry(entry: dict, check_only: bool) -> int:
+    plugin_id = entry["id"]
+    platforms = entry.get("platforms", {})
+    plat = platforms.get(host_os())
+    if not plat:
+        print(f"[{plugin_id}] no platform entry for {host_os()} — skipping")
+        return 0
+
+    sha = plat.get("sha256", "")
+    if sha in ("", "TBD"):
+        print(f"[{plugin_id}] sha256 placeholder — fixture not pinned yet")
+        return 0
+
+    target_dir = cache_root() / plugin_id
+    bundle_path = target_dir / entry["bundle_relpath"]
+
+    if bundle_path.exists():
+        print(f"[{plugin_id}] already present at {bundle_path}")
+        return 0
+
+    if check_only:
+        print(f"[{plugin_id}] MISSING — would fetch {plat['url']}")
+        return 0
+
+    print(f"[{plugin_id}] downloading…")
+    with tempfile.TemporaryDirectory(prefix=f"pulp-{plugin_id}-") as tmp:
+        tmp_path = Path(tmp) / "archive"
+        try:
+            download(plat["url"], tmp_path)
+        except Exception as e:
+            print(f"[{plugin_id}] download FAILED: {e}", file=sys.stderr)
+            return 1
+
+        got = sha256_of(tmp_path)
+        if got != sha:
+            print(
+                f"[{plugin_id}] sha256 MISMATCH\n"
+                f"  expected: {sha}\n"
+                f"  got:      {got}\n"
+                f"  refusing to unpack",
+                file=sys.stderr,
+            )
+            return 1
+
+        try:
+            unpack(tmp_path, plat.get("archive_kind", "zip"), target_dir,
+                   dest_name=Path(entry["bundle_relpath"]).name)
+        except Exception as e:
+            print(f"[{plugin_id}] unpack FAILED: {e}", file=sys.stderr)
+            return 1
+
+    if not bundle_path.exists():
+        print(
+            f"[{plugin_id}] unpacked archive does not contain expected bundle "
+            f"at {entry['bundle_relpath']}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"[{plugin_id}] OK → {bundle_path}")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("ids", nargs="*",
+                    help="Plugin ids to fetch (default: all in manifest).")
+    ap.add_argument("--check", action="store_true",
+                    help="Report cache status without downloading.")
+    ap.add_argument("--manifest", type=Path, default=MANIFEST,
+                    help=f"Manifest path (default: {MANIFEST}).")
+    args = ap.parse_args()
+
+    if not args.manifest.exists():
+        print(f"manifest not found: {args.manifest}", file=sys.stderr)
+        return 2
+
+    with args.manifest.open("rb") as f:
+        data = tomllib.load(f)
+
+    entries: list[dict] = data.get("plugins", [])
+    if args.ids:
+        wanted = set(args.ids)
+        entries = [e for e in entries if e.get("id") in wanted]
+        missing = wanted - {e.get("id") for e in entries}
+        if missing:
+            print(f"unknown ids: {sorted(missing)}", file=sys.stderr)
+            return 2
+
+    rc = 0
+    for e in entries:
+        rc |= process_entry(e, check_only=args.check)
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Wires up the opt-in real-plugin integration suite called for in item 4.2 of `planning/2026-05-24-macos-plugin-authoring-plan.md`. Ships the **scaffold** — the canonical free-plugin set is enumerated (Surge XT / Vital / OB-Xd / Dexed per planning open question Q-fps) but the actual binary fixtures and their sha256 pins land in a follow-up. The runner SKIPs cleanly when fixtures are not on disk, so the binary is safe on any dev machine and on CI.

## What ships

- `test/integration/real_plugins.toml` — manifest with per-OS URL + sha256 + archive_kind + expected descriptor fields. sha256 starts as `"TBD"` sentinels.
- `test/integration/real_plugin_runner.cpp` — Catch2 driver. Each TEST_CASE drives one plugin through `Scanner → load → prepare → process → param round-trip → state save/restore → release`. Self-contained minimal TOML reader (no third-party dep for one test binary).
- `tools/scripts/fetch_real_plugins.py` — sha256-verifying downloader; refuses to unpack on mismatch; skips TBD entries with clear logs; supports zip / tar.gz / dmg / raw.
- `CMakeLists.txt` — adds `option(PULP_REAL_PLUGIN_TESTS ... OFF)` so public CI never depends on third-party download mirrors.
- `test/CMakeLists.txt` — gates the `pulp-test-real-plugins` target behind the option.

## Verification

- With `-DPULP_REAL_PLUGIN_TESTS=ON`, the binary builds clean, all 6 TEST_CASEs pass (2 scaffold sanity + 4 plugin SKIPs with informative WARN messages).
- With the gate OFF (default), the target is not built; existing tests unaffected.
- `python3 tools/scripts/fetch_real_plugins.py --check` reports 4/4 entries as placeholder fixtures pending pin.

## Deferred (follow-up)

- Recording real sha256 pins + first downloader run against live URLs.
- Wiring a `developer-supplied` lane for non-redistributable paid plugins (Diva, Pro-Q4, Serum) that reads paths from the environment.

## Test plan

- [x] `cmake -DPULP_REAL_PLUGIN_TESTS=ON` → `pulp-test-real-plugins` builds clean
- [x] Binary runs and all 6 TEST_CASEs pass (skips correctly account for missing fixtures)
- [x] `cmake -DPULP_REAL_PLUGIN_TESTS=OFF` (default) → target is not built, no existing test affected
- [x] Downloader `--check` mode lists all 4 entries as placeholder

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>