### PR TITLE
fix(auv3): open fixed-design editors at design size

### DIFF
--- a/.agents/skills/auv3/SKILL.md
+++ b/.agents/skills/auv3/SKILL.md
@@ -585,11 +585,33 @@ directly while cfprefsd is killed.
 `set_fixed_aspect_ratio(w/h)` so the editor paints at design size and
 host-driven window resize is letterboxed proportionally.
 
+On macOS, the view controller's root view must be created at the
+compile-time design size when `PULP_PLUGIN_DESIGN_W/H` are available.
+REAPER can choose the initial AUv3 container from `loadView` /
+`viewDidLoad` before `createAudioUnit` provides the processor; falling
+back to `400x300` there opens imported/scripted UIs in a small padded
+window even though the later `ViewBridge` reports the correct design
+size.
+
+REAPER can also shrink the controller view after the first editor build
+on its in-process AUv3 path. The macOS controller has a one-shot initial
+size sync after attaching `PluginViewHost`: if the first live layout is
+smaller than the design viewport, it re-applies `preferredContentSize`,
+expands the host window by the exact view delta, and resizes the root
+view to the design. Keep this limited to initial attach; manual host
+resize must continue through `viewDidLayout` without being forced back.
+
 `PulpAudioUnit::supportedViewConfigurations:` accepts configurations
-within ~5% aspect tolerance of the design (a JUCE forum thread
-documents that Logic 10.6.1 probes 1024x768 / 1366x1024 — accepting
-at least one fixes a known Logic reopen-size bug). Falls back to
-accepting all configurations if none match the aspect floor.
+within ~5% aspect tolerance of the design only when they are also large
+enough to contain that design (a JUCE forum thread documents that Logic
+10.6.1 probes 1024x768 / 1366x1024 — accepting at least one fixes a
+known Logic reopen-size bug). If any aspect-correct, large-enough
+configuration exists, return only those; wrong-aspect "large enough"
+configs are fallbacks, otherwise Logic/REAPER can choose one first and
+open fixed-design editors with avoidable top/bottom padding. If every
+candidate is undersized for a fixed-design editor, return an empty set
+so CoreAudioKit falls back to the largest available view configuration
+instead of treating the tiny default as supported.
 
 Padding at the top/bottom (or left/right) of the editor in a host
 window is the **expected letterbox** when the host gives us a window

--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -706,6 +706,19 @@ Per-format wiring:
   the design aspect; `onSize`'s existing `host->set_size(...)` path
   resizes surfaces; `attached()` (or first `onSize`) calls
   `host->set_design_viewport(...)`.
