### PR TITLE
test(coverage): cover requested Swift and Python binding gaps

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -462,7 +462,7 @@ jobs:
         shell: bash
         env:
           CMAKE_GENERATOR: ${{ matrix.os == 'windows' && 'Ninja' || '' }}
-          PULP_COVERAGE_CMAKE_ARGS: ${{ matrix.os == 'linux' && '-DPULP_BUILD_PYTHON=ON' || '' }}
+          PULP_COVERAGE_CMAKE_ARGS: ${{ (matrix.os == 'linux' || matrix.os == 'macos') && '-DPULP_BUILD_PYTHON=ON' || '' }}
           # Coverage workflow targets C++ source coverage. The Rust CLI
           # (#778, Phase 8 PR #1) gets its own `cli-rust` Codecov tier
           # via a separate cargo-llvm-cov job (planned in PR #783) —

--- a/apple/Tests/PulpSwiftTests/PulpMotionProbeTests.swift
+++ b/apple/Tests/PulpSwiftTests/PulpMotionProbeTests.swift
@@ -1,4 +1,7 @@
 import XCTest
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
 @testable import PulpSwift
 
 final class PulpMotionProbeTests: XCTestCase {
@@ -88,6 +91,57 @@ final class PulpMotionProbeTests: XCTestCase {
         XCTAssertTrue(recorder.geometryUpdates.isEmpty)
         XCTAssertTrue(recorder.detachedTraceIds.isEmpty)
     }
+
+    func testGeometryProbePublishesMultipleRectsUntilDetached() {
+        let recorder = MotionBackendRecorder()
+        recorder.nextTraceId = 314
+        PulpMotionRuntime.installTestBackend(recorder.backend)
+
+        let probe = PulpMotionGeometryProbe(view: "Canvas", fps: 60,
+                                            metric: "scroll")
+
+        probe.update(minX: 0, minY: 0, width: 100, height: 200)
+        probe.update(minX: 5, minY: 10, width: 110, height: 210)
+        probe.detach()
+        probe.update(minX: 99, minY: 99, width: 99, height: 99)
+
+        XCTAssertEqual(recorder.registrations.count, 1)
+        XCTAssertEqual(recorder.registrations[0].view, "Canvas")
+        XCTAssertEqual(recorder.registrations[0].fps, 60)
+        XCTAssertEqual(recorder.geometryUpdates.count, 2)
+        XCTAssertEqual(recorder.geometryUpdates.map(\.traceId), [314, 314])
+        XCTAssertEqual(recorder.geometryUpdates.map(\.metric), ["scroll", "scroll"])
+        XCTAssertEqual(recorder.geometryUpdates[1].minX, 5)
+        XCTAssertEqual(recorder.geometryUpdates[1].minY, 10)
+        XCTAssertEqual(recorder.geometryUpdates[1].width, 110)
+        XCTAssertEqual(recorder.geometryUpdates[1].height, 210)
+        XCTAssertEqual(recorder.detachedTraceIds, [314])
+        XCTAssertFalse(probe.isAttached)
+    }
+
+#if canImport(SwiftUI)
+    @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+    func testSwiftUIViewModifierStoresTraceConfiguration() {
+        let metrics = [
+            Trace.geometry("frame"),
+            Trace.scrollGeometry("scroll"),
+            Trace.value("opacity", 0.5, epsilon: 0.01, precision: 2),
+        ]
+        let modifier = PulpMotionTraceModifier(name: "Panel",
+                                               fps: 24,
+                                               metrics: metrics)
+
+        XCTAssertEqual(modifier.name, "Panel")
+        XCTAssertEqual(modifier.fps, 24)
+        XCTAssertEqual(modifier.metrics.count, 3)
+        XCTAssertEqual(modifier.metrics.map(\.name), ["frame", "scroll", "opacity"])
+
+        _ = Text("Panel").pulpMotionTrace("Panel", fps: 24) {
+            Trace.geometry("frame")
+            Trace.value("opacity", 0.5)
+        }
+    }
+#endif
 }
 
 private final class MotionBackendRecorder {

--- a/test/test_design_debug_contracts.cpp
+++ b/test/test_design_debug_contracts.cpp
@@ -339,3 +339,71 @@ TEST_CASE("design-debug option validation fails before expensive render setup",
     std::error_code ec;
     std::filesystem::remove_all(temp, ec);
 }
+
+TEST_CASE("design-debug headless response-file run writes report artifacts",
+          "[tools][design-debug][coverage][requested]") {
+    auto temp = make_temp_dir("headless-run");
+    auto script = temp / "debug-tool.js";
+    auto response = temp / "response.txt";
+    auto output = temp / "artifacts";
+
+    REQUIRE(write_text_file(script, R"JS(
+createLabel('target1', 'Before', 10, 10, 120, 24);
+function setDesignDebugTarget(id) { globalThis.__target = id; }
+function clearInspectedComponent() { globalThis.__target = 'all'; }
+function setDesignDebugAIConfig(provider, model, effort) {
+  globalThis.__provider = provider;
+  globalThis.__model = model;
+  globalThis.__effort = effort;
+}
+function buildDesignChatPrompt(prompt) {
+  return 'prompt:' + prompt + ':' + globalThis.__target;
+}
+function applyDesignChatResponse(response) {
+  setText('target1', response);
+  return 'applied:' + response;
+}
+function getDesignDebugStateJson() {
+  return '{"targetBounds":{"x":10,"y":10,"width":120,"height":24}}';
+}
+)JS"));
+    REQUIRE(write_text_file(response, "After"));
+
+    const auto exit_code = run_design_debug({
+        "pulp-design-debug",
+        "--prompt", "make label explicit",
+        "--target", "target1",
+        "--script", script.string(),
+        "--response-file", response.string(),
+        "--output-dir", output.string(),
+        "--provider", "test-provider",
+        "--model", "test-model",
+        "--reasoning-effort", "low",
+        "--width", "180",
+        "--height", "80",
+        "--scale", "1"
+    });
+
+    REQUIRE(exit_code == 0);
+    REQUIRE(std::filesystem::exists(output / "latest-report.json"));
+    REQUIRE(std::filesystem::exists(output / "latest-run.json"));
+    REQUIRE(std::filesystem::exists(output / "runs.jsonl"));
+
+    auto report = read_file(output / "latest-report.json");
+    REQUIRE(report.find(R"("tool": "pulp-design-debug")") != std::string::npos);
+    REQUIRE(report.find(R"("provider": "test-provider")") != std::string::npos);
+    REQUIRE(report.find(R"("model": "test-model")") != std::string::npos);
+    REQUIRE(report.find(R"("target": "target1")") != std::string::npos);
+    REQUIRE(report.find(R"("target_found": true)") != std::string::npos);
+    REQUIRE(report.find(R"("apply_summary": "applied:After")") != std::string::npos);
+    REQUIRE(report.find(R"("target_before_image": )") != std::string::npos);
+    REQUIRE(report.find(R"("target_after_image": )") != std::string::npos);
+    REQUIRE(report.find(R"("target_region_changed": true)") != std::string::npos);
+
+    auto run_log = read_file(output / "runs.jsonl");
+    REQUIRE(run_log.find(R"("target":"target1")") != std::string::npos);
+    REQUIRE(run_log.find("make label explicit") != std::string::npos);
+
+    std::error_code ec;
+    std::filesystem::remove_all(temp, ec);
+}

--- a/test/test_screenshot_cli_contracts.cpp
+++ b/test/test_screenshot_cli_contracts.cpp
@@ -337,3 +337,33 @@ TEST_CASE("pulp-screenshot main handles early non-render exits",
     const auto missing_arg = missing_script.string();
     REQUIRE(run_screenshot_cli({"--script", missing_arg.c_str()}) == 1);
 }
+
+TEST_CASE("pulp-screenshot main renders demo files and base64 output",
+          "[tools][screenshot][coverage][requested]") {
+    auto output = temp_file_path("demo-output.png");
+    std::filesystem::remove(output);
+    const auto output_arg = output.string();
+
+    REQUIRE(run_screenshot_cli({
+        "--demo",
+        "--output", output_arg.c_str(),
+        "--width", "96",
+        "--height", "64",
+        "--scale", "1",
+        "--theme", "light",
+        "--backend", "default"
+    }) == 0);
+    REQUIRE(std::filesystem::is_regular_file(output));
+    REQUIRE(std::filesystem::file_size(output) > 8);
+
+    REQUIRE(run_screenshot_cli({
+        "--demo",
+        "--base64",
+        "--width", "48",
+        "--height", "32",
+        "--scale", "1",
+        "--backend", "default"
+    }) == 0);
+
+    std::filesystem::remove(output);
+}


### PR DESCRIPTION
Skill-Update: skip skill=ci reason="coverage lane now builds existing Python binding tests on macOS; CI workflow usage is unchanged"