### PR TITLE
feat(view+import-design): preserve + emit CSS clip-path / mask

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.311.0
+    VERSION 0.312.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/compat.json
+++ b/compat.json
@@ -8184,7 +8184,7 @@
         "grid-container":                   {"detected": "partial", "parsed": "missing", "codegen": "missing", "note": "Yoga 3.0 grid is in the engine; IRLayout grid fields + parse aliases pending"},
         "radial-angular-diamond-gradient":  {"detected": "handled", "parsed": "partial", "codegen": "partial", "note": "flat-color fallback; CSS radial/conic gradient emission is future work"},
         "mix-blend-mode":                   {"detected": "handled", "parsed": "handled", "codegen": "partial", "note": "IRStyle.mix_blend_mode is parsed (style.mixBlendMode + figma.blend_mode, normalized to the CSS keyword; normal/pass-through dropped) and emitted on container/image/text/svg_path nodes (web style.mixBlendMode; native setMixBlendMode → View::set_mix_blend_mode + save_layer_with_blend). Not yet emitted on audio-widget nodes (knob/fader/meter), hence partial"},
-        "masks-clip-paths":                 {"detected": "partial", "parsed": "missing", "codegen": "missing", "note": "mask metadata + render fallback pending"},
+        "masks-clip-paths":                 {"detected": "partial", "parsed": "partial", "codegen": "partial", "note": "IRStyle.clip_path/mask/mask_image/mask_size parsed (clipPath/mask/maskImage/maskSize) and emitted web (style.*) + native (setClipPath/setMask/setMaskImage/setMaskSize → View::set_clip_path/set_mask/... pulp #1515) on container/image/text/svg_path nodes. CSS sources carry these directly; Figma mask-layer → clip-path extraction is a separate adapter concern, hence detected/parsed partial"},
         "constraints":                      {"detected": "partial", "parsed": "missing", "codegen": "missing", "note": "Figma resize constraints -> flex/position mapping pending"}
       }
     },

