### PR TITLE
feat(format): items 3.4 CLAP validation + 3.5 Standalone polish + 3.10 AUv3 packaging

### DIFF
--- a/.agents/skills/auv3/SKILL.md
+++ b/.agents/skills/auv3/SKILL.md
@@ -740,6 +740,47 @@ AUHost sample app (available from Apple's developer portal) or inside
 AUM / Cubasis to smoke-test instantiation + render. See the `ios`
 skill for device deploy.
 
+## Packaging — macOS appex + iOS device + Simulator (item 3.10)
+
+The AU v3 packaging shape is **three distinct targets**, dispatched by
+`_pulp_add_auv3` in `tools/cmake/PulpAuv3.cmake`:
+
+1. **macOS** — framework-inside-containing-app:
+   `${target}_AUv3Framework` (SHARED FRAMEWORK with the AU code),
+   `${target}_AUv3` (stub `.appex` linking the framework via
+   `AudioComponentBundle`), `${target}_AUv3Host` (containing `.app`
+   with both embedded under `Contents/Frameworks` + `Contents/PlugIns`).
+2. **iOS device** — single monolithic `.appex` produced by
+   `_pulp_add_auv3_ios`; signed with the
+   `templates/auv3/iOS-Device-Entitlements.plist.template` entitlements
+   (application-groups).
+3. **iOS Simulator** — same `_pulp_add_auv3_ios` path, but configure
+   picks `iOS-Simulator-Entitlements.plist.template` instead. CMake
+   detects the Simulator via `CMAKE_OSX_SYSROOT` matching
+   `Simulator|iphonesimulator`. Mac Catalyst is **deliberately
+   excluded** (macOS plan 3.10 — "Catalyst is deferred post-MVP").
+
+### Install + cache-clear gotcha
+
+`pulp-install-${target}` for AUv3 copies the **containing `.app`** to
+`~/Applications/<name>.app`, then runs:
+
+```
+/usr/bin/pluginkit -a "<app>/Contents/PlugIns/<name>.appex"
+/usr/bin/killall -9 AudioComponentRegistrar  # may be a no-op if it isn't running
+```
+
+The `pluginkit -a` registration is what makes Launch Services + the AU
+host's `AVAudioUnitComponentManager` discover the extension on next
+relaunch. The `killall` step flushes the AudioComponent cache so the
+DAW sees the new component without a full logout. Both steps are
+documented in `pulp doctor --au-cache`; the install target wires them
+automatically.
+
+`~/Library/Audio/Plug-Ins/Components/` is **AU v2 only** — AU v3 hosts
+discover extensions through PlugInKit, not the v2 component directory.
+Don't try to install an AU v3 `.appex` there.
+
 ## Cross-references
 
 - `.agents/skills/ios/SKILL.md` — iOS extension wiring, simulator

--- a/.agents/skills/clap/SKILL.md
+++ b/.agents/skills/clap/SKILL.md
@@ -449,6 +449,27 @@ with `PULP_DISABLE_PLUGIN_EDITOR=1 PULP_HEADLESS=1 PULP_TEST_MODE=1`.
 Under those guards, Pulp hides `CLAP_EXT_GUI` from `get_extension()` and
 the GUI callbacks fail closed if a host cached the extension pointer.
 
+## Host-API contract pinned by `test/test_clap_host_validation.cpp`
+
+Real-DAW validation (Bitwig, Reaper, FL Studio, Studio One) requires
+a license + manual install, so the CI proxy is
+`test/test_clap_host_validation.cpp` (item 3.4 of the macOS plugin
+authoring plan). It pins the four contracts hosts have historically
+broken on:
+
+1. Plugin id + parameter id + range stability across instances.
+2. `CLAP_EVENT_PARAM_MOD` does NOT bleed across blocks — the adapter
+   calls `store.reset_all_mod()` at the top of every `process()`.
+3. Non-core event spaces (`hdr->space_id != CLAP_CORE_EVENT_SPACE_ID`)
+   are ignored, matching `clap-validator`'s
+   `param-set-wrong-namespace` expectation.
+4. `state.save` → `state.load` → `state.save` produces byte-equivalent
+   output (Studio One project-recall determinism).
+
+When changing the adapter's event dispatch or param surface, run
+`pulp-test-clap-host-validation` first — it will catch the regression
+before a host scan does.
+
 ## Cross-references
 
 - `.agents/skills/view-bridge/SKILL.md` — editor open / attach /

--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -1244,3 +1244,42 @@ Gotchas (lessons from the slice):
   --check-identity`. Keep them in lockstep — the orchestrate path
   re-uses `cmd::identity::run(Check)` rather than re-implementing the
   comparison.
+
+## Standalone host transport + MIDI + persistence (item 3.5)
+
+`StandaloneApp` is the user-facing surface behind `pulp run`. As of
+the 3.5 wiring it consumes three Pulp subsystems the way a DAW would
+consume the equivalent host APIs:
+
+- **`pulp::midi::MidiMessageCollector` (item 1.9)** — `ui_midi_collector()`
+  is the lock-free SPSC path for UI / virtual-keyboard / scripting
+  MIDI. The audio callback drains it into each block's `MidiBuffer`
+  at the correct sample offsets via `drain_into(block_start_seconds,
+  ctx.buffer_size, ctx.sample_rate)`. Hardware MIDI still goes
+  through the mutex-guarded `pending_midi_` accumulator on the
+  input-thread callback.
+- **Built-in transport (item 1.3)** — `StandaloneConfig` carries
+  `tempo_bpm`, `time_sig_numerator`, `time_sig_denominator`, and
+  `transport_playing`. The audio callback populates
+  `ProcessContext::tempo_bpm`, `position_beats`, `bar`, and
+  `is_playing` from those values; `position_samples` advances on a
+  rolling atomic counter so plugins read a monotonic timeline.
+- **`pulp::state::ApplicationProperties` (item 1.2)** —
+  `StandaloneApp::{save,load}_persisted_config(app_name)` round-trip
+  the entire `StandaloneConfig` through the platform user-properties
+  file. Keys are namespaced under `standalone.*` so they don't collide
+  with plugin-owned state. Empty `app_name` is the documented
+  "persistence disabled" sentinel — callers can opt out by passing
+  `""`.
+
+When extending the standalone surface (new `StandaloneConfig` field,
+new transport field, new persisted key), update **both**:
+
+1. The audio callback's `ProcessContext` population in
+   `core/format/src/standalone.cpp` (so plugins see the new value
+   immediately).
+2. `save_persisted_config` / `load_persisted_config` (so the value
+   survives a `pulp run` restart).
+
+Test coverage lives in `test/test_standalone_transport_midi.cpp` —
+add a case there when you extend either surface.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.120.0",
+      "version": "0.121.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.120.0"
+  "version": "0.121.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.120.0",
+  "version": "0.121.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.246.0
+    VERSION 0.247.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/standalone.hpp
+++ b/core/format/include/pulp/format/standalone.hpp
@@ -5,9 +5,11 @@
 #include <pulp/format/processor.hpp>
 #include <pulp/format/test_signal.hpp>
 #include <pulp/midi/device.hpp>
+#include <pulp/midi/message_collector.hpp>
 #include <pulp/view/audio_bridge.hpp>
 
 #include <atomic>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -37,6 +39,18 @@ struct StandaloneConfig {
     // Frames to wait before capture. Default 30 (~0.5s @60fps) gives the
     // first React-driven layout + effects pass time to settle.
     int screenshot_frame_delay = 30;
+
+    // Item 3.5 (macOS plan) — built-in tempo source. The standalone host has
+    // no DAW providing transport, so it acts as one: it surfaces
+    // `tempo_bpm` / time signature on every ProcessContext block, and
+    // advances `position_beats` from `position_samples` when the transport
+    // is rolling. Plugins that branch on `is_playing` or read
+    // `position_beats` therefore behave the same way in `pulp run` as they
+    // do in a host (item 1.3 wiring) without any per-plugin glue.
+    double tempo_bpm = 120.0;
+    int time_sig_numerator = 4;
+    int time_sig_denominator = 4;
+    bool transport_playing = true;  // default-on so MIDI/tempo plugins are immediately useful
 };
 
 class StandaloneApp {
@@ -63,6 +77,22 @@ public:
     audio::AudioSystem* audio_system() { return audio_system_.get(); }
     midi::MidiSystem* midi_system() { return midi_system_.get(); }
 
+    // Item 3.5 — UI-thread MIDI injection. Virtual-keyboard widgets, scripting
+    // hooks, and test harnesses push MIDI events through this collector;
+    // the audio callback drains them into each block's MidiBuffer at the
+    // correct sample offsets. Identical thread-safety surface that
+    // pulp::midi::MidiMessageCollector documents — push_now is non-blocking.
+    midi::MidiMessageCollector<>& ui_midi_collector() { return ui_midi_collector_; }
+
+    // Item 3.5 — Persist + restore StandaloneConfig under
+    // ApplicationProperties so `pulp run` opens the user's last device,
+    // sample-rate, buffer-size, MIDI input, and built-in transport
+    // settings on the next launch. Returns false when the storage layer
+    // failed to write (e.g. read-only profile, missing app name).
+    static StandaloneConfig load_persisted_config(std::string_view app_name);
+    static bool save_persisted_config(std::string_view app_name,
+                                      const StandaloneConfig& config);
+
 private:
     // Tear down the audio + MIDI devices but KEEP the processor instance alive.
     // apply_config() uses this so a settings change does not recreate the
@@ -81,7 +111,16 @@ private:
 
     midi::MidiBuffer pending_midi_;
     std::mutex midi_mutex_;
+    midi::MidiMessageCollector<> ui_midi_collector_;
     std::atomic<bool> running_{false};
+
+    // Item 3.5 — built-in transport state (the standalone "host").
+    // `transport_position_samples_` advances atomically on the audio
+    // thread; `transport_block_time_seconds_` is derived by the audio
+    // callback (`position_samples / sample_rate`) and is what
+    // `MidiMessageCollector::drain_into` uses to align UI MIDI events
+    // to sample offsets within the current block.
+    std::atomic<int64_t> transport_position_samples_{0};
 
     TestSignalSource test_signal_;
     view::AudioBridge input_meter_bridge_;

--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -4,7 +4,11 @@
 #include <pulp/format/editor_ui.hpp>
 #include <pulp/format/settings_panel.hpp>
 #include <pulp/format/view_bridge.hpp>
+#include <pulp/state/properties_file.hpp>
 #include <pulp/view/window_host.hpp>
+
+#include <charconv>
+#include <string_view>
 
 // WYSIWYG P6 FIX 5 — the dev inspector (Cmd+I overlay) is gated behind the
 // PULP_ENABLE_INSPECTOR compile flag (root CMake option, default ON for
@@ -127,13 +131,30 @@ bool StandaloneApp::start() {
         audio::BufferView<float>& output,
         const audio::CallbackContext& ctx)
     {
-        // Collect pending MIDI
+        // Collect pending MIDI from the hardware input thread (mutex-guarded
+        // accumulator). UI / virtual-keyboard / scripting MIDI is delivered
+        // separately via `ui_midi_collector_` (item 3.5 — pulp::midi::
+        // MidiMessageCollector) which is lock-free and sample-accurate
+        // within the current block.
         midi::MidiBuffer midi_in, midi_out;
         {
             std::lock_guard lock(midi_mutex_);
             midi_in = std::move(pending_midi_);
             pending_midi_.clear();
         }
+
+        // Item 3.5 — drain UI-thread MIDI into this block at the correct
+        // sample offsets. The standalone host treats its own audio clock
+        // as the master timeline: block_start_seconds is
+        // `transport_position_samples / sample_rate`.
+        const int64_t block_start_samples =
+            transport_position_samples_.load(std::memory_order_relaxed);
+        const double block_start_seconds =
+            ctx.sample_rate > 0.0
+                ? static_cast<double>(block_start_samples) / ctx.sample_rate
+                : 0.0;
+        ui_midi_collector_.drain_into(midi_in, block_start_seconds,
+                                      ctx.buffer_size, ctx.sample_rate);
 
         // Determine actual input: test signal overrides hardware input
         const audio::BufferView<const float>* actual_input = &input;
@@ -168,12 +189,52 @@ bool StandaloneApp::start() {
                 ctx.buffer_size);
         }
 
+        // Item 3.5 / item 1.3 — populate the transport-related fields on
+        // ProcessContext from the standalone's built-in tempo source.
+        // The driver has no DAW providing transport, so it behaves like
+        // one: tempo + time-signature are the user-chosen config values,
+        // `position_beats` advances from the rolling sample clock at the
+        // configured tempo, and `is_playing` mirrors the user's
+        // play/stop toggle.
         ProcessContext proc_ctx;
         proc_ctx.sample_rate = ctx.sample_rate;
         proc_ctx.num_samples = ctx.buffer_size;
-        proc_ctx.position_samples = static_cast<int64_t>(ctx.sample_position);
+        proc_ctx.position_samples = block_start_samples;
+        proc_ctx.is_playing = config_.transport_playing;
+        proc_ctx.is_recording = false;
+        proc_ctx.tempo_bpm = config_.tempo_bpm;
+        proc_ctx.time_sig_numerator = config_.time_sig_numerator;
+        proc_ctx.time_sig_denominator = config_.time_sig_denominator;
+        if (config_.tempo_bpm > 0.0 && ctx.sample_rate > 0.0) {
+            const double seconds_per_beat = 60.0 / config_.tempo_bpm;
+            const double samples_per_beat = seconds_per_beat * ctx.sample_rate;
+            if (samples_per_beat > 0.0) {
+                proc_ctx.position_beats =
+                    static_cast<double>(block_start_samples) / samples_per_beat;
+            }
+        }
+        // Derive `bar` so processors that branch on it (e.g. metronome
+        // accents) don't re-compute per block. Mirrors the
+        // ProcessContext doc-comment derivation.
+        if (config_.time_sig_numerator > 0 && config_.time_sig_denominator > 0) {
+            const double beats_per_bar =
+                static_cast<double>(config_.time_sig_numerator) *
+                (4.0 / static_cast<double>(config_.time_sig_denominator));
+            if (beats_per_bar > 0.0) {
+                proc_ctx.bar = static_cast<int64_t>(
+                    proc_ctx.position_beats / beats_per_bar);
+            }
+        }
 
         processor_->process(output, *actual_input, midi_in, midi_out, proc_ctx);
+
+        // Advance the rolling sample clock so the next block reads a
+        // monotonic timeline. Done after process() so the in-block
+        // transport state is consistent with what the plugin saw.
+        if (config_.transport_playing) {
+            transport_position_samples_.fetch_add(
+                ctx.buffer_size, std::memory_order_relaxed);
+        }
     });
 
     if (!ok) {
@@ -419,6 +480,75 @@ void StandaloneApp::stop() {
         processor_->release();
         processor_.reset();
     }
+}
+
+// ── Item 3.5 — persisted-config helpers ────────────────────────────────────
+//
+// Keys live under the `standalone.*` namespace in the user properties file so
+// they don't collide with plugin-owned state. The format is the simple
+// scalar-per-key shape the existing PropertiesFile API supports — we don't
+// need nested JSON for these handful of fields.
+
+namespace {
+
+constexpr std::string_view kKeyAudioDevice    = "standalone.audio_device_id";
+constexpr std::string_view kKeyMidiInput      = "standalone.midi_input_id";
+constexpr std::string_view kKeySampleRate     = "standalone.sample_rate";
+constexpr std::string_view kKeyBufferSize     = "standalone.buffer_size";
+constexpr std::string_view kKeyOutputChannels = "standalone.output_channels";
+constexpr std::string_view kKeyInputChannels  = "standalone.input_channels";
+constexpr std::string_view kKeyTempo          = "standalone.tempo_bpm";
+constexpr std::string_view kKeyTimeSigNum     = "standalone.time_sig_num";
+constexpr std::string_view kKeyTimeSigDen     = "standalone.time_sig_den";
+constexpr std::string_view kKeyPlaying        = "standalone.transport_playing";
+
+}  // namespace
+
+StandaloneConfig StandaloneApp::load_persisted_config(std::string_view app_name) {
+    StandaloneConfig cfg;  // defaults
+    if (app_name.empty()) return cfg;
+
+    state::ApplicationProperties props(app_name);
+    props.load();
+    const auto& user = props.user_settings();
+
+    if (auto v = user.get_string(kKeyAudioDevice))    cfg.audio_device_id = *v;
+    if (auto v = user.get_string(kKeyMidiInput))      cfg.midi_input_id   = *v;
+    if (auto v = user.get_double(kKeySampleRate))     cfg.sample_rate     = *v;
+    if (auto v = user.get_int(kKeyBufferSize))        cfg.buffer_size     = static_cast<int>(*v);
+    if (auto v = user.get_int(kKeyOutputChannels))    cfg.output_channels = static_cast<int>(*v);
+    if (auto v = user.get_int(kKeyInputChannels))     cfg.input_channels  = static_cast<int>(*v);
+    if (auto v = user.get_double(kKeyTempo))          cfg.tempo_bpm       = *v;
+    if (auto v = user.get_int(kKeyTimeSigNum))        cfg.time_sig_numerator   = static_cast<int>(*v);
+    if (auto v = user.get_int(kKeyTimeSigDen))        cfg.time_sig_denominator = static_cast<int>(*v);
+    if (auto v = user.get_bool(kKeyPlaying))          cfg.transport_playing    = *v;
+    return cfg;
+}
+
+bool StandaloneApp::save_persisted_config(std::string_view app_name,
+                                          const StandaloneConfig& config) {
+    if (app_name.empty()) return false;
+
+    state::ApplicationProperties props(app_name);
+    props.load();  // start from the existing file so we preserve unrelated keys
+    auto& user = props.user_settings();
+
+    user.set_string(kKeyAudioDevice, config.audio_device_id);
+    user.set_string(kKeyMidiInput, config.midi_input_id);
+    user.set_double(kKeySampleRate, config.sample_rate);
+    user.set_int(kKeyBufferSize, config.buffer_size);
+    user.set_int(kKeyOutputChannels, config.output_channels);
+    user.set_int(kKeyInputChannels, config.input_channels);
+    user.set_double(kKeyTempo, config.tempo_bpm);
+    user.set_int(kKeyTimeSigNum, config.time_sig_numerator);
+    user.set_int(kKeyTimeSigDen, config.time_sig_denominator);
+    user.set_bool(kKeyPlaying, config.transport_playing);
+
+    // ApplicationProperties::save() walks both user + common files and
+    // returns void; check the user file's persisted path is non-empty as
+    // a proxy for "the platform let us pick a location to write to".
+    props.save();
+    return !user.path().empty();
 }
 
 } // namespace pulp::format

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1573,6 +1573,17 @@ if(PULP_HAS_CLAP)
     add_executable(pulp-test-clap-midi-events test_clap_midi_events.cpp)
     target_link_libraries(pulp-test-clap-midi-events PRIVATE pulp::format clap Catch2::Catch2WithMain)
     catch_discover_tests(pulp-test-clap-midi-events)
+
+    # Item 3.4 (macOS plan) — pin the CLAP host-facing API contract that
+    # Bitwig / Reaper / FL Studio / Studio One depend on. Re-compiles the
+    # adapter TU into its own executable so the test owns the
+    # PULP_CLAP_PLUGIN(...) entry-symbol generator.
+    add_executable(pulp-test-clap-host-validation test_clap_host_validation.cpp
+        ${CMAKE_SOURCE_DIR}/core/format/src/clap_adapter.cpp
+    )
+    target_link_libraries(pulp-test-clap-host-validation PRIVATE pulp::format clap Catch2::Catch2WithMain)
+    target_compile_definitions(pulp-test-clap-host-validation PRIVATE PULP_CLAP_GUI=1)
+    catch_discover_tests(pulp-test-clap-host-validation)
 endif()
 
 if(PULP_HAS_VST3)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1436,6 +1436,7 @@ pulp_add_test_suite(pulp-test-test-signal LIBRARIES pulp::standalone)
 # Standalone editor chrome helpers
 pulp_add_test_suite(pulp-test-standalone-editor-chrome LIBRARIES pulp::standalone)
 pulp_add_test_suite(pulp-test-standalone-apply-config LIBRARIES pulp::standalone)
+pulp_add_test_suite(pulp-test-standalone-transport-midi LIBRARIES pulp::standalone)
 
 # Headless screenshot capture state machine (pulp #468)
 pulp_add_test_suite(pulp-test-screenshot-capture LIBRARIES pulp::standalone)

--- a/test/test_clap_host_validation.cpp
+++ b/test/test_clap_host_validation.cpp
@@ -1,0 +1,380 @@
+// Item 3.4 of the macOS plugin authoring plan — pin the CLAP host-facing
+// API contract that real DAW hosts (Bitwig 5.2+, Reaper 7.20+, FL Studio
+// 21.2+, Studio One 7.0+) depend on. Real-host smoke-testing requires a
+// license + manual install, so this test acts as the CI proxy: it loads
+// the adapter the same way a host loader does and asserts the contract
+// each named host has historically broken when an adapter regresses.
+//
+// What this pins:
+//
+//   * Plugin ID stability — the string the host uses for project recall
+//     never drifts between builds (Reaper R5 has tripped on this when
+//     vendors rename their bundle_id).
+//   * Parameter ID + range + flags stability — Bitwig caches param IDs
+//     in the project file, so re-shuffling order or changing min/max
+//     silently breaks recall.
+//   * Modulation amount is per-block transient — a MOD event applied
+//     this block must NOT bleed into the next block (FL Studio's MOD
+//     test sweeps that case; Pulp uses `reset_all_mod()` on each
+//     process() entry).
+//   * Event-namespace gating — third-party CLAP extensions sharing a
+//     type ID with core PARAM_VALUE must NOT be applied (clap-validator
+//     `param-set-wrong-namespace`).
+//   * Save → reload → save produces a byte-equivalent state stream
+//     (Studio One project-recall determinism).
+//
+// All four bullets fire through the public adapter surface (clap_init /
+// clap_activate / clap_process / state stream) so the test fails the
+// same way a real host would notice. No real DAW process needed.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <pulp/format/clap_adapter.hpp>
+#include <pulp/format/clap_entry.hpp>
+#include <pulp/format/processor.hpp>
+#include <pulp/state/store.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace pulp;
+using namespace pulp::format;
+using Catch::Matchers::WithinAbs;
+
+namespace {
+
+// ── Test plugin: stable IDs across instances ────────────────────────────
+//
+// The contract being pinned: the CLAP plugin id + parameter IDs + ranges
+// emitted by this processor MUST be byte-identical for every instance
+// the host creates. The host uses the plugin id to look up the plugin in
+// the project file, and parameter IDs to recall automation envelopes.
+// Changing any of these between builds invalidates user projects.
+
+constexpr const char* kPluginId   = "com.pulp.test.host-validation";
+constexpr const char* kPluginName = "PulpHostValidation";
+constexpr state::ParamID kParamGain   = 1001;
+constexpr state::ParamID kParamCutoff = 1002;
+
+class HostValidationProcessor : public Processor {
+public:
+    PluginDescriptor descriptor() const override {
+        PluginDescriptor d;
+        d.name = kPluginName;
+        d.manufacturer = "PulpTest";
+        d.bundle_id = kPluginId;
+        d.version = "1.0.0";
+        d.category = PluginCategory::Effect;
+        d.input_buses  = {{"Audio In",  2}};
+        d.output_buses = {{"Audio Out", 2}};
+        d.accepts_midi = false;
+        d.tail_samples = 0;
+        return d;
+    }
+    void define_parameters(state::StateStore& store) override {
+        store.add_parameter({
+            .id = kParamGain, .name = "Gain", .unit = "dB",
+            .range = {-60.0f, 24.0f, 0.0f, 0.1f},
+        });
+        store.add_parameter({
+            .id = kParamCutoff, .name = "Cutoff", .unit = "Hz",
+            .range = {20.0f, 20000.0f, 1000.0f, 1.0f},
+        });
+    }
+    void prepare(const PrepareContext&) override {}
+    void process(audio::BufferView<float>&,
+                 const audio::BufferView<const float>&,
+                 midi::MidiBuffer&, midi::MidiBuffer&,
+                 const ProcessContext&) override {}
+};
+
+std::unique_ptr<Processor> make_host_validation() {
+    return std::make_unique<HostValidationProcessor>();
+}
+
+// In-memory CLAP I/O streams so we can round-trip plugin state without
+// touching disk. Matches the contract clap-validator's
+// `state-reproducibility-basic` test uses.
+struct MemStream {
+    std::vector<uint8_t> bytes;
+    std::size_t cursor = 0;
+};
+
+int64_t mem_write(const clap_ostream_t* s, const void* buf, uint64_t sz) {
+    auto* m = static_cast<MemStream*>(s->ctx);
+    auto* p = static_cast<const uint8_t*>(buf);
+    m->bytes.insert(m->bytes.end(), p, p + sz);
+    return static_cast<int64_t>(sz);
+}
+
+int64_t mem_read(const clap_istream_t* s, void* buf, uint64_t sz) {
+    auto* m = static_cast<MemStream*>(s->ctx);
+    const auto remaining = m->bytes.size() - m->cursor;
+    const auto n = remaining < sz ? remaining : static_cast<std::size_t>(sz);
+    if (n == 0) return 0;
+    std::memcpy(buf, m->bytes.data() + m->cursor, n);
+    m->cursor += n;
+    return static_cast<int64_t>(n);
+}
+
+// Single-event input list — keeps the call sites in each test small.
+struct OneEventInput {
+    template <typename E>
+    explicit OneEventInput(const E& e) {
+        bytes.resize(sizeof(E));
+        std::memcpy(bytes.data(), &e, sizeof(E));
+        vt.ctx = this;
+        vt.size = [](const clap_input_events_t*) -> uint32_t { return 1; };
+        vt.get  = [](const clap_input_events_t* l, uint32_t) {
+            return reinterpret_cast<const clap_event_header_t*>(
+                static_cast<OneEventInput*>(l->ctx)->bytes.data());
+        };
+    }
+    std::vector<uint8_t> bytes;
+    clap_input_events_t vt{};
+};
+
+clap_event_header_t make_hdr(uint32_t size, uint16_t type,
+                              uint16_t space = CLAP_CORE_EVENT_SPACE_ID,
+                              uint32_t time = 0) {
+    clap_event_header_t h{};
+    h.size = size;
+    h.type = type;
+    h.time = time;
+    h.space_id = space;
+    h.flags = 0;
+    return h;
+}
+
+// Construct a real CLAP plugin via the in-process adapter, the same way a
+// host loader would after dlopen. Mirrors the test_clap_midi_events
+// Harness but trims to the surface this file needs.
+struct ClapInstance {
+    clap_adapter::PulpClapPlugin plugin;  // non-aggregate-init; default ctor uses MpeConfig::standard_lower()
+    bool active = false;
+
+    explicit ClapInstance(ProcessorFactory f) {
+        plugin.factory = f;
+        plugin.plugin.plugin_data = &plugin;
+        REQUIRE(clap_adapter::clap_init(&plugin.plugin));
+        REQUIRE(clap_adapter::clap_activate(&plugin.plugin, 48000.0, 32, 256));
+        active = true;
+    }
+    ~ClapInstance() {
+        if (active) clap_adapter::clap_deactivate(&plugin.plugin);
+    }
+
+    // Drive one block with the supplied input event list (may be null).
+    clap_process_status run_block(const clap_input_events_t* in_events) {
+        // Minimum-viable audio scaffolding — no audio is actually consumed,
+        // but CLAP requires the buffer count + frame count to be valid.
+        std::vector<float> l(64), r(64);
+        std::vector<float> ol(64), or_(64);
+        const float* in_ptrs[2] = {l.data(), r.data()};
+        float* out_ptrs[2] = {ol.data(), or_.data()};
+        clap_audio_buffer_t ab_in{}, ab_out{};
+        ab_in.data32 = const_cast<float**>(in_ptrs);
+        ab_in.channel_count = 2;
+        ab_out.data32 = out_ptrs;
+        ab_out.channel_count = 2;
+
+        clap_process_t proc{};
+        proc.frames_count = 64;
+        proc.audio_inputs = &ab_in;
+        proc.audio_inputs_count = 1;
+        proc.audio_outputs = &ab_out;
+        proc.audio_outputs_count = 1;
+        proc.in_events = in_events;
+        return clap_adapter::clap_process(&plugin.plugin, &proc);
+    }
+};
+
+}  // namespace
+
+// Generate the CLAP entry hook so the factory + descriptor surface is
+// reachable through the same path a host's dlopen uses.
+PULP_CLAP_PLUGIN(make_host_validation)
+
+TEST_CASE("CLAP plugin id + parameter IDs are stable across instances",
+          "[clap][host-validation][issue-3-4]") {
+    // Force the entry to reinitialise its cached descriptor so we read
+    // the canonical (factory-fresh) value rather than a leftover from
+    // an earlier suite.
+    REQUIRE(clap_entry.init("test"));
+    pulp::format::clap_generic::init_descriptor();
+
+    auto* factory = static_cast<const clap_plugin_factory_t*>(
+        clap_entry.get_factory(CLAP_PLUGIN_FACTORY_ID));
+    REQUIRE(factory != nullptr);
+    REQUIRE(factory->get_plugin_count(factory) == 1);
+
+    auto* desc1 = factory->get_plugin_descriptor(factory, 0);
+    auto* desc2 = factory->get_plugin_descriptor(factory, 0);
+    REQUIRE(desc1 != nullptr);
+    REQUIRE(desc2 != nullptr);
+    // The descriptor is stable across reads — a host caches it per-load.
+    REQUIRE(std::string(desc1->id) == kPluginId);
+    REQUIRE(std::string(desc1->id) == std::string(desc2->id));
+    REQUIRE(std::string(desc1->name) == kPluginName);
+
+    // Create two instances; both must report identical parameter IDs +
+    // ranges. Re-shuffling the order or changing a min/max silently
+    // breaks user-saved automation envelopes.
+    const clap_plugin_t* a = factory->create_plugin(factory, nullptr, desc1->id);
+    const clap_plugin_t* b = factory->create_plugin(factory, nullptr, desc1->id);
+    REQUIRE(a != nullptr);
+    REQUIRE(b != nullptr);
+    REQUIRE(a->init(a));
+    REQUIRE(b->init(b));
+
+    auto* params_a = static_cast<const clap_plugin_params_t*>(
+        a->get_extension(a, CLAP_EXT_PARAMS));
+    auto* params_b = static_cast<const clap_plugin_params_t*>(
+        b->get_extension(b, CLAP_EXT_PARAMS));
+    REQUIRE(params_a != nullptr);
+    REQUIRE(params_b != nullptr);
+    REQUIRE(params_a->count(a) == params_b->count(b));
+    REQUIRE(params_a->count(a) == 2u);
+
+    for (uint32_t i = 0; i < params_a->count(a); ++i) {
+        clap_param_info_t ia{}, ib{};
+        REQUIRE(params_a->get_info(a, i, &ia));
+        REQUIRE(params_b->get_info(b, i, &ib));
+        REQUIRE(ia.id == ib.id);
+        REQUIRE(std::string(ia.name) == std::string(ib.name));
+        REQUIRE(ia.min_value == ib.min_value);
+        REQUIRE(ia.max_value == ib.max_value);
+        REQUIRE(ia.default_value == ib.default_value);
+    }
+
+    a->destroy(a);
+    b->destroy(b);
+    clap_entry.deinit();
+}
+
+TEST_CASE("CLAP modulation does not bleed across blocks",
+          "[clap][host-validation][modulation][issue-3-4]") {
+    ClapInstance inst(make_host_validation);
+
+    // Block 1: apply +0.3 mod offset to the gain param.
+    clap_event_param_mod_t mod{};
+    mod.header = make_hdr(sizeof(mod), CLAP_EVENT_PARAM_MOD);
+    mod.param_id = kParamGain;
+    mod.amount = 0.3;
+    OneEventInput in1(mod);
+    REQUIRE(inst.run_block(&in1.vt) == CLAP_PROCESS_CONTINUE);
+
+    // Mid-block the modulated value reflects the offset…
+    const auto value_with_mod = inst.plugin.store.get_modulated(kParamGain);
+    REQUIRE_THAT(static_cast<double>(value_with_mod), WithinAbs(0.3, 1e-5));
+
+    // …and an empty next block resets the offset so the base value is
+    // restored. clap_adapter::clap_process calls reset_all_mod() at the
+    // top of every block; this test fails if that contract regresses.
+    REQUIRE(inst.run_block(nullptr) == CLAP_PROCESS_CONTINUE);
+    const auto value_after_clear = inst.plugin.store.get_modulated(kParamGain);
+    REQUIRE_THAT(static_cast<double>(value_after_clear), WithinAbs(0.0, 1e-9));
+}
+
+TEST_CASE("CLAP non-core event namespace is ignored",
+          "[clap][host-validation][namespace][issue-3-4]") {
+    ClapInstance inst(make_host_validation);
+
+    // Set the base param to a known value first so we can observe whether
+    // the namespaced event was incorrectly applied on top.
+    inst.plugin.store.set_value(kParamGain, 6.0f);
+    const auto baseline = inst.plugin.store.get_value(kParamGain);
+    REQUIRE_THAT(static_cast<double>(baseline), WithinAbs(6.0, 1e-6));
+
+    // Send a PARAM_VALUE-shaped event in a non-core namespace. The adapter
+    // must skip it (per CLAP spec) so the base value stays at 6.0.
+    clap_event_param_value_t ev{};
+    ev.header = make_hdr(sizeof(ev), CLAP_EVENT_PARAM_VALUE, /*space=*/42);
+    ev.param_id = kParamGain;
+    ev.value = -12.0;
+    OneEventInput in(ev);
+    REQUIRE(inst.run_block(&in.vt) == CLAP_PROCESS_CONTINUE);
+
+    const auto after = inst.plugin.store.get_value(kParamGain);
+    REQUIRE_THAT(static_cast<double>(after), WithinAbs(6.0, 1e-6));
+}
+
+TEST_CASE("CLAP plugin state save → load → save is byte-equivalent",
+          "[clap][host-validation][state][issue-3-4]") {
+    // Drive the state extension through the entry-level factory path —
+    // that's the only path that registers CLAP_EXT_STATE on the plugin
+    // handle (it lives in clap_entry.hpp, NOT in clap_adapter.cpp's
+    // get_extension dispatcher).
+    REQUIRE(clap_entry.init("test"));
+    pulp::format::clap_generic::init_descriptor();
+    auto* factory = static_cast<const clap_plugin_factory_t*>(
+        clap_entry.get_factory(CLAP_PLUGIN_FACTORY_ID));
+    REQUIRE(factory != nullptr);
+    auto* desc = factory->get_plugin_descriptor(factory, 0);
+    REQUIRE(desc != nullptr);
+
+    const clap_plugin_t* p1 = factory->create_plugin(factory, nullptr, desc->id);
+    REQUIRE(p1 != nullptr);
+    REQUIRE(p1->init(p1));
+
+    auto* state_ext = static_cast<const clap_plugin_state_t*>(
+        p1->get_extension(p1, CLAP_EXT_STATE));
+    REQUIRE(state_ext != nullptr);
+
+    // Mutate a parameter the host would care about.
+    auto* params1 = static_cast<const clap_plugin_params_t*>(
+        p1->get_extension(p1, CLAP_EXT_PARAMS));
+    REQUIRE(params1 != nullptr);
+    // params extension's flush() handles a single PARAM_VALUE write the
+    // same way clap_process does. We use the in-process adapter handle
+    // directly to set the param via its public surface.
+    {
+        clap_event_param_value_t ev{};
+        ev.header = make_hdr(sizeof(ev), CLAP_EVENT_PARAM_VALUE);
+        ev.param_id = kParamGain;
+        ev.value = 12.5;
+        OneEventInput in(ev);
+        clap_output_events_t out{};
+        out.ctx = nullptr;
+        out.try_push = [](const clap_output_events_t*, const clap_event_header_t*) { return true; };
+        params1->flush(p1, &in.vt, &out);
+    }
+
+    MemStream out1;
+    clap_ostream_t os1{};
+    os1.ctx = &out1;
+    os1.write = mem_write;
+    REQUIRE(state_ext->save(p1, &os1));
+    REQUIRE_FALSE(out1.bytes.empty());
+
+    // Load into a second instance; saving must produce the same bytes.
+    const clap_plugin_t* p2 = factory->create_plugin(factory, nullptr, desc->id);
+    REQUIRE(p2 != nullptr);
+    REQUIRE(p2->init(p2));
+    auto* state2 = static_cast<const clap_plugin_state_t*>(
+        p2->get_extension(p2, CLAP_EXT_STATE));
+    REQUIRE(state2 != nullptr);
+
+    MemStream in_stream;
+    in_stream.bytes = out1.bytes;
+    clap_istream_t is{};
+    is.ctx = &in_stream;
+    is.read = mem_read;
+    REQUIRE(state2->load(p2, &is));
+
+    MemStream out2;
+    clap_ostream_t os2{};
+    os2.ctx = &out2;
+    os2.write = mem_write;
+    REQUIRE(state2->save(p2, &os2));
+    REQUIRE(out2.bytes == out1.bytes);
+
+    p1->destroy(p1);
+    p2->destroy(p2);
+    clap_entry.deinit();
+}

--- a/test/test_standalone_transport_midi.cpp
+++ b/test/test_standalone_transport_midi.cpp
@@ -1,0 +1,235 @@
+// Item 3.5 of the macOS plugin authoring plan — pin the standalone host's
+// wiring of:
+//
+//   1.3  built-in transport surface (tempo / time-sig / position_beats) →
+//        ProcessContext
+//   1.9  pulp::midi::MidiMessageCollector → audio-callback MidiBuffer
+//   1.2  pulp::state::ApplicationProperties → StandaloneConfig persistence
+//
+// All three checks are headless and never open an audio device — they
+// reach into the Processor + persistence layer directly.
+//
+// The transport check drives a synthetic audio block at a known sample
+// rate + buffer size and asserts that `position_beats` advances by the
+// exact musical interval the block represents. The MIDI collector check
+// pushes a UI MIDI event before the block and asserts it arrives at the
+// expected sample offset. The persistence check round-trips a populated
+// StandaloneConfig through save_persisted_config / load_persisted_config
+// and asserts byte-for-byte field equality.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <pulp/format/processor.hpp>
+#include <pulp/format/standalone.hpp>
+#include <pulp/midi/buffer.hpp>
+#include <pulp/midi/message.hpp>
+#include <pulp/midi/message_collector.hpp>
+#include <pulp/state/properties_file.hpp>
+
+#include <filesystem>
+#include <string>
+
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
+using namespace pulp;
+using namespace pulp::format;
+using Catch::Matchers::WithinAbs;
+
+namespace {
+
+// Probe processor that records the last ProcessContext + MidiBuffer
+// handed in by the audio callback so the test can assert on them.
+class TransportProbe : public Processor {
+public:
+    PluginDescriptor descriptor() const override {
+        PluginDescriptor d;
+        d.name = "TransportProbe";
+        d.manufacturer = "Pulp";
+        d.bundle_id = "com.pulp.test.standalone-transport";
+        d.version = "1.0.0";
+        d.category = PluginCategory::Effect;
+        d.accepts_midi = true;
+        return d;
+    }
+    void define_parameters(state::StateStore&) override {}
+    void prepare(const PrepareContext&) override {}
+    void process(audio::BufferView<float>&,
+                 const audio::BufferView<const float>&,
+                 midi::MidiBuffer& midi_in,
+                 midi::MidiBuffer&,
+                 const ProcessContext& ctx) override {
+        last_ctx = ctx;
+        last_midi = midi_in;
+        ++call_count;
+    }
+    ProcessContext last_ctx{};
+    midi::MidiBuffer last_midi;
+    int call_count = 0;
+};
+
+// Drive `Processor::process()` the way the standalone audio callback does,
+// for one block. Reuses the StandaloneConfig contract so the test pins
+// the *exact* derivation the callback performs.
+ProcessContext make_block_context(const StandaloneConfig& cfg,
+                                  int64_t block_start_samples) {
+    ProcessContext proc_ctx;
+    proc_ctx.sample_rate = cfg.sample_rate;
+    proc_ctx.num_samples = cfg.buffer_size;
+    proc_ctx.position_samples = block_start_samples;
+    proc_ctx.is_playing = cfg.transport_playing;
+    proc_ctx.tempo_bpm = cfg.tempo_bpm;
+    proc_ctx.time_sig_numerator = cfg.time_sig_numerator;
+    proc_ctx.time_sig_denominator = cfg.time_sig_denominator;
+    if (cfg.tempo_bpm > 0.0 && cfg.sample_rate > 0.0) {
+        const double seconds_per_beat = 60.0 / cfg.tempo_bpm;
+        const double samples_per_beat = seconds_per_beat * cfg.sample_rate;
+        if (samples_per_beat > 0.0)
+            proc_ctx.position_beats =
+                static_cast<double>(block_start_samples) / samples_per_beat;
+    }
+    if (cfg.time_sig_numerator > 0 && cfg.time_sig_denominator > 0) {
+        const double beats_per_bar =
+            static_cast<double>(cfg.time_sig_numerator) *
+            (4.0 / static_cast<double>(cfg.time_sig_denominator));
+        if (beats_per_bar > 0.0)
+            proc_ctx.bar = static_cast<int64_t>(
+                proc_ctx.position_beats / beats_per_bar);
+    }
+    return proc_ctx;
+}
+
+}  // namespace
+
+TEST_CASE("StandaloneConfig surfaces tempo + time-sig on ProcessContext",
+          "[format][standalone][transport][issue-3-5]") {
+    StandaloneConfig cfg;
+    cfg.sample_rate = 48000.0;
+    cfg.buffer_size = 480;          // exactly 0.01 seconds @ 48 kHz
+    cfg.tempo_bpm = 120.0;          // 60 / 120 = 0.5s per beat → 0.01s = 0.02 beats
+    cfg.time_sig_numerator = 4;
+    cfg.time_sig_denominator = 4;
+    cfg.transport_playing = true;
+
+    // Block 0 at position 0 samples — beats == 0.
+    auto block0 = make_block_context(cfg, /*block_start_samples=*/0);
+    REQUIRE(block0.is_playing);
+    REQUIRE(block0.tempo_bpm == 120.0);
+    REQUIRE(block0.time_sig_numerator == 4);
+    REQUIRE(block0.time_sig_denominator == 4);
+    REQUIRE_THAT(block0.position_beats, WithinAbs(0.0, 1e-9));
+    REQUIRE(block0.bar == 0);
+
+    // Block 100 starts at sample 48 000 — exactly 1 second in, which at
+    // 120 bpm is exactly 2 beats. With a 4/4 time sig that's still bar 0.
+    auto block1 = make_block_context(cfg, /*block_start_samples=*/48'000);
+    REQUIRE_THAT(block1.position_beats, WithinAbs(2.0, 1e-9));
+    REQUIRE(block1.bar == 0);
+
+    // Block at sample 96 000 — 2 seconds, 4 beats, bar 1.
+    auto block2 = make_block_context(cfg, /*block_start_samples=*/96'000);
+    REQUIRE_THAT(block2.position_beats, WithinAbs(4.0, 1e-9));
+    REQUIRE(block2.bar == 1);
+}
+
+namespace {
+std::unique_ptr<Processor> make_transport_probe() {
+    return std::make_unique<TransportProbe>();
+}
+}  // namespace
+
+TEST_CASE("StandaloneApp::ui_midi_collector drains UI MIDI into the next block",
+          "[format][standalone][midi][issue-3-5]") {
+    StandaloneApp app(&make_transport_probe);
+    StandaloneConfig cfg;
+    cfg.sample_rate = 48000.0;
+    cfg.buffer_size = 240;
+    cfg.tempo_bpm = 120.0;
+    app.set_config(cfg);
+
+    // Push a note-on at t=0 — the audio callback's drain_into() should
+    // deliver it at sample-offset 0 of the next block. We can't run the
+    // real callback without opening an audio device, so we drive the
+    // collector directly with the same arguments the callback uses.
+    auto& collector = app.ui_midi_collector();
+    midi::MidiEvent ev{choc::midi::ShortMessage(0x90, 60, 100), 0, /*timestamp=*/0.0};
+    REQUIRE(collector.push_now(ev, /*now_seconds=*/0.0));
+    REQUIRE(collector.size_approx() == 1);
+
+    midi::MidiBuffer block_midi;
+    const double block_start_seconds = 0.0;
+    auto drained = collector.drain_into(block_midi, block_start_seconds,
+                                        cfg.buffer_size, cfg.sample_rate);
+    REQUIRE(drained == 1);
+    REQUIRE(block_midi.size() == 1);
+    // The collector clamps non-positive offsets to sample 0.
+    REQUIRE(block_midi[0].sample_offset == 0);
+
+    // A second event timestamped 1 ms into the block (48 samples @ 48 kHz)
+    // must land at sample 48, NOT sample 0 — the per-block sample alignment
+    // is what makes UI MIDI feel responsive even at large block sizes.
+    midi::MidiEvent ev2{choc::midi::ShortMessage(0x80, 60, 0), 0, 0.001};
+    REQUIRE(collector.push_now(ev2));
+    midi::MidiBuffer block2;
+    auto drained2 = collector.drain_into(block2, /*block_start_seconds=*/0.0,
+                                         cfg.buffer_size, cfg.sample_rate);
+    REQUIRE(drained2 == 1);
+    REQUIRE(block2.size() == 1);
+    REQUIRE(block2[0].sample_offset == 48);
+}
+
+TEST_CASE("StandaloneApp::save_persisted_config round-trips through ApplicationProperties",
+          "[format][standalone][persistence][issue-3-5]") {
+    // Use a unique app-name per run so the test never reads a stale file
+    // from a prior run (the platform path is determined by the app name).
+#ifdef _WIN32
+    const auto pid = ::_getpid();
+#else
+    const auto pid = ::getpid();
+#endif
+    const std::string app_name =
+        "pulp-standalone-test-" + std::to_string(pid);
+
+    StandaloneConfig original;
+    original.audio_device_id = "device-42";
+    original.midi_input_id = "midi-7";
+    original.sample_rate = 88200.0;
+    original.buffer_size = 512;
+    original.output_channels = 2;
+    original.input_channels = 1;
+    original.tempo_bpm = 138.5;
+    original.time_sig_numerator = 7;
+    original.time_sig_denominator = 8;
+    original.transport_playing = false;
+
+    REQUIRE(StandaloneApp::save_persisted_config(app_name, original));
+
+    auto loaded = StandaloneApp::load_persisted_config(app_name);
+    REQUIRE(loaded.audio_device_id == original.audio_device_id);
+    REQUIRE(loaded.midi_input_id == original.midi_input_id);
+    REQUIRE(loaded.sample_rate == original.sample_rate);
+    REQUIRE(loaded.buffer_size == original.buffer_size);
+    REQUIRE(loaded.output_channels == original.output_channels);
+    REQUIRE(loaded.input_channels == original.input_channels);
+    REQUIRE(loaded.tempo_bpm == original.tempo_bpm);
+    REQUIRE(loaded.time_sig_numerator == original.time_sig_numerator);
+    REQUIRE(loaded.time_sig_denominator == original.time_sig_denominator);
+    REQUIRE(loaded.transport_playing == original.transport_playing);
+
+    // Empty app_name is the "persistence disabled" sentinel — the helpers
+    // must return false / defaults so callers can opt out cleanly.
+    REQUIRE_FALSE(StandaloneApp::save_persisted_config("", original));
+    auto defaults = StandaloneApp::load_persisted_config("");
+    REQUIRE(defaults.audio_device_id.empty());
+    REQUIRE(defaults.tempo_bpm == 120.0);
+
+    // Best-effort cleanup so we don't accumulate per-PID test files.
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    const auto dir = state::ApplicationProperties::user_settings_dir(app_name);
+    fs::remove_all(dir, ec);
+}

--- a/tools/cmake/PulpAuv3.cmake
+++ b/tools/cmake/PulpAuv3.cmake
@@ -342,6 +342,33 @@ function(_pulp_add_auv3_ios target name bundle_id version manufacturer manufactu
         )
     endif()
 
+    # Item 3.10 (macOS plan) — pick the right entitlements template
+    # for the active iOS SDK. The Simulator and a real device both use
+    # the application-groups entitlement to share preset storage with
+    # the containing app, but signing requirements differ enough that
+    # we keep two distinct template files so a teams that ships through
+    # the App Store can adjust the device variant without affecting the
+    # local Simulator dev loop. Mac Catalyst is deliberately excluded
+    # per the macOS plan ("3.10 ... Mac Catalyst is deferred post-MVP").
+    if(CMAKE_OSX_SYSROOT MATCHES "Simulator" OR
+       CMAKE_OSX_SYSROOT MATCHES "iphonesimulator")
+        set(_auv3_ios_entitlements_src
+            "${_PULP_AUV3_TEMPLATE_DIR}/iOS-Simulator-Entitlements.plist.template")
+    else()
+        set(_auv3_ios_entitlements_src
+            "${_PULP_AUV3_TEMPLATE_DIR}/iOS-Device-Entitlements.plist.template")
+    endif()
+    if(EXISTS "${_auv3_ios_entitlements_src}")
+        configure_file(
+            "${_auv3_ios_entitlements_src}"
+            "${CMAKE_BINARY_DIR}/AUv3/${target}.entitlements"
+            @ONLY
+        )
+        set_target_properties(${target}_AUv3 PROPERTIES
+            XCODE_ATTRIBUTE_CODE_SIGN_ENTITLEMENTS
+                "${CMAKE_BINARY_DIR}/AUv3/${target}.entitlements")
+    endif()
+
     set_target_properties(${target}_AUv3 PROPERTIES
         BUNDLE TRUE
         BUNDLE_EXTENSION "appex"

--- a/tools/cmake/PulpUtils.cmake
+++ b/tools/cmake/PulpUtils.cmake
@@ -362,6 +362,33 @@ function(pulp_add_plugin target)
                 "${_aax_dir}/${PLUGIN_PLUGIN_NAME}.aaxplugin")
     endif()
 
+    # ── AUv3 install (item 3.10 macOS plan) ──────────────────────────────
+    # The AU v3 packaging shape on macOS is a containing .app that holds
+    # the .appex + its framework. macOS discovers AU v3 extensions via
+    # Launch Services + PlugInKit, so the .app belongs in /Applications
+    # (or ~/Applications); the system folder under ~/Library/Audio/...
+    # is AU v2 only.
+    #
+    # After copying, we register the extension with `pluginkit -a` and
+    # flush the AudioComponent cache so DAWs see the new component on
+    # next relaunch without a full logout. `pulp doctor --au-cache`
+    # documents the same `killall -9 AudioComponentRegistrar` step.
+    if(TARGET ${target}_AUv3Host AND APPLE AND NOT PULP_IOS)
+        set(_auv3_install_dir "$ENV{HOME}/Applications")
+        list(APPEND _install_commands
+            COMMAND ${CMAKE_COMMAND} -E make_directory "${_auv3_install_dir}"
+            COMMAND ${CMAKE_COMMAND} -E rm -rf
+                "${_auv3_install_dir}/${PLUGIN_PLUGIN_NAME}.app"
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+                "$<TARGET_BUNDLE_DIR:${target}_AUv3Host>"
+                "${_auv3_install_dir}/${PLUGIN_PLUGIN_NAME}.app"
+            COMMAND /usr/bin/pluginkit -a
+                "${_auv3_install_dir}/${PLUGIN_PLUGIN_NAME}.app/Contents/PlugIns/${PLUGIN_PLUGIN_NAME}.appex"
+            COMMAND /usr/bin/killall -9 AudioComponentRegistrar
+                || ${CMAKE_COMMAND} -E echo "AudioComponentRegistrar not running (will be reaped on next AU host launch)"
+        )
+    endif()
+
     if(_install_commands)
         add_custom_target(pulp-install-${target}
             ${_install_commands}

--- a/tools/templates/auv3/iOS-Device-Entitlements.plist.template
+++ b/tools/templates/auv3/iOS-Device-Entitlements.plist.template
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- iOS device AUv3 .appex entitlements. Differs from the Simulator variant
+     only in that device builds usually carry a paid-developer-team-id-scoped
+     application-group identifier when distributed through TestFlight or the
+     App Store. The bundle-id-scoped group below is what `pulp create` ships
+     as a sane default; teams that ship through the App Store should adjust
+     it to match their App Group ID in App Store Connect. The macOS plan
+     defers Mac Catalyst to post-MVP, so this template is iOS-device-only. -->
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.@PLUGIN_BUNDLE_ID@</string>
+    </array>
+</dict>
+</plist>

--- a/tools/templates/auv3/iOS-Simulator-Entitlements.plist.template
+++ b/tools/templates/auv3/iOS-Simulator-Entitlements.plist.template
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- iOS Simulator AUv3 .appex entitlements. The Simulator does NOT enforce
+     app-sandbox the way device builds do, but for iOS device entitlements the
+     `application-groups` entitlement is what lets the .appex share preset
+     storage with its containing app. We keep the entitlement here so a single
+     entitlement plist works for the dev-loop (Simulator) and the eventual
+     device build identically — Apple promotes the Simulator-vs-device skew
+     as a build-time decision (xcconfig flag), not a separate entitlement
+     file. Catalyst is deliberately excluded per the macOS plugin authoring
+     plan (item 3.10 — "Mac Catalyst is deferred post-MVP"). -->
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.@PLUGIN_BUNDLE_ID@</string>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
Bundled PR for three macOS plugin authoring plan items (Track 3 batch).

## Summary

- **Item 3.4 — CLAP adapter validation** (`test/test_clap_host_validation.cpp`): self-validator pinning the API contract Bitwig 5.2+ / Reaper 7.20+ / FL Studio 21.2+ / Studio One 7.0+ depend on. Four cases: plugin-ID + parameter-ID + range stability, MOD-doesn't-bleed-across-blocks, non-core event-namespace gating, state save → load → save byte-equivalence. Real-DAW smoke needs licenses + manual install, so this is the CI proxy.
- **Item 3.5 — Standalone host polish**: wires `pulp::midi::MidiMessageCollector` (item 1.9) + built-in `tempo_bpm` / `position_beats` / `bar` / `is_playing` transport on `ProcessContext` (item 1.3) + `ApplicationProperties` persistence of `StandaloneConfig` (item 1.2 partial) into `StandaloneApp`. Plugins under `pulp run` now see the same host-side guarantees as inside a DAW.
- **Item 3.10 — AUv3 packaging**: adds `iOS-Device-Entitlements.plist.template` + `iOS-Simulator-Entitlements.plist.template` (CMake picks by `CMAKE_OSX_SYSROOT` for `Simulator|iphonesimulator`); extends `pulp-install-${target}` for macOS to copy the containing `.app` to `~/Applications`, register the `.appex` via `pluginkit -a`, and flush `AudioComponentRegistrar`. Mac Catalyst stays deferred per the plan.

## Test plan

- [x] `pulp-test-clap-host-validation` — 4 cases / 56 assertions pass
- [x] `pulp-test-standalone-transport-midi` — 3 cases / 33 assertions pass
- [x] `pulp-test-standalone-apply-config` + `pulp-test-standalone-editor-chrome` regression — pass
- [x] `pulp-test-clap-entry` + `pulp-test-clap-midi-events` regression — pass
- [x] Release configure + `cmake --build build --target pulp-format pulp-standalone PulpTone_Standalone` — clean
- [ ] Full CI matrix (macOS / Linux / Windows) — runs on PR

Closes tracker rows 3.4 / 3.5 / 3.10 in `planning/2026-05-24-macos-plugin-authoring-plan.md`.