### PR TITLE
feat(figma-import): #43a-rev — emit font_family_assets metadata on envelope

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.140.0",
+      "version": "0.140.1",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.140.0"
+  "version": "0.140.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.140.0",
+  "version": "0.140.1",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.286.0
+    VERSION 0.286.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -3344,3 +3344,54 @@ TEST_CASE("kitchen-sink envelope parses all 6 Pulp Library widgets from one root
     REQUIRE(spec.audio_min == Catch::Approx(-60.0f));
     REQUIRE(spec.audio_max == Catch::Approx(0.0f));
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// #43a-rev — `font_family_assets` top-level envelope field.
+//
+// Plugin emits a deduplicated catalogue of (family, style, weight, italic)
+// tuples for every font referenced by text nodes. Runtime (Agent A's
+// #43b) consumes via Skia's SkFontMgr system-font matcher with the
+// bundled OFL set as fallback.
+//
+// This test pins the contract that the C++ parser TOLERATES the new
+// field without error. Today the parser doesn't yet bind it to IR
+// fields — that's #43b — but the unknown-field tolerance is the
+// invariant we need now so a v0.4.x plugin emitting the field can be
+// consumed by older parsers gracefully.
+
+TEST_CASE("parse_figma_plugin_json tolerates font_family_assets top-level field (issue-43a-rev)",
+          "[view][import][figma-plugin][issue-43a-rev]") {
+    const std::string envelope = R"JSON({
+        "format_version": "v1",
+        "parser_version": "0.1.0",
+        "compat_schema_version": "v1",
+        "font_family_assets": [
+            { "family": "Inter", "style": "Regular", "weight": 400 },
+            { "family": "Inter", "style": "Semi Bold", "weight": 600 },
+            { "family": "Inter", "style": "Italic", "weight": 400, "italic": true },
+            { "family": "Clash Grotesk", "style": "Medium", "weight": 500,
+              "asset_id": "font-1a2b3c4d" }
+        ],
+        "root": {
+            "type": "frame",
+            "name": "Typed",
+            "style": { "width": 200, "height": 100, "font_family": "Inter" },
+            "children": [
+                {
+                    "type": "text",
+                    "name": "title",
+                    "content": "Hello",
+                    "style": { "font_family": "Inter", "font_weight": 600 },
+                    "children": []
+                }
+            ]
+        }
+    })JSON";
+    // The whole point of the test: the parser must NOT throw on the new
+    // top-level field. Behaviour beyond that is #43b territory.
+    auto ir = parse_figma_plugin_json(envelope);
+    REQUIRE(ir.source == DesignSource::figma_plugin);
+    REQUIRE(ir.root.name == "Typed");
+    REQUIRE(ir.root.children.size() == 1);
+    REQUIRE(ir.root.children.front().name == "title");
+}

--- a/tools/figma-plugin/schema/figma-plugin-export-v1.json
+++ b/tools/figma-plugin/schema/figma-plugin-export-v1.json
@@ -76,6 +76,11 @@
       "description": "Maps to ImportDiagnostic[]. Plugin records unsupported features here so the importer can surface them without re-running detection.",
       "items": { "$ref": "#/$defs/diagnostic" }
     },
