### PR TITLE
test(coverage): cover requested platform and tool edges

### DIFF
--- a/apple/Tests/PulpSwiftTests/PulpMotionProbeTests.swift
+++ b/apple/Tests/PulpSwiftTests/PulpMotionProbeTests.swift
@@ -53,6 +53,21 @@ final class PulpMotionProbeTests: XCTestCase {
         XCTAssertEqual(recorder.detachedTraceIds, [42])
     }
 
+    func testGeometryProbeDeinitDetachesRegisteredTrace() {
+        let recorder = MotionBackendRecorder()
+        recorder.nextTraceId = 99
+        PulpMotionRuntime.installTestBackend(recorder.backend)
+
+        var probe: PulpMotionGeometryProbe? =
+            PulpMotionGeometryProbe(view: "Deinit", fps: 30)
+        XCTAssertTrue(probe?.isAttached == true)
+        XCTAssertEqual(recorder.detachedTraceIds, [])
+
+        probe = nil
+
+        XCTAssertEqual(recorder.detachedTraceIds, [99])
+    }
+
     func testGeometryProbeRegistrationDeclineClearsAmbientProvenance() {
         let recorder = MotionBackendRecorder()
         recorder.nextTraceId = 0

--- a/test/test_audio_thumbnail.cpp
+++ b/test/test_audio_thumbnail.cpp
@@ -17,6 +17,7 @@
 #include <pulp/audio/audio_thumbnail.hpp>
 #include <pulp/view/widgets.hpp>
 
+#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <filesystem>
@@ -55,8 +56,10 @@ AudioFileData make_sine(uint32_t sample_rate,
 
 std::filesystem::path unique_wav_path() {
     static int counter = 0;
+    const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
     auto stem = "pulp_test_thumbnail_"
               + std::to_string(reinterpret_cast<std::uintptr_t>(&counter))
+              + "_" + std::to_string(tick)
               + "_" + std::to_string(counter++) + ".wav";
     return std::filesystem::temp_directory_path() / stem;
 }
@@ -286,8 +289,10 @@ namespace {
 
 std::filesystem::path unique_cache_dir() {
     static int counter = 0;
+    const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
     auto name = "pulp_test_thumbcache_"
               + std::to_string(reinterpret_cast<std::uintptr_t>(&counter))
+              + "_" + std::to_string(tick)
               + "_" + std::to_string(counter++);
     auto p = std::filesystem::temp_directory_path() / name;
     std::error_code ec;

--- a/test/test_audio_tools.cpp
+++ b/test/test_audio_tools.cpp
@@ -252,6 +252,17 @@ TEST_CASE("audio model registry preserves URL bytes and rejects partial protocol
     REQUIRE(resolve_checkpoint_url("hf://org/repo/").empty());
 }
 
+TEST_CASE("audio model registry preserves concrete Hugging Face file paths",
+          "[audio][tools][model-registry][coverage][requested]") {
+    REQUIRE(resolve_checkpoint_url(" hf://org/repo/model.pt").empty());
+    REQUIRE(resolve_checkpoint_url("hf://org/repo//")
+            == "https://huggingface.co/org/repo/resolve/main//");
+    REQUIRE(resolve_checkpoint_url("hf://org/repo/\t")
+            == "https://huggingface.co/org/repo/resolve/main/\t");
+    REQUIRE(resolve_checkpoint_url("hf://org/repo/model.pt")
+            == "https://huggingface.co/org/repo/resolve/main/model.pt");
+}
+
 TEST_CASE("audio model store reads legacy metadata and malformed records fail closed",
           "[audio][tools][issue-643]") {
     TempDir temp;
@@ -1582,7 +1593,7 @@ TEST_CASE("excerpt find reports unsupported inputs after model resolution",
 }
 
 TEST_CASE("excerpt find records unreadable WAV inputs without writing dry-run bundles",
-          "[audio][tools][excerpt-service][coverage]") {
+          "[audio][tools][excerpt-service][coverage][requested]") {
     TempDir temp;
     auto checkpoint = install_active_clap_model(temp);
     auto corrupt_wav = temp.path / "corrupt.wav";

--- a/test/test_cli_import_detect.cpp
+++ b/test/test_cli_import_detect.cpp
@@ -99,6 +99,33 @@ TEST_CASE("parse_compat_json rejects malformed input", "[cli][import-detect][iss
     CHECK_FALSE(det::parse_compat_json("{\"compat-schema-version\":\"0.2\"}").has_value());
 }
 
+TEST_CASE("parse_compat_json preserves sources with empty detected formats",
+          "[cli][import-detect][coverage][requested]") {
+    auto manifest = det::parse_compat_json(R"({
+  "compat-schema-version": "1.0",
+  "imports": {
+    "empty": {"parser-version": "1.0", "detected-formats": []},
+    "bad": {"parser-version": "1.0", "detected-formats": [42, []]},
+    "good": {
+      "parser-version": "1.0",
+      "detected-formats": [{
+        "format-version": "2026.05",
+        "fingerprint": [{"kind": "filename", "regex": ".*\\.html"}]
+      }]
+    }
+  }
+})");
+
+    REQUIRE(manifest.has_value());
+    REQUIRE(manifest->sources.size() == 3);
+    REQUIRE(manifest->sources[0].source == "empty");
+    REQUIRE(manifest->sources[0].formats.empty());
+    REQUIRE(manifest->sources[1].source == "bad");
+    REQUIRE(manifest->sources[1].formats.empty());
+    REQUIRE(manifest->sources[2].source == "good");
+    REQUIRE(manifest->sources[2].formats.size() == 1);
+}
+
 TEST_CASE("parse_compat_json keeps optional format metadata and skips bad shapes",
           "[cli][import-detect][coverage]") {
     auto manifest = det::parse_compat_json(R"({
@@ -670,8 +697,8 @@ TEST_CASE("snapshot_input ignores script-like tags and prefixed attributes",
 }
 
 TEST_CASE("snapshot_input accepts script tag and attribute whitespace boundaries",
-          "[cli][import-detect][coverage]") {
-    auto dir = fs::temp_directory_path() / "pulp-import-detect-script-boundaries";
+          "[cli][import-detect][coverage][requested]") {
+    auto dir = fs::temp_directory_path() / "pulp-import-detect-script-whitespace-boundaries";
     fs::remove_all(dir);
     fs::create_directories(dir);
 

--- a/test/test_codesign.cpp
+++ b/test/test_codesign.cpp
@@ -276,6 +276,14 @@ Runtime Version=15.0.0
         "TeamIdentifier=VWXYZ98765\n");
     REQUIRE(missing_identity.identity.empty());
     REQUIRE(missing_identity.team_id == "VWXYZ98765");
+
+    auto first_authority = pulp::ship::detail::parse_codesign_details(R"(
+Authority=Developer ID Application: First Team (FIRST12345)
+Authority=Developer ID Application: Second Team (SECOND12345)
+TeamIdentifier=FIRST12345
+)");
+    REQUIRE(first_authority.identity == "Developer ID Application: First Team (FIRST12345)");
+    REQUIRE(first_authority.team_id == "FIRST12345");
 #endif
 }
 
@@ -350,5 +358,11 @@ TEST_CASE("security identity parser preserves quoted display names",
 
     auto none = pulp::ship::detail::parse_signing_identities("0 valid identities found\n");
     REQUIRE(none.empty());
+
+    auto unbalanced = pulp::ship::detail::parse_signing_identities(R"IDENTITIES(
+  1) AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA "Missing close
+  2) BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB No opening quote"
+)IDENTITIES");
+    REQUIRE(unbalanced.empty());
 #endif
 }

--- a/test/test_design_debug_contracts.cpp
+++ b/test/test_design_debug_contracts.cpp
@@ -137,6 +137,34 @@ TEST_CASE("design-debug repo discovery finds the design tool from nested directo
     std::filesystem::remove_all(temp, ec);
 }
 
+TEST_CASE("design-debug loads ordered design-tool modules from the entry path",
+          "[tools][design-debug][coverage][requested]") {
+    auto temp = make_temp_dir("module-load");
+    auto js_dir = temp / "examples" / "design-tool";
+    REQUIRE(std::filesystem::create_directories(js_dir));
+    REQUIRE(write_text_file(js_dir / "oklch.js", "globalThis.__load = ['oklch'];\n"));
+    for (const char* module : kDesignToolModules) {
+        REQUIRE(write_text_file(js_dir / module,
+                                "globalThis.__load.push('" + std::string(module) + "');\n"));
+    }
+
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+    load_design_tool(js_dir / kDesignToolEntry, bridge);
+    auto result = engine.evaluate("JSON.stringify(globalThis.__load)");
+    REQUIRE(result.isString());
+    auto text = std::string(result.getString());
+
+    REQUIRE(text.find("oklch") != std::string::npos);
+    REQUIRE(text.find("design-tool-core.js") != std::string::npos);
+    REQUIRE(text.find("design-tool-export.js") != std::string::npos);
+
+    std::error_code ec;
+    std::filesystem::remove_all(temp, ec);
+}
+
 TEST_CASE("design-debug capture metadata matches backend behavior",
           "[tools][design-debug][coverage]") {
     REQUIRE(std::string(capture_mode_flag_name(CaptureMode::headless_skia,

--- a/test/test_design_import_benchmark_contracts.cpp
+++ b/test/test_design_import_benchmark_contracts.cpp
@@ -97,6 +97,11 @@ TEST_CASE("design-import benchmark parse_int accepts complete integers only",
     REQUIRE_FALSE(parse_int("12ms", value));
     REQUIRE_FALSE(parse_int("1.5", value));
     REQUIRE_FALSE(parse_int("abc", value));
+    REQUIRE(parse_int(" 12", value));
+    REQUIRE(value == 12);
+    REQUIRE_FALSE(parse_int("12 ", value));
+    REQUIRE(parse_int("+12", value));
+    REQUIRE(value == 12);
 }
 
 TEST_CASE("design-import benchmark argument parser supports split and equals forms",

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -2026,6 +2026,45 @@ TEST_CASE("InspectorWindow default refresh and selection mirror contracts",
     REQUIRE(selected_callback_called);
 }
 
+TEST_CASE("Inspector overlay and window public header toggles are direct contracts",
+          "[inspect][overlay][window][coverage][requested]") {
+    View root;
+    root.set_bounds({0, 0, 320, 200});
+
+    InspectorOverlay overlay(root);
+    REQUIRE(&overlay.inspected_root() == &root);
+    REQUIRE_FALSE(overlay.is_active());
+    overlay.set_active(true);
+    REQUIRE(overlay.is_active());
+    overlay.toggle();
+    REQUIRE_FALSE(overlay.is_active());
+
+    REQUIRE(overlay.tool() == InspectorOverlay::Tool::select);
+    overlay.toggle_tool();
+    REQUIRE(overlay.tool() == InspectorOverlay::Tool::text);
+    overlay.set_tool(InspectorOverlay::Tool::select);
+    REQUIRE(overlay.tool() == InspectorOverlay::Tool::select);
+
+    REQUIRE_FALSE(overlay.manipulate_only());
+    REQUIRE_FALSE(overlay.dragging_enabled());
+    overlay.set_manipulate_only(true);
+    REQUIRE(overlay.manipulate_only());
+    REQUIRE(overlay.dragging_enabled());
+
+    REQUIRE_FALSE(overlay.has_reparent_source_sink());
+    overlay.set_reparent_source_sink([](const InspectorOverlay::ReparentSourceEdit&) {});
+    REQUIRE(overlay.has_reparent_source_sink());
+    overlay.set_reparent_source_sink({});
+    REQUIRE_FALSE(overlay.has_reparent_source_sink());
+
+    InspectorWindow window(root);
+    REQUIRE_FALSE(window.selection_readonly());
+    window.set_selection_readonly(true);
+    REQUIRE(window.selection_readonly());
+    window.set_selection_readonly(false);
+    REQUIRE_FALSE(window.selection_readonly());
+}
+
 TEST_CASE("InspectorWindow rebuilds tree and theme sections only from live roots",
           "[inspect][window][coverage][headers]") {
     View first_root;

--- a/test/test_inspector_server.cpp
+++ b/test/test_inspector_server.cpp
@@ -312,6 +312,36 @@ TEST_CASE("InspectorServer dispatches requests through the configured handler",
     server.stop();
 }
 
+TEST_CASE("InspectorServer uses the latest installed request handler",
+          "[inspect][server][coverage][requested]") {
+    InspectorServer server;
+    auto port = start_inspector_server(server);
+    REQUIRE(port.has_value());
+
+    server.set_request_handler([](const InspectorMessage& request) {
+        return make_response(request.id, R"({"value":"first"})");
+    });
+    server.set_request_handler([](const InspectorMessage& request) {
+        return make_response(request.id, R"({"value":"second"})");
+    });
+
+    RecordingClient client;
+    REQUIRE(client.connect(*port));
+    REQUIRE(wait_for_client_count(server, 1));
+
+    REQUIRE(client.conn.send_message(encode_message(make_request(17, "Echo.latest"))));
+
+    InspectorMessage message;
+    REQUIRE(decode_message(client.wait_for_message(0), message));
+    REQUIRE(message.id == 17);
+    REQUIRE_FALSE(message.is_error);
+    const auto response_json = choc::json::parse(message.params_json);
+    REQUIRE(std::string(response_json["value"].getString()) == "second");
+
+    client.conn.disconnect();
+    server.stop();
+}
+
 TEST_CASE("InspectorServer can refresh its discovery file after startup",
           "[inspect][server]") {
     const auto tmp = std::filesystem::temp_directory_path() /

--- a/test/test_linux_packaging.cpp
+++ b/test/test_linux_packaging.cpp
@@ -299,3 +299,25 @@ TEST_CASE("Linux packaging deb failures remove staging and preserve inputs",
     REQUIRE(fs::is_regular_file(build / "CLAP" / "Failure.clap"));
     REQUIRE(read_file(build / "CLAP" / "Failure.clap") == "clap");
 }
+
+TEST_CASE("Linux packaging deb generation removes stale staging before writing",
+          "[ship][linux-package][coverage][requested]") {
+    if (!command_available("dpkg-deb"))
+        SKIP("dpkg-deb is required to inspect generated deb archives");
+
+    TempDir temp("deb-stale-staging");
+    auto build = temp.path / "build";
+    write_file(build / "deb-staging" / "stale.txt", "must be removed");
+    write_file(build / "VST3" / "Fresh.vst3" / "Contents" / "module.txt", "fresh");
+
+    auto output = temp.path / "fresh.deb";
+    REQUIRE(pulp::ship::create_deb("pulp-fresh", "9.8.7", build.string(),
+                                   output.string(), "Pulp Tests"));
+    REQUIRE_FALSE(fs::exists(build / "deb-staging"));
+
+    auto contents = run_sh("dpkg-deb --contents " + quote(output));
+    REQUIRE(contents.exit_code == 0);
+    REQUIRE_THAT(contents.stdout_output,
+                 ContainsSubstring("./usr/lib/vst3/Fresh.vst3/Contents/module.txt"));
+    REQUIRE(contents.stdout_output.find("stale.txt") == std::string::npos);
+}

--- a/test/test_mcp_server.cpp
+++ b/test/test_mcp_server.cpp
@@ -326,6 +326,21 @@ TEST_CASE("MCP JSON helpers preserve raw tokens and reject partial scalars",
     REQUIRE_FALSE(extract_bool(payload, "array", false));
 }
 
+TEST_CASE("MCP JSON helpers keep adjacent keys and string escapes isolated",
+          "[mcp][json][coverage][requested]") {
+    const std::string payload =
+        R"({"tool":"pulp_build","tool_extra":"wrong","text":"a \"quoted\" value","n":17})";
+
+    REQUIRE(extract_string(payload, "tool") == "pulp_build");
+    REQUIRE(extract_string(payload, "tool_extra") == "wrong");
+    REQUIRE(extract_string(payload, "text") == R"(a \"quoted\" value)");
+    REQUIRE(extract_raw(payload, "n") == "17");
+
+    auto wrapped = json_tool_payload(R"({"ok":true,"value":"x"})");
+    require_contains(wrapped, R"("structuredContent":{"ok":true,"value":"x"})");
+    require_contains(wrapped, R"("text":"{\"ok\":true,\"value\":\"x\"}")");
+}
+
 TEST_CASE("MCP JSON-RPC envelopes escape structured payloads",
           "[mcp][json][coverage]") {
     const auto error = json_error("null", -32602, "bad \"arg\"\nline");

--- a/test/test_motion_swift_bridge.cpp
+++ b/test/test_motion_swift_bridge.cpp
@@ -133,10 +133,24 @@ TEST_CASE("pulp_motion_publish_components tolerates empty and null inputs",
     const char* keys[1] = {"x"};
     const double vals[1] = {1.0};
     pulp_motion_publish_components("Card", "p", keys, vals, 0, 0.001, 3);
+    pulp_motion_publish_components("Card", "p", keys, vals, -1, 0.001, 3);
     pulp_motion_publish_components("Card", "p", nullptr, vals, 1, 0.001, 3);
     pulp_motion_publish_components("Card", "p", keys, nullptr, 1, 0.001, 3);
 
     REQUIRE(count_kind(fx.buffer, SampleEvent::Kind::Baseline, "p") == 0);
+}
+
+TEST_CASE("pulp_motion bridge normalizes null C strings",
+          "[motion][swift-bridge][coverage][requested]") {
+    BridgeFixture fx;
+
+    pulp_motion_publish_value(nullptr, nullptr, 0.0, 0.001, 3);
+    pulp_motion_publish_value(nullptr, nullptr, 1.0, 0.001, 3);
+
+    const auto* baseline = first_of(fx.buffer, SampleEvent::Kind::Baseline);
+    REQUIRE(baseline != nullptr);
+    REQUIRE(baseline->view_name.empty());
+    REQUIRE(baseline->metric_name.empty());
 }
 
 // ── Ambient provenance ────────────────────────────────────────────────
@@ -265,4 +279,16 @@ TEST_CASE("pulp_motion geometry registry survives coordinator reset",
     const int fresh = pulp_motion_register_geometry_trace("ViewC", 30);
     REQUIRE(fresh > 0);
     pulp_motion_detach_trace(fresh);
+}
+
+TEST_CASE("pulp_motion geometry bridge ignores unknown trace ids",
+          "[motion][swift-bridge][coverage][requested]") {
+    BridgeFixture fx;
+
+    pulp_motion_update_geometry(123456, "frame", 1.0, 2.0, 3.0, 4.0);
+    pulp_motion_detach_trace(123456);
+    for (int i = 0; i < 4; ++i) fx.clock.tick(1.0f / 60.0f);
+
+    REQUIRE(count_kind(fx.buffer, SampleEvent::Kind::Baseline, "frame") == 0);
+    REQUIRE(count_kind(fx.buffer, SampleEvent::Kind::Start, "frame") == 0);
 }

--- a/test/test_python_bindings_embedded.cpp
+++ b/test/test_python_bindings_embedded.cpp
@@ -152,6 +152,7 @@ assert math.isclose(keyword_range.normalize(0.0), 0.5)
 assert math.isclose(keyword_range.denormalize(0.75), 1.0)
 assert raises(TypeError, lambda: pulp.ParamRange(min=0.0, max=1.0))
 assert raises(TypeError, lambda: pulp.ParamRange(0.0, 1.0, 0.5, 0.25))
+assert raises(TypeError, lambda: pulp.ParamRange("0", 1.0, 0.5))
 param_range.min = -60.0
 param_range.max = 24.0
 param_range.default_value = -12.0
@@ -223,6 +224,8 @@ params = store.all_params()
 assert len(params) == 2
 assert [param.name for param in params] == ["Python Gain", "Python Mix"]
 assert [param.id for param in params] == [8201, 8202]
+params[0].name = "Detached Copy"
+assert store.info(8201).name == "Python Gain"
 assert math.isclose(params[0].range.min, -60.0)
 assert math.isclose(params[0].range.max, 24.0)
 assert math.isclose(params[1].range.default_value, 0.5)
@@ -248,11 +251,14 @@ assert store.deserialize(state_blob)
 assert math.isclose(store.get_value(8201), -12.0)
 assert math.isclose(store.get_normalized(8202), 0.75)
 assert not store.deserialize(b"bad")
+assert not store.deserialize(b"")
 store.reset_to_default(8201)
 store.reset_all_to_defaults()
 assert math.isclose(store.get_value(8201), 0.0)
 assert math.isclose(store.get_value(8202), 0.5)
 assert math.isclose(store.get_default(8201), 0.0)
+assert math.isclose(store.get_value(999999), 0.0)
+assert math.isclose(store.get_normalized(999999), 0.0)
 assert raises(TypeError, lambda: store.set_value("gain", 0.5))
 assert raises(TypeError, lambda: store.set_normalized(8201, "hot"))
 
@@ -270,6 +276,7 @@ assert raises(AttributeError, lambda: setattr(descriptor, "bundle_id", "mutable"
 host.release()
 host.release()
 host.prepare(48000.0, 16, input_channels=1, output_channels=1)
+assert raises(TypeError, lambda: host.prepare(48000.0))
 
 host_state = host.state()
 assert host_state.param_count() == 1
@@ -282,6 +289,7 @@ host_state.set_value(8101, 0.0)
 assert host.load_state(saved)
 assert math.isclose(host_state.get_value(8101), 1.0)
 assert not host.load_state(b"not a valid host state")
+assert not host.load_state(b"")
 assert raises(TypeError, lambda: host.prepare("48000", 16))
 
 import numpy as np

--- a/test/test_screenshot_cli_contracts.cpp
+++ b/test/test_screenshot_cli_contracts.cpp
@@ -325,3 +325,15 @@ TEST_CASE("pulp-screenshot main rejects unknown backend before rendering",
     auto exit_code = run_screenshot_cli({"--demo", "--backend", "metal"});
     REQUIRE(exit_code == 1);
 }
+
+TEST_CASE("pulp-screenshot main handles early non-render exits",
+          "[tools][screenshot][coverage]") {
+    REQUIRE(run_screenshot_cli({"--help"}) == 0);
+    REQUIRE(run_screenshot_cli({"--width", "bad", "--help"}) == 0);
+    REQUIRE(run_screenshot_cli({}) == 1);
+
+    auto missing_script = temp_file_path("missing-script.js");
+    std::filesystem::remove(missing_script);
+    const auto missing_arg = missing_script.string();
+    REQUIRE(run_screenshot_cli({"--script", missing_arg.c_str()}) == 1);
+}

--- a/tools/scan-worker/test_scan_worker.cpp
+++ b/tools/scan-worker/test_scan_worker.cpp
@@ -4,6 +4,7 @@
 #include <pulp/platform/child_process.hpp>
 
 #include <chrono>
+#include <cstdio>
 #include <filesystem>
 #include <fstream>
 #include <string>
@@ -54,10 +55,20 @@ std::string json_escaped(std::string text) {
         switch (c) {
             case '"': escaped += "\\\""; break;
             case '\\': escaped += "\\\\"; break;
+            case '\b': escaped += "\\b"; break;
+            case '\f': escaped += "\\f"; break;
             case '\n': escaped += "\\n"; break;
             case '\r': escaped += "\\r"; break;
             case '\t': escaped += "\\t"; break;
-            default: escaped += static_cast<char>(c); break;
+            default:
+                if (c < 0x20) {
+                    char buf[7] = {};
+                    std::snprintf(buf, sizeof(buf), "\\u%04x", static_cast<unsigned>(c));
+                    escaped += buf;
+                } else {
+                    escaped += static_cast<char>(c);
+                }
+                break;
         }
     }
     return escaped;
@@ -214,6 +225,41 @@ TEST_CASE("pulp-scan-worker escapes fallback JSON descriptor strings",
     REQUIRE_THAT(result.stdout_output, ContainsSubstring(json_field("path", bundle.string())));
     REQUIRE(result.stdout_output.find("Quoted \"Name\"") == std::string::npos);
     REQUIRE(result.stdout_output.find("Name\"\nLine") == std::string::npos);
+#endif
+}
+
+TEST_CASE("pulp-scan-worker test JSON escape helper covers control bytes",
+          "[host][scan-worker][coverage]") {
+    const std::string text = std::string("Quote\" Slash\\ Back") + '\b'
+                           + " Form" + '\f' + " Line\nReturn\rTab\tUnit"
+                           + '\x01' + "End";
+    REQUIRE(json_escaped(text)
+            == "Quote\\\" Slash\\\\ Back\\b Form\\f Line\\nReturn\\rTab\\tUnit\\u0001End");
+}
+
+TEST_CASE("pulp-scan-worker escapes JSON control characters in fallback names",
+          "[host][scan-worker][coverage]") {
+#if defined(_WIN32)
+    SUCCEED("Windows filenames cannot contain the control characters needed for this fallback-name escape path");
+#else
+    ScratchDir scratch("control-clap");
+    const std::string name = std::string("Control") + '\b' + "Back"
+                           + '\f' + "Form" + '\x01' + "Unit";
+    auto bundle = scratch.path / (name + ".clap");
+    write_file(bundle, "not a dynamic library");
+
+    auto result = run_worker({bundle.string()});
+    REQUIRE(result.exit_code == 0);
+    REQUIRE_FALSE(result.stdout_output.empty());
+    REQUIRE(result.stdout_output.back() == '\n');
+    REQUIRE_THAT(result.stdout_output,
+                 ContainsSubstring("\"name\":\"Control\\bBack\\fForm\\u0001Unit\""));
+    REQUIRE_THAT(result.stdout_output,
+                 ContainsSubstring("\"unique_id\":\"Control\\bBack\\fForm\\u0001Unit\""));
+    REQUIRE_THAT(result.stdout_output, ContainsSubstring(json_field("path", bundle.string())));
+    REQUIRE(result.stdout_output.find('\b') == std::string::npos);
+    REQUIRE(result.stdout_output.find('\f') == std::string::npos);
+    REQUIRE(result.stdout_output.find('\x01') == std::string::npos);
 #endif
 }
 


### PR DESCRIPTION
## Summary

Single requested coverage batch for the targeted files/folders called out by the maintainer. This PR intentionally keeps production code untouched and adds focused unit/contract tests across the named platform, Apple, inspector, MCP, audio, design, import, scan-worker, and screenshot surfaces.

## Coverage ledger

- `bindings/python/bindings.cpp` -> `test/test_python_bindings_embedded.cpp` -> Python binding constructor/type/error/copy/state edge assertions -> `./build/bindings/python/pulp-test-python-bindings-embedded`
- `ship/platform/mac/codesign_mac.mm` -> `test/test_codesign.cpp` -> parser edge cases for codesign authorities and malformed security identity output -> `./build/test/pulp-test-codesign`
- `apple/Sources/PulpSwift/PulpBridge.cpp` -> `test/test_motion_swift_bridge.cpp` / `test/test_pulp_bridge.cpp` -> null-string motion shims, unknown geometry trace IDs, existing bridge state/param/plugin contracts -> `./build/test/pulp-test-motion-swift-bridge`, `./build/test/pulp-test-pulp-bridge`
- `apple/Sources/PulpSwift/PulpMotionProbe.swift` -> `apple/Tests/PulpSwiftTests/PulpMotionProbeTests.swift` -> probe deinit detaches registered trace -> `swift test --package-path apple`
- `ship/platform/linux/package_linux.cpp` -> `test/test_linux_packaging.cpp` -> stale deb staging cleanup and existing tar/deb contracts -> GitHub Linux runner / `pulp-test-linux-packaging`
- `inspect/include/pulp/inspect/inspector_server.hpp` + `inspect/src/inspector_server.cpp` -> `test/test_inspector_server.cpp` -> latest installed request handler wins -> `PULP_INSPECTOR_NO_LAUNCH=1 ./build/test/pulp-test-inspector-server`
- `inspect/include/pulp/inspect/inspector_window.hpp` -> `test/test_inspector.cpp` -> public selection-readonly/header toggle contract -> `PULP_INSPECTOR_NO_LAUNCH=1 ./build/test/pulp-test-inspector "[requested]"`
- `inspect/include/pulp/inspect/inspector_overlay.hpp` -> `test/test_inspector.cpp` -> public active/tool/manipulate/reparent-sink contract -> `PULP_INSPECTOR_NO_LAUNCH=1 ./build/test/pulp-test-inspector "[requested]"`
- `inspect/src/` -> `test/test_inspector.cpp`, `test/test_inspector_server.cpp`, `test/test_inspector_domain_helpers.cpp` -> overlay/window/server/domain helper contracts -> focused inspector targets above
- `tools/design/pulp_design_debug.cpp` + `tools/design/` -> `test/test_design_debug_contracts.cpp` -> ordered design-tool module loading from entry path -> `./build/test/pulp-test-design-debug-contracts`
- `tools/audio/src/excerpt_service.cpp` -> `test/test_audio_tools.cpp` -> unreadable WAV dry-run handling and unsupported-input path after model resolution -> `./build/test/pulp-test-audio-tools`
- `tools/audio/src/model_registry.cpp` -> `test/test_audio_tools.cpp` -> concrete Hugging Face checkpoint path preservation -> `./build/test/pulp-test-audio-tools`
- `tools/import-design/design_import_benchmark.cpp` -> `test/test_design_import_benchmark_contracts.cpp` -> `parse_int` whitespace/sign contract -> `./build/test/pulp-test-design-import-benchmark-contracts`
- `tools/import-design/import_detect.cpp` -> `test/test_cli_import_detect.cpp` -> empty/malformed detected-format source preservation and script whitespace boundary parsing -> `./build/test/pulp-test-cli-import-detect`
- `tools/mcp/` -> `test/test_mcp_server.cpp` -> adjacent-key JSON extraction and structured tool-payload envelope -> `./build/test/pulp-test-mcp-server`
- `tools/scan-worker/` -> `tools/scan-worker/test_scan_worker.cpp` -> fallback JSON control-byte escaping in plugin names -> `./build/tools/scan-worker/pulp-test-scan-worker`
- `tools/screenshot/` -> `test/test_screenshot_cli_contracts.cpp` -> early main exits before render setup -> `./build/test/pulp-test-screenshot-cli-contracts`

## Local validation

- Release configure: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=OFF -DPULP_ENABLE_GPU=ON -DPULP_BUILD_PYTHON=ON`
- Verified Release cache and `-O3 -DNDEBUG` flags for representative touched targets.
- Ran focused test binaries listed in the ledger, including the amended import-detect and excerpt-service requested cases.
- Ran `swift test --package-path apple`.
- Ran `git diff --check`.
- Ran `python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`.
- Ran `python3 tools/scripts/test_workflow_lint.py`.
- Ran `pulp_cli_version_check`.

## Notes

Linux packaging is compiled and run on the GitHub Linux lane; the macOS worktree does not generate `pulp-test-linux-packaging`.

This also includes test-only CI stability fixes in `test/test_audio_thumbnail.cpp` for Windows CTest parallel temp paths and `test/cmake/test_ios_auv3_configure.sh` for a `pipefail`/`grep -q` false negative in the AUv3 plist check; neither changes production code and both were required to keep the batch mergeable.