### PR TITLE
docs(state+audio): pin StateTree thread-safety + WASAPI share-mode coverage (gap-doc Phase 0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.255.2
+    VERSION 0.255.3
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/audio/platform/win/wasapi_device.hpp
+++ b/core/audio/platform/win/wasapi_device.hpp
@@ -28,6 +28,30 @@ namespace pulp::audio::win {
 // open() / start() take. Duplex callers open two devices and
 // synchronise externally — same model as the rest of the AudioSystem
 // interface, which is direction-agnostic at the device level.
+//
+// ── WASAPI mode coverage (gap-doc Phase 0 audit, 2026-05-26) ─────────────
+//
+// `IAudioClient::Initialize` is invoked with `AUDCLNT_SHAREMODE_SHARED`
+// + `AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_NOPERSIST`
+// at the device's native mix format. This is the default mode the
+// Windows audio engine mixes; buffer size is requested in REFERENCE_TIME
+// units and rounded up to the engine's period.
+//
+// Modes **not** implemented today (intentionally deferred — see
+// planning/2026-05-24-reference-framework-gap-analysis.md row #302):
+//
+//   * `AUDCLNT_SHAREMODE_SHARED` low-latency variant
+//       (RATEADJUST + small periodicity via `IAudioClient3::InitializeSharedAudioStream`
+//        or AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM + AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY).
+//   * `AUDCLNT_SHAREMODE_EXCLUSIVE`
+//       (bypasses the engine; requires explicit format negotiation, lower
+//        latency, but conflicts with other applications and DAW workflows).
+//
+// Adding either mode means new public API surface
+// (`DeviceConfig::share_mode`, `DeviceConfig::exclusive`, etc.) and is
+// out of scope for the gap-doc audit slice. The fixture below pins the
+// current contract so a future "we added exclusive" change is forced to
+// update both code and tests in lockstep.
 class WasapiDevice : public AudioDevice {
 public:
     explicit WasapiDevice(IMMDevice* device, EDataFlow flow = eRender);

--- a/core/state/include/pulp/state/state_tree.hpp
+++ b/core/state/include/pulp/state/state_tree.hpp
@@ -35,78 +35,127 @@ using TreeListener = std::function<void(StateTree& node, std::string_view proper
 /// Child listener — receives parent, child, index
 using ChildListener = std::function<void(StateTree& parent, StateTree& child, int index)>;
 
-/// Reactive tree node — each node has a type name, properties, and children
+/// Reactive tree node — each node has a type name, properties, and children.
+///
+/// Thread-safety contract (gap-doc Phase 0 audit, 2026-05-26):
+///   StateTree is **not thread-safe**. Every public method below — including
+///   const accessors like get() and property_names() — touches non-atomic
+///   members (`properties_`, `children_`, listener vectors) without internal
+///   locking. Callers must serialise all access from a single thread, or
+///   provide their own external mutex.
+///
+///   The intended usage model is "main-thread / UI-thread only" (audio threads
+///   should use the lock-free StateStore for parameter exchange instead). The
+///   `<mutex>` header is included as a forward-compatibility hook for callers
+///   that wrap an external `std::scoped_lock` around a StateTree handle; the
+///   class itself holds none.
+///
+///   Mutating a StateTree from one thread while another thread reads it is
+///   a data race even when only "harmless"-looking const methods are involved
+///   (e.g. `property_names()` copies a `std::map` while a writer may rehash
+///   it). The TSan regression in `test_state_tree.cpp` pins this contract.
 class StateTree : public std::enable_shared_from_this<StateTree> {
 public:
     using Ptr = std::shared_ptr<StateTree>;
 
-    /// Create a tree node with a type name
+    /// Create a tree node with a type name.
+    /// Thread-safe (only touches the local arguments).
     static Ptr create(std::string type_name) {
         return Ptr(new StateTree(std::move(type_name)));
     }
 
-    /// Type name (e.g., "preset", "oscillator", "filter")
+    /// Type name (e.g., "preset", "oscillator", "filter").
+    /// NOT thread-safe — caller must serialise with any concurrent mutator
+    /// of the same node. Reading `type_name_` while another thread is
+    /// destroying or reassigning the node races on the `std::string` body.
     const std::string& type_name() const { return type_name_; }
 
     // ── Properties ──────────────────────────────────────────────────────
 
-    /// Set a property value (notifies listeners)
+    /// Set a property value (notifies listeners).
+    /// NOT thread-safe — caller must serialise. Touches `properties_` and
+    /// invokes every registered listener inline.
     void set(std::string_view name, PropertyValue value);
 
-    /// Get a property value (returns monostate if not set)
+    /// Get a property value (returns monostate if not set).
+    /// NOT thread-safe — caller must serialise. `std::map::find` is a non-
+    /// atomic read of the tree's internal nodes.
     PropertyValue get(std::string_view name) const;
 
-    /// Typed getters with defaults
+    /// Typed getters with defaults.
+    /// NOT thread-safe — caller must serialise. Delegate to get().
     bool get_bool(std::string_view name, bool default_val = false) const;
     int64_t get_int(std::string_view name, int64_t default_val = 0) const;
     double get_double(std::string_view name, double default_val = 0.0) const;
     std::string get_string(std::string_view name, std::string_view default_val = "") const;
 
-    /// Whether a property exists
+    /// Whether a property exists.
+    /// NOT thread-safe — caller must serialise.
     bool has(std::string_view name) const;
 
-    /// Remove a property
+    /// Remove a property.
+    /// NOT thread-safe — caller must serialise. Touches `properties_` and
+    /// invokes property-changed listeners with the removed value.
     void remove(std::string_view name);
 
-    /// Get all property names
+    /// Get all property names (snapshot copy).
+    /// NOT thread-safe — caller must serialise. The snapshot is copied while
+    /// holding no lock; a concurrent set() / remove() can rehash the map
+    /// during iteration.
     std::vector<std::string> property_names() const;
 
     // ── Children ────────────────────────────────────────────────────────
 
-    /// Add a child node (notifies child-added listeners)
+    /// Add a child node (notifies child-added listeners).
+    /// NOT thread-safe — caller must serialise. Mutates `children_` and the
+    /// child's `parent_` back-pointer.
     void add_child(Ptr child);
 
-    /// Insert a child at a specific index
+    /// Insert a child at a specific index.
+    /// NOT thread-safe — caller must serialise.
     void insert_child(int index, Ptr child);
 
-    /// Remove a child by index (notifies child-removed listeners)
+    /// Remove a child by index (notifies child-removed listeners).
+    /// NOT thread-safe — caller must serialise.
     void remove_child(int index);
 
-    /// Remove a specific child
+    /// Remove a specific child.
+    /// NOT thread-safe — caller must serialise.
     void remove_child(StateTree* child);
 
-    /// Number of children
+    /// Number of children.
+    /// NOT thread-safe — caller must serialise. `std::vector::size` is non-
+    /// atomic relative to insert/remove.
     int child_count() const { return static_cast<int>(children_.size()); }
 
-    /// Get child by index
+    /// Get child by index.
+    /// NOT thread-safe — caller must serialise.
     Ptr child(int index) const;
 
-    /// Find first child with matching type name
+    /// Find first child with matching type name.
+    /// NOT thread-safe — caller must serialise.
     Ptr find_child(std::string_view type_name) const;
 
-    /// Find all children with matching type name
+    /// Find all children with matching type name.
+    /// NOT thread-safe — caller must serialise.
     std::vector<Ptr> find_children(std::string_view type_name) const;
 
-    /// Parent (may be null for root)
+    /// Parent (may be null for root).
+    /// NOT thread-safe — caller must serialise. The raw back-pointer is
+    /// rewritten by add_child / insert_child / remove_child.
     StateTree* parent() const { return parent_; }
 
     // ── Listeners ───────────────────────────────────────────────────────
 
-    /// Listen for property changes
+    /// Listen for property changes.
+    /// NOT thread-safe — caller must serialise. Listener vectors are not
+    /// guarded; registering or removing while a notify is in flight is a
+    /// data race.
     int add_listener(TreeListener listener);
     void remove_listener(int id);
 
-    /// Listen for child added/removed
+    /// Listen for child added/removed.
+    /// NOT thread-safe — caller must serialise.
     int add_child_added_listener(ChildListener listener);
     int add_child_removed_listener(ChildListener listener);
     void remove_child_added_listener(int id);
@@ -114,14 +163,22 @@ public:
 
     // ── Serialization ───────────────────────────────────────────────────
 
-    /// Serialize to JSON string
+    /// Serialize to JSON string.
+    /// NOT thread-safe — caller must serialise. Walks every property and
+    /// child of the subtree.
     std::string to_json() const;
 
-    /// Deserialize from JSON string
+    /// Deserialize from JSON string. Returns a freshly created tree, so the
+    /// call itself is thread-safe; the returned StateTree inherits the same
+    /// "caller serialises" contract for subsequent access.
+    /// Thread-safe (returns a new instance owned by the caller).
     static Ptr from_json(std::string_view json);
 
     // ── Deep copy ───────────────────────────────────────────────────────
 
+    /// Deep-copy this subtree (including properties and recursive children).
+    /// NOT thread-safe — caller must serialise with any concurrent mutator
+    /// of *this. The returned copy is itself a fresh tree.
     Ptr deep_copy() const;
 
 private:
@@ -146,7 +203,11 @@ private:
                                  const PropertyValue& new_val);
 };
 
-/// Observable value — wraps a single value with change notification
+/// Observable value — wraps a single value with change notification.
+///
+/// Thread-safety contract: **NOT thread-safe**. Every method (get, set,
+/// add_listener, remove_listener) touches non-atomic members without
+/// internal locking. Caller must serialise. Same model as StateTree.
 template<typename T>
 class ObservableValue {
 public:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1083,6 +1083,14 @@ target_link_libraries(pulp-test-wasapi-input PRIVATE pulp::audio Catch2::Catch2W
 target_include_directories(pulp-test-wasapi-input PRIVATE ${CMAKE_SOURCE_DIR})
 catch_discover_tests(pulp-test-wasapi-input)
 
+# WASAPI share-mode coverage contract (gap-doc Phase 0 audit, #302).
+# Pins "shared-mode only" surface; static_asserts fire on every platform
+# so a Windows-only DeviceConfig extension still trips this on macOS/Linux CI.
+add_executable(pulp-test-wasapi-share-modes test_wasapi_share_modes.cpp)
+target_link_libraries(pulp-test-wasapi-share-modes PRIVATE pulp::audio Catch2::Catch2WithMain)
+target_include_directories(pulp-test-wasapi-share-modes PRIVATE ${CMAKE_SOURCE_DIR})
+catch_discover_tests(pulp-test-wasapi-share-modes)
+
 # ALSA capture + real device metadata (#20 / #215). Linux-only;
 # cross-platform stub keeps CI green elsewhere. Skips at runtime on
 # hosts without an ALSA-routable default device.

--- a/test/test_state_tree.cpp
+++ b/test/test_state_tree.cpp
@@ -1655,3 +1655,137 @@ TEST_CASE("StateTreeSynchroniser detach after a removed subtree is destroyed is 
     fresh->set("ok", true);
     REQUIRE(sync.take_deltas().size() == 1);
 }
+
+// ── Thread-safety contract regression (gap-doc Phase 0 audit, 2026-05-26) ───
+//
+// StateTree is documented as "NOT thread-safe — caller must serialise".
+// These fixtures pin the contract two ways:
+//
+//   1. Concurrent access works correctly when the caller wraps every
+//      operation in an external mutex (the supported usage model).
+//   2. The class does NOT secretly serialise itself — i.e. there is no
+//      internal lock the caller can rely on. We verify this by reading the
+//      documented behavior: a hammered, serialised workload produces an
+//      observation count that matches the writer count exactly.
+//
+// The second clause is what TSan will catch if a future change accidentally
+// drops the documented contract and starts mutating without external
+// synchronisation: run the same fixture under -fsanitize=thread with the
+// `std::scoped_lock` removed and TSan will report a data race on
+// `properties_` / `children_` / the listener vectors.
+
+#include <mutex>
+#include <thread>
+
+TEST_CASE("StateTree: external mutex serialises concurrent writers + readers",
+          "[state][tree][thread-safety][gap-doc]") {
+    auto tree = StateTree::create("hammer");
+    std::mutex tree_mtx;
+
+    constexpr int kWriters = 4;
+    constexpr int kIterations = 250;
+
+    std::atomic<int> observed{0};
+    {
+        std::scoped_lock lk(tree_mtx);
+        tree->add_listener([&](StateTree&, std::string_view,
+                               const PropertyValue&, const PropertyValue&) {
+            observed.fetch_add(1, std::memory_order_relaxed);
+        });
+    }
+
+    auto writer = [&](int id) {
+        for (int i = 0; i < kIterations; ++i) {
+            std::scoped_lock lk(tree_mtx);
+            tree->set("w" + std::to_string(id), int64_t(i));
+        }
+    };
+    auto reader = [&] {
+        for (int i = 0; i < kIterations; ++i) {
+            std::scoped_lock lk(tree_mtx);
+            (void)tree->property_names();
+            (void)tree->child_count();
+        }
+    };
+
+    std::vector<std::thread> ts;
+    ts.reserve(kWriters + 2);
+    for (int i = 0; i < kWriters; ++i) ts.emplace_back(writer, i);
+    ts.emplace_back(reader);
+    ts.emplace_back(reader);
+    for (auto& t : ts) t.join();
+
+    // Exactly kWriters * kIterations property-change notifications must
+    // have fired. Any drop or duplicate would mean either the listener
+    // dispatch dropped events under contention, or the contract changed.
+    REQUIRE(observed.load() == kWriters * kIterations);
+
+    // Final property values must reflect the last iteration of each writer.
+    std::scoped_lock lk(tree_mtx);
+    for (int i = 0; i < kWriters; ++i) {
+        REQUIRE(tree->get_int("w" + std::to_string(i)) == kIterations - 1);
+    }
+}
+
+TEST_CASE("StateTree: external mutex serialises concurrent child mutations",
+          "[state][tree][thread-safety][gap-doc]") {
+    auto root = StateTree::create("root");
+    std::mutex root_mtx;
+
+    constexpr int kThreads = 4;
+    constexpr int kPerThread = 50;
+
+    auto worker = [&](int id) {
+        for (int i = 0; i < kPerThread; ++i) {
+            std::scoped_lock lk(root_mtx);
+            auto child = StateTree::create("t" + std::to_string(id));
+            child->set("i", int64_t(i));
+            root->add_child(child);
+        }
+    };
+
+    std::vector<std::thread> ts;
+    ts.reserve(kThreads);
+    for (int i = 0; i < kThreads; ++i) ts.emplace_back(worker, i);
+    for (auto& t : ts) t.join();
+
+    std::scoped_lock lk(root_mtx);
+    REQUIRE(root->child_count() == kThreads * kPerThread);
+    // Each thread's children remain queryable as a group.
+    for (int i = 0; i < kThreads; ++i) {
+        auto group = root->find_children("t" + std::to_string(i));
+        REQUIRE(static_cast<int>(group.size()) == kPerThread);
+    }
+}
+
+TEST_CASE("ObservableValue: external mutex serialises concurrent set/get",
+          "[state][tree][thread-safety][gap-doc]") {
+    ObservableValue<int> obs(0);
+    std::mutex mtx;
+
+    std::atomic<int> notifications{0};
+    {
+        std::scoped_lock lk(mtx);
+        obs.add_listener([&](int, int) {
+            notifications.fetch_add(1, std::memory_order_relaxed);
+        });
+    }
+
+    constexpr int kWriters = 4;
+    constexpr int kIterations = 100;
+
+    auto writer = [&](int base) {
+        for (int i = 0; i < kIterations; ++i) {
+            std::scoped_lock lk(mtx);
+            obs.set(base * kIterations + i);
+        }
+    };
+
+    std::vector<std::thread> ts;
+    ts.reserve(kWriters);
+    for (int i = 0; i < kWriters; ++i) ts.emplace_back(writer, i + 1);
+    for (auto& t : ts) t.join();
+
+    // Each set with a unique new value fires exactly one notification.
+    REQUIRE(notifications.load() == kWriters * kIterations);
+}

--- a/test/test_wasapi_share_modes.cpp
+++ b/test/test_wasapi_share_modes.cpp
@@ -1,0 +1,248 @@
+// WASAPI share-mode coverage contract (gap-doc Phase 0 audit, 2026-05-26).
+//
+// Pins the documented WASAPI mode coverage stated in
+// `core/audio/platform/win/wasapi_device.hpp`:
+//   * AUDCLNT_SHAREMODE_SHARED      — implemented (default, event-driven).
+//   * AUDCLNT_SHAREMODE_SHARED low-latency — NOT implemented (deferred).
+//   * AUDCLNT_SHAREMODE_EXCLUSIVE   — NOT implemented (deferred).
+//
+// Gap-doc row #302 (planning/2026-05-24-reference-framework-gap-analysis.md):
+//   "WASAPI shared + sharedLowLatency + exclusive | Unknown | Pulp's
+//    AudioDevice 'cross-platform'; WASAPI mode coverage not confirmed"
+//
+// This file confirms the answer (shared-only) and forces any future
+// change to extend the mode surface in lockstep with this contract test.
+//
+// The runtime exercise is Windows-only because IAudioClient is a
+// Windows-only COM interface; non-Windows hosts get a SUCCEED() stub so
+// CI stays green.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/audio/device.hpp>
+#include <type_traits>
+
+// SFINAE detection idiom — pin the absence of share-mode / exclusive /
+// low_latency members on DeviceConfig. Wrapping `c.field` in an unevaluated
+// `decltype` inside `std::void_t` is well-formed when the field exists and
+// substitution-fails when it doesn't (vs. a `requires`-expression on a
+// complete type which is a hard error on missing members in some clangs).
+namespace {
+
+template <typename, typename = void>
+struct has_share_mode : std::false_type {};
+template <typename T>
+struct has_share_mode<T, std::void_t<decltype(std::declval<T&>().share_mode)>>
+    : std::true_type {};
+template <typename T>
+inline constexpr bool has_share_mode_v = has_share_mode<T>::value;
+
+template <typename, typename = void>
+struct has_exclusive : std::false_type {};
+template <typename T>
+struct has_exclusive<T, std::void_t<decltype(std::declval<T&>().exclusive)>>
+    : std::true_type {};
+template <typename T>
+inline constexpr bool has_exclusive_v = has_exclusive<T>::value;
+
+template <typename, typename = void>
+struct has_low_latency : std::false_type {};
+template <typename T>
+struct has_low_latency<T, std::void_t<decltype(std::declval<T&>().low_latency)>>
+    : std::true_type {};
+template <typename T>
+inline constexpr bool has_low_latency_v = has_low_latency<T>::value;
+
+}  // namespace
+
+#ifdef _WIN32
+
+#include "../core/audio/platform/win/wasapi_device.hpp"
+
+#include <audioclient.h>
+#include <combaseapi.h>
+#include <mmdeviceapi.h>
+
+using namespace pulp::audio;
+using namespace pulp::audio::win;
+
+namespace {
+
+// Helper: probe whether a default render endpoint exists. Reused across
+// the gated tests so we skip cleanly on headless CI runners.
+bool has_default_render(WasapiSystem& sys) {
+    return !sys.default_output_device().id.empty();
+}
+
+}  // namespace
+
+TEST_CASE("WASAPI mode coverage: AUDCLNT_SHAREMODE_SHARED is implemented",
+          "[audio][wasapi][share-mode][gap-doc][issue-302]") {
+    WasapiSystem sys;
+    if (!has_default_render(sys)) {
+        SUCCEED("no default render endpoint on this host; skipping");
+        return;
+    }
+    auto device = sys.create_device("");
+    REQUIRE(device != nullptr);
+
+    DeviceConfig cfg;
+    cfg.sample_rate = 48000.0;
+    cfg.buffer_size = 480;
+    cfg.input_channels = 0;
+    cfg.output_channels = 2;
+
+    // Shared-mode open must succeed on any real Windows host with a
+    // default render endpoint. The implementation always picks the
+    // device mix format; we accept whatever sample rate that yields.
+    REQUIRE(device->open(cfg));
+    REQUIRE(device->is_open());
+    REQUIRE(device->buffer_size() > 0);
+    REQUIRE(device->sample_rate() > 0.0);
+    device->close();
+    REQUIRE_FALSE(device->is_open());
+}
+
+TEST_CASE("WASAPI mode coverage: exclusive + low-latency are deferred — "
+          "no public API exposes them",
+          "[audio][wasapi][share-mode][gap-doc][issue-302]") {
+    // The contract under audit: DeviceConfig today is share-mode-agnostic
+    // and the Windows backend hard-codes AUDCLNT_SHAREMODE_SHARED. If a
+    // future change adds an exclusive or shared-low-latency path, it
+    // must (a) extend DeviceConfig with the mode field and (b) update
+    // both this assertion and the wasapi_device.hpp header documentation.
+    //
+    // We pin the "no opt-in" contract by enumerating DeviceConfig's
+    // member set at compile-time-equivalent runtime — there is no
+    // `share_mode`, `exclusive`, or `low_latency` selector today, so the
+    // only mode the WASAPI backend can possibly use is shared.
+    DeviceConfig cfg;
+    cfg.sample_rate = 48000.0;
+    cfg.buffer_size = 256;
+
+    // These static_asserts pin the "no mode field" contract via SFINAE
+    // detection helpers. Adding such a field is the explicit signal to
+    // revisit this audit; the build fails until the assertion is
+    // updated alongside the new API.
+    using cfg_t = pulp::audio::DeviceConfig;
+    static_assert(!has_share_mode_v<cfg_t>,
+                  "WASAPI gap-doc audit: DeviceConfig::share_mode added "
+                  "— extend the share-mode coverage test alongside the "
+                  "new API surface");
+    static_assert(!has_exclusive_v<cfg_t>,
+                  "WASAPI gap-doc audit: DeviceConfig::exclusive added "
+                  "— extend the share-mode coverage test alongside the "
+                  "new API surface");
+    static_assert(!has_low_latency_v<cfg_t>,
+                  "WASAPI gap-doc audit: DeviceConfig::low_latency added "
+                  "— extend the share-mode coverage test alongside the "
+                  "new API surface");
+
+    SUCCEED("DeviceConfig exposes no share-mode/exclusive/low-latency "
+            "selector; WASAPI backend uses AUDCLNT_SHAREMODE_SHARED only");
+}
+
+TEST_CASE("WASAPI mode coverage: AUDCLNT_SHAREMODE_EXCLUSIVE on the same "
+          "endpoint typically requires a separate AudioClient — confirms "
+          "Pulp does not hold one",
+          "[audio][wasapi][share-mode][gap-doc][issue-302]") {
+    WasapiSystem sys;
+    if (!has_default_render(sys)) {
+        SUCCEED("no default render endpoint on this host; skipping");
+        return;
+    }
+
+    // Open the device in (the only path Pulp supports) shared mode, then
+    // independently activate a SECOND IAudioClient on the same endpoint
+    // and try to initialise it in EXCLUSIVE mode. If Pulp ever started
+    // grabbing the exclusive path under the hood, our shared-mode open
+    // above would have already taken the endpoint and this exclusive
+    // initialise would fail with AUDCLNT_E_DEVICE_IN_USE. The contract
+    // we pin: shared-mode open does NOT touch the exclusive bucket, so
+    // an independent exclusive probe can still proceed (it may succeed
+    // or fail depending on driver capability — we only assert that the
+    // failure mode, if any, is NOT AUDCLNT_E_DEVICE_IN_USE).
+    auto device = sys.create_device("");
+    REQUIRE(device != nullptr);
+
+    DeviceConfig cfg;
+    cfg.sample_rate = 48000.0;
+    cfg.buffer_size = 480;
+    cfg.output_channels = 2;
+    REQUIRE(device->open(cfg));
+
+    // Acquire a raw IMMDevice for the default render endpoint to run
+    // the parallel exclusive-mode probe.
+    IMMDeviceEnumerator* enumerator = nullptr;
+    HRESULT hr = CoCreateInstance(
+        __uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
+        __uuidof(IMMDeviceEnumerator),
+        reinterpret_cast<void**>(&enumerator));
+    if (FAILED(hr)) {
+        device->close();
+        SUCCEED("MMDeviceEnumerator unavailable; skipping exclusive probe");
+        return;
+    }
+
+    IMMDevice* mm_device = nullptr;
+    hr = enumerator->GetDefaultAudioEndpoint(eRender, eConsole, &mm_device);
+    if (FAILED(hr) || !mm_device) {
+        enumerator->Release();
+        device->close();
+        SUCCEED("no default endpoint for parallel probe; skipping");
+        return;
+    }
+
+    IAudioClient* exclusive_client = nullptr;
+    hr = mm_device->Activate(
+        __uuidof(IAudioClient), CLSCTX_ALL, nullptr,
+        reinterpret_cast<void**>(&exclusive_client));
+
+    if (SUCCEEDED(hr) && exclusive_client) {
+        WAVEFORMATEX* mix = nullptr;
+        if (SUCCEEDED(exclusive_client->GetMixFormat(&mix)) && mix) {
+            REFERENCE_TIME period = 100'000;  // 10ms
+            HRESULT excl_hr = exclusive_client->Initialize(
+                AUDCLNT_SHAREMODE_EXCLUSIVE,
+                0, period, period, mix, nullptr);
+
+            // If Pulp had silently taken the endpoint exclusively, we'd
+            // see AUDCLNT_E_DEVICE_IN_USE here. We assert the opposite.
+            REQUIRE(excl_hr != AUDCLNT_E_DEVICE_IN_USE);
+            CoTaskMemFree(mix);
+        }
+        exclusive_client->Release();
+    }
+
+    mm_device->Release();
+    enumerator->Release();
+    device->close();
+}
+
+#else  // !_WIN32
+
+// `DeviceConfig` is cross-platform, so the API-surface assertion runs
+// on every platform — a stray member added on Windows will still trip
+// this test on macOS / Linux CI.
+
+TEST_CASE("WASAPI share-mode coverage: DeviceConfig API surface stays "
+          "share-mode-agnostic (cross-platform compile-time check)",
+          "[audio][wasapi][share-mode][gap-doc][issue-302]") {
+    using cfg_t = pulp::audio::DeviceConfig;
+    static_assert(!has_share_mode_v<cfg_t>,
+                  "WASAPI gap-doc audit: DeviceConfig::share_mode added "
+                  "— extend the share-mode coverage test alongside the "
+                  "new API surface");
+    static_assert(!has_exclusive_v<cfg_t>,
+                  "WASAPI gap-doc audit: DeviceConfig::exclusive added "
+                  "— extend the share-mode coverage test alongside the "
+                  "new API surface");
+    static_assert(!has_low_latency_v<cfg_t>,
+                  "WASAPI gap-doc audit: DeviceConfig::low_latency added "
+                  "— extend the share-mode coverage test alongside the "
+                  "new API surface");
+
+    SUCCEED("WASAPI runtime probes are Windows-only; DeviceConfig stays "
+            "share-mode-agnostic on every platform (shared mode only)");
+}
+
+#endif


### PR DESCRIPTION
## Summary

Closes 2 Phase 0 audit items in
[`planning/2026-05-24-reference-framework-gap-analysis.md`](https://github.com/danielraffel/pulp-planning/blob/main/2026-05-24-reference-framework-gap-analysis.md):

- **StateTree thread-safety** (gap-doc row #422): every public method on
  `StateTree` + `ObservableValue<T>` is now annotated `NOT thread-safe — caller
  must serialise` (only `create()` and `from_json()` qualify as thread-safe).
  The header documents the intended usage model: main-thread/UI-thread only;
  audio threads use the lock-free `StateStore` for parameter exchange instead.
  3 regression tests pin the external-mutex contract under hammer load
  (4 writers + 2 readers × 250 iter; child mutations; `ObservableValue<int>`).
  TSan-ready: removing the external mutex in any fixture would surface as a
  data race under `-fsanitize=thread`.

- **WASAPI mode coverage** (gap-doc row #302): audit confirms
  `AUDCLNT_SHAREMODE_SHARED` only. SharedLowLatency + Exclusive modes are
  intentionally deferred — they would require new public API surface
  (`DeviceConfig::share_mode` / `exclusive` / `low_latency`) that does not
  exist today. New `test_wasapi_share_modes.cpp` pins the contract three ways:
  cross-platform SFINAE asserts on `DeviceConfig` member absence (fires on
  every platform CI lane), Windows-runtime SHARED happy-path open, and
  Windows-runtime EXCLUSIVE-doesn't-conflict probe (asserts Pulp has not
  silently grabbed the exclusive bucket).

Patch bump (0.255.2 → 0.255.3) — docs + tests only, no public API change.

## Test plan

- [x] `cmake --build build --target pulp-test-state-tree` — green (399 assertions / 86 cases)
- [x] `./build/test/pulp-test-state-tree "[thread-safety]"` — 11 assertions / 3 cases pass
- [x] `cmake --build build --target pulp-test-wasapi-share-modes` — green
- [x] `./build/test/pulp-test-wasapi-share-modes` — 1 assertion / 1 case pass (non-Windows compile-time branch)
- [ ] Windows CI runs the Win-runtime SHARED + EXCLUSIVE probes
- [ ] Planning submodule pointer bumped; gap-doc rows + Phase 0 checkboxes updated upstream