### PR TITLE
feat(ios): Phase iOS-D.1 — minimal 2D GPU AUv3 proof + FindSkia iOS framework split + GPU-required hard-fail

### DIFF
--- a/.agents/skills/ios/SKILL.md
+++ b/.agents/skills/ios/SKILL.md
@@ -555,6 +555,74 @@ option 1 + option 3 over chasing a Sim audio capture. See
 `.agents/skills/auv3/SKILL.md` "iOS AUv3 diagnostic recipe" for the
 chain of `PULP_` prints to grep.
 
+### iOS GPU (Skia/Dawn) header-namespace gotcha — Phase iOS-D.1
+
+When the iOS configure first turns on Skia (i.e.
+`PULP_ENABLE_GPU=ON` + `PULP_HAS_SKIA` is set), two pre-existing bugs
+in `core/view/platform/ios/{window_host,plugin_view_host}_ios.mm`
+surfaced — they were inert because no prior iOS build had ever defined
+`PULP_HAS_SKIA`:
+
+1. **Skia / Dawn / Metal headers `#include`d inside an open
+   `namespace pulp::view {`.** Symptom is a wall of compile errors
+   from Apple's Metal headers — "Objective-C declarations may only
+   appear in global scope" on every `@protocol`. Cause: the open
+   namespace nests every header symbol under `pulp::view`, and
+   `@protocol` outside the global scope is a hard syntax error.
+   Fix: close the namespace before the `#include` block, reopen it
+   after.
+
+2. **`std::make_unique<render::GpuSurface>()` /
+   `<render::SkiaSurface>()`.** Both classes are abstract — use the
+   factories `render::GpuSurface::create_dawn()` and
+   `render::SkiaSurface::create(GpuSurface&, Config)`. The Config
+   struct exposes only `width` / `height` / `scale_factor`; Dawn
+   device/queue/instance are queried from the GpuSurface internally.
+
+3. **`pulp::render` was not linked into `pulp-view-core` on iOS.** The
+   mac branch in `core/view/CMakeLists.txt` linked `pulp::render`
+   under `if(PULP_HAS_SKIA)`; the iOS branch did not. Phase iOS-D.1
+   adds the same gate.
+
+### iOS GPU AUv3 acceptance log markers — Phase iOS-D.1
+
+A GPU-backed AUv3 view that's actually using Skia/Dawn on iOS emits a
+specific log sequence (see
+`planning/2026-05-28-ios-d-gpu-auv3-crosscheck.md`):
+
+```
+[plugin-gpu-host] adapter mode=custom use_gpu=true ... requires_gpu_host=true
+GpuSurface: created Metal surface from CAMetalLayer
+GpuSurface: Dawn initialized (surface: presentable)
+GpuSurface: backend_type=Metal     ← added by Phase iOS-D.1
+AU iOS: view controller loaded, ... mode=custom, gpu=true
+```
+
+Capture with:
+
+```bash
+xcrun simctl spawn booted log stream \
+  --predicate 'process == "<AppName>" OR eventMessage CONTAINS "GpuSurface" OR eventMessage CONTAINS "[plugin-gpu-host]" OR eventMessage CONTAINS "AU iOS"' \
+  --level debug
+```
+
+Missing `backend_type=Metal` (or `backend_type=Null` / `OpenGL`)
+means GPU init silently fell back to a non-Metal adapter — treat
+that as a P0 since the AUv3 is then rendering through software. The
+first frame may also log a benign
+`WebGPU error (2): First instance (1) must be zero` — that's an
+upstream Skia/Dawn first-frame issue, not a Pulp regression.
+
+### iOS GPU configure hard-fail — `PULP_REQUIRE_GPU_FOR_SDK`
+
+Phase iOS-D.1 extends the existing release-lane guard (pulp #1817) so
+the contradiction `PULP_REQUIRE_GPU_FOR_SDK=ON + PULP_ENABLE_GPU=OFF`
+hard-fails at configure time. Test:
+`bash test/cmake/test_require_gpu_for_sdk.sh <pulp-src>` — three
+cases (REQUIRE+ENABLE+missing-Skia fail; REQUIRE off succeeds;
+REQUIRE on + ENABLE off fails). Add a case here whenever a new flag
+contradicts an existing one.
+
 ## See Also
 
 - `android` skill — parallel structure for Android NDK.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.271.0
+    VERSION 0.272.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/render/src/gpu_surface_dawn.cpp
+++ b/core/render/src/gpu_surface_dawn.cpp
@@ -157,6 +157,24 @@ public:
         initialized_ = true;
         runtime::log_info("GpuSurface: Dawn initialized (surface: {})",
             surface_ ? "presentable" : "offscreen-only");
+
+        // Phase iOS-D.1 hard-fail gate
+        // (planning/2026-05-28-ios-d-gpu-auv3-crosscheck.md): log the Dawn
+        // backend type that actually came up. Tests / CI scrape this line
+        // to assert `backend_type=Metal` on Apple platforms; a missing or
+        // unexpected backend means GPU init silently fell back to a
+        // different adapter (Null, OpenGL emulation, etc.) and the editor
+        // is rendering through CPU. The adapter info is queried after
+        // device creation so the result reflects the real selection.
+        if (adapter_) {
+            wgpu::AdapterInfo dawn_info{};
+            adapter_.GetInfo(&dawn_info);
+            runtime::log_info("GpuSurface: backend_type={}",
+                dawn_backend_type_name(dawn_info.backendType));
+        } else {
+            runtime::log_warn(
+                "GpuSurface: backend_type=unknown (adapter unset after init)");
+        }
         return true;
     }
 

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -526,6 +526,17 @@ if(APPLE)
             "-framework CoreGraphics"
             "-framework QuartzCore"
         )
