### PR TITLE
chore: gitignore fetched Skia build artifacts + clarify diff-cover bypass knobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,10 @@ android/app/.cxx/
 android/app/build/
 external/skia-src/
 external/skia-build/android-gpu/
+# Fetched/generated Skia artifacts (platform libs, headers, icudtl.dat ~10MB).
+# Populated at setup; nothing under build/ is tracked. Ignoring it keeps a
+# stray `git add -A` from sweeping hundreds of binaries into a commit.
+external/skia-build/build/
 
 # External SDKs cloned by setup.sh / FetchContent — never committed.
 external/AudioUnitSDK

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -768,6 +768,14 @@ sync. The pre-push hook runs this check enforcing-by-default
 (pulp #1144); `PULP_DISABLE_PREPUSH_DIFF_COVER=1` demotes it to
 advisory if you genuinely need to push a known coverage gap.
 
+**Two different knobs — pick the right one.** `PULP_DISABLE_PREPUSH_DIFF_COVER=1`
+still runs the full configure + build, then only *demotes the failure* to
+advisory — so it does NOT make the push faster (a push that looks "hung" right
+after this is the diff-cover build compiling, not the network). To skip the
+build entirely, use `PULP_SKIP_DIFF_COVER=1`, which exits before any
+configure/build while skill-sync / version-bump / compat gates still run. Reach
+for `PULP_SKIP_PREPUSH=1` only when those other gates must be skipped too.
+
 The Claude Code slash command `/coverage-diff` invokes the same
 script with the same args, so all four invocation surfaces share
 one implementation.
@@ -796,7 +804,8 @@ maps to the one gate you genuinely need to skip, not the nuclear
 
 | When you need to                          | Use (surgical)                                  | Avoid (nuclear)                  |
 |-------------------------------------------|-------------------------------------------------|----------------------------------|
-| Skip only diff-coverage (slow, flaky)     | `PULP_DISABLE_PREPUSH_DIFF_COVER=1 git push`    | `PULP_SKIP_PREPUSH=1 git push`   |
+| Skip the diff-cover BUILD (push fast)     | `PULP_SKIP_DIFF_COVER=1 git push`               | `PULP_SKIP_PREPUSH=1 git push`   |
+| Run diff-cover but ignore its result      | `PULP_DISABLE_PREPUSH_DIFF_COVER=1 git push` (still builds) | `PULP_SKIP_PREPUSH=1 git push`   |
 | Demote all gates to advisory              | `PULP_DISABLE_PREPUSH_GATES=1 git push`         | `PULP_SKIP_PREPUSH=1 git push`   |
 | Skip skill-sync for a single commit       | `Skill-Update: skip skill=<name> reason="…"` trailer | `PULP_SKIP_PREPUSH=1 git push`   |
 | Skip version-bump for a single commit     | `Version-Bump: skip reason="…"` trailer         | `PULP_SKIP_PREPUSH=1 git push`   |


### PR DESCRIPTION
Codifies two traps (previously only in agent memory) that cost ~40 min on the #3346 push, so they're durable and reviewed.

## 1. `.gitignore` — ignore `external/skia-build/build/`
Those platform libs, headers, and the ~10 MB `icudtl.dat` are fetched at setup; nothing under `build/` is tracked in any checkout. But the directory wasn't ignored, so a stray `git add -A` swept hundreds of binaries into a commit and bloated the push. Ignoring it prevents the mistake mechanically (verified: `git status` shows 0 artifacts after the rule).

## 2. `CLAUDE.md` — distinguish the two diff-cover bypass knobs
The prior text conflated them. Verified against `.githooks/pre-push:288` and `tools/scripts/local_diff_cover.sh:66`:

| Knob | Effect |
|------|--------|
| `PULP_SKIP_DIFF_COVER=1` | exits **before** any configure/build; skill-sync / version-bump / compat gates still run — the knob to push fast |
| `PULP_DISABLE_PREPUSH_DIFF_COVER=1` | **still runs the full build**, only demotes the *failure* to advisory (a push that looks "hung" right after is the build compiling, not the network) |
| `PULP_SKIP_PREPUSH=1` | nuclear — skips everything |

Updates the bypass-priority table row that mislabeled `DISABLE` as a "skip".

Docs/chore only — no source, no version bump. Pushed with `PULP_SKIP_DIFF_COVER=1` (dogfooding the documented knob).

🤖 Generated with [Claude Code](https://claude.com/claude-code)