### PR TITLE
feat(view+import-design): preserve + emit CSS mix-blend-mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.308.0
+    VERSION 0.309.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/compat.json
+++ b/compat.json
@@ -8183,7 +8183,7 @@
         "interactive-promotion":            {"detected": "handled", "parsed": "partial", "codegen": "partial", "note": "button/input promotion from onclick/aria/cursor signals; native-arm disposition is promotion-dependent"},
         "grid-container":                   {"detected": "partial", "parsed": "missing", "codegen": "missing", "note": "Yoga 3.0 grid is in the engine; IRLayout grid fields + parse aliases pending"},
         "radial-angular-diamond-gradient":  {"detected": "handled", "parsed": "partial", "codegen": "partial", "note": "flat-color fallback; CSS radial/conic gradient emission is future work"},
-        "mix-blend-mode":                   {"detected": "handled", "parsed": "missing", "codegen": "missing", "note": "captured by some adapters, dropped in the IR; IRStyle.mix_blend_mode + bridge emit pending"},
+        "mix-blend-mode":                   {"detected": "handled", "parsed": "handled", "codegen": "partial", "note": "IRStyle.mix_blend_mode is parsed (style.mixBlendMode + figma.blend_mode, normalized to the CSS keyword; normal/pass-through dropped) and emitted on container/image/text/svg_path nodes (web style.mixBlendMode; native setMixBlendMode → View::set_mix_blend_mode + save_layer_with_blend). Not yet emitted on audio-widget nodes (knob/fader/meter), hence partial"},
         "masks-clip-paths":                 {"detected": "partial", "parsed": "missing", "codegen": "missing", "note": "mask metadata + render fallback pending"},
         "constraints":                      {"detected": "partial", "parsed": "missing", "codegen": "missing", "note": "Figma resize constraints -> flex/position mapping pending"}
       }

