### PR TITLE
feat(format): 4 iPlug2-audit DAW quirks (REAPER AUv3, Studio One, DP, Cubase 13+)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.270.0
+    VERSION 0.270.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/host_quirks.hpp
+++ b/core/format/include/pulp/format/host_quirks.hpp
@@ -152,6 +152,54 @@ struct HostQuirks {
     // AU v3 cross-host
     bool au_v3_bypass_dual_tracking = false;           ///< row 21
     bool au_v3_host_id_from_wrapper = false;           ///< row 22
+
+    // iPlug2-audit batch 2026-05-26: 4 additional lessons (Reaper AU v3
+    // in-process, Studio One restart-component threading, Digital
+    // Performer controller-swap, Cubase 13+ MIDI CC ID stability).
+
+    /// Reaper's AU v3 host is **in-process** (it creates the
+    /// `AUAudioUnit` on the main thread via
+    /// `createAudioUnitWithComponentDescription`), unlike Logic /
+    /// GarageBand which run AU v3 plug-ins out-of-process. Setting the
+    /// view controller's `preferredContentSize` only from `viewDidLoad`
+    /// is too late on the in-process path — the editor opens at the
+    /// extension's default size and snaps to the requested size one
+    /// paint cycle later. AU v3 adapters must additionally set
+    /// `preferredContentSize` synchronously in `audioUnitInitialized`
+    /// (the in-process entry point); setting it twice is harmless on
+    /// the OOP path. Layered on top of the REAPER VST3 dispatch via
+    /// `apply_reaper_auv3_in_process`.
+    bool reaper_auv3_in_process_preferred_size_sync = false;
+
+    /// Studio One serializes `IComponentHandler::restartComponent`
+    /// notifications through a non-thread-safe lane: audio-thread calls
+    /// can deadlock the host or be dropped silently. The VST3 adapter
+    /// must marshal restart-component calls (especially
+    /// `kLatencyChanged`, which is the most common audio-thread
+    /// emitter) to the UI thread when this flag is set. Cubase /
+    /// Nuendo / Reaper accept the call from any thread.
+    bool studio_one_restart_component_ui_thread = false;
+
+    /// Digital Performer (MOTU) revives the edit controller on
+    /// preset-load / project-import paths without re-querying the
+    /// previously published parameter list. Plug-ins that mutate the
+    /// parameter set via `restartComponent(kParamValuesChanged |
+    /// kParamTitlesChanged)` end up with stale labels in DP's
+    /// automation lane. The VST3 adapter must layer an additional
+    /// `kReloadComponent` notification onto the standard restart bundle
+    /// when the detected host is Digital Performer; Cubase / Logic /
+    /// Reaper do not require this.
+    bool digital_performer_param_list_reload = false;
+
+    /// Cubase 13+ / Nuendo 13+ bind project automation lanes to the
+    /// VST3 MIDI CC parameter IDs at save-time and refuse to re-map
+    /// them on reload. Plug-ins that synthesize CC parameter IDs from
+    /// dynamic state (e.g. preset-driven parameter counts) will see
+    /// automation lanes orphaned on the 13.x line. The VST3 adapter
+    /// must derive CC parameter IDs from a stable hash (not the
+    /// runtime parameter index) when this flag is set. Cubase 12 was
+    /// forgiving; the flag stays off on 12 and earlier.
+    bool cubase13_midi_cc_param_id_stable = false;
 };
 
 /// Per-quirk validation status, parallel to `HostQuirks`.
@@ -242,6 +290,17 @@ struct HostQuirksMeta {
 
     QuirkStatus au_v3_bypass_dual_tracking = QuirkStatus::Speculative;
     QuirkStatus au_v3_host_id_from_wrapper = QuirkStatus::Speculative;
+
+    // iPlug2-audit batch 2026-05-26: documented from each host's
+    // vendor docs + reproducer issue (Pulp #3044 / #3045 / #3046 /
+    // #3047), no in-tree bench yet → LessonOnly. Cubase 13+ MIDI CC
+    // ID stability lands as Speculative because it has a per-host
+    // header + per-symptom isolation test, mirroring the rest of the
+    // Cubase rows.
+    QuirkStatus reaper_auv3_in_process_preferred_size_sync = QuirkStatus::LessonOnly;
+    QuirkStatus studio_one_restart_component_ui_thread = QuirkStatus::LessonOnly;
+    QuirkStatus digital_performer_param_list_reload = QuirkStatus::LessonOnly;
+    QuirkStatus cubase13_midi_cc_param_id_stable = QuirkStatus::Speculative;
 };
 
 /// Authoritative meta for the in-tree `HostQuirks`. Plugin authors and

