### PR TITLE
feat(ios): wire iOS Skia release assets for Phase iOS-D scaffold

### DIFF
--- a/.agents/skills/packages/SKILL.md
+++ b/.agents/skills/packages/SKILL.md
@@ -130,6 +130,17 @@ device, iOS simulator, visionOS device, visionOS simulator, mac-x86_64,
 and `Skia.xcframework` slices upstream does not. While upstream stays on
 m144, this fork is the active dependency; revisit when upstream catches up.
 
+iOS-specific layout gotcha (PR #3011): unlike the mac / linux / windows
+slices, the iOS zips ship libs under a per-arch subdir
+(`build/ios-gpu/lib/Release/{device-arm64,simulator-arm64,simulator-x86_64}/libskia.a`)
+because the device and fat-simulator zips would otherwise collide on
+identical lib names when unpacked into one tree. `FindSkia.cmake` picks
+the right subdir based on `CMAKE_OSX_SYSROOT` + `CMAKE_OSX_ARCHITECTURES`;
+`tools/scripts/fetch_skia_for_release.py` keeps the subdir intact for
+`ios-device-arm64` and `ios-simulator-arm64-x86_64` matrix slices via
+`_IOS_PRESERVE_ARCH_SUBDIR`. Do not extend the flatten step to iOS, and
+do not register a single combined iOS slice without per-arch handling.
+
 ## Bundled Fonts (and similar opt-in compile-time assets)
 
 Bundled fonts under `external/fonts/*.ttf` (`Inter`, `JetBrains Mono`,

--- a/.agents/skills/packages/SKILL.md
+++ b/.agents/skills/packages/SKILL.md
@@ -141,6 +141,17 @@ the right subdir based on `CMAKE_OSX_SYSROOT` + `CMAKE_OSX_ARCHITECTURES`;
 `_IOS_PRESERVE_ARCH_SUBDIR`. Do not extend the flatten step to iOS, and
 do not register a single combined iOS slice without per-arch handling.
 
+Multi-arch simulator builds (`-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64`,
+the default in `tools/cmake/ios.toolchain.cmake` with
+`ONLY_ACTIVE_ARCH=NO`) are intentionally rejected by `FindSkia.cmake`
+because each Skia archive is single-arch — silently picking
+`simulator-arm64` would arch-mismatch the x86_64 link. The fix is
+either to build a single arch (`-DCMAKE_OSX_ARCHITECTURES=arm64`
+with `ONLY_ACTIVE_ARCH=YES`) or to pre-fatten the two simulator
+archives with `lipo` into a combined `simulator/libskia.a` upstream
+of `find_package(Skia)`. The default Pulp iOS smoke (`pulp-ios-sim`,
+Apple Silicon dev machines) only needs `arm64`.
+
 ## Bundled Fonts (and similar opt-in compile-time assets)
 
 Bundled fonts under `external/fonts/*.ttf` (`Inter`, `JetBrains Mono`,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.258.0
+    VERSION 0.259.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/tools/cmake/FindSkia.cmake
+++ b/tools/cmake/FindSkia.cmake
@@ -48,16 +48,53 @@ if(APPLE)
         # Pick the right per-arch subdir under build/ios-gpu/lib/Release/.
         # CMAKE_OSX_SYSROOT names the active SDK; CMAKE_OSX_ARCHITECTURES
         # names the slice. Both are set by ios.toolchain.cmake.
+        #
+        # Multi-arch handling (Codex PR #3011 review):
+        # ios.toolchain.cmake defaults CMAKE_OSX_ARCHITECTURES to
+        # "arm64;x86_64" for the simulator (with ONLY_ACTIVE_ARCH=NO),
+        # meaning a universal simulator build expects BOTH slices to
+        # link. The Skia prebuilts ship two distinct archives —
+        # `simulator-arm64/libskia.a` (arm64-only) and
+        # `simulator-x86_64/libskia.a` (x86_64-only) — so picking one
+        # would silently produce arch-mismatch link errors for the
+        # other. When BOTH archs are requested, fail loudly with the
+        # remediation: set CMAKE_OSX_ARCHITECTURES to a single arch
+        # (or wire a `lipo` step upstream of FindSkia that produces a
+        # universal `simulator/libskia.a`). The fail is intentional —
+        # a silent partial-arch link is much worse than a config-time
+        # error pointing at the exact fix.
         set(_skia_ios_arch "")
         if(CMAKE_OSX_SYSROOT MATCHES "iphonesimulator|Simulator")
-            if(CMAKE_OSX_ARCHITECTURES MATCHES "arm64")
+            set(_archs "${CMAKE_OSX_ARCHITECTURES}")
+            set(_has_arm64 FALSE)
+            set(_has_x86_64 FALSE)
+            if(_archs MATCHES "arm64")
+                set(_has_arm64 TRUE)
+            endif()
+            if(_archs MATCHES "x86_64")
+                set(_has_x86_64 TRUE)
+            endif()
+            if(_has_arm64 AND _has_x86_64)
+                message(FATAL_ERROR
+                    "Skia (iOS Simulator): universal arm64;x86_64 builds "
+                    "are not supported by the per-arch Skia layout. "
+                    "The skia-builder zip ships `simulator-arm64/libskia.a` "
+                    "and `simulator-x86_64/libskia.a` as separate single-"
+                    "arch archives; linking one against a universal target "
+                    "produces arch-mismatch errors. Fix one of:\n"
+                    "  - Build a single arch: -DCMAKE_OSX_ARCHITECTURES=arm64 "
+                    "(or x86_64), with -DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH=YES.\n"
+                    "  - Pre-fatten Skia with lipo: combine the two arch "
+                    "directories into a universal `simulator/libskia.a` and "
+                    "set SKIA_DIR at it directly.\n"
+                    "Phase iOS-D plumbing (planning/2026-05-24-auv3-ios-validation.md)."
+                )
+            elseif(_has_arm64)
                 set(_skia_ios_arch "simulator-arm64")
-            elseif(CMAKE_OSX_ARCHITECTURES MATCHES "x86_64")
+            elseif(_has_x86_64)
                 set(_skia_ios_arch "simulator-x86_64")
             else()
-                # Default to the host arch when CMAKE_OSX_ARCHITECTURES
-                # wasn't pinned (some toolchains leave it empty for
-                # auto-detect). Honor CMAKE_HOST_SYSTEM_PROCESSOR.
+                # CMAKE_OSX_ARCHITECTURES empty — fall back to host arch.
                 if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
                     set(_skia_ios_arch "simulator-arm64")
                 else()

--- a/tools/cmake/FindSkia.cmake
+++ b/tools/cmake/FindSkia.cmake
@@ -31,10 +31,43 @@ if(NOT SKIA_DIR)
     return()
 endif()
 
-# Determine platform library directory
+# Determine platform library directory.
+#
+# iOS layout (skia-builder chrome/m149+): a single `build/ios-gpu/lib/Release/`
+# directory contains three arch subdirs — `device-arm64/`, `simulator-arm64/`,
+# and `simulator-x86_64/`. Unlike the mac slice, these CANNOT be flattened
+# together (they'd collide on identical library names with different arch
+# slices). FindSkia.cmake selects the right arch via `_skia_ios_arch`:
+#   - iphoneos SDK            → device-arm64
+#   - iphonesimulator SDK on arm64 host → simulator-arm64
+#   - iphonesimulator SDK on x86_64 host → simulator-x86_64
+# Phase iOS-D gate (planning/2026-05-24-auv3-ios-validation.md).
 if(APPLE)
     if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
         set(_skia_platform "ios")
+        # Pick the right per-arch subdir under build/ios-gpu/lib/Release/.
+        # CMAKE_OSX_SYSROOT names the active SDK; CMAKE_OSX_ARCHITECTURES
+        # names the slice. Both are set by ios.toolchain.cmake.
+        set(_skia_ios_arch "")
+        if(CMAKE_OSX_SYSROOT MATCHES "iphonesimulator|Simulator")
+            if(CMAKE_OSX_ARCHITECTURES MATCHES "arm64")
+                set(_skia_ios_arch "simulator-arm64")
+            elseif(CMAKE_OSX_ARCHITECTURES MATCHES "x86_64")
+                set(_skia_ios_arch "simulator-x86_64")
+            else()
+                # Default to the host arch when CMAKE_OSX_ARCHITECTURES
+                # wasn't pinned (some toolchains leave it empty for
+                # auto-detect). Honor CMAKE_HOST_SYSTEM_PROCESSOR.
+                if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
+                    set(_skia_ios_arch "simulator-arm64")
+                else()
+                    set(_skia_ios_arch "simulator-x86_64")
+                endif()
+            endif()
+        else()
+            # Device build: arm64 only.
+            set(_skia_ios_arch "device-arm64")
+        endif()
     else()
         set(_skia_platform "mac")
     endif()
@@ -57,13 +90,23 @@ else()
     return()
 endif()
 
-# Support both flat layout (mac/lib/) and skia-builder layout (build/mac-gpu/lib/Release/)
+# Support both flat layout (mac/lib/) and skia-builder layout
+# (build/<plat>-gpu/lib/Release/). The iOS slice keeps a per-arch subdir
+# under Release/ (device-arm64 / simulator-arm64 / simulator-x86_64) so
+# the device and simulator zips can be unpacked into the same tree
+# without colliding; FindSkia descends into that arch dir when set.
 if(EXISTS "${SKIA_DIR}/build/${_skia_platform}-gpu/lib/Release")
     set(_skia_lib_dir "${SKIA_DIR}/build/${_skia_platform}-gpu/lib/Release")
     set(_skia_include_dir "${SKIA_DIR}/build/include")
+    if(_skia_ios_arch AND EXISTS "${_skia_lib_dir}/${_skia_ios_arch}")
+        set(_skia_lib_dir "${_skia_lib_dir}/${_skia_ios_arch}")
+    endif()
 elseif(EXISTS "${SKIA_DIR}/${_skia_platform}-gpu/lib/Release")
     set(_skia_lib_dir "${SKIA_DIR}/${_skia_platform}-gpu/lib/Release")
     set(_skia_include_dir "${SKIA_DIR}/include")
+    if(_skia_ios_arch AND EXISTS "${_skia_lib_dir}/${_skia_ios_arch}")
+        set(_skia_lib_dir "${_skia_lib_dir}/${_skia_ios_arch}")
+    endif()
 elseif(EXISTS "${SKIA_DIR}/${_skia_platform}/lib")
     set(_skia_lib_dir "${SKIA_DIR}/${_skia_platform}/lib")
     set(_skia_include_dir "${SKIA_DIR}/include")

--- a/tools/deps/manifest.json
+++ b/tools/deps/manifest.json
@@ -560,6 +560,14 @@
         "skia_builder_fork": "https://github.com/danielraffel/skia-builder",
         "skia_python_smoke_version": "144.0.post2",
         "release_assets": {
+          "ios-device-arm64": {
+            "url": "https://github.com/danielraffel/skia-builder/releases/download/chrome/m149/skia-build-ios-device-arm64-gpu-release.zip",
+            "sha256": "a4bcb2d26cd19138e505606d568e9d5eaadeffd2be3e3ec77b1bb8af1fd2a654"
+          },
+          "ios-simulator-arm64-x86_64": {
+            "url": "https://github.com/danielraffel/skia-builder/releases/download/chrome/m149/skia-build-ios-simulator-arm64-x86_64-gpu-release.zip",
+            "sha256": "0c915135e9e2905b4dc5b9349e77e56fc0b1b1e63df6bc99b3c73c97de170898"
+          },
           "linux-x64": {
             "url": "https://github.com/danielraffel/skia-builder/releases/download/chrome/m149/skia-build-linux-x64-gpu-release.zip",
             "sha256": "53e2bfb5225148311da9bbcb7e65da4479acf774bc3d40b0341530cdc48e97b6"

--- a/tools/scripts/fetch_skia_for_release.py
+++ b/tools/scripts/fetch_skia_for_release.py
@@ -17,7 +17,14 @@ Usage:
     python3 tools/scripts/fetch_skia_for_release.py <matrix-platform>
 
 Where `<matrix-platform>` is one of the release-cli.yml matrix values:
-    darwin-arm64, linux-x64, linux-arm64, windows-x64, windows-arm64
+    darwin-arm64, linux-x64, linux-arm64, windows-x64, windows-arm64,
+    ios-device-arm64, ios-simulator-arm64-x86_64 (Phase iOS-D scaffold)
+
+iOS slices intentionally keep the per-arch subdir under
+`build/ios-gpu/lib/Release/` (device-arm64, simulator-arm64,
+simulator-x86_64) so the device and simulator zips can co-exist in one
+unpack tree. FindSkia.cmake selects the right subdir based on the
+active SDK.
 
 If the manifest has no asset for the requested platform (e.g. linux-arm64,
 windows-*), the script exits 0 with a message — those platforms keep
@@ -64,6 +71,21 @@ MATRIX_TO_MANIFEST = {
     "linux-arm64": "linux-arm64",
     "windows-x64": "win-x64",
     "windows-arm64": "win-arm64",
+    # Phase iOS-D scaffold (planning/2026-05-24-auv3-ios-validation.md):
+    # iOS device + simulator slices share the build/ios-gpu/lib/Release/
+    # tree but keep their arch subdir intact (see expected_library_path
+    # and the post-unpack flatten guard).
+    "ios-device-arm64": "ios-device-arm64",
+    "ios-simulator-arm64-x86_64": "ios-simulator-arm64-x86_64",
+}
+
+# iOS keeps its per-arch subdir under Release/ (device-arm64,
+# simulator-arm64, simulator-x86_64) because flattening would collide
+# library names across slices. The flatten step below is skipped for
+# any matrix entry in this set.
+_IOS_PRESERVE_ARCH_SUBDIR = {
+    "ios-device-arm64",
+    "ios-simulator-arm64-x86_64",
 }
 
 # Expected on-disk relative library path under external/skia-build/.
@@ -73,15 +95,36 @@ def expected_library_path(matrix_platform: str) -> Path:
     if matrix_platform.startswith("darwin"):
         plat_dir = "mac-gpu"
         lib_name = "libskia.a"
+        arch_subdir = ""
     elif matrix_platform.startswith("linux"):
         plat_dir = "linux-gpu"
         lib_name = "libskia.a"
+        arch_subdir = ""
     elif matrix_platform.startswith("windows"):
         plat_dir = "win-gpu"
         lib_name = "skia.lib"
+        arch_subdir = ""
+    elif matrix_platform == "ios-device-arm64":
+        # Phase iOS-D: device + simulator share build/ios-gpu/ and keep
+        # their arch subdir under Release/ to avoid filename collisions.
+        plat_dir = "ios-gpu"
+        lib_name = "libskia.a"
+        arch_subdir = "device-arm64"
+    elif matrix_platform == "ios-simulator-arm64-x86_64":
+        # Fat simulator zip contains both simulator-arm64/ and
+        # simulator-x86_64/. The arm64 slice is what runs on the
+        # local-CI Apple Silicon runners and is the canonical sanity
+        # check; the x86_64 slice ships alongside it untouched.
+        plat_dir = "ios-gpu"
+        lib_name = "libskia.a"
+        arch_subdir = "simulator-arm64"
     else:
         raise SystemExit(f"unknown matrix platform: {matrix_platform!r}")
-    return Path("external/skia-build/build") / plat_dir / "lib" / "Release" / lib_name
+    parts = ["external/skia-build/build", plat_dir, "lib", "Release"]
+    if arch_subdir:
+        parts.append(arch_subdir)
+    parts.append(lib_name)
+    return Path(*parts)
 
 
 def main(argv: list[str]) -> int:
@@ -206,7 +249,17 @@ def main(argv: list[str]) -> int:
     #   external/skia-build/build/<plat>-gpu/lib/Release/<arch>/<lib>
     # Flatten that arch directory into Release/ so FindSkia.cmake's
     # existing layout probe matches without further changes.
-    if not expected_lib.is_file():
+    #
+    # iOS is the deliberate exception: device-arm64, simulator-arm64,
+    # and simulator-x86_64 all ship libskia.a / libdawn_combined.a with
+    # the same names and CANNOT be flattened into one Release/ dir
+    # without collision. For iOS, expected_lib already points inside
+    # the arch subdir, so the flatten loop must be skipped entirely.
+    if matrix_platform in _IOS_PRESERVE_ARCH_SUBDIR:
+        # Nothing to do — the upstream layout is exactly what FindSkia
+        # expects for iOS. Drop into the sanity check below.
+        pass
+    elif not expected_lib.is_file():
         release_dir = expected_lib.parent
         if release_dir.is_dir():
             arch_subdirs = [p for p in release_dir.iterdir() if p.is_dir()]

--- a/tools/scripts/test_fetch_skia_for_release.py
+++ b/tools/scripts/test_fetch_skia_for_release.py
@@ -102,6 +102,45 @@ class ExpectedLibraryPath(unittest.TestCase):
         with self.assertRaises(SystemExit):
             fetch_skia.expected_library_path("haiku-ppc")
 
+    def test_ios_device_arm64_keeps_arch_subdir(self):
+        # Phase iOS-D: device + simulator zips share build/ios-gpu/, so
+        # the arch subdir under Release/ must be preserved (not flattened).
+        p = fetch_skia.expected_library_path("ios-device-arm64")
+        self.assertEqual(
+            str(p),
+            "external/skia-build/build/ios-gpu/lib/Release/device-arm64/libskia.a",
+        )
+
+    def test_ios_simulator_keeps_arch_subdir(self):
+        # The fat simulator zip ships both simulator-arm64 and
+        # simulator-x86_64; the sanity-check target is the arm64 slice.
+        p = fetch_skia.expected_library_path("ios-simulator-arm64-x86_64")
+        self.assertEqual(
+            str(p),
+            "external/skia-build/build/ios-gpu/lib/Release/simulator-arm64/libskia.a",
+        )
+
+
+class IosMatrixRegistration(unittest.TestCase):
+    """Phase iOS-D: iOS matrix slices must be wired and arch-preserving."""
+
+    def test_ios_keys_present_in_matrix_map(self):
+        self.assertIn("ios-device-arm64", fetch_skia.MATRIX_TO_MANIFEST)
+        self.assertIn(
+            "ios-simulator-arm64-x86_64", fetch_skia.MATRIX_TO_MANIFEST
+        )
+
+    def test_ios_keys_in_preserve_set(self):
+        # The flatten step would collide device-arm64 / simulator-arm64
+        # / simulator-x86_64 libskia.a copies into one Release/ dir.
+        self.assertIn(
+            "ios-device-arm64", fetch_skia._IOS_PRESERVE_ARCH_SUBDIR
+        )
+        self.assertIn(
+            "ios-simulator-arm64-x86_64",
+            fetch_skia._IOS_PRESERVE_ARCH_SUBDIR,
+        )
+
 
 class UnknownMatrixPlatform(unittest.TestCase):
     def test_missing_platform_argument_returns_usage_error(self):


### PR DESCRIPTION
## Summary

Phase iOS-D (planning/2026-05-24-auv3-ios-validation.md) was gated on
"iOS Skia ready". `skia-builder` chrome/m149 publishes both iOS slices
already — `skia-build-ios-device-arm64-gpu-release.zip` and
`skia-build-ios-simulator-arm64-x86_64-gpu-release.zip`. This PR plumbs
them through Pulp's release-fetch path so the Chainer iOS HostApp work
can target a real `libskia.a` for both `iphoneos` and `iphonesimulator`
SDKs.

- `tools/deps/manifest.json`: register `ios-device-arm64` +
  `ios-simulator-arm64-x86_64` `release_assets` under the `Skia` entry
  (sha256-pinned against the m149 release).
- `tools/cmake/FindSkia.cmake`: when `CMAKE_SYSTEM_NAME=iOS`, pick the
  per-arch subdir under `build/ios-gpu/lib/Release/` based on
  `CMAKE_OSX_SYSROOT` + `CMAKE_OSX_ARCHITECTURES`. Mac / Linux / Windows
  / Android paths unchanged.
- `tools/scripts/fetch_skia_for_release.py`: register the two iOS matrix
  slices and **skip** the arch-flatten step for them — flatten would
  collide identical lib names from three different arch subdirs
  (`device-arm64` / `simulator-arm64` / `simulator-x86_64`).
- `tools/scripts/test_fetch_skia_for_release.py`: lock the new
  `expected_library_path` values and the PRESERVE-arch set membership.

Planning tracker updated in the linked planning submodule commit
(`docs(ios): Phase iOS-D status — iOS Skia binaries wired`). With this
slice merged, the remaining Phase iOS-D work is purely Chainer +
HostApp scaffolding (see open question 2 in the planning doc — the
`pulp_add_ios_host_app(...)` helper).

## Test plan

- [x] `python3 tools/scripts/test_fetch_skia_for_release.py` — 29 tests pass (4 new)
- [x] `python3 tools/scripts/test_fetch_skia_for_release_extra.py` — 5 tests pass
- [x] `python3 tools/deps/audit.py --strict` — clean
- [x] Out-of-tree `find_package(Skia)` probe with simulated `SKIA_DIR`:
  - iphonesimulator + arm64 → `simulator-arm64/libskia.a`
  - iphoneos + arm64 → `device-arm64/libskia.a`
  - Darwin → `mac-gpu/lib/Release/libskia.a` (unchanged)
- [ ] CI macOS lane (no iOS-specific configure exercised — the new
      branches only activate under `CMAKE_SYSTEM_NAME=iOS`)