### PR TITLE
ci(macos): re-enable 2 audio tests via PROCESSORS reservation (RT-thread teardown fix)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -566,6 +566,20 @@ with a macOS-only `ctest --exclude-regex` in `build.yml`, keep Linux/Windows
 coverage intact, and open/follow a targeted fix. Do not hide failures that
 reproduce cross-platform or that are caused by the branch being shipped.
 
+**Real-time-thread teardown hangs need a `PROCESSORS` reservation, not an
+exclude.** A test that opens the real CoreAudio device (anything constructing a
+`StandaloneApp` or calling `AudioSystem::create_device()` + `start()`) tears it
+down via `AudioOutputUnitStop` / `AudioUnitUninitialize`, which **block until
+the real-time I/O thread observes the request**. Under `ctest -j8` full-suite
+load that RT thread is CPU-starved, so teardown hangs to the 120s timeout — a
+flake that reproduces **only** in the full run on a saturated runner, never in
+isolation or any concurrent subset (so don't waste time bisecting subsets). Fix
+it at the scheduler: `pulp_add_test_suite(... PROPERTIES PROCESSORS 8)` (== the
+CI `-j`) makes ctest run the suite alone so the RT thread gets the machine.
+Prefer this over an exclude — it keeps the test enabled everywhere. (Adding a
+shared `RESOURCE_LOCK` does NOT fix it: serializing the audio tests among
+themselves still leaves the other ~8 `-j8` tests starving the RT thread.)
+
 The required `macos` alias should not `need` the whole cross-platform build
 matrix. It should depend only on cheap setup/classification jobs and poll the
 macOS matrix leg by name, then exit as soon as that leg reports. Otherwise

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -808,14 +808,12 @@ jobs:
             exclude="${exclude}|mac harness scroll event carries non-zero deltas through PulpView"
             exclude="${exclude}|mac harness right-click reaches PulpView::rightMouseDown"
             exclude="${exclude}|pulp-mcp-launcher"
-            # 2026-06-04: these two open the real CoreAudio default-output device
-            # and hang (120s timeout) only in the full -j8 suite on the local
-            # runner image — they pass on main, in isolation, and in every
-            # concurrent subset reproduced locally. They block unrelated PRs
-            # behind the serialized macOS queue. Keep them on Linux/Windows;
-            # dedicated audio-device-isolation fix to follow.
-            exclude="${exclude}|CoreAudio render sine wave"
-            exclude="${exclude}|StandaloneApp::apply_config preserves the processor instance"
+            # NOTE: "CoreAudio render sine wave" + "StandaloneApp::apply_config"
+            # were temporarily excluded here on 2026-06-04 (full-suite-only 120s
+            # hang on the local runner). Root cause: CoreAudio teardown blocks on
+            # the RT I/O thread, which was CPU-starved under -j8. Fixed properly
+            # via a PROCESSORS reservation on the device-opening suites in
+            # test/CMakeLists.txt, so they are re-enabled here.
           fi
           ctest --test-dir "$PULP_BUILD_DIR" --output-on-failure -C Release -LE "$label_exclude" -j8 --timeout 120 --exclude-regex "$exclude"
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1784,12 +1784,19 @@ pulp_add_test_suite(pulp-test-convolver-non-uniform LIBRARIES pulp::signal)
 pulp_add_test_suite(pulp-test-test-signal LIBRARIES pulp::standalone)
 
 # Standalone editor chrome helpers
-pulp_add_test_suite(pulp-test-standalone-editor-chrome LIBRARIES pulp::standalone)
-pulp_add_test_suite(pulp-test-standalone-apply-config LIBRARIES pulp::standalone)
-pulp_add_test_suite(pulp-test-standalone-transport-midi LIBRARIES pulp::standalone)
+# These construct a StandaloneApp, which opens the real audio device on init
+# (standalone.cpp create_device/open/start) — same RT-thread-starved teardown
+# hazard as pulp-test-audio above, so they get the same PROCESSORS reservation.
+pulp_add_test_suite(pulp-test-standalone-editor-chrome LIBRARIES pulp::standalone
+    PROPERTIES PROCESSORS 8)
+pulp_add_test_suite(pulp-test-standalone-apply-config LIBRARIES pulp::standalone
+    PROPERTIES PROCESSORS 8)
+pulp_add_test_suite(pulp-test-standalone-transport-midi LIBRARIES pulp::standalone
+    PROPERTIES PROCESSORS 8)
 
 # Headless screenshot capture state machine (pulp #468)
-pulp_add_test_suite(pulp-test-screenshot-capture LIBRARIES pulp::standalone)
+pulp_add_test_suite(pulp-test-screenshot-capture LIBRARIES pulp::standalone
+    PROPERTIES PROCESSORS 8)
 
 # STFT and audio visualization signal tests
 pulp_add_test_suite(pulp-test-stft LIBRARIES pulp::signal)
@@ -1875,7 +1882,16 @@ pulp_add_test_suite(pulp-test-offline-processor-edges LIBRARIES pulp::audio)
 pulp_add_test_suite(pulp-test-ogg-reader LIBRARIES pulp::audio)
 
 # Audio tests
-pulp_add_test_suite(pulp-test-audio LIBRARIES pulp::audio)
+# PROCESSORS reservation for suites that open the REAL CoreAudio output device.
+# CoreAudioDevice::stop()/close() call AudioOutputUnitStop / AudioUnitUninitialize
+# (coreaudio_device.mm), which block until the real-time I/O thread observes the
+# request. Under `ctest -j8` heavy load that RT thread is CPU-starved and never
+# observes it, so teardown hangs to the 120s timeout — the full-suite-only flake
+# that wedged the macOS self-hosted runner. Reserving PROCESSORS == the CI -j
+# makes ctest schedule these alone, so the RT thread gets the machine and
+# teardown returns promptly. (Root-cause fix replacing the build.yml exclude.)
+pulp_add_test_suite(pulp-test-audio LIBRARIES pulp::audio
+    PROPERTIES PROCESSORS 8)
 
 pulp_add_test_suite(pulp-test-system-volume LIBRARIES pulp::audio)
 


### PR DESCRIPTION
Root-cause fix for the 2 audio tests excluded on macOS in #3436.

**Cause:** `CoreAudioDevice::stop()/close()` call `AudioOutputUnitStop` / `AudioUnitUninitialize`, which block until the real-time CoreAudio I/O thread observes the request. Under `ctest -j8` full-suite load that RT thread is CPU-starved → teardown hangs to the 120s timeout. Reproducible only in the full run on the saturated self-hosted runner — never in isolation, pairwise, 5-concurrent, or with the GPU harness.

**Fix:** reserve `PROCESSORS 8` (== CI `-j`) on every suite that opens the real audio device (`pulp-test-audio` + the `StandaloneApp` suites) so ctest runs them alone and the RT thread gets the machine. Re-enables both tests on all platforms (removes the build.yml exclude); no coverage loss. ci skill updated with the pattern.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enables two macOS CoreAudio tests by fixing a teardown hang caused by RT I/O thread starvation under `ctest -j8`. We reserve `PROCESSORS 8` for suites that open the real device so `ctest` schedules them alone and teardown completes reliably.

- **Bug Fixes**
  - Reserve `PROCESSORS 8` for suites that open the real audio device: `pulp-test-audio`, `pulp-test-standalone-editor-chrome`, `pulp-test-standalone-apply-config`, `pulp-test-standalone-transport-midi`, `pulp-test-screenshot-capture`.
  - Remove the macOS excludes in `build.yml` and restore the tests: "CoreAudio render sine wave" and "StandaloneApp::apply_config preserves the processor instance".
  - Add CI guidance to `.agents/skills/ci/SKILL.md`, explaining the RT-thread teardown issue and why `RESOURCE_LOCK` alone doesn’t fix it.

<sup>Written for commit ff447e584f2f51e2dc98739e8e5be18ead941998. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Re-enables two macOS audio tests ("CoreAudio render sine wave" and "StandaloneApp::apply_config") that were temporarily excluded in #3436 by addressing the root cause: `CoreAudioDevice::stop()/close()` blocks on the real-time I/O thread, which was CPU-starved under `ctest -j8` full-suite load. The fix adds `PROPERTIES PROCESSORS 8` to every test suite that opens the real CoreAudio device, so ctest schedules them in isolation and the RT thread gets the machine.

- `test/CMakeLists.txt` adds `PROCESSORS 8` to `pulp-test-audio` and three `pulp-test-standalone-*` suites (plus `pulp-test-screenshot-capture`, which may not need it — see comment).
- `.github/workflows/build.yml` removes the two `--exclude-regex` lines and replaces them with a comment explaining the now-resolved root cause.
- `SKILL.md` captures the pattern for future CI agents: use `PROCESSORS == -j` instead of an exclude when the failure is RT-thread starvation during teardown.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the `PROCESSORS 8` reservation correctly fixes the RT-thread starvation for the two re-enabled audio tests, but `pulp-test-screenshot-capture` appears to receive the reservation without actually opening the CoreAudio device, and the hardcoded `8` couples CMakeLists to the `-j8` flag in build.yml.

The core fix — reserving processor slots so the CoreAudio RT thread gets the machine during teardown — is well-reasoned and supported by the existing `pulp_add_test_suite` helper. Two quality concerns exist: the screenshot-capture suite is headless by design (its own source file says 'only the capture helper in isolation') yet receives a full 8-processor reservation with no explanation, and the magic number `8` duplicated across CMakeLists and build.yml means a future `-j` change would silently break or under-protect the audio suites without any compiler/CI warning.

test/CMakeLists.txt — verify whether `pulp-test-screenshot-capture` actually opens the real CoreAudio device, and consider extracting the processor count into a named variable shared with build.yml.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| test/CMakeLists.txt | Adds `PROCESSORS 8` to `pulp-test-audio` and four `pulp::standalone` suites to serialize them under ctest; `pulp-test-screenshot-capture` appears to receive the reservation unnecessarily (the test exercises only the capture helper in isolation with no real audio device), and the hardcoded `8` is tightly coupled to the CI `-j8` flag. |
| .github/workflows/build.yml | Removes the temporary `--exclude-regex` entries for "CoreAudio render sine wave" and "StandaloneApp::apply_config preserves the processor instance"; replaces with a comment explaining the root cause and the CMakeLists fix. Change is correct and well-documented. |
| .agents/skills/ci/SKILL.md | Adds documentation for the RT-thread teardown pattern and the `PROCESSORS` reservation fix; correctly captures the constraint (serializes among themselves via RESOURCE_LOCK is insufficient) and the preferred approach. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant ctest as ctest -j8
    participant slot as Processor Slots (8 total)
    participant suite as Audio/Standalone Suite
    participant rt as CoreAudio RT I/O Thread

    Note over ctest,slot: Without PROCESSORS reservation (old)
    ctest->>slot: Allocate 1 slot for suite
    ctest->>slot: Allocate 7 slots for other tests
    suite->>rt: AudioOutputUnitStop / AudioUnitUninitialize
    Note over rt: RT thread CPU-starved by 7 concurrent tests
    rt-->>suite: Never observes request → 120s timeout

    Note over ctest,slot: With PROCESSORS 8 (new)
    ctest->>slot: Wait until all 8 slots free
    ctest->>slot: Allocate all 8 slots for suite
    suite->>rt: AudioOutputUnitStop / AudioUnitUninitialize
    Note over rt: RT thread gets full CPU
    rt-->>suite: Observes request promptly → teardown succeeds
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci(macos): re-enable 2 audio tests via P..."](https://github.com/danielraffel/pulp/commit/ff447e584f2f51e2dc98739e8e5be18ead941998) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35650496)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->