### PR TITLE
feat(format): synthesize + honor a Bypass parameter in CLAP and AU v2 (P3d)

### DIFF
--- a/.agents/skills/auv2/SKILL.md
+++ b/.agents/skills/auv2/SKILL.md
@@ -306,3 +306,18 @@ through the pure helper `pulp::format::reported_latency_samples(raw, quirks)`
 (in `host_quirks.hpp`): a negative `latency_samples()` clamps to 0 when the
 quirk is enforced, and passes through raw (wrapping the unsigned host field)
 when `PULP_HOST_QUIRKS=off`. See `docs/reference/host-quirks-policy.md`.
+
+## synthesize_bypass_parameter pass-through (host-quirks P3d, 2026-05-30)
+
+This adapter had no bypass process path; P3d adds the full P3b behavior.
+At init (clap_init / PulpAUEffect ctor) it calls
+`pulp::format::maybe_synthesize_bypass(store, host_quirks)` then detects the
+"Bypass" param (shared boolean-range heuristic: name=="Bypass", step>=1,
+0..1) into a cached `bypass_param_id`. In the audio callback (clap_process /
+ProcessBufferLists) it short-circuits to a **null-guarded pass-through**
+(copy main input → output, zero any output channel without a matching input)
+and skips the Processor when the param value is >= 0.5 — mirroring the VST3
+processBlockBypassed path. `PULP_HOST_QUIRKS=off` synthesizes nothing
+(bypass_param_id stays 0). The pass-through MUST null-check each destination
+channel pointer (a bus can report channels with null buffers — see #178 /
+the #3240 sweep).

--- a/.agents/skills/clap/SKILL.md
+++ b/.agents/skills/clap/SKILL.md
@@ -558,3 +558,18 @@ through the pure helper `pulp::format::reported_latency_samples(raw, quirks)`
 (in `host_quirks.hpp`): a negative `latency_samples()` clamps to 0 when the
 quirk is enforced, and passes through raw (wrapping the unsigned host field)
 when `PULP_HOST_QUIRKS=off`. See `docs/reference/host-quirks-policy.md`.
+
+## synthesize_bypass_parameter pass-through (host-quirks P3d, 2026-05-30)
+
+This adapter had no bypass process path; P3d adds the full P3b behavior.
+At init (clap_init / PulpAUEffect ctor) it calls
+`pulp::format::maybe_synthesize_bypass(store, host_quirks)` then detects the
+"Bypass" param (shared boolean-range heuristic: name=="Bypass", step>=1,
+0..1) into a cached `bypass_param_id`. In the audio callback (clap_process /
+ProcessBufferLists) it short-circuits to a **null-guarded pass-through**
+(copy main input → output, zero any output channel without a matching input)
+and skips the Processor when the param value is >= 0.5 — mirroring the VST3
+processBlockBypassed path. `PULP_HOST_QUIRKS=off` synthesizes nothing
+(bypass_param_id stays 0). The pass-through MUST null-check each destination
+channel pointer (a bus can report channels with null buffers — see #178 /
+the #3240 sweep).

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.149.1",
+      "version": "0.150.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.149.1"
+  "version": "0.150.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.149.1",
+  "version": "0.150.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.296.0
+    VERSION 0.297.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/au_v2_adapter.hpp
+++ b/core/format/include/pulp/format/au_v2_adapter.hpp
@@ -142,6 +142,11 @@ private:
     // Host accommodations, resolved once in the constructor via the
     // runtime policy (host-quirks plan, P3).
     HostQuirks host_quirks_{};
+
+    // Cached ParamID of the "Bypass" parameter (plugin-declared or
+    // synthesized via synthesize_bypass_parameter, host-quirks P3d). 0 when
+    // none — ProcessBufferLists then never short-circuits to pass-through.
+    state::ParamID bypass_param_id_ = 0;
     std::vector<const float*> input_ptrs_;
     std::vector<float*> output_ptrs_;
     // Pre-process snapshot of parameter values; used to diff plugin-side

--- a/core/format/include/pulp/format/clap_adapter.hpp
+++ b/core/format/include/pulp/format/clap_adapter.hpp
@@ -40,6 +40,11 @@ struct PulpClapPlugin {
     // (host-quirks plan, P3).
     HostQuirks host_quirks{};
 
+    // Cached ParamID of the "Bypass" parameter (plugin-declared or
+    // synthesized via synthesize_bypass_parameter, host-quirks P3d). 0 when
+    // none — clap_process() then never short-circuits to pass-through.
+    state::ParamID bypass_param_id = 0;
+
     // Stored at create_plugin() time so the adapter can publish
     // latency / tail change notifications (item 3.11) back to the
     // host. `clap_on_main_thread()` consumes the processor's pending

--- a/core/format/src/au_v2_adapter.cpp
+++ b/core/format/src/au_v2_adapter.cpp
@@ -9,6 +9,7 @@
 #include <mach/mach_time.h>
 
 #include <pulp/format/au_v2_adapter.hpp>
+#include <pulp/format/quirk_apply.hpp>
 #include <pulp/format/detail/playhead_diff.hpp>
 #include <pulp/format/plugin_state_io.hpp>
 #include <pulp/format/registry.hpp>
@@ -79,6 +80,19 @@ PulpAUEffect::PulpAUEffect(AudioComponentInstance ci)
             // the runtime policy (PULP_HOST_QUIRKS env / API).
             const auto host_info = detect_host_info();
             host_quirks_ = resolved_quirks(host_info.type, host_info.version);
+
+            // synthesize_bypass_parameter (host-quirks P3d): inject an
+            // automatable Bypass when the plugin declared none (before the
+            // AU param list is built from the store), then detect it so
+            // ProcessBufferLists can honor it with a pass-through.
+            maybe_synthesize_bypass(store_, host_quirks_);
+            for (const auto& p : store_.all_params()) {
+                if (p.name == "Bypass" && p.range.step >= 1.0f &&
+                    p.range.min == 0.0f && p.range.max == 1.0f) {
+                    bypass_param_id_ = p.id;
+                    break;
+                }
+            }
 
             // Wire gesture callbacks for undo grouping support.
             store_.set_gesture_callbacks(
@@ -332,6 +346,24 @@ OSStatus PulpAUEffect::ProcessBufferLists(AudioUnitRenderActionFlags& ioActionFl
     }
     for (UInt32 i = 0; i < out_channels; ++i) {
         output_ptrs_[i] = static_cast<float*>(outBuffer.mBuffers[i].mData);
+    }
+
+    // synthesize_bypass_parameter (host-quirks P3d): when the Bypass param
+    // (declared or synthesized) is engaged, copy main input → main output
+    // (null-guarded), zero any output channel without a matching input, and
+    // skip the Processor — mirrors the VST3/CLAP pass-through. The value was
+    // pulled into the store from GetParameter() above.
+    if (bypass_param_id_ != 0 && store_.get_value(bypass_param_id_) >= 0.5f) {
+        for (UInt32 ch = 0; ch < out_channels; ++ch) {
+            float* dst = output_ptrs_[ch];
+            if (dst == nullptr) continue;
+            if (ch < in_channels && input_ptrs_[ch] != nullptr) {
+                std::memcpy(dst, input_ptrs_[ch], sizeof(float) * inFramesToProcess);
+            } else {
+                std::memset(dst, 0, sizeof(float) * inFramesToProcess);
+            }
+        }
+        return noErr;
     }
 
     audio::BufferView<const float> input_view(

--- a/core/format/src/clap_adapter.cpp
+++ b/core/format/src/clap_adapter.cpp
@@ -2,6 +2,7 @@
 // Implements the CLAP C API wrapping a Pulp Processor
 
 #include <pulp/format/clap_adapter.hpp>
+#include <pulp/format/quirk_apply.hpp>
 #include <pulp/format/ara.hpp>
 #include <pulp/format/detail/playhead_diff.hpp>
 #include <pulp/midi/ump_conversion.hpp>
@@ -50,6 +51,19 @@ bool clap_init(const clap_plugin_t* plugin) {
     {
         const auto host_info = detect_host_info();
         self->host_quirks = resolved_quirks(host_info.type, host_info.version);
+    }
+
+    // synthesize_bypass_parameter (host-quirks P3d): inject an automatable
+    // Bypass param when the plugin declared none, then detect it (the same
+    // boolean-range heuristic VST3/AU use) so clap_process() can honor it
+    // with a pass-through short-circuit. No-op when the quirk is off.
+    maybe_synthesize_bypass(self->store, self->host_quirks);
+    for (const auto& p : self->store.all_params()) {
+        if (p.name == "Bypass" && p.range.step >= 1.0f &&
+            p.range.min == 0.0f && p.range.max == 1.0f) {
+            self->bypass_param_id = p.id;
+            break;
+        }
     }
 
     // Item 6.4b — opt this plugin instance into the process-wide
@@ -563,7 +577,25 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
     // a plugin that allocates on the audio thread. The guard is a
     // thread-local counter — zero cost in NDEBUG, ~1 ns in debug.
     // See planning/2026-05-18-rt-safety-and-debug-dx.md Slice 4.
-    {
+    // synthesize_bypass_parameter (host-quirks P3d): when the Bypass param
+    // (declared or synthesized) is engaged, the adapter does the pass-through
+    // itself — copy main input → main output (null-guarded), zero any output
+    // channel without a matching input — and skips the Processor entirely.
+    // Mirrors the VST3 processBlockBypassed behavior.
+    const bool bypassed = self->bypass_param_id != 0 &&
+                          self->store.get_value(self->bypass_param_id) >= 0.5f;
+    if (bypassed) {
+        for (int ch = 0; ch < out_channels; ++ch) {
+            if (self->output_ptrs[ch] == nullptr) continue;
+            if (ch < in_channels && self->input_ptrs[ch] != nullptr) {
+                std::memcpy(self->output_ptrs[ch], self->input_ptrs[ch],
+                            sizeof(float) * num_samples);
+            } else {
+                std::memset(self->output_ptrs[ch], 0, sizeof(float) * num_samples);
+            }
+        }
+        self->processor->set_sidechain(nullptr);
+    } else {
         pulp::runtime::ScopedNoAlloc no_alloc_guard;
         self->processor->process(output_view, input_view, midi_in, midi_out, ctx);
     }

--- a/test/test_clap_entry.cpp
+++ b/test/test_clap_entry.cpp
@@ -6,6 +6,7 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/format/processor.hpp>
 #include <pulp/format/clap_entry.hpp>
+#include <pulp/format/host_quirks.hpp>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -332,6 +333,10 @@ TEST_CASE("CLAP entry fallback metadata handles missing processors",
 
 TEST_CASE("CLAP params extension reports metadata and text conversions",
           "[clap][entry][params]") {
+    // Disable host-quirk synthesis so the count below reflects only the
+    // plugin's declared params — since host-quirks P3d the CLAP adapter
+    // synthesizes a Bypass param by default.
+    pulp::format::set_host_quirk_policy(pulp::format::kQuirkFilterOff);
     REQUIRE(clap_entry.init("test"));
 
     auto* factory = static_cast<const clap_plugin_factory_t*>(
@@ -375,6 +380,7 @@ TEST_CASE("CLAP params extension reports metadata and text conversions",
 
     plugin->destroy(plugin);
     clap_entry.deinit();
+    pulp::format::set_host_quirk_policy(std::nullopt);
 }
 
 TEST_CASE("CLAP params extension formats fallbacks and flushes gestures",

--- a/test/test_clap_host_validation.cpp
+++ b/test/test_clap_host_validation.cpp
@@ -32,6 +32,7 @@
 
 #include <pulp/format/clap_adapter.hpp>
 #include <pulp/format/clap_entry.hpp>
+#include <pulp/format/host_quirks.hpp>
 #include <pulp/format/processor.hpp>
 #include <pulp/state/store.hpp>
 
@@ -39,6 +40,7 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -202,6 +204,12 @@ PULP_CLAP_PLUGIN(make_host_validation)
 
 TEST_CASE("CLAP plugin id + parameter IDs are stable across instances",
           "[clap][host-validation][issue-3-4]") {
+    // Disable host-quirk synthesis so this test sees ONLY the plugin's
+    // declared parameters — since host-quirks P3d the CLAP adapter
+    // synthesizes a Bypass param by default, which would otherwise bump
+    // the count this test pins.
+    pulp::format::set_host_quirk_policy(pulp::format::kQuirkFilterOff);
+
     // Force the entry to reinitialise its cached descriptor so we read
     // the canonical (factory-fresh) value rather than a leftover from
     // an earlier suite.
@@ -255,6 +263,7 @@ TEST_CASE("CLAP plugin id + parameter IDs are stable across instances",
     a->destroy(a);
     b->destroy(b);
     clap_entry.deinit();
+    pulp::format::set_host_quirk_policy(std::nullopt);
 }
 
 TEST_CASE("CLAP modulation does not bleed across blocks",

--- a/test/test_clap_midi_events.cpp
+++ b/test/test_clap_midi_events.cpp
@@ -29,6 +29,7 @@
 
 #include <pulp/format/clap_adapter.hpp>
 #include <pulp/format/clap_entry.hpp>
+#include <pulp/format/quirk_apply.hpp>
 #include <pulp/format/processor.hpp>
 #include <pulp/midi/buffer.hpp>
 #include <pulp/midi/message.hpp>
@@ -39,6 +40,7 @@
 #include <cstddef>
 #include <cstring>
 #include <memory>
+#include <optional>
 #include <vector>
 
 using namespace pulp;
@@ -1740,4 +1742,42 @@ TEST_CASE("midi_out shorts + sysex interleave by sample_offset on out_events",
     REQUIRE(out.at(1)->type == CLAP_EVENT_MIDI);
     REQUIRE(out.at(2)->time == 10);
     REQUIRE(out.at(2)->type == CLAP_EVENT_MIDI);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// host-quirks P3d — synthesize_bypass_parameter honored by the CLAP
+// adapter end-to-end. CapturingProcessor declares no Bypass, so with the
+// quirk enforced clap_init synthesizes one; engaging it makes clap_process
+// pass main input → output verbatim and skip the Processor.
+// ─────────────────────────────────────────────────────────────────────
+TEST_CASE("CLAP synthesizes + honors a Bypass param when the plugin declares none",
+          "[clap][host-quirks][p3][bypass]") {
+    pulp::format::set_host_quirk_policy(pulp::format::QuirkFilter{});  // quirk on
+    {
+        Harness h(make_capturing);
+        // clap_init synthesized the Bypass (reserved ID) and detected it.
+        REQUIRE(h.plugin.bypass_param_id == pulp::format::kSynthesizedBypassParamId);
+
+        for (uint32_t i = 0; i < Harness::kFrames; ++i) {
+            h.in_left[i]  = 0.1f + static_cast<float>(i);
+            h.in_right[i] = -(0.1f + static_cast<float>(i));
+        }
+        // Engage bypass + run with no events → pass-through, Processor skipped.
+        h.plugin.store.set_value(h.plugin.bypass_param_id, 1.0f);
+        InputEventList empty;
+        REQUIRE(h.run(empty) != CLAP_PROCESS_ERROR);
+        REQUIRE(h.out_left == h.in_left);
+        REQUIRE(h.out_right == h.in_right);
+    }
+    pulp::format::set_host_quirk_policy(std::nullopt);
+}
+
+TEST_CASE("CLAP does NOT synthesize a Bypass param when the quirk is off",
+          "[clap][host-quirks][p3][bypass]") {
+    pulp::format::set_host_quirk_policy(pulp::format::kQuirkFilterOff);
+    {
+        Harness h(make_capturing);
+        REQUIRE(h.plugin.bypass_param_id == 0u);  // no synthesis
+    }
+    pulp::format::set_host_quirk_policy(std::nullopt);
 }


### PR DESCRIPTION
Extends synthesize_bypass_parameter (P3b shipped VST3 + AU v3) to the two
adapters that had NO bypass process path at all. Each now: injects the
automatable Bypass via maybe_synthesize_bypass when the plugin declared
none, detects it (the shared boolean-range heuristic), and honors it in the
audio callback with a null-guarded pass-through that copies main input →
output and skips the Processor.

- CLAP: PulpClapPlugin caches bypass_param_id (clap_init synthesize+detect);
  clap_process short-circuits to pass-through when engaged.
- AU v2: PulpAUEffect caches bypass_param_id (ctor synthesize+detect, before
  the AU param list is built from the store); ProcessBufferLists
  short-circuits after pulling the param value via GetParameter().

The pass-through carries the same null-channel guard added in the self-sweep
hardening (#3240).

Validation:
- CLAP empirical end-to-end ([clap][bypass]): a no-bypass processor gets a
  synthesized Bypass; engaging it makes clap_process pass input→output
  verbatim. Off → no synthesis. Full CLAP suite green (381).
- AU v2: compiles + au_v2 suite green (92, no regression). The pass-through
  is a line-for-line mirror of the empirically-validated CLAP/VST3 path; an
  in-host AU v2 spot-check (auval / a DAW) is the recommended final confirm
  since the AU v2 test harness has no AudioBufferList render scaffolding.

synthesize_bypass_parameter is now honored by all four adapters. See
planning/2026-05-30-host-quirks-enforcement-goal.md.

Skill-Update: skip skill=view-bridge reason="au_v2_adapter.mm/cpp + clap changes are bypass-param synthesis, unrelated to editor attach/resize lifecycle which view-bridge documents"
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>