### PR TITLE
tart-ci skill + Skia/Dawn baked-cache optimization

### DIFF
--- a/.agents/skills/tart-ci/SKILL.md
+++ b/.agents/skills/tart-ci/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: tart-ci
+description: Stand up a fast, cached, isolated, disposable macOS CI lane on Tart — layered golden VM images, ephemeral per-job GitHub Actions runners, host-mounted caches, and a reusable per-repo vm-image manifest. Use when setting up VM-based CI for Pulp or generalizing it to another repo, building/refreshing golden images, wiring ephemeral runners, or debugging the VM lane.
+requires:
+  - tart            # brew install cirruslabs/cli/tart
+  - sshpass         # brew install hudochenkov/sshpass/sshpass (first-boot key injection only)
+  - gh              # authenticated; minting JIT runner configs needs repo admin
+---
+
+# Tart golden-VM CI lane
+
+Run every macOS build/validation in a **throwaway VM cloned from a versioned golden image** so the host stays responsive and builds are reproducible. Generalizes to any repo via one `vm-image` manifest. Born from Pulp `planning/2026-06-01-macos-ci-isolation-plan.md`; the scripts live in `tools/ci/`.
+
+## Why (the failure modes this fixes)
+- **Build-dir churn → ODR heap corruption.** One `build/` reconfigured across branches/build-types mixes object layouts → `malloc: error for object 0x3f800000` (that's `1.0f` freed as a pointer) aborting in e.g. `Theme::~Theme`. Every job in a *pristine* clone makes this impossible.
+- **Host-local validation is fragile + invasive.** Validating in the editing checkout inherits churn, pops GUI keychain dialogs, and competes for CPU. VMs are headless and disposable.
+- **Spotlight/`fseventsd` storms** from build churn make the Mac unusable. VMs + `.metadata_never_index` keep the host calm.
+
+## Core pieces (all in `tools/ci/`)
+| Script | Role |
+|---|---|
+| `tart-provision.sh` | Build/refresh layered golden images; `verify`/`tag`/`resize`/`manifest` helpers. Subcommands: `base` → `apple-xcode` → `pulp` → `runner`. |
+| `tart-runner.sh` | **Ephemeral per-job GitHub Actions runner.** Mints a JIT (single-job) runner config, clones the runner golden, boots with host ccache mounted, runs one job, destroys the VM. `--loop` keeps a fresh one ready; `--once` for a pilot. |
+| `tart-run-job.sh` | **Direct** ephemeral build (no GitHub runner): clone golden → virtio-fs mount host caches → build+ctest in-guest → discard. Useful for Shipyard `backend` / manual builds. |
+| `pulp-worktree.sh` | Per-branch worktrees + shared ccache (host-side dev isolation; complements the VM lane). |
+| `.shipyard/vm-image.toml` | **The per-repo reuse unit** (see below). |
+
+## The vm-image manifest (the unit of reuse)
+A new repo adds one `.shipyard/vm-image.toml` and the same `tart-provision.sh manifest <path>` bakes it — no hand-provisioning. Two strategies:
+- `strategy = "bake"` — pre-bake a project image (fast clones for hot repos).
+- `strategy = "configure-on-boot"` — clone the bare base + apply the manifest on boot (flexible/new repos).
+
+Fields: `base`, `disk_gb`, `auto_login`, `[toolchain].xcode` (omit → no Xcode tier), `[brew].packages`, `[pip].packages`, `[caches].ccache_max`, `[[mounts]]`. See `.shipyard/vm-image.toml` (Pulp: Xcode+Skia) and `tools/ci/examples/vm-image.rust-repo.toml` (a light Rust profile, no Xcode — proves generalization).
+
+## Verified base/runtime specifics (cirruslabs + Tart, 2026-06-01)
+- Base image `ghcr.io/cirruslabs/macos-tahoe-base:latest` = macOS 26 "Tahoe" (matches Xcode 26.5 / build 17F42). Default creds `admin`/`admin`.
+- The vanilla base **already** enables auto-login (kcpassword + `loginwindow autoLoginUser`) and Remote Login (sshd) — *verify*, don't recreate. Auto-login is REQUIRED for WindowServer/Metal.
+- `tart set <vm> --disk-size N` only grows, only on a **stopped** VM; the bundled tart-guest-agent grows APFS on next boot.
+- Prefer rsync'ing a **host-installed Xcode** into the golden over an in-guest `xcodes install` (interactive 2FA + multi-hour re-download). Remote rsync to `/Applications` needs `--rsync-path="sudo /opt/homebrew/bin/rsync"`.
+
+## Caching strategy (the smart split)
+- **Immutable, expensive-to-build deps → baked into the golden (CoW-shared, ~free per clone).** Skia + Dawn are prebuilt static libs (`libskia.a`, `libdawn_combined.a`, ~385 MB) baked at `~/pulp-skia-build`; `SKIA_DIR` points there. They are *never* recompiled.
+- **Mutable, growing caches → host-mounted via virtio-fs.** ccache (warm across clones — measured cold→warm 0.6%→88%) and FetchContent sources. Keep `CCACHE_TEMPDIR` **in-guest** (cross-fs rename onto virtio-fs breaks ccache); `CCACHE_BASEDIR` normalizes paths; guest `admin` is uid 501 == host primary user so the shared ccache is writable both ways.
+
+## GPU works in the guest (no hybrid lane needed)
+Apple Virtualization provides Metal in the guest **even with `--no-graphics`**. Verified: `pulp-screenshot --backend skia` renders a real Skia/Metal PNG, `nm pulp-ui-preview | grep MacGpuWindowHost` = present. So the full mac lane (build + GPU + tests) runs in-VM.
+
+## Dependency updates → golden re-bake (don't get stuck on old deps)
+Skia/Dawn are pinned in `tools/deps/manifest.json` (release-asset URL + sha256 per platform; `tools/scripts/fetch_skia_for_release.py` consumes it). Single source of truth = the manifest pin.
+- When deps bump (new `danielraffel/skia-builder` release, e.g. `chrome/m149` → newer), the Dependency Update Workflow bumps the manifest pin.
+- **Then re-bake the golden** so its baked Skia matches: re-run the `pulp`/`runner` tiers (they should fetch per the *current* pin, not a stale copy), tag a new `:<date>`, refresh `:latest`. Ephemeral jobs clone `:latest` → get the new Skia. Keep the last 1–2 dated goldens per tier; prune older.
+- Tie golden re-bakes to dependency-bump PRs and toolchain bumps (Xcode). Pinning Xcode + Skia in-image keeps font/raster goldens reproducible.
+
+## Concurrency & hosts
+- **macOS caps 2 concurrent running VMs PER HOST** (kernel quota; booting a 3rd throws "number of VMs exceeds the system limit"). For ≥3 concurrent, **distribute runners across multiple Macs** (e.g. Mac Studio + MacBook Pro M5 → 2+2 = 4) — each runs `tart-runner.sh`; new hosts inherit the host-class label (`*-studio`, `*-m1`, `*-m5`) and cap=2. A dedicated Studio *can* raise the cap via the kernel-quota override (plan Appendix D; SIP off + dev kernel — last resort).
+- A persistent operator VM (e.g. `pulp-vm`) on a host consumes 1 of its 2 slots.
+- Capacity-aware cloud→local queue draining belongs in Shipyard's multi-Mac controller: its "local idle" signal must become "free VM slot" (`running_macos_vms < cap`, summed across hosts) so a freed slot drains a still-queued job instead of leaving it on cloud. (Track the cross-cutting work in `planning/`, not here.)
+
+## Rollout: pilot → graduate
+1. **Additive pilot (safe):** run `tart-runner.sh --once` with a **non-required** label (`pulp-build-vm`). Trigger a real job without touching required routing: `gh workflow run build.yml -f macos_runner_selector_json='["self-hosted","pulp-build-vm"]'`. Confirm green.
+2. **Graduate:** add the runner to the required `pulp-build` pool (or stage replacing bare-metal), distributed across hosts. Never point a required check at an empty label; preflight that the label has online runners.
+
+## Gotchas (hard-won)
+- **NEVER run signing/keychain tests on a non-VM host.** `check_notarization`/codesign tests call `security`/`codesign`/`notarytool`, which on an interactive host pop GUI keychain dialogs and can disrupt the default keychain. Run them **only in the disposable VM**. Never click "Reset To Defaults" on a keychain prompt on a real Mac; never wipe a host keychain.
+- **Gatekeeper disabled in the CI base:** the cirruslabs base ships `spctl --master-disable`, so `spctl --assess` returns 0 for *any* path (even nonexistent). `check_notarization` was hardened with an `fs::exists` short-circuit so it's correct in both environments (see the `ship` skill).
+- **Clean the build dir on build-type flips.** Shipyard `backend=local` reconfiguring Debug over a Release `build/` reproduces the ODR churn → false test failures. `rm -rf build` first, or (better) validate in the VM, not the editing checkout.
+- **Disk: sparse + CoW.** Each `disk.img` is a sparse 150 GB file (~45 GB real); `du`/Finder show apparent size (N×150 GB) but `df` shows the truth (CoW clones share blocks — e.g. 13 VMs ≈ 313 GB real). Don't panic at apparent size; prune redundant bare working VMs (tags retain shared blocks).
+- **First key injection needs `sshpass`** (password auth once); afterward everything uses the injected `id_ed25519`. `tart ip` can take ~10–120 s after boot — poll, don't fixed-sleep.
+- **Use shipyard (its own higher-quota auth) over raw `gh`** for GitHub ops to avoid rate limits; `gh`'s token lives in the login keychain (or `~/.config/gh/hosts.yml` with config storage).
+
+## Store & hygiene
+`TART_HOME=/Volumes/Workshop/VMs` (Spotlight-excluded via `.metadata_never_index`). Tag goldens `:<date>` + roll `:latest`. Ephemeral job VMs are deleted after use; confirm cleanup (`tart delete` fails silently on a *running* VM — stop → delete → verify). Reclaim with `tart-provision.sh list` + prune.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -913,13 +913,14 @@ Alphabetical. One line of purpose per skill. Each directory at `.agents/skills/<
 | `sdf-text` | SDF / MSDF / PSDF glyph atlases: building, sampling via SkSL, shared text-layout helpers |
 | `ship` | Sign / notarize / package / distribute Pulp plugins and apps across macOS / Windows / Android |
 | `streams` | `pulp::runtime::AsyncStream` selection, async-callback wiring without deadlock, backpressure |
+| `tart-ci` | Tart golden-VM macOS CI: layered goldens, ephemeral per-job runners, vm-image manifest, caching/rebake, host-keychain safety |
 | `threejs-bridge` | Native Dawn-backed Three.js: three.webgpu.js renderer, bridge tests, native demo capture |
 | `upgrade` | `pulp upgrade` guidance: release discovery, migration notes, breaking-change fixes |
 | `view-bridge` | Editor lifecycle and multi-view attach — `Processor::create_view()`, open/notify/resize/close protocol |
 | `vst3` | VST3 adapter: SingleComponentEffect, bus arrangement, param/MIDI routing, state, Steinberg SDK traps |
 | `webview-ui` | WebView UI: native bridge, embedded assets, directory-backed dev resources, WebView validation |
 
-25 skills as of 2026-04-27. When adding a new skill, append its row here and register the subsystem in `tools/scripts/skill_path_map.json`.
+26 skills as of 2026-06-01. When adding a new skill, append its row here and register the subsystem in `tools/scripts/skill_path_map.json`.
 
 ### Claude Code Plugin
 

--- a/tools/ci/tart-provision.sh
+++ b/tools/ci/tart-provision.sh
@@ -229,6 +229,7 @@ provision_runner(){ # $1=from-pulp-vm  $2=new-vm
   vm_ssh "$ip" 'cat > ~/actions-runner/.env <<ENVV
 PATH=/Users/admin/.local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin
 SKIA_DIR=/Users/admin/pulp-skia-build
+PULP_USE_BAKED_SKIA=1
 CMAKE_C_COMPILER_LAUNCHER=ccache
 CMAKE_CXX_COMPILER_LAUNCHER=ccache
 CCACHE_DIR=/Users/admin/Library/Caches/ccache

--- a/tools/scripts/fetch_skia_for_release.py
+++ b/tools/scripts/fetch_skia_for_release.py
@@ -57,6 +57,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import sys
 import urllib.request
 import zipfile
@@ -183,6 +184,32 @@ def main(argv: list[str]) -> int:
     print(f"  url: {url}")
     print(f"  sha256: {expected_sha}")
     print(f"  expected lib: {expected_lib}")
+
+    # Opt-in baked-Skia short-circuit (PULP_USE_BAKED_SKIA — set ONLY by the
+    # Tart VM runner golden, never by releases or clean GitHub runners). The
+    # golden bakes Skia at $SKIA_DIR, so the workflow's fetch is redundant:
+    # FindSkia.cmake reads $SKIA_DIR before the checkout's external/skia-build.
+    # We skip the ~250-500 MiB download ONLY when the baked Skia's stamp matches
+    # the current manifest pin — so a pin bump on a not-yet-rebaked golden falls
+    # through to a normal fetch and is NEVER stuck on stale baked Skia. The same
+    # stamp invariant as the dest guard below, applied to $SKIA_DIR.
+    baked_dir = os.environ.get("SKIA_DIR", "").strip()
+    if os.environ.get("PULP_USE_BAKED_SKIA") and baked_dir:
+        baked_root = Path(baked_dir)
+        baked_lib = baked_root / expected_lib.relative_to("external/skia-build")
+        baked_stamp = baked_root / ".skia-asset-sha256"
+        if (baked_lib.is_file() and baked_stamp.is_file()
+                and baked_stamp.read_text(encoding="utf-8").strip() == expected_sha):
+            print(
+                f"OK: using baked Skia at {baked_dir} "
+                f"(sha256 {expected_sha} matches pin); skipping fetch "
+                f"(PULP_USE_BAKED_SKIA)"
+            )
+            return 0
+        print(
+            "PULP_USE_BAKED_SKIA set but baked Skia is missing or stale "
+            "(stamp != current pin) — re-fetching the pinned asset."
+        )
 
     # Idempotency stamp. A self-hosted CI runner checks out with
     # `clean: false`, so `external/skia-build/` persists between jobs;

--- a/tools/scripts/skill_path_map.json
+++ b/tools/scripts/skill_path_map.json
@@ -245,6 +245,14 @@
         "examples/stream-*/**"
       ]
     },
+    "tart-ci": {
+      "paths": [
+        "tools/ci/tart-*.sh",
+        "tools/ci/pulp-worktree.sh",
+        "tools/ci/examples/vm-image.*",
+        ".shipyard/vm-image.toml"
+      ]
+    },
     "threejs-bridge": {
       "paths": [
         "examples/threejs-*/**"

--- a/tools/scripts/test_fetch_skia_for_release_extra.py
+++ b/tools/scripts/test_fetch_skia_for_release_extra.py
@@ -188,5 +188,63 @@ class FetchSkiaForReleaseExtraTests(unittest.TestCase):
             self.assertIn("expected library not found", err.getvalue())
 
 
+class BakedSkiaShortCircuit(unittest.TestCase):
+    """PULP_USE_BAKED_SKIA: the Tart VM runner bakes Skia at $SKIA_DIR, so the
+    workflow fetch is redundant — but only skip when the baked stamp matches the
+    current pin, so a pin bump on a stale golden re-fetches (never stuck)."""
+
+    def _manifest(self, digest: str) -> None:
+        manifest = pathlib.Path("tools/deps/manifest.json")
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        manifest.write_text(
+            json.dumps({"dependencies": [{
+                "name": "Skia",
+                "determinism": {"release_assets": {
+                    "mac-arm64": {"url": "https://example.invalid/skia.zip", "sha256": digest},
+                }},
+            }]}),
+            encoding="utf-8",
+        )
+
+    def _bake(self, root: pathlib.Path, stamp: str) -> None:
+        lib = root / "build/mac-gpu/lib/Release/libskia.a"
+        lib.parent.mkdir(parents=True, exist_ok=True)
+        lib.write_bytes(b"baked")
+        (root / ".skia-asset-sha256").write_text(stamp, encoding="utf-8")
+
+    def test_baked_matching_stamp_skips_fetch_without_download(self) -> None:
+        with tempfile.TemporaryDirectory() as td, cwd(pathlib.Path(td)):
+            digest = "a" * 64
+            self._manifest(digest)
+            baked = pathlib.Path("baked"); self._bake(baked, digest)
+
+            def _boom(*a, **k):
+                raise AssertionError("urlopen must NOT be called when baked Skia matches the pin")
+
+            out = io.StringIO()
+            with mock.patch.dict(os.environ, {"PULP_USE_BAKED_SKIA": "1", "SKIA_DIR": str(baked.resolve())}), \
+                 mock.patch.object(skia.urllib.request, "urlopen", side_effect=_boom), \
+                 contextlib.redirect_stdout(out):
+                self.assertEqual(skia.main(["fetch", "darwin-arm64"]), 0)
+            self.assertIn("PULP_USE_BAKED_SKIA", out.getvalue())
+            self.assertIn("skipping fetch", out.getvalue())
+            self.assertFalse(pathlib.Path("external/skia-build").exists())
+
+    def test_baked_stale_stamp_refetches(self) -> None:
+        with tempfile.TemporaryDirectory() as td, cwd(pathlib.Path(td)):
+            data = make_zip_bytes(pathlib.Path("build/mac-gpu/lib/Release/libskia.a"), b"fresh")
+            digest = hashlib.sha256(data).hexdigest()
+            self._manifest(digest)
+            baked = pathlib.Path("baked"); self._bake(baked, "0" * 64)  # stale stamp != pin
+
+            out = io.StringIO()
+            with mock.patch.dict(os.environ, {"PULP_USE_BAKED_SKIA": "1", "SKIA_DIR": str(baked.resolve())}), \
+                 mock.patch.object(skia.urllib.request, "urlopen", return_value=_FakeResponse(data)), \
+                 contextlib.redirect_stdout(out):
+                self.assertEqual(skia.main(["fetch", "darwin-arm64"]), 0)
+            self.assertIn("missing or stale", out.getvalue())
+            self.assertTrue(pathlib.Path("external/skia-build/build/mac-gpu/lib/Release/libskia.a").is_file())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Follow-up to #3300 (the Tart golden-VM macOS CI lane).

## What
- **`.agents/skills/tart-ci`** — generalizable skill for the whole Tart golden-VM CI process: layered goldens, ephemeral per-job runners, the `vm-image` manifest as the per-repo reuse unit, the caching strategy, the dependency-bump→golden-rebake plan, the 2-VM/host cap + multi-host distribution, and the hard-won gotchas (Gatekeeper-disabled base, host-keychain safety, build-dir-churn false-failures). Registered in `skill_path_map.json` + the CLAUDE.md skill table.
- **`fetch_skia_for_release.py`** — opt-in `PULP_USE_BAKED_SKIA` short-circuit: the Tart runner uses the Skia/Dawn baked into the golden (`$SKIA_DIR`) instead of re-downloading the asset, **gated on a stamp match against the manifest pin**. A pin bump on a not-yet-rebaked golden falls through to a normal fetch — never stuck on stale baked Skia. Releases/clean runners (no flag) are unchanged. Wired `PULP_USE_BAKED_SKIA=1` into the runner golden's `.env`.
- Tests: baked-matching-stamp skips without download; stale-baked re-fetches.

## Validation note
Validated on clean GH runners. shipyard's `backend=local` is being routed to the VM lane separately (it false-fails on the editing checkout via Debug-over-Release build-dir churn — the very class of bug this work eliminates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)