### PR TITLE
fix(import-design): address Codex P2 review comments (container-guard, url-decode, image-fills, montage, doc)

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -1096,9 +1096,13 @@ After generating Pulp code, ALWAYS validate by comparing with the source design:
    > exactly the path that produced the accurate ELYSIUM sprite-strip /
    > native-silver-knob comparison renders in #3138.
 
-3. **Compare** reference vs render:
+3. **Compare** reference vs render. For designs WITHOUT image assets (pure native widgets/text), the importer's built-in `--validate --reference` diff is fine:
    ```bash
    pulp import-design --from X --file input --validate --reference source.png --diff diff.png
+   ```
+   But for designs WITH image `asset_ref`s, do NOT diff through `--validate` — its render placeholders images (see the ⚠️ above), so the diff would flag every image as a mismatch. Instead diff the **`pulp-screenshot`** render (step 2) against the reference directly with `fidelity_diff.py` / `figma_import_diff.py`:
+   ```bash
+   python3 tools/import-design/fidelity_diff.py --render render.png --scene scene.pulp.json --frame-reference source.png
    ```
 
 4. **Review the diff image** — red highlights show differences

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.150.1",
+      "version": "0.150.2",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.150.1"
+  "version": "0.150.2"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.150.1",
+  "version": "0.150.2",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/test/test_figma_rest_export.py
+++ b/test/test_figma_rest_export.py
@@ -38,5 +38,40 @@ class FontCaptureTest(unittest.TestCase):
         self.assertEqual(len(hashlib.sha256(blob).hexdigest()), 64)
 
 
+
+
+class CodexP2FollowupTest(unittest.TestCase):
+    def setUp(self):
+        frx.FONT_ASSETS.clear(); frx.ASSET_IDS.clear(); frx.IMAGE_FILL_REFS.clear()
+
+    def test_container_named_like_widget_not_promoted(self):
+        # Codex #3234: a "Knob Row" frame holding Knob instances must NOT be
+        # promoted to a leaf widget (which would drop its children).
+        container = {"type": "FRAME", "name": "Knob Row", "id": "1:1",
+                     "absoluteBoundingBox": {"x": 0, "y": 0, "width": 200, "height": 60},
+                     "children": [{"type": "INSTANCE", "name": "Knob", "id": "1:2",
+                                   "absoluteBoundingBox": {"x": 0, "y": 0, "width": 60, "height": 60}}]}
+        out = frx.walk(container, None, 0)
+        self.assertNotIn("audio_widget", out)        # not promoted
+        self.assertTrue(out.get("children"))         # children preserved
+        # A leaf knob instance (vector/group visual children) IS promoted.
+        leaf = {"type": "INSTANCE", "name": "Knob Small", "id": "2:1",
+                "absoluteBoundingBox": {"x": 0, "y": 0, "width": 28, "height": 41},
+                "children": [{"type": "GROUP", "name": "g"}, {"type": "VECTOR", "name": "v"}]}
+        self.assertEqual(frx.walk(leaf, None, 0).get("audio_widget"), "knob")
+
+    def test_parse_url_handles_percent_encoded_node_id(self):
+        self.assertEqual(frx.parse_url("https://figma.com/design/KEY/x?node-id=3%3A42"), ("KEY", "3:42"))
+        self.assertEqual(frx.parse_url("https://figma.com/design/KEY/x?node-id=3-42"), ("KEY", "3:42"))
+
+    def test_rewrite_image_fills_no_dangling_pending(self):
+        # Resolved ref → real path; unresolved → dropped (never leave "pending:").
+        tree = {"style": {"background_image": "pending:AAA"},
+                "children": [{"style": {"background_image": "pending:BBB"}}]}
+        frx._rewrite_image_fills(tree, {"AAA": "assets/aaa.png"})
+        self.assertEqual(tree["style"]["background_image"], "assets/aaa.png")
+        self.assertNotIn("background_image", tree["children"][0]["style"])  # BBB unresolved → dropped
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_import_montage.py
+++ b/test/test_import_montage.py
@@ -55,5 +55,20 @@ class MontageTest(unittest.TestCase):
             self.assertGreater(w, 200 * 2)  # two columns side by side
 
 
+
+
+class LabelColonTest(unittest.TestCase):
+    def test_label_with_colon_survives(self):
+        # Codex #3237: a label containing a colon must not be truncated.
+        import tempfile, os
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "ref.png"); Image.new("RGB", (10, 10)).save(p)
+            label, path = montage._parse_panel(f"{p}:1. Figma: source")
+            self.assertEqual(label, "1. Figma: source")
+            self.assertEqual(path, p)
+            # bare path (no label) → stem label
+            self.assertEqual(montage._parse_panel(p), ("ref", p))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/import-design/figma_rest_export.py
+++ b/tools/import-design/figma_rest_export.py
@@ -83,7 +83,9 @@ def extract_style(n):
             elif t == "GRADIENT_LINEAR": s["background_gradient"] = gradient_to_css(f)
             elif t == "IMAGE":
                 ih = f.get("imageRef") or f.get("imageHash")
