### PR TITLE
feat(format): runtime host-quirks policy gate + pulp doctor reporting (P2)

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -565,6 +565,35 @@ When adding a new validator: extend the `kValidators` array in
 all four states (Healthy, user-owned Broken, root-owned Broken,
 Missing).
 
+### `pulp doctor --host-quirks` (host-quirks integration plan P2)
+
+Reports the runtime DAW host-quirks policy. `cmd_doctor.cpp` reads the
+`pulp::format` host-quirks API directly:
+
+- `resolve_quirk_policy()` → effective `QuirkFilter` + `QuirkPolicySource`
+  (compile default / `PULP_HOST_QUIRKS` env / `set_host_quirk_policy()` API)
+- `detect_host_info()` → detected DAW + version
+- `resolved_quirks(type, version)` + `enumerate_quirk_fields(...)` → the
+  per-flag table (name · tier · enforced)
+
+`--host-quirks` (and the `pulp doctor quirks` synonym) prints **only** the
+section and exits 0 — that's the scriptable surface the `cli-doctor-host-quirks*`
+ctest cases pin. The same section is also appended to the default
+`pulp doctor` human output (gated on `mode.empty() && !ci_mode`).
+
+Gotchas:
+- The override-hint line always literally contains `off|validated-only|all`,
+  so a ctest `PASS_REGULAR_EXPRESSION` for a specific policy must anchor on
+  the **source label** (`... (PULP_HOST_QUIRKS env)`), which appears only on
+  the policy line — not on the hint line. See the three `cli-doctor-host-quirks*`
+  tests in `tools/cli/CMakeLists.txt`.
+- `PULP_HOST_QUIRKS` is parsed **once per process** (cached), so each policy
+  variant needs its own `add_test` (fresh process), not a single invocation.
+- The policy is layered on the compile-time `PULP_HOST_QUIRKS_DEFAULT_POLICY`;
+  with nothing set the source reads "compile default" and behaviour is
+  unchanged. Full precedence + the override API live in
+  `docs/reference/host-quirks-policy.md`.
+
 ## `pulp upgrade` — self-update
 
 Lives in `tools/cli/cmd_upgrade.cpp` (moved out of `cmd_misc.cpp` in

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.139.3",
+      "version": "0.140.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.139.3"
+  "version": "0.140.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.139.3",
+  "version": "0.140.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.285.1
+    VERSION 0.286.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/host_quirks.hpp
+++ b/core/format/include/pulp/format/host_quirks.hpp
@@ -44,6 +44,10 @@
 #include <pulp/format/host_type.hpp>
 #include <pulp/format/host_version.hpp>
 
+#include <optional>
+#include <string_view>
+#include <vector>
+
 namespace pulp::format {
 
 /// Validation tier for an individual host-quirk flag. See file header.
@@ -387,6 +391,80 @@ HostQuirks make_quirks_for_validated_only(HostType type, HostVersion version);
 /// Plugin authors can still override at runtime by ignoring this
 /// helper and constructing their own `HostQuirks` via
 /// `make_quirks_for(...)` + `apply_filter(...)`.
+///
+/// Since P2 this routes through `resolved_quirks(...)`, so the runtime
+/// policy (env / API / per-quirk override) applies here too. With no
+/// runtime override set, the effective filter is the compile-time
+/// default, so behavior is unchanged from before P2.
 HostQuirks detect_quirks();
+
+// ── Runtime policy (P2) ───────────────────────────────────────────────
+//
+// The compile-time `PULP_HOST_QUIRKS_DEFAULT_POLICY` option sets the
+// baseline tier filter. P2 layers a runtime override on top so a user
+// who doesn't trust a quirk can dial it back without recompiling, while
+// the default stays ON (validated quirks enforced). Precedence, highest
+// first:
+//
+//   per-quirk override  >  set_host_quirk_policy() (API)
+//                       >  PULP_HOST_QUIRKS env  >  compile-time default
+//
+// All of this is init-time configuration — resolve once when the adapter
+// is constructed. None of it is real-time safe; never call the setters
+// from the audio thread.
+
+/// Where the effective base tier-filter came from (for diagnostics —
+/// `pulp doctor` reports this).
+enum class QuirkPolicySource : unsigned char {
+    CompileDefault,  ///< PULP_HOST_QUIRKS_DEFAULT_POLICY build option.
+    Environment,     ///< PULP_HOST_QUIRKS environment variable.
+    Api,             ///< set_host_quirk_policy().
+};
+
+/// The runtime-resolved base filter together with its source.
+struct ResolvedQuirkPolicy {
+    QuirkFilter filter;
+    QuirkPolicySource source = QuirkPolicySource::CompileDefault;
+};
+
+/// Resolve the effective base tier-filter at runtime (does NOT apply
+/// per-quirk overrides — those layer on inside `resolved_quirks`). The
+/// `PULP_HOST_QUIRKS` env var is parsed once and cached; recognized
+/// values (case-insensitive) are `off`, `validated-only`, and `all`. An
+/// unrecognized value is ignored with a one-time warning and resolution
+/// falls through to the next layer.
+ResolvedQuirkPolicy resolve_quirk_policy();
+
+/// Programmatically set the base tier-filter (highest base-layer
+/// precedence, above the env var). Pass `std::nullopt` to clear it and
+/// fall back to env / compile default. Init-time only.
+void set_host_quirk_policy(std::optional<QuirkFilter> filter);
+
+/// Force a single quirk flag on or off by its `HostQuirks` field name,
+/// overriding the tier filter for just that flag. `enabled = true` keeps
+/// the host-populated value even when its tier is filtered out;
+/// `enabled = false` forces it back to the default (off). Unknown names
+/// are ignored. Init-time only.
+void set_quirk_override(std::string_view flag, bool enabled);
+
+/// Clear all per-quirk overrides set via `set_quirk_override`.
+void clear_quirk_overrides();
+
+/// One row of resolved quirk state, for diagnostics (`pulp doctor`).
+struct QuirkFieldStatus {
+    std::string_view name;  ///< `HostQuirks` field name (static storage).
+    QuirkStatus tier;       ///< Validation tier from `kHostQuirksMeta`.
+    bool enforced;          ///< Accommodation active (bool true; int != default).
+};
+
+/// Enumerate every quirk field of `q` with its tier and whether it is
+/// currently enforced, in `HostQuirks` declaration order. Used by
+/// `pulp doctor` to render the host-quirks table.
+std::vector<QuirkFieldStatus> enumerate_quirk_fields(const HostQuirks& q);
+
+/// The single entry adapters consume (P3): build the host's quirks, apply
+/// the runtime base filter (`resolve_quirk_policy`), then layer per-quirk
+/// overrides. Equivalent to `make_quirks_for` + the runtime policy.
+HostQuirks resolved_quirks(HostType type, HostVersion version);
 
 }  // namespace pulp::format

--- a/core/format/src/host_quirks.cpp
+++ b/core/format/src/host_quirks.cpp
@@ -14,7 +14,81 @@
 #include <pulp/format/host_quirks/wavelab.hpp>
 #include <pulp/format/host_version.hpp>
 
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <map>
+#include <mutex>
+#include <string>
+#include <string_view>
+
 namespace pulp::format {
+
+// ── Single source of truth for the HostQuirks field list ──────────────
+//
+// Every data member of `HostQuirks` is listed here exactly once. The
+// list drives three generated passes (apply_filter, per-quirk override
+// application, and field enumeration for `pulp doctor`) so they can
+// never drift from one another. When you add a field to `HostQuirks`
+// (and its tier to `HostQuirksMeta` + a row to host-quirks.json), add it
+// here too — the static_assert below and the catalog parity test guard
+// against forgetting. Keep declaration order in sync with the struct.
+#define PULP_HOST_QUIRK_FIELDS(X)                       \
+    X(synthesize_bypass_parameter)                      \
+    X(clamp_latency_to_nonneg)                          \
+    X(silence_unsupported_bus_arrangements)             \
+    X(cubase10_async_view_resize_queue)                 \
+    X(cubase10_param_gesture_ordering)                  \
+    X(cubase10_fractional_scale_correction)             \
+    X(cubase9_state_blob_size_validation)               \
+    X(live_vst3_canresize_ignore)                       \
+    X(live_vst3_windows_dpi_defer)                      \
+    X(double_string_buffer_for_live_10_1_13)            \
+    X(bitwig_vst3_linux_repaint_after_resize)           \
+    X(bitwig_vst3_setbusarrangements_while_active)      \
+    X(skip_bus_arrangement_call)                        \
+    X(wavelab_vst3_defer_activation)                    \
+    X(wavelab_state_blob_fallback)                      \
+    X(tolerate_state_read_nontrue_status)               \
+    X(fl_studio_setactive_process_mutex)                \
+    X(fl_studio_state_reader_skip)                      \
+    X(reaper_vst3_gesture_ordering)                     \
+    X(reaper_process_while_bypassed)                    \
+    X(reaper_keyboard_passthrough)                      \
+    X(reaper_permissive_bus_arrangements)               \
+    X(reaper_anticipative_fx_buffer_variability)        \
+    X(reaper_midsession_setstate)                       \
+    X(reaper_keyboard_only_space)                       \
+    X(pro_tools_aax_sidechain_negotiation)              \
+    X(pro_tools_aax_latency_callback_push)              \
+    X(pro_tools_aax_mono_second_bus)                    \
+    X(aax_vendor_version_unknown)                       \
+    X(logic_au_channel_probe_cap)                       \
+    X(logic_au_tail_time_conversion)                    \
+    X(au_v3_bypass_dual_tracking)                        \
+    X(au_v3_host_id_from_wrapper)                        \
+    X(reaper_auv3_in_process_preferred_size_sync)       \
+    X(studio_one_restart_component_ui_thread)           \
+    X(digital_performer_param_list_reload)              \
+    X(cubase13_midi_cc_param_id_stable)
+
+// Tripwire: the field count baked into the X-macro list above. If a new
+// HostQuirks field is added without extending PULP_HOST_QUIRK_FIELDS the
+// generated passes would silently skip it; bump this count in lock-step
+// (the catalog parity test independently asserts the struct/meta/JSON
+// flag sets all match, so a forgotten field surfaces there too).
+namespace {
+constexpr int count_quirk_fields() noexcept {
+    int n = 0;
+#define PULP_QUIRK_COUNT(name) ++n;
+    PULP_HOST_QUIRK_FIELDS(PULP_QUIRK_COUNT)
+#undef PULP_QUIRK_COUNT
+    return n;
+}
+}  // namespace
+static_assert(count_quirk_fields() == 37,
+              "PULP_HOST_QUIRK_FIELDS is out of sync with HostQuirks — "
+              "add the new field to the X-macro list and bump this count.");
 
 namespace {
 
@@ -103,76 +177,71 @@ constexpr QuirkFilter default_policy_filter() noexcept {
 #endif
 }
 
+// ── Runtime policy layer (P2) ─────────────────────────────────────────
+//
+// Layered on TOP of the compile-time default above. Precedence (highest
+// first): per-quirk override > set_host_quirk_policy() (API) >
+// PULP_HOST_QUIRKS env > compile-time default. All of this is init-time
+// state (adapters resolve once at construction); it is NOT touched on
+// the audio thread. A single mutex guards the API-set state.
+
+// Parse PULP_HOST_QUIRKS once. Recognized (case-insensitive):
+//   off | validated-only (or validated_only) | all.
+// An empty/unset var → nullopt (fall through). An unrecognized value →
+// nullopt + a one-time stderr warning (so a typo can't silently disable
+// accommodations).
+std::optional<QuirkFilter> parse_env_policy() {
+    const char* raw = std::getenv("PULP_HOST_QUIRKS");
+    if (raw == nullptr || raw[0] == '\0') return std::nullopt;
+    std::string v(raw);
+    for (char& c : v) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    if (v == "off") return kQuirkFilterOff;
+    if (v == "all") return QuirkFilter{};
+    if (v == "validated-only" || v == "validated_only" || v == "validatedonly")
+        return kQuirkFilterValidatedOnly;
+    std::fprintf(stderr,
+                 "[pulp] warning: ignoring unrecognized PULP_HOST_QUIRKS=%s "
+                 "(expected off|validated-only|all)\n",
+                 raw);
+    return std::nullopt;
+}
+
+const std::optional<QuirkFilter>& env_policy() {
+    static const std::optional<QuirkFilter> cached = parse_env_policy();
+    return cached;
+}
+
+std::mutex& policy_mutex() {
+    static std::mutex m;
+    return m;
+}
+
+// API-set whole-policy filter (highest base-layer precedence). nullopt
+// means "not set — fall through to env/compile".
+std::optional<QuirkFilter>& api_policy() {
+    static std::optional<QuirkFilter> p;
+    return p;
+}
+
+// Per-quirk forced state by field name. true → force the host-populated
+// value (exempt from the tier filter); false → force the default (off).
+std::map<std::string, bool, std::less<>>& quirk_overrides() {
+    static std::map<std::string, bool, std::less<>> m;
+    return m;
+}
+
 } // namespace
 
 void apply_filter(HostQuirks& q, QuirkFilter filter) {
     constexpr auto& m = kHostQuirksMeta;
     constexpr auto& d = kDefaultHostQuirks;
 
-#define PULP_QUIRK_FILTER_FIELD(name) \
-    reset_if_filtered(q.name, d.name, m.name, filter)
-
-    // Cheap defenses (Validated)
-    PULP_QUIRK_FILTER_FIELD(synthesize_bypass_parameter);
-    PULP_QUIRK_FILTER_FIELD(clamp_latency_to_nonneg);
-    PULP_QUIRK_FILTER_FIELD(silence_unsupported_bus_arrangements);
-
-    // Cubase
-    PULP_QUIRK_FILTER_FIELD(cubase10_async_view_resize_queue);
-    PULP_QUIRK_FILTER_FIELD(cubase10_param_gesture_ordering);
-    PULP_QUIRK_FILTER_FIELD(cubase10_fractional_scale_correction);
-    PULP_QUIRK_FILTER_FIELD(cubase9_state_blob_size_validation);
-
-    // Ableton Live
-    PULP_QUIRK_FILTER_FIELD(live_vst3_canresize_ignore);
-    PULP_QUIRK_FILTER_FIELD(live_vst3_windows_dpi_defer);
-    PULP_QUIRK_FILTER_FIELD(double_string_buffer_for_live_10_1_13);
-
-    // Bitwig
-    PULP_QUIRK_FILTER_FIELD(bitwig_vst3_linux_repaint_after_resize);
-    PULP_QUIRK_FILTER_FIELD(bitwig_vst3_setbusarrangements_while_active);
-
-    // Ardour family (Ardour + Mixbus 32C)
-    PULP_QUIRK_FILTER_FIELD(skip_bus_arrangement_call);
-
-    // Wavelab
-    PULP_QUIRK_FILTER_FIELD(wavelab_vst3_defer_activation);
-    PULP_QUIRK_FILTER_FIELD(wavelab_state_blob_fallback);
-    PULP_QUIRK_FILTER_FIELD(tolerate_state_read_nontrue_status);
-
-    // FL Studio
-    PULP_QUIRK_FILTER_FIELD(fl_studio_setactive_process_mutex);
-    PULP_QUIRK_FILTER_FIELD(fl_studio_state_reader_skip);
-
-    // Reaper
-    PULP_QUIRK_FILTER_FIELD(reaper_vst3_gesture_ordering);
-    PULP_QUIRK_FILTER_FIELD(reaper_process_while_bypassed);
-    PULP_QUIRK_FILTER_FIELD(reaper_keyboard_passthrough);
-    PULP_QUIRK_FILTER_FIELD(reaper_permissive_bus_arrangements);
-    PULP_QUIRK_FILTER_FIELD(reaper_anticipative_fx_buffer_variability);
-    PULP_QUIRK_FILTER_FIELD(reaper_midsession_setstate);
-    PULP_QUIRK_FILTER_FIELD(reaper_keyboard_only_space);
-
-    // Pro Tools
-    PULP_QUIRK_FILTER_FIELD(pro_tools_aax_sidechain_negotiation);
-    PULP_QUIRK_FILTER_FIELD(pro_tools_aax_latency_callback_push);
-    PULP_QUIRK_FILTER_FIELD(pro_tools_aax_mono_second_bus);
-    PULP_QUIRK_FILTER_FIELD(aax_vendor_version_unknown);
-
-    // Logic Pro AU (one int field — same machinery)
-    PULP_QUIRK_FILTER_FIELD(logic_au_channel_probe_cap);
-    PULP_QUIRK_FILTER_FIELD(logic_au_tail_time_conversion);
-
-    // AU v3 cross-host
-    PULP_QUIRK_FILTER_FIELD(au_v3_bypass_dual_tracking);
-    PULP_QUIRK_FILTER_FIELD(au_v3_host_id_from_wrapper);
-
-    // 2026-05-26 iPlug2-audit batch (Pulp #3044 / #3045 / #3046 / #3047).
-    PULP_QUIRK_FILTER_FIELD(reaper_auv3_in_process_preferred_size_sync);
-    PULP_QUIRK_FILTER_FIELD(studio_one_restart_component_ui_thread);
-    PULP_QUIRK_FILTER_FIELD(digital_performer_param_list_reload);
-    PULP_QUIRK_FILTER_FIELD(cubase13_midi_cc_param_id_stable);
-
+    // Reset every field whose meta tier is not allowed by `filter`. The
+    // field list lives in the single PULP_HOST_QUIRK_FIELDS X-macro so
+    // this pass, the per-quirk override pass, and the doctor enumeration
+    // all iterate identical sets (no manual list to drift).
+#define PULP_QUIRK_FILTER_FIELD(name) reset_if_filtered(q.name, d.name, m.name, filter);
+    PULP_HOST_QUIRK_FIELDS(PULP_QUIRK_FILTER_FIELD)
 #undef PULP_QUIRK_FILTER_FIELD
 }
 
@@ -214,11 +283,95 @@ HostQuirks make_quirks_for_validated_only(HostType type, HostVersion version) {
     return q;
 }
 
+ResolvedQuirkPolicy resolve_quirk_policy() {
+    std::lock_guard<std::mutex> lk(policy_mutex());
+    if (api_policy().has_value())
+        return {*api_policy(), QuirkPolicySource::Api};
+    if (env_policy().has_value())
+        return {*env_policy(), QuirkPolicySource::Environment};
+    return {default_policy_filter(), QuirkPolicySource::CompileDefault};
+}
+
+void set_host_quirk_policy(std::optional<QuirkFilter> filter) {
+    std::lock_guard<std::mutex> lk(policy_mutex());
+    api_policy() = filter;
+}
+
+void set_quirk_override(std::string_view flag, bool enabled) {
+    std::lock_guard<std::mutex> lk(policy_mutex());
+    quirk_overrides()[std::string(flag)] = enabled;
+}
+
+void clear_quirk_overrides() {
+    std::lock_guard<std::mutex> lk(policy_mutex());
+    quirk_overrides().clear();
+}
+
+namespace {
+// "Enforced" for the doctor view = the accommodation is actively in
+// effect. The meaning differs by field type, so these overloads pick
+// the right test per field (resolved at the X-macro expansion site):
+//   * bool flag  → enforced when true (the defense/workaround is on).
+//   * int field  → enforced when it differs from the cross-host default
+//     (e.g. Logic's channel-probe cap of 8 vs the default 64); the
+//     default value is "no host-specific accommodation".
+constexpr bool quirk_field_enforced(bool value, bool /*default_value*/) noexcept {
+    return value;
+}
+constexpr bool quirk_field_enforced(int value, int default_value) noexcept {
+    return value != default_value;
+}
+
+// The "off" value a force-off override sets — disabling an accommodation,
+// which is NOT the same as the struct default for cheap defenses (whose
+// default is true). Mirrors reset_if_filtered's behavior: bool → false,
+// int → its cross-host default (no host-specific cap).
+constexpr bool quirk_off_value(bool /*default_value*/) noexcept { return false; }
+constexpr int  quirk_off_value(int default_value) noexcept { return default_value; }
+
+// Apply per-quirk overrides on top of an already tier-filtered `q`.
+// `populated` is the unfiltered host result, so force-on restores the
+// real host value (handles the int field too); force-off resets to the
+// struct default. Field dispatch is generated from PULP_HOST_QUIRK_FIELDS.
+void apply_overrides(HostQuirks& q, const HostQuirks& populated) {
+    std::lock_guard<std::mutex> lk(policy_mutex());
+    auto& ov = quirk_overrides();
+    if (ov.empty()) return;
+    constexpr auto& d = kDefaultHostQuirks;
+#define PULP_QUIRK_OVERRIDE_FIELD(name)                       \
+    if (auto it = ov.find(#name); it != ov.end())             \
+        q.name = it->second ? populated.name : quirk_off_value(d.name);
+    PULP_HOST_QUIRK_FIELDS(PULP_QUIRK_OVERRIDE_FIELD)
+#undef PULP_QUIRK_OVERRIDE_FIELD
+}
+}  // namespace
+
+std::vector<QuirkFieldStatus> enumerate_quirk_fields(const HostQuirks& q) {
+    constexpr auto& m = kHostQuirksMeta;
+    constexpr auto& d = kDefaultHostQuirks;
+    std::vector<QuirkFieldStatus> out;
+    out.reserve(count_quirk_fields());
+    // `enforced` = the field differs from its default — true means the
+    // accommodation is active (covers both bool flags and the int
+    // logic_au_channel_probe_cap, whose default is 64).
+#define PULP_QUIRK_ENUM_FIELD(name) \
+    out.push_back(QuirkFieldStatus{#name, m.name, quirk_field_enforced(q.name, d.name)});
+    PULP_HOST_QUIRK_FIELDS(PULP_QUIRK_ENUM_FIELD)
+#undef PULP_QUIRK_ENUM_FIELD
+    return out;
+}
+
+HostQuirks resolved_quirks(HostType type, HostVersion version) {
+    const HostQuirks populated = make_quirks_for(type, version);
+    HostQuirks q = populated;
+    apply_filter(q, resolve_quirk_policy().filter);
+    apply_overrides(q, populated);
+    return q;
+}
+
 HostQuirks detect_quirks() {
     const auto info = detect_host_info();
-    auto q = make_quirks_for(info.type, info.version);
-    apply_filter(q, default_policy_filter());
-    return q;
+    return resolved_quirks(info.type, info.version);
 }
 
 }  // namespace pulp::format

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -278,7 +278,30 @@ pulp doctor --caches                 # FetchContent shared-source cache health
 pulp doctor --caches --fix           # heal user-owned dangling/stale-commit entries
 pulp doctor --caches --fix --dry-run # preview heal without removing anything
 pulp doctor --caches --json          # emit the cache report as stable JSON
+pulp doctor --host-quirks            # show the runtime DAW host-quirks policy + enforced accommodations
+pulp doctor quirks                   # synonym for --host-quirks
 ```
+
+`pulp doctor --host-quirks` reports whether Pulp is enforcing DAW
+host-quirk accommodations and under which policy. It prints the effective
+tier policy (`off` / `validated-only` / `all`) and where it came from
+(compile-time default, the `PULP_HOST_QUIRKS` env var, or a programmatic
+`set_host_quirk_policy()` call), the detected host + version, and the list
+of currently-enforced accommodations with their validation tier. The same
+section is appended to the default `pulp doctor` output.
+
+Override the policy at runtime without recompiling:
+
+```bash
+PULP_HOST_QUIRKS=off            pulp doctor --host-quirks  # disable all accommodations
+PULP_HOST_QUIRKS=validated-only pulp doctor --host-quirks  # only bench-validated fixes
+PULP_HOST_QUIRKS=all            pulp doctor --host-quirks  # every detected quirk (default)
+```
+
+Per-quirk provenance — `source_type`, `evidence`, and `last_verified`
+dates — lives in `core/format/host-quirks.json`. See
+[host-quirks policy](host-quirks-policy.md) for the full opt-in / opt-out
+story and the precedence rules.
 
 Checks are platform-gated — only relevant checks run on each OS:
 - **macOS**: git, compiler, CMake, git-lfs, LFS files, VST3 SDK, AudioUnitSDK, optional AAX SDK/validator, build state

--- a/docs/reference/host-quirks-policy.md
+++ b/docs/reference/host-quirks-policy.md
@@ -85,6 +85,63 @@ cheap defenses, pass `kQuirkFilterOff`.
 `apply_filter()` is idempotent — applying the same filter twice is a
 no-op on the second call.
 
+## Runtime policy: env var + API override (no recompile)
+
+The `make_quirks_for(...)` / `apply_filter(...)` route above is the
+fully manual surface. Since the host-quirks **enforcement layer** (P2),
+adapters resolve quirks through a single entry that also honours a
+*runtime* policy layered on top of the build-time default — so a user
+who doesn't trust a particular accommodation can dial it back without
+recompiling, while the trusted set stays enforced.
+
+```cpp
+// The single entry adapters consume. Equivalent to make_quirks_for(...)
+// plus the runtime base filter and any per-quirk overrides.
+HostQuirks q = resolved_quirks(host_type, host_version);
+```
+
+**Precedence (highest first):**
+
+1. **Per-quirk override** — `set_quirk_override("<field>", true|false)`.
+   `true` keeps the host-populated value even if its tier is filtered
+   out; `false` forces it back to the default (off). `clear_quirk_overrides()`
+   resets them.
+2. **API policy** — `set_host_quirk_policy(QuirkFilter{...})` sets the
+   whole-policy filter programmatically; pass `std::nullopt` to clear.
+3. **Environment** — `PULP_HOST_QUIRKS` (case-insensitive):
+   `off` | `validated-only` | `all`. Parsed once per process; an
+   unrecognized value is ignored with a one-time warning.
+4. **Build-time default** — the `PULP_HOST_QUIRKS_DEFAULT_POLICY` CMake
+   option (see above). When nothing else is set, behaviour is exactly
+   the build-time default — i.e. P2 changes nothing by default.
+
+All of these are **init-time** configuration: resolve once when the
+adapter is constructed. None of the setters are real-time safe — never
+call them from the audio thread.
+
+`resolve_quirk_policy()` returns the effective base filter together with
+its `QuirkPolicySource` (compile default / env / API) for diagnostics.
+
+### Inspecting the live policy: `pulp doctor`
+
+```text
+$ pulp doctor --host-quirks
+Host quirks
+  policy:        all  (compile default)
+  detected host: REAPER 7.20
+  enforced:      9 / 37 accommodations active
+    • reaper_vst3_gesture_ordering  [Speculative]
+    • ...
+  override with PULP_HOST_QUIRKS=off|validated-only|all
+  provenance + last-verified dates: core/format/host-quirks.json
+```
+
+The same section appears at the bottom of the default `pulp doctor`
+output. `PULP_HOST_QUIRKS=off pulp doctor --host-quirks` shows the
+policy switching to `off` with source `PULP_HOST_QUIRKS env`. Per-quirk
+provenance — `source_type`, `evidence`, and `last_verified` dates — lives
+in the machine-readable catalog `core/format/host-quirks.json`.
+
 ## Filing a new quirk
 
 When a Pulp plugin breaks in a DAW you should follow the discovery

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -424,6 +424,9 @@ commands:
       - name: --json
         kind: flag
         description: With --versions or --caches, emit the diagnostic as a single JSON object (stable schema — see reference/cli.md#doctor)
+      - name: --host-quirks
+        kind: flag
+        description: Print only the host-quirks section — the effective runtime policy (off/validated-only/all) and its source (compile default / PULP_HOST_QUIRKS env / API), the detected DAW + version, and which accommodations are enforced. Also rendered at the bottom of the default doctor view. `pulp doctor quirks` is a synonym. Exits 0. Override the policy with the PULP_HOST_QUIRKS env var.
     docs: reference/cli.md#doctor
 
   - name: clean

--- a/test/test_host_quirks.cpp
+++ b/test/test_host_quirks.cpp
@@ -1253,3 +1253,142 @@ TEST_CASE("kHostQuirksMeta tags the 4 new iPlug2-audit rows correctly",
 // bottom rather than mixed with the original includes so the diff
 // stays localized to the batch.
 
+
+// ─────────────────────────────────────────────────────────────────────
+// P2: runtime policy gate + per-quirk override + field enumeration.
+// (host-quirks integration plan → 2026-05-30-host-quirks-enforcement-goal)
+// ─────────────────────────────────────────────────────────────────────
+
+#include <algorithm>
+#include <optional>
+#include <string_view>
+
+namespace {
+// Find one enumerated field by name; returns nullptr if absent.
+const pulp::format::QuirkFieldStatus* find_field(
+    const std::vector<pulp::format::QuirkFieldStatus>& fields,
+    std::string_view name) {
+    auto it = std::find_if(fields.begin(), fields.end(),
+                           [&](const auto& f) { return f.name == name; });
+    return it == fields.end() ? nullptr : &*it;
+}
+
+// RAII reset so a test never leaks runtime-policy state into the next.
+struct QuirkPolicyGuard {
+    QuirkPolicyGuard() { reset(); }
+    ~QuirkPolicyGuard() { reset(); }
+    static void reset() {
+        pulp::format::set_host_quirk_policy(std::nullopt);
+        pulp::format::clear_quirk_overrides();
+    }
+};
+}  // namespace
+
+TEST_CASE("resolve_quirk_policy: API policy wins and reports source=Api",
+          "[format][host-quirks][runtime-policy][p2]") {
+    QuirkPolicyGuard guard;
+    pulp::format::set_host_quirk_policy(pulp::format::kQuirkFilterValidatedOnly);
+    auto resolved = pulp::format::resolve_quirk_policy();
+    REQUIRE(resolved.source == pulp::format::QuirkPolicySource::Api);
+    REQUIRE(resolved.filter.allow_validated == true);
+    REQUIRE(resolved.filter.allow_speculative == false);
+    REQUIRE(resolved.filter.allow_lesson_only == false);
+}
+
+TEST_CASE("resolved_quirks validated-only keeps cheap defenses, drops speculative",
+          "[format][host-quirks][runtime-policy][p2]") {
+    QuirkPolicyGuard guard;
+    pulp::format::set_host_quirk_policy(pulp::format::kQuirkFilterValidatedOnly);
+    auto q = pulp::format::resolved_quirks(HostType::Reaper, HostVersion{7, 20});
+    // Cheap defenses are Validated → survive.
+    REQUIRE(q.synthesize_bypass_parameter == true);
+    REQUIRE(q.clamp_latency_to_nonneg == true);
+    REQUIRE(q.silence_unsupported_bus_arrangements == true);
+    // REAPER rows are Speculative/LessonOnly → filtered out, even though
+    // make_quirks_for(Reaper) would have set them.
+    REQUIRE(make_quirks_for(HostType::Reaper, HostVersion{7, 20})
+                .reaper_vst3_gesture_ordering == true);
+    REQUIRE(q.reaper_vst3_gesture_ordering == false);
+}
+
+TEST_CASE("resolved_quirks off-policy zeroes everything including cheap defenses",
+          "[format][host-quirks][runtime-policy][p2]") {
+    QuirkPolicyGuard guard;
+    pulp::format::set_host_quirk_policy(pulp::format::kQuirkFilterOff);
+    auto q = pulp::format::resolved_quirks(HostType::Reaper, HostVersion{7, 20});
+    REQUIRE(q.synthesize_bypass_parameter == false);
+    REQUIRE(q.clamp_latency_to_nonneg == false);
+    REQUIRE(q.silence_unsupported_bus_arrangements == false);
+    REQUIRE(q.reaper_vst3_gesture_ordering == false);
+    // The int field reverts to its cross-host default.
+    auto logic = pulp::format::resolved_quirks(HostType::LogicPro, HostVersion{11, 0});
+    REQUIRE(logic.logic_au_channel_probe_cap == 64);
+}
+
+TEST_CASE("per-quirk override force-on exempts a tier-filtered flag",
+          "[format][host-quirks][runtime-policy][override][p2]") {
+    QuirkPolicyGuard guard;
+    // Base policy drops every speculative REAPER row...
+    pulp::format::set_host_quirk_policy(pulp::format::kQuirkFilterValidatedOnly);
+    // ...but the author trusts this one specifically.
+    pulp::format::set_quirk_override("reaper_keyboard_passthrough", true);
+    auto q = pulp::format::resolved_quirks(HostType::Reaper, HostVersion{7, 20});
+    REQUIRE(q.reaper_keyboard_passthrough == true);   // forced on
+    REQUIRE(q.reaper_vst3_gesture_ordering == false);  // still filtered
+}
+
+TEST_CASE("per-quirk override force-off beats an allowed flag (incl. int field)",
+          "[format][host-quirks][runtime-policy][override][p2]") {
+    QuirkPolicyGuard guard;
+    pulp::format::set_host_quirk_policy(pulp::format::QuirkFilter{});  // all tiers
+    pulp::format::set_quirk_override("synthesize_bypass_parameter", false);
+    pulp::format::set_quirk_override("logic_au_channel_probe_cap", false);
+    auto q = pulp::format::resolved_quirks(HostType::LogicPro, HostVersion{11, 0});
+    REQUIRE(q.synthesize_bypass_parameter == false);     // forced off
+    REQUIRE(q.clamp_latency_to_nonneg == true);          // untouched
+    REQUIRE(q.logic_au_channel_probe_cap == 64);         // forced to default
+}
+
+TEST_CASE("set_quirk_override ignores unknown flag names",
+          "[format][host-quirks][runtime-policy][override][p2]") {
+    QuirkPolicyGuard guard;
+    pulp::format::set_quirk_override("not_a_real_quirk_flag", true);
+    // Resolution proceeds normally; the bogus name is a no-op.
+    auto q = pulp::format::resolved_quirks(HostType::Unknown, HostVersion{});
+    REQUIRE(q.synthesize_bypass_parameter == true);
+}
+
+TEST_CASE("enumerate_quirk_fields covers every field with tier + enforced",
+          "[format][host-quirks][runtime-policy][doctor][p2]") {
+    auto q = make_quirks_for(HostType::Reaper, HostVersion{7, 20});
+    auto fields = pulp::format::enumerate_quirk_fields(q);
+    // One row per HostQuirks field (kept in lock-step with the X-macro
+    // count static_assert in host_quirks.cpp).
+    REQUIRE(fields.size() == 37);
+
+    const auto* bypass = find_field(fields, "synthesize_bypass_parameter");
+    REQUIRE(bypass != nullptr);
+    REQUIRE(bypass->tier == QuirkStatus::Validated);
+    REQUIRE(bypass->enforced == true);  // cheap defense on by default
+
+    const auto* reaper = find_field(fields, "reaper_vst3_gesture_ordering");
+    REQUIRE(reaper != nullptr);
+    REQUIRE(reaper->enforced == true);  // set for REAPER
+
+    const auto* cubase = find_field(fields, "cubase10_async_view_resize_queue");
+    REQUIRE(cubase != nullptr);
+    REQUIRE(cubase->enforced == false);  // not a REAPER flag
+}
+
+TEST_CASE("enumerate_quirk_fields enforced reflects the int channel-probe cap",
+          "[format][host-quirks][runtime-policy][doctor][p2]") {
+    auto logic = enumerate_quirk_fields(make_quirks_for(HostType::LogicPro, HostVersion{11, 0}));
+    const auto* cap = find_field(logic, "logic_au_channel_probe_cap");
+    REQUIRE(cap != nullptr);
+    REQUIRE(cap->enforced == true);  // Logic caps at 8 (!= default 64)
+
+    auto unknown = enumerate_quirk_fields(make_quirks_for(HostType::Unknown, HostVersion{}));
+    const auto* cap2 = find_field(unknown, "logic_au_channel_probe_cap");
+    REQUIRE(cap2 != nullptr);
+    REQUIRE(cap2->enforced == false);  // default 64 → not enforced
+}

--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -227,6 +227,34 @@ if(PULP_BUILD_TESTS)
         ENVIRONMENT "${_pulp_cli_doctor_ctest_env}"
         PASS_REGULAR_EXPRESSION "Validators")
 
+    # host-quirks integration plan P2: `pulp doctor --host-quirks` renders
+    # the runtime host-quirks policy section and exits 0. These tests pin
+    # the effective-policy line per PULP_HOST_QUIRKS value — a fresh
+    # process each time, so the env-var parse cache starts cold. The
+    # source label ("PULP_HOST_QUIRKS env") only appears on the policy
+    # line, so the regex can't collide with the override-hint line that
+    # always lists off|validated-only|all.
+    add_test(NAME cli-doctor-host-quirks
+        COMMAND pulp-cli doctor --host-quirks
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+    set_tests_properties(cli-doctor-host-quirks PROPERTIES
+        ENVIRONMENT "${_pulp_cli_doctor_ctest_env}"
+        PASS_REGULAR_EXPRESSION "Host quirks")
+
+    add_test(NAME cli-doctor-host-quirks-off
+        COMMAND pulp-cli doctor --host-quirks
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+    set_tests_properties(cli-doctor-host-quirks-off PROPERTIES
+        ENVIRONMENT "${_pulp_cli_doctor_ctest_env};PULP_HOST_QUIRKS=off"
+        PASS_REGULAR_EXPRESSION "off  \\(PULP_HOST_QUIRKS env\\)")
+
+    add_test(NAME cli-doctor-host-quirks-validated
+        COMMAND pulp-cli doctor --host-quirks
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+    set_tests_properties(cli-doctor-host-quirks-validated PROPERTIES
+        ENVIRONMENT "${_pulp_cli_doctor_ctest_env};PULP_HOST_QUIRKS=validated-only"
+        PASS_REGULAR_EXPRESSION "validated-only  \\(PULP_HOST_QUIRKS env\\)")
+
     add_test(NAME cli-status
         COMMAND pulp-cli status
         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")

--- a/tools/cli/cmd_doctor.cpp
+++ b/tools/cli/cmd_doctor.cpp
@@ -7,9 +7,14 @@
 #include "validator_discovery.hpp"
 #include "version_diag.hpp"
 
+#include <pulp/format/host_quirks.hpp>
+#include <pulp/format/host_type.hpp>
+#include <pulp/format/host_version.hpp>
+
 #include <algorithm>
 #include <cstdlib>
 #include <iostream>
+#include <ostream>
 
 #if defined(__APPLE__) || defined(__linux__)
 #include <sys/wait.h>
@@ -51,6 +56,76 @@ pulp::cli::version_diag::ProjectEntry make_project_entry(
     return e;
 }
 
+// ── Host-quirks reporting (host-quirks integration plan, P2) ──────────
+//
+// Surfaces the runtime host-quirks state so a user can see whether Pulp
+// is enforcing DAW accommodations, under which policy, and from where
+// (env / API / compile default). Rendered in the default `pulp doctor`
+// output and as the focused `pulp doctor --host-quirks` view.
+const char* quirk_policy_label(const pulp::format::QuirkFilter& f) {
+    if (!f.allow_validated && !f.allow_speculative && !f.allow_lesson_only)
+        return "off";
+    if (f.allow_validated && !f.allow_speculative && !f.allow_lesson_only)
+        return "validated-only";
+    if (f.allow_validated && f.allow_speculative && f.allow_lesson_only)
+        return "all";
+    return "custom";
+}
+
+const char* quirk_policy_source_label(pulp::format::QuirkPolicySource s) {
+    switch (s) {
+        case pulp::format::QuirkPolicySource::CompileDefault: return "compile default";
+        case pulp::format::QuirkPolicySource::Environment:    return "PULP_HOST_QUIRKS env";
+        case pulp::format::QuirkPolicySource::Api:            return "set_host_quirk_policy()";
+    }
+    return "?";
+}
+
+const char* quirk_tier_label(pulp::format::QuirkStatus t) {
+    switch (t) {
+        case pulp::format::QuirkStatus::Validated:   return "Validated";
+        case pulp::format::QuirkStatus::Speculative: return "Speculative";
+        case pulp::format::QuirkStatus::LessonOnly:  return "LessonOnly";
+    }
+    return "?";
+}
+
+void render_host_quirks_section(std::ostream& os, bool color) {
+    namespace fmt = pulp::format;
+    const auto policy = fmt::resolve_quirk_policy();
+    const auto info = fmt::detect_host_info();
+    const auto quirks = fmt::resolved_quirks(info.type, info.version);
+    const auto fields = fmt::enumerate_quirk_fields(quirks);
+
+    int enforced = 0;
+    for (const auto& f : fields)
+        if (f.enforced) ++enforced;
+
+    os << (color ? color::bold() : "") << "Host quirks"
+       << (color ? color::reset() : "") << "\n";
+    os << "  policy:        " << quirk_policy_label(policy.filter)
+       << "  (" << quirk_policy_source_label(policy.source) << ")\n";
+    os << "  detected host: " << fmt::host_type_name(info.type);
+    if (!info.version.is_unknown())
+        os << " " << info.version.major << "." << info.version.minor;
+    os << "\n";
+    os << "  enforced:      " << enforced << " / " << fields.size()
+       << " accommodations active\n";
+    for (const auto& f : fields) {
+        if (!f.enforced) continue;
+        os << "    \xe2\x80\xa2 " << f.name
+           << "  [" << quirk_tier_label(f.tier) << "]\n";
+    }
+    if (enforced == 0)
+        os << "    (none active for this host)\n";
+    os << "  override with " << (color ? color::cyan() : "")
+       << "PULP_HOST_QUIRKS=off|validated-only|all" << (color ? color::reset() : "")
+       << "\n";
+    os << "  " << (color ? color::dim() : "")
+       << "provenance + last-verified dates: core/format/host-quirks.json"
+       << (color ? color::reset() : "") << "\n";
+}
+
 }  // namespace
 
 int cmd_doctor(const std::vector<std::string>& args) {
@@ -73,10 +148,12 @@ int cmd_doctor(const std::vector<std::string>& args) {
     bool au_cache_mode = false;   // --au-cache (Slice 11): refresh macOS AU registrar
     bool json_mode = false;       // --json (works with --versions and --caches)
     bool list_mode = false;       // --list / `pulp doctor list` (R2-8)
+    bool host_quirks_mode = false; // --host-quirks / `pulp doctor quirks` (host-quirks P2)
     std::string only_filter;      // --only <name> (R2-8)
     for (size_t i = 0; i < args.size(); ++i) {
         const auto& arg = args[i];
         if (arg == "--fix") fix_mode = true;
+        else if (arg == "--host-quirks") host_quirks_mode = true;
         else if (arg == "--ci") ci_mode = true;
         else if (arg == "--dry-run") dry_run = true;
         else if (arg == "--versions") versions_mode = true;
@@ -89,7 +166,7 @@ int cmd_doctor(const std::vector<std::string>& args) {
         else if (arg == "--only") {
             if (i + 1 >= args.size() || args[i + 1].rfind("-", 0) == 0) {
                 std::cerr << "pulp doctor: --only requires a value\n";
-                std::cerr << "Usage: pulp doctor [android|ios|list] [--fix] [--ci] [--dry-run] [--versions] [--validators] [--scan-parents] [--caches] [--json] [--list] [--only <name>]\n";
+                std::cerr << "Usage: pulp doctor [android|ios|list|quirks] [--fix] [--ci] [--dry-run] [--versions] [--validators] [--scan-parents] [--caches] [--json] [--list] [--host-quirks] [--only <name>]\n";
                 return 2;
             }
             only_filter = args[++i];
@@ -97,13 +174,13 @@ int cmd_doctor(const std::vector<std::string>& args) {
             only_filter = arg.substr(7);
         } else if (arg.rfind("--", 0) == 0) {
             std::cerr << "pulp doctor: unknown flag: " << arg << "\n";
-            std::cerr << "Usage: pulp doctor [android|ios|list] [--fix] [--ci] [--dry-run] [--versions] [--validators] [--scan-parents] [--caches] [--au-cache] [--json] [--list] [--only <name>]\n";
+            std::cerr << "Usage: pulp doctor [android|ios|list|quirks] [--fix] [--ci] [--dry-run] [--versions] [--validators] [--scan-parents] [--caches] [--au-cache] [--json] [--list] [--host-quirks] [--only <name>]\n";
             return 2;
         } else if (mode.empty()) {
             mode = arg;
         } else {
             std::cerr << "pulp doctor: unexpected argument '" << arg << "'\n";
-            std::cerr << "Usage: pulp doctor [android|ios|list] [--fix] [--ci] [--dry-run] [--versions] [--validators] [--scan-parents] [--caches] [--json] [--list] [--only <name>]\n";
+            std::cerr << "Usage: pulp doctor [android|ios|list|quirks] [--fix] [--ci] [--dry-run] [--versions] [--validators] [--scan-parents] [--caches] [--json] [--list] [--host-quirks] [--only <name>]\n";
             return 2;
         }
     }
@@ -115,9 +192,23 @@ int cmd_doctor(const std::vector<std::string>& args) {
         mode.clear();
     }
 
+    // `pulp doctor quirks` is a synonym for `--host-quirks`.
+    if (mode == "quirks") {
+        host_quirks_mode = true;
+        mode.clear();
+    }
+
+    // Focused host-quirks view: print only the section and exit 0. Lets
+    // users (and the CLI test) inspect the runtime policy without running
+    // the full check battery. PULP_HOST_QUIRKS still applies.
+    if (host_quirks_mode) {
+        render_host_quirks_section(std::cout, !ci_mode && g_color_enabled);
+        return 0;
+    }
+
     if (!mode.empty() && mode != "android" && mode != "ios") {
         std::cerr << "pulp doctor: unknown subcommand '" << mode << "'\n";
-        std::cerr << "Usage: pulp doctor [android|ios|list] [--fix] [--ci] [--dry-run] [--versions] [--validators] [--scan-parents] [--caches] [--au-cache] [--json] [--list] [--only <name>]\n";
+        std::cerr << "Usage: pulp doctor [android|ios|list|quirks] [--fix] [--ci] [--dry-run] [--versions] [--validators] [--scan-parents] [--caches] [--au-cache] [--json] [--list] [--host-quirks] [--only <name>]\n";
         return 2;
     }
 
@@ -575,6 +666,14 @@ int cmd_doctor(const std::vector<std::string>& args) {
                 }
             }
         }
+    }
+
+    // Host-quirks summary — only in the default (non-mobile) doctor view,
+    // and only for humans (CI output stays machine-parseable). The focused
+    // `pulp doctor --host-quirks` path above is the scriptable surface.
+    if (mode.empty() && !ci_mode) {
+        std::cout << "\n";
+        render_host_quirks_section(std::cout, g_color_enabled);
     }
 
     if (!ci_mode) {


### PR DESCRIPTION
The host-quirks ledger was descriptive-only: a tier-tagged catalog with
a build-time policy filter, but no runtime control and no visibility into
what's enforced. This wires the enforcement layer's foundation
(host-quirks integration plan, P2 — no adapter consumes it yet; that's
P3, per-quirk with in-host validation).

- Runtime policy resolver layered on the compile-time default:
  PULP_HOST_QUIRKS env (off|validated-only|all), set_host_quirk_policy()
  API, and per-quirk set_quirk_override(). Precedence: per-quirk override
  > API > env > compile default. Falls through to the compile default
  when nothing is set, so behavior is unchanged by default.
- resolved_quirks(type, version): the single entry adapters will consume
  in P3 (make_quirks_for + runtime filter + overrides); detect_quirks()
  now routes through it.
- enumerate_quirk_fields(): tier + enforced state per flag, driven by a
  single PULP_HOST_QUIRK_FIELDS X-macro that also generates apply_filter
  and the override pass — one list, can't drift (count static_assert +
  the catalog parity test guard it).
- pulp doctor --host-quirks (and `pulp doctor quirks`): effective policy
  + source, detected host, enforced accommodations; also appended to the
  default doctor view.

"Enforced" and force-off are type-aware: a bool is active when true and
disables to false; the int channel-probe cap is active when it differs
from the cross-host default (64) and disables back to it — so cheap
defenses (default=true) report and toggle correctly.

Tests: 8 new [p2] unit cases + 3 doctor CLI tests pinning policy-per-env.
Full host-quirks suite green (450 assertions); catalog parity green.
Docs: host-quirks-policy.md runtime section, cli.md, cli-commands.yaml,
cli-maintenance SKILL.

See planning/2026-05-30-host-quirks-enforcement-goal.md.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>