### PR TITLE
ci(tart): Tart golden-VM macOS lane — layered goldens, ephemeral per-job runners, vm-image manifest

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -218,6 +218,20 @@ export ANDROID_HOME=~/Library/Android/sdk  # macOS
   (not just a development cert).
 - Check the notarization log: `xcrun notarytool log <UUID>`.
 
+### `check_notarization` and Gatekeeper-disabled CI environments
+
+`check_notarization(path)` runs `spctl --assess --type exec <path>`. On a stock
+Mac, `spctl --assess` returns non-zero for an unsigned or **nonexistent** path.
+But CI base images (notably the cirruslabs macOS bases used by the Tart VM lane)
+ship with Gatekeeper assessment **disabled** (`spctl --master-disable`), in which
+case `spctl --assess` returns **0 for any argument** — so it cannot distinguish a
+notarized binary from a bogus path. The fix (already applied in
+`ship/platform/mac/codesign_mac.mm`) is an explicit `fs::exists` short-circuit:
+a path that doesn't exist returns false before `spctl` is consulted, which is
+correct in both environments. If you add new spctl/codesign predicates, don't
+rely on `spctl --assess` alone for negative cases — guard with an existence /
+signature pre-check so they hold on Gatekeeper-disabled runners too.
+
 ### "Gradle build failed"
 
 - Run `pulp doctor` to check Android SDK/NDK/Java versions

--- a/.shipyard/vm-image.toml
+++ b/.shipyard/vm-image.toml
@@ -1,0 +1,57 @@
+# Pulp golden VM image manifest — the per-repo "unit of reuse" from
+# planning/2026-06-01-macos-ci-isolation-plan.md, Phase 3.
+#
+# One manifest, two strategies (see `strategy` below):
+#   • bake             — pre-bake a project image (fast clones for hot repos)
+#   • configure-on-boot — clone the bare base + apply this manifest on first boot
+#                          (flexible; good for new/low-volume repos)
+#
+# Consumed by tools/ci/tart-provision.sh (`manifest <path> <vm>`) today, and by
+# Shipyard's multi-Mac controller (Shipyard #316) when it lands. The schema is
+# deliberately small and declarative so a new repo only writes this file.
+schema   = 1
+name     = "pulp-build-base"
+strategy = "bake"
+
+# macOS 26 "Tahoe" matches Xcode 26.5 (build 17F42). Clones are CoW.
+base       = "ghcr.io/cirruslabs/macos-tahoe-base:latest"
+disk_gb    = 150
+auto_login = true          # REQUIRED for WindowServer/Metal GPU tests
+
+[toolchain]
+# Pin Xcode in-image so font/raster goldens are reproducible. Prefer copying a
+# host-installed Xcode (tart-provision PULP_HOST_XCODE_APP) over an in-guest
+# xcodes download (interactive 2FA).
+xcode = "26.5"
+
+[brew]
+# Tier 0 universal CI tooling + Tier 2 Pulp build deps.
+packages = [
+  "git", "gh", "rsync", "ccache", "jq", "coreutils", "tailscale",  # tier 0
+  "cmake", "ninja", "python@3.12",                                  # tier 2
+]
+
+[pip]
+# Visual-harness / screenshot tooling.
+packages = ["pillow", "numpy"]
+
+[caches]
+# ccache is the durable artifact; build dirs are disposable.
+ccache_max = "80G"
+
+# Host dirs mounted into each ephemeral job VM (virtio-fs). Paths are expanded
+# on the host; ccache TEMPDIR stays in-guest (handled by tart-run-job.sh).
+[[mounts]]
+name = "ccache"
+host = "~/.cache/pulp-ci/ccache"
+mode = "rw"
+
+[[mounts]]
+name = "skia"
+host = "~/.cache/pulp-ci/skia-build"
+mode = "ro"
+
+[[mounts]]
+name = "fetchcontent"
+host = "~/.cache/pulp-ci/fetchcontent-src"
+mode = "rw"

--- a/ship/platform/mac/codesign_mac.mm
+++ b/ship/platform/mac/codesign_mac.mm
@@ -130,6 +130,14 @@ SigningInfo check_codesign(const std::string& path) {
 }
 
 bool check_notarization(const std::string& path) {
+    // A path that doesn't exist cannot be notarized — short-circuit before
+    // consulting spctl. CI base images commonly disable Gatekeeper assessment
+    // (`spctl --master-disable`), in which case `spctl --assess` returns 0 for
+    // ANY argument (even a nonexistent path), so it can't be the sole signal.
+    // (Surfaced by the Tart VM CI lane: the cirruslabs macOS bases ship with
+    // assessment disabled, unlike a stock Mac where assess fails on a bad path.)
+    std::error_code ec;
+    if (!fs::exists(path, ec)) return false;
     return exec_status("spctl --assess --type exec \"" + path + "\" 2>/dev/null") == 0;
 }
 

--- a/tools/ci/examples/vm-image.rust-repo.toml
+++ b/tools/ci/examples/vm-image.rust-repo.toml
@@ -1,0 +1,35 @@
+# Example vm-image manifest for a SECOND, non-Pulp repo — proves the golden
+# image template generalizes (planning/2026-06-01-macos-ci-isolation-plan.md,
+# Phase 3 "reusable template" acceptance criterion).
+#
+# This is a light Rust profile (e.g. a `shipyard-build-base`): same Tier 0
+# universal base, but NO Xcode and NO Skia — just the rust toolchain. A new
+# repo drops a file like this in its own `.shipyard/vm-image.toml`; the same
+# tools/ci/tart-provision.sh bakes/clones it with zero hand-provisioning.
+#
+# Strategy `configure-on-boot` shows the other half of the template: instead of
+# pre-baking a project image, clone the bare macos-build-base and apply this
+# manifest on first boot. Good for new or low-volume repos that don't justify a
+# dedicated baked image.
+schema   = 1
+name     = "rust-build-base"
+strategy = "configure-on-boot"
+
+base       = "ghcr.io/cirruslabs/macos-tahoe-base:latest"
+disk_gb    = 80            # no Xcode/Skia → much smaller than Pulp's 150
+auto_login = false         # CLI/test-only repo; no GPU/WindowServer tests
+
+# No [toolchain].xcode key → tart-provision skips the entire Tier 1 Xcode step.
+
+[brew]
+# `rustup` is keg-only (not symlinked to PATH); a configure-on-boot repo would
+# run `"$(brew --prefix rustup)"/bin/rustup-init -y` to lay down the toolchain.
+packages = ["git", "gh", "rsync", "ccache", "jq", "rustup"]
+
+[caches]
+ccache_max = "20G"
+
+[[mounts]]
+name = "cargo"
+host = "~/.cache/rust-ci/cargo"
+mode = "rw"

