### PR TITLE
feat(view): vector-renderability fidelity invariant (dropped-vector)

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -1805,8 +1805,20 @@ rasterized shapes). Each cost a visible fidelity bug.
   carries the node, sanitized id, the emitted w/h, and the element kind.
   `design_codegen.cpp` keeps only thin call-sites: it captures the geometry it
   already computes and calls `run_fidelity_checks` in the image and container
-  branches. **Adding an invariant = one function + one registry row + a case in
-  `test_design_fidelity.cpp`.** Codegen does not grow.
+  branches. **Adding a PER-ELEMENT invariant = one function + one registry row +
+  a case in `test_design_fidelity.cpp`.** Codegen does not grow.
+- **Two invariant shapes.** Most checks are *per-element registry rows* (above).
+  A few need subtree/coverage context a single `FidelityContext` can't carry —
+  those are *tree passes*: free functions taking `(root, diagnostics, node_id_of,
+  sink)`, called once from `generate_pulp_js` after the emit walk, NOT in the
+  registry. A tree pass must mirror codegen's recursion exactly — descend EXCEPT
+  into the terminal image/widget/text branches (which return without emitting
+  children). Skipping that is a real FP source: a knob consumes its child
+  ellipses into its native paint, so a naive full-tree walk would flag that
+  consumed stroke-ellipse as a dropped vector. The pass also takes
+  `DesignIR::diagnostics` so a node already carrying a render-affecting import
+  diagnostic (matched by `stable_anchor_id` or structural `$`/`/children[i]`
+  path) is suppressed — never double-report a drop the importer already surfaced.
 - **Element dispatch is load-bearing.** A check runs ONLY for its element kind.
   Critical gotcha: the gross-size check must NOT see images — a bleed sprite's
   emitted box legitimately differs >3× from its style box (it sizes to
@@ -1825,6 +1837,21 @@ rasterized shapes). Each cost a visible fidelity bug.
   single-line label in a tall slot left top-aligned → `text-vcenter`; the text
   call-site stamps `_emitted_vertical_align` so the check sees codegen's
   decision). All four fire 0 on a faithful import (regression guards).
+- **Tree pass shipped:** `check_vector_renderability` (root walk; a visible
+  vector/path-like node — `path`/`svg_path`/`rect`/`svg_rect`/`rectangle`/`line`/
+  `svg_line`/`ellipse`/`circle`/`polygon`/`polyline`/`star`/`vector` — above a
+  256px² area floor that produces no renderable primitive → `dropped-vector`).
+  "Renders" = a rasterized `asset_path`, a native/audio widget, any children, or
+  a visible fill (`background_color`/`gradient`/`image`). The childless
+  no-fill-no-asset case hits codegen's generic-frame fall-through, which paints
+  only `background_color` and drops stroke/border/path art to an empty
+  `createRow` — that silent drop is the target. FP gates: invisible
+  (`opacity:0`/`display:none`/`visibility:hidden`), sub-256px² area (kills the
+  hairline dividers + EQ grid lines real designs are full of — e.g. ELYSIUM's
+  width-0 separator vectors), and already-diagnosed (see tree-pass note above).
+  Findings carry the exact bridge id via codegen's real node→id map. Fires 0 on
+  a faithful import (substantive shape art is rasterized at export and routes
+  through the image branch).
 - **`pulp import-design --strict-fidelity`** prints findings as `fidelity: …`
   warnings and exits 4 when any are present. Tests: unit cases per check in
   `test/test_design_fidelity.cpp`; the codegen-routing case is in

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.152.0",
+      "version": "0.153.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.152.0"
+  "version": "0.153.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.152.0",
+  "version": "0.153.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.303.0
+    VERSION 0.304.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/design_fidelity.hpp
+++ b/core/view/include/pulp/view/design_fidelity.hpp
@@ -12,6 +12,7 @@
 
 #include <pulp/view/design_ir.hpp>
 
+#include <functional>
 #include <optional>
 #include <string>
 #include <vector>