-                if ih: s["background_image"] = f"pending:{ih}"
+                if ih:
+                    s["background_image"] = f"pending:{ih}"
+                    IMAGE_FILL_REFS.add(ih)  # resolved → real path after the walk
             elif t in ("GRADIENT_RADIAL", "GRADIENT_ANGULAR", "GRADIENT_DIAMOND"):
                 s["background_color"] = gradient_flat(f)  # flat fallback (matches extract.ts)
     strokes = n.get("strokes")
@@ -178,6 +180,17 @@ def widget_kind_from_name(name):
     if "spectrum" in low: return "spectrum"
     return None
 
+def _has_child_containers(n):
+    """True if the node is a layout CONTAINER (has child frames/instances/
+    components) rather than a leaf widget. A container named like a widget
+    ("Knob Row" frame holding Knob instances) must NOT be promoted — that would
+    drop the real widgets inside. NOTE: GROUP/VECTOR/shape children are a leaf
+    widget's OWN visual content (e.g. an ELYSIUM 'Knob Small' instance wraps a
+    vector Group), so they do NOT count as containers — only structural nesting
+    (FRAME / INSTANCE / COMPONENT / COMPONENT_SET) does."""
+    return any(c.get("type") in ("FRAME", "INSTANCE", "COMPONENT", "COMPONENT_SET")
+               for c in n.get("children", []))
+
 def is_auto_layout(n):
     return n is not None and n.get("layoutMode") in ("HORIZONTAL", "VERTICAL")
 
@@ -206,6 +219,7 @@ def extract_layout(n):
 
 ASSET_IDS = []  # node ids to export as PNG via /images (filled during walk)
 FONT_ASSETS = {}  # (family, style, weight) -> {family, style, weight} (deduped, fill order)
