### PR TITLE
fix(view+import-design): faithful sprite sizing, widget recognition, and layout fidelity for design imports

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -1731,3 +1731,67 @@ correctness bug before it was made explicit; treat them as invariants.
   `non_negative_int`/`load_json`/`write_json`) live in `frontend_ir_common.py`
   and the canonical route set in `frontend_ir_validation.NATIVE_ROUTES` —
   import them, don't re-type them.
+
+## Sprite/asset sizing — never skew, size from the pixels
+
+Non-obvious rules for sizing captured image assets (knob graphics, icons,
+rasterized shapes). Each cost a visible fidelity bug.
+
+- **`render_bounds` is NOT a reliable size for scaled component instances.**
+  The figma-plugin export's `render_bounds {w,h,dx,dy}` (the on-canvas bleed
+  extent) can have a totally different aspect than the exported PNG — e.g. a
+  knob graphic with `render_bounds` aspect 1.81 but a PNG aspect 0.87, because
+  `render_bounds` reports the *component's* native box, not the scaled
+  *instance*. Sizing an element to `render_bounds` and letting the renderer
+  stretch the PNG into it skews the art ~2x. `setObjectFit` is **storage-only**
+  (the ImageView paint slice ignores it), so aspect can ONLY be preserved by
+  sizing the *element* itself.
+- **Recover real dims + the opaque-core bbox from the PNG; the manifest dims
+  are null.** The import CLI's asset-resolution pass stamps `png_natural_w/h`
+  (PNG header) and, for nodes carrying `render_bounds`, the `art_core_*` bbox
+  of pixels with alpha ≥ 0.5 (`compute_opaque_core`). Codegen scales the whole
+  PNG so the solid core fits the layout box (`min(box_w/core_w, box_h/core_h)`)
+  and positions it so the core lands on the box — the soft shadow then bleeds
+  beyond. This is the data-driven fix for "right size, not skewed", and it
+  generalizes to any sprite (knob disc, icon) — no layer-name matching.
+
+## Widget recognition vs decorative children
+
+- **A decorative stroke child must not block widget recognition.** A knob's
+  ~0-width stroked pointer hairline is demoted image→frame by the degenerate-
+  stroke pre-pass; before it was tagged, that lone leaf frame tripped the
+  `has_child_containers` gate in `detect_node_audio_widget` and the whole knob
+  fell through to a raw stack of images instead of a native `createKnob`. The
+  demotion now tags the node `__stroke_demoted`; the recognition gate treats a
+  tagged child as ornamentation, while a *populated* or genuinely structural
+  frame/group child still disqualifies (a widget-named row of sub-widgets stays
+  a row). When a degenerate stroke becomes a fill, also DROP its border — a
+  1.5px line plus a 1.5px border draws on both edges and renders ~3x too wide.
+
+## snake_case vs kebab-case + multi-line text
+
+- **`parse_align` must accept snake_case.** The figma-plugin export emits
+  `space_between`/`flex_end`; CSS sources emit `space-between`/`flex-end`.
+  `parse_align` normalizes `'_'→'-'` so both spell the same — otherwise
+  snake_case justify/align silently fall through to `flex_start`.
+- **Multi-line text heuristic is line_height-aware, with a TIGHT fallback.**
+  `multiline_box = height > line_h * 1.8`, where `line_h =
+  line_height.value_or(font_size * 1.2)`. The `*1.2` fallback (not `*1.4`)
+  matters: a genuine two-line paragraph (e.g. 26px box at 11px font, no
+  declared line_height) must read as multi-line, while a single small line in a
+  tall padded box (e.g. a search field: 17px box, 8px font, line_height 9.84)
+  must stay single so its vertical centering survives.
+
+## Rasterizing vector illustration frames
+
+- **A pure-vector illustration FRAME must be flattened to one PNG.** The
+  exporter rasterizes single vector *leaves* but walks a vector illustration
+  *group* (a frame whose whole subtree is vector/shape content — e.g. a 3-D
+  prism of rotated `REGULAR_POLYGON` faces) as a layout container; since Pulp
+  is flex/grid-only with no rotated-polygon primitive, those faces degrade to
+  axis-aligned bordered boxes. `tools/import-design/figma_rasterize_vector_frames.py`
+  is a post-export pass that detects such frames (subtree all vector/shape, no
+  text, no recognized widget — keyed on structure, NOT layer names) and
+  replaces each with a single PNG rasterized via the Figma `/images` endpoint.
+  It needs a Figma token + network, so it is a developer-time export helper,
+  never run in CI.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.298.0
+    VERSION 0.299.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/design_ir.hpp
+++ b/core/view/include/pulp/view/design_ir.hpp
@@ -115,6 +115,14 @@ struct IRStyle {
     std::optional<float> width, height;
     std::optional<float> min_width, min_height;
     std::optional<float> max_width, max_height;
+    // The asset's true visual extent in logical px when it bleeds past the
+    // layout box (figma-plugin `render_bounds`: drop shadows, glow, oversized
+    // chrome like the silver-knob graphic). w/h = rendered size, dx/dy = offset
+    // of the render origin relative to the layout box (negative = extends
+    // left/up). When present + larger than width/height, the importer sizes the
+    // image to render_bounds and offsets by dx/dy instead of squashing it.
+    struct RenderBounds { float w = 0, h = 0, dx = 0, dy = 0; };
+    std::optional<RenderBounds> render_bounds;
 };
 
 /// Layout properties for an IR container node.

--- a/core/view/src/design_codegen.cpp
+++ b/core/view/src/design_codegen.cpp
@@ -536,8 +536,8 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
         // auto-layout row that already arranges siblings) does the layout.
         // Wrapping in a col with +20 padding for absent labels makes the col
         // taller than the parent's hugged row height, breaking Yoga's flex
-        // layout (Track A regression on the ELYSIUM knob row: the wrapper
-        // was 28x61 / 62x111 / 28x61 inside a 158x91 parent).
+        // layout (Track A regression on a knob row: the wrapper was
+        // 28x61 / 62x111 / 28x61 inside a 158x91 parent).
         bool needs_label_wrapper = !label_text.empty() || !value_text.empty() || has_value_stack;
 
         // Create a wrapper column for the widget + value label (only when
