### PR TITLE
refactor(frontend-ir): schema-name registry + gate trust-boundary docstrings

### DIFF
--- a/tools/scripts/frontend_ir_codegen_artifact_gate.py
+++ b/tools/scripts/frontend_ir_codegen_artifact_gate.py
@@ -8,6 +8,7 @@ import json
 import pathlib
 from typing import Any
 from frontend_ir_common import as_dict, as_list, load_json, non_negative_int, write_json
+from frontend_ir_validation import SCHEMAS
 
 
 PASS_STATUS = "pass"
@@ -15,8 +16,8 @@ WARN_STATUS = "warn"
 FAIL_STATUS = "fail"
 READY_VERDICT = "ready"
 NOT_READY_VERDICT = "not_ready"
-CODEGEN_ARTIFACT_SCHEMA = "pulp-frontend-ir-codegen-artifacts-v0"
-GATE_SCHEMA = "pulp-frontend-ir-codegen-artifact-gate-v0"
+CODEGEN_ARTIFACT_SCHEMA = SCHEMAS["codegen_artifacts"]
+GATE_SCHEMA = SCHEMAS["codegen_artifact_gate"]
 NATIVE_CPP_ROUTE = "native_cpp"
 
 

--- a/tools/scripts/frontend_ir_codegen_artifacts.py
+++ b/tools/scripts/frontend_ir_codegen_artifacts.py
@@ -9,10 +9,11 @@ import json
 import pathlib
 from typing import Any
 from frontend_ir_common import as_list, load_json, write_json
+from frontend_ir_validation import SCHEMAS
 
 
-SCHEMA = "pulp-frontend-ir-codegen-artifacts-v0"
-BINDING_SCHEMA = "pulp-native-cpp-binding-manifest-v1"
+SCHEMA = SCHEMAS["codegen_artifacts"]
+BINDING_SCHEMA = SCHEMAS["native_cpp_binding_manifest"]
 NATIVE_CPP_ROUTE = "native_cpp"
 
 
