### PR TITLE
fix(import-design): detect_audio_widget matches whole words not substrings

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -198,6 +198,13 @@ mind when touching this:
 - **Recognized-widget gate.** Synthesis only fires when `audio_widget != none`.
   A generic/visual frame that happens to carry a `binding` attribute gets NO
   synthesized binding — it stays a generic node. Don't loosen this gate.
+- **`detect_audio_widget` matches whole WORD TOKENS, not substrings.** It
+  tokenizes the layer name on non-alnum + camelCase (acronym-aware, so
+  `VUMeter`→{vu,meter}) + letter↔digit, then matches whole tokens (simple
+  plural tolerated: `Knobs`→knob). This is deliberate: the old `find()` substring
+  match promoted `Dialog`/`Radial`→knob and `Parameter`/`Diameter`→meter (gap
+  survey). Don't revert to substring matching; add new keywords as tokens + a
+  false-positive regression case in `test_design_import.cpp`.
 - **Module/param split.** Split on the FIRST `.`: `"filter.cutoff_hz"` →
   `pulpBindingModule="filter"`, `pulpBindingParam="cutoff_hz"`,
   `pulpParamKey="filter.cutoff_hz"`. No dot → empty module, whole string is the

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.156.0",
+      "version": "0.156.1",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.156.0"
+  "version": "0.156.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.156.0",
+  "version": "0.156.1",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.312.0
+    VERSION 0.312.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/design_import.cpp
+++ b/core/view/src/design_import.cpp
@@ -467,23 +467,57 @@ static std::string to_lower(const std::string& s) {
     return result;
 }
 
+// Split a layer name into lowercase WORD tokens. Boundaries: any non-alnum
+// char, camelCase (lower→Upper), acronym→Word (Upper→Upper-then-lower), and
+// letter↔digit. So "GainKnob"→{gain,knob}, "VUMeter"→{vu,meter},
+// "FilterXYPad"→{filter,xy,pad}, "knob_01"→{knob,01} — but "Dialog"→{dialog}
+// and "Parameter"→{parameter} (NOT split into dial/meter). Word-boundary
+// matching is what kills the substring false-positives below.
+static std::vector<std::string> tokenize_name(const std::string& name) {
+    std::vector<std::string> tokens;
+    std::string cur;
+    auto flush = [&] { if (!cur.empty()) { tokens.push_back(cur); cur.clear(); } };
+    const std::size_t n = name.size();
+    for (std::size_t i = 0; i < n; ++i) {
+        const unsigned char c = static_cast<unsigned char>(name[i]);
+        if (!std::isalnum(c)) { flush(); continue; }
+        if (!cur.empty()) {
+            const unsigned char p = static_cast<unsigned char>(name[i - 1]);
+            bool boundary = false;
+            if (std::islower(p) && std::isupper(c)) boundary = true;            // aB → a|B
+            else if (std::isupper(p) && std::isupper(c) && i + 1 < n
+                     && std::islower(static_cast<unsigned char>(name[i + 1])))
+                boundary = true;                                               // ABc → A|Bc (acronym→Word)
+            else if ((std::isdigit(p) != 0) != (std::isdigit(c) != 0))
+                boundary = true;                                               // a1 / 1a
+            if (boundary) flush();
+        }
+        cur += static_cast<char>(std::tolower(c));
+    }
+    flush();
+    return tokens;
+}
+
+// Recognize audio widgets by WHOLE-WORD name tokens, not substrings. The old
+// substring match promoted any name *containing* "dial"/"meter"/… — so
+// "Dialog"/"Radial"/"Medallion" became knobs and "Parameter"/"diameter" became
+// meters. Token matching (pulp design-import gap survey) fixes those while
+// keeping "xy_pad"/"xypad" and acronym names like "VUMeter".
 AudioWidgetType detect_audio_widget(const std::string& name) {
-    auto lower = to_lower(name);
-    if (lower.find("knob") != std::string::npos)      return AudioWidgetType::knob;
-    if (lower.find("dial") != std::string::npos)       return AudioWidgetType::knob;
-    if (lower.find("fader") != std::string::npos)      return AudioWidgetType::fader;
-    if (lower.find("slider") != std::string::npos)     return AudioWidgetType::fader;
-    if (lower.find("meter") != std::string::npos)      return AudioWidgetType::meter;
-    if (lower.find("level") != std::string::npos)      return AudioWidgetType::meter;
-    if (lower.find("vu") != std::string::npos)         return AudioWidgetType::meter;
-    if (lower.find("xypad") != std::string::npos)      return AudioWidgetType::xy_pad;
-    if (lower.find("xy_pad") != std::string::npos)     return AudioWidgetType::xy_pad;
-    if (lower.find("xy pad") != std::string::npos)     return AudioWidgetType::xy_pad;
-    if (lower.find("waveform") != std::string::npos)   return AudioWidgetType::waveform;
-    if (lower.find("oscilloscope") != std::string::npos) return AudioWidgetType::waveform;
-    if (lower.find("spectrum") != std::string::npos)   return AudioWidgetType::spectrum;
-    if (lower.find("analyzer") != std::string::npos)   return AudioWidgetType::spectrum;
-    if (lower.find("analyser") != std::string::npos)   return AudioWidgetType::spectrum;
+    const auto toks = tokenize_name(name);
+    const std::unordered_set<std::string> t(toks.begin(), toks.end());
+    // Whole-token match, tolerant of a simple English plural ("Knobs"/"Faders"
+    // → knob/fader) which the old substring match also caught — but never a
+    // substring ("Dialog"/"Parameter" stay unmatched).
+    auto has = [&](const std::string& w) {
+        return t.find(w) != t.end() || t.find(w + "s") != t.end();
+    };
+    if (has("knob") || has("dial"))                            return AudioWidgetType::knob;
+    if (has("fader") || has("slider"))                         return AudioWidgetType::fader;
+    if (has("meter") || has("level") || has("vu"))             return AudioWidgetType::meter;
+    if (has("xypad") || (has("xy") && has("pad")))             return AudioWidgetType::xy_pad;
+    if (has("waveform") || has("oscilloscope"))                return AudioWidgetType::waveform;
+    if (has("spectrum") || has("analyzer") || has("analyser")) return AudioWidgetType::spectrum;
     return AudioWidgetType::none;
 }
 

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -1636,6 +1636,27 @@ TEST_CASE("detect_audio_widget identifies widget types from names", "[view][impo
     REQUIRE(detect_audio_widget("save_button") == AudioWidgetType::none);
 }
 
