### PR TITLE
docs(skills): sweep auv2/auv3/clap/vst3/hosting/cli-maintenance for /goal-run PR coverage

### DIFF
--- a/.agents/skills/auv2/SKILL.md
+++ b/.agents/skills/auv2/SKILL.md
@@ -80,6 +80,23 @@ The instrument adapter (`core/format/src/au_v2_instrument.cpp`) uses the same `p
 
 `AUMIDIBase::HandleSysEx(data, length)` does not carry a per-event sample offset at this SDK layer. We enqueue the payload with `sample_offset == 0` so it is delivered at the leading edge of the current `ProcessBufferLists()` block.
 
+## Recent changes
+
+### Latency / tail change notifications (PR #2934, item 3.11)
+
+A Processor flags a mid-render latency or tail change via
+`flag_latency_changed()` / `flag_tail_changed()` (RT-safe atomic
+store-release). Never call AU SDK property-change APIs from
+`process()` directly — the adapter owns the host-thread publish path.
+
+AU v2 wiring (post-process): the adapter checks the consume helpers
+and calls `PropertyChanged(kAudioUnitProperty_Latency)` /
+`PropertyChanged(kAudioUnitProperty_TailTime)`. The AU v2 SDK queues
+these for delivery on the main thread, so it's safe to invoke from
+the audio callback path. Tests live in
+`pulp-test-processor-layout-latency` plus the existing
+`pulp-test-au-v2-effect` suite.
+
 ## Current Gaps
 
 - **MIDI output from AU v2 effects** is not wired yet (tracked as #626). `Processor::process()` can write to `midi_out`, but `PulpAUEffect` has no render-notify callback / `MIDIOutput` mixin that emits those events back to the host. Effects that declare `produces_midi = true` work in CLAP / VST3 but stay silent on AU v2. `descriptor.produces_midi` is *not* wired to a CMake flag yet — the AU type selection is driven entirely by `accepts_midi`.

--- a/.agents/skills/auv3/SKILL.md
+++ b/.agents/skills/auv3/SKILL.md
@@ -581,6 +581,34 @@ Pulp's `descriptor().tail_samples` is an integer sample count;
 return `0` — a `0` tail tells the host "this plugin emits nothing
 after input stops" and delay/reverb tails get chopped.
 
+### Bypass routing — auto-detected Bypass parameter (PR #2937)
+
+`initialize` auto-detects a plugin-declared "Bypass" parameter and
+routes both AU v3 bypass surfaces (the host's `bypass` AUValue and
+the plugin's automation lane) through the **same StateStore atomic**
+so they stay in lockstep (DAW quirks row 21). When no Bypass param
+exists the bridge falls back to a local atomic so the contract still
+holds for plugins that don't declare one.
+
+`internalRenderBlock` short-circuits to pass-through audio when
+bypassed (in→out for effects, silence for instruments) and never
+calls `Processor::process`. **MIDI output stays empty** so bypassed
+MIDI FX don't leak notes. Diagnostic: read `pulpBypassParameterId`
+on `PulpAudioUnit` (also exposed from the shared `au_audio_unit.h`
+header) to confirm which ParamID got picked up.
+
+### Latency / tail change notifications (PR #2934, item 3.11)
+
+A Processor flags a mid-render latency or tail change via
+`flag_latency_changed()` / `flag_tail_changed()` (RT-safe atomic
+store-release). The adapter drains those edges post-process and
+`dispatch_async`s to the main queue → KVO `willChange/didChange` for
+`latency` / `tailTime`. The file is built **without ARC** because of
+the C++ `_bridge` struct, so the dispatch path uses MRC-safe
+retain/release rather than ARC capture semantics. Tests are in
+`pulp-test-processor-layout-latency` (round-trip × 2, two-thread
+hammer for data-race freedom).
+
 ### Sidechain pull uses its **own** `AudioBufferList`
 
 Aliasing the main `input_abl` into the sidechain pull corrupts the
@@ -759,6 +787,29 @@ The AU v3 packaging shape is **three distinct targets**, dispatched by
    detects the Simulator via `CMAKE_OSX_SYSROOT` matching
    `Simulator|iphonesimulator`. Mac Catalyst is **deliberately
    excluded** (macOS plan 3.10 — "Catalyst is deferred post-MVP").
+
+### Xcode-project generation: `pulp ship auv3-xcodeproj` (PR #2938, item 3.10)
+
+Once `pulp_add_plugin(... FORMATS AUv3)` is wired, the developer
+flow for iterating on the AUv3 target in Xcode (instruments,
+debugger, simulator profiles) is:
+
+```bash
+pulp ship auv3-xcodeproj <target>                    # iphonesimulator (default)
+pulp ship auv3-xcodeproj <target> --sdk iphoneos     # device
+pulp ship auv3-xcodeproj <target> --sdk macosx       # macOS lane
+pulp ship auv3-xcodeproj <target> --output build/xcode/MyPlugin
+pulp ship auv3-xcodeproj <target> --open             # open in Xcode after gen
+pulp ship auv3-xcodeproj <target> --dry-run          # print cmake invocation only
+```
+
+The wrapper runs `cmake -G Xcode -DPULP_AUV3_TARGET=<name>` against
+a **separate build dir** (default `build/xcode/<target>-<sdk>`) so
+it doesn't collide with the user's normal Ninja/Makefile cache. iOS
+SDKs pull in `tools/cmake/ios.toolchain.cmake` with the correct
+`IOS_PLATFORM` (OS for device, SIMULATOR64 for simulator). This is
+the closeout for item 3.10's deferred Xcode-project generation —
+the entitlement templates landed earlier in the same PR series.
 
 ### Install + cache-clear gotcha
 

--- a/.agents/skills/clap/SKILL.md
+++ b/.agents/skills/clap/SKILL.md
@@ -249,6 +249,43 @@ companion factory pointer. Only instantiates when the Processor
 overrode `create_ara_document_controller()` — plugins that don't
 participate in ARA return `nullptr` naturally. See the `ara` skill.
 
+### Bypass routing — auto-detected (PR #2937)
+
+CLAP doesn't model "bypass" as a first-class extension the way VST3
+(`kIsBypass`) or AU v3 (`AUAudioUnitBypass`) do — hosts treat a
+plugin-declared `"Bypass"` parameter as the on/off lane. The adapter
+auto-detects that parameter at `clap_init` and short-circuits
+`clap_process` to pass-through (in→out for effects, zero-fill for
+instruments) when the cached parameter's current value is `>= 0.5`,
+without invoking `Processor::process`. MIDI output stays empty so
+bypassed MIDI FX don't leak notes — same contract the VST3 and AU v3
+adapters honour.
+
+### Latency / tail change notifications (PR #2934, item 3.11)
+
+A Processor flags a mid-render latency or tail change via
+`flag_latency_changed()` / `flag_tail_changed()` (RT-safe atomic
+store-release). Don't call `clap_host_latency->changed()` from
+`process()` directly — the spec requires that on the main thread.
+
+CLAP wiring (the most involved of the four adapters):
+
+1. `create_plugin()` captures the `clap_host_t*` pointer for later
+   `request_callback()` use.
+2. `process()` peeks via `latency_change_pending()` /
+   `tail_change_pending()` (non-mutating — does NOT drain the edge)
+   and, if either is set, calls `host->request_callback()` to ask
+   the host for a main-thread callback.
+3. `clap_on_main_thread()` then drains via
+   `consume_latency_changed_flag()` / `consume_tail_changed_flag()`
+   and calls `clap_host_latency->changed()` /
+   `clap_host_tail->changed()`.
+
+The peek-vs-consume split exists specifically for CLAP — VST3 / AU
+v3 / AU v2 drain in-line because their host APIs are safe from the
+audio callback path. Don't collapse the two helpers into one if you
+add another adapter that needs the same edge.
+
 ### Preset loading
 
 `clap_plugin_preset_load` is exposed only when the Processor builds a

--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -1199,6 +1199,64 @@ Notes for CLI maintenance:
   logs `build=debug|release` on the `[plugin-gpu-host]` adapter line and warns
   once on Debug, so a host log immediately shows which build was loaded.
 
+## `pulp build --install` + `--skip-validation` (PR #2932, items 7.4 / 7.4b / 7.5)
+
+The documented `build → validate → install` pipeline now exists as
+real CLI flags rather than implied tooling. `tools/cli/cmd_build.cpp`
+gained:
+
+- `--install` — after a successful build, copy each format bundle to
+  its per-format system folder (`~/Library/Audio/Plug-Ins/Components`
+  for AU, `~/Library/Audio/Plug-Ins/VST3/` for VST3,
+  `~/Library/Audio/Plug-Ins/CLAP/` for CLAP). The install runs the
+  `cmd_validate(["--strict"])` gate first; a failing validator
+  refuses to copy anything to the user's system tree.
+- `--skip-validation` — debug-only escape hatch for adapter work. It
+  is **only valid when paired with `--install`** (using it alone is
+  rejected at parse time so users can't accidentally disable
+  validation on a normal build). `--install + --watch` is also
+  rejected — repeated installs from a watch loop would race the host.
+
+Implementation lives in `tools/cli/install_paths_mac.{hpp,cpp}` and is
+mediated through an `InstallEnv` interface so the 14 Catch2 cases in
+`pulp-test-cli-install-paths-mac` can verify the mkdir → rm → cp
+ordering, idempotency, and failure cases without writing to a real
+`~/Library` tree. CLI-surface contract is pinned by 2 shellout cases
+in `pulp-test-cli-ship-shellout`.
+
+Gotchas:
+
+- **rm comes before cp**, not the other way around. A leftover bundle
+  with stale Info.plist can confuse the AU registrar even after a
+  fresh copy. Tests pin this order.
+- **Relative `$HOME` is rejected.** The destination resolver refuses
+  any path that's not absolute under `$HOME/Library/Audio/Plug-Ins/`.
+- **Plugin Install Policy applies.** See CLAUDE.md "Plugin Install
+  Policy" — a plugin that crashes a DAW during scan is worse than no
+  plugin at all. The validation gate is non-optional in normal use.
+
+## `pulp ship auv3-xcodeproj` (PR #2938, item 3.10)
+
+Thin wrapper over `cmake -G Xcode` that generates an Xcode project
+for an AUv3 target without disturbing the user's regular Ninja /
+Makefile build dir. Surface:
+
+```bash
+pulp ship auv3-xcodeproj <target>                    # iphonesimulator (default)
+pulp ship auv3-xcodeproj <target> --sdk iphoneos     # device
+pulp ship auv3-xcodeproj <target> --sdk macosx       # macOS lane
+pulp ship auv3-xcodeproj <target> --output build/xcode/MyPlugin
+pulp ship auv3-xcodeproj <target> --open             # open in Xcode after gen
+pulp ship auv3-xcodeproj <target> --dry-run          # print cmake invocation only
+```
+
+Default output dir is `build/xcode/<target>-<sdk>`. iOS SDKs include
+`tools/cmake/ios.toolchain.cmake` with the correct `IOS_PLATFORM`
+(OS for device, SIMULATOR64 for simulator). The full Xcode-project
+generation flow plus device entitlement templates live in the `auv3`
+skill — this section just pins the CLI surface so the slash command,
+docs, and skill stay in lockstep.
+
 ## `pulp identity` — committed plugin identity lockfile
 
 Track 3.12 (macOS plugin-authoring plan) introduced a Rust-side surface

--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -346,6 +346,53 @@ Gotchas:
   reusable for any future ChildProcess-based isolation work — give
   the helper a mode argv and exec it from the parent.
 
+## PluginManagerPanel drag-add (PR #2929, item 4.3)
+
+Users now drag a row out of `PluginManagerPanel` and drop it onto a
+graph editor surface to add a plugin node. The panel itself stays
+surface-agnostic — it emits `on_row_drag_start` / `on_row_drag_end`
+callbacks with the row payload, and hosts wire the drop into whichever
+graph the cursor landed on.
+
+What changed in the panel:
+
+- `PluginManagerRow` gained the identity fields needed to round-trip
+  into a `PluginInfo` (`manufacturer`, `version`, `unique_id`,
+  `num_inputs`, `num_outputs`, `is_instrument`, `is_effect`) plus a
+  `to_plugin_info()` helper. All defaulted so older models keep
+  working.
+- The panel tracks press → drag-threshold → drag start, emits drag
+  callbacks only for `scanned` bucket rows (failed and blacklisted
+  rows are suppressed because they cannot load anyway), and exposes
+  `simulate_row_drag()` so tests and hosts can drive the callback
+  without synthesising motion events.
+
+Host-side: `pulp::host::add_plugin_node_from_drop(graph, info,
+&loaded)` attempts a live `PluginSlot::load` via `add_plugin_node`
+and falls back to `add_unresolved_plugin_node` when the bundle can't
+load — preserving user intent across save/reload. Don't bypass this
+helper and call `add_plugin_node` directly; the unresolved-fallback
+path is what keeps `.pulpgraph` round-trips honest when a plugin
+binary disappears between sessions.
+
+## ExtensionsVisitor — typed access to format-specific extensions (PR #2892, items 4.5/4.6/4.7)
+
+Hosts that need to reach a format-specific extension (CLAP note ports,
+VST3 IMidiMapping, AU AudioUnit property, LV2 instance) now subclass
+`ExtensionsVisitor`, override the `visit_*` methods they care about,
+and call `slot.accept(visitor)`. Default `visit_*` fall through to
+`visit_unknown` so a visitor that only cares about one format ignores
+the rest automatically. The base `PluginSlot` dispatches to
+`visit_unknown` for placeholder / unresolved slots so they degrade
+gracefully.
+
+Format-specific `*Extension` structs deliberately expose handles as
+`void*` so they don't pull SDK headers into client code. Callers that
+*do* link the SDK `static_cast` back to the concrete type. Wired in
+`ClapSlot`, `Vst3Slot`, `AuSlot`, `Lv2Slot`. Tests in
+`pulp-test-extensions-visitor` pin the visit dispatch + the
+`ExtensionFormat` enumerator values (the latter is a reorder-detector).
+
 ## Scanner identity rules (issue #491 P2)
 
 `PluginScanner` produces `PluginInfo::unique_id` values that

--- a/.agents/skills/vst3/SKILL.md
+++ b/.agents/skills/vst3/SKILL.md
@@ -89,15 +89,21 @@ the full story.
 ### Bus arrangement negotiation
 
 `setBusArrangements(inputs, numIns, outputs, numOuts)` is **not** a
-pass-through to the base class. Pulp's implementation:
+pass-through to the base class. As of PR #2934 (item 3.7) the adapter
+delegates the accept/reject decision to
+`Processor::is_bus_layout_supported(BusesLayout)` — the cross-adapter
+virtual hook that lets a plugin enforce tighter layout contracts
+(linked sidechain, surround, instrument-only output, etc.) without
+overriding `setBusArrangements` directly. The default policy still
+matches the descriptor's per-side bus count and only accepts mono /
+stereo per channel.
 
-1. Rejects with `kResultFalse` if `numIns`/`numOuts` don't match the
-   descriptor's declared bus counts.
-2. Rejects if any requested speaker arrangement is neither `kMono` nor
-   `kStereo` — negotiation is currently limited to those two.
-3. Otherwise updates each `AudioBus` via
-   `bus->setArrangement(arrangement)` in place, then re-propagates to
-   `SingleComponentEffect::setBusArrangements`.
+Order matters: **call the hook before mutating `audioInputs` /
+`audioOutputs`**. A rejected proposal returns `kResultFalse` and the
+host falls back to the default arrangement, matching Steinberg's
+spec — if you mutate first, the rejected reply leaves the bus state
+diverged from `descriptor()`. The AU v3 / AU v2 / CLAP adapters carry
+the same hook for the day they grow dynamic layout negotiation.
 
 Why: hosts swap project channel layouts (load a stereo session over a
 mono plugin slot) and expect the plugin's `descriptor()` view to
@@ -155,6 +161,39 @@ Parameters flow both ways:
 `kIsBypass` is auto-set on any parameter named `"Bypass"` whose range
 is `[0,1]` with `step >= 1` — Steinberg requires exactly one bypass
 parameter per plugin for the host bypass control to work.
+
+### Bypass routing — cached ParamID + render short-circuit (PR #2937)
+
+`initialize()` caches the `ParamID` of the kIsBypass-tagged parameter
+in `bypass_param_id_`; the value is exposed via
+`bypass_parameter_id()` for tests and diagnostics. Inside `process()`,
+when the cached parameter's current value is `>= 0.5`, the adapter
+short-circuits to processBlockBypassed-style pass-through — copies the
+main input to the main output (or zero-fills for instrument
+descriptors), drops the sidechain, and returns **without invoking
+`Processor::process`**.
+
+Why cache the ID: hosts hit `process()` thousands of times per second
+and walking the parameter table to find the bypass slot on every
+block is a non-trivial cost. The cache is set once at `initialize()`
+and never mutated. When a plugin has no Bypass parameter the adapter
+falls back to "always render" — no synthetic atomic.
+
+### Latency / tail change notifications (PR #2934, item 3.11)
+
+A Processor can flag a mid-render latency or tail change from the
+audio thread via `flag_latency_changed()` / `flag_tail_changed()`
+(RT-safe atomic store-release). Never call host APIs from `process()`
+directly — the format adapter owns the host-thread publish path.
+
+VST3 wiring (post-process): the adapter checks
+`consume_latency_changed_flag()` / `consume_tail_changed_flag()` and
+calls `componentHandler->restartComponent(kLatencyChanged |
+kReloadComponent)`. Steinberg documents `restartComponent` as safe
+from the audio callback (the handler queues main-thread delivery), so
+no extra dispatch is needed on the VST3 side. Tests in
+`pulp-test-processor-layout-latency` pin the round-trip and the
+two-thread hammer for data-race freedom.
 
 ### MIDI events
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.122.0",
+      "version": "0.122.1",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.122.0"
+  "version": "0.122.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.122.0",
+  "version": "0.122.1",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",


### PR DESCRIPTION
## Summary

Sweep six SKILL.md files for staleness after the macOS plugin-authoring /goal run landed ~68 PRs. Each entry captures the non-obvious lesson — the WHY and the watch-out-for parts, not what PR titles already say.

## What changed

- **vst3**: `Processor::is_bus_layout_supported()` hook (PR #2934/item 3.7) with the call-before-mutating ordering rule; cached bypass ParamID + render short-circuit (PR #2937); `restartComponent` host-thread publish path for latency/tail edges (PR #2934/item 3.11).
- **auv2**: `PropertyChanged(kAudioUnitProperty_Latency / TailTime)` drain path for the RT-safe `consume_*_changed_flag` helpers (#2934).
- **auv3**: Bypass routing through StateStore + `pulpBypassParameterId` diagnostic (#2937); MRC-safe `dispatch_async` + KVO publish for latency/tailTime (#2934, file built without ARC); `pulp ship auv3-xcodeproj` wrapper (#2938/item 3.10).
- **clap**: Auto-detected Bypass + render short-circuit (#2937); peek-vs-consume split CLAP needs because `clap_host_latency->changed()` must run on the main thread, with `request_callback()`/`clap_on_main_thread()` bridging (#2934/item 3.11).
- **hosting**: `PluginManagerPanel` drag-add → `add_plugin_node_from_drop` with unresolved-fallback (#2929/item 4.3); `ExtensionsVisitor` pattern + `ClapSlot/Vst3Slot/AuSlot/Lv2Slot` wiring (#2892/items 4.5/4.6/4.7).
- **cli-maintenance**: `pulp build --install`/`--skip-validation` surface (#2932/items 7.4/7.4b/7.5) with install-policy + rm-before-cp + relative-$HOME gotchas; `pulp ship auv3-xcodeproj` CLI shape so docs and slash-command stay in lockstep (#2938).

## Skills assessed and already current

`aax` (nothing shipped — Avid SDK pending), `android`, `ara` (#2854 already noted), `ci`, `engine`, `faust`, `import-design`, `ios`, `mpe` (#2860 + #2916 + #2891 already noted), `packages`, `prototype-loop`, `sdf-text`, `ship`, `streams`, `threejs-bridge`, `upgrade`, `view-bridge`, `webview-ui`.

## Test plan

- [x] `python3 tools/scripts/skill_sync_check.py --mode=report` — no mapped paths touched (docs-only).
- [x] `python3 tools/scripts/version_bump_check.py --mode=report` — plugin bumped 0.122.0 → 0.122.1.
- [x] Manual diff review — each entry tied to a specific merged PR (#2929, #2892, #2932, #2934, #2937, #2938).