--- a/core/view/include/pulp/view/design_ir.hpp
+++ b/core/view/include/pulp/view/design_ir.hpp
@@ -75,6 +75,10 @@ struct IRStyle {
     std::optional<std::string> background_repeat;
     std::optional<std::string> color;                  // text color
     std::optional<float> opacity;
+    // CSS mix-blend-mode keyword (e.g. "multiply", "screen", "color-dodge").
+    // Normalized to the lowercase-hyphen CSS spelling at parse time; the
+    // engine's View::set_mix_blend_mode + setMixBlendMode bridge consume it.
+    std::optional<std::string> mix_blend_mode;
     std::optional<float> border_radius;
     std::optional<std::string> border;                 // e.g. "1px solid #333"
     std::optional<std::string> border_color;

--- a/core/view/src/design_codegen.cpp
+++ b/core/view/src/design_codegen.cpp
@@ -225,6 +225,7 @@ static void generate_node(std::ostringstream& ss, const IRNode& node,
         ss << ind << var << ".style.background = '" << *s.background_gradient << "';\n";
     emit_str("color", s.color);
     emit_float("opacity", s.opacity);
+    emit_str("mixBlendMode", s.mix_blend_mode);
     emit_px("borderRadius", s.border_radius);
     emit_str("border", s.border);
     if (!s.box_shadow.empty())
@@ -412,6 +413,16 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
         if (s.top)    ss << ind << "setTop('"    << target_id << "', " << *s.top    << ");\n";
         if (s.right)  ss << ind << "setRight('"  << target_id << "', " << *s.right  << ");\n";
         if (s.bottom) ss << ind << "setBottom('" << target_id << "', " << *s.bottom << ");\n";
+    };
+
+    // Emit the node's CSS mix-blend-mode (parse-normalized to a lowercase-
+    // hyphen keyword). The native engine compositing path (View::set_mix_blend
+    // _mode + the setMixBlendMode bridge) consumes it; a normal / pass-through
+    // mode is dropped at parse, so this only fires for a real blend.
+    auto emit_mix_blend_mode = [&](const std::string& target_id) {
+        if (node.style.mix_blend_mode && !node.style.mix_blend_mode->empty())
+            ss << ind << "setMixBlendMode('" << target_id << "', '"
+               << js_single_quote_escape(*node.style.mix_blend_mode) << "');\n";
     };
 
     // Phase 0a: emit the anchor trail in bridge-native-JS codegen too. Same
@@ -951,6 +962,7 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
                 ss << ind << "// " << node.name << "\n";
             ss << ind << "createSvgPath('" << id << "', " << pid << ");\n";
             emit_position_if_absolute(id);
+            emit_mix_blend_mode(id);
             ss << ind << "setSvgPath('" << id << "', '"
                << js_single_quote_escape(pd->second) << "');\n";
             // viewBox is "minX minY width height" — the widget scales the path
@@ -1006,6 +1018,7 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
             ss << ind << "// " << node.name << "\n";
         ss << ind << "createImage('" << id << "', " << pid << ");\n";
         emit_position_if_absolute(id);
+        emit_mix_blend_mode(id);
         auto it = node.attributes.find("asset_path");
         if (it != node.attributes.end() && !it->second.empty()) {
             ss << ind << "setImageSource('" << id << "', '"
@@ -1127,6 +1140,7 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
         // Text node → createLabel with explicit height (Yoga requirement)
         ss << ind << "createLabel('" << id << "', '" << js_single_quote_escape(node.text_content) << "', " << pid << ");\n";  // pulp #81
         emit_position_if_absolute(id);
+        emit_mix_blend_mode(id);
 
         // Honour the IR-declared height when present. Pre-fix this branch
         // unconditionally recomputed from font_size, which clobbered Figma's
@@ -1246,6 +1260,7 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
         ss << ind << (is_row ? "createRow" : "createCol")
            << "('" << id << "', " << pid << ");\n";
         emit_position_if_absolute(id);
+        emit_mix_blend_mode(id);
 
         // Yoga: every container MUST have explicit height
         // Priority: _layoutHeight (from snapshot_layout) > style.height > fill > computed

--- a/core/view/src/design_ir_json.cpp
+++ b/core/view/src/design_ir_json.cpp
@@ -173,6 +173,21 @@ std::string box_shadow_to_css(const std::vector<IRBoxShadow>& shadows) {
 
 // ── IR from JSON ────────────────────────────────────────────────────────
 
+// Normalize a blend-mode keyword to its CSS lowercase-hyphen spelling. CSS
+// sources (v0 / Stitch / Pencil) already emit "multiply"; Figma's API uses
+// UPPER_SNAKE ("MULTIPLY", "COLOR_DODGE", "PASS_THROUGH"). The no-op modes
+// (normal / pass-through) return nullopt so codegen emits nothing for them.
+static std::optional<std::string> normalize_blend_mode(std::string raw) {
+    for (auto& c : raw) {
+        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        if (c == '_') c = '-';
+    }
+    if (raw.empty() || raw == "normal" || raw == "pass-through" ||
+        raw == "passthrough")
+        return std::nullopt;
+    return raw;
+}
+
 static IRStyle parse_ir_style(const choc::value::ValueView& obj) {
     IRStyle s;
     if (!obj.isObject()) return s;
@@ -214,6 +229,8 @@ static IRStyle parse_ir_style(const choc::value::ValueView& obj) {
     set_opt_str("backgroundRepeat", s.background_repeat);
     set_opt_str("color", s.color);
     set_opt_float("opacity", s.opacity);
+    set_opt_str("mixBlendMode", s.mix_blend_mode);
+    if (s.mix_blend_mode) s.mix_blend_mode = normalize_blend_mode(*s.mix_blend_mode);
     set_opt_float("borderRadius", s.border_radius);
     set_opt_str("border", s.border);
     set_opt_str("borderColor", s.border_color);
@@ -664,6 +681,16 @@ IRNode parse_ir_node(const choc::value::ValueView& obj) {
 
     if (obj.hasObjectMember("style"))
         node.style = parse_ir_style(obj["style"]);
+    // The figma-plugin export carries the blend mode in the `figma` block
+    // (e.g. {"figma": {"blend_mode": "MULTIPLY"}}), not in `style`. Promote it
+    // into the normalized IRStyle when `style.mixBlendMode` didn't already set
+    // one, so a Figma layer's blend mode survives the same as a CSS source's.
+    if (!node.style.mix_blend_mode && obj.hasObjectMember("figma") &&
+        obj["figma"].isObject() && obj["figma"].hasObjectMember("blend_mode") &&
+        obj["figma"]["blend_mode"].isString()) {
+        node.style.mix_blend_mode =
+            normalize_blend_mode(std::string(obj["figma"]["blend_mode"].toString()));
+    }
     if (obj.hasObjectMember("layout"))
         node.layout = parse_ir_layout(obj["layout"]);
     if (obj.hasObjectMember("attributes") && obj["attributes"].isObject()) {
@@ -1344,6 +1371,7 @@ static void write_ir_style_json(std::ostringstream& out, const IRStyle& s) {
     write_string_member(out, first, "backgroundRepeat", s.background_repeat);
     write_string_member(out, first, "color", s.color);
     write_float_member(out, first, "opacity", s.opacity);
+    write_string_member(out, first, "mixBlendMode", s.mix_blend_mode);
     write_float_member(out, first, "borderRadius", s.border_radius);
     write_string_member(out, first, "border", s.border);
     write_string_member(out, first, "borderColor", s.border_color);

--- a/test/test_cli_import_design.cpp
+++ b/test/test_cli_import_design.cpp
@@ -544,6 +544,45 @@ TEST_CASE("pulp import-design --knob-style sprite keeps a child-art knob interac
     REQUIRE(js.find("setWidgetStyle('GainKnob") == std::string::npos);
 }
 
+TEST_CASE("pulp import-design normalizes + emits a Figma blend mode (end-to-end)",
+          "[cli][import-design][blend][shellout]") {
+    // The figma-plugin export carries the blend mode in the `figma` block in
+    // UPPER_SNAKE. parse_ir_node normalizes it to the CSS keyword and codegen
+    // emits setMixBlendMode — except PASS_THROUGH (= normal), which is dropped.
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto tmp = unique_temp_dir("pulp-blend-mode");
+    {
+        std::ofstream f(tmp / "scene.pulp.json");
+        f << R"({
+  "format_version": "2026.05-figma-plugin-v1",
+  "provenance": {"adapter": "figma-plugin", "version": "t",
+                 "source_uri": "figma://x/1:1"},
+  "root": {"type": "frame", "name": "Root", "figma_node_id": "1:1",
+    "children": [
+      {"type": "frame", "name": "Glow", "figma_node_id": "1:2",
+       "style": {"width": 80, "height": 80, "backgroundColor": "#ff8800"},
+       "figma": {"blend_mode": "COLOR_DODGE"}},
+      {"type": "frame", "name": "Plain", "figma_node_id": "1:3",
+       "style": {"width": 80, "height": 80, "backgroundColor": "#223344"},
+       "figma": {"blend_mode": "PASS_THROUGH"}}
+    ]}
+})";
+    }
+    auto js_out = tmp / "ui.js";
+    auto r = run_pulp({"import-design", "--from", "figma-plugin",
+                       "--file", (tmp / "scene.pulp.json").string(),
+                       "--output", js_out.string(), "--no-tokens"});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code == 0);
+    const auto js = read_text(js_out);
+    // COLOR_DODGE → normalized to the CSS keyword and emitted on the Glow node.
+    REQUIRE(js.find("setMixBlendMode('Glow") != std::string::npos);
+    REQUIRE(js.find("'color-dodge')") != std::string::npos);
+    // PASS_THROUGH is a no-op → no blend call for the Plain node.
+    REQUIRE(js.find("setMixBlendMode('Plain") == std::string::npos);
+}
+
 TEST_CASE("pulp import-design lowers an SVG path node to a native SvgPath (end-to-end)",
           "[cli][import-design][vector][shellout]") {
     // Full pipeline: the figma-plugin parser routes a `path` node carrying `d`

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -4407,6 +4407,37 @@ TEST_CASE("codegen lowers a path-data vector to a native SvgPath (not dropped)",
     }
 }
 
+TEST_CASE("codegen emits mix-blend-mode on native + web-compat paths",
+          "[view][import][codegen][blend]") {
+    // A node's normalized mix_blend_mode lowers to setMixBlendMode (native
+    // bridge -> View::set_mix_blend_mode) and style.mixBlendMode (web-compat).
+    DesignIR ir;
+    ir.root.type = "frame";
+    ir.root.name = "Root";
+
+    IRNode overlay;
+    overlay.type = "frame";
+    overlay.name = "Overlay";
+    overlay.style.width = 100.0f;
+    overlay.style.height = 100.0f;
+    overlay.style.background_color = "#ff0000";
+    overlay.style.mix_blend_mode = "multiply";
+    ir.root.children.push_back(overlay);
+
+    CodeGenOptions nopts;
+    nopts.mode = CodeGenMode::bridge_native_js;
+    const auto njs = generate_pulp_js(ir, nopts);
+    INFO("native:\n" << njs);
+    CHECK(njs.find("setMixBlendMode('Overlay") != std::string::npos);
+    CHECK(njs.find("'multiply')") != std::string::npos);
+
+    CodeGenOptions wopts;
+    wopts.mode = CodeGenMode::web_compat;
+    const auto wjs = generate_pulp_js(ir, wopts);
+    INFO("web:\n" << wjs);
+    CHECK(wjs.find("mixBlendMode = 'multiply'") != std::string::npos);
+}
+
 TEST_CASE("web-compat codegen also runs the image-sizing fidelity check",
           "[view][import][codegen][fidelity][web-compat]") {
     // Codex #3267: fidelity checks previously ran only in the native-bridge


### PR DESCRIPTION
mix-blend-mode was captured by some source adapters but dropped in the
normalized IR, so an imported layer's blend never reached the screen even
though the engine already supports it (View::set_mix_blend_mode +
save_layer_with_blend, and the setMixBlendMode bridge).

- IRStyle gains `mix_blend_mode`; parse_ir_style reads `mixBlendMode` (both
  spellings) and the figma-plugin `figma.blend_mode` block, normalizing the
  keyword to its CSS lowercase-hyphen form (Figma `COLOR_DODGE` ->
  `color-dodge`); `normal` / `PASS_THROUGH` drop to no blend.
- codegen emits it on container / image / text / svg_path nodes: web-compat
  `style.mixBlendMode`, native `setMixBlendMode(id, kw)`. The IR-json writer
  round-trips it (`mixBlendMode`).
- compat.json object-coverage: mix-blend-mode parsed missing->handled,
  codegen missing->partial (audio-widget nodes not yet covered).

Source-agnostic (keyed on the normalized IR keyword, never a layer name).
ELYSIUM faithful import still passes --strict-fidelity.

Tests: [view][import][blend] codegen (native setMixBlendMode + web
style.mixBlendMode) and an end-to-end CLI shell-out asserting Figma
COLOR_DODGE normalizes + emits while PASS_THROUGH is dropped.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>