### PR TITLE
fix(view): limit aspect-preserving image sizing to bleed sprites only

### DIFF
--- a/core/view/src/design_codegen.cpp
+++ b/core/view/src/design_codegen.cpp
@@ -959,8 +959,14 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
                 if (node.style.top)
                     ss << ind << "setTop('" << id << "', " << (*node.style.top - core_y * s + pad_y) << ");\n";
             }
-        } else if (png_w > 0.0f && png_h > 0.0f && box_w > 0.0f && box_h > 0.0f) {
-            // No core data but real dims known → contain-fit preserving aspect.
+        } else if (node.style.render_bounds && png_w > 0.0f && png_h > 0.0f &&
+                   box_w > 0.0f && box_h > 0.0f) {
+            // A bleed sprite (render_bounds present) whose opaque core couldn't
+            // be recovered → contain-fit preserving aspect. Gated on
+            // render_bounds: an ORDINARY image/icon must keep the box the IR
+            // declared (a 100×100 node with a 200×100 bitmap fills its 100×100
+            // slot, as Figma's image-fill intends), so aspect-preservation is
+            // limited to bleed sprites and never reshapes normal images.
             const float png_aspect = png_w / png_h;
             float ew = box_w, eh = box_h;
             if (box_w / box_h > png_aspect) { eh = box_h; ew = box_h * png_aspect; }
@@ -968,7 +974,7 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
             ss << ind << "setFlex('" << id << "', 'width', " << ew << ");\n";
             ss << ind << "setFlex('" << id << "', 'height', " << eh << ");\n";
         } else {
-            // Aspect unknown → legacy box sizing.
+            // Ordinary image (no bleed) or unknown dims → keep the declared box.
             if (node.style.width)
                 ss << ind << "setFlex('" << id << "', 'width', " << *node.style.width << ");\n";
             if (node.style.height)

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -4148,3 +4148,36 @@ TEST_CASE("sprite image is sized preserving its source PNG aspect ratio (never s
     // And the core (115*s x 129*s, s = min(62/115,68/129)) fills the 62x68 box.
     CHECK(*w == Catch::Approx(420.0f * (68.0f / 129.0f)).epsilon(0.03));
 }
+
+TEST_CASE("ordinary image (no render_bounds) keeps its declared box, not its PNG aspect",
+          "[view][import][codegen][fidelity]") {
+    // Aspect-preservation is ONLY for bleed sprites (render_bounds present).
+    // A normal image/icon whose node is 100x100 but whose bitmap is 200x100
+    // must fill its declared 100x100 slot (Figma image-fill intent), NOT be
+    // contained to 100x50 — that would reshape ordinary images and shift flex
+    // layout. Guards the gating fix for the sprite-sizing path.
+    DesignIR ir;
+    ir.root.type = "frame";
+    ir.root.name = "Root";
+    ir.root.style.width = 300.0f;
+    ir.root.style.height = 300.0f;
+    IRNode img;
+    img.type = "image";
+    img.name = "Icon";
+    img.style.width = 100.0f;
+    img.style.height = 100.0f;
+    img.attributes["asset_path"] = "icon.png";
+    img.attributes["png_natural_w"] = "200";   // wide bitmap, no render_bounds
+    img.attributes["png_natural_h"] = "100";
+    ir.root.children.push_back(img);
+
+    const auto js = generate_pulp_js(ir);
+    const auto id = image_id_after_comment(js, "Icon");
+    REQUIRE(id.has_value());
+    const auto w = emitted_flex(js, *id, "width");
+    const auto h = emitted_flex(js, *id, "height");
+    REQUIRE(w.has_value());
+    REQUIRE(h.has_value());
+    CHECK(*w == Catch::Approx(100.0f));   // declared box preserved
+    CHECK(*h == Catch::Approx(100.0f));   // NOT 50 (contain to PNG aspect)
+}


### PR DESCRIPTION
Addresses Codex P2 on #3259. The contain-fit branch applied to every image
with known PNG dimensions, so an ordinary image/icon whose node is 100×100 but
whose bitmap is 200×100 was emitted as 100×50 instead of filling its declared
100×100 slot — reshaping normal images and shifting flex/absolute layout.

Gate the aspect-preserving path on `render_bounds` (the bleed-sprite marker):
- bleed sprite with a recovered opaque core → core-fit (unchanged)
- bleed sprite without a core → contain-fit preserving aspect (unchanged)
- ordinary image (no render_bounds) → keep the IR's declared box, as before,
  honoring Figma's image-fill intent.

Test: an ordinary image (no render_bounds, 200×100 bitmap, 100×100 box) keeps
its 100×100 box rather than containing to 100×50. Full design-import suite
green (99 cases).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>