+- **macOS AUv3** — no CLAP/VST3-style drag constraint callback.
+  `PulpAUMacViewController` must create its initial root view at the
+  compile-time design size when `PULP_PLUGIN_DESIGN_W/H` are available,
+  then call `host->set_design_viewport(...)` after `ViewBridge` opens.
+  `supportedViewConfigurations:` should return aspect-correct host
+  configs first, but only if they are large enough for the design;
+  wrong-aspect "large enough" configs are fallbacks. Undersized fixed-
+  design configs should be rejected so CoreAudioKit can choose the
+  largest available configuration. REAPER's in-process AUv3 path can
+  still shrink the first live layout after attach, so the macOS
+  controller has a one-shot initial size sync that expands the host
+  window by the view delta and reapplies the design size before normal
+  `viewDidLayout` resize takes over.
 - **AU v2** — cannot offer this; the DAW resizes the returned NSView
   directly with no host-side resize-hint analogue.
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.129.3",
+      "version": "0.129.4",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.129.3"
+  "version": "0.129.4"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.129.3",
+  "version": "0.129.4",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.272.0
+    VERSION 0.272.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/src/au_adapter.mm
+++ b/core/format/src/au_adapter.mm
@@ -973,11 +973,10 @@ static int32_t block_relative_sample_offset(AUEventSampleTime event_sample_time,
 // Hosts (Logic, MainStage, GarageBand) probe `supportedViewConfigurations:`
 // with a set of candidate window sizes and pick one via
 // `selectViewConfiguration:`. For a fixed-design GPU editor (the common
-// Pulp shape), we accept configurations whose aspect ratio is close to the
-// processor's design aspect, and we prefer the smallest config that can
-// contain the design viewport. The view controller's
-// `set_design_viewport` + `set_fixed_aspect_ratio` then scales the actual
-// paint at the host-chosen size.
+// Pulp shape), we accept configurations that are close to the processor's
+// design aspect *and* large enough to contain the design viewport. The view
+// controller's `set_design_viewport` + `set_fixed_aspect_ratio` then scales
+// the actual paint at the host-chosen size.
 //
 // preferredContentSize remains authoritative for the initial editor size
 // when no host-selected configuration applies. Don't put an internal corner
@@ -1005,6 +1004,9 @@ static int32_t block_relative_sample_offset(AUEventSampleTime event_sample_time,
     // wrong-aspect candidates, loose enough to land on Logic's defaults.
     constexpr double kAspectTolerance = 0.05;
 
+    NSMutableIndexSet *aspectMatches = [NSMutableIndexSet indexSet];
+    NSMutableIndexSet *largeEnoughFallbacks = [NSMutableIndexSet indexSet];
+
     for (NSUInteger i = 0; i < availableViewConfigurations.count; ++i) {
         AUAudioUnitViewConfiguration *cfg = availableViewConfigurations[i];
         const double w = static_cast<double>(cfg.width);
@@ -1013,24 +1015,31 @@ static int32_t block_relative_sample_offset(AUEventSampleTime event_sample_time,
 
         const double cfg_aspect = w / h;
         const double aspect_delta = std::abs(cfg_aspect - design_aspect) / design_aspect;
-        if (aspect_delta <= kAspectTolerance) {
-            [result addIndex:i];
+        if (aspect_delta <= kAspectTolerance && w >= design_w && h >= design_h) {
+            [aspectMatches addIndex:i];
             continue;
         }
 
         // Even on an aspect mismatch, accept configurations large enough to
-        // contain the design viewport — the controller will letterbox via
-        // set_design_viewport. Preferred only when at least one aspect-match
-        // option exists; if none do, the host needs some option to land on.
+        // contain the design viewport, but only as a fallback when no
+        // aspect-correct option exists. Returning both lets hosts choose a
+        // wrong-aspect "large enough" config first, which opens fixed-design
+        // editors with avoidable top/bottom padding in Logic/REAPER AUv3.
         if (w >= design_w && h >= design_h) {
-            [result addIndex:i];
+            [largeEnoughFallbacks addIndex:i];
         }
     }
 
-    // If nothing matched (extreme aspect / undersized configs), fall back to
-    // accepting everything rather than telling the host we have no UI.
-    if (result.count == 0) {
-        [result addIndexesInRange:NSMakeRange(0, availableViewConfigurations.count)];
+    if (aspectMatches.count > 0) {
+        [result addIndexes:aspectMatches];
+    } else if (largeEnoughFallbacks.count > 0) {
+        [result addIndexes:largeEnoughFallbacks];
+    } else {
+        // If every candidate is too small or wrong for a fixed-design editor,
+        // return an empty set. CoreAudioKit defines that as "use the largest
+        // available view configuration"; accepting undersized configs lets
+        // hosts open a truncated/padded editor and never revisit the design
+        // size.
     }
     return result;
 }

--- a/core/format/src/au_view_controller_mac.mm
+++ b/core/format/src/au_view_controller_mac.mm
@@ -30,6 +30,54 @@
 #include <algorithm>
 #include <memory>
 
+namespace {
+
+NSSize pulp_auv3_initial_editor_size() {
+#if defined(PULP_PLUGIN_DESIGN_W) && defined(PULP_PLUGIN_DESIGN_H)
+    if (PULP_PLUGIN_DESIGN_W > 0 && PULP_PLUGIN_DESIGN_H > 0) {
+        return NSMakeSize(static_cast<CGFloat>(PULP_PLUGIN_DESIGN_W),
+                          static_cast<CGFloat>(PULP_PLUGIN_DESIGN_H));
+    }
+#endif
+    return NSMakeSize(400, 300);
+}
+
+void pulp_auv3_apply_preferred_size(NSViewController *controller,
+                                    NSSize size,
+                                    bool resize_view_frame) {
+    if (!controller || size.width <= 0.0 || size.height <= 0.0) return;
+    controller.preferredContentSize = size;
+    if (!resize_view_frame || !controller.isViewLoaded) return;
+
+    NSView *view = controller.view;
+    NSRect frame = view.frame;
+    frame.size = size;
+    [view setFrame:frame];
+    [view setNeedsLayout:YES];
+}
+
+bool pulp_auv3_is_undersized(NSSize current, NSSize design) {
+    return current.width > 0.0 && current.height > 0.0 &&
+           design.width > 0.0 && design.height > 0.0 &&
+           (current.width < design.width || current.height < design.height);
+}
+
+void pulp_auv3_expand_window_for_view(NSView *view, NSSize design) {
+    if (!view || !view.window) return;
+    NSSize current = view.bounds.size;
+    if (!pulp_auv3_is_undersized(current, design)) return;
+
+    NSRect frame = view.window.frame;
+    const CGFloat delta_w = std::max<CGFloat>(0.0, design.width - current.width);
+    const CGFloat delta_h = std::max<CGFloat>(0.0, design.height - current.height);
+    frame.size.width += delta_w;
+    frame.size.height += delta_h;
+    frame.origin.y -= delta_h;
+    [view.window setFrame:frame display:YES animate:NO];
+}
+
+} // namespace
+
 /// AUViewController subclass + AUAudioUnitFactory for macOS AU v3.
 /// Apple's current pattern: the view controller IS the factory. Info.plist
 /// sets NSExtensionPrincipalClass = PulpAUMacViewController and
@@ -39,6 +87,8 @@
 @end
 
 @implementation PulpAUMacViewController {
+    NSSize _designSize;
+    NSUInteger _initialSizeSyncAttempts;
     // Ivar order is load-bearing — see -dealloc in
     // au_view_controller_ios.mm for the same contract. _viewHost holds
     // `View& root_` and MUST be destroyed before whichever object owns
@@ -51,9 +101,12 @@
 
 - (void)loadView {
     // We're not loading from a NIB — create the root NSView ourselves so
-    // `viewDidLoad` finds a sized container even before the host attaches
-    // us to a window.
-    NSView *root = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 400, 300)];
+    // `viewDidLoad` finds a correctly sized container even before the host
+    // attaches us to a window. REAPER's in-process AUv3 path can choose the
+    // initial container from this frame before createAudioUnit has provided
+    // the processor, so use compile-time design dimensions when available.
+    const NSSize initial = pulp_auv3_initial_editor_size();
+    NSView *root = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, initial.width, initial.height)];
     root.wantsLayer = YES;
     root.layer.backgroundColor = NSColor.blackColor.CGColor;
     self.view = root;
@@ -64,7 +117,9 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    self.preferredContentSize = NSMakeSize(400, 300);
+    _designSize = NSZeroSize;
+    _initialSizeSyncAttempts = 0;
+    pulp_auv3_apply_preferred_size(self, pulp_auv3_initial_editor_size(), true);
     [self rebuildEditorIfReady];
 }
 
@@ -183,7 +238,25 @@
         root = _fallbackView.get();
     }
 