@@ -24,6 +25,7 @@ struct FidelityIssue {
     std::string node_name;  ///< source layer name (for human-readable reports)
     std::string kind;       ///< "skew" | "aspect-unverified" | "gross-size"
                             ///<   | "widget-size" | "widget-undersized" | "text-vcenter"
+                            ///<   | "dropped-vector"
     std::string detail;     ///< one-line explanation with the measured numbers
 };
 
@@ -70,5 +72,35 @@ std::optional<FidelityIssue> check_text_vertical_centering(const FidelityContext
 /// `sink`. This is the ONLY entry point codegen calls. The registry below is
 /// the single place to add a new invariant.
 void run_fidelity_checks(const FidelityContext& ctx, std::vector<FidelityIssue>& sink);
+
+// ── Tree-level invariants (need subtree / coverage context) ──────────────────
+
+/// Vector-renderability: every visible vector/path-like node (svg path/rect/
+/// line, ellipse, polygon, …) above an area threshold must map to a real
+/// renderable primitive — a rasterized asset, a native widget, child paint, or
+/// a visible fill — OR already carry an explicit unsupported diagnostic. A bare
+/// vector that codegen would drop to an empty `createRow` frame (no asset, no
+/// children, no fill — its stroke/path/border art silently vanishes) is
+/// reported as "dropped-vector".
+///
+/// This is a TREE pass, not a per-element registry check, for two reasons the
+/// single-node FidelityContext cannot serve: (1) the dropped node hits codegen's
+/// generic-frame fall-through, which has no run_fidelity_checks call site; and
+/// (2) the false-positive gate "a vector child consumed into a parent widget is
+/// not dropped" needs subtree context. The walk mirrors generate_native_node's
+/// recursion exactly — it descends EXCEPT into the terminal image/widget/text
+/// branches — so a knob's consumed stroke-ellipse is never falsely flagged.
+///
+/// `diagnostics` is `DesignIR::diagnostics`: a node already carrying a
+/// render-affecting import diagnostic (matched by stable_anchor_id or structural
+/// path) is suppressed so the silent-drop finding never double-reports a drop
+/// the importer already surfaced. `node_id_of` maps a node to the bridge id
+/// codegen emitted for it (codegen passes a lookup over its real id map; tests
+/// pass an identity-ish stub).
+void check_vector_renderability(
+    const IRNode& root,
+    const std::vector<ImportDiagnostic>& diagnostics,
+    const std::function<std::string(const IRNode&)>& node_id_of,
+    std::vector<FidelityIssue>& sink);
 
 }  // namespace pulp::view

--- a/core/view/src/design_codegen.cpp
+++ b/core/view/src/design_codegen.cpp
@@ -20,7 +20,9 @@
 #include <cctype>
 #include <cmath>
 #include <cstdio>
+#include <functional>
 #include <sstream>
