### PR TITLE
docs(ios): reusable Apple dev-signing stub — notary.env template + source helper + ios-dev-signing guide

### DIFF
--- a/.agents/skills/auv3/SKILL.md
+++ b/.agents/skills/auv3/SKILL.md
@@ -358,6 +358,12 @@ You MUST:
 
 The full recipe is in `tools/scripts/sign-notarize-auv3-mac.sh`.
 
+For the reusable dev-signing cred layout that step 5 consumes
+(`PULP_TEAM_ID` / `PULP_NOTARY_*`), see
+[`docs/guides/ios-dev-signing.md`](../../../docs/guides/ios-dev-signing.md) —
+schema template + sourceable helper, no per-user identifiers in
+committed code.
+
 **Diagnostic for silent Pluginkit rejection:**
 
 ```bash

--- a/.agents/skills/ios/SKILL.md
+++ b/.agents/skills/ios/SKILL.md
@@ -336,7 +336,10 @@ xcrun simctl install booted build-ios-sim/AUv3/Release-iphonesimulator/PulpSineS
 xcrun simctl launch --console booted com.pulp.examples.sinesynth.host
 
 # Physical iPad (signed)
-source ~/.config/pulp/secrets/notary.env
+# Prefer the validated sourceable helper — it errors clearly on missing
+# keys / unfilled placeholders. See docs/guides/ios-dev-signing.md for
+# the full reusable dev-signing stub (schema template + one-time setup).
+. tools/scripts/source_dev_creds.sh
 cmake -S . -B build-ios-device -G Xcode \
   -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphoneos \
   -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=16.4 \

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -111,6 +111,10 @@ Two lanes, resolved in this precedence (CLI > env > file > config.toml):
    pulp ship notarize --dry-run        # prints resolved notarytool argv, no submit
    ```
 
