### PR TITLE
test(platform): cover bridge signing contracts

### DIFF
--- a/ship/platform/mac/codesign_mac.mm
+++ b/ship/platform/mac/codesign_mac.mm
@@ -31,7 +31,8 @@ SigningInfo parse_codesign_details(const std::string& output) {
 }
 
 std::optional<std::string> parse_notarytool_submit_id(const std::string& output) {
-    std::regex uuid_re("id: ([0-9a-f-]+)");
+    std::regex uuid_re(
+        R"(id: ([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})(?:\s|$))");
     std::smatch match;
     if (std::regex_search(output, match, uuid_re))
         return match[1].str();

--- a/test/test_codesign.cpp
+++ b/test/test_codesign.cpp
@@ -303,6 +303,16 @@ Submission ID received
     REQUIRE(lower.has_value());
     REQUIRE(*lower == "abcdefab-1234-5678-9abc-def012345678");
 
+    auto upper = pulp::ship::detail::parse_notarytool_submit_id(
+        "id: ABCDEFAB-1234-5678-9ABC-DEF012345678\nstatus: Accepted");
+    REQUIRE(upper.has_value());
+    REQUIRE(*upper == "ABCDEFAB-1234-5678-9ABC-DEF012345678");
+
+    REQUIRE_FALSE(pulp::ship::detail::parse_notarytool_submit_id("id: abc").has_value());
+    REQUIRE_FALSE(pulp::ship::detail::parse_notarytool_submit_id(
+        "id: abcdefab-1234-5678-9abc-def012345678-extra").has_value());
+    REQUIRE_FALSE(pulp::ship::detail::parse_notarytool_submit_id(
+        "id: abcdefab-1234-5678-9abc-def01234567g").has_value());
     REQUIRE_FALSE(pulp::ship::detail::parse_notarytool_submit_id("id: NOT-A-UUID").has_value());
     REQUIRE_FALSE(pulp::ship::detail::parse_notarytool_submit_id("status: Invalid").has_value());
 #endif

--- a/test/test_motion_swift_bridge.cpp
+++ b/test/test_motion_swift_bridge.cpp
@@ -288,7 +288,34 @@ TEST_CASE("pulp_motion_update_geometry with a non-default metric also emits",
     pulp_motion_update_geometry(id, "scroll", 0.0, 100.0, 320.0, 480.0);
     pulp_motion_update_geometry(id, "scroll", 0.0, 200.0, 320.0, 480.0);
 
-    REQUIRE(count_kind(fx.buffer, SampleEvent::Kind::Baseline, "scroll") >= 1);
+    const auto* baseline = first_of(fx.buffer, SampleEvent::Kind::Baseline, "scroll");
+    REQUIRE(baseline != nullptr);
+    REQUIRE(baseline->view_name == "ScrollView");
+    REQUIRE(baseline->components.size() == 4);
+    REQUIRE(baseline->components[0].first == "height");
+    REQUIRE(baseline->components[1].first == "minX");
+    REQUIRE(baseline->components[2].first == "minY");
+    REQUIRE(baseline->components[3].first == "width");
+
+    pulp_motion_detach_trace(id);
+}
+
+TEST_CASE("pulp_motion_update_geometry keeps frame metrics on the sampled trace only",
+          "[motion][swift-bridge][coverage][requested]") {
+    BridgeFixture fx;
+
+    const int id = pulp_motion_register_geometry_trace("FrameOnly", 60);
+    REQUIRE(id > 0);
+
+    pulp_motion_update_geometry(id, "frame", 1.0, 2.0, 3.0, 4.0);
+    REQUIRE(count_kind(fx.buffer, SampleEvent::Kind::Baseline, "frame") == 0);
+
+    fx.clock.tick(1.0f / 60.0f);
+    REQUIRE(count_kind(fx.buffer, SampleEvent::Kind::Baseline, "frame") == 1);
+    const auto* baseline = first_of(fx.buffer, SampleEvent::Kind::Baseline, "frame");
+    REQUIRE(baseline != nullptr);
+    REQUIRE(baseline->view_name == "FrameOnly");
+    REQUIRE(baseline->components.size() == 4);
 
     pulp_motion_detach_trace(id);
 }


### PR DESCRIPTION
Tighten the macOS notary submit parser so it accepts full UUID-shaped IDs instead of arbitrary lowercase hex fragments.

Extend requested coverage for the Apple motion bridge by asserting non-frame geometry keeps the registered view identity and frame metrics remain sampler-only.

Validation: ./build/test/pulp-test-codesign --reporter compact
Validation: ./build/test/pulp-test-motion-swift-bridge --reporter compact
Validation: python3 tools/scripts/skill_sync_check.py --base origin/main
Validation: python3 tools/scripts/version_bump_check.py --base origin/main --mode=report
Validation: python3 tools/scripts/docs_sync_check.py --base origin/main
Validation: python3 tools/scripts/test_run_coverage.py
Validation: python3 tools/scripts/test_workflow_lint.py
Skill-Update: skip skill=ship reason="coverage-only signing parser contract; existing guidance remains current"
Skill-Update: skip skill=motion reason="coverage-only bridge tests; existing guidance remains current"