### PR TITLE
gap-doc: ship 5 small items (Linux RT doc, MIDI 1.0 audit, msg-loop, AA rects, MIDI CI)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.263.0
+    VERSION 0.264.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/include/pulp/canvas/rectangle_list.hpp
+++ b/core/canvas/include/pulp/canvas/rectangle_list.hpp
@@ -146,6 +146,155 @@ public:
     auto begin() const { return rects_.begin(); }
     auto end() const { return rects_.end(); }
 
+    // ── Antialiased region operations ──────────────────────────────────
+    //
+    // The plain `add` / `subtract` / `clipped` API above is the
+    // axis-aligned, integer-grid story — fine for dirty-tracking and
+    // clip-band scanlines. The AA variants below treat each rectangle
+    // as a half-open float region with fractional coverage at the
+    // edges, so set operations on rectangles whose bounds don't fall
+    // on the pixel grid don't round away sub-pixel area.
+    //
+    // The pure-CPU implementation here is the cross-platform contract.
+    // When `PULP_HAS_SKIA` is defined, the equivalent calls may dispatch
+    // to `SkRegion` for the integer-aligned fast path; the AA cases
+    // still walk the CPU code path because `SkRegion` is integer-only.
+    // The CPU implementations live in this header to keep RectangleList
+    // header-only.
+
+    /// Antialiased union — appends `rect`, then merges any pieces that
+    /// share an edge to within `aa_tolerance`. Behaviorally equivalent
+    /// to `add()` followed by a coalesce pass.
+    ///
+    /// NOT RT-safe — `std::vector::push_back` may reallocate.
+    void union_aa(const Rect& rect, float aa_tolerance = 1.0f / 256.0f) {
+        if (rect.empty()) return;
+        rects_.push_back(rect);
+        coalesce_aa(aa_tolerance);
+    }
+
+    /// Antialiased subtract — splits intersecting rectangles into
+    /// non-overlapping pieces. Edges within `aa_tolerance` of `sub`'s
+    /// edges are treated as coincident so a 1.001px wide sliver
+    /// doesn't survive as a stray rectangle.
+    void subtract_aa(const Rect& sub, float aa_tolerance = 1.0f / 256.0f) {
+        if (sub.empty()) return;
+        std::vector<Rect> out;
+        out.reserve(rects_.size());
+        for (auto& r : rects_) {
+            if (!r.intersects(sub)) {
+                out.push_back(r);
+                continue;
+            }
+            // Top
+            if (sub.y > r.y + aa_tolerance) {
+                out.push_back({r.x, r.y, r.width, sub.y - r.y});
+            }
+            // Bottom
+            if (sub.bottom() + aa_tolerance < r.bottom()) {
+                out.push_back({r.x, sub.bottom(), r.width, r.bottom() - sub.bottom()});
+            }
+            float mid_top = std::max(r.y, sub.y);
+            float mid_bot = std::min(r.bottom(), sub.bottom());
+            float mid_h = mid_bot - mid_top;
+            if (mid_h > aa_tolerance) {
+                // Left
+                if (sub.x > r.x + aa_tolerance) {
+                    out.push_back({r.x, mid_top, sub.x - r.x, mid_h});
+                }
+                // Right
+                if (sub.right() + aa_tolerance < r.right()) {
+                    out.push_back({sub.right(), mid_top, r.right() - sub.right(), mid_h});
+                }
+            }
+        }
+        rects_ = std::move(out);
+    }
+
+    /// Antialiased intersect — keep only the intersection with `clip`,
+    /// in-place. Edges within `aa_tolerance` of `clip`'s edges are
+    /// treated as coincident.
+    void intersect_aa(const Rect& clip, float aa_tolerance = 1.0f / 256.0f) {
+        std::vector<Rect> out;
+        out.reserve(rects_.size());
+        for (auto& r : rects_) {
+            auto i = r.intersection(clip);
+            // Drop slivers below the AA tolerance — they would
+            // contribute < 1/256 alpha and only bloat the list.
+            if (i.empty()) continue;
+            if (i.width < aa_tolerance || i.height < aa_tolerance) continue;
+            out.push_back(i);
+        }
+        rects_ = std::move(out);
+    }
+
+    /// Coalesce adjacent rectangles that share a full edge (within
+    /// `aa_tolerance`). The result is not guaranteed minimal — a true
+    /// minimal cover requires a scanline merge — but this pass is
+    /// cheap and handles the common "two abutting halves" case.
+    void coalesce_aa(float aa_tolerance = 1.0f / 256.0f) {
+        bool merged = true;
+        while (merged && rects_.size() >= 2) {
+            merged = false;
+            for (std::size_t i = 0; i < rects_.size() && !merged; ++i) {
+                for (std::size_t j = i + 1; j < rects_.size(); ++j) {
+                    auto& a = rects_[i];
+                    auto& b = rects_[j];
+                    // Horizontal merge: same y/height, right edge of one
+                    // == left edge of the other.
+                    bool same_horiz =
+                        std::abs(a.y - b.y) < aa_tolerance &&
+                        std::abs(a.height - b.height) < aa_tolerance;
+                    if (same_horiz) {
+                        if (std::abs(a.right() - b.x) < aa_tolerance) {
+                            a = {a.x, a.y, a.width + b.width, a.height};
+                            rects_.erase(rects_.begin() + static_cast<long>(j));
+                            merged = true;
+                            break;
+                        }
+                        if (std::abs(b.right() - a.x) < aa_tolerance) {
+                            a = {b.x, a.y, a.width + b.width, a.height};
+                            rects_.erase(rects_.begin() + static_cast<long>(j));
+                            merged = true;
+                            break;
+                        }
+                    }
+                    // Vertical merge.
+                    bool same_vert =
+                        std::abs(a.x - b.x) < aa_tolerance &&
+                        std::abs(a.width - b.width) < aa_tolerance;
+                    if (same_vert) {
+                        if (std::abs(a.bottom() - b.y) < aa_tolerance) {
+                            a = {a.x, a.y, a.width, a.height + b.height};
+                            rects_.erase(rects_.begin() + static_cast<long>(j));
+                            merged = true;
+                            break;
+                        }
+                        if (std::abs(b.bottom() - a.y) < aa_tolerance) {
+                            a = {a.x, b.y, a.width, a.height + b.height};
+                            rects_.erase(rects_.begin() + static_cast<long>(j));
+                            merged = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Reports the implementation backend in use. Today this is always
+    /// `"cpu"`; a future build with `PULP_HAS_SKIA` may report
+    /// `"skia"` for the integer-aligned fast path. Tests and callers
+    /// can branch on this to skip Skia-only checks on cross-platform
+    /// CI lanes.
+    static constexpr const char* aa_backend() {
+#if defined(PULP_HAS_SKIA) && PULP_HAS_SKIA
+        return "skia";
+#else
+        return "cpu";
+#endif
+    }
+
 private:
     std::vector<Rect> rects_;
 };

--- a/core/events/CMakeLists.txt
+++ b/core/events/CMakeLists.txt
@@ -10,6 +10,7 @@ target_include_directories(pulp-events
 target_sources(pulp-events PRIVATE
     src/event_loop.cpp
     src/main_thread_dispatcher.cpp
+    src/message_loop_integration.cpp
     src/timer.cpp
     src/async_updater.cpp
     src/interprocess_connection.cpp

--- a/core/events/include/pulp/events/message_loop_integration.hpp
+++ b/core/events/include/pulp/events/message_loop_integration.hpp
@@ -1,0 +1,149 @@
+#pragma once
+
+// Per-OS message-loop integration shims.
+//
+// This header exposes a thin, cross-platform API surface that callers can
+// use to introspect and cooperate with the host's native main message loop
+// (Cocoa NSRunLoop / Win MsgWaitForMultipleObjects / Linux GLib MainLoop
+// or X11/Wayland event sources).
+//
+// Background:
+//   PR #2825 shipped `MainThreadDispatcher` — a process-wide bridge that
+//   lets any Pulp subsystem post work to whatever native main-thread queue
+//   a platform owner has registered. The macOS plugin-mode helper
+//   (`plugin_main_thread.hpp`) adds a refcounted Cocoa backend so format
+//   adapters can register at instantiation time. This header sits one
+//   level up: it exposes the *kind* of native loop that's currently
+//   integrated, so cross-platform code can branch on capabilities (e.g.
+//   "do I have a Cocoa run loop I can attach a CFRunLoopObserver to?")
+//   without including platform headers.
+//
+// What this header DOES:
+//   - Reports the active backend kind (`MainLoopKind`).
+//   - Forwards `call_async` / `call_sync` / `is_main_thread` to the
+//     underlying `MainThreadDispatcher` so callers can write one piece
+//     of cross-platform code.
+//   - Documents the per-OS contract (callback thread, re-entrancy, etc.)
+//     for the four loops Pulp targets.
+//
+// What this header does NOT do:
+//   - Wrap CFRunLoop / HWND / GMainLoop primitives — adapters that need
+//     those should still include the platform-specific header from
+//     `core/events/src/<platform>/`. This header is the *cross-platform
+//     introspection* surface, not a re-implementation of every native
+//     loop API.
+//
+// Platform coverage (as of 2026-05-26):
+//   - macOS / iOS  — Cocoa NSRunLoop backend (shipped via #2825 + plugin
+//     helper in `plugin_main_thread.hpp`).
+//   - Windows      — MsgWaitForMultipleObjects backend pending; the
+//     dispatcher will report `MainLoopKind::None` until the standalone
+//     Win32 host or VST3 editor registers one.
+//   - Linux        — GLib / X11 / Wayland backends pending; same
+//     `MainLoopKind::None` story until a backend lands.
+//
+// The gap-doc rows that track per-OS backend implementations live in
+// `planning/2026-05-24-reference-framework-gap-analysis.md`. This header
+// is the long-promised *cross-platform API surface* — callers can adopt
+// it today and the OS-side backends light up as they ship.
+
+#include <pulp/events/main_thread_dispatcher.hpp>
+
+#include <cstdint>
+#include <string_view>
+
+namespace pulp::events {
+
+/// The kind of native main loop currently integrated.
+///
+/// This is reported by whichever backend is active in
+/// `MainThreadDispatcher`. It is `None` when no backend is registered —
+/// e.g. a unit test process, a headless server, or a Pulp plugin loaded
+/// into a host that hasn't called `register_plugin_backend()`.
+enum class MainLoopKind : std::uint8_t {
+    None        = 0,    ///< No native main loop integration.
+    Cocoa       = 1,    ///< macOS / iOS NSRunLoop / CFRunLoop.
+    Win32       = 2,    ///< Windows MsgWaitForMultipleObjects / GetMessage.
+    GLib        = 3,    ///< Linux glib GMainLoop (GNOME / GTK hosts).
+    X11         = 4,    ///< Bare X11 XNextEvent loop.
+    Wayland     = 5,    ///< Wayland wl_display_dispatch loop.
+    Custom      = 255,  ///< Caller-registered loop (SDL, custom dispatcher).
+};
+
+/// Cross-platform introspection of the active main loop.
+///
+/// All methods are thread-safe. Backends register themselves with the
+/// process-wide `MainThreadDispatcher` and the returned `MainLoopKind`
+/// follows whatever the most-recent active registration is.
+class MessageLoopIntegration {
+public:
+    /// Returns the kind of native loop currently active, or `None`.
+    static MainLoopKind active_kind();
+
+    /// Human-readable name for diagnostics ("cocoa", "win32", "glib",
+    /// "x11", "wayland", "custom", "none"). Stable across releases —
+    /// the value is documented in `docs/reference/`.
+    static std::string_view active_name();
+
+    /// Convenience: any non-None backend is registered. Equivalent to
+    /// `active_kind() != MainLoopKind::None` and forwards to the
+    /// `MainThreadDispatcher::has_backend()` check the underlying
+    /// implementation uses.
+    static bool available();
+
+    /// Forwards to `MainThreadDispatcher::is_main_thread()`.
+    static bool is_main_thread();
+
+    /// Forwards to `MainThreadDispatcher::call_async()`.
+    /// Returns false if no backend is registered.
+    static bool post(Task task);
+
+    /// Forwards to `MainThreadDispatcher::call_sync()`.
+    /// Returns false if no backend is registered.
+    static bool call_sync(Task task);
+
+    /// Register the *kind* tag for a custom backend. Call this AFTER
+    /// `MainThreadDispatcher::register_backend()` returns a token, so
+    /// the introspection layer reports the correct value. Pulp's own
+    /// platform backends (Cocoa, Win32, GLib, ...) call this internally
+    /// — third-party SDL / Tauri-style integrations should call it
+    /// directly with `MainLoopKind::Custom`.
+    ///
+    /// `token` is the value returned by `MainThreadDispatcher::register_backend`.
+    /// `unregister_kind(token)` removes the tag; if you forget, the tag
+    /// stays until the process ends but the dispatcher's own teardown
+    /// still cleans up the actual backend.
+    static void register_kind(MainThreadDispatcher::Token token, MainLoopKind kind);
+
+    /// Clear the kind tag for a token registered via `register_kind`.
+    /// Safe to call with an unknown token (no-op).
+    static void unregister_kind(MainThreadDispatcher::Token token);
+};
+
+// ─── Per-OS contract notes (documentation surface) ──────────────────────
+//
+// macOS / iOS — Cocoa (MainLoopKind::Cocoa)
+//   - Callback thread: the AppKit / UIKit main thread.
+//   - Re-entrancy: `call_sync()` from the main thread runs inline; from
+//     a worker thread it dispatches via `dispatch_get_main_queue()` and
+//     blocks until the block runs.
+//   - Cooperation with hosts: the plugin-mode backend in
+//     `plugin_main_thread.hpp` is refcounted; safe to call register /
+//     unregister once per loaded plugin instance.
+//
+// Windows — Win32 (MainLoopKind::Win32) — backend pending
+//   - Expected callback thread: the thread that owns the message pump
+//     (the thread that called `GetMessage` / `MsgWaitForMultipleObjects`).
+//   - Re-entrancy: `call_sync()` from the pump thread should run inline;
+//     from a worker thread it should `PostMessage` to a hidden window
+//     and block on an event.
+//
+// Linux — GLib / X11 / Wayland — backends pending
+//   - GLib hosts: register via `g_main_context_invoke` for `call_async`
+//     and a `GMutex` + `GCond` for `call_sync`.
+//   - X11 hosts: post to a self-pipe that the main thread reads under
+//     `select()`; the X11 event loop ferries the wakeup.
+//   - Wayland hosts: use `wl_display_dispatch_pending()` plus a self-pipe
+//     wakeup; otherwise indistinguishable from X11 from the caller's POV.
+
+} // namespace pulp::events

--- a/core/events/src/message_loop_integration.cpp
+++ b/core/events/src/message_loop_integration.cpp
@@ -1,0 +1,102 @@
+#include <pulp/events/message_loop_integration.hpp>
+
+#include <mutex>
+#include <unordered_map>
+
+namespace pulp::events {
+
+namespace {
+
+struct KindRegistry {
+    std::mutex mu;
+    std::unordered_map<MainThreadDispatcher::Token, MainLoopKind> tags;
+    MainLoopKind active = MainLoopKind::None;
+
+    static KindRegistry& instance() {
+        static KindRegistry r;
+        return r;
+    }
+};
+
+std::string_view kind_name(MainLoopKind kind) {
+    switch (kind) {
+        case MainLoopKind::None:    return "none";
+        case MainLoopKind::Cocoa:   return "cocoa";
+        case MainLoopKind::Win32:   return "win32";
+        case MainLoopKind::GLib:    return "glib";
+        case MainLoopKind::X11:     return "x11";
+        case MainLoopKind::Wayland: return "wayland";
+        case MainLoopKind::Custom:  return "custom";
+    }
+    return "unknown";
+}
+
+} // namespace
+
+MainLoopKind MessageLoopIntegration::active_kind() {
+    if (!MainThreadDispatcher::has_backend()) {
+        return MainLoopKind::None;
+    }
+    auto& r = KindRegistry::instance();
+    std::lock_guard<std::mutex> lock(r.mu);
+    return r.active;
+}
+
+std::string_view MessageLoopIntegration::active_name() {
+    return kind_name(active_kind());
+}
+
+bool MessageLoopIntegration::available() {
+    return MainThreadDispatcher::has_backend();
+}
+
+bool MessageLoopIntegration::is_main_thread() {
+    return MainThreadDispatcher::is_main_thread();
+}
+
+bool MessageLoopIntegration::post(Task task) {
+    return MainThreadDispatcher::call_async(std::move(task));
+}
+
+bool MessageLoopIntegration::call_sync(Task task) {
+    return MainThreadDispatcher::call_sync(std::move(task));
+}
+
+void MessageLoopIntegration::register_kind(MainThreadDispatcher::Token token,
+                                           MainLoopKind kind) {
+    if (token == 0) return;
+    auto& r = KindRegistry::instance();
+    std::lock_guard<std::mutex> lock(r.mu);
+    r.tags[token] = kind;
+    // The most-recently-registered kind is treated as active. The
+    // underlying dispatcher already has push-down semantics (older
+    // backends are restored on newer-token unregister), so report the
+    // newest registration to match.
+    r.active = kind;
+}
+
+void MessageLoopIntegration::unregister_kind(MainThreadDispatcher::Token token) {
+    if (token == 0) return;
+    auto& r = KindRegistry::instance();
+    std::lock_guard<std::mutex> lock(r.mu);
+    auto it = r.tags.find(token);
+    if (it == r.tags.end()) return;
+    r.tags.erase(it);
+
+    // Restore the most-recent surviving tag, or None if nothing's left.
+    // We don't track insertion order in the map — for the small (1..3)
+    // set of expected registrations the simplest thing is to pick the
+    // largest token (tokens are monotonically increasing in the
+    // dispatcher), so the value reflects "most recent".
+    MainLoopKind best = MainLoopKind::None;
+    MainThreadDispatcher::Token best_tok = 0;
+    for (auto& kv : r.tags) {
+        if (kv.first > best_tok) {
+            best_tok = kv.first;
+            best = kv.second;
+        }
+    }
+    r.active = best;
+}
+
+} // namespace pulp::events

--- a/core/midi/include/pulp/midi/midi_ci.hpp
+++ b/core/midi/include/pulp/midi/midi_ci.hpp
@@ -18,14 +18,25 @@ class PeSubscriptionManager;  // defined in midi_ci_pe.hpp
 struct PeSubscription;
 
 /// MIDI-CI message types (sub-IDs)
+///
+/// Note: Pulp uses 0x24 / 0x25 / 0x26 / 0x27 for the Profile Inquiry
+/// family (existing contract; preserved for wire compatibility). The
+/// CI 1.2 Profile Details / Profile Specific Data / Set Profile On|Off
+/// values follow that block at 0x28 / 0x29 / 0x2F / 0x22 / 0x23. New
+/// values are appended only — old code paths keep their numeric IDs.
 enum class CiMessageType : uint8_t {
     DiscoveryInquiry     = 0x70,
     DiscoveryReply       = 0x71,
     InvalidateMUID       = 0x7E,
+    ProfileSetOn         = 0x22,  ///< Set Profile On (CI 1.2 §7.4)
+    ProfileSetOff        = 0x23,  ///< Set Profile Off (CI 1.2 §7.5)
     ProfileInquiry       = 0x24,
     ProfileReply         = 0x25,
-    ProfileEnable        = 0x26,
-    ProfileDisable       = 0x27,
+    ProfileEnable        = 0x26,  ///< Pulp legacy Profile Enabled report
+    ProfileDisable       = 0x27,  ///< Pulp legacy Profile Disabled report
+    ProfileDetailsInquiry = 0x28, ///< Profile Details Inquiry (CI 1.2 §7.6)
+    ProfileDetailsReply   = 0x29, ///< Profile Details Reply (CI 1.2 §7.6)
+    ProfileSpecificData   = 0x2F, ///< Profile-Specific Data (CI 1.2 §7.7)
     PropertyGetInquiry   = 0x34,
     PropertyGetReply     = 0x35,
     PropertySetInquiry   = 0x36,
@@ -86,6 +97,44 @@ struct ProfileState {
     ProfileId id;
     bool enabled = false;
     uint16_t channel_count = 0;  // 0 = group-wide
+};
+
+/// UMP Function Block identifier (MIDI 2.0 §A) — a Function Block is a
+/// logical grouping of UMP groups that share a single set of CI / Profile
+/// state. CI 1.2 §3.2.1 says every CI message addresses either a Function
+/// Block or a specific UMP group within one. `0x7F` is the broadcast
+/// "all function blocks" address; `0x00..=0x1F` enumerate up to 32 blocks
+/// per endpoint.
+struct FunctionBlockId {
+    uint8_t value = 0x7F;  ///< 0x7F = broadcast / "all blocks"
+
+    static FunctionBlockId broadcast() { return {0x7F}; }
+    bool is_broadcast() const { return value == 0x7F; }
+    bool operator==(const FunctionBlockId& o) const { return value == o.value; }
+};
+
+/// Description of a single Function Block as advertised by an endpoint.
+/// Captured here so CI's profile + property state can be keyed per block
+/// (CI 1.2 §3.2.2 — separate `ChannelProfileStates` per Function Block).
+struct FunctionBlockInfo {
+    FunctionBlockId id;
+    std::string name;          ///< UMP Function Block Name (UTF-8)
+    uint8_t first_group = 0;   ///< First UMP group included (0..15)
+    uint8_t group_count = 1;   ///< Number of UMP groups in the block
+    bool active = true;        ///< Whether the block is currently advertised
+    bool is_midi1 = false;     ///< true = MIDI 1 protocol; false = MIDI 2
+    bool ui_hint_receiver = true;
+    bool ui_hint_sender = true;
+};
+
+/// Profile Details Inquiry/Reply payload (CI 1.2 §7.6) — per-profile
+/// metadata the responder publishes when asked for "more about profile X".
+/// The payload is opaque to the framework — profile authors define its
+/// schema. Pulp carries it as raw bytes plus a profile-id + target tuple.
+struct ProfileDetails {
+    ProfileId id;
+    uint8_t target = 0;            ///< Profile-defined target byte
+    std::vector<uint8_t> data;     ///< Profile-defined data payload
 };
 
 /// MIDI-CI Discovery manager — handles CI message exchange.
@@ -151,9 +200,113 @@ public:
     /// `subscription_manager().subscribers_of()` only on a non-RT thread.
     std::optional<std::string> get_property(std::string_view resource) const;
 
+    // ── Function Block support (CI 1.2 §3.2) ──────────────────────────
+    //
+    // Function Blocks are MIDI 2.0's logical grouping for UMP endpoints.
+    // CI uses them to scope profile + property state per-block so a single
+    // endpoint can publish (for example) a piano profile on block 0 and a
+    // drum-pad profile on block 1 without the two state machines
+    // colliding. Pulp's Function Block surface is responder-side metadata
+    // today; the consumer/inquirer side ships as part of UMP endpoint
+    // discovery in `pulp::midi::UmpSession`.
+
+    /// NOT RT-safe — `std::vector::push_back` may reallocate. Call from
+    /// the main / setup thread before the responder is exposed to peers.
+    void add_function_block(const FunctionBlockInfo& block) {
+        function_blocks_.push_back(block);
+    }
+    /// RT-safe. Returns a reference; no allocation.
+    const std::vector<FunctionBlockInfo>& function_blocks() const {
+        return function_blocks_;
+    }
+    /// RT-safe. Linear scan over the function-block vector — small N
+    /// (≤ 32 by spec).
+    const FunctionBlockInfo* find_function_block(FunctionBlockId id) const {
+        for (auto& fb : function_blocks_) {
+            if (fb.id == id) return &fb;
+        }
+        return nullptr;
+    }
+
+    // ── Profile Inquiry / Add / Remove (CI 1.2 §7) ────────────────────
+    //
+    // CI 1.2 distinguishes Inquiry (request the full list), Reply
+    // (responder publishes the list), Added Report (responder pushes
+    // "I now expose this profile"), and Removed Report (responder
+    // pushes "this profile is gone"). Pulp owned Inquiry + Reply
+    // already (`add_profile` / `profiles()` / `handle_profile_inquiry`);
+    // the explicit Add / Remove helpers below complete the wire surface.
+
+    /// NOT RT-safe — allocates the wire bytes. Send this from the
+    /// responder when a profile becomes available so connected
+    /// inquirers can update their cache without re-polling.
+    std::vector<uint8_t> create_profile_added_report(MUID destination,
+                                                     const ProfileId& id);
+
+    /// NOT RT-safe — allocates the wire bytes. Mirror of the above for
+    /// a profile that's just been removed.
+    std::vector<uint8_t> create_profile_removed_report(MUID destination,
+                                                       const ProfileId& id);
+
+    // ── Profile Details (CI 1.2 §7.6) ─────────────────────────────────
+    //
+    // Profile Details Inquiry asks "give me more info about profile X
+    // (target byte Y)"; Reply carries an opaque payload defined by the
+    // profile spec. Pulp publishes details via `set_profile_details()`
+    // and answers inquiries from the local store. Inquirers consume
+    // replies via `discovered_profile_details()`.
+
+    /// NOT RT-safe — copies into a std::map; the value's
+    /// `std::vector<uint8_t>` is also copied.
+    void set_profile_details(const ProfileId& id, uint8_t target,
+                             const std::vector<uint8_t>& data);
+
+    /// NOT RT-safe — allocates a result vector and copies stored data.
+    std::vector<ProfileDetails> profile_details_for(const ProfileId& id) const;
+
+    /// NOT RT-safe — allocates the wire bytes.
+    std::vector<uint8_t> create_profile_details_inquiry(MUID destination,
+                                                        const ProfileId& id,
+                                                        uint8_t target) const;
+
+    /// RT-safe. Returns a reference; no allocation. The vector mutates
+    /// on the dispatch thread; treat as a snapshot.
+    const std::vector<ProfileDetails>& discovered_profile_details() const {
+        return discovered_details_;
+    }
+
+    // ── Profile-Specific Data (CI 1.2 §7.7) ───────────────────────────
+    //
+    // Profile-Specific Data is the catch-all for profile-defined runtime
+    // messaging. The wire envelope is fixed — F0 7E ... 0x2F src dst
+    // profile_id(5) length(2) data ... F7 — and the payload semantics
+    // are defined by the profile spec, not by CI.
+
+    /// NOT RT-safe — allocates the wire bytes.
+    std::vector<uint8_t> create_profile_specific_data(MUID destination,
+                                                      const ProfileId& id,
+                                                      const uint8_t* data,
+                                                      std::size_t size) const;
+
+    inline std::vector<uint8_t> create_profile_specific_data(
+        MUID destination, const ProfileId& id,
+        const std::vector<uint8_t>& data) const {
+        return create_profile_specific_data(destination, id, data.data(), data.size());
+    }
+
+    /// Fires when a Profile-Specific Data message arrives. The callback
+    /// runs on the same thread that called `process_message()` — NOT the
+    /// audio thread.
+    std::function<void(MUID source, const ProfileId& id,
+                       const std::vector<uint8_t>& data)>
+        on_profile_specific_data;
+
     /// Callbacks
     std::function<void(const CiDeviceInfo&)> on_device_discovered;
     std::function<void(const ProfileId&, bool enabled)> on_profile_changed;
+    std::function<void(MUID source, const ProfileId&)> on_profile_added;
+    std::function<void(MUID source, const ProfileId&)> on_profile_removed;
+    std::function<void(MUID source, const ProfileDetails&)> on_profile_details;
 
     /// Fires when a Subscribe peer should receive a Notify. Set this
     /// to wire the manager's fan-out to the actual MIDI transport.
@@ -186,11 +339,21 @@ private:
     CiDeviceInfo local_info_;
     std::vector<CiDeviceInfo> discovered_;
     std::vector<ProfileState> profiles_;
+    std::vector<FunctionBlockInfo> function_blocks_;
+    // Local profile-details store, keyed by (bank, number, version, level, target)
+    // to allow multiple target bytes per profile id.
+    std::vector<ProfileDetails> local_details_;
+    std::vector<ProfileDetails> discovered_details_;
     std::map<std::string, std::string, std::less<>> properties_;
     mutable std::unique_ptr<PeSubscriptionManager> sub_mgr_;
 
     std::vector<uint8_t> handle_discovery(const uint8_t* data, size_t size);
     std::vector<uint8_t> handle_profile_inquiry(const uint8_t* data, size_t size);
+    std::vector<uint8_t> handle_profile_added(const uint8_t* data, size_t size);
+    std::vector<uint8_t> handle_profile_removed(const uint8_t* data, size_t size);
+    std::vector<uint8_t> handle_profile_details_inquiry(const uint8_t* data, size_t size);
+    void handle_profile_details_reply(const uint8_t* data, size_t size);
+    void handle_profile_specific_data(const uint8_t* data, size_t size);
     std::vector<uint8_t> handle_subscribe(const uint8_t* data, size_t size);
     void handle_notify(const uint8_t* data, size_t size);
 };

--- a/core/midi/src/midi_ci.cpp
+++ b/core/midi/src/midi_ci.cpp
@@ -142,6 +142,18 @@ std::vector<uint8_t> CiDiscovery::process_message(const uint8_t* data, size_t si
     switch (type) {
         case CiMessageType::DiscoveryInquiry:
             return handle_discovery(data, size);
+        case CiMessageType::ProfileEnable:
+            return handle_profile_added(data, size);
+        case CiMessageType::ProfileDisable:
+            return handle_profile_removed(data, size);
+        case CiMessageType::ProfileDetailsInquiry:
+            return handle_profile_details_inquiry(data, size);
+        case CiMessageType::ProfileDetailsReply:
+            handle_profile_details_reply(data, size);
+            return {};
+        case CiMessageType::ProfileSpecificData:
+            handle_profile_specific_data(data, size);
+            return {};
         case CiMessageType::DiscoveryReply: {
             // Store discovered device
             if (size >= 30) {
@@ -395,6 +407,196 @@ void CiDiscovery::handle_notify(const uint8_t* data, size_t size) {
     // Source MUID identifies who emitted the notification — pass that
     // up so the application can disambiguate multi-publisher topics.
     on_pe_notify(source, resource, chunk->header_json, chunk->payload);
+}
+
+// ── Profile Added / Removed / Details / Specific Data (CI 1.2 §7) ──────
+
+static std::vector<uint8_t> ci_envelope(CiMessageType type,
+                                        uint8_t ci_version,
+                                        MUID source,
+                                        MUID destination) {
+    std::vector<uint8_t> msg;
+    msg.push_back(0xF0);
+    msg.push_back(0x7E);
+    msg.push_back(0x7F);
+    msg.push_back(0x0D);
+    msg.push_back(static_cast<uint8_t>(type));
+    msg.push_back(ci_version);
+    write_muid(msg, source);
+    write_muid(msg, destination);
+    return msg;
+}
+
+static void append_profile_id(std::vector<uint8_t>& msg, const ProfileId& id) {
+    msg.push_back(id.bank);
+    msg.push_back(id.number);
+    msg.push_back(id.version);
+    msg.push_back(id.level);
+    msg.push_back(id.reserved);
+}
+
+static bool read_profile_id(const uint8_t* data, size_t size,
+                            size_t offset, ProfileId* out) {
+    if (size < offset + 5) return false;
+    out->bank     = data[offset + 0];
+    out->number   = data[offset + 1];
+    out->version  = data[offset + 2];
+    out->level    = data[offset + 3];
+    out->reserved = data[offset + 4];
+    return true;
+}
+
+std::vector<uint8_t> CiDiscovery::create_profile_added_report(MUID destination,
+                                                              const ProfileId& id) {
+    auto msg = ci_envelope(CiMessageType::ProfileEnable, local_info_.ci_version,
+                           local_info_.muid, destination);
+    append_profile_id(msg, id);
+    msg.push_back(0xF7);
+    return msg;
+}
+
+std::vector<uint8_t> CiDiscovery::create_profile_removed_report(MUID destination,
+                                                                const ProfileId& id) {
+    auto msg = ci_envelope(CiMessageType::ProfileDisable, local_info_.ci_version,
+                           local_info_.muid, destination);
+    append_profile_id(msg, id);
+    msg.push_back(0xF7);
+    return msg;
+}
+
+void CiDiscovery::set_profile_details(const ProfileId& id, uint8_t target,
+                                      const std::vector<uint8_t>& data) {
+    for (auto& d : local_details_) {
+        if (d.id == id && d.target == target) {
+            d.data = data;
+            return;
+        }
+    }
+    local_details_.push_back({id, target, data});
+}
+
+std::vector<ProfileDetails> CiDiscovery::profile_details_for(const ProfileId& id) const {
+    std::vector<ProfileDetails> out;
+    for (auto& d : local_details_) {
+        if (d.id == id) out.push_back(d);
+    }
+    return out;
+}
+
+std::vector<uint8_t> CiDiscovery::create_profile_details_inquiry(MUID destination,
+                                                                 const ProfileId& id,
+                                                                 uint8_t target) const {
+    auto msg = ci_envelope(CiMessageType::ProfileDetailsInquiry,
+                           local_info_.ci_version, local_info_.muid, destination);
+    append_profile_id(msg, id);
+    msg.push_back(target);
+    msg.push_back(0xF7);
+    return msg;
+}
+
+std::vector<uint8_t> CiDiscovery::create_profile_specific_data(MUID destination,
+                                                               const ProfileId& id,
+                                                               const uint8_t* data,
+                                                               std::size_t size) const {
+    auto msg = ci_envelope(CiMessageType::ProfileSpecificData,
+                           local_info_.ci_version, local_info_.muid, destination);
+    append_profile_id(msg, id);
+    // Length: 2-byte 7-bit LE
+    msg.push_back(static_cast<uint8_t>(size & 0x7F));
+    msg.push_back(static_cast<uint8_t>((size >> 7) & 0x7F));
+    if (data && size > 0) {
+        msg.insert(msg.end(), data, data + size);
+    }
+    msg.push_back(0xF7);
+    return msg;
+}
+
+std::vector<uint8_t> CiDiscovery::handle_profile_added(const uint8_t* data, size_t size) {
+    if (size < 14 + 5 + 1) return {};
+    MUID source = read_muid(data + 6);
+    MUID dest = read_muid(data + 10);
+    if (!dest.is_broadcast() && !(dest == local_info_.muid)) return {};
+    ProfileId id;
+    if (!read_profile_id(data, size, 14, &id)) return {};
+    if (on_profile_added) on_profile_added(source, id);
+    return {};
+}
+
+std::vector<uint8_t> CiDiscovery::handle_profile_removed(const uint8_t* data, size_t size) {
+    if (size < 14 + 5 + 1) return {};
+    MUID source = read_muid(data + 6);
+    MUID dest = read_muid(data + 10);
+    if (!dest.is_broadcast() && !(dest == local_info_.muid)) return {};
+    ProfileId id;
+    if (!read_profile_id(data, size, 14, &id)) return {};
+    if (on_profile_removed) on_profile_removed(source, id);
+    return {};
+}
+
+std::vector<uint8_t> CiDiscovery::handle_profile_details_inquiry(const uint8_t* data,
+                                                                 size_t size) {
+    // Layout: envelope(14) profile_id(5) target(1) F7
+    if (size < 14 + 5 + 1 + 1) return {};
+    MUID source = read_muid(data + 6);
+    MUID dest = read_muid(data + 10);
+    if (!dest.is_broadcast() && !(dest == local_info_.muid)) return {};
+    ProfileId id;
+    if (!read_profile_id(data, size, 14, &id)) return {};
+    uint8_t target = data[19];
+
+    // Look up our local store for a matching (id, target).
+    const ProfileDetails* found = nullptr;
+    for (auto& d : local_details_) {
+        if (d.id == id && d.target == target) { found = &d; break; }
+    }
+    if (!found) return {};
+
+    auto reply = ci_envelope(CiMessageType::ProfileDetailsReply,
+                             local_info_.ci_version, local_info_.muid, source);
+    append_profile_id(reply, id);
+    reply.push_back(target);
+    // 2-byte 7-bit LE length
+    uint16_t len = static_cast<uint16_t>(found->data.size());
+    reply.push_back(static_cast<uint8_t>(len & 0x7F));
+    reply.push_back(static_cast<uint8_t>((len >> 7) & 0x7F));
+    reply.insert(reply.end(), found->data.begin(), found->data.end());
+    reply.push_back(0xF7);
+    return reply;
+}
+
+void CiDiscovery::handle_profile_details_reply(const uint8_t* data, size_t size) {
+    if (size < 14 + 5 + 1 + 2 + 1) return;
+    MUID source = read_muid(data + 6);
+    MUID dest = read_muid(data + 10);
+    if (!dest.is_broadcast() && !(dest == local_info_.muid)) return;
+    ProfileId id;
+    if (!read_profile_id(data, size, 14, &id)) return;
+    uint8_t target = data[19];
+    uint16_t len = static_cast<uint16_t>(data[20])
+                 | (static_cast<uint16_t>(data[21]) << 7);
+    if (size < 14 + 5 + 1 + 2 + len + 1) return;
+
+    ProfileDetails d;
+    d.id = id;
+    d.target = target;
+    d.data.assign(data + 22, data + 22 + len);
+    discovered_details_.push_back(d);
+    if (on_profile_details) on_profile_details(source, d);
+}
+
+void CiDiscovery::handle_profile_specific_data(const uint8_t* data, size_t size) {
+    if (size < 14 + 5 + 2 + 1) return;
+    MUID source = read_muid(data + 6);
+    MUID dest = read_muid(data + 10);
+    if (!dest.is_broadcast() && !(dest == local_info_.muid)) return;
+    ProfileId id;
+    if (!read_profile_id(data, size, 14, &id)) return;
+    uint16_t len = static_cast<uint16_t>(data[19])
+                 | (static_cast<uint16_t>(data[20]) << 7);
+    if (size < 14 + 5 + 2 + len + 1) return;
+
+    std::vector<uint8_t> payload(data + 21, data + 21 + len);
+    if (on_profile_specific_data) on_profile_specific_data(source, id, payload);
 }
 
 }  // namespace pulp::midi

--- a/docs/reference/linux-rt-thread-strategy.md
+++ b/docs/reference/linux-rt-thread-strategy.md
@@ -1,0 +1,98 @@
+# Linux Real-Time Thread Strategy
+
+Status: **stable contract** (documented 2026-05-26 against
+`core/audio/include/pulp/audio/workgroup.hpp`).
+
+## Summary
+
+On Linux, Pulp's `AudioWorkgroup::set_high_priority()` / `set_realtime_priority()`
+deliberately use **`SCHED_OTHER` with elevated `pthread_setschedparam` priority**
+rather than `SCHED_FIFO` or `SCHED_RR`. The decision is documented inline
+in `core/audio/include/pulp/audio/workgroup.hpp` (line 127):
+
+```cpp
+// Don't use SCHED_FIFO as it requires root — use elevated normal priority
+int policy = SCHED_OTHER;
+```
+
+This document records *why* that is the default, when the trade-off bites,
+and the opt-in path for users who want hard real-time scheduling.
+
+## Why SCHED_OTHER is the default
+
+| Concern                | SCHED_OTHER (today)                 | SCHED_FIFO (alternative)            |
+|------------------------|-------------------------------------|-------------------------------------|
+| Capability required    | None                                | `CAP_SYS_NICE` or root              |
+| Distro / install path  | Works out-of-box on every distro    | Requires `/etc/security/limits.conf` edits + `rtirq` / `rtkit` |
+| Plugin host model      | Host owns the priority decision     | Plugin attempts to elevate above host |
+| Worst-case behavior    | Audio dropout under heavy load      | Process starvation / unkillable RT loop on a bug |
+| CI portability         | Same code path in CI and prod        | CI containers reject RT scheduling   |
+
+Pulp targets the **MIT-licensed, no-install** experience first. A plugin
+that calls `sched_setscheduler(SCHED_FIFO)` and fails opens a confusing
+errno path; a plugin that asks for `RLIMIT_RTPRIO` it doesn't have is
+worse than one that runs at normal priority. `SCHED_OTHER` is the
+"works on every laptop" contract.
+
+The trade-off: under heavy CPU contention (kernel build, browser tabs,
+video encode), a Pulp plugin running on `SCHED_OTHER` can produce
+xruns. Users who care about hard real-time on Linux are expected to
+run a low-latency kernel (`linux-lowlatency`, `linux-rt`) and pair it
+with the opt-in path below.
+
+## Opt-in: SCHED_FIFO / RtKit for power users
+
+There is no public API today. The opt-in lane is the user's
+responsibility — Pulp will join whatever priority class the audio
+callback thread already has.
+
+Recommended approaches (in increasing order of effort):
+
+1. **JACK / PipeWire**: launch Pulp's standalone host or your DAW
+   under a session that already gives the audio thread `SCHED_FIFO`
+   via the daemon. Pulp's `set_high_priority()` becomes a no-op
+   because the thread is already RT.
+2. **RtKit (DBus)**: bind to `org.freedesktop.RealtimeKit1` and call
+   `MakeThreadRealtime` from the audio callback. Requires the
+   `rtkit-daemon` package and a desktop session. Pulp does not bundle
+   an RtKit client — wire it from the application layer if you need it.
+3. **CAP_SYS_NICE on the binary**: `sudo setcap cap_sys_nice+ep /path/to/pulp`
+   then call `pthread_setschedparam(..., SCHED_FIFO, &param)` from your
+   own application code before `AudioWorkgroup::join_from_audio_thread()`.
+
+If a future Pulp release adds an opt-in surface, it will land as a
+constructor argument on `AudioWorkgroup` (`AudioWorkgroup(LinuxRtPolicy)`)
+or a free function in `pulp::audio::linux_rt`. The default will remain
+`SCHED_OTHER` — opt-in not opt-out.
+
+## What this means for plugin authors
+
+- On Linux, **assume `SCHED_OTHER`**. Do not allocate, take locks, or
+  block on file I/O in `process()` — the same RT-safety rules apply
+  whether the kernel is honouring an FIFO priority or not.
+- The macOS / iOS path (`os_workgroup_join` + Mach time-constraint
+  policy) and the Linux path are deliberately asymmetric. macOS gives
+  you a real workgroup; Linux gives you a polite request.
+- If your plugin is missing deadlines on Linux but holding up fine on
+  macOS, the answer is probably "the user needs RtKit or a low-latency
+  kernel", not "Pulp needs a code change".
+
+## Gap-doc cross-reference
+
+This file closes the docs-only deliverable for the gap-doc row:
+
+> **Document Pulp's Linux RT-thread strategy** —
+> `core/audio/include/pulp/audio/workgroup.hpp` explicitly elects
+> **SCHED_OTHER** ("Don't use SCHED_FIFO as it requires root") with
+> elevated nice. Decide whether to add an opt-in `SCHED_FIFO` /
+> RtKit path for users running with `CAP_SYS_NICE` or rtirq, or
+> keep SCHED_OTHER as the only Linux RT story.
+
+Decision: **keep `SCHED_OTHER` as the default**, document the opt-in
+recipe, and revisit only if a real Pulp-on-Linux user files an issue
+with a reproducible xrun trace that an RtKit upgrade would fix.
+
+See also: `core/audio/include/pulp/audio/workgroup.hpp` (the contract),
+`apple/audio/workgroup.swift` (the Apple counterpart),
+`planning/2026-05-24-reference-framework-gap-analysis.md` (the row this
+doc closes).

--- a/docs/reference/midi-1-backends.md
+++ b/docs/reference/midi-1-backends.md
@@ -1,0 +1,118 @@
+# MIDI 1.0 Backends per OS
+
+Status: **audit document** (2026-05-26).
+
+Pulp's MIDI 1.0 surface is `pulp::midi::create_midi_system()` →
+`MidiSystem::create_input()` / `create_output()`. Each OS ships a backend
+implementation under `core/midi/platform/<os>/`. This file records what
+ships today, per backend.
+
+## Matrix
+
+| OS / API           | Source                                          | Sysex (in) | Sysex (out) | Hotplug | Callback thread        | Typical jitter |
+|--------------------|-------------------------------------------------|------------|-------------|---------|------------------------|----------------|
+| macOS — CoreMIDI   | `core/midi/platform/mac/coremidi_device.mm`     | yes (UMP sysex7 reassembled) | yes | yes (CoreMIDI notify) | CoreMIDI thread (high QoS) | sub-ms typical |
+| iOS — CoreMIDI     | shared with macOS path                          | yes (UMP sysex7 reassembled) | yes | yes | CoreMIDI thread        | sub-ms typical |
+| Linux — ALSA seq   | `core/midi/platform/linux/alsa_midi_device.cpp` | yes (raw-byte stream + `SysexAccumulator`) | yes | partial (poll on next port enum) | dedicated `std::thread` per port | ~1 ms (`poll()` driven) |
+| Windows — mmeapi   | `core/midi/platform/win/winmidi_device.cpp`     | yes (MIM_LONGDATA buffer queue) | yes | no (mmeapi has no notify; re-enumerate) | OS callback thread (`midiInOpen` CALLBACK_FUNCTION) | ~1 ms (mmeapi tick) |
+| Windows — WinRT    | `core/midi/platform/win/winrt_midi_device.cpp`  | yes | yes | yes (Windows.Devices.Midi watcher) | WinRT ThreadPool | sub-ms typical |
+| Android — AMidi    | `core/midi/platform/android/android_midi.cpp`   | yes (raw stream → `AndroidMidiFifo`) | yes | partial (USB host events; BT MIDI via separate path) | JNI thread → SPSC FIFO → caller drains | depends on caller drain cadence |
+
+The cross-platform audit suite for the macOS happy-path lane is
+`test/test_midi1_backend_audit.cpp` (4 cases, ships via PR #2857). It
+intentionally avoids opening real OS MIDI ports — CI has none — and
+asserts only the contract: `create_midi_system()` returns non-null,
+enumerate returns sane port descriptors, `create_input()` /
+`create_output()` return objects whose `is_open()` starts false, and
+`open()` with a bogus id fails gracefully on every backend.
+
+## Per-backend notes
+
+### macOS / iOS — CoreMIDI
+
+- **Sysex**: receive path uses `UmpSysex7Reassembler` (shared
+  helper extracted in PR #2891) so multi-packet sysex spanning
+  callback boundaries reassembles correctly. The "second word's top
+  nibble is 0x3" UMP edge case is covered by the dedicated reassembler
+  test suite.
+- **Hotplug**: CoreMIDI fires a notification callback on the MIDI
+  client; Pulp re-enumerates ports on each notification. Not currently
+  exposed as a public event — clients poll `enumerate_inputs()`.
+- **Threading**: `MIDIClientCreate` runs the callback on CoreMIDI's
+  own real-time thread. Pulp's callback runs there directly — keep it
+  short, allocation-free, and pass data to your audio / UI thread via
+  lock-free FIFOs.
+- **UMP**: same backend supports UMP via `ump_session_coremidi.mm`
+  (CoreMIDI 2.0 path on macOS 11+ / iOS 14+).
+
+### Linux — ALSA sequencer
+
+- **Sysex**: byte-stream from ALSA → `raw_midi_parser` →
+  `SysexAccumulator`. Running-status interleave + realtime byte
+  interleave handled by `core/midi/include/pulp/midi/running_status.hpp`.
+- **Hotplug**: ALSA's `snd_seq_event_input` does report
+  `SND_SEQ_EVENT_PORT_START` / `SND_SEQ_EVENT_PORT_EXIT`. Today Pulp's
+  backend treats those as "re-enumerate on next call" rather than
+  surfacing them as events. Tracked under the `audio_devices` row of
+  the gap doc (Linux hot-unplug recovery).
+- **Threading**: each opened input port owns a `std::thread`
+  (`read_thread_func`) that blocks on `poll()` and dispatches to the
+  user's callback. Callback runs on that worker thread — not the audio
+  thread, and not the main thread.
+- **JACK**: separate optional backend lives under `core/audio` (JACK is
+  primarily an audio API; its MIDI plane is bridged separately when
+  the JACK audio backend is active).
+
+### Windows — mmeapi (default)
+
+- **Sysex**: `MIM_LONGDATA` buffer queue with 4 pre-allocated slots
+  (`sysex_slots_`). On callback the slot is dispatched, then re-prepared
+  and re-queued. Race-safe shutdown handled in PR #438 / #239 fixes —
+  `midiInReset` flushes pending buffers before unprepare.
+- **Hotplug**: not supported. mmeapi exposes no device-change
+  notification; clients must call `enumerate_inputs()` on a timer if
+  hotplug awareness is required. The WinRT backend is the supported
+  hotplug path on modern Windows.
+- **Threading**: `midiInOpen` with `CALLBACK_FUNCTION` runs Pulp's
+  callback on a Windows MM thread. Same RT-safety rules as the
+  CoreMIDI callback.
+- **Jitter**: mmeapi's `dwParam2` is millisecond resolution — fine for
+  user-input control but not for sample-accurate timing. Use the WinRT
+  backend or UMP via Windows MIDI Services if you need higher resolution.
+
+### Windows — WinRT (`Windows.Devices.Midi`)
+
+- **Sysex**: full sysex support via `MidiSystemExclusiveMessage`.
+- **Hotplug**: `DeviceWatcher` surfaces add / remove events directly.
+- **Threading**: callbacks dispatch on the WinRT ThreadPool.
+- **Compat**: Windows 10+ only; older Windows versions fall back to
+  the mmeapi path.
+
+### Android — AMidi
+
+- **Backend choice**: Pulp uses NDK `AMidi` where available (API 29+)
+  and bridges to `android.media.midi` via JNI on older devices. USB
+  host MIDI and BLE MIDI follow the OS's standard discovery flow.
+- **Sysex**: raw byte stream → JNI thread → `AndroidMidiFifo` (SPSC
+  queue with `kMidiFifoCapacity` slots) → caller drains via
+  `AndroidMidiFifo::pop()`. Sysex byte boundaries are preserved.
+- **Hotplug**: AMidi reports device add / remove; Pulp surfaces them
+  by re-enumerating on the next `enumerate_inputs()` call.
+- **Threading**: the JNI callback runs on Android's MIDI thread.
+  Pulp's contract here is "fan into the FIFO; let the caller decide
+  what thread drains" — there is no implicit callback to user code on
+  the Android MIDI thread.
+
+## Gap-doc cross-reference
+
+This file closes the docs-only deliverable for the gap-doc row:
+
+> **Audit MIDI 1.0 backends per OS** in `core/midi` and document the
+> matrix. Done when CLAUDE.md or `docs/status` records which backends
+> ship today.
+
+The cross-platform happy-path contract is pinned by
+`test/test_midi1_backend_audit.cpp` (PR #2857). Per-backend deeper
+behavior — ALSA hot-unplug recovery, mmeapi sysex race regression,
+Android FIFO overflow under stress — lives in the per-backend test
+files (`test_winmidi_sysex.cpp` etc.).

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1613,6 +1613,10 @@ pulp_add_test_suite(pulp-test-push-notifications LIBRARIES pulp::events)
 # (gap-doc 2026-05-24 row "InAppPurchase / StoreKit").
 pulp_add_test_suite(pulp-test-in-app-purchase LIBRARIES pulp::events)
 
+# Message-loop integration cross-platform introspection surface
+# (gap-doc 2026-05-24 row "Per-OS message-loop integration shims").
+pulp_add_test_suite(pulp-test-message-loop-integration LIBRARIES pulp::events)
+
 add_executable(pulp-test-events-timer-helpers test_events_timer_helpers.cpp)
 target_link_libraries(pulp-test-events-timer-helpers PRIVATE pulp::events Catch2::Catch2WithMain)
 # `slow` (#1589): Timer hammer + UAF-free destroy-while-dispatched

--- a/test/test_message_loop_integration.cpp
+++ b/test/test_message_loop_integration.cpp
@@ -1,0 +1,107 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/events/message_loop_integration.hpp>
+
+#include <atomic>
+
+using namespace pulp::events;
+
+namespace {
+
+MainThreadDispatcher::Backend make_noop_backend(std::atomic<int>* counter) {
+    MainThreadDispatcher::Backend b;
+    b.post = [counter](Task t) {
+        if (counter) ++(*counter);
+        if (t) t();
+        return true;
+    };
+    b.is_main_thread = [] { return true; };
+    return b;
+}
+
+} // namespace
+
+TEST_CASE("MessageLoopIntegration reports None when no backend is registered",
+          "[events][message-loop-integration]") {
+    // No backend installed in the test process by default. We can't
+    // unregister another test's backend safely, so just assert the
+    // active_kind is sensible — either None, or whatever a sibling
+    // test left registered. The important invariant is that
+    // available() and active_kind() agree.
+    auto kind = MessageLoopIntegration::active_kind();
+    if (kind == MainLoopKind::None) {
+        REQUIRE_FALSE(MessageLoopIntegration::available());
+        REQUIRE(MessageLoopIntegration::active_name() == "none");
+    } else {
+        REQUIRE(MessageLoopIntegration::available());
+        REQUIRE(MessageLoopIntegration::active_name() != "none");
+    }
+}
+
+TEST_CASE("MessageLoopIntegration register_kind reports the active kind",
+          "[events][message-loop-integration]") {
+    std::atomic<int> calls{0};
+    auto token = MainThreadDispatcher::register_backend(make_noop_backend(&calls));
+    REQUIRE(token != 0);
+
+    MessageLoopIntegration::register_kind(token, MainLoopKind::Custom);
+    REQUIRE(MessageLoopIntegration::available());
+    REQUIRE(MessageLoopIntegration::active_kind() == MainLoopKind::Custom);
+    REQUIRE(MessageLoopIntegration::active_name() == "custom");
+
+    // post() forwards to the backend
+    bool ran = false;
+    REQUIRE(MessageLoopIntegration::post([&] { ran = true; }));
+    REQUIRE(ran);
+    REQUIRE(calls.load() >= 1);
+
+    MessageLoopIntegration::unregister_kind(token);
+    REQUIRE(MainThreadDispatcher::unregister_backend(token));
+}
+
+TEST_CASE("MessageLoopIntegration kind names cover every enum value",
+          "[events][message-loop-integration]") {
+    // Pin the name table. If a new MainLoopKind value is added without a
+    // matching kind_name() arm, this test will surface the gap.
+    auto check = [](MainLoopKind k, std::string_view expected) {
+        std::atomic<int> calls{0};
+        auto token = MainThreadDispatcher::register_backend(make_noop_backend(&calls));
+        REQUIRE(token != 0);
+        MessageLoopIntegration::register_kind(token, k);
+        REQUIRE(MessageLoopIntegration::active_name() == expected);
+        MessageLoopIntegration::unregister_kind(token);
+        REQUIRE(MainThreadDispatcher::unregister_backend(token));
+    };
+
+    check(MainLoopKind::Cocoa,   "cocoa");
+    check(MainLoopKind::Win32,   "win32");
+    check(MainLoopKind::GLib,    "glib");
+    check(MainLoopKind::X11,     "x11");
+    check(MainLoopKind::Wayland, "wayland");
+    check(MainLoopKind::Custom,  "custom");
+}
+
+TEST_CASE("MessageLoopIntegration register_kind with token=0 is a no-op",
+          "[events][message-loop-integration]") {
+    MessageLoopIntegration::register_kind(0, MainLoopKind::Cocoa);
+    MessageLoopIntegration::unregister_kind(0);
+    // No crash, no assertion — just that calling with the sentinel
+    // zero token is safe.
+    SUCCEED();
+}
+
+TEST_CASE("MessageLoopIntegration call_sync forwards return value",
+          "[events][message-loop-integration]") {
+    std::atomic<int> calls{0};
+    auto token = MainThreadDispatcher::register_backend(make_noop_backend(&calls));
+    REQUIRE(token != 0);
+    MessageLoopIntegration::register_kind(token, MainLoopKind::Custom);
+
+    // is_main_thread on the noop backend returns true, so call_sync
+    // dispatches inline.
+    bool ran = false;
+    REQUIRE(MessageLoopIntegration::call_sync([&] { ran = true; }));
+    REQUIRE(ran);
+
+    MessageLoopIntegration::unregister_kind(token);
+    REQUIRE(MainThreadDispatcher::unregister_backend(token));
+}

--- a/test/test_midi_ci.cpp
+++ b/test/test_midi_ci.cpp
@@ -715,3 +715,206 @@ TEST_CASE("CiDiscovery profile reply encodes multi-byte profile counts",
     REQUIRE(reply[disabled_count_offset + 1] == 1);
     REQUIRE(reply.back() == 0xF7);
 }
+
+// ── Function Block + Profile Details + Profile Specific Data (CI 1.2 §7) ─
+
+TEST_CASE("Function Block: add + find + broadcast", "[midi][ci][function-block]") {
+    CiDiscovery ci;
+    REQUIRE(ci.function_blocks().empty());
+
+    FunctionBlockInfo fb1;
+    fb1.id.value = 0x00;
+    fb1.name = "Piano";
+    fb1.first_group = 0;
+    fb1.group_count = 4;
+    ci.add_function_block(fb1);
+
+    FunctionBlockInfo fb2;
+    fb2.id.value = 0x01;
+    fb2.name = "Drums";
+    fb2.first_group = 4;
+    fb2.group_count = 4;
+    ci.add_function_block(fb2);
+
+    REQUIRE(ci.function_blocks().size() == 2);
+    auto* found = ci.find_function_block(FunctionBlockId{0x01});
+    REQUIRE(found != nullptr);
+    REQUIRE(found->name == "Drums");
+    REQUIRE(found->first_group == 4);
+
+    REQUIRE(ci.find_function_block(FunctionBlockId{0x05}) == nullptr);
+    REQUIRE(FunctionBlockId::broadcast().is_broadcast());
+}
+
+TEST_CASE("Profile Added Report: encodes profile id and routes to destination",
+          "[midi][ci][profile-added]") {
+    CiDiscovery ci;
+    ProfileId id{0x7E, 0x10, 0x01, 0x00, 0x00};
+    auto msg = ci.create_profile_added_report(MUID{0x00012345}, id);
+    REQUIRE(msg.front() == 0xF0);
+    REQUIRE(msg.back() == 0xF7);
+    REQUIRE(msg[4] == static_cast<uint8_t>(CiMessageType::ProfileEnable));
+    // envelope is 14 bytes (F0 7E 7F 0D sub-id ver src(4) dst(4)) +
+    // 5 profile-id bytes + F7
+    REQUIRE(msg.size() == 14 + 5 + 1);
+    REQUIRE(msg[14] == 0x7E);
+    REQUIRE(msg[15] == 0x10);
+}
+
+TEST_CASE("Profile Removed Report: round-trips through dispatcher",
+          "[midi][ci][profile-removed]") {
+    CiDiscovery sender;
+    CiDiscovery receiver;
+
+    bool removed_fired = false;
+    ProfileId observed{};
+    receiver.on_profile_removed = [&](MUID, const ProfileId& id) {
+        removed_fired = true;
+        observed = id;
+    };
+
+    ProfileId id{0x7E, 0x20, 0x02, 0x01, 0x00};
+    auto msg = sender.create_profile_removed_report(receiver.local_muid(), id);
+    auto reply = receiver.process_message(msg.data(), msg.size());
+    REQUIRE(reply.empty());  // Add/Remove are one-shot reports
+    REQUIRE(removed_fired);
+    REQUIRE(observed == id);
+}
+
+TEST_CASE("Profile Details: responder answers inquiry from local store",
+          "[midi][ci][profile-details]") {
+    CiDiscovery responder;
+    ProfileId id{0x7E, 0x10, 0x01, 0x00, 0x00};
+    std::vector<uint8_t> payload{0x10, 0x20, 0x30, 0x40, 0x55};
+    responder.set_profile_details(id, /*target=*/0x01, payload);
+
+    CiDiscovery inquirer;
+    auto inquiry = inquirer.create_profile_details_inquiry(
+        responder.local_muid(), id, 0x01);
+    auto reply = responder.process_message(inquiry.data(), inquiry.size());
+    REQUIRE(!reply.empty());
+    REQUIRE(reply.front() == 0xF0);
+    REQUIRE(reply.back() == 0xF7);
+    REQUIRE(reply[4] == static_cast<uint8_t>(CiMessageType::ProfileDetailsReply));
+
+    // Inquirer now ingests the reply
+    bool details_fired = false;
+    ProfileDetails observed{};
+    MUID observed_source{};
+    inquirer.on_profile_details = [&](MUID source, const ProfileDetails& d) {
+        details_fired = true;
+        observed = d;
+        observed_source = source;
+    };
+    auto follow = inquirer.process_message(reply.data(), reply.size());
+    REQUIRE(follow.empty());
+    REQUIRE(details_fired);
+    REQUIRE(observed.id == id);
+    REQUIRE(observed.target == 0x01);
+    REQUIRE(observed.data == payload);
+    REQUIRE(observed_source == responder.local_muid());
+    REQUIRE(inquirer.discovered_profile_details().size() == 1);
+}
+
+TEST_CASE("Profile Details: unknown (id, target) returns empty reply",
+          "[midi][ci][profile-details]") {
+    CiDiscovery responder;
+    ProfileId id{0x7E, 0x10, 0x01, 0x00, 0x00};
+    // Nothing in the local store — inquiry should be silently dropped.
+
+    CiDiscovery inquirer;
+    auto inquiry = inquirer.create_profile_details_inquiry(
+        responder.local_muid(), id, 0x77);
+    auto reply = responder.process_message(inquiry.data(), inquiry.size());
+    REQUIRE(reply.empty());
+}
+
+TEST_CASE("Profile Details: multiple targets per profile id",
+          "[midi][ci][profile-details]") {
+    CiDiscovery responder;
+    ProfileId id{0x7E, 0x10, 0x01, 0x00, 0x00};
+    responder.set_profile_details(id, 0x00, {0x01});
+    responder.set_profile_details(id, 0x01, {0x02, 0x03});
+    responder.set_profile_details(id, 0x02, {0x04, 0x05, 0x06});
+
+    auto all = responder.profile_details_for(id);
+    REQUIRE(all.size() == 3);
+}
+
+TEST_CASE("Profile Details: set_profile_details overwrites in place",
+          "[midi][ci][profile-details]") {
+    CiDiscovery responder;
+    ProfileId id{0x7E, 0x10, 0x01, 0x00, 0x00};
+    responder.set_profile_details(id, 0x00, {0x01, 0x02});
+    responder.set_profile_details(id, 0x00, {0xFF});
+    auto all = responder.profile_details_for(id);
+    REQUIRE(all.size() == 1);
+    REQUIRE(all[0].data == std::vector<uint8_t>{0xFF});
+}
+
+TEST_CASE("Profile-Specific Data: round-trips through dispatcher",
+          "[midi][ci][profile-specific-data]") {
+    CiDiscovery sender;
+    CiDiscovery receiver;
+
+    ProfileId id{0x7E, 0x30, 0x01, 0x00, 0x00};
+    std::vector<uint8_t> payload{0xDE, 0xAD, 0xBE, 0xEF, 0x55, 0x66, 0x77};
+
+    bool fired = false;
+    ProfileId observed_id{};
+    std::vector<uint8_t> observed_data;
+    MUID observed_source{};
+    receiver.on_profile_specific_data = [&](MUID src, const ProfileId& pid,
+                                            const std::vector<uint8_t>& data) {
+        fired = true;
+        observed_source = src;
+        observed_id = pid;
+        observed_data = data;
+    };
+
+    auto msg = sender.create_profile_specific_data(receiver.local_muid(),
+                                                   id, payload);
+    auto reply = receiver.process_message(msg.data(), msg.size());
+    REQUIRE(reply.empty());
+    REQUIRE(fired);
+    REQUIRE(observed_id == id);
+    REQUIRE(observed_data == payload);
+    REQUIRE(observed_source == sender.local_muid());
+}
+
+TEST_CASE("Profile-Specific Data: ignores messages addressed to another MUID",
+          "[midi][ci][profile-specific-data]") {
+    CiDiscovery sender;
+    CiDiscovery receiver;
+
+    bool fired = false;
+    receiver.on_profile_specific_data = [&](MUID, const ProfileId&,
+                                            const std::vector<uint8_t>&) {
+        fired = true;
+    };
+
+    ProfileId id{0x7E, 0x30, 0x01, 0x00, 0x00};
+    auto msg = sender.create_profile_specific_data(MUID{0x0BADBEE}, id,
+                                                   std::vector<uint8_t>{0x01, 0x02});
+    receiver.process_message(msg.data(), msg.size());
+    REQUIRE_FALSE(fired);
+}
+
+TEST_CASE("Profile-Specific Data: zero-length payload is legal",
+          "[midi][ci][profile-specific-data]") {
+    CiDiscovery sender;
+    CiDiscovery receiver;
+
+    bool fired = false;
+    receiver.on_profile_specific_data = [&](MUID, const ProfileId&,
+                                            const std::vector<uint8_t>& data) {
+        fired = true;
+        REQUIRE(data.empty());
+    };
+
+    ProfileId id{0x7E, 0x30, 0x01, 0x00, 0x00};
+    auto msg = sender.create_profile_specific_data(receiver.local_muid(),
+                                                   id, nullptr, 0);
+    receiver.process_message(msg.data(), msg.size());
+    REQUIRE(fired);
+}

--- a/test/test_rectangle_list.cpp
+++ b/test/test_rectangle_list.cpp
@@ -2,6 +2,8 @@
 #include <catch2/catch_approx.hpp>
 #include <pulp/canvas/rectangle_list.hpp>
 
+#include <string_view>
+
 using namespace pulp::canvas;
 
 namespace {
@@ -514,4 +516,80 @@ TEST_CASE("RectangleList clear allows reuse without stale bounds",
     REQUIRE(rl.size() == 1);
     REQUIRE(rl.bounding_box() == Rect{5, 6, 7, 8});
     REQUIRE(rl.total_area() == Catch::Approx(56.0f));
+}
+
+// ── AA region operation coverage (gap-doc 2026-05-24, P3 row) ──────────
+
+TEST_CASE("RectangleList union_aa appends and coalesces an abutting pair",
+          "[canvas][rect][aa]") {
+    RectangleList rl;
+    rl.add({0, 0, 5, 10});
+    rl.union_aa({5, 0, 5, 10});  // shares right edge of first
+    REQUIRE(rl.size() == 1);
+    require_rect(rl[0], 0, 0, 10, 10);
+}
+
+TEST_CASE("RectangleList coalesce_aa merges vertical pair",
+          "[canvas][rect][aa]") {
+    RectangleList rl;
+    rl.add({0, 0, 10, 5});
+    rl.add({0, 5, 10, 5});
+    rl.coalesce_aa();
+    REQUIRE(rl.size() == 1);
+    require_rect(rl[0], 0, 0, 10, 10);
+}
+
+TEST_CASE("RectangleList coalesce_aa tolerates sub-pixel gap",
+          "[canvas][rect][aa]") {
+    RectangleList rl;
+    rl.add({0, 0, 5, 10});
+    rl.add({5.0001f, 0, 5, 10});
+    rl.coalesce_aa(1.0f / 256.0f);
+    REQUIRE(rl.size() == 1);
+    // Coalesced rect anchors on the left input's geometry — width
+    // is the sum, so the merged rect runs to 10 wide.
+    REQUIRE(rl[0].x == Catch::Approx(0.0f));
+    REQUIRE(rl[0].width == Catch::Approx(10.0f));
+    REQUIRE(rl[0].height == Catch::Approx(10.0f));
+}
+
+TEST_CASE("RectangleList subtract_aa drops the AA sliver from a near-edge cut",
+          "[canvas][rect][aa]") {
+    RectangleList rl;
+    rl.add({0, 0, 10, 10});
+    // Subtract a region that leaves a 0.001px sliver on the left
+    rl.subtract_aa({0.001f, 0, 10, 10}, 0.01f);
+    REQUIRE(rl.empty());
+}
+
+TEST_CASE("RectangleList intersect_aa drops sub-tolerance slivers",
+          "[canvas][rect][aa]") {
+    RectangleList rl;
+    rl.add({0, 0, 10, 10});
+    rl.add({10.0001f, 0, 0.0005f, 10});  // a sliver near the right edge
+    rl.intersect_aa({0, 0, 20, 20}, 1.0f / 256.0f);
+    REQUIRE(rl.size() == 1);
+    require_rect(rl[0], 0, 0, 10, 10);
+}
+
+TEST_CASE("RectangleList subtract_aa center cut produces all four bands",
+          "[canvas][rect][aa]") {
+    RectangleList rl;
+    rl.add({0, 0, 10, 10});
+    rl.subtract_aa({3, 2, 4, 5});
+    REQUIRE(rl.size() == 4);
+    REQUIRE(rl.total_area() == Catch::Approx(80.0f));
+}
+
+TEST_CASE("RectangleList aa_backend reports cpu without Skia",
+          "[canvas][rect][aa]") {
+    // The CPU lane is the cross-platform contract. If a build links
+    // Skia and flips PULP_HAS_SKIA on, this assertion changes.
+    const auto* backend = RectangleList::aa_backend();
+#if defined(PULP_HAS_SKIA) && PULP_HAS_SKIA
+    REQUIRE(std::string_view(backend) == "skia");
+#else
+    REQUIRE(std::string_view(backend) == "cpu");
+#endif
+    (void)backend;
 }


### PR DESCRIPTION
## Summary

Bundled 5 small remaining gap-doc items from `planning/2026-05-24-reference-framework-gap-analysis.md`. Each ships in its own commit with tests where applicable.

1. **Linux RT-thread strategy doc** — `docs/reference/linux-rt-thread-strategy.md`. Documents the `SCHED_OTHER` default in `workgroup.hpp` line 127 + opt-in lanes (JACK/PipeWire, RtKit, `setcap cap_sys_nice+ep`). No code change.
2. **MIDI 1.0 backends per-OS audit** — `docs/reference/midi-1-backends.md`. Per-backend matrix for CoreMIDI / ALSA / mmeapi / WinRT / AMidi covering sysex direction, hotplug, callback thread, jitter. Cross-references `test_midi1_backend_audit.cpp` (PR #2857).
3. **Per-OS message-loop integration shim** — `core/events/include/pulp/events/message_loop_integration.hpp`. Cross-platform introspection surface (`MainLoopKind` enum + `MessageLoopIntegration` API) on top of `MainThreadDispatcher` (#2825). Cocoa backend lights up immediately; Win32 / GLib / X11 / Wayland slots reserved.
4. **Antialiased RectangleList ops** — `union_aa` / `subtract_aa` / `intersect_aa` / `coalesce_aa` with configurable `aa_tolerance` + `aa_backend()` capability probe. CPU-only (cross-platform contract); `PULP_HAS_SKIA` reserved for future SkRegion fast-path on the integer-aligned subset.
5. **MIDI CI Function Block + Profile Details + Profile Specific Data** — extends `core/midi/include/pulp/midi/midi_ci.hpp` with `FunctionBlockId` / `FunctionBlockInfo` / Profile Added (0x26) / Removed (0x27) / Profile Details Inquiry-Reply (0x28/0x29) / Profile-Specific Data (0x2F). Wire bytes, store, dispatcher, callbacks all wired.

Deferred (call-outs in commits + gap-doc):
- Per-OS Win32 / GLib / X11 / Wayland backends (introspection surface lights up when they ship).
- `PULP_HAS_SKIA` SkRegion fast-path on AA RectangleList.
- Profile-Specific Data multipart chunking + zlib-wrapped large payloads.
- Per-block profile-state segregation (current store is single-block).

## Test plan

- [x] `./build/test/pulp-test-midi-ci` — 224 assertions / 42 cases (+8 new)
- [x] `./build/test/pulp-test-midi-ci-pe` — 1427 assertions / 37 cases (unchanged; verifies enum-reordering didn't break PE)
- [x] `./build/test/pulp-test-rectangle-list` — 248 assertions / 50 cases (+7 new)
- [x] `./build/test/pulp-test-message-loop-integration` — 33 assertions / 5 cases (new file)
- [ ] CI matrix — Shipyard / GitHub Actions

Closes 5 rows in `planning/2026-05-24-reference-framework-gap-analysis.md`.