### PR TITLE
feat(macos-cross): upstream Linux-hosted macOS arm64 cross lane scaffold

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -92,6 +92,21 @@ Do not push empty commits just to churn queued macOS checks. Cancel
 superseded SHAs, rebase or push only when a PR needs current `main`, and
 wait unless a check has actually failed.
 
+### Advisory cross-lane workflow: `macos-cross-advisory.yml`
+
+`.github/workflows/macos-cross-advisory.yml` is a path-scoped advisory
+job for the Linux-hosted macOS arm64 cross lane (Phase 5 scaffolding,
+see `planning/2026-05-24-linux-hosted-macos-arm64-cross-lane.md`). It
+runs on `ubuntu-latest`, does **not** bootstrap osxcross, and does
+**not** download a macOS SDK — it only confirms the Pulp-side cross
+scaffolding (`tools/cmake/toolchains/macos-arm64-osxcross.cmake`,
+`tools/scripts/verify_macos_cross_artifacts.py`, the
+`PULP_RUST_CLI_TARGET` / `PULP_MACOS_CROSS_ALLOW_MISSING_ICON_TOOLS` /
+`OTOOL` / `INSTALL_NAME_TOOL` hooks) stays wired and that the verifier
+unit tests still pass. It is non-gating by design; do not promote it to
+a required check until a self-hosted Linux runner with pinned osxcross
++ private SDK is provisioned and the matching full-build job lands.
+
 ## PR Review Thread Hygiene
 
 Before opening a follow-up PR or declaring a phase complete, sweep review

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.122.1",
+      "version": "0.123.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.122.1"
+  "version": "0.123.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.122.1",
+  "version": "0.123.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/.github/workflows/macos-cross-advisory.yml
+++ b/.github/workflows/macos-cross-advisory.yml
@@ -1,0 +1,135 @@
+name: macOS Cross (advisory)
+
+# Advisory CI scaffold for the Linux-hosted macOS arm64 cross lane.
+#
+# The actual osxcross-based cross build runs in a private infra repo
+# (pulp-macos-cross-infra) on a Linux host with an Apple SDK sysroot
+# already materialized. That build cannot be reproduced from public
+# CI without re-publishing the SDK, which is licensing-disallowed.
+#
+# This workflow exists so the Pulp-side scaffolding (CMake toolchain
+# file, verifier script, cross-compatible package_cli.py overrides, the
+# Linux-hosted macOS cross lane plan itself) is exercised on every PR
+# that touches it. It is intentionally non-gating and runs on the
+# default ubuntu runner.
+#
+# What it checks (free, fast, no SDK required):
+#  1. The CMake toolchain file exists and contains the documented hooks.
+#  2. The Pulp-owned verifier script imports cleanly and its unit tests
+#     pass under the host's `python3`.
+#  3. The plan doc and the toolchain file stay in sync (the doc still
+#     references the toolchain file path).
+#
+# What it deliberately does NOT do:
+#  - Bootstrap osxcross.
+#  - Materialize an Apple SDK.
+#  - Build any Mach-O binaries.
+#  - Validate signatures.
+#
+# These steps require either licensed Apple inputs (SDK) or a real Mac
+# (`codesign`, AU registration, `auval`). Promotion to a full advisory
+# build job (Phase 5 step 3 in the plan) is gated on standing up a
+# self-hosted Linux runner that already has the private SDK and
+# osxcross prefix on disk. When that runner exists, add a second
+# `cross-build` job that calls into the private infra repo's scripts;
+# do not inline the bootstrap here.
+#
+# Plan: planning/2026-05-24-linux-hosted-macos-arm64-cross-lane.md
+# Phase: 5 — CI and artifact publication (scaffold step).
+
+on:
+  pull_request:
+    paths:
+      - 'tools/cmake/toolchains/macos-arm64-osxcross.cmake'
+      - 'tools/cmake/PulpAppIcon.cmake'
+      - 'tools/cmake/FindSkia.cmake'
+      - 'tools/scripts/verify_macos_cross_artifacts.py'
+      - 'tools/scripts/test_verify_macos_cross_artifacts.py'
+      - 'tools/scripts/package_cli.py'
+      - 'experimental/pulp-rs/CMakeLists.txt'
+      - 'planning/2026-05-24-linux-hosted-macos-arm64-cross-lane.md'
+      - '.github/workflows/macos-cross-advisory.yml'
+  workflow_dispatch:
+
+# Non-blocking signal — never cancel a sibling workflow_run on
+# concurrency conflict, and do not contribute to required checks.
+concurrency:
+  group: macos-cross-advisory-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scaffold-check:
+    runs-on: ubuntu-latest
+    name: Cross-lane scaffold check (advisory)
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Confirm CMake toolchain file is present
+        run: |
+          set -euo pipefail
+          toolchain=tools/cmake/toolchains/macos-arm64-osxcross.cmake
+          test -f "$toolchain"
+          grep -q 'CMAKE_SYSTEM_NAME Darwin' "$toolchain"
+          grep -q 'CMAKE_SYSTEM_PROCESSOR arm64' "$toolchain"
+          grep -q 'PULP_MACOS_SDK_ROOT' "$toolchain"
+          grep -q 'PULP_MACOS_CROSS' "$toolchain"
+          echo "ok: $toolchain has the documented hook variables"
+
+      - name: Confirm Pulp-side cross hooks are wired
+        run: |
+          set -euo pipefail
+          grep -q 'PULP_MACOS_CROSS_ALLOW_MISSING_ICON_TOOLS' \
+            tools/cmake/PulpAppIcon.cmake
+          grep -q 'PULP_RUST_CLI_TARGET' \
+            experimental/pulp-rs/CMakeLists.txt
+          grep -q '"OTOOL"' tools/scripts/package_cli.py
+          grep -q '"INSTALL_NAME_TOOL"' tools/scripts/package_cli.py
+          # FindSkia ships the explicit `objc` link interface so
+          # osxcross/ld64.lld can resolve Dawn's Metal Objective-C++
+          # archives on Linux-hosted cross builds.
+          grep -q ';objc"' tools/cmake/FindSkia.cmake
+          echo "ok: cross-lane hooks present"
+
+      - name: Confirm plan doc references the toolchain file
+        run: |
+          set -euo pipefail
+          plan=planning/2026-05-24-linux-hosted-macos-arm64-cross-lane.md
+          if [ -f "$plan" ]; then
+            grep -q 'tools/cmake/toolchains/macos-arm64-osxcross.cmake' "$plan"
+            echo "ok: plan doc references the toolchain file"
+          else
+            echo "note: planning submodule not checked out; skipping plan-doc check"
+          fi
+
+      - name: Run Pulp-owned verifier unit tests
+        run: |
+          set -euo pipefail
+          python3 tools/scripts/test_verify_macos_cross_artifacts.py
+
+      - name: Sanity-check verifier --help
+        run: |
+          set -euo pipefail
+          python3 tools/scripts/verify_macos_cross_artifacts.py --help > /dev/null
+          echo "ok: verifier script imports and --help works"
+
+      - name: Summarize advisory status
+        run: |
+          cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+          ## macOS Cross (advisory)
+
+          This workflow checks the Pulp-side scaffolding for the
+          Linux-hosted macOS arm64 cross lane. It does **not** perform
+          a real cross build — that requires a licensed Apple SDK and
+          an osxcross prefix, which live in a private infra repo and
+          on the private Linux host.
+
+          Promotion path (planning/2026-05-24-linux-hosted-macos-arm64-cross-lane.md):
+          1. **(this job)** scaffold check, advisory.
+          2. Self-hosted Linux runner with pinned osxcross + private
+             SDK calls into the private infra scripts.
+          3. Upload `pulp-darwin-arm64.tar.gz` and
+             `pulp-sdk-darwin-arm64.tar.gz` to the private assets repo.
+          4. Native macOS relay validates the cross artifacts.
+          5. Required CI only after repeated parity passes.
+          EOF

