### PR TITLE
feat(figma-import): Phase 5 part 2 — XYPad + Waveform + Spectrum library widgets

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.139.2",
+      "version": "0.139.3",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.139.2"
+  "version": "0.139.3"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.139.2",
+  "version": "0.139.3",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.285.0
+    VERSION 0.285.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -3047,3 +3047,117 @@ TEST_CASE("parse_figma_plugin_json maps Phase 5 Pulp / Meter envelope onto IR wi
     REQUIRE(ir.root.attributes.at("units") == "dB");
     REQUIRE(ir.root.attributes.at("binding") == "meter.out_l");
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// Phase 5 part 2 — Pulp / XYPad + Pulp / Waveform + Pulp / Spectrum.
+//
+// Library v0.3.0 adds three component-sets in
+// https://www.figma.com/design/vxW6btjzQtc4t9ITLNjev0/Pulp-Library:
+//   Pulp / XYPad     component_set_key 9dc09d4cbf65341f12c21ece408ad653886059b9
+//   Pulp / Waveform  component_set_key 2c0797af5c939638ec6a89d893ba310a088ce46c
+//   Pulp / Spectrum  component_set_key f6730821fc7557e93f904d171a45339207abf9e3
+//
+// XYPad uniquely carries a second-axis binding via attributes.binding_y;
+// Waveform and Spectrum's `binding` carries an audio-source path
+// (bus.master_l / bus.fft.master_l) instead of a parameter route.
+
+TEST_CASE("parse_figma_plugin_json maps Phase 5 part 2 Pulp / XYPad envelope onto IR widget",
+          "[view][import][figma-plugin][phase-5]") {
+    const std::string envelope = R"JSON({
+        "format_version": "v1",
+        "parser_version": "0.1.0",
+        "compat_schema_version": "v1",
+        "root": {
+            "type": "frame",
+            "name": "FilterPad",
+            "audio_widget": "xy_pad",
+            "label": "Filter",
+            "min": 20,
+            "max": 20000,
+            "default": 880,
+            "attributes": {
+                "units": "Hz",
+                "binding": "filter.cutoff_hz",
+                "binding_y": "filter.resonance"
+            },
+            "style": { "width": 120, "height": 120 },
+            "children": []
+        }
+    })JSON";
+    auto ir = parse_figma_plugin_json(envelope);
+    REQUIRE(ir.source == DesignSource::figma_plugin);
+    REQUIRE(ir.root.audio_widget == AudioWidgetType::xy_pad);
+    REQUIRE(ir.root.audio_label == "Filter");
+    REQUIRE(ir.root.audio_min == Catch::Approx(20.0f));
+    REQUIRE(ir.root.audio_max == Catch::Approx(20000.0f));
+    REQUIRE(ir.root.audio_default == Catch::Approx(880.0f));
+    REQUIRE(ir.root.attributes.at("units") == "Hz");
+    REQUIRE(ir.root.attributes.at("binding") == "filter.cutoff_hz");
+    // XYPad-specific second-axis binding rides on attributes.binding_y.
+    REQUIRE(ir.root.attributes.at("binding_y") == "filter.resonance");
+}
+
+TEST_CASE("parse_figma_plugin_json maps Phase 5 part 2 Pulp / Waveform envelope onto IR widget",
+          "[view][import][figma-plugin][phase-5]") {
+    const std::string envelope = R"JSON({
+        "format_version": "v1",
+        "parser_version": "0.1.0",
+        "compat_schema_version": "v1",
+        "root": {
+            "type": "frame",
+            "name": "Master scope",
+            "audio_widget": "waveform",
+            "label": "Master",
+            "min": -1,
+            "max": 1,
+            "attributes": {
+                "binding": "bus.master_l"
+            },
+            "style": { "width": 200, "height": 64 },
+            "children": []
+        }
+    })JSON";
+    auto ir = parse_figma_plugin_json(envelope);
+    REQUIRE(ir.root.audio_widget == AudioWidgetType::waveform);
+    REQUIRE(ir.root.audio_label == "Master");
+    REQUIRE(ir.root.audio_min == Catch::Approx(-1.0f));
+    REQUIRE(ir.root.audio_max == Catch::Approx(1.0f));
+    REQUIRE(ir.root.attributes.at("binding") == "bus.master_l");
+    // Waveform envelopes default to empty units and an audio-source
+    // path in binding (rather than a param route). Codegen branches on
+    // audio_widget to interpret accordingly.
+    REQUIRE(ir.root.attributes.count("units") == 0);
+    REQUIRE(ir.root.attributes.count("binding_y") == 0);
+}
+
+TEST_CASE("parse_figma_plugin_json maps Phase 5 part 2 Pulp / Spectrum envelope onto IR widget",
+          "[view][import][figma-plugin][phase-5]") {
+    const std::string envelope = R"JSON({
+        "format_version": "v1",
+        "parser_version": "0.1.0",
+        "compat_schema_version": "v1",
+        "root": {
+            "type": "frame",
+            "name": "MasterFFT",
+            "audio_widget": "spectrum",
+            "label": "Spectrum",
+            "min": -60,
+            "max": 0,
+            "attributes": {
+                "units": "dB",
+                "binding": "bus.fft.master_l"
+            },
+            "style": { "width": 200, "height": 64 },
+            "children": []
+        }
+    })JSON";
+    auto ir = parse_figma_plugin_json(envelope);
+    REQUIRE(ir.root.audio_widget == AudioWidgetType::spectrum);
+    REQUIRE(ir.root.audio_label == "Spectrum");
+    REQUIRE(ir.root.audio_min == Catch::Approx(-60.0f));
+    REQUIRE(ir.root.audio_max == Catch::Approx(0.0f));
+    REQUIRE(ir.root.attributes.at("units") == "dB");
+    // FFT source binding — the `fft.` segment is the convention
+    // distinguishing this from a parameter route to consumers that care.
+    REQUIRE(ir.root.attributes.at("binding") == "bus.fft.master_l");
+}

