### PR TITLE
fix(view+import-design): address design-import review findings

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -479,6 +479,33 @@ per-range styling. Now:
   conversion (follow-up). Tests use ASCII. Tests: `[view][import][text]` +
   the figma exporter python tests.
 
+### Design-import IR round-trip + review-hardening gotchas
+
+Lessons from the di-1..di-5 closeout review — keep these invariants:
+
+- **Serialize every new IR field.** `serialize_design_ir` →
+  `write_ir_layout_json` / `write_ir_node_json` must emit any field
+  `parse_ir_layout` / `parse_ir_node` reads, or a frozen `.pulp` / `--emit
+  ir-json` round-trip silently drops it. Constraints (`constraints:{horizontal,
+  vertical}`), grid (`gridTemplate*`/`gridAutoFlow`/`gridColumn`/`gridRow`), and
+  text `runs` are all written now; mirror this for future IR additions and add a
+  `[serialization]` round-trip test.
+- **Pencil stroke lives in an attribute.** Shape stroke can arrive as
+  `attributes["stroke_color"]` (+ `stroke_width`/`stroke-width`), NOT
+  `style.border_color`. `synthesize_primitive_paths` consumes both, else a
+  stroked Pencil rect/ellipse synthesizes to an invisible `fill:none` path.
+- **Grid needs a column track.** The native grid engine drops all children when
+  its column list is empty, so a `display:grid` node with no
+  `gridTemplateColumns` gets a default `'1fr'` column at codegen (don't emit a
+  bare `createGrid` with no template).
+- **Web-compat run children don't inherit.** Pulp's web-compat `<span>` Labels
+  don't inherit typography from the parent, so `emit_web_text_runs` copies the
+  node's dominant style onto each run child before applying the run override.
+- **Known follow-ups (documented, not yet fixed):** text-run offsets are byte
+  indices but Figma supplies UTF-16 code units (non-ASCII slices are
+  approximate); a `STRETCH` constraint is a no-op when the node also has an
+  explicit cross-axis dimension.
+
 ### Interactive (turnable) sprite knobs — `--knob-style sprite`
 
 `--knob-style sprite` no longer DEMOTES a recognized knob to a static image.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.161.0",
