### PR TITLE
fix(view+import-design): close 5 Codex P2s on the fidelity strict-gate

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -1852,10 +1852,31 @@ rasterized shapes). Each cost a visible fidelity bug.
   Findings carry the exact bridge id via codegen's real node→id map. Fires 0 on
   a faithful import (substantive shape art is rasterized at export and routes
   through the image branch).
+- **Informational vs hard findings (load-bearing for `--strict-fidelity`).**
+  `FidelityIssue::informational` marks advisory findings the importer should
+  surface but never fail on — currently `widget-undersized` (codegen
+  legitimately clamps a sub-native-minimum widget up). The CLI derives its exit
+  code from `count_strict_fidelity_failures()` (non-informational count), NOT the
+  raw finding count. If you add an advisory check, set `informational=true` at
+  construction AND assert it in a test — otherwise a "warn, don't fail" finding
+  silently exits 4 and breaks faithful imports.
+- **Auto-height text must self-skip the vcenter check.** When the IR carries no
+  explicit height, codegen synthesizes `label_h = font*1.4`, which lands inside
+  the tall-slot range and would falsely trip `text-vcenter` on ordinary labels.
+  The call-site stamps `_emitted_vertical_align = "n-a"` in that case and the
+  check treats `"n-a"` (like `"center"`) as a self-skip — only an EXPLICIT
+  taller-than-font slot is held to the centering invariant.
+- **`--strict-fidelity` covers BOTH codegen paths and `--dry-run`.** The checks
+  run in `generate_native_node` AND in `generate_node` (web-compat, image-skew
+  only — widget/text slot geometry differs on that path and full web-compat
+  coverage is a tracked hardening follow-up). `--dry-run` returns
+  `fidelity_failed ? 4 : 0`, not an unconditional 0 — a harness that imports with
+  `--dry-run --strict-fidelity` still sees the non-zero exit.
 - **`pulp import-design --strict-fidelity`** prints findings as `fidelity: …`
-  warnings and exits 4 when any are present. Tests: unit cases per check in
-  `test/test_design_fidelity.cpp`; the codegen-routing case is in
-  `test_design_import.cpp`.
+  warnings (informational ones tagged `[informational]`) and exits 4 when any
+  HARD finding is present. Tests: unit cases per check in
+  `test/test_design_fidelity.cpp`; codegen-routing + web-compat + informational
+  cases in `test_design_import.cpp`.
 - **Golden re-import regression — `tools/import-validation/golden_regression.py`.**
   Re-imports a design from scratch and compares its render to a committed
   baseline with TOLERANT/STRUCTURAL matching (per-pixel-over-tolerance fraction
@@ -1864,3 +1885,10 @@ rasterized shapes). Each cost a visible fidelity bug.
   sizing. Source-agnostic (any `--from`). Proprietary baselines stay local; CI
   uses synthetic ones. Run it (and `--strict-fidelity` on a real import) after
   any change to the sizing/fidelity paths to prove no visual regression.
+  - **uint8 wraparound gotcha:** the structural edge map (`edges()`) must cast
+    luminance to a SIGNED dtype before `np.diff` — on raw uint8 a `255→0`
+    dark-on-light edge wraps to `+1` and falls below the threshold, so the
+    strongest edges in dark-text/light-bg designs vanish and a removed/moved
+    thin feature can still read as "high edge agreement". The
+    `int16` cast fixes it. `golden_regression.py --selftest` (ctest
+    `golden-regression-selftest`, skips 77 without numpy) pins this.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.304.0
+    VERSION 0.305.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/design_fidelity.hpp
+++ b/core/view/include/pulp/view/design_fidelity.hpp
@@ -12,6 +12,7 @@
 
 #include <pulp/view/design_ir.hpp>
 
+#include <cstddef>
 #include <functional>
 #include <optional>
 #include <string>
@@ -27,6 +28,8 @@ struct FidelityIssue {
                             ///<   | "widget-size" | "widget-undersized" | "text-vcenter"
                             ///<   | "dropped-vector"
     std::string detail;     ///< one-line explanation with the measured numbers
+    bool informational = false;  ///< advisory only (e.g. a below-native-minimum
+                                 ///< clamp-up); --strict-fidelity must NOT fail on it
 };
 
 /// What codegen branch produced the emitted geometry — lets a check apply only