--- a/core/format/include/pulp/format/host_quirks/cubase.hpp
+++ b/core/format/include/pulp/format/host_quirks/cubase.hpp
@@ -15,10 +15,19 @@
 ///     must validate the actual read count rather than trusting the
 ///     host-reported size.
 ///
+/// Cubase 13+ vintage — 2026-05-26 iPlug2-audit batch (Pulp #3047):
+///   * MIDI CC parameter IDs must stay stable across project reloads;
+///     Cubase 12 was forgiving but Cubase 13 binds automation lanes
+///     to the IDs at save-time. Plug-ins that synthesize CC IDs from
+///     dynamic state need a stable-hash derivation. `Speculative`
+///     tier — per-host header + isolation test in place, in-DAW bench
+///     evidence still pending.
+///
 /// Version dispatch: Cubase 10 quirks fire on `major >= 10`; the
 /// Cubase 9 state-blob quirk only fires on the 9.x line (NOT on
-/// Cubase 10+) since 10 fixed the underlying stream bug. Cubase
-/// `HostVersion{0,0,0}` (unknown) intentionally leaves both bands
+/// Cubase 10+) since 10 fixed the underlying stream bug; the Cubase
+/// 13 MIDI CC ID stability quirk fires on `major >= 13` only. Cubase
+/// `HostVersion{0,0,0}` (unknown) intentionally leaves every band
 /// off — the adapter falls back to spec-compliant defaults.
 ///
 /// Nuendo is treated as Cubase in the dispatch table
@@ -48,6 +57,18 @@ inline void apply_cubase(HostQuirks& q, HostVersion v) {
     // path stays off there.
     if (v.is_at_least(9, 0) && v.is_before(10, 0)) {
         q.cubase9_state_blob_size_validation = true;
+    }
+    // 2026-05-26 iPlug2-audit batch (Pulp #3047) — Cubase 13+ tightened
+    // its handling of VST3 MIDI CC parameter IDs: project automation
+    // lanes are bound to the parameter IDs at save-time and the host
+    // refuses to re-map them on reload. Plug-ins that synthesize CC
+    // parameter IDs from dynamic state (e.g. preset-driven parameter
+    // counts) will see automation lanes orphaned on the 13.x line. The
+    // VST3 adapter must derive CC parameter IDs from a stable hash
+    // (not the runtime parameter index) when this flag is set. Cubase
+    // 12 was forgiving so the flag stays off on 12.x and earlier.
+    if (v.is_at_least(13, 0)) {
+        q.cubase13_midi_cc_param_id_stable = true;
     }
 }
 

--- a/core/format/include/pulp/format/host_quirks/digital_performer.hpp
+++ b/core/format/include/pulp/format/host_quirks/digital_performer.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+/// @file host_quirks/digital_performer.hpp
+/// Per-host quirks for MOTU Digital Performer.
+///
+/// Digital Performer revives the edit controller on preset-load /
+/// project-import paths without re-querying the previously published
+/// parameter list. Plug-ins that mutate the parameter set via
+/// `restartComponent(kParamValuesChanged | kParamTitlesChanged)` end up
+/// with stale labels and stale value-domain bounds in DP's automation
+/// lane.
+///
+/// The clean-room fix layers an additional `kReloadComponent`
+/// notification onto the standard restart bundle when the detected
+/// host is Digital Performer. Cubase / Logic / Reaper do not require
+/// this — they re-query the parameter list whenever the edit
+/// controller is recreated.
+///
+/// ## Rows covered
+///
+/// * `digital_performer_param_list_reload` — emit
+///   `IComponentHandler::kReloadComponent` on top of the standard
+///   `kParamValuesChanged | kParamTitlesChanged` notification when the
+///   plug-in mutates its parameter list mid-session.
+///
+/// ## Version handling
+///
+/// Documented across Digital Performer 10.x and 11.x; no fixed release
+/// announced. `apply_digital_performer` fires the flag
+/// unconditionally.
+///
+/// ## Tier status
+///
+/// `LessonOnly` as of the 2026-05-26 iPlug2-audit batch — documented
+/// from Steinberg's VST3 SDK + MOTU Digital Performer Plug-Ins Guide,
+/// no in-tree bench yet. Promote to `Speculative` after the
+/// per-symptom isolation tests ship; promote to `Validated` after
+/// Digital Performer bench evidence lands.
+///
+/// **Reference-Lineage**: cleanroom reproducer=#3046
+/// docs=https://steinbergmedia.github.io/vst3_dev_portal/pages/Technical+Documentation/Workflow+Diagrams/Edit+Controller+Call+Sequence.html
+
+#include <pulp/format/host_quirks.hpp>
+#include <pulp/format/host_version.hpp>
+
+namespace pulp::format::host_quirks {
+
+/// Populate Digital Performer host-gated flags onto `q`. `v` is unused
+/// today (the only flag here is version-invariant) but kept for
+/// signature uniformity with other per-host modules.
+inline void apply_digital_performer(HostQuirks& q, HostVersion /*v*/) {
+    q.digital_performer_param_list_reload = true;
+}
+
+}  // namespace pulp::format::host_quirks