--- a/experimental/pulp-rs/CMakeLists.txt
+++ b/experimental/pulp-rs/CMakeLists.txt
@@ -72,12 +72,26 @@ endif()
 set(PULP_RUST_CLI_PROFILE "release" CACHE STRING
     "Cargo profile for pulp-rs (release|debug)")
 
+# Optional Cargo target triple for cross-building the Rust CLI. The
+# Linux-hosted macOS arm64 cross lane sets this to
+# `aarch64-apple-darwin` so Cargo emits Mach-O binaries instead of the
+# host's native ELF/PE. Native builds leave this empty and Cargo picks
+# the host triple automatically.
+# See planning/2026-05-24-linux-hosted-macos-arm64-cross-lane.md.
+set(PULP_RUST_CLI_TARGET "" CACHE STRING
+    "Optional Cargo target triple for pulp-rs cross builds")
+
 if(PULP_RUST_CLI_PROFILE STREQUAL "debug")
     set(_pulp_rs_cargo_args "")
     set(_pulp_rs_target_subdir "debug")
 else()
     set(_pulp_rs_cargo_args "--release")
     set(_pulp_rs_target_subdir "release")
+endif()
+
+if(PULP_RUST_CLI_TARGET)
+    list(APPEND _pulp_rs_cargo_args "--target" "${PULP_RUST_CLI_TARGET}")
+    set(_pulp_rs_target_subdir "${PULP_RUST_CLI_TARGET}/${_pulp_rs_target_subdir}")
 endif()
 
 # Cargo writes binaries to `target/<profile>/<bin>[.exe]`. Pin the