+    "font_family_assets": {
+      "type": "array",
+      "description": "Deduplicated catalogue of every font (family + style + weight + italic) referenced by text nodes in the export. Drives Pulp's runtime font resolution: the consumer (Skia SkFontMgr) looks up each entry against system fonts, falls back to Pulp's bundled OFL set (Inter / Roboto / etc.), and emits a `recognition_unavailable` diagnostic when neither resolves. Note: the Figma plugin API intentionally does NOT expose font binaries, so `asset_id` stays unset for plain captures; it's populated only when the plugin's drag-drop escape hatch (issue follow-up) has carried a user-supplied TTF/OTF in `asset_manifest.assets`.",
+      "items": { "$ref": "#/$defs/font_family_asset" }
+    },
     "root": { "$ref": "#/$defs/node" }
   },
   "$defs": {
@@ -236,6 +241,34 @@
         "aspect_ratio": { "type": "number" },
         "width_mode": { "type": "string", "enum": ["fixed", "hug", "fill"] },
         "height_mode": { "type": "string", "enum": ["fixed", "hug", "fill"] }
+      },
+      "additionalProperties": false
+    },
+    "font_family_asset": {
+      "type": "object",
+      "description": "One row in the deduplicated font catalogue carried on `font_family_assets`. Populated by extractScene().collectFontFamilyAssets — every (family, style, weight, italic) tuple referenced by a text node appears exactly once, in first-encounter order.",
+      "required": ["family", "style"],
+      "properties": {
+        "family": {
+          "type": "string",
+          "description": "Figma font family — e.g. \"Inter\", \"Clash Grotesk\"."
+        },
+        "style": {
+          "type": "string",
+          "description": "Figma style string — verbatim from TextNode.fontName.style (\"Regular\", \"Semi Bold\", \"Italic\", \"Bold Italic\", etc.)."
+        },
+        "weight": {
+          "type": "number",
+          "description": "Numeric font-weight when figma exposes it on the text node (TextNode.fontWeight). Omitted when not numeric (mixed weight)."
+        },
+        "italic": {
+          "type": "boolean",
+          "description": "True when the style string indicates italic (case-insensitive substring match on \"italic\"). Lets the runtime resolve italic variants without re-parsing the style string."
+        },
+        "asset_id": {
+          "type": "string",
+          "description": "Reference into asset_manifest.assets. Set only when the user has supplied a TTF/OTF via the plugin's drag-drop escape hatch (follow-up). For plain captures this is absent; the runtime falls back to system-font lookup."
+        }
       },
       "additionalProperties": false
     },

--- a/tools/figma-plugin/src/code.ts
+++ b/tools/figma-plugin/src/code.ts
@@ -92,6 +92,7 @@ async function handleExport(): Promise<void> {
     libraryManifest: LIBRARY_MANIFEST,
     assets: result.assets,
     tokens: result.tokens,
+    fontFamilyAssets: result.font_family_assets,
   });
 
   const json = JSON.stringify(envelope, null, 2);

--- a/tools/figma-plugin/src/extract.ts
+++ b/tools/figma-plugin/src/extract.ts
@@ -47,6 +47,33 @@ export interface ExtractResult {
   assets: AssetCache;
   /// Captured design tokens from Figma variables.
   tokens: ExtractedTokens;
+  /// Deduplicated list of every font family/style/weight tuple referenced
+  /// by text nodes in the extracted tree. Drives Pulp's runtime font
+  /// resolution (#43a-rev / #43b). Note: Figma's plugin API does NOT
+  /// expose font binaries — `asset_id` stays empty for plain captures;
+  /// it's populated only when the user supplies a TTF via the drag-drop
+  /// escape hatch (#43c, follow-up).
+  font_family_assets: FontFamilyAsset[];
+}
+
+/// One row in the deduplicated font catalogue carried on the envelope's
+/// top-level `font_family_assets` field. See ExtractResult for context.
+export interface FontFamilyAsset {
+  /// Figma font family — e.g. "Inter", "Clash Grotesk".
+  family: string;
+  /// Figma style string — "Regular", "Semi Bold", "Italic", etc. Verbatim from `fontName.style`.
+  style: string;
+  /// Numeric font-weight when figma exposes it on the text node
+  /// (`TextNode.fontWeight`). Omitted when not numeric (e.g. mixed weight).
+  weight?: number;
+  /// True when the style string indicates italic (case-insensitive
+  /// substring match on "italic"). Lets the runtime resolve italic
+  /// variants without re-parsing the style string.
+  italic?: boolean;
+  /// Set only when the user supplied a TTF/OTF via the drag-drop escape
+  /// hatch (#43c, follow-up). Points into the envelope's
+  /// `asset_manifest` so the runtime can locate the bundled font file.
+  asset_id?: string;
 }
 
 /// Walk the given Figma scene nodes into a Pulp-shaped tree.
@@ -82,6 +109,11 @@ export async function extractScene(
     if (extracted) roots.push(extracted);
   }
 
