### PR TITLE
fix(view+ios): correct Three.js bundle path in .appex (Resources/threejs → threejs)

### DIFF
--- a/core/view/include/pulp/view/threejs_resources.hpp
+++ b/core/view/include/pulp/view/threejs_resources.hpp
@@ -6,8 +6,9 @@
 // embedded inside the AUv3 `.appex` (currently iOS). The IIFE bundle
 // is produced at build time by
 // `tools/scripts/bundle_threejs_for_jsc.mjs` and copied into
-// `<appex>/Resources/threejs/three.iife.js` by the iOS AUv3 CMake
-// rules.
+// `<appex>/threejs/three.iife.js` by the iOS AUv3 CMake rules. (iOS
+// bundles are flat — `<appex>/Resources/` is a macOS-only path that
+// NSBundle does not search on iOS.)
 //
 // On non-Apple-mobile platforms this returns `std::nullopt` — the
 // macOS / desktop lanes resolve Three.js source files via the
@@ -24,10 +25,12 @@ namespace pulp::view {
 
 // Returns the embedded `three.iife.js` source if available on this
 // platform. On iOS the source lives at
-// `Resources/threejs/three.iife.js` inside the AUv3 `.appex`, located
-// at runtime via `[NSBundle bundleForClass:[PulpAUViewController
-// class]]`. On non-iOS platforms (and on Apple-mobile builds where
-// the resource is missing), returns `std::nullopt`.
+// `threejs/three.iife.js` inside the AUv3 `.appex` (iOS bundles are
+// flat — `<appex>/Resources/` is macOS-only). It is located at
+// runtime via `[NSBundle bundleForClass:[PulpAUViewController class]]`
+// and `pathForResource:ofType:inDirectory:@"threejs"`. On non-iOS
+// platforms (and on Apple-mobile builds where the resource is
+// missing), returns `std::nullopt`.
 //
 // The returned string is the full IIFE wrapper that, when run through
 // JSC `evaluate()`, registers `THREE` on `globalThis`. Callers should

--- a/core/view/src/threejs_resources_apple.mm
+++ b/core/view/src/threejs_resources_apple.mm
@@ -3,12 +3,16 @@
 // threejs_resources_apple.mm — iOS-D.3b Slice 2.
 //
 // Apple-platform implementation of `pulp::view::threejs_iife_source()`.
-// On iOS we load `Resources/threejs/three.iife.js` from inside the
-// AUv3 `.appex` via `NSBundle`. The bundle is located by walking up
-// from the `PulpAUViewController` class (the principal class of the
-// `.appex`). On macOS we deliberately return `std::nullopt` — the
-// macOS lane resolves Three.js source files via V8's public ESM API,
-// not via the embedded IIFE bundle.
+// On iOS we load `threejs/three.iife.js` from inside the AUv3 `.appex`
+// via `NSBundle`. iOS bundles are flat — `[NSBundle resourcePath]` IS
+// the bundle root, so the loader resolves
+// `<resourcePath>/threejs/three.iife.js` = `<appex>/threejs/...`
+// (NOT `<appex>/Resources/threejs/...`, which is the macOS-only
+// layout that NSBundle does not search on iOS). The bundle is located
+// by walking up from the `PulpAUViewController` class (the principal
+// class of the `.appex`). On macOS we deliberately return
+// `std::nullopt` — the macOS lane resolves Three.js source files via
+// V8's public ESM API, not via the embedded IIFE bundle.
 
 #include "pulp/view/threejs_resources.hpp"
 

--- a/test/test_threejs_resources.cpp
+++ b/test/test_threejs_resources.cpp
@@ -13,12 +13,12 @@
 //   use the IIFE bundle).
 //
 // The "loads correctly when staged" assertion runs on iOS only via a
-// staged fixture under
-// `test/fixtures/threejs/Resources/threejs/three.iife.js` so the unit
-// test can exercise the load path without needing a real `.appex`.
-// That fixture is created on demand by the test below; we do NOT
-// ship a pre-staged copy because slice 2's bundle output may differ
-// per upstream Three.js pin.
+// staged fixture under `test/fixtures/threejs/threejs/three.iife.js`
+// (iOS bundles are flat — the subdirectory mirrors the runtime
+// `[bundle pathForResource:ofType:inDirectory:@"threejs"]` lookup,
+// NOT a macOS `Contents/Resources/` layout). That fixture is created
+// on demand; we do NOT ship a pre-staged copy because slice 2's
+// bundle output may differ per upstream Three.js pin.
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/tools/cmake/PulpAuv3.cmake
+++ b/tools/cmake/PulpAuv3.cmake
@@ -450,9 +450,20 @@ function(_pulp_add_auv3_ios target name bundle_id version manufacturer manufactu
     endif()
 
     # iOS-D.3b Slice 3: Embed three.iife.js + web-compat-three-shim.js
-    # into the .appex Resources/threejs/ so the JSC engine can load
+    # into the .appex `threejs/` subdirectory so the JSC engine can load
     # Three.js via plain `evaluate()` at runtime (iOS public JSC API
     # has no ESM module loader — see slice 2 / Codex pass-1 finding).
+    #
+    # iOS bundle layout is FLAT: `[NSBundle resourcePath]` IS the
+    # bundle root, NOT `<appex>/Resources/` (that is macOS-only).
+    # The matching loader in `core/view/src/threejs_resources_apple.mm`
+    # uses `[bundle pathForResource:@"three.iife" ofType:@"js"
+    #                inDirectory:@"threejs"]`, which resolves to
+    # `<resourcePath>/threejs/three.iife.js` = `<appex>/threejs/...`.
+    # Slice 3 originally wrote to `<appex>/Resources/threejs/` and
+    # NSBundle silently failed to locate the file at runtime (post-merge
+    # review on PR #3156). Writing under `<appex>/threejs/` directly
+    # aligns the build-time layout with the runtime lookup.
     #
     # The bundler script runs at build time, reading the pinned
     # three.webgpu.js (ESM) and emitting a self-contained IIFE wrapper.
@@ -464,17 +475,17 @@ function(_pulp_add_auv3_ios target name bundle_id version manufacturer manufactu
         find_program(_PULP_NODE_EXE NAMES node nodejs)
         if(_PULP_NODE_EXE)
             set(_three_in  "${threejs_SOURCE_DIR}/build/three.webgpu.js")
-            set(_three_iife "$<TARGET_BUNDLE_DIR:${target}_AUv3>/Resources/threejs/three.iife.js")
+            set(_three_iife "$<TARGET_BUNDLE_DIR:${target}_AUv3>/threejs/three.iife.js")
             set(_three_shim_src "${CMAKE_SOURCE_DIR}/core/view/js/web-compat-three-shim.js")
-            set(_three_shim_out "$<TARGET_BUNDLE_DIR:${target}_AUv3>/Resources/threejs/web-compat-three-shim.js")
+            set(_three_shim_out "$<TARGET_BUNDLE_DIR:${target}_AUv3>/threejs/web-compat-three-shim.js")
             set(_bundler_script "${CMAKE_SOURCE_DIR}/tools/scripts/bundle_threejs_for_jsc.mjs")
             add_custom_command(TARGET ${target}_AUv3 POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -E make_directory
-                        "$<TARGET_BUNDLE_DIR:${target}_AUv3>/Resources/threejs"
+                        "$<TARGET_BUNDLE_DIR:${target}_AUv3>/threejs"
                 COMMAND ${_PULP_NODE_EXE} ${_bundler_script}
                         --input "${_three_in}" --output "${_three_iife}"
                 COMMAND ${CMAKE_COMMAND} -E copy "${_three_shim_src}" "${_three_shim_out}"
-                COMMENT "iOS-D.3b: bundle Three.js IIFE + shim into ${target}.appex Resources/threejs"
+                COMMENT "iOS-D.3b: bundle Three.js IIFE + shim into ${target}.appex/threejs/"
                 VERBATIM
             )
         else()


### PR DESCRIPTION
## Summary

iOS-D.3b Slice 3 (PR #3156) writes the build-time Three.js IIFE
bundle to `<appex>/Resources/threejs/three.iife.js`. That subpath is
correct for macOS bundles but wrong for iOS — app extensions are
flat, so `[NSBundle resourcePath]` IS the bundle root. The matching
loader in `threejs_resources_apple.mm` uses
`pathForResource:ofType:inDirectory:@\"threejs\"`, which on iOS
resolves to `<appex>/threejs/three.iife.js`, **not**
`<appex>/Resources/threejs/three.iife.js`.

Result on a real iPad walk-through: NSBundle silently returns nil,
`pulp::view::threejs_iife_source()` returns `std::nullopt`, and JSC
can never load Three.js even though the bundler script ran cleanly at
build time. The macOS-only required CI lane cannot catch this because
the macOS path uses V8 + ESM, not the iOS IIFE-via-NSBundle path.

## Changes

- `tools/cmake/PulpAuv3.cmake` — POST_BUILD writes to
  `$<TARGET_BUNDLE_DIR:${target}_AUv3>/threejs/` instead of
  `.../Resources/threejs/` (three places: iife output, shim output,
  make_directory target). Comment expanded with a pointer back to PR
  #3156 and a one-line explanation of iOS flat-bundle layout.
- `core/view/include/pulp/view/threejs_resources.hpp` — doc comments
  updated (two places) to reflect the iOS flat layout.
- `core/view/src/threejs_resources_apple.mm` — header comment updated.
  Loader code is unchanged (it was already correct — only the
  build-time output path was wrong).
- `test/test_threejs_resources.cpp` — fixture-path comment updated.

## Test plan

- [x] CMake-paths-only change; no .cpp logic changed → no diff-coverage delta.
- [x] `skill_sync_check.py --mode=report` → no mapped paths touched.
- [x] `version_bump_check.py --mode=hint` → no bump needed.
- [ ] Real iOS .appex build verifies the file lands at
      `<appex>/threejs/three.iife.js` and NSBundle locates it.
- [ ] Optional follow-up: regression test that stages a fixture under
      the unit-test bundle's `threejs/` path and asserts
      `threejs_iife_source().has_value()` on iOS Simulator.

## Discovery

Found during deep-review sweep on iOS-D.3b slices 2-5 while Codex was
over GraphQL quota. The cross-platform CI matrix doesn't exercise the
NSBundle lookup path against an actual iOS .appex layout, so the bug
slipped through. macOS bundles handle `Resources/` correctly via
`Contents/Resources/`, but iOS doesn't — it's the kind of bug that
only surfaces on the iOS device walk-through that slice 3 ships
toward.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>