+   For the full reusable dev-signing stub (schema template + sourceable
+   helper + per-plug-in setup), see
+   [`docs/guides/ios-dev-signing.md`](../../../docs/guides/ios-dev-signing.md).
+
 2. **Legacy Apple-ID + app-specific password** — kept working as a fallback.
 
    ```bash

--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,18 @@ tools/local-ci/results/
 .env
 .env.*
 !.env.example
+# Apple signing / notarization creds — see docs/guides/ios-dev-signing.md.
+# Real creds live at ~/.config/pulp/secrets/ (chmod 600). Belt-and-
+# suspenders against accidental commits inside the repo too.
+secrets/
+*.notary.env
+*.p8
+*.p12
+# Keep the committed schema-only template; rule must come AFTER the
+# broad `secrets/` glob above so the negation actually takes effect.
+!templates/secrets/
+!templates/secrets/notary.env.example
+templates/secrets/notary.env
 examples/web-demos/wasm-build/build/
 /.private/
 test/assets/

--- a/docs/guides/ios-dev-signing.md
+++ b/docs/guides/ios-dev-signing.md
@@ -1,0 +1,171 @@
+# Reusable Apple Dev-Signing Stub
+
+A repeatable, agent-friendly way to stand up an iOS or macOS signing
+path for **test builds** without copy-pasting recipes or hard-coding
+team IDs into committed code. Pairs with
+[`templates/secrets/notary.env.example`](../../templates/secrets/notary.env.example)
+and [`tools/scripts/source_dev_creds.sh`](../../tools/scripts/source_dev_creds.sh).
+
+## What this is for
+
+- **Test builds** for plug-ins and host apps.
+- **Development on real iOS devices** (iPad / iPhone) for AUv3 walkthroughs.
+- **Pre-AppStore validation** — codesign + notarize a macOS build before
+  the real submission flow.
+
+What this is **not** for: App Store release builds. Those need
+explicit per-app App IDs, real entitlements, an App Store Connect
+distribution profile, and the full submission flow described under
+[What MUST change for App Store release](#what-must-change-for-app-store-release).
+
+## One-time Apple setup
+
+These steps run once per Apple Developer account, not once per project.
+
+1. **Register a WILDCARD App ID** at
+   <https://developer.apple.com/account/resources/identifiers/list>.
+   - Description: `Pulp Dev Wildcard`
+   - Bundle ID: `Wildcard`, e.g. `com.<your-handle>.pulpdev.*`
+   - All capabilities OFF. Wildcard App IDs cannot use App Groups,
+     Push, Sign in with Apple, etc — and **none** of those are needed
+     for a local test plug-in. Skip them.
+
+2. **Generate an App Store Connect API key** at
+   <https://appstoreconnect.apple.com/access/integrations/api>.
+   - Role: `Developer` is sufficient for notarization. (`Admin` if
+     you also use the same key for ASC uploads.)
+   - Download the `.p8` once (it cannot be re-downloaded) and save it
+     to `~/.config/pulp/secrets/AuthKey_<KEY_ID>.p8`.
+   - Record the Key ID (10 chars) and Issuer ID (UUID at the top of
+     the Keys page) — you'll paste them into `notary.env` below.
+   - This single API key works for both macOS `xcrun notarytool` and
+     Linux `rcodesign`.
+
+3. **Skip explicit per-plug-in App IDs entirely** for test builds.
+   The wildcard above covers every plug-in you ever scaffold under
+   `com.<your-handle>.pulpdev.*`.
+
+## One-time machine setup
+
+```bash
+mkdir -p ~/.config/pulp/secrets
+cp templates/secrets/notary.env.example ~/.config/pulp/secrets/notary.env
+chmod 600 ~/.config/pulp/secrets/notary.env
+$EDITOR ~/.config/pulp/secrets/notary.env   # fill in your real values
+```
+
+Then verify the helper picks them up cleanly:
+
+```bash
+. tools/scripts/source_dev_creds.sh   # exit 0 silently on success
+echo "$PULP_TEAM_ID"                   # should print your 10-char team ID
+```
+
+If a required key is missing or still contains a `<...>` placeholder,
+the helper exits non-zero with a clear list of what to fix.
+
+## Per-plug-in setup
+
+Bundle IDs in your `CMakeLists.txt` must live under your wildcard
+prefix. The Apple **parent-child rule** for app extensions
+(`pkd` enforces it) requires the extension's bundle ID to be a
+strict child of the host app's bundle ID — no exceptions.
+
+For a hypothetical `MyKnob` plug-in:
+
+| Target            | Bundle ID                                        |
+|-------------------|--------------------------------------------------|
+| HostApp           | `com.<your-handle>.pulpdev.myknob.host`          |
+| AUv3 .appex       | `com.<your-handle>.pulpdev.myknob.host.MyKnob`   |
+
+Both fall under the `com.<your-handle>.pulpdev.*` wildcard, so a
+single App ID registration covers every plug-in you build going
+forward. No App Store Connect roundtrip per plug-in.
+
+## Build invocations
+
+### Simulator (no signing)
+
+```bash
+cmake -S . -B build-ios-sim -G Xcode \
+  -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphonesimulator \
+  -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=16.4 \
+  -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_TESTS=OFF
+cmake --build build-ios-sim --target MyKnob_HostApp --config Release -- -sdk iphonesimulator
+```
+
+### Physical iOS device (signed, automatic profile)
+
+```bash
+. tools/scripts/source_dev_creds.sh
+cmake -S . -B build-ios-device -G Xcode \
+  -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphoneos \
+  -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=16.4 \
+  -DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM="${PULP_TEAM_ID}" \
+  -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY="Apple Development" \
+  -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_STYLE="Automatic"
+cmake --build build-ios-device --target MyKnob_HostApp --config Release -- -sdk iphoneos
+```
+
+### Notarized macOS build (Developer ID, distributable)
+
+```bash
+. tools/scripts/source_dev_creds.sh
+pulp build
+pulp ship sign --identity "${PULP_SIGN_IDENTITY}"
+pulp ship notarize                # picks ASC key fields up from sourced env
+pulp ship package --version 0.1.0
+```
+
+`pulp ship notarize` reads `PULP_NOTARY_KEY_PATH`, `PULP_NOTARY_KEY_ID`,
+and `PULP_NOTARY_ISSUER_ID` from the environment, so sourcing the
+helper first is all the wiring needed. See the [`ship` skill](../../.agents/skills/ship/SKILL.md)
+for the full notarization precedence and the legacy Apple-ID lane.
+
+## What MUST change for App Store release
+
+The stub above is intentionally *not* an App Store release flow. For
+an actual ASC submission:
+
+1. **Explicit App ID per app** — required if you want App Groups, Push,
+   Sign in with Apple, or any capability the wildcard can't host.
+   Register at developer.apple.com under `Identifiers → App IDs →
+   App` (not Wildcard).
+2. **Apple Distribution cert + App Store provisioning profile** —
+   not the `Apple Development` cert. Generate via Xcode → Settings →
+   Accounts → Manage Certificates, or fastlane match.
+3. **Real entitlements file** matching the explicit App ID's
+   capabilities. `Entitlements.plist` in `templates/ios-auv3/` is the
+   minimal shape; capabilities you enabled on the App ID must appear
+   here.
+4. **Versioning + ASC submission** via `xcrun altool --upload-app`
+   or `xcrun notarytool submit --wait` followed by the App Store
+   Connect web flow for store metadata.
+
+Full release flow: [`docs/guides/shipping.md`](shipping.md).
+
+## Why we use this stub pattern
+
+- **Avoids registering N App IDs for N test plug-ins.** One wildcard
+  covers every plug-in under your namespace.
+- **Avoids hard-coding personal Team IDs into committed code or docs.**
+  All identifying data lives in your per-user `notary.env`.
+- **Lets multiple developers share one Pulp checkout** — each
+  developer sources their own `notary.env`; the same repo builds
+  signed plug-ins for any team.
+- **Standard layout** means any agent or contributor can build a
+  signed test plug-in by reading this guide once, without
+  reverse-engineering a custom recipe.
+
+## Related
+
+- [`.agents/skills/ship/SKILL.md`](../../.agents/skills/ship/SKILL.md) —
+  full sign / notarize / package reference.
+- [`.agents/skills/ios/SKILL.md`](../../.agents/skills/ios/SKILL.md) —
+  iOS platform and AUv3 host-app build details.
+- [`.agents/skills/auv3/SKILL.md`](../../.agents/skills/auv3/SKILL.md) —
+  AUv3 adapter and macOS notarization recipe.
+- [`templates/secrets/notary.env.example`](../../templates/secrets/notary.env.example) —
+  schema-only template (committed). Copy + fill in.
+- [`tools/scripts/source_dev_creds.sh`](../../tools/scripts/source_dev_creds.sh) —
+  sourceable helper that loads + validates the creds file.

--- a/templates/secrets/notary.env.example
+++ b/templates/secrets/notary.env.example
@@ -1,0 +1,30 @@
+# Pulp signing/notary creds for test builds + pre-AppStore validation.
+# Copy this to ~/.config/pulp/secrets/notary.env (NOT committed) and
+# fill in your own values. See docs/guides/ios-dev-signing.md.
+#
+# NEVER commit a real notary.env to any repo, public or private.
+# Keep file permissions at 600 (chmod 600 notary.env).
+
+# Apple Developer Team ID (10-char alphanumeric). developer.apple.com →
+# Membership Details.
+PULP_TEAM_ID="<YOUR_10_CHAR_TEAM_ID>"
+
+# Codesign identity for macOS Developer ID Application or iOS Apple
+# Development cert. The string after `=` must match `security
+# find-identity -v -p codesigning` output exactly.
+PULP_SIGN_IDENTITY="Developer ID Application: <Your Name> (<YOUR_TEAM_ID>)"
+PULP_SIGN_IDENTITY_SHA="<40_CHAR_SHA1_OF_CERT>"
+
+# App Store Connect API key for notarization (notarytool + rcodesign).
+# Create at App Store Connect → Users and Access → Keys → Generate
+# Issuer ID is a UUID at the top of the Keys page.
+PULP_NOTARY_KEY_ID="<10_CHAR_ASC_KEY_ID>"
+PULP_NOTARY_ISSUER_ID="<UUID_FROM_ASC_KEYS_PAGE>"
+PULP_NOTARY_KEY_PATH="$HOME/.config/pulp/secrets/AuthKey_<YOUR_KEY_ID>.p8"
+
+# Optional: PKCS#12 export of the codesign identity for Linux
+# rcodesign use. Only needed if you sign Apple binaries from Linux.
+#   security export -k login.keychain -t identities -f pkcs12 \
+#     -P "<password>" -o ~/.config/pulp/secrets/developerID.p12
+PULP_SIGN_P12_PATH="$HOME/.config/pulp/secrets/developerID.p12"
+PULP_SIGN_P12_PASSWORD=""