--- a/tools/figma-plugin/library-manifest.json
+++ b/tools/figma-plugin/library-manifest.json
@@ -1,5 +1,5 @@
 {
-  "library_version": "0.2.0",
+  "library_version": "0.3.0",
   "library_file_key": "vxW6btjzQtc4t9ITLNjev0",
   "library_file_url": "https://www.figma.com/design/vxW6btjzQtc4t9ITLNjev0/Pulp-Library",
   "required_plugin_version": ">=0.1.0",
@@ -27,6 +27,30 @@
       "supported_property_definitions": ["label", "value", "min", "max", "units", "binding"],
       "supported_variant_axes": ["size", "state"],
       "since_library_version": "0.2.0"
+    },
+    "xy_pad": {
+      "component_set_key": "9dc09d4cbf65341f12c21ece408ad653886059b9",
+      "component_set_node_id": "24:171",
+      "name_prefix": "Pulp / XYPad",
+      "supported_property_definitions": ["label", "value", "min", "max", "units", "binding", "binding_y"],
+      "supported_variant_axes": ["size", "state"],
+      "since_library_version": "0.3.0"
+    },
+    "waveform": {
+      "component_set_key": "2c0797af5c939638ec6a89d893ba310a088ce46c",
+      "component_set_node_id": "24:702",
+      "name_prefix": "Pulp / Waveform",
+      "supported_property_definitions": ["label", "value", "min", "max", "units", "binding"],
+      "supported_variant_axes": ["size", "state"],
+      "since_library_version": "0.3.0"
+    },
+    "spectrum": {
+      "component_set_key": "f6730821fc7557e93f904d171a45339207abf9e3",
+      "component_set_node_id": "24:1209",
+      "name_prefix": "Pulp / Spectrum",
+      "supported_property_definitions": ["label", "value", "min", "max", "units", "binding"],
+      "supported_variant_axes": ["size", "state"],
+      "since_library_version": "0.3.0"
     }
   }
 }

--- a/tools/figma-plugin/src/extract-model.ts
+++ b/tools/figma-plugin/src/extract-model.ts
@@ -58,6 +58,10 @@ export interface ExtractedFigmaNode {
   audio_default?: number;
   audio_units?: string;
   audio_binding?: string;
+  // Phase 5 — XYPad carries a Y-axis binding alongside the primary
+  // `binding` (which holds the X-axis route). Lands in IRNode.attributes.binding_y.
+  // Populated only for `Pulp / XYPad` library instances.
+  audio_binding_y?: string;
 
   children: ExtractedFigmaNode[];
 }

--- a/tools/figma-plugin/src/extract.ts
+++ b/tools/figma-plugin/src/extract.ts
@@ -754,6 +754,10 @@ function extractAudioPropsFromComponentProperties(
   if (units !== undefined && units.length > 0) ex.audio_units = units;
   const binding = getRawString("binding");
   if (binding !== undefined && binding.length > 0) ex.audio_binding = binding;
+  // Phase 5: XYPad has a second binding for the Y axis. Only the XYPad
+  // library variant defines this property; other widgets fall through.
+  const binding_y = getRawString("binding_y");
+  if (binding_y !== undefined && binding_y.length > 0) ex.audio_binding_y = binding_y;
 }
 
 /// Detect audio widget kind from an instance's main-component name. Used

