### PR TITLE
feat(runtime): add AbstractFifo + FileSearchPath

### DIFF
--- a/core/runtime/include/pulp/runtime/abstract_fifo.hpp
+++ b/core/runtime/include/pulp/runtime/abstract_fifo.hpp
@@ -1,0 +1,172 @@
+#pragma once
+
+// AbstractFifo — abstract index-pair FIFO management for single-producer
+// single-consumer (SPSC) ring buffers.
+//
+// This class does NOT own a storage buffer. Instead it tracks the read and
+// write positions inside a caller-owned circular buffer (a contiguous array
+// the caller allocates separately — e.g. an `std::vector<float>` for an audio
+// sample ring, a `std::vector<uint8_t>` for a byte stream, etc.). The caller
+// uses the index ranges returned by `prepare_to_write()` / `prepare_to_read()`
+// to copy into / out of its own buffer; AbstractFifo only deals with the
+// modular arithmetic of "where to read/write next, and how many items can
+// be touched without wrapping past the producer/consumer cursor."
+//
+// Because a single linear range of items in the underlying buffer may wrap
+// around the end of the array, `prepare_to_*` returns **two** index ranges
+// (each `start` + `size`). The second range is empty (`size_2 == 0`) when
+// no wrap occurs. Callers iterate or copy both ranges in sequence.
+//
+// Lock-free for one producer thread + one consumer thread (SPSC) — the
+// reader and writer cursors are independent `std::atomic<int>` values with
+// acquire/release ordering. Multi-producer / multi-consumer usage requires
+// external synchronization.
+//
+// Usage mirrors JUCE's `AbstractFifo` — see the [Reference Framework Gap
+// Analysis](planning/2026-05-24-reference-framework-gap-analysis.md) row for
+// AbstractFifo for context. This is the "abstract index-pair" sibling to
+// `SpscQueue<T,N>` (which IS a queue + owns storage via choc FIFO) and
+// `TripleBuffer<T>` (which publishes a single latest value).
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+
+namespace pulp::runtime {
+
+class AbstractFifo {
+public:
+    /// Construct an AbstractFifo that manages indices in `[0, capacity)`.
+    /// `capacity` is the size of the caller-owned buffer in items. One slot
+    /// is reserved internally as the empty/full sentinel, so the maximum
+    /// number of items that can ever be queued is `capacity - 1`. Pick a
+    /// capacity one larger than the worst-case queue depth you need.
+    explicit AbstractFifo(int capacity) noexcept
+        : capacity_(capacity < 1 ? 1 : capacity) {}
+
+    /// Total size of the managed buffer in items.
+    int capacity() const noexcept { return capacity_; }
+
+    /// Number of items currently available to read.
+    int num_ready() const noexcept {
+        const int w = write_pos_.load(std::memory_order_acquire);
+        const int r = read_pos_.load(std::memory_order_acquire);
+        const int diff = w - r;
+        return diff >= 0 ? diff : diff + capacity_;
+    }
+
+    /// Free space (in items) available for new writes. The fifo reserves
+    /// one slot internally, so this is at most `capacity - 1`.
+    int free_space() const noexcept {
+        return capacity_ - num_ready() - 1;
+    }
+
+    /// Reset the cursors back to empty. Not thread-safe — the caller must
+    /// guarantee neither producer nor consumer is active.
+    void reset() noexcept {
+        read_pos_.store(0, std::memory_order_relaxed);
+        write_pos_.store(0, std::memory_order_relaxed);
+    }
+
+    /// Plan a write of up to `num_to_write` items. Returns two index ranges
+    /// `[start_1, start_1+size_1)` and `[start_2, start_2+size_2)` covering
+    /// contiguous regions of the caller-owned buffer that may be filled.
+    /// `size_2` is non-zero only when the write wraps past `capacity`.
+    /// The sum `size_1 + size_2` is `min(num_to_write, free_space())`.
+    /// The cursor is NOT advanced until `finish_write()` is called.
+    void prepare_to_write(int num_to_write,
+                          int& start_1, int& size_1,
+                          int& start_2, int& size_2) const noexcept {
+        const int w = write_pos_.load(std::memory_order_relaxed);
+        const int r = read_pos_.load(std::memory_order_acquire);
+        const int free = (r > w ? r - w : capacity_ - w + r) - 1;
+        const int can_write = std::min(num_to_write < 0 ? 0 : num_to_write,
+                                       free < 0 ? 0 : free);
+
+        if (can_write <= 0) {
+            start_1 = w;
+            size_1 = 0;
+            start_2 = 0;
+            size_2 = 0;
+            return;
+        }
+
+        start_1 = w;
+        const int contiguous = capacity_ - w;
+        if (can_write <= contiguous) {
+            size_1 = can_write;
+            start_2 = 0;
+            size_2 = 0;
+        } else {
+            size_1 = contiguous;
+            start_2 = 0;
+            size_2 = can_write - contiguous;
+        }
+    }
+
+    /// Advance the write cursor by `num_written` items. Must be called after
+    /// the caller has copied data into the ranges returned by
+    /// `prepare_to_write()`. Passing more than the prepared sum is a
+    /// programming error and is clamped to keep the fifo coherent.
+    void finish_write(int num_written) noexcept {
+        if (num_written <= 0) return;
+        const int w = write_pos_.load(std::memory_order_relaxed);
+        int next = w + num_written;
+        if (next >= capacity_) next -= capacity_;
+        write_pos_.store(next, std::memory_order_release);
+    }
+
+    /// Plan a read of up to `num_to_read` items. Returns two ranges the
+    /// caller may copy out of its buffer. Sum is `min(num_to_read, num_ready())`.
+    /// The cursor is NOT advanced until `finish_read()` is called.
+    void prepare_to_read(int num_to_read,
+                         int& start_1, int& size_1,
+                         int& start_2, int& size_2) const noexcept {
+        const int r = read_pos_.load(std::memory_order_relaxed);
+        const int w = write_pos_.load(std::memory_order_acquire);
+        const int available = (w >= r ? w - r : capacity_ - r + w);
+        const int can_read = std::min(num_to_read < 0 ? 0 : num_to_read,
+                                      available);
+
+        if (can_read <= 0) {
+            start_1 = r;
+            size_1 = 0;
+            start_2 = 0;
+            size_2 = 0;
+            return;
+        }
+
+        start_1 = r;
+        const int contiguous = capacity_ - r;
+        if (can_read <= contiguous) {
+            size_1 = can_read;
+            start_2 = 0;
+            size_2 = 0;
+        } else {
+            size_1 = contiguous;
+            start_2 = 0;
+            size_2 = can_read - contiguous;
+        }
+    }
+
+    /// Advance the read cursor by `num_read` items.
+    void finish_read(int num_read) noexcept {
+        if (num_read <= 0) return;
+        const int r = read_pos_.load(std::memory_order_relaxed);
+        int next = r + num_read;
+        if (next >= capacity_) next -= capacity_;
+        read_pos_.store(next, std::memory_order_release);
+    }
+
+    AbstractFifo(const AbstractFifo&) = delete;
+    AbstractFifo& operator=(const AbstractFifo&) = delete;
+    AbstractFifo(AbstractFifo&&) = delete;
+    AbstractFifo& operator=(AbstractFifo&&) = delete;
+
+private:
+    const int capacity_;
+    std::atomic<int> read_pos_{0};
+    std::atomic<int> write_pos_{0};
+};
+
+}  // namespace pulp::runtime