+IMAGE_FILL_REFS = set()  # Figma imageRefs from IMAGE fills, resolved after the walk
 
 def _record_font(n):
     """Collect a text node's font into FONT_ASSETS (deduped by family/style/weight).
@@ -255,7 +269,11 @@ def walk(n, parent, z):
     tiny = bb.get("width", 0) < 1 and bb.get("height", 0) < 1
     captured = False
     wkind = widget_kind_from_name(n.get("name", ""))
-    if wkind:
+    # Codex #3234 P2: only promote LEAF-ish nodes. A CONTAINER whose name merely
+    # contains a widget word (e.g. "Knob Row", "Fader Bank") must NOT be promoted
+    # to a leaf widget — that would drop its children (the real knobs inside).
+    # Mirrors the importer's detect_node_audio_widget has_child_containers rule.
+    if wkind and not _has_child_containers(n):
         out["audio_widget"] = wkind
         captured = True  # leaf widget: importer renders native; don't capture/recurse
     # Asset capture (extract.ts:268-322). Vector-like nodes → PNG asset_ref.
@@ -329,6 +347,10 @@ def resolve_token(explicit):
 
 def parse_url(url):
     # https://figma.com/design/<KEY>/<name>?node-id=<a-b>  (node-id uses '-'; API uses ':')
+    # Codex #3225 P2: copied URLs commonly percent-encode the separator
+    # (node-id=3%3A42, or %2D); unquote first so the regex still matches.
+    import urllib.parse
+    url = urllib.parse.unquote(url)
     m = re.search(r"/(?:design|file)/([A-Za-z0-9]+)", url)
     key = m.group(1) if m else None
     m2 = re.search(r"node-id=([0-9]+)[-:]([0-9]+)", url)
@@ -341,6 +363,53 @@ def fetch_nodes(file_key, node_id, token):
         headers={"X-Figma-Token": token})
     with urllib.request.urlopen(req, timeout=120) as r:
         return json.load(r)
+
+def resolve_image_fills(file_key, refs, token, out_dir):
+    """Codex #3225 P2: resolve IMAGE-fill imageRefs into real assets. The image
+    fill on a node references a file image by `imageRef`; the file-images
+    endpoint maps each ref to a (temporary) download URL. Download → assets/
+    (sha256-named, like node captures) → return (manifest_entries, {ref: rel_path})
+    so the caller can rewrite each node's `background_image: "pending:<ref>"` into
+    a real relative path instead of a dangling pending hash."""
+    import hashlib, os, urllib.request
+    os.makedirs(os.path.join(out_dir, "assets"), exist_ok=True)
+    req = urllib.request.Request(f"https://api.figma.com/v1/files/{file_key}/images",
+                                 headers={"X-Figma-Token": token})
+    with urllib.request.urlopen(req, timeout=60) as r:
+        url_map = (json.load(r).get("meta") or {}).get("images", {}) or {}
+    manifest, ref_to_rel = [], {}
+    for ref in refs:
+        url = url_map.get(ref)
+        if not url:
+            continue
+        try:
+            with urllib.request.urlopen(url, timeout=60) as r:
+                blob = r.read()
+            digest = hashlib.sha256(blob).hexdigest()
+            rel = f"assets/{digest}.png"
+            open(os.path.join(out_dir, rel), "wb").write(blob)
+            ref_to_rel[ref] = rel
+            manifest.append({"asset_id": f"imgfill-{ref}",
+                             "original_uri": f"figma-image://{ref}", "original_uri_aliases": [],
+                             "local_path": rel, "content_hash": digest, "mime": "image/png"})
+        except Exception as e:
+            print(f"  image fill {ref} failed: {e}", file=sys.stderr)
+    return manifest, ref_to_rel
+
+def _rewrite_image_fills(node, ref_to_rel):
+    """Replace style.background_image 'pending:<ref>' with the resolved relative
+    path (or drop it if the fill couldn't be resolved — never leave a pending:)."""
+    st = node.get("style")
+    if st:
+        bg = st.get("background_image", "")
+        if isinstance(bg, str) and bg.startswith("pending:"):
+            ref = bg[len("pending:"):]
+            if ref in ref_to_rel:
+                st["background_image"] = ref_to_rel[ref]
+            else:
+                st.pop("background_image", None)  # unresolved → no dangling pending:
+    for c in node.get("children", []):
+        _rewrite_image_fills(c, ref_to_rel)
 
 def main():
     ap = argparse.ArgumentParser(description="Headless Figma REST → Pulp figma-plugin envelope")
@@ -374,6 +443,17 @@ def main():
         print(f"exporting {len(ASSET_IDS)} assets via /images ...")
         asset_manifest_entries = export_assets(file_key, ASSET_IDS, token, out_dir)
         print(f"  captured {len(asset_manifest_entries)} PNGs")
+    # Resolve IMAGE-fill imageRefs → real assets, rewrite the dangling pending:
+    # markers (Codex #3225 P2). Even with --no-assets/--node-json we strip the
+    # pending: placeholders so the envelope never carries a dead reference.
+    if IMAGE_FILL_REFS:
+        ref_to_rel = {}
+        if not args.no_assets and token:
+            print(f"resolving {len(IMAGE_FILL_REFS)} image fill(s) ...")
+            fill_entries, ref_to_rel = resolve_image_fills(file_key, IMAGE_FILL_REFS, token, out_dir)
+            asset_manifest_entries += fill_entries
+            print(f"  resolved {len(fill_entries)} image fill(s)")
+        _rewrite_image_fills(root_node, ref_to_rel)
 
     envelope = {
         "$schema": "https://pulp.dev/schemas/figma-plugin-export-v1.json",

--- a/tools/import-design/montage.py
+++ b/tools/import-design/montage.py
@@ -82,13 +82,16 @@ def build_montage(panels, out_path, labels=True, columns=1, title_height=36,
     return out_path
 
 def _parse_panel(spec):
-    # "path:Label" — split on the LAST ':' not part of a drive/scheme; simplest:
-    # split on first ':' after the path if a label is given, else whole = path.
-    if ":" in spec:
-        # allow paths without labels; treat a trailing :Label as the label
-        path, _, label = spec.rpartition(":")
-        if path and os.path.exists(path):
-            return (label or os.path.splitext(os.path.basename(path))[0], path)
+    # "path:Label" → (label, path). Split on the FIRST ':' so a label that itself
+    # contains colons survives (Codex #3237: "x.png:1. Figma: source" must keep
+    # "1. Figma: source" as the label, not truncate at the last colon). Fall back
+    # to treating the whole spec as a path when the head isn't an existing file
+    # (bare path, or a path with no label).
+    if os.path.exists(spec):                      # whole spec is a real path → no label
+        return (os.path.splitext(os.path.basename(spec))[0], spec)
+    head, sep, label = spec.partition(":")        # first colon
+    if sep and head and os.path.exists(head):
+        return (label or os.path.splitext(os.path.basename(head))[0], head)
     return (os.path.splitext(os.path.basename(spec))[0], spec)
 
 def main():


### PR DESCRIPTION
Post-merge Codex P2 review feedback across the import-design PRs, batched into one cleanup (each with a regression test).

| From | Fix |
|------|-----|
| **#3234** | Guard name-based widget promotion to LEAF nodes — a container named like a widget (\"Knob Row\") is no longer promoted (which dropped the real knobs inside). GROUP/VECTOR visual children still count as a leaf. |
| **#3225** | `parse_url` unquotes percent-encoded node-ids (`node-id=3%3A42`); IMAGE-fill `imageRef`s now resolve to real assets via the file-images endpoint instead of a dangling `background_image:\"pending:<hash>\"` (unresolved → dropped). |
| **#3237** | `montage.py` splits panel specs on the FIRST colon so a label containing a colon survives. |
| **#3230** | SKILL: image-asset imports diff via the `pulp-screenshot` render + `fidelity_diff.py`, not `--validate` (which placeholders images). |

**Tests:** +3 in `test_figma_rest_export.py` (container-guard, url-decode, image-fill rewrite), +1 in `test_import_montage.py` (colon label). All green; existing suites unaffected.

Resolves the Codex review comments on #3225/#3234/#3237/#3230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)