### PR TITLE
fix(design-import): native knob + EQ image fidelity polish

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -630,17 +630,72 @@ in `design_import.cpp` beside the sibling importer passes `enrich_*` /
   (area 0) → not substantial →
   the knob HOISTS the disc and stays interactive. Two comparable layers (body +
   highlight) → demote to a static container.
+- **Capture the design's OWN pointer, don't synthesize one.** The disc body PNG
+  (ELYSIUM `Group 130`) is a CLEAN face with the min/center/max REFERENCE ticks
+  baked in; the moving pointer is a SEPARATE node (`Vector 7`, a ~4×16 hairline).
+  Before erasing the hairline, the hoist stamps its geometry onto the knob as
+  fractions of the disc half-extent: `knob_ind_r_in` / `knob_ind_r_out` (the
+  radii the line runs between, derived from the hairline's endpoints vs the disc
+  center), `knob_ind_w` (stroke width frac, from `border_width`), `knob_ind_color`
+  (from `border_color`). The materializer forwards these via
+  `Knob::set_captured_indicator`, and `Knob::paint` draws THAT pointer — pivoted
+  at the disc CORE center on the same `[-135°,+135°]` arc — instead of the generic
+  `draw_knob_indicator_notch`. Two bugs this fixes: (1) double line (the synthetic
+  notch + the disc's baked center tick); (2) misalignment (the synthetic notch
+  pivoted at the layout-BOX center with a guessed radius drifted off the baked
+  ticks). Pivot at the disc center + the design's own line ⇒ it rides the ticks by
+  construction. **The synthetic notch is still the fallback** for knobs with no
+  captured indicator metadata.
 - **Materializer skin** (`make_widget` knob branch): when the knob node carries
   an enrich-stamped `asset_path` (+ `png_natural_*`), it builds a single-frame
-  `SpriteStrip` + `set_sprite_core` from `art_core_*`. The engine overlays the
-  native rotating notch, so the knob is design-faithful AND turnable — Phase-D
-  drag still passes (`pulp-test-mac-platform-harness` knob_drag_probe).
+  `SpriteStrip` + `set_sprite_core` from `art_core_*`, then applies the captured
+  indicator above. The knob is design-faithful AND turnable — Phase-D drag still
+  passes (`pulp-test-mac-platform-harness` knob_drag_probe).
 - **Gotcha:** the harness pins `count_ir_nodes(ir.root)` on the *parsed* scene —
   assert structural counts BEFORE calling the hoist, since it removes the
   captured layers.
 - Tests: `[knob][sprite]` in `pulp-test-design-import-native-materializer`
-  (hoist promote + demote, pure, no I/O) + the GPU harness (end-to-end skin +
-  interactivity).
+  (hoist promote + demote + indicator-geometry capture + materializer forwarding,
+  pure, no I/O) + the GPU harness (end-to-end skin + interactivity).
+
+### Rasterized-vector image: suppress its baked stroke as a CSS border
+
+A Figma vector exported as a PNG (the FILTER & EQ curve `Vector 3`, every grid
+`Line`, dividers) carries its stroke as `border_color` + `border_width` in the
+IR — but **the stroke is already in the raster**. `apply_visual_style` draws a
+CSS border from those fields, which paints a spurious box outline around the
+image (the visible bug was a bright purple rectangle around the EQ curve). The
+materializer passes `skip_border=true` for `image_view` nodes so the border is
+not redrawn. If you add a code path that materializes images, keep that guard.
+Test: `[image][fidelity]` in `pulp-test-design-import-native-materializer`.
+
+### KNOWN GAP — imported text vertical centering must fix BOTH render paths
+
+The figma-plugin IR drops `textAlignVertical`, so a single-line label in a slot
+taller than its text rides the TOP of its box (visible bug: ELYSIUM "SEARCH" sits
+high; the `1·2·3·4` tab digits look off). It is tempting to fix this in the native
+materializer alone (`apply_label_style` → `set_vertical_align(center)` when
+`height > font_size*1.15`), **but that breaks the live↔baked parity invariant**:
+`pulp-test-design-import-screenshot-parity` pins `build_native_view_tree` ==
+web-compat `generate_pulp_js`, and the web-compat LIVE render does NOT center
+these labels even though `design_codegen.cpp` emits `setVerticalAlign('center')`
+and the bridge has a `setVerticalAlign` handler that maps to `Label`. So a
+native-only centering change diverged the `control-strip` fixture to similarity
+0.95 (< 0.97). The correct fix centers BOTH paths together (find why the live
+web-compat Label stays top despite the emitted call) and refreshes the parity
+baseline — do not land a native-only version.
+
+### KNOWN GAP — degenerate stroke-line images don't paint (EQ background grid)
+
+The FILTER & EQ background grid is 8 hairline `Line` images whose IR box has ONE
+dimension at ~0 (an exact 0 or a sub-pixel epsilon like `2.7e-06`). They resolve
+to valid PNGs (no missing-asset diagnostic) but paint NOTHING: flooring the thin
+flex dim (1px → 6px) changes zero pixels, so an absolute-positioned 0-area image
+is dropped at paint BEFORE the flex-dim path the materializer can reach. The
+reference shows them faint-but-present (10%-grey verticals at ~100/1K). Not yet
+fixed — it needs the layout/paint stage to honor a 1px floor for absolute
+0-area image rects (or to re-draw these as native 1px lines from their stroke).
+Parked as lower-impact than the spurious purple box, which IS fixed (see above).
 
 ### `IRStyle::box_shadow` is parsed layers, not a string (pulp #41)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.336.0
