### PR TITLE
refactor(view): extract layout/snapshot diagnostic helpers into import_validation_bridge (#3151)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.282.0
+    VERSION 0.282.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -277,6 +277,7 @@ endif()
 
 target_sources(pulp-view-core PRIVATE
     src/accessibility.cpp
+    src/import_validation_bridge.cpp
     ${PULP_TEXT_ACCESSIBILITY_SOURCE}
     src/threejs_resources_stub.cpp
     src/table_model.cpp

--- a/core/view/src/claude_bundle.cpp
+++ b/core/view/src/claude_bundle.cpp
@@ -43,6 +43,7 @@
 #include <cmath>
 
 #include "design_import_internal.hpp"
+#include "import_validation_bridge.hpp"
 
 namespace pulp::view {
 
@@ -525,16 +526,9 @@ size_t count_ir_nodes(const IRNode& n) {
     return total;
 }
 
-void layout_runtime_snapshot_root_if_requested(View& root, const ClaudeRuntimeOptions& opts) {
-    if (opts.runtime_snapshot_viewport_width <= 0 || opts.runtime_snapshot_viewport_height <= 0)
-        return;
-
-    root.set_bounds({0.0f,
-                     0.0f,
-                     static_cast<float>(opts.runtime_snapshot_viewport_width),
-                     static_cast<float>(opts.runtime_snapshot_viewport_height)});
-    root.layout_children();
-}
+// layout_runtime_snapshot_root_if_requested was extracted verbatim to
+// import_validation_bridge.{hpp,cpp} (#3151). The call site below uses the
+// shared definition.
 
 std::string color_to_hex(Color color) {
     std::ostringstream out;

--- a/core/view/src/import_validation_bridge.cpp
+++ b/core/view/src/import_validation_bridge.cpp
@@ -1,0 +1,81 @@
+#include "import_validation_bridge.hpp"
+
+#include <pulp/view/ui_components.hpp>  // ScrollView
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace pulp::view {
+
+// --- moved verbatim from widget_bridge.cpp ---------------------------------
+
+choc::value::Value make_layout_rect_value(View* v) {
+    auto result = choc::value::createObject("");
+    if (!v) return result;
+
+    float ax = 0.0f;
+    float ay = 0.0f;
+    View* cur = v;
+    while (cur) {
+        ax += cur->bounds().x;
+        ay += cur->bounds().y;
+        if (auto* scroll = dynamic_cast<ScrollView*>(cur->parent())) {
+            ax -= scroll->scroll_x();
+            ay -= scroll->scroll_y();
+        }
+        cur = cur->parent();
+    }
+
+    auto b = v->bounds();
+    result.addMember("x", choc::value::createFloat64(ax));
+    result.addMember("y", choc::value::createFloat64(ay));
+    result.addMember("width", choc::value::createFloat64(b.width));
+    result.addMember("height", choc::value::createFloat64(b.height));
+    result.addMember("top", choc::value::createFloat64(ay));
+    result.addMember("left", choc::value::createFloat64(ax));
+    result.addMember("right", choc::value::createFloat64(ax + b.width));
+    result.addMember("bottom", choc::value::createFloat64(ay + b.height));
+    return result;
+}
+
+static std::string layout_trace_id(const View& v) {
+    if (!v.anchor_id().empty()) return v.anchor_id();
+    if (!v.id().empty()) return v.id();
+    return {};
+}
+
+choc::value::Value make_layout_ancestor_chain_value(View* v) {
+    auto result = choc::value::createEmptyArray();
+    if (!v) return result;
+
+    std::vector<View*> chain;
+    for (auto* cur = v; cur != nullptr; cur = cur->parent())
+        chain.push_back(cur);
+    std::reverse(chain.begin(), chain.end());
+
+    for (auto* cur : chain) {
+        auto id = layout_trace_id(*cur);
+        if (id.empty()) continue;
+        auto entry = choc::value::createObject("");
+        entry.addMember("id", id);
+        entry.addMember("bounds", make_layout_rect_value(cur));
+        result.addArrayElement(entry);
+    }
+    return result;
+}
+
+// --- moved verbatim from claude_bundle.cpp ---------------------------------
+
+void layout_runtime_snapshot_root_if_requested(View& root, const ClaudeRuntimeOptions& opts) {
+    if (opts.runtime_snapshot_viewport_width <= 0 || opts.runtime_snapshot_viewport_height <= 0)
+        return;
+
+    root.set_bounds({0.0f,
+                     0.0f,
+                     static_cast<float>(opts.runtime_snapshot_viewport_width),
+                     static_cast<float>(opts.runtime_snapshot_viewport_height)});
+    root.layout_children();
+}
+
+}  // namespace pulp::view

--- a/core/view/src/import_validation_bridge.hpp
+++ b/core/view/src/import_validation_bridge.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+// Import / validation diagnostic helpers.
+//
+// These are pure functions that operate only on the public View API and the
+// ClaudeRuntimeOptions value type. They were extracted verbatim from
+// widget_bridge.cpp (make_layout_rect_value / make_layout_ancestor_chain_value)
+// and claude_bundle.cpp (layout_runtime_snapshot_root_if_requested) so the two
+// translation units can share one definition without copy/paste drift. No
+// behavior, ordering, or contract changes were made during the extraction (#3151).
+
+#include <choc/containers/choc_Value.h>
+
+#include <pulp/view/design_sources.hpp>  // ClaudeRuntimeOptions
+#include <pulp/view/view.hpp>            // View
+
+namespace pulp::view {
+
+// Compute the absolute (root-relative) layout rectangle for a view, walking the
+// parent chain and subtracting ScrollView scroll offsets. Returns a choc object
+// with x/y/width/height/top/left/right/bottom members.
+choc::value::Value make_layout_rect_value(View* v);
+
+// Build the ancestor chain (root → view) as a choc array of {id, bounds} entries,
+// skipping ancestors without an anchor/id. Used by the getLayoutAncestorRects
+// diagnostic trace.
+choc::value::Value make_layout_ancestor_chain_value(View* v);
+
+// If a runtime-snapshot viewport is requested in opts, resize the root view to
+// that viewport and re-run layout. No-op when the viewport is unset/non-positive.
+void layout_runtime_snapshot_root_if_requested(View& root, const ClaudeRuntimeOptions& opts);
+
+}  // namespace pulp::view

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -12,6 +12,7 @@
 #include <pulp/view/asset_manager.hpp>
 #include <pulp/view/sprite_strip.hpp>
 #include <pulp/view/design_import.hpp>
+#include "import_validation_bridge.hpp"
 #if __has_include(<pulp/render/gpu_surface.hpp>)
 #include <pulp/render/gpu_surface.hpp>
 #define PULP_WIDGET_BRIDGE_HAS_GPU_SURFACE 1
@@ -759,60 +760,9 @@ static void safe_dispatch_eval(const std::shared_ptr<std::atomic<bool>>& alive,
     }
 }
 
-static choc::value::Value make_layout_rect_value(View* v) {
-    auto result = choc::value::createObject("");
-    if (!v) return result;
-
-    float ax = 0.0f;
-    float ay = 0.0f;
-    View* cur = v;
-    while (cur) {
-        ax += cur->bounds().x;
-        ay += cur->bounds().y;
-        if (auto* scroll = dynamic_cast<ScrollView*>(cur->parent())) {
-            ax -= scroll->scroll_x();
-            ay -= scroll->scroll_y();
-        }
-        cur = cur->parent();
-    }
-
-    auto b = v->bounds();
-    result.addMember("x", choc::value::createFloat64(ax));
-    result.addMember("y", choc::value::createFloat64(ay));
-    result.addMember("width", choc::value::createFloat64(b.width));
-    result.addMember("height", choc::value::createFloat64(b.height));
-    result.addMember("top", choc::value::createFloat64(ay));
-    result.addMember("left", choc::value::createFloat64(ax));
-    result.addMember("right", choc::value::createFloat64(ax + b.width));
-    result.addMember("bottom", choc::value::createFloat64(ay + b.height));
-    return result;
-}
-
-static std::string layout_trace_id(const View& v) {
-    if (!v.anchor_id().empty()) return v.anchor_id();
-    if (!v.id().empty()) return v.id();
-    return {};
-}
-
-static choc::value::Value make_layout_ancestor_chain_value(View* v) {
-    auto result = choc::value::createEmptyArray();
-    if (!v) return result;
-
-    std::vector<View*> chain;
-    for (auto* cur = v; cur != nullptr; cur = cur->parent())
-        chain.push_back(cur);
-    std::reverse(chain.begin(), chain.end());
-
-    for (auto* cur : chain) {
-        auto id = layout_trace_id(*cur);
-        if (id.empty()) continue;
-        auto entry = choc::value::createObject("");
-        entry.addMember("id", id);
-        entry.addMember("bounds", make_layout_rect_value(cur));
-        result.addArrayElement(entry);
-    }
-    return result;
-}
+// make_layout_rect_value / make_layout_ancestor_chain_value were extracted
+// verbatim to import_validation_bridge.{hpp,cpp} (#3151). The getLayoutRect /
+// getLayoutAncestorRects registrations below call the shared definitions.
 
 static void eval_or_throw(ScriptEngine& engine, const char* name, const std::string& js) {
     try {


### PR DESCRIPTION
Narrow verbatim extraction of pure helpers only (make_layout_rect_value /
make_layout_ancestor_chain_value / layout_runtime_snapshot_root_if_requested);
registrations, ordering, and capture_method stamping unchanged; existing
design-import + screenshot-contract suites green.

Skill-Update: skip skill=import-design reason="verbatim relocation of pure diagnostic helpers; no behavior/contract change"
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>