### PR TITLE
feat(figma-plugin): capture all variable modes (light/dark) as tokens

### DIFF
--- a/tools/figma-plugin/package.json
+++ b/tools/figma-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulp/figma-plugin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Design for Pulp — Figma plugin that exports designs to the Pulp audio plugin framework",
   "license": "MIT",

--- a/tools/figma-plugin/src/tokens.ts
+++ b/tools/figma-plugin/src/tokens.ts
@@ -7,9 +7,11 @@
 //   tokens.strings[name]    → string
 //
 // Variable modes: a variable can have different values per mode (light/dark,
-// breakpoints). For v1 we capture the DEFAULT mode only and log a
-// `capture_partial` diagnostic when other modes exist. Multi-mode support is a
-// follow-up slice.
+// breakpoints). We capture EVERY mode — the default mode keeps the bare token
+// name and each other mode is emitted under a "<name>.<mode>" suffix (e.g.
+// "color.bg" + "color.bg.dark") so themed values survive import into Pulp's
+// flat theme maps. Aliases are resolved per mode, so a semantic color that
+// points at a different base-palette entry per mode yields the right value.
 
 import type { ExtractedDiagnostic } from "./extract-model";
 
@@ -56,11 +58,12 @@ async function ingestCollection(
 ): Promise<void> {
   const defaultModeId = coll.defaultModeId;
   if (coll.modes.length > 1) {
+    const defaultName = coll.modes.find((m) => m.modeId === defaultModeId)?.name ?? "?";
     diagnostics.push({
       severity: "info",
       code: "variable-multi-mode",
       kind: "capture_partial",
-      message: `Variable collection "${coll.name}" has ${coll.modes.length} modes; only the default mode "${coll.modes.find((m) => m.modeId === defaultModeId)?.name ?? "?"}" was captured.`,
+      message: `Variable collection "${coll.name}" has ${coll.modes.length} modes; all are captured — the default mode "${defaultName}" uses the bare token name and each other mode is suffixed (e.g. "token.dark"). Cross-collection alias values resolve against the referent's default mode.`,
       path: `/tokens/collection/${coll.name}`,
     });
   }
@@ -73,26 +76,20 @@ async function ingestCollection(
       continue;
     }
     if (!v) continue;
-    const name = canonicalName(coll.name, v.name);
-    out.variableIdToName[v.id] = name;
-    const raw = v.valuesByMode[defaultModeId];
-    if (raw === undefined) continue;
-    switch (v.resolvedType) {
-      case "COLOR":
-        out.colors[name] = renderColorValue(raw, defaultModeId);
-        break;
-      case "FLOAT":
-        if (typeof raw === "number") out.dimensions[name] = raw;
-        else out.dimensions[name] = await resolveNumberAlias(raw, defaultModeId);
-        break;
-      case "STRING":
-        if (typeof raw === "string") out.strings[name] = raw;
-        else out.strings[name] = String(await resolveAlias(raw, defaultModeId));
-        break;
-      case "BOOLEAN":
-        // Booleans don't fit IRTokens cleanly; encode as "true" / "false" strings.
-        if (typeof raw === "boolean") out.strings[name] = raw ? "true" : "false";
-        break;
+    const baseName = canonicalName(coll.name, v.name);
+    // Style references bind to the default-mode (bare) token name.
+    out.variableIdToName[v.id] = baseName;
+    for (const mode of coll.modes) {
+      const raw = v.valuesByMode[mode.modeId];
+      if (raw === undefined) continue;
+      // Default mode keeps the bare name (back-compat + the name style refs
+      // resolve to); every other mode is captured under "<name>.<mode>" so
+      // light/dark (and any multi-mode) values survive import.
+      const slug = modeSlug(mode.name);
+      const name = mode.modeId === defaultModeId || slug.length === 0
+        ? baseName
+        : `${baseName}.${slug}`;
+      await assignToken(out, name, raw, v.resolvedType, mode.modeId);
     }
   }
 }
@@ -107,7 +104,7 @@ function canonicalName(collectionName: string, varName: string): string {
     .replace(/[^a-z0-9._-]/g, "");
 }
 