@@ -102,5 +105,11 @@ void check_vector_renderability(
     const std::vector<ImportDiagnostic>& diagnostics,
     const std::function<std::string(const IRNode&)>& node_id_of,
     std::vector<FidelityIssue>& sink);
+
+/// Number of findings that should fail `--strict-fidelity`. Informational
+/// findings (advisory clamp-ups etc.) are surfaced as warnings but never gate
+/// the import, so the CLI decides its exit code from this count, not the raw
+/// finding count.
+std::size_t count_strict_fidelity_failures(const std::vector<FidelityIssue>& issues);
 
 }  // namespace pulp::view

--- a/core/view/src/design_codegen.cpp
+++ b/core/view/src/design_codegen.cpp
@@ -256,6 +256,17 @@ static void generate_node(std::ostringstream& ss, const IRNode& node,
     emit_px("maxWidth", s.max_width);
     emit_px("maxHeight", s.max_height);
 
+    // Reference-free image-sizing fidelity self-check on the web-compat path
+    // too (mirrors generate_native_node). The web-compat <img> emits the style
+    // box directly, so the emitted geometry is exactly s.width/s.height. The
+    // widget/text slot checks depend on native-emitted geometry and don't map
+    // 1:1 to web-compat output; full web-compat coverage is tracked as a
+    // hardening follow-up (see planning/2026-05-31-import-coverage-hardening-plan.md).
+    if (node.type == "image" && opts.fidelity_report && s.width && s.height) {
+        run_fidelity_checks({node, var, *s.width, *s.height, FidelityElement::image},
+                            *opts.fidelity_report);
+    }
+
     // Text content
     if (!node.text_content.empty())
         ss << ind << var << ".textContent = '" << js_single_quote_escape(node.text_content) << "';\n";  // pulp #81
@@ -1141,7 +1152,12 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
         // node is const here, so stamp the emitted vertical-align onto a copy.
         if (opts.fidelity_report) {
             IRNode fnode = node;
-            fnode.attributes["_emitted_vertical_align"] = emitted_vcenter ? "center" : "top";
+            // When the IR carried no explicit height, label_h is synthesized
+            // from the font (font_h * 1.4) — there is no design-reserved slot,
+            // so stamp "n-a" and the text check self-skips. Only an explicit
+            // taller-than-font slot is held to the vertical-centering invariant.
+            fnode.attributes["_emitted_vertical_align"] =
+                !ir_height_is_explicit ? "n-a" : (emitted_vcenter ? "center" : "top");
             run_fidelity_checks({fnode, id, 0.0f, label_h, FidelityElement::text},
                                 *opts.fidelity_report);
         }

--- a/core/view/src/design_fidelity.cpp
+++ b/core/view/src/design_fidelity.cpp
@@ -129,7 +129,10 @@ std::optional<FidelityIssue> check_widget_intrinsic_size(const FidelityContext& 
       << "H " << rh << "x (src " << src_h << " emit " << ctx.emitted_h << "px)";
     if (only_clamp) {
         d << " — below native minimum, clamped up";
-        return FidelityIssue{ctx.node_id, node.name, "widget-undersized", d.str()};
+        // Informational: codegen legitimately enlarges a sub-minimum source, so
+        // this must not trip --strict-fidelity (the CLI skips informational).
+        return FidelityIssue{ctx.node_id, node.name, "widget-undersized", d.str(),
+                             /*informational=*/true};
     }
     return FidelityIssue{ctx.node_id, node.name, "widget-size", d.str()};
 }
@@ -150,6 +153,10 @@ std::optional<FidelityIssue> check_text_vertical_centering(const FidelityContext
     auto it = node.attributes.find("_emitted_vertical_align");
     const std::string va = it != node.attributes.end() ? it->second : "";
     if (va == "center") return std::nullopt;      // centered as expected
+    // "n-a": codegen synthesized this height from the font (no design-reserved
+    // slot — auto-height text), so there is nothing to center within. Only an
+    // EXPLICIT taller-than-font slot obliges vertical centering.
+    if (va == "n-a") return std::nullopt;
 
     std::ostringstream d;
     d << "single-line text in a " << box_h << "px slot (line ~" << line_h
@@ -304,6 +311,12 @@ void check_vector_renderability(
             visit(n.children[i], path + "/children[" + std::to_string(i) + "]");
     };
     visit(root, "$");
+}
+
+std::size_t count_strict_fidelity_failures(const std::vector<FidelityIssue>& issues) {
+    return static_cast<std::size_t>(
+        std::count_if(issues.begin(), issues.end(),
+                      [](const FidelityIssue& fi) { return !fi.informational; }));
 }
 
 }  // namespace pulp::view

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -156,6 +156,19 @@ if(Python3_Interpreter_FOUND)
         LABELS "import;fidelity;slow"
         TIMEOUT 120)
 
