### PR TITLE
feat(format): AU v3 + VST3 adapter bypass hardening (items 3.1 + 3.2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.245.0
+    VERSION 0.246.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/vst3_adapter.hpp
+++ b/core/format/include/pulp/format/vst3_adapter.hpp
@@ -63,6 +63,15 @@ public:
         return param_events_;
     }
 
+    /// Item 3.2 — bypass-wiring diagnostic. Returns the StateStore
+    /// ParamID the adapter routes VST3's `kIsBypass` parameter to
+    /// (`process()` short-circuits to pass-through when this parameter's
+    /// value is >= 0.5). Returns 0 when the plugin did not declare a
+    /// "Bypass" parameter; in that case the VST3 adapter does not
+    /// synthesize one (VST3 hosts that need a bypass automation lane
+    /// rely on the plugin declaring it). Used by item 3.2 tests.
+    state::ParamID bypass_parameter_id() const { return bypass_param_id_; }
+
     // IComponent (state)
     Steinberg::tresult PLUGIN_API getState(Steinberg::IBStream* state) override;
     Steinberg::tresult PLUGIN_API setState(Steinberg::IBStream* state) override;
@@ -85,6 +94,11 @@ private:
     // Parameter output: snapshot values before process to detect plugin-side changes
     std::vector<float> param_snapshot_;
     state::ParameterEventQueue param_events_;
+
+    // Item 3.2 — Cached parameter ID of the plugin-declared "Bypass"
+    // parameter (the one we tag with kIsBypass in initialize()). 0 when
+    // none — process() then never short-circuits.
+    state::ParamID bypass_param_id_ = 0;
 };
 
 } // namespace pulp::format::vst3

--- a/core/format/src/au_adapter.mm
+++ b/core/format/src/au_adapter.mm
@@ -15,12 +15,22 @@
 #include <cmath>
 #include <memory>
 #include <array>
