### PR TITLE
fix(import-design): coerce CSS string dimensions to floats (no degenerate dims)

### DIFF
--- a/core/view/src/design_ir_json.cpp
+++ b/core/view/src/design_ir_json.cpp
@@ -217,7 +217,21 @@ static IRStyle parse_ir_style(const choc::value::ValueView& obj) {
         if (auto k = resolve_key(key)) field = std::string(obj[k->c_str()].toString());
     };
     auto set_opt_float = [&](const char* key, std::optional<float>& field) {
-        if (auto k = resolve_key(key)) field = static_cast<float>(obj[k->c_str()].getWithDefault<double>(0));
+        auto k = resolve_key(key);
+        if (!k) return;
+        const auto& v = obj[k->c_str()];
+        // v0 / Stitch / Pencil emit CSS string dimensions ("100px", "12") where
+        // the figma-plugin lane emits a bare number. getWithDefault<double> on a
+        // string returns 0, which silently degenerates the dimension (a "1px"
+        // border or width collapses to 0). Coerce a px-suffixed / numeric string
+        // through the shared length parser; a non-length string (e.g. "auto",
+        // "50%") leaves the field unset for the sizing-mode path to handle.
+        if (v.isString()) {
+            float parsed = 0.0f;
+            if (bxsh_parse_length(std::string(v.toString()), parsed)) field = parsed;
+        } else {
+            field = static_cast<float>(v.getWithDefault<double>(0));
+        }
     };
     auto set_opt_int = [&](const char* key, std::optional<int>& field) {
         if (auto k = resolve_key(key)) field = static_cast<int>(obj[k->c_str()].getWithDefault<int64_t>(0));

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -302,6 +302,32 @@ TEST_CASE("parse_design_source recognizes valid sources", "[view][import]") {
     REQUIRE_FALSE(parse_design_source("unknown").has_value());
 }
 
+TEST_CASE("parse coerces CSS string dimensions to floats", "[view][import][parse]") {
+    // v0 / Stitch / Pencil emit CSS string dims ("100px", "12"); a bare
+    // getWithDefault<double> on a string returns 0 and degenerates the
+    // dimension. parse_ir_style now routes string values through the length
+    // parser so px-suffixed and numeric strings coerce correctly.
+    const std::string json = R"({
+      "version": 1, "source": "figma",
+      "root": {"type": "frame", "name": "Root",
+        "style": {"width": "120px", "height": "80", "borderWidth": "1px",
+                  "opacity": "0.5"}}
+    })";
+    const auto ir = parse_design_ir_json(json);
+    REQUIRE(ir.root.style.width == 120.0f);
+    REQUIRE(ir.root.style.height == 80.0f);
+    REQUIRE(ir.root.style.border_width == 1.0f);
+    REQUIRE(ir.root.style.opacity == 0.5f);
+
+    // A non-length string ("auto", "50%") is NOT a px length, so the float
+    // field stays unset for the sizing-mode / percent path to interpret.
+    const auto ir2 = parse_design_ir_json(
+        R"({"version":1,"source":"figma",
+            "root":{"type":"frame","style":{"width":"auto","height":"50%"}}})");
+    REQUIRE_FALSE(ir2.root.style.width.has_value());
+    REQUIRE_FALSE(ir2.root.style.height.has_value());
+}
+
 TEST_CASE("design_source_name returns display names", "[view][import]") {
     REQUIRE(std::string(design_source_name(DesignSource::figma)) == "Figma");
     REQUIRE(std::string(design_source_name(DesignSource::v0)) == "v0");


### PR DESCRIPTION
v0 / Stitch / Pencil emit CSS string dimensions ("100px", "12") where the
figma-plugin lane emits a bare number. parse_ir_style's set_opt_float ran
every value through choc's getWithDefault<double>, which returns 0 for a
string — so a string width/height/borderWidth silently collapsed to 0 (a
"1px" border vanished, a "120px" frame degenerated). String values now route
through the shared bxsh_parse_length parser (px-suffixed or numeric); a
non-length string ("auto", "50%") leaves the float field unset for the
sizing-mode / percent path to interpret. One change fixes every float style
field. Source-agnostic, IR-level.

Test: [view][import][parse] — "120px"/"80"/"1px"/"0.5" coerce; "auto"/"50%"
stay unset.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>