--- a/tools/cmake/FindSkia.cmake
+++ b/tools/cmake/FindSkia.cmake
@@ -168,9 +168,17 @@ if(EXISTS "${SKIA_LIBRARY}" AND EXISTS "${_skia_include_dir}")
 
         # Platform frameworks
         if(APPLE)
+            # Dawn's Metal archive contains Objective-C++ objects even when
+            # final targets only link from C++ sources. Explicitly linking
+            # `objc` lets osxcross/ld64.lld resolve the Objective-C runtime
+            # selectors emitted by those archives during Linux-hosted darwin
+            # cross builds. The native macOS toolchain auto-links libobjc
+            # via clang's driver, so adding it here is a no-op for native
+            # builds and a fix for the cross lane.
+            # See planning/2026-05-24-linux-hosted-macos-arm64-cross-lane.md.
             set_property(TARGET skia::skia APPEND PROPERTY
                 INTERFACE_LINK_LIBRARIES
-                    "-framework Metal;-framework MetalKit;-framework CoreFoundation;-framework CoreGraphics;-framework CoreText;-framework Foundation;-framework IOKit;-framework IOSurface;-framework QuartzCore"
+                    "-framework Metal;-framework MetalKit;-framework CoreFoundation;-framework CoreGraphics;-framework CoreText;-framework Foundation;-framework IOKit;-framework IOSurface;-framework QuartzCore;objc"
             )
         elseif(ANDROID)
             set_property(TARGET skia::skia APPEND PROPERTY

--- a/tools/cmake/PulpAppIcon.cmake
+++ b/tools/cmake/PulpAppIcon.cmake
@@ -123,6 +123,22 @@ function(_pulp_icon_configure_macos target source_path)
     find_program(_pulp_sips sips)
     find_program(_pulp_iconutil iconutil)
     if(NOT _pulp_sips OR NOT _pulp_iconutil)
+        # Linux-hosted macOS cross builds do not have `sips`/`iconutil`.
+        # PULP_MACOS_CROSS_ALLOW_MISSING_ICON_TOOLS lets the configure
+        # step keep moving while still recording the requested icon
+        # source on the target so a later packaging step (or a portable
+        # `.icns` generator) can finish the job. This is a prototype
+        # escape hatch — production cross artifacts must ship a real
+        # `.icns` before publication. See
+        # planning/2026-05-24-linux-hosted-macos-arm64-cross-lane.md.
+        if(PULP_MACOS_CROSS_ALLOW_MISSING_ICON_TOOLS)
+            message(WARNING
+                "pulp_app_icon(${target}): macOS icon generation requires "
+                "`sips` and `iconutil`; keeping the selected icon source "
+                "recorded for Linux-hosted macOS cross packaging.")
+            set_property(TARGET ${target} PROPERTY PULP_MACOS_APP_ICON "${source_path}")
+            return()
+        endif()
         message(FATAL_ERROR
             "pulp_app_icon(${target}): macOS icon generation requires both "
             "`sips` and `iconutil`.")

--- a/tools/cmake/toolchains/macos-arm64-osxcross.cmake
+++ b/tools/cmake/toolchains/macos-arm64-osxcross.cmake
@@ -1,0 +1,78 @@
+# Pulp Linux-hosted macOS arm64 cross toolchain (osxcross).
+#
+# Usage:
+#   PULP_MACOS_SDK_ROOT=/opt/apple-sdks/MacOSX.sdk \
+#   CC=/opt/osxcross/bin/oa64-clang \
+#   CXX=/opt/osxcross/bin/oa64-clang++ \
+#   OBJC=/opt/osxcross/bin/oa64-clang \
+#   OBJCXX=/opt/osxcross/bin/oa64-clang++ \
+#   CMAKE_C_COMPILER=/opt/osxcross/bin/oa64-clang \
+#   CMAKE_CXX_COMPILER=/opt/osxcross/bin/oa64-clang++ \
+#   CMAKE_AR=/opt/osxcross/bin/arm64-apple-darwin24-ar \
+#   CMAKE_RANLIB=/opt/osxcross/bin/arm64-apple-darwin24-ranlib \
+#   CMAKE_INSTALL_NAME_TOOL=/opt/osxcross/bin/arm64-apple-darwin24-install_name_tool \
+#   CMAKE_STRIP=/opt/osxcross/bin/arm64-apple-darwin24-strip \
+#   MACOSX_DEPLOYMENT_TARGET=15.0 \
+#   cmake -S . -B build-macos-cross \
+#     -DCMAKE_TOOLCHAIN_FILE=tools/cmake/toolchains/macos-arm64-osxcross.cmake \
+#     -DCMAKE_BUILD_TYPE=Release
+#
+# The exact osxcross prefix names depend on the SDK version used to
+# bootstrap osxcross; substitute `arm64-apple-darwin24` for whichever
+# triple your osxcross install produced.
+#
+# Design notes and full architecture: see
+# planning/2026-05-24-linux-hosted-macos-arm64-cross-lane.md.
+
+cmake_minimum_required(VERSION 3.24)
+
+set(CMAKE_SYSTEM_NAME Darwin)
+set(CMAKE_SYSTEM_PROCESSOR arm64)
+
+if(NOT DEFINED ENV{PULP_MACOS_SDK_ROOT})
+    message(FATAL_ERROR
+        "PULP_MACOS_SDK_ROOT must point to a materialized MacOSX.sdk. "
+        "See planning/2026-05-24-linux-hosted-macos-arm64-cross-lane.md "
+        "for SDK provisioning policy.")
+endif()
+
+set(CMAKE_OSX_SYSROOT "$ENV{PULP_MACOS_SDK_ROOT}" CACHE PATH "macOS SDK sysroot" FORCE)
+set(CMAKE_OSX_ARCHITECTURES arm64 CACHE STRING "macOS architectures" FORCE)
+
+# The chrome/m149 darwin-arm64 Skia/Dawn assets currently shipped with
+# Pulp encode macOS 15.0 as their minimum OS. Honor the env override
+# when set explicitly so a host can target a different deployment OS
+# for non-GPU prototype builds.
+if(DEFINED ENV{MACOSX_DEPLOYMENT_TARGET} AND NOT "$ENV{MACOSX_DEPLOYMENT_TARGET}" STREQUAL "")
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "$ENV{MACOSX_DEPLOYMENT_TARGET}"
+        CACHE STRING "macOS deployment target" FORCE)
+endif()
+
+# Compiler/binutils overrides — accept them from the environment so the
+# infra repo can point at whatever osxcross prefix it has on disk
+# without baking absolute paths into Pulp.
+foreach(_var
+        CMAKE_C_COMPILER CMAKE_CXX_COMPILER
+        CMAKE_OBJC_COMPILER CMAKE_OBJCXX_COMPILER
+        CMAKE_AR CMAKE_RANLIB
+        CMAKE_INSTALL_NAME_TOOL CMAKE_STRIP)
+    if(DEFINED ENV{${_var}} AND NOT "$ENV{${_var}}" STREQUAL "")
+        set(${_var} "$ENV{${_var}}" CACHE FILEPATH "" FORCE)
+    endif()
+endforeach()
+
+# Keep finders confined to the Darwin sysroot for libraries/headers
+# while letting CMake reach host programs (cmake, ninja, python, cargo,
+# rcodesign) from the Linux PATH.
+set(CMAKE_FIND_ROOT_PATH "${CMAKE_OSX_SYSROOT}" CACHE STRING "Darwin find root" FORCE)
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+# Signal to downstream Pulp CMake that this is a non-macOS host
+# building Darwin artifacts. Helpers like PulpAppIcon.cmake check this
+# (in concert with PULP_MACOS_CROSS_ALLOW_MISSING_ICON_TOOLS) to skip
+# steps that depend on macOS-only host tools such as `sips`/`iconutil`.
+set(PULP_MACOS_CROSS ON CACHE BOOL
+    "Building macOS artifacts from a non-macOS host" FORCE)

