### PR TITLE
docs(import-design): codify pulp-screenshot (decodes images) vs --validate (layout-only)

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -1078,8 +1078,21 @@ After generating Pulp code, ALWAYS validate by comparing with the source design:
 
 2. **Render the generated JS** headlessly:
    ```bash
-   pulp-screenshot --script generated.js --output render.png --width W --height H
+   pulp-screenshot --script generated.js --output render.png --width W --height H --backend skia
    ```
+
+   > ⚠️ **`pulp-screenshot` is the ONLY render that decodes image assets.** Use it
+   > to *see* what an import looks like. The importer's `--validate` render is a
+   > **layout-only** check — it does NOT decode `setImageSource`/`createImage`
+   > files; `ImageView::paint` draws the filename as a placeholder (e.g.
+   > "3_228.png"). Native widgets (knob/fader/meter, CPU-canvas vectors) render in
+   > both, so a Pulp-library design looks fine under `--validate`, but any
+   > image-`asset_ref` design (generic-vector frames like ELYSIUM → captured PNGs)
+   > shows filename placeholders there. **Seeing placeholders means you used
+   > `--validate`/a non-Skia backend — NOT that image rendering regressed.**
+   > `pulp-screenshot` needs a `PULP_ENABLE_GPU=ON` (Skia-linked) build. This is
+   > exactly the path that produced the accurate ELYSIUM sprite-strip /
+   > native-silver-knob comparison renders in #3138.
 
 3. **Compare** reference vs render:
    ```bash

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.149.0",
+      "version": "0.149.1",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.149.0"
+  "version": "0.149.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.149.0",
+  "version": "0.149.1",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",


### PR DESCRIPTION
## Codify the render-tool distinction

Prevent a recurring false-alarm: the importer `--validate` render is a **layout-only** check that does NOT decode image assets (`ImageView::paint` draws the filename as a placeholder, e.g. `3_228.png`). Only **`pulp-screenshot`** (Skia) decodes `setImageSource`/`createImage` files and produces a faithful render.

Native widgets (knob/fader/meter — CPU-canvas vectors) render in *both*, so a Pulp-library design looks fine under `--validate`, while any image-`asset_ref` design (generic-vector frames like ELYSIUM → captured PNGs) shows placeholders there. Confusing the two reads as an image-render regression when there is none — verified 2026-05-31: ELYSIUM via `--validate` = placeholders, same envelope via `pulp-screenshot` = shapes/curve/images all decode.

Adds a ⚠️ callout to `import-design/SKILL.md` step 2 of the visual-validation flow: the right command to *see* an import, the tell-tale of the mistake, and the `PULP_ENABLE_GPU=ON` build requirement. This is the path that produced the accurate ELYSIUM comparison renders in #3138.

Docs/skill-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)