### PR TITLE
fix(import-design): tighten .pulp.zip zip-slip + zip-bomb guards

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -245,6 +245,8 @@ pulp import-design --from figma-plugin --file scene.pulp.json --output ui.js  # 
 ```
 Detection uses ZIP magic (`PK\x03\x04`), not the file extension — `.zip` renames still get unpacked. The temp dir is auto-cleaned at process exit. Older CLI builds read input via `std::ifstream` text mode and silently truncated at the first NUL byte in the ZIP header; the symptom was `parser threw an unknown exception` on any `.pulp.zip`. If you see that error, the CLI predates the auto-unpack support — rebuild from current `main`.
 
+The extractor refuses hostile archives at parse time: entries whose filename is so long it would truncate inside the stack buffer, entries containing `..` substrings, entries that resolve to an absolute path (`fs::path::is_absolute()`), entries with Windows drive-relative or UNC prefixes (`C:foo`, `C:\\foo`, `\\\\server\\share\\…`), entries beginning with `/` or `\\`, archives with more than 10000 entries, and archives whose total or per-file uncompressed size exceeds 256 MB / 64 MB respectively. Each rejection logs a labelled `Error: refusing unsafe zip entry (<reason>): <name>` (or `oversized filename`, `total uncompressed size > …`) on stderr and bails with a non-zero exit. If a legitimate plugin export ever trips one of these caps, the right move is to lift the cap deliberately in `extract_pulp_zip_if_present` rather than disable the guard.
+
 **Figma (MCP available)**:
 - Use `com.figma.mcp` to read the current file or selection
 - Extract frames, auto-layout, fills, strokes, effects, text, components

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.139.1",
+      "version": "0.139.2",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.139.1"
+  "version": "0.139.2"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.139.1",
+  "version": "0.139.2",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.284.1
+    VERSION 0.284.2
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/test/test_import_design_tool.cpp
+++ b/test/test_import_design_tool.cpp
@@ -1101,3 +1101,152 @@ TEST_CASE("pulp-import-design rejects .pulp.zip with no scene.pulp.json",
     REQUIRE(r.stderr_output.find("scene.pulp.json") != std::string::npos);
     REQUIRE_FALSE(fs::exists(output));
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// Issue #50 — adversarial-review hardening of the .pulp.zip extractor.
+//
+// Self-review on #3189 found three zip-slip/zip-bomb gaps the original
+// guards missed:
+//   (1) mz_zip_reader_get_filename truncates to the supplied buffer
+//       size; a 2-KB entry name like
+//         "<1020 safe chars>/../../../etc/passwd"
+//       becomes "<1020 safe chars>/..." after truncation — sneaks past
+//       the `..` substring check — and then extract_to_file is called
+//       with the FULL untruncated name from the central directory.
+//   (2) The path-prefix check only rejected entries starting with `/`
+//       or `\`. Windows drive-letter (C:\...) and UNC (\\srv\share\...)
+//       paths slipped through and would escape temp_dir on Windows.
+//   (3) No cap on total / per-file uncompressed size or entry count, so
+//       a zip-bomb could fill the temp filesystem.
+//
+// The fixtures below pin each guard with a hostile zip the CLI must
+// refuse.
+
+namespace {
+
+// Convenience: build a zip with one (name, contents) entry. Used to
+// construct hostile fixtures from inside the test.
+bool make_zip_with_entry(const fs::path& zip_path,
+                         const std::string& entry_name,
+                         const std::string& contents) {
+    mz_zip_archive zip{};
+    if (!mz_zip_writer_init_file(&zip, zip_path.string().c_str(), 0)) return false;
+    const bool ok = mz_zip_writer_add_mem(
+        &zip,
+        entry_name.c_str(),
+        contents.data(),
+        contents.size(),
+        MZ_DEFAULT_COMPRESSION);
+    if (!ok) { mz_zip_writer_end(&zip); return false; }
+    if (!mz_zip_writer_finalize_archive(&zip)) {
+        mz_zip_writer_end(&zip);
+        return false;
+    }
+    mz_zip_writer_end(&zip);
+    return true;
+}
+
+}  // namespace
+
+TEST_CASE("pulp-import-design refuses .pulp.zip with oversized filename (issue-50 truncation bypass)",
+          "[cli][import-design][tool][figma-plugin][issue-50]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp-import-design not built"); return; }
+
+    TempDir tmp("pulp-import-design-tool-zip-truncation");
+    const auto zip = tmp.path / "evil.pulp.zip";
+    const auto output = tmp.path / "ui.js";
+
+    // Craft a name long enough to truncate inside the original 1024-byte
+    // stack buffer (>= 1024 chars). The trailing `..` is what the
+    // truncation would have lost. With the new probe-first check the
+    // CLI must reject before ever calling extract_to_file.
+    const std::string oversized_name(1100, 'a');
+    REQUIRE(make_zip_with_entry(zip, oversized_name + "/../../../etc/passwd", "x"));
+
+    auto r = run_import_design({"--from", "figma-plugin",
+                                "--file", zip.string(),
+                                "--output", output.string()});
+
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code != 0);
+    INFO("stderr: " << r.stderr_output);
+    REQUIRE(r.stderr_output.find("oversized filename") != std::string::npos);
+    REQUIRE_FALSE(fs::exists(output));
+}
+
+TEST_CASE("pulp-import-design refuses .pulp.zip with `..` in entry path",
+          "[cli][import-design][tool][figma-plugin][issue-50]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp-import-design not built"); return; }
+
+    TempDir tmp("pulp-import-design-tool-zip-dotdot");
+    const auto zip = tmp.path / "evil.pulp.zip";
+
+    REQUIRE(make_zip_with_entry(zip, "subdir/../../../etc/passwd", "x"));
+
+    auto r = run_import_design({"--from", "figma-plugin",
+                                "--file", zip.string(),
+                                "--output", (tmp.path / "ui.js").string()});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code != 0);
+    INFO("stderr: " << r.stderr_output);
+    REQUIRE(r.stderr_output.find("'..'") != std::string::npos);
+    REQUIRE_FALSE(fs::exists(tmp.path / "ui.js"));
+}
+
+TEST_CASE("pulp-import-design refuses .pulp.zip with Windows drive-relative path",
+          "[cli][import-design][tool][figma-plugin][issue-50]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp-import-design not built"); return; }
+
+    TempDir tmp("pulp-import-design-tool-zip-driveletter");
+    const auto zip = tmp.path / "evil.pulp.zip";
+
+    // C:foo is drive-relative — fs::path::is_absolute() on Linux says
+    // false, so the explicit drive-letter guard is what catches it.
+    REQUIRE(make_zip_with_entry(zip, "C:Windows/system32/evil.dll", "x"));
+
+    auto r = run_import_design({"--from", "figma-plugin",
+                                "--file", zip.string(),
+                                "--output", (tmp.path / "ui.js").string()});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code != 0);
+    INFO("stderr: " << r.stderr_output);
+    REQUIRE(r.stderr_output.find("drive-relative") != std::string::npos);
+}
+
+// NOTE: a "leading slash absolute path" fixture is intentionally omitted —
+// miniz's writer (mz_zip_writer_add_mem) refuses entries beginning with
+// `/`, so a hand-crafted ZIP would be required to exercise that specific
+// path. The path-safety branch is already covered by the `..` test
+// (substring guard) and the Windows drive-relative test (explicit
+// drive-letter guard); the leading-slash fallback is defence-in-depth
+// for non-portable archives we'd never produce ourselves.
+
+TEST_CASE("pulp-import-design refuses .pulp.zip exceeding the file-count cap",
+          "[cli][import-design][tool][figma-plugin][issue-50]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp-import-design not built"); return; }
+
+    TempDir tmp("pulp-import-design-tool-zip-count-cap");
+    const auto zip = tmp.path / "many.pulp.zip";
+
+    // Pack 10001 minimal entries — one over the kMaxFileCount cap.
+    {
+        mz_zip_archive z{};
+        REQUIRE(mz_zip_writer_init_file(&z, zip.string().c_str(), 0));
+        for (int i = 0; i < 10001; ++i) {
+            const auto name = "f" + std::to_string(i) + ".bin";
+            const char body = 'x';
+            REQUIRE(mz_zip_writer_add_mem(&z, name.c_str(), &body, 1,
+                                          MZ_DEFAULT_COMPRESSION));
+        }
+        REQUIRE(mz_zip_writer_finalize_archive(&z));
+        mz_zip_writer_end(&z);
+    }
+
+    auto r = run_import_design({"--from", "figma-plugin",
+                                "--file", zip.string(),
+                                "--output", (tmp.path / "ui.js").string()});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code != 0);
+    INFO("stderr: " << r.stderr_output);
+    REQUIRE(r.stderr_output.find("entries (>") != std::string::npos);
+}

--- a/tools/import-design/pulp_import_design.cpp
+++ b/tools/import-design/pulp_import_design.cpp
@@ -8,7 +8,16 @@
 #include <pulp/state/store.hpp>
 #include "import_detect.hpp"
 #include <miniz.h>
-#include <unistd.h>     // getpid()
+// getpid() is POSIX-only via <unistd.h>; MSVC ships an equivalent
+// `_getpid` declaration in <process.h>. Wrap both to keep the
+// `pid_kind` lookup portable.
+#if defined(_WIN32)
+#  include <process.h>
+#  define pulp_getpid _getpid
+#else
+#  include <unistd.h>
+#  define pulp_getpid getpid
+#endif
 #include <algorithm>
 #include <cctype>
 #include <cstdlib>
@@ -764,7 +773,7 @@ static fs::path make_temp_dir() {
     if (ec) return {};
     // Names like pulp-import-design-<pid>-<rng>.
     std::random_device rd;
-    auto suffix = std::to_string(static_cast<unsigned long>(::getpid()))
+    auto suffix = std::to_string(static_cast<unsigned long>(::pulp_getpid()))
                 + "-"
                 + std::to_string(static_cast<uint32_t>(rd()));
     auto dir = tmp_root / ("pulp-import-design-" + suffix);
@@ -797,10 +806,42 @@ extract_pulp_zip_if_present(const std::string& input_file) {
         return out;
     }
 
+    // Bomb / over-quota caps. Realistic Pulp exports are a few MB of JSON
+    // + a few hundred KB of PNG/SVG assets; cap well above that but well
+    // below "fills /tmp on a CI runner". Numbers chosen to be ~10× any
+    // realistic plugin export.
+    constexpr std::uint64_t kMaxTotalUncompressed   = 256ull * 1024 * 1024;  // 256 MB
+    constexpr std::uint64_t kMaxPerFileUncompressed =  64ull * 1024 * 1024;  //  64 MB
+    constexpr mz_uint       kMaxFileCount           = 10000;
+
     const mz_uint n = mz_zip_reader_get_num_files(&zip);
+    if (n > kMaxFileCount) {
+        std::cerr << "Error: ZIP " << input_file << " has " << n
+                  << " entries (>" << kMaxFileCount
+                  << "); refusing to extract\n";
+        mz_zip_reader_end(&zip);
+        return out;
+    }
+    std::uint64_t total_uncompressed = 0;
     std::string scene_candidate;
     for (mz_uint i = 0; i < n; ++i) {
+        // mz_zip_reader_get_filename truncates silently when name_buf is
+        // too small. A malicious archive can stuff a 2-KB entry name like
+        // "<1020 safe chars>/../../../etc/passwd": the truncated string
+        // sails past our `..` substring check, but the central directory
+        // still holds the FULL name and mz_zip_reader_extract_to_file
+        // happily writes outside temp_dir. Probe required size first and
+        // reject anything that wouldn't fit (or exceeds a sane POSIX-y
+        // path limit) BEFORE we ever read the name.
+        const mz_uint name_size = mz_zip_reader_get_filename(&zip, i, nullptr, 0);
         char name_buf[1024]{};
+        if (name_size == 0 || name_size > sizeof(name_buf)) {
+            std::cerr << "Error: ZIP " << input_file << " entry " << i
+                      << " has oversized filename (" << name_size
+                      << " bytes); refusing\n";
+            mz_zip_reader_end(&zip);
+            return out;
+        }
         mz_zip_reader_get_filename(&zip, i, name_buf, sizeof(name_buf));
         const std::string entry_name(name_buf);
         if (entry_name.empty()) continue;
@@ -808,12 +849,62 @@ extract_pulp_zip_if_present(const std::string& input_file) {
         // Skip directory entries (trailing slash).
         if (entry_name.back() == '/') continue;
 
-        // Defence-in-depth path-safety: refuse absolute / `..` entries so
-        // a malicious archive can't escape temp_dir.
-        if (entry_name.find("..") != std::string::npos ||
-            (!entry_name.empty() && (entry_name[0] == '/' || entry_name[0] == '\\'))) {
-            std::cerr << "Error: refusing unsafe zip entry: " << entry_name
-                      << "\n";
+        // Per-file + running total uncompressed-size caps (zip-bomb guard).
+        mz_zip_archive_file_stat stat{};
+        if (!mz_zip_reader_file_stat(&zip, i, &stat)) {
+            std::cerr << "Error: ZIP " << input_file << " entry "
+                      << entry_name << " has unreadable stat; refusing\n";
+            mz_zip_reader_end(&zip);
+            return out;
+        }
+        if (stat.m_uncomp_size > kMaxPerFileUncompressed) {
+            std::cerr << "Error: ZIP " << input_file << " entry "
+                      << entry_name << " uncompressed size "
+                      << stat.m_uncomp_size << " > " << kMaxPerFileUncompressed
+                      << " bytes; refusing\n";
+            mz_zip_reader_end(&zip);
+            return out;
+        }
+        total_uncompressed += stat.m_uncomp_size;
+        if (total_uncompressed > kMaxTotalUncompressed) {
+            std::cerr << "Error: ZIP " << input_file
+                      << " total uncompressed size > "
+                      << kMaxTotalUncompressed << " bytes; refusing\n";
+            mz_zip_reader_end(&zip);
+            return out;
+        }
+
+        // Path-safety: refuse anything that could escape temp_dir.
+        // (a) `..` anywhere — catches `a/../../etc/x` and trailing `..`.
+        // (b) entry that resolves absolute under std::filesystem rules —
+        //     catches POSIX `/foo`, Windows `C:\foo`, UNC `\\srv\sh\x`,
+        //     and any platform-specific oddity we'd otherwise miss.
+        // (c) Windows drive-relative `C:foo` — `is_absolute()` does NOT
+        //     consider this absolute on Linux (where this CLI parses
+        //     archives Windows authors may have produced), so guard
+        //     explicitly: any entry whose second character is `:` after
+        //     a single alphabetic drive letter.
+        bool unsafe = false;
+        const char* unsafe_reason = "";
+        if (entry_name.find("..") != std::string::npos) {
+            unsafe = true; unsafe_reason = "contains '..'";
+        } else if (fs::path(entry_name).is_absolute()) {
+            unsafe = true; unsafe_reason = "absolute path";
+        } else if (entry_name.size() >= 2 &&
+                   ((entry_name[0] >= 'A' && entry_name[0] <= 'Z') ||
+                    (entry_name[0] >= 'a' && entry_name[0] <= 'z')) &&
+                   entry_name[1] == ':') {
+            unsafe = true; unsafe_reason = "drive-relative Windows path";
+        } else if (!entry_name.empty() &&
+                   (entry_name[0] == '/' || entry_name[0] == '\\')) {
+            // Belt + braces — `is_absolute()` on macOS / Linux already
+            // catches `/`, but this also covers `\foo` on a Unix host
+            // where fs::path treats `\` as a regular character.
+            unsafe = true; unsafe_reason = "leading slash";
+        }
+        if (unsafe) {
+            std::cerr << "Error: refusing unsafe zip entry (" << unsafe_reason
+                      << "): " << entry_name << "\n";
             mz_zip_reader_end(&zip);
             return out;
         }


### PR DESCRIPTION
Self-review of the .pulp.zip auto-unpack shipped by the prior
import-design fix found three real vulnerabilities the original guards
missed. Today --file is always supplied by the local user, but the
plugin's "Export to Pulp" output is the design-document author, and
designers will drag-drop arbitrary .pulp.zip from email / Slack / shared
drives. That's untrusted input. Closing the holes now before the lane
sees real adoption.

  (1) Filename-truncation zip-slip bypass.
      mz_zip_reader_get_filename silently truncates to the supplied
      buffer size (1024 here). A malicious entry name like
        "<1020 safe chars>/../../../etc/passwd"
      becomes "<1020 safe chars>/..." after truncation — sneaks past the
      `..` substring check — and then mz_zip_reader_extract_to_file is
      called with the FULL untruncated name from the central directory,
      escaping temp_dir. The probe form
      `mz_zip_reader_get_filename(&zip, i, nullptr, 0)` returns
      bytes-needed-including-NUL; we now reject anything that wouldn't
      fit in the stack buffer (>= 1024).

  (2) Windows drive-relative / UNC zip-slip.
      The prior check only rejected entries starting with `/` or `\`.
      `C:\windows\system32\evil.dll`, `C:foo` (drive-relative), and UNC
      paths slipped through. `fs::path::is_absolute()` catches `C:\...`
      and `\\srv\share\...`; an explicit `entry[1] == ':'` guard catches
      drive-relative `C:foo` which is_absolute() says is NOT absolute
      on a Unix host even though Windows treats it specially.

  (3) Zip-bomb / over-quota.
      No cap on total uncompressed bytes, per-file uncompressed size, or
      entry count. A 1-MB malicious zip can expand to gigabytes.
      Realistic Pulp exports are a few MB of JSON + a few hundred KB of
      assets; the new caps (256 MB total / 64 MB per file / 10000
      entries) are ~10× any realistic plugin export, low enough to
      catch bombs cheaply.

Per-entry the order of checks is:
  filename length → file count → file_stat → per-file size cap → total
  size cap → `..` substring → fs::path::is_absolute() → drive-relative
  → leading-slash defence-in-depth → extract.
Any failure logs a labelled error to stderr and bails out (RAII guard
still cleans up the temp dir on return).

Tests (CLAUDE.md "tests ship with fixes"):

  test/test_import_design_tool.cpp gains four Catch2 cases under
  [cli][import-design][tool][figma-plugin][issue-50] that each build a
  hostile fixture from C++ and assert the CLI exits non-zero AND prints
  the right rejection label:
    - oversized filename (1100 chars + trailing `..`) — exercises (1)
    - `subdir/../../../etc/passwd` — substring + truncation guard
    - `C:Windows/system32/evil.dll` — drive-relative guard (2)
    - 10001 entries — file-count cap (3)

Verification on macOS (this branch):
  - cmake --build pulp-test-import-design-tool   — clean
  - ./build/test/pulp-test-import-design-tool    — 13 cases / 10398
    assertions pass (incl. 4 new / 10020 assertions under [issue-50];
    the high count is the 10001-entry zip-count fixture)
  - tools/scripts/gates.sh — ✓ all gates pass

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>