### PR TITLE
feat(view): iOS-D.3b Slice 4 — surface presentable flag through canvas.getContext('webgpu') paths

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.134.0",
+      "version": "0.135.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.134.0"
+  "version": "0.135.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.134.0",
+  "version": "0.135.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.279.0
+    VERSION 0.280.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -22,6 +22,7 @@
 #include <pulp/platform/file_dialog.hpp>
 #include <pulp/platform/clipboard.hpp>
 #include <pulp/runtime/base64.hpp>
+#include <pulp/runtime/log.hpp>
 #include <web_compat_preludes_gen.hpp>
 #include <thread>
 #include <chrono>
@@ -8284,9 +8285,18 @@ void WidgetBridge::register_api() {
         auto usage = static_cast<uint32_t>(args.get<int32_t>(4, 0));
         auto alpha_mode = args.get<std::string>(5, "opaque");
 
+        // iOS-D.3b Slice 4: surface the GpuSurface's presentable/offscreen
+        // distinction to JS. Until slice 5 wires per-frame
+        // current_texture_handle() acquisition into getCurrentTexture(),
+        // configure() returning `presentable: true` is the program's
+        // contract that JS draws WILL hit the visible swapchain rather
+        // than a silent offscreen texture (Codex pass-1 finding #3).
+        const bool presentable = (gpu_surface_ != nullptr) && gpu_surface_->has_surface();
+
         auto result = choc::value::createObject("");
         result.addMember("nativeBridge", choc::value::createBool(false));
         result.addMember("configured", choc::value::createBool(false));
+        result.addMember("presentable", choc::value::createBool(presentable));
         result.addMember("width", choc::value::createInt32(static_cast<int32_t>(width)));
         result.addMember("height", choc::value::createInt32(static_cast<int32_t>(height)));
         result.addMember("format", choc::value::createString(format));
@@ -8329,9 +8339,23 @@ void WidgetBridge::register_api() {
         state.usage = static_cast<uint32_t>(texture_desc.usage);
         state.texture = device_ptr->CreateTexture(&texture_desc);
         state.configured = (state.texture != nullptr);
+        if (state.configured) {
+            // PULP_WEBGPU_BRIDGE log markers (slice 4 contract) — surface
+            // the presentable distinction in the runtime log so iPad
+            // device walk-throughs can grep the value without
+            // introspecting the JS-returned object. The `presentable`
+            // value comes from gpu_surface_->has_surface() above.
+            runtime::log_info(
+                "PULP_WEBGPU_BRIDGE: canvas.getContext('webgpu') ok (presentable={}, canvas={})",
+                presentable ? "true" : "false", canvas_id);
+            runtime::log_info(
+                "PULP_WEBGPU_BRIDGE: context.configure ok (format={}, size={}x{})",
+                format, width, height);
+        }
         auto native_result = choc::value::createObject("");
         native_result.addMember("nativeBridge", choc::value::createBool(state.configured));
         native_result.addMember("configured", choc::value::createBool(state.configured));
+        native_result.addMember("presentable", choc::value::createBool(presentable));
         native_result.addMember("width", choc::value::createInt32(static_cast<int32_t>(width)));
         native_result.addMember("height", choc::value::createInt32(static_cast<int32_t>(height)));
         native_result.addMember("format", choc::value::createString(format));
@@ -8342,9 +8366,17 @@ void WidgetBridge::register_api() {
     });
 
     engine_.register_function("__gpuCanvasDescribeCurrentTextureImpl", [this](choc::javascript::ArgumentList args) {
+        // iOS-D.3b Slice 4: surface the presentable flag here too so
+        // JS can verify per-frame that the texture it's about to draw
+        // into IS the visible swapchain (slice 5 wires
+        // gpu_surface_->current_texture_handle() through this path;
+        // slice 4 just plumbs the boolean).
+        const bool presentable = (gpu_surface_ != nullptr) && gpu_surface_->has_surface();
+
         auto descriptor = choc::value::createObject("");
         auto canvas_id = args.get<std::string>(0, "");
         descriptor.addMember("nativeBridge", choc::value::createBool(false));
+        descriptor.addMember("presentable", choc::value::createBool(presentable));
         descriptor.addMember("width", choc::value::createInt32(1));
         descriptor.addMember("height", choc::value::createInt32(1));
         descriptor.addMember("format", choc::value::createString("bgra8unorm"));
@@ -8362,6 +8394,7 @@ void WidgetBridge::register_api() {
 
         auto native_descriptor = choc::value::createObject("");
         native_descriptor.addMember("nativeBridge", choc::value::createBool(true));
+        native_descriptor.addMember("presentable", choc::value::createBool(presentable));
         native_descriptor.addMember("width", choc::value::createInt32(static_cast<int32_t>(it->second.width)));
         native_descriptor.addMember("height", choc::value::createInt32(static_cast<int32_t>(it->second.height)));
         native_descriptor.addMember("format", choc::value::createString(it->second.format));

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -2954,6 +2954,67 @@ TEST_CASE("WidgetBridge gpu_surface late-attach is idempotent and nullable",
     REQUIRE(bridge->has_native_gpu_bridge() == false);
 }
 
+TEST_CASE("WidgetBridge __gpuCanvasConfigureImpl surfaces presentable flag",
+          "[widget_bridge][gpu-canvas][ios-d3b-slice4]") {
+    // iOS-D.3b Slice 4: the configure result must carry a `presentable`
+    // boolean that reflects gpu_surface_->has_surface(). JS uses this to
+    // confirm draws WILL hit the visible swapchain (rather than a silent
+    // offscreen texture — Codex pass-1 finding #3).
+#if PULP_TEST_HAS_GPU_SURFACE
+    pulp::view::ScriptEngine engine;
+    pulp::view::View root;
+    pulp::state::StateStore store;
+
+    // No surface attached → presentable=false.
+    auto bridge = std::make_unique<pulp::view::WidgetBridge>(engine, root, store);
+    {
+        auto result = engine.evaluate(
+            "__gpuCanvasConfigureImpl('cv-no-surface', 32, 32, 'bgra8unorm', 0, 'opaque')");
+        REQUIRE_FALSE(result["presentable"].getWithDefault<bool>(true));
+    }
+
+    // Surface attached but has_surface=false (no native_surface_handle in
+    // Config) → presentable=false. This is the macOS-demo-style offscreen
+    // configuration where the bridge still functions but no swapchain is
+    // present.
+    TestGpuSurface offscreen_surface(test_gpu_info(true));
+    pulp::render::GpuSurface::Config offscreen_cfg;
+    offscreen_cfg.width = 64;
+    offscreen_cfg.height = 64;
+    offscreen_cfg.native_surface_handle = nullptr;
+    offscreen_surface.initialize(offscreen_cfg);
+    bridge->attach_gpu_surface(&offscreen_surface);
+    {
+        auto result = engine.evaluate(
+            "__gpuCanvasConfigureImpl('cv-offscreen', 64, 64, 'bgra8unorm', 0, 'opaque')");
+        REQUIRE_FALSE(result["presentable"].getWithDefault<bool>(true));
+        // Describe path mirrors the flag.
+        auto desc = engine.evaluate("__gpuCanvasDescribeCurrentTextureImpl('cv-offscreen')");
+        REQUIRE_FALSE(desc["presentable"].getWithDefault<bool>(true));
+    }
+
+    // Surface attached AND has_surface=true → presentable=true. This is
+    // the iOS path where slice 5 will hook up per-frame
+    // current_texture_handle() acquisition.
+    TestGpuSurface presentable_surface(test_gpu_info(true));
+    pulp::render::GpuSurface::Config presentable_cfg;
+    presentable_cfg.width = 128;
+    presentable_cfg.height = 128;
+    int dummy = 0;
+    presentable_cfg.native_surface_handle = static_cast<void*>(&dummy);
+    presentable_surface.initialize(presentable_cfg);
+    bridge->attach_gpu_surface(&presentable_surface);
+    REQUIRE(presentable_surface.has_surface() == true);
+    {
+        auto result = engine.evaluate(
+            "__gpuCanvasConfigureImpl('cv-presentable', 128, 128, 'bgra8unorm', 0, 'opaque')");
+        REQUIRE(result["presentable"].getWithDefault<bool>(false) == true);
+        auto desc = engine.evaluate("__gpuCanvasDescribeCurrentTextureImpl('cv-presentable')");
+        REQUIRE(desc["presentable"].getWithDefault<bool>(false) == true);
+    }
+#endif  // PULP_TEST_HAS_GPU_SURFACE
+}
+
 TEST_CASE("WidgetBridge ctor with non-null gpu_surface stores it",
           "[widget_bridge][gpu-surface-plumbing][issue-ios-d3b-slice1]") {
 #if PULP_TEST_HAS_GPU_SURFACE


### PR DESCRIPTION
Slice 4 of the iOS-D.3b program. Slices 1+2+3 (PR #3146 + #3154 + #3156) shipped GpuSurface plumbing + Three.js IIFE bundle + bundler-into-.appex wiring. This slice surfaces the presentable/offscreen distinction through the WebGPU canvas API so JS can confirm draws WILL hit the visible swapchain.

**Shipped**:
- `__gpuCanvasConfigureImpl`: derives `presentable` from `gpu_surface_->has_surface()`, emits 2 new `PULP_WEBGPU_BRIDGE:` log markers for iPad walks
- `__gpuCanvasDescribeCurrentTextureImpl`: mirrors the `presentable` field per-frame
- New `[widget_bridge][gpu-canvas][ios-d3b-slice4]` Catch2 case pins 3 contracts: no surface, has_surface=false, has_surface=true

**Deferred to slice 5** (per plan acceptance split): per-frame `current_texture_handle()` acquisition inside `getCurrentTexture`, `[jsc][promise-microtask]` case, visible-pixel readback test. Those depend on the GPU object proxies slice 5 introduces.

Plan: `planning/2026-05-29-ios-d3b-threejs-webgpu-program.md` slice 4 section.