### PR TITLE
feat(import-design): labeled comparison-montage helper (montage.py)

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -1090,6 +1090,16 @@ After generating Pulp code, ALWAYS validate by comparing with the source design:
 
 5. **Iterate if needed** — adjust the generated code and re-render until similarity is acceptable (>85%)
 
+**Always show comparisons as a LABELED montage** — `tools/import-design/montage.py` stacks N renders into one image with a titled bar above each panel (labels ON by default), so a reference-vs-render(s) comparison is self-documenting (you can tell which panel is which without an external caption — a bare montage gets misread):
+```bash
+python3 tools/import-design/montage.py --out compare.png \
+  "reference.png:1. Figma reference" \
+  "render.png:2. Pulp render (real export)" \
+  "rest.png:3. Pulp render (headless REST)"
+# --columns N for side-by-side; --no-labels to opt out; --config montage.json for defaults
+```
+Smoke-tested by `test/test_import_montage.py` (CTest `import-montage`, skips without PIL).
+
 ### Keyboard shortcut extraction (UX best-practice default)
 
 The library function `extract_keyboard_shortcuts(source, filename)` scans

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.148.2",
+      "version": "0.149.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.148.2"
+  "version": "0.149.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.148.2",
+  "version": "0.149.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -155,6 +155,17 @@ if(Python3_Interpreter_FOUND)
         SKIP_RETURN_CODE 77
         LABELS "import;fidelity;slow"
         TIMEOUT 120)
+
+    # Labeled comparison-montage helper (tools/import-design/montage.py).
+    # Builds titled reference-vs-render(s) montages (labels ON by default).
+    # PIL-based; exits 77 (skips) on a PIL-less interpreter.
+    add_test(NAME import-montage
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/test_import_montage.py)
+    set_tests_properties(import-montage PROPERTIES
+        SKIP_RETURN_CODE 77
+        LABELS "import;fidelity"
+        TIMEOUT 60)
 endif()
 
 # Setup-hook unit test — verifies hooks/scripts/check-pulp-cli.sh

