### PR TITLE
feat(view): widget-intrinsic-size + text-vertical-centering fidelity invariants

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -1815,9 +1815,16 @@ rasterized shapes). Each cost a visible fidelity bug.
   catches it if a new invariant is mis-mapped.
 - **Checks shipped:** `check_image_sizing_fidelity` (image; bleed sprite emitted
   aspect vs source PNG → `skew` / `aspect-unverified`; ordinary images fill
-  their box, never flagged) and `check_gross_size_divergence` (container; a
+  their box, never flagged), `check_gross_size_divergence` (container; a
   fixed/fixed node emitted >3× its source box → `gross-size`; hug/fill/absolute/
-  display:none self-skip).
+  display:none self-skip), `check_widget_intrinsic_size` (widget; a recognized
+  audio widget emitted >1.5× its source intrinsic → `widget-size`, or
+  `widget-undersized` when the source is below the widget's native minimum and
+  codegen clamps up — keep its native-min table in sync with the `kMin*` floors
+  in design_codegen.cpp), and `check_text_vertical_centering` (text; a
+  single-line label in a tall slot left top-aligned → `text-vcenter`; the text
+  call-site stamps `_emitted_vertical_align` so the check sees codegen's
+  decision). All four fire 0 on a faithful import (regression guards).
 - **`pulp import-design --strict-fidelity`** prints findings as `fidelity: …`
   warnings and exits 4 when any are present. Tests: unit cases per check in
   `test/test_design_fidelity.cpp`; the codegen-routing case is in

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.151.0",
+      "version": "0.152.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.151.0"
+  "version": "0.152.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.151.0",
+  "version": "0.152.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.302.0
+    VERSION 0.303.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/design_fidelity.hpp
+++ b/core/view/include/pulp/view/design_fidelity.hpp
@@ -23,6 +23,7 @@ struct FidelityIssue {
     std::string node_id;    ///< sanitized bridge id of the offending node
     std::string node_name;  ///< source layer name (for human-readable reports)
     std::string kind;       ///< "skew" | "aspect-unverified" | "gross-size"
+                            ///<   | "widget-size" | "widget-undersized" | "text-vcenter"
     std::string detail;     ///< one-line explanation with the measured numbers
 };
 
@@ -49,6 +50,19 @@ std::optional<FidelityIssue> check_image_sizing_fidelity(const FidelityContext&)
 /// Gross-size: a node the user pinned on BOTH axes (SizingMode::fixed) must not
 /// be emitted >3x its source box; hug/fill/absolute/display:none self-skip.
 std::optional<FidelityIssue> check_gross_size_divergence(const FidelityContext&);
+
+/// Widget-intrinsic-size: a recognized audio widget whose emitted box diverges
+/// >1.5x from its source intrinsic size (shape_width/height attrs, else style
+/// box). A source below the widget's native usable minimum is reported as
+/// informational "widget-undersized" (codegen clamps up); a real divergence is
+/// "widget-size". Heuristic detections with no source dims self-skip.
+std::optional<FidelityIssue> check_widget_intrinsic_size(const FidelityContext&);
+
+/// Text-vertical-centering: a SINGLE-LINE text given a reserved vertical slot
+/// (emitted box taller than one line, below the multi-line threshold) must be
+/// emitted vertically centered. A top-aligned single-line label in a tall slot
+/// is "text-vcenter". Multi-line, no-slack, and missing-metric cases self-skip.
+std::optional<FidelityIssue> check_text_vertical_centering(const FidelityContext&);
 
 // ── Registry + entry point ───────────────────────────────────────────────────
 

--- a/core/view/src/design_codegen.cpp
+++ b/core/view/src/design_codegen.cpp
@@ -416,6 +416,7 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
     // Audio widgets use native widget API
     if (node.audio_widget != AudioWidgetType::none) {
         auto wtype = node.audio_widget;
+        float fid_w = 0.0f, fid_h = 0.0f;  // emitted widget dims, set per sub-branch (fidelity)
 
         // Extract label text, value text, and stroke color from child nodes
         std::string label_text = node.audio_label;
@@ -577,6 +578,7 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
                 ss << ind << "setFlex('" << col_id << "', 'height', " << col_h << ");\n";
                 ss << ind << "setFlex('" << col_id << "', 'min_width', " << frame_w << ");\n";
             }
