### PR TITLE
feat(import-design): reference-free no-skew fidelity self-check

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -1795,3 +1795,20 @@ rasterized shapes). Each cost a visible fidelity bug.
   replaces each with a single PNG rasterized via the Figma `/images` endpoint.
   It needs a Figma token + network, so it is a developer-time export helper,
   never run in CI.
+
+## Fidelity self-check (reference-free no-skew invariant)
+
+- **Codegen self-checks every sprite it sizes.** `check_image_sizing_fidelity`
+  (design_codegen.cpp) is a pure, testable function: for a BLEED sprite
+  (`render_bounds` or `asset_bleed`) it compares the dimensions codegen emitted
+  against the source PNG aspect and returns a `FidelityIssue` of kind `skew`
+  (>5% aspect divergence) or `aspect-unverified` (no PNG dims). Ordinary
+  non-bleed images intentionally fill their box and are never flagged. Pass a
+  `CodeGenOptions::fidelity_report` sink to collect findings.
+- **`pulp import-design --strict-fidelity`** prints any findings as
+  `fidelity: …` warnings and exits 4 when one is present (distinct from a
+  parse/IO error). This is the first reference-free invariant from the
+  fidelity-harness plan — it would have caught the original knob-skew bug at
+  import time, with no reference image, generalizing to any design. Keep new
+  sizing paths covered: assign the emitted w/h to `emitted_w/emitted_h` so the
+  check runs on every branch.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.150.2",
+      "version": "0.151.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.150.2"
+  "version": "0.151.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.150.2",
+  "version": "0.151.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.299.0
+    VERSION 0.300.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/design_codegen.hpp
+++ b/core/view/include/pulp/view/design_codegen.hpp
@@ -7,6 +7,7 @@
 
 #include <pulp/view/design_ir.hpp>
 #include <pulp/view/design_shortcuts.hpp>  // DetectedShortcut (CodeGenOptions::shortcuts)
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -57,7 +58,34 @@ struct CodeGenOptions {
     /// state — we just intercept the OS chord and re-fire the synthetic
     /// keydown into the engine. Empty vector = no shortcut emission.
     std::vector<DetectedShortcut> shortcuts;
+
+    /// Optional fidelity-report sink. When non-null, codegen records a
+    /// FidelityIssue for any image it cannot prove it sized faithfully — a
+    /// bleed sprite whose emitted aspect diverges from its source PNG (skew),
+    /// or one missing the pixel dims needed to preserve aspect at all. This is
+    /// a reference-free self-consistency check (it compares the emitted
+    /// geometry against the asset's own pixels), so it generalizes to any
+    /// import without overfitting. Non-owning; the caller owns the vector.
+    std::vector<struct FidelityIssue>* fidelity_report = nullptr;
 };
+
+/// A single import-fidelity self-check finding.
+struct FidelityIssue {
+    std::string node_id;    ///< sanitized bridge id of the offending node
+    std::string node_name;  ///< source layer name (for human-readable reports)
+    std::string kind;       ///< "skew" | "aspect-unverified"
+    std::string detail;     ///< one-line explanation with the measured numbers
+};
+
+/// Reference-free check: did codegen size this image faithfully? Returns a
+/// finding when a BLEED sprite (render_bounds or asset_bleed) was emitted at an
+/// aspect that diverges from its source PNG (skew), or lacks the PNG dims
+/// needed to preserve aspect (aspect-unverified). Ordinary (non-bleed) images
+/// intentionally fill their declared box and are never flagged. Pure +
+/// testable in isolation; `emitted_w/h` are the dimensions codegen emitted.
+std::optional<FidelityIssue> check_image_sizing_fidelity(
+    const IRNode& node, const std::string& node_id,
+    float emitted_w, float emitted_h);
 
 /// Generate Pulp JS code from a DesignIR.
 /// Native mode (default) uses createCol/createRow/createKnob + setFlex.

--- a/core/view/src/design_codegen.cpp
+++ b/core/view/src/design_codegen.cpp
@@ -949,6 +949,10 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
             (node.attributes.count("asset_bleed") &&
              node.attributes.at("asset_bleed") == "1");
 
