### PR TITLE
feat(audio): AudioWorkgroup wiring + AudioDeviceManager lifecycle (items 1.1 + 1.2b)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.250.0
+    VERSION 0.251.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.251.0
+    VERSION 0.252.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/audio/include/pulp/audio/audio_device_manager.hpp
+++ b/core/audio/include/pulp/audio/audio_device_manager.hpp
@@ -1,12 +1,27 @@
 #pragma once
 
 /// @file audio_device_manager.hpp
-/// AudioDeviceManager — persistence + MIDI hub.
+/// AudioDeviceManager — persistence + MIDI hub + lifecycle / recovery.
 ///
-/// Part of macOS-plugin-authoring plan item 1.2a (Phase A). This is the
-/// persistence + MIDI-hub half of the manager. Lifecycle, hotplug, and
-/// recovery (1.2b) land in Phase B once `AudioWorkgroup` (1.1) and
-/// CoreAudio hotplug listeners are in place.
+/// Phase A (item 1.2a, PR #2936): persistence + MIDI hub + smoothed
+/// CPU-load surface — all backend-agnostic, no platform listeners.
+///
+/// Phase B (item 1.2b, this slice):
+///   - Live device hotplug detection (the manager observes a
+///     `pulp::audio::AudioSystem`'s device-change callback and
+///     republishes a structured `DeviceChangeEvent` to its own
+///     subscribers; tests can inject events without an AudioSystem).
+///   - Default-device-change recovery (subscribers learn when the
+///     system default output/input flipped underneath them).
+///   - Sample-rate-change recovery (subscribers learn when the active
+///     device's sample rate changed).
+///   - xrun counter exposed via `xrun_count()` for UI polling.
+///   - MIDI endpoint lifetime tracking — `set_midi_endpoints()`
+///     records the current input/output endpoint snapshot and
+///     dispatches `MidiEndpointChange` events on add/remove.
+///   - Concurrent-callback shutdown — `latch_close()` blocks until
+///     every in-flight dispatch returns and turns subsequent
+///     dispatches into no-ops.
 ///
 /// Responsibilities:
 ///   - Persists the user's selected audio device + sample rate + buffer
@@ -27,6 +42,8 @@
 #include <pulp/midi/device.hpp>
 #include <pulp/midi/message.hpp>
 
+#include <atomic>
+#include <condition_variable>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -202,18 +219,223 @@ public:
     /// Reset the peak tracker.
     void reset_peak_cpu_load();
 
+    // ── Lifecycle / hotplug / recovery (1.2b) ───────────────────────
+
+    /// What kind of device-list mutation occurred. `Unknown` is what
+    /// CoreAudio's hardware-devices listener delivers — the OS tells
+    /// us the list changed without saying how. The manager passes the
+    /// live device snapshot to the subscriber so it can diff against
+    /// its previous snapshot if it cares about adds / removes. Backends
+    /// that surface deltas natively (WASAPI IMMNotificationClient)
+    /// populate `Added`/`Removed`.
+    enum class DeviceChangeKind {
+        Unknown,   ///< List mutated; reason not disclosed.
+        Added,     ///< A device became available.
+        Removed,   ///< A device went away.
+        Replaced,  ///< Bulk swap (e.g., USB hub reset).
+    };
+
+    struct DeviceChangeEvent {
+        DeviceChangeKind kind = DeviceChangeKind::Unknown;
+        std::vector<DeviceInfo> devices;  ///< Snapshot at the time of the change.
+        std::string device_id;            ///< Affected id (when `kind != Unknown`).
+    };
+
+    using DeviceChangeHandler = std::function<void(const DeviceChangeEvent&)>;
+
+    /// RAII subscription token for device-change events. Same lifetime
+    /// rules as `MidiSubscriptionToken` — destruction unsubscribes,
+    /// outliving the manager is safe.
+    class DeviceChangeToken {
+    public:
+        DeviceChangeToken() = default;
+        DeviceChangeToken(const DeviceChangeToken&) = delete;
+        DeviceChangeToken& operator=(const DeviceChangeToken&) = delete;
+        DeviceChangeToken(DeviceChangeToken&& other) noexcept;
+        DeviceChangeToken& operator=(DeviceChangeToken&& other) noexcept;
+        ~DeviceChangeToken();
+
+        bool active() const noexcept {
+            return id_ != 0 && !manager_.expired();
+        }
+        void reset() noexcept;
+
+    private:
+        friend class AudioDeviceManager;
+        DeviceChangeToken(std::weak_ptr<void> manager_ptr,
+                          AudioDeviceManager* manager_raw,
+                          uint64_t id) noexcept
+            : manager_(std::move(manager_ptr)), manager_raw_(manager_raw), id_(id) {}
+
+        std::weak_ptr<void>  manager_;
+        AudioDeviceManager*  manager_raw_ = nullptr;
+        uint64_t             id_ = 0;
+    };
+
+    /// Subscribe to device-change events. Returns an RAII token whose
+    /// destruction unsubscribes. Safe to call from any thread.
+    [[nodiscard]] DeviceChangeToken subscribe_device_changes(DeviceChangeHandler handler);
+
+    /// Number of currently active device-change subscribers (tests).
+    std::size_t device_change_subscriber_count() const;
+
+    /// Bind a live `AudioSystem` whose device-change callback should
+    /// drive `dispatch_device_change()`. The manager registers itself
+    /// via `system->set_device_change_callback(...)` and re-issues
+    /// `DeviceChangeEvent`s with the snapshot. Pass `nullptr` to
+    /// unbind. Tests can skip this entirely and call
+    /// `dispatch_device_change` directly with an injected snapshot.
+    void attach_audio_system(AudioSystem* system);
+
+    /// Dispatch a device-change event to subscribers. Safe to call
+    /// from any thread; tests use it to simulate hotplug without an
+    /// AudioSystem. After `latch_close()` returns, this is a no-op.
+    void dispatch_device_change(const DeviceChangeEvent& event);
+
+    /// Subscribers learn when the system default output / input
+    /// changed. `is_input == true` means the default input device
+    /// changed; `false` means default output. The handler receives
+    /// the new device id (callers query the platform and forward it).
+    using DefaultDeviceChangeHandler =
+        std::function<void(bool is_input, const std::string& new_device_id)>;
+
+    /// Register a single default-device-change handler. Pass `nullptr`
+    /// to clear. The manager fans out to a single handler (not a list)
+    /// because the typical host has exactly one recovery policy.
+    void set_default_device_change_handler(DefaultDeviceChangeHandler handler);
+
+    /// Dispatch a default-device-change to the registered handler.
+    /// Safe to call from any thread; tests use it to simulate
+    /// default-device flips. No-op after `latch_close()`.
+    void dispatch_default_device_change(bool is_input,
+                                        const std::string& new_device_id);
+
+    /// Subscribers learn when the active device's nominal sample rate
+    /// changed. Hosts typically react by re-preparing their processor
+    /// graph against the new rate.
+    using SampleRateChangeHandler = std::function<void(double new_rate)>;
+
+    void set_sample_rate_change_handler(SampleRateChangeHandler handler);
+
+    /// Dispatch a sample-rate-change event to the registered handler.
+    /// Also bumps a counter so a host can observe how many rate
+    /// changes the active session has weathered. No-op after
+    /// `latch_close()`.
+    void dispatch_sample_rate_change(double new_rate);
+
+    /// Total number of sample-rate changes seen since construction.
+    std::uint64_t sample_rate_change_count() const;
+
+    /// Last known sample rate (set every `dispatch_sample_rate_change`).
+    double last_sample_rate() const;
+
+    // ── xrun tracking ──────────────────────────────────────────────
+
+    /// Increment the manager's internal xrun counter. Hosts wire this
+    /// to the active `AudioDevice::xrun_count()` delta, or call it
+    /// directly when a backend doesn't surface overload events.
+    void bump_xrun_counter(std::uint64_t delta = 1);
+
+    /// Snapshot the current xrun count. Safe from any thread.
+    std::uint64_t xrun_count() const;
+
+    /// Reset the xrun counter to zero.
+    void reset_xrun_counter();
+
+    // ── MIDI endpoint tracking ─────────────────────────────────────
+
+    struct MidiEndpoint {
+        std::string id;
+        std::string name;
+        bool is_input = false;  ///< true == input; false == output.
+    };
+
+    enum class MidiEndpointChangeKind {
+        Added,
+        Removed,
+    };
+
+    struct MidiEndpointChange {
+        MidiEndpointChangeKind kind;
+        MidiEndpoint endpoint;
+    };
+
+    using MidiEndpointChangeHandler = std::function<void(const MidiEndpointChange&)>;
+
+    /// Subscribe to MIDI endpoint add/remove events. Returns the same
+    /// `MidiSubscriptionToken` flavor as `subscribe_midi`. The id
+    /// namespace is separate from MIDI-event subscriptions, so
+    /// `midi_subscriber_count()` does not include endpoint listeners.
+    [[nodiscard]] MidiSubscriptionToken subscribe_midi_endpoints(
+        MidiEndpointChangeHandler handler);
+
+    std::size_t midi_endpoint_subscriber_count() const;
+
+    /// Replace the manager's snapshot of live MIDI endpoints. Deltas
+    /// from the previous snapshot dispatch to subscribers as
+    /// `MidiEndpointChange` events. Endpoint identity is by `id`.
+    /// No-op after `latch_close()` (state still updates, but no
+    /// dispatch fires).
+    void set_midi_endpoints(std::vector<MidiEndpoint> endpoints);
+
+    /// Current MIDI endpoint snapshot.
+    std::vector<MidiEndpoint> midi_endpoints() const;
+
+    // ── Concurrent-callback shutdown ───────────────────────────────
+
+    /// Latch the manager so subsequent dispatches are no-ops. Blocks
+    /// until any in-flight dispatch (MIDI event, device change,
+    /// default-device change, sample-rate change, endpoint change)
+    /// has returned. After `latch_close()` returns, the host can
+    /// safely destroy the objects that own the subscriber callbacks.
+    ///
+    /// Symmetric to the `close()`-then-`stop()` pattern in
+    /// `core/audio::AudioDevice` — this is the manager-level latch.
+    void latch_close();
+
+    /// True after `latch_close()` has been called.
+    bool is_closed() const noexcept;
+
 private:
     friend class MidiSubscriptionToken;
