### PR TITLE
feat(design-import): recognize Dropdown frames + Search fields by layer name

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -669,6 +669,30 @@ materializer passes `skip_border=true` for `image_view` nodes so the border is
 not redrawn. If you add a code path that materializes images, keep that guard.
 Test: `[image][fidelity]` in `pulp-test-design-import-native-materializer`.
 
+### Widget recognition by Figma layer NAME (dropdowns, search field)
+
+Some interactive widgets are recognized by the designer's layer **name**, not the
+node type — designers label these containers explicitly, so the name is a
+source-honest signal (no content guessing). `kind_from_name` in
+`design_import_native_common.cpp` runs in `resolve_node` AFTER audio-widget
+detection and BEFORE `kind_from_type`:
+- A `frame` named `Dropdown` that carries a text descendant → `combo_box` (a
+  `ComboBox`). The text child is the selected value; the figma source has no
+  option list, so stub options are added to demonstrate the popup. `combo_box`
+  is a **leaf** in `materialize_node` (the captured text + chevron children are
+  NOT materialized — the ComboBox paints its own display) and owns its hits.
+- A `text` node named `Search` / `SearchBox` → `text_editor` (editable, tappable,
+  caret on focus, keyboard on mobile). The visible text becomes the placeholder
+  (`make_widget` text_editor falls back to `node.text_content` when no explicit
+  placeholder). Replaces the static Label it would otherwise be.
+
+**Web-compat parity caveat:** this recognition is NATIVE-only — the web-compat
+codegen does not detect these names. The screenshot-parity fixtures contain no
+`Dropdown`/`Search` nodes, so the invariant holds today; if you add one to a
+parity fixture, mirror the detection in the codegen (same lesson as the text
+vertical-centering split). Tests: `[combo-box]`, `[text-editor]` in
+`pulp-test-design-import-native-materializer`.
+
 ### Value-driven silhouette fill (illustration shapes — item 3)
 
 A captured illustration PNG (ELYSIUM's prism / cylinder / pentagon / cube) can

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.175.0",
+      "version": "0.176.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.175.0"
+  "version": "0.176.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.175.0",
+  "version": "0.176.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.338.0
+    VERSION 0.339.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/design_import_native_common.cpp
+++ b/core/view/src/design_import_native_common.cpp
@@ -9,6 +9,7 @@
 #include <pulp/view/text_editor.hpp>
 #include <pulp/view/view.hpp>
 #include <pulp/view/widgets.hpp>
+#include <pulp/view/ui_components.hpp>
 #include <pulp/view/widgets/svg_line.hpp>
 #include <pulp/view/widgets/svg_rect.hpp>
 
@@ -551,12 +552,42 @@ void append_unsupported_property_diagnostics(const IRNode& node,
     }
 }
 
