### PR TITLE
feat(format): wire item-1.3 AudioPlayHead transport extensions into every adapter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.248.0
+    VERSION 0.249.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/au_v2_adapter.hpp
+++ b/core/format/include/pulp/format/au_v2_adapter.hpp
@@ -3,6 +3,7 @@
 #include <AudioUnitSDK/AUMIDIEffectBase.h>
 
 #include <pulp/format/processor.hpp>
+#include <pulp/format/detail/playhead_diff.hpp>
 #include <pulp/midi/buffer.hpp>
 #include <pulp/midi/message.hpp>
 
@@ -141,6 +142,13 @@ private:
     // Pre-process snapshot of parameter values; used to diff plugin-side
     // changes back to the host's parameter system (workstream 01 slice 1.3).
     std::vector<float> param_snapshot_;
+
+    // Item 1.3 — previous-block transport snapshot used to derive the
+    // change flags (tempo_changed / time_sig_changed /
+    // transport_changed) on `ProcessContext`. Default-constructed (no
+    // previous block) so the first process() call after init reports
+    // no changes.
+    detail::PlayheadSnapshot playhead_prev_{};
 
     // MIDI input path — AU v2 effects that declare accepts_midi are
     // packaged as aumf (kAudioUnitType_MusicEffect). The host then

--- a/core/format/include/pulp/format/au_v2_instrument.hpp
+++ b/core/format/include/pulp/format/au_v2_instrument.hpp
@@ -3,6 +3,7 @@
 #include <AudioUnitSDK/MusicDeviceBase.h>
 
 #include <pulp/format/processor.hpp>
+#include <pulp/format/detail/playhead_diff.hpp>
 
 #include <memory>
 #include <mutex>
@@ -60,6 +61,11 @@ private:
     std::vector<float*> output_ptrs_;
     std::mutex midi_mutex_;
     midi::MidiBuffer pending_midi_;
+
+    // Item 1.3 — previous-block transport snapshot used to derive the
+    // change flags on `ProcessContext`. Default-constructed so the
+    // first Render() call after Initialize() reports no changes.
+    detail::PlayheadSnapshot playhead_prev_{};
 };
 
 } // namespace pulp::format::au

--- a/core/format/include/pulp/format/clap_adapter.hpp
+++ b/core/format/include/pulp/format/clap_adapter.hpp
@@ -6,6 +6,7 @@
 
 #include <pulp/format/processor.hpp>
 #include <pulp/format/ara.hpp>
+#include <pulp/format/detail/playhead_diff.hpp>
 #include <pulp/state/parameter_event_queue.hpp>
 #include <pulp/state/preset_manager.hpp>
 #include <clap/clap.h>
@@ -81,6 +82,12 @@ struct PulpClapPlugin {
     std::unique_ptr<view::PluginViewHost> editor_host;
 #endif
     bool editor_visible = false;
+
+    // Item 1.3 — previous-block transport snapshot used to derive the
+    // `tempo_changed` / `time_sig_changed` / `transport_changed` flags
+    // on `ProcessContext`. Default-constructed (no previous block) so
+    // the first process() call after activation reports no changes.
+    detail::PlayheadSnapshot playhead_prev{};
 };
 
 // CLAP entry point and factory

--- a/core/format/include/pulp/format/detail/playhead_diff.hpp
+++ b/core/format/include/pulp/format/detail/playhead_diff.hpp
@@ -1,0 +1,103 @@
+#pragma once
+
+// Shared helpers for item 1.3 — AudioPlayHead transport-extension adapter wiring.
+//
+// Each format adapter (VST3, AU v2, AU v3, CLAP, AAX) populates the
+// item-1.3 fields on `ProcessContext` from its host's playhead API. The
+// derived fields — bar index from beats + time signature, and the three
+// change-flags (tempo / time-sig / transport) computed against the
+// previous block — are identical across adapters. This header factors
+// them out so each adapter just snapshots the previous block's
+// transport state and calls these helpers.
+//
+// Pure functions, header-only, no platform dependencies. Tests live in
+// `test/test_playhead_diff.cpp`.
+
+#include <pulp/format/processor.hpp>
+
+#include <cmath>
+#include <cstdint>
+
+namespace pulp::format::detail {
+
+/// Per-adapter snapshot of the transport fields that contribute to the
+/// `tempo_changed` / `time_sig_changed` / `transport_changed` flags.
+/// Adapters keep one instance as a member and pass it to
+/// `compute_playhead_changes` once per block.
+///
+/// Default-constructed = "no previous block" — `apply_first_block()`
+/// resets the snapshot in-place so the very first block does not raise
+/// spurious change flags. Subsequent blocks diff against the captured
+/// state.
+struct PlayheadSnapshot {
+    bool has_previous = false;
+    double tempo_bpm = 0.0;
+    int time_sig_numerator = 0;
+    int time_sig_denominator = 0;
+    bool is_playing = false;
+    bool is_recording = false;
+    bool is_looping = false;
+};
+
+/// Derive `ctx.bar` from `ctx.position_beats` + the active time
+/// signature, when the host does not supply a precomputed bar.
+///
+/// `bar = floor(position_beats * (time_sig_denominator / 4) /
+/// time_sig_numerator)` — matches the formula documented on
+/// `ProcessContext::bar`.
+///
+/// Adapters that already have a host-provided bar (VST3
+/// `barPositionMusic`) should write `ctx.bar` directly and skip this
+/// helper. Skips work safely when the time signature is degenerate
+/// (numerator <= 0 or denominator <= 0) by leaving `ctx.bar` at 0.
+inline void derive_bar_from_beats(ProcessContext& ctx) noexcept {
+    if (ctx.time_sig_numerator <= 0 || ctx.time_sig_denominator <= 0) {
+        ctx.bar = 0;
+        return;
+    }
+    const double beats_per_bar = static_cast<double>(ctx.time_sig_numerator) *
+                                 (4.0 / static_cast<double>(ctx.time_sig_denominator));
+    if (beats_per_bar <= 0.0) {
+        ctx.bar = 0;
+        return;
+    }
+    const double bar_d = std::floor(ctx.position_beats / beats_per_bar);
+    ctx.bar = static_cast<int64_t>(bar_d);
+}
+
+/// Compute the three change-flags by diffing `ctx` against the
+/// adapter's previous-block `snapshot`, then update the snapshot in
+/// place so the next block's diff is against the values just written.
+///
+/// First call after a default-constructed snapshot raises no change
+/// flags (the "no previous block" contract) — matches the documented
+/// default that the very first block does not falsely signal a
+/// transition. Subsequent calls flip the flags whenever any field
+/// differs from the previous block.
+inline void compute_playhead_changes(ProcessContext& ctx,
+                                     PlayheadSnapshot& snapshot) noexcept {
+    if (!snapshot.has_previous) {
+        ctx.tempo_changed = false;
+        ctx.time_sig_changed = false;
+        ctx.transport_changed = false;
+    } else {
+        ctx.tempo_changed = (ctx.tempo_bpm != snapshot.tempo_bpm);
+        ctx.time_sig_changed =
+            (ctx.time_sig_numerator != snapshot.time_sig_numerator) ||
+            (ctx.time_sig_denominator != snapshot.time_sig_denominator);
+        ctx.transport_changed =
+            (ctx.is_playing != snapshot.is_playing) ||
+            (ctx.is_recording != snapshot.is_recording) ||
+            (ctx.is_looping != snapshot.is_looping);
+    }
+
+    snapshot.has_previous = true;
+    snapshot.tempo_bpm = ctx.tempo_bpm;
+    snapshot.time_sig_numerator = ctx.time_sig_numerator;
+    snapshot.time_sig_denominator = ctx.time_sig_denominator;
+    snapshot.is_playing = ctx.is_playing;
+    snapshot.is_recording = ctx.is_recording;
+    snapshot.is_looping = ctx.is_looping;
+}
+
+} // namespace pulp::format::detail

