### PR TITLE
feat(figma-import): Phase 5 part 1 — Pulp / Fader + Pulp / Meter library widgets

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.138.0",
+      "version": "0.138.1",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.138.0"
+  "version": "0.138.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.138.0",
+  "version": "0.138.1",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.283.0
+    VERSION 0.283.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -2764,3 +2764,91 @@ TEST_CASE("parse_figma_plugin_json handles a Phase 3 knob without optional units
     REQUIRE(ir.root.attributes.at("binding") == "param.mix");
     REQUIRE(ir.root.attributes.count("units") == 0);
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// Phase 5 part 1 — Pulp / Fader + Pulp / Meter recognition.
+//
+// Mirrors the Phase 3 contract for the two new library widgets added in
+// Pulp Library v0.2.0:
+//   - Pulp / Fader  (component_set_key 1c2b727f0c0e11026512725aeb546997f16042bd)
+//   - Pulp / Meter  (component_set_key 52e1636086b855cb2d20d341d4cfa15e94151eef)
+//
+// Same envelope shape as Pulp / Knob; only audio_widget enum changes.
+TEST_CASE("parse_figma_plugin_json maps Phase 5 Pulp / Fader envelope onto IR widget",
+          "[view][import][figma-plugin][phase-5]") {
+    const std::string envelope = R"JSON({
+        "format_version": "v1",
+        "parser_version": "0.1.0",
+        "compat_schema_version": "v1",
+        "provenance": {
+            "adapter": "figma-plugin",
+            "version": "0.1.0",
+            "source_uri": "figma://design/vxW6btjzQtc4t9ITLNjev0/Pulp-Library"
+        },
+        "root": {
+            "type": "frame",
+            "name": "LevelFader",
+            "audio_widget": "fader",
+            "label": "Master",
+            "min": -inf-replaced-below,
+            "max": 6,
+            "default": 0,
+            "attributes": {
+                "units": "dB",
+                "binding": "param.master_level"
+            },
+            "style": { "width": 28, "height": 120 },
+            "layout": { "direction": "column" },
+            "children": []
+        }
+    })JSON";
+    // The literal "-inf-replaced-below" above is a sentinel — replace it
+    // with a real number (-60) so the JSON parser doesn't choke. (Keeps
+    // the envelope structure inline-readable in this test source.)
+    auto json = envelope;
+    auto pos = json.find("-inf-replaced-below");
+    REQUIRE(pos != std::string::npos);
+    json.replace(pos, std::string("-inf-replaced-below").size(), "-60");
+
+    auto ir = parse_figma_plugin_json(json);
+    REQUIRE(ir.source == DesignSource::figma_plugin);
+    REQUIRE(ir.root.audio_widget == AudioWidgetType::fader);
+    REQUIRE(ir.root.audio_label == "Master");
+    REQUIRE(ir.root.audio_min == Catch::Approx(-60.0f));
+    REQUIRE(ir.root.audio_max == Catch::Approx(6.0f));
+    REQUIRE(ir.root.audio_default == Catch::Approx(0.0f));
+    REQUIRE(ir.root.attributes.at("units") == "dB");
+    REQUIRE(ir.root.attributes.at("binding") == "param.master_level");
+}
+
+TEST_CASE("parse_figma_plugin_json maps Phase 5 Pulp / Meter envelope onto IR widget",
+          "[view][import][figma-plugin][phase-5]") {
+    const std::string envelope = R"JSON({
+        "format_version": "v1",
+        "parser_version": "0.1.0",
+        "compat_schema_version": "v1",
+        "root": {
+            "type": "frame",
+            "name": "OutputMeter",
+            "audio_widget": "meter",
+            "label": "Out L",
+            "min": -60,
+            "max": 0,
+            "default": -12,
+            "attributes": {
+                "units": "dB",
+                "binding": "meter.out_l"
+            },
+            "style": { "width": 18, "height": 120 },
+            "children": []
+        }
+    })JSON";
+    auto ir = parse_figma_plugin_json(envelope);
+    REQUIRE(ir.root.audio_widget == AudioWidgetType::meter);
+    REQUIRE(ir.root.audio_label == "Out L");
+    REQUIRE(ir.root.audio_min == Catch::Approx(-60.0f));
+    REQUIRE(ir.root.audio_max == Catch::Approx(0.0f));
+    REQUIRE(ir.root.audio_default == Catch::Approx(-12.0f));
+    REQUIRE(ir.root.attributes.at("units") == "dB");
+    REQUIRE(ir.root.attributes.at("binding") == "meter.out_l");
+}

