### PR TITLE
feat(view+ios): full-width responsive iOS AUv3 editor + working host slider

### DIFF
--- a/.agents/skills/auv3/SKILL.md
+++ b/.agents/skills/auv3/SKILL.md
@@ -599,9 +599,14 @@ directly while cfprefsd is killed.
 `PulpAUMacViewController` + `PulpAUViewController` implement
 `AUAudioUnitFactory`, open `ViewBridge` against the AU's real
 `pulpProcessor` + `pulpStore`, build `PluginViewHost` via
-`decide_gpu_host`, and call `set_design_viewport(w, h)` +
+`decide_gpu_host`, and (on macOS) call `set_design_viewport(w, h)` +
 `set_fixed_aspect_ratio(w/h)` so the editor paints at design size and
-host-driven window resize is letterboxed proportionally.
+host-driven window resize is letterboxed proportionally. **iOS differs:**
+`au_view_controller_ios.mm` deliberately does NOT force a design viewport —
+it lays the root out at the actual pane bounds so a responsive flex scene
+fills edge-to-edge (aspect-locked scaling left dark letterbox bars on the
+sides and pushed header text to the edge). A fixed-aspect iOS editor that
+needs letterboxing can call `set_design_viewport` itself; see the `ios` skill.
 
 On macOS, the view controller's root view must be created at the
 compile-time design size when `PULP_PLUGIN_DESIGN_W/H` are available.

--- a/.agents/skills/ios/SKILL.md
+++ b/.agents/skills/ios/SKILL.md
@@ -279,18 +279,32 @@ xcodebuild test -project ... -scheme AUv3Tests -sdk iphonesimulator
   real `__dispatch__(<canvas._id>, 'pointermove', {...})` entrypoint (the same
   one the native handlers call) from a hot-patched `scene.js` and assert camera
   state / `document`-level listener counts in the `dev.pulp.runtime` log.
