### PR TITLE
fix(scan-worker): preserve symlink-alias identity in bundle filtering

### DIFF
--- a/test/test_isolated_scanner.cpp
+++ b/test/test_isolated_scanner.cpp
@@ -120,6 +120,39 @@ TEST_CASE("pulp-scan-worker command line reports usage and unsupported bundles",
     REQUIRE(rejected.stdout_output.empty());
 }
 
+// Regression for the Codex P2 finding on PR #3110: when a directory contains
+// multiple `.vst3` symlinks pointing at the same real bundle, the worker must
+// preserve the requested-alias identity (lexical absolute path) instead of
+// canonicalizing through symlinks. Otherwise a request for `alias.vst3` could
+// emit a descriptor for `real.vst3` and `IsolatedPluginScanner::scan` (which
+// consumes only the first JSON line) would return or blacklist a sibling.
+TEST_CASE("pulp-scan-worker preserves requested-alias identity for symlinks",
+          "[tools][scan-worker][coverage][issue-3110]") {
+    ScratchDir scratch("symlink-alias");
+    auto real_bundle = scratch.path / "Real.vst3";
+    fs::create_directories(real_bundle / "Contents" / "Resources");
+    auto alias_bundle = scratch.path / "Alias.vst3";
+
+    std::error_code ec;
+    fs::create_symlink(real_bundle, alias_bundle, ec);
+    if (ec) {
+        WARN("create_symlink not supported on this platform: " + ec.message());
+        return;
+    }
+
+    IsolatedPluginScanner scanner{PULP_ISOLATED_SCANNER_REAL_WORKER};
+
+    auto real_result = scanner.scan(real_bundle.string(), /*timeout_ms=*/5000);
+    REQUIRE(real_result.status == ScanStatus::Ok);
+    REQUIRE(real_result.descriptor.has_value());
+    REQUIRE(real_result.descriptor->path == real_bundle.string());
+
+    auto alias_result = scanner.scan(alias_bundle.string(), /*timeout_ms=*/5000);
+    REQUIRE(alias_result.status == ScanStatus::Ok);
+    REQUIRE(alias_result.descriptor.has_value());
+    REQUIRE(alias_result.descriptor->path == alias_bundle.string());
+}
+
 // ── Crash path: deliberate-crash helper ────────────────────────────────
 
 TEST_CASE("IsolatedPluginScanner classifies a worker SIGSEGV as Crash",

--- a/tools/scan-worker/scan_worker_main.cpp
+++ b/tools/scan-worker/scan_worker_main.cpp
@@ -82,11 +82,19 @@ void write_json_descriptor(const pulp::host::PluginInfo& info) {
     std::printf("\"format\":\"%s\"}\n", fmt);
 }
 
+// Lex-only normalization: collapse `.`/`..` segments and resolve to an
+// absolute path WITHOUT following symlinks. `weakly_canonical` resolves
+// symlinks, so two `.clap`/`.vst3` aliases pointing at the same real
+// bundle would compare equal and the worker would lose the ability to
+// filter to the exact directory entry it was asked to scan. The parent
+// scanner only consumes the first JSON line of our output, so a request
+// for one symlink could otherwise return or blacklist a sibling alias
+// depending on sort order.
 fs::path normalized_bundle_path(const std::string& path) {
     std::error_code ec;
-    auto canonical = fs::weakly_canonical(fs::path(path), ec);
-    if (!ec) return canonical;
-    return fs::absolute(fs::path(path), ec).lexically_normal();
+    auto absolute = fs::absolute(fs::path(path), ec);
+    if (ec) return fs::path(path).lexically_normal();
+    return absolute.lexically_normal();
 }
 
 bool same_bundle_path(const std::string& lhs, const std::string& rhs) {


### PR DESCRIPTION
## Summary

Addresses the Codex P2 finding on PR #3110.

The scan-worker filters bundles by comparing the requested path against each scanner result using `weakly_canonical`, which resolves symlinks. If the same directory holds multiple `.clap` / `.vst3` symlinks pointing at the same real bundle, every alias canonicalizes to the same target — so the worker can emit a descriptor for a sibling alias instead of the one it was asked to scan. Since `IsolatedPluginScanner::scan` only consumes the first JSON line, the caller would then return or blacklist the wrong alias depending on directory sort order.

Switches `normalized_bundle_path` to `fs::absolute(...).lexically_normal()` — a lex-only normalization that collapses `./..` segments without following symlinks.

Two commits:
1. `fix(scan-worker): preserve symlink identity in bundle filtering`
2. `test(scan-worker): cover symlink-alias identity preservation`

## Test plan

- [x] `cmake --build build --target pulp-test-isolated-scanner` builds clean
- [x] `./build/test/pulp-test-isolated-scanner` — 39 assertions across 9 test cases pass locally (macOS Release)
- [x] New regression test (`[issue-3110]` tag) verifies that scanning `Alias.vst3` (symlink → `Real.vst3`) returns a descriptor with `path == Alias.vst3`
- [x] Locally reverted the production fix to confirm the test fails without it — does fail with `descriptor->path == "Alias.vst3"` evaluating to `"Real.vst3"`
- [ ] CI macOS lane passes (Linux/Windows advisory)

Closes the Codex P2 review comment above.

Generated as part of a Codex P1/P2 sweep across the last ~15 merged PRs.