### PR TITLE
docs(design-import): semantic model + Figma plugin setup/publish guide

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -28,6 +28,8 @@ If you prefer writing DSP in a dedicated language, Pulp integrates with Faust (o
 
 Import from Figma, Pencil.dev, Google Stich and more. Define your visual identity as a design token system — colors, typography, widget geometry, knob styles, button shapes, shadows, gradients. Apply one design language across many plugins. Change a token, and changes appear live in the standalone host via hot-reload.
 
+The Figma import is **semantic, not visual**. A Pulp library component — "Pulp / Knob", "Pulp / Fader", "Pulp / Meter" — tells Pulp *what a control is* (its parameter binding, label, range, and units), not just what it looks like. Recognition keys off component identity, so you can restyle freely without breaking the binding. The library is **additive fidelity**: a design that uses none of it still imports, and every Pulp component you add upgrades exactly the control it sits on. Author once in Figma, then flow the same design into a **live JavaScript UI**, a **native app**, or a **fully compiled C++ plugin** — no rebuilding the UI by hand. (Details: [`docs/reference/design-import-model.md`](docs/reference/design-import-model.md).)
+
 Describe a look in natural language — "80s Macintosh", "neon cyberpunk", "minimal Dieter Rams" — and watch the entire interface transform. The design system is structured data, not compiled C++, so any AI tool that can read JSON can modify your theme.
 
 Tokens export to JSON, CSS variables, C++ headers, GPU shader uniforms, and OKLCH color systems.

--- a/docs/guides/figma-plugin.md
+++ b/docs/guides/figma-plugin.md
@@ -1,0 +1,173 @@
+# The "Design for Pulp" Figma plugin
+
+This guide covers getting the Figma plugin, exporting a design, and feeding it
+to Pulp. There are **two install paths** and they are easy to mix up, so they
+are spelled out separately below:
+
+- **[A) Install from the Figma Community](#a-install-from-the-figma-community)** —
+  no build step, for designers.
+- **[B) Local development install](#b-local-development-install)** — for
+  contributors and pre-publish testing.
+
+For the conceptual model behind the import (semantic-not-visual, the
+additive-fidelity guarantee, restyling), read
+[The Figma → Pulp Design-Import Model](../reference/design-import-model.md)
+first. For the full CLI reference, see
+[Design Import API Reference](../reference/design-import.md).
+
+---
+
+## A) Install from the Figma Community
+
+This is the path for designers. **No build step, ever.**
+
+> **Status: once published.** At the time of writing, the plugin's publish to
+> the Figma Community is in progress. The **component library** below is already
+> published and usable today. Until the plugin is live in the Community, use the
+> [local development install](#b-local-development-install).
+
+1. **Install the plugin.** In Figma, install the **"Design for Pulp"** plugin
+   from the Figma Community.
+
+2. **Add the Pulp component library.** Add the published example library so you
+   can drop "Pulp / Knob", "Pulp / Fader", and "Pulp / Meter" instances into
+   your design:
+   <https://www.figma.com/community/file/1642409275200893924>
+
+3. **Design.** Lay out your plugin UI. Drop in Pulp library components wherever
+   you want a recognized, parameter-bound control. Restyle them however you like
+   — the [semantic link survives restyling](../reference/design-import-model.md#restyle-freely).
+
+4. **Export.** Select the frame(s) you want, run the plugin, and choose
+   **Export to Pulp**. The plugin downloads a `*.pulp.json` file (or a
+   `*.pulp.zip` when your design includes image assets — see
+   [Exports with assets](#exports-with-assets)).
+
+5. **Import into Pulp:**
+
+   ```bash
+   pulp import-design --from figma-plugin my-design.pulp.json
+   ```
+
+That's the whole loop. No build, no toolchain.
+
+---
+
+## B) Local development install
+
+This is the path for contributors, and the only path until the plugin is
+published to the Community.
+
+### Build the plugin
+
+```bash
+cd tools/figma-plugin
+npm install
+npm run gen-types   # only if the export schema changed
+npm run build       # produces dist/code.js + dist/ui.html
+```
+
+`npm run gen-types` regenerates `src/types.generated.ts` from
+`schema/figma-plugin-export-v1.json`; you only need it when that schema
+changes. `npm run build` is what produces the runnable plugin in `dist/`.
+
+### Import it into Figma (first time only)
+
+In Figma **desktop**:
+
+1. **Plugins → Development → Import plugin from manifest…**
+2. Pick `tools/figma-plugin/manifest.json` from your checkout.
+
+The plugin now appears under **Plugins → Development → Design for Pulp**.
+
+### Rebuild, don't re-import
+
+This is the **#1 point of confusion**, so read it carefully:
+
+> **After the first import, you pick up code changes by *rebuild + re-run*, NOT
+> by re-importing.** Figma re-reads `dist/` fresh every time you run the plugin.
+> You only **re-import the manifest** if `manifest.json` itself changes.
+
+In other words:
+
+| You changed…                              | What to do                       |
+|-------------------------------------------|----------------------------------|
+| anything under `tools/figma-plugin/src/**` | `npm run build`, then re-run the plugin in Figma |
+| the export schema (`schema/…-v1.json`)    | `npm run gen-types && npm run build`, then re-run |
+| `manifest.json`                           | **re-import** the manifest in Figma |
+
+**When you need to rebuild:** any time you pull new plugin changes, or edit
+anything under `src/**` or the export schema. To avoid running `npm run build`
+by hand each time, use the watcher:
+
+```bash
+npm run build:watch
+```
+
+Then just re-run the plugin in Figma after each save.
+
+### Gotcha: local-dev plugins need a Figma Pro workspace
+
+Figma only loads local-development plugins in a workspace/file that allows them
+— that's **Figma Pro**. Community and free files **reject** local-dev plugins.
+If the plugin won't load, **duplicate your design into a Pro file** and test
+there.
+
+---
+
+## Exports with assets
+
+The exporter downloads one of two things:
+
+- **`*.pulp.json`** — when your design has no image assets. This is the file you
+  pass directly to `pulp import-design --from figma-plugin`.
+- **`*.pulp.zip`** — when your design includes image assets. The zip contains a
+  `scene.pulp.json` plus the asset files. Unzip it and point the importer at the
+  extracted `scene.pulp.json`; the importer resolves the bundled assets from the
+  accompanying asset manifest.
+
+The plugin runs **entirely on your machine** — its manifest declares
+`networkAccess: { allowedDomains: ["none"] }`, so no design data leaves your
+computer.
+
+---
+
+## Publishing the plugin to the Figma Community (maintainers)
+
+Publishing is a **manual action in Figma desktop**. There is no CI step for it.
+
+1. In Figma desktop: **Plugins → Development → "Design for Pulp" → Publish…**
+   (or **Manage plugins → Publish**).
+
+2. Fill in Figma's publish form. It requires:
+   - a **128×128 icon**,
+   - a **cover image**,
+   - a **tagline + description**,
+   - **tags**,
+   - a **support contact**.
+
+   The manifest's `networkAccess` is `"none"` (no data leaves the machine),
+   which eases Figma's review.
+
+3. **Submit for review.** Approval typically takes a few days. Once approved,
+   the plugin is public.
+
+Two things live in the Figma Community and should be cross-linked for users:
+
+- the **component library** (already published):
+  <https://www.figma.com/community/file/1642409275200893924>
+- the **plugin** (this publish flow).
+
+---
+
+## See also
+
+- [The Figma → Pulp Design-Import Model](../reference/design-import-model.md) —
+  the conceptual model: semantic-not-visual, additive fidelity, restyle freely.
+- [Importing Designs](importing-designs.md) — the broader import guide across
+  all sources.
+- [Design Import API Reference](../reference/design-import.md) — CLI flags, IR,
+  validation, token sync.
+- `tools/figma-plugin/README.md` — plugin internals and dev layout.
+- `tools/figma-plugin/docs/building-the-pulp-library.md` — how the Pulp Figma
+  library file itself is built.

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,7 @@ MIT-licensed. No royalties. No copyleft.
 - [Building](guides/build.md) — requirements, options, platform notes
 - [Testing](guides/testing.md) — running tests, validation, writing tests
 - [Web Plugins](guides/web-plugins.md) — WAMv2, WebCLAP, browser demos
+- [Design from Figma](guides/figma-plugin.md) — the "Design for Pulp" plugin, export, and import ([model](reference/design-import-model.md))
 - [Docs Maintenance](guides/docs-maintenance.md) — how docs stay consistent with code
 
 ## Policies

--- a/docs/reference/design-import-model.md
+++ b/docs/reference/design-import-model.md
@@ -1,0 +1,159 @@
+# The Figma → Pulp Design-Import Model
+
+This is the conceptual reference for how a design authored in Figma becomes a
+Pulp UI. It is written for both designers and developers: designers who want to
+know *what to draw* and *how much they can restyle*, and developers who want to
+know *what gets wired automatically* and *what they still own*.
+
+For the practical how-to (installing the plugin, exporting, running
+`pulp import-design`), see the [Figma plugin guide](../guides/figma-plugin.md).
+For the CLI and pipeline reference, see
+[Design Import API Reference](design-import.md).
+
+---
+
+## The model: semantic, not visual
+
+Most design-to-code tools treat a design as a picture: they try to reproduce
+pixels. Pulp's import is different. When you drop a **Pulp library component**
+— "Pulp / Knob", "Pulp / Fader", "Pulp / Meter" — into your design, you are not
+just placing a graphic. You are declaring **what the control *means***.
+
+A Pulp library component carries semantic metadata alongside its appearance:
+
+- the kind of control it is (knob, fader, meter, …),
+- its label,
+- its parameter range (min / max / default),
+- its units,
+- and the parameter it should bind to.
+
+The picture tells Pulp how the control should *look*. The library component
+tells Pulp what the control *is*. Pulp imports the meaning, not just the
+pixels.
+
+### Three layers worth naming
+
+It helps to separate three distinct concerns:
+
+| Layer          | Who defines it          | What it controls |
+|----------------|-------------------------|------------------|
+| **Meaning**    | The Pulp library        | The semantic contract: this node is a knob bound to a parameter, with a label, range, and units. Fixed by the library component you chose. |
+| **Appearance** | You, the designer       | Everything visual: fill, size, typography, layout, corner radius, gradients, the whole look. Fully customizable. |
+| **Route**      | Pulp, per control       | How the control is realized at runtime — a native widget, a custom-rendered widget, or a live/visual fallback. Decided by the importer from the meaning it recognized. |
+
+You own **appearance**. The library defines **meaning**. Pulp decides the
+**route**. Keeping these three apart is the key to understanding everything
+below.
+
+---
+
+## The additive-fidelity guarantee
+
+The single most important property of this pipeline: **the Pulp library is
+purely additive fidelity. It only ever helps — it never gates the import.**
+
+Concretely:
+
+- **A design that uses *none* of the Pulp library components still imports.**
+  It does not break. Nodes the importer doesn't recognize as semantic controls
+  fall back to a visual/live route — the importer's fallback route for an
+  untagged node is `hybrid`, with a recorded `fallback_reason` so the choice is
+  always explainable. You get a faithful import of the layout and visuals; you
+  just wire up the behavior yourself afterward.
+
+- **Linking a "Pulp / Knob" *upgrades* that node.** Where a recognized library
+  component is present, the importer keys off its `audio_widget` semantic field
+  and imports the node as a **native Knob** with its parameter binding already
+  wired. Recognition is by the published component's **key** (authoritative),
+  and as a fallback by **name prefix** ("Pulp / Knob…") for designs that follow
+  the naming convention without having pulled in the published library.
+
+- **Net effect:** every Pulp library component you use raises the fidelity of
+  that one control from "draw it, wire it yourself" to "recognized, bound,
+  native." Components you *don't* use cost you nothing — they import as before.
+  There is no all-or-nothing cliff. Start with zero Pulp components and a design
+  still imports; add them one at a time and each one upgrades exactly the
+  control it sits on.
+
+> Mapping precedence inside the importer is `audio_widget` first, then the
+> node's element type, then HTML-style subtype attributes — with anything
+> unsupported degrading to a diagnostic rather than failing the import.
+
+---
+
+## Restyle freely
+
+A common worry: *if I change how the Pulp / Knob looks, will Pulp stop
+recognizing it?* No.
+
+Recognition keys off the **component identity** — the Figma library component
+and its name — **not the pixels**. In Figma, an instance keeps its link to the
+main component even when you override its fill, size, text, layout, or corner
+radius. Those overrides are exactly what instance overrides are *for*. So:
+
+- Repaint the knob, resize it, swap its label font, restructure its
+  auto-layout — **the semantic link survives.** The instance is still a
+  "Pulp / Knob", so it still imports as a native, bound Knob.
+- The library defines **meaning**; your design defines **appearance**. Changing
+  appearance never severs meaning.
+
+This is what makes the model usable for real design work: you are not boxed
+into the library's default look. You inherit the library's *semantics* and keep
+*total* control over the visuals.
+
+---
+
+## One design → multiple runtimes
+
+The same imported design is not tied to a single output. Author once in Figma,
+then flow it into whichever runtime fits the moment:
+
+- **Live JavaScript UI** — for rapid iteration and hot reload. Change the design
+  or the script and see it immediately.
+- **Native desktop / mobile app** — the design materializes into Pulp's native
+  view tree.
+- **Fully compiled C++ app or audio plugin** — the design bakes into C++ for the
+  production plugin or app.
+
+You don't rebuild the UI by hand for each target. The import pipeline carries
+one design into all three. (The CLI flags that select these — `--mode live` vs
+`--mode baked`, `--emit js|ir-json|cpp` — are documented in the
+[Design Import API Reference](design-import.md).)
+
+---
+
+## Where the contract lives (cross-links)
+
+The model above is backed by machine-readable schemas and an agent-facing
+skill, so the behavior is checkable, not just described:
+
+- **The semantic source contract** —
+  [`tools/import-validation/schemas/source-contract-v0.schema.json`](https://github.com/danielraffel/pulp/blob/main/tools/import-validation/schemas/source-contract-v0.schema.json).
+  One serialized shape for the per-node source / route / value / event / state /
+  style evidence, shared by the C++ importer and the audit summary so both can
+  be checked against a single definition. This is where the route taxonomy
+  (`native_cpp`, `native_html`, `live_js`, `hybrid`, `recorded_paint`,
+  `unsupported`) and the `fallback_reason` field are defined.
+
+- **The Figma plugin export schema** —
+  [`tools/figma-plugin/schema/figma-plugin-export-v1.json`](https://github.com/danielraffel/pulp/blob/main/tools/figma-plugin/schema/figma-plugin-export-v1.json).
+  The JSON shape the "Design for Pulp" plugin emits, including the audio-widget
+  fields that the importer maps to `audio_widget` / `audio_label` /
+  `audio_min` / `audio_max` / `audio_default`.
+
+- **The agent-facing skill** —
+  [`.agents/skills/import-design/SKILL.md`](https://github.com/danielraffel/pulp/blob/main/.agents/skills/import-design/SKILL.md).
+  How Claude Code and Codex drive the import end to end, including the mapping
+  precedence and native-resolution layer.
+
+---
+
+## See also
+
+- [Figma plugin guide](../guides/figma-plugin.md) — install the plugin, export,
+  and run the importer.
+- [Importing Designs](../guides/importing-designs.md) — the broader import guide
+  covering all sources (Figma, Stitch, v0, Pencil, …).
+- [Design Import API Reference](design-import.md) — CLI flags, IR, validation.
+- [Layout model](layout-model.md) — why Pulp is Flexbox + Grid only, and why
+  that keeps the design-import contract clean.

--- a/docs/status/docs-index.yaml
+++ b/docs/status/docs-index.yaml
@@ -159,6 +159,11 @@ docs:
     kind: guide
     summary: Importing UI structure and design tokens from Figma, Stitch, v0, and Pencil
 
+  - slug: figma-plugin
+    path: guides/figma-plugin.md
+    kind: guide
+    summary: The "Design for Pulp" Figma plugin — Community install, local-dev install (rebuild-not-reimport), export, and publishing
+
   - slug: design-debugging
     path: guides/design-debugging.md
     kind: guide
@@ -298,6 +303,11 @@ docs:
     path: reference/design-import.md
     kind: reference
     summary: CLI and pipeline reference for design import adapters, IR, validation, and token sync
+
+  - slug: design-import-model
+    path: reference/design-import-model.md
+    kind: reference
+    summary: Conceptual model for Figma → Pulp import — semantic-not-visual, the additive-fidelity guarantee, restyle freely, and one design → live-JS/native/compiled-C++
 
   - slug: design-ir-v1
     path: reference/design-ir-v1.md

--- a/tools/figma-plugin/README.md
+++ b/tools/figma-plugin/README.md
@@ -2,7 +2,16 @@
 
 Exports Figma designs to a Pulp-native JSON schema that the Pulp importer (`pulp import-design --from figma-plugin`) consumes. Plan: [`planning/2026-05-28-pulp-figma-plugin-strategy.md`](../../planning/2026-05-28-pulp-figma-plugin-strategy.md) (in the `pulp-planning` submodule).
 
-Phase 1 status: **scaffold only.** The plugin loads in Figma, shows its UI, reports your current selection back. No extraction or export yet — Phase 2a adds the walker.
+**Status: working exporter with Pulp library recognition.** The plugin walks the
+selected frame(s), extracts geometry / layout / typography / style / tokens /
+assets, recognizes Pulp library components (Knob / Fader / Meter) and emits them
+as semantic audio-widget nodes, and exports a `*.pulp.json` (or `*.pulp.zip`
+when assets are present) that `pulp import-design --from figma-plugin` consumes.
+The exporter lives in `src/extract.ts`, `src/serialize.ts`, and
+`src/library-registry.ts`, and builds to `dist/code.js`.
+
+For full setup — both the Figma Community install path and the local-dev path,
+plus publishing — see [`docs/guides/figma-plugin.md`](../../docs/guides/figma-plugin.md).
 
 ---
 
@@ -16,14 +25,21 @@ npm run build         # produces dist/code.js + dist/ui.html
 npm run typecheck     # both sides
 ```
 
-Then in Figma desktop:
+Then in Figma desktop (**first time only**):
 
-1. Open any file.
+1. Open any file (a **Figma Pro** workspace — local-dev plugins don't load in
+   Community/free files).
 2. **Plugins → Development → Import plugin from manifest…**
 3. Pick `tools/figma-plugin/manifest.json` from this checkout.
 4. **Plugins → Development → Design for Pulp** to launch.
 
-Select a frame in your Figma canvas and click "Refresh selection" — the plugin echoes its name and type back. That's the Phase 1 milestone.
+Select a frame, then **Export to Pulp** to download the `*.pulp.json` (or
+`*.pulp.zip` when the design has assets).
+
+**Rebuild, don't re-import.** After the first manifest import, code changes are
+picked up by **`npm run build` + re-running the plugin** — Figma re-reads
+`dist/` fresh on every run. You only **re-import the manifest** if
+`manifest.json` itself changes. Use `npm run build:watch` to rebuild on save.
 
 ---
 
@@ -74,11 +90,20 @@ The plugin embeds its `library_manifest` snapshot into every export so the Pulp 
 
 ---
 
-## Next phases
+## Pipeline (all landed)
 
-- **Phase 2a** — Figma extractor: walk selection, build the `ExtractedFigmaNode` model in memory.
-- **Phase 2b** — Serialize the model into the v1 JSON schema.
-- **Phase 3** — Recognize Pulp Library components and emit them as widget nodes (knob/fader/meter/…) instead of generic frames.
-- **Phase 4** — Pulp CLI lane: `parse_figma_plugin_json` parser in `core/view/src/`, `--from figma-plugin` dispatch in the CLI.
+- **Extract** (`src/extract.ts`) — walk the selection into an `ExtractedFigmaNode`
+  tree: geometry, auto-layout, typography, fills/strokes/radius/opacity, images,
+  and recursive children.
+- **Recognize** (`src/library-registry.ts`) — map Pulp library component
+  instances to audio-widget kinds (Knob / Fader / Meter), authoritatively by
+  component key and as a fallback by name prefix.
+- **Serialize** (`src/serialize.ts`) — emit the v1 JSON envelope declared in
+  `schema/figma-plugin-export-v1.json`, with provenance, the library-manifest
+  snapshot, tokens, an asset manifest, and diagnostics.
+- **Import** — the Pulp CLI lane: `parse_figma_plugin_json` in
+  `core/view/src/design_import.cpp`, reached via
+  `pulp import-design --from figma-plugin`.
 
-See the planning doc for details.
+See the planning doc and [`docs/guides/figma-plugin.md`](../../docs/guides/figma-plugin.md)
+for details.


### PR DESCRIPTION
## What
User-facing documentation for the Figma → Pulp design-import pipeline, written
to answer the real questions that were unclear, all verified against the code.

### New
- **`docs/reference/design-import-model.md`** — the conceptual model: semantic
  (not visual); the three layers **meaning / appearance / route**; the
  **additive-fidelity guarantee** (a design with zero Pulp components still
  imports — the library only ever *upgrades* recognized controls, never gates
  the import); **restyle freely** (recognition keys off component identity, not
  pixels, so overriding fill/size/text keeps the semantic link); and one design →
  **live-JS / native / compiled-C++**. Cross-links the `source-contract-v0` +
  plugin export schemas and the import-design skill.
- **`docs/guides/figma-plugin.md`** — getting + using the plugin, both paths
  spelled out separately so they can't be confused:
  - **Published Community** (no build; install plugin + the library —
    https://www.figma.com/community/file/1642409275200893924), marked "once
    published" where the plugin publish is still in progress.
  - **Local development** — `npm run build`, and the key clarification that code
    changes are picked up by **rebuild + re-run, not re-import** (re-import only
    when `manifest.json` changes); when a rebuild is needed; and the Figma-Pro
    gotcha for local-dev plugins.
  - The manual **Figma Community publish** flow.

### Fixed
- `tools/figma-plugin/README.md` — replaced the stale "Phase 1: scaffold only,
  no export yet" status (the exporter + Knob/Fader/Meter recognition actually
  landed) with an accurate status pointing to the new guide; corrected the
  dev instructions to the rebuild-don't-reimport reality.

### Wired
- Indexed both docs (`docs/status/docs-index.yaml`, `docs/index.md`) and added a
  semantic-not-visual paragraph to `VISION.md` linking the model doc.

`tools/check-docs.sh` passes (the new files are clean; remaining warnings are
pre-existing and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)