+TEST_CASE("detect_audio_widget matches whole words not substrings", "[view][import]") {
+    // Regression (gap survey): substring matching promoted any name *containing*
+    // a keyword. These embed a keyword as a substring but are NOT audio widgets —
+    // word-boundary tokenization must return none.
+    REQUIRE(detect_audio_widget("Dialog") == AudioWidgetType::none);      // "dial"og
+    REQUIRE(detect_audio_widget("Radial") == AudioWidgetType::none);      // ra"dial"
+    REQUIRE(detect_audio_widget("Parameter") == AudioWidgetType::none);   // para"meter"
+    REQUIRE(detect_audio_widget("Diameter") == AudioWidgetType::none);    // dia"meter"
+    REQUIRE(detect_audio_widget("sublevel") == AudioWidgetType::none);    // sub"level"
+    REQUIRE(detect_audio_widget("Knobby") == AudioWidgetType::none);      // "knob"by
+
+    // True positives still recognized: separators, acronym camelCase, plurals.
+    REQUIRE(detect_audio_widget("VUMeter") == AudioWidgetType::meter);    // acronym→Word: {vu,meter}
+    REQUIRE(detect_audio_widget("xy pad") == AudioWidgetType::xy_pad);    // space-separated
+    REQUIRE(detect_audio_widget("XYPad") == AudioWidgetType::xy_pad);     // {xy,pad}
+    REQUIRE(detect_audio_widget("Knob 01") == AudioWidgetType::knob);     // letter↔digit split keeps "knob"
+    REQUIRE(detect_audio_widget("main-fader") == AudioWidgetType::fader);
+    REQUIRE(detect_audio_widget("Knobs") == AudioWidgetType::knob);       // simple plural still matches
+    REQUIRE(detect_audio_widget("Faders") == AudioWidgetType::fader);
+}
+
 // ── Figma JSON parsing ──────────────────────────────────────────────────
 
 TEST_CASE("parse_figma_json parses IR format", "[view][import]") {


### PR DESCRIPTION
Design-import gap-survey quick-win. `detect_audio_widget` used substring `find()`, so any name *containing* a keyword was promoted: **Dialog/Radial → knob**, **Parameter/Diameter → meter**, etc.

Now it tokenizes the layer name on non-alnum + camelCase (acronym-aware: `VUMeter` → {vu,meter}) + letter↔digit, and matches **whole tokens** (simple plural tolerated: `Knobs` → knob). True positives unchanged; substring false-positives return `none`.

- Regression test (`test_design_import.cpp`): Dialog/Radial/Parameter/Diameter/sublevel/Knobby → none; VUMeter/xy pad/XYPad/Knobs/Faders still recognized. Built + ran locally: 28 assertions, 2 cases green.
- Documents the whole-word invariant in the `import-design` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)