### PR TITLE
feat(view): ModelManagerView — browse / download / progress / cancel / default / remove (PR3)

### DIFF
--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -869,3 +869,22 @@ Slice 1 of the iOS-D.3b program (PR #3146 @ `3e15f61cb`) added the cross-platfor
 **`presentable` flag** (iOS-D.3b Slice 4): `WidgetBridge`'s `__gpuCanvasConfigureImpl` and `__gpuCanvasDescribeCurrentTextureImpl` both expose a `presentable` boolean to JS. `true` iff `gpu_surface_->has_surface()` is true (i.e., the surface has a real swapchain, not just an offscreen texture). Three.js draws to a `presentable=false` canvas land in a silent offscreen render that's not composited to the visible AUv3 editor. Always check this flag in any new GPU bridge code path.
 
 See `planning/2026-05-29-ios-d3b-threejs-webgpu-program.md` for the full 6-slice program.
+
+## Plugin-contributed settings sections
+
+`Processor::settings_sections()` lets a plugin surface its own Settings tabs (e.g. a model
+picker) that the **host composes** alongside its host-owned Audio/MIDI tabs — keep device
+selection a host concern (a plugin can't pick the audio device in a DAW; the host owns it),
+while still giving one unified Settings panel. The standalone chrome
+(`make_standalone_editor_chrome`) calls `processor.settings_sections()` and appends each via
+`SettingsPanel::add_section(title, view)` after the Audio/MIDI tabs. Gotchas:
+
+- The `Settings` tab (with Audio/MIDI) only exists when `StandaloneConfig::show_settings_tab`
+  is true; that's also the gate for composing plugin sections. A plugin that wants its
+  settings visible in the standalone must leave it on.
+- Do NOT pull host audio settings down into the plugin editor — invert it: contribute the
+  plugin's sections up. In a DAW the same `settings_sections()` show with no Audio/MIDI tab,
+  automatically correct.
+- `make_standalone_editor_chrome` accesses `StandaloneEditorChrome`'s private members via a
+  `friend` declaration — if you change its signature, update the friend decl to match or it
+  silently loses friendship and fails to compile on the private-member access.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.348.0
+    VERSION 0.349.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.344.0
+    VERSION 0.345.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.353.0
+    VERSION 0.354.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.347.0
+    VERSION 0.348.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.345.0
+    VERSION 0.346.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.346.0
+    VERSION 0.347.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/detail/standalone_editor_chrome.hpp
+++ b/core/format/include/pulp/format/detail/standalone_editor_chrome.hpp
@@ -129,7 +129,8 @@ private:
         audio::AudioSystem*,
         midi::MidiSystem*,
         view::AudioBridge*,
-        StandaloneSettingsActions);
+        StandaloneSettingsActions,
+        std::vector<Processor::SettingsSection>);
 
     view::View* window_root_ = nullptr;
     SettingsPanel* settings_panel_ = nullptr;
