### PR TITLE
fix(sdk): install au_view_controller_mac.mm for macOS AUv3 framework builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.254.0
+    VERSION 0.254.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,6 +69,21 @@ set_tests_properties(cmake-pulp-install-layout PROPERTIES
     LABELS "cmake;binary-data;issue-905;slow"
     TIMEOUT 120)
 
+# Install-layout regression for format helper sources used by
+# PulpAuv3.cmake / PulpPluginFormats.cmake from _PULP_FORMAT_SOURCE_DIR.
+# Without au_view_controller_mac.mm in the installed SDK, downstream
+# pulp_add_plugin(FORMATS AUv3 ...) builds on macOS fail with a
+# missing-source error. Tracked by the Linux/macOS Chainer gap-closure
+# plan (planning/2026-05-24-linux-macos-chainer-gap-closure-plan.md,
+# Phase 0/3).
+add_test(NAME cmake-pulp-install-format-sources
+    COMMAND ${CMAKE_COMMAND}
+        -DPULP_BUILD_DIR=${CMAKE_BINARY_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/test_pulp_install_format_sources.cmake)
+set_tests_properties(cmake-pulp-install-format-sources PROPERTIES
+    LABELS "cmake;sdk;auv3;chainer-cross;slow"
+    TIMEOUT 120)
+
 # PULP_REQUIRE_GPU_FOR_SDK gate smoke (pulp #1817). Two full configures
 # in a tmpdir: ON+missing-skia must FAIL, OFF+missing-skia must SUCCEED.
 # Tagged `slow` because each configure pays the SDL3 / FetchContent cost.

--- a/test/cmake/test_pulp_install_format_sources.cmake
+++ b/test/cmake/test_pulp_install_format_sources.cmake
@@ -1,0 +1,91 @@
+#[[
+Install-layout regression: macOS AUv3 framework helper sources.
+
+PulpAuv3.cmake's _pulp_add_auv3_macos_framework() compiles
+${_PULP_FORMAT_SOURCE_DIR}/au_view_controller_mac.mm — the
+PulpAUMacViewController principal class that NSExtensionMain looks up
+when the macOS AUv3 .appex is loaded. When the Pulp SDK is consumed via
+find_package(Pulp), _PULP_FORMAT_SOURCE_DIR resolves to
+<prefix>/src/pulp/format/ (see tools/cmake/PulpUtils.cmake). If the
+install rule omits au_view_controller_mac.mm, downstream
+pulp_add_plugin(FORMATS AUv3 ...) builds on macOS fail at the
+add_library() call with a missing-source error.
+
+This regression is the SDK packaging fix called out in
+planning/2026-05-24-linux-macos-chainer-gap-closure-plan.md
+(Phase 3 / Phase 0 "upstream the SDK packaging fix that installs
+au_view_controller_mac.mm").
+
+Inputs (passed via -D):
+  PULP_BUILD_DIR — path to a configured Pulp build directory.
+]]
+
+cmake_minimum_required(VERSION 3.20)
+
+if(NOT DEFINED PULP_BUILD_DIR)
+    message(FATAL_ERROR
+        "test_pulp_install_format_sources.cmake requires -DPULP_BUILD_DIR=<dir> "
+        "pointing at a configured Pulp build.")
+endif()
+get_filename_component(PULP_BUILD_DIR "${PULP_BUILD_DIR}" ABSOLUTE)
+if(NOT EXISTS "${PULP_BUILD_DIR}/CMakeCache.txt")
+    message(FATAL_ERROR
+        "PULP_BUILD_DIR=${PULP_BUILD_DIR} is not a configured CMake build "
+        "directory (no CMakeCache.txt).")
+endif()
+
+set(_prefix "${CMAKE_CURRENT_BINARY_DIR}/pulp-install-format-sources-prefix")
+file(REMOVE_RECURSE "${_prefix}")
+file(MAKE_DIRECTORY "${_prefix}")
+
+execute_process(
+    COMMAND "${CMAKE_COMMAND}"
+            --install "${PULP_BUILD_DIR}"
+            --prefix  "${_prefix}"
+    RESULT_VARIABLE _rc
+    OUTPUT_VARIABLE _stdout
+    ERROR_VARIABLE  _stderr)
+if(NOT _rc EQUAL 0)
+    message(FATAL_ERROR
+        "cmake --install failed (rc=${_rc}):\n"
+        "----- stdout -----\n${_stdout}\n"
+        "----- stderr -----\n${_stderr}\n----- end -----")
+endif()
+
+# Helper sources are published under <prefix>/src/pulp/format/ by
+# tools/cmake/PulpInstallRules.cmake. The set must include every source
+# referenced by PulpUtils / PulpAuv3 / PulpPluginFormats from
+# _PULP_FORMAT_SOURCE_DIR so an installed-SDK consumer can build any
+# format the SDK ships.
+set(_required_sources
+    aax_runtime.cpp
+    au_adapter.mm
+    au_audio_unit.h
+    au_entry.mm
+    au_v2_cocoa_view.mm
+    au_view_controller_ios.mm
+    au_view_controller_mac.mm
+    vst3_plug_view.cpp)
+
+set(_missing "")
+foreach(_src IN LISTS _required_sources)
+    set(_path "${_prefix}/src/pulp/format/${_src}")
+    if(NOT EXISTS "${_path}")
+        list(APPEND _missing "${_src}")
+    endif()
+endforeach()
+
+if(_missing)
+    message(FATAL_ERROR
+        "Installed Pulp SDK is missing format helper sources required by "
+        "PulpAuv3.cmake / PulpPluginFormats.cmake from _PULP_FORMAT_SOURCE_DIR:\n"
+        "  ${_missing}\n"
+        "Expected under: ${_prefix}/src/pulp/format/\n"
+        "Without these, pulp_add_plugin(FORMATS AUv3 ...) on macOS (and other "
+        "format helpers) fail in installed-SDK builds. Update the install(FILES "
+        "...) block in tools/cmake/PulpInstallRules.cmake.")
+endif()
+
+message(STATUS
+    "Install layout: ${_prefix}/src/pulp/format/ contains all required "
+    "format helper sources (${_required_sources}).")