+#include <unordered_map>
 
 namespace pulp::view {
 
@@ -374,10 +376,15 @@ static float compute_node_height(const IRNode& node) {
 
 static void generate_native_node(std::ostringstream& ss, const IRNode& node,
                                   const CodeGenOptions& opts, int depth,
-                                  int& var_counter, const std::string& parent_id) {
+                                  int& var_counter, const std::string& parent_id,
+                                  std::unordered_map<const IRNode*, std::string>* id_map = nullptr) {
     std::string id = sanitize_var(node.name.empty() ? node.type : node.name);
     if (depth > 0) id += std::to_string(var_counter++);
     else id = opts.root_variable;
+    // Record the exact emitted bridge id so the tree-level fidelity pass
+    // (check_vector_renderability) can point findings at the real node id
+    // codegen used, not a re-derived best-effort name.
+    if (id_map) (*id_map)[&node] = id;
 
     std::string ind = indent(depth, opts.indent_spaces);
     std::string pid = parent_id.empty() ? "''" : ("'" + parent_id + "'");
@@ -1364,7 +1371,7 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
                     nudge_this_child = true;
                 }
             }
-            generate_native_node(ss, child, opts, depth + 1, var_counter, id);
+            generate_native_node(ss, child, opts, depth + 1, var_counter, id, id_map);
             if (nudge_this_child) {
                 std::string child_ind = indent(depth + 1, opts.indent_spaces);
                 ss << child_ind << "setFlex('" << child_var_id_pre
@@ -1579,8 +1586,25 @@ std::string generate_pulp_js(const DesignIR& ir, const CodeGenOptions& opts) {
     if (opts.mode == CodeGenMode::bridge_native_js) {
         // Native-bridge JS API
         int var_counter = 0;
-        generate_native_node(ss, ir.root, opts, 0, var_counter, "");
+        std::unordered_map<const IRNode*, std::string> id_map;
+        generate_native_node(ss, ir.root, opts, 0, var_counter, "", &id_map);
         ss << "void 0;\n";
+
+        // Tree-level fidelity pass: catch vector/path nodes codegen dropped to
+        // empty frames. No per-node branch fires for them (the generic-frame
+        // fall-through has no run_fidelity_checks call site), so this runs once
+        // over the IR after the emit walk. Native arm only — the web-compat
+        // lowering does not own the dropped-shape fall-through.
+        if (opts.fidelity_report) {
+            check_vector_renderability(
+                ir.root, ir.diagnostics,
+                [&id_map](const IRNode& n) -> std::string {
+                    auto it = id_map.find(&n);
+                    if (it != id_map.end()) return it->second;
+                    return sanitize_var(n.name.empty() ? n.type : n.name);
+                },
+                *opts.fidelity_report);
+        }
     } else {
         // Web-compat DOM API
         int var_counter = 0;

--- a/core/view/src/design_fidelity.cpp
+++ b/core/view/src/design_fidelity.cpp
@@ -4,8 +4,12 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstddef>
 #include <cstdlib>
+#include <functional>
 #include <sstream>
+#include <string_view>
+#include <unordered_set>
 
 namespace pulp::view {
 namespace {
@@ -173,6 +177,133 @@ void run_fidelity_checks(const FidelityContext& ctx, std::vector<FidelityIssue>&
     for (const auto& c : kChecks)
         if (c.applies_to == ctx.element)
             if (auto issue = c.fn(ctx)) sink.push_back(std::move(*issue));
+}
+
+// ── Tree-level: vector-renderability ─────────────────────────────────────────
+namespace {
+
+// Vector/path-like source kinds, matched on normalized IR type only (never a
+// layer name) so the check is identical across figma/pencil/stitch/v0. Unions
+// the svg_*/path/rect/line kinds resolved in design_import_native_common.cpp
+// with the ellipse/rectangle shapes codegen consumes, plus the
+// polygon/polyline/star/circle/vector kinds vector sources emit.
+bool is_vector_kind(const std::string& type) {
+    static constexpr std::string_view kVectorKinds[] = {
+        "vector",  "path",     "svg_path",
+        "rect",    "svg_rect", "rectangle",
+        "line",    "svg_line",
+        "ellipse", "circle",
+        "polygon", "polyline", "star",
+    };
+    for (auto k : kVectorKinds)
+        if (type == k) return true;
+    return false;
+}
+
+bool attr_eq(const IRNode& n, const char* key, const char* val) {
+    auto it = n.attributes.find(key);
+    return it != n.attributes.end() && it->second == val;
+}
+
+bool is_invisible(const IRNode& n) {
+    if (n.style.opacity && *n.style.opacity <= 0.0f) return true;
+    if (n.layout.display && *n.layout.display == "none") return true;
+    if (attr_eq(n, "visibility", "hidden")) return true;
+    return false;
+}
+
+// A solid/gradient/image fill is author intent to paint the box. codegen's
+// generic-frame branch paints background_color directly; gradient/image fills
+// are tracked by the gradient/paint work, so treat any declared fill as
+// "renders" here to keep this invariant focused on the silent stroke/path drop.
+bool has_visible_fill(const IRNode& n) {
+    if (n.style.background_color && !n.style.background_color->empty()) return true;
+    if (n.style.background_gradient && !n.style.background_gradient->empty()) return true;
+    if (n.style.background_image && !n.style.background_image->empty() &&
+        *n.style.background_image != "none") return true;
+    return false;
+}
+
+// Mirrors codegen's is_image: an asset_path (or literal image type) routes
+// through the rasterized-image branch, which is terminal.
+bool renders_as_image(const IRNode& n) {
+    return n.type == "image" || n.type == "img" || n.attributes.count("asset_path") > 0;
+}
+
+// codegen lowers these to real primitives in TERMINAL branches (image L908,
+// widget L416-900, text L1035) — generate_native_node returns without
+// descending into their children. The tree walk must stop at the same nodes,
+// or a vector child consumed into a parent (e.g. a knob's stroke ellipse) is
+// falsely flagged as dropped.
+bool is_terminal_renderable(const IRNode& n) {
+    return renders_as_image(n) ||
+           n.audio_widget != AudioWidgetType::none ||
+           n.type == "text" || n.type == "label";
+}
+
+}  // namespace
+
+void check_vector_renderability(
+    const IRNode& root,
+    const std::vector<ImportDiagnostic>& diagnostics,
+    const std::function<std::string(const IRNode&)>& node_id_of,
+    std::vector<FidelityIssue>& sink) {
+
+    constexpr float kMinVectorArea = 16.0f * 16.0f;  // 256 px²; below = hairline/rule, skip
+
+    // Flag A — the "already surfaced to the user" gate. Adapters anchor an
+    // ImportDiagnostic to a node by stable_anchor_id and/or structural path
+    // ("$", "$/children[i]/…"; see design_import_native_common.cpp), so suppress
+    // a node when a render-affecting diagnostic already names it. The silent-drop
+    // finding exists to catch UNANNOUNCED degradations, not ones the importer
+    // already reported.
+    std::unordered_set<std::string> diagnosed_anchors;
+    std::unordered_set<std::string> diagnosed_paths;
+    for (const auto& d : diagnostics) {
+        const bool affects_render =
+            d.severity == ImportDiagnosticSeverity::error ||
+            d.kind == ImportDiagnosticKind::unsupported_property ||
+            d.kind == ImportDiagnosticKind::unresolved_asset ||
+            d.kind == ImportDiagnosticKind::fallback_used ||
+            d.kind == ImportDiagnosticKind::capture_partial;
+        if (!affects_render) continue;
+        if (d.anchor_id && !d.anchor_id->empty()) diagnosed_anchors.insert(*d.anchor_id);
+        if (!d.path.empty()) diagnosed_paths.insert(d.path);
+    }
+    auto already_diagnosed = [&](const IRNode& n, const std::string& path) {
+        if (n.confidence && *n.confidence == IRConfidence::not_impl) return true;
+        if (n.stable_anchor_id && !n.stable_anchor_id->empty() &&
+            diagnosed_anchors.count(*n.stable_anchor_id)) return true;
+        if (!path.empty() && diagnosed_paths.count(path)) return true;
+        return false;
+    };
+
+    // Depth-first walk mirroring generate_native_node's recursion. `path` tracks
+    // the same structural key adapters use to anchor diagnostics.
+    std::function<void(const IRNode&, const std::string&)> visit =
+        [&](const IRNode& n, const std::string& path) {
+        if (is_vector_kind(n.type) && !is_invisible(n) && !already_diagnosed(n, path)) {
+            const bool renders = is_terminal_renderable(n) ||
+                                 !n.children.empty() || has_visible_fill(n);
+            if (!renders) {
+                const float w = n.style.width.value_or(0.0f);
+                const float h = n.style.height.value_or(0.0f);
+                if (w > 0.0f && h > 0.0f && w * h >= kMinVectorArea) {
+                    std::ostringstream detail;
+                    detail << "vector node type='" << n.type << "' (" << w << "x" << h
+                           << "px) produced no renderable primitive (no rasterized "
+                              "asset, native widget, child, or visible fill) — shape "
+                              "dropped to an empty frame";
+                    sink.push_back(FidelityIssue{node_id_of(n), n.name,
+                                                 "dropped-vector", detail.str()});
+                }
+            }
+        }
+        if (is_terminal_renderable(n)) return;  // codegen does not descend here
+        for (std::size_t i = 0; i < n.children.size(); ++i)
+            visit(n.children[i], path + "/children[" + std::to_string(i) + "]");
+    };
+    visit(root, "$");
 }
 
 }  // namespace pulp::view

--- a/test/test_design_fidelity.cpp
+++ b/test/test_design_fidelity.cpp
@@ -252,3 +252,153 @@ TEST_CASE("text-vcenter: a box with no vertical slack self-skips",
     CHECK_FALSE(check_text_vertical_centering(
         {n, "T0", 0.0f, 18.0f, FidelityElement::text}).has_value());
 }
+
+// ── Vector-renderability invariant (tree pass) ──────────────────────────────
+namespace {
+IRNode make_vector_node(const std::string& type, float w, float h) {
+    IRNode n;
+    n.type = type;
+    n.name = "Shape";
+    n.style.width = w;
+    n.style.height = h;
+    return n;
+}
+// Identity-ish id mapper for tests (codegen passes its real node→id map).
+std::string vec_id_of(const IRNode& n) { return n.name.empty() ? n.type : n.name; }
+const std::vector<ImportDiagnostic> kNoDiagnostics{};
+}  // namespace
+
+TEST_CASE("vector-renderability flags a bare path that produced no primitive",
+          "[view][import][fidelity][harness][vector]") {
+    IRNode n = make_vector_node("path", 64.0f, 48.0f);  // no asset_path, no fill, no children
+    std::vector<FidelityIssue> sink;
+    check_vector_renderability(n, kNoDiagnostics, vec_id_of, sink);
+    REQUIRE(sink.size() == 1);
+    CHECK(sink[0].kind == "dropped-vector");
+    CHECK(sink[0].node_id == "Shape");
+}
+
+TEST_CASE("vector-renderability flags a stroke-only rect (border dropped by frame branch)",
+          "[view][import][fidelity][harness][vector]") {
+    // A bare rect carrying only a border falls to codegen's generic-frame
+    // branch, which paints background_color only — the stroke silently vanishes.
+    IRNode n = make_vector_node("rect", 80.0f, 40.0f);
+    n.style.border_color = "#333333";
+    n.style.border_width = 1.0f;
+    std::vector<FidelityIssue> sink;
+    check_vector_renderability(n, kNoDiagnostics, vec_id_of, sink);
+    REQUIRE(sink.size() == 1);
+    CHECK(sink[0].kind == "dropped-vector");
+}
+
+TEST_CASE("vector-renderability passes a rasterized vector (has asset_path)",
+          "[view][import][fidelity][harness][vector]") {
+    IRNode n = make_vector_node("vector", 100.0f, 100.0f);
+    n.attributes["asset_path"] = "/tmp/shape.png";  // importer rasterized it → image branch
+    std::vector<FidelityIssue> sink;
+    check_vector_renderability(n, kNoDiagnostics, vec_id_of, sink);
+    CHECK(sink.empty());
+}
+
+TEST_CASE("vector-renderability passes a filled rect (renders via frame branch)",
+          "[view][import][fidelity][harness][vector]") {
+    IRNode n = make_vector_node("rect", 80.0f, 40.0f);
+    n.style.background_color = "#ff0000";  // solid fill renders
+    std::vector<FidelityIssue> sink;
+    check_vector_renderability(n, kNoDiagnostics, vec_id_of, sink);
+    CHECK(sink.empty());
+}
+
+TEST_CASE("vector-renderability skips invisible / zero-area / sub-threshold nodes",
+          "[view][import][fidelity][harness][vector]") {
+    std::vector<FidelityIssue> sink;
+
+    IRNode hidden = make_vector_node("path", 64.0f, 64.0f);
+    hidden.style.opacity = 0.0f;                       // invisible
+    check_vector_renderability(hidden, kNoDiagnostics, vec_id_of, sink);
+    CHECK(sink.empty());
+
+    IRNode none_disp = make_vector_node("ellipse", 64.0f, 64.0f);
+    none_disp.layout.display = "none";                 // display:none
+    check_vector_renderability(none_disp, kNoDiagnostics, vec_id_of, sink);
+    CHECK(sink.empty());
+
+    IRNode hairline = make_vector_node("line", 200.0f, 1.0f);  // area 200 < 256
+    check_vector_renderability(hairline, kNoDiagnostics, vec_id_of, sink);
+    CHECK(sink.empty());
+
+    IRNode zero = make_vector_node("rect", 0.0f, 0.0f);
+    check_vector_renderability(zero, kNoDiagnostics, vec_id_of, sink);
+    CHECK(sink.empty());
+}
+
+TEST_CASE("vector-renderability does not double-report an already-diagnosed vector",
+          "[view][import][fidelity][harness][vector]") {
+    SECTION("confidence == not_impl") {
+        IRNode n = make_vector_node("path", 64.0f, 64.0f);
+        n.confidence = IRConfidence::not_impl;         // importer already told the user
+        std::vector<FidelityIssue> sink;
+        check_vector_renderability(n, kNoDiagnostics, vec_id_of, sink);
+        CHECK(sink.empty());
+    }
+    SECTION("a render-affecting diagnostic anchors the node by structural path") {
+        IRNode n = make_vector_node("path", 64.0f, 64.0f);
+        ImportDiagnostic d;
+        d.kind = ImportDiagnosticKind::unsupported_property;
+        d.path = "$";                                  // root path of the node passed below
+        std::vector<ImportDiagnostic> diags{d};
+        std::vector<FidelityIssue> sink;
+        check_vector_renderability(n, diags, vec_id_of, sink);
+        CHECK(sink.empty());
+    }
+    SECTION("a render-affecting diagnostic anchors the node by stable_anchor_id") {
+        IRNode n = make_vector_node("path", 64.0f, 64.0f);
+        n.stable_anchor_id = "anchor-7";
+        ImportDiagnostic d;
+        d.kind = ImportDiagnosticKind::unresolved_asset;
+        d.anchor_id = "anchor-7";
+        std::vector<ImportDiagnostic> diags{d};
+        std::vector<FidelityIssue> sink;
+        check_vector_renderability(n, diags, vec_id_of, sink);
+        CHECK(sink.empty());
+    }
+}
+
+TEST_CASE("vector-renderability is a tree pass: group with renderable child passes, "
+          "lone bare child is flagged",
+          "[view][import][fidelity][harness][vector]") {
+    IRNode group = make_vector_node("vector", 200.0f, 200.0f);
+    group.name = "Group";
+    IRNode raster = make_vector_node("rect", 100.0f, 100.0f);
+    raster.name = "Raster";
+    raster.attributes["asset_path"] = "/tmp/icon.png";  // renderable child
+    group.children.push_back(raster);
+    IRNode dropped = make_vector_node("path", 50.0f, 50.0f);
+    dropped.name = "DroppedPath";
+    group.children.push_back(dropped);
+
+    std::vector<FidelityIssue> sink;
+    check_vector_renderability(group, kNoDiagnostics, vec_id_of, sink);
+    // Group passes (has children); raster child passes (asset_path); only the
+    // bare path is flagged.
+    REQUIRE(sink.size() == 1);
+    CHECK(sink[0].node_id == "DroppedPath");
+    CHECK(sink[0].kind == "dropped-vector");
+}
+
+TEST_CASE("vector-renderability does not descend into a widget subtree "
+          "(consumed stroke children are not flagged)",
+          "[view][import][fidelity][harness][vector]") {
+    // A knob consumes its child ellipses into its native paint; codegen's widget
+    // branch is terminal and never emits them, so they must not be flagged.
+    IRNode knob = make_vector_node("ellipse", 56.0f, 56.0f);
+    knob.name = "Knob";
+    knob.audio_widget = AudioWidgetType::knob;
+    IRNode stroke = make_vector_node("ellipse", 40.0f, 40.0f);  // bare, would trip in isolation
+    stroke.name = "Stroke";
+    knob.children.push_back(stroke);
+
+    std::vector<FidelityIssue> sink;
+    check_vector_renderability(knob, kNoDiagnostics, vec_id_of, sink);
+    CHECK(sink.empty());
+}

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -4256,3 +4256,33 @@ TEST_CASE("codegen routes a fixed container through the gross-size check",
         if (iss.kind == "gross-size" && iss.node_name == "Box") found = true;
     CHECK(found);
 }
+
+TEST_CASE("codegen routes a dropped vector through the vector-renderability check",
+          "[view][import][fidelity][vector]") {
+    // A bare vector child (no asset_path / fill / children) hits codegen's
+    // generic-frame fall-through and silently degrades to an empty row. The
+    // tree-level vector-renderability pass, wired into generate_pulp_js on the
+    // native arm, must surface a "dropped-vector" finding for it.
+    DesignIR ir;
+    ir.root.type = "frame";
+    ir.root.name = "Root";
+    ir.root.style.width = 400.0f;
+    ir.root.style.height = 200.0f;
+
+    IRNode glyph;
+    glyph.type = "path";
+    glyph.name = "Glyph";
+    glyph.style.width = 64.0f;   // no asset_path / fill / children
+    glyph.style.height = 64.0f;
+    ir.root.children.push_back(glyph);
+
+    std::vector<pulp::view::FidelityIssue> report;
+    CodeGenOptions opts;            // defaults to bridge_native_js
+    opts.fidelity_report = &report;
+    (void)generate_pulp_js(ir, opts);
+
+    bool found = false;
+    for (const auto& iss : report)
+        if (iss.kind == "dropped-vector" && iss.node_name == "Glyph") found = true;
+    CHECK(found);
+}


### PR DESCRIPTION
Add the deferred third import-fidelity invariant from the coverage-hardening
batch (widget-size + text-center landed in #3274). A visible vector/path-like
node above a 256px² area floor that codegen would lower to nothing renderable
— no rasterized asset, native widget, child paint, or visible fill — silently
degrades to an empty createRow frame via the generic-frame fall-through, which
paints only background_color and drops stroke/border/path art. This catches
that silent drop as a "dropped-vector" finding.

Unlike the four registry checks, this is a TREE pass: it needs subtree context
the single-node FidelityContext can't carry, and the dropped node hits a
codegen branch with no run_fidelity_checks call site. It runs once from
generate_pulp_js after the native emit walk and mirrors generate_native_node's
recursion exactly — descending EXCEPT into the terminal image/widget/text
branches. That terminal-stop is load-bearing: a knob consumes its child stroke
ellipses into its native paint, so a naive full-tree walk would falsely flag
them as dropped.

Resolves the three draft flags against real code:
- Flag A (already-diagnosed gate): adapters anchor an ImportDiagnostic to a
  node by stable_anchor_id and/or structural path, not node attributes — so
  the pass takes DesignIR::diagnostics and suppresses any node a render-
  affecting diagnostic already names, never double-reporting a surfaced drop.
- Flag B (node->id mapping): codegen now records an exact node->id map during
  the emit walk; findings carry the real bridge id, consistent with the other
  checks, instead of a re-derived name.
- Flag E (vector-kind set): unions the svg_*/path/rect/line kinds resolved in
  design_import_native_common with the ellipse/rectangle shapes codegen
  consumes, plus polygon/polyline/star/circle/vector.

Tests (Catch2, same PR): 8 unit cases in test_design_fidelity.cpp (bare-flag,
stroke-only-rect, asset-pass, fill-pass, invisible/zero/sub-threshold skip,
already-diagnosed-by-confidence/path/anchor skip, tree child-coverage, and the
widget-subtree no-descend FP gate) + 1 codegen-routing case in
test_design_import.cpp. Verified: e2e `pulp import-design --strict-fidelity` on
the faithful kitchen-sink synthetic export exits 0; zero new dropped-vector
findings on elysium + kitchen-sink; golden re-import regression PASS (0.000%
pixel diff — the pass is observer-only and does not alter emitted JS).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>