--- a/core/format/include/pulp/format/vst3_adapter.hpp
+++ b/core/format/include/pulp/format/vst3_adapter.hpp
@@ -24,6 +24,7 @@
 #include <pluginterfaces/base/ibstream.h>
 
 #include <pulp/format/processor.hpp>
+#include <pulp/format/detail/playhead_diff.hpp>
 #include <pulp/state/parameter_event_queue.hpp>
 
 #include <pluginterfaces/gui/iplugview.h>
@@ -99,6 +100,12 @@ private:
     // parameter (the one we tag with kIsBypass in initialize()). 0 when
     // none — process() then never short-circuits.
     state::ParamID bypass_param_id_ = 0;
+
+    // Item 1.3 — previous-block transport snapshot used to derive the
+    // `tempo_changed` / `time_sig_changed` / `transport_changed` flags
+    // on `ProcessContext`. Default-constructed (no previous block) so
+    // the first process() call after construction reports no changes.
+    detail::PlayheadSnapshot playhead_prev_{};
 };
 
 } // namespace pulp::format::vst3

--- a/core/format/src/au_adapter.mm
+++ b/core/format/src/au_adapter.mm
@@ -5,10 +5,12 @@
 #import <AudioToolbox/AudioToolbox.h>
 #import <AVFoundation/AVFoundation.h>
 #import <CoreAudioKit/CoreAudioKit.h>
+#import <mach/mach_time.h>
 #include <pulp/format/processor.hpp>
 #include <pulp/format/plugin_state_io.hpp>
 #include <pulp/format/registry.hpp>
 #include <pulp/format/ara.hpp>
+#include <pulp/format/detail/playhead_diff.hpp>
 #include <pulp/midi/ump_sysex7_reassembler.hpp>
 #include <pulp/runtime/log.hpp>
 #include <pulp/state/parameter_event_queue.hpp>
