### PR TITLE
refactor(frontend-ir): model one-to-many native bindings explicitly (#3125)

### DIFF
--- a/tools/scripts/frontend_ir_codegen_artifact_gate.py
+++ b/tools/scripts/frontend_ir_codegen_artifact_gate.py
@@ -19,6 +19,9 @@ NOT_READY_VERDICT = "not_ready"
 CODEGEN_ARTIFACT_SCHEMA = SCHEMAS["codegen_artifacts"]
 GATE_SCHEMA = SCHEMAS["codegen_artifact_gate"]
 NATIVE_CPP_ROUTE = "native_cpp"
+PROVENANCE_EXPLICIT = "explicit_source_route_id"
+PROVENANCE_PREFIX = "id_prefix"
+SPLIT_PROVENANCE_VALUES = {PROVENANCE_EXPLICIT, PROVENANCE_PREFIX}
 
 
 def check(check_id: str, status: str, message: str, **details: Any) -> dict[str, Any]:
@@ -86,6 +89,61 @@ def validate_codegen_artifacts(report: dict[str, Any]) -> None:
     if summary["directly_bound_native_routes"] + summary["missing_native_route_bindings"] != summary["native_cpp_routes"]:
         raise ValueError("summary.directly_bound_native_routes plus summary.missing_native_route_bindings must equal summary.native_cpp_routes")
 
+    # Optional one-to-many provenance breakdown (explicit_source_route_id vs
+    # id_prefix). When present, validate the per-row shape and that the two
+    # provenance counts partition split_binding_candidates.
+    has_explicit_count = "explicit_split_bindings" in summary
+    has_prefix_count = "prefix_split_bindings" in summary
+    if has_explicit_count != has_prefix_count:
+        raise ValueError(
+            "summary.explicit_split_bindings and summary.prefix_split_bindings must both be present or both absent"
+        )
+    for key in ("explicit_split_bindings", "prefix_split_bindings"):
+        if key in summary and (
+            not isinstance(summary.get(key), int)
+            or isinstance(summary.get(key), bool)
+            or summary[key] < 0
+        ):
+            raise ValueError(f"summary.{key} must be a non-negative integer")
+
+    explicit_rows = 0
+    prefix_rows = 0
+    for row in report["split_binding_candidates"]:
+        if not isinstance(row, dict):
+            raise ValueError("split_binding_candidates entries must be objects")
+        provenance = row.get("provenance")
+        if provenance is not None:
+            if provenance not in SPLIT_PROVENANCE_VALUES:
+                raise ValueError(
+                    "split_binding_candidates.provenance must be one of "
+                    f"{sorted(SPLIT_PROVENANCE_VALUES)}"
+                )
+            if provenance == PROVENANCE_EXPLICIT:
+                explicit_rows += 1
+            else:
+                prefix_rows += 1
+        parts = row.get("parts")
+        if parts is not None:
+            if not isinstance(parts, list):
+                raise ValueError("split_binding_candidates.parts must be an array")
+            for part in parts:
+                if not isinstance(part, dict):
+                    raise ValueError("split_binding_candidates.parts entries must be objects")
+
+    if has_explicit_count:
+        if summary["explicit_split_bindings"] != explicit_rows:
+            raise ValueError(
+                "summary.explicit_split_bindings must match the count of explicit_source_route_id split candidates"
+            )
+        if summary["prefix_split_bindings"] != prefix_rows:
+            raise ValueError(
+                "summary.prefix_split_bindings must match the count of id_prefix split candidates"
+            )
+        if summary["explicit_split_bindings"] + summary["prefix_split_bindings"] != summary["split_binding_candidates"]:
+            raise ValueError(
+                "summary.explicit_split_bindings plus summary.prefix_split_bindings must equal summary.split_binding_candidates"
+            )
+
 
 def split_route_ids(report: dict[str, Any]) -> set[str]:
     ids: set[str] = set()
@@ -97,6 +155,18 @@ def split_route_ids(report: dict[str, Any]) -> set[str]:
         if isinstance(route_id, str) and route_id and isinstance(bindings, list) and bindings:
             ids.add(route_id)
     return ids
+
+
+def split_candidate_rows(report: dict[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for row in as_list(report.get("split_binding_candidates")):
+        if not isinstance(row, dict):
+            continue
+        route_id = row.get("route_id")
+        bindings = row.get("binding_entry_ids")
+        if isinstance(route_id, str) and route_id and isinstance(bindings, list) and bindings:
+            rows.append(row)
+    return rows
 
 
 def coverage_checks(report: dict[str, Any]) -> list[dict[str, Any]]:
@@ -149,6 +219,67 @@ def coverage_checks(report: dict[str, Any]) -> list[dict[str, Any]]:
             "unaccounted_native_route_bindings",
             PASS_STATUS,
             "all missing direct native route bindings are accounted for",
+        ))
+
+    split_rows = split_candidate_rows(report)
+    extra_entry_set = set(extra_entries)
+    explicit_rows = [row for row in split_rows if row.get("provenance") == PROVENANCE_EXPLICIT]
+    prefix_only_rows = [row for row in split_rows if row.get("provenance") == PROVENANCE_PREFIX]
+
+    # explicit_one_to_many_bindings: every binding id named by an explicit
+    # parent-child link must be a real generated sub-binding (present in
+    # extra_binding_entries). A phantom reference means a broken parent-child
+    # link and fails the gate.
+    broken_links: list[dict[str, Any]] = []
+    for row in explicit_rows:
+        missing_children = [
+            entry_id
+            for entry_id in as_list(row.get("binding_entry_ids"))
+            if isinstance(entry_id, str) and entry_id not in extra_entry_set
+        ]
+        if missing_children:
+            broken_links.append({
+                "route_id": row.get("route_id"),
+                "missing_binding_entry_ids": missing_children,
+            })
+    if broken_links:
+        checks.append(check(
+            "explicit_one_to_many_bindings",
+            FAIL_STATUS,
+            "explicit one-to-many bindings reference binding ids not present in generated sub-bindings",
+            broken_links=broken_links,
+        ))
+    elif explicit_rows:
+        checks.append(check(
+            "explicit_one_to_many_bindings",
+            PASS_STATUS,
+            "all explicit one-to-many bindings reference real generated sub-bindings",
+            explicit_split_bindings=len(explicit_rows),
+        ))
+    else:
+        checks.append(check(
+            "explicit_one_to_many_bindings",
+            PASS_STATUS,
+            "no explicit one-to-many bindings",
+        ))
+
+    # prefix_only_split_bindings: surface (but do not fail) missing routes that
+    # are accounted for ONLY by id-prefix convention, to encourage migration to
+    # explicit source_route_id modeling.
+    if prefix_only_rows:
+        checks.append(check(
+            "prefix_only_split_bindings",
+            WARN_STATUS,
+            "some native C++ routes are accounted for only by id-prefix convention; prefer explicit source_route_id",
+            route_ids=sorted(
+                str(row.get("route_id")) for row in prefix_only_rows if row.get("route_id")
+            ),
+        ))
+    else:
+        checks.append(check(
+            "prefix_only_split_bindings",
+            PASS_STATUS,
+            "no prefix-only split bindings",
         ))
 
     if direct_routes < native_routes:

--- a/tools/scripts/frontend_ir_codegen_artifacts.py
+++ b/tools/scripts/frontend_ir_codegen_artifacts.py
@@ -82,15 +82,81 @@ def count_by(entries: list[dict[str, Any]], key: str) -> dict[str, int]:
     return dict(sorted(counts.items()))
 
 
-def split_candidates(missing_routes: set[str], entries: set[str]) -> list[dict[str, Any]]:
-    candidates = []
+PROVENANCE_EXPLICIT = "explicit_source_route_id"
+PROVENANCE_PREFIX = "id_prefix"
+SPLIT_PART_KEYS = ("channel", "axis", "part")
+
+
+def split_candidates(
+    missing_routes: set[str],
+    extra_entries: set[str],
+    entries: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Determine the split bindings for each missing native route.
+
+    A single source native route can map to multiple generated native
+    bindings (one-to-many). This is modeled two ways, explicit-preferred:
+
+    * Explicit: binding manifest entries that carry ``source_route_id ==
+      route_id``. When present, that is the authoritative parent-child link
+      and the candidate is tagged ``provenance=explicit_source_route_id``.
+      Split metadata (``channel`` / ``axis`` / ``part``) carried on those
+      entries is surfaced via a ``parts`` list so the split structure is
+      reviewable.
+    * Prefix fallback: otherwise, entries whose id starts with
+      ``route_id + "."`` (the historical string convention). Tagged
+      ``provenance=id_prefix`` so callers can encourage migration.
+
+    Only "extra" entries (sub-bindings not claimed by their own native
+    route) are eligible, so an entry that directly binds a *different* route
+    can never account for an unrelated unbound route via prefix collision.
+    """
+    entries = entries or []
+    # Index extra entries by id so explicit metadata can be looked up while
+    # still constraining candidates to the eligible (extra) id set.
+    extra_by_id = {
+        entry.get("id"): entry
+        for entry in entries
+        if isinstance(entry.get("id"), str) and entry.get("id") in extra_entries
+    }
+    # Group eligible extra entries by their explicit parent route, when set.
+    explicit_children: dict[str, list[str]] = {}
+    for entry_id, entry in extra_by_id.items():
+        source_route_id = entry.get("source_route_id")
+        if isinstance(source_route_id, str) and source_route_id:
+            explicit_children.setdefault(source_route_id, []).append(entry_id)
+
+    candidates: list[dict[str, Any]] = []
     for route_id in sorted(missing_routes):
+        explicit_ids = sorted(explicit_children.get(route_id, []))
+        if explicit_ids:
+            candidate: dict[str, Any] = {
+                "route_id": route_id,
+                "binding_entry_ids": explicit_ids,
+                "provenance": PROVENANCE_EXPLICIT,
+            }
+            parts = []
+            for entry_id in explicit_ids:
+                entry = extra_by_id.get(entry_id, {})
+                part: dict[str, Any] = {"binding_entry_id": entry_id}
+                for key in SPLIT_PART_KEYS:
+                    value = entry.get(key)
+                    if isinstance(value, str) and value:
+                        part[key] = value
+                parts.append(part)
+            # Only emit parts when at least one child carries split metadata.
+            if any(len(part) > 1 for part in parts):
+                candidate["parts"] = parts
+            candidates.append(candidate)
+            continue
+
         prefix = route_id + "."
-        split = sorted(entry_id for entry_id in entries if entry_id.startswith(prefix))
+        split = sorted(entry_id for entry_id in extra_entries if entry_id.startswith(prefix))
         if split:
             candidates.append({
                 "route_id": route_id,
                 "binding_entry_ids": split,
+                "provenance": PROVENANCE_PREFIX,
             })
     return candidates
 
@@ -116,7 +182,13 @@ def build_codegen_artifact_report(
     # that directly binds a *different* route (e.g. "foo.label") account for an
     # unrelated unbound route "foo" purely on a string-prefix collision,
     # downgrading a real binding hole from FAIL to WARN.
-    splits = split_candidates(missing, extra)
+    splits = split_candidates(missing, extra, entries)
+    explicit_split_count = sum(
+        1 for s in splits if s.get("provenance") == PROVENANCE_EXPLICIT
+    )
+    prefix_split_count = sum(
+        1 for s in splits if s.get("provenance") == PROVENANCE_PREFIX
+    )
 
     return {
         "schema": SCHEMA,
@@ -139,6 +211,8 @@ def build_codegen_artifact_report(
             "missing_native_route_bindings": len(missing),
             "extra_binding_entries": len(extra),
             "split_binding_candidates": len(splits),
+            "explicit_split_bindings": explicit_split_count,
+            "prefix_split_bindings": prefix_split_count,
             "binding_primitives": count_by(entries, "native_primitive"),
             "binding_route_types": count_by(entries, "route_type"),
         },

--- a/tools/scripts/test_frontend_ir_codegen_artifact_gate.py
+++ b/tools/scripts/test_frontend_ir_codegen_artifact_gate.py
@@ -54,9 +54,29 @@ def sample_report() -> dict:
             {
                 "route_id": "panel.meter.out",
                 "binding_entry_ids": ["panel.meter.out.left", "panel.meter.out.right"],
+                "provenance": "id_prefix",
             }
         ],
     }
+
+
+def explicit_report() -> dict:
+    """A report where the meter split is modeled explicitly via source_route_id."""
+    report = sample_report()
+    report["summary"]["explicit_split_bindings"] = 1
+    report["summary"]["prefix_split_bindings"] = 0
+    report["split_binding_candidates"] = [
+        {
+            "route_id": "panel.meter.out",
+            "binding_entry_ids": ["panel.meter.out.left", "panel.meter.out.right"],
+            "provenance": "explicit_source_route_id",
+            "parts": [
+                {"binding_entry_id": "panel.meter.out.left", "channel": "left"},
+                {"binding_entry_id": "panel.meter.out.right", "channel": "right"},
+            ],
+        }
+    ]
+    return report
 
 
 class FrontendIrCodegenArtifactGateTests(unittest.TestCase):
@@ -69,6 +89,70 @@ class FrontendIrCodegenArtifactGateTests(unittest.TestCase):
         warnings = {item["id"] for item in gate["checks"] if item["status"] == "warn"}
         self.assertIn("direct_binding_coverage", warnings)
         self.assertIn("extra_binding_entries", warnings)
+        # Prefix-accounted split surfaces the migration warning but stays ready.
+        self.assertIn("prefix_only_split_bindings", warnings)
+        by_id = {item["id"]: item for item in gate["checks"]}
+        self.assertEqual(by_id["explicit_one_to_many_bindings"]["status"], "pass")
+        self.assertIn("no explicit", by_id["explicit_one_to_many_bindings"]["message"])
+
+    def test_explicit_one_to_many_meter_is_ready_without_prefix_warn(self) -> None:
+        gate = codegen_gate.gate_codegen_artifacts(explicit_report())
+
+        self.assertEqual(gate["verdict"], "ready")
+        self.assertEqual(gate["summary"]["failures"], 0)
+        by_id = {item["id"]: item for item in gate["checks"]}
+        self.assertEqual(by_id["explicit_one_to_many_bindings"]["status"], "pass")
+        self.assertEqual(by_id["prefix_only_split_bindings"]["status"], "pass")
+
+    def test_explicit_xy_axis_split_is_ready(self) -> None:
+        report = sample_report()
+        report["missing_native_route_bindings"] = ["panel.xy.pan"]
+        report["extra_binding_entries"] = ["panel.xy.pan.x", "panel.xy.pan.y"]
+        report["summary"]["explicit_split_bindings"] = 1
+        report["summary"]["prefix_split_bindings"] = 0
+        report["split_binding_candidates"] = [
+            {
+                "route_id": "panel.xy.pan",
+                "binding_entry_ids": ["panel.xy.pan.x", "panel.xy.pan.y"],
+                "provenance": "explicit_source_route_id",
+                "parts": [
+                    {"binding_entry_id": "panel.xy.pan.x", "axis": "x"},
+                    {"binding_entry_id": "panel.xy.pan.y", "axis": "y"},
+                ],
+            }
+        ]
+
+        gate = codegen_gate.gate_codegen_artifacts(report)
+
+        self.assertEqual(gate["verdict"], "ready")
+        by_id = {item["id"]: item for item in gate["checks"]}
+        self.assertEqual(by_id["explicit_one_to_many_bindings"]["status"], "pass")
+        self.assertEqual(by_id["prefix_only_split_bindings"]["status"], "pass")
+
+    def test_broken_explicit_link_fails(self) -> None:
+        report = explicit_report()
+        # The explicit candidate references a binding id that does not exist in
+        # the generated sub-bindings.
+        report["extra_binding_entries"] = ["panel.meter.out.left"]
+        report["summary"]["extra_binding_entries"] = 1
+
+        gate = codegen_gate.gate_codegen_artifacts(report)
+
+        self.assertEqual(gate["verdict"], "not_ready")
+        failures = {item["id"] for item in gate["checks"] if item["status"] == "fail"}
+        self.assertIn("explicit_one_to_many_bindings", failures)
+
+    def test_provenance_count_mismatch_fails_schema_validation(self) -> None:
+        report = explicit_report()
+        report["summary"]["explicit_split_bindings"] = 0
+        report["summary"]["prefix_split_bindings"] = 0
+
+        gate = codegen_gate.gate_codegen_artifacts(report)
+
+        self.assertEqual(gate["verdict"], "not_ready")
+        failures = [item for item in gate["checks"] if item["status"] == "fail"]
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(failures[0]["id"], "schema_valid")
 
     def test_unaccounted_missing_route_fails(self) -> None:
         report = sample_report()

--- a/tools/scripts/test_frontend_ir_codegen_artifacts.py
+++ b/tools/scripts/test_frontend_ir_codegen_artifacts.py
@@ -55,6 +55,27 @@ def sample_binding_manifest() -> dict:
 
 
 class FrontendIrCodegenArtifactTests(unittest.TestCase):
+    def _build_report(self, frontend_ir: dict, manifest: dict) -> dict:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            frontend_ir_path = root / "frontend-ir.json"
+            source_cpp = root / "generated.cpp"
+            header = root / "generated.hpp"
+            binding_manifest = root / "generated.bindings.json"
+            frontend_ir_path.write_text(json.dumps(frontend_ir), encoding="utf-8")
+            source_cpp.write_text("// cpp\n", encoding="utf-8")
+            header.write_text("// hpp\n", encoding="utf-8")
+            binding_manifest.write_text(json.dumps(manifest), encoding="utf-8")
+            return codegen_artifacts.build_codegen_artifact_report(
+                frontend_ir,
+                manifest,
+                frontend_ir_path=frontend_ir_path,
+                source_cpp=source_cpp,
+                header=header,
+                binding_manifest_path=binding_manifest,
+                repo_root=root,
+            )
+
     def test_builds_codegen_artifact_report(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = pathlib.Path(td)
@@ -88,6 +109,12 @@ class FrontendIrCodegenArtifactTests(unittest.TestCase):
         self.assertEqual(report["missing_native_route_bindings"], ["panel.meter.out"])
         self.assertEqual(report["extra_binding_entries"], ["panel.meter.out.left", "panel.meter.out.right"])
         self.assertEqual(report["split_binding_candidates"][0]["route_id"], "panel.meter.out")
+        # Default fixture has no source_route_id, so the split is inferred by the
+        # historical id-prefix convention.
+        self.assertEqual(report["split_binding_candidates"][0]["provenance"], "id_prefix")
+        self.assertNotIn("parts", report["split_binding_candidates"][0])
+        self.assertEqual(report["summary"]["explicit_split_bindings"], 0)
+        self.assertEqual(report["summary"]["prefix_split_bindings"], 1)
         self.assertEqual(report["summary"]["binding_primitives"], {"knob": 1, "meter": 2})
 
     def test_cli_writes_codegen_artifact_report(self) -> None:
@@ -122,6 +149,96 @@ class FrontendIrCodegenArtifactTests(unittest.TestCase):
             written = json.loads(output.read_text(encoding="utf-8"))
             self.assertEqual(written["frontend_ir"]["path"], "frontend-ir.json")
             self.assertEqual(written["artifacts"]["source_cpp"]["byte_size"], 7)
+
+    def test_explicit_source_route_id_split_is_modeled(self) -> None:
+        frontend_ir = sample_frontend_ir()
+        manifest = {
+            "schema": "pulp-native-cpp-binding-manifest-v1",
+            "entries": [
+                {
+                    "id": "panel.knob.freq",
+                    "native_primitive": "knob",
+                    "route_type": "native_cpp",
+                },
+                {
+                    "id": "panel.meter.out.left",
+                    "native_primitive": "meter",
+                    "route_type": "native_cpp",
+                    "source_route_id": "panel.meter.out",
+                    "channel": "left",
+                },
+                {
+                    "id": "panel.meter.out.right",
+                    "native_primitive": "meter",
+                    "route_type": "native_cpp",
+                    "source_route_id": "panel.meter.out",
+                    "channel": "right",
+                },
+            ],
+        }
+
+        report = self._build_report(frontend_ir, manifest)
+
+        candidate = report["split_binding_candidates"][0]
+        self.assertEqual(candidate["route_id"], "panel.meter.out")
+        self.assertEqual(candidate["provenance"], "explicit_source_route_id")
+        self.assertEqual(
+            candidate["binding_entry_ids"],
+            ["panel.meter.out.left", "panel.meter.out.right"],
+        )
+        self.assertEqual(
+            candidate["parts"],
+            [
+                {"binding_entry_id": "panel.meter.out.left", "channel": "left"},
+                {"binding_entry_id": "panel.meter.out.right", "channel": "right"},
+            ],
+        )
+        self.assertEqual(report["summary"]["explicit_split_bindings"], 1)
+        self.assertEqual(report["summary"]["prefix_split_bindings"], 0)
+        self.assertEqual(report["summary"]["split_binding_candidates"], 1)
+
+    def test_explicit_xy_axis_split_is_modeled(self) -> None:
+        frontend_ir = {
+            "schema": "pulp-frontend-ir-v0",
+            "fixture_id": "panel",
+            "routes": [
+                {"node_id": "panel.xy.pan", "chosen_route": "native_cpp"},
+            ],
+        }
+        manifest = {
+            "schema": "pulp-native-cpp-binding-manifest-v1",
+            "entries": [
+                {
+                    "id": "panel.xy.pan.x",
+                    "native_primitive": "xy_pad",
+                    "route_type": "native_cpp",
+                    "source_route_id": "panel.xy.pan",
+                    "axis": "x",
+                },
+                {
+                    "id": "panel.xy.pan.y",
+                    "native_primitive": "xy_pad",
+                    "route_type": "native_cpp",
+                    "source_route_id": "panel.xy.pan",
+                    "axis": "y",
+                },
+            ],
+        }
+
+        report = self._build_report(frontend_ir, manifest)
+
+        candidate = report["split_binding_candidates"][0]
+        self.assertEqual(candidate["route_id"], "panel.xy.pan")
+        self.assertEqual(candidate["provenance"], "explicit_source_route_id")
+        self.assertEqual(
+            candidate["parts"],
+            [
+                {"binding_entry_id": "panel.xy.pan.x", "axis": "x"},
+                {"binding_entry_id": "panel.xy.pan.y", "axis": "y"},
+            ],
+        )
+        self.assertEqual(report["summary"]["explicit_split_bindings"], 1)
+        self.assertEqual(report["summary"]["prefix_split_bindings"], 0)
 
     def test_rejects_unexpected_binding_manifest_schema(self) -> None:
         with self.assertRaisesRegex(ValueError, "binding manifest schema"):


### PR DESCRIPTION
## What
Model one-to-many native import bindings **explicitly** instead of by string-prefix
inference. Closes #3125.

One source native route can map to multiple generated native bindings (e.g.
`chainer.meter.0.output` → `…output.left` / `…output.right`). Previously the codegen
artifact gate accounted for this by recognizing a string-PREFIX split candidate; this
PR adds an explicit parent-child model while keeping prefix as a fallback (first pass —
no generator rewrites, nothing regresses).

### Changes (`tools/scripts/`)
- **`frontend_ir_codegen_artifacts.py`** — binding entries may carry optional
  `source_route_id` + split metadata (`channel`/`axis`/`part`). `split_candidates`
  resolves **explicit-first** (entries with `source_route_id == route_id`), prefix
  fallback otherwise. Each candidate records `provenance`
  (`explicit_source_route_id` | `id_prefix`) + a `parts` list when metadata is
  present. New `summary.explicit_split_bindings` / `summary.prefix_split_bindings`
  partition the existing `split_binding_candidates` total.
- **`frontend_ir_codegen_artifact_gate.py`** — new checks:
  `explicit_one_to_many_bindings` (FAIL if an explicit candidate references a binding
  id not present in generated sub-bindings — a broken parent-child link; PASS
  otherwise) and `prefix_only_split_bindings` (WARN, not fail — surfaces routes
  accounted for only by prefix convention to encourage migration). Unaccounted
  missing routes still FAIL. Explicit one-to-many → ready.

## Verification
- Tests ship with it: 6 new cases (explicit output-meter one-to-many; a second
  multi-part axis shape; prefix-only fallback still ready+WARN; broken explicit link
  → FAIL/not_ready; unaccounted → FAIL preserved). Full suite green:
  `python3 -m unittest discover -s tools/scripts -p 'test_frontend_ir*.py'` → 90 passed.
- No C++ generator changes; live runtime fallback intact; prefix path preserved.

## Acceptance criteria (#3125)
- [x] Binding manifests can represent one→many without id-prefix inference
- [x] Gate fails unaccounted native route gaps, passes explicit one-to-many mappings
- [x] Tests cover output meters + a second multi-part control shape
- [x] Keeps live runtime fallback; no broad generator rewrites in the first pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)