### PR TITLE
feat(format): default host-quirks policy to validated_only

### DIFF
--- a/core/format/CMakeLists.txt
+++ b/core/format/CMakeLists.txt
@@ -62,6 +62,34 @@ else()
     target_compile_definitions(pulp-format PRIVATE PULP_ENABLE_INSPECTOR=0)
 endif()
 
+# Host-quirks default policy (host-quirks enforcement plan).
+#
+# Selects the baseline tier filter detect_quirks() / resolved_quirks() apply
+# when no runtime override (PULP_HOST_QUIRKS env / set_host_quirk_policy API /
+# per-quirk override) is set. Shipped default is `validated_only`: only
+# bench-validated accommodations fire by default; Speculative / LessonOnly
+# rows stay dormant until explicitly opted in. The currently-enforced quirks
+# (clamp_latency_to_nonneg, silence_unsupported_bus_arrangements,
+# synthesize_bypass_parameter — all Validated) survive this filter, so the
+# default flip is behavior-neutral today and evidence-gates future
+# host-specific quirks. Override at configure time:
+#   -DPULP_HOST_QUIRKS_DEFAULT_POLICY=all | validated_only | off
+# The define is PUBLIC so default_policy_filter() in host_quirks.cpp AND the
+# policy-aware unit tests both compile against the same baseline.
+set(PULP_HOST_QUIRKS_DEFAULT_POLICY "validated_only" CACHE STRING
+    "Baseline host-quirks tier filter: all | validated_only | off")
+set_property(CACHE PULP_HOST_QUIRKS_DEFAULT_POLICY PROPERTY STRINGS
+    all validated_only off)
+if(PULP_HOST_QUIRKS_DEFAULT_POLICY STREQUAL "validated_only")
+    target_compile_definitions(pulp-format PUBLIC PULP_HOST_QUIRKS_DEFAULT_POLICY_VALIDATED_ONLY=1)
+elseif(PULP_HOST_QUIRKS_DEFAULT_POLICY STREQUAL "off")
+    target_compile_definitions(pulp-format PUBLIC PULP_HOST_QUIRKS_DEFAULT_POLICY_OFF=1)
+elseif(NOT PULP_HOST_QUIRKS_DEFAULT_POLICY STREQUAL "all")
+    message(FATAL_ERROR
+        "PULP_HOST_QUIRKS_DEFAULT_POLICY must be all|validated_only|off, got "
+        "'${PULP_HOST_QUIRKS_DEFAULT_POLICY}'")
+endif()
+
 # VST3 adapter (when SDK is available)
 if(PULP_HAS_VST3)
     target_sources(pulp-format PRIVATE

--- a/core/format/src/host_quirks.cpp
+++ b/core/format/src/host_quirks.cpp
@@ -168,9 +168,12 @@ constexpr void reset_if_filtered(int& field, int default_value,
 // call) makes apply_filter() noexcept + cheap.
 constexpr HostQuirks kDefaultHostQuirks{};
 
-// Compile-time policy selection for `detect_quirks()`. The build-time
-// option `PULP_HOST_QUIRKS_DEFAULT_POLICY` toggles `_VALIDATED_ONLY`
-// or `_OFF`; default is "all quirks fire" (matches pre-tier behavior).
+// Compile-time policy selection (the baseline the runtime layer falls
+// through to). The CMake option `PULP_HOST_QUIRKS_DEFAULT_POLICY`
+// (core/format/CMakeLists.txt) defines `_VALIDATED_ONLY` (the shipped
+// default — only bench-validated accommodations fire), `_OFF`, or
+// neither (`all` — every detected quirk fires; the pre-enforcement
+// behavior, kept as an explicit opt-in).
 constexpr QuirkFilter default_policy_filter() noexcept {
 #if defined(PULP_HOST_QUIRKS_DEFAULT_POLICY_OFF)
     return kQuirkFilterOff;

--- a/docs/reference/host-quirks-policy.md
+++ b/docs/reference/host-quirks-policy.md
@@ -33,15 +33,24 @@ The CMake cache variable `PULP_HOST_QUIRKS_DEFAULT_POLICY` selects what
 `pulp::format::detect_quirks()` returns by default:
 
 ```bash
-# Apply every detected quirk, regardless of tier (current Pulp default).
-cmake -S . -B build -DPULP_HOST_QUIRKS_DEFAULT_POLICY=all
-
-# Only Validated accommodations fire — Speculative + LessonOnly stay default.
+# Only Validated accommodations fire — Speculative + LessonOnly stay at
+# their defaults. This is the SHIPPED Pulp default: enforce what's been
+# bench-validated, evidence-gate the rest.
 cmake -S . -B build -DPULP_HOST_QUIRKS_DEFAULT_POLICY=validated_only
+
+# Apply every detected quirk regardless of tier (pre-enforcement behavior).
+cmake -S . -B build -DPULP_HOST_QUIRKS_DEFAULT_POLICY=all
 
 # Diagnostic build: no accommodations at all (including cheap defenses).
 cmake -S . -B build -DPULP_HOST_QUIRKS_DEFAULT_POLICY=off
 ```
+
+The flip to `validated_only` is behavior-neutral today: every quirk an
+adapter currently consumes (`clamp_latency_to_nonneg`,
+`silence_unsupported_bus_arrangements`, `synthesize_bypass_parameter`) is
+`Validated`, so it survives the filter. It evidence-gates *future*
+host-specific quirks — a `Speculative` row won't fire by default until it
+earns `Validated` status.
 
 The policy is compiled into the `pulp::format` library. Plugins built
 against that library inherit whichever policy was chosen at configure
@@ -210,9 +219,12 @@ planning submodule):
 
 | Audience                                                                 | Suggested policy        |
 |--------------------------------------------------------------------------|-------------------------|
-| Plugin authors who trust Pulp's curated catalog (most users).            | `all` (default)         |
-| Plugin authors who want strict in-DAW evidence before applying a fix.    | `validated_only`        |
+| Most users — enforce bench-validated accommodations, evidence-gate the rest. | `validated_only` (default) |
+| Plugin authors who trust Pulp's full curated catalog (incl. Speculative). | `all`                  |
 | Compliance / diagnostic builds investigating whether a host or a Pulp accommodation is misbehaving. | `off` |
 
-The default stays `all` so existing builds keep their current behavior
-after upgrading to a tier-aware Pulp.
+The default is `validated_only`: only quirks that have been bench-validated
+(and the always-on cheap defenses, which are `Validated`) fire by default.
+Because every quirk an adapter currently consumes is `Validated`, flipping
+to this default changed no shipped behavior — it sets the contract that
+future `Speculative` host quirks stay dormant until they earn `Validated`.


### PR DESCRIPTION
Flip the shipped baseline tier filter from "all" to "validated_only"
(owner decision, host-quirks enforcement plan). Only bench-validated
accommodations fire by default; Speculative / LessonOnly rows stay dormant
until they earn Validated status — evidence-gating future host-specific
quirks instead of firing them speculatively.

- New CMake cache option PULP_HOST_QUIRKS_DEFAULT_POLICY
  (all | validated_only | off), default validated_only, sets the
  PUBLIC compile define consumed by default_policy_filter() in
  host_quirks.cpp AND by the policy-aware unit tests.

Behavior-neutral today: every quirk an adapter currently consumes
(clamp_latency_to_nonneg, silence_unsupported_bus_arrangements,
synthesize_bypass_parameter) is Validated, so it survives the filter. No
shipped plugin changes; the flip sets the forward contract.

Tests: the existing policy-aware cases (detect_quirks invariants) now
compile + assert the validated_only branch — full host-quirks suite green
(473). Docs (host-quirks-policy.md) updated: validated_only is the default,
`all` is the opt-in for the full curated catalog.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>