-- **GPU AUv3 editor design-viewport scaling** — `IOSGpuPluginViewHost` now
-  overrides `set_design_viewport`/`set_fixed_aspect_ratio`/
-  `set_design_viewport_top_align`/`window_to_root_point` (they were base
-  no-ops, so the AU view controller's existing calls did nothing and the
-  design rendered at native size in the pane's top-left). `render_frame` lays
-  the root out at the design size and applies an aspect-correct translate+scale
-  to the Skia canvas; the Three.js cube composites through that same scaled
-  canvas (`CanvasWidget` draws its Dawn texture at the widget's bounds), so it
-  scales coherently with the 2D UI. To actually fill the iPad pane you ALSO
-  need `templates/ios-auv3/HostApp/ContentView.swift` to give the editor
-  `.frame(maxWidth:.infinity, maxHeight:.infinity)` — without it SwiftUI pins
-  the editor to its intrinsic `preferredContentSize`.
+- **GPU AUv3 editor fills the pane (responsive), no forced design viewport** —
+  `IOSGpuPluginViewHost` CAN scale a fixed design viewport (it overrides
+  `set_design_viewport`/`set_fixed_aspect_ratio`/`set_design_viewport_top_align`/
+  `window_to_root_point`, and `render_frame` applies an aspect-correct
+  translate+scale that the Three.js cube composites through coherently). BUT
+  the iOS AU view controller (`au_view_controller_ios.mm`) deliberately does
+  NOT force a design viewport: aspect-locked scaling letterboxed the pane (dark
+  bars on the sides) and pushed header text to the edge. It instead lays the
+  root out at the ACTUAL pane bounds (`resizeEditorToViewBounds` → `set_size` +
+  `bridge->resize`) so a responsive flex scene fills edge-to-edge. The scene
+  must be responsive to benefit: `examples/ios-auv3-jsc-threejs/js/scene.js`
+  flex-fills the body/shell at `width:100%` and `syncCanvasSize()` resizes the
+  Three.js drawing buffer + camera aspect to the canvas's measured size each
+  frame (a fixed-size canvas would just sit small in a wide pane). To fill the
+  pane you ALSO need `ContentView.swift` to give the editor
+  `.frame(maxWidth:.infinity, maxHeight:.infinity)`. A genuinely fixed-aspect
+  editor that wants letterboxing can call `set_design_viewport` itself.
+- **Host-app AUParameter slider must mirror value in `@State`** — binding a
+  SwiftUI `Slider` straight to `AUParameter.value` (get/set) does NOT update:
+  SwiftUI doesn't observe `AUParameter`, so dragging writes the param but never
+  re-renders, leaving the thumb + readout stuck at 0.00. The `ParameterRow`
+  view in `templates/ios-auv3/HostApp/ContentView.swift` mirrors the value in
+  `@State` (slider + readout bind to that, so they move live), writes through
+  in `onChange` via `setValue(_, originator: token)`, and installs an
+  `AUParameterObserverToken` to reflect host/automation changes back — passing
+  the token as originator so the observer doesn't echo the gesture.
 
 ### Plugin Editor Child Views
 

--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -139,6 +139,16 @@ move `notify_attached()` back inline; it reintroduces the first-paint clip.
 Rationale + the view-config/first-paint root cause are in
 `.agents/skills/auv3/SKILL.md → "Logic OOP first-paint clip"`. The same controller also calls `set_design_viewport_top_align(true)` so the AU design anchors to the TOP of a taller host pane (REAPER FX-chain) like CLAP/VST3 instead of centering between bands — see the auv3 SKILL.
 
+**iOS editor sizing differs from macOS — it FILLS the pane.**
+`au_view_controller_ios.mm` deliberately does NOT pin a design viewport: it
+lays the root out at the actual pane bounds (via `resizeEditorToViewBounds` →
+`set_size` + `ViewBridge::resize`) so a responsive flex scene fills edge-to-edge.
+Aspect-locked design-viewport scaling letterboxed the pane (dark bars on the
+sides) and pushed header text to the edge. The `notify_attached` → `resize`
+protocol is unchanged; only the viewport policy differs. A genuinely
+fixed-aspect iOS editor that wants letterboxing can call `set_design_viewport`
+itself. See the `ios` skill for the responsive-scene + `syncCanvasSize` contract.
+
 ## AU v2 dual-Processor gotcha (fixed)
 
 Pre-ViewBridge, the AU v2 Cocoa view factory called

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.155.0",
+      "version": "0.156.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.155.0"
+  "version": "0.156.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.155.0",
+  "version": "0.156.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.310.0
+    VERSION 0.311.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/src/au_view_controller_ios.mm
+++ b/core/format/src/au_view_controller_ios.mm
@@ -200,13 +200,16 @@
         return;
     }
 
-    // Phase 3 viewport pin + aspect lock — paint at design size; host owns
-    // window size; PluginViewHost scales the paint/input transform.
-    if (w > 0 && h > 0) {
-        _viewHost->set_design_viewport(w, h);
-        _viewHost->set_fixed_aspect_ratio(static_cast<float>(w) /
-                                          static_cast<float>(h));
-    }
+    // iOS AU editors FILL the host pane and let the scripted UI reflow
+    // responsively — Pulp scenes are flex-based and adapt to any size. We
+    // deliberately do NOT pin a fixed design viewport here: aspect-locked
+    // letterboxing scaled the design uniformly and left dark bars on the
+    // sides of a scene (e.g. the Three.js cube) that can fill any size, and
+    // pushed header text to the pane edge. Laying the root out at the actual
+    // pane bounds (resizeEditorToViewBounds drives set_size + bridge resize)
+    // lets a responsive scene fill edge-to-edge. A fixed-design editor that
+    // genuinely needs letterboxing can call set_design_viewport itself.
+    // (#3286 follow-up — full-width responsive editor.)
 
     _viewHost->attach_to_parent((__bridge void*)self.view);
     if (_bridge) _bridge->notify_attached();

--- a/examples/ios-auv3-jsc-threejs/js/scene.js
+++ b/examples/ios-auv3-jsc-threejs/js/scene.js
@@ -92,12 +92,11 @@
     document.body.style.backgroundColor = "#040912";
     document.body.style.padding = "18px";
 
-    // iOS-D.3c polish: flex-fill the body so the shell uses whatever size the
-    // host hands the editor. The AUv3 GPU host pins the root to the 540×720
-    // design viewport and scales the composited output up to the editor pane
-    // (set_design_viewport in plugin_view_host_ios.mm), so filling the body
-    // here means the shell — and the cube card inside it — fill that pane
-    // edge-to-edge instead of sitting at a fixed size in one corner.
+    // Flex-fill the body so the shell uses the full editor pane the host hands
+    // us. The iOS AU editor now lays the root out at the actual pane bounds
+    // (no fixed design viewport — see au_view_controller_ios.mm), so a body +
+    // shell at width:100% fill the pane edge-to-edge with no letterbox bars;
+    // `syncCanvasSize()` then sizes the cube canvas to match.
     document.body.style.flexDirection = "column";
     document.body.style.width = "100%";
     document.body.style.height = "100%";
@@ -158,24 +157,28 @@
     shell.appendChild(subtitle);
 
     var canvasCard = document.createElement("div");
+    canvasCard.style.flexDirection = "column";  // so the canvas can flex-fill it
     canvasCard.style.flexGrow = "1";
     canvasCard.style.padding = "12px";
     canvasCard.style.backgroundColor = "#06101c";
     canvasCard.style.borderRadius = "16px";
     shell.appendChild(canvasCard);
 
-    // ── Canvas: sized in CSS pixels; Three.js sets the drawing buffer
-    //    via `renderer.setSize` below. The exact pixel size is less
-    //    important than the canvas existing before
-    //    `canvas.getContext('webgpu')` is queried.
+    // ── Canvas: flex-fills the card so it tracks the full editor width.
+    //    The width/height ATTRIBUTES seed the drawing buffer before
+    //    `getContext('webgpu')` is queried; `syncCanvasSize()` (in the frame
+    //    loop) then resizes the buffer + camera to the canvas's measured
+    //    layout size so the cube fills whatever width the pane gives it,
+    //    without stretching.
     var canvasWidth = Math.max(260, rootWidth - 84);
     var canvasHeight = Math.max(320, rootHeight - 220);
     var canvasEl = document.createElement("canvas");
     canvasEl.id = "pulp-three-demo-canvas";
     canvasEl.width = canvasWidth;
     canvasEl.height = canvasHeight;
-    canvasEl.style.width = canvasWidth + "px";
-    canvasEl.style.height = canvasHeight + "px";
+    canvasEl.style.width = "100%";
+    canvasEl.style.height = "100%";
+    canvasEl.style.flexGrow = "1";
     canvasEl.style.borderRadius = "12px";
     canvasCard.appendChild(canvasEl);
 
@@ -292,6 +295,38 @@
             + "(three.iife.js bundle did not include the OrbitControls addon).");
     }
 
