### PR TITLE
fix(ci): unblock macOS lane (rustc gate) + isolate test git from inherited GIT_DIR

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -42,6 +42,21 @@ Slice 6 (#551).
 
 ## GitHub workflow gotchas
 
+- **Hooks inherit `GIT_DIR` — tests that shell out to git can corrupt the live
+  worktree.** Git exports `GIT_DIR`/`GIT_WORK_TREE` into hook environments, and
+  a set `GIT_DIR` *overrides* `git -C <dir>` discovery. So when the pre-push
+  hook (or `shipyard`) runs the full `ctest` and a test does
+  `git -C <tempdir> init/commit/checkout`, those commands silently hit THIS
+  worktree's repo instead — stray `initial` commits, throwaway branches, and a
+  `core.bare=true` flip in the shared config (which makes the main checkout
+  look "not a work tree"). `.githooks/pre-push` and
+  `tools/scripts/local_diff_cover.sh` now `unset GIT_DIR GIT_WORK_TREE …`
+  before running gates/ctest, and the git-shelling tests scrub the same vars
+  in-process (see the regression test in `test_mcp_server.cpp`). If you add a
+  test that shells out to git on a temp repo, clear the inherited git env first
+  (or run from a context with no `GIT_DIR`), and never assume `-C` alone
+  isolates it. Recovery if a worktree was hit: `git config core.bare false`,
+  reset the branch off the stray `initial` commit, delete the throwaway branch.
 - The required `macos` alias in `.github/workflows/build.yml` mirrors the
   macOS matrix leg by polling the Actions jobs API. Keep that poll retry-safe:
   API failures or malformed JSON must log and continue the loop, not trip

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -27,6 +27,18 @@ set -u
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
 cd "$ROOT" || exit 0
 
+# Git exports GIT_DIR / GIT_WORK_TREE (and friends) into hook environments.
+# A set GIT_DIR OVERRIDES `git -C <dir>` repository discovery, so any test the
+# downstream gates run via ctest (e.g. local_diff_cover.sh) that shells out to
+# `git -C <tempdir> …` would silently operate on THIS worktree's repo instead —
+# committing fixtures, creating throwaway branches, and flipping core.bare in
+# the shared config. Scrub the inherited git environment now that we've cd'd to
+# the worktree root; the hook's own later `git` calls rediscover the repo from
+# cwd. (Root-caused after a full-suite ctest under this hook corrupted a live
+# worktree — see tools/scripts/local_diff_cover.sh and test_mcp_server.cpp.)
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
+      GIT_COMMON_DIR GIT_PREFIX GIT_NAMESPACE GIT_QUARANTINE_PATH
+
 if [ "${PULP_SKIP_PREPUSH:-0}" = "1" ]; then
     echo "[pre-push] PULP_SKIP_PREPUSH=1 — skipping gates." >&2
     exit 0

--- a/experimental/pulp-rs/CMakeLists.txt
+++ b/experimental/pulp-rs/CMakeLists.txt
@@ -65,6 +65,36 @@ if(NOT _pulp_rs_cargo_version_result EQUAL 0)
     return()
 endif()
 
+# `cargo` can be present without a working `rustc` — a partial Rust install
+# (e.g. a Homebrew `cargo` with no rustup toolchain, or a CI runner where the
+# toolchain was never completed). `cargo --version` still succeeds in that
+# state, but `cargo build` then hard-fails with
+# `error: could not execute process \`rustc -vV\``. Verify rustc is both found
+# AND runnable so an incomplete toolchain SKIPS the experimental CLI instead of
+# breaking the whole build (this is what wedged the required macOS CI lane).
+find_program(RUSTC_EXECUTABLE rustc
+    HINTS "$ENV{HOME}/.cargo/bin" "$ENV{USERPROFILE}/.cargo/bin")
+
+if(NOT RUSTC_EXECUTABLE)
+    message(STATUS
+        "pulp-rs: skipped (cargo found at ${CARGO_EXECUTABLE} but rustc is not "
+        "on PATH — incomplete Rust toolchain; run `rustup default stable` or "
+        "set PULP_SKIP_RUST_CLI=1 to silence this message)")
+    return()
+endif()
+
+execute_process(
+    COMMAND "${RUSTC_EXECUTABLE}" --version
+    RESULT_VARIABLE _pulp_rs_rustc_version_result
+    OUTPUT_QUIET ERROR_QUIET)
+
+if(NOT _pulp_rs_rustc_version_result EQUAL 0)
+    message(STATUS
+        "pulp-rs: skipped (rustc at ${RUSTC_EXECUTABLE} is not runnable; "
+        "set PULP_SKIP_RUST_CLI=1 to silence this message)")
+    return()
+endif()
+
 # Pick the Cargo profile. Default to release for installable
 # artifacts; let the build matrix override via PULP_RUST_CLI_PROFILE
 # (e.g. "debug" for faster CI iteration where binary speed doesn't

--- a/test/test_cli_project_command.cpp
+++ b/test/test_cli_project_command.cpp
@@ -168,6 +168,26 @@ void require_run_ok(const std::string& cmd) {
     REQUIRE(run(cmd) == 0);
 }
 
+// A set GIT_DIR/GIT_WORK_TREE in the environment OVERRIDES `git -C <dir>`
+// discovery. When this binary runs under a git hook or `shipyard` (which
+// inject those vars), the throwaway `git -C <tempdir>` commands below would
+// commit "initial" / branch / flip core.bare on the SOURCE worktree instead of
+// the temp repo. Scrub the inherited git environment so temp-repo git is
+// isolated regardless of who launched the test. (Mirrors the scrub in the
+// pre-push hook, local_diff_cover.sh, and test_mcp_server.cpp.)
+void clear_inherited_git_env() {
+    for (const char* var : {"GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE",
+                            "GIT_OBJECT_DIRECTORY", "GIT_COMMON_DIR",
+                            "GIT_PREFIX", "GIT_NAMESPACE",
+                            "GIT_QUARANTINE_PATH"}) {
+#if defined(_WIN32)
+        _putenv_s(var, "");
+#else
+        ::unsetenv(var);
+#endif
+    }
+}
+
 void configure_git_identity(const fs::path& repo) {
     require_run_ok("git -C " + quote(repo) + " config user.name \"Pulp Test\"");
     require_run_ok("git -C " + quote(repo) + " config user.email \"pulp-test@example.com\"");
@@ -226,6 +246,7 @@ void make_fake_sdk(const fs::path& sdk_root,
 }
 
 void init_clean_git_repo(const fs::path& repo) {
+    clear_inherited_git_env();  // don't let an inherited GIT_DIR hijack `git -C`
     require_run_ok("git init -q " + quote(repo));
     configure_git_identity(repo);
     require_run_ok("git -C " + quote(repo) + " add CMakeLists.txt pulp.toml");

--- a/test/test_mcp_server.cpp
+++ b/test/test_mcp_server.cpp
@@ -135,6 +135,29 @@ private:
     bool had_previous_ = false;
 };
 
+// Several tests below shell out to `git -C <tempdir> …` on throwaway repos.
+// If this binary is launched from a git-invoked context — a hook (pre-push),
+// `shipyard`, or any parent `git` process — then GIT_DIR / GIT_WORK_TREE are
+// inherited in the environment. A set GIT_DIR *overrides* `git -C <dir>`
+// repository discovery, so those commands would silently operate on the
+// SOURCE worktree's repo instead of their temp repo: stray "initial" commits,
+// throwaway branches, and `core.bare` flips in the shared config. Clearing the
+// inherited git environment makes temp-repo git deterministic regardless of
+// who launched the test. (The pre-push hook and local_diff_cover.sh scrub the
+// same vars; this is the in-process belt-and-suspenders for other runners.)
+void clear_inherited_git_env() {
+    for (const char* var : {"GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE",
+                            "GIT_OBJECT_DIRECTORY", "GIT_COMMON_DIR",
+                            "GIT_PREFIX", "GIT_NAMESPACE",
+                            "GIT_QUARANTINE_PATH"}) {
+#if defined(_WIN32)
+        _putenv_s(var, "");
+#else
+        ::unsetenv(var);
+#endif
+    }
+}
+
 bool has_repo_markers(const std::filesystem::path& candidate) {
     return std::filesystem::exists(candidate / "CMakeLists.txt") &&
            std::filesystem::exists(candidate / "tools" / "mcp" / "pulp_mcp.cpp");
@@ -742,6 +765,7 @@ TEST_CASE("MCP status quotes project roots before reading Git branch",
 #if defined(_WIN32)
     SKIP("POSIX shell quoting assertion is only used on non-Windows");
 #else
+    clear_inherited_git_env();  // never let an inherited GIT_DIR hijack `git -C`
     TempDir scratch;
     const auto project = scratch.path / "Project With Spaces And 'Quotes'";
     std::filesystem::create_directories(project / "core");
@@ -759,6 +783,53 @@ TEST_CASE("MCP status quotes project roots before reading Git branch",
     require_contains(response, R"JSON("id":37)JSON");
     require_contains(response, "Project With Spaces And 'Quotes'");
     require_contains(response, "Branch: mcp-status-quoted-root");
+#endif
+}
+
+// Regression: a throwaway temp repo must stay isolated even when the process
+// inherited a GIT_DIR/GIT_WORK_TREE pointing at another repo (as happens when
+// the suite runs under a git hook). Before the fix, `git -C <temp>` honored the
+// inherited GIT_DIR and mutated the WRONG repo — corrupting live worktrees
+// during pre-push / shipyard ctest runs.
+TEST_CASE("temp-repo git stays isolated despite an inherited GIT_DIR",
+          "[mcp][git-isolation][regression][coverage]") {
+#if defined(_WIN32)
+    SKIP("POSIX git-environment isolation assertion is only used on non-Windows");
+#else
+    // A "sentinel" repo standing in for the source worktree. If isolation
+    // breaks, the temp-repo git commands below would land here.
+    TempDir sentinel;
+    REQUIRE(std::system(("git -C " + shell_quote(sentinel.path.string()) +
+                         " init --quiet").c_str()) == 0);
+    REQUIRE(std::system(("git -C " + shell_quote(sentinel.path.string()) +
+                         " symbolic-ref HEAD refs/heads/sentinel-main").c_str()) == 0);
+
+    // Simulate the hook environment: export GIT_DIR/GIT_WORK_TREE at the
+    // sentinel, exactly what a parent `git` process would inject.
+    ScopedEnvVar git_dir("GIT_DIR", (sentinel.path / ".git").string());
+    ScopedEnvVar git_work_tree("GIT_WORK_TREE", sentinel.path.string());
+
+    // The code under test: scrub the inherited git environment.
+    clear_inherited_git_env();
+    REQUIRE(std::getenv("GIT_DIR") == nullptr);
+    REQUIRE(std::getenv("GIT_WORK_TREE") == nullptr);
+
+    // Now a temp-repo git op must target the temp repo, not the sentinel.
+    TempDir project;
+    REQUIRE(std::system(("git -C " + shell_quote(project.path.string()) +
+                         " init --quiet").c_str()) == 0);
+    REQUIRE(std::system(("git -C " + shell_quote(project.path.string()) +
+                         " checkout -b isolated-branch --quiet").c_str()) == 0);
+
+    // The project's own repo was created and switched (proves the temp-repo
+    // git commands actually ran against the temp repo).
+    REQUIRE(std::filesystem::exists(project.path / ".git" / "HEAD"));
+    // The sentinel repo is untouched: it still has no isolated-branch.
+    const int sentinel_has_branch = std::system(
+        ("git -C " + shell_quote(sentinel.path.string()) +
+         " rev-parse --verify --quiet refs/heads/isolated-branch >/dev/null")
+            .c_str());
+    REQUIRE(sentinel_has_branch != 0);  // sentinel must NOT have the branch
 #endif
 }
 

--- a/tools/scripts/local_diff_cover.sh
+++ b/tools/scripts/local_diff_cover.sh
@@ -47,6 +47,18 @@ CONFIG_JSON="${REPO_ROOT}/tools/scripts/coverage_config.json"
 BUILD_DIR="${REPO_ROOT}/build-cov"
 HTML_REPORT="${TMPDIR:-/tmp}/diff-cover.html"
 
+# Scrub any inherited git environment. When this script runs from a git hook
+# (e.g. pre-push) or another git-invoked context, GIT_DIR / GIT_WORK_TREE are
+# set — and a set GIT_DIR OVERRIDES `git -C <dir>` discovery, so the test
+# binaries ctest runs below (which shell out to `git -C <tempdir> …`) would
+# operate on THIS worktree's repo instead of their throwaway temp repos,
+# corrupting it (stray "initial" commits, throwaway branches, core.bare flips).
+# This script discovers the repo from cwd, so unsetting these is also correct
+# for its own `git`/diff-cover calls. Root-caused: a full-suite ctest under the
+# pre-push hook mutated a live worktree's .git.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
+      GIT_COMMON_DIR GIT_PREFIX GIT_NAMESPACE GIT_QUARANTINE_PATH
+
 # ── PULP_SKIP_DIFF_COVER bypass ─────────────────────────────────────────────
 # Honor PULP_SKIP_DIFF_COVER=1 before doing ANY other work (no config
 # read, no dep check) so a workflow-only or doc-only PR can bypass even


### PR DESCRIPTION
Two CI-infra repairs that unblock the required macOS lane and stop a worktree-corruption bug. (The M_PI/MSVC issue is already fixed on `main` via #3332's `kSynthPi`, so it's not included here.)

## 1. `pulp-rs` gate: skip when `rustc` is missing, not just `cargo`

The required macOS lane fails on the self-hosted runners with `error: could not execute process 'rustc -vV'`. The runners have a partial Rust install — `cargo` present, `rustc` absent — and the gate only checked `cargo`. `cargo --version` succeeds, then `cargo build` hard-fails, breaking the whole build for every PR. Fix: also `find_program(rustc)` + probe `rustc --version`, skipping the experimental CLI on an incomplete toolchain (matching the existing cargo-missing path). No change when a full toolchain is present.

## 2. Isolate test git from an inherited `GIT_DIR`

Root cause: git exports `GIT_DIR`/`GIT_WORK_TREE` into hook environments, and a set `GIT_DIR` **overrides** `git -C <dir>` discovery. So when the pre-push hook (or shipyard) runs the full `ctest`, tests that shell out to `git -C <tempdir> …` silently operate on the **source worktree's** repo — stray `initial` commits, throwaway branches (`mcp-status-quoted-root`), and `core.bare=true` flips in the shared config. This corrupted live worktrees during ctest runs.

Fix, in layers:
- `.githooks/pre-push` and `tools/scripts/local_diff_cover.sh` scrub the inherited git env before running gates/ctest (both discover the repo from cwd).
- `test_mcp_server.cpp` and `test_cli_project_command.cpp` (the confirmed escapees) clear the same vars in-process, so they're isolated under any runner.
- New regression test: a `git -C <temp>` op stays in the temp repo even with `GIT_DIR` pointed at a sentinel.

**Verified:** running both test binaries with `GIT_DIR`/`GIT_WORK_TREE` exported leaves the worktree's HEAD/branch/`core.bare`/branch-list untouched; this PR's own push (through the fixed hook) ran clean.

Unblocks #3318 (its required macOS lane was wedged on the same rustc issue) once this lands and #3318 rebases onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)