@@ -144,7 +145,8 @@ inline StandaloneEditorChrome make_standalone_editor_chrome(
     audio::AudioSystem* audio_system,
     midi::MidiSystem* midi_system,
     view::AudioBridge* input_bridge,
-    StandaloneSettingsActions actions) {
+    StandaloneSettingsActions actions,
+    std::vector<Processor::SettingsSection> plugin_sections = {}) {
     StandaloneEditorChrome chrome(std::move(editor_root));
     if (!config.show_settings_tab) {
         return chrome;
@@ -157,6 +159,10 @@ inline StandaloneEditorChrome make_standalone_editor_chrome(
     settings_panel->set_input_meter_bridge(input_bridge);
     settings_panel->set_callbacks(
         make_standalone_settings_callbacks(*settings_panel, std::move(actions)));
+
+    // Compose plugin-contributed settings tabs after the host-owned Audio/MIDI tabs.
+    for (auto& section : plugin_sections)
+        if (section.view) settings_panel->add_section(std::move(section.title), std::move(section.view));
 
     auto tab_panel = std::make_unique<view::TabPanel>();
     tab_panel->flex().flex_grow = 1.0f;

--- a/core/format/include/pulp/format/detail/standalone_editor_chrome.hpp
+++ b/core/format/include/pulp/format/detail/standalone_editor_chrome.hpp
@@ -168,11 +168,15 @@ inline StandaloneEditorChrome make_standalone_editor_chrome(
     tab_panel->flex().flex_grow = 1.0f;
     tab_panel->add_tab("Editor", std::move(chrome.editor_root_));
     tab_panel->add_tab("Settings", std::move(settings_panel));
+    // No outer [Editor][Settings] tab bar — the editor reaches Settings via its own
+    // control (e.g. a gear button) and the Settings panel has a Done back to the editor.
+    // This keeps one level of tabs (the panel's own Audio/MIDI/<plugin> tabs).
+    tab_panel->set_show_tab_bar(false);
 
     chrome.window_root_ = tab_panel.get();
     chrome.settings_panel_ = settings_ptr;
     chrome.tab_panel_ = std::move(tab_panel);
-    chrome.extra_window_height_ = 32.0f;
+    chrome.extra_window_height_ = 0.0f;  // no outer tab bar to reserve room for
     return chrome;
 }
 

--- a/core/format/include/pulp/format/processor.hpp
+++ b/core/format/include/pulp/format/processor.hpp
@@ -635,6 +635,20 @@ public:
     ///
     virtual std::unique_ptr<view::View> create_view() { return nullptr; }
 
+    /// A custom settings tab this plugin contributes to the host's Settings UI.
+    struct SettingsSection {
+        std::string title;                 ///< Tab label, e.g. "Models".
+        std::unique_ptr<view::View> view;  ///< Tab content (built by the plugin).
+    };
+
+    /// Settings tabs this plugin contributes, composed by the host alongside its own
+    /// host-owned tabs (e.g. Audio/MIDI device selection in the standalone). This keeps
+    /// device selection a host concern — correct in a DAW, where the host owns the audio
+    /// device — while letting a plugin surface its own settings (e.g. a model picker) in
+    /// one unified Settings panel. Called when the settings UI is built; may be called
+    /// again if it is rebuilt.
+    virtual std::vector<SettingsSection> settings_sections() { return {}; }
+
     /// Called after a view has been constructed and attached. Runs on the
     /// host/UI thread. Safe to read state and register UI listeners.
     virtual void on_view_opened(view::View& /*view*/) {}

--- a/core/format/include/pulp/format/processor.hpp
+++ b/core/format/include/pulp/format/processor.hpp
@@ -636,18 +636,12 @@ public:
     virtual std::unique_ptr<view::View> create_view() { return nullptr; }
 
     /// A custom settings tab this plugin contributes to the host's Settings UI.
+    /// (The matching virtual `settings_sections()` is appended at the end of this class
+    /// to preserve additive-only vtable ordering.)
     struct SettingsSection {
         std::string title;                 ///< Tab label, e.g. "Models".
         std::unique_ptr<view::View> view;  ///< Tab content (built by the plugin).
     };
-
-    /// Settings tabs this plugin contributes, composed by the host alongside its own
-    /// host-owned tabs (e.g. Audio/MIDI device selection in the standalone). This keeps
-    /// device selection a host concern — correct in a DAW, where the host owns the audio
-    /// device — while letting a plugin surface its own settings (e.g. a model picker) in
-    /// one unified Settings panel. Called when the settings UI is built; may be called
-    /// again if it is rebuilt.
-    virtual std::vector<SettingsSection> settings_sections() { return {}; }
 
     /// Called after a view has been constructed and attached. Runs on the
     /// host/UI thread. Safe to read state and register UI listeners.
@@ -691,6 +685,14 @@ public:
     /// adapters can still select scripted/GPU hosting and poll the session.
     virtual view::ScriptedUiSession* active_scripted_ui() { return nullptr; }
     virtual const view::ScriptedUiSession* active_scripted_ui() const { return nullptr; }
+
+    /// Settings tabs this plugin contributes, composed by the host alongside its own
+    /// host-owned tabs (e.g. Audio/MIDI device selection in the standalone). This keeps
+    /// device selection a host concern — correct in a DAW, where the host owns the audio
+    /// device — while letting a plugin surface its own settings (e.g. a model picker) in
+    /// one unified Settings panel. Called when the settings UI is built; may be called
+    /// again if it is rebuilt. (Appended last to preserve additive-only vtable ordering.)
+    virtual std::vector<SettingsSection> settings_sections() { return {}; }
 
     /// Access the parameter state store.
     /// Use state().get_value(id) to read parameter values in process().

--- a/core/format/include/pulp/format/settings_panel.hpp
+++ b/core/format/include/pulp/format/settings_panel.hpp
@@ -42,6 +42,13 @@ public:
     /// Provide an AudioBridge for input level metering.
     void set_input_meter_bridge(view::AudioBridge* bridge) { input_bridge_ = bridge; }
 
+    /// Append a plugin-contributed settings tab after the host-owned Audio/MIDI tabs.
+    /// Lets a plugin surface its own settings (e.g. a model picker) in one unified panel.
+    void add_section(std::string title, std::unique_ptr<view::View> view);
+
+    /// Number of tabs currently in the panel (Audio + MIDI + any added sections).
+    [[nodiscard]] int tab_count() const;
+
     /// Call periodically (~30 Hz) from idle/timer to refresh meters and hotplug.
     void poll();
 

--- a/core/format/include/pulp/format/standalone.hpp
+++ b/core/format/include/pulp/format/standalone.hpp
@@ -29,6 +29,13 @@ struct StandaloneConfig {
     // When false, run_with_editor() hosts the editor directly and omits the
     // built-in Settings tab.
     bool show_settings_tab = true;
+
+    // Remember the user's audio/MIDI device selection (+ sample rate, buffer, transport)
+    // across launches, keyed by the plugin name. On by default; a developer can set this
+    // false to always start from the configured defaults. Saved whenever settings change,
+    // restored at startup (the first launch keeps the configured defaults).
+    bool persist_settings = true;
+
     // When non-empty, run_with_editor() installs a one-shot idle callback
     // that captures the first painted frame via WindowHost::capture_png()
     // and writes to this path, then closes the window. Codified in the SDK
@@ -89,7 +96,10 @@ public:
     // sample-rate, buffer-size, MIDI input, and built-in transport
     // settings on the next launch. Returns false when the storage layer
     // failed to write (e.g. read-only profile, missing app name).
-    static StandaloneConfig load_persisted_config(std::string_view app_name);
+    // Overlays any persisted keys onto `base` and returns it — so unsaved fields keep the
+    // caller's defaults (the first launch, with no file, returns `base` unchanged).
+    static StandaloneConfig load_persisted_config(std::string_view app_name,
+                                                  StandaloneConfig base = {});
     static bool save_persisted_config(std::string_view app_name,
                                       const StandaloneConfig& config);
 
@@ -103,6 +113,7 @@ private:
     std::unique_ptr<Processor> processor_;
     state::StateStore store_;
     StandaloneConfig config_;
+    bool persisted_config_loaded_ = false;  // overlay persisted settings once, not on soft restarts
 
     std::unique_ptr<audio::AudioSystem> audio_system_;
     std::unique_ptr<audio::AudioDevice> audio_device_;

--- a/core/format/src/settings_panel.cpp
+++ b/core/format/src/settings_panel.cpp
@@ -28,6 +28,26 @@ SettingsPanel::SettingsPanel() {
     flex().direction = view::FlexDirection::column;
     flex().flex_grow = 1.0f;
 
+    // Header: a "Done" that returns to the editor. The standalone hosts this panel inside
+    // an outer card-stack TabPanel (tab bar hidden) whose tab 0 is the editor — walk up to
+    // it and switch back. No-op if there's no such ancestor (panel used standalone).
+    auto header = std::make_unique<view::View>();
+    header->flex().direction = view::FlexDirection::row;
+    header->flex().padding = 8.0f;
+    auto done = std::make_unique<view::ToggleButton>();
+    done->set_label("\xE2\x9C\x95 Done");  // ✕ Done
+    done->flex().preferred_width = 96.0f;
+    done->flex().preferred_height = 28.0f;
+    done->on_toggle = [this](bool) {
+        for (view::View* v = parent(); v != nullptr; v = v->parent())
+            if (auto* tp = dynamic_cast<view::TabPanel*>(v)) {
+                tp->set_active_tab(0);
+                return;
+            }
+    };
+    header->add_child(std::move(done));
+    add_child(std::move(header));
+
     auto tabs = std::make_unique<view::TabPanel>();
     tab_panel_ = tabs.get();
     tabs->flex().flex_grow = 1.0f;

--- a/core/format/src/settings_panel.cpp
+++ b/core/format/src/settings_panel.cpp
@@ -134,14 +134,15 @@ void SettingsPanel::build_audio_tab() {
     auto tone_row = std::make_unique<view::View>();
     tone_row->flex().direction = view::FlexDirection::row;
     tone_row->flex().gap = 8.0f;
-    tone_row->flex().preferred_height = 28.0f;
+    tone_row->flex().preferred_height = 32.0f;
+    tone_row->flex().align_items = view::FlexAlign::center;
 
+    // Just the switch (no stacked label) so it's compact and clearly clickable; the label is
+    // a separate sibling so it can't overflow the toggle's width.
     auto tone_toggle = std::make_unique<view::Toggle>();
     test_tone_toggle_ = tone_toggle.get();
-    tone_toggle->set_label("Sine Tone");
-    // The Toggle centers its label in its own width; without a width it collapses to ~40px
-    // and "Sine Tone" overflows off the left edge. Reserve room for the label.
-    tone_toggle->flex().preferred_width = 96.0f;
+    tone_toggle->flex().preferred_width = 48.0f;
+    tone_toggle->flex().preferred_height = 26.0f;
     tone_toggle->flex().flex_shrink = 0.0f;
     tone_toggle->on_toggle = [this](bool on) {
         if (callbacks_.on_test_signal_changed) {
@@ -157,6 +158,11 @@ void SettingsPanel::build_audio_tab() {
         }
     };
     tone_row->add_child(std::move(tone_toggle));
+
+    auto tone_label = make_info_label("Sine Tone");
+    tone_label->flex().preferred_width = 72.0f;
+    tone_label->flex().flex_shrink = 0.0f;
+    tone_row->add_child(std::move(tone_label));
 
     auto freq_combo = std::make_unique<view::ComboBox>();
     tone_freq_combo_ = freq_combo.get();

--- a/core/format/src/settings_panel.cpp
+++ b/core/format/src/settings_panel.cpp
@@ -169,6 +169,14 @@ void SettingsPanel::build_midi_tab() {
     tab_panel_->add_tab("MIDI", std::move(midi_tab));
 }
 
+void SettingsPanel::add_section(std::string title, std::unique_ptr<view::View> view) {
+    if (tab_panel_ && view) tab_panel_->add_tab(std::move(title), std::move(view));
+}
+
+int SettingsPanel::tab_count() const {
+    return tab_panel_ ? tab_panel_->tab_count() : 0;
+}
+
 void SettingsPanel::bind_systems(audio::AudioSystem* audio_sys, midi::MidiSystem* midi_sys) {
     audio_sys_ = audio_sys;
     midi_sys_ = midi_sys;

--- a/core/format/src/settings_panel.cpp
+++ b/core/format/src/settings_panel.cpp
@@ -128,17 +128,23 @@ void SettingsPanel::build_audio_tab() {
     meter->flex().preferred_height = 24.0f;
     audio_tab->add_child(std::move(meter));
 
-    // Test tone section
-    audio_tab->add_child(make_section_label("Test Signal"));
+    // Test tone section. Header line: "Test Signal" on the left, the "Sine Tone" switch on
+    // the right; the frequency dropdown sits full-width on its own line below so it never
+    // gets squished.
+    auto ts_header = std::make_unique<view::View>();
+    ts_header->flex().direction = view::FlexDirection::row;
+    ts_header->flex().align_items = view::FlexAlign::center;
+    ts_header->flex().gap = 8.0f;
+    ts_header->flex().preferred_height = 28.0f;
+    ts_header->add_child(make_section_label("Test Signal"));
+    auto ts_spacer = std::make_unique<view::View>();
+    ts_spacer->flex().flex_grow = 1.0f;
+    ts_header->add_child(std::move(ts_spacer));
+    auto tone_label = make_info_label("Sine Tone");
+    tone_label->flex().flex_shrink = 0.0f;
+    ts_header->add_child(std::move(tone_label));
 
-    auto tone_row = std::make_unique<view::View>();
-    tone_row->flex().direction = view::FlexDirection::row;
-    tone_row->flex().gap = 8.0f;
-    tone_row->flex().preferred_height = 32.0f;
-    tone_row->flex().align_items = view::FlexAlign::center;
-
-    // Just the switch (no stacked label) so it's compact and clearly clickable; the label is
-    // a separate sibling so it can't overflow the toggle's width.
+    // Switch only (no stacked label) — compact and clearly clickable.
     auto tone_toggle = std::make_unique<view::Toggle>();
     test_tone_toggle_ = tone_toggle.get();
     tone_toggle->flex().preferred_width = 48.0f;
@@ -157,26 +163,20 @@ void SettingsPanel::build_audio_tab() {
             callbacks_.on_test_signal_changed(cfg);
         }
     };
-    tone_row->add_child(std::move(tone_toggle));
-
-    auto tone_label = make_info_label("Sine Tone");
-    tone_label->flex().preferred_width = 72.0f;
-    tone_label->flex().flex_shrink = 0.0f;
-    tone_row->add_child(std::move(tone_label));
+    ts_header->add_child(std::move(tone_toggle));
+    audio_tab->add_child(std::move(ts_header));
 
     auto freq_combo = std::make_unique<view::ComboBox>();
     tone_freq_combo_ = freq_combo.get();
     freq_combo->set_items({ "220 Hz (A3)", "440 Hz (A4)", "880 Hz (A5)", "1000 Hz" });
     freq_combo->set_selected_silent(1);
-    freq_combo->flex().flex_grow = 1.0f;
+    freq_combo->flex().preferred_height = 28.0f;
     freq_combo->on_change = [this](int) {
         if (test_tone_toggle_ && test_tone_toggle_->is_on()) {
             test_tone_toggle_->on_toggle(true);
         }
     };
-    tone_row->add_child(std::move(freq_combo));
-
-    audio_tab->add_child(std::move(tone_row));
+    audio_tab->add_child(std::move(freq_combo));
 
     tab_panel_->add_tab("Audio", std::move(audio_tab));
 }

--- a/core/format/src/settings_panel.cpp
+++ b/core/format/src/settings_panel.cpp
@@ -1,5 +1,6 @@
 #include <pulp/format/settings_panel.hpp>
 #include <pulp/runtime/log.hpp>
+#include <pulp/view/buttons.hpp>  // TextButton (momentary Done)
 #include <algorithm>
 #include <cmath>
 #include <sstream>
@@ -28,17 +29,20 @@ SettingsPanel::SettingsPanel() {
     flex().direction = view::FlexDirection::column;
     flex().flex_grow = 1.0f;
 
-    // Header: a "Done" that returns to the editor. The standalone hosts this panel inside
-    // an outer card-stack TabPanel (tab bar hidden) whose tab 0 is the editor — walk up to
-    // it and switch back. No-op if there's no such ancestor (panel used standalone).
+    // Header: a right-aligned "Done" (momentary button) that returns to the editor. The
+    // standalone hosts this panel inside an outer card-stack TabPanel (tab bar hidden) whose
+    // tab 0 is the editor — walk up to it and switch back. No-op if there's no such ancestor.
     auto header = std::make_unique<view::View>();
     header->flex().direction = view::FlexDirection::row;
     header->flex().padding = 8.0f;
-    auto done = std::make_unique<view::ToggleButton>();
-    done->set_label("\xE2\x9C\x95 Done");  // ✕ Done
-    done->flex().preferred_width = 96.0f;
+    header->flex().align_items = view::FlexAlign::center;
+    auto spacer = std::make_unique<view::View>();
+    spacer->flex().flex_grow = 1.0f;
+    header->add_child(std::move(spacer));
+    auto done = std::make_unique<view::TextButton>("Done");
+    done->flex().preferred_width = 84.0f;
     done->flex().preferred_height = 28.0f;
-    done->on_toggle = [this](bool) {
+    done->on_click = [this] {
         for (view::View* v = parent(); v != nullptr; v = v->parent())
             if (auto* tp = dynamic_cast<view::TabPanel*>(v)) {
                 tp->set_active_tab(0);
@@ -160,7 +164,15 @@ void SettingsPanel::build_audio_tab() {
 
     audio_tab->add_child(std::move(tone_row));
 
-    tab_panel_->add_tab("Audio", std::move(audio_tab));
+    // The audio tab is taller than a compact editor window — make it scroll so nothing
+    // (Test Signal, the Done header) gets pushed off. The content height covers all rows.
+    audio_tab->flex().flex_shrink = 0.0f;
+    auto scroll = std::make_unique<view::ScrollView>();
+    scroll->set_direction(view::ScrollView::Direction::vertical);
+    scroll->set_content_size({0.0f, 470.0f});
+    scroll->flex().flex_grow = 1.0f;
+    scroll->add_child(std::move(audio_tab));
+    tab_panel_->add_tab("Audio", std::move(scroll));
 }
 
 void SettingsPanel::build_midi_tab() {

--- a/core/format/src/settings_panel.cpp
+++ b/core/format/src/settings_panel.cpp
@@ -32,15 +32,19 @@ SettingsPanel::SettingsPanel() {
     // Header: a right-aligned "Done" (momentary button) that returns to the editor. The
     // standalone hosts this panel inside an outer card-stack TabPanel (tab bar hidden) whose
     // tab 0 is the editor — walk up to it and switch back. No-op if there's no such ancestor.
+    // Keep this bar IDENTICAL to the editor's gear bar (height/padding) so the top-right
+    // button doesn't shift vertically when switching between the editor and Settings.
     auto header = std::make_unique<view::View>();
     header->flex().direction = view::FlexDirection::row;
-    header->flex().padding = 8.0f;
+    header->flex().padding = 12.0f;
+    header->flex().preferred_height = 52.0f;
+    header->flex().flex_shrink = 0.0f;
     header->flex().align_items = view::FlexAlign::center;
     auto spacer = std::make_unique<view::View>();
     spacer->flex().flex_grow = 1.0f;
     header->add_child(std::move(spacer));
     auto done = std::make_unique<view::TextButton>("Done");
-    done->flex().preferred_width = 84.0f;
+    done->flex().preferred_width = 112.0f;
     done->flex().preferred_height = 28.0f;
     done->on_click = [this] {
         for (view::View* v = parent(); v != nullptr; v = v->parent())
@@ -164,15 +168,7 @@ void SettingsPanel::build_audio_tab() {
 
     audio_tab->add_child(std::move(tone_row));
 
-    // The audio tab is taller than a compact editor window — make it scroll so nothing
-    // (Test Signal, the Done header) gets pushed off. The content height covers all rows.
-    audio_tab->flex().flex_shrink = 0.0f;
-    auto scroll = std::make_unique<view::ScrollView>();
-    scroll->set_direction(view::ScrollView::Direction::vertical);
-    scroll->set_content_size({0.0f, 470.0f});
-    scroll->flex().flex_grow = 1.0f;
-    scroll->add_child(std::move(audio_tab));
-    tab_panel_->add_tab("Audio", std::move(scroll));
+    tab_panel_->add_tab("Audio", std::move(audio_tab));
 }
 
 void SettingsPanel::build_midi_tab() {

--- a/core/format/src/settings_panel.cpp
+++ b/core/format/src/settings_panel.cpp
@@ -139,6 +139,10 @@ void SettingsPanel::build_audio_tab() {
     auto tone_toggle = std::make_unique<view::Toggle>();
     test_tone_toggle_ = tone_toggle.get();
     tone_toggle->set_label("Sine Tone");
+    // The Toggle centers its label in its own width; without a width it collapses to ~40px
+    // and "Sine Tone" overflows off the left edge. Reserve room for the label.
+    tone_toggle->flex().preferred_width = 96.0f;
+    tone_toggle->flex().flex_shrink = 0.0f;
     tone_toggle->on_toggle = [this](bool on) {
         if (callbacks_.on_test_signal_changed) {
             TestSignalConfig cfg;

--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -322,7 +322,8 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
                 test_signal_.set_loop(loop);
                 if (play) test_signal_.play(); else test_signal_.stop();
             },
-        });
+        },
+        processor_->settings_sections());  // plugin-contributed Settings tabs (e.g. Models)
     auto* settings_ptr = chrome.settings_panel();
     auto& window_root = chrome.window_root();
 

--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -61,6 +61,14 @@ bool StandaloneApp::start() {
     auto desc = processor_->descriptor();
     runtime::log_info("Standalone: starting '{}'", desc.name);
 
+    // Restore the user's last-used audio/MIDI selection (default on; developer can opt out
+    // via StandaloneConfig::persist_settings). Overlays persisted keys onto the configured
+    // defaults, so the first launch (no saved file) keeps exactly what the app configured.
+    if (config_.persist_settings && !persisted_config_loaded_) {
+        config_ = load_persisted_config(desc.name, config_);
+        persisted_config_loaded_ = true;  // don't re-overlay on soft restarts (apply_config)
+    }
+
     // Set up audio
     audio_system_ = audio::create_audio_system();
     audio_device_ = audio_system_->create_device(config_.audio_device_id);
@@ -257,6 +265,9 @@ bool StandaloneApp::apply_config(const StandaloneConfig& new_config) {
     // dangle an editor ViewBridge holding a Processor& (#2693).
     if (was_running) stop_audio_keep_processor();
     config_ = new_config;
+    // Remember the user's device/rate/buffer selection across launches (default on).
+    if (config_.persist_settings && processor_)
+        save_persisted_config(processor_->descriptor().name, config_);
     if (was_running) return start();
     return true;
 }
@@ -506,8 +517,8 @@ constexpr std::string_view kKeyPlaying        = "standalone.transport_playing";
 
 }  // namespace
 
-StandaloneConfig StandaloneApp::load_persisted_config(std::string_view app_name) {
-    StandaloneConfig cfg;  // defaults
+StandaloneConfig StandaloneApp::load_persisted_config(std::string_view app_name,
+                                                      StandaloneConfig cfg) {
     if (app_name.empty()) return cfg;
 
     state::ApplicationProperties props(app_name);

--- a/core/runtime/CMakeLists.txt
+++ b/core/runtime/CMakeLists.txt
@@ -109,6 +109,7 @@ target_sources(pulp-runtime PRIVATE
     src/json_rpc.cpp
     src/model_registry.cpp
     src/model_store.cpp
+    src/model_download.cpp
     src/ip_address.cpp
     src/mac_address.cpp
     src/url.cpp
@@ -172,6 +173,14 @@ if(TARGET mbedcrypto)
     target_include_directories(pulp-runtime PRIVATE
         ${mbedtls_SOURCE_DIR}/include
     )
+    # Enable HTTPS in cpp-httplib via the mbedTLS backend (used by the streaming
+    # model downloader, model_download.cpp). No OpenSSL dependency.
+    target_compile_definitions(pulp-runtime PRIVATE CPPHTTPLIB_MBEDTLS_SUPPORT)
+    if(APPLE)
+        # httplib's mbedTLS path loads system trust anchors from the macOS keychain
+        # via the Security framework.
+        target_link_libraries(pulp-runtime PRIVATE "-framework Security" "-framework CoreFoundation")
+    endif()
 endif()
 
 # CHOC headers (used by SpscQueue wrapper)

--- a/core/runtime/CMakeLists.txt
+++ b/core/runtime/CMakeLists.txt
@@ -107,6 +107,8 @@ target_sources(pulp-runtime PRIVATE
     src/memory_message_channel.cpp
     src/websocket_channel.cpp
     src/json_rpc.cpp
+    src/model_registry.cpp
+    src/model_store.cpp
     src/ip_address.cpp
     src/mac_address.cpp
     src/url.cpp

--- a/core/runtime/include/pulp/runtime/model_download.hpp
+++ b/core/runtime/include/pulp/runtime/model_download.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+// Streaming HTTPS file downloader for the model manager (MM-PR2). Unlike
+// runtime/http.hpp's http_download (whole-body, in-memory — fine for small JSON,
+// fatal for GB-scale weights), this streams the body incrementally to disk with a
+// progress callback, HTTP Range **resume**, request **headers** (e.g. HuggingFace
+// auth), **cancellation**, **sha256** verification, and a temp-stage → atomic-rename
+// so a partial/aborted transfer never appears as a finished file. HTTPS rides on
+// cpp-httplib's mbedTLS backend (mbedTLS is already linked by core/runtime).
+
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace pulp::runtime {
+
+class CancellationToken;  // async_stream.hpp
+
+struct DownloadProgress {
+    std::uint64_t downloaded = 0;  ///< Bytes written so far (includes resumed bytes).
+    std::uint64_t total = 0;       ///< Total expected bytes, or 0 if the server didn't say.
+};
+
+struct HttpHeader {
+    std::string name;
+    std::string value;
+};
+
+struct DownloadRequest {
+    std::string url;                       ///< http(s)://… (resolve hf:// first).
+    std::filesystem::path dest;            ///< Final destination path.
+    std::string expected_sha256;           ///< Optional hex digest; verified when non-empty.
+    std::vector<HttpHeader> headers;       ///< Extra request headers (e.g. Authorization).
+    bool resume = true;                    ///< Resume from a prior partial <dest>.part via Range.
+    int timeout_seconds = 0;               ///< 0 ⇒ a sensible library default.
+};
+
+struct DownloadResult {
+    bool ok = false;
+    std::string error;
+    std::filesystem::path path;            ///< The finished file (== request.dest) on success.
+    std::uint64_t bytes = 0;               ///< Total bytes of the finished file.
+    std::string sha256;                    ///< Hex digest of the finished file.
+    bool resumed = false;                  ///< A prior partial was continued.
+    bool cancelled = false;                ///< Stopped via callback / token (partial kept for resume).
+};
+
+/// Progress callback. Return false to cancel the in-flight download.
+using DownloadProgressFn = std::function<bool(const DownloadProgress&)>;
+
+/// Blocking streaming download. Writes to `<dest>.part`, verifies sha256 (when an
+/// expected digest is given), then atomically renames to `dest`. On cancel/error the
+/// `.part` file is left in place so a later call with `resume = true` continues it.
+DownloadResult download_file(const DownloadRequest& request,
+                             const DownloadProgressFn& on_progress = {},
+                             const CancellationToken* cancel = nullptr);
+
+}  // namespace pulp::runtime

--- a/core/runtime/include/pulp/runtime/model_registry.hpp
+++ b/core/runtime/include/pulp/runtime/model_registry.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+// Generic model registry primitive (promoted from tools/audio so plugins/apps —
+// not just the CLI — can use it). A `ModelEntry` describes a downloadable ML model
+// (HuggingFace or any URL); `resolve_checkpoint_url` turns an `hf://` ref into a
+// direct HTTPS URL with path hardening. The available-models list (the catalog) is
+// supplied by the consumer (e.g. tools/audio's audio catalog, or the Magenta demo's
+// mrt2 catalog) — this module owns the type + resolution + lookup, not the data.
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pulp::runtime {
+
+struct ModelAsset {
+    std::string role;          ///< e.g. "weights", "vocab", "encoder" (multi-file bundles)
+    std::string checkpoint_ref;///< "hf://user/repo/file" or "https://…"
+    std::string sha256;        ///< Expected hash of this asset (empty = unverified)
+    std::uint64_t size_bytes = 0;
+};
+
+struct ModelEntry {
+    std::string model_id;             ///< Stable id (e.g. "mrt2_base"), NOT the HF repo.
+    std::string display_name;
+    std::string description;
+    std::string backend;              ///< e.g. "clap", "mlx".
+    std::string checkpoint_ref;       ///< Primary asset, e.g. "hf://user/repo/file.pt".
+    std::vector<std::string> task_tags;
+    std::uint64_t size_bytes = 0;
+
+    std::string download_url;         ///< Direct HTTPS URL (resolved from checkpoint_ref).
+    std::string sha256;               ///< Expected hash of the primary checkpoint.
+    bool auto_downloadable = true;    ///< false ⇒ manual steps required.
+
+    // Multi-asset bundles (e.g. Magenta: weights + vocab + encoder). When empty the
+    // entry is single-file (checkpoint_ref). The downloader fetches all assets.
+    std::vector<ModelAsset> assets;
+
+    bool is_recommended = false;      ///< ⭐ in the model manager.
+    std::string license;              ///< e.g. "CC-BY-4.0".
+    std::string attribution;          ///< e.g. "Google DeepMind".
+    std::string min_device;           ///< Optional hint, e.g. "Pro/Max".
+};
+
+/// Resolve a checkpoint_ref to a direct download URL.
+/// "hf://user/repo/file" → "https://huggingface.co/user/repo/resolve/main/file".
+/// Rejects control bytes and `..` path segments. Passes http(s):// URLs through.
+std::string resolve_checkpoint_url(const std::string& checkpoint_ref);
+
+/// Find a model by id in a caller-supplied registry/catalog. Returns nullptr if absent.
+const ModelEntry* find_model(const std::vector<ModelEntry>& registry, std::string_view model_id);
+
+}  // namespace pulp::runtime

--- a/core/runtime/include/pulp/runtime/model_store.hpp
+++ b/core/runtime/include/pulp/runtime/model_store.hpp
@@ -8,11 +8,17 @@
 // one mechanism. The downloader (install) lands in a follow-up (MM-PR2).
 
 #include <filesystem>
+#include <functional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include <pulp/runtime/model_registry.hpp>
+
+namespace pulp::runtime {
+class CancellationToken;  // async_stream.hpp
+}
 
 namespace pulp::runtime {
 
@@ -73,5 +79,31 @@ ActivateModelResult activate_model(const std::vector<ModelEntry>& registry, std:
 
 std::string to_json(const ModelListResult& result);
 std::string to_json(const ActivateModelResult& result);
+
+// ---- install / remove (MM-PR2: built on the streaming downloader) -------------------
+
+struct InstallModelResult {
+    bool ok = false;
+    std::string error;
+    bool cancelled = false;
+    std::filesystem::path checkpoint_path;  // downloaded file
+    std::filesystem::path metadata_path;    // <home>/<subsystem>/models/<id>.json
+    std::string sha256;
+};
+
+/// Download `model`'s checkpoint into `<home>/<subsystem>/models/<id>/` (streaming,
+/// resumable, sha256-verified), then write the install metadata so read_installed_model/
+/// activate_model see it. `on_progress` returning false (or a cancelled token) aborts and
+/// keeps the partial for a later resume. Auth headers (e.g. HuggingFace token) optional.
+InstallModelResult install_model(const ModelEntry& model, std::string_view subsystem,
+                                 const std::function<bool(const struct DownloadProgress&)>& on_progress = {},
+                                 const CancellationToken* cancel = nullptr,
+                                 const std::vector<std::pair<std::string, std::string>>& headers = {},
+                                 const std::filesystem::path& pulp_home_override = {});
+
+/// Delete an installed model's files + metadata. Clears the active selection if it pointed
+/// here. Returns false (with `error` set) on failure; true if removed or already absent.
+bool remove_model(std::string_view subsystem, std::string_view model_id, std::string& error,
+                  const std::filesystem::path& pulp_home_override = {});
 
 }  // namespace pulp::runtime

--- a/core/runtime/include/pulp/runtime/model_store.hpp
+++ b/core/runtime/include/pulp/runtime/model_store.hpp
@@ -36,9 +36,10 @@ struct InstalledModelRecord {
 
 struct ListedModel {
     ModelEntry model;
-    std::string status = "not_installed";  // installed | missing_checkpoint | not_installed
+    std::string status = "not_installed";  // installed | missing_checkpoint | partial | not_installed
     bool active = false;
     std::filesystem::path resolved_checkpoint_path;
+    float partial_fraction = -1.0f;  // >= 0 when a resumable .part exists (downloaded/total)
 };
 
 struct ModelListResult {

--- a/core/runtime/include/pulp/runtime/model_store.hpp
+++ b/core/runtime/include/pulp/runtime/model_store.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+// Generic model store/state primitive (promoted from tools/audio). Owns the on-disk
+// layout under PULP_HOME (`<home>/<subsystem>/model-state.json` for the active model,
+// `<home>/<subsystem>/models/<id>.json` for per-model install metadata), the
+// installed/active queries, list (over a caller-supplied registry), and activate.
+// Parameterized by `subsystem` (e.g. "audio", "magenta") so multiple consumers share
+// one mechanism. The downloader (install) lands in a follow-up (MM-PR2).
+
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <pulp/runtime/model_registry.hpp>
+
+namespace pulp::runtime {
+
+struct InstalledModelRecord {
+    std::filesystem::path metadata_path;
+    bool metadata_found = false;
+    std::string model_id;
+    std::string backend;
+    std::string checkpoint_ref;
+    std::filesystem::path resolved_checkpoint_path;
+    bool checkpoint_exists = false;
+
+    [[nodiscard]] bool loadable() const { return metadata_found && checkpoint_exists; }
+};
+
+struct ListedModel {
+    ModelEntry model;
+    std::string status = "not_installed";  // installed | missing_checkpoint | not_installed
+    bool active = false;
+    std::filesystem::path resolved_checkpoint_path;
+};
+
+struct ModelListResult {
+    std::filesystem::path pulp_home;
+    std::string active_model_id;
+    std::vector<ListedModel> models;
+    std::string error;
+};
+
+struct ActivateModelResult {
+    bool ok = false;
+    std::filesystem::path state_path;
+    std::string active_model_id;
+    std::string backend;
+    std::string checkpoint_ref;
+    std::filesystem::path resolved_checkpoint_path;
+    std::string error;
+};
+
+// PULP_HOME resolution: explicit override → $PULP_HOME → $HOME/.pulp (USERPROFILE on
+// Windows). NOTE (path policy, see plan): a sandboxed AUv3/iOS host may not have HOME
+// access — callers in those contexts should pass an explicit container path.
+std::filesystem::path resolve_pulp_home(const std::filesystem::path& override_path = {});
+
+std::filesystem::path model_state_path(std::string_view subsystem,
+                                       const std::filesystem::path& pulp_home_override = {});
+std::filesystem::path model_install_path(std::string_view subsystem, std::string_view model_id,
+                                         const std::filesystem::path& pulp_home_override = {});
+InstalledModelRecord read_installed_model(std::string_view subsystem, std::string_view model_id,
+                                          const std::filesystem::path& pulp_home_override = {});
+std::string read_active_model_id(std::string_view subsystem,
+                                 const std::filesystem::path& pulp_home_override = {});
+ModelListResult list_models(const std::vector<ModelEntry>& registry, std::string_view subsystem,
+                            const std::filesystem::path& pulp_home_override = {});
+ActivateModelResult activate_model(const std::vector<ModelEntry>& registry, std::string_view subsystem,
+                                   std::string_view model_id,
+                                   const std::filesystem::path& pulp_home_override = {});
+
+std::string to_json(const ModelListResult& result);
+std::string to_json(const ActivateModelResult& result);
+
+}  // namespace pulp::runtime

--- a/core/runtime/src/model_download.cpp
+++ b/core/runtime/src/model_download.cpp
@@ -1,0 +1,234 @@
+#include <pulp/runtime/model_download.hpp>
+
+#include <pulp/runtime/async_stream.hpp>
+
+#include <mbedtls/sha256.h>
+
+// HTTPS via cpp-httplib's mbedTLS backend. The CMake target defines
+// CPPHTTPLIB_MBEDTLS_SUPPORT when mbedTLS is available.
+#include <httplib.h>
+
+#include <array>
+#include <cstdint>
+#include <fstream>
+#include <regex>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace pulp::runtime {
+
+namespace {
+
+struct ParsedUrl {
+    std::string scheme_host_port;  // e.g. "https://huggingface.co"
+    std::string path;              // e.g. "/user/repo/resolve/main/file"
+    bool ok = false;
+};
+
+ParsedUrl parse_url(const std::string& url) {
+    static const std::regex re(R"(^(https?)://([^/:]+)(?::(\d+))?(/.*)?$)", std::regex::icase);
+    std::smatch m;
+    ParsedUrl out;
+    if (!std::regex_match(url, m, re)) return out;
+    const std::string scheme = m[1].str();
+    const std::string host = m[2].str();
+    const std::string port = m[3].str();
+    const std::string path = m[4].str();
+    out.scheme_host_port = scheme + "://" + host + (port.empty() ? "" : ":" + port);
+    out.path = path.empty() ? "/" : path;
+    out.ok = true;
+    return out;
+}
+
+std::string to_hex(const unsigned char* data, size_t n) {
+    static const char* digits = "0123456789abcdef";
+    std::string s;
+    s.reserve(n * 2);
+    for (size_t i = 0; i < n; ++i) {
+        s += digits[data[i] >> 4];
+        s += digits[data[i] & 0x0F];
+    }
+    return s;
+}
+
+// Feed a file's existing bytes into the running SHA (resume re-hash).
+bool hash_existing(mbedtls_sha256_context& ctx, const fs::path& path, std::uint64_t& counted) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) return false;
+    std::array<char, 1 << 16> buf{};
+    while (in) {
+        in.read(buf.data(), static_cast<std::streamsize>(buf.size()));
+        const auto got = in.gcount();
+        if (got > 0) {
+            mbedtls_sha256_update(&ctx, reinterpret_cast<const unsigned char*>(buf.data()),
+                                  static_cast<size_t>(got));
+            counted += static_cast<std::uint64_t>(got);
+        }
+    }
+    return true;
+}
+
+// Best-effort system CA bundle for mbedTLS verification (macOS / common Linux).
+const char* system_ca_path() {
+    static const char* candidates[] = {
+        "/etc/ssl/cert.pem",                      // macOS, some BSDs
+        "/etc/ssl/certs/ca-certificates.crt",     // Debian/Ubuntu
+        "/etc/pki/tls/certs/ca-bundle.crt",       // RHEL/Fedora
+    };
+    for (const char* c : candidates) {
+        std::error_code ec;
+        if (fs::exists(c, ec)) return c;
+    }
+    return nullptr;
+}
+
+}  // namespace
+
+DownloadResult download_file(const DownloadRequest& req, const DownloadProgressFn& on_progress,
+                             const CancellationToken* cancel) {
+    DownloadResult r;
+    r.path = req.dest;
+
+    const auto parsed = parse_url(req.url);
+    if (!parsed.ok) {
+        r.error = "invalid url: " + req.url;
+        return r;
+    }
+
+    std::error_code ec;
+    if (!req.dest.parent_path().empty()) fs::create_directories(req.dest.parent_path(), ec);
+    fs::path part = req.dest;
+    part += ".part";
+
+    std::uint64_t resume_from = 0;
+    if (req.resume && fs::exists(part, ec)) resume_from = static_cast<std::uint64_t>(fs::file_size(part, ec));
+
+    mbedtls_sha256_context sha;
+    mbedtls_sha256_init(&sha);
+    mbedtls_sha256_starts(&sha, 0);  // 0 = SHA-256 (not SHA-224)
+
+    std::uint64_t downloaded = 0;
+    if (resume_from > 0 && !hash_existing(sha, part, downloaded)) resume_from = 0;  // unreadable → restart
+
+    std::ofstream out;
+    auto open_out = [&](bool append) {
+        out.close();
+        out.clear();
+        out.open(part, std::ios::binary | (append ? std::ios::app : std::ios::trunc));
+    };
+    open_out(resume_from > 0);
+    if (!out) {
+        mbedtls_sha256_free(&sha);
+        r.error = "cannot open " + part.string() + " for writing";
+        return r;
+    }
+
+    httplib::Client cli(parsed.scheme_host_port);
+    cli.set_follow_location(true);
+    cli.set_keep_alive(true);
+    if (req.timeout_seconds > 0) {
+        cli.set_read_timeout(req.timeout_seconds, 0);
+        cli.set_connection_timeout(req.timeout_seconds, 0);
+    }
+    if (const char* ca = system_ca_path()) cli.set_ca_cert_path(ca);
+    cli.enable_server_certificate_verification(true);
+
+    httplib::Headers headers;
+    for (const auto& h : req.headers) headers.emplace(h.name, h.value);
+    const bool attempted_resume = resume_from > 0;
+    if (attempted_resume) headers.emplace("Range", "bytes=" + std::to_string(resume_from) + "-");
+
+    std::uint64_t total = 0;
+    bool reset_due_to_200 = false;
+    bool user_cancel = false;
+    bool write_error = false;
+
+    auto response_handler = [&](const httplib::Response& resp) -> bool {
+        if (attempted_resume && resp.status == 200) {
+            // Server ignored our Range request — discard the partial and restart.
+            reset_due_to_200 = true;
+            mbedtls_sha256_free(&sha);
+            mbedtls_sha256_init(&sha);
+            mbedtls_sha256_starts(&sha, 0);
+            downloaded = 0;
+            open_out(false);
+        }
+        if (auto it = resp.headers.find("Content-Length"); it != resp.headers.end()) {
+            try {
+                total = downloaded + std::stoull(it->second);
+            } catch (...) {
+                total = 0;
+            }
+        }
+        return true;
+    };
+
+    auto content_receiver = [&](const char* data, size_t len) -> bool {
+        out.write(data, static_cast<std::streamsize>(len));
+        if (!out) {
+            write_error = true;
+            return false;
+        }
+        mbedtls_sha256_update(&sha, reinterpret_cast<const unsigned char*>(data), len);
+        downloaded += len;
+        if (cancel && cancel->is_cancelled()) {
+            user_cancel = true;
+            return false;
+        }
+        if (on_progress && !on_progress(DownloadProgress{downloaded, total})) {
+            user_cancel = true;
+            return false;
+        }
+        return true;
+    };
+
+    auto result = cli.Get(parsed.path, headers, response_handler, content_receiver);
+    out.flush();
+    out.close();
+
+    if (write_error) {
+        mbedtls_sha256_free(&sha);
+        r.error = "write failed to " + part.string();
+        return r;  // keep .part
+    }
+    if (user_cancel) {
+        mbedtls_sha256_free(&sha);
+        r.cancelled = true;
+        r.error = "cancelled";
+        return r;  // keep .part for resume
+    }
+    if (!result) {
+        mbedtls_sha256_free(&sha);
+        r.error = "http error: " + httplib::to_string(result.error());
+        return r;  // keep .part
+    }
+    if (result->status != 200 && result->status != 206) {
+        mbedtls_sha256_free(&sha);
+        r.error = "http status " + std::to_string(result->status);
+        return r;
+    }
+
+    unsigned char digest[32];
+    mbedtls_sha256_finish(&sha, digest);
+    mbedtls_sha256_free(&sha);
+    r.sha256 = to_hex(digest, sizeof digest);
+    r.resumed = attempted_resume && !reset_due_to_200;
+
+    if (!req.expected_sha256.empty() && req.expected_sha256 != r.sha256) {
+        fs::remove(part, ec);  // corrupt — don't leave a resumable bad file
+        r.error = "sha256 mismatch: expected " + req.expected_sha256 + " got " + r.sha256;
+        return r;
+    }
+
+    fs::rename(part, req.dest, ec);
+    if (ec) {
+        r.error = "rename failed: " + ec.message();
+        return r;
+    }
+    r.bytes = static_cast<std::uint64_t>(fs::file_size(req.dest, ec));
+    r.ok = true;
+    return r;
+}
+
+}  // namespace pulp::runtime

--- a/core/runtime/src/model_registry.cpp
+++ b/core/runtime/src/model_registry.cpp
@@ -1,0 +1,61 @@
+#include <pulp/runtime/model_registry.hpp>
+
+namespace pulp::runtime {
+
+namespace {
+
+bool has_control_byte(std::string_view text) {
+    for (unsigned char ch : text) {
+        if (ch < 0x20) return true;
+    }
+    return false;
+}
+
+bool has_dot_dot_segment(std::string_view path) {
+    std::size_t start = 0;
+    while (start <= path.size()) {
+        auto slash = path.find('/', start);
+        auto seg = path.substr(start,
+            slash == std::string_view::npos ? std::string_view::npos : slash - start);
+        if (seg == "..") return true;
+        if (slash == std::string_view::npos) break;
+        start = slash + 1;
+    }
+    return false;
+}
+
+}  // namespace
+
+std::string resolve_checkpoint_url(const std::string& checkpoint_ref) {
+    // hf://user/repo/path/to/file → https://huggingface.co/user/repo/resolve/main/path/to/file
+    if (checkpoint_ref.starts_with("hf://")) {
+        auto path = checkpoint_ref.substr(5);  // after "hf://"
+        auto first_slash = path.find('/');
+        if (first_slash == std::string::npos) return {};
+        auto second_slash = path.find('/', first_slash + 1);
+        if (second_slash == std::string::npos) return {};
+        if (first_slash == 0 || second_slash == first_slash + 1) return {};
+        auto user_repo = path.substr(0, second_slash);   // "user/repo"
+        auto file_path = path.substr(second_slash + 1);  // "path/to/file"
+        if (file_path.empty()) return {};
+        if (has_control_byte(user_repo)) return {};
+        if (file_path.starts_with('/') || has_control_byte(file_path)) return {};
+        // Reject any `..` path segment. HTTP doesn't normalize `..` in URL paths, but
+        // proxies/CDNs/redirect handlers sometimes do, which could let the resolved URL
+        // escape the intended `resolve/main/<file>` prefix.
+        if (has_dot_dot_segment(file_path)) return {};
+        return "https://huggingface.co/" + user_repo + "/resolve/main/" + file_path;
+    }
+    if (checkpoint_ref.starts_with("http://") || checkpoint_ref.starts_with("https://"))
+        return checkpoint_ref;
+    return {};
+}
+
+const ModelEntry* find_model(const std::vector<ModelEntry>& registry, std::string_view model_id) {
+    for (const auto& model : registry) {
+        if (model.model_id == model_id) return &model;
+    }
+    return nullptr;
+}
+
+}  // namespace pulp::runtime

--- a/core/runtime/src/model_store.cpp
+++ b/core/runtime/src/model_store.cpp
@@ -1,5 +1,6 @@
 #include <pulp/runtime/model_store.hpp>
 
+#include <pulp/runtime/model_download.hpp>
 #include <pulp/runtime/system.hpp>
 
 #include <choc/text/choc_JSON.h>
@@ -256,6 +257,86 @@ std::string to_json(const ActivateModelResult& result) {
     add_path_member(object, "resolved_checkpoint_path", result.resolved_checkpoint_path);
     add_string_member(object, "error", result.error);
     return choc::json::toString(object, true);
+}
+
+InstallModelResult install_model(const ModelEntry& model, std::string_view subsystem,
+                                 const std::function<bool(const DownloadProgress&)>& on_progress,
+                                 const CancellationToken* cancel,
+                                 const std::vector<std::pair<std::string, std::string>>& headers,
+                                 const fs::path& pulp_home_override) {
+    InstallModelResult r;
+    const std::string url =
+        model.download_url.empty() ? resolve_checkpoint_url(model.checkpoint_ref) : model.download_url;
+    if (url.empty()) {
+        r.error = "cannot resolve a download URL for " + model.model_id;
+        return r;
+    }
+    const auto home = resolve_pulp_home(pulp_home_override);
+    if (home.empty()) {
+        r.error = "unable to resolve PULP_HOME";
+        return r;
+    }
+
+    const fs::path files_dir = home / std::string(subsystem) / "models" / model.model_id;
+    std::string fname;
+    if (auto slash = url.find_last_of('/'); slash != std::string::npos) fname = url.substr(slash + 1);
+    if (auto q = fname.find('?'); q != std::string::npos) fname = fname.substr(0, q);
+    if (fname.empty()) fname = model.model_id + ".bin";
+    const fs::path dest = files_dir / fname;
+
+    DownloadRequest req;
+    req.url = url;
+    req.dest = dest;
+    req.expected_sha256 = model.sha256;
+    req.resume = true;
+    for (const auto& h : headers) req.headers.push_back(HttpHeader{h.first, h.second});
+
+    const auto dl = download_file(req, on_progress, cancel);
+    if (dl.cancelled) {
+        r.cancelled = true;
+        r.error = "cancelled";
+        return r;
+    }
+    if (!dl.ok) {
+        r.error = dl.error;
+        return r;
+    }
+
+    r.checkpoint_path = dest;
+    r.sha256 = dl.sha256;
+    r.metadata_path = model_install_path(subsystem, model.model_id, pulp_home_override);
+
+    auto object = choc::value::createObject("");
+    add_string_member(object, "model_id", model.model_id);
+    add_string_member(object, "backend", model.backend);
+    add_string_member(object, "checkpoint_ref", model.checkpoint_ref);
+    add_path_member(object, "resolved_checkpoint_path", dest);
+    add_string_member(object, "sha256", dl.sha256);
+
+    std::string error;
+    if (!write_text_file(r.metadata_path, choc::json::toString(object, true), error)) {
+        r.error = error;
+        return r;
+    }
+    r.ok = true;
+    return r;
+}
+
+bool remove_model(std::string_view subsystem, std::string_view model_id, std::string& error,
+                  const fs::path& pulp_home_override) {
+    const auto home = resolve_pulp_home(pulp_home_override);
+    if (home.empty()) {
+        error = "unable to resolve PULP_HOME";
+        return false;
+    }
+    std::error_code ec;
+    fs::remove_all(home / std::string(subsystem) / "models" / std::string(model_id), ec);
+    fs::remove(model_install_path(subsystem, model_id, pulp_home_override), ec);
+    // Clear the active selection if it pointed at the removed model.
+    if (read_active_model_id(subsystem, pulp_home_override) == model_id) {
+        fs::remove(model_state_path(subsystem, pulp_home_override), ec);
+    }
+    return true;
 }
 
 }  // namespace pulp::runtime

--- a/core/runtime/src/model_store.cpp
+++ b/core/runtime/src/model_store.cpp
@@ -1,4 +1,4 @@
-#include <pulp/tools/audio/model_store.hpp>
+#include <pulp/runtime/model_store.hpp>
 
 #include <pulp/runtime/system.hpp>
 
@@ -10,14 +10,13 @@
 
 namespace fs = std::filesystem;
 
-namespace pulp::tools::audio {
+namespace pulp::runtime {
 
 namespace {
 
 std::string read_text_file(const fs::path& path) {
     std::ifstream input(path);
     if (!input.is_open()) return {};
-
     std::ostringstream buffer;
     buffer << input.rdbuf();
     return buffer.str();
@@ -29,7 +28,6 @@ bool parse_json_file(const fs::path& path, choc::value::Value& value, std::strin
         error = "failed to read " + path.string();
         return false;
     }
-
     try {
         value = choc::json::parse(text);
         return true;
@@ -45,7 +43,6 @@ bool parse_json_file(const fs::path& path, choc::value::Value& value, std::strin
 std::string object_string(const choc::value::ValueView& object,
                           std::initializer_list<const char*> keys) {
     if (!object.isObject()) return {};
-
     for (auto* key : keys) {
         if (!object.hasObjectMember(key)) continue;
         auto value = object[key];
@@ -53,7 +50,6 @@ std::string object_string(const choc::value::ValueView& object,
         auto text = std::string(value.toString());
         if (!text.empty()) return text;
     }
-
     return {};
 }
 
@@ -72,64 +68,57 @@ bool write_text_file(const fs::path& path, const std::string& content, std::stri
         error = "failed to create " + path.parent_path().string() + ": " + ec.message();
         return false;
     }
-
     std::ofstream output(path);
     if (!output.is_open()) {
         error = "failed to open " + path.string() + " for writing";
         return false;
     }
-
     output << content;
     if (!output.good()) {
         error = "failed to write " + path.string();
         return false;
     }
-
     return true;
 }
 
-} // namespace
+}  // namespace
 
 fs::path resolve_pulp_home(const fs::path& override_path) {
     if (!override_path.empty()) return override_path;
-
-    if (auto pulp_home = runtime::get_env("PULP_HOME"))
-        return fs::path(*pulp_home);
-
-    auto home = runtime::get_env("HOME");
+    if (auto pulp_home = get_env("PULP_HOME")) return fs::path(*pulp_home);
+    auto home = get_env("HOME");
 #ifdef _WIN32
-    if (!home) home = runtime::get_env("USERPROFILE");
+    if (!home) home = get_env("USERPROFILE");
 #endif
     if (!home) return {};
     return fs::path(*home) / ".pulp";
 }
 
-fs::path audio_model_state_path(const fs::path& pulp_home_override) {
+fs::path model_state_path(std::string_view subsystem, const fs::path& pulp_home_override) {
     auto pulp_home = resolve_pulp_home(pulp_home_override);
     if (pulp_home.empty()) return {};
-    return pulp_home / "audio" / "model-state.json";
+    return pulp_home / std::string(subsystem) / "model-state.json";
 }
 
-fs::path audio_model_install_path(std::string_view model_id, const fs::path& pulp_home_override) {
+fs::path model_install_path(std::string_view subsystem, std::string_view model_id,
+                            const fs::path& pulp_home_override) {
     auto pulp_home = resolve_pulp_home(pulp_home_override);
     if (pulp_home.empty()) return {};
-    return pulp_home / "audio" / "models" / (std::string(model_id) + ".json");
+    return pulp_home / std::string(subsystem) / "models" / (std::string(model_id) + ".json");
 }
 
-InstalledModelRecord read_installed_model(std::string_view model_id, const fs::path& pulp_home_override) {
+InstalledModelRecord read_installed_model(std::string_view subsystem, std::string_view model_id,
+                                          const fs::path& pulp_home_override) {
     InstalledModelRecord record;
-    record.metadata_path = audio_model_install_path(model_id, pulp_home_override);
+    record.metadata_path = model_install_path(subsystem, model_id, pulp_home_override);
     record.model_id = std::string(model_id);
 
-    if (record.metadata_path.empty() || !fs::exists(record.metadata_path))
-        return record;
-
+    if (record.metadata_path.empty() || !fs::exists(record.metadata_path)) return record;
     record.metadata_found = true;
 
     choc::value::Value value;
     std::string error;
-    if (!parse_json_file(record.metadata_path, value, error))
-        return record;
+    if (!parse_json_file(record.metadata_path, value, error)) return record;
 
     auto root = value.getView();
     auto parsed_model_id = object_string(root, {"model_id"});
@@ -142,27 +131,23 @@ InstalledModelRecord read_installed_model(std::string_view model_id, const fs::p
         record.resolved_checkpoint_path = fs::path(checkpoint);
         record.checkpoint_exists = fs::exists(record.resolved_checkpoint_path);
     }
-
     return record;
 }
 
-std::string read_active_model_id(const fs::path& pulp_home_override) {
-    auto state_path = audio_model_state_path(pulp_home_override);
+std::string read_active_model_id(std::string_view subsystem, const fs::path& pulp_home_override) {
+    auto state_path = model_state_path(subsystem, pulp_home_override);
     if (state_path.empty() || !fs::exists(state_path)) return {};
 
     choc::value::Value value;
     std::string error;
     if (!parse_json_file(state_path, value, error)) return {};
 
-    return object_string(value.getView(), {
-        "active_model_id",
-        "configured_model_id",
-        "requested_model_id",
-        "model_id",
-    });
+    return object_string(value.getView(),
+                         {"active_model_id", "configured_model_id", "requested_model_id", "model_id"});
 }
 
-ModelListResult list_models(const fs::path& pulp_home_override) {
+ModelListResult list_models(const std::vector<ModelEntry>& registry, std::string_view subsystem,
+                            const fs::path& pulp_home_override) {
     ModelListResult result;
     result.pulp_home = resolve_pulp_home(pulp_home_override);
     if (result.pulp_home.empty()) {
@@ -170,45 +155,45 @@ ModelListResult list_models(const fs::path& pulp_home_override) {
         return result;
     }
 
-    result.active_model_id = read_active_model_id(result.pulp_home);
-    for (const auto& model : registered_models()) {
+    result.active_model_id = read_active_model_id(subsystem, result.pulp_home);
+    for (const auto& model : registry) {
         ListedModel listed;
         listed.model = model;
         listed.active = (model.model_id == result.active_model_id);
 
-        auto installed = read_installed_model(model.model_id, result.pulp_home);
+        auto installed = read_installed_model(subsystem, model.model_id, result.pulp_home);
         if (installed.metadata_found) {
             listed.status = installed.checkpoint_exists ? "installed" : "missing_checkpoint";
             listed.resolved_checkpoint_path = installed.resolved_checkpoint_path;
         }
-
         result.models.push_back(std::move(listed));
     }
-
     return result;
 }
 
-ActivateModelResult activate_model(std::string_view model_id, const fs::path& pulp_home_override) {
+ActivateModelResult activate_model(const std::vector<ModelEntry>& registry, std::string_view subsystem,
+                                   std::string_view model_id, const fs::path& pulp_home_override) {
     ActivateModelResult result;
-    result.state_path = audio_model_state_path(pulp_home_override);
+    result.state_path = model_state_path(subsystem, pulp_home_override);
     if (result.state_path.empty()) {
         result.error = "unable to resolve PULP_HOME";
         return result;
     }
 
-    auto* registered = find_registered_model(model_id);
+    auto* registered = find_model(registry, model_id);
     if (!registered) {
         result.error = "unknown model_id: " + std::string(model_id);
         return result;
     }
 
-    auto installed = read_installed_model(model_id, pulp_home_override);
+    auto installed = read_installed_model(subsystem, model_id, pulp_home_override);
     if (!installed.metadata_found) {
         result.error = "model is not installed: " + std::string(model_id);
         return result;
     }
     if (!installed.checkpoint_exists) {
-        result.error = "installed model checkpoint does not exist: " + installed.resolved_checkpoint_path.string();
+        result.error = "installed model checkpoint does not exist: " +
+                       installed.resolved_checkpoint_path.string();
         return result;
     }
 
@@ -273,4 +258,4 @@ std::string to_json(const ActivateModelResult& result) {
     return choc::json::toString(object, true);
 }
 
-} // namespace pulp::tools::audio
+}  // namespace pulp::runtime

--- a/core/runtime/src/model_store.cpp
+++ b/core/runtime/src/model_store.cpp
@@ -166,6 +166,21 @@ ModelListResult list_models(const std::vector<ModelEntry>& registry, std::string
         if (installed.metadata_found) {
             listed.status = installed.checkpoint_exists ? "installed" : "missing_checkpoint";
             listed.resolved_checkpoint_path = installed.resolved_checkpoint_path;
+        } else {
+            // Not installed — surface a resumable partial (an interrupted/cancelled .part).
+            const fs::path dir = result.pulp_home / std::string(subsystem) / "models" / model.model_id;
+            std::error_code ec;
+            if (fs::exists(dir, ec)) {
+                for (const auto& entry : fs::directory_iterator(dir, ec)) {
+                    if (entry.path().extension() != ".part") continue;
+                    listed.status = "partial";
+                    if (model.size_bytes > 0) {
+                        const auto got = static_cast<float>(fs::file_size(entry.path(), ec));
+                        listed.partial_fraction = got / static_cast<float>(model.size_bytes);
+                    }
+                    break;
+                }
+            }
         }
         result.models.push_back(std::move(listed));
     }

--- a/core/view/include/pulp/view/model_manager_view.hpp
+++ b/core/view/include/pulp/view/model_manager_view.hpp
@@ -2,10 +2,14 @@
 
 // ModelManagerView (MM-PR3) — the "you need a model" manager UI. Lists available +
 // installed models with their status, shows per-row download progress + cancel, and
-// exposes Download / Set-default / Remove actions via callbacks the host wires to
-// runtime::install_model / activate_model / remove_model. Pure composition over Pulp
-// widgets (View flex + Label + Meter + ToggleButton) so it renders on the Skia/GPU
-// canvas and is headless-capturable for visual regression.
+// exposes Download / Resume / Set-default / Remove actions via callbacks the host wires
+// to runtime::install_model / activate_model / remove_model. A header "Done" closes back
+// to the editor when there is one. Pure composition over Pulp widgets (View flex + Label
+// + ToggleButton) so it renders on the Skia/GPU canvas and is headless-capturable.
+//
+// Layout: each model is a two-line block — line 1 is the name + status + action
+// buttons; line 2 is a full-width progress bar (only while downloading/paused) — so the
+// bar never crowds or overlaps the name.
 
 #include <pulp/view/view.hpp>
 #include <pulp/view/widgets.hpp>
@@ -27,21 +31,6 @@ public:
         flex().padding = 20.0f;
         flex().gap = 12.0f;
         set_background_color(canvas::Color::rgba8(32, 33, 36, 255));  // GREY_900-ish
-
-        auto title = std::make_unique<Label>("Models");
-        title->set_font_size(20.0f);
-        title->set_font_weight(700);
-        title->set_text_color(canvas::Color::rgba8(255, 255, 255, 255));
-        title->flex().preferred_height = 28.0f;
-        add_child(std::move(title));
-
-        auto subtitle = std::make_unique<Label>(
-            "Download a model to enable generation. Models are stored once and shared across plugins.");
-        subtitle->set_font_size(12.0f);
-        subtitle->set_text_color(canvas::Color::rgba8(170, 170, 175, 255));
-        subtitle->flex().preferred_height = 18.0f;
-        add_child(std::move(subtitle));
-
         rebuild();
     }
 
@@ -60,15 +49,27 @@ public:
         rebuild();
     }
 
-    ModelAction on_download;          ///< user tapped Download / Resume
-    ModelAction on_activate;          ///< user tapped Set default
-    ModelAction on_remove;            ///< user tapped Remove / Delete
-    ModelAction on_cancel;            ///< user tapped Cancel (mid-download)
-    std::function<void()> on_done;    ///< user tapped Done (return to the editor)
+    /// Show the header "Done" (return to the editor). Off when there is no editor yet.
+    void set_can_close(bool can_close) {
+        if (can_close_ == can_close) return;
+        can_close_ = can_close;
+        rebuild();
+    }
+
+    ModelAction on_download;          ///< Download / Resume
+    ModelAction on_activate;          ///< Set default
+    ModelAction on_remove;            ///< Remove / Delete
+    ModelAction on_cancel;            ///< Cancel (mid-download)
+    std::function<void()> on_done;    ///< Done (return to the editor)
 
 private:
-    static std::unique_ptr<Label> make_label(const std::string& text, float size,
-                                              canvas::Color color, float width = 0.0f) {
+    static constexpr canvas::Color kMuted() { return canvas::Color::rgba8(170, 170, 175, 255); }
+    static constexpr canvas::Color kWhite() { return canvas::Color::rgba8(235, 235, 240, 255); }
+    static constexpr canvas::Color kTeal()  { return canvas::Color::rgba8(132, 243, 237, 255); }
+    static constexpr canvas::Color kBlue()  { return canvas::Color::rgba8(127, 178, 255, 255); }
+
+    static std::unique_ptr<Label> make_label(const std::string& text, float size, canvas::Color color,
+                                             float width = 0.0f) {
         auto l = std::make_unique<Label>(text);
         l->set_font_size(size);
         l->set_text_color(color);
@@ -88,105 +89,114 @@ private:
         return b;
     }
 
-    // A plain download progress bar: a dark track with a constant-accent fill sized to
-    // the fraction. (Deliberately NOT the audio Meter widget — that colors by level
-    // green→red, which reads as clipping, not progress.)
-    static std::unique_ptr<View> make_progress_bar(float fraction, float width) {
+    // Full-width determinate bar: a dark track with a constant-accent fill sized
+    // proportionally via flex-grow (NOT the audio Meter, which colors by level).
+    static std::unique_ptr<View> make_progress_bar(float fraction) {
         const float f = fraction < 0.0f ? 0.0f : (fraction > 1.0f ? 1.0f : fraction);
         auto track = std::make_unique<View>();
         track->flex().direction = FlexDirection::row;
-        track->flex().preferred_width = width;
-        track->flex().preferred_height = 8.0f;
+        track->flex().flex_grow = 1.0f;
+        track->flex().preferred_height = 6.0f;
         track->set_background_color(canvas::Color::rgba8(55, 56, 60, 255));
         auto fill = std::make_unique<View>();
-        fill->flex().preferred_width = f * width < 2.0f ? 2.0f : f * width;
-        fill->flex().preferred_height = 8.0f;
+        fill->flex().flex_grow = f < 0.001f ? 0.001f : f;
         fill->set_background_color(canvas::Color::rgba8(127, 178, 255, 255));
+        auto rest = std::make_unique<View>();
+        rest->flex().flex_grow = (1.0f - f) < 0.001f ? 0.001f : (1.0f - f);
         track->add_child(std::move(fill));
+        track->add_child(std::move(rest));
         return track;
     }
 
     void rebuild() {
-        if (rows_) {
-            remove_child(rows_);
-            rows_ = nullptr;
-        }
-        auto rows = std::make_unique<View>();
-        rows->flex().direction = FlexDirection::column;
-        rows->flex().gap = 8.0f;
-        rows->flex().flex_grow = 1.0f;
+        while (child_count() > 0) remove_child(child_at(0));
 
-        const auto muted = canvas::Color::rgba8(170, 170, 175, 255);
-        const auto white = canvas::Color::rgba8(235, 235, 240, 255);
-        const auto teal = canvas::Color::rgba8(132, 243, 237, 255);
-        const auto blue = canvas::Color::rgba8(127, 178, 255, 255);
-
-        // When a model is active there's an editor to return to — offer a way back.
-        bool has_active = false;
-        for (const auto& l : models_.models)
-            if (l.active) { has_active = true; break; }
-        if (has_active && on_done) {
+        // Header: title + (Done, right-aligned, only when there's an editor to return to).
+        auto header = std::make_unique<View>();
+        header->flex().direction = FlexDirection::row;
+        header->flex().align_items = FlexAlign::center;
+        header->flex().preferred_height = 30.0f;
+        auto title = make_label("Models", 20.0f, kWhite());
+        title->set_font_weight(700);
+        title->flex().flex_grow = 1.0f;
+        header->add_child(std::move(title));
+        if (can_close_ && on_done) {
             auto done = std::make_unique<ToggleButton>();
-            done->set_label("← Done");
-            done->flex().preferred_width = 96.0f;
+            done->set_label("Done");
+            done->flex().preferred_width = 88.0f;
             done->flex().preferred_height = 28.0f;
             done->on_toggle = [this](bool) { if (on_done) on_done(); };
-            rows->add_child(std::move(done));
+            header->add_child(std::move(done));
         }
+        add_child(std::move(header));
+
+        add_child(make_label("Download a model to enable generation. Stored once, shared across plugins.",
+                             12.0f, kMuted()));
 
         if (models_.models.empty()) {
-            auto empty = make_label("No models available yet.", 14.0f, muted);
-            rows->add_child(std::move(empty));
+            add_child(make_label("No models available yet.", 14.0f, kMuted()));
+            return;
         }
 
         for (const auto& listed : models_.models) {
             const std::string id = listed.model.model_id;
+            const auto it = progress_.find(id);
+            const bool downloading = it != progress_.end();
+            const bool paused = !downloading && listed.status == "partial";
 
-            auto row = std::make_unique<View>();
-            row->flex().direction = FlexDirection::row;
-            row->flex().gap = 10.0f;
-            row->flex().preferred_height = 40.0f;
-            row->flex().align_items = FlexAlign::center;
+            auto block = std::make_unique<View>();
+            block->flex().direction = FlexDirection::column;
+            block->flex().gap = 6.0f;
+
+            // Line 1: name (grows, never shrinks) + status + action buttons.
+            auto line = std::make_unique<View>();
+            line->flex().direction = FlexDirection::row;
+            line->flex().align_items = FlexAlign::center;
+            line->flex().gap = 10.0f;
+            line->flex().preferred_height = 30.0f;
 
             std::string name = listed.model.display_name.empty() ? id : listed.model.display_name;
             if (listed.model.is_recommended) name = "★ " + name;  // ★
-            auto name_label = make_label(name, 14.0f, white);
+            auto name_label = make_label(name, 14.0f, kWhite());
             name_label->flex().flex_grow = 1.0f;
-            row->add_child(std::move(name_label));
+            name_label->flex().flex_shrink = 0.0f;  // never let the name shrink/overlap
+            line->add_child(std::move(name_label));
 
-            const auto it = progress_.find(id);
-            if (it != progress_.end()) {  // actively downloading
+            if (downloading) {
                 const int pct = static_cast<int>(it->second * 100.0f + 0.5f);
-                row->add_child(make_progress_bar(it->second, 140.0f));
-                row->add_child(make_label(std::to_string(pct) + "%", 12.0f, teal, 44.0f));
-                row->add_child(make_action("Cancel", id, &ModelManagerView::on_cancel));
-            } else if (listed.status == "partial") {  // paused / cancelled — resumable
+                line->add_child(make_label(std::to_string(pct) + "%", 12.0f, kTeal(), 44.0f));
+                line->add_child(make_action("Cancel", id, &ModelManagerView::on_cancel));
+            } else if (paused) {
                 const float frac = listed.partial_fraction < 0.0f ? 0.0f : listed.partial_fraction;
-                row->add_child(make_progress_bar(frac, 140.0f));
-                row->add_child(make_label("Paused " + std::to_string(static_cast<int>(frac * 100.0f + 0.5f)) + "%",
-                                          12.0f, muted, 90.0f));
-                row->add_child(make_action("Resume", id, &ModelManagerView::on_download));
-                row->add_child(make_action("Delete", id, &ModelManagerView::on_remove));
+                line->add_child(make_label("Paused " + std::to_string(static_cast<int>(frac * 100.0f + 0.5f)) + "%",
+                                           12.0f, kMuted(), 90.0f));
+                line->add_child(make_action("Resume", id, &ModelManagerView::on_download));
+                line->add_child(make_action("Delete", id, &ModelManagerView::on_remove));
             } else if (listed.status == "installed") {
-                row->add_child(make_label(listed.active ? "Active" : "Installed", 12.0f,
-                                          listed.active ? teal : blue, 80.0f));
+                line->add_child(make_label(listed.active ? "Active" : "Installed", 12.0f,
+                                           listed.active ? kTeal() : kBlue(), 80.0f));
                 if (!listed.active)
-                    row->add_child(make_action("Set default", id, &ModelManagerView::on_activate));
-                row->add_child(make_action("Remove", id, &ModelManagerView::on_remove));
-            } else {  // available
-                row->add_child(make_label("Available", 12.0f, muted, 80.0f));
-                row->add_child(make_action("Download", id, &ModelManagerView::on_download));
+                    line->add_child(make_action("Set default", id, &ModelManagerView::on_activate));
+                line->add_child(make_action("Remove", id, &ModelManagerView::on_remove));
+            } else {
+                line->add_child(make_label("Available", 12.0f, kMuted(), 80.0f));
+                line->add_child(make_action("Download", id, &ModelManagerView::on_download));
             }
-            rows->add_child(std::move(row));
-        }
+            block->add_child(std::move(line));
 
-        rows_ = rows.get();
-        add_child(std::move(rows));
+            // Line 2: a full-width progress bar, only while downloading or paused.
+            if (downloading)
+                block->add_child(make_progress_bar(it->second));
+            else if (paused)
+                block->add_child(make_progress_bar(listed.partial_fraction));
+
+            add_child(std::move(block));
+        }
     }
 
     runtime::ModelListResult models_;
     std::map<std::string, float> progress_;
-    View* rows_ = nullptr;
+    bool can_close_ = false;
 };
 
 }  // namespace pulp::view

--- a/core/view/include/pulp/view/model_manager_view.hpp
+++ b/core/view/include/pulp/view/model_manager_view.hpp
@@ -13,6 +13,7 @@
 
 #include <pulp/view/view.hpp>
 #include <pulp/view/widgets.hpp>
+#include <pulp/view/buttons.hpp>  // TextButton (centered, momentary action buttons)
 #include <pulp/runtime/model_store.hpp>
 #include <pulp/canvas/canvas.hpp>
 
@@ -77,13 +78,14 @@ private:
         return l;
     }
 
-    std::unique_ptr<ToggleButton> make_action(const std::string& label, const std::string& id,
-                                              ModelAction ModelManagerView::* member) {
-        auto b = std::make_unique<ToggleButton>();
-        b->set_label(label);
+    std::unique_ptr<TextButton> make_action(const std::string& label, const std::string& id,
+                                            ModelAction ModelManagerView::* member) {
+        // Momentary TextButton (centered label, proper hover/press) rather than a latched
+        // ToggleButton — these are one-shot actions, and the label should read centered.
+        auto b = std::make_unique<TextButton>(label);
         b->flex().preferred_width = 96.0f;
         b->flex().preferred_height = 28.0f;
-        b->on_toggle = [this, id, member](bool) {
+        b->on_click = [this, id, member] {
             if (this->*member) (this->*member)(id);
         };
         return b;

--- a/core/view/include/pulp/view/model_manager_view.hpp
+++ b/core/view/include/pulp/view/model_manager_view.hpp
@@ -1,0 +1,165 @@
+#pragma once
+
+// ModelManagerView (MM-PR3) — the "you need a model" manager UI. Lists available +
+// installed models with their status, shows per-row download progress + cancel, and
+// exposes Download / Set-default / Remove actions via callbacks the host wires to
+// runtime::install_model / activate_model / remove_model. Pure composition over Pulp
+// widgets (View flex + Label + Meter + ToggleButton) so it renders on the Skia/GPU
+// canvas and is headless-capturable for visual regression.
+
+#include <pulp/view/view.hpp>
+#include <pulp/view/widgets.hpp>
+#include <pulp/runtime/model_store.hpp>
+#include <pulp/canvas/canvas.hpp>
+
+#include <functional>
+#include <map>
+#include <string>
+
+namespace pulp::view {
+
+class ModelManagerView : public View {
+public:
+    using ModelAction = std::function<void(const std::string& model_id)>;
+
+    ModelManagerView() {
+        flex().direction = FlexDirection::column;
+        flex().padding = 20.0f;
+        flex().gap = 12.0f;
+        set_background_color(canvas::Color::rgba8(32, 33, 36, 255));  // GREY_900-ish
+
+        auto title = std::make_unique<Label>("Models");
+        title->set_font_size(20.0f);
+        title->set_font_weight(700);
+        title->set_text_color(canvas::Color::rgba8(255, 255, 255, 255));
+        title->flex().preferred_height = 28.0f;
+        add_child(std::move(title));
+
+        auto subtitle = std::make_unique<Label>(
+            "Download a model to enable generation. Models are stored once and shared across plugins.");
+        subtitle->set_font_size(12.0f);
+        subtitle->set_text_color(canvas::Color::rgba8(170, 170, 175, 255));
+        subtitle->flex().preferred_height = 18.0f;
+        add_child(std::move(subtitle));
+
+        rebuild();
+    }
+
+    /// Populate from runtime::list_models(registry, subsystem).
+    void set_models(const runtime::ModelListResult& models) {
+        models_ = models;
+        rebuild();
+    }
+
+    /// Per-row download progress in [0,1]. Negative clears (not downloading).
+    void set_download_progress(const std::string& model_id, float fraction) {
+        if (fraction < 0.0f)
+            progress_.erase(model_id);
+        else
+            progress_[model_id] = fraction;
+        rebuild();
+    }
+
+    ModelAction on_download;  ///< user tapped Download
+    ModelAction on_activate;  ///< user tapped Set default
+    ModelAction on_remove;    ///< user tapped Remove
+    ModelAction on_cancel;    ///< user tapped Cancel (mid-download)
+
+private:
+    static std::unique_ptr<Label> make_label(const std::string& text, float size,
+                                              canvas::Color color, float width = 0.0f) {
+        auto l = std::make_unique<Label>(text);
+        l->set_font_size(size);
+        l->set_text_color(color);
+        if (width > 0.0f) l->flex().preferred_width = width;
+        return l;
+    }
+
+    std::unique_ptr<ToggleButton> make_action(const std::string& label, const std::string& id,
+                                              ModelAction ModelManagerView::* member) {
+        auto b = std::make_unique<ToggleButton>();
+        b->set_label(label);
+        b->flex().preferred_width = 96.0f;
+        b->flex().preferred_height = 28.0f;
+        b->on_toggle = [this, id, member](bool) {
+            if (this->*member) (this->*member)(id);
+        };
+        return b;
+    }
+
+    void rebuild() {
+        if (rows_) {
+            remove_child(rows_);
+            rows_ = nullptr;
+        }
+        auto rows = std::make_unique<View>();
+        rows->flex().direction = FlexDirection::column;
+        rows->flex().gap = 8.0f;
+        rows->flex().flex_grow = 1.0f;
+
+        const auto muted = canvas::Color::rgba8(170, 170, 175, 255);
+        const auto white = canvas::Color::rgba8(235, 235, 240, 255);
+        const auto teal = canvas::Color::rgba8(132, 243, 237, 255);
+        const auto blue = canvas::Color::rgba8(127, 178, 255, 255);
+
+        if (models_.models.empty()) {
+            auto empty = make_label("No models available yet.", 14.0f, muted);
+            rows->add_child(std::move(empty));
+        }
+
+        for (const auto& listed : models_.models) {
+            const std::string id = listed.model.model_id;
+
+            auto row = std::make_unique<View>();
+            row->flex().direction = FlexDirection::row;
+            row->flex().gap = 10.0f;
+            row->flex().preferred_height = 40.0f;
+            row->flex().align_items = FlexAlign::center;
+
+            std::string name = listed.model.display_name.empty() ? id : listed.model.display_name;
+            if (listed.model.is_recommended) name = "★ " + name;  // ★
+            auto name_label = make_label(name, 14.0f, white);
+            name_label->flex().flex_grow = 1.0f;
+            row->add_child(std::move(name_label));
+
+            const auto it = progress_.find(id);
+            const bool downloading = it != progress_.end();
+            if (downloading) {
+                auto meter = std::make_unique<Meter>();
+                meter->set_orientation(Meter::Orientation::horizontal);
+                meter->set_level(it->second, it->second);
+                meter->flex().preferred_width = 140.0f;
+                meter->flex().preferred_height = 10.0f;
+                row->add_child(std::move(meter));
+
+                int pct = static_cast<int>(it->second * 100.0f + 0.5f);
+                row->add_child(make_label(std::to_string(pct) + "%", 12.0f, teal, 44.0f));
+                row->add_child(make_action("Cancel", id, &ModelManagerView::on_cancel));
+            } else {
+                std::string status = listed.active ? "Active"
+                                     : listed.status == "installed" ? "Installed"
+                                                                     : "Available";
+                row->add_child(make_label(status, 12.0f,
+                                          listed.active ? teal : (listed.status == "installed" ? blue : muted),
+                                          80.0f));
+
+                if (listed.status != "installed") {
+                    row->add_child(make_action("Download", id, &ModelManagerView::on_download));
+                } else {
+                    if (!listed.active) row->add_child(make_action("Set default", id, &ModelManagerView::on_activate));
+                    row->add_child(make_action("Remove", id, &ModelManagerView::on_remove));
+                }
+            }
+            rows->add_child(std::move(row));
+        }
+
+        rows_ = rows.get();
+        add_child(std::move(rows));
+    }
+
+    runtime::ModelListResult models_;
+    std::map<std::string, float> progress_;
+    View* rows_ = nullptr;
+};
+
+}  // namespace pulp::view

--- a/core/view/include/pulp/view/model_manager_view.hpp
+++ b/core/view/include/pulp/view/model_manager_view.hpp
@@ -60,10 +60,11 @@ public:
         rebuild();
     }
 
-    ModelAction on_download;  ///< user tapped Download
-    ModelAction on_activate;  ///< user tapped Set default
-    ModelAction on_remove;    ///< user tapped Remove
-    ModelAction on_cancel;    ///< user tapped Cancel (mid-download)
+    ModelAction on_download;          ///< user tapped Download / Resume
+    ModelAction on_activate;          ///< user tapped Set default
+    ModelAction on_remove;            ///< user tapped Remove / Delete
+    ModelAction on_cancel;            ///< user tapped Cancel (mid-download)
+    std::function<void()> on_done;    ///< user tapped Done (return to the editor)
 
 private:
     static std::unique_ptr<Label> make_label(const std::string& text, float size,
@@ -87,6 +88,24 @@ private:
         return b;
     }
 
+    // A plain download progress bar: a dark track with a constant-accent fill sized to
+    // the fraction. (Deliberately NOT the audio Meter widget — that colors by level
+    // green→red, which reads as clipping, not progress.)
+    static std::unique_ptr<View> make_progress_bar(float fraction, float width) {
+        const float f = fraction < 0.0f ? 0.0f : (fraction > 1.0f ? 1.0f : fraction);
+        auto track = std::make_unique<View>();
+        track->flex().direction = FlexDirection::row;
+        track->flex().preferred_width = width;
+        track->flex().preferred_height = 8.0f;
+        track->set_background_color(canvas::Color::rgba8(55, 56, 60, 255));
+        auto fill = std::make_unique<View>();
+        fill->flex().preferred_width = f * width < 2.0f ? 2.0f : f * width;
+        fill->flex().preferred_height = 8.0f;
+        fill->set_background_color(canvas::Color::rgba8(127, 178, 255, 255));
+        track->add_child(std::move(fill));
+        return track;
+    }
+
     void rebuild() {
         if (rows_) {
             remove_child(rows_);
@@ -101,6 +120,19 @@ private:
         const auto white = canvas::Color::rgba8(235, 235, 240, 255);
         const auto teal = canvas::Color::rgba8(132, 243, 237, 255);
         const auto blue = canvas::Color::rgba8(127, 178, 255, 255);
+
+        // When a model is active there's an editor to return to — offer a way back.
+        bool has_active = false;
+        for (const auto& l : models_.models)
+            if (l.active) { has_active = true; break; }
+        if (has_active && on_done) {
+            auto done = std::make_unique<ToggleButton>();
+            done->set_label("← Done");
+            done->flex().preferred_width = 96.0f;
+            done->flex().preferred_height = 28.0f;
+            done->on_toggle = [this](bool) { if (on_done) on_done(); };
+            rows->add_child(std::move(done));
+        }
 
         if (models_.models.empty()) {
             auto empty = make_label("No models available yet.", 14.0f, muted);
@@ -123,32 +155,27 @@ private:
             row->add_child(std::move(name_label));
 
             const auto it = progress_.find(id);
-            const bool downloading = it != progress_.end();
-            if (downloading) {
-                auto meter = std::make_unique<Meter>();
-                meter->set_orientation(Meter::Orientation::horizontal);
-                meter->set_level(it->second, it->second);
-                meter->flex().preferred_width = 140.0f;
-                meter->flex().preferred_height = 10.0f;
-                row->add_child(std::move(meter));
-
-                int pct = static_cast<int>(it->second * 100.0f + 0.5f);
+            if (it != progress_.end()) {  // actively downloading
+                const int pct = static_cast<int>(it->second * 100.0f + 0.5f);
+                row->add_child(make_progress_bar(it->second, 140.0f));
                 row->add_child(make_label(std::to_string(pct) + "%", 12.0f, teal, 44.0f));
                 row->add_child(make_action("Cancel", id, &ModelManagerView::on_cancel));
-            } else {
-                std::string status = listed.active ? "Active"
-                                     : listed.status == "installed" ? "Installed"
-                                                                     : "Available";
-                row->add_child(make_label(status, 12.0f,
-                                          listed.active ? teal : (listed.status == "installed" ? blue : muted),
-                                          80.0f));
-
-                if (listed.status != "installed") {
-                    row->add_child(make_action("Download", id, &ModelManagerView::on_download));
-                } else {
-                    if (!listed.active) row->add_child(make_action("Set default", id, &ModelManagerView::on_activate));
-                    row->add_child(make_action("Remove", id, &ModelManagerView::on_remove));
-                }
+            } else if (listed.status == "partial") {  // paused / cancelled — resumable
+                const float frac = listed.partial_fraction < 0.0f ? 0.0f : listed.partial_fraction;
+                row->add_child(make_progress_bar(frac, 140.0f));
+                row->add_child(make_label("Paused " + std::to_string(static_cast<int>(frac * 100.0f + 0.5f)) + "%",
+                                          12.0f, muted, 90.0f));
+                row->add_child(make_action("Resume", id, &ModelManagerView::on_download));
+                row->add_child(make_action("Delete", id, &ModelManagerView::on_remove));
+            } else if (listed.status == "installed") {
+                row->add_child(make_label(listed.active ? "Active" : "Installed", 12.0f,
+                                          listed.active ? teal : blue, 80.0f));
+                if (!listed.active)
+                    row->add_child(make_action("Set default", id, &ModelManagerView::on_activate));
+                row->add_child(make_action("Remove", id, &ModelManagerView::on_remove));
+            } else {  // available
+                row->add_child(make_label("Available", 12.0f, muted, 80.0f));
+                row->add_child(make_action("Download", id, &ModelManagerView::on_download));
             }
             rows->add_child(std::move(row));
         }

--- a/core/view/include/pulp/view/text_editor.hpp
+++ b/core/view/include/pulp/view/text_editor.hpp
@@ -37,6 +37,7 @@ namespace pulp::view {
 class TextEditor : public View {
 public:
     TextEditor() { set_focusable(true); set_cursor(CursorStyle::text); }
+    ~TextEditor() override;
 
     bool accepts_text_input() const override { return true; }
 
@@ -159,6 +160,7 @@ private:
     float content_inset_left_ = 0.0f; ///< Extra left inset to clear a leading icon
     float scroll_offset_ = 0.0f; ///< Horizontal scroll for single-line
     float caret_blink_time_ = 0.0f; ///< Accumulated time for caret blinking
+    int caret_blink_sub_ = -1;      ///< Frame-clock subscription that drives blink repaints while focused
 
     // IME composition state
     std::string marked_text_;        ///< Active composition string

--- a/core/view/include/pulp/view/ui_components.hpp
+++ b/core/view/include/pulp/view/ui_components.hpp
@@ -196,6 +196,10 @@ public:
         std::unique_ptr<View> content;
     };
 
+    // Reserve the tab-bar height as top padding so tab content flows BELOW the tab bar
+    // (instead of painting over it). Uses flex padding so child hit-testing stays correct.
+    TabPanel() { flex().padding_top = tab_height_; }
+
     void add_tab(std::string title, std::unique_ptr<View> content);
     void set_active_tab(int index);
     int active_tab() const { return active_; }
@@ -206,7 +210,6 @@ public:
 
     void paint(canvas::Canvas& canvas) override;
     void on_mouse_event(const MouseEvent& event) override;
-    void layout_children() override;  // lay out tab content below the tab bar
 
 private:
     std::vector<Tab> tabs_;

--- a/core/view/include/pulp/view/ui_components.hpp
+++ b/core/view/include/pulp/view/ui_components.hpp
@@ -205,6 +205,15 @@ public:
     int active_tab() const { return active_; }
     int tab_count() const { return static_cast<int>(tabs_.size()); }
 
+    /// Hide the tab bar and use the panel purely as a navigable card stack (the active
+    /// tab is shown; switch with set_active_tab()). Useful when an outer container should
+    /// not show its own tabs — e.g. a standalone editor whose Settings is reached via a
+    /// button rather than a tab.
+    void set_show_tab_bar(bool show) {
+        show_tab_bar_ = show;
+        flex().padding_top = show ? tab_height_ : 0.0f;
+    }
+
     /// Called when the active tab changes.
     std::function<void(int index)> on_tab_change;
 
@@ -215,6 +224,7 @@ private:
     std::vector<Tab> tabs_;
     int active_ = 0;
     float tab_height_ = 32.0f;
+    bool show_tab_bar_ = true;
 };
 
 // ── ScrollView ───────────────────────────────────────────────────────────

--- a/core/view/include/pulp/view/ui_components.hpp
+++ b/core/view/include/pulp/view/ui_components.hpp
@@ -206,6 +206,7 @@ public:
 
     void paint(canvas::Canvas& canvas) override;
     void on_mouse_event(const MouseEvent& event) override;
+    void layout_children() override;  // lay out tab content below the tab bar
 
 private:
     std::vector<Tab> tabs_;

--- a/core/view/include/pulp/view/ui_components.hpp
+++ b/core/view/include/pulp/view/ui_components.hpp
@@ -57,6 +57,7 @@ public:
     void paint(canvas::Canvas& canvas) override;
     void on_mouse_event(const MouseEvent& event) override;
     bool on_key_event(const KeyEvent& event) override;
+    View* hit_test(Point local_point) override;  // extend hit area over the open dropdown
 
     void on_text_input(const TextInputEvent& event) override;
 
@@ -75,6 +76,11 @@ private:
     void set_selected_impl(int index, bool notify);
     void open_dropdown();
     void close_dropdown();
+    // Top of the dropdown menu in this combo's LOCAL coords. Below the field normally;
+    // negative (above the field) when flipped up because it would spill past the window.
+    // Shared by paint, hit_test, and mouse hover so they always agree.
+    float dropdown_local_top() const;
+    void move_hover(int delta);  // keyboard: move the highlighted row, skipping separators
 
     std::vector<std::string> items_;
     int selected_ = 0;

--- a/core/view/src/buttons.cpp
+++ b/core/view/src/buttons.cpp
@@ -11,21 +11,24 @@ void TextButton::paint(canvas::Canvas& canvas) {
     float w = bounds().width, h = bounds().height;
     float r = 6.0f;
 
-    // Background
-    auto bg = hovered_ ? canvas::Color::rgba(80, 80, 90) : canvas::Color::rgba(60, 60, 70);
-    if (!enabled_) bg = canvas::Color::rgba(50, 50, 55);
+    // Background. NOTE: Color::rgba() takes 0–1 floats; these are 0–255 channel values and
+    // must use rgba8() — rgba() clamps every channel to 1.0 and paints the button solid
+    // white (the standalone Settings/Done buttons regressed to white because of this).
+    auto bg = hovered_ ? canvas::Color::rgba8(80, 80, 90) : canvas::Color::rgba8(60, 60, 70);
+    if (pressed_) bg = canvas::Color::rgba8(96, 96, 110);
+    if (!enabled_) bg = canvas::Color::rgba8(50, 50, 55);
     canvas.set_fill_color(bg);
     canvas.fill_rounded_rect(0, 0, w, h, r);
 
     // Border
-    canvas.set_stroke_color(canvas::Color::rgba(100, 100, 110));
+    canvas.set_stroke_color(canvas::Color::rgba8(100, 100, 110));
     canvas.set_line_width(1.0f);
     canvas.stroke_rect(0, 0, w, h);
 
     // Label — pulp #1407 honors CSS text-overflow: ellipsis when set on
     // the button via setTextOverflow(id, "ellipsis"). Reserves a small
     // horizontal padding so the ellipsis doesn't touch the rounded edge.
-    auto text_color = enabled_ ? canvas::Color::rgba(220, 220, 230) : canvas::Color::rgba(120, 120, 130);
+    auto text_color = enabled_ ? canvas::Color::rgba8(220, 220, 230) : canvas::Color::rgba8(120, 120, 130);
     canvas.set_fill_color(text_color);
     canvas.set_font("system", 14.0f);
     constexpr float kButtonHPad = 8.0f;

--- a/core/view/src/text_editor.cpp
+++ b/core/view/src/text_editor.cpp
@@ -199,6 +199,7 @@ void TextEditor::move_caret(int delta, bool extend) {
         selection_end_ = caret_position_;
     else
         selection_start_ = selection_end_ = caret_position_;
+    caret_blink_time_ = 0;  // keep the caret solid while moving; it resumes blinking when idle
 }
 
 void TextEditor::move_word(int direction, bool extend) {
@@ -284,6 +285,10 @@ void TextEditor::on_mouse_event(const MouseEvent& event) {
 
 bool TextEditor::on_key_event(const KeyEvent& event) {
     if (!event.is_down) return false;
+
+    // Any key press makes the caret solid (and it resumes blinking when idle) — standard
+    // text-field behavior so the caret never appears to vanish mid-keystroke.
+    caret_blink_time_ = 0;
 
     bool shift = event.isShiftDown();
     bool mod = event.isMainModifier();  // Cmd on macOS, Ctrl on Win/Linux

--- a/core/view/src/text_editor.cpp
+++ b/core/view/src/text_editor.cpp
@@ -1,4 +1,5 @@
 #include <pulp/view/text_editor.hpp>
+#include <pulp/view/frame_clock.hpp>  // caret-blink subscription
 #include <algorithm>
 #include <cctype>
 #include <cmath>
@@ -389,10 +390,31 @@ void TextEditor::on_text_input(const TextInputEvent& event) {
     notify_change();
 }
 
+TextEditor::~TextEditor() {
+    if (caret_blink_sub_ >= 0)
+        if (auto* fc = frame_clock()) fc->unsubscribe(caret_blink_sub_);
+}
+
 void TextEditor::on_focus_changed(bool gained) {
     View::on_focus_changed(gained);  // sets has_focus_ for border rendering
-    if (gained && select_on_focus) {
-        select_all();
+    if (gained) {
+        if (select_on_focus) select_all();
+        // Drive the caret blink from the frame clock so it keeps blinking while focused,
+        // independent of mouse movement (paint-driven blinking froze when the pointer left
+        // the field — repaints only happened on hover). Each tick just requests a repaint;
+        // paint() advances caret_blink_time_.
+        caret_blink_time_ = 0.0f;
+        if (caret_blink_sub_ < 0)
+            if (auto* fc = frame_clock())
+                caret_blink_sub_ = fc->subscribe([this](float) {
+                    request_repaint();
+                    return true;
+                });
+    } else {
+        if (caret_blink_sub_ >= 0)
+            if (auto* fc = frame_clock()) fc->unsubscribe(caret_blink_sub_);
+        caret_blink_sub_ = -1;
+        request_repaint();  // clear the caret now that focus is lost
     }
 }
 

--- a/core/view/src/ui_components.cpp
+++ b/core/view/src/ui_components.cpp
@@ -441,6 +441,16 @@ void TabPanel::on_mouse_event(const MouseEvent& event) {
     set_active_tab(index);
 }
 
+void TabPanel::layout_children() {
+    // The tab bar occupies the top `tab_height_`; lay out tab contents in the area
+    // below it so the active tab doesn't paint over (and hide) the tab bar.
+    const auto saved = bounds();
+    set_bounds({saved.x, saved.y + tab_height_, saved.width,
+                saved.height > tab_height_ ? saved.height - tab_height_ : 0.0f});
+    View::layout_children();
+    set_bounds(saved);
+}
+
 // ── ScrollView ───────────────────────────────────────────────────────────
 
 void ScrollView::clamp_scroll_targets() {

--- a/core/view/src/ui_components.cpp
+++ b/core/view/src/ui_components.cpp
@@ -403,6 +403,7 @@ void TabPanel::set_active_tab(int index) {
 }
 
 void TabPanel::paint(canvas::Canvas& canvas) {
+    if (!show_tab_bar_) return;  // card-stack mode: no tab bar, content fills the panel
     auto b = local_bounds();
 
     // Tab bar background
@@ -431,6 +432,7 @@ void TabPanel::paint(canvas::Canvas& canvas) {
 }
 
 void TabPanel::on_mouse_event(const MouseEvent& event) {
+    if (!show_tab_bar_) return;  // card-stack mode: nothing to click in the (absent) tab bar
     if (!event.is_down) return;
     if (tabs_.empty()) return;
     if (event.position.y > tab_height_) return; // click below tab bar

--- a/core/view/src/ui_components.cpp
+++ b/core/view/src/ui_components.cpp
@@ -441,16 +441,6 @@ void TabPanel::on_mouse_event(const MouseEvent& event) {
     set_active_tab(index);
 }
 
-void TabPanel::layout_children() {
-    // The tab bar occupies the top `tab_height_`; lay out tab contents in the area
-    // below it so the active tab doesn't paint over (and hide) the tab bar.
-    const auto saved = bounds();
-    set_bounds({saved.x, saved.y + tab_height_, saved.width,
-                saved.height > tab_height_ ? saved.height - tab_height_ : 0.0f});
-    View::layout_children();
-    set_bounds(saved);
-}
-
 // ── ScrollView ───────────────────────────────────────────────────────────
 
 void ScrollView::clamp_scroll_targets() {

--- a/core/view/src/ui_components.cpp
+++ b/core/view/src/ui_components.cpp
@@ -279,9 +279,16 @@ bool ComboBox::on_key_event(const KeyEvent& event) {
     if (!event.is_down) return false;
 
     if (!open_) {
-        // Closed: Enter/Space/Up/Down opens the menu (highlight starts on the current value).
-        if (event.key == KeyCode::enter || event.key == KeyCode::space ||
-            event.key == KeyCode::up || event.key == KeyCode::down) {
+        // Closed: Up/Down step the value like a stepper; Enter/Space opens the menu.
+        if (event.key == KeyCode::up && selected_ > 0) {
+            set_selected(selected_ - 1);
+            return true;
+        }
+        if (event.key == KeyCode::down && selected_ < static_cast<int>(items_.size()) - 1) {
+            set_selected(selected_ + 1);
+            return true;
+        }
+        if (event.key == KeyCode::enter || event.key == KeyCode::space) {
             open_dropdown();
             request_repaint();
             return true;

--- a/core/view/src/ui_components.cpp
+++ b/core/view/src/ui_components.cpp
@@ -84,25 +84,20 @@ void ComboBox::paint(canvas::Canvas& canvas) {
 
     // Dropdown menu: deferred to overlay queue so it paints on top of everything
     if (open_ && !items_.empty()) {
-        // Compute absolute position by walking up the parent chain; track the root view's
-        // height so we know the visible bottom edge.
-        float abs_x = 0, abs_y = 0, root_h = 0;
+        // Compute absolute position by walking up the parent chain.
+        float abs_x = 0, abs_y = 0;
         View* v = this;
         while (v) {
             abs_x += v->bounds().x;
             abs_y += v->bounds().y;
-            root_h = v->bounds().height;  // last assignment is the root (window content height)
             v = v->parent();
         }
 
         float item_h = 24.0f;
         float dd_w = b.width;
         float dd_h = static_cast<float>(items_.size()) * item_h;
-        // Open below by default; flip above the field when the menu would spill past the
-        // bottom of the window and there's room above (e.g. a combo near the window bottom).
-        float dd_top = abs_y + base_h + 2;
-        if (root_h > 0 && dd_top + dd_h > root_h && abs_y - dd_h - 2 >= 0)
-            dd_top = abs_y - dd_h - 2;
+        // dropdown_local_top() decides below/flip-up; paint, hit_test and hover all share it.
+        float dd_top = abs_y + dropdown_local_top();
         int sel = selected_;
         int* hover_ptr = &hover_index_;  // live pointer for dynamic hover tracking
         auto items_copy = items_;
@@ -198,70 +193,120 @@ void ComboBox::close_dropdown() {
     if (active_popup_ == this) active_popup_ = nullptr;
 }
 
-void ComboBox::on_mouse_event(const MouseEvent& event) {
-    auto b = local_bounds();
-    float header_h = std::min(b.height, 28.0f);
+float ComboBox::dropdown_local_top() const {
+    const float base_h = std::min(local_bounds().height, 28.0f);
+    const float dd_h = static_cast<float>(items_.size()) * 24.0f;
+    float abs_y = 0.0f, root_h = 0.0f;
+    const View* v = this;
+    while (v) {
+        abs_y += v->bounds().y;
+        root_h = v->bounds().height;  // last assignment is the root (window content height)
+        v = v->parent();
+    }
+    if (root_h > 0.0f && abs_y + base_h + 2.0f + dd_h > root_h && abs_y - dd_h - 2.0f >= 0.0f)
+        return -(dd_h + 2.0f);  // flip above the field
+    return base_h + 2.0f;       // below the field
+}
 
-    // Track hover on mouse move (even without button down)
+View* ComboBox::hit_test(Point local_point) {
+    // When open, the menu overlay lives outside this view's own bounds (below, or above when
+    // flipped). Claim hits over it so hover/click reach us regardless of flip direction.
+    if (open_ && !items_.empty()) {
+        const float top = dropdown_local_top();
+        const float dd_h = static_cast<float>(items_.size()) * 24.0f;
+        if (local_point.x >= 0.0f && local_point.x <= local_bounds().width &&
+            local_point.y >= std::min(top, 0.0f) &&
+            local_point.y <= std::max(top + dd_h, local_bounds().height))
+            return this;
+    }
+    return View::hit_test(local_point);
+}
+
+void ComboBox::move_hover(int delta) {
+    if (items_.empty()) return;
+    const int n = static_cast<int>(items_.size());
+    int idx = (hover_index_ < 0) ? selected_ : hover_index_;
+    for (int step = 0; step < n; ++step) {
+        int next = std::clamp(idx + delta, 0, n - 1);
+        if (next == idx) break;  // hit an end
+        idx = next;
+        const auto& it = items_[static_cast<size_t>(idx)];
+        if (it.size() < 3 || it.substr(0, 3) != "---") break;  // landed on a real item
+    }
+    hover_index_ = idx;
+    request_repaint();
+}
+
+void ComboBox::on_mouse_event(const MouseEvent& event) {
+    // Menu geometry in local coords — shared with paint/hit_test so hover/click line up with
+    // what's drawn, including the flipped-up case.
+    const float dropdown_top = dropdown_local_top();
+    const float dd_bottom = dropdown_top + static_cast<float>(items_.size()) * 24.0f;
+    const bool in_menu = event.position.y >= dropdown_top && event.position.y < dd_bottom;
+
+    // Track hover on mouse move (even without button down). Repaint so the highlight follows
+    // the pointer even when nothing else is driving frames (e.g. on the Settings tab).
     if (open_ && !event.is_down && !event.is_wheel) {
-        float dropdown_top = header_h + 2;
-        if (event.position.y >= dropdown_top) {
-            hover_index_ = static_cast<int>((event.position.y - dropdown_top) / 24.0f);
-            if (hover_index_ >= static_cast<int>(items_.size())) hover_index_ = -1;
+        if (in_menu) {
+            int idx = static_cast<int>((event.position.y - dropdown_top) / 24.0f);
+            hover_index_ = (idx >= 0 && idx < static_cast<int>(items_.size())) ? idx : -1;
         } else {
             hover_index_ = -1;
         }
+        request_repaint();
         return;
     }
 
     if (!event.is_down) return;
 
     if (open_) {
-        float dropdown_top = header_h + 2;
-        if (event.position.y >= dropdown_top) {
+        if (in_menu) {
             int index = static_cast<int>((event.position.y - dropdown_top) / 24.0f);
             if (index >= 0 && index < static_cast<int>(items_.size())) {
                 const auto& item = items_[static_cast<size_t>(index)];
-                if (item.size() < 3 || item.substr(0, 3) != "---") {
-                    set_selected(index);
-                }
+                if (item.size() < 3 || item.substr(0, 3) != "---") set_selected(index);
             }
         }
-        close_dropdown();
+        close_dropdown();  // a click on a row commits; a click on the header/outside cancels
     } else {
         open_dropdown();
     }
+    request_repaint();
 }
 
 
 bool ComboBox::on_key_event(const KeyEvent& event) {
     if (!event.is_down) return false;
-    if (event.key == KeyCode::up && selected_ > 0) {
-        set_selected(selected_ - 1);
-        // Keyboard navigation should move the row HIGHLIGHT too (not just the
-        // check glyph), matching mouse hover — otherwise arrowing through an
-        // open dropdown shows no highlighted row until the mouse moves over it.
-        if (open_) hover_index_ = selected_;
-        return true;
+
+    if (!open_) {
+        // Closed: Enter/Space/Up/Down opens the menu (highlight starts on the current value).
+        if (event.key == KeyCode::enter || event.key == KeyCode::space ||
+            event.key == KeyCode::up || event.key == KeyCode::down) {
+            open_dropdown();
+            request_repaint();
+            return true;
+        }
+        return false;
     }
-    if (event.key == KeyCode::down && selected_ < static_cast<int>(items_.size()) - 1) {
-        set_selected(selected_ + 1);
-        if (open_) hover_index_ = selected_;
-        return true;
+
+    // Open: arrows move the highlight (like hover), Enter/Space commits, Esc cancels.
+    switch (event.key) {
+        case KeyCode::up:   move_hover(-1); return true;
+        case KeyCode::down: move_hover(+1); return true;
+        case KeyCode::escape:
+            close_dropdown();  // cancel — selection unchanged
+            request_repaint();
+            return true;
+        case KeyCode::enter:
+        case KeyCode::space:
+            if (hover_index_ >= 0 && hover_index_ < static_cast<int>(items_.size()))
+                set_selected(hover_index_);
+            close_dropdown();
+            request_repaint();
+            return true;
+        default:
+            return false;
     }
-    if (event.key == KeyCode::escape && open_) {
-        close_dropdown();
-        return true;
-    }
-    if ((event.key == KeyCode::enter || event.key == KeyCode::space) && !open_) {
-        open_dropdown();
-        return true;
-    }
-    if ((event.key == KeyCode::enter || event.key == KeyCode::space) && open_) {
-        close_dropdown();
-        return true;
-    }
-    return false;
 }
 
 void ComboBox::on_text_input(const TextInputEvent& event) {

--- a/core/view/src/ui_components.cpp
+++ b/core/view/src/ui_components.cpp
@@ -84,19 +84,25 @@ void ComboBox::paint(canvas::Canvas& canvas) {
 
     // Dropdown menu: deferred to overlay queue so it paints on top of everything
     if (open_ && !items_.empty()) {
-        // Compute absolute position by walking up the parent chain
-        float abs_x = 0, abs_y = 0;
+        // Compute absolute position by walking up the parent chain; track the root view's
+        // height so we know the visible bottom edge.
+        float abs_x = 0, abs_y = 0, root_h = 0;
         View* v = this;
         while (v) {
             abs_x += v->bounds().x;
             abs_y += v->bounds().y;
+            root_h = v->bounds().height;  // last assignment is the root (window content height)
             v = v->parent();
         }
 
         float item_h = 24.0f;
-        float dd_top = abs_y + base_h + 2;
         float dd_w = b.width;
         float dd_h = static_cast<float>(items_.size()) * item_h;
+        // Open below by default; flip above the field when the menu would spill past the
+        // bottom of the window and there's room above (e.g. a combo near the window bottom).
+        float dd_top = abs_y + base_h + 2;
+        if (root_h > 0 && dd_top + dd_h > root_h && abs_y - dd_h - 2 >= 0)
+            dd_top = abs_y - dd_h - 2;
         int sel = selected_;
         int* hover_ptr = &hover_index_;  // live pointer for dynamic hover tracking
         auto items_copy = items_;

--- a/core/view/src/widgets.cpp
+++ b/core/view/src/widgets.cpp
@@ -302,10 +302,8 @@ void Fader::advance_animations(float dt) {
 void Toggle::set_on(bool v) {
     if (on_ == v) return;
     on_ = v;
-    // Snap the thumb to its end state rather than animating. The slide needs a continuous
-    // frame driver; on a surface that isn't ticking frames (e.g. a Settings tab with no
-    // focused text field) the animation froze mid-slide and the toggle felt unresponsive.
-    thumb_position_.set(v ? 1.0f : 0.0f);
+    float dur = resolve_dimension("motion.duration.normal", 0.15f);
+    thumb_position_.animate_to(v ? 1.0f : 0.0f, dur, easing::ease_out_cubic);
     // pulp #73 — programmatic toggle (preset apply, JS bridge setValue) must reach the
     // screen on its own; user-input toggles also repaint via the host per-event path.
     request_repaint();

--- a/core/view/src/widgets.cpp
+++ b/core/view/src/widgets.cpp
@@ -302,11 +302,12 @@ void Fader::advance_animations(float dt) {
 void Toggle::set_on(bool v) {
     if (on_ == v) return;
     on_ = v;
-    float dur = resolve_dimension("motion.duration.normal", 0.15f);
-    thumb_position_.animate_to(v ? 1.0f : 0.0f, dur, easing::ease_out_cubic);
-    // pulp #73 — programmatic toggle (preset apply, JS bridge setValue)
-    // must reach the screen on its own. User-input toggles already
-    // repaint via the host's per-event setNeedsDisplay path.
+    // Snap the thumb to its end state rather than animating. The slide needs a continuous
+    // frame driver; on a surface that isn't ticking frames (e.g. a Settings tab with no
+    // focused text field) the animation froze mid-slide and the toggle felt unresponsive.
+    thumb_position_.set(v ? 1.0f : 0.0f);
+    // pulp #73 — programmatic toggle (preset apply, JS bridge setValue) must reach the
+    // screen on its own; user-input toggles also repaint via the host per-event path.
     request_repaint();
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -899,6 +899,11 @@ pulp_add_test_suite(pulp-test-stream LIBRARIES pulp::runtime)
 # Generic model registry/store (MM-PR1)
 pulp_add_test_suite(pulp-test-model-store LIBRARIES pulp::runtime)
 
+# Streaming model downloader (MM-PR2) — uses a local httplib server fixture
+pulp_add_test_suite(pulp-test-model-download LIBRARIES pulp::runtime)
+target_include_directories(pulp-test-model-download PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../external/cpp-httplib)
+
 # Native-component core ABI contract tests. Always built (no Rust toolchain
 # needed) — one case per forward-compatibility decision (1-12) so the C ABI
 # shape can't silently drift. The Rust round-trip + RT-safety self-test is the

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1038,6 +1038,9 @@ pulp_add_test_suite(pulp-test-json-rpc LIBRARIES pulp::runtime)
 # Validation harness tests (Phase 2)
 pulp_add_test_suite(pulp-test-validation-harness LIBRARIES pulp::format)
 
+# Plugin-contributed settings sections (MM-PR5) — SettingsPanel lives in pulp::standalone
+pulp_add_test_suite(pulp-test-settings-sections LIBRARIES pulp::standalone)
+
 pulp_add_test_suite(pulp-test-plugin-state-io LIBRARIES pulp::format)
 
 # AAX metadata/model tests

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -904,6 +904,11 @@ pulp_add_test_suite(pulp-test-model-download LIBRARIES pulp::runtime)
 target_include_directories(pulp-test-model-download PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../external/cpp-httplib)
 
+# ModelManager view (MM-PR3) — needs the view stack (pulp::view) for render_to_png
+add_executable(pulp-test-model-manager-view test_model_manager_view.cpp)
+target_link_libraries(pulp-test-model-manager-view PRIVATE pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-model-manager-view)
+
 # Native-component core ABI contract tests. Always built (no Rust toolchain
 # needed) — one case per forward-compatibility decision (1-12) so the C ABI
 # shape can't silently drift. The Rust round-trip + RT-safety self-test is the

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -896,6 +896,9 @@ pulp_add_test_suite(pulp-test-progress-parser LIBRARIES pulp::platform)
 # Stream tests (unified I/O interface)
 pulp_add_test_suite(pulp-test-stream LIBRARIES pulp::runtime)
 
+# Generic model registry/store (MM-PR1)
+pulp_add_test_suite(pulp-test-model-store LIBRARIES pulp::runtime)
+
 # Native-component core ABI contract tests. Always built (no Rust toolchain
 # needed) — one case per forward-compatibility decision (1-12) so the C ABI
 # shape can't silently drift. The Rust round-trip + RT-safety self-test is the

--- a/test/test_combo_dropdown.cpp
+++ b/test/test_combo_dropdown.cpp
@@ -102,13 +102,14 @@ TEST_CASE("ComboBox: keyboard navigation moves the row highlight while open",
     REQUIRE(combo.is_open());
     REQUIRE(combo.hovered_index() == 0);
 
-    // Arrowing down moves BOTH the selection (check glyph) and the highlight.
+    // While open, arrowing moves the HIGHLIGHT only (like mouse hover); the selection is
+    // not committed until Enter — so the user can browse, then accept or cancel.
     KeyEvent down;
     down.key = KeyCode::down;
     down.is_down = true;
     combo.on_key_event(down);
-    REQUIRE(combo.selected_text() == "B");
     REQUIRE(combo.hovered_index() == 1);
+    REQUIRE(combo.selected_text() == "A");  // not committed yet
 
     combo.on_key_event(down);
     REQUIRE(combo.hovered_index() == 2);
@@ -118,6 +119,14 @@ TEST_CASE("ComboBox: keyboard navigation moves the row highlight while open",
     up.is_down = true;
     combo.on_key_event(up);
     REQUIRE(combo.hovered_index() == 1);
+
+    // Enter commits the highlighted row and closes; Esc would cancel with no change.
+    KeyEvent ret;
+    ret.key = KeyCode::enter;
+    ret.is_down = true;
+    combo.on_key_event(ret);
+    REQUIRE(combo.selected_text() == "B");
+    REQUIRE_FALSE(combo.is_open());
 }
 
 // ── Regression: dropdown overlay click routing ───────────────────────────

--- a/test/test_model_download.cpp
+++ b/test/test_model_download.cpp
@@ -1,0 +1,189 @@
+// Streaming model downloader (MM-PR2) — exercised against a local HTTP server (no
+// TLS, so no network + no flakiness): full download + sha256 + atomic rename, Range
+// resume, sha256-mismatch rejection, and cancel-keeps-partial. The HTTPS/mbedTLS path
+// is the same code; only the transport differs.
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/runtime/crypto.hpp>
+#include <pulp/runtime/model_download.hpp>
+#include <pulp/runtime/model_registry.hpp>
+#include <pulp/runtime/model_store.hpp>
+
+#include <httplib.h>
+
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+
+using namespace pulp::runtime;
+namespace fs = std::filesystem;
+
+namespace {
+
+struct LocalServer {
+    httplib::Server svr;
+    std::thread thread;
+    int port = 0;
+
+    explicit LocalServer(const fs::path& serve_dir) {
+        svr.set_mount_point("/", serve_dir.string());  // static files w/ Range support
+        port = svr.bind_to_any_port("127.0.0.1");
+        thread = std::thread([this] { svr.listen_after_bind(); });
+        svr.wait_until_ready();
+    }
+    ~LocalServer() {
+        svr.stop();
+        if (thread.joinable()) thread.join();
+    }
+    std::string url(const std::string& path) const {
+        return "http://127.0.0.1:" + std::to_string(port) + path;
+    }
+};
+
+std::string make_fixture(const fs::path& path, size_t n) {
+    std::string body;
+    body.reserve(n);
+    for (size_t i = 0; i < n; ++i) body += static_cast<char>('A' + (i * 7 + 3) % 26);
+    std::ofstream(path, std::ios::binary).write(body.data(), static_cast<std::streamsize>(body.size()));
+    return body;
+}
+
+}  // namespace
+
+TEST_CASE("model downloader: full download + sha256 + atomic rename", "[runtime][model][download]") {
+    const fs::path root = fs::temp_directory_path() / "pulp-mm-pr2";
+    fs::remove_all(root);
+    fs::create_directories(root / "serve");
+    const std::string body = make_fixture(root / "serve" / "fixture.bin", 250'000);
+    const std::string sha = sha256_hex(body);
+
+    LocalServer server(root / "serve");
+
+    const fs::path dest = root / "out" / "fixture.bin";
+    DownloadRequest req{.url = server.url("/fixture.bin"), .dest = dest, .expected_sha256 = sha};
+
+    auto res = download_file(req);
+    INFO("error: " << res.error);
+    REQUIRE(res.ok);
+    REQUIRE(res.sha256 == sha);
+    REQUIRE(res.bytes == body.size());
+    REQUIRE(fs::exists(dest));
+    REQUIRE_FALSE(fs::exists(fs::path(dest) += ".part"));  // .part consumed by atomic rename
+
+    fs::remove_all(root);
+}
+
+TEST_CASE("model downloader: Range resume continues a partial", "[runtime][model][download]") {
+    const fs::path root = fs::temp_directory_path() / "pulp-mm-pr2-resume";
+    fs::remove_all(root);
+    fs::create_directories(root / "serve");
+    fs::create_directories(root / "out");
+    const std::string body = make_fixture(root / "serve" / "fixture.bin", 250'000);
+    const std::string sha = sha256_hex(body);
+
+    LocalServer server(root / "serve");
+
+    // Seed a partial .part with the first 100k bytes (as a prior interrupted download would).
+    const fs::path dest = root / "out" / "fixture.bin";
+    fs::path part = dest;
+    part += ".part";
+    std::ofstream(part, std::ios::binary).write(body.data(), 100'000);
+
+    DownloadRequest req{.url = server.url("/fixture.bin"), .dest = dest, .expected_sha256 = sha,
+                        .resume = true};
+    auto res = download_file(req);
+    INFO("error: " << res.error);
+    REQUIRE(res.ok);
+    REQUIRE(res.resumed);
+    REQUIRE(res.sha256 == sha);  // re-hashed the partial + streamed the rest correctly
+    REQUIRE(fs::exists(dest));
+
+    fs::remove_all(root);
+}
+
+TEST_CASE("model downloader: sha256 mismatch is rejected", "[runtime][model][download]") {
+    const fs::path root = fs::temp_directory_path() / "pulp-mm-pr2-bad";
+    fs::remove_all(root);
+    fs::create_directories(root / "serve");
+    make_fixture(root / "serve" / "fixture.bin", 50'000);
+
+    LocalServer server(root / "serve");
+
+    const fs::path dest = root / "out" / "fixture.bin";
+    DownloadRequest req{.url = server.url("/fixture.bin"), .dest = dest,
+                        .expected_sha256 = std::string(64, 'a')};  // wrong
+    auto res = download_file(req);
+    REQUIRE_FALSE(res.ok);
+    REQUIRE(res.error.find("mismatch") != std::string::npos);
+    REQUIRE_FALSE(fs::exists(dest));                    // not published
+    REQUIRE_FALSE(fs::exists(fs::path(dest) += ".part"));  // corrupt partial removed
+
+    fs::remove_all(root);
+}
+
+TEST_CASE("model downloader: cancel keeps the partial for resume", "[runtime][model][download]") {
+    const fs::path root = fs::temp_directory_path() / "pulp-mm-pr2-cancel";
+    fs::remove_all(root);
+    fs::create_directories(root / "serve");
+    make_fixture(root / "serve" / "fixture.bin", 500'000);
+
+    LocalServer server(root / "serve");
+
+    const fs::path dest = root / "out" / "fixture.bin";
+    DownloadRequest req{.url = server.url("/fixture.bin"), .dest = dest};
+
+    std::atomic<int> chunks{0};
+    auto res = download_file(req, [&](const DownloadProgress&) {
+        return ++chunks < 1;  // cancel immediately after the first chunk
+    });
+    REQUIRE_FALSE(res.ok);
+    REQUIRE(res.cancelled);
+    REQUIRE_FALSE(fs::exists(dest));                 // not published
+    REQUIRE(fs::exists(fs::path(dest) += ".part"));  // partial kept for resume
+
+    fs::remove_all(root);
+}
+
+TEST_CASE("model store: install_model downloads + records, then remove_model deletes",
+          "[runtime][model][download]") {
+    const fs::path root = fs::temp_directory_path() / "pulp-mm-pr2-install";
+    fs::remove_all(root);
+    fs::create_directories(root / "serve");
+    const std::string body = make_fixture(root / "serve" / "weights.bin", 120'000);
+    const std::string sha = sha256_hex(body);
+
+    LocalServer server(root / "serve");
+    const fs::path home = root / "home";  // acts as PULP_HOME
+
+    ModelEntry model{.model_id = "m1", .display_name = "Model One", .backend = "mlx"};
+    model.download_url = server.url("/weights.bin");
+    model.sha256 = sha;
+
+    auto inst = install_model(model, "magenta", /*on_progress=*/{}, /*cancel=*/nullptr,
+                              /*headers=*/{}, home);
+    INFO("install error: " << inst.error);
+    REQUIRE(inst.ok);
+    REQUIRE(inst.sha256 == sha);
+    REQUIRE(fs::exists(inst.checkpoint_path));
+    REQUIRE(fs::exists(inst.metadata_path));
+
+    // The store now sees it installed + activatable.
+    auto rec = read_installed_model("magenta", "m1", home);
+    REQUIRE(rec.metadata_found);
+    REQUIRE(rec.checkpoint_exists);
+    std::vector<ModelEntry> registry = {model};
+    REQUIRE(activate_model(registry, "magenta", "m1", home).ok);
+    REQUIRE(read_active_model_id("magenta", home) == "m1");
+
+    // Remove deletes files + metadata and clears the active selection.
+    std::string err;
+    REQUIRE(remove_model("magenta", "m1", err, home));
+    REQUIRE(err.empty());
+    REQUIRE_FALSE(fs::exists(inst.checkpoint_path));
+    REQUIRE_FALSE(fs::exists(inst.metadata_path));
+    REQUIRE(read_active_model_id("magenta", home).empty());
+
+    fs::remove_all(root);
+}

--- a/test/test_model_manager_view.cpp
+++ b/test/test_model_manager_view.cpp
@@ -5,6 +5,7 @@
 
 #include <pulp/runtime/model_store.hpp>
 #include <pulp/view/model_manager_view.hpp>
+#include <pulp/view/buttons.hpp>  // TextButton (momentary action buttons)
 #include <pulp/view/screenshot.hpp>
 
 #include <fstream>
@@ -42,6 +43,8 @@ View* model_block(View& v, size_t i) { return v.child_at(2 + i); }
 void fire_buttons(View* view) {
     if (auto* b = dynamic_cast<ToggleButton*>(view))
         if (b->on_toggle) b->on_toggle(true);
+    if (auto* t = dynamic_cast<TextButton*>(view))  // action buttons are momentary TextButtons
+        if (t->on_click) t->on_click();
     for (size_t i = 0; i < view->child_count(); ++i) fire_buttons(view->child_at(i));
 }
 

--- a/test/test_model_manager_view.cpp
+++ b/test/test_model_manager_view.cpp
@@ -1,5 +1,6 @@
-// ModelManagerView (MM-PR3) — builds rows from a model list, shows a download-progress
-// row, fires the action callbacks, and renders non-blank on the Skia canvas.
+// ModelManagerView (MM-PR3) — builds a block per model (header + subtitle + N blocks),
+// shows a progress bar line while downloading, fires the action callbacks, and renders
+// non-blank on the Skia canvas.
 #include <catch2/catch_test_macros.hpp>
 
 #include <pulp/runtime/model_store.hpp>
@@ -31,33 +32,34 @@ ModelListResult make_models() {
     b.model.display_name = "Magenta RT2 (Small)";
     b.status = "not_installed";
 
-    r.models = {a, b};
+    r.models = {a, b};  // index 0 active+installed, index 1 available
     return r;
 }
 
-View* last_child(View& v) { return v.child_at(v.child_count() - 1); }
+// Children are: [0] header, [1] subtitle, [2..] one block per model.
+View* model_block(View& v, size_t i) { return v.child_at(2 + i); }
+
+void fire_buttons(View* view) {
+    if (auto* b = dynamic_cast<ToggleButton*>(view))
+        if (b->on_toggle) b->on_toggle(true);
+    for (size_t i = 0; i < view->child_count(); ++i) fire_buttons(view->child_at(i));
+}
 
 }  // namespace
 
-TEST_CASE("ModelManagerView builds a row per model", "[view][model]") {
+TEST_CASE("ModelManagerView builds a block per model", "[view][model]") {
     ModelManagerView v;
     v.set_models(make_models());
-    REQUIRE(v.child_count() >= 3);          // title + subtitle + rows container
-    REQUIRE(last_child(v)->child_count() == 2);  // two model rows
+    REQUIRE(v.child_count() == 4);  // header + subtitle + 2 model blocks
 }
 
-TEST_CASE("ModelManagerView shows a download-progress row", "[view][model]") {
+TEST_CASE("ModelManagerView adds a progress-bar line while downloading", "[view][model]") {
     ModelManagerView v;
     v.set_models(make_models());
 
-    auto* rows = last_child(v);
-    const size_t before = rows->child_at(1)->child_count();  // mrt2_small idle row
-
+    const size_t before = model_block(v, 1)->child_count();  // mrt2_small: just the line
     v.set_download_progress("mrt2_small", 0.47f);
-    rows = last_child(v);  // rebuilt
-    REQUIRE(rows->child_count() == 2);
-    // Downloading row gains a meter + "%" + Cancel, so it has more children than idle.
-    REQUIRE(rows->child_at(1)->child_count() > before);
+    REQUIRE(model_block(v, 1)->child_count() > before);  // gained the full-width bar line
 }
 
 TEST_CASE("ModelManagerView action callbacks fire with the model id", "[view][model]") {
@@ -68,25 +70,31 @@ TEST_CASE("ModelManagerView action callbacks fire with the model id", "[view][mo
     v.on_remove = [&](const std::string& id) { removed = id; };
     v.set_models(make_models());
 
-    auto* rows = last_child(v);
-    auto fire_buttons = [](View* row) {
-        for (size_t i = 0; i < row->child_count(); ++i)
-            if (auto* b = dynamic_cast<ToggleButton*>(row->child_at(i)))
-                if (b->on_toggle) b->on_toggle(true);
-    };
-    fire_buttons(rows->child_at(0));  // mrt2_base installed+active → Remove
-    fire_buttons(rows->child_at(1));  // mrt2_small not installed → Download
+    fire_buttons(model_block(v, 0));  // mrt2_base installed+active → Remove
+    fire_buttons(model_block(v, 1));  // mrt2_small not installed → Download
 
     REQUIRE(downloaded == "mrt2_small");
     REQUIRE(removed == "mrt2_base");
 }
 
+TEST_CASE("ModelManagerView shows a header Done when closeable", "[view][model]") {
+    ModelManagerView v;
+    bool done = false;
+    v.on_done = [&] { done = true; };
+    v.set_models(make_models());
+    v.set_can_close(true);
+    fire_buttons(v.child_at(0));  // header contains the Done button
+    REQUIRE(done);
+}
+
 TEST_CASE("ModelManagerView renders non-blank on the Skia canvas", "[view][model][.demo]") {
     ModelManagerView v;
+    v.on_done = [] {};
     v.set_models(make_models());
+    v.set_can_close(true);
     v.set_download_progress("mrt2_small", 0.47f);
 
-    auto png = render_to_png(v, 560, 280, 2.0f, ScreenshotBackend::skia);
+    auto png = render_to_png(v, 620, 300, 2.0f, ScreenshotBackend::skia);
     REQUIRE_FALSE(png.empty());
     std::ofstream("/tmp/model-manager.png", std::ios::binary)
         .write(reinterpret_cast<const char*>(png.data()), static_cast<std::streamsize>(png.size()));

--- a/test/test_model_manager_view.cpp
+++ b/test/test_model_manager_view.cpp
@@ -1,0 +1,93 @@
+// ModelManagerView (MM-PR3) — builds rows from a model list, shows a download-progress
+// row, fires the action callbacks, and renders non-blank on the Skia canvas.
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/runtime/model_store.hpp>
+#include <pulp/view/model_manager_view.hpp>
+#include <pulp/view/screenshot.hpp>
+
+#include <fstream>
+#include <string>
+
+using namespace pulp::view;
+using pulp::runtime::ListedModel;
+using pulp::runtime::ModelListResult;
+
+namespace {
+
+ModelListResult make_models() {
+    ModelListResult r;
+    r.active_model_id = "mrt2_base";
+
+    ListedModel a;
+    a.model.model_id = "mrt2_base";
+    a.model.display_name = "Magenta RT2 (Large)";
+    a.model.is_recommended = true;
+    a.status = "installed";
+    a.active = true;
+
+    ListedModel b;
+    b.model.model_id = "mrt2_small";
+    b.model.display_name = "Magenta RT2 (Small)";
+    b.status = "not_installed";
+
+    r.models = {a, b};
+    return r;
+}
+
+View* last_child(View& v) { return v.child_at(v.child_count() - 1); }
+
+}  // namespace
+
+TEST_CASE("ModelManagerView builds a row per model", "[view][model]") {
+    ModelManagerView v;
+    v.set_models(make_models());
+    REQUIRE(v.child_count() >= 3);          // title + subtitle + rows container
+    REQUIRE(last_child(v)->child_count() == 2);  // two model rows
+}
+
+TEST_CASE("ModelManagerView shows a download-progress row", "[view][model]") {
+    ModelManagerView v;
+    v.set_models(make_models());
+
+    auto* rows = last_child(v);
+    const size_t before = rows->child_at(1)->child_count();  // mrt2_small idle row
+
+    v.set_download_progress("mrt2_small", 0.47f);
+    rows = last_child(v);  // rebuilt
+    REQUIRE(rows->child_count() == 2);
+    // Downloading row gains a meter + "%" + Cancel, so it has more children than idle.
+    REQUIRE(rows->child_at(1)->child_count() > before);
+}
+
+TEST_CASE("ModelManagerView action callbacks fire with the model id", "[view][model]") {
+    ModelManagerView v;
+    std::string downloaded;
+    std::string removed;
+    v.on_download = [&](const std::string& id) { downloaded = id; };
+    v.on_remove = [&](const std::string& id) { removed = id; };
+    v.set_models(make_models());
+
+    auto* rows = last_child(v);
+    auto fire_buttons = [](View* row) {
+        for (size_t i = 0; i < row->child_count(); ++i)
+            if (auto* b = dynamic_cast<ToggleButton*>(row->child_at(i)))
+                if (b->on_toggle) b->on_toggle(true);
+    };
+    fire_buttons(rows->child_at(0));  // mrt2_base installed+active → Remove
+    fire_buttons(rows->child_at(1));  // mrt2_small not installed → Download
+
+    REQUIRE(downloaded == "mrt2_small");
+    REQUIRE(removed == "mrt2_base");
+}
+
+TEST_CASE("ModelManagerView renders non-blank on the Skia canvas", "[view][model][.demo]") {
+    ModelManagerView v;
+    v.set_models(make_models());
+    v.set_download_progress("mrt2_small", 0.47f);
+
+    auto png = render_to_png(v, 560, 280, 2.0f, ScreenshotBackend::skia);
+    REQUIRE_FALSE(png.empty());
+    std::ofstream("/tmp/model-manager.png", std::ios::binary)
+        .write(reinterpret_cast<const char*>(png.data()), static_cast<std::streamsize>(png.size()));
+}

--- a/test/test_model_store.cpp
+++ b/test/test_model_store.cpp
@@ -1,0 +1,78 @@
+// Generic pulp::runtime model registry/store (MM-PR1) — proves a non-audio consumer
+// can link the runtime header and that list/install/activate round-trips, with
+// subsystem isolation. (The audio CLI's behavior is covered by test_audio_tools.cpp.)
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/runtime/model_registry.hpp>
+#include <pulp/runtime/model_store.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <vector>
+
+using namespace pulp::runtime;
+namespace fs = std::filesystem;
+
+TEST_CASE("resolve_checkpoint_url: hf:// resolution + path hardening", "[runtime][model]") {
+    REQUIRE(resolve_checkpoint_url("hf://user/repo/file.pt") ==
+            "https://huggingface.co/user/repo/resolve/main/file.pt");
+    REQUIRE(resolve_checkpoint_url("hf://user/repo/path/to/w.mlxfn") ==
+            "https://huggingface.co/user/repo/resolve/main/path/to/w.mlxfn");
+    REQUIRE(resolve_checkpoint_url("https://example.com/m.bin") == "https://example.com/m.bin");
+    REQUIRE(resolve_checkpoint_url("hf://user/repo/../escape").empty());  // `..` rejected
+    REQUIRE(resolve_checkpoint_url("hf://user/repo").empty());            // no file part
+    REQUIRE(resolve_checkpoint_url("ftp://x/y").empty());                 // unsupported scheme
+}
+
+TEST_CASE("generic model store: list / install / activate round-trip + isolation",
+          "[runtime][model]") {
+    const fs::path home = fs::temp_directory_path() / "pulp-mm-pr1-test";
+    fs::remove_all(home);
+
+    std::vector<ModelEntry> registry = {
+        ModelEntry{.model_id = "m1", .display_name = "Model One", .backend = "mlx",
+                   .checkpoint_ref = "hf://a/b/w.mlxfn"},
+    };
+
+    // Nothing installed yet.
+    auto before = list_models(registry, "magenta", home);
+    REQUIRE(before.error.empty());
+    REQUIRE(before.models.size() == 1);
+    REQUIRE(before.models[0].status == "not_installed");
+    REQUIRE_FALSE(before.models[0].active);
+    REQUIRE(read_active_model_id("magenta", home).empty());
+
+    // Simulate an install: a checkpoint file + the per-model install metadata.
+    const fs::path ckpt = home / "magenta" / "models" / "w.mlxfn";
+    fs::create_directories(ckpt.parent_path());
+    std::ofstream(ckpt) << "weights-bytes";
+
+    const fs::path meta = model_install_path("magenta", "m1", home);
+    REQUIRE(meta == home / "magenta" / "models" / "m1.json");
+    fs::create_directories(meta.parent_path());
+    std::ofstream(meta) << R"({"model_id":"m1","backend":"mlx","checkpoint_ref":"hf://a/b/w.mlxfn",)"
+                        << R"("resolved_checkpoint_path":")" << ckpt.generic_string() << R"("})";
+
+    auto inst = read_installed_model("magenta", "m1", home);
+    REQUIRE(inst.metadata_found);
+    REQUIRE(inst.checkpoint_exists);
+    REQUIRE(inst.loadable());
+
+    auto act = activate_model(registry, "magenta", "m1", home);
+    INFO("activate error: " << act.error);
+    REQUIRE(act.ok);
+    REQUIRE(act.active_model_id == "m1");
+    REQUIRE(read_active_model_id("magenta", home) == "m1");
+
+    auto after = list_models(registry, "magenta", home);
+    REQUIRE(after.models[0].status == "installed");
+    REQUIRE(after.models[0].active);
+
+    // Subsystem isolation: the "audio" subsystem shares the home but sees no active model.
+    REQUIRE(read_active_model_id("audio", home).empty());
+
+    // Activating an unknown / uninstalled model fails cleanly.
+    REQUIRE_FALSE(activate_model(registry, "magenta", "nope", home).ok);
+
+    fs::remove_all(home);
+}

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -1165,23 +1165,15 @@ TEST_CASE("http helpers parse default ports without explicit port text",
     REQUIRE(default_http.error.find('\0') == std::string::npos);
     REQUIRE((default_http.status_code == 0 || default_http.status_code >= 100));
 
-    bool default_https_threw = false;
-    try {
-        (void)http_get("https://127.0.0.1", 1);
-    } catch (const std::exception& e) {
-        default_https_threw = true;
-        REQUIRE(std::string(e.what()) == "'https' scheme is not supported.");
-    }
-    REQUIRE(default_https_threw);
+    // https resolves to the default port 443 and the request fails with a clean error
+    // response (the plain http_get client does not throw or hang on the scheme).
+    const auto default_https = http_get("https://127.0.0.1", 1);
+    REQUIRE(default_https.body.find('\0') == std::string::npos);
+    REQUIRE(default_https.error.find('\0') == std::string::npos);
+    REQUIRE((default_https.status_code == 0 || default_https.status_code >= 100));
 
-    bool explicit_https_threw = false;
-    try {
-        (void)http_get("https://127.0.0.1:1/secure", 1);
-    } catch (const std::exception& e) {
-        explicit_https_threw = true;
-        REQUIRE(std::string(e.what()) == "'https' scheme is not supported.");
-    }
-    REQUIRE(explicit_https_threw);
+    const auto explicit_https = http_get("https://127.0.0.1:1/secure", 1);
+    REQUIRE_FALSE(explicit_https.ok());  // nothing listens on :1
 }
 
 TEST_CASE("http_post reports connection failure on refused loopback port",

--- a/test/test_settings_sections.cpp
+++ b/test/test_settings_sections.cpp
@@ -8,7 +8,9 @@
 #include <pulp/format/settings_panel.hpp>
 #include <pulp/format/standalone.hpp>
 #include <pulp/view/widgets.hpp>
+#include <pulp/view/screenshot.hpp>
 
+#include <fstream>
 #include <memory>
 #include <string>
 #include <vector>
@@ -85,6 +87,15 @@ TEST_CASE("add_section ignores a null view", "[format][settings]") {
     const int before = panel.tab_count();
     panel.add_section("Nope", nullptr);
     REQUIRE(panel.tab_count() == before);
+}
+
+TEST_CASE("SettingsPanel Audio tab renders for visual inspection", "[format][settings][.demo]") {
+    SettingsPanel panel;  // default Audio tab active; combos empty without bound systems
+    auto png = pulp::view::render_to_png(panel, 700, 460, 2.0f,
+                                         pulp::view::ScreenshotBackend::skia);
+    REQUIRE_FALSE(png.empty());
+    std::ofstream("/tmp/settings-audio.png", std::ios::binary)
+        .write(reinterpret_cast<const char*>(png.data()), static_cast<std::streamsize>(png.size()));
 }
 
 TEST_CASE("Standalone settings persist across launches (save → load round-trip)", "[format][settings]") {

--- a/test/test_settings_sections.cpp
+++ b/test/test_settings_sections.cpp
@@ -1,0 +1,99 @@
+// Plugin-contributed settings sections (MM-PR5). Verifies the contract that lets a
+// plugin surface its own Settings tabs (e.g. a model picker) which the host composes
+// alongside its own host-owned Audio/MIDI tabs — keeping device selection a host concern
+// while giving one unified Settings panel.
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/format/processor.hpp>
+#include <pulp/format/settings_panel.hpp>
+#include <pulp/view/widgets.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+using pulp::format::Processor;
+using pulp::format::SettingsPanel;
+
+namespace {
+
+// Minimal concrete Processor whose contributed sections are configurable per test.
+struct TestProcessor : Processor {
+    std::vector<std::string> section_titles;
+
+    pulp::format::PluginDescriptor descriptor() const override {
+        pulp::format::PluginDescriptor d;
+        d.name = "Test";
+        d.manufacturer = "Pulp";
+        d.bundle_id = "com.pulp.test.settings";
+        d.version = "1.0.0";
+        return d;
+    }
+    void define_parameters(pulp::state::StateStore&) override {}
+    void prepare(const pulp::format::PrepareContext&) override {}
+    void process(pulp::audio::BufferView<float>&, const pulp::audio::BufferView<const float>&,
+                 pulp::midi::MidiBuffer&, pulp::midi::MidiBuffer&,
+                 const pulp::format::ProcessContext&) override {}
+
+    std::vector<SettingsSection> settings_sections() override {
+        std::vector<SettingsSection> out;
+        for (const auto& title : section_titles)
+            out.push_back({title, std::make_unique<pulp::view::Label>(title)});
+        return out;
+    }
+};
+
+std::unique_ptr<pulp::view::View> label(const std::string& t) {
+    return std::make_unique<pulp::view::Label>(t);
+}
+
+}  // namespace
+
+TEST_CASE("Processor::settings_sections defaults to none", "[format][settings]") {
+    struct Bare : TestProcessor {};
+    Bare p;
+    REQUIRE(p.settings_sections().empty());
+}
+
+TEST_CASE("A plugin contributes named settings sections with views", "[format][settings]") {
+    TestProcessor p;
+    p.section_titles = {"Models", "About"};
+    auto secs = p.settings_sections();
+    REQUIRE(secs.size() == 2);
+    REQUIRE(secs[0].title == "Models");
+    REQUIRE(secs[0].view != nullptr);
+    REQUIRE(secs[1].title == "About");
+    REQUIRE(secs[1].view != nullptr);
+}
+
+TEST_CASE("SettingsPanel starts with host-owned Audio + MIDI tabs", "[format][settings]") {
+    SettingsPanel panel;
+    REQUIRE(panel.tab_count() == 2);  // Audio + MIDI
+}
+
+TEST_CASE("add_section appends plugin tabs after Audio/MIDI", "[format][settings]") {
+    SettingsPanel panel;
+    panel.add_section("Models", label("models"));
+    REQUIRE(panel.tab_count() == 3);
+    panel.add_section("License", label("license"));
+    REQUIRE(panel.tab_count() == 4);
+}
+
+TEST_CASE("add_section ignores a null view", "[format][settings]") {
+    SettingsPanel panel;
+    const int before = panel.tab_count();
+    panel.add_section("Nope", nullptr);
+    REQUIRE(panel.tab_count() == before);
+}
+
+TEST_CASE("Host composition: plugin sections compose onto the host panel", "[format][settings]") {
+    // Mirrors exactly what the standalone chrome does with processor.settings_sections().
+    TestProcessor p;
+    p.section_titles = {"Models", "License"};
+
+    SettingsPanel panel;
+    for (auto& sec : p.settings_sections())
+        if (sec.view) panel.add_section(std::move(sec.title), std::move(sec.view));
+
+    REQUIRE(panel.tab_count() == 4);  // Audio + MIDI + Models + License
+}

--- a/test/test_settings_sections.cpp
+++ b/test/test_settings_sections.cpp
@@ -6,6 +6,7 @@
 
 #include <pulp/format/processor.hpp>
 #include <pulp/format/settings_panel.hpp>
+#include <pulp/format/standalone.hpp>
 #include <pulp/view/widgets.hpp>
 
 #include <memory>
@@ -84,6 +85,42 @@ TEST_CASE("add_section ignores a null view", "[format][settings]") {
     const int before = panel.tab_count();
     panel.add_section("Nope", nullptr);
     REQUIRE(panel.tab_count() == before);
+}
+
+TEST_CASE("Standalone settings persist across launches (save → load round-trip)", "[format][settings]") {
+    using pulp::format::StandaloneApp;
+    using pulp::format::StandaloneConfig;
+    const std::string app = "pulp-test-persist-roundtrip";
+
+    // The user picks a device / rate / buffer; the standalone saves it.
+    StandaloneConfig saved;
+    saved.audio_device_id = "test-headphones";
+    saved.midi_input_id = "test-midi";
+    saved.sample_rate = 44100.0;
+    saved.buffer_size = 256;
+    REQUIRE(StandaloneApp::save_persisted_config(app, saved));
+
+    // Next launch: load overlays the saved keys onto the app's configured defaults.
+    StandaloneConfig defaults;
+    defaults.sample_rate = 48000.0;
+    defaults.buffer_size = 512;
+    auto restored = StandaloneApp::load_persisted_config(app, defaults);
+    REQUIRE(restored.audio_device_id == "test-headphones");
+    REQUIRE(restored.midi_input_id == "test-midi");
+    REQUIRE(restored.sample_rate == 44100.0);  // persisted value wins over the default
+    REQUIRE(restored.buffer_size == 256);
+}
+
+TEST_CASE("load_persisted_config keeps the caller's defaults for an unknown app", "[format][settings]") {
+    using pulp::format::StandaloneApp;
+    using pulp::format::StandaloneConfig;
+    // An app name with no saved file returns the base untouched (the first-launch case).
+    StandaloneConfig defaults;
+    defaults.audio_device_id = "configured-default";
+    defaults.sample_rate = 96000.0;
+    auto restored = StandaloneApp::load_persisted_config("pulp-test-no-such-app-9F3A2", defaults);
+    REQUIRE(restored.audio_device_id == "configured-default");
+    REQUIRE(restored.sample_rate == 96000.0);
 }
 
 TEST_CASE("Host composition: plugin sections compose onto the host panel", "[format][settings]") {

--- a/test/test_standalone_editor_chrome.cpp
+++ b/test/test_standalone_editor_chrome.cpp
@@ -200,10 +200,13 @@ std::vector<T*> descendants(View& root) {
 }
 
 TabPanel& settings_tabs(SettingsPanel& panel) {
-    REQUIRE(panel.child_count() == 1);
-    auto* tabs = dynamic_cast<TabPanel*>(panel.child_at(0));
-    REQUIRE(tabs != nullptr);
-    return *tabs;
+    // The panel hosts a "Done" header plus the Audio/MIDI/<plugin> TabPanel — find the
+    // TabPanel among the children rather than assuming it's the only child.
+    for (int i = 0; i < panel.child_count(); ++i)
+        if (auto* tabs = dynamic_cast<TabPanel*>(panel.child_at(static_cast<size_t>(i))))
+            return *tabs;
+    REQUIRE(false);  // no TabPanel found
+    static TabPanel never; return never;  // unreachable; satisfies the return type
 }
 
 } // namespace
@@ -591,7 +594,7 @@ TEST_CASE("Standalone editor chrome wraps editor and settings in a tab panel",
     REQUIRE(&chrome.window_root() == chrome.tab_panel());
     REQUIRE(chrome.settings_panel() != nullptr);
     REQUIRE(chrome.tab_panel()->tab_count() == 2);
-    REQUIRE(chrome.extra_window_height() == 32.0f);
+    REQUIRE(chrome.extra_window_height() == 0.0f);  // outer tab bar hidden — reserves no height
     REQUIRE(chrome.chrome_label() == std::string_view("tabs"));
 }
 
@@ -654,9 +657,11 @@ TEST_CASE("Standalone editor content size subtracts chrome height",
     auto tabs = make_standalone_editor_chrome(
         std::move(editor_root), StandaloneConfig{}, nullptr, nullptr, nullptr, {});
 
+    // The outer [Editor][Settings] tab bar is hidden (card-stack chrome), so it reserves no
+    // height — the editor fills the whole window and content height == window height.
     auto size = standalone_editor_content_size({640, 392}, tabs);
     REQUIRE(size.width == 640);
-    REQUIRE(size.height == 360);
+    REQUIRE(size.height == 392);
 
     auto editor_only = make_standalone_editor_chrome(
         std::make_unique<View>(),
@@ -705,12 +710,12 @@ TEST_CASE("Standalone host sync installs a resize callback and applies initial s
     REQUIRE(window.resize_callback_ != nullptr);
     REQUIRE(seen_sizes.size() == 1);
     REQUIRE(seen_sizes[0].width == 800);
-    REQUIRE(seen_sizes[0].height == 400);
+    REQUIRE(seen_sizes[0].height == 432);  // hidden outer tab bar reserves no height
 
     window.resize_callback_(900, 532);
     REQUIRE(seen_sizes.size() == 2);
     REQUIRE(seen_sizes[1].width == 900);
-    REQUIRE(seen_sizes[1].height == 500);
+    REQUIRE(seen_sizes[1].height == 532);
 }
 
 TEST_CASE("Standalone host sync skips zero-sized initial host content",
@@ -734,7 +739,7 @@ TEST_CASE("Standalone host sync skips zero-sized initial host content",
     window.resize_callback_(900, 532);
     REQUIRE(seen_sizes.size() == 1);
     REQUIRE(seen_sizes[0].width == 900);
-    REQUIRE(seen_sizes[0].height == 500);
+    REQUIRE(seen_sizes[0].height == 532);  // no outer-chrome height subtracted
 }
 
 TEST_CASE("Standalone bridge attach forwards host sizing through bridge resize",
@@ -750,12 +755,12 @@ TEST_CASE("Standalone bridge attach forwards host sizing through bridge resize",
     REQUIRE(window.resize_callback_ != nullptr);
     REQUIRE(bridge.resize_calls_.size() == 1);
     REQUIRE(bridge.resize_calls_[0].width == 840);
-    REQUIRE(bridge.resize_calls_[0].height == 420);
+    REQUIRE(bridge.resize_calls_[0].height == 452);  // no outer-chrome height subtracted
 
     window.resize_callback_(900, 500);
     REQUIRE(bridge.resize_calls_.size() == 2);
     REQUIRE(bridge.resize_calls_[1].width == 900);
-    REQUIRE(bridge.resize_calls_[1].height == 468);
+    REQUIRE(bridge.resize_calls_[1].height == 500);
 }
 
 TEST_CASE("Standalone design viewport applies proportional window resize",
@@ -792,8 +797,8 @@ TEST_CASE("Standalone design viewport includes settings chrome height",
     configure_standalone_design_viewport(window, hints, chrome);
 
     REQUIRE(window.design_width_ == Catch::Approx(900.0f));
-    REQUIRE(window.design_height_ == Catch::Approx(552.0f));
-    REQUIRE(window.aspect_ratio_ == Catch::Approx(900.0f / 552.0f));
+    REQUIRE(window.design_height_ == Catch::Approx(520.0f));  // no outer-chrome height
+    REQUIRE(window.aspect_ratio_ == Catch::Approx(900.0f / 520.0f));
 }
 
 TEST_CASE("Standalone log helper formats the chrome mode",
@@ -971,15 +976,14 @@ TEST_CASE("make_standalone_window_options leaves min_* at zero when unset",
 
 TEST_CASE("make_standalone_window_options extends min_height when chrome adds rows",
           "[standalone][chrome][issue-1362]") {
-    // Settings tab adds 32px of chrome — the height min must rise in
-    // lockstep with the preferred-height extension so the editor area
-    // can never be squeezed below its declared min.
+    // The Settings tab is reached via the editor's own control (the outer tab bar is hidden),
+    // so the chrome reserves no extra height and the window/min sizes are unchanged.
     auto editor_root = std::make_unique<View>();
     auto chrome = make_standalone_editor_chrome(
         std::move(editor_root),
         StandaloneConfig{.show_settings_tab = true},
         nullptr, nullptr, nullptr, {});
-    REQUIRE(chrome.extra_window_height() == Catch::Approx(32.0f));
+    REQUIRE(chrome.extra_window_height() == Catch::Approx(0.0f));
 
     pulp::format::ViewSize hints;
     hints.preferred_width = 1320;
@@ -990,9 +994,7 @@ TEST_CASE("make_standalone_window_options extends min_height when chrome adds ro
     auto opts = make_standalone_window_options(hints, chrome, "Plug", false);
 
     // Preferred height = preferred_height + chrome.extra_window_height()
-    REQUIRE(opts.height == Catch::Approx(892.0f));
-    // Min height is shifted by the same chrome amount so the editor
-    // area's own minimum is never violated.
+    REQUIRE(opts.height == Catch::Approx(860.0f));  // preferred_height + 0 chrome
     REQUIRE(opts.min_width == Catch::Approx(800.0f));
-    REQUIRE(opts.min_height == Catch::Approx(632.0f));
+    REQUIRE(opts.min_height == Catch::Approx(600.0f));  // min unchanged (no chrome height)
 }

--- a/tools/audio/CMakeLists.txt
+++ b/tools/audio/CMakeLists.txt
@@ -10,7 +10,6 @@ target_include_directories(pulp-tool-audio
 target_sources(pulp-tool-audio PRIVATE
     src/excerpt_service.cpp
     src/model_registry.cpp
-    src/model_store.cpp
     src/service.cpp
 )
 

--- a/tools/audio/include/pulp/tools/audio/model_registry.hpp
+++ b/tools/audio/include/pulp/tools/audio/model_registry.hpp
@@ -1,31 +1,23 @@
 #pragma once
 
-#include <cstdint>
-#include <string>
+// The generic model registry now lives in pulp::runtime (so plugins/apps can link it).
+// tools/audio keeps the audio *catalog* (the data) + these compatibility aliases.
+
+#include <pulp/runtime/model_registry.hpp>
+
 #include <string_view>
 #include <vector>
 
 namespace pulp::tools::audio {
 
-struct RegisteredModel {
-    std::string model_id;
-    std::string display_name;
-    std::string backend;
-    std::string checkpoint_ref;       // e.g., "hf://user/repo/file.pt"
-    std::vector<std::string> task_tags;
-    std::uint64_t size_bytes = 0;
+using RegisteredModel = pulp::runtime::ModelEntry;
+using pulp::runtime::resolve_checkpoint_url;
 
-    // Phase 4 additions
-    std::string download_url;         // Direct HTTPS URL (resolved from checkpoint_ref)
-    std::string sha256;               // Expected hash of the checkpoint file
-    bool auto_downloadable = true;    // false if manual steps required
-};
-
-/// Resolve a checkpoint_ref to a direct download URL.
-/// "hf://user/repo/file" → "https://huggingface.co/user/repo/resolve/main/file"
-std::string resolve_checkpoint_url(const std::string& checkpoint_ref);
-
+/// The audio model catalog (CLAP etc.). Data lives here; the mechanism is generic.
 const std::vector<RegisteredModel>& registered_models();
-const RegisteredModel* find_registered_model(std::string_view model_id);
 
-} // namespace pulp::tools::audio
+inline const RegisteredModel* find_registered_model(std::string_view model_id) {
+    return pulp::runtime::find_model(registered_models(), model_id);
+}
+
+}  // namespace pulp::tools::audio

--- a/tools/audio/include/pulp/tools/audio/model_store.hpp
+++ b/tools/audio/include/pulp/tools/audio/model_store.hpp
@@ -1,62 +1,44 @@
 #pragma once
 
+// The generic model store now lives in pulp::runtime. tools/audio keeps these
+// thin wrappers (subsystem = "audio") so the CLI / MCP surface is unchanged.
+
 #include <filesystem>
 #include <string>
 #include <string_view>
-#include <vector>
 
+#include <pulp/runtime/model_store.hpp>
 #include <pulp/tools/audio/model_registry.hpp>
 
 namespace pulp::tools::audio {
 
-struct InstalledModelRecord {
-    std::filesystem::path metadata_path;
-    bool metadata_found = false;
-    std::string model_id;
-    std::string backend;
-    std::string checkpoint_ref;
-    std::filesystem::path resolved_checkpoint_path;
-    bool checkpoint_exists = false;
+using pulp::runtime::ActivateModelResult;
+using pulp::runtime::InstalledModelRecord;
+using pulp::runtime::ListedModel;
+using pulp::runtime::ModelListResult;
+using pulp::runtime::resolve_pulp_home;
+using pulp::runtime::to_json;
 
-    [[nodiscard]] bool loadable() const { return metadata_found && checkpoint_exists; }
-};
+inline std::filesystem::path audio_model_state_path(const std::filesystem::path& pulp_home_override = {}) {
+    return pulp::runtime::model_state_path("audio", pulp_home_override);
+}
+inline std::filesystem::path audio_model_install_path(std::string_view model_id,
+                                                      const std::filesystem::path& pulp_home_override = {}) {
+    return pulp::runtime::model_install_path("audio", model_id, pulp_home_override);
+}
+inline InstalledModelRecord read_installed_model(std::string_view model_id,
+                                                 const std::filesystem::path& pulp_home_override = {}) {
+    return pulp::runtime::read_installed_model("audio", model_id, pulp_home_override);
+}
+inline std::string read_active_model_id(const std::filesystem::path& pulp_home_override = {}) {
+    return pulp::runtime::read_active_model_id("audio", pulp_home_override);
+}
+inline ModelListResult list_models(const std::filesystem::path& pulp_home_override = {}) {
+    return pulp::runtime::list_models(registered_models(), "audio", pulp_home_override);
+}
+inline ActivateModelResult activate_model(std::string_view model_id,
+                                          const std::filesystem::path& pulp_home_override = {}) {
+    return pulp::runtime::activate_model(registered_models(), "audio", model_id, pulp_home_override);
+}
 
-struct ListedModel {
-    RegisteredModel model;
-    std::string status = "not_installed";
-    bool active = false;
-    std::filesystem::path resolved_checkpoint_path;
-};
-
-struct ModelListResult {
-    std::filesystem::path pulp_home;
-    std::string active_model_id;
-    std::vector<ListedModel> models;
-    std::string error;
-};
-
-struct ActivateModelResult {
-    bool ok = false;
-    std::filesystem::path state_path;
-    std::string active_model_id;
-    std::string backend;
-    std::string checkpoint_ref;
-    std::filesystem::path resolved_checkpoint_path;
-    std::string error;
-};
-
-std::filesystem::path resolve_pulp_home(const std::filesystem::path& override_path = {});
-std::filesystem::path audio_model_state_path(const std::filesystem::path& pulp_home_override = {});
-std::filesystem::path audio_model_install_path(std::string_view model_id,
-                                               const std::filesystem::path& pulp_home_override = {});
-InstalledModelRecord read_installed_model(std::string_view model_id,
-                                          const std::filesystem::path& pulp_home_override = {});
-std::string read_active_model_id(const std::filesystem::path& pulp_home_override = {});
-ModelListResult list_models(const std::filesystem::path& pulp_home_override = {});
-ActivateModelResult activate_model(std::string_view model_id,
-                                   const std::filesystem::path& pulp_home_override = {});
-
-std::string to_json(const ModelListResult& result);
-std::string to_json(const ActivateModelResult& result);
-
-} // namespace pulp::tools::audio
+}  // namespace pulp::tools::audio

--- a/tools/audio/src/model_registry.cpp
+++ b/tools/audio/src/model_registry.cpp
@@ -2,30 +2,8 @@
 
 namespace pulp::tools::audio {
 
-namespace {
-
-bool has_control_byte(std::string_view text) {
-    for (unsigned char ch : text) {
-        if (ch < 0x20) return true;
-    }
-    return false;
-}
-
-bool has_dot_dot_segment(std::string_view path) {
-    std::size_t start = 0;
-    while (start <= path.size()) {
-        auto slash = path.find('/', start);
-        auto seg = path.substr(start,
-            slash == std::string_view::npos ? std::string_view::npos : slash - start);
-        if (seg == "..") return true;
-        if (slash == std::string_view::npos) break;
-        start = slash + 1;
-    }
-    return false;
-}
-
-} // namespace
-
+// The audio model catalog. The registry type + URL resolution + lookup are generic
+// (pulp::runtime); only this data lives here.
 const std::vector<RegisteredModel>& registered_models() {
     static const std::vector<RegisteredModel> models = {{
         .model_id = "clap_music_audioset_v1",
@@ -41,38 +19,4 @@ const std::vector<RegisteredModel>& registered_models() {
     return models;
 }
 
-const RegisteredModel* find_registered_model(std::string_view model_id) {
-    for (const auto& model : registered_models()) {
-        if (model.model_id == model_id) return &model;
-    }
-    return nullptr;
-}
-
-std::string resolve_checkpoint_url(const std::string& checkpoint_ref) {
-    // Handle hf:// protocol: hf://user/repo/path/to/file → https://huggingface.co/user/repo/resolve/main/path/to/file
-    if (checkpoint_ref.starts_with("hf://")) {
-        auto path = checkpoint_ref.substr(5);  // after "hf://"
-        auto first_slash = path.find('/');
-        if (first_slash == std::string::npos) return {};
-        auto second_slash = path.find('/', first_slash + 1);
-        if (second_slash == std::string::npos) return {};
-        if (first_slash == 0 || second_slash == first_slash + 1) return {};
-        auto user_repo = path.substr(0, second_slash);   // "user/repo"
-        auto file_path = path.substr(second_slash + 1);  // "path/to/file"
-        if (file_path.empty()) return {};
-        if (has_control_byte(user_repo)) return {};
-        if (file_path.starts_with('/') || has_control_byte(file_path)) return {};
-        // Reject any `..` path segment. HTTP technically does not normalize
-        // `..` in URL paths, but proxies, CDNs, and redirect handlers
-        // sometimes do, and that would let the resolved URL escape the
-        // intended `resolve/main/<file>` prefix.
-        if (has_dot_dot_segment(file_path)) return {};
-        return "https://huggingface.co/" + user_repo + "/resolve/main/" + file_path;
-    }
-    // Handle direct URLs
-    if (checkpoint_ref.starts_with("http://") || checkpoint_ref.starts_with("https://"))
-        return checkpoint_ref;
-    return {};
-}
-
-} // namespace pulp::tools::audio
+}  // namespace pulp::tools::audio

--- a/tools/scripts/package-lock.json
+++ b/tools/scripts/package-lock.json
@@ -1,0 +1,472 @@
+{
+  "name": "pulp-scripts",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pulp-scripts",
+      "version": "0.0.0",
+      "dependencies": {
+        "esbuild": "0.25.10"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
+      }
+    }
+  }
+}


### PR DESCRIPTION
**ModelManager plan, PR3 of 4** (stacked on #3463). The "you need a model" manager UI, lifting [Pause](Pause)'s nice traits.

Lists available + installed models with status (★ recommended, **Active**, Installed, Available), a per-row **download progress bar + % + Cancel**, and **Download / Set-default / Remove** actions wired to callbacks the host binds to `runtime::install_model`/`activate_model`/`remove_model` (PR2). Plus a "no models" empty-state. Pure composition over Pulp widgets (View flex + Label + Meter + ToggleButton) → renders on the Skia/GPU canvas, headless-capturable via P1.

**Rendered (Skia):**
- ★ Magenta RT2 (Large) — **Active** (teal) — Remove
- Magenta RT2 (Small) — ▓▓▓▓░░ **47%** — Cancel

Tests: `pulp-test-model-manager-view` — builds a row per model, shows the progress row, action callbacks fire with the model id (6 assertions) + a `[.demo]` Skia render.

Next: **PR4** — Magenta first use (register mrt2_small/mrt2_base) + the active-model indicator in E1 (examples repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ModelManagerView`, a compact model picker with per-row download progress/cancel/resume and a Done header to return to the editor. Promotes the model registry/store and a streaming HTTPS downloader to `pulp::runtime`, and unifies Settings with plugin-contributed tabs and persisted audio/MIDI settings.

- **New Features**
  - `ModelManagerView`: lists models with statuses (Active/Installed/Available/Paused N%), with Download/Resume/Set default/Remove/Cancel via `on_download`/`on_activate`/`on_remove`/`on_cancel`/`on_done`; two-line rows with a full-width progress bar; progress via `set_download_progress(model_id, fraction)`; partials from `runtime::list_models`.
  - Runtime: generic model registry/store in `pulp::runtime`; streaming HTTPS downloader with SHA-256, Range resume, cancellation, and atomic rename; install/remove/activate APIs.
  - Settings: plugins contribute tabs via `Processor::settings_sections()`; standalone composes [Audio][MIDI][<plugin tabs>] with a single-level panel (gear opens, Done closes); audio/MIDI settings load at startup and save on apply.

- **Bug Fixes**
  - `TextButton`: color fix to `rgba8` with a pressed shade; model actions use centered momentary buttons.
  - `TabPanel`: reserves/hides its bar correctly; clicks route to content.
  - `ComboBox`: flips up near the window bottom; open mode uses hover + Enter/Space to commit; shared geometry aligns hover/click.
  - `TextEditor`: caret blink driven by the frame clock, reset on keypress, unsubscribed on blur/destruction.
  - Tests: new suites for model store/download/view/settings and updates for combo and standalone chrome.

<sup>Written for commit 24c114b8eb40d7f45fa8ac36ca99971545d7ad37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces `ModelManagerView` — a Skia-renderable model browser with per-row progress bars, action callbacks, and a "Done" header — while promoting the model registry, store, and streaming HTTPS downloader from `tools/audio` into `pulp::runtime`. It also unifies Settings with plugin-contributed tabs and fixes several pre-existing bugs (rgba8 color, caret blink, ComboBox flip and keyboard open).

- **`ModelManagerView`** (`core/view/include/pulp/view/model_manager_view.hpp`): pure composition over existing Pulp widgets; per-row Download / Resume / Set-default / Remove / Cancel via `TextButton` callbacks; header \"Done\" via `ToggleButton`; `set_download_progress` drives an inline progress bar.
- **`pulp::runtime` model primitives** (`core/runtime/src/model_store.cpp`, `model_download.cpp`, `model_registry.cpp`): streaming, resumable, SHA-256-verified HTTPS downloader; `hf://` URL resolver with control-byte and `..`-segment guards; install / activate / remove / list operations over a subsystem-keyed on-disk layout.
- **`StandaloneApp` settings persistence** (`core/format/src/standalone.cpp`): persisted audio/MIDI config loaded at startup and saved on `apply_config`; plugin-contributed tabs wired via `Processor::settings_sections()`.
</details>


<h3>Confidence Score: 3/5</h3>

Several issues across the new runtime primitives need resolution before this reaches production: the HTTPS downloader leaks auth headers on cross-origin redirects, hash_existing misreports I/O errors as success, remove_model silently discards filesystem errors, and unchecked fs::file_size can trigger undefined behaviour.

The authorization-header leak to redirect destinations, the corrupt-resume path when hash_existing returns true on a bad read, and the UB-reachable path through an unchecked file_size error code are all concrete defects on the download/install path that ships in this PR. The remove_model false-success return also violates its documented contract.

core/runtime/src/model_download.cpp and core/runtime/src/model_store.cpp carry the most risk; core/view/src/ui_components.cpp has a new separator-selection gap in on_text_input joining the ones flagged in the prior round.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| core/view/include/pulp/view/model_manager_view.hpp | New ModelManagerView widget; active-model with missing_checkpoint renders misleading 'Active' status, rebuild on every progress tick, and ToggleButton visual state lingers on fire-and-forget actions (flagged in prior review threads). |
| core/runtime/src/model_download.cpp | New streaming HTTPS downloader; hash_existing returns true on I/O error (corrupt resume) and set_follow_location leaks auth headers to cross-origin redirect targets — both flagged in prior review threads. |
| core/runtime/src/model_store.cpp | Model store promoted from tools/audio; unchecked fs::file_size error code can produce UB via out-of-range float→int cast, remove_model silently swallows filesystem errors always returning true, and partial_fraction omitted from to_json — flagged in prior review threads. |
| core/view/src/ui_components.cpp | ComboBox keyboard navigation refactored; Enter/Space commit and closed-dropdown stepper both lack separator guards (flagged in prior threads); on_text_input character-jump also lacks a separator guard (new). |
| core/format/src/standalone.cpp | Persisted config is written before start() confirms the device opens successfully, leaving a broken config on disk if startup fails (flagged in prior review thread). |
| core/runtime/src/model_registry.cpp | New hf:// URL resolver with control-byte and dot-dot guards; straightforward path hardening. |
| test/CMakeLists.txt | pulp-test-model-manager-view registered with bare add_executable instead of pulp_add_test_suite, missing sanitizer/coverage instrumentation (flagged in prior thread). |
| core/view/src/text_editor.cpp | Caret blink moved to frame clock subscription; destructor and on_focus_changed(false) both unsubscribe — cleanup path looks correct. |
| core/view/src/buttons.cpp | Fixes rgba8 vs rgba confusion (buttons were painting solid white); pressed shade added; straightforward bug fix. |
| test/test_model_manager_view.cpp | fire_buttons now dispatches to both ToggleButton::on_toggle and TextButton::on_click; action-callback assertions should fire correctly with the updated helper. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Host
    participant ModelManagerView
    participant runtime_install_model
    participant model_download
    participant model_store

    Host->>ModelManagerView: set_models(list_models(...))
    Host->>ModelManagerView: on_download / on_activate / on_remove / on_cancel wired
    ModelManagerView-->>Host: renders rows (name + status + action buttons)

    Host->>runtime_install_model: install_model(entry, subsystem, on_progress, cancel)
    runtime_install_model->>model_download: download_file(req, on_progress, cancel)
    model_download-->>runtime_install_model: DownloadResult (ok / cancelled / error)
    runtime_install_model->>model_store: write metadata JSON
    runtime_install_model-->>Host: InstallModelResult

    loop every progress tick
        Host->>ModelManagerView: set_download_progress(model_id, fraction)
        ModelManagerView-->>ModelManagerView: rebuild() update progress bar + % label
    end

    Host->>model_store: activate_model(registry, subsystem, model_id)
    model_store-->>Host: ActivateModelResult (writes model-state.json)
    Host->>ModelManagerView: set_models(list_models(...))
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `core/runtime/src/model_store.cpp`, line 255-258 ([link](https://github.com/danielraffel/pulp/blob/64d31b91dde0df904a0bb836f5e5ce73c0c250d0/core/runtime/src/model_store.cpp#L255-L258)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`partial_fraction` silently dropped from JSON serialization**

   The new `partial_fraction` field added to `ListedModel` is not emitted by `to_json(const ModelListResult&)`. A consumer reading the JSON output (CLI tooling, IPC, diagnostics) will see `"status": "partial"` but have no way to extract the download percentage without re-querying the filesystem. Every other meaningful field in `ListedModel` (`status`, `active`, `resolved_checkpoint_path`) is serialized, making this omission inconsistent. Add `value.addMember("partial_fraction", choc::value::createFloat32(item.partial_fraction));` alongside the existing `status` and `active` members in the serialization loop.

2. `core/view/src/ui_components.cpp`, line 327-331 ([link](https://github.com/danielraffel/pulp/blob/24c114b8eb40d7f45fa8ac36ca99971545d7ad37/core/view/src/ui_components.cpp#L327-L331)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `on_text_input` character-jump can select a separator item. The loop finds the first item whose first character matches the typed character without checking for the `"---"` separator prefix. Since separators start with `-`, typing `-` will call `set_selected` with the separator's index, causing `selected_text()` to return `"---"` and firing `on_change` with that index — delivering an invalid selection (e.g., an empty device name) to the downstream handler. The open-menu Enter/Space and closed-stepper paths have a similar gap already noted, but this is a separate code path with the same missing guard.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (17): Last reviewed commit: ["chore: bump versions"](https://github.com/danielraffel/pulp/commit/24c114b8eb40d7f45fa8ac36ca99971545d7ad37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35977017)</sub>

<!-- /greptile_comment -->