### PR TITLE
fix(skia): correct linux-arm64 Skia SHA-256 (#3036 follow-up)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.126.1",
+      "version": "0.126.2",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.125.1"
+  "version": "0.125.2"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.126.1",
+  "version": "0.126.2",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.268.0
+    VERSION 0.268.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/external/skia-build/VERSION.md
+++ b/external/skia-build/VERSION.md
@@ -78,7 +78,7 @@ Or run: `./tools/build-skia.sh <platform>` to build from source.
 
 | Asset | SHA-256 |
 |-------|---------|
-| `skia-build-linux-arm64-gpu-release.zip` | `6dfd451aa27df4f200fae0d728ccfa31e3c0b0ae16e20f136a384c93d3b5e45e` |
+| `skia-build-linux-arm64-gpu-release.zip` | `4a6a99a7abefdaae83b864f2103bebdcf7c1455a20f726f2cdba44f51d52bf05` |
 | `skia-build-linux-x64-gpu-release.zip` | `53e2bfb5225148311da9bbcb7e65da4479acf774bc3d40b0341530cdc48e97b6` |
 | `skia-build-mac-arm64-gpu-release.zip` | `774f5df966cd7133d05ce217eb3ed7bb226246ac336f764d7409350f175437f7` |
 | `skia-build-mac-universal-gpu-release.zip` | `416c5872296bd69f307cd279a3125e6574b86ef9effbb10adc31203781e434aa` |

--- a/tools/deps/manifest.json
+++ b/tools/deps/manifest.json
@@ -570,7 +570,7 @@
           },
           "linux-arm64": {
             "url": "https://github.com/danielraffel/skia-builder/releases/download/chrome/m149/skia-build-linux-arm64-gpu-release.zip",
-            "sha256": "6dfd451aa27df4f200fae0d728ccfa31e3c0b0ae16e20f136a384c93d3b5e45e"
+            "sha256": "4a6a99a7abefdaae83b864f2103bebdcf7c1455a20f726f2cdba44f51d52bf05"
           },
           "linux-x64": {
             "url": "https://github.com/danielraffel/skia-builder/releases/download/chrome/m149/skia-build-linux-x64-gpu-release.zip",

--- a/tools/harness/visual/pins.py
+++ b/tools/harness/visual/pins.py
@@ -30,7 +30,7 @@ FONT_SHA256 = {
 
 RELEASE_ASSET_SHA256 = {
     "linux-arm64": (
-        "6dfd451aa27df4f200fae0d728ccfa31e3c0b0ae16e20f136a384c93d3b5e45e"
+        "4a6a99a7abefdaae83b864f2103bebdcf7c1455a20f726f2cdba44f51d52bf05"
     ),
     "linux-x64": (
         "53e2bfb5225148311da9bbcb7e65da4479acf774bc3d40b0341530cdc48e97b6"


### PR DESCRIPTION
## Summary

PR #3036 merged a fabricated SHA-256 sentinel for the linux-arm64 Skia asset that does **not** match the actual zip on the build host, and the asset itself was **not** actually uploaded (the `gh release upload` step was rate-limited at the time but the SHA-update commit went in anyway).

This PR corrects the digest in all three places (`tools/deps/manifest.json`, `tools/harness/visual/pins.py`, `external/skia-build/VERSION.md`) to match the real zip that `tools/build-skia.sh linux` produces on the project's Ubuntu 24.04 aarch64 host.

## Evidence

```
$ ssh ubuntu sha256sum /home/daniel/skia-build-linux-arm64-gpu-release.zip
4a6a99a7abefdaae83b864f2103bebdcf7c1455a20f726f2cdba44f51d52bf05  ...
$ curl -sIL "https://github.com/danielraffel/skia-builder/releases/download/chrome/m149/skia-build-linux-arm64-gpu-release.zip" | head -1
HTTP/2 404
```

- Real digest (against the zip on the build host): `4a6a99a7abefdaae83b864f2103bebdcf7c1455a20f726f2cdba44f51d52bf05`
- Sentinel committed by #3036: `6dfd451aa27df4f200fae0d728ccfa31e3c0b0ae16e20f136a384c93d3b5e45e` (no real file produces this)

## What this PR does NOT do

- It does not upload the asset to the GitHub Release. That step is gated on the `danielraffel/skia-builder` releases endpoint secondary rate-limit clearing. A watchdog is running on the build host that retries `gh release upload chrome/m149 /home/daniel/skia-build-linux-arm64-gpu-release.zip --repo danielraffel/skia-builder` until it succeeds.

## Failure mode while asset is pending

Until the asset is uploaded:
- `tools/scripts/fetch_skia_for_release.py linux-arm64` fails at the **download** step with `HTTP/2 404`.

That is the correct failure mode — better a loud download error than a silently-wrong digest that will never match the actual asset once it ships. With the SHA in this PR, the digest will match the moment the zip lands at the release URL.

## Test plan

- [x] `python3 tools/scripts/test_skia_linux_arm64_asset.py` — green
- [x] `python3 tools/scripts/test_fetch_skia_for_release.py` — green
- [x] `version_bump_check.py --require-bump-for-fix-feat` — green (plugin bumped 0.126.1 → 0.126.2; `chore: bump versions` commit present)
- [x] `skill_sync_check.py` — green via `Skill-Update: skip skill=packages` trailer (additive SHA correction, no schema change)
- [ ] After upload completes: re-download from the release URL, compute SHA-256, verify equality to the committed value

Refs: #47, #3030, #3036