### PR TITLE
feat(examples): launchable ELYSIUM standalone — native import with sprite knobs

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -81,6 +81,10 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/design-tool/CMakeLists.txt)
     add_subdirectory(design-tool)
 endif()
 
+# ELYSIUM standalone: imports the committed figma-plugin .pulp.zip natively
+# (sprite-knob hoist) and renders it in a GPU window — launchable demo.
+add_subdirectory(elysium-standalone)
+
 # TextEditor keyboard input test (Phase 21.1)
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/text-input-test/CMakeLists.txt)
     add_subdirectory(text-input-test)

--- a/examples/elysium-standalone/CMakeLists.txt
+++ b/examples/elysium-standalone/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ELYSIUM standalone — imports the committed figma-plugin ELYSIUM .pulp.zip at
+# runtime via the native materializer (with the sprite-knob hoist) and renders
+# it in a real GPU window. Requires the GPU host (MacGpuWindowHost), so it is
+# gated the same way as pulp-design-tool.
+if(APPLE AND NOT PULP_IOS AND PULP_ENABLE_GPU)
+    if(NOT PULP_HAS_SKIA)
+        message(FATAL_ERROR
+            "pulp-elysium-standalone requires PULP_HAS_SKIA=TRUE (Skia linked) "
+            "for the GPU window host. Build Skia (tools/build-skia.sh) or pass "
+            "-DPULP_ENABLE_GPU=OFF to skip this example.")
+    endif()
+
+    add_executable(pulp-elysium-standalone MACOSX_BUNDLE main.cpp)
+
+    target_link_libraries(pulp-elysium-standalone PRIVATE
+        pulp::view pulp::canvas pulp::state)
+
+    # miniz for reading the .pulp.zip; mirrors the mac-platform-harness.
+    target_include_directories(pulp-elysium-standalone PRIVATE
+        ${CMAKE_SOURCE_DIR}/external/miniz)
+
+    target_compile_features(pulp-elysium-standalone PRIVATE cxx_std_20)
+    target_compile_definitions(pulp-elysium-standalone PRIVATE
+        PULP_HAS_SKIA
+        PULP_ELYSIUM_DEFAULT_ZIP="${CMAKE_SOURCE_DIR}/planning/fixtures/figma-plugin/real-designs/elysium.pulp.zip")
+
+    set_target_properties(pulp-elysium-standalone PROPERTIES
+        OUTPUT_NAME "ElysiumStandalone"
+        MACOSX_BUNDLE_BUNDLE_NAME "ELYSIUM (imported native)"
+        MACOSX_BUNDLE_GUI_IDENTIFIER "com.pulp.elysium-standalone"
+        MACOSX_BUNDLE_SHORT_VERSION_STRING "0.1.0"
+        MACOSX_BUNDLE_BUNDLE_VERSION "0.1.0")
+endif()