-    self.preferredContentSize = NSMakeSize(w, h);
+    // If the host has not attached the controller yet, update the root frame
+    // too so preferredContentSize and the actual view bounds agree. REAPER's
+    // in-process AUv3 path can attach first and hand us its small default
+    // container; on that first build, expand the root to the design before
+    // attaching the GPU host. Later user/host resize still flows through
+    // viewDidLayout without being forced back to the design size.
+    const NSSize designSize = NSMakeSize(w, h);
+    _designSize = designSize;
+    _initialSizeSyncAttempts = 0;
+    NSSize currentSize = self.view.bounds.size;
+    const bool currentUndersized = pulp_auv3_is_undersized(currentSize, designSize);
+    const bool resizeInitialRoot = self.view.window == nil || currentUndersized;
+    if (currentUndersized) {
+        pulp::runtime::log_info("AU mac: expanding undersized initial root {}x{} to design {}x{}",
+                                static_cast<int>(currentSize.width),
+                                static_cast<int>(currentSize.height),
+                                w, h);
+    }
+    pulp_auv3_apply_preferred_size(self, designSize, resizeInitialRoot);
 
     pulp::view::PluginViewHost::Options opts;
     opts.size = {w, h};
@@ -222,7 +295,40 @@
     pulp::runtime::log_info("AU mac: editor attached, design={}x{}, mode={}, gpu={}",
                             w, h, mode, _viewHost->is_gpu_backed());
 
