### PR TITLE
feat(view): headless GPU view capture + smart capture_view (P1)

### DIFF
--- a/.agents/skills/screenshot/SKILL.md
+++ b/.agents/skills/screenshot/SKILL.md
@@ -16,13 +16,27 @@ inspect the view tree and do the right thing, and **never return a silent blank*
 
 | The view tree… | …gets | Why |
 |---|---|---|
-| has a `contains_native_overlay()` subtree (a WebView / native NSView) | **refused** with a reason | A WebKit/native overlay is composited by the OS, NOT painted into the Pulp canvas — headless capture can't see it (use a real window / OS screencapture) |
+| has a `contains_native_overlay()` subtree (a WebView / native NSView) | the overlay's **in-process snapshot** (`View::capture_native_overlay_png` → e.g. WKWebView `takeSnapshot`); **refused** with a reason only if no snapshot is available | A WebKit/native overlay is composited by the OS, NOT painted into the Pulp canvas — headless raster can't see it, but a backend that exposes an in-process snapshot can still be captured |
 | has a `requires_gpu_host()` view (GPU content, custom SkSL) | the **`gpu`** path (`render_to_png_gpu`, offscreen Dawn+Skia via `HeadlessSurface`) | CPU raster does NOT render GPU-required views correctly — they come out blank/wrong |
-| neither | CPU raster (`skia`) | fast, faithful for vector + image widgets |
+| neither | CPU raster (`skia` when Skia is built, else the platform `default_backend` / a registered provider) | fast, faithful for vector + image widgets |
 
 `capture_view` returns `{png, ok, used, reason}`; a blank/essentially-empty frame
 sets `ok=false`. The CLI exits 3 (not a saved blank) on refuse/blank. This is the
 "always-capturable" contract — if a UI didn't paint, you get told, not a blank PNG.
+
+**Wrappers must opt in.** A WebView is only captured/refused correctly when the
+owning Pulp `View` actually sets `set_contains_native_overlay(true)` and overrides
+`capture_native_overlay_png()` to forward `WebViewPanel::snapshot_png()`. Without
+that flag, `auto` rasters the (blank) overlay area silently — set it on any
+wrapper that attaches a native child via `attach_native_child_view` (see
+`examples/webview-plugin` `WebViewEditorPane`).
+
+**Build gating.** The `gpu` path and `has_gpu_capture()` are compiled in only when
+Skia is present (`PULP_VIEW_HAS_GPU_CAPTURE`, gated on `PULP_HAS_SKIA` — not merely
+on the `pulp-render` target, whose `HeadlessSurface::create()` is a null stub in a
+no-Skia build). In a no-Skia build the auto raster fallback is `default_backend`
+(so a host-registered `ScreenshotProvider` handles it), not a forced `skia` that
+would return empty bytes.
 
 **When to override:** force `--backend gpu` to capture a GPU view that isn't
 flagged `requires_gpu_host()`; use `skia`/`coregraphics` for the explicit cases

--- a/.agents/skills/screenshot/SKILL.md
+++ b/.agents/skills/screenshot/SKILL.md
@@ -8,7 +8,27 @@ description: Capture faithful PNGs of Pulp view trees / imported UIs headlessly.
 Pulp has two headless capture surfaces plus the live-host capture. Picking the
 wrong one wastes time on renders that look broken but aren't.
 
