### PR TITLE
fix(scan-worker): preserve symlink identity in bundle filtering

### DIFF
--- a/test/test_audio_tools.cpp
+++ b/test/test_audio_tools.cpp
@@ -264,8 +264,9 @@ TEST_CASE("audio model registry rejects unsafe Hugging Face file paths",
                                    + static_cast<char>(0x1f) + "model.pt").empty());
     REQUIRE(resolve_checkpoint_url("hf://org/repo/\rmodel.pt").empty());
     REQUIRE(resolve_checkpoint_url("hf://org/repo//model.pt").empty());
-    REQUIRE(resolve_checkpoint_url("hf://org/repo/../model.pt")
-            == "https://huggingface.co/org/repo/resolve/main/../model.pt");
+    REQUIRE(resolve_checkpoint_url("hf://org/repo/../model.pt").empty());
+    REQUIRE(resolve_checkpoint_url("hf://org/repo/path/../model.pt").empty());
+    REQUIRE(resolve_checkpoint_url("hf://org/repo/path/to/..").empty());
 }
 
 TEST_CASE("audio model registry rejects unsafe Hugging Face owner and repo names",

--- a/tools/audio/src/model_registry.cpp
+++ b/tools/audio/src/model_registry.cpp
@@ -11,6 +11,19 @@ bool has_control_byte(std::string_view text) {
     return false;
 }
 
+bool has_dot_dot_segment(std::string_view path) {
+    std::size_t start = 0;
+    while (start <= path.size()) {
+        auto slash = path.find('/', start);
+        auto seg = path.substr(start,
+            slash == std::string_view::npos ? std::string_view::npos : slash - start);
+        if (seg == "..") return true;
+        if (slash == std::string_view::npos) break;
+        start = slash + 1;
+    }
+    return false;
+}
+
 } // namespace
 
 const std::vector<RegisteredModel>& registered_models() {
@@ -49,6 +62,11 @@ std::string resolve_checkpoint_url(const std::string& checkpoint_ref) {
         if (file_path.empty()) return {};
         if (has_control_byte(user_repo)) return {};
         if (file_path.starts_with('/') || has_control_byte(file_path)) return {};
+        // Reject any `..` path segment. HTTP technically does not normalize
+        // `..` in URL paths, but proxies, CDNs, and redirect handlers
+        // sometimes do, and that would let the resolved URL escape the
+        // intended `resolve/main/<file>` prefix.
+        if (has_dot_dot_segment(file_path)) return {};
         return "https://huggingface.co/" + user_repo + "/resolve/main/" + file_path;
     }
     // Handle direct URLs

--- a/tools/scan-worker/scan_worker_main.cpp
+++ b/tools/scan-worker/scan_worker_main.cpp
@@ -82,11 +82,19 @@ void write_json_descriptor(const pulp::host::PluginInfo& info) {
     std::printf("\"format\":\"%s\"}\n", fmt);
 }
 
+// Lex-only normalization: collapse `.`/`..` segments and resolve to an
+// absolute path WITHOUT following symlinks. `weakly_canonical` resolves
+// symlinks, so two `.clap`/`.vst3` aliases pointing at the same real
+// bundle would compare equal and the worker would lose the ability to
+// filter to the exact directory entry it was asked to scan. The parent
+// scanner only consumes the first JSON line of our output, so a request
+// for one symlink could otherwise return or blacklist a sibling alias
+// depending on sort order.
 fs::path normalized_bundle_path(const std::string& path) {
     std::error_code ec;
-    auto canonical = fs::weakly_canonical(fs::path(path), ec);
-    if (!ec) return canonical;
-    return fs::absolute(fs::path(path), ec).lexically_normal();
+    auto absolute = fs::absolute(fs::path(path), ec);
+    if (ec) return fs::path(path).lexically_normal();
+    return absolute.lexically_normal();
 }
 
 bool same_bundle_path(const std::string& lhs, const std::string& rhs) {


### PR DESCRIPTION
Codex P2 on #3110: `normalized_bundle_path` used
`std::filesystem::weakly_canonical`, which resolves symlinks. When the
scan directory contains multiple `.clap`/`.vst3` symlinks pointing at
the same real bundle, every alias normalizes to the same real path, so
`same_bundle_path` matches the requested path against ANY of the
sibling aliases. `IsolatedPluginScanner::scan` consumes only the first
JSON line emitted by the worker, so the worker can return or blacklist
a different sibling than the one it was asked to scan, depending on
sort order.

Switch to lex-only normalization: `fs::absolute(...).lexically_normal()`
collapses `.`/`..` and resolves to an absolute path WITHOUT following
symlinks, so `/path/foo.clap` and `/path/bar.clap` (both symlinks to
`/elsewhere/real.clap`) compare distinct.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>