### PR TITLE
refactor(view): typed NativeBindingMetadata for the pulp* binding contract

### DIFF
--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -301,6 +301,7 @@ target_sources(pulp-view-core PRIVATE
     src/relative_point.cpp
     src/design_export.cpp
     src/design_import.cpp
+    src/design_binding_metadata.cpp
     src/design_ir_json.cpp
     src/design_import_v0_tsx.cpp
     src/design_import_native_common.cpp

--- a/core/view/src/design_binding_metadata.cpp
+++ b/core/view/src/design_binding_metadata.cpp
@@ -1,0 +1,221 @@
+// design_binding_metadata.cpp — single parse/serialize path for the `pulp*`
+// native-binding attribute contract. See design_binding_metadata.hpp.
+
+#include "design_binding_metadata.hpp"
+
+#include <cctype>
+#include <cstdlib>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace pulp::view {
+
+namespace {
+
+// Reads attribute `key` off `node`. Returns the raw value (including empty
+// strings) when present, std::nullopt when absent — mirrors the original
+// attr() helpers in the consumers.
+std::optional<std::string> read_attr(const IRNode& node, std::string_view key) {
+    auto it = node.attributes.find(std::string(key));
+    if (it == node.attributes.end())
+        return std::nullopt;
+    return it->second;
+}
+
+// Identical to the consumers' parse_float(): strtof, tolerate trailing
+// whitespace, nullopt on non-numeric / empty input.
+std::optional<float> parse_float(const std::string& text) {
+    char* end = nullptr;
+    const float parsed = std::strtof(text.c_str(), &end);
+    if (end == text.c_str())
+        return std::nullopt;
+    while (*end != '\0') {
+        if (!std::isspace(static_cast<unsigned char>(*end)))
+            return std::nullopt;
+        ++end;
+    }
+    return parsed;
+}
+
+std::optional<float> parse_float_opt(const std::optional<std::string>& raw) {
+    if (!raw)
+        return std::nullopt;
+    return parse_float(*raw);
+}
+
+std::string lower_copy(std::string value) {
+    for (auto& c : value)
+        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    return value;
+}
+
+// set_contract_attr semantics from design_import_v0_tsx.cpp: skip empty
+// values; only write when the node has no existing non-empty value for `key`.
+void set_contract_attr(IRNode& node, const char* key, const std::optional<std::string>& value) {
+    if (!value || value->empty())
+        return;
+    auto it = node.attributes.find(key);
+    if (it == node.attributes.end() || it->second.empty())
+        node.attributes[key] = *value;
+}
+
+}  // namespace
+
+NativeBindingMetadata NativeBindingMetadata::parse(const IRNode& node) {
+    NativeBindingMetadata md;
+
+    md.route_id = read_attr(node, "pulpRouteId");
+    md.route_type = read_attr(node, "pulpRouteType");
+    md.source_family = read_attr(node, "pulpSourceFamily");
+    md.source_path = read_attr(node, "pulpSourcePath");
+
+    md.param_key = read_attr(node, "pulpParamKey");
+    md.binding_module = read_attr(node, "pulpBindingModule");
+    md.binding_param = read_attr(node, "pulpBindingParam");
+
+    md.choice_value = read_attr(node, "pulpChoiceValue");
+    md.choice_label = read_attr(node, "pulpChoiceLabel");
+
+    md.x_param_key = read_attr(node, "pulpParamKeyX");
+    md.y_param_key = read_attr(node, "pulpParamKeyY");
+    md.x_binding_module = read_attr(node, "pulpBindingModuleX");
+    md.x_binding_param = read_attr(node, "pulpBindingParamX");
+    md.y_binding_module = read_attr(node, "pulpBindingModuleY");
+    md.y_binding_param = read_attr(node, "pulpBindingParamY");
+
+    md.meter_source = read_attr(node, "pulpMeterSource");
+    md.meter_channel = read_attr(node, "pulpMeterChannel");
+    md.meter_value_key = read_attr(node, "pulpMeterValueKey");
+    md.waveform_shape = read_attr(node, "pulpWaveformShape");
+
+    md.value_key = read_attr(node, "pulpValueKey");
+    md.initial_value = read_attr(node, "pulpInitialValue");
+    md.placeholder = read_attr(node, "pulpPlaceholder");
+    md.default_value_source = read_attr(node, "pulpDefaultValueSource");
+
+    md.focus_contract = read_attr(node, "pulpFocusContract");
+    md.payload_contract = read_attr(node, "pulpPayloadContract");
+    md.host_action = read_attr(node, "pulpHostAction");
+    md.host_action_label = read_attr(node, "pulpHostActionLabel");
+    md.type_label = read_attr(node, "pulpTypeLabel");
+    md.description = read_attr(node, "pulpDescription");
+    md.event_contract = read_attr(node, "pulpEventContract");
+    md.gesture_contract = read_attr(node, "pulpGestureContract");
+    md.style_tokens = read_attr(node, "pulpStyleTokens");
+    md.fallback_reason = read_attr(node, "pulpFallbackReason");
+    md.widget_schema = read_attr(node, "pulpWidgetSchema");
+
+    md.grid_template_columns = read_attr(node, "pulpGridTemplateColumns");
+    md.grid_template_rows = read_attr(node, "pulpGridTemplateRows");
+
+    md.thumb_width = read_attr(node, "pulpThumbWidth");
+    md.thumb_height = read_attr(node, "pulpThumbHeight");
+    md.thumb_corner_radius = read_attr(node, "pulpThumbCornerRadius");
+    md.corner_radius = read_attr(node, "pulpCornerRadius");
+    md.font_size = read_attr(node, "pulpFontSize");
+
+    md.thumb_shape = read_attr(node, "pulpThumbShape");
+    md.on_background_color = read_attr(node, "pulpOnBackgroundColor");
+    md.off_background_color = read_attr(node, "pulpOffBackgroundColor");
+    md.on_text_color = read_attr(node, "pulpOnTextColor");
+    md.off_text_color = read_attr(node, "pulpOffTextColor");
+    md.on_border_color = read_attr(node, "pulpOnBorderColor");
+    md.off_border_color = read_attr(node, "pulpOffBorderColor");
+
+    md.show_internal_label = read_attr(node, "pulpShowInternalLabel");
+    md.hit_testable = read_attr(node, "pulpHitTestable");
+
+    return md;
+}
+
+void NativeBindingMetadata::serialize(IRNode& node) const {
+    set_contract_attr(node, "pulpRouteId", route_id);
+    set_contract_attr(node, "pulpRouteType", route_type);
+    set_contract_attr(node, "pulpSourceFamily", source_family);
+    set_contract_attr(node, "pulpSourcePath", source_path);
+
+    set_contract_attr(node, "pulpParamKey", param_key);
+    set_contract_attr(node, "pulpBindingModule", binding_module);
+    set_contract_attr(node, "pulpBindingParam", binding_param);
+
+    set_contract_attr(node, "pulpChoiceValue", choice_value);
+    set_contract_attr(node, "pulpChoiceLabel", choice_label);
+
+    set_contract_attr(node, "pulpParamKeyX", x_param_key);
+    set_contract_attr(node, "pulpParamKeyY", y_param_key);
+    set_contract_attr(node, "pulpBindingModuleX", x_binding_module);
+    set_contract_attr(node, "pulpBindingParamX", x_binding_param);
+    set_contract_attr(node, "pulpBindingModuleY", y_binding_module);
+    set_contract_attr(node, "pulpBindingParamY", y_binding_param);
+
+    set_contract_attr(node, "pulpMeterSource", meter_source);
+    set_contract_attr(node, "pulpMeterChannel", meter_channel);
+    set_contract_attr(node, "pulpMeterValueKey", meter_value_key);
+    set_contract_attr(node, "pulpWaveformShape", waveform_shape);
+
+    set_contract_attr(node, "pulpValueKey", value_key);
+    set_contract_attr(node, "pulpInitialValue", initial_value);
+    set_contract_attr(node, "pulpPlaceholder", placeholder);
+    set_contract_attr(node, "pulpDefaultValueSource", default_value_source);
+
+    set_contract_attr(node, "pulpFocusContract", focus_contract);
+    set_contract_attr(node, "pulpPayloadContract", payload_contract);
+    set_contract_attr(node, "pulpHostAction", host_action);
+    set_contract_attr(node, "pulpHostActionLabel", host_action_label);
+    set_contract_attr(node, "pulpTypeLabel", type_label);
+    set_contract_attr(node, "pulpDescription", description);
+    set_contract_attr(node, "pulpEventContract", event_contract);
+    set_contract_attr(node, "pulpGestureContract", gesture_contract);
+    set_contract_attr(node, "pulpStyleTokens", style_tokens);
+    set_contract_attr(node, "pulpFallbackReason", fallback_reason);
+    set_contract_attr(node, "pulpWidgetSchema", widget_schema);
+
+    set_contract_attr(node, "pulpGridTemplateColumns", grid_template_columns);
+    set_contract_attr(node, "pulpGridTemplateRows", grid_template_rows);
+
+    set_contract_attr(node, "pulpThumbWidth", thumb_width);
+    set_contract_attr(node, "pulpThumbHeight", thumb_height);
+    set_contract_attr(node, "pulpThumbCornerRadius", thumb_corner_radius);
+    set_contract_attr(node, "pulpCornerRadius", corner_radius);
+    set_contract_attr(node, "pulpFontSize", font_size);
+
+    set_contract_attr(node, "pulpThumbShape", thumb_shape);
+    set_contract_attr(node, "pulpOnBackgroundColor", on_background_color);
+    set_contract_attr(node, "pulpOffBackgroundColor", off_background_color);
+    set_contract_attr(node, "pulpOnTextColor", on_text_color);
+    set_contract_attr(node, "pulpOffTextColor", off_text_color);
+    set_contract_attr(node, "pulpOnBorderColor", on_border_color);
+    set_contract_attr(node, "pulpOffBorderColor", off_border_color);
+
+    set_contract_attr(node, "pulpShowInternalLabel", show_internal_label);
+    set_contract_attr(node, "pulpHitTestable", hit_testable);
+}
+
+std::optional<float> NativeBindingMetadata::thumb_width_value() const {
+    return parse_float_opt(thumb_width);
+}
+
+std::optional<float> NativeBindingMetadata::thumb_height_value() const {
+    return parse_float_opt(thumb_height);
+}
+
+std::optional<float> NativeBindingMetadata::thumb_corner_radius_value() const {
+    return parse_float_opt(thumb_corner_radius);
+}
+
+std::optional<float> NativeBindingMetadata::corner_radius_value() const {
+    return parse_float_opt(corner_radius);
+}
+
+std::optional<float> NativeBindingMetadata::font_size_value() const {
+    return parse_float_opt(font_size);
+}
+
+bool NativeBindingMetadata::show_internal_label_value() const {
+    if (show_internal_label && lower_copy(*show_internal_label) == "false")
+        return false;
+    return true;
+}
+
+}  // namespace pulp::view