--- a/core/format/include/pulp/format/host_quirks/reaper.hpp
+++ b/core/format/include/pulp/format/host_quirks/reaper.hpp
@@ -133,4 +133,26 @@ inline void apply_reaper_keyboard(HostQuirks& q, HostVersion /*v*/) {
     q.reaper_keyboard_only_space = true;
 }
 
+/// Populate REAPER AU v3 in-process `preferredContentSize` lesson onto
+/// `q`. Layered on top of `apply_reaper(...)` so the 2026-05-26
+/// iPlug2-audit lesson can stay at a different validation tier
+/// (LessonOnly today) without changing the rest of the REAPER
+/// dispatch.
+///
+/// REAPER's AU v3 host is in-process: it creates the `AUAudioUnit` on
+/// the main thread via `createAudioUnitWithComponentDescription`,
+/// rather than the out-of-process path Logic / GarageBand use. Setting
+/// `preferredContentSize` only from `viewDidLoad` is too late on that
+/// path — the editor opens at the extension's default size and snaps
+/// to the requested size one paint cycle later. AU v3 adapters must
+/// additionally set `preferredContentSize` synchronously in
+/// `audioUnitInitialized`; setting it twice is harmless on the OOP
+/// path.
+///
+/// Reference: https://developer.apple.com/documentation/audiotoolbox/auaudiounit
+/// (in-process host extension contract) + Pulp issue #3044.
+inline void apply_reaper_auv3_in_process(HostQuirks& q, HostVersion /*v*/) {
+    q.reaper_auv3_in_process_preferred_size_sync = true;
+}
+
 }  // namespace pulp::format::host_quirks

--- a/core/format/include/pulp/format/host_quirks/studio_one.hpp
+++ b/core/format/include/pulp/format/host_quirks/studio_one.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+/// @file host_quirks/studio_one.hpp
+/// Per-host quirks for PreSonus Studio One.
+///
+/// Studio One's VST3 host serializes `IComponentHandler::restartComponent`
+/// notifications through a non-thread-safe lane: calls that arrive from
+/// the audio thread (most commonly `kLatencyChanged` from a delay-line
+/// resize) can deadlock the host or be silently dropped. Cubase /
+/// Nuendo / Reaper accept the call from any thread; Studio One does
+/// not.
+///
+/// The clean-room fix marshals `restartComponent` calls to the UI
+/// thread when the host is detected as Studio One. The dispatch lives
+/// here; the VST3 adapter consults the flag to decide whether to
+/// post the notification through `core/events::EventLoop` rather than
+/// invoking the host handler directly.
+///
+/// ## Rows covered
+///
+/// * `studio_one_restart_component_ui_thread` — UI-thread restart
+///   marshalling for any audio-thread-emitted notification (the field
+///   primarily targets `kLatencyChanged` but the adapter can layer on
+///   the same defense for `kParamValuesChanged` and friends).
+///
+/// ## Version handling
+///
+/// The threading contract appears in every Studio One release Pulp
+/// has surveyed (5.x and 6.x). `apply_studio_one` fires the flag
+/// unconditionally; if a future Studio One release switches to a
+/// thread-safe restart-component lane, add an `is_before(major,
+/// minor)` guard at that point.
+///
+/// ## Tier status
+///
+/// `LessonOnly` as of the 2026-05-26 iPlug2-audit batch — documented
+/// from Steinberg's VST3 SDK threading contract + PreSonus user-forum
+/// reports, no in-tree bench yet. Promote to `Speculative` after the
+/// per-symptom isolation tests ship; promote to `Validated` after
+/// Studio One bench evidence lands.
+///
+/// **Reference-Lineage**: cleanroom reproducer=#3045
+/// docs=https://steinbergmedia.github.io/vst3_dev_portal/pages/Technical+Documentation/Workflow+Diagrams/Edit+Controller+Call+Sequence.html
+
+#include <pulp/format/host_quirks.hpp>
+#include <pulp/format/host_version.hpp>
+
+namespace pulp::format::host_quirks {
+
+/// Populate Studio One host-gated flags onto `q`. `v` is unused today
+/// (the only flag here is version-invariant) but kept for signature
+/// uniformity with other per-host modules.
+inline void apply_studio_one(HostQuirks& q, HostVersion /*v*/) {
+    q.studio_one_restart_component_ui_thread = true;
+}
+
+}  // namespace pulp::format::host_quirks