+        // Capture the dimensions actually emitted so the fidelity self-check
+        // can verify them against the source PNG aspect (no-skew invariant).
+        float emitted_w = 0.0f, emitted_h = 0.0f;
+
         if (have_core) {
             // Uniform scale that fits the solid core inside the layout box
             // (preserves aspect — never skews). The whole PNG scales by `s`,
@@ -956,6 +960,7 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
             const float s = std::min(box_w / core_w, box_h / core_h);
             const float ew = png_w * s;
             const float eh = png_h * s;
+            emitted_w = ew; emitted_h = eh;
             ss << ind << "setFlex('" << id << "', 'width', " << ew << ");\n";
             ss << ind << "setFlex('" << id << "', 'height', " << eh << ");\n";
             // Place so the core's top-left lands on the layout box, then nudge
@@ -982,6 +987,7 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
             float ew = box_w, eh = box_h;
             if (box_w / box_h > png_aspect) { eh = box_h; ew = box_h * png_aspect; }
             else                            { ew = box_w; eh = box_w / png_aspect; }
+            emitted_w = ew; emitted_h = eh;
             ss << ind << "setFlex('" << id << "', 'width', " << ew << ");\n";
             ss << ind << "setFlex('" << id << "', 'height', " << eh << ");\n";
             // Center the contained element within the declared box — the bleed
@@ -1002,9 +1008,16 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
                 ss << ind << "setFlex('" << id << "', 'width', " << *node.style.width << ");\n";
             if (node.style.height)
                 ss << ind << "setFlex('" << id << "', 'height', " << *node.style.height << ");\n";
+            emitted_w = node.style.width.value_or(0.0f);
+            emitted_h = node.style.height.value_or(0.0f);
             auto bleed_it = node.attributes.find("asset_bleed");
             if (bleed_it != node.attributes.end() && bleed_it->second == "1")
                 ss << ind << "setObjectFit('" << id << "', 'none');\n";
+        }
+        // Fidelity self-check: confirm a bleed sprite was sized without skew.
+        if (opts.fidelity_report) {
+            if (auto issue = check_image_sizing_fidelity(node, id, emitted_w, emitted_h))
+                opts.fidelity_report->push_back(std::move(*issue));
         }
         ss << "\n";
         return;
@@ -1339,6 +1352,44 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
     if (node.style.background_color)
         ss << ind << "setBackground('" << id << "', '" << *node.style.background_color << "');\n";
     ss << "\n";
+}
+
+// ── Fidelity self-check (reference-free no-skew invariant) ───────────────
+
+std::optional<FidelityIssue> check_image_sizing_fidelity(
+    const IRNode& node, const std::string& node_id,
+    float emitted_w, float emitted_h) {
+    // Only bleed sprites are sized to preserve aspect; an ordinary image
+    // intentionally fills its declared box, so it is never a skew finding.
+    const bool is_bleed =
+        node.style.render_bounds.has_value() ||
+        (node.attributes.count("asset_bleed") &&
+         node.attributes.at("asset_bleed") == "1");
+    if (!is_bleed) return std::nullopt;
+
+    auto attr_f = [&](const char* k) -> float {
+        auto it = node.attributes.find(k);
+        return it != node.attributes.end() ? std::strtof(it->second.c_str(), nullptr) : 0.0f;
+    };
+    const float png_w = attr_f("png_natural_w");
+    const float png_h = attr_f("png_natural_h");
+    if (png_w <= 0.0f || png_h <= 0.0f) {
+        return FidelityIssue{node_id, node.name, "aspect-unverified",
+            "bleed sprite has no source PNG dimensions; aspect could not be verified"};
+    }
+    if (emitted_w <= 0.0f || emitted_h <= 0.0f) return std::nullopt;
+
+    const float png_aspect = png_w / png_h;
+    const float emitted_aspect = emitted_w / emitted_h;
+    const float rel = std::fabs(emitted_aspect - png_aspect) / png_aspect;
+    if (rel > 0.05f) {
+        std::ostringstream d;
+        d << "emitted aspect " << emitted_aspect << " diverges from source PNG aspect "
+          << png_aspect << " (" << static_cast<int>(rel * 100.0f + 0.5f)
+          << "% off) — sprite skewed";
+        return FidelityIssue{node_id, node.name, "skew", d.str()};
+    }
+    return std::nullopt;
 }
 
 // ── Public code generation ──────────────────────────────────────────────

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -4222,3 +4222,62 @@ TEST_CASE("asset_bleed sprite (no render_bounds) preserves PNG aspect",
     CHECK(js.find("setTop('" + *id + "', 35") != std::string::npos);
     CHECK(js.find("setLeft('" + *id + "', 10") != std::string::npos);
 }
