### PR TITLE
[codex] Fix macOS WebGPU runtime rpath

### DIFF
--- a/tools/cmake/PulpWebGpuImportedTarget.cmake
+++ b/tools/cmake/PulpWebGpuImportedTarget.cmake
@@ -72,6 +72,18 @@ if(NOT TARGET webgpu
 endif()
 
 if(NOT COMMAND target_copy_webgpu_binaries)
+    function(_pulp_target_append_unique_property target property value)
+        get_target_property(_pulp_existing_values ${target} ${property})
+        if(NOT _pulp_existing_values OR _pulp_existing_values STREQUAL "_pulp_existing_values-NOTFOUND")
+            set(_pulp_existing_values "")
+        endif()
+
+        list(FIND _pulp_existing_values "${value}" _pulp_value_index)
+        if(_pulp_value_index EQUAL -1)
+            set_property(TARGET ${target} APPEND PROPERTY ${property} "${value}")
+        endif()
+    endfunction()
+
     function(target_copy_webgpu_binaries target)
         if(TARGET webgpu AND EXISTS "${_pulp_webgpu_runtime}")
             add_custom_command(
@@ -82,6 +94,19 @@ if(NOT COMMAND target_copy_webgpu_binaries)
                     $<TARGET_FILE_DIR:${target}>
                 COMMENT "Copying WebGPU runtime next to ${target}"
             )
+
+            if(APPLE)
+                # wgpu-native's macOS dylib uses @rpath. Since this helper
+                # copies the runtime next to the consuming binary/framework,
+                # the binary should resolve it from its bundle, not from the
+                # SDK install prefix used at build time. This keeps signed
+                # Developer ID bundles compatible with library validation.
+                set_target_properties(${target} PROPERTIES
+                    BUILD_WITH_INSTALL_RPATH TRUE
+                    MACOSX_RPATH TRUE
+                )
+                _pulp_target_append_unique_property(${target} INSTALL_RPATH "@loader_path")
+            endif()
         endif()
     endfunction()
 endif()


### PR DESCRIPTION
## Summary
- add a macOS-specific `@loader_path` install rpath when `target_copy_webgpu_binaries()` copies `libwgpu_native.dylib` next to app/plugin targets
- enable build-time install rpath for those Apple targets so signed bundles resolve the bundled WebGPU runtime instead of an SDK-prefix copy

## Why
Developer ID signed Chainer artifacts could load `/tmp/pulp-hardening-sdk-macos15/lib/libwgpu_native.dylib` via an absolute SDK rpath. macOS library validation then rejected the mapping because the process and SDK dylib signatures did not share a Team ID. Resolving `@rpath/libwgpu_native.dylib` from `@loader_path` keeps the dependency inside the signed bundle.

## Validation
- `cmake -S /private/tmp/pulp-webgpu-rpath-smoke -B /private/tmp/pulp-webgpu-rpath-smoke/build -G Ninja`
- `cmake --build /private/tmp/pulp-webgpu-rpath-smoke/build`
- `otool -l /private/tmp/pulp-webgpu-rpath-smoke/build/consumer` confirmed `LC_RPATH @loader_path`
- Chainer native macOS artifacts built from the patched SDK were installed and validated locally: strict codesign passed for standalone, AUv3 host, VST3, and CLAP; `auval -v aumu Chnr Pulp -strict -o -oop` passed; pluginval VST3 strictness 5 passed; clap-validator passed
