### PR TITLE
chore(format): add host-quirks catalog JSON + parity test (P1)

### DIFF
--- a/core/format/host-quirks.json
+++ b/core/format/host-quirks.json
@@ -1,0 +1,387 @@
+{
+  "$schema": "./host-quirks.schema.json",
+  "schema_version": 1,
+  "_comment": "Machine-readable index of the HostQuirks ledger. The C++ struct pulp::format::HostQuirksMeta (core/format/include/pulp/format/host_quirks.hpp) is the SINGLE SOURCE OF TRUTH for the set of flags and their validation tier; this JSON is a parallel, machine-readable catalog consumed by provenance/staleness tooling (host-quirks integration plan P2+). The parity test tools/scripts/test_host_quirks_catalog_parity.py fails CI if this file and HostQuirksMeta ever drift (different flag set or mismatched tier). Rich rationale lives in the C++ comments and planning/host-quirks-log.md; this JSON is the index. Provenance fields (source_type, evidence, last_verified) are best-effort from the log + per-host headers; 'unknown' where the record is not explicit. This file introduces NO behavior change (P1: documentation/catalog hardening only).",
+  "_field_docs": {
+    "flag": "Field name in HostQuirks / HostQuirksMeta (exact match).",
+    "tier": "Validated | Speculative | LessonOnly — MUST match kHostQuirksMeta.",
+    "host": "DAW / host the quirk accommodates (free text; matches the per-host header / log entry).",
+    "symptom_area": "Coarse area label for bug-context matching (e.g. sizing, bus-arrangement, state-io, params, keyboard, threading, latency, bypass, dpi, midi).",
+    "source_type": "spec | release-notes | repro | in-DAW-bench | unknown — how the quirk was established.",
+    "evidence": "Issue/PR/doc reference or short pointer; 'unknown' where the log is not explicit.",
+    "last_verified": "ISO date the tier was last affirmed, or 'unknown'.",
+    "note": "One-line human-readable summary."
+  },
+  "quirks": [
+    {
+      "flag": "synthesize_bypass_parameter",
+      "tier": "Validated",
+      "host": "cross-format",
+      "symptom_area": "bypass",
+      "source_type": "repro",
+      "evidence": "macOS plan item 5.12 (DAW-quirks rows 23-26); founding cheap-defense, on the test bench since item 5.1",
+      "last_verified": "2026-05-25",
+      "note": "Synthesize a bypass parameter when the plugin doesn't declare one."
+    },
+    {
+      "flag": "clamp_latency_to_nonneg",
+      "tier": "Validated",
+      "host": "cross-format",
+      "symptom_area": "latency",
+      "source_type": "spec",
+      "evidence": "macOS plan item 5.12; VST3 requires unsigned latency",
+      "last_verified": "2026-05-25",
+      "note": "Clamp Processor::latency_samples() to non-negative when reporting to the host."
+    },
+    {
+      "flag": "silence_unsupported_bus_arrangements",
+      "tier": "Validated",
+      "host": "cross-format",
+      "symptom_area": "bus-arrangement",
+      "source_type": "repro",
+      "evidence": "macOS plan item 5.12",
+      "last_verified": "2026-05-25",
+      "note": "Accept unsupported bus arrangements and emit silence on extra channels rather than failing."
+    },
+    {
+      "flag": "cubase10_async_view_resize_queue",
+      "tier": "Speculative",
+      "host": "Cubase 10+",
+      "symptom_area": "sizing",
+      "source_type": "spec",
+      "evidence": "macOS plan item 5.2 (DAW-quirks row 1); host-quirks-log.md 2026-05-25",
+      "last_verified": "2026-05-25",
+      "note": "Async window resize after IPlugView::onSize()."
+    },
+    {
+      "flag": "cubase10_param_gesture_ordering",
+      "tier": "Speculative",
+      "host": "Cubase 10+",
+      "symptom_area": "params",
+      "source_type": "spec",
+      "evidence": "macOS plan item 5.2 (DAW-quirks row 2); host-quirks-log.md 2026-05-25",
+      "last_verified": "2026-05-25",
+      "note": "Parameter automation gesture ordering."
+    },
+    {
+      "flag": "cubase10_fractional_scale_correction",
+      "tier": "Speculative",
+      "host": "Cubase 10+",
+      "symptom_area": "dpi",
+      "source_type": "spec",
+      "evidence": "macOS plan item 5.2 (DAW-quirks row 3); host-quirks-log.md 2026-05-25",
+      "last_verified": "2026-05-25",
+      "note": "Integer-rounded fractional DPI scale correction."
+    },
+    {
+      "flag": "cubase9_state_blob_size_validation",
+      "tier": "Speculative",
+      "host": "Cubase 9",
+      "symptom_area": "state-io",
+      "source_type": "spec",
+      "evidence": "macOS plan item 5.3 (DAW-quirks row 4); host-quirks-log.md 2026-05-25",
+      "last_verified": "2026-05-25",
+      "note": "State-blob stream-size mismatch validation."
+    },
+    {
+      "flag": "live_vst3_canresize_ignore",
+      "tier": "Speculative",
+      "host": "Ableton Live",
+      "symptom_area": "sizing",
+      "source_type": "repro",
+      "evidence": "macOS plan item 5.4 (DAW-quirks row 5); host-quirks-log.md 2026-05-25",
+      "last_verified": "2026-05-25",
+      "note": "Live VST3 ignores canResize()."
+    },
+    {
+      "flag": "live_vst3_windows_dpi_defer",
+      "tier": "Speculative",
+      "host": "Ableton Live",
+      "symptom_area": "dpi",
+      "source_type": "repro",
+      "evidence": "macOS plan item 5.4 (DAW-quirks row 6, Windows-only); host-quirks-log.md 2026-05-25",
+      "last_verified": "2026-05-25",
+      "note": "Windows per-monitor DPI defers view attach (Windows-only)."
+    },
+    {
+      "flag": "double_string_buffer_for_live_10_1_13",
+      "tier": "LessonOnly",
+      "host": "Ableton Live 10.1.13",
+      "symptom_area": "state-io",
+      "source_type": "release-notes",
+      "evidence": "iPlug2 quirks audit 2026-05-25 (clean-room lessons); host-quirks-log.md 2026-05-25",
+      "last_verified": "2026-05-25",
+      "note": "Live 10.1.13 IInfoListener::getString writes past spec buffer length; allocate buffers at twice spec size."
+    },
+    {
+      "flag": "bitwig_vst3_linux_repaint_after_resize",
+      "tier": "Speculative",
+      "host": "Bitwig Studio (Linux)",
+      "symptom_area": "sizing",
+      "source_type": "repro",
+      "evidence": "macOS plan item 5.5 (DAW-quirks row 8, Linux-only); host-quirks-log.md 2026-05-25",
+      "last_verified": "2026-05-25",
+      "note": "VST3 editor repaint after resize (Linux-only)."
+    },
+    {
+      "flag": "bitwig_vst3_setbusarrangements_while_active",
+      "tier": "Speculative",
+      "host": "Bitwig Studio (< 6.0)",
+      "symptom_area": "bus-arrangement",
+      "source_type": "repro",
+      "evidence": "macOS plan item 5.5 (DAW-quirks row 9); host-quirks-log.md 2026-05-25",
+      "last_verified": "2026-05-25",
+      "note": "VST3 setBusArrangements invoked while active."
+    },
+    {
+      "flag": "skip_bus_arrangement_call",
+      "tier": "LessonOnly",
+      "host": "Ardour + Harrison Mixbus 32C",
+      "symptom_area": "bus-arrangement",
+      "source_type": "spec",
+      "evidence": "iPlug2 quirks audit 2026-05-25 (PR #2908); host-quirks-log.md 2026-05-25",
+      "last_verified": "2026-05-25",
+      "note": "setBusArrangements returns success without applying; skip the call and accept the host default arrangement."
+    },
+    {
+      "flag": "wavelab_vst3_defer_activation",
+      "tier": "Speculative",
+      "host": "Wavelab 11+",
+      "symptom_area": "bus-arrangement",
+      "source_type": "repro",
+      "evidence": "macOS plan item 5.6 (DAW-quirks row 10); host-quirks-log.md 2026-05-25",
+      "last_verified": "2026-05-25",
+      "note": "Re-entrant setBusArrangements during prepareToPlay; defer activation."
+    },
+    {
+      "flag": "wavelab_state_blob_fallback",
+      "tier": "Speculative",
+      "host": "Wavelab",
+      "symptom_area": "state-io",
+      "source_type": "repro",
+      "evidence": "macOS plan item 5.6 (DAW-quirks row 11); host-quirks-log.md 2026-05-25",
+      "last_verified": "2026-05-25",
+      "note": "State-blob graceful-restore fallback."
+    },
+    {
+      "flag": "tolerate_state_read_nontrue_status",
+      "tier": "LessonOnly",
+      "host": "Wavelab",
+      "symptom_area": "state-io",
+      "source_type": "spec",
+      "evidence": "iPlug2 quirks audit 2026-05-25 (Steinberg spec + reproducer notes); host-quirks-log.md 2026-05-25",
+      "last_verified": "2026-05-25",
+      "note": "IBStream::read may return non-kResultTrue at EOF with the buffer populated; accept when read count matches requested bytes."
+    },
+    {
+      "flag": "fl_studio_setactive_process_mutex",
+      "tier": "Speculative",
+      "host": "FL Studio",
+      "symptom_area": "threading",
+      "source_type": "repro",
+      "evidence": "macOS plan item 5.7 (DAW-quirks row 13); host-quirks-log.md 2026-05-25",
+      "last_verified": "2026-05-25",
+      "note": "VST3 Patcher activation race; serialize setActive/process/setBusArrangements."
+    },
+    {
+      "flag": "fl_studio_state_reader_skip",
+      "tier": "Speculative",
+      "host": "FL Studio",
+      "symptom_area": "state-io",
+      "source_type": "repro",
+      "evidence": "macOS plan item 5.7 (DAW-quirks row 14); host-quirks-log.md 2026-05-25",
+      "last_verified": "2026-05-25",
+      "note": "VST3 state-blob MemoryStream reader skip."
+    },
+    {
+      "flag": "reaper_vst3_gesture_ordering",
+      "tier": "Speculative",
+      "host": "REAPER",
+      "symptom_area": "params",
+      "source_type": "repro",
+      "evidence": "macOS plan item 5.8 (DAW-quirks row 15); host-quirks-log.md 2026-05-26",
+      "last_verified": "2026-05-26",
+      "note": "VST3 parameter gesture ordering."
+    },
+    {
+      "flag": "reaper_process_while_bypassed",
+      "tier": "Speculative",
+      "host": "REAPER",
+      "symptom_area": "bypass",
+      "source_type": "repro",
+      "evidence": "macOS plan item 5.8 (DAW-quirks row R1); host-quirks-log.md 2026-05-26",
+      "last_verified": "2026-05-26",
+      "note": "REAPER calls process() while bypassed."
+    },
+    {
+      "flag": "reaper_keyboard_passthrough",
+      "tier": "Speculative",
+      "host": "REAPER",
+      "symptom_area": "keyboard",
+      "source_type": "repro",
+      "evidence": "macOS plan item 5.8 (DAW-quirks row R2); host-quirks-log.md 2026-05-26",
+      "last_verified": "2026-05-26",
+      "note": "Keyboard passthrough handling."
+    },
+    {
+      "flag": "reaper_permissive_bus_arrangements",
+      "tier": "Speculative",
+      "host": "REAPER",
+      "symptom_area": "bus-arrangement",
+      "source_type": "repro",
+      "evidence": "macOS plan item 5.8 (DAW-quirks row R3); host-quirks-log.md 2026-05-26",
+      "last_verified": "2026-05-26",
+      "note": "Permissive bus arrangements."
+    },
+    {
+      "flag": "reaper_anticipative_fx_buffer_variability",
+      "tier": "Speculative",
+      "host": "REAPER",
+      "symptom_area": "process",
+      "source_type": "repro",
+      "evidence": "macOS plan item 5.8 (DAW-quirks row R4); host-quirks-log.md 2026-05-26",
+      "last_verified": "2026-05-26",
+      "note": "Anticipative FX buffer-size variability."
+    },
+    {
+      "flag": "reaper_midsession_setstate",
+      "tier": "Speculative",
+      "host": "REAPER",
+      "symptom_area": "state-io",
+      "source_type": "repro",
+      "evidence": "macOS plan item 5.8 (DAW-quirks row R6); host-quirks-log.md 2026-05-26",
+      "last_verified": "2026-05-26",
+      "note": "Mid-session setState."
+    },
+    {
+      "flag": "reaper_keyboard_only_space",
+      "tier": "LessonOnly",
+      "host": "REAPER",
+      "symptom_area": "keyboard",
+      "source_type": "release-notes",
+      "evidence": "iPlug2 quirks audit 2026-05-25 (clean-room lessons, 5.x-7.x); host-quirks-log.md 2026-05-25",
+      "last_verified": "2026-05-25",
+      "note": "Only VKEY_SPACE delivers a well-formed keyMsg; reject non-Space keys."
+    },
+    {
+      "flag": "pro_tools_aax_sidechain_negotiation",
+      "tier": "Speculative",
+      "host": "Pro Tools (AAX)",
+      "symptom_area": "bus-arrangement",
+      "source_type": "spec",
+      "evidence": "macOS plan item 5.9 (DAW-quirks row 16); host-quirks-log.md 2026-05-26",
+      "last_verified": "2026-05-26",
+      "note": "AAX sidechain negotiation."
+    },
+    {
+      "flag": "pro_tools_aax_latency_callback_push",
+      "tier": "Speculative",
+      "host": "Pro Tools (AAX)",
+      "symptom_area": "latency",
+      "source_type": "spec",
+      "evidence": "macOS plan item 5.9 (DAW-quirks row 17); host-quirks-log.md 2026-05-26",
+      "last_verified": "2026-05-26",
+      "note": "AAX latency callback push."
+    },
+    {
+      "flag": "pro_tools_aax_mono_second_bus",
+      "tier": "Speculative",
+      "host": "Pro Tools (AAX)",
+      "symptom_area": "bus-arrangement",
+      "source_type": "spec",
+      "evidence": "macOS plan item 5.9 (DAW-quirks row 18); host-quirks-log.md 2026-05-26",
+      "last_verified": "2026-05-26",
+      "note": "AAX mono second bus."
+    },
+    {
+      "flag": "aax_vendor_version_unknown",
+      "tier": "LessonOnly",
+      "host": "Pro Tools (AAX)",
+      "symptom_area": "version",
+      "source_type": "spec",
+      "evidence": "iPlug2 quirks audit 2026-05-25 (Avid AAX docs); host-quirks-log.md 2026-05-25",
+      "last_verified": "2026-05-25",
+      "note": "AAX wrapper reports vendor version unreliably; treat Pro Tools version as unknown and avoid version-gated branching."
+    },
+    {
+      "flag": "logic_au_channel_probe_cap",
+      "tier": "Speculative",
+      "host": "Logic Pro / GarageBand (AU)",
+      "symptom_area": "bus-arrangement",
+      "source_type": "repro",
+      "evidence": "macOS plan item 5.10 (DAW-quirks row 19); host-quirks-log.md 2026-05-25",
+      "last_verified": "2026-05-25",
+      "note": "AU channel-probe cap (numeric; default 64, Logic = 8)."
+    },
+    {
+      "flag": "logic_au_tail_time_conversion",
+      "tier": "Speculative",
+      "host": "Logic Pro / GarageBand (AU)",
+      "symptom_area": "latency",
+      "source_type": "repro",
+      "evidence": "macOS plan item 5.10 (DAW-quirks row 20); host-quirks-log.md 2026-05-25",
+      "last_verified": "2026-05-25",
+      "note": "AU tail-time wall-clock conversion."
+    },
+    {
+      "flag": "au_v3_bypass_dual_tracking",
+      "tier": "Speculative",
+      "host": "AU v3 cross-host",
+      "symptom_area": "bypass",
+      "source_type": "repro",
+      "evidence": "macOS plan item 5.11 (DAW-quirks row 21); host-quirks-log.md 2026-05-25",
+      "last_verified": "2026-05-25",
+      "note": "AU v3 bypass dual-tracking."
+    },
+    {
+      "flag": "au_v3_host_id_from_wrapper",
+      "tier": "Speculative",
+      "host": "AU v3 cross-host",
+      "symptom_area": "host-detection",
+      "source_type": "repro",
+      "evidence": "macOS plan item 5.11 (DAW-quirks row 22); host-quirks-log.md 2026-05-25",
+      "last_verified": "2026-05-25",
+      "note": "Wrapper-reported host identifier."
+    },
+    {
+      "flag": "reaper_auv3_in_process_preferred_size_sync",
+      "tier": "LessonOnly",
+      "host": "REAPER (AU v3 in-process)",
+      "symptom_area": "sizing",
+      "source_type": "repro",
+      "evidence": "Pulp #3044 (iPlug2-audit batch 2026-05-26); host-quirks-log.md 2026-05-26",
+      "last_verified": "2026-05-26",
+      "note": "In-process AU v3: set preferredContentSize synchronously in audioUnitInitialized, not only viewDidLoad."
+    },
+    {
+      "flag": "studio_one_restart_component_ui_thread",
+      "tier": "LessonOnly",
+      "host": "Studio One",
+      "symptom_area": "threading",
+      "source_type": "repro",
+      "evidence": "Pulp #3045 (iPlug2-audit batch 2026-05-26); host-quirks-log.md 2026-05-26",
+      "last_verified": "2026-05-26",
+      "note": "Marshal IComponentHandler::restartComponent (esp. kLatencyChanged) to the UI thread."
+    },
+    {
+      "flag": "digital_performer_param_list_reload",
+      "tier": "LessonOnly",
+      "host": "Digital Performer (MOTU)",
+      "symptom_area": "params",
+      "source_type": "repro",
+      "evidence": "Pulp #3046 (iPlug2-audit batch 2026-05-26); host-quirks-log.md 2026-05-26",
+      "last_verified": "2026-05-26",
+      "note": "Layer kReloadComponent onto restart bundle on preset-load/project-import so automation labels aren't stale."
+    },
+    {
+      "flag": "cubase13_midi_cc_param_id_stable",
+      "tier": "Speculative",
+      "host": "Cubase 13+ / Nuendo 13+",
+      "symptom_area": "midi",
+      "source_type": "repro",
+      "evidence": "Pulp #3047 (iPlug2-audit batch 2026-05-26); host-quirks-log.md 2026-05-26",
+      "last_verified": "2026-05-26",
+      "note": "Derive MIDI CC parameter IDs from a stable hash (not runtime index) so automation lanes survive reload on 13.x."
+    }
+  ]
+}