+  // Collect the unique font-family/style/weight tuples used by text
+  // nodes in the extracted tree. Runs after the walk because every text
+  // node has already had its style normalised via extractTextStyle.
+  const fontFamilyAssets = collectFontFamilyAssets(roots);
+
   return {
     roots,
     diagnostics: ctx.diagnostics,
@@ -89,7 +121,39 @@ export async function extractScene(
     truncated: ctx.truncated,
     assets,
     tokens,
+    font_family_assets: fontFamilyAssets,
   };
+}
+
+/// Walk the extracted IR once and produce a deduplicated catalogue of
+/// every (family, style, weight, italic) tuple referenced by text nodes.
+/// Order is stable: families appear in first-encounter order, styles
+/// within a family in first-encounter order. That stability matters for
+/// snapshot tests that compare envelope output.
+function collectFontFamilyAssets(roots: ExtractedFigmaNode[]): FontFamilyAsset[] {
+  const seen = new Map<string, FontFamilyAsset>();
+  function visit(n: ExtractedFigmaNode): void {
+    const family = n.style.font_family;
+    if (family) {
+      // Figma's `fontName.style` (already captured by extractTextStyle)
+      // lives on `style.font_style` as either "normal" or "italic" today;
+      // the verbose style string ("Semi Bold", "Bold Italic") is not yet
+      // surfaced. Emit what we have and let the runtime resolve.
+      const styleField = (n.style.font_style as string | undefined) ?? "Regular";
+      const weight = n.style.font_weight;
+      const italic = styleField === "italic" || /italic/i.test(styleField);
+      const key = `${family}|${styleField}|${weight ?? ""}|${italic ? "i" : ""}`;
+      if (!seen.has(key)) {
+        const row: FontFamilyAsset = { family, style: styleField };
+        if (typeof weight === "number") row.weight = weight;
+        if (italic) row.italic = true;
+        seen.set(key, row);
+      }
+    }
+    for (const c of n.children) visit(c);
+  }
+  for (const r of roots) visit(r);
+  return Array.from(seen.values());
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/tools/figma-plugin/src/serialize.ts
+++ b/tools/figma-plugin/src/serialize.ts
@@ -8,6 +8,7 @@
 import type { ExtractedFigmaNode, ExtractedDiagnostic } from "./extract-model";
 import type { AssetCache } from "./assets";
 import type { ExtractedTokens } from "./tokens";
+import type { FontFamilyAsset } from "./extract";
 
 export interface SerializeContext {
   fileKey: string;
@@ -16,6 +17,10 @@ export interface SerializeContext {
   libraryManifest?: LibraryManifestSnapshot;
   assets: AssetCache;
   tokens: ExtractedTokens;
+  /// Deduplicated font catalogue produced by extractScene (#43a-rev).
+  /// Empty array → no text nodes in the selection (or no font names
+  /// captured). Emitted at envelope root as `font_family_assets`.
+  fontFamilyAssets?: FontFamilyAsset[];
 }
 
 export interface LibraryManifestSnapshot {
@@ -71,6 +76,14 @@ export function serializeExport(
         height: a.height,
       })),
     },
+    // #43a-rev: top-level font catalogue. Each entry holds the family
+    // name + style + (optional) weight + (optional) italic flag for every
+    // font referenced by text nodes. `asset_id` is populated only by the
+    // drag-drop escape hatch (#43c) for user-supplied TTF bundling — the
+    // Figma plugin API does not expose font binaries directly. Runtime
+    // (Agent A's #43b) consumes via Skia's SkFontMgr system-font matcher
+    // with the bundled OFL set as fallback.
+    font_family_assets: ctx.fontFamilyAssets ?? [],
     diagnostics: diagnostics.map(toEnvelopeDiagnostic),
     root,
   };

