### PR TITLE
test(coverage): cover requested surfaces batch

### DIFF
--- a/apple/Tests/PulpSwiftTests/PulpMotionProbeTests.swift
+++ b/apple/Tests/PulpSwiftTests/PulpMotionProbeTests.swift
@@ -119,6 +119,36 @@ final class PulpMotionProbeTests: XCTestCase {
         XCTAssertFalse(probe.isAttached)
     }
 
+    func testGeometryProbeDefaultOptionsUseFrameMetricAndThirtyFps() {
+        let recorder = MotionBackendRecorder()
+        recorder.nextTraceId = 515
+        PulpMotionRuntime.installTestBackend(recorder.backend)
+
+        let probe = PulpMotionGeometryProbe(view: "Defaulted")
+
+        XCTAssertTrue(probe.isAttached)
+        XCTAssertEqual(probe.name, "Defaulted")
+        XCTAssertEqual(probe.metricName, "frame")
+        XCTAssertEqual(recorder.registrations.count, 1)
+        XCTAssertEqual(recorder.registrations[0].view, "Defaulted")
+        XCTAssertEqual(recorder.registrations[0].fps, 30)
+        XCTAssertEqual(recorder.events, ["set:swiftui:Defaulted", "register:Defaulted:30", "clear"])
+
+        probe.update(minX: -1, minY: -2, width: 10, height: 20)
+        XCTAssertEqual(recorder.geometryUpdates.count, 1)
+        XCTAssertEqual(recorder.geometryUpdates[0].traceId, 515)
+        XCTAssertEqual(recorder.geometryUpdates[0].metric, "frame")
+        XCTAssertEqual(recorder.geometryUpdates[0].minX, -1)
+        XCTAssertEqual(recorder.geometryUpdates[0].minY, -2)
+        XCTAssertEqual(recorder.geometryUpdates[0].width, 10)
+        XCTAssertEqual(recorder.geometryUpdates[0].height, 20)
+
+        probe.detach()
+        probe.detach()
+        XCTAssertEqual(recorder.detachedTraceIds, [515])
+        XCTAssertFalse(probe.isAttached)
+    }
+
 #if canImport(SwiftUI)
     @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
     func testSwiftUIViewModifierStoresTraceConfiguration() {

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -194,6 +194,65 @@ TEST_CASE("ViewInspector type_name", "[view][inspector]") {
     REQUIRE(ViewInspector::type_name(sp) == "SpectrumView");
 }
 
+TEST_CASE("InspectorWindow public controls clamp and toggle deterministic state",
+          "[view][inspector][window][coverage][requested]") {
+    View root;
+    root.set_id("root");
+    root.set_bounds({0, 0, 640, 480});
+
+    InspectorWindow window(root);
+    REQUIRE_FALSE(window.selection_readonly());
+    REQUIRE(window.active_tool() == 0);
+
+    window.set_selection_readonly(true);
+    REQUIRE(window.selection_readonly());
+    window.set_selection_readonly(false);
+    REQUIRE_FALSE(window.selection_readonly());
+
+    window.set_active_tool(1);
+    REQUIRE(window.active_tool() == 1);
+    window.set_active_tool(0);
+    REQUIRE(window.active_tool() == 0);
+    window.set_active_tool(-1);
+    REQUIRE(window.active_tool() == 0);
+    window.set_active_tool(42);
+    REQUIRE(window.active_tool() == 0);
+}
+
+TEST_CASE("CollapsableSection toggles only from header mouse-down events",
+          "[view][inspector][window][coverage][requested]") {
+    CollapsableSection section("Layout", true);
+    section.set_bounds({0, 0, 200, 120});
+
+    REQUIRE(section.is_expanded());
+    REQUIRE(section.content() != nullptr);
+    REQUIRE(section.content()->visible());
+
+    MouseEvent move;
+    move.position = {8, 8};
+    move.is_down = false;
+    section.on_mouse_event(move);
+    REQUIRE(section.is_expanded());
+    REQUIRE(section.content()->visible());
+
+    MouseEvent content_click;
+    content_click.position = {8, 48};
+    content_click.is_down = true;
+    section.on_mouse_event(content_click);
+    REQUIRE(section.is_expanded());
+
+    MouseEvent header_click;
+    header_click.position = {8, 8};
+    header_click.is_down = true;
+    section.on_mouse_event(header_click);
+    REQUIRE_FALSE(section.is_expanded());
+    REQUIRE_FALSE(section.content()->visible());
+
+    section.set_expanded(true);
+    REQUIRE(section.is_expanded());
+    REQUIRE(section.content()->visible());
+}
+
 TEST_CASE("ViewInspector count_views", "[view][inspector]") {
     View root;
     root.add_child(std::make_unique<Knob>());

--- a/test/test_motion_swift_bridge.cpp
+++ b/test/test_motion_swift_bridge.cpp
@@ -153,6 +153,41 @@ TEST_CASE("pulp_motion bridge normalizes null C strings",
     REQUIRE(baseline->metric_name.empty());
 }
 
+TEST_CASE("pulp_motion bridge normalizes null provenance and geometry names",
+          "[motion][swift-bridge][coverage][requested]") {
+    BridgeFixture fx;
+
+    pulp_motion_set_ambient_provenance(nullptr, nullptr, nullptr, 0);
+    pulp_motion_publish_value("Card", "opacity", 0.0, 0.001, 3);
+    pulp_motion_publish_value("Card", "opacity", 1.0, 0.001, 3);
+
+    const auto* opacity = first_of(fx.buffer, SampleEvent::Kind::Baseline, "opacity");
+    REQUIRE(opacity != nullptr);
+    REQUIRE(opacity->view_name == "Card");
+    REQUIRE(opacity->provenance.source_kind.empty());
+    REQUIRE(opacity->provenance.source_id.empty());
+    REQUIRE(opacity->provenance.source_file.empty());
+    REQUIRE(opacity->provenance.source_line == 0);
+
+    const int id = pulp_motion_register_geometry_trace(nullptr, -10);
+    REQUIRE(id > 0);
+
+    pulp_motion_update_geometry(id, "bounds", 1.0, 2.0, 3.0, 4.0);
+    pulp_motion_update_geometry(id, "bounds", 5.0, 6.0, 7.0, 8.0);
+
+    const auto* bounds = first_of(fx.buffer, SampleEvent::Kind::Baseline, "bounds");
+    REQUIRE(bounds != nullptr);
+    REQUIRE(bounds->view_name == "swiftui");
+    REQUIRE(bounds->metric_name == "bounds");
+    REQUIRE(bounds->components.size() == 4);
+    REQUIRE(bounds->components[0].first == "height");
+    REQUIRE(bounds->components[1].first == "minX");
+    REQUIRE(bounds->components[2].first == "minY");
+    REQUIRE(bounds->components[3].first == "width");
+
+    pulp_motion_detach_trace(id);
+}
+
 // ── Ambient provenance ────────────────────────────────────────────────
 
 TEST_CASE("pulp_motion_set_ambient_provenance stamps subsequent publishes",

--- a/tools/scan-worker/test_scan_worker.cpp
+++ b/tools/scan-worker/test_scan_worker.cpp
@@ -104,6 +104,29 @@ TEST_CASE("pulp-scan-worker rejects unsupported bundle extensions",
     REQUIRE(result.stdout_output.empty());
 }
 
+TEST_CASE("pulp-scan-worker rejects extension variants before scanning",
+          "[host][scan-worker][coverage][requested]") {
+    ScratchDir scratch("extension-variants");
+    auto upper_vst3 = scratch.path / "Upper.VST3";
+    auto partial = scratch.path / "Almost.vst3.tmp";
+    fs::create_directories(upper_vst3 / "Contents" / "Resources");
+    write_file(partial, "not a plugin");
+
+    auto upper_result = run_worker({upper_vst3.string()});
+    REQUIRE(upper_result.exit_code == 3);
+    REQUIRE_THAT(upper_result.stderr_output,
+                 ContainsSubstring("unsupported bundle extension"));
+    REQUIRE_THAT(upper_result.stderr_output, ContainsSubstring("Upper.VST3"));
+    REQUIRE(upper_result.stdout_output.empty());
+
+    auto partial_result = run_worker({partial.string()});
+    REQUIRE(partial_result.exit_code == 3);
+    REQUIRE_THAT(partial_result.stderr_output,
+                 ContainsSubstring("unsupported bundle extension"));
+    REQUIRE_THAT(partial_result.stderr_output, ContainsSubstring("Almost.vst3.tmp"));
+    REQUIRE(partial_result.stdout_output.empty());
+}
+
 TEST_CASE("pulp-scan-worker emits JSON for a manifest-free VST3 bundle",
           "[host][scan-worker][issue-493]") {
     ScratchDir scratch("vst3");


### PR DESCRIPTION
Adds targeted coverage for requested files/folders: Apple motion bridge/probe contracts, inspector window/section contracts, and scan-worker extension rejection paths. Also retains the requested coverage from prior merged batches for MCP/audio/import-design/codesign/inspector server-overlay areas.