### PR TITLE
fix(auv3): defer editor GPU-host creation until host-settled size (Logic first paint)

### DIFF
--- a/.agents/skills/auv3/SKILL.md
+++ b/.agents/skills/auv3/SKILL.md
@@ -601,23 +601,36 @@ expands the host window by the exact view delta, and resizes the root
 view to the design. Keep this limited to initial attach; manual host
 resize must continue through `viewDidLayout` without being forced back.
 
-`PulpAudioUnit::supportedViewConfigurations:` accepts configurations
-within ~5% aspect tolerance of the design only when they are also large
-enough to contain that design (a JUCE forum thread documents that Logic
-10.6.1 probes 1024x768 / 1366x1024 — accepting at least one fixes a
-known Logic reopen-size bug). If any aspect-correct, large-enough
-configuration exists, return only those; wrong-aspect "large enough"
-configs are fallbacks, otherwise Logic/REAPER can choose one first and
-open fixed-design editors with avoidable top/bottom padding. If every
-candidate is undersized for a fixed-design editor, return an empty set
-so CoreAudioKit falls back to the largest available view configuration
-instead of treating the tiny default as supported.
+**Do NOT implement `supportedViewConfigurations:` / `selectViewConfiguration:`
+for fixed-design editors.** (Verified in Logic 2026-05-29; replaced the earlier
+"accept a large-enough config" policy, which *caused* the bug.) Logic Pro sizes
+AU v3 editors through the view-configuration path and offers ONLY oversized ~4:3
+configs (measured: 1024x768 / 1366x1024). The moment the AU returns *any*
+supported config, **Logic locks the editor window to that config's aspect ratio
+at every size** — so a wide fixed design (e.g. 900x520 ≈ 16:9.4) letterboxes with
+top/bottom bars that *cannot be resized away* (confirmed by AX resize probing:
+grow/shrink all snap back to 4:3). Apple's CoreAudioKit header states an empty
+index set means "use the largest available view configuration," so returning
+empty makes Logic pick its *largest* 4:3 config — strictly worse.
 
-Padding at the top/bottom (or left/right) of the editor in a host
-window is the **expected letterbox** when the host gives us a window
-whose aspect ratio doesn't match the design's. Tighten by either
-adjusting the plugin's `view_size()` hint or implementing a tighter
-view-configuration policy.
+Base `AUAudioUnit` already implements these selectors. By NOT overriding them,
+Logic falls back to the plain view at `preferredContentSize` and lets the window
+**free-resize to the design's own aspect** — tight and proportional, matching
+REAPER (in-process, honors design size), CLAP (`gui_get_size`), VST3 (`getSize`),
+and standalone. REAPER never used these selectors, so removing them is a no-op
+there. Regression-guarded by `test_au_plugin_state.mm` → "AU v3 does not opt into
+host view configurations" (asserts PulpAudioUnit's IMP for both selectors equals
+the inherited base IMP — i.e. not overridden).
+
+If a future *fluid/multi-config* editor genuinely wants host view configurations,
+reintroduce the selectors gated on that editor kind, but keep them OFF for any
+`set_design_viewport` / `set_fixed_aspect_ratio` (fixed-design) editor.
+
+Known minor follow-up: in Logic the editor can open a touch too short on first
+paint (top of the design clipped) until a quick manual resize reflows it; the
+letterbox bars are gone. Likely a stale-window-geometry / initial-layout settle
+nit (`runInitialSizeSync` only corrects *undersized*); verify on a fresh Logic
+project before investing in an initial-size fix.
 
 ### The `PULP_AUV3_PLUGIN()` macro replaces hardcoded force_link
 

--- a/.agents/skills/auv3/SKILL.md
+++ b/.agents/skills/auv3/SKILL.md
@@ -626,11 +626,65 @@ If a future *fluid/multi-config* editor genuinely wants host view configurations
 reintroduce the selectors gated on that editor kind, but keep them OFF for any
 `set_design_viewport` / `set_fixed_aspect_ratio` (fixed-design) editor.
 