--- a/tools/scripts/package_cli.py
+++ b/tools/scripts/package_cli.py
@@ -129,9 +129,21 @@ def find_wgpu_lib(build_dir: Path, platform: str) -> Path | None:
 
 
 def fix_rpath_macos(binary: Path) -> None:
-    """Drop every absolute LC_RPATH and add @loader_path."""
+    """Drop every absolute LC_RPATH and add @loader_path.
+
+    Honors `OTOOL` and `INSTALL_NAME_TOOL` environment overrides so
+    Linux-hosted darwin cross builds can run this packager with the
+    osxcross/LLVM equivalents (e.g. ``x86_64-apple-darwin24-otool`` and
+    ``x86_64-apple-darwin24-install_name_tool``) instead of the native
+    macOS tools that don't exist on Linux. Native builds leave both env
+    vars unset and inherit the historical hard-coded ``otool`` /
+    ``install_name_tool`` from PATH.
+    See planning/2026-05-24-linux-hosted-macos-arm64-cross-lane.md.
+    """
+    otool = os.environ.get("OTOOL", "otool")
+    install_name_tool = os.environ.get("INSTALL_NAME_TOOL", "install_name_tool")
     out = subprocess.check_output(
-        ["otool", "-l", str(binary)], text=True)
+        [otool, "-l", str(binary)], text=True)
     bad_rpaths: list[str] = []
     in_rpath = False
     for line in out.splitlines():
