### PR TITLE
feat(ship): one-off sign+notarize via `share`, `--path` primitives, release notarizes its artifact

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -275,6 +275,32 @@ Reference implementation: PR landing `feature/asc-notary-key-flow`
 `tools/cli/cmd_ship.cpp` (`notarize` block), `test/test_notary_env.cpp`,
 `test/test_cli_ship_shellout.cpp` ASC-key cases.
 
+### A subcommand that orchestrates other subcommands (`pulp ship share`)
+
+`cmd_ship` calls itself recursively (`cmd_ship({"notarize", "--path", ...})`)
+to compose stages — `share` and `release` both reuse the `notarize` handler's
+credential-resolution chain rather than duplicating it. When you add a flag
+like `--path` to a leaf subcommand, any orchestrating subcommand can thread it
+through for free. Conventions that kept this testable without Apple creds:
+
+- Add a `--dry-run` to orchestrators (`share`) that prints the plan and returns
+  0 before any `codesign`/`notarytool`/`spctl` call — shellout tests assert the
+  plan text. Mirror the existing `notarize --dry-run` / `auv3-xcodeproj
+  --dry-run` pattern.
+- Put guard rails (input not found, unsupported extension, missing identity)
+  *before* the side-effecting work so they're exercised by credential-free
+  shellout tests.
+- A subcommand of `ship` does NOT need its own top-level slash command or a
+  `commands` top-level entry — it lives under the `ship` entry's `subcommands`
+  in `cli-commands.yaml` and the `/ship` slash command. `cli_sync_check.py`
+  only diffs top-level commands, so a new ship subcommand won't show there;
+  keep the `ship` subcommand list in `cli-commands.yaml` current by hand.
+
+Reference: `feature/ship-oneoff-notarize` (2026-06-01). Files:
+`tools/cli/cmd_ship.cpp` (`sign --path`, `notarize --path`, `release` artifact
+selection, `share`), `test/test_cli_ship_shellout.cpp` `[oneoff]` cases,
+`.claude/commands/ship.md`, `.agents/skills/ship/SKILL.md`.
+
 ## Removing a CLI Command
 
 - [ ] Remove from `cmd_*.cpp` and command table in `pulp_cli.cpp`

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -42,9 +42,11 @@ Advisory only — never blocks. Full contract + override knobs in the
 
 | Command | Platform | What It Does |
 |---------|----------|-------------|
-| `sign` | macOS, Windows, Android | Sign plugin bundles or APK/AAB |
-| `notarize` | macOS only | Submit to Apple notarization, poll, staple |
-| `package` | All | Create .pkg (macOS), NSIS (Windows), APK+AAB (Android) |
+| `sign` | macOS, Windows, Android | Sign plugin bundles or APK/AAB; `--path <file>` signs one explicit `.app`/`.dmg`/bundle |
+| `notarize` | macOS only | Submit to Apple notarization, poll, staple; `--path <file>` notarizes one explicit `.dmg`/`.pkg`/`.app` (repeatable) |
+| `package` | All | Create .pkg/.dmg (macOS), NSIS (Windows), APK+AAB (Android) |
+| `release` | macOS only | One command: sign → package → **notarize + staple the .pkg/.dmg it builds** → verify |
+| `share` | macOS only | One-off: sign → wrap `.app` in DMG → notarize → staple → Gatekeeper-verify a single artifact for sharing |
 | `appcast` | All | Generate Sparkle-compatible XML update feed |
 | `check` | All | Verify signing status of built artifacts |
 
@@ -78,6 +80,54 @@ Before executing any signing, notarization, or packaging action, the `/ship` com
 When invoked via skill trigger (not slash command), apply the same pattern: always show what will happen and confirm before executing.
 
 ## Workflows
+
+### One-off share (macOS): hand a build to a friend, properly signed
+
+When a developer just wants to give someone a working `.app`/`.dmg`/`.pkg` —
+NOT cut a versioned GitHub release — reach for `share`. It is the opinionated
+one-command path and is fully separate from the repo release pipeline.
+
+```bash
+# .app → signs, wraps in a DMG, signs the DMG, notarizes, staples, then runs
+# the exact `spctl -a -t open --context context:primary-signature` Gatekeeper
+# check. Green = the recipient will NOT see "Unnotarized Developer ID".
+pulp ship share MyApp.app --identity "Developer ID Application: Name (TEAMID)"
+
+pulp ship share MyApp.dmg            # already a DMG → skip the wrap step
+pulp ship share Installer.pkg        # pkg assumed installer-signed → notarize only
+pulp ship share MyApp.app --dry-run  # print the plan; sign/notarize nothing
+```
+
+Why this exists: a Developer-ID-signed-but-**unnotarized** DMG is rejected by
+Gatekeeper (`source=Unnotarized Developer ID`). The cert is fine; the gap is
+notarization. `share` closes that gap in one step. Credentials resolve through
+the same chain as `pulp ship notarize` (App Store Connect API key preferred);
+without creds, the notarize step fails loudly rather than shipping unnotarized.
+
+The composable primitives underneath:
+- `pulp ship sign --path <app|dmg|bundle>` — sign exactly one artifact.
+- `pulp ship notarize --path <dmg|pkg|app>` — notarize + staple one artifact (repeatable).
+
+**Do not confuse with the production release.** `share`/`release`/`sign`/
+`notarize` are local developer commands. The versioned GitHub Release (all
+example plugins, appcast, downloads) runs through CI
+(`.github/workflows/sign-and-release.yml`), which does its own
+`codesign` + `pkgbuild`/`productbuild` + `xcrun notarytool submit` +
+`stapler staple` and never calls these CLI subcommands. Changing the CLI
+ship subcommands cannot affect a regular release.
+
+### macOS one-command pipeline: `pulp ship release`
+
+```bash
+pulp ship release --dmg --identity "Developer ID Application: ..."   # standalone app
+pulp ship release --pkg --identity "..."                            # plugin installers
+```
+
+Runs sign → package → notarize → staple as one command. Unlike calling the
+stages by hand, the notarize stage targets the **distributable `.pkg`/`.dmg`
+that packaging produced** (selected by build time), so `release --dmg` leaves a
+Gatekeeper-ready disk image in `artifacts/`, not a signed-but-unnotarized one.
+`--skip-sign` / `--skip-package` / `--skip-notarize` gate stages for CI dry-runs.
 
 ### macOS: Build → Sign → Notarize → Package → Appcast
 

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -129,6 +129,18 @@ that packaging produced** (selected by build time), so `release --dmg` leaves a
 Gatekeeper-ready disk image in `artifacts/`, not a signed-but-unnotarized one.
 `--skip-sign` / `--skip-package` / `--skip-notarize` gate stages for CI dry-runs.
 