--- a/tools/figma-plugin/src/serialize.ts
+++ b/tools/figma-plugin/src/serialize.ts
@@ -107,10 +107,17 @@ function toEnvelopeNode(n: ExtractedFigmaNode): unknown {
   if (n.audio_min !== undefined) out.min = n.audio_min;
   if (n.audio_max !== undefined) out.max = n.audio_max;
   if (n.audio_default !== undefined) out.default = n.audio_default;
-  if (n.audio_units !== undefined || n.audio_binding !== undefined) {
+  if (n.audio_units !== undefined ||
+      n.audio_binding !== undefined ||
+      n.audio_binding_y !== undefined) {
     const attrs: Record<string, string> = {};
     if (n.audio_units !== undefined) attrs.units = n.audio_units;
     if (n.audio_binding !== undefined) attrs.binding = n.audio_binding;
+    // Phase 5: XYPad carries a second-axis binding alongside the primary
+    // `binding`. Lands in IRNode.attributes.binding_y; codegen consumes
+    // when the audio_widget="xy_pad" branch is wired up to route two
+    // parameter targets (see planning/2026-05-30-figma-import-fidelity-coordination.md).
+    if (n.audio_binding_y !== undefined) attrs.binding_y = n.audio_binding_y;
     out.attributes = attrs;
   }
 


### PR DESCRIPTION
Adds the next three Pulp Library widgets so the library covers the
typical six-widget audio-plugin UI (Knob/Fader/Meter/XYPad/Waveform/
Spectrum). Authored via Figma MCP into the Pulp Library design source
(https://www.figma.com/design/vxW6btjzQtc4t9ITLNjev0/Pulp-Library) and
wired into the recognition pass.

Library v0.2.0 → v0.3.0. Three new component-sets published in the
source file (user republishes to Community to make them designer-
installable):

  Pulp / XYPad     component_set_key 9dc09d4cbf65341f12c21ece408ad653886059b9 (page 24:2, cs 24:171)
  Pulp / Waveform  component_set_key 2c0797af5c939638ec6a89d893ba310a088ce46c (page 24:245, cs 24:702)
  Pulp / Spectrum  component_set_key f6730821fc7557e93f904d171a45339207abf9e3 (page 24:764, cs 24:1209)

Each: 3 sizes × 4 states = 12 variants. XYPad uniquely has a 7th
instance property `binding_y` for the Y-axis route; the standard
`binding` carries the X axis. Lands in `IRNode.attributes.binding_y` —
no new IR fields needed, codegen consumes when wired (Agent A's lane).

Waveform + Spectrum's `binding` carries an audio-source path
(e.g. `bus.master_l`, `bus.fft.master_l`) rather than a parameter
route. The `audio_widget` enum (`waveform` / `spectrum`) is what
distinguishes the two semantics on the consumer side.

Code changes:

  * tools/figma-plugin/library-manifest.json — three new entries with
    keys + supported_property_definitions (XYPad lists 7, others 6).
    library_version bumped to 0.3.0.

  * tools/figma-plugin/src/extract-model.ts — one new optional
    field `audio_binding_y` on ExtractedFigmaNode.

  * tools/figma-plugin/src/extract.ts — extractAudioPropsFromComponent
    Properties() now reads the optional `binding_y` instance property
    into `ex.audio_binding_y` (only XYPad defines this property; other
    widgets fall through harmlessly).

  * tools/figma-plugin/src/serialize.ts — emit attributes.binding_y in
    the JSON envelope when present. Backward-compatible (waveform /
    spectrum / knob / fader / meter envelopes are unchanged).

Tests (CLAUDE.md "tests ship with fixes"):

  * test/test_design_import.cpp gains three Catch2 cases under
    [view][import][figma-plugin][phase-5] pinning the IR contract:
      - XYPad envelope (audio_widget=xy_pad + label + range +
        attributes.binding + attributes.binding_y) → asserts both
        bindings make it through parse_figma_plugin_json.
      - Waveform envelope (audio_widget=waveform + bus.master_l) →
        asserts empty units / no binding_y on a single-binding widget.
      - Spectrum envelope (audio_widget=spectrum + bus.fft.master_l +
        dB units) → asserts FFT source path is carried verbatim.

Verification on macOS:
  - npm run typecheck (figma-plugin)            — clean
  - npm run build (figma-plugin)                — clean
  - cmake --build pulp-test-design-import       — clean
  - ./build/test/pulp-test-design-import        — 698 assertions / 68
    cases pass (incl. 5 figma-plugin / 38 assertions; 3 of those new).

Hand-off note: Agent A picks up the codegen side of binding_y when
the design_codegen.cpp xy_pad branch lands (currently routes the
single `binding`; the binding_y attribute is carried into IRNode.
attributes.binding_y verbatim so the wiring is straightforward).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>