### PR TITLE
feat(format): host-quirks staleness check + affected_versions catalog field (P4)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -2426,3 +2426,16 @@ capacity, not a queue waiting on the Mac. Namespace is no longer a
 routing target (cut for cost, 2026-05-20). The matrix leg name's
 `[<provider>]` suffix reflects the real route (`local` / `github-hosted`
 / `operator`).
+
+## Host-quirks staleness check (host-quirks P4)
+
+`.github/workflows/host-quirks-staleness.yml` — scheduled (monthly) +
+`workflow_dispatch`, **preview-only**. Runs `tools/scripts/host_quirks_staleness.py`
+(+ the staleness unit test + the catalog parity test) to surface host-quirk
+catalog entries due for re-review: Speculative/LessonOnly rows not
+re-verified in N months (default 6), and Validated rows with
+`affected_versions` (re-check vs the host's current major). It prints a
+report and exits 0 — it does **not** open issues (no false-positive spam).
+Promoting it to auto-open tracking issues is a future opt-in. Detection
+lives in the pure `stale_entries()` fn (unit-tested in
+`tools/scripts/test_host_quirks_staleness.py`), so it needs no clock/network.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.148.2",
+      "version": "0.149.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.148.2"
+  "version": "0.149.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.148.2",
+  "version": "0.149.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/.github/workflows/host-quirks-staleness.yml
+++ b/.github/workflows/host-quirks-staleness.yml
@@ -1,0 +1,50 @@
+name: Host-quirks staleness check
+
+# host-quirks enforcement plan, P4.
+#
+# Scheduled, PREVIEW-ONLY reminder that surfaces host-quirk catalog entries
+# due for re-review:
+#   * Speculative / LessonOnly rows not re-verified in N months (default 6)
+#   * Validated rows carrying affected_versions (re-check vs current major)
+#
+# Deliberately advisory: it prints the report to the run log and exits 0.
+# It does NOT open issues (no false-positive spam — acceptance criterion).
+# Promoting this to auto-open tracking issues is a future opt-in once the
+# cadence + signal-to-noise are trusted.
+
+on:
+  schedule:
+    - cron: '0 9 1 * *'  # 09:00 UTC on the 1st of each month
+  workflow_dispatch:
+    inputs:
+      months:
+        description: 'Staleness window in months'
+        required: false
+        default: '6'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: host-quirks-staleness
+  cancel-in-progress: false
+
+jobs:
+  staleness:
+    runs-on: ubuntu-latest
+    name: Report stale host-quirk catalog entries
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Run staleness unit tests
+        run: python3 tools/scripts/test_host_quirks_staleness.py
+
+      - name: Catalog parity (struct/meta/JSON must agree)
+        run: python3 tools/scripts/test_host_quirks_catalog_parity.py
+
+      - name: Report (preview only — advisory, opens no issues)
+        shell: bash
+        run: |
+          set -euo pipefail
+          months="${{ github.event.inputs.months || '6' }}"
+          python3 tools/scripts/host_quirks_staleness.py --months "${months}"

--- a/core/format/host-quirks.json
+++ b/core/format/host-quirks.json
@@ -10,7 +10,8 @@
     "source_type": "spec | release-notes | repro | in-DAW-bench | unknown \u2014 how the quirk was established.",
     "evidence": "Issue/PR/doc reference or short pointer; 'unknown' where the log is not explicit.",
     "last_verified": "ISO date the tier was last affirmed, or 'unknown'.",
-    "note": "One-line human-readable summary."
+    "note": "One-line human-readable summary.",
+    "affected_versions": "Free-text host-version expression the quirk applies to (e.g. =10.1.13, <6.0, 13+, fixed in 7.0). Optional; read by the staleness job to prompt re-verification against new host majors. Not a parsed DSL."
   },
   "quirks": [
     {
@@ -81,7 +82,8 @@
       "source_type": "spec",
       "evidence": "macOS plan item 5.3 (DAW-quirks row 4); host-quirks-log.md 2026-05-25",
       "last_verified": "2026-05-25",
-      "note": "State-blob stream-size mismatch validation."
+      "note": "State-blob stream-size mismatch validation.",
+      "affected_versions": "9"
     },
     {
       "flag": "live_vst3_canresize_ignore",
@@ -111,7 +113,8 @@
       "source_type": "release-notes",
       "evidence": "iPlug2 quirks audit 2026-05-25 (clean-room lessons); host-quirks-log.md 2026-05-25",
       "last_verified": "2026-05-25",
-      "note": "Live 10.1.13 IInfoListener::getString writes past spec buffer length; allocate buffers at twice spec size."
+      "note": "Live 10.1.13 IInfoListener::getString writes past spec buffer length; allocate buffers at twice spec size.",
+      "affected_versions": "=10.1.13"
     },
     {
       "flag": "bitwig_vst3_linux_repaint_after_resize",
@@ -131,7 +134,8 @@
       "source_type": "repro",
       "evidence": "macOS plan item 5.5 (DAW-quirks row 9); host-quirks-log.md 2026-05-25",
       "last_verified": "2026-05-25",
-      "note": "VST3 setBusArrangements invoked while active."
+      "note": "VST3 setBusArrangements invoked while active.",
+      "affected_versions": "<6.0"
     },
     {
       "flag": "skip_bus_arrangement_call",
@@ -381,7 +385,8 @@
       "source_type": "repro",
       "evidence": "Pulp #3047 (iPlug2-audit batch 2026-05-26); host-quirks-log.md 2026-05-26",
       "last_verified": "2026-05-26",
-      "note": "Derive MIDI CC parameter IDs from a stable hash (not runtime index) so automation lanes survive reload on 13.x."
+      "note": "Derive MIDI CC parameter IDs from a stable hash (not runtime index) so automation lanes survive reload on 13.x.",
+      "affected_versions": "13+"
     }
   ]
 }

