### PR TITLE
fix(view): include asset_bleed in the bleed sprite sizing gate

### DIFF
--- a/core/view/src/design_codegen.cpp
+++ b/core/view/src/design_codegen.cpp
@@ -938,6 +938,16 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
         const bool have_core = png_w > 0.0f && png_h > 0.0f &&
                                core_w > 0.0f && core_h > 0.0f &&
                                box_w > 0.0f && box_h > 0.0f;
+        // A sprite "bleeds" past its box either because the export carried a
+        // render_bounds extent OR because the importer's pixel-vs-box heuristic
+        // stamped asset_bleed=1 (PNG dims ≫ layout box). Both mark art that
+        // must preserve its source aspect; an asset_bleed-only sprite has no
+        // render_bounds, and object-fit is storage-only, so without this it
+        // would size to its box and skew.
+        const bool is_bleed_sprite =
+            node.style.render_bounds.has_value() ||
+            (node.attributes.count("asset_bleed") &&
+             node.attributes.at("asset_bleed") == "1");
 
         if (have_core) {
             // Uniform scale that fits the solid core inside the layout box
@@ -959,14 +969,15 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
                 if (node.style.top)
                     ss << ind << "setTop('" << id << "', " << (*node.style.top - core_y * s + pad_y) << ");\n";
             }
-        } else if (node.style.render_bounds && png_w > 0.0f && png_h > 0.0f &&
+        } else if (is_bleed_sprite && png_w > 0.0f && png_h > 0.0f &&
                    box_w > 0.0f && box_h > 0.0f) {
-            // A bleed sprite (render_bounds present) whose opaque core couldn't
-            // be recovered → contain-fit preserving aspect. Gated on
-            // render_bounds: an ORDINARY image/icon must keep the box the IR
-            // declared (a 100×100 node with a 200×100 bitmap fills its 100×100
-            // slot, as Figma's image-fill intends), so aspect-preservation is
-            // limited to bleed sprites and never reshapes normal images.
+            // A bleed sprite (render_bounds or asset_bleed) whose opaque core
+            // couldn't be recovered → contain-fit preserving aspect. Gated on
+            // the bleed markers: an ORDINARY image/icon must keep the box the
+            // IR declared (a 100×100 node with a 200×100 bitmap fills its
+            // 100×100 slot, as Figma's image-fill intends), so aspect-
+            // preservation is limited to bleed sprites and never reshapes
+            // normal images.
             const float png_aspect = png_w / png_h;
             float ew = box_w, eh = box_h;
             if (box_w / box_h > png_aspect) { eh = box_h; ew = box_h * png_aspect; }

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -4181,3 +4181,37 @@ TEST_CASE("ordinary image (no render_bounds) keeps its declared box, not its PNG
     CHECK(*w == Catch::Approx(100.0f));   // declared box preserved
     CHECK(*h == Catch::Approx(100.0f));   // NOT 50 (contain to PNG aspect)
 }
+
+TEST_CASE("asset_bleed sprite (no render_bounds) preserves PNG aspect",
+          "[view][import][codegen][fidelity]") {
+    // The importer's pixel-vs-box heuristic stamps asset_bleed=1 on sprites
+    // that bleed past their box without a render_bounds extent. Those must
+    // still preserve their source aspect (object-fit is storage-only, so the
+    // element box has to carry the aspect) — otherwise they skew.
+    DesignIR ir;
+    ir.root.type = "frame";
+    ir.root.name = "Root";
+    ir.root.style.width = 300.0f;
+    ir.root.style.height = 300.0f;
+    IRNode img;
+    img.type = "image";
+    img.name = "Bleed";
+    img.style.width = 100.0f;
+    img.style.height = 100.0f;
+    img.attributes["asset_path"] = "bleed.png";
+    img.attributes["png_natural_w"] = "200";   // wide bitmap
+    img.attributes["png_natural_h"] = "100";
+    img.attributes["asset_bleed"] = "1";        // bleed marker, NO render_bounds
+    ir.root.children.push_back(img);
+
+    const auto js = generate_pulp_js(ir);
+    const auto id = image_id_after_comment(js, "Bleed");
+    REQUIRE(id.has_value());
+    const auto w = emitted_flex(js, *id, "width");
+    const auto h = emitted_flex(js, *id, "height");
+    REQUIRE(w.has_value());
+    REQUIRE(h.has_value());
+    // 100x100 box, aspect 2.0 → contain → 100x50 (aspect preserved, not skewed).
+    CHECK(*w == Catch::Approx(100.0f));
+    CHECK(*h == Catch::Approx(50.0f));
+}


### PR DESCRIPTION
Addresses Codex P2 on #3260. The bleed predicate gated aspect-preserving image
sizing on `render_bounds` alone, but the importer also marks bleed sprites with
`asset_bleed=1` (pixel-vs-box heuristic) and those carry no render_bounds. Such
a sprite fell to the ordinary-image fallback and was sized to its declared box;
since object-fit is storage-only, a differing PNG aspect then visibly skewed —
a regression from the prior PNG-aspect sizing.

The bleed gate now triggers on render_bounds OR asset_bleed, so asset-bleed-only
sprites contain-fit and preserve aspect, while ordinary images still keep their
declared box.

Test: an asset_bleed image (no render_bounds, 200×100 bitmap, 100×100 box)
emits 100×50 (aspect preserved), not 100×100. Full design-import suite green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>