### PR TITLE
feat(format): synthesize a Bypass parameter (VST3 + AU v3) when the plugin declares none (P3b)

### DIFF
--- a/.agents/skills/auv3/SKILL.md
+++ b/.agents/skills/auv3/SKILL.md
@@ -1119,3 +1119,17 @@ lookup of namespace free functions fails to compile. Qualify them:
 cached `HostQuirks host_quirks` resolve fine — the struct is in-namespace.)
 The core lib doesn't compile this `.mm`, so only the AU target/test catches
 such errors — build `pulp-test-au-plugin-state`.
+
+## synthesize_bypass_parameter (host-quirks P3b, 2026-05-30)
+
+When the plugin declares no Bypass parameter and the quirk is enforced,
+the adapter calls `pulp::format::maybe_synthesize_bypass(store, quirks)`
+(in `quirk_apply.hpp`) right after `define_parameters` — injecting an
+automatable boolean `"Bypass"` param with the reserved ID
+`kSynthesizedBypassParamId` (0x70427970). The adapter's EXISTING bypass
+detection (name == "Bypass", boolean range) then adopts it, so the
+pass-through short-circuit honors it with no further wiring.
+`PULP_HOST_QUIRKS=off` synthesizes nothing. Existing "no-bypass" tests
+must set `kQuirkFilterOff` to keep that premise. (CLAP + AU v2 are NOT
+wired — they have no bypass process path; injecting a param there would
+appear-but-do-nothing, so they're a separate follow-up.)

--- a/.agents/skills/vst3/SKILL.md
+++ b/.agents/skills/vst3/SKILL.md
@@ -532,3 +532,17 @@ processor never reads/writes past what `prepare()` allocated, and the host's
 extra channels emit silence instead of uninitialised memory. Empirical proof:
 `pulp-test-vst3-plugin-state` `[bus-arrangement]` drives a 5.1 output through
 a stereo processor and asserts channels 2–5 are silent + the processor saw 2.
+
+## synthesize_bypass_parameter (host-quirks P3b, 2026-05-30)
+
+When the plugin declares no Bypass parameter and the quirk is enforced,
+the adapter calls `pulp::format::maybe_synthesize_bypass(store, quirks)`
+(in `quirk_apply.hpp`) right after `define_parameters` — injecting an
+automatable boolean `"Bypass"` param with the reserved ID
+`kSynthesizedBypassParamId` (0x70427970). The adapter's EXISTING bypass
+detection (name == "Bypass", boolean range) then adopts it, so the
+pass-through short-circuit honors it with no further wiring.
+`PULP_HOST_QUIRKS=off` synthesizes nothing. Existing "no-bypass" tests
+must set `kQuirkFilterOff` to keep that premise. (CLAP + AU v2 are NOT
+wired — they have no bypass process path; injecting a param there would
+appear-but-do-nothing, so they're a separate follow-up.)

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.147.0",
+      "version": "0.148.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.147.0"
+  "version": "0.148.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.147.0",
+  "version": "0.148.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.294.0
+    VERSION 0.295.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/host-quirks.json
+++ b/core/format/host-quirks.json
@@ -20,8 +20,8 @@
       "symptom_area": "bypass",
       "source_type": "repro",
       "evidence": "macOS plan item 5.12 (DAW-quirks rows 23-26); founding cheap-defense, on the test bench since item 5.1",
-      "last_verified": "2026-05-25",
-      "note": "Synthesize a bypass parameter when the plugin doesn't declare one."
+      "last_verified": "2026-05-30",
+      "note": "Synthesize a bypass parameter when the plugin doesn't declare one. (VST3 + AU v3 adapters synthesize + honor this since host-quirks P3b; CLAP/AU v2 pending)."
     },
     {
       "flag": "clamp_latency_to_nonneg",

--- a/core/format/include/pulp/format/quirk_apply.hpp
+++ b/core/format/include/pulp/format/quirk_apply.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+/// @file quirk_apply.hpp
+/// StateStore-aware host-quirk application helpers (host-quirks plan, P3).
+///
+/// Kept separate from `host_quirks.hpp` so that header stays free of a
+/// `pulp::state` dependency — only adapters that actually mutate the
+/// StateStore (to synthesize parameters) include this.
+
+#include <pulp/format/host_quirks.hpp>
+#include <pulp/state/parameter.hpp>
+#include <pulp/state/store.hpp>
+
+namespace pulp::format {
+
+/// Reserved ParamID for the synthesized Bypass parameter (P3b). Chosen
+/// high + distinctive so it does not collide with plugin-declared IDs.
+/// Stable across builds so host automation envelopes survive reloads.
+inline constexpr state::ParamID kSynthesizedBypassParamId = 0x70427970;  // 'pByp'
+
+/// synthesize_bypass_parameter (host-quirks P3b): when the plugin declares
+/// no Bypass parameter and the quirk is enforced, inject an automatable
+/// boolean "Bypass" parameter into the StateStore so the host gets a
+/// bypass control. Returns true if one was synthesized.
+///
+/// The range (min 0, max 1, default 0, step 1) matches the boolean-bypass
+/// shape the VST3 / AU v3 adapters already detect (they tag it kIsBypass /
+/// the AU bypass surface and pass-through audio in process when it is
+/// engaged), so callers just inject it before their existing bypass-param
+/// detection pass and the rest flows through unchanged.
+///
+/// No-op (returns false) when: the quirk is filtered out, a parameter
+/// named "Bypass" already exists, or the reserved ID is already taken.
+/// Not real-time safe — call once at adapter init, before processing.
+inline bool maybe_synthesize_bypass(state::StateStore& store, const HostQuirks& q) {
+    if (!q.synthesize_bypass_parameter) return false;
+    for (const auto& p : store.all_params()) {
+        if (p.name == "Bypass") return false;            // plugin already declares one
+        if (p.id == kSynthesizedBypassParamId) return false;  // ID-collision guard
+    }
+    state::ParamInfo info;
+    info.id = kSynthesizedBypassParamId;
+    info.name = "Bypass";
+    info.range = {0.0f, 1.0f, 0.0f, 1.0f};  // boolean: step 1 → two states
+    store.add_parameter(info);
+    return true;
+}
+
+}  // namespace pulp::format

--- a/core/format/src/au_adapter.mm
+++ b/core/format/src/au_adapter.mm
@@ -58,6 +58,7 @@
 #include <pulp/format/processor.hpp>
 #include <pulp/format/plugin_state_io.hpp>
 #include <pulp/format/host_quirks.hpp>
+#include <pulp/format/quirk_apply.hpp>
 #include <pulp/format/registry.hpp>
 #include <pulp/format/ara.hpp>
 #include <pulp/format/detail/playhead_diff.hpp>
@@ -265,6 +266,12 @@ static int32_t block_relative_sample_offset(AUEventSampleTime event_sample_time,
         _bridge.host_quirks =
             pulp::format::resolved_quirks(host_info.type, host_info.version);
     }
+
+    // synthesize_bypass_parameter (host-quirks P3b): inject an automatable
+    // "Bypass" param when the plugin declared none, BEFORE the detection
+    // pass below — which then mirrors it onto the AU bypass surface. No-op
+    // when the quirk is filtered out. Qualified (Obj-C method file scope).
+    pulp::format::maybe_synthesize_bypass(_bridge.store, _bridge.host_quirks);
 
     // Item 3.1 — auto-detect a plugin-declared Bypass parameter so the
     // host's `shouldBypassEffect` AUValue and the plugin's

--- a/core/format/src/vst3_adapter.cpp
+++ b/core/format/src/vst3_adapter.cpp
@@ -9,6 +9,7 @@
 #include <pulp/format/detail/vst3_frame_rate.hpp>
 #include <pulp/format/plugin_state_io.hpp>
 #include <pulp/format/vst3_plug_view.hpp>
+#include <pulp/format/quirk_apply.hpp>
 #include <pulp/format/ara.hpp>
 #include <pulp/runtime/log.hpp>
 #include <pulp/runtime/scoped_no_alloc.hpp>
@@ -74,6 +75,14 @@ tresult PLUGIN_API PulpVst3Processor::initialize(FUnknown* context) {
     auto desc = processor_->descriptor();
     processor_->set_state_store(&store_);
     processor_->define_parameters(store_);
+
+    // synthesize_bypass_parameter (host-quirks P3b): if the plugin
+    // declared no Bypass parameter, inject an automatable one BEFORE the
+    // parameter-registration loop below — that loop then detects the
+    // synthesized "Bypass" (boolean range), tags it kIsBypass, and caches
+    // bypass_param_id_, so process()'s pass-through path honors it with no
+    // further wiring. No-op when the quirk is filtered out.
+    maybe_synthesize_bypass(store_, quirks_);
 
     // Wire gesture callbacks to VST3 host
     store_.set_gesture_callbacks(

--- a/docs/reference/host-quirks-policy.md
+++ b/docs/reference/host-quirks-policy.md
@@ -137,6 +137,13 @@ init and gate accommodations on the flags. Flags wired so far:
   channel count + silences the host's extra channels. `PULP_HOST_QUIRKS=off`
   preserves the original reject behavior. (VST3-scoped — the AU/CLAP adapters
   are declarative and don't reject arrangements.)
+- **`synthesize_bypass_parameter`** (P3b) — when the plugin declares no
+  Bypass param, VST3 + AU v3 inject an automatable one (`maybe_synthesize_bypass`
+  in `quirk_apply.hpp`, reserved ID `kSynthesizedBypassParamId`); the
+  adapters' existing bypass detection adopts it and `process()` honors the
+  pass-through. `PULP_HOST_QUIRKS=off` synthesizes nothing. (CLAP + AU v2
+  have no bypass process path yet — a synthesized param there would
+  appear-but-do-nothing, so they're a separate follow-up.)
 
 Remaining flags are wired incrementally, one PR per quirk, each with its own
 validation — a flag is only meaningfully `Validated` once an adapter consumes

--- a/test/test_au_plugin_state.mm
+++ b/test/test_au_plugin_state.mm
@@ -7,8 +7,10 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/format/au_v2_adapter.hpp>
 #include <pulp/format/au_v2_instrument.hpp>
+#include <pulp/format/host_quirks.hpp>
 #include <pulp/format/host_type.hpp>
 #include <pulp/format/processor.hpp>
+#include <pulp/format/quirk_apply.hpp>
 #include <pulp/format/registry.hpp>
 
 #import "../core/format/src/au_audio_unit.h"
@@ -876,6 +878,10 @@ TEST_CASE("AU v3 render block short-circuits to pass-through when bypassed",
 
 TEST_CASE("AU v3 without a Bypass parameter still honours setShouldBypassEffect",
           "[au][auv3][bypass][item-3.1]") {
+    // The atomic-fallback path this test pins only exists when no Bypass
+    // param is present — since host-quirks P3b one is synthesized by
+    // default, so disable synthesis here.
+    pulp::format::set_host_quirk_policy(pulp::format::kQuirkFilterOff);
     @autoreleasepool {
         AudioComponentDescription desc{};
         desc.componentType = kAudioUnitType_Effect;
@@ -904,6 +910,40 @@ TEST_CASE("AU v3 without a Bypass parameter still honours setShouldBypassEffect"
 
         [unit release];
     }
+    pulp::format::set_host_quirk_policy(std::nullopt);
+}
+
+TEST_CASE("AU v3 synthesizes a Bypass param when the plugin declares none (P3b)",
+          "[au][auv3][host-quirks][p3][bypass]") {
+    pulp::format::set_host_quirk_policy(pulp::format::QuirkFilter{});  // quirk on
+    @autoreleasepool {
+        AudioComponentDescription desc{};
+        desc.componentType = kAudioUnitType_Effect;
+        desc.componentSubType = 'TstE';
+        desc.componentManufacturer = 'Plup';
+
+        ScopedFactoryRegistration registration(create_effect_processor);  // no Bypass param
+
+        NSError* err = nil;
+        PulpAudioUnit* unit =
+            [[PulpAudioUnit alloc] initWithComponentDescription:desc
+                                                       options:0
+                                                         error:&err];
+        REQUIRE(unit != nil);
+        REQUIRE(err == nil);
+
+        // The adapter synthesized a Bypass param (reserved ID) and the
+        // detection pass adopted it onto the AU bypass surface; it now
+        // appears in the parameter tree and drives shouldBypassEffect.
+        REQUIRE([unit pulpBypassParameterId] ==
+                static_cast<uint32_t>(pulp::format::kSynthesizedBypassParamId));
+        AUParameterTree* tree = unit.parameterTree;
+        REQUIRE(tree != nil);
+        REQUIRE(tree.allParameters.count == 2u);  // processor's Gain + synthesized Bypass
+
+        [unit release];
+    }
+    pulp::format::set_host_quirk_policy(std::nullopt);
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -917,6 +957,10 @@ TEST_CASE("AU v3 without a Bypass parameter still honours setShouldBypassEffect"
 
 TEST_CASE("AU v3 per-method audit invariants",
           "[au][auv3][audit][item-3.1]") {
+    // Pin the test processor's own 1-parameter tree — disable bypass
+    // synthesis (host-quirks P3b) so the count reflects only the plugin's
+    // declared params, not the synthesized Bypass.
+    pulp::format::set_host_quirk_policy(pulp::format::kQuirkFilterOff);
     @autoreleasepool {
         AudioComponentDescription desc{};
         desc.componentType = kAudioUnitType_Effect;
@@ -970,6 +1014,7 @@ TEST_CASE("AU v3 per-method audit invariants",
 
         [unit release];
     }
+    pulp::format::set_host_quirk_policy(std::nullopt);
 }
 
 // Regression guard for the AUv3-in-Logic sizing fix.

--- a/test/test_host_quirks.cpp
+++ b/test/test_host_quirks.cpp
@@ -1427,3 +1427,53 @@ TEST_CASE("latency clamp follows the runtime policy via resolved_quirks",
     REQUIRE(off.clamp_latency_to_nonneg == false);
     REQUIRE(pulp::format::reported_latency_samples(-7, off) == -7);  // raw reported
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// P3b: maybe_synthesize_bypass helper (synthesize_bypass_parameter).
+// ─────────────────────────────────────────────────────────────────────
+
+#include <pulp/format/quirk_apply.hpp>
+#include <pulp/state/store.hpp>
+
+TEST_CASE("maybe_synthesize_bypass injects a Bypass param only when warranted",
+          "[format][host-quirks][p3][bypass]") {
+    using pulp::format::maybe_synthesize_bypass;
+    using pulp::format::kSynthesizedBypassParamId;
+
+    SECTION("synthesizes when enforced and no Bypass exists") {
+        pulp::state::StateStore store;
+        store.add_parameter({.id = 1, .name = "Gain", .range = {-60, 24, 0, 0.1f}});
+        HostQuirks q;  // synthesize_bypass_parameter defaults true
+        REQUIRE(maybe_synthesize_bypass(store, q) == true);
+        REQUIRE(store.param_count() == 2);
+        // The synthesized one carries the reserved ID + boolean range.
+        bool found = false;
+        for (const auto& p : store.all_params()) {
+            if (p.id == kSynthesizedBypassParamId) {
+                found = true;
+                REQUIRE(p.name == "Bypass");
+                REQUIRE(p.range.step >= 1.0f);
+                REQUIRE(p.range.min == 0.0f);
+                REQUIRE(p.range.max == 1.0f);
+            }
+        }
+        REQUIRE(found);
+    }
+
+    SECTION("no-op when the quirk is filtered out") {
+        pulp::state::StateStore store;
+        store.add_parameter({.id = 1, .name = "Gain", .range = {-60, 24, 0, 0.1f}});
+        HostQuirks q;
+        q.synthesize_bypass_parameter = false;
+        REQUIRE(maybe_synthesize_bypass(store, q) == false);
+        REQUIRE(store.param_count() == 1);
+    }
+
+    SECTION("no-op when the plugin already declares a Bypass param") {
+        pulp::state::StateStore store;
+        store.add_parameter({.id = 5, .name = "Bypass", .range = {0, 1, 0, 1}});
+        HostQuirks q;
+        REQUIRE(maybe_synthesize_bypass(store, q) == false);
+        REQUIRE(store.param_count() == 1);
+    }
+}

--- a/test/test_vst3_plugin_state.cpp
+++ b/test/test_vst3_plugin_state.cpp
@@ -2,6 +2,7 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/format/vst3_adapter.hpp>
 #include <pulp/format/host_quirks.hpp>
+#include <pulp/format/quirk_apply.hpp>
 #include <public.sdk/source/vst/hosting/eventlist.h>
 #include <public.sdk/source/vst/hosting/parameterchanges.h>
 
@@ -699,8 +700,10 @@ TEST_CASE("VST3 getState/setState fail cleanly without a live processor",
 //   * When the host sets that parameter to >= 0.5 (denormalized) before
 //     process(), the adapter short-circuits to in→out copy and does NOT
 //     call Processor::process().
-//   * Plugins without a Bypass parameter never see the short-circuit
-//     (the adapter doesn't synthesize one — that's a per-plugin opt-in).
+//   * Plugins without a Bypass parameter see the short-circuit only when
+//     the synthesize_bypass_parameter host-quirk is enforced (P3b), which
+//     injects an automatable Bypass param the detection pass then adopts.
+//     With PULP_HOST_QUIRKS=off no param is synthesized.
 
 TEST_CASE("VST3 processBlockBypassed copies input to output without calling Processor::process",
           "[vst3][bypass][item-3.2]") {
@@ -797,6 +800,11 @@ TEST_CASE("VST3 processBlockBypassed copies input to output without calling Proc
 
 TEST_CASE("VST3 adapter without a Bypass parameter never short-circuits",
           "[vst3][bypass][item-3.2]") {
+    // Since host-quirks P3b the adapter SYNTHESIZES a Bypass param by
+    // default, so the "no bypass surface at all" scenario this test pins
+    // only exists when synthesize_bypass_parameter is disabled.
+    pulp::format::set_host_quirk_policy(pulp::format::kQuirkFilterOff);
+
     TestVst3Config config; // add_bypass_param defaults to false
     reset_test_processor(config);
 
@@ -804,9 +812,109 @@ TEST_CASE("VST3 adapter without a Bypass parameter never short-circuits",
     pulp::format::vst3::PulpVst3Processor processor(create_test_processor);
     REQUIRE(processor.initialize(&host_app) == Steinberg::kResultOk);
 
-    // No "Bypass" parameter declared by the plugin — the adapter should
-    // report the no-op sentinel ID 0 so process() never short-circuits.
+    // No "Bypass" parameter declared by the plugin AND none synthesized —
+    // the adapter reports the no-op sentinel ID 0 so process() never
+    // short-circuits.
     REQUIRE(processor.bypass_parameter_id() == 0u);
+
+    pulp::format::set_host_quirk_policy(std::nullopt);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// host-quirks P3b — synthesize_bypass_parameter, end-to-end (VST3).
+//
+// A plugin that declares NO Bypass parameter: with the quirk enforced the
+// adapter synthesizes an automatable "Bypass" param (reserved ID), the
+// existing detection tags it kIsBypass, and process() honors it with the
+// pass-through short-circuit. With PULP_HOST_QUIRKS=off nothing is
+// synthesized (original behavior).
+// ─────────────────────────────────────────────────────────────────────
+
+TEST_CASE("VST3 synthesizes an automatable Bypass param when the plugin declares none",
+          "[vst3][host-quirks][p3][bypass]") {
+    pulp::format::set_host_quirk_policy(pulp::format::QuirkFilter{});  // quirk on
+
+    TestVst3Config config;
+    config.add_bypass_param = false;  // plugin declares ONLY Gain
+    reset_test_processor(config);
+    HostApp host_app;
+    pulp::format::vst3::PulpVst3Processor processor(create_test_processor);
+    REQUIRE(processor.initialize(&host_app) == Steinberg::kResultOk);
+    auto* test_processor = TestVst3Processor::g_last_processor;
+    REQUIRE(test_processor != nullptr);
+
+    // A synthesized Bypass now exists, carrying the reserved ID + kIsBypass.
+    REQUIRE(processor.getParameterCount() == 2);  // Gain + synthesized Bypass
+    REQUIRE(processor.bypass_parameter_id() ==
+            pulp::format::kSynthesizedBypassParamId);
+
+    Steinberg::Vst::SpeakerArrangement io[1] = {SpeakerArr::kStereo};
+    REQUIRE(processor.setBusArrangements(io, 1, io, 1) == Steinberg::kResultTrue);
+    Steinberg::Vst::ProcessSetup setup{};
+    setup.processMode = Steinberg::Vst::kRealtime;
+    setup.symbolicSampleSize = Steinberg::Vst::kSample32;
+    setup.maxSamplesPerBlock = 4;
+    setup.sampleRate = 48000.0;
+    REQUIRE(processor.setupProcessing(setup) == Steinberg::kResultOk);
+
+    constexpr int kFrames = 4;
+    std::array<float, kFrames> in_l{{0.1f, 0.2f, 0.3f, 0.4f}};
+    std::array<float, kFrames> in_r{{-0.1f, -0.2f, -0.3f, -0.4f}};
+    std::array<float, kFrames> out_l{};
+    std::array<float, kFrames> out_r{};
+    out_l.fill(99.0f);
+    out_r.fill(99.0f);
+    float* ins[2]  = {in_l.data(), in_r.data()};
+    float* outs[2] = {out_l.data(), out_r.data()};
+    Steinberg::Vst::AudioBusBuffers ab_in[1]{};
+    ab_in[0].numChannels = 2; ab_in[0].channelBuffers32 = ins;
+    Steinberg::Vst::AudioBusBuffers ab_out[1]{};
+    ab_out[0].numChannels = 2; ab_out[0].channelBuffers32 = outs;
+
+    // Engage the SYNTHESIZED bypass via its reserved ID → pass-through.
+    Steinberg::Vst::ParameterChanges params(1);
+    Steinberg::int32 q_index = 0;
+    auto* queue = params.addParameterData(
+        static_cast<Steinberg::Vst::ParamID>(pulp::format::kSynthesizedBypassParamId),
+        q_index);
+    REQUIRE(queue != nullptr);
+    Steinberg::int32 pt = 0;
+    REQUIRE(queue->addPoint(0, 1.0, pt) == Steinberg::kResultTrue);
+
+    Steinberg::Vst::ProcessData data{};
+    data.numSamples = kFrames;
+    data.numInputs = 1; data.numOutputs = 1;
+    data.inputs = ab_in; data.outputs = ab_out;
+    data.inputParameterChanges = &params;
+
+    const int before = test_processor->process_count;
+    REQUIRE(processor.process(data) == Steinberg::kResultOk);
+    // Synthesized bypass engaged → input copied through, Processor skipped.
+    for (int i = 0; i < kFrames; ++i) {
+        REQUIRE_THAT(out_l[i], WithinAbs(in_l[i], 1e-6f));
+        REQUIRE_THAT(out_r[i], WithinAbs(in_r[i], 1e-6f));
+    }
+    REQUIRE(test_processor->process_count == before);
+
+    pulp::format::set_host_quirk_policy(std::nullopt);
+}
+
+TEST_CASE("VST3 does NOT synthesize a Bypass param when the quirk is off",
+          "[vst3][host-quirks][p3][bypass]") {
+    pulp::format::set_host_quirk_policy(pulp::format::kQuirkFilterOff);
+
+    TestVst3Config config;
+    config.add_bypass_param = false;
+    reset_test_processor(config);
+    HostApp host_app;
+    pulp::format::vst3::PulpVst3Processor processor(create_test_processor);
+    REQUIRE(processor.initialize(&host_app) == Steinberg::kResultOk);
+
+    // No synthesis: only the plugin's own Gain param, no bypass surface.
+    REQUIRE(processor.getParameterCount() == 1);
+    REQUIRE(processor.bypass_parameter_id() == 0);
+
+    pulp::format::set_host_quirk_policy(std::nullopt);
 }
 
 // ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Implement the third host-quirk cheap defense. synthesize_bypass_parameter
was marked Validated but implemented NOWHERE — the adapters only DETECTED
a plugin-declared bypass, never synthesized one. This wires it for the two
adapters that already have bypass detection + a process pass-through path.

- New shared helper `maybe_synthesize_bypass(store, quirks)` in
  quirk_apply.hpp (kept out of host_quirks.hpp so that header stays free
  of a pulp::state dependency). When the quirk is enforced and no "Bypass"
  param exists, it injects an automatable boolean "Bypass" param with the
  reserved, stable ID kSynthesizedBypassParamId (0x70427970).
- VST3 + AU v3 call it right after define_parameters, BEFORE their existing
  bypass-detection pass — which then adopts the synthesized param (tags it
  kIsBypass / mirrors it onto the AU bypass surface), so process()'s
  pass-through short-circuit honors it with zero further wiring.
- Param enumeration, automation, and state round-trip all flow through the
  StateStore for free.

Validation (empirical, the quirk is respected when enabled):
- VST3 [bypass]: a Gain-only processor gets a synthesized Bypass — param
  count 2, bypass_parameter_id == reserved ID, and engaging it via the
  reserved ID short-circuits to pass-through (Processor not called). Off →
  count 1, id 0.
- AU v3 [bypass]: same processor → pulpBypassParameterId == reserved ID and
  the param appears in the AUParameterTree (count 2).
- Helper unit test: synthesizes when warranted, no-op when filtered out or
  when a Bypass already exists.
- Pre-existing "no-bypass" tests (VST3 + AU v3) updated to set
  PULP_HOST_QUIRKS=off, since synthesis is now the default; full suites
  green (VST3 186, AU v3 205, host-quirks 471, parity OK).

CLAP + AU v2 are intentionally NOT wired — they have no bypass process
path, so a synthesized param would appear-but-do-nothing; inject+honor
together is a separate follow-up. synthesize_bypass_parameter stays
Validated (now genuinely so for VST3/AU v3); catalog last_verified bumped.
See planning/2026-05-30-host-quirks-enforcement-goal.md.

Skill-Update: skip skill=view-bridge reason="au_adapter.mm change is bypass-param synthesis, unrelated to editor attach/resize lifecycle which view-bridge documents"
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>