### PR TITLE
test(python): cover binding export contracts

### DIFF
--- a/test/test_python_bindings.py
+++ b/test/test_python_bindings.py
@@ -7,6 +7,7 @@ import importlib.util
 import math
 import pathlib
 import sys
+from collections.abc import Callable
 
 
 def load_module(module_path: pathlib.Path):
@@ -66,6 +67,85 @@ def assert_param_range_bindings(pulp) -> None:
     assert math.isclose(info.range.denormalize(0.75), 0.5)
     info.range.default_value = 0.25
     assert math.isclose(info.range.default_value, 0.25)
+
+
+def assert_raises(exc_type: type[BaseException], fn: Callable[[], object]) -> None:
+    try:
+        fn()
+    except exc_type:
+        return
+    raise AssertionError(f"expected {exc_type.__name__}")
+
+
+def assert_exported_type_contracts(pulp) -> None:
+    expected_classes = {
+        "ParamRange",
+        "ParamInfo",
+        "StateStore",
+        "PluginDescriptor",
+        "MidiEvent",
+        "MidiBuffer",
+        "HeadlessHost",
+    }
+    for name in expected_classes:
+        obj = getattr(pulp, name)
+        assert obj.__module__ == "pulp"
+        assert obj.__name__ == name
+
+    assert hasattr(pulp.StateStore, "get_value")
+    assert hasattr(pulp.StateStore, "set_value")
+    assert hasattr(pulp.StateStore, "get_normalized")
+    assert hasattr(pulp.StateStore, "set_normalized")
+    assert hasattr(pulp.StateStore, "get_default")
+    assert hasattr(pulp.StateStore, "reset_to_default")
+    assert hasattr(pulp.StateStore, "reset_all_to_defaults")
+    assert hasattr(pulp.StateStore, "param_count")
+    assert hasattr(pulp.StateStore, "info")
+    assert hasattr(pulp.StateStore, "all_params")
+    assert hasattr(pulp.StateStore, "serialize")
+    assert hasattr(pulp.StateStore, "deserialize")
+
+    assert hasattr(pulp.PluginDescriptor, "name")
+    assert hasattr(pulp.PluginDescriptor, "manufacturer")
+    assert hasattr(pulp.PluginDescriptor, "version")
+    assert hasattr(pulp.PluginDescriptor, "bundle_id")
+    assert hasattr(pulp.PluginDescriptor, "is_instrument")
+
+    assert hasattr(pulp.HeadlessHost, "prepare")
+    assert hasattr(pulp.HeadlessHost, "release")
+    assert hasattr(pulp.HeadlessHost, "state")
+    assert hasattr(pulp.HeadlessHost, "descriptor")
+    assert hasattr(pulp.HeadlessHost, "save_state")
+    assert hasattr(pulp.HeadlessHost, "load_state")
+    assert hasattr(pulp.HeadlessHost, "process_numpy")
+    assert hasattr(pulp.HeadlessHost, "process_numpy_midi")
+
+    assert_raises(TypeError, lambda: pulp.StateStore())
+    assert_raises(TypeError, lambda: pulp.PluginDescriptor())
+    assert_raises(TypeError, lambda: pulp.HeadlessHost())
+
+
+def assert_binding_error_contracts(pulp) -> None:
+    keyword_range = pulp.ParamRange(min=-2.0, max=2.0, default_val=0.25)
+    assert math.isclose(keyword_range.min, -2.0)
+    assert math.isclose(keyword_range.max, 2.0)
+    assert math.isclose(keyword_range.default_value, 0.25)
+    assert math.isclose(keyword_range.normalize(0.0), 0.5)
+    assert math.isclose(keyword_range.denormalize(0.75), 1.0)
+    assert_raises(TypeError, lambda: pulp.ParamRange(min=0.0, max=1.0))
+    assert_raises(TypeError, lambda: pulp.ParamRange(0.0, 1.0, 0.5, 0.25))
+    assert_raises(TypeError, lambda: pulp.ParamRange("0", 1.0, 0.5))
+
+    info = pulp.ParamInfo()
+    assert_raises(TypeError, lambda: setattr(info, "id", "not-an-int"))
+    assert_raises(TypeError, lambda: setattr(info, "range", 123))
+
+    midi = pulp.MidiBuffer()
+    assert_raises(TypeError, lambda: midi.add(object()))
+    assert_raises(TypeError, lambda: pulp.MidiEvent.note_on(1, 60))
+    assert_raises(TypeError, lambda: pulp.MidiEvent.note_off(channel=1))
+    assert_raises(TypeError, lambda: pulp.MidiEvent.cc(1, 74))
+    assert_raises(TypeError, lambda: pulp.MidiEvent.pitch_bend(1))
 
 
 def assert_midi_bindings(pulp) -> None:
@@ -133,10 +213,15 @@ def main() -> int:
     assert pulp.__doc__ == "Pulp audio plugin framework — Python bindings"
     assert pulp.ParamRange.__name__ == "ParamRange"
     assert pulp.ParamInfo.__name__ == "ParamInfo"
+    assert pulp.StateStore.__name__ == "StateStore"
+    assert pulp.PluginDescriptor.__name__ == "PluginDescriptor"
     assert pulp.MidiEvent.__name__ == "MidiEvent"
     assert pulp.MidiBuffer.__name__ == "MidiBuffer"
+    assert pulp.HeadlessHost.__name__ == "HeadlessHost"
 
+    assert_exported_type_contracts(pulp)
     assert_param_range_bindings(pulp)
+    assert_binding_error_contracts(pulp)
     assert_midi_bindings(pulp)
 
     return 0


### PR DESCRIPTION
Add direct shared-module smoke coverage for the requested Python binding surface: exported class names, method/property exposure, constructor availability, and pybind TypeError paths.

Skill-Update: skip skill=python-bindings reason="test-only coverage for existing binding contracts"