### PR TITLE
feat(view): add PreferencesPanel + TooltipWindow + ComponentDragger widgets (gap-doc P2/P3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.255.3
+    VERSION 0.256.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/component_dragger.hpp
+++ b/core/view/include/pulp/view/component_dragger.hpp
@@ -1,0 +1,115 @@
+#pragma once
+
+/// @file component_dragger.hpp
+/// ComponentDragger — drag-to-move helper for any View
+/// (closes the gap-doc P2 row "Drag & drop ComponentDragger utility").
+///
+/// A `ComponentDragger` adds "click and drag to move me within my parent"
+/// behavior to any `View`. It is intentionally a free helper (not a mixin)
+/// so that owners stay in control of which mouse phases get forwarded.
+///
+/// Usage:
+/// @code
+///   ComponentDragger dragger;
+///   class DraggableBox : public View {
+///       ComponentDragger dragger;
+///   public:
+///       void on_mouse_event(const MouseEvent& e) override {
+///           if (e.isPress())   dragger.start_dragging(*this, e.position);
+///           else if (e.isDrag()) dragger.drag_view(*this, e.position);
+///       }
+///   };
+/// @endcode
+///
+/// `start_dragging()` snapshots the drag origin (in the dragged view's
+/// local coordinates) plus the view's bounds at gesture start.
+/// `drag_view()` translates the bounds by the delta between the current
+/// pointer position and that snapshot, optionally constraining the new
+/// origin so the view stays inside its parent's local bounds.
+///
+/// Headless-friendly: no window host, no scheduler. Pure arithmetic over
+/// the dragged view's bounds; tests can call `start_dragging` /
+/// `drag_view` directly without simulating real mouse events.
+///
+/// License-lineage note: the name is Pulp-native per the gap-doc rule —
+/// the behavior mirrors a well-trodden idiom across UI toolkits, but the
+/// implementation here is independent.
+
+#include <algorithm>
+#include <pulp/view/geometry.hpp>
+#include <pulp/view/view.hpp>
+
+namespace pulp::view {
+
+class ComponentDragger {
+public:
+    ComponentDragger() = default;
+
+    /// Begin a drag gesture. `mouse_local` is the press position in the
+    /// dragged view's LOCAL coordinate space (i.e. the same `pos` value
+    /// you'd hand to `View::on_mouse_down`).
+    void start_dragging(View& view, Point mouse_local) {
+        mouse_start_ = mouse_local;
+        bounds_start_ = view.bounds();
+        active_ = true;
+    }
+
+    /// Continue a drag gesture. Moves the view's bounds so the press
+    /// position stays under the cursor. Honors `constrain_to_parent()`.
+    /// No-op when not currently dragging.
+    void drag_view(View& view, Point mouse_local) {
+        if (!active_) return;
+        const Point delta{mouse_local.x - mouse_start_.x,
+                          mouse_local.y - mouse_start_.y};
+        Rect target = bounds_start_;
+        target.x += delta.x;
+        target.y += delta.y;
+
+        if (constrain_to_parent_) {
+            if (auto* p = view.parent()) {
+                const Rect parent_local = p->local_bounds();
+                target.x = std::clamp(target.x,
+                                      parent_local.x,
+                                      std::max(parent_local.x,
+                                               parent_local.right() - target.width));
+                target.y = std::clamp(target.y,
+                                      parent_local.y,
+                                      std::max(parent_local.y,
+                                               parent_local.bottom() - target.height));
+            }
+        }
+        view.set_bounds(target);
+        if (on_drag) on_drag(target);
+    }
+
+    /// End the gesture. Subsequent `drag_view` calls become no-ops until
+    /// the next `start_dragging`.
+    void end_dragging() {
+        active_ = false;
+        if (on_end) on_end();
+    }
+
+    /// When true (the default), `drag_view` clamps the dragged view's
+    /// origin so it stays fully inside the parent's local bounds.
+    void set_constrain_to_parent(bool yes) { constrain_to_parent_ = yes; }
+    bool constrain_to_parent() const { return constrain_to_parent_; }
+
+    bool is_dragging() const { return active_; }
+
+    /// Mouse-local press position captured at `start_dragging`.
+    Point mouse_start() const { return mouse_start_; }
+    /// Dragged view's bounds captured at `start_dragging`.
+    Rect bounds_start() const { return bounds_start_; }
+
+    /// Optional callbacks for tests / app glue.
+    std::function<void(Rect)> on_drag;
+    std::function<void()> on_end;
+
+private:
+    bool active_ = false;
+    bool constrain_to_parent_ = true;
+    Point mouse_start_{};
+    Rect bounds_start_{};
+};
+
+} // namespace pulp::view

--- a/core/view/include/pulp/view/preferences_panel.hpp
+++ b/core/view/include/pulp/view/preferences_panel.hpp
@@ -1,0 +1,173 @@
+#pragma once
+
+/// @file preferences_panel.hpp
+/// PreferencesPanel — sidebar-of-pages container for app preferences
+/// (closes the gap-doc P3 row "PreferencesPanel").
+///
+/// `PreferencesPanel` is a `View` subclass that hosts a sidebar of named
+/// "pages". Each page is a (title, icon, content) tuple; the panel
+/// shows the sidebar entries on the left and the active page's content
+/// view filling the rest. Setting the active page is one of:
+///   - `set_active_page(index)` — programmatic switch.
+///   - `set_active_page(title)` — switch by title (no-op if not found).
+///   - clicking a sidebar row (drives the same switch via the host's
+///     mouse routing; tests can call `simulate_select(index)` instead).
+///
+/// **Persistence**: a `PreferencesPanel` can be bound to a
+/// `pulp::state::PropertiesFile` (typically the user lane of
+/// `ApplicationProperties`) so the last-selected page survives
+/// across runs. The persistence key defaults to
+/// `"preferences.active_page"` and is configurable via
+/// `set_persistence_key`. `bind_persistence()` does a one-shot read
+/// of the stored title and selects the matching page (no-op if the
+/// page is gone). Subsequent `set_active_page` calls write back.
+///
+/// Headless-friendly: pages register `View` content but `PreferencesPanel`
+/// never paints in tests — it just owns the registry + active-index state.
+///
+/// License-lineage note: the name is Pulp-native per the gap-doc rule.
+
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <pulp/state/properties_file.hpp>
+#include <pulp/view/view.hpp>
+
+namespace pulp::view {
+
+class PreferencesPanel : public View {
+public:
+    struct Page {
+        std::string title;
+        std::string icon;    ///< Icon glyph / asset id; opaque to the panel.
+        View* content = nullptr;  ///< Non-owning — actual ownership is in
+                                  ///  the View tree (children_), so the
+                                  ///  page entry just remembers the slot.
+    };
+
+    PreferencesPanel() = default;
+
+    // ── Page registry ────────────────────────────────────────────────
+
+    /// Register a new page. The first registered page becomes active
+    /// unless an explicit `set_active_page` runs first. `content` is
+    /// added as a child of the panel so its layout/paint are wired
+    /// through the standard View tree.
+    void add_page(std::string title,
+                  std::string icon,
+                  std::unique_ptr<View> content) {
+        auto* content_raw = content.get();
+        // First page must establish active_=0; later pages stay hidden.
+        if (!pages_.empty()) {
+            content_raw->set_visible(false);
+        }
+        add_child(std::move(content));
+        pages_.push_back({std::move(title), std::move(icon), content_raw});
+        if (pages_.size() == 1) {
+            active_ = 0;
+            notify_change();
+        }
+    }
+
+    size_t page_count() const { return pages_.size(); }
+
+    /// Returns nullptr if `index` is out of range. The returned View*
+    /// is owned by the panel (added as a child).
+    View* page_content(size_t index) const {
+        return index < pages_.size() ? pages_[index].content : nullptr;
+    }
+    const std::string& page_title(size_t index) const {
+        return index < pages_.size() ? pages_[index].title : empty_string();
+    }
+    const std::string& page_icon(size_t index) const {
+        return index < pages_.size() ? pages_[index].icon : empty_string();
+    }
+
+    // ── Active page ──────────────────────────────────────────────────
+
+    int active_page() const { return active_; }
+    std::string active_page_title() const {
+        return (active_ >= 0 && static_cast<size_t>(active_) < pages_.size())
+                   ? pages_[static_cast<size_t>(active_)].title
+                   : std::string{};
+    }
+
+    /// Switch by index. No-op when out of range.
+    void set_active_page(int index) {
+        if (index < 0 || static_cast<size_t>(index) >= pages_.size()) return;
+        if (index == active_) return;
+        // Hide previous, show new.
+        if (active_ >= 0 && static_cast<size_t>(active_) < pages_.size()) {
+            if (auto* v = pages_[static_cast<size_t>(active_)].content) v->set_visible(false);
+        }
+        active_ = index;
+        if (auto* v = pages_[static_cast<size_t>(active_)].content) v->set_visible(true);
+        persist_active();
+        notify_change();
+    }
+
+    /// Switch by title. Returns true if a matching page was found.
+    bool set_active_page(std::string_view title) {
+        for (size_t i = 0; i < pages_.size(); ++i) {
+            if (pages_[i].title == title) {
+                set_active_page(static_cast<int>(i));
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// Test helper — mirrors what a sidebar click would do.
+    void simulate_select(int index) { set_active_page(index); }
+
+    // ── Persistence ──────────────────────────────────────────────────
+
+    /// Bind to a JSON-backed `PropertiesFile` (typically
+    /// `ApplicationProperties::user_settings()`). One-shot read of the
+    /// stored page title selects it now if present; subsequent
+    /// selections write back under `persistence_key()`.
+    void bind_persistence(pulp::state::PropertiesFile* props) {
+        props_ = props;
+        if (!props_) return;
+        if (auto stored = props_->get_string(persistence_key_)) {
+            set_active_page(*stored);
+        }
+    }
+    /// Detach from persistence without touching the store.
+    void clear_persistence() { props_ = nullptr; }
+    bool has_persistence() const { return props_ != nullptr; }
+
+    void set_persistence_key(std::string key) {
+        persistence_key_ = std::move(key);
+    }
+    const std::string& persistence_key() const { return persistence_key_; }
+
+    // ── Observers ────────────────────────────────────────────────────
+
+    std::function<void(int active_index)> on_page_change;
+
+private:
+    void persist_active() const {
+        if (!props_) return;
+        if (active_ < 0 || static_cast<size_t>(active_) >= pages_.size()) return;
+        props_->set_string(persistence_key_, pages_[static_cast<size_t>(active_)].title);
+    }
+    void notify_change() {
+        if (on_page_change) on_page_change(active_);
+    }
+    static const std::string& empty_string() {
+        static const std::string s;
+        return s;
+    }
+
+    std::vector<Page> pages_;                 ///< title + icon + non-owning content view ptr.
+    int active_ = -1;
+    pulp::state::PropertiesFile* props_ = nullptr;
+    std::string persistence_key_ = "preferences.active_page";
+};
+
+} // namespace pulp::view

--- a/core/view/include/pulp/view/tooltip_window.hpp
+++ b/core/view/include/pulp/view/tooltip_window.hpp
@@ -1,0 +1,211 @@
+#pragma once
+
+/// @file tooltip_window.hpp
+/// TooltipWindow — transient floating tooltip near the cursor
+/// (closes the gap-doc P2 row "TooltipWindow").
+///
+/// A `TooltipWindow` is a tiny stateful holder that drives a tooltip
+/// "popup" near a pointer:
+///   - `show(text, anchor)` — start a hover-delay timer; once elapsed
+///     the tooltip is `visible()` and `position()` is anchored to the
+///     last `anchor`. Fade-in honors `MotionPreferences` via
+///     `ValueAnimation` (motion off → snap to full opacity).
+///   - `move_to(anchor)` — update the anchor position while the
+///     tooltip is already showing (mouse moved within the same hover).
+///   - `hide()` — fade out; once elapsed the tooltip is no longer
+///     visible.
+///   - `tick(dt)` — drives the hover-delay timer + auto-hide timer +
+///     fade animations. Headless tests can call this directly.
+///
+/// The "window" half of the name is conceptual — `TooltipWindow` does
+/// not own an OS window. It owns the *state* of a floating tooltip
+/// that a host (the editor's overlay layer, a window manager, a
+/// design-tool inspector) is free to render however it likes. Hosts
+/// observe `visible()`, `opacity()`, `position()`, and `text()` and
+/// paint accordingly.
+///
+/// Headless-friendly: no scheduler, no OS coupling. Everything time-
+/// related is driven by `tick(dt)`, so unit tests can drain timers
+/// without sleeping.
+///
+/// License-lineage note: the name is Pulp-native per the gap-doc rule.
+
+#include <algorithm>
+#include <functional>
+#include <string>
+#include <pulp/view/animation.hpp>
+#include <pulp/view/geometry.hpp>
+#include <pulp/view/motion_preferences.hpp>
+
+namespace pulp::view {
+
+class TooltipWindow {
+public:
+    enum class Phase {
+        idle,        ///< Nothing showing, no pending show.
+        pending,     ///< Hover-delay timer running, not yet visible.
+        showing,     ///< Visible (possibly still fading in).
+        hiding,      ///< Fade-out in progress.
+    };
+
+    TooltipWindow() = default;
+
+    /// Begin showing a tooltip near `anchor`. Anchor is in whatever
+    /// coordinate space the host wants (typically window-local or
+    /// screen-local — `TooltipWindow` stores it verbatim).
+    ///
+    /// The tooltip is not immediately visible: it waits `hover_delay()`
+    /// seconds (default 0.6s) before fading in. Calling `show()` again
+    /// with the same `anchor` is a no-op; calling it with a different
+    /// `anchor` while pending resets the timer; calling it while
+    /// already showing updates the anchor (`move_to` behavior).
+    void show(std::string text, Point anchor) {
+        last_anchor_ = anchor;
+        if (phase_ == Phase::showing || phase_ == Phase::hiding) {
+            // Already up — replace text + anchor and re-anchor.
+            text_ = std::move(text);
+            position_ = compute_position(anchor);
+            if (phase_ == Phase::hiding) {
+                phase_ = Phase::showing;
+                opacity_.animate_to(1.0f, fade_duration_);
+                elapsed_visible_ = 0;
+            }
+            return;
+        }
+        text_ = std::move(text);
+        position_ = compute_position(anchor);
+        elapsed_pending_ = 0;
+        elapsed_visible_ = 0;
+        phase_ = Phase::pending;
+    }
+
+    /// Update the anchor position. Useful while the pointer is moving
+    /// over the same target — the tooltip follows it. No-op when idle.
+    void move_to(Point anchor) {
+        last_anchor_ = anchor;
+        if (phase_ == Phase::idle) return;
+        position_ = compute_position(anchor);
+    }
+
+    /// Begin fade-out. No-op when already idle/hiding. From `pending`
+    /// (never appeared) jumps straight to idle without a fade.
+    void hide() {
+        if (phase_ == Phase::idle || phase_ == Phase::hiding) return;
+        if (phase_ == Phase::pending) {
+            phase_ = Phase::idle;
+            elapsed_pending_ = 0;
+            return;
+        }
+        opacity_.animate_to(0.0f, fade_duration_);
+        phase_ = Phase::hiding;
+    }
+
+    /// Cancel any pending hover-delay without showing. Cheap "user
+    /// moved off the target before the tooltip appeared" path.
+    void cancel_pending() {
+        if (phase_ == Phase::pending) {
+            phase_ = Phase::idle;
+            elapsed_pending_ = 0;
+        }
+    }
+
+    /// Advance time. Drives hover-delay, fade animations, and
+    /// auto-hide. Returns true while any work remains (delay running,
+    /// animation running, or visible+auto_hide armed).
+    bool tick(float dt) {
+        switch (phase_) {
+            case Phase::idle:
+                return false;
+
+            case Phase::pending:
+                elapsed_pending_ += dt;
+                if (elapsed_pending_ >= hover_delay_) {
+                    phase_ = Phase::showing;
+                    opacity_.set(0.0f);
+                    opacity_.animate_to(1.0f, fade_duration_);
+                    elapsed_visible_ = 0;
+                }
+                return true;
+
+            case Phase::showing:
+                opacity_.advance(dt);
+                elapsed_visible_ += dt;
+                if (auto_hide_ > 0 && elapsed_visible_ >= auto_hide_) {
+                    hide();
+                }
+                return opacity_.animating() || (auto_hide_ > 0);
+
+            case Phase::hiding:
+                opacity_.advance(dt);
+                if (!opacity_.animating()) {
+                    phase_ = Phase::idle;
+                    return false;
+                }
+                return true;
+        }
+        return false;
+    }
+
+    // ── State accessors ──────────────────────────────────────────────
+
+    /// True once the tooltip is past the hover-delay (showing or
+    /// hiding). Hosts should paint when this is true and opacity > 0.
+    bool visible() const {
+        return phase_ == Phase::showing || phase_ == Phase::hiding;
+    }
+    bool pending() const { return phase_ == Phase::pending; }
+    Phase phase() const { return phase_; }
+
+    float opacity() const { return opacity_.value(); }
+    Point position() const { return position_; }
+    const std::string& text() const { return text_; }
+    Point last_anchor() const { return last_anchor_; }
+
+    // ── Configuration ────────────────────────────────────────────────
+
+    /// Time in seconds the pointer must hover before the tooltip
+    /// appears. Default 0.6s.
+    void set_hover_delay(float seconds) { hover_delay_ = std::max(0.0f, seconds); }
+    float hover_delay() const { return hover_delay_; }
+
+    /// Fade-in / fade-out duration in seconds. Honored by
+    /// `MotionPreferences` via the embedded `ValueAnimation`. Default
+    /// 0.12s.
+    void set_fade_duration(float seconds) { fade_duration_ = std::max(0.0f, seconds); }
+    float fade_duration() const { return fade_duration_; }
+
+    /// When > 0, the tooltip auto-hides this many seconds after it
+    /// becomes visible. Default 0 (no auto-hide; the caller drives
+    /// `hide()` on mouse-leave).
+    void set_auto_hide(float seconds) { auto_hide_ = std::max(0.0f, seconds); }
+    float auto_hide() const { return auto_hide_; }
+
+    /// Pixel offset applied to `anchor` when computing the tooltip's
+    /// rendered position. Default (12, 18) — below + right of cursor.
+    void set_cursor_offset(Point offset) { cursor_offset_ = offset; }
+    Point cursor_offset() const { return cursor_offset_; }
+
+    /// Optional observer fired on every phase transition.
+    std::function<void(Phase)> on_phase_change;
+
+private:
+    Point compute_position(Point anchor) const {
+        return {anchor.x + cursor_offset_.x, anchor.y + cursor_offset_.y};
+    }
+
+    Phase phase_ = Phase::idle;
+    std::string text_;
+    Point last_anchor_{};
+    Point position_{};
+
+    float hover_delay_ = 0.6f;
+    float fade_duration_ = 0.12f;
+    float auto_hide_ = 0.0f;
+    Point cursor_offset_{12, 18};
+
+    float elapsed_pending_ = 0;
+    float elapsed_visible_ = 0;
+    ValueAnimation opacity_{0.0f};
+};
+
+} // namespace pulp::view

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2764,6 +2764,9 @@ pulp_add_test_suite(pulp-test-component-dragger LIBRARIES pulp::view)
 # TooltipWindow — transient floating tooltip near cursor (gap-doc P2)
 pulp_add_test_suite(pulp-test-tooltip-window LIBRARIES pulp::view)
 
+# PreferencesPanel — sidebar-of-pages container (gap-doc P3)
+pulp_add_test_suite(pulp-test-preferences-panel LIBRARIES pulp::view)
+
 # UI components tests (ComboBox, TabPanel, ListBox, ScrollView, Tooltip, ProgressBar, CallOutBox)
 pulp_add_test_suite(pulp-test-ui-components LIBRARIES pulp::view)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2758,6 +2758,9 @@ pulp_add_test_suite(pulp-test-web-compat-overlay LIBRARIES pulp::view)
 # Panel widget tests (styled containers)
 pulp_add_test_suite(pulp-test-panel LIBRARIES pulp::view)
 
+# ComponentDragger — drag-to-move helper for any View (gap-doc P2)
+pulp_add_test_suite(pulp-test-component-dragger LIBRARIES pulp::view)
+
 # UI components tests (ComboBox, TabPanel, ListBox, ScrollView, Tooltip, ProgressBar, CallOutBox)
 pulp_add_test_suite(pulp-test-ui-components LIBRARIES pulp::view)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2761,6 +2761,9 @@ pulp_add_test_suite(pulp-test-panel LIBRARIES pulp::view)
 # ComponentDragger — drag-to-move helper for any View (gap-doc P2)
 pulp_add_test_suite(pulp-test-component-dragger LIBRARIES pulp::view)
 
+# TooltipWindow — transient floating tooltip near cursor (gap-doc P2)
+pulp_add_test_suite(pulp-test-tooltip-window LIBRARIES pulp::view)
+
 # UI components tests (ComboBox, TabPanel, ListBox, ScrollView, Tooltip, ProgressBar, CallOutBox)
 pulp_add_test_suite(pulp-test-ui-components LIBRARIES pulp::view)
 

--- a/test/test_component_dragger.cpp
+++ b/test/test_component_dragger.cpp
@@ -1,0 +1,152 @@
+// ComponentDragger drag-to-move helper tests
+// (closes the gap-doc P2 row "Drag & drop ComponentDragger utility").
+//
+// Validates the snapshot + translate contract:
+//   - start_dragging snapshots mouse origin + view bounds,
+//   - drag_view translates the bounds by the cursor delta,
+//   - end_dragging makes subsequent drag_view a no-op,
+//   - constrain_to_parent (default on) clamps inside the parent's local bounds,
+//   - constrain_to_parent off lets the view escape its parent.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <memory>
+#include <pulp/view/component_dragger.hpp>
+#include <pulp/view/view.hpp>
+
+using namespace pulp::view;
+
+namespace {
+// Minimal concrete View for the harness — View is abstract-friendly but
+// not abstract; we just need an instantiable subclass to set bounds on.
+class TestView : public View {};
+
+// Parent/child pair set up at known coordinates. Returns the raw
+// pointer to the child for assertions; the parent owns it.
+struct ParentChild {
+    std::unique_ptr<TestView> parent;
+    TestView* child = nullptr;
+};
+
+ParentChild make_pair(Rect parent_bounds, Rect child_bounds) {
+    ParentChild pc;
+    pc.parent = std::make_unique<TestView>();
+    pc.parent->set_bounds(parent_bounds);
+    auto child = std::make_unique<TestView>();
+    child->set_bounds(child_bounds);
+    pc.child = child.get();
+    pc.parent->add_child(std::move(child));
+    return pc;
+}
+} // namespace
+
+TEST_CASE("ComponentDragger: defaults are idle and constrain-on",
+          "[component-dragger]") {
+    ComponentDragger d;
+    REQUIRE_FALSE(d.is_dragging());
+    REQUIRE(d.constrain_to_parent());
+}
+
+TEST_CASE("ComponentDragger: start_dragging snapshots origin and bounds",
+          "[component-dragger]") {
+    auto pc = make_pair({0, 0, 400, 300}, {50, 60, 100, 80});
+    ComponentDragger d;
+    d.set_constrain_to_parent(false);
+    d.start_dragging(*pc.child, {10, 12});
+
+    REQUIRE(d.is_dragging());
+    REQUIRE(d.mouse_start().x == Catch::Approx(10));
+    REQUIRE(d.mouse_start().y == Catch::Approx(12));
+    REQUIRE(d.bounds_start() == Rect{50, 60, 100, 80});
+}
+
+TEST_CASE("ComponentDragger: drag_view translates bounds by delta",
+          "[component-dragger]") {
+    auto pc = make_pair({0, 0, 400, 300}, {50, 60, 100, 80});
+    ComponentDragger d;
+    d.set_constrain_to_parent(false);
+    d.start_dragging(*pc.child, {10, 12});
+    d.drag_view(*pc.child, {30, 50});  // delta = (+20, +38)
+
+    REQUIRE(pc.child->bounds() == Rect{70, 98, 100, 80});
+}
+
+TEST_CASE("ComponentDragger: drag_view is a no-op when not dragging",
+          "[component-dragger]") {
+    auto pc = make_pair({0, 0, 400, 300}, {50, 60, 100, 80});
+    ComponentDragger d;
+    d.drag_view(*pc.child, {999, 999});  // no start_dragging
+    REQUIRE(pc.child->bounds() == Rect{50, 60, 100, 80});
+}
+
+TEST_CASE("ComponentDragger: end_dragging freezes subsequent drags",
+          "[component-dragger]") {
+    auto pc = make_pair({0, 0, 400, 300}, {50, 60, 100, 80});
+    ComponentDragger d;
+    d.set_constrain_to_parent(false);
+    d.start_dragging(*pc.child, {0, 0});
+    d.drag_view(*pc.child, {10, 10});
+    REQUIRE(pc.child->bounds() == Rect{60, 70, 100, 80});
+
+    d.end_dragging();
+    REQUIRE_FALSE(d.is_dragging());
+    d.drag_view(*pc.child, {100, 100});  // ignored
+    REQUIRE(pc.child->bounds() == Rect{60, 70, 100, 80});
+}
+
+TEST_CASE("ComponentDragger: constrain_to_parent clamps origin inside parent",
+          "[component-dragger]") {
+    // Parent is 400x300, child 100x80. Constraining means child.x stays
+    // in [0, 400-100=300] and child.y stays in [0, 300-80=220].
+    auto pc = make_pair({0, 0, 400, 300}, {10, 10, 100, 80});
+    ComponentDragger d;
+    REQUIRE(d.constrain_to_parent());
+    d.start_dragging(*pc.child, {0, 0});
+
+    // Try to drag far past the right + bottom edges.
+    d.drag_view(*pc.child, {9999, 9999});
+    REQUIRE(pc.child->bounds().x == Catch::Approx(300));
+    REQUIRE(pc.child->bounds().y == Catch::Approx(220));
+
+    // And far past the top-left.
+    d.drag_view(*pc.child, {-9999, -9999});
+    REQUIRE(pc.child->bounds().x == Catch::Approx(0));
+    REQUIRE(pc.child->bounds().y == Catch::Approx(0));
+}
+
+TEST_CASE("ComponentDragger: constrain off lets child escape parent",
+          "[component-dragger]") {
+    auto pc = make_pair({0, 0, 100, 100}, {0, 0, 50, 50});
+    ComponentDragger d;
+    d.set_constrain_to_parent(false);
+    d.start_dragging(*pc.child, {0, 0});
+    d.drag_view(*pc.child, {500, 500});
+    REQUIRE(pc.child->bounds() == Rect{500, 500, 50, 50});
+}
+
+TEST_CASE("ComponentDragger: on_drag fires with the new bounds",
+          "[component-dragger]") {
+    auto pc = make_pair({0, 0, 400, 300}, {0, 0, 50, 50});
+    ComponentDragger d;
+    d.set_constrain_to_parent(false);
+    Rect last{};
+    int calls = 0;
+    d.on_drag = [&](Rect r) { last = r; ++calls; };
+
+    d.start_dragging(*pc.child, {0, 0});
+    d.drag_view(*pc.child, {25, 30});
+    REQUIRE(calls == 1);
+    REQUIRE(last == Rect{25, 30, 50, 50});
+}
+
+TEST_CASE("ComponentDragger: constrain with no parent is a safe no-op",
+          "[component-dragger]") {
+    // Lone view without a parent — clamp branch must not crash.
+    TestView orphan;
+    orphan.set_bounds({10, 10, 50, 50});
+    ComponentDragger d;  // constrain-on by default
+    d.start_dragging(orphan, {0, 0});
+    d.drag_view(orphan, {20, 20});
+    REQUIRE(orphan.bounds() == Rect{30, 30, 50, 50});
+}

--- a/test/test_preferences_panel.cpp
+++ b/test/test_preferences_panel.cpp
@@ -1,0 +1,196 @@
+// PreferencesPanel sidebar-of-pages container tests
+// (closes the gap-doc P3 row "PreferencesPanel").
+//
+// Validates the page registry + active-page selection contract:
+//   - add_page wires content into the View tree,
+//   - first registered page is active by default + visible,
+//   - set_active_page(index) / (title) swap visibility and fire callback,
+//   - persistence via PropertiesFile round-trips the last-selected page,
+//   - bind_persistence honors stored value at bind time,
+//   - bind_persistence with an unknown title leaves active page unchanged.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <memory>
+#include <pulp/state/properties_file.hpp>
+#include <pulp/view/preferences_panel.hpp>
+#include <pulp/view/view.hpp>
+
+using namespace pulp::view;
+
+namespace {
+class TestView : public View {};
+
+std::unique_ptr<TestView> make_view() { return std::make_unique<TestView>(); }
+} // namespace
+
+TEST_CASE("PreferencesPanel: defaults are empty + no active page",
+          "[preferences-panel]") {
+    PreferencesPanel p;
+    REQUIRE(p.page_count() == 0);
+    REQUIRE(p.active_page() == -1);
+    REQUIRE(p.active_page_title().empty());
+    REQUIRE_FALSE(p.has_persistence());
+}
+
+TEST_CASE("PreferencesPanel: first registered page becomes active and visible",
+          "[preferences-panel]") {
+    PreferencesPanel p;
+    auto v1 = make_view();
+    auto* raw1 = v1.get();
+    p.add_page("General", "gear", std::move(v1));
+
+    REQUIRE(p.page_count() == 1);
+    REQUIRE(p.active_page() == 0);
+    REQUIRE(p.active_page_title() == "General");
+    REQUIRE(p.page_title(0) == "General");
+    REQUIRE(p.page_icon(0) == "gear");
+    REQUIRE(p.page_content(0) == raw1);
+    REQUIRE(raw1->visible());
+}
+
+TEST_CASE("PreferencesPanel: subsequent pages register hidden",
+          "[preferences-panel]") {
+    PreferencesPanel p;
+    auto v1 = make_view(); auto* raw1 = v1.get();
+    auto v2 = make_view(); auto* raw2 = v2.get();
+    p.add_page("General", "gear", std::move(v1));
+    p.add_page("Audio",   "audio", std::move(v2));
+
+    REQUIRE(p.page_count() == 2);
+    REQUIRE(p.active_page() == 0);
+    REQUIRE(raw1->visible());
+    REQUIRE_FALSE(raw2->visible());
+}
+
+TEST_CASE("PreferencesPanel: set_active_page(index) swaps visibility",
+          "[preferences-panel]") {
+    PreferencesPanel p;
+    auto v1 = make_view(); auto* raw1 = v1.get();
+    auto v2 = make_view(); auto* raw2 = v2.get();
+    p.add_page("General", "gear", std::move(v1));
+    p.add_page("Audio",   "audio", std::move(v2));
+
+    p.set_active_page(1);
+    REQUIRE(p.active_page() == 1);
+    REQUIRE(p.active_page_title() == "Audio");
+    REQUIRE_FALSE(raw1->visible());
+    REQUIRE(raw2->visible());
+
+    p.set_active_page(0);
+    REQUIRE(raw1->visible());
+    REQUIRE_FALSE(raw2->visible());
+}
+
+TEST_CASE("PreferencesPanel: set_active_page(title) selects by name",
+          "[preferences-panel]") {
+    PreferencesPanel p;
+    p.add_page("General", "gear",  make_view());
+    p.add_page("Audio",   "audio", make_view());
+    p.add_page("MIDI",    "midi",  make_view());
+
+    REQUIRE(p.set_active_page("MIDI"));
+    REQUIRE(p.active_page() == 2);
+    REQUIRE(p.active_page_title() == "MIDI");
+
+    REQUIRE_FALSE(p.set_active_page("Bogus"));
+    REQUIRE(p.active_page() == 2);  // unchanged
+}
+
+TEST_CASE("PreferencesPanel: out-of-range set_active_page is a no-op",
+          "[preferences-panel]") {
+    PreferencesPanel p;
+    p.add_page("General", "gear", make_view());
+    p.set_active_page(5);
+    REQUIRE(p.active_page() == 0);
+    p.set_active_page(-1);
+    REQUIRE(p.active_page() == 0);
+}
+
+TEST_CASE("PreferencesPanel: on_page_change fires for transitions",
+          "[preferences-panel]") {
+    PreferencesPanel p;
+    std::vector<int> seen;
+    p.on_page_change = [&](int idx) { seen.push_back(idx); };
+    p.add_page("General", "gear",  make_view());  // first → fires 0
+    p.add_page("Audio",   "audio", make_view());
+    p.set_active_page(1);                          // fires 1
+    p.set_active_page(1);                          // duplicate — no fire
+    p.set_active_page(0);                          // fires 0
+
+    REQUIRE(seen.size() == 3);
+    REQUIRE(seen[0] == 0);
+    REQUIRE(seen[1] == 1);
+    REQUIRE(seen[2] == 0);
+}
+
+TEST_CASE("PreferencesPanel: persistence writes selected page to PropertiesFile",
+          "[preferences-panel]") {
+    pulp::state::PropertiesFile props;
+    PreferencesPanel p;
+    p.add_page("General", "gear",  make_view());
+    p.add_page("Audio",   "audio", make_view());
+
+    p.bind_persistence(&props);
+    REQUIRE(p.has_persistence());
+    REQUIRE(p.persistence_key() == "preferences.active_page");
+
+    p.set_active_page(1);
+    auto stored = props.get_string("preferences.active_page");
+    REQUIRE(stored.has_value());
+    REQUIRE(*stored == "Audio");
+
+    p.set_active_page(0);
+    REQUIRE(props.get_string("preferences.active_page") == std::optional<std::string>("General"));
+}
+
+TEST_CASE("PreferencesPanel: bind_persistence selects stored page at bind time",
+          "[preferences-panel]") {
+    pulp::state::PropertiesFile props;
+    props.set_string("preferences.active_page", "Audio");
+
+    PreferencesPanel p;
+    p.add_page("General", "gear",  make_view());
+    p.add_page("Audio",   "audio", make_view());
+
+    p.bind_persistence(&props);
+    REQUIRE(p.active_page() == 1);
+    REQUIRE(p.active_page_title() == "Audio");
+}
+
+TEST_CASE("PreferencesPanel: bind_persistence leaves active unchanged for missing title",
+          "[preferences-panel]") {
+    pulp::state::PropertiesFile props;
+    props.set_string("preferences.active_page", "DeletedPage");
+
+    PreferencesPanel p;
+    p.add_page("General", "gear",  make_view());
+    p.add_page("Audio",   "audio", make_view());
+
+    p.bind_persistence(&props);
+    // No matching page → stays on default (first registered).
+    REQUIRE(p.active_page() == 0);
+}
+
+TEST_CASE("PreferencesPanel: custom persistence key is honored",
+          "[preferences-panel]") {
+    pulp::state::PropertiesFile props;
+    PreferencesPanel p;
+    p.set_persistence_key("mysettings.tab");
+    p.add_page("General", "gear",  make_view());
+    p.add_page("Audio",   "audio", make_view());
+    p.bind_persistence(&props);
+
+    p.set_active_page(1);
+    REQUIRE(props.get_string("mysettings.tab") == std::optional<std::string>("Audio"));
+    REQUIRE_FALSE(props.get_string("preferences.active_page").has_value());
+}
+
+TEST_CASE("PreferencesPanel: simulate_select drives selection like a sidebar click",
+          "[preferences-panel]") {
+    PreferencesPanel p;
+    p.add_page("General", "gear", make_view());
+    p.add_page("Audio",   "audio", make_view());
+    p.simulate_select(1);
+    REQUIRE(p.active_page() == 1);
+}

--- a/test/test_tooltip_window.cpp
+++ b/test/test_tooltip_window.cpp
@@ -1,0 +1,196 @@
+// TooltipWindow transient floating tooltip tests
+// (closes the gap-doc P2 row "TooltipWindow").
+//
+// Validates the idle → pending → showing → hiding → idle state machine:
+//   - show() waits for hover_delay before appearing,
+//   - tick() drives the timer + fade animations,
+//   - move_to / show on a different anchor re-anchors live,
+//   - hide() runs a fade-out,
+//   - cancel_pending bails before the tooltip ever shows,
+//   - auto_hide elapses + drives hide() automatically,
+//   - MotionPolicy::Off snaps fade animations to their target.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <pulp/view/tooltip_window.hpp>
+#include <pulp/view/motion_preferences.hpp>
+
+using namespace pulp::view;
+
+namespace {
+// Drain ticks until the tooltip's tick() reports "no more work" or we
+// hit `max_seconds`. Always advances at least one tick.
+void drain(TooltipWindow& t, float max_seconds = 1.5f) {
+    constexpr float dt = 1.0f / 60.0f;
+    int steps = static_cast<int>(max_seconds / dt) + 2;
+    for (int i = 0; i < steps; ++i) {
+        if (!t.tick(dt)) break;
+    }
+}
+} // namespace
+
+TEST_CASE("TooltipWindow: defaults to idle and invisible",
+          "[tooltip-window]") {
+    TooltipWindow t;
+    REQUIRE(t.phase() == TooltipWindow::Phase::idle);
+    REQUIRE_FALSE(t.visible());
+    REQUIRE_FALSE(t.pending());
+    REQUIRE(t.opacity() == Catch::Approx(0.0f));
+}
+
+TEST_CASE("TooltipWindow: show() waits for hover_delay before appearing",
+          "[tooltip-window]") {
+    TooltipWindow t;
+    t.set_hover_delay(0.2f);
+    t.set_fade_duration(0.05f);
+    t.show("hello", {100, 100});
+
+    REQUIRE(t.phase() == TooltipWindow::Phase::pending);
+    REQUIRE_FALSE(t.visible());
+    REQUIRE(t.text() == "hello");
+
+    // Mid-delay: still pending.
+    t.tick(0.1f);
+    REQUIRE(t.phase() == TooltipWindow::Phase::pending);
+
+    // After delay elapses: transitions to showing.
+    t.tick(0.15f);
+    REQUIRE(t.phase() == TooltipWindow::Phase::showing);
+    REQUIRE(t.visible());
+
+    drain(t, 0.2f);
+    REQUIRE(t.opacity() == Catch::Approx(1.0f));
+}
+
+TEST_CASE("TooltipWindow: position applies cursor_offset to anchor",
+          "[tooltip-window]") {
+    TooltipWindow t;
+    t.set_cursor_offset({4, 8});
+    t.show("x", {100, 200});
+    REQUIRE(t.position().x == Catch::Approx(104));
+    REQUIRE(t.position().y == Catch::Approx(208));
+    REQUIRE(t.last_anchor() == Point{100, 200});
+}
+
+TEST_CASE("TooltipWindow: move_to re-anchors while visible",
+          "[tooltip-window]") {
+    TooltipWindow t;
+    t.set_hover_delay(0.05f);
+    t.set_fade_duration(0.02f);
+    t.set_cursor_offset({0, 0});
+    t.show("x", {0, 0});
+    drain(t, 0.2f);
+    REQUIRE(t.visible());
+
+    t.move_to({50, 75});
+    REQUIRE(t.position() == Point{50, 75});
+    REQUIRE(t.last_anchor() == Point{50, 75});
+}
+
+TEST_CASE("TooltipWindow: move_to is a no-op when idle", "[tooltip-window]") {
+    TooltipWindow t;
+    t.move_to({10, 10});
+    REQUIRE(t.phase() == TooltipWindow::Phase::idle);
+    REQUIRE_FALSE(t.visible());
+}
+
+TEST_CASE("TooltipWindow: hide() runs a fade-out and returns to idle",
+          "[tooltip-window]") {
+    TooltipWindow t;
+    t.set_hover_delay(0.05f);
+    t.set_fade_duration(0.05f);
+    t.show("x", {0, 0});
+    drain(t, 0.2f);
+    REQUIRE(t.opacity() == Catch::Approx(1.0f));
+
+    t.hide();
+    REQUIRE(t.phase() == TooltipWindow::Phase::hiding);
+
+    // Mid-fade: opacity is between 0 and 1.
+    t.tick(0.02f);
+    REQUIRE(t.opacity() > 0.0f);
+    REQUIRE(t.opacity() < 1.0f);
+
+    drain(t, 0.2f);
+    REQUIRE(t.phase() == TooltipWindow::Phase::idle);
+    REQUIRE_FALSE(t.visible());
+    REQUIRE(t.opacity() == Catch::Approx(0.0f));
+}
+
+TEST_CASE("TooltipWindow: cancel_pending bails out of the hover delay",
+          "[tooltip-window]") {
+    TooltipWindow t;
+    t.set_hover_delay(0.5f);
+    t.show("x", {0, 0});
+    REQUIRE(t.pending());
+
+    t.cancel_pending();
+    REQUIRE(t.phase() == TooltipWindow::Phase::idle);
+    REQUIRE_FALSE(t.visible());
+
+    // Future ticks do nothing.
+    REQUIRE_FALSE(t.tick(1.0f));
+}
+
+TEST_CASE("TooltipWindow: hide() before delay elapses goes straight to idle",
+          "[tooltip-window]") {
+    TooltipWindow t;
+    t.set_hover_delay(0.5f);
+    t.show("x", {0, 0});
+    REQUIRE(t.pending());
+    t.hide();
+    REQUIRE(t.phase() == TooltipWindow::Phase::idle);
+}
+
+TEST_CASE("TooltipWindow: auto_hide triggers hide after elapsed seconds",
+          "[tooltip-window]") {
+    TooltipWindow t;
+    t.set_hover_delay(0.0f);
+    t.set_fade_duration(0.02f);
+    t.set_auto_hide(0.1f);
+    t.show("x", {0, 0});
+    t.tick(0.0001f);  // get past pending → showing transition
+    REQUIRE(t.visible());
+
+    // Tick past the auto-hide window — should flip into hiding.
+    for (int i = 0; i < 20; ++i) t.tick(0.01f);
+    REQUIRE((t.phase() == TooltipWindow::Phase::hiding ||
+             t.phase() == TooltipWindow::Phase::idle));
+}
+
+TEST_CASE("TooltipWindow: showing a different anchor re-anchors live",
+          "[tooltip-window]") {
+    TooltipWindow t;
+    t.set_hover_delay(0.05f);
+    t.set_fade_duration(0.02f);
+    t.set_cursor_offset({0, 0});
+    t.show("hello", {10, 10});
+    drain(t, 0.2f);
+    REQUIRE(t.visible());
+
+    // Live re-anchor + text update.
+    t.show("world", {100, 200});
+    REQUIRE(t.visible());
+    REQUIRE(t.text() == "world");
+    REQUIRE(t.position() == Point{100, 200});
+}
+
+TEST_CASE("TooltipWindow: MotionPolicy::Off snaps fade-in instantly",
+          "[tooltip-window]") {
+    MotionPreferences::instance().set_override(MotionPolicy::Off);
+
+    TooltipWindow t;
+    t.set_hover_delay(0.05f);
+    t.set_fade_duration(0.5f);
+    t.show("x", {0, 0});
+    drain(t, 0.2f);
+    REQUIRE(t.opacity() == Catch::Approx(1.0f));
+
+    t.hide();
+    drain(t, 0.2f);
+    REQUIRE(t.opacity() == Catch::Approx(0.0f));
+    REQUIRE_FALSE(t.visible());
+
+    MotionPreferences::instance().reset_for_tests();
+}


### PR DESCRIPTION
## Summary

Closes 3 gap-doc rows from `planning/2026-05-24-reference-framework-gap-analysis.md` with small, headless-friendly Pulp-native widgets:

- **`pulp::view::ComponentDragger`** (P2) — drag-to-move helper for any `View`. Snapshots mouse origin + bounds at `start_dragging`; `drag_view` translates by delta; optional constrain-to-parent + `on_drag` callback. Header-only at `core/view/include/pulp/view/component_dragger.hpp`.
- **`pulp::view::TooltipWindow`** (P2) — transient floating tooltip state machine (idle → pending → showing → hiding). Hover-delay timer, motion-aware fade via `ValueAnimation` (`MotionPolicy::Off` snaps), auto-hide, cursor-offset. Header-only at `core/view/include/pulp/view/tooltip_window.hpp`. Conceptual "window" — the host paints, the widget owns state.
- **`pulp::view::PreferencesPanel`** (P3) — sidebar-of-pages container. `add_page(title, icon, content)` registry; `set_active_page(index/title)` swaps visibility; `bind_persistence(PropertiesFile*)` reads stored title at bind time and writes back on each select. Header-only at `core/view/include/pulp/view/preferences_panel.hpp`.

All three names are Pulp-native per the gap-doc license-lineage rule.

## Test plan

- [x] `pulp-test-component-dragger` — 9 cases, 20 assertions.
- [x] `pulp-test-tooltip-window` — 11 cases, 41 assertions.
- [x] `pulp-test-preferences-panel` — 12 cases, 43 assertions.
- [x] All 32 tests run green via `ctest -R "PreferencesPanel|TooltipWindow|ComponentDragger"`.
- [x] Planning gap-doc rows updated (3 main rows + 3 phase checklist items).
- [x] SDK minor bump 0.254.1 → 0.255.0.

Planning submodule pointer bumped in the PreferencesPanel commit.