### PR TITLE
fix(import-design): UTF-16 code-unit offsets for emoji in text runs

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -483,12 +483,14 @@ per-range styling. Now:
   stays **codegen partial**. `Label::set_attributed_string` + the `setTextRuns`
   bridge fn are the wiring (offsets are UTF-8 byte offsets, same as the web arm).
 - **Offsets are UTF-8 BYTE offsets** into `text_content`. The Figma exporter
-  converts its per-character `characterStyleOverrides` indices to byte offsets
-  (`len(chars[:i].encode('utf-8'))`, correct for all BMP text); `emit_web_text_runs`
+  builds a UTF-16-code-unit → UTF-8-byte map (`characterStyleOverrides` is
+  UTF-16-indexed: a BMP char is 1 unit, an astral char / emoji is a surrogate
+  pair = 2 units) so a run after an emoji lands on the right byte — a plain
+  code-point slice was off by a byte-position per astral char. `emit_web_text_runs`
   slices by byte and snaps boundaries forward to the next codepoint start
   (continuation bytes are `10xxxxxx`) so a stray mid-codepoint offset never emits
   invalid UTF-8. Tests: `[view][import][text]` (incl. a multibyte case) + the
-  figma exporter python tests.
+  figma exporter python tests (incl. an emoji/surrogate-pair case).
 
 ### Design-import IR round-trip + review-hardening gotchas
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.162.0",
+      "version": "0.162.1",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.162.0"
+  "version": "0.162.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.162.0",
+  "version": "0.162.1",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/test/test_figma_rest_export.py
+++ b/test/test_figma_rest_export.py
@@ -139,6 +139,19 @@ class TextRunsTest(unittest.TestCase):
         self.assertEqual(runs[0]["start"], 6)   # byte offset (char index would be 5)
         self.assertEqual(runs[0]["end"], 11)
 
+    def test_astral_emoji_offsets_use_utf16_to_byte_map(self):
+        # "A😀B": the emoji is 2 UTF-16 code units (a surrogate pair) and 4 UTF-8
+        # bytes. characterStyleOverrides is UTF-16-indexed (length 4), so a run
+        # over "B" begins at UTF-16 unit 3 -> byte offset 5 (A=1 + emoji=4), not
+        # code-point index 2. Guards the surrogate-pair conversion.
+        n = {"type": "TEXT", "characters": "A\U0001F600B",
+             "characterStyleOverrides": [0, 0, 0, 1],
+             "styleOverrideTable": {"1": {"fontWeight": 700}}}
+        runs = frx.extract_text_runs(n)
+        self.assertEqual(len(runs), 1)
+        self.assertEqual(runs[0]["start"], 5)
+        self.assertEqual(runs[0]["end"], 6)
+
     def test_no_overrides_yields_no_runs(self):
         self.assertEqual(frx.extract_text_runs({"characters": "hi"}), [])
         self.assertEqual(frx.extract_text_runs(

--- a/tools/import-design/figma_rest_export.py
+++ b/tools/import-design/figma_rest_export.py
@@ -161,10 +161,23 @@ def extract_text_runs(n):
     if not chars or not isinstance(overrides, list) or not isinstance(table, dict):
         return []
 
-    # char-index -> UTF-8 byte offset (prefix-length lookup; len(overrides) may
-    # exceed len(chars), so clamp).
+    # UTF-16 code-unit index -> UTF-8 byte offset. Figma's
+    # characterStyleOverrides is indexed by UTF-16 code units (a BMP char is 1
+    # unit, an astral char like an emoji is a surrogate pair = 2 units), while
+    # the IR contract is UTF-8 byte offsets into `content`. Build the map up
+    # front so a run beginning after an emoji lands on the right byte (a plain
+    # `chars[:i]` code-point slice would be off by one byte-position per astral
+    # char before the run). u16_to_byte[k] = byte offset at UTF-16 unit k.
+    u16_to_byte = []
+    _byte = 0
+    for ch in chars:
+        units = 2 if ord(ch) > 0xFFFF else 1
+        for _ in range(units):
+            u16_to_byte.append(_byte)
+        _byte += len(ch.encode("utf-8"))
+    u16_to_byte.append(_byte)  # past-the-end sentinel
     def byte_off(ci):
-        return len(chars[:min(ci, len(chars))].encode("utf-8"))
+        return u16_to_byte[ci] if 0 <= ci < len(u16_to_byte) else _byte
 
     runs = []
     i, L = 0, len(overrides)


### PR DESCRIPTION
Addresses the Codex review follow-up on #3332.

The Figma text-run exporter converted `characterStyleOverrides` indices to byte offsets via a Python **code-point** slice, but `characterStyleOverrides` is indexed by **UTF-16 code units** — an astral character (emoji) is a surrogate pair (2 units). So for `"A😀B"` a run over `"B"` (UTF-16 index 3) was emitted at byte offset 6 instead of 5 and later dropped/misapplied.

Fix: build a UTF-16-unit → UTF-8-byte map up front and index it. BMP text is unchanged (1 unit/char; the existing `"café world"` test still asserts byte [6,11)).

Test: `"A😀B"` surrogate-pair case asserts the run lands at byte [5,6). Python exporter tests 15/15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)