+    friend class DeviceChangeToken;
 
     void unsubscribe_midi(uint64_t id) noexcept;
+    void unsubscribe_device_change(uint64_t id) noexcept;
+    void unsubscribe_midi_endpoint(uint64_t id) noexcept;
 
-    /// Lifetime peg for `MidiSubscriptionToken`. Token holds a
-    /// `weak_ptr<void>` to this; destruction marks the manager dead.
+    // RAII guard used by every dispatcher; blocks latch_close() until
+    // all in-flight dispatches return.
+    class DispatchGuard;
+
+    /// Lifetime peg for tokens. Token holds a `weak_ptr<void>` to
+    /// this; destruction marks the manager dead.
     std::shared_ptr<void>                        lifetime_;
 
     mutable std::mutex                           midi_mu_;
     std::unordered_map<uint64_t, MidiHandler>    midi_subs_;
     uint64_t                                     next_midi_id_ = 1;
+
+    mutable std::mutex                                          device_change_mu_;
+    std::unordered_map<uint64_t, DeviceChangeHandler>           device_change_subs_;
+    uint64_t                                                    next_device_change_id_ = 1;
+
+    mutable std::mutex                              default_dev_mu_;
+    DefaultDeviceChangeHandler                      default_dev_handler_;
+
+    mutable std::mutex                              sr_mu_;
+    SampleRateChangeHandler                         sr_handler_;
+    std::atomic<std::uint64_t>                      sr_change_count_{0};
+    std::atomic<double>                             last_sr_{0.0};
+
+    std::atomic<std::uint64_t>                      xrun_counter_{0};
+
+    mutable std::mutex                                                midi_ep_mu_;
+    std::unordered_map<uint64_t, MidiEndpointChangeHandler>           midi_ep_subs_;
+    uint64_t                                                          next_midi_ep_id_ = 1;
+    std::vector<MidiEndpoint>                                         midi_endpoints_;
+
+    AudioSystem*                                    attached_system_ = nullptr;
 
     /// CPU-load mutex protects begin/end against load() readers on
     /// other threads. The measurer itself is not thread-safe, so we
@@ -222,6 +444,14 @@ private:
     /// callback.
     mutable std::mutex                           load_mu_;
     AudioProcessLoadMeasurer                     load_;
+
+    /// Latch state. `closed_` flips true in `latch_close()` and stays
+    /// that way for the manager's lifetime. `in_flight_` counts active
+    /// dispatchers; `latch_close()` waits for it to reach zero.
+    std::atomic<bool>                            closed_{false};
+    mutable std::mutex                           latch_mu_;
+    std::condition_variable                      latch_cv_;
+    int                                          in_flight_ = 0;
 };
 
 }  // namespace pulp::audio

--- a/core/audio/include/pulp/audio/device.hpp
+++ b/core/audio/include/pulp/audio/device.hpp
@@ -62,6 +62,32 @@ public:
     virtual DeviceInfo info() const = 0;
     virtual double sample_rate() const = 0;
     virtual int buffer_size() const = 0;
+
+    /// Opaque handle to the OS-supplied real-time workgroup associated
+    /// with this device's I/O thread, or `nullptr` if the platform does
+    /// not expose one. On macOS 13+ / iOS 16+ this returns the
+    /// `os_workgroup_t` queried via `kAudioDevicePropertyIOThreadOSWorkgroup`;
+    /// on older Apple targets and on non-Apple platforms this returns
+    /// `nullptr` and callers fall back to
+    /// `AudioWorkgroup::set_realtime_priority()`.
+    ///
+    /// The returned pointer is owned by the device and remains valid
+    /// for the lifetime of the open device. Callers must not free it.
+    /// Pass it to `AudioWorkgroup::set_workgroup(static_cast<os_workgroup_t>(...))`
+    /// before joining from the audio thread.
+    ///
+    /// Default returns `nullptr` so non-Apple backends inherit the
+    /// best-effort priority fallback for free.
+    virtual void* callback_workgroup() const { return nullptr; }
+
+    /// Cumulative xrun (overload/underrun) count since `start()` or
+    /// the last `reset_xrun_counter()`. CoreAudio devices increment on
+    /// every `kAudioDeviceProcessorOverload` notification; backends
+    /// that do not surface overload events stay at 0.
+    virtual std::uint64_t xrun_count() const { return 0; }
+
+    /// Reset the xrun counter to 0. Safe from any thread.
+    virtual void reset_xrun_counter() {}
 };
 
 // Audio system — enumerates devices and creates device instances

--- a/core/audio/platform/mac/coreaudio_device.hpp
+++ b/core/audio/platform/mac/coreaudio_device.hpp
@@ -1,7 +1,15 @@
 #pragma once
 
 #include <pulp/audio/device.hpp>
+#include <pulp/audio/workgroup.hpp>
 #include <AudioToolbox/AudioToolbox.h>
+
+#include <atomic>
+#include <cstdint>
+
+#if defined(__APPLE__)
+#include <os/workgroup.h>
+#endif
 
 namespace pulp::audio::mac {
 
@@ -21,6 +29,27 @@ public:
     double sample_rate() const override { return config_.sample_rate; }
     int buffer_size() const override { return config_.buffer_size; }
 
+    /// Returns the device's I/O thread workgroup (`os_workgroup_t`)
+    /// queried via `kAudioDevicePropertyIOThreadOSWorkgroup` on
+    /// macOS 13+, or `nullptr` on older targets / when the device
+    /// does not publish a workgroup. Owned by the device; valid for
+    /// the lifetime of the open device.
+    void* callback_workgroup() const override {
+#if defined(__APPLE__)
+        return reinterpret_cast<void*>(workgroup_);
+#else
+        return nullptr;
+#endif
+    }
+
+    std::uint64_t xrun_count() const override {
+        return xrun_counter_.load(std::memory_order_relaxed);
+    }
+
+    void reset_xrun_counter() override {
+        xrun_counter_.store(0, std::memory_order_relaxed);
+    }
+
 private:
     static OSStatus render_callback(
         void* inRefCon,
@@ -30,6 +59,17 @@ private:
         UInt32 inNumberFrames,
         AudioBufferList* ioData);
 
+    static OSStatus overload_listener(
+        AudioObjectID inObjectID,
+        UInt32 inNumberAddresses,
+        const AudioObjectPropertyAddress* inAddresses,
+        void* inClientData);
+
+    /// Query the active device for its IO-thread workgroup; cache it
+    /// into `workgroup_`. No-op on older OS / when the device does
+    /// not publish one.
+    void query_callback_workgroup();
+
     AudioDeviceID device_id_;
     AudioComponentInstance audio_unit_ = nullptr;
     DeviceConfig config_;
@@ -38,6 +78,17 @@ private:
     bool is_running_ = false;
     bool input_enabled_ = false;
     uint64_t sample_position_ = 0;
+
+#if defined(__APPLE__)
+    os_workgroup_t workgroup_ = nullptr;
+#endif
+
+    // RAII workgroup join that lives on the render thread. First
+    // invocation of render_callback joins; leaves on device close().
+    AudioWorkgroup wg_join_;
+    std::atomic<bool> wg_joined_{false};
+    std::atomic<std::uint64_t> xrun_counter_{0};
+    bool overload_listener_installed_ = false;
 
     // Buffers for the callback
     std::vector<float*> output_ptrs_;
@@ -52,7 +103,7 @@ private:
 
 class CoreAudioSystem : public AudioSystem {
 public:
-    CoreAudioSystem() = default;
+    CoreAudioSystem();
     ~CoreAudioSystem() override;
 
     std::vector<DeviceInfo> enumerate_devices() override;
@@ -61,14 +112,24 @@ public:
     DeviceInfo default_input_device() override;
     void set_device_change_callback(DeviceChangeCallback cb) override;
 
+    /// Subscribe to default-device-change events. The callback fires
+    /// on a CoreAudio thread; subscribers must marshal to the UI
+    /// thread themselves if needed. Pass `nullptr` to clear.
+    using DefaultDeviceChangeCallback = std::function<void(bool is_input)>;
+    void set_default_device_change_callback(DefaultDeviceChangeCallback cb);
+
     static DeviceInfo query_device_info(AudioDeviceID device_id);
     static AudioDeviceID get_default_device(bool input);
 
 private:
     static OSStatus device_list_changed(AudioObjectID, UInt32,
                                         const AudioObjectPropertyAddress*, void*);
+    static OSStatus default_device_changed(AudioObjectID, UInt32,
+                                           const AudioObjectPropertyAddress*, void*);
     DeviceChangeCallback device_change_cb_;
+    DefaultDeviceChangeCallback default_device_change_cb_;
     bool listener_installed_ = false;
+    bool default_listener_installed_ = false;
 };
 
 } // namespace pulp::audio::mac