+    // Responsive sizing: the editor fills the host pane (no fixed design
+    // viewport), so the canvas card can be any size/aspect. Track the canvas's
+    // laid-out size each frame and resize the Three.js drawing buffer + camera
+    // aspect to match, so the cube fills the full-width canvas without
+    // stretching. Only acts when the measured size actually changes, so it's a
+    // cheap getBoundingClientRect compare on a static pane.
+    // Measure the CARD (a plain div that flex-stretches to the full pane
+    // width), not the canvas: Pulp's CanvasWidget lays out from its width/height
+    // ATTRIBUTES (the drawing buffer), not CSS flex, so a canvas left at its
+    // initial 456px never grows. We drive the canvas attributes — and the
+    // Three.js drawing buffer + camera aspect — from the card's measured
+    // content box so the cube fills whatever width the pane gives us.
+    var CARD_PAD = 12;  // canvasCard padding (keep in sync with the style above)
+    var lastCanvasW = 0, lastCanvasH = 0;
+    function syncCanvasSize() {
+        var rect = (typeof canvasCard.getBoundingClientRect === "function")
+            ? canvasCard.getBoundingClientRect() : null;
+        if (!rect) return;
+        var w = Math.round(rect.width) - CARD_PAD * 2;
+        var h = Math.round(rect.height) - CARD_PAD * 2;
+        if (w <= 0 || h <= 0) return;                 // layout not ready yet
+        if (w === lastCanvasW && h === lastCanvasH) return;
+        lastCanvasW = w;
+        lastCanvasH = h;
+        canvasEl.width = w;   // drawing buffer == card content; widget lays out here
+        canvasEl.height = h;
+        // false → don't let Three.js overwrite our CSS sizing.
+        renderer.setSize(w, h, false);
+        camera.aspect = w / h;
+        camera.updateProjectionMatrix();
+    }
+
     var firstFrameSubmitted = false;
     var frameCount = 0;
     var lastSampleTime = 0;
