### PR TITLE
fix(view): center asset-bleed sprites after contain sizing

### DIFF
--- a/core/view/src/design_codegen.cpp
+++ b/core/view/src/design_codegen.cpp
@@ -984,6 +984,18 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
             else                            { ew = box_w; eh = box_w / png_aspect; }
             ss << ind << "setFlex('" << id << "', 'width', " << ew << ");\n";
             ss << ind << "setFlex('" << id << "', 'height', " << eh << ");\n";
+            // Center the contained element within the declared box — the bleed
+            // art is documented as centered, and leaving the original top/left
+            // (from emit_position_if_absolute) would pin the reduced element to
+            // the box's top-left, visibly shifting it.
+            if (node.style.position && *node.style.position == "absolute") {
+                const float pad_x = (box_w - ew) * 0.5f;
+                const float pad_y = (box_h - eh) * 0.5f;
+                if (node.style.left)
+                    ss << ind << "setLeft('" << id << "', " << (*node.style.left + pad_x) << ");\n";
+                if (node.style.top)
+                    ss << ind << "setTop('" << id << "', " << (*node.style.top + pad_y) << ");\n";
+            }
         } else {
             // Ordinary image (no bleed) or unknown dims → keep the declared box.
             if (node.style.width)

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -4198,6 +4198,9 @@ TEST_CASE("asset_bleed sprite (no render_bounds) preserves PNG aspect",
     img.name = "Bleed";
     img.style.width = 100.0f;
     img.style.height = 100.0f;
+    img.style.position = "absolute";
+    img.style.left = 10.0f;
+    img.style.top = 10.0f;
     img.attributes["asset_path"] = "bleed.png";
     img.attributes["png_natural_w"] = "200";   // wide bitmap
     img.attributes["png_natural_h"] = "100";
@@ -4214,4 +4217,8 @@ TEST_CASE("asset_bleed sprite (no render_bounds) preserves PNG aspect",
     // 100x100 box, aspect 2.0 → contain → 100x50 (aspect preserved, not skewed).
     CHECK(*w == Catch::Approx(100.0f));
     CHECK(*h == Catch::Approx(50.0f));
+    // …and centered in the box: 50px of vertical slack → top offset by +25
+    // (10 → 35); no horizontal slack (width fills) → left unchanged (10).
+    CHECK(js.find("setTop('" + *id + "', 35") != std::string::npos);
+    CHECK(js.find("setLeft('" + *id + "', 10") != std::string::npos);
 }


### PR DESCRIPTION
Addresses Codex P2 on #3262. When an asset_bleed sprite (no render_bounds) is
contain-fit to preserve aspect, the reduced element kept the original top/left
emitted by emit_position_if_absolute, pinning it to the box's top-left and
visibly shifting it — the bleed art is documented as centered in its box.

Offset an absolutely-positioned contained element by half the unused width/
height so it stays centered (matching the core-fit path's centering).

Test: extends the asset_bleed case — a 200×100 bitmap in a 100×100 absolute box
at (10,10) emits 100×50 centered (top 10→35, left unchanged). Suite green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>