### PR TITLE
fix(view+import-design): design-import codegen/exporter correctness follow-ups

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -414,10 +414,10 @@ Facts / gotchas:
   grid too). Per-item placement (`emit_grid_item_placement`, folded into
   `emit_position_if_absolute`): `grid_column`/`grid_row` `"N / M"` → `setGrid(id,
   'column_start'/'column_end'/'row_start'/'row_end', N)`.
-- **Deferred** (codegen partial): `span N`, named lines, and `minmax()` are not
-  emitted as explicit placement — they fall through to the grid's auto-flow.
-  `setGrid` `column/row_start/end` take **ints** only, so non-numeric placement
-  is skipped. Stays within Flex+Grid (CLAUDE.md layout-model contract).
+- **Span**: `"<start> / span <n>"` resolves to `column/row_end = start + n`.
+  Still deferred (auto-placed): span-WITHOUT-a-start-line, named lines, and
+  `minmax()` track sizing — `setGrid column/row_start/end` take **ints** only.
+  Stays within Flex+Grid (CLAUDE.md layout-model contract).
 - Native arm only; `compat.json features.grid-container` tracks it (parsed
   handled, codegen partial). Tests: `[view][import][grid]`.
 
@@ -477,10 +477,13 @@ per-range styling. Now:
   the `Label` widget doesn't expose them — wiring `Label::set_attributed_string`
   + a `setRichText` bridge is the follow-up. Hence `compat.json
   features.text-per-range-styles` = parsed handled, **codegen partial**.
-- **Gotcha**: char offsets are treated as BYTE indices into `text_content`;
-  Figma supplies UTF-16 code-unit indices, so non-ASCII text needs UTF-16→byte
-  conversion (follow-up). Tests use ASCII. Tests: `[view][import][text]` +
-  the figma exporter python tests.
+- **Offsets are UTF-8 BYTE offsets** into `text_content`. The Figma exporter
+  converts its per-character `characterStyleOverrides` indices to byte offsets
+  (`len(chars[:i].encode('utf-8'))`, correct for all BMP text); `emit_web_text_runs`
+  slices by byte and snaps boundaries forward to the next codepoint start
+  (continuation bytes are `10xxxxxx`) so a stray mid-codepoint offset never emits
+  invalid UTF-8. Tests: `[view][import][text]` (incl. a multibyte case) + the
+  figma exporter python tests.
 
 ### Design-import IR round-trip + review-hardening gotchas
 
@@ -504,10 +507,10 @@ Lessons from the di-1..di-5 closeout review — keep these invariants:
 - **Web-compat run children don't inherit.** Pulp's web-compat `<span>` Labels
   don't inherit typography from the parent, so `emit_web_text_runs` copies the
   node's dominant style onto each run child before applying the run override.
-- **Known follow-ups (documented, not yet fixed):** text-run offsets are byte
-  indices but Figma supplies UTF-16 code units (non-ASCII slices are
-  approximate); a `STRETCH` constraint is a no-op when the node also has an
-  explicit cross-axis dimension.
+  A `STRETCH` constraint now also emits `min_width`/`min_height: '100%'` so it
+  fills its axis even when the node has an explicit cross-axis size (Yoga clamps
+  up to the min) — no longer a no-op. (Text-run UTF-16→byte offset conversion is
+  also handled now — see the per-range text section.)
 
 ### Interactive (turnable) sprite knobs — `--knob-style sprite`
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.161.3",
+      "version": "0.161.4",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.161.3"
+  "version": "0.161.4"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.161.3",
+  "version": "0.161.4",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.317.2
+    VERSION 0.317.3
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/design_ir.hpp
+++ b/core/view/include/pulp/view/design_ir.hpp
@@ -262,7 +262,9 @@ struct IRProvenance {
 };
 
 /// One styled character range inside a text node. Offsets are [start, end)
-/// indices into `IRNode::text_content`. Only the fields a run actually overrides
+/// UTF-8 BYTE offsets into `IRNode::text_content` (the Figma exporter converts
+/// its per-character indices to byte offsets; codegen slices by byte and snaps
+/// to codepoint boundaries defensively). Only the fields a run actually overrides
 /// are set; everything else inherits the node's dominant style. Mixed-style text
 /// (a bold word, a colored span, a different size mid-string) becomes an ordered
 /// list of these so codegen can emit per-range <span>s instead of collapsing to