+    [self scheduleInitialSizeSync];
     [self resizeEditorToViewBounds];
+}
+
+- (void)scheduleInitialSizeSync {
+    if (_initialSizeSyncAttempts >= 3) return;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self runInitialSizeSync];
+    });
+}
+
+- (void)runInitialSizeSync {
+    if (!_viewHost || _designSize.width <= 0.0 || _designSize.height <= 0.0) return;
+    if (_initialSizeSyncAttempts >= 3) return;
+    ++_initialSizeSyncAttempts;
+
+    NSSize currentSize = self.view.bounds.size;
+    if (!pulp_auv3_is_undersized(currentSize, _designSize)) return;
+
+    pulp::runtime::log_info("AU mac: correcting undersized initial layout {}x{} to design {}x{}",
+                            static_cast<int>(currentSize.width),
+                            static_cast<int>(currentSize.height),
+                            static_cast<int>(_designSize.width),
+                            static_cast<int>(_designSize.height));
+    pulp_auv3_expand_window_for_view(self.view, _designSize);
+    pulp_auv3_apply_preferred_size(self, _designSize, true);
+    [self resizeEditorToViewBounds];
+
+    if (_initialSizeSyncAttempts < 3) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 50 * NSEC_PER_MSEC),
+                       dispatch_get_main_queue(), ^{
+            [self runInitialSizeSync];
+        });
+    }
 }
 
 - (void)resizeEditorToViewBounds {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1816,6 +1816,7 @@ if(APPLE AND PULP_HAS_AUSDK)
         Catch2::Catch2WithMain
         "-framework AudioToolbox"
         "-framework AVFoundation"
+        "-framework CoreAudioKit"
         "-framework Foundation"
     )
     set_target_properties(pulp-test-au-plugin-state PROPERTIES

--- a/test/test_au_plugin_state.mm
+++ b/test/test_au_plugin_state.mm
@@ -1,4 +1,5 @@
 #import <AudioToolbox/AudioToolbox.h>
+#import <CoreAudioKit/CoreAudioKit.h>
 #import <Foundation/Foundation.h>
 
 #include <catch2/catch_test_macros.hpp>
@@ -127,12 +128,23 @@ public:
     std::string plugin_state;
 };
 