+    VERSION 0.337.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/widgets.hpp
+++ b/core/view/include/pulp/view/widgets.hpp
@@ -429,12 +429,36 @@ public:
     }
     bool has_sprite_core() const { return sprite_core_w_ > 0.0f && sprite_core_h_ > 0.0f; }
 
+    /// Geometry of the design's OWN pointer (e.g. the Figma "Vector 7" hairline)
+    /// captured by hoist_captured_art_knobs, expressed relative to the disc core
+    /// so the renderer can reproduce the design's indicator instead of the
+    /// generic synthetic notch. `r_in`/`r_out` are fractions of the core's half
+    /// extent (the radius the line runs between); `width_px` is the logical
+    /// stroke width; `color` is the line color. When set on a single-frame
+    /// captured-art knob, Knob::paint draws THIS pointer — pivoted at the disc
+    /// core center on the [-135°,+135°] arc — and skips the synthetic notch, so
+    /// the moving line rides the disc's baked min/center/max reference ticks.
+    void set_captured_indicator(float r_in, float r_out, float width_px,
+                                canvas::Color color) {
+        ind_r_in_ = r_in; ind_r_out_ = r_out;
+        ind_width_ = width_px; ind_color_ = color;
+        has_captured_indicator_ = true;
+    }
+    bool has_captured_indicator() const { return has_captured_indicator_; }
+    float captured_indicator_r_in() const { return ind_r_in_; }
+    float captured_indicator_r_out() const { return ind_r_out_; }
+
 private:
     std::shared_ptr<SpriteStrip> sprite_strip_;
     float sprite_core_x_ = 0.0f;
     float sprite_core_y_ = 0.0f;
     float sprite_core_w_ = 0.0f;
     float sprite_core_h_ = 0.0f;
+    bool has_captured_indicator_ = false;
+    float ind_r_in_ = 0.0f;
+    float ind_r_out_ = 0.0f;
+    float ind_width_ = 0.0f;
+    canvas::Color ind_color_ = canvas::Color::rgba(1.0f, 1.0f, 1.0f, 1.0f);
 };
 
 // ── Fader ────────────────────────────────────────────────────────────────────

--- a/core/view/src/design_import.cpp
+++ b/core/view/src/design_import.cpp
@@ -15,6 +15,7 @@
 #include <fstream>
 #include <sstream>
 #include <algorithm>
+#include <limits>
 #include <cctype>
 #include <cstring>
 #include <cstdlib>
