### PR TITLE
ci(skia): backfill real SHA-256 for linux-arm64 Skia asset

### DIFF
--- a/external/skia-build/VERSION.md
+++ b/external/skia-build/VERSION.md
@@ -78,7 +78,7 @@ Or run: `./tools/build-skia.sh <platform>` to build from source.
 
 | Asset | SHA-256 |
 |-------|---------|
-| `skia-build-linux-arm64-gpu-release.zip` | `PLACEHOLDER_LINUX_ARM64_SHA256` (pulp #47 — built on the project's Ubuntu 24.04 aarch64 host; real digest backfills once `gh release upload danielraffel/skia-builder chrome/m149 skia-build-linux-arm64-gpu-release.zip` completes) |
+| `skia-build-linux-arm64-gpu-release.zip` | `6dfd451aa27df4f200fae0d728ccfa31e3c0b0ae16e20f136a384c93d3b5e45e` |
 | `skia-build-linux-x64-gpu-release.zip` | `53e2bfb5225148311da9bbcb7e65da4479acf774bc3d40b0341530cdc48e97b6` |
 | `skia-build-mac-arm64-gpu-release.zip` | `774f5df966cd7133d05ce217eb3ed7bb226246ac336f764d7409350f175437f7` |
 | `skia-build-mac-universal-gpu-release.zip` | `416c5872296bd69f307cd279a3125e6574b86ef9effbb10adc31203781e434aa` |

--- a/tools/deps/manifest.json
+++ b/tools/deps/manifest.json
@@ -570,7 +570,7 @@
           },
           "linux-arm64": {
             "url": "https://github.com/danielraffel/skia-builder/releases/download/chrome/m149/skia-build-linux-arm64-gpu-release.zip",
-            "sha256": "PLACEHOLDER_LINUX_ARM64_SHA256"
+            "sha256": "6dfd451aa27df4f200fae0d728ccfa31e3c0b0ae16e20f136a384c93d3b5e45e"
           },
           "linux-x64": {
             "url": "https://github.com/danielraffel/skia-builder/releases/download/chrome/m149/skia-build-linux-x64-gpu-release.zip",

--- a/tools/harness/visual/pins.py
+++ b/tools/harness/visual/pins.py
@@ -30,7 +30,7 @@ FONT_SHA256 = {
 
 RELEASE_ASSET_SHA256 = {
     "linux-arm64": (
-        "PLACEHOLDER_LINUX_ARM64_SHA256"
+        "6dfd451aa27df4f200fae0d728ccfa31e3c0b0ae16e20f136a384c93d3b5e45e"
     ),
     "linux-x64": (
         "53e2bfb5225148311da9bbcb7e65da4479acf774bc3d40b0341530cdc48e97b6"


### PR DESCRIPTION
## Summary

Follow-up to #3030. Replaces the three `PLACEHOLDER_LINUX_ARM64_SHA256` sentinels with the real digest of the published Skia release asset.

## Asset

- Built on the project Ubuntu 24.04 aarch64 host via `python3 build-skia.py linux -archs arm64 -branch chrome/m149 --shallow` (second attempt succeeded after a transient `googlesource.com` `RESOURCE_EXHAUSTED` retry).
- Packaged with `/home/daniel/zip-and-sha.sh` mirroring the x64 layout (`build/include` + `build/linux-gpu/lib/Release/arm64`).
- Uploaded to: https://github.com/danielraffel/skia-builder/releases/tag/chrome%2Fm149
- Asset: `skia-build-linux-arm64-gpu-release.zip` (36 MB)
- SHA-256: `6dfd451aa27df4f200fae0d728ccfa31e3c0b0ae16e20f136a384c93d3b5e45e`

## What changed

- `tools/deps/manifest.json` — real SHA in the `linux-arm64` release_assets entry.
- `tools/harness/visual/pins.py` — mirror SHA so `test_skia_determinism.py` matches.
- `external/skia-build/VERSION.md` — Release Asset Digests table row.

## Test plan

- [x] `python3 tools/scripts/test_skia_linux_arm64_asset.py` — green (3/3)
- [x] `python3 tools/scripts/test_fetch_skia_for_release.py` — green (29/29)
- [x] `python3 tools/scripts/test_fetch_skia_for_release_extra.py` — green (5/5)
- [x] `version_bump_check.py --mode=report` — no bump needed (pin update)
- [x] `skill_sync_check.py --mode=report` — no mapped paths touched
- [ ] CI: workflow-lint + build matrix

Closing follow-up for #47 — the linux-arm64 lane no longer falls back to the no-Skia / CG path silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)