--- a/core/runtime/include/pulp/runtime/file_search_path.hpp
+++ b/core/runtime/include/pulp/runtime/file_search_path.hpp
@@ -1,0 +1,173 @@
+#pragma once
+
+// FileSearchPath — ordered list of directories to scan when resolving a
+// file by relative name. Mirrors the JUCE class of the same name; see the
+// [Reference Framework Gap Analysis](planning/2026-05-24-reference-framework-gap-analysis.md)
+// row for FileSearchPath.
+//
+// Typical use: a plugin needs to locate a "preset.xml" or a font file that
+// might live in any of several user-/installer-/bundle-supplied roots, and
+// wants the lookup order to be controllable (and persistable into a
+// settings file). FileSearchPath holds the ordered roots, finds the first
+// match, optionally finds all matches across all roots, and can serialize
+// to / from the platform's PATH-style separator (`:` on POSIX, `;` on
+// Windows) so it round-trips through `PropertiesFile` cleanly.
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pulp::runtime {
+
+class FileSearchPath {
+public:
+    /// Construct an empty search path.
+    FileSearchPath() = default;
+
+    /// Construct from a PATH-style serialized string. Same semantics as
+    /// `from_string()` — empty/duplicate entries are dropped.
+    explicit FileSearchPath(std::string_view serialized) {
+        from_string(serialized);
+    }
+
+    /// The platform-native PATH separator: `:` on POSIX, `;` on Windows.
+    static constexpr char separator() noexcept {
+#if defined(_WIN32) || defined(_WIN64)
+        return ';';
+#else
+        return ':';
+#endif
+    }
+
+    /// Number of directories in the search path.
+    std::size_t size() const noexcept { return paths_.size(); }
+
+    /// True when the search path contains no directories.
+    bool empty() const noexcept { return paths_.empty(); }
+
+    /// Access the path at index `i` (no bounds check beyond size()).
+    const std::filesystem::path& operator[](std::size_t i) const {
+        return paths_[i];
+    }
+
+    /// Append `dir` to the end of the search list. No-op if `dir` is
+    /// already present (preserves the existing position).
+    void add(const std::filesystem::path& dir) {
+        if (dir.empty()) return;
+        for (const auto& existing : paths_) {
+            if (existing == dir) return;
+        }
+        paths_.push_back(dir);
+    }
+
+    /// Insert `dir` at the front so it is searched before everything else.
+    /// If `dir` is already present elsewhere in the list it is moved to
+    /// the front (no duplicates).
+    void add_at_front(const std::filesystem::path& dir) {
+        if (dir.empty()) return;
+        for (auto it = paths_.begin(); it != paths_.end(); ++it) {
+            if (*it == dir) {
+                paths_.erase(it);
+                break;
+            }
+        }
+        paths_.insert(paths_.begin(), dir);
+    }
+
+    /// Remove all directories.
+    void clear() noexcept { paths_.clear(); }
+
+    /// Remove the directory at index `i`. Out-of-range index is a no-op.
+    void remove(std::size_t i) {
+        if (i < paths_.size()) {
+            paths_.erase(paths_.begin() + static_cast<std::ptrdiff_t>(i));
+        }
+    }
+
+    /// Read-only view of the directories in search order.
+    const std::vector<std::filesystem::path>& paths() const noexcept {
+        return paths_;
+    }
+
+    /// Search the path for `filename` and return the first match, or
+    /// `nullopt` if no directory contains it. `filename` is appended as a
+    /// relative path to each directory in order; the first hit that
+    /// `std::filesystem::exists()` accepts wins.
+    std::optional<std::filesystem::path> find(
+        const std::filesystem::path& filename) const {
+        if (filename.empty()) return std::nullopt;
+        std::error_code ec;
+        for (const auto& dir : paths_) {
+            auto candidate = dir / filename;
+            if (std::filesystem::exists(candidate, ec)) {
+                return candidate;
+            }
+        }
+        return std::nullopt;
+    }
+
+    /// Search the path for `filename` and return ALL matches across every
+    /// directory, in search order. Useful for overlays where later
+    /// directories shadow earlier ones and the caller wants to see both.
+    std::vector<std::filesystem::path> find_all(
+        const std::filesystem::path& filename) const {
+        std::vector<std::filesystem::path> hits;
+        if (filename.empty()) return hits;
+        std::error_code ec;
+        for (const auto& dir : paths_) {
+            auto candidate = dir / filename;
+            if (std::filesystem::exists(candidate, ec)) {
+                hits.push_back(candidate);
+            }
+        }
+        return hits;
+    }
+
+    /// Serialize the search path to a PATH-style string using `separator()`.
+    /// Round-trips through `from_string()`.
+    std::string to_string() const {
+        std::string out;
+        const char sep = separator();
+        bool first = true;
+        for (const auto& p : paths_) {
+            if (!first) out.push_back(sep);
+            out += p.string();
+            first = false;
+        }
+        return out;
+    }
+
+    /// Replace the contents of the search path with the entries parsed
+    /// from `serialized`. Splits on the platform PATH separator; empty
+    /// segments and duplicates are dropped. Existing entries are cleared
+    /// first.
+    void from_string(std::string_view serialized) {
+        paths_.clear();
+        const char sep = separator();
+        std::size_t start = 0;
+        while (start <= serialized.size()) {
+            std::size_t end = serialized.find(sep, start);
+            if (end == std::string_view::npos) end = serialized.size();
+            if (end > start) {
+                auto piece = serialized.substr(start, end - start);
+                add(std::filesystem::path(std::string(piece)));
+            }
+            if (end == serialized.size()) break;
+            start = end + 1;
+        }
+    }
+
+    bool operator==(const FileSearchPath& other) const noexcept {
+        return paths_ == other.paths_;
+    }
+    bool operator!=(const FileSearchPath& other) const noexcept {
+        return !(*this == other);
+    }
+
+private:
+    std::vector<std::filesystem::path> paths_;
+};
+
+}  // namespace pulp::runtime

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1569,6 +1569,9 @@ pulp_add_test_suite(pulp-test-runtime LIBRARIES pulp::runtime)
 # AbstractFifo (index-pair SPSC FIFO management)
 pulp_add_test_suite(pulp-test-abstract-fifo LIBRARIES pulp::runtime)
 
