### PR TITLE
feat(figma-import): Phase 3 — Pulp library component recognition + Knob library key wired

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.137.0",
+      "version": "0.137.1",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.137.0"
+  "version": "0.137.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.137.0",
+  "version": "0.137.1",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.282.1
+    VERSION 0.282.2
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 #include <pulp/state/store.hpp>
 #include <pulp/view/anchor_strategy.hpp>
 #include <pulp/view/design_import.hpp>
@@ -2673,4 +2674,93 @@ TEST_CASE("generate_pulp_js bridge_native_js mode covers fill-height and leaf fa
     REQUIRE(js.find("setFlex('root', 'flex_grow', 1)") != std::string::npos);
     REQUIRE(js.find("createRow('empty_divider0', 'root')") != std::string::npos);
     REQUIRE(js.find("setFlex('empty_divider0', 'height', 1)") != std::string::npos);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Phase 3 — Pulp Library component recognition (figma-plugin lane).
+//
+// The TypeScript extractor (tools/figma-plugin/src/extract.ts) matches an
+// INSTANCE node's `component_set_key` against `library-manifest.json`. When
+// matched, it stamps `library_widget_kind` and lifts the instance's structured
+// component properties to the JSON envelope's node root:
+//   audio_widget=<kind>, label, min, max, default, attributes.{units,binding}
+// design_ir_json.cpp::parse_ir_node maps these to IRNode.audio_widget /
+// audio_label / audio_min / audio_max / audio_default and the attributes map.
+//
+// This test pins that contract — without it the figma-plugin extractor and
+// design_import.cpp parser can drift apart silently.
+TEST_CASE("parse_figma_plugin_json maps Phase 3 Pulp / Knob envelope onto IR widget",
+          "[view][import][figma-plugin][phase-3]") {
+    // Envelope shape mirrors what tools/figma-plugin/src/serialize.ts emits
+    // for an instance of the Pulp / Knob component-set (the file authored
+    // in Phase 0 at https://www.figma.com/design/vxW6btjzQtc4t9ITLNjev0/Pulp-Library).
+    const std::string envelope = R"JSON({
+        "format_version": "v1",
+        "parser_version": "0.1.0",
+        "compat_schema_version": "v1",
+        "provenance": {
+            "adapter": "figma-plugin",
+            "version": "0.1.0",
+            "source_uri": "figma://design/vxW6btjzQtc4t9ITLNjev0/Pulp-Library"
+        },
+        "root": {
+            "type": "frame",
+            "name": "VolumeKnob",
+            "audio_widget": "knob",
+            "label": "Cutoff",
+            "min": 20,
+            "max": 20000,
+            "default": 880,
+            "attributes": {
+                "units": "Hz",
+                "binding": "filter.cutoff_hz"
+            },
+            "style": { "width": 56, "height": 56 },
+            "layout": { "direction": "column" },
+            "children": []
+        }
+    })JSON";
+
+    auto ir = parse_figma_plugin_json(envelope);
+    REQUIRE(ir.source == DesignSource::figma_plugin);
+    REQUIRE(ir.root.audio_widget == AudioWidgetType::knob);
+    REQUIRE(ir.root.audio_label == "Cutoff");
+    REQUIRE(ir.root.audio_min == Catch::Approx(20.0f));
+    REQUIRE(ir.root.audio_max == Catch::Approx(20000.0f));
+    REQUIRE(ir.root.audio_default == Catch::Approx(880.0f));
+    REQUIRE(ir.root.attributes.at("units") == "Hz");
+    REQUIRE(ir.root.attributes.at("binding") == "filter.cutoff_hz");
+}
+
+TEST_CASE("parse_figma_plugin_json handles a Phase 3 knob without optional units",
+          "[view][import][figma-plugin][phase-3]") {
+    // An instance can leave `units` empty (the Pulp / Knob default is an
+    // empty string). The extractor SHOULD omit empty units; check that the
+    // parser still maps the rest of the envelope correctly without it.
+    const std::string envelope = R"JSON({
+        "format_version": "v1",
+        "parser_version": "0.1.0",
+        "compat_schema_version": "v1",
+        "root": {
+            "type": "frame",
+            "name": "Mix",
+            "audio_widget": "knob",
+            "label": "Mix",
+            "min": 0,
+            "max": 1,
+            "default": 0.5,
+            "attributes": { "binding": "param.mix" },
+            "style": { "width": 32, "height": 32 },
+            "children": []
+        }
+    })JSON";
+
+    auto ir = parse_figma_plugin_json(envelope);
+    REQUIRE(ir.root.audio_widget == AudioWidgetType::knob);
+    REQUIRE(ir.root.audio_label == "Mix");
+    REQUIRE(ir.root.audio_min == Catch::Approx(0.0f));
+    REQUIRE(ir.root.audio_max == Catch::Approx(1.0f));
+    REQUIRE(ir.root.audio_default == Catch::Approx(0.5f));
+    REQUIRE(ir.root.attributes.at("binding") == "param.mix");
+    REQUIRE(ir.root.attributes.count("units") == 0);
 }