+
+// ── Reference-free fidelity self-check (no-skew invariant) ──────────────────
+namespace {
+IRNode make_image_node(bool bleed_via_render_bounds, bool asset_bleed,
+                       float png_w, float png_h) {
+    IRNode n;
+    n.type = "image";
+    n.name = "Sprite";
+    n.style.width = 100.0f;
+    n.style.height = 100.0f;
+    if (bleed_via_render_bounds)
+        n.style.render_bounds = IRStyle::RenderBounds{200.0f, 200.0f, 0.0f, 0.0f};
+    if (asset_bleed) n.attributes["asset_bleed"] = "1";
+    if (png_w > 0.0f) n.attributes["png_natural_w"] = std::to_string((int)png_w);
+    if (png_h > 0.0f) n.attributes["png_natural_h"] = std::to_string((int)png_h);
+    return n;
+}
+}  // namespace
+
+TEST_CASE("fidelity self-check passes when a bleed sprite preserves its aspect",
+          "[view][import][fidelity][harness]") {
+    // png 200x100 (aspect 2.0); emitted 120x60 (aspect 2.0) → no finding.
+    const auto n = make_image_node(/*render_bounds*/true, /*asset_bleed*/false, 200, 100);
+    CHECK_FALSE(check_image_sizing_fidelity(n, "Sprite0", 120.0f, 60.0f).has_value());
+}
+
+TEST_CASE("fidelity self-check flags a skewed bleed sprite",
+          "[view][import][fidelity][harness]") {
+    // png 200x100 (aspect 2.0); emitted 100x100 (aspect 1.0) → skew.
+    const auto n = make_image_node(true, false, 200, 100);
+    const auto issue = check_image_sizing_fidelity(n, "Sprite0", 100.0f, 100.0f);
+    REQUIRE(issue.has_value());
+    CHECK(issue->kind == "skew");
+    CHECK(issue->node_id == "Sprite0");
+}
+
+TEST_CASE("fidelity self-check flags an asset_bleed sprite missing PNG dims",
+          "[view][import][fidelity][harness]") {
+    const auto n = make_image_node(/*render_bounds*/false, /*asset_bleed*/true, 0, 0);
+    const auto issue = check_image_sizing_fidelity(n, "Sprite0", 100.0f, 100.0f);
+    REQUIRE(issue.has_value());
+    CHECK(issue->kind == "aspect-unverified");
+}
+
+TEST_CASE("fidelity self-check ignores ordinary (non-bleed) images",
+          "[view][import][fidelity][harness]") {
+    // No render_bounds, no asset_bleed: filling the box is intentional, never
+    // a finding even when the emitted aspect differs from the PNG.
+    const auto n = make_image_node(false, false, 200, 100);
+    CHECK_FALSE(check_image_sizing_fidelity(n, "Sprite0", 100.0f, 100.0f).has_value());
+}
+
+TEST_CASE("fidelity self-check flags an asset_bleed sprite that skews",
+          "[view][import][fidelity][harness]") {
+    const auto n = make_image_node(false, true, 200, 100);  // aspect 2.0
+    const auto issue = check_image_sizing_fidelity(n, "Sprite0", 100.0f, 100.0f);  // aspect 1.0
+    REQUIRE(issue.has_value());
+    CHECK(issue->kind == "skew");
+}