-## The one rule: use the **Skia** backend for anything with images
+## Default to `capture_view` / `--backend auto` — it picks the backend for you
+
+Don't hand-pick a backend unless you have a reason. `capture_view(root, w, h,
+scale)` (`screenshot.hpp`) and the CLI default `pulp-screenshot --backend auto`
+inspect the view tree and do the right thing, and **never return a silent blank**:
+
+| The view tree… | …gets | Why |
+|---|---|---|
+| has a `contains_native_overlay()` subtree (a WebView / native NSView) | **refused** with a reason | A WebKit/native overlay is composited by the OS, NOT painted into the Pulp canvas — headless capture can't see it (use a real window / OS screencapture) |
+| has a `requires_gpu_host()` view (GPU content, custom SkSL) | the **`gpu`** path (`render_to_png_gpu`, offscreen Dawn+Skia via `HeadlessSurface`) | CPU raster does NOT render GPU-required views correctly — they come out blank/wrong |
+| neither | CPU raster (`skia`) | fast, faithful for vector + image widgets |
+
+`capture_view` returns `{png, ok, used, reason}`; a blank/essentially-empty frame
+sets `ok=false`. The CLI exits 3 (not a saved blank) on refuse/blank. This is the
+"always-capturable" contract — if a UI didn't paint, you get told, not a blank PNG.
+
+**When to override:** force `--backend gpu` to capture a GPU view that isn't
+flagged `requires_gpu_host()`; use `skia`/`coregraphics` for the explicit cases
+below. The image-compositing rule still applies to the raster backends.
+
+## The image rule (raster backends): use **Skia** for anything with images
 
 `render_to_png(root, w, h, scale, backend)`
 (`core/view/include/pulp/view/screenshot.hpp`) takes a `ScreenshotBackend`:

--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -888,3 +888,14 @@ while still giving one unified Settings panel. The standalone chrome
 - `make_standalone_editor_chrome` accesses `StandaloneEditorChrome`'s private members via a
   `friend` declaration — if you change its signature, update the friend decl to match or it
   silently loses friendship and fails to compile on the private-member access.
+
+## Headless screenshot captures native overlays
+
+`StandaloneApp::run_with_editor`'s `--screenshot` path normally reads the host's
+Skia back buffer (`capture_back_buffer_png`), which can't see an OS-composited
+**native overlay** (a WebView child view). When the editor view hosts a native
+overlay (`View::contains_native_overlay()`), the standalone now routes through
+`pulp::view::capture_view()`, which calls the overlay's
+`capture_native_overlay_png()` (e.g. `WebViewPanel::snapshot_png()` → WKWebView
+takeSnapshot) so WebView editors are self-verifiable headlessly. A plain Skia UI
+falls through to the back-buffer capture unchanged. See the `screenshot` skill.

--- a/.agents/skills/webview-ui/SKILL.md
+++ b/.agents/skills/webview-ui/SKILL.md
@@ -199,6 +199,25 @@ For Monaco specifically:
 - browser-served proof page is useful to confirm bundling, workers, and CSS
 - native-host proof is still required before claiming the bridge is working
 
+### Headless capture of a native WebView overlay
+
+A WebView is an OS-composited native child view (`attach_native_child_view`); it
+is NOT painted into the Pulp Skia canvas, so a plain headless capture
+(`render_to_png` / a host back-buffer read) of an editor that hosts one sees a
+blank where the WebView is. To make a WebView editor self-verifiable headlessly,
+the **owning Pulp `View` wrapper** must opt in:
+
+1. call `set_contains_native_overlay(true)` when it attaches the WebView, and
+2. override `capture_native_overlay_png()` to forward `WebViewPanel::snapshot_png()`
+   (macOS: WKWebView `takeSnapshot`, no screen-recording permission needed).
+
+The smart capture path (`pulp::view::capture_view` / `pulp-screenshot --backend
+auto` / standalone `--screenshot`) then returns the in-process WebView snapshot
+instead of silently rastering a blank, and **refuses with a reason** only when no
+snapshot is available. Without the flag+override, `auto` captures a blank overlay
+area silently. See `examples/webview-plugin` `WebViewEditorPane` for the pattern
+and the `screenshot` skill for the dispatch contract.
+
 ## Canvas2D bridge gotchas (when the editor is on the @pulp/react native path, NOT WebView)
 
 When porting a WebView editor to the native bridge (translating browser `<canvas>` + Canvas2D code to pulp's `canvas*` bridge globals via a JS shim like Spectr's `canvas2d-shim.ts`), several browser idioms silently break. Authoritative reference is the **`import-design` skill's "Canvas2D Bridge Gotchas" section** — see that for the full rule set with example code. Top-of-mind summary:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.356.0
+    VERSION 0.357.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -1,5 +1,6 @@
 #include <pulp/format/standalone.hpp>
 #include <pulp/format/detail/screenshot_capture.hpp>
+#include <pulp/view/screenshot.hpp>
 #include <pulp/format/detail/standalone_editor_chrome.hpp>
 #include <pulp/format/editor_ui.hpp>
 #include <pulp/format/settings_panel.hpp>
@@ -446,7 +447,20 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
         cap.delay = effective_config.screenshot_frame_delay > 0
             ? effective_config.screenshot_frame_delay : 30;
         cap.path = effective_config.screenshot_path;
-        cap.capture_fn = [host] { return host->capture_back_buffer_png(); };
+        auto* editor_view = bridge->view();
+        cap.capture_fn = [host, editor_view, w, h] {
+            // If the editor hosts a native overlay (a WebView), use its in-process
+            // snapshot (WKWebView takeSnapshot) — capture_back_buffer_png() reads the
+            // Skia back buffer and can't see an OS-composited native overlay. For a
+            // normal Skia UI, capture_view rasters via `skia`, so we fall through to
+            // the live back-buffer capture below.
+            if (editor_view) {
+                auto r = pulp::view::capture_view(*editor_view, w, h);
+                if (r.ok && r.used == pulp::view::ScreenshotBackend::default_backend)
+                    return r.png;
+            }
+            return host->capture_back_buffer_png();
+        };
         cap.close_fn   = [host] { host->request_close(); };
         cap.on_error   = [out_path = effective_config.screenshot_path](const std::string& msg) {
             runtime::log_error("Standalone: screenshot {} ({})", msg, out_path);

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -410,6 +410,9 @@ if(PULP_BUILD_WEBVIEW)
     # detector TU was compiled with.
     target_compile_definitions(pulp-view-core PUBLIC PULP_BUILD_WEBVIEW=1)
     if(APPLE AND NOT PULP_IOS)
+        # In-process WKWebView snapshot → PNG so native WebView overlays are
+        # headlessly capturable (WebViewPanel::snapshot_png()).
+        target_sources(pulp-view-core PRIVATE platform/mac/web_view_snapshot_mac.mm)
         target_link_libraries(pulp-view-core PRIVATE "-framework WebKit")
     elseif(UNIX AND NOT APPLE AND NOT ANDROID)
         find_package(PkgConfig REQUIRED)

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -316,6 +316,7 @@ target_sources(pulp-view-core PRIVATE
     src/design_import_designmd.cpp
     src/token_lock.cpp
     src/screenshot_compare.cpp
+    src/screenshot_gpu.cpp
     src/app_framework.cpp
     src/canvas_widget.cpp
     src/design_frame_view.cpp
@@ -632,6 +633,10 @@ endif()
 if(TARGET pulp-render)
     target_link_libraries(pulp-view-core PRIVATE pulp::render)
     target_link_libraries(pulp-view-script PRIVATE pulp::render)
+    # Enables the offscreen-GPU view-capture path (render_to_png_gpu / capture_view
+    # via pulp::render::HeadlessSurface) in src/screenshot_gpu.cpp. Without
+    # pulp-render the capture degrades to raster honestly (has_gpu_capture()==false).
+    target_compile_definitions(pulp-view-core PRIVATE PULP_VIEW_HAS_GPU_CAPTURE=1)
     # Slice 16 — when pulp-render is linked, WindowHost::mark_dirty() can
     # route dirty marks through a vblank-paced RenderLoop. GPU-off builds
     # (sanitizer matrix) have no pulp-render target, so mark_dirty() there

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -637,9 +637,17 @@ if(TARGET pulp-render)
     target_link_libraries(pulp-view-core PRIVATE pulp::render)
     target_link_libraries(pulp-view-script PRIVATE pulp::render)
     # Enables the offscreen-GPU view-capture path (render_to_png_gpu / capture_view
-    # via pulp::render::HeadlessSurface) in src/screenshot_gpu.cpp. Without
-    # pulp-render the capture degrades to raster honestly (has_gpu_capture()==false).
-    target_compile_definitions(pulp-view-core PRIVATE PULP_VIEW_HAS_GPU_CAPTURE=1)
+    # via pulp::render::HeadlessSurface) in src/screenshot_gpu.cpp. Gate on Skia,
+    # not merely on the pulp-render target: in a no-Skia build pulp-render still
+    # exists but HeadlessSurface::create() is compiled as the stub that always
+    # returns null, so the GPU path could never produce bytes. Defining the macro
+    # there would make has_gpu_capture() report true and suppress the honest raster
+    # fallback, ending in a no-bytes failure. Only claim GPU capture when Skia (and
+    # thus a real HeadlessSurface) is present; otherwise capture degrades to raster
+    # honestly (has_gpu_capture()==false).
+    if(PULP_HAS_SKIA)
+        target_compile_definitions(pulp-view-core PRIVATE PULP_VIEW_HAS_GPU_CAPTURE=1)
+    endif()
     # Slice 16 — when pulp-render is linked, WindowHost::mark_dirty() can
     # route dirty marks through a vblank-paced RenderLoop. GPU-off builds
     # (sanitizer matrix) have no pulp-render target, so mark_dirty() there

--- a/core/view/include/pulp/view/screenshot.hpp
+++ b/core/view/include/pulp/view/screenshot.hpp
@@ -9,9 +9,13 @@
 namespace pulp::view {
 
 enum class ScreenshotBackend {
-    default_backend,
-    coregraphics,
-    skia,
+    default_backend,  ///< Platform default raster (CoreGraphics on Apple).
+    coregraphics,     ///< Apple CoreGraphics raster.
+    skia,             ///< CPU Skia raster (SkSurfaces::Raster).
+    gpu,              ///< Offscreen GPU (Dawn + Skia via pulp::render::HeadlessSurface).
+                      ///< The ONLY backend that renders `requires_gpu_host()` views correctly.
+    auto_select,      ///< Smart dispatch (see capture_view): native-overlay → refuse;
+                      ///< requires_gpu_host → gpu; else → raster.
 };
 
 // Render a view tree to a PNG image buffer (headless, no window needed).
@@ -43,6 +47,51 @@ bool render_to_file(
     float scale = 2.0f,
     ScreenshotBackend backend = ScreenshotBackend::default_backend
 );
+
+// ── Smart, always-honest capture (the "always-capturable" must-have) ─────
+//
+// One entry point so agents/CI don't pick the wrong backend. capture_view()
+// inspects the view tree and does the right thing, and NEVER returns a silent
+// blank:
+//   1. A subtree marked `contains_native_overlay()` (a WebView / native NSView
+//      composited by the OS, not painted into the Pulp canvas) → ok=false with a
+//      reason; such overlays are invisible to headless capture (use a real
+//      window / OS screencapture).
+//   2. `requires_gpu_host()` anywhere in the tree → the `gpu` backend
+//      (HeadlessSurface, Dawn+Skia) which renders GPU content correctly.
+//   3. Otherwise → CPU raster (`skia` / platform default).
+// The captured PNG is gated by the content floor (analyze_screenshot_content):
+// a blank / clear-only frame sets ok=false with a reason. `png` may still be
+// populated when !ok so callers can save it for debugging.
+struct CaptureResult {
+    std::vector<uint8_t> png;
+    bool ok = false;
+    ScreenshotBackend used = ScreenshotBackend::default_backend;
+    std::string reason;  ///< Empty when ok; otherwise why the capture isn't trustworthy.
+};
+
+CaptureResult capture_view(
+    View& root,
+    uint32_t width,
+    uint32_t height,
+    float scale = 2.0f,
+    ScreenshotBackend backend = ScreenshotBackend::auto_select  // smart by default
+);
+
+// Render a view tree through the offscreen GPU surface (Dawn + Skia via
+// pulp::render::HeadlessSurface). Returns empty bytes if this build has no GPU
+// backend (PULP_HAS_SKIA off / no pulp-render). Unlike the raster backends,
+// this renders `requires_gpu_host()` views correctly.
+std::vector<uint8_t> render_to_png_gpu(
+    View& root,
+    uint32_t width,
+    uint32_t height,
+    float scale = 2.0f
+);
+
+// True when render_to_png_gpu can produce frames in this build (GPU backend
+// compiled in). Lets capture_view fall back honestly when GPU is unavailable.
+bool has_gpu_capture();
 
 // ── Host-registered screenshot provider (#299) ──────────────────────────
 //

--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -322,6 +322,16 @@ public:
     bool contains_native_overlay() const { return contains_native_overlay_; }
     void set_contains_native_overlay(bool v) { contains_native_overlay_ = v; }
 
+    /// When this view owns a native overlay (a WebView pane), it overrides this to
+    /// return an in-process PNG snapshot of that overlay (e.g. WKWebView
+    /// takeSnapshot). `capture_view` calls it for `contains_native_overlay()`
+    /// subtrees so even native overlays are headlessly capturable instead of
+    /// refused. Default empty = "no in-process snapshot available". Main-thread.
+    virtual std::vector<uint8_t> capture_native_overlay_png(uint32_t /*width*/,
+                                                            uint32_t /*height*/) {
+        return {};
+    }
+
     /// Mark layout as needing recalculation (auto-invalidation)
     void invalidate_layout() { layout_dirty_ = true; }
     bool layout_dirty() const { return layout_dirty_; }

--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -311,6 +311,17 @@ public:
     bool requires_gpu_host() const { return requires_gpu_host_; }
     void set_requires_gpu_host(bool v) { requires_gpu_host_ = v; }
 
+    /// True when this view (or its subtree) attaches a NATIVE child overlay — a
+    /// WebView / NSView / HWND that is composited by the OS window server, NOT
+    /// painted into the Pulp Skia canvas by `paint_all()`. Such overlays are
+    /// invisible to headless capture (`render_to_png` / `HeadlessSurface`); the
+    /// smart capture path (`capture_view`) reads this to refuse with a clear
+    /// reason instead of silently returning a blank frame. Generic on purpose —
+    /// the owning wrapper view sets it (e.g. a WebView pane), so capture does not
+    /// need to know about WebView specifically.
+    bool contains_native_overlay() const { return contains_native_overlay_; }
+    void set_contains_native_overlay(bool v) { contains_native_overlay_ = v; }
+
     /// Mark layout as needing recalculation (auto-invalidation)
     void invalidate_layout() { layout_dirty_ = true; }
     bool layout_dirty() const { return layout_dirty_; }
@@ -1466,6 +1477,7 @@ private:
     PointerEvents pointer_events_ = PointerEvents::auto_;
     bool backface_visible_ = true;
     bool requires_gpu_host_ = false;
+    bool contains_native_overlay_ = false;
     FrameClock* frame_clock_ = nullptr;
 
     // Visual properties

--- a/core/view/include/pulp/view/web_view.hpp
+++ b/core/view/include/pulp/view/web_view.hpp
@@ -172,6 +172,13 @@ public:
     // whose native child-view attach contract returns true.
     virtual NativeViewHandle native_handle() = 0;
 
+    // In-process PNG snapshot of the rendered web content (macOS: WKWebView
+    // takeSnapshot — no screen-recording permission needed). This is how a native
+    // WebView overlay becomes headlessly capturable even though it isn't painted
+    // into the Pulp Skia canvas. Returns empty bytes when unsupported / not ready.
+    // Must be called on the main thread.
+    virtual std::vector<uint8_t> snapshot_png() { return {}; }
+
     // Navigate to a URL
     virtual void navigate(const std::string& url) = 0;
 

--- a/core/view/platform/mac/web_view_snapshot_mac.mm
+++ b/core/view/platform/mac/web_view_snapshot_mac.mm
@@ -1,0 +1,69 @@
+// In-process snapshot of a native WKWebView (macOS) → PNG bytes.
+//
+// A WebView is a native NSView composited by the window server, NOT painted into
+// the Pulp Skia canvas — so render_to_png / HeadlessSurface can't see it. WebKit's
+// own `takeSnapshotWithConfiguration:completionHandler:` renders the page content
+// in-process (no screen-recording permission needed), which is exactly what we want
+// so that even WebView UIs are headlessly capturable. The async completion fires on
+// the main run loop, so we pump it (bounded) until the snapshot lands.
+//
+// Compiled only when PULP_BUILD_WEBVIEW is on (the CMake gate also links WebKit).
+
+#import <WebKit/WebKit.h>
+#import <AppKit/AppKit.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace pulp::view::detail {
+
+static WKWebView* find_wkwebview(NSView* view) {
+    if (!view) return nil;
+    if ([view isKindOfClass:[WKWebView class]]) return (WKWebView*)view;
+    for (NSView* sub in view.subviews) {
+        if (WKWebView* found = find_wkwebview(sub)) return found;
+    }
+    return nil;
+}
+
+// `ns_view_ptr` is the WebViewPanel's native_handle() (a WKWebView or its container).
+std::vector<uint8_t> web_view_snapshot_png(void* ns_view_ptr) {
+    if (!ns_view_ptr) return {};
+    @autoreleasepool {
+        NSView* view = (__bridge NSView*)ns_view_ptr;
+        WKWebView* webview = find_wkwebview(view);
+        if (!webview) return {};
+
+        __block NSImage* snapshot = nil;
+        __block bool done = false;
+        WKSnapshotConfiguration* cfg = [[WKSnapshotConfiguration alloc] init];
+        cfg.afterScreenUpdates = YES;
+        [webview takeSnapshotWithConfiguration:cfg
+                            completionHandler:^(NSImage* image, NSError* error) {
+                              (void)error;
+                              snapshot = image;
+                              done = true;
+                            }];
+
+        // Pump the main run loop until the snapshot completes (bounded ~3s). The
+        // caller must be on the main thread (WKWebView is main-thread-only).
+        NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:3.0];
+        while (!done && [deadline timeIntervalSinceNow] > 0) {
+            [[NSRunLoop currentRunLoop]
+                runMode:NSDefaultRunLoopMode
+                beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.02]];
+        }
+        if (!snapshot) return {};
+
+        CGImageRef cg = [snapshot CGImageForProposedRect:NULL context:nil hints:nil];
+        if (!cg) return {};
+        NSBitmapImageRep* rep = [[NSBitmapImageRep alloc] initWithCGImage:cg];
+        NSData* png = [rep representationUsingType:NSBitmapImageFileTypePNG
+                                        properties:@{}];
+        if (!png || png.length == 0) return {};
+        const uint8_t* bytes = static_cast<const uint8_t*>(png.bytes);
+        return std::vector<uint8_t>(bytes, bytes + png.length);
+    }
+}
+
+}  // namespace pulp::view::detail

--- a/core/view/platform/mac/web_view_snapshot_mac.mm
+++ b/core/view/platform/mac/web_view_snapshot_mac.mm
@@ -34,14 +34,34 @@ std::vector<uint8_t> web_view_snapshot_png(void* ns_view_ptr) {
         WKWebView* webview = find_wkwebview(view);
         if (!webview) return {};
 
-        __block NSImage* snapshot = nil;
+        // Convert NSImage → PNG bytes INSIDE the completion handler, while the
+        // image is still alive — this file isn't ARC, and the snapshot image is
+        // autoreleased, so holding the NSImage* past the run-loop pump would
+        // dangle. Storing plain bytes sidesteps all ObjC lifetime concerns.
+        __block std::vector<uint8_t> result;
         __block bool done = false;
         WKSnapshotConfiguration* cfg = [[WKSnapshotConfiguration alloc] init];
         cfg.afterScreenUpdates = YES;
         [webview takeSnapshotWithConfiguration:cfg
                             completionHandler:^(NSImage* image, NSError* error) {
                               (void)error;
-                              snapshot = image;
+                              if (image) {
+                                  CGImageRef cg = [image CGImageForProposedRect:NULL
+                                                                        context:nil
+                                                                          hints:nil];
+                                  if (cg) {
+                                      NSBitmapImageRep* rep = [[NSBitmapImageRep alloc]
+                                          initWithCGImage:cg];
+                                      NSData* png = [rep
+                                          representationUsingType:NSBitmapImageFileTypePNG
+                                                       properties:@{}];
+                                      if (png && png.length > 0) {
+                                          const uint8_t* b =
+                                              static_cast<const uint8_t*>(png.bytes);
+                                          result.assign(b, b + png.length);
+                                      }
+                                  }
+                              }
                               done = true;
                             }];
 
@@ -53,16 +73,7 @@ std::vector<uint8_t> web_view_snapshot_png(void* ns_view_ptr) {
                 runMode:NSDefaultRunLoopMode
                 beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.02]];
         }
-        if (!snapshot) return {};
-
-        CGImageRef cg = [snapshot CGImageForProposedRect:NULL context:nil hints:nil];
-        if (!cg) return {};
-        NSBitmapImageRep* rep = [[NSBitmapImageRep alloc] initWithCGImage:cg];
-        NSData* png = [rep representationUsingType:NSBitmapImageFileTypePNG
-                                        properties:@{}];
-        if (!png || png.length == 0) return {};
-        const uint8_t* bytes = static_cast<const uint8_t*>(png.bytes);
-        return std::vector<uint8_t>(bytes, bytes + png.length);
+        return result;
     }
 }
 

--- a/core/view/src/screenshot_gpu.cpp
+++ b/core/view/src/screenshot_gpu.cpp
@@ -36,6 +36,18 @@ bool subtree_any(const View& v, Pred pred) {
     return false;
 }
 
+// First view in the tree that owns a native overlay (non-const, so we can call
+// its capture_native_overlay_png hook).
+View* find_native_overlay(View& v) {
+    if (v.contains_native_overlay()) return &v;
+    for (std::size_t i = 0; i < v.child_count(); ++i) {
+        if (View* c = v.child_at(i)) {
+            if (View* found = find_native_overlay(*c)) return found;
+        }
+    }
+    return nullptr;
+}
+
 #ifdef PULP_VIEW_HAS_GPU_CAPTURE
 // The standard headless paint sequence (mirrors render_to_png_skia): opaque
 // background, then layout + paint the tree + overlays.
@@ -85,12 +97,27 @@ CaptureResult capture_view(View& root, uint32_t width, uint32_t height, float sc
                            ScreenshotBackend backend) {
     CaptureResult r;
 
-    // 1. Native overlay (WebView / native NSView) → not headlessly capturable.
-    if (subtree_any(root, [](const View& v) { return v.contains_native_overlay(); })) {
+    // 1. Native overlay (WebView / native NSView). It isn't painted into the Pulp
+    //    canvas, so ask the owning view for an in-process snapshot (e.g. WKWebView
+    //    takeSnapshot). If one comes back non-blank we're done; only if there's no
+    //    in-process snapshot do we refuse (rather than return a silent blank).
+    if (View* overlay = find_native_overlay(root)) {
+        std::vector<uint8_t> png = overlay->capture_native_overlay_png(width, height);
+        if (!png.empty()) {
+            const ScreenshotContentStats st = analyze_screenshot_content(png);
+            r.png = std::move(png);
+            r.used = ScreenshotBackend::default_backend;  // native-overlay snapshot
+            if (st.passes_content_floor(/*colors=*/3, /*non_bg=*/0.001, /*opaque=*/0.0)) {
+                r.ok = true;
+            } else {
+                r.reason = "native-overlay (WebView) snapshot came back essentially blank";
+            }
+            return r;
+        }
         r.reason =
-            "view contains a native overlay (WebView / native child view) composited by "
-            "the OS window server, not painted into the Pulp canvas — headless capture "
-            "cannot see it; use a real window or an OS screencapture";
+            "view contains a native overlay (WebView / native child view) with no "
+            "in-process snapshot available — it's OS-composited, not on the Pulp canvas; "
+            "use a real window or an OS screencapture";
         return r;  // ok=false
     }
 

--- a/core/view/src/screenshot_gpu.cpp
+++ b/core/view/src/screenshot_gpu.cpp
@@ -120,12 +120,18 @@ CaptureResult capture_view(View& root, uint32_t width, uint32_t height, float sc
         return r;  // ok=false
     }
 
-    // 4. Content floor — a blank / clear-only frame is a hard, explained failure.
+    // 4. Content floor — catch a BLANK / essentially-empty frame, the thing that
+    //    silently passed before. Deliberately lenient: a real but sparse UI must
+    //    still pass (the strict default floor is for golden-image work, not the
+    //    "did anything paint" guard). A native-overlay blank is already refused in
+    //    step 1, so here we only reject "nothing but the background fill".
     const ScreenshotContentStats stats = analyze_screenshot_content(r.png);
-    if (!stats.passes_content_floor()) {
+    if (!stats.passes_content_floor(/*min_unique_colors=*/3,
+                                    /*min_non_background_coverage=*/0.001,
+                                    /*min_opaque_coverage=*/0.0)) {
         r.reason =
-            "captured frame failed the content floor (too few unique colors / too little "
-            "non-background coverage) — the UI almost certainly did not paint";
+            "captured frame is essentially blank (only the background fill — no widgets "
+            "painted); the UI almost certainly did not render";
         return r;  // ok=false, png retained for debugging
     }
 

--- a/core/view/src/screenshot_gpu.cpp
+++ b/core/view/src/screenshot_gpu.cpp
@@ -25,27 +25,53 @@ namespace pulp::view {
 
 namespace {
 
-// Depth-first "does any node in the tree satisfy pred".
-template <typename Pred>
-bool subtree_any(const View& v, Pred pred) {
-    if (pred(v)) return true;
-    for (std::size_t i = 0; i < v.child_count(); ++i) {
-        const View* c = v.child_at(i);
-        if (c && subtree_any(*c, pred)) return true;
-    }
-    return false;
-}
+// Single depth-first walk that collects everything capture_view needs to route a
+// tree: the first view owning a native overlay (non-const, so we can call its
+// capture_native_overlay_png hook) and whether any node requires a GPU host. One
+// pass instead of two so a large tree is walked once, not once per predicate.
+struct TreeScan {
+    View* overlay = nullptr;   ///< First native-overlay-owning view, or null.
+    bool needs_gpu = false;    ///< Any requires_gpu_host() in the subtree.
+};
 
-// First view in the tree that owns a native overlay (non-const, so we can call
-// its capture_native_overlay_png hook).
-View* find_native_overlay(View& v) {
-    if (v.contains_native_overlay()) return &v;
+void scan_tree(View& v, TreeScan& s) {
+    if (!s.overlay && v.contains_native_overlay()) s.overlay = &v;
+    if (!s.needs_gpu && v.requires_gpu_host()) s.needs_gpu = true;
+    if (s.overlay && s.needs_gpu) return;  // both answered — stop early.
     for (std::size_t i = 0; i < v.child_count(); ++i) {
         if (View* c = v.child_at(i)) {
-            if (View* found = find_native_overlay(*c)) return found;
+            scan_tree(*c, s);
+            if (s.overlay && s.needs_gpu) return;
         }
     }
-    return nullptr;
+}
+
+// The raster backend the smart path falls back to. When this build has a real
+// Skia/HeadlessSurface (PULP_VIEW_HAS_GPU_CAPTURE, gated on PULP_HAS_SKIA in
+// CMake), the `skia` CPU backend renders correctly — including file images, which
+// the macOS CoreGraphics default cannot. Without Skia we must NOT force `skia`
+// (it would return empty bytes); defer to the platform default so a host-
+// registered ScreenshotProvider can handle the capture.
+constexpr ScreenshotBackend raster_fallback() {
+#ifdef PULP_VIEW_HAS_GPU_CAPTURE
+    return ScreenshotBackend::skia;
+#else
+    return ScreenshotBackend::default_backend;
+#endif
+}
+
+// The lenient "did anything paint?" floor used by capture_view. This is NOT the
+// strict golden-image floor — a real but sparse UI (few widgets, partly
+// transparent / non-opaque background) must still pass; we only reject a frame
+// that is nothing but the background fill. NOTE: passes_content_floor's positional
+// signature is (min_unique_colors, min_luminance_stddev, min_non_background_coverage,
+// min_opaque_coverage) — all four MUST be passed explicitly, otherwise the strict
+// defaults (5% non-background, 95% opaque) silently apply and reject sparse UIs.
+bool passes_capture_floor(const ScreenshotContentStats& st) {
+    return st.passes_content_floor(/*min_unique_colors=*/3,
+                                   /*min_luminance_stddev=*/0.0,
+                                   /*min_non_background_coverage=*/0.001,
+                                   /*min_opaque_coverage=*/0.0);
 }
 
 #ifdef PULP_VIEW_HAS_GPU_CAPTURE
@@ -97,17 +123,21 @@ CaptureResult capture_view(View& root, uint32_t width, uint32_t height, float sc
                            ScreenshotBackend backend) {
     CaptureResult r;
 
+    // Walk the tree once: find any native overlay AND whether GPU is required.
+    TreeScan scan;
+    scan_tree(root, scan);
+
     // 1. Native overlay (WebView / native NSView). It isn't painted into the Pulp
     //    canvas, so ask the owning view for an in-process snapshot (e.g. WKWebView
     //    takeSnapshot). If one comes back non-blank we're done; only if there's no
     //    in-process snapshot do we refuse (rather than return a silent blank).
-    if (View* overlay = find_native_overlay(root)) {
+    if (View* overlay = scan.overlay) {
         std::vector<uint8_t> png = overlay->capture_native_overlay_png(width, height);
         if (!png.empty()) {
             const ScreenshotContentStats st = analyze_screenshot_content(png);
             r.png = std::move(png);
             r.used = ScreenshotBackend::default_backend;  // native-overlay snapshot
-            if (st.passes_content_floor(/*colors=*/3, /*non_bg=*/0.001, /*opaque=*/0.0)) {
+            if (passes_capture_floor(st)) {
                 r.ok = true;
             } else {
                 r.reason = "native-overlay (WebView) snapshot came back essentially blank";
@@ -124,15 +154,13 @@ CaptureResult capture_view(View& root, uint32_t width, uint32_t height, float sc
     // 2. Resolve the backend.
     ScreenshotBackend chosen = backend;
     if (chosen == ScreenshotBackend::auto_select) {
-        const bool needs_gpu =
-            subtree_any(root, [](const View& v) { return v.requires_gpu_host(); });
-        chosen = needs_gpu ? ScreenshotBackend::gpu : ScreenshotBackend::skia;
+        chosen = scan.needs_gpu ? ScreenshotBackend::gpu : raster_fallback();
     }
     if (chosen == ScreenshotBackend::gpu && !has_gpu_capture()) {
         runtime::log_warn(
             "capture_view: GPU backend needed but not compiled in; falling back to "
             "raster (a requires_gpu_host view may render incompletely)");
-        chosen = ScreenshotBackend::skia;
+        chosen = raster_fallback();
     }
     r.used = chosen;
 
@@ -153,9 +181,7 @@ CaptureResult capture_view(View& root, uint32_t width, uint32_t height, float sc
     //    "did anything paint" guard). A native-overlay blank is already refused in
     //    step 1, so here we only reject "nothing but the background fill".
     const ScreenshotContentStats stats = analyze_screenshot_content(r.png);
-    if (!stats.passes_content_floor(/*min_unique_colors=*/3,
-                                    /*min_non_background_coverage=*/0.001,
-                                    /*min_opaque_coverage=*/0.0)) {
+    if (!passes_capture_floor(stats)) {
         r.reason =
             "captured frame is essentially blank (only the background fill — no widgets "
             "painted); the UI almost certainly did not render";

--- a/core/view/src/screenshot_gpu.cpp
+++ b/core/view/src/screenshot_gpu.cpp
@@ -1,0 +1,136 @@
+// Smart, always-honest view capture + the offscreen-GPU capture path.
+//
+// `render_to_png_gpu` renders a View tree through pulp::render::HeadlessSurface
+// (offscreen Dawn + Skia + readback) — the only path that renders
+// `requires_gpu_host()` views correctly (CPU raster backends do not). `capture_view`
+// is the smart dispatcher: it refuses native-overlay subtrees (WebViews are composited
+// by the OS, invisible to headless capture), routes GPU-required trees to the GPU
+// backend, raster otherwise, and gates the result on the content floor so a blank /
+// clear-only frame is a hard, explained failure instead of a silent pass.
+//
+// GPU support is compiled in only when pulp-render is linked (PULP_VIEW_HAS_GPU_CAPTURE,
+// set by the CMake `if(TARGET pulp-render)` block). Otherwise the GPU path degrades to
+// "unavailable" and capture_view falls back to raster honestly.
+
+#include <pulp/view/screenshot.hpp>
+#include <pulp/view/screenshot_compare.hpp>
+#include <pulp/runtime/log.hpp>
+
+#ifdef PULP_VIEW_HAS_GPU_CAPTURE
+#include <pulp/render/headless_surface.hpp>
+#include <pulp/canvas/canvas.hpp>
+#endif
+
+namespace pulp::view {
+
+namespace {
+
+// Depth-first "does any node in the tree satisfy pred".
+template <typename Pred>
+bool subtree_any(const View& v, Pred pred) {
+    if (pred(v)) return true;
+    for (std::size_t i = 0; i < v.child_count(); ++i) {
+        const View* c = v.child_at(i);
+        if (c && subtree_any(*c, pred)) return true;
+    }
+    return false;
+}
+
+#ifdef PULP_VIEW_HAS_GPU_CAPTURE
+// The standard headless paint sequence (mirrors render_to_png_skia): opaque
+// background, then layout + paint the tree + overlays.
+void paint_root(canvas::Canvas& c, View& root, uint32_t w, uint32_t h) {
+    c.set_fill_color(canvas::Color::rgba8(30, 30, 46));
+    c.fill_rect(0, 0, static_cast<float>(w), static_cast<float>(h));
+    root.set_bounds({0, 0, static_cast<float>(w), static_cast<float>(h)});
+    root.layout_children();
+    root.paint_all(c);
+    View::paint_overlays(c, &root);
+}
+#endif
+
+}  // namespace
+
+bool has_gpu_capture() {
+#ifdef PULP_VIEW_HAS_GPU_CAPTURE
+    return true;
+#else
+    return false;
+#endif
+}
+
+std::vector<uint8_t> render_to_png_gpu(View& root, uint32_t width, uint32_t height,
+                                       float scale) {
+#ifdef PULP_VIEW_HAS_GPU_CAPTURE
+    pulp::render::HeadlessSurface::Config cfg;
+    cfg.width = width;
+    cfg.height = height;
+    cfg.scale_factor = scale;
+    std::string err;
+    auto surface = pulp::render::HeadlessSurface::create(cfg, &err);
+    if (!surface) {
+        runtime::log_warn("render_to_png_gpu: HeadlessSurface unavailable ({})",
+                          err.empty() ? "no GPU surface" : err);
+        return {};
+    }
+    return surface->render_png(
+        [&](canvas::Canvas& c) { paint_root(c, root, width, height); });
+#else
+    (void)root; (void)width; (void)height; (void)scale;
+    return {};
+#endif
+}
+
+CaptureResult capture_view(View& root, uint32_t width, uint32_t height, float scale,
+                           ScreenshotBackend backend) {
+    CaptureResult r;
+
+    // 1. Native overlay (WebView / native NSView) → not headlessly capturable.
+    if (subtree_any(root, [](const View& v) { return v.contains_native_overlay(); })) {
+        r.reason =
+            "view contains a native overlay (WebView / native child view) composited by "
+            "the OS window server, not painted into the Pulp canvas — headless capture "
+            "cannot see it; use a real window or an OS screencapture";
+        return r;  // ok=false
+    }
+
+    // 2. Resolve the backend.
+    ScreenshotBackend chosen = backend;
+    if (chosen == ScreenshotBackend::auto_select) {
+        const bool needs_gpu =
+            subtree_any(root, [](const View& v) { return v.requires_gpu_host(); });
+        chosen = needs_gpu ? ScreenshotBackend::gpu : ScreenshotBackend::skia;
+    }
+    if (chosen == ScreenshotBackend::gpu && !has_gpu_capture()) {
+        runtime::log_warn(
+            "capture_view: GPU backend needed but not compiled in; falling back to "
+            "raster (a requires_gpu_host view may render incompletely)");
+        chosen = ScreenshotBackend::skia;
+    }
+    r.used = chosen;
+
+    // 3. Render.
+    r.png = (chosen == ScreenshotBackend::gpu)
+                ? render_to_png_gpu(root, width, height, scale)
+                : render_to_png(root, width, height, scale, chosen);
+    if (r.png.empty()) {
+        r.reason =
+            "capture produced no bytes (no screenshot backend available for this "
+            "build/platform — register a provider or build with a GPU/Skia backend)";
+        return r;  // ok=false
+    }
+
+    // 4. Content floor — a blank / clear-only frame is a hard, explained failure.
+    const ScreenshotContentStats stats = analyze_screenshot_content(r.png);
+    if (!stats.passes_content_floor()) {
+        r.reason =
+            "captured frame failed the content floor (too few unique colors / too little "
+            "non-background coverage) — the UI almost certainly did not paint";
+        return r;  // ok=false, png retained for debugging
+    }
+
+    r.ok = true;
+    return r;
+}
+
+}  // namespace pulp::view

--- a/core/view/src/web_view.cpp
+++ b/core/view/src/web_view.cpp
@@ -17,6 +17,14 @@
 #include <unordered_map>
 
 namespace pulp::view {
+
+#if defined(__APPLE__)
+// Implemented in platform/mac/web_view_snapshot_mac.mm (WKWebView takeSnapshot).
+namespace detail {
+std::vector<uint8_t> web_view_snapshot_png(void* ns_view_ptr);
+}  // namespace detail
+#endif
+
 namespace {
 
 constexpr const char* kPostMessageBinding = "__pulpPostMessage";
@@ -515,6 +523,16 @@ public:
     NativeViewHandle native_handle() override {
         if (!webview_ || !webview_->loadedOK()) return nullptr;
         return webview_->getViewHandle();
+    }
+
+    std::vector<uint8_t> snapshot_png() override {
+#if defined(__APPLE__)
+        NativeViewHandle nh = native_handle();
+        if (!nh) return {};
+        return detail::web_view_snapshot_png(nh);
+#else
+        return {};
+#endif
     }
 
     void navigate(const std::string& url) override {

--- a/core/view/src/web_view.cpp
+++ b/core/view/src/web_view.cpp
@@ -16,9 +16,21 @@
 #include <sstream>
 #include <unordered_map>
 
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
+// web_view_snapshot_mac.mm (the WKWebView takeSnapshot impl) is compiled ONLY on
+// macOS (CMake: APPLE AND NOT PULP_IOS), so the forward declaration and the call
+// site must be macOS-only too — guarding them with bare __APPLE__ would compile a
+// call to an undefined symbol on iOS (also __APPLE__) and break the iOS link.
+#if defined(__APPLE__) && TARGET_OS_OSX
+#define PULP_WEB_VIEW_HAS_MAC_SNAPSHOT 1
+#endif
+
 namespace pulp::view {
 
-#if defined(__APPLE__)
+#ifdef PULP_WEB_VIEW_HAS_MAC_SNAPSHOT
 // Implemented in platform/mac/web_view_snapshot_mac.mm (WKWebView takeSnapshot).
 namespace detail {
 std::vector<uint8_t> web_view_snapshot_png(void* ns_view_ptr);
@@ -526,11 +538,12 @@ public:
     }
 
     std::vector<uint8_t> snapshot_png() override {
-#if defined(__APPLE__)
+#ifdef PULP_WEB_VIEW_HAS_MAC_SNAPSHOT
         NativeViewHandle nh = native_handle();
         if (!nh) return {};
         return detail::web_view_snapshot_png(nh);
 #else
+        // No in-process snapshot backend on this platform (iOS/Windows/Linux yet).
         return {};
 #endif
     }

--- a/examples/webview-plugin/webview_plugin.hpp
+++ b/examples/webview-plugin/webview_plugin.hpp
@@ -156,10 +156,27 @@ public:
                 panel_->set_html(kWebViewEditorHtml);
             }
         });
+
+        // This pane attaches a native WebView child that the OS composites — it
+        // is NOT painted into the Pulp Skia canvas. Mark the subtree so the smart
+        // capture path (view::capture_view / standalone --screenshot) routes to
+        // the in-process WebView snapshot below instead of silently rastering a
+        // blank area where the native overlay sits.
+        set_contains_native_overlay(true);
     }
 
     ~WebViewEditorPane() override {
         detach_if_needed();
+    }
+
+    // Headless snapshot of the OS-composited WebView (WKWebView takeSnapshot on
+    // macOS). capture_view() calls this for the contains_native_overlay() subtree
+    // so the native overlay is captured rather than refused. Empty when the
+    // backend has no in-process snapshot (capture_view then reports an honest
+    // "not capturable" reason instead of a silent blank).
+    std::vector<uint8_t> capture_native_overlay_png(uint32_t /*width*/,
+                                                    uint32_t /*height*/) override {
+        return panel_ ? panel_->snapshot_png() : std::vector<uint8_t>{};
     }
 
     void attach_if_needed() {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3959,6 +3959,11 @@ if(APPLE)
     target_link_libraries(pulp-test-screenshot PRIVATE pulp::view Catch2::Catch2WithMain)
     catch_discover_tests(pulp-test-screenshot)
 
+    # P1 — smart capture (capture_view) + offscreen-GPU path (render_to_png_gpu).
+    add_executable(pulp-test-screenshot-gpu test_screenshot_gpu.cpp)
+    target_link_libraries(pulp-test-screenshot-gpu PRIVATE pulp::view Catch2::Catch2WithMain)
+    catch_discover_tests(pulp-test-screenshot-gpu)
+
     add_executable(pulp-test-screenshot-cli-contracts test_screenshot_cli_contracts.cpp)
     target_link_libraries(pulp-test-screenshot-cli-contracts PRIVATE
         pulp::view

--- a/test/test_screenshot_cli_contracts.cpp
+++ b/test/test_screenshot_cli_contracts.cpp
@@ -425,6 +425,73 @@ TEST_CASE("pulp-screenshot main renders demo files and base64 output",
     std::filesystem::remove(output);
 }
 
+TEST_CASE("pulp-screenshot main captures the demo through the smart auto backend",
+          "[tools][screenshot][coverage][requested]") {
+    auto output = temp_file_path("auto-output.png");
+    std::filesystem::remove(output);
+    const auto output_arg = output.string();
+
+    // `--backend auto` routes through capture_view (smart dispatch): no native
+    // overlay + no requires_gpu_host → raster. The CLI is always honest about the
+    // result: 0 = a trustworthy frame was captured and written; 3 = an explained
+    // refusal (blank / no usable backend). It must never silently report success.
+    const int rc = run_screenshot_cli({
+        "--demo",
+        "--output", output_arg.c_str(),
+        "--width", "96",
+        "--height", "64",
+        "--scale", "1",
+        "--theme", "light",
+        "--backend", "auto"
+    });
+    REQUIRE((rc == 0 || rc == 3));
+    if (rc == 0) {
+        REQUIRE(std::filesystem::is_regular_file(output));
+        REQUIRE(std::filesystem::file_size(output) > 8);
+    }
+
+    std::filesystem::remove(output);
+}
+
+TEST_CASE("pulp-screenshot --compare scores similarity and writes a diff image",
+          "[tools][screenshot][coverage][requested]") {
+    auto img = temp_file_path("compare-input.png");
+    auto diff = temp_file_path("compare-diff.png");
+    std::filesystem::remove(img);
+    std::filesystem::remove(diff);
+    const auto img_arg = img.string();
+
+    // Produce a real PNG to feed the parity comparison.
+    const int made = run_screenshot_cli({
+        "--demo",
+        "--output", img_arg.c_str(),
+        "--width", "48",
+        "--height", "32",
+        "--scale", "1",
+        "--backend", "default"
+    });
+    if (made != 0 || !std::filesystem::is_regular_file(img)) {
+        SUCCEED("no raster backend in this build — cannot produce a PNG to compare");
+        return;
+    }
+
+    // Identical inputs → similarity 1.0 ≥ threshold → exit 0 (PASS).
+    const auto diff_arg = diff.string();
+    REQUIRE(run_screenshot_cli({
+        "--compare", img_arg.c_str(), img_arg.c_str(),
+        "--threshold", "0.99",
+        "--diff", diff_arg.c_str()
+    }) == 0);
+
+    // An unreadable / missing reference → exit 2 (compare could not run).
+    REQUIRE(run_screenshot_cli({
+        "--compare", "/no/such/reference.png", img_arg.c_str()
+    }) == 2);
+
+    std::filesystem::remove(img);
+    std::filesystem::remove(diff);
+}
+
 TEST_CASE("pulp-screenshot main renders script files through the CLI path",
           "[tools][screenshot][coverage][requested]") {
     auto script = temp_file_path("script-render.js");

--- a/test/test_screenshot_cli_contracts.cpp
+++ b/test/test_screenshot_cli_contracts.cpp
@@ -160,7 +160,7 @@ TEST_CASE("pulp-screenshot option parser preserves documented defaults",
     REQUIRE_FALSE(options.demo);
     REQUIRE_FALSE(options.help);
 #ifdef PULP_HAS_SKIA
-    REQUIRE(options.backend_name == "skia");
+    REQUIRE(options.backend_name == "auto");  // default is smart dispatch
 #else
     REQUIRE(options.backend_name == "coregraphics");
 #endif
@@ -303,7 +303,7 @@ TEST_CASE("pulp-screenshot backend normalization rejects unavailable explicit Sk
     REQUIRE(default_backend.backend_was_defaulted);
     REQUIRE(normalize_backend(default_backend));
 #ifdef PULP_HAS_SKIA
-    REQUIRE(default_backend.backend_name == "skia");
+    REQUIRE(default_backend.backend_name == "auto");
 #else
     REQUIRE(default_backend.backend_name == "coregraphics");
 #endif
@@ -322,7 +322,7 @@ TEST_CASE("pulp-screenshot option parser handles malformed non-help invocations"
     auto incomplete_options = parse_args({"--script", "--output", "--backend"});
     REQUIRE(incomplete_options.script_path == "--output");
 #ifdef PULP_HAS_SKIA
-    REQUIRE(incomplete_options.backend_name == "skia");
+    REQUIRE(incomplete_options.backend_name == "auto");
 #else
     REQUIRE(incomplete_options.backend_name == "coregraphics");
 #endif

--- a/test/test_screenshot_gpu.cpp
+++ b/test/test_screenshot_gpu.cpp
@@ -17,6 +17,24 @@
 
 using namespace pulp::view;
 
+namespace {
+// A view that owns a "native overlay" and returns a caller-supplied PNG from its
+// in-process snapshot hook — the stand-in for a real WebView pane (whose
+// capture_native_overlay_png forwards WKWebView takeSnapshot). Empty bytes model
+// "no in-process snapshot available".
+class SnapshotOverlayView : public View {
+public:
+    explicit SnapshotOverlayView(std::vector<uint8_t> png) : png_(std::move(png)) {
+        set_contains_native_overlay(true);
+    }
+    std::vector<uint8_t> capture_native_overlay_png(uint32_t, uint32_t) override {
+        return png_;
+    }
+private:
+    std::vector<uint8_t> png_;
+};
+}  // namespace
+
 TEST_CASE("capture_view refuses a native-overlay subtree with a reason",
           "[view][screenshot][gpu]") {
     View root;
@@ -55,6 +73,41 @@ static std::unique_ptr<View> make_capture_tree() {
     return root;
 }
 
+// A real but SPARSE UI: a solid background with one small label covering well
+// under 5% of the frame. This is the regression guard for the content-floor
+// parameter-position bug — passes_content_floor's signature is
+// (min_unique_colors, min_luminance_stddev, min_non_background_coverage,
+// min_opaque_coverage). A 3-argument call silently left min_non_background_coverage
+// at its strict 0.05 default, so this sparse-but-valid UI was wrongly rejected as
+// "blank". capture_view must accept it.
+TEST_CASE("capture_view accepts a sparse-but-real UI (content-floor leniency)",
+          "[view][screenshot][gpu]") {
+    // Solid dark background + one small painted element covering ~1% of the frame
+    // (well under the strict 5% non-background default). A gradient fill — not text
+    // — so the assertion holds on raster backends that don't render glyphs.
+    View root;
+    root.set_theme(Theme::dark());
+    auto chip = std::make_unique<View>();
+    chip->set_bounds({4.0f, 4.0f, 80.0f, 40.0f});  // 3200 / 240000 ≈ 1.3% of 600x400
+    chip->set_background_gradient_linear(
+        0.0f, 0.0f, 1.0f, 1.0f,
+        {pulp::canvas::Color::rgba8(240, 120, 60), pulp::canvas::Color::rgba8(80, 200, 250)},
+        {0.0f, 1.0f});
+    root.add_child(std::move(chip));
+
+    const CaptureResult r = capture_view(root, 600, 400, 1.0f);
+    if (r.png.empty() || r.used != ScreenshotBackend::skia) {
+        // The CoreGraphics raster path renders root-level fills but not child
+        // sub-element gradients, so the sparse-coverage distinction is only
+        // observable on the Skia backend. Skip elsewhere rather than assert a
+        // backend limitation.
+        SUCCEED("sparse-content floor is only observable on the Skia raster backend");
+        return;
+    }
+    INFO("sparse capture reason: " << r.reason);
+    REQUIRE(r.ok);  // false under the buggy 3-arg call (strict 5% non-background floor)
+}
+
 TEST_CASE("capture_view passes a non-blank widget tree (raster)", "[view][screenshot][gpu]") {
     auto root = make_capture_tree();
     const CaptureResult r = capture_view(*root, 520, 200, 1.0f);
@@ -63,6 +116,46 @@ TEST_CASE("capture_view passes a non-blank widget tree (raster)", "[view][screen
     REQUIRE_FALSE(r.png.empty());
     REQUIRE(r.png.size() > 8);
     REQUIRE(r.png[1] == 'P');  // PNG magic "\x89PNG"
+}
+
+TEST_CASE("capture_view returns a non-blank native-overlay snapshot instead of refusing",
+          "[view][screenshot][gpu]") {
+    // A real WebView pane returns an in-process snapshot (WKWebView takeSnapshot).
+    // Model it with content-rich PNG bytes produced by the raster path. capture_view
+    // must surface that snapshot (used == default_backend) rather than refuse.
+    auto content = make_capture_tree();
+    auto png = render_to_png(*content, 520, 200, 1.0f, ScreenshotBackend::skia);
+    if (png.empty()) {
+        SUCCEED("no raster backend in this build — cannot synthesize an overlay snapshot");
+        return;
+    }
+    View root;
+    root.add_child(std::make_unique<SnapshotOverlayView>(std::move(png)));
+
+    const CaptureResult r = capture_view(root, 520, 200, 1.0f);
+    INFO("overlay-snapshot reason: " << r.reason);
+    REQUIRE(r.ok);
+    REQUIRE(r.used == ScreenshotBackend::default_backend);  // native-overlay snapshot
+    REQUIRE_FALSE(r.png.empty());
+    REQUIRE(r.png[1] == 'P');
+}
+
+TEST_CASE("capture_view refuses an essentially-blank native-overlay snapshot",
+          "[view][screenshot][gpu]") {
+    // A WebView that snapshots to a single flat color (e.g. not yet loaded) must
+    // be refused with a "blank" reason, not silently accepted.
+    View flat;  // nothing painted but the background fill → one color
+    auto blank_png = render_to_png(flat, 64, 64, 1.0f, ScreenshotBackend::skia);
+    if (blank_png.empty()) {
+        SUCCEED("no raster backend in this build — cannot synthesize a blank snapshot");
+        return;
+    }
+    View root;
+    root.add_child(std::make_unique<SnapshotOverlayView>(std::move(blank_png)));
+
+    const CaptureResult r = capture_view(root, 64, 64, 1.0f);
+    REQUIRE_FALSE(r.ok);
+    REQUIRE(r.reason.find("blank") != std::string::npos);
 }
 
 TEST_CASE("capture_view routes a requires_gpu_host tree to the GPU backend",

--- a/test/test_screenshot_gpu.cpp
+++ b/test/test_screenshot_gpu.cpp
@@ -34,7 +34,7 @@ TEST_CASE("capture_view rejects a blank / clear-only frame (content floor)",
     View root;  // nothing painted but the background fill → 1 unique color
     const CaptureResult r = capture_view(root, 200, 120, 1.0f);
     REQUIRE_FALSE(r.ok);
-    REQUIRE(r.reason.find("content floor") != std::string::npos);
+    REQUIRE(r.reason.find("blank") != std::string::npos);
 }
 
 // A reliably content-rich tree: a diagonal gradient background (hundreds of

--- a/test/test_screenshot_gpu.cpp
+++ b/test/test_screenshot_gpu.cpp
@@ -1,0 +1,100 @@
+// P1 — smart/unified view capture (capture_view) + offscreen-GPU path.
+// Proves the "always-capturable" contract: a native overlay is refused with a
+// reason, a blank/clear-only frame fails the content floor, and a real widget
+// tree captures non-blank.
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/view/frame_clock.hpp>
+#include <pulp/view/screenshot.hpp>
+#include <pulp/view/widgets.hpp>
+#include <pulp/view/theme.hpp>
+#include <pulp/canvas/canvas.hpp>
+
+#include <cstdlib>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace pulp::view;
+
+TEST_CASE("capture_view refuses a native-overlay subtree with a reason",
+          "[view][screenshot][gpu]") {
+    View root;
+    auto pane = std::make_unique<View>();
+    pane->set_contains_native_overlay(true);  // e.g. a WebView pane
+    root.add_child(std::move(pane));
+
+    const CaptureResult r = capture_view(root, 200, 120, 1.0f);
+    REQUIRE_FALSE(r.ok);
+    REQUIRE(r.reason.find("overlay") != std::string::npos);  // honest, not a blank
+}
+
+TEST_CASE("capture_view rejects a blank / clear-only frame (content floor)",
+          "[view][screenshot][gpu]") {
+    View root;  // nothing painted but the background fill → 1 unique color
+    const CaptureResult r = capture_view(root, 200, 120, 1.0f);
+    REQUIRE_FALSE(r.ok);
+    REQUIRE(r.reason.find("content floor") != std::string::npos);
+}
+
+// A reliably content-rich tree: a diagonal gradient background (hundreds of
+// interpolated colors at full, opaque coverage — clears the content floor
+// regardless of child flex layout) plus a Label. Exercises paint_all → the
+// capture canvas → the content floor with real painted content.
+static std::unique_ptr<View> make_capture_tree() {
+    auto root = std::make_unique<View>();
+    root->set_theme(Theme::dark());
+    root->set_background_gradient_linear(
+        0.0f, 0.0f, 1.0f, 1.0f,
+        {pulp::canvas::Color::rgba8(28, 31, 46), pulp::canvas::Color::rgba8(96, 150, 240),
+         pulp::canvas::Color::rgba8(168, 140, 250)},
+        {0.0f, 0.55f, 1.0f});
+    auto label = std::make_unique<Label>("Promptable Accompanist");
+    label->set_bounds({16.0f, 80.0f, 480.0f, 32.0f});
+    root->add_child(std::move(label));
+    return root;
+}
+
+TEST_CASE("capture_view passes a non-blank widget tree (raster)", "[view][screenshot][gpu]") {
+    auto root = make_capture_tree();
+    const CaptureResult r = capture_view(*root, 520, 200, 1.0f);
+    INFO("capture_view reason: " << r.reason << " (backend " << static_cast<int>(r.used) << ")");
+    REQUIRE(r.ok);
+    REQUIRE_FALSE(r.png.empty());
+    REQUIRE(r.png.size() > 8);
+    REQUIRE(r.png[1] == 'P');  // PNG magic "\x89PNG"
+}
+
+TEST_CASE("capture_view routes a requires_gpu_host tree to the GPU backend",
+          "[view][screenshot][gpu]") {
+    if (!has_gpu_capture()) {
+        SUCCEED("GPU capture not compiled in (no pulp-render)");
+        return;
+    }
+    auto root = make_capture_tree();
+    root->set_requires_gpu_host(true);  // forces the GPU (HeadlessSurface) path
+
+    const CaptureResult r = capture_view(*root, 520, 200, 1.0f);
+    INFO("gpu capture_view reason: " << r.reason);
+    // The GPU surface may be absent on a headless CI adapter; if it produced a
+    // frame it must pass the content floor (proving the GPU path paints content).
+    if (!r.png.empty()) {
+        REQUIRE(r.used == ScreenshotBackend::gpu);
+        REQUIRE(r.ok);
+        REQUIRE(r.png[1] == 'P');
+    }
+}
+
+// Hidden demo (run with the [.demo] tag): writes a real GPU-captured PNG to disk
+// so the capture pipeline can be eyeballed. Not part of the default suite.
+TEST_CASE("demo: write a GPU-captured PNG to disk", "[.][demo]") {
+    auto root = make_capture_tree();
+    root->set_requires_gpu_host(true);
+    const CaptureResult r = capture_view(*root, 520, 200, 2.0f);
+    INFO("reason: " << r.reason);
+    REQUIRE(r.ok);
+    const char* out = std::getenv("P1_DEMO_PNG");
+    std::ofstream f(out ? out : "/tmp/p1-gpu-capture.png", std::ios::binary);
+    f.write(reinterpret_cast<const char*>(r.png.data()),
+            static_cast<std::streamsize>(r.png.size()));
+}

--- a/tools/screenshot/pulp_screenshot.cpp
+++ b/tools/screenshot/pulp_screenshot.cpp
@@ -53,7 +53,7 @@ static void print_usage() {
     std::cerr << "  --height <px>        Height in points (default: 300)\n";
     std::cerr << "  --scale <factor>     Scale factor (default: 2.0)\n";
     std::cerr << "  --theme <name>       Theme: dark, light, pro_audio (default: dark)\n";
-    std::cerr << "  --backend <name>     Render backend: skia, coregraphics (default: skia)\n";
+    std::cerr << "  --backend <name>     Render backend: auto, skia, coregraphics, gpu (default: auto — smart: native-overlay refuse / GPU view / raster)\n";
     std::cerr << "  --runtime-trace <file.json>\n";
     std::cerr << "                       Dump JS listener/callback trace after settle\n";
     std::cerr << "  --base64             Output base64-encoded PNG to stdout\n";
@@ -99,7 +99,8 @@ struct ScreenshotCliOptions {
     float scale = 2.0f;
     std::string theme_name = "dark";
 #ifdef PULP_HAS_SKIA
-    std::string backend_name = "skia";
+    std::string backend_name = "auto";  // smart dispatch (capture_view): native-overlay
+                                        // refuse / GPU-required → gpu / else raster
 #else
     std::string backend_name = "coregraphics";
 #endif
@@ -383,11 +384,15 @@ int main(int argc, char* argv[]) {
         backend = ScreenshotBackend::coregraphics;
     } else if (options.backend_name == "skia") {
         backend = ScreenshotBackend::skia;
+    } else if (options.backend_name == "auto") {
+        backend = ScreenshotBackend::auto_select;
+    } else if (options.backend_name == "gpu") {
+        backend = ScreenshotBackend::gpu;
     } else if (options.backend_name == "default") {
         backend = ScreenshotBackend::default_backend;
     } else {
         std::cerr << "Error: unknown --backend '" << options.backend_name
-                  << "' (valid: skia, coregraphics, default)\n";
+                  << "' (valid: auto, skia, coregraphics, gpu, default)\n";
         return 1;
     }
 
@@ -500,22 +505,45 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    // Render
-    if (options.output_base64) {
-        auto png = render_to_png(root, options.width, options.height, options.scale, backend);
+    // Render. For the smart backends (auto/gpu) route through capture_view so the
+    // backend is auto-selected, native-overlay views are refused, and a blank /
+    // clear-only frame is a hard error (exit 3) instead of a silently saved blank.
+    const bool smart = (backend == ScreenshotBackend::auto_select ||
+                        backend == ScreenshotBackend::gpu);
+    std::vector<uint8_t> png;
+    std::string used_label = options.backend_name;
+    if (smart) {
+        CaptureResult cap =
+            capture_view(root, options.width, options.height, options.scale, backend);
+        if (!cap.ok) {
+            std::cerr << "Error: capture is not trustworthy — " << cap.reason << "\n";
+            return 3;  // native overlay / blank / no backend
+        }
+        png = std::move(cap.png);
+        used_label = (cap.used == ScreenshotBackend::gpu)          ? "gpu"
+                     : (cap.used == ScreenshotBackend::coregraphics) ? "coregraphics"
+                                                                     : "skia";
+    } else {
+        png = render_to_png(root, options.width, options.height, options.scale, backend);
         if (png.empty()) {
             std::cerr << "Error: rendering failed\n";
             return 1;
         }
+    }
+
+    if (options.output_base64) {
         std::cout << base64_encode(png);
         return 0;
-    } else {
-        bool ok = render_to_file(root, options.width, options.height, options.output_path, options.scale, backend);
-        if (!ok) {
-            std::cerr << "Error: rendering failed\n";
-            return 1;
-        }
-        std::cout << "Screenshot saved to " << options.output_path << " (" << options.width << "x" << options.height << " @" << options.scale << "x, backend=" << options.backend_name << ")\n";
-        return 0;
     }
+    std::ofstream out(options.output_path, std::ios::binary);
+    if (!out) {
+        std::cerr << "Error: cannot open output '" << options.output_path << "'\n";
+        return 1;
+    }
+    out.write(reinterpret_cast<const char*>(png.data()),
+              static_cast<std::streamsize>(png.size()));
+    std::cout << "Screenshot saved to " << options.output_path << " (" << options.width
+              << "x" << options.height << " @" << options.scale << "x, backend="
+              << used_label << ")\n";
+    return 0;
 }

--- a/tools/screenshot/pulp_screenshot.cpp
+++ b/tools/screenshot/pulp_screenshot.cpp
@@ -7,6 +7,7 @@
 #include <pulp/view/script_engine.hpp>
 #include <pulp/view/widget_bridge.hpp>
 #include <pulp/view/screenshot.hpp>
+#include <pulp/view/screenshot_compare.hpp>
 #include <pulp/state/store.hpp>
 #include <pulp/view/viewport_reconcile.hpp>
 #include <iostream>
@@ -58,6 +59,7 @@ static void print_usage() {
     std::cerr << "                       Dump JS listener/callback trace after settle\n";
     std::cerr << "  --base64             Output base64-encoded PNG to stdout\n";
     std::cerr << "  --demo               Render a demo UI (no script needed)\n";
+    std::cerr << "  --compare A.png B.png [--threshold 0.85] [--diff D.png]  Parity check: print similarity, exit 0 if >= threshold\n";
 }
 
 static std::string read_file(const std::string& path) {
@@ -367,6 +369,44 @@ static const char* runtime_trace_script() {
 }
 
 int main(int argc, char* argv[]) {
+    // Parity mode: `pulp-screenshot --compare <reference.png> <rendered.png>
+    //               [--threshold 0.85] [--diff <out.png>]`
+    // Prints similarity + mean error; exits 0 if similarity >= threshold else 1.
+    // Reuses the design-import / visual-regression comparison (compare_screenshot_files).
+    for (int i = 1; i + 2 < argc; ++i) {
+        if (std::string(argv[i]) != "--compare") continue;
+        const std::string ref = argv[i + 1];
+        const std::string rendered = argv[i + 2];
+        float threshold = 0.85f;
+        std::string diff_out;
+        for (int j = 1; j < argc; ++j) {
+            const std::string a = argv[j];
+            if (a == "--threshold" && j + 1 < argc) threshold = std::stof(argv[j + 1]);
+            else if (a == "--diff" && j + 1 < argc) diff_out = argv[j + 1];
+        }
+        const auto result = pulp::view::compare_screenshot_files(ref, rendered);
+        if (!result.valid) {
+            std::cerr << "Error: compare failed — could not read or size-match '" << ref
+                      << "' and '" << rendered << "'\n";
+            return 2;
+        }
+        const bool pass = result.passes(threshold);
+        std::cout << "similarity=" << result.similarity << " mean_error=" << result.mean_error
+                  << " threshold=" << threshold << " => " << (pass ? "PASS" : "FAIL") << "\n";
+        if (!diff_out.empty()) {
+            const auto a = read_file(ref), b = read_file(rendered);
+            const std::vector<uint8_t> ab(a.begin(), a.end()), bb(b.begin(), b.end());
+            const auto diff = pulp::view::generate_diff_image(ab, bb);
+            if (!diff.empty()) {
+                std::ofstream(diff_out, std::ios::binary)
+                    .write(reinterpret_cast<const char*>(diff.data()),
+                           static_cast<std::streamsize>(diff.size()));
+                std::cout << "diff image saved to " << diff_out << "\n";
+            }
+        }
+        return pass ? 0 : 1;
+    }
+
     auto options = parse_options(argc, argv);
     if (options.help) { print_usage(); return 0; }
 