+    # Golden re-import regression tool (tools/import-validation/golden_regression.py)
+    # — self-test for its structural edge map. Guards the uint8-wraparound fix
+    # (a 255->0 dark-on-light edge must not vanish). Exits 77 (skips) when numpy
+    # is unavailable.
+    add_test(NAME golden-regression-selftest
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/../tools/import-validation/golden_regression.py
+                --selftest)
+    set_tests_properties(golden-regression-selftest PROPERTIES
+        SKIP_RETURN_CODE 77
+        LABELS "import;fidelity"
+        TIMEOUT 30)
+
     # Labeled comparison-montage helper (tools/import-design/montage.py).
     # Builds titled reference-vs-render(s) montages (labels ON by default).
     # PIL-based; exits 77 (skips) on a PIL-less interpreter.

--- a/test/test_cli_import_design.cpp
+++ b/test/test_cli_import_design.cpp
@@ -251,6 +251,32 @@ TEST_CASE("pulp import-design --from claude emits classnames.json by default",
     REQUIRE(combined.find(classnames_out.string()) != std::string::npos);
 }
 
+TEST_CASE("pulp import-design --dry-run --strict-fidelity exits 0 on a clean import",
+          "[cli][import-design][fidelity][shellout]") {
+    // Codex #3267: the dry-run branch must honor --strict-fidelity (return
+    // fidelity_failed ? 4 : 0), not an unconditional 0. A clean import has no
+    // hard findings, so a harness running --dry-run --strict-fidelity sees 0 —
+    // and the new return path is exercised. (The failure→4 path needs real
+    // skewed PNG assets; the geometry logic is unit-covered in
+    // test_design_fidelity.cpp / test_design_import.cpp.)
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto tmp = unique_temp_dir("pulp-import-design-dryrun-strict");
+    auto html_in = fixture_dir() / "example.html";
+    auto js_out = tmp / "ui.js";
+
+    auto r = run_pulp({"import-design",
+                       "--from", "claude",
+                       "--file", html_in.string(),
+                       "--output", js_out.string(),
+                       "--dry-run",
+                       "--strict-fidelity"});
+    REQUIRE_FALSE(r.timed_out);
+    CHECK(r.exit_code == 0);
+    // --dry-run is a preview: it must not write the output file.
+    CHECK_FALSE(fs::exists(js_out));
+}
+
 TEST_CASE("pulp import-design --from claude --no-emit-classnames suppresses the artifact",
           "[cli][import-design][issue-1035][shellout]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }

--- a/test/test_design_fidelity.cpp
+++ b/test/test_design_fidelity.cpp
@@ -194,6 +194,19 @@ TEST_CASE("widget-size: below-native-minimum clamp-up is informational",
         {n, "K0", 56.0f, 56.0f, FidelityElement::widget});
     REQUIRE(i.has_value());
     CHECK(i->kind == "widget-undersized");
+    // Codex #3274: the clamp-up is advisory — it must carry the informational
+    // flag so --strict-fidelity (which fails on hard findings only) ignores it.
+    CHECK(i->informational);
+}
+
+TEST_CASE("widget-size: a real divergence is a hard (non-informational) finding",
+          "[view][import][fidelity][harness]") {
+    const auto n = make_widget_node(AudioWidgetType::knob, 62, 62);
+    const auto i = check_widget_intrinsic_size(
+        {n, "K0", 130.0f, 62.0f, FidelityElement::widget});  // ~2.1x, above native min
+    REQUIRE(i.has_value());
+    CHECK(i->kind == "widget-size");
+    CHECK_FALSE(i->informational);
 }
 
 TEST_CASE("widget-size: reads the shape_* attribute as the source",
@@ -401,4 +414,39 @@ TEST_CASE("vector-renderability does not descend into a widget subtree "
     std::vector<FidelityIssue> sink;
     check_vector_renderability(knob, kNoDiagnostics, vec_id_of, sink);
     CHECK(sink.empty());
+}
+
+TEST_CASE("count_strict_fidelity_failures ignores informational findings",
+          "[view][import][fidelity][harness]") {
+    // The CLI derives its --strict-fidelity exit code from this count, so an
+    // informational finding (clamp-up) must not contribute a failure.
+    std::vector<FidelityIssue> issues = {
+        {"a", "A", "skew", "hard", /*informational=*/false},
+        {"b", "B", "widget-undersized", "advisory", /*informational=*/true},
+        {"c", "C", "gross-size", "hard", /*informational=*/false},
+    };
+    CHECK(count_strict_fidelity_failures(issues) == 2);
+
+    std::vector<FidelityIssue> all_info = {
+        {"b", "B", "widget-undersized", "advisory", /*informational=*/true},
+    };
+    CHECK(count_strict_fidelity_failures(all_info) == 0);
+    CHECK(count_strict_fidelity_failures({}) == 0);
+}
+
+TEST_CASE("text-vcenter: an auto-height label (n-a) in a tall slot self-skips",
+          "[view][import][fidelity][harness]") {
+    // Codex #3274: when the IR carries no explicit height, codegen synthesizes
+    // label_h = font*1.4 (19.6 for 14px), which lands in the tall-slot range and
+    // is stamped top-aligned. Without the "n-a" guard this fires a FALSE
+    // text-vcenter on every ordinary auto-height label and breaks
+    // --strict-fidelity. The stamp must make it self-skip.
+    IRNode n;
+    n.type = "text";
+    n.name = "T";
+    n.text_content = "Search";
+    n.style.font_size = 14.0f;
+    n.attributes["_emitted_vertical_align"] = "n-a";
+    CHECK_FALSE(check_text_vertical_centering(
+        {n, "T0", 0.0f, 19.6f, FidelityElement::text}).has_value());
 }

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -4286,3 +4286,72 @@ TEST_CASE("codegen routes a dropped vector through the vector-renderability chec
         if (iss.kind == "dropped-vector" && iss.node_name == "Glyph") found = true;
     CHECK(found);
 }
+
+TEST_CASE("web-compat codegen also runs the image-sizing fidelity check",
+          "[view][import][codegen][fidelity][web-compat]") {
+    // Codex #3267: fidelity checks previously ran only in the native-bridge
+    // branch, so `--web-compat --strict-fidelity` exited 0 even for a skewed
+    // bleed sprite. The web-compat <img> emits the style box directly, so the
+    // image-sizing check now runs on that path too.
+    DesignIR ir;
+    ir.root.type = "frame";
+    ir.root.name = "Root";
+
+    IRNode img;
+    img.type = "image";
+    img.name = "Sprite";
+    img.attributes["asset_bleed"]   = "1";    // bleed marker
+    img.attributes["png_natural_w"] = "100";  // source aspect 1.0
+    img.attributes["png_natural_h"] = "100";
+    img.style.width  = 100.0f;                 // emitted aspect 2.0 → skewed
+    img.style.height = 50.0f;
+    ir.root.children.push_back(img);
+
+    std::vector<pulp::view::FidelityIssue> report;
+    CodeGenOptions opts;
+    opts.mode = CodeGenMode::web_compat;
+    opts.fidelity_report = &report;
+    (void)generate_pulp_js(ir, opts);
+
+    bool skew = false;
+    for (const auto& iss : report)
+        if (iss.kind == "skew" && iss.node_name == "Sprite") skew = true;
+    CHECK(skew);
+}
+
+
+TEST_CASE("an undersized widget reports informational (never a hard finding)",
+          "[view][import][codegen][fidelity]") {
+    // Codex #3274: a below-native-minimum widget is legitimately clamped up by
+    // codegen, so its finding must carry the informational flag and never be a
+    // hard finding the import CLI fails on under --strict-fidelity. The xy_pad
+    // branch clamps its emitted size up to the 80px native minimum (sz =
+    // max(width, 80)), so a 20px source produces the widget-undersized path.
+    DesignIR ir;
+    ir.root.type = "frame";
+    ir.root.name = "Root";
+
+    IRNode pad;
+    pad.type = "frame";
+    pad.name = "Tiny";
+    pad.audio_widget = AudioWidgetType::xy_pad;
+    pad.style.width  = 20.0f;   // far below the 80px native minimum → clamped up
+    pad.style.height = 20.0f;
+    ir.root.children.push_back(pad);
+
+    std::vector<pulp::view::FidelityIssue> report;
+    CodeGenOptions opts;
+    opts.fidelity_report = &report;
+    (void)generate_pulp_js(ir, opts);
+
+    bool saw_undersized = false;
+    for (const auto& iss : report) {
+        if (iss.kind == "widget-undersized") {
+            saw_undersized = true;
+            CHECK(iss.informational);          // the load-bearing assertion
+        }
+        // Whatever else surfaces, nothing about a clamp-up may be a hard finding.
+        if (iss.node_name == "Tiny") CHECK(iss.informational);
+    }
+    CHECK(saw_undersized);
+}

--- a/tools/import-design/pulp_import_design.cpp
+++ b/tools/import-design/pulp_import_design.cpp
@@ -2205,12 +2205,18 @@ int main(int argc, char* argv[]) {
     // Reference-free fidelity self-check: surface any sprite the importer could
     // not prove it sized faithfully. Always reported as warnings; with
     // --strict-fidelity a finding makes the import exit non-zero.
+    // Informational findings (e.g. a below-native-minimum widget codegen clamps
+    // up) are surfaced as warnings but never gate the import — only "hard"
+    // findings trip --strict-fidelity (see count_strict_fidelity_failures).
     for (const auto& fi : fidelity_issues) {
         std::cerr << "fidelity: [" << fi.kind << "] " << fi.node_name
-                  << " (" << fi.node_id << "): " << fi.detail << "\n";
+                  << " (" << fi.node_id << "): " << fi.detail
+                  << (fi.informational ? "  [informational]" : "") << "\n";
     }
-    if (strict_fidelity && !fidelity_issues.empty()) {
-        std::cerr << "fidelity: " << fidelity_issues.size()
+    const std::size_t hard_findings =
+        pulp::view::count_strict_fidelity_failures(fidelity_issues);
+    if (strict_fidelity && hard_findings > 0) {
+        std::cerr << "fidelity: " << hard_findings
                   << " issue(s); failing due to --strict-fidelity\n";
         fidelity_failed = true;
     }
@@ -2225,7 +2231,9 @@ int main(int argc, char* argv[]) {
             std::cout << "\n=== W3C Design Tokens (" << tokens_file << ") ===\n\n";
             std::cout << w3c;
         }
-        return 0;
+        // --dry-run still honors --strict-fidelity: a harness that imports with
+        // both must see the non-zero exit, not a silent success.
+        return fidelity_failed ? 4 : 0;
     }
 
     auto t_codegen = std::chrono::steady_clock::now();

--- a/tools/import-validation/golden_regression.py
+++ b/tools/import-validation/golden_regression.py
@@ -48,8 +48,13 @@ def render(args, out_png) -> bool:
 
 def edges(gray):
     np = _np()
-    gx = np.abs(np.diff(gray, axis=1, prepend=gray[:, :1]))
-    gy = np.abs(np.diff(gray, axis=0, prepend=gray[:1, :]))
+    # Cast to signed before differencing: on uint8 luminance np.diff wraps
+    # negative deltas (a 255->0 dark-on-light edge becomes +1, below threshold),
+    # so the strongest edges in dark-text/light-bg designs would vanish from the
+    # structural map. int16 keeps the true signed magnitude.
+    g = gray.astype(np.int16)
+    gx = np.abs(np.diff(g, axis=1, prepend=g[:, :1]))
+    gy = np.abs(np.diff(g, axis=0, prepend=g[:1, :]))
     return ((gx + gy) > 32)  # binary edge map, threshold robust to soft noise
 
 def _dilate(mask, r=2):
@@ -115,7 +120,29 @@ def _write_compare(base, cur, diff, frac, edge_agree, path):
     canvas.save(path)
     print(f"golden: wrote comparison {path}")
 
+def _selftest() -> int:
+    """Verify edges() captures strong dark-on-light transitions (the uint8
+    wraparound regression). Skips cleanly if numpy is unavailable."""
+    try:
+        np = _np()
+    except Exception as e:  # numpy not installed in this environment
+        print(f"golden: selftest skipped (numpy unavailable: {e})")
+        return 77  # ctest SKIP_RETURN_CODE
+    # A 255 -> 0 column transition is the strongest possible dark-on-light edge.
+    # Under the old uint8 np.diff it wrapped to +1 and fell below the threshold,
+    # so the edge vanished; with the int16 cast it must be detected.
+    row = np.array([[255, 255, 0, 0]], dtype=np.uint8)
+    e = edges(row)
+    assert bool(e[0, 2]), "edges() missed a 255->0 dark-on-light transition"
+    # An ascending 0 -> 255 edge must likewise be detected (symmetry).
+    row2 = np.array([[0, 0, 255, 255]], dtype=np.uint8)
+    assert bool(edges(row2)[0, 2]), "edges() missed a 0->255 transition"
+    print("golden: selftest passed (edges() handles signed luminance deltas)")
+    return 0
+
 def main() -> int:
+    if "--selftest" in sys.argv:
+        return _selftest()
     ap = argparse.ArgumentParser()
     ap.add_argument("--from", dest="source", required=True)
     ap.add_argument("--file", required=True)


### PR DESCRIPTION
Post-merge review sweep of #3267/#3268/#3272/#3274 surfaced five P2
findings, four of which let --strict-fidelity silently skip or falsely
fail — the exact e2e gate downstream import hardening builds on. All
five fixed, each with a regression test (Catch2 / ctest):

- #3267 dry-run honored the strict gate: the --dry-run branch returned
  0 unconditionally, so a harness using --dry-run --strict-fidelity
  never saw the non-zero exit. Now returns `fidelity_failed ? 4 : 0`.
  (test_cli_import_design: dry-run+strict shellout)
- #3267 web-compat coverage: fidelity checks ran only in
  generate_native_node, so --web-compat --strict-fidelity exited 0 on a
  skewed sprite. Wired check_image_sizing_fidelity into generate_node
  (the web-compat <img> emits the style box directly; widget/text slot
  geometry differs there and full web-compat coverage is a tracked
  follow-up). (test_design_import: web-compat image case)
- #3274 auto-height text false-positive: synthesized label_h (font*1.4)
  landed in the tall-slot range and tripped text-vcenter on ordinary
  no-explicit-height labels. The call-site now stamps
  _emitted_vertical_align="n-a" and the check self-skips — only an
  explicit taller-than-font slot is held to the invariant.
  (test_design_fidelity: n-a self-skip)
- #3274 undersized-widget false-fail: widget-undersized is documented
  "warn, don't fail" but still gated --strict-fidelity. Added a
  FidelityIssue::informational flag + count_strict_fidelity_failures();
  the CLI derives its exit code from the hard-finding count.
  (test_design_fidelity + test_design_import: informational gating)
- #3272 golden uint8 wraparound: edges() ran np.diff on uint8, so a
  255->0 dark-on-light edge wrapped to +1 and vanished below threshold.
  Cast luminance to int16 first. (golden-regression-selftest, ctest)

import-design SKILL.md updated with all five gotchas (skill owns
pulp_import_design.cpp + golden_regression.py).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>