### PR TITLE
feat(audio): AudioDeviceManager persistence + MIDI hub (item 1.2a)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.245.0
+    VERSION 0.246.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/audio/CMakeLists.txt
+++ b/core/audio/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(pulp-audio PRIVATE
     src/buffer_ops.cpp
     src/audio_thumbnail.cpp
     src/wav_metadata.cpp
+    src/audio_device_manager.cpp
 )
 
 # CoreAudioFormat reader (macOS only — AAC, ALAC, CAF via ExtAudioFile)
@@ -61,7 +62,7 @@ if(TARGET alac)
     message(STATUS "Pulp: ALAC write enabled (Apple ALAC — Apache 2.0)")
 endif()
 
-target_link_libraries(pulp-audio PUBLIC pulp::runtime)
+target_link_libraries(pulp-audio PUBLIC pulp::runtime pulp::midi pulp::state)
 
 # CHOC headers (audio file I/O)
 target_include_directories(pulp-audio PRIVATE

--- a/core/audio/include/pulp/audio/audio_device_manager.hpp
+++ b/core/audio/include/pulp/audio/audio_device_manager.hpp
@@ -1,0 +1,227 @@
+#pragma once
+
+/// @file audio_device_manager.hpp
+/// AudioDeviceManager — persistence + MIDI hub.
+///
+/// Part of macOS-plugin-authoring plan item 1.2a (Phase A). This is the
+/// persistence + MIDI-hub half of the manager. Lifecycle, hotplug, and
+/// recovery (1.2b) land in Phase B once `AudioWorkgroup` (1.1) and
+/// CoreAudio hotplug listeners are in place.
+///
+/// Responsibilities:
+///   - Persists the user's selected audio device + sample rate + buffer
+///     size + I/O channel masks under `audio_device_manager.*` keys in
+///     `pulp::state::ApplicationProperties::user_settings()`. Settings
+///     survive a host restart.
+///   - Single source of truth for connected MIDI inputs/outputs.
+///     Dispatches incoming MIDI to subscribers. A subscription returns
+///     an RAII token whose destruction auto-unsubscribes — the typical
+///     pattern is to hold the token as a member; lifetime ends with
+///     the owning object and the manager stops calling the callback.
+///   - Exposes a smoothed CPU-load signal (wraps
+///     `pulp::audio::AudioProcessLoadMeasurer`) so a host UI can read
+///     a stable percentage without poking the realtime callback.
+
+#include <pulp/audio/device.hpp>
+#include <pulp/audio/load_measurer.hpp>
+#include <pulp/midi/device.hpp>
+#include <pulp/midi/message.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace pulp::state { class ApplicationProperties; }
+
+namespace pulp::audio {
+
+/// Persisted audio-device selection.
+///
+/// `output_channel_mask` / `input_channel_mask` are 64-bit bitmasks
+/// over the device's natural channel order. Bit `i` set means channel
+/// `i` is enabled. Channels 64+ collapse onto bit 63 conservatively
+/// (Pulp targets stereo / multichannel-up-to-32, so this is fine for
+/// every shipping audio interface). Zero mask + non-zero channel count
+/// in `DeviceConfig` means "use the first N channels" (legacy default).
+struct DeviceSelection {
+    std::string output_device;
+    std::string input_device;
+    double      sample_rate = 0.0;   ///< 0 = use default
+    int         buffer_size = 0;     ///< 0 = use default
+    uint64_t    output_channel_mask = 0;
+    uint64_t    input_channel_mask  = 0;
+};
+
+/// Keys used under `ApplicationProperties::user_settings()`. Exposed so
+/// callers can `set_string` directly when migrating from another store
+/// or when bulk-clearing for tests.
+namespace adm_keys {
+constexpr const char* kPrefix             = "audio_device_manager.";
+constexpr const char* kOutputDevice       = "audio_device_manager.output_device";
+constexpr const char* kInputDevice        = "audio_device_manager.input_device";
+constexpr const char* kSampleRate         = "audio_device_manager.sample_rate";
+constexpr const char* kBufferSize         = "audio_device_manager.buffer_size";
+constexpr const char* kOutputChannelMask  = "audio_device_manager.output_channel_mask";
+constexpr const char* kInputChannelMask   = "audio_device_manager.input_channel_mask";
+}  // namespace adm_keys
+
+class AudioDeviceManager;
+
+/// RAII subscription token. Destruction auto-unsubscribes from the
+/// owning `AudioDeviceManager`'s MIDI hub. The token holds only a
+/// weak reference to the manager — outliving the manager is safe and
+/// becomes a no-op on destruction.
+class MidiSubscriptionToken {
+public:
+    MidiSubscriptionToken() = default;
+    MidiSubscriptionToken(const MidiSubscriptionToken&) = delete;
+    MidiSubscriptionToken& operator=(const MidiSubscriptionToken&) = delete;
+    MidiSubscriptionToken(MidiSubscriptionToken&& other) noexcept;
+    MidiSubscriptionToken& operator=(MidiSubscriptionToken&& other) noexcept;
+    ~MidiSubscriptionToken();
+
+    bool active() const noexcept { return id_ != 0 && !manager_.expired(); }
+
+    /// Reset and unsubscribe early.
+    void reset() noexcept;
+
+private:
+    friend class AudioDeviceManager;
+    MidiSubscriptionToken(std::weak_ptr<void> manager_ptr,
+                          AudioDeviceManager* manager_raw,
+                          uint64_t id) noexcept
+        : manager_(std::move(manager_ptr)), manager_raw_(manager_raw), id_(id) {}
+
+    std::weak_ptr<void>    manager_;       ///< Lifetime peg.
+    AudioDeviceManager*    manager_raw_ = nullptr;
+    uint64_t               id_ = 0;
+};
+
+/// AudioDeviceManager — persistence + MIDI hub.
+///
+/// Construct one per application (the standalone host owns one; plugin
+/// adapters typically don't). Threading:
+///   - `save()` / `load()` and the subscription API run on the
+///     caller's thread (typically the main/UI thread).
+///   - `dispatch_midi_event()` may run on any thread (CoreMIDI, ALSA
+///     seq, or a WinMM thread). Subscriber callbacks therefore must
+///     be thread-tolerant; subscribers that need UI-thread marshalling
+///     should hop themselves.
+///   - `cpu_load()` and `peak_cpu_load()` are safe to read from any
+///     thread. `begin_cpu_measure()` / `end_cpu_measure()` are intended
+///     to be called from the audio thread, mirroring
+///     `AudioProcessLoadMeasurer`.
+class AudioDeviceManager {
+public:
+    using MidiHandler = std::function<void(const pulp::midi::MidiEvent&)>;
+
+    AudioDeviceManager();
+    ~AudioDeviceManager();
+
+    AudioDeviceManager(const AudioDeviceManager&) = delete;
+    AudioDeviceManager& operator=(const AudioDeviceManager&) = delete;
+
+    // ── Persistence ─────────────────────────────────────────────────
+
+    /// Read persisted selection from `props.user_settings()`. Returns
+    /// `std::nullopt` if no `audio_device_manager.*` keys exist.
+    static std::optional<DeviceSelection> load_selection(
+        const pulp::state::ApplicationProperties& props);
+
+    /// Write `sel` into `props.user_settings()` and `save()` the
+    /// underlying file. Returns true on successful save.
+    static bool save_selection(pulp::state::ApplicationProperties& props,
+                               const DeviceSelection& sel);
+
+    /// Resolve a stored selection against the live device list. If
+    /// `sel.output_device` (or `.input_device`) is empty or no longer
+    /// present in `available`, falls back to the system-default device
+    /// id (`fallback_output_id` / `fallback_input_id`) and records that
+    /// fallback in the returned struct. `fallback_used_output` /
+    /// `fallback_used_input` flags surface to the caller so it can log
+    /// the substitution.
+    struct ResolveResult {
+        DeviceSelection resolved;
+        bool fallback_used_output = false;
+        bool fallback_used_input  = false;
+    };
+    static ResolveResult resolve_selection(
+        const DeviceSelection& sel,
+        const std::vector<DeviceInfo>& available,
+        const std::string& fallback_output_id,
+        const std::string& fallback_input_id);
+
+    /// Convenience: convert a `DeviceSelection` to a `DeviceConfig`
+    /// for `AudioDevice::open()`. Channel counts derive from
+    /// `popcount()` of the masks when non-zero; otherwise the caller's
+    /// `default_output_channels` / `default_input_channels` win.
+    static DeviceConfig selection_to_config(
+        const DeviceSelection& sel,
+        int default_output_channels = 2,
+        int default_input_channels  = 0);
+
+    // ── MIDI hub ────────────────────────────────────────────────────
+
+    /// Subscribe `handler` to incoming MIDI events. The returned token
+    /// auto-unsubscribes on destruction. Subscribers are invoked in
+    /// registration order on whatever thread `dispatch_midi_event()`
+    /// runs on.
+    [[nodiscard]] MidiSubscriptionToken subscribe_midi(MidiHandler handler);
+
+    /// Dispatch `event` to every active subscriber. Typically invoked
+    /// from the MIDI input callback (`MidiInput::open` callback) by
+    /// the standalone host or plugin glue. Safe to call from any
+    /// thread.
+    void dispatch_midi_event(const pulp::midi::MidiEvent& event);
+
+    /// Number of currently registered subscribers. Mostly used by
+    /// tests; safe to call from any thread.
+    std::size_t midi_subscriber_count() const;
+
+    // ── CPU load ────────────────────────────────────────────────────
+
+    /// Begin a CPU-load measurement window. Mirrors
+    /// `AudioProcessLoadMeasurer::begin()` — call at the start of the
+    /// audio callback.
+    void begin_cpu_measure(int num_frames, float sample_rate);
+
+    /// End the current CPU-load window.
+    void end_cpu_measure();
+
+    /// Smoothed CPU load in `[0, +inf)`. 1.0 == full buffer.
+    float cpu_load() const;
+
+    /// Peak CPU load since last `reset_peak_cpu_load()`.
+    float peak_cpu_load() const;
+
+    /// Reset the peak tracker.
+    void reset_peak_cpu_load();
+
+private:
+    friend class MidiSubscriptionToken;
+
+    void unsubscribe_midi(uint64_t id) noexcept;
+
+    /// Lifetime peg for `MidiSubscriptionToken`. Token holds a
+    /// `weak_ptr<void>` to this; destruction marks the manager dead.
+    std::shared_ptr<void>                        lifetime_;
+
+    mutable std::mutex                           midi_mu_;
+    std::unordered_map<uint64_t, MidiHandler>    midi_subs_;
+    uint64_t                                     next_midi_id_ = 1;
+
+    /// CPU-load mutex protects begin/end against load() readers on
+    /// other threads. The measurer itself is not thread-safe, so we
+    /// guard every access. Contention is negligible — readers are UI
+    /// thread polling once per frame, begin/end runs once per audio
+    /// callback.
+    mutable std::mutex                           load_mu_;
+    AudioProcessLoadMeasurer                     load_;
+};
+
+}  // namespace pulp::audio

--- a/core/audio/src/audio_device_manager.cpp
+++ b/core/audio/src/audio_device_manager.cpp
@@ -1,0 +1,234 @@
+/// @file audio_device_manager.cpp
+/// AudioDeviceManager — persistence + MIDI hub (item 1.2a).
+
+#include <pulp/audio/audio_device_manager.hpp>
+#include <pulp/state/properties_file.hpp>
+
+#include <bitset>
+#include <utility>
+
+namespace pulp::audio {
+
+namespace {
+
+int popcount64(uint64_t v) noexcept {
+    return static_cast<int>(std::bitset<64>(v).count());
+}
+
+}  // namespace
+
+// ── MidiSubscriptionToken ───────────────────────────────────────────
+
+MidiSubscriptionToken::MidiSubscriptionToken(MidiSubscriptionToken&& other) noexcept
+    : manager_(std::move(other.manager_)),
+      manager_raw_(other.manager_raw_),
+      id_(other.id_) {
+    other.manager_raw_ = nullptr;
+    other.id_ = 0;
+}
+
+MidiSubscriptionToken& MidiSubscriptionToken::operator=(MidiSubscriptionToken&& other) noexcept {
+    if (this != &other) {
+        reset();
+        manager_     = std::move(other.manager_);
+        manager_raw_ = other.manager_raw_;
+        id_          = other.id_;
+        other.manager_raw_ = nullptr;
+        other.id_          = 0;
+    }
+    return *this;
+}
+
+MidiSubscriptionToken::~MidiSubscriptionToken() {
+    reset();
+}
+
+void MidiSubscriptionToken::reset() noexcept {
+    if (id_ == 0) return;
+    if (auto pegged = manager_.lock()) {
+        // Manager still alive — pegged keeps it alive until we return.
+        if (manager_raw_) {
+            manager_raw_->unsubscribe_midi(id_);
+        }
+    }
+    manager_.reset();
+    manager_raw_ = nullptr;
+    id_ = 0;
+}
+
+// ── AudioDeviceManager ──────────────────────────────────────────────
+
+AudioDeviceManager::AudioDeviceManager()
+    : lifetime_(std::make_shared<int>(0)) {
+}
+
+AudioDeviceManager::~AudioDeviceManager() {
+    // Drop lifetime_ first so any outstanding tokens that observe via
+    // weak_ptr.lock() see the manager as already dead and skip the
+    // unsubscribe call. The token destructor is then a safe no-op.
+    lifetime_.reset();
+    std::lock_guard<std::mutex> lk(midi_mu_);
+    midi_subs_.clear();
+}
+
+// ── Persistence ─────────────────────────────────────────────────────
+
+std::optional<DeviceSelection> AudioDeviceManager::load_selection(
+    const pulp::state::ApplicationProperties& props) {
+    const auto& user = props.user_settings();
+
+    const bool any_present =
+        user.contains(adm_keys::kOutputDevice) ||
+        user.contains(adm_keys::kInputDevice)  ||
+        user.contains(adm_keys::kSampleRate)   ||
+        user.contains(adm_keys::kBufferSize)   ||
+        user.contains(adm_keys::kOutputChannelMask) ||
+        user.contains(adm_keys::kInputChannelMask);
+    if (!any_present) return std::nullopt;
+
+    DeviceSelection sel;
+    if (auto v = user.get_string(adm_keys::kOutputDevice))      sel.output_device = *v;
+    if (auto v = user.get_string(adm_keys::kInputDevice))       sel.input_device  = *v;
+    if (auto v = user.get_double(adm_keys::kSampleRate))        sel.sample_rate   = *v;
+    if (auto v = user.get_int   (adm_keys::kBufferSize))        sel.buffer_size   = static_cast<int>(*v);
+    if (auto v = user.get_int   (adm_keys::kOutputChannelMask)) sel.output_channel_mask = static_cast<uint64_t>(*v);
+    if (auto v = user.get_int   (adm_keys::kInputChannelMask))  sel.input_channel_mask  = static_cast<uint64_t>(*v);
+    return sel;
+}
+
+bool AudioDeviceManager::save_selection(pulp::state::ApplicationProperties& props,
+                                        const DeviceSelection& sel) {
+    auto& user = props.user_settings();
+    user.set_string(adm_keys::kOutputDevice,      sel.output_device);
+    user.set_string(adm_keys::kInputDevice,       sel.input_device);
+    user.set_double(adm_keys::kSampleRate,        sel.sample_rate);
+    user.set_int   (adm_keys::kBufferSize,        sel.buffer_size);
+    user.set_int   (adm_keys::kOutputChannelMask, static_cast<int64_t>(sel.output_channel_mask));
+    user.set_int   (adm_keys::kInputChannelMask,  static_cast<int64_t>(sel.input_channel_mask));
+    // PropertiesFile::save() requires a path. If the caller never
+    // load()ed (so path_ is empty), point it at the platform-standard
+    // location `user_settings_dir(app_name)/settings.json` so the
+    // first save() succeeds without round-tripping through
+    // ApplicationProperties::save() (which is void).
+    if (user.path().empty()) {
+        const std::string dir = pulp::state::ApplicationProperties::user_settings_dir(props.app_name());
+        return user.save(dir + "/settings.json");
+    }
+    return user.save();
+}
+
+AudioDeviceManager::ResolveResult AudioDeviceManager::resolve_selection(
+    const DeviceSelection& sel,
+    const std::vector<DeviceInfo>& available,
+    const std::string& fallback_output_id,
+    const std::string& fallback_input_id) {
+    auto present = [&](const std::string& id) {
+        if (id.empty()) return false;
+        for (const auto& d : available) {
+            if (d.id == id) return true;
+        }
+        return false;
+    };
+
+    ResolveResult r{sel, false, false};
+    if (!present(sel.output_device)) {
+        r.resolved.output_device = fallback_output_id;
+        r.fallback_used_output = true;
+    }
+    if (!present(sel.input_device)) {
+        // Empty input is valid (output-only host); only flag a fallback
+        // when the persisted id was non-empty but missing.
+        if (!sel.input_device.empty()) r.fallback_used_input = true;
+        r.resolved.input_device = fallback_input_id;
+        // If both persisted and fallback are empty, no fallback occurred.
+        if (sel.input_device.empty() && fallback_input_id.empty()) {
+            r.fallback_used_input = false;
+        }
+    }
+    return r;
+}
+
+DeviceConfig AudioDeviceManager::selection_to_config(
+    const DeviceSelection& sel,
+    int default_output_channels,
+    int default_input_channels) {
+    DeviceConfig cfg;
+    cfg.device_id   = sel.output_device;
+    cfg.sample_rate = sel.sample_rate > 0.0 ? sel.sample_rate : 48000.0;
+    cfg.buffer_size = sel.buffer_size > 0   ? sel.buffer_size : 256;
+    cfg.output_channels = sel.output_channel_mask != 0
+        ? popcount64(sel.output_channel_mask)
+        : default_output_channels;
+    cfg.input_channels = sel.input_channel_mask != 0
+        ? popcount64(sel.input_channel_mask)
+        : default_input_channels;
+    return cfg;
+}
+
+// ── MIDI hub ────────────────────────────────────────────────────────
+
+MidiSubscriptionToken AudioDeviceManager::subscribe_midi(MidiHandler handler) {
+    if (!handler) return {};
+    std::lock_guard<std::mutex> lk(midi_mu_);
+    const uint64_t id = next_midi_id_++;
+    midi_subs_.emplace(id, std::move(handler));
+    return MidiSubscriptionToken(
+        std::weak_ptr<void>(lifetime_),
+        this,
+        id);
+}
+
+void AudioDeviceManager::dispatch_midi_event(const pulp::midi::MidiEvent& event) {
+    // Snapshot under lock so a subscriber callback that itself
+    // (un)subscribes doesn't iterate-while-mutating. Copy is cheap —
+    // std::function holds a small handler, and the subscriber count
+    // for a host is typically O(few).
+    std::vector<MidiHandler> handlers;
+    {
+        std::lock_guard<std::mutex> lk(midi_mu_);
+        handlers.reserve(midi_subs_.size());
+        for (auto& [_id, fn] : midi_subs_) handlers.push_back(fn);
+    }
+    for (auto& fn : handlers) {
+        if (fn) fn(event);
+    }
+}
+
+std::size_t AudioDeviceManager::midi_subscriber_count() const {
+    std::lock_guard<std::mutex> lk(midi_mu_);
+    return midi_subs_.size();
+}
+
+void AudioDeviceManager::unsubscribe_midi(uint64_t id) noexcept {
+    std::lock_guard<std::mutex> lk(midi_mu_);
+    midi_subs_.erase(id);
+}
+
+// ── CPU load ────────────────────────────────────────────────────────
+
+void AudioDeviceManager::begin_cpu_measure(int num_frames, float sample_rate) {
+    std::lock_guard<std::mutex> lk(load_mu_);
+    load_.begin(num_frames, sample_rate);
+}
+
+void AudioDeviceManager::end_cpu_measure() {
+    std::lock_guard<std::mutex> lk(load_mu_);
+    load_.end();
+}
+
+float AudioDeviceManager::cpu_load() const {
+    std::lock_guard<std::mutex> lk(load_mu_);
+    return load_.load();
+}
+
+float AudioDeviceManager::peak_cpu_load() const {
+    std::lock_guard<std::mutex> lk(load_mu_);
+    return load_.peak_load();
+}
+
+void AudioDeviceManager::reset_peak_cpu_load() {
+    std::lock_guard<std::mutex> lk(load_mu_);
+    load_.reset_peak();
+}
+
+}  // namespace pulp::audio

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1340,6 +1340,11 @@ pulp_add_test_suite(pulp-test-code-editor LIBRARIES pulp::view)
 # PropertiesFile JSON persistence tests
 pulp_add_test_suite(pulp-test-properties SOURCES test_properties_file.cpp LIBRARIES pulp::state pulp::runtime)
 
+# AudioDeviceManager — persistence + MIDI hub (macOS plan item 1.2a)
+pulp_add_test_suite(pulp-test-audio-device-manager
+    SOURCES test_audio_device_manager.cpp
+    LIBRARIES pulp::audio pulp::midi pulp::state pulp::runtime)
+
 # DSP enhancement tests (dry/wet mixer, processor duplicator, matrix, special functions)
 pulp_add_test_suite(pulp-test-dsp-enhancements LIBRARIES pulp::signal)
 

--- a/test/test_audio_device_manager.cpp
+++ b/test/test_audio_device_manager.cpp
@@ -1,0 +1,305 @@
+/// @file test_audio_device_manager.cpp
+/// Item 1.2a — AudioDeviceManager persistence + MIDI hub.
+///
+/// Acceptance from the macOS-plugin-authoring plan:
+///   - restart-with-same-device — save then load round-trips
+///   - fallback-to-default-when-persisted-missing — resolver returns
+///     the default id and sets the fallback flag
+///   - subscriber callback fires
+///   - subscriber-out-of-scope (no use-after-free) — token dtor
+///     unsubscribes; later dispatch sees zero subscribers
+///   - CPU-load reads sensibly under simulated load
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <pulp/audio/audio_device_manager.hpp>
+#include <pulp/state/properties_file.hpp>
+#include <pulp/runtime/temporary_file.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+
+using namespace pulp::audio;
+using Catch::Matchers::WithinAbs;
+
+namespace {
+
+class ScopedEnvVar {
+public:
+    ScopedEnvVar(const char* name, const std::string& value) : name_(name) {
+        if (const char* existing = std::getenv(name)) old_value_ = existing;
+        set(name, value);
+    }
+    ~ScopedEnvVar() {
+        if (old_value_) set(name_.c_str(), *old_value_);
+        else            unset(name_.c_str());
+    }
+private:
+    static void set(const char* n, const std::string& v) {
+#ifdef _WIN32
+        _putenv_s(n, v.c_str());
+#else
+        setenv(n, v.c_str(), 1);
+#endif
+    }
+    static void unset(const char* n) {
+#ifdef _WIN32
+        _putenv_s(n, "");
+#else
+        unsetenv(n);
+#endif
+    }
+    std::string name_;
+    std::optional<std::string> old_value_;
+};
+
+// Spin up a sandboxed `ApplicationProperties` whose paths land under a
+// per-test temp directory. Avoids stomping the developer's real
+// settings.
+struct PropsSandbox {
+    pulp::runtime::TemporaryFile marker;
+    std::filesystem::path        home;
+    std::unique_ptr<ScopedEnvVar> env;
+    std::unique_ptr<pulp::state::ApplicationProperties> props;
+
+    explicit PropsSandbox(const std::string& app_name)
+        : marker(".home"),
+          home(marker.path_string() + "_dir") {
+        std::filesystem::create_directories(home);
+#ifdef _WIN32
+        env = std::make_unique<ScopedEnvVar>("APPDATA", home.string());
+#else
+        env = std::make_unique<ScopedEnvVar>("HOME", home.string());
+#endif
+        props = std::make_unique<pulp::state::ApplicationProperties>(app_name);
+    }
+};
+
+DeviceInfo make_device(std::string id, std::string name) {
+    DeviceInfo d;
+    d.id = std::move(id);
+    d.name = std::move(name);
+    d.max_input_channels = 2;
+    d.max_output_channels = 2;
+    return d;
+}
+
+}  // namespace
+
+TEST_CASE("AudioDeviceManager save/load round-trips selection",
+          "[audio][audio-device-manager][issue-2935]") {
+    PropsSandbox box("PulpADMRoundtrip");
+
+    DeviceSelection sel;
+    sel.output_device       = "device:built-in:out";
+    sel.input_device        = "device:built-in:in";
+    sel.sample_rate         = 48000.0;
+    sel.buffer_size         = 256;
+    sel.output_channel_mask = 0b11ULL;
+    sel.input_channel_mask  = 0b1ULL;
+
+    REQUIRE(AudioDeviceManager::save_selection(*box.props, sel));
+
+    // Fresh ApplicationProperties pointed at the same file should see
+    // the persisted values after load() — this is the "restart with
+    // same device" path.
+    pulp::state::ApplicationProperties reopened("PulpADMRoundtrip");
+    reopened.load();
+    auto loaded = AudioDeviceManager::load_selection(reopened);
+    REQUIRE(loaded.has_value());
+    REQUIRE(loaded->output_device       == sel.output_device);
+    REQUIRE(loaded->input_device        == sel.input_device);
+    REQUIRE_THAT(loaded->sample_rate, WithinAbs(48000.0, 0.001));
+    REQUIRE(loaded->buffer_size         == 256);
+    REQUIRE(loaded->output_channel_mask == 0b11ULL);
+    REQUIRE(loaded->input_channel_mask  == 0b1ULL);
+}
+
+TEST_CASE("AudioDeviceManager load returns nullopt when no keys exist",
+          "[audio][audio-device-manager][issue-2935]") {
+    PropsSandbox box("PulpADMNoKeys");
+    REQUIRE_FALSE(AudioDeviceManager::load_selection(*box.props).has_value());
+}
+
+TEST_CASE("AudioDeviceManager resolves missing devices to the system default",
+          "[audio][audio-device-manager][issue-2935]") {
+    std::vector<DeviceInfo> available = {
+        make_device("device:builtin:out", "Built-in Output"),
+        make_device("device:builtin:in",  "Built-in Input"),
+    };
+
+    SECTION("persisted device exists — no fallback") {
+        DeviceSelection sel;
+        sel.output_device = "device:builtin:out";
+        sel.input_device  = "device:builtin:in";
+        auto r = AudioDeviceManager::resolve_selection(
+            sel, available, "device:builtin:out", "device:builtin:in");
+        REQUIRE_FALSE(r.fallback_used_output);
+        REQUIRE_FALSE(r.fallback_used_input);
+        REQUIRE(r.resolved.output_device == "device:builtin:out");
+    }
+
+    SECTION("persisted output device missing — falls back, flag set") {
+        DeviceSelection sel;
+        sel.output_device = "device:scarlett-2i2";  // unplugged
+        sel.input_device  = "device:builtin:in";
+        auto r = AudioDeviceManager::resolve_selection(
+            sel, available, "device:builtin:out", "device:builtin:in");
+        REQUIRE(r.fallback_used_output);
+        REQUIRE_FALSE(r.fallback_used_input);
+        REQUIRE(r.resolved.output_device == "device:builtin:out");
+    }
+
+    SECTION("persisted input device missing — falls back independently") {
+        DeviceSelection sel;
+        sel.output_device = "device:builtin:out";
+        sel.input_device  = "device:unknown-input";
+        auto r = AudioDeviceManager::resolve_selection(
+            sel, available, "device:builtin:out", "device:builtin:in");
+        REQUIRE_FALSE(r.fallback_used_output);
+        REQUIRE(r.fallback_used_input);
+        REQUIRE(r.resolved.input_device == "device:builtin:in");
+    }
+
+    SECTION("empty input id with empty fallback — no fallback flagged") {
+        DeviceSelection sel;
+        sel.output_device = "device:builtin:out";
+        sel.input_device  = "";
+        auto r = AudioDeviceManager::resolve_selection(
+            sel, available, "device:builtin:out", "");
+        REQUIRE_FALSE(r.fallback_used_input);
+        REQUIRE(r.resolved.input_device.empty());
+    }
+}
+
+TEST_CASE("AudioDeviceManager selection_to_config derives channel counts from masks",
+          "[audio][audio-device-manager][issue-2935]") {
+    DeviceSelection sel;
+    sel.output_device       = "id";
+    sel.sample_rate         = 96000.0;
+    sel.buffer_size         = 128;
+    sel.output_channel_mask = 0b1111ULL;  // 4 channels
+    sel.input_channel_mask  = 0b101ULL;   // 2 channels
+
+    auto cfg = AudioDeviceManager::selection_to_config(sel);
+    REQUIRE(cfg.device_id == "id");
+    REQUIRE_THAT(cfg.sample_rate, WithinAbs(96000.0, 0.001));
+    REQUIRE(cfg.buffer_size     == 128);
+    REQUIRE(cfg.output_channels == 4);
+    REQUIRE(cfg.input_channels  == 2);
+}
+
+TEST_CASE("AudioDeviceManager selection_to_config falls back to defaults on zero",
+          "[audio][audio-device-manager][issue-2935]") {
+    DeviceSelection sel;  // all defaulted
+    auto cfg = AudioDeviceManager::selection_to_config(sel, 2, 1);
+    REQUIRE_THAT(cfg.sample_rate, WithinAbs(48000.0, 0.001));
+    REQUIRE(cfg.buffer_size     == 256);
+    REQUIRE(cfg.output_channels == 2);
+    REQUIRE(cfg.input_channels  == 1);
+}
+
+TEST_CASE("AudioDeviceManager dispatches MIDI to live subscribers",
+          "[audio][audio-device-manager][midi][issue-2935]") {
+    AudioDeviceManager mgr;
+
+    std::atomic<int> count_a{0};
+    std::atomic<int> count_b{0};
+    auto token_a = mgr.subscribe_midi(
+        [&](const pulp::midi::MidiEvent&) { ++count_a; });
+    auto token_b = mgr.subscribe_midi(
+        [&](const pulp::midi::MidiEvent&) { ++count_b; });
+
+    REQUIRE(mgr.midi_subscriber_count() == 2);
+    REQUIRE(token_a.active());
+    REQUIRE(token_b.active());
+
+    auto note = pulp::midi::MidiEvent::note_on(0, 60, 100);
+    mgr.dispatch_midi_event(note);
+    mgr.dispatch_midi_event(note);
+
+    REQUIRE(count_a.load() == 2);
+    REQUIRE(count_b.load() == 2);
+}
+
+TEST_CASE("AudioDeviceManager subscriber going out of scope auto-unsubscribes",
+          "[audio][audio-device-manager][midi][issue-2935]") {
+    AudioDeviceManager mgr;
+    std::atomic<int> count{0};
+
+    {
+        auto tok = mgr.subscribe_midi(
+            [&](const pulp::midi::MidiEvent&) { ++count; });
+        REQUIRE(mgr.midi_subscriber_count() == 1);
+        mgr.dispatch_midi_event(pulp::midi::MidiEvent::note_on(0, 60, 100));
+        REQUIRE(count.load() == 1);
+    }  // tok destroyed here → automatic unsubscribe
+
+    REQUIRE(mgr.midi_subscriber_count() == 0);
+
+    // Dispatch after unsubscribe must NOT call the stale handler — if
+    // it did, we'd touch a dangling reference to `count`. Catch2 + ASan
+    // CI catch the use-after-free; the assertion here is the
+    // observable post-condition.
+    mgr.dispatch_midi_event(pulp::midi::MidiEvent::note_on(0, 60, 100));
+    REQUIRE(count.load() == 1);
+}
+
+TEST_CASE("AudioDeviceManager outliving the manager is a safe no-op",
+          "[audio][audio-device-manager][midi][issue-2935]") {
+    MidiSubscriptionToken tok;
+    {
+        AudioDeviceManager mgr;
+        tok = mgr.subscribe_midi([](const pulp::midi::MidiEvent&) {});
+        REQUIRE(tok.active());
+        // Manager goes out of scope here while `tok` lives on.
+    }
+    // Token destructor must not deref the dead manager.
+    REQUIRE_FALSE(tok.active());
+    // Explicit reset() on the dead-manager token also safe.
+    tok.reset();
+}
+
+TEST_CASE("AudioDeviceManager CPU-load tracks work performed in the audio window",
+          "[audio][audio-device-manager][cpu-load][issue-2935]") {
+    AudioDeviceManager mgr;
+
+    // Take a few cheap measurements first — load should stay well
+    // below 1.0 when essentially no work happens inside the window.
+    for (int i = 0; i < 32; ++i) {
+        mgr.begin_cpu_measure(/*num_frames=*/512, /*sample_rate=*/48000.0f);
+        // No work — exit immediately.
+        mgr.end_cpu_measure();
+    }
+    const float idle_load = mgr.cpu_load();
+    REQUIRE(idle_load >= 0.0f);
+    REQUIRE(idle_load < 0.5f);
+
+    // Now simulate a stressed callback: sleep for ~half a buffer worth
+    // of wall-clock time inside the window.
+    const auto half_buffer = std::chrono::microseconds(
+        (512 * 1'000'000) / 48000 / 2);
+    for (int i = 0; i < 32; ++i) {
+        mgr.begin_cpu_measure(512, 48000.0f);
+        std::this_thread::sleep_for(half_buffer);
+        mgr.end_cpu_measure();
+    }
+    const float busy_load = mgr.cpu_load();
+    REQUIRE(busy_load > idle_load);
+    // Peak from the busy run must be at least non-trivial. We don't
+    // assert a tight upper bound — CI machines vary wildly under
+    // load — but the value must be a finite positive number.
+    REQUIRE(mgr.peak_cpu_load() > 0.0f);
+    REQUIRE(std::isfinite(mgr.peak_cpu_load()));
+
+    mgr.reset_peak_cpu_load();
+    REQUIRE(mgr.peak_cpu_load() == 0.0f);
+}


### PR DESCRIPTION
## Summary

First half of the macOS-plugin-authoring plan's AudioDeviceManager work (item 1.2a). Lifecycle/hotplug recovery lands in 1.2b once AudioWorkgroup (1.1) and CoreAudio property listeners are in place.

- **Persistence** — output/input device id, sample rate, buffer size, and I/O channel masks under `audio_device_manager.*` keys in `pulp::state::ApplicationProperties::user_settings()`. Round-trips across host restarts.
- **MIDI hub** — subscribers register a handler and receive an RAII `MidiSubscriptionToken`. Token destruction auto-unsubscribes. A token that outlives the manager observes the dead lifetime peg via `weak_ptr` and is a safe no-op.
- **CPU-load surface** — wraps `AudioProcessLoadMeasurer` behind a mutex so UI-thread readers can poll a smoothed value without poking the realtime measurer directly.
- **Fallback resolver** — `resolve_selection()` falls back to the system-default device id when the persisted device is no longer enumerable and flags the substitution to the caller (for logging).

## Test plan

- [x] `pulp-test-audio-device-manager` — 9 cases, 46 assertions, all green
- [x] save -> fresh `ApplicationProperties` -> load round-trips every field
- [x] missing-keys returns `nullopt`
- [x] resolver fallback (output / input / empty-input edge case)
- [x] mask -> channel-count conversion
- [x] subscriber callback fires
- [x] subscriber-out-of-scope auto-unsubscribes (no UAF)
- [x] token outlives manager -> safe no-op
- [x] CPU-load idle-vs-busy delta + peak finite
- [x] `pulp-test-properties` still 44/44 green
- [x] `pulp-host` rebuilds clean

Tracker: `planning/2026-05-24-macos-plugin-authoring-plan.md` row 1.2a flipped to in-progress.

Generated with Claude Code.