### PR TITLE
ci(create): template integrity smoke for pulp create materializer

### DIFF
--- a/.github/workflows/templates-smoke.yml
+++ b/.github/workflows/templates-smoke.yml
@@ -1,0 +1,69 @@
+name: Templates smoke
+
+# Structural smoke for the `pulp create` template tree.
+#
+# `pulp create --type <effect|instrument|app|bare>` materializes a Pulp
+# project by walking `tools/templates/<type>/*.template` and substituting
+# `{{VAR}}` placeholders against the inline substitution map in
+# `tools/cli/cmd_create.cpp`. Without a guard, the two surfaces drift:
+# adding a `{{NEW_VAR}}` to a template without registering it in the
+# substitution map silently ships the literal placeholder in generated
+# user code; deleting a required template file (e.g.
+# `instrument/CMakeLists.txt.template`) only surfaces the next time a
+# real user runs `pulp create --type instrument`.
+#
+# This workflow runs the Python smoke `verify_create_templates.py` plus
+# its unit tests. It does NOT build the CLI, does NOT need GPU/Skia
+# binaries, and runs in seconds. Hosts that cannot build the full
+# GPU-gated CLI (e.g. linux-arm64 without a Skia binary in the deps
+# manifest) can still validate template integrity this way.
+#
+# This unblocks Chainer Phase 1 ("Materialize Chainer Project") in
+# `planning/2026-05-24-linux-macos-chainer-gap-closure-plan.md`: the
+# materializer is only deterministic if the template tree it walks is
+# itself shaped correctly. Confirmed working on the real Ubuntu 24.04
+# arm64 host the cross lane uses (2026-05-26).
+
+on:
+  pull_request:
+    paths:
+      - 'tools/templates/**'
+      - 'tools/cli/cmd_create.cpp'
+      - 'tools/scripts/verify_create_templates.py'
+      - 'tools/scripts/test_verify_create_templates.py'
+      - '.github/workflows/templates-smoke.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: templates-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    name: pulp create template integrity
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run template-tree integrity smoke
+        run: python3 tools/scripts/verify_create_templates.py
+
+      - name: Run verifier unit tests
+        run: python3 tools/scripts/test_verify_create_templates.py
+
+      - name: Summarize
+        run: |
+          cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+          ## Templates smoke
+
+          Validated that every `tools/templates/<type>/*.template` file
+          references only `{{VAR}}` placeholders listed in the
+          substitution map in `tools/cli/cmd_create.cpp`, and that each
+          plugin/app template directory ships its required minimum file
+          set.
+
+          This is the structural prerequisite for Chainer Phase 1
+          ("Materialize Chainer Project") in the cross-lane plan:
+          a deterministic materializer requires a sound template tree.
+          EOF