--- a/core/view/src/design_codegen.cpp
+++ b/core/view/src/design_codegen.cpp
@@ -132,6 +132,15 @@ static void emit_web_text_runs(std::ostringstream& ss, const std::string& ind,
     std::sort(runs.begin(), runs.end(),
               [](const IRTextRun* a, const IRTextRun* b) { return a->start < b->start; });
 
+    // Run offsets are UTF-8 byte offsets, but defend against a source that
+    // passes a boundary landing mid-codepoint: snap forward to the next
+    // codepoint start (continuation bytes are 10xxxxxx) so we never slice a
+    // multibyte character in half and emit invalid UTF-8.
+    auto snap = [&](int k) {
+        while (k > 0 && k < n && (static_cast<unsigned char>(text[k]) & 0xC0) == 0x80) ++k;
+        return k;
+    };
+
     auto append_plain = [&](int a, int b) {
         if (b <= a) return;
         ss << ind << var << ".appendChild(document.createTextNode('"
@@ -140,7 +149,7 @@ static void emit_web_text_runs(std::ostringstream& ss, const std::string& ind,
 
     int cursor = 0, idx = 0;
     for (const auto* r : runs) {
-        int rs = std::max(0, r->start), re = std::min(n, r->end);
+        int rs = snap(std::max(0, r->start)), re = snap(std::min(n, r->end));
         if (re <= cursor) continue;          // wholly behind cursor (overlap) — skip
         if (rs < cursor) rs = cursor;        // clip a partial overlap
         append_plain(cursor, rs);            // base-styled gap before the run
@@ -276,7 +285,12 @@ static void generate_node(std::ostringstream& ss, const IRNode& node,
     // Apply visual styles
     auto& s = node.style;
     auto emit_str = [&](const char* prop, const std::optional<std::string>& val) {
-        if (val) ss << ind << var << ".style." << prop << " = '" << *val << "';\n";
+        // Escape the value — raw CSS (esp. clip-path / mask, which can carry
+        // url("...") with quotes) must not break out of the JS string literal
+        // (#3288 P2). js_single_quote_escape is a no-op for the common
+        // quote-free keyword/color values, so this is regression-safe.
+        if (val) ss << ind << var << ".style." << prop << " = '"
+                    << js_single_quote_escape(*val) << "';\n";
     };
     auto emit_px = [&](const char* prop, const std::optional<float>& val) {
         if (val) ss << ind << var << ".style." << prop << " = '" << format_px(*val) << "';\n";
@@ -287,7 +301,7 @@ static void generate_node(std::ostringstream& ss, const IRNode& node,
 
     emit_str("backgroundColor", s.background_color);
     if (s.background_gradient)
-        ss << ind << var << ".style.background = '" << *s.background_gradient << "';\n";
+        ss << ind << var << ".style.background = '" << js_single_quote_escape(*s.background_gradient) << "';\n";
     emit_str("color", s.color);
     emit_float("opacity", s.opacity);
     emit_str("mixBlendMode", s.mix_blend_mode);
@@ -508,6 +522,11 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
                 grow();
             } else if (h == "stretch") {
                 stretch();
+                // Pin both horizontal edges = fill width. min-width:100% keeps
+                // this effective even when the node ALSO has an explicit width
+                // (Yoga clamps the final width up to min-width), so STRETCH is no
+                // longer a no-op against a defined cross-size.
+                ss << ind << "setFlex('" << target_id << "', 'min_width', '100%');\n";
             }
         }
         if (L.v_constraint) {
@@ -521,14 +540,15 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
                 grow();
             } else if (v == "stretch") {
                 stretch();
+                ss << ind << "setFlex('" << target_id << "', 'min_height', '100%');\n";
             }
         }
     };
 
     // Grid item placement: a child of a grid container can carry grid-column /
-    // grid-row LINE placement ("1 / 3", "2"). Lower to setGrid column/row
-    // start/end on the child. Non-numeric forms (span N, named lines, auto) are
-    // skipped — they fall through to the grid's auto-placement.
+    // grid-row LINE placement ("1 / 3", "2", "1 / span 2"). Lower to setGrid
+    // column/row start/end on the child. A "span N" END resolves to start+N.
+    // Span-only (no start line) and named lines are left to auto-placement.
     auto emit_grid_item_placement = [&](const std::string& target_id) {
         if (depth == 0) return;
         auto emit_track = [&](const std::optional<std::string>& v,
@@ -547,15 +567,24 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
                 if (t.empty()) return false;
                 char* e = nullptr;
                 long n = std::strtol(t.c_str(), &e, 10);
-                if (e == t.c_str()) return false;  // span / named / auto -> skip
+                if (e == t.c_str()) return false;  // named / auto -> skip
                 out = static_cast<int>(n);
                 return true;
             };
-            int iv;
-            if (as_int(lo, iv))
-                ss << ind << "setGrid('" << target_id << "', '" << start_key << "', " << iv << ");\n";
-            if (as_int(hi, iv))
-                ss << ind << "setGrid('" << target_id << "', '" << end_key << "', " << iv << ");\n";
+            int lo_i = 0;
+            const bool have_lo = as_int(lo, lo_i);
+            if (have_lo)
+                ss << ind << "setGrid('" << target_id << "', '" << start_key << "', " << lo_i << ");\n";
+            int hi_i;
+            if (as_int(hi, hi_i)) {
+                ss << ind << "setGrid('" << target_id << "', '" << end_key << "', " << hi_i << ");\n";
+            } else if (have_lo && hi.rfind("span", 0) == 0) {
+                // "<start> / span <n>"  ->  end line = start + n
+                int span = 0;
+                if (as_int(trim(hi.substr(4)), span) && span > 0)
+                    ss << ind << "setGrid('" << target_id << "', '" << end_key << "', "
+                       << (lo_i + span) << ");\n";
+            }
         };
         emit_track(node.layout.grid_column, "column_start", "column_end");
         emit_track(node.layout.grid_row, "row_start", "row_end");

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -4887,6 +4887,75 @@ TEST_CASE("per-range run children carry the node's dominant style",
     CHECK(count(".style.color = '#222222'") >= 2);
 }
 
+TEST_CASE("STRETCH constraint fills its axis even with an explicit size",
+          "[view][import][codegen][constraints]") {
+    // A STRETCH constraint pins both edges = fill that dimension. min-width/
+    // height:100% makes it effective even when the node also has an explicit
+    // pixel size (Yoga clamps up to min), so STRETCH is no longer a no-op.
+    DesignIR ir;
+    ir.root.type = "frame"; ir.root.name = "Root";
+    ir.root.style.width = 400.0f; ir.root.style.height = 400.0f;
+    IRNode c; c.type = "frame"; c.name = "C";
+    c.style.width = 50.0f; c.style.height = 50.0f;   // explicit cross-size
+    c.layout.h_constraint = "stretch";
+    c.layout.v_constraint = "stretch";
+    ir.root.children.push_back(c);
+    CodeGenOptions opts;
+    const auto js = generate_pulp_js(ir, opts);
+    INFO(js);
+    CHECK(js.find("'min_width', '100%'") != std::string::npos);
+    CHECK(js.find("'min_height', '100%'") != std::string::npos);
+}
+
+TEST_CASE("grid item 'N / span M' resolves to an end line",
+          "[view][import][codegen][grid]") {
+    DesignIR ir;
+    ir.root.type = "frame"; ir.root.name = "G";
+    ir.root.layout.display = "grid";
+    ir.root.layout.grid_template_columns = "1fr 1fr 1fr";
+    IRNode a; a.type = "frame"; a.name = "A"; a.style.width = 10.0f; a.style.height = 10.0f;
+    a.layout.grid_column = "1 / span 2";  // start line 1, span 2 -> end line 3
+    ir.root.children.push_back(a);
+    CodeGenOptions opts;
+    const auto js = generate_pulp_js(ir, opts);
+    INFO(js);
+    CHECK(js.find("'column_start', 1)") != std::string::npos);
+    CHECK(js.find("'column_end', 3)") != std::string::npos);
+}
+
+TEST_CASE("web codegen escapes clip-path / mask CSS (no JS string break)",
+          "[view][import][codegen][mask]") {
+    // Raw clip-path/mask CSS can carry url('...') with quotes; emit_str must
+    // escape it so it can't break out of the JS string literal (#3288 P2).
+    DesignIR ir;
+    ir.root.type = "frame"; ir.root.name = "Root";
+    ir.root.style.clip_path = "url('#a')";  // contains single quotes
+    CodeGenOptions opts; opts.mode = CodeGenMode::web_compat;
+    const auto js = generate_pulp_js(ir, opts);
+    INFO(js);
+    CHECK(js.find("\\'#a\\'") != std::string::npos);          // quotes escaped
+    CHECK(js.find("clipPath = 'url('#a')'") == std::string::npos);  // not raw
+}
+
+TEST_CASE("per-range text runs slice multibyte text on byte offsets",
+          "[view][import][codegen][text]") {
+    // "café world" — é is 2 UTF-8 bytes, so "world" begins at BYTE offset 6.
+    // The run must slice on bytes (not char index 5), leaving the "café " gap
+    // intact and the run text == "world".
+    DesignIR ir;
+    ir.root.type = "frame"; ir.root.name = "Root";
+    IRNode t; t.type = "text"; t.name = "M";
+    t.text_content = "caf\xc3\xa9 world";   // "café world", é = 0xC3 0xA9
+    IRTextRun run; run.start = 6; run.end = 11; run.font_weight = 700;  // "world"
+    t.text_runs.push_back(run);
+    ir.root.children.push_back(t);
+    CodeGenOptions opts; opts.mode = CodeGenMode::web_compat;
+    const auto js = generate_pulp_js(ir, opts);
+    INFO(js);
+    CHECK(js.find("createTextNode('caf\xc3\xa9 ')") != std::string::npos);  // gap intact
+    CHECK(js.find(".textContent = 'world'") != std::string::npos);          // run text
+}
+
 TEST_CASE("codegen emits mix-blend-mode on native + web-compat paths",
           "[view][import][codegen][blend]") {
     // A node's normalized mix_blend_mode lowers to setMixBlendMode (native

--- a/test/test_figma_rest_export.py
+++ b/test/test_figma_rest_export.py
@@ -128,6 +128,17 @@ class TextRunsTest(unittest.TestCase):
         runs = frx.extract_text_runs(n)
         self.assertEqual([(r["start"], r["end"]) for r in runs], [(0, 1), (1, 2)])
 
+    def test_run_offsets_are_utf8_byte_offsets(self):
+        # "café world": é is 2 UTF-8 bytes, so the run over "world" (char index 5)
+        # must be emitted as BYTE offset 6, not char index 5.
+        n = {"type": "TEXT", "characters": "café world",
+             "characterStyleOverrides": [0, 0, 0, 0, 0, 1, 1, 1, 1, 1],
+             "styleOverrideTable": {"1": {"fontWeight": 700}}}
+        runs = frx.extract_text_runs(n)
+        self.assertEqual(len(runs), 1)
+        self.assertEqual(runs[0]["start"], 6)   # byte offset (char index would be 5)
+        self.assertEqual(runs[0]["end"], 11)
+
     def test_no_overrides_yields_no_runs(self):
         self.assertEqual(frx.extract_text_runs({"characters": "hi"}), [])
         self.assertEqual(frx.extract_text_runs(

--- a/tools/import-design/figma_rest_export.py
+++ b/tools/import-design/figma_rest_export.py
@@ -151,14 +151,21 @@ def extract_style(n):
 def extract_text_runs(n):
     # Figma per-character style overrides -> ordered IR text runs. Group
     # consecutive characters that share a non-zero override id into [start,end)
-    # ranges and resolve each id through styleOverrideTable. Char indices are
-    # UTF-16 code units (Figma); for non-ASCII text the consumer's byte-offset
-    # slicing is approximate — a follow-up. Returns [] when no overrides.
+    # ranges and resolve each id through styleOverrideTable. The IR contract is
+    # UTF-8 BYTE offsets into `content` (the native slicer is byte-based), so we
+    # convert the per-character index to a byte offset here — correct for all
+    # BMP text (accents/CJK/etc.). Returns [] when no overrides.
     chars = n.get("characters", "")
     overrides = n.get("characterStyleOverrides")
     table = n.get("styleOverrideTable")
     if not chars or not isinstance(overrides, list) or not isinstance(table, dict):
         return []
+
+    # char-index -> UTF-8 byte offset (prefix-length lookup; len(overrides) may
+    # exceed len(chars), so clamp).
+    def byte_off(ci):
+        return len(chars[:min(ci, len(chars))].encode("utf-8"))
+
     runs = []
     i, L = 0, len(overrides)
     while i < L:
@@ -170,7 +177,7 @@ def extract_text_runs(n):
             j += 1
         st = table.get(str(sid)) or table.get(sid)
         if st:
-            run = {"start": i, "end": j}
+            run = {"start": byte_off(i), "end": byte_off(j)}
             if "fontSize" in st:   run["fontSize"] = st["fontSize"]
             if "fontWeight" in st: run["fontWeight"] = st["fontWeight"]
             fn = st.get("fontName") or {}


### PR DESCRIPTION
Four review-driven design-import fixes (closeout of the di-1..di-5 Codex findings + non-ASCII robustness), each with tests:

- **Text-run offsets are UTF-8 byte offsets.** The Figma exporter converts its per-character `characterStyleOverrides` indices to byte offsets (correct for all BMP text); `emit_web_text_runs` slices by byte and snaps to codepoint starts so a stray mid-codepoint offset never emits invalid UTF-8.
- **Escape raw clip-path / mask CSS** (and the background-gradient string) in web-compat output — `emit_str` now `js_single_quote_escape`s (#3288 P2). No-op for quote-free values.
- **STRETCH constraint** also emits `min_width`/`min_height: '100%'` so it fills its axis even with an explicit cross-size (Yoga clamps up to min) — no longer a no-op.
- **Grid `"<start> / span <n>"`** resolves to `column/row_end = start + n` (was skipped). Span-without-start, named lines, minmax() remain auto-placed.

Tests: `[text]` multibyte ("café world") byte-offset slice; `[mask]` clip-path quote escaping; `[constraints]` STRETCH min-width/height fill; `[grid]` "1 / span 2" → end line 3; figma exporter python byte-offset test. Full `pulp-test-design-import` green (1063 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)