### PR TITLE
feat(view): RelativePoint / RelativeExpression layout primitive

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.125.0",
+      "version": "0.126.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.124.0"
+  "version": "0.125.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.125.0",
+  "version": "0.126.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.262.0
+    VERSION 0.263.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -299,6 +299,7 @@ target_sources(pulp-view-core PRIVATE
     src/ui_components.cpp
     src/scroll_bar.cpp
     src/anchor_strategy.cpp
+    src/relative_point.cpp
     src/design_export.cpp
     src/design_import.cpp
     src/design_import_native_common.cpp

--- a/core/view/include/pulp/view/relative_point.hpp
+++ b/core/view/include/pulp/view/relative_point.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+// RelativePoint — expression-based positioning primitive.
+//
+// Closes the "Relative coordinates" P3 row in
+// planning/2026-05-24-reference-framework-gap-analysis.md. Pulp's flex +
+// grid layout covers ~95% of real layouts; RelativePoint fills the
+// remaining "I want this anchored to another element's edge" cases
+// without forcing a full constraint solver.
+//
+// Grammar:
+//
+//   point      ::= expr ',' expr             // (x, y) pair
+//   expr       ::= term  (('+' | '-') term)*
+//   term       ::= factor (('*' | '/') factor)*
+//   factor     ::= number
+//                | identifier               // 'left', 'right', 'top', 'bottom',
+//                                           //   'width', 'height',
+//                                           //   'centerx', 'centery'
+//                | qualified                // <name>.<identifier> e.g.
+//                                           //   parent.right, prev.left
+//                | '(' expr ')'
+//                | '-' factor                // unary minus
+//   number     ::= [0-9]+ ('.' [0-9]+)?
+//   identifier ::= [a-zA-Z_][a-zA-Z0-9_]*
+//   qualified  ::= identifier '.' identifier
+//
+// Built-in names (unqualified) refer to the `parent` rectangle. Qualified
+// names route to the `named` map at evaluate time. Unknown qualified
+// names cause `evaluate()` to throw — that's a runtime error, not a
+// parse error, because the named-rect environment is only known at
+// layout time.
+//
+// Numeric values are treated as device pixels (no DimensionUnit support —
+// keep this primitive narrow; if you need %/vw/vh, compose with the
+// existing Dimension type at the caller).
+
+#include "pulp/view/geometry.hpp"
+
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace pulp::view {
+
+class RelativeExpression {
+public:
+    /// Evaluate this expression against the given parent rectangle and
+    /// optional environment of named rectangles. Throws std::runtime_error
+    /// if a qualified name refers to a missing rectangle.
+    float evaluate(const Rect& parent,
+                   const std::map<std::string, Rect>& named = {}) const;
+
+    /// Round-trip text form for diagnostics. Re-parses to the same tree
+    /// (numbers may be reformatted).
+    std::string to_string() const;
+
+    /// Convenience: parse + evaluate in one shot. Throws on parse error.
+    static float evaluate(const std::string& source,
+                          const Rect& parent,
+                          const std::map<std::string, Rect>& named = {});
+
+    /// Parse a single-axis expression (e.g. "right - 10"). Throws
+    /// std::invalid_argument on syntax error with a position-bearing
+    /// message.
+    static RelativeExpression parse(const std::string& source);
+
+    // Internal AST node (public for to_string traversal). Hidden from
+    // generic consumers behind opaque ptr.
+    struct Node;
+
+private:
+    explicit RelativeExpression(std::shared_ptr<Node> root) : root_(std::move(root)) {}
+    std::shared_ptr<Node> root_;
+};
+
+class RelativePoint {
+public:
+    /// Parse a "x, y" expression. Throws std::invalid_argument on syntax
+    /// error.
+    static RelativePoint parse(const std::string& source);
+
+    /// Evaluate both axes against the given environment.
+    Point evaluate(const Rect& parent,
+                   const std::map<std::string, Rect>& named = {}) const;
+
+    const RelativeExpression& x() const noexcept { return x_; }
+    const RelativeExpression& y() const noexcept { return y_; }
+
+private:
+    RelativePoint(RelativeExpression x, RelativeExpression y)
+        : x_(std::move(x)), y_(std::move(y)) {}
+    RelativeExpression x_;
+    RelativeExpression y_;
+};
+
+} // namespace pulp::view

--- a/core/view/src/relative_point.cpp
+++ b/core/view/src/relative_point.cpp
@@ -1,0 +1,386 @@
+#include "pulp/view/relative_point.hpp"
+
+#include <cctype>
+#include <cstddef>
+#include <cstdio>
+#include <sstream>
+#include <stdexcept>
+
+namespace pulp::view {
+
+// ── AST ────────────────────────────────────────────────────────────────────
+
+struct RelativeExpression::Node {
+    enum class Kind {
+        Number,
+        Identifier,   // unqualified (parent-relative built-in)
+        Qualified,    // <ns>.<member>
+        BinaryOp,     // + - * /
+        UnaryMinus,
+    };
+
+    Kind kind = Kind::Number;
+    float number = 0.0f;
+    std::string ident;       // for Identifier
+    std::string qual_ns;     // for Qualified — namespace ("parent", "prev", ...)
+    std::string qual_member; // for Qualified — member ("right", "top", ...)
+    char op = 0;             // for BinaryOp ('+','-','*','/')
+    std::shared_ptr<Node> lhs;
+    std::shared_ptr<Node> rhs;
+};
+
+namespace {
+
+// ── Rect member access ─────────────────────────────────────────────────────
+//
+// Returns the named coordinate on a rectangle. Throws if the member is
+// not one of the supported names.
+float rect_member(const Rect& r, const std::string& name) {
+    if (name == "left" || name == "x")          return r.x;
+    if (name == "right")                         return r.right();
+    if (name == "top" || name == "y")            return r.y;
+    if (name == "bottom")                        return r.bottom();
+    if (name == "width" || name == "w")          return r.width;
+    if (name == "height" || name == "h")         return r.height;
+    if (name == "centerx" || name == "centerX")  return r.center().x;
+    if (name == "centery" || name == "centerY")  return r.center().y;
+    throw std::runtime_error("RelativeExpression: unknown rect member '" + name + "'");
+}
+
+// ── Parser ─────────────────────────────────────────────────────────────────
+//
+// Recursive-descent over a tokenised view of the source string. Errors
+// carry the byte position so callers can surface useful diagnostics.
+
+struct Token {
+    enum class Kind {
+        End, Number, Ident, Plus, Minus, Star, Slash, Dot, LParen, RParen, Comma,
+    };
+    Kind kind = Kind::End;
+    std::string text;
+    float number = 0.0f;
+    size_t pos = 0;
+};
+
+class Lexer {
+public:
+    explicit Lexer(const std::string& s) : s_(s) {}
+
+    Token next() {
+        skip_ws();
+        Token t;
+        t.pos = pos_;
+        if (pos_ >= s_.size()) { t.kind = Token::Kind::End; return t; }
+        char c = s_[pos_];
+        if (c == '+') { ++pos_; t.kind = Token::Kind::Plus;   t.text = "+"; return t; }
+        if (c == '-') { ++pos_; t.kind = Token::Kind::Minus;  t.text = "-"; return t; }
+        if (c == '*') { ++pos_; t.kind = Token::Kind::Star;   t.text = "*"; return t; }
+        if (c == '/') { ++pos_; t.kind = Token::Kind::Slash;  t.text = "/"; return t; }
+        if (c == '.') {
+            // Period followed by a non-digit is the qualified-name separator.
+            // Period followed by a digit (e.g. ".5") is a leading-dot number.
+            if (pos_ + 1 < s_.size() && std::isdigit(static_cast<unsigned char>(s_[pos_ + 1]))) {
+                return read_number();
+            }
+            ++pos_; t.kind = Token::Kind::Dot; t.text = "."; return t;
+        }
+        if (c == '(') { ++pos_; t.kind = Token::Kind::LParen; t.text = "("; return t; }
+        if (c == ')') { ++pos_; t.kind = Token::Kind::RParen; t.text = ")"; return t; }
+        if (c == ',') { ++pos_; t.kind = Token::Kind::Comma;  t.text = ","; return t; }
+        if (std::isdigit(static_cast<unsigned char>(c))) return read_number();
+        if (std::isalpha(static_cast<unsigned char>(c)) || c == '_') return read_ident();
+        throw std::invalid_argument(fmt_err(pos_, std::string("unexpected character '") + c + "'"));
+    }
+
+private:
+    void skip_ws() {
+        while (pos_ < s_.size() && std::isspace(static_cast<unsigned char>(s_[pos_]))) ++pos_;
+    }
+
+    Token read_number() {
+        Token t; t.pos = pos_; t.kind = Token::Kind::Number;
+        size_t start = pos_;
+        bool seen_dot = false;
+        while (pos_ < s_.size()) {
+            char c = s_[pos_];
+            if (std::isdigit(static_cast<unsigned char>(c))) { ++pos_; continue; }
+            if (c == '.' && !seen_dot) { seen_dot = true; ++pos_; continue; }
+            break;
+        }
+        t.text = s_.substr(start, pos_ - start);
+        try {
+            t.number = std::stof(t.text);
+        } catch (...) {
+            throw std::invalid_argument(fmt_err(start, "malformed number '" + t.text + "'"));
+        }
+        return t;
+    }
+
+    Token read_ident() {
+        Token t; t.pos = pos_; t.kind = Token::Kind::Ident;
+        size_t start = pos_;
+        while (pos_ < s_.size()) {
+            char c = s_[pos_];
+            if (std::isalnum(static_cast<unsigned char>(c)) || c == '_') { ++pos_; continue; }
+            break;
+        }
+        t.text = s_.substr(start, pos_ - start);
+        return t;
+    }
+
+    static std::string fmt_err(size_t pos, const std::string& msg) {
+        std::ostringstream oss;
+        oss << "RelativeExpression parse error at column " << pos << ": " << msg;
+        return oss.str();
+    }
+
+    const std::string& s_;
+    size_t pos_ = 0;
+};
+
+class Parser {
+public:
+    explicit Parser(const std::string& s) : lex_(s), src_(s) { advance(); }
+
+    // expr = term (('+'|'-') term)*
+    std::shared_ptr<RelativeExpression::Node> parse_expr() {
+        auto lhs = parse_term();
+        while (cur_.kind == Token::Kind::Plus || cur_.kind == Token::Kind::Minus) {
+            char op = cur_.text[0];
+            advance();
+            auto rhs = parse_term();
+            auto n = std::make_shared<RelativeExpression::Node>();
+            n->kind = RelativeExpression::Node::Kind::BinaryOp;
+            n->op = op;
+            n->lhs = lhs;
+            n->rhs = rhs;
+            lhs = n;
+        }
+        return lhs;
+    }
+
+    // term = factor (('*'|'/') factor)*
+    std::shared_ptr<RelativeExpression::Node> parse_term() {
+        auto lhs = parse_factor();
+        while (cur_.kind == Token::Kind::Star || cur_.kind == Token::Kind::Slash) {
+            char op = cur_.text[0];
+            advance();
+            auto rhs = parse_factor();
+            auto n = std::make_shared<RelativeExpression::Node>();
+            n->kind = RelativeExpression::Node::Kind::BinaryOp;
+            n->op = op;
+            n->lhs = lhs;
+            n->rhs = rhs;
+            lhs = n;
+        }
+        return lhs;
+    }
+
+    // factor = number | identifier | qualified | '(' expr ')' | '-' factor
+    std::shared_ptr<RelativeExpression::Node> parse_factor() {
+        if (cur_.kind == Token::Kind::Minus) {
+            advance();
+            auto inner = parse_factor();
+            auto n = std::make_shared<RelativeExpression::Node>();
+            n->kind = RelativeExpression::Node::Kind::UnaryMinus;
+            n->lhs = inner;
+            return n;
+        }
+        if (cur_.kind == Token::Kind::LParen) {
+            advance();
+            auto inner = parse_expr();
+            expect(Token::Kind::RParen, "expected ')'");
+            advance();
+            return inner;
+        }
+        if (cur_.kind == Token::Kind::Number) {
+            auto n = std::make_shared<RelativeExpression::Node>();
+            n->kind = RelativeExpression::Node::Kind::Number;
+            n->number = cur_.number;
+            advance();
+            return n;
+        }
+        if (cur_.kind == Token::Kind::Ident) {
+            std::string ident = cur_.text;
+            advance();
+            if (cur_.kind == Token::Kind::Dot) {
+                advance();
+                if (cur_.kind != Token::Kind::Ident)
+                    throw std::invalid_argument(err_at(cur_.pos, "expected identifier after '.'"));
+                auto n = std::make_shared<RelativeExpression::Node>();
+                n->kind = RelativeExpression::Node::Kind::Qualified;
+                n->qual_ns = ident;
+                n->qual_member = cur_.text;
+                advance();
+                return n;
+            }
+            auto n = std::make_shared<RelativeExpression::Node>();
+            n->kind = RelativeExpression::Node::Kind::Identifier;
+            n->ident = ident;
+            return n;
+        }
+        throw std::invalid_argument(err_at(cur_.pos, "expected expression"));
+    }
+
+    void expect_end() {
+        if (cur_.kind != Token::Kind::End)
+            throw std::invalid_argument(err_at(cur_.pos, "unexpected trailing token '" + cur_.text + "'"));
+    }
+
+    Token& cur() { return cur_; }
+    void advance() { cur_ = lex_.next(); }
+
+private:
+    void expect(Token::Kind k, const std::string& msg) {
+        if (cur_.kind != k) throw std::invalid_argument(err_at(cur_.pos, msg));
+    }
+
+    std::string err_at(size_t pos, const std::string& msg) const {
+        std::ostringstream oss;
+        oss << "RelativeExpression parse error at column " << pos << " in \"" << src_ << "\": " << msg;
+        return oss.str();
+    }
+
+    Lexer lex_;
+    const std::string& src_;
+    Token cur_;
+};
+
+// ── Evaluator ──────────────────────────────────────────────────────────────
+
+float eval_node(const RelativeExpression::Node& n,
+                const Rect& parent,
+                const std::map<std::string, Rect>& named) {
+    using Kind = RelativeExpression::Node::Kind;
+    switch (n.kind) {
+        case Kind::Number:
+            return n.number;
+        case Kind::Identifier:
+            // Unqualified identifiers resolve against the parent rect.
+            return rect_member(parent, n.ident);
+        case Kind::Qualified: {
+            // `parent.foo` is the same as the unqualified `foo` for ergonomics.
+            if (n.qual_ns == "parent") return rect_member(parent, n.qual_member);
+            auto it = named.find(n.qual_ns);
+            if (it == named.end())
+                throw std::runtime_error("RelativeExpression: undefined named rect '" + n.qual_ns + "'");
+            return rect_member(it->second, n.qual_member);
+        }
+        case Kind::UnaryMinus:
+            return -eval_node(*n.lhs, parent, named);
+        case Kind::BinaryOp: {
+            float l = eval_node(*n.lhs, parent, named);
+            float r = eval_node(*n.rhs, parent, named);
+            switch (n.op) {
+                case '+': return l + r;
+                case '-': return l - r;
+                case '*': return l * r;
+                case '/':
+                    if (r == 0.0f)
+                        throw std::runtime_error("RelativeExpression: division by zero");
+                    return l / r;
+            }
+        }
+    }
+    return 0.0f;  // unreachable
+}
+
+// ── Serialiser ─────────────────────────────────────────────────────────────
+
+int op_prec(char op) {
+    switch (op) {
+        case '+': case '-': return 1;
+        case '*': case '/': return 2;
+    }
+    return 0;
+}
+
+void emit(const RelativeExpression::Node& n, std::ostringstream& out, int parent_prec) {
+    using Kind = RelativeExpression::Node::Kind;
+    switch (n.kind) {
+        case Kind::Number: {
+            // Compact representation — strip trailing zeros / unnecessary dot.
+            char buf[32];
+            std::snprintf(buf, sizeof(buf), "%g", n.number);
+            out << buf;
+            return;
+        }
+        case Kind::Identifier:
+            out << n.ident;
+            return;
+        case Kind::Qualified:
+            out << n.qual_ns << '.' << n.qual_member;
+            return;
+        case Kind::UnaryMinus:
+            out << '-';
+            emit(*n.lhs, out, 3);  // bind tighter than any binary op
+            return;
+        case Kind::BinaryOp: {
+            int p = op_prec(n.op);
+            bool paren = p < parent_prec;
+            if (paren) out << '(';
+            emit(*n.lhs, out, p);
+            out << ' ' << n.op << ' ';
+            emit(*n.rhs, out, p + 1);
+            if (paren) out << ')';
+            return;
+        }
+    }
+}
+
+}  // namespace
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+RelativeExpression RelativeExpression::parse(const std::string& source) {
+    Parser p(source);
+    auto root = p.parse_expr();
+    p.expect_end();
+    return RelativeExpression(std::move(root));
+}
+
+float RelativeExpression::evaluate(const Rect& parent,
+                                   const std::map<std::string, Rect>& named) const {
+    if (!root_) throw std::runtime_error("RelativeExpression: evaluate on empty expression");
+    return eval_node(*root_, parent, named);
+}
+
+float RelativeExpression::evaluate(const std::string& source,
+                                   const Rect& parent,
+                                   const std::map<std::string, Rect>& named) {
+    return parse(source).evaluate(parent, named);
+}
+
+std::string RelativeExpression::to_string() const {
+    if (!root_) return {};
+    std::ostringstream out;
+    emit(*root_, out, 0);
+    return out.str();
+}
+
+RelativePoint RelativePoint::parse(const std::string& source) {
+    // Split on the top-level comma. We can't just split on the first comma
+    // because parenthesised sub-expressions don't contain commas (the
+    // grammar above forbids commas inside expr), so a single scan suffices.
+    int depth = 0;
+    std::size_t comma_pos = std::string::npos;
+    for (std::size_t i = 0; i < source.size(); ++i) {
+        char c = source[i];
+        if (c == '(') ++depth;
+        else if (c == ')') --depth;
+        else if (c == ',' && depth == 0) { comma_pos = i; break; }
+    }
+    if (comma_pos == std::string::npos)
+        throw std::invalid_argument("RelativePoint: expected 'x, y' — comma missing in \"" + source + "\"");
+
+    auto x = RelativeExpression::parse(source.substr(0, comma_pos));
+    auto y = RelativeExpression::parse(source.substr(comma_pos + 1));
+    return RelativePoint(std::move(x), std::move(y));
+}
+
+Point RelativePoint::evaluate(const Rect& parent,
+                              const std::map<std::string, Rect>& named) const {
+    return Point{ x_.evaluate(parent, named), y_.evaluate(parent, named) };
+}
+
+}  // namespace pulp::view

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2867,6 +2867,16 @@ target_link_libraries(pulp-test-view-core-link PRIVATE pulp::view-core Catch2::C
 catch_discover_tests(pulp-test-view-core-link
     PROPERTIES LABELS "parser-import")
 
+# RelativePoint expression layout (parser + evaluator + serializer).
+# Lives under pulp::view-core so the test binary doesn't transitively
+# need the JS engine. See planning/2026-05-24-reference-framework-
+# gap-analysis.md "Relative coordinates" row.
+add_executable(pulp-test-relative-point test_relative_point.cpp)
+target_link_libraries(pulp-test-relative-point
+    PRIVATE pulp::view-core Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-relative-point
+    PROPERTIES LABELS "view")
+
 if(APPLE AND NOT PULP_IOS)
     add_executable(pulp-test-view-core-window-host-link
         test_view_core_window_host_link.mm)

--- a/test/test_relative_point.cpp
+++ b/test/test_relative_point.cpp
@@ -1,0 +1,161 @@
+// RelativePoint / RelativeExpression tests.
+//
+// Covers:
+//   1. Lexer/parser edge cases (whitespace, unary minus, parens, qualified
+//      identifiers, leading-dot numbers).
+//   2. Evaluator correctness for common layout idioms (right-aligned,
+//      centered, sibling-relative).
+//   3. Error reporting on malformed input (column-bearing messages,
+//      undefined named rects, divide-by-zero).
+//   4. to_string round-trip preserves semantics (re-parse + re-eval
+//      matches original).
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <pulp/view/relative_point.hpp>
+
+using namespace pulp::view;
+using Catch::Matchers::WithinAbs;
+
+namespace {
+Rect parent() { return Rect{0, 0, 200, 100}; }
+}  // namespace
+
+TEST_CASE("RelativeExpression parses numeric literals", "[relpoint][parse]") {
+    REQUIRE(RelativeExpression::evaluate("42",      parent()) == 42.0f);
+    REQUIRE(RelativeExpression::evaluate("3.5",     parent()) == 3.5f);
+    REQUIRE(RelativeExpression::evaluate(".75",     parent()) == 0.75f);
+    REQUIRE(RelativeExpression::evaluate("  100 ",  parent()) == 100.0f);
+}
+
+TEST_CASE("RelativeExpression parses built-in identifiers", "[relpoint][parse]") {
+    Rect p = parent();  // x=0 y=0 w=200 h=100
+    REQUIRE(RelativeExpression::evaluate("left",    p) == 0.0f);
+    REQUIRE(RelativeExpression::evaluate("right",   p) == 200.0f);
+    REQUIRE(RelativeExpression::evaluate("top",     p) == 0.0f);
+    REQUIRE(RelativeExpression::evaluate("bottom",  p) == 100.0f);
+    REQUIRE(RelativeExpression::evaluate("width",   p) == 200.0f);
+    REQUIRE(RelativeExpression::evaluate("height",  p) == 100.0f);
+    REQUIRE(RelativeExpression::evaluate("centerx", p) == 100.0f);
+    REQUIRE(RelativeExpression::evaluate("centery", p) == 50.0f);
+}
+
+TEST_CASE("RelativeExpression — common layout idioms", "[relpoint][eval]") {
+    Rect p = parent();
+    // right-align with 10px margin
+    REQUIRE(RelativeExpression::evaluate("right - 10",      p) == 190.0f);
+    // center horizontally
+    REQUIRE(RelativeExpression::evaluate("centerx",         p) == 100.0f);
+    // half-width
+    REQUIRE(RelativeExpression::evaluate("width / 2",       p) == 100.0f);
+    // golden-ratio split
+    REQUIRE_THAT(RelativeExpression::evaluate("width * 0.618", p),
+                 WithinAbs(123.6f, 1e-4f));
+}
+
+TEST_CASE("RelativeExpression — operator precedence and parens", "[relpoint][eval]") {
+    Rect p = parent();
+    // 2 + 3 * 4 = 14 (not 20)
+    REQUIRE(RelativeExpression::evaluate("2 + 3 * 4",       p) == 14.0f);
+    REQUIRE(RelativeExpression::evaluate("(2 + 3) * 4",     p) == 20.0f);
+    // unary minus
+    REQUIRE(RelativeExpression::evaluate("-10",             p) == -10.0f);
+    REQUIRE(RelativeExpression::evaluate("right + -10",     p) == 190.0f);
+    // nested parens
+    REQUIRE(RelativeExpression::evaluate("((width - 20) / 2) + 5", p) == 95.0f);
+}
+
+TEST_CASE("RelativeExpression — qualified names from named rects",
+          "[relpoint][named]") {
+    Rect p = parent();
+    std::map<std::string, Rect> env;
+    env["prev"]   = Rect{10, 20, 60, 30};   // right=70, bottom=50, centery=35
+    env["sibling"] = Rect{80, 40, 50, 25};   // left=80, top=40
+
+    REQUIRE(RelativeExpression::evaluate("prev.right + 8",         p, env) == 78.0f);
+    REQUIRE(RelativeExpression::evaluate("sibling.left - 4",       p, env) == 76.0f);
+    REQUIRE(RelativeExpression::evaluate("prev.centery",           p, env) == 35.0f);
+    // parent.foo == foo
+    REQUIRE(RelativeExpression::evaluate("parent.width",           p, env) == 200.0f);
+}
+
+TEST_CASE("RelativeExpression — error reporting", "[relpoint][error]") {
+    SECTION("empty expression") {
+        REQUIRE_THROWS_AS(RelativeExpression::parse(""), std::invalid_argument);
+    }
+    SECTION("trailing garbage") {
+        REQUIRE_THROWS_AS(RelativeExpression::parse("10 +"), std::invalid_argument);
+        REQUIRE_THROWS_AS(RelativeExpression::parse("right 10"), std::invalid_argument);
+    }
+    SECTION("unbalanced paren") {
+        REQUIRE_THROWS_AS(RelativeExpression::parse("(width + 10"), std::invalid_argument);
+    }
+    SECTION("unknown character") {
+        REQUIRE_THROWS_AS(RelativeExpression::parse("width @ 10"), std::invalid_argument);
+    }
+    SECTION("qualified without member") {
+        REQUIRE_THROWS_AS(RelativeExpression::parse("prev."), std::invalid_argument);
+    }
+    SECTION("unknown built-in member") {
+        auto e = RelativeExpression::parse("nope");
+        REQUIRE_THROWS_AS(e.evaluate(parent()), std::runtime_error);
+    }
+    SECTION("undefined named rect") {
+        auto e = RelativeExpression::parse("ghost.right");
+        REQUIRE_THROWS_AS(e.evaluate(parent()), std::runtime_error);
+    }
+    SECTION("divide by zero") {
+        auto e = RelativeExpression::parse("10 / 0");
+        REQUIRE_THROWS_AS(e.evaluate(parent()), std::runtime_error);
+    }
+    SECTION("error message carries column number") {
+        try {
+            RelativeExpression::parse("right @ 10");
+            FAIL("expected throw");
+        } catch (const std::invalid_argument& e) {
+            std::string what = e.what();
+            REQUIRE(what.find("column") != std::string::npos);
+        }
+    }
+}
+
+TEST_CASE("RelativeExpression — to_string round-trips", "[relpoint][serialize]") {
+    auto roundtrip = [](const std::string& src) {
+        auto e1 = RelativeExpression::parse(src);
+        auto s  = e1.to_string();
+        auto e2 = RelativeExpression::parse(s);
+        // Numerical equivalence is the contract (formatting may differ).
+        Rect p = parent();
+        std::map<std::string, Rect> env{ {"prev", Rect{10, 20, 60, 30}} };
+        REQUIRE(e1.evaluate(p, env) == e2.evaluate(p, env));
+    };
+    roundtrip("right - 10");
+    roundtrip("(2 + 3) * 4");
+    roundtrip("-width / 2 + centerx");
+    roundtrip("prev.right + 8");
+    roundtrip("width * 0.618");
+}
+
+TEST_CASE("RelativePoint — x/y pair parsing and eval", "[relpoint][pair]") {
+    Rect p = parent();
+    auto rp = RelativePoint::parse("right - 10, centery");
+    Point pt = rp.evaluate(p);
+    REQUIRE(pt.x == 190.0f);
+    REQUIRE(pt.y == 50.0f);
+}
+
+TEST_CASE("RelativePoint — error when comma missing", "[relpoint][pair][error]") {
+    REQUIRE_THROWS_AS(RelativePoint::parse("right - 10"), std::invalid_argument);
+}
+
+TEST_CASE("RelativePoint — both axes resolve named rects", "[relpoint][pair][named]") {
+    Rect p = parent();
+    std::map<std::string, Rect> env{
+        {"prev", Rect{10, 20, 60, 30}},
+    };
+    auto rp = RelativePoint::parse("prev.right + 4, prev.bottom + 6");
+    Point pt = rp.evaluate(p, env);
+    REQUIRE(pt.x == 74.0f);
+    REQUIRE(pt.y == 56.0f);
+}


### PR DESCRIPTION
## Summary
- Adds `pulp::view::RelativePoint` + `RelativeExpression` — parser + evaluator for expression-based positioning.
- Grammar: numeric literals, parent-relative built-ins (`left/right/top/bottom/width/height/centerx/centery`), qualified names against a caller-supplied named-rect map (`prev.right`, `sibling.left`), standard arithmetic precedence with parens and unary minus.
- Closes the **Relative coordinates** P3 row in `planning/2026-05-24-reference-framework-gap-analysis.md`. Row demoted Missing → Partial; RelativeRectangle / Coordinate / Path / MarkerList intentionally not shipped (flex + grid covers most demand).

## Test plan
- [x] `pulp-test-relative-point`: parser, every built-in identifier, common idioms, operator precedence, error reporting with column-bearing messages, to_string round-trips, qualified-name resolution.
- [x] All 10 test cases / 45 assertions green.