--- a/tools/scripts/test_verify_create_templates.py
+++ b/tools/scripts/test_verify_create_templates.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Unit tests for verify_create_templates.py.
+
+Run directly:
+    python3 tools/scripts/test_verify_create_templates.py
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+# Allow running this file standalone without packaging.
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE))
+import verify_create_templates as vct  # noqa: E402
+
+
+class TestScanTemplateVars(unittest.TestCase):
+    def test_finds_simple_var(self) -> None:
+        self.assertEqual(vct.scan_template_vars("Hello {{NAME}}"), {"NAME"})
+
+    def test_finds_multiple_vars(self) -> None:
+        text = "{{PLUGIN_NAME}} by {{MANUFACTURER}} ({{VERSION}})"
+        self.assertEqual(
+            vct.scan_template_vars(text),
+            {"PLUGIN_NAME", "MANUFACTURER", "VERSION"},
+        )
+
+    def test_ignores_single_braces(self) -> None:
+        self.assertEqual(vct.scan_template_vars("not a {VAR} ref"), set())
+
+    def test_ignores_lowercase(self) -> None:
+        # Substitution is uppercase-only by convention.
+        self.assertEqual(vct.scan_template_vars("{{plugin_name}}"), set())
+
+    def test_allows_digits_after_first_char(self) -> None:
+        self.assertEqual(vct.scan_template_vars("{{VST3_UID}}"), {"VST3_UID"})
+
+
+class TestCheckTemplateDir(unittest.TestCase):
+    def _write(self, root: Path, name: str, content: str) -> None:
+        (root / name).write_text(content, encoding="utf-8")
+
+    def test_passes_when_all_required_files_and_known_vars(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            for name in vct.REQUIRED_FILES_BY_TYPE["app"]:
+                self._write(root, name, "// {{PLUGIN_NAME}} {{VERSION}}\n")
+            failures = vct.check_template_dir("app", root)
+            self.assertEqual(failures, [])
+
+    def test_flags_missing_required_file(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            self._write(
+                root, "CMakeLists.txt.template",
+                "# {{PLUGIN_NAME}}\n",
+            )
+            # Missing processor.hpp.template and test.cpp.template.
+            failures = vct.check_template_dir("app", root)
+            self.assertEqual(len(failures), 1)
+            self.assertIn("missing required template files", failures[0])
+            self.assertIn("processor.hpp.template", failures[0])
+            self.assertIn("test.cpp.template", failures[0])
+
+    def test_flags_unknown_template_var(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            for name in vct.REQUIRED_FILES_BY_TYPE["bare"]:
+                self._write(root, name, "// {{PLUGIN_NAME}}\n")
+            self._write(
+                root, "extra.cpp.template",
+                "// {{TOTALLY_NEW_THING}}\n",
+            )
+            failures = vct.check_template_dir("bare", root)
+            self.assertEqual(len(failures), 1)
+            self.assertIn("TOTALLY_NEW_THING", failures[0])
+            self.assertIn("unknown template variable", failures[0])
+
+    def test_skips_required_check_for_unmapped_type(self) -> None:
+        # `android` is intentionally NOT in REQUIRED_FILES_BY_TYPE — it
+        # is a partial template tree. Vars are still validated, but the
+        # required-files check is skipped.
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            self._write(
+                root, "one_file.template",
+                "// {{PLUGIN_NAME}}\n",
+            )
+            failures = vct.check_template_dir("android", root)
+            self.assertEqual(failures, [])
+
+
+class TestMain(unittest.TestCase):
+    def test_pass_run_on_real_pulp_templates(self) -> None:
+        # The committed template tree must pass at HEAD; that is the
+        # whole point of the smoke. If this fails, either:
+        #   a) a template introduced a `{{VAR}}` not in KNOWN_TEMPLATE_VARS,
+        #   b) a template directory lost a required file, or
+        #   c) the substitution map in tools/cli/cmd_create.cpp changed
+        #      and KNOWN_TEMPLATE_VARS here is stale.
+        templates_root = _HERE.parent / "templates"
+        if not templates_root.is_dir():
+            self.skipTest(
+                f"tools/templates not present at {templates_root} "
+                "(running outside Pulp checkout)"
+            )
+        rc = vct.main(["--templates-root", str(templates_root)])
+        self.assertEqual(rc, 0, "verify_create_templates must pass at HEAD")
+
+    def test_fails_on_missing_root(self) -> None:
+        rc = vct.main(["--templates-root", "/nonexistent/path/xyz"])
+        self.assertEqual(rc, 1)
+
+    def test_fails_on_empty_root(self) -> None:
+        with TemporaryDirectory() as td:
+            rc = vct.main(["--templates-root", td])
+            self.assertEqual(rc, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/verify_create_templates.py
+++ b/tools/scripts/verify_create_templates.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Template integrity smoke for `pulp create`.
+
+`pulp create <name> --type <effect|instrument|app|bare>` materializes a
+buildable Pulp project by walking `tools/templates/<type>/*.template` and
+substituting `{{VAR}}` placeholders. The Chainer cross-lane plan
+(`planning/2026-05-24-linux-macos-chainer-gap-closure-plan.md`, Phase 1
+"Materialize Chainer Project") depends on the materializer being
+deterministic and bitrot-free.
+
+Today nothing guards the template tree itself: a template that picks up
+a stray `{{NEW_VAR}}` not in the substitution map in
+`tools/cli/cmd_create.cpp` will silently ship to users with the
+unsubstituted literal in their generated source. Likewise, deleting a
+required template file (e.g. `instrument/CMakeLists.txt.template`) only
+surfaces the next time someone runs `pulp create --type instrument`.
+
+This script is the structural guard:
+
+  1. Every `{{VAR}}` referenced by a `.template` file is listed in
+     `KNOWN_TEMPLATE_VARS`.
+  2. Every plugin/app template directory ships the minimum required
+     files for that template type.
+
+It does NOT build anything. It does NOT need the CLI binary. It runs
+in seconds on every supported platform (Linux x86_64, Linux arm64,
+macOS, Windows), which makes it the right shape for a public-CI gate
+on a host (e.g. the user's Ubuntu arm64 SSH host) that cannot ship the
+GPU/Skia-gated CLI build.
+
+Exit codes:
+    0 — all templates passed structural validation.
+    1 — one or more templates failed (details printed to stderr).
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Keep this list in sync with the `vars` substitution map in
+# `tools/cli/cmd_create.cpp` (the inline `std::vector<std::pair<...>>`
+# inside `cmd_create()`). If you add a new substitution there, add it
+# here too — this script's whole point is to fail loudly when those two
+# lists drift apart.
+KNOWN_TEMPLATE_VARS = frozenset({
+    "PLUGIN_NAME",
+    "CLASS_NAME",
+    "LOWER_NAME",
+    "PLUGIN_URI",
+    "NAMESPACE",
+    "FACTORY_NAME",
+    "HEADER_NAME",
+    "TARGET_NAME",
+    "MANUFACTURER",
+    "MANUFACTURER_CODE",
+    "BUNDLE_ID",
+    "VERSION",
+    "PLUGIN_CODE",
+    "AAX_PRODUCT_CODE",
+    "AAX_NATIVE_CODE",
+    "FORMATS",
+    "DESCRIPTION",
+    "VST3_UID",
+    "SDK_VERSION",
+})
+
+# Per-template-type minimum file set. Missing any of these fails — the
+# template is broken in a way that `pulp create --type <type>` would
+# silently materialize an unbuildable project.
+REQUIRED_FILES_BY_TYPE = {
+    "effect": {
+        "CMakeLists.txt.template",
+        "processor.hpp.template",
+        "test.cpp.template",
+        "au_v2_entry.cpp.template",
+        "clap_entry.cpp.template",
+        "vst3_entry.cpp.template",
+    },
+    "instrument": {
+        "CMakeLists.txt.template",
+        "processor.hpp.template",
+        "test.cpp.template",
+        "au_v2_entry.cpp.template",
+        "clap_entry.cpp.template",
+        "vst3_entry.cpp.template",
+    },
+    "app": {
+        "CMakeLists.txt.template",
+        "processor.hpp.template",
+        "test.cpp.template",
+    },
+    "bare": {
+        "CMakeLists.txt.template",
+        "processor.hpp.template",
+        "test.cpp.template",
+    },
+    # `gain` is a named template (--template gain) that uses the
+    # effect surface.
+    "gain": {
+        "CMakeLists.txt.template",
+        "processor.hpp.template",
+        "test.cpp.template",
+    },
+}
+
+_VAR_PATTERN = re.compile(r"\{\{([A-Z_][A-Z0-9_]*)\}\}")
+
+
+def scan_template_vars(text: str) -> set[str]:
+    """Return the set of `{{VAR}}` names referenced in `text`."""
+    return set(_VAR_PATTERN.findall(text))
+
+
+def check_template_dir(type_name: str, dir_path: Path) -> list[str]:
+    """Return a list of human-readable failure messages for `dir_path`."""
+    failures: list[str] = []
+    required = REQUIRED_FILES_BY_TYPE.get(type_name)
+    if required is None:
+        # Template type isn't in the required-set map (e.g. android,
+        # auv3, standalone, from-figma, from-v0). Those are partial
+        # template trees that compose with another type; their
+        # structural rules differ and are out of scope for this smoke.
+        # We still validate every `{{VAR}}` they reference.
+        present = set()
+    else:
+        present = {p.name for p in dir_path.glob("*.template")}
+        missing = required - present
+        if missing:
+            failures.append(
+                f"[{type_name}] missing required template files: "
+                + ", ".join(sorted(missing))
+            )
+
+    for template_file in sorted(dir_path.glob("*.template")):
+        try:
+            text = template_file.read_text(encoding="utf-8")
+        except UnicodeDecodeError as e:
+            failures.append(
+                f"[{type_name}] {template_file.name}: not valid UTF-8: {e}"
+            )
+            continue
+        unknown = scan_template_vars(text) - KNOWN_TEMPLATE_VARS
+        if unknown:
+            failures.append(
+                f"[{type_name}] {template_file.name}: references "
+                f"unknown template variable(s): "
+                + ", ".join(f"{{{{{v}}}}}" for v in sorted(unknown))
+                + " (add to KNOWN_TEMPLATE_VARS here and to the "
+                  "substitution map in tools/cli/cmd_create.cpp)"
+            )
+    return failures
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Structural smoke for pulp create templates",
+    )
+    parser.add_argument(
+        "--templates-root",
+        type=Path,
+        default=None,
+        help=(
+            "Path to tools/templates/ (default: resolved relative to "
+            "this script)"
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if args.templates_root is None:
+        # tools/scripts/verify_create_templates.py  →  tools/templates/
+        script_dir = Path(__file__).resolve().parent
+        templates_root = script_dir.parent / "templates"
+    else:
+        templates_root = args.templates_root
+
+    if not templates_root.is_dir():
+        print(
+            f"verify_create_templates: templates root not found: "
+            f"{templates_root}",
+            file=sys.stderr,
+        )
+        return 1
+
+    all_failures: list[str] = []
+    type_dirs = [
+        d for d in sorted(templates_root.iterdir())
+        if d.is_dir() and any(d.glob("*.template"))
+    ]
+    if not type_dirs:
+        print(
+            f"verify_create_templates: no template directories with "
+            f"*.template files under {templates_root}",
+            file=sys.stderr,
+        )
+        return 1
+
+    for type_dir in type_dirs:
+        all_failures.extend(check_template_dir(type_dir.name, type_dir))
+
+    if all_failures:
+        for line in all_failures:
+            print(line, file=sys.stderr)
+        print(
+            f"\nverify_create_templates: {len(all_failures)} failure(s) "
+            f"across {len(type_dirs)} template directory/ies",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"verify_create_templates: {len(type_dirs)} template directories "
+        f"OK — all `{{{{VAR}}}}` references match the substitution map"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a structural smoke for `pulp create` template tree:

- `tools/scripts/verify_create_templates.py` — walks every `tools/templates/<type>/*.template` and fails loudly when a `{{VAR}}` placeholder is missing from the substitution map in `tools/cli/cmd_create.cpp`, or when a plugin/app template directory is missing its required minimum file set
- `tools/scripts/test_verify_create_templates.py` — 12 unit tests covering var scanning, required-file detection, and end-to-end pass against the committed template tree
- `.github/workflows/templates-smoke.yml` — advisory CI workflow that runs on PRs touching templates / `cmd_create.cpp` / the verifier

## Why

Nothing guarded the template tree itself. Adding a `{{NEW_VAR}}` without registering it in `cmd_create.cpp` silently shipped the literal placeholder in generated user code. Deleting a required template file only surfaced the next time someone ran `pulp create --type <that-type>`.

## Cross-lane context

This is the public-CI prerequisite for **Chainer Phase 1** ("Materialize Chainer Project") in `planning/2026-05-24-linux-macos-chainer-gap-closure-plan.md`. The Chainer materializer the private infra lane depends on is only deterministic if the template tree it walks is sound.

The smoke does not build the CLI and does not need GPU/Skia binaries, so it works on hosts where the GPU-gated CLI cannot build today — notably the user's Ubuntu 24.04 arm64 host that the cross lane uses. `tools/deps/manifest.json` has no `linux-arm64` Skia asset, so the CLI's `PULP_ENABLE_GPU`-gated build at `CMakeLists.txt:255` cannot complete on arm64 Linux. The planning docs are updated in lockstep with that real-host finding.

## Test plan

- [x] `python3 tools/scripts/verify_create_templates.py` reports 9 directories OK (local)
- [x] `python3 tools/scripts/test_verify_create_templates.py` — 12/12 pass (local)
- [x] Both commands pass on Ubuntu 24.04 arm64 over SSH
- [x] `yamllint` + `actionlint` clean on the new workflow
- [ ] Templates-smoke CI workflow runs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)