### PR TITLE
fix(audio): reject `..` segments in hf:// checkpoint paths + Windows-safe model.json assertions

### DIFF
--- a/test/test_audio_tools.cpp
+++ b/test/test_audio_tools.cpp
@@ -264,8 +264,9 @@ TEST_CASE("audio model registry rejects unsafe Hugging Face file paths",
                                    + static_cast<char>(0x1f) + "model.pt").empty());
     REQUIRE(resolve_checkpoint_url("hf://org/repo/\rmodel.pt").empty());
     REQUIRE(resolve_checkpoint_url("hf://org/repo//model.pt").empty());
-    REQUIRE(resolve_checkpoint_url("hf://org/repo/../model.pt")
-            == "https://huggingface.co/org/repo/resolve/main/../model.pt");
+    REQUIRE(resolve_checkpoint_url("hf://org/repo/../model.pt").empty());
+    REQUIRE(resolve_checkpoint_url("hf://org/repo/path/../model.pt").empty());
+    REQUIRE(resolve_checkpoint_url("hf://org/repo/path/to/..").empty());
 }
 
 TEST_CASE("audio model registry rejects unsafe Hugging Face owner and repo names",

--- a/test/test_audio_tools.cpp
+++ b/test/test_audio_tools.cpp
@@ -112,7 +112,7 @@ fs::path install_active_clap_model(const TempDir& temp) {
   "model_id": "clap_music_audioset_v1",
   "backend": "clap",
   "checkpoint_ref": "hf://lukewys/laion_clap/music.pt",
-  "resolved_checkpoint_path": ")JSON" + checkpoint.generic_string() + R"JSON("
+  "resolved_checkpoint_path": ")JSON" + checkpoint.string() + R"JSON("
 }
 )JSON");
     write_text(temp.path / "audio" / "model-state.json", R"JSON({
@@ -140,7 +140,7 @@ void write_installed_model_metadata(const fs::path& pulp_home,
   "model_id": "clap_music_audioset_v1",
   "backend": "clap",
   "checkpoint_ref": "hf://lukewys/laion_clap/music.pt",
-  ")JSON" + std::string(checkpoint_key) + R"JSON(": ")JSON" + checkpoint.generic_string() + R"JSON("
+  ")JSON" + std::string(checkpoint_key) + R"JSON(": ")JSON" + checkpoint.string() + R"JSON("
 }
 )JSON");
 }
@@ -442,7 +442,7 @@ TEST_CASE("audio model list reports registry and install state", "[audio][tools]
   "model_id": "clap_music_audioset_v1",
   "backend": "clap",
   "checkpoint_ref": "hf://lukewys/laion_clap/music.pt",
-  "resolved_checkpoint_path": ")JSON" + checkpoint.generic_string() + R"JSON("
+  "resolved_checkpoint_path": ")JSON" + checkpoint.string() + R"JSON("
 }
 )JSON");
     write_text(temp.path / "audio" / "model-state.json", R"JSON({
@@ -504,7 +504,7 @@ TEST_CASE("audio model status reports configured checkpoint loadability", "[audi
   "configured_model_id": "clap_music_audioset_v1",
   "backend": "clap",
   "checkpoint_ref": "hf://lukewys/laion_clap/music.pt",
-  "resolved_checkpoint_path": ")JSON" + checkpoint.generic_string() + R"JSON("
+  "resolved_checkpoint_path": ")JSON" + checkpoint.string() + R"JSON("
 }
 )JSON");
 
@@ -558,7 +558,7 @@ TEST_CASE("audio model status reports incomplete state shapes",
 
     write_text(temp.path / "audio" / "model-state.json", R"JSON({
   "configured_model_id": "clap_music_audioset_v1",
-  "resolved_checkpoint_path": ")JSON" + (temp.path / "missing.pt").generic_string() + R"JSON("
+  "resolved_checkpoint_path": ")JSON" + (temp.path / "missing.pt").string() + R"JSON("
 }
 )JSON");
 
@@ -577,7 +577,7 @@ TEST_CASE("audio model status reads legacy model.json and installed metadata fal
   "model_id": "clap_music_audioset_v1",
   "backend": "clap",
   "checkpoint_ref": "hf://lukewys/laion_clap/music.pt",
-  "resolved_checkpoint_path": ")JSON" + checkpoint.generic_string() + R"JSON("
+  "resolved_checkpoint_path": ")JSON" + checkpoint.string() + R"JSON("
 }
 )JSON");
     write_text(temp.path / "audio" / "model.json", R"JSON({
@@ -604,7 +604,7 @@ TEST_CASE("audio model activate writes state from installed metadata", "[audio][
   "model_id": "clap_music_audioset_v1",
   "backend": "clap",
   "checkpoint_ref": "hf://lukewys/laion_clap/music.pt",
-  "resolved_checkpoint_path": ")JSON" + checkpoint.generic_string() + R"JSON("
+  "resolved_checkpoint_path": ")JSON" + checkpoint.string() + R"JSON("
 }
 )JSON");
 
