### PR TITLE
fix(format): expose scripted plugin UIs to hosts

### DIFF
--- a/.agents/skills/auv3/SKILL.md
+++ b/.agents/skills/auv3/SKILL.md
@@ -156,7 +156,12 @@ not apply — `_bridge` is a C++ struct). The block:
 
 1. Zeroes outputs and returns `noErr` if the Processor is null (host
    calling render before `allocateRenderResources` succeeded).
-2. Points `output_ptrs[i]` at `outputData->mBuffers[i].mData`.
+2. Rejects `frameCount > maximumFramesToRender` with
+   `kAudioUnitErr_TooManyFramesToProcess`. If a host or validator
+   passes null or undersized `outputData->mBuffers[i].mData`, the
+   adapter assigns slices from `AUBridge::output_storage`, which is
+   pre-sized in `allocateRenderResources`. Do not heap-allocate in the
+   steady-state render path.
 3. Pulls the main input via `pullInputBlock(…, 0, &input_abl)`. This
    reuses the **output** buffers as the input destination — in-place
    processing is allowed (`canProcessInPlace` returns `YES`).

--- a/.agents/skills/clap/SKILL.md
+++ b/.agents/skills/clap/SKILL.md
@@ -90,6 +90,16 @@ struct. It owns:
   `PULP_CLAP_GUI`. Editor lifecycle flows through `ViewBridge`; see the
   `view-bridge` skill for the open/attach/close protocol.
 
+`PulpClapPlugin` is consumed from two translation units: the per-plugin
+`clap_entry.cpp` and the shared `clap_adapter.cpp` in `pulp-format`.
+They must see the same GUI define. Desktop plugin builds compile both
+with `PULP_CLAP_GUI=1`; WCLAP/non-GUI builds compile both with
+`PULP_CLAP_GUI=0`. Do not add GUI-only fields under a preprocessor
+condition unless the shared adapter target receives the same condition.
+A layout mismatch presents as random CLAP lifecycle corruption, often a
+REAPER crash in `gui_create()` or `clap_activate()` touching a bogus
+`bridge`/`editor_host` pointer.
+
 ### Parameters
 
 Parameters are defined by the Processor during `define_parameters(store)`
@@ -200,8 +210,9 @@ round-trip parity is trivial to test.
 
 ### Editor
 
-Gated on `PULP_CLAP_GUI` (set for plugin targets, off for the shared
-format lib to keep the core thin). Lifecycle flows through
+Gated on `PULP_CLAP_GUI`; for desktop CLAP, both the shared
+`pulp-format` adapter TU and the per-plugin entry TU must compile with
+the same value. Lifecycle flows through
 `pulp::format::ViewBridge`: `gui_create` → `bridge->open()`, the host
 then calls `gui_set_parent(window)` → `editor_host->attach_to_parent` +
 `bridge->notify_attached()`, `gui_destroy` → `bridge->close()`. See the
@@ -385,12 +396,14 @@ future `CLAP_EVENT_*` additions — the CLAP header does not define
 them as macros. See PR #627's `clap_adapter.cpp` for the canonical
 guard shape.
 
-### GUI is gated on `PULP_CLAP_GUI`
+### GUI layout must match across CLAP TUs
 
-The shared `pulp_format` library is built without `PULP_CLAP_GUI` so
-the adapter stays thin. Only the per-plugin CLAP target turns it on.
-If you add a new GUI-dependent member to `PulpClapPlugin`, wrap it in
-`#ifdef PULP_CLAP_GUI` or the non-GUI builds break.
+Do not use `#ifdef PULP_CLAP_GUI` for CLAP GUI fields or extension
+dispatch; use `#if defined(PULP_CLAP_GUI) && PULP_CLAP_GUI`. The WCLAP
+path may define `PULP_CLAP_GUI=0`, and `#ifdef` treats that as enabled.
+The desktop shared adapter and the per-plugin entry must agree on
+whether GUI fields exist in `PulpClapPlugin`, or later lifecycle fields
+shift and hosts crash when opening or activating the editor.
 
 ### ARA CLAP lives outside `CLAP_EXT_*`
 

--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -645,10 +645,15 @@ honoring the `PULP_DISABLE_PLUGIN_GPU` runtime opt-out. Hardcoding
 back to the AutoUi CPU path (the GPU-plugin-view-host work, 2026-05).
 
 Rules when touching an adapter's editor-attach path:
