### PR TITLE
fix(audio): shared token-id counter for MIDI subscription hub (closes #2976 P1 batch 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.255.3
+    VERSION 0.256.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/audio/include/pulp/audio/audio_device_manager.hpp
+++ b/core/audio/include/pulp/audio/audio_device_manager.hpp
@@ -412,13 +412,21 @@ private:
     /// this; destruction marks the manager dead.
     std::shared_ptr<void>                        lifetime_;
 
+    /// Single monotonic counter shared by every subscription API on
+    /// this manager (MIDI events, MIDI endpoints, device-change). The
+    /// unsubscribe path is allowed to probe multiple maps with the
+    /// same id, so the id must be globally unique across all maps —
+    /// otherwise destroying one subscription token can erase an
+    /// unrelated subscription that happens to share the numeric id
+    /// (see issue #2976 / PR #2970 Codex finding). Atomic so callers
+    /// don't need to hold any particular mutex to allocate one.
+    std::atomic<uint64_t>                        next_token_id_{1};
+
     mutable std::mutex                           midi_mu_;
     std::unordered_map<uint64_t, MidiHandler>    midi_subs_;
-    uint64_t                                     next_midi_id_ = 1;
 
     mutable std::mutex                                          device_change_mu_;
     std::unordered_map<uint64_t, DeviceChangeHandler>           device_change_subs_;
-    uint64_t                                                    next_device_change_id_ = 1;
 
     mutable std::mutex                              default_dev_mu_;
     DefaultDeviceChangeHandler                      default_dev_handler_;
@@ -432,7 +440,6 @@ private:
 
     mutable std::mutex                                                midi_ep_mu_;
     std::unordered_map<uint64_t, MidiEndpointChangeHandler>           midi_ep_subs_;
-    uint64_t                                                          next_midi_ep_id_ = 1;
     std::vector<MidiEndpoint>                                         midi_endpoints_;
 
     AudioSystem*                                    attached_system_ = nullptr;

--- a/core/audio/src/audio_device_manager.cpp
+++ b/core/audio/src/audio_device_manager.cpp
@@ -227,8 +227,13 @@ DeviceConfig AudioDeviceManager::selection_to_config(
 
 MidiSubscriptionToken AudioDeviceManager::subscribe_midi(MidiHandler handler) {
     if (!handler) return {};
+    // Allocate the id BEFORE taking midi_mu_. Token ids are globally
+    // unique across every subscription map on this manager — see the
+    // comment on next_token_id_ in the header. Doing it outside the
+    // lock keeps the critical section minimal and means a hypothetical
+    // future reordering of subscribe calls can never reuse an id.
+    const uint64_t id = next_token_id_.fetch_add(1, std::memory_order_relaxed);
     std::lock_guard<std::mutex> lk(midi_mu_);
-    const uint64_t id = next_midi_id_++;
     midi_subs_.emplace(id, std::move(handler));
     return MidiSubscriptionToken(
         std::weak_ptr<void>(lifetime_),
@@ -352,8 +357,13 @@ void AudioDeviceManager::DeviceChangeToken::reset() noexcept {
 AudioDeviceManager::DeviceChangeToken
 AudioDeviceManager::subscribe_device_changes(DeviceChangeHandler handler) {
     if (!handler) return {};
+    // Shared counter — see next_token_id_ comment in the header.
+    // DeviceChangeToken routes to its own unsubscribe path, so this
+    // particular allocation can't currently collide with MIDI, but
+    // using the shared counter guarantees future-proofing if any
+    // unsubscribe path ever probes additional maps.
+    const uint64_t id = next_token_id_.fetch_add(1, std::memory_order_relaxed);
     std::lock_guard<std::mutex> lk(device_change_mu_);
-    const uint64_t id = next_device_change_id_++;
     device_change_subs_.emplace(id, std::move(handler));
     return DeviceChangeToken(
         std::weak_ptr<void>(lifetime_),
@@ -479,8 +489,13 @@ void AudioDeviceManager::reset_xrun_counter() {
 MidiSubscriptionToken AudioDeviceManager::subscribe_midi_endpoints(
     MidiEndpointChangeHandler handler) {
     if (!handler) return {};
+    // Globally unique across midi_subs_ AND midi_ep_subs_; see
+    // next_token_id_ comment in the header. This is what stops
+    // unsubscribe_midi() from erasing the wrong subscriber when a
+    // MIDI handler and an endpoint handler happen to share an id
+    // (previously both counters started at 1).
+    const uint64_t id = next_token_id_.fetch_add(1, std::memory_order_relaxed);
     std::lock_guard<std::mutex> lk(midi_ep_mu_);
-    const uint64_t id = next_midi_ep_id_++;
     midi_ep_subs_.emplace(id, std::move(handler));
     // Reuse MidiSubscriptionToken; its unsubscribe routes via
     // unsubscribe_midi_endpoint() because we mark the id with the

--- a/test/test_audio_device_manager.cpp
+++ b/test/test_audio_device_manager.cpp
@@ -507,6 +507,120 @@ TEST_CASE("AudioDeviceManager MIDI endpoint delta tracking fires per change",
     REQUIRE(mgr.midi_endpoints()[0].id == "ep:mini");
 }
 
+// Regression for issue #2976 / PR #2970 Codex P1 finding:
+// subscribe_midi() and subscribe_midi_endpoints() previously used two
+// independent counters that both started at 1. unsubscribe_midi()
+// erases by id from BOTH maps, so destroying the endpoint token (id=1)
+// would erase the unrelated MIDI subscriber (also id=1) and leave the
+// endpoint subscriber alive. The fix is a single monotonic counter
+// shared across all subscription maps so ids never collide.
+TEST_CASE("AudioDeviceManager MIDI and endpoint token ids do not collide",
+          "[audio][audio-device-manager][midi][issue-2976][issue-2970]") {
+    AudioDeviceManager mgr;
+
+    std::atomic<int> midi_calls{0};
+    std::atomic<int> ep_calls{0};
+
+    // Subscribe order matters: this is the order that previously
+    // produced id=1 on both maps under the old counter scheme.
+    auto midi_tok = mgr.subscribe_midi(
+        [&](const pulp::midi::MidiEvent&) { ++midi_calls; });
+    auto ep_tok = mgr.subscribe_midi_endpoints(
+        [&](const AudioDeviceManager::MidiEndpointChange&) { ++ep_calls; });
+
+    REQUIRE(mgr.midi_subscriber_count() == 1);
+    REQUIRE(mgr.midi_endpoint_subscriber_count() == 1);
+
+    // Destroy the endpoint token first. Under the bug, this routed
+    // through unsubscribe_midi(), which probed midi_subs_ first, found
+    // a matching id, and erased the MIDI subscriber by mistake. The
+    // endpoint subscriber stayed live.
+    ep_tok.reset();
+
+    // Post-condition the bug violated:
+    //   - the MIDI subscriber must still be live
+    //   - the endpoint subscriber must be gone
+    REQUIRE(mgr.midi_subscriber_count() == 1);
+    REQUIRE(mgr.midi_endpoint_subscriber_count() == 0);
+
+    // Functional confirmation: dispatch hits MIDI (still alive) and
+    // does NOT hit endpoints.
+    mgr.dispatch_midi_event(pulp::midi::MidiEvent::note_on(0, 60, 100));
+    REQUIRE(midi_calls.load() == 1);
+
+    AudioDeviceManager::MidiEndpoint ep;
+    ep.id = "ep:new";
+    ep.name = "New Device";
+    ep.is_input = true;
+    mgr.set_midi_endpoints({ep});
+    REQUIRE(ep_calls.load() == 0);
+}
+
+// Stress regression: many register/unregister cycles for both MIDI and
+// endpoint hubs interleaved across multiple threads. Under the old
+// per-map counters, destroying an endpoint token could erase the
+// wrong MIDI subscriber (same numeric id), so subscriber counts would
+// drift away from what the test explicitly held. With the shared
+// monotonic counter, post-condition counts match the held tokens
+// exactly.
+TEST_CASE("AudioDeviceManager subscriptions stay globally consistent under load",
+          "[audio][audio-device-manager][midi][issue-2976][issue-2970]") {
+    AudioDeviceManager mgr;
+
+    constexpr int kPerThread = 64;
+    constexpr int kThreads   = 4;
+
+    std::mutex hold_mu;
+    std::vector<MidiSubscriptionToken> midi_hold;
+    std::vector<MidiSubscriptionToken> ep_hold;
+    midi_hold.reserve(kThreads * kPerThread);
+    ep_hold.reserve(kThreads * kPerThread);
+
+    auto worker = [&](bool use_endpoints) {
+        std::vector<MidiSubscriptionToken> local;
+        local.reserve(kPerThread);
+        for (int i = 0; i < kPerThread; ++i) {
+            auto tok = use_endpoints
+                ? mgr.subscribe_midi_endpoints(
+                    [](const AudioDeviceManager::MidiEndpointChange&) {})
+                : mgr.subscribe_midi([](const pulp::midi::MidiEvent&) {});
+            REQUIRE(tok.active());
+            local.push_back(std::move(tok));
+        }
+        std::lock_guard<std::mutex> lk(hold_mu);
+        auto& dest = use_endpoints ? ep_hold : midi_hold;
+        for (auto& t : local) dest.push_back(std::move(t));
+    };
+
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+    for (int t = 0; t < kThreads; ++t) {
+        // Half the threads subscribe MIDI events, half subscribe
+        // endpoints. The bug surfaced when both sides issued the same
+        // low ids (1, 2, 3, …) and destruction order crossed maps.
+        threads.emplace_back(worker, /*use_endpoints=*/(t % 2 == 0));
+    }
+    for (auto& th : threads) th.join();
+
+    const int midi_threads = (kThreads + 1) / 2;
+    const int ep_threads   = kThreads - midi_threads;
+    REQUIRE(mgr.midi_subscriber_count() ==
+            static_cast<size_t>(midi_threads * kPerThread));
+    REQUIRE(mgr.midi_endpoint_subscriber_count() ==
+            static_cast<size_t>(ep_threads * kPerThread));
+
+    // Now drop all endpoint tokens. If destroying one could erase the
+    // wrong subscriber (the bug), the MIDI count would visibly drift.
+    ep_hold.clear();
+    REQUIRE(mgr.midi_endpoint_subscriber_count() == 0);
+    REQUIRE(mgr.midi_subscriber_count() ==
+            static_cast<size_t>(midi_threads * kPerThread));
+
+    // Drop the remaining MIDI tokens; counters return to zero.
+    midi_hold.clear();
+    REQUIRE(mgr.midi_subscriber_count() == 0);
+}
+
 TEST_CASE("AudioDeviceManager latch_close drops subsequent dispatches",
           "[audio][audio-device-manager][lifecycle][shutdown][issue-2935]") {
     AudioDeviceManager mgr;


### PR DESCRIPTION
Closes the remaining two P1 Codex findings tracked in #2976.

## Summary

- **`audio_device_manager` MIDI/endpoint token-id collision** (PR #2970 finding) — `subscribe_midi()` and `subscribe_midi_endpoints()` allocated ids from independent counters that both started at 1. Token destruction routes through `unsubscribe_midi()`, which erases by id from BOTH maps, so destroying an endpoint token with id N would erase a MIDI subscriber with the same N. Fix: single `std::atomic<uint64_t> next_token_id_` shared across every subscription API on the manager. Ids are globally unique → cross-map probes are inert by construction.

- **`osc_udp` socket close on callback-thread stop** (PR #2822 finding) — already closed in `main` by commit `bbc1506ed2` (merged via PR #2822). The current `stop_impl()` calls `close_socket(sock)` on the callback-thread branch (line 421), and `test_osc.cpp` "OSC Receiver callbacks can request stop without self-joining" pins it by binding a fresh receiver to the same port immediately after a callback-triggered stop. No additional fix or test needed.

## Regression tests

Both new tests in `test/test_audio_device_manager.cpp`:

1. **"MIDI and endpoint token ids do not collide"** — pins the exact failure mode. Subscribe MIDI → subscribe endpoint → drop endpoint token → assert MIDI sub is still live and endpoint sub is gone. Plus a functional dispatch assertion.

2. **"subscriptions stay globally consistent under load"** — 4 threads × 64 cycles register both MIDI and endpoint subscribers in parallel, holding tokens. Asserts post-condition counts match exactly. Under the bug, cross-map id collisions caused observable drift.

## Validation

```
$ ./build/test/pulp-test-audio-device-manager '[issue-2970]'
All tests passed (267 assertions in 2 test cases)

$ ./build/test/pulp-test-audio-device-manager
All tests passed (366 assertions in 22 test cases)

$ ./build/test/pulp-test-osc 'OSC Receiver callbacks can request stop without self-joining'
All tests passed (28 assertions in 1 test case)
```

Release build, GPU off, on origin/main rebased.

Refs #2976 #2970 #2822