--- a/examples/elysium-standalone/main.cpp
+++ b/examples/elysium-standalone/main.cpp
@@ -1,0 +1,186 @@
+// ELYSIUM standalone — imports the real figma-plugin ELYSIUM .pulp.zip from
+// scratch and renders it as native Pulp UI in a GPU window. The GRAINS knobs
+// come up as the design's captured metallic discs (sprite-skinned) with a
+// native rotating indicator notch, and they TURN under the mouse.
+//
+// This is the production wiring of the sprite-knob path: the import pipeline
+// calls hoist_captured_art_knobs() (which promotes a captured-art knob to a
+// skinned-but-turnable native Knob) BEFORE enrich_imported_image_asset_metadata,
+// then materializes via build_native_view_tree — the same path proven by the
+// mac-platform-harness, now in a launchable app.
+//
+//   pulp-elysium-standalone                       # open the window, turn knobs
+//   pulp-elysium-standalone /path/to/scene.pulp.zip
+//   pulp-elysium-standalone --screenshot=out.png  # headless capture
+#include <pulp/view/design_import.hpp>
+#include <pulp/view/view.hpp>
+#include <pulp/view/window_host.hpp>
+
+#include <miniz.h>
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// A zip entry is safe when it stays inside the destination (no absolute paths,
+// no `..` traversal). The committed fixture is trusted; this guards against a
+// malformed user-supplied zip.
+bool is_safe_zip_entry(const std::string& name) {
+    if (name.empty() || name.front() == '/') return false;
+    if (name.find("..") != std::string::npos) return false;
+    return true;
+}
+
+bool extract_zip_to_dir(const fs::path& zip_path, const fs::path& dest_dir,
+                        std::string& error) {
+    mz_zip_archive zip{};
+    if (!mz_zip_reader_init_file(&zip, zip_path.string().c_str(), 0)) {
+        error = "could not open ZIP " + zip_path.string();
+        return false;
+    }
+    const mz_uint count = mz_zip_reader_get_num_files(&zip);
+    for (mz_uint i = 0; i < count; ++i) {
+        const mz_uint name_size = mz_zip_reader_get_filename(&zip, i, nullptr, 0);
+        if (name_size == 0 || name_size > 4096) {
+            error = "unsafe ZIP filename size";
+            mz_zip_reader_end(&zip);
+            return false;
+        }
+        std::vector<char> name_buf(name_size);
+        mz_zip_reader_get_filename(&zip, i, name_buf.data(), name_buf.size());
+        const std::string entry_name(name_buf.data());
+        if (!is_safe_zip_entry(entry_name)) {
+            error = "unsafe ZIP entry " + entry_name;
+            mz_zip_reader_end(&zip);
+            return false;
+        }
+        const auto out_path = dest_dir / fs::path(entry_name);
+        if (mz_zip_reader_is_file_a_directory(&zip, i)) {
+            std::error_code ec;
+            fs::create_directories(out_path, ec);
+            continue;
+        }
+        std::error_code ec;
+        fs::create_directories(out_path.parent_path(), ec);
+        if (!mz_zip_reader_extract_to_file(&zip, i, out_path.string().c_str(), 0)) {
+            error = "could not extract ZIP entry " + entry_name;
+            mz_zip_reader_end(&zip);
+            return false;
+        }
+    }
+    mz_zip_reader_end(&zip);
+    return true;
+}
+
+void absolutize_asset_paths(pulp::view::IRAssetManifest& manifest,
+                            const fs::path& base_dir) {
+    for (auto& asset : manifest.assets) {
+        if (!asset.local_path || asset.local_path->empty()) continue;
+        fs::path path(*asset.local_path);
+        if (path.is_relative()) path = base_dir / path;
+        asset.local_path = path.lexically_normal().string();
+    }
+}
+
+std::string read_text_file(const fs::path& p) {
+    std::ifstream in(p, std::ios::binary);
+    return std::string((std::istreambuf_iterator<char>(in)),
+                       std::istreambuf_iterator<char>());
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    std::string screenshot_path;
+    fs::path zip_path = PULP_ELYSIUM_DEFAULT_ZIP;  // committed fixture (CMake)
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg(argv[i]);
+        constexpr std::string_view prefix = "--screenshot=";
+        if (arg.rfind(prefix, 0) == 0)
+            screenshot_path = arg.substr(prefix.size());
+        else if (!arg.empty() && arg[0] != '-')
+            zip_path = arg;
+    }
+
+    if (!fs::exists(zip_path)) {
+        std::cerr << "scene zip not found: " << zip_path << "\n";
+        return 1;
+    }
+
+    // 1) Extract the .pulp.zip (scene.pulp.json + assets/).
+    const fs::path extract_dir =
+        fs::temp_directory_path() / "pulp-elysium-standalone";
+    std::error_code ec;
+    fs::remove_all(extract_dir, ec);
+    fs::create_directories(extract_dir, ec);
+    std::string err;
+    if (!extract_zip_to_dir(zip_path, extract_dir, err)) {
+        std::cerr << "extract failed: " << err << "\n";
+        return 1;
+    }
+    const auto scene_json = read_text_file(extract_dir / "scene.pulp.json");
+    if (scene_json.empty()) {
+        std::cerr << "scene.pulp.json missing or empty in " << zip_path << "\n";
+        return 1;
+    }
+
+    // 2) Import: parse -> hoist sprite-knob art -> enrich -> materialize.
+    auto ir = pulp::view::parse_figma_plugin_json(scene_json);
+    absolutize_asset_paths(ir.asset_manifest, extract_dir);
+    pulp::view::hoist_captured_art_knobs(ir);  // skin captured-art knobs, keep them turnable
+    pulp::view::enrich_imported_image_asset_metadata(ir, ir.asset_manifest);
+
+    std::vector<pulp::view::ImportDiagnostic> diagnostics;
+    auto root = pulp::view::build_native_view_tree(
+        ir, ir.asset_manifest, {.diagnostics_out = &diagnostics});
+    if (!root) {
+        std::cerr << "materialize failed\n";
+        return 1;
+    }
+    root->set_requires_gpu_host(true);
+
+    // 3) Open a GPU window (or capture a screenshot headlessly).
+    const float design_w = ir.root.style.width.value_or(1000.0f);
+    const float design_h = ir.root.style.height.value_or(600.0f);
+
+    pulp::view::WindowOptions options;
+    options.title = "ELYSIUM — imported native (turn the knobs)";
+    options.width = design_w;
+    options.height = design_h;
+    options.min_width = design_w * 0.6f;
+    options.min_height = design_h * 0.6f;
+    options.resizable = true;
+    options.use_gpu = true;
+    options.initially_hidden = !screenshot_path.empty();
+
+    auto window = pulp::view::WindowHost::create(*root, options);
+    if (!window) {
+        std::cerr << "failed to create GPU window host (is Skia linked?)\n";
+        return 1;
+    }
+    window->set_design_viewport(design_w, design_h);
+    window->set_fixed_aspect_ratio(design_w / design_h);
+    window->set_close_callback([] {});
+
+    if (!screenshot_path.empty()) {
+        int frame_count = 0;
+        window->set_idle_callback([&] {
+            if (++frame_count < 6) return;  // let the GPU surface settle
+            auto png = window->capture_back_buffer_png();
+            std::ofstream out(screenshot_path, std::ios::binary);
+            out.write(reinterpret_cast<const char*>(png.data()),
+                      static_cast<std::streamsize>(png.size()));
+            window->request_close();
+        });
+    }
+
+    window->run_event_loop();
+    return 0;
+}