--- a/tools/scripts/source_dev_creds.sh
+++ b/tools/scripts/source_dev_creds.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# source_dev_creds.sh — load Pulp Apple signing / notary creds into the
+# current shell.
+#
+# Designed to be SOURCED, not executed. Examples:
+#
+#   . tools/scripts/source_dev_creds.sh
+#   cmake -S . -B build-ios-device -G Xcode \
+#     -DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM=$PULP_TEAM_ID \
+#     -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY="Apple Development" \
+#     -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_STYLE="Automatic"
+#
+# Lookup priority for the creds file:
+#   1. $PULP_SECRETS_FILE                        (env override)
+#   2. ./secrets/notary.env                      (project-local; useful in CI caches)
+#   3. ~/.config/pulp/secrets/notary.env         (per-user default)
+#
+# Schema:  templates/secrets/notary.env.example
+# Guide:   docs/guides/ios-dev-signing.md
+#
+# Errors out with a clear message when:
+#   - no creds file is found in any of the lookup locations
+#   - the file is found but a required key is missing
+#   - the file is found but a required key still contains a "<...>" placeholder
+#
+# Idempotent: sourcing twice is a no-op (re-exports the same values).
+
+# Detect sourced vs. executed — only sourced makes sense.
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  printf 'source_dev_creds.sh: this script must be SOURCED, not executed.\n' >&2
+  printf '  usage: . tools/scripts/source_dev_creds.sh\n' >&2
+  exit 64
+fi
+
+_pulp_creds_err() {
+  printf 'source_dev_creds.sh: %s\n' "$1" >&2
+  printf '  see docs/guides/ios-dev-signing.md and templates/secrets/notary.env.example\n' >&2
+  return 1
+}
+
+# Resolve creds file path.
+_pulp_creds_file=""
+if [ -n "${PULP_SECRETS_FILE:-}" ]; then
+  if [ -f "$PULP_SECRETS_FILE" ]; then
+    _pulp_creds_file="$PULP_SECRETS_FILE"
+  else
+    _pulp_creds_err "PULP_SECRETS_FILE='$PULP_SECRETS_FILE' set but file does not exist" || return 1
+  fi
+elif [ -f "./secrets/notary.env" ]; then
+  _pulp_creds_file="./secrets/notary.env"
+elif [ -f "$HOME/.config/pulp/secrets/notary.env" ]; then
+  _pulp_creds_file="$HOME/.config/pulp/secrets/notary.env"
+else
+  _pulp_creds_err "no creds file found. Tried: \$PULP_SECRETS_FILE, ./secrets/notary.env, ~/.config/pulp/secrets/notary.env" || return 1
+fi
+
+# Source it. set -a exports every assignment.
+set -a
+# shellcheck disable=SC1090
+. "$_pulp_creds_file"
+set +a
+
+# Validate required keys are set and don't still contain placeholders.
+_pulp_required_keys="PULP_TEAM_ID PULP_SIGN_IDENTITY PULP_NOTARY_KEY_ID PULP_NOTARY_ISSUER_ID PULP_NOTARY_KEY_PATH"
+
+_pulp_missing=""
+_pulp_placeholder=""
+for _k in $_pulp_required_keys; do
+  _v=$(eval "printf '%s' \"\${${_k}:-}\"")
+  if [ -z "$_v" ]; then
+    _pulp_missing="$_pulp_missing $_k"
+  elif printf '%s' "$_v" | grep -q '<.*>'; then
+    _pulp_placeholder="$_pulp_placeholder $_k"
+  fi
+done
+
+if [ -n "$_pulp_missing" ] || [ -n "$_pulp_placeholder" ]; then
+  printf 'source_dev_creds.sh: creds file %s is incomplete.\n' "$_pulp_creds_file" >&2
+  [ -n "$_pulp_missing" ] && printf '  missing keys:    %s\n' "${_pulp_missing# }" >&2
+  [ -n "$_pulp_placeholder" ] && printf '  placeholder values still present in: %s\n' "${_pulp_placeholder# }" >&2
+  printf '  fill in real values from your Apple Developer account, then re-source.\n' >&2
+  printf '  schema: templates/secrets/notary.env.example\n' >&2
+  printf '  guide:  docs/guides/ios-dev-signing.md\n' >&2
+  unset _pulp_creds_file _pulp_required_keys _pulp_missing _pulp_placeholder _k _v
+  return 1
+fi
+
+# Success — quiet by default. Set PULP_SECRETS_VERBOSE=1 to confirm.
+if [ "${PULP_SECRETS_VERBOSE:-0}" = "1" ]; then
+  printf 'source_dev_creds.sh: loaded creds from %s\n' "$_pulp_creds_file" >&2
+fi
+
+unset _pulp_creds_file _pulp_required_keys _pulp_missing _pulp_placeholder _k _v
+return 0


