### PR TITLE
test(ios): drive HostApp_Embed target so .appex actually lands in PlugIns/

### DIFF
--- a/test/cmake/test_ios_auv3_configure.sh
+++ b/test/cmake/test_ios_auv3_configure.sh
@@ -173,8 +173,19 @@ if [[ "${PULP_IOS_AUV3_SMOKE_BUILD:-1}" == "1" ]]; then
     # docs/getting-started/ios-deployment.md.
     hostapp_log="${build_dir}/hostapp_build.log"
     set +e
+    # Build the HostApp + the sibling `_Embed` custom target.
+    # `pulp_add_ios_host_app()` registers an `add_custom_target(...
+    # ALL DEPENDS sentinel)` named `<HostApp>_Embed` whose command
+    # copies the `.appex` from `build/AUv3/.../<plugin>.appex` into
+    # `<HostApp>.app/PlugIns/<plugin>.appex`. Driving only
+    # `--target PulpSineSynth_HostApp` produces the .app shell but
+    # skips the embed step, so the bundle ships without an embedded
+    # AUv3 — the user installs the HostApp on iPad and GarageBand /
+    # AUM never see the plugin in the Audio Unit picker. Build both
+    # so the bundle is complete.
     "${timeout_cmd[@]}" cmake --build "${build_dir}/build" \
         --target PulpSineSynth_HostApp \
+        --target PulpSineSynth_HostApp_Embed \
         --config Release \
         -- -sdk iphonesimulator \
         >"${hostapp_log}" 2>&1

--- a/test/cmake/test_ios_hostapp_links.sh
+++ b/test/cmake/test_ios_hostapp_links.sh
@@ -97,17 +97,23 @@ if [[ ${status} -ne 0 ]]; then
     exit 1
 fi
 
-# Build the HostApp (this also builds the .appex it embeds).
+# Build the HostApp + the sibling `_Embed` custom target — the latter
+# copies the `.appex` into `<HostApp>.app/PlugIns/`. Just building
+# `PulpSineSynth_HostApp` produces the .app shell but skips the embed
+# step (the embed lives on `PulpSineSynth_HostApp_Embed`), so the
+# bundle ships without an embedded AUv3 extension.
 set +e
 if [[ ${#timeout_cmd[@]} -gt 0 ]]; then
     "${timeout_cmd[@]}" 1500 cmake --build "${build_dir}/build" \
         --target PulpSineSynth_HostApp \
+        --target PulpSineSynth_HostApp_Embed \
         --config Release \
         -- -sdk iphonesimulator \
         >"${build_log}" 2>&1
 else
     cmake --build "${build_dir}/build" \
         --target PulpSineSynth_HostApp \
+        --target PulpSineSynth_HostApp_Embed \
         --config Release \
         -- -sdk iphonesimulator \
         >"${build_log}" 2>&1


### PR DESCRIPTION
## Summary

Follow-up to #3088 — the iOS smoke now builds the HostApp end-to-end, but it builds only the bare `PulpSineSynth_HostApp` Xcode target.

`pulp_add_ios_host_app()` (`tools/cmake/PulpIosHostApp.cmake`) registers a sibling `add_custom_target(... ALL DEPENDS sentinel)` named `<HostApp>_Embed` whose custom-command copies the `.appex` from `build/AUv3/.../<plugin>.appex` into `<HostApp>.app/PlugIns/<plugin>.appex`. The embed step lives on that second target, not on the HostApp itself.

The result on main today: the smoke produces `PulpSineSynth.app` (Mach-O + Info.plist OK) but `PulpSineSynth.app/PlugIns/PulpSineSynth.appex` is missing.

- `test_ios_hostapp_links.sh` catches this as `FAIL: PulpSineSynth.appex not embedded in HostApp .app under PlugIns/`.
- In the iPad walkthrough this is invisible: the HostApp installs fine, but GarageBand / AUM never see the plugin in the Audio Unit picker because there's no embedded AUv3.

## Fix

Add `--target PulpSineSynth_HostApp_Embed` to the build invocation in both smoke scripts (the AUv3 + HostApp full smoke, and the focused link-time regression test). `--target X --target Y` is the documented CMake multi-target syntax.

## Test plan

- [ ] `PULP_IOS_AUV3_SMOKE_BUILD=1 test/cmake/test_ios_auv3_configure.sh <pulp-source>` exits 0 and reports `OK: pulp_add_ios_auv3() + pulp_add_ios_host_app() iOS Simulator configure + build succeeded`.
- [ ] `test/cmake/test_ios_hostapp_links.sh <pulp-source>` exits 0 and reports `OK: PulpSineSynth_HostApp iOS Simulator build produced a real .app`.
- [ ] `find build/build -path '*/PulpSineSynth.app/PlugIns/PulpSineSynth.appex' -type d` returns a non-empty result.