--- a/core/view/src/design_binding_metadata.hpp
+++ b/core/view/src/design_binding_metadata.hpp
@@ -1,0 +1,137 @@
+// design_binding_metadata.hpp — typed model of the `pulp*` native-binding
+// attribute contract.
+//
+// Created in the 2026-05-29 frontend-IR refactor (PR-3). Before this, the
+// stringly-typed `pulp*` attributes that carry the native-C++ binding
+// contract were read by hand in three places — the v0/TSX writer
+// (design_import_v0_tsx.cpp), the widget-semantics reader
+// (design_import_native_common.cpp), and the C++ codegen / binding-manifest
+// emitter (design_cpp_codegen.cpp) — each re-enumerating the ~45 `pulp*`
+// keys with ad-hoc `attr(node, "pulp...")` calls. NativeBindingMetadata is
+// the single typed model: one parse() reads the attributes, one serialize()
+// writes them back. Field presence/absence and exact string values round-trip
+// byte-identically, so the emitted attribute strings and the generated
+// binding-manifest JSON are unchanged.
+//
+// PRIVATE: lives under core/view/src/, not the installed include tree. Do not
+// reference from headers outside core/view/src/.
+
+#pragma once
+
+#include <pulp/view/design_ir.hpp>
+
+#include <optional>
+#include <string>
+
+namespace pulp::view {
+
+// Typed model of the `pulp*` binding-contract attributes on an IRNode.
+//
+// Every field uses std::optional<std::string> for free / open-domain string
+// values so that "absent" vs "present-but-empty" vs "present-with-value"
+// round-trips exactly. Numeric thumb/corner/font fields parse to
+// std::optional<float>; the two boolean flags carry their semantic defaults
+// (both true) for the reader, and remember whether the attribute was actually
+// present so serialize() can reproduce write-time presence.
+struct NativeBindingMetadata {
+    // Routing / family.
+    std::optional<std::string> route_id;             // pulpRouteId
+    std::optional<std::string> route_type;           // pulpRouteType ("native_cpp")
+    std::optional<std::string> source_family;        // pulpSourceFamily
+    std::optional<std::string> source_path;          // pulpSourcePath
+
+    // Single-parameter binding.
+    std::optional<std::string> param_key;            // pulpParamKey
+    std::optional<std::string> binding_module;       // pulpBindingModule
+    std::optional<std::string> binding_param;        // pulpBindingParam
+
+    // Choice (toggle) binding.
+    std::optional<std::string> choice_value;         // pulpChoiceValue
+    std::optional<std::string> choice_label;         // pulpChoiceLabel
+
+    // XY-pad binding.
+    std::optional<std::string> x_param_key;          // pulpParamKeyX
+    std::optional<std::string> y_param_key;          // pulpParamKeyY
+    std::optional<std::string> x_binding_module;     // pulpBindingModuleX
+    std::optional<std::string> x_binding_param;      // pulpBindingParamX
+    std::optional<std::string> y_binding_module;     // pulpBindingModuleY
+    std::optional<std::string> y_binding_param;      // pulpBindingParamY
+
+    // Meter / waveform.
+    std::optional<std::string> meter_source;         // pulpMeterSource
+    std::optional<std::string> meter_channel;        // pulpMeterChannel
+    std::optional<std::string> meter_value_key;      // pulpMeterValueKey
+    std::optional<std::string> waveform_shape;       // pulpWaveformShape
+
+    // Value / text.
+    std::optional<std::string> value_key;            // pulpValueKey
+    std::optional<std::string> initial_value;        // pulpInitialValue
+    std::optional<std::string> placeholder;          // pulpPlaceholder
+    std::optional<std::string> default_value_source; // pulpDefaultValueSource
+
+    // Contracts / host actions / docs.
+    std::optional<std::string> focus_contract;       // pulpFocusContract
+    std::optional<std::string> payload_contract;     // pulpPayloadContract
+    std::optional<std::string> host_action;          // pulpHostAction
+    std::optional<std::string> host_action_label;    // pulpHostActionLabel
+    std::optional<std::string> type_label;           // pulpTypeLabel
+    std::optional<std::string> description;          // pulpDescription
+    std::optional<std::string> event_contract;       // pulpEventContract
+    std::optional<std::string> gesture_contract;     // pulpGestureContract
+    std::optional<std::string> style_tokens;         // pulpStyleTokens
+    std::optional<std::string> fallback_reason;      // pulpFallbackReason
+    std::optional<std::string> widget_schema;        // pulpWidgetSchema
+
+    // Grid templates.
+    std::optional<std::string> grid_template_columns; // pulpGridTemplateColumns
+    std::optional<std::string> grid_template_rows;    // pulpGridTemplateRows
+
+    // Numeric visuals. Stored as the *raw* attribute text so the
+    // binding-manifest emission (which writes the raw string) stays
+    // byte-identical; the semantics reader parses on demand via the helpers
+    // below, matching the original attr_float() behavior exactly.
+    std::optional<std::string> thumb_width;          // pulpThumbWidth
+    std::optional<std::string> thumb_height;         // pulpThumbHeight
+    std::optional<std::string> thumb_corner_radius;  // pulpThumbCornerRadius
+    std::optional<std::string> corner_radius;        // pulpCornerRadius
+    std::optional<std::string> font_size;            // pulpFontSize
+
+    // Toggle visuals (free strings — colors are raw attribute text).
+    std::optional<std::string> thumb_shape;          // pulpThumbShape (raw, un-normalized)
+    std::optional<std::string> on_background_color;  // pulpOnBackgroundColor
+    std::optional<std::string> off_background_color; // pulpOffBackgroundColor
+    std::optional<std::string> on_text_color;        // pulpOnTextColor
+    std::optional<std::string> off_text_color;       // pulpOffTextColor
+    std::optional<std::string> on_border_color;      // pulpOnBorderColor
+    std::optional<std::string> off_border_color;     // pulpOffBorderColor
+
+    // Boolean flags, stored as the raw attribute text so presence and exact
+    // spelling round-trip. show_internal_label() and hit_testable() apply the
+    // reader's original semantics (default true; only an explicit "false"
+    // disables show_internal_label; hit_testable uses the general bool parse).
+    std::optional<std::string> show_internal_label;  // pulpShowInternalLabel
+    std::optional<std::string> hit_testable;         // pulpHitTestable
+
+    // Parsed-float accessors — match attr_float(): strtof with trailing
+    // whitespace tolerance, std::nullopt on non-numeric / empty.
+    std::optional<float> thumb_width_value() const;
+    std::optional<float> thumb_height_value() const;
+    std::optional<float> thumb_corner_radius_value() const;
+    std::optional<float> corner_radius_value() const;
+    std::optional<float> font_size_value() const;
+
+    // show_internal_label is disabled iff the raw attribute equals "false"
+    // (case-insensitive); default true otherwise.
+    bool show_internal_label_value() const;
+
+    // Read the `pulp*` contract attributes off `node` into a typed model.
+    static NativeBindingMetadata parse(const IRNode& node);
+
+    // Write this model back onto `node.attributes` using the writer's
+    // no-overwrite / skip-empty semantics (set_contract_attr): a key is only
+    // written when the value is present and non-empty AND the node does not
+    // already carry a non-empty value for that key.
+    void serialize(IRNode& node) const;
+};
+
+}  // namespace pulp::view