--- a/tools/figma-plugin/library-manifest.json
+++ b/tools/figma-plugin/library-manifest.json
@@ -1,5 +1,5 @@
 {
-  "library_version": "0.1.0",
+  "library_version": "0.2.0",
   "library_file_key": "vxW6btjzQtc4t9ITLNjev0",
   "library_file_url": "https://www.figma.com/design/vxW6btjzQtc4t9ITLNjev0/Pulp-Library",
   "required_plugin_version": ">=0.1.0",
@@ -11,6 +11,22 @@
       "supported_property_definitions": ["label", "value", "min", "max", "units", "binding"],
       "supported_variant_axes": ["size", "state"],
       "since_library_version": "0.1.0"
+    },
+    "fader": {
+      "component_set_key": "1c2b727f0c0e11026512725aeb546997f16042bd",
+      "component_set_node_id": "10:87",
+      "name_prefix": "Pulp / Fader",
+      "supported_property_definitions": ["label", "value", "min", "max", "units", "binding"],
+      "supported_variant_axes": ["size", "state"],
+      "since_library_version": "0.2.0"
+    },
+    "meter": {
+      "component_set_key": "52e1636086b855cb2d20d341d4cfa15e94151eef",
+      "component_set_node_id": "10:234",
+      "name_prefix": "Pulp / Meter",
+      "supported_property_definitions": ["label", "value", "min", "max", "units", "binding"],
+      "supported_variant_axes": ["size", "state"],
+      "since_library_version": "0.2.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

Sequel to #3177 (Phase 3 — library component recognition). Adds the next two Pulp library widgets — **Fader** and **Meter** — to the published [Pulp Library Figma file](https://www.figma.com/design/vxW6btjzQtc4t9ITLNjev0/Pulp-Library) and wires them into the manifest. The Phase 3 recognition pass picks them up automatically because they share the Knob's property + variant schema.

Strategy doc: `planning/2026-05-28-pulp-figma-plugin-strategy.md` §8 Phase 5.

## What's in the library now

| Widget | component_set_key | node id |
|---|---|---|
| Pulp / Knob | `f74264ffa9108521fb0d3398dc8f5ea88e23a84e` | 3:74 (page 0:1) |
| Pulp / Fader | `1c2b727f0c0e11026512725aeb546997f16042bd` | 10:87 (page 10:2) |
| Pulp / Meter | `52e1636086b855cb2d20d341d4cfa15e94151eef` | 10:234 (page 10:149) |

Each component-set:
- 3 sizes × 4 states = 12 variants
- 6 instance properties: `label`, `value`, `min`, `max`, `units`, `binding`
- Defaults appropriate to the widget kind (Fader: 0–1 unitless; Meter: -60–0 dB)

## How recognition works

Same three-tier cascade from Phase 3 (`extract.ts`), now covering three widget kinds:

| Tier | Trigger | Fidelity |
|---|---|---|
| 1. Library key match | `component_set_key` matches manifest | ★★★★ |
| 2. Name-prefix match | `"Pulp / Fader"`, `"Pulp / Meter"`, etc. | ★★★ |
| 3. Permissive name match | name contains `"fader"`, `"slider"`, `"meter"`, `"level"`, `"vu"` | ★★ |

No code change required in `extract.ts` / `serialize.ts` / `library-registry.ts` — they iterate over `library-manifest.json.widgets` and apply the same recognition path.

## Tests (CLAUDE.md tests-with-fixes)

Two new Catch2 cases under `[view][import][figma-plugin][phase-5]`:
- Fader envelope (`audio_widget=fader`, label "Master", min=-60, max=6, default=0, attributes binding=`param.master_level`, units=dB)
- Meter envelope (`audio_widget=meter`, label "Out L", min=-60, max=0, default=-12, attributes binding=`meter.out_l`)

Each pins that `parse_figma_plugin_json` maps the envelope onto `IRNode.audio_widget / audio_label / audio_min / audio_max / audio_default / attributes`.

## Verification (macOS, this branch)

| | Result |
|---|---|
| `npm run typecheck` (figma-plugin) | clean |
| `npm run build` (figma-plugin) | clean |
| `cmake --build pulp-test-design-import` | clean |
| `./build/test/pulp-test-design-import` | **639 assertions / 60 cases pass** (incl. 4 figma-plugin / 31 assertions) |
| `tools/scripts/gates.sh` | ✓ all gates pass |

## Visual proof

Fader (12 variants): three sizes × four states with chrome thumbs and blue glow on hover/active.

Meter (12 variants): three sizes × four states with green→yellow→red gradient, white peak indicator, blue-glow hover bezel.

## What's not in this PR

- **XYPad** — 2-axis bindings need IR shape decisions (use attributes or extend the IR? user-facing trade-off worth picking deliberately).
- **Waveform / Spectrum** — display-only widgets; need a "binding" semantic for audio source rather than parameter, and the design language for static-vs-live preview deserves its own thought.
- **`design_codegen.cpp` binding wiring** — same status as #3177 / #3138: attributes carried through but not yet consumed by the param-binding system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)