### PR TITLE
fix(figma-plugin): #43c hardening — reject invalid font drops + diagnose orphan user fonts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.148.0",
+      "version": "0.148.1",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.148.0"
+  "version": "0.148.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.148.0",
+  "version": "0.148.1",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.295.0
+    VERSION 0.295.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/tools/figma-plugin/src/serialize.ts
+++ b/tools/figma-plugin/src/serialize.ts
@@ -42,6 +42,37 @@ export function serializeExport(
   diagnostics: ExtractedDiagnostic[],
   ctx: SerializeContext,
 ): unknown {
+  // #43c orphan-font check — if the user dropped a TTF/OTF for
+  // (family, style) tuples that don't appear in font_family_assets
+  // (drop happened before scan, or selection changed before export),
+  // the bytes still ride in asset_manifest but no catalogue entry
+  // references them. The runtime can find them by hash, but the dead
+  // weight + lack of pointer is worth surfacing so the user knows
+  // they bundled bytes that won't auto-resolve.
+  if (ctx.userFonts && ctx.userFonts.size() > 0) {
+    const stampedKeys = new Set<string>();
+    for (const f of ctx.fontFamilyAssets ?? []) {
+      if (ctx.userFonts.lookup(f.family, f.style)) {
+        stampedKeys.add(`${f.family}|${f.style}`);
+      }
+    }
+    for (const userFont of ctx.userFonts.entries()) {
+      const key = `${userFont.family}|${userFont.style}`;
+      if (!stampedKeys.has(key)) {
+        diagnostics.push({
+          severity: "info",
+          code: "userfont-orphan",
+          kind: "fallback_used",
+          message: `User-supplied font "${userFont.family} ${userFont.style}" ` +
+                   `(${userFont.original_filename}) is bundled in asset_manifest ` +
+                   `but no text node in this selection references that (family, style). ` +
+                   `Runtime can still locate it by content_hash; consider re-scanning fonts before export.`,
+          path: "/font_family_assets",
+        });
+      }
+    }
+  }
+
   // Multi-root: wrap in a synthetic frame so the schema's single-root contract holds.
   const root = roots.length === 1
     ? toEnvelopeNode(roots[0])

--- a/tools/figma-plugin/src/user-fonts.ts
+++ b/tools/figma-plugin/src/user-fonts.ts
@@ -52,22 +52,52 @@ export class UserFontCache {
 
   /// Add a user-supplied font, returning the asset_id. Idempotent on the
   /// (family, style) key — re-adding overwrites the previous bytes.
+  ///
+  /// Throws if the bytes don't look like a real font file. Two gates:
+  ///   1. Bytes must contain at least one full SFNT/WOFF header
+  ///      (4 magic + 8 table-count region = 12 bytes minimum). A 0-byte
+  ///      or under-12-byte drop is rejected here; the previous behaviour
+  ///      was to fall through to filename-based mime detection, which
+  ///      silently propagated an empty / corrupt blob into the zip.
+  ///   2. The bytes' SFNT magic OR a recognisable font-file extension
+  ///      must match — at least one must say "this is a font." Pure
+  ///      magic-byte rejection would be too strict (older font tools
+  ///      occasionally produce non-standard headers); pure
+  ///      filename-trust is too loose (any `.ttf`-renamed binary would
+  ///      pass). Requiring at least one signal catches the common
+  ///      "I dropped the wrong file" UX failure mode.
   async add(
     family: string,
     style: string,
     bytes: Uint8Array,
     original_filename: string,
   ): Promise<UserFontEntry> {
+    if (bytes.length === 0) {
+      throw new Error(
+        `font drop "${original_filename}" is empty (0 bytes); refusing to add to the asset cache.`,
+      );
+    }
+    if (bytes.length < 12) {
+      throw new Error(
+        `font drop "${original_filename}" is ${bytes.length} bytes — too short to be a valid SFNT/WOFF font (need at least 12 bytes for the header). Refusing to add.`,
+      );
+    }
+    const sniffed = detectFontMime(bytes, original_filename);
+    if (sniffed === "application/octet-stream") {
+      throw new Error(
+        `font drop "${original_filename}" doesn't match any known font format ` +
+        `(no SFNT/WOFF magic bytes, filename has no font extension). Refusing to add.`,
+      );
+    }
     const content_hash = await sha256Hex(bytes);
     const asset_id = `userfont-${content_hash.slice(0, 12)}`;
-    const mime = detectFontMime(bytes, original_filename);
     const entry: UserFontEntry = {
       family,
       style,
       asset_id,
       content_hash,
       bytes,
-      mime,
+      mime: sniffed,
       original_filename,
     };
     this.byKey.set(UserFontCache.makeKey(family, style), entry);

--- a/tools/figma-plugin/test/serialize.test.ts
+++ b/tools/figma-plugin/test/serialize.test.ts
@@ -235,7 +235,10 @@ import { UserFontCache } from "../src/user-fonts";
 
 test("serializeExport stamps user-supplied font asset_id (#43c)", async () => {
   const cache = new UserFontCache();
-  const bytes = new Uint8Array([0x00, 0x01, 0x00, 0x00, 0xde, 0xad, 0xbe, 0xef]);
+  // SFNT TrueType magic (0x00010000) + filler bytes to clear the 12-byte minimum header.
+  const bytes = new Uint8Array(16);
+  bytes[0] = 0x00; bytes[1] = 0x01; bytes[2] = 0x00; bytes[3] = 0x00;
+  for (let i = 4; i < 16; i++) bytes[i] = 0xab;
   const entry = await cache.add("Clash Grotesk", "Medium", bytes, "ClashGrotesk-Medium.ttf");
 
   const fontFamilyAssets = [
@@ -280,16 +283,118 @@ test("serializeExport stamps user-supplied font asset_id (#43c)", async () => {
 test("UserFontCache sniffs SFNT magic for font/ttf vs font/otf (#43c)", async () => {
   const cache = new UserFontCache();
 
-  // TrueType magic: 0x00 0x01 0x00 0x00
-  const ttf = await cache.add("F", "R", new Uint8Array([0x00, 0x01, 0x00, 0x00, 0xff]), "any.ttf");
+  // TrueType magic: 0x00 0x01 0x00 0x00 + enough bytes to clear the 12-byte minimum.
+  const ttfBytes = new Uint8Array(16);
+  ttfBytes[0] = 0x00; ttfBytes[1] = 0x01; ttfBytes[2] = 0x00; ttfBytes[3] = 0x00;
+  const ttf = await cache.add("F", "R", ttfBytes, "any.ttf");
   assert.equal(ttf.mime, "font/ttf");
 
-  // OpenType CFF: "OTTO" (0x4f 0x54 0x54 0x4f)
-  const otf = await cache.add("F", "B", new Uint8Array([0x4f, 0x54, 0x54, 0x4f, 0xff]), "any.otf");
+  // OpenType CFF: "OTTO" (0x4f 0x54 0x54 0x4f).
+  const otfBytes = new Uint8Array(16);
+  otfBytes[0] = 0x4f; otfBytes[1] = 0x54; otfBytes[2] = 0x54; otfBytes[3] = 0x4f;
+  const otf = await cache.add("F", "B", otfBytes, "any.otf");
   assert.equal(otf.mime, "font/otf");
 
-  // Filename fallback when bytes are too short or unknown.
-  const fallback = await cache.add("F", "I", new Uint8Array([0xff]), "no-magic.otf");
+  // Filename fallback when bytes don't match a known magic but the filename
+  // has a font extension — still accepted (older font tools or transcoded
+  // assets can produce non-standard headers).
+  const fallbackBytes = new Uint8Array(16); // arbitrary non-magic bytes
+  const fallback = await cache.add("F", "I", fallbackBytes, "no-magic.otf");
   assert.equal(fallback.mime, "font/otf");
+});
+
+// ---------------------------------------------------------------------------
+// #43c follow-up — input validation hardening (filed after self-review).
+// Pulp's "no silent failures" rule: drag-drop UX gaps that let an empty /
+// corrupt blob into the asset cache get caught here, not at runtime three
+// systems away.
+// ---------------------------------------------------------------------------
+
+test("UserFontCache rejects 0-byte drops (#43c hardening)", async () => {
+  const cache = new UserFontCache();
+  await assert.rejects(
+    async () => cache.add("Garbage", "Regular", new Uint8Array(0), "empty.ttf"),
+    /empty/i,
+    "0-byte drop must throw, not silently succeed",
+  );
+  assert.equal(cache.size(), 0, "rejected drop must not enter the cache");
+});
+
+test("UserFontCache rejects too-short drops (#43c hardening)", async () => {
+  const cache = new UserFontCache();
+  // 5 bytes — has SFNT magic prefix but truncated before the 12-byte header
+  // SFNT needs (magic + numTables + searchRange + entrySelector + rangeShift =
+  // 12 bytes minimum). Anything shorter is definitely not a font, regardless
+  // of filename.
+  const truncated = new Uint8Array([0x00, 0x01, 0x00, 0x00, 0xff]);
+  await assert.rejects(
+    async () => cache.add("Garbage", "Regular", truncated, "short.ttf"),
+    /too short/i,
+    "5-byte drop must throw — too short for any valid font header",
+  );
+  assert.equal(cache.size(), 0);
+});
+
+test("UserFontCache rejects non-font drops with no magic + no font extension (#43c hardening)", async () => {
+  const cache = new UserFontCache();
+  // Plain binary, no SFNT/WOFF magic, no font extension.
+  const blob = new Uint8Array(64);
+  blob.fill(0xab);
+  await assert.rejects(
+    async () => cache.add("Suspicious", "Regular", blob, "screenshot.png"),
+    /doesn't match any known font format/i,
+    "non-font binary with non-font filename must throw",
+  );
+  assert.equal(cache.size(), 0);
+});
+
+test("serializeExport emits userfont-orphan diagnostic for unmatched user fonts (#43c hardening)", async () => {
+  const cache = new UserFontCache();
+  const orphanBytes = new Uint8Array(16);
+  orphanBytes[0] = 0x00; orphanBytes[1] = 0x01; orphanBytes[2] = 0x00; orphanBytes[3] = 0x00;
+  await cache.add("Clash Grotesk", "Medium", orphanBytes, "ClashGrotesk-Medium.ttf");
+
+  // The font_family_assets catalogue is empty — the user dropped a TTF for a
+  // family that no text node in this selection references (drop happened
+  // before scan, or selection changed before export).
+  const diagnostics: any[] = [];
+  const out = serializeExport([knobNode()], diagnostics, ctx({
+    fontFamilyAssets: [],
+    userFonts: cache,
+  })) as Record<string, any>;
+
+  const env_diags = out.diagnostics as Array<Record<string, any>>;
+  const orphan = env_diags.find((d) => d.code === "userfont-orphan");
+  assert.ok(orphan, `expected userfont-orphan diagnostic, got: ${JSON.stringify(env_diags)}`);
+  assert.equal(orphan.severity, "info");
+  assert.equal(orphan.kind, "fallback_used");
+  assert.match(orphan.message, /Clash Grotesk Medium/, "diagnostic identifies the orphan family");
+  assert.match(orphan.message, /ClashGrotesk-Medium\.ttf/, "diagnostic identifies the source filename");
+
+  // The bytes still appear in asset_manifest — orphan is a warning, not a drop.
+  const assetEntry = (out.asset_manifest.assets as Array<Record<string, any>>).find(
+    (a) => a.asset_id.startsWith("userfont-"),
+  );
+  assert.ok(assetEntry, "orphan bytes still ride in asset_manifest by content_hash");
+});
+
+test("serializeExport does NOT emit userfont-orphan when every cached font is referenced (#43c hardening)", async () => {
+  const cache = new UserFontCache();
+  const okBytes = new Uint8Array(16);
+  okBytes[0] = 0x00; okBytes[1] = 0x01; okBytes[2] = 0x00; okBytes[3] = 0x00;
+  await cache.add("Inter", "Regular", okBytes, "Inter-Regular.ttf");
+
+  const diagnostics: any[] = [];
+  const out = serializeExport([knobNode()], diagnostics, ctx({
+    fontFamilyAssets: [{ family: "Inter", style: "Regular", weight: 400 }],
+    userFonts: cache,
+  })) as Record<string, any>;
+
+  const env_diags = out.diagnostics as Array<Record<string, any>>;
+  assert.equal(
+    env_diags.filter((d) => d.code === "userfont-orphan").length,
+    0,
+    "no orphan diagnostic when every cached font matches a catalogue entry",
+  );
 });
 


### PR DESCRIPTION
# fix(figma-plugin): #43c hardening — reject invalid font drops + diagnose orphan user fonts

## Summary

Two real input-validation gaps surfaced in a self-review sweep of #3215 (the drag-drop UI escape hatch). Both violate Pulp's "no silent failures" rule.

## What's fixed

### (1) `UserFontCache.add` silently accepted invalid drops

Before this PR, the following all succeeded:

- **0-byte file** dropped as `Foo.ttf` → cache stored an empty entry, UI flipped to "✓ bundled", export zipped the empty blob, runtime later failed.
- **<12-byte file** (too short for any valid SFNT/WOFF header) — same flow.
- **Arbitrary binary** (e.g. a PNG dropped as `screenshot.png`) — fell through to filename → mime `application/octet-stream`, still cached.

`add()` now throws (the existing try/catch in `code.ts` surfaces the error to the UI as an `error` reply) on each of those cases. The validation requires:

1. `bytes.length >= 12` (SFNT/WOFF minimum header)
2. **At least one signal** says "this is a font" — either SFNT/WOFF magic bytes OR a recognised font-file extension. Bytes that match neither are rejected. This catches the "I dropped the wrong file" UX failure without being too strict (older font tools occasionally emit non-standard headers; a `.otf` filename salvages those).

### (2) Orphan user fonts now emit a diagnostic

If the user drops a TTF for `(family, style)` tuples that **don't appear** in `font_family_assets` (drop happened before scan, or selection changed before export), the bytes still ride in `asset_manifest` but no `font_family_assets` entry references them. Bytes weren't dropped, but the runtime could only locate them by `content_hash` with no semantic pointer.

`serializeExport` now emits:

```json
{
  "severity": "info",
  "code": "userfont-orphan",
  "kind": "fallback_used",
  "message": "User-supplied font \"Clash Grotesk Medium\" (ClashGrotesk-Medium.ttf) is bundled in asset_manifest but no text node in this selection references that (family, style). Runtime can still locate it by content_hash; consider re-scanning fonts before export.",
  "path": "/font_family_assets"
}
```

so the user knows to re-scan fonts before export.

## Tests (CLAUDE.md "tests ship with fixes")

5 new tests under `test/serialize.test.ts`:

| Test | Pins |
|---|---|
| `UserFontCache rejects 0-byte drops (#43c hardening)` | Empty file → throws, cache stays empty |
| `UserFontCache rejects too-short drops (#43c hardening)` | <12-byte file → throws |
| `UserFontCache rejects non-font drops with no magic + no font extension (#43c hardening)` | Arbitrary binary with non-font filename → throws |
| `serializeExport emits userfont-orphan diagnostic for unmatched user fonts (#43c hardening)` | Orphan → diagnostic emitted, bytes still ride in asset_manifest |
| `serializeExport does NOT emit userfont-orphan when every cached font is referenced (#43c hardening)` | No orphan → no diagnostic noise |

Two pre-existing tests (`stamps user-supplied font asset_id` and `sniffs SFNT magic`) updated to use ≥12-byte buffers — same operation, satisfies the new minimum-size gate.

**Test count: 16 → 21.**

## Verification

```
$ npm run typecheck     # clean (all three entries)
$ npm run build         # clean. Headless bundle 26 332 bytes (23 668 headroom under 50KB cap).
$ npm test              # 21/21 pass
```

## Source

Self-review sweep using the parallel-subagent + diff-scoped approach from CLAUDE.md memory (`Codex scans: diff-scoped beats whole-file`). Three subagents reviewed PRs #3209/#3215/#3227/#3229 + the planning tooling; this PR addresses the only **P2 real-bug** finding plus the orphan-diagnostic UX gap. Three cosmetic items (default mime fallback for unknown bytes, redundant equality check in `collectFontFamilyAssets`, `CSS.escape` fallback that never fires in practice) are intentionally skipped — pure noise.

## Version bumps

- SDK (`CMakeLists.txt`) 0.295.0 → **0.295.1** (patch; fix)
- Claude plugin (`.claude-plugin/`) 0.148.0 → **0.148.1** (patch; fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)