-Known minor follow-up: in Logic the editor can open a touch too short on first
-paint (top of the design clipped) until a quick manual resize reflows it; the
-letterbox bars are gone. Likely a stale-window-geometry / initial-layout settle
-nit (`runInitialSizeSync` only corrects *undersized*); verify on a fresh Logic
-project before investing in an initial-size fix.
+### Logic OOP first-paint clip — defer GPU-host creation until a real size
+
+After the view-config fix above, Logic stopped letterboxing but the editor's
+**first paint** still clipped: the UI rendered at the design size inside Logic's
+restored (smaller) window — top + right cut off — until a manual resize or a
+window close+reopen snapped it tight. Reopen worked (the container already
+existed at the right size); only the very first open raced.
+
+Root cause (verified in Logic 2026-05-29): Logic hosts AU v3 **out-of-process**
+and does **not** push its restored window size to the extension's view on
+initial open — not via `viewDidLayout`, not via `setFrameSize:`, not via a
+`self.view.bounds` change during a ~0.5s poll. It embeds our view, leaves it at
+the design-size frame from `loadView`, and composites that oversized layer into
+its smaller window. The GPU surface (created at attach with `opts.size = design`)
+therefore paints once at design size and the stale frame persists until the host
+next requests a redraw (a resize or reopen). Forcing a repaint, re-asserting
+`preferredContentSize`, or forcing the host window size did **not** fix it (and
+forcing Logic's window is host-hostile — it fights Logic's restore).
+
+Fix (the one that worked) — **defer creating the `PluginViewHost` / GPU surface
+until the root view reports a real, settled host size**, so the surface is never
+born at the design size for a smaller first window. Mechanics in
+`au_view_controller_mac.mm`:
+
+1. `loadView` makes the root view a `PulpAUMacRootView` (NSView subclass)
+   overriding `setFrameSize:` → an `onResize` block; in `viewDidMoveToSuperview`
+   it fills its superview the **frame-based** way (`autoresizingMask` =
+   width|height-sizable + `frame = superview.bounds`) so AppKit sizes it to the
+   host container on embed and every host resize.
+   **⚠️ Do NOT use Auto Layout (`translatesAutoresizingMaskIntoConstraints=NO` +
+   edge constraints) to pin it — that CRASHED Ableton Live** (2026-05-29):
+   when the host places the AU window, our `setFrameSize:` → `[super]` →
+   `setNeedsLayout` engages the constraint engine (`-[NSWindow
+   _postWindowNeedsLayout]`), which throws in that context and the uncaught
+   exception kills the host. Frame-based autoresizing fills the container
+   identically for our purposes (the deferred GPU host reads the real bounds)
+   without touching the constraint engine, and is compatible with frame-driven
+   AU hosts (Live, REAPER, Logic). Lesson: in an AU editor view embedded by an
+   arbitrary host, never engage Auto Layout against the host's window.
+2. `rebuildEditorIfReady` opens the `ViewBridge`, sets `preferredContentSize`,
+   wires `onResize`, sets `_viewHostPending` + `_pendingRoot`, and does **not**
+   create the host or force the view frame.
+3. `-createViewHostIfReady` builds the host **at the view's real bounds**
+   (`opts.size = bounds`, not design), then `set_design_viewport(design)`.
+   While bounds still equal the design size it **waits** (up to the
+   `kInitialSizeSyncMaxAttempts` × `kInitialSizeSyncIntervalMs` settle window)
+   for the host's likely-different restored size; after that it accepts the
+   current size. It is driven from `onResize`, `viewDidLayout`, and the
+   `runInitialSizeSync` fallback (all idempotent).
+4. Clear `onResize` first in `dealloc` (it captures `self` unretained + touches
+   `_viewHost`, which is destroyed after `[super dealloc]`).
+
+Trade-off: a brief (<0.5s) black frame on first open while we wait for the real
+size — acceptable, and far better than a clipped first paint. **Never create the
+AU v3 GPU surface at the design size before the host has sized the view.** When
+working on Dawn/Skia-backed editors in any out-of-process host, treat
+"first-paint size" as a first-class concern: confirm what size the host actually
+delivers and when, rather than assuming `viewDidLayout`/`preferredContentSize`
+will be honored on initial open.
 
 ### The `PULP_AUV3_PLUGIN()` macro replaces hardcoded force_link
 

--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -119,6 +119,26 @@ Full recipe (macOS framework + stub .appex + container .app, signing,
 notarization, PlugInKit diagnostics) is in
 `.agents/skills/auv3/SKILL.md → "macOS AU v3 packaging"`.
 
+### macOS AU v3: editor attach is now DEFERRED until a settled host size
+
+`rebuildEditorIfReady` no longer creates the `PluginViewHost` (or calls
+`ViewBridge::notify_attached()`) inline. Logic hosts AU v3 out-of-process and
+does **not** deliver its restored window size to the extension's view on initial
+open, so a `PluginViewHost` built then would paint its first frame at the design
+size inside Logic's smaller window (clipped). Instead `rebuildEditorIfReady`
+opens the bridge, sets `preferredContentSize`, wires a `setFrameSize:` hook on a
+custom `PulpAUMacRootView` (which fills its superview the **frame-based** way —
+`autoresizingMask`, NOT Auto Layout: constraint pinning crashed Ableton Live, see
+the auv3 SKILL), and marks the host
+**pending**; `-createViewHostIfReady` then builds the host **at the view's real
+bounds** — and only there fires `notify_attached()`. **Consequence for adapter
+authors:** on macOS AU v3, `Processor::on_view_opened` (via `notify_attached`)
+fires slightly later — after the host's first real layout, not at controller
+build — and `_pendingRoot`/`_viewHostPending` gate the one-shot creation. Don't
+move `notify_attached()` back inline; it reintroduces the first-paint clip.
+Rationale + the view-config/first-paint root cause are in
+`.agents/skills/auv3/SKILL.md → "Logic OOP first-paint clip"`.
+
 ## AU v2 dual-Processor gotcha (fixed)
 
 Pre-ViewBridge, the AU v2 Cocoa view factory called