### PR DESCRIPTION
Captures the dev-signing recipe we keep re-deriving for iOS test
builds, AUv3 walkthroughs, and pre-AppStore notarization passes —
so any Pulp developer (or agent) can stand up a signing path
without copy-pasting and without leaking personal identifiers
into committed code.

What ships:

- templates/secrets/notary.env.example — schema-only template
  with PULP_TEAM_ID / PULP_SIGN_IDENTITY / PULP_NOTARY_* keys
  and "<placeholder>" values. Developer copies to
  ~/.config/pulp/secrets/notary.env (chmod 600) and fills in.

- tools/scripts/source_dev_creds.sh — sourceable helper.
  Looks up creds via \$PULP_SECRETS_FILE, ./secrets/notary.env,
  then ~/.config/pulp/secrets/notary.env. Validates required
  keys are present and don't still contain "<...>" placeholders.
  Errors clearly on missing file / missing key / placeholder.
  Idempotent — re-sourcing is a no-op.

- docs/guides/ios-dev-signing.md — user-facing guide. Covers
  one-time Apple setup (wildcard App ID + ASC API key), one-time
  machine setup, per-plug-in bundle-ID layout under the
  wildcard, build invocations for Simulator / physical iOS /
  notarized macOS, and the explicit list of what MUST change
  for an actual App Store release flow.

- .gitignore — belt-and-suspenders: ignore secrets/, *.p8,
  *.p12, *.notary.env, templates/secrets/notary.env; keep
  the schema-only example committed.

- .agents/skills/{auv3,ios,ship}/SKILL.md — brief cross-link
  pointers to the new guide. No duplication.

Pattern intentionally:
- carries zero per-user identifiers in committed files
- avoids the per-plugin App ID registration cost (wildcard covers all)
- works for both macOS (notarytool) and Linux (rcodesign) lanes
- complements the existing ~/.config/pulp/secrets/ layout already
  documented in the ship skill

For App Store release flow, see docs/guides/shipping.md — this
stub is explicitly for test / dev / pre-validation builds only.

Refs: task #46