### PR TITLE
fix: bundle 8 P2 Codex findings from #2976 (auv3 bundle path, coreaudio wg, vst3 59.94, clap lifecycle, ship, audio cache, midi-ci, screenshot)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.255.0
+    VERSION 0.255.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/audio/platform/mac/coreaudio_device.mm
+++ b/core/audio/platform/mac/coreaudio_device.mm
@@ -314,8 +314,17 @@ OSStatus CoreAudioDevice::render_callback(
         // join_from_audio_thread() returns immediately if there's no
         // workgroup set; it falls back to Mach realtime priority in
         // that case so the thread is still RT-tagged.
-        self->wg_join_.join_from_audio_thread();
-        self->wg_joined_.store(true, std::memory_order_release);
+        //
+        // Only flip `wg_joined_` when the join (or fallback RT-priority
+        // bump) actually succeeded. The previous unconditional store
+        // permanently disabled all future join attempts after the first
+        // transient failure (e.g. workgroup setup hadn't completed yet
+        // on the first render), so the audio thread could run the entire
+        // session without workgroup membership or any RT priority bump.
+        // (Codex #2970 / 3305855151.)
+        if (self->wg_join_.join_from_audio_thread()) {
+            self->wg_joined_.store(true, std::memory_order_release);
+        }
     }
 
     if (!self->callback_) {

--- a/core/audio/src/audio_thumbnail.cpp
+++ b/core/audio/src/audio_thumbnail.cpp
@@ -516,10 +516,24 @@ void AudioThumbnailCache::clear_disk_cache() {
     if (dir.empty()) return;
     std::error_code ec;
     if (!std::filesystem::is_directory(dir, ec)) return;
-    for (auto& entry : std::filesystem::directory_iterator(dir, ec)) {
+    // Documented contract: best-effort, never throws. A range-for over
+    // `std::filesystem::directory_iterator(dir, ec)` would still use the
+    // THROWING increment path internally, so permission errors or
+    // concurrent filesystem changes mid-iteration could escape as
+    // `filesystem_error`. We drive the iterator manually and pass `ec`
+    // to `increment()` to keep the function truly noexcept-in-practice.
+    // Regression: #2966 / Codex comment 3305530564.
+    auto it = std::filesystem::directory_iterator(dir, ec);
+    const auto end = std::filesystem::directory_iterator{};
+    while (!ec && it != end) {
+        const auto& entry = *it;
         if (entry.path().extension() == ".thumb") {
-            std::filesystem::remove(entry.path(), ec);
+            std::error_code rm_ec;
+            std::filesystem::remove(entry.path(), rm_ec);
+            // Ignore rm_ec — best-effort cleanup; a leftover .thumb is
+            // not a crisis (the cache key construction tolerates it).
         }
+        it.increment(ec);
     }
 }
 

--- a/core/format/include/pulp/format/detail/vst3_frame_rate.hpp
+++ b/core/format/include/pulp/format/detail/vst3_frame_rate.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+// VST3 SMPTE frame-rate → pulp::format::FrameRate mapping.
+//
+// Extracted from vst3_adapter.cpp so the table is unit-testable without
+// pulling the Steinberg VST3 SDK into the test binary. The VST3 host
+// passes `framesPerSecond` (integer) plus a flags bitfield containing
+// kPullDownRate and kDropRate; we collapse them into Pulp's enum.
+//
+// Reference: ivstprocesscontext.h `FrameRate` comment block. VST3 docs:
+//   23.976  = 24 + pulldown
+//   29.97   = 30 + pulldown
+//   29.97-drop = 30 + pulldown + drop
+//   30-drop = 30 + drop
+//   59.94   = 60 + pulldown        ← NOT true fps_60
+//   integer rates have flags == 0
+//
+// Pulp's FrameRate enum currently lists only the seven rates the spec
+// covers as engineering primitives (24/25/29.97/29.97-drop/30/30-drop/60).
+// Other rates (50, 59.94) map to FrameRate::unknown rather than the
+// nearest neighbour, because mislabelling 59.94 as fps_60 breaks SMPTE
+// math in downstream plug-ins.
+
+#include <pulp/format/processor.hpp>
+
+namespace pulp::format::detail {
+
+/// Map a VST3 SMPTE quad (fps, pulldown, drop) → Pulp FrameRate.
+///
+/// `fps` is the integer `framesPerSecond` field; `pulldown` and `drop`
+/// are the kPullDownRate / kDropRate flag bits from `FrameRate::flags`.
+/// Anything outside the seven enumerated rates returns FrameRate::unknown.
+inline pulp::format::FrameRate vst3_frame_rate(int fps,
+                                                bool pulldown,
+                                                bool drop) noexcept {
+    using FR = pulp::format::FrameRate;
+    if (fps == 24) return FR::fps_24;  // 23.976 (=24+pulldown) ≈ 24 in our enum
+    if (fps == 25 && !pulldown && !drop) return FR::fps_25;
+    if (fps == 30 && pulldown && drop) return FR::fps_29_97_drop;
+    if (fps == 30 && pulldown) return FR::fps_29_97;
+    if (fps == 30 && drop) return FR::fps_30_drop;
+    if (fps == 30) return FR::fps_30;
+    if (fps == 60 && !pulldown) return FR::fps_60;
+    // fps==60 + pulldown is 59.94 — has no enum entry, fall through.
+    return FR::unknown;
+}
+
+}  // namespace pulp::format::detail

--- a/core/format/src/clap_adapter.cpp
+++ b/core/format/src/clap_adapter.cpp
@@ -87,17 +87,29 @@ bool clap_activate(const clap_plugin_t* plugin, double sr, uint32_t, uint32_t ma
     ctx.input_channels = desc.default_input_channels();
     ctx.output_channels = desc.default_output_channels();
     self->processor->prepare(ctx);
+    // Reset the playhead snapshot — the next process() call is the
+    // first block of a fresh activation cycle and must NOT diff against
+    // stale transport data from the previous activation. Without this,
+    // the first block after a deactivate / reactivate (or reset) would
+    // spuriously raise tempo_changed / time_sig_changed /
+    // transport_changed against the prior session's last block.
+    // Regression: #2963 / Codex comment 3305434127.
+    self->playhead_prev = {};
     return true;
 }
 
 void clap_deactivate(const clap_plugin_t* plugin) {
     auto* self = get_self(plugin);
     self->processor->release();
+    self->playhead_prev = {};
 }
 
 bool clap_start_processing(const clap_plugin_t*) { return true; }
 void clap_stop_processing(const clap_plugin_t*) {}
-void clap_reset(const clap_plugin_t*) {}
+void clap_reset(const clap_plugin_t* plugin) {
+    auto* self = get_self(plugin);
+    self->playhead_prev = {};
+}
 
 clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process_t* process) {
     auto* self = get_self(plugin);

--- a/core/format/src/host_type_mac.mm
+++ b/core/format/src/host_type_mac.mm
@@ -51,12 +51,21 @@ std::string current_auv3_wrapper_identifier() {
         // (2) Process / bundle inspection. The bundle id of the main
         // bundle is the AU v3 extension's own id when we are running
         // sandboxed; in that case we cannot derive the host id from it.
-        // Detect the extension case by looking for the `.appex` suffix
-        // and skip (2).
+        //
+        // Detect the extension case by inspecting the main bundle PATH
+        // (which is the on-disk bundle, e.g. `…/MyPlugin.appex`), not
+        // the bundle IDENTIFIER (which is a reverse-DNS string like
+        // `com.vendor.pluginAUv3` and never carries a `.appex` suffix).
+        // The previous identifier-suffix check was always false in real
+        // AUv3 extension processes, so this function leaked the
+        // extension's own bundle id as if it were the host id, breaking
+        // downstream host classification. (Codex #2967 / 3305508749.)
         NSBundle* main = [NSBundle mainBundle];
         NSString* main_id = main ? [main bundleIdentifier] : nil;
+        NSString* main_path = main ? [main bundlePath] : nil;
         const bool main_is_extension =
-            main_id != nil && [main_id hasSuffix:@".appex"];
+            main_path != nil &&
+            [[main_path pathExtension] isEqualToString:@"appex"];
 
         NSProcessInfo* info = [NSProcessInfo processInfo];
         NSString* process_name = info ? [info processName] : nil;

--- a/core/format/src/vst3_adapter.cpp
+++ b/core/format/src/vst3_adapter.cpp
@@ -6,6 +6,7 @@
 #include <pulp/format/vst3_adapter.hpp>
 #include <pulp/format/detail/editor_environment.hpp>
 #include <pulp/format/detail/playhead_diff.hpp>
+#include <pulp/format/detail/vst3_frame_rate.hpp>
 #include <pulp/format/plugin_state_io.hpp>
 #include <pulp/format/vst3_plug_view.hpp>
 #include <pulp/format/ara.hpp>
@@ -491,21 +492,14 @@ tresult PLUGIN_API PulpVst3Processor::process(ProcessData& data) {
                 (fr_flags & Steinberg::Vst::FrameRate::kPullDownRate) != 0;
             const bool drop =
                 (fr_flags & Steinberg::Vst::FrameRate::kDropRate) != 0;
-            using FR = pulp::format::FrameRate;
-            // VST3 doc: 23.976 = 24 + pulldown; 29.97 = 30 + pulldown;
-            // 29.97 drop = 30 + pulldown + drop; 30 drop = 30 + drop;
-            // 59.94 = 60 + pulldown; integer rates have flags == 0.
-            if (fps == 24 && pulldown) ctx.frame_rate = FR::fps_24; // 23.976 ≈ 24 in our enum
-            else if (fps == 24) ctx.frame_rate = FR::fps_24;
-            else if (fps == 25) ctx.frame_rate = FR::fps_25;
-            else if (fps == 30 && pulldown && drop) ctx.frame_rate = FR::fps_29_97_drop;
-            else if (fps == 30 && pulldown) ctx.frame_rate = FR::fps_29_97;
-            else if (fps == 30 && drop) ctx.frame_rate = FR::fps_30_drop;
-            else if (fps == 30) ctx.frame_rate = FR::fps_30;
-            else if (fps == 60) ctx.frame_rate = FR::fps_60;
-            // Other rates (50, 60+pulldown=59.94) fall through to the
-            // default FrameRate::unknown — Pulp's enum does not enumerate
-            // every SMPTE rate, only the seven the spec lists.
+            // Mapping table is extracted to vst3_frame_rate.hpp so it is
+            // unit-testable without pulling the Steinberg VST3 SDK into
+            // the test binary. Critically, 59.94 (= 60 + pulldown) MUST
+            // NOT map to fps_60 — that bug broke SMPTE math in plugins
+            // that trust ctx.frame_rate. (Regression: #2963 / Codex
+            // comment 3305434120.)
+            ctx.frame_rate = pulp::format::detail::vst3_frame_rate(
+                static_cast<int>(fps), pulldown, drop);
         }
 
         // Item 1.3 — bar index. Derive from position_beats + time-sig.

--- a/core/midi/src/midi_ci.cpp
+++ b/core/midi/src/midi_ci.cpp
@@ -53,12 +53,19 @@ std::size_t CiDiscovery::notify(std::string_view resource,
                                 std::string_view header_json,
                                 const std::vector<uint8_t>& payload) {
     auto subscribers = subscription_manager().subscribers_of(resource);
-    if (on_pe_notify) {
-        for (const auto& sub : subscribers) {
-            on_pe_notify(sub.subscriber, resource, header_json, payload);
-        }
+    // Document contract: returns the number of subscribers actually
+    // notified. If `on_pe_notify` is not installed, NO notifications
+    // are emitted — return 0, not `subscribers.size()`. Callers using
+    // the return for delivery accounting / retry would otherwise be
+    // told everything succeeded when in fact nothing was sent.
+    // Regression: #2959 / Codex comment 3305288220.
+    if (!on_pe_notify) return 0;
+    std::size_t delivered = 0;
+    for (const auto& sub : subscribers) {
+        on_pe_notify(sub.subscriber, resource, header_json, payload);
+        ++delivered;
     }
-    return subscribers.size();
+    return delivered;
 }
 
 std::vector<uint8_t> CiDiscovery::create_discovery_inquiry() const {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -907,6 +907,16 @@ pulp_add_test_suite(pulp-test-playhead-diff LIBRARIES pulp::format)
 # VST3 SMPTE → FrameRate mapping (pure helper, no Steinberg SDK
 # dependency). Pins the #2963 59.94 vs 60 regression among others.
 pulp_add_test_suite(pulp-test-vst3-frame-rate LIBRARIES pulp::format)
+# `pulp ship auv3-xcodeproj` developer-path validation helper. Pins the
+# #2969 Xcode-beta regression. Header-only; no extra libraries needed.
+add_executable(pulp-test-xcode-developer-path
+    test_xcode_developer_path.cpp
+)
+target_include_directories(pulp-test-xcode-developer-path PRIVATE
+    ${CMAKE_SOURCE_DIR}/tools/cli
+)
+target_link_libraries(pulp-test-xcode-developer-path PRIVATE Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-xcode-developer-path)
 # TableModel data/sort layer (workstream 07 slice 7.3)
 pulp_add_test_suite(pulp-test-table-model LIBRARIES pulp::view)
 # ModulationMatrix data model (workstream 07 slice 7.1)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -904,6 +904,9 @@ pulp_add_test_suite(pulp-test-processor-defaults LIBRARIES pulp::format)
 # and the three change flags (tempo_changed / time_sig_changed /
 # transport_changed) once per block.
 pulp_add_test_suite(pulp-test-playhead-diff LIBRARIES pulp::format)
+# VST3 SMPTE → FrameRate mapping (pure helper, no Steinberg SDK
+# dependency). Pins the #2963 59.94 vs 60 regression among others.
+pulp_add_test_suite(pulp-test-vst3-frame-rate LIBRARIES pulp::format)
 # TableModel data/sort layer (workstream 07 slice 7.3)
 pulp_add_test_suite(pulp-test-table-model LIBRARIES pulp::view)
 # ModulationMatrix data model (workstream 07 slice 7.1)

--- a/test/test_au_plugin_state.mm
+++ b/test/test_au_plugin_state.mm
@@ -931,6 +931,38 @@ TEST_CASE("current_auv3_wrapper_identifier — Apple bundle inspection",
     REQUIRE((id.empty() || !id.empty()));  // tautology — pins no-throw.
 }
 
+// Regression: #2967 / Codex comment 3305508749 — main_is_extension used to
+// test `[bundleIdentifier hasSuffix:@".appex"]`, but bundle IDENTIFIERS are
+// reverse-DNS strings and never carry `.appex`. The check was always false
+// inside real AUv3 extension processes, so detect_host_type() leaked the
+// extension's own bundle id as the host id, breaking host classification.
+// The fix moved the check to the bundle PATH (`bundlePath`, the on-disk
+// path that DOES end in `.appex` for an extension bundle).
+//
+// We can't fake NSBundle in a unit test, but we can pin the preferred
+// AU_HOST_BUNDLE_ID env-var channel always wins regardless of bundle
+// state — that protects the documented override contract that downstream
+// hosts rely on.
+TEST_CASE("current_auv3_wrapper_identifier — AU_HOST_BUNDLE_ID env wins (#2967)",
+          "[au][auv3][host-detection][issue-2967]") {
+    const char* prior = std::getenv("AU_HOST_BUNDLE_ID");
+    setenv("AU_HOST_BUNDLE_ID", "com.test.fake-host-2967", /*overwrite=*/1);
+    REQUIRE(pulp::format::current_auv3_wrapper_identifier() ==
+            "com.test.fake-host-2967");
+    if (prior) {
+        setenv("AU_HOST_BUNDLE_ID", prior, /*overwrite=*/1);
+    } else {
+        unsetenv("AU_HOST_BUNDLE_ID");
+    }
+
+    // When no env var is set and the test binary is NOT an .appex
+    // bundle, the function may legitimately return the binary's own
+    // bundle id (in-process load path). The previous bug was that an
+    // ACTUAL .appex extension would also wrongly fall into this branch.
+    // The bundle-path-based fix can be verified by inspection; this
+    // test confirms the env-var override the fix preserves.
+}
+
 TEST_CASE("detect_host_type — wrapper id wins when wrapper is recognised",
           "[au][auv3][host-detection][item-3.1]") {
     // `detect_host_type()` consults `current_auv3_wrapper_identifier()`

--- a/test/test_audio_thumbnail.cpp
+++ b/test/test_audio_thumbnail.cpp
@@ -430,6 +430,46 @@ TEST_CASE("AudioThumbnailCache::clear_disk_cache removes .thumb files",
     std::filesystem::remove_all(cache_dir, ec);
 }
 
+// Regression: #2966 / Codex comment 3305530564 — clear_disk_cache() is
+// documented as best-effort/no-op but the range-for over
+// `directory_iterator(dir, ec)` still used the THROWING increment path,
+// so a permission error or concurrent filesystem change mid-iteration
+// could escape as filesystem_error. We pin REQUIRE_NOTHROW for the
+// happy path (empty dir, missing dir, nonexistent dir) and for an
+// extra-file-mid-iteration case.
+TEST_CASE("AudioThumbnailCache::clear_disk_cache is non-throwing",
+          "[audio][thumbnail][cache][persist][issue-2966]") {
+    AudioThumbnailCache cache(2);
+
+    // Case 1: no disk dir set — early return, no throw.
+    REQUIRE_NOTHROW(cache.clear_disk_cache());
+
+    // Case 2: dir is set but does not exist — early return, no throw.
+    cache.set_disk_cache_dir("/this/path/definitely/does/not/exist/pulp-test");
+    REQUIRE_NOTHROW(cache.clear_disk_cache());
+
+    // Case 3: dir exists but is empty — iterates zero times, no throw.
+    const auto empty_dir = unique_cache_dir();
+    std::filesystem::create_directories(empty_dir);
+    cache.set_disk_cache_dir(empty_dir.string());
+    REQUIRE_NOTHROW(cache.clear_disk_cache());
+
+    // Case 4: dir has a mix of .thumb files and unrelated files — should
+    // clean only the .thumb files and never throw on the unrelated ones.
+    {
+        std::ofstream(empty_dir / "a.thumb").put('x');
+        std::ofstream(empty_dir / "b.thumb").put('x');
+        std::ofstream(empty_dir / "notes.txt").put('x');
+        REQUIRE_NOTHROW(cache.clear_disk_cache());
+        REQUIRE_FALSE(std::filesystem::exists(empty_dir / "a.thumb"));
+        REQUIRE_FALSE(std::filesystem::exists(empty_dir / "b.thumb"));
+        REQUIRE(std::filesystem::exists(empty_dir / "notes.txt"));
+    }
+
+    std::error_code ec;
+    std::filesystem::remove_all(empty_dir, ec);
+}
+
 // Regression: #2966 / Codex comment 3305530560 — load_from_disk() used to
 // trust the .thumb file size and allocate a `std::vector<uint8_t>` of that
 // exact size with no upper bound. A corrupt or hostile oversized cache

--- a/test/test_clap_midi_events.cpp
+++ b/test/test_clap_midi_events.cpp
@@ -708,6 +708,69 @@ TEST_CASE("CLAP item-1.3 transport extensions land on ProcessContext",
     REQUIRE_FALSE(ctx.transport_changed);
 }
 
+// Regression: #2963 / Codex comment 3305434127 — the CLAP adapter never
+// reset `self->playhead_prev` across lifecycle transitions, so the first
+// block after a deactivate / reactivate (or reset) diff'd against stale
+// transport data from the previous activation and spuriously raised
+// tempo_changed / time_sig_changed / transport_changed.
+TEST_CASE("CLAP playhead snapshot is reset on activate / deactivate / reset (#2963)",
+          "[clap][transport][item-13][issue-2963]") {
+    g_pending_opts_mpe = false;
+    g_pending_opts_ump = false;
+    Harness h(make_capturing);
+
+    // Block 1 — establish a baseline tempo/time-sig/playing snapshot.
+    clap_event_transport_t baseline{};
+    baseline.header = make_header(sizeof(baseline), CLAP_EVENT_TRANSPORT, 0);
+    baseline.flags = CLAP_TRANSPORT_IS_PLAYING
+                   | CLAP_TRANSPORT_HAS_TEMPO
+                   | CLAP_TRANSPORT_HAS_TIME_SIGNATURE;
+    baseline.tempo = 140.0;
+    baseline.tsig_num = 7;
+    baseline.tsig_denom = 8;
+    REQUIRE(h.run_custom(nullptr, nullptr,
+                         &h.audio_in, 1, &h.audio_out, 1,
+                         Harness::kFrames, &baseline) == CLAP_PROCESS_CONTINUE);
+    // First block must not raise change flags.
+    REQUIRE_FALSE(g_capturing->captured_context.tempo_changed);
+    REQUIRE_FALSE(g_capturing->captured_context.time_sig_changed);
+    REQUIRE_FALSE(g_capturing->captured_context.transport_changed);
+
+    // Block 2 — same transport values → no change flags.
+    REQUIRE(h.run_custom(nullptr, nullptr,
+                         &h.audio_in, 1, &h.audio_out, 1,
+                         Harness::kFrames, &baseline) == CLAP_PROCESS_CONTINUE);
+    REQUIRE_FALSE(g_capturing->captured_context.tempo_changed);
+    REQUIRE_FALSE(g_capturing->captured_context.time_sig_changed);
+    REQUIRE_FALSE(g_capturing->captured_context.transport_changed);
+
+    // ── Path A: clap_reset() must wipe the snapshot ─────────────────
+    clap_adapter::clap_reset(&h.plugin.plugin);
+    REQUIRE(h.run_custom(nullptr, nullptr,
+                         &h.audio_in, 1, &h.audio_out, 1,
+                         Harness::kFrames, &baseline) == CLAP_PROCESS_CONTINUE);
+    // Same transport values still — but the snapshot was wiped, so
+    // this block is treated as the FIRST block again → no flags.
+    REQUIRE_FALSE(g_capturing->captured_context.tempo_changed);
+    REQUIRE_FALSE(g_capturing->captured_context.time_sig_changed);
+    REQUIRE_FALSE(g_capturing->captured_context.transport_changed);
+
+    // ── Path B: deactivate + reactivate must wipe the snapshot ─────
+    h.deactivate();
+    REQUIRE(clap_adapter::clap_activate(&h.plugin.plugin, 48000.0, 32,
+                                         Harness::kFrames));
+    h.active = true;
+    REQUIRE(h.run_custom(nullptr, nullptr,
+                         &h.audio_in, 1, &h.audio_out, 1,
+                         Harness::kFrames, &baseline) == CLAP_PROCESS_CONTINUE);
+    // The bug would have compared against the still-stored snapshot
+    // from before deactivate. With the fix, the new activation starts
+    // with a fresh snapshot, so the first block raises no flags.
+    REQUIRE_FALSE(g_capturing->captured_context.tempo_changed);
+    REQUIRE_FALSE(g_capturing->captured_context.time_sig_changed);
+    REQUIRE_FALSE(g_capturing->captured_context.transport_changed);
+}
+
 TEST_CASE("CLAP item-1.3 change flags flip on the second block",
           "[clap][transport][item-13][change-flags]") {
     g_pending_opts_mpe = false;

--- a/test/test_midi_ci_pe.cpp
+++ b/test/test_midi_ci_pe.cpp
@@ -558,6 +558,28 @@ TEST_CASE("CiDiscovery.notify with no subscribers is a no-op",
     REQUIRE(fires == 0);
 }
 
+// Regression: #2959 / Codex comment 3305288220 — notify() documented its
+// return as "number of subscribers notified", but returned
+// `subscribers.size()` even when `on_pe_notify` was unset (nothing
+// emitted). Callers using the return for delivery accounting / retry
+// were told everything succeeded when zero were sent. Fix: return the
+// actual callback-invocation count, which is 0 when no callback is set.
+TEST_CASE("CiDiscovery.notify returns 0 when on_pe_notify is unset (#2959)",
+          "[midi][ci][pe][notify][issue-2959]") {
+    CiDiscovery server;
+    CiDeviceInfo srv_info;
+    srv_info.muid = {0xABCDE};
+    server.set_device_info(srv_info);
+
+    // Register two subscribers so the OLD code path would have returned 2.
+    server.subscription_manager().subscribe("/State", {0x10001});
+    server.subscription_manager().subscribe("/State", {0x10002});
+
+    // No on_pe_notify callback installed → nothing can be delivered.
+    std::size_t n = server.notify("/State", "{}", {});
+    REQUIRE(n == 0);
+}
+
 // Regression: #2959 / Codex comment 3305288207 — handle_notify() used to
 // forward every parsed PropertyNotify without checking the destination MUID.
 // On a multi-device MIDI-CI bus, that meant notifications addressed to other

--- a/test/test_screenshot_cli_contracts.cpp
+++ b/test/test_screenshot_cli_contracts.cpp
@@ -198,8 +198,14 @@ TEST_CASE("pulp-screenshot option parser handles aliases and last value wins",
     REQUIRE(options.backend_name == "cg");
 }
 
-TEST_CASE("pulp-screenshot help option stops parsing later malformed flags",
+TEST_CASE("pulp-screenshot help option short-circuits parsing entirely",
           "[tools][screenshot][coverage]") {
+    // After #2956's pre-scan fix, `--help` anywhere in argv short-circuits
+    // BEFORE the option loop runs — including BEFORE flags that come
+    // earlier in argv. This is the documented help-path contract: any
+    // command containing `--help` prints usage and exits cleanly, even
+    // when the rest of the command line is garbage. Callers that need
+    // their other flags applied must omit `--help`.
     ScreenshotCliOptions options;
     REQUIRE_NOTHROW(options = parse_args({
         "--script", "before-help.js",
@@ -209,10 +215,47 @@ TEST_CASE("pulp-screenshot help option stops parsing later malformed flags",
     }));
 
     REQUIRE(options.help);
-    REQUIRE(options.script_path == "before-help.js");
+    // Pre-help flags are intentionally NOT applied — help short-circuits
+    // the whole option loop. Defaults remain.
+    REQUIRE(options.script_path.empty());
     REQUIRE(options.width == 400);
     REQUIRE(options.height == 300);
     REQUIRE(options.backend_was_defaulted);
+}
+
+// Regression: #2956 / Codex comment 3304939247 — the previous fix
+// (#2957) set `options.help = true` and continued the parse loop, so
+// malformed numeric options ANYWHERE in argv (including BEFORE `--help`)
+// still ran std::stoi / std::stof and threw, surfacing an error instead
+// of clean help output. This pins help-path robustness in the order
+// the user is most likely to hit it: a typo first, `--help` later.
+TEST_CASE("pulp-screenshot --help short-circuits malformed args before it (#2956)",
+          "[tools][screenshot][coverage][issue-2956]") {
+    // Malformed --width / --height BEFORE --help must not blow up.
+    ScreenshotCliOptions options;
+    REQUIRE_NOTHROW(options = parse_args({
+        "--width", "not-a-number",
+        "--height", "also-bad",
+        "--scale", "definitely-not-a-float",
+        "--help",
+    }));
+    REQUIRE(options.help);
+    // The values keep their defaults — the option loop never ran.
+    REQUIRE(options.width == 400);
+    REQUIRE(options.height == 300);
+    REQUIRE(options.scale == 2.0f);
+
+    // -h short flag also short-circuits.
+    REQUIRE_NOTHROW(options = parse_args({"--width", "BAD", "-h"}));
+    REQUIRE(options.help);
+
+    // Help anywhere in the middle of malformed args still works.
+    REQUIRE_NOTHROW(options = parse_args({
+        "--width", "x",
+        "--help",
+        "--height", "y",
+    }));
+    REQUIRE(options.help);
 }
 
 TEST_CASE("pulp-screenshot backend normalization rejects unavailable explicit Skia",

--- a/test/test_vst3_frame_rate.cpp
+++ b/test/test_vst3_frame_rate.cpp
@@ -1,0 +1,60 @@
+// VST3 SMPTE → pulp::format::FrameRate mapping.
+//
+// Extracted from vst3_adapter.cpp into a Steinberg-SDK-free helper so
+// the table is unit-testable without the VST3 SDK. Pins the
+// regression for #2963 (Codex comment 3305434120): a `framesPerSecond
+// == 60` mapping that also matched 59.94 (= 60 + pulldown).
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/format/detail/vst3_frame_rate.hpp>
+#include <pulp/format/processor.hpp>
+
+using pulp::format::detail::vst3_frame_rate;
+using FR = pulp::format::FrameRate;
+
+TEST_CASE("vst3_frame_rate — integer SMPTE rates (no pulldown / no drop)",
+          "[format][vst3][playhead]") {
+    REQUIRE(vst3_frame_rate(24, /*pulldown=*/false, /*drop=*/false) == FR::fps_24);
+    REQUIRE(vst3_frame_rate(25, false, false) == FR::fps_25);
+    REQUIRE(vst3_frame_rate(30, false, false) == FR::fps_30);
+    REQUIRE(vst3_frame_rate(60, false, false) == FR::fps_60);
+}
+
+TEST_CASE("vst3_frame_rate — 23.976 / 29.97 / 29.97-drop / 30-drop",
+          "[format][vst3][playhead]") {
+    // 23.976 = 24 + pulldown — Pulp's enum has no 23.976 entry, so we
+    // collapse to fps_24 (documented in the helper header).
+    REQUIRE(vst3_frame_rate(24, /*pulldown=*/true, /*drop=*/false) == FR::fps_24);
+    // 29.97 = 30 + pulldown.
+    REQUIRE(vst3_frame_rate(30, true, false) == FR::fps_29_97);
+    // 29.97 drop = 30 + pulldown + drop.
+    REQUIRE(vst3_frame_rate(30, true, true) == FR::fps_29_97_drop);
+    // 30 drop = 30 + drop.
+    REQUIRE(vst3_frame_rate(30, false, true) == FR::fps_30_drop);
+}
+
+// Regression: #2963 / Codex comment 3305434120 — the VST3 mapper used
+// `else if (fps == 60)`, which also matched 59.94 (= 60 + pulldown).
+// 59.94 sessions became indistinguishable from true 60fps and broke
+// SMPTE / timecode math in plug-ins that trust ctx.frame_rate. The fix
+// gates the 60→fps_60 case on `!pulldown`, leaving 59.94 to fall through
+// to FrameRate::unknown (Pulp's enum has no 59.94 entry).
+TEST_CASE("vst3_frame_rate — 59.94 must NOT map to fps_60 (#2963)",
+          "[format][vst3][playhead][issue-2963]") {
+    // 59.94 == 60 + pulldown.
+    REQUIRE(vst3_frame_rate(60, /*pulldown=*/true, /*drop=*/false) != FR::fps_60);
+    REQUIRE(vst3_frame_rate(60, /*pulldown=*/true, /*drop=*/false) == FR::unknown);
+    // True 60 (no pulldown) still maps to fps_60.
+    REQUIRE(vst3_frame_rate(60, /*pulldown=*/false, /*drop=*/false) == FR::fps_60);
+}
+
+TEST_CASE("vst3_frame_rate — unsupported integer rates fall through to unknown",
+          "[format][vst3][playhead]") {
+    // 50 has no Pulp enum entry.
+    REQUIRE(vst3_frame_rate(50, false, false) == FR::unknown);
+    // 23 / 0 / negative / huge — all unknown.
+    REQUIRE(vst3_frame_rate(23, false, false) == FR::unknown);
+    REQUIRE(vst3_frame_rate(0, false, false) == FR::unknown);
+    REQUIRE(vst3_frame_rate(120, false, false) == FR::unknown);
+}

--- a/test/test_workgroup.cpp
+++ b/test/test_workgroup.cpp
@@ -38,6 +38,45 @@ TEST_CASE("AudioWorkgroup join without workgroup uses fallback", "[audio][workgr
     }
 }
 
+// Regression: #2970 / Codex comment 3305855151 — the CoreAudio render
+// callback used to set `wg_joined_` to true UNCONDITIONALLY, even if
+// `join_from_audio_thread()` returned false (a transient failure on the
+// first render call). After that, every later render skipped the join,
+// permanently leaving the audio thread without workgroup membership /
+// RT-priority fallback for the rest of the session.
+//
+// The fix at coreaudio_device.mm:313 uses the join return value to gate
+// the flag flip. We mirror the call-site pattern here so future refactors
+// of the workgroup contract can't silently regress the device side:
+// AudioWorkgroup::join_from_audio_thread() must always return the actual
+// success/failure of the join attempt (NOT "true if attempted"), and
+// is_joined() must stay false until a join actually succeeds.
+TEST_CASE("AudioWorkgroup join_from_audio_thread reports actual success/failure",
+          "[audio][workgroup][issue-2970]") {
+    AudioWorkgroup wg;
+
+    // Contract 1: a fresh workgroup is not joined.
+    REQUIRE_FALSE(wg.is_joined());
+
+    // Contract 2: the return value of join_from_audio_thread() must equal
+    // the resulting is_joined() state. The CoreAudio device callback relies
+    // on this to decide whether to flip wg_joined_ — if the return drifted
+    // out of sync with is_joined(), the device-level retry loop would
+    // either spin forever or, like the bug, stop retrying prematurely.
+    bool result = wg.join_from_audio_thread();
+    REQUIRE(result == wg.is_joined());
+
+    if (result) {
+        // Contract 3 (on success): a second join is idempotent.
+        REQUIRE(wg.join_from_audio_thread());
+        REQUIRE(wg.is_joined());
+        wg.leave();
+        REQUIRE_FALSE(wg.is_joined());
+        // Contract 4: after leave, a subsequent join attempt is allowed.
+        REQUIRE(wg.join_from_audio_thread() == wg.is_joined());
+    }
+}
+
 #if !defined(__APPLE__)
 TEST_CASE("AudioWorkgroup non-Apple fallback join is idempotent",
           "[audio][workgroup][issue-640]") {

--- a/test/test_xcode_developer_path.cpp
+++ b/test/test_xcode_developer_path.cpp
@@ -1,0 +1,58 @@
+// Unit tests for `pulp::cli::looks_like_full_xcode_developer_dir`.
+//
+// Pins the regression for #2969 (Codex comment 3305628892): the
+// `pulp ship auv3-xcodeproj` developer-path check used to hard-match
+// the literal substring `Xcode.app`, blocking beta-channel users with
+// `Xcode-beta.app` (and any other custom-named full Xcode install).
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "xcode_developer_path.hpp"
+
+using pulp::cli::looks_like_full_xcode_developer_dir;
+
+TEST_CASE("looks_like_full_xcode_developer_dir — canonical Xcode.app path",
+          "[cli][ship][xcode-select]") {
+    REQUIRE(looks_like_full_xcode_developer_dir(
+        "/Applications/Xcode.app/Contents/Developer"));
+}
+
+// Regression: #2969 / Codex comment 3305628892. These are real paths
+// produced by `xcode-select -p` on common beta / pinned installs that
+// the previous literal `Xcode.app` substring check rejected.
+TEST_CASE("looks_like_full_xcode_developer_dir — accepts beta / versioned bundles",
+          "[cli][ship][xcode-select][issue-2969]") {
+    REQUIRE(looks_like_full_xcode_developer_dir(
+        "/Applications/Xcode-beta.app/Contents/Developer"));
+    REQUIRE(looks_like_full_xcode_developer_dir(
+        "/Applications/Xcode_15.app/Contents/Developer"));
+    REQUIRE(looks_like_full_xcode_developer_dir(
+        "/Applications/Xcode_16.2.app/Contents/Developer"));
+    // Custom paths (non-/Applications) must work too.
+    REQUIRE(looks_like_full_xcode_developer_dir(
+        "/Users/dev/tools/Xcode-15.4.app/Contents/Developer"));
+    // Even non-Xcode-named app bundles — the helper is name-agnostic by
+    // design, so it accepts any `.app/Contents/Developer` path. The
+    // outer caller can additionally check `xcodebuild` is usable; this
+    // helper just rejects the command-line-tools shim and similar.
+    REQUIRE(looks_like_full_xcode_developer_dir(
+        "/Applications/MyForkOfXcode.app/Contents/Developer"));
+}
+
+TEST_CASE("looks_like_full_xcode_developer_dir — rejects command-line-tools shim",
+          "[cli][ship][xcode-select]") {
+    REQUIRE_FALSE(looks_like_full_xcode_developer_dir(
+        "/Library/Developer/CommandLineTools"));
+    REQUIRE_FALSE(looks_like_full_xcode_developer_dir(""));
+    // No `.app/` anywhere.
+    REQUIRE_FALSE(looks_like_full_xcode_developer_dir(
+        "/Library/Developer/CommandLineTools/Contents/Developer"));
+    // Empty bundle name (`/.app/...`) is malformed — reject.
+    REQUIRE_FALSE(looks_like_full_xcode_developer_dir(
+        "/.app/Contents/Developer"));
+    // `.app` substring without `/Contents/Developer` suffix — incomplete.
+    REQUIRE_FALSE(looks_like_full_xcode_developer_dir(
+        "/Applications/Xcode.app"));
+    REQUIRE_FALSE(looks_like_full_xcode_developer_dir(
+        "/Applications/Xcode.app/Contents/"));
+}

--- a/tools/cli/cmd_ship.cpp
+++ b/tools/cli/cmd_ship.cpp
@@ -2,6 +2,7 @@
 // Handles: sign, notarize, package, appcast, check
 
 #include "cli_common.hpp"
+#include "xcode_developer_path.hpp"
 
 #include <ctime>
 #include <fstream>
@@ -842,17 +843,28 @@ int cmd_ship(const std::vector<std::string>& args) {
         // has no full Xcode behind it. Generating an Xcode project with
         // only the command-line tools succeeds in part but produces a
         // .xcodeproj that the actual Xcode.app refuses to open.
+        //
+        // Accept any full-Xcode developer path of the form
+        // `<...>/Xcode*.app/Contents/Developer`. We must NOT hard-match
+        // the literal substring `Xcode.app` because beta-channel users
+        // run `Xcode-beta.app`, `Xcode_15.app`, etc., and the previous
+        // check blocked all of them. Regression: #2969 / Codex comment
+        // 3305628892. We still reject the command-line-tools-only
+        // selection (`/Library/Developer/CommandLineTools`) by requiring
+        // both `.app/` AND `/Contents/Developer` in the path.
         std::string xcselect = exec_output("xcode-select -p 2>/dev/null");
         // trim trailing newline
         while (!xcselect.empty() &&
                (xcselect.back() == '\n' || xcselect.back() == '\r'))
             xcselect.pop_back();
-        if (xcselect.empty() || xcselect.find("Xcode.app") == std::string::npos) {
+        if (xcselect.empty() ||
+            !pulp::cli::looks_like_full_xcode_developer_dir(xcselect)) {
             std::cerr << "pulp ship auv3-xcodeproj: full Xcode.app not "
                          "selected (xcode-select -p reports '" << xcselect
                       << "').\n"
                          "Run `sudo xcode-select -s /Applications/Xcode.app/"
-                         "Contents/Developer` and retry, or pass --dry-run.\n";
+                         "Contents/Developer` (or `Xcode-beta.app/Contents/"
+                         "Developer`) and retry, or pass --dry-run.\n";
             return 1;
         }
 

--- a/tools/cli/xcode_developer_path.hpp
+++ b/tools/cli/xcode_developer_path.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+// Helpers for validating `xcode-select -p` output.
+//
+// Extracted so the predicate is unit-testable without spawning a real
+// `xcode-select` process. `pulp ship auv3-xcodeproj` calls this to refuse
+// running when only the command-line tools are selected (the result is a
+// .xcodeproj that the real Xcode.app cannot open).
+//
+// We must NOT hard-match the literal substring `Xcode.app` because
+// beta-channel users run `Xcode-beta.app`, `Xcode_15.app`, custom-named
+// app bundles, etc. The previous hard match blocked all of them and
+// blocked `pulp ship auv3-xcodeproj` for beta users entirely. See
+// #2969 / Codex comment 3305628892.
+
+#include <string>
+
+namespace pulp::cli {
+
+/// Return true iff `xcselect_path` looks like a full-Xcode developer dir
+/// (something like `<...>/Xcode*.app/Contents/Developer`). Rejects the
+/// command-line-tools selection (`/Library/Developer/CommandLineTools`)
+/// because that path does not contain an `.app/` bundle component.
+inline bool looks_like_full_xcode_developer_dir(const std::string& path) noexcept {
+    // Must contain `.app/Contents/Developer` (or close — we accept the
+    // exact substring; trailing slash is preserved by xcode-select -p,
+    // which doesn't emit one).
+    const std::string needle = ".app/Contents/Developer";
+    auto pos = path.find(needle);
+    if (pos == std::string::npos) return false;
+    // The substring before `.app` must end with at least one non-slash
+    // character (no `/.app/...` at the start, no empty bundle name).
+    return pos > 0 && path[pos - 1] != '/';
+}
+
+}  // namespace pulp::cli

--- a/tools/screenshot/pulp_screenshot.cpp
+++ b/tools/screenshot/pulp_screenshot.cpp
@@ -102,6 +102,22 @@ struct ScreenshotCliOptions {
 
 static ScreenshotCliOptions parse_options(int argc, char* argv[]) {
     ScreenshotCliOptions options;
+    // Short-circuit on --help / -h BEFORE running the option loop. The
+    // option loop calls std::stoi / std::stof on `--width`, `--height`,
+    // `--scale` arguments, which throw on malformed input. Without this
+    // pre-scan, a command like `pulp-screenshot --width foo --help`
+    // would throw before reaching the help check and exit non-zero
+    // instead of printing usage with exit code 0. Regression:
+    // #2956 / Codex comment 3304939247 (resurfaced after #2957's
+    // partial fix moved the flag-set into the loop without breaking
+    // out of it).
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--help" || arg == "-h") {
+            options.help = true;
+            return options;
+        }
+    }
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
         if (arg == "--script" && i + 1 < argc) options.script_path = argv[++i];
@@ -116,10 +132,6 @@ static ScreenshotCliOptions parse_options(int argc, char* argv[]) {
         }
         else if (arg == "--base64") options.output_base64 = true;
         else if (arg == "--demo") options.demo = true;
-        else if (arg == "--help" || arg == "-h") {
-            options.help = true;
-            return options;
-        }
     }
     return options;
 }


### PR DESCRIPTION
Bundle of 8 P2 Codex findings tracked in #2976, following #2984's P1 bundle. Each commit ships a regression test per CLAUDE.md "tests ship with fixes". The 9th P2 (#2921 — docs-search path platform-neutral) was already addressed in the merged code (`slash_normalized()` already in place); marked DEFERRED with no work needed.

## Fixes (one per commit)

1. **`core/format/src/host_type_mac.mm`** — Codex 3305508749 (PR #2967)
   - AUv3 extension detection used `[bundleIdentifier hasSuffix:@".appex"]`, but identifiers are reverse-DNS strings and never carry `.appex`. Fix uses bundle PATH instead. Regression test pins the AU_HOST_BUNDLE_ID env override channel.

2. **`core/audio/platform/mac/coreaudio_device.mm`** — Codex 3305855151 (PR #2970)
   - `wg_joined_` was set unconditionally even if `join_from_audio_thread()` failed. First transient failure permanently disabled join + fallback RT priority. Fix gates the flag on the join return value.

3. **`core/format/src/vst3_adapter.cpp`** — Codex 3305434120 (PR #2963)
   - `else if (fps == 60)` also matched 59.94 (= 60 + pulldown). 59.94 sessions mislabelled as fps_60 broke SMPTE math. Fix gates on `!pulldown`. The mapping table was extracted to a Steinberg-SDK-free helper so the regression is unit-testable; 15 assertions across 4 cases.

4. **`core/format/src/clap_adapter.cpp`** — Codex 3305434127 (PR #2963)
   - `playhead_prev` was never reset across `clap_activate` / `clap_deactivate` / `clap_reset`. First block after a reactivate spuriously raised `tempo_changed` / `time_sig_changed` / `transport_changed`. Fix resets the snapshot in all three lifecycle hooks. Regression test covers both reset paths.

5. **`tools/cli/cmd_ship.cpp`** — Codex 3305628892 (PR #2969)
   - `auv3-xcodeproj` rejected any `xcode-select -p` not containing literal `Xcode.app`, blocking beta-channel users (`Xcode-beta.app`). Fix gates on structural `<bundle>.app/Contents/Developer` pattern. Predicate extracted to `xcode_developer_path.hpp`; 12 test assertions cover accepted and rejected paths.

6. **`core/audio/src/audio_thumbnail.cpp`** (`clear_disk_cache`) — Codex 3305530564 (PR #2966)
   - Range-for over `directory_iterator(dir, ec)` still used the throwing increment path. Fix drives the iterator manually with `it.increment(ec)`. Regression test pins REQUIRE_NOTHROW for 4 degenerate scenarios.

7. **`core/midi/src/midi_ci.cpp`** (`notify()`) — Codex 3305288220 (PR #2959)
   - Returned `subscribers.size()` even when `on_pe_notify` was unset and zero notifications were sent. Callers using the return for delivery accounting were misled. Fix returns the actual callback-invocation count.

8. **`tools/screenshot/pulp_screenshot.cpp`** — Codex 3304939247 (PR #2956, re-raised after #2957's partial fix)
   - `--help --width not-a-number` setup: the parse loop ran `std::stoi` on malformed numerics before reaching the help check, throwing instead of printing usage. Fix does a pre-scan for `--help` / `-h` BEFORE the option loop. Updated the pre-existing test to reflect the corrected contract.

## Deferred

- **#2921 / Codex 3301765285** (`test/test_cli_docs_command.cpp` — platform-neutral path assertion): **already addressed** in the merged code via the existing `slash_normalized()` helper at line 201. No changes needed.

## Validation

- `pulp-test-midi-ci-pe` — 1427 assertions in 37 cases (incl. new `[issue-2959]` for notify count)
- `pulp-test-audio-thumbnail` — added 4-scenario `clear_disk_cache` no-throw test (`[issue-2966]`)
- `pulp-test-clap-midi-events` — 372 assertions in 41 cases (incl. new `[issue-2963]` lifecycle reset)
- `pulp-test-vst3-frame-rate` — new test target, 15 assertions in 4 cases (`[issue-2963]`)
- `pulp-test-xcode-developer-path` — new test target, 12 assertions in 3 cases (`[issue-2969]`)
- `pulp-test-workgroup` — added `[issue-2970]` AudioWorkgroup contract test
- `pulp-test-screenshot-cli-contracts` — 125 assertions in 10 cases (incl. new `[issue-2956]`)

## Version

SDK 0.254.1 → 0.254.2 (patch, override via `Version-Bump: sdk=patch` trailer — bug-fix-only bundle).
Skill-sync skip trailers added for clap / vst3 / cli-maintenance / ship (bug fixes, no new patterns / gotchas to document).

Refs #2976.