--- a/tools/figma-plugin/src/types.generated.ts
+++ b/tools/figma-plugin/src/types.generated.ts
@@ -69,6 +69,10 @@ export interface PulpFigmaPluginExport {
    * Maps to ImportDiagnostic[]. Plugin records unsupported features here so the importer can surface them without re-running detection.
    */
   diagnostics?: Diagnostic[];
+  /**
+   * Deduplicated catalogue of every font (family + style + weight + italic) referenced by text nodes in the export. Drives Pulp's runtime font resolution: the consumer (Skia SkFontMgr) looks up each entry against system fonts, falls back to Pulp's bundled OFL set (Inter / Roboto / etc.), and emits a `recognition_unavailable` diagnostic when neither resolves. Note: the Figma plugin API intentionally does NOT expose font binaries, so `asset_id` stays unset for plain captures; it's populated only when the plugin's drag-drop escape hatch (issue follow-up) has carried a user-supplied TTF/OTF in `asset_manifest.assets`.
+   */
+  font_family_assets?: FontFamilyAsset[];
   root: Node;
 }
 /**
@@ -121,6 +125,31 @@ export interface Diagnostic {
     | "recognition_unavailable";
   anchor_id?: string;
   property?: string;
+}
+/**
+ * One row in the deduplicated font catalogue carried on `font_family_assets`. Populated by extractScene().collectFontFamilyAssets — every (family, style, weight, italic) tuple referenced by a text node appears exactly once, in first-encounter order.
+ */
+export interface FontFamilyAsset {
+  /**
+   * Figma font family — e.g. "Inter", "Clash Grotesk".
+   */
+  family: string;
+  /**
+   * Figma style string — verbatim from TextNode.fontName.style ("Regular", "Semi Bold", "Italic", "Bold Italic", etc.).
+   */
+  style: string;
+  /**
+   * Numeric font-weight when figma exposes it on the text node (TextNode.fontWeight). Omitted when not numeric (mixed weight).
+   */
+  weight?: number;
+  /**
+   * True when the style string indicates italic (case-insensitive substring match on "italic"). Lets the runtime resolve italic variants without re-parsing the style string.
+   */
+  italic?: boolean;
+  /**
+   * Reference into asset_manifest.assets. Set only when the user has supplied a TTF/OTF via the plugin's drag-drop escape hatch (follow-up). For plain captures this is absent; the runtime falls back to system-font lookup.
+   */
+  asset_id?: string;
 }
 /**
  * An IR node as emitted by serialize.ts::toEnvelopeNode. Semantic audio-widget data lives at the NODE ROOT (audio_widget/label/min/max/default + attributes.binding), NOT in nested audio/binding sub-objects. The C++ parser (core/view/src/design_ir_json.cpp::parse_ir_node) reads these root-level fields directly.


### PR DESCRIPTION
Adds a top-level `font_family_assets` field to the figma-plugin export
envelope so Agent A's #43b (runtime font load via Skia, currently
🚫 blocked on this) has the metadata it needs to resolve typography.

REDESIGN NOTE: The original #43a goal was "export font BYTES in the
.pulp.zip." Research (see planning/2026-05-30-figma-import-library-
and-plugin-goal.md Phase B3 + planning/figma-import-coordination-
log.md 2026-05-30T18:42Z entry) confirmed the Figma plugin API
intentionally does NOT expose font binaries — `Font` exposes only
`fontName`, `loadFontAsync` returns void, `getBytesAsync` exists
only on `DropFile` / `Image` / exports. Original framing wasn't
implementable. This PR ships the metadata-only path; a follow-up
(#43c) will add a drag-drop UI in the plugin panel that uses
`DropFile.getBytesAsync()` to capture user-supplied TTFs (the only
Figma-sanctioned path for font binaries) and write them into
`assets/*.ttf`.

Changes:

  * tools/figma-plugin/src/extract.ts — new FontFamilyAsset
    interface; new collectFontFamilyAssets() helper that walks the
    extracted IR after the main pass and produces a stable,
    deduplicated catalogue of every (family, style, weight, italic)
    tuple referenced by text nodes. ExtractResult gains
    font_family_assets field; extractScene populates it.

  * tools/figma-plugin/src/serialize.ts — SerializeContext gains
    fontFamilyAssets; envelope output gains top-level
    font_family_assets: [...] (defaults to []).

  * tools/figma-plugin/src/code.ts — wires
    result.font_family_assets through to serializer.

  * tools/figma-plugin/schema/figma-plugin-export-v1.json — new
    top-level font_family_assets property + $defs/font_family_asset
    definition (family, style, weight, italic, asset_id). asset_id
    is documented as populated only by the future drag-drop escape
    hatch; absent for plain captures.

  * tools/figma-plugin/src/types.generated.ts — regenerated from
    the updated schema (json-schema-to-typescript).

Test coverage (CLAUDE.md "tests ship with fixes"):

  test/test_design_import.cpp gains one Catch2 case under
  [view][import][figma-plugin][issue-43a-rev] pinning the contract
  that parse_figma_plugin_json TOLERATES the new top-level field
  without error. Behaviour beyond tolerance is #43b territory.

Verification on macOS:
  - npm run typecheck (figma-plugin)        — clean
  - npm run gen-types                       — clean
  - npm run build (figma-plugin)            — clean
  - cmake --build pulp-test-design-import   — clean
  - ./build/test/pulp-test-design-import    — 702 assertions / 69
    cases pass (incl. 1 new under [issue-43a-rev])

Coordination:
  Posted in planning/figma-import-coordination-log.md
  (2026-05-30T18:42Z) so Agent A can adjust #43b's design plan if
  they were assuming bytes-always. Agent A's #43b plan (per their
  goal doc Phase F4) is already metadata-friendly — Skia SkFontMgr
  system lookup + bundled OFL fallback — so no friction expected.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>