@@ -627,7 +627,7 @@ TEST_CASE("audio model activate falls back to registered metadata",
     write_text(checkpoint, "stub");
     write_text(temp.path / "audio" / "models" / "clap_music_audioset_v1.json", R"JSON({
   "model_id": "clap_music_audioset_v1",
-  "resolved_checkpoint_path": ")JSON" + checkpoint.generic_string() + R"JSON("
+  "resolved_checkpoint_path": ")JSON" + checkpoint.string() + R"JSON("
 }
 )JSON");
 
@@ -663,7 +663,7 @@ TEST_CASE("audio model activate rejects installed metadata with missing checkpoi
   "model_id": "clap_music_audioset_v1",
   "backend": "clap",
   "checkpoint_ref": "hf://lukewys/laion_clap/music.pt",
-  "resolved_checkpoint_path": ")JSON" + checkpoint.generic_string() + R"JSON("
+  "resolved_checkpoint_path": ")JSON" + checkpoint.string() + R"JSON("
 }
 )JSON");
 
@@ -694,7 +694,7 @@ TEST_CASE("audio model store accepts overrides and legacy checkpoint metadata",
   "model_id": "clap_music_audioset_v1",
   "backend": "legacy-clap",
   "checkpoint_ref": "manual://legacy",
-  "checkpoint_path": ")JSON" + checkpoint.generic_string() + R"JSON("
+  "checkpoint_path": ")JSON" + checkpoint.string() + R"JSON("
 }
 )JSON");
     auto installed = read_installed_model("clap_music_audioset_v1", temp.path);
