### PR TITLE
feat(view): iOS-D.3b Slice 5 — queue.submit log marker + engine-agnostic input contract pin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.135.0",
+      "version": "0.136.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.135.0"
+  "version": "0.136.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.135.0",
+  "version": "0.136.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.280.0
+    VERSION 0.281.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -8582,6 +8582,16 @@ void WidgetBridge::register_api() {
 
         auto command_buffer = encoder.Finish();
         queue_ptr->Submit(1, &command_buffer);
+
+        // iOS-D.3b Slice 5: surface the queue.submit success in the
+        // runtime log so iPad device walks can grep `PULP_WEBGPU_BRIDGE:
+        // queue.submit ok` without instrumenting JS. `commands=1` is
+        // accurate for this single-command-buffer code path; the buffered
+        // shim (`__gpuQueueDrawBufferedImpl` etc.) handles multi-command
+        // submissions and would emit a different count.
+        runtime::log_info(
+            "PULP_WEBGPU_BRIDGE: queue.submit ok (canvas={}, commands=1)",
+            canvas_id);
         return choc::value::createBool(true);
 #endif
     });

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -2954,6 +2954,45 @@ TEST_CASE("WidgetBridge gpu_surface late-attach is idempotent and nullable",
     REQUIRE(bridge->has_native_gpu_bridge() == false);
 }
 
+TEST_CASE("WidgetBridge __gpuQueueSubmitImpl returns boolean for all engine inputs",
+          "[widget_bridge][gpu-queue][ios-d3b-slice5]") {
+    // iOS-D.3b Slice 5: pin the engine-agnostic contract of
+    // __gpuQueueSubmitImpl — must return a JS-side boolean for every
+    // input shape, never throw / return undefined / return a type that
+    // JSC would coerce surprisingly. This is the canonical "bridge
+    // survived the call" check that the buffered-skips probe in
+    // web-compat-gpu-buffered.js relies on. The wgpu device-side
+    // success path is exercised by the live tests; this case pins the
+    // input-validation surface so a regression returning undefined
+    // (falsy-coerced) doesn't silently break the bridge.
+    pulp::view::ScriptEngine engine;
+    pulp::view::View root;
+    pulp::state::StateStore store;
+    auto bridge = std::make_unique<pulp::view::WidgetBridge>(engine, root, store);
+
+    // 1. Empty canvas_id → false (early return, no surface required).
+    {
+        auto result = engine.evaluate(
+            "(function() { var r = __gpuQueueSubmitImpl('', 0, 0, 0, 1); return typeof r === 'boolean' && r === false; })()");
+        REQUIRE(result.getWithDefault<bool>(false));
+    }
+
+    // 2. Non-empty canvas_id but no gpu_surface attached → false.
+    {
+        auto result = engine.evaluate(
+            "(function() { var r = __gpuQueueSubmitImpl('cv-no-surface', 0.5, 0.5, 0.5, 1.0); return typeof r === 'boolean' && r === false; })()");
+        REQUIRE(result.getWithDefault<bool>(false));
+    }
+
+    // 3. Bad numeric inputs (NaN) → bridge must still return boolean,
+    //    not propagate NaN through the wgpu clearValue path.
+    {
+        auto result = engine.evaluate(
+            "(function() { var r = __gpuQueueSubmitImpl('cv-nan', NaN, NaN, NaN, 1.0); return typeof r === 'boolean'; })()");
+        REQUIRE(result.getWithDefault<bool>(false));
+    }
+}
+
 TEST_CASE("WidgetBridge __gpuCanvasConfigureImpl surfaces presentable flag",
           "[widget_bridge][gpu-canvas][ios-d3b-slice4]") {
     // iOS-D.3b Slice 4: the configure result must carry a `presentable`


### PR DESCRIPTION
Slice 5 of the iOS-D.3b program. Adds the `PULP_WEBGPU_BRIDGE: queue.submit ok` runtime log marker + pins the engine-agnostic input contract of `__gpuQueueSubmitImpl` (3 input-validation cases: empty canvas_id, missing surface, NaN clearValue).

**Deferred to slice 6** (per plan split): per-frame `current_texture_handle()` acquisition inside `getCurrentTexture`, threejs-native-demo JSC variant test, visible-pixel readback acceptance, renderer.init + pipeline-built markers in the demo scene runner.

Plan: `planning/2026-05-29-ios-d3b-threejs-webgpu-program.md` slice 5 section.