--- a/test/test_import_montage.py
+++ b/test/test_import_montage.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Smoke test for tools/import-design/montage.py — the labeled comparison
+montage helper. Skips cleanly on a PIL-less interpreter (matches the
+fidelity-diff harness test). Verifies labels are ON by default and that the
+title bars add the expected vertical space."""
+from __future__ import annotations
+import importlib.util, pathlib, sys, tempfile, unittest
+
+try:
+    from PIL import Image  # noqa: F401
+except Exception:  # pragma: no cover
+    sys.stderr.write("Pillow not installed — skipping montage test\n")
+    sys.exit(77)  # CTest SKIP_RETURN_CODE
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location(
+    "montage", REPO / "tools" / "import-design" / "montage.py")
+montage = importlib.util.module_from_spec(spec); spec.loader.exec_module(montage)
+
+
+def _img(tmp, name, w, h, color):
+    from PIL import Image
+    p = pathlib.Path(tmp) / name
+    Image.new("RGB", (w, h), color).save(p)
+    return str(p)
+
+
+class MontageTest(unittest.TestCase):
+    def test_labeled_by_default_adds_title_space(self):
+        from PIL import Image
+        with tempfile.TemporaryDirectory() as tmp:
+            a = _img(tmp, "a.png", 200, 100, (10, 20, 30))
+            b = _img(tmp, "b.png", 200, 100, (30, 20, 10))
+            out = str(pathlib.Path(tmp) / "m.png")
+            montage.build_montage([("Ref", a), ("Render", b)], out,
+                                  title_height=36, pad=14, panel_width=200)
+            self.assertTrue(pathlib.Path(out).exists())
+            h_labeled = Image.open(out).size[1]
+            out2 = str(pathlib.Path(tmp) / "m2.png")
+            montage.build_montage([("Ref", a), ("Render", b)], out2,
+                                  labels=False, title_height=36, pad=14, panel_width=200)
+            h_plain = Image.open(out2).size[1]
+            # Two title bars => labeled montage is ~2*title_height taller.
+            self.assertGreater(h_labeled, h_plain)
+            self.assertGreaterEqual(h_labeled - h_plain, 2 * 36 - 2)
+
+    def test_columns_side_by_side(self):
+        from PIL import Image
+        with tempfile.TemporaryDirectory() as tmp:
+            a = _img(tmp, "a.png", 200, 100, (10, 20, 30))
+            b = _img(tmp, "b.png", 200, 100, (30, 20, 10))
+            out = str(pathlib.Path(tmp) / "m.png")
+            montage.build_montage([("A", a), ("B", b)], out, columns=2, panel_width=200)
+            w = Image.open(out).size[0]
+            self.assertGreater(w, 200 * 2)  # two columns side by side
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/import-design/montage.py
+++ b/tools/import-design/montage.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Labeled comparison montage for design-import renders.
+
+Stacks N images into one montage with a titled bar above each panel, so a
+reference-vs-render(s) comparison is self-documenting (you can tell which panel
+is which without an external caption). Labels are ON by default — that's the
+point. Used for figma-import fidelity comparisons (reference / sprite-strip /
+native-vector / headless-REST, etc.).
+
+Usage:
+  # path:Label pairs (label defaults to the file stem if omitted)
+  montage.py --out compare.png ref.png:"Figma reference" render.png:"Pulp render"
+  montage.py --out compare.png --columns 2 a.png:"A" b.png:"B"   # side-by-side
+  montage.py --out compare.png --no-labels a.png b.png            # opt out
+  montage.py --out compare.png --config montage.json ...          # defaults via config
+
+Config (JSON, all optional; CLI overrides): {
+  "labels": true, "columns": 1, "title_height": 36, "pad": 14,
+  "bg": [20,20,24], "title_bg": [12,12,14], "title_fg": [235,235,240],
+  "panel_width": 1000, "font_size": 22
+}
+Importable: build_montage(panels, out_path, **opts) where panels=[(label, path), ...].
+"""
+import argparse, json, os, sys
+
+def _load_pil():
+    try:
+        from PIL import Image, ImageDraw, ImageFont
+        return Image, ImageDraw, ImageFont
+    except ImportError:
+        sys.stderr.write("montage.py requires Pillow (pip install pillow)\n")
+        raise
+
+def _font(ImageFont, size):
+    for p in ("/System/Library/Fonts/SFNSMono.ttf",
+              "/System/Library/Fonts/Supplemental/Arial.ttf",
+              "/Library/Fonts/Arial.ttf"):
+        if os.path.exists(p):
+            try: return ImageFont.truetype(p, size)
+            except Exception: pass
+    return ImageFont.load_default()
+
+def build_montage(panels, out_path, labels=True, columns=1, title_height=36,
+                  pad=14, bg=(20, 20, 24), title_bg=(12, 12, 14),
+                  title_fg=(235, 235, 240), panel_width=1000, font_size=22):
+    """panels: list of (label, image_path). Returns the output path."""
+    Image, ImageDraw, ImageFont = _load_pil()
+    font = _font(ImageFont, font_size)
+    cells = []  # (label, resized-image)
+    for label, path in panels:
+        im = Image.open(path).convert("RGB")
+        w, h = im.size
+        if w != panel_width:
+            im = im.resize((panel_width, max(1, int(h * panel_width / w))))
+        cells.append((label, im))
+    th = title_height if labels else 0
+    col_w = panel_width + pad * 2
+    rows = (len(cells) + columns - 1) // columns
+    # Per-row height = max cell height in that row + title + pad.
+    row_heights = []
+    for r in range(rows):
+        rowcells = cells[r * columns:(r + 1) * columns]
+        row_heights.append(max(c[1].height for c in rowcells) + th + pad)
+    W = col_w * columns + pad
+    H = sum(row_heights) + pad
+    canvas = Image.new("RGB", (W, H), bg)
+    draw = ImageDraw.Draw(canvas)
+    y = pad
+    for r in range(rows):
+        x = pad
+        for c in range(columns):
+            idx = r * columns + c
+            if idx >= len(cells): break
+            label, im = cells[idx]
+            if labels:
+                draw.rectangle([x, y, x + panel_width, y + th], fill=title_bg)
+                draw.text((x + 10, y + (th - font_size) // 2), label, fill=title_fg, font=font)
+            canvas.paste(im, (x, y + th))
+            x += col_w
+        y += row_heights[r]
+    canvas.save(out_path)
+    return out_path
+
+def _parse_panel(spec):
+    # "path:Label" — split on the LAST ':' not part of a drive/scheme; simplest:
+    # split on first ':' after the path if a label is given, else whole = path.
+    if ":" in spec:
+        # allow paths without labels; treat a trailing :Label as the label
+        path, _, label = spec.rpartition(":")
+        if path and os.path.exists(path):
+            return (label or os.path.splitext(os.path.basename(path))[0], path)
+    return (os.path.splitext(os.path.basename(spec))[0], spec)
+
+def main():
+    ap = argparse.ArgumentParser(description="Labeled comparison montage for import renders")
+    ap.add_argument("panels", nargs="+", help='image specs: path or "path:Label"')
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--no-labels", action="store_true", help="disable titles (default: labeled)")
+    ap.add_argument("--columns", type=int)
+    ap.add_argument("--config", help="JSON defaults (CLI overrides)")
+    args = ap.parse_args()
+    opts = {}
+    if args.config and os.path.exists(args.config):
+        opts = json.load(open(args.config))
+    if args.no_labels: opts["labels"] = False
+    if args.columns is not None: opts["columns"] = args.columns
+    panels = [_parse_panel(s) for s in args.panels]
+    out = build_montage(panels, args.out, **opts)
+    print(f"wrote {out}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Labeled comparison montages (default-on)

Codifies the labeled reference-vs-render montage format: `tools/import-design/montage.py` stacks N renders into one image with a **titled bar above each panel, labels ON by default**, so an import comparison is self-documenting. A bare unlabeled montage gets misread (which panel is the reference vs which render lane?) — labels fix that.

- Standalone CLI: `montage.py --out c.png \"ref.png:Figma reference\" \"render.png:Pulp render\"`
- `--columns N` (side-by-side), `--no-labels` (opt out), `--config montage.json` (defaults)
- Importable `build_montage(panels, out, **opts)`
- Smoke test `test/test_import_montage.py` (CTest `import-montage`; exits 77 / skips without PIL)
- Documented in the import-design skill's visual-validation flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)