+# FileSearchPath (ordered directory search list)
+pulp_add_test_suite(pulp-test-file-search-path LIBRARIES pulp::runtime)
+
 # Sync-primitive hammer (TSan-focused, #412 step 4).
 # Runs under the tag-scoped TSan subset via the [concurrent][race]
 # tags embedded in each TEST_CASE (matches the 'Race|Concurrent'

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1566,6 +1566,9 @@ pulp_add_test_suite(pulp-test-environment LIBRARIES pulp::platform)
 # Runtime tests
 pulp_add_test_suite(pulp-test-runtime LIBRARIES pulp::runtime)
 
+# AbstractFifo (index-pair SPSC FIFO management)
+pulp_add_test_suite(pulp-test-abstract-fifo LIBRARIES pulp::runtime)
+
 # Sync-primitive hammer (TSan-focused, #412 step 4).
 # Runs under the tag-scoped TSan subset via the [concurrent][race]
 # tags embedded in each TEST_CASE (matches the 'Race|Concurrent'

--- a/test/test_abstract_fifo.cpp
+++ b/test/test_abstract_fifo.cpp
@@ -1,0 +1,203 @@
+// Tests for pulp::runtime::AbstractFifo — wrap-around correctness,
+// capacity/empty/full boundaries, prepare/finish contract, and an SPSC
+// hammer that drives the producer + consumer on separate threads to assert
+// every item arrives in order with no loss or duplication.
+
+#include <atomic>
+#include <catch2/catch_test_macros.hpp>
+#include <thread>
+#include <vector>
+
+#include <pulp/runtime/abstract_fifo.hpp>
+
+using pulp::runtime::AbstractFifo;
+
+namespace {
+
+// Convenience: write `count` items (values starting at `seed`) into `buf` via
+// the fifo, return how many were actually written (free space may clamp it).
+int write_via_fifo(AbstractFifo& fifo, std::vector<int>& buf,
+                   int count, int seed) {
+    int s1 = 0, n1 = 0, s2 = 0, n2 = 0;
+    fifo.prepare_to_write(count, s1, n1, s2, n2);
+    for (int i = 0; i < n1; ++i) buf[s1 + i] = seed + i;
+    for (int i = 0; i < n2; ++i) buf[s2 + i] = seed + n1 + i;
+    fifo.finish_write(n1 + n2);
+    return n1 + n2;
+}
+
+// Convenience: read up to `count` items into `out`. Returns # read.
+int read_via_fifo(AbstractFifo& fifo, const std::vector<int>& buf,
+                  std::vector<int>& out, int count) {
+    int s1 = 0, n1 = 0, s2 = 0, n2 = 0;
+    fifo.prepare_to_read(count, s1, n1, s2, n2);
+    for (int i = 0; i < n1; ++i) out.push_back(buf[s1 + i]);
+    for (int i = 0; i < n2; ++i) out.push_back(buf[s2 + i]);
+    fifo.finish_read(n1 + n2);
+    return n1 + n2;
+}
+
+}  // namespace
+
+TEST_CASE("AbstractFifo starts empty with full free_space minus reserved slot",
+          "[runtime][abstract_fifo]") {
+    AbstractFifo fifo(8);
+    REQUIRE(fifo.capacity() == 8);
+    REQUIRE(fifo.num_ready() == 0);
+    REQUIRE(fifo.free_space() == 7);  // one slot reserved as sentinel
+}
+
+TEST_CASE("AbstractFifo prepare_to_write within contiguous range",
+          "[runtime][abstract_fifo]") {
+    AbstractFifo fifo(8);
+    int s1 = -1, n1 = -1, s2 = -1, n2 = -1;
+    fifo.prepare_to_write(3, s1, n1, s2, n2);
+    REQUIRE(s1 == 0);
+    REQUIRE(n1 == 3);
+    REQUIRE(n2 == 0);
+}
+
+TEST_CASE("AbstractFifo prepare_to_write wraps around the buffer end",
+          "[runtime][abstract_fifo]") {
+    AbstractFifo fifo(8);
+    std::vector<int> buf(8, 0);
+
+    // Push the write cursor to position 6, then drain reads so free space
+    // is the full capacity-1 again but the write cursor is at offset 6.
+    REQUIRE(write_via_fifo(fifo, buf, 6, 1000) == 6);
+    std::vector<int> out;
+    REQUIRE(read_via_fifo(fifo, buf, out, 6) == 6);
+    REQUIRE(fifo.num_ready() == 0);
+    REQUIRE(fifo.free_space() == 7);
+
+    int s1 = -1, n1 = -1, s2 = -1, n2 = -1;
+    fifo.prepare_to_write(5, s1, n1, s2, n2);
+    REQUIRE(s1 == 6);
+    REQUIRE(n1 == 2);   // slots 6, 7
+    REQUIRE(s2 == 0);
+    REQUIRE(n2 == 3);   // wraps to 0, 1, 2
+}
+
+TEST_CASE("AbstractFifo full state clamps writes to zero",
+          "[runtime][abstract_fifo]") {
+    AbstractFifo fifo(4);
+    std::vector<int> buf(4, 0);
+    REQUIRE(write_via_fifo(fifo, buf, 3, 100) == 3);
+    REQUIRE(fifo.num_ready() == 3);
+    REQUIRE(fifo.free_space() == 0);
+
+    int s1 = -1, n1 = -1, s2 = -1, n2 = -1;
+    fifo.prepare_to_write(2, s1, n1, s2, n2);
+    REQUIRE(n1 == 0);
+    REQUIRE(n2 == 0);
+}
+
+TEST_CASE("AbstractFifo prepare_to_write clamps overshoot to free_space",
+          "[runtime][abstract_fifo]") {
+    AbstractFifo fifo(8);
+    std::vector<int> buf(8, 0);
+    REQUIRE(write_via_fifo(fifo, buf, 100, 0) == 7);  // capacity-1
+}
+
+TEST_CASE("AbstractFifo empty state clamps reads to zero",
+          "[runtime][abstract_fifo]") {
+    AbstractFifo fifo(8);
+    int s1 = -1, n1 = -1, s2 = -1, n2 = -1;
+    fifo.prepare_to_read(4, s1, n1, s2, n2);
+    REQUIRE(n1 == 0);
+    REQUIRE(n2 == 0);
+}
+
+TEST_CASE("AbstractFifo write+read round-trip preserves order across a wrap",
+          "[runtime][abstract_fifo]") {
+    AbstractFifo fifo(6);
+    std::vector<int> buf(6, 0);
+    std::vector<int> out;
+
+    // Write 5, read 5 — cursors now both at 5.
+    REQUIRE(write_via_fifo(fifo, buf, 5, 10) == 5);
+    REQUIRE(read_via_fifo(fifo, buf, out, 5) == 5);
+
+    // Write 4 more — this MUST wrap (only 1 slot at the tail).
+    REQUIRE(write_via_fifo(fifo, buf, 4, 100) == 4);
+    REQUIRE(fifo.num_ready() == 4);
+
+    out.clear();
+    REQUIRE(read_via_fifo(fifo, buf, out, 4) == 4);
+    REQUIRE(out == std::vector<int>{100, 101, 102, 103});
+}
+
+TEST_CASE("AbstractFifo finish_* with non-positive args is a no-op",
+          "[runtime][abstract_fifo]") {
+    AbstractFifo fifo(4);
+    fifo.finish_write(0);
+    fifo.finish_write(-5);
+    fifo.finish_read(0);
+    fifo.finish_read(-5);
+    REQUIRE(fifo.num_ready() == 0);
+    REQUIRE(fifo.free_space() == 3);
+}
+
+TEST_CASE("AbstractFifo reset returns cursors to zero",
+          "[runtime][abstract_fifo]") {
+    AbstractFifo fifo(8);
+    std::vector<int> buf(8, 0);
+    REQUIRE(write_via_fifo(fifo, buf, 4, 1) == 4);
+    REQUIRE(fifo.num_ready() == 4);
+    fifo.reset();
+    REQUIRE(fifo.num_ready() == 0);
+    REQUIRE(fifo.free_space() == 7);
+}
+
+TEST_CASE("AbstractFifo SPSC hammer — one producer, one consumer",
+          "[runtime][abstract_fifo][hammer]") {
+    constexpr int kCapacity = 64;
+    constexpr int kTotal = 200'000;
+
+    AbstractFifo fifo(kCapacity);
+    std::vector<int> buf(kCapacity, 0);
+    std::atomic<bool> producer_done{false};
+
+    std::vector<int> consumed;
+    consumed.reserve(kTotal);
+
+    std::thread producer([&] {
+        int sent = 0;
+        while (sent < kTotal) {
+            const int want = std::min(17, kTotal - sent);  // odd chunk → forces wraps
+            int s1 = 0, n1 = 0, s2 = 0, n2 = 0;
+            fifo.prepare_to_write(want, s1, n1, s2, n2);
+            for (int i = 0; i < n1; ++i) buf[s1 + i] = sent + i;
+            for (int i = 0; i < n2; ++i) buf[s2 + i] = sent + n1 + i;
+            fifo.finish_write(n1 + n2);
+            sent += n1 + n2;
+            if (n1 + n2 == 0) std::this_thread::yield();
+        }
+        producer_done.store(true, std::memory_order_release);
+    });
+
+    std::thread consumer([&] {
+        while (true) {
+            int s1 = 0, n1 = 0, s2 = 0, n2 = 0;
+            fifo.prepare_to_read(23, s1, n1, s2, n2);  // different chunk → tests both wrap sides
+            for (int i = 0; i < n1; ++i) consumed.push_back(buf[s1 + i]);
+            for (int i = 0; i < n2; ++i) consumed.push_back(buf[s2 + i]);
+            fifo.finish_read(n1 + n2);
+            if (n1 + n2 == 0) {
+                if (producer_done.load(std::memory_order_acquire)
+                    && fifo.num_ready() == 0) {
+                    break;
+                }
+                std::this_thread::yield();
+            }
+        }
+    });
+
+    producer.join();
+    consumer.join();
+
+    REQUIRE(static_cast<int>(consumed.size()) == kTotal);
+    for (int i = 0; i < kTotal; ++i) {
+        REQUIRE(consumed[i] == i);
+    }
+}