+#include <atomic>
 #include <limits>
 
 namespace pulp::format::au {
 
 static constexpr int kMaxChannels = 8;
 
+// AU v3 row 21 (DAW quirks) — the bypass parameter has to be tracked on
+// two surfaces: AUAudioUnit's `shouldBypassEffect` AUValue **and** the
+// plugin-provided `Bypass` parameter when present. We scan the
+// descriptor's parameter list at init for a parameter named "Bypass"
+// (boolean, 0..1, step==1) and route both surfaces to it. Hosts that
+// observe one but not the other (Logic vs MainStage) then see a
+// consistent value. When no such parameter exists, we still track the
+// bypass flag in a bridge-local atomic so the host's
+// `setShouldBypassEffect:` request is honoured at the audio thread.
 struct AUBridge {
     std::unique_ptr<Processor> processor;
     state::StateStore store;
@@ -32,6 +42,15 @@ struct AUBridge {
     // descriptor has no second input bus — the render block then skips
     // the sidechain pull + calls Processor::set_sidechain(nullptr).
     int sidechain_channels = 0;
+    // Item 3.1 — dual-tracked bypass.
+    //   * `bypass_param_id != 0` means the plugin declared a "Bypass"
+    //     parameter; the AUAudioUnit's `shouldBypassEffect` reads/writes
+    //     it through StateStore.
+    //   * Otherwise, `bypass_flag` is the only authority. The render
+    //     block consults whichever path is live and short-circuits the
+    //     processor with a pass-through (or silence for instruments).
+    state::ParamID bypass_param_id = 0;
+    std::atomic<bool> bypass_flag{false};
 
     // Pre-allocated — no heap allocation on audio thread
     float* output_ptrs[kMaxChannels] = {};
@@ -111,6 +130,12 @@ static int32_t block_relative_sample_offset(AUEventSampleTime event_sample_time,
 /// otherwise NULL. Issue #252.
 @property (nonatomic, readonly, nullable) void *audioUnitARAFactory;
 
+/// Item 3.1 — diagnostic accessor for the bypass-param wiring decision
+/// the adapter made at init. Returns 0 when no plugin-declared bypass
+/// parameter matched (the synthesized-AUValue path is in use); otherwise
+/// the StateStore parameter ID that proxies the bypass surface.
+- (uint32_t)pulpBypassParameterId;
+
 - (NSUInteger)pulpLastParameterEventCount;
 - (uint32_t)pulpLastParameterEventParamIDAtIndex:(NSUInteger)index;
 - (int32_t)pulpLastParameterEventSampleOffsetAtIndex:(NSUInteger)index;
@@ -150,6 +175,20 @@ static int32_t block_relative_sample_offset(AUEventSampleTime event_sample_time,
     }
     _bridge.processor->set_state_store(&_bridge.store);
     _bridge.processor->define_parameters(_bridge.store);
+
+    // Item 3.1 — auto-detect a plugin-declared Bypass parameter so the
+    // host's `shouldBypassEffect` AUValue and the plugin's
+    // automatable parameter stay in lockstep. Match the same heuristic
+    // VST3 uses for `kIsBypass`: name == "Bypass", boolean range 0..1
+    // with step >= 1. When found, the AUv3 surface mirrors it.
+    for (const auto& p : _bridge.store.all_params()) {
+        if (p.name == "Bypass" &&
+            p.range.min == 0.0f && p.range.max == 1.0f &&
+            p.range.step >= 1.0f) {
+            _bridge.bypass_param_id = p.id;
+            break;
+        }
+    }
 
     auto desc = _bridge.processor->descriptor();
     _bridge.input_channels = desc.default_input_channels();
@@ -298,8 +337,38 @@ static int32_t block_relative_sample_offset(AUEventSampleTime event_sample_time,
     return tree;
 }
 
-- (BOOL)shouldBypassEffect { return NO; }
-- (void)setShouldBypassEffect:(BOOL)bypass { (void)bypass; }
+// Item 3.1 — dual-tracked bypass.
+//
+// Hosts read these to render the bypass button in their channel-strip UI
+// (Logic) or treat them as the source of truth for the bypass automation
+// lane (MainStage). Without dual tracking, one surface goes stale.
+//
+// Strategy: when the plugin exposes a parameter named "Bypass" (boolean,
+// 0..1, step==1) we treat that StateStore parameter as authoritative
+// — write to it via the RT-safe path so a host setShouldBypassEffect:
+// call propagates to the plugin's parameter lane (and any UI bindings
+// observing it) without allocating on the audio thread. When the plugin
+// has no Bypass param, we keep the request in a bridge-local atomic so
+// the AUAudioUnit contract still works (the render block then handles
+// pass-through itself; see internalRenderBlock).
+- (BOOL)shouldBypassEffect {
+    if (_bridge.bypass_param_id != 0) {
+        return _bridge.store.get_value(_bridge.bypass_param_id) >= 0.5f
+            ? YES : NO;
+    }
+    return _bridge.bypass_flag.load(std::memory_order_acquire) ? YES : NO;
+}
+
+- (void)setShouldBypassEffect:(BOOL)bypass {
+    if (_bridge.bypass_param_id != 0) {
+        // RT-safe — the AU v3 host may call this from a high-priority
+        // thread that touches the render path; never allocate.
+        _bridge.store.set_value_rt(_bridge.bypass_param_id,
+                                   bypass ? 1.0f : 0.0f);
+    }
+    _bridge.bypass_flag.store(bypass ? true : false,
+                              std::memory_order_release);
+}
 
 // ── Render resources ───────────────────────────────────────────────────────
 
@@ -543,6 +612,34 @@ static int32_t block_relative_sample_offset(AUEventSampleTime event_sample_time,
         }
         bridge->param_events.sort();
 
+        // Item 3.1 — bypass short-circuit. Consult the plugin's Bypass
+        // parameter when it has one; otherwise the bridge-local atomic
+        // the host wrote via setShouldBypassEffect:. When bypassed we
+        // skip `processor_->process()` entirely and emit pass-through:
+        //   * effects (input_channels > 0): copy input → output per
+        //     channel, padding extra outputs with silence;
+        //   * instruments / generators: zero-fill (no input to copy).
+        // MIDI output is intentionally empty when bypassed — matches
+        // every DAW's expectation that a bypassed effect does not emit
+        // arpeggiator notes or MIDI FX into the host's bus.
+        const bool bypassed = (bridge->bypass_param_id != 0)
+            ? (bridge->store.get_value(bridge->bypass_param_id) >= 0.5f)
+            : bridge->bypass_flag.load(std::memory_order_acquire);
+        if (bypassed) {
+            const UInt32 inCount = static_cast<UInt32>(bridge->input_channels);
+            for (UInt32 i = 0; i < outChans; ++i) {
+                if (i < inCount && bridge->input_ptrs[i]) {
+                    std::memcpy(bridge->output_ptrs[i],
+                                bridge->input_ptrs[i],
+                                frameCount * sizeof(float));
+                } else {
+                    std::memset(bridge->output_ptrs[i], 0,
+                                frameCount * sizeof(float));
+                }
+            }
+            return noErr;
+        }
+
         // Process
         pulp::format::ProcessContext ctx;
         ctx.sample_rate = bridge->sample_rate;
@@ -644,6 +741,10 @@ static int32_t block_relative_sample_offset(AUEventSampleTime event_sample_time,
 
 - (pulp::state::StateStore *)pulpStore {
     return &_bridge.store;
+}
+
+- (uint32_t)pulpBypassParameterId {
+    return static_cast<uint32_t>(_bridge.bypass_param_id);
 }
 
 - (NSUInteger)pulpLastParameterEventCount {

--- a/core/format/src/au_audio_unit.h
+++ b/core/format/src/au_audio_unit.h
@@ -32,6 +32,13 @@ class StateStore;
 - (pulp::format::Processor *)pulpProcessor;
 - (pulp::state::StateStore *)pulpStore;
 
+// Bypass-wiring diagnostic. Returns the StateStore ParamID the adapter
+// chose to route the AUv3 `shouldBypassEffect` surface to, or 0 when no
+// plugin-declared "Bypass" parameter matched (in which case the
+// AUAudioUnit's bypass AUValue is tracked in an internal atomic).
+// Used by tests that pin item 3.1 (AU v3 hardening: dual-tracked bypass).
+- (uint32_t)pulpBypassParameterId;
+
 // Parameter-event introspection. Used by `test_au_plugin_state.mm` to
 // assert ramp-event payload survives the AUParameterTree → ParameterEventQueue
 // translation in `au_adapter.mm`.

--- a/core/format/src/vst3_adapter.cpp
+++ b/core/format/src/vst3_adapter.cpp
@@ -109,6 +109,10 @@ tresult PLUGIN_API PulpVst3Processor::initialize(FUnknown* context) {
             step_count = 1;
             if (param.name == "Bypass") {
                 flags |= ParameterInfo::kIsBypass;
+                // Item 3.2 — remember which ParamID carries kIsBypass so
+                // process() can short-circuit to pass-through audio
+                // without invoking the Processor when the host sets it.
+                bypass_param_id_ = param.id;
             }
         }
 
@@ -377,6 +381,28 @@ tresult PLUGIN_API PulpVst3Processor::process(ProcessData& data) {
         const_cast<const float* const*>(sidechain_ptrs_.data()),
         sc_channels, num_samples);
     processor_->set_sidechain(sc_channels > 0 ? &sidechain_view : nullptr);
+
+    // Item 3.2 — VST3 `processBlockBypassed` behaviour. When the plugin
+    // declared a Bypass parameter (kIsBypass) and the current normalized
+    // value is >= 0.5, the adapter does the pass-through itself instead
+    // of asking the Processor. Effects copy main input → main output;
+    // instruments / generators zero-fill. MIDI output stays empty so a
+    // bypassed MIDI FX does not leak notes into the host bus. Matches
+    // every shipping DAW's expectation that a bypassed plugin is a wire.
+    if (bypass_param_id_ != 0 &&
+        store_.get_value(bypass_param_id_) >= 0.5f) {
+        for (int ch = 0; ch < out_channels; ++ch) {
+            if (ch < in_channels && input_ptrs_[ch] != nullptr) {
+                std::memcpy(output_ptrs_[ch], input_ptrs_[ch],
+                            sizeof(float) * num_samples);
+            } else {
+                std::memset(output_ptrs_[ch], 0,
+                            sizeof(float) * num_samples);
+            }
+        }
+        processor_->set_sidechain(nullptr);
+        return kResultOk;
+    }
 
     // Build MIDI buffers from VST3 events
     midi::MidiBuffer midi_in, midi_out;

--- a/test/test_au_plugin_state.mm
+++ b/test/test_au_plugin_state.mm
@@ -542,3 +542,243 @@ TEST_CASE("AU v3 setFullState ignores invalid plugin payload",
         [unit release];
     }
 }
+
+// ── Item 3.1 — AU v3 dual-tracked bypass ───────────────────────────────────
+//
+// Pins three contract points:
+//   * AUv3 init auto-detects a "Bypass" parameter and routes
+//     `shouldBypassEffect` / `setShouldBypassEffect:` to it.
+//   * `setShouldBypassEffect:` writes the plugin's StateStore param.
+//   * The render block short-circuits to pass-through audio when
+//     bypassed (in→out for effects), and never calls Processor::process.
+namespace {
+
+class TestAUBypassProcessor : public pulp::format::Processor {
+public:
+    TestAUBypassProcessor() { g_last = this; }
+
+    pulp::format::PluginDescriptor descriptor() const override {
+        return {
+            .name = "AUBypassEffectTest",
+            .manufacturer = "PulpTest",
+            .bundle_id = "com.pulp.test.au-bypass",
+            .version = "1.0.0",
+            .category = pulp::format::PluginCategory::Effect,
+            .input_buses = {{"Audio In", 2}},
+            .output_buses = {{"Audio Out", 2}},
+        };
+    }
+
+    void define_parameters(pulp::state::StateStore& store) override {
+        store.add_parameter({
+            .id = 7,
+            .name = "Gain",
+            .unit = "dB",
+            .range = {-60.0f, 24.0f, 0.0f, 0.1f},
+        });
+        store.add_parameter({
+            .id = 9,
+            .name = "Bypass",
+            .range = {0.0f, 1.0f, 0.0f, 1.0f},
+        });
+    }
+
+    void prepare(const pulp::format::PrepareContext&) override {}
+
+    void process(pulp::audio::BufferView<float>& out,
+                 const pulp::audio::BufferView<const float>& in,
+                 pulp::midi::MidiBuffer&,
+                 pulp::midi::MidiBuffer&,
+                 const pulp::format::ProcessContext&) override {
+        ++process_count;
+        // Fill output with a sentinel value so a buggy bypass path
+        // (one that called process() anyway) would be observable.
+        for (std::size_t ch = 0; ch < out.num_channels(); ++ch) {
+            float* dst = out.channel_ptr(ch);
+            for (std::size_t i = 0; i < out.num_samples(); ++i) {
+                dst[i] = -99.0f;
+            }
+        }
+        (void)in;
+    }
+
+    int process_count = 0;
+    static TestAUBypassProcessor* g_last;
+};
+
+TestAUBypassProcessor* TestAUBypassProcessor::g_last = nullptr;
+
+std::unique_ptr<pulp::format::Processor> create_bypass_processor() {
+    return std::make_unique<TestAUBypassProcessor>();
+}
+
+} // namespace
+
+TEST_CASE("AU v3 auto-detects plugin-declared Bypass parameter",
+          "[au][auv3][bypass][item-3.1]") {
+    @autoreleasepool {
+        AudioComponentDescription desc{};
+        desc.componentType = kAudioUnitType_Effect;
+        desc.componentSubType = 'TBpE';
+        desc.componentManufacturer = 'Plup';
+
+        ScopedFactoryRegistration registration(create_bypass_processor);
+
+        NSError* err = nil;
+        PulpAudioUnit* unit =
+            [[PulpAudioUnit alloc] initWithComponentDescription:desc
+                                                       options:0
+                                                         error:&err];
+        REQUIRE(unit != nil);
+        REQUIRE(err == nil);
+
+        // The Bypass parameter was registered with id 9 — assert the
+        // adapter routed shouldBypassEffect to it instead of falling
+        // back to the bridge-local atomic.
+        REQUIRE([unit pulpBypassParameterId] == 9u);
+        REQUIRE([unit shouldBypassEffect] == NO);
+
+        // Host writes through the AU surface — the StateStore parameter
+        // must update so plugin-side UI bindings stay coherent.
+        [unit setShouldBypassEffect:YES];
+        auto* processor = TestAUBypassProcessor::g_last;
+        REQUIRE(processor != nullptr);
+        REQUIRE_THAT(processor->state().get_value(9), WithinAbs(1.0f, 1e-6f));
+        REQUIRE([unit shouldBypassEffect] == YES);
+
+        // Plugin-side write reflects back to the AU surface.
+        processor->state().set_value(9, 0.0f);
+        REQUIRE([unit shouldBypassEffect] == NO);
+
+        [unit release];
+    }
+}
+
+TEST_CASE("AU v3 render block short-circuits to pass-through when bypassed",
+          "[au][auv3][bypass][item-3.1]") {
+    @autoreleasepool {
+        AudioComponentDescription desc{};
+        desc.componentType = kAudioUnitType_Effect;
+        desc.componentSubType = 'TBpE';
+        desc.componentManufacturer = 'Plup';
+
+        ScopedFactoryRegistration registration(create_bypass_processor);
+
+        NSError* err = nil;
+        PulpAudioUnit* unit =
+            [[PulpAudioUnit alloc] initWithComponentDescription:desc
+                                                       options:0
+                                                         error:&err];
+        REQUIRE(unit != nil);
+        REQUIRE(err == nil);
+
+        auto* processor = TestAUBypassProcessor::g_last;
+        REQUIRE(processor != nullptr);
+
+        NSError* allocate_error = nil;
+        REQUIRE([unit allocateRenderResourcesAndReturnError:&allocate_error]);
+        REQUIRE(allocate_error == nil);
+
+        constexpr UInt32 kFrames = 4;
+        float left[kFrames] = {1.0f, 2.0f, 3.0f, 4.0f};
+        float right[kFrames] = {5.0f, 6.0f, 7.0f, 8.0f};
+        struct StereoBufferList {
+            AudioBufferList list;
+            AudioBuffer extra[1];
+        } output{};
+        output.list.mNumberBuffers = 2;
+        output.list.mBuffers[0].mNumberChannels = 1;
+        output.list.mBuffers[0].mDataByteSize = kFrames * sizeof(float);
+        output.list.mBuffers[0].mData = left;
+        output.list.mBuffers[1].mNumberChannels = 1;
+        output.list.mBuffers[1].mDataByteSize = kFrames * sizeof(float);
+        output.list.mBuffers[1].mData = right;
+
+        // Pull block returns simple input so the bypass copy has
+        // something concrete to assert against.
+        AURenderPullInputBlock pull = ^AUAudioUnitStatus(
+            AudioUnitRenderActionFlags* /*pullFlags*/,
+            const AudioTimeStamp* /*ts*/,
+            AUAudioFrameCount /*nframes*/,
+            NSInteger /*busNumber*/,
+            AudioBufferList* inputData) {
+            // Fill each pulled channel with a per-channel sentinel.
+            for (UInt32 b = 0; b < inputData->mNumberBuffers; ++b) {
+                float* ptr = static_cast<float*>(inputData->mBuffers[b].mData);
+                const UInt32 n = inputData->mBuffers[b].mDataByteSize / sizeof(float);
+                for (UInt32 i = 0; i < n; ++i) {
+                    ptr[i] = static_cast<float>(10 + b);
+                }
+            }
+            return noErr;
+        };
+
+        AudioUnitRenderActionFlags flags = 0;
+        AudioTimeStamp timestamp{};
+        timestamp.mFlags = kAudioTimeStampSampleTimeValid;
+        timestamp.mSampleTime = 0;
+
+        AUInternalRenderBlock block = [unit internalRenderBlock];
+        REQUIRE(block != nil);
+
+        // Bypass on.
+        [unit setShouldBypassEffect:YES];
+        const int before = processor->process_count;
+        auto status = block(&flags, &timestamp, kFrames, 0,
+                            &output.list, nullptr, pull);
+        REQUIRE(status == noErr);
+        // Processor::process must NOT have been called when bypassed.
+        REQUIRE(processor->process_count == before);
+        // Output channels must hold the pulled input verbatim (10.0 on
+        // channel 0, 11.0 on channel 1) — confirms in→out pass-through,
+        // not the -99.0 sentinel the processor would have written.
+        for (UInt32 i = 0; i < kFrames; ++i) {
+            REQUIRE_THAT(left[i],  WithinAbs(10.0f, 1e-6f));
+            REQUIRE_THAT(right[i], WithinAbs(11.0f, 1e-6f));
+        }
+
+        // Bypass off — the processor must run and stamp its sentinel.
+        [unit setShouldBypassEffect:NO];
+        status = block(&flags, &timestamp, kFrames, 0,
+                       &output.list, nullptr, pull);
+        REQUIRE(status == noErr);
+        REQUIRE(processor->process_count == before + 1);
+        REQUIRE_THAT(left[0],  WithinAbs(-99.0f, 1e-6f));
+        REQUIRE_THAT(right[0], WithinAbs(-99.0f, 1e-6f));
+
+        [unit deallocateRenderResources];
+        [unit release];
+    }
+}
+
+TEST_CASE("AU v3 without a Bypass parameter still honours setShouldBypassEffect",
+          "[au][auv3][bypass][item-3.1]") {
+    @autoreleasepool {
+        AudioComponentDescription desc{};
+        desc.componentType = kAudioUnitType_Effect;
+        desc.componentSubType = 'TstE';
+        desc.componentManufacturer = 'Plup';
+
+        // Use the existing effect processor — it has no Bypass param.
+        ScopedFactoryRegistration registration(create_effect_processor);
+
+        NSError* err = nil;
+        PulpAudioUnit* unit =
+            [[PulpAudioUnit alloc] initWithComponentDescription:desc
+                                                       options:0
+                                                         error:&err];
+        REQUIRE(unit != nil);
+        REQUIRE(err == nil);
+
+        // No Bypass parameter — the bridge falls back to its atomic.
+        REQUIRE([unit pulpBypassParameterId] == 0u);
+        REQUIRE([unit shouldBypassEffect] == NO);
+
+        [unit setShouldBypassEffect:YES];
+        REQUIRE([unit shouldBypassEffect] == YES);
+        [unit setShouldBypassEffect:NO];
+        REQUIRE([unit shouldBypassEffect] == NO);
+
+        [unit release];
+    }
+}

--- a/test/test_vst3_plugin_state.cpp
+++ b/test/test_vst3_plugin_state.cpp
@@ -689,3 +689,121 @@ TEST_CASE("VST3 getState/setState fail cleanly without a live processor",
         REQUIRE(processor.setState(&in_stream) == Steinberg::kResultFalse);
     }
 }
+
+// ── Item 3.2 — VST3 processBlockBypassed pass-through ──────────────────────
+//
+// Pins three contract points:
+//   * initialize() caches the StateStore ParamID of the "Bypass"
+//     parameter (visible via bypass_parameter_id()).
+//   * When the host sets that parameter to >= 0.5 (denormalized) before
+//     process(), the adapter short-circuits to in→out copy and does NOT
+//     call Processor::process().
+//   * Plugins without a Bypass parameter never see the short-circuit
+//     (the adapter doesn't synthesize one — that's a per-plugin opt-in).
+
+TEST_CASE("VST3 processBlockBypassed copies input to output without calling Processor::process",
+          "[vst3][bypass][item-3.2]") {
+    TestVst3Config config;
+    config.add_bypass_param = true;
+    reset_test_processor(config);
+
+    HostApp host_app;
+    pulp::format::vst3::PulpVst3Processor processor(create_test_processor);
+    REQUIRE(processor.initialize(&host_app) == Steinberg::kResultOk);
+    auto* test_processor = TestVst3Processor::g_last_processor;
+    REQUIRE(test_processor != nullptr);
+
+    // The adapter should have noticed the Bypass parameter and routed
+    // its kIsBypass surface to it.
+    REQUIRE(processor.bypass_parameter_id() == kBypassParamId);
+
+    Steinberg::Vst::SpeakerArrangement inputs[1]  = {SpeakerArr::kStereo};
+    Steinberg::Vst::SpeakerArrangement outputs[1] = {SpeakerArr::kStereo};
+    REQUIRE(processor.setBusArrangements(inputs, 1, outputs, 1) ==
+            Steinberg::kResultTrue);
+
+    Steinberg::Vst::ProcessSetup setup{};
+    setup.processMode = Steinberg::Vst::kRealtime;
+    setup.symbolicSampleSize = Steinberg::Vst::kSample32;
+    setup.maxSamplesPerBlock = 4;
+    setup.sampleRate = 48000.0;
+    REQUIRE(processor.setupProcessing(setup) == Steinberg::kResultOk);
+
+    constexpr int kFrames = 4;
+    std::array<float, kFrames> in_l{{0.1f, 0.2f, 0.3f, 0.4f}};
+    std::array<float, kFrames> in_r{{-0.1f, -0.2f, -0.3f, -0.4f}};
+    std::array<float, kFrames> out_l{};
+    std::array<float, kFrames> out_r{};
+    out_l.fill(99.0f); // sentinel — must be overwritten by pass-through copy
+    out_r.fill(99.0f);
+
+    float* main_inputs[2]  = {in_l.data(), in_r.data()};
+    float* main_outputs[2] = {out_l.data(), out_r.data()};
+
+    Steinberg::Vst::AudioBusBuffers audio_inputs[1]{};
+    audio_inputs[0].numChannels = 2;
+    audio_inputs[0].channelBuffers32 = main_inputs;
+    Steinberg::Vst::AudioBusBuffers audio_outputs[1]{};
+    audio_outputs[0].numChannels = 2;
+    audio_outputs[0].channelBuffers32 = main_outputs;
+
+    // Engage bypass via an input parameter change at sample 0.
+    // VST3 hosts deliver bypass via the kIsBypass parameter on the
+    // normalized lane (0..1).
+    Steinberg::Vst::ParameterChanges input_params(1);
+    Steinberg::int32 q_index = 0;
+    auto* bypass_queue = input_params.addParameterData(kBypassParamId, q_index);
+    REQUIRE(bypass_queue != nullptr);
+    Steinberg::int32 pt_index = 0;
+    REQUIRE(bypass_queue->addPoint(0, 1.0, pt_index) == Steinberg::kResultTrue);
+
+    Steinberg::Vst::ProcessData data{};
+    data.numSamples = kFrames;
+    data.numInputs = 1;
+    data.numOutputs = 1;
+    data.inputs = audio_inputs;
+    data.outputs = audio_outputs;
+    data.inputParameterChanges = &input_params;
+
+    const int before = test_processor->process_count;
+    REQUIRE(processor.process(data) == Steinberg::kResultOk);
+
+    // Pass-through must have copied input → output verbatim.
+    for (int i = 0; i < kFrames; ++i) {
+        REQUIRE_THAT(out_l[i], WithinAbs(in_l[i], 1e-6f));
+        REQUIRE_THAT(out_r[i], WithinAbs(in_r[i], 1e-6f));
+    }
+    // The Processor must NOT have been called.
+    REQUIRE(test_processor->process_count == before);
+
+    // Releasing bypass restores the normal process() path. Reset
+    // outputs and run again with bypass = 0.
+    out_l.fill(99.0f);
+    out_r.fill(99.0f);
+    Steinberg::Vst::ParameterChanges release_params(1);
+    auto* release_queue = release_params.addParameterData(kBypassParamId, q_index);
+    REQUIRE(release_queue != nullptr);
+    pt_index = 0;
+    REQUIRE(release_queue->addPoint(0, 0.0, pt_index) == Steinberg::kResultTrue);
+    data.inputParameterChanges = &release_params;
+
+    REQUIRE(processor.process(data) == Steinberg::kResultOk);
+    REQUIRE(test_processor->process_count == before + 1);
+    // TestVst3Processor::process copies input → output, so out should
+    // also match in — but importantly, the Processor::process counter
+    // moved.
+}
+
+TEST_CASE("VST3 adapter without a Bypass parameter never short-circuits",
+          "[vst3][bypass][item-3.2]") {
+    TestVst3Config config; // add_bypass_param defaults to false
+    reset_test_processor(config);
+
+    HostApp host_app;
+    pulp::format::vst3::PulpVst3Processor processor(create_test_processor);
+    REQUIRE(processor.initialize(&host_app) == Steinberg::kResultOk);
+
+    // No "Bypass" parameter declared by the plugin — the adapter should
+    // report the no-op sentinel ID 0 so process() never short-circuits.
+    REQUIRE(processor.bypass_parameter_id() == 0u);
+}


### PR DESCRIPTION
## Summary

Bundled hardening for AU v3 and VST3 adapter items 3.1 + 3.2 from
`planning/2026-05-24-macos-plugin-authoring-plan.md`.

**AU v3 (item 3.1) — `shouldBypassEffect` dual-tracking:**
- `shouldBypassEffect` / `setShouldBypassEffect:` were one-line stubs
  returning `NO` / discarding writes.
- Now auto-detect a plugin-declared `"Bypass"` parameter at init and
  route both AUv3 surfaces through StateStore (DAW quirks row 21 —
  one-sided updates cause stale UI in Logic or stale audio in
  MainStage). When no `Bypass` parameter exists, the bridge falls back
  to a local atomic.
- `internalRenderBlock` short-circuits to pass-through audio when
  bypassed and never calls `Processor::process`. MIDI output stays
  empty so bypassed MIDI FX don't leak notes.
- Exposes `pulpBypassParameterId` diagnostic for tests.

**VST3 (item 3.2) — `processBlockBypassed` pass-through:**
- `initialize()` caches the ParamID of the `kIsBypass`-tagged
  parameter; surfaces it via `bypass_parameter_id()`.
- `process()` short-circuits to pass-through when that parameter's
  value is >= 0.5: copies main input → main output (or zero-fills
  instruments), drops the sidechain, returns without invoking the
  Processor.

**Acceptance contract pinned by tests:**
- AU: 3 cases — param detection, render-block pass-through with input
  pull, no-bypass-param fallback.
- VST3: 2 cases — cached ID matches the declared param, parameter-driven
  pass-through under a sample-0 host write copies in→out and skips
  `Processor::process`.

5 new test cases, 57 new assertions; existing suites still green.

## Test plan

- [x] `pulp-test-au-plugin-state` — 10 cases (was 7), 145 assertions
- [x] `pulp-test-vst3-plugin-state` — 8 cases (was 6), 165 assertions
- [x] `pulp-test-au-v2-effect` — 7 cases, 92 assertions (no regression)
- [x] `pulp-format` static-lib build clean on Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)