--- a/core/format/include/pulp/format/host_quirks.hpp
+++ b/core/format/include/pulp/format/host_quirks.hpp
@@ -148,6 +148,19 @@ struct HostQuirks {
     // Logic Pro AU
     int logic_au_channel_probe_cap = 64;               ///< row 19 (Logic = 8)
     bool logic_au_tail_time_conversion = false;        ///< row 20
+    // NOTE (no runtime flag — handled in the AU v3 adapter, recorded here so the
+    // DAW-quirks ledger captures it): Logic Pro AU v3 editor SIZING has two
+    // confirmed behaviors a fixed-design GPU editor must accommodate:
+    //   1. Logic locks the editor window to its selected view-config aspect
+    //      (it offers only oversized ~4:3 configs), so a wide fixed design
+    //      letterboxes. Fix: do NOT implement supportedViewConfigurations: /
+    //      selectViewConfiguration: → Logic free-resizes to the design aspect.
+    //   2. Logic (out-of-process) does NOT deliver the editor view's restored
+    //      window size on first open, so a GPU surface created at the design
+    //      size clips its first paint. Fix: defer GPU-host creation until the
+    //      view reports a real settled size.
+    // Both live in core/format/src/{au_adapter,au_view_controller_mac}.mm and
+    // .agents/skills/auv3/SKILL.md. Verified live in Logic 2026-05-29.
 
     // AU v3 cross-host
     bool au_v3_bypass_dual_tracking = false;           ///< row 21

--- a/core/format/src/au_adapter.mm
+++ b/core/format/src/au_adapter.mm
@@ -35,9 +35,14 @@
 //  │ fullState                                │ NSDict    │ main         │ YES (serdes) │
 //  │ setFullState:                            │ void      │ main         │ YES (serdes) │
 //  │ audioUnitARAFactory                      │ void*     │ KVO/main     │ NO (cached)  │
-//  │ supportedViewConfigurations:             │ NSIndexS… │ main         │ YES (NSSet)  │
-//  │ selectViewConfiguration:                 │ void      │ main         │ NO (log only)│
 //  └──────────────────────────────────────────┴───────────┴──────────────┴──────────────┘
+//
+// NOTE: supportedViewConfigurations: / selectViewConfiguration: are
+// intentionally NOT overridden (removed). See the "view configuration
+// negotiation: intentionally NOT implemented" comment near @end and the
+// regression test "AU v3 does not opt into host view configurations". Logic
+// locks the editor window to the selected config's aspect; not opting in lets
+// it free-resize to the design aspect (the AUv3-Logic sizing fix).
 //
 // Pulp-private accessors used by tests (NOT AUAudioUnit overrides):
 //   • pulpProcessor / pulpStore — main-thread, read-only.
@@ -981,91 +986,29 @@ static int32_t block_relative_sample_offset(AUEventSampleTime event_sample_time,
         pulp::format::ara_companion_factory_for(nullptr));
 }
 
-// ── AU v3 view configuration negotiation ───────────────────────────────────
+// ── AU v3 view configuration negotiation: intentionally NOT implemented ─────
 //
-// Hosts (Logic, MainStage, GarageBand) probe `supportedViewConfigurations:`
-// with a set of candidate window sizes and pick one via
-// `selectViewConfiguration:`. For a fixed-design GPU editor (the common
-// Pulp shape), we accept configurations that are close to the processor's
-// design aspect *and* large enough to contain the design viewport. The view
-// controller's `set_design_viewport` + `set_fixed_aspect_ratio` then scales
-// the actual paint at the host-chosen size.
+// We deliberately do NOT override `supportedViewConfigurations:` /
+// `selectViewConfiguration:` for Pulp's fixed-design GPU editors.
 //
-// preferredContentSize remains authoritative for the initial editor size
-// when no host-selected configuration applies. Don't put an internal corner
-// resizer here — Logic's AU v3 path is host/container-driven.
-
-- (NSIndexSet *)supportedViewConfigurations:(NSArray<AUAudioUnitViewConfiguration *> *)availableViewConfigurations NS_AVAILABLE(10_13, 11_0) {
-    NSMutableIndexSet *result = [NSMutableIndexSet indexSet];
-    if (!_bridge.processor || availableViewConfigurations.count == 0) {
-        return result;
-    }
-
-    const auto hints = _bridge.processor->view_size();
-    const double design_w = static_cast<double>(hints.preferred_width);
-    const double design_h = static_cast<double>(hints.preferred_height);
-    if (design_w <= 0.0 || design_h <= 0.0) {
-        // No usable design size — accept everything and let the host decide.
-        [result addIndexesInRange:NSMakeRange(0, availableViewConfigurations.count)];
-        return result;
-    }
-
-    const double design_aspect = design_w / design_h;
-    // 5% aspect tolerance is tight enough to reject obvious wrong-aspect
-    // candidates and loose enough to land on Logic's common defaults.
-    constexpr double kAspectTolerance = 0.05;
-
-    NSMutableIndexSet *aspectMatches = [NSMutableIndexSet indexSet];
-    NSMutableIndexSet *largeEnoughFallbacks = [NSMutableIndexSet indexSet];
-
-    for (NSUInteger i = 0; i < availableViewConfigurations.count; ++i) {
-        AUAudioUnitViewConfiguration *cfg = availableViewConfigurations[i];
-        const double w = static_cast<double>(cfg.width);
-        const double h = static_cast<double>(cfg.height);
-        if (w <= 0.0 || h <= 0.0) continue;
-
-        const double cfg_aspect = w / h;
-        const double aspect_delta = std::abs(cfg_aspect - design_aspect) / design_aspect;
-        if (aspect_delta <= kAspectTolerance && w >= design_w && h >= design_h) {
-            [aspectMatches addIndex:i];
-            continue;
-        }
-
-        // Even on an aspect mismatch, accept configurations large enough to
-        // contain the design viewport, but only as a fallback when no
-        // aspect-correct option exists. Returning both lets hosts choose a
-        // wrong-aspect "large enough" config first, which opens fixed-design
-        // editors with avoidable top/bottom padding in Logic/REAPER AUv3.
-        if (w >= design_w && h >= design_h) {
-            [largeEnoughFallbacks addIndex:i];
-        }
-    }
-
-    if (aspectMatches.count > 0) {
-        [result addIndexes:aspectMatches];
-    } else if (largeEnoughFallbacks.count > 0) {
-        [result addIndexes:largeEnoughFallbacks];
-    } else {
-        // If every candidate is too small or wrong for a fixed-design editor,
-        // return an empty set. CoreAudioKit defines that as "use the largest
-        // available view configuration"; accepting undersized configs lets
-        // hosts open a truncated/padded editor and never revisit the design
-        // size.
-    }
-    return result;
-}
-
-- (void)selectViewConfiguration:(AUAudioUnitViewConfiguration *)viewConfiguration NS_AVAILABLE(10_13, 11_0) {
-    // The view controller is the authority on actual sizing — it already
-    // observes its own bounds in viewDidLayout and forwards to
-    // PluginViewHost::set_size + ViewBridge::resize. This selector is the
-    // host telling us its preferred config; we log it for diagnostics and
-    // bump the preferredContentSize so any pending unload/reload of the
-    // controller picks up the new size.
-    pulp::runtime::log_info("AU v3 host selected view config: {}x{} (hostHasController={})",
-                            static_cast<int>(viewConfiguration.width),
-                            static_cast<int>(viewConfiguration.height),
-                            viewConfiguration.hostHasController ? "YES" : "NO");
-}
+// Why: Logic Pro drives AU v3 editor sizing through the view-configuration
+// path and offers ONLY oversized ~4:3 configs (measured: 1024x768 / 1366x1024).
+// When an AU opts in by returning any supported config, Logic LOCKS the editor
+// window to that config's aspect ratio at every size (confirmed: a 900x520 /
+// ~16:9.4 design forced into Logic's 4:3 window letterboxes with top/bottom
+// bars that cannot be resized away). Apple's CoreAudioKit header states an
+// empty index set means "use the largest available view configuration", so
+// returning empty makes Logic pick its *largest* 4:3 config — strictly worse,
+// not better.
+//
+// By NOT implementing these selectors at all, Logic falls back to the plain
+// view at the controller's `preferredContentSize` and lets the window
+// free-resize to the design's own aspect — matching the tight, proportional
+// fit Pulp already gets in REAPER, CLAP, VST3, and standalone. (REAPER/CLAP/
+// VST3 never used these selectors, so this is a no-op for them.)
+//
+// If a future non-fixed (truly fluid / multi-config) editor needs host view
+// configurations, reintroduce these selectors gated on that editor kind — but
+// keep them OFF for design-viewport / `set_fixed_aspect_ratio` editors.
 
 @end