@@ -73,6 +75,12 @@ struct AUBridge {
     // (sized at init to match max_frames * kMaxChannels).
     std::vector<float> sidechain_storage;
     state::ParameterEventQueue param_events;
+
+    // Item 1.3 — previous-block transport snapshot used to derive the
+    // change flags on `ProcessContext`. Default-constructed (no
+    // previous block) so the first render-block invocation reports no
+    // changes.
+    detail::PlayheadSnapshot playhead_prev;
 };
 
 static int32_t block_relative_sample_offset(AUEventSampleTime event_sample_time,
@@ -402,6 +410,16 @@ static int32_t block_relative_sample_offset(AUEventSampleTime event_sample_time,
 - (AUInternalRenderBlock)internalRenderBlock {
     auto* bridge = &_bridge;
 
+    // Item 1.3 — capture the host's musical-context and transport-state
+    // blocks at render-block construction time, per Apple's render-block
+    // contract. AUAudioUnit::musicalContextBlock and transportStateBlock
+    // are KVO-able read/write properties the host installs (often only
+    // after `allocateRenderResources`). They are safe to invoke from
+    // the render thread; the block we hand back to the host captures
+    // them via `__block` so the call sites below stay self-contained.
+    AUHostMusicalContextBlock musicalContextBlock = self.musicalContextBlock;
+    AUHostTransportStateBlock transportStateBlock = self.transportStateBlock;
+
     AUInternalRenderBlock renderBlock = ^AUAudioUnitStatus(
         AudioUnitRenderActionFlags *actionFlags,
         const AudioTimeStamp *timestamp,
@@ -644,6 +662,77 @@ static int32_t block_relative_sample_offset(AUEventSampleTime event_sample_time,
         pulp::format::ProcessContext ctx;
         ctx.sample_rate = bridge->sample_rate;
         ctx.num_samples = static_cast<int>(frameCount);
+
+        // Item 1.3 — populate transport fields from the host blocks the
+        // AUv3 host installed via the KVO-able properties on
+        // AUAudioUnit. The blocks may legitimately be nil (hosts that
+        // don't expose transport state, AUv2-bridged hosts, render
+        // tests). In that case the fields stay at their documented
+        // defaults so the plugin's process() sees the same
+        // pre-extension behaviour.
+        if (musicalContextBlock) {
+            double tempo_bpm = 0.0;
+            double time_sig_numerator = 0.0;
+            NSInteger time_sig_denominator = 0;
+            double current_beat_position = 0.0;
+            NSInteger sample_offset_to_next_beat = 0;
+            double current_measure_downbeat_position = 0.0;
+            const BOOL ok = musicalContextBlock(
+                &tempo_bpm,
+                &time_sig_numerator,
+                &time_sig_denominator,
+                &current_beat_position,
+                &sample_offset_to_next_beat,
+                &current_measure_downbeat_position);
+            if (ok) {
+                if (tempo_bpm > 0.0) ctx.tempo_bpm = tempo_bpm;
+                if (time_sig_numerator > 0.0) {
+                    ctx.time_sig_numerator = static_cast<int>(time_sig_numerator);
+                }
+                if (time_sig_denominator > 0) {
+                    ctx.time_sig_denominator = static_cast<int>(time_sig_denominator);
+                }
+                ctx.position_beats = current_beat_position;
+            }
+        }
+        if (transportStateBlock) {
+            AUHostTransportStateFlags transport_flags = 0;
+            double current_sample_position = 0.0;
+            double cycle_start_beat_position = 0.0;
+            double cycle_end_beat_position = 0.0;
+            const BOOL ok = transportStateBlock(
+                &transport_flags,
+                &current_sample_position,
+                &cycle_start_beat_position,
+                &cycle_end_beat_position);
+            if (ok) {
+                ctx.is_playing =
+                    (transport_flags & AUHostTransportStateMoving) != 0;
+                ctx.is_recording =
+                    (transport_flags & AUHostTransportStateRecording) != 0;
+                ctx.is_looping =
+                    (transport_flags & AUHostTransportStateCycling) != 0;
+                ctx.position_samples =
+                    static_cast<int64_t>(current_sample_position);
+                if (ctx.is_looping) {
+                    ctx.loop_start_beats = cycle_start_beat_position;
+                    ctx.loop_end_beats = cycle_end_beat_position;
+                }
+            }
+        }
+        if (timestamp && (timestamp->mFlags & kAudioTimeStampHostTimeValid) != 0) {
+            static mach_timebase_info_data_t timebase = {0, 0};
+            if (timebase.denom == 0) mach_timebase_info(&timebase);
+            if (timebase.denom != 0) {
+                ctx.host_time_ns = static_cast<int64_t>(
+                    (timestamp->mHostTime * timebase.numer) / timebase.denom);
+            }
+        }
+        // AUv3 has no host-supplied frame-rate; `ctx.frame_rate` stays
+        // `FrameRate::unknown` per the documented sentinel.
+        pulp::format::detail::derive_bar_from_beats(ctx);
+        pulp::format::detail::compute_playhead_changes(ctx, bridge->playhead_prev);
+
         bridge->processor->set_param_events(&bridge->param_events);
         bridge->processor->process(output_view, input_view, midi_in, midi_out, ctx);
 

--- a/core/format/src/au_v2_adapter.cpp
+++ b/core/format/src/au_v2_adapter.cpp
@@ -6,7 +6,10 @@
 #include <AudioToolbox/AudioUnitUtilities.h>
 #include <AudioToolbox/AudioToolbox.h>  // kAudioUnitProperty_CocoaUI, AudioUnitCocoaViewInfo
 
+#include <mach/mach_time.h>
+
 #include <pulp/format/au_v2_adapter.hpp>
+#include <pulp/format/detail/playhead_diff.hpp>
 #include <pulp/format/plugin_state_io.hpp>
 #include <pulp/format/registry.hpp>
 #include <pulp/runtime/log.hpp>
@@ -348,6 +351,80 @@ OSStatus PulpAUEffect::ProcessBufferLists(AudioUnitRenderActionFlags& ioActionFl
     ProcessContext ctx;
     ctx.sample_rate = GetSampleRate();
     ctx.num_samples = static_cast<int>(inFramesToProcess);
+
+    // Item 1.3 — populate transport fields from the host callbacks the
+    // host installed via kAudioUnitProperty_HostCallbacks. The
+    // AudioUnitSDK wraps these as `CallHostBeatAndTempo` /
+    // `CallHostMusicalTimeLocation` / `CallHostTransportState`. They
+    // are render-thread-only; calling outside ProcessBufferLists
+    // returns `kAudioUnitErr_CannotDoInCurrentContext`. AU has no
+    // dedicated frame-rate or loop callback — `frame_rate` stays
+    // `FrameRate::unknown` and the loop range falls back to the
+    // transport callback's outCycleStartBeat / outCycleEndBeat (only
+    // valid when outIsCycling is true).
+    {
+        Float64 beat = 0.0;
+        Float64 tempo = 0.0;
+        if (CallHostBeatAndTempo(&beat, &tempo) == noErr) {
+            ctx.position_beats = beat;
+            if (tempo > 0.0) ctx.tempo_bpm = tempo;
+        }
+
+        UInt32 delta_samples = 0;
+        Float32 ts_num = 0.0f;
+        UInt32 ts_denom = 0;
+        Float64 current_measure_downbeat = 0.0;
+        if (CallHostMusicalTimeLocation(&delta_samples, &ts_num, &ts_denom,
+                                        &current_measure_downbeat) == noErr) {
+            if (ts_num > 0.0f) {
+                ctx.time_sig_numerator = static_cast<int>(ts_num);
+            }
+            if (ts_denom > 0) {
+                ctx.time_sig_denominator = static_cast<int>(ts_denom);
+            }
+        }
+
+        Boolean is_playing = false;
+        Boolean transport_state_changed = false;
+        Float64 current_sample_in_timeline = 0.0;
+        Boolean is_cycling = false;
+        Float64 cycle_start = 0.0;
+        Float64 cycle_end = 0.0;
+        if (CallHostTransportState(&is_playing, &transport_state_changed,
+                                   &current_sample_in_timeline, &is_cycling,
+                                   &cycle_start, &cycle_end) == noErr) {
+            ctx.is_playing = (is_playing != 0);
+            ctx.position_samples =
+                static_cast<int64_t>(current_sample_in_timeline);
+            ctx.is_looping = (is_cycling != 0);
+            if (ctx.is_looping) {
+                ctx.loop_start_beats = cycle_start;
+                ctx.loop_end_beats = cycle_end;
+            }
+            // `is_recording` is not exposed by HostCallback_GetTransportState;
+            // the v2 GetTransportState2 callback adds it but AUBase's
+            // CallHostTransportState wrapper only calls the v1 proc. Leave
+            // `is_recording` at the default false sentinel — plug-ins that
+            // need recording state must use AU v3 today.
+        }
+
+        // Host clock for video sync. AU doesn't surface a "host time"
+        // callback, but `mach_absolute_time` ticks the same monotonic
+        // clock the host renders against on Apple platforms, so it is
+        // the closest analogue. Convert ticks to nanoseconds via
+        // `mach_timebase_info` (cached on first use).
+        static mach_timebase_info_data_t timebase = {0, 0};
+        if (timebase.denom == 0) mach_timebase_info(&timebase);
+        if (timebase.denom != 0) {
+            const uint64_t now = mach_absolute_time();
+            ctx.host_time_ns = static_cast<int64_t>(
+                (now * timebase.numer) / timebase.denom);
+        }
+
+        pulp::format::detail::derive_bar_from_beats(ctx);
+    }
+
+    pulp::format::detail::compute_playhead_changes(ctx, playhead_prev_);
 
     processor_->process(output_view, input_view, midi_in, midi_out, ctx);
 

--- a/core/format/src/au_v2_instrument.cpp
+++ b/core/format/src/au_v2_instrument.cpp
@@ -5,9 +5,11 @@
 #include <AudioUnitSDK/AUPlugInDispatch.h>
 #include <AudioUnitSDK/AUOutputElement.h>
 #include <AudioToolbox/AudioToolbox.h>  // kAudioUnitProperty_CocoaUI, AudioUnitCocoaViewInfo
+#include <mach/mach_time.h>
 
 #include <pulp/format/au_v2_instrument.hpp>
 #include <pulp/format/au_v2_adapter.hpp>  // kPulpEditorContextProperty, PulpEditorContext, fill_cocoa_view_info
+#include <pulp/format/detail/playhead_diff.hpp>
 #include <pulp/format/plugin_state_io.hpp>
 #include <pulp/format/registry.hpp>
 #include <pulp/runtime/log.hpp>
@@ -233,6 +235,60 @@ OSStatus PulpAUInstrument::Render(AudioUnitRenderActionFlags& ioActionFlags,
     ProcessContext ctx;
     ctx.sample_rate = GetOutput(0)->GetStreamFormat().mSampleRate;
     ctx.num_samples = static_cast<int>(inNumberFrames);
+
+    // Item 1.3 — populate transport fields from the host callbacks
+    // (kAudioUnitProperty_HostCallbacks). Same wiring as PulpAUEffect
+    // — the instrument adapter is also AUBase-derived so the
+    // CallHostBeatAndTempo / CallHostMusicalTimeLocation /
+    // CallHostTransportState helpers route through the same proc
+    // pointers the host installed.
+    {
+        Float64 beat = 0.0;
+        Float64 tempo = 0.0;
+        if (CallHostBeatAndTempo(&beat, &tempo) == noErr) {
+            ctx.position_beats = beat;
+            if (tempo > 0.0) ctx.tempo_bpm = tempo;
+        }
+
+        UInt32 delta_samples = 0;
+        Float32 ts_num = 0.0f;
+        UInt32 ts_denom = 0;
+        Float64 current_measure_downbeat = 0.0;
+        if (CallHostMusicalTimeLocation(&delta_samples, &ts_num, &ts_denom,
+                                        &current_measure_downbeat) == noErr) {
+            if (ts_num > 0.0f) ctx.time_sig_numerator = static_cast<int>(ts_num);
+            if (ts_denom > 0) ctx.time_sig_denominator = static_cast<int>(ts_denom);
+        }
+
+        Boolean is_playing = false;
+        Boolean transport_state_changed = false;
+        Float64 current_sample_in_timeline = 0.0;
+        Boolean is_cycling = false;
+        Float64 cycle_start = 0.0;
+        Float64 cycle_end = 0.0;
+        if (CallHostTransportState(&is_playing, &transport_state_changed,
+                                   &current_sample_in_timeline, &is_cycling,
+                                   &cycle_start, &cycle_end) == noErr) {
+            ctx.is_playing = (is_playing != 0);
+            ctx.position_samples = static_cast<int64_t>(current_sample_in_timeline);
+            ctx.is_looping = (is_cycling != 0);
+            if (ctx.is_looping) {
+                ctx.loop_start_beats = cycle_start;
+                ctx.loop_end_beats = cycle_end;
+            }
+        }
+
+        static mach_timebase_info_data_t timebase = {0, 0};
+        if (timebase.denom == 0) mach_timebase_info(&timebase);
+        if (timebase.denom != 0) {
+            const uint64_t now = mach_absolute_time();
+            ctx.host_time_ns = static_cast<int64_t>(
+                (now * timebase.numer) / timebase.denom);
+        }
+
+        pulp::format::detail::derive_bar_from_beats(ctx);
+    }
+    pulp::format::detail::compute_playhead_changes(ctx, playhead_prev_);
 
     processor_->process(output_view, input_view, midi_in, midi_out, ctx);
 

--- a/core/format/src/clap_adapter.cpp
+++ b/core/format/src/clap_adapter.cpp
@@ -3,6 +3,7 @@
 
 #include <pulp/format/clap_adapter.hpp>
 #include <pulp/format/ara.hpp>
+#include <pulp/format/detail/playhead_diff.hpp>
 #include <pulp/midi/ump_conversion.hpp>
 #include <pulp/runtime/log.hpp>
 #include <pulp/runtime/scoped_no_alloc.hpp>
@@ -420,16 +421,55 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
     ctx.sample_rate = self->sample_rate;
     ctx.num_samples = static_cast<int>(num_samples);
     if (process->transport) {
-        ctx.is_playing = (process->transport->flags & CLAP_TRANSPORT_IS_PLAYING) != 0;
-        ctx.tempo_bpm = process->transport->tempo;
-        if (process->transport->flags & CLAP_TRANSPORT_HAS_BEATS_TIMELINE) {
-            ctx.position_beats = static_cast<double>(process->transport->song_pos_beats) / CLAP_BEATTIME_FACTOR;
+        const auto* tr = process->transport;
+        const uint32_t flags = tr->flags;
+
+        ctx.is_playing = (flags & CLAP_TRANSPORT_IS_PLAYING) != 0;
+        ctx.is_recording = (flags & CLAP_TRANSPORT_IS_RECORDING) != 0;
+        if (flags & CLAP_TRANSPORT_HAS_TEMPO) {
+            ctx.tempo_bpm = tr->tempo;
         }
-        if (process->transport->flags & CLAP_TRANSPORT_HAS_TIME_SIGNATURE) {
-            ctx.time_sig_numerator = static_cast<int>(process->transport->tsig_num);
-            ctx.time_sig_denominator = static_cast<int>(process->transport->tsig_denom);
+        if (flags & CLAP_TRANSPORT_HAS_BEATS_TIMELINE) {
+            ctx.position_beats =
+                static_cast<double>(tr->song_pos_beats) / CLAP_BEATTIME_FACTOR;
         }
+        if (flags & CLAP_TRANSPORT_HAS_TIME_SIGNATURE) {
+            ctx.time_sig_numerator = static_cast<int>(tr->tsig_num);
+            ctx.time_sig_denominator = static_cast<int>(tr->tsig_denom);
+        }
+
+        // Item 1.3 — cycle / loop range. CLAP gates this on
+        // CLAP_TRANSPORT_IS_LOOP_ACTIVE; loop_start_beats /
+        // loop_end_beats are CLAP fixed-point `clap_beattime` so they
+        // convert through the same factor as song_pos_beats.
+        ctx.is_looping = (flags & CLAP_TRANSPORT_IS_LOOP_ACTIVE) != 0;
+        if (ctx.is_looping) {
+            ctx.loop_start_beats =
+                static_cast<double>(tr->loop_start_beats) / CLAP_BEATTIME_FACTOR;
+            ctx.loop_end_beats =
+                static_cast<double>(tr->loop_end_beats) / CLAP_BEATTIME_FACTOR;
+        }
+
+        // Item 1.3 — bar index. CLAP exposes `bar_number` directly
+        // (bar at song pos 0 has bar 0), so prefer that over deriving
+        // from beats. Hosts that don't supply a beats timeline leave
+        // `bar_number` at 0, which matches the documented default.
+        if (flags & CLAP_TRANSPORT_HAS_BEATS_TIMELINE) {
+            ctx.bar = static_cast<int64_t>(tr->bar_number);
+        } else {
+            pulp::format::detail::derive_bar_from_beats(ctx);
+        }
+
+        // Item 1.3 — host clock / SMPTE frame rate are intentionally
+        // left at the documented "host did not provide" sentinels:
+        // CLAP 1.2.2's `clap_event_transport` carries neither field.
+        // `ctx.host_time_ns` stays 0, `ctx.frame_rate` stays
+        // FrameRate::unknown — plugin authors must check before use.
     }
+
+    // Item 1.3 — diff against the previous block to populate the three
+    // change flags. Stateful; updates `self->playhead_prev` in place.
+    pulp::format::detail::compute_playhead_changes(ctx, self->playhead_prev);
 
     // Snapshot parameter values to detect plugin-side changes
     auto all_params = self->store.all_params();

--- a/core/format/src/vst3_adapter.cpp
+++ b/core/format/src/vst3_adapter.cpp
@@ -5,6 +5,7 @@
 
 #include <pulp/format/vst3_adapter.hpp>
 #include <pulp/format/detail/editor_environment.hpp>
+#include <pulp/format/detail/playhead_diff.hpp>
 #include <pulp/format/plugin_state_io.hpp>
 #include <pulp/format/vst3_plug_view.hpp>
 #include <pulp/format/ara.hpp>
@@ -449,14 +450,77 @@ tresult PLUGIN_API PulpVst3Processor::process(ProcessData& data) {
     ctx.sample_rate = processSetup.sampleRate;
     ctx.num_samples = num_samples;
     if (data.processContext) {
-        ctx.is_playing = (data.processContext->state & Steinberg::Vst::ProcessContext::kPlaying) != 0;
-        ctx.tempo_bpm = data.processContext->tempo;
-        ctx.position_samples = data.processContext->projectTimeSamples;
-        if (data.processContext->state & Steinberg::Vst::ProcessContext::kTimeSigValid) {
-            ctx.time_sig_numerator = data.processContext->timeSigNumerator;
-            ctx.time_sig_denominator = data.processContext->timeSigDenominator;
+        const auto* pc = data.processContext;
+        const uint32_t state = pc->state;
+        ctx.is_playing = (state & Steinberg::Vst::ProcessContext::kPlaying) != 0;
+        ctx.is_recording = (state & Steinberg::Vst::ProcessContext::kRecording) != 0;
+        ctx.position_samples = pc->projectTimeSamples;
+        if (state & Steinberg::Vst::ProcessContext::kTempoValid) {
+            ctx.tempo_bpm = pc->tempo;
         }
+        if (state & Steinberg::Vst::ProcessContext::kProjectTimeMusicValid) {
+            ctx.position_beats = pc->projectTimeMusic;
+        }
+        if (state & Steinberg::Vst::ProcessContext::kTimeSigValid) {
+            ctx.time_sig_numerator = pc->timeSigNumerator;
+            ctx.time_sig_denominator = pc->timeSigDenominator;
+        }
+
+        // Item 1.3 — cycle / loop. kCycleValid covers cycleStartMusic +
+        // cycleEndMusic; kCycleActive indicates the host is currently
+        // looping. Both must be set for the loop range to be meaningful.
+        ctx.is_looping = (state & Steinberg::Vst::ProcessContext::kCycleActive) != 0;
+        if (state & Steinberg::Vst::ProcessContext::kCycleValid) {
+            ctx.loop_start_beats = pc->cycleStartMusic;
+            ctx.loop_end_beats = pc->cycleEndMusic;
+        }
+
+        // Item 1.3 — host clock for video sync.
+        if (state & Steinberg::Vst::ProcessContext::kSystemTimeValid) {
+            ctx.host_time_ns = pc->systemTime;
+        }
+
+        // Item 1.3 — SMPTE frame rate enum. VST3 reports it as an
+        // integer framesPerSecond plus pulldown / drop flags. Map the
+        // documented combinations from the FrameRate doc comment in
+        // ivstprocesscontext.h onto Pulp's FrameRate enum.
+        if (state & Steinberg::Vst::ProcessContext::kSmpteValid) {
+            const auto fps = pc->frameRate.framesPerSecond;
+            const auto fr_flags = pc->frameRate.flags;
+            const bool pulldown =
+                (fr_flags & Steinberg::Vst::FrameRate::kPullDownRate) != 0;
+            const bool drop =
+                (fr_flags & Steinberg::Vst::FrameRate::kDropRate) != 0;
+            using FR = pulp::format::FrameRate;
+            // VST3 doc: 23.976 = 24 + pulldown; 29.97 = 30 + pulldown;
+            // 29.97 drop = 30 + pulldown + drop; 30 drop = 30 + drop;
+            // 59.94 = 60 + pulldown; integer rates have flags == 0.
+            if (fps == 24 && pulldown) ctx.frame_rate = FR::fps_24; // 23.976 ≈ 24 in our enum
+            else if (fps == 24) ctx.frame_rate = FR::fps_24;
+            else if (fps == 25) ctx.frame_rate = FR::fps_25;
+            else if (fps == 30 && pulldown && drop) ctx.frame_rate = FR::fps_29_97_drop;
+            else if (fps == 30 && pulldown) ctx.frame_rate = FR::fps_29_97;
+            else if (fps == 30 && drop) ctx.frame_rate = FR::fps_30_drop;
+            else if (fps == 30) ctx.frame_rate = FR::fps_30;
+            else if (fps == 60) ctx.frame_rate = FR::fps_60;
+            // Other rates (50, 60+pulldown=59.94) fall through to the
+            // default FrameRate::unknown — Pulp's enum does not enumerate
+            // every SMPTE rate, only the seven the spec lists.
+        }
+
+        // Item 1.3 — bar index. Derive from position_beats + time-sig.
+        // VST3 also exposes `barPositionMusic` directly when
+        // kBarPositionValid is set, but it's the quarter-note position
+        // of the last bar start, not a bar *index* — so deriving
+        // matches the documented `ProcessContext::bar` contract and
+        // stays consistent with the AU/CLAP paths that have no
+        // host-precomputed bar.
+        pulp::format::detail::derive_bar_from_beats(ctx);
     }
+
+    // Item 1.3 — diff against the previous block to populate the three
+    // change flags. Stateful; updates `playhead_prev_` in place.
+    pulp::format::detail::compute_playhead_changes(ctx, playhead_prev_);
 
     // Snapshot parameter values before processing so we can detect
     // plugin-side changes and report them to the host for automation recording

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -863,6 +863,11 @@ pulp_add_test_suite(pulp-test-processor-ara-hook LIBRARIES pulp::format)
 pulp_add_test_suite(pulp-test-processor-layout-latency LIBRARIES pulp::format)
 # Processor and descriptor default contracts
 pulp_add_test_suite(pulp-test-processor-defaults LIBRARIES pulp::format)
+# Item 1.3 AudioPlayHead transport-extension helpers used by every
+# format adapter (VST3, AU v2 / v3, CLAP) to derive `ProcessContext::bar`
+# and the three change flags (tempo_changed / time_sig_changed /
+# transport_changed) once per block.
+pulp_add_test_suite(pulp-test-playhead-diff LIBRARIES pulp::format)
 # TableModel data/sort layer (workstream 07 slice 7.3)
 pulp_add_test_suite(pulp-test-table-model LIBRARIES pulp::view)
 # ModulationMatrix data model (workstream 07 slice 7.1)

--- a/test/test_clap_midi_events.cpp
+++ b/test/test_clap_midi_events.cpp
@@ -636,7 +636,11 @@ TEST_CASE("CLAP transport state maps into ProcessContext",
 
     clap_event_transport_t transport{};
     transport.header = make_header(sizeof(transport), CLAP_EVENT_TRANSPORT, 0);
+    // Item 1.3 — adapter now gates `tempo_bpm` on CLAP_TRANSPORT_HAS_TEMPO
+    // per the CLAP spec contract (transport.tempo is only valid when the
+    // HAS_TEMPO flag is set; pre-1.3 code read it unconditionally).
     transport.flags = CLAP_TRANSPORT_IS_PLAYING
+                    | CLAP_TRANSPORT_HAS_TEMPO
                     | CLAP_TRANSPORT_HAS_BEATS_TIMELINE
                     | CLAP_TRANSPORT_HAS_TIME_SIGNATURE;
     transport.tempo = 132.25;
@@ -657,6 +661,92 @@ TEST_CASE("CLAP transport state maps into ProcessContext",
     REQUIRE(g_capturing->captured_context.time_sig_numerator == 7);
     REQUIRE(g_capturing->captured_context.time_sig_denominator == 8);
     REQUIRE(g_capturing->captured_context.num_samples == static_cast<int>(Harness::kFrames));
+}
+
+TEST_CASE("CLAP item-1.3 transport extensions land on ProcessContext",
+          "[clap][transport][item-13]") {
+    g_pending_opts_mpe = false;
+    g_pending_opts_ump = false;
+    Harness h(make_capturing);
+
+    clap_event_transport_t transport{};
+    transport.header = make_header(sizeof(transport), CLAP_EVENT_TRANSPORT, 0);
+    transport.flags = CLAP_TRANSPORT_IS_PLAYING
+                    | CLAP_TRANSPORT_IS_RECORDING
+                    | CLAP_TRANSPORT_IS_LOOP_ACTIVE
+                    | CLAP_TRANSPORT_HAS_TEMPO
+                    | CLAP_TRANSPORT_HAS_BEATS_TIMELINE
+                    | CLAP_TRANSPORT_HAS_TIME_SIGNATURE;
+    transport.tempo = 100.0;
+    transport.song_pos_beats = 8 * CLAP_BEATTIME_FACTOR;       // beat 8
+    transport.loop_start_beats = 4 * CLAP_BEATTIME_FACTOR;     // beat 4
+    transport.loop_end_beats = 12 * CLAP_BEATTIME_FACTOR;      // beat 12
+    transport.bar_number = 2;
+    transport.tsig_num = 4;
+    transport.tsig_denom = 4;
+
+    REQUIRE(h.run_custom(nullptr, nullptr,
+                         &h.audio_in, 1,
+                         &h.audio_out, 1,
+                         Harness::kFrames,
+                         &transport) == CLAP_PROCESS_CONTINUE);
+
+    const auto& ctx = g_capturing->captured_context;
+    REQUIRE(ctx.is_playing);
+    REQUIRE(ctx.is_recording);
+    REQUIRE(ctx.is_looping);
+    REQUIRE(ctx.loop_start_beats == 4.0);
+    REQUIRE(ctx.loop_end_beats == 12.0);
+    REQUIRE(ctx.bar == 2);
+    // CLAP carries neither host_time_ns nor frame_rate — the adapter
+    // leaves the documented sentinels alone.
+    REQUIRE(ctx.host_time_ns == 0);
+    REQUIRE(ctx.frame_rate == pulp::format::FrameRate::unknown);
+    // First block raises no change flags (no previous-block snapshot).
+    REQUIRE_FALSE(ctx.tempo_changed);
+    REQUIRE_FALSE(ctx.time_sig_changed);
+    REQUIRE_FALSE(ctx.transport_changed);
+}
+
+TEST_CASE("CLAP item-1.3 change flags flip on the second block",
+          "[clap][transport][item-13][change-flags]") {
+    g_pending_opts_mpe = false;
+    g_pending_opts_ump = false;
+    Harness h(make_capturing);
+
+    clap_event_transport_t initial{};
+    initial.header = make_header(sizeof(initial), CLAP_EVENT_TRANSPORT, 0);
+    initial.flags = CLAP_TRANSPORT_HAS_TEMPO | CLAP_TRANSPORT_HAS_TIME_SIGNATURE;
+    initial.tempo = 100.0;
+    initial.tsig_num = 4;
+    initial.tsig_denom = 4;
+
+    REQUIRE(h.run_custom(nullptr, nullptr,
+                         &h.audio_in, 1,
+                         &h.audio_out, 1,
+                         Harness::kFrames, &initial) == CLAP_PROCESS_CONTINUE);
+
+    // First block — no previous snapshot — never raises change flags.
+    REQUIRE_FALSE(g_capturing->captured_context.tempo_changed);
+
+    clap_event_transport_t bumped{};
+    bumped.header = make_header(sizeof(bumped), CLAP_EVENT_TRANSPORT, 0);
+    bumped.flags = CLAP_TRANSPORT_IS_PLAYING
+                 | CLAP_TRANSPORT_HAS_TEMPO
+                 | CLAP_TRANSPORT_HAS_TIME_SIGNATURE;
+    bumped.tempo = 180.0;        // changed
+    bumped.tsig_num = 7;         // changed
+    bumped.tsig_denom = 8;       // changed
+
+    REQUIRE(h.run_custom(nullptr, nullptr,
+                         &h.audio_in, 1,
+                         &h.audio_out, 1,
+                         Harness::kFrames, &bumped) == CLAP_PROCESS_CONTINUE);
+
+    const auto& ctx = g_capturing->captured_context;
+    REQUIRE(ctx.tempo_changed);
+    REQUIRE(ctx.time_sig_changed);
+    REQUIRE(ctx.transport_changed);  // is_playing flipped false → true
 }
 
 TEST_CASE("CLAP emits parameter event when processor changes automatable state",

--- a/test/test_playhead_diff.cpp
+++ b/test/test_playhead_diff.cpp
@@ -1,0 +1,329 @@
+// Item 1.3 — AudioPlayHead transport-extension adapter wiring helpers.
+//
+// `detail::derive_bar_from_beats` and `detail::compute_playhead_changes`
+// are the two pieces of pure logic the VST3, AU v2 / v3, and CLAP
+// adapters share when they populate the new `ProcessContext` fields
+// from their respective host APIs. Each adapter then queries its host
+// (VST3 `Vst::ProcessContext`, AU v2 `CallHostBeatAndTempo` /
+// `CallHostMusicalTimeLocation` / `CallHostTransportState`, AU v3
+// `musicalContextBlock` / `transportStateBlock`, CLAP
+// `clap_event_transport`) and feeds the populated context through the
+// two helpers — so pinning the helpers covers the cross-adapter
+// contract end-to-end. Per-host validation that actually drives a real
+// DAW (Logic, Cubase, Bitwig, Reaper) is captured as a follow-up under
+// item 1.3 of the macOS plan.
+//
+// The adapter wiring itself is exercised by:
+//   * test_clap_entry.cpp / test_clap_host_validation.cpp — CLAP
+//     adapter loads + render at the dlopen level.
+//   * test_vst3_plugin_state.cpp — VST3 SingleComponentEffect state
+//     round-trip.
+//   * test_au_v2_effect.cpp + test_au_v2_cocoa_ui.mm — AU v2 surface.
+//   * test_au_plugin_state.mm — AU v3 state surface.
+// Those tests don't drive the host's playhead push API (no host is
+// running), so the field-population path here lives behind a host
+// driver. That gap is the planned 1.3 acceptance test once a real-DAW
+// harness exists.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/format/detail/playhead_diff.hpp>
+#include <pulp/format/processor.hpp>
+
+using pulp::format::FrameRate;
+using pulp::format::ProcessContext;
+using pulp::format::detail::PlayheadSnapshot;
+using pulp::format::detail::compute_playhead_changes;
+using pulp::format::detail::derive_bar_from_beats;
+
+TEST_CASE("derive_bar_from_beats: 4/4 maps every 4 beats to one bar",
+          "[format][playhead][item-13][derive-bar]") {
+    ProcessContext ctx;
+    ctx.time_sig_numerator = 4;
+    ctx.time_sig_denominator = 4;
+
+    ctx.position_beats = 0.0;
+    derive_bar_from_beats(ctx);
+    REQUIRE(ctx.bar == 0);
+
+    ctx.position_beats = 3.999;
+    derive_bar_from_beats(ctx);
+    REQUIRE(ctx.bar == 0);
+
+    ctx.position_beats = 4.0;
+    derive_bar_from_beats(ctx);
+    REQUIRE(ctx.bar == 1);
+
+    ctx.position_beats = 16.5;
+    derive_bar_from_beats(ctx);
+    REQUIRE(ctx.bar == 4);
+}
+
+TEST_CASE("derive_bar_from_beats: 3/4 maps every 3 beats to one bar",
+          "[format][playhead][item-13][derive-bar]") {
+    ProcessContext ctx;
+    ctx.time_sig_numerator = 3;
+    ctx.time_sig_denominator = 4;
+
+    ctx.position_beats = 0.0;
+    derive_bar_from_beats(ctx);
+    REQUIRE(ctx.bar == 0);
+
+    ctx.position_beats = 2.999;
+    derive_bar_from_beats(ctx);
+    REQUIRE(ctx.bar == 0);
+
+    ctx.position_beats = 3.0;
+    derive_bar_from_beats(ctx);
+    REQUIRE(ctx.bar == 1);
+
+    ctx.position_beats = 9.5;
+    derive_bar_from_beats(ctx);
+    REQUIRE(ctx.bar == 3);
+}
+
+TEST_CASE("derive_bar_from_beats: 6/8 maps every 3 quarter notes to one bar",
+          "[format][playhead][item-13][derive-bar]") {
+    // 6/8 = 6 eighths per bar = 3 quarter notes per bar.
+    ProcessContext ctx;
+    ctx.time_sig_numerator = 6;
+    ctx.time_sig_denominator = 8;
+
+    ctx.position_beats = 0.0;
+    derive_bar_from_beats(ctx);
+    REQUIRE(ctx.bar == 0);
+
+    ctx.position_beats = 2.999;
+    derive_bar_from_beats(ctx);
+    REQUIRE(ctx.bar == 0);
+
+    ctx.position_beats = 3.0;
+    derive_bar_from_beats(ctx);
+    REQUIRE(ctx.bar == 1);
+
+    ctx.position_beats = 9.0;
+    derive_bar_from_beats(ctx);
+    REQUIRE(ctx.bar == 3);
+}
+
+TEST_CASE("derive_bar_from_beats: degenerate time signatures stay at bar 0",
+          "[format][playhead][item-13][derive-bar][edge]") {
+    ProcessContext ctx;
+    ctx.position_beats = 17.0;
+
+    SECTION("numerator <= 0") {
+        ctx.time_sig_numerator = 0;
+        ctx.time_sig_denominator = 4;
+        derive_bar_from_beats(ctx);
+        REQUIRE(ctx.bar == 0);
+    }
+
+    SECTION("denominator <= 0") {
+        ctx.time_sig_numerator = 4;
+        ctx.time_sig_denominator = 0;
+        derive_bar_from_beats(ctx);
+        REQUIRE(ctx.bar == 0);
+    }
+
+    SECTION("both <= 0") {
+        ctx.time_sig_numerator = 0;
+        ctx.time_sig_denominator = 0;
+        derive_bar_from_beats(ctx);
+        REQUIRE(ctx.bar == 0);
+    }
+}
+
+TEST_CASE("compute_playhead_changes: first call after construction reports no changes",
+          "[format][playhead][item-13][change-flags]") {
+    PlayheadSnapshot snapshot;
+    REQUIRE_FALSE(snapshot.has_previous);
+
+    ProcessContext ctx;
+    ctx.tempo_bpm = 137.5;
+    ctx.time_sig_numerator = 7;
+    ctx.time_sig_denominator = 8;
+    ctx.is_playing = true;
+    ctx.is_recording = true;
+    ctx.is_looping = true;
+
+    compute_playhead_changes(ctx, snapshot);
+
+    REQUIRE_FALSE(ctx.tempo_changed);
+    REQUIRE_FALSE(ctx.time_sig_changed);
+    REQUIRE_FALSE(ctx.transport_changed);
+
+    REQUIRE(snapshot.has_previous);
+    REQUIRE(snapshot.tempo_bpm == 137.5);
+    REQUIRE(snapshot.time_sig_numerator == 7);
+    REQUIRE(snapshot.time_sig_denominator == 8);
+    REQUIRE(snapshot.is_playing);
+    REQUIRE(snapshot.is_recording);
+    REQUIRE(snapshot.is_looping);
+}
+
+TEST_CASE("compute_playhead_changes: second identical call still reports no changes",
+          "[format][playhead][item-13][change-flags]") {
+    PlayheadSnapshot snapshot;
+    ProcessContext ctx;
+    ctx.tempo_bpm = 120.0;
+    ctx.time_sig_numerator = 4;
+    ctx.time_sig_denominator = 4;
+
+    compute_playhead_changes(ctx, snapshot);  // first call seeds the snapshot
+    compute_playhead_changes(ctx, snapshot);  // identical context
+
+    REQUIRE_FALSE(ctx.tempo_changed);
+    REQUIRE_FALSE(ctx.time_sig_changed);
+    REQUIRE_FALSE(ctx.transport_changed);
+}
+
+TEST_CASE("compute_playhead_changes: tempo bump flips tempo_changed only",
+          "[format][playhead][item-13][change-flags]") {
+    PlayheadSnapshot snapshot;
+    ProcessContext seed;
+    seed.tempo_bpm = 120.0;
+    compute_playhead_changes(seed, snapshot);
+
+    ProcessContext next;
+    next.tempo_bpm = 140.0;  // changed
+    next.time_sig_numerator = 4;
+    next.time_sig_denominator = 4;
+    compute_playhead_changes(next, snapshot);
+
+    REQUIRE(next.tempo_changed);
+    REQUIRE_FALSE(next.time_sig_changed);
+    REQUIRE_FALSE(next.transport_changed);
+}
+
+TEST_CASE("compute_playhead_changes: time-sig numerator change flips time_sig_changed",
+          "[format][playhead][item-13][change-flags]") {
+    PlayheadSnapshot snapshot;
+    ProcessContext seed;
+    seed.time_sig_numerator = 4;
+    seed.time_sig_denominator = 4;
+    compute_playhead_changes(seed, snapshot);
+
+    ProcessContext next;
+    next.tempo_bpm = 120.0;
+    next.time_sig_numerator = 3;  // changed
+    next.time_sig_denominator = 4;
+    compute_playhead_changes(next, snapshot);
+
+    REQUIRE_FALSE(next.tempo_changed);
+    REQUIRE(next.time_sig_changed);
+    REQUIRE_FALSE(next.transport_changed);
+}
+
+TEST_CASE("compute_playhead_changes: time-sig denominator change flips time_sig_changed",
+          "[format][playhead][item-13][change-flags]") {
+    PlayheadSnapshot snapshot;
+    ProcessContext seed;
+    seed.time_sig_numerator = 4;
+    seed.time_sig_denominator = 4;
+    compute_playhead_changes(seed, snapshot);
+
+    ProcessContext next;
+    next.tempo_bpm = 120.0;
+    next.time_sig_numerator = 4;
+    next.time_sig_denominator = 8;  // changed
+    compute_playhead_changes(next, snapshot);
+
+    REQUIRE_FALSE(next.tempo_changed);
+    REQUIRE(next.time_sig_changed);
+    REQUIRE_FALSE(next.transport_changed);
+}
+
+TEST_CASE("compute_playhead_changes: is_playing flip raises transport_changed",
+          "[format][playhead][item-13][change-flags]") {
+    PlayheadSnapshot snapshot;
+    ProcessContext seed;
+    seed.is_playing = false;
+    compute_playhead_changes(seed, snapshot);
+
+    ProcessContext next;
+    next.tempo_bpm = 120.0;
+    next.time_sig_numerator = 4;
+    next.time_sig_denominator = 4;
+    next.is_playing = true;  // changed
+    compute_playhead_changes(next, snapshot);
+
+    REQUIRE_FALSE(next.tempo_changed);
+    REQUIRE_FALSE(next.time_sig_changed);
+    REQUIRE(next.transport_changed);
+}
+
+TEST_CASE("compute_playhead_changes: is_recording or is_looping flip raises transport_changed",
+          "[format][playhead][item-13][change-flags]") {
+    PlayheadSnapshot snapshot;
+    ProcessContext seed;
+    compute_playhead_changes(seed, snapshot);
+
+    SECTION("recording flip") {
+        ProcessContext next;
+        next.tempo_bpm = 120.0;
+        next.time_sig_numerator = 4;
+        next.time_sig_denominator = 4;
+        next.is_recording = true;
+        compute_playhead_changes(next, snapshot);
+        REQUIRE(next.transport_changed);
+    }
+
+    SECTION("looping flip") {
+        ProcessContext next;
+        next.tempo_bpm = 120.0;
+        next.time_sig_numerator = 4;
+        next.time_sig_denominator = 4;
+        next.is_looping = true;
+        compute_playhead_changes(next, snapshot);
+        REQUIRE(next.transport_changed);
+    }
+}
+
+TEST_CASE("compute_playhead_changes: multiple fields can flip in the same block",
+          "[format][playhead][item-13][change-flags]") {
+    PlayheadSnapshot snapshot;
+    ProcessContext seed;
+    seed.tempo_bpm = 100.0;
+    seed.time_sig_numerator = 4;
+    seed.time_sig_denominator = 4;
+    seed.is_playing = false;
+    compute_playhead_changes(seed, snapshot);
+
+    ProcessContext next;
+    next.tempo_bpm = 200.0;
+    next.time_sig_numerator = 7;
+    next.time_sig_denominator = 8;
+    next.is_playing = true;
+    compute_playhead_changes(next, snapshot);
+
+    REQUIRE(next.tempo_changed);
+    REQUIRE(next.time_sig_changed);
+    REQUIRE(next.transport_changed);
+}
+
+TEST_CASE("compute_playhead_changes: returning to previous values clears the flags",
+          "[format][playhead][item-13][change-flags]") {
+    PlayheadSnapshot snapshot;
+    ProcessContext seed;
+    seed.tempo_bpm = 120.0;
+    seed.time_sig_numerator = 4;
+    seed.time_sig_denominator = 4;
+    compute_playhead_changes(seed, snapshot);
+
+    ProcessContext bump;
+    bump.tempo_bpm = 180.0;
+    bump.time_sig_numerator = 4;
+    bump.time_sig_denominator = 4;
+    compute_playhead_changes(bump, snapshot);
+    REQUIRE(bump.tempo_changed);
+
+    ProcessContext steady;
+    steady.tempo_bpm = 180.0;
+    steady.time_sig_numerator = 4;
+    steady.time_sig_denominator = 4;
+    compute_playhead_changes(steady, snapshot);
+
+    REQUIRE_FALSE(steady.tempo_changed);
+    REQUIRE_FALSE(steady.time_sig_changed);
+    REQUIRE_FALSE(steady.transport_changed);
+}


### PR DESCRIPTION
## Summary

Closes the deferred follow-up on item **1.3 AudioPlayHead transport-extension adapter wiring** from the macOS plugin authoring plan. PR #2883 landed the struct-only slice (extended `ProcessContext` with `bar`, `is_looping`, `loop_start_beats`, `loop_end_beats`, `host_time_ns`, `frame_rate`, and `tempo_changed` / `time_sig_changed` / `transport_changed` flags). This PR wires those fields through every format adapter so plugins actually see the host's playhead state.

## What shipped

- **New** `core/format/include/pulp/format/detail/playhead_diff.hpp` — shared `derive_bar_from_beats` + `compute_playhead_changes` helpers used by every adapter (one source of truth for the bar derivation formula and the change-flag diff logic).
- **VST3** (`core/format/src/vst3_adapter.cpp`) — populates `is_recording`, `position_beats`, `is_looping` + loop range, `host_time_ns`, `frame_rate`, `bar`, and gates `tempo_bpm` on `kTempoValid`. Maps the seven SMPTE rates from VST3's `FrameRate` struct onto Pulp's enum.
- **AU v2** (`core/format/src/au_v2_adapter.cpp` + `core/format/src/au_v2_instrument.cpp`) — calls `CallHostBeatAndTempo` / `CallHostMusicalTimeLocation` / `CallHostTransportState` from the render path; `host_time_ns` from `mach_absolute_time` since AU has no host-time proc. `frame_rate` stays `unknown` (AU has no frame-rate proc).
- **AU v3** (`core/format/src/au_adapter.mm`) — captures `musicalContextBlock` + `transportStateBlock` at internalRenderBlock construction time per Apple's contract; `host_time_ns` from `timestamp->mHostTime`. `frame_rate` stays `unknown`.
- **CLAP** (`core/format/src/clap_adapter.cpp`) — reads `is_recording`, loop fields, `bar_number` from `clap_event_transport`; gates `tempo_bpm` on `CLAP_TRANSPORT_HAS_TEMPO` per the CLAP spec contract. `host_time_ns` + `frame_rate` stay at sentinels (CLAP carries neither).
- Each adapter gets a `PlayheadSnapshot` member to compute the three change flags by diffing against the previous block.

## Tests

- **New** `test/test_playhead_diff.cpp` (13 cases, 50 assertions) — pins the shared bar-derivation + change-flag helpers across 4/4, 3/4, 6/8, degenerate signatures, first-block contract, and every per-field flip.
- **Extended** `test/test_clap_midi_events.cpp` — two new end-to-end cases drive the CLAP harness with item-1.3 transport fields populated; one asserts every field lands; one asserts the change flags flip on the second block. The pre-existing "CLAP transport state" test now sets `CLAP_TRANSPORT_HAS_TEMPO` explicitly (the previous test silently relied on the unconditional-read behaviour that the spec forbids).
- All pre-existing adapter tests (clap-entry, clap-host-validation, vst3-plugin-state, au-v2-effect, au-v2-cocoa-ui, au-plugin-state, processor-defaults) stay green.

## Deferred

Per-host real-DAW validation (Logic 11+, Cubase, Bitwig, Reaper, AUM, StudioOne installing the actual `musicalContextBlock` / `HostCallbackInfo` / `Vst::ProcessContext` push paths) cannot be driven by Catch2 — it needs a real-host harness. Captured as the final acceptance gate on item 1.3 of the macOS plan; the unit + CLAP-harness coverage in this PR pins the adapter-side contract end to end.

AAX is not in this PR — the AAX SDK is developer-supplied and gated off the public CI matrix, so it ships as a follow-up alongside any AAX-skill work.

## Test plan

- [x] `pulp-test-playhead-diff` — 50 assertions / 13 cases
- [x] `pulp-test-clap-midi-events` — 352 assertions / 40 cases (includes 2 new item-1.3 cases)
- [x] `pulp-test-clap-entry` — 155 / 9
- [x] `pulp-test-clap-host-validation` — 56 / 4
- [x] `pulp-test-au-v2-effect` — 92 / 7
- [x] `pulp-test-au-plugin-state` — 145 / 10
- [x] `pulp-test-vst3-plugin-state` — 165 / 8
- [x] `pulp-test-processor-defaults` — 243 / 29

Skill-Update: skip skill=auv3 reason="adapter populates ProcessContext fields landed in #2883 via documented AUAudioUnit host blocks; no new gotchas vs the skill's existing render-block guidance"
Skill-Update: skip skill=auv2 reason="adapter populates ProcessContext fields landed in #2883 via documented AUSDK CallHost* helpers; no new gotchas vs the skill's existing MIDI/component-type guidance"
Skill-Update: skip skill=vst3 reason="adapter populates ProcessContext fields landed in #2883 via documented Vst::ProcessContext sources; no new gotchas vs the skill's existing transport-routing guidance"
Skill-Update: skip skill=clap reason="adapter populates ProcessContext fields landed in #2883 via documented clap_event_transport sources; no new gotchas vs the skill's existing transport-routing guidance"
Skill-Update: skip skill=view-bridge reason="ProcessContext transport extension does not touch editor lifecycle / view attach surface"

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>