--- a/tools/screenshot/pulp_screenshot.cpp
+++ b/tools/screenshot/pulp_screenshot.cpp
@@ -582,6 +582,16 @@ int main(int argc, char* argv[]) {
     }
     out.write(reinterpret_cast<const char*>(png.data()),
               static_cast<std::streamsize>(png.size()));
+    // Check the stream state before reporting success: out.write() can fail
+    // silently (disk full, quota exceeded, I/O error, short write on a network
+    // filesystem). Flush/close explicitly so a deferred write error surfaces in
+    // the stream state rather than after the success message has been printed.
+    out.close();
+    if (!out) {
+        std::cerr << "Error: failed writing screenshot to '" << options.output_path
+                  << "' (disk full or I/O error)\n";
+        return 1;
+    }
     std::cout << "Screenshot saved to " << options.output_path << " (" << options.width
               << "x" << options.height << " @" << options.scale << "x, backend="
               << used_label << ")\n";


### PR DESCRIPTION
**Magenta-UI parity plan, Phase 1** (planning/2026-06-05-magenta-native-ui-parity-plan.md): the "always-capturable" SDK primitive.

## What
- **`render_to_png_gpu(View&,...)`** — renders a view tree through the existing `pulp::render::HeadlessSurface` (offscreen Dawn+Skia+readback). The only path that renders `requires_gpu_host()` views correctly (CPU raster doesn't). Compiled in when `pulp-render` is linked (`PULP_VIEW_HAS_GPU_CAPTURE`); degrades honestly otherwise (`has_gpu_capture()`).
- **`capture_view(View&,...)`** — smart, always-honest dispatcher (`auto` by default): a `contains_native_overlay()` subtree is **refused with a reason** (WebView/native NSView is OS-composited, invisible to headless capture — never a silent blank); `requires_gpu_host()` → GPU; else raster. Result gated by the content floor so an essentially-blank frame is a hard, explained failure.
- **`View::contains_native_overlay()`** — generic marker (WebViewPanel isn't a View) set by the wrapper view that attaches a native child.
- **`pulp-screenshot --backend auto`** (now the default) routes through `capture_view`; adds `--backend gpu`; exit 3 (not a saved blank) on refuse/blank.
- `screenshot` skill documents the smart dispatch so agents stop hand-picking backends.

## Why
Shipping a WebView plugin UI rendered blank *and* couldn't be captured by `render_to_png` (native overlay isn't on the Skia canvas). Codex confirmed the deeper issue: the Skia backend is CPU raster and ignores `requires_gpu_host()`, so *any* GPU-required view captures blank. This adds the real headless-GPU capture + makes "did it paint?" an enforced contract.

## Tests
`pulp-test-screenshot-gpu`: overlay-refuse, blank-reject (content floor), content-rich raster pass, and a `requires_gpu_host` tree routed through the GPU path producing a content-floor-passing frame (Metal/Graphite verified). No regression: screenshot (53) / screenshot-compare (101) / cli-contracts (173) green.

Proof: a real headless GPU capture PNG (gradient+label) — the exact thing that was blank with WebView.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds headless GPU view capture and a smart `capture_view` that auto-picks backends, captures native WebView overlays in‑process, and rejects blank frames. `pulp-screenshot` now defaults to `--backend auto`, adds `--backend gpu` and `--compare`, and standalone `--screenshot` uses the smart path for editors with native overlays.

- **New Features**
  - `render_to_png_gpu(View&, ...)` + `has_gpu_capture()`: offscreen GPU capture via `pulp::render::HeadlessSurface`; compile‑gated by Skia (`PULP_VIEW_HAS_GPU_CAPTURE`) and degrades honestly when unavailable.
  - `capture_view(View&, ...)`: returns `{png, ok, used, reason}` — native overlay → in‑process snapshot via `View::capture_native_overlay_png()` (macOS uses WKWebView `takeSnapshot` via `WebViewPanel::snapshot_png()`), else GPU for `requires_gpu_host()`, else raster; a lenient content floor refuses essentially blank frames.
  - View API: `set_contains_native_overlay(true)` and override `capture_native_overlay_png(...)` to supply an overlay snapshot; macOS adds `WebViewPanel::snapshot_png()`.
  - CLI: `pulp-screenshot` defaults to `--backend auto`, adds `--backend gpu`, exits 3 on untrustworthy capture; new `--compare A.png B.png [--threshold ...] [--diff ...]` prints similarity and optional diff; verifies screenshot file writes.
  - Standalone: `--screenshot` uses `capture_view` to return native overlay snapshots; otherwise falls back to the live Skia back buffer.

- **Migration**
  - Prefer `capture_view` or CLI `--backend auto`; only force a backend when needed.
  - For views with native children, set `set_contains_native_overlay(true)` and implement `capture_native_overlay_png()` to forward `WebViewPanel::snapshot_png()` (see `examples/webview-plugin`).
  - Build with Skia to enable GPU capture; otherwise raster/host providers handle capture. Handle exit code 3 in scripts/CI when a capture isn’t trustworthy.

<sup>Written for commit 1438f2c58659832fd05fb4211b8333e1182c7979. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds the "always-capturable" view primitive: headless GPU capture via `render_to_png_gpu` (Dawn+Skia `HeadlessSurface`), a smart `capture_view` dispatcher that refuses native overlays with an explanation rather than returning a silent blank, and an in-process WKWebView snapshot path so WebView editors become headlessly verifiable. The previous review threads' fixes (double tree traversal, `raster_fallback()` returning `default_backend` on non-Skia builds, and the main-path write-check) all land cleanly in this revision.

- **`capture_view` + `scan_tree`**: single DFS over the view tree collects the native-overlay node and the `requires_gpu_host` flag simultaneously; the four-way dispatch (overlay snapshot → GPU → raster → blank rejection) is clearly gated on `PULP_VIEW_HAS_GPU_CAPTURE` / `PULP_HAS_SKIA` without conflating the two.
- **`pulp-screenshot` CLI**: defaults to `--backend auto`, adds `--backend gpu`, exits 3 on untrustworthy capture, and gains `--compare A B [--threshold] [--diff]` for parity checks; the main screenshot write path now guards open and write errors.
- **`web_view_snapshot_mac.mm`**: bounded run-loop pump (~3 s) captures PNG bytes inside the completion handler before the autoreleased `NSImage` is reclaimed, correctly scoped to macOS only via `TARGET_OS_OSX`.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge; all changes are additive new paths behind compile-time and runtime guards, with no modifications to existing raster backends.

All three items flagged in prior review rounds are confirmed fixed. The new code is well-guarded (PULP_VIEW_HAS_GPU_CAPTURE, PULP_WEB_VIEW_HAS_MAC_SNAPSHOT), degrades honestly when capabilities are absent, and is covered by a dedicated test suite. The two remaining findings are minor quality nits that do not affect correctness or exit codes.

tools/screenshot/pulp_screenshot.cpp — the --compare diff image write path lacks the same open/write error checking added to the main screenshot write in this PR.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| core/view/src/screenshot_gpu.cpp | New file implementing capture_view smart dispatcher and render_to_png_gpu; single-pass scan_tree replaces the two-traversal approach flagged in prior review; raster_fallback() correctly returns default_backend on non-Skia builds. |
| tools/screenshot/pulp_screenshot.cpp | CLI gains --backend auto/gpu, smart capture_view routing, and --compare mode; main screenshot write-checking is fixed and thorough, but the --compare diff image write uses a temporary ofstream without checking for open or write failures while unconditionally printing success. |
| core/view/platform/mac/web_view_snapshot_mac.mm | New macOS WKWebView in-process snapshot via takeSnapshotWithConfiguration; run-loop pump is bounded at ~3s; PNG bytes extracted inside the completion handler to avoid ObjC lifetime issues across the pump boundary. |
| core/format/src/standalone.cpp | Standalone --screenshot path now routes through capture_view for native-overlay editors; falls back to live back-buffer capture for normal Skia UIs, which is the correct behavior for a windowed app. |
| core/view/include/pulp/view/screenshot.hpp | Adds ScreenshotBackend::gpu and auto_select enum values, CaptureResult struct, capture_view(), render_to_png_gpu(), and has_gpu_capture(); API is clear and well-documented. |
| core/view/include/pulp/view/view.hpp | Adds contains_native_overlay_ bool, its accessor/setter, and virtual capture_native_overlay_png() defaulting to empty bytes; cleanly generic with no WebView-specific coupling in the base View class. |
| test/test_screenshot_gpu.cpp | New test suite covering overlay-refuse, blank-reject, sparse-UI leniency, content-rich raster pass, non-blank overlay snapshot, blank overlay snapshot refuse, and GPU-path routing; hidden [.][demo] test writes a real GPU-captured PNG to disk. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["capture_view(root, w, h, scale, backend)"] --> B["scan_tree() — single DFS\ncollects overlay + needs_gpu"]
    B --> C{overlay found?}
    C -->|Yes| D["Call overlay->capture_native_overlay_png()"]
    D --> E{png non-empty?}
    E -->|Yes| F["passes_capture_floor?"]
    F -->|Yes| G["✅ ok=true, used=default_backend"]
    F -->|No| H["❌ ok=false: overlay snapshot blank"]
    E -->|No| I["❌ ok=false: no in-process snapshot"]
    C -->|No| J{backend == auto_select?}
    J -->|Yes| K{needs_gpu?}
    K -->|Yes| L["chosen = gpu"]
    K -->|No| M["chosen = raster_fallback()"]
    J -->|No| N["chosen = explicit backend"]
    L --> O{has_gpu_capture?}
    O -->|No| P["⚠️ fallback to raster"]
    O -->|Yes| Q["render_to_png_gpu()"]
    P --> M
    M --> R["render_to_png()"]
    N --> Q
    Q --> T{png empty?}
    R --> T
    T -->|Yes| U["❌ ok=false: no backend"]
    T -->|No| V["passes_capture_floor?"]
    V -->|Yes| W["✅ ok=true"]
    V -->|No| X["❌ ok=false: blank frame"]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tools/screenshot/pulp_screenshot.cpp`, line 163-176 ([link](https://github.com/danielraffel/pulp/blob/ef019ed611fa1c1588ea2ee00f52aa5e1ef6e271/tools/screenshot/pulp_screenshot.cpp#L163-L176)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `normalize_backend` only guards `"skia"` against non-Skia builds; it lets `"auto"` through even when `PULP_HAS_SKIA` is false. If a caller explicitly passes `--backend auto` on a non-Skia build, `auto_select` resolves to `skia` internally, `render_to_png` returns empty bytes, and the tool exits 3 with "no backend available" — a much less helpful message than the existing "Skia not compiled" diagnostic.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["chore: bump versions"](https://github.com/danielraffel/pulp/commit/1438f2c58659832fd05fb4211b8333e1182c7979) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35921142)</sub>

<!-- /greptile_comment -->