+      "version": "0.161.1",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.161.0"
+  "version": "0.161.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.161.0",
+  "version": "0.161.1",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.317.0
+    VERSION 0.317.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/design_codegen.cpp
+++ b/core/view/src/design_codegen.cpp
@@ -146,6 +146,21 @@ static void emit_web_text_runs(std::ostringstream& ss, const std::string& ind,
         append_plain(cursor, rs);            // base-styled gap before the run
         const std::string child = var + "_r" + std::to_string(idx++);
         ss << ind << "const " << child << " = document.createElement('span');\n";
+        // Carry the node's dominant style onto the run child first — Pulp's
+        // web-compat Labels do not inherit from the parent span, so without this
+        // a run that overrides only one field would render the rest with Label
+        // defaults. The run overrides below win over these base values.
+        const auto& base = node.style;
+        if (base.font_family)
+            ss << ind << child << ".style.fontFamily = '" << js_single_quote_escape(*base.font_family) << "';\n";
+        if (base.font_size)
+            ss << ind << child << ".style.fontSize = '" << *base.font_size << "px';\n";
+        if (base.font_weight)
+            ss << ind << child << ".style.fontWeight = '" << *base.font_weight << "';\n";
+        if (base.color)
+            ss << ind << child << ".style.color = '" << js_single_quote_escape(*base.color) << "';\n";
+        if (base.letter_spacing)
+            ss << ind << child << ".style.letterSpacing = '" << *base.letter_spacing << "px';\n";
         if (r->font_weight)
             ss << ind << child << ".style.fontWeight = '" << *r->font_weight << "';\n";
         if (r->font_size)
@@ -1430,9 +1445,15 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
         emit_position_if_absolute(id);
         emit_node_visual_overrides(id);
         if (is_grid) {
+            // The native grid layout drops all children when its column track
+            // list is empty, so a `display:grid` node with no explicit columns
+            // (only rows, or none) gets a single implicit column rather than
+            // vanishing — matches CSS auto-column behavior closely enough.
             if (node.layout.grid_template_columns)
                 ss << ind << "setGrid('" << id << "', 'template_columns', '"
                    << js_single_quote_escape(*node.layout.grid_template_columns) << "');\n";
+            else
+                ss << ind << "setGrid('" << id << "', 'template_columns', '1fr');\n";
             if (node.layout.grid_template_rows)
                 ss << ind << "setGrid('" << id << "', 'template_rows', '"
                    << js_single_quote_escape(*node.layout.grid_template_rows) << "');\n";

--- a/core/view/src/design_import.cpp
+++ b/core/view/src/design_import.cpp
@@ -1824,6 +1824,16 @@ void synthesize_node(IRNode& n) {
     if (n.style.border_color && !n.style.border_color->empty()) {
         n.attributes["svg_stroke"] = *n.style.border_color;
         n.attributes["svg_stroke_width"] = svg_num(n.style.border_width.value_or(1.0f));
+    } else if (auto sc = n.attributes.find("stroke_color");
+               sc != n.attributes.end() && !sc->second.empty()) {
+        // Pencil-style shapes record their stroke as a `stroke_color` attribute
+        // rather than style.border_color. Consume it (and its width) so a
+        // stroked rect/ellipse is not synthesized as an invisible fill-none path.
+        n.attributes["svg_stroke"] = sc->second;
+        auto sw = n.attributes.find("stroke_width");
+        if (sw == n.attributes.end()) sw = n.attributes.find("stroke-width");
+        n.attributes["svg_stroke_width"] =
+            (sw != n.attributes.end() && !sw->second.empty()) ? sw->second : "1";
     }
 }
 

--- a/core/view/src/design_ir_json.cpp
+++ b/core/view/src/design_ir_json.cpp
@@ -1565,6 +1565,22 @@ static void write_ir_layout_json(std::ostringstream& out, const IRLayout& l) {
     write_string_member(out, first, "overflowY", l.overflow_y);
     write_string_member(out, first, "widthMode", sizing_mode_id(l.width_mode));
     write_string_member(out, first, "heightMode", sizing_mode_id(l.height_mode));
+    // CSS grid + Figma resize constraints — round-trip the fields parse_ir_layout
+    // / parse_ir_node read back, so a frozen/serialized DesignIR does not lose
+    // them on the second parse+codegen pass.
+    write_string_member(out, first, "gridTemplateColumns", l.grid_template_columns);
+    write_string_member(out, first, "gridTemplateRows", l.grid_template_rows);
+    write_string_member(out, first, "gridAutoFlow", l.grid_auto_flow);
+    write_string_member(out, first, "gridColumn", l.grid_column);
+    write_string_member(out, first, "gridRow", l.grid_row);
+    if (l.h_constraint || l.v_constraint) {
+        write_key(out, first, "constraints");
+        out << '{';
+        bool cf = true;
+        write_string_member(out, cf, "horizontal", l.h_constraint);
+        write_string_member(out, cf, "vertical", l.v_constraint);
+        out << '}';
+    }
     out << '}';
 }
 
@@ -1576,6 +1592,29 @@ static void write_ir_node_json(std::ostringstream& out, const IRNode& node,
     write_string_member(out, first, "name", node.name);
     if (!node.text_content.empty())
         write_string_member(out, first, "content", node.text_content);
+
+    // Per-range text style runs — round-trip so mixed-style text survives a
+    // serialize -> re-parse pass (e.g. `--emit ir-json` then re-import).
+    if (!node.text_runs.empty()) {
+        write_key(out, first, "runs");
+        out << '[';
+        for (size_t i = 0; i < node.text_runs.size(); ++i) {
+            if (i) out << ',';
+            const auto& r = node.text_runs[i];
+            out << '{';
+            bool rf = true;
+            write_int_member(out, rf, "start", r.start);
+            write_int_member(out, rf, "end", r.end);
+            write_float_member(out, rf, "fontSize", r.font_size);
+            write_int_member(out, rf, "fontWeight", r.font_weight);
+            write_string_member(out, rf, "fontStyle", r.font_style);
+            write_string_member(out, rf, "color", r.color);
+            write_float_member(out, rf, "letterSpacing", r.letter_spacing);
+            write_string_member(out, rf, "textDecoration", r.text_decoration);
+            out << '}';
+        }
+        out << ']';
+    }
 
     write_key(out, first, "style");
     write_ir_style_json(out, node.style);

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -4791,6 +4791,102 @@ TEST_CASE("single-run text keeps the plain textContent path (no regression)",
     CHECK(js.find("createTextNode(") == std::string::npos);  // no run splitting
 }
 
+TEST_CASE("serialize_design_ir round-trips constraints, grid, and text runs",
+          "[view][import][serialization]") {
+    // Regression: the new IRLayout/IRNode fields must survive a
+    // serialize -> re-parse pass (frozen .pulp IR / --emit ir-json).
+    DesignIR ir;
+    ir.root.type = "frame"; ir.root.name = "Root";
+    ir.root.layout.display = "grid";
+    ir.root.layout.grid_template_columns = "1fr 1fr";
+    ir.root.layout.grid_auto_flow = "row";
+
+    IRNode child; child.type = "text"; child.name = "T"; child.text_content = "Hi world";
+    child.layout.h_constraint = "center";
+    child.layout.v_constraint = "bottom";
+    child.layout.grid_column = "1 / 3";
+    IRTextRun run; run.start = 3; run.end = 8; run.font_weight = 700; run.color = "#abcdef";
+    child.text_runs.push_back(run);
+    ir.root.children.push_back(child);
+
+    const auto rt = parse_design_ir_json(serialize_design_ir(ir));
+    REQUIRE(rt.root.children.size() == 1);
+    const auto& c = rt.root.children[0];
+    CHECK(rt.root.layout.grid_template_columns == "1fr 1fr");
+    CHECK(rt.root.layout.grid_auto_flow == "row");
+    CHECK(c.layout.h_constraint == "center");
+    CHECK(c.layout.v_constraint == "bottom");
+    CHECK(c.layout.grid_column == "1 / 3");
+    REQUIRE(c.text_runs.size() == 1);
+    CHECK(c.text_runs[0].start == 3);
+    CHECK(c.text_runs[0].end == 8);
+    CHECK(c.text_runs[0].font_weight == 700);
+    CHECK(c.text_runs[0].color == "#abcdef");
+}
+
+TEST_CASE("synthesized primitive consumes a Pencil stroke_color attribute",
+          "[view][import][codegen][vector]") {
+    // Pencil records a shape's stroke as a stroke_color attribute, not in
+    // style.border_color — the synthesizer must still paint it.
+    DesignIR ir;
+    ir.root.type = "frame"; ir.root.name = "Root";
+    ir.root.style.width = 100.0f; ir.root.style.height = 100.0f;
+    IRNode rect; rect.type = "rect"; rect.name = "Stroked";
+    rect.style.width = 40.0f; rect.style.height = 40.0f;
+    rect.attributes["stroke_color"] = "#13579b";
+    rect.attributes["stroke_width"] = "2";
+    ir.root.children.push_back(rect);
+    CodeGenOptions opts;
+    const auto js = generate_pulp_js(ir, opts);
+    INFO(js);
+    CHECK(js.find("createSvgPath('Stroked") != std::string::npos);
+    CHECK(js.find("setSvgStroke('Stroked") != std::string::npos);
+    CHECK(js.find("'#13579b')") != std::string::npos);
+}
+
+TEST_CASE("grid container with no explicit columns gets a default column",
+          "[view][import][codegen][grid]") {
+    // display:grid with no track template would drop all children in the native
+    // grid engine (cols empty); emit a default single column instead.
+    DesignIR ir;
+    ir.root.type = "frame"; ir.root.name = "G";
+    ir.root.layout.display = "grid";  // no gridTemplateColumns
+    IRNode a; a.type = "frame"; a.name = "A"; a.style.width = 10.0f; a.style.height = 10.0f;
+    ir.root.children.push_back(a);
+    CodeGenOptions opts;
+    const auto js = generate_pulp_js(ir, opts);
+    INFO(js);
+    CHECK(js.find("createGrid(") != std::string::npos);
+    CHECK(js.find("'template_columns', '1fr')") != std::string::npos);
+}
+
+TEST_CASE("per-range run children carry the node's dominant style",
+          "[view][import][codegen][text]") {
+    // A run that overrides only weight must still render the base size/color —
+    // web-compat Labels don't inherit, so the base style is copied onto each run
+    // child (so it appears on both the base span AND the run child).
+    DesignIR ir;
+    ir.root.type = "frame"; ir.root.name = "Root";
+    IRNode t; t.type = "text"; t.name = "Mixed"; t.text_content = "ab cd";
+    t.style.font_size = 18.0f;
+    t.style.color = "#222222";
+    IRTextRun run; run.start = 3; run.end = 5; run.font_weight = 700;  // "cd" bold
+    t.text_runs.push_back(run);
+    ir.root.children.push_back(t);
+    CodeGenOptions opts;
+    opts.mode = CodeGenMode::web_compat;
+    const auto js = generate_pulp_js(ir, opts);
+    INFO(js);
+    auto count = [&](const std::string& needle) {
+        size_t n = 0, p = 0;
+        while ((p = js.find(needle, p)) != std::string::npos) { n++; p += needle.size(); }
+        return n;
+    };
+    CHECK(js.find(".style.fontWeight = '700'") != std::string::npos);
+    CHECK(count(".style.fontSize = '18px'") >= 2);   // base span + run child
+    CHECK(count(".style.color = '#222222'") >= 2);
+}
+
 TEST_CASE("codegen emits mix-blend-mode on native + web-compat paths",
           "[view][import][codegen][blend]") {
     // A node's normalized mix_blend_mode lowers to setMixBlendMode (native


### PR DESCRIPTION
Closeout review of the di-1..di-5 design-import slices (PRs #3309–#3314) surfaced a serialization **P1** and several **P2**s — fixed here with tests.

## Fixes

- **Serialize the new IR fields (P1, #3310 + #3314).** `write_ir_layout_json` now emits the grid tracks (`gridTemplateColumns`/`Rows`, `gridAutoFlow`, `gridColumn`/`Row`) and a `constraints{horizontal,vertical}` object; `write_ir_node_json` emits text `runs`. Previously a frozen `.pulp` / `--emit ir-json` round-trip dropped all resize constraints, grid placement, and per-range text styling on the second parse.
- **Synthesize strokes from `stroke_color` (#3309).** Pencil-style shapes carry their stroke in `attributes["stroke_color"]` (+ `stroke_width`), not `style.border_color`; `synthesize_primitive_paths` now consumes it so a stroked rect/ellipse isn't emitted as an invisible `fill:none` path.
- **Default a grid column (#3311).** A `display:grid` node with no `gridTemplateColumns` made the native grid engine drop every child (empty column list); codegen now emits a default `'1fr'` column.
- **Carry base text style onto run children (#3314).** Pulp's web-compat `<span>` Labels don't inherit, so `emit_web_text_runs` copies the node's dominant font/size/weight/color/letter-spacing onto each run child before the run override.

## Tests

- `[serialization]` round-trip (constraints + grid + text runs survive serialize→parse), Pencil `stroke_color`, grid default column, run-child base style.
- Full `pulp-test-design-import` 1055 assertions — no regressions.

Documented follow-ups (not fixed here): text-run offsets are byte indices vs Figma's UTF-16 (non-ASCII slices approximate); a `STRETCH` constraint is a no-op when the node also has an explicit cross-axis dimension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)