### PR TITLE
fix(ios-host): pair editor observer registration with dismantle cleanup

### DIFF
--- a/.agents/skills/ios/SKILL.md
+++ b/.agents/skills/ios/SKILL.md
@@ -240,6 +240,20 @@ xcodebuild test -project ... -scheme AUv3Tests -sdk iphonesimulator
   `set_resize_callback(...)` on both the CPU and Metal hosts, driven from
   `layoutSubviews`. For native child embeds, size from the host's reported
   content bounds instead of hard-coding `UIScreen.mainScreen.bounds`.
+- **`UIViewControllerRepresentable` observer registrations must be paired
+  with `dismantleUIViewController` removal** — the HostApp template's
+  `PulpAUv3EditorView` mounts the AUv3 editor by registering a closure on
+  the `@StateObject` `PulpAUv3Host` that captures the container
+  `UIViewController`. SwiftUI rebuilds the representable on orientation
+  change, scene reset, and iPad split-view shuffles, calling
+  `makeUIViewController` each time. If the observer list is append-only,
+  every rebuild leaks one container VC for the lifetime of the host
+  (which is the lifetime of the SwiftUI app). Use the
+  install-token / remove-by-token pattern in
+  `templates/ios-auv3/HostApp/ContentView.swift`: store the token in a
+  `Coordinator`, call `removeEditorObserver(token)` from the static
+  `dismantleUIViewController(_:coordinator:)` hook, and capture the
+  container VC weakly inside the closure as a second layer of safety.
 
 ### Accessibility
 

--- a/templates/ios-auv3/HostApp/ContentView.swift
+++ b/templates/ios-auv3/HostApp/ContentView.swift
@@ -151,6 +151,7 @@ struct PulpAUv3EditorView: UIViewControllerRepresentable {
         _ uiViewController: EditorContainerViewController,
         coordinator: Coordinator
     ) {
+        uiViewController.setEditor(nil)
         if let token = coordinator.observerToken {
             coordinator.host?.removeEditorObserver(token)
         }

--- a/templates/ios-auv3/HostApp/ContentView.swift
+++ b/templates/ios-auv3/HostApp/ContentView.swift
@@ -121,17 +121,46 @@ struct ContentView: View {
 struct PulpAUv3EditorView: UIViewControllerRepresentable {
     @ObservedObject var host: PulpAUv3Host
 
+    // Coordinator carries the observer token and a host reference so
+    // dismantleUIViewController (a static method) can unregister the
+    // observer when SwiftUI tears down this representable. Without
+    // that pairing, `host.installEditorObserver { ... }` strongly
+    // captures the container VC; every SwiftUI rebuild (orientation
+    // change, scene reset, iPad split-view shuffle) appends a new
+    // closure to the host's observer list and never removes the old
+    // one, so dead container VCs are kept alive for the lifetime of
+    // the `@StateObject` host.
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
     func makeUIViewController(context: Context) -> EditorContainerViewController {
         let vc = EditorContainerViewController()
-        host.installEditorObserver { editorVC in
-            vc.setEditor(editorVC)
+        let token = host.installEditorObserver { [weak vc] editorVC in
+            vc?.setEditor(editorVC)
         }
+        context.coordinator.host = host
+        context.coordinator.observerToken = token
         return vc
     }
 
     func updateUIViewController(_ uiViewController: EditorContainerViewController, context: Context) {
         // No-op — the container observes host.editorViewController updates
         // through installEditorObserver.
+    }
+
+    static func dismantleUIViewController(
+        _ uiViewController: EditorContainerViewController,
+        coordinator: Coordinator
+    ) {
+        if let token = coordinator.observerToken {
+            coordinator.host?.removeEditorObserver(token)
+        }
+        coordinator.observerToken = nil
+        coordinator.host = nil
+    }
+
+    final class Coordinator {
+        var host: PulpAUv3Host?
+        var observerToken: Int?
     }
 
     final class EditorContainerViewController: UIViewController {
@@ -197,17 +226,32 @@ final class PulpAUv3Host: ObservableObject {
     // AUAudioUnit.requestViewController. We hold the most recent VC and
     // notify subscribers so the SwiftUI container can re-mount when the
     // extension finishes loading after the HostApp view tree exists.
+    //
+    // Observer storage is keyed by an opaque token so SwiftUI's
+    // dismantleUIViewController hook can unregister cleanly on view
+    // rebuild — otherwise the closure strongly retains the container
+    // VC and every rebuild leaks one VC for the lifetime of this
+    // `@StateObject` host.
     @Published private(set) var editorViewController: UIViewController?
-    private var editorObservers: [(UIViewController?) -> Void] = []
+    private var editorObservers: [Int: (UIViewController?) -> Void] = [:]
+    private var nextEditorObserverToken: Int = 0
 
-    func installEditorObserver(_ block: @escaping (UIViewController?) -> Void) {
-        editorObservers.append(block)
+    @discardableResult
+    func installEditorObserver(_ block: @escaping (UIViewController?) -> Void) -> Int {
+        let token = nextEditorObserverToken
+        nextEditorObserverToken += 1
+        editorObservers[token] = block
         block(editorViewController)
+        return token
+    }
+
+    func removeEditorObserver(_ token: Int) {
+        editorObservers.removeValue(forKey: token)
     }
 
     fileprivate func setEditorVC(_ vc: UIViewController?) {
         editorViewController = vc
-        for obs in editorObservers { obs(vc) }
+        for obs in editorObservers.values { obs(vc) }
     }
 #endif
 


### PR DESCRIPTION
## Summary

Follow-up to PR #3127 (Phase iOS-D.2) — addresses a P2 leak in the SwiftUI HostApp template's AUv3 editor mount path that I caught during a self-review code sweep.

`PulpAUv3Host.installEditorObserver` appended a closure to an array but never removed it. Each `PulpAUv3EditorView` instance (the `UIViewControllerRepresentable` that mounts the AUv3 editor) called `installEditorObserver` in its `makeUIViewController`, and the closure strongly captured the container `EditorContainerViewController`. Because `PulpAUv3Host` is a `@StateObject` that persists across SwiftUI view rebuilds (orientation change, scene reset, iPad split-view shuffle), every rebuild appended one more closure that kept a dead container VC alive for the lifetime of the host. Memory grew linearly with rebuild count, and every `setEditorVC` walked an ever-longer observer list calling no-op `setEditor` on defunct VCs.

## Changes

- `installEditorObserver` returns an opaque `Int` token (existing call sites continue to compile via `@discardableResult`).
- New `removeEditorObserver(_:)` drops the entry.
- `PulpAUv3EditorView` stashes the token in a `Coordinator` and implements `dismantleUIViewController(_:coordinator:)` to unregister cleanly when SwiftUI tears down the representable.
- Observer storage switched from `[(UIViewController?) -> Void]` to `[Int: (UIViewController?) -> Void]`.
- Closure captures the container VC weakly as a second layer of safety, so a missed remove can't keep the VC alive.
- iOS SKILL.md gains a "Plugin Editor Child Views" gotcha documenting the `UIViewControllerRepresentable` observer/dismantle pairing pattern so future contributors don't reintroduce the same leak.

## Test plan

- [x] Skill-sync gate passes (iOS SKILL.md updated)
- [x] Version-bump gate auto-bumped Claude plugin patch
- [x] Shipyard macOS lane PASSED
- [ ] GHA Linux/Windows lanes (template/CMake-only changes; no platform-specific risk)
- [ ] Auto-merge will fire on green

Compat: existing call sites are unaffected — `installEditorObserver` keeps the same parameter type and gains a `@discardableResult Int` return value. `removeEditorObserver` is purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)