### PR TITLE
feat: DAW-bench harness package for graduating quirk tiers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.252.0
+    VERSION 0.253.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/docs/validation/daw-bench/01-logic-pro-au.md
+++ b/docs/validation/daw-bench/01-logic-pro-au.md
@@ -1,0 +1,96 @@
+# 01 — Logic Pro (AU v2)
+
+**Target quirks** (from `core/format/include/pulp/format/host_quirks.hpp::HostQuirksMeta`):
+
+- `logic_au_channel_probe_cap` (catalog row #19) — Logic hangs probing >8 channels.
+- `logic_au_tail_time_conversion` (catalog row #20) — AU tail time depends on cached sample rate.
+- General lifecycle: `prepare` → `process` → `release` ordering.
+
+**Prereqs**: macOS 13+, Logic Pro 10.7+, `PulpHostBench.component` installed under `~/Library/Audio/Plug-Ins/Components/` and re-validated by Logic (Logic Pro → Settings → Audio → Audio Units Manager → "Reset & Rescan Selection").
+
+## Steps
+
+1. **Clear stale logs** in a terminal:
+   ```bash
+   rm -rf ~/Library/Logs/PulpHostBench/
+   ```
+
+2. **Launch Logic Pro**, create a new empty project (Audio template, 48 kHz, 1 audio track).
+
+3. **Insert PulpHostBench** on track 1 (Audio FX slot → Audio Units → Pulp → PulpHostBench).
+
+4. **Confirm session log appears**:
+   ```bash
+   ls -lt ~/Library/Logs/PulpHostBench/ | head -3
+   # Expect: LogicPro-AU-<timestamp>-pid<NNNN>.log
+   ```
+
+5. **Open the log** and confirm the **header**:
+   ```bash
+   head -5 ~/Library/Logs/PulpHostBench/LogicPro-AU-*.log
+   # Look for: session_start  host=LogicPro  format=AU
+   # Look for: prepare        sample_rate=48000  max_buffer_size=<N>
+   ```
+   → confirms Logic detected via `HostType::LogicPro` (catalog row #22 cross-host detection).
+
+6. **Hit Play, let one second go by, hit Stop**.
+   ```bash
+   grep -E "transport_changed|process_is_playing_edge" ~/Library/Logs/PulpHostBench/LogicPro-AU-*.log
+   ```
+   → confirms `on_host_transport_changed()` fires and `ProcessContext::is_playing` flips.
+
+7. **Switch the project's sample rate** to 44.1 kHz (File → Project Settings → Audio).
+   Hit Play once again.
+   ```bash
+   grep "process_sample_rate_drift\|prepare" ~/Library/Logs/PulpHostBench/LogicPro-AU-*.log | tail -5
+   # Expect either: a NEW prepare event (sample_rate=44100), OR
+   #                process_sample_rate_drift entries.
+   ```
+   → catalog row **#20**: if a fresh `prepare` event arrives, the AU adapter is
+     correctly re-cached; if `process_sample_rate_drift` events appear, that's
+     evidence the AU adapter is NOT re-preparing on sample-rate change (so
+     `logic_au_tail_time_conversion` should stay Speculative pending a fix).
+
+8. **Try inserting PulpHostBench on a multi-output bus** (right-click track →
+   Configure Track Header → enable Output → set Output to Surround 5.1 if your
+   audio interface supports it, otherwise the largest channel count Logic allows).
+   ```bash
+   grep "bus_layout_proposal" ~/Library/Logs/PulpHostBench/LogicPro-AU-*.log
+   # Look for: inputs=N  outputs=M  where M reflects Logic's probe.
+   ```
+   → catalog row **#19**: if Logic does NOT probe channels >8 before stalling /
+     crashing, that's evidence the existing cap is doing its job.
+
+9. **Save the project**, close it, reopen it.
+   ```bash
+   grep -E "serialize_plugin_state|deserialize_plugin_state" ~/Library/Logs/PulpHostBench/LogicPro-AU-*.log
+   ```
+   → confirms state round-trip; `marker_ok=true` on the deserialize line is the
+     blob-integrity proof.
+
+10. **Resize the plugin window** (drag the corner).
+    ```bash
+    grep "view_resized" ~/Library/Logs/PulpHostBench/LogicPro-AU-*.log
+    ```
+    → confirms `on_view_resized()` fires with the new dimensions.
+
+11. **Quit Logic** (or just delete the plugin from the track).
+    ```bash
+    tail -5 ~/Library/Logs/PulpHostBench/LogicPro-AU-*.log
+    # Expect: release, then session_end.
+    ```
+
+## Result
+
+Paste this section into the follow-up PR (one row per catalog flag):
+
+| Quirk flag                            | Catalog row | Observed | Notes                                              |
+|---------------------------------------|-------------|----------|----------------------------------------------------|
+| `logic_au_channel_probe_cap`          | #19         | <Confirmed/Refuted/Not Triggered> | <e.g. "Logic never probed above 8 ch in step 8."> |
+| `logic_au_tail_time_conversion`       | #20         | <C/R/NT> | <e.g. "prepare re-fired on SR change in step 7."> |
+| `synthesize_bypass_parameter` (general) | #23       | <C/R/NT> | <e.g. "Logic shows a bypass control regardless."> |
+| `clamp_latency_to_nonneg` (general)   | #24         | <C/R/NT> | <Logic queried latency at prepare; see log.>      |
+| `silence_unsupported_bus_arrangements` (general) | #25 | <C/R/NT> | <e.g. "step 8 layout was accepted; no crash.">    |
+
+**Log file(s)**: `<paste relative path under docs/validation/daw-bench/results/.../logs/>`
+**Logic Pro version**: `<x.y.z>` — **macOS**: `<x.y.z>` — **Date**: `<YYYY-MM-DD>`

--- a/docs/validation/daw-bench/02-cubase-12-vst3.md
+++ b/docs/validation/daw-bench/02-cubase-12-vst3.md
@@ -1,0 +1,103 @@
+# 02 — Cubase 12 (VST3)
+
+**Target quirks** (catalog rows in `host_quirks.hpp::HostQuirksMeta`):
+
+- `cubase10_async_view_resize_queue` (row #1) — async view resize timing.
+- `cubase10_param_gesture_ordering` (row #2) — automation gesture order.
+- `cubase10_fractional_scale_correction` (row #3) — DPI rounding.
+- General defaults: bypass synth (#23), latency clamp (#24), bus silence (#25).
+
+> "Cubase 10" was the original catalog evidence — Cubase 11/12/13 retain the
+> same behaviors except where Steinberg shipped fixes. If your bench host is
+> Cubase 11 or 13, the script still applies; record the actual version in
+> the Result section below.
+
+**Prereqs**: Cubase Pro 12.x, `PulpHostBench.vst3` installed under
+`~/Library/Audio/Plug-Ins/VST3/` (macOS) or
+`C:\Program Files\Common Files\VST3\` (Windows).
+
+## Steps
+
+1. **Clear stale logs**:
+   ```bash
+   rm -rf ~/Library/Logs/PulpHostBench/           # macOS
+   # rmdir /S /Q %LOCALAPPDATA%\PulpHostBench    # Windows
+   ```
+
+2. **Launch Cubase 12**, new empty project, 48 kHz / 32-bit float.
+
+3. **Add an audio track**, insert PulpHostBench (Inserts → Pulp → PulpHostBench).
+
+4. **Confirm log file exists + Cubase is detected**:
+   ```bash
+   head -5 ~/Library/Logs/PulpHostBench/Cubase-VST3-*.log
+   # session_start  host=Cubase  format=VST3
+   ```
+
+5. **Resize the plugin window** (drag corner slowly).
+   ```bash
+   grep "view_resized" ~/Library/Logs/PulpHostBench/Cubase-VST3-*.log
+   ```
+   → catalog row **#1**: count the `view_resized` events. If Cubase emits MORE
+     events than discrete drag pauses, the host is firing the async-resize race
+     described in the catalog. If the count matches discrete pauses, the host
+     coalesces — no async accommodation needed for this version.
+
+6. **Move the bench window between displays** (if you have a multi-monitor setup
+   with at least one non-integer scale factor like 125% or 150%).
+   ```bash
+   grep "view_resized" ~/Library/Logs/PulpHostBench/Cubase-VST3-*.log | tail -10
+   ```
+   → catalog row **#3**: the dimensions should reflect the destination display's
+     scale. Fractional DPI typically shows up as widths/heights that are NOT
+     multiples of 100/8.
+
+7. **Right-click the Bench Gain parameter** → Show Automation → write-enable.
+   Touch the knob, write a 2-second automation pass, stop. Play back. Touch the
+   knob again to overwrite.
+   ```bash
+   grep "tempo_changed\|transport_changed\|process_is_playing_edge" \
+       ~/Library/Logs/PulpHostBench/Cubase-VST3-*.log | tail -5
+   ```
+   → catalog row **#2**: the bench plugin can't directly see the gesture-edit
+     sequence (that lives in the format adapter), but the parameter events
+     show up in StateStore and the host-event ordering can be visually
+     confirmed: the value should sweep on playback. If the automation lane
+     ends up "touched" but value never changes, that's evidence of the
+     gesture-ordering bug.
+
+8. **Save project, close, reopen**.
+   ```bash
+   grep -E "serialize_plugin_state|deserialize_plugin_state" \
+       ~/Library/Logs/PulpHostBench/Cubase-VST3-*.log
+   ```
+   → confirms state round-trip.
+
+9. **Render-in-place / Export Audio Mixdown** with PulpHostBench on the track.
+   ```bash
+   grep "prepare\|suspend\|resume" ~/Library/Logs/PulpHostBench/Cubase-VST3-*.log | tail -10
+   ```
+   → tail-time + offline-render: Cubase may call `prepare()` with a different
+     buffer size than the live session. If the bench logs `prepare` with a
+     different `max_buffer_size`, the host is honoring the offline-render
+     prepare contract.
+
+10. **Quit Cubase** or remove the plugin.
+    ```bash
+    tail -3 ~/Library/Logs/PulpHostBench/Cubase-VST3-*.log
+    # Expect: session_end at the bottom.
+    ```
+
+## Result
+
+| Quirk flag                                    | Row | Observed | Notes |
+|-----------------------------------------------|-----|----------|-------|
+| `cubase10_async_view_resize_queue`            | #1  | <C/R/NT> |       |
+| `cubase10_param_gesture_ordering`             | #2  | <C/R/NT> |       |
+| `cubase10_fractional_scale_correction`        | #3  | <C/R/NT> |       |
+| `synthesize_bypass_parameter`                 | #23 | <C/R/NT> |       |
+| `clamp_latency_to_nonneg`                     | #24 | <C/R/NT> |       |
+| `silence_unsupported_bus_arrangements`        | #25 | <C/R/NT> |       |
+
+**Log file(s)**: `<paste path>`
+**Cubase version**: `<Pro 12.x.y>` — **OS**: `<macOS x.y / Win x.y>` — **Date**: `<YYYY-MM-DD>`

--- a/docs/validation/daw-bench/03-cubase-9-vst3.md
+++ b/docs/validation/daw-bench/03-cubase-9-vst3.md
@@ -1,0 +1,64 @@
+# 03 — Cubase 9 (VST3)
+
+**Target quirks**:
+
+- `cubase9_state_blob_size_validation` (catalog row #4) — Cubase 9 stream-size
+  bug where `IBStream::read` reports the wrong remaining-byte count.
+
+> Cubase 9 is a legacy benchmark. Skip this script unless you have a working
+> Cubase 9 (Pro 9.0.40 was the last 9.x release). The bench plugin works
+> identically; the value is in observing the state-blob path under the
+> older host.
+
+**Prereqs**: Cubase 9 Pro, `PulpHostBench.vst3` installed.
+
+## Steps
+
+1. **Clear stale logs**.
+
+2. **Launch Cubase 9**, new empty project, 48 kHz.
+
+3. **Add an audio track**, insert PulpHostBench.
+
+4. **Confirm session start**:
+   ```bash
+   head -5 ~/Library/Logs/PulpHostBench/Cubase-VST3-*.log
+   # session_start  host=Cubase
+   ```
+   (Cubase 9 reports as `Cubase` — same detection as Cubase 12. The bench
+   script's value is in the per-step *behavior* differences, not the host
+   tag.)
+
+5. **Wiggle the Bench Gain knob** (turn it from 0 dB to +12 dB).
+
+6. **Save the project as a .cpr file**.
+
+7. **Close the project**. Quit Cubase. Relaunch. Reopen the .cpr.
+   ```bash
+   ls -lt ~/Library/Logs/PulpHostBench/ | head -5
+   # A NEW LogicPro/Cubase log file should appear — the relaunch creates
+   # a fresh PID, so a fresh log.
+
+   tail -20 ~/Library/Logs/PulpHostBench/Cubase-VST3-*.log
+   # Look for: deserialize_plugin_state  bytes=18  marker_ok=true
+   ```
+   → catalog row **#4**: if the deserialize log line shows `bytes=18` and
+     `marker_ok=true`, Cubase 9 correctly conveyed the blob. If `bytes` is
+     less than 18 or `marker_ok=false`, the host truncated the blob, which
+     is exactly the bug the quirk flag exists to handle.
+
+8. **In the reopened project**, the Bench Gain knob should still read +12 dB.
+   If it's back to 0 dB, the state didn't round-trip — confirming the
+   `cubase9_state_blob_size_validation` quirk is needed for this version.
+
+9. **Quit Cubase** to flush the log.
+
+## Result
+
+| Quirk flag                            | Row | Observed | Notes |
+|---------------------------------------|-----|----------|-------|
+| `cubase9_state_blob_size_validation`  | #4  | <C/R/NT> | <e.g. "deserialize bytes=18, knob restored OK"> |
+| Cross-format defaults (#23–#25)       | —   | <C/R/NT> |       |
+
+**Log file(s)**: `<paste>`
+**Cubase version**: `Pro 9.0.x` — **OS**: `<macOS x.y / Win x.y>` — **Date**: `<YYYY-MM-DD>`

--- a/docs/validation/daw-bench/04-live-vst3.md
+++ b/docs/validation/daw-bench/04-live-vst3.md
@@ -1,0 +1,91 @@
+# 04 — Ableton Live (VST3)
+
+**Target quirks**:
+
+- `live_vst3_canresize_ignore` (row #5) — Live probes `checkSizeConstraint`
+  even when `canResize == false`.
+- `live_vst3_windows_dpi_defer` (row #6) — Windows-only DPI/window-handle
+  timing race on per-monitor-V2 DPI.
+- `double_string_buffer_for_live_10_1_13` (row added 2026-05-25) — Live
+  10.1.13 over-reads from `IInfoListener::getString` channel-name buffers.
+
+**Prereqs**: Ableton Live 11 or 12 Suite (or Standard), `PulpHostBench.vst3`
+installed and Live rescan completed (Preferences → Plug-Ins → Rescan).
+
+## Steps
+
+1. **Clear stale logs**.
+
+2. **Launch Live**, new empty project, 48 kHz.
+
+3. **Drop PulpHostBench on Audio 1** (Plug-Ins browser → Pulp → PulpHostBench).
+
+4. **Confirm session start**:
+   ```bash
+   head -5 ~/Library/Logs/PulpHostBench/AbletonLive-VST3-*.log
+   # session_start  host=AbletonLive  format=VST3
+   ```
+
+5. **Open the plugin window**. Click the header to toggle the editor open / closed
+   three times.
+   ```bash
+   grep -c "view_opened\|view_closed" ~/Library/Logs/PulpHostBench/AbletonLive-VST3-*.log
+   # Expect 6 events total (3 open + 3 close).
+   ```
+
+6. **Resize the plugin window** by dragging the corner (Live 11+ supports
+   plugin window resize via the gear icon → "Show plug-in window" toggle).
+   ```bash
+   grep "view_resized\|bus_layout_proposal" ~/Library/Logs/PulpHostBench/AbletonLive-VST3-*.log
+   ```
+   → catalog row **#5**: Live calling `view_resized` even on plugins that
+     advertise non-resizable size is the symptom. The bench plugin's bounds
+     are 400×300 with no explicit aspect; if Live forces a different size
+     (other than your drag), record that here.
+
+7. **(Windows only)** Move the Live window between displays with different DPI
+   (e.g. 100% and 150%). Watch for editor-render glitches on the first frame.
+   This is the qualitative check for row #6 — the log file won't show DPI
+   directly, but a `view_resized` event with new dimensions is the trigger
+   point where the bug shows up visually.
+
+8. **Switch the Audio 1 routing** from "Ext. Out 1/2" stereo to "Ext. Out 1/2"
+   mono via the small triangle next to the routing dropdown.
+   ```bash
+   grep "bus_layout_proposal" ~/Library/Logs/PulpHostBench/AbletonLive-VST3-*.log
+   # Look for: inputs=1  outputs=1  (or inputs=2  outputs=1)
+   ```
+   → confirms Live re-proposes a layout when the user changes channel format,
+     and that the bench plugin's permissive `is_bus_layout_supported`
+     accepts it. If the plugin disappears from the chain, that's evidence
+     row #25 (`silence_unsupported_bus_arrangements`) is not being honored.
+
+9. **Set the Audio 1 sidechain input** to "Audio 2" (right-click on the
+   plugin → Sidechain Input).
+   ```bash
+   grep "sidechain_edge" ~/Library/Logs/PulpHostBench/AbletonLive-VST3-*.log
+   # Expect: connected=true after wiring the sidechain.
+   ```
+
+10. **Hit Play for a few seconds, then Stop**.
+    ```bash
+    grep "transport_changed\|process_is_playing_edge" ~/Library/Logs/PulpHostBench/AbletonLive-VST3-*.log
+    ```
+
+11. **Save the .als project**, close, reopen — confirm state round-trip
+    (the Bench Gain knob value should persist).
+
+12. **Quit Live** to flush.
+
+## Result
+
+| Quirk flag                                    | Row | Observed | Notes |
+|-----------------------------------------------|-----|----------|-------|
+| `live_vst3_canresize_ignore`                  | #5  | <C/R/NT> | <step 6 observations> |
+| `live_vst3_windows_dpi_defer` (Win only)      | #6  | <C/R/NT> | <step 7 observations or N/A on macOS> |
+| `double_string_buffer_for_live_10_1_13`       | (LessonOnly) | <C/R/NT> | <set Refuted unless on 10.1.13 specifically> |
+| `silence_unsupported_bus_arrangements`        | #25 | <C/R/NT> | <step 8 observations> |
+| `synthesize_bypass_parameter`                 | #23 | <C/R/NT> | <Live shows a "bypass" toggle in the device header> |
+
+**Log file(s)**: `<paste>`
+**Live version**: `<11.x.y / 12.x.y>` — **OS**: `<x.y>` — **Date**: `<YYYY-MM-DD>`

--- a/docs/validation/daw-bench/05-bitwig-vst3.md
+++ b/docs/validation/daw-bench/05-bitwig-vst3.md
@@ -1,0 +1,69 @@
+# 05 — Bitwig Studio (VST3)
+
+**Target quirks**:
+
+- `bitwig_vst3_linux_repaint_after_resize` (row #8) — Linux-only repaint bug.
+- `bitwig_vst3_setbusarrangements_while_active` (row #9) — Bitwig calls
+  `setBusArrangements` while the plugin is active (spec violation).
+
+**Prereqs**: Bitwig Studio 5+, `PulpHostBench.vst3` installed and Bitwig has
+rescanned plugins.
+
+## Steps
+
+1. **Clear stale logs**.
+
+2. **Launch Bitwig Studio**, new empty project, 48 kHz.
+
+3. **Add an audio track**, drag PulpHostBench from the device browser into
+   the device chain.
+
+4. **Confirm session log**:
+   ```bash
+   head -5 ~/Library/Logs/PulpHostBench/BitwigStudio-VST3-*.log
+   # session_start  host=BitwigStudio  format=VST3
+   ```
+   (If the file is named `Bitwig-` instead, that's the same — the exact spelling
+   depends on `host_type_name(HostType::Bitwig)`.)
+
+5. **Drag the plugin window's corner** to resize it (Bitwig 5+ supports
+   plugin-window resize through the "expand" toggle in the device header).
+   ```bash
+   grep "view_resized" ~/Library/Logs/PulpHostBench/Bitwig*-VST3-*.log
+   ```
+   → catalog row **#8** (Linux only): after a `view_resized` event, the
+     plugin should repaint. Visually verify the bench plugin's
+     "Last event" string updates on screen. If it freezes / shows stale
+     content, the Linux repaint-after-resize quirk is firing and the
+     flag should stay enabled.
+
+6. **Change the track input from stereo to mono** (right-click track → I/O →
+   change input format).
+   ```bash
+   grep "bus_layout_proposal\|process_without_prepare" ~/Library/Logs/PulpHostBench/Bitwig*-VST3-*.log
+   ```
+   → catalog row **#9**: if `bus_layout_proposal` events arrive WITHOUT a
+     fresh `prepare` event between them — i.e. the host is changing
+     layout without deactivating — that's evidence of the spec-violation
+     quirk. The bench's `is_bus_layout_supported` always accepts, but the
+     pattern in the log is the evidence.
+
+7. **Hit Play**, let it loop for a few seconds, Stop.
+   ```bash
+   grep "transport_changed\|tempo_changed" ~/Library/Logs/PulpHostBench/Bitwig*-VST3-*.log
+   ```
+
+8. **Save .bwproject, close, reopen** to confirm state round-trip.
+
+9. **Quit Bitwig**.
+
+## Result
+
+| Quirk flag                                       | Row | Observed | Notes |
+|--------------------------------------------------|-----|----------|-------|
+| `bitwig_vst3_linux_repaint_after_resize` (Linux) | #8  | <C/R/NT> | <visual repaint check from step 5> |
+| `bitwig_vst3_setbusarrangements_while_active`    | #9  | <C/R/NT> | <step 6 pattern> |
+| `silence_unsupported_bus_arrangements`           | #25 | <C/R/NT> | <bench accepted; plugin stayed loaded> |
+
+**Log file(s)**: `<paste>`
+**Bitwig version**: `<5.x.y>` — **OS**: `<x.y>` — **Date**: `<YYYY-MM-DD>`

--- a/docs/validation/daw-bench/06-reaper-vst3.md
+++ b/docs/validation/daw-bench/06-reaper-vst3.md
@@ -1,0 +1,112 @@
+# 06 — Reaper (VST3)
+
+**Target quirks** (Reaper has the widest catalog footprint — rows 15 + R1–R7):
+
+- `reaper_vst3_gesture_ordering` (#15) — gesture begin/end ordering.
+- `reaper_process_while_bypassed` (R1) — Reaper may call `process()` while bypassed.
+- `reaper_keyboard_passthrough` (R2) — key events route through plugin first.
+- `reaper_permissive_bus_arrangements` (R3) — Reaper accepts arbitrary pin wiring.
+- `reaper_anticipative_fx_buffer_variability` (R4) — variable buffer sizes mid-block.
+- `reaper_midsession_setstate` (R6) — `setState` called any time.
+- `reaper_keyboard_only_space` — REAPER only delivers a well-formed keyMsg for Space.
+
+**Prereqs**: Reaper 7.x, `PulpHostBench.vst3` installed and rescanned
+(Reaper → Options → Preferences → Plug-ins → VST → Re-scan).
+
+## Steps
+
+1. **Clear stale logs**.
+
+2. **Launch Reaper**, new empty project, 48 kHz, 32-bit float.
+
+3. **Insert a track**, add PulpHostBench on the FX chain.
+
+4. **Confirm session log**:
+   ```bash
+   head -5 ~/Library/Logs/PulpHostBench/Reaper-VST3-*.log
+   # session_start  host=Reaper  format=VST3
+   ```
+
+5. **Bypass the plugin via the FX-chain bypass button**. Hit Play. Stop.
+   Unbypass. Hit Play. Stop.
+   ```bash
+   grep "process_block_count\|suspend\|resume" ~/Library/Logs/PulpHostBench/Reaper-VST3-*.log
+   # Also check the plugin UI shows process_block_count > 0 during bypass
+   # (you'll need to peek at the bench's "Last event" string for a "process_*" event).
+   ```
+   → catalog row **R1**: if `process_*` events appear in the log even while
+     bypassed, Reaper is honoring "Run FX while bypassed" — confirming the
+     quirk. The bench plugin doesn't implement `process_bypassed()` (it
+     doesn't exist yet — see catalog), so process() runs as normal.
+
+6. **Right-click the track's FX-chain header** → Send all keyboard input to plugin.
+   Open the plugin window. Press Space.
+   ```bash
+   grep "view_opened\|view_resized" ~/Library/Logs/PulpHostBench/Reaper-VST3-*.log
+   # No direct key event — the bench plugin doesn't have a text widget, so
+   # the key-routing observation is whether REAPER's transport (Space = play)
+   # still works (it should — that's the desired behavior).
+   ```
+   → catalog row **R2**: if pressing Space starts Reaper's transport, REAPER
+     correctly bubbles keys it doesn't see consumed. If it freezes / does
+     nothing, the plugin is swallowing keys (which the bench doesn't).
+   → catalog row `reaper_keyboard_only_space`: try pressing other keys
+     (Tab, Esc, Return) — they should NOT trigger anything in the bench
+     plugin (no text widget); record whether REAPER's own shortcuts still fire.
+
+7. **Right-click the bench plugin's FX-chain entry** → Pin Connector. Connect
+   stereo output → left only of the next plugin, or to a 5-channel send.
+   ```bash
+   grep "bus_layout_proposal" ~/Library/Logs/PulpHostBench/Reaper-VST3-*.log
+   # Look for: outputs=N where N > 2 if you set up a wider send.
+   ```
+   → catalog row **R3**: Reaper may propose unusual channel counts. The bench
+     plugin's `is_bus_layout_supported` is permissive (accepts 1–8), so as long
+     as the count is in range the layout is accepted. If you see "Refused"
+     visually in Reaper's FX UI for a layout you tried to wire, that's evidence
+     the default-strict policy (rather than the permissive Reaper override) is
+     active.
+
+8. **Render the project to disk** (File → Render to File → set Sample Rate
+   to 96 kHz, Format = WAV, render).
+   ```bash
+   grep "prepare\|process_sample_rate_drift\|process_buffer_overrun" \
+       ~/Library/Logs/PulpHostBench/Reaper-VST3-*.log
+   ```
+   → catalog row **R4**: if a new `prepare` event appears with
+     `sample_rate=96000` (different from the project's 48 kHz), Reaper is
+     correctly re-preparing for the render. If only `process_sample_rate_drift`
+     events appear (without a fresh prepare), the offline-render path is
+     skipping prepare — that's the anticipative-FX quirk.
+
+9. **In the FX chain, right-click the bench plugin → Save FX chain → save as
+   `pulp-bench-test.RfxChain`. Delete the plugin from the track. Drag the
+   .RfxChain back from the FX browser onto the track.**
+   ```bash
+   grep -E "serialize_plugin_state|deserialize_plugin_state" \
+       ~/Library/Logs/PulpHostBench/Reaper-VST3-*.log
+   ```
+   → catalog row **R6**: Reaper just called `setState` on a freshly loaded
+     plugin instance, in the middle of an active project. Confirms the
+     mid-session-setState path works (and that the bench plugin doesn't
+     crash on it).
+
+10. **Save .rpp project**, close, reopen — confirm overall round-trip.
+
+11. **Quit Reaper**.
+
+## Result
+
+| Quirk flag                                       | Row | Observed | Notes |
+|--------------------------------------------------|-----|----------|-------|
+| `reaper_vst3_gesture_ordering`                   | #15 | <C/R/NT> | <only fully visible via host-side automation lane> |
+| `reaper_process_while_bypassed`                  | R1  | <C/R/NT> | <step 5> |
+| `reaper_keyboard_passthrough`                    | R2  | <C/R/NT> | <step 6: Space starts transport?> |
+| `reaper_keyboard_only_space` (Lesson)            | (LO)| <C/R/NT> | <step 6 other keys> |
+| `reaper_permissive_bus_arrangements`             | R3  | <C/R/NT> | <step 7> |
+| `reaper_anticipative_fx_buffer_variability`      | R4  | <C/R/NT> | <step 8> |
+| `reaper_midsession_setstate`                     | R6  | <C/R/NT> | <step 9> |
+| Cross-format defaults (#23/#24/#25)              | —   | <C/R/NT> |       |
+
+**Log file(s)**: `<paste>`
+**Reaper version**: `<7.x.y>` — **OS**: `<x.y>` — **Date**: `<YYYY-MM-DD>`

--- a/docs/validation/daw-bench/07-reaper-clap.md
+++ b/docs/validation/daw-bench/07-reaper-clap.md
@@ -1,0 +1,80 @@
+# 07 — Reaper (CLAP)
+
+**Target quirks**:
+
+- `reaper_process_while_bypassed` (R1) — applies across CLAP + VST3 + AU.
+- `reaper_anticipative_fx_buffer_variability` (R4) — also CLAP-relevant.
+- `reaper_midsession_setstate` (R6) — CLAP `state.save/load` round-trip.
+- R7 (catalog note) — Reaper CLAP is reference-strict; any drift here
+  surfaces bugs other hosts hide.
+
+**Prereqs**: Reaper 7.20+ (CLAP support landed in 7.0 and improved through
+7.x), `PulpHostBench.clap` installed under
+`~/Library/Audio/Plug-Ins/CLAP/` (macOS) or the platform CLAP folder.
+
+## Steps
+
+1. **Clear stale logs**.
+
+2. **Launch Reaper**, new empty project. Verify CLAP is enabled:
+   Options → Preferences → Plug-ins → CLAP → "Enable CLAP support".
+
+3. **Add a track, insert PulpHostBench (CLAP)** from the FX browser. (If you
+   have both the VST3 and CLAP variants installed, pick the CLAP filter
+   first to be sure.)
+
+4. **Confirm session log shows format=CLAP**:
+   ```bash
+   head -5 ~/Library/Logs/PulpHostBench/Reaper-CLAP-*.log
+   # session_start  host=Reaper  format=CLAP
+   ```
+
+5. **Hit Play, let it run a few seconds, Stop**.
+   ```bash
+   grep "transport_changed\|tempo_changed\|process_is_playing_edge" \
+       ~/Library/Logs/PulpHostBench/Reaper-CLAP-*.log
+   ```
+   → catalog row **R7** sanity: every transport edge produces an event. If a
+     play-then-stop yields zero `process_is_playing_edge` events, the CLAP
+     adapter is not surfacing transport state correctly.
+
+6. **Bypass via the FX-chain bypass button**, hit Play, observe the bench
+   plugin's "Last event" indicator (visually) — it should keep advancing
+   `process_*` events even while bypassed if R1 is firing.
+
+7. **Render to file at a different sample rate** (96 kHz):
+   ```bash
+   grep "prepare\|process_sample_rate_drift\|process_buffer_overrun" \
+       ~/Library/Logs/PulpHostBench/Reaper-CLAP-*.log
+   ```
+   → catalog row **R4**.
+
+8. **Save an FX chain** (right-click bench → Save FX chain), delete + reload.
+   ```bash
+   grep -E "serialize_plugin_state|deserialize_plugin_state" \
+       ~/Library/Logs/PulpHostBench/Reaper-CLAP-*.log
+   ```
+   → catalog row **R6** — CLAP `clap_plugin_state` round-trip.
+
+9. **Add a second track with a stereo audio file, set its output as a
+   sidechain to the bench-plugin track via Reaper's pin connector** (right-
+   click bench → Pin Connector → enable sidechain input).
+   ```bash
+   grep "sidechain_edge" ~/Library/Logs/PulpHostBench/Reaper-CLAP-*.log
+   # Expect: connected=true once the sidechain is wired and audio is playing.
+   ```
+
+10. **Quit Reaper**.
+
+## Result
+
+| Quirk flag                              | Row | Observed | Notes |
+|-----------------------------------------|-----|----------|-------|
+| `reaper_process_while_bypassed`         | R1  | <C/R/NT> | <step 6> |
+| `reaper_anticipative_fx_buffer_variability` | R4 | <C/R/NT> | <step 7> |
+| `reaper_midsession_setstate`            | R6  | <C/R/NT> | <step 8> |
+| `silence_unsupported_bus_arrangements`  | #25 | <C/R/NT> | <bench accepted layouts> |
+| (CLAP canary — R7)                      | —   | <C/R/NT> | <any new drift visible vs the VST3 run?> |
+
+**Log file(s)**: `<paste>`
+**Reaper version**: `<7.x.y>` — **OS**: `<x.y>` — **Date**: `<YYYY-MM-DD>`

--- a/docs/validation/daw-bench/08-aum-auv3.md
+++ b/docs/validation/daw-bench/08-aum-auv3.md
@@ -1,0 +1,66 @@
+# 08 — AUM (iOS, AU v3)
+
+**Target quirks**:
+
+- `au_v3_bypass_dual_tracking` (row #21) — AU v3 expects bypass to be tracked
+  twice (plugin param + platform `getShouldBypassEffect`).
+- `au_v3_host_id_from_wrapper` (row #22) — AU v3 host ID arrives via the
+  wrapper, not the executable path.
+
+> AUM is the iPad audio router/mixer. PulpHostBench needs to be built for iOS
+> first (`pulp_add_plugin` AUv3 path; see `examples/ios-auv3-synth/` for a
+> working example and `pulp:ios` skill for build steps).
+
+**Prereqs**: iPad with iOS 15+, AUM installed from the App Store,
+PulpHostBench iOS .ipa side-loaded or distributed via TestFlight.
+
+## Steps
+
+1. **Connect the iPad to a Mac and use macOS Console.app** to capture
+   live log output. Filter on subsystem `com.pulp.host-bench` (the bench
+   plugin's bundle id) so only its messages show up.
+
+   (The bench plugin writes to the iOS sandbox file system under
+   `<app-group>/Library/Logs/PulpHostBench/`. The Console.app live filter
+   gives you the same evidence in real time when file access is awkward.)
+
+2. **Launch AUM**, create a new session, add a channel, insert
+   PulpHostBench from the AU effects browser.
+
+3. **Confirm the bench plugin logged session start** in the iOS Console
+   filter. Look for `processor_construct` with `format=AU`.
+
+4. **Tap the channel's bypass button** in AUM. Tap it again.
+   → catalog row **#21**: AU v3 expects both the user-facing bypass param
+     and the platform `getShouldBypassEffect` to flip. The bench plugin
+     exposes a Bench Bypass parameter (kBenchBypass) that AUM should drive
+     via the AU parameter tree. If AUM's track-level bypass also flips the
+     param value (visible in the AU's parameter UI), dual-tracking works.
+
+5. **Switch the AUM session sample rate** (Settings → 44.1 / 48 / 96 kHz).
+   Watch the Console output for a `prepare` event with the new sample rate.
+
+6. **Background the AUM app** (return to home screen). Wait 10 seconds.
+   Reopen AUM. Watch for either `suspend`/`resume` events or
+   `process_*` events depending on AUM's background-audio policy.
+
+7. **Save the AUM session, force-quit AUM, relaunch**.
+   → confirms iOS state round-trip via `serialize/deserialize_plugin_state`.
+     This is also the row #22 evidence: when AUM relaunches and re-inserts
+     the plugin, the wrapper-ID-based host detection should resolve to
+     AUM (or `Unknown` until AUM's bundle id graduates into the
+     `host_type_from_auv3_wrapper()` switch). Record the `host=` value
+     from `session_start`.
+
+8. **Quit AUM**.
+
+## Result
+
+| Quirk flag                            | Row | Observed | Notes |
+|---------------------------------------|-----|----------|-------|
+| `au_v3_bypass_dual_tracking`          | #21 | <C/R/NT> | <step 4: AUM bypass flipped param?> |
+| `au_v3_host_id_from_wrapper`          | #22 | <C/R/NT> | <step 7: host string in session_start = ?> |
+| `synthesize_bypass_parameter`         | #23 | <C/R/NT> | <general — AU v3 always-on?> |
+
+**Log file(s)**: `<paste console capture or sandbox export>`
+**AUM version**: `<x.y>` — **iOS version**: `<x.y>` — **Date**: `<YYYY-MM-DD>`

--- a/docs/validation/daw-bench/09-studio-one-vst3.md
+++ b/docs/validation/daw-bench/09-studio-one-vst3.md
@@ -1,0 +1,69 @@
+# 09 — Studio One (VST3)
+
+**Target quirks**:
+
+- Studio One is not in the dense per-host catalog rows (1–22), but it is the
+  primary target of the cross-format defaults — `synthesize_bypass_parameter`
+  (#23), `clamp_latency_to_nonneg` (#24), `silence_unsupported_bus_arrangements`
+  (#25) — and the bench plugin confirms those behaviors hold in PreSonus's
+  host.
+
+**Prereqs**: PreSonus Studio One 6.x, `PulpHostBench.vst3` installed and
+Studio One has rescanned plugins (Studio One → Preferences → Locations →
+VST Plug-Ins → Reset Blocklist & Rescan).
+
+## Steps
+
+1. **Clear stale logs**.
+
+2. **Launch Studio One**, new empty Song, 48 kHz.
+
+3. **Add an audio track**, insert PulpHostBench (drag from Browser → Effects).
+
+4. **Confirm session log**:
+   ```bash
+   head -5 ~/Library/Logs/PulpHostBench/StudioOne-VST3-*.log
+   # session_start  host=StudioOne  format=VST3
+   ```
+
+5. **Drag the Bench Gain knob** from 0 dB to +6 dB; touch it again to go back
+   to 0 dB.
+
+6. **Hit Play, Stop**.
+   ```bash
+   grep "transport_changed\|process_is_playing_edge" ~/Library/Logs/PulpHostBench/StudioOne-VST3-*.log
+   ```
+
+7. **Toggle the channel-strip bypass** (the channel-level bypass, not the
+   plugin's own Bypass param).
+   → catalog row **#23**: Studio One should successfully bypass the plugin
+     regardless of whether the plugin declared its own bypass param. The
+     bench plugin DOES declare one, so this is more about confirming no
+     duplicate "Bypass" entries appear in the param list (which would
+     indicate row #23 over-synthesizing).
+
+8. **Try a multi-bus / sidechain configuration**: right-click the bench plugin
+   header → Sidechain → pick another track's output as the sidechain input.
+   ```bash
+   grep "bus_layout_proposal\|sidechain_edge" ~/Library/Logs/PulpHostBench/StudioOne-VST3-*.log
+   ```
+
+9. **Save the Song, close, reopen**.
+   ```bash
+   grep -E "serialize_plugin_state|deserialize_plugin_state" \
+       ~/Library/Logs/PulpHostBench/StudioOne-VST3-*.log
+   ```
+
+10. **Quit Studio One**.
+
+## Result
+
+| Quirk flag                                | Row | Observed | Notes |
+|-------------------------------------------|-----|----------|-------|
+| `synthesize_bypass_parameter`             | #23 | <C/R/NT> | <step 7> |
+| `clamp_latency_to_nonneg`                 | #24 | <C/R/NT> | <bench reports latency=0; no negative> |
+| `silence_unsupported_bus_arrangements`    | #25 | <C/R/NT> | <step 8> |
+| (host detection)                          | —   | <C/R/NT> | <session_start host= ?> |
+
+**Log file(s)**: `<paste>`
+**Studio One version**: `<6.x.y>` — **OS**: `<x.y>` — **Date**: `<YYYY-MM-DD>`

--- a/docs/validation/daw-bench/10-wavelab-vst3.md
+++ b/docs/validation/daw-bench/10-wavelab-vst3.md
@@ -1,0 +1,78 @@
+# 10 — Wavelab (VST3)
+
+**Target quirks**:
+
+- `wavelab_vst3_defer_activation` (row #10) — `setBusArrangements` called
+  re-entrantly inside `prepareToPlay` when the plugin invokes `setLatencySamples`.
+- `wavelab_state_blob_fallback` (row #11) — Wavelab tolerates state-blob
+  read failures; strict failure causes session loss.
+- `tolerate_state_read_nontrue_status` (LessonOnly) — `IBStream::read`
+  may return non-`kResultTrue` while still having populated the buffer.
+
+**Prereqs**: Steinberg Wavelab 11.1+ (or earlier — the bench will confirm
+behavior on whichever version you have), `PulpHostBench.vst3` installed.
+
+## Steps
+
+1. **Clear stale logs**.
+
+2. **Launch Wavelab**, open an Audio Editor with any source file
+   (Wavelab is mastering-centric — most users will start in the Audio
+   Editor window rather than a Montage).
+
+3. **Insert PulpHostBench in the Master Section** (Master Section panel →
+   any insert slot → choose PulpHostBench).
+
+4. **Confirm session log**:
+   ```bash
+   head -5 ~/Library/Logs/PulpHostBench/Wavelab-VST3-*.log
+   # session_start  host=Wavelab  format=VST3
+   ```
+
+5. **Hit Play in the Audio Editor**.
+   ```bash
+   grep -E "prepare|bus_layout_proposal|process_without_prepare" \
+       ~/Library/Logs/PulpHostBench/Wavelab-VST3-*.log | head -20
+   ```
+   → catalog row **#10**: count the order of `prepare` and `bus_layout_proposal`
+     events. If `bus_layout_proposal` interleaves WITH or INSIDE the prepare
+     sequence (i.e. multiple proposals between processor_construct and the
+     first process block), Wavelab's re-entrant negotiation pattern is firing.
+
+6. **Save the Audio Editor's plugin chain as a preset**, close the file,
+   reopen the saved preset.
+   ```bash
+   grep -E "serialize_plugin_state|deserialize_plugin_state" \
+       ~/Library/Logs/PulpHostBench/Wavelab-VST3-*.log
+   ```
+   → catalog rows **#11** / `tolerate_state_read_nontrue_status`: the bench's
+     `marker_ok` field on the deserialize line confirms whether Wavelab read
+     back the exact bytes. If `bytes < 18` or `marker_ok=false`, the Wavelab-
+     style truncation / non-true-status path is the cause and the quirk is
+     warranted.
+
+7. **Try a Montage workflow** (File → New → Audio Montage), drop a clip in,
+   put PulpHostBench on the clip's effect chain. Play.
+   ```bash
+   ls -lt ~/Library/Logs/PulpHostBench/ | head -3
+   # A new log file (different PID) typically appears for Montage's instance.
+   ```
+
+8. **Render the Montage to file** (Workspace → Render).
+   ```bash
+   grep "prepare\|suspend\|resume" ~/Library/Logs/PulpHostBench/Wavelab-VST3-*.log | tail -10
+   ```
+
+9. **Quit Wavelab**.
+
+## Result
+
+| Quirk flag                                   | Row | Observed | Notes |
+|----------------------------------------------|-----|----------|-------|
+| `wavelab_vst3_defer_activation`              | #10 | <C/R/NT> | <step 5 ordering pattern> |
+| `wavelab_state_blob_fallback`                | #11 | <C/R/NT> | <step 6 marker_ok value> |
+| `tolerate_state_read_nontrue_status` (Lesson)| (LO)| <C/R/NT> | <step 6 bytes value vs 18> |
+| `synthesize_bypass_parameter`                | #23 | <C/R/NT> |       |
+
+**Log file(s)**: `<paste>`
+**Wavelab version**: `<11.x.y>` — **OS**: `<x.y>` — **Date**: `<YYYY-MM-DD>`

--- a/docs/validation/daw-bench/11-fl-studio-vst3.md
+++ b/docs/validation/daw-bench/11-fl-studio-vst3.md
@@ -1,0 +1,73 @@
+# 11 — FL Studio (VST3)
+
+**Target quirks**:
+
+- `fl_studio_setactive_process_mutex` (row #13) — FL's Patcher calls
+  `process()` before `setActive(true)` and concurrently with
+  `setBusArrangements()`.
+- `fl_studio_state_reader_skip` (row #14) — FL's state blob layout differs
+  from VST3 reference; strict `MemoryStream` reader fails.
+
+**Prereqs**: Image-Line FL Studio 21+, `PulpHostBench.vst3` installed and
+FL has rescanned (Options → Manage Plugins → Find Plugins).
+
+## Steps
+
+1. **Clear stale logs**.
+
+2. **Launch FL Studio**, new empty project, 48 kHz.
+
+3. **Open the Mixer**, select Insert 1, click the "+" slot →
+   PulpHostBench from the plugin list. Click "Add to insert".
+
+4. **Confirm session log**:
+   ```bash
+   head -5 ~/Library/Logs/PulpHostBench/FLStudio-VST3-*.log
+   # session_start  host=FLStudio  format=VST3
+   ```
+
+5. **Open the Patcher** (Channels → Add One → Patcher). Drop PulpHostBench
+   into the Patcher.
+   ```bash
+   grep -E "process_without_prepare|bus_layout_proposal|prepare" \
+       ~/Library/Logs/PulpHostBench/FLStudio-VST3-*.log | head -20
+   ```
+   → catalog row **#13**: if any `process_without_prepare` events appear
+     in the log, FL's Patcher is the prime suspect — it is documented as
+     calling `process()` before `setActive(true)`. The bench plugin
+     captures this as a first-class log line specifically because of
+     this row.
+
+6. **Hit Play, Stop, repeatedly toggle the Patcher's bypass**.
+   ```bash
+   grep "process_without_prepare\|process_sample_rate_drift\|process_buffer_overrun" \
+       ~/Library/Logs/PulpHostBench/FLStudio-VST3-*.log
+   ```
+
+7. **Change the project sample rate** (Options → Audio Settings → Sample Rate
+   → e.g. 96000). Hit Play again.
+   ```bash
+   grep "prepare\|process_sample_rate_drift" ~/Library/Logs/PulpHostBench/FLStudio-VST3-*.log
+   ```
+
+8. **Save the .flp project, close, reopen**.
+   ```bash
+   grep -E "serialize_plugin_state|deserialize_plugin_state" \
+       ~/Library/Logs/PulpHostBench/FLStudio-VST3-*.log
+   ```
+   → catalog row **#14**: `marker_ok=true` on the deserialize line means
+     FL conveyed the blob correctly via its own reader path. If
+     `marker_ok=false`, the `fl_studio_state_reader_skip` quirk is needed.
+
+9. **Quit FL Studio**.
+
+## Result
+
+| Quirk flag                                | Row | Observed | Notes |
+|-------------------------------------------|-----|----------|-------|
+| `fl_studio_setactive_process_mutex`       | #13 | <C/R/NT> | <count of process_without_prepare events> |
+| `fl_studio_state_reader_skip`             | #14 | <C/R/NT> | <step 8 marker_ok value> |
+| Cross-format defaults (#23/#24/#25)       | —   | <C/R/NT> |       |
+
+**Log file(s)**: `<paste>`
+**FL Studio version**: `<21.x.y>` — **OS**: `<x.y>` — **Date**: `<YYYY-MM-DD>`

--- a/docs/validation/daw-bench/README.md
+++ b/docs/validation/daw-bench/README.md
@@ -1,0 +1,135 @@
+# DAW Bench — Manual Validation Scripts
+
+This directory holds the per-DAW manual test scripts for the
+**PulpHostBench** validation plugin (`examples/host-bench-plugin/`).
+
+The goal is to graduate `Speculative` rows in
+`core/format/include/pulp/format/host_quirks.hpp::HostQuirksMeta`
+into `Validated` by observing the host's behavior in a real DAW
+session.
+
+## How the package fits together
+
+```
+   examples/host-bench-plugin/
+       ↓ builds → AU + VST3 + CLAP bundles + Standalone host
+                  emits one log per session under
+                  ~/Library/Logs/PulpHostBench/
+                  (macOS — Linux + Windows use platform-default
+                  log dirs; see bench_logger.hpp)
+
+   docs/validation/daw-bench/
+       11 numbered .md scripts                     ← YOU ARE HERE
+       (Logic, Cubase x2, Live, Bitwig, Reaper x2,
+        AUM, Studio One, Wavelab, FL Studio)
+
+   tools/scripts/promote_quirk_tiers.py
+       Reads the .log files written during the scripts above.
+       Emits a unified diff against
+       core/format/include/pulp/format/host_quirks.hpp that
+       promotes the rows the logs confirmed.
+```
+
+## End-to-end workflow (~30 min for one DAW)
+
+1. **Build the bench plugin** in your Pulp checkout:
+   ```bash
+   cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF
+   cmake --build build --target PulpHostBench_CLAP PulpHostBench_Standalone
+   # macOS, with AudioUnitSDK installed:
+   cmake --build build --target PulpHostBench_AU
+   # macOS, with VST3 SDK installed:
+   cmake --build build --target PulpHostBench_VST3
+   ```
+2. **Install** into the platform plugin folders:
+   - AU:   `cp -R build/AU/PulpHostBench.component ~/Library/Audio/Plug-Ins/Components/`
+   - VST3: `cp -R build/VST3/PulpHostBench.vst3 ~/Library/Audio/Plug-Ins/VST3/`
+   - CLAP: `cp -R build/CLAP/PulpHostBench.clap ~/Library/Audio/Plug-Ins/CLAP/`
+3. **Clear stale logs** so this session's events stand alone:
+   ```bash
+   rm -rf ~/Library/Logs/PulpHostBench/   # macOS
+   ```
+4. **Open the per-DAW script** for whatever you're benching:
+   - [`01-logic-pro-au.md`](01-logic-pro-au.md)
+   - [`02-cubase-12-vst3.md`](02-cubase-12-vst3.md)
+   - [`03-cubase-9-vst3.md`](03-cubase-9-vst3.md)
+   - [`04-live-vst3.md`](04-live-vst3.md)
+   - [`05-bitwig-vst3.md`](05-bitwig-vst3.md)
+   - [`06-reaper-vst3.md`](06-reaper-vst3.md)
+   - [`07-reaper-clap.md`](07-reaper-clap.md)
+   - [`08-aum-auv3.md`](08-aum-auv3.md)
+   - [`09-studio-one-vst3.md`](09-studio-one-vst3.md)
+   - [`10-wavelab-vst3.md`](10-wavelab-vst3.md)
+   - [`11-fl-studio-vst3.md`](11-fl-studio-vst3.md)
+5. **Follow the numbered steps** in the chosen script. Each step
+   says "do action X in the DAW", "now check the log file for
+   line Y". The script names the specific quirk row(s) being
+   confirmed.
+6. **Fill in the Result table** at the bottom of the script.
+   Mark each row Confirmed / Refuted / Not Triggered. Save the
+   resulting `.md` so it can be pasted back into the follow-up PR.
+7. **Run the aggregator** when you've benched as many hosts as
+   you plan to in this round:
+   ```bash
+   python3 tools/scripts/promote_quirk_tiers.py \
+       ~/Library/Logs/PulpHostBench/*.log \
+       --quirks-header core/format/include/pulp/format/host_quirks.hpp \
+       --output /tmp/promote.patch
+   git apply /tmp/promote.patch
+   git diff core/format/include/pulp/format/host_quirks.hpp
+   ```
+8. **Open a PR** that includes the patch plus the filled-in
+   scripts under `docs/validation/daw-bench/results/<date>/`.
+
+## What the bench plugin logs
+
+Every script's "check the log" steps reference one of these stable
+event names:
+
+| Event                          | Trigger                                                            |
+|--------------------------------|--------------------------------------------------------------------|
+| `session_start`                | Processor instance constructed                                     |
+| `session_end`                  | Processor instance destroyed                                       |
+| `processor_construct`          | Includes plugin version + detected host                            |
+| `processor_destruct`           | Symmetric counterpart                                              |
+| `define_parameters`            | Host built the parameter list                                      |
+| `prepare`                      | Host called `prepare()` — sample rate + max buffer + channels      |
+| `release`                      | Host called `release()`                                            |
+| `suspend` / `resume`           | Host stalled/resumed processing (preset load, sample-rate change)  |
+| `bus_layout_proposal`          | Host asked "do you support inputs=X outputs=Y?"                    |
+| `transport_changed`            | Host transport flipped play state or jumped position               |
+| `tempo_changed`                | Host BPM changed                                                   |
+| `serialize_plugin_state`       | Host wrote a project snapshot                                      |
+| `deserialize_plugin_state`     | Host restored a project snapshot                                   |
+| `view_opened` / `closed`       | Editor opened or closed                                            |
+| `view_resized`                 | Editor resized                                                     |
+| `process_without_prepare`      | **Spec violation** — host called `process()` before `prepare()`    |
+| `process_sample_rate_drift`    | **Drift** — runtime SR differs from `prepare()` SR                 |
+| `process_buffer_overrun`       | **Drift** — runtime buffer larger than `prepare()` max             |
+| `process_is_playing_edge`      | First block to see a transport-state edge                          |
+| `sidechain_edge`               | Sidechain bus connected/disconnected                               |
+| `midi_in`                      | Block carried inbound MIDI events                                  |
+
+The aggregator only reads the event names + the optional `key=value`
+fields after them, so adding new always-additive events is safe.
+
+## Filing results
+
+When a per-DAW session is complete:
+
+1. Copy the filled-in `.md` to
+   `docs/validation/daw-bench/results/YYYY-MM-DD/<NN-host>.md`
+   (the results subdir is checked in but session files live under
+   it; create the dated subfolder on first use).
+2. Include the matching `.log` file(s) under
+   `docs/validation/daw-bench/results/YYYY-MM-DD/logs/` if they're
+   small enough; large logs can be summarized in the `.md` and
+   linked from a gist.
+3. Run the aggregator + include the resulting patch in the PR
+   that promotes the tier flips.
+
+Where the catalog row says "Reference evidence" — that's a
+*study trail*, not a porting source. The Pulp bench reproduces the
+quirk from the host alone; the aggregator's promotion is the
+in-tree validation evidence. The license-hygiene rules in
+`planning/2026-05-24-daw-host-quirks-inheritance.md` still apply.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -10,6 +10,10 @@ endif()
 # Phase 2-3: PulpGain (trivial gain plugin)
 add_subdirectory(pulp-gain)
 
+# DAW bench harness — load in real DAWs to graduate host-quirk rows from
+# Speculative → Validated. See docs/validation/daw-bench/.
+add_subdirectory(host-bench-plugin)
+
 # Phase 4: PulpTone (oscillator synth + musical typing)
 add_subdirectory(pulp-tone)
 

--- a/examples/host-bench-plugin/CMakeLists.txt
+++ b/examples/host-bench-plugin/CMakeLists.txt
@@ -1,0 +1,41 @@
+# PulpHostBench — DAW-quirk validation bench plugin.
+#
+# Loads in every DAW under test and writes a tab-separated event log
+# per session under `~/Library/Logs/PulpHostBench/` (macOS) or the
+# equivalent on other platforms. The per-DAW manual scripts under
+# `docs/validation/daw-bench/` drive the plugin; the aggregator
+# `tools/scripts/promote_quirk_tiers.py` reads the logs.
+
+if(PULP_BUILD_TESTS)
+    add_executable(pulp-host-bench-test test_host_bench.cpp)
+    target_link_libraries(pulp-host-bench-test
+        PRIVATE pulp::format Catch2::Catch2WithMain)
+    target_include_directories(pulp-host-bench-test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    catch_discover_tests(pulp-host-bench-test)
+endif()
+
+set(PULP_HOST_BENCH_FORMATS VST3 CLAP Standalone)
+if(APPLE)
+    list(APPEND PULP_HOST_BENCH_FORMATS AU)
+endif()
+
+pulp_add_plugin(PulpHostBench
+    FORMATS         ${PULP_HOST_BENCH_FORMATS}
+    PLUGIN_NAME     "PulpHostBench"
+    BUNDLE_ID       "com.pulp.host-bench"
+    MANUFACTURER    "Pulp"
+    VERSION         "1.0.0"
+    CATEGORY        Effect
+    PLUGIN_CODE     "PHBn"
+    MANUFACTURER_CODE "Pulp"
+)
+
+# CLAP dlopen smoke (parity with PulpGain).
+if(PULP_HAS_CLAP AND APPLE)
+    add_test(
+        NAME clap-dlopen-PulpHostBench
+        COMMAND bash -c "python3 -c \"import ctypes; ctypes.CDLL('${CMAKE_BINARY_DIR}/CLAP/PulpHostBench.clap/Contents/MacOS/PulpHostBench'); print('OK')\""
+    )
+    set_tests_properties(clap-dlopen-PulpHostBench PROPERTIES LABELS "validation;clap" TIMEOUT 10)
+endif()

--- a/examples/host-bench-plugin/Info.plist.au
+++ b/examples/host-bench-plugin/Info.plist.au
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>PulpHostBench</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.pulp.host-bench.au</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>PulpHostBench</string>
+    <key>CFBundlePackageType</key>
+    <string>BNDL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>AudioComponents</key>
+    <array>
+        <dict>
+            <key>name</key>
+            <string>Pulp: PulpHostBench</string>
+            <key>description</key>
+            <string>PulpHostBench — DAW quirk validation bench</string>
+            <key>manufacturer</key>
+            <string>Pulp</string>
+            <key>type</key>
+            <string>aufx</string>
+            <key>subtype</key>
+            <string>PHBn</string>
+            <key>version</key>
+            <integer>65536</integer>
+            <key>factoryFunction</key>
+            <string>PulpHostBenchAUFactory</string>
+            <key>sandboxSafe</key>
+            <true/>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/examples/host-bench-plugin/Info.plist.vst3
+++ b/examples/host-bench-plugin/Info.plist.vst3
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>PulpHostBench</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.pulp.host-bench.vst3</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>PulpHostBench</string>
+    <key>CFBundlePackageType</key>
+    <string>BNDL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0.0</string>
+    <key>CFBundleVersion</key>
+    <string>1.0.0</string>
+</dict>
+</plist>

--- a/examples/host-bench-plugin/au_register.cpp
+++ b/examples/host-bench-plugin/au_register.cpp
@@ -1,0 +1,9 @@
+// PulpHostBench AU — plugin registration (force-link).
+
+#include "host_bench.hpp"
+
+#include <pulp/format/registry.hpp>
+
+PULP_REGISTER_PLUGIN(pulp::examples::create_host_bench_au)
+
+extern "C" void pulp_host_bench_force_link() {}

--- a/examples/host-bench-plugin/au_v2_entry.cpp
+++ b/examples/host-bench-plugin/au_v2_entry.cpp
@@ -1,0 +1,9 @@
+// PulpHostBench AU v2 entry.
+// Format label "AU" is encoded into the log filename so the per-DAW
+// scripts can grep for AU-specific quirk evidence.
+
+#include "host_bench.hpp"
+
+#include <pulp/format/au_v2_entry.hpp>
+
+PULP_AU_PLUGIN(PulpHostBenchAU, pulp::examples::create_host_bench_au)

--- a/examples/host-bench-plugin/bench_logger.hpp
+++ b/examples/host-bench-plugin/bench_logger.hpp
@@ -1,0 +1,194 @@
+#pragma once
+
+// PulpHostBench — per-instance event logger.
+//
+// One file per (host, format, pid, timestamp) tuple, written under
+//
+//   macOS:   $HOME/Library/Logs/PulpHostBench/
+//   Linux:   $XDG_STATE_HOME/pulp-host-bench/  (falls back to ~/.local/state/...)
+//   Windows: %LOCALAPPDATA%/PulpHostBench/    (falls back to %USERPROFILE%/...)
+//
+// Each log line is a single tab-separated record:
+//
+//   <iso8601-ts>\t<event>\t<key=value>\t<key=value>...
+//
+// Event names are stable and consumed verbatim by
+// `tools/scripts/promote_quirk_tiers.py`, so keep new events additive.
+
+#include <pulp/format/host_type.hpp>
+#include <pulp/runtime/log.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <thread>
+
+#if defined(_WIN32)
+#  include <process.h>
+#  define PULP_BENCH_GETPID _getpid
+#else
+#  include <unistd.h>
+#  define PULP_BENCH_GETPID ::getpid
+#endif
+
+namespace pulp::examples::bench {
+
+inline std::string host_name(format::HostType type) {
+    return format::host_type_name(type);
+}
+
+inline std::filesystem::path bench_log_dir() {
+#if defined(__APPLE__)
+    const char* home = std::getenv("HOME");
+    if (home && *home) {
+        return std::filesystem::path(home) / "Library" / "Logs" / "PulpHostBench";
+    }
+#elif defined(_WIN32)
+    const char* local = std::getenv("LOCALAPPDATA");
+    if (local && *local) {
+        return std::filesystem::path(local) / "PulpHostBench";
+    }
+    const char* profile = std::getenv("USERPROFILE");
+    if (profile && *profile) {
+        return std::filesystem::path(profile) / "PulpHostBench";
+    }
+#else
+    const char* xdg = std::getenv("XDG_STATE_HOME");
+    if (xdg && *xdg) {
+        return std::filesystem::path(xdg) / "pulp-host-bench";
+    }
+    const char* home = std::getenv("HOME");
+    if (home && *home) {
+        return std::filesystem::path(home) / ".local" / "state" / "pulp-host-bench";
+    }
+#endif
+    return std::filesystem::temp_directory_path() / "pulp-host-bench";
+}
+
+inline std::string iso8601_now() {
+    using clock = std::chrono::system_clock;
+    auto now = clock::now();
+    auto secs = std::chrono::time_point_cast<std::chrono::seconds>(now);
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - secs).count();
+    std::time_t t = clock::to_time_t(secs);
+    std::tm tm_buf{};
+#if defined(_WIN32)
+    gmtime_s(&tm_buf, &t);
+#else
+    gmtime_r(&t, &tm_buf);
+#endif
+    std::ostringstream os;
+    os << std::put_time(&tm_buf, "%Y-%m-%dT%H:%M:%S") << '.'
+       << std::setw(3) << std::setfill('0') << ms << 'Z';
+    return os.str();
+}
+
+inline std::string compact_now() {
+    using clock = std::chrono::system_clock;
+    std::time_t t = clock::to_time_t(clock::now());
+    std::tm tm_buf{};
+#if defined(_WIN32)
+    gmtime_s(&tm_buf, &t);
+#else
+    gmtime_r(&t, &tm_buf);
+#endif
+    std::ostringstream os;
+    os << std::put_time(&tm_buf, "%Y%m%dT%H%M%SZ");
+    return os.str();
+}
+
+/// One logger per processor instance — writes to a unique file so
+/// parallel hosts (e.g. AU + VST3 in the same Logic session) don't stomp.
+class BenchLogger {
+public:
+    BenchLogger(std::string format_label, format::HostType host)
+        : format_(std::move(format_label)),
+          host_(host_name(host)),
+          host_type_(host) {
+        std::error_code ec;
+        auto dir = bench_log_dir();
+        std::filesystem::create_directories(dir, ec);
+
+        std::ostringstream filename;
+        filename << host_ << '-' << format_ << '-' << compact_now()
+                 << "-pid" << PULP_BENCH_GETPID() << ".log";
+        path_ = (dir / filename.str()).string();
+
+        out_.open(path_, std::ios::out | std::ios::app);
+        write_event("session_start",
+                    {{"host", host_},
+                     {"format", format_},
+                     {"pulp_bench_plugin", "1.0.0"}});
+    }
+
+    ~BenchLogger() {
+        write_event("session_end", {});
+    }
+
+    BenchLogger(const BenchLogger&) = delete;
+    BenchLogger& operator=(const BenchLogger&) = delete;
+
+    using KV = std::pair<std::string, std::string>;
+    using KVList = std::initializer_list<KV>;
+
+    /// Append one event. Thread-safe — called from audio thread (process)
+    /// and host thread (prepare/setState/…). The audio-thread path keeps
+    /// allocations on the stack-ish std::ostringstream but does take the
+    /// mutex; this is acceptable because the harness is a *bench* tool
+    /// (not a shipping plugin) and the user runs it deliberately.
+    void write_event(std::string_view event, KVList kvs) {
+        std::lock_guard<std::mutex> lock(mtx_);
+        if (!out_.is_open()) return;
+        out_ << iso8601_now() << '\t' << event;
+        for (auto const& kv : kvs) {
+            out_ << '\t' << kv.first << '=' << kv.second;
+        }
+        out_ << '\t' << "n=" << ++event_count_ << '\n';
+        out_.flush();
+        last_event_ = std::string(event);
+    }
+
+    std::string last_event() const {
+        std::lock_guard<std::mutex> lock(mtx_);
+        return last_event_;
+    }
+
+    std::uint64_t event_count() const {
+        return event_count_.load(std::memory_order_relaxed);
+    }
+
+    const std::string& path() const { return path_; }
+    format::HostType host_type() const { return host_type_; }
+    const std::string& format() const { return format_; }
+    const std::string& host() const { return host_; }
+
+    // Helpers for common stringifications.
+    template <typename T>
+    static std::string to_str(T const& v) {
+        std::ostringstream os;
+        os << v;
+        return os.str();
+    }
+    static std::string bool_str(bool b) { return b ? "true" : "false"; }
+
+private:
+    mutable std::mutex mtx_;
+    std::ofstream out_;
+    std::string path_;
+    std::string format_;
+    std::string host_;
+    format::HostType host_type_;
+    std::string last_event_;
+    std::atomic<std::uint64_t> event_count_{0};
+};
+
+}  // namespace pulp::examples::bench

--- a/examples/host-bench-plugin/clap_entry.cpp
+++ b/examples/host-bench-plugin/clap_entry.cpp
@@ -1,0 +1,7 @@
+// PulpHostBench CLAP entry.
+
+#include "host_bench.hpp"
+
+#include <pulp/format/clap_entry.hpp>
+
+PULP_CLAP_PLUGIN(pulp::examples::create_host_bench_clap)

--- a/examples/host-bench-plugin/host_bench.hpp
+++ b/examples/host-bench-plugin/host_bench.hpp
@@ -1,0 +1,313 @@
+#pragma once
+
+// PulpHostBench — the DAW-bench validation plugin.
+//
+// Purpose: load this plugin in every DAW under test, drive it through the
+// per-DAW manual script at `docs/validation/daw-bench/`, and read back the
+// log file at `~/Library/Logs/PulpHostBench/<host>-<format>-<ts>.log` to
+// confirm which quirk rows in
+// `planning/2026-05-24-daw-host-quirks-inheritance.md` the host actually
+// triggered. The aggregator at `tools/scripts/promote_quirk_tiers.py`
+// reads those logs to produce a patch promoting `Speculative` →
+// `Validated` rows in `core/format/include/pulp/format/host_quirks.hpp`.
+//
+// The plugin is intentionally minimal as a DSP — a passthrough with a
+// gain knob. The interesting surface is the **lifecycle events** every
+// override records into the bench log.
+
+#include "bench_logger.hpp"
+
+#include <pulp/format/processor.hpp>
+
+#include <atomic>
+#include <cmath>
+#include <memory>
+#include <string>
+
+namespace pulp::examples {
+
+enum HostBenchParams : state::ParamID {
+    kBenchGain    = 1,  ///< User-driven param (host writes this; we log)
+    kBenchBypass  = 2,  ///< User-driven bypass (host may also synthesize one)
+    kBenchTrigger = 3,  ///< User-driven button; the per-DAW script asks the
+                         ///< human to wiggle this to confirm gestures work
+};
+
+/// Hard-coded version. Bumping this should also bump the row in
+/// `planning/host-quirks-log.md`'s "tooling versions" section so the
+/// aggregator can refuse logs from older mismatched plugin builds.
+inline constexpr const char* kBenchPluginVersion = "1.0.0";
+
+class HostBenchProcessor : public format::Processor {
+public:
+    explicit HostBenchProcessor(std::string format_label)
+        : format_label_(std::move(format_label)),
+          host_type_(format::detect_host_type()),
+          logger_(std::make_unique<bench::BenchLogger>(format_label_, host_type_)) {
+        logger_->write_event("processor_construct",
+                             {{"plugin_version", kBenchPluginVersion}});
+    }
+
+    ~HostBenchProcessor() override {
+        if (logger_) {
+            logger_->write_event("processor_destruct", {});
+        }
+    }
+
+    format::PluginDescriptor descriptor() const override {
+        return {
+            .name = "PulpHostBench",
+            .manufacturer = "Pulp",
+            .bundle_id = "com.pulp.host-bench",
+            .version = kBenchPluginVersion,
+            .category = format::PluginCategory::Effect,
+            .input_buses = {{"Audio In", 2}, {"Sidechain", 2, /*optional=*/true}},
+            .output_buses = {{"Audio Out", 2}},
+            .accepts_midi = true,
+            .produces_midi = false,
+            .tail_samples = 0,
+        };
+    }
+
+    void define_parameters(state::StateStore& store) override {
+        store.add_parameter({
+            .id = kBenchGain,
+            .name = "Bench Gain",
+            .unit = "dB",
+            .range = {-60.0f, 24.0f, 0.0f, 0.1f},
+        });
+        store.add_parameter({
+            .id = kBenchBypass,
+            .name = "Bench Bypass",
+            .unit = "",
+            .range = {0.0f, 1.0f, 0.0f, 1.0f},
+        });
+        store.add_parameter({
+            .id = kBenchTrigger,
+            .name = "Bench Trigger",
+            .unit = "",
+            .range = {0.0f, 1.0f, 0.0f, 1.0f},
+        });
+        logger_->write_event("define_parameters",
+                             {{"count", bench::BenchLogger::to_str(store.param_count())}});
+    }
+
+    void prepare(const format::PrepareContext& ctx) override {
+        prepared_ = true;
+        sample_rate_.store(static_cast<int>(ctx.sample_rate), std::memory_order_relaxed);
+        max_buffer_.store(ctx.max_buffer_size, std::memory_order_relaxed);
+        prepare_count_.fetch_add(1, std::memory_order_relaxed);
+        logger_->write_event("prepare",
+                             {{"sample_rate", bench::BenchLogger::to_str(ctx.sample_rate)},
+                              {"max_buffer_size", bench::BenchLogger::to_str(ctx.max_buffer_size)},
+                              {"input_channels", bench::BenchLogger::to_str(ctx.input_channels)},
+                              {"output_channels", bench::BenchLogger::to_str(ctx.output_channels)},
+                              {"prepare_count", bench::BenchLogger::to_str(prepare_count_.load())}});
+    }
+
+    void release() override {
+        prepared_ = false;
+        logger_->write_event("release", {});
+    }
+
+    void suspend() override {
+        logger_->write_event("suspend", {});
+    }
+
+    void resume() override {
+        logger_->write_event("resume", {});
+    }
+
+    int latency_samples() const override { return 0; }
+
+    bool is_bus_layout_supported(const BusesLayout& layout) const override {
+        std::string in_csv, out_csv;
+        for (size_t i = 0; i < layout.inputs.size(); ++i) {
+            if (i) in_csv += ',';
+            in_csv += bench::BenchLogger::to_str(layout.inputs[i]);
+        }
+        for (size_t i = 0; i < layout.outputs.size(); ++i) {
+            if (i) out_csv += ',';
+            out_csv += bench::BenchLogger::to_str(layout.outputs[i]);
+        }
+        logger_->write_event("bus_layout_proposal",
+                             {{"inputs", in_csv}, {"outputs", out_csv}});
+        // Bench plugin is permissive: accept any mono/stereo combo, plus
+        // record the proposal regardless. The default Processor policy is
+        // stricter than what some hosts (Reaper R3, FL Studio) send.
+        auto ok = [](int n) { return n >= 1 && n <= 8; };
+        for (int n : layout.inputs)  if (!ok(n)) return false;
+        for (int n : layout.outputs) if (!ok(n)) return false;
+        return true;
+    }
+
+    void on_host_transport_changed(bool is_playing, double position_seconds) override {
+        logger_->write_event("transport_changed",
+                             {{"is_playing", bench::BenchLogger::bool_str(is_playing)},
+                              {"position_seconds", bench::BenchLogger::to_str(position_seconds)}});
+    }
+
+    void on_host_tempo_changed(double new_tempo_bpm) override {
+        logger_->write_event("tempo_changed",
+                             {{"tempo_bpm", bench::BenchLogger::to_str(new_tempo_bpm)}});
+    }
+
+    std::vector<uint8_t> serialize_plugin_state() const override {
+        logger_->write_event("serialize_plugin_state", {});
+        // Magic marker so the host's blob round-trip can be validated.
+        std::string marker = "PULP-HOST-BENCH-v1";
+        return std::vector<uint8_t>(marker.begin(), marker.end());
+    }
+
+    bool deserialize_plugin_state(std::span<const uint8_t> data) override {
+        std::string marker(data.begin(), data.end());
+        bool ok = (marker == "PULP-HOST-BENCH-v1");
+        logger_->write_event("deserialize_plugin_state",
+                             {{"bytes", bench::BenchLogger::to_str(data.size())},
+                              {"marker_ok", bench::BenchLogger::bool_str(ok)}});
+        return ok || data.empty();
+    }
+
+    void on_view_opened(view::View&) override {
+        view_open_count_.fetch_add(1, std::memory_order_relaxed);
+        logger_->write_event("view_opened",
+                             {{"open_count", bench::BenchLogger::to_str(view_open_count_.load())}});
+    }
+    void on_view_closed(view::View&) override {
+        logger_->write_event("view_closed", {});
+    }
+    void on_view_resized(view::View&, uint32_t w, uint32_t h) override {
+        logger_->write_event("view_resized",
+                             {{"width", bench::BenchLogger::to_str(w)},
+                              {"height", bench::BenchLogger::to_str(h)}});
+    }
+
+    void process(
+        audio::BufferView<float>& output,
+        const audio::BufferView<const float>& input,
+        midi::MidiBuffer& midi_in,
+        midi::MidiBuffer& midi_out,
+        const format::ProcessContext& ctx) override
+    {
+        process_block_count_.fetch_add(1, std::memory_order_relaxed);
+
+        // Honest spec-violation canary: was the host able to call process()
+        // even though we never got a prepare()? That's row #13 (FL Studio)
+        // and a worth-knowing signal for any host.
+        if (!prepared_) {
+            unprepared_process_count_.fetch_add(1, std::memory_order_relaxed);
+            logger_->write_event("process_without_prepare",
+                                 {{"block_count", bench::BenchLogger::to_str(process_block_count_.load())}});
+        }
+
+        const int n = ctx.num_samples;
+        const double sr = ctx.sample_rate;
+        const int last_sr = sample_rate_.load(std::memory_order_relaxed);
+        if (static_cast<int>(sr) != last_sr && last_sr != 0) {
+            logger_->write_event("process_sample_rate_drift",
+                                 {{"prepared_sr", bench::BenchLogger::to_str(last_sr)},
+                                  {"process_sr", bench::BenchLogger::to_str(sr)}});
+        }
+
+        const int last_max = max_buffer_.load(std::memory_order_relaxed);
+        if (n > last_max) {
+            logger_->write_event("process_buffer_overrun",
+                                 {{"prepared_max", bench::BenchLogger::to_str(last_max)},
+                                  {"process_n", bench::BenchLogger::to_str(n)}});
+        }
+
+        if (ctx.is_playing != last_is_playing_) {
+            last_is_playing_ = ctx.is_playing;
+            logger_->write_event("process_is_playing_edge",
+                                 {{"is_playing", bench::BenchLogger::bool_str(ctx.is_playing)}});
+        }
+
+        // Honor bypass; light DSP — bench-time correctness over speed.
+        bool bypass = state().get_value(kBenchBypass) >= 0.5f;
+        float gain_db = state().get_value(kBenchGain);
+        float gain = bypass ? 1.0f : std::pow(10.0f, gain_db / 20.0f);
+
+        const std::size_t channels = output.num_channels();
+        const std::size_t in_channels = input.num_channels();
+        for (std::size_t ch = 0; ch < channels; ++ch) {
+            auto out = output.channel(ch);
+            if (ch < in_channels) {
+                auto in = input.channel(ch);
+                for (std::size_t i = 0; i < output.num_samples(); ++i) {
+                    out[i] = in[i] * gain;
+                }
+            } else {
+                for (std::size_t i = 0; i < output.num_samples(); ++i) {
+                    out[i] = 0.0f;
+                }
+            }
+        }
+
+        // Sidechain observation — only logged on edges (connect/disconnect),
+        // not every block, to keep logs manageable.
+        bool sc_now = (sidechain_input() != nullptr);
+        if (sc_now != last_sidechain_connected_) {
+            last_sidechain_connected_ = sc_now;
+            logger_->write_event("sidechain_edge",
+                                 {{"connected", bench::BenchLogger::bool_str(sc_now)}});
+        }
+
+        // MIDI in count — edge-logged only.
+        const auto midi_count = midi_in.size();
+        if (midi_count > 0 && midi_count != last_midi_in_count_) {
+            last_midi_in_count_ = midi_count;
+            logger_->write_event("midi_in",
+                                 {{"events", bench::BenchLogger::to_str(midi_count)}});
+        }
+        (void)midi_out;
+    }
+
+    // Helpers a custom view would call.
+    std::string format_label() const { return format_label_; }
+    format::HostType host_type() const { return host_type_; }
+    std::string last_event() const { return logger_ ? logger_->last_event() : ""; }
+    std::uint64_t event_count() const { return logger_ ? logger_->event_count() : 0; }
+    std::string log_path() const { return logger_ ? logger_->path() : ""; }
+    int prepare_count() const { return prepare_count_.load(std::memory_order_relaxed); }
+    int process_block_count() const { return process_block_count_.load(std::memory_order_relaxed); }
+    int unprepared_process_count() const {
+        return unprepared_process_count_.load(std::memory_order_relaxed);
+    }
+
+private:
+    std::string format_label_;
+    format::HostType host_type_;
+    std::unique_ptr<bench::BenchLogger> logger_;
+    std::atomic<bool> prepared_{false};
+    // double is not std::atomic_double-safe on every supported toolchain;
+    // store as a relaxed integer in Hz (rounded). The drift check below
+    // tolerates fractional rates by comparing rounded values.
+    std::atomic<int> sample_rate_{0};
+    std::atomic<int> max_buffer_{0};
+    std::atomic<int> prepare_count_{0};
+    std::atomic<int> process_block_count_{0};
+    std::atomic<int> unprepared_process_count_{0};
+    std::atomic<int> view_open_count_{0};
+    bool last_is_playing_ = false;
+    bool last_sidechain_connected_ = false;
+    std::size_t last_midi_in_count_ = 0;
+};
+
+inline std::unique_ptr<format::Processor> create_host_bench_au() {
+    return std::make_unique<HostBenchProcessor>("AU");
+}
+inline std::unique_ptr<format::Processor> create_host_bench_vst3() {
+    return std::make_unique<HostBenchProcessor>("VST3");
+}
+inline std::unique_ptr<format::Processor> create_host_bench_clap() {
+    return std::make_unique<HostBenchProcessor>("CLAP");
+}
+// Default factory used by pulp_add_plugin / registry. The format label
+// will be reset by the format-specific entry TUs above when a real host
+// loads the plugin; the registry path is used for ctest dlopen + the
+// standalone host.
+inline std::unique_ptr<format::Processor> create_host_bench() {
+    return std::make_unique<HostBenchProcessor>("Standalone");
+}
+
+}  // namespace pulp::examples

--- a/examples/host-bench-plugin/main.cpp
+++ b/examples/host-bench-plugin/main.cpp
@@ -1,0 +1,56 @@
+// PulpHostBench Standalone — for smoke-loading the plugin outside any DAW.
+//
+// Useful as a sanity check: launch this and you should see a log file
+// appear under `~/Library/Logs/PulpHostBench/` with a single
+// `session_start` event and the host name "Standalone".
+
+#include "host_bench.hpp"
+
+#include <pulp/format/standalone.hpp>
+#include <pulp/runtime/log.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <iostream>
+#include <thread>
+
+namespace {
+std::atomic<bool> should_quit{false};
+void signal_handler(int) { should_quit.store(true); }
+}  // namespace
+
+int main() {
+    std::signal(SIGINT, signal_handler);
+    std::signal(SIGTERM, signal_handler);
+
+    pulp::runtime::log_info("PulpHostBench Standalone v1.0.0");
+
+    pulp::format::StandaloneApp app(pulp::examples::create_host_bench);
+
+    pulp::format::StandaloneConfig config;
+    config.sample_rate = 48000.0;
+    config.buffer_size = 256;
+    config.output_channels = 2;
+    config.input_channels = 2;
+    app.set_config(config);
+
+    if (!app.start()) {
+        pulp::runtime::log_error("Failed to start standalone bench app");
+        return 1;
+    }
+
+    std::cout << "\nPulpHostBench is running. The log file appears under\n"
+              << "  ~/Library/Logs/PulpHostBench/  (macOS)\n"
+              << "  %LOCALAPPDATA%/PulpHostBench/  (Windows)\n"
+              << "  ${XDG_STATE_HOME}/pulp-host-bench/  (Linux)\n"
+              << "Ctrl+C to stop.\n" << std::endl;
+
+    while (!should_quit.load()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    app.stop();
+    pulp::runtime::log_info("PulpHostBench stopped");
+    return 0;
+}

--- a/examples/host-bench-plugin/test_host_bench.cpp
+++ b/examples/host-bench-plugin/test_host_bench.cpp
@@ -1,0 +1,179 @@
+// PulpHostBench — bench plugin unit coverage.
+//
+// The interesting integration evidence comes from running the plugin
+// inside a real DAW; these tests just confirm the lifecycle hooks all
+// fire and the log file gets written so the per-DAW scripts have
+// something to chew on.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "host_bench.hpp"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+
+using namespace pulp;
+using namespace pulp::examples;
+
+namespace {
+
+// Force log writes into a per-test tmp dir so we don't pollute the
+// real `~/Library/Logs/PulpHostBench/`.
+class ScopedBenchLogDir {
+public:
+    ScopedBenchLogDir() {
+        dir_ = std::filesystem::temp_directory_path() /
+               ("pulp-host-bench-test-" + std::to_string(::time(nullptr)));
+        std::filesystem::create_directories(dir_);
+#if defined(__APPLE__)
+        prev_ = std::getenv("HOME") ? std::getenv("HOME") : "";
+        setenv("HOME", dir_.string().c_str(), 1);
+#elif defined(_WIN32)
+        prev_ = std::getenv("LOCALAPPDATA") ? std::getenv("LOCALAPPDATA") : "";
+        _putenv_s("LOCALAPPDATA", dir_.string().c_str());
+#else
+        prev_ = std::getenv("XDG_STATE_HOME") ? std::getenv("XDG_STATE_HOME") : "";
+        setenv("XDG_STATE_HOME", dir_.string().c_str(), 1);
+#endif
+    }
+    ~ScopedBenchLogDir() {
+#if defined(__APPLE__)
+        if (prev_.empty()) unsetenv("HOME"); else setenv("HOME", prev_.c_str(), 1);
+#elif defined(_WIN32)
+        if (prev_.empty()) _putenv_s("LOCALAPPDATA", ""); else _putenv_s("LOCALAPPDATA", prev_.c_str());
+#else
+        if (prev_.empty()) unsetenv("XDG_STATE_HOME"); else setenv("XDG_STATE_HOME", prev_.c_str(), 1);
+#endif
+        std::error_code ec;
+        std::filesystem::remove_all(dir_, ec);
+    }
+    std::filesystem::path root() const { return dir_; }
+
+private:
+    std::filesystem::path dir_;
+    std::string prev_;
+};
+
+struct BenchFixture {
+    ScopedBenchLogDir tmp;
+    state::StateStore store;
+    std::unique_ptr<HostBenchProcessor> processor;
+
+    BenchFixture() {
+        processor = std::make_unique<HostBenchProcessor>("Standalone");
+        processor->set_state_store(&store);
+        processor->define_parameters(store);
+    }
+
+    void prepare(double sr = 48000.0, int n = 512) {
+        format::PrepareContext ctx{sr, n, 2, 2};
+        processor->prepare(ctx);
+    }
+    void process(int n = 256) {
+        audio::Buffer<float> in(2, n), out(2, n);
+        for (std::size_t ch = 0; ch < 2; ++ch)
+            for (std::size_t i = 0; i < static_cast<std::size_t>(n); ++i)
+                in.channel(ch)[i] = 0.5f;
+        auto out_view = out.view();
+        const float* in_ptrs[2] = {in.channel(0).data(), in.channel(1).data()};
+        audio::BufferView<const float> const_in(in_ptrs, 2, n);
+        midi::MidiBuffer mi, mo;
+        format::ProcessContext ctx;
+        ctx.sample_rate = 48000.0;
+        ctx.num_samples = n;
+        processor->process(out_view, const_in, mi, mo, ctx);
+    }
+};
+
+}  // namespace
+
+TEST_CASE("HostBench descriptor declares sidechain + MIDI in", "[bench]") {
+    HostBenchProcessor proc("Standalone");
+    auto desc = proc.descriptor();
+    REQUIRE(desc.name == "PulpHostBench");
+    REQUIRE(desc.accepts_midi);
+    REQUIRE(desc.input_buses.size() == 2);
+    REQUIRE(desc.input_buses[1].name == "Sidechain");
+    REQUIRE(desc.input_buses[1].optional);
+}
+
+TEST_CASE("HostBench parameters register", "[bench]") {
+    BenchFixture fx;
+    REQUIRE(fx.store.param_count() == 3);
+    REQUIRE(fx.store.info(kBenchGain) != nullptr);
+}
+
+TEST_CASE("HostBench prepare/process logs lifecycle", "[bench]") {
+    BenchFixture fx;
+    auto path = fx.processor->log_path();
+    REQUIRE_FALSE(path.empty());
+    REQUIRE(std::filesystem::exists(path));
+
+    fx.prepare();
+    fx.process();
+
+    REQUIRE(fx.processor->prepare_count() == 1);
+    REQUIRE(fx.processor->process_block_count() == 1);
+    REQUIRE(fx.processor->unprepared_process_count() == 0);
+
+    // Read back the file — should contain the expected events.
+    std::ifstream f(path);
+    std::string body((std::istreambuf_iterator<char>(f)),
+                     std::istreambuf_iterator<char>());
+    REQUIRE(body.find("session_start") != std::string::npos);
+    REQUIRE(body.find("prepare") != std::string::npos);
+    REQUIRE(body.find("define_parameters") != std::string::npos);
+}
+
+TEST_CASE("HostBench logs process_without_prepare", "[bench]") {
+    BenchFixture fx;
+    // Intentionally skip prepare()
+    fx.process();
+    REQUIRE(fx.processor->unprepared_process_count() == 1);
+
+    std::ifstream f(fx.processor->log_path());
+    std::string body((std::istreambuf_iterator<char>(f)),
+                     std::istreambuf_iterator<char>());
+    REQUIRE(body.find("process_without_prepare") != std::string::npos);
+}
+
+TEST_CASE("HostBench bus layout proposal records inputs+outputs", "[bench]") {
+    BenchFixture fx;
+    format::Processor::BusesLayout layout{{2, 2}, {2}};
+    REQUIRE(fx.processor->is_bus_layout_supported(layout));
+
+    std::ifstream f(fx.processor->log_path());
+    std::string body((std::istreambuf_iterator<char>(f)),
+                     std::istreambuf_iterator<char>());
+    REQUIRE(body.find("bus_layout_proposal") != std::string::npos);
+    REQUIRE(body.find("inputs=2,2") != std::string::npos);
+}
+
+TEST_CASE("HostBench state round-trip serializes marker", "[bench]") {
+    BenchFixture fx;
+    auto blob = fx.processor->serialize_plugin_state();
+    REQUIRE_FALSE(blob.empty());
+    REQUIRE(fx.processor->deserialize_plugin_state(std::span<const uint8_t>(blob)));
+
+    std::ifstream f(fx.processor->log_path());
+    std::string body((std::istreambuf_iterator<char>(f)),
+                     std::istreambuf_iterator<char>());
+    REQUIRE(body.find("serialize_plugin_state") != std::string::npos);
+    REQUIRE(body.find("marker_ok=true") != std::string::npos);
+}
+
+TEST_CASE("HostBench transport-change and tempo-change events fire", "[bench]") {
+    BenchFixture fx;
+    fx.processor->on_host_transport_changed(true, 1.25);
+    fx.processor->on_host_tempo_changed(140.0);
+
+    std::ifstream f(fx.processor->log_path());
+    std::string body((std::istreambuf_iterator<char>(f)),
+                     std::istreambuf_iterator<char>());
+    REQUIRE(body.find("transport_changed") != std::string::npos);
+    REQUIRE(body.find("is_playing=true") != std::string::npos);
+    REQUIRE(body.find("tempo_changed") != std::string::npos);
+    REQUIRE(body.find("tempo_bpm=140") != std::string::npos);
+}

--- a/examples/host-bench-plugin/vst3_entry.cpp
+++ b/examples/host-bench-plugin/vst3_entry.cpp
@@ -1,0 +1,19 @@
+// PulpHostBench VST3 entry. Stable UID — never change in-place.
+
+#include "host_bench.hpp"
+
+#include <pulp/format/vst3_entry.hpp>
+
+// Reserved bench UID. The first word "HOST" is intentional; the second
+// word "BNCH" makes the asset trivially greppable across crash logs.
+static const Steinberg::FUID PulpHostBenchUID(
+    0x484F5354,  // 'HOST'
+    0x424E4348,  // 'BNCH'
+    0x00000001,
+    0x00000001);
+
+PULP_VST3_PLUGIN(PulpHostBenchUID, "PulpHostBench",
+                  Steinberg::Vst::PlugType::kFx,
+                  "Pulp", "1.0.0",
+                  "https://github.com/danielraffel/pulp",
+                  pulp::examples::create_host_bench_vst3)

--- a/tools/scripts/promote_quirk_tiers.py
+++ b/tools/scripts/promote_quirk_tiers.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""promote_quirk_tiers.py — turn DAW-bench evidence into a quirks-header patch.
+
+Pipeline:
+
+  1. Read one or more **bench result files**. Two accepted shapes:
+
+     a. The filled-in markdown templates under
+        ``docs/validation/daw-bench/results/<date>/*.md`` — each contains
+        a "Result" table whose rows look like::
+
+            | `flag_name`              | Row | Confirmed | notes |
+
+     b. The raw event-log files written by the bench plugin under
+        ``~/Library/Logs/PulpHostBench/`` — the script can also infer
+        a subset of flags directly from the events (e.g. seeing a
+        ``process_without_prepare`` event Confirms
+        ``fl_studio_setactive_process_mutex`` when the host tag is
+        FLStudio).
+
+  2. Build a ``{flag_name: highest_observed_status}`` map. Statuses sort
+     ``Confirmed > Not Triggered > Refuted``: any Confirmed wins.
+
+  3. Read the canonical quirks header (default:
+     ``core/format/include/pulp/format/host_quirks.hpp``) and locate the
+     ``HostQuirksMeta`` struct.
+
+  4. For every flag with status ``Confirmed`` whose current meta tier is
+     ``Speculative``, rewrite it to ``Validated`` in-place. Other tiers
+     and flags untouched.
+
+  5. Emit either a unified diff (``--output PATH`` or stdout) or write
+     the file in place (``--in-place``).
+
+Example::
+
+    python3 tools/scripts/promote_quirk_tiers.py \\
+        docs/validation/daw-bench/results/2026-06-01/*.md \\
+        ~/Library/Logs/PulpHostBench/Reaper-CLAP-*.log \\
+        --output /tmp/promote.patch
+    git apply /tmp/promote.patch
+
+The script intentionally never DOWNGRADES a tier. A Refuted row in the
+result file does NOT flip Validated → Speculative or Speculative →
+LessonOnly. That's an explicit ticket / decision, not an automation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+# ---------------------------------------------------------------------------
+# Status model
+# ---------------------------------------------------------------------------
+
+STATUS_CONFIRMED = "Confirmed"
+STATUS_REFUTED = "Refuted"
+STATUS_NOT_TRIGGERED = "NotTriggered"
+
+# Ordering: higher wins.
+_STATUS_ORDER = {
+    STATUS_REFUTED: 0,
+    STATUS_NOT_TRIGGERED: 1,
+    STATUS_CONFIRMED: 2,
+}
+
+_STATUS_ALIASES = {
+    "confirmed": STATUS_CONFIRMED,
+    "c": STATUS_CONFIRMED,
+    "yes": STATUS_CONFIRMED,
+    "pass": STATUS_CONFIRMED,
+    "refuted": STATUS_REFUTED,
+    "r": STATUS_REFUTED,
+    "no": STATUS_REFUTED,
+    "fail": STATUS_REFUTED,
+    "not triggered": STATUS_NOT_TRIGGERED,
+    "nottriggered": STATUS_NOT_TRIGGERED,
+    "nt": STATUS_NOT_TRIGGERED,
+    "n/a": STATUS_NOT_TRIGGERED,
+    "na": STATUS_NOT_TRIGGERED,
+}
+
+
+def _normalize_status(raw: str) -> str | None:
+    key = raw.strip().lower()
+    return _STATUS_ALIASES.get(key)
+
+
+def _merge(prev: str | None, new: str) -> str:
+    """Keep the highest-rank observation."""
+    if prev is None:
+        return new
+    if _STATUS_ORDER[new] > _STATUS_ORDER[prev]:
+        return new
+    return prev
+
+
+# ---------------------------------------------------------------------------
+# Result-file parsing — markdown templates
+# ---------------------------------------------------------------------------
+
+# Flag column: backtick-quoted identifier OR bare identifier.
+# Status column matches one of the alias strings above.
+_RESULT_ROW = re.compile(
+    r"^\|\s*`?(?P<flag>[A-Za-z_][A-Za-z0-9_]*)`?\s*"
+    r"\|[^|]*"  # row-number column (catalog ref)
+    r"\|\s*(?P<status>[^|]+?)\s*"
+    r"\|.*\|\s*$"
+)
+
+
+def parse_markdown_results(path: Path) -> dict[str, str]:
+    """Return ``{flag: status}`` extracted from the Result table of *path*."""
+    out: dict[str, str] = {}
+    if not path.is_file():
+        return out
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        m = _RESULT_ROW.match(line)
+        if not m:
+            continue
+        flag = m.group("flag")
+        status = _normalize_status(m.group("status"))
+        if status is None:
+            # Could be the placeholder "<C/R/NT>" — silently skip.
+            continue
+        out[flag] = _merge(out.get(flag), status)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Result-file parsing — raw bench logs
+# ---------------------------------------------------------------------------
+
+# Filename convention: <host>-<format>-<timestamp>-pidNNN.log
+_LOG_FILENAME = re.compile(r"^(?P<host>[A-Za-z][A-Za-z0-9]*)-(?P<format>[A-Za-z0-9]+)-")
+
+# Each log line: <iso>\t<event>\tkey=value\tkey=value...
+_LOG_LINE = re.compile(r"^[^\t]+\t(?P<event>[A-Za-z_][A-Za-z0-9_]*)(?P<rest>(\t[^\t]+)*)\s*$")
+
+
+def _parse_event_kv(rest: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for tok in rest.split("\t"):
+        tok = tok.strip()
+        if not tok or "=" not in tok:
+            continue
+        k, _, v = tok.partition("=")
+        out[k] = v
+    return out
+
+
+# Mapping: a (host, observed-event-condition) → list of flags to mark Confirmed.
+# The condition is either a literal event name (any occurrence) or a callable
+# that inspects the event's key=value payload. Hosts use the same string as
+# `pulp::format::host_type_name()` (e.g. "Reaper", "FLStudio", "AbletonLive").
+
+HostEventRule = tuple[str, "object", tuple[str, ...]]
+
+LOG_PROMOTION_RULES: tuple[HostEventRule, ...] = (
+    # General defaults: any session that produced a `prepare` + a
+    # successful `serialize_plugin_state` round-trip implies the cheap-
+    # defense flags are observably valid in that host.
+    ("*",      "prepare",                ("clamp_latency_to_nonneg",)),
+    # Reaper rows.
+    ("Reaper", "process_is_playing_edge",("reaper_vst3_gesture_ordering",)),
+    ("Reaper", "process_without_prepare",("reaper_process_while_bypassed",)),
+    ("Reaper", "bus_layout_proposal",    ("reaper_permissive_bus_arrangements",)),
+    ("Reaper", "process_buffer_overrun", ("reaper_anticipative_fx_buffer_variability",)),
+    ("Reaper", "process_sample_rate_drift", ("reaper_anticipative_fx_buffer_variability",)),
+    ("Reaper", "deserialize_plugin_state",  ("reaper_midsession_setstate",)),
+    # FL Studio.
+    ("FLStudio", "process_without_prepare", ("fl_studio_setactive_process_mutex",)),
+    ("FLStudio", "deserialize_plugin_state",("fl_studio_state_reader_skip",)),
+    # Cubase 9.
+    ("Cubase", "deserialize_plugin_state",  ("cubase9_state_blob_size_validation",)),
+    # Cubase 10/11/12 — view resize cadence.
+    ("Cubase", "view_resized",              ("cubase10_async_view_resize_queue",)),
+    # Live.
+    ("AbletonLive", "view_resized",         ("live_vst3_canresize_ignore",)),
+    # Bitwig.
+    ("BitwigStudio", "bus_layout_proposal", ("bitwig_vst3_setbusarrangements_while_active",)),
+    ("Bitwig",       "bus_layout_proposal", ("bitwig_vst3_setbusarrangements_while_active",)),
+    # Wavelab.
+    ("Wavelab", "deserialize_plugin_state", ("wavelab_state_blob_fallback",)),
+    ("Wavelab", "bus_layout_proposal",      ("wavelab_vst3_defer_activation",)),
+    # Logic.
+    ("LogicPro", "prepare",                 ("logic_au_tail_time_conversion",)),
+)
+
+
+def parse_log_results(path: Path) -> dict[str, str]:
+    """Walk a single bench log file and return inferred flag→status hits."""
+    if not path.is_file():
+        return {}
+    m = _LOG_FILENAME.match(path.name)
+    if not m:
+        return {}
+    host = m.group("host")
+    events: set[str] = set()
+    try:
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            mm = _LOG_LINE.match(line)
+            if mm:
+                events.add(mm.group("event"))
+    except OSError:
+        return {}
+
+    out: dict[str, str] = {}
+    for rule_host, rule_event, flags in LOG_PROMOTION_RULES:
+        if rule_host != "*" and rule_host != host:
+            continue
+        if rule_event not in events:
+            continue
+        for f in flags:
+            out[f] = _merge(out.get(f), STATUS_CONFIRMED)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Aggregation:
+    flag_status: dict[str, str] = field(default_factory=dict)
+    sources: dict[str, list[str]] = field(default_factory=dict)
+
+    def merge(self, partial: dict[str, str], source: str) -> None:
+        for flag, status in partial.items():
+            prev = self.flag_status.get(flag)
+            new = _merge(prev, status)
+            if new != prev:
+                self.flag_status[flag] = new
+            self.sources.setdefault(flag, []).append(source)
+
+
+def aggregate(paths: Iterable[Path]) -> Aggregation:
+    agg = Aggregation()
+    for p in paths:
+        if p.suffix.lower() == ".md":
+            agg.merge(parse_markdown_results(p), source=str(p))
+        else:
+            # Treat anything else as a bench log; the filename pattern guard
+            # in parse_log_results will silently skip non-bench files.
+            agg.merge(parse_log_results(p), source=str(p))
+    return agg
+
+
+# ---------------------------------------------------------------------------
+# Quirks header rewrite
+# ---------------------------------------------------------------------------
+
+# Match a HostQuirksMeta field assignment line. The struct uses default-
+# member-initializer syntax:
+#
+#     QuirkStatus some_flag = QuirkStatus::Speculative;
+#
+# (potentially with leading whitespace; we preserve it). Captures the flag
+# name and the original status so we can pinpoint Speculative→Validated
+# promotions exclusively.
+_META_FIELD = re.compile(
+    r"^(?P<indent>\s*)QuirkStatus\s+(?P<flag>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*"
+    r"QuirkStatus::(?P<tier>Validated|Speculative|LessonOnly)\s*;\s*$"
+)
+
+
+def promote_meta(src: str, confirmed: set[str]) -> tuple[str, list[str]]:
+    """Return (new_source, promoted_flags) by flipping Speculative→Validated."""
+    promoted: list[str] = []
+    out_lines: list[str] = []
+    in_meta = False
+    for raw in src.splitlines(keepends=True):
+        if not in_meta:
+            if "struct HostQuirksMeta" in raw:
+                in_meta = True
+            out_lines.append(raw)
+            continue
+
+        if raw.lstrip().startswith("};"):
+            in_meta = False
+            out_lines.append(raw)
+            continue
+
+        m = _META_FIELD.match(raw.rstrip("\n"))
+        if m and m.group("flag") in confirmed and m.group("tier") == "Speculative":
+            new_line = (
+                f"{m.group('indent')}QuirkStatus {m.group('flag')}"
+                f" = QuirkStatus::Validated;\n"
+            )
+            out_lines.append(new_line)
+            promoted.append(m.group("flag"))
+        else:
+            out_lines.append(raw)
+    return "".join(out_lines), promoted
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+DEFAULT_QUIRKS_HEADER = Path("core/format/include/pulp/format/host_quirks.hpp")
+
+
+def _make_diff(rel_path: str, before: str, after: str) -> str:
+    return "".join(
+        difflib.unified_diff(
+            before.splitlines(keepends=True),
+            after.splitlines(keepends=True),
+            fromfile=f"a/{rel_path}",
+            tofile=f"b/{rel_path}",
+        )
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "results",
+        nargs="*",
+        type=Path,
+        help="Markdown result files and/or raw bench log files.",
+    )
+    p.add_argument(
+        "--quirks-header",
+        type=Path,
+        default=DEFAULT_QUIRKS_HEADER,
+        help=f"Path to host_quirks.hpp (default {DEFAULT_QUIRKS_HEADER}).",
+    )
+    p.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Write unified diff here (default: stdout).",
+    )
+    p.add_argument(
+        "--in-place",
+        action="store_true",
+        help="Apply the promotion directly to --quirks-header instead of emitting a diff.",
+    )
+    p.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repo root used to compute the diff's relative path (default: cwd).",
+    )
+    p.add_argument(
+        "--print-status",
+        action="store_true",
+        help="Just print the aggregated flag→status table; don't touch the header.",
+    )
+    args = p.parse_args(argv)
+
+    if not args.results and not args.print_status:
+        # Allow --print-status with no inputs (prints empty table); otherwise
+        # require at least one result file.
+        p.error("at least one result/log file required (or use --print-status)")
+
+    agg = aggregate(args.results)
+
+    if args.print_status:
+        if not agg.flag_status:
+            print("(no flags observed)")
+            return 0
+        width = max(len(f) for f in agg.flag_status)
+        for f in sorted(agg.flag_status):
+            print(f"{f:<{width}}  {agg.flag_status[f]:<13}  "
+                  f"({len(agg.sources.get(f, []))} source(s))")
+        return 0
+
+    confirmed = {f for f, s in agg.flag_status.items() if s == STATUS_CONFIRMED}
+
+    header_path: Path = args.quirks_header
+    if not header_path.is_absolute():
+        header_path = (args.repo_root / header_path).resolve()
+    if not header_path.is_file():
+        print(f"error: quirks header not found at {header_path}", file=sys.stderr)
+        return 2
+
+    before = header_path.read_text(encoding="utf-8")
+    after, promoted = promote_meta(before, confirmed)
+
+    if not promoted:
+        print(
+            f"no promotions: {len(confirmed)} flag(s) confirmed, "
+            "but none currently sit at Speculative — nothing to do.",
+            file=sys.stderr,
+        )
+        return 0
+
+    print(f"promoting {len(promoted)} flag(s) Speculative → Validated:",
+          file=sys.stderr)
+    for f in promoted:
+        print(f"  {f}", file=sys.stderr)
+
+    if args.in_place:
+        header_path.write_text(after, encoding="utf-8")
+        return 0
+
+    try:
+        rel = os.path.relpath(header_path, args.repo_root)
+    except ValueError:
+        rel = str(header_path)
+    diff = _make_diff(rel, before, after)
+    if args.output:
+        args.output.write_text(diff, encoding="utf-8")
+    else:
+        sys.stdout.write(diff)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/scripts/test_promote_quirk_tiers.py
+++ b/tools/scripts/test_promote_quirk_tiers.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Coverage tests for tools/scripts/promote_quirk_tiers.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import pathlib
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).resolve().parent / "promote_quirk_tiers.py"
+spec = importlib.util.spec_from_file_location("promote_quirk_tiers", SCRIPT)
+assert spec and spec.loader
+pqt = importlib.util.module_from_spec(spec)
+sys.modules["promote_quirk_tiers"] = pqt
+spec.loader.exec_module(pqt)
+
+
+SAMPLE_HEADER = textwrap.dedent(
+    """\
+    #pragma once
+
+    namespace pulp::format {
+
+    enum class QuirkStatus : unsigned char { Validated, Speculative, LessonOnly };
+
+    struct HostQuirksMeta {
+        QuirkStatus synthesize_bypass_parameter = QuirkStatus::Validated;
+        QuirkStatus reaper_process_while_bypassed = QuirkStatus::Speculative;
+        QuirkStatus reaper_midsession_setstate = QuirkStatus::Speculative;
+        QuirkStatus fl_studio_state_reader_skip = QuirkStatus::Speculative;
+        QuirkStatus cubase9_state_blob_size_validation = QuirkStatus::Speculative;
+        QuirkStatus skip_bus_arrangement_call = QuirkStatus::LessonOnly;
+    };
+
+    }  // namespace pulp::format
+    """
+)
+
+
+def _write(tmp: pathlib.Path, name: str, body: str) -> pathlib.Path:
+    path = tmp / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+class StatusModelTests(unittest.TestCase):
+    def test_alias_normalization(self) -> None:
+        self.assertEqual(pqt._normalize_status("Confirmed"), pqt.STATUS_CONFIRMED)
+        self.assertEqual(pqt._normalize_status("c"), pqt.STATUS_CONFIRMED)
+        self.assertEqual(pqt._normalize_status("REFUTED"), pqt.STATUS_REFUTED)
+        self.assertEqual(pqt._normalize_status("nt"), pqt.STATUS_NOT_TRIGGERED)
+        self.assertEqual(pqt._normalize_status("N/A"), pqt.STATUS_NOT_TRIGGERED)
+        self.assertIsNone(pqt._normalize_status("<C/R/NT>"))
+        self.assertIsNone(pqt._normalize_status(""))
+
+    def test_merge_keeps_highest(self) -> None:
+        self.assertEqual(
+            pqt._merge(None, pqt.STATUS_REFUTED), pqt.STATUS_REFUTED
+        )
+        self.assertEqual(
+            pqt._merge(pqt.STATUS_REFUTED, pqt.STATUS_CONFIRMED),
+            pqt.STATUS_CONFIRMED,
+        )
+        self.assertEqual(
+            pqt._merge(pqt.STATUS_CONFIRMED, pqt.STATUS_REFUTED),
+            pqt.STATUS_CONFIRMED,
+        )
+        self.assertEqual(
+            pqt._merge(pqt.STATUS_NOT_TRIGGERED, pqt.STATUS_REFUTED),
+            pqt.STATUS_NOT_TRIGGERED,
+        )
+
+
+class MarkdownParseTests(unittest.TestCase):
+    def test_extracts_confirmed_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            tmp = pathlib.Path(d)
+            md = _write(
+                tmp,
+                "06-reaper-vst3.md",
+                textwrap.dedent(
+                    """\
+                    # 06 — Reaper
+
+                    ## Result
+
+                    | Quirk flag                      | Row | Observed | Notes |
+                    |---------------------------------|-----|----------|-------|
+                    | `reaper_process_while_bypassed` | R1  | Confirmed | step 5 |
+                    | `reaper_midsession_setstate`    | R6  | Refuted   | not seen |
+                    | `synthesize_bypass_parameter`   | #23 | <C/R/NT>  | placeholder |
+                    | `cubase9_state_blob_size_validation` | #4 | nt | wrong host |
+                    """
+                ),
+            )
+            got = pqt.parse_markdown_results(md)
+            self.assertEqual(
+                got,
+                {
+                    "reaper_process_while_bypassed": pqt.STATUS_CONFIRMED,
+                    "reaper_midsession_setstate": pqt.STATUS_REFUTED,
+                    "cubase9_state_blob_size_validation": pqt.STATUS_NOT_TRIGGERED,
+                },
+            )
+
+    def test_missing_file_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            tmp = pathlib.Path(d)
+            self.assertEqual(pqt.parse_markdown_results(tmp / "no.md"), {})
+
+
+class LogParseTests(unittest.TestCase):
+    def _make_log(self, tmp: pathlib.Path, name: str, events: list[str]) -> pathlib.Path:
+        ts = "2026-05-26T12:00:00.000Z"
+        lines = [
+            f"{ts}\t{event}\tn={i+1}\n" for i, event in enumerate(events)
+        ]
+        return _write(tmp, name, "".join(lines))
+
+    def test_reaper_log_promotes_multiple_flags(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            tmp = pathlib.Path(d)
+            log = self._make_log(
+                tmp,
+                "Reaper-VST3-20260526T120000Z-pid42.log",
+                [
+                    "session_start",
+                    "prepare",
+                    "bus_layout_proposal",
+                    "deserialize_plugin_state",
+                    "process_without_prepare",
+                ],
+            )
+            got = pqt.parse_log_results(log)
+            # All Reaper rules whose event appeared should be Confirmed.
+            self.assertEqual(got.get("reaper_permissive_bus_arrangements"), pqt.STATUS_CONFIRMED)
+            self.assertEqual(got.get("reaper_midsession_setstate"), pqt.STATUS_CONFIRMED)
+            self.assertEqual(got.get("reaper_process_while_bypassed"), pqt.STATUS_CONFIRMED)
+            self.assertEqual(got.get("clamp_latency_to_nonneg"), pqt.STATUS_CONFIRMED)
+
+    def test_fl_studio_log_promotes_state_reader(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            tmp = pathlib.Path(d)
+            log = self._make_log(
+                tmp,
+                "FLStudio-VST3-20260526T120000Z-pid7.log",
+                ["session_start", "prepare", "process_without_prepare",
+                 "deserialize_plugin_state"],
+            )
+            got = pqt.parse_log_results(log)
+            self.assertEqual(got.get("fl_studio_setactive_process_mutex"),
+                             pqt.STATUS_CONFIRMED)
+            self.assertEqual(got.get("fl_studio_state_reader_skip"),
+                             pqt.STATUS_CONFIRMED)
+
+    def test_unrelated_filename_is_skipped(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            tmp = pathlib.Path(d)
+            log = _write(tmp, "random-other-file.txt", "garbage\n")
+            self.assertEqual(pqt.parse_log_results(log), {})
+
+
+class PromoteMetaTests(unittest.TestCase):
+    def test_promotes_speculative_only_for_confirmed_flags(self) -> None:
+        confirmed = {
+            "reaper_process_while_bypassed",
+            "fl_studio_state_reader_skip",
+            "skip_bus_arrangement_call",  # LessonOnly — should NOT promote
+            "synthesize_bypass_parameter",  # already Validated — no-op
+        }
+        new_src, promoted = pqt.promote_meta(SAMPLE_HEADER, confirmed)
+        self.assertCountEqual(
+            promoted,
+            ["reaper_process_while_bypassed", "fl_studio_state_reader_skip"],
+        )
+        self.assertIn(
+            "QuirkStatus reaper_process_while_bypassed = QuirkStatus::Validated;",
+            new_src,
+        )
+        self.assertIn(
+            "QuirkStatus fl_studio_state_reader_skip = QuirkStatus::Validated;",
+            new_src,
+        )
+        # LessonOnly preserved.
+        self.assertIn(
+            "QuirkStatus skip_bus_arrangement_call = QuirkStatus::LessonOnly;",
+            new_src,
+        )
+        # Untouched Speculative rows preserved.
+        self.assertIn(
+            "QuirkStatus cubase9_state_blob_size_validation = QuirkStatus::Speculative;",
+            new_src,
+        )
+
+    def test_empty_confirmed_is_noop(self) -> None:
+        new_src, promoted = pqt.promote_meta(SAMPLE_HEADER, set())
+        self.assertEqual(promoted, [])
+        self.assertEqual(new_src, SAMPLE_HEADER)
+
+
+class CliTests(unittest.TestCase):
+    def _setup(self, tmp: pathlib.Path) -> pathlib.Path:
+        header = _write(tmp, "host_quirks.hpp", SAMPLE_HEADER)
+        return header
+
+    def test_print_status_reports_aggregation(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            tmp = pathlib.Path(d)
+            md = _write(
+                tmp,
+                "07-reaper-clap.md",
+                textwrap.dedent(
+                    """\
+                    ## Result
+
+                    | `reaper_process_while_bypassed` | R1 | Confirmed | x |
+                    | `fl_studio_state_reader_skip`   | #14 | Refuted | not in scope |
+                    """
+                ),
+            )
+            buf = io.StringIO()
+            sys.stdout, prev = buf, sys.stdout
+            try:
+                rc = pqt.main([str(md), "--print-status"])
+            finally:
+                sys.stdout = prev
+            self.assertEqual(rc, 0)
+            self.assertIn("reaper_process_while_bypassed", buf.getvalue())
+            self.assertIn("Confirmed", buf.getvalue())
+            self.assertIn("Refuted", buf.getvalue())
+
+    def test_diff_output_contains_promotion(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            tmp = pathlib.Path(d)
+            header = self._setup(tmp)
+            md = _write(
+                tmp,
+                "06-reaper-vst3.md",
+                textwrap.dedent(
+                    """\
+                    ## Result
+
+                    | `reaper_process_while_bypassed` | R1 | Confirmed | x |
+                    """
+                ),
+            )
+            out_patch = tmp / "out.patch"
+            rc = pqt.main([
+                str(md),
+                "--quirks-header", str(header),
+                "--repo-root", str(tmp),
+                "--output", str(out_patch),
+            ])
+            self.assertEqual(rc, 0)
+            patch_body = out_patch.read_text(encoding="utf-8")
+            self.assertIn(
+                "-    QuirkStatus reaper_process_while_bypassed = QuirkStatus::Speculative;",
+                patch_body,
+            )
+            self.assertIn(
+                "+    QuirkStatus reaper_process_while_bypassed = QuirkStatus::Validated;",
+                patch_body,
+            )
+
+    def test_in_place_rewrites_header(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            tmp = pathlib.Path(d)
+            header = self._setup(tmp)
+            md = _write(
+                tmp,
+                "11-fl-studio-vst3.md",
+                textwrap.dedent(
+                    """\
+                    ## Result
+
+                    | `fl_studio_state_reader_skip` | #14 | Confirmed | step 8 |
+                    """
+                ),
+            )
+            rc = pqt.main([
+                str(md),
+                "--quirks-header", str(header),
+                "--in-place",
+            ])
+            self.assertEqual(rc, 0)
+            after = header.read_text(encoding="utf-8")
+            self.assertIn(
+                "QuirkStatus fl_studio_state_reader_skip = QuirkStatus::Validated;",
+                after,
+            )
+            # Untouched Speculative entries remain.
+            self.assertIn(
+                "QuirkStatus reaper_process_while_bypassed = QuirkStatus::Speculative;",
+                after,
+            )
+
+    def test_no_inputs_errors_out(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            pqt.main([])
+        self.assertNotEqual(ctx.exception.code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Ships the **DAW-bench harness package** so the 🟡 `Speculative` rows in `core/format/include/pulp/format/host_quirks.hpp::HostQuirksMeta` can be graduated to `Validated` by running a real DAW session — no more hand-coding what we think a DAW does.

Three pieces:

- **`examples/host-bench-plugin/`** — a CLAP + AU (when AudioUnitSDK is installed) + Standalone validation plugin that overrides every observable `pulp::format::Processor` hook and writes one tab-separated event log per session under `~/Library/Logs/PulpHostBench/<host>-<format>-<ts>-pid<N>.log`. Edge-logs sidechain + transport + MIDI; first-class log lines for spec-violation canaries (`process_without_prepare`, `process_sample_rate_drift`, `process_buffer_overrun`). 7 Catch2 cases + 1 CLAP dlopen smoke. All targets build/dlopen cleanly in Release.
- **`docs/validation/daw-bench/`** — 11 numbered manual scripts (`01-logic-pro-au.md` … `11-fl-studio-vst3.md`) plus a `README.md`. Each script names the specific catalog rows being exercised (with their `cubase10_*`, `reaper_*`, `fl_studio_*`, … flag IDs) and ends with a fill-in-the-blank Result table.
- **`tools/scripts/promote_quirk_tiers.py`** — aggregator that reads filled-in result `.md` files **and/or** raw bench `.log` files (the script has per-host inference rules for the latter). Emits a unified diff against `host_quirks.hpp` flipping `Speculative` → `Validated` for `Confirmed` rows. Never downgrades. 13 unittests at `test_promote_quirk_tiers.py` pin the status model, markdown parsing, log-rule inference, header rewriting, and the CLI surfaces (`--print-status`, diff output, `--in-place`).

Planning note added to `planning/2026-05-24-daw-host-quirks-inheritance.md` with a per-DAW-script status table.

## Test plan

- [x] `cmake --build build --target pulp-host-bench-test` builds in Release.
- [x] `ctest -R HostBench` — 7 Catch2 cases + 1 CLAP dlopen smoke, all pass locally on darwin-arm64.
- [x] `python3 -m unittest tools.scripts.test_promote_quirk_tiers` — 13 cases, all pass.
- [x] End-to-end smoke: piped a fake `Confirmed` markdown row through `promote_quirk_tiers.py` against the real `core/format/include/pulp/format/host_quirks.hpp`, generated a unified diff promoting `reaper_process_while_bypassed`/`reaper_permissive_bus_arrangements`/`reaper_midsession_setstate` from Speculative → Validated — diff applies cleanly.
- [ ] Per-DAW bench evidence: tracked as follow-up — each filled-in `docs/validation/daw-bench/<NN-*>.md` lands in a separate PR with the aggregator's promotion patch.

## How to run it in 30 minutes (per-DAW)

```bash
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF
cmake --build build --target PulpHostBench_CLAP   # + AU/VST3 when SDKs present
cp -R build/CLAP/PulpHostBench.clap ~/Library/Audio/Plug-Ins/CLAP/
rm -rf ~/Library/Logs/PulpHostBench/
# Open your DAW, follow docs/validation/daw-bench/<NN-*>.md step by step.
python3 tools/scripts/promote_quirk_tiers.py \
    ~/Library/Logs/PulpHostBench/*.log path/to/filled-in.md \
    --output /tmp/promote.patch
git apply /tmp/promote.patch
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)