### PR TITLE
feat(design-import): shape-fill capability + text-centering + EQ grid

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -669,33 +669,44 @@ materializer passes `skip_border=true` for `image_view` nodes so the border is
 not redrawn. If you add a code path that materializes images, keep that guard.
 Test: `[image][fidelity]` in `pulp-test-design-import-native-materializer`.
 
-### KNOWN GAP — imported text vertical centering must fix BOTH render paths
+### Imported text vertical centering — fix BOTH render paths together
 
 The figma-plugin IR drops `textAlignVertical`, so a single-line label in a slot
 taller than its text rides the TOP of its box (visible bug: ELYSIUM "SEARCH" sits
-high; the `1·2·3·4` tab digits look off). It is tempting to fix this in the native
-materializer alone (`apply_label_style` → `set_vertical_align(center)` when
-`height > font_size*1.15`), **but that breaks the live↔baked parity invariant**:
-`pulp-test-design-import-screenshot-parity` pins `build_native_view_tree` ==
-web-compat `generate_pulp_js`, and the web-compat LIVE render does NOT center
-these labels even though `design_codegen.cpp` emits `setVerticalAlign('center')`
-and the bridge has a `setVerticalAlign` handler that maps to `Label`. So a
-native-only centering change diverged the `control-strip` fixture to similarity
-0.95 (< 0.97). The correct fix centers BOTH paths together (find why the live
-web-compat Label stays top despite the emitted call) and refreshes the parity
-baseline — do not land a native-only version.
+high; the `1·2·3·4` tab digits look off). The rule: center when
+`height > font_size * 1.15`. **It must be applied to BOTH render paths or the
+parity gate fails** — `pulp-test-design-import-screenshot-parity` pins
+`build_native_view_tree` (baked/native) == web-compat `generate_pulp_js` (live).
 
-### KNOWN GAP — degenerate stroke-line images don't paint (EQ background grid)
+The two paths are SEPARATE codegens:
+- **Native** (`apply_label_style`, `design_import_native_common.cpp`):
+  `label.set_vertical_align(center)`.
+- **Web-compat** is the **HTML/DOM** emitter (the `.style.*` block in
+  `design_codegen.cpp` — `document.createElement('span')` + `.style.verticalAlign`),
+  NOT the `createLabel`/`setVerticalAlign` branch (that serves bridge-native-js).
+  It emits `span.style.verticalAlign = 'middle'`; the web-compat shim
+  (`web-compat-style-decl-typography.js`) maps `verticalAlign` →
+  `setVerticalAlign` → `Label::set_vertical_align`.
 
-The FILTER & EQ background grid is 8 hairline `Line` images whose IR box has ONE
-dimension at ~0 (an exact 0 or a sub-pixel epsilon like `2.7e-06`). They resolve
-to valid PNGs (no missing-asset diagnostic) but paint NOTHING: flooring the thin
-flex dim (1px → 6px) changes zero pixels, so an absolute-positioned 0-area image
-is dropped at paint BEFORE the flex-dim path the materializer can reach. The
-reference shows them faint-but-present (10%-grey verticals at ~100/1K). Not yet
-fixed — it needs the layout/paint stage to honor a 1px floor for absolute
-0-area image rects (or to re-draw these as native 1px lines from their stroke).
-Parked as lower-impact than the spurious purple box, which IS fixed (see above).
+Both converge on one `Label` mechanism ⇒ identical pixels ⇒ parity holds. A
+NATIVE-ONLY change diverged the `control-strip` fixture to 0.95 (< 0.97) because
+the web-compat span otherwise top-aligns. Tests: `[text]` in the native
+materializer suite + the parity suite (both fixtures green).
+
+### Hairline strokes (EQ grid) → demoted to 1px frames; parse the rgba() fill
+
+The FILTER & EQ background grid is 8 hairline `Line` nodes. By the time they
+reach `materialize_node` an upstream pass has already demoted them from
+stroke-only images to **1px frames** (one axis floored to 1, marked
+`__stroke_demoted=1`) whose `background_color` is the stroke color — typically
+`rgba(171, 171, 171, 0.1)`. They still painted nothing because
+`apply_visual_style` resolved `background_color` with `parse_hex_color`, which
+does NOT handle `rgb()/rgba()`, so the fill was dropped and the grid vanished.
+Fix: `apply_visual_style` now falls back to the shared `parse_css_color`
+(exported from `css_gradient.hpp`) for `rgb()/rgba()/transparent`. So the bug was
+NOT a 0-area-paint drop (that red herring cost time — flooring the flex dim did
+nothing because the node is already a 1px frame, not an image); it was an
+unparsed rgba fill. Test: `[color]` in the native materializer suite.
 
 ### `IRStyle::box_shadow` is parsed layers, not a string (pulp #41)
 

--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -669,6 +669,30 @@ materializer passes `skip_border=true` for `image_view` nodes so the border is
 not redrawn. If you add a code path that materializes images, keep that guard.
 Test: `[image][fidelity]` in `pulp-test-design-import-native-materializer`.
 
