### PR TITLE
test(figma-plugin): emitter tests + align export schema with real shape

### DIFF
--- a/tools/figma-plugin/package.json
+++ b/tools/figma-plugin/package.json
@@ -10,7 +10,8 @@
     "gen-types": "node scripts/gen-types.mjs",
     "typecheck:code": "tsc -p src/code.tsconfig.json",
     "typecheck:ui": "tsc -p src/ui.tsconfig.json",
-    "typecheck": "npm run typecheck:code && npm run typecheck:ui"
+    "typecheck": "npm run typecheck:code && npm run typecheck:ui",
+    "test": "node scripts/test.mjs"
   },
   "devDependencies": {
     "@figma/plugin-typings": "^1.115.0",

--- a/tools/figma-plugin/schema/figma-plugin-export-v1.json
+++ b/tools/figma-plugin/schema/figma-plugin-export-v1.json
@@ -35,8 +35,8 @@
       }
     },
     "library_manifest": {
-      "type": "object",
-      "description": "Pulp Figma Library version metadata at time of export. Plugin reads tools/figma-plugin/library-manifest.json and copies the active section here.",
+      "type": ["object", "null"],
+      "description": "Pulp Figma Library version metadata at time of export. Plugin reads tools/figma-plugin/library-manifest.json and copies the active section here. Emitted as null when no library snapshot is available (serialize.ts: ctx.libraryManifest ?? null).",
       "properties": {
         "library_version": { "type": "string" },
         "required_plugin_version": { "type": "string" },
@@ -81,6 +81,7 @@
   "$defs": {
     "node": {
       "type": "object",
+      "description": "An IR node as emitted by serialize.ts::toEnvelopeNode. Semantic audio-widget data lives at the NODE ROOT (audio_widget/label/min/max/default + attributes.binding), NOT in nested audio/binding sub-objects. The C++ parser (core/view/src/design_ir_json.cpp::parse_ir_node) reads these root-level fields directly.",
       "required": ["type", "name", "figma_node_id"],
       "properties": {
         "type": {
@@ -102,10 +103,30 @@
           "type": "string",
           "description": "Text content (when type=text). Maps to IRNode.text_content."
         },
+        "audio_widget": {
+          "type": "string",
+          "description": "Recognised Pulp audio-widget kind. Emitted at the node root when serialize.ts sees node.library_widget_kind. The C++ parser maps this onto IRNode.audio_widget (enum). Equal to figma.library_widget_kind when present.",
+          "enum": ["knob", "fader", "meter", "xy_pad", "waveform", "spectrum"]
+        },
+        "label": {
+          "type": "string",
+          "description": "Audio-widget label. Root-level; maps to IRNode.audio_label."
+        },
+        "min": {
+          "type": "number",
+          "description": "Audio-widget minimum value. Root-level; maps to IRNode.audio_min."
+        },
+        "max": {
+          "type": "number",
+          "description": "Audio-widget maximum value. Root-level; maps to IRNode.audio_max."
+        },
+        "default": {
+          "type": "number",
+          "description": "Audio-widget default value. Root-level; maps to IRNode.audio_default."
+        },
+        "attributes": { "$ref": "#/$defs/attributes" },
         "style": { "$ref": "#/$defs/style" },
         "layout": { "$ref": "#/$defs/layout" },
-        "audio": { "$ref": "#/$defs/audio" },
-        "binding": { "$ref": "#/$defs/binding" },
         "figma": { "$ref": "#/$defs/figma_metadata" },
         "asset_ref": {
           "type": "string",
@@ -116,6 +137,21 @@
           "items": { "$ref": "#/$defs/node" }
         }
       }
+    },
+    "attributes": {
+      "type": "object",
+      "description": "Free-form string passthrough map emitted at the node root by serialize.ts. Each entry becomes an IRNode.attributes[*] entry in the C++ parser. Emitted only when at least one attribute is present.",
+      "properties": {
+        "binding": {
+          "type": "string",
+          "description": "Audio param / event / theme binding identifier (from node.audio_binding). Consumed by the binding resolver (bindParam JS helper + `pulp bindings check`)."
+        },
+        "units": {
+          "type": "string",
+          "description": "Display units for the audio-widget value (from node.audio_units)."
+        }
+      },
+      "additionalProperties": { "type": "string" }
     },
     "style": {
       "type": "object",
@@ -203,58 +239,33 @@
       },
       "additionalProperties": false
     },
-    "audio": {
-      "type": "object",
-      "description": "Present when node.type is one of the audio-widget kinds (knob/fader/meter/xy_pad/waveform/spectrum). Parser maps to IRNode.audio_label/audio_min/audio_max/audio_default and audio_widget enum (derived from node.type).",
-      "properties": {
-        "label": { "type": "string" },
-        "min": { "type": "number" },
-        "max": { "type": "number" },
-        "default": { "type": "number" },
-        "value_domain": {
-          "type": "string",
-          "enum": ["normalized", "raw"],
-          "default": "normalized",
-          "description": "normalized = 0..1 (param-range mapping applied at runtime); raw = values are in real units (passed through to setParam)."
-        },
-        "step": { "type": "number" }
-      },
-      "additionalProperties": false
-    },
-    "binding": {
-      "type": "object",
-      "description": "Audio param / event / theme binding metadata. Carries forward into IRNode.attributes['binding'] as a JSON-encoded string and is consumed by the binding resolver (bindParam JS helper + `pulp bindings check`).",
-      "required": ["kind", "key", "source", "resolved"],
-      "properties": {
-        "kind": { "type": "string", "enum": ["param", "event", "theme", "none"] },
-        "key": { "type": "string", "description": "Designer-supplied identifier. Matches against ParamInfo.name for kind=param. Blank means TODO_BIND." },
-        "source": { "type": "string", "enum": ["figma-component-property", "figma-name-suffix", "none"] },
-        "resolved": { "type": "boolean", "description": "False initially; flipped to true by `pulp bindings` after StateStore registration check." }
-      },
-      "additionalProperties": false
-    },
     "figma_metadata": {
       "type": "object",
-      "description": "Figma-specific metadata captured at extraction. Parser flattens to IRNode.attributes['figma:*'] keys as JSON-encoded strings.",
+      "description": "Figma-specific identity / provenance, packed into the node's `figma` sub-object by serialize.ts. The C++ parser reads figma.library_widget_kind / figma.component_key as needed. The six positional fields below are always present; the component/library fields are emitted only when the node is an instance / recognised library widget.",
+      "required": ["parent_id", "z_order", "absolute_transform", "visible", "locked", "blend_mode"],
       "properties": {
-        "component_key": { "type": "string" },
-        "component_set_name": { "type": "string" },
-        "main_component_id": { "type": "string" },
-        "main_component_name": { "type": "string" },
-        "library_widget_kind": { "type": "string" },
-        "library_version": { "type": "string" },
-        "component_properties": { "type": "object", "additionalProperties": true },
-        "variant_properties": { "type": "object", "additionalProperties": { "type": "string" } },
         "parent_id": { "type": ["string", "null"] },
         "z_order": { "type": "integer" },
         "absolute_transform": {
           "type": "array",
-          "items": { "type": "array", "items": { "type": "number" } }
+          "items": { "type": "array", "items": { "type": "number" } },
+          "description": "Node.relative_transform copied through as a 2x3 affine matrix."
         },
         "visible": { "type": "boolean", "default": true },
         "locked": { "type": "boolean", "default": false },
         "blend_mode": { "type": "string" },
-        "mask": { "type": "boolean", "description": "True if this node is a mask layer. Pulp does not support masks; importer emits opaque + diagnostic." }
+        "component_key": { "type": "string" },
+        "component_set_name": { "type": "string" },
+        "main_component_id": { "type": "string" },
+        "main_component_name": { "type": "string" },
+        "library_widget_kind": {
+          "type": "string",
+          "description": "Recognised Pulp widget kind, mirrors the node-root audio_widget field.",
+          "enum": ["knob", "fader", "meter", "xy_pad", "waveform", "spectrum"]
+        },
+        "library_version": { "type": "string" },
+        "component_properties": { "type": "object", "additionalProperties": true },
+        "variant_properties": { "type": "object", "additionalProperties": { "type": "string" } }
       },
       "additionalProperties": true
     },

--- a/tools/figma-plugin/scripts/test.mjs
+++ b/tools/figma-plugin/scripts/test.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// Test runner for the Figma plugin.
+//
+// The plugin sources are TypeScript that also import JSON
+// (library-manifest.json) and reference Figma sandbox globals. Rather than
+// pull in a TS test loader, we reuse esbuild (already a devDep, same as
+// scripts/build.mjs) to bundle each test/*.test.ts file — together with the
+// real plugin sources it imports — into a temporary .mjs, then hand the
+// bundle to Node's built-in test runner (`node --test`). This exercises the
+// REAL serialize / library-registry code, not a reimplementation.
+
+import { build } from "esbuild";
+import { spawnSync } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, "..");
+const testDir = path.join(root, "test");
+
+const entries = (await fs.readdir(testDir))
+  .filter((f) => f.endsWith(".test.ts"))
+  .map((f) => path.join(testDir, f));
+
+if (entries.length === 0) {
+  console.error("[pulp figma plugin] no test/*.test.ts files found");
+  process.exit(1);
+}
+
+const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "pulp-figma-test-"));
+
+try {
+  await build({
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    target: ["node18"],
+    entryPoints: entries,
+    outdir: outDir,
+    outExtension: { ".js": ".mjs" },
+    logLevel: "warning",
+    // node:test / node:assert stay external so the real built-in runner is used.
+    external: ["node:test", "node:assert"],
+  });
+
+  const bundled = (await fs.readdir(outDir))
+    .filter((f) => f.endsWith(".mjs"))
+    .map((f) => path.join(outDir, f));
+
+  const res = spawnSync(
+    process.execPath,
+    ["--test", ...bundled],
+    { stdio: "inherit" },
+  );
+  process.exit(res.status ?? 1);
+} finally {
+  await fs.rm(outDir, { recursive: true, force: true });
+}