+class TestAUWideEditorProcessor : public TestAUEffectProcessor {
+public:
+    pulp::format::ViewSize view_size() const override {
+        return pulp::format::view_size_from_design(900, 520);
+    }
+};
+
 std::unique_ptr<pulp::format::Processor> create_effect_processor() {
     return std::make_unique<TestAUEffectProcessor>();
 }
 
 std::unique_ptr<pulp::format::Processor> create_instrument_processor() {
     return std::make_unique<TestAUInstrumentProcessor>();
+}
+
+std::unique_ptr<pulp::format::Processor> create_wide_editor_processor() {
+    return std::make_unique<TestAUWideEditorProcessor>();
 }
 
 void require_plst_blob(const uint8_t* bytes, std::size_t size) {
@@ -954,6 +966,77 @@ TEST_CASE("AU v3 per-method audit invariants",
         // drift bug the AU v2 path used to hit.
         REQUIRE([unit pulpProcessor] != nullptr);
         REQUIRE([unit pulpStore] != nullptr);
+
+        [unit release];
+    }
+}
+
+TEST_CASE("AU v3 view configurations prefer aspect-correct editor sizes",
+          "[au][auv3][view-config][resize]") {
+    @autoreleasepool {
+        AudioComponentDescription desc{};
+        desc.componentType = kAudioUnitType_Effect;
+        desc.componentSubType = 'TstE';
+        desc.componentManufacturer = 'Plup';
+
+        ScopedFactoryRegistration registration(create_wide_editor_processor);
+
+        NSError* err = nil;
+        PulpAudioUnit* unit =
+            [[PulpAudioUnit alloc] initWithComponentDescription:desc
+                                                       options:0
+                                                         error:&err];
+        REQUIRE(unit != nil);
+        REQUIRE(err == nil);
+
+        NSArray<AUAudioUnitViewConfiguration*>* mixedConfigs = @[
+            [[[AUAudioUnitViewConfiguration alloc] initWithWidth:486
+                                                          height:290
+                                               hostHasController:NO] autorelease],
+            [[[AUAudioUnitViewConfiguration alloc] initWithWidth:1024
+                                                          height:768
+                                               hostHasController:NO] autorelease],
+            [[[AUAudioUnitViewConfiguration alloc] initWithWidth:900
+                                                          height:520
+                                               hostHasController:NO] autorelease],
+            [[[AUAudioUnitViewConfiguration alloc] initWithWidth:1366
+                                                          height:1024
+                                               hostHasController:NO] autorelease],
+        ];
+
+        NSIndexSet* supported = [unit supportedViewConfigurations:mixedConfigs];
+        REQUIRE(supported != nil);
+        REQUIRE([supported containsIndex:2]);
+        REQUIRE_FALSE([supported containsIndex:0]);
+        REQUIRE_FALSE([supported containsIndex:1]);
+        REQUIRE_FALSE([supported containsIndex:3]);
+
+        NSArray<AUAudioUnitViewConfiguration*>* noAspectMatchConfigs = @[
+            [[[AUAudioUnitViewConfiguration alloc] initWithWidth:1024
+                                                          height:768
+                                               hostHasController:NO] autorelease],
+            [[[AUAudioUnitViewConfiguration alloc] initWithWidth:1366
+                                                          height:1024
+                                               hostHasController:NO] autorelease],
+        ];
+
+        NSIndexSet* fallback = [unit supportedViewConfigurations:noAspectMatchConfigs];
+        REQUIRE(fallback != nil);
+        REQUIRE([fallback containsIndex:0]);
+        REQUIRE([fallback containsIndex:1]);
+
+        NSArray<AUAudioUnitViewConfiguration*>* undersizedConfigs = @[
+            [[[AUAudioUnitViewConfiguration alloc] initWithWidth:486
+                                                          height:290
+                                               hostHasController:NO] autorelease],
+            [[[AUAudioUnitViewConfiguration alloc] initWithWidth:640
+                                                          height:370
+                                               hostHasController:NO] autorelease],
+        ];
+
+        NSIndexSet* undersized = [unit supportedViewConfigurations:undersizedConfigs];
+        REQUIRE(undersized != nil);
+        REQUIRE(undersized.count == 0u);
 
         [unit release];
     }


### PR DESCRIPTION
## Summary

- Open macOS AUv3 fixed-design editors at their compiled design size instead of accepting undersized host defaults on first attach.
- Tighten AUv3 view-configuration negotiation so aspect-correct configs must also be large enough for the editor design.
- Add a one-shot REAPER initial-layout correction for AUv3 when the host first lays out the view smaller than the design viewport, while leaving later/manual resize behavior host-driven.
- Document the AUv3/view-bridge proportional-resize contract in the relevant skills.

## Validation

- `./build-auv3-sizing/test/pulp-test-au-plugin-state "AU v3 view configurations prefer aspect-correct editor sizes"` -> passed, 12 assertions.
- `./build-auv3-sizing/test/pulp-test-au-plugin-state` -> passed, 208 assertions in 19 test cases.
- `python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report` -> passed.
- `python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat --pr-title 'fix(auv3): open fixed-design editors at design size'` -> passed after the `chore: bump versions` commit.
- `git diff --check origin/main...HEAD` -> clean.

## Chainer AUv3 Evidence

Built and installed a fresh Release Chainer AUv3 from this branch. `auval -v aumu Chnr Pulp` passed. REAPER AUv3 unattended evidence changed from the bad baseline first frame of `486x290` to the intended design first frame:

```text
[pulp:info] AU mac: correcting undersized initial layout 486x290 to design 900x520
[plugin-gpu-host] first frame logical=900x520 gpu=1800x1040 scale=2.0
```

Screenshot evidence is local at:

```text
/Users/danielraffel/Code/pulp-macos-cross-infra/planning/qa/screenshots/macos-native-auv3-sizing-fix-1b31a945-r4/reaper-auv3-initial-fixed.png
```

No Chainer packaging/notarization was performed.

## Notes

Shipyard was used for the PR flow where possible. The local `ubuntu` and `windows` targets were unreachable during this work and were skipped in the Shipyard attempt. A local diff-cover configure also hit the existing FetchContent `mbedtls` checkout failure, so the final force-with-lease push used the pre-push diff-cover bypass and leaves full CI as the authoritative cross-platform validation.