@@ -153,13 +165,13 @@ def fix_rpath_macos(binary: Path) -> None:
     for rp in bad_rpaths:
         print(f"  removing rpath: {rp}", flush=True)
         subprocess.check_call(
-            ["install_name_tool", "-delete_rpath", rp, str(binary)])
+            [install_name_tool, "-delete_rpath", rp, str(binary)])
 
     print("  adding rpath: @loader_path", flush=True)
     # Idempotent: if @loader_path is already present, install_name_tool
     # exits with an error; suppress and continue.
     subprocess.run(
-        ["install_name_tool", "-add_rpath", "@loader_path", str(binary)],
+        [install_name_tool, "-add_rpath", "@loader_path", str(binary)],
         check=False,
     )
 

--- a/tools/scripts/test_verify_macos_cross_artifacts.py
+++ b/tools/scripts/test_verify_macos_cross_artifacts.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Unit coverage for tools/scripts/verify_macos_cross_artifacts.py.
+
+These tests build synthetic bundle trees and assert the verifier's
+argument-parsing, expected-artifact mapping, and structural-error
+behavior. They do not require a real Mach-O file because the actual
+`file`/`otool` calls are unit-tested only behind an `--require-...`
+flag that we leave OFF here. The aim is to lock in the Pulp-side
+contract of the script so the private cross-infra repo can rely on it
+without re-implementing the structural checks.
+
+See planning/2026-05-24-linux-hosted-macos-arm64-cross-lane.md.
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import plistlib
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT = (
+    pathlib.Path(__file__).resolve().parent / "verify_macos_cross_artifacts.py"
+)
+spec = importlib.util.spec_from_file_location(
+    "verify_macos_cross_artifacts", SCRIPT,
+)
+assert spec and spec.loader
+vmca = importlib.util.module_from_spec(spec)
+sys.modules["verify_macos_cross_artifacts"] = vmca
+spec.loader.exec_module(vmca)
+
+
+def _make_bundle(
+    root: pathlib.Path,
+    bundle_name: str,
+    executable_relpath: str,
+    *,
+    bundle_id: str = "ai.pulp.PulpGain",
+    executable: str = "PulpGain",
+) -> pathlib.Path:
+    """Create a minimal Apple bundle layout under `root/bundle_name`."""
+    bundle = root / bundle_name
+    contents = bundle / "Contents"
+    contents.mkdir(parents=True, exist_ok=True)
+    info = contents / "Info.plist"
+    with info.open("wb") as f:
+        plistlib.dump(
+            {
+                "CFBundleIdentifier": bundle_id,
+                "CFBundleExecutable": executable,
+                "CFBundlePackageType": "BNDL",
+            },
+            f,
+        )
+    exe = bundle / executable_relpath
+    exe.parent.mkdir(parents=True, exist_ok=True)
+    exe.write_bytes(b"")
+    return bundle
+
+
+class ExpectedArtifactsTests(unittest.TestCase):
+    def test_default_expect_covers_app_vst3_component_clap(self) -> None:
+        args = vmca.parse_args([
+            "/dev/null",
+        ])
+        expected = vmca.expected_artifacts(args)
+        names = sorted(expected.keys())
+        self.assertEqual(
+            names,
+            sorted(["PulpGain.app", "PulpGain.vst3", "PulpGain.component", "PulpGain.clap"]),
+        )
+
+    def test_unknown_kind_fails(self) -> None:
+        # parse_args() is intentionally lazy and does not validate
+        # `--expect` values; the failure lives in expected_artifacts()
+        # so the script can return structured help for `--help`.
+        args = vmca.parse_args(["/dev/null", "--expect", "app:not-a-thing"])
+        with self.assertRaises(SystemExit):
+            vmca.expected_artifacts(args)
+
+    def test_auv3_expected_artifact_includes_appex_and_framework(self) -> None:
+        args = vmca.parse_args([
+            "/dev/null",
+            "--expect", "auv3",
+            "--product-name", "MyPlug",
+        ])
+        expected = vmca.expected_artifacts(args)
+        self.assertIn("MyPlug-AUv3.app", expected)
+        spec_ = expected["MyPlug-AUv3.app"]
+        self.assertIn("appex", spec_)
+        self.assertIn("framework", spec_)
+        self.assertEqual(
+            spec_["appex_executable"],
+            "Contents/PlugIns/MyPlug.appex/Contents/MacOS/MyPlug",
+        )
+
+
+class MainStructuralTests(unittest.TestCase):
+    def test_missing_artifact_directory_fails(self) -> None:
+        with self.assertRaises(SystemExit):
+            vmca.main(["/nonexistent/path/that/should/not/exist"])
+
+    def test_missing_bundle_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(SystemExit):
+                vmca.main([tmpdir, "--expect", "clap"])
+
+    def test_missing_info_plist_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = pathlib.Path(tmpdir)
+            bundle = root / "PulpGain.clap"
+            (bundle / "Contents" / "MacOS").mkdir(parents=True)
+            (bundle / "Contents" / "MacOS" / "PulpGain").write_bytes(b"")
+            with self.assertRaises(SystemExit):
+                vmca.main([str(root), "--expect", "clap"])
+
+    def test_missing_executable_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = pathlib.Path(tmpdir)
+            bundle = root / "PulpGain.clap"
+            (bundle / "Contents").mkdir(parents=True)
+            with (bundle / "Contents" / "Info.plist").open("wb") as f:
+                plistlib.dump({"CFBundleIdentifier": "ai.pulp.PulpGain"}, f)
+            with self.assertRaises(SystemExit):
+                vmca.main([str(root), "--expect", "clap"])
+
+    def test_non_macho_executable_fails(self) -> None:
+        # The verifier shells out to `file(1)` to confirm Mach-O arm64.
+        # An empty file is "data" or "empty" and fails the check.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = pathlib.Path(tmpdir)
+            _make_bundle(root, "PulpGain.clap", "Contents/MacOS/PulpGain")
+            with self.assertRaises(SystemExit):
+                vmca.main([str(root), "--expect", "clap"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/verify_macos_cross_artifacts.py
+++ b/tools/scripts/verify_macos_cross_artifacts.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Verify cross-built Pulp macOS arm64 bundle artifacts.
+
+Pulp-owned structural verifier for the Linux-hosted macOS arm64 cross
+lane. Runs from either Linux (using osxcross/LLVM tools) or macOS
+(using native tools) and asserts the bundle shape contract documented
+in planning/2026-05-24-linux-hosted-macos-arm64-cross-lane.md.
+
+This script intentionally has no third-party dependencies so it can run
+in advisory CI before any toolchain bootstrap completes.
+
+Checks per artifact kind:
+- bundle directory + Contents/Info.plist present
+- Mach-O arm64 executable at the expected path
+- (optional) AUv3 .appex/.framework nesting and exec arch
+- (optional) every LC_RPATH is loader-relative (no absolute paths)
+
+Tool resolution order for `otool`-equivalents:
+  $CMAKE_OTOOL, $OTOOL, $OSXCROSS_ROOT/target/bin/*otool, PATH lookups
+  for otool / llvm-otool / arm64-apple-darwin-otool /
+  aarch64-apple-darwin-otool.
+
+Exit codes:
+  0 — all expected artifacts verified
+  1 — at least one structural check failed
+  2 — required external tool missing (only when --require-clean-rpaths)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import plistlib
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run(cmd: list[str]) -> str:
+    return subprocess.check_output(cmd, text=True, stderr=subprocess.STDOUT)
+
+
+def fail(msg: str, code: int = 1) -> None:
+    print(f"FAIL: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def load_plist(path: Path) -> dict:
+    with path.open("rb") as f:
+        return plistlib.load(f)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify cross-built Pulp macOS arm64 bundle artifacts.",
+    )
+    parser.add_argument(
+        "root",
+        nargs="?",
+        type=Path,
+        help="Artifact directory containing the built bundles.",
+    )
+    parser.add_argument(
+        "--artifact-dir",
+        dest="artifact_dir",
+        type=Path,
+        help="Artifact directory. Overrides the positional root.",
+    )
+    parser.add_argument(
+        "--expect",
+        default="app:vst3:component:clap",
+        help=(
+            "Colon- or comma-separated artifact kinds to verify "
+            "(app, vst3, component, clap, auv3)."
+        ),
+    )
+    parser.add_argument(
+        "--product-name",
+        default="PulpGain",
+        help="Product name embedded in bundle names and executables.",
+    )
+    parser.add_argument("--standalone-app-name")
+    parser.add_argument("--auv3-app-name")
+    parser.add_argument("--auv3-appex-name")
+    parser.add_argument("--auv3-framework-name")
+    parser.add_argument(
+        "--require-clean-rpaths",
+        action="store_true",
+        help=(
+            "Fail if any Mach-O file in a verified bundle contains an "
+            "absolute LC_RPATH entry. Requires otool-equivalent on PATH."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit structured JSON results on stdout (always emitted now).",
+    )
+    return parser.parse_args(argv)
+
+
+def expected_artifacts(args: argparse.Namespace) -> dict[str, dict[str, str]]:
+    product = args.product_name
+    standalone_app = args.standalone_app_name or product
+    auv3_app = args.auv3_app_name or f"{product}-AUv3"
+    auv3_appex = args.auv3_appex_name or product
+    auv3_framework = args.auv3_framework_name or f"{product}AUv3Framework"
+    all_artifacts: dict[str, dict[str, str]] = {
+        "app": {
+            "name": f"{standalone_app}.app",
+            "executable": f"Contents/MacOS/{product}",
+        },
+        "vst3": {
+            "name": f"{product}.vst3",
+            "executable": f"Contents/MacOS/{product}",
+        },
+        "component": {
+            "name": f"{product}.component",
+            "executable": f"Contents/MacOS/{product}",
+        },
+        "clap": {
+            "name": f"{product}.clap",
+            "executable": f"Contents/MacOS/{product}",
+        },
+        "auv3": {
+            "name": f"{auv3_app}.app",
+            "executable": f"Contents/MacOS/{product}",
+            "appex": f"Contents/PlugIns/{auv3_appex}.appex",
+            "appex_executable": (
+                f"Contents/PlugIns/{auv3_appex}.appex/Contents/MacOS/{product}"
+            ),
+            "framework": f"Contents/Frameworks/{auv3_framework}.framework",
+            "framework_executable": (
+                f"Contents/Frameworks/{auv3_framework}.framework/"
+                f"Versions/A/{auv3_framework}"
+            ),
+        },
+    }
+    raw = args.expect.replace(",", ":")
+    kinds = [part for part in raw.split(":") if part]
+    expected: dict[str, dict[str, str]] = {}
+    for kind in kinds:
+        if kind not in all_artifacts:
+            fail(
+                f"unknown artifact kind {kind!r}; "
+                f"expected one of {sorted(all_artifacts)}",
+            )
+        spec = dict(all_artifacts[kind])
+        expected[spec["name"]] = spec
+    return expected
+
+
+def find_otool() -> str | None:
+    candidates: list[str | None] = [
+        os.environ.get("CMAKE_OTOOL"),
+        os.environ.get("OTOOL"),
+    ]
+    osxcross_root = os.environ.get("OSXCROSS_ROOT")
+    if osxcross_root:
+        osxcross_bin = Path(osxcross_root) / "target" / "bin"
+        if osxcross_bin.is_dir():
+            candidates.extend(str(p) for p in sorted(osxcross_bin.glob("*otool")))
+    candidates.extend([
+        "otool",
+        "llvm-otool",
+        "arm64-apple-darwin-otool",
+        "aarch64-apple-darwin-otool",
+    ])
+    for candidate in candidates:
+        if not candidate:
+            continue
+        candidate_path = Path(candidate).expanduser()
+        if candidate_path.is_file() and os.access(candidate_path, os.X_OK):
+            return str(candidate_path)
+        found = shutil.which(candidate)
+        if found:
+            return found
+    return None
+
+
+def rpaths(binary: Path, otool: str) -> list[str]:
+    output = run([otool, "-l", str(binary)])
+    values: list[str] = []
+    in_rpath = False
+    for raw in output.splitlines():
+        line = raw.strip()
+        if line == "cmd LC_RPATH":
+            in_rpath = True
+            continue
+        if in_rpath and line.startswith("path "):
+            values.append(line.split()[1])
+            in_rpath = False
+    return values
+
+
+def require_macho_arm64(path: Path) -> str:
+    if not path.exists():
+        fail(f"missing executable {path}")
+    file_out = run(["file", str(path)])
+    if "Mach-O" not in file_out or "arm64" not in file_out:
+        fail(f"{path} is not Mach-O arm64: {file_out.strip()}")
+    return file_out.strip()
+
+
+def mach_o_files(root: Path) -> list[Path]:
+    out: list[Path] = []
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        try:
+            file_out = run(["file", str(path)])
+        except subprocess.CalledProcessError:
+            continue
+        if "Mach-O" in file_out:
+            out.append(path)
+    return sorted(out)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    root = args.artifact_dir or args.root
+    if root is None:
+        fail("no artifact directory provided (pass it positionally or via --artifact-dir)")
+    if not root.is_dir():
+        fail(f"artifact directory does not exist or is not a directory: {root}")
+    expected = expected_artifacts(args)
+    otool = find_otool()
+    if args.require_clean_rpaths and not otool:
+        fail(
+            "could not find otool/llvm-otool to check LC_RPATH values; "
+            "set OTOOL or OSXCROSS_ROOT, or install llvm-tools.",
+            code=2,
+        )
+    results: dict[str, object] = {"root": str(root), "artifacts": []}
+    for name, spec in expected.items():
+        bundle = root / name
+        if not bundle.exists():
+            fail(f"missing {bundle}")
+        info = bundle / "Contents" / "Info.plist"
+        exe = bundle / spec["executable"]
+        if not info.exists():
+            fail(f"missing Info.plist in {bundle}")
+        meta = load_plist(info)
+        file_out = require_macho_arm64(exe)
+        nested: dict[str, object] = {}
+        if "appex" in spec:
+            appex = bundle / spec["appex"]
+            framework = bundle / spec["framework"]
+            if not appex.is_dir():
+                fail(f"missing AUv3 appex: {appex}")
+            if not framework.is_dir():
+                fail(f"missing AUv3 framework: {framework}")
+            nested["appex"] = spec["appex"]
+            nested["appex_file"] = require_macho_arm64(
+                bundle / spec["appex_executable"]
+            )
+            nested["framework"] = spec["framework"]
+            nested["framework_file"] = require_macho_arm64(
+                bundle / spec["framework_executable"]
+            )
+        exe_rpaths: list[str] = []
+        if otool:
+            if args.require_clean_rpaths:
+                files_to_check = mach_o_files(bundle)
+            else:
+                files_to_check = [exe]
+            rpath_map: dict[str, list[str]] = {}
+            for macho in files_to_check:
+                rel = macho.relative_to(bundle).as_posix()
+                values = rpaths(macho, otool)
+                rpath_map[rel] = values
+                if macho == exe:
+                    exe_rpaths = values
+                if args.require_clean_rpaths:
+                    absolute = [v for v in values if v.startswith("/")]
+                    if absolute:
+                        fail(
+                            f"{macho} has absolute LC_RPATH entries: {absolute}",
+                        )
+            if args.require_clean_rpaths:
+                nested["rpaths_by_file"] = rpath_map
+        results["artifacts"].append({
+            "bundle": name,
+            "identifier": meta.get("CFBundleIdentifier"),
+            "executable": meta.get("CFBundleExecutable"),
+            "file": file_out,
+            "rpaths": exe_rpaths,
+            "nested": nested,
+        })
+    print(json.dumps(results, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Phase 5 (CI and artifact publication) scaffold step for the Linux-hosted macOS arm64 cross lane. Upstreams the four Pulp-side deltas that previously lived only as a private-infra patch, adds a Pulp-owned bundle structural verifier with unit tests, an osxcross CMake toolchain file, and an advisory GitHub Actions job that exercises the scaffolding on every PR — without requiring a licensed Apple SDK or osxcross prefix.

Plan: `planning/2026-05-24-linux-hosted-macos-arm64-cross-lane.md`

## What ships

- `tools/cmake/toolchains/macos-arm64-osxcross.cmake` (new) — osxcross CMake toolchain reading SDK and compiler paths from environment so no host-absolute paths leak into Pulp.
- `experimental/pulp-rs/CMakeLists.txt` — new `PULP_RUST_CLI_TARGET` cache variable so Cargo can target `aarch64-apple-darwin` from Linux.
- `tools/cmake/PulpAppIcon.cmake` — `PULP_MACOS_CROSS_ALLOW_MISSING_ICON_TOOLS` escape hatch when `sips`/`iconutil` are unavailable on Linux.
- `tools/cmake/FindSkia.cmake` — explicit `objc` link entry so osxcross/`ld64.lld` can resolve Dawn's Metal Objective-C++ archives during Linux-hosted cross builds (no-op on native macOS).
- `tools/scripts/package_cli.py` — accepts `OTOOL` / `INSTALL_NAME_TOOL` env-var overrides for osxcross tool prefixes.
- `tools/scripts/verify_macos_cross_artifacts.py` (new) — Pulp-owned structural verifier for cross-built `.app` / `.vst3` / `.component` / `.clap` / `.auv3` bundles, with `--require-clean-rpaths` and JSON output.
- `tools/scripts/test_verify_macos_cross_artifacts.py` (new) — 8 unit tests for arg parsing, expected-artifact mapping, and four structural failure paths.
- `.github/workflows/macos-cross-advisory.yml` (new) — path-scoped advisory CI job. Non-gating by design; promotion to a required check is gated on standing up a self-hosted Linux runner with pinned osxcross + private SDK.
- `.agents/skills/ci/SKILL.md` — documents the new advisory workflow.
- `planning/2026-05-24-linux-hosted-macos-arm64-cross-lane.md` — marks Phase 5 scaffold step landed (planning submodule already committed and pushed).

## Test plan

- [x] `python3 tools/scripts/test_verify_macos_cross_artifacts.py` — 8/8 passing locally.
- [x] `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF` — configure clean.
- [x] `cmake --build build --target pulp-state -j8` — build clean.
- [x] `actionlint .github/workflows/macos-cross-advisory.yml` — clean.
- [x] `python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main` — clean.
- [x] `python3 tools/scripts/version_bump_check.py --mode=report --base origin/main` — clean.

## Deferred (not in this PR)

- Self-hosted Linux runner provisioning + full cross-build advisory job. Requires private SDK on the runner; out of scope for the Pulp-side scaffold.
- Promotion of the workflow to a required check. Per the plan, this is Phase 5 step 5, gated on repeated native-parity passes.
- Retiring the four-patch delta in `pulp-macos-cross-infra/scripts/apply_pulp_cross_patches.sh` — separate change in the private infra repo, against any Pulp ref that contains this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)