### PR TITLE
docs(figma-plugin): expand widget list to all six Pulp Library v0.3.0 widgets

### DIFF
--- a/docs/guides/figma-plugin.md
+++ b/docs/guides/figma-plugin.md
@@ -32,8 +32,8 @@ This is the path for designers. **No build step, ever.**
    <https://www.figma.com/community/plugin/1642456870947996392>
 
 2. **Add the Pulp component library.** Add the published example library so you
-   can drop "Pulp / Knob", "Pulp / Fader", and "Pulp / Meter" instances into
-   your design:
+   can drop "Pulp / Knob", "Pulp / Fader", "Pulp / Meter", "Pulp / XYPad",
+   "Pulp / Waveform", and "Pulp / Spectrum" instances into your design:
    <https://www.figma.com/community/file/1642409275200893924>
 
 3. **Design.** Lay out your plugin UI. Drop in Pulp library components wherever

--- a/docs/reference/design-import-model.md
+++ b/docs/reference/design-import-model.md
@@ -16,7 +16,8 @@ For the CLI and pipeline reference, see
 
 Most design-to-code tools treat a design as a picture: they try to reproduce
 pixels. Pulp's import is different. When you drop a **Pulp library component**
-— "Pulp / Knob", "Pulp / Fader", "Pulp / Meter" — into your design, you are not
+— "Pulp / Knob", "Pulp / Fader", "Pulp / Meter", "Pulp / XYPad", "Pulp / Waveform",
+"Pulp / Spectrum" — into your design, you are not
 just placing a graphic. You are declaring **what the control *means***.
 
 A Pulp library component carries semantic metadata alongside its appearance:

--- a/docs/reference/design-import.md
+++ b/docs/reference/design-import.md
@@ -307,7 +307,7 @@ Accepts IR-format JSON. In Claude Code flows, the Figma MCP (`get_design_context
 ### Figma plugin (`parse_figma_plugin_json`)
 
 The **"Design for Pulp"** Figma plugin export envelope. Recognized Pulp library
-components (Knob / Fader / Meter) carry semantic `audio_widget` metadata +
+components (Knob / Fader / Meter / XYPad / Waveform / Spectrum) carry semantic `audio_widget` metadata +
 parameter bindings, so they materialize as native, bound widgets rather than
 generic frames; everything else imports as layout/visual. Accepts a `.pulp.zip`
 (assets bundled) directly — the importer unpacks it and resolves assets from the

--- a/tools/figma-plugin/README.md
+++ b/tools/figma-plugin/README.md
@@ -4,7 +4,7 @@ Exports Figma designs to a Pulp-native JSON schema that the Pulp importer (`pulp
 
 **Status: working exporter with Pulp library recognition.** The plugin walks the
 selected frame(s), extracts geometry / layout / typography / style / tokens /
-assets, recognizes Pulp library components (Knob / Fader / Meter) and emits them
+assets, recognizes Pulp library components (Knob / Fader / Meter / XYPad / Waveform / Spectrum) and emits them
 as semantic audio-widget nodes, and exports a `*.pulp.json` (or `*.pulp.zip`
 when assets are present) that `pulp import-design --from figma-plugin` consumes.
 The exporter lives in `src/extract.ts`, `src/serialize.ts`, and
@@ -97,7 +97,7 @@ The plugin embeds its `library_manifest` snapshot into every export so the Pulp 
   tree: geometry, auto-layout, typography, fills/strokes/radius/opacity, images,
   and recursive children.
 - **Recognize** (`src/library-registry.ts`) — map Pulp library component
-  instances to audio-widget kinds (Knob / Fader / Meter), authoritatively by
+  instances to audio-widget kinds (Knob / Fader / Meter / XYPad / Waveform / Spectrum), authoritatively by
   component key and as a fallback by name prefix.
 - **Serialize** (`src/serialize.ts`) — emit the v1 JSON envelope declared in
   `schema/figma-plugin-export-v1.json`, with provenance, the library-manifest


### PR DESCRIPTION
# docs(figma-plugin): expand widget list to all six Pulp Library v0.3.0 widgets

## Summary

PR #3205 bumped the Pulp Library from v0.2.0 (3 widgets) to v0.3.0 (6 widgets) by adding **XYPad**, **Waveform**, and **Spectrum** to the component-set. Four user-facing docs still listed only the three v0.2.0 widgets. This PR fixes that — pure docs sync, no code.

## Surfaces updated

| File | What changed |
|---|---|
| `tools/figma-plugin/README.md` | Status blurb + Recognize-pipeline bullet now name all six |
| `docs/guides/figma-plugin.md` | "Add the Pulp component library" step lists all six instances designers can drop |
| `docs/reference/design-import-model.md` | Semantic-not-visual intro names all six |
| `docs/reference/design-import.md` | `parse_figma_plugin_json` recognised-components note names all six |

Source of truth (already in main): `tools/figma-plugin/library-manifest.json` carries `library_version: "0.3.0"` with all six widget entries; `library-registry.ts::LIBRARY_VERSION` reflects that. The docs were the only surface still pointing at the v0.2.0 list.

## Test

Pure markdown change. No build, no tests, no schema, no extractor / parser code. mkdocs preview still builds (no broken anchors introduced).

## Coordination

This is the additive part of Phase B4 in `planning/2026-05-30-figma-import-library-and-plugin-goal.md`. The remaining Phase B4 items (flipping the "in review" banner to "live" + post-approval verification PR per #3195) stay deferred until Figma's review queue clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)