### PR TITLE
feat(import-design): headless Figma REST export + --from figma auto-route guardrail (#41 follow-up)

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -338,12 +338,26 @@ Ask the user or detect from context:
 
 ### Step 2: Read the design data
 
+**`--from figma-plugin`, NOT `--from figma`, for any `.pulp.json`/`.pulp.zip` envelope.**
+There are two distinct Figma sources: `--from figma` → `parse_figma_json` (the old Figma REST/file format) and `--from figma-plugin` → `parse_figma_plugin_json` (the plugin/headless **export envelope**, `format_version 2026.05-figma-plugin-v1`). Feeding a plugin envelope to `--from figma` historically produced a **silent empty import** — `parse_figma_json` found none of its structure and emitted only `createCol('root')` (`1 elements: 1 containers, 0 widgets, 0 labels`). The CLI now **auto-detects** the envelope and routes to the plugin parser with a `note:` on stderr (see `looks_like_figma_plugin_export` + `test_import_source_routing.cpp`), but always pass `--from figma-plugin` explicitly. Tell-tale of the old mistake: a ~13-line `ui.js` with only the root, or `0 widgets, 0 labels` on a design that clearly has widgets.
+
 **Figma plugin export — `.pulp.zip` is the default ship shape**:
 The "Export to Pulp" button in `tools/figma-plugin` emits a `.pulp.zip` containing `scene.pulp.json` + `assets/*.png` whenever the design has images. The CLI auto-unpacks ZIPs transparently (look for `Unpacked …` on stdout); point `--file` directly at either form:
 ```bash
 pulp import-design --from figma-plugin --file design.pulp.zip --output ui.js  # canonical
 pulp import-design --from figma-plugin --file scene.pulp.json --output ui.js  # also fine
 ```
+
+**Headless alternative — `tools/import-design/figma_rest_export.py` (no plugin click).**
+For iterative dev you don't have to open Figma desktop and click Export every time. This script pulls a frame via the Figma **REST API** and emits the same `figma-plugin-export-v1` envelope (it's a faithful PORT of `pulp-figma-plugin/src/extract.ts` — keep the two in sync). It captures vector/illustration nodes as PNG `asset_ref`s via the REST `/images` endpoint, exactly like the plugin's `exportAsync`.
+```bash
+# one-time: figma.com -> Settings -> Security -> Personal access tokens ->
+# Generate, check ONLY file_content:read, save to ~/.config/pulp/figma-token (chmod 600)
+python3 tools/import-design/figma_rest_export.py \
+  --url 'https://figma.com/design/<KEY>/...?node-id=3-42' --out scene.pulp.json
+pulp import-design --from figma-plugin --file scene.pulp.json --output ui.js
+```
+Token resolves from `--token`, then `$FIGMA_TOKEN`, then `~/.config/pulp/figma-token`; lifecycle (added/expiry) tracked in `~/.config/pulp/figma.json`. PATs expire (≤90 days) — regenerate same-scope; Figma OAuth2 is the permanent path (future). The plugin lane remains source-of-truth (audio-widget recognition, Pulp Library matching); the REST port covers generic frames/text/vectors/assets, which is what non-library designs (e.g. ELYSIUM) use. **Asset PNGs only raster-render in a GPU/Skia-enabled build** (`PULP_HAS_SKIA`); a GPU-off build draws filename placeholders for images while native widgets still paint.
 Detection uses ZIP magic (`PK\x03\x04`), not the file extension — `.zip` renames still get unpacked. The temp dir is auto-cleaned at process exit. Older CLI builds read input via `std::ifstream` text mode and silently truncated at the first NUL byte in the ZIP header; the symptom was `parser threw an unknown exception` on any `.pulp.zip`. If you see that error, the CLI predates the auto-unpack support — rebuild from current `main`.
 
 The extractor refuses hostile archives at parse time: entries whose filename is so long it would truncate inside the stack buffer, entries containing `..` substrings, entries that resolve to an absolute path (`fs::path::is_absolute()`), entries with Windows drive-relative or UNC prefixes (`C:foo`, `C:\\foo`, `\\\\server\\share\\…`), entries beginning with `/` or `\\`, archives with more than 10000 entries, and archives whose total or per-file uncompressed size exceeds 256 MB / 64 MB respectively. Each rejection logs a labelled `Error: refusing unsafe zip entry (<reason>): <name>` (or `oversized filename`, `total uncompressed size > …`) on stderr and bails with a non-zero exit. If a legitimate plugin export ever trips one of these caps, the right move is to lift the cap deliberately in `extract_pulp_zip_if_present` rather than disable the guard.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.143.0",