-- A custom `Processor::create_view()` that paints via the GPU (scripted React
-  UI, WebGPU/Three.js canvas) MUST call `view->set_requires_gpu_host(true)` on
-  its root, or `decide_gpu_host` returns `mode=autoui` and it gets CPU. The
-  framework scripted-UI root (`editor_ui.hpp`) already sets it.
+- A custom `Processor::create_view()` that owns a `ScriptedUiSession` MUST
+  override `Processor::active_scripted_ui()` so `ViewBridge` reports
+  `uses_script_ui()`, adapters log `mode=scripted`, select the GPU host, and
+  `make_scripted_idle_pump` can poll that session. Chainer-style generated
+  processors use this path.
+- A custom non-scripted GPU view (WebGPU/Three.js canvas, hand-built Skia view)
+  MUST call `view->set_requires_gpu_host(true)` on its root, or
+  `decide_gpu_host` returns `mode=autoui` and it gets CPU. The framework
+  scripted-UI root (`editor_ui.hpp`) already sets it.
 - After `PluginViewHost::create(...)`, call
   `format::warn_if_unexpected_cpu_fallback(decision, host.get())` — it screams
   (`runtime::log_error`) if GPU was requested but the host fell back to CPU.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.270.2
+    VERSION 0.271.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/CMakeLists.txt
+++ b/core/format/CMakeLists.txt
@@ -77,7 +77,10 @@ if(PULP_HAS_CLAP)
         src/clap_adapter.cpp
     )
     target_link_libraries(pulp-format PUBLIC clap)
-    target_compile_definitions(pulp-format PRIVATE PULP_CLAP=1)
+    # Keep PulpClapPlugin's layout identical between clap_adapter.cpp and the
+    # per-plugin clap_entry.cpp TU. The entry target defines PULP_CLAP_GUI=1;
+    # the shared adapter must do the same or GUI members shift later fields.
+    target_compile_definitions(pulp-format PRIVATE PULP_CLAP=1 PULP_CLAP_GUI=1)
 endif()
 
 # LV2 adapter

--- a/core/format/include/pulp/format/clap_adapter.hpp
+++ b/core/format/include/pulp/format/clap_adapter.hpp
@@ -12,8 +12,13 @@
 #include <pulp/state/preset_manager.hpp>
 #include <clap/clap.h>
 
-// View includes only when building plugin targets (not the shared format lib)
-#ifdef PULP_CLAP_GUI
+// View includes only when building GUI-capable CLAP targets.
+//
+// Important: PulpClapPlugin is shared across clap_entry.hpp (compiled into the
+// plugin module) and clap_adapter.cpp (compiled into pulp-format). Both
+// translation units must see the same PULP_CLAP_GUI value or the instance
+// layout diverges and lifecycle callbacks write through the wrong offsets.
+#if defined(PULP_CLAP_GUI) && PULP_CLAP_GUI
 #include <pulp/format/view_bridge.hpp>
 #include <pulp/view/plugin_view_host.hpp>
 #endif