@@ -2164,13 +2165,66 @@ void hoist_captured_art_knobs(DesignIR& ir) {
                 }
                 if (substantial == 0) {
                     // One body disc (+ only pointer hairlines): hoist the disc so
-                    // the materializer skins the knob and overlays the native
-                    // rotating notch. The knob stays interactive AND faithful.
+                    // the materializer skins the knob and draws the design's own
+                    // pointer over it. The knob stays interactive AND faithful.
                     n.attributes["asset_ref"] = body->attributes.at("asset_ref");
                     if (body->style.render_bounds && !n.style.render_bounds)
                         n.style.render_bounds = body->style.render_bounds;
                     if (!n.attributes.count("sprite_strip_frame_count"))
                         n.attributes["sprite_strip_frame_count"] = "1";
+
+                    // Capture the design's OWN pointer geometry (the hairline
+                    // vector — Figma "Vector 7") before erasing it, so the
+                    // renderer reproduces it pivoting at the disc center on the
+                    // value arc instead of drawing a guessed synthetic notch.
+                    // The hairline = the smallest-area non-body captured layer.
+                    // Geometry is recorded as fractions of the disc's half-extent
+                    // so it survives the importer's core-fit rescale.
+                    const float bx = body->style.left.value_or(0.0f);
+                    const float by = body->style.top.value_or(0.0f);
+                    const float bw = body->style.width.value_or(0.0f);
+                    const float bh = body->style.height.value_or(0.0f);
+                    const float dcx = bx + bw * 0.5f;
+                    const float dcy = by + bh * 0.5f;
+                    const float half = std::min(bw, bh) * 0.5f;
+                    IRNode* pointer = nullptr;
+                    float pointer_area = std::numeric_limits<float>::max();
+                    for (auto* layer : captured) {
+                        if (layer == body) continue;
+                        const float a = layer->style.width.value_or(0.0f) *
+                                        layer->style.height.value_or(0.0f);
+                        if (a < pointer_area) { pointer_area = a; pointer = layer; }
+                    }
+                    if (pointer != nullptr && half > 0.0f) {
+                        const float px = pointer->style.left.value_or(0.0f);
+                        const float py = pointer->style.top.value_or(0.0f);
+                        const float pw = pointer->style.width.value_or(0.0f);
+                        const float pyh = pointer->style.height.value_or(0.0f);
+                        // The hairline runs along its long axis; its two ends are
+                        // the extremes of its box. Measure each end's radius from
+                        // the disc center, keep the near/far pair.
+                        const float pcx = px + pw * 0.5f;
+                        auto rad = [&](float ex, float ey) {
+                            const float dx = ex - dcx, dy = ey - dcy;
+                            return std::sqrt(dx * dx + dy * dy);
+                        };
+                        const float r_a = rad(pcx, py);
+                        const float r_b = rad(pcx, py + pyh);
+                        const float r_out = std::max(r_a, r_b) / half;
+                        const float r_in = std::min(r_a, r_b) / half;
+                        const float w_frac =
+                            pointer->style.border_width.value_or(1.5f) / half;
+                        if (r_out > r_in) {
+                            n.attributes["knob_ind_r_in"] = std::to_string(r_in);
+                            n.attributes["knob_ind_r_out"] = std::to_string(r_out);
+                            n.attributes["knob_ind_w"] = std::to_string(w_frac);
+                            if (pointer->style.border_color)
+                                n.attributes["knob_ind_color"] =
+                                    *pointer->style.border_color;
+                            else if (pointer->style.color)
+                                n.attributes["knob_ind_color"] = *pointer->style.color;
+                        }
+                    }
                     n.children.erase(
                         std::remove_if(n.children.begin(), n.children.end(),
                             [](const IRNode& c) {

--- a/core/view/src/design_import_native_common.cpp
+++ b/core/view/src/design_import_native_common.cpp
@@ -1078,7 +1078,8 @@ void apply_layout(View& view, const IRNode& node, std::optional<LayoutDirection>
         flex.dim_height = {0.0f, DimensionUnit::auto_};
 }
 
-void apply_visual_style(View& view, const IRStyle& style) {
+void apply_visual_style(View& view, const IRStyle& style,
+                        bool skip_border = false) {
     if (style.background_color) {
         if (auto color = parse_hex_color(*style.background_color))
             view.set_background_color(*color);
@@ -1099,31 +1100,38 @@ void apply_visual_style(View& view, const IRStyle& style) {
         view.set_opacity(*style.opacity);
     if (style.border_radius)
         view.set_border_radius(*style.border_radius);
-    if (style.border_width)
-        view.set_border_width(*style.border_width);
-    if (style.border_color) {
-        if (auto color = parse_hex_color(*style.border_color))
-            view.set_border_color(*color);
-    }
-    if (style.border_top_width) view.set_border_top_width(*style.border_top_width);
-    if (style.border_right_width) view.set_border_right_width(*style.border_right_width);
-    if (style.border_bottom_width) view.set_border_bottom_width(*style.border_bottom_width);
-    if (style.border_left_width) view.set_border_left_width(*style.border_left_width);
-    if (style.border_top_color) {
-        if (auto color = parse_hex_color(*style.border_top_color))
-            view.set_border_top_color(*color);
-    }
-    if (style.border_right_color) {
-        if (auto color = parse_hex_color(*style.border_right_color))
-            view.set_border_right_color(*color);
-    }
-    if (style.border_bottom_color) {
-        if (auto color = parse_hex_color(*style.border_bottom_color))
-            view.set_border_bottom_color(*color);
-    }
-    if (style.border_left_color) {
-        if (auto color = parse_hex_color(*style.border_left_color))
-            view.set_border_left_color(*color);
+    // A rasterized-vector image (a Figma vector/line exported as a PNG) carries
+    // the source stroke as border_color/border_width, but the stroke is already
+    // baked into the raster. Drawing it again paints a spurious box outline —
+    // the visible bug was a bright purple rectangle around the FILTER & EQ curve
+    // (Vector 3, stroke #7e6aff). Skip the border for those nodes.
+    if (!skip_border) {
+        if (style.border_width)
+            view.set_border_width(*style.border_width);
+        if (style.border_color) {
+            if (auto color = parse_hex_color(*style.border_color))
+                view.set_border_color(*color);
+        }
+        if (style.border_top_width) view.set_border_top_width(*style.border_top_width);
+        if (style.border_right_width) view.set_border_right_width(*style.border_right_width);
+        if (style.border_bottom_width) view.set_border_bottom_width(*style.border_bottom_width);
+        if (style.border_left_width) view.set_border_left_width(*style.border_left_width);
+        if (style.border_top_color) {
+            if (auto color = parse_hex_color(*style.border_top_color))
+                view.set_border_top_color(*color);
+        }
+        if (style.border_right_color) {
+            if (auto color = parse_hex_color(*style.border_right_color))
+                view.set_border_right_color(*color);
+        }
+        if (style.border_bottom_color) {
+            if (auto color = parse_hex_color(*style.border_bottom_color))
+                view.set_border_bottom_color(*color);
+        }
+        if (style.border_left_color) {
+            if (auto color = parse_hex_color(*style.border_left_color))
+                view.set_border_left_color(*color);
+        }
     }
     if (style.border_top_left_radius) view.set_corner_radius_tl(*style.border_top_left_radius);
     if (style.border_top_right_radius) view.set_corner_radius_tr(*style.border_top_right_radius);
@@ -1232,6 +1240,19 @@ void apply_captured_art_knob_skin(Knob& knob, const IRNode& node) {
     if (cw > 0.0f && ch > 0.0f)
         knob.set_sprite_core(attr_float(node, "art_core_x").value_or(0.0f),
                              attr_float(node, "art_core_y").value_or(0.0f), cw, ch);
+    // Design's own pointer geometry (Figma "Vector 7"), captured by
+    // hoist_captured_art_knobs as fractions of the disc half-extent. When
+    // present, Knob::paint draws THIS pointer over the static disc — pivoting at
+    // the disc core center on the value arc — instead of the synthetic notch, so
+    // it rides the disc's baked min/center/max reference ticks.
+    if (auto r_out = attr_float(node, "knob_ind_r_out")) {
+        const float r_in = attr_float(node, "knob_ind_r_in").value_or(0.0f);
+        const float w = attr_float(node, "knob_ind_w").value_or(0.0f);
+        Color color = Color::rgba(0.92f, 0.92f, 0.92f, 1.0f);
+        if (auto hex = attr(node, "knob_ind_color"))
+            if (auto parsed = parse_hex_color(*hex)) color = *parsed;
+        knob.set_captured_indicator(r_in, *r_out, w, color);
+    }
 }
 
 std::unique_ptr<View> make_widget(const IRNode& node,
@@ -1416,7 +1437,8 @@ std::unique_ptr<View> materialize_node(const IRNode& node,
     auto view = make_widget(node, resolved, manifest, options, path, diagnostics);
     apply_identity(*view, node, resolved);
     apply_layout(*view, node, parent_direction);
-    apply_visual_style(*view, node.style);
+    apply_visual_style(*view, node.style,
+                       /*skip_border=*/resolved.kind == NativeWidgetKind::image_view);
     if (resolved.kind == NativeWidgetKind::image_view)
         apply_imported_image_sizing(*view, node);
 

--- a/core/view/src/widgets.cpp
+++ b/core/view/src/widgets.cpp
@@ -366,6 +366,29 @@ static void draw_knob_indicator_notch(canvas::Canvas& canvas,
     canvas.stroke_line(inner_x, inner_y, outer_x, outer_y);
 }
 
+// Pointer reproduced from the design's OWN indicator node (set_captured_indicator).
+// Same [-135°,+135°] value→angle arc as the synthetic notch, but the radii, width
+// and color come from the imported art, and it pivots at the disc core center
+// (cx, cy) — so the line rides the disc's baked min/center/max reference ticks
+// instead of a guessed sweep. A faint dark backing keeps a hairline legible on a
+// bright metallic face without reading as a second line.
+static void draw_knob_captured_pointer(canvas::Canvas& canvas,
+                                       float cx, float cy,
+                                       float r_in, float r_out, float width,
+                                       canvas::Color color, float value) {
+    float angle = -1.5707963f + (value - 0.5f) * 4.7123890f;
+    float ox = cx + r_out * std::cos(angle);
+    float oy = cy + r_out * std::sin(angle);
+    float ix = cx + r_in  * std::cos(angle);
+    float iy = cy + r_in  * std::sin(angle);
+    canvas.set_stroke_color(canvas::Color::rgba(0.10f, 0.11f, 0.13f, 0.45f));
+    canvas.set_line_width(width + 1.25f);
+    canvas.stroke_line(ix, iy, ox, oy);
+    canvas.set_stroke_color(color);
+    canvas.set_line_width(width);
+    canvas.stroke_line(ix, iy, ox, oy);
+}
+
 void Knob::paint(canvas::Canvas& canvas) {
     auto b = local_bounds();
     float cx = b.width * 0.5f;
@@ -457,7 +480,16 @@ void Knob::paint(canvas::Canvas& canvas) {
         // the frames themselves (frame_for_value picks the angle), so they
         // get no overlay.
         if (sprite_strip_->frame_count() == 1) {
-            draw_knob_indicator_notch(canvas, cx, cy, notch_r, notch_r, value_);
+            if (has_captured_indicator_) {
+                // Reproduce the design's own pointer over the static disc.
+                float r_out = ind_r_out_ * notch_r;
+                float r_in  = ind_r_in_  * notch_r;
+                float w = std::max(1.5f, ind_width_ * notch_r);
+                draw_knob_captured_pointer(canvas, cx, cy, r_in, r_out, w,
+                                           ind_color_, value_);
+            } else {
+                draw_knob_indicator_notch(canvas, cx, cy, notch_r, notch_r, value_);
+            }
         }
         // Fall through to draw labels on top
     }

--- a/test/test_design_import_native_materializer.cpp
+++ b/test/test_design_import_native_materializer.cpp
@@ -701,6 +701,75 @@ TEST_CASE("baked native materializer applies a CSS background gradient",
     REQUIRE(root->background_gradient_type() == 1);  // 1 = linear
 }
 
+TEST_CASE("baked native materializer reproduces the design's captured knob pointer",
+          "[view][import][native-materializer][knob][sprite]") {
+    // hoist_captured_art_knobs stamps the design's own pointer geometry; the
+    // materializer must forward it to the Knob (set_captured_indicator) so the
+    // renderer draws THAT pointer over the disc instead of a synthetic notch —
+    // killing the double line and aligning to the disc's baked reference ticks.
+    DesignIR ir;
+    ir.root.type = "frame";
+    ir.root.stable_anchor_id = "root";
+    ir.root.style.width = 100.0f;
+    ir.root.style.height = 100.0f;
+
+    IRNode knob;
+    knob.type = "frame";
+    knob.stable_anchor_id = "knob";
+    knob.audio_widget = AudioWidgetType::knob;
+    knob.style.width = 30.0f;
+    knob.style.height = 32.0f;
+    // Post-hoist + post-enrich attribute contract for a captured-art knob.
+    knob.attributes["asset_ref"] = "disc";
+    knob.attributes["asset_path"] = "/resolved/disc.png";
+    knob.attributes["png_natural_w"] = "420";
+    knob.attributes["png_natural_h"] = "484";
+    knob.attributes["knob_ind_r_in"] = "0.604";
+    knob.attributes["knob_ind_r_out"] = "0.936";
+    knob.attributes["knob_ind_w"] = "0.05";
+    knob.attributes["knob_ind_color"] = "#ffffff";
+    ir.root.children.push_back(std::move(knob));
+
+    auto root = build_native_view_tree(ir, {}, {});
+    REQUIRE(root != nullptr);
+    REQUIRE(root->child_count() == 1);
+    auto* k = dynamic_cast<Knob*>(root->child_at(0));
+    REQUIRE(k != nullptr);
+    REQUIRE(k->has_captured_indicator());
+    CHECK(k->captured_indicator_r_out() == Catch::Approx(0.936f));
+    CHECK(k->captured_indicator_r_in() == Catch::Approx(0.604f));
+}
+
+TEST_CASE("rasterized-vector image does not redraw its baked stroke as a box border",
+          "[view][import][native-materializer][image][fidelity]") {
+    // A Figma vector exported as a PNG carries its stroke as border_color /
+    // border_width, but the stroke is already in the raster. Drawing it again
+    // paints a spurious outline — the visible bug was a purple rectangle around
+    // the FILTER & EQ curve. Image views must suppress the CSS border.
+    DesignIR ir;
+    ir.source = DesignSource::figma_plugin;
+    ir.root.type = "image";
+    ir.root.stable_anchor_id = "curve";
+    ir.root.attributes["asset_ref"] = "3:188";
+    ir.root.style.width = 177.0f;
+    ir.root.style.height = 26.0f;
+    ir.root.style.border_color = "#7e6aff";
+    ir.root.style.border_width = 1.0f;
+
+    IRAssetRef asset;
+    asset.asset_id = "3:188";
+    asset.original_uri = "figma://fixture/3:188";
+    asset.local_path = "/resolved/assets/3_188.png";
+    asset.mime = "image/png";
+    ir.asset_manifest.assets.push_back(asset);
+
+    auto root = build_native_view_tree(ir, ir.asset_manifest, {});
+    REQUIRE(root != nullptr);
+    auto* image = dynamic_cast<ImageView*>(root.get());
+    REQUIRE(image != nullptr);
+    CHECK(image->border_width() == Catch::Approx(0.0f));
+}
+
 TEST_CASE("hoist_captured_art_knobs promotes a body disc + pointer to an interactive skin",
           "[view][import][native-materializer][knob][sprite]") {
     // A captured-art knob ships a body disc image + a ~0-area pointer hairline
@@ -714,18 +783,24 @@ TEST_CASE("hoist_captured_art_knobs promotes a body disc + pointer to an interac
     knob.type = "frame";
     knob.stable_anchor_id = "knob";
     knob.audio_widget = AudioWidgetType::knob;
-    IRNode body;       // the disc
+    IRNode body;       // the disc, at (0,0), 30x32 → center (15,16), half-extent 15
     body.type = "image";
     body.stable_anchor_id = "body";
     body.attributes["asset_ref"] = "disc-asset";
+    body.style.left = 0.0f;
+    body.style.top = 0.0f;
     body.style.width = 30.0f;
     body.style.height = 32.0f;
-    IRNode pointer;    // a 0-area stroked pointer hairline
+    IRNode pointer;    // a ~0-width stroked pointer hairline near top-center
     pointer.type = "image";
     pointer.stable_anchor_id = "ptr";
     pointer.attributes["asset_ref"] = "ptr-asset";
+    pointer.style.left = 14.0f;   // ~centered on the 30-wide disc
+    pointer.style.top = 2.0f;
     pointer.style.width = 0.0f;
-    pointer.style.height = 5.0f;
+    pointer.style.height = 5.0f;  // spans y 2..7
+    pointer.style.border_width = 1.5f;
+    pointer.style.border_color = "#ffffff";
     knob.children.push_back(body);
     knob.children.push_back(pointer);
     ir.root.children.push_back(std::move(knob));
@@ -736,8 +811,18 @@ TEST_CASE("hoist_captured_art_knobs promotes a body disc + pointer to an interac
     REQUIRE(k.audio_widget == AudioWidgetType::knob);          // stays interactive
     REQUIRE(k.attributes.at("asset_ref") == "disc-asset");     // disc hoisted
     REQUIRE(k.attributes.at("sprite_strip_frame_count") == "1");
-    // Captured layers (disc + pointer) are gone; the native notch draws the indicator.
+    // Captured layers (disc + pointer) are gone — the design's pointer geometry
+    // is stamped instead, so the renderer reproduces the real indicator.
     REQUIRE(k.children.empty());
+    // pointer ends (14,2)/(14,7) from disc center (15,16): far ≈ 14.04, near ≈ 9.06;
+    // half-extent 15 → r_out ≈ 0.936, r_in ≈ 0.604.
+    REQUIRE(k.attributes.count("knob_ind_r_out") == 1);
+    const float r_out = std::stof(k.attributes.at("knob_ind_r_out"));
+    const float r_in = std::stof(k.attributes.at("knob_ind_r_in"));
+    CHECK(r_out == Catch::Approx(0.936f).margin(0.02f));
+    CHECK(r_in == Catch::Approx(0.604f).margin(0.02f));
+    CHECK(r_out > r_in);
+    REQUIRE(k.attributes.at("knob_ind_color") == "#ffffff");
 }
 
 TEST_CASE("hoist_captured_art_knobs demotes a multi-layer knob to a static container",


### PR DESCRIPTION
Two native-materializer fidelity fixes, each verified against the frozen Figma reference with the ELYSIUM standalone.

## 1. Captured-art knob — single, aligned pointer
The disc body PNG is a clean face with the min/center/max **reference ticks baked in**; the moving pointer is a **separate** hairline node (ELYSIUM `Vector 7`). `hoist_captured_art_knobs` now captures that pointer's geometry (radii, width, color as fractions of the disc half-extent) before erasing it, and `Knob::paint` reproduces it **pivoting at the disc core center** on the `[-135°,+135°]` arc instead of drawing a synthetic notch.

Fixes (a) the **double line** (synthetic notch + the disc's baked center tick) and (b) the **tick misalignment** (notch pivoted at the box center with a guessed radius). The synthetic notch stays as the fallback for knobs without captured-indicator metadata.

## 2. Rasterized-vector image border
A Figma vector exported as a PNG carries its stroke as `border_color`/`border_width`, but the stroke is already in the raster. `apply_visual_style` drew it again as a CSS box outline — the **spurious purple rectangle** around the FILTER & EQ curve. `image_view` nodes now pass `skip_border=true`.

## Deferred (documented in the import-design skill as KNOWN GAPs)
- **Text vertical centering.** A native-only fix breaks the live↔baked screenshot-parity invariant — the web-compat live render does not center these labels despite the emitted `setVerticalAlign`. Needs a fix that centers **both** paths and refreshes the parity baseline.
- **EQ background grid.** The 8 hairline `Line` images (one ~0 box dimension) still don't paint — an absolute 0-area image rect is dropped before the flex-dim path. Lower-impact than the purple box.

## Tests
`[knob][sprite]` (indicator-geometry capture + materializer forwarding) and `[image][fidelity]` (border suppressed) in `pulp-test-design-import-native-materializer`. Full materializer suite (309), screenshot-parity (130), and the ELYSIUM GPU harness (knob still drags 0.5→0.9) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Three targeted fidelity fixes for the native design-import materializer, each addressing a visible rendering artifact in the ELYSIUM standalone verified against the frozen Figma reference. The version is bumped to 0.337.0.

- **Knob captured pointer**: `hoist_captured_art_knobs` now records the design's hairline indicator node (`Vector 7`) as disc-half-extent fractions (`knob_ind_r_in/out/w/color`) before erasing it; `apply_captured_art_knob_skin` forwards these to `Knob::set_captured_indicator`; `Knob::paint` reproduces the design's own line pivoting at the disc core center instead of a guessed synthetic notch, eliminating the double-line and radius misalignment. The synthetic notch remains the fallback.
- **Rasterized-vector image border**: `apply_visual_style` now accepts a `skip_border` flag; `materialize_node` passes `skip_border=true` for `image_view` nodes so the stroke already baked into the exported PNG is not redrawn as a CSS box outline (was causing the purple rectangle around the FILTER & EQ curve).
- **Text vertical centering**: described in the PR as Fix #2 but not present in the diff — the SKILL.md added here explicitly documents it as a KNOWN GAP that must not be landed as a native-only change because it fails the screenshot-parity threshold (0.95 < 0.97).
</details>

<h3>Confidence Score: 4/5</h3>

The knob and image fixes are mechanically correct and well-tested; the PR description claims a third fix (text vertical centering) that is not in the code and that the updated SKILL.md explicitly says must not be landed.

The text-centering change is described in the PR as landed but is entirely absent from the diff. The SKILL.md added in this same PR explains why it cannot be done as a native-only change — it breaks the screenshot-parity threshold. A reviewer approving on the basis of the description would believe the label bug is fixed when it is not.

.agents/skills/import-design/SKILL.md — the new KNOWN GAP entry directly contradicts the PR description's Fix #2 claim; the description needs updating before merge.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .agents/skills/import-design/SKILL.md | Adds detailed docs for captured-indicator knob logic, image border suppression, and two new known-gap sections. The text-centering known-gap entry contradicts the PR description's claim that Fix #2 was landed. |
| core/view/src/design_import.cpp | Captures design's own pointer geometry (r_in, r_out, width, color as disc-half-extent fractions) in hoist_captured_art_knobs before erasing the hairline layer; geometry is stamped as IR attributes for the materializer to forward. |
| core/view/src/design_import_native_common.cpp | Adds skip_border param to apply_visual_style (guards all border sets) and calls it with skip_border=true for image_view nodes; apply_captured_art_knob_skin now reads and forwards captured-indicator geometry to Knob. |
| core/view/src/widgets.cpp | Adds draw_knob_captured_pointer and routes single-frame sprite knobs through it when has_captured_indicator_ is true, using design's own radii/width/color multiplied by notch_r; synthetic notch remains the fallback. |
| core/view/include/pulp/view/widgets.hpp | Adds set_captured_indicator / has_captured_indicator / captured_indicator_r_in / captured_indicator_r_out API and backing private fields to the Knob class. |
| test/test_design_import_native_materializer.cpp | Adds two new test cases: knob indicator geometry capture+forwarding and image border suppression; also enriches the existing hoist promotion test with pointer geometry assertions. |
| CMakeLists.txt | Version bump 0.336.0 → 0.337.0. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant H as hoist_captured_art_knobs
    participant IR as IRNode (knob)
    participant M as apply_captured_art_knob_skin
    participant K as Knob::paint

    H->>IR: read body disc geometry (bx,by,bw,bh)
    H->>IR: find smallest-area non-body layer (pointer hairline)
    H->>IR: compute r_in/r_out/w_frac as disc-half-extent fractions
    H->>IR: stamp knob_ind_r_in/out/w/color attrs
    H->>IR: erase captured child layers

    M->>IR: read knob_ind_r_out (present?)
    IR-->>M: r_out, r_in, w, color
    M->>K: set_captured_indicator(r_in, r_out, w, color)

    K->>K: "paint() — sprite strip loaded, frame_count==1"
    alt has_captured_indicator_
        K->>K: "draw_knob_captured_pointer(cx,cy,r_in*notch_r,r_out*notch_r,...)"
    else
        K->>K: draw_knob_indicator_notch(cx,cy,notch_r,...)
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: bump versions"](https://github.com/danielraffel/pulp/commit/67216c3fda3966c82657e46fd9af353f3ce6b604) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35676037)</sub>

<!-- /greptile_comment -->