-function renderColorValue(raw: VariableValue, modeId: string): string {
+function renderColorValue(raw: VariableValue): string {
   if (typeof raw === "object" && raw && "r" in raw && "g" in raw && "b" in raw) {
     const { r, g, b, a } = raw as RGBA;
     const rh = Math.round(r * 255).toString(16).padStart(2, "0");
@@ -119,19 +116,57 @@ function renderColorValue(raw: VariableValue, modeId: string): string {
   return "#000000";
 }
 
-async function resolveAlias(raw: VariableValue, modeId: string): Promise<unknown> {
+/** Sanitize a Figma mode name into a token-name-safe slug (same rules as canonicalName). */
+function modeSlug(modeName: string): string {
+  return modeName.toLowerCase().replace(/\s+/g, "").replace(/[^a-z0-9._-]/g, "");
+}
+
+/**
+ * Follow VARIABLE_ALIAS references for a given mode until a concrete value is
+ * reached (bounded to avoid cycles). Resolving per-mode is what makes
+ * multi-mode capture meaningful: a semantic variable usually aliases a
+ * different base-palette entry in each mode (light vs dark). A referenced
+ * variable in another collection won't share this collection's modeId, so we
+ * fall back to the referent's own first/default mode value.
+ */
+async function resolveValue(
+  raw: VariableValue,
+  modeId: string,
+  depth = 0,
+): Promise<VariableValue> {
+  if (depth >= 10) return raw;
   if (typeof raw === "object" && raw && "type" in raw && (raw as VariableAlias).type === "VARIABLE_ALIAS") {
     const referent = await figma.variables.getVariableByIdAsync((raw as VariableAlias).id);
-    if (referent) {
-      const next = referent.valuesByMode[modeId];
-      if (next !== undefined) return next;
-    }
+    if (!referent) return raw;
+    const next = referent.valuesByMode[modeId] ?? Object.values(referent.valuesByMode)[0];
+    if (next === undefined) return raw;
+    return resolveValue(next, modeId, depth + 1);
   }
   return raw;
 }
 
-async function resolveNumberAlias(raw: VariableValue, modeId: string): Promise<number> {
-  const resolved = await resolveAlias(raw, modeId);
-  if (typeof resolved === "number") return resolved;
-  return 0;
+/** Resolve + assign one variable's value for a given mode into the token maps. */
+async function assignToken(
+  out: ExtractedTokens,
+  name: string,
+  raw: VariableValue,
+  resolvedType: Variable["resolvedType"],
+  modeId: string,
+): Promise<void> {
+  const value = await resolveValue(raw, modeId);
+  switch (resolvedType) {
+    case "COLOR":
+      if (typeof value === "object" && value && "r" in value) out.colors[name] = renderColorValue(value);
+      break;
+    case "FLOAT":
+      if (typeof value === "number") out.dimensions[name] = value;
+      break;
+    case "STRING":
+      if (typeof value === "string") out.strings[name] = value;
+      break;
+    case "BOOLEAN":
+      // Booleans don't fit IRTokens cleanly; encode as "true" / "false" strings.
+      if (typeof value === "boolean") out.strings[name] = value ? "true" : "false";
+      break;
+  }
 }

--- a/tools/figma-plugin/test/tokens.test.ts
+++ b/tools/figma-plugin/test/tokens.test.ts
@@ -1,0 +1,91 @@
+// Exercises the REAL token extractor (src/tokens.ts::extractTokens) against a
+// minimal Figma Variables API mock. Focus: multi-mode capture — every variable
+// mode is emitted (default mode under the bare token name, other modes under a
+// "<name>.<mode>" suffix) and aliases resolve per mode so a semantic color that
+// points at a different base-palette entry per mode yields the right value.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { extractTokens } from "../src/tokens";
+
+type Mode = { modeId: string; name: string };
+type Coll = { name: string; defaultModeId: string; modes: Mode[]; variableIds: string[] };
+type Var = { id: string; name: string; resolvedType: string; valuesByMode: Record<string, unknown> };
+
+const white = { r: 1, g: 1, b: 1, a: 1 };
+const black = { r: 0, g: 0, b: 0, a: 1 };
+const alias = (id: string) => ({ type: "VARIABLE_ALIAS", id });
+
+function installFigma(collections: Coll[], variables: Record<string, Var>): void {
+  (globalThis as unknown as { figma: unknown }).figma = {
+    variables: {
+      getLocalVariableCollectionsAsync: async () => collections,
+      getVariableByIdAsync: async (id: string) => variables[id] ?? null,
+    },
+  };
+}
+
+test("multi-mode variables: default bare + suffixed non-default modes, per-mode alias resolution", async () => {
+  const variables: Record<string, Var> = {
+    v_bg: { id: "v_bg", name: "bg", resolvedType: "COLOR", valuesByMode: { m_light: white, m_dark: black } },
+    v_radius: { id: "v_radius", name: "radius", resolvedType: "FLOAT", valuesByMode: { m_light: 8, m_dark: 8 } },
+    // Semantic color aliases a different base-palette entry per mode.
+    v_semantic: {
+      id: "v_semantic", name: "semantic", resolvedType: "COLOR",
+      valuesByMode: { m_light: alias("v_base_white"), m_dark: alias("v_base_black") },
+    },
+    // Base palette lives in its own single-mode collection (modeId differs), so
+    // resolveValue must fall back to the referent's first/default mode value.
+    v_base_white: { id: "v_base_white", name: "base/white", resolvedType: "COLOR", valuesByMode: { m_base: white } },
+    v_base_black: { id: "v_base_black", name: "base/black", resolvedType: "COLOR", valuesByMode: { m_base: black } },
+  };
+  const theme: Coll = {
+    name: "Theme",
+    defaultModeId: "m_light",
+    modes: [{ modeId: "m_light", name: "Light" }, { modeId: "m_dark", name: "Dark" }],
+    variableIds: ["v_bg", "v_radius", "v_semantic"],
+  };
+  installFigma([theme], variables);
+
+  const diagnostics: Array<{ code: string }> = [];
+  const tokens = await extractTokens(diagnostics as never);
+
+  // Default (Light) → bare name; Dark → ".dark" suffix.
+  assert.equal(tokens.colors["theme.bg"], "#ffffff");
+  assert.equal(tokens.colors["theme.bg.dark"], "#000000");
+
+  // FLOAT captured per mode.
+  assert.equal(tokens.dimensions["theme.radius"], 8);
+  assert.equal(tokens.dimensions["theme.radius.dark"], 8);
+
+  // Per-mode alias resolution: white in light, black in dark.
+  assert.equal(tokens.colors["theme.semantic"], "#ffffff");
+  assert.equal(tokens.colors["theme.semantic.dark"], "#000000");
+
+  // Style refs bind to the bare (default-mode) token name.
+  assert.equal(tokens.variableIdToName["v_bg"], "theme.bg");
+
+  // Multi-mode collections emit the informational expansion diagnostic.
+  assert.ok(diagnostics.some((d) => d.code === "variable-multi-mode"));
+});
+
+test("single-mode collection: bare names only, no suffix, no multi-mode diagnostic", async () => {
+  const variables: Record<string, Var> = {
+    v_gap: { id: "v_gap", name: "gap", resolvedType: "FLOAT", valuesByMode: { m_only: 16 } },
+  };
+  const spacing: Coll = {
+    name: "Spacing",
+    defaultModeId: "m_only",
+    modes: [{ modeId: "m_only", name: "Mode 1" }],
+    variableIds: ["v_gap"],
+  };
+  installFigma([spacing], variables);
+
+  const diagnostics: Array<{ code: string }> = [];
+  const tokens = await extractTokens(diagnostics as never);
+
+  assert.equal(tokens.dimensions["spacing.gap"], 16);
+  assert.ok(!("spacing.gap.mode1" in tokens.dimensions));
+  assert.ok(!diagnostics.some((d) => d.code === "variable-multi-mode"));
+});


### PR DESCRIPTION
## Why

Pulp's Figma plugin already reads the **Variables API** (collections, modes, aliases) — but `tokens.ts` emitted only the **default mode** per collection and logged a `capture_partial` diagnostic, so **light/dark (and any multi-mode) theming was silently dropped at import.** This was a known follow-up (the old code comment: *"For v1 we capture the DEFAULT mode only … Multi-mode support is a follow-up slice."*).

Surfaced while studying an external Figma→DTCG exporter, whose key idea is treating Figma Variables modes as first-class. Implemented clean-room against the documented Figma API (no third-party code copied).

## What

`extractTokens` now iterates **every** mode in a collection:
- the **default mode keeps the bare token name** (back-compat; style references bind to it),
- every **other mode is emitted under a `<name>.<mode>` suffix** — e.g. `color.bg` + `color.bg.dark`.

This needs **no schema or C++ change**: the extra mode-suffixed entries are just more keys in the existing flat `colors`/`dimensions`/`strings` maps, which already flow `serialize.ts` → `parse_ir_tokens` → `tokens.json` / theme. Pulp's theme model is flat, so suffixed names map onto it directly.

Aliases are now resolved **per mode** (bounded multi-hop): a semantic color that aliases a different base-palette entry per mode yields the right value, instead of the previous single-hop path that rendered aliased colors as `#000000` (which would have made multi-mode colors useless).

## Tests

`tools/figma-plugin/test/tokens.test.ts` (new, runs under `npm test` — 23/23 pass, typecheck clean):
- **multi-mode**: default→bare name, dark→`.dark` suffix, FLOAT captured per mode, and per-mode alias resolution (semantic = white in Light, black in Dark)
- **single-mode**: bare names only, no suffix, no multi-mode diagnostic

Bumps `@pulp/figma-plugin` 0.1.0 → 0.2.0. No SDK/CLI or Claude-plugin surface touched (`Version-Bump: skip` trailer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)