--- a/test/test_file_search_path.cpp
+++ b/test/test_file_search_path.cpp
@@ -1,0 +1,209 @@
+// Tests for pulp::runtime::FileSearchPath — ordered search semantics,
+// duplicate suppression, find vs. find_all, and PATH-style serialization
+// round-trip.
+
+#include <atomic>
+#include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include <pulp/runtime/file_search_path.hpp>
+
+using pulp::runtime::FileSearchPath;
+namespace fs = std::filesystem;
+
+namespace {
+
+// Create a unique scratch dir under temp_directory_path/<token>/ and ensure
+// it is removed at scope exit.
+struct ScratchDir {
+    fs::path root;
+
+    explicit ScratchDir(const std::string& token) {
+        static std::atomic<unsigned> counter{0};
+        const auto stamp =
+            std::chrono::steady_clock::now().time_since_epoch().count();
+        root = fs::temp_directory_path()
+             / ("pulp-file-search-path-test-" + token + "-"
+                + std::to_string(stamp) + "-"
+                + std::to_string(counter.fetch_add(1)));
+        fs::create_directories(root);
+    }
+
+    ~ScratchDir() {
+        std::error_code ec;
+        fs::remove_all(root, ec);
+    }
+
+    fs::path mkdir(const std::string& name) {
+        auto p = root / name;
+        fs::create_directories(p);
+        return p;
+    }
+
+    void touch(const fs::path& p) {
+        std::ofstream(p) << "x";
+    }
+};
+
+}  // namespace
+
+TEST_CASE("FileSearchPath starts empty", "[runtime][file_search_path]") {
+    FileSearchPath path;
+    REQUIRE(path.empty());
+    REQUIRE(path.size() == 0);
+    REQUIRE_FALSE(path.find("anything.txt").has_value());
+    REQUIRE(path.find_all("anything.txt").empty());
+}
+
+TEST_CASE("FileSearchPath add appends and dedupes",
+          "[runtime][file_search_path]") {
+    FileSearchPath path;
+    path.add("/a");
+    path.add("/b");
+    path.add("/a");  // duplicate — must not append
+    REQUIRE(path.size() == 2);
+    REQUIRE(path[0] == fs::path("/a"));
+    REQUIRE(path[1] == fs::path("/b"));
+}
+
+TEST_CASE("FileSearchPath add_at_front moves existing entry to front",
+          "[runtime][file_search_path]") {
+    FileSearchPath path;
+    path.add("/a");
+    path.add("/b");
+    path.add("/c");
+    path.add_at_front("/c");  // move /c to front
+    REQUIRE(path.size() == 3);
+    REQUIRE(path[0] == fs::path("/c"));
+    REQUIRE(path[1] == fs::path("/a"));
+    REQUIRE(path[2] == fs::path("/b"));
+
+    path.add_at_front("/d");  // brand-new entry at front
+    REQUIRE(path.size() == 4);
+    REQUIRE(path[0] == fs::path("/d"));
+}
+
+TEST_CASE("FileSearchPath remove drops indexed entry, OOB no-op",
+          "[runtime][file_search_path]") {
+    FileSearchPath path;
+    path.add("/a");
+    path.add("/b");
+    path.add("/c");
+    path.remove(1);
+    REQUIRE(path.size() == 2);
+    REQUIRE(path[0] == fs::path("/a"));
+    REQUIRE(path[1] == fs::path("/c"));
+    path.remove(99);  // OOB — no-op
+    REQUIRE(path.size() == 2);
+}
+
+TEST_CASE("FileSearchPath find returns first match in search order",
+          "[runtime][file_search_path]") {
+    ScratchDir scratch("find");
+    auto d1 = scratch.mkdir("d1");
+    auto d2 = scratch.mkdir("d2");
+    auto d3 = scratch.mkdir("d3");
+    // Only d2 and d3 hold the target.
+    scratch.touch(d2 / "preset.xml");
+    scratch.touch(d3 / "preset.xml");
+
+    FileSearchPath path;
+    path.add(d1);
+    path.add(d2);
+    path.add(d3);
+
+    auto hit = path.find("preset.xml");
+    REQUIRE(hit.has_value());
+    REQUIRE(*hit == d2 / "preset.xml");
+}
+
+TEST_CASE("FileSearchPath find returns nullopt when filename missing",
+          "[runtime][file_search_path]") {
+    ScratchDir scratch("miss");
+    auto d1 = scratch.mkdir("d1");
+    auto d2 = scratch.mkdir("d2");
+
+    FileSearchPath path;
+    path.add(d1);
+    path.add(d2);
+
+    REQUIRE_FALSE(path.find("nope.xml").has_value());
+    REQUIRE_FALSE(path.find("").has_value());
+}
+
+TEST_CASE("FileSearchPath find_all returns every match across roots in order",
+          "[runtime][file_search_path]") {
+    ScratchDir scratch("findall");
+    auto a = scratch.mkdir("a");
+    auto b = scratch.mkdir("b");
+    auto c = scratch.mkdir("c");
+    scratch.touch(a / "font.ttf");
+    // intentionally NOT b/font.ttf
+    scratch.touch(c / "font.ttf");
+
+    FileSearchPath path;
+    path.add(a);
+    path.add(b);
+    path.add(c);
+
+    auto hits = path.find_all("font.ttf");
+    REQUIRE(hits.size() == 2);
+    REQUIRE(hits[0] == a / "font.ttf");
+    REQUIRE(hits[1] == c / "font.ttf");
+}
+
+TEST_CASE("FileSearchPath serializes with platform separator and round-trips",
+          "[runtime][file_search_path]") {
+    const char sep = FileSearchPath::separator();
+#if defined(_WIN32) || defined(_WIN64)
+    REQUIRE(sep == ';');
+#else
+    REQUIRE(sep == ':');
+#endif
+
+    FileSearchPath path;
+    path.add("/usr/local/share");
+    path.add("/opt/pulp/presets");
+
+    const std::string serialized = path.to_string();
+    const std::string expected =
+        std::string("/usr/local/share") + sep + "/opt/pulp/presets";
+    REQUIRE(serialized == expected);
+
+    FileSearchPath round_trip(serialized);
+    REQUIRE(round_trip == path);
+}
+
+TEST_CASE("FileSearchPath from_string drops empty segments and duplicates",
+          "[runtime][file_search_path]") {
+    const char sep = FileSearchPath::separator();
+    // Build: "<sep>/a<sep><sep>/b<sep>/a<sep>"
+    std::string s;
+    s += sep;
+    s += "/a";
+    s += sep;
+    s += sep;
+    s += "/b";
+    s += sep;
+    s += "/a";  // duplicate
+    s += sep;
+
+    FileSearchPath path;
+    path.from_string(s);
+    REQUIRE(path.size() == 2);
+    REQUIRE(path[0] == fs::path("/a"));
+    REQUIRE(path[1] == fs::path("/b"));
+}
+
+TEST_CASE("FileSearchPath clear empties the list",
+          "[runtime][file_search_path]") {
+    FileSearchPath path;
+    path.add("/a");
+    path.add("/b");
+    path.clear();
+    REQUIRE(path.empty());
+    REQUIRE(path.to_string().empty());
+}


