### PR TITLE
feat(figma-plugin): #43c — drag-drop UI for user-supplied font bundling

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.140.1",
+      "version": "0.141.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.140.1"
+  "version": "0.141.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.140.1",
+  "version": "0.141.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.286.1
+    VERSION 0.287.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/tools/figma-plugin/src/assets.ts
+++ b/tools/figma-plugin/src/assets.ts
@@ -135,7 +135,7 @@ export class AssetCache {
 // for content-addressable dedupe. Collisions are theoretically possible but
 // vanishingly rare within a single export and acceptable here — we're hashing
 // for de-duplication, not cryptographic integrity.
-async function sha256Hex(bytes: Uint8Array): Promise<string> {
+export async function sha256Hex(bytes: Uint8Array): Promise<string> {
   try {
     if (typeof crypto !== "undefined" && crypto.subtle && typeof crypto.subtle.digest === "function") {
       const ab = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;

--- a/tools/figma-plugin/src/code.ts
+++ b/tools/figma-plugin/src/code.ts
@@ -2,9 +2,10 @@
 
 import { extractScene } from "./extract";
 import { serializeExport, type LibraryManifestSnapshot } from "./serialize";
-import type { PulpFigmaUIMessage, PulpSandboxMessage } from "./types";
+import type { FontFamilyAssetSummary, PulpFigmaUIMessage, PulpSandboxMessage } from "./types";
+import { UserFontCache } from "./user-fonts";
 
-const PLUGIN_VERSION = "0.1.0";
+const PLUGIN_VERSION = "0.2.0";
 
 const LIBRARY_MANIFEST: LibraryManifestSnapshot = {
   library_version: "0.1.0",
@@ -15,6 +16,12 @@ const LIBRARY_MANIFEST: LibraryManifestSnapshot = {
 };
 
 let knownFileKey: string | null = null;
+
+/// #43c — sandbox-side store of user-dropped TTF/OTF bytes, keyed by
+/// (family, style). Survives across export attempts within a single
+/// plugin session so the user can drop, preview, export, drop more,
+/// re-export. Discarded when the plugin closes.
+const userFonts = new UserFontCache();
 
 figma.showUI(__html__, { width: 360, height: 540, themeColors: true });
 
@@ -45,6 +52,14 @@ figma.ui.onmessage = async (msg: PulpFigmaUIMessage) => {
 
       case "export":
         await handleExport();
+        break;
+
+      case "scan-fonts":
+        await handleScanFonts();
+        break;
+
+      case "user-font":
+        await handleUserFont(msg);
         break;
 
       case "close":
@@ -93,6 +108,7 @@ async function handleExport(): Promise<void> {
     assets: result.assets,
     tokens: result.tokens,
     fontFamilyAssets: result.font_family_assets,
+    userFonts,
   });
 
   const json = JSON.stringify(envelope, null, 2);
@@ -100,18 +116,29 @@ async function handleExport(): Promise<void> {
 
   // Hand the assets to the UI as { content_hash, mime, bytes } records.
   // Bytes are transferred as plain arrays to keep postMessage compatibility;
-  // the UI converts back to Uint8Array for the zip writer.
-  const assetBundles = result.assets.entries().map((a) => ({
-    content_hash: a.content_hash,
-    mime: a.mime,
-    bytes: Array.from(a.bytes), // postMessage-safe; ~1.5x size overhead vs raw buffer
-  }));
+  // the UI converts back to Uint8Array for the zip writer. The user-font
+  // entries (#43c) ride in the same bundle list — the UI doesn't need to
+  // distinguish them; the zip writer picks the file extension from mime.
+  const assetBundles = [
+    ...result.assets.entries().map((a) => ({
+      content_hash: a.content_hash,
+      mime: a.mime,
+      bytes: Array.from(a.bytes), // postMessage-safe; ~1.5x size overhead vs raw buffer
+    })),
+    ...userFonts.entries().map((f) => ({
+      content_hash: f.content_hash,
+      mime: f.mime,
+      bytes: Array.from(f.bytes),
+    })),
+  ];
+
+  const totalAssetCount = result.assets.size() + userFonts.size();
 
   reply({
     type: "export-result",
     nodeCount: result.nodeCount,
     diagnosticCount: result.diagnostics.length,
-    assetCount: result.assets.size(),
+    assetCount: totalAssetCount,
     tokenCount:
       Object.keys(result.tokens.colors).length +
       Object.keys(result.tokens.dimensions).length +
@@ -120,6 +147,48 @@ async function handleExport(): Promise<void> {
     suggestedName,
     json,
     assets: assetBundles,
+  });
+}
+
+/// #43c — walk the current selection, collect the unique (family, style,
+/// weight?, italic?) tuples referenced by text nodes, and reply with a
+/// `fonts-detected` message annotated with which entries already have
+/// user-supplied bytes in the cache. The same logic the export path
+/// uses (collectFontFamilyAssets) — invoked early so the UI can render
+/// drop zones before the user commits to a full export.
+async function handleScanFonts(): Promise<void> {
+  const sel = figma.currentPage.selection;
+  if (sel.length === 0) {
+    reply({ type: "fonts-detected", fonts: [] });
+    return;
+  }
+  const result = await extractScene(sel);
+  const fonts: FontFamilyAssetSummary[] = result.font_family_assets.map((f) => ({
+    family: f.family,
+    style: f.style,
+    weight: f.weight,
+    italic: f.italic,
+    has_user_font: !!userFonts.lookup(f.family, f.style),
+  }));
+  reply({ type: "fonts-detected", fonts });
+}
+
+/// #43c — user dropped a TTF/OTF onto the UI. Store in the cache and
+/// ack with the asset_id so the UI can flip the row state. The cache
+/// survives until plugin close.
+async function handleUserFont(msg: {
+  family: string;
+  style: string;
+  bytes: number[];
+  filename: string;
+}): Promise<void> {
+  const bytes = new Uint8Array(msg.bytes);
+  const entry = await userFonts.add(msg.family, msg.style, bytes, msg.filename);
+  reply({
+    type: "user-font-staged",
+    family: entry.family,
+    style: entry.style,
+    asset_id: entry.asset_id,
   });
 }
 

--- a/tools/figma-plugin/src/serialize.ts
+++ b/tools/figma-plugin/src/serialize.ts
@@ -9,6 +9,7 @@ import type { ExtractedFigmaNode, ExtractedDiagnostic } from "./extract-model";
 import type { AssetCache } from "./assets";
 import type { ExtractedTokens } from "./tokens";
 import type { FontFamilyAsset } from "./extract";
+import type { UserFontCache } from "./user-fonts";
 
 export interface SerializeContext {
   fileKey: string;
@@ -21,6 +22,13 @@ export interface SerializeContext {
   /// Empty array → no text nodes in the selection (or no font names
   /// captured). Emitted at envelope root as `font_family_assets`.
   fontFamilyAssets?: FontFamilyAsset[];
+  /// #43c — user-supplied font bytes captured via the drag-drop UI.
+  /// When present, every `font_family_assets` entry whose (family, style)
+  /// matches a cache entry gets `asset_id` stamped, and the bytes flow
+  /// through the asset_manifest into the `.pulp.zip`. Optional — empty
+  /// or undefined cache is a no-op (the envelope still emits the
+  /// metadata-only catalogue per #43a-rev).
+  userFonts?: UserFontCache;
 }
 
 export interface LibraryManifestSnapshot {
@@ -65,16 +73,30 @@ export function serializeExport(
     },
     asset_manifest: {
       version: 1,
-      assets: ctx.assets.entries().map((a) => ({
-        asset_id: a.asset_id,
-        original_uri: a.original_uri,
-        original_uri_aliases: a.original_uri_aliases,
-        local_path: `assets/${a.content_hash}.${extOf(a.mime)}`,
-        content_hash: a.content_hash,
-        mime: a.mime,
-        width: a.width,
-        height: a.height,
-      })),
+      assets: [
+        ...ctx.assets.entries().map((a) => ({
+          asset_id: a.asset_id,
+          original_uri: a.original_uri,
+          original_uri_aliases: a.original_uri_aliases,
+          local_path: `assets/${a.content_hash}.${extOf(a.mime)}`,
+          content_hash: a.content_hash,
+          mime: a.mime,
+          width: a.width,
+          height: a.height,
+        })),
+        // #43c — user-supplied fonts ride alongside the image / vector
+        // assets in the same manifest. The local_path always ends in
+        // .ttf / .otf so the zip writer and downstream consumers can
+        // pick them out by extension without re-sniffing the mime.
+        ...(ctx.userFonts?.entries() ?? []).map((f) => ({
+          asset_id: f.asset_id,
+          original_uri: `userfont://${encodeURIComponent(f.original_filename)}`,
+          original_uri_aliases: [],
+          local_path: `assets/${f.content_hash}.${extOfFontMime(f.mime)}`,
+          content_hash: f.content_hash,
+          mime: f.mime,
+        })),
+      ],
     },
     // #43a-rev: top-level font catalogue. Each entry holds the family
     // name + style + (optional) weight + (optional) italic flag for every
@@ -83,7 +105,7 @@ export function serializeExport(
     // Figma plugin API does not expose font binaries directly. Runtime
     // (Agent A's #43b) consumes via Skia's SkFontMgr system-font matcher
     // with the bundled OFL set as fallback.
-    font_family_assets: ctx.fontFamilyAssets ?? [],
+    font_family_assets: stampUserFonts(ctx.fontFamilyAssets ?? [], ctx.userFonts),
     diagnostics: diagnostics.map(toEnvelopeDiagnostic),
     root,
   };
@@ -98,6 +120,33 @@ function extOf(mime: string): string {
     case "image/svg+xml": return "svg";
     default: return "bin";
   }
+}
+
+function extOfFontMime(mime: string): string {
+  switch (mime) {
+    case "font/ttf":   return "ttf";
+    case "font/otf":   return "otf";
+    case "font/woff":  return "woff";
+    case "font/woff2": return "woff2";
+    default: return "ttf";
+  }
+}
+
+/// #43c — for every font_family_assets entry, if the user has
+/// supplied a matching (family, style) cache entry, stamp it with
+/// the cached asset_id. Pure function; the original list is preserved
+/// otherwise so the metadata-only catalogue from #43a-rev is unchanged
+/// when no user fonts are present.
+function stampUserFonts(
+  fonts: FontFamilyAsset[],
+  cache: UserFontCache | undefined,
+): FontFamilyAsset[] {
+  if (!cache || cache.size() === 0) return fonts;
+  return fonts.map((f) => {
+    const match = cache.lookup(f.family, f.style);
+    if (!match) return f;
+    return { ...f, asset_id: match.asset_id };
+  });
 }
 
 function toEnvelopeNode(n: ExtractedFigmaNode): unknown {

--- a/tools/figma-plugin/src/types.ts
+++ b/tools/figma-plugin/src/types.ts
@@ -5,6 +5,20 @@ export type PulpFigmaUIMessage =
   | { type: "report-file-key"; fileKey: string | null }
   | { type: "get-selection-summary" }
   | { type: "export" }
+  /// #43c — user dragged a TTF/OTF onto the plugin UI to satisfy a
+  /// non-system font. `bytes` is the raw font file as a number[]
+  /// (postMessage-safe transit).
+  | {
+      type: "user-font";
+      family: string;
+      style: string;
+      bytes: number[];
+      filename: string;
+    }
+  /// #43c — UI asks the sandbox to scan the current selection's text
+  /// nodes and report back the unique font tuples so it can render
+  /// per-family drop zones.
+  | { type: "scan-fonts" }
   | { type: "close" };
 
 export interface AssetBundle {
@@ -13,11 +27,32 @@ export interface AssetBundle {
   bytes: number[]; // Uint8Array serialized as plain array for postMessage transit
 }
 
+export interface FontFamilyAssetSummary {
+  family: string;
+  style: string;
+  weight?: number;
+  italic?: boolean;
+  /// True when the sandbox already has a user-supplied TTF/OTF cached
+  /// for this (family, style) tuple. The UI uses this to render
+  /// "✓ bundled" instead of an empty drop zone.
+  has_user_font?: boolean;
+}
+
 export type PulpSandboxMessage =
   | { type: "ready"; pluginVersion: string }
   | { type: "pong"; figmaVersion: string; editorType: string; documentName: string }
   | { type: "selection-summary"; count: number; names: string[]; firstTypeIfAny: string | null }
   | { type: "progress"; stage: "extracting" | "serializing"; message: string }
+  /// #43c — sandbox responds to scan-fonts with the unique
+  /// (family, style, weight?, italic?) tuples referenced by the
+  /// current selection's text nodes, plus a flag for which are
+  /// already bundled via a user drop.
+  | { type: "fonts-detected"; fonts: FontFamilyAssetSummary[] }
+  /// #43c — sandbox acknowledges a user-font upload. The UI uses this
+  /// to flip the row to "✓ bundled" state. `asset_id` is the
+  /// content-hashed handle the envelope will carry on the matching
+  /// font_family_assets entry.
+  | { type: "user-font-staged"; family: string; style: string; asset_id: string }
   | {
       type: "export-result";
       nodeCount: number;

--- a/tools/figma-plugin/src/ui.html
+++ b/tools/figma-plugin/src/ui.html
@@ -66,6 +66,48 @@
         line-height: 1.4;
         margin-top: 16px;
       }
+      #fonts-list {
+        margin-top: 6px;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .font-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        padding: 6px 8px;
+        border: 1px dashed color-mix(in srgb, currentColor 25%, transparent);
+        border-radius: 4px;
+        font-size: 11px;
+      }
+      .font-row.bundled {
+        border-style: solid;
+        border-color: color-mix(in srgb, #2c8 40%, transparent);
+        background: color-mix(in srgb, #2c8 6%, transparent);
+      }
+      .font-row.dragover {
+        border-color: color-mix(in srgb, currentColor 60%, transparent);
+        background: color-mix(in srgb, currentColor 8%, transparent);
+      }
+      .font-row .meta {
+        color: #888;
+        font-size: 10px;
+        margin-left: 6px;
+      }
+      .font-row .badge {
+        flex-shrink: 0;
+        font-size: 10px;
+        color: #888;
+      }
+      .font-row.bundled .badge { color: #2c8; }
+      #fonts-empty {
+        color: #888;
+        font-size: 11px;
+        font-style: italic;
+        padding: 4px 0;
+      }
     </style>
   </head>
   <body>
@@ -80,6 +122,21 @@
         <button id="btn-refresh">Refresh</button>
         <button id="btn-export"><strong>Export to Pulp</strong></button>
         <button id="btn-close">Close</button>
+      </div>
+    </div>
+
+    <div class="panel">
+      <h2>Fonts</h2>
+      <p class="subtitle" style="margin: 0 0 8px;">
+        Drop a <code>.ttf</code>/<code>.otf</code> onto a row to bundle a non-system
+        font into the export. Otherwise Pulp falls back to a system match or its
+        bundled OFL set at import.
+      </p>
+      <div id="fonts-list">
+        <div id="fonts-empty">Click "Scan fonts" to detect fonts used in the current selection.</div>
+      </div>
+      <div class="row">
+        <button id="btn-scan-fonts">Scan fonts</button>
       </div>
     </div>
 

--- a/tools/figma-plugin/src/ui.ts
+++ b/tools/figma-plugin/src/ui.ts
@@ -1,7 +1,12 @@
 // Pulp Figma Plugin — UI iframe code.
 
 import { zipSync } from "fflate";
-import type { AssetBundle, PulpFigmaUIMessage, PulpSandboxMessage } from "./types";
+import type {
+  AssetBundle,
+  FontFamilyAssetSummary,
+  PulpFigmaUIMessage,
+  PulpSandboxMessage,
+} from "./types";
 
 const el = (id: string): HTMLElement => {
   const e = document.getElementById(id);
@@ -65,8 +70,89 @@ function extOfMime(m: string): string {
     case "image/gif": return "gif";
     case "image/webp": return "webp";
     case "image/svg+xml": return "svg";
+    // #43c — user-supplied font assets ride alongside image assets in
+    // the same bundle list; the zip writer needs to recognise them.
+    case "font/ttf": return "ttf";
+    case "font/otf": return "otf";
+    case "font/woff": return "woff";
+    case "font/woff2": return "woff2";
     default: return "bin";
   }
+}
+
+// #43c — font drop-zone state. `bundled` reflects sandbox confirmation
+// (we asked for a stage and got back `user-font-staged`); the row
+// turns green when this fires. Keyed by the same `family|style` tuple
+// the sandbox uses.
+const bundledFonts = new Set<string>();
+const fontKey = (family: string, style: string): string => `${family}|${style}`;
+
+function renderFonts(fonts: FontFamilyAssetSummary[]): void {
+  const list = el("fonts-list");
+  while (list.firstChild) list.removeChild(list.firstChild);
+
+  if (fonts.length === 0) {
+    const empty = document.createElement("div");
+    empty.id = "fonts-empty";
+    empty.textContent = "No fonts detected in the current selection.";
+    list.appendChild(empty);
+    return;
+  }
+
+  for (const f of fonts) {
+    const key = fontKey(f.family, f.style);
+    if (f.has_user_font) bundledFonts.add(key);
+
+    const row = document.createElement("div");
+    row.className = "font-row";
+    if (bundledFonts.has(key)) row.classList.add("bundled");
+    row.dataset.family = f.family;
+    row.dataset.style = f.style;
+
+    const left = document.createElement("div");
+    const name = document.createElement("strong");
+    name.textContent = f.family;
+    left.appendChild(name);
+    const meta = document.createElement("span");
+    meta.className = "meta";
+    const bits: string[] = [f.style];
+    if (typeof f.weight === "number") bits.push(`w${f.weight}`);
+    if (f.italic) bits.push("italic");
+    meta.textContent = ` · ${bits.join(" · ")}`;
+    left.appendChild(meta);
+    row.appendChild(left);
+
+    const badge = document.createElement("span");
+    badge.className = "badge";
+    badge.textContent = bundledFonts.has(key) ? "✓ bundled" : "drop .ttf";
+    row.appendChild(badge);
+
+    wireDropZone(row, f);
+    list.appendChild(row);
+  }
+}
+
+function wireDropZone(row: HTMLDivElement, font: FontFamilyAssetSummary): void {
+  row.addEventListener("dragover", (e) => {
+    e.preventDefault();
+    row.classList.add("dragover");
+  });
+  row.addEventListener("dragleave", () => row.classList.remove("dragover"));
+  row.addEventListener("drop", async (e) => {
+    e.preventDefault();
+    row.classList.remove("dragover");
+    const file = e.dataTransfer?.files?.[0];
+    if (!file) return;
+    const ab = await file.arrayBuffer();
+    const bytes = Array.from(new Uint8Array(ab));
+    send({
+      type: "user-font",
+      family: font.family,
+      style: font.style,
+      bytes,
+      filename: file.name,
+    });
+  });
 }
 
 window.onmessage = (e: MessageEvent) => {
@@ -109,14 +195,37 @@ window.onmessage = (e: MessageEvent) => {
       }
       break;
     }
+    case "fonts-detected":
+      renderFonts(msg.fonts);
+      break;
+    case "user-font-staged": {
+      // Sandbox accepted the bundled font; flip the row state.
+      bundledFonts.add(fontKey(msg.family, msg.style));
+      const row = el("fonts-list").querySelector<HTMLDivElement>(
+        `.font-row[data-family="${cssEscape(msg.family)}"][data-style="${cssEscape(msg.style)}"]`,
+      );
+      if (row) {
+        row.classList.add("bundled");
+        const badge = row.querySelector(".badge");
+        if (badge) badge.textContent = "✓ bundled";
+      }
+      break;
+    }
     case "error":
       showStatus(`Error: ${msg.message}`);
       break;
   }
 };
 
+// CSS.escape may not exist in older WebViews; provide a tiny fallback.
+function cssEscape(s: string): string {
+  if (typeof CSS !== "undefined" && typeof CSS.escape === "function") return CSS.escape(s);
+  return s.replace(/["\\]/g, "\\$&");
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   el("btn-refresh").addEventListener("click", () => send({ type: "get-selection-summary" }));
   el("btn-export").addEventListener("click", () => send({ type: "export" }));
   el("btn-close").addEventListener("click", () => send({ type: "close" }));
+  el("btn-scan-fonts").addEventListener("click", () => send({ type: "scan-fonts" }));
 });

--- a/tools/figma-plugin/src/user-fonts.ts
+++ b/tools/figma-plugin/src/user-fonts.ts
@@ -1,0 +1,102 @@
+// #43c — User-supplied font cache for the drag-drop escape hatch.
+//
+// The Figma plugin API intentionally does not expose font byte access (see
+// #43a-rev redesign note). Users with non-system fonts (custom foundry
+// faces, restricted-license families like Clash Grotesk) supply the
+// `.ttf` / `.otf` file via a drag-drop zone in the plugin UI. The UI
+// reads bytes via FileReader and forwards them to the sandbox; this
+// module is the sandbox-side store.
+//
+// Storage shape: keyed by `family|style` (the same tuple
+// `font_family_assets` entries are deduped on), value carries the
+// bytes plus a content-hashed asset_id stable across re-imports.
+//
+// At envelope serialize time, every `font_family_assets[i]` entry whose
+// (family, style) matches a cache entry gets `asset_id = "userfont-<hash>"`
+// stamped on it; the bytes are added to the asset_manifest so the zip
+// writer (UI side) packages them as `assets/<hash>.ttf`.
+
+import { sha256Hex } from "./assets";
+
+export interface UserFontEntry {
+  family: string;
+  style: string;
+  asset_id: string;
+  content_hash: string;
+  bytes: Uint8Array;
+  mime: string;
+  original_filename: string;
+}
+
+export class UserFontCache {
+  private byKey = new Map<string, UserFontEntry>();
+
+  private static makeKey(family: string, style: string): string {
+    return `${family}|${style}`;
+  }
+
+  size(): number {
+    return this.byKey.size;
+  }
+
+  entries(): UserFontEntry[] {
+    return Array.from(this.byKey.values());
+  }
+
+  /// Look up an entry by (family, style). Used at serialize time to
+  /// decide whether a font_family_assets entry should be stamped with
+  /// an asset_id.
+  lookup(family: string, style: string): UserFontEntry | undefined {
+    return this.byKey.get(UserFontCache.makeKey(family, style));
+  }
+
+  /// Add a user-supplied font, returning the asset_id. Idempotent on the
+  /// (family, style) key — re-adding overwrites the previous bytes.
+  async add(
+    family: string,
+    style: string,
+    bytes: Uint8Array,
+    original_filename: string,
+  ): Promise<UserFontEntry> {
+    const content_hash = await sha256Hex(bytes);
+    const asset_id = `userfont-${content_hash.slice(0, 12)}`;
+    const mime = detectFontMime(bytes, original_filename);
+    const entry: UserFontEntry = {
+      family,
+      style,
+      asset_id,
+      content_hash,
+      bytes,
+      mime,
+      original_filename,
+    };
+    this.byKey.set(UserFontCache.makeKey(family, style), entry);
+    return entry;
+  }
+}
+
+/// SFNT magic-number sniff with filename fallback. Order matters:
+/// fonts share a common 4-byte tag at offset 0 (`OTTO` for OpenType
+/// CFF, `\0\1\0\0` for TrueType, `true` for legacy TT, `wOFF`/`wOF2`
+/// for WOFF). If bytes are too short, fall back to the filename
+/// extension — the file came from the user, so we trust their naming.
+function detectFontMime(bytes: Uint8Array, filename: string): string {
+  if (bytes.length >= 4) {
+    const b0 = bytes[0], b1 = bytes[1], b2 = bytes[2], b3 = bytes[3];
+    // OpenType (CFF): "OTTO"
+    if (b0 === 0x4f && b1 === 0x54 && b2 === 0x54 && b3 === 0x4f) return "font/otf";
+    // TrueType: 0x00010000
+    if (b0 === 0x00 && b1 === 0x01 && b2 === 0x00 && b3 === 0x00) return "font/ttf";
+    // Legacy "true"
+    if (b0 === 0x74 && b1 === 0x72 && b2 === 0x75 && b3 === 0x65) return "font/ttf";
+    // WOFF / WOFF2
+    if (b0 === 0x77 && b1 === 0x4f && b2 === 0x46 && b3 === 0x46) return "font/woff";
+    if (b0 === 0x77 && b1 === 0x4f && b2 === 0x46 && b3 === 0x32) return "font/woff2";
+  }
+  const lower = filename.toLowerCase();
+  if (lower.endsWith(".otf")) return "font/otf";
+  if (lower.endsWith(".ttf")) return "font/ttf";
+  if (lower.endsWith(".woff2")) return "font/woff2";
+  if (lower.endsWith(".woff")) return "font/woff";
+  return "application/octet-stream";
+}

--- a/tools/figma-plugin/test/serialize.test.ts
+++ b/tools/figma-plugin/test/serialize.test.ts
@@ -220,3 +220,76 @@ test("serialized knob validates against figma-plugin-export-v1 schema", () => {
   validate(rootOf(out), (schema as any).$defs.node, schema as any, "root", nodeErrors);
   assert.deepEqual(nodeErrors, [], `node schema violations:\n${nodeErrors.join("\n")}`);
 });
+
+// ---------------------------------------------------------------------------
+// #43c — user-supplied font bundling. When a UserFontCache carries a TTF
+// for a (family, style) tuple matching a font_family_assets entry, the
+// serializer must:
+//   1. Stamp the entry with the cache's `asset_id`.
+//   2. Add a corresponding entry to `asset_manifest.assets` so the zip
+//      writer packages the bytes as `assets/<hash>.ttf`.
+//   3. Leave NON-matching entries untouched (metadata-only per #43a-rev).
+// ---------------------------------------------------------------------------
+
+import { UserFontCache } from "../src/user-fonts";
+
+test("serializeExport stamps user-supplied font asset_id (#43c)", async () => {
+  const cache = new UserFontCache();
+  const bytes = new Uint8Array([0x00, 0x01, 0x00, 0x00, 0xde, 0xad, 0xbe, 0xef]);
+  const entry = await cache.add("Clash Grotesk", "Medium", bytes, "ClashGrotesk-Medium.ttf");
+
+  const fontFamilyAssets = [
+    { family: "Inter", style: "Regular", weight: 400 },
+    { family: "Clash Grotesk", style: "Medium", weight: 500 },
+    { family: "Clash Grotesk", style: "Bold", weight: 700 }, // intentionally unmatched
+  ];
+
+  const out = serializeExport([knobNode()], [], ctx({
+    fontFamilyAssets,
+    userFonts: cache,
+  })) as Record<string, any>;
+
+  // 1 — asset_id stamped on the matching (family, style) tuple only.
+  const stamped = out.font_family_assets as Array<Record<string, any>>;
+  assert.equal(stamped[0].asset_id, undefined, "Inter Regular had no user-supplied font");
+  assert.equal(stamped[1].asset_id, entry.asset_id, "Clash Grotesk Medium matched");
+  assert.equal(stamped[2].asset_id, undefined, "Clash Grotesk Bold had no user-supplied font");
+
+  // 2 — bytes flow into asset_manifest with local_path ending in .ttf.
+  const fontAssets = out.asset_manifest.assets.filter(
+    (a: any) => a.asset_id === entry.asset_id,
+  );
+  assert.equal(fontAssets.length, 1, "exactly one asset_manifest entry for the font");
+  assert.equal(fontAssets[0].mime, "font/ttf");
+  assert.equal(fontAssets[0].content_hash, entry.content_hash);
+  assert.ok(
+    fontAssets[0].local_path.endsWith(".ttf"),
+    `local_path should end in .ttf, got ${fontAssets[0].local_path}`,
+  );
+
+  // 3 — the metadata-only path (#43a-rev) still works when no cache is given.
+  const noCacheOut = serializeExport([knobNode()], [], ctx({
+    fontFamilyAssets,
+  })) as Record<string, any>;
+  const noStamp = noCacheOut.font_family_assets as Array<Record<string, any>>;
+  for (const f of noStamp) {
+    assert.equal(f.asset_id, undefined, `no cache → no asset_id stamp (got ${f.asset_id})`);
+  }
+});
+
+test("UserFontCache sniffs SFNT magic for font/ttf vs font/otf (#43c)", async () => {
+  const cache = new UserFontCache();
+
+  // TrueType magic: 0x00 0x01 0x00 0x00
+  const ttf = await cache.add("F", "R", new Uint8Array([0x00, 0x01, 0x00, 0x00, 0xff]), "any.ttf");
+  assert.equal(ttf.mime, "font/ttf");
+
+  // OpenType CFF: "OTTO" (0x4f 0x54 0x54 0x4f)
+  const otf = await cache.add("F", "B", new Uint8Array([0x4f, 0x54, 0x54, 0x4f, 0xff]), "any.otf");
+  assert.equal(otf.mime, "font/otf");
+
+  // Filename fallback when bytes are too short or unknown.
+  const fallback = await cache.add("F", "I", new Uint8Array([0xff]), "no-magic.otf");
+  assert.equal(fallback.mime, "font/otf");
+});
+


### PR DESCRIPTION
# feat(figma-plugin): #43c — drag-drop UI for user-supplied font bundling

## Summary

Adds the escape hatch promised by `#43a-rev`: users drop TTF/OTF files onto the plugin UI to bundle non-system fonts (Clash Grotesk, foundry faces, restricted-licence families) into the `.pulp.zip` alongside the metadata-only `font_family_assets` catalogue.

Background: the Figma plugin API intentionally does NOT expose font binaries (see `planning/figma-import-coordination-log.md` 18:42Z entry). #43a-rev shipped metadata-only emit. For the ~20% of designs whose fonts aren't in Pulp's bundled OFL set and don't match a system font, this PR closes the gap.

## Flow

1. User clicks **Scan fonts** in the new Fonts panel → sandbox walks the current selection's text nodes, replies `fonts-detected` with the unique `(family, style, weight?, italic?)` tuples.
2. UI renders one row per font with a drop zone. Already-bundled rows show a green "✓ bundled" badge.
3. User drops a `.ttf`/`.otf` onto a row → FileReader → `postMessage({type:"user-font", family, style, bytes, filename})` → sandbox.
4. Sandbox stores in a per-session `UserFontCache` (keyed by `family|style`, content-hashed `asset_id`, SFNT-magic mime sniffing). Replies `user-font-staged` → UI flips the row's state.
5. On Export, `serialize.ts` stamps `asset_id` on matching `font_family_assets` entries AND adds the bytes to `asset_manifest.assets` so the zip writer packages them as `assets/<hash>.ttf`.

## Files

| File | Change |
|---|---|
| `src/user-fonts.ts` (NEW) | `UserFontCache` — keyed store, SFNT-magic mime sniff, content-hashed asset_id |
| `src/types.ts` | New UI→sandbox messages (`scan-fonts`, `user-font`), new sandbox→UI messages (`fonts-detected`, `user-font-staged`), `FontFamilyAssetSummary` |
| `src/serialize.ts` | Accepts `userFonts?: UserFontCache`; stamps `asset_id` on matching `font_family_assets`; emits bytes into `asset_manifest` |
| `src/code.ts` | Module-level `userFonts` instance; `handleScanFonts()`, `handleUserFont()`; export wires cache through |
| `src/ui.html` | New Fonts panel with per-row drop zones; CSS for bundled / dragover states |
| `src/ui.ts` | `renderFonts()`, `wireDropZone()`, FileReader → postMessage; CSS.escape fallback |
| `src/assets.ts` | `sha256Hex` exported so user-fonts.ts can share the impl |
| `test/serialize.test.ts` | +2 cases pinning asset_id stamping + SFNT magic sniff |

## Schema

No schema changes needed. `asset_id` was already optional on `font_family_assets` (#43a-rev anticipated this). `asset_manifest` entry's `mime` is an open string and `width`/`height` are optional.

## Version bumps

- Plugin (`tools/figma-plugin/`) `0.1.0 → 0.2.0` — new user-visible feature; `PLUGIN_VERSION` lands in the envelope's `provenance.version` so consumers can recognise post-#43c envelopes.
- SDK (CMakeLists.txt) `0.286.1 → 0.287.0` (minor; feat).
- Claude plugin (.claude-plugin/) `0.140.1 → 0.141.0` (minor; feat).

## Test (CLAUDE.md "tests ship with fixes")

```
$ npm run typecheck     # clean
$ npm run build         # clean (dist/code.js 48.5kb, dist/ui.js 25.4kb)
$ npm test
# tests 16
# pass 16    (was 14, +2 for #43c)
```

New cases:
- `serializeExport stamps user-supplied font asset_id (#43c)` — cache match stamps the matching entry only, bytes appear in `asset_manifest` under a `.ttf` path; cache-less call leaves entries untouched (preserves #43a-rev path).
- `UserFontCache sniffs SFNT magic for font/ttf vs font/otf (#43c)` — pins TT magic `0x00010000`, OT magic `OTTO`, and filename fallback.

## Coordination

Lands the Phase B3 follow-up promised in the `#43a-rev` MERGE log entry (`planning/figma-import-coordination-log.md` 19:02Z). Goal doc: `planning/2026-05-30-figma-import-library-and-plugin-goal.md` Phase B3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)