@@ -120,7 +121,7 @@ def build_codegen_artifact_report(
     return {
         "schema": SCHEMA,
         "fixture_id": str(frontend_ir.get("fixture_id", "")),
-        "frontend_ir": artifact_ref(frontend_ir_path, repo_root, "frontend_ir", "pulp-frontend-ir-v0"),
+        "frontend_ir": artifact_ref(frontend_ir_path, repo_root, "frontend_ir", SCHEMAS["frontend_ir"]),
         "artifacts": {
             "source_cpp": artifact_ref(source_cpp, repo_root, "generated_cpp_source"),
             "header": artifact_ref(header, repo_root, "generated_cpp_header"),

--- a/tools/scripts/frontend_ir_gate.py
+++ b/tools/scripts/frontend_ir_gate.py
@@ -13,6 +13,7 @@ from frontend_ir_validation import (
     ROUTE_HYBRID,
     ROUTE_LIVE_JS,
     ROUTE_UNSUPPORTED,
+    SCHEMAS,
     validate_frontend_ir,
 )
 from frontend_ir_common import load_json, write_json
@@ -274,7 +275,7 @@ def gate_frontend_ir(report: dict[str, Any], mode: str) -> dict[str, Any]:
     warnings = sum(1 for item in checks if item["status"] == WARN_STATUS)
     verdict = READY_VERDICT if failures == 0 else NOT_READY_VERDICT
     return {
-        "schema": "pulp-frontend-ir-gate-v0",
+        "schema": SCHEMAS["gate"],
         "fixture_id": str(report.get("fixture_id", "")),
         "mode": mode,
         "verdict": verdict,

--- a/tools/scripts/frontend_ir_inspector.py
+++ b/tools/scripts/frontend_ir_inspector.py
@@ -8,6 +8,7 @@ import json
 import pathlib
 from typing import Any
 from frontend_ir_common import as_dict, as_list, load_json, write_json
+from frontend_ir_validation import SCHEMAS
 
 
 def repo_relative(path: pathlib.Path, repo_root: pathlib.Path) -> str:
@@ -306,7 +307,7 @@ def build_inspector_report(report: dict[str, Any], gates: list[dict[str, Any]] |
     tokens = token_summary(report)
     tweaks = tweak_summary(report)
     return {
-        "schema": "pulp-frontend-ir-inspector-v0",
+        "schema": SCHEMAS["inspector"],
         "fixture_id": str(report.get("fixture_id", "")),
         "source": {
             "kind": source.get("kind", ""),

--- a/tools/scripts/frontend_ir_native_validation_gate.py
+++ b/tools/scripts/frontend_ir_native_validation_gate.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Evaluate native end-to-end readiness from existing FrontendIR proof artifacts."""
+"""Evaluate native end-to-end readiness from existing FrontendIR proof artifacts.
+
+This gate is an *evidence aggregator* over child verdicts: it does not re-run any
+upstream validation. It trusts each child artifact's own pass/fail determination
+and re-derives only the cross-cutting invariants needed to keep a child from
+contributing a silent or self-certified PASS to the aggregate verdict. The
+per-function docstrings below spell out the trust boundary each check enforces.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +15,7 @@ import json
 import pathlib
 from typing import Any
 from frontend_ir_common import as_dict, as_list, load_json, non_negative_int, write_json
+from frontend_ir_validation import SCHEMAS
 
 
 PASS_STATUS = "pass"
@@ -15,11 +23,11 @@ WARN_STATUS = "warn"
 FAIL_STATUS = "fail"
 READY_VERDICT = "ready"
 NOT_READY_VERDICT = "not_ready"
-GATE_SCHEMA = "pulp-frontend-ir-native-validation-gate-v0"
+GATE_SCHEMA = SCHEMAS["native_validation_gate"]
 
-FRONTEND_IR_GATE_SCHEMA = "pulp-frontend-ir-gate-v0"
-PRIMITIVE_GATE_SCHEMA = "pulp-frontend-ir-primitive-gate-v0"
-CODEGEN_GATE_SCHEMA = "pulp-frontend-ir-codegen-artifact-gate-v0"
+FRONTEND_IR_GATE_SCHEMA = SCHEMAS["gate"]
+PRIMITIVE_GATE_SCHEMA = SCHEMAS["primitive_gate"]
+CODEGEN_GATE_SCHEMA = SCHEMAS["codegen_artifact_gate"]
 CPP_ONLY_SCHEMA = "pulp-native-ui-phase-g-cpp-only-audit-v1"
 BEHAVIOR_VISUAL_SCHEMA = "pulp-native-ui-phase-g-cpp-only-behavior-visual-v1"
 COST_SCHEMA = "pulp-native-ui-phase-g-cpp-only-cost-audit-v1"
@@ -54,6 +62,16 @@ def child_gate_check(report: dict[str, Any],
                      expected_schema: str,
                      check_id: str,
                      label: str) -> list[dict[str, Any]]:
+    """Aggregate a child gate's verdict (FrontendIR / primitive / codegen).
+
+    TRUST BOUNDARY: trusts the child gate's own ``verdict`` and ``summary``
+    counts as the authoritative result of the validation it ran — this gate does
+    not re-run that validation. It independently re-derives only the structural
+    guards that prevent a vacuous PASS: the report must carry the expected
+    ``schema``, must contain at least one ``checks`` entry (a "ready" verdict
+    with no checks has verified nothing), and must report ``verdict == ready``
+    with zero failures. Child warnings are surfaced but not treated as failing.
+    """
     checks: list[dict[str, Any]] = []
     if report.get("schema") != expected_schema:
         return [check(check_id, FAIL_STATUS, f"{label} schema must be {expected_schema}")]
@@ -104,6 +122,16 @@ def child_gate_check(report: dict[str, Any],
 
 
 def cpp_only_checks(report: dict[str, Any]) -> list[dict[str, Any]]:
+    """Confirm the phase-G cpp-only audit proves a no-runtime-JS native binary.
+
+    TRUST BOUNDARY: trusts the audit's reported ``criteria`` booleans, its
+    ``binary`` descriptor (existence, byte count, sha256), and its
+    ``phase_g_cpp_only_proven`` claim as produced facts — it does not re-run the
+    build or re-hash the binary. It independently re-derives the *completeness*
+    conjunction: the schema must match, every required criterion must be exactly
+    ``True``, the binary must exist with non-zero bytes and a 64-char sha256, and
+    the proven flag must be set. A missing field reads as not-proven, never PASS.
+    """
     if report.get("schema") != CPP_ONLY_SCHEMA:
         return [check("cpp_only_audit", FAIL_STATUS, f"cpp-only audit schema must be {CPP_ONLY_SCHEMA}")]
 
@@ -137,6 +165,19 @@ def cpp_only_checks(report: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def behavior_visual_checks(report: dict[str, Any]) -> list[dict[str, Any]]:
+    """Confirm the phase-G behavior/visual parity proof is complete and passing.
+
+    TRUST BOUNDARY: trusts the report's measured numbers (``threshold``,
+    ``full_similarity``, ``routed_region_similarity``, interaction/parameter
+    counts, ``bound_counts``) and its boolean claims as produced evidence — it
+    does not re-capture screenshots or replay interactions. It independently
+    re-derives the guards that stop a report from self-certifying: the schema
+    must match, it must compile cpp-only and not link the script runtime, a
+    *positive* similarity threshold must be present (a zero threshold makes the
+    ``<`` comparison toothless), measured similarity must clear that threshold,
+    behavior must have passed, and interaction / parameter / bound counts must
+    all be non-zero so the proof actually exercised the UI.
+    """
     if report.get("schema") != BEHAVIOR_VISUAL_SCHEMA:
         return [check(
             "behavior_visual_parity",
@@ -198,6 +239,16 @@ def behavior_visual_checks(report: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def cost_checks(report: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Confirm the optional phase-G cost proof is complete when supplied.
+
+    TRUST BOUNDARY: the cost proof is optional — a missing report is a WARN, not
+    a failure, so its absence cannot block readiness. When present, this trusts
+    the report's ``status``, ``binary_size_delta`` and ``cost_metrics`` as
+    produced measurements (no re-measurement here) and independently re-derives
+    completeness: the schema must match, status and ``criteria.complete`` must
+    both signal complete, and the cpp-only byte delta plus startup metrics must
+    be present and non-empty.
+    """
     if report is None:
         return [check("cost_proof", WARN_STATUS, "cost proof was not supplied")]
     if report.get("schema") != COST_SCHEMA:
@@ -220,6 +271,15 @@ def cost_checks(report: dict[str, Any] | None) -> list[dict[str, Any]]:
 
 
 def gpu_preview_checks(report: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Confirm the optional phase-F GPU preview proof loaded GPU but not JS.
+
+    TRUST BOUNDARY: the GPU preview proof is optional — a missing report is a
+    WARN, not a failure. When present, this trusts the report's boolean claims
+    and ``runtime`` observations as produced facts and independently re-derives
+    completeness: the schema must match, ``gpu_preview_proven`` / ``gpu_linked``
+    / ``no_js_engine_symbols`` must each be ``True``, the GPU runtime must have
+    loaded, and the JS runtime must explicitly *not* have loaded.
+    """
     if report is None:
         return [check("gpu_preview_proof", WARN_STATUS, "GPU preview proof was not supplied")]
     if report.get("schema") != GPU_PREVIEW_SCHEMA:
@@ -262,6 +322,16 @@ def build_native_validation_gate(
     gpu_preview_report: dict[str, Any] | None = None,
     artifact_paths: dict[str, str] | None = None,
 ) -> dict[str, Any]:
+    """Compose all child verdicts into the aggregate native-validation gate.
+
+    TRUST BOUNDARY: this is the top-level aggregator. It owns no validation of
+    its own — it trusts each child check function (above) to enforce its
+    respective trust boundary and simply unions their emitted checks. The
+    aggregate ``verdict`` is mechanically derived: ``ready`` iff zero FAIL checks
+    across all children (WARN does not block). The required FrontendIR /
+    primitive / codegen child gates are mandatory inputs; the cost and GPU
+    preview proofs are optional and contribute WARN-only when absent.
+    """
     checks: list[dict[str, Any]] = []
     checks.extend(child_gate_check(
         frontend_ir_gate,

--- a/tools/scripts/frontend_ir_primitive_gate.py
+++ b/tools/scripts/frontend_ir_primitive_gate.py
@@ -10,7 +10,7 @@ from typing import Any
 from frontend_ir_common import as_dict, as_list, load_json, non_negative_int, write_json
 # Import the canonical native-route set rather than re-typing the string
 # literals — a local copy silently drifts when a route is added to the set.
-from frontend_ir_validation import NATIVE_ROUTES
+from frontend_ir_validation import NATIVE_ROUTES, SCHEMAS
 
 
 PASS_STATUS = "pass"
@@ -47,7 +47,7 @@ def check(check_id: str, status: str, message: str, **details: Any) -> dict[str,
 
 
 def validate_primitive_coverage(report: dict[str, Any]) -> None:
-    if report.get("schema") != "pulp-frontend-ir-primitive-coverage-v0":
+    if report.get("schema") != SCHEMAS["primitive_coverage"]:
         raise ValueError("schema must be pulp-frontend-ir-primitive-coverage-v0")
     if not isinstance(report.get("fixture_id"), str):
         raise ValueError("fixture_id must be a string")
@@ -296,7 +296,7 @@ def gate_primitive_coverage(report: dict[str, Any], mode: str) -> dict[str, Any]
     failures = sum(1 for item in checks if item["status"] == FAIL_STATUS)
     warnings = sum(1 for item in checks if item["status"] == WARN_STATUS)
     return {
-        "schema": "pulp-frontend-ir-primitive-gate-v0",
+        "schema": SCHEMAS["primitive_gate"],
         "fixture_id": str(report.get("fixture_id", "")),
         "mode": mode,
         "verdict": READY_VERDICT if failures == 0 else NOT_READY_VERDICT,

--- a/tools/scripts/frontend_ir_primitives.py
+++ b/tools/scripts/frontend_ir_primitives.py
@@ -8,6 +8,7 @@ import json
 import pathlib
 from typing import Any
 from frontend_ir_common import as_dict, as_list, load_json, write_json
+from frontend_ir_validation import SCHEMAS
 
 
 PRIMITIVE_CATALOG: dict[str, dict[str, Any]] = {
@@ -219,7 +220,7 @@ def build_primitive_report(
     summary["nodes_with_binding"] = sum(row["nodes_with_binding"] for row in primitives)
     summary["nodes_requiring_js"] = sum(row["nodes_requiring_js"] for row in primitives)
     return {
-        "schema": "pulp-frontend-ir-primitive-coverage-v0",
+        "schema": SCHEMAS["primitive_coverage"],
         "fixture_id": str(report.get("fixture_id", "")),
         "frontend_ir": {
             "path": repo_relative(source_path, root) if source_path else "",

--- a/tools/scripts/frontend_ir_report.py
+++ b/tools/scripts/frontend_ir_report.py
@@ -23,6 +23,7 @@ from frontend_ir_validation import (
     ROUTE_NATIVE_HTML,
     ROUTE_RECORDED_PAINT,
     ROUTE_UNSUPPORTED,
+    SCHEMAS,
     SOURCE_TRUTHS,
     is_finite_number,
     is_non_negative_int,
@@ -767,7 +768,7 @@ def build_frontend_ir(
         notes.append(f"attached {len(tweaks)} tweak sidecar edits without mutating imported source.")
 
     report: dict[str, Any] = {
-        "schema": "pulp-frontend-ir-v0",
+        "schema": SCHEMAS["frontend_ir"],
         "fixture_id": str(route_manifest.get("fixture") or overlay.get("fixture_id") or ""),
         "source": {
             "kind": source_kind(source_path),

--- a/tools/scripts/frontend_ir_session.py
+++ b/tools/scripts/frontend_ir_session.py
@@ -8,6 +8,7 @@ import json
 import pathlib
 from typing import Any
 from frontend_ir_common import load_json, write_json
+from frontend_ir_validation import SCHEMAS
 
 
 CHANGE_SCOPES = (
@@ -263,7 +264,7 @@ def compare_reports(before: dict[str, Any], after: dict[str, Any],
 
     root = repo_root or pathlib.Path.cwd()
     report: dict[str, Any] = {
-        "schema": "pulp-frontend-ir-session-diff-v0",
+        "schema": SCHEMAS["session_diff"],
         "fixture_id": str(after.get("fixture_id") or before.get("fixture_id") or ""),
         "before": {
             "fixture_id": str(before.get("fixture_id", "")),

--- a/tools/scripts/frontend_ir_session_manifest.py
+++ b/tools/scripts/frontend_ir_session_manifest.py
@@ -10,6 +10,7 @@ import mimetypes
 import pathlib
 from typing import Any
 from frontend_ir_common import as_dict, as_list, load_json, write_json
+from frontend_ir_validation import SCHEMAS
 
 
 def repo_relative(path: pathlib.Path, repo_root: pathlib.Path) -> str:
@@ -353,7 +354,7 @@ def build_session_manifest(
     session_diff_summary = as_dict(as_dict(session_diff[1]).get("summary")) if session_diff else {}
     inspector_summary = as_dict(as_dict(inspector[1]).get("summary")) if inspector else {}
     return {
-        "schema": "pulp-frontend-ir-session-v0",
+        "schema": SCHEMAS["session"],
         "fixture_id": str(report.get("fixture_id", "")),
         "summary": {
             "artifacts": len(artifacts),

--- a/tools/scripts/frontend_ir_tweaks.py
+++ b/tools/scripts/frontend_ir_tweaks.py
@@ -7,6 +7,8 @@ import json
 import pathlib
 from typing import Any
 
+from frontend_ir_validation import SCHEMAS
+
 
 VALID_INVALIDATIONS = {"source", "style", "resource", "route", "validation"}
 
@@ -81,7 +83,7 @@ def tweaks_from_sidecar(path: pathlib.Path, valid_node_ids: set[str] | None = No
         raw_tweaks = data
     else:
         schema = data.get("schema")
-        if schema is not None and schema not in {"pulp-tweaks-v0", "pulp-frontend-ir-tweaks-v0"}:
+        if schema is not None and schema not in {SCHEMAS["tweaks"], SCHEMAS["tweaks_namespaced"]}:
             raise ValueError(f"{path} has unsupported tweak sidecar schema: {schema}")
         raw_tweaks = data.get("tweaks", [])
     if not isinstance(raw_tweaks, list):

--- a/tools/scripts/frontend_ir_validation.py
+++ b/tools/scripts/frontend_ir_validation.py
@@ -35,6 +35,38 @@ SOURCE_TRUTHS = {"archived_fixture", "local_file", "mcp_payload", "generated", "
 SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
 
 
+# Canonical registry of frontend-IR schema name strings.
+#
+# Single source of truth for the schema identifiers emitted and checked by the
+# frontend_ir producer/consumer scripts. Logical key -> exact wire string. The
+# string VALUES are the contract: they are matched byte-for-byte by producers,
+# consumers, and external tooling, so they must never change here without a
+# coordinated schema-version bump. Add a new key rather than editing a value.
+SCHEMAS = {
+    # Core frontend-IR report and its acceptance gate.
+    "frontend_ir": "pulp-frontend-ir-v0",
+    "gate": "pulp-frontend-ir-gate-v0",
+    # Primitive-coverage report and its gate.
+    "primitive_coverage": "pulp-frontend-ir-primitive-coverage-v0",
+    "primitive_gate": "pulp-frontend-ir-primitive-gate-v0",
+    # Codegen artifacts manifest and its gate.
+    "codegen_artifacts": "pulp-frontend-ir-codegen-artifacts-v0",
+    "codegen_artifact_gate": "pulp-frontend-ir-codegen-artifact-gate-v0",
+    # Aggregate native-validation gate verdict.
+    "native_validation_gate": "pulp-frontend-ir-native-validation-gate-v0",
+    # Inspector snapshot.
+    "inspector": "pulp-frontend-ir-inspector-v0",
+    # Session manifest and session diff.
+    "session": "pulp-frontend-ir-session-v0",
+    "session_diff": "pulp-frontend-ir-session-diff-v0",
+    # Tweaks payloads (legacy + namespaced aliases, both accepted on read).
+    "tweaks": "pulp-tweaks-v0",
+    "tweaks_namespaced": "pulp-frontend-ir-tweaks-v0",
+    # Native C++ binding manifest consumed by the codegen-artifacts producer.
+    "native_cpp_binding_manifest": "pulp-native-cpp-binding-manifest-v1",
+}
+
+
 def expect(condition: bool, message: str) -> None:
     if not condition:
         raise ValueError(message)
@@ -121,7 +153,7 @@ def validate_tweak(value: Any, field: str) -> None:
 
 
 def validate_frontend_ir(report: dict[str, Any]) -> None:
-    expect(report.get("schema") == "pulp-frontend-ir-v0", "schema must be pulp-frontend-ir-v0")
+    expect(report.get("schema") == SCHEMAS["frontend_ir"], "schema must be pulp-frontend-ir-v0")
     for key in ("source", "design_ir", "nodes", "routes", "validation"):
         expect(key in report, f"missing required field: {key}")
 


### PR DESCRIPTION
Add a single canonical SCHEMAS registry in frontend_ir_validation.py mapping a
logical key to the exact frontend-IR schema wire string, and route the
producer/consumer scripts through it instead of repeating bare string literals
at 15+ sites. The string VALUES are unchanged and byte-identical to the prior
literals, so emitted and checked schema names are preserved; only the source of
the strings is centralized. Two assertion *message* strings are left as literals
intentionally. Test files keep their own literals as an independent check.

Also document the trust boundary of each check in
frontend_ir_native_validation_gate.py: the module docstring now notes the gate
is an evidence aggregator over child verdicts, and each gate/check function
(child_gate_check, cpp_only_checks, behavior_visual_checks, cost_checks,
gpu_preview_checks, build_native_validation_gate) gains a docstring spelling out
what it trusts from upstream child artifacts vs. what it independently
re-derives. Docstrings only -- no SOURCE_TRUTHS enforcement and no behavior
change (the warn-first enforcement follow-up is deliberately deferred).

Skill-Update: skip skill=import-design reason="Python tooling cleanup; no behavior or contract change"
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>