+            fid_w = shape_w; fid_h = shape_h;  // emitted widget dims (fidelity)
             ss << ind << "createKnob('" << id << "', '" << col_id << "');\n";
             if (!needs_label_wrapper) emit_position_if_absolute(id);
             ss << ind << "setFlex('" << id << "', 'width', " << shape_w << ");\n";
@@ -737,6 +739,7 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
             float col_h = shape_h + 20 + value_stack_h;
             ss << ind << "setFlex('" << col_id << "', 'height', " << col_h << ");\n";
             ss << ind << "setFlex('" << col_id << "', 'min_width', " << frame_w << ");\n";
+            fid_w = widget_w; fid_h = shape_h;  // emitted widget dims (fidelity)
             ss << ind << "createFader('" << id << "', 'vertical', '" << col_id << "');\n";
             ss << ind << "setFlex('" << id << "', 'width', " << widget_w << ");\n";
             ss << ind << "setFlex('" << id << "', 'height', " << shape_h << ");\n";
@@ -816,6 +819,7 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
             float col_h = shape_h + 20 + value_stack_h;
             ss << ind << "setFlex('" << col_id << "', 'height', " << col_h << ");\n";
             ss << ind << "setFlex('" << col_id << "', 'min_width', " << frame_w << ");\n";
+            fid_w = widget_w; fid_h = shape_h;  // emitted widget dims (fidelity)
             ss << ind << "createMeter('" << id << "', 'vertical', '" << col_id << "');\n";
             ss << ind << "setFlex('" << id << "', 'width', " << widget_w << ");\n";
             ss << ind << "setFlex('" << id << "', 'height', " << shape_h << ");\n";
@@ -871,6 +875,7 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
         else if (wtype == AudioWidgetType::xy_pad) {
             float sz = std::max(node.style.width.value_or(100.0f), 80.0f);
             ss << ind << "setFlex('" << col_id << "', 'height', " << (sz + 20) << ");\n";
+            fid_w = sz; fid_h = sz;  // emitted widget dims (fidelity)
             ss << ind << "createXYPad('" << id << "', '" << col_id << "');\n";
             ss << ind << "setFlex('" << id << "', 'width', " << sz << ");\n";
             ss << ind << "setFlex('" << id << "', 'height', " << sz << ");\n";
@@ -880,11 +885,16 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
             float h = node.style.height.value_or(80.0f);
             ss << ind << "setFlex('" << col_id << "', 'height', " << (h + 20) << ");\n";
             auto fn = (wtype == AudioWidgetType::waveform) ? "createWaveform" : "createSpectrum";
+            fid_w = w; fid_h = h;  // emitted widget dims (fidelity)
             ss << ind << fn << "('" << id << "', '" << col_id << "');\n";
             ss << ind << "setFlex('" << id << "', 'width', " << w << ");\n";
             ss << ind << "setFlex('" << id << "', 'height', " << h << ");\n";
         }
 
+        // Reference-free fidelity self-checks for this widget (see design_fidelity).
+        if (opts.fidelity_report)
+            run_fidelity_checks({node, id, fid_w, fid_h, FidelityElement::widget},
+                                *opts.fidelity_report);
         ss << "\n";
         return;
     }
@@ -1049,8 +1059,10 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
         // middle. Without this Label defaults to top-aligned, and the
         // SEARCH input's "Search" text rides above the magnifying-glass
         // icon instead of baseline-aligning with it.
+        bool emitted_vcenter = false;
         if (ir_height_is_explicit && label_h > font_h * 1.15f) {
             ss << ind << "setVerticalAlign('" << id << "', 'center');\n";
+            emitted_vcenter = true;
         }
 
         if (node.style.font_size)
@@ -1117,6 +1129,15 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
             }
         }
 
+        // Reference-free fidelity self-check for this text (see design_fidelity):
+        // a single-line label given a tall slot must be vertically centered.
+        // node is const here, so stamp the emitted vertical-align onto a copy.
+        if (opts.fidelity_report) {
+            IRNode fnode = node;
+            fnode.attributes["_emitted_vertical_align"] = emitted_vcenter ? "center" : "top";
+            run_fidelity_checks({fnode, id, 0.0f, label_h, FidelityElement::text},
+                                *opts.fidelity_report);
+        }
         ss << "\n";
         return;
     }

