### PR TITLE
feat(design-import): search-box field, dropdown precision, knob/dropdown polish

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -646,6 +646,15 @@ in `design_import.cpp` beside the sibling importer passes `enrich_*` /
   ticks). Pivot at the disc center + the design's own line ⇒ it rides the ticks by
   construction. **The synthetic notch is still the fallback** for knobs with no
   captured indicator metadata.
+- **Baked-indicator cover** (`Knob::paint`): many captured discs (ELYSIUM's
+  included) BAKE an indicator groove into the disc PNG at the rest/up position.
+  Our pointer rotates with value, so that baked groove lingers at 12 o'clock as a
+  second line. `Knob::paint` covers the groove's ON-FACE portion by copying a
+  clean face strip from beside it (same radius ⇒ matching gradient) before
+  drawing the pointer. **Limitation:** a baked indicator that extends ABOVE the
+  ring (onto the PNG's transparent background) can't be covered by compositing —
+  the cleanest result is an indicator-FREE disc (remove the groove in the design
+  art; our pointer already draws at the right place).
 - **Materializer skin** (`make_widget` knob branch): when the knob node carries
   an enrich-stamped `asset_path` (+ `png_natural_*`), it builds a single-frame
   `SpriteStrip` + `set_sprite_core` from `art_core_*`, then applies the captured
@@ -676,15 +685,24 @@ node type — designers label these containers explicitly, so the name is a
 source-honest signal (no content guessing). `kind_from_name` in
 `design_import_native_common.cpp` runs in `resolve_node` AFTER audio-widget
 detection and BEFORE `kind_from_type`:
-- A `frame` named `Dropdown` that carries a text descendant → `combo_box` (a
-  `ComboBox`). The text child is the selected value; the figma source has no
-  option list, so stub options are added to demonstrate the popup. `combo_box`
-  is a **leaf** in `materialize_node` (the captured text + chevron children are
-  NOT materialized — the ComboBox paints its own display) and owns its hits.
-- A `text` node named `Search` / `SearchBox` → `text_editor` (editable, tappable,
-  caret on focus, keyboard on mobile). The visible text becomes the placeholder
-  (`make_widget` text_editor falls back to `node.text_content` when no explicit
-  placeholder). Replaces the static Label it would otherwise be.
+- A `frame` named `Dropdown` → `combo_box` (a `ComboBox`) ONLY when
+  `looks_like_real_dropdown`: it carries a real selected value AND a SINGLE
+  square-ish down-chevron (aspect ≤ 1.8). The name alone over-matches — ELYSIUM
+  reuses "Dropdown" for two non-dropdowns that must stay plain frames:
+  - a prev/next preset **cycler** whose icon is a WIDE `< >` pair (e.g. the 42×16
+    "Frame 41" on the ENVELOPE/FILTER/FX-RACK headers) — leave static (faithful)
+    until a real cycler interaction exists;
+  - an unconfigured design-system **template** whose value is the literal word
+    "Dropdown" (the stray "VST Style" placeholder).
+  `combo_box` is a **leaf** in `materialize_node` (text + chevron children are NOT
+  re-materialized — the ComboBox paints its own display) and owns its hits.
+- A search field is a `frame` CONTAINER (`is_search_container`: it wraps a text
+  child named `Search`/`SearchBox`) → `text_editor` sized to the WHOLE box (not
+  the inner text cell, so the field spans the box and the placeholder isn't
+  truncated). The inner text becomes the placeholder; the editor inherits its
+  font size and a `content_inset_left` so the caret clears the leading magnifier.
+  In `materialize_node` a promoted text_editor keeps only IMAGE children (the
+  icon) and drops the placeholder text + bg-pill chrome.
 
 **Web-compat parity caveat:** this recognition is NATIVE-only — the web-compat
 codegen does not detect these names. The screenshot-parity fixtures contain no

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.176.1",
+      "version": "0.177.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.176.1"
+  "version": "0.177.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.176.1",
+  "version": "0.177.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.339.0
+    VERSION 0.340.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/text_editor.hpp
+++ b/core/view/include/pulp/view/text_editor.hpp
@@ -114,6 +114,11 @@ public:
     void set_font_size(float size) { font_size_ = size; }
     float font_size() const { return font_size_; }
 
+    /// Extra left inset (px) for the text / placeholder / caret — used to clear a
+    /// leading icon (an imported search field's magnifier). 0 = default padding.
+    void set_content_inset_left(float px) { content_inset_left_ = px; }
+    float content_inset_left() const { return content_inset_left_; }
+
     // ── IME composition (marked text) ────────────────────────────────────
 
     /// Set composition text from input method. Replaces any existing marked text.
@@ -151,6 +156,7 @@ private:
     int selection_start_ = 0;    ///< Selection anchor
     int selection_end_ = 0;      ///< Selection active end (= caret)
     float font_size_ = 13.0f;
+    float content_inset_left_ = 0.0f; ///< Extra left inset to clear a leading icon
     float scroll_offset_ = 0.0f; ///< Horizontal scroll for single-line
     float caret_blink_time_ = 0.0f; ///< Accumulated time for caret blinking
 

--- a/core/view/include/pulp/view/ui_components.hpp
+++ b/core/view/include/pulp/view/ui_components.hpp
@@ -61,6 +61,8 @@ public:
     void on_text_input(const TextInputEvent& event) override;
 
     bool is_open() const { return open_; }
+    /// Index of the row painted with the hover/keyboard highlight (-1 = none).
+    int hovered_index() const { return hover_index_; }
     float dropdown_width_hint() const;
 
     /// Close any currently open ComboBox (call before opening a new one).

--- a/core/view/src/design_import_native_common.cpp
+++ b/core/view/src/design_import_native_common.cpp
@@ -552,15 +552,55 @@ void append_unsupported_property_diagnostics(const IRNode& node,
     }
 }
 
