### PR TITLE
feat(format): enforce silence_unsupported_bus_arrangements in VST3 (P3c)

### DIFF
--- a/.agents/skills/vst3/SKILL.md
+++ b/.agents/skills/vst3/SKILL.md
@@ -511,3 +511,24 @@ through the pure helper `pulp::format::reported_latency_samples(raw, quirks)`
 (in `host_quirks.hpp`): a negative `latency_samples()` clamps to 0 when the
 quirk is enforced, and passes through raw (wrapping the unsigned host field)
 when `PULP_HOST_QUIRKS=off`. See `docs/reference/host-quirks-policy.md`.
+
+## silence_unsupported_bus_arrangements (host-quirks P3c, 2026-05-30)
+
+`setBusArrangements` now gates its rejection of unsupported layouts on the
+`silence_unsupported_bus_arrangements` quirk (cached in `quirks_` at init):
+
+- Bus-COUNT mismatch still hard-rejects (structural, not an arrangement issue).
+- An arrangement the processor can't natively support (non-mono/stereo, or
+  `is_bus_layout_supported()` says no): with the quirk enforced it is
+  **accepted** (`setArrangement` to the host request, `silence_unsupported_active_=true`);
+  with `PULP_HOST_QUIRKS=off` the original `kResultFalse` reject is preserved.
+
+**Key invariant:** `setupProcessing` always `prepare()`s the processor with
+*descriptor-default* channel counts (cached as `native_in_`/`native_out_`),
+NOT the negotiated arrangement. So when `silence_unsupported_active_`,
+`process()` hands the processor **clamped** views (`min(host, native)`) and
+**zero-fills all of the host's main-bus output channels first** — the
+processor never reads/writes past what `prepare()` allocated, and the host's
+extra channels emit silence instead of uninitialised memory. Empirical proof:
+`pulp-test-vst3-plugin-state` `[bus-arrangement]` drives a 5.1 output through
+a stereo processor and asserts channels 2–5 are silent + the processor saw 2.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.146.2",
+      "version": "0.147.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.146.2"
+  "version": "0.147.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.146.2",
+  "version": "0.147.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.293.1
+    VERSION 0.294.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/host-quirks.json
+++ b/core/format/host-quirks.json
@@ -4,10 +4,10 @@
   "_comment": "Machine-readable index of the HostQuirks ledger. The C++ struct pulp::format::HostQuirksMeta (core/format/include/pulp/format/host_quirks.hpp) is the SINGLE SOURCE OF TRUTH for the set of flags and their validation tier; this JSON is a parallel, machine-readable catalog consumed by provenance/staleness tooling (host-quirks integration plan P2+). The parity test tools/scripts/test_host_quirks_catalog_parity.py fails CI if this file and HostQuirksMeta ever drift (different flag set or mismatched tier). Rich rationale lives in the C++ comments and planning/host-quirks-log.md; this JSON is the index. Provenance fields (source_type, evidence, last_verified) are best-effort from the log + per-host headers; 'unknown' where the record is not explicit. This file introduces NO behavior change (P1: documentation/catalog hardening only).",
   "_field_docs": {
     "flag": "Field name in HostQuirks / HostQuirksMeta (exact match).",
-    "tier": "Validated | Speculative | LessonOnly — MUST match kHostQuirksMeta.",
+    "tier": "Validated | Speculative | LessonOnly \u2014 MUST match kHostQuirksMeta.",
     "host": "DAW / host the quirk accommodates (free text; matches the per-host header / log entry).",
     "symptom_area": "Coarse area label for bug-context matching (e.g. sizing, bus-arrangement, state-io, params, keyboard, threading, latency, bypass, dpi, midi).",
-    "source_type": "spec | release-notes | repro | in-DAW-bench | unknown — how the quirk was established.",
+    "source_type": "spec | release-notes | repro | in-DAW-bench | unknown \u2014 how the quirk was established.",
     "evidence": "Issue/PR/doc reference or short pointer; 'unknown' where the log is not explicit.",
     "last_verified": "ISO date the tier was last affirmed, or 'unknown'.",
     "note": "One-line human-readable summary."
@@ -40,8 +40,8 @@
       "symptom_area": "bus-arrangement",
       "source_type": "repro",
       "evidence": "macOS plan item 5.12",
-      "last_verified": "2026-05-25",
-      "note": "Accept unsupported bus arrangements and emit silence on extra channels rather than failing."
+      "last_verified": "2026-05-30",
+      "note": "Accept unsupported bus arrangements and emit silence on extra channels rather than failing. (VST3 adapter consumes this since host-quirks P3c; setBusArrangements accept + process() silence, validated)."
     },
     {
       "flag": "cubase10_async_view_resize_queue",

--- a/core/format/include/pulp/format/vst3_adapter.hpp
+++ b/core/format/include/pulp/format/vst3_adapter.hpp
@@ -108,6 +108,19 @@ private:
     // instead of hardcoding DAW workarounds (host-quirks plan, P3).
     HostQuirks quirks_{};
 
+    // silence_unsupported_bus_arrangements (host-quirks P3c). The
+    // processor is always prepare()'d with the DESCRIPTOR-DEFAULT channel
+    // counts (see setupProcessing), so these cache what the processor's
+    // buffers are sized for. When setBusArrangements accepts an
+    // arrangement the processor does NOT natively support (only because
+    // the quirk is enforced), `silence_unsupported_active_` is set; then
+    // process() hands the processor only its prepared channel counts and
+    // zero-fills the host's extra channels rather than letting the
+    // processor read/write past what prepare() allocated.
+    int native_in_ = 0;
+    int native_out_ = 0;
+    bool silence_unsupported_active_ = false;
+
     // Item 1.3 — previous-block transport snapshot used to derive the
     // `tempo_changed` / `time_sig_changed` / `transport_changed` flags
     // on `ProcessContext`. Default-constructed (no previous block) so

--- a/core/format/src/vst3_adapter.cpp
+++ b/core/format/src/vst3_adapter.cpp
@@ -211,48 +211,71 @@ tresult PLUGIN_API PulpVst3Processor::setBusArrangements(
         return kResultFalse;
     }
 
-    // Only mono + stereo are negotiable today — anything else is
-    // refused so the host falls back to the default arrangement.
-    auto supported = [](SpeakerArrangement a) {
+    // Only mono + stereo are translatable to a Processor::BusesLayout
+    // proposal today; any other arrangement is "unsupported" by
+    // definition. Item 3.7 — the Processor also gets a veto on the
+    // proposed mono/stereo layout via is_bus_layout_supported().
+    auto is_mono_stereo = [](SpeakerArrangement a) {
         return a == SpeakerArr::kMono || a == SpeakerArr::kStereo;
     };
-    for (int32 i = 0; i < numIns;  ++i) if (!supported(inputs[i]))  return kResultFalse;
-    for (int32 i = 0; i < numOuts; ++i) if (!supported(outputs[i])) return kResultFalse;
-
-    // Item 3.7 — let the Processor reject the layout before we mutate
-    // anything. Translate VST3 SpeakerArrangement masks to channel
-    // counts (1 = mono, 2 = stereo today; the mono/stereo guard above
-    // already filtered out other arrangements).
     auto channel_count = [](SpeakerArrangement a) -> int {
         if (a == SpeakerArr::kMono)   return 1;
         if (a == SpeakerArr::kStereo) return 2;
         return 0;
     };
-    Processor::BusesLayout proposal;
-    proposal.inputs.reserve(static_cast<std::size_t>(numIns));
-    proposal.outputs.reserve(static_cast<std::size_t>(numOuts));
-    for (int32 i = 0; i < numIns;  ++i) proposal.inputs.push_back(channel_count(inputs[i]));
-    for (int32 i = 0; i < numOuts; ++i) proposal.outputs.push_back(channel_count(outputs[i]));
-    if (!processor_->is_bus_layout_supported(proposal)) {
-        runtime::log_info(
-            "VST3 setBusArrangements: processor rejected proposed layout "
-            "({} in / {} out buses)", numIns, numOuts);
-        return kResultFalse;
+
+    bool all_mono_stereo = true;
+    for (int32 i = 0; i < numIns;  ++i) if (!is_mono_stereo(inputs[i]))  all_mono_stereo = false;
+    for (int32 i = 0; i < numOuts; ++i) if (!is_mono_stereo(outputs[i])) all_mono_stereo = false;
+
+    bool natively_supported = false;
+    if (all_mono_stereo) {
+        Processor::BusesLayout proposal;
+        proposal.inputs.reserve(static_cast<std::size_t>(numIns));
+        proposal.outputs.reserve(static_cast<std::size_t>(numOuts));
+        for (int32 i = 0; i < numIns;  ++i) proposal.inputs.push_back(channel_count(inputs[i]));
+        for (int32 i = 0; i < numOuts; ++i) proposal.outputs.push_back(channel_count(outputs[i]));
+        natively_supported = processor_->is_bus_layout_supported(proposal);
     }
 
     // Apply channel counts to the AudioBus objects the parent registered
     // from descriptor() during initialize(). setArrangement is the VST3
     // SDK's canonical in-place mutator for a bus's channel layout.
-    for (int32 i = 0; i < numIns; ++i) {
-        if (auto* bus = FCast<AudioBus>(audioInputs.at(i))) {
-            bus->setArrangement(inputs[i]);
+    auto apply_arrangements = [&] {
+        for (int32 i = 0; i < numIns; ++i)
+            if (auto* bus = FCast<AudioBus>(audioInputs.at(i))) bus->setArrangement(inputs[i]);
+        for (int32 i = 0; i < numOuts; ++i)
+            if (auto* bus = FCast<AudioBus>(audioOutputs.at(i))) bus->setArrangement(outputs[i]);
+    };
+
+    if (!natively_supported) {
+        // silence_unsupported_bus_arrangements (host-quirks P3c): rather
+        // than failing the whole proposal, accept the host's arrangement
+        // and emit silence on the channels the processor doesn't produce.
+        // process() enforces this by clamping the processor's views to its
+        // prepared (descriptor-default) channel counts and zero-filling
+        // the host's extra channels — so the processor never reads/writes
+        // past what prepare() allocated. When the quirk is filtered out
+        // (PULP_HOST_QUIRKS=off) the original reject-the-proposal behavior
+        // is preserved exactly.
+        if (!quirks_.silence_unsupported_bus_arrangements) {
+            runtime::log_info(
+                "VST3 setBusArrangements: rejected unsupported layout "
+                "({} in / {} out buses) — silence accommodation off",
+                numIns, numOuts);
+            return kResultFalse;
         }
+        apply_arrangements();
+        silence_unsupported_active_ = true;
+        runtime::log_info(
+            "VST3 setBusArrangements: accepted UNSUPPORTED layout via silence "
+            "accommodation ({} in / {} out buses); extra channels silenced",
+            numIns, numOuts);
+        return kResultTrue;
     }
-    for (int32 i = 0; i < numOuts; ++i) {
-        if (auto* bus = FCast<AudioBus>(audioOutputs.at(i))) {
-            bus->setArrangement(outputs[i]);
-        }
-    }
+
+    silence_unsupported_active_ = false;
+    apply_arrangements();
     runtime::log_info(
         "VST3 setBusArrangements: accepted {} in / {} out buses", numIns, numOuts);
     return kResultTrue;
@@ -273,6 +296,11 @@ tresult PLUGIN_API PulpVst3Processor::setupProcessing(ProcessSetup& setup) {
     ctx.output_channels = out_ch;
 
     processor_->prepare(ctx);
+
+    // Cache what the processor's buffers are prepared for — the silence
+    // accommodation (P3c) clamps process() views to these counts.
+    native_in_ = in_ch;
+    native_out_ = out_ch;
 
     // Pre-allocate buffer pointer arrays for real-time safety
     input_ptrs_.resize(ctx.input_channels);
@@ -403,11 +431,31 @@ tresult PLUGIN_API PulpVst3Processor::process(ProcessData& data) {
         }
     }
 
+    // silence_unsupported_bus_arrangements (host-quirks P3c): the host
+    // accepted an arrangement the processor does NOT natively support, so
+    // the processor was prepare()'d for native_in_/native_out_ channels
+    // only (setupProcessing uses descriptor defaults). Hand the processor
+    // exactly those counts, and zero-fill ALL of the host's main-bus
+    // OUTPUT channels first so the ones the processor doesn't write emit
+    // silence instead of uninitialised memory. No-op when the arrangement
+    // is natively supported (the common path).
+    int proc_in = in_channels;
+    int proc_out = out_channels;
+    if (silence_unsupported_active_) {
+        for (int ch = 0; ch < out_channels; ++ch) {
+            if (output_ptrs_[ch] != nullptr) {
+                std::memset(output_ptrs_[ch], 0, sizeof(float) * num_samples);
+            }
+        }
+        proc_in  = (in_channels  < native_in_)  ? in_channels  : native_in_;
+        proc_out = (out_channels < native_out_) ? out_channels : native_out_;
+    }
+
     audio::BufferView<const float> input_view(
         const_cast<const float* const*>(input_ptrs_.data()),
-        in_channels, num_samples);
+        proc_in, num_samples);
     audio::BufferView<float> output_view(
-        output_ptrs_.data(), out_channels, num_samples);
+        output_ptrs_.data(), proc_out, num_samples);
     audio::BufferView<const float> sidechain_view(
         const_cast<const float* const*>(sidechain_ptrs_.data()),
         sc_channels, num_samples);

--- a/docs/reference/host-quirks-policy.md
+++ b/docs/reference/host-quirks-policy.md
@@ -125,13 +125,22 @@ its `QuirkPolicySource` (compile default / env / API) for diagnostics.
 ### Adapter consumption (enforcement status)
 
 The format adapters cache `resolved_quirks(detect_host_info()...)` once at
-init and gate accommodations on the flags. As of P3a, the first wired flag
-is **`clamp_latency_to_nonneg`** — VST3 / CLAP / AU v2 / AU v3 route latency
-reporting through `reported_latency_samples()`, so a negative
-`latency_samples()` clamps to 0 by default and reports raw under
-`PULP_HOST_QUIRKS=off`. Remaining flags are wired incrementally, one PR per
-quirk, each with its own validation — a flag is only meaningfully
-`Validated` once an adapter consumes it under test.
+init and gate accommodations on the flags. Flags wired so far:
+
+- **`clamp_latency_to_nonneg`** (P3a) — VST3 / CLAP / AU v2 / AU v3 route
+  latency reporting through `reported_latency_samples()`; a negative
+  `latency_samples()` clamps to 0 by default and reports raw under
+  `PULP_HOST_QUIRKS=off`.
+- **`silence_unsupported_bus_arrangements`** (P3c) — VST3 `setBusArrangements`
+  accepts an arrangement the processor can't natively support (instead of
+  `kResultFalse`) and `process()` clamps the processor to its prepared
+  channel count + silences the host's extra channels. `PULP_HOST_QUIRKS=off`
+  preserves the original reject behavior. (VST3-scoped — the AU/CLAP adapters
+  are declarative and don't reject arrangements.)
+
+Remaining flags are wired incrementally, one PR per quirk, each with its own
+validation — a flag is only meaningfully `Validated` once an adapter consumes
+it under test.
 
 ### Inspecting the live policy: `pulp doctor`
 

--- a/test/test_vst3_plugin_state.cpp
+++ b/test/test_vst3_plugin_state.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/format/vst3_adapter.hpp>
+#include <pulp/format/host_quirks.hpp>
 #include <public.sdk/source/vst/hosting/eventlist.h>
 #include <public.sdk/source/vst/hosting/parameterchanges.h>
 
@@ -806,4 +807,121 @@ TEST_CASE("VST3 adapter without a Bypass parameter never short-circuits",
     // No "Bypass" parameter declared by the plugin — the adapter should
     // report the no-op sentinel ID 0 so process() never short-circuits.
     REQUIRE(processor.bypass_parameter_id() == 0u);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// host-quirks P3c — silence_unsupported_bus_arrangements, end-to-end.
+//
+// Empirical proof the VST3 adapter RESPECTS the quirk: with it enforced
+// (default), setBusArrangements accepts an arrangement the processor does
+// NOT natively support (6-ch 5.1) instead of failing, the processor still
+// runs at its prepared (stereo) channel count, and the host's extra output
+// channels are silenced. With PULP_HOST_QUIRKS=off the original
+// reject-the-proposal behavior is preserved exactly.
+// ─────────────────────────────────────────────────────────────────────
+
+TEST_CASE("VST3 accepts an unsupported arrangement and silences extras when the quirk is enforced",
+          "[vst3][host-quirks][p3][bus-arrangement]") {
+    pulp::format::set_host_quirk_policy(pulp::format::QuirkFilter{});  // all tiers → quirk on
+
+    TestVst3Config config;  // stereo in / stereo out
+    reset_test_processor(config);
+    HostApp host_app;
+    pulp::format::vst3::PulpVst3Processor processor(create_test_processor);
+    REQUIRE(processor.initialize(&host_app) == Steinberg::kResultOk);
+    auto* test_processor = TestVst3Processor::g_last_processor;
+    REQUIRE(test_processor != nullptr);
+
+    Steinberg::Vst::ProcessSetup setup{};
+    setup.processMode = Steinberg::Vst::kRealtime;
+    setup.symbolicSampleSize = Steinberg::Vst::kSample32;
+    setup.maxSamplesPerBlock = 64;
+    setup.sampleRate = 48000.0;
+    REQUIRE(processor.setupProcessing(setup) == Steinberg::kResultOk);
+
+    // Host requests a 5.1 (6-channel) output — not mono/stereo, so the
+    // processor cannot natively support it. With the quirk enforced the
+    // adapter accepts rather than returning kResultFalse.
+    Steinberg::Vst::SpeakerArrangement inputs[1]  = {SpeakerArr::kStereo};
+    Steinberg::Vst::SpeakerArrangement outputs[1] = {SpeakerArr::k51};
+    REQUIRE(processor.setBusArrangements(inputs, 1, outputs, 1) == Steinberg::kResultTrue);
+
+    // Drive a process block with a 6-channel output buffer; pre-fill with a
+    // sentinel so we can tell "silenced" (0) from "left untouched" (9).
+    constexpr int kFrames = 8;
+    std::array<float, kFrames> in_l{{0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f}};
+    std::array<float, kFrames> in_r{{-0.1f, -0.2f, -0.3f, -0.4f, -0.5f, -0.6f, -0.7f, -0.8f}};
+    std::array<std::array<float, kFrames>, 6> outs{};
+    for (auto& o : outs) o.fill(9.0f);
+
+    float* main_inputs[2] = {in_l.data(), in_r.data()};
+    float* main_outputs[6];
+    for (int ch = 0; ch < 6; ++ch) main_outputs[ch] = outs[ch].data();
+
+    Steinberg::Vst::AudioBusBuffers audio_inputs[1]{};
+    audio_inputs[0].numChannels = 2;
+    audio_inputs[0].channelBuffers32 = main_inputs;
+    Steinberg::Vst::AudioBusBuffers audio_outputs[1]{};
+    audio_outputs[0].numChannels = 6;
+    audio_outputs[0].channelBuffers32 = main_outputs;
+
+    Steinberg::Vst::ParameterChanges input_params;
+    Steinberg::Vst::ParameterChanges output_params;
+    Steinberg::Vst::EventList input_events(4);
+    Steinberg::Vst::EventList output_events(4);
+    Steinberg::Vst::ProcessContext process_context{};
+
+    Steinberg::Vst::ProcessData data{};
+    data.numSamples = kFrames;
+    data.numInputs = 1;
+    data.numOutputs = 1;
+    data.inputs = audio_inputs;
+    data.outputs = audio_outputs;
+    data.inputParameterChanges = &input_params;
+    data.outputParameterChanges = &output_params;
+    data.inputEvents = &input_events;
+    data.outputEvents = &output_events;
+    data.processContext = &process_context;
+
+    REQUIRE(processor.process(data) == Steinberg::kResultOk);
+
+    // The processor saw only its prepared (stereo) channel count — not 6.
+    REQUIRE(test_processor->last_output_channels == 2);
+
+    // Channels 0..1: the processor copied the input through.
+    REQUIRE_THAT(outs[0][0], WithinAbs(0.1, 1e-6));
+    REQUIRE_THAT(outs[1][0], WithinAbs(-0.1, 1e-6));
+    // Channels 2..5: silenced (0), NOT the 9.0 sentinel and NOT garbage.
+    for (int ch = 2; ch < 6; ++ch) {
+        for (int s = 0; s < kFrames; ++s) {
+            REQUIRE_THAT(outs[ch][s], WithinAbs(0.0, 1e-9));
+        }
+    }
+
+    pulp::format::set_host_quirk_policy(std::nullopt);
+}
+
+TEST_CASE("VST3 rejects an unsupported arrangement when silence accommodation is off",
+          "[vst3][host-quirks][p3][bus-arrangement]") {
+    pulp::format::set_host_quirk_policy(pulp::format::kQuirkFilterOff);
+
+    TestVst3Config config;
+    reset_test_processor(config);
+    HostApp host_app;
+    pulp::format::vst3::PulpVst3Processor processor(create_test_processor);
+    REQUIRE(processor.initialize(&host_app) == Steinberg::kResultOk);
+
+    Steinberg::Vst::ProcessSetup setup{};
+    setup.processMode = Steinberg::Vst::kRealtime;
+    setup.symbolicSampleSize = Steinberg::Vst::kSample32;
+    setup.maxSamplesPerBlock = 64;
+    setup.sampleRate = 48000.0;
+    REQUIRE(processor.setupProcessing(setup) == Steinberg::kResultOk);
+
+    Steinberg::Vst::SpeakerArrangement inputs[1]  = {SpeakerArr::kStereo};
+    Steinberg::Vst::SpeakerArrangement outputs[1] = {SpeakerArr::k51};
+    // Quirk off → original behavior: reject the unsupported proposal.
+    REQUIRE(processor.setBusArrangements(inputs, 1, outputs, 1) == Steinberg::kResultFalse);
+
+    pulp::format::set_host_quirk_policy(std::nullopt);
 }


### PR DESCRIPTION
Implement the second host-quirk cheap defense end-to-end. The flag was
marked Validated but the behavior never existed — VST3 setBusArrangements
actually did the OPPOSITE (rejected unsupported arrangements with
kResultFalse). This wires the documented "accept + silence extras"
behavior, gated on the quirk.

- setBusArrangements: bus-COUNT mismatch still hard-rejects (structural).
  An arrangement the processor can't natively support (non-mono/stereo or
  is_bus_layout_supported() == false) is now ACCEPTED when the quirk is
  enforced (setArrangement to the host request + mark silence-active);
  PULP_HOST_QUIRKS=off preserves the original kResultFalse reject exactly.
- process(): setupProcessing always prepare()s the processor with
  descriptor-default channel counts (cached as native_in_/native_out_),
  NOT the negotiated arrangement. So when silence-active, process() hands
  the processor clamped views (min(host, native)) and zero-fills ALL of
  the host's main-bus output channels first — the processor never
  reads/writes past what prepare() allocated, and the host's extra
  channels emit silence instead of uninitialised memory.

Validation (empirical, the quirk is respected when enabled):
- pulp-test-vst3-plugin-state [bus-arrangement]: drives a 5.1 (6-ch)
  output through a stereo processor — asserts setBusArrangements accepts
  (enforced) / rejects (PULP_HOST_QUIRKS=off), the processor saw exactly
  2 channels, and output channels 2..5 are silent (not the 9.0 sentinel).
- No regression: full vst3-plugin-state (208) + processor-layout-latency
  (28) suites green.

VST3-scoped: the AU/CLAP adapters are declarative and never rejected
arrangements, so there's nothing to gate there. silence_unsupported_bus_
arrangements stays Validated (now genuinely so); catalog last_verified
bumped. See planning/2026-05-30-host-quirks-enforcement-goal.md.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>