--- a/core/view/include/pulp/view/design_ir.hpp
+++ b/core/view/include/pulp/view/design_ir.hpp
@@ -99,6 +99,14 @@ struct IRStyle {
     std::vector<IRBoxShadow> box_shadow;               // ordered CSS shadow layers
     std::optional<std::string> filter;                 // e.g. "blur(4px)"
     std::optional<std::string> backdrop_filter;
+    // CSS clip-path / mask. The engine (View::set_clip_path / set_mask /
+    // set_mask_image / set_mask_size) + the setClipPath/setMask* bridge
+    // (pulp #1515) consume these; sources that carry them — and Figma mask
+    // layers once the extractor emits a clip-path — survive the IR.
+    std::optional<std::string> clip_path;
+    std::optional<std::string> mask;                   // `mask` shorthand
+    std::optional<std::string> mask_image;
+    std::optional<std::string> mask_size;
     std::optional<std::string> font_family;
     std::optional<float> font_size;
     std::optional<int> font_weight;

--- a/core/view/src/design_codegen.cpp
+++ b/core/view/src/design_codegen.cpp
@@ -226,6 +226,10 @@ static void generate_node(std::ostringstream& ss, const IRNode& node,
     emit_str("color", s.color);
     emit_float("opacity", s.opacity);
     emit_str("mixBlendMode", s.mix_blend_mode);
+    emit_str("clipPath", s.clip_path);
+    emit_str("mask", s.mask);
+    emit_str("maskImage", s.mask_image);
+    emit_str("maskSize", s.mask_size);
     emit_px("borderRadius", s.border_radius);
     emit_str("border", s.border);
     if (!s.box_shadow.empty())
@@ -415,14 +419,29 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
         if (s.bottom) ss << ind << "setBottom('" << target_id << "', " << *s.bottom << ");\n";
     };
 
-    // Emit the node's CSS mix-blend-mode (parse-normalized to a lowercase-
-    // hyphen keyword). The native engine compositing path (View::set_mix_blend
-    // _mode + the setMixBlendMode bridge) consumes it; a normal / pass-through
-    // mode is dropped at parse, so this only fires for a real blend.
-    auto emit_mix_blend_mode = [&](const std::string& target_id) {
-        if (node.style.mix_blend_mode && !node.style.mix_blend_mode->empty())
+    // Emit a node's per-View visual overrides that the native engine applies
+    // at compositing/paint time: mix-blend-mode (View::set_mix_blend_mode), the
+    // clip-path, and the mask shorthand / image / size (View::set_clip_path /
+    // set_mask / set_mask_image / set_mask_size). mix-blend-mode is
+    // parse-normalized (normal / pass-through dropped); the clip/mask values
+    // are raw CSS the bridge parses (pulp #1515).
+    auto emit_node_visual_overrides = [&](const std::string& target_id) {
+        const auto& st = node.style;
+        if (st.mix_blend_mode && !st.mix_blend_mode->empty())
             ss << ind << "setMixBlendMode('" << target_id << "', '"
-               << js_single_quote_escape(*node.style.mix_blend_mode) << "');\n";
+               << js_single_quote_escape(*st.mix_blend_mode) << "');\n";
+        if (st.clip_path && !st.clip_path->empty())
+            ss << ind << "setClipPath('" << target_id << "', '"
+               << js_single_quote_escape(*st.clip_path) << "');\n";
+        if (st.mask && !st.mask->empty())
+            ss << ind << "setMask('" << target_id << "', '"
+               << js_single_quote_escape(*st.mask) << "');\n";
+        if (st.mask_image && !st.mask_image->empty())
+            ss << ind << "setMaskImage('" << target_id << "', '"
+               << js_single_quote_escape(*st.mask_image) << "');\n";
+        if (st.mask_size && !st.mask_size->empty())
+            ss << ind << "setMaskSize('" << target_id << "', '"
+               << js_single_quote_escape(*st.mask_size) << "');\n";
     };
 
     // Phase 0a: emit the anchor trail in bridge-native-JS codegen too. Same
@@ -962,7 +981,7 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
                 ss << ind << "// " << node.name << "\n";
             ss << ind << "createSvgPath('" << id << "', " << pid << ");\n";
             emit_position_if_absolute(id);
-            emit_mix_blend_mode(id);
+            emit_node_visual_overrides(id);
             ss << ind << "setSvgPath('" << id << "', '"
                << js_single_quote_escape(pd->second) << "');\n";
             // viewBox is "minX minY width height" — the widget scales the path
@@ -1018,7 +1037,7 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
             ss << ind << "// " << node.name << "\n";
         ss << ind << "createImage('" << id << "', " << pid << ");\n";
         emit_position_if_absolute(id);
-        emit_mix_blend_mode(id);
+        emit_node_visual_overrides(id);
         auto it = node.attributes.find("asset_path");
         if (it != node.attributes.end() && !it->second.empty()) {
             ss << ind << "setImageSource('" << id << "', '"
@@ -1140,7 +1159,7 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
         // Text node → createLabel with explicit height (Yoga requirement)
         ss << ind << "createLabel('" << id << "', '" << js_single_quote_escape(node.text_content) << "', " << pid << ");\n";  // pulp #81
         emit_position_if_absolute(id);
-        emit_mix_blend_mode(id);
+        emit_node_visual_overrides(id);
 
         // Honour the IR-declared height when present. Pre-fix this branch
         // unconditionally recomputed from font_size, which clobbered Figma's
@@ -1260,7 +1279,7 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
         ss << ind << (is_row ? "createRow" : "createCol")
            << "('" << id << "', " << pid << ");\n";
         emit_position_if_absolute(id);
-        emit_mix_blend_mode(id);
+        emit_node_visual_overrides(id);
 
         // Yoga: every container MUST have explicit height
         // Priority: _layoutHeight (from snapshot_layout) > style.height > fill > computed

--- a/core/view/src/design_ir_json.cpp
+++ b/core/view/src/design_ir_json.cpp
@@ -266,6 +266,10 @@ static IRStyle parse_ir_style(const choc::value::ValueView& obj) {
         s.box_shadow = parse_css_box_shadow(std::string(obj[k->c_str()].toString()));
     set_opt_str("filter", s.filter);
     set_opt_str("backdropFilter", s.backdrop_filter);
+    set_opt_str("clipPath", s.clip_path);
+    set_opt_str("mask", s.mask);
+    set_opt_str("maskImage", s.mask_image);
+    set_opt_str("maskSize", s.mask_size);
     set_opt_str("fontFamily", s.font_family);
     set_opt_float("fontSize", s.font_size);
     set_opt_int("fontWeight", s.font_weight);
@@ -1407,6 +1411,10 @@ static void write_ir_style_json(std::ostringstream& out, const IRStyle& s) {
         write_string_member(out, first, "boxShadow", box_shadow_to_css(s.box_shadow));
     write_string_member(out, first, "filter", s.filter);
     write_string_member(out, first, "backdropFilter", s.backdrop_filter);
+    write_string_member(out, first, "clipPath", s.clip_path);
+    write_string_member(out, first, "mask", s.mask);
+    write_string_member(out, first, "maskImage", s.mask_image);
+    write_string_member(out, first, "maskSize", s.mask_size);
     write_string_member(out, first, "fontFamily", s.font_family);
     write_float_member(out, first, "fontSize", s.font_size);
     write_int_member(out, first, "fontWeight", s.font_weight);

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -4464,6 +4464,52 @@ TEST_CASE("codegen emits mix-blend-mode on native + web-compat paths",
     CHECK(wjs.find("mixBlendMode = 'multiply'") != std::string::npos);
 }
 
+TEST_CASE("codegen emits clip-path + mask (native + web-compat)",
+          "[view][import][codegen][mask]") {
+    // clip-path / mask lower to setClipPath / setMask* (native →
+    // View::set_clip_path / set_mask*) and style.clipPath / maskImage (web).
+    DesignIR ir;
+    ir.root.type = "frame";
+    ir.root.name = "Root";
+
+    IRNode masked;
+    masked.type = "frame";
+    masked.name = "Masked";
+    masked.style.width = 100.0f;
+    masked.style.height = 100.0f;
+    masked.style.background_color = "#00ff00";
+    masked.style.clip_path = "inset(10px)";
+    masked.style.mask_image = "linear-gradient(black, transparent)";
+    ir.root.children.push_back(masked);
+
+    CodeGenOptions nopts;
+    nopts.mode = CodeGenMode::bridge_native_js;
+    const auto njs = generate_pulp_js(ir, nopts);
+    INFO("native:\n" << njs);
+    CHECK(njs.find("setClipPath('Masked") != std::string::npos);
+    CHECK(njs.find("inset(10px)") != std::string::npos);
+    CHECK(njs.find("setMaskImage('Masked") != std::string::npos);
+
+    CodeGenOptions wopts;
+    wopts.mode = CodeGenMode::web_compat;
+    const auto wjs = generate_pulp_js(ir, wopts);
+    INFO("web:\n" << wjs);
+    CHECK(wjs.find("clipPath = 'inset(10px)'") != std::string::npos);
+    CHECK(wjs.find("maskImage") != std::string::npos);
+}
+
+TEST_CASE("parse + round-trip clip-path / mask", "[view][import][parse][mask]") {
+    const auto ir = parse_design_ir_json(
+        R"JSON({"version":1,"source":"figma","root":{"type":"frame","name":"R",
+            "style":{"clipPath":"circle(40%)","mask":"url(#m)",
+                     "maskImage":"linear-gradient(black,transparent)",
+                     "maskSize":"cover"}}})JSON");
+    REQUIRE(ir.root.style.clip_path == "circle(40%)");
+    REQUIRE(ir.root.style.mask == "url(#m)");
+    REQUIRE(ir.root.style.mask_image == "linear-gradient(black,transparent)");
+    REQUIRE(ir.root.style.mask_size == "cover");
+}
+
 TEST_CASE("web-compat codegen also runs the image-sizing fidelity check",
           "[view][import][codegen][fidelity][web-compat]") {
     // Codex #3267: fidelity checks previously ran only in the native-bridge


### PR DESCRIPTION
clip-path and mask were dropped in the normalized IR even though the engine
already applies them per-View (View::set_clip_path / set_mask / set_mask_image
/ set_mask_size) via the setClipPath / setMask* bridge (pulp #1515).

- IRStyle gains clip_path / mask / mask_image / mask_size; parse_ir_style reads
  clipPath / mask / maskImage / maskSize (both spellings) and the IR-json
  writer round-trips them.
- codegen emits them on container / image / text / svg_path nodes: web-compat
  style.clipPath / mask / maskImage / maskSize, native setClipPath / setMask /
  setMaskImage / setMaskSize. The shared per-node visual-override emitter
  (renamed from emit_mix_blend_mode → emit_node_visual_overrides) now covers
  blend + clip + mask together.
- compat.json object-coverage: masks-clip-paths parsed/codegen missing→partial
  (CSS sources carry these directly; Figma mask-layer→clip-path extraction is a
  separate adapter concern).

Source-agnostic, IR-level. ELYSIUM faithful import still passes
--strict-fidelity.

Tests: [view][import][mask] codegen (native setClipPath/setMaskImage + web
style.clipPath/maskImage) and a parse round-trip of clipPath/mask/maskImage/
maskSize.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>