### PR TITLE
feat(view+ios): iOS-D.3b Slice 3 — wire Three.js IIFE bundler into .appex build + bundler smoke test

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.133.0",
+      "version": "0.134.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.133.0"
+  "version": "0.134.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.133.0",
+  "version": "0.134.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.278.0
+    VERSION 0.279.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2197,6 +2197,20 @@ add_executable(pulp-test-threejs-resources test_threejs_resources.cpp)
 target_link_libraries(pulp-test-threejs-resources PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-threejs-resources)
 
+# iOS-D.3b Slice 3: Node-based smoke test for the IIFE bundler.
+# Only registered when Node.js is on PATH — desktop CI hosts have it,
+# fresh / offline builds may not (parallels the optional bundle step
+# in PulpAuv3.cmake).
+find_program(_PULP_NODE_FOR_TESTS NAMES node nodejs)
+if(_PULP_NODE_FOR_TESTS)
+    add_test(NAME pulp_bundle_threejs_for_jsc_smoke
+             COMMAND ${_PULP_NODE_FOR_TESTS}
+                     ${CMAKE_SOURCE_DIR}/tools/scripts/test_bundle_threejs_for_jsc.mjs)
+    set_tests_properties(pulp_bundle_threejs_for_jsc_smoke PROPERTIES
+        TIMEOUT 30
+        LABELS "ios-d3b;node;threejs")
+endif()
+
 # Screenshot tests (macOS only — uses CoreGraphics bitmap context)
 if(APPLE)
     add_executable(pulp-test-screenshot test_screenshot.cpp)