--- a/core/view/src/design_fidelity.cpp
+++ b/core/view/src/design_fidelity.cpp
@@ -76,6 +76,83 @@ std::optional<FidelityIssue> check_gross_size_divergence(const FidelityContext& 
     return std::nullopt;
 }
 
+std::optional<FidelityIssue> check_widget_intrinsic_size(const FidelityContext& ctx) {
+    const IRNode& node = ctx.node;
+    if (node.audio_widget == AudioWidgetType::none) return std::nullopt;
+
+    // Source intrinsic size: an explicit child-shape size (shape_width/height,
+    // stamped by extract_widget_shape_dims) wins, else the node's own box.
+    const float attr_w = attr_f(node, "shape_width");
+    const float attr_h = attr_f(node, "shape_height");
+    const float src_w = attr_w > 0.0f ? attr_w : node.style.width.value_or(0.0f);
+    const float src_h = attr_h > 0.0f ? attr_h : node.style.height.value_or(0.0f);
+    if (src_w <= 0.0f || src_h <= 0.0f) return std::nullopt;  // heuristic detect, nothing to verify
+    if (ctx.emitted_w <= 0.0f || ctx.emitted_h <= 0.0f) return std::nullopt;
+
+    // Native usable minimums codegen clamps up to (kept in sync with the kMin*
+    // floors in design_codegen.cpp). A source below these is legitimately
+    // enlarged, so that divergence is informational, not a real finding.
+    struct NMin { float w, h; };
+    auto native_min = [](AudioWidgetType t) -> NMin {
+        switch (t) {
+            case AudioWidgetType::knob:     return {56.0f, 56.0f};
+            case AudioWidgetType::fader:    return {40.0f, 80.0f};
+            case AudioWidgetType::meter:    return {20.0f, 80.0f};
+            case AudioWidgetType::xy_pad:   return {80.0f, 80.0f};
+            case AudioWidgetType::waveform: return {200.0f, 80.0f};
+            case AudioWidgetType::spectrum: return {200.0f, 80.0f};
+            default:                        return {0.0f, 0.0f};
+        }
+    };
+    const NMin nmin = native_min(node.audio_widget);
+
+    auto ratio = [](float a, float b) { return std::max(a, b) / std::min(a, b); };
+    const float rw = ratio(ctx.emitted_w, src_w);
+    const float rh = ratio(ctx.emitted_h, src_h);
+    constexpr float kMaxRatio = 1.5f;
+    if (rw <= kMaxRatio && rh <= kMaxRatio) return std::nullopt;
+
+    // A diverging axis is "expected" only if the source was below the native
+    // minimum on that axis (codegen clamps it up) — then warn, don't fail.
+    const bool w_div = rw > kMaxRatio, h_div = rh > kMaxRatio;
+    const bool w_clamp = src_w < nmin.w && ctx.emitted_w >= src_w;
+    const bool h_clamp = src_h < nmin.h && ctx.emitted_h >= src_h;
+    const bool only_clamp = (!w_div || w_clamp) && (!h_div || h_clamp);
+
+    std::ostringstream d;
+    d << "widget emitted box diverges from source intrinsic: "
+      << "W " << rw << "x (src " << src_w << " emit " << ctx.emitted_w << "px), "
+      << "H " << rh << "x (src " << src_h << " emit " << ctx.emitted_h << "px)";
+    if (only_clamp) {
+        d << " — below native minimum, clamped up";
+        return FidelityIssue{ctx.node_id, node.name, "widget-undersized", d.str()};
+    }
+    return FidelityIssue{ctx.node_id, node.name, "widget-size", d.str()};
+}
+
+std::optional<FidelityIssue> check_text_vertical_centering(const FidelityContext& ctx) {
+    const IRNode& node = ctx.node;
+    const float box_h = ctx.emitted_h;            // codegen passes the emitted label box height
+    const float font_h = node.style.font_size.value_or(0.0f);
+    if (box_h <= 0.0f || font_h <= 0.0f) return std::nullopt;
+    const float line_h = node.style.line_height.value_or(font_h * 1.2f);
+
+    // Multi-line wraps (no single-line center to verify); a box with no slack
+    // beyond one line has nothing to center within — both self-skip.
+    if (box_h > line_h * 1.8f) return std::nullopt;
+    if (box_h <= line_h * 1.15f) return std::nullopt;
+
+    // The text call-site stamps whether codegen emitted vertical centering.
+    auto it = node.attributes.find("_emitted_vertical_align");
+    const std::string va = it != node.attributes.end() ? it->second : "";
+    if (va == "center") return std::nullopt;      // centered as expected
+
+    std::ostringstream d;
+    d << "single-line text in a " << box_h << "px slot (line ~" << line_h
+      << "px) is top-aligned, not vertically centered";
+    return FidelityIssue{ctx.node_id, node.name, "text-vcenter", d.str()};
+}
+
 // ── Registry: the single place to add a new invariant ────────────────────────
 // Each entry pairs a check with the element kind it applies to. A check runs
 // ONLY for its element (an image's emitted box legitimately differs from its