--- a/tools/cmake/PulpInstallRules.cmake
+++ b/tools/cmake/PulpInstallRules.cmake
@@ -300,6 +300,14 @@ endif()
 
 # Helper sources needed by installed-SDK plugin targets. These are shared by
 # the unified PulpUtils.cmake implementation when it is used from find_package.
+#
+# au_view_controller_mac.mm is the macOS AUv3 principal-class view controller
+# (PulpAUMacViewController), referenced by PulpAuv3.cmake's macOS framework
+# target. Without it, an installed-SDK consumer that calls
+# pulp_add_plugin(FORMATS AUv3 ...) on macOS fails at configure time because
+# _PULP_FORMAT_SOURCE_DIR/au_view_controller_mac.mm doesn't exist in the SDK
+# tree (only au_view_controller_ios.mm was being shipped). This is the SDK
+# packaging fix tracked in the Linux/macOS Chainer gap-closure plan.
 install(FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/core/format/src/aax_runtime.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/core/format/src/au_adapter.mm"
@@ -307,6 +315,7 @@ install(FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/core/format/src/au_entry.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/core/format/src/au_v2_cocoa_view.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/core/format/src/au_view_controller_ios.mm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/core/format/src/au_view_controller_mac.mm"
     "${CMAKE_CURRENT_SOURCE_DIR}/core/format/src/vst3_plug_view.cpp"
     DESTINATION src/pulp/format
 )

--- a/tools/validation/sdk-smoke/CMakeLists.txt
+++ b/tools/validation/sdk-smoke/CMakeLists.txt
@@ -1,5 +1,29 @@
 cmake_minimum_required(VERSION 3.24)
 
+# Pulp SDK smoke project.
+#
+# Verifies a `cmake --install`-produced Pulp SDK is consumable end-to-end
+# through find_package(Pulp). The smoke project enumerates every plugin
+# format the installed SDK advertises and builds a single probe plugin
+# (PulpSDKSmokeProbe) against them.
+#
+# Two opt-in tightenings for the Linux/macOS Chainer gap-closure plan
+# (planning/2026-05-24-linux-macos-chainer-gap-closure-plan.md, Phase 3):
+#
+#   PULP_SDK_SMOKE_REQUIRE_FORMATS — semicolon-separated list of formats
+#       that MUST be present in the installed SDK. Configure-time
+#       FATAL_ERROR if any required format is missing. Example for the
+#       Chainer release lane:
+#         -DPULP_SDK_SMOKE_REQUIRE_FORMATS="Standalone;VST3;CLAP;AU;AUv3"
+#       Default empty (permissive) so existing callers don't break.
+#
+#   PULP_SDK_SMOKE_INCLUDE_AUV3 — when ON on Apple platforms, wires the
+#       AUv3 format into the probe (requires PLUGIN_CODE +
+#       MANUFACTURER_CODE). Default OFF because not every SDK install
+#       intends to ship AUv3 macOS, but ON is the production posture for
+#       the Chainer lane and exercises PulpAuv3.cmake's macOS framework /
+#       appex / container-app helpers against the installed SDK tree.
+
 if(APPLE)
     project(PulpSDKSmoke LANGUAGES CXX OBJCXX)
     set(CMAKE_OBJCXX_STANDARD 20)
@@ -10,6 +34,13 @@ endif()
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+option(PULP_SDK_SMOKE_INCLUDE_AUV3
+    "Include AUv3 in the SDK smoke (Apple only; exercises macOS container helper)"
+    OFF)
+set(PULP_SDK_SMOKE_REQUIRE_FORMATS ""
+    CACHE STRING
+    "Formats that must be present in the installed SDK (semicolon-separated)")
 
 find_package(Pulp REQUIRED CONFIG)
 
@@ -26,12 +57,40 @@ endif()
 if(APPLE AND TARGET Pulp::ausdk)
     list(APPEND PULP_SDK_SMOKE_FORMATS AU)
 endif()
+if(PULP_SDK_SMOKE_INCLUDE_AUV3 AND APPLE AND TARGET Pulp::ausdk)
+    # AUv3 doesn't have its own imported target; it reuses AU SDK + the
+    # PulpAuv3.cmake helpers shipped in lib/cmake/Pulp. Gate it on the
+    # AU SDK being installed so the smoke fails loud when AU was
+    # filtered out of the SDK.
+    list(APPEND PULP_SDK_SMOKE_FORMATS AUv3)
+endif()
 if((APPLE OR WIN32) AND PULP_HAS_AAX)
     list(APPEND PULP_SDK_SMOKE_FORMATS AAX)
 endif()
 
 if(NOT PULP_SDK_SMOKE_FORMATS)
     message(FATAL_ERROR "Pulp SDK smoke project found no supported installed formats")
+endif()
+
+# Required-format gate. The Chainer release lane (and any production
+# packaging path) should set PULP_SDK_SMOKE_REQUIRE_FORMATS so a silently
+# under-packaged SDK fails at configure time instead of producing a
+# smoke build that quietly skipped the format the consumer cares about.
+if(PULP_SDK_SMOKE_REQUIRE_FORMATS)
+    set(_pulp_sdk_smoke_missing "")
+    foreach(_required IN LISTS PULP_SDK_SMOKE_REQUIRE_FORMATS)
+        if(NOT _required IN_LIST PULP_SDK_SMOKE_FORMATS)
+            list(APPEND _pulp_sdk_smoke_missing "${_required}")
+        endif()
+    endforeach()
+    if(_pulp_sdk_smoke_missing)
+        message(FATAL_ERROR
+            "Pulp SDK smoke: required formats not available in the installed SDK: "
+            "${_pulp_sdk_smoke_missing}\n"
+            "Detected formats: ${PULP_SDK_SMOKE_FORMATS}\n"
+            "Either rebuild the SDK with the missing formats enabled, or drop "
+            "them from PULP_SDK_SMOKE_REQUIRE_FORMATS.")
+    endif()
 endif()
 
 pulp_add_plugin(PulpSDKSmokeProbe


### PR DESCRIPTION
## Summary

Phase 0/3 Pulp-side win for the **Linux/macOS Chainer gap-closure plan** (`planning/2026-05-24-linux-macos-chainer-gap-closure-plan.md`). Closes the SDK-packaging gap that blocked installed-SDK consumers from building macOS AUv3 plugins — complements PR #2980 (Linux-hosted macOS arm64 cross lane scaffold).

- **fix:** install `core/format/src/au_view_controller_mac.mm` so `pulp_add_plugin(FORMATS AUv3 ...)` on macOS works from a `find_package(Pulp)` consumer. Previously only `au_view_controller_ios.mm` shipped, so `PulpAuv3.cmake`'s `_pulp_add_auv3_macos_framework` failed at `add_library()` with a missing-source error in installed-SDK builds.
- **smoke:** tighten `tools/validation/sdk-smoke/CMakeLists.txt` with two opt-in cache vars called for by the plan (Phase 3):
  - `PULP_SDK_SMOKE_REQUIRE_FORMATS` — semicolon-list of formats that MUST be present; fail-loud configure error if missing.
  - `PULP_SDK_SMOKE_INCLUDE_AUV3` — Apple-only opt-in that wires AUv3 into the probe so the macOS container helper is exercised end-to-end against the installed SDK.
- **test:** new `cmake-pulp-install-format-sources` regression. Runs `cmake --install` into a temp prefix and asserts every format-helper source referenced from `_PULP_FORMAT_SOURCE_DIR` ships. Verified the test correctly fails without the install fix and passes with it.

## Test plan

- [x] `ctest -R cmake-pulp-install-format-sources` passes locally (Release + GPU=OFF)
- [x] `ctest -R cmake-pulp-install-layout` (existing install-layout test) still passes
- [x] Confirmed test fails when `au_view_controller_mac.mm` is removed from `install(FILES ...)` (verified via `git stash` / re-configure)
- [x] `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF` configures clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)