+        # Phase iOS-D.1 — wire iOS GPU window host (window_host_ios.mm's
+        # IOSGpuWindowHost branch). Mirrors the mac branch below:
+        # `pulp::render` exposes Dawn / Skia Graphite + the GpuSurface
+        # interface, and the Metal framework backs the CAMetalLayer.
+        # `pulp::render` is gated by PULP_HAS_SKIA so a no-Skia iOS
+        # configure (CG-only) still links cleanly.
+        if(PULP_HAS_SKIA)
+            target_link_libraries(pulp-view-core PRIVATE pulp::render
+                "-framework Metal"
+            )
+        endif()
     else()
         target_sources(pulp-view-core PRIVATE
             platform/mac/window_host_mac.mm

--- a/core/view/platform/ios/plugin_view_host_ios.mm
+++ b/core/view/platform/ios/plugin_view_host_ios.mm
@@ -308,14 +308,27 @@ private:
 
 // ── GPU-accelerated iOS plugin view host ─────────────────────────────────
 
+// Close the open `namespace pulp::view {` before pulling in Skia / Dawn /
+// Metal headers — otherwise `pulp::render::*` ends up nested as
+// `pulp::view::pulp::render::*` and Metal's Objective-C `@protocol`
+// declarations land inside a C++ namespace, which the compiler rejects
+// ("Objective-C declarations may only appear in global scope"). The
+// bug was inert before Phase iOS-D.1 because no iOS configure had
+// `PULP_HAS_SKIA` defined; turning Skia on for iOS surfaced it
+// immediately.
+}  // namespace pulp::view
+
 #ifdef PULP_HAS_SKIA
 #include <pulp/render/gpu_surface.hpp>
 #include <pulp/render/skia_surface.hpp>
 #include <pulp/view/frame_clock.hpp>
+#include <pulp/runtime/log.hpp>
 #include <functional>
 #include <memory>
 #import <QuartzCore/CAMetalLayer.h>
 #import <Metal/Metal.h>
+
+namespace pulp::view {
 
 class IOSGpuPluginViewHost;
 

--- a/core/view/platform/ios/plugin_view_host_ios.mm
+++ b/core/view/platform/ios/plugin_view_host_ios.mm
@@ -637,9 +637,9 @@ private:
 }
 @end
 
