### PR TITLE
feat(format): enforce clamp_latency_to_nonneg via resolved_quirks across all adapters (P3a)

### DIFF
--- a/.agents/skills/auv2/SKILL.md
+++ b/.agents/skills/auv2/SKILL.md
@@ -292,3 +292,17 @@ plugin whose UI uses Three.js or raw WebGPU JS renders black — the JS
 shim silently falls back to mocks. See the `view-bridge` skill's
 "GpuSurface plumbing into WidgetBridge" section for the cross-platform
 contract.
+
+## Host-quirks consumption (P3a, 2026-05-30)
+
+This adapter consumes the host-quirks ledger at init: it caches
+`resolved_quirks(detect_host_info().type, version)` once (the runtime
+policy — `PULP_HOST_QUIRKS` env / `set_host_quirk_policy()` API / compile
+default — applies via `resolved_quirks()`), then gates DAW accommodations
+on those flags instead of hardcoding them.
+
+First wired flag: `clamp_latency_to_nonneg`. Latency reporting routes
+through the pure helper `pulp::format::reported_latency_samples(raw, quirks)`
+(in `host_quirks.hpp`): a negative `latency_samples()` clamps to 0 when the
+quirk is enforced, and passes through raw (wrapping the unsigned host field)
+when `PULP_HOST_QUIRKS=off`. See `docs/reference/host-quirks-policy.md`.

