### PR TITLE
ci(release): build release without examples so the design-tool Skia gate can't block sign-and-release

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -42,6 +42,18 @@ Slice 6 (#551).
 
 ## GitHub workflow gotchas
 
+- **Release builds must pass `-DPULP_BUILD_EXAMPLES=OFF`.** The
+  `pulp-design-tool` example hard-fails CMake configure when `PULP_HAS_SKIA`
+  is FALSE (belt-and-suspenders, code 78). `sign-and-release.yml` builds on a
+  GitHub-hosted macOS runner with no Skia, so configuring the full tree
+  (examples included) aborts the entire run → **no GitHub Release publishes**
+  even when `release-cli.yml` (the CLI build) is green. This silently broke
+  Release publication (the release watchdog flagged the missing Releases). The
+  release ships the CLI + plugins
+  (`build/VST3`,`/CLAP`,`/AU`), never the example apps, so the release legs
+  build with `-DPULP_BUILD_EXAMPLES=OFF` (matching `build.yml`). If you add a
+  new release/packaging workflow, configure with examples OFF (or a populated
+  `SKIA_DIR`), or the design-tool Skia gate will block it.
 - **Hooks inherit `GIT_DIR` — tests that shell out to git can corrupt the live
   worktree.** Git exports `GIT_DIR`/`GIT_WORK_TREE` into hook environments, and
   a set `GIT_DIR` *overrides* `git -C <dir>` discovery. So when the pre-push

--- a/.github/workflows/sign-and-release.yml
+++ b/.github/workflows/sign-and-release.yml
@@ -78,7 +78,13 @@ jobs:
             external/AudioUnitSDK
 
       - name: Configure
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
+        # -DPULP_BUILD_EXAMPLES=OFF: the release ships the CLI + plugins
+        # (build/VST3, build/CLAP, build/AU), never the example apps. The
+        # pulp-design-tool example hard-fails configure when PULP_HAS_SKIA is
+        # FALSE (this runner has no Skia), so building examples here aborts the
+        # whole sign-and-release run and no GitHub Release is published. Skip
+        # examples to match build.yml's release legs.
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DPULP_BUILD_EXAMPLES=OFF
 
       - name: Build
         run: cmake --build build --config ${{ env.BUILD_TYPE }} -j$(sysctl -n hw.ncpu)


### PR DESCRIPTION
**Root cause of the still-missing GitHub Releases (rest of #3312).** After #3319 made release-cli's Windows leg green, Releases *still* didn't publish — `sign-and-release.yml` (build+sign+publish) fails at Configure because it builds the full tree (examples) on a Skia-less GitHub runner and the `pulp-design-tool` example hard-fails configure (`PULP_HAS_SKIA=FALSE`). The release ships only CLI + plugins, never examples, so configure with `-DPULP_BUILD_EXAMPLES=OFF` (matching build.yml). `ci:` title (no version bump); ship-skill skip-trailered (gotcha lives in the ci skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)