@@ -78,7 +83,7 @@ struct PulpClapPlugin {
     // `bridge` owns the view tree and dispatches Processor lifecycle
     // callbacks (on_view_opened/closed/resized). editor_host is the
     // platform-native window surface that hosts bridge->view().
-#ifdef PULP_CLAP_GUI
+#if defined(PULP_CLAP_GUI) && PULP_CLAP_GUI
     std::unique_ptr<ViewBridge> bridge;
     std::unique_ptr<view::PluginViewHost> editor_host;
 #endif

--- a/core/format/include/pulp/format/clap_entry.hpp
+++ b/core/format/include/pulp/format/clap_entry.hpp
@@ -14,7 +14,7 @@
 #include <pulp/format/plugin_state_io.hpp>
 #include <pulp/format/registry.hpp>
 #include <pulp/format/clap_adapter.hpp>
-#ifdef PULP_CLAP_GUI
+#if defined(PULP_CLAP_GUI) && PULP_CLAP_GUI
 #include <pulp/format/editor_ui.hpp>
 #include <pulp/format/gpu_host_select.hpp>
 #endif
@@ -266,7 +266,7 @@ inline const clap_plugin_tail_t tail_ext = { .get = tail_get };
 
 // ── GUI extension (only in plugin targets that define PULP_CLAP_GUI) ──
 
-#ifdef PULP_CLAP_GUI
+#if defined(PULP_CLAP_GUI) && PULP_CLAP_GUI
 
 inline bool gui_is_api_supported(const clap_plugin_t*, const char* api, bool is_floating) {
     if (pulp::format::detail::editor_launch_blocked_by_environment()) return false;
@@ -561,7 +561,7 @@ inline const clap_plugin_gui_t gui_ext = {
 
 // ── Extension dispatch ─────────────────────────────────────────────────
 inline const void* get_extension(const clap_plugin_t*, const char* id) {
-#ifdef PULP_CLAP_GUI
+#if defined(PULP_CLAP_GUI) && PULP_CLAP_GUI
     if (strcmp(id, CLAP_EXT_GUI) == 0) {
         if (pulp::format::detail::editor_launch_blocked_by_environment()) return nullptr;
         return &gui_ext;

--- a/core/format/include/pulp/format/detail/standalone_editor_chrome.hpp
+++ b/core/format/include/pulp/format/detail/standalone_editor_chrome.hpp
@@ -225,6 +225,33 @@ inline view::WindowHost::ResizeCallback make_standalone_editor_resize_callback(
     };
 }
 
+inline view::WindowHost::ContentSize standalone_design_viewport_size(
+    const ViewSize& size_hints,
+    const StandaloneEditorChrome& chrome) {
+    const auto extra_height = static_cast<uint32_t>(
+        chrome.extra_window_height() > 0.0f ? chrome.extra_window_height() : 0.0f);
+    return {
+        size_hints.preferred_width,
+        size_hints.preferred_height + extra_height,
+    };
+}
+
+inline void configure_standalone_design_viewport(
+    view::WindowHost& window,
+    const ViewSize& size_hints,
+    const StandaloneEditorChrome& chrome) {
+    const auto viewport = standalone_design_viewport_size(size_hints, chrome);
+    if (viewport.width == 0 || viewport.height == 0)
+        return;
+
+    window.set_design_viewport(
+        static_cast<float>(viewport.width),
+        static_cast<float>(viewport.height));
+    window.set_fixed_aspect_ratio(
+        static_cast<float>(viewport.width) /
+        static_cast<float>(viewport.height));
+}
+
 template <typename ResizeFn>
 inline void sync_standalone_editor_host(
     view::WindowHost& window,

--- a/core/format/include/pulp/format/processor.hpp
+++ b/core/format/include/pulp/format/processor.hpp
@@ -14,6 +14,8 @@
 #include <string>
 #include <vector>
 
+namespace pulp::view { class ScriptedUiSession; }
+
 namespace pulp::format {
 
 /// Editor size hints (in logical pixels). preferred is used for the
@@ -668,6 +670,13 @@ public:
     /// need to pull `pulp/format/ara.hpp`.
     virtual std::unique_ptr<class AraDocumentController>
     create_ara_document_controller();
+
+    /// Return the active scripted UI session when a custom create_view()
+    /// path owns one. The default framework editor path is tracked by
+    /// ViewBridge directly; processor-owned sessions use this hook so format
+    /// adapters can still select scripted/GPU hosting and poll the session.
+    virtual view::ScriptedUiSession* active_scripted_ui() { return nullptr; }
+    virtual const view::ScriptedUiSession* active_scripted_ui() const { return nullptr; }
 
     /// Access the parameter state store.
     /// Use state().get_value(id) to read parameter values in process().

--- a/core/format/include/pulp/format/view_bridge.hpp
+++ b/core/format/include/pulp/format/view_bridge.hpp
@@ -97,10 +97,11 @@ public:
     bool uses_script_ui() const { return uses_script_ui_; }
 
     /// Access the scripted UI session, if the primary view was built from
-    /// a JS script (via `PULP_UI_SCRIPT_PATH`). Returns nullptr otherwise,
-    /// including when the processor supplied a custom `create_view()`.
-    view::ScriptedUiSession* scripted_ui() { return scripted_ui_.get(); }
-    const view::ScriptedUiSession* scripted_ui() const { return scripted_ui_.get(); }
+    /// a JS script. This includes the framework-owned `PULP_UI_SCRIPT_PATH`
+    /// path and custom processors that expose a session through
+    /// `Processor::active_scripted_ui()`.
+    view::ScriptedUiSession* scripted_ui();
+    const view::ScriptedUiSession* scripted_ui() const;
 
     uint32_t width() const { return width_; }
     uint32_t height() const { return height_; }

--- a/core/format/src/au_adapter.mm
+++ b/core/format/src/au_adapter.mm
@@ -63,6 +63,7 @@
 #include <array>
 #include <atomic>
 #include <limits>
+#include <vector>
 
 namespace pulp::format::au {
 
@@ -102,6 +103,7 @@ struct AUBridge {
     float* output_ptrs[kMaxChannels] = {};
     const float* input_ptrs[kMaxChannels] = {};
     const float* sidechain_ptrs[kMaxChannels] = {};
+    std::vector<float> output_storage;
 
     // Pre-allocated input buffer list for pulling input (stereo max for now)
     struct InputBufferStorage {
@@ -441,6 +443,9 @@ static int32_t block_relative_sample_offset(AUEventSampleTime event_sample_time,
 
     _bridge.sample_rate = _outputBus.format.sampleRate;
     _bridge.max_frames = self.maximumFramesToRender;
+    _bridge.output_storage.assign(
+        static_cast<std::size_t>(pulp::format::au::kMaxChannels) * _bridge.max_frames,
+        0.0f);
 
     if (_bridge.processor) {
         pulp::format::PrepareContext ctx;
@@ -496,18 +501,42 @@ static int32_t block_relative_sample_offset(AUEventSampleTime event_sample_time,
         AURenderPullInputBlock __unsafe_unretained pullInputBlock)
     {
         if (!bridge->processor) {
-            for (UInt32 i = 0; i < outputData->mNumberBuffers; ++i)
-                memset(outputData->mBuffers[i].mData, 0, outputData->mBuffers[i].mDataByteSize);
+            if (outputData) {
+                for (UInt32 i = 0; i < outputData->mNumberBuffers; ++i) {
+                    if (outputData->mBuffers[i].mData) {
+                        memset(outputData->mBuffers[i].mData, 0, outputData->mBuffers[i].mDataByteSize);
+                    }
+                }
+            }
             return noErr;
+        }
+        if (!outputData) return noErr;
+        if (frameCount > bridge->max_frames) {
+            return kAudioUnitErr_TooManyFramesToProcess;
         }
         bridge->param_events.clear();
 
         UInt32 outChans = std::min(outputData->mNumberBuffers,
             static_cast<UInt32>(pulp::format::au::kMaxChannels));
 
-        // Output buffer view (no allocation)
-        for (UInt32 i = 0; i < outChans; ++i)
-            bridge->output_ptrs[i] = static_cast<float*>(outputData->mBuffers[i].mData);
+        const std::size_t neededOutputStorage =
+            static_cast<std::size_t>(outChans) * frameCount;
+        if (bridge->output_storage.size() < neededOutputStorage) {
+            bridge->output_storage.assign(neededOutputStorage, 0.0f);
+        }
+
+        // Output buffer view (uses preallocated scratch when the host passes
+        // null mData during validation/probing).
+        for (UInt32 i = 0; i < outChans; ++i) {
+            auto& buffer = outputData->mBuffers[i];
+            if (!buffer.mData || buffer.mDataByteSize < frameCount * sizeof(float)) {
+                buffer.mNumberChannels = 1;
+                buffer.mDataByteSize = frameCount * sizeof(float);
+                buffer.mData = bridge->output_storage.data() +
+                    static_cast<std::size_t>(i) * frameCount;
+            }
+            bridge->output_ptrs[i] = static_cast<float*>(buffer.mData);
+        }
         pulp::audio::BufferView<float> output_view(bridge->output_ptrs, outChans, frameCount);
 
         // Input: pull from upstream if we have input channels

--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -340,6 +340,7 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
         stop();
         return false;
     }
+    detail::configure_standalone_design_viewport(*window, size_hints, chrome);
 
     // Window host is live — fire Processor::on_view_opened now.
     bridge->notify_attached();

--- a/core/format/src/view_bridge.cpp
+++ b/core/format/src/view_bridge.cpp
@@ -30,6 +30,9 @@ bool ViewBridge::open(std::string* error) {
     auto custom = processor_.create_view();
     if (custom) {
         view_ = std::move(custom);
+        if (processor_.active_scripted_ui()) {
+            uses_script_ui_ = true;
+        }
     } else {
         // Fall back to the scripted-UI or AutoUi default.
         auto instance = build_editor_ui(store_, options_.enable_hot_reload, &last_error_);
@@ -49,6 +52,16 @@ bool ViewBridge::open(std::string* error) {
     attached_ = false;
     released_ = false;
     return true;
+}
+
+view::ScriptedUiSession* ViewBridge::scripted_ui() {
+    if (scripted_ui_) return scripted_ui_.get();
+    return processor_.active_scripted_ui();
+}
+
+const view::ScriptedUiSession* ViewBridge::scripted_ui() const {
+    if (scripted_ui_) return scripted_ui_.get();
+    return processor_.active_scripted_ui();
 }
 
 void ViewBridge::notify_attached() {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -942,8 +942,12 @@ if(NOT PULP_IOS)
 endif()
 # ARA scaffolding (workstream 06 slice 6.1)
 pulp_add_test_suite(pulp-test-ara LIBRARIES pulp::format)
-# CLAP ARA extension end-to-end (workstream 06 A2a)
-pulp_add_test_suite(pulp-test-clap-ara-extension LIBRARIES pulp::format)
+# CLAP ARA extension end-to-end (workstream 06 A2a). This suite instantiates
+# PulpClapPlugin directly, so it must see the same layout as pulp-format's
+# desktop CLAP adapter TU.
+pulp_add_test_suite(pulp-test-clap-ara-extension
+    LIBRARIES pulp::format
+    COMPILE_DEFINITIONS PULP_CLAP_GUI=1)
 # Processor ARA hook (workstream 06 slice 6.3a)
 pulp_add_test_suite(pulp-test-processor-ara-hook LIBRARIES pulp::format)
 # Processor bus-layout validation + processBlock precision contract +
@@ -1753,6 +1757,7 @@ if(PULP_HAS_CLAP)
     # / 62% CI" reports on PR #627.
     add_executable(pulp-test-clap-midi-events test_clap_midi_events.cpp)
     target_link_libraries(pulp-test-clap-midi-events PRIVATE pulp::format clap Catch2::Catch2WithMain)
+    target_compile_definitions(pulp-test-clap-midi-events PRIVATE PULP_CLAP_GUI=1)
     catch_discover_tests(pulp-test-clap-midi-events)
 
     # Item 3.4 (macOS plan) — pin the CLAP host-facing API contract that

--- a/test/test_au_plugin_state.mm
+++ b/test/test_au_plugin_state.mm
@@ -376,6 +376,115 @@ TEST_CASE("AU v3 render events preserve parameter sample offsets and update Stat
     }
 }
 
+TEST_CASE("AU v3 render block rejects frame counts above maximumFramesToRender",
+          "[au][auv3][render][bounds]") {
+    @autoreleasepool {
+        AudioComponentDescription desc{};
+        desc.componentType = kAudioUnitType_Effect;
+        desc.componentSubType = 'TstE';
+        desc.componentManufacturer = 'Plup';
+
+        ScopedFactoryRegistration registration(create_effect_processor);
+
+        NSError* error = nil;
+        PulpAudioUnit* unit =
+            [[PulpAudioUnit alloc] initWithComponentDescription:desc
+                                                       options:0
+                                                         error:&error];
+        REQUIRE(unit != nil);
+        REQUIRE(error == nil);
+
+        auto* processor = g_last_effect_processor;
+        REQUIRE(processor != nullptr);
+
+        NSError* allocate_error = nil;
+        REQUIRE([unit allocateRenderResourcesAndReturnError:&allocate_error]);
+        REQUIRE(allocate_error == nil);
+
+        AudioBufferList output{};
+        output.mNumberBuffers = 1;
+        AudioUnitRenderActionFlags flags = 0;
+        AudioTimeStamp timestamp{};
+        AUInternalRenderBlock block = [unit internalRenderBlock];
+        REQUIRE(block != nil);
+
+        const AUAudioFrameCount too_many = unit.maximumFramesToRender + 1;
+        auto status = block(&flags,
+                            &timestamp,
+                            too_many,
+                            0,
+                            &output,
+                            nullptr,
+                            nil);
+        REQUIRE(status == kAudioUnitErr_TooManyFramesToProcess);
+        REQUIRE(processor->process_count == 0);
+
+        [unit deallocateRenderResources];
+        [unit release];
+    }
+}
+
+TEST_CASE("AU v3 render block substitutes scratch output buffers when host buffers are absent",
+          "[au][auv3][render][scratch]") {
+    @autoreleasepool {
+        AudioComponentDescription desc{};
+        desc.componentType = kAudioUnitType_Effect;
+        desc.componentSubType = 'TstE';
+        desc.componentManufacturer = 'Plup';
+
+        ScopedFactoryRegistration registration(create_effect_processor);
+
+        NSError* error = nil;
+        PulpAudioUnit* unit =
+            [[PulpAudioUnit alloc] initWithComponentDescription:desc
+                                                       options:0
+                                                         error:&error];
+        REQUIRE(unit != nil);
+        REQUIRE(error == nil);
+
+        auto* processor = g_last_effect_processor;
+        REQUIRE(processor != nullptr);
+
+        constexpr UInt32 kFrames = 8;
+        float undersized = 0.0f;
+        struct StereoBufferList {
+            AudioBufferList list;
+            AudioBuffer extra[1];
+        } output{};
+        output.list.mNumberBuffers = 2;
+        output.list.mBuffers[0].mNumberChannels = 2;
+        output.list.mBuffers[0].mDataByteSize = 0;
+        output.list.mBuffers[0].mData = nullptr;
+        output.list.mBuffers[1].mNumberChannels = 2;
+        output.list.mBuffers[1].mDataByteSize = sizeof(float);
+        output.list.mBuffers[1].mData = &undersized;
+
+        AudioUnitRenderActionFlags flags = 0;
+        AudioTimeStamp timestamp{};
+        AUInternalRenderBlock block = [unit internalRenderBlock];
+        REQUIRE(block != nil);
+
+        auto status = block(&flags,
+                            &timestamp,
+                            kFrames,
+                            0,
+                            &output.list,
+                            nullptr,
+                            nil);
+        REQUIRE(status == noErr);
+        REQUIRE(processor->process_count == 1);
+
+        for (UInt32 i = 0; i < output.list.mNumberBuffers; ++i) {
+            REQUIRE(output.list.mBuffers[i].mNumberChannels == 1);
+            REQUIRE(output.list.mBuffers[i].mDataByteSize == kFrames * sizeof(float));
+            REQUIRE(output.list.mBuffers[i].mData != nullptr);
+        }
+        REQUIRE(output.list.mBuffers[1].mData != &undersized);
+
+        [unit release];
+    }
+}
+
 TEST_CASE("AU v2 SaveState accepts pre-existing property lists",
           "[au][auv2][state]") {
     SECTION("effect") {

--- a/test/test_design_debug_contracts.cpp
+++ b/test/test_design_debug_contracts.cpp
@@ -342,6 +342,10 @@ TEST_CASE("design-debug option validation fails before expensive render setup",
 
 TEST_CASE("design-debug headless response-file run writes report artifacts",
           "[tools][design-debug][coverage][requested]") {
+#if !defined(__APPLE__)
+    SKIP("design-debug artifact comparison needs the native screenshot backend");
+#endif
+
     auto temp = make_temp_dir("headless-run");
     auto script = temp / "debug-tool.js";
     auto response = temp / "response.txt";

--- a/test/test_standalone_editor_chrome.cpp
+++ b/test/test_standalone_editor_chrome.cpp
@@ -53,6 +53,9 @@ public:
     ContentSize content_size_{640, 360};
     std::function<void()> idle_callback_;
     ResizeCallback resize_callback_;
+    float design_width_ = 0.0f;
+    float design_height_ = 0.0f;
+    float aspect_ratio_ = 0.0f;
     int repaint_calls_ = 0;
 
     void show() override {}
@@ -65,6 +68,13 @@ public:
     }
     void set_resize_callback(ResizeCallback cb) override {
         resize_callback_ = std::move(cb);
+    }
+    void set_design_viewport(float design_w, float design_h) override {
+        design_width_ = design_w;
+        design_height_ = design_h;
+    }
+    void set_fixed_aspect_ratio(float ratio) override {
+        aspect_ratio_ = ratio;
     }
     void set_close_callback(std::function<void()>) override {}
     void run_event_loop() override {}
@@ -746,6 +756,44 @@ TEST_CASE("Standalone bridge attach forwards host sizing through bridge resize",
     REQUIRE(bridge.resize_calls_.size() == 2);
     REQUIRE(bridge.resize_calls_[1].width == 900);
     REQUIRE(bridge.resize_calls_[1].height == 468);
+}
+
+TEST_CASE("Standalone design viewport applies proportional window resize",
+          "[standalone][chrome][resize][proportional]") {
+    StubWindowHost window;
+    auto chrome = make_standalone_editor_chrome(
+        std::make_unique<View>(),
+        StandaloneConfig{.show_settings_tab = false},
+        nullptr,
+        nullptr,
+        nullptr,
+        {});
+
+    ViewSize hints = view_size_from_design(900, 520);
+    configure_standalone_design_viewport(window, hints, chrome);
+
+    REQUIRE(window.design_width_ == Catch::Approx(900.0f));
+    REQUIRE(window.design_height_ == Catch::Approx(520.0f));
+    REQUIRE(window.aspect_ratio_ == Catch::Approx(900.0f / 520.0f));
+}
+
+TEST_CASE("Standalone design viewport includes settings chrome height",
+          "[standalone][chrome][resize][proportional]") {
+    StubWindowHost window;
+    auto chrome = make_standalone_editor_chrome(
+        std::make_unique<View>(),
+        StandaloneConfig{},
+        nullptr,
+        nullptr,
+        nullptr,
+        {});
+
+    ViewSize hints = view_size_from_design(900, 520);
+    configure_standalone_design_viewport(window, hints, chrome);
+
+    REQUIRE(window.design_width_ == Catch::Approx(900.0f));
+    REQUIRE(window.design_height_ == Catch::Approx(552.0f));
+    REQUIRE(window.aspect_ratio_ == Catch::Approx(900.0f / 552.0f));
 }
 
 TEST_CASE("Standalone log helper formats the chrome mode",

--- a/test/test_view_bridge.cpp
+++ b/test/test_view_bridge.cpp
@@ -3,6 +3,7 @@
 #include <pulp/format/view_bridge.hpp>
 #include <pulp/runtime/message_channel.hpp>
 #include <pulp/state/store.hpp>
+#include <pulp/view/scripted_ui.hpp>
 #include <pulp/view/view.hpp>
 #include <functional>
 
@@ -44,6 +45,26 @@ public:
         last_w = w;
         last_h = h;
     }
+};
+
+class ScriptedCustomViewProcessor : public StubProcessor {
+public:
+    view::ScriptedUiSession* active_scripted_ui() override {
+        return scripted_session.get();
+    }
+
+    const view::ScriptedUiSession* active_scripted_ui() const override {
+        return scripted_session.get();
+    }
+
+    std::unique_ptr<view::View> create_view() override {
+        auto root = std::make_unique<view::View>();
+        scripted_session = std::make_unique<view::ScriptedUiSession>(
+            *root, state(), view::ScriptedUiOptions{});
+        return root;
+    }
+
+    std::unique_ptr<view::ScriptedUiSession> scripted_session;
 };
 
 } // namespace
@@ -93,6 +114,31 @@ TEST_CASE("ViewBridge honors custom create_view()", "[view_bridge]") {
     bridge.notify_attached();
     REQUIRE(bridge.view() == raw);
     REQUIRE_FALSE(bridge.uses_script_ui());
+}
+
+TEST_CASE("ViewBridge detects processor-owned scripted custom views",
+          "[view_bridge][scripted-ui]") {
+    ScriptedCustomViewProcessor p;
+    state::StateStore store;
+    p.set_state_store(&store);
+    p.define_parameters(store);
+
+    format::ViewBridge bridge(p, store);
+    REQUIRE(bridge.open());
+    REQUIRE(bridge.uses_script_ui());
+    REQUIRE(p.scripted_session != nullptr);
+    REQUIRE(bridge.scripted_ui() == p.scripted_session.get());
+
+    const auto& const_bridge = bridge;
+    REQUIRE(const_bridge.scripted_ui() == p.scripted_session.get());
+}
+
+TEST_CASE("Processor scripted UI accessors default to null", "[view_bridge][scripted-ui]") {
+    StubProcessor p;
+    REQUIRE(p.active_scripted_ui() == nullptr);
+
+    const auto& const_processor = p;
+    REQUIRE(const_processor.active_scripted_ui() == nullptr);
 }
 
 TEST_CASE("ViewBridge primary helpers are idempotent and role-aware",

--- a/tools/cmake/PulpAuv3.cmake
+++ b/tools/cmake/PulpAuv3.cmake
@@ -110,6 +110,11 @@ function(_pulp_add_auv3_macos_framework target name bundle_id version auv3_entry
         "-framework Cocoa"
     )
     target_include_directories(${fw_target} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    _pulp_apply_macho_exports(${fw_target} "${fw_target}"
+        "_OBJC_CLASS_$_PulpAUMacViewController"
+        "_OBJC_METACLASS_$_PulpAUMacViewController"
+        "_OBJC_CLASS_$_PulpAudioUnit"
+        "_OBJC_METACLASS_$_PulpAudioUnit")
 
     # Framework Info.plist
     set(PLUGIN_NAME "${name}")
@@ -318,6 +323,11 @@ function(_pulp_add_auv3_ios target name bundle_id version manufacturer manufactu
         "-framework UIKit"
     )
     target_include_directories(${target}_AUv3 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    _pulp_apply_macho_exports(${target}_AUv3 "${target}_AUv3"
+        "_OBJC_CLASS_$_PulpAUViewController"
+        "_OBJC_METACLASS_$_PulpAUViewController"
+        "_OBJC_CLASS_$_PulpAudioUnit"
+        "_OBJC_METACLASS_$_PulpAudioUnit")
 
     set(PLUGIN_NAME "${name}")
     set(PLUGIN_BUNDLE_ID "${bundle_id}")

--- a/tools/cmake/PulpPluginFormats.cmake
+++ b/tools/cmake/PulpPluginFormats.cmake
@@ -64,6 +64,10 @@ function(_pulp_add_vst3 target name bundle_id version manufacturer category)
     )
     target_compile_definitions(${target}_VST3 PRIVATE PULP_VST3_GUI=1)
     _pulp_apply_ui_script_definition(${target}_VST3 "${PULP_${target}_UI_SCRIPT}")
+    _pulp_apply_macho_exports(${target}_VST3 "${target}_VST3"
+        "_bundleEntry"
+        "_bundleExit"
+        "_GetPluginFactory")
     target_include_directories(${target}_VST3 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
     # VST3 bundle structure
@@ -143,6 +147,8 @@ function(_pulp_add_clap target name bundle_id version manufacturer category)
     )
     target_compile_definitions(${target}_CLAP PRIVATE PULP_CLAP_GUI=1)
     _pulp_apply_ui_script_definition(${target}_CLAP "${PULP_${target}_UI_SCRIPT}")
+    _pulp_apply_macho_exports(${target}_CLAP "${target}_CLAP"
+        "_clap_entry")
     target_include_directories(${target}_CLAP PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
     set_target_properties(${target}_CLAP PROPERTIES
@@ -319,6 +325,10 @@ function(_pulp_add_au target name bundle_id version manufacturer category plugin
     target_compile_definitions(${target}_AU PRIVATE
         PULP_AU_GUI=1
         PULP_AU_COCOA_VIEW_CLASS=PulpAUCocoaViewFactory_${_pulp_au_cocoa_class_suffix})
+    _pulp_apply_macho_exports(${target}_AU "${target}_AU"
+        "_${target}AUFactory"
+        "_OBJC_CLASS_$_PulpAUCocoaViewFactory_${_pulp_au_cocoa_class_suffix}"
+        "_OBJC_METACLASS_$_PulpAUCocoaViewFactory_${_pulp_au_cocoa_class_suffix}")
     # AudioUnitSDK 1.4 headers use std::expected (C++23). CMAKE_CXX_STANDARD=20
     # at the repo root is authoritative under CMake 3.24's policy — target
     # compile_features are ignored when a lower CXX_STANDARD is already set.

--- a/tools/cmake/PulpUtils.cmake
+++ b/tools/cmake/PulpUtils.cmake
@@ -119,6 +119,24 @@ function(_pulp_apply_ui_script_definition target ui_script_path)
     )
 endfunction()
 
+function(_pulp_apply_macho_exports target file_stem)
+    if(NOT APPLE)
+        return()
+    endif()
+    if("${ARGN}" STREQUAL "")
+        return()
+    endif()
+
+    set(_pulp_export_file "${CMAKE_CURRENT_BINARY_DIR}/${file_stem}.exports")
+    file(WRITE "${_pulp_export_file}" "")
+    foreach(_pulp_symbol IN LISTS ARGN)
+        file(APPEND "${_pulp_export_file}" "${_pulp_symbol}\n")
+    endforeach()
+
+    target_link_options(${target} PRIVATE
+        "LINKER:-exported_symbols_list,${_pulp_export_file}")
+endfunction()
+
 # ── pulp_add_plugin ─────────────────────────────────────────────────────────
 # Creates plugin targets for each requested format from a single declaration.
 #


### PR DESCRIPTION
## Summary
- expose processor-owned `ScriptedUiSession` instances through `Processor::active_scripted_ui()` and `ViewBridge::scripted_ui()` so Chainer-style custom scripted views use the common scripted/GPU host path
- fix CLAP desktop builds so `clap_entry.cpp` and shared `clap_adapter.cpp` agree on `PULP_CLAP_GUI` layout, preventing REAPER crashes in `gui_create()` after activation
- preserve proportional standalone resize for fixed-design scripted UIs, harden AUv3 render output handling for validation hosts, and restrict macOS plugin exports to expected entry symbols
- document the CLAP/AUv3/ViewBridge gotchas in the mapped skills
- merge current `origin/main` and gate the new design-debug native artifact contract off non-Apple screenshot stubs

## Validation
- `python3 tools/scripts/node_abi_gate.py --base origin/main`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report`
- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report`
- `git diff --check`
- `ctest --test-dir build-clap-layout -R "design-debug headless response-file|CLAP|ViewBridge|Standalone design viewport|AU v3 render block" --output-on-failure -j1` — 72/72 passed
- manual diff coverage equivalent after local helper reconfigure quirk — 82% diff coverage before the final main merge

## Chainer Release Smoke
- Linux-cross Release build installed as `linux-cross-clap-layout-fix`
- codesign strict passed for standalone, AUv3 host app, VST3, and CLAP
- `auval -v aumu Chnr Pulp` passed for AUv3 after PlugInKit refresh
- VST3 pluginval strictness 5 passed and logged `mode=scripted`, `gpu=true`, `build=release`
- CLAP validator passed; installed CLAP GUI smoke called `activate()` then `gui_create()` and reported `mode=scripted`, `gpu=true`, `preserve_aspect_ratio=true`
- standalone screenshot smoke rendered scripted GPU UI at 900x520 logical / 1800x1040 GPU
- Daniel manually confirmed: all formats work in REAPER; AUv3 opens in Logic; AUv3 and VST open in Live

Notes: local test apps are Developer-ID signed but not notarized/stapled, so `spctl` rejects them as `Unnotarized Developer ID`. That is expected for this local test install.