### PR TITLE
feat(runtime): ModelManager service — registry/store promotion + streaming downloader (PR1+PR2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.344.0
+    VERSION 0.345.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.345.0
+    VERSION 0.346.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/runtime/CMakeLists.txt
+++ b/core/runtime/CMakeLists.txt
@@ -109,6 +109,7 @@ target_sources(pulp-runtime PRIVATE
     src/json_rpc.cpp
     src/model_registry.cpp
     src/model_store.cpp
+    src/model_download.cpp
     src/ip_address.cpp
     src/mac_address.cpp
     src/url.cpp
@@ -172,6 +173,14 @@ if(TARGET mbedcrypto)
     target_include_directories(pulp-runtime PRIVATE
         ${mbedtls_SOURCE_DIR}/include
     )
+    # Enable HTTPS in cpp-httplib via the mbedTLS backend (used by the streaming
+    # model downloader, model_download.cpp). No OpenSSL dependency.
+    target_compile_definitions(pulp-runtime PRIVATE CPPHTTPLIB_MBEDTLS_SUPPORT)
+    if(APPLE)
+        # httplib's mbedTLS path loads system trust anchors from the macOS keychain
+        # via the Security framework.
+        target_link_libraries(pulp-runtime PRIVATE "-framework Security" "-framework CoreFoundation")
+    endif()
 endif()
 
 # CHOC headers (used by SpscQueue wrapper)

--- a/core/runtime/CMakeLists.txt
+++ b/core/runtime/CMakeLists.txt
@@ -107,6 +107,8 @@ target_sources(pulp-runtime PRIVATE
     src/memory_message_channel.cpp
     src/websocket_channel.cpp
     src/json_rpc.cpp
+    src/model_registry.cpp
+    src/model_store.cpp
     src/ip_address.cpp
     src/mac_address.cpp
     src/url.cpp

--- a/core/runtime/include/pulp/runtime/model_download.hpp
+++ b/core/runtime/include/pulp/runtime/model_download.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+// Streaming HTTPS file downloader for the model manager (MM-PR2). Unlike
+// runtime/http.hpp's http_download (whole-body, in-memory — fine for small JSON,
+// fatal for GB-scale weights), this streams the body incrementally to disk with a
+// progress callback, HTTP Range **resume**, request **headers** (e.g. HuggingFace
+// auth), **cancellation**, **sha256** verification, and a temp-stage → atomic-rename
+// so a partial/aborted transfer never appears as a finished file. HTTPS rides on
+// cpp-httplib's mbedTLS backend (mbedTLS is already linked by core/runtime).
+
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace pulp::runtime {
+
+class CancellationToken;  // async_stream.hpp
+
+struct DownloadProgress {
+    std::uint64_t downloaded = 0;  ///< Bytes written so far (includes resumed bytes).
+    std::uint64_t total = 0;       ///< Total expected bytes, or 0 if the server didn't say.
+};
+
+struct HttpHeader {
+    std::string name;
+    std::string value;
+};
+
+struct DownloadRequest {
+    std::string url;                       ///< http(s)://… (resolve hf:// first).
+    std::filesystem::path dest;            ///< Final destination path.
+    std::string expected_sha256;           ///< Optional hex digest; verified when non-empty.
+    std::vector<HttpHeader> headers;       ///< Extra request headers (e.g. Authorization).
+    bool resume = true;                    ///< Resume from a prior partial <dest>.part via Range.
+    int timeout_seconds = 0;               ///< 0 ⇒ a sensible library default.
+};
+
+struct DownloadResult {
+    bool ok = false;
+    std::string error;
+    std::filesystem::path path;            ///< The finished file (== request.dest) on success.
+    std::uint64_t bytes = 0;               ///< Total bytes of the finished file.
+    std::string sha256;                    ///< Hex digest of the finished file.
+    bool resumed = false;                  ///< A prior partial was continued.
+    bool cancelled = false;                ///< Stopped via callback / token (partial kept for resume).
+};
+
+/// Progress callback. Return false to cancel the in-flight download.
+using DownloadProgressFn = std::function<bool(const DownloadProgress&)>;
+
+/// Blocking streaming download. Writes to `<dest>.part`, verifies sha256 (when an
+/// expected digest is given), then atomically renames to `dest`. On cancel/error the
+/// `.part` file is left in place so a later call with `resume = true` continues it.
+DownloadResult download_file(const DownloadRequest& request,
+                             const DownloadProgressFn& on_progress = {},
+                             const CancellationToken* cancel = nullptr);
+
+}  // namespace pulp::runtime

--- a/core/runtime/include/pulp/runtime/model_registry.hpp
+++ b/core/runtime/include/pulp/runtime/model_registry.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+// Generic model registry primitive (promoted from tools/audio so plugins/apps —
+// not just the CLI — can use it). A `ModelEntry` describes a downloadable ML model
+// (HuggingFace or any URL); `resolve_checkpoint_url` turns an `hf://` ref into a
+// direct HTTPS URL with path hardening. The available-models list (the catalog) is
+// supplied by the consumer (e.g. tools/audio's audio catalog, or the Magenta demo's
+// mrt2 catalog) — this module owns the type + resolution + lookup, not the data.
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pulp::runtime {
+
+struct ModelAsset {
+    std::string role;          ///< e.g. "weights", "vocab", "encoder" (multi-file bundles)
+    std::string checkpoint_ref;///< "hf://user/repo/file" or "https://…"
+    std::string sha256;        ///< Expected hash of this asset (empty = unverified)
+    std::uint64_t size_bytes = 0;
+};
+
+struct ModelEntry {
+    std::string model_id;             ///< Stable id (e.g. "mrt2_base"), NOT the HF repo.
+    std::string display_name;
+    std::string description;
+    std::string backend;              ///< e.g. "clap", "mlx".
+    std::string checkpoint_ref;       ///< Primary asset, e.g. "hf://user/repo/file.pt".
+    std::vector<std::string> task_tags;
+    std::uint64_t size_bytes = 0;
+
+    std::string download_url;         ///< Direct HTTPS URL (resolved from checkpoint_ref).
+    std::string sha256;               ///< Expected hash of the primary checkpoint.
+    bool auto_downloadable = true;    ///< false ⇒ manual steps required.
+
+    // Multi-asset bundles (e.g. Magenta: weights + vocab + encoder). When empty the
+    // entry is single-file (checkpoint_ref). The downloader fetches all assets.
+    std::vector<ModelAsset> assets;
+
+    bool is_recommended = false;      ///< ⭐ in the model manager.
+    std::string license;              ///< e.g. "CC-BY-4.0".
+    std::string attribution;          ///< e.g. "Google DeepMind".
+    std::string min_device;           ///< Optional hint, e.g. "Pro/Max".
+};
+
+/// Resolve a checkpoint_ref to a direct download URL.
+/// "hf://user/repo/file" → "https://huggingface.co/user/repo/resolve/main/file".
+/// Rejects control bytes and `..` path segments. Passes http(s):// URLs through.
+std::string resolve_checkpoint_url(const std::string& checkpoint_ref);
+
+/// Find a model by id in a caller-supplied registry/catalog. Returns nullptr if absent.
+const ModelEntry* find_model(const std::vector<ModelEntry>& registry, std::string_view model_id);
+
+}  // namespace pulp::runtime

--- a/core/runtime/include/pulp/runtime/model_store.hpp
+++ b/core/runtime/include/pulp/runtime/model_store.hpp
@@ -8,11 +8,17 @@
 // one mechanism. The downloader (install) lands in a follow-up (MM-PR2).
 
 #include <filesystem>
+#include <functional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include <pulp/runtime/model_registry.hpp>
+
+namespace pulp::runtime {
+class CancellationToken;  // async_stream.hpp
+}
 
 namespace pulp::runtime {
 
@@ -73,5 +79,31 @@ ActivateModelResult activate_model(const std::vector<ModelEntry>& registry, std:
 
 std::string to_json(const ModelListResult& result);
 std::string to_json(const ActivateModelResult& result);
+
+// ---- install / remove (MM-PR2: built on the streaming downloader) -------------------
+
+struct InstallModelResult {
+    bool ok = false;
+    std::string error;
+    bool cancelled = false;
+    std::filesystem::path checkpoint_path;  // downloaded file
+    std::filesystem::path metadata_path;    // <home>/<subsystem>/models/<id>.json
+    std::string sha256;
+};
+
+/// Download `model`'s checkpoint into `<home>/<subsystem>/models/<id>/` (streaming,
+/// resumable, sha256-verified), then write the install metadata so read_installed_model/
+/// activate_model see it. `on_progress` returning false (or a cancelled token) aborts and
+/// keeps the partial for a later resume. Auth headers (e.g. HuggingFace token) optional.
+InstallModelResult install_model(const ModelEntry& model, std::string_view subsystem,
+                                 const std::function<bool(const struct DownloadProgress&)>& on_progress = {},
+                                 const CancellationToken* cancel = nullptr,
+                                 const std::vector<std::pair<std::string, std::string>>& headers = {},
+                                 const std::filesystem::path& pulp_home_override = {});
+
+/// Delete an installed model's files + metadata. Clears the active selection if it pointed
+/// here. Returns false (with `error` set) on failure; true if removed or already absent.
+bool remove_model(std::string_view subsystem, std::string_view model_id, std::string& error,
+                  const std::filesystem::path& pulp_home_override = {});
 
 }  // namespace pulp::runtime

--- a/core/runtime/include/pulp/runtime/model_store.hpp
+++ b/core/runtime/include/pulp/runtime/model_store.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+// Generic model store/state primitive (promoted from tools/audio). Owns the on-disk
+// layout under PULP_HOME (`<home>/<subsystem>/model-state.json` for the active model,
+// `<home>/<subsystem>/models/<id>.json` for per-model install metadata), the
+// installed/active queries, list (over a caller-supplied registry), and activate.
+// Parameterized by `subsystem` (e.g. "audio", "magenta") so multiple consumers share
+// one mechanism. The downloader (install) lands in a follow-up (MM-PR2).
+
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <pulp/runtime/model_registry.hpp>
+
+namespace pulp::runtime {
+
+struct InstalledModelRecord {
+    std::filesystem::path metadata_path;
+    bool metadata_found = false;
+    std::string model_id;
+    std::string backend;
+    std::string checkpoint_ref;
+    std::filesystem::path resolved_checkpoint_path;
+    bool checkpoint_exists = false;
+
+    [[nodiscard]] bool loadable() const { return metadata_found && checkpoint_exists; }
+};
+
+struct ListedModel {
+    ModelEntry model;
+    std::string status = "not_installed";  // installed | missing_checkpoint | not_installed
+    bool active = false;
+    std::filesystem::path resolved_checkpoint_path;
+};
+
+struct ModelListResult {
+    std::filesystem::path pulp_home;
+    std::string active_model_id;
+    std::vector<ListedModel> models;
+    std::string error;
+};
+
+struct ActivateModelResult {
+    bool ok = false;
+    std::filesystem::path state_path;
+    std::string active_model_id;
+    std::string backend;
+    std::string checkpoint_ref;
+    std::filesystem::path resolved_checkpoint_path;
+    std::string error;
+};
+
+// PULP_HOME resolution: explicit override → $PULP_HOME → $HOME/.pulp (USERPROFILE on
+// Windows). NOTE (path policy, see plan): a sandboxed AUv3/iOS host may not have HOME
+// access — callers in those contexts should pass an explicit container path.
+std::filesystem::path resolve_pulp_home(const std::filesystem::path& override_path = {});
+
+std::filesystem::path model_state_path(std::string_view subsystem,
+                                       const std::filesystem::path& pulp_home_override = {});
+std::filesystem::path model_install_path(std::string_view subsystem, std::string_view model_id,
+                                         const std::filesystem::path& pulp_home_override = {});
+InstalledModelRecord read_installed_model(std::string_view subsystem, std::string_view model_id,
+                                          const std::filesystem::path& pulp_home_override = {});
+std::string read_active_model_id(std::string_view subsystem,
+                                 const std::filesystem::path& pulp_home_override = {});
+ModelListResult list_models(const std::vector<ModelEntry>& registry, std::string_view subsystem,
+                            const std::filesystem::path& pulp_home_override = {});
+ActivateModelResult activate_model(const std::vector<ModelEntry>& registry, std::string_view subsystem,
+                                   std::string_view model_id,
+                                   const std::filesystem::path& pulp_home_override = {});
+
+std::string to_json(const ModelListResult& result);
+std::string to_json(const ActivateModelResult& result);
+
+}  // namespace pulp::runtime

--- a/core/runtime/src/model_download.cpp
+++ b/core/runtime/src/model_download.cpp
@@ -1,0 +1,234 @@
+#include <pulp/runtime/model_download.hpp>
+
+#include <pulp/runtime/async_stream.hpp>
+
+#include <mbedtls/sha256.h>
+
+// HTTPS via cpp-httplib's mbedTLS backend. The CMake target defines
+// CPPHTTPLIB_MBEDTLS_SUPPORT when mbedTLS is available.
+#include <httplib.h>
+
+#include <array>
+#include <cstdint>
+#include <fstream>
+#include <regex>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace pulp::runtime {
+
+namespace {
+
+struct ParsedUrl {
+    std::string scheme_host_port;  // e.g. "https://huggingface.co"
+    std::string path;              // e.g. "/user/repo/resolve/main/file"
+    bool ok = false;
+};
+
+ParsedUrl parse_url(const std::string& url) {
+    static const std::regex re(R"(^(https?)://([^/:]+)(?::(\d+))?(/.*)?$)", std::regex::icase);
+    std::smatch m;
+    ParsedUrl out;
+    if (!std::regex_match(url, m, re)) return out;
+    const std::string scheme = m[1].str();
+    const std::string host = m[2].str();
+    const std::string port = m[3].str();
+    const std::string path = m[4].str();
+    out.scheme_host_port = scheme + "://" + host + (port.empty() ? "" : ":" + port);
+    out.path = path.empty() ? "/" : path;
+    out.ok = true;
+    return out;
+}
+
+std::string to_hex(const unsigned char* data, size_t n) {
+    static const char* digits = "0123456789abcdef";
+    std::string s;
+    s.reserve(n * 2);
+    for (size_t i = 0; i < n; ++i) {
+        s += digits[data[i] >> 4];
+        s += digits[data[i] & 0x0F];
+    }
+    return s;
+}
+
+// Feed a file's existing bytes into the running SHA (resume re-hash).
+bool hash_existing(mbedtls_sha256_context& ctx, const fs::path& path, std::uint64_t& counted) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) return false;
+    std::array<char, 1 << 16> buf{};
+    while (in) {
+        in.read(buf.data(), static_cast<std::streamsize>(buf.size()));
+        const auto got = in.gcount();
+        if (got > 0) {
+            mbedtls_sha256_update(&ctx, reinterpret_cast<const unsigned char*>(buf.data()),
+                                  static_cast<size_t>(got));
+            counted += static_cast<std::uint64_t>(got);
+        }
+    }
+    return true;
+}
+
+// Best-effort system CA bundle for mbedTLS verification (macOS / common Linux).
+const char* system_ca_path() {
+    static const char* candidates[] = {
+        "/etc/ssl/cert.pem",                      // macOS, some BSDs
+        "/etc/ssl/certs/ca-certificates.crt",     // Debian/Ubuntu
+        "/etc/pki/tls/certs/ca-bundle.crt",       // RHEL/Fedora
+    };
+    for (const char* c : candidates) {
+        std::error_code ec;
+        if (fs::exists(c, ec)) return c;
+    }
+    return nullptr;
+}
+
+}  // namespace
+
+DownloadResult download_file(const DownloadRequest& req, const DownloadProgressFn& on_progress,
+                             const CancellationToken* cancel) {
+    DownloadResult r;
+    r.path = req.dest;
+
+    const auto parsed = parse_url(req.url);
+    if (!parsed.ok) {
+        r.error = "invalid url: " + req.url;
+        return r;
+    }
+
+    std::error_code ec;
+    if (!req.dest.parent_path().empty()) fs::create_directories(req.dest.parent_path(), ec);
+    fs::path part = req.dest;
+    part += ".part";
+
+    std::uint64_t resume_from = 0;
+    if (req.resume && fs::exists(part, ec)) resume_from = static_cast<std::uint64_t>(fs::file_size(part, ec));
+
+    mbedtls_sha256_context sha;
+    mbedtls_sha256_init(&sha);
+    mbedtls_sha256_starts(&sha, 0);  // 0 = SHA-256 (not SHA-224)
+
+    std::uint64_t downloaded = 0;
+    if (resume_from > 0 && !hash_existing(sha, part, downloaded)) resume_from = 0;  // unreadable → restart
+
+    std::ofstream out;
+    auto open_out = [&](bool append) {
+        out.close();
+        out.clear();
+        out.open(part, std::ios::binary | (append ? std::ios::app : std::ios::trunc));
+    };
+    open_out(resume_from > 0);
+    if (!out) {
+        mbedtls_sha256_free(&sha);
+        r.error = "cannot open " + part.string() + " for writing";
+        return r;
+    }
+
+    httplib::Client cli(parsed.scheme_host_port);
+    cli.set_follow_location(true);
+    cli.set_keep_alive(true);
+    if (req.timeout_seconds > 0) {
+        cli.set_read_timeout(req.timeout_seconds, 0);
+        cli.set_connection_timeout(req.timeout_seconds, 0);
+    }
+    if (const char* ca = system_ca_path()) cli.set_ca_cert_path(ca);
+    cli.enable_server_certificate_verification(true);
+
+    httplib::Headers headers;
+    for (const auto& h : req.headers) headers.emplace(h.name, h.value);
+    const bool attempted_resume = resume_from > 0;
+    if (attempted_resume) headers.emplace("Range", "bytes=" + std::to_string(resume_from) + "-");
+
+    std::uint64_t total = 0;
+    bool reset_due_to_200 = false;
+    bool user_cancel = false;
+    bool write_error = false;
+
+    auto response_handler = [&](const httplib::Response& resp) -> bool {
+        if (attempted_resume && resp.status == 200) {
+            // Server ignored our Range request — discard the partial and restart.
+            reset_due_to_200 = true;
+            mbedtls_sha256_free(&sha);
+            mbedtls_sha256_init(&sha);
+            mbedtls_sha256_starts(&sha, 0);
+            downloaded = 0;
+            open_out(false);
+        }
+        if (auto it = resp.headers.find("Content-Length"); it != resp.headers.end()) {
+            try {
+                total = downloaded + std::stoull(it->second);
+            } catch (...) {
+                total = 0;
+            }
+        }
+        return true;
+    };
+
+    auto content_receiver = [&](const char* data, size_t len) -> bool {
+        out.write(data, static_cast<std::streamsize>(len));
+        if (!out) {
+            write_error = true;
+            return false;
+        }
+        mbedtls_sha256_update(&sha, reinterpret_cast<const unsigned char*>(data), len);
+        downloaded += len;
+        if (cancel && cancel->is_cancelled()) {
+            user_cancel = true;
+            return false;
+        }
+        if (on_progress && !on_progress(DownloadProgress{downloaded, total})) {
+            user_cancel = true;
+            return false;
+        }
+        return true;
+    };
+
+    auto result = cli.Get(parsed.path, headers, response_handler, content_receiver);
+    out.flush();
+    out.close();
+
+    if (write_error) {
+        mbedtls_sha256_free(&sha);
+        r.error = "write failed to " + part.string();
+        return r;  // keep .part
+    }
+    if (user_cancel) {
+        mbedtls_sha256_free(&sha);
+        r.cancelled = true;
+        r.error = "cancelled";
+        return r;  // keep .part for resume
+    }
+    if (!result) {
+        mbedtls_sha256_free(&sha);
+        r.error = "http error: " + httplib::to_string(result.error());
+        return r;  // keep .part
+    }
+    if (result->status != 200 && result->status != 206) {
+        mbedtls_sha256_free(&sha);
+        r.error = "http status " + std::to_string(result->status);
+        return r;
+    }
+
+    unsigned char digest[32];
+    mbedtls_sha256_finish(&sha, digest);
+    mbedtls_sha256_free(&sha);
+    r.sha256 = to_hex(digest, sizeof digest);
+    r.resumed = attempted_resume && !reset_due_to_200;
+
+    if (!req.expected_sha256.empty() && req.expected_sha256 != r.sha256) {
+        fs::remove(part, ec);  // corrupt — don't leave a resumable bad file
+        r.error = "sha256 mismatch: expected " + req.expected_sha256 + " got " + r.sha256;
+        return r;
+    }
+
+    fs::rename(part, req.dest, ec);
+    if (ec) {
+        r.error = "rename failed: " + ec.message();
+        return r;
+    }
+    r.bytes = static_cast<std::uint64_t>(fs::file_size(req.dest, ec));
+    r.ok = true;
+    return r;
+}
+
+}  // namespace pulp::runtime

--- a/core/runtime/src/model_registry.cpp
+++ b/core/runtime/src/model_registry.cpp
@@ -1,0 +1,61 @@
+#include <pulp/runtime/model_registry.hpp>
+
+namespace pulp::runtime {
+
+namespace {
+
+bool has_control_byte(std::string_view text) {
+    for (unsigned char ch : text) {
+        if (ch < 0x20) return true;
+    }
+    return false;
+}
+
+bool has_dot_dot_segment(std::string_view path) {
+    std::size_t start = 0;
+    while (start <= path.size()) {
+        auto slash = path.find('/', start);
+        auto seg = path.substr(start,
+            slash == std::string_view::npos ? std::string_view::npos : slash - start);
+        if (seg == "..") return true;
+        if (slash == std::string_view::npos) break;
+        start = slash + 1;
+    }
+    return false;
+}
+
+}  // namespace
+
+std::string resolve_checkpoint_url(const std::string& checkpoint_ref) {
+    // hf://user/repo/path/to/file → https://huggingface.co/user/repo/resolve/main/path/to/file
+    if (checkpoint_ref.starts_with("hf://")) {
+        auto path = checkpoint_ref.substr(5);  // after "hf://"
+        auto first_slash = path.find('/');
+        if (first_slash == std::string::npos) return {};
+        auto second_slash = path.find('/', first_slash + 1);
+        if (second_slash == std::string::npos) return {};
+        if (first_slash == 0 || second_slash == first_slash + 1) return {};
+        auto user_repo = path.substr(0, second_slash);   // "user/repo"
+        auto file_path = path.substr(second_slash + 1);  // "path/to/file"
+        if (file_path.empty()) return {};
+        if (has_control_byte(user_repo)) return {};
+        if (file_path.starts_with('/') || has_control_byte(file_path)) return {};
+        // Reject any `..` path segment. HTTP doesn't normalize `..` in URL paths, but
+        // proxies/CDNs/redirect handlers sometimes do, which could let the resolved URL
+        // escape the intended `resolve/main/<file>` prefix.
+        if (has_dot_dot_segment(file_path)) return {};
+        return "https://huggingface.co/" + user_repo + "/resolve/main/" + file_path;
+    }
+    if (checkpoint_ref.starts_with("http://") || checkpoint_ref.starts_with("https://"))
+        return checkpoint_ref;
+    return {};
+}
+
+const ModelEntry* find_model(const std::vector<ModelEntry>& registry, std::string_view model_id) {
+    for (const auto& model : registry) {
+        if (model.model_id == model_id) return &model;
+    }
+    return nullptr;
+}
+
+}  // namespace pulp::runtime

--- a/core/runtime/src/model_store.cpp
+++ b/core/runtime/src/model_store.cpp
@@ -1,5 +1,6 @@
 #include <pulp/runtime/model_store.hpp>
 
+#include <pulp/runtime/model_download.hpp>
 #include <pulp/runtime/system.hpp>
 
 #include <choc/text/choc_JSON.h>
@@ -256,6 +257,86 @@ std::string to_json(const ActivateModelResult& result) {
     add_path_member(object, "resolved_checkpoint_path", result.resolved_checkpoint_path);
     add_string_member(object, "error", result.error);
     return choc::json::toString(object, true);
+}
+
+InstallModelResult install_model(const ModelEntry& model, std::string_view subsystem,
+                                 const std::function<bool(const DownloadProgress&)>& on_progress,
+                                 const CancellationToken* cancel,
+                                 const std::vector<std::pair<std::string, std::string>>& headers,
+                                 const fs::path& pulp_home_override) {
+    InstallModelResult r;
+    const std::string url =
+        model.download_url.empty() ? resolve_checkpoint_url(model.checkpoint_ref) : model.download_url;
+    if (url.empty()) {
+        r.error = "cannot resolve a download URL for " + model.model_id;
+        return r;
+    }
+    const auto home = resolve_pulp_home(pulp_home_override);
+    if (home.empty()) {
+        r.error = "unable to resolve PULP_HOME";
+        return r;
+    }
+
+    const fs::path files_dir = home / std::string(subsystem) / "models" / model.model_id;
+    std::string fname;
+    if (auto slash = url.find_last_of('/'); slash != std::string::npos) fname = url.substr(slash + 1);
+    if (auto q = fname.find('?'); q != std::string::npos) fname = fname.substr(0, q);
+    if (fname.empty()) fname = model.model_id + ".bin";
+    const fs::path dest = files_dir / fname;
+
+    DownloadRequest req;
+    req.url = url;
+    req.dest = dest;
+    req.expected_sha256 = model.sha256;
+    req.resume = true;
+    for (const auto& h : headers) req.headers.push_back(HttpHeader{h.first, h.second});
+
+    const auto dl = download_file(req, on_progress, cancel);
+    if (dl.cancelled) {
+        r.cancelled = true;
+        r.error = "cancelled";
+        return r;
+    }
+    if (!dl.ok) {
+        r.error = dl.error;
+        return r;
+    }
+
+    r.checkpoint_path = dest;
+    r.sha256 = dl.sha256;
+    r.metadata_path = model_install_path(subsystem, model.model_id, pulp_home_override);
+
+    auto object = choc::value::createObject("");
+    add_string_member(object, "model_id", model.model_id);
+    add_string_member(object, "backend", model.backend);
+    add_string_member(object, "checkpoint_ref", model.checkpoint_ref);
+    add_path_member(object, "resolved_checkpoint_path", dest);
+    add_string_member(object, "sha256", dl.sha256);
+
+    std::string error;
+    if (!write_text_file(r.metadata_path, choc::json::toString(object, true), error)) {
+        r.error = error;
+        return r;
+    }
+    r.ok = true;
+    return r;
+}
+
+bool remove_model(std::string_view subsystem, std::string_view model_id, std::string& error,
+                  const fs::path& pulp_home_override) {
+    const auto home = resolve_pulp_home(pulp_home_override);
+    if (home.empty()) {
+        error = "unable to resolve PULP_HOME";
+        return false;
+    }
+    std::error_code ec;
+    fs::remove_all(home / std::string(subsystem) / "models" / std::string(model_id), ec);
+    fs::remove(model_install_path(subsystem, model_id, pulp_home_override), ec);
+    // Clear the active selection if it pointed at the removed model.
+    if (read_active_model_id(subsystem, pulp_home_override) == model_id) {
+        fs::remove(model_state_path(subsystem, pulp_home_override), ec);
+    }
+    return true;
 }
 
 }  // namespace pulp::runtime