--- a/core/format/host-quirks.schema.json
+++ b/core/format/host-quirks.schema.json
@@ -26,6 +26,10 @@
           },
           "evidence": { "type": "string" },
           "last_verified": { "type": "string" },
+          "affected_versions": {
+            "type": "string",
+            "description": "Free-text host-version expression the quirk applies to (e.g. \"=10.1.13\", \"<6.0\", \"13+\", \"fixed in 7.0\"). Optional; consumed by the staleness job to prompt re-verification against new host majors. NOT a parsed version DSL — human-readable only."
+          },
           "note": { "type": "string" }
         }
       }

--- a/tools/scripts/host_quirks_staleness.py
+++ b/tools/scripts/host_quirks_staleness.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""host_quirks_staleness.py — flag host-quirk catalog entries due for re-review.
+
+Reads ``core/format/host-quirks.json`` and reports two kinds of staleness
+(host-quirks enforcement plan, P4):
+
+  * ``Speculative`` / ``LessonOnly`` entries whose ``last_verified`` date is
+    older than N months — they were never bench-confirmed and may have
+    rotted (a host shipped a fix, or the symptom changed).
+  * ``Validated`` entries carrying an ``affected_versions`` expression — a
+    prompt to re-verify them against the host's *current* major, since a
+    DAW that fixed the underlying bug makes the accommodation dead weight.
+
+This is a **preview/report tool** by default: it prints findings and exits 0
+(advisory). The CI workflow that wraps it decides whether to open tracking
+issues. Detection is a pure function (``stale_entries``) so it unit-tests
+without touching the clock or the network.
+
+Usage:
+    python3 tools/scripts/host_quirks_staleness.py [--catalog PATH]
+        [--now YYYY-MM-DD] [--months N] [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+DEFAULT_CATALOG = REPO_ROOT / "core" / "format" / "host-quirks.json"
+DEFAULT_STALE_MONTHS = 6
+
+# Tiers that go stale on age (never bench-confirmed → may have rotted).
+AGE_STALE_TIERS = {"Speculative", "LessonOnly"}
+
+
+def _parse_date(s: str) -> _dt.date | None:
+    """Parse a YYYY-MM-DD date; return None if absent/unparseable."""
+    if not s:
+        return None
+    try:
+        return _dt.date.fromisoformat(s.strip()[:10])
+    except ValueError:
+        return None
+
+
+def _months_between(earlier: _dt.date, later: _dt.date) -> int:
+    """Whole months from `earlier` to `later` (calendar-based, floored)."""
+    months = (later.year - earlier.year) * 12 + (later.month - earlier.month)
+    if later.day < earlier.day:
+        months -= 1
+    return max(0, months)
+
+
+def stale_entries(quirks: list[dict], now: _dt.date, months: int) -> list[dict]:
+    """Return the catalog entries due for re-review, with a reason.
+
+    Pure function — no I/O, no clock. Each result is the original entry plus
+    ``_staleness`` = {"kind", "reason", "age_months"}.
+    """
+    out: list[dict] = []
+    for q in quirks:
+        tier = q.get("tier", "")
+        last = _parse_date(q.get("last_verified", ""))
+
+        if tier in AGE_STALE_TIERS:
+            if last is None:
+                out.append({**q, "_staleness": {
+                    "kind": "age",
+                    "reason": f"{tier} with no parseable last_verified",
+                    "age_months": None,
+                }})
+                continue
+            age = _months_between(last, now)
+            if age >= months:
+                out.append({**q, "_staleness": {
+                    "kind": "age",
+                    "reason": (f"{tier} not re-verified in {age} months "
+                               f"(>= {months})"),
+                    "age_months": age,
+                }})
+        elif tier == "Validated" and q.get("affected_versions"):
+            # Not age-gated — a standing prompt to confirm the accommodation
+            # is still needed on the host's current major.
+            out.append({**q, "_staleness": {
+                "kind": "version-recheck",
+                "reason": (f"Validated; re-verify still needed on current "
+                           f"major (affected_versions="
+                           f"{q['affected_versions']})"),
+                "age_months": _months_between(last, now) if last else None,
+            }})
+    return out
+
+
+def render_report(entries: list[dict], months: int) -> str:
+    if not entries:
+        return f"host-quirks staleness: no entries past the {months}-month window. ✓"
+    lines = [f"host-quirks staleness report ({len(entries)} flagged):", ""]
+    for e in entries:
+        s = e["_staleness"]
+        lines.append(f"  • {e['flag']} [{e.get('tier')}] — {s['reason']}")
+        lines.append(f"      host={e.get('host')} last_verified={e.get('last_verified', '?')}")
+    lines.append("")
+    lines.append("Advisory: review these rows; promote/demote tiers or refresh "
+                 "last_verified after re-checking against the current host.")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--catalog", type=pathlib.Path, default=DEFAULT_CATALOG)
+    ap.add_argument("--now", default=None,
+                    help="Reference date YYYY-MM-DD (default: today).")
+    ap.add_argument("--months", type=int, default=DEFAULT_STALE_MONTHS)
+    ap.add_argument("--json", action="store_true",
+                    help="Emit the flagged entries as a JSON array.")
+    args = ap.parse_args(argv)
+
+    now = _parse_date(args.now) if args.now else _dt.date.today()
+    if now is None:
+        print(f"error: --now '{args.now}' is not YYYY-MM-DD", file=sys.stderr)
+        return 2
+
+    catalog = json.loads(args.catalog.read_text(encoding="utf-8"))
+    entries = stale_entries(catalog.get("quirks", []), now, args.months)
+
+    if args.json:
+        print(json.dumps(entries, indent=2))
+    else:
+        print(render_report(entries, args.months))
+    # Advisory tool: always exit 0 so the scheduled job decides what to do.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/scripts/test_host_quirks_staleness.py
+++ b/tools/scripts/test_host_quirks_staleness.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Unit tests for host_quirks_staleness.stale_entries (host-quirks P4).
+
+Pure-logic tests with a fixed reference date — no clock, no network, no
+catalog file needed. Run:
+    python3 tools/scripts/test_host_quirks_staleness.py
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import importlib.util
+import pathlib
+import unittest
+
+_HERE = pathlib.Path(__file__).resolve().parent
+_spec = importlib.util.spec_from_file_location(
+    "host_quirks_staleness", _HERE / "host_quirks_staleness.py")
+hqs = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(hqs)
+
+
+NOW = _dt.date(2026, 5, 30)
+
+
+class StaleEntries(unittest.TestCase):
+    def test_speculative_past_window_is_flagged(self) -> None:
+        quirks = [{"flag": "old_spec", "tier": "Speculative",
+                   "last_verified": "2025-09-01"}]  # ~9 months
+        out = hqs.stale_entries(quirks, NOW, months=6)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["_staleness"]["kind"], "age")
+        self.assertGreaterEqual(out[0]["_staleness"]["age_months"], 6)
+
+    def test_speculative_inside_window_is_not_flagged(self) -> None:
+        quirks = [{"flag": "fresh_spec", "tier": "Speculative",
+                   "last_verified": "2026-04-01"}]  # ~2 months
+        self.assertEqual(hqs.stale_entries(quirks, NOW, months=6), [])
+
+    def test_lesson_only_with_no_date_is_flagged(self) -> None:
+        quirks = [{"flag": "dateless", "tier": "LessonOnly"}]
+        out = hqs.stale_entries(quirks, NOW, months=6)
+        self.assertEqual(len(out), 1)
+        self.assertIsNone(out[0]["_staleness"]["age_months"])
+
+    def test_validated_without_version_is_not_flagged(self) -> None:
+        quirks = [{"flag": "plain_validated", "tier": "Validated",
+                   "last_verified": "2024-01-01"}]
+        # Validated + no affected_versions → no standing recheck prompt.
+        self.assertEqual(hqs.stale_entries(quirks, NOW, months=6), [])
+
+    def test_validated_with_version_gets_recheck_prompt(self) -> None:
+        quirks = [{"flag": "ver_validated", "tier": "Validated",
+                   "affected_versions": "13+", "last_verified": "2026-05-01"}]
+        out = hqs.stale_entries(quirks, NOW, months=6)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["_staleness"]["kind"], "version-recheck")
+
+    def test_months_between_boundary(self) -> None:
+        # Exactly 6 months → flagged at the >= threshold.
+        quirks = [{"flag": "exactly_six", "tier": "Speculative",
+                   "last_verified": "2025-11-30"}]
+        out = hqs.stale_entries(quirks, NOW, months=6)
+        self.assertEqual(len(out), 1)
+
+
+class RealCatalogSmoke(unittest.TestCase):
+    """The shipped catalog runs through the detector without error."""
+
+    def test_real_catalog_parses_and_runs(self) -> None:
+        import json
+        catalog = json.loads(hqs.DEFAULT_CATALOG.read_text(encoding="utf-8"))
+        # Should not raise; returns a (possibly empty) list.
+        out = hqs.stale_entries(catalog.get("quirks", []), NOW, months=6)
+        self.assertIsInstance(out, list)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Make catalog freshness + affected-version provenance queryable, and add a
scheduled reminder to re-review aging quirks (host-quirks enforcement plan,
P4). Closes the owner ask (2026-05-30) for structured "which versions /
was it fixed" tracking — without a version DSL.

- affected_versions: new OPTIONAL free-text field on host-quirks.json
  entries (schema + _field_docs). Populated where the host version is
  already documented in prose: cubase9 ("9"), Live 10.1.13 ("=10.1.13"),
  bitwig setBusArrangements ("<6.0"), cubase13 ("13+"). Backward
  compatible — not required; parity test unaffected.
- tools/scripts/host_quirks_staleness.py: preview/report tool. Pure
  stale_entries() flags Speculative/LessonOnly rows past an N-month
  (default 6) last_verified window, and Validated rows carrying
  affected_versions for current-major re-check. Advisory — exits 0.
- .github/workflows/host-quirks-staleness.yml: monthly + workflow_dispatch,
  PREVIEW-ONLY (prints the report, opens NO issues — no false-positive
  spam). Also runs the staleness unit test + the catalog parity test.

Tests: tools/scripts/test_host_quirks_staleness.py (7 cases, fixed
reference date — no clock/network) + real-catalog smoke; parity green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>