+### Value-driven silhouette fill (illustration shapes — item 3)
+
+A captured illustration PNG (ELYSIUM's prism / cylinder / pentagon / cube) can
+be "filled" to a bound value via `ImageView::set_fill_value(0..1)` +
+`set_fill_color`. `ImageView::paint` overlays the color from the bottom up to
+`value` of the height, masked to the image's OWN alpha through the canvas
+`save_layer_with_mask` url() path — so the fill clips to the shape silhouette.
+
+The alpha-mask primitive: `SkiaCanvas::save_layer_with_mask` Phase 1 only
+shipped gradient masks; `url(<file>)` image masks were future work. They are now
+implemented (`skia_canvas_mask.cpp` `parse_url_image_mask` — decode the file to
+an `SkImage`, build a kDecal shader scaled to the mask box; kDstIn keeps painted
+content only where the image alpha is non-zero). Works on Skia raster AND
+Graphite/GPU.
+
+Binding which knob drives which shape is NOT in the figma source (no Figma
+binding), so the import does not auto-wire it. The `elysium-standalone` example
+demonstrates the capability by pairing each upper illustration with its column
+knob and driving `set_fill_value` from the knob each frame. Verify headlessly on
+the **Skia raster** backend, not a GPU window: `render_to_png(view, ...,
+ScreenshotBackend::skia)` exercises the url() mask without Dawn/Metal. Test:
+`[view][image][fill]` in `pulp-test-image-view-fill` (renders fill 0.5 / 1.0 via
+raster, asserts the overlay scales with value).
+
 ### Imported text vertical centering — fix BOTH render paths together
 
 The figma-plugin IR drops `textAlignVertical`, so a single-line label in a slot

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.174.1",
+      "version": "0.175.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.174.1"
+  "version": "0.175.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.174.1",
+  "version": "0.175.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.337.0
+    VERSION 0.338.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/src/skia_canvas_mask.cpp
+++ b/core/canvas/src/skia_canvas_mask.cpp
@@ -25,6 +25,7 @@
 #include <cmath>
 #include <optional>
 #include <sstream>
+#include <string_view>
 #include <unordered_map>
 
 #ifdef PULP_HAS_SKIA
@@ -33,6 +34,9 @@
 #include "include/core/SkColorSpace.h"
 #include "include/core/SkData.h"
 #include "include/core/SkImage.h"
+#include "include/core/SkMatrix.h"
+#include "include/core/SkSamplingOptions.h"
+#include "include/core/SkTileMode.h"
 #include "include/core/SkPaint.h"
 #include "include/core/SkPath.h"
 #include "include/core/SkPathBuilder.h"
@@ -315,6 +319,43 @@ std::pair<float, float> parse_mask_size(const std::string& s, float w, float h) 
     return {*wf, *hf};
 }
 