--- a/core/view/src/design_cpp_codegen.cpp
+++ b/core/view/src/design_cpp_codegen.cpp
@@ -8,6 +8,7 @@
 #include <pulp/view/widgets/svg_line.hpp>
 #include <pulp/view/widgets/svg_rect.hpp>
 
+#include "design_binding_metadata.hpp"
 #include "design_import_native_common.hpp"
 
 #include <algorithm>
@@ -1265,13 +1266,14 @@ void collect_binding_manifest_entries(std::ostringstream& out,
                                       const ResolvedNativeNode& resolved,
                                       std::string_view ir_path,
                                       bool& first_entry) {
+    const auto md = NativeBindingMetadata::parse(node);
     if (has_binding_manifest_metadata(node)) {
         if (!first_entry)
             out << ",";
         out << "\n    {";
         bool first_field = true;
-        if (auto route_id = attr(node, "pulpRouteId"); route_id && !route_id->empty()) {
-            append_json_field(out, first_field, "id", *route_id);
+        if (md.route_id && !md.route_id->empty()) {
+            append_json_field(out, first_field, "id", *md.route_id);
         } else if (node.stable_anchor_id && !node.stable_anchor_id->empty()) {
             append_json_field(out, first_field, "id", *node.stable_anchor_id);
         } else if (!node.name.empty()) {
@@ -1281,50 +1283,50 @@ void collect_binding_manifest_entries(std::ostringstream& out,
         if (node.stable_anchor_id && !node.stable_anchor_id->empty())
             append_json_field(out, first_field, "anchor_id", *node.stable_anchor_id);
         append_json_field(out, first_field, "native_primitive", native_widget_kind_name(resolved.kind));
-        append_json_field_if_present(out, first_field, "route_type", attr(node, "pulpRouteType"));
-        append_json_field_if_present(out, first_field, "source_family", attr(node, "pulpSourceFamily"));
-        append_json_field_if_present(out, first_field, "source_path", attr(node, "pulpSourcePath"));
-        append_json_field_if_present(out, first_field, "param_key", attr(node, "pulpParamKey"));
-        append_json_field_if_present(out, first_field, "binding_module", attr(node, "pulpBindingModule"));
-        append_json_field_if_present(out, first_field, "binding_param", attr(node, "pulpBindingParam"));
-        append_json_field_if_present(out, first_field, "choice_value", attr(node, "pulpChoiceValue"));
-        append_json_field_if_present(out, first_field, "choice_label", attr(node, "pulpChoiceLabel"));
-        append_json_field_if_present(out, first_field, "x_param_key", attr(node, "pulpParamKeyX"));
-        append_json_field_if_present(out, first_field, "y_param_key", attr(node, "pulpParamKeyY"));
-        append_json_field_if_present(out, first_field, "x_binding_module", attr(node, "pulpBindingModuleX"));
-        append_json_field_if_present(out, first_field, "x_binding_param", attr(node, "pulpBindingParamX"));
-        append_json_field_if_present(out, first_field, "y_binding_module", attr(node, "pulpBindingModuleY"));
-        append_json_field_if_present(out, first_field, "y_binding_param", attr(node, "pulpBindingParamY"));
-        append_json_field_if_present(out, first_field, "meter_source", attr(node, "pulpMeterSource"));
-        append_json_field_if_present(out, first_field, "meter_channel", attr(node, "pulpMeterChannel"));
-        append_json_field_if_present(out, first_field, "meter_value_key", attr(node, "pulpMeterValueKey"));
-        append_json_field_if_present(out, first_field, "waveform_shape", attr(node, "pulpWaveformShape"));
-        append_json_field_if_present(out, first_field, "value_key", attr(node, "pulpValueKey"));
-        append_json_field_if_present(out, first_field, "initial_value", attr(node, "pulpInitialValue"));
-        append_json_field_if_present(out, first_field, "placeholder", attr(node, "pulpPlaceholder"));
-        append_json_field_if_present(out, first_field, "focus_contract", attr(node, "pulpFocusContract"));
-        append_json_field_if_present(out, first_field, "payload_contract", attr(node, "pulpPayloadContract"));
-        append_json_field_if_present(out, first_field, "host_action_label", attr(node, "pulpHostActionLabel"));
-        append_json_field_if_present(out, first_field, "component_type_label", attr(node, "pulpTypeLabel"));
-        append_json_field_if_present(out, first_field, "description", attr(node, "pulpDescription"));
-        append_json_field_if_present(out, first_field, "thumb_shape", attr(node, "pulpThumbShape"));
-        append_json_field_if_present(out, first_field, "thumb_width", attr(node, "pulpThumbWidth"));
-        append_json_field_if_present(out, first_field, "thumb_height", attr(node, "pulpThumbHeight"));
-        append_json_field_if_present(out, first_field, "thumb_corner_radius", attr(node, "pulpThumbCornerRadius"));
-        append_json_field_if_present(out, first_field, "on_background_color", attr(node, "pulpOnBackgroundColor"));
-        append_json_field_if_present(out, first_field, "off_background_color", attr(node, "pulpOffBackgroundColor"));
-        append_json_field_if_present(out, first_field, "on_text_color", attr(node, "pulpOnTextColor"));
-        append_json_field_if_present(out, first_field, "off_text_color", attr(node, "pulpOffTextColor"));
-        append_json_field_if_present(out, first_field, "on_border_color", attr(node, "pulpOnBorderColor"));
-        append_json_field_if_present(out, first_field, "off_border_color", attr(node, "pulpOffBorderColor"));
-        append_json_field_if_present(out, first_field, "corner_radius", attr(node, "pulpCornerRadius"));
-        append_json_field_if_present(out, first_field, "font_size", attr(node, "pulpFontSize"));
-        append_json_field_if_present(out, first_field, "event_contract", attr(node, "pulpEventContract"));
-        append_json_field_if_present(out, first_field, "gesture_contract", attr(node, "pulpGestureContract"));
-        append_json_field_if_present(out, first_field, "host_action", attr(node, "pulpHostAction"));
-        append_json_field_if_present(out, first_field, "style_tokens", attr(node, "pulpStyleTokens"));
-        append_json_field_if_present(out, first_field, "default_value_source", attr(node, "pulpDefaultValueSource"));
-        append_json_field_if_present(out, first_field, "fallback_reason", attr(node, "pulpFallbackReason"));
+        append_json_field_if_present(out, first_field, "route_type", md.route_type);
+        append_json_field_if_present(out, first_field, "source_family", md.source_family);
+        append_json_field_if_present(out, first_field, "source_path", md.source_path);
+        append_json_field_if_present(out, first_field, "param_key", md.param_key);
+        append_json_field_if_present(out, first_field, "binding_module", md.binding_module);
+        append_json_field_if_present(out, first_field, "binding_param", md.binding_param);
+        append_json_field_if_present(out, first_field, "choice_value", md.choice_value);
+        append_json_field_if_present(out, first_field, "choice_label", md.choice_label);
+        append_json_field_if_present(out, first_field, "x_param_key", md.x_param_key);
+        append_json_field_if_present(out, first_field, "y_param_key", md.y_param_key);
+        append_json_field_if_present(out, first_field, "x_binding_module", md.x_binding_module);
+        append_json_field_if_present(out, first_field, "x_binding_param", md.x_binding_param);
+        append_json_field_if_present(out, first_field, "y_binding_module", md.y_binding_module);
+        append_json_field_if_present(out, first_field, "y_binding_param", md.y_binding_param);
+        append_json_field_if_present(out, first_field, "meter_source", md.meter_source);
+        append_json_field_if_present(out, first_field, "meter_channel", md.meter_channel);
+        append_json_field_if_present(out, first_field, "meter_value_key", md.meter_value_key);
+        append_json_field_if_present(out, first_field, "waveform_shape", md.waveform_shape);
+        append_json_field_if_present(out, first_field, "value_key", md.value_key);
+        append_json_field_if_present(out, first_field, "initial_value", md.initial_value);
+        append_json_field_if_present(out, first_field, "placeholder", md.placeholder);
+        append_json_field_if_present(out, first_field, "focus_contract", md.focus_contract);
+        append_json_field_if_present(out, first_field, "payload_contract", md.payload_contract);
+        append_json_field_if_present(out, first_field, "host_action_label", md.host_action_label);
+        append_json_field_if_present(out, first_field, "component_type_label", md.type_label);
+        append_json_field_if_present(out, first_field, "description", md.description);
+        append_json_field_if_present(out, first_field, "thumb_shape", md.thumb_shape);
+        append_json_field_if_present(out, first_field, "thumb_width", md.thumb_width);
+        append_json_field_if_present(out, first_field, "thumb_height", md.thumb_height);
+        append_json_field_if_present(out, first_field, "thumb_corner_radius", md.thumb_corner_radius);
+        append_json_field_if_present(out, first_field, "on_background_color", md.on_background_color);
+        append_json_field_if_present(out, first_field, "off_background_color", md.off_background_color);
+        append_json_field_if_present(out, first_field, "on_text_color", md.on_text_color);
+        append_json_field_if_present(out, first_field, "off_text_color", md.off_text_color);
+        append_json_field_if_present(out, first_field, "on_border_color", md.on_border_color);
+        append_json_field_if_present(out, first_field, "off_border_color", md.off_border_color);
+        append_json_field_if_present(out, first_field, "corner_radius", md.corner_radius);
+        append_json_field_if_present(out, first_field, "font_size", md.font_size);
+        append_json_field_if_present(out, first_field, "event_contract", md.event_contract);
+        append_json_field_if_present(out, first_field, "gesture_contract", md.gesture_contract);
+        append_json_field_if_present(out, first_field, "host_action", md.host_action);
+        append_json_field_if_present(out, first_field, "style_tokens", md.style_tokens);
+        append_json_field_if_present(out, first_field, "default_value_source", md.default_value_source);
+        append_json_field_if_present(out, first_field, "fallback_reason", md.fallback_reason);
         out << "\n    }";
         first_entry = false;
     }
@@ -1383,16 +1385,17 @@ struct BindingHelperRoute {
 void collect_binding_helper_routes(std::vector<BindingHelperRoute>& routes,
                                    const IRNode& node,
                                    const ResolvedNativeNode& resolved) {
-    auto route_id = attr(node, "pulpRouteId");
-    auto param_key = attr(node, "pulpParamKey");
-    auto x_param_key = attr(node, "pulpParamKeyX");
-    auto y_param_key = attr(node, "pulpParamKeyY");
-    auto meter_source = attr(node, "pulpMeterSource");
-    auto meter_channel = attr(node, "pulpMeterChannel");
-    auto choice_value = attr(node, "pulpChoiceValue");
-    auto waveform_shape = attr(node, "pulpWaveformShape");
-    auto value_key = attr(node, "pulpValueKey");
-    auto host_action = attr(node, "pulpHostAction");
+    const auto md = NativeBindingMetadata::parse(node);
+    const auto& route_id = md.route_id;
+    const auto& param_key = md.param_key;
+    const auto& x_param_key = md.x_param_key;
+    const auto& y_param_key = md.y_param_key;
+    const auto& meter_source = md.meter_source;
+    const auto& meter_channel = md.meter_channel;
+    const auto& choice_value = md.choice_value;
+    const auto& waveform_shape = md.waveform_shape;
+    const auto& value_key = md.value_key;
+    const auto& host_action = md.host_action;
     const bool has_single_param = param_key && !param_key->empty();
     const bool has_scalar_param_control =
         (resolved.kind == NativeWidgetKind::knob ||
@@ -1422,29 +1425,29 @@ void collect_binding_helper_routes(std::vector<BindingHelperRoute>& routes,
             .anchor_id = *node.stable_anchor_id,
             .route_id = *route_id,
             .param_key = param_key.value_or(std::string{}),
-            .binding_module = attr(node, "pulpBindingModule").value_or(std::string{}),
-            .binding_param = attr(node, "pulpBindingParam").value_or(std::string{}),
+            .binding_module = md.binding_module.value_or(std::string{}),
+            .binding_param = md.binding_param.value_or(std::string{}),
             .choice_value = choice_value.value_or(std::string{}),
-            .choice_label = attr(node, "pulpChoiceLabel").value_or(std::string{}),
+            .choice_label = md.choice_label.value_or(std::string{}),
             .x_param_key = x_param_key.value_or(std::string{}),
             .y_param_key = y_param_key.value_or(std::string{}),
-            .x_binding_module = attr(node, "pulpBindingModuleX").value_or(std::string{}),
-            .x_binding_param = attr(node, "pulpBindingParamX").value_or(std::string{}),
-            .y_binding_module = attr(node, "pulpBindingModuleY").value_or(std::string{}),
-            .y_binding_param = attr(node, "pulpBindingParamY").value_or(std::string{}),
+            .x_binding_module = md.x_binding_module.value_or(std::string{}),
+            .x_binding_param = md.x_binding_param.value_or(std::string{}),
+            .y_binding_module = md.y_binding_module.value_or(std::string{}),
+            .y_binding_param = md.y_binding_param.value_or(std::string{}),
             .meter_source = meter_source.value_or(std::string{}),
             .meter_channel = meter_channel.value_or(std::string{}),
-            .meter_value_key = attr(node, "pulpMeterValueKey").value_or(std::string{}),
+            .meter_value_key = md.meter_value_key.value_or(std::string{}),
             .waveform_shape = waveform_shape.value_or(std::string{}),
             .value_key = value_key.value_or(std::string{}),
-            .initial_value = attr(node, "pulpInitialValue").value_or(std::string{}),
-            .placeholder = attr(node, "pulpPlaceholder").value_or(std::string{}),
-            .focus_contract = attr(node, "pulpFocusContract").value_or(std::string{}),
+            .initial_value = md.initial_value.value_or(std::string{}),
+            .placeholder = md.placeholder.value_or(std::string{}),
+            .focus_contract = md.focus_contract.value_or(std::string{}),
             .host_action = host_action.value_or(std::string{}),
-            .host_action_label = attr(node, "pulpHostActionLabel").value_or(std::string{}),
-            .payload_contract = attr(node, "pulpPayloadContract").value_or(std::string{}),
-            .event_contract = attr(node, "pulpEventContract").value_or(std::string{}),
-            .gesture_contract = attr(node, "pulpGestureContract").value_or(std::string{}),
+            .host_action_label = md.host_action_label.value_or(std::string{}),
+            .payload_contract = md.payload_contract.value_or(std::string{}),
+            .event_contract = md.event_contract.value_or(std::string{}),
+            .gesture_contract = md.gesture_contract.value_or(std::string{}),
         });
     }
 

--- a/core/view/src/design_import_native_common.cpp
+++ b/core/view/src/design_import_native_common.cpp
@@ -1,5 +1,7 @@
 #include "design_import_native_common.hpp"
 
+#include "design_binding_metadata.hpp"
+
 #include <pulp/view/buttons.hpp>
 #include <pulp/view/canvas_widget.hpp>
 #include <pulp/view/svg_path_widget.hpp>
@@ -984,23 +986,28 @@ ImportedWidgetSemantics imported_widget_semantics(const IRNode& node,
     ImportedWidgetSemantics out;
     out.text = resolved.text.value_or(node.text_content);
 
-    auto non_empty_attr = [&](std::string_view key) -> std::optional<std::string> {
-        auto value = attr(node, key);
+    // Single typed parse of the pulp* binding contract; all pulp* reads below
+    // go through this model. Non-pulp* attributes (checked/value/orientation/
+    // x/y/jsxTag/...) stay on the raw attr() helpers.
+    const auto md = NativeBindingMetadata::parse(node);
+
+    auto non_empty = [](const std::optional<std::string>& value)
+        -> std::optional<std::string> {
         if (value && !value->empty()) return value;
         return std::nullopt;
     };
 
-    out.text_placeholder = non_empty_attr("pulpPlaceholder");
-    if (auto value = non_empty_attr("pulpInitialValue"))
+    out.text_placeholder = non_empty(md.placeholder);
+    if (auto value = non_empty(md.initial_value))
         out.text_value = value;
-    else if (auto value = non_empty_attr("value"))
+    else if (auto value = attr(node, "value"); value && !value->empty())
         out.text_value = value;
     else if (!out.text.empty()) {
         // Only treat display text as the editor's value for a <textarea>, whose
         // element body IS the value. For other controls the node's text_content
         // is typically an adjacent label/heading, not editable contents —
         // injecting it would prefill the editor with a label.
-        const auto family = attr(node, "pulpSourceFamily");
+        const auto& family = md.source_family;
         const auto tag = attr(node, "jsxTag");
         const bool is_textarea =
             (family && lower_copy(*family) == "textarea") ||
@@ -1011,14 +1018,14 @@ ImportedWidgetSemantics imported_widget_semantics(const IRNode& node,
 
     out.checked = attr_bool(node, "checked");
     out.toggle_on = out.checked || attr_bool(node, "value");
-    out.toggle_on_background_color = non_empty_attr("pulpOnBackgroundColor");
-    out.toggle_off_background_color = non_empty_attr("pulpOffBackgroundColor");
-    out.toggle_on_text_color = non_empty_attr("pulpOnTextColor");
-    out.toggle_off_text_color = non_empty_attr("pulpOffTextColor");
-    out.toggle_on_border_color = non_empty_attr("pulpOnBorderColor");
-    out.toggle_off_border_color = non_empty_attr("pulpOffBorderColor");
-    out.toggle_corner_radius = attr_float(node, "pulpCornerRadius");
-    out.toggle_font_size = attr_float(node, "pulpFontSize");
+    out.toggle_on_background_color = non_empty(md.on_background_color);
+    out.toggle_off_background_color = non_empty(md.off_background_color);
+    out.toggle_on_text_color = non_empty(md.on_text_color);
+    out.toggle_off_text_color = non_empty(md.off_text_color);
+    out.toggle_on_border_color = non_empty(md.on_border_color);
+    out.toggle_off_border_color = non_empty(md.off_border_color);
+    out.toggle_corner_radius = md.corner_radius_value();
+    out.toggle_font_size = md.font_size_value();
 
     out.normalized_value = normalized_audio_value(node);
     out.normalized_default = normalized_audio_default(node);
@@ -1040,28 +1047,25 @@ ImportedWidgetSemantics imported_widget_semantics(const IRNode& node,
         }
     }
 
-    out.widget_schema = non_empty_attr("pulpWidgetSchema");
-    if (auto show_label = attr(node, "pulpShowInternalLabel");
-        show_label && lower_copy(*show_label) == "false") {
-        out.show_internal_label = false;
-    }
+    out.widget_schema = non_empty(md.widget_schema);
+    out.show_internal_label = md.show_internal_label_value();
 
-    if (auto shape = attr(node, "pulpThumbShape")) {
-        const auto lower = lower_copy(*shape);
+    if (md.thumb_shape) {
+        const auto lower = lower_copy(*md.thumb_shape);
         if (lower == "rectangle" || lower == "rect" || lower == "rounded_rect")
             out.fader_thumb_shape = ImportedFaderThumbShape::rectangle;
         else if (lower == "circle" || lower == "round" || lower == "dot")
             out.fader_thumb_shape = ImportedFaderThumbShape::circle;
     }
-    out.fader_thumb_width = attr_float(node, "pulpThumbWidth");
-    out.fader_thumb_height = attr_float(node, "pulpThumbHeight");
-    out.fader_thumb_corner_radius = attr_float(node, "pulpThumbCornerRadius");
+    out.fader_thumb_width = md.thumb_width_value();
+    out.fader_thumb_height = md.thumb_height_value();
+    out.fader_thumb_corner_radius = md.thumb_corner_radius_value();
 
     out.x_value = attr_float(node, "x").value_or(0.5f);
     out.y_value = attr_float(node, "y").value_or(0.5f);
-    out.x_label = non_empty_attr("xLabel");
-    out.y_label = non_empty_attr("yLabel");
-    out.waveform_shape = non_empty_attr("pulpWaveformShape");
+    out.x_label = non_empty(attr(node, "xLabel"));
+    out.y_label = non_empty(attr(node, "yLabel"));
+    out.waveform_shape = non_empty(md.waveform_shape);
 
     return out;
 }


### PR DESCRIPTION
Replace the stringly-typed pulp* IRNode.attributes binding contract with a
single typed model. NativeBindingMetadata::parse() reads the ~45 pulp* keys
once into typed optional fields; serialize() writes them back with the
writer's set_contract_attr (skip-empty / no-overwrite) semantics. Numeric
thumb/corner/font fields keep the raw attribute text so the binding-manifest
JSON stays byte-identical and parse on demand via *_value() accessors that
mirror the original attr_float() behavior; show_internal_label keeps its
false-only opt-out semantics via show_internal_label_value().

Consumers unified onto the typed read path:
- design_import_native_common.cpp (imported_widget_semantics): all pulp*
  reads now go through one NativeBindingMetadata::parse(); non-pulp attrs
  (checked/value/orientation/x/y/jsxTag) stay on the raw attr() helpers.
- design_cpp_codegen.cpp (collect_binding_manifest_entries and
  collect_binding_helper_routes): parse once at the top of each pass; the
  manifest JSON field names/order/presence are unchanged
  (append_json_field_if_present still includes a field iff present AND
  non-empty).

The v0/TSX writer (design_import_v0_tsx.cpp) is intentionally left on its
existing set_contract_attr path: its writes are interleaved with
style.width/height side effects and on_change-conditional branching, so a
serialize() rewrite there carried byte-parity risk with no test benefit. The
shared serialize() uses identical semantics and is available for a future
writer pass.

Byte-identical behavior: emitted pulp* attribute strings AND generated
binding-manifest JSON are unchanged. Parity oracle — all 18 design-import
test binaries pass, including pulp-test-design-import (608 assertions, pulp*
attr asserts) and pulp-test-design-import-cpp-codegen (15175 assertions,
manifest JSON).

Skill-Update: skip skill=import-design reason="typed wrapper over existing pulp* attribute contract; emitted attrs and manifest JSON byte-identical"
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>