### PR TITLE
test(harness): rasterized ELYSIUM fixture re-freeze (defect-2)

### DIFF
--- a/test/test_mac_platform_harness.cpp
+++ b/test/test_mac_platform_harness.cpp
@@ -249,8 +249,8 @@ std::unique_ptr<View> load_elysium_default_cpp_view(const fs::path& fixture_zip,
     ir = pulp::view::parse_figma_plugin_json(scene_json);
     absolutize_asset_paths(ir.asset_manifest, extracted.path);
     REQUIRE(ir.root.name == "VST Style");
-    REQUIRE(count_ir_nodes(ir.root) == 213);
-    REQUIRE(ir.asset_manifest.assets.size() == 72);
+    REQUIRE(count_ir_nodes(ir.root) == 187);  // rasterized: 3 vector frames -> image leaves
+    REQUIRE(ir.asset_manifest.assets.size() == 75);  // +3 rasterized illustration PNGs
 
     // Promote captured-art knobs (hoist body disc + drop pointer hairlines)
     // BEFORE enrich so the hoisted asset_ref receives its absolute asset_path +
@@ -599,8 +599,8 @@ TEST_CASE("mac harness captures ELYSIUM default C++ import through GPU path",
     auto ir = pulp::view::parse_figma_plugin_json(scene_json);
     absolutize_asset_paths(ir.asset_manifest, extracted.path);
     REQUIRE(ir.root.name == "VST Style");
-    REQUIRE(count_ir_nodes(ir.root) == 213);
-    REQUIRE(ir.asset_manifest.assets.size() == 72);
+    REQUIRE(count_ir_nodes(ir.root) == 187);  // rasterized: 3 vector frames -> image leaves
+    REQUIRE(ir.asset_manifest.assets.size() == 75);  // +3 rasterized illustration PNGs
 
     // Promote captured-art knobs (hoist body disc + drop pointer hairlines)
     // BEFORE enrich so the hoisted asset_ref receives its absolute asset_path +


### PR DESCRIPTION
Repoints the planning submodule to the planning-main commit (#2 in pulp-planning) that re-freezes ELYSIUM with the 3 transformed vector frames rasterized to PNGs. Resolves the dangling import-hardening-fixtures pointer too. Harness now renders the prism/cube as rasterized images: range_prism ROI 0.78->0.93. Updates parsed-scene assertions (node 213->187, assets 72->75). validate_source_manifest --require-reference green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repoints the `planning` submodule to the `planning-main` commit that re-freezes the ELYSIUM fixture with 3 vector frames rasterized to PNGs. The GPU harness now renders the prism/cube as images, improving range_prism ROI from 0.78 to 0.93.

- **Bug Fixes**
  - Resolved dangling `import-hardening-fixtures` pointer; `pulp` now references `pulp-planning` main.
  - Updated parsed-scene expectations: nodes 213 → 187; assets 72 → 75 (+3 PNGs).
  - `validate_source_manifest --require-reference` passes.

<sup>Written for commit d47cfb75848dcd9c64427a21df02f6916648d22c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR advances the `planning` private submodule to commit `178f4e3b` (re-frozen ELYSIUM fixture with 3 vector frames rasterized to PNGs) and updates the corresponding parsed-scene assertions in the harness test to match the new fixture state. It also resolves a previously dangling submodule pointer.

- **`planning` submodule**: Pointer moved from `0a0bf75f` → `178f4e3b`; the new commit re-freezes the ELYSIUM fixture so three complex vector sub-trees are replaced by single image leaves backed by rasterized PNGs, and resolves the dangling import-hardening-fixtures pointer.
- **`test/test_mac_platform_harness.cpp`**: Two parallel `REQUIRE` blocks (one in `load_elysium_default_cpp_view()` helper and one inlined in the GPU-path test case) are updated from node count 213 → 187 and asset count 72 → 75, with inline comments explaining the delta (−26 nodes = 3 vector sub-trees collapsed to image leaves; +3 PNG entries added to the asset manifest).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — both assertion updates are consistent with each other and with the described fixture change, no logic is modified, and the test skips cleanly when the private submodule is absent.

The only changed logic is two pairs of hardcoded numeric assertions, updated identically in both the shared helper and the inlined GPU-path test. The delta (−26 nodes, +3 assets) matches the '3 vector frames → single image leaves + 3 PNG entries' description exactly. No stale values remain, the inline comments explain the change, and the PR reports validate_source_manifest --require-reference passing green.

No files require special attention. The planning submodule content is private and unverifiable directly, but the test-side assertions are self-consistent and the fixture skip guard ensures no breakage on checkouts without the submodule.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| planning | Submodule pointer advanced from 0a0bf75f to 178f4e3b; re-freezes ELYSIUM fixture with rasterized PNGs and resolves dangling import-hardening-fixtures pointer. |
| test/test_mac_platform_harness.cpp | Two assertion pairs updated consistently (node count 213→187, asset count 72→75) in both the shared helper and the GPU-path test; inline comments correctly explain the delta from rasterization. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["planning submodule"] --> B["elysium.pulp.zip re-frozen fixture"]
    B --> D["parse_figma_plugin_json()"]
    D --> E["IR node count 213 -> 187"]
    D --> F["asset_manifest.assets 72 -> 75"]
    E --> G["REQUIRE count_ir_nodes == 187"]
    F --> H["REQUIRE assets.size() == 75"]
    G --> I["load_elysium_default_cpp_view helper"]
    G --> J["GPU-path TEST_CASE inline"]
    H --> I
    H --> J
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(harness): repoint planning submodul..."](https://github.com/danielraffel/pulp/commit/d47cfb75848dcd9c64427a21df02f6916648d22c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35662505)</sub>

<!-- /greptile_comment -->