--- a/core/runtime/src/model_store.cpp
+++ b/core/runtime/src/model_store.cpp
@@ -1,4 +1,4 @@
-#include <pulp/tools/audio/model_store.hpp>
+#include <pulp/runtime/model_store.hpp>
 
 #include <pulp/runtime/system.hpp>
 
@@ -10,14 +10,13 @@
 
 namespace fs = std::filesystem;
 
-namespace pulp::tools::audio {
+namespace pulp::runtime {
 
 namespace {
 
 std::string read_text_file(const fs::path& path) {
     std::ifstream input(path);
     if (!input.is_open()) return {};
-
     std::ostringstream buffer;
     buffer << input.rdbuf();
     return buffer.str();
@@ -29,7 +28,6 @@ bool parse_json_file(const fs::path& path, choc::value::Value& value, std::strin
         error = "failed to read " + path.string();
         return false;
     }
-
     try {
         value = choc::json::parse(text);
         return true;
@@ -45,7 +43,6 @@ bool parse_json_file(const fs::path& path, choc::value::Value& value, std::strin
 std::string object_string(const choc::value::ValueView& object,
                           std::initializer_list<const char*> keys) {
     if (!object.isObject()) return {};
-
     for (auto* key : keys) {
         if (!object.hasObjectMember(key)) continue;
         auto value = object[key];
@@ -53,7 +50,6 @@ std::string object_string(const choc::value::ValueView& object,
         auto text = std::string(value.toString());
         if (!text.empty()) return text;
     }
-
     return {};
 }
 
@@ -72,64 +68,57 @@ bool write_text_file(const fs::path& path, const std::string& content, std::stri
         error = "failed to create " + path.parent_path().string() + ": " + ec.message();
         return false;
     }
-
     std::ofstream output(path);
     if (!output.is_open()) {
         error = "failed to open " + path.string() + " for writing";
         return false;
     }
-
     output << content;
     if (!output.good()) {
         error = "failed to write " + path.string();
         return false;
     }
-
     return true;
 }
 
-} // namespace
+}  // namespace
 
 fs::path resolve_pulp_home(const fs::path& override_path) {
     if (!override_path.empty()) return override_path;
-
-    if (auto pulp_home = runtime::get_env("PULP_HOME"))
-        return fs::path(*pulp_home);
-
-    auto home = runtime::get_env("HOME");
+    if (auto pulp_home = get_env("PULP_HOME")) return fs::path(*pulp_home);
+    auto home = get_env("HOME");
 #ifdef _WIN32
-    if (!home) home = runtime::get_env("USERPROFILE");
+    if (!home) home = get_env("USERPROFILE");
 #endif
     if (!home) return {};
     return fs::path(*home) / ".pulp";
 }
 
-fs::path audio_model_state_path(const fs::path& pulp_home_override) {
+fs::path model_state_path(std::string_view subsystem, const fs::path& pulp_home_override) {
     auto pulp_home = resolve_pulp_home(pulp_home_override);
     if (pulp_home.empty()) return {};
-    return pulp_home / "audio" / "model-state.json";
+    return pulp_home / std::string(subsystem) / "model-state.json";
 }
 
-fs::path audio_model_install_path(std::string_view model_id, const fs::path& pulp_home_override) {
+fs::path model_install_path(std::string_view subsystem, std::string_view model_id,
+                            const fs::path& pulp_home_override) {
     auto pulp_home = resolve_pulp_home(pulp_home_override);
     if (pulp_home.empty()) return {};
-    return pulp_home / "audio" / "models" / (std::string(model_id) + ".json");
+    return pulp_home / std::string(subsystem) / "models" / (std::string(model_id) + ".json");
 }
 
-InstalledModelRecord read_installed_model(std::string_view model_id, const fs::path& pulp_home_override) {
+InstalledModelRecord read_installed_model(std::string_view subsystem, std::string_view model_id,
+                                          const fs::path& pulp_home_override) {
     InstalledModelRecord record;
-    record.metadata_path = audio_model_install_path(model_id, pulp_home_override);
+    record.metadata_path = model_install_path(subsystem, model_id, pulp_home_override);
     record.model_id = std::string(model_id);
 
-    if (record.metadata_path.empty() || !fs::exists(record.metadata_path))
-        return record;
-
+    if (record.metadata_path.empty() || !fs::exists(record.metadata_path)) return record;
     record.metadata_found = true;
 
     choc::value::Value value;
     std::string error;
-    if (!parse_json_file(record.metadata_path, value, error))
-        return record;
+    if (!parse_json_file(record.metadata_path, value, error)) return record;
 
     auto root = value.getView();
     auto parsed_model_id = object_string(root, {"model_id"});
@@ -142,27 +131,23 @@ InstalledModelRecord read_installed_model(std::string_view model_id, const fs::p
         record.resolved_checkpoint_path = fs::path(checkpoint);
         record.checkpoint_exists = fs::exists(record.resolved_checkpoint_path);
     }
-
     return record;
 }
 
-std::string read_active_model_id(const fs::path& pulp_home_override) {
-    auto state_path = audio_model_state_path(pulp_home_override);
+std::string read_active_model_id(std::string_view subsystem, const fs::path& pulp_home_override) {
+    auto state_path = model_state_path(subsystem, pulp_home_override);
     if (state_path.empty() || !fs::exists(state_path)) return {};
 
     choc::value::Value value;
     std::string error;
     if (!parse_json_file(state_path, value, error)) return {};
 
-    return object_string(value.getView(), {
-        "active_model_id",
-        "configured_model_id",
-        "requested_model_id",
-        "model_id",
-    });
+    return object_string(value.getView(),
+                         {"active_model_id", "configured_model_id", "requested_model_id", "model_id"});
 }
 
-ModelListResult list_models(const fs::path& pulp_home_override) {
+ModelListResult list_models(const std::vector<ModelEntry>& registry, std::string_view subsystem,
+                            const fs::path& pulp_home_override) {
     ModelListResult result;
     result.pulp_home = resolve_pulp_home(pulp_home_override);
     if (result.pulp_home.empty()) {
@@ -170,45 +155,45 @@ ModelListResult list_models(const fs::path& pulp_home_override) {
         return result;
     }
 
-    result.active_model_id = read_active_model_id(result.pulp_home);
-    for (const auto& model : registered_models()) {
+    result.active_model_id = read_active_model_id(subsystem, result.pulp_home);
+    for (const auto& model : registry) {
         ListedModel listed;
         listed.model = model;
         listed.active = (model.model_id == result.active_model_id);
 
-        auto installed = read_installed_model(model.model_id, result.pulp_home);
+        auto installed = read_installed_model(subsystem, model.model_id, result.pulp_home);
         if (installed.metadata_found) {
             listed.status = installed.checkpoint_exists ? "installed" : "missing_checkpoint";
             listed.resolved_checkpoint_path = installed.resolved_checkpoint_path;
         }
-
         result.models.push_back(std::move(listed));
     }
-
     return result;
 }
 
-ActivateModelResult activate_model(std::string_view model_id, const fs::path& pulp_home_override) {
+ActivateModelResult activate_model(const std::vector<ModelEntry>& registry, std::string_view subsystem,
+                                   std::string_view model_id, const fs::path& pulp_home_override) {
     ActivateModelResult result;
-    result.state_path = audio_model_state_path(pulp_home_override);
+    result.state_path = model_state_path(subsystem, pulp_home_override);
     if (result.state_path.empty()) {
         result.error = "unable to resolve PULP_HOME";
         return result;
     }
 
-    auto* registered = find_registered_model(model_id);
+    auto* registered = find_model(registry, model_id);
     if (!registered) {
         result.error = "unknown model_id: " + std::string(model_id);
         return result;
     }
 
-    auto installed = read_installed_model(model_id, pulp_home_override);
+    auto installed = read_installed_model(subsystem, model_id, pulp_home_override);
     if (!installed.metadata_found) {
         result.error = "model is not installed: " + std::string(model_id);
         return result;
     }
     if (!installed.checkpoint_exists) {
-        result.error = "installed model checkpoint does not exist: " + installed.resolved_checkpoint_path.string();
+        result.error = "installed model checkpoint does not exist: " +
+                       installed.resolved_checkpoint_path.string();
         return result;
     }
 
@@ -273,4 +258,4 @@ std::string to_json(const ActivateModelResult& result) {
     return choc::json::toString(object, true);
 }
 
-} // namespace pulp::tools::audio
+}  // namespace pulp::runtime

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -899,6 +899,11 @@ pulp_add_test_suite(pulp-test-stream LIBRARIES pulp::runtime)
 # Generic model registry/store (MM-PR1)
 pulp_add_test_suite(pulp-test-model-store LIBRARIES pulp::runtime)
 
+# Streaming model downloader (MM-PR2) — uses a local httplib server fixture
+pulp_add_test_suite(pulp-test-model-download LIBRARIES pulp::runtime)
+target_include_directories(pulp-test-model-download PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../external/cpp-httplib)
+
 # Native-component core ABI contract tests. Always built (no Rust toolchain
 # needed) — one case per forward-compatibility decision (1-12) so the C ABI
 # shape can't silently drift. The Rust round-trip + RT-safety self-test is the

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -896,6 +896,9 @@ pulp_add_test_suite(pulp-test-progress-parser LIBRARIES pulp::platform)
 # Stream tests (unified I/O interface)
 pulp_add_test_suite(pulp-test-stream LIBRARIES pulp::runtime)
 
+# Generic model registry/store (MM-PR1)
+pulp_add_test_suite(pulp-test-model-store LIBRARIES pulp::runtime)
+
 # Native-component core ABI contract tests. Always built (no Rust toolchain
 # needed) — one case per forward-compatibility decision (1-12) so the C ABI
 # shape can't silently drift. The Rust round-trip + RT-safety self-test is the

--- a/test/test_model_download.cpp
+++ b/test/test_model_download.cpp
@@ -1,0 +1,189 @@
+// Streaming model downloader (MM-PR2) — exercised against a local HTTP server (no
+// TLS, so no network + no flakiness): full download + sha256 + atomic rename, Range
+// resume, sha256-mismatch rejection, and cancel-keeps-partial. The HTTPS/mbedTLS path
+// is the same code; only the transport differs.
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/runtime/crypto.hpp>
+#include <pulp/runtime/model_download.hpp>
+#include <pulp/runtime/model_registry.hpp>
+#include <pulp/runtime/model_store.hpp>
+
+#include <httplib.h>
+
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+
+using namespace pulp::runtime;
+namespace fs = std::filesystem;
+
+namespace {
+
+struct LocalServer {
+    httplib::Server svr;
+    std::thread thread;
+    int port = 0;
+
+    explicit LocalServer(const fs::path& serve_dir) {
+        svr.set_mount_point("/", serve_dir.string());  // static files w/ Range support
+        port = svr.bind_to_any_port("127.0.0.1");
+        thread = std::thread([this] { svr.listen_after_bind(); });
+        svr.wait_until_ready();
+    }
+    ~LocalServer() {
+        svr.stop();
+        if (thread.joinable()) thread.join();
+    }
+    std::string url(const std::string& path) const {
+        return "http://127.0.0.1:" + std::to_string(port) + path;
+    }
+};
+
+std::string make_fixture(const fs::path& path, size_t n) {
+    std::string body;
+    body.reserve(n);
+    for (size_t i = 0; i < n; ++i) body += static_cast<char>('A' + (i * 7 + 3) % 26);
+    std::ofstream(path, std::ios::binary).write(body.data(), static_cast<std::streamsize>(body.size()));
+    return body;
+}
+
+}  // namespace
+
+TEST_CASE("model downloader: full download + sha256 + atomic rename", "[runtime][model][download]") {
+    const fs::path root = fs::temp_directory_path() / "pulp-mm-pr2";
+    fs::remove_all(root);
+    fs::create_directories(root / "serve");
+    const std::string body = make_fixture(root / "serve" / "fixture.bin", 250'000);
+    const std::string sha = sha256_hex(body);
+
+    LocalServer server(root / "serve");
+
+    const fs::path dest = root / "out" / "fixture.bin";
+    DownloadRequest req{.url = server.url("/fixture.bin"), .dest = dest, .expected_sha256 = sha};
+
+    auto res = download_file(req);
+    INFO("error: " << res.error);
+    REQUIRE(res.ok);
+    REQUIRE(res.sha256 == sha);
+    REQUIRE(res.bytes == body.size());
+    REQUIRE(fs::exists(dest));
+    REQUIRE_FALSE(fs::exists(fs::path(dest) += ".part"));  // .part consumed by atomic rename
+
+    fs::remove_all(root);
+}
+
+TEST_CASE("model downloader: Range resume continues a partial", "[runtime][model][download]") {
+    const fs::path root = fs::temp_directory_path() / "pulp-mm-pr2-resume";
+    fs::remove_all(root);
+    fs::create_directories(root / "serve");
+    fs::create_directories(root / "out");
+    const std::string body = make_fixture(root / "serve" / "fixture.bin", 250'000);
+    const std::string sha = sha256_hex(body);
+
+    LocalServer server(root / "serve");
+
+    // Seed a partial .part with the first 100k bytes (as a prior interrupted download would).
+    const fs::path dest = root / "out" / "fixture.bin";
+    fs::path part = dest;
+    part += ".part";
+    std::ofstream(part, std::ios::binary).write(body.data(), 100'000);
+
+    DownloadRequest req{.url = server.url("/fixture.bin"), .dest = dest, .expected_sha256 = sha,
+                        .resume = true};
+    auto res = download_file(req);
+    INFO("error: " << res.error);
+    REQUIRE(res.ok);
+    REQUIRE(res.resumed);
+    REQUIRE(res.sha256 == sha);  // re-hashed the partial + streamed the rest correctly
+    REQUIRE(fs::exists(dest));
+
+    fs::remove_all(root);
+}
+
+TEST_CASE("model downloader: sha256 mismatch is rejected", "[runtime][model][download]") {
+    const fs::path root = fs::temp_directory_path() / "pulp-mm-pr2-bad";
+    fs::remove_all(root);
+    fs::create_directories(root / "serve");
+    make_fixture(root / "serve" / "fixture.bin", 50'000);
+
+    LocalServer server(root / "serve");
+
+    const fs::path dest = root / "out" / "fixture.bin";
+    DownloadRequest req{.url = server.url("/fixture.bin"), .dest = dest,
+                        .expected_sha256 = std::string(64, 'a')};  // wrong
+    auto res = download_file(req);
+    REQUIRE_FALSE(res.ok);
+    REQUIRE(res.error.find("mismatch") != std::string::npos);
+    REQUIRE_FALSE(fs::exists(dest));                    // not published
+    REQUIRE_FALSE(fs::exists(fs::path(dest) += ".part"));  // corrupt partial removed
+
+    fs::remove_all(root);
+}
+
+TEST_CASE("model downloader: cancel keeps the partial for resume", "[runtime][model][download]") {
+    const fs::path root = fs::temp_directory_path() / "pulp-mm-pr2-cancel";
+    fs::remove_all(root);
+    fs::create_directories(root / "serve");
+    make_fixture(root / "serve" / "fixture.bin", 500'000);
+
+    LocalServer server(root / "serve");
+
+    const fs::path dest = root / "out" / "fixture.bin";
+    DownloadRequest req{.url = server.url("/fixture.bin"), .dest = dest};
+
+    std::atomic<int> chunks{0};
+    auto res = download_file(req, [&](const DownloadProgress&) {
+        return ++chunks < 1;  // cancel immediately after the first chunk
+    });
+    REQUIRE_FALSE(res.ok);
+    REQUIRE(res.cancelled);
+    REQUIRE_FALSE(fs::exists(dest));                 // not published
+    REQUIRE(fs::exists(fs::path(dest) += ".part"));  // partial kept for resume
+
+    fs::remove_all(root);
+}
+
+TEST_CASE("model store: install_model downloads + records, then remove_model deletes",
+          "[runtime][model][download]") {
+    const fs::path root = fs::temp_directory_path() / "pulp-mm-pr2-install";
+    fs::remove_all(root);
+    fs::create_directories(root / "serve");
+    const std::string body = make_fixture(root / "serve" / "weights.bin", 120'000);
+    const std::string sha = sha256_hex(body);
+
+    LocalServer server(root / "serve");
+    const fs::path home = root / "home";  // acts as PULP_HOME
+
+    ModelEntry model{.model_id = "m1", .display_name = "Model One", .backend = "mlx"};
+    model.download_url = server.url("/weights.bin");
+    model.sha256 = sha;
+
+    auto inst = install_model(model, "magenta", /*on_progress=*/{}, /*cancel=*/nullptr,
+                              /*headers=*/{}, home);
+    INFO("install error: " << inst.error);
+    REQUIRE(inst.ok);
+    REQUIRE(inst.sha256 == sha);
+    REQUIRE(fs::exists(inst.checkpoint_path));
+    REQUIRE(fs::exists(inst.metadata_path));
+
+    // The store now sees it installed + activatable.
+    auto rec = read_installed_model("magenta", "m1", home);
+    REQUIRE(rec.metadata_found);
+    REQUIRE(rec.checkpoint_exists);
+    std::vector<ModelEntry> registry = {model};
+    REQUIRE(activate_model(registry, "magenta", "m1", home).ok);
+    REQUIRE(read_active_model_id("magenta", home) == "m1");
+
+    // Remove deletes files + metadata and clears the active selection.
+    std::string err;
+    REQUIRE(remove_model("magenta", "m1", err, home));
+    REQUIRE(err.empty());
+    REQUIRE_FALSE(fs::exists(inst.checkpoint_path));
+    REQUIRE_FALSE(fs::exists(inst.metadata_path));
+    REQUIRE(read_active_model_id("magenta", home).empty());
+
+    fs::remove_all(root);
+}

--- a/test/test_model_store.cpp
+++ b/test/test_model_store.cpp
@@ -1,0 +1,78 @@
+// Generic pulp::runtime model registry/store (MM-PR1) — proves a non-audio consumer
+// can link the runtime header and that list/install/activate round-trips, with
+// subsystem isolation. (The audio CLI's behavior is covered by test_audio_tools.cpp.)
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/runtime/model_registry.hpp>
+#include <pulp/runtime/model_store.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <vector>
+
+using namespace pulp::runtime;
+namespace fs = std::filesystem;
+
+TEST_CASE("resolve_checkpoint_url: hf:// resolution + path hardening", "[runtime][model]") {
+    REQUIRE(resolve_checkpoint_url("hf://user/repo/file.pt") ==
+            "https://huggingface.co/user/repo/resolve/main/file.pt");
+    REQUIRE(resolve_checkpoint_url("hf://user/repo/path/to/w.mlxfn") ==
+            "https://huggingface.co/user/repo/resolve/main/path/to/w.mlxfn");
+    REQUIRE(resolve_checkpoint_url("https://example.com/m.bin") == "https://example.com/m.bin");
+    REQUIRE(resolve_checkpoint_url("hf://user/repo/../escape").empty());  // `..` rejected
+    REQUIRE(resolve_checkpoint_url("hf://user/repo").empty());            // no file part
+    REQUIRE(resolve_checkpoint_url("ftp://x/y").empty());                 // unsupported scheme
+}
+
+TEST_CASE("generic model store: list / install / activate round-trip + isolation",
+          "[runtime][model]") {
+    const fs::path home = fs::temp_directory_path() / "pulp-mm-pr1-test";
+    fs::remove_all(home);
+
+    std::vector<ModelEntry> registry = {
+        ModelEntry{.model_id = "m1", .display_name = "Model One", .backend = "mlx",
+                   .checkpoint_ref = "hf://a/b/w.mlxfn"},
+    };
+
+    // Nothing installed yet.
+    auto before = list_models(registry, "magenta", home);
+    REQUIRE(before.error.empty());
+    REQUIRE(before.models.size() == 1);
+    REQUIRE(before.models[0].status == "not_installed");
+    REQUIRE_FALSE(before.models[0].active);
+    REQUIRE(read_active_model_id("magenta", home).empty());
+
+    // Simulate an install: a checkpoint file + the per-model install metadata.
+    const fs::path ckpt = home / "magenta" / "models" / "w.mlxfn";
+    fs::create_directories(ckpt.parent_path());
+    std::ofstream(ckpt) << "weights-bytes";
+
+    const fs::path meta = model_install_path("magenta", "m1", home);
+    REQUIRE(meta == home / "magenta" / "models" / "m1.json");
+    fs::create_directories(meta.parent_path());
+    std::ofstream(meta) << R"({"model_id":"m1","backend":"mlx","checkpoint_ref":"hf://a/b/w.mlxfn",)"
+                        << R"("resolved_checkpoint_path":")" << ckpt.generic_string() << R"("})";
+
+    auto inst = read_installed_model("magenta", "m1", home);
+    REQUIRE(inst.metadata_found);
+    REQUIRE(inst.checkpoint_exists);
+    REQUIRE(inst.loadable());
+
+    auto act = activate_model(registry, "magenta", "m1", home);
+    INFO("activate error: " << act.error);
+    REQUIRE(act.ok);
+    REQUIRE(act.active_model_id == "m1");
+    REQUIRE(read_active_model_id("magenta", home) == "m1");
+
+    auto after = list_models(registry, "magenta", home);
+    REQUIRE(after.models[0].status == "installed");
+    REQUIRE(after.models[0].active);
+
+    // Subsystem isolation: the "audio" subsystem shares the home but sees no active model.
+    REQUIRE(read_active_model_id("audio", home).empty());
+
+    // Activating an unknown / uninstalled model fails cleanly.
+    REQUIRE_FALSE(activate_model(registry, "magenta", "nope", home).ok);
+
+    fs::remove_all(home);
+}

--- a/tools/audio/CMakeLists.txt
+++ b/tools/audio/CMakeLists.txt
@@ -10,7 +10,6 @@ target_include_directories(pulp-tool-audio
 target_sources(pulp-tool-audio PRIVATE
     src/excerpt_service.cpp
     src/model_registry.cpp
-    src/model_store.cpp
     src/service.cpp
 )
 

--- a/tools/audio/include/pulp/tools/audio/model_registry.hpp
+++ b/tools/audio/include/pulp/tools/audio/model_registry.hpp
@@ -1,31 +1,23 @@
 #pragma once
 
-#include <cstdint>
-#include <string>
+// The generic model registry now lives in pulp::runtime (so plugins/apps can link it).
+// tools/audio keeps the audio *catalog* (the data) + these compatibility aliases.
+
+#include <pulp/runtime/model_registry.hpp>
+
 #include <string_view>
 #include <vector>
 
 namespace pulp::tools::audio {
 
-struct RegisteredModel {
-    std::string model_id;
-    std::string display_name;
-    std::string backend;
-    std::string checkpoint_ref;       // e.g., "hf://user/repo/file.pt"
-    std::vector<std::string> task_tags;
-    std::uint64_t size_bytes = 0;
+using RegisteredModel = pulp::runtime::ModelEntry;
+using pulp::runtime::resolve_checkpoint_url;
 
-    // Phase 4 additions
-    std::string download_url;         // Direct HTTPS URL (resolved from checkpoint_ref)
-    std::string sha256;               // Expected hash of the checkpoint file
-    bool auto_downloadable = true;    // false if manual steps required
-};
-
-/// Resolve a checkpoint_ref to a direct download URL.
-/// "hf://user/repo/file" → "https://huggingface.co/user/repo/resolve/main/file"
-std::string resolve_checkpoint_url(const std::string& checkpoint_ref);
-
+/// The audio model catalog (CLAP etc.). Data lives here; the mechanism is generic.
 const std::vector<RegisteredModel>& registered_models();
-const RegisteredModel* find_registered_model(std::string_view model_id);
 
-} // namespace pulp::tools::audio
+inline const RegisteredModel* find_registered_model(std::string_view model_id) {
+    return pulp::runtime::find_model(registered_models(), model_id);
+}
+
+}  // namespace pulp::tools::audio

--- a/tools/audio/include/pulp/tools/audio/model_store.hpp
+++ b/tools/audio/include/pulp/tools/audio/model_store.hpp
@@ -1,62 +1,44 @@
 #pragma once
 
+// The generic model store now lives in pulp::runtime. tools/audio keeps these
+// thin wrappers (subsystem = "audio") so the CLI / MCP surface is unchanged.
+
 #include <filesystem>
 #include <string>
 #include <string_view>
-#include <vector>
 
+#include <pulp/runtime/model_store.hpp>
 #include <pulp/tools/audio/model_registry.hpp>
 
 namespace pulp::tools::audio {
 
-struct InstalledModelRecord {
-    std::filesystem::path metadata_path;
-    bool metadata_found = false;
-    std::string model_id;
-    std::string backend;
-    std::string checkpoint_ref;
-    std::filesystem::path resolved_checkpoint_path;
-    bool checkpoint_exists = false;
+using pulp::runtime::ActivateModelResult;
+using pulp::runtime::InstalledModelRecord;
+using pulp::runtime::ListedModel;
+using pulp::runtime::ModelListResult;
+using pulp::runtime::resolve_pulp_home;
+using pulp::runtime::to_json;
 
-    [[nodiscard]] bool loadable() const { return metadata_found && checkpoint_exists; }
-};
+inline std::filesystem::path audio_model_state_path(const std::filesystem::path& pulp_home_override = {}) {
+    return pulp::runtime::model_state_path("audio", pulp_home_override);
+}
+inline std::filesystem::path audio_model_install_path(std::string_view model_id,
+                                                      const std::filesystem::path& pulp_home_override = {}) {
+    return pulp::runtime::model_install_path("audio", model_id, pulp_home_override);
+}
+inline InstalledModelRecord read_installed_model(std::string_view model_id,
+                                                 const std::filesystem::path& pulp_home_override = {}) {
+    return pulp::runtime::read_installed_model("audio", model_id, pulp_home_override);
+}
+inline std::string read_active_model_id(const std::filesystem::path& pulp_home_override = {}) {
+    return pulp::runtime::read_active_model_id("audio", pulp_home_override);
+}
+inline ModelListResult list_models(const std::filesystem::path& pulp_home_override = {}) {
+    return pulp::runtime::list_models(registered_models(), "audio", pulp_home_override);
+}
+inline ActivateModelResult activate_model(std::string_view model_id,
+                                          const std::filesystem::path& pulp_home_override = {}) {
+    return pulp::runtime::activate_model(registered_models(), "audio", model_id, pulp_home_override);
+}
 
-struct ListedModel {
-    RegisteredModel model;
-    std::string status = "not_installed";
-    bool active = false;
-    std::filesystem::path resolved_checkpoint_path;
-};
-
-struct ModelListResult {
-    std::filesystem::path pulp_home;
-    std::string active_model_id;
-    std::vector<ListedModel> models;
-    std::string error;
-};
-
-struct ActivateModelResult {
-    bool ok = false;
-    std::filesystem::path state_path;
-    std::string active_model_id;
-    std::string backend;
-    std::string checkpoint_ref;
-    std::filesystem::path resolved_checkpoint_path;
-    std::string error;
-};
-
-std::filesystem::path resolve_pulp_home(const std::filesystem::path& override_path = {});
-std::filesystem::path audio_model_state_path(const std::filesystem::path& pulp_home_override = {});
-std::filesystem::path audio_model_install_path(std::string_view model_id,
-                                               const std::filesystem::path& pulp_home_override = {});
-InstalledModelRecord read_installed_model(std::string_view model_id,
-                                          const std::filesystem::path& pulp_home_override = {});
-std::string read_active_model_id(const std::filesystem::path& pulp_home_override = {});
-ModelListResult list_models(const std::filesystem::path& pulp_home_override = {});
-ActivateModelResult activate_model(std::string_view model_id,
-                                   const std::filesystem::path& pulp_home_override = {});
-
-std::string to_json(const ModelListResult& result);
-std::string to_json(const ActivateModelResult& result);
-
-} // namespace pulp::tools::audio
+}  // namespace pulp::tools::audio

--- a/tools/audio/src/model_registry.cpp
+++ b/tools/audio/src/model_registry.cpp
@@ -2,30 +2,8 @@
 
 namespace pulp::tools::audio {
 
-namespace {
-
-bool has_control_byte(std::string_view text) {
-    for (unsigned char ch : text) {
-        if (ch < 0x20) return true;
-    }
-    return false;
-}
-
-bool has_dot_dot_segment(std::string_view path) {
-    std::size_t start = 0;
-    while (start <= path.size()) {
-        auto slash = path.find('/', start);
-        auto seg = path.substr(start,
-            slash == std::string_view::npos ? std::string_view::npos : slash - start);
-        if (seg == "..") return true;
-        if (slash == std::string_view::npos) break;
-        start = slash + 1;
-    }
-    return false;
-}
-
-} // namespace
-
+// The audio model catalog. The registry type + URL resolution + lookup are generic
+// (pulp::runtime); only this data lives here.
 const std::vector<RegisteredModel>& registered_models() {
     static const std::vector<RegisteredModel> models = {{
         .model_id = "clap_music_audioset_v1",
@@ -41,38 +19,4 @@ const std::vector<RegisteredModel>& registered_models() {
     return models;
 }
 
-const RegisteredModel* find_registered_model(std::string_view model_id) {
-    for (const auto& model : registered_models()) {
-        if (model.model_id == model_id) return &model;
-    }
-    return nullptr;
-}
-
-std::string resolve_checkpoint_url(const std::string& checkpoint_ref) {
-    // Handle hf:// protocol: hf://user/repo/path/to/file → https://huggingface.co/user/repo/resolve/main/path/to/file
-    if (checkpoint_ref.starts_with("hf://")) {
-        auto path = checkpoint_ref.substr(5);  // after "hf://"
-        auto first_slash = path.find('/');
-        if (first_slash == std::string::npos) return {};
-        auto second_slash = path.find('/', first_slash + 1);
-        if (second_slash == std::string::npos) return {};
-        if (first_slash == 0 || second_slash == first_slash + 1) return {};
-        auto user_repo = path.substr(0, second_slash);   // "user/repo"
-        auto file_path = path.substr(second_slash + 1);  // "path/to/file"
-        if (file_path.empty()) return {};
-        if (has_control_byte(user_repo)) return {};
-        if (file_path.starts_with('/') || has_control_byte(file_path)) return {};
-        // Reject any `..` path segment. HTTP technically does not normalize
-        // `..` in URL paths, but proxies, CDNs, and redirect handlers
-        // sometimes do, and that would let the resolved URL escape the
-        // intended `resolve/main/<file>` prefix.
-        if (has_dot_dot_segment(file_path)) return {};
-        return "https://huggingface.co/" + user_repo + "/resolve/main/" + file_path;
-    }
-    // Handle direct URLs
-    if (checkpoint_ref.starts_with("http://") || checkpoint_ref.starts_with("https://"))
-        return checkpoint_ref;
-    return {};
-}
-
-} // namespace pulp::tools::audio
+}  // namespace pulp::tools::audio


### PR DESCRIPTION
**ModelManager plan, PR1 of 4** (`planning/2026-06-05-pulp-model-manager-primitive.md`). Promotes Pulp's half-built model registry/store from `tools/audio` into `pulp::runtime` so plugins/apps — not just the CLI — can link it (the foundation for the model-download manager; the Magenta demo will be the first consumer, so we link to + download weights on demand instead of shipping a 2.6 GB installer).

## What
- `pulp::runtime` gains a generic **`ModelStore`/registry**: `ModelEntry`, `resolve_checkpoint_url` (`hf://` → HTTPS, with `..`/control-byte hardening), and install-path/state/list/activate — **parameterized by `subsystem`** (e.g. `"audio"`, `"magenta"`) + a caller-supplied registry, so multiple consumers share one mechanism. `ModelEntry` gains `assets[]` (multi-asset bundles), `license`/`attribution`, `min_device` for later phases.
- `tools/audio` is now **thin aliases + wrappers** (subsystem `"audio"`) — its CLI/MCP surface is unchanged.
- **No downloader yet** (that's PR2, per Codex's slicing — it flagged that runtime HTTP has TLS disabled + is in-memory-only, both fixed there).

## Tests
- `pulp-test-model-store` (new): generic list/install/activate round-trip + subsystem isolation + `hf://` hardening (22 assertions).
- `pulp-test-audio-tools` unchanged + green (**669 assertions** — behavior preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes the model registry/store from `tools/audio` into `pulp::runtime` and adds a streaming HTTPS downloader with install/remove, so plugins and apps share one model manager and can fetch GB-scale weights safely. Keeps subsystem-scoped state; audio CLI/MCP stays the same.

- **New Features**
  - Generic registry/store in `pulp::runtime`: `ModelEntry` (with `assets[]`, `license`, `attribution`, `min_device`), `find_model`, `resolve_checkpoint_url` (`hf://` → HTTPS with `..`/control-byte checks), and subsystem-scoped APIs (`model_state_path`, `model_install_path`, `list_models`, `activate_model`, `read_installed_model`, `read_active_model_id`, `to_json`).
  - Streaming downloader: `download_file` over HTTPS via `cpp-httplib` + mbedTLS with Range resume, progress callback, cancellation, sha256 verification, and `.part` → atomic rename.
  - Install/remove: `install_model` (resolve URL → stream to `<home>/<subsystem>/models/<id>/` → write metadata) and `remove_model` (delete files + metadata, clear active selection).

- **Refactors**
  - `tools/audio` now thin aliases/wrappers over `pulp::runtime` (subsystem "audio"); public surface unchanged.
  - Tests: added `pulp-test-model-store` and `pulp-test-model-download` (resume/sha256/cancel + install→activate→remove); existing audio tests remain green.
  - Version bumped to 0.346.0.

<sup>Written for commit 82de01a8afb083a3c88543442d2487ca957ba337. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Promotes Pulp's model registry and store from `tools/audio` into `pulp::runtime`, making it available to all plugins and apps rather than just the CLI. `tools/audio` becomes a thin compatibility shim with subsystem `"audio"`, preserving the existing CLI/MCP surface unchanged.

- **New runtime primitives**: `ModelEntry`/`ModelAsset` types, `resolve_checkpoint_url` (`hf://` \u2192 HTTPS with `..`/control-byte hardening), `ModelStore` path/state/list/activate parameterised by subsystem, and a full streaming downloader (`download_file`) with Range resume, SHA-256 verification, atomic rename, and cancellation support.
- **`tools/audio` refactored**: all former implementations removed; only the audio model catalog data remains, with the registry/store API delegated to `pulp::runtime` via inline wrappers.
- **Tests added**: `pulp-test-model-store` (list/activate round-trip, subsystem isolation, `hf://` hardening) and `pulp-test-model-download` (full download, Range resume, SHA-256 mismatch rejection, cancel-keeps-partial, `install_model`/`remove_model` integration).
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing remove_model error propagation; the refactor is mechanically correct and the audio CLI surface is preserved.

The concrete defect in remove_model silently discards I/O errors and always returns true, breaking its documented contract and misleading any PR2 retry logic that depends on the return value.

core/runtime/src/model_store.cpp (remove_model error propagation) and core/runtime/CMakeLists.txt (model_download.cpp placement relative to the mbedcrypto guard)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| core/runtime/src/model_store.cpp | Core store logic promoted from tools/audio; adds install_model and remove_model. remove_model always returns true regardless of filesystem errors (violates its own contract), and install_model fname extraction lacks a dotdot guard. |
| core/runtime/src/model_registry.cpp | New resolve_checkpoint_url with hf:// to HTTPS conversion and path hardening; has_dot_dot_segment applied only to file_path (not user_repo, flagged in a previous thread). |
| core/runtime/src/model_download.cpp | New streaming downloader: Range resume, SHA-256, atomic rename, cancel-keeps-partial. Added unconditionally to pulp-runtime but includes mbedTLS headers only reachable inside if(TARGET mbedcrypto). |
| core/runtime/include/pulp/runtime/model_store.hpp | New generic store API parameterised by subsystem; remove_model doc says Returns false on failure but the implementation never does for I/O errors. |
| core/runtime/CMakeLists.txt | model_download.cpp added unconditionally to pulp-runtime sources but mbedTLS include path only set inside if(TARGET mbedcrypto); will fail to compile in builds without mbedTLS. |
| test/test_model_store.cpp | Good round-trip coverage for list/activate/subsystem isolation and hf:// hardening; no failure-path test for remove_model to catch the silent-error bug. |
| test/test_model_download.cpp | Solid local-server fixture testing full download, Range resume, sha256 mismatch rejection, and cancel-keeps-partial; install_model and remove_model round-trip also covered. |
| tools/audio/include/pulp/tools/audio/model_store.hpp | Replaced with thin inline wrappers over pulp::runtime with subsystem audio; public surface preserved, correctly delegates to runtime. |
| tools/audio/src/model_registry.cpp | Stripped down to just the audio catalog data; URL resolution and find logic correctly removed in favour of the runtime implementations. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Consumer["Consumer (plugin / app / CLI)"]
        A[tools/audio wrappers\nsubsystem = 'audio']
        B[Magenta demo / future consumer\nsubsystem = 'magenta']
    end
    subgraph Runtime["pulp::runtime (new)"]
        C[model_registry\nModelEntry resolve_checkpoint_url find_model]
        D[model_store\nlist activate read_installed install remove]
        E[model_download\ndownload_file Range resume SHA-256 atomic rename]
    end
    subgraph FS["Filesystem PULP_HOME"]
        F["home/subsystem/model-state.json"]
        G["home/subsystem/models/id.json"]
        H["home/subsystem/models/id/file"]
    end
    A -->|delegates| D
    B -->|delegates| D
    D --> C
    D --> E
    D --> F
    D --> G
    E --> H
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `core/runtime/src/model_store.cpp`, line 129-132 ([link](https://github.com/danielraffel/pulp/blob/6c81c9b432630018d816f09a3026b856391ca808/core/runtime/src/model_store.cpp#L129-L132)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`resolved_checkpoint_path` read from untrusted JSON**

   `checkpoint` is sourced directly from the on-disk install metadata JSON and turned into `record.resolved_checkpoint_path` with no sanitization. While this field is only used for `fs::exists` checks today, PR2's downloader will likely consume it for actual file operations. Consider validating that `checkpoint` stays under `pulp_home` before accepting it, or add a note so PR2 handles it explicitly before using the path for I/O.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["chore: bump versions"](https://github.com/danielraffel/pulp/commit/82de01a8afb083a3c88543442d2487ca957ba337) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35975918)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->