### PR TITLE
docs(ci): guard against stale-SHA merge race in shipyard ship

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -205,6 +205,40 @@ diagnostics, experimental branches, existing Shipyard-managed PRs, or when
 `shipyard pr` itself is being debugged. Do not use them as the primary ship
 path.
 
+### Stale-SHA merge race — DO NOT push onto a PR that's being shipped
+
+**The failure mode (observed 2026-05-29):** Shipyard's `can_merge()`
+validates the *exact merge-candidate SHA* and then merges that SHA. If a
+developer/agent pushes new commits to the same branch while a `shipyard ship`
+is mid-flight, Shipyard merges the **already-validated older SHA** and the new
+commits are stranded on the branch — the PR squash-merges *without* them. In
+the observed case a PR merged at its pre-fix SHA, dropping a whole review-fix
+push; the fixes had to be re-landed via a fresh fast-follow PR.
+
+`expected_head_oid` alone would NOT have caught it — the validated SHA *was*
+GitHub's PR head at the merge instant; the new push only advanced the branch
+ref moments later. The only true prevention is the merger re-checking the
+branch tip immediately before merging and aborting if it advanced past the
+validated SHA — that lives in Shipyard (tracked upstream as Shipyard issue
+321). <!-- docs-noise-lint: skip — stable cross-repo tracking ref for the root fix -->.
+
+**Operational rules (enforce these; they are the practical fix):**
+1. **Never push commits onto a PR that has an in-flight `shipyard ship` or
+   armed auto-merge.** Check `shipyard ship-state list` (shows PR/url/sha) and
+   GitHub's auto-merge state first. If a ship is running, let it finish.
+2. **Land post-review fixes as a fresh PR off `main`**, not as a push onto the
+   already-green PR you just reviewed. (Review comes after green; the green PR
+   is exactly when auto-merge fires.)
+3. **After any ship, verify the merge actually carried your latest commits.**
+   Don't trust "merged" — confirm the merge SHA's tree contains your changes:
+   `git fetch origin main` then check a file you changed is present on
+   `origin/main` (e.g. `git show origin/main:<path> | grep <marker>`), or
+   compare `gh api repos/<o>/<r>/pulls/<n> --jq .merge_commit_sha`. If your
+   commits are missing, re-land them as a fresh PR immediately.
+4. A degraded/rate-limited `gh pr view ... headRefOid` read can return a stale
+   SHA — corroborate branch state with `git ls-remote` / a real `git fetch`
+   before concluding the branch moved or was reset.
+
 ### Shipyard pin and behaviour notes
 
 Pin bumps must go through `shipyard pin bump --to vX.Y.Z`, not a hand edit.


### PR DESCRIPTION
A mid-flight `shipyard ship` validates and merges the exact candidate SHA;
pushing new commits to the same branch while it runs causes the older
validated SHA to merge and strands the new commits (a PR can merge without
just-pushed review fixes — observed 2026-05-29, recovered via a fast-follow
PR). The root fix (re-check branch tip before merge) is tracked upstream as
Shipyard issue 321; this documents the operational guard so all agents follow
it: never push onto a PR with an in-flight ship/armed auto-merge, land
post-review fixes as a fresh PR, and verify the merge SHA carried your commits.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>