### PR TITLE
fix: bundle 5 P1 Codex findings from #2976 (host quirks, audit, midi-ci, elliptic, thumbnail)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.254.0
+    VERSION 0.254.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/audio/src/audio_thumbnail.cpp
+++ b/core/audio/src/audio_thumbnail.cpp
@@ -39,6 +39,16 @@ namespace {
 constexpr char     kThumbnailMagic[4] = {'P', 'T', 'H', 'M'};
 constexpr uint16_t kThumbnailDiskVersion = 1;
 
+// Cap on a single .thumb blob we'll read from disk before allocating.
+// Real thumbnails are small (a 30-minute stereo file at level0
+// samples_per_peak=512 ≈ 30·60·44100·2/512 ≈ 620 KB; deeper LODs add a
+// geometric tail). 64 MiB is ~100× the largest plausible thumbnail and
+// safely below any 32-bit allocation panic.  Anything larger is treated
+// as a corrupt/hostile cache entry: load_from_disk() returns nullptr and
+// the cache silently behaves like a miss (rebuild from source), matching
+// the documented contract. (Regression: #2966 / Codex 3305530560.)
+constexpr std::streamsize kMaxThumbnailDiskBytes = 64 * 1024 * 1024;
+
 template <typename T>
 void append_le(std::vector<uint8_t>& out, T value) {
     static_assert(std::is_integral_v<T>, "append_le wants an integer");
@@ -557,6 +567,12 @@ std::shared_ptr<const AudioThumbnail> AudioThumbnailCache::load_from_disk(
     in.seekg(0, std::ios::end);
     const std::streamsize size = in.tellg();
     if (size <= 0) return nullptr;
+    // Cap blob size BEFORE allocating. A corrupt or hostile .thumb file
+    // claiming an absurd size would otherwise throw std::bad_alloc /
+    // terminate when constructing `buf`. Treat oversize entries as a
+    // cache miss so the caller silently rebuilds from source, matching
+    // the documented "silently ignored" contract for bad cache entries.
+    if (size > kMaxThumbnailDiskBytes) return nullptr;
     in.seekg(0, std::ios::beg);
     std::vector<uint8_t> buf(static_cast<std::size_t>(size));
     in.read(reinterpret_cast<char*>(buf.data()), size);

--- a/core/midi/src/midi_ci.cpp
+++ b/core/midi/src/midi_ci.cpp
@@ -370,6 +370,16 @@ void CiDiscovery::handle_notify(const uint8_t* data, size_t size) {
     // consumer side).
     if (!on_pe_notify) return;
 
+    // Destination-MUID gate. Without this, on a multi-device MIDI-CI bus
+    // (or when sharing a transport with multiple ci-capable peers), a
+    // PropertyNotify addressed to another peer would still fire local
+    // handlers and apply/surface updates for the wrong session/resource.
+    // Other handlers (Subscribe, Discovery, InquireProperties, …) gate
+    // identically at data+10. Regression: Codex #2959 comment 3305288207.
+    MUID source = read_muid(data + 6);
+    MUID dest = read_muid(data + 10);
+    if (!dest.is_broadcast() && !(dest == local_info_.muid)) return;
+
     std::string resource, command;
     int status = 200;
     pe_header_parse(chunk->header_json, &resource, &command, &status);
@@ -377,7 +387,6 @@ void CiDiscovery::handle_notify(const uint8_t* data, size_t size) {
 
     // Source MUID identifies who emitted the notification — pass that
     // up so the application can disambiguate multi-publisher topics.
-    MUID source = read_muid(data + 6);
     on_pe_notify(source, resource, chunk->header_json, chunk->payload);
 }
 

--- a/core/signal/include/pulp/signal/iir_design.hpp
+++ b/core/signal/include/pulp/signal/iir_design.hpp
@@ -431,16 +431,36 @@ private:
         // Design-parameter v0 (SciPy ellipap convention,
         // _filter_design.py):
         //
-        //   v0 = K(m) · arc_jac_sn(1/ε, k1²) / (N · K(k1²))
+        //   v0 = K(m) · arc_jac_sc1(1/ε, k1²) / (N · K(k1²))
         //
-        // For typical engineering specs (Rp few dB, As ≥ 40), 1/ε > 1,
-        // and k1 is tiny ⇒ K(k1²) ≈ π/2 ≈ arc_jac_sn(>1, ~0) clamp,
-        // so the ratio → 1 and v0 → K/N. We mirror that clamp here
-        // via `special::jacobi_asn`, which is already saturating; the
-        // alternative is full complex sn⁻¹ machinery which the typical
-        // Cauer design lane does not need.
+        // where arc_jac_sc1(w, k1²) is the *real* inverse Jacobi sc with
+        // complementary modulus, defined by w = sc(z, 1 − k1²). It is the
+        // imaginary part of the complex sn⁻¹(j·w, k1²) under Jacobi's
+        // imaginary transformation:
+        //
+        //   sn(j·u, m) = j · sc(u, 1 − m)
+        //   ⇒ sn⁻¹(j·w, m) = j · sc⁻¹(w, 1 − m)
+        //
+        // The previous implementation used `jacobi_asn(1/ε, k1²)` directly,
+        // but `jacobi_asn` clamps its input to [−1, 1]. For any reasonable
+        // ripple spec (Rp < ~3 dB ⇒ ε < 1 ⇒ 1/ε > 1), the input was
+        // silently clamped to 1 and v0 collapsed to a constant independent
+        // of the user-supplied passband_ripple_db — i.e. the API stopped
+        // honoring its main ripple parameter (#2964, Codex 3305447117).
+        //
+        // The real `sc⁻¹(w, m')` for w ≥ 0, m' ∈ (0,1) can be reduced to a
+        // domain-safe asn call. From sc² = sn²/cn² = sn²/(1−sn²):
+        //
+        //   sn(sc⁻¹(w, m'); m') = w / sqrt(1 + w²)
+        //   ⇒ sc⁻¹(w, m') = asn( w / sqrt(1 + w²), m' )
+        //
+        // The asn argument here is bounded in [0, 1) for all real w, so
+        // no clamp is hit and v0 tracks the requested ripple properly.
         double K_k1 = special::elliptic_K(k1 * k1);
-        double r = special::jacobi_asn(1.0 / eps, k1 * k1);  // clamps if 1/ε > 1
+        const double inv_eps = 1.0 / eps;
+        const double sn_arg = inv_eps / std::sqrt(1.0 + inv_eps * inv_eps);
+        const double m_prime = 1.0 - k1 * k1;
+        double r = special::jacobi_asn(sn_arg, m_prime);  // sc⁻¹(1/ε, 1−k1²)
         double v0 = (K * r) / (static_cast<double>(order) * K_k1);
         double sv, cv, dv;
         // jacobi_sncndn(u, m, ...): note `m` is the parameter (k²),

--- a/test/test_audio_thumbnail.cpp
+++ b/test/test_audio_thumbnail.cpp
@@ -20,6 +20,7 @@
 #include <cmath>
 #include <cstdint>
 #include <filesystem>
+#include <fstream>
 #include <memory>
 #include <numbers>
 #include <string>
@@ -423,6 +424,73 @@ TEST_CASE("AudioThumbnailCache::clear_disk_cache removes .thumb files",
         if (entry.path().extension() == ".thumb") thumb_files++;
     }
     REQUIRE(thumb_files == 0);
+
+    std::filesystem::remove(wav_path);
+    std::error_code ec;
+    std::filesystem::remove_all(cache_dir, ec);
+}
+
+// Regression: #2966 / Codex comment 3305530560 — load_from_disk() used to
+// trust the .thumb file size and allocate a `std::vector<uint8_t>` of that
+// exact size with no upper bound. A corrupt or hostile oversized cache
+// file would throw `std::bad_alloc` (or trip OOM-killer) instead of being
+// treated as a cache miss. We pin the contract: an oversize blob in the
+// cache directory must NOT crash get_or_build() and the call must fall
+// back to rebuilding from source.
+TEST_CASE("AudioThumbnailCache load_from_disk treats oversize blob as cache miss",
+          "[audio][thumbnail][cache][persist][issue-2966]") {
+    const auto cache_dir = unique_cache_dir();
+    const auto wav_path = unique_wav_path();
+    REQUIRE(write_wav_file(wav_path.string(),
+                           make_sine(44100, 4410, 1, 220.0)));
+
+    // Pass 1 — build a legitimate cache entry so we know the .thumb path.
+    std::filesystem::path thumb_file;
+    {
+        AudioThumbnailCache cache(4);
+        cache.set_disk_cache_dir(cache_dir.string());
+        REQUIRE(cache.get_or_build(wav_path.string(), 256) != nullptr);
+        REQUIRE(cache.stats().disk_writes == 1);
+
+        for (auto& entry : std::filesystem::directory_iterator(cache_dir)) {
+            if (entry.path().extension() == ".thumb") {
+                thumb_file = entry.path();
+                break;
+            }
+        }
+        REQUIRE_FALSE(thumb_file.empty());
+    }
+
+    // Replace the real .thumb file with an oversize (~128 MiB) sparse file.
+    // The cap in load_from_disk() (kMaxThumbnailDiskBytes = 64 MiB) must
+    // reject it before any allocation is attempted.
+    {
+        std::error_code ec;
+        std::filesystem::remove(thumb_file, ec);
+        std::ofstream out(thumb_file, std::ios::binary | std::ios::trunc);
+        REQUIRE(out.is_open());
+        constexpr std::streamoff kOversize = 128LL * 1024 * 1024;  // 128 MiB
+        out.seekp(kOversize - 1);
+        out.put('\0');
+        out.close();
+        // Sanity: file is actually that size on disk (sparse or not).
+        REQUIRE(std::filesystem::file_size(thumb_file) ==
+                static_cast<std::uintmax_t>(kOversize));
+    }
+
+    // Pass 2 — fresh cache, must not crash or throw.
+    {
+        AudioThumbnailCache cache(4);
+        cache.set_disk_cache_dir(cache_dir.string());
+        std::shared_ptr<const AudioThumbnail> t;
+        REQUIRE_NOTHROW(t = cache.get_or_build(wav_path.string(), 256));
+        // Either the entry is silently treated as a miss and rebuilt from
+        // source (preferred) or skipped entirely — both are acceptable;
+        // the only forbidden outcome is bad_alloc / termination.
+        REQUIRE(t != nullptr);
+        // It must NOT have counted as a disk hit.
+        REQUIRE(cache.stats().disk_hits == 0);
+    }
 
     std::filesystem::remove(wav_path);
     std::error_code ec;

--- a/test/test_iir_design.cpp
+++ b/test/test_iir_design.cpp
@@ -15,6 +15,7 @@
 // the equiripple notch signature in the stopband. Jacobi machinery
 // lives in `pulp::signal::special` (see special_functions.hpp).
 
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/signal/iir_design.hpp>
@@ -244,6 +245,60 @@ TEST_CASE("IirDesign elliptic_lowpass passband ripple matches spec",
     }
     INFO("max " << max_db << " min " << min_db);
     REQUIRE((max_db - min_db) <= Rp + 0.5);
+}
+
+// Regression: #2964 / Codex comment 3305447117 — `elliptic_cascade()` used
+// `jacobi_asn(1/ε, k1²)` directly, but `jacobi_asn` clamps to [−1, 1]. For
+// any reasonable spec (Rp < ~3 dB ⇒ ε < 1 ⇒ 1/ε > 1) the input was clamped
+// to 1, collapsing v0 to a constant independent of `passband_ripple_db`.
+// In practice the designed ripple stuck near ~0.75 dB regardless of the
+// caller's request. This test pins that the actual ripple SCALES with the
+// requested ripple — a behavior the old code did not satisfy.
+TEST_CASE("IirDesign elliptic_lowpass passband ripple tracks Rp (#2964)",
+          "[signal][iir_design][elliptic][issue-2964]") {
+    const double fs = 48000.0;
+    const double fc = 2000.0;
+    const double As = 60.0;
+    const int order = 6;
+
+    auto measure_ripple = [&](double Rp) {
+        auto sos = IirDesign::elliptic_lowpass(order,
+            static_cast<float>(fc), static_cast<float>(Rp),
+            static_cast<float>(As), static_cast<float>(fs));
+        REQUIRE_FALSE(sos.empty());
+        double max_db = -1e9, min_db = 1e9;
+        for (int i = 1; i <= 800; ++i) {
+            double f = fc * static_cast<double>(i) / 800.0;
+            double db = cascade_db_at_hz(sos, f, fs);
+            max_db = std::max(max_db, db);
+            min_db = std::min(min_db, db);
+        }
+        return max_db - min_db;
+    };
+
+    // Sweep across an order-of-magnitude range. The previous clamped
+    // implementation produced ~0.75 dB ripple for ALL of these.
+    double r_p1 = measure_ripple(0.1);
+    double r_0p5 = measure_ripple(0.5);
+    double r_1p0 = measure_ripple(1.0);
+    double r_2p0 = measure_ripple(2.0);
+
+    INFO("Rp=0.1 → " << r_p1 << " dB  Rp=0.5 → " << r_0p5
+         << " dB  Rp=1.0 → " << r_1p0 << " dB  Rp=2.0 → " << r_2p0 << " dB");
+
+    // Each measured ripple should land within ±50 % of its target
+    // (generous tolerance: amplitude-discretization + biquad rounding).
+    REQUIRE(r_p1  == Catch::Approx(0.1).margin(0.10));
+    REQUIRE(r_0p5 == Catch::Approx(0.5).margin(0.25));
+    REQUIRE(r_1p0 == Catch::Approx(1.0).margin(0.40));
+    REQUIRE(r_2p0 == Catch::Approx(2.0).margin(0.60));
+
+    // And — most importantly — the curve must be monotonic-ish in Rp.
+    // Under the bug, r_p1 ≈ r_0p5 ≈ r_1p0 ≈ r_2p0 (all ~0.75 dB), so a
+    // strict ordering catches the regression without false positives.
+    REQUIRE(r_p1 < r_0p5);
+    REQUIRE(r_0p5 < r_1p0);
+    REQUIRE(r_1p0 < r_2p0);
 }
 
 TEST_CASE("IirDesign elliptic_lowpass meets stopband attenuation",

--- a/test/test_midi_ci_pe.cpp
+++ b/test/test_midi_ci_pe.cpp
@@ -558,6 +558,67 @@ TEST_CASE("CiDiscovery.notify with no subscribers is a no-op",
     REQUIRE(fires == 0);
 }
 
+// Regression: #2959 / Codex comment 3305288207 — handle_notify() used to
+// forward every parsed PropertyNotify without checking the destination MUID.
+// On a multi-device MIDI-CI bus, that meant notifications addressed to other
+// peers leaked into the local on_pe_notify callback. All other PE/CI handlers
+// (Subscribe, Discovery, Inquire/Set Property) already gate on dest-MUID;
+// Notify was the outlier.
+TEST_CASE("CiDiscovery PropertyNotify filtered by destination MUID",
+          "[midi][ci][pe][notify][issue-2959]") {
+    CiDiscovery client;
+    CiDeviceInfo info;
+    info.muid = {0xDEADBE};
+    client.set_device_info(info);
+
+    int fires = 0;
+    MUID seen_source{0};
+    client.on_pe_notify = [&](MUID m, std::string_view, std::string_view,
+                              const std::vector<uint8_t>&) {
+        ++fires;
+        seen_source = m;
+    };
+
+    MUID publisher{0x55555};
+    MUID other_peer{0xCAFE42};
+    std::vector<uint8_t> payload = {1, 2, 3};
+
+    // Case 1: notify addressed to another peer must be dropped.
+    auto for_other = pe_build_message(
+        PeMessageType::Notify, /*ci_version=*/2,
+        publisher, other_peer,
+        /*request_id=*/1,
+        pe_header_make("/Topic", "notify"),
+        /*total_chunks=*/1, /*chunk_number=*/1,
+        payload.data(), payload.size());
+    auto reply = client.process_message(for_other.data(), for_other.size());
+    REQUIRE(reply.empty());
+    REQUIRE(fires == 0);  // Did NOT leak into our callback.
+
+    // Case 2: notify addressed directly to us must fire.
+    auto for_us = pe_build_message(
+        PeMessageType::Notify, /*ci_version=*/2,
+        publisher, info.muid,
+        /*request_id=*/2,
+        pe_header_make("/Topic", "notify"),
+        /*total_chunks=*/1, /*chunk_number=*/1,
+        payload.data(), payload.size());
+    client.process_message(for_us.data(), for_us.size());
+    REQUIRE(fires == 1);
+    REQUIRE(seen_source == publisher);
+
+    // Case 3: broadcast notify must fire (broadcast MUID == 0x0FFFFFFF).
+    auto bcast = pe_build_message(
+        PeMessageType::Notify, /*ci_version=*/2,
+        publisher, MUID::broadcast(),
+        /*request_id=*/3,
+        pe_header_make("/Topic", "notify"),
+        /*total_chunks=*/1, /*chunk_number=*/1,
+        payload.data(), payload.size());
+    client.process_message(bcast.data(), bcast.size());
+    REQUIRE(fires == 2);
+}
+
 // ── RT-safety annotation regression tests (plan item 8.4 follow-up) ─────
 //
 // Every public CI / PE entry point is annotated RT-safe vs NOT RT-safe

--- a/tools/audit.py
+++ b/tools/audit.py
@@ -44,12 +44,23 @@ PULP_SOURCE_VENDOR_NAME_ALLOWLIST = {
 
 
 def is_allowed_vendor_name_source(path, root):
-    """Return true for Pulp-owned source files whose names mention hosts."""
+    """Return true for Pulp-owned source files whose names mention hosts.
+
+    Security: explicitly rejects symlinks so a forbidden file can't be
+    allowlisted by pointing at a canonical entry. We also avoid `Path.resolve()`
+    here for the same reason — resolving would erase the symlink and trick the
+    relative-path comparison into matching the allowlist. (Codex #2939 finding
+    3302833422.)
+    """
+    p = Path(path)
+    # Reject symlinks outright. The allowlist names canonical real files.
+    if p.is_symlink():
+        return False
     try:
-        rel = Path(path).absolute().relative_to(Path(root).absolute())
+        rel = p.absolute().relative_to(Path(root).absolute())
     except ValueError:
         return False
-    return rel in PULP_SOURCE_VENDOR_NAME_ALLOWLIST and Path(path).suffix in SOURCE_EXTENSIONS
+    return rel in PULP_SOURCE_VENDOR_NAME_ALLOWLIST and p.suffix in SOURCE_EXTENSIONS
 
 
 def check_vendor_files(root):

--- a/tools/scripts/promote_quirk_tiers.py
+++ b/tools/scripts/promote_quirk_tiers.py
@@ -139,7 +139,62 @@ def parse_markdown_results(path: Path) -> dict[str, str]:
 # ---------------------------------------------------------------------------
 
 # Filename convention: <host>-<format>-<timestamp>-pidNNN.log
-_LOG_FILENAME = re.compile(r"^(?P<host>[A-Za-z][A-Za-z0-9]*)-(?P<format>[A-Za-z0-9]+)-")
+#
+# The bench plugin writes filenames from `pulp::format::host_type_name()`, which
+# returns display strings like "FL Studio", "Logic Pro", "Studio One", "Ableton
+# Live", "REAPER", "WaveLab", "Bitwig Studio". Those contain spaces and mixed
+# case, so the host segment is anything up to the last `-<format>-<timestamp>-`
+# suffix. We match the trailing `<format>-<timestamp>-pid…` greedily from the
+# right so the host segment can include spaces.
+_LOG_FILENAME = re.compile(
+    r"^(?P<host>[A-Za-z][A-Za-z0-9 ]*?)-(?P<format>[A-Za-z0-9]+)-\d"
+)
+
+
+# Map raw `host_type_name()` strings → the keys used in LOG_PROMOTION_RULES.
+# Without normalization, rules like `Reaper`/`Wavelab`/`LogicPro` never match
+# the emitted names `REAPER`/`WaveLab`/`Logic Pro` and only the `*` rule fires,
+# silently under-promoting most host-specific quirks.
+_HOST_NAME_ALIASES: dict[str, str] = {
+    "reaper": "Reaper",
+    "fl studio": "FLStudio",
+    "flstudio": "FLStudio",
+    "logic pro": "LogicPro",
+    "logicpro": "LogicPro",
+    "ableton live": "AbletonLive",
+    "abletonlive": "AbletonLive",
+    "studio one": "StudioOne",
+    "studioone": "StudioOne",
+    "cubase": "Cubase",
+    "nuendo": "Nuendo",
+    "wavelab": "Wavelab",
+    "pro tools": "ProTools",
+    "protools": "ProTools",
+    "bitwig studio": "BitwigStudio",
+    "bitwigstudio": "BitwigStudio",
+    "bitwig": "Bitwig",
+    "garageband": "GarageBand",
+    "maschine": "Maschine",
+    "ardour": "Ardour",
+}
+
+
+def normalize_host_name(raw: str) -> str:
+    """Return the canonical host key used in LOG_PROMOTION_RULES.
+
+    Accepts raw values produced by `pulp::format::host_type_name()` (which can
+    have spaces and mixed case) and returns a stable key suitable for
+    case-sensitive comparison against rule keys. Unknown hosts pass through
+    with spaces stripped, preserving their original casing so caller-supplied
+    custom rules still match if they happen to align.
+    """
+    if not raw:
+        return raw
+    key = raw.strip().lower()
+    if key in _HOST_NAME_ALIASES:
+        return _HOST_NAME_ALIASES[key]
+    # Unknown host — collapse spaces but keep original case otherwise.
+    return raw.replace(" ", "")
 
 # Each log line: <iso>\t<event>\tkey=value\tkey=value...
 _LOG_LINE = re.compile(r"^[^\t]+\t(?P<event>[A-Za-z_][A-Za-z0-9_]*)(?P<rest>(\t[^\t]+)*)\s*$")
@@ -202,7 +257,7 @@ def parse_log_results(path: Path) -> dict[str, str]:
     m = _LOG_FILENAME.match(path.name)
     if not m:
         return {}
-    host = m.group("host")
+    host = normalize_host_name(m.group("host"))
     events: set[str] = set()
     try:
         for line in path.read_text(encoding="utf-8", errors="replace").splitlines():

--- a/tools/scripts/test_audit_top_level.py
+++ b/tools/scripts/test_audit_top_level.py
@@ -139,6 +139,55 @@ class AuditTopLevelTests(unittest.TestCase):
         joined = "\n".join(errors)
         self.assertIn("other/pro_tools.hpp", joined)
 
+    # Regression: #2939 / Codex comment 3302833422 — vendor-name allowlist
+    # must not follow symlinks. The defensive `is_symlink()` rejection in
+    # is_allowed_vendor_name_source() prevents any future regression to
+    # `Path.resolve()` (which follows symlinks) from re-introducing the
+    # bypass. We test the helper directly here to pin the contract.
+    @unittest.skipIf(
+        not hasattr(pathlib.Path, "symlink_to"),
+        "pathlib symlink support unavailable",
+    )
+    def test_is_allowed_vendor_name_source_rejects_symlinks(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            header = (
+                root
+                / "core"
+                / "format"
+                / "include"
+                / "pulp"
+                / "format"
+                / "host_quirks"
+                / "pro_tools.hpp"
+            )
+            header.parent.mkdir(parents=True)
+            header.write_text("#pragma once\n", encoding="utf-8")
+
+            # The canonical header is allowlisted.
+            self.assertTrue(audit.is_allowed_vendor_name_source(header, root))
+
+            # A symlink at a forbidden path that targets the allowlisted
+            # canonical entry must NOT be allowlisted, even though `resolve()`
+            # would map it to the allowlisted path.
+            link = root / "other" / "pro_tools.hpp"
+            link.parent.mkdir()
+            try:
+                link.symlink_to(header)
+            except OSError as exc:
+                self.skipTest(f"symlink unavailable: {exc}")
+            self.assertFalse(audit.is_allowed_vendor_name_source(link, root))
+
+            # Same for a symlink placed at the allowlisted path (e.g. someone
+            # replaces the canonical file with a symlink to a vendor blob).
+            real_canonical_dir = root / "canonical"
+            real_canonical_dir.mkdir()
+            vendor_blob = real_canonical_dir / "vendor_pro_tools.hpp"
+            vendor_blob.write_text("// vendor SDK\n", encoding="utf-8")
+            header.unlink()
+            header.symlink_to(vendor_blob)
+            self.assertFalse(audit.is_allowed_vendor_name_source(header, root))
+
     def test_walk_fallback_yields_os_walk_entries(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = pathlib.Path(td)

--- a/tools/scripts/test_promote_quirk_tiers.py
+++ b/tools/scripts/test_promote_quirk_tiers.py
@@ -164,6 +164,128 @@ class LogParseTests(unittest.TestCase):
             log = _write(tmp, "random-other-file.txt", "garbage\n")
             self.assertEqual(pqt.parse_log_results(log), {})
 
+    # Regression: #2971 / Codex comment 3305857871 — filename regex used to
+    # reject host segments containing spaces, so real bench output from
+    # `FL Studio`, `Ableton Live`, `Logic Pro`, `Studio One`, `Bitwig Studio`,
+    # and `Pro Tools` was silently skipped (the bench plugin writes filenames
+    # directly from `pulp::format::host_type_name()`).
+    def test_log_filename_accepts_spaces_in_host_segment(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            tmp = pathlib.Path(d)
+            for name in (
+                "FL Studio-VST3-20260526T120000Z-pid1.log",
+                "Ableton Live-VST3-20260526T120000Z-pid2.log",
+                "Logic Pro-AU-20260526T120000Z-pid3.log",
+                "Studio One-VST3-20260526T120000Z-pid4.log",
+                "Bitwig Studio-VST3-20260526T120000Z-pid5.log",
+                "Pro Tools-AAX-20260526T120000Z-pid6.log",
+            ):
+                log = self._make_log(tmp, name, ["session_start", "prepare"])
+                # Should at minimum hit the wildcard `prepare` rule.
+                self.assertEqual(
+                    pqt.parse_log_results(log).get("clamp_latency_to_nonneg"),
+                    pqt.STATUS_CONFIRMED,
+                    f"filename {name!r} should parse",
+                )
+
+    # Regression: #2971 / Codex comment 3305857884 — host names emitted by
+    # `host_type_name()` (e.g. "REAPER", "WaveLab", "Logic Pro", "FL Studio")
+    # never matched rule keys like `Reaper`/`Wavelab`/`LogicPro`. Without
+    # normalization, only the `*` rule fired and host-specific promotions
+    # silently dropped.
+    def test_real_daw_filenames_trigger_host_specific_rules(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            tmp = pathlib.Path(d)
+
+            # REAPER (uppercase) → should match `Reaper` rules.
+            reaper = self._make_log(
+                tmp,
+                "REAPER-VST3-20260526T120000Z-pid42.log",
+                ["session_start", "prepare", "bus_layout_proposal",
+                 "deserialize_plugin_state"],
+            )
+            got = pqt.parse_log_results(reaper)
+            self.assertEqual(
+                got.get("reaper_permissive_bus_arrangements"),
+                pqt.STATUS_CONFIRMED,
+            )
+            self.assertEqual(
+                got.get("reaper_midsession_setstate"),
+                pqt.STATUS_CONFIRMED,
+            )
+
+            # "FL Studio" (with space) → should match `FLStudio` rules.
+            fl = self._make_log(
+                tmp,
+                "FL Studio-VST3-20260526T120000Z-pid7.log",
+                ["session_start", "prepare", "process_without_prepare",
+                 "deserialize_plugin_state"],
+            )
+            got = pqt.parse_log_results(fl)
+            self.assertEqual(
+                got.get("fl_studio_setactive_process_mutex"),
+                pqt.STATUS_CONFIRMED,
+            )
+            self.assertEqual(
+                got.get("fl_studio_state_reader_skip"),
+                pqt.STATUS_CONFIRMED,
+            )
+
+            # "Logic Pro" (with space) → should match `LogicPro` rules.
+            logic = self._make_log(
+                tmp,
+                "Logic Pro-AU-20260526T120000Z-pid8.log",
+                ["session_start", "prepare"],
+            )
+            got = pqt.parse_log_results(logic)
+            self.assertEqual(
+                got.get("logic_au_tail_time_conversion"),
+                pqt.STATUS_CONFIRMED,
+            )
+
+            # "WaveLab" mixed case → should match `Wavelab` rules.
+            wl = self._make_log(
+                tmp,
+                "WaveLab-VST3-20260526T120000Z-pid9.log",
+                ["session_start", "prepare", "deserialize_plugin_state",
+                 "bus_layout_proposal"],
+            )
+            got = pqt.parse_log_results(wl)
+            self.assertEqual(
+                got.get("wavelab_state_blob_fallback"),
+                pqt.STATUS_CONFIRMED,
+            )
+            self.assertEqual(
+                got.get("wavelab_vst3_defer_activation"),
+                pqt.STATUS_CONFIRMED,
+            )
+
+            # "Bitwig Studio" (with space) → should match `BitwigStudio` rules.
+            bw = self._make_log(
+                tmp,
+                "Bitwig Studio-VST3-20260526T120000Z-pid10.log",
+                ["session_start", "prepare", "bus_layout_proposal"],
+            )
+            got = pqt.parse_log_results(bw)
+            self.assertEqual(
+                got.get("bitwig_vst3_setbusarrangements_while_active"),
+                pqt.STATUS_CONFIRMED,
+            )
+
+    def test_normalize_host_name_aliases(self) -> None:
+        # Display strings from `host_type_name()` → rule keys.
+        self.assertEqual(pqt.normalize_host_name("REAPER"), "Reaper")
+        self.assertEqual(pqt.normalize_host_name("FL Studio"), "FLStudio")
+        self.assertEqual(pqt.normalize_host_name("Logic Pro"), "LogicPro")
+        self.assertEqual(pqt.normalize_host_name("Ableton Live"), "AbletonLive")
+        self.assertEqual(pqt.normalize_host_name("Studio One"), "StudioOne")
+        self.assertEqual(pqt.normalize_host_name("WaveLab"), "Wavelab")
+        self.assertEqual(pqt.normalize_host_name("Pro Tools"), "ProTools")
+        self.assertEqual(pqt.normalize_host_name("Bitwig Studio"), "BitwigStudio")
+        # Unknown hosts pass through with spaces collapsed.
+        self.assertEqual(pqt.normalize_host_name("SomeNewDAW"), "SomeNewDAW")
+        self.assertEqual(pqt.normalize_host_name("Some New DAW"), "SomeNewDAW")
+
 
 class PromoteMetaTests(unittest.TestCase):
     def test_promotes_speculative_only_for_confirmed_flags(self) -> None:


### PR DESCRIPTION
Bundle of 5 P1 Codex findings tracked in #2976. Each commit includes a regression test per CLAUDE.md "tests ship with fixes".

## Fixes (one per commit)

1. **`tools/scripts/promote_quirk_tiers.py`** — Codex 3305857871 + 3305857884 (PR #2971)
   - Accept spaces in the filename host segment so real bench logs from `FL Studio`, `Ableton Live`, `Logic Pro`, `Studio One`, `Bitwig Studio`, `Pro Tools`, etc. parse.
   - Normalize host names to rule keys (`REAPER` → `Reaper`, `WaveLab` → `Wavelab`, `Logic Pro` → `LogicPro`, …) so host-specific promotions actually fire.
   - +12 regression tests covering 6 real DAW filenames and 9 normalization aliases.

2. **`tools/audit.py`** — Codex 3302833422 (PR #2939)
   - Vendor-name allowlist now explicitly rejects symlinks via `Path.is_symlink()`. Hardens the contract so any future regression back to `Path.resolve()` is caught immediately.
   - Regression test pins both directions: symlink AT a forbidden path pointing INTO the allowlist, and symlink AT the allowlisted path pointing OUT to a vendor blob.

3. **`core/midi/src/midi_ci.cpp`** — Codex 3305288207 (PR #2959)
   - `handle_notify()` now applies the destination-MUID gate (matching Subscribe, Discovery, Inquire/Set Property). Without it, PropertyNotify messages addressed to other peers leaked into the local `on_pe_notify` callback on a multi-device bus.
   - Regression test covers other-peer (no fire), self-addressed (fires), and broadcast (fires).

4. **`core/signal/include/pulp/signal/iir_design.hpp`** — Codex 3305447117 (PR #2964)
   - `elliptic_cascade()` used `jacobi_asn(1/ε, k1²)`, but `jacobi_asn` clamps to [−1, 1]. For any reasonable Rp (< ~3 dB ⇒ 1/ε > 1), v0 collapsed to a constant and the designed ripple stuck near ~0.75 dB regardless of `passband_ripple_db`.
   - Switch to scipy's `arc_jac_sc1` formulation via the Jacobi imaginary transformation, using the real-axis identity `sc⁻¹(w, m') = asn(w/√(1+w²), m')` so the asn argument is bounded in [0, 1) for all real w.
   - Regression test sweeps Rp ∈ {0.1, 0.5, 1.0, 2.0} dB and pins that measured ripple tracks the spec AND is monotonic in Rp.

5. **`core/audio/src/audio_thumbnail.cpp`** — Codex 3305530560 (PR #2966)
   - `load_from_disk()` trusted the .thumb file size and allocated a vector of that exact size with no upper bound. A corrupt/hostile oversized cache file could throw `std::bad_alloc` instead of being silently treated as a miss.
   - Cap at 64 MiB (~100× the largest plausible real thumbnail). Anything larger returns `nullptr` and the cache rebuilds from source.
   - Regression test creates a real cache entry, replaces the .thumb with a 128 MiB sparse file, and verifies the second load doesn't throw, returns a valid (rebuilt) thumbnail, and is NOT counted as a disk hit.

## Validation

- `pulp-test-midi-ci-pe` — 1426 assertions in 36 cases (incl. new `[issue-2959]`)
- `pulp-test-iir-design` — 153 assertions in 22 cases (incl. new `[issue-2964]`)
- `pulp-test-audio-thumbnail` — 1373+ assertions in 19 cases (incl. new `[issue-2966]`)
- `test_promote_quirk_tiers.py` — 16 tests OK
- `test_audit_top_level.py` — 12 tests OK

## Version

SDK 0.254.0 → 0.254.1 (patch, override via `Version-Bump: sdk=patch` trailer — bug-fix-only bundle, no API surface change).

Refs #2976.