### PR TITLE
test(import): compat.json object-coverage matrix + drift guard

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -8156,6 +8156,38 @@
   },
   "imports": {
     "_note": "The 'imports' prefix tracks design-import format detection (see core/dsl/import-design / tools/cli/src/import_design.cpp / docs/reference/imports/*). Each top-level key is a recognized import source (claude, figma, pencil, stitch, v0); each entry carries 'parser-version' (the Pulp-side detector version) and 'detected-formats' (a list of {format-version, introduced, deprecated, fingerprint, notes} objects). The `fingerprint` field is the heuristic the parser uses to recognize the source format from a directory or file payload. When a new import source lands or an existing source's export format changes, add a detected-formats entry rather than mutating an existing one (so historical exports keep parsing). Tracked via PR #1047 (pulp #1031) for versioned import-design detection.",
+    "object-coverage": {
+      "_note": "IR-level, source-agnostic coverage of normalized DesignIR object types across the import pipeline. For each type, the support level at three stages: 'detected' (an adapter recognizes the source object), 'parsed' (it is lowered into the normalized IR), 'codegen' (generate_pulp_js emits a real renderable primitive for it). Source-agnostic by construction: the importer and codegen operate on the normalized IR, so a 'handled' type renders identically for figma/figma-plugin/pencil/stitch/v0/claude. Levels: handled | partial | missing. The 'types' rows are DRIFT-CHECKED by test/test_import_object_coverage.cpp (binary pulp-test-import-object-coverage, Catch2 tag [object-coverage]): it builds a synthetic IRNode per type, runs generate_pulp_js, and FAILS if a 'codegen: handled' type drops to an empty frame, or a 'codegen: missing' vector-kind does not trip the dropped-vector invariant (#3275) — keeping this matrix honest against the code. The 'features' rows track cross-cutting paint/layout capabilities owned by separate hardening slices; they are documented here but not type-drift-checked. Seeded from planning/2026-05-31-import-coverage-hardening-plan.md section 3.",
+      "levels": ["handled", "partial", "missing"],
+      "types": {
+        "frame":     {"detected": "handled", "parsed": "handled", "codegen": "handled", "note": "group/section/slice normalize to frame; emits createRow/createCol"},
+        "text":      {"detected": "handled", "parsed": "handled", "codegen": "handled", "note": "first-char dominant style; emits createLabel. Per-range runs tracked in features.text-per-range-styles"},
+        "label":     {"detected": "handled", "parsed": "handled", "codegen": "handled", "note": "alias of text; emits createLabel"},
+        "image":     {"detected": "handled", "parsed": "handled", "codegen": "handled", "note": "solid/linear-gradient/image fills; emits createImage; no-skew + gross-size invariants guard sizing"},
+        "vector":    {"detected": "handled", "parsed": "partial", "codegen": "missing", "note": "path/stroke art is not lowered to a primitive; the dropped-vector invariant (#3275) flags the silent drop. Rasterize-at-export covers the faithful path"},
+        "path":      {"detected": "handled", "parsed": "partial", "codegen": "missing", "note": "see vector"},
+        "svg_path":  {"detected": "handled", "parsed": "partial", "codegen": "missing", "note": "see vector"},
+        "rect":      {"detected": "handled", "parsed": "partial", "codegen": "missing", "note": "stroke/border-only rect drops in the generic-frame branch (which paints background_color only); a filled rect renders. dropped-vector guards the stroke-only case"},
+        "svg_rect":  {"detected": "handled", "parsed": "partial", "codegen": "missing", "note": "see rect"},
+        "rectangle": {"detected": "handled", "parsed": "partial", "codegen": "missing", "note": "see rect"},
+        "line":      {"detected": "handled", "parsed": "partial", "codegen": "missing", "note": "see vector; hairline lines (area < 256px^2) are intentionally not flagged by the dropped-vector invariant"},
+        "svg_line":  {"detected": "handled", "parsed": "partial", "codegen": "missing", "note": "see line"},
+        "ellipse":   {"detected": "handled", "parsed": "partial", "codegen": "missing", "note": "see vector; ellipse children consumed into a parent widget's native paint are not flagged"},
+        "circle":    {"detected": "handled", "parsed": "partial", "codegen": "missing", "note": "see ellipse"},
+        "polygon":   {"detected": "handled", "parsed": "partial", "codegen": "missing", "note": "rasterize-to-PNG at export covers the faithful path; the bare form drops"},
+        "polyline":  {"detected": "handled", "parsed": "partial", "codegen": "missing", "note": "see polygon"},
+        "star":      {"detected": "handled", "parsed": "partial", "codegen": "missing", "note": "see polygon"}
+      },
+      "features": {
+        "text-per-range-styles":            {"detected": "handled", "parsed": "partial", "codegen": "partial", "note": "first-char dominant style only; per-range runs -> <span> emission is future work"},
+        "interactive-promotion":            {"detected": "handled", "parsed": "partial", "codegen": "partial", "note": "button/input promotion from onclick/aria/cursor signals; native-arm disposition is promotion-dependent"},
+        "grid-container":                   {"detected": "partial", "parsed": "missing", "codegen": "missing", "note": "Yoga 3.0 grid is in the engine; IRLayout grid fields + parse aliases pending"},
+        "radial-angular-diamond-gradient":  {"detected": "handled", "parsed": "partial", "codegen": "partial", "note": "flat-color fallback; CSS radial/conic gradient emission is future work"},
+        "mix-blend-mode":                   {"detected": "handled", "parsed": "missing", "codegen": "missing", "note": "captured by some adapters, dropped in the IR; IRStyle.mix_blend_mode + bridge emit pending"},
+        "masks-clip-paths":                 {"detected": "partial", "parsed": "missing", "codegen": "missing", "note": "mask metadata + render fallback pending"},
+        "constraints":                      {"detected": "partial", "parsed": "missing", "codegen": "missing", "note": "Figma resize constraints -> flex/position mapping pending"}
+      }
+    },
     "claude": {
       "parser-version": "2.1",
       "detected-formats": [

--- a/docs/reference/compat/imports.md
+++ b/docs/reference/compat/imports.md
@@ -43,6 +43,43 @@ Each `detected-formats` entry carries:
   - `tailwind-config-token` — Tailwind utility token presence (any-of)
 - `notes`: human-readable description.
 
+## Object coverage
+
+Beyond *format detection*, the `imports/object-coverage` block tracks
+which normalized **DesignIR object types** the pipeline lowers, at three
+stages:
+
+- `detected` — an adapter recognizes the source object.
+- `parsed` — it is lowered into the normalized IR.
+- `codegen` — `generate_pulp_js` emits a real renderable primitive for it.
+
+Levels are `handled | partial | missing`. The matrix is **IR-level and
+source-agnostic**: because the importer and codegen operate on the
+normalized IR, a `handled` type renders identically for every source
+(figma, figma-plugin, pencil, stitch, v0, claude).
+
+`types` rows are **drift-checked** by
+`test/test_import_object_coverage.cpp` (binary
+`pulp-test-import-object-coverage`, Catch2 tag `[object-coverage]`): it
+builds a synthetic `IRNode` per type, runs `generate_pulp_js`, and fails
+if a `codegen: handled` type drops to an empty frame, or a
+`codegen: missing` vector/path kind does not trip the dropped-vector
+invariant. This keeps the matrix honest against the code — a claim
+cannot silently rot.
+
+`features` rows track cross-cutting paint/layout capabilities
+(per-range text, gradients, masks, mix-blend-mode, constraints, grid)
+owned by separate hardening slices; they are documented here but not
+type-drift-checked.
+
+The current snapshot: `frame`/`text`/`label`/`image` are `codegen:
+handled`; all vector/path kinds (`vector`/`path`/`svg_*`/`rect`/
+`rectangle`/`line`/`ellipse`/`circle`/`polygon`/`polyline`/`star`) are
+`codegen: missing` — their bare form silently degrades, guarded by the
+dropped-vector invariant, while the faithful path rasterizes them at
+export. Seeded from
+`planning/2026-05-31-import-coverage-hardening-plan.md` §3.
+
 ## Adding a new format
 
 When a new import source lands or an existing source's export format

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3078,6 +3078,15 @@ catch_discover_tests(pulp-test-design-import
 add_executable(pulp-test-design-fidelity test_design_fidelity.cpp)
 target_link_libraries(pulp-test-design-fidelity PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-design-fidelity PROPERTIES LABELS "parser-import")
+
+# Drift guard for the compat.json imports/object-coverage matrix. Reads the
+# matrix (PULP_SRC_DIR/compat.json) and validates each `types` row's codegen
+# claim against the real generate_pulp_js lowering.
+add_executable(pulp-test-import-object-coverage test_import_object_coverage.cpp)
+target_link_libraries(pulp-test-import-object-coverage PRIVATE pulp::view Catch2::Catch2WithMain)
+target_compile_definitions(pulp-test-import-object-coverage PRIVATE
+    PULP_SRC_DIR="${CMAKE_SOURCE_DIR}")
+catch_discover_tests(pulp-test-import-object-coverage PROPERTIES LABELS "parser-import")
 catch_discover_tests(pulp-test-design-import
     TEST_SPEC "[network]"
     PROPERTIES

--- a/test/test_import_object_coverage.cpp
+++ b/test/test_import_object_coverage.cpp
@@ -1,0 +1,183 @@
+// test_import_object_coverage.cpp — drift guard for the import object-coverage
+// matrix (compat.json `imports/object-coverage`).
+//
+// The matrix is a human-curated claim about which normalized DesignIR object
+// types codegen actually lowers to a renderable primitive. A claim rots the
+// moment codegen changes underneath it. This test keeps the matrix HONEST:
+// for every `types` row it builds a synthetic IRNode of that type, runs the
+// real `generate_pulp_js` native lowering, and asserts the observed codegen
+// disposition matches the matrix's `codegen` level. It FAILS if:
+//
+//   * a type marked `codegen: handled` is dropped to an empty frame (the
+//     dropped-vector invariant flags it, or its primitive is never emitted), or
+//   * a type marked `codegen: missing` (always a vector/path kind here) is NOT
+//     flagged by the dropped-vector invariant — i.e. the matrix under-claims a
+//     silent drop, or codegen quietly started handling it (update the matrix), or
+//   * the matrix lists a `types` row this test has no synthetic builder for, or
+//     a builder has no matching matrix row (matrix/test drift).
+//
+// Source-agnostic by construction: the probes are hand-built IRNodes with no
+// provenance / layer names, so this asserts the codegen contract, not any
+// source. `features` rows are documented-only (cross-cutting paint/layout
+// capabilities owned by separate slices) and are intentionally not probed here.
+//
+// Tag: [view][import][fidelity][object-coverage]
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/view/design_ir.hpp>
+#include <pulp/view/design_import.hpp>
+
+#include <choc/text/choc_JSON.h>
+
+#include <fstream>
+#include <functional>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace pulp::view;
+
+#ifndef PULP_SRC_DIR
+#error "PULP_SRC_DIR must be defined (path to the repo root holding compat.json)"
+#endif
+
+namespace {
+
+std::string read_file(const std::string& path) {
+    std::ifstream in(path, std::ios::binary);
+    REQUIRE(in.good());
+    std::ostringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+}
+
+// One synthetic probe per drift-checkable IR type. `render_token` is a JS
+// substring that MUST appear when the type lowers to a real primitive; an empty
+// token means the type is expected to be DROPPED (the dropped-vector invariant
+// must flag it). Root is emitted as a column container (createCol) so each
+// probe's render token stays unambiguous against the root's own container call.
+struct Probe {
+    std::function<IRNode()> build;
+    std::string render_token;  // "" => expected dropped (vector kind)
+};
+
+IRNode sized(const std::string& type, const std::string& name) {
+    IRNode n;
+    n.type = type;
+    n.name = name;
+    n.style.width = 64.0f;   // >= 16x16 so the dropped-vector area gate engages
+    n.style.height = 64.0f;
+    return n;
+}
+
+std::map<std::string, Probe> build_registry() {
+    std::map<std::string, Probe> r;
+
+    // Renderable types.
+    r["frame"] = {[] {
+        IRNode n = sized("frame", "probe_frame");
+        n.layout.direction = LayoutDirection::row;  // -> createRow (root is createCol)
+        return n;
+    }, "createRow"};
+    r["text"]  = {[] { IRNode n = sized("text",  "probe_text");  n.text_content = "Hi"; return n; }, "createLabel"};
+    r["label"] = {[] { IRNode n = sized("label", "probe_label"); n.text_content = "Hi"; return n; }, "createLabel"};
+    r["image"] = {[] { IRNode n = sized("image", "probe_image"); n.attributes["asset_path"] = "/tmp/x.png"; return n; }, "createImage"};
+
+    // Vector/path kinds: bare (no asset / fill / children) -> dropped, flagged
+    // by the dropped-vector invariant.
+    for (const char* t : {"vector", "path", "svg_path", "rect", "svg_rect",
+                          "rectangle", "line", "svg_line", "ellipse", "circle",
+                          "polygon", "polyline", "star"}) {
+        const std::string type = t;
+        r[type] = {[type] { return sized(type, "probe_" + type); }, ""};
+    }
+    return r;
+}
+
+// Run a single probe through the real native codegen and report whether the
+// dropped-vector invariant flagged it and the full emitted JS.
+struct ProbeResult { bool dropped = false; std::string js; };
+
+ProbeResult run_probe(const IRNode& probe) {
+    DesignIR ir;
+    ir.root.type = "frame";
+    ir.root.name = "probe_root";
+    ir.root.layout.direction = LayoutDirection::column;  // root emits createCol
+    ir.root.style.width = 400.0f;
+    ir.root.style.height = 400.0f;
+    ir.root.children.push_back(probe);
+
+    std::vector<FidelityIssue> report;
+    CodeGenOptions opts;                 // defaults to bridge_native_js
+    opts.fidelity_report = &report;
+    ProbeResult out;
+    out.js = generate_pulp_js(ir, opts);
+    for (const auto& iss : report)
+        if (iss.kind == "dropped-vector" && iss.node_name == probe.name)
+            out.dropped = true;
+    return out;
+}
+
+}  // namespace
+
+TEST_CASE("object-coverage matrix matches codegen reality (drift guard)",
+          "[view][import][fidelity][object-coverage]") {
+    const std::string text = read_file(std::string(PULP_SRC_DIR) + "/compat.json");
+    const auto root = choc::json::parse(text);
+
+    REQUIRE(root.isObject());
+    const auto imports = root["imports"];
+    REQUIRE(imports.isObject());
+    const auto oc = imports["object-coverage"];
+    REQUIRE(oc.isObject());
+    const auto types = oc["types"];
+    REQUIRE(types.isObject());
+    REQUIRE(types.size() > 0);
+
+    const auto registry = build_registry();
+
+    // Track which builders the matrix exercised, to catch builder-without-row drift.
+    std::map<std::string, bool> seen;
+    for (const auto& kv : registry) seen[kv.first] = false;
+
+    for (uint32_t i = 0; i < types.size(); ++i) {
+        const auto member = types.getObjectMemberAt(i);
+        const std::string type = std::string(member.name);
+        const auto codegen_v = member.value["codegen"];
+        REQUIRE(codegen_v.isString());
+        const std::string codegen = std::string(codegen_v.getString());
+
+        INFO("object-coverage type=" << type << " codegen=" << codegen);
+
+        // Every matrix `types` row must have a synthetic builder, or the matrix
+        // claims something this drift guard cannot verify.
+        const auto it = registry.find(type);
+        REQUIRE(it != registry.end());
+        seen[type] = true;
+
+        const Probe& probe = it->second;
+        const ProbeResult res = run_probe(probe.build());
+
+        if (codegen == "handled") {
+            // Must emit its primitive and must NOT be flagged as a silent drop.
+            CHECK_FALSE(res.dropped);
+            CHECK(res.js.find(probe.render_token) != std::string::npos);
+        } else if (codegen == "missing") {
+            // Every `missing` type in the matrix is a vector/path kind whose bare
+            // form silently degrades — the dropped-vector invariant must catch it.
+            CHECK(probe.render_token.empty());
+            CHECK(res.dropped);
+        } else {
+            // "partial" rows are documented but not strictly asserted here.
+            CHECK(codegen == "partial");
+        }
+    }
+
+    // No builder may lack a matrix row (the matrix is the source of truth).
+    for (const auto& kv : seen) {
+        INFO("builder type without a matrix row: " << kv.first);
+        CHECK(kv.second);
+    }
+}


### PR DESCRIPTION
Make per-object-type import coverage explicit and self-enforcing. Adds an
`imports/object-coverage` block to compat.json: an IR-level, source-agnostic
matrix of every normalized DesignIR object type at three pipeline stages
(detected / parsed / codegen), levels handled|partial|missing, seeded from the
hardening plan's object-type table. Source-agnostic by construction — codegen
operates on the normalized IR, so a `handled` type renders identically across
figma/figma-plugin/pencil/stitch/v0/claude.

The matrix is kept honest by a drift guard, test/test_import_object_coverage.cpp
(pulp-test-import-object-coverage, tag [object-coverage]): it reads the matrix,
builds a synthetic IRNode per `types` row, runs the real generate_pulp_js native
lowering, and FAILS if
  - a `codegen: handled` type is dropped to an empty frame or never emits its
    primitive (frame->createRow/Col, text/label->createLabel, image->createImage),
  - a `codegen: missing` vector/path kind does NOT trip the dropped-vector
    invariant (#3275) — catching both an under-claimed silent drop and codegen
    quietly starting to handle a type, or
  - the matrix and the test's synthetic-builder registry drift apart (a row with
    no builder, or a builder with no row).

So the matrix cannot silently rot: the next codegen change that alters a type's
disposition reddens this test until the matrix is updated to match. `features`
rows (per-range text, gradients, masks, mix-blend-mode, constraints, grid) are
documented but owned by separate slices, so they are not type-drift-checked.

Synthetic fixtures only (hand-built IRNodes, no provenance/layer names).
Verified: drift test green (91 assertions); e2e `pulp import-design
--strict-fidelity` on the faithful kitchen-sink export exits 0; golden
re-import PASS (0.000% — no codegen change); compat-sync clean; docs PASS.
Docs: docs/reference/compat/imports.md gains an "Object coverage" section.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>