### PR DESCRIPTION
## Summary

Two header-only runtime utilities from the Reference Framework Gap Analysis runtime sweep (`planning/2026-05-24-reference-framework-gap-analysis.md`).

- **`pulp::runtime::AbstractFifo`** (`core/runtime/include/pulp/runtime/abstract_fifo.hpp`) — lock-free SPSC index-pair manager for a caller-owned circular buffer. API mirrors the reference framework: `prepare_to_write(n, &s1, &n1, &s2, &n2)` returns the two ranges to handle the wrap, `finish_write(n)` advances. Mirrored read side. `num_ready`, `free_space`, `reset`. One slot reserved as empty/full sentinel.
- **`pulp::runtime::FileSearchPath`** (`core/runtime/include/pulp/runtime/file_search_path.hpp`) — ordered directory list with `add` (dedup), `add_at_front` (move-to-front semantics), `find` (first match), `find_all` (every match in search order), and platform PATH-style `to_string` / `from_string` (`:` POSIX, `;` Windows) for `PropertiesFile` round-trip.

Both ship in independent feat commits. Tests use the standard `pulp_add_test_suite` helper.

## Test plan

- [x] `pulp-test-abstract-fifo` — 10 cases, 200,035 assertions. Covers empty/full boundaries, prepare/finish contract, wrap-around, reset, no-op finish_* on non-positive args, and a 200k-item two-thread SPSC hammer with odd chunk sizes that force wraps on both sides.
- [x] `pulp-test-file-search-path` — 10 cases, 32 assertions. Covers empty state, add dedup, add_at_front move semantics, remove (incl. OOB no-op), ordered find, find_all across multiple roots, missing-file nullopt, platform separator, from_string drops empties + duplicates, to_string ⇄ from_string round-trip.
- [x] Both built clean against Release + GPU off on macOS arm64.

Closes the AbstractFifo and FileSearchPath rows of the gap doc (planning/main `1f6d813`).