--- a/tools/import-design/pulp_import_design.cpp
+++ b/tools/import-design/pulp_import_design.cpp
@@ -833,6 +833,8 @@ static void print_usage() {
     std::cout << "  --no-comments     Omit comments from generated code\n";
     std::cout << "  --web-compat      Use DOM API instead of native Pulp API\n";
     std::cout << "  --validate        Render generated JS and validate layout\n";
+    std::cout << "  --strict-fidelity Fail (exit 4) if the import-time fidelity self-check\n";
+    std::cout << "                    finds a skewed / unverifiable sprite (always warns)\n";
     std::cout << "  --reference <png> Compare render against a reference screenshot\n";
     std::cout << "  --diff <png>      Save visual diff image\n";
     std::cout << "  --render-size WxH Render dimensions (default: 340x280)\n";
@@ -1159,6 +1161,8 @@ int main(int argc, char* argv[]) {
     bool include_comments = true;
     bool export_tokens_mode = false;
     bool validate = false;           // --validate: render + compare after import
+    bool strict_fidelity = false;    // --strict-fidelity: fail on a fidelity self-check finding
+    bool fidelity_failed = false;    // set when strict_fidelity + at least one finding
     bool use_web_compat = false;     // --web-compat: use DOM API instead of native
     bool preview_mode = false;       // --preview: minimal widget style for design comparison
     // figma-plugin lane only: knob render style.
@@ -1243,6 +1247,8 @@ int main(int argc, char* argv[]) {
             use_web_compat = true;
         } else if (std::strcmp(argv[i], "--validate") == 0) {
             validate = true;
+        } else if (std::strcmp(argv[i], "--strict-fidelity") == 0) {
+            strict_fidelity = true;
         } else if (std::strcmp(argv[i], "--reference") == 0 && i + 1 < argc) {
             reference_image = argv[++i];
             validate = true;
@@ -2192,7 +2198,22 @@ int main(int argc, char* argv[]) {
         }
     }
 
+    std::vector<pulp::view::FidelityIssue> fidelity_issues;
+    opts.fidelity_report = &fidelity_issues;
     auto js = generate_pulp_js(ir, opts);
+
+    // Reference-free fidelity self-check: surface any sprite the importer could
+    // not prove it sized faithfully. Always reported as warnings; with
+    // --strict-fidelity a finding makes the import exit non-zero.
+    for (const auto& fi : fidelity_issues) {
+        std::cerr << "fidelity: [" << fi.kind << "] " << fi.node_name
+                  << " (" << fi.node_id << "): " << fi.detail << "\n";
+    }
+    if (strict_fidelity && !fidelity_issues.empty()) {
+        std::cerr << "fidelity: " << fidelity_issues.size()
+                  << " issue(s); failing due to --strict-fidelity\n";
+        fidelity_failed = true;
+    }
 
     if (dry_run) {
         std::cout << "=== Generated Pulp JS (" << design_source_name(*source) << " → " << output_file << ") ===\n\n";
@@ -2528,5 +2549,8 @@ int main(int argc, char* argv[]) {
         }
     }
 
+    // --strict-fidelity: a self-check finding fails the import (distinct exit
+    // code so callers/harness can tell it apart from a parse/IO error).
+    if (fidelity_failed) return 4;
     return 0;
 }


### PR DESCRIPTION
First invariant from the fidelity-harness plan. Codegen now self-checks every
sprite it sizes: check_image_sizing_fidelity (pure, testable) compares the
emitted element aspect against the source PNG aspect for a BLEED sprite
(render_bounds or asset_bleed) and reports a FidelityIssue — `skew` (>5%
divergence) or `aspect-unverified` (no PNG dims). Ordinary non-bleed images
intentionally fill their box and are never flagged.

Plumbed through CodeGenOptions::fidelity_report (non-owning sink). The import
CLI collects findings, prints them as `fidelity: …` warnings, and a new
`--strict-fidelity` flag exits 4 when any are present (distinct from a
parse/IO error) so a harness/CI can gate on it.

This is reference-free (compares emitted geometry to the asset's own pixels),
so it would have caught the original knob-skew at import time with no reference
image and generalizes to any design — no overfitting.

Tests: 5 unit cases (passes when aspect preserved; fires `skew` on a stretched
bleed sprite; `aspect-unverified` when PNG dims are missing; ignores ordinary
images). Full design-import suite green (105 cases). End-to-end: the real
sprite import passes `--strict-fidelity` (exit 0).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>