### PR TITLE
fix(view): honor text-align in per-range styled labels + clear stale runs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.319.0
+    VERSION 0.320.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/widgets.hpp
+++ b/core/view/include/pulp/view/widgets.hpp
@@ -50,6 +50,11 @@ public:
     void set_text(std::string text) {
         if (text == text_) return;
         text_ = std::move(text);
+        // A plain set_text() supersedes any per-range styled runs from a
+        // prior set_attributed_string(): the old spans index into the OLD
+        // string and are stale. Drop them so paint() takes the single-style
+        // path for the new text. (Codex #3336.)
+        has_attributed_ = false;
         // WYSIWYG P5 FIX 4 — the Yoga measure callback (yoga_measure ->
         // Label::intrinsic_width / measured_height) re-runs TextShaper::prepare
         // keyed on the CURRENT text_, so a text change re-shapes correctly —
@@ -267,6 +272,7 @@ private:
     canvas::AttributedString attributed_runs_;  ///< per-range styled text (mixed)
     bool has_attributed_ = false;
     void paint_attributed_(canvas::Canvas& canvas);  ///< single-line span draw
+    LabelAlign resolve_effective_align_();            ///< text-align cascade (auto/match-parent resolved)
     bool has_own_font_size_ = false;
     bool has_own_font_weight_ = false;
     bool has_own_letter_spacing_ = false;

--- a/core/view/src/widgets/label.cpp
+++ b/core/view/src/widgets/label.cpp
@@ -541,6 +541,46 @@ Label::TextEditMetrics Label::text_edit_metrics(canvas::Canvas& canvas,
     return m;
 }
 
+LabelAlign Label::resolve_effective_align_() {
+    // issue-969: text-align cascade. Own value wins, otherwise inherited.
+    LabelAlign effective = text_align_;
+    if (!has_own_text_align_) {
+        if (auto inh = inheritable_text_align(); inh.has_value()) {
+            int v = inh.value();
+            if (v == 1) effective = LabelAlign::center;
+            else if (v == 2) effective = LabelAlign::right;
+            else if (v == 3) effective = LabelAlign::auto_;
+            else if (v == 4) effective = LabelAlign::justify;
+            else if (v == 5) effective = LabelAlign::match_parent;
+            else effective = LabelAlign::left;
+        }
+    }
+    // pulp #1434 — resolve `match-parent` at paint time: the computed value
+    // matches the parent's resolved text-align. Walk the ancestor chain
+    // manually (skipping intermediate match-parent ancestors); fall back to
+    // `left` (CSS default) if no ancestor sets a concrete value. See PR #1879.
+    if (effective == LabelAlign::match_parent) {
+        LabelAlign parent_resolved = LabelAlign::left;
+        for (auto* anc = parent(); anc != nullptr; anc = anc->parent()) {
+            auto inh = anc->inheritable_text_align();
+            if (!inh.has_value()) continue;
+            int v = inh.value();
+            if (v == 5) continue;  // intermediate match-parent — keep walking
+            if      (v == 1) parent_resolved = LabelAlign::center;
+            else if (v == 2) parent_resolved = LabelAlign::right;
+            else if (v == 3) parent_resolved = LabelAlign::auto_;
+            else if (v == 4) parent_resolved = LabelAlign::justify;
+            else             parent_resolved = LabelAlign::left;
+            break;
+        }
+        effective = parent_resolved;
+    }
+    // pulp #1434 — `auto` is writing-direction-relative; Pulp is LTR-only for
+    // now, so `auto` degrades to `left`.
+    if (effective == LabelAlign::auto_) effective = LabelAlign::left;
+    return effective;
+}
+
 void Label::paint_attributed_(canvas::Canvas& canvas) {
     const auto& spans = attributed_runs_.spans();
     if (spans.empty()) return;
@@ -550,8 +590,22 @@ void Label::paint_attributed_(canvas::Canvas& canvas) {
     // web-compat nested <span> path.
     const float fs = spans.front().font_size;
     const float baseline = bounds().height * 0.5f + fs * 0.32f;
+    // Each span is drawn left-anchored at an explicit x, so honor text-align
+    // by shifting the STARTING x rather than the canvas anchor (which only
+    // positions a single draw call). Measure the full run first. (Codex #3336.)
     canvas.set_text_align(canvas::TextAlign::left);
+    float total = 0.0f;
+    for (const auto& s : spans) {
+        const std::string fam = s.font_family.empty() ? std::string("Inter") : s.font_family;
+        canvas.set_font_full(fam, s.font_size, s.font_weight, s.italic ? 1 : 0, s.letter_spacing);
+        total += canvas.measure_text(s.text);
+    }
     float x = 0.0f;
+    switch (resolve_effective_align_()) {
+        case LabelAlign::center: x = (bounds().width - total) * 0.5f; break;
+        case LabelAlign::right:  x = bounds().width - total; break;
+        default: break;  // left / justify → leading edge at 0
+    }
     for (const auto& s : spans) {
         const std::string fam = s.font_family.empty() ? std::string("Inter") : s.font_family;
         canvas.set_font_full(fam, s.font_size, s.font_weight, s.italic ? 1 : 0, s.letter_spacing);
@@ -734,85 +788,10 @@ void Label::paint(canvas::Canvas& canvas) {
             break;
     }
 
-    // issue-969: text-align cascade. Own value wins, otherwise inherited.
-    LabelAlign effective_text_align = text_align_;
-    if (!has_own_text_align_) {
-        if (auto inh = inheritable_text_align(); inh.has_value()) {
-            int v = inh.value();
-            if (v == 1) effective_text_align = LabelAlign::center;
-            else if (v == 2) effective_text_align = LabelAlign::right;
-            else if (v == 3) effective_text_align = LabelAlign::auto_;
-            else if (v == 4) effective_text_align = LabelAlign::justify;
-            else if (v == 5) effective_text_align = LabelAlign::match_parent;
-            else effective_text_align = LabelAlign::left;
-        }
-    }
-
-    // pulp #1434 — resolve `match-parent` at paint time. CSS spec: the
-    // computed value matches the parent's resolved `text-align`. We walk
-    // the View parent chain via `inheritable_text_align()` starting from
-    // `parent_` (NOT the Label itself — the Label's own value IS
-    // match-parent, which would loop). If no ancestor set a value, fall
-    // back to `left` (the CSS spec default for `text-align`).
-    //
-    // If the parent's resolved value is itself `start`/`end` (encoded as
-    // `left`/`right` here since pulp aliases them at the setter), the
-    // existing LTR-only writing-direction policy applies — same as `auto`.
-    if (effective_text_align == LabelAlign::match_parent) {
-        // Walk ancestor chain manually, skipping any intermediate
-        // View whose own inh_text_align_ is also 5 (match-parent).
-        // `View::inheritable_text_align()` is unsuitable here because
-        // it returns the first SET value, not the first NON-match-parent
-        // value — if the immediate parent is also match-parent, the
-        // walk has to continue. Codex P1 on PR #1879 (2026-05-12).
-        //
-        // Example chain we now resolve correctly:
-        //   grandparent  text-align: center        (slot = 1)
-        //   parent       text-align: match-parent  (slot = 5)
-        //   child Label  text-align: match-parent  → renders center
-        //
-        // Previous code stopped at parent.inheritable_text_align()
-        // returning 5 and degraded to `left`.
-        LabelAlign parent_resolved = LabelAlign::left;
-        for (auto* anc = parent(); anc != nullptr; anc = anc->parent()) {
-            auto inh = anc->inheritable_text_align();
-            if (!inh.has_value()) continue;
-            int v = inh.value();
-            if (v == 5) {
-                // Intermediate match-parent ancestor — keep walking.
-                // Note: `inheritable_text_align()` already walks up
-                // until it finds a SET value. We need the loop here
-                // because the SET value might itself be 5; we want
-                // the first non-5 SET value in the chain.
-                //
-                // To skip past this anc's own slot in the next
-                // iteration, we must continue from its parent and
-                // re-enter inheritable_text_align() — but since
-                // inheritable walks again from there, we need to
-                // explicitly bypass anc's slot. Easiest: peek at
-                // anc->parent() directly and re-loop.
-                continue;
-            }
-            if      (v == 1) parent_resolved = LabelAlign::center;
-            else if (v == 2) parent_resolved = LabelAlign::right;
-            else if (v == 3) parent_resolved = LabelAlign::auto_;
-            else if (v == 4) parent_resolved = LabelAlign::justify;
-            else             parent_resolved = LabelAlign::left;
-            break;
-        }
-        // If every ancestor stored 5 (or no ancestor set anything),
-        // CSS spec says fall back to `start` ≡ `left` under LTR.
-        effective_text_align = parent_resolved;
-    }
-
-    // pulp #1434 — resolve `auto` at paint time. `auto` is CSS
-    // writing-direction-relative: LTR → left, RTL → right. Pulp doesn't
-    // model RTL yet (yoga/direction is still NOT-IMPL), so `auto`
-    // currently degrades to `left`. When RTL lands, this becomes a
-    // lookup against the writing-direction context.
-    if (effective_text_align == LabelAlign::auto_) {
-        effective_text_align = LabelAlign::left;
-    }
+    // issue-969 / pulp #1434 — text-align cascade with `auto` + `match-parent`
+    // fully resolved. Shared with paint_attributed_() so per-range styled text
+    // honors the same alignment. (Codex #3336.)
+    const LabelAlign effective_text_align = resolve_effective_align_();
 
     float x = 0;
     switch (effective_text_align) {

--- a/test/test_widget_bridge_wave2_cheap.cpp
+++ b/test/test_widget_bridge_wave2_cheap.cpp
@@ -837,3 +837,75 @@ TEST_CASE("setTextRuns builds a styled AttributedString on the Label",
     CHECK(lbl->has_attributed_string());
     CHECK(lbl->attributed_span_count() == 2);  // "Hello" styled run + " world" gap
 }
+
+// Codex #3336: a plain set_text() must supersede prior per-range runs. The old
+// spans index into the OLD string, so leaving has_attributed_ set would paint
+// stale, mis-indexed runs over the new text.
+TEST_CASE("set_text clears stale attributed runs (Codex #3336)",
+          "[view][widget][text][issue-3336]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 200, 40});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+    bridge.load_script(
+        "createLabel('t', 'Hello world', '');\n"
+        "setTextRuns('t', [{ start: 0, end: 5, fontWeight: 700 }]);");
+    auto* lbl = dynamic_cast<Label*>(bridge.widget("t"));
+    REQUIRE(lbl != nullptr);
+    REQUIRE(lbl->has_attributed_string());
+    lbl->set_text("Different text");
+    CHECK_FALSE(lbl->has_attributed_string());  // runs dropped → single-style path
+}
+
+// Codex #3336: paint_attributed_ must honor the text-align cascade instead of
+// hard-coding a left/x=0 anchor. RecordingCanvas measures 7px/char, so the two
+// spans ("Hello"+" world" = 11 chars) span 77px inside a 200px-wide label.
+TEST_CASE("paint_attributed_ honors text-align (Codex #3336)",
+          "[view][widget][text][issue-3336]") {
+    using pulp::canvas::DrawCommand;
+    using pulp::canvas::RecordingCanvas;
+    auto first_fill_x = [](RecordingCanvas& rc) -> float {
+        for (const auto& c : rc.commands())
+            if (c.type == DrawCommand::Type::fill_text) return c.f[0];
+        return -999.0f;
+    };
+
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 200, 40});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+    bridge.load_script(
+        "createLabel('t', 'Hello world', '');\n"
+        "setFontSize('t', 16);\n"
+        "setTextRuns('t', [{ start: 0, end: 5, fontWeight: 700, color: '#ff0000' }]);");
+    auto* lbl = dynamic_cast<Label*>(bridge.widget("t"));
+    REQUIRE(lbl != nullptr);
+    REQUIRE(lbl->has_attributed_string());
+    lbl->set_bounds({0, 0, 200, 40});
+
+    constexpr float kTotal = 11 * 7.0f;  // RecordingCanvas measure model
+
+    lbl->set_text_align(LabelAlign::left);
+    RecordingCanvas left;
+    lbl->paint(left);
+    const float xl = first_fill_x(left);
+    REQUIRE_THAT(xl, WithinAbs(0.0f, 1e-4f));
+
+    lbl->set_text_align(LabelAlign::center);
+    RecordingCanvas center;
+    lbl->paint(center);
+    const float xc = first_fill_x(center);
+    REQUIRE_THAT(xc, WithinAbs((200.0f - kTotal) * 0.5f, 1e-4f));
+    CHECK(xc > xl);
+
+    lbl->set_text_align(LabelAlign::right);
+    RecordingCanvas right;
+    lbl->paint(right);
+    const float xr = first_fill_x(right);
+    REQUIRE_THAT(xr, WithinAbs(200.0f - kTotal, 1e-4f));
+    CHECK(xr > xc);
+}


### PR DESCRIPTION
Addresses two Codex review findings from PR #3336 (native per-range text) that the post-merge PR sweep surfaced as unaddressed.

## Findings fixed

1. **`Label::paint_attributed_` ignored text-align.** It hard-coded a `left` / `x = 0` anchor, so per-range styled single-line text always rendered left-aligned regardless of the label's `text-align`. It now resolves the same effective alignment as the single-style path (with `auto` and `match-parent` fully resolved) and offsets the starting `x` by the measured run width for `center` / `right`. The cascade resolution is extracted into a shared `resolve_effective_align_()` helper so both paint paths stay in lock-step.

2. **`Label::set_text()` left stale attributed runs.** After a `set_attributed_string()`, a later plain `set_text()` did not drop the prior spans — which index into the *old* string — so paint would render stale, mis-indexed runs over the new text. `set_text()` now clears `has_attributed_`.

## Tests (`pulp-test-widget-bridge-wave2-cheap`)

- `set_text clears stale attributed runs` — set runs, then `set_text(...)`, assert `has_attributed_string() == false`.
- `paint_attributed_ honors text-align` — left anchors at `x = 0`; center/right offset by the measured 77px run width inside a 200px-wide label, asserted via `RecordingCanvas` fill_text positions.

Existing `pulp-test-widgets-label` (80 assertions) and `pulp-test-typography-inheritance` (57 assertions) stay green, confirming the `paint()` refactor is behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)