--- a/tools/figma-plugin/library-manifest.json
+++ b/tools/figma-plugin/library-manifest.json
@@ -1,11 +1,12 @@
 {
   "library_version": "0.1.0",
-  "library_file_url": "https://www.figma.com/community/file/PENDING-Pulp-library-publish",
+  "library_file_key": "vxW6btjzQtc4t9ITLNjev0",
+  "library_file_url": "https://www.figma.com/design/vxW6btjzQtc4t9ITLNjev0/Pulp-Library",
   "required_plugin_version": ">=0.1.0",
   "widgets": {
     "knob": {
-      "_note": "component_set_key gets filled in by hand AFTER the Pulp Figma library file is built and we read the key via the plugin or the REST API. Until then, the plugin treats Pulp / Knob name-prefix matches as a fallback recognition path.",
-      "component_set_key": "TBD-paste-after-library-publish",
+      "component_set_key": "f74264ffa9108521fb0d3398dc8f5ea88e23a84e",
+      "component_set_node_id": "3:74",
       "name_prefix": "Pulp / Knob",
       "supported_property_definitions": ["label", "value", "min", "max", "units", "binding"],
       "supported_variant_axes": ["size", "state"],

--- a/tools/figma-plugin/src/code.tsconfig.json
+++ b/tools/figma-plugin/src/code.tsconfig.json
@@ -10,7 +10,8 @@
     "lib": ["es2019", "webworker"],
     "types": ["@figma/plugin-typings"],
     "noEmit": true,
-    "rootDir": "."
+    "resolveJsonModule": true,
+    "rootDir": ".."
   },
-  "include": ["code.ts", "types.ts", "extract.ts", "extract-model.ts", "serialize.ts", "assets.ts", "tokens.ts"]
+  "include": ["code.ts", "types.ts", "extract.ts", "extract-model.ts", "serialize.ts", "assets.ts", "tokens.ts", "library-registry.ts", "../library-manifest.json"]
 }

--- a/tools/figma-plugin/src/extract-model.ts
+++ b/tools/figma-plugin/src/extract-model.ts
@@ -47,6 +47,18 @@ export interface ExtractedFigmaNode {
   library_widget_kind?: AudioWidgetKind;
   library_version?: string;
 
+  // Structured audio-widget properties (Phase 3). Populated when a Pulp
+  // library widget is recognised; carried into the JSON envelope at the
+  // node root so design_import.cpp::parse_ir_node maps them onto
+  // IRNode.audio_label / audio_min / audio_max / audio_default and the
+  // attributes map (units, binding).
+  audio_label?: string;
+  audio_min?: number;
+  audio_max?: number;
+  audio_default?: number;
+  audio_units?: string;
+  audio_binding?: string;
+
   children: ExtractedFigmaNode[];
 }
 

--- a/tools/figma-plugin/src/extract.ts
+++ b/tools/figma-plugin/src/extract.ts
@@ -19,6 +19,11 @@ import type {
 } from "./extract-model";
 import { AssetCache } from "./assets";
 import { extractTokens, type ExtractedTokens } from "./tokens";
+import {
+  widgetKindByLibraryKey,
+  widgetKindByNamePrefix,
+  LIBRARY_VERSION,
+} from "./library-registry";
 
 // ──────────────────────────────────────────────────────────────────────────
 // Public entry point
@@ -190,17 +195,46 @@ async function walk(
   if (node.type === "INSTANCE") {
     await captureInstanceMetadata(node as InstanceNode, ex, ctx);
 
-    // Track A2 — audio-widget instances export as a single PNG so the
-    // import lane can attach them as a sprite-strip skin via the A1
-    // setKnobSpriteStrip bridge. The native widget keeps full
-    // interactivity; the PNG provides Figma-quality visual fidelity.
-    // Detection is conservative (name-based) and ONLY fires for INSTANCE
-    // nodes whose main-component name maps to a known audio-widget kind.
-    // Non-audio instances continue to walk their child structure as
-    // normal.
-    const widgetKind = audioWidgetKindFromName(
-      ex.main_component_name ?? node.name,
-    );
+    // Phase 3 — Pulp Library component recognition.
+    //
+    // Recognition order:
+    //   1. Authoritative key-based match: ex.component_key matches a
+    //      Pulp-library component_set_key from library-manifest.json.
+    //      This is the canonical Phase 3 path — designs that pulled in
+    //      the published Pulp library hit this regardless of layer name.
+    //   2. Name-prefix fallback: name starts with a manifest-registered
+    //      prefix (e.g. "Pulp / Knob"). Lets designs use the convention
+    //      without depending on the published library file.
+    //   3. Permissive name match: the broader audioWidgetKindFromName()
+    //      heuristic ("knob" / "fader" / "meter" appearing anywhere in
+    //      the name) — preserves pre-Phase-3 behaviour for sprite-strip
+    //      detection on ad-hoc designs.
+    //
+    // The first match wins. When a library or prefix match fires we
+    // also stamp ex.library_version so the importer can tell apart
+    // "real published library" instances from heuristic detections.
+    let widgetKind = widgetKindByLibraryKey(ex.component_key);
+    if (widgetKind) {
+      ex.library_version = LIBRARY_VERSION;
+    } else {
+      widgetKind = widgetKindByNamePrefix(ex.main_component_name ?? node.name);
+      if (widgetKind) {
+        ex.library_version = LIBRARY_VERSION;
+      } else {
+        widgetKind = audioWidgetKindFromName(
+          ex.main_component_name ?? node.name,
+        );
+      }
+    }
+
+    // When recognised, extract the structured property values (label /
+    // min / max / value / units / binding) from componentProperties so
+    // the downstream serializer can emit them at the IR node root for
+    // design_import.cpp::parse_ir_node to pick up.
+    if (widgetKind) {
+      extractAudioPropsFromComponentProperties(ex);
+    }
+
     if (widgetKind) {
       const res = await ctx.assets.captureExportedNode(node, "PNG");
       if ("assetId" in res) {
@@ -675,6 +709,51 @@ function pushDiag(
 
 function pathOf(ctx: WalkCtx): string {
   return ctx.pathStack.join("");
+}
+
+/// Phase 3 — read the structured audio-widget properties (label, min,
+/// max, value, units, binding) off `ex.component_properties` and stamp
+/// them onto `ex.audio_*` fields so the serializer can emit them at the
+/// IR node root for design_import.cpp::parse_ir_node to consume.
+///
+/// componentProperties keys carry a "#<unique-id>" suffix (e.g.
+/// "binding#01:02"); we match on the prefix before the "#".
+function extractAudioPropsFromComponentProperties(
+  ex: ExtractedFigmaNode,
+): void {
+  if (!ex.component_properties) return;
+  const cp = ex.component_properties;
+
+  function getRawString(propName: string): string | undefined {
+    for (const key of Object.keys(cp)) {
+      const base = key.split("#")[0];
+      if (base !== propName) continue;
+      const entry = cp[key];
+      if (!entry || entry.type !== "TEXT") continue;
+      const v = entry.value;
+      return typeof v === "string" ? v : String(v);
+    }
+    return undefined;
+  }
+  function getNumeric(propName: string): number | undefined {
+    const s = getRawString(propName);
+    if (s === undefined || s.length === 0) return undefined;
+    const n = parseFloat(s);
+    return Number.isFinite(n) ? n : undefined;
+  }
+
+  const label = getRawString("label");
+  if (label !== undefined) ex.audio_label = label;
+  const min = getNumeric("min");
+  if (min !== undefined) ex.audio_min = min;
+  const max = getNumeric("max");
+  if (max !== undefined) ex.audio_max = max;
+  const value = getNumeric("value");
+  if (value !== undefined) ex.audio_default = value;
+  const units = getRawString("units");
+  if (units !== undefined && units.length > 0) ex.audio_units = units;
+  const binding = getRawString("binding");
+  if (binding !== undefined && binding.length > 0) ex.audio_binding = binding;
 }
 
 /// Detect audio widget kind from an instance's main-component name. Used

--- a/tools/figma-plugin/src/library-registry.ts
+++ b/tools/figma-plugin/src/library-registry.ts
@@ -1,0 +1,92 @@
+// library-registry.ts — Phase 3 (planning/2026-05-28-pulp-figma-plugin-strategy.md §8)
+//
+// Loads tools/figma-plugin/library-manifest.json at build time and exposes
+// typed lookups for:
+//   (a) component_set_key → AudioWidgetKind  (authoritative, key-based)
+//   (b) name-prefix       → AudioWidgetKind  (fallback for unpublished libraries)
+//
+// The manifest is the single source of truth for which Pulp library widgets
+// the importer recognises and which Figma component-set keys / name prefixes
+// they map to. Adding a new widget = adding one entry to the JSON.
+
+import manifest from "../library-manifest.json";
+import type { AudioWidgetKind } from "./extract-model";
+
+export interface LibraryWidgetEntry {
+  kind: AudioWidgetKind;
+  component_set_key: string;
+  name_prefix: string;
+  supported_property_definitions: ReadonlyArray<string>;
+  supported_variant_axes: ReadonlyArray<string>;
+  since_library_version: string;
+}
+
+const widgetEntries: ReadonlyArray<LibraryWidgetEntry> = (() => {
+  const out: LibraryWidgetEntry[] = [];
+  const widgets = manifest.widgets as Record<string, {
+    component_set_key: string;
+    name_prefix: string;
+    supported_property_definitions: string[];
+    supported_variant_axes: string[];
+    since_library_version: string;
+  }>;
+  for (const kind of Object.keys(widgets)) {
+    const w = widgets[kind];
+    out.push({
+      kind: kind as AudioWidgetKind,
+      component_set_key: w.component_set_key,
+      name_prefix: w.name_prefix,
+      supported_property_definitions: w.supported_property_definitions,
+      supported_variant_axes: w.supported_variant_axes,
+      since_library_version: w.since_library_version,
+    });
+  }
+  return out;
+})();
+
+// Build a key → kind lookup at module load. Entries whose key starts with
+// "TBD-" (placeholder until the library publishes) are excluded so a real
+// Figma key collision is impossible.
+const keyToKind: Record<string, AudioWidgetKind> = {};
+for (const e of widgetEntries) {
+  if (e.component_set_key && !e.component_set_key.startsWith("TBD-")) {
+    keyToKind[e.component_set_key] = e.kind;
+  }
+}
+
+export const LIBRARY_VERSION: string = manifest.library_version;
+
+/// Authoritative key-based recognition. Returns the AudioWidgetKind for a
+/// known Pulp-library component_set_key (or undefined for non-Pulp instances).
+/// `componentKey` is the `key` field of the INSTANCE node's main-component or
+/// the main-component's parent component-set in Figma.
+export function widgetKindByLibraryKey(
+  componentKey: string | undefined | null,
+): AudioWidgetKind | undefined {
+  if (!componentKey) return undefined;
+  return keyToKind[componentKey];
+}
+
+/// Fallback name-prefix recognition for designs that use a layer naming
+/// convention like "Pulp / Knob" but haven't pulled in the published library.
+/// Case-insensitive prefix match. Returns the first matching widget kind.
+export function widgetKindByNamePrefix(
+  name: string | undefined | null,
+): AudioWidgetKind | undefined {
+  if (!name) return undefined;
+  const lower = name.toLowerCase();
+  for (const e of widgetEntries) {
+    if (lower.startsWith(e.name_prefix.toLowerCase())) {
+      return e.kind;
+    }
+  }
+  return undefined;
+}
+
+/// Return the manifest entry for a kind, used by callers that need to
+/// validate property definitions / variant axes.
+export function entryForKind(
+  kind: AudioWidgetKind,
+): LibraryWidgetEntry | undefined {
+  return widgetEntries.find((e) => e.kind === kind);
+}

--- a/tools/figma-plugin/src/serialize.ts
+++ b/tools/figma-plugin/src/serialize.ts
@@ -96,6 +96,24 @@ function toEnvelopeNode(n: ExtractedFigmaNode): unknown {
   if (n.content !== undefined) out.content = n.content;
   if (n.asset_ref) out.asset_ref = n.asset_ref;
 
+  // Phase 3 — emit audio-widget metadata at the IR node root. The C++
+  // parser (design_ir_json.cpp::parse_ir_node) reads:
+  //   audio_widget  → IRNode.audio_widget enum
+  //   label         → IRNode.audio_label
+  //   min/max/default → IRNode.audio_min/max/default (float)
+  //   attributes.* → IRNode.attributes (free-form passthrough)
+  if (n.library_widget_kind) out.audio_widget = n.library_widget_kind;
+  if (n.audio_label !== undefined) out.label = n.audio_label;
+  if (n.audio_min !== undefined) out.min = n.audio_min;
+  if (n.audio_max !== undefined) out.max = n.audio_max;
+  if (n.audio_default !== undefined) out.default = n.audio_default;
+  if (n.audio_units !== undefined || n.audio_binding !== undefined) {
+    const attrs: Record<string, string> = {};
+    if (n.audio_units !== undefined) attrs.units = n.audio_units;
+    if (n.audio_binding !== undefined) attrs.binding = n.audio_binding;
+    out.attributes = attrs;
+  }
+
   // Style: pass through truthy fields only (envelope schema says additionalProperties:false)
   const styleEntries = Object.entries(n.style).filter(([, v]) => v !== undefined && v !== null && v !== "");
   if (styleEntries.length > 0) out.style = Object.fromEntries(styleEntries);


### PR DESCRIPTION
## Summary

Sequel to #3138 (figma-plugin lane). Now that Phase 0 has published the [Pulp Library Figma file](https://www.figma.com/design/vxW6btjzQtc4t9ITLNjev0/Pulp-Library), this PR flips the figma-plugin extractor from heuristic name matching to authoritative `component_set_key` matching for the published `Pulp / Knob` component-set, and lifts structured component properties (label / min / max / value / units / binding) to the IR envelope's node root so `design_ir_json.cpp::parse_ir_node` maps them onto `IRNode.audio_widget` / `audio_label` / `audio_min` / `audio_max` / `audio_default` / `attributes`.

Strategy doc: `planning/2026-05-28-pulp-figma-plugin-strategy.md` §8 Phase 3.

## What changed

- **`tools/figma-plugin/library-manifest.json`** — pasted the real `component_set_key` (`f74264ffa9108521fb0d3398dc8f5ea88e23a84e`) returned by the Figma plugin API on the published `Pulp / Knob` node; replaced the `TBD-` placeholder.
- **`tools/figma-plugin/src/library-registry.ts`** (new) — loads the manifest at build time, exposes typed `widgetKindByLibraryKey(...)` and `widgetKindByNamePrefix(...)`. Entries whose key starts with `TBD-` are excluded so adding a widget to the manifest before publish can't false-match.
- **`extract.ts`** — three-tier recognition order inside the `INSTANCE` block: library key → name prefix → permissive name match (preserves pre-Phase-3 sprite-strip behaviour). New helper `extractAudioPropsFromComponentProperties()` lifts the instance's `componentProperties` text values onto `ex.audio_*` fields.
- **`extract-model.ts`** — six new optional fields on `ExtractedFigmaNode`.
- **`serialize.ts`** — emit `audio_widget`, `label`, `min`, `max`, `default` at the IR node root, and `units` / `binding` into `node.attributes`. Matches what `design_ir_json.cpp::parse_ir_node` reads.
- **`code.tsconfig.json`** — `resolveJsonModule` + widened `rootDir` so the manifest JSON is reachable.

## Tests (CLAUDE.md tests-with-fixes rule)

Two new Catch2 cases under `[view][import][figma-plugin][phase-3]` pinning the JSON envelope shape Phase 3 produces:

1. Full `Pulp / Knob` envelope with `audio_widget=knob`, `label`, `min/max/default`, `attributes.{units,binding}` → asserts the IR has `IRNode.audio_widget == knob`, all numeric fields parsed, both attributes present.
2. Same envelope without `units` (the Pulp / Knob default `units` is an empty string and the extractor SHOULD omit it) → asserts the absence is handled cleanly.

Without these the extractor and the C++ parser can drift apart silently.

## Verification (macOS, this branch)

| Surface | Result |
|---|---|
| `npm run typecheck` (figma-plugin) | clean |
| `npm run build` (figma-plugin) | clean (`dist/code.js`, `dist/ui.html`) |
| `cmake --build pulp-test-design-import` | clean |
| `./build/test/pulp-test-design-import` | **623 assertions / 58 cases pass** (incl. 2 new / 15 assertions) |
| `tools/scripts/gates.sh` | **✓ all gates pass** |

## What is NOT in this PR (deliberately)

- **Phase 5** — extending the library with Fader / Meter / XYPad / Waveform / Spectrum. Iterative, separate PRs.
- **`design_codegen.cpp` binding wiring** — the attribute is carried into `IRNode.attributes["binding"]` but not yet routed into the param-binding system. Next step beyond this PR.

## Test plan

- [x] Local typecheck + build (figma-plugin TS)
- [x] Local Catch2 tests (`pulp-test-design-import` — 58/58)
- [x] Local gates green
- [ ] CI macOS / Linux / Windows
- [ ] CI Diff coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)