### PR TITLE
test(tools): cover audio linux package contracts

### DIFF
--- a/test/test_audio_tools.cpp
+++ b/test/test_audio_tools.cpp
@@ -65,6 +65,21 @@ std::string read_text(const fs::path& path) {
     return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
 }
 
+std::string json_escape(std::string_view text) {
+    std::string out;
+    for (char ch : text) {
+        switch (ch) {
+            case '\\': out += "\\\\"; break;
+            case '"': out += "\\\""; break;
+            case '\n': out += "\\n"; break;
+            case '\r': out += "\\r"; break;
+            case '\t': out += "\\t"; break;
+            default: out += ch; break;
+        }
+    }
+    return out;
+}
+
 pulp::audio::AudioFileData make_audio(uint32_t sample_rate, uint64_t frame_count) {
     pulp::audio::AudioFileData data;
     data.sample_rate = sample_rate;
@@ -1771,7 +1786,8 @@ TEST_CASE("excerpt find bundle metadata falls back to registered model fields",
     auto model_json = read_text(result.bundle_path / "model.json");
     REQUIRE(model_json.find("\"checkpoint_ref\": \"hf://lukewys/laion_clap/music.pt\"")
             != std::string::npos);
-    REQUIRE(model_json.find("\"resolved_checkpoint_path\": \"" + checkpoint.generic_string() + "\"")
+    REQUIRE(model_json.find("\"resolved_checkpoint_path\": \""
+                            + json_escape(checkpoint.string()) + "\"")
             != std::string::npos);
 }
 

--- a/test/test_audio_tools.cpp
+++ b/test/test_audio_tools.cpp
@@ -59,6 +59,12 @@ void write_text(const fs::path& path, const std::string& text) {
     output << text;
 }
 
+std::string read_text(const fs::path& path) {
+    std::ifstream input(path);
+    REQUIRE(input.good());
+    return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+}
+
 pulp::audio::AudioFileData make_audio(uint32_t sample_rate, uint64_t frame_count) {
     pulp::audio::AudioFileData data;
     data.sample_rate = sample_rate;
@@ -1719,6 +1725,54 @@ TEST_CASE("excerpt find JSON serializer preserves ranked bundle metadata",
     REQUIRE(json.find("\"excerpt_file\": \"excerpts/rank-01-loop-1.000-1.250.wav\"")
             != std::string::npos);
     REQUIRE(json.find("/audio/readme.txt (unsupported; WAV only)") != std::string::npos);
+}
+
+TEST_CASE("excerpt find bundle metadata falls back to registered model fields",
+          "[audio][tools][excerpt-service][model-registry][coverage][requested]") {
+    TempDir temp;
+    auto checkpoint = temp.path / "models" / "clap.pt";
+    write_text(checkpoint, "stub");
+    write_text(temp.path / "audio" / "models" / "clap_music_audioset_v1.json", R"JSON({
+  "backend": "clap",
+  "resolved_checkpoint_path": ")JSON" + checkpoint.generic_string() + R"JSON("
+}
+)JSON");
+    write_text(temp.path / "audio" / "model-state.json", R"JSON({
+  "active_model_id": "clap_music_audioset_v1"
+}
+)JSON");
+
+    auto input = temp.path / "fallback.wav";
+    REQUIRE(pulp::audio::write_wav_file(input.string(), make_audio(48000, 48000)));
+
+    ExcerptFindRequest request;
+    request.text = "fallback metadata";
+    request.input_path = input;
+    request.bundle_out = temp.path / "bundles";
+    request.top_k = 1;
+    request.window_ms = 1000;
+    request.hop_ms = 1000;
+    request.max_candidates_per_file = 1;
+
+    auto result = run_excerpt_find(request, temp.path);
+
+    REQUIRE(result.ok);
+    REQUIRE(result.requested_model_id == "clap_music_audioset_v1");
+    REQUIRE(result.loaded_model_id == "clap_music_audioset_v1");
+    REQUIRE(result.resolved_checkpoint_path == checkpoint);
+    REQUIRE(result.results.size() == 1);
+
+    auto bundle = read_excerpt_bundle(result.bundle_path);
+    REQUIRE(bundle.ok);
+    REQUIRE(bundle.requested_model_id == "clap_music_audioset_v1");
+    REQUIRE(bundle.loaded_model_id == "clap_music_audioset_v1");
+    REQUIRE(bundle.backend == "null");
+
+    auto model_json = read_text(result.bundle_path / "model.json");
+    REQUIRE(model_json.find("\"checkpoint_ref\": \"hf://lukewys/laion_clap/music.pt\"")
+            != std::string::npos);
+    REQUIRE(model_json.find("\"resolved_checkpoint_path\": \"" + checkpoint.generic_string() + "\"")
+            != std::string::npos);
 }
 
 #if !defined(_WIN32)

--- a/test/test_linux_packaging.cpp
+++ b/test/test_linux_packaging.cpp
@@ -165,6 +165,31 @@ TEST_CASE("Linux packaging tarballs support LV2-only bundles",
     REQUIRE_FALSE(fs::exists(extract / "Docs" / "readme.txt"));
 }
 
+TEST_CASE("Linux packaging tarballs preserve nested plugin payloads only",
+          "[ship][linux-package][coverage][requested]") {
+    TempDir temp("nested-plugin-payloads");
+    auto build = temp.path / "build";
+    write_file(build / "VST3" / "Nested.vst3" / "Contents" / "Resources" / "preset.json", "preset");
+    write_file(build / "CLAP" / "Nested.clap" / "resources" / "skin.png", "png");
+    write_file(build / "LV2" / "Nested.lv2" / "resources" / "manifest.ttl", "ttl");
+    write_file(build / "vst3" / "lowercase.vst3", "ignored");
+    write_file(build / "Other" / "Nested.vst3", "ignored");
+
+    auto output = temp.path / "nested.tar.gz";
+    REQUIRE(pulp::ship::create_tar_gz("Nested", build.string(), output.string()));
+
+    auto extract = temp.path / "extract";
+    fs::create_directories(extract);
+    auto unpack = run_sh("tar xzf " + quote(output) + " -C " + quote(extract));
+    REQUIRE(unpack.exit_code == 0);
+
+    REQUIRE(read_file(extract / "VST3" / "Nested.vst3" / "Contents" / "Resources" / "preset.json") == "preset");
+    REQUIRE(read_file(extract / "CLAP" / "Nested.clap" / "resources" / "skin.png") == "png");
+    REQUIRE(read_file(extract / "LV2" / "Nested.lv2" / "resources" / "manifest.ttl") == "ttl");
+    REQUIRE_FALSE(fs::exists(extract / "vst3" / "lowercase.vst3"));
+    REQUIRE_FALSE(fs::exists(extract / "Other" / "Nested.vst3"));
+}
+
 TEST_CASE("Linux packaging tarball command quotes paths with spaces",
           "[ship][linux-package][coverage]") {
     TempDir temp("space-tarball");
@@ -320,4 +345,34 @@ TEST_CASE("Linux packaging deb generation removes stale staging before writing",
     REQUIRE_THAT(contents.stdout_output,
                  ContainsSubstring("./usr/lib/vst3/Fresh.vst3/Contents/module.txt"));
     REQUIRE(contents.stdout_output.find("stale.txt") == std::string::npos);
+}
+
+TEST_CASE("Linux packaging deb preserves recursive plugin directories only",
+          "[ship][linux-package][coverage][requested]") {
+    if (!command_available("dpkg-deb"))
+        SKIP("dpkg-deb is required to inspect generated deb archives");
+
+    TempDir temp("deb-recursive-plugin-dirs");
+    auto build = temp.path / "build";
+    write_file(build / "VST3" / "Nested.vst3" / "Contents" / "Resources" / "preset.json", "preset");
+    write_file(build / "CLAP" / "Nested.clap" / "resources" / "skin.png", "png");
+    write_file(build / "LV2" / "Nested.lv2" / "resources" / "manifest.ttl", "ttl");
+    write_file(build / "vst3" / "lowercase.vst3", "ignored");
+    write_file(build / "Docs" / "manual.txt", "ignored");
+
+    auto output = temp.path / "nested.deb";
+    REQUIRE(pulp::ship::create_deb("pulp-nested", "2.0.0", build.string(),
+                                   output.string(), "Pulp Tests"));
+    REQUIRE_FALSE(fs::exists(build / "deb-staging"));
+
+    auto contents = run_sh("dpkg-deb --contents " + quote(output));
+    REQUIRE(contents.exit_code == 0);
+    REQUIRE_THAT(contents.stdout_output,
+                 ContainsSubstring("./usr/lib/vst3/Nested.vst3/Contents/Resources/preset.json"));
+    REQUIRE_THAT(contents.stdout_output,
+                 ContainsSubstring("./usr/lib/clap/Nested.clap/resources/skin.png"));
+    REQUIRE_THAT(contents.stdout_output,
+                 ContainsSubstring("./usr/lib/lv2/Nested.lv2/resources/manifest.ttl"));
+    REQUIRE(contents.stdout_output.find("lowercase.vst3") == std::string::npos);
+    REQUIRE(contents.stdout_output.find("manual.txt") == std::string::npos);
 }


### PR DESCRIPTION
Add requested coverage for audio excerpt/model registry contracts by asserting generated bundles fall back to registered model metadata when installed metadata omits optional fields.

Add Linux packaging coverage for nested tar/deb plugin payloads and exclusion of unrelated directories.

Validation: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=OFF

Validation: cmake --build build --target pulp-test-audio-tools -j10

Validation: ./build/test/pulp-test-audio-tools --reporter compact

Validation: c++ -std=c++20 -fsyntax-only -Ibuild/_deps/catch2-build/generated-includes -I/Users/danielraffel/Library/Caches/Pulp/fetchcontent-src/catch2-v3.7.1/src -Iship/include -Icore/platform/include test/test_linux_packaging.cpp

Validation: git diff --check

Validation: python3 tools/scripts/skill_sync_check.py --base origin/main

Validation: python3 tools/scripts/version_bump_check.py --base origin/main --mode=report

Validation: python3 tools/scripts/docs_sync_check.py --base origin/main

Validation: python3 tools/scripts/test_run_coverage.py

Validation: python3 tools/scripts/test_workflow_lint.py