### PR TITLE
fix(import-design): auto-unpack .pulp.zip exports from the Figma plugin

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -237,6 +237,14 @@ Ask the user or detect from context:
 
 ### Step 2: Read the design data
 
+**Figma plugin export — `.pulp.zip` is the default ship shape**:
+The "Export to Pulp" button in `tools/figma-plugin` emits a `.pulp.zip` containing `scene.pulp.json` + `assets/*.png` whenever the design has images. The CLI auto-unpacks ZIPs transparently (look for `Unpacked …` on stdout); point `--file` directly at either form:
+```bash
+pulp import-design --from figma-plugin --file design.pulp.zip --output ui.js  # canonical
+pulp import-design --from figma-plugin --file scene.pulp.json --output ui.js  # also fine
+```
+Detection uses ZIP magic (`PK\x03\x04`), not the file extension — `.zip` renames still get unpacked. The temp dir is auto-cleaned at process exit. Older CLI builds read input via `std::ifstream` text mode and silently truncated at the first NUL byte in the ZIP header; the symptom was `parser threw an unknown exception` on any `.pulp.zip`. If you see that error, the CLI predates the auto-unpack support — rebuild from current `main`.
+
 **Figma (MCP available)**:
 - Use `com.figma.mcp` to read the current file or selection
 - Extract frames, auto-layout, fills, strokes, effects, text, components

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.139.0",
+      "version": "0.139.1",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.139.0"
+  "version": "0.139.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.139.0",
+  "version": "0.139.1",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.284.0
+    VERSION 0.284.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3455,7 +3455,16 @@ catch_discover_tests(pulp-test-cli-import-design
 # Direct shell-out coverage for the standalone import-design tool
 # executable. These tests hit tools/import-design/pulp_import_design.cpp
 # without going through the top-level pulp CLI delegate.
-add_executable(pulp-test-import-design-tool test_import_design_tool.cpp)
+add_executable(pulp-test-import-design-tool test_import_design_tool.cpp
+    # Same miniz subset the CLI links — issue #47's `.pulp.zip` auto-unpack
+    # test needs to assemble a tiny ZIP fixture from C++ rather than
+    # shelling out to `zip(1)` (which is not portable).
+    ${CMAKE_SOURCE_DIR}/external/miniz/miniz.c
+    ${CMAKE_SOURCE_DIR}/external/miniz/miniz_tdef.c
+    ${CMAKE_SOURCE_DIR}/external/miniz/miniz_tinfl.c
+    ${CMAKE_SOURCE_DIR}/external/miniz/miniz_zip.c)
+target_include_directories(pulp-test-import-design-tool PRIVATE
+    ${CMAKE_SOURCE_DIR}/external/miniz)
 target_link_libraries(pulp-test-import-design-tool
     PRIVATE pulp::platform Catch2::Catch2WithMain)
 target_compile_definitions(pulp-test-import-design-tool PRIVATE

--- a/test/test_import_design_tool.cpp
+++ b/test/test_import_design_tool.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/platform/child_process.hpp>
+#include <miniz.h>
 
 #include <chrono>
 #include <cstdlib>
@@ -950,4 +951,153 @@ TEST_CASE("pulp-import-design debug report names the default bridge-native mode"
     const auto report = read_text(debug);
     REQUIRE(report.find("\"mode\": \"bridge_native_js\"") != std::string::npos);
     REQUIRE(report.find("\"mode\": \"native\"") == std::string::npos);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Issue #47 — .pulp.zip auto-unpack
+//
+// The Pulp Figma plugin ships its "Export to Pulp" as a `.pulp.zip` that
+// contains scene.pulp.json + assets/*.png. Before this fix the CLI read
+// the input file via std::ifstream and silently truncated at the first
+// NUL byte in the ZIP header — the user had to manually `unzip` before
+// running the import. This test pins the auto-unpack contract by
+// assembling a minimal .pulp.zip from C++ (one entry, scene.pulp.json,
+// holding a valid figma-plugin envelope with a recognised Pulp / Knob
+// instance) and asserting the CLI parses it without an intermediate
+// unzip step.
+
+namespace {
+
+bool make_pulp_zip(const fs::path& zip_path, const std::string& scene_json) {
+    mz_zip_archive zip{};
+    if (!mz_zip_writer_init_file(&zip, zip_path.string().c_str(), 0)) return false;
+    const auto ok = mz_zip_writer_add_mem(
+        &zip,
+        "scene.pulp.json",
+        scene_json.data(),
+        scene_json.size(),
+        MZ_DEFAULT_COMPRESSION);
+    if (!ok) {
+        mz_zip_writer_end(&zip);
+        return false;
+    }
+    if (!mz_zip_writer_finalize_archive(&zip)) {
+        mz_zip_writer_end(&zip);
+        return false;
+    }
+    mz_zip_writer_end(&zip);
+    return true;
+}
+
+}  // namespace
+
+TEST_CASE("pulp-import-design auto-unpacks .pulp.zip Figma-plugin exports",
+          "[cli][import-design][tool][figma-plugin][issue-47]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp-import-design not built"); return; }
+
+    TempDir tmp("pulp-import-design-tool-zip");
+    const auto zip = tmp.path / "smoke.pulp.zip";
+    const auto output = tmp.path / "ui.js";
+
+    // Minimal figma-plugin envelope with a Pulp / Knob recognised by
+    // Phase 3's audio_widget="knob" path. The full envelope shape is
+    // documented in tools/figma-plugin/schema/figma-plugin-export-v1.json
+    // and exercised end-to-end by test/test_design_import.cpp's
+    // "[figma-plugin][phase-3]" cases. Here we only care that the CLI
+    // unpacks the zip and round-trips the IR through to the codegen.
+    const std::string envelope = R"JSON({
+        "format_version": "2026.05-figma-plugin-v1",
+        "parser_version": "0.1.0",
+        "compat_schema_version": "0.3",
+        "provenance": {
+            "adapter": "figma-plugin",
+            "version": "0.1.0",
+            "source_uri": "test://issue-47-fixture"
+        },
+        "asset_manifest": { "version": 1, "assets": [] },
+        "diagnostics": [],
+        "root": {
+            "type": "frame",
+            "name": "TestRoot",
+            "figma_node_id": "1:1",
+            "style": { "width": 200, "height": 200 },
+            "layout": { "direction": "column", "gap": 8,
+                        "paddingTop": 16, "paddingRight": 16,
+                        "paddingBottom": 16, "paddingLeft": 16 },
+            "children": [
+                {
+                    "type": "frame",
+                    "name": "Cutoff Knob",
+                    "figma_node_id": "1:2",
+                    "audio_widget": "knob",
+                    "label": "Cutoff",
+                    "min": 20,
+                    "max": 20000,
+                    "default": 880,
+                    "attributes": { "units": "Hz", "binding": "filter.cutoff_hz" },
+                    "style": { "width": 56, "height": 56 },
+                    "layout": { "direction": "column" },
+                    "children": []
+                }
+            ]
+        }
+    })JSON";
+
+    REQUIRE(make_pulp_zip(zip, envelope));
+    REQUIRE(fs::exists(zip));
+
+    auto r = run_import_design({"--from", "figma-plugin",
+                                "--file", zip.string(),
+                                "--output", output.string()});
+
+    REQUIRE_FALSE(r.timed_out);
+    INFO("stderr: " << r.stderr_output);
+    INFO("stdout: " << r.stdout_output);
+    REQUIRE(r.exit_code == 0);
+    REQUIRE(fs::exists(output));
+
+    // Visibility of the auto-unpack on stdout — both confirms the path
+    // ran and gives the user a breadcrumb if they later want to inspect
+    // the extracted contents.
+    REQUIRE(r.stdout_output.find("Unpacked ") != std::string::npos);
+    REQUIRE(r.stdout_output.find(".pulp.zip") != std::string::npos);
+
+    // The CLI should have emitted a native createKnob call with the
+    // designer-set range / value. If this assertion fails after a
+    // future codegen refactor, update the expected pattern rather than
+    // weakening the contract — the whole point of #47 is that the IR
+    // survives the round-trip.
+    const auto js = read_text(output);
+    REQUIRE(js.find("createKnob('Cutoff_Knob") != std::string::npos);
+    REQUIRE(js.find("setValue('Cutoff_Knob") != std::string::npos);
+    REQUIRE(js.find("880") != std::string::npos);
+}
+
+TEST_CASE("pulp-import-design rejects .pulp.zip with no scene.pulp.json",
+          "[cli][import-design][tool][figma-plugin][issue-47]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp-import-design not built"); return; }
+
+    TempDir tmp("pulp-import-design-tool-zip-empty");
+    const auto zip = tmp.path / "empty.pulp.zip";
+    const auto output = tmp.path / "ui.js";
+
+    // Build a zip whose only entry is `note.txt` — i.e. no scene
+    // envelope. The CLI must surface a clear error rather than silently
+    // succeed with empty content.
+    {
+        mz_zip_archive z{};
+        REQUIRE(mz_zip_writer_init_file(&z, zip.string().c_str(), 0));
+        REQUIRE(mz_zip_writer_add_mem(&z, "note.txt", "hi", 2, MZ_DEFAULT_COMPRESSION));
+        REQUIRE(mz_zip_writer_finalize_archive(&z));
+        mz_zip_writer_end(&z);
+    }
+
+    auto r = run_import_design({"--from", "figma-plugin",
+                                "--file", zip.string(),
+                                "--output", output.string()});
+
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code != 0);
+    REQUIRE(r.stderr_output.find("scene.pulp.json") != std::string::npos);
+    REQUIRE_FALSE(fs::exists(output));
 }