--- a/core/format/include/pulp/format/host_type.hpp
+++ b/core/format/include/pulp/format/host_type.hpp
@@ -25,6 +25,7 @@ enum class HostType {
     AudacityTenacity,
     Ardour,
     Mixbus32C,   // Harrison Mixbus 32C — Ardour derivative with separate quirk profile
+    DigitalPerformer, // MOTU Digital Performer — VST3 controller-swap quirk profile
     Standalone,  // Pulp standalone host
     Other
 };

--- a/core/format/src/host_quirks.cpp
+++ b/core/format/src/host_quirks.cpp
@@ -5,10 +5,12 @@
 #include <pulp/format/host_quirks/auv3_cross_host.hpp>
 #include <pulp/format/host_quirks/bitwig.hpp>
 #include <pulp/format/host_quirks/cubase.hpp>
+#include <pulp/format/host_quirks/digital_performer.hpp>
 #include <pulp/format/host_quirks/fl_studio.hpp>
 #include <pulp/format/host_quirks/logic_pro.hpp>
 #include <pulp/format/host_quirks/pro_tools.hpp>
 #include <pulp/format/host_quirks/reaper.hpp>
+#include <pulp/format/host_quirks/studio_one.hpp>
 #include <pulp/format/host_quirks/wavelab.hpp>
 #include <pulp/format/host_version.hpp>
 