--- a/core/format/host-quirks.schema.json
+++ b/core/format/host-quirks.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://pulp.audio/schemas/host-quirks.schema.json",
+  "title": "Pulp host-quirks catalog",
+  "description": "Machine-readable index of the HostQuirks ledger. Parity with the C++ HostQuirksMeta is enforced by tools/scripts/test_host_quirks_catalog_parity.py.",
+  "type": "object",
+  "required": ["schema_version", "quirks"],
+  "properties": {
+    "$schema": { "type": "string" },
+    "schema_version": { "type": "integer" },
+    "_comment": { "type": "string" },
+    "_field_docs": { "type": "object" },
+    "quirks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["flag", "tier", "host", "symptom_area", "note"],
+        "additionalProperties": false,
+        "properties": {
+          "flag": { "type": "string" },
+          "tier": { "enum": ["Validated", "Speculative", "LessonOnly"] },
+          "host": { "type": "string" },
+          "symptom_area": { "type": "string" },
+          "source_type": {
+            "enum": ["spec", "release-notes", "repro", "in-DAW-bench", "unknown"]
+          },
+          "evidence": { "type": "string" },
+          "last_verified": { "type": "string" },
+          "note": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2512,6 +2512,20 @@ pulp_add_test_suite(pulp-test-edit-history LIBRARIES pulp::state)
 pulp_add_test_suite(pulp-test-host-version LIBRARIES pulp::format)
 pulp_add_test_suite(pulp-test-host-quirks LIBRARIES pulp::format)
 
+# Host-quirks catalog parity (host-quirks integration plan, P1) — the
+# machine-readable core/format/host-quirks.json must list EXACTLY the
+# flags + tiers in the C++ HostQuirksMeta. Pure-Python parser, no C++
+# build needed, so it runs cheaply on every PR and guards against the
+# JSON and the struct drifting apart.
+if(Python3_Interpreter_FOUND)
+    add_test(NAME host-quirks-catalog-parity
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/../tools/scripts/test_host_quirks_catalog_parity.py)
+    set_tests_properties(host-quirks-catalog-parity PROPERTIES
+        LABELS "format;host-quirks;catalog"
+        TIMEOUT 30)
+endif()
+
 # macOS plan Batch B (partial: mixers) — DryWetMixer + Panner pan laws
 pulp_add_test_suite(pulp-test-pan-mix-laws LIBRARIES pulp::signal)
 

--- a/tools/scripts/test_host_quirks_catalog_parity.py
+++ b/tools/scripts/test_host_quirks_catalog_parity.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Parity test: core/format/host-quirks.json vs. the C++ HostQuirksMeta.
+
+The C++ struct ``pulp::format::HostQuirksMeta`` in
+``core/format/include/pulp/format/host_quirks.hpp`` is the single source
+of truth for the set of host-quirk flags and each flag's validation tier
+(``QuirkStatus::{Validated|Speculative|LessonOnly}``). The machine-readable
+catalog ``core/format/host-quirks.json`` is a parallel index consumed by
+provenance / staleness tooling (host-quirks integration plan, P2+).
+
+This test fails if the two ever drift:
+
+  * a flag present in one but not the other, or
+  * a flag whose JSON ``tier`` disagrees with its ``kHostQuirksMeta`` default.
+
+It is intentionally a pure-Python parser (no C++ build needed): it scans
+the ``struct HostQuirksMeta { ... }`` body for ``QuirkStatus <name> =
+QuirkStatus::<Tier>;`` defaults and compares them to the JSON. That keeps
+the parity gate cheap enough to run on every PR (mirrors the pattern in
+tools/scripts/test_local_diff_cover.py).
+
+Run:
+    python3 tools/scripts/test_host_quirks_catalog_parity.py
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+HEADER = REPO_ROOT / "core" / "format" / "include" / "pulp" / "format" / "host_quirks.hpp"
+CATALOG = REPO_ROOT / "core" / "format" / "host-quirks.json"
+
+VALID_TIERS = {"Validated", "Speculative", "LessonOnly"}
+VALID_SOURCE_TYPES = {"spec", "release-notes", "repro", "in-DAW-bench", "unknown"}
+
+
+def parse_meta_tiers() -> dict[str, str]:
+    """Return {flag: tier} parsed from the HostQuirksMeta struct body.
+
+    Looks for the ``struct HostQuirksMeta { ... };`` block and extracts
+    every ``QuirkStatus <field> = QuirkStatus::<Tier>;`` default. Comments
+    (``// ...``) are stripped first so commented-out fields never count.
+    """
+    text = HEADER.read_text(encoding="utf-8")
+
+    match = re.search(r"struct\s+HostQuirksMeta\s*\{(.*?)\n\};", text, re.DOTALL)
+    if not match:
+        raise AssertionError(
+            "Could not locate `struct HostQuirksMeta { ... };` in "
+            f"{HEADER} — did the struct get renamed?"
+        )
+    body = match.group(1)
+    # Strip line comments so a commented `// QuirkStatus foo = ...` line is
+    # never mistaken for a real field default.
+    body = re.sub(r"//[^\n]*", "", body)
+
+    tiers: dict[str, str] = {}
+    for name, tier in re.findall(
+        r"QuirkStatus\s+(\w+)\s*=\s*QuirkStatus::(\w+)\s*;", body
+    ):
+        tiers[name] = tier
+    return tiers
+
+
+def load_catalog() -> dict:
+    return json.loads(CATALOG.read_text(encoding="utf-8"))
+
+
+class CatalogWellFormed(unittest.TestCase):
+    """host-quirks.json parses and every entry has the required shape."""
+
+    def test_files_exist(self) -> None:
+        self.assertTrue(HEADER.is_file(), f"missing {HEADER}")
+        self.assertTrue(CATALOG.is_file(), f"missing {CATALOG}")
+
+    def test_entries_have_required_fields(self) -> None:
+        catalog = load_catalog()
+        self.assertIn("quirks", catalog, "catalog must have a `quirks` array")
+        required = {"flag", "tier", "host", "symptom_area", "note"}
+        seen: set[str] = set()
+        for entry in catalog["quirks"]:
+            missing = required - set(entry)
+            self.assertFalse(
+                missing, f"quirk {entry.get('flag', '?')} missing fields: {missing}"
+            )
+            self.assertIn(
+                entry["tier"],
+                VALID_TIERS,
+                f"quirk {entry['flag']} has invalid tier {entry['tier']!r}",
+            )
+            # Provenance fields are optional but, when present, must use the
+            # documented vocabulary.
+            if "source_type" in entry:
+                self.assertIn(
+                    entry["source_type"],
+                    VALID_SOURCE_TYPES,
+                    f"quirk {entry['flag']} has invalid source_type "
+                    f"{entry['source_type']!r}",
+                )
+            self.assertNotIn(
+                entry["flag"],
+                seen,
+                f"duplicate flag {entry['flag']!r} in host-quirks.json",
+            )
+            seen.add(entry["flag"])
+
+
+class CatalogStructParity(unittest.TestCase):
+    """The JSON lists EXACTLY the HostQuirksMeta flags, with matching tiers."""
+
+    def test_flag_sets_match(self) -> None:
+        meta = parse_meta_tiers()
+        self.assertTrue(
+            meta, "parsed zero fields from HostQuirksMeta — parser likely broke"
+        )
+        catalog = {q["flag"]: q["tier"] for q in load_catalog()["quirks"]}
+
+        only_in_meta = set(meta) - set(catalog)
+        only_in_json = set(catalog) - set(meta)
+        self.assertFalse(
+            only_in_meta,
+            "Flags in HostQuirksMeta but NOT in host-quirks.json "
+            f"(add catalog entries): {sorted(only_in_meta)}",
+        )
+        self.assertFalse(
+            only_in_json,
+            "Flags in host-quirks.json but NOT in HostQuirksMeta "
+            f"(remove stale catalog entries): {sorted(only_in_json)}",
+        )
+
+    def test_tiers_match(self) -> None:
+        meta = parse_meta_tiers()
+        catalog = {q["flag"]: q["tier"] for q in load_catalog()["quirks"]}
+        mismatches = {
+            flag: (meta[flag], catalog[flag])
+            for flag in meta
+            if flag in catalog and catalog[flag] != meta[flag]
+        }
+        self.assertFalse(
+            mismatches,
+            "Tier mismatch between HostQuirksMeta (left) and host-quirks.json "
+            f"(right): {mismatches}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds core/format/host-quirks.json, a machine-readable index of the
HostQuirks ledger, recording flag, tier, host, symptom_area, and
best-effort provenance (source_type/evidence/last_verified) for every
field in HostQuirksMeta. Provenance is drawn from planning/host-quirks-log.md
and the per-host headers under host_quirks/; 'unknown' where the log is
not explicit.

Adds tools/scripts/test_host_quirks_catalog_parity.py, a pure-Python
parity gate (no C++ build needed) wired into ctest as
host-quirks-catalog-parity. It parses the HostQuirksMeta struct body for
QuirkStatus defaults and fails if the JSON and the struct ever drift in
flag set or tier. Verified: passes against the current struct, and fails
on an injected extra-flag or tier mismatch.

This is P1 of the host-quirks integration plan
(planning/2026-05-29-host-quirks-integration-plan.md, revised second
pass): documentation/catalog hardening only, ZERO behavior change. No
adapter consumes any flag; enforcement (P3) and the bug-bot (P2) are out
of scope here.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>