@@ -910,19 +910,72 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
             ss << ind << "setImageSource('" << id << "', '"
                << js_single_quote_escape(it->second) << "');\n";
         }
-        if (node.style.width)
-            ss << ind << "setFlex('" << id << "', 'width', " << *node.style.width << ");\n";
-        if (node.style.height)
-            ss << ind << "setFlex('" << id << "', 'height', " << *node.style.height << ");\n";
-        // When the importer flagged this asset as bleed (PNG pixel dims
-        // exceed twice the layout dims by 1.5× — typical drop-shadow case),
-        // tell ImageView to render at natural size centered instead of
-        // stretching the PNG into the smaller layout box. Same effect as
-        // the Knob::paint natural-size fix, generalised through CSS
-        // object-fit:none which ImageView already supports.
-        auto bleed_it = node.attributes.find("asset_bleed");
-        if (bleed_it != node.attributes.end() && bleed_it->second == "1") {
-            ss << ind << "setObjectFit('" << id << "', 'none');\n";
+        // Sprite sizing. A captured sprite (knob graphic, etc.) is exported as
+        // a PNG that bleeds well past its layout box: the solid art sits in
+        // part of the PNG with a soft drop-shadow/glow filling the rest. The
+        // renderer always stretches the PNG to its element box (setObjectFit
+        // is storage-only), so to avoid skew + get the size right we size the
+        // ELEMENT to the PNG's real aspect and place it so the art's SOLID
+        // CORE lands on the layout box. The solid-core bbox + true pixel dims
+        // are recovered from the PNG itself at asset resolution
+        // (art_core_*/png_natural_*); nothing is hardcoded and render_bounds —
+        // which is unreliable for scaled component instances (e.g. a knob
+        // whose render_bounds aspect is 1.81 while its PNG is 0.87) — is not
+        // trusted for
+        // sizing. Falls back to legacy box sizing when no core data exists.
+        const float box_w = node.style.width.value_or(0.0f);
+        const float box_h = node.style.height.value_or(0.0f);
+        auto attr_f = [&](const char* k) -> float {
+            auto it = node.attributes.find(k);
+            return it != node.attributes.end() ? std::strtof(it->second.c_str(), nullptr) : 0.0f;
+        };
+        const float png_w = attr_f("png_natural_w");
+        const float png_h = attr_f("png_natural_h");
+        const float core_w = attr_f("art_core_w");
+        const float core_h = attr_f("art_core_h");
+        const float core_x = attr_f("art_core_x");
+        const float core_y = attr_f("art_core_y");
+        const bool have_core = png_w > 0.0f && png_h > 0.0f &&
+                               core_w > 0.0f && core_h > 0.0f &&
+                               box_w > 0.0f && box_h > 0.0f;
+
+        if (have_core) {
+            // Uniform scale that fits the solid core inside the layout box
+            // (preserves aspect — never skews). The whole PNG scales by `s`,
+            // so the shadow extends naturally beyond the box.
+            const float s = std::min(box_w / core_w, box_h / core_h);
+            const float ew = png_w * s;
+            const float eh = png_h * s;
+            ss << ind << "setFlex('" << id << "', 'width', " << ew << ");\n";
+            ss << ind << "setFlex('" << id << "', 'height', " << eh << ");\n";
+            // Place so the core's top-left lands on the layout box, then nudge
+            // so the core is centered within the box on each axis.
+            const float core_box_w = core_w * s, core_box_h = core_h * s;
+            const float pad_x = (box_w - core_box_w) * 0.5f;
+            const float pad_y = (box_h - core_box_h) * 0.5f;
+            if (node.style.position && *node.style.position == "absolute") {
+                if (node.style.left)
+                    ss << ind << "setLeft('" << id << "', " << (*node.style.left - core_x * s + pad_x) << ");\n";
+                if (node.style.top)
+                    ss << ind << "setTop('" << id << "', " << (*node.style.top - core_y * s + pad_y) << ");\n";
+            }
+        } else if (png_w > 0.0f && png_h > 0.0f && box_w > 0.0f && box_h > 0.0f) {
+            // No core data but real dims known → contain-fit preserving aspect.
+            const float png_aspect = png_w / png_h;
+            float ew = box_w, eh = box_h;
+            if (box_w / box_h > png_aspect) { eh = box_h; ew = box_h * png_aspect; }
+            else                            { ew = box_w; eh = box_w / png_aspect; }
+            ss << ind << "setFlex('" << id << "', 'width', " << ew << ");\n";
+            ss << ind << "setFlex('" << id << "', 'height', " << eh << ");\n";
+        } else {
+            // Aspect unknown → legacy box sizing.
+            if (node.style.width)
+                ss << ind << "setFlex('" << id << "', 'width', " << *node.style.width << ");\n";
+            if (node.style.height)
+                ss << ind << "setFlex('" << id << "', 'height', " << *node.style.height << ");\n";
+            auto bleed_it = node.attributes.find("asset_bleed");
+            if (bleed_it != node.attributes.end() && bleed_it->second == "1")
+                ss << ind << "setObjectFit('" << id << "', 'none');\n";
         }
         ss << "\n";
         return;
@@ -1000,8 +1053,23 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
             // here: forcing its narrow hug-width as a hard wrap box would make
             // it wrap when Pulp's font metrics run a hair wider than Figma's,
             // breaking a title that the design drew on one line.
+            // Multi-line only when the box clears ~TWO line boxes. Keying on
+            // font_h * 1.6 false-fired on single-line text whose Figma box
+            // carries normal line-box padding (e.g. an 8px "Search" in a 17px
+            // box: 17 > 8*1.6=12.8), which flipped it to multi-line and pushed
+            // the vertically-centered baseline down. Use the IR's own
+            // line_height (fallback font_h*1.4) × 1.8 so one line + padding
+            // doesn't trip it. Generalizable: reads Figma's declared metrics.
+            // Multi-line only when the box clears ~1.8 line boxes. Prefer the
+            // IR's declared line_height; when absent assume a tight font*1.2
+            // (a single rendered line), NOT font*1.4 — the looser fallback let
+            // a genuine two-line paragraph (e.g. 26px box at 11px font) read as
+            // one line. A single line of small text in a tall padded box (e.g.
+            // a 17px search field around 8px text, line_height 9.84) still
+            // stays single. Generalizable: reads Figma's declared metrics.
+            const float line_h = node.style.line_height.value_or(font_h * 1.2f);
             bool multiline_box =
-                node.style.height && *node.style.height > font_h * 1.6f;
+                node.style.height && *node.style.height > line_h * 1.8f;
             if (multiline_box) {
                 ss << ind << "setFlex('" << id << "', 'width', " << *node.style.width << ");\n";
                 ss << ind << "setMultiLine('" << id << "', true);\n";
@@ -1068,8 +1136,8 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
         // mean "spread items out", then drop a single child in. With one
         // child, CSS / Yoga space-between degenerates to flex-start, so
         // the lone item left-aligns instead of centering — visible bug
-        // on every numbered tab button in ELYSIUM ("1" "2" "3" "4" sat
-        // at the left edge of their 29×20 button boxes). When the IR
+        // on a numbered tab button (e.g. "1" "2" "3" "4" sitting at the
+        // left edge of their 29×20 button boxes). When the IR
         // says space_between AND there's exactly one child, the design
         // intent is centering — emit that.
         LayoutAlign effective_justify = node.layout.justify;
@@ -1114,10 +1182,10 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
         if (node.style.border_radius)
             ss << ind << "setCornerRadius('" << id << "', 'All', " << *node.style.border_radius << ");\n";
         // Emit border (Figma frame stroke) as setBorder(id, color, width).
-        // The codegen was previously dropping these — visible effect: the
-        // 4 column frames inside the ELYSIUM gradient panel each have a
-        // 1px rgba(0,0,0,0.1) border that Figma renders as the thin
-        // vertical separators between GRAINS/CURSOR/RANGE/TUNING. The
+        // The codegen was previously dropping these — visible effect:
+        // column frames inside a gradient panel each carry a 1px
+        // rgba(0,0,0,0.1) border that Figma renders as the thin vertical
+        // separators between columns. The
         // bridge's parseColor accepts both hex and rgba(...) so we can
         // pass border_color verbatim from the IR.
         if (node.style.border_color && node.style.border_width &&

--- a/core/view/src/design_ir_json.cpp
+++ b/core/view/src/design_ir_json.cpp
@@ -262,6 +262,21 @@ static IRStyle parse_ir_style(const choc::value::ValueView& obj) {
     set_opt_float("maxWidth", s.max_width);
     set_opt_float("maxHeight", s.max_height);
 
+    // render_bounds {w,h,dx,dy} — the asset's true visual extent when it bleeds
+    // past the layout box (figma-plugin). Without this the silver-knob graphic
+    // (210px wide) gets squashed into its 62px layout box.
+    if (auto k = resolve_key("renderBounds")) {
+        auto rb = obj[k->c_str()];
+        if (rb.isObject()) {
+            IRStyle::RenderBounds out{};
+            auto rbf = [&](const char* m, float& f) {
+                if (rb.hasObjectMember(m)) f = static_cast<float>(rb[m].getWithDefault<double>(0));
+            };
+            rbf("w", out.w); rbf("h", out.h); rbf("dx", out.dx); rbf("dy", out.dy);
+            if (out.w > 0 && out.h > 0) s.render_bounds = out;
+        }
+    }
+
     return s;
 }
 
@@ -302,9 +317,17 @@ static IRLayout parse_ir_layout(const choc::value::ValueView& obj) {
     if (obj.hasObjectMember("marginBottom"))  l.margin_bottom = get_float(obj, "marginBottom");
     if (obj.hasObjectMember("marginLeft"))    l.margin_left = get_float(obj, "marginLeft");
 
-    auto parse_align = [](const std::string& s) -> LayoutAlign {
+    auto parse_align = [](std::string s) -> LayoutAlign {
+        // The figma-plugin export uses snake_case (flex_end, space_between);
+        // earlier callers used kebab-case (flex-end). Normalize '_'→'-' so both
+        // spell the same — otherwise snake_case justify/align silently fell
+        // through to flex_start, leaving column `justify:flex_end` titles pinned
+        // to the top (overlapping their sublabels) and dropping every
+        // `space_between` row's distribution.
+        for (auto& c : s) if (c == '_') c = '-';
         if (s == "center")        return LayoutAlign::center;
         if (s == "flex-end" || s == "end") return LayoutAlign::flex_end;
+        if (s == "flex-start" || s == "start") return LayoutAlign::flex_start;
         if (s == "stretch")       return LayoutAlign::stretch;
         if (s == "space-between") return LayoutAlign::space_between;
         if (s == "space-around")  return LayoutAlign::space_around;
@@ -517,9 +540,23 @@ static void detect_node_audio_widget(IRNode& node, bool explicit_audio_widget) {
         detected = detect_audio_widget(node.type);
     if (detected == AudioWidgetType::none) return;
 
+    // A child that is itself a container — a populated frame/group, or any
+    // nested-frame/group structure — marks this node as a composite layout
+    // that must NOT be collapsed into a single audio widget (a widget-named
+    // row of sub-widgets stays a row). The ONE exception is a stroke-demoted
+    // decoration: a ~0-width stroked leaf (e.g. a knob's pointer hairline)
+    // that the pre-pass above retypes image→frame. Without this exception that
+    // lone decorative box blocked recognition, so a knob shipping a pointer
+    // line fell through to a raw container of images instead of a native knob.
+    // The decoration is tagged at demotion time (__stroke_demoted).
     bool has_child_containers = false;
     for (auto& child : node.children) {
-        if (child.type == "frame" || child.type == "group" || !child.children.empty()) {
+        const bool decorative_stroke =
+            child.attributes.count("__stroke_demoted") != 0;
+        const bool is_container =
+            !child.children.empty() ||
+            ((child.type == "frame" || child.type == "group") && !decorative_stroke);
+        if (is_container) {
             has_child_containers = true;
             break;
         }
@@ -555,6 +592,7 @@ static void extract_widget_shape_dims(IRNode& node) {
             break;
         }
     }
+
 }
 
 IRNode parse_ir_node(const choc::value::ValueView& obj) {
@@ -829,12 +867,25 @@ IRNode parse_ir_node(const choc::value::ValueView& obj) {
             // a zero-area image and would render nothing anyway.
             if (!node.style.background_color && node.style.border_color)
                 node.style.background_color = node.style.border_color;
+            // The fill now IS the hairline. Drop the stroke so codegen does
+            // not ALSO emit a border — a 1.5px line + a 1.5px border draws on
+            // both edges and renders ~3× too wide (e.g. a knob pointer line).
+            // The width was already set to the stroke weight above, so the
+            // filled rect alone reproduces the line at its true thickness.
+            node.style.border.reset();
+            node.style.border_color.reset();
+            node.style.border_width.reset();
+            node.style.border_style.reset();
             // Strip the asset_ref so codegen's image branch doesn't try to
             // emit setImageSource on a degenerate PNG.
             node.attributes.erase("asset_ref");
             // Demote from "image" to "frame" so codegen emits a styled
             // container instead of an <img>-style image element.
             if (node.type == "image") node.type = "frame";
+            // Tag it as a decorative stroke so a parent widget's recognition
+            // gate treats it as ornamentation, not as a disqualifying nested
+            // container (a knob keeps its pointer hairline AND its widget-ness).
+            node.attributes["__stroke_demoted"] = "1";
         }
     }
 
@@ -889,9 +940,9 @@ IRNode parse_ir_node(const choc::value::ValueView& obj) {
     // breaking the connection visual. Convert the line to absolute,
     // span the full row width, and centre it vertically. Because it
     // stays first in z-order, subsequent children draw on top — the
-    // visible segments emerge as gaps. Generalises the FX RACK pattern
-    // in ELYSIUM (Vector 177 + 1/4 DELAY + REVERB + "+") to any flex
-    // row with a connector hairline + ≥ 2 sibling widgets.
+    // visible segments emerge as gaps. Generalises a connector-rail
+    // pattern (e.g. an FX-rack row: a hairline + chained dropdowns + "+")
+    // to any flex row with a connector hairline + ≥ 2 sibling widgets.
     if (node.layout.direction == LayoutDirection::row && node.children.size() >= 3) {
         auto& first = node.children.front();
         float fw = first.style.width.value_or(0.0f);

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -3,6 +3,7 @@
 #include <pulp/state/store.hpp>
 #include <pulp/view/anchor_strategy.hpp>
 #include <pulp/view/design_import.hpp>
+#include <pulp/view/design_sources.hpp>
 #include <pulp/view/design_codegen.hpp>
 #include <pulp/view/script_engine.hpp>
 #include <pulp/view/widget_bridge.hpp>
@@ -3954,4 +3955,196 @@ TEST_CASE("design IR JSON round-trip preserves font_family_assets", "[design-imp
     CHECK(reparsed.font_family_assets[0].family == "Inter");
     CHECK(reparsed.font_family_assets[0].weight == 400);
     CHECK(reparsed.font_family_assets[0].resolved_path == "/x/inter.ttf");
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Design-import sprite & widget-recognition fidelity invariants.
+// Each guards a general importer rule: widget recognition is not blocked by a
+// decorative leaf child, render_bounds parses, snake_case align keywords are
+// honored, a degenerate stroke is not double-drawn, single-line text is not
+// flipped to multi-line, and a sprite image is sized preserving its source
+// aspect ratio. Fixtures are synthetic; nothing here is tied to one design.
+// ───────────────────────────────────────────────────────────────────────────
+namespace {
+const IRNode* find_node_by_name(const IRNode& n, const std::string& name) {
+    if (n.name == name) return &n;
+    for (const auto& c : n.children)
+        if (const IRNode* r = find_node_by_name(c, name)) return r;
+    return nullptr;
+}
+
+// Pull the float arg of the first `setFlex('<id>', '<dim>', N)` for a given id.
+std::optional<float> emitted_flex(const std::string& js, const std::string& id,
+                                  const std::string& dim) {
+    const std::string needle = "setFlex('" + id + "', '" + dim + "', ";
+    auto pos = js.find(needle);
+    if (pos == std::string::npos) return std::nullopt;
+    pos += needle.size();
+    return std::strtof(js.c_str() + pos, nullptr);
+}
+
+// Find the sanitized bridge id of the createImage call for a comment-labelled
+// node (codegen prints `// <name>` immediately before the create call).
+std::optional<std::string> image_id_after_comment(const std::string& js,
+                                                   const std::string& name) {
+    auto cpos = js.find("// " + name + "\n");
+    if (cpos == std::string::npos) return std::nullopt;
+    auto cipos = js.find("createImage('", cpos);
+    if (cipos == std::string::npos) return std::nullopt;
+    cipos += std::string("createImage('").size();
+    auto end = js.find('\'', cipos);
+    if (end == std::string::npos) return std::nullopt;
+    return js.substr(cipos, end - cipos);
+}
+}  // namespace
+
+TEST_CASE("figma-plugin knob with a stroked indicator child is recognized as a native knob",
+          "[view][import][figma-plugin][fidelity]") {
+    // A knob frame whose children are the captured silver-graphic image, a
+    // ~0-width stroked pointer hairline, and value/label text. The hairline is
+    // demoted image->frame; before the fix that leaf frame tripped the
+    // has_child_containers gate and the whole knob fell through to a raw stack
+    // of images instead of a native createKnob.
+    const std::string json = R"json({
+      "provenance": {"adapter":"figma-plugin","version":"test"},
+      "root": {"type":"frame","name":"Root","style":{"width":200,"height":200},"children":[
+        {"type":"frame","name":"Knob","style":{"width":62,"height":91,"position":"absolute","left":20,"top":20},"children":[
+          {"type":"image","name":"Group 130","asset_ref":"a","style":{"width":62,"height":68,"position":"absolute","left":0,"top":0,"renderBounds":{"w":210,"h":116,"dx":-74,"dy":0}}},
+          {"type":"image","name":"Vector 7","asset_ref":"b","style":{"width":0.0001,"height":8,"border":"2px solid #ffffff","borderColor":"#ffffff","borderWidth":2,"position":"absolute","left":31,"top":17}},
+          {"type":"text","name":"VALUE","content":"VALUE","style":{"width":40,"height":12}},
+          {"type":"text","name":"80%","content":"80%","style":{"width":40,"height":12}}
+        ]}
+      ]}
+    })json";
+    const auto ir = parse_figma_plugin_json(json);
+    const IRNode* knob = find_node_by_name(ir.root, "Knob");
+    REQUIRE(knob != nullptr);
+    CHECK(knob->audio_widget == AudioWidgetType::knob);
+    const auto js = generate_pulp_js(ir);
+    CHECK(js.find("createKnob") != std::string::npos);
+}
+
+TEST_CASE("figma-plugin render_bounds parses into IRStyle (drop-shadow / bleed extent)",
+          "[view][import][figma-plugin][fidelity]") {
+    const std::string json = R"json({
+      "provenance": {"adapter":"figma-plugin","version":"test"},
+      "root": {"type":"frame","name":"Root","style":{"width":200,"height":200},"children":[
+        {"type":"image","name":"Art","asset_ref":"a","style":{"width":62,"height":68,"renderBounds":{"w":210,"h":116,"dx":-74,"dy":0}}}
+      ]}
+    })json";
+    const auto ir = parse_figma_plugin_json(json);
+    const IRNode* art = find_node_by_name(ir.root, "Art");
+    REQUIRE(art != nullptr);
+    REQUIRE(art->style.render_bounds.has_value());
+    CHECK(art->style.render_bounds->w == Catch::Approx(210.0f));
+    CHECK(art->style.render_bounds->h == Catch::Approx(116.0f));
+    CHECK(art->style.render_bounds->dx == Catch::Approx(-74.0f));
+    CHECK(art->style.render_bounds->dy == Catch::Approx(0.0f));
+}
+
+TEST_CASE("figma-plugin snake_case align keywords are honored (titles not pinned to top)",
+          "[view][import][figma-plugin][fidelity]") {
+    // The figma-plugin export emits snake_case (`space_between`), not the CSS
+    // kebab-case parse_align previously required; the keyword was silently
+    // dropped, collapsing column justification.
+    const std::string json = R"json({
+      "provenance": {"adapter":"figma-plugin","version":"test"},
+      "root": {"type":"frame","name":"Root","style":{"width":200,"height":400},
+        "layout":{"direction":"column","justify":"space_between","align":"center"},"children":[
+        {"type":"text","name":"Title","content":"SECTION","style":{"width":80,"height":20}}
+      ]}
+    })json";
+    const auto ir = parse_figma_plugin_json(json);
+    CHECK(ir.root.layout.justify == LayoutAlign::space_between);
+    CHECK(ir.root.layout.align == LayoutAlign::center);
+}
+
+TEST_CASE("figma-plugin degenerate stroke hairline renders as a thin fill, not a doubled border",
+          "[view][import][figma-plugin][fidelity]") {
+    // A ~0-width 2px-stroke pointer: the fill becomes the line. Keeping the
+    // border too drew it on both edges and rendered ~3x too wide.
+    const std::string json = R"json({
+      "provenance": {"adapter":"figma-plugin","version":"test"},
+      "root": {"type":"frame","name":"Root","style":{"width":200,"height":200},"children":[
+        {"type":"image","name":"Hairline","asset_ref":"a","style":{"width":0.0001,"height":8,"border":"2px solid #ababab","borderColor":"#ababab","borderWidth":2,"position":"absolute","left":31,"top":17}}
+      ]}
+    })json";
+    const auto ir = parse_figma_plugin_json(json);
+    const IRNode* h = find_node_by_name(ir.root, "Hairline");
+    REQUIRE(h != nullptr);
+    CHECK(h->style.background_color.has_value());        // the fill IS the line
+    CHECK_FALSE(h->style.border_width.has_value());      // no doubled stroke
+    CHECK_FALSE(h->style.border_color.has_value());
+}
+
+TEST_CASE("single-line text taller than its font is not flipped to multi-line (search box)",
+          "[view][import][codegen][fidelity]") {
+    // An 8-14px label in a ~30px Figma box (line-box padding) must stay
+    // single-line so its vertical centering survives; the old font_h*1.6
+    // heuristic false-fired and pushed the baseline down.
+    DesignIR ir;
+    ir.root.type = "frame";
+    ir.root.name = "Root";
+    ir.root.style.width = 200.0f;
+    ir.root.style.height = 200.0f;
+    IRNode label;
+    label.type = "text";
+    label.name = "Search";
+    label.text_content = "Search";
+    label.style.width = 120.0f;
+    label.style.height = 26.0f;       // > font*1.6 (old heuristic) but < ~1.8 line boxes (new)
+    label.style.font_size = 14.0f;
+    ir.root.children.push_back(label);
+    const auto js = generate_pulp_js(ir);
+    CHECK(js.find("setMultiLine") == std::string::npos);
+
+    // A genuinely tall box still flips to multi-line.
+    DesignIR ir2 = ir;
+    ir2.root.children[0].style.height = 90.0f;
+    const auto js2 = generate_pulp_js(ir2);
+    CHECK(js2.find("setMultiLine") != std::string::npos);
+}
+
+TEST_CASE("sprite image is sized preserving its source PNG aspect ratio (never skewed)",
+          "[view][import][codegen][fidelity]") {
+    // A captured component-instance sprite: layout box 62x68, render_bounds
+    // 210x116 (aspect 1.81), but the PNG is 420x484 (aspect 0.87) with its
+    // solid core in the top. Codegen must scale by the core->box fit and emit
+    // an element at the PNG's aspect — not stretch it into render_bounds.
+    DesignIR ir;
+    ir.root.type = "frame";
+    ir.root.name = "Root";
+    ir.root.style.width = 300.0f;
+    ir.root.style.height = 300.0f;
+    IRNode img;
+    img.type = "image";
+    img.name = "Art";
+    img.style.width = 62.0f;
+    img.style.height = 68.0f;
+    img.style.position = "absolute";
+    img.style.left = 0.0f;
+    img.style.top = 0.0f;
+    img.style.render_bounds = IRStyle::RenderBounds{210.0f, 116.0f, -74.0f, 0.0f};
+    img.attributes["asset_path"] = "knob.png";
+    img.attributes["png_natural_w"] = "420";
+    img.attributes["png_natural_h"] = "484";
+    img.attributes["art_core_x"] = "148";
+    img.attributes["art_core_y"] = "0";
+    img.attributes["art_core_w"] = "115";
+    img.attributes["art_core_h"] = "129";
+    ir.root.children.push_back(img);
+
+    const auto js = generate_pulp_js(ir);
+    const auto id = image_id_after_comment(js, "Art");
+    REQUIRE(id.has_value());
+    const auto w = emitted_flex(js, *id, "width");
+    const auto h = emitted_flex(js, *id, "height");
+    REQUIRE(w.has_value());
+    REQUIRE(h.has_value());
+    REQUIRE(*h > 0.0f);
+    // Emitted aspect must equal the source PNG aspect (420/484), NOT
+    // render_bounds (210/116) — that is the no-skew invariant.
+    CHECK((*w / *h) == Catch::Approx(420.0f / 484.0f).epsilon(0.02));
+    // And the core (115*s x 129*s, s = min(62/115,68/129)) fills the 62x68 box.
+    CHECK(*w == Catch::Approx(420.0f * (68.0f / 129.0f)).epsilon(0.03));
 }

--- a/tools/import-design/figma_rasterize_vector_frames.py
+++ b/tools/import-design/figma_rasterize_vector_frames.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Flatten pure-vector illustration frames in a figma-plugin scene to single PNGs.
+
+Why this exists
+---------------
+The figma-plugin / REST exporter rasterizes *leaf* vector nodes (a single
+VECTOR / ELLIPSE / BOOLEAN_OPERATION) into one PNG, which is why a single-node
+vector graphic renders perfectly. But a vector *illustration group* (a
+FRAME/GROUP whose whole subtree is vector content — e.g. a 3-D prism built from
+rotated REGULAR_POLYGON faces) is walked as a layout container instead. Pulp is
+flex/grid-only and has no rotated-polygon primitive, so the rotated faces
+degrade to axis-aligned bordered frames and the shape renders as a flat stack
+of boxes.
+
+The fix is the *same path a single vector leaf already takes*: rasterize the
+whole illustration frame to one PNG via the Figma `/images` endpoint and replace
+the node with an image node. This is a generalizable rule keyed on node structure
+(no hardcoded layer names): a frame is flattened iff its entire subtree is
+vector/shape content with no text and no recognized interactive widget.
+
+This runs as a post-export pass over a `*.pulp.json` scene that still carries
+`figma_node_id` on every node (the figma-plugin envelope does). It needs a
+Figma personal access token (``--token-file`` or ``$FIGMA_TOKEN``) and network
+access, so it is a developer-time export helper — never part of CI.
+
+Usage:
+  figma_rasterize_vector_frames.py --scene scene.pulp.json \
+      --assets-dir scene_assets/ --out scene.rasterized.pulp.json [--scale 3]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.request
+
+# Figma layer "type" values (preserved in node['figma']['figma_type'] when the
+# exporter kept it) that are intrinsically vector/shape primitives.
+VECTOR_FIGMA_TYPES = {
+    "VECTOR", "BOOLEAN_OPERATION", "STAR", "LINE", "ELLIPSE",
+    "REGULAR_POLYGON", "POLYGON", "RECTANGLE",
+}
+
+# Substrings that mark a node as an interactive widget / text-bearing control.
+# A subtree containing any of these is a layout container, not an illustration,
+# so it must NOT be flattened.
+WIDGET_NAME_HINTS = (
+    "knob", "fader", "slider", "meter", "button", "dropdown", "search",
+    "toggle", "switch", "checkbox", "radio", "input", "field", "tab",
+    "menu", "scrollbar", "xy", "pad",
+)
+
+
+def _figma_type(node: dict) -> str | None:
+    fig = node.get("figma") or {}
+    return node.get("figma_type") or fig.get("figma_type")
+
+
+def _name_is_widget(name: str) -> bool:
+    low = name.lower()
+    return any(h in low for h in WIDGET_NAME_HINTS)
+
+
+def _is_vectorish_leaf(node: dict) -> bool:
+    """True if this leaf is a strong vector signal — an actual vector type, an
+    already-rasterized vector fragment (Vector N → image), or a degraded
+    polygon face (border-only frame). Used to require that a flattened frame
+    contains *some* real vector content, not just plain fill plates."""
+    ft = _figma_type(node)
+    if ft in VECTOR_FIGMA_TYPES:
+        return True
+    if node.get("type") == "image":
+        return True
+    style = node.get("style") or {}
+    if node.get("type") == "frame" and (style.get("border") or style.get("border_width")):
+        return True
+    return False
+
+
+def _leaf_is_illustration_content(node: dict) -> bool:
+    """A leaf is acceptable inside an illustration iff it is neither text nor a
+    named interactive widget. Fill-plate rectangles, gradient frames, polygon
+    faces and rasterized vector fragments all qualify."""
+    if node.get("type") == "text":
+        return False
+    if _name_is_widget(node.get("name", "")):
+        return False
+    return True
+
+
+def is_vector_illustration(node: dict) -> bool:
+    """True iff `node` is a frame/group whose entire subtree is vector/shape
+    content with no text and no interactive widget — i.e. a decorative
+    illustration that should be rasterized whole."""
+    if node.get("type") not in ("frame", "group"):
+        return False
+    children = node.get("children") or []
+    if not children:
+        return False  # leaves are already handled by the exporter
+    if _name_is_widget(node.get("name", "")):
+        return False
+
+    saw_vector = False
+
+    def walk(n: dict) -> bool:
+        nonlocal saw_vector
+        if n.get("type") == "text":
+            return False
+        if _name_is_widget(n.get("name", "")):
+            return False
+        kids = n.get("children") or []
+        if not kids:
+            # leaf — must be non-text/non-widget illustration content
+            if not _leaf_is_illustration_content(n):
+                return False
+            if _is_vectorish_leaf(n):
+                saw_vector = True
+            return True
+        for c in kids:
+            if not walk(c):
+                return False
+        return True
+
+    for c in children:
+        if not walk(c):
+            return False
+    return saw_vector
+
+
+def collect_targets(root: dict) -> list[dict]:
+    """Topmost vector-illustration frames (do not descend into a flattened
+    frame — we rasterize at the outermost illustration boundary)."""
+    targets: list[dict] = []
+
+    def walk(n: dict):
+        if is_vector_illustration(n):
+            if n.get("figma_node_id"):
+                targets.append(n)
+            return  # don't descend — flatten whole
+        for c in (n.get("children") or []):
+            walk(c)
+
+    walk(root)
+    return targets
+
+
+def fetch_image_urls(file_key: str, ids: list[str], token: str,
+                     scale: float) -> dict:
+    q = ",".join(ids)
+    url = (f"https://api.figma.com/v1/images/{file_key}"
+           f"?ids={q}&format=png&scale={scale}")
+    req = urllib.request.Request(url, headers={"X-Figma-Token": token})
+    with urllib.request.urlopen(req, timeout=60) as r:
+        data = json.load(r)
+    if data.get("err"):
+        raise RuntimeError(f"Figma /images error: {data['err']}")
+    return data.get("images", {})
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--scene", required=True)
+    ap.add_argument("--assets-dir", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--scale", type=float, default=3.0)
+    ap.add_argument("--token-file",
+                    default=os.path.expanduser("~/.config/pulp/figma-token"))
+    ap.add_argument("--dry-run", action="store_true",
+                    help="List the frames that would be flattened, don't fetch.")
+    args = ap.parse_args()
+
+    scene = json.load(open(args.scene))
+    root = scene.get("root", scene)
+
+    # Derive the file key from any node's source_uri / provenance.
+    prov = scene.get("provenance", {})
+    src = prov.get("source_uri", "")
+    file_key = ""
+    if src.startswith("figma://"):
+        file_key = src[len("figma://"):].split("/", 1)[0]
+    if not file_key:
+        print("ERROR: could not derive Figma file key from provenance.source_uri",
+              file=sys.stderr)
+        return 2
+
+    targets = collect_targets(root)
+    print(f"Found {len(targets)} vector-illustration frame(s) to flatten:")
+    for t in targets:
+        print(f"  {t['figma_node_id']:>8}  {t.get('name')!r}")
+    if not targets:
+        json.dump(scene, open(args.out, "w"), indent=1)
+        print("Nothing to flatten; wrote scene unchanged.")
+        return 0
+    if args.dry_run:
+        return 0
+
+    token = open(args.token_file).read().strip()
+    ids = [t["figma_node_id"] for t in targets]
+    urls = fetch_image_urls(file_key, ids, token, args.scale)
+
+    os.makedirs(args.assets_dir, exist_ok=True)
+    for t in targets:
+        nid = t["figma_node_id"]
+        url = urls.get(nid)
+        if not url:
+            print(f"  WARN: no render URL for {nid}; leaving as-is")
+            continue
+        fname = nid.replace(":", "_") + ".png"
+        path = os.path.join(args.assets_dir, fname)
+        urllib.request.urlretrieve(url, path)
+        # Replace the frame with an image node covering the whole frame box.
+        # Keep position/size; drop the degraded children. asset_ref + asset_path
+        # so the importer treats it exactly like the cylinder (Torus) node.
+        t["type"] = "image"
+        t["asset_ref"] = nid
+        t["children"] = []
+        attrs = t.setdefault("attributes", {})
+        attrs["asset_path"] = path
+        print(f"  flattened {nid} -> {fname}")
+
+    json.dump(scene, open(args.out, "w"), indent=1)
+    print(f"Wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/import-design/pulp_import_design.cpp
+++ b/tools/import-design/pulp_import_design.cpp
@@ -70,6 +70,24 @@ static uint32_t png_be32(const uint8_t* p) {
            (static_cast<uint32_t>(p[2]) << 8) | static_cast<uint32_t>(p[3]);
 }
 
+// Read a PNG's pixel dimensions from its IHDR header (width @ byte 16, height
+// @ byte 20) without decoding the pixel data. Returns {0,0} on any non-PNG or
+// unreadable file. Used to recover the true source aspect ratio so imported
+// images/sprites are never skewed.
+static std::pair<int, int> read_png_dimensions(const std::string& path) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f.good()) return {0, 0};
+    uint8_t hdr[24];
+    f.read(reinterpret_cast<char*>(hdr), sizeof(hdr));
+    if (f.gcount() < static_cast<std::streamsize>(sizeof(hdr))) return {0, 0};
+    static const uint8_t sig[8] = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+    if (std::memcmp(hdr, sig, 8) != 0) return {0, 0};
+    int w = static_cast<int>(png_be32(hdr + 16));
+    int h = static_cast<int>(png_be32(hdr + 20));
+    if (w <= 0 || h <= 0) return {0, 0};
+    return {w, h};
+}
+
 static DecodedPng decode_png_rgba(const uint8_t* data, size_t size) {
     DecodedPng out;
     static const uint8_t sig[8] = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
@@ -159,6 +177,43 @@ static DecodedPng decode_png_rgba(const uint8_t* data, size_t size) {
     out.width = width;
     out.height = height;
     return out;
+}
+
+// The bbox of an image's *solid* content — pixels whose alpha is at least
+// `min_alpha` (default 0.5). For a captured sprite this isolates the drawn
+// geometry (a knob's disc, a shape's body) from the soft drop-shadow / glow
+// that bleeds far past it. Lets the importer scale a sprite so its solid core
+// fills the node's logical box while the shadow is free to extend beyond —
+// the generalizable answer to "size sprites correctly without skew", derived
+// from the pixels themselves. Returns false if no qualifying pixels.
+struct OpaqueCore { int x = 0, y = 0, w = 0, h = 0, png_w = 0, png_h = 0; };
+static bool compute_opaque_core(const std::string& path, OpaqueCore& out,
+                                float min_alpha = 0.5f) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f.good()) return false;
+    std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(f)),
+                               std::istreambuf_iterator<char>());
+    auto img = decode_png_rgba(bytes.data(), bytes.size());
+    if (!img.valid()) return false;
+    const uint8_t thresh = static_cast<uint8_t>(
+        std::clamp(min_alpha, 0.0f, 1.0f) * 255.0f + 0.5f);
+    int minx = img.width, miny = img.height, maxx = -1, maxy = -1;
+    for (int y = 0; y < img.height; ++y) {
+        const uint8_t* row = img.rgba.data() + static_cast<size_t>(y) * img.width * 4;
+        for (int x = 0; x < img.width; ++x) {
+            if (row[x * 4 + 3] >= thresh) {
+                if (x < minx) minx = x;
+                if (x > maxx) maxx = x;
+                if (y < miny) miny = y;
+                if (y > maxy) maxy = y;
+            }
+        }
+    }
+    if (maxx < minx || maxy < miny) return false;
+    out.x = minx; out.y = miny;
+    out.w = maxx - minx + 1; out.h = maxy - miny + 1;
+    out.png_w = img.width; out.png_h = img.height;
+    return true;
 }
 
 enum class ArtifactEmit {
@@ -1898,6 +1953,31 @@ int main(int argc, char* argv[]) {
         opts.shortcuts = detected_shortcuts;
     }
 
+    // Sprite knob style = pixel-exact Figma reproduction. When a knob frame
+    // ships a captured graphic child (an image with an asset_ref — e.g. a
+    // silver-knob body group), the most faithful sprite rendering is to draw
+    // that PNG directly at its full render_bounds extent — exactly what the
+    // image codegen path does — rather than collapse the frame into a native
+    // knob and skin it (which fits the art to the knob box and loses the
+    // bleed/3-D chrome). So in sprite mode we DEMOTE such recognized knobs
+    // back to plain containers; their art child then renders as a normal
+    // bleed-sized image. Silver mode keeps the native-vector widget. This is
+    // the swap the design-import contract promises: sprite = captured art,
+    // silver = native vector. Generalizable: keyed on widget kind + an
+    // asset-bearing image child, no layer-name match.
+    if (!use_silver_knobs) {
+        std::function<void(IRNode&)> demote = [&](IRNode& n) {
+            if (n.audio_widget == pulp::view::AudioWidgetType::knob) {
+                bool has_art = false;
+                for (auto& c : n.children)
+                    if (c.type == "image" && c.attributes.count("asset_ref")) { has_art = true; break; }
+                if (has_art) n.audio_widget = pulp::view::AudioWidgetType::none;
+            }
+            for (auto& c : n.children) demote(c);
+        };
+        demote(ir.root);
+    }
+
     // Resolve asset_ref → absolute file path. For envelopes that include an
     // asset_manifest with local_path entries (figma-plugin lane), walk the IR
     // tree and stamp each node's attributes["asset_path"] with the absolute
@@ -1918,6 +1998,39 @@ int main(int argc, char* argv[]) {
                         if (p.is_relative()) p = base_dir / p;
                         std::string abs = p.lexically_normal().string();
                         n.attributes["asset_path"] = abs;
+
+                        // Stamp the asset's TRUE pixel dimensions from the PNG
+                        // header (the manifest ships null dims). Codegen uses
+                        // this to preserve the source aspect ratio — sprites
+                        // must never be skewed (e.g. a knob graphic whose
+                        // render_bounds claim a 1.81 aspect while the PNG is
+                        // 0.87: naively sizing to render_bounds stretches it
+                        // ~2× wide). Generalizable: every imported image
+                        // carries its real aspect.
+                        if (auto d = read_png_dimensions(abs); d.first > 0 && d.second > 0) {
+                            n.attributes["png_natural_w"] = std::to_string(d.first);
+                            n.attributes["png_natural_h"] = std::to_string(d.second);
+                        }
+                        // For a sprite that bleeds past its layout box
+                        // (render_bounds present), also recover the solid-core
+                        // bbox so codegen can scale the art so its core fills
+                        // the box while the soft shadow extends beyond — the
+                        // correct, data-driven sprite size+placement (the knob
+                        // disc sits in the PNG's top with a long shadow below,
+                        // so render_bounds and naive centering both misplace
+                        // it). Decode is gated on render_bounds to keep the
+                        // common image path header-only cheap.
+                        if (n.style.render_bounds) {
+                            OpaqueCore core;
+                            if (compute_opaque_core(abs, core)) {
+                                n.attributes["art_core_x"] = std::to_string(core.x);
+                                n.attributes["art_core_y"] = std::to_string(core.y);
+                                n.attributes["art_core_w"] = std::to_string(core.w);
+                                n.attributes["art_core_h"] = std::to_string(core.h);
+                                n.attributes["png_natural_w"] = std::to_string(core.png_w);
+                                n.attributes["png_natural_h"] = std::to_string(core.png_h);
+                            }
+                        }
 
                         // pulp #3191 — derive a value-driven skin for recognised
                         // faders/meters by SAMPLING the captured PNG (not baking


### PR DESCRIPTION
Addresses a set of generic design-import fidelity gaps surfaced while importing
a real Figma plugin UI. Every fix reads exported data/pixels — no hardcoding,
no per-design tuning.

Sizing (never skew a sprite):
- Read each asset's TRUE pixel dimensions from the PNG header (the manifest
  ships null dims) plus its opaque-core bbox, and size images preserving the
  source aspect ratio. A captured component-instance sprite (e.g. a knob whose
  render_bounds aspect is 1.81 while the PNG is 0.87) is scaled so its solid
  core fills the layout box while the soft shadow bleeds beyond — instead of
  stretching the PNG into render_bounds.
- Parse render_bounds {w,h,dx,dy} into IRStyle (was parsed nowhere).

Widget recognition:
- A widget-named frame is no longer denied recognition by a decorative
  stroke-demoted child: a ~0-width stroked pointer hairline (image->frame at
  demotion) is tagged and skipped by the recognition gate, so a knob keeps both
  its pointer line AND its native widget-ness. Real structural containers
  (populated/nested frames, sub-widget rows) still disqualify, as before.

Layout/text:
- Honor snake_case align keywords (space_between, flex_end) alongside
  kebab-case; snake_case justify/align were silently dropping to flex_start.
- line_height-aware multi-line heuristic: a single line of small text in a
  tall padded box (e.g. a search field) is no longer flipped to multi-line,
  while a genuine two-line paragraph still wraps.
- A degenerate stroke hairline renders as a thin fill, not a fill PLUS a
  same-color border (which drew on both edges and rendered ~3x too wide).

Tooling:
- tools/import-design/figma_rasterize_vector_frames.py: a post-export pass that
  flattens a pure-vector illustration frame (subtree is all vector/shape, no
  text/widget) to one rasterized PNG via the Figma /images endpoint, so a 3-D
  vector illustration renders faithfully instead of degrading to a flat stack
  of axis-aligned boxes (Pulp is flex/grid-only with no rotated-polygon prim).
  Generalizable by node structure; no layer-name matching.

Tests: 6 new regression cases in test_design_import.cpp (recognition past a
decorative child, render_bounds parse, snake_case align, doubled-stroke clear,
single- vs multi-line text, no-skew sprite sizing). Full design-import suite
green (98 cases, 855 assertions).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>