+**Signing identities matter per artifact.** A `.pkg` must be signed with a
+**Developer ID Installer** identity (distinct from the Developer ID
+*Application* identity that signs bundles/apps/dmgs) or notarization rejects it.
+Pass it via `--installer-identity "Developer ID Installer: …"` (or
+`signing.apple.installer_identity` in config); `release` also signs standalone
+`.app`s and the produced `.dmg`. As a safety net, the notarize stage verifies
+each artifact's signature and **skips (does not submit) any unsigned `.pkg`/
+`.dmg`** — so a missing installer identity yields a clear "skipping unsigned
+artifact" warning instead of a failed notarytool submission. `notarize --path`
+likewise rejects a raw `.app` (notarytool needs a `.dmg`/`.pkg`/`.zip`
+container — use `share` for an app).
+
 ### macOS: Build → Sign → Notarize → Package → Appcast
 
 ```bash

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.162.1",
+      "version": "0.163.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.162.1"
+  "version": "0.163.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.162.1",
+  "version": "0.163.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -28,13 +28,29 @@ Ship a Pulp plugin or app — sign, notarize, package, and generate update feeds
    - "Android SDK not found. Would you like help setting it up?"
    - Options: "Show install instructions" / "I'll set it up myself" / "Skip Android"
 
-## Standard workflow order
+## Pick the path first: one-off share vs full release
+
+- **"Make a build I can send a friend / share / put on a download page"**, or any
+  single `.app`/`.dmg`/`.pkg` you want to hand off → use **`pulp ship share`**
+  (one command: sign → wrap `.app` in a DMG → notarize → staple → Gatekeeper-verify).
+  This is the right tool when the user says things like "sign this so my friend can
+  open it", "bundle the app to share", "make a DMG I can send". It does NOT touch the
+  repo / GitHub release pipeline.
+- **Full distribution release** (versioned GitHub Release, appcast, all example
+  plugins) → that runs through CI (`sign-and-release.yml`), not these local
+  subcommands. For shipping a PR/release say "ship this" or use the `ci` skill.
+
+## Standard workflow order (manual, per-stage)
 
 1. **Build** — `pulp build` (must complete before signing)
 2. **Sign** — `pulp ship sign` (must sign before notarizing)
 3. **Notarize** — `pulp ship notarize` (macOS only, after signing)
 4. **Package** — `pulp ship package` (creates installer from signed bundles)
 5. **Appcast** — `pulp ship appcast` (generate update feed pointing to packaged artifact)
+
+Or collapse 2–4 into one command: `pulp ship release --pkg` / `--dmg` signs,
+packages, and **notarizes + staples the .pkg/.dmg it builds** (not just the loose
+bundles), so the artifact in `artifacts/` is Gatekeeper-ready.
 
 ## Subcommands
 
@@ -46,10 +62,22 @@ Ship a Pulp plugin or app — sign, notarize, package, and generate update feeds
 
 Note: `--key-pass` defaults to `--store-pass` if omitted. `sign --target android` operates on existing APK/AAB files in `artifacts/` — use `package --target android` to build from Gradle.
 
+- `pulp ship sign --path MyApp.app` — sign one explicit `.app`/`.dmg`/bundle (not the whole build dir)
+
 **Notarization (macOS only):**
 - `pulp ship notarize` — uses apple_id/team_id from config
 - `pulp ship notarize --apple-id you@example.com --team-id ABCDE12345 --password @keychain:AC_PASSWORD`
+- `pulp ship notarize --path MyApp-1.0.dmg` — notarize + staple one explicit artifact (repeatable)
 - `pulp ship notarize --staple` — staple only (skip submission)
+
+**One-off share (macOS only) — sign + notarize + verify in one shot:**
+- `pulp ship share MyApp.app --identity "Developer ID Application: ..."` — for an
+  `.app`: signs, wraps in a DMG under `artifacts/`, signs the DMG, notarizes,
+  staples, then runs the exact `spctl` Gatekeeper check. A green result means the
+  recipient won't see "Unnotarized Developer ID".
+- `pulp ship share MyApp.dmg` / `pulp ship share Installer.pkg` — skips the wrap step
+- `pulp ship share MyApp.app --dry-run` — print the plan without doing anything
+- Credentials resolve through the same chain as `notarize` (App Store Connect API key preferred)
 
 **Packaging:**
 - `pulp ship package --version 1.0.0` — .pkg (macOS) or NSIS .exe (Windows)
@@ -137,6 +165,8 @@ This "show then confirm" pattern applies to:
 - `pulp ship notarize` — show credentials and bundles
 - `pulp ship package` — show target, version, and signing mode
 - `pulp ship package --target android` — show ABIs, keystore, Gradle project
+- `pulp ship share <artifact>` — show the input, resolved identity, and the
+  sign→wrap→notarize→staple→verify plan (offer `--dry-run` first if creds are unconfirmed)
 
 Run the appropriate subcommand based on $ARGUMENTS. If no arguments, run `pulp ship check` to show current signing status, then use AskUserQuestion to suggest next steps:
 - "Sign plugin bundles" (if unsigned bundles found)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.318.0
+    VERSION 0.319.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -689,24 +689,54 @@ Signing and packaging subcommands.
 ```bash
 pulp ship sign --identity "Developer ID Application: ..."
 pulp ship sign --identity "..." --entitlements path/to/entitlements.plist
+pulp ship sign --identity "..." --path MyApp.app   # sign one explicit artifact
 pulp ship package --version 1.0.0
 pulp ship check
 pulp ship notarize --api-key ~/key.p8 --api-key-id ABC --api-issuer <uuid>