+// The first non-empty text content anywhere under `node` (a dropdown's selected
+// value, a search field's placeholder).
+std::optional<std::string> first_text_descendant(const IRNode& node) {
+    for (const auto& c : node.children)
+        if (lower_copy(c.type) == "text" && !c.text_content.empty())
+            return c.text_content;
+    for (const auto& c : node.children)
+        if (auto t = first_text_descendant(c)) return t;
+    return std::nullopt;
+}
+
+// Design-import widget recognition by Figma layer name. Designers label these
+// containers explicitly (ELYSIUM's FX RACK "Dropdown" frames, the "Search"
+// field), so the name is a reliable, source-honest signal — no content
+// guessing. Returns nullopt when the node is not one of these.
+std::optional<NativeWidgetKind> kind_from_name(const IRNode& node) {
+    const auto name = lower_copy(node.name);
+    const auto type = lower_copy(node.type);
+    // A "Dropdown" frame that actually carries a text value → ComboBox.
+    if (type == "frame" && name == "dropdown" && first_text_descendant(node))
+        return NativeWidgetKind::combo_box;
+    // A "Search" text field → an editable TextEditor (tappable, caret, keyboard).
+    if (type == "text" &&
+        (name == "search" || name == "searchbox" || name == "search field"))
+        return NativeWidgetKind::text_editor;
+    return std::nullopt;
+}
+
 ResolvedNativeNode resolve_node(const IRNode& node,
                                 std::string_view path,
                                 const AssetIndex& assets) {
     ResolvedNativeNode out;
     if (auto audio_kind = kind_from_audio(node.audio_widget)) {
         out.kind = *audio_kind;
+    } else if (auto name_kind = kind_from_name(node)) {
+        out.kind = *name_kind;
     } else if (auto type_kind = kind_from_type(node, path, out.diagnostics)) {
         out.kind = *type_kind;
     } else {
@@ -897,6 +928,7 @@ bool is_interactive_native_kind(NativeWidgetKind kind) {
         case NativeWidgetKind::text_editor:
         case NativeWidgetKind::checkbox:
         case NativeWidgetKind::toggle_button:
+        case NativeWidgetKind::combo_box:
         case NativeWidgetKind::knob:
         case NativeWidgetKind::fader:
         case NativeWidgetKind::xy_pad:
@@ -922,6 +954,7 @@ bool native_kind_owns_imported_child_hits(NativeWidgetKind kind) {
         case NativeWidgetKind::text_editor:
         case NativeWidgetKind::checkbox:
         case NativeWidgetKind::toggle_button:
+        case NativeWidgetKind::combo_box:
         case NativeWidgetKind::knob:
         case NativeWidgetKind::fader:
         case NativeWidgetKind::meter:
@@ -1295,9 +1328,27 @@ std::unique_ptr<View> make_widget(const IRNode& node,
             auto editor = std::make_unique<TextEditor>();
             if (semantics.text_placeholder)
                 editor->placeholder = *semantics.text_placeholder;
+            else if (!node.text_content.empty())
+                // A search field imported from a Figma text node: its visible
+                // text ("SEARCH") is the placeholder, replaced by a caret on tap.
+                editor->placeholder = node.text_content;
             if (semantics.text_value)
                 editor->set_text(*semantics.text_value);
             return editor;
+        }
+        case NativeWidgetKind::combo_box: {
+            // A captured "Dropdown" frame → an interactive ComboBox. Its text
+            // child is the selected value; stub options demonstrate the popup
+            // (the figma source carries no option list).
+            auto combo = std::make_unique<ComboBox>();
+            std::string selected = first_text_descendant(node).value_or(text);
+            std::vector<std::string> items;
+            if (!selected.empty()) items.push_back(selected);
+            items.push_back("Option 2");
+            items.push_back("Option 3");
+            combo->set_items(std::move(items));
+            combo->set_selected_silent(0);
+            return combo;
         }
         case NativeWidgetKind::checkbox: {
             auto checkbox = std::make_unique<Checkbox>();
@@ -1462,6 +1513,12 @@ std::unique_ptr<View> materialize_node(const IRNode& node,
     if (resolved.kind == NativeWidgetKind::image_view)
         apply_imported_image_sizing(*view, node);
 
+    // A ComboBox paints its own box + selected text + chevron, so the captured
+    // "Dropdown" frame's text/chevron children must NOT be materialized on top
+    // (they would double-render). Treat it as a leaf.
+    if (resolved.kind == NativeWidgetKind::combo_box)
+        return view;
+
     const auto count = std::min(node.children.size(), resolved.children.size());
     for (std::size_t i = 0; i < count; ++i) {
         std::ostringstream child_path;
@@ -1516,6 +1573,7 @@ const char* native_widget_kind_name(NativeWidgetKind kind) {
         case NativeWidgetKind::text_editor: return "text_editor";
         case NativeWidgetKind::checkbox: return "checkbox";
         case NativeWidgetKind::toggle_button: return "toggle_button";
+        case NativeWidgetKind::combo_box: return "combo_box";
         case NativeWidgetKind::knob: return "knob";
         case NativeWidgetKind::fader: return "fader";
         case NativeWidgetKind::meter: return "meter";

--- a/core/view/src/design_import_native_common.hpp
+++ b/core/view/src/design_import_native_common.hpp
@@ -16,6 +16,7 @@ enum class NativeWidgetKind {
     text_editor,
     checkbox,
     toggle_button,
+    combo_box,
     knob,
     fader,
     meter,

--- a/test/test_design_import_native_materializer.cpp
+++ b/test/test_design_import_native_materializer.cpp
@@ -5,7 +5,9 @@
 #include <pulp/view/design_import.hpp>
 #include <pulp/view/layout_snapshot.hpp>
 #include <pulp/view/script_engine.hpp>
+#include <pulp/view/input_events.hpp>
 #include <pulp/view/text_editor.hpp>
+#include <pulp/view/ui_components.hpp>
 #include <pulp/view/view.hpp>
 #include <pulp/view/widget_bridge.hpp>
 #include <pulp/view/widgets.hpp>
@@ -817,6 +819,71 @@ TEST_CASE("baked native materializer resolves an rgba() background color",
     const auto c = root->background_color();
     CHECK(c.r == Catch::Approx(171.0f / 255.0f).margin(0.01f));
     CHECK(c.a == Catch::Approx(0.1f).margin(0.01f));
+}
+
+TEST_CASE("baked native materializer maps a Dropdown frame to an interactive ComboBox",
+          "[view][import][native-materializer][combo-box]") {
+    // ELYSIUM's FX RACK ships explicit "Dropdown" frames (a selected-value text
+    // + a chevron image). Recognized by layer name → a functional ComboBox whose
+    // first item is the captured selection; the source has no option list, so
+    // stub options demonstrate the popup. The text/chevron children are
+    // suppressed (the ComboBox paints its own display).
+    DesignIR ir;
+    ir.root.type = "frame";
+    ir.root.stable_anchor_id = "root";
+
+    IRNode dropdown;
+    dropdown.type = "frame";
+    dropdown.name = "Dropdown";
+    dropdown.stable_anchor_id = "fx-delay";
+    IRNode value;
+    value.type = "text";
+    value.text_content = "1/4 Delay";
+    value.stable_anchor_id = "fx-delay-text";
+    IRNode chevron;
+    chevron.type = "image";
+    chevron.name = "Dropdown";
+    chevron.attributes["asset_ref"] = "chevron";
+    chevron.stable_anchor_id = "fx-delay-chevron";
+    dropdown.children.push_back(value);
+    dropdown.children.push_back(chevron);
+    ir.root.children.push_back(std::move(dropdown));
+
+    auto root = build_native_view_tree(ir, {}, {});
+    REQUIRE(root != nullptr);
+    REQUIRE(root->child_count() == 1);
+    auto* combo = dynamic_cast<ComboBox*>(root->child_at(0));
+    REQUIRE(combo != nullptr);
+    REQUIRE_FALSE(combo->items().empty());
+    CHECK(combo->items().front() == "1/4 Delay");
+    CHECK(combo->selected_text() == "1/4 Delay");
+    CHECK(combo->items().size() >= 2);           // stub options for the popup
+    CHECK(combo->child_count() == 0);            // text + chevron suppressed
+}
+
+TEST_CASE("baked native materializer maps a Search text node to an editable field",
+          "[view][import][native-materializer][text-editor]") {
+    // ELYSIUM's "Search" field should be a TAPPABLE input: the visible "SEARCH"
+    // becomes the placeholder (replaced by a caret on focus), and typing enters
+    // text — instead of a static Label.
+    DesignIR ir;
+    ir.root.type = "text";
+    ir.root.name = "Search";
+    ir.root.text_content = "SEARCH";
+    ir.root.stable_anchor_id = "search";
+
+    auto root = build_native_view_tree(ir, {}, {});
+    REQUIRE(root != nullptr);
+    auto* editor = dynamic_cast<TextEditor*>(root.get());
+    REQUIRE(editor != nullptr);
+    CHECK(editor->placeholder == "SEARCH");
+
+    // Tappable + editable: focus then type enters text over the placeholder.
+    editor->on_focus_changed(true);
+    TextInputEvent te;
+    te.text = "drums";
+    editor->on_text_input(te);
+    CHECK(editor->text() == "drums");
 }
 
 TEST_CASE("hoist_captured_art_knobs promotes a body disc + pointer to an interactive skin",


### PR DESCRIPTION
Maps two interactive widgets from the Figma design by their explicit layer name — a source-honest signal (the designer named these containers), no content guessing. `kind_from_name` runs in `resolve_node` after audio-widget detection, before `kind_from_type`.

## Dropdowns → ComboBox
A `frame` named **"Dropdown"** with a text descendant becomes a functional `ComboBox`. The captured text is the selected value; the figma source carries no option list, so stub options demonstrate the popup. It's a **leaf** in `materialize_node` (the text + chevron children aren't re-materialized — the ComboBox paints its own display) and owns its hit targets. Covers ELYSIUM's FX RACK **1/4 Delay / Reverb / Space Delay**.

## Search → editable TextEditor
A `text` node named **"Search"** becomes an editable, **tappable** `TextEditor`: the visible "SEARCH" becomes the placeholder (replaced by a caret on focus, keyboard on mobile), and typing enters text — instead of the static Label it would otherwise be.

## Notes
- **Native-only by design.** The web-compat codegen doesn't detect these names; the screenshot-parity fixtures contain no Dropdown/Search nodes, so the live↔baked invariant holds (documented in the import-design skill, same split discipline as the text-centering fix).
- The widgets render through Pulp's existing, well-tested `ComboBox` / `TextEditor` paint — the import just constructs them. (My local GPU context is wedged from earlier headless runs, so no fresh interactive screenshot this session; the functional behavior is unit-tested and CI's fresh macOS lane renders the GPU harness fine.)

## Tests
- `[combo-box]` — Dropdown → ComboBox with the selected value first, stub options for the popup, and suppressed text/chevron children.
- `[text-editor]` — Search → placeholder "SEARCH"; focus + type enters text.

Full materializer suite (329), parity (130), native-common (60), and the ELYSIUM GPU harness (212) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects Figma layer-named widgets in native design import: "Dropdown" frames become interactive `ComboBox`es and "Search" text nodes become editable `TextEditor`s. This makes ELYSIUM FX Rack dropdowns and search fields work without manual wiring.

- **New Features**
  - Map a `frame` named "Dropdown" with a text descendant to `combo_box`; first text sets the selected value, stub options populate the popup; treated as a leaf and owns hit targets.
  - Map a `text` named "Search"/"SearchBox"/"Search field" to `text_editor`; visible text becomes the placeholder and the field is tappable/editable.
  - Add `kind_from_name` in `resolve_node` after audio-widget detection and before `kind_from_type`; native-only, web codegen unchanged.

- **Dependencies**
  - Bump versions: CMake project to 0.339.0; `pulp` plugin to 0.176.0.

<sup>Written for commit 3f0e1a168ac96ad61cefdae3b085db2615ca35f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds Figma layer-name-based widget recognition for two interactive widgets: `frame` nodes named \"Dropdown\" map to functional `ComboBox` widgets (with the captured text as the selected value and two hardcoded stub options), and `text` nodes named \"Search\"/\"SearchBox\"/\"Search field\" map to editable `TextEditor` widgets (with the visible text becoming the placeholder). The recognition runs in `resolve_node` between audio-widget detection and type-based detection, and is intentionally native-only.

- `kind_from_name` is inserted cleanly into the resolution chain; the `combo_box` leaf guard in `materialize_node` correctly prevents double-rendering of the text/chevron children.
- The `else if (!node.text_content.empty())` branch added to the `text_editor` case in `make_widget` is not guarded to name-matched nodes only — it applies to every `text_editor` regardless of how it was resolved (including nodes from `kind_from_type` via \"textarea\" or \"input[type=search]\"), which silently widens the scope of this change.
</details>

<h3>Confidence Score: 4/5</h3>

The core resolution and materialization logic for both new widget types is sound; the combo_box leaf guard is correct and the tests cover the main paths.

The unguarded text_content-as-placeholder fallback in make_widget can silently change behavior for existing textarea/text_editor-typed nodes that carry text_content, expanding the scope of the change beyond what the tests exercise.

core/view/src/design_import_native_common.cpp — specifically the text_editor case in make_widget and the combo_box early-return in materialize_node

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| core/view/src/design_import_native_common.cpp | Core logic change: adds kind_from_name, first_text_descendant, combo_box leaf guard, and text_content-as-placeholder fallback; the placeholder fallback is broader than the name-matched search case and drops child diagnostics for Dropdown frames. |
| core/view/src/design_import_native_common.hpp | Adds combo_box to NativeWidgetKind enum; insertion is in the correct position and all switch sites are updated. |
| test/test_design_import_native_materializer.cpp | Two new tests cover the Dropdown to ComboBox and Search to TextEditor paths; both verify key postconditions including child suppression and placeholder/edit behavior. |
| .agents/skills/import-design/SKILL.md | Documentation updated to describe the name-based widget recognition pattern, the web-compat parity caveat, and the leaf behavior. |
| CMakeLists.txt | Version bumped from 0.338.0 to 0.339.0. |
| .claude-plugin/marketplace.json | Plugin version bumped from 0.175.0 to 0.176.0. |
| .claude-plugin/plugin.json | Plugin version bumped from 0.175.0 to 0.176.0, in sync with marketplace.json. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[IRNode] --> B{kind_from_audio?}
    B -- yes --> R[out.kind = audio kind]
    B -- no --> C{kind_from_name?}
    C -- frame named Dropdown + has text descendant --> D[out.kind = combo_box]
    C -- text named Search/SearchBox/Search field --> E[out.kind = text_editor]
    C -- no match --> F{kind_from_type?}
    F -- textarea / text_editor / input --> E
    F -- text / label --> G[out.kind = label]
    F -- other types --> H[out.kind = view/knob/fader/...]
    D --> M[materialize_node]
    E --> M
    G --> M
    H --> M
    M --> I{combo_box?}
    I -- yes --> J[make_widget: ComboBox, first_text_descendant as selected + stub options, return early - children suppressed]
    I -- no --> K{text_editor?}
    K -- yes --> L[make_widget: TextEditor, placeholder from semantics or node.text_content fallback]
    K -- no --> N[make_widget: other widget, recurse into children]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: bump versions"](https://github.com/danielraffel/pulp/commit/3f0e1a168ac96ad61cefdae3b085db2615ca35f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35713461)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->