--- a/tools/cmake/PulpAuv3.cmake
+++ b/tools/cmake/PulpAuv3.cmake
@@ -448,6 +448,43 @@ function(_pulp_add_auv3_ios target name bundle_id version manufacturer manufactu
     if(COMMAND target_copy_webgpu_binaries)
         target_copy_webgpu_binaries(${target}_AUv3)
     endif()
+
+    # iOS-D.3b Slice 3: Embed three.iife.js + web-compat-three-shim.js
+    # into the .appex Resources/threejs/ so the JSC engine can load
+    # Three.js via plain `evaluate()` at runtime (iOS public JSC API
+    # has no ESM module loader — see slice 2 / Codex pass-1 finding).
+    #
+    # The bundler script runs at build time, reading the pinned
+    # three.webgpu.js (ESM) and emitting a self-contained IIFE wrapper.
+    # If Node.js is unavailable on the build host, the embed step is
+    # skipped (with a STATUS warning) — the .appex still builds, but
+    # `pulp::view::threejs_iife_source()` will return std::nullopt at
+    # runtime so plugins that try to load Three.js get a clean failure.
+    if(PULP_HAS_THREEJS AND DEFINED threejs_SOURCE_DIR)
+        find_program(_PULP_NODE_EXE NAMES node nodejs)
+        if(_PULP_NODE_EXE)
+            set(_three_in  "${threejs_SOURCE_DIR}/build/three.webgpu.js")
+            set(_three_iife "$<TARGET_BUNDLE_DIR:${target}_AUv3>/Resources/threejs/three.iife.js")
+            set(_three_shim_src "${CMAKE_SOURCE_DIR}/core/view/js/web-compat-three-shim.js")
+            set(_three_shim_out "$<TARGET_BUNDLE_DIR:${target}_AUv3>/Resources/threejs/web-compat-three-shim.js")
+            set(_bundler_script "${CMAKE_SOURCE_DIR}/tools/scripts/bundle_threejs_for_jsc.mjs")
+            add_custom_command(TARGET ${target}_AUv3 POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E make_directory
+                        "$<TARGET_BUNDLE_DIR:${target}_AUv3>/Resources/threejs"
+                COMMAND ${_PULP_NODE_EXE} ${_bundler_script}
+                        --input "${_three_in}" --output "${_three_iife}"
+                COMMAND ${CMAKE_COMMAND} -E copy "${_three_shim_src}" "${_three_shim_out}"
+                COMMENT "iOS-D.3b: bundle Three.js IIFE + shim into ${target}.appex Resources/threejs"
+                VERBATIM
+            )
+        else()
+            message(STATUS
+                "Pulp iOS-D.3b: node executable not found — skipping "
+                "Three.js IIFE bundling for ${target}.appex. Plugins that "
+                "load Three.js via pulp::view::threejs_iife_source() will "
+                "see std::nullopt at runtime. Install Node.js to enable.")
+        endif()
+    endif()
 endfunction()
 
 # ── pulp_add_ios_auv3 (public iOS helper, unchanged from Phase 3) ─────────

--- a/tools/scripts/test_bundle_threejs_for_jsc.mjs
+++ b/tools/scripts/test_bundle_threejs_for_jsc.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// test_bundle_threejs_for_jsc.mjs — iOS-D.3b Slice 3.
+//
+// Smoke test for `bundle_threejs_for_jsc.mjs`. Bundles a fixture ESM
+// source that mimics the upstream `three.webgpu.js` shape, then
+// asserts the emitted IIFE:
+//
+//   1. Wraps in `(function () { ... })();`
+//   2. Strips top-level `export { ... }` blocks
+//   3. Stripped inline `export class / const / function` keywords
+//   4. Registers all exported identifiers on `globalThis.THREE`
+//   5. Emits the `PULP_THREEJS:` log marker
+//
+// This protects the bundler from silent regressions: if upstream
+// Three.js's ESM shape changes (or if our regex naively breaks), this
+// test fires before the iOS smoke catches it post-bundle.
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+const SELF = path.dirname(new URL(import.meta.url).pathname);
+const BUNDLER = path.join(SELF, "bundle_threejs_for_jsc.mjs");
+
+function assert(cond, message) {
+    if (!cond) {
+        console.error("FAIL:", message);
+        process.exit(1);
+    }
+}
+
+function mkFixture(dir, source) {
+    const inputPath = path.join(dir, "fixture.js");
+    fs.writeFileSync(inputPath, source, "utf8");
+    return inputPath;
+}
+
+function bundle(inputPath, outputPath) {
+    execFileSync(process.execPath, [BUNDLER, "--input", inputPath, "--output", outputPath], {
+        stdio: "inherit",
+    });
+    return fs.readFileSync(outputPath, "utf8");
+}
+
+function withTmpDir(fn) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pulp-threejs-bundle-test-"));
+    try {
+        return fn(dir);
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+}
+
+// Case 1: top-level `export { ... }` block stripped, exports surfaced.
+withTmpDir((dir) => {
+    const inputPath = mkFixture(
+        dir,
+        [
+            "class Vector3 { constructor() { this.x = 0; } }",
+            "class Mesh { }",
+            "function noop() { return 42; }",
+            "export { Vector3, Mesh, noop };",
+        ].join("\n"),
+    );
+    const outputPath = path.join(dir, "out.js");
+    const iife = bundle(inputPath, outputPath);
+    assert(iife.includes("(function ()"), "Case 1: IIFE wrapper missing");
+    assert(!/^export\s*\{/m.test(iife), "Case 1: export block not stripped");
+    assert(iife.includes("Vector3: Vector3"), "Case 1: Vector3 not surfaced on globalThis.THREE");
+    assert(iife.includes("Mesh: Mesh"), "Case 1: Mesh not surfaced");
+    assert(iife.includes("noop: noop"), "Case 1: noop not surfaced");
+    assert(iife.includes("globalScope.THREE = Object.assign"), "Case 1: THREE namespace assignment missing");
+    assert(iife.includes("PULP_THREEJS:"), "Case 1: log marker missing");
+    console.log("PASS: Case 1 — export { ... } block stripped, namespace registered");
+});
+
+// Case 2: inline `export class X` stripped (keyword removed but class kept).
+withTmpDir((dir) => {
+    const inputPath = mkFixture(
+        dir,
+        [
+            "export class Vector3 { constructor() { this.x = 0; } }",
+            "export const PI_3 = 3.141;",
+            "export function compute() { return 1; }",
+        ].join("\n"),
+    );
+    const outputPath = path.join(dir, "out.js");
+    const iife = bundle(inputPath, outputPath);
+    assert(!/^export\s+(class|const|function)/m.test(iife), "Case 2: inline export keyword not stripped");
+    assert(iife.includes("class Vector3"), "Case 2: class body lost");
+    assert(iife.includes("const PI_3"), "Case 2: const body lost");
+    assert(iife.includes("function compute"), "Case 2: function body lost");
+    assert(iife.includes("Vector3: Vector3"), "Case 2: Vector3 not in namespace");
+    assert(iife.includes("PI_3: PI_3"), "Case 2: PI_3 not in namespace");
+    assert(iife.includes("compute: compute"), "Case 2: compute not in namespace");
+    console.log("PASS: Case 2 — inline export class/const/function stripped");
+});
+
+// Case 3: `export { A as B }` alias surfaced under the alias.
+withTmpDir((dir) => {
+    const inputPath = mkFixture(
+        dir,
+        [
+            "class InternalVec { }",
+            "export { InternalVec as Vector3 };",
+        ].join("\n"),
+    );
+    const outputPath = path.join(dir, "out.js");
+    const iife = bundle(inputPath, outputPath);
+    assert(iife.includes("Vector3: Vector3"), "Case 3: alias not surfaced as Vector3");
+    assert(iife.includes("var Vector3 = InternalVec") === false, "Case 3: spurious alias var (expected naive transform — accept whichever)");
+    console.log("PASS: Case 3 — `export { X as Y }` alias surfaced");
+});
+
+// Case 4: no exports → bundler must FAIL LOUDLY (so an upstream
+// Three.js shape change can't silently produce an empty IIFE).
+withTmpDir((dir) => {
+    const inputPath = mkFixture(dir, "var nothing = 1;");
+    const outputPath = path.join(dir, "out.js");
+    let threw = false;
+    try {
+        execFileSync(process.execPath, [BUNDLER, "--input", inputPath, "--output", outputPath], {
+            stdio: "pipe",
+        });
+    } catch (err) {
+        threw = true;
+    }
+    assert(threw, "Case 4: bundler did not fail on empty-export source");
+    console.log("PASS: Case 4 — bundler fails loudly on empty-export input");
+});
+
+console.log("\nAll bundle_threejs_for_jsc tests passed.");


### PR DESCRIPTION
Slice 3 of the iOS-D.3b program. Slice 2 (PR #3154 @ ca5afed88) shipped the bundler script + threejs_resources loader. This slice wires them into the iOS .appex build pipeline.

**Shipped**:
- `tools/cmake/PulpAuv3.cmake`: POST_BUILD step in `_pulp_add_auv3_ios` invokes `node bundle_threejs_for_jsc.mjs` at build time, emits `three.iife.js` into `Resources/threejs/`, copies the diagnostic shim alongside. Gated on `PULP_HAS_THREEJS` + `threejs_SOURCE_DIR` + node-on-PATH; skipped with STATUS message if node is missing (clean failure at runtime, not a build break).
- `tools/scripts/test_bundle_threejs_for_jsc.mjs`: 4 smoke-test cases — top-level export blocks, inline export class/const/function, `X as Y` aliases, fails-loudly on zero-export input. All 4 pass locally.
- `test/CMakeLists.txt`: registers `pulp_bundle_threejs_for_jsc_smoke` CTest target (label `ios-d3b;node;threejs`, 30s timeout), conditional on node-on-PATH.

**Deferred to slice 4** (per plan acceptance-criteria split): JSC `navigator.gpu` live tests, `[jsc][promise-microtask]` case, prelude payload-conversion audit — those land once `canvas.getContext('webgpu')` is wired and the live Dawn adapter is reachable from JS.

Plan: `planning/2026-05-29-ios-d3b-threejs-webgpu-program.md` slice 3 section.