### PR TITLE
refactor(figma-plugin): P2 — split pure helpers out of extract.ts → extract-pure.ts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.146.0",
+      "version": "0.146.1",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.146.0"
+  "version": "0.146.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.146.0",
+  "version": "0.146.1",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.293.0
+    VERSION 0.293.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/tools/figma-plugin/src/code.tsconfig.json
+++ b/tools/figma-plugin/src/code.tsconfig.json
@@ -13,5 +13,5 @@
     "resolveJsonModule": true,
     "rootDir": ".."
   },
-  "include": ["code.ts", "types.ts", "extract.ts", "extract-model.ts", "serialize.ts", "assets.ts", "tokens.ts", "library-registry.ts", "../library-manifest.json"]
+  "include": ["code.ts", "types.ts", "extract.ts", "extract-pure.ts", "extract-model.ts", "serialize.ts", "assets.ts", "tokens.ts", "library-registry.ts", "../library-manifest.json"]
 }

--- a/tools/figma-plugin/src/extract-pure.ts
+++ b/tools/figma-plugin/src/extract-pure.ts
@@ -1,0 +1,209 @@
+// Pure, host-neutral helpers split out of `extract.ts` (P2 — see
+// planning/figma-import-coordination-log.md 22:50Z roadmap).
+//
+// Every function here operates on types only (SceneNode shape, RGBA,
+// Paint, GradientPaint, FrameNode axis enums) — no `await
+// figma.X.Async()`, no `getBytesAsync`, no `exportAsync`. Anything
+// pulling bytes through the Figma Plugin API stays in `extract.ts`.
+//
+// **Why split this out:** the extractor has two real consumers — the
+// UI plugin (`code.ts`) and the headless bundle (`headless.ts`) — and
+// a structural neighbour, Agent A's Python REST port at
+// `tools/import-design/figma_rest_export.py`, which mirrors these
+// helpers field-for-field. Co-locating the pure logic makes drift
+// between the two language ports visible in one file and reduces the
+// surface area future provider abstractions (`NodeProvider`,
+// `AssetProvider`, etc.) have to thread through.
+//
+// **No behaviour change.** Functions kept verbatim; only `export`
+// added so `extract.ts` can re-import them.
+
+import type { ExtractedFigmaNode, ExtractedLayout } from "./extract-model";
+import type { AudioWidgetKind } from "./extract-model";
+import type { FontFamilyAsset } from "./extract";
+
+// ──────────────────────────────────────────────────────────────────────────
+// Color helpers — convert Figma Paint / RGBA shapes into CSS strings.
+
+export function paintToColor(p: SolidPaint): string {
+  const c = p.color;
+  const a = p.opacity !== undefined ? p.opacity : 1;
+  const r = Math.round(c.r * 255);
+  const g = Math.round(c.g * 255);
+  const b = Math.round(c.b * 255);
+  if (a >= 1) return `#${hex2(r)}${hex2(g)}${hex2(b)}`;
+  return `rgba(${r}, ${g}, ${b}, ${a.toFixed(3)})`;
+}
+
+export function rgbaToCss(c: RGBA): string {
+  const r = Math.round(c.r * 255);
+  const g = Math.round(c.g * 255);
+  const b = Math.round(c.b * 255);
+  if (c.a === undefined || c.a >= 1) {
+    return `#${hex2(r)}${hex2(g)}${hex2(b)}`;
+  }
+  return `rgba(${r}, ${g}, ${b}, ${c.a.toFixed(3)})`;
+}
+
+export function hex2(n: number): string {
+  return n.toString(16).padStart(2, "0");
+}
+
+export function gradientToCss(p: GradientPaint): string {
+  if (!p.gradientStops || p.gradientStops.length === 0) return "linear-gradient(transparent, transparent)";
+  // Pulp's setBackgroundGradient bridge takes color stop positions implicitly by
+  // index, and its parseColor doesn't strip trailing `Npc%` from a token.
+  // Emit colors only (no inline percentages).
+  const stops = p.gradientStops.map((s) => rgbaToCss(s.color)).join(", ");
+  return `linear-gradient(to bottom, ${stops})`;
+}
+
+export function gradientFallbackFlat(p: GradientPaint): string {
+  const first = p.gradientStops?.[0]?.color;
+  if (!first) return "transparent";
+  return rgbaToCss(first);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Type and layout mapping — Plugin API enums → envelope strings.
+
+export function mapNodeType(n: SceneNode): string {
+  switch (n.type) {
+    case "FRAME":
+    case "GROUP":
+    case "SECTION":
+      return "frame";
+    case "COMPONENT":
+    case "COMPONENT_SET":
+      return "frame"; // Phase 3 will promote recognized instances to widget kinds
+    case "INSTANCE":
+      return "frame"; // ditto
+    case "TEXT":
+      return "text";
+    case "RECTANGLE":
+    case "ELLIPSE":
+    case "POLYGON":
+    case "STAR":
+    case "LINE":
+      return "frame";
+    case "VECTOR":
+    case "BOOLEAN_OPERATION":
+      return "vector";
+    case "SLICE":
+      return "frame";
+    default:
+      return "frame";
+  }
+}
+
+export function mapPrimaryAxisAlign(v: FrameNode["primaryAxisAlignItems"]): ExtractedLayout["justify"] {
+  switch (v) {
+    case "MIN": return "flex_start";
+    case "MAX": return "flex_end";
+    case "CENTER": return "center";
+    case "SPACE_BETWEEN": return "space_between";
+    default: return "flex_start";
+  }
+}
+
+export function mapCounterAxisAlign(v: FrameNode["counterAxisAlignItems"]): ExtractedLayout["align"] {
+  switch (v) {
+    case "MIN": return "flex_start";
+    case "MAX": return "flex_end";
+    case "CENTER": return "center";
+    case "BASELINE": return "flex_start"; // Pulp Yoga doesn't model baseline; closest fallback
+    default: return "stretch";
+  }
+}
+
+export function mapAxisSize(v: FrameNode["layoutSizingHorizontal"]): ExtractedLayout["width_mode"] {
+  switch (v) {
+    case "HUG": return "hug";
+    case "FILL": return "fill";
+    case "FIXED":
+    default: return "fixed";
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Library recognition fallback — name-based heuristic when the
+// component_set_key match doesn't hit (e.g. unpublished local
+// components, or designs that use the audio widget visual without
+// installing the published library).
+
+export function audioWidgetKindFromName(name: string): AudioWidgetKind | undefined {
+  const lower = name.toLowerCase();
+  if (lower.includes("knob") || lower.includes("dial")) return "knob";
+  if (lower.includes("fader") || lower.includes("slider")) return "fader";
+  if (lower.includes("meter") || lower.includes("level") || lower.includes("vu")) return "meter";
+  if (lower.includes("xypad") || lower.includes("xy_pad") || lower.includes("xy-pad")) return "xy_pad";
+  if (lower.includes("waveform")) return "waveform";
+  if (lower.includes("spectrum")) return "spectrum";
+  return undefined;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Vector-illustration detection — heuristic, used to flatten an entire
+// shape illustration frame to a single SVG export instead of walking
+// each primitive. Recursive but bounded by tree depth.
+
+/// Returns true if the node and all its recursive descendants are
+/// vector-like primitives (or empty frames wrapping them).
+export function isPureVectorIllustration(node: SceneNode): boolean {
+  if (!("children" in node)) return false;
+  const children = (node as ChildrenMixin).children;
+  if (children.length === 0) return false;
+  for (const child of children) {
+    const t = child.type;
+    if (
+      t === "VECTOR" ||
+      t === "BOOLEAN_OPERATION" ||
+      t === "LINE" ||
+      t === "STAR" ||
+      t === "POLYGON" ||
+      t === "ELLIPSE" ||
+      t === "RECTANGLE"
+    ) {
+      continue;
+    }
+    if (t === "FRAME" || t === "GROUP") {
+      if (!isPureVectorIllustration(child)) return false;
+      continue;
+    }
+    // text, instance, image, anything else → not a pure illustration
+    return false;
+  }
+  return true;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Font catalogue — walks the post-extraction IR (not the Figma scene),
+// so it's already host-neutral and operates only on ExtractedFigmaNode
+// trees. Emitted as the envelope's top-level `font_family_assets` per
+// #43a-rev.
+
+export function collectFontFamilyAssets(roots: ExtractedFigmaNode[]): FontFamilyAsset[] {
+  const seen = new Map<string, FontFamilyAsset>();
+  function visit(n: ExtractedFigmaNode): void {
+    const family = n.style.font_family;
+    if (family) {
+      // Figma's `fontName.style` (already captured by extractTextStyle)
+      // lives on `style.font_style` as either "normal" or "italic" today;
+      // the verbose style string ("Semi Bold", "Bold Italic") is not yet
+      // surfaced. Emit what we have and let the runtime resolve.
+      const styleField = (n.style.font_style as string | undefined) ?? "Regular";
+      const weight = n.style.font_weight;
+      const italic = styleField === "italic" || /italic/i.test(styleField);
+      const key = `${family}|${styleField}|${weight ?? ""}|${italic ? "i" : ""}`;
+      if (!seen.has(key)) {
+        const row: FontFamilyAsset = { family, style: styleField };
+        if (typeof weight === "number") row.weight = weight;
+        if (italic) row.italic = true;
+        seen.set(key, row);
+      }
+    }
+    for (const c of n.children) visit(c);
+  }
+  for (const r of roots) visit(r);
+  return Array.from(seen.values());
+}

--- a/tools/figma-plugin/src/extract.ts
+++ b/tools/figma-plugin/src/extract.ts
@@ -24,6 +24,21 @@ import {
   widgetKindByNamePrefix,
   LIBRARY_VERSION,
 } from "./library-registry";
+// P2 — pure, host-neutral helpers split for clarity + maintainability.
+// Behaviour-unchanged from when these lived inline here.
+import {
+  paintToColor,
+  rgbaToCss,
+  gradientToCss,
+  gradientFallbackFlat,
+  mapNodeType,
+  mapPrimaryAxisAlign,
+  mapCounterAxisAlign,
+  mapAxisSize,
+  audioWidgetKindFromName,
+  isPureVectorIllustration,
+  collectFontFamilyAssets,
+} from "./extract-pure";
 
 // ──────────────────────────────────────────────────────────────────────────
 // Public entry point
@@ -130,31 +145,8 @@ export async function extractScene(
 /// Order is stable: families appear in first-encounter order, styles
 /// within a family in first-encounter order. That stability matters for
 /// snapshot tests that compare envelope output.
-function collectFontFamilyAssets(roots: ExtractedFigmaNode[]): FontFamilyAsset[] {
-  const seen = new Map<string, FontFamilyAsset>();
-  function visit(n: ExtractedFigmaNode): void {
-    const family = n.style.font_family;
-    if (family) {
-      // Figma's `fontName.style` (already captured by extractTextStyle)
-      // lives on `style.font_style` as either "normal" or "italic" today;
-      // the verbose style string ("Semi Bold", "Bold Italic") is not yet
-      // surfaced. Emit what we have and let the runtime resolve.
-      const styleField = (n.style.font_style as string | undefined) ?? "Regular";
-      const weight = n.style.font_weight;
-      const italic = styleField === "italic" || /italic/i.test(styleField);
-      const key = `${family}|${styleField}|${weight ?? ""}|${italic ? "i" : ""}`;
-      if (!seen.has(key)) {
-        const row: FontFamilyAsset = { family, style: styleField };
-        if (typeof weight === "number") row.weight = weight;
-        if (italic) row.italic = true;
-        seen.set(key, row);
-      }
-    }
-    for (const c of n.children) visit(c);
-  }
-  for (const r of roots) visit(r);
-  return Array.from(seen.values());
-}
+// `collectFontFamilyAssets` moved to ./extract-pure.ts (P2). Behaviour-identical;
+// imported above. Kept the call site in `extractScene` unchanged.
 
 // ──────────────────────────────────────────────────────────────────────────
 // Internal walker
@@ -396,34 +388,7 @@ async function walk(
 // ──────────────────────────────────────────────────────────────────────────
 // Type mapping
 
-function mapNodeType(n: SceneNode): string {
-  switch (n.type) {
-    case "FRAME":
-    case "GROUP":
-    case "SECTION":
-      return "frame";
-    case "COMPONENT":
-    case "COMPONENT_SET":
-      return "frame"; // Phase 3 will promote recognized instances to widget kinds
-    case "INSTANCE":
-      return "frame"; // ditto
-    case "TEXT":
-      return "text";
-    case "RECTANGLE":
-    case "ELLIPSE":
-    case "POLYGON":
-    case "STAR":
-    case "LINE":
-      return "frame";
-    case "VECTOR":
-    case "BOOLEAN_OPERATION":
-      return "vector";
-    case "SLICE":
-      return "frame";
-    default:
-      return "frame";
-  }
-}
+// `mapNodeType` moved to ./extract-pure.ts (P2). Behaviour-identical.
 
 // ──────────────────────────────────────────────────────────────────────────
 // Geometry
@@ -687,76 +652,9 @@ function extractLayout(n: SceneNode, ctx: WalkCtx): ExtractedLayout {
   return l;
 }
 
-function mapPrimaryAxisAlign(v: FrameNode["primaryAxisAlignItems"]): ExtractedLayout["justify"] {
-  switch (v) {
-    case "MIN": return "flex_start";
-    case "MAX": return "flex_end";
-    case "CENTER": return "center";
-    case "SPACE_BETWEEN": return "space_between";
-    default: return "flex_start";
-  }
-}
-
-function mapCounterAxisAlign(v: FrameNode["counterAxisAlignItems"]): ExtractedLayout["align"] {
-  switch (v) {
-    case "MIN": return "flex_start";
-    case "MAX": return "flex_end";
-    case "CENTER": return "center";
-    case "BASELINE": return "flex_start"; // Pulp Yoga doesn't model baseline; closest fallback
-    default: return "stretch";
-  }
-}
-
-function mapAxisSize(v: FrameNode["layoutSizingHorizontal"]): ExtractedLayout["width_mode"] {
-  switch (v) {
-    case "HUG": return "hug";
-    case "FILL": return "fill";
-    case "FIXED":
-    default: return "fixed";
-  }
-}
-
-// ──────────────────────────────────────────────────────────────────────────
-// Color helpers
-
-function paintToColor(p: SolidPaint): string {
-  const c = p.color;
-  const a = p.opacity !== undefined ? p.opacity : 1;
-  const r = Math.round(c.r * 255);
-  const g = Math.round(c.g * 255);
-  const b = Math.round(c.b * 255);
-  if (a >= 1) return `#${hex2(r)}${hex2(g)}${hex2(b)}`;
-  return `rgba(${r}, ${g}, ${b}, ${a.toFixed(3)})`;
-}
-
-function rgbaToCss(c: RGBA): string {
-  const r = Math.round(c.r * 255);
-  const g = Math.round(c.g * 255);
-  const b = Math.round(c.b * 255);
-  if (c.a === undefined || c.a >= 1) {
-    return `#${hex2(r)}${hex2(g)}${hex2(b)}`;
-  }
-  return `rgba(${r}, ${g}, ${b}, ${c.a.toFixed(3)})`;
-}
-
-function hex2(n: number): string {
-  return n.toString(16).padStart(2, "0");
-}
-
-function gradientToCss(p: GradientPaint): string {
-  if (!p.gradientStops || p.gradientStops.length === 0) return "linear-gradient(transparent, transparent)";
-  // Pulp's setBackgroundGradient bridge takes color stop positions implicitly by
-  // index, and its parseColor doesn't strip trailing `Npc%` from a token.
-  // Emit colors only (no inline percentages).
-  const stops = p.gradientStops.map((s) => rgbaToCss(s.color)).join(", ");
-  return `linear-gradient(to bottom, ${stops})`;
-}
-
-function gradientFallbackFlat(p: GradientPaint): string {
-  const first = p.gradientStops?.[0]?.color;
-  if (!first) return "transparent";
-  return rgbaToCss(first);
-}
+// `mapPrimaryAxisAlign`, `mapCounterAxisAlign`, `mapAxisSize`, `paintToColor`,
+// `rgbaToCss`, `hex2`, `gradientToCss`, `gradientFallbackFlat` all moved to
+// ./extract-pure.ts (P2). Behaviour-identical.
 
 // ──────────────────────────────────────────────────────────────────────────
 // Diagnostic helpers
@@ -827,46 +725,8 @@ function extractAudioPropsFromComponentProperties(
 /// Detect audio widget kind from an instance's main-component name. Used
 /// to flatten widget instances to a PNG skin (Track A2). Patterns match
 /// Pulp's IR-side detect_audio_widget() (core/view/src/design_import.cpp).
-function audioWidgetKindFromName(name: string): import("./extract-model").AudioWidgetKind | undefined {
-  const lower = name.toLowerCase();
-  if (lower.includes("knob") || lower.includes("dial")) return "knob";
-  if (lower.includes("fader") || lower.includes("slider")) return "fader";
-  if (lower.includes("meter") || lower.includes("level") || lower.includes("vu")) return "meter";
-  if (lower.includes("xypad") || lower.includes("xy_pad") || lower.includes("xy-pad")) return "xy_pad";
-  if (lower.includes("waveform")) return "waveform";
-  if (lower.includes("spectrum")) return "spectrum";
-  return undefined;
-}
-
-/// Heuristic: returns true if the node and all its recursive descendants are
-/// vector-like primitives (or empty frames wrapping them). Used to detect
-/// "shape illustration" frames that should export as a single SVG.
-function isPureVectorIllustration(node: SceneNode): boolean {
-  if (!("children" in node)) return false;
-  const children = (node as ChildrenMixin).children;
-  if (children.length === 0) return false;
-  for (const child of children) {
-    const t = child.type;
-    if (
-      t === "VECTOR" ||
-      t === "BOOLEAN_OPERATION" ||
-      t === "LINE" ||
-      t === "STAR" ||
-      t === "POLYGON" ||
-      t === "ELLIPSE" ||
-      t === "RECTANGLE"
-    ) {
-      continue;
-    }
-    if (t === "FRAME" || t === "GROUP") {
-      if (!isPureVectorIllustration(child)) return false;
-      continue;
-    }
-    // text, instance, image, anything else → not a pure illustration
-    return false;
-  }
-  return true;
-}
+// `audioWidgetKindFromName` and `isPureVectorIllustration` moved to
+// ./extract-pure.ts (P2). Behaviour-identical.
 
 // ──────────────────────────────────────────────────────────────────────────
 // Instance metadata capture (Phase 2a slice 2)

--- a/tools/figma-plugin/src/headless.tsconfig.json
+++ b/tools/figma-plugin/src/headless.tsconfig.json
@@ -13,5 +13,5 @@
     "resolveJsonModule": true,
     "rootDir": ".."
   },
-  "include": ["headless.ts", "types.ts", "extract.ts", "extract-model.ts", "serialize.ts", "assets.ts", "tokens.ts", "library-registry.ts", "user-fonts.ts", "../library-manifest.json"]
+  "include": ["headless.ts", "types.ts", "extract.ts", "extract-pure.ts", "extract-model.ts", "serialize.ts", "assets.ts", "tokens.ts", "library-registry.ts", "user-fonts.ts", "../library-manifest.json"]
 }


### PR DESCRIPTION
# refactor(figma-plugin): P2 — split pure helpers out of `extract.ts` → `extract-pure.ts`

## Summary

Pure mechanical refactor — **no behaviour change.** Moves 12 leaf helpers from `extract.ts` (which had grown to 928 lines mixing pure helpers with async Plugin API surface) into a new `src/extract-pure.ts`. The async Plugin API consumers (`extractScene`, `walk`, `captureInstanceMetadata`) stay in `extract.ts`.

Roadmap: P1 (`#3227` headless MCP bridge) + P3-alt (envelope conformance test + diff tool in `planning/fixtures/figma-plugin/conformance/`) shipped earlier; this is **P2** — the cleanest of the three to land last because P3-alt is now in place to catch any drift between the plugin's headless bundle and Agent A's Python REST port at `tools/import-design/figma_rest_export.py`.

## Helpers moved

| Category | Functions |
|---|---|
| Color | `paintToColor`, `rgbaToCss`, `hex2`, `gradientToCss`, `gradientFallbackFlat` |
| Type / layout mapping | `mapNodeType`, `mapPrimaryAxisAlign`, `mapCounterAxisAlign`, `mapAxisSize` |
| Library recognition fallback | `audioWidgetKindFromName` |
| Vector heuristic | `isPureVectorIllustration` |
| Font catalogue | `collectFontFamilyAssets` |

All twelve are leaf functions operating on type-level Plugin API shapes (`SceneNode`, `RGBA`, `Paint`, `GradientPaint`, `FrameNode` axis enums) — no `await figma.X.Async()`, no `getBytesAsync`, no `exportAsync`.

## Sizes

| File | Before | After |
|---|---|---|
| `src/extract.ts` | 928 lines | 788 lines (−140, −15%) |
| `src/extract-pure.ts` | — | 209 lines (new) |
| `dist/headless.js` bundle | 25 240 bytes | 25 265 bytes (+25 bytes — ESM import overhead under esbuild minify; well under the 50 KB MCP cap) |

## tsconfig wiring

`code.tsconfig.json` + `headless.tsconfig.json` updated to include `extract-pure.ts`. `ui.tsconfig.json` is unchanged — UI doesn't import extract.

## Verification (CLAUDE.md "tests ship with fixes")

```
$ npm run typecheck         # clean (all three entries)
$ npm run build             # clean. Headless 25 265 bytes (24 735 headroom).
$ npm test                  # 16/16 pass (no regression)
```

The conformance gate from P3-alt (`planning/fixtures/figma-plugin/conformance/diff_envelopes.py`) will catch any silent behaviour drift on the next re-capture cycle — confidence-multiplier for landing this refactor.

## Why we stopped here (P2-lite, not full provider facade)

The original Codex recommendation for P2 was a full `NodeProvider` / `AssetProvider` / `FontProvider` / `ComponentRegistryProvider` facade. The honest cost/benefit after P3-alt landed:

- Agent A's Python REST port doesn't share TS code (different language), so the facade doesn't help cross-language reuse.
- The only TS consumers are `code.ts` (UI plugin) and `headless.ts` (headless bundle), both bound to the Plugin API. They don't need swappable providers.
- Provider abstraction is the right move IF/WHEN a second TS consumer appears (e.g. a TS REST adapter, which is currently deferred — Agent A's Python port subsumes that need).

This PR delivers the **structural win** (extract.ts shrinks 15%, pure logic is co-located and easy to mirror in the Python port) without paying the cost of an abstraction with no current consumer. Filed in my head for a future "we have two TS consumers that want different providers" trigger.

## Version bumps

- SDK (`CMakeLists.txt`) 0.293.0 → **0.293.1** (patch; refactor)
- Claude plugin (`.claude-plugin/`) 0.146.0 → **0.146.1** (patch; refactor)

Strictly optional since `refactor:` PR titles don't require a bump marker — kept for consistency with previous P1 release cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)