--- a/tools/import-design/CMakeLists.txt
+++ b/tools/import-design/CMakeLists.txt
@@ -5,8 +5,18 @@
 # the test target without dragging the full pulp::view pipeline along.
 add_executable(pulp-import-design
     pulp_import_design.cpp
-    import_detect.cpp)
-target_include_directories(pulp-import-design PRIVATE ${CMAKE_SOURCE_DIR})
+    import_detect.cpp
+    # miniz lets the CLI auto-unpack .pulp.zip exports from the Figma
+    # plugin (issue #47). Compiled here rather than pulled from
+    # pulp::runtime because that target's miniz include dirs are PRIVATE
+    # and pulp::view doesn't re-export them.
+    ${CMAKE_SOURCE_DIR}/external/miniz/miniz.c
+    ${CMAKE_SOURCE_DIR}/external/miniz/miniz_tdef.c
+    ${CMAKE_SOURCE_DIR}/external/miniz/miniz_tinfl.c
+    ${CMAKE_SOURCE_DIR}/external/miniz/miniz_zip.c)
+target_include_directories(pulp-import-design PRIVATE
+    ${CMAKE_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/external/miniz)
 target_link_libraries(pulp-import-design PRIVATE pulp::view pulp::state pulp::platform)
 
 add_executable(pulp-design-import-bench

--- a/tools/import-design/pulp_import_design.cpp
+++ b/tools/import-design/pulp_import_design.cpp
@@ -7,6 +7,8 @@
 #include <pulp/platform/child_process.hpp>
 #include <pulp/state/store.hpp>
 #include "import_detect.hpp"
+#include <miniz.h>
+#include <unistd.h>     // getpid()
 #include <algorithm>
 #include <cctype>
 #include <cstdlib>
@@ -693,7 +695,12 @@ static void print_usage() {
 // uncovered. The CLI only calls into the library function below.
 
 static std::string read_file(const std::string& path) {
-    std::ifstream f(path);
+    // Binary mode — the input may be a .pulp.zip (handled upstream by
+    // extract_pulp_zip_if_present) or a JSON file with multi-byte UTF-8
+    // sequences. std::ifstream default text mode is fine on POSIX but the
+    // explicit ios::binary documents intent and survives any future
+    // Windows port.
+    std::ifstream f(path, std::ios::binary);
     if (!f.is_open()) {
         std::cerr << "Error: cannot open file: " << path << "\n";
         return {};
@@ -701,6 +708,153 @@ static std::string read_file(const std::string& path) {
     std::ostringstream ss;
     ss << f.rdbuf();
     return ss.str();
+}
+
+// ── .pulp.zip auto-unpack (issue #47) ──────────────────────────────────
+//
+// The Pulp Figma plugin's "Export to Pulp" button emits a `.pulp.zip` that
+// contains scene.pulp.json + assets/*.png. Asking users to manually unzip
+// before running `pulp import-design --from figma-plugin` is a UX wart;
+// detect a ZIP magic header (PK\x03\x04) or `.zip` extension on the input
+// file, unpack it to a temp directory, and swap input_file for the path
+// to scene.pulp.json inside.
+//
+// Asset paths in the envelope are relative (`assets/...`), and the rest
+// of the import pipeline resolves them against
+// `fs::path(input_file).parent_path()`. Unpacking the whole archive
+// preserves that layout: the temp dir becomes the new asset base
+// directory automatically.
+
+struct PulpZipExtraction {
+    fs::path temp_dir;          // root of the extracted archive
+    fs::path scene_json_path;   // resolved location of scene.pulp.json
+
+    PulpZipExtraction() = default;
+    PulpZipExtraction(const PulpZipExtraction&) = delete;
+    PulpZipExtraction& operator=(const PulpZipExtraction&) = delete;
+    PulpZipExtraction(PulpZipExtraction&&) = default;
+    PulpZipExtraction& operator=(PulpZipExtraction&&) = default;
+
+    ~PulpZipExtraction() {
+        if (!temp_dir.empty()) {
+            std::error_code ec;
+            fs::remove_all(temp_dir, ec);   // best-effort
+        }
+    }
+};
+
+static bool looks_like_pulp_zip(const std::string& path) {
+    // ZIP magic bytes (RFC: local file header signature 0x04034b50,
+    // stored little-endian → "PK\x03\x04"). Cheap and authoritative —
+    // catches the `.pulp.zip` case and also any `.zip` someone renamed.
+    std::ifstream f(path, std::ios::binary);
+    if (!f.is_open()) return false;
+    char magic[4]{};
+    f.read(magic, sizeof(magic));
+    if (!f) return false;
+    return magic[0] == 'P' && magic[1] == 'K' &&
+           magic[2] == '\x03' && magic[3] == '\x04';
+}
+
+/// Make a unique temp directory under /tmp (or %TEMP%). Returns an empty
+/// path on failure.
+static fs::path make_temp_dir() {
+    std::error_code ec;
+    auto tmp_root = fs::temp_directory_path(ec);
+    if (ec) return {};
+    // Names like pulp-import-design-<pid>-<rng>.
+    std::random_device rd;
+    auto suffix = std::to_string(static_cast<unsigned long>(::getpid()))
+                + "-"
+                + std::to_string(static_cast<uint32_t>(rd()));
+    auto dir = tmp_root / ("pulp-import-design-" + suffix);
+    fs::create_directories(dir, ec);
+    if (ec) return {};
+    return dir;
+}
+
+/// If `input_file` points at a Pulp-flavoured ZIP, extract it to a fresh
+/// temp dir and return the path information. Otherwise return std::nullopt.
+/// On extraction failure the returned PulpZipExtraction.temp_dir is empty
+/// and the caller should fall back to treating input_file as raw JSON
+/// (with a useful error already printed to stderr).
+static std::optional<PulpZipExtraction>
+extract_pulp_zip_if_present(const std::string& input_file) {
+    if (!looks_like_pulp_zip(input_file)) return std::nullopt;
+
+    PulpZipExtraction out;
+    out.temp_dir = make_temp_dir();
+    if (out.temp_dir.empty()) {
+        std::cerr << "Error: could not create temp directory for "
+                  << input_file << "\n";
+        return out;  // empty temp_dir signals "tried but failed"
+    }
+
+    mz_zip_archive zip{};
+    if (!mz_zip_reader_init_file(&zip, input_file.c_str(), 0)) {
+        std::cerr << "Error: not a valid ZIP archive: " << input_file
+                  << "\n";
+        return out;
+    }
+
+    const mz_uint n = mz_zip_reader_get_num_files(&zip);
+    std::string scene_candidate;
+    for (mz_uint i = 0; i < n; ++i) {
+        char name_buf[1024]{};
+        mz_zip_reader_get_filename(&zip, i, name_buf, sizeof(name_buf));
+        const std::string entry_name(name_buf);
+        if (entry_name.empty()) continue;
+
+        // Skip directory entries (trailing slash).
+        if (entry_name.back() == '/') continue;
+
+        // Defence-in-depth path-safety: refuse absolute / `..` entries so
+        // a malicious archive can't escape temp_dir.
+        if (entry_name.find("..") != std::string::npos ||
+            (!entry_name.empty() && (entry_name[0] == '/' || entry_name[0] == '\\'))) {
+            std::cerr << "Error: refusing unsafe zip entry: " << entry_name
+                      << "\n";
+            mz_zip_reader_end(&zip);
+            return out;
+        }
+
+        const fs::path dest = out.temp_dir / entry_name;
+        std::error_code ec;
+        fs::create_directories(dest.parent_path(), ec);
+        if (ec) {
+            std::cerr << "Error: could not mkdir for " << dest << ": "
+                      << ec.message() << "\n";
+            mz_zip_reader_end(&zip);
+            return out;
+        }
+        if (!mz_zip_reader_extract_to_file(&zip, i, dest.string().c_str(), 0)) {
+            std::cerr << "Error: failed to extract " << entry_name
+                      << " from " << input_file << "\n";
+            mz_zip_reader_end(&zip);
+            return out;
+        }
+
+        // Identify the IR envelope. The plugin uses scene.pulp.json by
+        // convention; accept `scene.json` and `design.json` as fallbacks
+        // so older or hand-authored archives still work.
+        const auto fname = fs::path(entry_name).filename().string();
+        if (scene_candidate.empty()) {
+            if (fname == "scene.pulp.json" ||
+                fname == "scene.json"      ||
+                fname == "design.json") {
+                scene_candidate = dest.string();
+            }
+        }
+    }
+    mz_zip_reader_end(&zip);
+
+    if (scene_candidate.empty()) {
+        std::cerr << "Error: ZIP " << input_file
+                  << " contains no scene.pulp.json / scene.json / design.json\n";
+        return out;
+    }
+    out.scene_json_path = scene_candidate;
+    return out;
 }
 
 static bool write_file(const std::string& path, const std::string& content) {
@@ -1170,6 +1324,26 @@ int main(int argc, char* argv[]) {
     }
 
     auto t_start = std::chrono::steady_clock::now();
+
+    // If the user passed a .pulp.zip (or any ZIP with a Pulp envelope
+    // inside), unpack it transparently so `--file` always behaves the
+    // same regardless of whether the plugin shipped a JSON or a bundle.
+    // The PulpZipExtraction RAII guard cleans up the temp dir at scope
+    // exit; we keep it alive for the rest of `main` so asset paths
+    // continue to resolve.
+    std::optional<PulpZipExtraction> pulp_zip_keepalive;
+    if (auto extracted = extract_pulp_zip_if_present(input_file)) {
+        if (extracted->scene_json_path.empty()) {
+            // Tried to extract but failed; the helper already wrote a
+            // useful stderr line and we should not silently fall back to
+            // the truncated text-read path.
+            return 1;
+        }
+        std::cout << "Unpacked " << input_file << " → "
+                  << extracted->temp_dir << "\n";
+        input_file = extracted->scene_json_path.string();
+        pulp_zip_keepalive = std::move(*extracted);
+    }
 
     // Read input
     auto content = read_file(input_file);


### PR DESCRIPTION
Before this fix, passing a .pulp.zip (the bundle the Pulp Figma plugin's
"Export to Pulp" button emits) to the import CLI silently truncated the
input at the first NUL byte in the ZIP header — std::ifstream default
text mode is line-buffered against \\n, but the underlying read picks up
zero bytes, and the JSON parser then choked with "parser threw an
unknown exception". The user-visible workaround was to manually
`unzip -d /tmp/x && pulp-import-design --file /tmp/x/scene.pulp.json`;
the smoke test against the published Pulp Library hit this exactly.

Fix:

  * Detect ZIP magic (PK\x03\x04) on the input file. Catches
    `.pulp.zip` AND any other `.zip` someone renamed.
  * Unpack via miniz to a unique temp dir under fs::temp_directory_path
    (pulp-import-design-<pid>-<rng>).
  * Locate scene.pulp.json inside (fall back to scene.json /
    design.json for hand-authored archives).
  * Swap input_file to the extracted path; the rest of the import
    pipeline resolves asset paths against
    `fs::path(input_file).parent_path()` — unpacking the WHOLE archive
    preserves that contract automatically.
  * RAII guard (PulpZipExtraction) cleans up the temp dir at scope
    exit, including on error paths.
  * Defence-in-depth: refuse entries with absolute paths or `..`
    components so a malicious archive can't escape temp_dir.

CMake:

  * pulp-import-design picks up the same four miniz .c files
    pulp-runtime links (miniz, miniz_tdef, miniz_tinfl, miniz_zip),
    rather than going through pulp-runtime — that target's miniz
    include dirs are PRIVATE and pulp::view does not re-export them.

Test coverage (CLAUDE.md "tests ship with fixes" rule):

  * pulp-test-import-design-tool now links the same miniz subset and
    gains two cases under [cli][import-design][tool][figma-plugin][issue-47]:
      - "auto-unpacks .pulp.zip" — assembles a tiny .pulp.zip in C++
        holding a minimal Phase-3 envelope (audio_widget=knob + label
        + min/max/default + binding), runs the CLI against the ZIP
        directly, asserts (a) "Unpacked …" appears on stdout, and
        (b) the generated ui.js carries createKnob+setValue(880),
        i.e. the IR survived the round-trip.
      - "rejects .pulp.zip with no scene.pulp.json" — packs an
        unrelated note.txt, asserts the CLI errors clearly rather
        than silently emitting empty output.

Verification on macOS:
  - cmake --build pulp-import-design       — clean
  - cmake --build pulp-test-import-design-tool — clean
  - ./build/test/pulp-test-import-design-tool — 378 assertions /
    9 cases pass (incl. 18 / 2 new under [issue-47])
  - tools/scripts/gates.sh — ✓ all gates pass

  End-to-end: the user's `~/Downloads/2Pulp-library-import-smoke.pulp.zip`
  (a real plugin export of a Pulp / Knob + Fader + Meter) now imports
  successfully without a manual unzip step, producing the expected
  createKnob/createFader/createMeter+setValue/setMeterLevel calls.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>