-namespace pulp::view {
-
 #endif // PULP_HAS_SKIA
+
+namespace pulp::view {
 
 // Factory functions
 std::unique_ptr<PluginViewHost> PluginViewHost::create(View& root, Size size) {

--- a/core/view/platform/ios/window_host_ios.mm
+++ b/core/view/platform/ios/window_host_ios.mm
@@ -380,9 +380,23 @@ private:
 
 // ── IOSGpuWindowHost (GPU rendering via Dawn/Skia Graphite) ─────────────
 
+// Close the `namespace pulp::view {` opened around IOSWindowHost so the
+// Skia / Dawn / runtime headers below resolve at the global ::pulp::*
+// scope. Phase iOS-D.1: previously the includes were emitted INSIDE the
+// open namespace, which nested everything as
+// `pulp::view::pulp::render::*` and made every later use of
+// `render::GpuSurface` fail to resolve (it became
+// `pulp::view::render::GpuSurface`, which does not exist). The bug went
+// undetected because no iOS build had `PULP_HAS_SKIA` defined until
+// Phase iOS-D.1 wired the iOS Skia/Dawn link.
+}  // namespace pulp::view
+
 #ifdef PULP_HAS_SKIA
 #include <pulp/render/gpu_surface.hpp>
 #include <pulp/render/skia_surface.hpp>
+#include <pulp/runtime/log.hpp>
+
+namespace pulp::view {
 
 // Forward decl for the display-link bridge.
 class IOSGpuWindowHost;
@@ -534,30 +548,37 @@ public:
             uint32_t pw = static_cast<uint32_t>(bounds.width * scale);
             uint32_t ph = static_cast<uint32_t>(bounds.height * scale);
 
-            // Initialize GPU surface with Metal layer
-            render::GpuSurface::Config gpu_config;
-            gpu_config.width = pw;
-            gpu_config.height = ph;
-            gpu_config.native_surface_handle = (__bridge void*)[metal_view_ metalLayer];
-
-            gpu_surface_ = std::make_unique<render::GpuSurface>();
-            if (!gpu_surface_->initialize(gpu_config)) {
-                runtime::log_error("iOS GPU: GpuSurface init failed, falling back to CPU");
-                gpu_surface_.reset();
+            // Initialize GPU surface with Metal layer.
+            // GpuSurface is an abstract interface — use the create_dawn()
+            // factory, not std::make_unique. SkiaSurface::create() takes
+            // a GpuSurface& and a Config struct that exposes only width,
+            // height, and scale_factor (it queries the GPU side for the
+            // Dawn device/queue handles internally). Phase iOS-D.1.
+            gpu_surface_ = render::GpuSurface::create_dawn();
+            if (!gpu_surface_) {
+                runtime::log_error("iOS GPU: GpuSurface::create_dawn() returned null, "
+                                   "falling back to CPU");
             } else {
-                // Initialize Skia surface sharing Dawn device
-                render::SkiaSurface::Config skia_config;
-                skia_config.width = pw;
-                skia_config.height = ph;
-                skia_config.dawn_device = gpu_surface_->dawn_device_handle();
-                skia_config.dawn_queue = gpu_surface_->dawn_queue_handle();
-                skia_config.dawn_instance = gpu_surface_->dawn_instance_handle();
+                render::GpuSurface::Config gpu_config{};
+                gpu_config.width = pw;
+                gpu_config.height = ph;
+                gpu_config.native_surface_handle = (__bridge void*)[metal_view_ metalLayer];
 
-                skia_surface_ = std::make_unique<render::SkiaSurface>();
-                if (!skia_surface_->initialize(skia_config)) {
-                    runtime::log_error("iOS GPU: SkiaSurface init failed");
-                    skia_surface_.reset();
+                if (!gpu_surface_->initialize(gpu_config)) {
+                    runtime::log_error("iOS GPU: GpuSurface init failed, falling back to CPU");
                     gpu_surface_.reset();
+                } else {
+                    CGFloat layer_scale = metal_view_.metalLayer.contentsScale;
+                    render::SkiaSurface::Config skia_config{};
+                    skia_config.width = static_cast<uint32_t>(bounds.width);
+                    skia_config.height = static_cast<uint32_t>(bounds.height);
+                    skia_config.scale_factor = static_cast<float>(layer_scale);
+
+                    skia_surface_ = render::SkiaSurface::create(*gpu_surface_, skia_config);
+                    if (!skia_surface_) {
+                        runtime::log_error("iOS GPU: SkiaSurface::create returned null");
+                        gpu_surface_.reset();
+                    }
                 }
             }
 

--- a/core/view/platform/ios/window_host_ios.mm
+++ b/core/view/platform/ios/window_host_ios.mm
@@ -697,9 +697,9 @@ private:
 }
 @end
 
-namespace pulp::view {
-
 #endif // PULP_HAS_SKIA
+
+namespace pulp::view {
 
 std::unique_ptr<WindowHost> WindowHost::create(View& root, const WindowOptions& options) {
 #ifdef PULP_HAS_SKIA

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -111,6 +111,9 @@ add_subdirectory(stream-demo)
 # iOS AUv3 example (workstream 05 slice 5.1) — gated on CMAKE_SYSTEM_NAME=iOS
 if(IOS)
     add_subdirectory(ios-auv3-synth)
+    # Phase iOS-D.1 — minimal 2D GPU AUv3 proof
+    # (planning/2026-05-24-auv3-ios-validation.md).
+    add_subdirectory(ios-auv3-gpu-smoke)
 endif()
 
 # ARA pitch tracker example (workstream 06 slice A3)

--- a/examples/ios-auv3-gpu-smoke/CMakeLists.txt
+++ b/examples/ios-auv3-gpu-smoke/CMakeLists.txt
@@ -1,0 +1,50 @@
+# Phase iOS-D.1 — minimal 2D GPU AUv3 proof on iOS.
+#
+# The smallest possible AU effect whose view renders a single animated
+# 2D primitive through Skia/Dawn on iOS, proving that the GPU plugin
+# host (`core/view/platform/ios/plugin_view_host_ios.mm`) and the Dawn
+# Metal surface path (`core/render/src/gpu_surface_dawn.cpp`) work
+# end-to-end inside an AUv3 .appex.
+#
+# Build (Simulator):
+#   cmake -S . -B build-ios-sim-gpu -G Xcode \
+#     -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphonesimulator \
+#     -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=16.4 \
+#     -DPULP_ENABLE_GPU=ON -DPULP_REQUIRE_GPU_FOR_SDK=ON
+#   cmake --build build-ios-sim-gpu --target PulpGpuSmoke_HostApp_Embed \
+#     --config Release -- -sdk iphonesimulator
+#
+# Validation log markers (search syslog/Xcode console):
+#   AU iOS: view controller loaded, ... gpu=1
+#   GpuSurface: created Metal surface from CAMetalLayer
+#   GpuSurface: Dawn initialized
+#   GpuSurface: backend_type=Metal
+#
+# See planning/2026-05-24-auv3-ios-validation.md Phase iOS-D and the
+# Codex crosscheck at planning/2026-05-28-ios-d-gpu-auv3-crosscheck.md.
+
+if(NOT IOS)
+    return()
+endif()
+
+pulp_add_ios_auv3(
+    NAME            PulpGpuSmoke
+    BUNDLE_ID       com.danielraffel.pulpdev.gpusmoke.host.PulpGpuSmoke
+    MANUFACTURER    Pulp
+    MANUFACTURER_CODE  Pulp
+    SUBTYPE_CODE    PgSm
+    AU_TYPE         aufx            # effect (no MIDI required, no synth voice)
+    VERSION         0.1.0
+    SOURCES
+        src/gpu_smoke.cpp
+        src/gpu_smoke.hpp
+        src/au_v3_entry.cpp
+)
+
+pulp_add_ios_host_app(PulpGpuSmoke_HostApp
+    AUV3_EXTENSION    PulpGpuSmoke_AUv3
+    BUNDLE_ID         com.danielraffel.pulpdev.gpusmoke.host
+    NAME              "PulpGpuSmoke"
+    VERSION           0.1.0
+    DEPLOYMENT_TARGET 16.4
+)

--- a/examples/ios-auv3-gpu-smoke/src/au_v3_entry.cpp
+++ b/examples/ios-auv3-gpu-smoke/src/au_v3_entry.cpp
@@ -1,0 +1,16 @@
+// Phase iOS-D.1 — AU v3 entry for the iOS GPU smoke example.
+// Mirrors examples/ios-auv3-synth/src/au_v3_entry.cpp: registers the
+// processor factory with the AU v3 shared entry. Without this TU the
+// .appex links but `PulpAUFactory` finds `registered_factory()` == null
+// and refuses to instantiate the AU.
+
+#include "gpu_smoke.hpp"
+#include <pulp/format/au_v3_entry.hpp>
+
+namespace {
+std::unique_ptr<pulp::format::Processor> create_gpu_smoke() {
+    return std::make_unique<pulp::examples::ios_gpu_smoke::GpuSmoke>();
+}
+} // namespace
+
+PULP_AUV3_PLUGIN(create_gpu_smoke)

--- a/examples/ios-auv3-gpu-smoke/src/gpu_smoke.cpp
+++ b/examples/ios-auv3-gpu-smoke/src/gpu_smoke.cpp
@@ -1,0 +1,132 @@
+#include "gpu_smoke.hpp"
+
+#include <pulp/canvas/canvas.hpp>
+#include <pulp/runtime/log.hpp>
+#include <pulp/view/frame_clock.hpp>
+#include <pulp/view/view.hpp>
+
+#include <cmath>
+#include <memory>
+
+namespace pulp::examples::ios_gpu_smoke {
+
+using namespace pulp::format;
+using namespace pulp::state;
+using namespace pulp::audio;
+using namespace pulp::midi;
+
+namespace {
+
+// View subclass with one animated 2D primitive driven off FrameClock.
+// Flags `requires_gpu_host=true` so decide_gpu_host() routes through the
+// Metal/Dawn PluginViewHost on iOS — that's the path Phase iOS-D.1 is
+// proving end-to-end.
+class GpuSmokeView : public pulp::view::View {
+public:
+    GpuSmokeView() {
+        set_requires_gpu_host(true);
+    }
+
+    void on_attached() override {
+        // Subscribe to the frame clock so we re-paint on every vsync tick
+        // the iOS CADisplayLink delivers via PluginViewHost.
+        if (auto* clock = frame_clock()) {
+            sub_id_ = clock->subscribe([this](float dt) {
+                t_ += dt;
+                request_repaint();
+                return true;
+            });
+        }
+        pulp::runtime::log_info(
+            "[gpu-smoke] view attached, awaiting FrameClock ticks");
+    }
+
+    void on_detached() override {
+        if (auto* clock = frame_clock()) {
+            if (sub_id_ != 0) clock->unsubscribe(sub_id_);
+        }
+        sub_id_ = 0;
+    }
+
+    void paint(pulp::canvas::Canvas& canvas) override {
+        const auto r = local_bounds();
+        // Background: dark blue so a CPU-fallback fill (pure black) is
+        // immediately obvious if Skia/Dawn never came up.
+        canvas.set_fill_color(pulp::canvas::Color::rgba(0.04f, 0.06f, 0.12f));
+        canvas.fill_rect(r.x, r.y, r.width, r.height);
+
+        // One rotating coloured quad in the centre. Cheap to draw, but
+        // animates every frame so a Metal frame capture from Xcode shows
+        // real command buffers landing on the iPad GPU.
+        const float cx = r.x + r.width * 0.5f;
+        const float cy = r.y + r.height * 0.5f;
+        const float side = std::min(r.width, r.height) * 0.4f;
+
+        const float angle = t_ * 1.2f; // ~0.2 turns/sec
+
+        canvas.save();
+        canvas.translate(cx, cy);
+        canvas.rotate(angle);  // composes onto current transform
+        const float hue = std::fmod(t_ * 60.0f, 360.0f);
+        const auto col = pulp::canvas::Color::from_hsv(
+            {hue, 0.8f, 1.0f});
+        canvas.set_fill_color(col);
+        canvas.fill_rect(-side * 0.5f, -side * 0.5f, side, side);
+        canvas.restore();
+    }
+
+private:
+    int sub_id_ = 0;
+    float t_ = 0.0f;
+};
+
+} // namespace
+
+PluginDescriptor GpuSmoke::descriptor() const {
+    PluginDescriptor d;
+    d.name = "Pulp GPU Smoke";
+    d.manufacturer = "Pulp";
+    d.bundle_id = "com.pulp.examples.gpusmoke";
+    d.version = "0.1.0";
+    d.category = PluginCategory::Effect;
+    d.accepts_midi = false;
+    d.produces_midi = false;
+    d.input_buses = {{"Main In", 2, false}};
+    d.output_buses = {{"Main Out", 2, false}};
+    return d;
+}
+
+void GpuSmoke::define_parameters(StateStore& /*store*/) {
+    // No parameters — keeps the AU surface as small as possible so the
+    // proof is exclusively about the GPU view path.
+}
+
+void GpuSmoke::prepare(const PrepareContext& /*ctx*/) {}
+
+void GpuSmoke::process(BufferView<float>& out,
+                       const BufferView<const float>& in,
+                       MidiBuffer& /*midi_in*/,
+                       MidiBuffer& /*midi_out*/,
+                       const ProcessContext& ctx) {
+    // Bit-perfect bypass: copy input to output, fill silence on any
+    // missing channel. Effect plug-ins with no audio path still must
+    // not leave garbage in the output buffers.
+    const int n = ctx.num_samples;
+    const int out_chs = out.num_channels();
+    const int in_chs = in.num_channels();
+    for (int ch = 0; ch < out_chs; ++ch) {
+        auto dst = out.channel(ch);
+        if (ch < in_chs) {
+            auto src = in.channel(ch);
+            for (int i = 0; i < n; ++i) dst[i] = src[i];
+        } else {
+            for (int i = 0; i < n; ++i) dst[i] = 0.0f;
+        }
+    }
+}
+
+std::unique_ptr<pulp::view::View> GpuSmoke::create_view() {
+    return std::make_unique<GpuSmokeView>();
+}
+
+} // namespace pulp::examples::ios_gpu_smoke

--- a/examples/ios-auv3-gpu-smoke/src/gpu_smoke.hpp
+++ b/examples/ios-auv3-gpu-smoke/src/gpu_smoke.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+// Phase iOS-D.1 — minimal 2D GPU AUv3 proof.
+//
+// A near-silent effect plug-in whose only job is to install a custom
+// view that draws ONE animated 2D primitive through the Skia/Dawn path.
+// The view sets `requires_gpu_host(true)` so the format adapter's
+// `decide_gpu_host()` routes through the Metal/Dawn PluginViewHost; on
+// iOS that exercises `core/render/src/gpu_surface_dawn.cpp`'s
+// CAMetalLayer surface creation.
+//
+// Hard fail expectations on success:
+//   - log line: `AU iOS ... gpu=1`
+//   - log line: `GpuSurface: created Metal surface from CAMetalLayer`
+//   - log line: `GpuSurface: Dawn initialized`
+//   - log line: `GpuSurface: backend_type=Metal`
+//   - visible animated quad rotating at the centre of the editor.
+//
+// See planning/2026-05-24-auv3-ios-validation.md Phase iOS-D and
+// the Codex crosscheck at planning/2026-05-28-ios-d-gpu-auv3-crosscheck.md.
+
+#include <pulp/format/processor.hpp>
+
+namespace pulp::examples::ios_gpu_smoke {
+
+class GpuSmoke : public pulp::format::Processor {
+public:
+    pulp::format::PluginDescriptor descriptor() const override;
+    void define_parameters(pulp::state::StateStore& store) override;
+    void prepare(const pulp::format::PrepareContext& ctx) override;
+    void process(pulp::audio::BufferView<float>& out,
+                 const pulp::audio::BufferView<const float>& in,
+                 pulp::midi::MidiBuffer& midi_in,
+                 pulp::midi::MidiBuffer& midi_out,
+                 const pulp::format::ProcessContext& ctx) override;
+
+    std::pair<uint32_t, uint32_t> editor_size() const override { return {320, 320}; }
+    std::unique_ptr<pulp::view::View> create_view() override;
+};
+
+} // namespace pulp::examples::ios_gpu_smoke

--- a/test/cmake/test_require_gpu_for_sdk.sh
+++ b/test/cmake/test_require_gpu_for_sdk.sh
@@ -105,4 +105,41 @@ if grep -q "PULP_REQUIRE_GPU_FOR_SDK=ON but Skia binaries were not found" "${cas
 fi
 
 echo "OK case 2: PULP_REQUIRE_GPU_FOR_SDK=OFF (default) configures without Skia"
-echo "OK: PULP_REQUIRE_GPU_FOR_SDK gate behaves correctly (pulp #1817)"
+
+# ── Case 3: PULP_REQUIRE_GPU_FOR_SDK=ON + PULP_ENABLE_GPU=OFF contradicts ─
+#
+# Phase iOS-D.1 added an inverse guard (planning/2026-05-28-ios-d-gpu-auv3-
+# crosscheck.md): asking the release lane to enforce GPU while disabling
+# it is a misconfiguration that the SDK consumer can never recover from.
+# Without this guard the previous Case 1 was the only enforcement, and a
+# release lane that flipped both flags would silently ship a CG-only SDK.
+case3_build="${tmp_root}/case3-require-on-gpu-off"
+case3_log="${tmp_root}/case3.log"
+
+set +e
+cmake \
+    -S "${pulp_root}" \
+    -B "${case3_build}" \
+    -DSKIA_DIR="${fake_skia}" \
+    -DPULP_ENABLE_GPU=OFF \
+    -DPULP_REQUIRE_GPU_FOR_SDK=ON \
+    -DPULP_BUILD_TESTS=OFF \
+    -DPULP_BUILD_EXAMPLES=OFF \
+    >"${case3_log}" 2>&1
+case3_status=$?
+set -e
+
+if [[ ${case3_status} -eq 0 ]]; then
+    echo "FAIL: REQUIRE_GPU_FOR_SDK=ON + ENABLE_GPU=OFF should have failed configure but it succeeded" >&2
+    tail -n 60 "${case3_log}" >&2
+    exit 1
+fi
+
+if ! grep -q "PULP_ENABLE_GPU=OFF" "${case3_log}"; then
+    echo "FAIL: expected the contradiction diagnostic to mention PULP_ENABLE_GPU=OFF" >&2
+    tail -n 80 "${case3_log}" >&2
+    exit 1
+fi
+
+echo "OK case 3: PULP_REQUIRE_GPU_FOR_SDK=ON + PULP_ENABLE_GPU=OFF correctly failed configure"
+echo "OK: PULP_REQUIRE_GPU_FOR_SDK gate behaves correctly (pulp #1817 + Phase iOS-D.1)"

--- a/tools/cmake/FindSkia.cmake
+++ b/tools/cmake/FindSkia.cmake
@@ -256,10 +256,26 @@ if(EXISTS "${SKIA_LIBRARY}" AND EXISTS "${_skia_include_dir}")
             # via clang's driver, so adding it here is a no-op for native
             # builds and a fix for the cross lane.
             # See planning/2026-05-24-linux-hosted-macos-arm64-cross-lane.md.
-            set_property(TARGET skia::skia APPEND PROPERTY
-                INTERFACE_LINK_LIBRARIES
-                    "-framework Metal;-framework MetalKit;-framework CoreFoundation;-framework CoreGraphics;-framework CoreText;-framework Foundation;-framework IOKit;-framework IOSurface;-framework QuartzCore;objc"
-            )
+            #
+            # iOS / macOS framework split (Phase iOS-D.1, crosscheck
+            # planning/2026-05-28-ios-d-gpu-auv3-crosscheck.md):
+            #   * macOS exposes IOKit; iOS does not (UIKit replaces it),
+            #     and linking `-framework IOKit` against the iPhoneOS /
+            #     iPhoneSimulator SDK fails with "framework not found".
+            #   * The remaining frameworks (Metal, MetalKit, CoreFoundation,
+            #     CoreGraphics, CoreText, Foundation, IOSurface, QuartzCore)
+            #     are available on both platforms — split is IOKit only.
+            if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+                set_property(TARGET skia::skia APPEND PROPERTY
+                    INTERFACE_LINK_LIBRARIES
+                        "-framework Metal;-framework MetalKit;-framework CoreFoundation;-framework CoreGraphics;-framework CoreText;-framework Foundation;-framework IOSurface;-framework QuartzCore;objc"
+                )
+            else()
+                set_property(TARGET skia::skia APPEND PROPERTY
+                    INTERFACE_LINK_LIBRARIES
+                        "-framework Metal;-framework MetalKit;-framework CoreFoundation;-framework CoreGraphics;-framework CoreText;-framework Foundation;-framework IOKit;-framework IOSurface;-framework QuartzCore;objc"
+                )
+            endif()
         elseif(ANDROID)
             set_property(TARGET skia::skia APPEND PROPERTY
                 INTERFACE_LINK_LIBRARIES

--- a/tools/cmake/PulpDependencies.cmake
+++ b/tools/cmake/PulpDependencies.cmake
@@ -177,6 +177,24 @@ if(PULP_ENABLE_GPU AND PULP_REQUIRE_GPU_FOR_SDK AND NOT PULP_HAS_SKIA)
         "fetch) or set PULP_ENABLE_GPU=OFF if you intend a CG-only build.")
 endif()
 
+# Phase iOS-D.1 — `PULP_REQUIRE_GPU_FOR_SDK=ON + PULP_ENABLE_GPU=OFF` is a
+# misconfiguration: the consumer asked the release lane to enforce GPU but
+# then disabled it. Without this guard the configure succeeded, the
+# resulting tarball silently #ifdef'd out the GPU code path, and downstream
+# consumers got the same CG-only fallback the option exists to prevent —
+# defeating the whole purpose of the flag. Fail loudly at configure time.
+# (planning/2026-05-28-ios-d-gpu-auv3-crosscheck.md, hard-fail-on-CPU rule.)
+if(PULP_REQUIRE_GPU_FOR_SDK AND NOT PULP_ENABLE_GPU)
+    message(FATAL_ERROR
+        "PULP_REQUIRE_GPU_FOR_SDK=ON but PULP_ENABLE_GPU=OFF — these "
+        "options contradict each other. PULP_REQUIRE_GPU_FOR_SDK exists to "
+        "guarantee the SDK release ships with the GPU code path linked, "
+        "and PULP_ENABLE_GPU=OFF #ifdef's that exact path out. Either set "
+        "PULP_ENABLE_GPU=ON (and let the existing FATAL_ERROR above catch "
+        "a missing Skia archive) or set PULP_REQUIRE_GPU_FOR_SDK=OFF for a "
+        "deliberate CG-only build.")
+endif()
+
 # Text shaping requires GPU/Skia — validate even when GPU is off
 if(PULP_TEXT_SHAPING AND NOT PULP_ENABLE_GPU)
     message(WARNING "PULP_TEXT_SHAPING requires PULP_ENABLE_GPU — disabling text shaping")


### PR DESCRIPTION
Phase iOS-D.1 of planning/2026-05-24-auv3-ios-validation.md — the
smallest possible proof that Pulp's Skia + Dawn GPU stack rasterizes
on iOS inside an AUv3 extension. Per the Codex crosscheck at
planning/2026-05-28-ios-d-gpu-auv3-crosscheck.md, this is the FIRST of
three sub-slices and intentionally excludes Chainer / WebGPU /
Three.js — those land in iOS-D.2 and iOS-D.3 once the Skia/Dawn
baseline is proven.

What's in this PR:

* examples/ios-auv3-gpu-smoke/ — minimal AU effect (aufx) whose
  custom view draws ONE rotating coloured 2D quad through Skia/Dawn.
  The view sets `requires_gpu_host(true)` so `decide_gpu_host()`
  routes through the Metal/Dawn PluginViewHost on iOS (mode=custom).

* tools/cmake/FindSkia.cmake — split Apple framework list per
  platform. iOS doesn't have `-framework IOKit` (UIKit replaces it),
  so the old list failed at link time. Split to drop IOKit on iOS,
  keep everything else identical.

* tools/cmake/PulpDependencies.cmake — add inverse hard-fail for
  `PULP_REQUIRE_GPU_FOR_SDK=ON + PULP_ENABLE_GPU=OFF`. Without this,
  the release lane could silently ship a CG-only SDK by flipping
  one flag without the other.

* core/render/src/gpu_surface_dawn.cpp — emit a new
  `GpuSurface: backend_type=<Metal|...>` log line after Dawn init so
  CI and smoke can assert the real adapter backend that came up, not
  just "Dawn initialized" (which doesn't say WHICH backend).

* core/view/platform/ios/{plugin_view_host,window_host}_ios.mm —
  fix pre-existing bug where Skia / Dawn / Metal headers were
  `#include`d inside `namespace pulp::view {`. The nested namespace
  put every `@protocol` declaration in the included Metal headers
  outside global scope and made every later `render::GpuSurface`
  reference resolve to `pulp::view::render::GpuSurface` (which
  doesn't exist). The bug was inert because no iOS configure had
  `PULP_HAS_SKIA` defined before iOS-D.1 turned it on; the fix is to
  close the namespace before the includes and reopen after. Also
  switch `window_host_ios.mm`'s GPU init to the
  `GpuSurface::create_dawn()` + `SkiaSurface::create(gpu, cfg)`
  factories (the previous code called `std::make_unique<GpuSurface>()`
  on the abstract base, which would have crashed at run time if it
  ever compiled).

* core/view/CMakeLists.txt — link `pulp::render` and `-framework
  Metal` to `pulp-view-core` on iOS when `PULP_HAS_SKIA` is set.
  Mirrors the existing mac branch.

* test/cmake/test_require_gpu_for_sdk.sh — add case 3 for the new
  contradiction hard-fail.

* .agents/skills/ios/SKILL.md — document the four iOS GPU
  bring-up gotchas (header-namespace bug, abstract-class factory
  usage, missing `pulp::render` link, required log markers) so the
  next agent landing iOS-D.2 / iOS-D.3 doesn't relearn them.

Sim validation (iPad Pro 13-inch M5, iOS 26.4) — all required log
markers from the crosscheck captured:

  [plugin-gpu-host] adapter mode=custom use_gpu=true requires_gpu_host=true build=release
  GpuSurface: created Metal surface from CAMetalLayer
  GpuSurface: Dawn initialized (surface: presentable)
  GpuSurface: backend_type=Metal
  AU iOS: view controller loaded, 320x320, mode=custom, gpu=true

Screenshot: planning/screenshots/2026-05-28-ios-d1-gpu-smoke/sim-launch.png.

Device build is signed and ready at
build-ios-device-gpu/AUv3/Release/PulpGpuSmoke.app for physical
iPad install.

Depends on PR #3095 (fix/ios-auv3-audio-path) — built on top of
4cd58d0e3 which carries the MH_EXECUTE binary + .loadOutOfProcess
host + MIDI wiring without which the .appex can't even instantiate.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Skill-Update: skip skill=motion reason="pre-existing test from base branch, not modified in this PR"