@@ -317,6 +352,7 @@
     // is itself driven by the iOS PluginViewHost's `idle_callback_`
     // running before the per-vsync repaint (pulp #1402 contract).
     function tick() {
+        syncCanvasSize();  // fill whatever width the pane currently gives us
         cube.rotation.x += 0.01;
         cube.rotation.y += 0.01;
         // OrbitControls orbits the CAMERA around the target; the cube's own

--- a/templates/ios-auv3/HostApp/ContentView.swift
+++ b/templates/ios-auv3/HostApp/ContentView.swift
@@ -58,19 +58,7 @@ struct ContentView: View {
             }
 
             ForEach(host.parameters, id: \.address) { p in
-                HStack {
-                    Text(p.displayName).frame(maxWidth: .infinity, alignment: .leading)
-                    Slider(
-                        value: Binding(
-                            get: { Double(p.value) },
-                            set: { p.value = AUValue($0) }
-                        ),
-                        in: Double(p.minValue)...Double(p.maxValue)
-                    )
-                    Text(String(format: "%.2f", p.value))
-                        .frame(width: 56, alignment: .trailing)
-                        .monospacedDigit()
-                }
+                ParameterRow(param: p)
             }
 
             // Phase iOS-D.2 — mount the AUv3 extension's own view inside
@@ -153,6 +141,52 @@ struct ContentView: View {
                     if host.audioUnit != nil { return }
                     host.discover()
                 }
+            }
+        }
+    }
+}
+
+// One parameter row. The earlier inline `Slider(value: Binding(get/set))`
+// bound straight to `AUParameter.value`, which SwiftUI does not observe — so
+// dragging wrote the AU param but never re-rendered, leaving the thumb and the
+// "0.00" readout stuck. Mirroring the value in `@State` makes the slider move
+// and the number update live as you drag, while `onChange` writes through to
+// the AU parameter, and an observer reflects host/automation changes back.
+@available(iOS 15.0, macOS 12.0, *)
+private struct ParameterRow: View {
+    let param: AUParameter
+    @State private var value: Double
+    @State private var observerToken: AUParameterObserverToken?
+
+    init(param: AUParameter) {
+        self.param = param
+        _value = State(initialValue: Double(param.value))
+    }
+
+    var body: some View {
+        HStack {
+            Text(param.displayName).frame(maxWidth: .infinity, alignment: .leading)
+            Slider(value: $value, in: Double(param.minValue)...Double(param.maxValue))
+                .onChange(of: value) { newValue in
+                    // Write through as the user drags. Pass our own observer
+                    // token as originator so the observer below doesn't echo
+                    // this back into `value` and fight the gesture.
+                    param.setValue(AUValue(newValue), originator: observerToken)
+                }
+            Text(String(format: "%.2f", value))
+                .frame(width: 56, alignment: .trailing)
+                .monospacedDigit()
+        }
+        .onAppear {
+            value = Double(param.value)
+            observerToken = param.token(byAddingParameterObserver: { _, newValue in
+                Task { @MainActor in value = Double(newValue) }
+            })
+        }
+        .onDisappear {
+            if let token = observerToken {
+                param.removeParameterObserver(token)
+                observerToken = nil
             }
         }
     }


### PR DESCRIPTION
Follow-up polish to the iOS Three.js cube demo (#3286), verified on a
physical iPad Pro:

- Full-width, no letterbox. The iOS AU view controller no longer forces a
  fixed design viewport on the GPU editor — aspect-locked scaling left dark
  bars on the sides of a scene that can fill any size and pushed header text
  to the edge. au_view_controller_ios.mm now lays the root out at the actual
  pane bounds and lets the responsive flex scene fill edge-to-edge. The host
  GPU design-viewport overrides remain available for genuinely fixed-aspect
  editors to opt into.
- Responsive canvas. scene.js flex-fills the body/shell at width:100% and a
  new syncCanvasSize() resizes the Three.js drawing buffer + camera aspect to
  the canvas card's measured size each frame, so the cube fills whatever width
  the pane gives it without stretching. (Pulp's CanvasWidget lays out from the
  width/height attributes, not CSS flex, so we measure the card — a plain div
  that does flex-stretch — and drive the canvas attributes from it.)
- Working host slider. Binding a SwiftUI Slider straight to AUParameter.value
  never updated — SwiftUI doesn't observe AUParameter, so dragging wrote the
  param but never re-rendered, leaving the thumb + readout stuck at 0.00. The
  new ParameterRow mirrors the value in @State (slider + readout move live),
  writes through in onChange, and installs an AUParameterObserverToken to
  reflect host/automation changes (passing the token as originator so the
  observer doesn't echo the gesture).

Platform-UI polish with no headless-testable surface (iOS AU view controller,
SwiftUI host template, demo JS); verified on the iOS Simulator and a physical
iPad (full-width render, drag-rotate, pinch-zoom, live slider).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>