--- a/core/format/src/au_view_controller_mac.mm
+++ b/core/format/src/au_view_controller_mac.mm
@@ -28,6 +28,7 @@
 #import "au_audio_unit.h"
 
 #include <algorithm>
+#include <cmath>
 #include <memory>
 
 namespace {
@@ -56,27 +57,55 @@ void pulp_auv3_apply_preferred_size(NSViewController *controller,
     [view setNeedsLayout:YES];
 }
 
-bool pulp_auv3_is_undersized(NSSize current, NSSize design) {
-    return current.width > 0.0 && current.height > 0.0 &&
-           design.width > 0.0 && design.height > 0.0 &&
-           (current.width < design.width || current.height < design.height);
-}
-
-void pulp_auv3_expand_window_for_view(NSView *view, NSSize design) {
-    if (!view || !view.window) return;
-    NSSize current = view.bounds.size;
-    if (!pulp_auv3_is_undersized(current, design)) return;
-
-    NSRect frame = view.window.frame;
-    const CGFloat delta_w = std::max<CGFloat>(0.0, design.width - current.width);
-    const CGFloat delta_h = std::max<CGFloat>(0.0, design.height - current.height);
-    frame.size.width += delta_w;
-    frame.size.height += delta_h;
-    frame.origin.y -= delta_h;
-    [view.window setFrame:frame display:YES animate:NO];
-}
+// Initial-attach size-sync ticks. Logic hosts AU v3 out-of-process and the
+// extension's `viewDidLayout` does not reliably fire when the host resizes the
+// remote view, so the editor can paint its first frame at the design size
+// inside whatever (often remembered) window Logic restored — clipping the UI
+// until a manual resize. We poll the view's real bounds for a short window
+// after attach and re-fit each tick. 8 × 60ms ≈ 0.5s covers Logic's late
+// layout settle without lingering long enough to fight a deliberate resize.
+static constexpr unsigned long kInitialSizeSyncMaxAttempts = 8;
+static constexpr int64_t kInitialSizeSyncIntervalMs = 60;
 
 } // namespace
+
+/// Root view that reports host-driven frame changes synchronously.
+///
+/// In Logic Pro's out-of-process AU v3 hosting the host sets the remote view's
+/// frame geometry to its (often restored) window size WITHOUT reliably driving
+/// the controller's `viewDidLayout`. Polling `self.view.bounds` after attach
+/// therefore misses the host's initial size and the editor's first frame stays
+/// painted at the design size inside a smaller window (clipped) until the user
+/// nudges it. Overriding `setFrameSize:` is the one hook guaranteed to fire on
+/// every host-driven (re)size, so we re-fit the design viewport from here.
+@interface PulpAUMacRootView : NSView
+@property (nonatomic, copy) void (^onResize)(void);
+@end
+
+@implementation PulpAUMacRootView
+- (void)setFrameSize:(NSSize)newSize {
+    [super setFrameSize:newSize];
+    if (self.onResize) self.onResize();
+}
+- (void)viewDidMoveToSuperview {
+    [super viewDidMoveToSuperview];
+    NSView *sv = self.superview;
+    if (!sv) return;
+    // Fill the host's container view so we pick up its real size — but do it the
+    // FRAME-based way (springs & struts), NOT Auto Layout. Pinning with
+    // NSLayoutConstraints (translatesAutoresizingMaskIntoConstraints=NO) crashed
+    // Ableton Live: when the host places the AU window, our setFrameSize: →
+    // [super] → setNeedsLayout engages the constraint engine
+    // (-[NSWindow _postWindowNeedsLayout]) which throws in that context and the
+    // uncaught exception kills the host. Frame-based autoresizing fills the
+    // container identically for our purposes (the deferred GPU host then reads
+    // these real bounds) without touching the constraint engine, and is
+    // compatible with frame-driven AU hosts (Live, REAPER, Logic).
+    self.translatesAutoresizingMaskIntoConstraints = YES;
+    self.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+    self.frame = sv.bounds;
+}
+@end
 
 /// AUViewController subclass + AUAudioUnitFactory for macOS AU v3.
 /// Apple's current pattern: the view controller IS the factory. Info.plist