--- a/.agents/skills/auv3/SKILL.md
+++ b/.agents/skills/auv3/SKILL.md
@@ -1096,3 +1096,26 @@ Full cross-platform contract lives in the `view-bridge` skill's
 - Memory note: AAX-parity sweep — AU sysex (#288), VST3 sysex (#274),
   CLAP sysex (#269) and AAX sysex (#239) all share the same
   sidecar. Fixing one means checking the other three.
+
+## Host-quirks consumption (P3a, 2026-05-30)
+
+This adapter consumes the host-quirks ledger at init: it caches
+`resolved_quirks(detect_host_info().type, version)` once (the runtime
+policy — `PULP_HOST_QUIRKS` env / `set_host_quirk_policy()` API / compile
+default — applies via `resolved_quirks()`), then gates DAW accommodations
+on those flags instead of hardcoding them.
+
+First wired flag: `clamp_latency_to_nonneg`. Latency reporting routes
+through the pure helper `pulp::format::reported_latency_samples(raw, quirks)`
+(in `host_quirks.hpp`): a negative `latency_samples()` clamps to 0 when the
+quirk is enforced, and passes through raw (wrapping the unsigned host field)
+when `PULP_HOST_QUIRKS=off`. See `docs/reference/host-quirks-policy.md`.
+
+**Obj-C gotcha:** in `au_adapter.mm` the `@implementation` method bodies are
+at *file scope*, NOT inside `namespace pulp::format::au`, so unqualified
+lookup of namespace free functions fails to compile. Qualify them:
+`pulp::format::detect_host_info()`, `pulp::format::resolved_quirks(...)`,
+`pulp::format::reported_latency_samples(...)`. (Struct members like the
+cached `HostQuirks host_quirks` resolve fine — the struct is in-namespace.)
+The core lib doesn't compile this `.mm`, so only the AU target/test catches
+such errors — build `pulp-test-au-plugin-state`.

--- a/.agents/skills/clap/SKILL.md
+++ b/.agents/skills/clap/SKILL.md
@@ -544,3 +544,17 @@ right after `PluginViewHost::create()` succeeds. Without this, a
 CLAP plugin whose UI uses Three.js or raw WebGPU JS renders black —
 the JS shim silently falls back to mocks. See the `view-bridge` skill's
 "GpuSurface plumbing into WidgetBridge" section.
+
+## Host-quirks consumption (P3a, 2026-05-30)
+
+This adapter consumes the host-quirks ledger at init: it caches
+`resolved_quirks(detect_host_info().type, version)` once (the runtime
+policy — `PULP_HOST_QUIRKS` env / `set_host_quirk_policy()` API / compile
+default — applies via `resolved_quirks()`), then gates DAW accommodations
+on those flags instead of hardcoding them.
+
+First wired flag: `clamp_latency_to_nonneg`. Latency reporting routes
+through the pure helper `pulp::format::reported_latency_samples(raw, quirks)`
+(in `host_quirks.hpp`): a negative `latency_samples()` clamps to 0 when the
+quirk is enforced, and passes through raw (wrapping the unsigned host field)
+when `PULP_HOST_QUIRKS=off`. See `docs/reference/host-quirks-policy.md`.

--- a/.agents/skills/vst3/SKILL.md
+++ b/.agents/skills/vst3/SKILL.md
@@ -497,3 +497,17 @@ Do not remove this environment just because `pluginval` also has
 - Memory note: "Tests ship with fixes" — every VST3 process-path
   behaviour change needs a Catch2 fixture (the #290 coverage lane
   explicitly names `format` as under active hardening).
+
+## Host-quirks consumption (P3a, 2026-05-30)
+
+This adapter consumes the host-quirks ledger at init: it caches
+`resolved_quirks(detect_host_info().type, version)` once (the runtime
+policy — `PULP_HOST_QUIRKS` env / `set_host_quirk_policy()` API / compile
+default — applies via `resolved_quirks()`), then gates DAW accommodations
+on those flags instead of hardcoding them.
+
+First wired flag: `clamp_latency_to_nonneg`. Latency reporting routes
+through the pure helper `pulp::format::reported_latency_samples(raw, quirks)`
+(in `host_quirks.hpp`): a negative `latency_samples()` clamps to 0 when the
+quirk is enforced, and passes through raw (wrapping the unsigned host field)
+when `PULP_HOST_QUIRKS=off`. See `docs/reference/host-quirks-policy.md`.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.144.0",
+      "version": "0.145.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.144.0"
+  "version": "0.145.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.144.0",
+  "version": "0.145.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.291.0
+    VERSION 0.292.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/au_v2_adapter.hpp
+++ b/core/format/include/pulp/format/au_v2_adapter.hpp
@@ -3,6 +3,7 @@
 #include <AudioUnitSDK/AUMIDIEffectBase.h>
 
 #include <pulp/format/processor.hpp>
+#include <pulp/format/host_quirks.hpp>
 #include <pulp/format/detail/playhead_diff.hpp>
 #include <pulp/midi/buffer.hpp>
 #include <pulp/midi/message.hpp>
@@ -137,6 +138,10 @@ protected:
 private:
     std::unique_ptr<Processor> processor_;
     state::StateStore store_;
+
+    // Host accommodations, resolved once in the constructor via the
+    // runtime policy (host-quirks plan, P3).
+    HostQuirks host_quirks_{};
     std::vector<const float*> input_ptrs_;
     std::vector<float*> output_ptrs_;
     // Pre-process snapshot of parameter values; used to diff plugin-side

--- a/core/format/include/pulp/format/clap_adapter.hpp
+++ b/core/format/include/pulp/format/clap_adapter.hpp
@@ -6,6 +6,7 @@
 
 #include <pulp/format/processor.hpp>
 #include <pulp/format/ara.hpp>
+#include <pulp/format/host_quirks.hpp>
 #include <pulp/format/detail/playhead_diff.hpp>
 #include <pulp/events/plugin_main_thread.hpp>
 #include <pulp/state/parameter_event_queue.hpp>
@@ -33,6 +34,11 @@ struct PulpClapPlugin {
     std::unique_ptr<Processor> processor;
     state::StateStore store;
     ProcessorFactory factory;
+
+    // Host accommodations, resolved once in clap_init() via the runtime
+    // policy. Adapters consult these instead of hardcoding workarounds
+    // (host-quirks plan, P3).
+    HostQuirks host_quirks{};
 
     // Stored at create_plugin() time so the adapter can publish
     // latency / tail change notifications (item 3.11) back to the

--- a/core/format/include/pulp/format/clap_entry.hpp
+++ b/core/format/include/pulp/format/clap_entry.hpp
@@ -248,7 +248,12 @@ inline const clap_plugin_note_ports_t note_ports_ext = {
 inline uint32_t latency_get(const clap_plugin_t* plugin) {
     auto* self = static_cast<clap_adapter::PulpClapPlugin*>(plugin->plugin_data);
     if (!self->processor) return 0;
-    return static_cast<uint32_t>(self->processor->latency_samples());
+    // clamp_latency_to_nonneg (host-quirks P3): CLAP reports latency as
+    // unsigned; clamp a negative latency_samples() to 0 unless the quirk
+    // is filtered out (PULP_HOST_QUIRKS=off).
+    return static_cast<uint32_t>(
+        reported_latency_samples(self->processor->latency_samples(),
+                                 self->host_quirks));
 }
 
 inline const clap_plugin_latency_t latency_ext = { .get = latency_get };

--- a/core/format/include/pulp/format/host_quirks.hpp
+++ b/core/format/include/pulp/format/host_quirks.hpp
@@ -467,4 +467,21 @@ std::vector<QuirkFieldStatus> enumerate_quirk_fields(const HostQuirks& q);
 /// overrides. Equivalent to `make_quirks_for` + the runtime policy.
 HostQuirks resolved_quirks(HostType type, HostVersion version);
 
+// ── Accommodation application helpers (P3) ────────────────────────────
+//
+// Small pure helpers that apply a single quirk to a value, so format
+// adapters share one tested implementation instead of open-coding the
+// accommodation at each call site. Each takes the resolved `HostQuirks`
+// the adapter cached at init.
+
+/// Apply `clamp_latency_to_nonneg` to a raw `Processor::latency_samples()`
+/// value before reporting it to the host. When the quirk is enforced, a
+/// negative latency is clamped to 0 (VST3/CLAP report unsigned, so a raw
+/// negative would wrap to a huge value); when it is filtered out, the raw
+/// value passes through unchanged. Pure + constexpr so it is unit-tested
+/// directly without instantiating an adapter.
+constexpr int reported_latency_samples(int raw, const HostQuirks& q) noexcept {
+    return (q.clamp_latency_to_nonneg && raw < 0) ? 0 : raw;
+}
+
 }  // namespace pulp::format

--- a/core/format/include/pulp/format/vst3_adapter.hpp
+++ b/core/format/include/pulp/format/vst3_adapter.hpp
@@ -25,6 +25,7 @@
 
 #include <pulp/events/plugin_main_thread.hpp>
 #include <pulp/format/processor.hpp>
+#include <pulp/format/host_quirks.hpp>
 #include <pulp/format/detail/playhead_diff.hpp>
 #include <pulp/state/parameter_event_queue.hpp>
 
@@ -101,6 +102,11 @@ private:
     // parameter (the one we tag with kIsBypass in initialize()). 0 when
     // none — process() then never short-circuits.
     state::ParamID bypass_param_id_ = 0;
+
+    // Host accommodations, resolved once in initialize() via the runtime
+    // policy (env / API / compile default). Adapters consult these flags
+    // instead of hardcoding DAW workarounds (host-quirks plan, P3).
+    HostQuirks quirks_{};
 
     // Item 1.3 — previous-block transport snapshot used to derive the
     // `tempo_changed` / `time_sig_changed` / `transport_changed` flags

--- a/core/format/src/au_adapter.mm
+++ b/core/format/src/au_adapter.mm
@@ -57,6 +57,7 @@
 #include <pulp/events/plugin_main_thread.hpp>
 #include <pulp/format/processor.hpp>
 #include <pulp/format/plugin_state_io.hpp>
+#include <pulp/format/host_quirks.hpp>
 #include <pulp/format/registry.hpp>
 #include <pulp/format/ara.hpp>
 #include <pulp/format/detail/playhead_diff.hpp>
@@ -136,6 +137,10 @@ struct AUBridge {
     // previous block) so the first render-block invocation reports no
     // changes.
     detail::PlayheadSnapshot playhead_prev;
+
+    // Host accommodations, resolved once at init via the runtime policy
+    // (host-quirks plan, P3).
+    HostQuirks host_quirks{};
 };
 
 static int32_t block_relative_sample_offset(AUEventSampleTime event_sample_time,
@@ -251,6 +256,16 @@ static int32_t block_relative_sample_offset(AUEventSampleTime event_sample_time,
     _bridge.processor->set_state_store(&_bridge.store);
     _bridge.processor->define_parameters(_bridge.store);
 
+    // Resolve host accommodations once (host-quirks plan, P3) via the
+    // runtime policy (PULP_HOST_QUIRKS env / set_host_quirk_policy API).
+    // Qualified: this @implementation method body is at file scope, not
+    // inside namespace pulp::format::au, so unqualified lookup misses it.
+    {
+        const auto host_info = pulp::format::detect_host_info();
+        _bridge.host_quirks =
+            pulp::format::resolved_quirks(host_info.type, host_info.version);
+    }
+
     // Item 3.1 — auto-detect a plugin-declared Bypass parameter so the
     // host's `shouldBypassEffect` AUValue and the plugin's
     // automatable parameter stay in lockstep. Match the same heuristic
@@ -333,8 +348,11 @@ static int32_t block_relative_sample_offset(AUEventSampleTime event_sample_time,
 
 - (NSTimeInterval)latency {
     if (!_bridge.processor) return 0.0;
-    int samples = _bridge.processor->latency_samples();
-    return samples > 0 ? static_cast<double>(samples) / _bridge.sample_rate : 0.0;
+    // clamp_latency_to_nonneg (host-quirks P3): route the existing clamp
+    // through the quirk so PULP_HOST_QUIRKS=off reports raw latency too.
+    int samples = pulp::format::reported_latency_samples(
+        _bridge.processor->latency_samples(), _bridge.host_quirks);
+    return _bridge.sample_rate > 0 ? static_cast<double>(samples) / _bridge.sample_rate : 0.0;
 }
 
 - (NSTimeInterval)tailTime {

--- a/core/format/src/au_v2_adapter.cpp
+++ b/core/format/src/au_v2_adapter.cpp
@@ -75,6 +75,11 @@ PulpAUEffect::PulpAUEffect(AudioComponentInstance ci)
             processor_->set_state_store(&store_);
             processor_->define_parameters(store_);
 
+            // Resolve host accommodations once (host-quirks plan, P3) via
+            // the runtime policy (PULP_HOST_QUIRKS env / API).
+            const auto host_info = detect_host_info();
+            host_quirks_ = resolved_quirks(host_info.type, host_info.version);
+
             // Wire gesture callbacks for undo grouping support.
             store_.set_gesture_callbacks(
                 [this](state::ParamID id) {
@@ -546,8 +551,10 @@ Float64 PulpAUEffect::GetTailTime()
 Float64 PulpAUEffect::GetLatency()
 {
     if (!processor_) return 0.0;
-    int latency = processor_->latency_samples();
-    return latency > 0 ? static_cast<Float64>(latency) / GetSampleRate() : 0.0;
+    // clamp_latency_to_nonneg (host-quirks P3): route the existing clamp
+    // through the quirk so PULP_HOST_QUIRKS=off reports raw latency too.
+    int latency = reported_latency_samples(processor_->latency_samples(), host_quirks_);
+    return GetSampleRate() > 0 ? static_cast<Float64>(latency) / GetSampleRate() : 0.0;
 }
 
 } // namespace pulp::format::au

--- a/core/format/src/clap_adapter.cpp
+++ b/core/format/src/clap_adapter.cpp
@@ -45,6 +45,13 @@ bool clap_init(const clap_plugin_t* plugin) {
     self->processor->set_state_store(&self->store);
     self->processor->define_parameters(self->store);
 
+    // Resolve host accommodations once (host-quirks plan, P3) via the
+    // runtime policy (PULP_HOST_QUIRKS env / set_host_quirk_policy API).
+    {
+        const auto host_info = detect_host_info();
+        self->host_quirks = resolved_quirks(host_info.type, host_info.version);
+    }
+
     // Item 6.4b — opt this plugin instance into the process-wide
     // MainThreadDispatcher backend. On macOS this installs (or refcount-
     // bumps) a Cocoa backend posting to `dispatch_get_main_queue`, so any

--- a/core/format/src/vst3_adapter.cpp
+++ b/core/format/src/vst3_adapter.cpp
@@ -61,6 +61,16 @@ tresult PLUGIN_API PulpVst3Processor::initialize(FUnknown* context) {
     processor_ = factory_();
     if (!processor_) return kInternalError;
 
+    // Resolve host accommodations once (host-quirks plan, P3). Cross-host
+    // cheap defenses (e.g. clamp_latency_to_nonneg) fire regardless of the
+    // detected DAW; host-specific quirks key off the detected host. The
+    // runtime policy (PULP_HOST_QUIRKS env / set_host_quirk_policy API)
+    // applies here via resolved_quirks().
+    {
+        const auto host_info = detect_host_info();
+        quirks_ = resolved_quirks(host_info.type, host_info.version);
+    }
+
     auto desc = processor_->descriptor();
     processor_->set_state_store(&store_);
     processor_->define_parameters(store_);
@@ -280,7 +290,12 @@ tresult PLUGIN_API PulpVst3Processor::setActive(TBool state) {
 
 uint32 PLUGIN_API PulpVst3Processor::getLatencySamples() {
     if (!processor_) return 0;
-    return static_cast<uint32>(processor_->latency_samples());
+    // clamp_latency_to_nonneg (host-quirks P3): VST3 reports latency as
+    // unsigned, so a negative latency_samples() would wrap to a huge value
+    // without the clamp. When the quirk is filtered out (PULP_HOST_QUIRKS=
+    // off) the raw value passes through.
+    return static_cast<uint32>(
+        reported_latency_samples(processor_->latency_samples(), quirks_));
 }
 
 uint32 PLUGIN_API PulpVst3Processor::getTailSamples() {

--- a/docs/reference/host-quirks-policy.md
+++ b/docs/reference/host-quirks-policy.md
@@ -122,6 +122,17 @@ call them from the audio thread.
 `resolve_quirk_policy()` returns the effective base filter together with
 its `QuirkPolicySource` (compile default / env / API) for diagnostics.
 
+### Adapter consumption (enforcement status)
+
+The format adapters cache `resolved_quirks(detect_host_info()...)` once at
+init and gate accommodations on the flags. As of P3a, the first wired flag
+is **`clamp_latency_to_nonneg`** — VST3 / CLAP / AU v2 / AU v3 route latency
+reporting through `reported_latency_samples()`, so a negative
+`latency_samples()` clamps to 0 by default and reports raw under
+`PULP_HOST_QUIRKS=off`. Remaining flags are wired incrementally, one PR per
+quirk, each with its own validation — a flag is only meaningfully
+`Validated` once an adapter consumes it under test.
+
 ### Inspecting the live policy: `pulp doctor`
 
 ```text

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1817,6 +1817,17 @@ if(PULP_HAS_CLAP)
     target_link_libraries(pulp-test-clap-host-validation PRIVATE pulp::format clap Catch2::Catch2WithMain)
     target_compile_definitions(pulp-test-clap-host-validation PRIVATE PULP_CLAP_GUI=1)
     catch_discover_tests(pulp-test-clap-host-validation)
+
+    # host-quirks P3a — empirical proof the CLAP adapter respects
+    # clamp_latency_to_nonneg end-to-end (negative latency → 0 when the
+    # quirk is enforced, raw-wrapped when PULP_HOST_QUIRKS=off). Drives the
+    # adapter through its public header surface (init() caches the resolved
+    # quirks), so link-only — no clap_adapter.cpp re-compile, keeping the
+    # diff-cover TU attribution single (same rationale as the MIDI test).
+    add_executable(pulp-test-clap-latency-quirk test_clap_latency_quirk.cpp)
+    target_link_libraries(pulp-test-clap-latency-quirk PRIVATE pulp::format clap Catch2::Catch2WithMain)
+    target_compile_definitions(pulp-test-clap-latency-quirk PRIVATE PULP_CLAP_GUI=1)
+    catch_discover_tests(pulp-test-clap-latency-quirk)
 endif()
 
 if(PULP_HAS_VST3)

--- a/test/test_clap_latency_quirk.cpp
+++ b/test/test_clap_latency_quirk.cpp
@@ -1,0 +1,115 @@
+// test_clap_latency_quirk.cpp — empirical proof that the CLAP adapter
+// actually RESPECTS the `clamp_latency_to_nonneg` host-quirk end-to-end
+// (host-quirks enforcement plan, P3a).
+//
+// The unit tests in test_host_quirks.cpp prove the helper logic + runtime
+// policy in isolation. This test drives the *real* CLAP adapter through
+// the clap_plugin_latency extension with a processor that reports a
+// negative latency, and asserts the host-visible value:
+//   * quirk enforced (default policy)         → clamped to 0
+//   * quirk disabled (PULP_HOST_QUIRKS=off)   → raw value wraps (unsigned)
+// proving the adapter consults the quirk rather than hardcoding behavior.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/format/clap_entry.hpp>
+#include <pulp/format/host_quirks.hpp>
+#include <pulp/format/processor.hpp>
+#include <pulp/state/store.hpp>
+
+#include <clap/clap.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+
+using namespace pulp;
+using namespace pulp::format;
+
+namespace {
+
+constexpr const char* kPluginId = "com.pulp.test.latency-quirk";
+
+// Pathological processor: reports a negative latency so the clamp is
+// observable. CLAP reports latency as uint32, so the raw value wraps when
+// the quirk is filtered out.
+class NegativeLatencyProcessor : public Processor {
+public:
+    static constexpr int kRawLatency = -64;
+
+    PluginDescriptor descriptor() const override {
+        PluginDescriptor d;
+        d.name = "PulpLatencyQuirk";
+        d.manufacturer = "PulpTest";
+        d.bundle_id = kPluginId;
+        d.version = "1.0.0";
+        d.category = PluginCategory::Effect;
+        d.input_buses = {{"Audio In", 2}};
+        d.output_buses = {{"Audio Out", 2}};
+        d.accepts_midi = false;
+        d.tail_samples = 0;
+        return d;
+    }
+    void define_parameters(state::StateStore&) override {}
+    void prepare(const PrepareContext&) override {}
+    void process(audio::BufferView<float>&,
+                 const audio::BufferView<const float>&,
+                 midi::MidiBuffer&, midi::MidiBuffer&,
+                 const ProcessContext&) override {}
+    int latency_samples() const override { return kRawLatency; }
+};
+
+std::unique_ptr<Processor> make_negative_latency() {
+    return std::make_unique<NegativeLatencyProcessor>();
+}
+
+}  // namespace
+
+PULP_CLAP_PLUGIN(make_negative_latency)
+
+namespace {
+
+// Create + init a fresh plugin instance (init() is where the adapter
+// caches resolved_quirks()), read its host-reported latency via the CLAP
+// latency extension, then destroy it. Set the desired policy BEFORE
+// calling this so the cached quirks reflect it.
+uint32_t adapter_reported_latency() {
+    auto* factory = static_cast<const clap_plugin_factory_t*>(
+        clap_entry.get_factory(CLAP_PLUGIN_FACTORY_ID));
+    REQUIRE(factory != nullptr);
+    auto* desc = factory->get_plugin_descriptor(factory, 0);
+    REQUIRE(desc != nullptr);
+    const clap_plugin_t* p = factory->create_plugin(factory, nullptr, desc->id);
+    REQUIRE(p != nullptr);
+    REQUIRE(p->init(p));  // caches resolved_quirks() under the current policy
+    auto* latency = static_cast<const clap_plugin_latency_t*>(
+        p->get_extension(p, CLAP_EXT_LATENCY));
+    REQUIRE(latency != nullptr);
+    const uint32_t reported = latency->get(p);
+    p->destroy(p);
+    return reported;
+}
+
+}  // namespace
+
+TEST_CASE("CLAP adapter respects clamp_latency_to_nonneg end-to-end",
+          "[format][host-quirks][p3][clap][latency]") {
+    REQUIRE(clap_entry.init("test"));
+    clap_generic::init_descriptor();
+    set_host_quirk_policy(std::nullopt);
+    clear_quirk_overrides();
+
+    SECTION("enforced policy clamps the processor's negative latency to 0") {
+        set_host_quirk_policy(QuirkFilter{});  // all tiers — clamp is Validated
+        REQUIRE(adapter_reported_latency() == 0u);
+    }
+
+    SECTION("PULP_HOST_QUIRKS=off lets the raw negative latency wrap through") {
+        set_host_quirk_policy(kQuirkFilterOff);
+        REQUIRE(adapter_reported_latency()
+                == static_cast<uint32_t>(NegativeLatencyProcessor::kRawLatency));
+    }
+
+    set_host_quirk_policy(std::nullopt);
+    clap_entry.deinit();
+}

--- a/test/test_host_quirks.cpp
+++ b/test/test_host_quirks.cpp
@@ -1392,3 +1392,38 @@ TEST_CASE("enumerate_quirk_fields enforced reflects the int channel-probe cap",
     REQUIRE(cap2 != nullptr);
     REQUIRE(cap2->enforced == false);  // default 64 → not enforced
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// P3: clamp_latency_to_nonneg enforcement — the accommodation helper that
+// the VST3 / CLAP / AU adapters consume. (2026-05-30 enforcement goal)
+// ─────────────────────────────────────────────────────────────────────
+
+TEST_CASE("reported_latency_samples clamps negatives only when the quirk is on",
+          "[format][host-quirks][p3][latency]") {
+    HostQuirks on;  // default-constructed: clamp_latency_to_nonneg == true
+    REQUIRE(on.clamp_latency_to_nonneg == true);
+    REQUIRE(pulp::format::reported_latency_samples(-5, on) == 0);
+    REQUIRE(pulp::format::reported_latency_samples(0, on) == 0);
+    REQUIRE(pulp::format::reported_latency_samples(128, on) == 128);
+
+    HostQuirks off = on;
+    off.clamp_latency_to_nonneg = false;
+    REQUIRE(pulp::format::reported_latency_samples(-5, off) == -5);  // raw through
+    REQUIRE(pulp::format::reported_latency_samples(128, off) == 128);
+}
+
+TEST_CASE("latency clamp follows the runtime policy via resolved_quirks",
+          "[format][host-quirks][p3][latency][runtime-policy]") {
+    QuirkPolicyGuard guard;
+    // Enforced under the 'all' policy (clamp_latency is Validated)...
+    pulp::format::set_host_quirk_policy(pulp::format::QuirkFilter{});
+    auto on = pulp::format::resolved_quirks(HostType::Reaper, HostVersion{7, 0});
+    REQUIRE(on.clamp_latency_to_nonneg == true);
+    REQUIRE(pulp::format::reported_latency_samples(-7, on) == 0);
+
+    // ...and disabled when the user opts out via PULP_HOST_QUIRKS=off.
+    pulp::format::set_host_quirk_policy(pulp::format::kQuirkFilterOff);
+    auto off = pulp::format::resolved_quirks(HostType::Reaper, HostVersion{7, 0});
+    REQUIRE(off.clamp_latency_to_nonneg == false);
+    REQUIRE(pulp::format::reported_latency_samples(-7, off) == -7);  // raw reported
+}


### PR DESCRIPTION
Make the host-quirks ledger actually drive adapter behavior (host-quirks
enforcement plan, P3). Until now no adapter consumed the ledger — the
cheap-defense flags were descriptive only, and the latency clamp existed
hardcoded in AU but was MISSING in VST3/CLAP (raw int→uint32 wrap on a
negative latency).

This wires the first flag end-to-end and builds the reusable infra:

- Each adapter (VST3 initialize / CLAP clap_init / AU v3
  initWithComponentDescription / AU v2 ctor) caches
  resolved_quirks(detect_host_info()...) once at init. The runtime policy
  (PULP_HOST_QUIRKS env / set_host_quirk_policy API / compile default)
  applies via resolved_quirks(), so users can dial accommodations without
  recompiling.
- New pure helper reported_latency_samples(raw, quirks) in host_quirks.hpp;
  every adapter's latency-report site routes through it. Negative latency
  clamps to 0 when clamp_latency_to_nonneg is enforced (default), passes
  raw through under PULP_HOST_QUIRKS=off.

Validation (the quirk is genuinely respected when enabled):
- Unit: reported_latency_samples on/off/positive + runtime-policy gating
  through resolved_quirks ([p3], test_host_quirks.cpp).
- Empirical end-to-end: test_clap_latency_quirk.cpp drives the REAL CLAP
  adapter via the latency extension with a processor reporting -64 →
  reports 0 when enforced, 4294967232 (wrapped) under PULP_HOST_QUIRKS=off.
- No regression: clap entry/host-validation/midi (583 assertions), VST3 +
  AU v2 + AU v3 plugin-state/effect tests all green.

AU v3 note: au_adapter.mm @implementation bodies are at file scope, so the
namespace free functions are called qualified (pulp::format::...). The core
lib doesn't compile that .mm, so the AU target/test is the only build that
catches such errors.

Default policy stays 'all' here (clamp_latency is Validated → identical
under all/validated-only); the validated-only default flip lands separately
once a Speculative quirk is wired. See
planning/2026-05-30-host-quirks-enforcement-goal.md.

Skill-Update: skip skill=view-bridge reason="au_adapter.mm change is host-quirks latency wiring, unrelated to editor attach/resize lifecycle which view-bridge documents"
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>