--- a/core/audio/platform/mac/coreaudio_device.mm
+++ b/core/audio/platform/mac/coreaudio_device.mm
@@ -2,7 +2,19 @@
 #include <pulp/runtime/log.hpp>
 #include <CoreAudio/CoreAudio.h>
 
+#include <cstring>
+
 namespace pulp::audio::mac {
+
+namespace {
+
+// kAudioDevicePropertyIOThreadOSWorkgroup is declared in the macOS 11+
+// SDK but Apple's docs only guarantee a usable workgroup on macOS 13 /
+// iOS 16+. Phase B floor follows that guarantee.
+constexpr AudioObjectPropertySelector kIOThreadWorkgroupSelector =
+    kAudioDevicePropertyIOThreadOSWorkgroup;
+
+}  // namespace
 
 // ── CoreAudioDevice ────────────────────────────────────────────────────────
 
@@ -14,6 +26,36 @@ CoreAudioDevice::CoreAudioDevice(AudioDeviceID device_id)
 CoreAudioDevice::~CoreAudioDevice() {
     if (is_running_) stop();
     if (is_open_) close();
+}
+
+void CoreAudioDevice::query_callback_workgroup() {
+#if defined(__APPLE__)
+    workgroup_ = nullptr;
+    if (__builtin_available(macOS 13.0, iOS 16.0, *)) {
+        AudioObjectPropertyAddress prop{};
+        prop.mSelector = kIOThreadWorkgroupSelector;
+        prop.mScope    = kAudioObjectPropertyScopeGlobal;
+        prop.mElement  = kAudioObjectPropertyElementMain;
+
+        os_workgroup_t wg = nullptr;
+        UInt32 size = sizeof(wg);
+        OSStatus status = AudioObjectGetPropertyData(
+            device_id_, &prop, 0, nullptr, &size, &wg);
+        if (status == noErr && wg != nullptr) {
+            workgroup_ = wg;
+            runtime::log_info(
+                "CoreAudio: extracted IO-thread workgroup for device {}",
+                static_cast<unsigned>(device_id_));
+        } else if (status != noErr) {
+            // Device does not publish a workgroup. The render
+            // callback's first entry falls back to Mach RT priority.
+            runtime::log_debug(
+                "CoreAudio: device {} has no IO workgroup (status {})",
+                static_cast<unsigned>(device_id_),
+                static_cast<int>(status));
+        }
+    }
+#endif
 }
 
 bool CoreAudioDevice::open(const DeviceConfig& config) {
@@ -153,6 +195,34 @@ bool CoreAudioDevice::open(const DeviceConfig& config) {
         return false;
     }
 
+    // Query the IO-thread workgroup and arm wg_join_ before the callback
+    // starts firing. First callback entry joins on the audio thread.
+    query_callback_workgroup();
+#if defined(__APPLE__)
+    if (workgroup_) {
+        wg_join_.set_workgroup(workgroup_);
+    }
+#endif
+
+    // Install a device-overload listener so we can count xruns. The
+    // notification fires on a CoreAudio thread; we only increment an
+    // atomic, so it's safe.
+    {
+        AudioObjectPropertyAddress overload_prop{};
+        overload_prop.mSelector = kAudioDeviceProcessorOverload;
+        overload_prop.mScope    = kAudioObjectPropertyScopeGlobal;
+        overload_prop.mElement  = kAudioObjectPropertyElementMain;
+        OSStatus overload_status = AudioObjectAddPropertyListener(
+            device_id_, &overload_prop, overload_listener, this);
+        overload_listener_installed_ = (overload_status == noErr);
+        if (!overload_listener_installed_) {
+            runtime::log_debug(
+                "CoreAudio: device {} did not accept overload listener ({})",
+                static_cast<unsigned>(device_id_),
+                static_cast<int>(overload_status));
+        }
+    }
+
     is_open_ = true;
     runtime::log_info("CoreAudio: opened device '{}' at {} Hz, buffer {}, input {}ch",
         info().name, config_.sample_rate, config_.buffer_size,
@@ -161,11 +231,32 @@ bool CoreAudioDevice::open(const DeviceConfig& config) {
 }
 
 void CoreAudioDevice::close() {
+    // Tear the callback path down first. AudioUnitUninitialize blocks
+    // until any in-flight render_callback returns — combined with
+    // is_running_ being cleared in stop(), this gives the manager's
+    // "callback won't re-fire after close()" guarantee.
+    if (overload_listener_installed_) {
+        AudioObjectPropertyAddress overload_prop{};
+        overload_prop.mSelector = kAudioDeviceProcessorOverload;
+        overload_prop.mScope    = kAudioObjectPropertyScopeGlobal;
+        overload_prop.mElement  = kAudioObjectPropertyElementMain;
+        AudioObjectRemovePropertyListener(
+            device_id_, &overload_prop, overload_listener, this);
+        overload_listener_installed_ = false;
+    }
     if (audio_unit_) {
         AudioUnitUninitialize(audio_unit_);
         AudioComponentInstanceDispose(audio_unit_);
         audio_unit_ = nullptr;
     }
+    // Leave the workgroup (no-op if never joined). After
+    // AudioUnitUninitialize returns no callback can still be in
+    // flight, so this is race-free.
+    wg_join_.leave();
+    wg_joined_.store(false, std::memory_order_relaxed);
+#if defined(__APPLE__)
+    workgroup_ = nullptr;
+#endif
     if (input_buffer_list_) {
         std::free(input_buffer_list_);
         input_buffer_list_ = nullptr;
@@ -192,6 +283,9 @@ bool CoreAudioDevice::start(AudioCallback callback) {
 
 void CoreAudioDevice::stop() {
     if (audio_unit_ && is_running_) {
+        // AudioOutputUnitStop blocks until the I/O thread observes
+        // the stop request. Subsequent callbacks observe
+        // `is_running_ == false` and bail before invoking `callback_`.
         AudioOutputUnitStop(audio_unit_);
     }
     is_running_ = false;
@@ -211,6 +305,19 @@ OSStatus CoreAudioDevice::render_callback(
     AudioBufferList* ioData)
 {
     auto* self = static_cast<CoreAudioDevice*>(inRefCon);
+
+    // First-entry: join the audio device's workgroup on the render
+    // thread. acquire/release on `wg_joined_` keeps the join visible
+    // to subsequent renders without a CAS hot path. The boolean also
+    // means join is at most once per render thread.
+    if (!self->wg_joined_.load(std::memory_order_acquire)) {
+        // join_from_audio_thread() returns immediately if there's no
+        // workgroup set; it falls back to Mach realtime priority in
+        // that case so the thread is still RT-tagged.
+        self->wg_join_.join_from_audio_thread();
+        self->wg_joined_.store(true, std::memory_order_release);
+    }
+
     if (!self->callback_) {
         // Silence
         for (UInt32 i = 0; i < ioData->mNumberBuffers; ++i) {
@@ -262,7 +369,22 @@ OSStatus CoreAudioDevice::render_callback(
     return noErr;
 }
 
+OSStatus CoreAudioDevice::overload_listener(
+    AudioObjectID /*inObjectID*/,
+    UInt32 /*inNumberAddresses*/,
+    const AudioObjectPropertyAddress* /*inAddresses*/,
+    void* inClientData)
+{
+    auto* self = static_cast<CoreAudioDevice*>(inClientData);
+    if (self) {
+        self->xrun_counter_.fetch_add(1, std::memory_order_relaxed);
+    }
+    return noErr;
+}
+
 // ── CoreAudioSystem ────────────────────────────────────────────────────────
+
+CoreAudioSystem::CoreAudioSystem() = default;
 
 CoreAudioSystem::~CoreAudioSystem() {
     if (listener_installed_) {
@@ -273,10 +395,27 @@ CoreAudioSystem::~CoreAudioSystem() {
         AudioObjectRemovePropertyListener(kAudioObjectSystemObject, &prop,
                                           device_list_changed, this);
     }
+    if (default_listener_installed_) {
+        AudioObjectPropertyAddress out_prop{};
+        out_prop.mSelector = kAudioHardwarePropertyDefaultOutputDevice;
+        out_prop.mScope    = kAudioObjectPropertyScopeGlobal;
+        out_prop.mElement  = kAudioObjectPropertyElementMain;
+        AudioObjectRemovePropertyListener(kAudioObjectSystemObject, &out_prop,
+                                          default_device_changed, this);
+
+        AudioObjectPropertyAddress in_prop = out_prop;
+        in_prop.mSelector = kAudioHardwarePropertyDefaultInputDevice;
+        AudioObjectRemovePropertyListener(kAudioObjectSystemObject, &in_prop,
+                                          default_device_changed, this);
+    }
 }
 
 void CoreAudioSystem::set_device_change_callback(DeviceChangeCallback cb) {
     device_change_cb_ = std::move(cb);
+    // Also store the callback in the base class so
+    // `AudioSystem::fire_device_change()` finds it for cross-backend
+    // helpers (e.g. AudioDeviceManager wiring).
+    AudioSystem::set_device_change_callback(device_change_cb_);
 
     if (device_change_cb_ && !listener_installed_) {
         AudioObjectPropertyAddress prop{};
@@ -291,6 +430,28 @@ void CoreAudioSystem::set_device_change_callback(DeviceChangeCallback cb) {
     }
 }
 
+void CoreAudioSystem::set_default_device_change_callback(DefaultDeviceChangeCallback cb) {
+    default_device_change_cb_ = std::move(cb);
+
+    if (default_device_change_cb_ && !default_listener_installed_) {
+        AudioObjectPropertyAddress out_prop{};
+        out_prop.mSelector = kAudioHardwarePropertyDefaultOutputDevice;
+        out_prop.mScope    = kAudioObjectPropertyScopeGlobal;
+        out_prop.mElement  = kAudioObjectPropertyElementMain;
+        OSStatus s1 = AudioObjectAddPropertyListener(
+            kAudioObjectSystemObject, &out_prop, default_device_changed, this);
+
+        AudioObjectPropertyAddress in_prop = out_prop;
+        in_prop.mSelector = kAudioHardwarePropertyDefaultInputDevice;
+        OSStatus s2 = AudioObjectAddPropertyListener(
+            kAudioObjectSystemObject, &in_prop, default_device_changed, this);
+
+        if (s1 == noErr || s2 == noErr) {
+            default_listener_installed_ = true;
+        }
+    }
+}
+
 OSStatus CoreAudioSystem::device_list_changed(
     AudioObjectID, UInt32,
     const AudioObjectPropertyAddress*, void* inClientData)
@@ -299,6 +460,26 @@ OSStatus CoreAudioSystem::device_list_changed(
     if (self->device_change_cb_) {
         self->device_change_cb_();
     }
+    return noErr;
+}
+
+OSStatus CoreAudioSystem::default_device_changed(
+    AudioObjectID,
+    UInt32 nAddresses,
+    const AudioObjectPropertyAddress* addresses,
+    void* inClientData)
+{
+    auto* self = static_cast<CoreAudioSystem*>(inClientData);
+    if (!self || !self->default_device_change_cb_) return noErr;
+
+    bool is_input = false;
+    for (UInt32 i = 0; i < nAddresses; ++i) {
+        if (addresses[i].mSelector == kAudioHardwarePropertyDefaultInputDevice) {
+            is_input = true;
+            break;
+        }
+    }
+    self->default_device_change_cb_(is_input);
     return noErr;
 }
 

--- a/core/audio/src/audio_device_manager.cpp
+++ b/core/audio/src/audio_device_manager.cpp
@@ -1,10 +1,13 @@
 /// @file audio_device_manager.cpp
-/// AudioDeviceManager — persistence + MIDI hub (item 1.2a).
+/// AudioDeviceManager — persistence + MIDI hub (item 1.2a) + lifecycle
+/// / hotplug / recovery (item 1.2b).
 
 #include <pulp/audio/audio_device_manager.hpp>
 #include <pulp/state/properties_file.hpp>
 
+#include <algorithm>
 #include <bitset>
+#include <unordered_set>
 #include <utility>
 
 namespace pulp::audio {
@@ -58,17 +61,72 @@ void MidiSubscriptionToken::reset() noexcept {
 
 // ── AudioDeviceManager ──────────────────────────────────────────────
 
+// DispatchGuard: RAII ref-count that increments `in_flight_` on
+// construction (unless the manager is already closed) and decrements
+// + notifies `latch_close()` on destruction. Single-purpose helper —
+// defined inline here at the top of the TU so every dispatcher in the
+// file can construct one on the stack.
+class AudioDeviceManager::DispatchGuard {
+public:
+    explicit DispatchGuard(AudioDeviceManager* mgr) : mgr_(mgr) {
+        std::lock_guard<std::mutex> lk(mgr_->latch_mu_);
+        if (mgr_->closed_.load(std::memory_order_acquire)) {
+            entered_ = false;  // closed; dispatchers bail on entered() == false.
+            return;
+        }
+        ++mgr_->in_flight_;
+        entered_ = true;
+    }
+    ~DispatchGuard() {
+        if (!entered_) return;
+        std::lock_guard<std::mutex> lk(mgr_->latch_mu_);
+        if (--mgr_->in_flight_ == 0) {
+            mgr_->latch_cv_.notify_all();
+        }
+    }
+    bool entered() const noexcept { return entered_; }
+    DispatchGuard(const DispatchGuard&) = delete;
+    DispatchGuard& operator=(const DispatchGuard&) = delete;
+private:
+    AudioDeviceManager* mgr_;
+    bool entered_ = false;
+};
+
 AudioDeviceManager::AudioDeviceManager()
     : lifetime_(std::make_shared<int>(0)) {
 }
 
 AudioDeviceManager::~AudioDeviceManager() {
-    // Drop lifetime_ first so any outstanding tokens that observe via
+    // Latch the manager first so any in-flight dispatcher returns
+    // before we tear state down. After latch_close(), subsequent
+    // dispatches are no-ops, and `in_flight_` is guaranteed zero.
+    latch_close();
+
+    // Detach from any bound AudioSystem so its callback can no longer
+    // reach us. Equivalent to attach_audio_system(nullptr) without
+    // the dispatch indirection.
+    if (attached_system_) {
+        attached_system_->set_device_change_callback(nullptr);
+        attached_system_ = nullptr;
+    }
+
+    // Drop lifetime_ so any outstanding tokens that observe via
     // weak_ptr.lock() see the manager as already dead and skip the
     // unsubscribe call. The token destructor is then a safe no-op.
     lifetime_.reset();
-    std::lock_guard<std::mutex> lk(midi_mu_);
-    midi_subs_.clear();
+
+    {
+        std::lock_guard<std::mutex> lk(midi_mu_);
+        midi_subs_.clear();
+    }
+    {
+        std::lock_guard<std::mutex> lk(device_change_mu_);
+        device_change_subs_.clear();
+    }
+    {
+        std::lock_guard<std::mutex> lk(midi_ep_mu_);
+        midi_ep_subs_.clear();
+    }
 }
 
 // ── Persistence ─────────────────────────────────────────────────────
@@ -179,6 +237,12 @@ MidiSubscriptionToken AudioDeviceManager::subscribe_midi(MidiHandler handler) {
 }
 
 void AudioDeviceManager::dispatch_midi_event(const pulp::midi::MidiEvent& event) {
+    // After latch_close() this returns immediately, so a host can
+    // safely destroy subscribers' owning objects once the latch
+    // returns.
+    DispatchGuard guard(this);
+    if (!guard.entered()) return;
+
     // Snapshot under lock so a subscriber callback that itself
     // (un)subscribes doesn't iterate-while-mutating. Copy is cheap —
     // std::function holds a small handler, and the subscriber count
@@ -200,8 +264,17 @@ std::size_t AudioDeviceManager::midi_subscriber_count() const {
 }
 
 void AudioDeviceManager::unsubscribe_midi(uint64_t id) noexcept {
-    std::lock_guard<std::mutex> lk(midi_mu_);
-    midi_subs_.erase(id);
+    // Token destructors call this for both MIDI-event and MIDI-endpoint
+    // subscriptions (they share the MidiSubscriptionToken type for
+    // brevity). Try both maps — erase() of a missing key is a no-op.
+    {
+        std::lock_guard<std::mutex> lk(midi_mu_);
+        if (midi_subs_.erase(id) != 0) return;
+    }
+    {
+        std::lock_guard<std::mutex> lk(midi_ep_mu_);
+        midi_ep_subs_.erase(id);
+    }
 }
 
 // ── CPU load ────────────────────────────────────────────────────────
@@ -229,6 +302,279 @@ float AudioDeviceManager::peak_cpu_load() const {
 void AudioDeviceManager::reset_peak_cpu_load() {
     std::lock_guard<std::mutex> lk(load_mu_);
     load_.reset_peak();
+}
+
+// ── Lifecycle / hotplug / recovery (1.2b) ───────────────────────────
+
+// ── DeviceChangeToken ───────────────────────────────────────────────
+
+AudioDeviceManager::DeviceChangeToken::DeviceChangeToken(
+    DeviceChangeToken&& other) noexcept
+    : manager_(std::move(other.manager_)),
+      manager_raw_(other.manager_raw_),
+      id_(other.id_) {
+    other.manager_raw_ = nullptr;
+    other.id_ = 0;
+}
+
+AudioDeviceManager::DeviceChangeToken&
+AudioDeviceManager::DeviceChangeToken::operator=(
+    DeviceChangeToken&& other) noexcept {
+    if (this != &other) {
+        reset();
+        manager_     = std::move(other.manager_);
+        manager_raw_ = other.manager_raw_;
+        id_          = other.id_;
+        other.manager_raw_ = nullptr;
+        other.id_          = 0;
+    }
+    return *this;
+}
+
+AudioDeviceManager::DeviceChangeToken::~DeviceChangeToken() {
+    reset();
+}
+
+void AudioDeviceManager::DeviceChangeToken::reset() noexcept {
+    if (id_ == 0) return;
+    if (auto pegged = manager_.lock()) {
+        if (manager_raw_) {
+            manager_raw_->unsubscribe_device_change(id_);
+        }
+    }
+    manager_.reset();
+    manager_raw_ = nullptr;
+    id_ = 0;
+}
+
+// ── Hotplug / device change ─────────────────────────────────────────
+
+AudioDeviceManager::DeviceChangeToken
+AudioDeviceManager::subscribe_device_changes(DeviceChangeHandler handler) {
+    if (!handler) return {};
+    std::lock_guard<std::mutex> lk(device_change_mu_);
+    const uint64_t id = next_device_change_id_++;
+    device_change_subs_.emplace(id, std::move(handler));
+    return DeviceChangeToken(
+        std::weak_ptr<void>(lifetime_),
+        this,
+        id);
+}
+
+std::size_t AudioDeviceManager::device_change_subscriber_count() const {
+    std::lock_guard<std::mutex> lk(device_change_mu_);
+    return device_change_subs_.size();
+}
+
+void AudioDeviceManager::unsubscribe_device_change(uint64_t id) noexcept {
+    std::lock_guard<std::mutex> lk(device_change_mu_);
+    device_change_subs_.erase(id);
+}
+
+void AudioDeviceManager::attach_audio_system(AudioSystem* system) {
+    // If we were already bound, clear the old callback so the previous
+    // AudioSystem stops talking to us.
+    if (attached_system_ && attached_system_ != system) {
+        attached_system_->set_device_change_callback(nullptr);
+    }
+    attached_system_ = system;
+    if (!system) return;
+
+    // Bridge the AudioSystem's "the list changed" callback into a
+    // structured DeviceChangeEvent the manager can fan out. We can't
+    // know "what" changed from the CoreAudio side without diffing
+    // (which is the subscriber's job if they care), so the kind is
+    // `Unknown` here.
+    system->set_device_change_callback([this, system]() {
+        DeviceChangeEvent ev;
+        ev.kind    = DeviceChangeKind::Unknown;
+        ev.devices = system->enumerate_devices();
+        dispatch_device_change(ev);
+    });
+}
+
+void AudioDeviceManager::dispatch_device_change(const DeviceChangeEvent& event) {
+    DispatchGuard guard(this);
+    if (!guard.entered()) return;  // closed; drop event.
+
+    std::vector<DeviceChangeHandler> handlers;
+    {
+        std::lock_guard<std::mutex> lk(device_change_mu_);
+        handlers.reserve(device_change_subs_.size());
+        for (auto& [_id, fn] : device_change_subs_) handlers.push_back(fn);
+    }
+    for (auto& fn : handlers) {
+        if (fn) fn(event);
+    }
+}
+
+// ── Default-device change ───────────────────────────────────────────
+
+void AudioDeviceManager::set_default_device_change_handler(
+    DefaultDeviceChangeHandler handler) {
+    std::lock_guard<std::mutex> lk(default_dev_mu_);
+    default_dev_handler_ = std::move(handler);
+}
+
+void AudioDeviceManager::dispatch_default_device_change(
+    bool is_input, const std::string& new_device_id) {
+    DispatchGuard guard(this);
+    if (!guard.entered()) return;
+
+    DefaultDeviceChangeHandler handler;
+    {
+        std::lock_guard<std::mutex> lk(default_dev_mu_);
+        handler = default_dev_handler_;
+    }
+    if (handler) handler(is_input, new_device_id);
+}
+
+// ── Sample-rate change ──────────────────────────────────────────────
+
+void AudioDeviceManager::set_sample_rate_change_handler(
+    SampleRateChangeHandler handler) {
+    std::lock_guard<std::mutex> lk(sr_mu_);
+    sr_handler_ = std::move(handler);
+}
+
+void AudioDeviceManager::dispatch_sample_rate_change(double new_rate) {
+    DispatchGuard guard(this);
+    if (!guard.entered()) return;
+
+    last_sr_.store(new_rate, std::memory_order_relaxed);
+    sr_change_count_.fetch_add(1, std::memory_order_relaxed);
+
+    SampleRateChangeHandler handler;
+    {
+        std::lock_guard<std::mutex> lk(sr_mu_);
+        handler = sr_handler_;
+    }
+    if (handler) handler(new_rate);
+}
+
+std::uint64_t AudioDeviceManager::sample_rate_change_count() const {
+    return sr_change_count_.load(std::memory_order_relaxed);
+}
+
+double AudioDeviceManager::last_sample_rate() const {
+    return last_sr_.load(std::memory_order_relaxed);
+}
+
+// ── xrun tracking ───────────────────────────────────────────────────
+
+void AudioDeviceManager::bump_xrun_counter(std::uint64_t delta) {
+    xrun_counter_.fetch_add(delta, std::memory_order_relaxed);
+}
+
+std::uint64_t AudioDeviceManager::xrun_count() const {
+    return xrun_counter_.load(std::memory_order_relaxed);
+}
+
+void AudioDeviceManager::reset_xrun_counter() {
+    xrun_counter_.store(0, std::memory_order_relaxed);
+}
+
+// ── MIDI endpoint tracking ──────────────────────────────────────────
+
+MidiSubscriptionToken AudioDeviceManager::subscribe_midi_endpoints(
+    MidiEndpointChangeHandler handler) {
+    if (!handler) return {};
+    std::lock_guard<std::mutex> lk(midi_ep_mu_);
+    const uint64_t id = next_midi_ep_id_++;
+    midi_ep_subs_.emplace(id, std::move(handler));
+    // Reuse MidiSubscriptionToken; its unsubscribe routes via
+    // unsubscribe_midi_endpoint() because we mark the id with the
+    // bit-31 channel — but that pattern bloats the token surface for
+    // little gain. Instead, both unsubscribe paths run a quick erase()
+    // on both maps with their respective mutexes. erase() of a missing
+    // key is a no-op, so a token from subscribe_midi_endpoints() that
+    // gets routed to unsubscribe_midi() is harmless: the wrong map is
+    // checked, erase returns 0, lookup of the right map happens next
+    // call. To keep semantics clear, we make the token always call
+    // unsubscribe_midi(), and unsubscribe_midi() tries both maps.
+    return MidiSubscriptionToken(
+        std::weak_ptr<void>(lifetime_),
+        this,
+        id);
+}
+
+std::size_t AudioDeviceManager::midi_endpoint_subscriber_count() const {
+    std::lock_guard<std::mutex> lk(midi_ep_mu_);
+    return midi_ep_subs_.size();
+}
+
+void AudioDeviceManager::unsubscribe_midi_endpoint(uint64_t id) noexcept {
+    std::lock_guard<std::mutex> lk(midi_ep_mu_);
+    midi_ep_subs_.erase(id);
+}
+
+void AudioDeviceManager::set_midi_endpoints(std::vector<MidiEndpoint> endpoints) {
+    // Compute additions / removals before we publish, then dispatch
+    // outside the lock.
+    std::vector<MidiEndpointChange> changes;
+    {
+        std::lock_guard<std::mutex> lk(midi_ep_mu_);
+
+        std::unordered_set<std::string> old_ids;
+        old_ids.reserve(midi_endpoints_.size());
+        for (const auto& ep : midi_endpoints_) old_ids.insert(ep.id);
+
+        std::unordered_set<std::string> new_ids;
+        new_ids.reserve(endpoints.size());
+        for (const auto& ep : endpoints) new_ids.insert(ep.id);
+
+        // Removals: in old, not in new.
+        for (const auto& ep : midi_endpoints_) {
+            if (new_ids.find(ep.id) == new_ids.end()) {
+                changes.push_back({MidiEndpointChangeKind::Removed, ep});
+            }
+        }
+        // Additions: in new, not in old.
+        for (const auto& ep : endpoints) {
+            if (old_ids.find(ep.id) == old_ids.end()) {
+                changes.push_back({MidiEndpointChangeKind::Added, ep});
+            }
+        }
+
+        midi_endpoints_ = std::move(endpoints);
+    }
+
+    if (changes.empty()) return;
+
+    DispatchGuard guard(this);
+    if (!guard.entered()) return;
+
+    std::vector<MidiEndpointChangeHandler> handlers;
+    {
+        std::lock_guard<std::mutex> lk(midi_ep_mu_);
+        handlers.reserve(midi_ep_subs_.size());
+        for (auto& [_id, fn] : midi_ep_subs_) handlers.push_back(fn);
+    }
+    for (auto& fn : handlers) {
+        if (!fn) continue;
+        for (const auto& change : changes) fn(change);
+    }
+}
+
+std::vector<AudioDeviceManager::MidiEndpoint>
+AudioDeviceManager::midi_endpoints() const {
+    std::lock_guard<std::mutex> lk(midi_ep_mu_);
+    return midi_endpoints_;
+}
+
+// ── Concurrent-callback shutdown ────────────────────────────────────
+
+void AudioDeviceManager::latch_close() {
+    // Mark closed first so any dispatcher that wins the race observes
+    // the close before it increments `in_flight_`.
+    closed_.store(true, std::memory_order_release);
+
+    std::unique_lock<std::mutex> lk(latch_mu_);
+    latch_cv_.wait(lk, [this] { return in_flight_ == 0; });
+}
+
+bool AudioDeviceManager::is_closed() const noexcept {
+    return closed_.load(std::memory_order_acquire);
 }
 
 }  // namespace pulp::audio

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3087,6 +3087,11 @@ pulp_add_test_suite(pulp-test-buffering-reader LIBRARIES pulp::audio)
 # AudioWorkgroup tests
 pulp_add_test_suite(pulp-test-workgroup LIBRARIES pulp::audio)
 
+# AudioWorkgroup ↔ AudioDevice wiring (macOS plan item 1.1)
+pulp_add_test_suite(pulp-test-audio-workgroup-wiring
+    SOURCES test_audio_workgroup_wiring.cpp
+    LIBRARIES pulp::audio)
+
 # Plugin matrix tests (sample rate/buffer size/edge case sweep)
 add_executable(pulp-test-matrix test_plugin_matrix.cpp)
 target_link_libraries(pulp-test-matrix PRIVATE pulp::format Catch2::Catch2WithMain)

--- a/test/test_audio_device_manager.cpp
+++ b/test/test_audio_device_manager.cpp
@@ -303,3 +303,379 @@ TEST_CASE("AudioDeviceManager CPU-load tracks work performed in the audio window
     mgr.reset_peak_cpu_load();
     REQUIRE(mgr.peak_cpu_load() == 0.0f);
 }
+
+// ── 1.2b — Lifecycle / hotplug / recovery ──────────────────────────
+
+TEST_CASE("AudioDeviceManager dispatches injected device-change events",
+          "[audio][audio-device-manager][lifecycle][issue-2935]") {
+    AudioDeviceManager mgr;
+
+    std::atomic<int> received{0};
+    AudioDeviceManager::DeviceChangeEvent last_event{};
+    std::mutex captured_mu;
+
+    auto tok = mgr.subscribe_device_changes(
+        [&](const AudioDeviceManager::DeviceChangeEvent& ev) {
+            std::lock_guard<std::mutex> lk(captured_mu);
+            last_event = ev;
+            ++received;
+        });
+    REQUIRE(mgr.device_change_subscriber_count() == 1);
+    REQUIRE(tok.active());
+
+    AudioDeviceManager::DeviceChangeEvent ev;
+    ev.kind = AudioDeviceManager::DeviceChangeKind::Added;
+    ev.device_id = "device:scarlett-2i2";
+    ev.devices = {
+        make_device("device:builtin:out", "Built-in Output"),
+        make_device("device:scarlett-2i2",  "Scarlett 2i2"),
+    };
+    mgr.dispatch_device_change(ev);
+
+    REQUIRE(received.load() == 1);
+    {
+        std::lock_guard<std::mutex> lk(captured_mu);
+        REQUIRE(last_event.kind == AudioDeviceManager::DeviceChangeKind::Added);
+        REQUIRE(last_event.device_id == "device:scarlett-2i2");
+        REQUIRE(last_event.devices.size() == 2);
+    }
+}
+
+TEST_CASE("AudioDeviceManager device-change subscribers auto-unsubscribe",
+          "[audio][audio-device-manager][lifecycle][issue-2935]") {
+    AudioDeviceManager mgr;
+    std::atomic<int> received{0};
+
+    {
+        auto tok = mgr.subscribe_device_changes(
+            [&](const AudioDeviceManager::DeviceChangeEvent&) { ++received; });
+        REQUIRE(mgr.device_change_subscriber_count() == 1);
+
+        AudioDeviceManager::DeviceChangeEvent ev;
+        mgr.dispatch_device_change(ev);
+        REQUIRE(received.load() == 1);
+    }  // tok destroyed → unsubscribe
+
+    REQUIRE(mgr.device_change_subscriber_count() == 0);
+    mgr.dispatch_device_change({});
+    // No callback should have fired; ASan/TSan would catch a
+    // use-after-free against the dangling `received` reference.
+    REQUIRE(received.load() == 1);
+}
+
+TEST_CASE("AudioDeviceManager device-change token outliving manager is safe",
+          "[audio][audio-device-manager][lifecycle][issue-2935]") {
+    AudioDeviceManager::DeviceChangeToken tok;
+    {
+        AudioDeviceManager mgr;
+        tok = mgr.subscribe_device_changes(
+            [](const AudioDeviceManager::DeviceChangeEvent&) {});
+        REQUIRE(tok.active());
+    }
+    REQUIRE_FALSE(tok.active());
+    tok.reset();  // safe no-op on dead manager
+}
+
+TEST_CASE("AudioDeviceManager dispatches default-device-change to handler",
+          "[audio][audio-device-manager][lifecycle][issue-2935]") {
+    AudioDeviceManager mgr;
+    std::atomic<int> output_changes{0};
+    std::atomic<int> input_changes{0};
+    std::string captured_id;
+    std::mutex id_mu;
+
+    mgr.set_default_device_change_handler(
+        [&](bool is_input, const std::string& new_id) {
+            if (is_input) ++input_changes;
+            else          ++output_changes;
+            std::lock_guard<std::mutex> lk(id_mu);
+            captured_id = new_id;
+        });
+
+    mgr.dispatch_default_device_change(false, "device:airpods");
+    mgr.dispatch_default_device_change(true,  "device:built-in-mic");
+
+    REQUIRE(output_changes.load() == 1);
+    REQUIRE(input_changes.load()  == 1);
+    {
+        std::lock_guard<std::mutex> lk(id_mu);
+        REQUIRE(captured_id == "device:built-in-mic");
+    }
+
+    // Clearing the handler stops dispatch (and is a safe no-op for
+    // any callback currently in flight).
+    mgr.set_default_device_change_handler(nullptr);
+    mgr.dispatch_default_device_change(false, "device:airpods");
+    REQUIRE(output_changes.load() == 1);
+}
+
+TEST_CASE("AudioDeviceManager tracks sample-rate changes",
+          "[audio][audio-device-manager][lifecycle][issue-2935]") {
+    AudioDeviceManager mgr;
+    std::atomic<int> calls{0};
+    std::atomic<double> last_seen{0.0};
+
+    mgr.set_sample_rate_change_handler(
+        [&](double new_rate) {
+            last_seen.store(new_rate);
+            ++calls;
+        });
+
+    REQUIRE(mgr.sample_rate_change_count() == 0u);
+    REQUIRE(mgr.last_sample_rate() == 0.0);
+
+    mgr.dispatch_sample_rate_change(44100.0);
+    mgr.dispatch_sample_rate_change(48000.0);
+    mgr.dispatch_sample_rate_change(96000.0);
+
+    REQUIRE(calls.load() == 3);
+    REQUIRE_THAT(last_seen.load(), WithinAbs(96000.0, 0.001));
+    REQUIRE(mgr.sample_rate_change_count() == 3u);
+    REQUIRE_THAT(mgr.last_sample_rate(), WithinAbs(96000.0, 0.001));
+}
+
+TEST_CASE("AudioDeviceManager xrun counter increments and resets",
+          "[audio][audio-device-manager][lifecycle][issue-2935]") {
+    AudioDeviceManager mgr;
+    REQUIRE(mgr.xrun_count() == 0u);
+
+    mgr.bump_xrun_counter();
+    mgr.bump_xrun_counter();
+    mgr.bump_xrun_counter(5);
+    REQUIRE(mgr.xrun_count() == 7u);
+
+    mgr.reset_xrun_counter();
+    REQUIRE(mgr.xrun_count() == 0u);
+}
+
+TEST_CASE("AudioDeviceManager MIDI endpoint delta tracking fires per change",
+          "[audio][audio-device-manager][midi][lifecycle][issue-2935]") {
+    AudioDeviceManager mgr;
+
+    std::vector<AudioDeviceManager::MidiEndpointChange> changes;
+    std::mutex changes_mu;
+    auto tok = mgr.subscribe_midi_endpoints(
+        [&](const AudioDeviceManager::MidiEndpointChange& c) {
+            std::lock_guard<std::mutex> lk(changes_mu);
+            changes.push_back(c);
+        });
+    REQUIRE(mgr.midi_endpoint_subscriber_count() == 1);
+
+    auto make_ep = [](std::string id, std::string name, bool is_input) {
+        AudioDeviceManager::MidiEndpoint ep;
+        ep.id = std::move(id);
+        ep.name = std::move(name);
+        ep.is_input = is_input;
+        return ep;
+    };
+
+    // Initial publish: empty → {Push, Mini}. Both are adds.
+    mgr.set_midi_endpoints({
+        make_ep("ep:push", "Push 2", true),
+        make_ep("ep:mini", "MiniLab",  true),
+    });
+    {
+        std::lock_guard<std::mutex> lk(changes_mu);
+        REQUIRE(changes.size() == 2);
+        REQUIRE(changes[0].kind == AudioDeviceManager::MidiEndpointChangeKind::Added);
+        REQUIRE(changes[1].kind == AudioDeviceManager::MidiEndpointChangeKind::Added);
+        changes.clear();
+    }
+
+    // Unplug Push, keep MiniLab. One removal, no adds.
+    mgr.set_midi_endpoints({
+        make_ep("ep:mini", "MiniLab", true),
+    });
+    {
+        std::lock_guard<std::mutex> lk(changes_mu);
+        REQUIRE(changes.size() == 1);
+        REQUIRE(changes[0].kind == AudioDeviceManager::MidiEndpointChangeKind::Removed);
+        REQUIRE(changes[0].endpoint.id == "ep:push");
+        changes.clear();
+    }
+
+    // No change → no dispatch.
+    mgr.set_midi_endpoints({
+        make_ep("ep:mini", "MiniLab", true),
+    });
+    {
+        std::lock_guard<std::mutex> lk(changes_mu);
+        REQUIRE(changes.empty());
+    }
+
+    REQUIRE(mgr.midi_endpoints().size() == 1);
+    REQUIRE(mgr.midi_endpoints()[0].id == "ep:mini");
+}
+
+TEST_CASE("AudioDeviceManager latch_close drops subsequent dispatches",
+          "[audio][audio-device-manager][lifecycle][shutdown][issue-2935]") {
+    AudioDeviceManager mgr;
+    std::atomic<int> midi_calls{0};
+    std::atomic<int> dev_calls{0};
+
+    auto midi_tok = mgr.subscribe_midi(
+        [&](const pulp::midi::MidiEvent&) { ++midi_calls; });
+    auto dev_tok  = mgr.subscribe_device_changes(
+        [&](const AudioDeviceManager::DeviceChangeEvent&) { ++dev_calls; });
+    mgr.set_default_device_change_handler(
+        [&](bool, const std::string&) { ++dev_calls; });
+
+    REQUIRE_FALSE(mgr.is_closed());
+    mgr.dispatch_midi_event(pulp::midi::MidiEvent::note_on(0, 60, 100));
+    mgr.dispatch_device_change({});
+    mgr.dispatch_default_device_change(false, "device:x");
+    REQUIRE(midi_calls.load() == 1);
+    REQUIRE(dev_calls.load()  == 2);
+
+    mgr.latch_close();
+    REQUIRE(mgr.is_closed());
+
+    // Post-close dispatches are no-ops.
+    mgr.dispatch_midi_event(pulp::midi::MidiEvent::note_on(0, 60, 100));
+    mgr.dispatch_device_change({});
+    mgr.dispatch_default_device_change(false, "device:y");
+    mgr.dispatch_sample_rate_change(96000.0);
+    REQUIRE(midi_calls.load() == 1);
+    REQUIRE(dev_calls.load()  == 2);
+}
+
+TEST_CASE("AudioDeviceManager latch_close waits for in-flight dispatchers",
+          "[audio][audio-device-manager][lifecycle][shutdown][issue-2935]") {
+    AudioDeviceManager mgr;
+    std::atomic<int> in_callback{0};
+    std::atomic<int> entered{0};
+    std::atomic<int> exited{0};
+    std::atomic<bool> can_exit{false};
+
+    // Subscriber that camps inside the dispatch until we let it out.
+    // This models a slow audio thread that is mid-dispatch when the
+    // host calls latch_close() on shutdown — the latch MUST wait for
+    // it to return before declaring the manager closed.
+    auto tok = mgr.subscribe_midi(
+        [&](const pulp::midi::MidiEvent&) {
+            ++entered;
+            ++in_callback;
+            // Spin until the test releases us.
+            while (!can_exit.load(std::memory_order_acquire)) {
+                std::this_thread::sleep_for(std::chrono::microseconds(50));
+            }
+            --in_callback;
+            ++exited;
+        });
+
+    // Kick off the slow dispatcher on a worker thread.
+    std::thread dispatcher([&] {
+        mgr.dispatch_midi_event(pulp::midi::MidiEvent::note_on(0, 60, 100));
+    });
+
+    // Wait until the subscriber is parked inside the dispatch.
+    while (entered.load() == 0) {
+        std::this_thread::sleep_for(std::chrono::microseconds(50));
+    }
+    REQUIRE(in_callback.load() == 1);
+
+    // Start the latch on another thread. It must NOT return while the
+    // dispatcher is still inside the callback.
+    std::thread latcher([&] { mgr.latch_close(); });
+
+    // Give latch a chance to bail early (bug). If it does, exited is
+    // still 0 because we haven't released the subscriber yet.
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    REQUIRE(exited.load() == 0);
+    // Either `closed_` is still being set or the dispatcher is still
+    // in flight — both are valid pre-release. The forbidden state is
+    // "manager declared itself closed AND nothing is in flight" before
+    // the dispatcher actually returned.
+    bool latched_too_early = mgr.is_closed() && in_callback.load() == 0;
+    REQUIRE_FALSE(latched_too_early);
+
+    // Release the subscriber. Latch should return promptly and
+    // observe in_flight_ == 0.
+    can_exit.store(true, std::memory_order_release);
+    dispatcher.join();
+    latcher.join();
+
+    REQUIRE(exited.load() == 1);
+    REQUIRE(in_callback.load() == 0);
+    REQUIRE(mgr.is_closed());
+}
+
+TEST_CASE("AudioDeviceManager destructor latches without an explicit close",
+          "[audio][audio-device-manager][lifecycle][shutdown][issue-2935]") {
+    // Even if the host forgets latch_close(), the destructor must
+    // wait for in-flight dispatches. This guards the "concurrent-
+    // callback shutdown" acceptance for the typical case where a
+    // host just lets the manager fall out of scope.
+    std::atomic<int> calls{0};
+    auto* mgr = new AudioDeviceManager();
+    auto tok  = mgr->subscribe_midi(
+        [&](const pulp::midi::MidiEvent&) { ++calls; });
+    mgr->dispatch_midi_event(pulp::midi::MidiEvent::note_on(0, 60, 100));
+    REQUIRE(calls.load() == 1);
+    delete mgr;
+    // No assertion after delete is meaningful — but the test fails
+    // (TSan/ASan) if the destructor races a dispatcher.
+}
+
+TEST_CASE("AudioDeviceManager attach_audio_system bridges to device changes",
+          "[audio][audio-device-manager][lifecycle][issue-2935]") {
+    // Stand-in AudioSystem whose set_device_change_callback() drives
+    // dispatch_device_change(). The test verifies the bridge fires
+    // and enumerate_devices() snapshot reaches subscribers.
+    class FakeAudioSystem : public AudioSystem {
+    public:
+        std::vector<DeviceInfo> enumerate_devices() override {
+            return devices_;
+        }
+        std::unique_ptr<AudioDevice> create_device(const std::string&) override {
+            return nullptr;
+        }
+        DeviceInfo default_output_device() override { return {}; }
+        DeviceInfo default_input_device()  override { return {}; }
+
+        // Drive the registered callback (bound via the base class slot
+        // by attach_audio_system → set_device_change_callback).
+        void simulate_device_list_change() { fire_device_change(); }
+
+        std::vector<DeviceInfo> devices_;
+    };
+
+    FakeAudioSystem sys;
+    sys.devices_ = {{"device:a", "A", 0, 2, {}, {}, false, true},
+                    {"device:b", "B", 2, 2, {}, {}, true,  false}};
+
+    AudioDeviceManager mgr;
+    std::atomic<int> calls{0};
+    std::size_t last_snapshot_size = 0;
+    std::mutex snap_mu;
+
+    auto tok = mgr.subscribe_device_changes(
+        [&](const AudioDeviceManager::DeviceChangeEvent& ev) {
+            ++calls;
+            std::lock_guard<std::mutex> lk(snap_mu);
+            last_snapshot_size = ev.devices.size();
+        });
+
+    mgr.attach_audio_system(&sys);
+    sys.simulate_device_list_change();
+    REQUIRE(calls.load() == 1);
+    {
+        std::lock_guard<std::mutex> lk(snap_mu);
+        REQUIRE(last_snapshot_size == 2);
+    }
+
+    // Simulate a USB hub reset — devices_ shrinks before the
+    // callback fires.
+    sys.devices_ = {{"device:a", "A", 0, 2, {}, {}, false, true}};
+    sys.simulate_device_list_change();
+    REQUIRE(calls.load() == 2);
+    {
+        std::lock_guard<std::mutex> lk(snap_mu);
+        REQUIRE(last_snapshot_size == 1);
+    }
+
+    // Unbinding stops the bridge.
+    mgr.attach_audio_system(nullptr);
+    sys.simulate_device_list_change();
+    REQUIRE(calls.load() == 2);
+}

--- a/test/test_audio_workgroup_wiring.cpp
+++ b/test/test_audio_workgroup_wiring.cpp
@@ -1,0 +1,162 @@
+/// @file test_audio_workgroup_wiring.cpp
+/// Item 1.1 — AudioWorkgroup wired to AudioDevice + render-callback path.
+///
+/// Plan acceptance (per `planning/2026-05-24-macos-plugin-authoring-plan.md`
+/// section "### 1.1 AudioWorkgroup wired to AudioDevice + processor
+/// callback", reviewer decision 2026-05-25):
+///
+///   (1) extraction of `kAudioDevicePropertyIOThreadOSWorkgroup` is the
+///       required path on macOS 13+ / iOS 16+ — `AudioDevice::callback_workgroup()`
+///       is the surface, and the default base-class implementation
+///       returns `nullptr` so non-Apple backends inherit the fallback;
+///   (2) RAII `AudioWorkgroupJoin` joins exactly once on first
+///       callback entry and leaves on thread exit;
+///   (3) the Mach-priority fallback path in
+///       `AudioWorkgroup::set_realtime_priority` stays as defensive
+///       code for the case where extraction returns null (a property
+///       the spec allows).
+///
+/// This file tests the contract pieces that don't require a real
+/// audio device:
+///   - `AudioDevice::callback_workgroup()` default returns null (so
+///     non-Apple backends don't break);
+///   - the new xrun counter / reset path on the base class;
+///   - `AudioWorkgroup::set_workgroup(nullptr)` keeps the fallback
+///     path safe (the "device has no workgroup" branch);
+///   - `join_from_audio_thread()` is idempotent under repeat-entry
+///     across `wg_joined_` (mirrors the per-render-callback first-
+///     entry guard).
+///
+/// Real-device acceptance (#4 in the plan — `os_signpost` verifying
+/// workgroup membership on Apple Silicon) lives in a manual smoke
+/// step documented in the macOS plan; CI cannot guarantee Apple
+/// Silicon hardware, so it stays out of the unit suite. Pass-2
+/// reviewer note: the unit suite explicitly verifies the contract
+/// surface the production path consumes (callback_workgroup() ->
+/// AudioWorkgroup::set_workgroup() -> join_from_audio_thread()), so
+/// the integration risk surface is the OS plumbing alone.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/audio/device.hpp>
+#include <pulp/audio/workgroup.hpp>
+
+#include <atomic>
+#include <thread>
+
+using namespace pulp::audio;
+
+namespace {
+
+/// Stub AudioDevice that overrides nothing — exercises the base-class
+/// `callback_workgroup()` / `xrun_count()` / `reset_xrun_counter()`
+/// defaults that non-Apple backends inherit. Pure-virtual stubs return
+/// safe values.
+class StubDevice : public AudioDevice {
+public:
+    bool open(const DeviceConfig&) override { return true; }
+    void close() override {}
+    bool start(AudioCallback) override { return true; }
+    void stop() override {}
+    bool is_open() const override { return false; }
+    bool is_running() const override { return false; }
+    DeviceInfo info() const override { return {}; }
+    double sample_rate() const override { return 48000.0; }
+    int buffer_size() const override { return 256; }
+};
+
+}  // namespace
+
+TEST_CASE("AudioDevice base class callback_workgroup defaults to null",
+          "[audio][workgroup][wiring][issue-2935]") {
+    StubDevice dev;
+    REQUIRE(dev.callback_workgroup() == nullptr);
+}
+
+TEST_CASE("AudioDevice base class xrun_count defaults to zero and reset is safe",
+          "[audio][workgroup][wiring][issue-2935]") {
+    StubDevice dev;
+    REQUIRE(dev.xrun_count() == 0);
+    dev.reset_xrun_counter();  // safe no-op on the default implementation
+    REQUIRE(dev.xrun_count() == 0);
+}
+
+TEST_CASE("AudioWorkgroup with explicit null workgroup falls back safely",
+          "[audio][workgroup][wiring][issue-2935]") {
+    // Mirrors the case where CoreAudio returns noErr but a null
+    // workgroup pointer — query_callback_workgroup() leaves the
+    // cached value at nullptr and the render callback's join is
+    // still safe.
+    AudioWorkgroup wg;
+#if defined(__APPLE__)
+    wg.set_workgroup(nullptr);
+#endif
+    bool joined_first  = wg.join_from_audio_thread();
+    bool joined_second = wg.join_from_audio_thread();
+    // join_from_audio_thread is idempotent: a second call without a
+    // leave() in between must report joined (or both must remain
+    // un-joined if the platform refuses RT priority entirely).
+    REQUIRE(joined_first == joined_second);
+    wg.leave();
+    REQUIRE_FALSE(wg.is_joined());
+}
+
+TEST_CASE("AudioWorkgroup leave-then-rejoin tracks per-thread join state",
+          "[audio][workgroup][wiring][issue-2935]") {
+    // The render callback's first-entry guard
+    // (`wg_joined_` atomic in CoreAudioDevice) relies on
+    // AudioWorkgroup::leave() actually clearing the joined flag so
+    // the next start() can re-join on the new render thread without
+    // tripping any "already joined" debug assertion.
+    AudioWorkgroup wg;
+    bool joined = wg.join_from_audio_thread();
+    if (joined) {
+        wg.leave();
+        REQUIRE_FALSE(wg.is_joined());
+        bool rejoined = wg.join_from_audio_thread();
+        REQUIRE(rejoined);
+        wg.leave();
+        REQUIRE_FALSE(wg.is_joined());
+    } else {
+        // Test environment refuses RT priority; rejoining must also
+        // refuse, but neither call may crash.
+        bool rejoined = wg.join_from_audio_thread();
+        REQUIRE_FALSE(rejoined);
+    }
+}
+
+TEST_CASE("AudioWorkgroup first-entry guard pattern is race-free",
+          "[audio][workgroup][wiring][issue-2935]") {
+    // Models the exact acquire/release pattern in
+    // CoreAudioDevice::render_callback: a relaxed-ordered atomic guard
+    // that gates a one-shot join. Hammer it across N threads to
+    // confirm the pattern works under concurrency. (CoreAudio only
+    // ever runs render_callback on a single I/O thread, but TSan in
+    // CI should not flag the pattern.)
+    AudioWorkgroup wg;
+    std::atomic<bool> joined_flag{false};
+    std::atomic<int>  join_count{0};
+
+    auto worker = [&] {
+        if (!joined_flag.load(std::memory_order_acquire)) {
+            wg.join_from_audio_thread();
+            // Only the winning thread observes `false` here, so the
+            // counter increments exactly once.
+            bool expected = false;
+            if (joined_flag.compare_exchange_strong(
+                    expected, true, std::memory_order_release)) {
+                join_count.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+    };
+
+    std::thread t1(worker);
+    std::thread t2(worker);
+    std::thread t3(worker);
+    t1.join();
+    t2.join();
+    t3.join();
+
+    REQUIRE(join_count.load() == 1);
+    wg.leave();
+}


### PR DESCRIPTION
## Summary

Ships **macOS-plugin-authoring plan items 1.1 (AudioWorkgroup wired to AudioDevice) + 1.2b (AudioDeviceManager lifecycle / hotplug / recovery)**. Unblocked by PR #2825 (native main-thread dispatcher, merged as 9c96f3dfa).

### Item 1.1 — AudioWorkgroup wired to AudioDevice IO thread

- `AudioDevice` gains virtual `callback_workgroup()` / `xrun_count()` / `reset_xrun_counter()` with safe defaults so non-Apple backends inherit the fallback for free.
- `CoreAudioDevice::open()` queries `kAudioDevicePropertyIOThreadOSWorkgroup` gated by `__builtin_available(macOS 13.0, iOS 16.0, *)` per the plan's Phase B floor decision, arms the existing `AudioWorkgroup`, and installs a `kAudioDeviceProcessorOverload` listener for xrun tracking.
- `render_callback` first-entry guard joins the workgroup on the render thread via an acquire/release atomic; `close()` waits for `AudioUnitUninitialize` (which blocks any in-flight callback) before leaving the workgroup, so the join/leave is race-free.
- `CoreAudioSystem` gains an optional default-device-change callback hooked to `kAudioHardwarePropertyDefault{Output,Input}Device` listeners.

### Item 1.2b — AudioDeviceManager lifecycle / hotplug / recovery

Phase B of the manager. Builds on 1.2a (PR #2936). API additions on `pulp::audio::AudioDeviceManager`:

- **Device-change hub** — `subscribe_device_changes()` (RAII `DeviceChangeToken`); `attach_audio_system(AudioSystem*)` bridges the system's device-change callback through the manager so subscribers receive a structured `DeviceChangeEvent` with the live snapshot; `dispatch_device_change()` callable directly for tests / non-CoreAudio backends.
- **Default-device recovery** — `set_default_device_change_handler()` + `dispatch_default_device_change(bool is_input, new_id)`.
- **Sample-rate recovery** — `set_sample_rate_change_handler()` + `dispatch_sample_rate_change(rate)`; manager tracks `sample_rate_change_count()` and `last_sample_rate()`.
- **xrun counter** — `bump_xrun_counter(delta)`, `xrun_count()`, `reset_xrun_counter()`. Atomic, thread-safe.
- **MIDI endpoint tracking** — `set_midi_endpoints(snapshot)` diffs against the previous snapshot and dispatches `MidiEndpointChange` (Added/Removed) events to endpoint subscribers (separate token namespace from MIDI events).
- **Concurrent-callback shutdown** — `latch_close()` blocks until every in-flight dispatcher returns and turns subsequent dispatches into no-ops. RAII `DispatchGuard` wraps every dispatch. Destructor latches automatically, so the "host just lets the manager fall out of scope" path is race-free under TSan.

## Test plan

- [x] New `pulp-test-audio-workgroup-wiring` covers the AudioDevice base-class contract (non-Apple backends get `nullptr` + zero-xrun safely), explicit-null workgroup fallback, leave-then-rejoin tracking, and the multi-thread first-entry guard pattern that mirrors `CoreAudioDevice::render_callback`'s `wg_joined_` atomic — 5 cases, 9 assertions.
- [x] Extended `pulp-test-audio-device-manager` 9 → 20 cases, 46 → 99 assertions: injected device-change dispatch + snapshot delivery; auto-unsubscribe + token-outlives-manager safety; default-device-change handler swap; sample-rate change counter; xrun bump/reset; MIDI endpoint delta tracking; `latch_close()` drops subsequent dispatches; `latch_close()` waits for in-flight callback (fixture spins a subscriber inside `dispatch_midi_event` and verifies the latch returns AFTER the subscriber); destructor-latches-without-explicit-close; `attach_audio_system` bridges to a fake `AudioSystem`.
- [x] Local `cmake --build` clean on `pulp-audio`, `pulp-host`, both test binaries.
- [x] All 9 existing 1.2a tests still pass.
- [ ] Real-device `os_signpost` verification of workgroup membership (plan acceptance #4) — manual smoke per the plan; CI cannot guarantee Apple Silicon hardware.
- [ ] Live USB hotplug + default-device flip on real macOS hardware — deferred per the plan; the listener registration + injected-event fixtures cover the wiring contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)