@@ -1069,7 +1069,7 @@ TEST_CASE("excerpt find writes a deterministic WAV-first bundle", "[audio][tools
   "model_id": "clap_music_audioset_v1",
   "backend": "clap",
   "checkpoint_ref": "hf://lukewys/laion_clap/music.pt",
-  "resolved_checkpoint_path": ")JSON" + checkpoint.generic_string() + R"JSON("
+  "resolved_checkpoint_path": ")JSON" + checkpoint.string() + R"JSON("
 }
 )JSON");
     write_text(temp.path / "audio" / "model-state.json", R"JSON({
@@ -1225,7 +1225,7 @@ TEST_CASE("excerpt find reports unsupported inputs after resolving a model",
   "model_id": "clap_music_audioset_v1",
   "backend": "clap",
   "checkpoint_ref": "hf://lukewys/laion_clap/music.pt",
-  "resolved_checkpoint_path": ")JSON" + checkpoint.generic_string() + R"JSON("
+  "resolved_checkpoint_path": ")JSON" + checkpoint.string() + R"JSON("
 }
 )JSON");
     write_text(temp.path / "audio" / "model-state.json", R"JSON({
@@ -1316,7 +1316,7 @@ TEST_CASE("excerpt find reports inactive and unavailable installed models",
 
     write_text(temp.path / "audio" / "models" / "clap_music_audioset_v1.json", R"JSON({
   "model_id": "clap_music_audioset_v1",
-  "resolved_checkpoint_path": ")JSON" + (temp.path / "missing.pt").generic_string() + R"JSON("
+  "resolved_checkpoint_path": ")JSON" + (temp.path / "missing.pt").string() + R"JSON("
 }
 )JSON");
     auto missing_checkpoint = run_excerpt_find(request, temp.path);
@@ -1450,7 +1450,7 @@ TEST_CASE("excerpt find deterministic scores use a stable hash", "[audio][tools]
   "model_id": "clap_music_audioset_v1",
   "backend": "clap",
   "checkpoint_ref": "hf://lukewys/laion_clap/music.pt",
-  "resolved_checkpoint_path": ")JSON" + checkpoint.generic_string() + R"JSON("
+  "resolved_checkpoint_path": ")JSON" + checkpoint.string() + R"JSON("
 }
 )JSON");
     write_text(temp.path / "audio" / "model-state.json", R"JSON({
@@ -1825,7 +1825,7 @@ TEST_CASE("excerpt find bundle metadata falls back to registered model fields",
     write_text(checkpoint, "stub");
     write_text(temp.path / "audio" / "models" / "clap_music_audioset_v1.json", R"JSON({
   "backend": "clap",
-  "resolved_checkpoint_path": ")JSON" + checkpoint.generic_string() + R"JSON("
+  "resolved_checkpoint_path": ")JSON" + checkpoint.string() + R"JSON("
 }
 )JSON");
     write_text(temp.path / "audio" / "model-state.json", R"JSON({
@@ -1862,12 +1862,13 @@ TEST_CASE("excerpt find bundle metadata falls back to registered model fields",
     auto model_json = read_text(result.bundle_path / "model.json");
     REQUIRE(model_json.find("\"checkpoint_ref\": \"hf://lukewys/laion_clap/music.pt\"")
             != std::string::npos);
+    // Production writes the path through add_path_member -> value.string(),
+    // so fixtures and assertions both use .string(). On Windows the native
+    // path differs from generic_string(); using .string() here keeps the
+    // text-search assertion stable across platforms.
     const auto native_path = "\"resolved_checkpoint_path\": \""
                            + json_escape(checkpoint.string()) + "\"";
-    const auto generic_path = "\"resolved_checkpoint_path\": \""
-                            + json_escape(checkpoint.generic_string()) + "\"";
-    REQUIRE((model_json.find(native_path) != std::string::npos
-             || model_json.find(generic_path) != std::string::npos));
+    REQUIRE(model_json.find(native_path) != std::string::npos);
 }
 
 #if !defined(_WIN32)
@@ -1969,7 +1970,7 @@ TEST_CASE("excerpt find skips unreadable recursive subdirectories", "[audio][too
   "model_id": "clap_music_audioset_v1",
   "backend": "clap",
   "checkpoint_ref": "hf://lukewys/laion_clap/music.pt",
-  "resolved_checkpoint_path": ")JSON" + checkpoint.generic_string() + R"JSON("
+  "resolved_checkpoint_path": ")JSON" + checkpoint.string() + R"JSON("
 }
 )JSON");
     write_text(temp.path / "audio" / "model-state.json", R"JSON({

--- a/tools/audio/src/model_registry.cpp
+++ b/tools/audio/src/model_registry.cpp
@@ -11,6 +11,19 @@ bool has_control_byte(std::string_view text) {
     return false;
 }
 
+bool has_dot_dot_segment(std::string_view path) {
+    std::size_t start = 0;
+    while (start <= path.size()) {
+        auto slash = path.find('/', start);
+        auto seg = path.substr(start,
+            slash == std::string_view::npos ? std::string_view::npos : slash - start);
+        if (seg == "..") return true;
+        if (slash == std::string_view::npos) break;
+        start = slash + 1;
+    }
+    return false;
+}
+
 } // namespace
 
 const std::vector<RegisteredModel>& registered_models() {
@@ -49,6 +62,11 @@ std::string resolve_checkpoint_url(const std::string& checkpoint_ref) {
         if (file_path.empty()) return {};
         if (has_control_byte(user_repo)) return {};
         if (file_path.starts_with('/') || has_control_byte(file_path)) return {};
+        // Reject any `..` path segment. HTTP technically does not normalize
+        // `..` in URL paths, but proxies, CDNs, and redirect handlers
+        // sometimes do, and that would let the resolved URL escape the
+        // intended `resolve/main/<file>` prefix.
+        if (has_dot_dot_segment(file_path)) return {};
         return "https://huggingface.co/" + user_repo + "/resolve/main/" + file_path;
     }
     // Handle direct URLs


### PR DESCRIPTION
## Summary

Sweeps two Codex P2 findings on recent merged PRs into one focused audio-subsystem fix.

- **PR #3118 P2-A** — `resolve_checkpoint_url("hf://org/repo/../model.pt")` previously returned a URL containing `/resolve/main/../model.pt`. HTTP itself does not normalize `..` segments, but proxies / CDNs / redirect handlers sometimes do, which would let a checkpoint ref escape the `resolve/main/<file>` prefix. Production now rejects any `..` path segment in `hf://` refs and the test pins `.empty()` expectations for `../`, `path/../model.pt`, and `path/to/..`. The original PR #3118 test that pinned the unsafe behavior is replaced.
- **PR #3105 P2-C** — `add_path_member` writes paths via `value.string()` (native representation), but fixture writes and one model.json read-back assertion used `checkpoint.generic_string()` (forward slashes). On Windows the assertion text search would fail even though the path value was correct. Normalizes all 17 fixture writes to `.string()` and collapses the redundant native-or-generic OR-expression to a single `.string()`-based check.

Two commits:
1. `fix(audio): reject `..` segments in hf:// checkpoint paths`
2. `test(audio): match production path serialization for Windows lane`

## Test plan

- [x] `cmake --build build --target pulp-test-audio-tools` builds clean
- [x] `./build/test/pulp-test-audio-tools` — 669 assertions across 63 test cases pass locally (macOS Release)
- [x] New negative-path tests (`hf://org/repo/../model.pt`, `path/../model.pt`, `path/to/..`) all return empty
- [ ] CI macOS lane passes (Linux/Windows advisory)

Closes the two Codex P2 review comments above.

Generated as part of a Codex P1/P2 sweep across the last ~15 merged PRs.