-pulp ship notarize --dry-run                     # print resolved argv, no submit
+pulp ship notarize --path MyApp-1.0.dmg            # notarize + staple one artifact
+pulp ship notarize --dry-run                       # print resolved argv, no submit
+pulp ship share MyApp.app --identity "..."         # one-shot: sign+notarize+verify
 ```
 
 **Subcommands**:
 
 | Subcommand | What it does |
 |------------|-------------|
-| `sign`     | Code-sign all built plugin bundles (VST3, CLAP, AU) |
-| `notarize` | Submit signed bundles to Apple notarytool (macOS) |
-| `package`  | Create `.pkg` installers in `artifacts/` |
+| `sign`     | Code-sign all built plugin bundles (VST3, CLAP, AU), or one `--path` artifact |
+| `notarize` | Submit signed bundles (or `--path` artifacts) to Apple notarytool (macOS) |
+| `package`  | Create `.pkg`/`.dmg` installers in `artifacts/` |
+| `release`  | macOS one-command pipeline: sign → package → **notarize the .pkg/.dmg it builds** → staple |
+| `share`    | One-shot for sharing a single artifact: sign → wrap `.app` in DMG → notarize → staple → Gatekeeper-verify |
 | `check`    | Check signing status of all built plugins |
 
 `sign` requires `--identity`. The default entitlements file is `ship/templates/entitlements.plist`.
+`--path` signs exactly one `.app`, `.dmg`, or plugin bundle instead of scanning the build dirs;
+`.pkg` installers are signed at creation time with a Developer ID **Installer** identity, not here.
 
-`package` creates per-format `.pkg` files using `pkgbuild`. macOS only.
+`package` creates per-format `.pkg` files using `pkgbuild` (or `.dmg` with `--dmg`). macOS only.
+
+#### `pulp ship share` — one-off "sign it for a friend"
+
+`share` is the opinionated, single-command path for handing a build to someone
+without running the full release pipeline. Point it at a `.app`, `.dmg`, or
+`.pkg`:
+
+```bash
+pulp ship share MyApp.app --identity "Developer ID Application: Name (TEAMID)"
+pulp ship share MyApp.app --dry-run        # print the plan, do nothing
+```
+
+For a `.app` it code-signs (hardened runtime + secure timestamp), wraps it in a
+DMG under `artifacts/`, signs the DMG, notarizes + staples it, then runs the
+exact `spctl -a -t open --context context:primary-signature` check Gatekeeper
+performs on download. A green result means the recipient will **not** see
+"Unnotarized Developer ID". Notarization credentials resolve through the same
+chain as `pulp ship notarize` (App Store Connect API key preferred). `.dmg`
+inputs skip the wrap step; `.pkg` inputs are assumed already installer-signed
+and are only notarized + verified.
+
+`release --dmg`/`--pkg` notarizes and staples the distributable it produces, so
+the artifact it leaves in `artifacts/` is Gatekeeper-ready, not merely signed.
 
 #### `pulp ship notarize`
 

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -70,6 +70,9 @@ commands:
         args:
           - name: --identity
             required: false
+          - name: --path
+            required: false
+            description: Sign one explicit artifact (.app/.dmg/bundle) instead of scanning build dirs
           - name: --entitlements
             required: false
           - name: --target
@@ -85,6 +88,9 @@ commands:
       - name: notarize
         summary: Submit signed bundles for Apple notarization (macOS)
         args:
+          - name: --path
+            required: false
+            description: Notarize + staple an explicit artifact (.dmg/.pkg/.app); repeatable
           - name: --api-key
             required: false
           - name: --api-key-id
@@ -143,6 +149,35 @@ commands:
         summary: Check signing status of built plugins or Android artifacts
         args:
           - name: --target
+            required: false
+      - name: share
+        summary: "One-shot sign → wrap (.app → DMG) → notarize → staple → Gatekeeper-verify a single artifact for sharing (macOS)"
+        args:
+          - name: input
+            kind: positional
+            required: true
+            description: The .app, .dmg, or .pkg to prepare for sharing
+          - name: --identity
+            required: false
+          - name: --version
+            required: false
+          - name: --output
+            required: false
+          - name: --entitlements
+            required: false
+          - name: --api-key
+            required: false
+          - name: --api-key-id
+            required: false
+          - name: --api-issuer
+            required: false
+          - name: --apple-id
+            required: false
+          - name: --team-id
+            required: false
+          - name: --password
+            required: false
+          - name: --dry-run
             required: false
     docs: reference/cli.md#ship
 

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -90,7 +90,7 @@ commands:
         args:
           - name: --path
             required: false
-            description: Notarize + staple an explicit artifact (.dmg/.pkg/.app); repeatable
+            description: Notarize + staple an explicit artifact (.dmg/.pkg/.zip — not a raw .app); repeatable
           - name: --api-key
             required: false
           - name: --api-key-id
@@ -126,6 +126,9 @@ commands:
             required: false
           - name: --abi
             required: false
+          - name: --installer-identity
+            required: false
+            description: Developer ID Installer identity used to sign the macOS .pkg
           - name: --apk-only
             required: false
           - name: --aab-only

--- a/test/test_cli_ship_shellout.cpp
+++ b/test/test_cli_ship_shellout.cpp
@@ -290,7 +290,7 @@ TEST_CASE_METHOD(ShipShelloutFixture,
     REQUIRE(r.exit_code == 0);
     // Help branch reached — every shipping subcommand must be listed.
     for (const char* sub : {"sign", "notarize", "package", "appcast",
-                            "check", "auv3-xcodeproj"}) {
+                            "check", "auv3-xcodeproj", "release", "share"}) {
         INFO("ship help missing subcommand: " << sub);
         REQUIRE(contains(r.stdout_output, sub));
     }
@@ -395,6 +395,7 @@ TEST_CASE_METHOD(ShipShelloutFixture,
     };
     std::vector<ParserCase> cases = {
         {{"ship", "sign", "--identity"}, "--identity requires a value"},
+        {{"ship", "sign", "--path"}, "--path requires a value"},
         {{"ship", "sign", "--bogus"}, "unknown argument"},
         {{"ship", "package", "--version"}, "--version requires a value"},
         {{"ship", "package", "--abi"}, "--abi requires a value"},
@@ -410,6 +411,7 @@ TEST_CASE_METHOD(ShipShelloutFixture,
         {{"ship", "notarize", "--apple-id"}, "--apple-id requires a value"},
         {{"ship", "notarize", "--team-id"}, "--team-id requires a value"},
         {{"ship", "notarize", "--password"}, "--password requires a value"},
+        {{"ship", "notarize", "--path"}, "--path requires a value"},
         {{"ship", "notarize", "--bogus"}, "unknown argument"},
         {{"ship", "release", "--target"}, "--target requires a value"},
         {{"ship", "release", "--identity"}, "--identity requires a value"},
@@ -417,6 +419,9 @@ TEST_CASE_METHOD(ShipShelloutFixture,
         {{"ship", "release", "--team-id"}, "--team-id requires a value"},
         {{"ship", "release", "--password"}, "--password requires a value"},
         {{"ship", "release", "--version"}, "--version requires a value"},
+        {{"ship", "share", "--identity"}, "--identity requires a value"},
+        {{"ship", "share", "--version"}, "--version requires a value"},
+        {{"ship", "share", "--bogus"}, "unknown argument"},
     });
 #endif
 
@@ -1103,3 +1108,219 @@ TEST_CASE_METHOD(ShipShelloutFixture,
     fs::remove_all(root);
 }
 #endif
+
+// ── one-off signing/notarization primitives (sign --path, notarize --path,
+//    release-notarizes-the-dmg, share) ────────────────────────────────────
+//
+// These cover the "a developer built an app/DMG and wants to hand it to a
+// friend, signed + notarized, without the full repo release pipeline" flow.
+// The success paths call real `codesign`/`notarytool`/`spctl` and need Apple
+// credentials, so the automated coverage exercises the argument plumbing,
+// guard rails, and dry-run plans that run without contacting Apple.
+
+TEST_CASE_METHOD(ShipShelloutFixture,
+                 "pulp ship sign --path rejects a missing artifact",
+                 "[cli][shellout][ship][sign][oneoff]") {
+    if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
+    auto root = make_fake_project("sign-path-missing", true);
+
+    auto r = run_pulp_in(root,
+        {"ship", "sign", "--identity", "Developer ID Application: Fake",
+         "--path", (root / "does-not-exist.app").string()});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code == 1);
+    auto combined = r.stdout_output + r.stderr_output;
+    REQUIRE(contains(combined, "--path not found"));
+    // Must not have attempted to scan/sign the build dirs.
+    REQUIRE_FALSE(contains(combined, "No plugin bundles found"));
+
+    fs::remove_all(root);
+}
+
+TEST_CASE_METHOD(ShipShelloutFixture,
+                 "pulp ship sign --path refuses a .pkg with a productsign pointer",
+                 "[cli][shellout][ship][sign][oneoff]") {
+    if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
+    auto root = make_fake_project("sign-path-pkg", true);
+    auto pkg = root / "Installer.pkg";
+    { std::ofstream out(pkg); out << "not a real pkg"; }
+
+    auto r = run_pulp_in(root,
+        {"ship", "sign", "--identity", "Developer ID Application: Fake",
+         "--path", pkg.string()});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code == 1);
+    auto combined = r.stdout_output + r.stderr_output;
+    REQUIRE(contains(combined, ".pkg installers are signed when created"));
+
+    fs::remove_all(root);
+}
+
+#ifdef __APPLE__
+TEST_CASE_METHOD(ShipShelloutFixture,
+                 "pulp ship notarize --path targets the explicit artifact in dry-run argv",
+                 "[cli][shellout][ship][notarize][oneoff]") {
+    if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
+    auto root = make_fake_project("notarize-path", true);
+    auto dmg = (root / "PulpDemo-1.2.3.dmg").string();
+
+    auto r = run_pulp_in(root,
+        {"ship", "notarize", "--dry-run", "--path", dmg,
+         "--api-key", "/path/AuthKey_FAKE.p8",
+         "--api-key-id", "FAKEKEYID", "--api-issuer", "fake-issuer"});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code == 0);
+    auto combined = r.stdout_output + r.stderr_output;
+    // The submit argv must point at our explicit artifact, not a scanned bundle.
+    REQUIRE(contains(combined, "xcrun notarytool submit \"" + dmg + "\""));
+    REQUIRE(contains(combined, "PulpDemo-1.2.3.dmg"));
+
+    fs::remove_all(root);
+}
+
+TEST_CASE_METHOD(ShipShelloutFixture,
+                 "pulp ship release --dmg notarizes the disk image it builds",
+                 "[cli][shellout][ship][release][oneoff]") {
+    if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
+    auto root = make_fake_project("release-dmg-notarize", true);
+    // A standalone .app under build/Standalone is packaged to a .dmg by the
+    // package stage; release must then hand THAT dmg to notarize via --path.
+    auto app = root / "build" / "Standalone" / "PulpDemo.app";
+    fs::create_directories(app / "Contents");
+    { std::ofstream out(app / "Contents" / "Info.plist");
+      out << "<plist><dict></dict></plist>\n"; }
+
+    // No notary credentials are configured (fixture isolates them), so the
+    // notarize stage fails *after* the dmg is built and selected — which is
+    // exactly the signal we assert on: the dmg reached the notarize step.
+    auto r = run_pulp_in(root, {"ship", "release", "--dmg", "--skip-sign"}, 90000);
+    REQUIRE_FALSE(r.timed_out);
+    auto combined = r.stdout_output + r.stderr_output;
+    INFO("release output:\n" << combined);
+    REQUIRE(r.exit_code != 0);
+    // The built dmg was collected and routed to notarization...
+    REQUIRE(contains(combined, "artifact: PulpDemo-2.3.4.dmg"));
+    // ...and notarization stopped on missing credentials, not on "no bundles".
+    REQUIRE(contains(combined, "no notary credentials"));
+    REQUIRE_FALSE(contains(combined, "No plugin bundles found"));
+
+    fs::remove_all(root);
+}
+
+TEST_CASE_METHOD(ShipShelloutFixture,
+                 "pulp ship share requires an input artifact",
+                 "[cli][shellout][ship][share][oneoff]") {
+    if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
+    auto root = make_fake_project("share-usage", true);
+
+    auto r = run_pulp_in(root, {"ship", "share"});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code == 2);
+    REQUIRE(contains(r.stdout_output + r.stderr_output,
+                     "Usage: pulp ship share"));
+
+    fs::remove_all(root);
+}
+
+TEST_CASE_METHOD(ShipShelloutFixture,
+                 "pulp ship share rejects a missing and an unsupported input",
+                 "[cli][shellout][ship][share][oneoff]") {
+    if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
+    auto root = make_fake_project("share-bad-input", true);
+
+    auto missing = run_pulp_in(root,
+        {"ship", "share", (root / "ghost.app").string()});
+    REQUIRE_FALSE(missing.timed_out);
+    REQUIRE(missing.exit_code == 1);
+    REQUIRE(contains(missing.stdout_output + missing.stderr_output, "not found"));
+
+    auto bad = root / "notes.txt";
+    { std::ofstream out(bad); out << "x"; }
+    auto unsupported = run_pulp_in(root, {"ship", "share", bad.string()});
+    REQUIRE_FALSE(unsupported.timed_out);
+    REQUIRE(unsupported.exit_code == 2);
+    REQUIRE(contains(unsupported.stdout_output + unsupported.stderr_output,
+                     "unsupported input"));
+
+    fs::remove_all(root);
+}
+
+TEST_CASE_METHOD(ShipShelloutFixture,
+                 "pulp ship share --dry-run prints the full plan for an app",
+                 "[cli][shellout][ship][share][oneoff]") {
+    if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
+    auto root = make_fake_project("share-dry-app", true);
+    auto app = root / "Cube.app";
+    fs::create_directories(app / "Contents");
+    { std::ofstream out(app / "Contents" / "Info.plist");
+      out << "<plist><dict></dict></plist>\n"; }
+
+    auto r = run_pulp_in(root,
+        {"ship", "share", app.string(), "--dry-run"});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code == 0);
+    auto combined = r.stdout_output + r.stderr_output;
+    REQUIRE(contains(combined, "share plan"));
+    REQUIRE(contains(combined, "create DMG"));
+    REQUIRE(contains(combined, "notarize --path"));
+    REQUIRE(contains(combined, "spctl -a -t open"));
+    // Version falls back to the project CMakeLists value (2.3.4).
+    REQUIRE(contains(combined, "Cube-2.3.4.dmg"));
+    // Nothing was actually performed.
+    REQUIRE_FALSE(contains(combined, "Wrapping into DMG"));
+
+    fs::remove_all(root);
+}
+
+TEST_CASE_METHOD(ShipShelloutFixture,
+                 "pulp ship share --dry-run notes pkg is already productsigned",
+                 "[cli][shellout][ship][share][oneoff]") {
+    if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
+    auto root = make_fake_project("share-dry-pkg", true);
+    auto pkg = root / "Demo.pkg";
+    { std::ofstream out(pkg); out << "x"; }
+
+    auto r = run_pulp_in(root, {"ship", "share", pkg.string(), "--dry-run"});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code == 0);
+    auto combined = r.stdout_output + r.stderr_output;
+    REQUIRE(contains(combined, "already productsigned"));
+    REQUIRE(contains(combined, "spctl --assess --type install"));
+
+    fs::remove_all(root);
+}
+
+TEST_CASE_METHOD(ShipShelloutFixture,
+                 "pulp ship share without an identity refuses to sign an app",
+                 "[cli][shellout][ship][share][oneoff]") {
+    if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
+    auto root = make_fake_project("share-no-identity", true);
+    auto app = root / "Cube.app";
+    fs::create_directories(app / "Contents");
+    { std::ofstream out(app / "Contents" / "Info.plist");
+      out << "<plist><dict></dict></plist>\n"; }
+
+    // Real run (not --dry-run), no identity resolvable (fixture isolation).
+    auto r = run_pulp_in(root, {"ship", "share", app.string()});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code == 1);
+    auto combined = r.stdout_output + r.stderr_output;
+    REQUIRE(contains(combined, "Developer ID Application identity is required"));
+    // Must not have created or signed anything.
+    REQUIRE_FALSE(contains(combined, "Wrapping into DMG"));
+
+    fs::remove_all(root);
+}
+#else  // !__APPLE__
+TEST_CASE_METHOD(ShipShelloutFixture,
+                 "pulp ship share is macOS-only on other platforms",
+                 "[cli][shellout][ship][share][oneoff]") {
+    if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
+    auto root = make_fake_project("share-non-apple", true);
+    auto r = run_pulp_in(root, {"ship", "share", "whatever.app"});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code == 1);
+    REQUIRE(contains(r.stdout_output + r.stderr_output, "macOS-only"));
+    fs::remove_all(root);
+}
+#endif  // __APPLE__

--- a/test/test_cli_ship_shellout.cpp
+++ b/test/test_cli_ship_shellout.cpp
@@ -399,6 +399,7 @@ TEST_CASE_METHOD(ShipShelloutFixture,
         {{"ship", "sign", "--bogus"}, "unknown argument"},
         {{"ship", "package", "--version"}, "--version requires a value"},
         {{"ship", "package", "--abi"}, "--abi requires a value"},
+        {{"ship", "package", "--installer-identity"}, "--installer-identity requires a value"},
         {{"ship", "package", "--bogus"}, "unknown argument"},
         {{"ship", "check", "--target"}, "--target requires a value"},
         {{"ship", "check", "--bogus"}, "unknown argument"},
@@ -419,6 +420,7 @@ TEST_CASE_METHOD(ShipShelloutFixture,
         {{"ship", "release", "--team-id"}, "--team-id requires a value"},
         {{"ship", "release", "--password"}, "--password requires a value"},
         {{"ship", "release", "--version"}, "--version requires a value"},
+        {{"ship", "release", "--installer-identity"}, "--installer-identity requires a value"},
         {{"ship", "share", "--identity"}, "--identity requires a value"},
         {{"ship", "share", "--version"}, "--version requires a value"},
         {{"ship", "share", "--bogus"}, "unknown argument"},
@@ -1179,30 +1181,54 @@ TEST_CASE_METHOD(ShipShelloutFixture,
 }
 
 TEST_CASE_METHOD(ShipShelloutFixture,
-                 "pulp ship release --dmg notarizes the disk image it builds",
+                 "pulp ship notarize --path rejects a raw .app bundle",
+                 "[cli][shellout][ship][notarize][oneoff]") {
+    if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
+    auto root = make_fake_project("notarize-path-app", true);
+    auto appp = (root / "Demo.app").string();
+
+    // notarytool can't submit a bare .app (Codex P2). Reject it with a
+    // pointer to `share`, before any submission — even in --dry-run.
+    auto r = run_pulp_in(root, {"ship", "notarize", "--path", appp, "--dry-run"});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code == 2);
+    auto combined = r.stdout_output + r.stderr_output;
+    REQUIRE(contains(combined, "cannot submit a raw .app"));
+    REQUIRE(contains(combined, "pulp ship share"));
+    // Must not have produced a notarytool submit line for the app.
+    REQUIRE_FALSE(contains(combined, "notarytool submit \"" + appp));
+
+    fs::remove_all(root);
+}
+
+TEST_CASE_METHOD(ShipShelloutFixture,
+                 "pulp ship release --dmg builds the disk image and refuses to notarize it unsigned",
                  "[cli][shellout][ship][release][oneoff]") {
     if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
     auto root = make_fake_project("release-dmg-notarize", true);
     // A standalone .app under build/Standalone is packaged to a .dmg by the
-    // package stage; release must then hand THAT dmg to notarize via --path.
+    // package stage; release collects THAT dmg as the distributable.
     auto app = root / "build" / "Standalone" / "PulpDemo.app";
     fs::create_directories(app / "Contents");
     { std::ofstream out(app / "Contents" / "Info.plist");
       out << "<plist><dict></dict></plist>\n"; }
 
-    // No notary credentials are configured (fixture isolates them), so the
-    // notarize stage fails *after* the dmg is built and selected — which is
-    // exactly the signal we assert on: the dmg reached the notarize step.
+    // --skip-sign leaves the dmg unsigned. The signature guard must skip it
+    // rather than submit an unsigned image to notarytool (Codex P1 fix:
+    // never route an unsigned .pkg/.dmg to notarization).
     auto r = run_pulp_in(root, {"ship", "release", "--dmg", "--skip-sign"}, 90000);
     REQUIRE_FALSE(r.timed_out);
     auto combined = r.stdout_output + r.stderr_output;
     INFO("release output:\n" << combined);
     REQUIRE(r.exit_code != 0);
-    // The built dmg was collected and routed to notarization...
-    REQUIRE(contains(combined, "artifact: PulpDemo-2.3.4.dmg"));
-    // ...and notarization stopped on missing credentials, not on "no bundles".
-    REQUIRE(contains(combined, "no notary credentials"));
+    // The dmg WAS built and considered (proving package + collection ran)...
+    REQUIRE(contains(combined, "PulpDemo-2.3.4.dmg"));
+    // ...but was skipped as unsigned and never submitted.
+    REQUIRE(contains(combined, "skipping unsigned artifact"));
+    REQUIRE(contains(combined, "no signed distributable to notarize"));
+    // It must NOT have fallen through to notarizing loose bundles.
     REQUIRE_FALSE(contains(combined, "No plugin bundles found"));
+    REQUIRE_FALSE(contains(combined, "no notary credentials"));
 
     fs::remove_all(root);
 }

--- a/tools/cli/cmd_ship.cpp
+++ b/tools/cli/cmd_ship.cpp
@@ -71,10 +71,13 @@ int cmd_ship(const std::vector<std::string>& args) {
     // ── sign ────────────────────────────────────────────────────────────────
     if (sub == "sign") {
         std::string identity, target, keystore_path, key_alias, store_pass, key_pass;
+        std::string sign_path;  // --path: sign one explicit artifact (.app/.dmg/bundle)
         std::string entitlements = (root / "ship" / "templates" / "entitlements.plist").string();
         for (size_t i = 1; i < args.size(); ++i) {
             if (args[i] == "--identity") {
                 if (!take_ship_value(args, i, sub, args[i], identity)) return 2;
+            } else if (args[i] == "--path") {
+                if (!take_ship_value(args, i, sub, args[i], sign_path)) return 2;
             } else if (args[i] == "--entitlements") {
                 if (!take_ship_value(args, i, sub, args[i], entitlements)) return 2;
             } else if (args[i] == "--target") {
@@ -161,6 +164,40 @@ int cmd_ship(const std::vector<std::string>& args) {
             std::cerr << "    identity = \"Developer ID Application: Your Name (TEAMID)\"\n\n";
             std::cerr << "  Or run: pulp config set signing.apple.identity \"Developer ID Application: ...\"\n";
             return 1;
+        }
+
+        // --path: sign exactly one artifact instead of auto-scanning the
+        // build dirs. This is the composable primitive behind the one-off
+        // "I built an app/DMG and want to hand it to a friend" flow — point
+        // it at a standalone `.app`, a `.dmg`, or a single plugin bundle.
+        // `.pkg` installers are signed at creation time (`productsign` via
+        // `create_pkg`'s signing_identity), not here, so reject them with a
+        // pointer rather than producing a broken signature.
+        if (!sign_path.empty()) {
+            if (!fs::exists(sign_path)) {
+                std::cerr << "pulp ship sign: --path not found: " << sign_path << "\n";
+                return 1;
+            }
+            auto ext = fs::path(sign_path).extension().string();
+            if (ext == ".pkg") {
+                std::cerr << "pulp ship sign: .pkg installers are signed when created"
+                             " — pass a Developer ID Installer identity to\n"
+                             "  `pulp ship package` / `create_pkg`, not `sign --path`.\n";
+                return 1;
+            }
+            // Hardened runtime + secure timestamp are mandatory for
+            // notarization. Entitlements only apply to executables, so we
+            // only attach them for app/plugin bundles, never a `.dmg`.
+            std::cout << "Signing " << fs::path(sign_path).filename().string() << "...\n";
+            const bool is_disk_image = (ext == ".dmg");
+            bool ok = pulp::ship::codesign(
+                sign_path, identity, is_disk_image ? "" : entitlements);
+            if (!ok) {
+                std::cerr << "  FAILED to sign " << sign_path << "\n";
+                return 1;
+            }
+            std::cout << "Signed " << sign_path << "\n";
+            return 0;
         }
 
         int signed_count = 0;
@@ -516,11 +553,16 @@ int cmd_ship(const std::vector<std::string>& args) {
         std::string apple_id, team_id, password;
         std::string api_key, api_key_id, api_issuer;
         std::string env_file_override;
+        std::vector<std::string> explicit_paths;  // --path (repeatable)
         bool staple_only = false;
         bool dry_run = false;
         for (size_t i = 1; i < args.size(); ++i) {
             if (args[i] == "--apple-id") {
                 if (!take_ship_value(args, i, sub, args[i], apple_id)) return 2;
+            } else if (args[i] == "--path") {
+                std::string p;
+                if (!take_ship_value(args, i, sub, args[i], p)) return 2;
+                explicit_paths.push_back(p);
             } else if (args[i] == "--team-id") {
                 if (!take_ship_value(args, i, sub, args[i], team_id)) return 2;
             } else if (args[i] == "--password") {
@@ -539,19 +581,30 @@ int cmd_ship(const std::vector<std::string>& args) {
             else return unknown_ship_arg(sub, args[i]);
         }
 
+        // When --path is given, notarize exactly those artifacts (a
+        // `.dmg`, `.pkg`, `.app`, or zipped bundle) instead of auto-
+        // scanning the plugin build dirs. This is what lets `release`
+        // notarize the distributable it just packaged, and what the
+        // `share` one-shot points at.
         std::vector<std::string> bundles;
-        for (auto dir_name : {"VST3", "CLAP", "AU"}) {
-            auto dir = build_dir / dir_name;
-            if (!fs::exists(dir)) continue;
-            for (auto& entry : fs::directory_iterator(dir)) {
-                auto ext = entry.path().extension().string();
-                if (ext == ".vst3" || ext == ".clap" || ext == ".component")
-                    bundles.push_back(entry.path().string());
+        if (!explicit_paths.empty()) {
+            bundles = explicit_paths;
+        } else {
+            for (auto dir_name : {"VST3", "CLAP", "AU"}) {
+                auto dir = build_dir / dir_name;
+                if (!fs::exists(dir)) continue;
+                for (auto& entry : fs::directory_iterator(dir)) {
+                    auto ext = entry.path().extension().string();
+                    if (ext == ".vst3" || ext == ".clap" || ext == ".component")
+                        bundles.push_back(entry.path().string());
+                }
             }
         }
 
         if (bundles.empty() && !dry_run) {
-            std::cerr << "No plugin bundles found.\n";
+            std::cerr << (explicit_paths.empty()
+                              ? "No plugin bundles found.\n"
+                              : "No --path artifacts to notarize.\n");
             return 1;
         }
 
@@ -782,6 +835,16 @@ int cmd_ship(const std::vector<std::string>& args) {
 
         // Stage 2: package. The pkg vs dmg decision lives in cmd_ship
         // 'package' itself (item 7.5 wiring below).
+        //
+        // We notarize the *distributable* (the `.dmg`/`.pkg` this stage
+        // produces), not the loose plugin bundles — otherwise `release
+        // --dmg` would emit a signed-but-unnotarized disk image and the
+        // command name would be a lie (Gatekeeper rejects it with
+        // "Unnotarized Developer ID"). Stamp the time before packaging so
+        // we can tell freshly-built artifacts from stale ones left in
+        // artifacts/ by an earlier run.
+        std::vector<std::string> release_artifacts;
+        auto pkg_t0 = fs::file_time_type::clock::now();
         if (!skip_package) {
             std::cout << "── Stage 2/4: package ─────────────────────────────\n";
             std::vector<std::string> pkg_args = {"package"};
@@ -796,6 +859,17 @@ int cmd_ship(const std::vector<std::string>& args) {
                 std::cerr << "pulp ship release: package stage failed; "
                              "aborting before notarize.\n";
                 return pkg_rc;
+            }
+            auto artifacts = root / "artifacts";
+            if (fs::exists(artifacts)) {
+                for (auto& entry : fs::directory_iterator(artifacts)) {
+                    auto ext = entry.path().extension().string();
+                    if (ext != ".dmg" && ext != ".pkg") continue;
+                    std::error_code ec;
+                    auto mtime = fs::last_write_time(entry.path(), ec);
+                    if (!ec && mtime >= pkg_t0)
+                        release_artifacts.push_back(entry.path().string());
+                }
             }
         } else {
             std::cout << "── Stage 2/4: package (SKIPPED) ───────────────────\n";
@@ -824,6 +898,17 @@ int cmd_ship(const std::vector<std::string>& args) {
         if (!apple_id.empty()) { nz_args.push_back("--apple-id"); nz_args.push_back(apple_id); }
         if (!team_id.empty())  { nz_args.push_back("--team-id");  nz_args.push_back(team_id); }
         if (!password.empty()) { nz_args.push_back("--password"); nz_args.push_back(password); }
+        // Notarize + staple the distributable artifact(s) when packaging
+        // produced any. Falling back to the notarize handler's own bundle
+        // scan only when packaging was skipped keeps `--skip-package`
+        // working for plugin-only flows.
+        if (!release_artifacts.empty()) {
+            for (auto& a : release_artifacts) {
+                nz_args.push_back("--path");
+                nz_args.push_back(a);
+                std::cout << "  artifact: " << fs::path(a).filename().string() << "\n";
+            }
+        }
         int nz_rc = cmd_ship(nz_args);
         if (nz_rc != 0) {
             std::cerr << "pulp ship release: notarize stage failed.\n";
@@ -1127,6 +1212,193 @@ int cmd_ship(const std::vector<std::string>& args) {
         return 0;
     }
 
+    // ── share ─────────────────────────────────────────────────────────────
+    //
+    // Opinionated one-shot for the "I built something cool and want to hand
+    // it to a friend / put it on a TestFlight-style page" case — point it at
+    // a standalone `.app`, a `.dmg`, or a `.pkg` and it produces a signed,
+    // notarized, stapled, Gatekeeper-accepted distributable without the full
+    // repo release pipeline. Built on the `sign --path` / `notarize --path`
+    // primitives:
+    //
+    //   .app  → codesign (hardened runtime) → wrap in DMG → codesign DMG →
+    //           notarize+staple DMG → spctl verify
+    //   .dmg  → codesign DMG → notarize+staple → spctl verify
+    //   .pkg  → notarize+staple (already productsigned) → spctl verify
+    //
+    // The final `spctl` is the exact check a downloader's Gatekeeper runs, so
+    // a green result here means the friend will not see "Unnotarized
+    // Developer ID". `--dry-run` prints the plan without touching anything.
+    if (sub == "share") {
+#ifndef __APPLE__
+        std::cerr << "pulp ship share: macOS-only (codesign + notarization + DMG).\n";
+        return 1;
+#else
+        std::string input, identity, version, output_dir, entitlements;
+        std::string api_key, api_key_id, api_issuer, apple_id, team_id, password;
+        bool dry_run = false;
+        for (size_t i = 1; i < args.size(); ++i) {
+            if (args[i] == "--identity") {
+                if (!take_ship_value(args, i, sub, args[i], identity)) return 2;
+            } else if (args[i] == "--version") {
+                if (!take_ship_value(args, i, sub, args[i], version)) return 2;
+            } else if (args[i] == "--output") {
+                if (!take_ship_value(args, i, sub, args[i], output_dir)) return 2;
+            } else if (args[i] == "--entitlements") {
+                if (!take_ship_value(args, i, sub, args[i], entitlements)) return 2;
+            } else if (args[i] == "--api-key") {
+                if (!take_ship_value(args, i, sub, args[i], api_key)) return 2;
+            } else if (args[i] == "--api-key-id") {
+                if (!take_ship_value(args, i, sub, args[i], api_key_id)) return 2;
+            } else if (args[i] == "--api-issuer") {
+                if (!take_ship_value(args, i, sub, args[i], api_issuer)) return 2;
+            } else if (args[i] == "--apple-id") {
+                if (!take_ship_value(args, i, sub, args[i], apple_id)) return 2;
+            } else if (args[i] == "--team-id") {
+                if (!take_ship_value(args, i, sub, args[i], team_id)) return 2;
+            } else if (args[i] == "--password") {
+                if (!take_ship_value(args, i, sub, args[i], password)) return 2;
+            } else if (args[i] == "--dry-run") {
+                dry_run = true;
+            } else if (!args[i].empty() && args[i][0] != '-' && input.empty()) {
+                input = args[i];
+            } else {
+                return unknown_ship_arg(sub, args[i]);
+            }
+        }
+
+        if (input.empty()) {
+            std::cerr <<
+                "Usage: pulp ship share <app-or-dmg-or-pkg> [--identity \"...\"]\n"
+                "                       [--version X.Y.Z] [--output <dir>]\n"
+                "                       [notarization creds] [--dry-run]\n"
+                "Signs, notarizes, staples, and Gatekeeper-verifies a single\n"
+                "artifact for sharing. .app inputs are wrapped in a DMG first.\n";
+            return 2;
+        }
+        if (!fs::exists(input)) {
+            std::cerr << "pulp ship share: not found: " << input << "\n";
+            return 1;
+        }
+        auto ext = fs::path(input).extension().string();
+        if (ext != ".app" && ext != ".dmg" && ext != ".pkg") {
+            std::cerr << "pulp ship share: unsupported input '" << ext
+                      << "' — expected .app, .dmg, or .pkg.\n";
+            return 2;
+        }
+
+        if (version.empty()) version = read_project_cmake_version(root);
+        if (version.empty()) version = PULP_SDK_VERSION;
+        identity = ship_config(identity, "PULP_SIGN_IDENTITY",
+                               "signing.apple", "identity");
+        if (entitlements.empty()) {
+            auto def = root / "ship" / "templates" / "entitlements.plist";
+            if (fs::exists(def)) entitlements = def.string();
+        }
+
+        auto artifacts = output_dir.empty() ? (root / "artifacts")
+                                            : fs::path(output_dir);
+        auto stem = fs::path(input).stem().string();
+        auto dmg_target = (artifacts / (stem + "-" + version + ".dmg")).string();
+
+        if (dry_run) {
+            std::cout << "pulp ship share plan for " << input << ":\n";
+            if (ext == ".app") {
+                std::cout << "  1. codesign (hardened runtime) " << input << "\n"
+                          << "  2. create DMG → " << dmg_target << "\n"
+                          << "  3. codesign DMG\n"
+                          << "  4. notarize --path <DMG> + staple\n"
+                          << "  5. spctl -a -t open --context context:primary-signature -vv <DMG>\n";
+            } else if (ext == ".dmg") {
+                std::cout << "  1. codesign (hardened runtime) " << input << "\n"
+                          << "  2. notarize --path " << input << " + staple\n"
+                          << "  3. spctl -a -t open --context context:primary-signature -vv " << input << "\n";
+            } else {
+                std::cout << "  1. notarize --path " << input
+                          << " + staple  (.pkg already productsigned)\n"
+                          << "  2. spctl --assess --type install -vv " << input << "\n";
+            }
+            std::cout << "  identity: "
+                      << (identity.empty() ? "(unset — required for .app/.dmg)"
+                                           : identity)
+                      << "\n  version : " << version << "\n";
+            std::cout << "(--dry-run: nothing signed, packaged, or notarized)\n";
+            return 0;
+        }
+
+        if (ext != ".pkg" && identity.empty()) {
+            std::cerr << "pulp ship share: a Developer ID Application identity is "
+                         "required to sign a " << ext << ".\n";
+            std::cerr << "  pulp ship share " << input
+                      << " --identity \"Developer ID Application: Name (TEAMID)\"\n";
+            std::cerr << "  Or: pulp config set signing.apple.identity \"...\"\n";
+            return 1;
+        }
+
+        fs::create_directories(artifacts);
+        std::string artifact;  // the distributable we notarize + verify
+        if (ext == ".app") {
+            std::cout << "Signing app " << fs::path(input).filename().string()
+                      << "...\n";
+            if (!pulp::ship::codesign(input, identity, entitlements)) {
+                std::cerr << "  FAILED to codesign " << input << "\n";
+                return 1;
+            }
+            std::cout << "Wrapping into DMG → "
+                      << fs::path(dmg_target).filename().string() << "...\n";
+            if (!pulp::ship::create_dmg(input, dmg_target, stem)) {
+                std::cerr << "  FAILED to create DMG\n";
+                return 1;
+            }
+            std::cout << "Signing DMG...\n";
+            if (!pulp::ship::codesign(dmg_target, identity, "")) {
+                std::cerr << "  FAILED to codesign DMG\n";
+                return 1;
+            }
+            artifact = dmg_target;
+        } else if (ext == ".dmg") {
+            std::cout << "Signing DMG " << fs::path(input).filename().string()
+                      << "...\n";
+            if (!pulp::ship::codesign(input, identity, "")) {
+                std::cerr << "  FAILED to codesign " << input << "\n";
+                return 1;
+            }
+            artifact = input;
+        } else {  // .pkg — installer cert signing happens at build time
+            std::cout << "Using pre-signed .pkg as-is (installer cert).\n";
+            artifact = input;
+        }
+
+        std::vector<std::string> nz_args = {"notarize", "--path", artifact};
+        if (!api_key.empty())    { nz_args.push_back("--api-key");    nz_args.push_back(api_key); }
+        if (!api_key_id.empty()) { nz_args.push_back("--api-key-id"); nz_args.push_back(api_key_id); }
+        if (!api_issuer.empty()) { nz_args.push_back("--api-issuer"); nz_args.push_back(api_issuer); }
+        if (!apple_id.empty())   { nz_args.push_back("--apple-id");   nz_args.push_back(apple_id); }
+        if (!team_id.empty())    { nz_args.push_back("--team-id");    nz_args.push_back(team_id); }
+        if (!password.empty())   { nz_args.push_back("--password");   nz_args.push_back(password); }
+        int nz_rc = cmd_ship(nz_args);
+        if (nz_rc != 0) {
+            std::cerr << "pulp ship share: notarization failed.\n";
+            return nz_rc;
+        }
+
+        std::cout << "Verifying Gatekeeper acceptance...\n";
+        std::string verify_cmd = (ext == ".pkg")
+            ? "spctl --assess --type install -vv " + shell_quote(artifact)
+            : "spctl -a -t open --context context:primary-signature -vv "
+              + shell_quote(artifact);
+        if (run(verify_cmd) == 0) {
+            std::cout << "\n✓ " << fs::path(artifact).filename().string()
+                      << " is signed, notarized, stapled, and Gatekeeper-accepted.\n"
+                      << "  Ready to share: " << artifact << "\n";
+            return 0;
+        }
+        std::cerr << "\n✗ Gatekeeper did not accept " << artifact
+                  << " — inspect the spctl output above.\n";
+        return 1;
+#endif
+    }
+
     if (sub != "help" && sub != "--help" && sub != "-h") {
         std::cerr << "pulp ship: unknown subcommand: " << sub << "\n";
         return 2;
@@ -1137,10 +1409,12 @@ int cmd_ship(const std::vector<std::string>& args) {
     std::cout << "Subcommands:\n";
     std::cout << "  sign       Sign plugin bundles or Android artifacts\n";
     std::cout << "             --identity \"Developer ID Application: ...\"  (macOS/Windows)\n";
+    std::cout << "             --path <app|dmg|bundle>  (sign one explicit artifact)\n";
     std::cout << "             --target android --keystore key.jks  (Android)\n";
     std::cout << "  notarize   Submit signed bundles for Apple notarization (macOS)\n";
     std::cout << "             --api-key <p8> --api-key-id <id> --api-issuer <uuid>   (preferred)\n";
     std::cout << "             --apple-id you@example.com --team-id ABCDE12345        (legacy)\n";
+    std::cout << "             --path <dmg|pkg|app>  (notarize+staple an explicit artifact; repeatable)\n";
     std::cout << "             --env-file <path>  (override ~/.config/pulp/secrets/notary.env)\n";
     std::cout << "             --staple   (staple only, skip submission)\n";
     std::cout << "             --dry-run  (print resolved notarytool argv, no submission)\n";
@@ -1150,8 +1424,11 @@ int cmd_ship(const std::vector<std::string>& args) {
     std::cout << "             --target android --keystore key.jks --abi arm64-v8a|x86_64|all\n";
     std::cout << "  release    macOS: sign → package → notarize → staple in one command\n";
     std::cout << "             --target macos --identity \"...\" --apple-id ... --team-id ...\n";
-    std::cout << "             --pkg | --dmg                                       (item 7.5)\n";
+    std::cout << "             --pkg | --dmg   (notarizes the .pkg/.dmg it builds)   (item 7.5)\n";
     std::cout << "             --skip-sign | --skip-package | --skip-notarize      (CI flags)\n";
+    std::cout << "  share      One-shot: sign → (wrap .app in DMG) → notarize → staple → verify\n";
+    std::cout << "             <app|dmg|pkg> --identity \"...\" [--version X.Y.Z] [creds]\n";
+    std::cout << "             --dry-run  (print the plan without doing anything)\n";
     std::cout << "  appcast    Generate Sparkle-compatible update feed\n";
     std::cout << "             --url https://... --version 1.0.0 --notes \"...\"\n";
     std::cout << "  check      Check signing status of built plugins\n";

--- a/tools/cli/cmd_ship.cpp
+++ b/tools/cli/cmd_ship.cpp
@@ -230,6 +230,7 @@ int cmd_ship(const std::vector<std::string>& args) {
         fs::create_directories(artifacts);
 
         std::string version, target, keystore_path, key_alias, store_pass, key_pass, abi_arg;
+        std::string installer_identity;  // Developer ID Installer (macOS .pkg signing)
         bool per_user = false, apk_only = false, aab_only = false;
         // Item 7.5: per-artifact packaging on macOS. When the user
         // passes neither flag we use the historical default — `.pkg`
@@ -257,6 +258,8 @@ int cmd_ship(const std::vector<std::string>& args) {
                 if (!take_ship_value(args, i, sub, args[i], key_pass)) return 2;
             } else if (args[i] == "--abi") {
                 if (!take_ship_value(args, i, sub, args[i], abi_arg)) return 2;
+            } else if (args[i] == "--installer-identity") {
+                if (!take_ship_value(args, i, sub, args[i], installer_identity)) return 2;
             }
             else if (args[i] == "--apk-only") apk_only = true;
             else if (args[i] == "--aab-only") aab_only = true;
@@ -390,6 +393,15 @@ int cmd_ship(const std::vector<std::string>& args) {
         // distribution pattern).
         int pkg_count = 0, dmg_count = 0;
 
+        // Resolve the Developer ID Installer identity for flat-package
+        // signing. Apple's installer-distribution flow requires the `.pkg`
+        // itself to be signed (separate from the Developer ID *Application*
+        // identity that signs the bundles), or notarization rejects it. When
+        // none is configured we build an unsigned `.pkg` as before; `release`
+        // then declines to notarize it rather than submitting garbage.
+        installer_identity = ship_config(installer_identity, "PULP_INSTALLER_IDENTITY",
+                                         "signing.apple", "installer_identity");
+
 #ifdef __APPLE__
         // Standalone `.app` bundles → `.dmg` by default (or when --dmg).
         auto standalone_dir = build_dir / "Standalone";
@@ -450,12 +462,15 @@ int cmd_ship(const std::vector<std::string>& args) {
                 else install_loc = pulp::runtime::get_env("HOME").value_or("~")
                                  + "/Library/Audio/Plug-Ins/Components/";
 
-                std::cout << "Packaging " << name << " (" << dir_name << " → .pkg)...\n";
+                std::cout << "Packaging " << name << " (" << dir_name << " → .pkg"
+                          << (installer_identity.empty() ? "" : ", signed") << ")...\n";
                 std::string cmd = "pkgbuild --component \"" + entry.path().string() + "\""
                     + " --identifier \"com.pulp." + name + "." + format_lower + "\""
                     + " --version \"" + version + "\""
-                    + " --install-location \"" + install_loc + "\""
-                    + " \"" + pkg_path.string() + "\" 2>/dev/null";
+                    + " --install-location \"" + install_loc + "\"";
+                if (!installer_identity.empty())
+                    cmd += " --sign \"" + installer_identity + "\"";
+                cmd += " \"" + pkg_path.string() + "\" 2>/dev/null";
                 if (run(cmd) == 0) ++pkg_count;
                 else std::cerr << "  FAILED\n";
             }
@@ -588,6 +603,22 @@ int cmd_ship(const std::vector<std::string>& args) {
         // `share` one-shot points at.
         std::vector<std::string> bundles;
         if (!explicit_paths.empty()) {
+            // notarytool only accepts upload containers — UDIF disk images
+            // (.dmg), signed flat packages (.pkg), and .zip archives. A raw
+            // .app bundle cannot be submitted directly, so reject it with a
+            // pointer to `share` (which wraps it in a DMG) rather than letting
+            // notarytool fail mid-submission.
+            for (const auto& p : explicit_paths) {
+                if (fs::path(p).extension() == ".app") {
+                    std::cerr << "pulp ship notarize: notarytool cannot submit a raw"
+                                 " .app bundle:\n  " << p << "\n"
+                                 "  Use `pulp ship share " << p << "` (wraps it in a"
+                                 " DMG, signs, notarizes, staples),\n"
+                                 "  or zip it first:"
+                                 " ditto -c -k --keepParent \"" << p << "\" out.zip\n";
+                    return 2;
+                }
+            }
             bundles = explicit_paths;
         } else {
             for (auto dir_name : {"VST3", "CLAP", "AU"}) {
@@ -762,7 +793,7 @@ int cmd_ship(const std::vector<std::string>& args) {
     if (sub == "release") {
         std::string target = "macos";
         std::string identity, apple_id, team_id, password, version;
-        std::string api_key, api_key_id, api_issuer;
+        std::string api_key, api_key_id, api_issuer, installer_identity;
         bool want_pkg = false, want_dmg = false;
         bool skip_sign = false, skip_package = false, skip_notarize = false;
 
@@ -771,6 +802,8 @@ int cmd_ship(const std::vector<std::string>& args) {
                 if (!take_ship_value(args, i, sub, args[i], target)) return 2;
             } else if (args[i] == "--identity") {
                 if (!take_ship_value(args, i, sub, args[i], identity)) return 2;
+            } else if (args[i] == "--installer-identity") {
+                if (!take_ship_value(args, i, sub, args[i], installer_identity)) return 2;
             } else if (args[i] == "--apple-id") {
                 if (!take_ship_value(args, i, sub, args[i], apple_id)) return 2;
             } else if (args[i] == "--team-id") {
@@ -829,6 +862,27 @@ int cmd_ship(const std::vector<std::string>& args) {
                              "before package/notarize.\n";
                 return sign_rc;
             }
+            // The bundle pass above only walks VST3/CLAP/AU. Standalone
+            // `.app` bundles (which the package stage wraps into a DMG) must
+            // be signed too, or notarizing the resulting disk image fails on
+            // an unsigned app. Sign each one explicitly via `sign --path`.
+            auto standalone = build_dir / "Standalone";
+            if (fs::exists(standalone)) {
+                for (auto& e : fs::directory_iterator(standalone)) {
+                    if (e.path().extension() != ".app") continue;
+                    std::vector<std::string> app_args =
+                        {"sign", "--path", e.path().string()};
+                    if (!identity.empty()) {
+                        app_args.push_back("--identity");
+                        app_args.push_back(identity);
+                    }
+                    if (cmd_ship(app_args) != 0) {
+                        std::cerr << "pulp ship release: failed to sign standalone app "
+                                  << e.path().filename().string() << "\n";
+                        return 1;
+                    }
+                }
+            }
         } else {
             std::cout << "── Stage 1/4: sign (SKIPPED) ──────────────────────\n";
         }
@@ -854,6 +908,12 @@ int cmd_ship(const std::vector<std::string>& args) {
             }
             if (want_pkg) pkg_args.push_back("--pkg");
             if (want_dmg) pkg_args.push_back("--dmg");
+            // Plumb the Developer ID Installer identity so `package` signs the
+            // flat package it builds — an unsigned .pkg cannot be notarized.
+            if (!installer_identity.empty()) {
+                pkg_args.push_back("--installer-identity");
+                pkg_args.push_back(installer_identity);
+            }
             int pkg_rc = cmd_ship(pkg_args);
             if (pkg_rc != 0) {
                 std::cerr << "pulp ship release: package stage failed; "
@@ -869,6 +929,23 @@ int cmd_ship(const std::vector<std::string>& args) {
                     auto mtime = fs::last_write_time(entry.path(), ec);
                     if (!ec && mtime >= pkg_t0)
                         release_artifacts.push_back(entry.path().string());
+                }
+            }
+            // `package` builds the DMG but does not sign the disk image
+            // itself. Sign each freshly-built .dmg (unless signing was
+            // skipped) so it passes the signature guard below and Gatekeeper
+            // accepts the downloaded image.
+            if (!skip_sign) {
+                for (auto& a : release_artifacts) {
+                    if (fs::path(a).extension() != ".dmg") continue;
+                    std::vector<std::string> dmg_args = {"sign", "--path", a};
+                    if (!identity.empty()) {
+                        dmg_args.push_back("--identity");
+                        dmg_args.push_back(identity);
+                    }
+                    if (cmd_ship(dmg_args) != 0)
+                        std::cerr << "pulp ship release: warning — failed to sign "
+                                  << fs::path(a).filename().string() << "\n";
                 }
             }
         } else {
@@ -898,16 +975,40 @@ int cmd_ship(const std::vector<std::string>& args) {
         if (!apple_id.empty()) { nz_args.push_back("--apple-id"); nz_args.push_back(apple_id); }
         if (!team_id.empty())  { nz_args.push_back("--team-id");  nz_args.push_back(team_id); }
         if (!password.empty()) { nz_args.push_back("--password"); nz_args.push_back(password); }
-        // Notarize + staple the distributable artifact(s) when packaging
-        // produced any. Falling back to the notarize handler's own bundle
-        // scan only when packaging was skipped keeps `--skip-package`
-        // working for plugin-only flows.
-        if (!release_artifacts.empty()) {
-            for (auto& a : release_artifacts) {
-                nz_args.push_back("--path");
-                nz_args.push_back(a);
-                std::cout << "  artifact: " << fs::path(a).filename().string() << "\n";
+        // Only submit artifacts that are actually signed. notarytool rejects
+        // an unsigned .pkg/.dmg, and an unsigned installer would never pass
+        // Gatekeeper, so verify each and skip (loudly) the unsigned ones
+        // instead of submitting garbage. `.pkg` needs a Developer ID
+        // Installer signature; `.dmg` a Developer ID Application one.
+        std::vector<std::string> signed_artifacts;
+        for (auto& a : release_artifacts) {
+            auto ext = fs::path(a).extension().string();
+            std::string verify = (ext == ".pkg")
+                ? "pkgutil --check-signature \"" + a + "\" >/dev/null 2>&1"
+                : "codesign --verify \"" + a + "\" >/dev/null 2>&1";
+            if (run(verify) == 0) {
+                signed_artifacts.push_back(a);
+            } else {
+                std::cerr << "  skipping unsigned artifact "
+                          << fs::path(a).filename().string()
+                          << (ext == ".pkg"
+                                  ? " — pass --installer-identity \"Developer ID Installer: ...\"\n"
+                                  : " — needs a Developer ID Application signature\n");
             }
+        }
+        // When packaging produced artifacts but none are signed, refuse to
+        // fall through to the bundle scan (that would notarize loose bundles
+        // the user didn't ask to distribute). Only the genuine
+        // `--skip-package` plugin flow keeps the bundle-scan fallback.
+        if (!release_artifacts.empty() && signed_artifacts.empty()) {
+            std::cerr << "pulp ship release: no signed distributable to notarize"
+                         " — configure the signing identities and re-run.\n";
+            return 1;
+        }
+        for (auto& a : signed_artifacts) {
+            nz_args.push_back("--path");
+            nz_args.push_back(a);
+            std::cout << "  artifact: " << fs::path(a).filename().string() << "\n";
         }
         int nz_rc = cmd_ship(nz_args);
         if (nz_rc != 0) {
@@ -1414,17 +1515,19 @@ int cmd_ship(const std::vector<std::string>& args) {
     std::cout << "  notarize   Submit signed bundles for Apple notarization (macOS)\n";
     std::cout << "             --api-key <p8> --api-key-id <id> --api-issuer <uuid>   (preferred)\n";
     std::cout << "             --apple-id you@example.com --team-id ABCDE12345        (legacy)\n";
-    std::cout << "             --path <dmg|pkg|app>  (notarize+staple an explicit artifact; repeatable)\n";
+    std::cout << "             --path <dmg|pkg|zip>  (notarize+staple an explicit artifact; repeatable; not a raw .app)\n";
     std::cout << "             --env-file <path>  (override ~/.config/pulp/secrets/notary.env)\n";
     std::cout << "             --staple   (staple only, skip submission)\n";
     std::cout << "             --dry-run  (print resolved notarytool argv, no submission)\n";
     std::cout << "  package    Create installers for the target platform\n";
     std::cout << "             --version 1.0.0\n";
     std::cout << "             --pkg | --dmg  (item 7.5: per-artifact macOS packaging)\n";
+    std::cout << "             --installer-identity \"Developer ID Installer: ...\"  (sign the .pkg)\n";
     std::cout << "             --target android --keystore key.jks --abi arm64-v8a|x86_64|all\n";
     std::cout << "  release    macOS: sign → package → notarize → staple in one command\n";
     std::cout << "             --target macos --identity \"...\" --apple-id ... --team-id ...\n";
-    std::cout << "             --pkg | --dmg   (notarizes the .pkg/.dmg it builds)   (item 7.5)\n";
+    std::cout << "             --installer-identity \"Developer ID Installer: ...\"  (.pkg signing)\n";
+    std::cout << "             --pkg | --dmg   (notarizes the signed .pkg/.dmg it builds) (item 7.5)\n";
     std::cout << "             --skip-sign | --skip-package | --skip-notarize      (CI flags)\n";
     std::cout << "  share      One-shot: sign → (wrap .app in DMG) → notarize → staple → verify\n";
     std::cout << "             <app|dmg|pkg> --identity \"...\" [--version X.Y.Z] [creds]\n";


### PR DESCRIPTION
## What

Adds the composable + opinionated paths for "I built something and want to hand it to a friend, signed and notarized" without the full release pipeline.

- **`pulp ship sign --path <app|dmg|bundle>`** — sign one explicit artifact instead of scanning build dirs. Rejects `.pkg` with a productsign pointer.
- **`pulp ship notarize --path <dmg|pkg|app>`** — notarize + staple explicit artifacts (repeatable); falls back to the bundle scan when absent.
- **`pulp ship share <app|dmg|pkg>`** — one-shot: sign → wrap `.app` in a DMG → sign DMG → notarize → staple → `spctl` Gatekeeper verify. `--dry-run` prints the plan. This closes the "Unnotarized Developer ID" Gatekeeper rejection (valid Developer ID signature, no notarization ticket).
- **`pulp ship release --dmg/--pkg`** now notarizes + staples the distributable it packaged (selected by build time), not the loose bundles — so the artifact in `artifacts/` is Gatekeeper-ready and the command name is honest.

## Safety / compatibility

`sign`/`notarize` are backward compatible (identical behavior without `--path`). The production GitHub release pipeline (`.github/workflows/sign-and-release.yml`) does its own `codesign` + `pkgbuild`/`productbuild` + `xcrun notarytool submit` + `stapler staple` and **never invokes these CLI subcommands**, so regular releases are unaffected.

## Tests

9 new shellout cases in `test_cli_ship_shellout.cpp` covering `sign --path` (missing / `.pkg`), `notarize --path` dry-run argv, `release --dmg` actually notarizing the built DMG (real `hdiutil` path), and `share` usage / not-found / bad-ext / dry-run / no-identity + the non-macOS guard. Full ship suite green locally (408 assertions, 45 cases).

## Docs / skills

`cli-commands.yaml`, `docs/reference/cli.md`, `ship` SKILL.md, `cli-maintenance` SKILL.md, and the `/ship` slash command updated with the share flow, `--path` primitives, and the one-off-vs-release distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)