### PR TITLE
docs: codify local-dev audio etiquette in CLAUDE.md + ios/auv3 skills (interim for #3173)

### DIFF
--- a/.agents/skills/auv3/SKILL.md
+++ b/.agents/skills/auv3/SKILL.md
@@ -503,6 +503,12 @@ auval -a | grep <your-fourcc>
 auval -v aumu <subtype> <manufacturer>
 ```
 
+**Audio etiquette**: `auval -v` plays test tones / noise through the host's
+default audio device while running RENDER. Announce before invoking
+(per CLAUDE.md → *Local-dev audio etiquette*) and prefer the shortest
+necessary validation when the user may be listening to something else.
+Tracked as issue [#3173](https://github.com/danielraffel/pulp/issues/3173).
+
 **auval does NOT exercise the AU v3 controller path** — auval calls
 `AudioComponentInstantiate` directly, bypassing the
 `AUAudioUnitFactory` lifecycle that hosts use via XPC. Threading bugs

--- a/.agents/skills/ios/SKILL.md
+++ b/.agents/skills/ios/SKILL.md
@@ -111,6 +111,8 @@ xcrun simctl launch --console booted com.example.MyApp
 
 **Policy**: assume XcodeBuildMCP when the user has it configured; do not hard-require or auto-install it. Leave install to user preference.
 
+**Audio etiquette for Sim launches**: `simctl launch --console …` opens a virtual coreaudio device that routes through the host Mac's `coreaudiod` — any non-muted audio path the app exercises plays out the host's speakers. Per CLAUDE.md → *Working with AI Tools* → *Local-dev audio etiquette*, announce before launching ("heads up — about to launch the Sim, audio may be active for ~30s"), cap the verify duration, and `simctl terminate` + `simctl shutdown` when done. Tracked as issue [#3173](https://github.com/danielraffel/pulp/issues/3173).
+
 ## AUv3 App Extension
 
 > **macOS AU v3 is architecturally different — see the `auv3` skill.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -865,6 +865,43 @@ git worktree add /tmp/pulp-audit origin/main
 - AI tools are collaborators, not autopilots. Review all generated code.
 - Tests validate AI output. Don't trust, verify.
 
+### Local-dev audio etiquette (interim — see issue #3173)
+
+Several Pulp dev workflows can produce host audio out of the user's
+speakers without warning: `xcrun simctl launch` of an iOS Sim app that
+opens a virtual coreaudio device, `auval` validating an AU plug-in,
+loading any AUv3/VST3/CLAP into a host (Logic, GarageBand, REAPER,
+AUM, Cubasis) for scan or validation, or any test that exercises the
+audio render path with non-zero gain on an unmuted bus. If the user
+is listening to music, on a call, near sleeping people, or just away
+from the desk, mystery audio is at minimum confusing and at worst
+embarrassing or harmful.
+
+Until issue [#3173](https://github.com/danielraffel/pulp/issues/3173)
+ships a real solution (announce-before / bounded-duration / muting /
+configurable signature / `audio_consent` knob), the interim contract
+for every agent (Claude Code, Codex, human-driven scripts) is:
+
+1. **Announce before launching.** In the user-facing message that
+   dispatches the work, include a one-liner naming the source and an
+   expected duration: "heads up — about to launch the iOS Sim with
+   the demo plugin; audio may be active for ~30s while the cube
+   renders." Same for `auval`, host launches, etc.
+2. **Cap the duration.** Pre-PR / pre-merge verification steps that
+   open an audio device should have a hard wall-clock cap. Don't let
+   a verify wait hang an open coreaudio session for hours; terminate
+   the launch after the relevant marker fires (or after ~90s if it
+   doesn't).
+3. **Tear down promptly.** When verification is done, terminate the
+   launched app and shut down the Sim (`xcrun simctl terminate ...`
+   + `xcrun simctl shutdown ...`) rather than leaving it open. Same
+   for `auval` host processes, REAPER / Logic test instances.
+
+When [#3173](https://github.com/danielraffel/pulp/issues/3173) lands a
+real solution, **remove this section** and replace it with a pointer
+to the new mechanism. This contract exists only because the proper
+fix is still on the issue tracker.
+
 ---
 
 ## Shared Agent Skills


### PR DESCRIPTION
## Summary

Promotes the local-dev audio etiquette contract from a single agent's private memory into the shared repo, so Claude Code, Codex, and human contributors all see the same rules. Linked back to #3173 (the real-fix tracking issue) with explicit instructions to *delete* this interim section once the proper feature lands.

## What's in CLAUDE.md

- New 'Local-dev audio etiquette (interim — see issue #3173)' subsection under 'Working with AI Tools'.
- Three rules: announce before launching, cap verify duration, tear down promptly.
- Removal instruction so the interim guidance can't outlive its reason for existing.

## What's in the skills

- `.agents/skills/ios/SKILL.md` — one-paragraph audio note next to the existing `simctl launch` example.
- `.agents/skills/auv3/SKILL.md` — analogous note next to the auval invocation.

Both skill notes point back to the CLAUDE.md contract and to #3173.

## Why now

User caught a ~30min iOS Sim launch from a background subagent producing mystery rumble out of the host speakers during iOS-D.3c verification. The interim contract prevents a repeat in any future subagent run, while #3173 owns the real solution (announce-before / bounded-duration / muting / configurable signature / `audio_consent` knob).

## Test plan

- [x] Docs-only change; no code touched.
- [x] `skill_sync_check.py` mapping is path → SKILL, not the reverse, so touching SKILL.md alone is allowed.
- [x] Patch bump SDK 0.284.0 → 0.284.1 + plugin 0.139.0 → 0.139.1.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)