+// url(<file>) mask: decode the image and build a shader scaled to the mask box
+// so the kDstIn composite keeps painted content ONLY where the image's alpha is
+// non-zero — an arbitrary-silhouette clip (the design-import shape-fill path
+// masks a value-height gradient by an illustration PNG). Mirrors
+// decode_pattern_image() in skia_canvas_gradients.cpp. kDecal tiling makes
+// everything outside the image box fully transparent (= masked away).
+sk_sp<SkShader> parse_url_image_mask(const std::string& value,
+                                     float x, float y, float w, float h) {
+    const auto open = value.find("url(");
+    if (open == std::string::npos) return nullptr;
+    const auto close = value.find(')', open);
+    if (close == std::string::npos) return nullptr;
+    std::string path = value.substr(open + 4, close - (open + 4));
+    auto trim = [](std::string& s) {
+        while (!s.empty() &&
+               (s.front() == ' ' || s.front() == '"' || s.front() == '\''))
+            s.erase(s.begin());
+        while (!s.empty() &&
+               (s.back() == ' ' || s.back() == '"' || s.back() == '\''))
+            s.pop_back();
+    };
+    trim(path);
+    constexpr std::string_view kFile = "file://";
+    if (path.size() >= kFile.size() && path.compare(0, kFile.size(), kFile) == 0)
+        path = path.substr(kFile.size());
+    if (path.empty()) return nullptr;
+    auto data = SkData::MakeFromFileName(path.c_str());
+    if (!data) return nullptr;
+    auto image = SkImages::DeferredFromEncodedData(data);
+    if (!image || image->width() <= 0 || image->height() <= 0) return nullptr;
+    SkMatrix m = SkMatrix::Translate(x, y);
+    m.preScale(w / static_cast<float>(image->width()),
+               h / static_cast<float>(image->height()));
+    return image->makeShader(SkTileMode::kDecal, SkTileMode::kDecal,
+                             SkSamplingOptions(SkFilterMode::kLinear), &m);
+}
+
 }  // namespace
 
 void SkiaCanvas::save_layer_with_mask(float x, float y, float w, float h,
@@ -335,11 +376,13 @@ void SkiaCanvas::save_layer_with_mask(float x, float y, float w, float h,
     sk_sp<SkShader> mask_shader;
     if (mask_image.find("linear-gradient(") != std::string::npos) {
         mask_shader = parse_linear_gradient_mask(mask_image, x, y, scaled_w, scaled_h);
+    } else if (mask_image.find("url(") != std::string::npos) {
+        mask_shader = parse_url_image_mask(mask_image, x, y, scaled_w, scaled_h);
     }
-    // Other forms (radial-gradient / url / none / unparseable) drop to
-    // the no-mask path: the layer opens with content opacity, restore()
-    // sees no pending mask shader and just closes plainly. Net behavior
-    // = pre-#1737 (no mask applied) — safe regression-free fallback.
+    // Other forms (radial-gradient / none / unparseable) drop to the
+    // no-mask path: the layer opens with content opacity, restore() sees
+    // no pending mask shader and just closes plainly. Net behavior =
+    // pre-#1737 (no mask applied) — safe regression-free fallback.
 
     SkRect bounds = SkRect::MakeXYWH(x, y, w, h);
     SkPaint outer_paint;

--- a/core/view/include/pulp/view/css_gradient.hpp
+++ b/core/view/include/pulp/view/css_gradient.hpp
@@ -17,6 +17,12 @@ class View;
 /// colors continue to resolve there.
 using CssColorParser = std::function<canvas::Color(const std::string&)>;
 
+/// The built-in CSS color parser: `#RGB` / `#RRGGBB` / `#RRGGBBAA`, `rgb()`,
+/// `rgba()`, and `transparent`. Returned opaque white on an unrecognized token.
+/// Exposed so other import lanes (e.g. the materializer's hairline-stroke path)
+/// can resolve `rgba(...)` strokes that `parse_hex_color` does not cover.
+canvas::Color parse_css_color(const std::string& token);
+
 /// Parse a CSS `linear-gradient(...)`, `radial-gradient(...)`, or
 /// `conic-gradient(...)` string and apply it to `v`'s background via the
 /// View::set_background_gradient_* API. Returns true iff a gradient was

--- a/core/view/include/pulp/view/widgets.hpp
+++ b/core/view/include/pulp/view/widgets.hpp
@@ -920,6 +920,23 @@ public:
     void set_image_cache(ImageCache* cache) { cache_ = cache; }
     ImageCache* image_cache() const { return cache_; }
 
+    /// Value-driven silhouette fill (design-import shape-fill, e.g. ELYSIUM's
+    /// prism / cube / cylinder illustrations). When `value` is in [0,1], paint()
+    /// overlays `fill_color` from the bottom up to `value` of the height, masked
+    /// to this image's own alpha silhouette via the canvas url() mask — so the
+    /// shape "fills" with color as the bound value rises. A negative value (the
+    /// default) disables the overlay and the image renders plainly.
+    void set_fill_value(float value) {
+        fill_value_ = value;
+        request_repaint();
+    }
+    float fill_value() const { return fill_value_; }
+    void set_fill_color(canvas::Color color) {
+        fill_color_ = color;
+        request_repaint();
+    }
+    bool has_fill() const { return fill_value_ >= 0.0f; }
+
     void paint(canvas::Canvas& canvas) override;
 
 private:
@@ -927,6 +944,8 @@ private:
     bool loaded_ = false;
     std::vector<uint8_t> cached_data_;  // File bytes cached after first successful load
     ImageCache* cache_ = nullptr;       // optional; owned externally
+    float fill_value_ = -1.0f;          // <0 disables the silhouette fill overlay
+    canvas::Color fill_color_ = canvas::Color::rgba(0.49f, 0.42f, 1.0f, 0.55f);
 };
 
 // ── Meter ────────────────────────────────────────────────────────────────────

--- a/core/view/src/css_gradient.cpp
+++ b/core/view/src/css_gradient.cpp
@@ -14,12 +14,11 @@
 // UI does. See core/view/src/widget_bridge.cpp (setBackgroundGradient), which
 // now delegates here.
 namespace pulp::view {
-namespace {
 
 // Built-in CSS color parser: #RGB / #RRGGBB / #RRGGBBAA, rgb(), rgba(),
 // `transparent`. Mirrors WidgetBridge's parseColor minus named colors (the
-// bridge passes its own parser to cover those).
-canvas::Color default_parse_color(const std::string& str) {
+// bridge passes its own parser to cover those). Exported via css_gradient.hpp.
+canvas::Color parse_css_color(const std::string& str) {
     canvas::Color c = canvas::Color::rgba(1.0f, 1.0f, 1.0f, 1.0f);
     if (str.empty()) return c;
     if (str == "transparent") return canvas::Color::rgba(0.0f, 0.0f, 0.0f, 0.0f);
@@ -61,6 +60,8 @@ canvas::Color default_parse_color(const std::string& str) {
     }
     return c;
 }
+
+namespace {
 
 // Paren-aware comma split (so rgba(...) stays intact) + trailing position peel
 // (Npx / N%). Fills colors/positions in parallel.
@@ -164,7 +165,7 @@ bool apply_css_background_gradient(View& v, std::string_view css_view,
     if (gradient.empty()) return false;
     const CssColorParser color_of = parse_color
         ? parse_color
-        : CssColorParser(&default_parse_color);
+        : CssColorParser(&parse_css_color);
 
     // Simple parser for "linear-gradient(to right, color1, color2, ...)"
     if (gradient.substr(0, 16) == "linear-gradient(") {

--- a/core/view/src/design_codegen.cpp
+++ b/core/view/src/design_codegen.cpp
@@ -340,6 +340,18 @@ static void generate_node(std::ostringstream& ss, const IRNode& node,
     emit_px("maxWidth", s.max_width);
     emit_px("maxHeight", s.max_height);
 
+    // Vertically center single-line text in a slot taller than its font, so the
+    // web-compat LIVE render matches the native materializer (which applies
+    // Label::set_vertical_align(center) under the SAME rule). The shim maps
+    // style.verticalAlign → setVerticalAlign → Label, so both render paths
+    // converge on one mechanism and the screenshot-parity invariant holds.
+    // Figma reserves a tall text slot for centered text, but the IR drops
+    // textAlignVertical, so derive it from slot-vs-font. Without this the
+    // <span> top-aligns and parity diverges (control-strip fixture).
+    if (node.type == "text" && s.height && s.font_size &&
+        *s.height > *s.font_size * 1.15f)
+        ss << ind << var << ".style.verticalAlign = 'middle';\n";
+
     // Reference-free image-sizing fidelity self-check on the web-compat path
     // too (mirrors generate_native_node). The web-compat <img> emits the style
     // box directly, so the emitted geometry is exactly s.width/s.height. The

--- a/core/view/src/design_import_native_common.cpp
+++ b/core/view/src/design_import_native_common.cpp
@@ -1081,8 +1081,18 @@ void apply_layout(View& view, const IRNode& node, std::optional<LayoutDirection>
 void apply_visual_style(View& view, const IRStyle& style,
                         bool skip_border = false) {
     if (style.background_color) {
-        if (auto color = parse_hex_color(*style.background_color))
-            view.set_background_color(*color);
+        // Prefer the hex fast path; fall back to the shared CSS parser for
+        // rgb()/rgba()/transparent. Figma demotes a hairline stroke (the
+        // FILTER & EQ grid `Line`s) to a 1px frame whose fill is the stroke
+        // color — often rgba(171,171,171,0.1) — which parse_hex_color drops,
+        // leaving the grid invisible. parse_css_color resolves it.
+        auto color = parse_hex_color(*style.background_color);
+        if (!color) {
+            const std::string& bc = *style.background_color;
+            if (bc.rfind("rgb", 0) == 0 || bc == "transparent")
+                color = parse_css_color(bc);
+        }
+        if (color) view.set_background_color(*color);
     }
     // A CSS background-gradient (the light "hero" panels and the cube/prism/
     // cylinder illustration fills in real Figma imports) paints over the solid
@@ -1183,6 +1193,16 @@ void apply_label_style(Label& label, const IRStyle& style) {
     }
     if (style.white_space && lower_copy(*style.white_space) != "nowrap")
         label.set_multi_line(true);
+    // Vertically center a single-line label whose design slot is taller than its
+    // font (e.g. an 8px "SEARCH" in a 17px box, tab digits in a 20px button).
+    // Figma centers text in a fixed-height frame but the IR drops
+    // textAlignVertical, so derive it from slot-vs-font. The web-compat codegen
+    // emits the SAME rule as `verticalAlign:middle` (design_codegen.cpp), so
+    // both render paths converge on Label::set_vertical_align(center) and the
+    // screenshot-parity invariant holds. The Label default is top.
+    if (style.height && style.font_size &&
+        *style.height > *style.font_size * 1.15f)
+        label.set_vertical_align(canvas::TextVerticalAlign::center);
 }
 
 void apply_svg_paint(SvgPathWidget& path, const IRNode& node) {

--- a/core/view/src/widgets/visualizers.cpp
+++ b/core/view/src/widgets/visualizers.cpp
@@ -31,6 +31,28 @@ namespace pulp::view {
 void ImageView::paint(canvas::Canvas& canvas) {
     auto b = local_bounds();
 
+    // Value-driven silhouette fill: overlay fill_color_ from the bottom up to
+    // fill_value_ of the height, masked to this image's own alpha via the canvas
+    // url() mask, so the illustration "fills" as its bound value rises. Call
+    // after a successful image draw so the fill sits over the art.
+    auto emit_silhouette_fill = [&](const std::string& fs) {
+        if (fill_value_ < 0.0f || fs.empty()) return;
+        const float frac = std::clamp(fill_value_, 0.0f, 1.0f);
+        const float fh = b.height * frac;
+        if (fh <= 0.0f) return;
+        canvas.save_layer_with_mask(0, 0, b.width, b.height, 1.0f,
+                                    "url(" + fs + ")", "100% 100%");
+        canvas.set_fill_color(fill_color_);
+        canvas.fill_rect(0, b.height - fh, b.width, fh);
+        canvas.restore();
+    };
+    auto strip_scheme = [](std::string p) {
+        constexpr std::string_view kFile = "file://";
+        if (p.size() >= kFile.size() && p.compare(0, kFile.size(), kFile) == 0)
+            p = p.substr(kFile.size());
+        return p;
+    };
+
     if (path_.empty()) {
         // Placeholder: gray rect with "IMG" text
         canvas.set_fill_color(resolve_color("bg.surface", canvas::Color::rgba8(50, 50, 60)));
@@ -55,6 +77,7 @@ void ImageView::paint(canvas::Canvas& canvas) {
             // Skia → SkImage*) blit it; others no-op and we fall through
             // to the filename placeholder. Workstream 07 slice B4/#255.
             canvas.draw_image(decoded->native_handle, 0, 0, b.width, b.height);
+            emit_silhouette_fill(strip_scheme(path_));
             return;
         }
     }
@@ -249,10 +272,15 @@ void ImageView::paint(canvas::Canvas& canvas) {
             drawn = canvas.draw_image_from_file(
                 fs_path, dst.x, dst.y, dst.width, dst.height);
         }
-        if (drawn) { loaded_ = true; return; }
+        if (drawn) {
+            loaded_ = true;
+            emit_silhouette_fill(fs_path);
+            return;
+        }
     } else if (!fs_path.empty() &&
                canvas.draw_image_from_file(fs_path, 0, 0, b.width, b.height)) {
         loaded_ = true;
+        emit_silhouette_fill(fs_path);
         return;
     }
 

--- a/examples/elysium-standalone/main.cpp
+++ b/examples/elysium-standalone/main.cpp
@@ -14,7 +14,12 @@
 //   pulp-elysium-standalone --screenshot=out.png  # headless capture
 #include <pulp/view/design_import.hpp>
 #include <pulp/view/view.hpp>
+#include <pulp/view/widgets.hpp>
 #include <pulp/view/window_host.hpp>
+
+#include <algorithm>
+#include <functional>
+#include <tuple>
 
 #include <miniz.h>
 
@@ -169,17 +174,65 @@ int main(int argc, char** argv) {
     window->set_fixed_aspect_ratio(design_w / design_h);
     window->set_close_callback([] {});
 
-    if (!screenshot_path.empty()) {
-        int frame_count = 0;
-        window->set_idle_callback([&] {
-            if (++frame_count < 6) return;  // let the GPU surface settle
-            auto png = window->capture_back_buffer_png();
-            std::ofstream out(screenshot_path, std::ios::binary);
-            out.write(reinterpret_cast<const char*>(png.data()),
-                      static_cast<std::streamsize>(png.size()));
-            window->request_close();
-        });
-    }
+    // Item 3 demo wiring: pair each upper illustration shape with its column
+    // knob, then drive the shape's value-driven silhouette fill from the knob.
+    // Turning a knob fills/empties its shape (the prism / cylinder / pentagon /
+    // cube) through the new ImageView::set_fill_value + canvas url() alpha mask.
+    // The pairing runs lazily once layout has produced real bounds.
+    struct FillPair { pulp::view::ImageView* shape; pulp::view::Knob* knob; };
+    auto fill_pairs = std::make_shared<std::vector<FillPair>>();
+    auto wired = std::make_shared<bool>(false);
+    auto wire_fills = [root = root.get(), design_h, fill_pairs]() -> bool {
+        std::vector<std::pair<float, pulp::view::Knob*>> knobs;
+        std::vector<std::pair<float, pulp::view::ImageView*>> shapes;
+        std::function<void(pulp::view::View*, float, float)> walk =
+            [&](pulp::view::View* v, float ox, float oy) {
+                const auto bn = v->bounds();
+                const float gx = ox + bn.x, gy = oy + bn.y;
+                if (auto* k = dynamic_cast<pulp::view::Knob*>(v)) {
+                    if (bn.width > 45.0f)  // the big column knobs, not the VALUE minis
+                        knobs.emplace_back(gx + bn.width * 0.5f, k);
+                } else if (auto* img = dynamic_cast<pulp::view::ImageView*>(v)) {
+                    if (bn.width > 50.0f && bn.height > 50.0f &&
+                        gy < design_h * 0.45f)  // the upper illustration band
+                        shapes.emplace_back(gx + bn.width * 0.5f, img);
+                }
+                for (std::size_t i = 0; i < v->child_count(); ++i)
+                    walk(v->child_at(i), gx, gy);
+            };
+        walk(root, 0.0f, 0.0f);
+        if (knobs.empty() || shapes.empty()) return false;  // layout not ready yet
+        std::sort(knobs.begin(), knobs.end(),
+                  [](auto& a, auto& b) { return a.first < b.first; });
+        std::sort(shapes.begin(), shapes.end(),
+                  [](auto& a, auto& b) { return a.first < b.first; });
+        const std::size_t n = std::min(knobs.size(), shapes.size());
+        for (std::size_t i = 0; i < n; ++i)
+            fill_pairs->push_back({shapes[i].second, knobs[i].second});
+        return !fill_pairs->empty();
+    };
+
+    int frame_count = 0;
+    const bool capture = !screenshot_path.empty();
+    window->set_idle_callback([&, fill_pairs, wired] {
+        if (!*wired) *wired = wire_fills();
+        // In headless capture mode, stagger the knob values once wired so the
+        // single shot shows clearly different fill levels; the live window
+        // instead reflects whatever the user turns the knobs to.
+        if (capture && *wired)
+            for (std::size_t i = 0; i < fill_pairs->size(); ++i)
+                (*fill_pairs)[i].knob->set_value(
+                    0.2f + 0.25f * static_cast<float>(i));
+        for (const auto& p : *fill_pairs)
+            p.shape->set_fill_value(p.knob->value());
+        if (!capture) return;
+        if (++frame_count < 6) return;  // let the GPU surface settle
+        auto png = window->capture_back_buffer_png();
+        std::ofstream out(screenshot_path, std::ios::binary);
+        out.write(reinterpret_cast<const char*>(png.data()),
+                  static_cast<std::streamsize>(png.size()));
+        window->request_close();
+    });
 
     window->run_event_loop();
     return 0;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5038,6 +5038,16 @@ target_link_libraries(pulp-test-design-import-screenshot-parity
 catch_discover_tests(pulp-test-design-import-screenshot-parity
     PROPERTIES LABELS "parser-import")
 
+# Value-driven silhouette fill (design-import shape-fill — item 3): exercises
+# ImageView::set_fill_value + the canvas url() image mask on the Skia raster
+# backend (no GPU window).
+add_executable(pulp-test-image-view-fill
+    test_image_view_fill.cpp)
+target_link_libraries(pulp-test-image-view-fill
+    PRIVATE pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-image-view-fill
+    PROPERTIES LABELS "view")
+
 # P5-3 follow-up — W3C Design Tokens cluster extracted from
 # test_design_import.cpp. Covers parse_w3c_tokens, export_w3c_tokens,
 # composite typography/shadow shapes, alias resolution, math

--- a/test/test_design_import_native_materializer.cpp
+++ b/test/test_design_import_native_materializer.cpp
@@ -740,6 +740,33 @@ TEST_CASE("baked native materializer reproduces the design's captured knob point
     CHECK(k->captured_indicator_r_in() == Catch::Approx(0.604f));
 }
 
+TEST_CASE("imported text vertically centers in a slot taller than its line",
+          "[view][import][native-materializer][text]") {
+    // Figma centers text in a fixed-height frame, but the IR carries no
+    // textAlignVertical. A single-line label given a slot taller than its font
+    // (e.g. an 8px "SEARCH" in a 17px box) must center; a tight box stays top.
+    // The web-compat codegen emits verticalAlign:middle under the SAME rule, so
+    // the two render paths agree (screenshot-parity invariant). Label default top.
+    SECTION("tall slot → center") {
+        DesignIR ir;
+        ir.root = label("search", "SEARCH", 80.0f, 17.0f);
+        ir.root.style.font_size = 8.0f;
+        auto root = build_native_view_tree(ir, {}, {});
+        auto* lbl = dynamic_cast<Label*>(root.get());
+        REQUIRE(lbl != nullptr);
+        REQUIRE(lbl->vertical_align() == pulp::canvas::TextVerticalAlign::center);
+    }
+    SECTION("tight slot → top (unchanged)") {
+        DesignIR ir;
+        ir.root = label("tight", "Hz", 40.0f, 9.0f);
+        ir.root.style.font_size = 8.0f;  // 9 <= 8 * 1.15 → not centered
+        auto root = build_native_view_tree(ir, {}, {});
+        auto* lbl = dynamic_cast<Label*>(root.get());
+        REQUIRE(lbl != nullptr);
+        REQUIRE(lbl->vertical_align() == pulp::canvas::TextVerticalAlign::top);
+    }
+}
+
 TEST_CASE("rasterized-vector image does not redraw its baked stroke as a box border",
           "[view][import][native-materializer][image][fidelity]") {
     // A Figma vector exported as a PNG carries its stroke as border_color /
@@ -768,6 +795,28 @@ TEST_CASE("rasterized-vector image does not redraw its baked stroke as a box bor
     auto* image = dynamic_cast<ImageView*>(root.get());
     REQUIRE(image != nullptr);
     CHECK(image->border_width() == Catch::Approx(0.0f));
+}
+
+TEST_CASE("baked native materializer resolves an rgba() background color",
+          "[view][import][native-materializer][color]") {
+    // Figma demotes a hairline stroke (the FILTER & EQ grid Line images) to a
+    // 1px frame whose fill is the stroke color — typically rgba(171,171,171,0.1).
+    // parse_hex_color drops rgba(), so the grid painted nothing; apply_visual_style
+    // now falls back to the shared CSS color parser. Without this the EQ grid
+    // (and any rgba fill) is invisible.
+    DesignIR ir;
+    ir.root.type = "frame";
+    ir.root.stable_anchor_id = "grid-line";
+    ir.root.style.width = 177.0f;
+    ir.root.style.height = 1.0f;
+    ir.root.style.background_color = "rgba(171, 171, 171, 0.1)";
+
+    auto root = build_native_view_tree(ir, {}, {});
+    REQUIRE(root != nullptr);
+    REQUIRE(root->has_background_color());
+    const auto c = root->background_color();
+    CHECK(c.r == Catch::Approx(171.0f / 255.0f).margin(0.01f));
+    CHECK(c.a == Catch::Approx(0.1f).margin(0.01f));
 }
 
 TEST_CASE("hoist_captured_art_knobs promotes a body disc + pointer to an interactive skin",

--- a/test/test_image_view_fill.cpp
+++ b/test/test_image_view_fill.cpp
@@ -1,0 +1,82 @@
+// Value-driven silhouette fill (design-import shape-fill — item 3).
+//
+// ImageView::set_fill_value() overlays a color from the bottom up to `value`
+// of the height, masked to the image's own alpha via the canvas url() mask
+// (SkiaCanvas::save_layer_with_mask). This exercises the full path on the Skia
+// raster backend (no GPU window needed): set_fill_value -> save_layer_with_mask
+// "url(<file>)" -> fill_rect -> restore. We assert the fill visibly changes the
+// render and scales with the value.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/view/screenshot.hpp>
+#include <pulp/view/screenshot_compare.hpp>
+#include <pulp/view/widgets.hpp>
+
+#include <cstdlib>
+#include <memory>
+#include <string>
+
+using namespace pulp::view;
+
+namespace {
+
+std::string tmp_path(const char* name) {
+    const char* dir = std::getenv("TMPDIR");
+    std::string base = dir && *dir ? dir : "/tmp/";
+    if (base.back() != '/') base.push_back('/');
+    return base + name;
+}
+
+// Render a plain opaque box to a PNG to use as the ImageView source. The fill
+// masks to the image's alpha; an opaque box gives a full-box silhouette, which
+// is enough to prove the fill overlays and scales (alpha-shaped clipping is the
+// Skia mask's job, shared with the gradient-mask path).
+std::string make_source_image() {
+    auto box = std::make_unique<View>();
+    box->set_background_color(Color::rgba8(210, 90, 90));
+    std::string path = tmp_path("pulp-fill-source.png");
+    render_to_file(*box, 48, 48, path, 1.0f, ScreenshotBackend::skia);
+    return path;
+}
+
+std::vector<uint8_t> render_fill(const std::string& img, float value,
+                                 const std::string& dump = "") {
+    auto view = std::make_unique<ImageView>();
+    view->set_image_path(img);
+    if (value >= 0.0f) {
+        view->set_fill_value(value);
+        view->set_fill_color(Color::rgba(0.2f, 0.45f, 1.0f, 0.85f));
+    }
+    if (!dump.empty())
+        render_to_file(*view, 48, 48, dump, 1.0f, ScreenshotBackend::skia);
+    return render_to_png(*view, 48, 48, 1.0f, ScreenshotBackend::skia);
+}
+
+}  // namespace
+
+TEST_CASE("ImageView value-driven silhouette fill scales with value",
+          "[view][image][fill]") {
+    const std::string img = make_source_image();
+    auto base = render_fill(img, -1.0f);  // fill disabled
+    if (base.empty()) {
+        SKIP("Skia raster screenshot backend unavailable on this platform");
+    }
+
+    auto half = render_fill(img, 0.5f, tmp_path("pulp-fill-half.png"));
+    auto full = render_fill(img, 1.0f, tmp_path("pulp-fill-full.png"));
+    REQUIRE_FALSE(half.empty());
+    REQUIRE_FALSE(full.empty());
+
+    // The fill must visibly change the render vs. the un-filled baseline...
+    const auto base_vs_half = compare_screenshots(base, half);
+    const auto base_vs_full = compare_screenshots(base, full);
+    REQUIRE(base_vs_half.valid);
+    REQUIRE(base_vs_full.valid);
+    CHECK(base_vs_half.similarity < 0.99f);
+    CHECK(base_vs_full.similarity < 0.99f);
+
+    // ...and a fuller fill must diverge from the baseline MORE than a half fill
+    // (the overlay covers a larger fraction of the box as the value rises).
+    CHECK(base_vs_full.similarity < base_vs_half.similarity);
+}


### PR DESCRIPTION
Round 2 of the ELYSIUM import-fidelity work — three items, each tested.

## Item 4 — text vertical centering (BOTH render paths)
The IR drops Figma's `textAlignVertical`, so single-line labels in a taller slot rode the top of their box (ELYSIUM `SEARCH`, the `1·2·3·4` tabs). Fixed in **both** paths so the screenshot-parity invariant holds: the native materializer sets `Label::set_vertical_align(center)` and the web-compat DOM codegen emits `span.style.verticalAlign = 'middle'` under the same `height > font_size*1.15` rule — both converge on one `Label` mechanism. (A native-only fix diverged the `control-strip` fixture to 0.95 < 0.97; that's why round 1 deferred it.)

## Item 2b — FILTER & EQ background grid
The grid `Line` nodes are demoted upstream to 1px frames whose fill is the stroke color, usually `rgba(171,171,171,0.1)`. `apply_visual_style` resolved `background_color` with `parse_hex_color`, which drops `rgba()`, so the grid was invisible. It now falls back to the shared `parse_css_color` (exported from `css_gradient.hpp`).

## Item 3 — value-driven silhouette fill (new capability)
An illustration PNG (prism / cylinder / pentagon / cube) "fills" with color to a bound value:
- **Canvas:** `SkiaCanvas::save_layer_with_mask` gains a `url(<file>)` image-mask branch (`parse_url_image_mask`) — Phase 1 had shipped only gradient masks. Decodes the file to an `SkImage`, builds a kDecal shader scaled to the mask box; the kDstIn composite keeps painted content only where the image alpha is non-zero (arbitrary-silhouette clip). Works on Skia raster and Graphite/GPU.
- **ImageView:** `set_fill_value(0..1)` + `set_fill_color` overlay the color from the bottom up to `value` of the height, masked to the image's own alpha.
- **elysium-standalone:** pairs each upper illustration with its column knob and drives the fill from the knob, so turning a knob fills/empties its shape. (The knob→shape binding is undefined in the figma source, so the import doesn't auto-wire it — the example demonstrates the capability.)

## Verification
- `[text]`, `[color]` in `pulp-test-design-import-native-materializer`; screenshot-parity (130) green.
- `[view][image][fill]` in `pulp-test-image-view-fill` renders the fill at 0.5 / 1.0 on the **Skia raster** backend and asserts the overlay scales with value (the 0.5 dump shows top half = source color, bottom half = fill color).
- Mask/clip suites (`view-mask-overflow`, `widget-bridge-clip-mask`) and the ELYSIUM GPU harness (212) stay green.

Note: the interactive GPU standalone demo couldn't be screenshot-verified in my local session (a GPU context wedged after killing earlier headless runs — fresh processes like the harness and CI are unaffected). The fill capability itself is proven on the raster backend, which shares the same `SkiaCanvas` mask code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds value-driven silhouette fill for imported illustrations, fixes vertical text centering across both render paths, and restores the FILTER/EQ grid by correctly parsing rgba fills. Keeps screenshot parity intact.

- New Features
  - Image fill overlay: `ImageView::set_fill_value`/`set_fill_color` fills from the bottom, masked by the image’s alpha via a canvas `url(<file>)` mask; supported on Skia raster and GPU.
  - `elysium-standalone` wires each upper illustration to its column knob to demo the fill behavior.

- Bug Fixes
  - Vertically centers single-line labels when `height > font_size * 1.15` in both native and web-compat paths, fixing ELYSIUM “SEARCH” and tab digits while preserving screenshot parity.
  - FILTER/EQ grid renders again: `apply_visual_style` falls back to shared `parse_css_color` for `rgb()/rgba()/transparent` fills. Tests added for text centering, rgba background, and image fill.

<sup>Written for commit a208b9a446cd5706763c52db7811ca1d246b764a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR ships three ELYSIUM import-fidelity improvements: value-driven silhouette fill for illustration shapes (new `ImageView` fill API + Skia `url()` alpha-mask path), vertical text centering applied symmetrically to both the native materializer and web-compat codegen, and an `rgba()` fallback in `apply_visual_style` so the EQ grid's hairline strokes become visible.

- **Shape fill (item 3):** `SkiaCanvas::save_layer_with_mask` gains a `url(<file>)` branch (`parse_url_image_mask`) that builds a kDecal shader scaled to the mask box; `ImageView` exposes `set_fill_value / set_fill_color` and calls this on every successful image draw. The `elysium-standalone` demo pairs each shape with its column knob and drives the fill each frame. New `pulp-test-image-view-fill` test validates on the Skia raster backend.
- **Text centering (item 4):** `apply_label_style` and `design_codegen.cpp` apply the same `height > font_size * 1.15` rule so both baked-native and web-compat live paths converge on `Label::set_vertical_align(center)`, keeping the screenshot-parity invariant intact.
- **EQ grid rgba() fix (item 2b):** `apply_visual_style` now falls through from `parse_hex_color` to `parse_css_color` (newly exported from `css_gradient.cpp`) when the background color starts with `rgb`/`rgba` or equals `transparent`.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; all three fixes are well-targeted and backed by new tests. The main things to track are the per-frame disk read in the mask path (benign in CI but measurable in the interactive demo) and the ELYSIUM-specific default fill color in the public ImageView API.

The correctness fixes (rgba() color parsing, text centering, Skia matrix math) are solid and each accompanied by a targeted test. The only open gaps are quality/API-design concerns: the mask image is re-read from disk on every paint, and the default fill color is an ELYSIUM-specific purple that will surprise other ImageView consumers.

core/view/include/pulp/view/widgets.hpp (default fill_color_ and missing getter) and core/canvas/src/skia_canvas_mask.cpp (per-frame SkData::MakeFromFileName call)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| core/canvas/src/skia_canvas_mask.cpp | Adds parse_url_image_mask to decode a PNG as an alpha-mask shader for the kDstIn composite; matrix ordering is correct (T(x,y)·S(w/iw, h/ih) maps texture→canvas), but the function reads the file from disk via SkData::MakeFromFileName on every invocation with no caching. |
| core/view/src/widgets/visualizers.cpp | Adds emit_silhouette_fill lambda and hooks it into all three image-draw return paths; correctly strips the file:// scheme before passing to the url() mask. The strip_scheme call is redundant (parse_url_image_mask also strips it) but harmless. |
| core/view/include/pulp/view/widgets.hpp | Adds fill API (set_fill_value / fill_value / set_fill_color / has_fill) to ImageView; default fill_color_ is ELYSIUM-specific purple rgba(0.49,0.42,1,0.55), and there is no fill_color() getter to complete the read/write symmetry. |
| core/view/src/design_import_native_common.cpp | Two fixes: rgba() background-color now falls back to parse_css_color when parse_hex_color returns nullopt; apply_label_style vertically centers labels with height > font_size * 1.15. Both match the codegen rule in design_codegen.cpp. |
| core/view/src/design_codegen.cpp | Emits style.verticalAlign = 'middle' for text nodes where height > font_size * 1.15, matching the native materializer rule exactly so both render paths converge. |
| test/test_image_view_fill.cpp | New test exercises the full set_fill_value → save_layer_with_mask url() path on the Skia raster backend; asserts fill changes render and that a fuller fill diverges more from the baseline. |
| test/test_design_import_native_materializer.cpp | Two new test cases added: vertical centering (tall slot → center, tight slot → top) and rgba() background color resolution. Both validate the specific fixes in this PR. |
| examples/elysium-standalone/main.cpp | Adds layout-tree walk + lazy wiring to pair each Knob with an ImageView, driving fill_value from knob value each frame; uses shared_ptr for fill_pairs/wired flags to avoid dangling refs in the idle callback. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant K as Knob (value)
    participant IV as ImageView
    participant C as SkiaCanvas
    participant M as save_layer_with_mask
    participant S as parse_url_image_mask

    K->>IV: set_fill_value(v)
    IV->>IV: request_repaint()
    note over IV: paint() called

    IV->>C: draw_image_from_file(path, ...)
    C-->>IV: "drawn=true"
    IV->>C: save_layer_with_mask(0,0,w,h, url(path), 100% 100%)
    C->>M: dispatch url() branch
    M->>S: parse_url_image_mask(path, x, y, w, h)
    S->>S: SkData::MakeFromFileName(path)
    S->>S: SkImages::DeferredFromEncodedData(data)
    S->>S: build SkShader T(x,y) S(w/iw, h/ih) kDecal
    S-->>M: sk_sp SkShader
    M->>M: push PendingMask shader bounds
    IV->>C: set_fill_color + fill_rect(0, h-fh, w, fh)
    IV->>C: restore()
    C->>C: kDstIn composite clip fill to image alpha
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: bump versions"](https://github.com/danielraffel/pulp/commit/a208b9a446cd5706763c52db7811ca1d246b764a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35706982)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->