### PR TITLE
feat(design-import): wire figma-plugin parameter bindings into native widgets

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -180,6 +180,42 @@ attribute, while `set_default_value(...)` must come from normalized
 and emit non-hex semantic color tokens as strings rather than trying to parse
 them as colors.
 
+#### figma-plugin `binding` → canonical `pulp*` binding contract
+
+The figma-plugin extractor (`tools/figma-plugin/`) exports a recognized Pulp
+Library control as an audio widget (`audio_widget`) plus a single free-form
+`attributes["binding"]` string (e.g. `"filter.cutoff_hz"`). The whole native
+binding pipeline — the materializer (`design_import_native_common.cpp`,
+`NativeBindingMetadata::parse`) and the binding-manifest codegen
+(`design_cpp_codegen.cpp`) — only consumes the `pulp*`-prefixed contract, so a
+raw `binding` string is invisible to them on its own.
+
+`parse_ir_node` (`design_ir_json.cpp`, `normalize_figma_plugin_binding`)
+normalizes that string into the canonical `pulp*` contract at the IR-ingest
+boundary, so there is exactly ONE downstream binding consumer. Rules to keep in
+mind when touching this:
+
+- **Recognized-widget gate.** Synthesis only fires when `audio_widget != none`.
+  A generic/visual frame that happens to carry a `binding` attribute gets NO
+  synthesized binding — it stays a generic node. Don't loosen this gate.
+- **Module/param split.** Split on the FIRST `.`: `"filter.cutoff_hz"` →
+  `pulpBindingModule="filter"`, `pulpBindingParam="cutoff_hz"`,
+  `pulpParamKey="filter.cutoff_hz"`. No dot → empty module, whole string is the
+  param. `param_key` (non-empty) is what drives both the manifest entry and the
+  codegen `bind_knob`/`bind_fader` helper gate.
+- **Meters differ.** `knob`/`fader`/`waveform` map to a writable param
+  (`pulpParamKey`); `meter`/`spectrum` map to `pulpMeterSource` +
+  `pulpMeterChannel` (no `pulpParamKey`), since a meter reads a metering input.
+- **`pulpRouteId` is required** for the codegen helper to emit a live bind call;
+  it's synthesized deterministically as `"figma-plugin:<binding>"`.
+- **No-overwrite / no-regression.** Synthesis routes through
+  `NativeBindingMetadata::serialize()` (skip-empty, no-overwrite) and bails if
+  any canonical binding attr is already present, so a JSX/Claude node that
+  already carries `pulp*` is untouched. The raw `attributes["binding"]` is
+  always preserved — never delete the source evidence.
+- **This is a generalizable importer rule**, not a per-fixture patch: it reads
+  the figma-plugin data and produces the contract for ANY recognized widget.
+
 The Phase 5/7/9 benchmark harness lives at `pulp-design-import-bench` and is driven
 by `tools/scripts/design_import_benchmark.py`. Run it under no-launch env
 (`PULP_DISABLE_PLUGIN_EDITOR=1 PULP_HEADLESS=1 PULP_TEST_MODE=1

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.138.1",
+      "version": "0.139.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.138.1"
+  "version": "0.139.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.138.1",
+  "version": "0.139.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.283.1
+    VERSION 0.284.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/design_ir_json.cpp
+++ b/core/view/src/design_ir_json.cpp
@@ -13,6 +13,7 @@
 
 #include <pulp/view/design_import.hpp>
 
+#include "design_binding_metadata.hpp"
 #include "design_import_internal.hpp"
 
 #include <choc/text/choc_JSON.h>
@@ -198,6 +199,97 @@ bool is_asset_reference_key(std::string_view key) {
     }
     if (key.rfind("htmlAsset", 0) == 0) return true;
     return false;
+}
+
+// ── figma-plugin binding normalization ──────────────────────────────────────
+//
+// The figma-plugin extractor (tools/figma-plugin/src/extract.ts) emits a Pulp
+// Library control as a recognized audio widget plus a single free-form
+// `attributes["binding"]` string (e.g. "filter.cutoff_hz"). Historically that
+// string reached the IR but was dropped: the native materializer
+// (design_import_native_common.cpp) and the binding-manifest codegen
+// (design_cpp_codegen.cpp) only consume the `pulp*`-prefixed binding contract,
+// never the raw `binding` attribute.
+//
+// This normalizes the figma-plugin `binding` into the SAME internal binding
+// representation that the JSX / Claude path already feeds —
+// NativeBindingMetadata — so the native materializer and the codegen manifest
+// both pick it up via their existing logic, with no duplicated downstream
+// consumer. It runs at the IR-ingest boundary (end of parse_ir_node), gated on
+// the node being a semantically-recognized audio widget. An unrecognized /
+// generic node (audio_widget == none) never gets a synthesized binding.
+//
+// The raw `attributes["binding"]` is preserved (the evidence is not deleted),
+// and NativeBindingMetadata::serialize() uses no-overwrite / skip-empty
+// semantics so a node that already carries `pulp*` binding attributes (e.g. a
+// JSX/Claude import that happens to also carry a `binding` key) is left exactly
+// as-is — no regression to the existing pulp* path.
+void normalize_figma_plugin_binding(IRNode& node) {
+    // Gate 1: only semantically-recognized widgets get a synthesized binding.
+    if (node.audio_widget == AudioWidgetType::none)
+        return;
+
+    // Gate 2: must carry a non-empty figma-plugin `binding` string.
+    auto binding_it = node.attributes.find("binding");
+    if (binding_it == node.attributes.end() || binding_it->second.empty())
+        return;
+
+    // Gate 3: if the node already carries any of the canonical single-param /
+    // meter binding-contract attributes, leave it untouched. This keeps the
+    // existing pulp* path byte-identical and avoids double-synthesis on a node
+    // that was already lowered by the JSX/Claude writer.
+    for (const char* existing : {"pulpParamKey", "pulpBindingModule",
+                                 "pulpBindingParam", "pulpMeterSource",
+                                 "pulpMeterChannel"}) {
+        auto it = node.attributes.find(existing);
+        if (it != node.attributes.end() && !it->second.empty())
+            return;
+    }
+
+    const std::string& binding = binding_it->second;
+
+    // Split on the first '.': "<module>.<param>". A binding with no '.' has an
+    // empty module and the whole string as the param/channel.
+    std::string module_part;
+    std::string param_part = binding;
+    if (auto dot = binding.find('.'); dot != std::string::npos) {
+        module_part = binding.substr(0, dot);
+        param_part = binding.substr(dot + 1);
+    }
+
+    NativeBindingMetadata md;
+    // route_id is required for the codegen helper gate to emit a live bind_*()
+    // call; make it deterministic from the binding so re-imports are stable.
+    md.route_id = "figma-plugin:" + binding;
+    md.route_type = "native_cpp";
+
+    switch (node.audio_widget) {
+        case AudioWidgetType::meter:
+        case AudioWidgetType::spectrum:
+            // Meters read from a metering source/channel, not a writable param.
+            md.source_family = "meter";
+            md.meter_source = module_part.empty() ? binding : module_part;
+            md.meter_channel = param_part;
+            break;
+        case AudioWidgetType::knob:
+        case AudioWidgetType::fader:
+        case AudioWidgetType::xy_pad:
+        case AudioWidgetType::waveform:
+        default:
+            // Scalar parameter controls. param_key drives both the manifest
+            // entry and the codegen helper gate (has_single_param).
+            md.source_family = "param";
+            md.param_key = binding;
+            if (!module_part.empty())
+                md.binding_module = module_part;
+            md.binding_param = param_part;
+            break;
+    }
+
+    // serialize() writes only present, non-empty values and never overwrites an
+    // existing non-empty attribute — so `attributes["binding"]` and any other
+    // pre-existing data survive untouched.
+    md.serialize(node);
 }
 
 IRNode parse_ir_node(const choc::value::ValueView& obj) {
@@ -735,6 +827,11 @@ IRNode parse_ir_node(const choc::value::ValueView& obj) {
             }
         }
     }
+
+    // Normalize a recognized figma-plugin widget's free-form `binding` string
+    // into the canonical pulp* binding contract. Runs after audio_widget is
+    // finalized (covers both explicit `audio_widget` and name-detected widgets).
+    normalize_figma_plugin_binding(node);
 
     return node;
 }

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -2766,6 +2766,201 @@ TEST_CASE("parse_figma_plugin_json handles a Phase 3 knob without optional units
 }
 
 // ──────────────────────────────────────────────────────────────────────────
+// figma-plugin binding wire-up (feat/figma-plugin-binding-wireup).
+//
+// The figma-plugin extractor emits a recognized Pulp Library control as an
+// audio widget plus a single free-form `attributes["binding"]` string. Before
+// this slice that string reached the IR but was dropped — the native
+// materializer and the binding-manifest codegen only consume the
+// `pulp*`-prefixed binding contract. These tests pin that a recognized widget's
+// `binding` is now normalized into the SAME canonical pulp* binding
+// representation (so it produces a real native param hookup AND a
+// binding-manifest entry), while an unrecognized/generic node gets nothing.
+
+TEST_CASE("figma-plugin knob binding lowers to a real native param binding",
+          "[view][import][figma-plugin][binding-wireup]") {
+    const std::string envelope = R"JSON({
+        "format_version": "v1",
+        "parser_version": "0.1.0",
+        "compat_schema_version": "v1",
+        "root": {
+            "type": "frame",
+            "name": "VolumeKnob",
+            "audio_widget": "knob",
+            "label": "Cutoff",
+            "min": 20,
+            "max": 20000,
+            "default": 880,
+            "attributes": {
+                "units": "Hz",
+                "binding": "filter.cutoff_hz"
+            },
+            "style": { "width": 56, "height": 56 },
+            "layout": { "direction": "column" },
+            "children": []
+        }
+    })JSON";
+
+    auto ir = parse_figma_plugin_json(envelope);
+    REQUIRE(ir.root.audio_widget == AudioWidgetType::knob);
+
+    // The raw evidence is preserved.
+    REQUIRE(ir.root.attributes.at("binding") == "filter.cutoff_hz");
+
+    // The binding is materialized into the canonical pulp* binding contract —
+    // the SAME representation the JSX / Claude path feeds. This is the real
+    // native param binding (param_key drives the manifest + codegen helper),
+    // not merely a preserved string.
+    REQUIRE(ir.root.attributes.at("pulpParamKey") == "filter.cutoff_hz");
+    REQUIRE(ir.root.attributes.at("pulpBindingModule") == "filter");
+    REQUIRE(ir.root.attributes.at("pulpBindingParam") == "cutoff_hz");
+    REQUIRE(ir.root.attributes.at("pulpRouteType") == "native_cpp");
+    REQUIRE(ir.root.attributes.at("pulpRouteId") == "figma-plugin:filter.cutoff_hz");
+
+    // The binding-manifest codegen emits a binding entry carrying the param —
+    // proof the downstream consumer picks the binding up via its existing logic.
+    const auto result = generate_pulp_cpp(ir, ir.asset_manifest, {});
+    REQUIRE(result.binding_manifest.find("\"param_key\": \"filter.cutoff_hz\"") != std::string::npos);
+    REQUIRE(result.binding_manifest.find("\"binding_module\": \"filter\"") != std::string::npos);
+    REQUIRE(result.binding_manifest.find("\"binding_param\": \"cutoff_hz\"") != std::string::npos);
+    REQUIRE(result.binding_manifest.find("\"native_primitive\": \"knob\"") != std::string::npos);
+
+    // And the generated native helper emits a live bind_knob() hookup.
+    REQUIRE(result.source.find("ctx.bind_knob(") != std::string::npos);
+    REQUIRE(result.source.find("\"filter.cutoff_hz\"") != std::string::npos);
+}
+
+TEST_CASE("figma-plugin knob binding without a module dot binds the whole key",
+          "[view][import][figma-plugin][binding-wireup]") {
+    // "param.mix" splits module/param on the first dot; a binding with no dot
+    // (defensive) keeps the whole string as the param key.
+    const std::string envelope = R"JSON({
+        "format_version": "v1",
+        "parser_version": "0.1.0",
+        "compat_schema_version": "v1",
+        "root": {
+            "type": "frame",
+            "name": "Mix",
+            "audio_widget": "knob",
+            "label": "Mix",
+            "min": 0,
+            "max": 1,
+            "default": 0.5,
+            "attributes": { "binding": "param.mix" },
+            "style": { "width": 32, "height": 32 },
+            "children": []
+        }
+    })JSON";
+
+    auto ir = parse_figma_plugin_json(envelope);
+    REQUIRE(ir.root.audio_widget == AudioWidgetType::knob);
+    REQUIRE(ir.root.attributes.at("pulpParamKey") == "param.mix");
+    REQUIRE(ir.root.attributes.at("pulpBindingModule") == "param");
+    REQUIRE(ir.root.attributes.at("pulpBindingParam") == "mix");
+    // Raw evidence preserved.
+    REQUIRE(ir.root.attributes.at("binding") == "param.mix");
+}
+
+TEST_CASE("figma-plugin meter binding lowers to a meter source/channel input",
+          "[view][import][figma-plugin][binding-wireup]") {
+    const std::string envelope = R"JSON({
+        "format_version": "v1",
+        "parser_version": "0.1.0",
+        "compat_schema_version": "v1",
+        "root": {
+            "type": "frame",
+            "name": "OutputMeter",
+            "audio_widget": "meter",
+            "label": "Out L",
+            "attributes": { "binding": "meter.out_l" },
+            "style": { "width": 12, "height": 64 },
+            "children": []
+        }
+    })JSON";
+
+    auto ir = parse_figma_plugin_json(envelope);
+    REQUIRE(ir.root.audio_widget == AudioWidgetType::meter);
+    // A meter reads from a metering source/channel, not a writable param.
+    REQUIRE(ir.root.attributes.at("pulpMeterSource") == "meter");
+    REQUIRE(ir.root.attributes.at("pulpMeterChannel") == "out_l");
+    REQUIRE(ir.root.attributes.count("pulpParamKey") == 0);
+    REQUIRE(ir.root.attributes.at("binding") == "meter.out_l");
+
+    const auto result = generate_pulp_cpp(ir, ir.asset_manifest, {});
+    REQUIRE(result.binding_manifest.find("\"meter_source\": \"meter\"") != std::string::npos);
+    REQUIRE(result.binding_manifest.find("\"meter_channel\": \"out_l\"") != std::string::npos);
+}
+
+TEST_CASE("figma-plugin generic frame with a binding attribute gets no synthesized binding",
+          "[view][import][figma-plugin][binding-wireup]") {
+    // A node that is NOT a semantically-recognized audio widget must stay a
+    // generic/visual node — no pulp* binding is synthesized, and the codegen
+    // emits no binding-manifest entry for it. This pins the recognized-widget
+    // gate (audio_widget != none).
+    const std::string envelope = R"JSON({
+        "format_version": "v1",
+        "parser_version": "0.1.0",
+        "compat_schema_version": "v1",
+        "root": {
+            "type": "frame",
+            "name": "DecorativePanel",
+            "attributes": { "binding": "filter.cutoff_hz" },
+            "style": { "width": 200, "height": 120 },
+            "layout": { "direction": "column" },
+            "children": []
+        }
+    })JSON";
+
+    auto ir = parse_figma_plugin_json(envelope);
+    REQUIRE(ir.root.audio_widget == AudioWidgetType::none);
+
+    // No binding contract synthesized.
+    REQUIRE(ir.root.attributes.count("pulpParamKey") == 0);
+    REQUIRE(ir.root.attributes.count("pulpBindingModule") == 0);
+    REQUIRE(ir.root.attributes.count("pulpBindingParam") == 0);
+    REQUIRE(ir.root.attributes.count("pulpRouteId") == 0);
+    REQUIRE(ir.root.attributes.count("pulpMeterSource") == 0);
+    // Raw attribute is still preserved untouched.
+    REQUIRE(ir.root.attributes.at("binding") == "filter.cutoff_hz");
+
+    // No binding-manifest entry for an unrecognized node — the manifest holds
+    // an empty entries array and never mentions the binding's param.
+    const auto result = generate_pulp_cpp(ir, ir.asset_manifest, {});
+    REQUIRE(result.binding_manifest.find("\"entries\": []") != std::string::npos);
+    REQUIRE(result.binding_manifest.find("filter.cutoff_hz") == std::string::npos);
+}
+
+TEST_CASE("figma-plugin knob with explicit pulp* binding is not overwritten",
+          "[view][import][figma-plugin][binding-wireup]") {
+    // No-regression: a node that already carries the canonical pulp* binding
+    // (e.g. authored or produced by another writer) keeps its values; the
+    // figma-plugin `binding` normalization is a no-op there.
+    const std::string envelope = R"JSON({
+        "format_version": "v1",
+        "parser_version": "0.1.0",
+        "compat_schema_version": "v1",
+        "root": {
+            "type": "frame",
+            "name": "Knob",
+            "audio_widget": "knob",
+            "attributes": {
+                "binding": "filter.cutoff_hz",
+                "pulpParamKey": "osc.detune",
+                "pulpBindingModule": "osc",
+                "pulpBindingParam": "detune"
+            },
+            "style": { "width": 56, "height": 56 },
+            "children": []
+        }
+    })JSON";
+
+    auto ir = parse_figma_plugin_json(envelope);
+    REQUIRE(ir.root.attributes.at("pulpParamKey") == "osc.detune");
+    REQUIRE(ir.root.attributes.at("pulpBindingModule") == "osc");
+    REQUIRE(ir.root.attributes.at("pulpBindingParam") == "detune");
+}
+
+// ──────────────────────────────────────────────────────────────────────────
 // Phase 5 part 1 — Pulp / Fader + Pulp / Meter recognition.
 //
 // Mirrors the Phase 3 contract for the two new library widgets added in


### PR DESCRIPTION
## What
Wire the parameter binding discovered on a recognized Pulp library control
(e.g. a "Pulp / Knob" exported from the Figma plugin) into a **real native
parameter binding** — both a live widget hookup and a binding-manifest entry in
codegen. Previously the binding string reached `IRNode.attributes["binding"]`
and was dropped: the native materializer and the codegen manifest only read
`pulp*`-prefixed attributes.

Closes the "binding preserved but not wired" gap found during the figma-plugin
import review.

## How
`normalize_figma_plugin_binding()` in `core/view/src/design_ir_json.cpp`, called
at the end of `parse_ir_node` once `audio_widget` is finalized, translates the
figma-plugin `binding` string into the **same `NativeBindingMetadata` contract**
(`pulpParamKey`/`pulpBindingModule`/`pulpBindingParam`, or
`pulpMeterSource`/`pulpMeterChannel` for meters) that the JSX/Claude path
already emits via `NativeBindingMetadata::serialize()`. So the native
materializer and the codegen manifest pick it up through their **existing**
logic — no duplicated downstream consumer.

Gated so it only ever fires for **semantically-recognized widgets**:
- `audio_widget == none` (a generic frame) → no synthesized binding.
- empty `binding` → nothing.
- node already carries any canonical `pulp*` binding attr → left untouched
  (keeps the existing path byte-identical, no double-synthesis).

`binding` of the form `"module.param"` splits on the first `.`; a deterministic
`route_id = "figma-plugin:<binding>"` satisfies the codegen helper gate so a
live `ctx.bind_knob(...)` / `bind_fader(...)` is emitted.

## Tests (ship with the change)
5 new `[binding-wireup]` cases in `test/test_design_import.cpp`:
- figma-plugin knob + binding → materialized native binding contract **and**
  manifest `param_key`/`binding_module`/`binding_param` + emitted `ctx.bind_knob(`;
- no-dot binding variant; meter → source/channel;
- no-overwrite no-regression over the existing `pulp*` path;
- **negative**: a generic frame with a `binding` attribute gets NO synthesized binding.

`[binding-wireup]` 37 assertions / `[figma-plugin]` 68 assertions / full
`pulp-test-design-import` suite green (`-DPULP_ENABLE_GPU=OFF`).

## Notes
- xy_pad: a single `binding` string can't express both axes, so it falls through
  to the scalar path (the XY helper needs `x_param_key`+`y_param_key`); acceptable
  for this slice.
- The codegen byte-parity oracle is unaffected — no existing fixture carries a
  raw `binding` attribute on an audio widget (verified), so synthesis never fires
  for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)