-// The first non-empty text content anywhere under `node` (a dropdown's selected
-// value, a search field's placeholder).
-std::optional<std::string> first_text_descendant(const IRNode& node) {
+// The first text node anywhere under `node` with non-empty content (a dropdown's
+// selected value, a search field's placeholder) — returns the node for its style.
+const IRNode* first_text_descendant_node(const IRNode& node) {
     for (const auto& c : node.children)
         if (lower_copy(c.type) == "text" && !c.text_content.empty())
-            return c.text_content;
+            return &c;
     for (const auto& c : node.children)
-        if (auto t = first_text_descendant(c)) return t;
+        if (auto* t = first_text_descendant_node(c)) return t;
+    return nullptr;
+}
+
+std::optional<std::string> first_text_descendant(const IRNode& node) {
+    if (auto* t = first_text_descendant_node(node)) return t->text_content;
     return std::nullopt;
+}
+
+// True when this frame is a search field: it wraps a "Search" text (the
+// placeholder), typically with a magnifier icon and a background pill. The WHOLE
+// box becomes the input, not just the inner text cell.
+bool is_search_container(const IRNode& node) {
+    if (lower_copy(node.type) != "frame") return false;
+    for (const auto& c : node.children) {
+        const auto cn = lower_copy(c.name);
+        if (lower_copy(c.type) == "text" &&
+            (cn == "search" || cn == "searchbox" || cn == "search field"))
+            return true;
+    }
+    return false;
+}
+
+// A "Dropdown"-named frame is a REAL dropdown only when it carries a selected
+// value AND a single down-chevron. ELYSIUM reuses the "Dropdown" name for two
+// other things that must NOT become ComboBoxes:
+//   - an unconfigured design-system TEMPLATE whose value is the literal word
+//     "Dropdown" (the stray "VST Style" placeholder);
+//   - a prev/next preset CYCLER, whose icon is a WIDE "< >" pair (e.g. the
+//     42×16 "Frame 41" on the ENVELOPE/FILTER/FX-RACK headers) rather than a
+//     square down-chevron. Those stay static (faithful to the design) until a
+//     real cycler interaction exists.
+bool looks_like_real_dropdown(const IRNode& node) {
+    const auto value = first_text_descendant(node);
+    if (!value || lower_copy(*value) == "dropdown") return false;
+    for (const auto& c : node.children) {
+        if (lower_copy(c.type) != "image") continue;
+        const float w = c.style.width.value_or(0.0f);
+        const float h = c.style.height.value_or(0.0f);
+        if (w > 0.0f && h > 0.0f && w / h <= 1.8f) return true;  // square chevron
+    }
+    return false;
 }
 
 // Design-import widget recognition by Figma layer name. Designers label these
@@ -570,12 +610,12 @@ std::optional<std::string> first_text_descendant(const IRNode& node) {
 std::optional<NativeWidgetKind> kind_from_name(const IRNode& node) {
     const auto name = lower_copy(node.name);
     const auto type = lower_copy(node.type);
-    // A "Dropdown" frame that actually carries a text value → ComboBox.
-    if (type == "frame" && name == "dropdown" && first_text_descendant(node))
+    if (type == "frame" && name == "dropdown" && looks_like_real_dropdown(node))
         return NativeWidgetKind::combo_box;
-    // A "Search" text field → an editable TextEditor (tappable, caret, keyboard).
-    if (type == "text" &&
-        (name == "search" || name == "searchbox" || name == "search field"))
+    // A search field → an editable TextEditor sized to the whole box. Promote
+    // the CONTAINER (not the inner text cell) so the field spans the box and the
+    // placeholder isn't truncated.
+    if (is_search_container(node))
         return NativeWidgetKind::text_editor;
     return std::nullopt;
 }
@@ -1326,12 +1366,25 @@ std::unique_ptr<View> make_widget(const IRNode& node,
             return std::make_unique<TextButton>(text);
         case NativeWidgetKind::text_editor: {
             auto editor = std::make_unique<TextEditor>();
-            if (semantics.text_placeholder)
+            if (semantics.text_placeholder) {
                 editor->placeholder = *semantics.text_placeholder;
-            else if (!node.text_content.empty())
-                // A search field imported from a Figma text node: its visible
-                // text ("SEARCH") is the placeholder, replaced by a caret on tap.
+            } else if (!node.text_content.empty()) {
                 editor->placeholder = node.text_content;
+            } else if (const auto* t = first_text_descendant_node(node)) {
+                // A promoted search CONTAINER: the inner "SEARCH" text is the
+                // placeholder (replaced by a caret on tap); inherit its font size.
+                editor->placeholder = t->text_content;
+                if (t->style.font_size) editor->set_font_size(*t->style.font_size);
+                // Inset the text past the leading magnifier icon (the kept image
+                // child) so the placeholder/caret don't overlap it.
+                for (const auto& c : node.children) {
+                    if (lower_copy(c.type) != "image") continue;
+                    const float right = c.style.left.value_or(0.0f) +
+                                        c.style.width.value_or(0.0f);
+                    editor->set_content_inset_left(right + 6.0f);
+                    break;
+                }
+            }
             if (semantics.text_value)
                 editor->set_text(*semantics.text_value);
             return editor;
@@ -1519,8 +1572,17 @@ std::unique_ptr<View> materialize_node(const IRNode& node,
     if (resolved.kind == NativeWidgetKind::combo_box)
         return view;
 
+    // A promoted search CONTAINER → a TextEditor that paints its own box +
+    // placeholder. Keep only IMAGE children (the magnifier icon, an overlay);
+    // drop the placeholder text + background-pill chrome the editor replaces.
+    const bool editor_keeps_images_only =
+        resolved.kind == NativeWidgetKind::text_editor && !node.children.empty();
+
     const auto count = std::min(node.children.size(), resolved.children.size());
     for (std::size_t i = 0; i < count; ++i) {
+        if (editor_keeps_images_only &&
+            resolved.children[i].kind != NativeWidgetKind::image_view)
+            continue;
         std::ostringstream child_path;
         child_path << path << "/children[" << i << "]";
         auto child = materialize_node(node.children[i],

--- a/core/view/src/text_editor.cpp
+++ b/core/view/src/text_editor.cpp
@@ -612,8 +612,9 @@ void TextEditor::paint(canvas::Canvas& canvas) {
     }
 
     const float text_pad_x = std::max(9.0f, border_width() + 7.0f);
-    const float text_inner_x = b.x + text_pad_x;
-    const float text_inner_w = std::max(0.0f, b.width - text_pad_x * 2.0f);
+    const float left_pad = std::max(text_pad_x, content_inset_left_);
+    const float text_inner_x = b.x + left_pad;
+    const float text_inner_w = std::max(0.0f, b.width - left_pad - text_pad_x);
     const auto metrics = canvas.measure_text_full(display.empty() ? std::string("Ag") : display);
     const float text_y = b.y + std::max(0.0f, (b.height - metrics.line_height) * 0.5f) + metrics.ascent;
 
@@ -754,7 +755,8 @@ void TextEditor::paint(canvas::Canvas& canvas) {
 
 int TextEditor::char_index_at_x(float x) const {
     float char_w = font_size_ * 0.6f;
-    float text_x = std::max(9.0f, border_width() + 7.0f) - scroll_offset_;
+    float text_x = std::max(std::max(9.0f, border_width() + 7.0f),
+                            content_inset_left_) - scroll_offset_;
     int index = static_cast<int>((x - text_x) / char_w + 0.5f);
     return std::clamp(index, 0, static_cast<int>(text_.size()));
 }

--- a/core/view/src/ui_components.cpp
+++ b/core/view/src/ui_components.cpp
@@ -180,6 +180,8 @@ void ComboBox::open_dropdown() {
     close_active_popup();  // close any other open dropdown first
     set_overflow(Overflow::visible);
     open_ = true;
+    hover_index_ = selected_;  // highlight the current selection on open so
+                               // keyboard navigation has a visible starting row
     active_popup_ = this;
 }
 
@@ -230,10 +232,15 @@ bool ComboBox::on_key_event(const KeyEvent& event) {
     if (!event.is_down) return false;
     if (event.key == KeyCode::up && selected_ > 0) {
         set_selected(selected_ - 1);
+        // Keyboard navigation should move the row HIGHLIGHT too (not just the
+        // check glyph), matching mouse hover — otherwise arrowing through an
+        // open dropdown shows no highlighted row until the mouse moves over it.
+        if (open_) hover_index_ = selected_;
         return true;
     }
     if (event.key == KeyCode::down && selected_ < static_cast<int>(items_.size()) - 1) {
         set_selected(selected_ + 1);
+        if (open_) hover_index_ = selected_;
         return true;
     }
     if (event.key == KeyCode::escape && open_) {

--- a/core/view/src/widgets.cpp
+++ b/core/view/src/widgets.cpp
@@ -407,6 +407,10 @@ void Knob::paint(canvas::Canvas& canvas) {
         // sweeps within. Defaults to the layout box; the core-fit branch
         // below tightens it to the disc's actual rendered radius.
         float notch_r = std::min(b.width, b.height) * 0.5f;
+        // Rendered rect the disc PNG was drawn to (core-fit branch fills these);
+        // used to map between rendered coords and PNG pixels for the baked-groove
+        // cover below. Zero ⇒ no mapping available (skip the cover).
+        float disc_dst_x = 0.0f, disc_dst_y = 0.0f, disc_dst_w = 0.0f, disc_dst_h = 0.0f;
         if (sprite_strip_->source() == SpriteStrip::Source::image_file) {
             if (has_sprite_core()) {
                 // Core-fit: scale the WHOLE frame uniformly so its opaque core
@@ -431,6 +435,8 @@ void Knob::paint(canvas::Canvas& canvas) {
                     sprite_strip_->path(),
                     static_cast<float>(fx), static_cast<float>(fy), fw, fh,
                     dst_x, dst_y, dst_w, dst_h);
+                disc_dst_x = dst_x; disc_dst_y = dst_y;
+                disc_dst_w = dst_w; disc_dst_h = dst_h;
             } else {
                 // Legacy fallback (no recovered core): render the frame at its
                 // NATURAL logical size centered on the layout box. Figma's PNG
@@ -481,10 +487,35 @@ void Knob::paint(canvas::Canvas& canvas) {
         // get no overlay.
         if (sprite_strip_->frame_count() == 1) {
             if (has_captured_indicator_) {
-                // Reproduce the design's own pointer over the static disc.
                 float r_out = ind_r_out_ * notch_r;
                 float r_in  = ind_r_in_  * notch_r;
                 float w = std::max(1.5f, ind_width_ * notch_r);
+                // Many captured discs (e.g. ELYSIUM's) BAKE an indicator groove
+                // into the disc art at the rest/up position. Our pointer rotates
+                // with value, so that baked groove lingers at 12 o'clock as a
+                // second line. Cover it by copying a clean face strip from beside
+                // it (same radius ⇒ same gradient) before drawing our pointer.
+                if (disc_dst_w > 0.0f && disc_dst_h > 0.0f) {
+                    const float gw = std::max(4.0f, w + 5.0f);
+                    // Extend the cover slightly past the groove ends so the
+                    // baked line's anti-aliased tips don't peek out.
+                    const float cover_x = cx - gw * 0.5f;
+                    const float cover_y = cy - r_out - 2.0f;   // straight up
+                    const float cover_w = gw;
+                    const float cover_h = std::max(1.0f, (r_out - r_in) + 4.0f);
+                    // Map the cover (rendered) rect back to PNG pixels, then take
+                    // the SOURCE from just to the side (clean face at the same
+                    // radius ⇒ matching gradient). A small offset keeps it on the
+                    // same highlight band the groove sits in.
+                    const float sx = fw / disc_dst_w, sy = fh / disc_dst_h;
+                    const float src_x = fx + (cover_x - disc_dst_x) * sx + (gw + 1.0f) * sx;
+                    const float src_y = fy + (cover_y - disc_dst_y) * sy;
+                    canvas.draw_image_from_file_rect(
+                        sprite_strip_->path(),
+                        src_x, src_y, cover_w * sx, cover_h * sy,
+                        cover_x, cover_y, cover_w, cover_h);
+                }
+                // Reproduce the design's own pointer over the static disc.
                 draw_knob_captured_pointer(canvas, cx, cy, r_in, r_out, w,
                                            ind_color_, value_);
             } else {

--- a/examples/elysium-standalone/main.cpp
+++ b/examples/elysium-standalone/main.cpp
@@ -13,6 +13,7 @@
 //   pulp-elysium-standalone /path/to/scene.pulp.zip
 //   pulp-elysium-standalone --screenshot=out.png  # headless capture
 #include <pulp/view/design_import.hpp>
+#include <pulp/view/screenshot.hpp>
 #include <pulp/view/view.hpp>
 #include <pulp/view/widgets.hpp>
 #include <pulp/view/window_host.hpp>
@@ -100,16 +101,53 @@ std::string read_text_file(const fs::path& p) {
                        std::istreambuf_iterator<char>());
 }
 
+// Generic post-import wiring (NOT baked into the importer): pair each upper
+// illustration shape with its column knob by laid-out x-position, then drive the
+// shape's value-driven silhouette fill from the knob's value. This is exactly
+// the kind of customization an "after-import" step would do — the import only
+// provides the generic ImageView::set_fill_value primitive. Requires layout to
+// have run (real bounds).
+void apply_shape_knob_fills(pulp::view::View* root, float design_h) {
+    using namespace pulp::view;
+    std::vector<std::pair<float, Knob*>> knobs;
+    std::vector<std::pair<float, ImageView*>> shapes;
+    std::function<void(View*, float, float)> walk =
+        [&](View* v, float ox, float oy) {
+            const auto bn = v->bounds();
+            const float gx = ox + bn.x, gy = oy + bn.y;
+            if (auto* k = dynamic_cast<Knob*>(v)) {
+                if (bn.width > 45.0f) knobs.emplace_back(gx + bn.width * 0.5f, k);
+            } else if (auto* img = dynamic_cast<ImageView*>(v)) {
+                if (bn.width > 50.0f && bn.height > 50.0f && gy < design_h * 0.45f)
+                    shapes.emplace_back(gx + bn.width * 0.5f, img);
+            }
+            for (std::size_t i = 0; i < v->child_count(); ++i)
+                walk(v->child_at(i), gx, gy);
+        };
+    walk(root, 0.0f, 0.0f);
+    std::sort(knobs.begin(), knobs.end(),
+              [](auto& a, auto& b) { return a.first < b.first; });
+    std::sort(shapes.begin(), shapes.end(),
+              [](auto& a, auto& b) { return a.first < b.first; });
+    const std::size_t n = std::min(knobs.size(), shapes.size());
+    for (std::size_t i = 0; i < n; ++i)
+        shapes[i].second->set_fill_value(knobs[i].second->value());
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
     std::string screenshot_path;
+    std::string raster_path;  // headless Skia-raster preview (no GPU window)
     fs::path zip_path = PULP_ELYSIUM_DEFAULT_ZIP;  // committed fixture (CMake)
     for (int i = 1; i < argc; ++i) {
         const std::string arg(argv[i]);
-        constexpr std::string_view prefix = "--screenshot=";
-        if (arg.rfind(prefix, 0) == 0)
-            screenshot_path = arg.substr(prefix.size());
+        constexpr std::string_view shot = "--screenshot=";
+        constexpr std::string_view raster = "--raster=";
+        if (arg.rfind(shot, 0) == 0)
+            screenshot_path = arg.substr(shot.size());
+        else if (arg.rfind(raster, 0) == 0)
+            raster_path = arg.substr(raster.size());
         else if (!arg.empty() && arg[0] != '-')
             zip_path = arg;
     }
@@ -151,9 +189,44 @@ int main(int argc, char** argv) {
     }
     root->set_requires_gpu_host(true);
 
-    // 3) Open a GPU window (or capture a screenshot headlessly).
     const float design_w = ir.root.style.width.value_or(1000.0f);
     const float design_h = ir.root.style.height.value_or(600.0f);
+
+    // Headless Skia-RASTER preview: renders the imported tree (sprite knobs,
+    // gradients, shapes — same SkiaCanvas paint as the GPU host) to a PNG with
+    // no GPU window. Useful when no GPU surface is available; the sprite knobs
+    // still come up as the design's captured disc art.
+    if (!raster_path.empty()) {
+        // Optional --knob-value=0..1 sets every Knob (preview off-center states,
+        // e.g. to check the sprite-knob indicator at non-default angles).
+        if (const char* kv = std::getenv("PULP_KNOB_VALUE")) {
+            const float v = std::strtof(kv, nullptr);
+            std::function<void(pulp::view::View*)> set_knobs =
+                [&](pulp::view::View* n) {
+                    if (auto* k = dynamic_cast<pulp::view::Knob*>(n)) k->set_value(v);
+                    for (std::size_t i = 0; i < n->child_count(); ++i)
+                        set_knobs(n->child_at(i));
+                };
+            set_knobs(root.get());
+        }
+        // Lay out so bounds exist, then wire the shape fills to the knobs (the
+        // generic post-import customization) before rendering.
+        root->set_bounds({0, 0, design_w, design_h});
+        root->layout_children();
+        apply_shape_knob_fills(root.get(), design_h);
+        if (pulp::view::render_to_file(
+                *root, static_cast<uint32_t>(design_w),
+                static_cast<uint32_t>(design_h), raster_path, 2.0f,
+                pulp::view::ScreenshotBackend::skia)) {
+            std::cout << "wrote raster preview: " << raster_path << "\n";
+            return 0;
+        }
+        std::cerr << "raster render failed (is the Skia screenshot backend "
+                     "available?)\n";
+        return 1;
+    }
+
+    // 3) Open a GPU window (or capture a screenshot headlessly).
 
     pulp::view::WindowOptions options;
     options.title = "ELYSIUM — imported native (turn the knobs)";
@@ -174,57 +247,13 @@ int main(int argc, char** argv) {
     window->set_fixed_aspect_ratio(design_w / design_h);
     window->set_close_callback([] {});
 
-    // Item 3 demo wiring: pair each upper illustration shape with its column
-    // knob, then drive the shape's value-driven silhouette fill from the knob.
-    // Turning a knob fills/empties its shape (the prism / cylinder / pentagon /
-    // cube) through the new ImageView::set_fill_value + canvas url() alpha mask.
-    // The pairing runs lazily once layout has produced real bounds.
-    struct FillPair { pulp::view::ImageView* shape; pulp::view::Knob* knob; };
-    auto fill_pairs = std::make_shared<std::vector<FillPair>>();
-    auto wired = std::make_shared<bool>(false);
-    auto wire_fills = [root = root.get(), design_h, fill_pairs]() -> bool {
-        std::vector<std::pair<float, pulp::view::Knob*>> knobs;
-        std::vector<std::pair<float, pulp::view::ImageView*>> shapes;
-        std::function<void(pulp::view::View*, float, float)> walk =
-            [&](pulp::view::View* v, float ox, float oy) {
-                const auto bn = v->bounds();
-                const float gx = ox + bn.x, gy = oy + bn.y;
-                if (auto* k = dynamic_cast<pulp::view::Knob*>(v)) {
-                    if (bn.width > 45.0f)  // the big column knobs, not the VALUE minis
-                        knobs.emplace_back(gx + bn.width * 0.5f, k);
-                } else if (auto* img = dynamic_cast<pulp::view::ImageView*>(v)) {
-                    if (bn.width > 50.0f && bn.height > 50.0f &&
-                        gy < design_h * 0.45f)  // the upper illustration band
-                        shapes.emplace_back(gx + bn.width * 0.5f, img);
-                }
-                for (std::size_t i = 0; i < v->child_count(); ++i)
-                    walk(v->child_at(i), gx, gy);
-            };
-        walk(root, 0.0f, 0.0f);
-        if (knobs.empty() || shapes.empty()) return false;  // layout not ready yet
-        std::sort(knobs.begin(), knobs.end(),
-                  [](auto& a, auto& b) { return a.first < b.first; });
-        std::sort(shapes.begin(), shapes.end(),
-                  [](auto& a, auto& b) { return a.first < b.first; });
-        const std::size_t n = std::min(knobs.size(), shapes.size());
-        for (std::size_t i = 0; i < n; ++i)
-            fill_pairs->push_back({shapes[i].second, knobs[i].second});
-        return !fill_pairs->empty();
-    };
-
+    // Item 3 demo: each frame, drive the upper illustration shapes' value-driven
+    // silhouette fills from their column knobs (the generic post-import wiring),
+    // so turning a knob fills/empties its shape through ImageView::set_fill_value.
     int frame_count = 0;
     const bool capture = !screenshot_path.empty();
-    window->set_idle_callback([&, fill_pairs, wired] {
-        if (!*wired) *wired = wire_fills();
-        // In headless capture mode, stagger the knob values once wired so the
-        // single shot shows clearly different fill levels; the live window
-        // instead reflects whatever the user turns the knobs to.
-        if (capture && *wired)
-            for (std::size_t i = 0; i < fill_pairs->size(); ++i)
-                (*fill_pairs)[i].knob->set_value(
-                    0.2f + 0.25f * static_cast<float>(i));
-        for (const auto& p : *fill_pairs)
-            p.shape->set_fill_value(p.knob->value());
+    window->set_idle_callback([&] {
+        apply_shape_knob_fills(root.get(), design_h);
         if (!capture) return;
         if (++frame_count < 6) return;  // let the GPU surface settle
         auto png = window->capture_back_buffer_png();

--- a/test/test_combo_dropdown.cpp
+++ b/test/test_combo_dropdown.cpp
@@ -87,6 +87,39 @@ TEST_CASE("ComboBox: keyboard up/down changes selection", "[combo]") {
     REQUIRE(combo.selected_text() == "B");
 }
 
+TEST_CASE("ComboBox: keyboard navigation moves the row highlight while open",
+          "[combo]") {
+    ComboBox combo;
+    combo.set_bounds({0, 0, 120, 24});
+    combo.set_items({"A", "B", "C"});
+    combo.set_selected(0);
+
+    // Open the dropdown → the current selection is highlighted from the start.
+    KeyEvent enter;
+    enter.key = KeyCode::enter;
+    enter.is_down = true;
+    combo.on_key_event(enter);
+    REQUIRE(combo.is_open());
+    REQUIRE(combo.hovered_index() == 0);
+
+    // Arrowing down moves BOTH the selection (check glyph) and the highlight.
+    KeyEvent down;
+    down.key = KeyCode::down;
+    down.is_down = true;
+    combo.on_key_event(down);
+    REQUIRE(combo.selected_text() == "B");
+    REQUIRE(combo.hovered_index() == 1);
+
+    combo.on_key_event(down);
+    REQUIRE(combo.hovered_index() == 2);
+
+    KeyEvent up;
+    up.key = KeyCode::up;
+    up.is_down = true;
+    combo.on_key_event(up);
+    REQUIRE(combo.hovered_index() == 1);
+}
+
 // ── Regression: dropdown overlay click routing ───────────────────────────
 //
 // The ComboBox dropdown is a paint-only overlay (queued via

--- a/test/test_design_import_native_materializer.cpp
+++ b/test/test_design_import_native_materializer.cpp
@@ -840,10 +840,12 @@ TEST_CASE("baked native materializer maps a Dropdown frame to an interactive Com
     value.type = "text";
     value.text_content = "1/4 Delay";
     value.stable_anchor_id = "fx-delay-text";
-    IRNode chevron;
+    IRNode chevron;                  // a SQUARE down-chevron marks a real dropdown
     chevron.type = "image";
-    chevron.name = "Dropdown";
+    chevron.name = "expand_more";
     chevron.attributes["asset_ref"] = "chevron";
+    chevron.style.width = 16.0f;
+    chevron.style.height = 16.0f;
     chevron.stable_anchor_id = "fx-delay-chevron";
     dropdown.children.push_back(value);
     dropdown.children.push_back(chevron);
@@ -861,22 +863,89 @@ TEST_CASE("baked native materializer maps a Dropdown frame to an interactive Com
     CHECK(combo->child_count() == 0);            // text + chevron suppressed
 }
 
-TEST_CASE("baked native materializer maps a Search text node to an editable field",
+TEST_CASE("baked native materializer leaves prev/next cyclers and templates alone",
+          "[view][import][native-materializer][combo-box]") {
+    // Not every "Dropdown"-named frame is a dropdown. A prev/next preset CYCLER
+    // (ELYSIUM's ENVELOPE/FILTER/FX-RACK headers) uses a WIDE "< >" icon, and an
+    // unconfigured design-system TEMPLATE shows the literal word "Dropdown".
+    // Neither must become a ComboBox — they stay plain frames.
+    auto make_dropdown = [](const std::string& value_text, float icon_w,
+                            float icon_h) {
+        IRNode dd;
+        dd.type = "frame";
+        dd.name = "Dropdown";
+        dd.stable_anchor_id = "dd";
+        IRNode v;
+        v.type = "text";
+        v.text_content = value_text;
+        v.stable_anchor_id = "dd-text";
+        IRNode icon;
+        icon.type = "image";
+        icon.attributes["asset_ref"] = "icon";
+        icon.style.width = icon_w;
+        icon.style.height = icon_h;
+        icon.stable_anchor_id = "dd-icon";
+        dd.children.push_back(v);
+        dd.children.push_back(icon);
+        return dd;
+    };
+
+    SECTION("prev/next cycler (wide < > icon) stays a frame") {
+        DesignIR ir;
+        ir.root = make_dropdown("Short Plucks", 42.0f, 16.0f);  // aspect 2.6
+        auto root = build_native_view_tree(ir, {}, {});
+        REQUIRE(root != nullptr);
+        REQUIRE(dynamic_cast<ComboBox*>(root.get()) == nullptr);
+    }
+    SECTION("unconfigured template ('Dropdown' value) stays a frame") {
+        DesignIR ir;
+        ir.root = make_dropdown("Dropdown", 16.0f, 16.0f);  // square but template
+        auto root = build_native_view_tree(ir, {}, {});
+        REQUIRE(root != nullptr);
+        REQUIRE(dynamic_cast<ComboBox*>(root.get()) == nullptr);
+    }
+}
+
+TEST_CASE("baked native materializer maps a Search container to a full-box field",
           "[view][import][native-materializer][text-editor]") {
-    // ELYSIUM's "Search" field should be a TAPPABLE input: the visible "SEARCH"
-    // becomes the placeholder (replaced by a caret on focus), and typing enters
-    // text — instead of a static Label.
+    // ELYSIUM's "Search" field is a CONTAINER (a background pill + a "Search"
+    // placeholder text + a magnifier icon). The WHOLE box becomes a TAPPABLE
+    // input (not just the tiny text cell): the placeholder is "SEARCH", the icon
+    // is kept as an overlay, and the placeholder text + bg chrome are dropped.
     DesignIR ir;
-    ir.root.type = "text";
-    ir.root.name = "Search";
-    ir.root.text_content = "SEARCH";
-    ir.root.stable_anchor_id = "search";
+    ir.root.type = "frame";          // the search container (e.g. "Group 59")
+    ir.root.stable_anchor_id = "search-box";
+    ir.root.style.width = 184.0f;
+    ir.root.style.height = 26.0f;
+
+    IRNode bg;                        // background pill — dropped
+    bg.type = "frame";
+    bg.name = "Rectangle 66";
+    bg.stable_anchor_id = "search-bg";
+    IRNode placeholder;              // the placeholder text — becomes the editor's
+    placeholder.type = "text";
+    placeholder.name = "Search";
+    placeholder.text_content = "SEARCH";
+    placeholder.style.font_size = 8.0f;
+    placeholder.stable_anchor_id = "search-text";
+    IRNode icon;                     // magnifier — kept as an overlay child
+    icon.type = "image";
+    icon.name = "ic:round-search";
+    icon.attributes["asset_ref"] = "search-icon";
+    icon.style.left = 6.0f;
+    icon.style.width = 15.0f;
+    icon.stable_anchor_id = "search-icon";
+    ir.root.children.push_back(bg);
+    ir.root.children.push_back(placeholder);
+    ir.root.children.push_back(icon);
 
     auto root = build_native_view_tree(ir, {}, {});
     REQUIRE(root != nullptr);
     auto* editor = dynamic_cast<TextEditor*>(root.get());
     REQUIRE(editor != nullptr);
     CHECK(editor->placeholder == "SEARCH");
+    CHECK(editor->content_inset_left() > 15.0f);   // text cleared past the icon
+    CHECK(root->child_count() == 1);               // only the icon kept (no text/bg)
 
     // Tappable + editable: focus then type enters text over the placeholder.
     editor->on_focus_changed(true);


### PR DESCRIPTION
Round 3 of ELYSIUM import polish, from interactive testing.

## 1. Search → full-box field
Promote the search **container** (background pill + "Search" + magnifier) to one `TextEditor` sized to the whole box — the field spans the box and "SEARCH" isn't truncated to a tiny cell. The magnifier is kept as an overlay; the editor gets a `content_inset_left` (new) so the caret clears it.

## 2. Dropdown over-detection fixed (two regressions)
A "Dropdown"-named frame becomes a `ComboBox` only when it has a real value **and a single square chevron**. Excludes:
- prev/next preset **cyclers** with a wide `< >` icon (the ENVELOPE/FILTER/FX-RACK headers — now faithfully static title + chevrons, not dropdowns);
- an unconfigured "Dropdown" **template** (the stray box that was appearing between the panels).

The genuine FX RACK dropdowns (1/4 Delay, Reverb) are unaffected.

## 3. Dropdown keyboard highlight
Arrow up/down (and opening) now move the row **highlight** with the selection, matching mouse hover — not just the check glyph.

## 4. Knob baked-indicator cover
The disc PNG bakes an indicator groove at 12 o'clock; our pointer rotates away, leaving it as a second line. `Knob::paint` covers the on-face groove by copying a clean face strip from beside it. (A portion that extends *above* the ring, on the PNG's transparent background, can't be composited away — an indicator-free disc is the clean contract; documented.)

## 5. Shape fill — generic + demonstrable
`elysium-standalone` wires each illustration's value-driven fill to its column knob via a shared `apply_shape_knob_fills` (post-import customization, **not** baked into the importer), plus a `--raster` headless preview and `--knob-value` flag so the fill is visible without a GPU window.

## Tests
`[combo-box]` (real vs cycler vs template), `[text-editor]` (full-box search + icon kept), `[combo]` keyboard-highlight; materializer (335), combo (46), fill (7), parity (130), ELYSIUM GPU harness (212) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polish ELYSIUM design import and UI: the search box is now a full-width editable field, dropdowns are detected and highlighted precisely, knob discs lose the second baked indicator, and shape fills are demoable without a GPU via a headless raster preview.

- New Features
  - Promote the search container to a full-box `TextEditor`; keep the magnifier icon and add a left content inset so the caret/placeholder clear it.
  - Dropdowns now highlight the current row on open and move the highlight with up/down keys.
  - Cover baked 12 o’clock indicator grooves on sprite-knob discs to remove the lingering second line.
  - `elysium-standalone`: shared shape-to-knob fill wiring, `--raster=out.png` headless render, and optional `PULP_KNOB_VALUE=0..1` to preview knob states.

- Bug Fixes
  - Tighten dropdown recognition: only treat a “Dropdown” frame as real when it has a value and a single square chevron; exclude wide-icon cyclers and unconfigured templates.

<sup>Written for commit 42519b512c5a8751e2fbca0027c151c27c9cf841. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR delivers round 3 of ELYSIUM design-import polish across five areas: full-box search field promotion, tighter dropdown recognition, keyboard row highlight, knob baked-indicator cover, and a shared shape-fill helper with a headless raster preview mode.

- **Search field**: promotes the search container frame (not the inner text node) to a `TextEditor` sized to the whole box; keeps the magnifier as an overlay child and uses `content_inset_left_` to clear the caret past it.
- **Dropdown precision**: `looks_like_real_dropdown` gates `ComboBox` creation on a real value AND a square chevron (aspect ≤ 1.8), excluding wide cycler icons and unconfigured templates.
- **Keyboard highlight + knob cover**: `hover_index_` is now synced to `selected_` on open and on up/down; `Knob::paint` copies a clean face strip over the baked 12-o'clock groove before drawing the pointer (core-fit path only).
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are scoped to the ELYSIUM design-import path and the standalone example, with no regressions in shared widget logic.

The core widget changes (TextEditor inset, ComboBox hover sync) are correct and well-tested. The editor_keeps_images_only guard in materialize_node is slightly over-broad — it fires for any text_editor with children rather than specifically for promoted search containers — which is harmless today but could silently drop children if a second frame→text_editor path is ever added. The GPU idle callback now does a full tree walk every frame instead of using the previously cached pair list, a minor performance step-back in main.cpp.

core/view/src/design_import_native_common.cpp — the editor_keeps_images_only guard and the zero-dimension chevron edge case in looks_like_real_dropdown are worth a second look.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| core/view/src/design_import_native_common.cpp | Adds is_search_container (frame→TextEditor promotion) and looks_like_real_dropdown (aspect-ratio + value guard). The editor_keeps_images_only flag is broader than the search-container case warrants. Logic is otherwise correct and well-tested. |
| core/view/src/text_editor.cpp | Adds content_inset_left_ to paint and char_index_at_x; both use the same max(default_pad, inset) formula so click-to-caret mapping stays consistent with rendering. |
| core/view/src/ui_components.cpp | Sets hover_index_ = selected_ on open and on up/down key events so the row highlight follows keyboard navigation; straightforward and well-covered by the new combo test. |
| core/view/src/widgets.cpp | Knob::paint copies a clean face strip over the baked 12-o'clock groove before drawing the pointer. Logic is sound for the core-fit path; gracefully skipped (disc_dst_w == 0) for the legacy non-core-fit path. |
| examples/elysium-standalone/main.cpp | Extracts apply_shape_knob_fills into a shared helper (used by both raster and GPU paths) and adds --raster headless mode. The GPU idle callback now does a full tree walk every frame instead of using a cached pair list, which is a minor per-frame regression compared to the old approach. |
| test/test_combo_dropdown.cpp | New tests cover: keyboard highlight follows up/down, cycler (wide icon) stays a frame, unconfigured template stays a frame, and the full-box search container TextEditor upgrade. Coverage is thorough for the changed paths. |
| test/test_design_import_native_materializer.cpp | Updated to reflect the new search-container IR shape (frame wrapping bg + placeholder text + icon) and adds assertions for content_inset_left and child count filtering. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[IRNode in resolve_node] --> B{kind_from_name?}
    B -->|frame named Dropdown| C{looks_like_real_dropdown?}
    C -->|has real value + square chevron| D[combo_box → ComboBox]
    C -->|wide icon or 'Dropdown' value| E[plain frame]
    B -->|is_search_container frame| F[text_editor → TextEditor]
    F --> G[make_widget: find first_text_descendant_node, set placeholder + font_size + content_inset_left_]
    F --> H[materialize_node: editor_keeps_images_only, keep IMAGE children only]
    B -->|no match| I[kind_from_type / default]
    D --> J[materialize_node: combo_box is leaf, text + chevron children suppressed]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `core/view/src/design_import_native_common.cpp`, line 1260-1267 ([link](https://github.com/danielraffel/pulp/blob/42519b512c5a8751e2fbca0027c151c27c9cf841/core/view/src/design_import_native_common.cpp#L1260-L1267)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`editor_keeps_images_only` condition is broader than intended**

   The guard `resolved.kind == NativeWidgetKind::text_editor && !node.children.empty()` fires for *any* `text_editor` node that has children, not specifically for promoted search containers. Currently only `is_search_container` produces a `text_editor` from a frame (and only frames have children in the IR), so this is safe today. However, if a future caller adds another frame→`text_editor` path in `kind_from_name`, this heuristic will silently drop all non-image children for that new case too. A more precise guard — e.g., checking `lower_copy(node.type) == "frame"` or calling `is_search_container(node)` — would limit the side-effect to the case it was written for.


2. `examples/elysium-standalone/main.cpp`, line 561-562 ([link](https://github.com/danielraffel/pulp/blob/42519b512c5a8751e2fbca0027c151c27c9cf841/examples/elysium-standalone/main.cpp#L561-L562)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Per-frame tree walk replaces cached pairing**

   The old `wire_fills` ran once, stored knob/shape pointer pairs, and iterated the cached vector on every frame. The new `apply_shape_knob_fills` walks the entire view tree on every idle callback — a linear traversal each frame. For ELYSIUM's standalone app this is inconsequential, but it's a deliberate performance regression in the GPU path that wasn't present before. The raster path already calls it once after an explicit layout, so only the GPU window loop is affected. If the widget tree grows, or if this pattern is copy-pasted to production code, the per-frame walk will compound.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


3. `core/view/src/design_import_native_common.cpp`, line 190-200 ([link](https://github.com/danielraffel/pulp/blob/42519b512c5a8751e2fbca0027c151c27c9cf841/core/view/src/design_import_native_common.cpp#L190-L200)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Dropdown detection fails silently when chevron has no explicit dimensions**

   `looks_like_real_dropdown` requires `w > 0.0f && h > 0.0f` on an image child to recognise a real chevron. If a Figma export omits explicit `width`/`height` on the chevron image (using `value_or(0.0f)` gives 0), the loop exhausts all children and returns `false` — the "Dropdown"-named frame stays a plain frame, not a `ComboBox`, with no diagnostic. All current fixtures set dimensions explicitly, so this is fine today, but a silent miss here would be hard to debug when importing a new design.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["chore: bump versions"](https://github.com/danielraffel/pulp/commit/42519b512c5a8751e2fbca0027c151c27c9cf841) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35767870)</sub>

<!-- /greptile_comment -->