--- a/tools/ci/pulp-worktree.sh
+++ b/tools/ci/pulp-worktree.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# pulp-worktree.sh — per-branch git worktrees with isolated build dirs and a
+# SHARED build cache, so parallel branch work never churns one build/ dir
+# (which caused ODR heap corruption: a hung free() in View::~View when objects
+# compiled against different IRStyle layouts were mixed — see
+# planning/2026-06-01-macos-ci-isolation-plan.md, Phase 1).
+#
+# Each worktree gets its OWN build/, but ccache + Skia + FetchContent sources
+# are shared from one cache root. ccache is configured to actually share across
+# worktrees (Codex review): CCACHE_BASEDIR points at the common worktree PARENT
+# (not a single workspace) so absolute paths normalize and hit-rates hold.
+#
+# Build dirs are disposable; ccache is the durable artifact. `gc` reclaims disk.
+#
+# Usage:
+#   pulp-worktree.sh new <branch> [--base origin/main]   # create + configure
+#   pulp-worktree.sh env <branch>                          # print cache env to source
+#   pulp-worktree.sh list                                  # worktrees + build-dir sizes
+#   pulp-worktree.sh gc [--max-total-gb N] [--max-age-days N] [--merged]
+#
+# Env overrides: PULP_WT_ROOT (default ../pulp-worktrees), PULP_CI_CACHE
+# (default ~/.cache/pulp-ci), PULP_CCACHE_MAX_SIZE (default 80G).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WT_ROOT="${PULP_WT_ROOT:-$(cd "$REPO_ROOT/.." && pwd)/pulp-worktrees}"
+CACHE_ROOT="${PULP_CI_CACHE:-$HOME/.cache/pulp-ci}"
+CCACHE_MAX_SIZE="${PULP_CCACHE_MAX_SIZE:-80G}"
+
+# CCACHE_BASEDIR is the COMMON PARENT of the repo and every worktree so a hit
+# in /a/pulp-worktrees/X normalizes against /a/pulp-worktrees/Y and the primary
+# checkout. WT_ROOT defaults to <repo-parent>/pulp-worktrees, so its parent is
+# the shared root. Computed with dirname (WT_ROOT may not exist yet).
+BASEDIR="$(dirname "$WT_ROOT")"
+
+note() { printf '\033[36m• %s\033[0m\n' "$*" >&2; }
+die()  { printf '\033[31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
+
+ensure_cache() {
+  mkdir -p "$CACHE_ROOT"/{ccache,skia-build,fetchcontent-src,tmp}
+  # Seed the shared Skia cache from the primary checkout once.
+  if [ -z "$(ls -A "$CACHE_ROOT/skia-build" 2>/dev/null || true)" ] && \
+     [ -d "$REPO_ROOT/external/skia-build/build" ]; then
+    note "seeding shared Skia cache from primary checkout"
+    rsync -a "$REPO_ROOT/external/skia-build/" "$CACHE_ROOT/skia-build/"
+  fi
+  command -v ccache >/dev/null 2>&1 && \
+    CCACHE_DIR="$CACHE_ROOT/ccache" ccache --set-config "max_size=$CCACHE_MAX_SIZE" 2>/dev/null || true
+}
+
+cache_env() {  # emit the env every worktree build should use
+  cat <<ENV
+export CCACHE_DIR="$CACHE_ROOT/ccache"
+export CCACHE_BASEDIR="$BASEDIR"
+export CCACHE_NOHASHDIR=true
+export CCACHE_DEPEND=true
+export CCACHE_SLOPPINESS=time_macros,pch_defines
+export FETCHCONTENT_BASE_DIR="$CACHE_ROOT/fetchcontent-src"
+export SKIA_DIR="$CACHE_ROOT/skia-build/build/mac-gpu"
+# Make object paths relative so ccache hits survive different worktree paths
+# (pairs with CCACHE_NOHASHDIR; required for Debug/RelWithDebInfo).
+export CMAKE_CXX_FLAGS="\${CMAKE_CXX_FLAGS:-} -fdebug-prefix-map=$BASEDIR=."
+ENV
+}
+
+cmd_new() {
+  local branch="$1"; shift || true
+  local base="origin/main"
+  [ "${1:-}" = "--base" ] && { base="$2"; shift 2; }
+  [ -n "$branch" ] || die "usage: new <branch> [--base <ref>]"
+  ensure_cache
+  local wt="$WT_ROOT/$branch"
+  mkdir -p "$WT_ROOT"
+  git -C "$REPO_ROOT" fetch origin --quiet || true
+  if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$branch"; then
+    git -C "$REPO_ROOT" worktree add "$wt" "$branch"
+  else
+    git -C "$REPO_ROOT" worktree add -b "$branch" "$wt" "$base"
+  fi
+  ln -sfn "$CACHE_ROOT/skia-build" "$wt/external/skia-build" 2>/dev/null || true
+  touch "$wt/build/.metadata_never_index" 2>/dev/null || { mkdir -p "$wt/build" && touch "$wt/build/.metadata_never_index"; }
+  cache_env > "$wt/.pulp-ci-env"
+  note "worktree ready: $wt"
+  note "configure with:  cd '$wt' && source .pulp-ci-env && cmake -S . -B build -DCMAKE_BUILD_TYPE=Release"
+}
+
+cmd_env()  { cache_env; }
+cmd_list() {
+  git -C "$REPO_ROOT" worktree list
+  echo "--- build-dir sizes ---"
+  for wt in "$WT_ROOT"/*/; do [ -d "$wt/build" ] && du -sh "$wt/build" 2>/dev/null; done
+  echo "--- ccache ---"
+  CCACHE_DIR="$CACHE_ROOT/ccache" ccache --show-stats 2>/dev/null | grep -iE "cache size|hit rate|hits|misses" || true
+}
+cmd_gc() {
+  local max_age="" merged=0
+  while [ $# -gt 0 ]; do case "$1" in
+    --max-age-days) max_age="$2"; shift 2;;
+    --merged) merged=1; shift;;
+    *) die "unknown gc arg: $1";; esac; done
+  # Auto-cleanup of merged branches. Pulp SQUASH-merges and shipyard
+  # auto-merge runs --delete-branch, so a merged branch's original commits are
+  # NOT ancestors of origin/main — the reliable signal is its upstream going
+  # "[gone]" after a pruning fetch. This also avoids false-pruning a brand-new
+  # branch that was never pushed (no upstream → not [gone]).
+  if [ "$merged" = 1 ]; then
+    git -C "$REPO_ROOT" fetch -p origin --quiet 2>/dev/null || true
+    local gone; gone="$(git -C "$REPO_ROOT" for-each-ref \
+      --format '%(refname:short) %(upstream:track)' refs/heads \
+      | awk '$2=="[gone]"{print $1}')"
+    local b wt
+    for b in $gone; do
+      wt="$(git -C "$REPO_ROOT" worktree list --porcelain \
+        | awk -v br="refs/heads/$b" 'f&&$1=="branch"&&$2==br{print p} {if($1=="worktree")p=$2; f=1}')"
+      [ -n "$wt" ] && [ "$wt" != "$REPO_ROOT" ] && {
+        note "merged+deleted upstream → pruning worktree $wt ($b)"
+        git -C "$REPO_ROOT" worktree remove --force "$wt" 2>/dev/null || true
+      }
+      git -C "$REPO_ROOT" branch -D "$b" 2>/dev/null || true
+    done
+  fi
+  [ -n "$max_age" ] && find "$WT_ROOT" -maxdepth 2 -name build -type d -mtime +"$max_age" \
+    -exec sh -c 'echo "stale build (>'"$max_age"'d): $1"; rm -rf "$1"' _ {} \; 2>/dev/null || true
+  git -C "$REPO_ROOT" worktree prune
+  note "gc done — run 'list' to review remaining build-dir sizes"
+}
+
+case "${1:-}" in
+  new)  shift; cmd_new "$@";;
+  env)  shift; cmd_env "$@";;
+  list) shift; cmd_list "$@";;
+  gc)   shift; cmd_gc "$@";;
+  *) sed -n '2,30p' "$0"; exit 1;;
+esac

--- a/tools/ci/tart-provision.sh
+++ b/tools/ci/tart-provision.sh
@@ -2,88 +2,336 @@
 # tart-provision.sh — build/refresh layered "golden master" Tart VMs for CI,
 # and resize them. Encodes the tier checklist from
 # planning/2026-06-01-macos-ci-isolation-plan.md as reproducible steps (the
-# "defined and easy" template), so a new golden master is `provision <tier>`
+# "defined and easy" template), so a new golden master is `tart-provision <tier>`
 # rather than hand-clicking.
 #
-# Images (date-tag with `--tag`):
+# Images (date-tag with the `tag` subcommand):
 #   macos-build-base   Tier 0: sshd+key, auto-login, brew(git gh rsync ccache jq
-#                              coreutils), tailscale, runner agent          ~50 GB
+#                              coreutils tailscale), runner agent           ~50 GB
 #   macos-apple-xcode  Tier 1: + Xcode 26.5 (17F42) + CLT, sim runtimes trimmed ~90 GB
 #   pulp-build-base    Tier 2: + cmake ninja python@3.12(PIL,numpy) + Skia +
 #                              warm ccache/FetchContent                   ~110-130 GB
 #
 # Storage: TART_HOME=/Volumes/Workshop/VMs (Spotlight-excluded). Clones are CoW.
-# NOTE: Tart is not yet installed here — run this in the dedicated CI session
-# with Tart present. Steps marked [VERIFY] depend on Tart/Xcode versions; the
-# new session should confirm them against `tart --help` + current docs before
-# trusting unattended runs. See the plan's "unknowns to validate first".
+#
+# Verified facts (cirruslabs macos-image-templates, tart docs — 2026-06-01):
+#   • Base image  ghcr.io/cirruslabs/macos-tahoe-base:latest is macOS 26 "Tahoe",
+#     which matches Xcode 26.5's required macOS.
+#   • Default creds are admin / admin.
+#   • The vanilla base ALREADY enables auto-login (kcpassword + loginwindow
+#     autoLoginUser=admin) and Remote Login (sshd). We verify/inject, not re-create.
+#   • `tart set <vm> --disk-size N` only grows, and only on a STOPPED VM; the
+#     bundled tart-guest-agent grows the APFS container on next boot. Manual
+#     fallback: `diskutil apfs resizeContainer disk0s2 0` over ssh.
+#   • Xcode: re-downloading in-guest re-triggers Apple-ID/2FA and a multi-hour
+#     fetch. Prefer rsync'ing a host-installed Xcode (PULP_HOST_XCODE_APP);
+#     `xcodes install` is the fallback and needs interactive auth.
 set -euo pipefail
 
 export TART_HOME="${TART_HOME:-/Volumes/Workshop/VMs}"
 SSH_KEY_PUB="${PULP_VM_SSH_KEY_PUB:-$HOME/.ssh/id_ed25519.pub}"
-BASE_MACOS_IMAGE="${PULP_MACOS_BASE_IMAGE:-ghcr.io/cirruslabs/macos-sequoia-base:latest}" # [VERIFY] match host macOS / Xcode 26.5 needs Tahoe
+SSH_KEY_PRIV="${SSH_KEY_PUB%.pub}"
+# Tahoe matches Xcode 26.5. Override with PULP_MACOS_BASE_IMAGE if Apple ships a
+# newer macOS for a future Xcode.
+BASE_MACOS_IMAGE="${PULP_MACOS_BASE_IMAGE:-ghcr.io/cirruslabs/macos-tahoe-base:latest}"
 XCODE_VERSION="${PULP_XCODE_VERSION:-26.5}"          # build 17F42 — goldens are toolchain-coupled
-VM_USER="${PULP_VM_USER:-admin}"; VM_PASS="${PULP_VM_PASS:-admin}"  # Cirrus base default [VERIFY]
+# xcodes installs to /Applications/Xcode-<version>.app; on the host, an already
+# xcodes-installed 26.5 is typically /Applications/Xcode-26.5.0.app.
+XCODE_APP="${PULP_XCODE_APP:-/Applications/Xcode-${XCODE_VERSION}.0.app}"
+HOST_XCODE_APP="${PULP_HOST_XCODE_APP:-}"            # if set, rsync this host Xcode in (no re-download)
+VM_USER="${PULP_VM_USER:-admin}"; VM_PASS="${PULP_VM_PASS:-admin}"  # Cirrus base default
 DISK_GB="${PULP_VM_DISK_GB:-150}"
+SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ConnectTimeout=10)
 
 note(){ printf '\033[36m• %s\033[0m\n' "$*" >&2; }
+warn(){ printf '\033[33m⚠ %s\033[0m\n' "$*" >&2; }
 die(){ printf '\033[31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
-need_tart(){ command -v tart >/dev/null 2>&1 || die "tart not installed — see plan Phase 3 (brew install cirruslabs/cli/tart)"; }
+need_tart(){ command -v tart >/dev/null 2>&1 || die "tart not installed — brew install cirruslabs/cli/tart (plan Phase 3)"; }
+have_sshpass(){ command -v sshpass >/dev/null 2>&1; }
 
-# Run a command inside a booted VM over ssh (Cirrus base enables ssh w/ user/pass).
-vm_ssh(){ local ip="$1"; shift; sshpass -p "$VM_PASS" ssh -o StrictHostKeyChecking=no "$VM_USER@$ip" "$@"; }
-vm_ip(){ tart ip "$1"; }
+# Run a command inside a booted VM over ssh. Prefer key auth (present after Tier
+# 0 injection); fall back to password auth via sshpass for the very first
+# bootstrap connection. sshpass: brew install hudochenkov/sshpass/sshpass
+vm_ssh(){
+  local ip="$1"; shift
+  if ssh "${SSH_OPTS[@]}" -o BatchMode=yes -i "$SSH_KEY_PRIV" "$VM_USER@$ip" true 2>/dev/null; then
+    ssh "${SSH_OPTS[@]}" -i "$SSH_KEY_PRIV" "$VM_USER@$ip" "$@"
+  elif have_sshpass; then
+    sshpass -p "$VM_PASS" ssh "${SSH_OPTS[@]}" "$VM_USER@$ip" "$@"
+  else
+    die "no key auth yet and sshpass missing — brew install hudochenkov/sshpass/sshpass"
+  fi
+}
+vm_rsync(){  # vm_rsync <src> <ip>:<dest> [extra rsync opts...]
+  local src="$1" dst="$2"; shift 2
+  rsync -a --delete "$@" -e "ssh ${SSH_OPTS[*]} -i $SSH_KEY_PRIV" "$src" "$VM_USER@$dst"
+}
+
+# Boot a VM headless and wait until ssh answers. Echoes the IP. Caller keeps the
+# returned pid to stop later. Usage:  rpid=$(boot_vm "$vm"); ip=$(vm_ip "$vm")
+boot_vm(){ # $1=vm  -> prints run-pid on stdout
+  local vm="$1"
+  tart run --no-graphics "$vm" >/dev/null 2>&1 & local rpid=$!
+  echo "$rpid"
+}
+vm_ip(){ # $1=vm — poll up to ~120s for an IP
+  local vm="$1" ip="" i
+  for i in $(seq 1 60); do
+    ip="$(tart ip "$vm" 2>/dev/null || true)"
+    [ -n "$ip" ] && { echo "$ip"; return 0; }
+    sleep 2
+  done
+  die "timed out waiting for IP of $vm"
+}
+wait_ssh(){ # $1=ip — poll up to ~180s for ssh to answer (key OR password)
+  local ip="$1" i
+  for i in $(seq 1 90); do
+    if vm_ssh "$ip" true 2>/dev/null; then return 0; fi
+    sleep 2
+  done
+  die "timed out waiting for ssh on $ip"
+}
+stop_vm(){ # graceful stop, fall back to killing the run pid
+  local vm="$1" rpid="${2:-}"
+  tart stop "$vm" >/dev/null 2>&1 || true
+  [ -n "$rpid" ] && kill "$rpid" 2>/dev/null || true
+  # give the VZ process a moment to release the disk image
+  sleep 3
+}
 
 # ── Tier 0 — universal base ────────────────────────────────────────────────
 provision_base(){ # $1=vm-name
-  need_tart; local vm="$1"
-  note "Tier 0: cloning $BASE_MACOS_IMAGE → $vm (disk ${DISK_GB}G)"
+  need_tart; local vm="${1:-macos-build-base}"
+  [ -f "$SSH_KEY_PUB" ] || die "ssh pubkey not found: $SSH_KEY_PUB (set PULP_VM_SSH_KEY_PUB)"
+  note "Tier 0: cloning $BASE_MACOS_IMAGE → $vm"
   tart clone "$BASE_MACOS_IMAGE" "$vm"
-  tart set "$vm" --disk-size "$DISK_GB"            # [VERIFY] grow APFS in-guest if not auto
-  tart run --no-graphics "$vm" & local rpid=$!; sleep 30
+  note "growing disk → ${DISK_GB}G (guest-agent grows APFS on boot)"
+  tart set "$vm" --disk-size "$DISK_GB"            # VM is stopped here — required
+  local rpid; rpid="$(boot_vm "$vm")"
   local ip; ip="$(vm_ip "$vm")"; note "vm ip=$ip"
-  # sshd is on in the Cirrus base; inject our key + the rest.
-  [ -f "$SSH_KEY_PUB" ] && vm_ssh "$ip" "mkdir -p ~/.ssh && echo '$(cat "$SSH_KEY_PUB")' >> ~/.ssh/authorized_keys"
-  vm_ssh "$ip" 'sudo systemsetup -setremotelogin on || true'      # [VERIFY]
-  # auto-login (WindowServer/Metal for GPU tests) — [VERIFY] exact mechanism.
-  vm_ssh "$ip" 'echo "enable auto-login per plan Phase 3"'
-  # Homebrew + common tooling.
-  vm_ssh "$ip" 'command -v brew >/dev/null || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
-  vm_ssh "$ip" 'eval "$(/opt/homebrew/bin/brew shellenv)" && brew install git gh rsync ccache jq coreutils tailscale'
-  note "Tier 0 ready in $vm — operator: run 'tailscale up' to authenticate; install the GH runner agent."
-  note "Stop + tag:  tart stop $vm  (snapshot/tag externally as macos-build-base:<date>)"
-  kill $rpid 2>/dev/null || true
+  wait_ssh "$ip"
+  # Inject our key (first connection uses password via sshpass).
+  note "injecting ssh key"
+  vm_ssh "$ip" "mkdir -p ~/.ssh && chmod 700 ~/.ssh && grep -qxF '$(cat "$SSH_KEY_PUB")' ~/.ssh/authorized_keys 2>/dev/null || echo '$(cat "$SSH_KEY_PUB")' >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"
+  vm_ssh "$ip" 'sudo systemsetup -setremotelogin on >/dev/null 2>&1 || true'   # idempotent; base already on
+  # Auto-login is set by the cirrus vanilla base. Verify; warn (don't silently
+  # regenerate kcpassword) if a non-cirrus base lacks it — GPU/WindowServer/Metal
+  # tests REQUIRE a logged-in session.
+  local autouser; autouser="$(vm_ssh "$ip" 'defaults read /Library/Preferences/com.apple.loginwindow autoLoginUser 2>/dev/null || true')"
+  if [ "$autouser" = "$VM_USER" ]; then note "auto-login OK (autoLoginUser=$autouser)"
+  else warn "auto-login NOT set to $VM_USER (got '${autouser:-none}') — Metal/GPU tests need it; configure kcpassword + loginwindow autoLoginUser before GPU probe"; fi
+  # Homebrew + common CI tooling (+ tailscale for mesh SSH to the VM).
+  vm_ssh "$ip" 'command -v brew >/dev/null || NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
+  vm_ssh "$ip" 'eval "$(/opt/homebrew/bin/brew shellenv)" && brew install --quiet git gh rsync ccache jq coreutils tailscale'
+  note "Tier 0 provisioned. Operator: run 'tailscale up' in-VM to authenticate the mesh; install the GH runner agent if this VM will self-host."
+  stop_vm "$vm" "$rpid"
+  note "Tier 0 ready. Tag it:  $0 tag $vm macos-build-base"
 }
 
 # ── Tier 1 — Xcode (Apple projects) ────────────────────────────────────────
 provision_apple_xcode(){ # $1=from-base-vm  $2=new-vm
-  need_tart; local from="$1" vm="$2"; tart clone "$from" "$vm"
-  tart run --no-graphics "$vm" & local rpid=$!; sleep 30
-  local ip; ip="$(vm_ip "$vm")"
-  vm_ssh "$ip" "eval \"\$(/opt/homebrew/bin/brew shellenv)\" && brew install xcodesorg/made/xcodes && xcodes install $XCODE_VERSION --experimental-unxip"  # [VERIFY] auth/cookies for Xcode download
-  vm_ssh "$ip" "sudo xcode-select -s /Applications/Xcode-$XCODE_VERSION.app && sudo xcodebuild -license accept"  # [VERIFY] app name
-  vm_ssh "$ip" 'for r in $(xcrun simctl runtime list -j | jq -r "keys[]" 2>/dev/null); do xcrun simctl runtime delete "$r" || true; done'  # trim sims
-  note "Tier 1 ready in $vm — tag as macos-apple-xcode:<date>"; kill $rpid 2>/dev/null || true
+  need_tart; local from="${1:-macos-build-base}" vm="${2:-macos-apple-xcode}"
+  note "Tier 1: cloning $from → $vm"
+  tart clone "$from" "$vm"
+  local rpid; rpid="$(boot_vm "$vm")"
+  local ip; ip="$(vm_ip "$vm")"; wait_ssh "$ip"
+  if [ -n "$HOST_XCODE_APP" ] && [ -d "$HOST_XCODE_APP" ]; then
+    # Fast path: copy the operator's already-downloaded Xcode (no re-auth/re-download).
+    local appname; appname="$(basename "$HOST_XCODE_APP")"
+    note "rsync host Xcode $HOST_XCODE_APP → VM:/Applications/$appname (no re-download)"
+    # Remote rsync runs as root (passwordless sudo) so it can write /Applications
+    # and preserve root ownership; full path pins brew rsync on both ends so the
+    # protocol matches (macOS 26 ships openrsync at /usr/bin/rsync).
+    vm_rsync "$HOST_XCODE_APP/" "$ip:/Applications/$appname/" --rsync-path="sudo /opt/homebrew/bin/rsync"
+    vm_ssh "$ip" "sudo xcode-select -s /Applications/$appname/Contents/Developer"
+  else
+    warn "PULP_HOST_XCODE_APP unset — installing Xcode $XCODE_VERSION in-guest via xcodes (needs Apple-ID + interactive 2FA; multi-hour download)"
+    vm_ssh "$ip" 'eval "$(/opt/homebrew/bin/brew shellenv)" && brew install --quiet xcodesorg/made/xcodes aria2'
+    # XCODES_USERNAME/XCODES_PASSWORD may be exported to reduce prompts; 2FA is
+    # still interactive. Run this attached if auth is needed.
+    vm_ssh "$ip" "eval \"\$(/opt/homebrew/bin/brew shellenv)\" && xcodes install '$XCODE_VERSION' --experimental-unxip --no-superuser || true"
+    vm_ssh "$ip" "sudo xcode-select -s '$XCODE_APP/Contents/Developer'"
+  fi
+  vm_ssh "$ip" 'sudo xcodebuild -license accept && sudo xcodebuild -runFirstLaunch' || warn "xcodebuild license/firstlaunch step needs attention"
+  # Trim simulator runtimes (large; CI plugin builds don't need them).
+  vm_ssh "$ip" 'for r in $(xcrun simctl runtime list -j 2>/dev/null | jq -r "keys[]" 2>/dev/null); do xcrun simctl runtime delete "$r" 2>/dev/null || true; done'
+  note "Tier 1 provisioned."
+  stop_vm "$vm" "$rpid"
+  note "Tier 1 ready. Tag it:  $0 tag $vm macos-apple-xcode"
 }
 
 # ── Tier 2 — Pulp ──────────────────────────────────────────────────────────
 provision_pulp(){ # $1=from-apple-xcode-vm  $2=new-vm
-  need_tart; local from="$1" vm="$2"; tart clone "$from" "$vm"
-  tart run --no-graphics "$vm" & local rpid=$!; sleep 30
-  local ip; ip="$(vm_ip "$vm")"
-  vm_ssh "$ip" 'eval "$(/opt/homebrew/bin/brew shellenv)" && brew install cmake ninja python@3.12 && python3.12 -m pip install --break-system-packages pillow numpy'
-  note "Tier 2: copy prebuilt Skia in (rsync external/skia-build) + pre-warm one Release build to seed ccache — see plan."
-  note "Tier 2 ready in $vm — tag as pulp-build-base:<date>"; kill $rpid 2>/dev/null || true
+  need_tart; local from="${1:-macos-apple-xcode}" vm="${2:-pulp-build-base}"
+  note "Tier 2: cloning $from → $vm"
+  tart clone "$from" "$vm"
+  local rpid; rpid="$(boot_vm "$vm")"
+  local ip; ip="$(vm_ip "$vm")"; wait_ssh "$ip"
+  vm_ssh "$ip" 'eval "$(/opt/homebrew/bin/brew shellenv)" && brew install --quiet cmake ninja python@3.12 && python3.12 -m pip install --break-system-packages --quiet pillow numpy'
+  # Seed prebuilt Skia so the first in-VM configure doesn't rebuild it.
+  local repo_root; repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  if [ -d "$repo_root/external/skia-build/build" ]; then
+    note "seeding prebuilt Skia into VM (~/pulp-skia-build)"
+    vm_ssh "$ip" 'mkdir -p ~/pulp-skia-build'
+    vm_rsync "$repo_root/external/skia-build/" "$ip:pulp-skia-build/"
+    note "in-VM builds should: export SKIA_DIR=~/pulp-skia-build (FindSkia wants the dir CONTAINING build/, not .../build/mac-gpu)"
+  else
+    warn "no prebuilt Skia at $repo_root/external/skia-build/build — the VM's first build will fetch/build it"
+  fi
+  note "Tier 2 provisioned. Pre-warm ccache by running one Release build in-VM before tagging (see headline-path proof in the plan)."
+  stop_vm "$vm" "$rpid"
+  note "Tier 2 ready. Tag it:  $0 tag $vm pulp-build-base"
 }
 
-cmd_resize(){ need_tart; local vm="$1" gb="$2"; tart set "$vm" --disk-size "$gb"; note "resized $vm disk → ${gb}G (grow APFS in-guest if needed: diskutil apfs resizeContainer disk0s2 0)"; }
-cmd_list(){ need_tart; tart list; echo "--- store ---"; du -sh "$TART_HOME"/vms/* 2>/dev/null || true; }
+# ── tag / resize / list ─────────────────────────────────────────────────────
+# Tart local VM names are arbitrary strings and may include ':'. We tag golden
+# masters as <name>:<date> (CoW clone) so per-job clones come from a frozen,
+# dated image and the live VM stays editable.
+cmd_tag(){ # $1=src-vm  $2=base-name  [$3=date]
+  need_tart; local src="$1" name="$2" d="${3:-$(date +%Y-%m-%d)}"
+  [ -n "$src" ] && [ -n "$name" ] || die "usage: tag <src-vm> <base-name> [YYYY-MM-DD]"
+  tart clone "$src" "$name:$d"
+  note "tagged $src → $name:$d"
+  note "also refreshing rolling alias $name:latest"
+  tart delete "$name:latest" >/dev/null 2>&1 || true
+  tart clone "$name:$d" "$name:latest"
+  note "clone for a job:  tart clone $name:latest <job-vm>"
+}
+
+# ── Runner layer — CI-complete ephemeral GitHub Actions runner golden ───────
+# Clones pulp-build-base and adds the env-parity + agent that let the STOCK
+# build.yml workflow pass the full ctest suite in a throwaway VM:
+#   • node + git-lfs (threejs smoke + lfs checkout)   — the env gaps behind the
+#   • shipyard (pulp status/version/pr CLI tests)        23 in-VM ctest failures
+#   • actions-runner agent (configured per-boot via JIT by tools/ci/tart-runner.sh)
+# Skia/SDKs/ccache stay handled by the workflow's own setup.sh + actions/cache;
+# SKIA_DIR in the runner .env points at the baked Skia so setup.sh can skip it.
+RUNNER_VERSION="${PULP_RUNNER_VERSION:-2.334.0}"
+HOST_SHIPYARD="${PULP_HOST_SHIPYARD:-$HOME/.local/bin/shipyard}"
+provision_runner(){ # $1=from-pulp-vm  $2=new-vm
+  need_tart; local from="${1:-pulp-build-base}" vm="${2:-pulp-build-runner}"
+  note "Runner layer: cloning $from → $vm"
+  tart clone "$from" "$vm"
+  local rpid; rpid="$(boot_vm "$vm")"
+  local ip; ip="$(vm_ip "$vm")"; wait_ssh "$ip"
+  note "installing node + git-lfs (env-parity for threejs smoke + lfs checkout)"
+  vm_ssh "$ip" 'eval "$(/opt/homebrew/bin/brew shellenv)" && brew install --quiet node git-lfs && git lfs install'
+  if [ -x "$HOST_SHIPYARD" ]; then
+    note "copying pinned shipyard ($("$HOST_SHIPYARD" --version 2>/dev/null | head -1)) → VM ~/.local/bin"
+    vm_ssh "$ip" 'mkdir -p ~/.local/bin'
+    vm_rsync "$HOST_SHIPYARD" "$ip:.local/bin/shipyard"
+    vm_ssh "$ip" 'chmod +x ~/.local/bin/shipyard'
+  else warn "host shipyard not found at $HOST_SHIPYARD — pulp CLI tests that need it will fail; set PULP_HOST_SHIPYARD"; fi
+  note "installing actions-runner agent v$RUNNER_VERSION (configured per-boot via JIT)"
+  vm_ssh "$ip" "mkdir -p ~/actions-runner && cd ~/actions-runner && curl -fsSL -o r.tar.gz https://github.com/actions/runner/releases/download/v$RUNNER_VERSION/actions-runner-osx-arm64-$RUNNER_VERSION.tar.gz && tar xzf r.tar.gz && rm r.tar.gz"
+  # Runner-wide env: stock workflow picks these up. Baked Skia + ccache warmth +
+  # ccache as the compiler launcher (CMake reads these env vars at configure).
+  vm_ssh "$ip" 'cat > ~/actions-runner/.env <<ENVV
+PATH=/Users/admin/.local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin
+SKIA_DIR=/Users/admin/pulp-skia-build
+CMAKE_C_COMPILER_LAUNCHER=ccache
+CMAKE_CXX_COMPILER_LAUNCHER=ccache
+CCACHE_DIR=/Users/admin/Library/Caches/ccache
+CCACHE_TEMPDIR=/Users/admin/.ccache-tmp
+CCACHE_NOHASHDIR=true
+CCACHE_SLOPPINESS=time_macros,pch_defines
+ENVV'
+  note "Runner layer provisioned."
+  stop_vm "$vm" "$rpid"
+  note "Runner ready. Tag it:  $0 tag $vm pulp-build-runner   then drive with tools/ci/tart-runner.sh"
+}
+
+cmd_resize(){ # $1=vm  $2=GB  — VM must be stopped; guest-agent grows APFS on boot
+  need_tart; local vm="$1" gb="$2"
+  [ -n "$vm" ] && [ -n "$gb" ] || die "usage: resize <vm> <GB>"
+  tart stop "$vm" >/dev/null 2>&1 || true; sleep 2
+  tart set "$vm" --disk-size "$gb"
+  note "resized $vm disk → ${gb}G. The tart-guest-agent grows the APFS container on next boot."
+  note "manual fallback (over ssh, normal boot — NOT recovery): diskutil apfs resizeContainer disk0s2 0"
+}
+
+cmd_list(){ need_tart; tart list; echo "--- store (du) ---"; du -sh "$TART_HOME"/vms/* 2>/dev/null || true; }
+
+# ── manifest-driven bake (the reusable template; plan Phase 3) ──────────────
+# Reads a per-repo .shipyard/vm-image.toml and bakes (or configures-on-boot) a
+# golden image with ZERO hand-provisioning. Same script serves any repo: Pulp
+# (Xcode+Skia) and e.g. a light rust profile (no Xcode) both come from one file.
+_manifest_read(){ # $1=manifest-path — emits shell KEY=VALUE lines
+  python3 - "$1" <<'PY'
+import sys, tomllib
+m = tomllib.load(open(sys.argv[1], "rb"))
+def out(k, v): print(f'{k}={v!r}'.replace("'", '"'))
+out("MF_NAME", m.get("name", ""))
+out("MF_STRATEGY", m.get("strategy", "bake"))
+out("MF_BASE", m.get("base", ""))
+out("MF_DISK", str(m.get("disk_gb", 150)))
+out("MF_AUTOLOGIN", "1" if m.get("auto_login") else "0")
+out("MF_XCODE", m.get("toolchain", {}).get("xcode", ""))
+out("MF_BREW", " ".join(m.get("brew", {}).get("packages", [])))
+out("MF_PIP", " ".join(m.get("pip", {}).get("packages", [])))
+PY
+}
+
+cmd_manifest(){ # $1=manifest-path  $2=vm-name(optional)
+  need_tart; local path="$1" vm="${2:-}"
+  [ -f "$path" ] || die "manifest not found: $path"
+  command -v python3 >/dev/null 2>&1 || die "python3 required to parse the manifest"
+  local MF_NAME MF_STRATEGY MF_BASE MF_DISK MF_AUTOLOGIN MF_XCODE MF_BREW MF_PIP
+  eval "$(_manifest_read "$path")"
+  vm="${vm:-$MF_NAME}"
+  [ -n "$MF_BASE" ] && [ -n "$vm" ] || die "manifest needs base + name (or pass a vm name)"
+  note "manifest: name=$MF_NAME strategy=$MF_STRATEGY base=$MF_BASE disk=${MF_DISK}G xcode=${MF_XCODE:-none}"
+  [ -f "$SSH_KEY_PUB" ] || die "ssh pubkey not found: $SSH_KEY_PUB"
+
+  note "cloning $MF_BASE → $vm"
+  tart clone "$MF_BASE" "$vm"
+  tart set "$vm" --disk-size "$MF_DISK"
+  local rpid; rpid="$(boot_vm "$vm")"
+  local ip; ip="$(vm_ip "$vm")"; wait_ssh "$ip"
+  # Inject key (Tier 0 universal step, identical for every repo).
+  vm_ssh "$ip" "mkdir -p ~/.ssh && chmod 700 ~/.ssh && grep -qxF '$(cat "$SSH_KEY_PUB")' ~/.ssh/authorized_keys 2>/dev/null || echo '$(cat "$SSH_KEY_PUB")' >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"
+  vm_ssh "$ip" 'sudo systemsetup -setremotelogin on >/dev/null 2>&1 || true'
+  vm_ssh "$ip" 'command -v brew >/dev/null || NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
+  [ -n "$MF_BREW" ] && vm_ssh "$ip" "eval \"\$(/opt/homebrew/bin/brew shellenv)\" && brew install --quiet $MF_BREW"
+  [ -n "$MF_PIP" ]  && vm_ssh "$ip" "python3 -m pip install --break-system-packages --quiet $MF_PIP"
+  # Toolchain: only repos that declare toolchain.xcode pay the Xcode cost.
+  if [ -n "$MF_XCODE" ]; then
+    warn "manifest declares Xcode $MF_XCODE — run '$0 apple-xcode $vm $vm' or set PULP_HOST_XCODE_APP to copy a host Xcode; skipping in manifest bake to keep it unattended"
+  fi
+  if [ "$MF_STRATEGY" = "configure-on-boot" ]; then
+    note "configure-on-boot: $vm is provisioned and left as a reusable base. Clone per-job with tart clone."
+    stop_vm "$vm" "$rpid"
+  else
+    note "bake: provisioning complete."
+    stop_vm "$vm" "$rpid"
+    note "tag it:  $0 tag $vm $MF_NAME"
+  fi
+  note "manifest bake done — NO hand-provisioning needed for $MF_NAME"
+}
+
+# Preflight the [VERIFY] surface before a long unattended bake.
+cmd_verify(){
+  need_tart
+  note "tart: $(tart --version 2>/dev/null || echo '?')"
+  note "TART_HOME=$TART_HOME ($( [ -d "$TART_HOME" ] && echo present || echo MISSING ))"
+  [ -f "$SSH_KEY_PUB" ] && note "ssh pubkey: $SSH_KEY_PUB" || warn "ssh pubkey missing: $SSH_KEY_PUB"
+  have_sshpass && note "sshpass present (first-boot password auth OK)" || warn "sshpass missing — brew install hudochenkov/sshpass/sshpass (needed for first key injection)"
+  if [ -n "$HOST_XCODE_APP" ]; then [ -d "$HOST_XCODE_APP" ] && note "host Xcode to copy: $HOST_XCODE_APP" || warn "PULP_HOST_XCODE_APP set but not found: $HOST_XCODE_APP"
+  else warn "PULP_HOST_XCODE_APP unset — Tier 1 will use xcodes (interactive 2FA). Set it to the host's Xcode-${XCODE_VERSION}.0.app to skip re-download."; fi
+  note "base image: $BASE_MACOS_IMAGE  (pull check below)"
+  tart pull "$BASE_MACOS_IMAGE" --concurrency 4 >/dev/null 2>&1 && note "base image pullable/cached" || warn "could not pull $BASE_MACOS_IMAGE — check name/network"
+  note "verify complete"
+}
 
 case "${1:-}" in
+  verify)       shift; cmd_verify;;
   base)         shift; provision_base "${1:-macos-build-base}";;
   apple-xcode)  shift; provision_apple_xcode "${1:-macos-build-base}" "${2:-macos-apple-xcode}";;
   pulp)         shift; provision_pulp "${1:-macos-apple-xcode}" "${2:-pulp-build-base}";;
-  resize)       shift; cmd_resize "$1" "$2";;
+  runner)       shift; provision_runner "${1:-pulp-build-base}" "${2:-pulp-build-runner}";;
+  tag)          shift; cmd_tag "$@";;
+  resize)       shift; cmd_resize "$@";;
   list)         shift; cmd_list;;
-  *) sed -n '2,18p' "$0"; exit 1;;
+  manifest)     shift; cmd_manifest "$@";;
+  *) sed -n '2,18p' "$0"; echo; echo "subcommands: verify | base | apple-xcode | pulp | runner | tag | resize | list | manifest <path> [vm]"; exit 1;;
 esac

--- a/tools/ci/tart-provision.sh
+++ b/tools/ci/tart-provision.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# tart-provision.sh — build/refresh layered "golden master" Tart VMs for CI,
+# and resize them. Encodes the tier checklist from
+# planning/2026-06-01-macos-ci-isolation-plan.md as reproducible steps (the
+# "defined and easy" template), so a new golden master is `provision <tier>`
+# rather than hand-clicking.
+#
+# Images (date-tag with `--tag`):
+#   macos-build-base   Tier 0: sshd+key, auto-login, brew(git gh rsync ccache jq
+#                              coreutils), tailscale, runner agent          ~50 GB
+#   macos-apple-xcode  Tier 1: + Xcode 26.5 (17F42) + CLT, sim runtimes trimmed ~90 GB
+#   pulp-build-base    Tier 2: + cmake ninja python@3.12(PIL,numpy) + Skia +
+#                              warm ccache/FetchContent                   ~110-130 GB
+#
+# Storage: TART_HOME=/Volumes/Workshop/VMs (Spotlight-excluded). Clones are CoW.
+# NOTE: Tart is not yet installed here — run this in the dedicated CI session
+# with Tart present. Steps marked [VERIFY] depend on Tart/Xcode versions; the
+# new session should confirm them against `tart --help` + current docs before
+# trusting unattended runs. See the plan's "unknowns to validate first".
+set -euo pipefail
+
+export TART_HOME="${TART_HOME:-/Volumes/Workshop/VMs}"
+SSH_KEY_PUB="${PULP_VM_SSH_KEY_PUB:-$HOME/.ssh/id_ed25519.pub}"
+BASE_MACOS_IMAGE="${PULP_MACOS_BASE_IMAGE:-ghcr.io/cirruslabs/macos-sequoia-base:latest}" # [VERIFY] match host macOS / Xcode 26.5 needs Tahoe
+XCODE_VERSION="${PULP_XCODE_VERSION:-26.5}"          # build 17F42 — goldens are toolchain-coupled
+VM_USER="${PULP_VM_USER:-admin}"; VM_PASS="${PULP_VM_PASS:-admin}"  # Cirrus base default [VERIFY]
+DISK_GB="${PULP_VM_DISK_GB:-150}"
+
+note(){ printf '\033[36m• %s\033[0m\n' "$*" >&2; }
+die(){ printf '\033[31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
+need_tart(){ command -v tart >/dev/null 2>&1 || die "tart not installed — see plan Phase 3 (brew install cirruslabs/cli/tart)"; }
+
+# Run a command inside a booted VM over ssh (Cirrus base enables ssh w/ user/pass).
+vm_ssh(){ local ip="$1"; shift; sshpass -p "$VM_PASS" ssh -o StrictHostKeyChecking=no "$VM_USER@$ip" "$@"; }
+vm_ip(){ tart ip "$1"; }
+
+# ── Tier 0 — universal base ────────────────────────────────────────────────
+provision_base(){ # $1=vm-name
+  need_tart; local vm="$1"
+  note "Tier 0: cloning $BASE_MACOS_IMAGE → $vm (disk ${DISK_GB}G)"
+  tart clone "$BASE_MACOS_IMAGE" "$vm"
+  tart set "$vm" --disk-size "$DISK_GB"            # [VERIFY] grow APFS in-guest if not auto
+  tart run --no-graphics "$vm" & local rpid=$!; sleep 30
+  local ip; ip="$(vm_ip "$vm")"; note "vm ip=$ip"
+  # sshd is on in the Cirrus base; inject our key + the rest.
+  [ -f "$SSH_KEY_PUB" ] && vm_ssh "$ip" "mkdir -p ~/.ssh && echo '$(cat "$SSH_KEY_PUB")' >> ~/.ssh/authorized_keys"
+  vm_ssh "$ip" 'sudo systemsetup -setremotelogin on || true'      # [VERIFY]
+  # auto-login (WindowServer/Metal for GPU tests) — [VERIFY] exact mechanism.
+  vm_ssh "$ip" 'echo "enable auto-login per plan Phase 3"'
+  # Homebrew + common tooling.
+  vm_ssh "$ip" 'command -v brew >/dev/null || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
+  vm_ssh "$ip" 'eval "$(/opt/homebrew/bin/brew shellenv)" && brew install git gh rsync ccache jq coreutils tailscale'
+  note "Tier 0 ready in $vm — operator: run 'tailscale up' to authenticate; install the GH runner agent."
+  note "Stop + tag:  tart stop $vm  (snapshot/tag externally as macos-build-base:<date>)"
+  kill $rpid 2>/dev/null || true
+}
+
+# ── Tier 1 — Xcode (Apple projects) ────────────────────────────────────────
+provision_apple_xcode(){ # $1=from-base-vm  $2=new-vm
+  need_tart; local from="$1" vm="$2"; tart clone "$from" "$vm"
+  tart run --no-graphics "$vm" & local rpid=$!; sleep 30
+  local ip; ip="$(vm_ip "$vm")"
+  vm_ssh "$ip" "eval \"\$(/opt/homebrew/bin/brew shellenv)\" && brew install xcodesorg/made/xcodes && xcodes install $XCODE_VERSION --experimental-unxip"  # [VERIFY] auth/cookies for Xcode download
+  vm_ssh "$ip" "sudo xcode-select -s /Applications/Xcode-$XCODE_VERSION.app && sudo xcodebuild -license accept"  # [VERIFY] app name
+  vm_ssh "$ip" 'for r in $(xcrun simctl runtime list -j | jq -r "keys[]" 2>/dev/null); do xcrun simctl runtime delete "$r" || true; done'  # trim sims
+  note "Tier 1 ready in $vm — tag as macos-apple-xcode:<date>"; kill $rpid 2>/dev/null || true
+}
+
+# ── Tier 2 — Pulp ──────────────────────────────────────────────────────────
+provision_pulp(){ # $1=from-apple-xcode-vm  $2=new-vm
+  need_tart; local from="$1" vm="$2"; tart clone "$from" "$vm"
+  tart run --no-graphics "$vm" & local rpid=$!; sleep 30
+  local ip; ip="$(vm_ip "$vm")"
+  vm_ssh "$ip" 'eval "$(/opt/homebrew/bin/brew shellenv)" && brew install cmake ninja python@3.12 && python3.12 -m pip install --break-system-packages pillow numpy'
+  note "Tier 2: copy prebuilt Skia in (rsync external/skia-build) + pre-warm one Release build to seed ccache — see plan."
+  note "Tier 2 ready in $vm — tag as pulp-build-base:<date>"; kill $rpid 2>/dev/null || true
+}
+
+cmd_resize(){ need_tart; local vm="$1" gb="$2"; tart set "$vm" --disk-size "$gb"; note "resized $vm disk → ${gb}G (grow APFS in-guest if needed: diskutil apfs resizeContainer disk0s2 0)"; }
+cmd_list(){ need_tart; tart list; echo "--- store ---"; du -sh "$TART_HOME"/vms/* 2>/dev/null || true; }
+
+case "${1:-}" in
+  base)         shift; provision_base "${1:-macos-build-base}";;
+  apple-xcode)  shift; provision_apple_xcode "${1:-macos-build-base}" "${2:-macos-apple-xcode}";;
+  pulp)         shift; provision_pulp "${1:-macos-apple-xcode}" "${2:-pulp-build-base}";;
+  resize)       shift; cmd_resize "$1" "$2";;
+  list)         shift; cmd_list;;
+  *) sed -n '2,18p' "$0"; exit 1;;
+esac

--- a/tools/ci/tart-run-job.sh
+++ b/tools/ci/tart-run-job.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# tart-run-job.sh — run ONE Pulp build+test inside an ephemeral Tart VM cloned
+# from a golden master, with the durable caches mounted from the host, then
+# discard the clone. This is how the VM pool "takes over the build load"
+# (planning/2026-06-01-macos-ci-isolation-plan.md, Phase 3/4): build dirs are
+# disposable, ccache/Skia/FetchContent are host-durable and shared across clones.
+#
+# Flow:
+#   tart clone <golden> <job-vm>          # CoW, seconds
+#   tart run --dir=ccache:… --dir=skia:…  # virtio-fs host mounts
+#   ssh → build + ctest in-guest          # SKIA_DIR + ccache point at mounts
+#   tart stop && tart delete <job-vm>      # discard (unless --keep)
+#
+# virtio-fs notes (Phase 3 "unknowns to validate first"):
+#   • Tart mounts a --dir=<name>:<path> at "/Volumes/My Shared Files/<name>".
+#     We symlink each into $HOME to dodge the space in the path.
+#   • ccache must keep its TEMPDIR IN-GUEST (CCACHE_TEMPDIR) — cross-fs renames
+#     onto a virtio-fs mount break ccache. CCACHE_BASEDIR normalizes abs paths.
+#   • Same UID/GID (guest admin uid 501 == host primary user) keeps the shared
+#     ccache writable both ways. Stress-test two concurrent clones before
+#     relying on a single shared ccache (race-safe: ccache uses atomic renames).
+#
+# Usage:
+#   tart-run-job.sh --golden pulp-build-base:latest --src /path/to/checkout \
+#       [--vm job-NAME] [--disk 150] [--build-type Release] \
+#       [--cache-root ~/.cache/pulp-ci] [--ctest-args "..."] [--keep]
+set -euo pipefail
+
+export TART_HOME="${TART_HOME:-/Volumes/Workshop/VMs}"
+SSH_KEY_PRIV="${PULP_VM_SSH_KEY:-$HOME/.ssh/id_ed25519}"
+VM_USER="${PULP_VM_USER:-admin}"
+SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ConnectTimeout=10)
+
+GOLDEN=""; SRC=""; VM=""; DISK=""; BUILD_TYPE="Release"
+CACHE_ROOT="${PULP_CI_CACHE:-$HOME/.cache/pulp-ci}"
+CTEST_ARGS="--output-on-failure --exclude-regex AudioWorkgroup --label-exclude slow"
+KEEP=0
+
+note(){ printf '\033[36m• %s\033[0m\n' "$*" >&2; }
+die(){ printf '\033[31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
+command -v tart >/dev/null 2>&1 || die "tart not installed — brew install cirruslabs/cli/tart"
+
+while [ $# -gt 0 ]; do case "$1" in
+  --golden) GOLDEN="$2"; shift 2;;
+  --src) SRC="$2"; shift 2;;
+  --vm) VM="$2"; shift 2;;
+  --disk) DISK="$2"; shift 2;;
+  --build-type) BUILD_TYPE="$2"; shift 2;;
+  --cache-root) CACHE_ROOT="$2"; shift 2;;
+  --ctest-args) CTEST_ARGS="$2"; shift 2;;
+  --keep) KEEP=1; shift;;
+  *) die "unknown arg: $1";;
+esac; done
+
+[ -n "$GOLDEN" ] || die "--golden <image> required (e.g. pulp-build-base:latest)"
+[ -n "$SRC" ] && [ -d "$SRC" ] || die "--src <checkout-dir> required and must exist"
+SRC="$(cd "$SRC" && pwd)"
+# A unique-but-deterministic-per-invocation name. Caller can pass --vm; default
+# uses the parent shell PID (no Date.now/rand needed and unique enough per run).
+VM="${VM:-job-$$}"
+mkdir -p "$CACHE_ROOT"/{ccache,skia-build,fetchcontent-src}
+
+cleanup(){
+  [ "$KEEP" = 1 ] && { note "--keep: leaving $VM (delete with: tart delete $VM)"; return; }
+  tart stop "$VM" >/dev/null 2>&1 || true
+  [ -n "${RPID:-}" ] && kill "$RPID" 2>/dev/null || true
+  sleep 2
+  tart delete "$VM" >/dev/null 2>&1 || true
+  note "discarded ephemeral VM $VM"
+}
+trap cleanup EXIT
+
+note "cloning $GOLDEN → $VM (CoW)"
+tart clone "$GOLDEN" "$VM"
+if [ -n "$DISK" ]; then tart set "$VM" --disk-size "$DISK"; note "disk → ${DISK}G (guest-agent grows APFS on boot)"; fi
+
+note "booting with host mounts (src ro, ccache/fetchcontent rw); Skia is baked into the golden"
+tart run --no-graphics \
+  --dir="src:$SRC:ro" \
+  --dir="ccache:$CACHE_ROOT/ccache" \
+  --dir="fetchcontent:$CACHE_ROOT/fetchcontent-src" \
+  "$VM" >/dev/null 2>&1 & RPID=$!
+
+# Wait for IP + ssh.
+IP=""; for i in $(seq 1 60); do IP="$(tart ip "$VM" 2>/dev/null || true)"; [ -n "$IP" ] && break; sleep 2; done
+[ -n "$IP" ] || die "no IP for $VM"
+for i in $(seq 1 90); do ssh "${SSH_OPTS[@]}" -i "$SSH_KEY_PRIV" "$VM_USER@$IP" true 2>/dev/null && break; sleep 2; done
+note "vm $VM up at $IP"
+
+vmsh(){ ssh "${SSH_OPTS[@]}" -i "$SSH_KEY_PRIV" "$VM_USER@$IP" "$@"; }
+
+# The in-guest build script. Symlink the space-laden mount paths into $HOME,
+# point caches at them, build into an in-guest dir, run ctest. Exit code
+# propagates back through ssh.
+note "running build ($BUILD_TYPE) + ctest in-guest"
+set +e
+vmsh "BUILD_TYPE='$BUILD_TYPE' CTEST_ARGS='$CTEST_ARGS' bash -s" <<'GUEST'
+set -euo pipefail
+eval "$(/opt/homebrew/bin/brew shellenv)"
+SHARED="/Volumes/My Shared Files"
+ln -sfn "$SHARED/src" "$HOME/src"
+ln -sfn "$SHARED/ccache" "$HOME/ccache"
+ln -sfn "$SHARED/fetchcontent" "$HOME/fetchcontent"
+
+export CCACHE_DIR="$HOME/ccache"
+export CCACHE_TEMPDIR="$HOME/.ccache-tmp"        # IN-GUEST — never on the virtio-fs mount
+mkdir -p "$CCACHE_TEMPDIR"
+export CCACHE_BASEDIR="$HOME/src"
+export CCACHE_NOHASHDIR=true
+export CCACHE_SLOPPINESS=time_macros,pch_defines
+export CCACHE_DEPEND=true
+# Skia is baked into the pulp-build-base golden at ~/pulp-skia-build (Tier 2).
+# FindSkia.cmake wants the dir CONTAINING build/, not .../build/mac-gpu.
+export SKIA_DIR="$HOME/pulp-skia-build"
+export FETCHCONTENT_BASE_DIR="$HOME/fetchcontent"
+
+ccache --zero-stats >/dev/null 2>&1 || true
+BUILD="$HOME/build"
+rm -rf "$BUILD"
+cmake -S "$HOME/src" -B "$BUILD" \
+  -G Ninja \
+  -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
+  -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=ON \
+  -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+cmake --build "$BUILD" --parallel "$(sysctl -n hw.ncpu)"
+echo "=== ccache stats (warmth) ==="
+ccache --show-stats | grep -iE 'cacheable|hit|miss|cache size' || ccache -s
+ctest --test-dir "$BUILD" $CTEST_ARGS
+GUEST
+RC=$?
+set -e
+
+note "in-guest exit=$RC"
+echo "=== host ccache after job (durable across clones) ==="
+CCACHE_DIR="$CACHE_ROOT/ccache" ccache --show-stats 2>/dev/null | grep -iE 'cache size|hits|misses|hit rate' || true
+exit $RC

--- a/tools/ci/tart-runner.sh
+++ b/tools/ci/tart-runner.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# tart-runner.sh — ephemeral, per-job GitHub Actions runner on Tart.
+#
+# This is the "right long-term" execution model from
+# planning/2026-06-01-macos-ci-isolation-plan.md: every CI job runs in a FRESH
+# clone of the runner golden, then the VM is destroyed. No build-dir churn, no
+# state drift, no ODR class of bug (the 0x3f800000 crash) — ever. The host stays
+# responsive because builds never touch it directly.
+#
+# Mechanism: mint a Just-In-Time (JIT) runner config from GitHub (inherently
+# single-job / ephemeral), clone pulp-build-runner, boot it with the host ccache
+# mounted for warmth, run the agent once with that JIT config, then discard.
+#
+# CONCURRENCY: macOS caps 2 running VMs PER HOST (kernel quota; see plan
+# Appendix D). With `pulp-vm` (operator's box) running, only 1 ephemeral slot is
+# free on that host. To exceed 2 concurrent, run this supervisor on multiple
+# Macs (the same hosts that run the bare-metal runners today) or enable the
+# Appendix-D quota override on the dedicated Studio.
+# TODO (capacity+queue-aware --loop): only boot a VM when there is queued work
+# AND running_macos_vms < cap, cooperating with tools/scripts/macos_reroute_watcher.py
+# (task #22), whose "local idle" check should evolve to "free VM slot". That
+# closes the loop the operator described: when the host frees up later, drain
+# still-queued GitHub macOS jobs locally instead of leaving them on cloud.
+#
+# Pilot-safe by default: the label is `pulp-build-vm` (NOT the required
+# `pulp-build`), so jobs only land here when explicitly routed
+# (`gh workflow run build.yml -f macos_runner_selector_json='["self-hosted","pulp-build-vm"]'`).
+# Promote to `pulp-build` only after a clean pilot.
+#
+# Usage:
+#   tart-runner.sh                     # one ephemeral job then exit (pilot default)
+#   tart-runner.sh --loop              # keep spinning a fresh VM after each job
+#   tart-runner.sh --labels self-hosted,macos,arm64,pulp-build   # promote
+#   tart-runner.sh --golden pulp-build-runner:latest --repo danielraffel/pulp
+set -euo pipefail
+
+export TART_HOME="${TART_HOME:-/Volumes/Workshop/VMs}"
+SSH_KEY_PRIV="${PULP_VM_SSH_KEY:-$HOME/.ssh/id_ed25519}"
+VM_USER="${PULP_VM_USER:-admin}"
+CACHE_ROOT="${PULP_CI_CACHE:-$HOME/.cache/pulp-ci}"
+GOLDEN="${PULP_RUNNER_GOLDEN:-pulp-build-runner:latest}"
+REPO="${PULP_RUNNER_REPO:-danielraffel/pulp}"
+LABELS="${PULP_RUNNER_LABELS:-self-hosted,macos,arm64,pulp-build-vm}"
+RUNNER_GROUP_ID="${PULP_RUNNER_GROUP_ID:-1}"
+LOOP=0
+SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ConnectTimeout=10 -o BatchMode=yes)
+
+note(){ printf '\033[36m• %s\033[0m\n' "$*" >&2; }
+die(){ printf '\033[31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
+command -v tart >/dev/null 2>&1 || die "tart not installed"
+command -v gh   >/dev/null 2>&1 || die "gh not installed / authed (need admin to mint JIT config)"
+
+while [ $# -gt 0 ]; do case "$1" in
+  --loop) LOOP=1; shift;;
+  --once) LOOP=0; shift;;
+  --golden) GOLDEN="$2"; shift 2;;
+  --labels) LABELS="$2"; shift 2;;
+  --repo) REPO="$2"; shift 2;;
+  *) die "unknown arg: $1";;
+esac; done
+
+run_one(){ # $1=iteration index (keeps VM name unique without Date.now/rand)
+  local i="$1" vm="ephr-$$-$1" jit
+  note "[$i] minting JIT runner config (labels=$LABELS, ephemeral)"
+  local label_args=(); local l; IFS=',' read -ra _ls <<< "$LABELS"
+  for l in "${_ls[@]}"; do label_args+=(-f "labels[]=$l"); done
+  jit="$(gh api -X POST "repos/$REPO/actions/runners/generate-jitconfig" \
+        -f "name=$vm" -F "runner_group_id=$RUNNER_GROUP_ID" "${label_args[@]}" \
+        --jq '.encoded_jit_config')" || die "JIT config mint failed (need repo admin)"
+  [ -n "$jit" ] || die "empty JIT config"
+
+  note "[$i] clone $GOLDEN → $vm (CoW) + boot with host ccache mounted"
+  tart clone "$GOLDEN" "$vm"
+  local rpid; tart run --no-graphics --dir="ccache:$CACHE_ROOT/ccache" "$vm" >/dev/null 2>&1 & rpid=$!
+
+  local ip=""; local k
+  for k in $(seq 1 60); do ip="$(tart ip "$vm" 2>/dev/null || true)"; [ -n "$ip" ] && break; sleep 2; done
+  [ -n "$ip" ] || { tart stop "$vm" >/dev/null 2>&1||true; kill "$rpid" 2>/dev/null||true; tart delete "$vm" >/dev/null 2>&1||true; die "[$i] no IP"; }
+  for k in $(seq 1 90); do ssh "${SSH_OPTS[@]}" -i "$SSH_KEY_PRIV" "$VM_USER@$ip" true 2>/dev/null && break; sleep 2; done
+  note "[$i] vm $vm up at $ip — wiring ccache mount + launching JIT runner (one job)"
+
+  # Point the (no-space) CCACHE_DIR from the golden .env at the virtio-fs mount,
+  # keep CCACHE_TEMPDIR in-guest (set in the golden .env). Then run the agent
+  # once; a JIT runner processes exactly one job and deregisters.
+  # Source brew's shellenv so the runner PROCESS (and therefore every job step
+  # it spawns) inherits /opt/homebrew/bin on PATH + HOMEBREW_*. Without this the
+  # SSH non-interactive shell has a minimal PATH and `brew` is exit-127 in steps
+  # (the bare-metal runners get this via their login shell instead).
+  ssh "${SSH_OPTS[@]}" -i "$SSH_KEY_PRIV" "$VM_USER@$ip" \
+    "mkdir -p ~/Library/Caches ~/.ccache-tmp && ln -sfn '/Volumes/My Shared Files/ccache' ~/Library/Caches/ccache && \
+     printf '%s' '$jit' > ~/jit.cfg && eval \"\$(/opt/homebrew/bin/brew shellenv)\" && cd ~/actions-runner && ./run.sh --jitconfig \"\$(cat ~/jit.cfg)\"" \
+    || note "[$i] runner exited non-zero (job failure or no job) — VM will be discarded regardless"
+
+  note "[$i] discarding ephemeral VM $vm"
+  tart stop "$vm" >/dev/null 2>&1 || true; kill "$rpid" 2>/dev/null || true; sleep 2
+  tart delete "$vm" >/dev/null 2>&1 || true
+}
+
+i=0
+if [ "$LOOP" = 1 ]; then
+  note "ephemeral runner LOOP (Ctrl-C to stop); golden=$GOLDEN labels=$LABELS"
+  while true; do i=$((i+1)); run_one "$i" || true; done
+else
+  note "ephemeral runner ONCE; golden=$GOLDEN labels=$LABELS"
+  run_one 1
+fi


### PR DESCRIPTION
Stand up a fast/cached/isolated/disposable macOS CI lane on Tart so builds
run in throwaway VMs cloned from versioned golden images and the host stays
responsive.

- tools/ci/tart-provision.sh: finalize layered goldens
  (base -> apple-xcode -> pulp -> runner) with verified Cirrus/Tart specifics
  (Tahoe base, admin/admin, auto-login, guest-agent disk grow, host-Xcode
  rsync), plus verify/tag/resize and manifest-driven baking.
- tools/ci/tart-run-job.sh: ephemeral per-job build (clone -> mount host
  ccache/FetchContent via virtio-fs -> build+ctest in-guest -> discard).
- tools/ci/tart-runner.sh: ephemeral JIT GitHub Actions runner — one real
  job per pristine VM, then destroyed. Permanently removes the build-dir
  churn / ODR class of failure.
- .shipyard/vm-image.toml + tools/ci/examples/vm-image.rust-repo.toml:
  reusable per-repo golden-image manifest (bake or configure-on-boot).
- ship: check_notarization() returns false for a nonexistent path before
  consulting spctl — CI base images disable Gatekeeper assessment, so
  `spctl --assess` returns 0 for any argument. Surfaced and verified by the
  Tart VM lane; documented in the ship skill.

Proven on real runs: clone->build->test->discard; ccache warmth 0.6%->88%
across sequential clones; headless Skia/Metal GPU render; full ctest green
in-VM after the ship fix.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>