+      "version": "0.144.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.143.0"
+  "version": "0.144.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.143.0",
+  "version": "0.144.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.290.0
+    VERSION 0.291.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/test/test_cli_import_design.cpp
+++ b/test/test_cli_import_design.cpp
@@ -409,3 +409,42 @@ TEST_CASE("pulp import-design respects explicit sidecar paths over --output anch
 // `tools/import-design/pulp_import_design.cpp` is preserved; tests
 // tracked under #1180 (env-aware ProcessResult) for later restoration
 // once we can deterministically influence the child's getenv() lookups.
+
+// ── pulp #41 follow-up: --from figma auto-routes a figma-plugin envelope ──
+// A Figma-plugin export passed to `--from figma` used to be fed to
+// parse_figma_json (the old Figma format), which read none of its structure
+// and silently emitted an empty root-only import. The CLI now detects the
+// envelope (looks_like_figma_plugin_export) and routes to the plugin parser
+// with a stderr note. This guards against the silent-empty footgun.
+TEST_CASE("pulp import-design --from figma auto-routes a figma-plugin envelope",
+          "[cli][import-design][issue-41][shellout]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto tmp = unique_temp_dir("pulp-import-source-routing");
+    auto scene = tmp / "scene.pulp.json";
+    {
+        std::ofstream f(scene);
+        f << R"({
+  "format_version": "2026.05-figma-plugin-v1",
+  "provenance": {"adapter": "figma-plugin", "version": "t",
+                 "source_uri": "figma://x/1:1"},
+  "root": {"type": "frame", "name": "Root", "figma_node_id": "1:1",
+           "children": [{"type": "text", "name": "Hello", "figma_node_id": "1:2",
+                         "content": "Hello world"}]}
+})";
+    }
+    auto js_out = tmp / "ui.js";
+    // Deliberately the WRONG flag (--from figma) to exercise the guardrail.
+    auto r = run_pulp({"import-design", "--from", "figma",
+                       "--file", scene.string(), "--output", js_out.string(),
+                       "--no-tokens"});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code == 0);
+    // Guardrail fired: routed to the plugin parser with a notice.
+    const auto combined = r.stdout_output + r.stderr_output;
+    REQUIRE(combined.find("figma-plugin export envelope") != std::string::npos);
+    // Children were actually parsed (NOT the empty root-only output): the
+    // text node's content reaches the generated JS.
+    REQUIRE(fs::exists(js_out));
+    REQUIRE(read_text(js_out).find("Hello world") != std::string::npos);
+}