@@ -35,6 +37,12 @@ void apply_reaper_quirks(HostQuirks& q, HostVersion v) {
     // separate factory so its LessonOnly tier can evolve independently
     // of the rest of the REAPER dispatch (Speculative).
     host_quirks::apply_reaper_keyboard(q, v);
+    // 2026-05-26 iPlug2-audit batch (Pulp #3044): REAPER hosts AU v3
+    // in-process and needs preferredContentSize set synchronously
+    // during audioUnitInitialized. Layered via a separate factory so
+    // the LessonOnly tier can evolve independently of the rest of the
+    // REAPER dispatch.
+    host_quirks::apply_reaper_auv3_in_process(q, v);
 }
 
 void apply_pro_tools_quirks(HostQuirks& q, HostVersion v) {
@@ -159,6 +167,12 @@ void apply_filter(HostQuirks& q, QuirkFilter filter) {
     PULP_QUIRK_FILTER_FIELD(au_v3_bypass_dual_tracking);
     PULP_QUIRK_FILTER_FIELD(au_v3_host_id_from_wrapper);
 
+    // 2026-05-26 iPlug2-audit batch (Pulp #3044 / #3045 / #3046 / #3047).
+    PULP_QUIRK_FILTER_FIELD(reaper_auv3_in_process_preferred_size_sync);
+    PULP_QUIRK_FILTER_FIELD(studio_one_restart_component_ui_thread);
+    PULP_QUIRK_FILTER_FIELD(digital_performer_param_list_reload);
+    PULP_QUIRK_FILTER_FIELD(cubase13_midi_cc_param_id_stable);
+
 #undef PULP_QUIRK_FILTER_FIELD
 }
 
@@ -185,8 +199,10 @@ HostQuirks make_quirks_for(HostType type, HostVersion version) {
         case HostType::ProTools:      apply_pro_tools_quirks(q, version); break;
         case HostType::Ardour:        host_quirks::apply_ardour(q, version); break;
         case HostType::Mixbus32C:     host_quirks::apply_mixbus32c(q, version); break;
-        // StudioOne / DigitalPerformer / etc. land their flags here
-        // when the per-host fixes ship in later batches.
+        case HostType::StudioOne:     host_quirks::apply_studio_one(q, version); break;
+        case HostType::DigitalPerformer:
+            host_quirks::apply_digital_performer(q, version);
+            break;
         default: break;
     }
     return q;

--- a/core/format/src/host_type.cpp
+++ b/core/format/src/host_type.cpp
@@ -60,6 +60,13 @@ HostType host_type_from_process_name(std::string_view process_name) {
     if (name.find("bitwig") != std::string::npos) return HostType::Bitwig;
     if (name.find("maschine") != std::string::npos) return HostType::Maschine;
     if (name.find("audacity") != std::string::npos || name.find("tenacity") != std::string::npos) return HostType::AudacityTenacity;
+    // MOTU Digital Performer's macOS process is "DP11" / "DP10" /
+    // "Digital Performer"; the Windows build is just "Digital
+    // Performer.exe". Match the canonical name first, then the
+    // short DP-prefixed form. Pulp #3046.
+    if (name.find("digital performer") != std::string::npos
+        || name.find("digitalperformer") != std::string::npos
+        || name == "dp11" || name == "dp10" || name == "dp12") return HostType::DigitalPerformer;
     // Mixbus32C must be checked before Ardour: Harrison Mixbus 32C is an
     // Ardour derivative whose process name carries the "mixbus" /
     // "mixbus 32c" / "mixbus32c" substring while sometimes also retaining
@@ -138,6 +145,7 @@ std::string host_type_name(HostType type) {
         case HostType::AudacityTenacity: return "Audacity/Tenacity";
         case HostType::Ardour: return "Ardour";
         case HostType::Mixbus32C: return "Harrison Mixbus 32C";
+        case HostType::DigitalPerformer: return "Digital Performer";
         case HostType::Standalone: return "Pulp Standalone";
         case HostType::Other: return "Other";
         case HostType::Unknown: return "Unknown";

--- a/test/test_host_quirks.cpp
+++ b/test/test_host_quirks.cpp
@@ -1,7 +1,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/format/host_quirks.hpp>
+#include <pulp/format/host_quirks/cubase.hpp>
+#include <pulp/format/host_quirks/digital_performer.hpp>
 #include <pulp/format/host_quirks/pro_tools.hpp>
 #include <pulp/format/host_quirks/reaper.hpp>
+#include <pulp/format/host_quirks/studio_one.hpp>
 #include <pulp/format/host_type.hpp>
 
 #include <array>
@@ -1049,3 +1052,204 @@ TEST_CASE("detect_quirks respects PULP_HOST_QUIRKS_DEFAULT_POLICY compile-time p
     REQUIRE(q.silence_unsupported_bus_arrangements == true);
 #endif
 }
+
+// ── 2026-05-26 iPlug2-audit batch — 4 additional clean-room lessons
+//    sourced from each host's public vendor documentation + a Pulp
+//    reproducer issue. Each row is wired through a dedicated per-host
+//    factory (or layered on top of an existing one) so its validation
+//    tier can evolve independently. ──
+
+// REAPER AU v3 in-process preferredContentSize lesson (Pulp #3044).
+
+TEST_CASE("apply_reaper_auv3_in_process fires the preferredContentSize-sync lesson",
+          "[format][host-quirks][reaper][isolation][issue-3044]") {
+    HostQuirks q;
+    host_quirks::apply_reaper_auv3_in_process(q, HostVersion{7, 20});
+    REQUIRE(q.reaper_auv3_in_process_preferred_size_sync == true);
+    // Standalone factory must not touch the main 6 REAPER rows.
+    REQUIRE(q.reaper_vst3_gesture_ordering == false);
+    REQUIRE(q.reaper_keyboard_only_space == false);
+}
+
+TEST_CASE("apply_reaper alone does not flip the AU v3 in-process lesson",
+          "[format][host-quirks][reaper][isolation][issue-3044]") {
+    // Tier isolation: the main 6 REAPER rows (Speculative) must stay
+    // composable independently of the iPlug2-audit lesson (LessonOnly).
+    HostQuirks q;
+    host_quirks::apply_reaper(q, HostVersion{7, 20});
+    REQUIRE(q.reaper_auv3_in_process_preferred_size_sync == false);
+}
+
+TEST_CASE("make_quirks_for Reaper layers the AU v3 in-process lesson on top",
+          "[format][host-quirks][reaper][issue-3044]") {
+    auto q = make_quirks_for(HostType::Reaper, HostVersion{7, 20});
+    REQUIRE(q.reaper_auv3_in_process_preferred_size_sync == true);
+    // Cross-host bleed: non-REAPER hosts must stay clean.
+    auto cubase = make_quirks_for(HostType::Cubase, HostVersion{12, 0});
+    REQUIRE(cubase.reaper_auv3_in_process_preferred_size_sync == false);
+    auto logic = make_quirks_for(HostType::LogicPro, HostVersion{11, 0});
+    REQUIRE(logic.reaper_auv3_in_process_preferred_size_sync == false);
+}
+
+// Studio One restart-component UI-thread lesson (Pulp #3045).
+
+TEST_CASE("apply_studio_one fires the restart-component UI-thread lesson",
+          "[format][host-quirks][studio-one][isolation][issue-3045]") {
+    HostQuirks q;
+    host_quirks::apply_studio_one(q, HostVersion{6, 5});
+    REQUIRE(q.studio_one_restart_component_ui_thread == true);
+    // No cross-host bleed.
+    REQUIRE(q.cubase10_async_view_resize_queue == false);
+    REQUIRE(q.live_vst3_canresize_ignore == false);
+    REQUIRE(q.wavelab_state_blob_fallback == false);
+}
+
+TEST_CASE("apply_studio_one fires the lesson regardless of version",
+          "[format][host-quirks][studio-one][issue-3045]") {
+    // Version-invariant: the threading contract is the same across 5.x
+    // and 6.x.
+    HostQuirks q;
+    host_quirks::apply_studio_one(q, HostVersion{});
+    REQUIRE(q.studio_one_restart_component_ui_thread == true);
+    HostQuirks q5;
+    host_quirks::apply_studio_one(q5, HostVersion{5, 5});
+    REQUIRE(q5.studio_one_restart_component_ui_thread == true);
+}
+
+TEST_CASE("make_quirks_for Studio One routes through the per-host header",
+          "[format][host-quirks][studio-one][issue-3045]") {
+    auto q = make_quirks_for(HostType::StudioOne, HostVersion{6, 5});
+    REQUIRE(q.studio_one_restart_component_ui_thread == true);
+    // Cheap defenses still on, no cross-host bleed.
+    REQUIRE(q.synthesize_bypass_parameter == true);
+    REQUIRE(q.reaper_keyboard_only_space == false);
+    REQUIRE(q.fl_studio_setactive_process_mutex == false);
+    // Other hosts must NOT pick up the Studio One flag.
+    auto cubase = make_quirks_for(HostType::Cubase, HostVersion{12, 0});
+    REQUIRE(cubase.studio_one_restart_component_ui_thread == false);
+    auto reaper = make_quirks_for(HostType::Reaper, HostVersion{7, 20});
+    REQUIRE(reaper.studio_one_restart_component_ui_thread == false);
+}
+
+// Digital Performer param-list reload lesson (Pulp #3046).
+
+TEST_CASE("apply_digital_performer fires the param-list reload lesson",
+          "[format][host-quirks][digital-performer][isolation][issue-3046]") {
+    HostQuirks q;
+    host_quirks::apply_digital_performer(q, HostVersion{11, 0});
+    REQUIRE(q.digital_performer_param_list_reload == true);
+    // No cross-host bleed.
+    REQUIRE(q.cubase10_async_view_resize_queue == false);
+    REQUIRE(q.studio_one_restart_component_ui_thread == false);
+}
+
+TEST_CASE("make_quirks_for DigitalPerformer routes through the per-host header",
+          "[format][host-quirks][digital-performer][issue-3046]") {
+    auto q = make_quirks_for(HostType::DigitalPerformer, HostVersion{11, 0});
+    REQUIRE(q.digital_performer_param_list_reload == true);
+    // Cheap defenses still on, no cross-host bleed.
+    REQUIRE(q.synthesize_bypass_parameter == true);
+    REQUIRE(q.reaper_keyboard_only_space == false);
+    REQUIRE(q.studio_one_restart_component_ui_thread == false);
+    // Other hosts must NOT pick up the DP flag.
+    auto cubase = make_quirks_for(HostType::Cubase, HostVersion{12, 0});
+    REQUIRE(cubase.digital_performer_param_list_reload == false);
+    auto reaper = make_quirks_for(HostType::Reaper, HostVersion{7, 20});
+    REQUIRE(reaper.digital_performer_param_list_reload == false);
+}
+
+TEST_CASE("apply_digital_performer is version-invariant",
+          "[format][host-quirks][digital-performer][issue-3046]") {
+    HostQuirks q;
+    host_quirks::apply_digital_performer(q, HostVersion{});
+    REQUIRE(q.digital_performer_param_list_reload == true);
+    HostQuirks q12;
+    host_quirks::apply_digital_performer(q12, HostVersion{12, 0});
+    REQUIRE(q12.digital_performer_param_list_reload == true);
+}
+
+// Cubase 13+ MIDI CC parameter ID stability (Pulp #3047).
+
+TEST_CASE("apply_cubase fires the Cubase 13+ MIDI CC stability flag on 13+",
+          "[format][host-quirks][cubase][issue-3047]") {
+    HostQuirks q;
+    host_quirks::apply_cubase(q, HostVersion{13, 0});
+    REQUIRE(q.cubase13_midi_cc_param_id_stable == true);
+    // Existing Cubase 10+ flags still fire (layering doesn't clobber).
+    REQUIRE(q.cubase10_async_view_resize_queue == true);
+}
+
+TEST_CASE("apply_cubase keeps the Cubase 13+ MIDI CC stability flag off on 12.x",
+          "[format][host-quirks][cubase][issue-3047]") {
+    HostQuirks q;
+    host_quirks::apply_cubase(q, HostVersion{12, 0});
+    REQUIRE(q.cubase13_midi_cc_param_id_stable == false);
+    // Cubase 12 still gets all of the 10+ flags.
+    REQUIRE(q.cubase10_async_view_resize_queue == true);
+}
+
+TEST_CASE("apply_cubase keeps the Cubase 13+ MIDI CC stability flag off on 11.x and 10.x",
+          "[format][host-quirks][cubase][issue-3047]") {
+    HostQuirks q10;
+    host_quirks::apply_cubase(q10, HostVersion{10, 5});
+    REQUIRE(q10.cubase13_midi_cc_param_id_stable == false);
+    HostQuirks q11;
+    host_quirks::apply_cubase(q11, HostVersion{11, 0});
+    REQUIRE(q11.cubase13_midi_cc_param_id_stable == false);
+}
+
+TEST_CASE("make_quirks_for Nuendo 13 inherits the Cubase 13+ MIDI CC stability flag",
+          "[format][host-quirks][cubase][issue-3047]") {
+    // Nuendo dispatches through apply_cubase, so the Nuendo 13+ line
+    // inherits row 3047 automatically.
+    auto q = make_quirks_for(HostType::Nuendo, HostVersion{13, 0});
+    REQUIRE(q.cubase13_midi_cc_param_id_stable == true);
+}
+
+TEST_CASE("Cubase 13+ MIDI CC stability flag stays off for non-Cubase hosts",
+          "[format][host-quirks][cubase][isolation][issue-3047]") {
+    auto reaper = make_quirks_for(HostType::Reaper, HostVersion{7, 20});
+    REQUIRE(reaper.cubase13_midi_cc_param_id_stable == false);
+    auto live = make_quirks_for(HostType::AbletonLive, HostVersion{12, 0});
+    REQUIRE(live.cubase13_midi_cc_param_id_stable == false);
+    auto studio_one = make_quirks_for(HostType::StudioOne, HostVersion{6, 5});
+    REQUIRE(studio_one.cubase13_midi_cc_param_id_stable == false);
+    auto dp = make_quirks_for(HostType::DigitalPerformer, HostVersion{11, 0});
+    REQUIRE(dp.cubase13_midi_cc_param_id_stable == false);
+}
+
+// Tier-filter coverage for the new flags.
+
+TEST_CASE("validated-only filter zeroes the 4 new iPlug2-audit lessons",
+          "[format][host-quirks][tiers][issue-3044][issue-3045][issue-3046][issue-3047]") {
+    // All 4 land at LessonOnly/Speculative — none should survive a
+    // validated-only filter.
+    auto reaper = make_quirks_for_validated_only(HostType::Reaper, HostVersion{7, 20});
+    REQUIRE(reaper.reaper_auv3_in_process_preferred_size_sync == false);
+    auto studio_one = make_quirks_for_validated_only(HostType::StudioOne, HostVersion{6, 5});
+    REQUIRE(studio_one.studio_one_restart_component_ui_thread == false);
+    auto dp = make_quirks_for_validated_only(HostType::DigitalPerformer, HostVersion{11, 0});
+    REQUIRE(dp.digital_performer_param_list_reload == false);
+    auto cubase = make_quirks_for_validated_only(HostType::Cubase, HostVersion{13, 0});
+    REQUIRE(cubase.cubase13_midi_cc_param_id_stable == false);
+}
+
+TEST_CASE("kHostQuirksMeta tags the 4 new iPlug2-audit rows correctly",
+          "[format][host-quirks][tiers][issue-3044][issue-3045][issue-3046][issue-3047]") {
+    STATIC_REQUIRE(kHostQuirksMeta.reaper_auv3_in_process_preferred_size_sync
+                   == QuirkStatus::LessonOnly);
+    STATIC_REQUIRE(kHostQuirksMeta.studio_one_restart_component_ui_thread
+                   == QuirkStatus::LessonOnly);
+    STATIC_REQUIRE(kHostQuirksMeta.digital_performer_param_list_reload
+                   == QuirkStatus::LessonOnly);
+    // Cubase 13+ MIDI CC ID stability lands as Speculative because it
+    // has a per-host header + per-symptom isolation tests, mirroring
+    // the rest of the Cubase rows.
+    STATIC_REQUIRE(kHostQuirksMeta.cubase13_midi_cc_param_id_stable
+                   == QuirkStatus::Speculative);
+}
+
+// Header includes for the new per-host modules — kept inline at the
+// bottom rather than mixed with the original includes so the diff
+// stays localized to the batch.
+

--- a/test/test_host_version.cpp
+++ b/test/test_host_version.cpp
@@ -86,3 +86,27 @@ TEST_CASE("host_type_from_process_name still classifies vanilla Ardour as Ardour
 TEST_CASE("host_type_name covers Mixbus32C", "[format][host-type][mixbus32c]") {
     REQUIRE(host_type_name(HostType::Mixbus32C) == "Harrison Mixbus 32C");
 }
+
+// ── 2026-05-26 iPlug2-audit batch — Digital Performer classifier
+//    coverage. MOTU's macOS process is "Digital Performer" / "DP11" /
+//    "DP10"; Windows builds expose "Digital Performer.exe". The
+//    classifier matches the canonical name first, then the short
+//    DP-prefixed form. Pulp #3046. ──
+
+TEST_CASE("host_type_from_process_name classifies Digital Performer variants",
+          "[format][host-type][digital-performer][issue-3046]") {
+    REQUIRE(host_type_from_process_name("Digital Performer")
+            == HostType::DigitalPerformer);
+    REQUIRE(host_type_from_process_name("/Applications/Digital Performer.app/Contents/MacOS/DP11")
+            == HostType::DigitalPerformer);
+    REQUIRE(host_type_from_process_name("DP11") == HostType::DigitalPerformer);
+    REQUIRE(host_type_from_process_name("DP10") == HostType::DigitalPerformer);
+    REQUIRE(host_type_from_process_name("DP12") == HostType::DigitalPerformer);
+    REQUIRE(host_type_from_process_name("digitalperformer")
+            == HostType::DigitalPerformer);
+}
+
+TEST_CASE("host_type_name covers DigitalPerformer",
+          "[format][host-type][digital-performer][issue-3046]") {
+    REQUIRE(host_type_name(HostType::DigitalPerformer) == "Digital Performer");
+}


### PR DESCRIPTION
## Summary

Clean-room batch of 4 additional iPlug2-audit DAW quirks, sourced from each host's public vendor docs + reproducer issues filed during the 2026-05-26 audit pass. No reference framework source transcribed.

**New `HostQuirks` flags (default false, populated per-host):**

- `reaper_auv3_in_process_preferred_size_sync` — REAPER hosts AU v3 in-process and needs `preferredContentSize` set synchronously in `audioUnitInitialized`. Layered onto REAPER dispatch via `apply_reaper_auv3_in_process`. LessonOnly. (Pulp #3044)
- `studio_one_restart_component_ui_thread` — Studio One's `restartComponent` lane is not thread-safe; audio-thread calls must be deferred to the UI thread. New `apply_studio_one` per-host header. LessonOnly. (Pulp #3045)
- `digital_performer_param_list_reload` — Digital Performer skips re-querying the parameter list on controller swap; plug-ins must layer `kReloadComponent` onto the standard restart bundle. New `apply_digital_performer` per-host header. LessonOnly. (Pulp #3046)
- `cubase13_midi_cc_param_id_stable` — Cubase 13+ binds project automation lanes to MIDI CC parameter IDs at save-time; plug-ins must derive CC IDs from a stable hash. Extends the existing Cubase header with a `>= 13.0` version guard. Speculative (per-host header + isolation tests in place, bench evidence pending). (Pulp #3047)

**Other changes:**

- New `HostType::DigitalPerformer` enum value + classifier branch (matches \"Digital Performer\" / \"DP10\" / \"DP11\" / \"DP12\") + `host_type_name` entry.
- `apply_filter()` handles the 4 new flags so validated-only / off filters zero them correctly.
- 16 new Catch2 cases (per-symptom isolation, cross-host bleed, validated-only filter, meta tier checks).
- 2 new HostType classifier cases for Digital Performer.
- Planning log updated at `planning/host-quirks-log.md` (submodule pointer bumped).

**License hygiene:**

Every commit under `core/format/host_quirks*` carries the
`Reference-Lineage: cleanroom reproducer=#<issue> docs=<url>` trailer
required by CI. Reproducer issues #3044-#3047 + each host's public
vendor doc URL.

## Test plan

- [x] `./build/test/pulp-test-host-quirks` — 90 cases, 418 assertions (16 new cases / ~40 new assertions for this batch).
- [x] `./build/test/pulp-test-host-version` — 10 cases, 41 assertions (2 new cases for Digital Performer classifier + display name).
- [x] Release build on macOS arm64 (`-DPULP_ENABLE_GPU=OFF`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)