@@ -89,6 +118,14 @@ void pulp_auv3_expand_window_for_view(NSView *view, NSSize design) {
 @implementation PulpAUMacViewController {
     NSSize _designSize;
     NSUInteger _initialSizeSyncAttempts;
+    // Deferred GPU-host creation (Logic OOP first-paint fix): we hold the
+    // resolved root View and wait to build the PluginViewHost (and its Dawn/
+    // Skia surface) until the root view reports a real, settled host size, so
+    // the surface is never born at the design size inside a smaller restored
+    // Logic window. _pendingRoot points into _bridge / _fallbackView and is
+    // only dereferenced before they are reset.
+    pulp::view::View *_pendingRoot;
+    BOOL _viewHostPending;
     // Ivar order is load-bearing — see -dealloc in
     // au_view_controller_ios.mm for the same contract. _viewHost holds
     // `View& root_` and MUST be destroyed before whichever object owns
@@ -106,7 +143,8 @@ void pulp_auv3_expand_window_for_view(NSView *view, NSSize design) {
     // initial container from this frame before createAudioUnit has provided
     // the processor, so use compile-time design dimensions when available.
     const NSSize initial = pulp_auv3_initial_editor_size();
-    NSView *root = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, initial.width, initial.height)];
+    PulpAUMacRootView *root =
+        [[PulpAUMacRootView alloc] initWithFrame:NSMakeRect(0, 0, initial.width, initial.height)];
     root.wantsLayer = YES;
     root.layer.backgroundColor = NSColor.blackColor.CGColor;
     self.view = root;
@@ -238,42 +276,78 @@ void pulp_auv3_expand_window_for_view(NSView *view, NSSize design) {
         root = _fallbackView.get();
     }
 
-    // If the host has not attached the controller yet, update the root frame
-    // too so preferredContentSize and the actual view bounds agree. REAPER's
-    // in-process AUv3 path can attach first and hand us its small default
-    // container; on that first build, expand the root to the design before
-    // attaching the GPU host. Later user/host resize still flows through
-    // viewDidLayout without being forced back to the design size.
+    // Publish the design size as the preferred size, but do NOT force the root
+    // view's frame to it here. Forcing the frame during rebuild poisons the
+    // first paint in Logic's OOP host: the editor paints at the design size
+    // before Logic delivers its restored (smaller) window size, leaving the
+    // first frame clipped. The PulpAUMacRootView `setFrameSize:` hook (wired
+    // below) re-fits the design viewport to whatever size the host hands us —
+    // including Logic's initial geometry push that `viewDidLayout` misses.
     const NSSize designSize = NSMakeSize(w, h);
     _designSize = designSize;
     _initialSizeSyncAttempts = 0;
-    NSSize currentSize = self.view.bounds.size;
-    const bool currentUndersized = pulp_auv3_is_undersized(currentSize, designSize);
-    const bool resizeInitialRoot = self.view.window == nil || currentUndersized;
-    if (currentUndersized) {
-        pulp::runtime::log_info("AU mac: expanding undersized initial root {}x{} to design {}x{}",
-                                static_cast<int>(currentSize.width),
-                                static_cast<int>(currentSize.height),
-                                w, h);
+    pulp_auv3_apply_preferred_size(self, designSize, /*resize_view_frame=*/false);
+
+    // Defer PluginViewHost creation until the root view reports a real, settled
+    // host size (see -createViewHostIfReady). Wire the frame-change hook first:
+    // when Logic's OOP host finally sizes our (superview-pinned) view to its
+    // restored window, this fires and builds the GPU host at THAT size — so the
+    // first painted frame is already correct, never the design-size frame Logic
+    // would otherwise composite (clipped) into a smaller window.
+    _pendingRoot = root;
+    _viewHostPending = YES;
+    if ([self.view isKindOfClass:[PulpAUMacRootView class]]) {
+        __unsafe_unretained PulpAUMacViewController *weakSelf = self;
+        ((PulpAUMacRootView *)self.view).onResize = ^{
+            [weakSelf createViewHostIfReady];
+            [weakSelf resizeEditorToViewBounds];
+        };
     }
-    pulp_auv3_apply_preferred_size(self, designSize, resizeInitialRoot);
+
+    // Try immediately (REAPER's in-process path hands us a real size up front)
+    // and start the settle driver as a fallback for hosts that size us late.
+    [self createViewHostIfReady];
+    [self scheduleInitialSizeSync];
+}
+
+// Build the GPU host lazily, at the view's REAL bounds, once the host has
+// settled them. While the bounds still equal the design size we wait (up to the
+// initial-size-sync window) for the host to deliver its possibly-smaller
+// restored size; after that we accept the current size. Creating at the real
+// size is what makes Logic's first paint correct instead of design-sized.
+- (void)createViewHostIfReady {
+    if (!_viewHostPending || !_pendingRoot) return;
+
+    const NSSize b = self.view.bounds.size;
+    if (b.width < 1.0 || b.height < 1.0) return;  // no real layout yet
+
+    const bool boundsMatchDesign =
+        std::abs(b.width - _designSize.width) < 1.0 &&
+        std::abs(b.height - _designSize.height) < 1.0;
+    if (boundsMatchDesign && _initialSizeSyncAttempts < kInitialSizeSyncMaxAttempts) {
+        return;  // keep waiting for the host's settled (likely different) size
+    }
+
+    _viewHostPending = NO;
+
+    const uint32_t w = static_cast<uint32_t>(_designSize.width);
+    const uint32_t h = static_cast<uint32_t>(_designSize.height);
 
     pulp::view::PluginViewHost::Options opts;
-    opts.size = {w, h};
+    opts.size = {std::max(1u, static_cast<uint32_t>(b.width)),
+                 std::max(1u, static_cast<uint32_t>(b.height))};  // REAL host size
     const char *mode = "fallback";
     if (_bridge) {
         const auto gpu = pulp::format::decide_gpu_host(*_bridge);
         opts.use_gpu = gpu.use_gpu;
         mode = gpu.mode;
-        _viewHost = pulp::view::PluginViewHost::create(*root, opts);
+        _viewHost = pulp::view::PluginViewHost::create(*_pendingRoot, opts);
         if (_viewHost) {
             pulp::format::warn_if_unexpected_cpu_fallback(gpu, _viewHost.get());
             _viewHost->set_idle_callback(pulp::format::make_scripted_idle_pump(*_bridge));
-            // Phase iOS-D.3b Slice 1 (cross-platform): hand the host's live
-            // GpuSurface to the scripted-UI session so JS navigator.gpu /
-            // canvas.getContext('webgpu') routes through Pulp's Dawn
-            // instance instead of mocks. See
-            // planning/2026-05-29-ios-d3b-threejs-webgpu-program.md § Slice 1.
+            // Phase iOS-D.3b Slice 1: hand the host's live GpuSurface to the
+            // scripted-UI session so JS navigator.gpu / canvas.getContext(
+            // 'webgpu') routes through Pulp's Dawn instance instead of mocks.
             if (auto* scripted = _bridge->scripted_ui()) {
                 scripted->attach_gpu_surface(_viewHost->gpu_surface());
                 if (_viewHost->gpu_surface()) {
@@ -284,18 +358,16 @@ void pulp_auv3_expand_window_for_view(NSView *view, NSSize design) {
             }
         }
     } else {
-        _viewHost = pulp::view::PluginViewHost::create(*root, opts);
+        _viewHost = pulp::view::PluginViewHost::create(*_pendingRoot, opts);
     }
 
     if (!_viewHost) {
         pulp::runtime::log_error("AU mac: PluginViewHost::create returned null");
+        _viewHostPending = YES;  // allow a later attempt
         return;
     }
 
-    // Phase 3 viewport pin + aspect lock: paint at design size; let the
-    // host size the window. The host receives the *container* size in
-    // resize(), not the design size — PluginViewHost::set_design_viewport
-    // scales the paint/input transform.
+    // Phase 3 viewport pin + aspect lock: paint the design at the host size.
     if (w > 0 && h > 0) {
         _viewHost->set_design_viewport(w, h);
         _viewHost->set_fixed_aspect_ratio(static_cast<float>(w) /
@@ -305,39 +377,39 @@ void pulp_auv3_expand_window_for_view(NSView *view, NSSize design) {
     _viewHost->attach_to_parent((__bridge void *)self.view);
     if (_bridge) _bridge->notify_attached();
 
-    pulp::runtime::log_info("AU mac: editor attached, design={}x{}, mode={}, gpu={}",
+    pulp::runtime::log_info("AU mac: editor attached at {}x{}, design={}x{}, mode={}, gpu={}",
+                            static_cast<int>(b.width), static_cast<int>(b.height),
                             w, h, mode, _viewHost->is_gpu_backed());
 
-    [self scheduleInitialSizeSync];
     [self resizeEditorToViewBounds];
 }
 
 - (void)scheduleInitialSizeSync {
-    if (_initialSizeSyncAttempts >= 3) return;
+    if (_initialSizeSyncAttempts >= kInitialSizeSyncMaxAttempts) return;
     dispatch_async(dispatch_get_main_queue(), ^{
         [self runInitialSizeSync];
     });
 }
 
 - (void)runInitialSizeSync {
-    if (!_viewHost || _designSize.width <= 0.0 || _designSize.height <= 0.0) return;
-    if (_initialSizeSyncAttempts >= 3) return;
-    ++_initialSizeSyncAttempts;
+    if (_designSize.width <= 0.0 || _designSize.height <= 0.0) return;
+    if (_initialSizeSyncAttempts < kInitialSizeSyncMaxAttempts) {
+        ++_initialSizeSyncAttempts;
+    }
 
-    NSSize currentSize = self.view.bounds.size;
-    if (!pulp_auv3_is_undersized(currentSize, _designSize)) return;
+    // Settle driver / fallback for hosts that size us late: builds the deferred
+    // GPU host once the view's bounds settle (or, on the final attempt, at
+    // whatever size we have). We let the host own the window — no forced
+    // window resize here (Codex: forcing Logic's window fights its restore
+    // behavior). Once the host exists, just re-fit the design viewport.
+    [self createViewHostIfReady];
+    if (_viewHost) {
+        [self resizeEditorToViewBounds];
+    }
 
-    pulp::runtime::log_info("AU mac: correcting undersized initial layout {}x{} to design {}x{}",
-                            static_cast<int>(currentSize.width),
-                            static_cast<int>(currentSize.height),
-                            static_cast<int>(_designSize.width),
-                            static_cast<int>(_designSize.height));
-    pulp_auv3_expand_window_for_view(self.view, _designSize);
-    pulp_auv3_apply_preferred_size(self, _designSize, true);
-    [self resizeEditorToViewBounds];
-
-    if (_initialSizeSyncAttempts < 3) {
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 50 * NSEC_PER_MSEC),
+    if (_initialSizeSyncAttempts < kInitialSizeSyncMaxAttempts) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
+                                     kInitialSizeSyncIntervalMs * NSEC_PER_MSEC),
                        dispatch_get_main_queue(), ^{
             [self runInitialSizeSync];
         });
@@ -351,10 +423,21 @@ void pulp_auv3_expand_window_for_view(NSView *view, NSSize design) {
     const uint32_t h = std::max(1u, static_cast<uint32_t>(size.height));
     _viewHost->set_size(w, h);
     if (_bridge) _bridge->resize(w, h);
+    // Force a repaint at the new size. On Logic's first open the GPU surface
+    // paints once at the design size before the superview-pin resolves the view
+    // to Logic's container size; set_size alone updates the logical size but the
+    // stale first frame can persist (clipped) until the host next requests a
+    // redraw (a window reopen or a manual resize). Requesting the repaint here
+    // makes the corrected size show on the first settle.
+    _viewHost->repaint();
 }
 
 - (void)viewDidLayout {
     [super viewDidLayout];
+    // Also a creation trigger: on hosts where viewDidLayout *does* fire with a
+    // real size, build the deferred GPU host here too (idempotent — no-op once
+    // created or while still waiting for a settled size).
+    [self createViewHostIfReady];
     [self resizeEditorToViewBounds];
 }
 
@@ -371,6 +454,12 @@ void pulp_auv3_expand_window_for_view(NSView *view, NSSize design) {
 
 #if !__has_feature(objc_arc)
 - (void)dealloc {
+    // Clear the root view's resize hook FIRST: it captures self unretained and
+    // touches _viewHost (destroyed below, after [super dealloc]), so a stray
+    // setFrameSize: during teardown must not call back into us.
+    if ([self.view isKindOfClass:[PulpAUMacRootView class]]) {
+        ((PulpAUMacRootView *)self.view).onResize = nil;
+    }
     // Same destruction-order contract as au_view_controller_ios.mm:
     // ivars destroy in reverse declaration order after [super dealloc].
     // 1. ~PluginViewHost runs first, clears back-pointer on root_ View.

--- a/core/view/platform/mac/plugin_view_host_mac.mm
+++ b/core/view/platform/mac/plugin_view_host_mac.mm
@@ -958,6 +958,16 @@ private:
     float design_viewport_h_ = 0.0f;
     float fixed_aspect_ratio_ = 0.0f;
 
+    // FIRST-PAINT SIZE matters: the (width,height) this surface is created at
+    // becomes the first painted frame's size. In an out-of-process plugin host
+    // (notably Logic AU v3) the host may NOT have delivered the editor view's
+    // real window size yet at attach time, so creating the surface at the
+    // DESIGN size paints an oversized first frame that the host clips/composites
+    // into a smaller window until a resize/reopen. Callers embedding this host
+    // in such a DAW must defer creation until the view reports a real settled
+    // size and pass THAT as the initial size (see
+    // core/format/src/au_view_controller_mac.mm `-createViewHostIfReady` and
+    // `.agents/skills/auv3/SKILL.md → "Logic OOP first-paint clip"`).
     void init_gpu(float width, float height) {
         gpu_surface_ = render::GpuSurface::create_dawn();
         if (!gpu_surface_) {

--- a/test/test_au_plugin_state.mm
+++ b/test/test_au_plugin_state.mm
@@ -1,6 +1,7 @@
 #import <AudioToolbox/AudioToolbox.h>
 #import <CoreAudioKit/CoreAudioKit.h>
 #import <Foundation/Foundation.h>
+#import <objc/runtime.h>
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
@@ -971,7 +972,23 @@ TEST_CASE("AU v3 per-method audit invariants",
     }
 }
 
-TEST_CASE("AU v3 view configurations prefer aspect-correct editor sizes",
+// Regression guard for the AUv3-in-Logic sizing fix.
+//
+// Pulp deliberately does NOT implement `supportedViewConfigurations:` /
+// `selectViewConfiguration:`. Logic Pro sizes AU v3 editors through the
+// view-configuration path and offers only oversized ~4:3 configs (measured
+// 1024x768 / 1366x1024). The moment an AU returns ANY supported config, Logic
+// locks the editor window to that config's aspect ratio at every size, so a
+// wide fixed-design editor (e.g. 900x520 ≈ 16:9.4) letterboxes with top/bottom
+// bars that can't be resized away. Apple's empty-set semantics ("use the
+// largest available view configuration") make returning empty strictly worse.
+//
+// By NOT overriding these selectors, `respondsToSelector:` returns NO, Logic
+// skips config negotiation entirely, and the editor free-resizes to the
+// design's own aspect — matching the tight, proportional fit Pulp gets in
+// REAPER / CLAP / VST3 / standalone (verified in Logic 2026-05-29). If anyone
+// reintroduces these overrides, this test fails to flag the regression.
+TEST_CASE("AU v3 does not opt into host view configurations (Logic 4:3-lock fix)",
           "[au][auv3][view-config][resize]") {
     @autoreleasepool {
         AudioComponentDescription desc{};
@@ -989,54 +1006,22 @@ TEST_CASE("AU v3 view configurations prefer aspect-correct editor sizes",
         REQUIRE(unit != nil);
         REQUIRE(err == nil);
 
-        NSArray<AUAudioUnitViewConfiguration*>* mixedConfigs = @[
-            [[[AUAudioUnitViewConfiguration alloc] initWithWidth:486
-                                                          height:290
-                                               hostHasController:NO] autorelease],
-            [[[AUAudioUnitViewConfiguration alloc] initWithWidth:1024
-                                                          height:768
-                                               hostHasController:NO] autorelease],
-            [[[AUAudioUnitViewConfiguration alloc] initWithWidth:900
-                                                          height:520
-                                               hostHasController:NO] autorelease],
-            [[[AUAudioUnitViewConfiguration alloc] initWithWidth:1366
-                                                          height:1024
-                                               hostHasController:NO] autorelease],
-        ];
+        // Base AUAudioUnit *does* implement these selectors, so respondsToSelector
+        // is always YES. The regression guard that matters is that PulpAudioUnit
+        // does NOT OVERRIDE them — i.e. its method implementation is the inherited
+        // base one. If someone re-adds an override (reintroducing the Logic
+        // 4:3-lock), the IMP diverges and this fails.
+        IMP pulpSupported = class_getMethodImplementation(
+            [PulpAudioUnit class], @selector(supportedViewConfigurations:));
+        IMP baseSupported = class_getMethodImplementation(
+            [AUAudioUnit class], @selector(supportedViewConfigurations:));
+        REQUIRE(pulpSupported == baseSupported);
 
-        NSIndexSet* supported = [unit supportedViewConfigurations:mixedConfigs];
-        REQUIRE(supported != nil);
-        REQUIRE([supported containsIndex:2]);
-        REQUIRE_FALSE([supported containsIndex:0]);
-        REQUIRE_FALSE([supported containsIndex:1]);
-        REQUIRE_FALSE([supported containsIndex:3]);
-
-        NSArray<AUAudioUnitViewConfiguration*>* noAspectMatchConfigs = @[
-            [[[AUAudioUnitViewConfiguration alloc] initWithWidth:1024
-                                                          height:768
-                                               hostHasController:NO] autorelease],
-            [[[AUAudioUnitViewConfiguration alloc] initWithWidth:1366
-                                                          height:1024
-                                               hostHasController:NO] autorelease],
-        ];
-
-        NSIndexSet* fallback = [unit supportedViewConfigurations:noAspectMatchConfigs];
-        REQUIRE(fallback != nil);
-        REQUIRE([fallback containsIndex:0]);
-        REQUIRE([fallback containsIndex:1]);
-
-        NSArray<AUAudioUnitViewConfiguration*>* undersizedConfigs = @[
-            [[[AUAudioUnitViewConfiguration alloc] initWithWidth:486
-                                                          height:290
-                                               hostHasController:NO] autorelease],
-            [[[AUAudioUnitViewConfiguration alloc] initWithWidth:640
-                                                          height:370
-                                               hostHasController:NO] autorelease],
-        ];
-
-        NSIndexSet* undersized = [unit supportedViewConfigurations:undersizedConfigs];
-        REQUIRE(undersized != nil);
-        REQUIRE(undersized.count == 0u);
+        IMP pulpSelect = class_getMethodImplementation(
+            [PulpAudioUnit class], @selector(selectViewConfiguration:));
+        IMP baseSelect = class_getMethodImplementation(
+            [AUAudioUnit class], @selector(selectViewConfiguration:));
+        REQUIRE(pulpSelect == baseSelect);
 
         [unit release];
     }

--- a/tools/scripts/coverage_config.json
+++ b/tools/scripts/coverage_config.json
@@ -7,6 +7,7 @@
     "**/cg_canvas.mm",
     "**/window_host_mac.mm",
     "**/window_host_ios.mm",
+    "**/au_view_controller_mac.mm",
     "**/sdl_window_host.cpp",
     "**/scanner_clap.cpp",
     "**/cmd_projects.cpp",


### PR DESCRIPTION
After dropping the view-config opt-in, Logic stopped letterboxing but the
editor's FIRST paint still clipped: the UI rendered at the design size inside
Logic's restored (smaller) window until a manual resize or window reopen.

Root cause (verified in Logic 2026-05-29): Logic hosts AU v3 out-of-process and
does NOT push its restored window size to the extension's view on initial open
(not via viewDidLayout, setFrameSize:, or a bounds poll). It leaves our view at
the design-size loadView frame and composites that oversized layer into its
smaller window. The GPU surface, created at attach with opts.size=design, paints
once oversized and the stale frame persists until the host next redraws.

Fix: defer PluginViewHost / GPU-surface creation until the root view reports a
real, settled host size, then create at THAT size and set_design_viewport(design)
so the first painted frame is already correct.

- PulpAUMacRootView (NSView): overrides setFrameSize: (onResize hook) and pins
  itself to its superview's edges in viewDidMoveToSuperview, so AppKit sizes it
  to Logic's container on embed + every resize (Apple AUv3-sample approach).
- rebuildEditorIfReady defers creation (no host, no forced view frame); wires
  onResize; stores _viewHostPending/_pendingRoot.
- createViewHostIfReady builds at the view's real bounds, waiting (settle window)
  while bounds still equal design for the host's likely-different size; driven
  from onResize, viewDidLayout, and the runInitialSizeSync fallback.
- Removed the host-window-forcing path (Codex: forcing Logic's window fights its
  restore); clear onResize first in dealloc (captures self unretained + uses
  _viewHost).

Verified live in Logic: first open now fits tight, no clip, no bars. REAPER/CLAP/
VST3/standalone unaffected. Behavior is host-integration (real AU host) — no
headless unit test; covered by the in-DAW verification + auv3 SKILL.

Ref: planning/2026-05-29-chainer-auv3-logic-sizing-rootcause.md