@@ -84,9 +161,11 @@ std::optional<FidelityIssue> check_gross_size_divergence(const FidelityContext& 
 namespace {
 using CheckFn = std::optional<FidelityIssue> (*)(const FidelityContext&);
 struct RegisteredCheck { FidelityElement applies_to; CheckFn fn; };
-constexpr std::array<RegisteredCheck, 2> kChecks = {{
+constexpr std::array<RegisteredCheck, 4> kChecks = {{
     {FidelityElement::image,     &check_image_sizing_fidelity},
     {FidelityElement::container, &check_gross_size_divergence},
+    {FidelityElement::widget,    &check_widget_intrinsic_size},
+    {FidelityElement::text,      &check_text_vertical_centering},
 }};
 }  // namespace
 

--- a/test/test_design_fidelity.cpp
+++ b/test/test_design_fidelity.cpp
@@ -150,3 +150,105 @@ TEST_CASE("run_fidelity_checks dispatches by element kind",
     REQUIRE(s_box.size() == 1);
     CHECK(s_box[0].kind == "gross-size");
 }
+
+// ── Widget intrinsic-size invariant ─────────────────────────────────────────
+namespace {
+IRNode make_widget_node(AudioWidgetType t, float src_w, float src_h,
+                        bool via_shape_attr = false) {
+    IRNode n;
+    n.type = "frame";
+    n.name = "W";
+    n.audio_widget = t;
+    if (via_shape_attr) {
+        n.attributes["shape_width"]  = std::to_string((int)src_w);
+        n.attributes["shape_height"] = std::to_string((int)src_h);
+    } else {
+        n.style.width = src_w;
+        n.style.height = src_h;
+    }
+    return n;
+}
+}  // namespace
+
+TEST_CASE("widget-size: emitted matching source intrinsic passes",
+          "[view][import][fidelity][harness]") {
+    const auto n = make_widget_node(AudioWidgetType::knob, 62, 62);
+    CHECK_FALSE(check_widget_intrinsic_size(
+        {n, "K0", 62.0f, 62.0f, FidelityElement::widget}).has_value());
+}
+
+TEST_CASE("widget-size: >1.5x divergence is flagged",
+          "[view][import][fidelity][harness]") {
+    const auto n = make_widget_node(AudioWidgetType::knob, 62, 62);
+    const auto i = check_widget_intrinsic_size(
+        {n, "K0", 130.0f, 62.0f, FidelityElement::widget});  // ~2.1x on W
+    REQUIRE(i.has_value());
+    CHECK(i->kind == "widget-size");
+}
+
+TEST_CASE("widget-size: below-native-minimum clamp-up is informational",
+          "[view][import][fidelity][harness]") {
+    // 20x20 knob source clamped up to the 56x56 native minimum → not a hard fail.
+    const auto n = make_widget_node(AudioWidgetType::knob, 20, 20);
+    const auto i = check_widget_intrinsic_size(
+        {n, "K0", 56.0f, 56.0f, FidelityElement::widget});
+    REQUIRE(i.has_value());
+    CHECK(i->kind == "widget-undersized");
+}
+
+TEST_CASE("widget-size: reads the shape_* attribute as the source",
+          "[view][import][fidelity][harness]") {
+    const auto n = make_widget_node(AudioWidgetType::fader, 44, 120, /*shape*/true);
+    CHECK_FALSE(check_widget_intrinsic_size(
+        {n, "F0", 44.0f, 120.0f, FidelityElement::widget}).has_value());
+}
+
+TEST_CASE("widget-size: a non-widget node self-skips",
+          "[view][import][fidelity][harness]") {
+    IRNode n; n.type = "frame"; n.style.width = 100.0f; n.style.height = 100.0f;
+    CHECK_FALSE(check_widget_intrinsic_size(
+        {n, "X0", 400.0f, 100.0f, FidelityElement::widget}).has_value());
+}
+
+// ── Text vertical-centering invariant ───────────────────────────────────────
+namespace {
+IRNode make_text_node(float font, bool emitted_center) {
+    IRNode n;
+    n.type = "text";
+    n.name = "T";
+    n.text_content = "Search";
+    n.style.font_size = font;   // line_height defaults to font*1.2
+    n.attributes["_emitted_vertical_align"] = emitted_center ? "center" : "top";
+    return n;
+}
+}  // namespace
+
+TEST_CASE("text-vcenter: centered single-line in a tall slot passes",
+          "[view][import][fidelity][harness]") {
+    const auto n = make_text_node(14.0f, /*center*/true);  // line ~16.8; slot 26 has slack, single-line
+    CHECK_FALSE(check_text_vertical_centering(
+        {n, "T0", 0.0f, 26.0f, FidelityElement::text}).has_value());
+}
+
+TEST_CASE("text-vcenter: top-aligned single-line in a tall slot is flagged",
+          "[view][import][fidelity][harness]") {
+    const auto n = make_text_node(14.0f, /*center*/false);
+    const auto i = check_text_vertical_centering(
+        {n, "T0", 0.0f, 26.0f, FidelityElement::text});
+    REQUIRE(i.has_value());
+    CHECK(i->kind == "text-vcenter");
+}
+
+TEST_CASE("text-vcenter: a multi-line box self-skips",
+          "[view][import][fidelity][harness]") {
+    const auto n = make_text_node(14.0f, false);  // line ~16.8; 40 > 1.8*line → multi-line
+    CHECK_FALSE(check_text_vertical_centering(
+        {n, "T0", 0.0f, 40.0f, FidelityElement::text}).has_value());
+}
+
+TEST_CASE("text-vcenter: a box with no vertical slack self-skips",
+          "[view][import][fidelity][harness]") {
+    const auto n = make_text_node(14.0f, false);  // line ~16.8; 18 < 1.15*line → no slack
+    CHECK_FALSE(check_text_vertical_centering(
+        {n, "T0", 0.0f, 18.0f, FidelityElement::text}).has_value());
+}


### PR DESCRIPTION
Two more reference-free fidelity self-checks on the design_fidelity registry
(element-dispatched, source-agnostic), batched into one PR per the single-runner
cadence.

- check_widget_intrinsic_size (FidelityElement::widget): a recognized audio
  widget (knob/fader/meter/xy_pad/waveform/spectrum) whose emitted box diverges
  >1.5x from its source intrinsic size (shape_width/height attrs, else style
  box) → "widget-size". When the source is below the widget's native usable
  minimum, codegen legitimately clamps up → informational "widget-undersized".
  The native-min table mirrors the kMin* floors in design_codegen.cpp.
- check_text_vertical_centering (FidelityElement::text): a SINGLE-LINE label
  given a reserved vertical slot (box taller than one line, below the multi-line
  threshold) must be emitted vertically centered; a top-aligned one →
  "text-vcenter". Multi-line / no-slack / missing-metric cases self-skip. The
  text codegen branch stamps `_emitted_vertical_align` so the check reads
  codegen's actual decision.

Codegen call-sites: the widget branch captures the emitted dims across its five
sub-branches into fid_w/fid_h and calls run_fidelity_checks once before its
return; the text branch captures the vcenter decision and routes a stamped node
copy (node is const there). Both go through the existing fidelity_report sink.

Element dispatch keeps each check on its own kind (no cross-element FPs). Both
fire 0 on a faithful import — they are regression guards. Verified: 20 fidelity
unit cases green, full design-import suite green (101 cases, 868 assertions),
the real import passes --strict-fidelity with zero findings (both knob modes),
and the golden re-import gate is unchanged (edge-agree 1.0, observers only).

Vector-renderability (the third drafted invariant) is deferred to a follow-up:
it is a tree pass, not a registry check, with open wiring (its already-diagnosed
signal lives in DesignIR::diagnostics, plus node->id mapping) to resolve first.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>