### PR TITLE
fix(model-manager): address code-review findings from PRs #3463/#3464

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.357.0
+    VERSION 0.358.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -266,11 +266,14 @@ bool StandaloneApp::apply_config(const StandaloneConfig& new_config) {
     // dangle an editor ViewBridge holding a Processor& (#2693).
     if (was_running) stop_audio_keep_processor();
     config_ = new_config;
-    // Remember the user's device/rate/buffer selection across launches (default on).
-    if (config_.persist_settings && processor_)
+    bool ok = true;
+    if (was_running) ok = start();
+    // Remember the user's device/rate/buffer selection across launches (default on),
+    // but only after a successful (re)start — otherwise a failed apply would persist
+    // a broken selection that the next launch restores.
+    if (ok && config_.persist_settings && processor_)
         save_persisted_config(processor_->descriptor().name, config_);
-    if (was_running) return start();
-    return true;
+    return ok;
 }
 
 bool StandaloneApp::run_with_editor(bool use_gpu) {

--- a/core/runtime/CMakeLists.txt
+++ b/core/runtime/CMakeLists.txt
@@ -173,9 +173,15 @@ if(TARGET mbedcrypto)
     target_include_directories(pulp-runtime PRIVATE
         ${mbedtls_SOURCE_DIR}/include
     )
-    # Enable HTTPS in cpp-httplib via the mbedTLS backend (used by the streaming
-    # model downloader, model_download.cpp). No OpenSSL dependency.
-    target_compile_definitions(pulp-runtime PRIVATE CPPHTTPLIB_MBEDTLS_SUPPORT)
+    # Enable HTTPS in cpp-httplib via the mbedTLS backend ONLY for the streaming
+    # model downloader (model_download.cpp). Scoping the define to that one
+    # source file avoids flipping every other httplib consumer in pulp-runtime
+    # onto the TLS code path and changing existing HTTP helper behavior. No
+    # OpenSSL dependency.
+    set_source_files_properties(
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/model_download.cpp
+        PROPERTIES COMPILE_DEFINITIONS CPPHTTPLIB_MBEDTLS_SUPPORT
+    )
     if(APPLE)
         # httplib's mbedTLS path loads system trust anchors from the macOS keychain
         # via the Security framework.

--- a/core/runtime/include/pulp/runtime/model_registry.hpp
+++ b/core/runtime/include/pulp/runtime/model_registry.hpp
@@ -46,7 +46,8 @@ struct ModelEntry {
 
 /// Resolve a checkpoint_ref to a direct download URL.
 /// "hf://user/repo/file" → "https://huggingface.co/user/repo/resolve/main/file".
-/// Rejects control bytes and `..` path segments. Passes http(s):// URLs through.
+/// Rejects control bytes, `..` segments (in both the user/repo and file parts),
+/// and percent-encoded path content. Passes http(s):// URLs through.
 std::string resolve_checkpoint_url(const std::string& checkpoint_ref);
 
 /// Find a model by id in a caller-supplied registry/catalog. Returns nullptr if absent.

--- a/core/runtime/include/pulp/runtime/model_store.hpp
+++ b/core/runtime/include/pulp/runtime/model_store.hpp
@@ -103,7 +103,8 @@ InstallModelResult install_model(const ModelEntry& model, std::string_view subsy
                                  const std::filesystem::path& pulp_home_override = {});
 
 /// Delete an installed model's files + metadata. Clears the active selection if it pointed
-/// here. Returns false (with `error` set) on failure; true if removed or already absent.
+/// here. Returns false (with `error` set) on a filesystem error or invalid input, and false
+/// (no error) when nothing was present to remove; true only when files/metadata were deleted.
 bool remove_model(std::string_view subsystem, std::string_view model_id, std::string& error,
                   const std::filesystem::path& pulp_home_override = {});
 

--- a/core/runtime/src/model_download.cpp
+++ b/core/runtime/src/model_download.cpp
@@ -41,6 +41,28 @@ ParsedUrl parse_url(const std::string& url) {
     return out;
 }
 
+// Resolve a redirect Location (absolute, host-absolute, or relative) against the
+// current scheme/host/port + path. Returns ok=false if it can't be resolved.
+ParsedUrl resolve_redirect(const std::string& cur_scheme_host_port, const std::string& cur_path,
+                           const std::string& location) {
+    ParsedUrl out;
+    if (location.empty()) return out;
+    if (location.starts_with("http://") || location.starts_with("https://"))
+        return parse_url(location);
+    if (location.front() == '/') {  // host-absolute
+        out.scheme_host_port = cur_scheme_host_port;
+        out.path = location;
+        out.ok = true;
+        return out;
+    }
+    // Path-relative: replace the last segment of the current path.
+    out.scheme_host_port = cur_scheme_host_port;
+    auto slash = cur_path.find_last_of('/');
+    out.path = (slash == std::string::npos ? std::string("/") : cur_path.substr(0, slash + 1)) + location;
+    out.ok = true;
+    return out;
+}
+
 std::string to_hex(const unsigned char* data, size_t n) {
     static const char* digits = "0123456789abcdef";
     std::string s;
@@ -66,8 +88,30 @@ bool hash_existing(mbedtls_sha256_context& ctx, const fs::path& path, std::uint6
             counted += static_cast<std::uint64_t>(got);
         }
     }
+    // Distinguish a clean EOF from a genuine read error: badbit means the
+    // partial could not be fully re-hashed, so the caller must restart rather
+    // than trust a truncated hash for a resumed transfer.
+    if (in.bad()) return false;
     return true;
 }
+
+// Verify a 206 (Partial Content) response actually continues from the byte
+// offset we asked for. A server that returns 206 but a different range (or no
+// Content-Range at all) would corrupt the appended .part + rehash, so treat
+// any mismatch as untrusted.
+bool content_range_starts_at(const httplib::Response& resp, std::uint64_t expected_start) {
+    auto it = resp.headers.find("Content-Range");
+    if (it == resp.headers.end()) return false;  // 206 must carry Content-Range
+    static const std::regex re(R"(bytes\s+(\d+)-(\d+)/(\d+|\*))", std::regex::icase);
+    std::smatch m;
+    if (!std::regex_search(it->second, m, re)) return false;
+    try {
+        return std::stoull(m[1].str()) == expected_start;
+    } catch (...) {
+        return false;
+    }
+}
+
 
 // Best-effort system CA bundle for mbedTLS verification (macOS / common Linux).
 const char* system_ca_path() {
@@ -102,7 +146,13 @@ DownloadResult download_file(const DownloadRequest& req, const DownloadProgressF
     part += ".part";
 
     std::uint64_t resume_from = 0;
-    if (req.resume && fs::exists(part, ec)) resume_from = static_cast<std::uint64_t>(fs::file_size(part, ec));
+    if (req.resume && fs::exists(part, ec)) {
+        const auto sz = fs::file_size(part, ec);
+        // file_size returns static_cast<uintmax_t>(-1) and sets `ec` on error;
+        // guard against that turning into a bogus huge Range offset.
+        if (!ec && sz != static_cast<std::uintmax_t>(-1))
+            resume_from = static_cast<std::uint64_t>(sz);
+    }
 
     mbedtls_sha256_context sha;
     mbedtls_sha256_init(&sha);
@@ -124,16 +174,6 @@ DownloadResult download_file(const DownloadRequest& req, const DownloadProgressF
         return r;
     }
 
-    httplib::Client cli(parsed.scheme_host_port);
-    cli.set_follow_location(true);
-    cli.set_keep_alive(true);
-    if (req.timeout_seconds > 0) {
-        cli.set_read_timeout(req.timeout_seconds, 0);
-        cli.set_connection_timeout(req.timeout_seconds, 0);
-    }
-    if (const char* ca = system_ca_path()) cli.set_ca_cert_path(ca);
-    cli.enable_server_certificate_verification(true);
-
     httplib::Headers headers;
     for (const auto& h : req.headers) headers.emplace(h.name, h.value);
     const bool attempted_resume = resume_from > 0;
@@ -143,8 +183,39 @@ DownloadResult download_file(const DownloadRequest& req, const DownloadProgressF
     bool reset_due_to_200 = false;
     bool user_cancel = false;
     bool write_error = false;
+    bool http_status_error = false;
+    bool range_mismatch = false;
+    bool is_redirect = false;
+    int response_status = 0;
+    std::string redirect_location;
 
     auto response_handler = [&](const httplib::Response& resp) -> bool {
+        response_status = resp.status;
+        // Redirect: capture Location and abort before any body is streamed into
+        // .part. We follow redirects manually (below) so we can strip sensitive
+        // headers on a cross-origin hop.
+        if (resp.status >= 300 && resp.status < 400) {
+            if (auto it = resp.headers.find("Location"); it != resp.headers.end()) {
+                redirect_location = it->second;
+                is_redirect = true;
+                return false;
+            }
+            http_status_error = true;  // 3xx without Location — give up
+            return false;
+        }
+        // Reject other non-success responses before any content is received so an
+        // error body is never written into the resumable .part file.
+        if (resp.status != 200 && resp.status != 206) {
+            http_status_error = true;
+            return false;
+        }
+        // A 206 must continue from exactly the offset we requested; otherwise
+        // appending its bytes to our partial would corrupt the file + hash.
+        if (attempted_resume && resp.status == 206 &&
+            !content_range_starts_at(resp, resume_from)) {
+            range_mismatch = true;
+            return false;
+        }
         if (attempted_resume && resp.status == 200) {
             // Server ignored our Range request — discard the partial and restart.
             reset_due_to_200 = true;
@@ -183,7 +254,54 @@ DownloadResult download_file(const DownloadRequest& req, const DownloadProgressF
         return true;
     };
 
-    auto result = cli.Get(parsed.path, headers, response_handler, content_receiver);
+    // Manual redirect loop. set_follow_location is OFF so cpp-httplib can't replay
+    // the (possibly sensitive) request headers to a redirect target on another
+    // host — HF gated downloads 302 to a pre-signed S3 URL, and the Authorization
+    // token must not travel there (httplib::Headers compares keys case-insensitively).
+    std::string cur_shp = parsed.scheme_host_port;
+    std::string cur_path = parsed.path;
+    int redirects_left = 8;
+    httplib::Result result;
+    while (true) {
+        is_redirect = false;
+        redirect_location.clear();
+
+        httplib::Client cli(cur_shp);
+        cli.set_follow_location(false);
+        cli.set_keep_alive(true);
+        if (req.timeout_seconds > 0) {
+            cli.set_read_timeout(req.timeout_seconds, 0);
+            cli.set_connection_timeout(req.timeout_seconds, 0);
+        }
+        if (const char* ca = system_ca_path()) cli.set_ca_cert_path(ca);
+        cli.enable_server_certificate_verification(true);
+
+        result = cli.Get(cur_path, headers, response_handler, content_receiver);
+
+        if (!is_redirect) break;
+        if (redirects_left-- <= 0) {
+            mbedtls_sha256_free(&sha);
+            out.close();
+            r.error = "too many redirects";
+            return r;
+        }
+        const auto next = resolve_redirect(cur_shp, cur_path, redirect_location);
+        if (!next.ok) {
+            mbedtls_sha256_free(&sha);
+            out.close();
+            r.error = "invalid redirect location: " + redirect_location;
+            return r;
+        }
+        if (next.scheme_host_port != cur_shp) {
+            // Cross-origin hop: drop credentials so they don't leak to the new host.
+            headers.erase("Authorization");
+            headers.erase("Proxy-Authorization");
+            headers.erase("Cookie");
+        }
+        cur_shp = next.scheme_host_port;
+        cur_path = next.path;
+    }
+
     out.flush();
     out.close();
 
@@ -197,6 +315,21 @@ DownloadResult download_file(const DownloadRequest& req, const DownloadProgressF
         r.cancelled = true;
         r.error = "cancelled";
         return r;  // keep .part for resume
+    }
+    // Status / range checks happen in the response handler (which aborts the
+    // transfer via `return false`) so no error/short body is ever appended to
+    // .part. Surface those before the generic transport-error path, since an
+    // aborted handler makes `result` falsy with Error::Canceled.
+    if (http_status_error) {
+        mbedtls_sha256_free(&sha);
+        r.error = "http status " + std::to_string(response_status);
+        return r;  // .part untouched — safe to resume against later
+    }
+    if (range_mismatch) {
+        mbedtls_sha256_free(&sha);
+        fs::remove(part, ec);  // partial no longer trustworthy
+        r.error = "server returned unexpected content-range for resume";
+        return r;
     }
     if (!result) {
         mbedtls_sha256_free(&sha);

--- a/core/runtime/src/model_registry.cpp
+++ b/core/runtime/src/model_registry.cpp
@@ -24,6 +24,14 @@ bool has_dot_dot_segment(std::string_view path) {
     return false;
 }
 
+// Reject percent-encoded path content. hf:// checkpoint paths are plain
+// user/repo/file references; a `%` only appears as an encoded byte (e.g.
+// `%2e%2e` for `..`), which a normalizing proxy/CDN could decode into a
+// traversal segment that `has_dot_dot_segment` cannot see. Fail closed.
+bool has_percent_encoding(std::string_view text) {
+    return text.find('%') != std::string_view::npos;
+}
+
 }  // namespace
 
 std::string resolve_checkpoint_url(const std::string& checkpoint_ref) {
@@ -40,10 +48,15 @@ std::string resolve_checkpoint_url(const std::string& checkpoint_ref) {
         if (file_path.empty()) return {};
         if (has_control_byte(user_repo)) return {};
         if (file_path.starts_with('/') || has_control_byte(file_path)) return {};
-        // Reject any `..` path segment. HTTP doesn't normalize `..` in URL paths, but
-        // proxies/CDNs/redirect handlers sometimes do, which could let the resolved URL
-        // escape the intended `resolve/main/<file>` prefix.
-        if (has_dot_dot_segment(file_path)) return {};
+        // Reject any `..` path segment in BOTH the user/repo and file portions. HTTP
+        // doesn't normalize `..` in URL paths, but proxies/CDNs/redirect handlers
+        // sometimes do, which could let the resolved URL escape the intended
+        // `resolve/main/<file>` prefix (or escape the user/repo namespace entirely,
+        // e.g. `hf://user/../evil/file.pt`).
+        if (has_dot_dot_segment(user_repo) || has_dot_dot_segment(file_path)) return {};
+        // Reject percent-encoded segments (e.g. `%2e%2e`) that could decode to `..`
+        // after the literal check above.
+        if (has_percent_encoding(user_repo) || has_percent_encoding(file_path)) return {};
         return "https://huggingface.co/" + user_repo + "/resolve/main/" + file_path;
     }
     if (checkpoint_ref.starts_with("http://") || checkpoint_ref.starts_with("https://"))

--- a/core/runtime/src/model_store.cpp
+++ b/core/runtime/src/model_store.cpp
@@ -82,6 +82,18 @@ bool write_text_file(const fs::path& path, const std::string& content, std::stri
     return true;
 }
 
+// Reject path segments (subsystem, model_id) that could escape pulp_home via
+// path traversal or absolute paths. These are public-API inputs even though
+// current callers pass safe literals. A valid segment is non-empty, contains
+// no path separators (`/`, `\\`), no drive/scheme colon, and no `..` segment.
+bool is_safe_path_segment(std::string_view segment) {
+    if (segment.empty()) return false;
+    if (segment.find_first_of("/\\:") != std::string_view::npos) return false;
+    if (segment == "." || segment == "..") return false;
+    if (segment.find("..") != std::string_view::npos) return false;
+    return true;
+}
+
 }  // namespace
 
 fs::path resolve_pulp_home(const fs::path& override_path) {
@@ -98,6 +110,7 @@ fs::path resolve_pulp_home(const fs::path& override_path) {
 fs::path model_state_path(std::string_view subsystem, const fs::path& pulp_home_override) {
     auto pulp_home = resolve_pulp_home(pulp_home_override);
     if (pulp_home.empty()) return {};
+    if (!is_safe_path_segment(subsystem)) return {};
     return pulp_home / std::string(subsystem) / "model-state.json";
 }
 
@@ -105,6 +118,7 @@ fs::path model_install_path(std::string_view subsystem, std::string_view model_i
                             const fs::path& pulp_home_override) {
     auto pulp_home = resolve_pulp_home(pulp_home_override);
     if (pulp_home.empty()) return {};
+    if (!is_safe_path_segment(subsystem) || !is_safe_path_segment(model_id)) return {};
     return pulp_home / std::string(subsystem) / "models" / (std::string(model_id) + ".json");
 }
 
@@ -168,17 +182,31 @@ ModelListResult list_models(const std::vector<ModelEntry>& registry, std::string
             listed.resolved_checkpoint_path = installed.resolved_checkpoint_path;
         } else {
             // Not installed — surface a resumable partial (an interrupted/cancelled .part).
+            // Pick deterministically (the largest .part = most-complete resume) rather
+            // than the first one the OS happens to enumerate, since stale partials may
+            // coexist.
             const fs::path dir = result.pulp_home / std::string(subsystem) / "models" / model.model_id;
             std::error_code ec;
+            std::uint64_t best_bytes = 0;
+            bool found_part = false;
             if (fs::exists(dir, ec)) {
                 for (const auto& entry : fs::directory_iterator(dir, ec)) {
                     if (entry.path().extension() != ".part") continue;
-                    listed.status = "partial";
-                    if (model.size_bytes > 0) {
-                        const auto got = static_cast<float>(fs::file_size(entry.path(), ec));
-                        listed.partial_fraction = got / static_cast<float>(model.size_bytes);
-                    }
-                    break;
+                    std::error_code size_ec;
+                    const auto sz = fs::file_size(entry.path(), size_ec);
+                    if (size_ec || sz == static_cast<std::uintmax_t>(-1)) continue;
+                    found_part = true;
+                    if (static_cast<std::uint64_t>(sz) >= best_bytes)
+                        best_bytes = static_cast<std::uint64_t>(sz);
+                }
+            }
+            if (found_part) {
+                listed.status = "partial";
+                if (model.size_bytes > 0) {
+                    float frac = static_cast<float>(best_bytes) / static_cast<float>(model.size_bytes);
+                    if (frac < 0.0f) frac = 0.0f;
+                    if (frac > 1.0f) frac = 1.0f;  // clamp: stale/oversized .part
+                    listed.partial_fraction = frac;
                 }
             }
         }
@@ -245,6 +273,7 @@ std::string to_json(const ModelListResult& result) {
         auto value = choc::value::createObject("");
         add_string_member(value, "model_id", item.model.model_id);
         add_string_member(value, "display_name", item.model.display_name);
+        add_string_member(value, "description", item.model.description);
         add_string_member(value, "backend", item.model.backend);
         add_string_member(value, "checkpoint_ref", item.model.checkpoint_ref);
         auto tags = choc::value::createEmptyArray();
@@ -252,9 +281,30 @@ std::string to_json(const ModelListResult& result) {
             tags.addArrayElement(choc::value::createString(tag));
         value.addMember("task_tags", tags);
         value.addMember("size_bytes", choc::value::createInt64(static_cast<int64_t>(item.model.size_bytes)));
+        // Round-trip the remaining catalog metadata so CLI / MCP JSON consumers
+        // see download URL, hashes, licensing, attribution, and device hints.
+        add_string_member(value, "download_url", item.model.download_url);
+        add_string_member(value, "sha256", item.model.sha256);
+        value.addMember("auto_downloadable", choc::value::createBool(item.model.auto_downloadable));
+        value.addMember("is_recommended", choc::value::createBool(item.model.is_recommended));
+        add_string_member(value, "license", item.model.license);
+        add_string_member(value, "attribution", item.model.attribution);
+        add_string_member(value, "min_device", item.model.min_device);
+        auto assets = choc::value::createEmptyArray();
+        for (const auto& asset : item.model.assets) {
+            auto a = choc::value::createObject("");
+            add_string_member(a, "role", asset.role);
+            add_string_member(a, "checkpoint_ref", asset.checkpoint_ref);
+            add_string_member(a, "sha256", asset.sha256);
+            a.addMember("size_bytes", choc::value::createInt64(static_cast<int64_t>(asset.size_bytes)));
+            assets.addArrayElement(a);
+        }
+        value.addMember("assets", assets);
         add_string_member(value, "status", item.status);
         value.addMember("active", choc::value::createBool(item.active));
         add_path_member(value, "resolved_checkpoint_path", item.resolved_checkpoint_path);
+        // Resumable-progress for a "partial" entry (>= 0 only when a .part exists).
+        value.addMember("partial_fraction", choc::value::createFloat64(item.partial_fraction));
         models.addArrayElement(value);
     }
     object.addMember("models", models);
@@ -285,6 +335,11 @@ InstallModelResult install_model(const ModelEntry& model, std::string_view subsy
         r.error = "unable to resolve PULP_HOME";
         return r;
     }
+    if (!is_safe_path_segment(subsystem) || !is_safe_path_segment(model.model_id)) {
+        r.error = "invalid subsystem or model_id";
+        return r;
+    }
+
     const fs::path files_dir = home / std::string(subsystem) / "models" / model.model_id;
 
     // A model is either a single primary checkpoint or a multi-asset bundle (e.g. Magenta's
@@ -405,14 +460,38 @@ bool remove_model(std::string_view subsystem, std::string_view model_id, std::st
         error = "unable to resolve PULP_HOME";
         return false;
     }
+    if (!is_safe_path_segment(subsystem) || !is_safe_path_segment(model_id)) {
+        error = "invalid subsystem or model_id";
+        return false;
+    }
     std::error_code ec;
-    fs::remove_all(home / std::string(subsystem) / "models" / std::string(model_id), ec);
-    fs::remove(model_install_path(subsystem, model_id, pulp_home_override), ec);
+    const auto files_dir = home / std::string(subsystem) / "models" / std::string(model_id);
+    const auto metadata_path = model_install_path(subsystem, model_id, pulp_home_override);
+    const bool had_files = fs::exists(files_dir, ec);
+    const bool had_metadata = fs::exists(metadata_path, ec);
+
+    fs::remove_all(files_dir, ec);
+    if (ec) {
+        error = "failed to remove model files: " + ec.message();
+        return false;
+    }
+    fs::remove(metadata_path, ec);
+    if (ec) {
+        error = "failed to remove model metadata: " + ec.message();
+        return false;
+    }
     // Clear the active selection if it pointed at the removed model.
     if (read_active_model_id(subsystem, pulp_home_override) == model_id) {
         fs::remove(model_state_path(subsystem, pulp_home_override), ec);
+        if (ec) {
+            error = "failed to clear active model state: " + ec.message();
+            return false;
+        }
     }
-    return true;
+    error.clear();
+    // Report whether anything was actually removed so callers can distinguish a
+    // no-op (nothing installed) from a successful deletion.
+    return had_files || had_metadata;
 }
 
 }  // namespace pulp::runtime

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -475,7 +475,11 @@ endif()
 target_link_libraries(pulp-view-script PUBLIC pulp::view-core)
 # pulp #468 — design_import.cpp uses pulp::runtime::base64_decode +
 # gzip_decompress to unpack Claude Design's base64-gzip envelope.
-target_link_libraries(pulp-view-core PRIVATE pulp::runtime)
+# PUBLIC because the public header model_manager_view.hpp includes
+# <pulp/runtime/model_store.hpp> (exposes runtime::ModelListResult in its API),
+# so downstream targets that link only pulp::view must inherit the runtime
+# include path + link.
+target_link_libraries(pulp-view-core PUBLIC pulp::runtime)
 target_link_libraries(pulp-view-script PRIVATE pulp::runtime)
 
 # yaml-cpp (MIT) — DESIGN.md frontmatter parsing.

--- a/core/view/include/pulp/view/model_manager_view.hpp
+++ b/core/view/include/pulp/view/model_manager_view.hpp
@@ -42,6 +42,9 @@ public:
     }
 
     /// Per-row download progress in [0,1]. Negative clears (not downloading).
+    /// NOTE: this rebuilds the full row subtree (Yoga layout + Skia repaint), so
+    /// callers driving live download progress should throttle updates (e.g. ~4 Hz)
+    /// rather than calling it at the raw byte-callback rate.
     void set_download_progress(const std::string& model_id, float fraction) {
         if (fraction < 0.0f)
             progress_.erase(model_id);

--- a/core/view/include/pulp/view/text_editor.hpp
+++ b/core/view/include/pulp/view/text_editor.hpp
@@ -161,6 +161,10 @@ private:
     float scroll_offset_ = 0.0f; ///< Horizontal scroll for single-line
     float caret_blink_time_ = 0.0f; ///< Accumulated time for caret blinking
     int caret_blink_sub_ = -1;      ///< Frame-clock subscription that drives blink repaints while focused
+    FrameClock* caret_blink_clock_ = nullptr;  ///< Clock the subscription lives on; cached so we can
+                                               ///< always unsubscribe even after the editor is detached
+                                               ///< from the view tree (frame_clock() walks parent_ and
+                                               ///< would return null once detached → leaked sub + UAF).
 
     // IME composition state
     std::string marked_text_;        ///< Active composition string

--- a/core/view/src/text_editor.cpp
+++ b/core/view/src/text_editor.cpp
@@ -396,8 +396,13 @@ void TextEditor::on_text_input(const TextInputEvent& event) {
 }
 
 TextEditor::~TextEditor() {
-    if (caret_blink_sub_ >= 0)
-        if (auto* fc = frame_clock()) fc->unsubscribe(caret_blink_sub_);
+    // Unsubscribe from the clock we actually subscribed to (cached), NOT
+    // frame_clock() — by destruction the editor may already be detached from the
+    // view tree, in which case frame_clock() walks a null parent_ and returns
+    // nullptr, leaking the subscription with a dangling `this` (use-after-free on
+    // the next tick).
+    if (caret_blink_sub_ >= 0 && caret_blink_clock_)
+        caret_blink_clock_->unsubscribe(caret_blink_sub_);
 }
 
 void TextEditor::on_focus_changed(bool gained) {
@@ -410,15 +415,18 @@ void TextEditor::on_focus_changed(bool gained) {
         // paint() advances caret_blink_time_.
         caret_blink_time_ = 0.0f;
         if (caret_blink_sub_ < 0)
-            if (auto* fc = frame_clock())
+            if (auto* fc = frame_clock()) {
+                caret_blink_clock_ = fc;  // cache so we can always unsubscribe later
                 caret_blink_sub_ = fc->subscribe([this](float) {
                     request_repaint();
                     return true;
                 });
+            }
     } else {
-        if (caret_blink_sub_ >= 0)
-            if (auto* fc = frame_clock()) fc->unsubscribe(caret_blink_sub_);
+        if (caret_blink_sub_ >= 0 && caret_blink_clock_)
+            caret_blink_clock_->unsubscribe(caret_blink_sub_);
         caret_blink_sub_ = -1;
+        caret_blink_clock_ = nullptr;
         request_repaint();  // clear the caret now that focus is lost
     }
 }

--- a/core/view/src/ui_components.cpp
+++ b/core/view/src/ui_components.cpp
@@ -6,6 +6,13 @@ namespace pulp::view {
 
 const std::string ComboBox::empty_string_;
 
+namespace {
+// Rows whose text starts with "---" are non-selectable visual separators.
+bool is_separator_item(const std::string& item) {
+    return item.size() >= 3 && item.substr(0, 3) == "---";
+}
+}  // namespace
+
 // ── ComboBox ─────────────────────────────────────────────────────────────
 
 void ComboBox::set_selected_impl(int index, bool notify) {
@@ -280,14 +287,24 @@ bool ComboBox::on_key_event(const KeyEvent& event) {
 
     if (!open_) {
         // Closed: Up/Down step the value like a stepper; Enter/Space opens the menu.
-        if (event.key == KeyCode::up && selected_ > 0) {
-            set_selected(selected_ - 1);
-            return true;
-        }
-        if (event.key == KeyCode::down && selected_ < static_cast<int>(items_.size()) - 1) {
-            set_selected(selected_ + 1);
-            return true;
-        }
+        // Step OVER "---" separators so the stepper can never commit a separator
+        // index (which would fire on_change with an invalid/empty value).
+        auto step_to_selectable = [&](int delta) -> bool {
+            const int n = static_cast<int>(items_.size());
+            int idx = selected_;
+            for (int s = 0; s < n; ++s) {
+                const int next = idx + delta;
+                if (next < 0 || next >= n) return false;  // ran off the end
+                idx = next;
+                if (!is_separator_item(items_[static_cast<size_t>(idx)])) {
+                    set_selected(idx);
+                    return true;
+                }
+            }
+            return false;
+        };
+        if (event.key == KeyCode::up) return step_to_selectable(-1);
+        if (event.key == KeyCode::down) return step_to_selectable(+1);
         if (event.key == KeyCode::enter || event.key == KeyCode::space) {
             open_dropdown();
             request_repaint();
@@ -306,8 +323,9 @@ bool ComboBox::on_key_event(const KeyEvent& event) {
             return true;
         case KeyCode::enter:
         case KeyCode::space:
-            if (hover_index_ >= 0 && hover_index_ < static_cast<int>(items_.size()))
-                set_selected(hover_index_);
+            if (hover_index_ >= 0 && hover_index_ < static_cast<int>(items_.size()) &&
+                !is_separator_item(items_[static_cast<size_t>(hover_index_)]))
+                set_selected(hover_index_);  // never commit a "---" separator row
             close_dropdown();
             request_repaint();
             return true;

--- a/test/test_combo_dropdown.cpp
+++ b/test/test_combo_dropdown.cpp
@@ -344,3 +344,64 @@ TEST_CASE("ComboBox: close_active_popup is focus-independent [issue-68]",
     REQUIRE(ComboBox::active_popup_ == nullptr);
 }
 
+
+TEST_CASE("ComboBox: closed-stepper arrow keys skip separators (no separator commit)", "[combo]") {
+    // Regression: when closed, Up/Down must step OVER "---" separator rows rather
+    // than committing a separator index (which would fire on_change with an empty
+    // selection). Items: 0=A, 1="---", 2=B.
+    ComboBox combo;
+    combo.set_items({"A", "---", "B"});
+    combo.set_selected(0);
+
+    int changed_to = -1;
+    std::string changed_text;
+    combo.on_change = [&](int idx) {
+        changed_to = idx;
+        changed_text = combo.selected_text();
+    };
+
+    KeyEvent down;
+    down.key = KeyCode::down;
+    down.is_down = true;
+    REQUIRE(combo.on_key_event(down));   // steps from 0 over the separator to 2
+    REQUIRE(changed_to == 2);            // NOT 1 (the "---" separator)
+    REQUIRE(changed_text == "B");
+    REQUIRE(combo.selected_text() == "B");
+
+    // Going back up lands on A, never on the separator.
+    KeyEvent up;
+    up.key = KeyCode::up;
+    up.is_down = true;
+    REQUIRE(combo.on_key_event(up));
+    REQUIRE(combo.selected_text() == "A");
+}
+
+TEST_CASE("ComboBox: open-menu Enter on a separator does not commit", "[combo]") {
+    ComboBox combo;
+    combo.set_items({"A", "---", "B"});
+    combo.set_selected(0);
+    combo.set_bounds({0, 0, 140, 120});
+
+    // Open the menu.
+    KeyEvent space;
+    space.key = KeyCode::space;
+    space.is_down = true;
+    REQUIRE(combo.on_key_event(space));
+
+    // Down from selected (0) should skip the separator via move_hover, but even if
+    // a separator were highlighted, Enter must not commit it.
+    int changed_to = -1;
+    combo.on_change = [&](int idx) { changed_to = idx; };
+
+    KeyEvent down;
+    down.key = KeyCode::down;
+    down.is_down = true;
+    combo.on_key_event(down);  // move_hover skips "---" → highlights B (index 2)
+
+    KeyEvent enter;
+    enter.key = KeyCode::enter;
+    enter.is_down = true;
+    REQUIRE(combo.on_key_event(enter));
+    REQUIRE(changed_to != 1);  // separator index 1 was never committed
+    REQUIRE(combo.selected_text() != "---");
+}

--- a/test/test_model_download.cpp
+++ b/test/test_model_download.cpp
@@ -146,6 +146,123 @@ TEST_CASE("model downloader: cancel keeps the partial for resume", "[runtime][mo
     fs::remove_all(root);
 }
 
+TEST_CASE("model downloader: http error status is reported and not written into .part",
+          "[runtime][model][download]") {
+    const fs::path root = fs::temp_directory_path() / "pulp-mm-pr2-404";
+    fs::remove_all(root);
+    fs::create_directories(root / "out");
+
+    // A server that answers everything with a distinctive 404 error body.
+    httplib::Server svr;
+    const std::string error_body = "NOT-FOUND-ERROR-PAYLOAD";
+    svr.Get(".*", [&](const httplib::Request&, httplib::Response& res) {
+        res.status = 404;
+        res.set_content(error_body, "text/plain");
+    });
+    int port = svr.bind_to_any_port("127.0.0.1");
+    std::thread th([&] { svr.listen_after_bind(); });
+    svr.wait_until_ready();
+
+    const fs::path dest = root / "out" / "fixture.bin";
+    DownloadRequest req{.url = "http://127.0.0.1:" + std::to_string(port) + "/missing.bin",
+                        .dest = dest};
+    auto res = download_file(req);
+    REQUIRE_FALSE(res.ok);
+    REQUIRE(res.error.find("http status 404") != std::string::npos);
+    REQUIRE_FALSE(fs::exists(dest));  // not published
+
+    // The error body must never end up in the resumable .part.
+    fs::path part = dest;
+    part += ".part";
+    if (fs::exists(part)) {
+        std::ifstream in(part, std::ios::binary);
+        std::string contents((std::istreambuf_iterator<char>(in)), {});
+        REQUIRE(contents.find(error_body) == std::string::npos);
+    }
+
+    svr.stop();
+    if (th.joinable()) th.join();
+    fs::remove_all(root);
+}
+
+TEST_CASE("model downloader: a stale oversized partial fails closed instead of resuming blindly",
+          "[runtime][model][download]") {
+    // A resumed download must verify the server is actually continuing from the
+    // requested offset rather than trusting the 206. A conforming server (httplib)
+    // can't be coerced into emitting a *lying* Content-Range — it returns the
+    // correct range or a 416 when the requested offset is unsatisfiable. This test
+    // exercises the latter, real, fail-closed path: a partial larger than the file
+    // on the server must NOT be silently accepted as a finished download. (The
+    // content-range-start check in download_file guards the complementary case of a
+    // non-conforming server that returns 206 from the wrong offset.)
+    const fs::path root = fs::temp_directory_path() / "pulp-mm-pr2-badrange";
+    fs::remove_all(root);
+    fs::create_directories(root / "serve");
+    fs::create_directories(root / "out");
+    make_fixture(root / "serve" / "fixture.bin", 10);  // tiny real file
+
+    // Seed a 100k partial — much larger than the 10-byte file on the server.
+    make_fixture(root / "out" / "fixture.bin.part", 100'000);
+
+    LocalServer server(root / "serve");
+    const fs::path dest = root / "out" / "fixture.bin";
+    DownloadRequest req{.url = server.url("/fixture.bin"), .dest = dest, .resume = true};
+    auto res = download_file(req);
+    INFO("error: " << res.error);
+    REQUIRE_FALSE(res.ok);
+    REQUIRE_FALSE(fs::exists(dest));  // not published as a completed download
+
+    fs::remove_all(root);
+}
+
+TEST_CASE("model downloader: cross-origin redirect drops the Authorization header",
+          "[runtime][model][download]") {
+    // HF gated downloads 302 from huggingface.co to a pre-signed S3 URL on another
+    // host. The auth token must NOT be replayed to the redirect target. Two local
+    // servers on different ports model the two origins; the second records whether
+    // it saw an Authorization header.
+    const fs::path root = fs::temp_directory_path() / "pulp-mm-pr2-redirect";
+    fs::remove_all(root);
+    fs::create_directories(root / "out");
+    const std::string body = make_fixture(root / "out" / "payload-src.bin", 4096);
+    const std::string sha = sha256_hex(body);
+
+    // Origin B: serves the real bytes, records any Authorization header it received.
+    std::atomic<bool> saw_auth_on_b{false};
+    httplib::Server b;
+    b.Get("/payload.bin", [&](const httplib::Request& reqB, httplib::Response& res) {
+        if (reqB.has_header("Authorization")) saw_auth_on_b = true;
+        res.set_content(body, "application/octet-stream");
+    });
+    int port_b = b.bind_to_any_port("127.0.0.1");
+    std::thread tb([&] { b.listen_after_bind(); });
+    b.wait_until_ready();
+
+    // Origin A: 302-redirects to origin B (different port == different origin).
+    httplib::Server a;
+    a.Get("/gated.bin", [&](const httplib::Request&, httplib::Response& res) {
+        res.status = 302;
+        res.set_header("Location", "http://127.0.0.1:" + std::to_string(port_b) + "/payload.bin");
+    });
+    int port_a = a.bind_to_any_port("127.0.0.1");
+    std::thread ta([&] { a.listen_after_bind(); });
+    a.wait_until_ready();
+
+    const fs::path dest = root / "out" / "fixture.bin";
+    DownloadRequest req{.url = "http://127.0.0.1:" + std::to_string(port_a) + "/gated.bin",
+                        .dest = dest, .expected_sha256 = sha};
+    req.headers.push_back(HttpHeader{"Authorization", "Bearer hf_secret_token"});
+    auto res = download_file(req);
+    INFO("error: " << res.error);
+    REQUIRE(res.ok);              // redirect followed, bytes fetched
+    REQUIRE(res.sha256 == sha);
+    REQUIRE_FALSE(saw_auth_on_b); // token did NOT leak to the cross-origin target
+
+    a.stop(); if (ta.joinable()) ta.join();
+    b.stop(); if (tb.joinable()) tb.join();
+    fs::remove_all(root);
+}
+
 TEST_CASE("model store: install_model downloads + records, then remove_model deletes",
           "[runtime][model][download]") {
     const fs::path root = fs::temp_directory_path() / "pulp-mm-pr2-install";

--- a/test/test_model_store.cpp
+++ b/test/test_model_store.cpp
@@ -19,9 +19,63 @@ TEST_CASE("resolve_checkpoint_url: hf:// resolution + path hardening", "[runtime
     REQUIRE(resolve_checkpoint_url("hf://user/repo/path/to/w.mlxfn") ==
             "https://huggingface.co/user/repo/resolve/main/path/to/w.mlxfn");
     REQUIRE(resolve_checkpoint_url("https://example.com/m.bin") == "https://example.com/m.bin");
-    REQUIRE(resolve_checkpoint_url("hf://user/repo/../escape").empty());  // `..` rejected
-    REQUIRE(resolve_checkpoint_url("hf://user/repo").empty());            // no file part
-    REQUIRE(resolve_checkpoint_url("ftp://x/y").empty());                 // unsupported scheme
+    REQUIRE(resolve_checkpoint_url("hf://user/repo/../escape").empty());   // `..` in file_path rejected
+    REQUIRE(resolve_checkpoint_url("hf://user/../evil/file.pt").empty());  // `..` in user_repo rejected
+    REQUIRE(resolve_checkpoint_url("hf://user/repo/a/../b.pt").empty());   // nested `..` rejected
+    REQUIRE(resolve_checkpoint_url("hf://user/repo/%2e%2e/x.pt").empty()); // encoded `..` rejected
+    REQUIRE(resolve_checkpoint_url("hf://%2e%2e/repo/x.pt").empty());      // encoded `..` in user_repo
+    REQUIRE(resolve_checkpoint_url("hf://user/repo").empty());             // no file part
+    REQUIRE(resolve_checkpoint_url("ftp://x/y").empty());                  // unsupported scheme
+}
+
+TEST_CASE("model path builders reject traversal in subsystem/model_id", "[runtime][model]") {
+    const fs::path home = fs::temp_directory_path() / "pulp-mm-pathguard";
+    // Safe literals resolve normally.
+    REQUIRE(model_state_path("magenta", home) == home / "magenta" / "model-state.json");
+    REQUIRE(model_install_path("magenta", "m1", home) == home / "magenta" / "models" / "m1.json");
+
+    // Unsafe subsystem values are rejected (empty path returned).
+    REQUIRE(model_state_path("..", home).empty());
+    REQUIRE(model_state_path("../secrets", home).empty());
+    REQUIRE(model_state_path("a/b", home).empty());
+    REQUIRE(model_state_path("", home).empty());
+    REQUIRE(model_install_path("..", "m1", home).empty());
+    REQUIRE(model_install_path("magenta", "../etc", home).empty());
+    REQUIRE(model_install_path("magenta", "a/b", home).empty());
+    REQUIRE(model_install_path("magenta", "", home).empty());
+#ifdef _WIN32
+    REQUIRE(model_install_path("magenta", "a\\b", home).empty());  // backslash separator
+    REQUIRE(model_state_path("c:evil", home).empty());             // drive-relative
+#endif
+}
+
+TEST_CASE("remove_model: return value reflects what was actually removed", "[runtime][model]") {
+    const fs::path home = fs::temp_directory_path() / "pulp-mm-remove";
+    fs::remove_all(home);
+    std::string err;
+
+    // Nothing installed → no-op, returns false (no error).
+    REQUIRE_FALSE(remove_model("magenta", "ghost", err, home));
+    REQUIRE(err.empty());
+
+    // Invalid subsystem/model_id → false with an error, never touches the FS.
+    REQUIRE_FALSE(remove_model("..", "m1", err, home));
+    REQUIRE_FALSE(err.empty());
+    err.clear();
+    REQUIRE_FALSE(remove_model("magenta", "../escape", err, home));
+    REQUIRE_FALSE(err.empty());
+
+    // Something present → removes it and returns true.
+    const fs::path meta = model_install_path("magenta", "m1", home);
+    fs::create_directories(meta.parent_path());
+    std::ofstream(meta) << R"({"model_id":"m1"})";
+    REQUIRE(fs::exists(meta));
+    err.clear();
+    REQUIRE(remove_model("magenta", "m1", err, home));
+    REQUIRE(err.empty());
+    REQUIRE_FALSE(fs::exists(meta));
+
+    fs::remove_all(home);
 }
 
 TEST_CASE("generic model store: list / install / activate round-trip + isolation",

--- a/test/test_text_editor.cpp
+++ b/test/test_text_editor.cpp
@@ -1,6 +1,9 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/view/text_editor.hpp>
+#include <pulp/view/frame_clock.hpp>
 #include <pulp/canvas/canvas.hpp>
+
+#include <memory>
 
 using namespace pulp::view;
 using namespace pulp::canvas;
@@ -709,4 +712,33 @@ TEST_CASE("TextEditor multi-line wheel clamps scroll offset before hit testing",
     editor.on_mouse_event(click);
     REQUIRE(editor.caret_pos() >= 0);
     REQUIRE(editor.caret_pos() <= static_cast<int>(editor.text().size()));
+}
+
+TEST_CASE("TextEditor caret-blink subscription is removed even after detach", "[view][text_editor]") {
+    // Regression: the caret-blink frame-clock subscription must be torn down on
+    // destruction even when the editor was removed from the view tree first.
+    // frame_clock() walks parent_, so a detached editor can't find its clock; the
+    // editor caches the clock pointer at subscribe time so it can always
+    // unsubscribe. If it doesn't, the clock holds a callback capturing a destroyed
+    // `this` and the next tick() is a use-after-free.
+    FrameClock clock;
+
+    auto parent = std::make_unique<View>();
+    parent->set_frame_clock(&clock);
+
+    auto editor_owned = std::make_unique<TextEditor>();
+    TextEditor* editor = editor_owned.get();
+    parent->add_child(std::move(editor_owned));
+
+    editor->on_focus_changed(true);                 // subscribes to the clock
+    REQUIRE(clock.has_active_subscribers());
+
+    // Detach from the tree BEFORE destruction — now frame_clock() would return null.
+    auto detached = parent->remove_child(editor);
+    REQUIRE(detached != nullptr);
+    detached.reset();                               // destroy the editor
+
+    REQUIRE_FALSE(clock.has_active_subscribers());  // subscription cleaned up
+    clock.tick(0.016f);                             // must not touch freed memory
+    SUCCEED("tick after destruction did not use freed memory");
 }


### PR DESCRIPTION
## Why a new PR

PR #3464 (ModelManagerView, stacked on #3463) was **merged** to main with the
code-review comments on both PRs left unaddressed; #3463 was then **closed**
because its runtime content had already landed via #3464. Since both PRs are
closed/merged, this follow-up applies the outstanding fixes directly on main.

## Fixes

### Runtime (from #3463)
- **Path traversal (P1):** `resolve_checkpoint_url` now rejects `..` in the
  user/repo segment (not just the file path) and rejects percent-encoded path
  content (`%2e%2e`). `model_state_path`/`model_install_path`/`install_model`/
  `remove_model` validate `subsystem`/`model_id` (reject empty, separators,
  drive colon, `..`) before building any path.
- **`remove_model` (P1):** propagates filesystem errors and returns `false` on a
  no-op; `true` only when something was removed. Header contract updated.
- **Downloader (P1):** fail-closed on `file_size()` error (no bogus resume
  offset); fail `hash_existing` on mid-stream I/O error; reject non-success HTTP
  status in the response handler so an error body never lands in `.part`; verify
  a 206 continues from the requested offset.
- **Auth-header leak (P1, security):** follow redirects manually
  (`set_follow_location` off) and strip `Authorization`/`Proxy-Authorization`/
  `Cookie` on a cross-origin hop, so an HF token doesn't leak to the S3
  pre-signed redirect target.
- **CMake (P1):** scope `CPPHTTPLIB_MBEDTLS_SUPPORT` to `model_download.cpp`.
- **P2s:** round-trip remaining `ModelEntry` metadata + `partial_fraction`
  through the list JSON; deterministic partial detection (largest `.part`) with
  clamping.

### View / standalone (from #3464)
- **Caret-blink UAF (P0):** cache the frame-clock pointer at subscribe time so
  the `TextEditor` destructor can always unsubscribe even after the editor is
  detached from the view tree (`frame_clock()` walks `parent_` and returns null
  once detached → leaked subscription with a dangling `this`).
- **ComboBox separators (P1):** closed-stepper Up/Down and open-menu Enter/Space
  now skip `---` separator rows so a separator index is never committed.
- **Runtime dep propagation (P1):** `pulp-view-core` links `pulp::runtime`
  PUBLIC so consumers of the public `model_manager_view.hpp` inherit the runtime
  include path.
- **Standalone (P1):** persist device config only after a successful (re)start.
- **P2:** throttle note on `set_download_progress`.

### Tests
Strengthened `test_model_store`, `test_model_download` (incl. a cross-origin
redirect auth-strip test), `test_text_editor` (caret-blink subscription removed
after detach), and `test_combo_dropdown` (separator-skip).

### Deferred (noted, not fixed)
- P3 `buttons.cpp` pressed-state (needs mouse-up wiring; risk of stuck-pressed).
- P2 standalone lifecycle items (sticky `persisted_config_loaded_`, eager
  settings-section construction, `effective_config` staleness) — lifecycle-subtle,
  deferred to avoid regression.
- P3 downloader URL-parse dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the model manager runtime and fixes UI edge cases: secure redirects/resumes in the downloader, stricter path guards, correct `remove_model` semantics, and non-selectable ComboBox separators. Also fixes a TextEditor caret unsubscribe UAF and only persists audio settings after a successful restart.

- **Bug Fixes**
  - Downloader: follow redirects manually and strip `Authorization`/`Proxy-Authorization`/`Cookie` on cross-origin hops; reject non-200/206; verify 206 `Content-Range` starts at the requested offset; guard resume offset on `file_size` errors; fail `hash_existing` on mid-stream I/O; never write error bodies to `.part`; drop untrusted partials on range mismatch.
  - Path hardening: reject `..` and percent-encoded path content in `hf://` user/repo and file; validate `subsystem`/`model_id` before building any path.
  - `remove_model`: propagate filesystem errors; return true only when something was deleted; false on no-op.
  - Model list JSON: round-trip remaining `ModelEntry` metadata and `partial_fraction`; detect partial by largest `.part` and clamp.
  - TextEditor: cache frame-clock pointer to unsubscribe after detach (fixes caret-blink UAF).
  - ComboBox: skip `---` separators for arrow stepper and Enter/Space; never commit a separator.
  - Standalone: persist device config only after a successful (re)start.
  - Tests: add coverage for redirect auth-strip, error body not written to `.part`, stale oversized partial fails closed, range checks, path guards, unsubscribe-after-detach, and separator skipping.

- **Dependencies**
  - Scope `CPPHTTPLIB_MBEDTLS_SUPPORT` to `core/runtime/src/model_download.cpp` only.
  - Link `pulp-view-core` to `pulp::runtime` PUBLIC so downstreams inherit runtime headers.
  - Bump project version to 0.358.0.

<sup>Written for commit 7fa1df33349e1ecd91be47ebcb0ad458ddf3aa2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR applies outstanding code-review findings from the merged model-manager PRs (#3463/#3464), addressing security hardening, correctness fixes, and a UAF in the view layer.

- **Runtime security (model_download.cpp):** Manual redirect loop replaces `set_follow_location(true)` to strip `Authorization`/`Proxy-Authorization`/`Cookie` on cross-origin hops (HF → S3); response handler now rejects non-200/206 before writing to `.part`; `file_size()` error guards against bogus resume offsets; 206 `Content-Range` offset verified against the requested start.
- **Path traversal hardening (model_store.cpp, model_registry.cpp):** `is_safe_path_segment` validates `subsystem`/`model_id` before any path construction; `resolve_checkpoint_url` now checks both the `user/repo` and `file` segments for `..` and percent-encoding; `remove_model` propagates filesystem errors and returns `false`/no-error for a no-op.
- **View layer (text_editor.cpp, ui_components.cpp, standalone.cpp):** Caret-blink UAF fixed by caching the `FrameClock*` at subscribe time; ComboBox arrow/Enter keys skip separator rows; device config persisted only after a successful audio restart.
</details>


<h3>Confidence Score: 4/5</h3>

The change is safe to merge; the security-critical redirect and path-traversal fixes are well-implemented with real integration tests covering the exact failure scenarios.

The redirect-loop auth-stripping, path-traversal guards, and caret-blink UAF fix are all implemented correctly and covered by new tests. Two over-restriction issues exist: is_safe_path_segment's substring .. check would silently reject valid model IDs containing .. (e.g., v1..2), and has_percent_encoding blocks legitimate percent-encoded hf:// paths without a useful error. Neither breaks existing callers but both could cause confusing silent failures with future model registries.

core/runtime/src/model_store.cpp (is_safe_path_segment substring check) and core/runtime/src/model_registry.cpp (blanket percent-encoding rejection) are worth a second look before expanding the model registry to third-party sources.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| core/runtime/src/model_download.cpp | Major security overhaul: manual redirect loop strips auth headers on cross-origin hops, response_handler rejects non-200/206 before writing to .part, file_size error guarded, 206 Content-Range offset verified, hash_existing fails on I/O error. Path-relative Location values are not dot-normalized (minor edge case). |
| core/runtime/src/model_store.cpp | Path traversal guards added to model_state_path/model_install_path/install_model/remove_model; remove_model now propagates fs errors and correctly returns false for no-op; is_safe_path_segment's find("..") check is overly broad and rejects valid identifiers containing .. as a substring. |
| core/runtime/src/model_registry.cpp | resolve_checkpoint_url now checks for .. in both user/repo and file segments, and rejects any % (percent-encoded content). The blanket % rejection silently blocks valid percent-encoded paths with no error surface for callers. |
| core/view/src/text_editor.cpp | Caret-blink UAF fixed by caching the FrameClock* at subscribe time; destructor and focus-lost path now use the cached pointer instead of frame_clock() which returns null after detach. |
| core/view/src/ui_components.cpp | ComboBox closed-stepper and open-menu Enter/Space now skip separator rows so a separator index is never committed to on_change. |
| core/format/src/standalone.cpp | apply_config now persists device config only after a successful (re)start, preventing a failed audio restart from storing a broken device selection. |
| test/test_model_download.cpp | Three new integration tests: 404 error body not written to .part, stale oversized partial rejected via 416, cross-origin redirect strips Authorization header. |
| test/test_model_store.cpp | Tests added for path traversal rejection and remove_model return-value semantics (no-op vs. actual deletion vs. invalid input). |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant download_file
    participant OriginA as Origin A (HF)
    participant OriginB as Origin B (S3)
    Caller->>download_file: "DownloadRequest{url, headers{Authorization}}"
    download_file->>download_file: parse_url, open .part, build Range header
    loop redirect loop (max 8 hops)
        download_file->>OriginA: GET /gated.bin [Authorization, Range]
        OriginA-->>download_file: 302 Location: https://s3.../payload.bin
        Note over download_file: response_handler sets is_redirect=true, returns false
        download_file->>download_file: resolve_redirect, detect cross-origin hop
        download_file->>download_file: headers.erase(Authorization, Proxy-Authorization, Cookie)
        download_file->>OriginB: GET /payload.bin [Range] (no Authorization)
        OriginB-->>download_file: 206 Partial Content + Content-Range
        Note over download_file: content_range_starts_at() verifies offset == resume_from
        download_file->>download_file: content_receiver writes to .part, updates SHA
    end
    download_file->>download_file: flush+close .part, verify SHA256, rename to dest
    download_file-->>Caller: "DownloadResult{ok=true, sha256}"
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `core/runtime/src/model_registry.cpp`, line 311-317 ([link](https://github.com/danielraffel/pulp/blob/d930f4c3caae1c439d87e2ff2a21c3b499c8513c/core/runtime/src/model_registry.cpp#L311-L317)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Blanket `%` rejection silently blocks legitimate percent-encoded paths**

   `has_percent_encoding` rejects any `%` character, so a valid `hf://` reference like `hf://user/repo/path%20with%20spaces/model.bin` (or any file whose name uses percent-encoding) returns an empty string without explaining why. The fail-closed design is sound, but the failure is currently invisible to callers — `resolve_checkpoint_url` returns `{}` with no error surface. If the intent is to keep percent-encoding permanently blocked, the header comment on `resolve_checkpoint_url` should state this constraint explicitly so callers know to pass pre-decoded paths.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["chore: bump versions"](https://github.com/danielraffel/pulp/commit/d930f4c3caae1c439d87e2ff2a21c3b499c8513c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36040097)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->