### PR TITLE
feat(view): CodeEditor tokenizers + PropertyPanel variants + BubbleMessage + styled AlertWindow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.126.0",
+      "version": "0.127.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.125.0"
+  "version": "0.126.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.126.0",
+  "version": "0.127.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.264.1
+    VERSION 0.266.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -335,6 +335,7 @@ target_sources(pulp-view-core PRIVATE
     src/file_browser.cpp
     src/file_chooser.cpp
     src/code_editor.cpp
+    src/code_editor_tokenizer.cpp
     src/table.cpp
     src/toolbar.cpp
     src/concertina_panel.cpp

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -345,6 +345,7 @@ target_sources(pulp-view-core PRIVATE
     src/command_registry.cpp
     src/key_mapping_editor.cpp
     src/window_classes.cpp
+    src/bubble_message.cpp
 )
 
 target_sources(pulp-view-script PRIVATE

--- a/core/view/include/pulp/view/bubble_message.hpp
+++ b/core/view/include/pulp/view/bubble_message.hpp
@@ -1,0 +1,188 @@
+#pragma once
+
+/// @file bubble_message.hpp
+/// BubbleMessageComponent — small floating message bubble anchored to a
+/// source View with auto-dismiss + transient lifetime (closes the
+/// gap-doc Phase 3 row
+/// "TooltipWindow + BubbleMessageComponent + AlertWindow styled" for
+/// the BubbleMessage half).
+///
+/// A `BubbleMessageComponent` is conceptually a tooltip with a stronger
+/// caller-driven story:
+///   - the bubble is shown by `show_for(view, text, dt_lifetime)`,
+///   - it stays anchored to the *source view*: position updates with
+///     anchor changes via `move_to(anchor)`, OR (when the caller wants
+///     auto-tracking) the host can call `recompute_anchor()` on every
+///     tick to re-derive the position from the source view's bounds,
+///   - it auto-dismisses after `lifetime()` seconds, then fades out
+///     and finally goes idle,
+///   - it is transient: dismissing it nullifies the source-view pointer
+///     so subsequent `tick(dt)` calls do not chase a deleted view.
+///
+/// The widget is headless-friendly: time is driven by `tick(dt)`, no
+/// scheduler, no OS coupling. Hosts observe `visible()`, `opacity()`,
+/// `position()`, `text()`, and `source_view()` and paint accordingly.
+///
+/// License-lineage note: the type, accessors, and lifetime contract
+/// are Pulp-native per the gap-doc rule. The "anchored bubble" idea is
+/// generic UI.
+
+#include <algorithm>
+#include <functional>
+#include <string>
+
+#include <pulp/view/animation.hpp>
+#include <pulp/view/geometry.hpp>
+
+namespace pulp::view {
+
+class View;  // fwd
+
+class BubbleMessageComponent {
+public:
+    enum class Phase {
+        idle,     ///< Not currently shown.
+        showing,  ///< Visible (possibly still fading in).
+        hiding,   ///< Fade-out in progress.
+    };
+
+    /// Anchor edge — where the bubble is placed relative to the source
+    /// view's bounds. The caller can pick a side and the bubble's
+    /// position will be derived from `source_view->bounds()` whenever
+    /// `recompute_anchor()` runs.
+    enum class Side {
+        above,   ///< Bubble sits above the top edge of the source.
+        below,   ///< Bubble sits below the bottom edge of the source.
+        left,    ///< Bubble sits to the left of the source.
+        right,   ///< Bubble sits to the right of the source.
+    };
+
+    BubbleMessageComponent() = default;
+
+    /// Begin showing the bubble anchored to `source`. If `source` is
+    /// not null, `recompute_anchor()` will project the source's
+    /// `bounds().center()` (offset by `side`) into the position. The
+    /// bubble is visible immediately and fades out after `lifetime`
+    /// seconds.
+    ///
+    /// Calling `show_for` while already visible swaps the text, source,
+    /// and resets the lifetime timer.
+    void show_for(View* source, std::string text, float lifetime = 3.0f) {
+        source_ = source;
+        text_ = std::move(text);
+        lifetime_ = std::max(0.0f, lifetime);
+        elapsed_ = 0.0f;
+        recompute_anchor();
+        if (phase_ != Phase::showing) {
+            phase_ = Phase::showing;
+            opacity_.set(0.0f);
+            opacity_.animate_to(1.0f, fade_duration_);
+        }
+    }
+
+    /// Update the anchor explicitly (skip the source-view lookup).
+    /// Useful when the caller wants to position the bubble at a
+    /// pointer or arbitrary screen coordinate.
+    void move_to(Point anchor) {
+        explicit_anchor_ = anchor;
+        has_explicit_anchor_ = true;
+        position_ = compute_offset(anchor);
+    }
+
+    /// Re-derive the position from `source_view()->bounds()` and the
+    /// configured `side()`. Safe to call every tick. No-op if the
+    /// source is null or an explicit anchor is in force.
+    void recompute_anchor();
+
+    /// Begin fade-out. From `showing` jumps to `hiding`; from `idle`
+    /// or already-`hiding` is a no-op.
+    void hide() {
+        if (phase_ != Phase::showing) return;
+        opacity_.animate_to(0.0f, fade_duration_);
+        phase_ = Phase::hiding;
+    }
+
+    /// Advance time. Drives the auto-dismiss timer + fade animations.
+    /// Returns `true` while the bubble is still doing work (visible,
+    /// fading, or counting down).
+    bool tick(float dt) {
+        switch (phase_) {
+            case Phase::idle:
+                return false;
+            case Phase::showing:
+                opacity_.advance(dt);
+                elapsed_ += dt;
+                if (lifetime_ > 0.0f && elapsed_ >= lifetime_) {
+                    hide();
+                }
+                return true;
+            case Phase::hiding:
+                opacity_.advance(dt);
+                if (!opacity_.animating()) {
+                    phase_ = Phase::idle;
+                    source_ = nullptr;  // Transient: forget the source.
+                    has_explicit_anchor_ = false;
+                    return false;
+                }
+                return true;
+        }
+        return false;
+    }
+
+    // ── State ────────────────────────────────────────────────────────
+
+    bool visible() const {
+        return phase_ == Phase::showing || phase_ == Phase::hiding;
+    }
+    Phase phase() const { return phase_; }
+    float opacity() const { return opacity_.value(); }
+    Point position() const { return position_; }
+    const std::string& text() const { return text_; }
+    View* source_view() const { return source_; }
+    float elapsed() const { return elapsed_; }
+
+    // ── Configuration ───────────────────────────────────────────────
+
+    void set_side(Side s) { side_ = s; }
+    Side side() const { return side_; }
+
+    /// Pixel offset added to the computed anchor after the `side`
+    /// projection. Default (0, -8) — small gap above the source.
+    void set_offset(Point offset) { offset_ = offset; }
+    Point offset() const { return offset_; }
+
+    /// Time in seconds the bubble stays visible before auto-fade.
+    /// 0 disables auto-dismiss (caller drives `hide()`).
+    void set_lifetime(float seconds) { lifetime_ = std::max(0.0f, seconds); }
+    float lifetime() const { return lifetime_; }
+
+    /// Fade-in / fade-out duration.
+    void set_fade_duration(float seconds) {
+        fade_duration_ = std::max(0.0f, seconds);
+    }
+    float fade_duration() const { return fade_duration_; }
+
+    /// Optional observer fired on every phase transition.
+    std::function<void(Phase)> on_phase_change;
+
+private:
+    Point compute_offset(Point anchor) const {
+        return {anchor.x + offset_.x, anchor.y + offset_.y};
+    }
+
+    View* source_ = nullptr;
+    std::string text_;
+    Side side_ = Side::above;
+    Point position_{};
+    Point offset_{0, -8};
+    Point explicit_anchor_{};
+    bool has_explicit_anchor_ = false;
+
+    Phase phase_ = Phase::idle;
+    float lifetime_ = 3.0f;
+    float elapsed_ = 0.0f;
+    float fade_duration_ = 0.12f;
+    ValueAnimation opacity_{0.0f};
+};
+
+} // namespace pulp::view

--- a/core/view/include/pulp/view/code_editor_tokenizer.hpp
+++ b/core/view/include/pulp/view/code_editor_tokenizer.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+/// @file code_editor_tokenizer.hpp
+/// Lightweight per-language tokenizers for `CodeEditor` syntax
+/// highlighting (closes the gap-doc Phase 4 row "CodeEditor language
+/// coverage").
+///
+/// Each call to `tokenize_line(line, language)` walks a single source
+/// line and returns a flat list of `Token` spans the editor can color.
+/// The tokenizers are deliberately tiny — they are NOT full parsers,
+/// just enough state to color keywords, strings, comments, numbers, and
+/// preprocessor directives the way a typical IDE skim does. Multi-line
+/// constructs (block comments, multi-line strings) are reported on the
+/// first line only; the editor paints each line independently in the
+/// existing native fallback paint path.
+///
+/// All tokenizers are stateless, allocation-free per token, and run in
+/// O(n) over the input characters — safe to call on every paint without
+/// caching. Headless-friendly: no platform / canvas dependencies.
+///
+/// License-lineage note: the tokenizer keyword lists are derived from
+/// the official language references (ISO C++, ECMAScript, Python,
+/// CommonMark, ECMA-404 JSON, Lua manual) — no copy from the reference
+/// framework's tokeniser sources.
+
+#include <cstddef>
+#include <string_view>
+#include <vector>
+
+#include <pulp/view/code_editor.hpp>
+
+namespace pulp::view {
+
+/// Token classification for `tokenize_line`. The colors the editor
+/// renders for each class are theme-driven; the tokenizer only labels
+/// the span.
+enum class TokenClass {
+    text,        ///< Plain text (default color)
+    keyword,     ///< Language keyword (e.g. `if`, `return`, `class`)
+    type,        ///< Built-in / common type name (e.g. `int`, `Number`)
+    identifier,  ///< Identifier — the tokenizer rarely emits this on
+                 ///  its own; callers can treat unmatched text as
+                 ///  identifier.
+    number,      ///< Numeric literal (int / float / hex / bin)
+    string,      ///< String / character literal (single or double quote)
+    comment,     ///< Single-line comment (`//`, `#`, `--`) or the start
+                 ///  of a block comment.
+    preprocessor,///< Preprocessor / directive line (e.g. `#include`).
+    punctuation, ///< Operators and structural punctuation.
+    heading,     ///< Markdown heading (`#`, `##`, …).
+    link,        ///< Markdown / hyperlink span.
+};
+
+/// One token span — half-open `[start, start+length)` into the line.
+struct Token {
+    std::size_t start = 0;
+    std::size_t length = 0;
+    TokenClass cls = TokenClass::text;
+};
+
+/// Tokenize a single line of source text for `language`. Returns an
+/// ordered, non-overlapping list of spans. Characters not covered by a
+/// span are treated as `TokenClass::text` by the editor.
+///
+/// `language` mappings:
+///   - `Cpp`        → `tokenize_cpp_line`
+///   - `JavaScript` → `tokenize_javascript_line`
+///   - `Python`     → `tokenize_python_line`
+///   - `JSON`       → `tokenize_json_line`
+///   - `Lua`        → `tokenize_lua_line`
+///   - everything else (including `PlainText`, `XML`, `GLSL`, `Faust`,
+///     `JSFX`) → returns the line as a single `text` span.
+///
+/// Markdown does not have an entry in `CodeLanguage` yet — callers can
+/// invoke `tokenize_markdown_line` directly for `*.md` content.
+std::vector<Token> tokenize_line(std::string_view line, CodeLanguage language);
+
+// ── Per-language entry points (callable independently) ────────────────
+
+std::vector<Token> tokenize_cpp_line(std::string_view line);
+std::vector<Token> tokenize_javascript_line(std::string_view line);
+std::vector<Token> tokenize_python_line(std::string_view line);
+std::vector<Token> tokenize_json_line(std::string_view line);
+std::vector<Token> tokenize_lua_line(std::string_view line);
+std::vector<Token> tokenize_markdown_line(std::string_view line);
+
+/// True when `name` is one of the keywords the tokenizer recognises
+/// for `language`. Useful for editor callers that want to do their own
+/// scanning but reuse the keyword set.
+bool is_keyword(std::string_view name, CodeLanguage language);
+
+} // namespace pulp::view

--- a/core/view/include/pulp/view/property_panel.hpp
+++ b/core/view/include/pulp/view/property_panel.hpp
@@ -1,0 +1,495 @@
+#pragma once
+
+/// @file property_panel.hpp
+/// PropertyPanel — typed property editor with Boolean / Choice / Slider
+/// / Button / MultiChoice / Text variants and optional `PropertiesFile`
+/// persistence (closes the gap-doc Phase 4 row
+/// "PreferencesPanel + PropertyPanel widgets").
+///
+/// `PropertyPanel` is a sister widget to `PreferencesPanel`: while
+/// PreferencesPanel manages "which page is shown", PropertyPanel hosts
+/// the typed property *editors* on a page. Each property has a stable
+/// `key`, a display `label`, a `kind` (BooleanToggle, Choice, Slider,
+/// Button, MultiChoice, Text), and a typed value. The panel exposes:
+///
+///   - `add_*` builders for each typed variant,
+///   - `value_for(key)` / `set_value(key, ...)` typed getters/setters,
+///   - `simulate_*` test helpers (toggle, choose, slide, click,
+///     multi-check, set-text) that fire the same logic a real UI event
+///     would,
+///   - `bind_persistence(PropertiesFile*)` to read all current values
+///     from a `PropertiesFile` lane (one-shot at bind time) and to
+///     write every subsequent change back under each property's key.
+///
+/// The persistence keys are the property keys verbatim — callers
+/// typically pass a "section.field" form (e.g. `"audio.input_gain"`).
+/// `bind_persistence` is idempotent: a second bind to a different store
+/// drops the first.
+///
+/// `PropertyPanel` extends `View` so it can sit in a `PreferencesPanel`
+/// page. It does *not* paint chrome in the headless / fallback path —
+/// hosts can render the typed editors however they want by observing
+/// `properties()` + per-property `on_change`. The widget is the
+/// authoritative state holder.
+///
+/// License-lineage note: the typed variants mirror the conceptual menu
+/// of the reference framework's `PropertyPanel`, but the surface
+/// (`add_boolean`, `add_choice`, …, `bind_persistence`) is Pulp-native
+/// and the persistence story leans on Pulp's existing
+/// `state::PropertiesFile`.
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include <pulp/state/properties_file.hpp>
+#include <pulp/view/view.hpp>
+
+namespace pulp::view {
+
+class PropertyPanel : public View {
+public:
+    enum class Kind {
+        BooleanToggle,  ///< bool — round-trips as 0/1
+        Choice,         ///< single int index into `options`
+        Slider,         ///< float in [min, max]
+        Button,         ///< action only (no persisted state)
+        MultiChoice,    ///< ordered set of int indices into `options`
+        Text,           ///< std::string value
+    };
+
+    using Value = std::variant<bool,
+                               int,
+                               float,
+                               std::vector<int>,
+                               std::string,
+                               std::monostate>;
+
+    struct Property {
+        std::string key;        ///< Persistence + lookup key.
+        std::string label;      ///< Display label.
+        Kind kind = Kind::Text;
+        Value value{};
+        // Slider-only constraints.
+        float min = 0.0f;
+        float max = 1.0f;
+        // Choice / MultiChoice options.
+        std::vector<std::string> options;
+        // Per-property change observer fires AFTER the value updates +
+        // BEFORE persistence is written.
+        std::function<void(const Value&)> on_change;
+        // Button-only action; fires on `click`.
+        std::function<void()> on_click;
+    };
+
+    PropertyPanel() = default;
+
+    // ── Builders (preferred entry points) ────────────────────────────
+
+    void add_boolean(std::string key, std::string label, bool initial,
+                     std::function<void(bool)> on_change = {}) {
+        Property p;
+        p.kind = Kind::BooleanToggle;
+        p.key = std::move(key);
+        p.label = std::move(label);
+        p.value = initial;
+        if (on_change) {
+            p.on_change = [cb = std::move(on_change)](const Value& v) {
+                if (auto* b = std::get_if<bool>(&v)) cb(*b);
+            };
+        }
+        register_property(std::move(p));
+    }
+
+    void add_choice(std::string key, std::string label,
+                    std::vector<std::string> options, int initial_index,
+                    std::function<void(int)> on_change = {}) {
+        Property p;
+        p.kind = Kind::Choice;
+        p.key = std::move(key);
+        p.label = std::move(label);
+        p.options = std::move(options);
+        // Clamp the initial index defensively so the panel never holds
+        // an out-of-range value.
+        if (p.options.empty()) {
+            p.value = 0;
+        } else {
+            if (initial_index < 0) initial_index = 0;
+            if (initial_index >= static_cast<int>(p.options.size())) {
+                initial_index = static_cast<int>(p.options.size()) - 1;
+            }
+            p.value = initial_index;
+        }
+        if (on_change) {
+            p.on_change = [cb = std::move(on_change)](const Value& v) {
+                if (auto* i = std::get_if<int>(&v)) cb(*i);
+            };
+        }
+        register_property(std::move(p));
+    }
+
+    void add_slider(std::string key, std::string label, float min, float max,
+                    float initial, std::function<void(float)> on_change = {}) {
+        Property p;
+        p.kind = Kind::Slider;
+        p.key = std::move(key);
+        p.label = std::move(label);
+        p.min = min;
+        p.max = max;
+        p.value = clamp(initial, min, max);
+        if (on_change) {
+            p.on_change = [cb = std::move(on_change)](const Value& v) {
+                if (auto* f = std::get_if<float>(&v)) cb(*f);
+            };
+        }
+        register_property(std::move(p));
+    }
+
+    void add_button(std::string key, std::string label,
+                    std::function<void()> on_click) {
+        Property p;
+        p.kind = Kind::Button;
+        p.key = std::move(key);
+        p.label = std::move(label);
+        p.value = std::monostate{};
+        p.on_click = std::move(on_click);
+        register_property(std::move(p));
+    }
+
+    void add_multi_choice(std::string key, std::string label,
+                          std::vector<std::string> options,
+                          std::vector<int> initial_selection,
+                          std::function<void(const std::vector<int>&)> on_change = {}) {
+        Property p;
+        p.kind = Kind::MultiChoice;
+        p.key = std::move(key);
+        p.label = std::move(label);
+        p.options = std::move(options);
+        normalize_indices(initial_selection, p.options.size());
+        p.value = std::move(initial_selection);
+        if (on_change) {
+            p.on_change = [cb = std::move(on_change)](const Value& v) {
+                if (auto* xs = std::get_if<std::vector<int>>(&v)) cb(*xs);
+            };
+        }
+        register_property(std::move(p));
+    }
+
+    void add_text(std::string key, std::string label, std::string initial,
+                  std::function<void(const std::string&)> on_change = {}) {
+        Property p;
+        p.kind = Kind::Text;
+        p.key = std::move(key);
+        p.label = std::move(label);
+        p.value = std::move(initial);
+        if (on_change) {
+            p.on_change = [cb = std::move(on_change)](const Value& v) {
+                if (auto* s = std::get_if<std::string>(&v)) cb(*s);
+            };
+        }
+        register_property(std::move(p));
+    }
+
+    // ── Read access ──────────────────────────────────────────────────
+
+    std::size_t size() const { return properties_.size(); }
+    bool empty() const { return properties_.empty(); }
+
+    const std::vector<Property>& properties() const { return properties_; }
+
+    const Property* find(std::string_view key) const {
+        for (const auto& p : properties_) {
+            if (p.key == key) return &p;
+        }
+        return nullptr;
+    }
+
+    std::optional<bool> get_bool(std::string_view key) const {
+        if (const auto* p = find(key))
+            if (const auto* b = std::get_if<bool>(&p->value)) return *b;
+        return std::nullopt;
+    }
+    std::optional<int> get_choice(std::string_view key) const {
+        if (const auto* p = find(key))
+            if (const auto* i = std::get_if<int>(&p->value)) return *i;
+        return std::nullopt;
+    }
+    std::optional<float> get_slider(std::string_view key) const {
+        if (const auto* p = find(key))
+            if (const auto* f = std::get_if<float>(&p->value)) return *f;
+        return std::nullopt;
+    }
+    std::optional<std::vector<int>> get_multi_choice(std::string_view key) const {
+        if (const auto* p = find(key))
+            if (const auto* xs = std::get_if<std::vector<int>>(&p->value)) return *xs;
+        return std::nullopt;
+    }
+    std::optional<std::string> get_text(std::string_view key) const {
+        if (const auto* p = find(key))
+            if (const auto* s = std::get_if<std::string>(&p->value)) return *s;
+        return std::nullopt;
+    }
+
+    // ── Mutation (drives observers + persistence) ────────────────────
+
+    /// Set a Boolean property. No-op when the key is missing or the
+    /// kind is not Boolean.
+    bool set_bool(std::string_view key, bool v) {
+        auto* p = find_mut(key);
+        if (!p || p->kind != Kind::BooleanToggle) return false;
+        p->value = v;
+        fire(*p);
+        return true;
+    }
+    bool set_choice(std::string_view key, int index) {
+        auto* p = find_mut(key);
+        if (!p || p->kind != Kind::Choice) return false;
+        if (p->options.empty()) {
+            p->value = 0;
+        } else {
+            if (index < 0) index = 0;
+            if (index >= static_cast<int>(p->options.size())) {
+                index = static_cast<int>(p->options.size()) - 1;
+            }
+            p->value = index;
+        }
+        fire(*p);
+        return true;
+    }
+    bool set_slider(std::string_view key, float v) {
+        auto* p = find_mut(key);
+        if (!p || p->kind != Kind::Slider) return false;
+        p->value = clamp(v, p->min, p->max);
+        fire(*p);
+        return true;
+    }
+    bool set_multi_choice(std::string_view key, std::vector<int> selection) {
+        auto* p = find_mut(key);
+        if (!p || p->kind != Kind::MultiChoice) return false;
+        normalize_indices(selection, p->options.size());
+        p->value = std::move(selection);
+        fire(*p);
+        return true;
+    }
+    bool set_text(std::string_view key, std::string v) {
+        auto* p = find_mut(key);
+        if (!p || p->kind != Kind::Text) return false;
+        p->value = std::move(v);
+        fire(*p);
+        return true;
+    }
+
+    /// Click a Button property. No-op when the key is missing or the
+    /// kind is not Button.
+    bool click(std::string_view key) {
+        auto* p = find_mut(key);
+        if (!p || p->kind != Kind::Button) return false;
+        if (p->on_click) p->on_click();
+        return true;
+    }
+
+    // ── Simulation aliases (named for headless tests) ───────────────
+
+    bool simulate_toggle(std::string_view key) {
+        auto cur = get_bool(key);
+        if (!cur) return false;
+        return set_bool(key, !*cur);
+    }
+    bool simulate_choose(std::string_view key, int index) {
+        return set_choice(key, index);
+    }
+    bool simulate_slide(std::string_view key, float v) {
+        return set_slider(key, v);
+    }
+    bool simulate_click(std::string_view key) { return click(key); }
+    bool simulate_multi_check(std::string_view key, int index, bool on) {
+        auto cur = get_multi_choice(key);
+        if (!cur) return false;
+        std::vector<int> next = *cur;
+        if (on) {
+            // Insert sorted-unique.
+            if (std::find(next.begin(), next.end(), index) == next.end()) {
+                next.push_back(index);
+            }
+        } else {
+            next.erase(std::remove(next.begin(), next.end(), index), next.end());
+        }
+        return set_multi_choice(key, std::move(next));
+    }
+    bool simulate_set_text(std::string_view key, std::string v) {
+        return set_text(key, std::move(v));
+    }
+
+    // ── Persistence ──────────────────────────────────────────────────
+
+    /// Bind the panel to a `PropertiesFile`. One-shot read populates
+    /// every registered property whose key is present; subsequent
+    /// mutations write back. Pass `nullptr` to detach.
+    void bind_persistence(pulp::state::PropertiesFile* props) {
+        props_ = props;
+        if (!props_) return;
+        for (auto& p : properties_) {
+            load_from_props(p);
+        }
+    }
+    bool has_persistence() const { return props_ != nullptr; }
+
+private:
+    void register_property(Property p) {
+        // Deduplicate by key: re-registering the same key replaces the
+        // old slot in place (callers might rebuild a panel on theme
+        // switch, etc.).
+        for (auto& existing : properties_) {
+            if (existing.key == p.key) {
+                existing = std::move(p);
+                if (props_) load_from_props(existing);
+                return;
+            }
+        }
+        properties_.push_back(std::move(p));
+        if (props_) load_from_props(properties_.back());
+    }
+
+    Property* find_mut(std::string_view key) {
+        for (auto& p : properties_) {
+            if (p.key == key) return &p;
+        }
+        return nullptr;
+    }
+
+    void fire(const Property& p) {
+        if (p.on_change) p.on_change(p.value);
+        persist(p);
+    }
+
+    void persist(const Property& p) const {
+        if (!props_) return;
+        switch (p.kind) {
+            case Kind::BooleanToggle:
+                if (auto* b = std::get_if<bool>(&p.value))
+                    props_->set_bool(p.key, *b);
+                break;
+            case Kind::Choice:
+                if (auto* i = std::get_if<int>(&p.value))
+                    props_->set_int(p.key, *i);
+                break;
+            case Kind::Slider:
+                if (auto* f = std::get_if<float>(&p.value))
+                    props_->set_double(p.key, static_cast<double>(*f));
+                break;
+            case Kind::MultiChoice:
+                if (auto* xs = std::get_if<std::vector<int>>(&p.value))
+                    props_->set_string(p.key, encode_indices(*xs));
+                break;
+            case Kind::Text:
+                if (auto* s = std::get_if<std::string>(&p.value))
+                    props_->set_string(p.key, *s);
+                break;
+            case Kind::Button:
+                break;  // No persisted state.
+        }
+    }
+
+    void load_from_props(Property& p) {
+        if (!props_) return;
+        switch (p.kind) {
+            case Kind::BooleanToggle:
+                if (auto v = props_->get_bool(p.key)) p.value = *v;
+                break;
+            case Kind::Choice:
+                if (auto v = props_->get_int(p.key)) {
+                    int i = static_cast<int>(*v);
+                    if (!p.options.empty()) {
+                        if (i < 0) i = 0;
+                        if (i >= static_cast<int>(p.options.size())) {
+                            i = static_cast<int>(p.options.size()) - 1;
+                        }
+                    } else {
+                        i = 0;
+                    }
+                    p.value = i;
+                }
+                break;
+            case Kind::Slider:
+                if (auto v = props_->get_double(p.key)) {
+                    p.value = clamp(static_cast<float>(*v), p.min, p.max);
+                }
+                break;
+            case Kind::MultiChoice:
+                if (auto v = props_->get_string(p.key)) {
+                    auto xs = decode_indices(*v);
+                    normalize_indices(xs, p.options.size());
+                    p.value = std::move(xs);
+                }
+                break;
+            case Kind::Text:
+                if (auto v = props_->get_string(p.key)) p.value = *v;
+                break;
+            case Kind::Button:
+                break;
+        }
+    }
+
+    static float clamp(float v, float lo, float hi) {
+        if (hi < lo) return v;
+        if (v < lo) return lo;
+        if (v > hi) return hi;
+        return v;
+    }
+    static void normalize_indices(std::vector<int>& xs, std::size_t option_count) {
+        std::unordered_set<int> seen;
+        std::vector<int> out;
+        out.reserve(xs.size());
+        for (int i : xs) {
+            if (option_count > 0
+                && (i < 0 || i >= static_cast<int>(option_count))) continue;
+            if (seen.insert(i).second) out.push_back(i);
+        }
+        std::sort(out.begin(), out.end());
+        xs.swap(out);
+    }
+    static std::string encode_indices(const std::vector<int>& xs) {
+        std::string out;
+        for (std::size_t i = 0; i < xs.size(); ++i) {
+            if (i) out.push_back(',');
+            out += std::to_string(xs[i]);
+        }
+        return out;
+    }
+    static std::vector<int> decode_indices(std::string_view s) {
+        std::vector<int> out;
+        std::size_t i = 0;
+        while (i < s.size()) {
+            std::size_t j = s.find(',', i);
+            if (j == std::string_view::npos) j = s.size();
+            auto tok = s.substr(i, j - i);
+            // Trim whitespace.
+            while (!tok.empty() && (tok.front() == ' ' || tok.front() == '\t'))
+                tok.remove_prefix(1);
+            while (!tok.empty() && (tok.back() == ' ' || tok.back() == '\t'))
+                tok.remove_suffix(1);
+            if (!tok.empty()) {
+                try {
+                    out.push_back(std::stoi(std::string(tok)));
+                } catch (...) {
+                    // Skip malformed entries — defensive against
+                    // hand-edited properties files.
+                }
+            }
+            i = j + 1;
+        }
+        return out;
+    }
+
+    std::vector<Property> properties_;
+    pulp::state::PropertiesFile* props_ = nullptr;
+};
+
+} // namespace pulp::view

--- a/core/view/include/pulp/view/window_classes.hpp
+++ b/core/view/include/pulp/view/window_classes.hpp
@@ -248,6 +248,41 @@ public:
                                               const std::string& message,
                                               ButtonHandler handler = {});
 
+    /// "Warning" alert with a single OK button — sibling of `info` /
+    /// `error` (closes the gap-doc Phase 3 row
+    /// "TooltipWindow + BubbleMessageComponent + AlertWindow styled"
+    /// for the warning variant).
+    static std::unique_ptr<AlertWindow> warning(const std::string& title,
+                                                const std::string& message,
+                                                ButtonHandler handler = {});
+
+    // ── Styled-variant theme tokens ───────────────────────────────────
+
+    /// Theme color-token names the host should look up when painting
+    /// each `AlertIcon`. These names are stable identifiers — themes
+    /// that define them get the styled treatment; themes that do not
+    /// fall back to the default text color. Token names follow the
+    /// `alert.<icon>.<role>` convention.
+    struct StyleTokens {
+        const char* icon_color = "";       ///< Token for the icon glyph color.
+        const char* accent_color = "";     ///< Token for the chrome accent (border / title).
+        const char* glyph = "";            ///< Glyph hint (e.g. "i", "!", "x", "?").
+    };
+
+    /// Returns the style tokens for an icon. The host can use these to
+    /// paint the alert chrome in a theme-driven color without baking
+    /// a specific palette into the alert window itself.
+    ///
+    /// info → "alert.info.icon" + "alert.info.accent" + glyph "i"
+    /// warning → "alert.warning.icon" + "alert.warning.accent" + glyph "!"
+    /// error → "alert.error.icon" + "alert.error.accent" + glyph "x"
+    /// question → "alert.question.icon" + "alert.question.accent" + "?"
+    /// none → empty tokens.
+    static StyleTokens style_tokens_for(AlertIcon icon);
+
+    /// Convenience that returns this alert's styled tokens.
+    StyleTokens style_tokens() const { return style_tokens_for(icon_); }
+
 private:
     std::string title_;
     std::string message_;

--- a/core/view/src/bubble_message.cpp
+++ b/core/view/src/bubble_message.cpp
@@ -1,0 +1,31 @@
+#include <pulp/view/bubble_message.hpp>
+#include <pulp/view/view.hpp>
+
+namespace pulp::view {
+
+void BubbleMessageComponent::recompute_anchor() {
+    if (has_explicit_anchor_) {
+        position_ = compute_offset(explicit_anchor_);
+        return;
+    }
+    if (!source_) return;
+    Rect b = source_->bounds();
+    Point anchor;
+    switch (side_) {
+        case Side::above:
+            anchor = {b.x + b.width * 0.5f, b.y};
+            break;
+        case Side::below:
+            anchor = {b.x + b.width * 0.5f, b.y + b.height};
+            break;
+        case Side::left:
+            anchor = {b.x, b.y + b.height * 0.5f};
+            break;
+        case Side::right:
+            anchor = {b.x + b.width, b.y + b.height * 0.5f};
+            break;
+    }
+    position_ = compute_offset(anchor);
+}
+
+}  // namespace pulp::view

--- a/core/view/src/code_editor.cpp
+++ b/core/view/src/code_editor.cpp
@@ -1,4 +1,5 @@
 #include <pulp/view/code_editor.hpp>
+#include <pulp/view/code_editor_tokenizer.hpp>
 #include <filesystem>
 #include <fstream>
 #include <algorithm>
@@ -48,8 +49,31 @@ void CodeEditor::paint(canvas::Canvas& canvas) {
     auto keyword_color = (config_.theme == "vs-light")
         ? canvas::Color::rgba(0, 0, 200)
         : canvas::Color::rgba(86, 156, 214);
+    auto type_color = (config_.theme == "vs-light")
+        ? canvas::Color::rgba(38, 127, 153)
+        : canvas::Color::rgba(78, 201, 176);
+    auto number_color = (config_.theme == "vs-light")
+        ? canvas::Color::rgba(9, 134, 88)
+        : canvas::Color::rgba(181, 206, 168);
+    auto preprocessor_color = (config_.theme == "vs-light")
+        ? canvas::Color::rgba(175, 0, 219)
+        : canvas::Color::rgba(197, 134, 192);
     auto comment_color = canvas::Color::rgba(106, 153, 85);
     auto string_color = canvas::Color::rgba(206, 145, 120);
+
+    auto color_for = [&](TokenClass cls) {
+        switch (cls) {
+            case TokenClass::keyword:      return keyword_color;
+            case TokenClass::type:         return type_color;
+            case TokenClass::number:       return number_color;
+            case TokenClass::string:       return string_color;
+            case TokenClass::comment:      return comment_color;
+            case TokenClass::preprocessor: return preprocessor_color;
+            case TokenClass::heading:      return keyword_color;
+            case TokenClass::link:         return type_color;
+            default:                       return text_color;
+        }
+    };
 
     float y = line_h;
     int line_num = 1;
@@ -74,20 +98,42 @@ void CodeEditor::paint(canvas::Canvas& canvas) {
             canvas.fill_rect(gutter_w, y - config_.font_size, w - gutter_w, line_h);
         }
 
-        // Basic syntax coloring: detect comments and strings
-        bool is_comment = false;
-        if (line.size() >= 2 && line[0] == '/' && line[1] == '/') is_comment = true;
-        if (line.size() >= 1 && line[0] == '#') is_comment = true;
-
-        if (is_comment) {
-            canvas.set_fill_color(comment_color);
-        } else if (line.find('"') != std::string::npos || line.find('\'') != std::string::npos) {
-            canvas.set_fill_color(string_color);
-        } else {
-            canvas.set_fill_color(text_color);
+        // Per-token painting via the per-language tokenizer. For
+        // `PlainText` we fall back to the historical "first character
+        // sniff" so the existing whole-line color contract holds.
+        std::vector<Token> tokens;
+        if (config_.language != CodeLanguage::PlainText) {
+            tokens = tokenize_line(line, config_.language);
         }
 
-        canvas.fill_text(line, gutter_w + 8.0f, y);
+        if (config_.language == CodeLanguage::PlainText) {
+            bool is_comment = (line.size() >= 2 && line[0] == '/' && line[1] == '/')
+                              || (!line.empty() && line[0] == '#');
+            if (is_comment) {
+                canvas.set_fill_color(comment_color);
+            } else if (line.find('"') != std::string::npos
+                       || line.find('\'') != std::string::npos) {
+                canvas.set_fill_color(string_color);
+            } else {
+                canvas.set_fill_color(text_color);
+            }
+            canvas.fill_text(line, gutter_w + 8.0f, y);
+        } else {
+            // Default paint the entire line as text — token spans paint
+            // over it in their typed color. This preserves the "render
+            // every visible character" contract the older paint had.
+            canvas.set_fill_color(text_color);
+            canvas.fill_text(line, gutter_w + 8.0f, y);
+
+            for (const auto& tok : tokens) {
+                if (tok.length == 0 || tok.cls == TokenClass::text) continue;
+                std::string before = line.substr(0, tok.start);
+                std::string span = line.substr(tok.start, tok.length);
+                float x_off = canvas.measure_text(before);
+                canvas.set_fill_color(color_for(tok.cls));
+                canvas.fill_text(span, gutter_w + 8.0f + x_off, y);
+            }
+        }
 
         y += line_h;
         line_num++;

--- a/core/view/src/code_editor_tokenizer.cpp
+++ b/core/view/src/code_editor_tokenizer.cpp
@@ -1,0 +1,487 @@
+#include <pulp/view/code_editor_tokenizer.hpp>
+
+#include <array>
+#include <cctype>
+#include <string_view>
+
+// Lightweight, allocation-friendly tokenizers used by the
+// CodeEditor's native paint path. Each language tokenizer walks the
+// line character-by-character and emits non-overlapping `Token` spans.
+// Multi-line constructs (block comments, multi-line strings) emit the
+// opener on the first line only — the editor paints each line
+// independently and re-tokenizes on every paint, so spanning state
+// across lines is not worth the complexity in the fallback renderer.
+
+namespace pulp::view {
+
+namespace {
+
+constexpr bool is_id_start(char c) {
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_';
+}
+constexpr bool is_id_cont(char c) {
+    return is_id_start(c) || (c >= '0' && c <= '9');
+}
+constexpr bool is_digit(char c) { return c >= '0' && c <= '9'; }
+constexpr bool is_hex_digit(char c) {
+    return is_digit(c) || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}
+
+// Linear keyword lookup. The lists are small (<60 entries) so a sorted
+// std::lower_bound is not measurably faster than the obvious scan.
+bool contains(std::initializer_list<std::string_view> set,
+              std::string_view word) {
+    for (auto s : set) {
+        if (s == word) return true;
+    }
+    return false;
+}
+
+constexpr std::array<std::string_view, 60> kCppKeywords{
+    "alignas", "alignof", "and", "asm", "auto", "break", "case",
+    "catch", "class", "concept", "const", "consteval", "constexpr",
+    "constinit", "continue", "co_await", "co_return", "co_yield",
+    "decltype", "default", "delete", "do", "else", "enum", "explicit",
+    "export", "extern", "false", "final", "for", "friend", "goto",
+    "if", "inline", "module", "mutable", "namespace", "new", "noexcept",
+    "not", "nullptr", "operator", "or", "private", "protected", "public",
+    "requires", "return", "sizeof", "static", "static_assert", "struct",
+    "switch", "template", "this", "throw", "true", "try", "typedef",
+    "typename"};
+
+constexpr std::array<std::string_view, 18> kCppTypes{
+    "void", "bool", "char", "char8_t", "char16_t", "char32_t",
+    "wchar_t", "short", "int", "long", "signed", "unsigned", "float",
+    "double", "size_t", "ptrdiff_t", "int64_t", "uint64_t"};
+
+constexpr std::array<std::string_view, 38> kJsKeywords{
+    "async", "await", "break", "case", "catch", "class", "const",
+    "continue", "debugger", "default", "delete", "do", "else", "enum",
+    "export", "extends", "false", "finally", "for", "function",
+    "if", "import", "in", "instanceof", "let", "new", "null", "of",
+    "return", "static", "super", "switch", "this", "throw", "true",
+    "try", "typeof", "var"};
+
+constexpr std::array<std::string_view, 8> kJsTypes{
+    "Number", "String", "Boolean", "Object", "Array", "Symbol",
+    "Promise", "BigInt"};
+
+constexpr std::array<std::string_view, 35> kPythonKeywords{
+    "and", "as", "assert", "async", "await", "break", "class",
+    "continue", "def", "del", "elif", "else", "except", "False",
+    "finally", "for", "from", "global", "if", "import", "in", "is",
+    "lambda", "None", "nonlocal", "not", "or", "pass", "raise",
+    "return", "True", "try", "while", "with", "yield"};
+
+constexpr std::array<std::string_view, 22> kLuaKeywords{
+    "and", "break", "do", "else", "elseif", "end", "false", "for",
+    "function", "goto", "if", "in", "local", "nil", "not", "or",
+    "repeat", "return", "then", "true", "until", "while"};
+
+constexpr std::array<std::string_view, 3> kJsonKeywords{
+    "true", "false", "null"};
+
+template <std::size_t N>
+bool in_set(const std::array<std::string_view, N>& set,
+            std::string_view word) {
+    for (const auto& s : set) {
+        if (s == word) return true;
+    }
+    return false;
+}
+
+// Scan a string literal beginning at `start` whose quote character is
+// `line[start]`. Returns the index *after* the closing quote, or
+// `line.size()` if the string runs to the end of the line.
+std::size_t scan_string(std::string_view line, std::size_t start) {
+    char quote = line[start];
+    std::size_t i = start + 1;
+    while (i < line.size()) {
+        if (line[i] == '\\' && i + 1 < line.size()) {
+            i += 2;
+            continue;
+        }
+        if (line[i] == quote) {
+            return i + 1;
+        }
+        ++i;
+    }
+    return line.size();
+}
+
+// Scan a numeric literal beginning at `start`. Handles 0x / 0b prefixes
+// + decimal + simple float exponent. Returns the index past the literal.
+std::size_t scan_number(std::string_view line, std::size_t start) {
+    std::size_t i = start;
+    if (line[i] == '0' && i + 1 < line.size()
+        && (line[i + 1] == 'x' || line[i + 1] == 'X')) {
+        i += 2;
+        while (i < line.size() && (is_hex_digit(line[i]) || line[i] == '_')) ++i;
+        return i;
+    }
+    if (line[i] == '0' && i + 1 < line.size()
+        && (line[i + 1] == 'b' || line[i + 1] == 'B')) {
+        i += 2;
+        while (i < line.size() && (line[i] == '0' || line[i] == '1' || line[i] == '_')) ++i;
+        return i;
+    }
+    while (i < line.size() && (is_digit(line[i]) || line[i] == '_')) ++i;
+    if (i < line.size() && line[i] == '.') {
+        ++i;
+        while (i < line.size() && (is_digit(line[i]) || line[i] == '_')) ++i;
+    }
+    if (i < line.size() && (line[i] == 'e' || line[i] == 'E')) {
+        ++i;
+        if (i < line.size() && (line[i] == '+' || line[i] == '-')) ++i;
+        while (i < line.size() && is_digit(line[i])) ++i;
+    }
+    // Type suffix (f, L, u, ll, etc.) — keep it inside the number span.
+    while (i < line.size()
+           && (line[i] == 'f' || line[i] == 'F' || line[i] == 'l'
+               || line[i] == 'L' || line[i] == 'u' || line[i] == 'U')) {
+        ++i;
+    }
+    return i;
+}
+
+void emit(std::vector<Token>& out, std::size_t start, std::size_t length,
+          TokenClass cls) {
+    if (length == 0) return;
+    out.push_back({start, length, cls});
+}
+
+} // namespace
+
+// ── Public dispatch ───────────────────────────────────────────────────
+
+std::vector<Token> tokenize_line(std::string_view line, CodeLanguage language) {
+    switch (language) {
+        case CodeLanguage::Cpp:        return tokenize_cpp_line(line);
+        case CodeLanguage::JavaScript: return tokenize_javascript_line(line);
+        case CodeLanguage::Python:     return tokenize_python_line(line);
+        case CodeLanguage::JSON:       return tokenize_json_line(line);
+        case CodeLanguage::Lua:        return tokenize_lua_line(line);
+        case CodeLanguage::PlainText:
+        case CodeLanguage::XML:
+        case CodeLanguage::GLSL:
+        case CodeLanguage::Faust:
+        case CodeLanguage::JSFX:
+        default: {
+            std::vector<Token> out;
+            if (!line.empty()) emit(out, 0, line.size(), TokenClass::text);
+            return out;
+        }
+    }
+}
+
+bool is_keyword(std::string_view name, CodeLanguage language) {
+    switch (language) {
+        case CodeLanguage::Cpp:        return in_set(kCppKeywords, name);
+        case CodeLanguage::JavaScript: return in_set(kJsKeywords, name);
+        case CodeLanguage::Python:     return in_set(kPythonKeywords, name);
+        case CodeLanguage::JSON:       return in_set(kJsonKeywords, name);
+        case CodeLanguage::Lua:        return in_set(kLuaKeywords, name);
+        default: return false;
+    }
+}
+
+// ── C++ ───────────────────────────────────────────────────────────────
+
+std::vector<Token> tokenize_cpp_line(std::string_view line) {
+    std::vector<Token> out;
+    std::size_t i = 0;
+
+    // Skip leading whitespace and look for `#` as the first non-blank
+    // character → preprocessor directive line.
+    {
+        std::size_t j = 0;
+        while (j < line.size() && (line[j] == ' ' || line[j] == '\t')) ++j;
+        if (j < line.size() && line[j] == '#') {
+            emit(out, j, line.size() - j, TokenClass::preprocessor);
+            return out;
+        }
+    }
+
+    while (i < line.size()) {
+        char c = line[i];
+
+        // Line comment
+        if (c == '/' && i + 1 < line.size() && line[i + 1] == '/') {
+            emit(out, i, line.size() - i, TokenClass::comment);
+            return out;
+        }
+        // Block comment opener (single-line scope)
+        if (c == '/' && i + 1 < line.size() && line[i + 1] == '*') {
+            std::size_t end = line.find("*/", i + 2);
+            std::size_t len = (end == std::string_view::npos)
+                                  ? line.size() - i
+                                  : end - i + 2;
+            emit(out, i, len, TokenClass::comment);
+            i += len;
+            continue;
+        }
+        // String / char literal
+        if (c == '"' || c == '\'') {
+            std::size_t end = scan_string(line, i);
+            emit(out, i, end - i, TokenClass::string);
+            i = end;
+            continue;
+        }
+        // Number
+        if (is_digit(c)) {
+            std::size_t end = scan_number(line, i);
+            emit(out, i, end - i, TokenClass::number);
+            i = end;
+            continue;
+        }
+        // Identifier / keyword
+        if (is_id_start(c)) {
+            std::size_t end = i + 1;
+            while (end < line.size() && is_id_cont(line[end])) ++end;
+            auto word = line.substr(i, end - i);
+            TokenClass cls = TokenClass::text;
+            if (in_set(kCppKeywords, word))      cls = TokenClass::keyword;
+            else if (in_set(kCppTypes, word))    cls = TokenClass::type;
+            if (cls != TokenClass::text) emit(out, i, end - i, cls);
+            i = end;
+            continue;
+        }
+        ++i;
+    }
+    return out;
+}
+
+// ── JavaScript ────────────────────────────────────────────────────────
+
+std::vector<Token> tokenize_javascript_line(std::string_view line) {
+    std::vector<Token> out;
+    std::size_t i = 0;
+    while (i < line.size()) {
+        char c = line[i];
+        if (c == '/' && i + 1 < line.size() && line[i + 1] == '/') {
+            emit(out, i, line.size() - i, TokenClass::comment);
+            return out;
+        }
+        if (c == '/' && i + 1 < line.size() && line[i + 1] == '*') {
+            std::size_t end = line.find("*/", i + 2);
+            std::size_t len = (end == std::string_view::npos)
+                                  ? line.size() - i
+                                  : end - i + 2;
+            emit(out, i, len, TokenClass::comment);
+            i += len;
+            continue;
+        }
+        if (c == '"' || c == '\'' || c == '`') {
+            std::size_t end = scan_string(line, i);
+            emit(out, i, end - i, TokenClass::string);
+            i = end;
+            continue;
+        }
+        if (is_digit(c)) {
+            std::size_t end = scan_number(line, i);
+            emit(out, i, end - i, TokenClass::number);
+            i = end;
+            continue;
+        }
+        if (is_id_start(c)) {
+            std::size_t end = i + 1;
+            while (end < line.size() && is_id_cont(line[end])) ++end;
+            auto word = line.substr(i, end - i);
+            TokenClass cls = TokenClass::text;
+            if (in_set(kJsKeywords, word))      cls = TokenClass::keyword;
+            else if (in_set(kJsTypes, word))    cls = TokenClass::type;
+            if (cls != TokenClass::text) emit(out, i, end - i, cls);
+            i = end;
+            continue;
+        }
+        ++i;
+    }
+    return out;
+}
+
+// ── Python ────────────────────────────────────────────────────────────
+
+std::vector<Token> tokenize_python_line(std::string_view line) {
+    std::vector<Token> out;
+    std::size_t i = 0;
+    while (i < line.size()) {
+        char c = line[i];
+        if (c == '#') {
+            emit(out, i, line.size() - i, TokenClass::comment);
+            return out;
+        }
+        // Triple-quoted strings — emit the visible portion of the
+        // opener as a string span; the editor re-tokenizes per line so
+        // we cannot reasonably span the next lines from here.
+        if ((c == '"' || c == '\'') && i + 2 < line.size()
+            && line[i + 1] == c && line[i + 2] == c) {
+            std::size_t end = line.find(std::string_view(&c, 1).data(), i + 3);
+            // Simpler: search for the triple-quote terminator on the
+            // same line; if it is not there, paint to end-of-line.
+            std::string_view tq(&line[i], 3);
+            std::size_t close = line.find(tq, i + 3);
+            std::size_t len = (close == std::string_view::npos)
+                                  ? line.size() - i
+                                  : close - i + 3;
+            emit(out, i, len, TokenClass::string);
+            i += len;
+            continue;
+        }
+        if (c == '"' || c == '\'') {
+            std::size_t end = scan_string(line, i);
+            emit(out, i, end - i, TokenClass::string);
+            i = end;
+            continue;
+        }
+        if (is_digit(c)) {
+            std::size_t end = scan_number(line, i);
+            emit(out, i, end - i, TokenClass::number);
+            i = end;
+            continue;
+        }
+        if (is_id_start(c)) {
+            std::size_t end = i + 1;
+            while (end < line.size() && is_id_cont(line[end])) ++end;
+            auto word = line.substr(i, end - i);
+            if (in_set(kPythonKeywords, word)) {
+                emit(out, i, end - i, TokenClass::keyword);
+            }
+            i = end;
+            continue;
+        }
+        ++i;
+    }
+    return out;
+}
+
+// ── JSON ──────────────────────────────────────────────────────────────
+
+std::vector<Token> tokenize_json_line(std::string_view line) {
+    std::vector<Token> out;
+    std::size_t i = 0;
+    while (i < line.size()) {
+        char c = line[i];
+        if (c == '"') {
+            std::size_t end = scan_string(line, i);
+            emit(out, i, end - i, TokenClass::string);
+            i = end;
+            continue;
+        }
+        if (is_digit(c) || (c == '-' && i + 1 < line.size()
+                            && is_digit(line[i + 1]))) {
+            std::size_t start = i;
+            if (c == '-') ++i;
+            std::size_t end = scan_number(line, i);
+            emit(out, start, end - start, TokenClass::number);
+            i = end;
+            continue;
+        }
+        if (is_id_start(c)) {
+            std::size_t end = i + 1;
+            while (end < line.size() && is_id_cont(line[end])) ++end;
+            auto word = line.substr(i, end - i);
+            if (in_set(kJsonKeywords, word)) {
+                emit(out, i, end - i, TokenClass::keyword);
+            }
+            i = end;
+            continue;
+        }
+        ++i;
+    }
+    return out;
+}
+
+// ── Lua ───────────────────────────────────────────────────────────────
+
+std::vector<Token> tokenize_lua_line(std::string_view line) {
+    std::vector<Token> out;
+    std::size_t i = 0;
+    while (i < line.size()) {
+        char c = line[i];
+        if (c == '-' && i + 1 < line.size() && line[i + 1] == '-') {
+            emit(out, i, line.size() - i, TokenClass::comment);
+            return out;
+        }
+        if (c == '"' || c == '\'') {
+            std::size_t end = scan_string(line, i);
+            emit(out, i, end - i, TokenClass::string);
+            i = end;
+            continue;
+        }
+        if (is_digit(c)) {
+            std::size_t end = scan_number(line, i);
+            emit(out, i, end - i, TokenClass::number);
+            i = end;
+            continue;
+        }
+        if (is_id_start(c)) {
+            std::size_t end = i + 1;
+            while (end < line.size() && is_id_cont(line[end])) ++end;
+            auto word = line.substr(i, end - i);
+            if (in_set(kLuaKeywords, word)) {
+                emit(out, i, end - i, TokenClass::keyword);
+            }
+            i = end;
+            continue;
+        }
+        ++i;
+    }
+    return out;
+}
+
+// ── Markdown ──────────────────────────────────────────────────────────
+
+std::vector<Token> tokenize_markdown_line(std::string_view line) {
+    std::vector<Token> out;
+    if (line.empty()) return out;
+
+    // Heading: 1–6 `#` followed by space.
+    std::size_t lead = 0;
+    while (lead < line.size() && (line[lead] == ' ' || line[lead] == '\t')) ++lead;
+    if (lead < line.size() && line[lead] == '#') {
+        std::size_t hashes = lead;
+        while (hashes < line.size() && line[hashes] == '#'
+               && hashes - lead < 6) {
+            ++hashes;
+        }
+        if (hashes > lead && hashes < line.size() && line[hashes] == ' ') {
+            emit(out, lead, line.size() - lead, TokenClass::heading);
+            return out;
+        }
+    }
+
+    // Inline code, links, and emphasis runs.
+    std::size_t i = 0;
+    while (i < line.size()) {
+        char c = line[i];
+        // Backtick code span
+        if (c == '`') {
+            std::size_t end = line.find('`', i + 1);
+            std::size_t len = (end == std::string_view::npos)
+                                  ? line.size() - i
+                                  : end - i + 1;
+            emit(out, i, len, TokenClass::string);
+            i += len;
+            continue;
+        }
+        // Link: [text](url) — emit the whole thing as `link`.
+        if (c == '[') {
+            std::size_t bracket = line.find(']', i + 1);
+            if (bracket != std::string_view::npos
+                && bracket + 1 < line.size()
+                && line[bracket + 1] == '(') {
+                std::size_t paren = line.find(')', bracket + 2);
+                std::size_t end = (paren == std::string_view::npos)
+                                      ? line.size()
+                                      : paren + 1;
+                emit(out, i, end - i, TokenClass::link);
+                i = end;
+                continue;
+            }
+        }
+        ++i;
+    }
+    return out;
+}
+
+} // namespace pulp::view

--- a/core/view/src/window_classes.cpp
+++ b/core/view/src/window_classes.cpp
@@ -186,4 +186,40 @@ std::unique_ptr<AlertWindow> AlertWindow::error(const std::string& title,
     return a;
 }
 
+std::unique_ptr<AlertWindow> AlertWindow::warning(const std::string& title,
+                                                   const std::string& message,
+                                                   ButtonHandler handler) {
+    auto a = std::make_unique<AlertWindow>(title, message, AlertIcon::warning);
+    a->add_button("OK");
+    if (handler) a->set_button_handler(std::move(handler));
+    return a;
+}
+
+AlertWindow::StyleTokens AlertWindow::style_tokens_for(AlertIcon icon) {
+    // Stable identifier names so hosts + themes can agree on a vocab.
+    // `glyph` is an ASCII hint the host can fall back on when an icon
+    // asset is not available.
+    switch (icon) {
+        case AlertIcon::info:
+            return {"alert.info.icon",
+                    "alert.info.accent",
+                    "i"};
+        case AlertIcon::warning:
+            return {"alert.warning.icon",
+                    "alert.warning.accent",
+                    "!"};
+        case AlertIcon::error:
+            return {"alert.error.icon",
+                    "alert.error.accent",
+                    "x"};
+        case AlertIcon::question:
+            return {"alert.question.icon",
+                    "alert.question.accent",
+                    "?"};
+        case AlertIcon::none:
+        default:
+            return {"", "", ""};
+    }
+}
+
 } // namespace pulp::view

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2846,6 +2846,13 @@ pulp_add_test_suite(pulp-test-tooltip-window LIBRARIES pulp::view)
 # PreferencesPanel — sidebar-of-pages container (gap-doc P3)
 pulp_add_test_suite(pulp-test-preferences-panel LIBRARIES pulp::view)
 
+# PropertyPanel — typed property editor sister widget (gap-doc Phase 4
+# row "PreferencesPanel + PropertyPanel"). Header-only, links state
+# for PropertiesFile persistence.
+pulp_add_test_suite(pulp-test-property-panel
+    SOURCES test_property_panel.cpp
+    LIBRARIES pulp::view pulp::state)
+
 # UI components tests (ComboBox, TabPanel, ListBox, ScrollView, Tooltip, ProgressBar, CallOutBox)
 pulp_add_test_suite(pulp-test-ui-components LIBRARIES pulp::view)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1437,6 +1437,10 @@ pulp_add_test_suite(pulp-test-table-list-box LIBRARIES pulp::view)
 # CodeEditor / FileBasedDocument / RecentlyOpenedFilesList tests
 pulp_add_test_suite(pulp-test-code-editor LIBRARIES pulp::view)
 
+# CodeEditor per-language tokenizer (gap-doc Phase 4 row "CodeEditor
+# language coverage")
+pulp_add_test_suite(pulp-test-code-editor-tokenizer LIBRARIES pulp::view)
+
 # PropertiesFile JSON persistence tests
 pulp_add_test_suite(pulp-test-properties SOURCES test_properties_file.cpp LIBRARIES pulp::state pulp::runtime)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2843,6 +2843,10 @@ pulp_add_test_suite(pulp-test-component-dragger LIBRARIES pulp::view)
 # TooltipWindow — transient floating tooltip near cursor (gap-doc P2)
 pulp_add_test_suite(pulp-test-tooltip-window LIBRARIES pulp::view)
 
+# BubbleMessageComponent — floating message bubble anchored to a source
+# view with auto-dismiss (gap-doc Phase 3 sister of TooltipWindow)
+pulp_add_test_suite(pulp-test-bubble-message LIBRARIES pulp::view)
+
 # PreferencesPanel — sidebar-of-pages container (gap-doc P3)
 pulp_add_test_suite(pulp-test-preferences-panel LIBRARIES pulp::view)
 

--- a/test/test_bubble_message.cpp
+++ b/test/test_bubble_message.cpp
@@ -1,0 +1,159 @@
+// BubbleMessageComponent tests
+// (closes the gap-doc Phase 3 row
+//  "TooltipWindow + BubbleMessageComponent + AlertWindow styled" for
+//  the BubbleMessage half).
+//
+// Validates:
+//   - show_for puts the bubble in `showing` immediately + sets text +
+//     starts the fade-in,
+//   - tick(dt) auto-dismisses after `lifetime()`,
+//   - hide() fades out without auto-dismissing,
+//   - move_to overrides the source-anchored position,
+//   - recompute_anchor projects the source view's bounds per `Side`,
+//   - the bubble forgets its source when it returns to idle (transient
+//     lifetime — safe against the source view being deleted afterwards).
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <memory>
+#include <pulp/view/bubble_message.hpp>
+#include <pulp/view/view.hpp>
+
+using namespace pulp::view;
+
+namespace {
+class TestView : public View {};
+}  // namespace
+
+TEST_CASE("BubbleMessageComponent: defaults are idle + invisible",
+          "[bubble-message]") {
+    BubbleMessageComponent b;
+    REQUIRE_FALSE(b.visible());
+    REQUIRE(b.phase() == BubbleMessageComponent::Phase::idle);
+    REQUIRE(b.opacity() == 0.0f);
+    REQUIRE(b.text().empty());
+    REQUIRE(b.source_view() == nullptr);
+    REQUIRE(b.lifetime() == 3.0f);  // default
+}
+
+TEST_CASE("BubbleMessageComponent: show_for goes immediately to showing",
+          "[bubble-message]") {
+    TestView v;
+    v.set_bounds({100, 100, 80, 24});
+    BubbleMessageComponent b;
+    b.show_for(&v, "saved", 1.0f);
+
+    REQUIRE(b.visible());
+    REQUIRE(b.phase() == BubbleMessageComponent::Phase::showing);
+    REQUIRE(b.text() == "saved");
+    REQUIRE(b.source_view() == &v);
+    REQUIRE(b.lifetime() == 1.0f);
+
+    // Initial position derives from the source bounds + default
+    // side (above) + default offset (0, -8).
+    auto pos = b.position();
+    REQUIRE(pos.x == 140.0f);  // bounds center x
+    REQUIRE(pos.y == 92.0f);   // bounds.y - 8
+}
+
+TEST_CASE("BubbleMessageComponent: lifetime auto-dismisses + fades to idle",
+          "[bubble-message]") {
+    TestView v;
+    BubbleMessageComponent b;
+    b.set_fade_duration(0.05f);
+    b.show_for(&v, "ack", 0.5f);
+    REQUIRE(b.visible());
+
+    // Tick under lifetime — still showing.
+    REQUIRE(b.tick(0.3f));
+    REQUIRE(b.phase() == BubbleMessageComponent::Phase::showing);
+
+    // Tick past lifetime — flips into hiding.
+    REQUIRE(b.tick(0.3f));
+    REQUIRE(b.phase() == BubbleMessageComponent::Phase::hiding);
+
+    // Drain the fade — settles into idle.
+    while (b.tick(0.05f)) { /* keep ticking */ }
+    REQUIRE_FALSE(b.visible());
+    REQUIRE(b.phase() == BubbleMessageComponent::Phase::idle);
+    REQUIRE(b.source_view() == nullptr);  // transient: source forgotten
+}
+
+TEST_CASE("BubbleMessageComponent: hide() fades out without auto-dismiss",
+          "[bubble-message]") {
+    TestView v;
+    BubbleMessageComponent b;
+    b.set_fade_duration(0.05f);
+    b.show_for(&v, "msg", 0.0f);  // 0 lifetime → no auto-dismiss
+
+    REQUIRE(b.tick(0.5f));  // sits in `showing` since lifetime is off
+    REQUIRE(b.phase() == BubbleMessageComponent::Phase::showing);
+
+    b.hide();
+    REQUIRE(b.phase() == BubbleMessageComponent::Phase::hiding);
+    while (b.tick(0.05f)) { /* drain */ }
+    REQUIRE(b.phase() == BubbleMessageComponent::Phase::idle);
+}
+
+TEST_CASE("BubbleMessageComponent: move_to overrides source-derived anchor",
+          "[bubble-message]") {
+    TestView v;
+    v.set_bounds({0, 0, 50, 50});
+    BubbleMessageComponent b;
+    b.show_for(&v, "msg");
+    b.move_to({500, 200});
+    REQUIRE(b.position().x == 500.0f);
+    REQUIRE(b.position().y == 192.0f);  // +offset (0, -8)
+
+    // recompute_anchor honors the explicit anchor.
+    b.recompute_anchor();
+    REQUIRE(b.position().x == 500.0f);
+    REQUIRE(b.position().y == 192.0f);
+}
+
+TEST_CASE("BubbleMessageComponent: side enum projects through bounds",
+          "[bubble-message]") {
+    TestView v;
+    v.set_bounds({100, 200, 40, 20});
+    BubbleMessageComponent b;
+    b.set_offset({0, 0});
+
+    b.set_side(BubbleMessageComponent::Side::above);
+    b.show_for(&v, "x");
+    REQUIRE(b.position().x == 120.0f);
+    REQUIRE(b.position().y == 200.0f);
+
+    b.set_side(BubbleMessageComponent::Side::below);
+    b.recompute_anchor();
+    REQUIRE(b.position().y == 220.0f);
+
+    b.set_side(BubbleMessageComponent::Side::left);
+    b.recompute_anchor();
+    REQUIRE(b.position().x == 100.0f);
+    REQUIRE(b.position().y == 210.0f);
+
+    b.set_side(BubbleMessageComponent::Side::right);
+    b.recompute_anchor();
+    REQUIRE(b.position().x == 140.0f);
+}
+
+TEST_CASE("BubbleMessageComponent: show_for while visible swaps text + resets",
+          "[bubble-message]") {
+    TestView v;
+    BubbleMessageComponent b;
+    b.show_for(&v, "first", 5.0f);
+    REQUIRE(b.tick(2.0f));
+    REQUIRE(b.elapsed() == 2.0f);
+
+    b.show_for(&v, "second", 1.0f);
+    REQUIRE(b.text() == "second");
+    REQUIRE(b.lifetime() == 1.0f);
+    REQUIRE(b.elapsed() == 0.0f);
+}
+
+TEST_CASE("BubbleMessageComponent: tick on idle is a no-op",
+          "[bubble-message]") {
+    BubbleMessageComponent b;
+    REQUIRE_FALSE(b.tick(1.0f));
+    REQUIRE(b.phase() == BubbleMessageComponent::Phase::idle);
+}

--- a/test/test_code_editor_tokenizer.cpp
+++ b/test/test_code_editor_tokenizer.cpp
@@ -1,0 +1,254 @@
+// CodeEditor language-tokenizer tests
+// (closes the gap-doc Phase 4 row "CodeEditor language coverage").
+//
+// Validates the per-language regex-lite tokenizers used by the
+// CodeEditor's native paint path:
+//   - C++ keywords + types + numbers + strings + comments + preprocessor,
+//   - JavaScript keywords + types + template strings + comments,
+//   - Python keywords + comments + triple-quoted strings,
+//   - JSON literals + numbers + strings,
+//   - Lua keywords + comments,
+//   - Markdown headings + inline code + links,
+//   - dispatch fallback for `PlainText` and other languages without
+//     tokenizers returns a single `text` span.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <pulp/view/code_editor.hpp>
+#include <pulp/view/code_editor_tokenizer.hpp>
+
+using namespace pulp::view;
+
+namespace {
+
+bool has_token(const std::vector<Token>& tokens,
+               std::string_view line,
+               std::string_view span,
+               TokenClass cls) {
+    return std::any_of(tokens.begin(), tokens.end(), [&](const Token& t) {
+        return t.cls == cls
+            && t.start + t.length <= line.size()
+            && line.substr(t.start, t.length) == span;
+    });
+}
+
+const Token* find_at(const std::vector<Token>& tokens, std::size_t start) {
+    for (const auto& t : tokens) {
+        if (t.start == start) return &t;
+    }
+    return nullptr;
+}
+
+} // namespace
+
+// ── Dispatch ─────────────────────────────────────────────────────────
+
+TEST_CASE("tokenize_line: PlainText returns a single text span",
+          "[code-editor][tokenizer]") {
+    auto toks = tokenize_line("hello world", CodeLanguage::PlainText);
+    REQUIRE(toks.size() == 1);
+    REQUIRE(toks[0].cls == TokenClass::text);
+    REQUIRE(toks[0].start == 0);
+    REQUIRE(toks[0].length == 11);
+}
+
+TEST_CASE("tokenize_line: empty line yields no tokens",
+          "[code-editor][tokenizer]") {
+    auto cpp = tokenize_line("", CodeLanguage::Cpp);
+    REQUIRE(cpp.empty());
+    auto plain = tokenize_line("", CodeLanguage::PlainText);
+    REQUIRE(plain.empty());
+}
+
+TEST_CASE("tokenize_line: unsupported languages fall back to text",
+          "[code-editor][tokenizer]") {
+    auto xml = tokenize_line("<tag>", CodeLanguage::XML);
+    REQUIRE(xml.size() == 1);
+    REQUIRE(xml[0].cls == TokenClass::text);
+
+    auto faust = tokenize_line("process = _;", CodeLanguage::Faust);
+    REQUIRE(faust.size() == 1);
+    REQUIRE(faust[0].cls == TokenClass::text);
+
+    auto jsfx = tokenize_line("@sample", CodeLanguage::JSFX);
+    REQUIRE(jsfx.size() == 1);
+    REQUIRE(jsfx[0].cls == TokenClass::text);
+
+    auto glsl = tokenize_line("void main() {}", CodeLanguage::GLSL);
+    REQUIRE(glsl.size() == 1);
+    REQUIRE(glsl[0].cls == TokenClass::text);
+}
+
+// ── C++ ──────────────────────────────────────────────────────────────
+
+TEST_CASE("tokenize_cpp_line: keywords + types + numbers + comments",
+          "[code-editor][tokenizer][cpp]") {
+    std::string_view line = "int main() { return 0; } // entry";
+    auto toks = tokenize_cpp_line(line);
+
+    REQUIRE(has_token(toks, line, "int", TokenClass::type));
+    REQUIRE(has_token(toks, line, "return", TokenClass::keyword));
+    REQUIRE(has_token(toks, line, "0", TokenClass::number));
+    REQUIRE(has_token(toks, line, "// entry", TokenClass::comment));
+    REQUIRE_FALSE(has_token(toks, line, "main", TokenClass::keyword));
+}
+
+TEST_CASE("tokenize_cpp_line: string literals and escape sequences",
+          "[code-editor][tokenizer][cpp]") {
+    std::string_view line = R"(const char* s = "hello \"world\"";)";
+    auto toks = tokenize_cpp_line(line);
+
+    REQUIRE(has_token(toks, line, "const", TokenClass::keyword));
+    REQUIRE(has_token(toks, line, "char", TokenClass::type));
+    REQUIRE(has_token(toks, line, R"("hello \"world\"")", TokenClass::string));
+}
+
+TEST_CASE("tokenize_cpp_line: preprocessor directives are a whole-line span",
+          "[code-editor][tokenizer][cpp]") {
+    std::string_view line = "#include <vector>";
+    auto toks = tokenize_cpp_line(line);
+    REQUIRE(toks.size() == 1);
+    REQUIRE(toks[0].cls == TokenClass::preprocessor);
+    REQUIRE(toks[0].start == 0);
+    REQUIRE(toks[0].length == line.size());
+}
+
+TEST_CASE("tokenize_cpp_line: block comment and hex numbers",
+          "[code-editor][tokenizer][cpp]") {
+    std::string_view line = "auto x = 0xFF; /* hex */";
+    auto toks = tokenize_cpp_line(line);
+    REQUIRE(has_token(toks, line, "auto", TokenClass::keyword));
+    REQUIRE(has_token(toks, line, "0xFF", TokenClass::number));
+    REQUIRE(has_token(toks, line, "/* hex */", TokenClass::comment));
+}
+
+TEST_CASE("tokenize_cpp_line: unterminated block comment paints to end",
+          "[code-editor][tokenizer][cpp]") {
+    std::string_view line = "/* open";
+    auto toks = tokenize_cpp_line(line);
+    REQUIRE(toks.size() == 1);
+    REQUIRE(toks[0].cls == TokenClass::comment);
+    REQUIRE(toks[0].length == line.size());
+}
+
+// ── JavaScript ───────────────────────────────────────────────────────
+
+TEST_CASE("tokenize_javascript_line: keywords + template strings",
+          "[code-editor][tokenizer][js]") {
+    std::string_view line = "const x = `hello ${name}`;";
+    auto toks = tokenize_javascript_line(line);
+    REQUIRE(has_token(toks, line, "const", TokenClass::keyword));
+    REQUIRE(has_token(toks, line, "`hello ${name}`", TokenClass::string));
+}
+
+TEST_CASE("tokenize_javascript_line: types and arrow function",
+          "[code-editor][tokenizer][js]") {
+    std::string_view line = "let p = new Promise((r) => r());";
+    auto toks = tokenize_javascript_line(line);
+    REQUIRE(has_token(toks, line, "let", TokenClass::keyword));
+    REQUIRE(has_token(toks, line, "new", TokenClass::keyword));
+    REQUIRE(has_token(toks, line, "Promise", TokenClass::type));
+}
+
+// ── Python ───────────────────────────────────────────────────────────
+
+TEST_CASE("tokenize_python_line: def + keywords + hash comment",
+          "[code-editor][tokenizer][python]") {
+    std::string_view line = "def fn(x): return x + 1  # add one";
+    auto toks = tokenize_python_line(line);
+    REQUIRE(has_token(toks, line, "def", TokenClass::keyword));
+    REQUIRE(has_token(toks, line, "return", TokenClass::keyword));
+    REQUIRE(has_token(toks, line, "1", TokenClass::number));
+    REQUIRE(has_token(toks, line, "# add one", TokenClass::comment));
+}
+
+TEST_CASE("tokenize_python_line: triple-quoted string on one line",
+          "[code-editor][tokenizer][python]") {
+    std::string_view line = R"(s = """doc""")";
+    auto toks = tokenize_python_line(line);
+    REQUIRE(has_token(toks, line, R"("""doc""")", TokenClass::string));
+}
+
+TEST_CASE("tokenize_python_line: unterminated triple-quoted string spans to EOL",
+          "[code-editor][tokenizer][python]") {
+    std::string_view line = R"(s = """open)";
+    auto toks = tokenize_python_line(line);
+    auto* t = find_at(toks, 4);
+    REQUIRE(t != nullptr);
+    REQUIRE(t->cls == TokenClass::string);
+    REQUIRE(t->length == line.size() - 4);
+}
+
+// ── JSON ─────────────────────────────────────────────────────────────
+
+TEST_CASE("tokenize_json_line: string keys + literals + numbers",
+          "[code-editor][tokenizer][json]") {
+    std::string_view line = R"({ "ok": true, "n": -3.14, "v": null })";
+    auto toks = tokenize_json_line(line);
+    REQUIRE(has_token(toks, line, "\"ok\"", TokenClass::string));
+    REQUIRE(has_token(toks, line, "true", TokenClass::keyword));
+    REQUIRE(has_token(toks, line, "-3.14", TokenClass::number));
+    REQUIRE(has_token(toks, line, "null", TokenClass::keyword));
+}
+
+// ── Lua ──────────────────────────────────────────────────────────────
+
+TEST_CASE("tokenize_lua_line: function + double-dash comment",
+          "[code-editor][tokenizer][lua]") {
+    std::string_view line = "local function f() return 42 end -- done";
+    auto toks = tokenize_lua_line(line);
+    REQUIRE(has_token(toks, line, "local", TokenClass::keyword));
+    REQUIRE(has_token(toks, line, "function", TokenClass::keyword));
+    REQUIRE(has_token(toks, line, "return", TokenClass::keyword));
+    REQUIRE(has_token(toks, line, "end", TokenClass::keyword));
+    REQUIRE(has_token(toks, line, "42", TokenClass::number));
+    REQUIRE(has_token(toks, line, "-- done", TokenClass::comment));
+}
+
+// ── Markdown ─────────────────────────────────────────────────────────
+
+TEST_CASE("tokenize_markdown_line: heading line emits one heading span",
+          "[code-editor][tokenizer][markdown]") {
+    std::string_view line = "## Section title";
+    auto toks = tokenize_markdown_line(line);
+    REQUIRE(toks.size() == 1);
+    REQUIRE(toks[0].cls == TokenClass::heading);
+    REQUIRE(toks[0].length == line.size());
+}
+
+TEST_CASE("tokenize_markdown_line: inline code and link",
+          "[code-editor][tokenizer][markdown]") {
+    std::string_view line = "see `Widget` in [docs](http://x)";
+    auto toks = tokenize_markdown_line(line);
+    REQUIRE(has_token(toks, line, "`Widget`", TokenClass::string));
+    REQUIRE(has_token(toks, line, "[docs](http://x)", TokenClass::link));
+}
+
+TEST_CASE("tokenize_markdown_line: too many leading hashes is not a heading",
+          "[code-editor][tokenizer][markdown]") {
+    std::string_view line = "####### not a heading";
+    auto toks = tokenize_markdown_line(line);
+    // 7 hashes — Markdown caps at 6, so this should NOT be a heading.
+    bool any_heading = std::any_of(toks.begin(), toks.end(),
+        [](const Token& t) { return t.cls == TokenClass::heading; });
+    REQUIRE_FALSE(any_heading);
+}
+
+// ── is_keyword ───────────────────────────────────────────────────────
+
+TEST_CASE("is_keyword classifies per-language sets correctly",
+          "[code-editor][tokenizer][keyword-set]") {
+    REQUIRE(is_keyword("return", CodeLanguage::Cpp));
+    REQUIRE(is_keyword("class",  CodeLanguage::Cpp));
+    REQUIRE_FALSE(is_keyword("Promise", CodeLanguage::Cpp));
+
+    REQUIRE(is_keyword("function", CodeLanguage::JavaScript));
+    REQUIRE_FALSE(is_keyword("function", CodeLanguage::Cpp));
+
+    REQUIRE(is_keyword("def",   CodeLanguage::Python));
+    REQUIRE(is_keyword("true",  CodeLanguage::JSON));
+    REQUIRE(is_keyword("end",   CodeLanguage::Lua));
+    REQUIRE_FALSE(is_keyword("notakeyword", CodeLanguage::Lua));
+    REQUIRE_FALSE(is_keyword("if", CodeLanguage::PlainText));
+}

--- a/test/test_property_panel.cpp
+++ b/test/test_property_panel.cpp
@@ -1,0 +1,271 @@
+// PropertyPanel typed-variant tests
+// (closes the gap-doc Phase 4 row "PreferencesPanel + PropertyPanel"
+//  for the PropertyPanel half).
+//
+// Validates:
+//   - the six typed variants (Boolean, Choice, Slider, Button,
+//     MultiChoice, Text) register + round-trip values,
+//   - simulate_* helpers fire the same path a real UI event would,
+//   - bounds + clamping for slider + choice + multi-choice,
+//   - PropertiesFile persistence round-trips every variant under each
+//     property's key,
+//   - bind_persistence with an existing store seeds the panel from
+//     stored values,
+//   - re-registering a key replaces the old entry in place.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+#include <pulp/state/properties_file.hpp>
+#include <pulp/view/property_panel.hpp>
+
+using namespace pulp::view;
+
+namespace {
+
+std::filesystem::path scratch_props_file(const std::string& tag) {
+    auto dir = std::filesystem::temp_directory_path() / "pulp-property-panel-tests";
+    std::filesystem::create_directories(dir);
+    auto path = dir / (tag + ".json");
+    std::filesystem::remove(path);
+    return path;
+}
+
+} // namespace
+
+// ── Variant builders + reads ─────────────────────────────────────────
+
+TEST_CASE("PropertyPanel: defaults are empty", "[property-panel]") {
+    PropertyPanel p;
+    REQUIRE(p.empty());
+    REQUIRE(p.size() == 0);
+    REQUIRE_FALSE(p.has_persistence());
+    REQUIRE(p.find("missing") == nullptr);
+}
+
+TEST_CASE("PropertyPanel: add_boolean stores value + fires observer",
+          "[property-panel][boolean]") {
+    PropertyPanel p;
+    bool last = false;
+    int calls = 0;
+    p.add_boolean("audio.mono", "Force Mono", true,
+                  [&](bool v) { last = v; ++calls; });
+
+    REQUIRE(p.size() == 1);
+    REQUIRE(p.get_bool("audio.mono").value_or(false));
+
+    REQUIRE(p.set_bool("audio.mono", false));
+    REQUIRE_FALSE(p.get_bool("audio.mono").value_or(true));
+    REQUIRE(calls == 1);
+    REQUIRE_FALSE(last);
+
+    REQUIRE(p.simulate_toggle("audio.mono"));
+    REQUIRE(p.get_bool("audio.mono").value_or(false));
+    REQUIRE(calls == 2);
+    REQUIRE(last);
+}
+
+TEST_CASE("PropertyPanel: add_choice clamps index + fires observer",
+          "[property-panel][choice]") {
+    PropertyPanel p;
+    int last = -1;
+    p.add_choice("audio.driver", "Driver",
+                 {"CoreAudio", "JACK", "PortAudio"}, 10,
+                 [&](int i) { last = i; });
+
+    // Initial clamped down to 2 (3 options, index 0..2).
+    REQUIRE(p.get_choice("audio.driver") == 2);
+
+    REQUIRE(p.simulate_choose("audio.driver", 1));
+    REQUIRE(p.get_choice("audio.driver") == 1);
+    REQUIRE(last == 1);
+
+    REQUIRE(p.simulate_choose("audio.driver", -5));
+    REQUIRE(p.get_choice("audio.driver") == 0);
+    REQUIRE(last == 0);
+}
+
+TEST_CASE("PropertyPanel: add_slider clamps to min/max",
+          "[property-panel][slider]") {
+    PropertyPanel p;
+    float last = 0.0f;
+    p.add_slider("audio.gain", "Input gain", -60.0f, 12.0f, 100.0f,
+                 [&](float v) { last = v; });
+
+    REQUIRE(p.get_slider("audio.gain") == 12.0f);  // clamped initial
+
+    REQUIRE(p.simulate_slide("audio.gain", -200.0f));
+    REQUIRE(p.get_slider("audio.gain") == -60.0f);
+    REQUIRE(last == -60.0f);
+
+    REQUIRE(p.simulate_slide("audio.gain", 0.0f));
+    REQUIRE(p.get_slider("audio.gain") == 0.0f);
+}
+
+TEST_CASE("PropertyPanel: add_button fires click handler",
+          "[property-panel][button]") {
+    PropertyPanel p;
+    int clicks = 0;
+    p.add_button("audio.reset", "Reset", [&] { ++clicks; });
+
+    REQUIRE(p.size() == 1);
+    REQUIRE(p.simulate_click("audio.reset"));
+    REQUIRE(p.simulate_click("audio.reset"));
+    REQUIRE(clicks == 2);
+
+    // Wrong kind / missing key — no-op + false.
+    REQUIRE_FALSE(p.simulate_click("does.not.exist"));
+}
+
+TEST_CASE("PropertyPanel: multi_choice normalizes selection + observer",
+          "[property-panel][multi-choice]") {
+    PropertyPanel p;
+    std::vector<int> last;
+    p.add_multi_choice("ports.in", "Input ports",
+                       {"L", "R", "FX1", "FX2"}, {3, 0, 0, 5},
+                       [&](const std::vector<int>& xs) { last = xs; });
+
+    // Dedup + clamp: 5 is out of range, double 0 collapses → {0, 3}.
+    auto initial = p.get_multi_choice("ports.in").value();
+    REQUIRE(initial == std::vector<int>{0, 3});
+
+    REQUIRE(p.simulate_multi_check("ports.in", 2, true));
+    REQUIRE(p.get_multi_choice("ports.in") == std::vector<int>{0, 2, 3});
+    REQUIRE(last == std::vector<int>{0, 2, 3});
+
+    REQUIRE(p.simulate_multi_check("ports.in", 0, false));
+    REQUIRE(p.get_multi_choice("ports.in") == std::vector<int>{2, 3});
+
+    // Out-of-range simulate_multi_check still normalizes.
+    REQUIRE(p.simulate_multi_check("ports.in", 99, true));
+    REQUIRE(p.get_multi_choice("ports.in") == std::vector<int>{2, 3});
+}
+
+TEST_CASE("PropertyPanel: text variant", "[property-panel][text]") {
+    PropertyPanel p;
+    std::string last;
+    p.add_text("user.name", "Name", "Anonymous",
+               [&](const std::string& v) { last = v; });
+
+    REQUIRE(p.get_text("user.name") == "Anonymous");
+    REQUIRE(p.simulate_set_text("user.name", "Alice"));
+    REQUIRE(p.get_text("user.name") == "Alice");
+    REQUIRE(last == "Alice");
+}
+
+TEST_CASE("PropertyPanel: typed setters reject mismatched kinds",
+          "[property-panel][type-safety]") {
+    PropertyPanel p;
+    p.add_text("a", "A", "x");
+    REQUIRE_FALSE(p.set_bool("a", true));
+    REQUIRE_FALSE(p.set_choice("a", 0));
+    REQUIRE_FALSE(p.set_slider("a", 0.5f));
+    REQUIRE_FALSE(p.set_multi_choice("a", {0}));
+    REQUIRE_FALSE(p.click("a"));
+    REQUIRE(p.get_text("a") == "x");  // value untouched
+}
+
+TEST_CASE("PropertyPanel: re-registering a key replaces the slot in place",
+          "[property-panel][registry]") {
+    PropertyPanel p;
+    p.add_text("name", "Name", "first");
+    p.add_text("name", "Name", "second");
+    REQUIRE(p.size() == 1);
+    REQUIRE(p.get_text("name") == "second");
+}
+
+// ── Persistence ───────────────────────────────────────────────────────
+
+TEST_CASE("PropertyPanel: persistence round-trips all typed variants",
+          "[property-panel][persistence]") {
+    auto path = scratch_props_file("roundtrip");
+    pulp::state::PropertiesFile out;
+
+    {
+        PropertyPanel p;
+        p.add_boolean("b", "B", false);
+        p.add_choice("c", "C", {"a", "b", "c"}, 0);
+        p.add_slider("s", "S", 0.0f, 1.0f, 0.25f);
+        p.add_multi_choice("mc", "MC", {"x", "y", "z"}, {});
+        p.add_text("t", "T", "");
+
+        p.bind_persistence(&out);
+        REQUIRE(p.has_persistence());
+
+        p.set_bool("b", true);
+        p.set_choice("c", 2);
+        p.set_slider("s", 0.75f);
+        p.set_multi_choice("mc", {0, 2});
+        p.set_text("t", "value");
+    }
+
+    REQUIRE(out.get_bool("b") == true);
+    REQUIRE(out.get_int("c") == 2);
+    REQUIRE(out.get_double("s") == 0.75);
+    REQUIRE(out.get_string("mc") == std::string("0,2"));
+    REQUIRE(out.get_string("t") == std::string("value"));
+
+    // Save → reload through a fresh panel, verify state restores.
+    REQUIRE(out.save(path.string()));
+    pulp::state::PropertiesFile reloaded;
+    REQUIRE(reloaded.load(path.string()));
+
+    PropertyPanel q;
+    q.add_boolean("b", "B", false);
+    q.add_choice("c", "C", {"a", "b", "c"}, 0);
+    q.add_slider("s", "S", 0.0f, 1.0f, 0.0f);
+    q.add_multi_choice("mc", "MC", {"x", "y", "z"}, {});
+    q.add_text("t", "T", "");
+    q.bind_persistence(&reloaded);
+
+    REQUIRE(q.get_bool("b") == true);
+    REQUIRE(q.get_choice("c") == 2);
+    REQUIRE(q.get_slider("s") == 0.75f);
+    REQUIRE(q.get_multi_choice("mc") == std::vector<int>{0, 2});
+    REQUIRE(q.get_text("t") == "value");
+
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("PropertyPanel: bind_persistence clamps stored out-of-range Choice",
+          "[property-panel][persistence][defensive]") {
+    pulp::state::PropertiesFile pf;
+    pf.set_int("c", 99);  // someone hand-edited the JSON
+
+    PropertyPanel p;
+    p.add_choice("c", "C", {"a", "b"}, 0);
+    p.bind_persistence(&pf);
+    REQUIRE(p.get_choice("c") == 1);  // clamped
+}
+
+TEST_CASE("PropertyPanel: bind_persistence(nullptr) detaches without erasing",
+          "[property-panel][persistence]") {
+    pulp::state::PropertiesFile pf;
+    PropertyPanel p;
+    p.add_text("t", "T", "before");
+    p.bind_persistence(&pf);
+    p.set_text("t", "after");
+    REQUIRE(pf.get_string("t") == std::string("after"));
+
+    p.bind_persistence(nullptr);
+    REQUIRE_FALSE(p.has_persistence());
+
+    p.set_text("t", "later");
+    // Detached — store still has the old value.
+    REQUIRE(pf.get_string("t") == std::string("after"));
+    REQUIRE(p.get_text("t") == "later");
+}
+
+TEST_CASE("PropertyPanel: decode_indices tolerates malformed entries",
+          "[property-panel][persistence][defensive]") {
+    pulp::state::PropertiesFile pf;
+    pf.set_string("mc", "0,not-a-num, 2 ,99");
+
+    PropertyPanel p;
+    p.add_multi_choice("mc", "MC", {"a", "b", "c"}, {});
+    p.bind_persistence(&pf);
+
+    auto xs = p.get_multi_choice("mc").value();
+    // 0 and 2 are valid; "not-a-num" skipped; 99 dropped; result sorted.
+    REQUIRE(xs == std::vector<int>{0, 2});
+}


### PR DESCRIPTION
## Summary

Three gap-doc widget items from `planning/2026-05-24-reference-framework-gap-analysis.md`, shipped together to reduce CI roundtrips:

1. **CodeEditor language coverage** (Phase 4 row) — new `core/view/include/pulp/view/code_editor_tokenizer.hpp` with lightweight regex-lite tokenizers for **C++, JavaScript, Python, JSON, Lua, plus Markdown**. PlainText/XML/GLSL/Faust/JSFX fall through to a single text span. Drives the existing `CodeEditor` native paint path; PlainText preserves the historical first-character-sniff fallback so existing assertions keep passing.

2. **PropertyPanel typed variants** (Phase 4 row, sister of `PreferencesPanel`) — new `core/view/include/pulp/view/property_panel.hpp` with six variants (Boolean / Choice / Slider / Button / MultiChoice / Text). Persistence via `bind_persistence(PropertiesFile*)` round-trips every variant under each property key; `simulate_*` helpers fire the same path real UI events would.

3. **BubbleMessageComponent + styled AlertWindow** (Phase 3 row) — new `core/view/include/pulp/view/bubble_message.hpp` (anchored-to-source-view floating bubble with `recompute_anchor()`, lifetime auto-dismiss, motion-aware fade, transient source pointer). AlertWindow extended with `warning()` factory + `style_tokens_for(icon)` theme-token vocabulary (`alert.<icon>.icon` / `alert.<icon>.accent` + ASCII glyph hint).

## Test plan

- `pulp-test-code-editor-tokenizer` — 19 cases, 71 assertions
- `pulp-test-property-panel` — 13 cases, 71 assertions
- `pulp-test-bubble-message` — 8 cases, 42 assertions
- `pulp-test-document-window` — styled AlertWindow section (3 new cases)
- `pulp-test-code-editor` and `pulp-test-preferences-panel` continue to pass

All local: 88+71+71+42+78+43 assertions across 78 cases pass clean.

Gap doc updated (PropertyPanel + CodeEditor rows → Most/Full, Phase 3 + Phase 4 bullets marked shipped).

Co-authored by Claude Opus 4.7 (1M context).