--- a/tools/figma-plugin/src/types.generated.ts
+++ b/tools/figma-plugin/src/types.generated.ts
@@ -32,7 +32,7 @@ export interface PulpFigmaPluginExport {
     exported_at?: string;
   };
   /**
-   * Pulp Figma Library version metadata at time of export. Plugin reads tools/figma-plugin/library-manifest.json and copies the active section here.
+   * Pulp Figma Library version metadata at time of export. Plugin reads tools/figma-plugin/library-manifest.json and copies the active section here. Emitted as null when no library snapshot is available (serialize.ts: ctx.libraryManifest ?? null).
    */
   library_manifest?: {
     library_version?: string;
@@ -43,7 +43,7 @@ export interface PulpFigmaPluginExport {
        */
       [k: string]: string;
     };
-  };
+  } | null;
   /**
    * Design tokens extracted from Figma variables. Maps to IRTokens in Pulp.
    */
@@ -122,6 +122,9 @@ export interface Diagnostic {
   anchor_id?: string;
   property?: string;
 }
+/**
+ * An IR node as emitted by serialize.ts::toEnvelopeNode. Semantic audio-widget data lives at the NODE ROOT (audio_widget/label/min/max/default + attributes.binding), NOT in nested audio/binding sub-objects. The C++ parser (core/view/src/design_ir_json.cpp::parse_ir_node) reads these root-level fields directly.
+ */
 export interface Node {
   /**
    * Node kind. Pulp library widgets get specific kinds (knob, fader, meter, ...). Everything else is one of the generic types.
@@ -152,16 +155,49 @@ export interface Node {
    * Text content (when type=text). Maps to IRNode.text_content.
    */
   content?: string;
+  /**
+   * Recognised Pulp audio-widget kind. Emitted at the node root when serialize.ts sees node.library_widget_kind. The C++ parser maps this onto IRNode.audio_widget (enum). Equal to figma.library_widget_kind when present.
+   */
+  audio_widget?: "knob" | "fader" | "meter" | "xy_pad" | "waveform" | "spectrum";
+  /**
+   * Audio-widget label. Root-level; maps to IRNode.audio_label.
+   */
+  label?: string;
+  /**
+   * Audio-widget minimum value. Root-level; maps to IRNode.audio_min.
+   */
+  min?: number;
+  /**
+   * Audio-widget maximum value. Root-level; maps to IRNode.audio_max.
+   */
+  max?: number;
+  /**
+   * Audio-widget default value. Root-level; maps to IRNode.audio_default.
+   */
+  default?: number;
+  attributes?: Attributes;
   style?: Style;
   layout?: Layout;
-  audio?: Audio;
-  binding?: Binding;
   figma?: FigmaMetadata;
   /**
    * When type=image, references asset_manifest.assets[*].asset_id
    */
   asset_ref?: string;
   children?: Node[];
+}
+/**
+ * Free-form string passthrough map emitted at the node root by serialize.ts. Each entry becomes an IRNode.attributes[*] entry in the C++ parser. Emitted only when at least one attribute is present.
+ */
+export interface Attributes {
+  /**
+   * Audio param / event / theme binding identifier (from node.audio_binding). Consumed by the binding resolver (bindParam JS helper + `pulp bindings check`).
+   */
+  binding?: string;
+  /**
+   * Display units for the audio-widget value (from node.audio_units).
+   */
+  units?: string;
+  [k: string]: string;
 }
 /**
  * Snake_case keys. Parser maps to IRStyle (which uses the same snake_case in C++).
@@ -238,43 +274,26 @@ export interface Layout {
   height_mode?: "fixed" | "hug" | "fill";
 }
 /**
- * Present when node.type is one of the audio-widget kinds (knob/fader/meter/xy_pad/waveform/spectrum). Parser maps to IRNode.audio_label/audio_min/audio_max/audio_default and audio_widget enum (derived from node.type).
- */
-export interface Audio {
-  label?: string;
-  min?: number;
-  max?: number;
-  default?: number;
-  /**
-   * normalized = 0..1 (param-range mapping applied at runtime); raw = values are in real units (passed through to setParam).
-   */
-  value_domain?: "normalized" | "raw";
-  step?: number;
-}
-/**
- * Audio param / event / theme binding metadata. Carries forward into IRNode.attributes['binding'] as a JSON-encoded string and is consumed by the binding resolver (bindParam JS helper + `pulp bindings check`).
- */
-export interface Binding {
-  kind: "param" | "event" | "theme" | "none";
-  /**
-   * Designer-supplied identifier. Matches against ParamInfo.name for kind=param. Blank means TODO_BIND.
-   */
-  key: string;
-  source: "figma-component-property" | "figma-name-suffix" | "none";
-  /**
-   * False initially; flipped to true by `pulp bindings` after StateStore registration check.
-   */
-  resolved: boolean;
-}
-/**
- * Figma-specific metadata captured at extraction. Parser flattens to IRNode.attributes['figma:*'] keys as JSON-encoded strings.
+ * Figma-specific identity / provenance, packed into the node's `figma` sub-object by serialize.ts. The C++ parser reads figma.library_widget_kind / figma.component_key as needed. The six positional fields below are always present; the component/library fields are emitted only when the node is an instance / recognised library widget.
  */
 export interface FigmaMetadata {
+  parent_id: string | null;
+  z_order: number;
+  /**
+   * Node.relative_transform copied through as a 2x3 affine matrix.
+   */
+  absolute_transform: number[][];
+  visible: boolean;
+  locked: boolean;
+  blend_mode: string;
   component_key?: string;
   component_set_name?: string;
   main_component_id?: string;
   main_component_name?: string;
-  library_widget_kind?: string;
+  /**
+   * Recognised Pulp widget kind, mirrors the node-root audio_widget field.
+   */
+  library_widget_kind?: "knob" | "fader" | "meter" | "xy_pad" | "waveform" | "spectrum";
   library_version?: string;
   component_properties?: {
     [k: string]: unknown;
@@ -282,15 +301,5 @@ export interface FigmaMetadata {
   variant_properties?: {
     [k: string]: string;
   };
-  parent_id?: string | null;
-  z_order?: number;
-  absolute_transform?: number[][];
-  visible?: boolean;
-  locked?: boolean;
-  blend_mode?: string;
-  /**
-   * True if this node is a mask layer. Pulp does not support masks; importer emits opaque + diagnostic.
-   */
-  mask?: boolean;
   [k: string]: unknown;
 }

--- a/tools/figma-plugin/test/library-registry.test.ts
+++ b/tools/figma-plugin/test/library-registry.test.ts
@@ -1,0 +1,72 @@
+// Exercises the REAL recognition logic in src/library-registry.ts against the
+// real tools/figma-plugin/library-manifest.json. These are the two functions
+// extract.ts calls to decide whether a Figma instance is a Pulp library widget.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  widgetKindByLibraryKey,
+  widgetKindByNamePrefix,
+  entryForKind,
+  LIBRARY_VERSION,
+} from "../src/library-registry";
+import manifest from "../library-manifest.json";
+
+test("widgetKindByLibraryKey: real knob component_set_key → 'knob'", () => {
+  const knobKey = manifest.widgets.knob.component_set_key;
+  assert.equal(widgetKindByLibraryKey(knobKey), "knob");
+});
+
+test("widgetKindByLibraryKey: real fader/meter keys resolve to their kinds", () => {
+  assert.equal(
+    widgetKindByLibraryKey(manifest.widgets.fader.component_set_key),
+    "fader",
+  );
+  assert.equal(
+    widgetKindByLibraryKey(manifest.widgets.meter.component_set_key),
+    "meter",
+  );
+});
+
+test("widgetKindByLibraryKey: unknown / nullish keys → undefined", () => {
+  assert.equal(widgetKindByLibraryKey("not-a-pulp-key"), undefined);
+  assert.equal(widgetKindByLibraryKey(undefined), undefined);
+  assert.equal(widgetKindByLibraryKey(null), undefined);
+  assert.equal(widgetKindByLibraryKey(""), undefined);
+});
+
+test("widgetKindByLibraryKey: placeholder TBD- keys are never registered", () => {
+  // Any manifest entry whose key is a TBD- placeholder must NOT be a real
+  // collision target. Guard so a future placeholder doesn't silently match.
+  for (const w of Object.values(manifest.widgets)) {
+    if (w.component_set_key.startsWith("TBD-")) {
+      assert.equal(widgetKindByLibraryKey(w.component_set_key), undefined);
+    }
+  }
+});
+
+test("widgetKindByNamePrefix: 'Pulp / Knob …' → 'knob'", () => {
+  assert.equal(widgetKindByNamePrefix("Pulp / Knob"), "knob");
+  assert.equal(widgetKindByNamePrefix("Pulp / Knob / Large"), "knob");
+});
+
+test("widgetKindByNamePrefix: case-insensitive", () => {
+  assert.equal(widgetKindByNamePrefix("pulp / knob"), "knob");
+  assert.equal(widgetKindByNamePrefix("PULP / KNOB / Cutoff"), "knob");
+});
+
+test("widgetKindByNamePrefix: non-Pulp name → undefined", () => {
+  assert.equal(widgetKindByNamePrefix("Rectangle 42"), undefined);
+  assert.equal(widgetKindByNamePrefix("Some Other / Knob"), undefined);
+  assert.equal(widgetKindByNamePrefix(undefined), undefined);
+  assert.equal(widgetKindByNamePrefix(""), undefined);
+});
+
+test("entryForKind + LIBRARY_VERSION are wired from the manifest", () => {
+  assert.equal(LIBRARY_VERSION, manifest.library_version);
+  const knob = entryForKind("knob");
+  assert.ok(knob);
+  assert.equal(knob.component_set_key, manifest.widgets.knob.component_set_key);
+  assert.equal(knob.name_prefix, "Pulp / Knob");
+});

--- a/tools/figma-plugin/test/serialize.test.ts
+++ b/tools/figma-plugin/test/serialize.test.ts
@@ -1,0 +1,222 @@
+// Exercises the REAL emitter (src/serialize.ts::serializeExport) end-to-end and
+// asserts the de-facto wire shape the C++ importer
+// (core/view/src/design_ir_json.cpp::parse_ir_node) consumes: root-level
+// audio_widget / label / min / max / default, attributes.binding, and the
+// figma.library_widget_kind sub-object. It also validates a serialized knob
+// against schema/figma-plugin-export-v1.json so emitter ↔ schema can't drift.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { serializeExport, type SerializeContext } from "../src/serialize";
+import type { ExtractedFigmaNode } from "../src/extract-model";
+import { AssetCache } from "../src/assets";
+import schema from "../schema/figma-plugin-export-v1.json";
+
+function baseNode(over: Partial<ExtractedFigmaNode>): ExtractedFigmaNode {
+  return {
+    type: "frame",
+    figma_type: "FRAME",
+    name: "Node",
+    figma_node_id: "1:2",
+    parent_id: null,
+    z_order: 0,
+    absolute_bounds: { x: 0, y: 0, w: 100, h: 100 },
+    relative_transform: [
+      [1, 0, 0],
+      [0, 1, 0],
+    ],
+    visible: true,
+    locked: false,
+    opacity: 1,
+    blend_mode: "NORMAL",
+    style: {},
+    layout: {},
+    children: [],
+    ...over,
+  };
+}
+
+function ctx(over: Partial<SerializeContext> = {}): SerializeContext {
+  return {
+    fileKey: "abc123",
+    rootNodeId: "1:2",
+    pluginVersion: "0.1.0",
+    assets: new AssetCache(),
+    tokens: { colors: {}, dimensions: {}, strings: {} },
+    ...over,
+  };
+}
+
+// A recognised Pulp knob, as the extractor would produce it for a published
+// "Pulp / Knob" instance (library kind stamped, structured audio props +
+// binding/units extracted from component properties).
+function knobNode(): ExtractedFigmaNode {
+  return baseNode({
+    type: "knob",
+    figma_type: "INSTANCE",
+    name: "Pulp / Knob",
+    figma_node_id: "3:74",
+    component_key: "f74264ffa9108521fb0d3398dc8f5ea88e23a84e",
+    main_component_name: "Pulp / Knob",
+    library_widget_kind: "knob",
+    library_version: "0.2.0",
+    audio_label: "Cutoff",
+    audio_min: 20,
+    audio_max: 20000,
+    audio_default: 1000,
+    audio_units: "Hz",
+    audio_binding: "cutoff",
+    asset_ref: "img-deadbeef0001",
+  });
+}
+
+function rootOf(out: unknown): Record<string, any> {
+  const env = out as Record<string, any>;
+  return env.root as Record<string, any>;
+}
+
+test("serializeExport: recognised knob emits root-level audio_widget + numeric fields", () => {
+  const out = serializeExport([knobNode()], [], ctx());
+  const root = rootOf(out);
+
+  assert.equal(root.type, "knob");
+  assert.equal(root.audio_widget, "knob");
+  assert.equal(root.label, "Cutoff");
+  assert.equal(root.min, 20);
+  assert.equal(root.max, 20000);
+  assert.equal(root.default, 1000);
+});
+
+test("serializeExport: binding + units land in attributes (NOT a binding sub-object)", () => {
+  const out = serializeExport([knobNode()], [], ctx());
+  const root = rootOf(out);
+
+  assert.deepEqual(root.attributes, { units: "Hz", binding: "cutoff" });
+  // Make sure the legacy nested shape is NOT emitted.
+  assert.equal(root.binding, undefined);
+  assert.equal(root.audio, undefined);
+});
+
+test("serializeExport: figma sub-object carries library_widget_kind + component_key", () => {
+  const out = serializeExport([knobNode()], [], ctx());
+  const root = rootOf(out);
+
+  assert.ok(root.figma, "expected a figma sub-object");
+  assert.equal(root.figma.library_widget_kind, "knob");
+  assert.equal(root.figma.component_key, "f74264ffa9108521fb0d3398dc8f5ea88e23a84e");
+  assert.equal(root.figma.library_version, "0.2.0");
+  // The six always-present positional fields.
+  assert.equal(root.figma.parent_id, null);
+  assert.equal(root.figma.z_order, 0);
+  assert.equal(root.figma.visible, true);
+  assert.equal(root.figma.locked, false);
+  assert.equal(root.figma.blend_mode, "NORMAL");
+  assert.deepEqual(root.figma.absolute_transform, [
+    [1, 0, 0],
+    [0, 1, 0],
+  ]);
+});
+
+test("serializeExport: envelope carries provenance + format_version", () => {
+  const out = serializeExport([knobNode()], [], ctx()) as Record<string, any>;
+  assert.equal(out.format_version, "2026.05-figma-plugin-v1");
+  assert.equal(out.provenance.adapter, "figma-plugin");
+  assert.equal(out.provenance.version, "0.1.0");
+  assert.equal(out.provenance.source_uri, "figma://abc123/1:2");
+});
+
+test("serializeExport: a plain frame serializes WITHOUT audio_widget (generic)", () => {
+  const frame = baseNode({
+    type: "frame",
+    name: "Panel",
+    figma_node_id: "5:9",
+  });
+  const out = serializeExport([frame], [], ctx());
+  const root = rootOf(out);
+
+  assert.equal(root.type, "frame");
+  assert.equal(root.audio_widget, undefined);
+  assert.equal(root.label, undefined);
+  assert.equal(root.min, undefined);
+  assert.equal(root.max, undefined);
+  assert.equal(root.default, undefined);
+  assert.equal(root.attributes, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Emitter ↔ schema agreement. A tiny structural validator over the subset of
+// JSON Schema the export uses (type, enum, required, properties, $ref,
+// additionalProperties for the node-level objects we assert on). Proves the
+// serialized knob conforms to the updated schema/figma-plugin-export-v1.json.
+// ---------------------------------------------------------------------------
+
+function resolveRef(ref: string, root: any): any {
+  // Only local "#/$defs/<name>" refs are used in this schema.
+  const m = /^#\/\$defs\/(.+)$/.exec(ref);
+  if (!m) throw new Error(`unsupported $ref: ${ref}`);
+  return root.$defs[m[1]];
+}
+
+function validate(value: any, sch: any, root: any, path: string, errors: string[]): void {
+  if (sch.$ref) {
+    validate(value, resolveRef(sch.$ref, root), root, path, errors);
+    return;
+  }
+  const types = Array.isArray(sch.type) ? sch.type : sch.type ? [sch.type] : [];
+  if (types.length > 0) {
+    const ok = types.some((t: string) => matchesType(value, t));
+    if (!ok) {
+      errors.push(`${path}: expected type ${types.join("|")}, got ${value === null ? "null" : typeof value}`);
+      return;
+    }
+  }
+  if (sch.enum && !sch.enum.includes(value)) {
+    errors.push(`${path}: value ${JSON.stringify(value)} not in enum ${JSON.stringify(sch.enum)}`);
+  }
+  if (matchesType(value, "object") && value !== null) {
+    if (Array.isArray(sch.required)) {
+      for (const r of sch.required) {
+        if (!(r in value)) errors.push(`${path}: missing required property '${r}'`);
+      }
+    }
+    const props = sch.properties ?? {};
+    for (const [k, v] of Object.entries(value)) {
+      if (props[k]) {
+        validate(v, props[k], root, `${path}/${k}`, errors);
+      } else if (sch.additionalProperties === false) {
+        errors.push(`${path}: unexpected property '${k}' (additionalProperties:false)`);
+      } else if (sch.additionalProperties && typeof sch.additionalProperties === "object") {
+        validate(v, sch.additionalProperties, root, `${path}/${k}`, errors);
+      }
+    }
+  }
+  if (sch.type === "array" && Array.isArray(value) && sch.items) {
+    value.forEach((el: any, i: number) => validate(el, sch.items, root, `${path}[${i}]`, errors));
+  }
+}
+
+function matchesType(value: any, t: string): boolean {
+  switch (t) {
+    case "object": return typeof value === "object" && value !== null && !Array.isArray(value);
+    case "array": return Array.isArray(value);
+    case "string": return typeof value === "string";
+    case "number": return typeof value === "number";
+    case "integer": return typeof value === "number" && Number.isInteger(value);
+    case "boolean": return typeof value === "boolean";
+    case "null": return value === null;
+    default: return true;
+  }
+}
+
+test("serialized knob validates against figma-plugin-export-v1 schema", () => {
+  const out = serializeExport([knobNode()], [], ctx());
+  const errors: string[] = [];
+  validate(out, schema as any, schema as any, "$", errors);
+  assert.deepEqual(errors, [], `schema violations:\n${errors.join("\n")}`);
+
+  // And specifically the node-level shape we care about.
+  const nodeErrors: string[] = [];
+  validate(rootOf(out), (schema as any).$defs.node, schema as any, "root", nodeErrors);
+  assert.deepEqual(nodeErrors, [], `node schema violations:\n${nodeErrors.join("\n")}`);
+});


### PR DESCRIPTION
## What
Two fixes from the figma-plugin import review, plugin-side only (no C++, no
runtime emission change):

### Gap 2 — align the export schema with what the plugin actually emits
`schema/figma-plugin-export-v1.json` declared the semantic data in `audio` /
`binding` **sub-objects**, but `serialize.ts` (and the C++ parser
`design_ir_json.cpp`) actually use **node-root** fields: `audio_widget`,
`label`/`min`/`max`/`default`, `attributes.{binding,units}`, and a `figma`
sub-object. Serializer and parser already agreed; only the published schema was
wrong. This rewrites the schema to match the **real** shape (root-level semantic
fields, typed `attributes`, documented `figma` object, deleted the unused
`audio`/`binding` defs, `library_manifest` nullable). `serialize.ts` runtime
output is **unchanged** (`git diff src/serialize.ts` empty); `gen-types`,
`typecheck`, and `build` stay green.

### Gap 1 — no test exercised the real emitter
Added Node's built-in test runner (`node --test`, no new heavy deps) + a `test`
script, and tests that drive the **real** emitter/recognition code:
- `library-registry.test.ts` — `widgetKindByLibraryKey` (real manifest keys →
  kind) + `widgetKindByNamePrefix` ("Pulp / Knob" → knob, case-insensitive,
  non-Pulp → undefined).
- `serialize.test.ts` — drives the real `serializeExport`: a recognized knob →
  root-level `audio_widget:"knob"` + numerics + `attributes.binding` (asserts no
  nested `binding`/`audio`) + `figma.library_widget_kind`; a plain frame →
  **no** `audio_widget`; and validates a serialized knob against the updated
  schema (proving emitter ↔ schema agree — this caught the `library_manifest:
  null` mismatch).

`npm test`: **14/14 pass**.

## Not covered
`extract.ts` (the `figma.*` walker) is bound to the live Figma runtime and
wasn't mocked — the registry + serialize tests cover the load-bearing
recognition/emission logic it calls. A true end-to-end (real Figma export) is
tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)