--- a/tools/import-design/figma_rest_export.py
+++ b/tools/import-design/figma_rest_export.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Headless Figma → Pulp import: pull a frame via the Figma REST API and emit the
+`figma-plugin-export-v1` envelope that `pulp import-design --from figma-plugin`
+consumes — no Figma desktop, no plugin click, no manual export.
+
+This is a faithful PORT of the Pulp Figma plugin's extractor, not an
+approximation: every field mapping mirrors
+`pulp-figma-plugin/tools/figma-plugin/src/extract.ts` + `serialize.ts`
+(walk / extractStyle / extractLayout / extractTextStyle / mapNodeType +
+the color helpers + the vector/illustration asset-capture rules). Because it
+mirrors that TS, **keep the two in sync** when either changes (the plugin lane
+remains the source of truth; this is the headless dev companion).
+
+Token (read-only, scope `file_content:read`) is resolved from, in order:
+  1. --token <value>
+  2. $FIGMA_TOKEN
+  3. ~/.config/pulp/figma-token  (chmod 600; lifecycle tracked in ~/.config/pulp/figma.json)
+Generate one at figma.com → Settings → Security → Personal access tokens
+(check ONLY `file_content:read`). PATs are short-lived (≤90 days); for a
+permanent setup, Figma OAuth2 refresh tokens are the future path.
+
+Usage:
+  figma_rest_export.py --file-key <KEY> --node <3:42> --out scene.pulp.json [--no-assets]
+  # or extract KEY/NODE from a URL:
+  figma_rest_export.py --url 'https://figma.com/design/<KEY>/...?node-id=3-42' --out scene.pulp.json
+"""
+import argparse, json, os, re, sys, urllib.request
+
+def hex2(v): return format(max(0, min(255, int(round(v)))), "02x")
+
+def paint_to_color(p):
+    c = p["color"]; a = p.get("opacity", 1.0)
+    r, g, b = c["r"] * 255, c["g"] * 255, c["b"] * 255
+    # Figma SOLID paint colour alpha lives on color.a; opacity multiplies it.
+    ca = c.get("a", 1.0) * a
+    if ca >= 1.0: return f"#{hex2(r)}{hex2(g)}{hex2(b)}"
+    return f"rgba({int(round(r))}, {int(round(g))}, {int(round(b))}, {ca:.3f})"
+
+def rgba_to_css(c):
+    r, g, b = c["r"] * 255, c["g"] * 255, c["b"] * 255
+    a = c.get("a", 1.0)
+    if a >= 1.0: return f"#{hex2(r)}{hex2(g)}{hex2(b)}"
+    return f"rgba({int(round(r))}, {int(round(g))}, {int(round(b))}, {a:.3f})"
+
+def gradient_to_css(p):
+    stops = p.get("gradientStops", [])
+    if not stops: return "linear-gradient(transparent, transparent)"
+    return "linear-gradient(to bottom, " + ", ".join(rgba_to_css(s["color"]) for s in stops) + ")"
+
+def gradient_flat(p):
+    stops = p.get("gradientStops", [])
+    return rgba_to_css(stops[0]["color"]) if stops else "transparent"
+
+def map_node_type(t):
+    if t in ("FRAME", "GROUP", "SECTION", "COMPONENT", "COMPONENT_SET", "INSTANCE",
+             "RECTANGLE", "ELLIPSE", "POLYGON", "STAR", "LINE", "SLICE"):
+        return "frame"
+    if t == "TEXT": return "text"
+    if t in ("VECTOR", "BOOLEAN_OPERATION"): return "vector"
+    return "frame"
+
+def first_visible(paints):
+    return next((p for p in paints if p.get("visible", True) is not False), None)
+
+def extract_style(n):
+    s = {}
+    bb = n.get("absoluteBoundingBox")
+    if bb:
+        s["width"] = bb["width"]; s["height"] = bb["height"]
+    rb = n.get("absoluteRenderBounds")
+    if rb and bb:
+        inflated = (rb["width"] > bb["width"] + 0.5 or rb["height"] > bb["height"] + 0.5
+                    or rb["x"] < bb["x"] - 0.5 or rb["y"] < bb["y"] - 0.5)
+        if inflated:
+            s["render_bounds"] = {"w": rb["width"], "h": rb["height"],
+                                  "dx": rb["x"] - bb["x"], "dy": rb["y"] - bb["y"]}
+    fills = n.get("fills")
+    if isinstance(fills, list) and fills:
+        f = first_visible(fills)
+        if f:
+            t = f.get("type")
+            if t == "SOLID": s["background_color"] = paint_to_color(f)
+            elif t == "GRADIENT_LINEAR": s["background_gradient"] = gradient_to_css(f)
+            elif t == "IMAGE":
+                ih = f.get("imageRef") or f.get("imageHash")
+                if ih: s["background_image"] = f"pending:{ih}"
+            elif t in ("GRADIENT_RADIAL", "GRADIENT_ANGULAR", "GRADIENT_DIAMOND"):
+                s["background_color"] = gradient_flat(f)  # flat fallback (matches extract.ts)
+    strokes = n.get("strokes")
+    if isinstance(strokes, list) and strokes:
+        f = first_visible(strokes)
+        if f and f.get("type") == "SOLID":
+            color = paint_to_color(f)
+            weight = n.get("strokeWeight", 1)
+            s["border"] = f"{weight}px solid {color}"
+            s["border_color"] = color; s["border_width"] = weight; s["border_style"] = "solid"
+    if isinstance(n.get("cornerRadius"), (int, float)):
+        s["border_radius"] = n["cornerRadius"]
+    op = n.get("opacity")
+    if isinstance(op, (int, float)) and op < 1: s["opacity"] = op
+    effects = n.get("effects")
+    if isinstance(effects, list):
+        shadows = []; filt = None
+        for e in effects:
+            if e.get("visible", True) is False: continue
+            et = e.get("type")
+            if et in ("DROP_SHADOW", "INNER_SHADOW"):
+                inner = "inset " if et == "INNER_SHADOW" else ""
+                off = e.get("offset", {"x": 0, "y": 0})
+                shadows.append(f"{inner}{off['x']}px {off['y']}px {e.get('radius',0)}px "
+                               f"{e.get('spread',0)}px {rgba_to_css(e['color'])}")
+            elif et == "LAYER_BLUR": filt = f"blur({e.get('radius',0)}px)"
+            elif et == "BACKGROUND_BLUR": s["backdrop_filter"] = f"blur({e.get('radius',0)}px)"
+        if shadows: s["box_shadow"] = ", ".join(shadows)
+        if filt: s["filter"] = filt
+    if n.get("clipsContent") is True: s["overflow"] = "clip"
+    return s
+
+def extract_text_style(n, s):
+    st = n.get("style", {})
+    if "fontSize" in st: s["font_size"] = st["fontSize"]
+    if "fontFamily" in st:
+        s["font_family"] = st["fontFamily"]
+        s["font_style"] = "italic" if "italic" in str(st.get("italic", "")).lower() or st.get("italic") else "normal"
+    if "fontWeight" in st: s["font_weight"] = st["fontWeight"]
+    ls = st.get("letterSpacing")
+    if isinstance(ls, (int, float)): s["letter_spacing"] = ls
+    lh = st.get("lineHeightPx")
+    if isinstance(lh, (int, float)): s["line_height"] = lh
+    if st.get("textAlignHorizontal"): s["text_align"] = st["textAlignHorizontal"].lower()
+    tc = st.get("textCase")
+    if tc == "UPPER": s["text_transform"] = "uppercase"
+    elif tc == "LOWER": s["text_transform"] = "lowercase"
+    elif tc == "TITLE": s["text_transform"] = "capitalize"
+    fills = n.get("fills")
+    if isinstance(fills, list):
+        f = next((p for p in fills if p.get("type") == "SOLID" and p.get("visible", True) is not False), None)
+        if f:
+            s["color"] = paint_to_color(f)
+            s.pop("background_color", None)
+
+def is_vector_like(t):
+    return t in ("VECTOR", "BOOLEAN_OPERATION", "STAR", "POLYGON", "LINE")
+
+def is_pure_vector_illustration(n):
+    kids = n.get("children", [])
+    if not kids: return False
+    for c in kids:
+        t = c.get("type")
+        if t in ("VECTOR", "BOOLEAN_OPERATION", "LINE", "STAR", "POLYGON", "ELLIPSE", "RECTANGLE"):
+            continue
+        if t in ("FRAME", "GROUP"):
+            if not is_pure_vector_illustration(c): return False
+            continue
+        return False  # text/instance/image → not a pure illustration
+    return True
+
+def is_auto_layout(n):
+    return n is not None and n.get("layoutMode") in ("HORIZONTAL", "VERTICAL")
+
+def extract_layout(n):
+    l = {}
+    if n.get("type") not in ("FRAME", "COMPONENT", "INSTANCE", "COMPONENT_SET"):
+        return l
+    lm = n.get("layoutMode")
+    if lm in ("HORIZONTAL", "VERTICAL"):
+        l["display"] = "flex"
+        l["direction"] = "row" if lm == "HORIZONTAL" else "column"
+        l["gap"] = n.get("itemSpacing", 0)
+        l["padding"] = {"top": n.get("paddingTop", 0), "right": n.get("paddingRight", 0),
+                        "bottom": n.get("paddingBottom", 0), "left": n.get("paddingLeft", 0)}
+        pa = {"MIN": "flex_start", "MAX": "flex_end", "CENTER": "center", "SPACE_BETWEEN": "space_between"}
+        ca = {"MIN": "flex_start", "MAX": "flex_end", "CENTER": "center", "BASELINE": "flex_start"}
+        sz = {"HUG": "hug", "FILL": "fill", "FIXED": "fixed"}
+        l["justify"] = pa.get(n.get("primaryAxisAlignItems"), "flex_start")
+        l["align"] = ca.get(n.get("counterAxisAlignItems"), "stretch")
+        l["wrap"] = n.get("layoutWrap") == "WRAP"
+        l["width_mode"] = sz.get(n.get("layoutSizingHorizontal"), "fixed")
+        l["height_mode"] = sz.get(n.get("layoutSizingVertical"), "fixed")
+    else:
+        l["width_mode"] = "fixed"; l["height_mode"] = "fixed"
+    return l
+
+ASSET_IDS = []  # node ids to export as PNG via /images (filled during walk)
+
+def walk(n, parent, z):
+    ntype = n.get("type")
+    t = map_node_type(ntype)
+    style = extract_style(n)
+    layout = extract_layout(n)
+    # Absolute positioning when parent isn't auto-layout (extract.ts:158-188)
+    if parent is not None and not is_auto_layout(parent):
+        cbb = n.get("absoluteBoundingBox"); pbb = parent.get("absoluteBoundingBox")
+        if cbb and pbb:
+            style["position"] = "absolute"
+            style["left"] = cbb["x"] - pbb["x"]
+            style["top"] = cbb["y"] - pbb["y"]
+    out = {"type": t, "name": n.get("name", ""), "figma_node_id": n.get("id", "")}
+    if ntype == "TEXT":
+        out["content"] = n.get("characters", "")
+        extract_text_style(n, style)
+
+    # Asset capture (extract.ts:268-322). Vector-like nodes → PNG asset_ref.
+    # Pure-vector-illustration frames → whole-frame PNG, drop children.
+    bb = n.get("absoluteBoundingBox") or {}
+    tiny = bb.get("width", 0) < 1 and bb.get("height", 0) < 1
+    captured = False
+    if is_vector_like(ntype) and not tiny:
+        out["type"] = "image"; out["asset_ref"] = n["id"]; ASSET_IDS.append(n["id"]); captured = True
+    elif (ntype in ("FRAME", "GROUP") and n.get("children")
+          and is_pure_vector_illustration(n)):
+        out["type"] = "image"; out["asset_ref"] = n["id"]; ASSET_IDS.append(n["id"]); captured = True
+
+    style = {k: v for k, v in style.items() if v not in (None, "")}
+    layout = {k: v for k, v in layout.items() if v is not None}
+    if style: out["style"] = style
+    if layout: out["layout"] = layout
+    out["figma"] = {"parent_id": parent.get("id") if parent else None, "z_order": z,
+                    "visible": n.get("visible", True), "locked": n.get("locked", False),
+                    "blend_mode": n.get("blendMode", "PASS_THROUGH")}
+    if not captured:  # illustration frames drop their children (rasterized whole)
+        kids = [c for c in n.get("children", []) if c.get("visible", True) is not False]
+        if kids:
+            out["children"] = [walk(c, n, i) for i, c in enumerate(kids)]
+    return out
+
+def export_assets(file_key, ids, token, out_dir):
+    """Batch-render node ids to PNG via the Figma REST /images endpoint, download
+    to out_dir/assets/, and return asset_manifest entries (mirrors AssetCache)."""
+    import os, urllib.request
+    os.makedirs(os.path.join(out_dir, "assets"), exist_ok=True)
+    manifest = []
+    # /images caps url length; chunk the id list.
+    CHUNK = 50
+    url_map = {}
+    for i in range(0, len(ids), CHUNK):
+        batch = ids[i:i+CHUNK]
+        q = ",".join(batch)
+        req = urllib.request.Request(
+            f"https://api.figma.com/v1/images/{file_key}?ids={q}&format=png&scale=2",
+            headers={"X-Figma-Token": token})
+        with urllib.request.urlopen(req, timeout=60) as r:
+            data = json.load(r)
+        url_map.update(data.get("images", {}) or {})
+    for nid in ids:
+        url = url_map.get(nid)
+        safe = nid.replace(":", "_")
+        rel = f"assets/{safe}.png"
+        if url:
+            try:
+                with urllib.request.urlopen(url, timeout=60) as r:
+                    blob = r.read()
+                open(os.path.join(out_dir, rel), "wb").write(blob)
+                manifest.append({"asset_id": nid, "original_uri": f"figma://{file_key}/{nid}",
+                                 "original_uri_aliases": [], "local_path": rel,
+                                 "content_hash": safe, "mime": "image/png"})
+            except Exception as e:
+                print(f"  asset {nid} download failed: {e}", file=sys.stderr)
+    return manifest
+
+def resolve_token(explicit):
+    if explicit: return explicit.strip()
+    env = os.environ.get("FIGMA_TOKEN")
+    if env: return env.strip()
+    path = os.path.expanduser("~/.config/pulp/figma-token")
+    if os.path.exists(path):
+        return open(path).read().strip()
+    return None
+
+def parse_url(url):
+    # https://figma.com/design/<KEY>/<name>?node-id=<a-b>  (node-id uses '-'; API uses ':')
+    m = re.search(r"/(?:design|file)/([A-Za-z0-9]+)", url)
+    key = m.group(1) if m else None
+    m2 = re.search(r"node-id=([0-9]+)[-:]([0-9]+)", url)
+    node = f"{m2.group(1)}:{m2.group(2)}" if m2 else None
+    return key, node
+
+def fetch_nodes(file_key, node_id, token):
+    req = urllib.request.Request(
+        f"https://api.figma.com/v1/files/{file_key}/nodes?ids={node_id}&geometry=paths",
+        headers={"X-Figma-Token": token})
+    with urllib.request.urlopen(req, timeout=120) as r:
+        return json.load(r)
+
+def main():
+    ap = argparse.ArgumentParser(description="Headless Figma REST → Pulp figma-plugin envelope")
+    ap.add_argument("--file-key"); ap.add_argument("--node")
+    ap.add_argument("--url", help="Figma design URL (extracts --file-key + --node)")
+    ap.add_argument("--out", required=True, help="output scene.pulp.json")
+    ap.add_argument("--token", help="Figma PAT (else $FIGMA_TOKEN or ~/.config/pulp/figma-token)")
+    ap.add_argument("--no-assets", action="store_true", help="skip /images PNG capture (geometry+style only)")
+    ap.add_argument("--node-json", help="use a pre-fetched /v1/.../nodes JSON instead of calling REST")
+    args = ap.parse_args()
+
+    file_key, node_id = args.file_key, args.node
+    if args.url:
+        k, n = parse_url(args.url)
+        file_key = file_key or k; node_id = node_id or n
+    if not file_key or not node_id:
+        ap.error("need --file-key + --node (or --url)")
+
+    token = resolve_token(args.token)
+    if not token and not args.node_json:
+        ap.error("no Figma token (pass --token, set $FIGMA_TOKEN, or create ~/.config/pulp/figma-token). "
+                 "Generate at figma.com -> Settings -> Security -> Personal access tokens (scope file_content:read).")
+
+    doc = json.load(open(args.node_json)) if args.node_json else fetch_nodes(file_key, node_id, token)
+    root = doc["nodes"][node_id]["document"]
+    root_node = walk(root, None, 0)
+
+    out_dir = os.path.dirname(os.path.abspath(args.out))
+    asset_manifest_entries = []
+    if not args.no_assets and token and ASSET_IDS:
+        print(f"exporting {len(ASSET_IDS)} assets via /images ...")
+        asset_manifest_entries = export_assets(file_key, ASSET_IDS, token, out_dir)
+        print(f"  captured {len(asset_manifest_entries)} PNGs")
+
+    envelope = {
+        "$schema": "https://pulp.dev/schemas/figma-plugin-export-v1.json",
+        "format_version": "2026.05-figma-plugin-v1",
+        "parser_version": "0.1.0",
+        "compat_schema_version": "0.3",
+        "provenance": {"adapter": "figma-plugin", "version": "rest-export-0.1",
+                       "source_uri": f"figma://{file_key}/{node_id}",
+                       "exported_at": "1970-01-01T00:00:00.000Z"},
+        "library_manifest": None,
+        "tokens": {"colors": {}, "dimensions": {}, "strings": {}},
+        "asset_manifest": {"version": 1, "assets": asset_manifest_entries},
+        "diagnostics": [],
+        "root": root_node,
+    }
+    json.dump(envelope, open(args.out, "w"), indent=1)
+    cnt = [0]
+    def c(n):
+        cnt[0] += 1
+        for k in n.get("children", []): c(k)
+    c(envelope["root"])
+    print(f"wrote {args.out}: {cnt[0]} nodes, {len(asset_manifest_entries)} assets")
+
+if __name__ == "__main__":
+    main()

--- a/tools/import-design/pulp_import_design.cpp
+++ b/tools/import-design/pulp_import_design.cpp
@@ -210,6 +210,19 @@ bool looks_like_serialized_design_ir(const std::string& content) {
         && trimmed.find("\"root\"") != std::string::npos;
 }
 
+// Detect a Figma-plugin export envelope (the `.pulp.json` the Pulp Figma plugin
+// and the headless REST exporter emit), so `--from figma` doesn't silently feed
+// it to parse_figma_json — which reads none of its structure and produces an
+// empty root-only import. Keyed on the envelope's stable identity fields:
+// format_version `...-figma-plugin-v1` or provenance.adapter "figma-plugin".
+bool looks_like_figma_plugin_export(const std::string& content) {
+    const auto trimmed = trim_copy(content);
+    if (trimmed.empty() || trimmed.front() != '{') return false;
+    return trimmed.find("figma-plugin-v1") != std::string::npos
+        || trimmed.find("\"adapter\": \"figma-plugin\"") != std::string::npos
+        || trimmed.find("\"adapter\":\"figma-plugin\"") != std::string::npos;
+}
+
 std::string strip_quotes_copy(const std::string& s) {
     if (s.size() >= 2
         && ((s.front() == '"' && s.back() == '"')
@@ -1597,7 +1610,21 @@ int main(int argc, char* argv[]) {
             parsed_serialized_design_ir = true;
         } else {
             switch (*source) {
-                case DesignSource::figma:        ir = parse_figma_json(content); break;
+                case DesignSource::figma:
+                    // Guardrail (pulp #41 follow-up): a Figma-plugin export
+                    // envelope passed to `--from figma` would otherwise be fed
+                    // to parse_figma_json, which finds none of its structure and
+                    // silently yields an empty root-only import. Auto-route to
+                    // the plugin parser and tell the user once.
+                    if (looks_like_figma_plugin_export(content)) {
+                        std::cerr << "note: input is a Figma-plugin export envelope; "
+                                     "using the figma-plugin parser. Pass "
+                                     "--from figma-plugin to silence this notice.\n";
+                        ir = parse_figma_plugin_json(content);
+                    } else {
+                        ir = parse_figma_json(content);
+                    }
+                    break;
                 case DesignSource::figma_plugin: ir = parse_figma_plugin_json(content); break;
                 case DesignSource::stitch: ir = parse_stitch_html(content); break;
                 case DesignSource::v0:     ir = parse_v0_tsx(content); break;


### PR DESCRIPTION
## Headless Figma import + `--from figma` guardrail

Two related changes so figma-plugin imports stop biting us, and so dev no longer requires clicking the plugin.

### 1. Guardrail — `--from figma` auto-routes a plugin envelope (the #41 footgun)
A Figma-plugin export envelope (`format_version 2026.05-figma-plugin-v1`) passed to `--from figma` was fed to `parse_figma_json` (the *old* Figma format), which read none of its structure and **silently emitted an empty root-only import** (`createCol('root')`; `1 elements: 1 containers, 0 widgets, 0 labels`). The CLI now detects the envelope (`looks_like_figma_plugin_export`) and routes to `parse_figma_plugin_json` with a stderr `note:`.
- **Test:** shell-out regression in `test_cli_import_design.cpp` (`[issue-41]`) — feeds a plugin envelope via `--from figma`, asserts the note fires + the child text node reaches the generated JS.
- **Verified:** `--from figma` on a real 405-node envelope → note + `213 elements` (was `1 element`).

### 2. Headless REST exporter — `tools/import-design/figma_rest_export.py`
Pulls a frame via the Figma **REST API** and emits the same `figma-plugin-export-v1` envelope, capturing vector/illustration nodes as PNG `asset_ref`s via `/images`. It's a faithful **port** of `pulp-figma-plugin/src/extract.ts` (walk/extractStyle/extractLayout/extractTextStyle/mapNodeType + color helpers + capture rules) — the plugin lane stays source-of-truth; this is the headless dev companion.
- **Validated:** reproduced the ELYSIUM frame's full **213-element** structure headless (no plugin click).
- Token (read-only, `file_content:read`) resolves from `--token` → `$FIGMA_TOKEN` → `~/.config/pulp/figma-token`.

### Skill
`import-design/SKILL.md` now documents `--from figma-plugin` (vs `figma`) + the footgun tell-tale + the headless option (enablement, token scope/storage, 90-day note, OAuth as the permanent path) + that asset PNGs only raster-render in a `PULP_HAS_SKIA` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)