### PR DESCRIPTION
## What

A launchable macOS standalone (`examples/elysium-standalone/`) that imports the committed ELYSIUM figma-plugin `.pulp.zip` **from scratch** and renders it as native Pulp UI in a real Metal/Skia GPU window — with the GRAINS knobs coming up as the design's captured metallic discs (sprite-skinned) and a native rotating indicator notch, so they **turn under the mouse**.

This is the production wiring of the sprite-knob path proven by the mac-platform-harness, now in an app you can run:

```
pulp-elysium-standalone                       # open the window, turn knobs
pulp-elysium-standalone /path/to/scene.pulp.zip
pulp-elysium-standalone --screenshot=out.png  # headless capture
```

The import pipeline is the same one the harness exercises:
`extract zip → parse_figma_plugin_json → absolutize_asset_paths → hoist_captured_art_knobs → enrich_imported_image_asset_metadata → build_native_view_tree`.

## Why

Closes the loop on the Rust-UI native-import hardening series: end-to-end import → native materialize → GPU render is now demonstrable interactively, not just in a headless test. The captured-art knob hoist promotes the body disc to a skinned-but-turnable native `Knob`, which this app shows live.

## Scope / risk

Example-only addition. No SDK, plugin, or core source change. Gated `if(APPLE AND NOT PULP_IOS AND PULP_ENABLE_GPU)` and hard-requires `PULP_HAS_SKIA` (FATAL_ERROR otherwise), mirroring `pulp-design-tool`. No version bump needed (example-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a launchable macOS example that imports the committed ELYSIUM Figma-plugin `.pulp.zip` and renders it as native Pulp UI in a Metal/Skia GPU window with sprite-skinned knobs that turn under the mouse. Example-only; gated to GPU builds with Skia on macOS.

- **New Features**
  - New example at `examples/elysium-standalone/`; builds the `pulp-elysium-standalone` app.
  - Runs the full import path: extract zip → `parse_figma_plugin_json` → `hoist_captured_art_knobs` → `enrich_imported_image_asset_metadata` → `build_native_view_tree`.
  - Opens a GPU window with native knobs (sprite-skinned discs with a rotating notch). Supports `--screenshot=out.png` for headless capture and an optional zip path.
  - Uses `miniz` for zip extraction and absolutizes asset paths. Builds only when `APPLE` and `NOT PULP_IOS` and `PULP_ENABLE_GPU`; hard-requires `PULP_HAS_SKIA` (fatal otherwise). No SDK/core changes.

<sup>Written for commit e44ae0b9a0e3130627521acd6b61545f0c72aaed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `examples/elysium-standalone/`, a macOS GPU standalone that imports the committed ELYSIUM Figma-plugin `.pulp.zip` through the native import pipeline and renders sprite-skinned knobs in a live Metal/Skia window. The code is example-only and correctly mirrors the `pulp-design-tool` platform gate.

- The default ZIP path is compiled in from `${CMAKE_SOURCE_DIR}/planning/fixtures/…` — the private, optional `planning/` submodule. External contributors who build without initialising the submodule will get a binary that fails at runtime by default, and the error message leaks the internal planning-submodule path. The fixture should either be committed under a public `examples/` or `test/` tree, or the binary should fall back to a helpful "supply a path on the command line" message.
- No headless test accompanies the new end-to-end import path. CLAUDE.md's testing policy ("non-negotiable") requires a Catch2 fixture or `--screenshot`-mode integration test alongside the feature slice.
- Two minor runtime gaps: `create_directories` errors are silently swallowed before the zip extraction, and `capture_back_buffer_png()` is written to disk without checking for an empty vector.
</details>

<h3>Confidence Score: 3/5</h3>

The example compiles and runs correctly for internal developers with the planning submodule, but is broken by default for any external contributor cloning the public repo.

The compiled-in default zip path lives inside the private planning submodule, making the example non-functional out of the box for external users, and the repo is explicitly being prepared for open-source release. The import pipeline also introduces new end-to-end behavior with no accompanying test, which CLAUDE.md treats as non-negotiable. Together these two issues mean the PR needs rework before merging safely to main.

examples/elysium-standalone/CMakeLists.txt (PULP_ELYSIUM_DEFAULT_ZIP path) and examples/elysium-standalone/main.cpp (missing test, minor runtime gaps)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| examples/CMakeLists.txt | Adds unconditional add_subdirectory(elysium-standalone) without an EXISTS guard, diverging from the pattern used by design-tool and other optional examples; the inner CMakeLists.txt handles the platform gate, so non-Apple/non-GPU builds are safe, but sparse-checkout users may hit a configure-time error. |
| examples/elysium-standalone/CMakeLists.txt | Platform gating mirrors pulp-design-tool correctly, but PULP_ELYSIUM_DEFAULT_ZIP is compiled in from the private planning/ submodule — external contributors get a binary that fails at runtime by default and leaks internal submodule paths. |
| examples/elysium-standalone/main.cpp | Import pipeline wiring is correct and the zip-safety guard is reasonable; missing test coverage for the new end-to-end path, and minor gaps: create_directories errors are silently ignored and capture_back_buffer_png() result is written without an emptiness check. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as CLI / argv
    participant Main as main.cpp
    participant FS as std::filesystem
    participant Miniz as miniz (extract_zip_to_dir)
    participant Import as pulp::view import pipeline
    participant Window as WindowHost (GPU)

    CLI->>Main: zip_path / --screenshot flag
    Main->>FS: exists(zip_path)?
    FS-->>Main: yes / no
    Main->>FS: remove_all + create_directories(extract_dir)
    Main->>Miniz: extract_zip_to_dir(zip_path, extract_dir)
    Miniz-->>Main: success / error
    Main->>FS: read_text_file(scene.pulp.json)
    FS-->>Main: JSON string
    Main->>Import: parse_figma_plugin_json(json)
    Import-->>Main: IRScene
    Main->>Import: absolutize_asset_paths(ir, extract_dir)
    Main->>Import: hoist_captured_art_knobs(ir)
    Main->>Import: enrich_imported_image_asset_metadata(ir)
    Main->>Import: build_native_view_tree(ir)
    Import-->>Main: root View
    Main->>Window: "WindowHost::create(*root, options)"
    alt screenshot mode
        Window->>Window: "idle_callback (frame_count >= 6)"
        Window->>Window: capture_back_buffer_png()
        Window-->>Main: PNG bytes written to file
        Main->>Window: request_close()
    else interactive
        Window->>Window: run_event_loop() — turn knobs
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(examples): launchable ELYSIUM stand..."](https://github.com/danielraffel/pulp/commit/e44ae0b9a0e3130627521acd6b61545f0c72aaed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35665355)</sub>

> Greptile also left **4 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/generous-corp/github/danielraffel/pulp/-/custom-context?memory=ba4e5be8-bd46-4c12-958b-f42e6404037d))

<!-- /greptile_comment -->