### PR TITLE
feat(runtime): install_model fetches every asset of a multi-asset bundle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.354.0
+    VERSION 0.355.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/runtime/src/model_store.cpp
+++ b/core/runtime/src/model_store.cpp
@@ -280,53 +280,114 @@ InstallModelResult install_model(const ModelEntry& model, std::string_view subsy
                                  const std::vector<std::pair<std::string, std::string>>& headers,
                                  const fs::path& pulp_home_override) {
     InstallModelResult r;
-    const std::string url =
-        model.download_url.empty() ? resolve_checkpoint_url(model.checkpoint_ref) : model.download_url;
-    if (url.empty()) {
-        r.error = "cannot resolve a download URL for " + model.model_id;
-        return r;
-    }
     const auto home = resolve_pulp_home(pulp_home_override);
     if (home.empty()) {
         r.error = "unable to resolve PULP_HOME";
         return r;
     }
-
     const fs::path files_dir = home / std::string(subsystem) / "models" / model.model_id;
-    std::string fname;
-    if (auto slash = url.find_last_of('/'); slash != std::string::npos) fname = url.substr(slash + 1);
-    if (auto q = fname.find('?'); q != std::string::npos) fname = fname.substr(0, q);
-    if (fname.empty()) fname = model.model_id + ".bin";
-    const fs::path dest = files_dir / fname;
 
-    DownloadRequest req;
-    req.url = url;
-    req.dest = dest;
-    req.expected_sha256 = model.sha256;
-    req.resume = true;
-    for (const auto& h : headers) req.headers.push_back(HttpHeader{h.first, h.second});
-
-    const auto dl = download_file(req, on_progress, cancel);
-    if (dl.cancelled) {
-        r.cancelled = true;
-        r.error = "cancelled";
-        return r;
+    // A model is either a single primary checkpoint or a multi-asset bundle (e.g. Magenta's
+    // weights + state). Fetch EVERY asset so the model is complete on disk — a half-downloaded
+    // bundle (weights only) silently fails to load. Falls back to the primary checkpoint when
+    // assets[] is empty.
+    struct Item {
+        std::string url, role, sha;
+    };
+    std::vector<Item> items;
+    if (!model.assets.empty()) {
+        for (const auto& a : model.assets) {
+            const std::string u = (a.checkpoint_ref.rfind("http", 0) == 0)
+                                      ? a.checkpoint_ref
+                                      : resolve_checkpoint_url(a.checkpoint_ref);
+            if (u.empty()) {
+                r.error = "cannot resolve a download URL for asset '" + a.role + "' of " + model.model_id;
+                return r;
+            }
+            items.push_back({u, a.role.empty() ? "asset" : a.role, ""});
+        }
+    } else {
+        const std::string u =
+            model.download_url.empty() ? resolve_checkpoint_url(model.checkpoint_ref) : model.download_url;
+        if (u.empty()) {
+            r.error = "cannot resolve a download URL for " + model.model_id;
+            return r;
+        }
+        items.push_back({u, "primary", model.sha256});
     }
-    if (!dl.ok) {
-        r.error = dl.error;
-        return r;
+
+    auto filename_of = [](const std::string& url, const std::string& fallback) {
+        std::string fname;
+        if (auto slash = url.find_last_of('/'); slash != std::string::npos) fname = url.substr(slash + 1);
+        if (auto q = fname.find('?'); q != std::string::npos) fname = fname.substr(0, q);
+        return fname.empty() ? fallback : fname;
+    };
+
+    const int n = static_cast<int>(items.size());
+    auto assets_obj = choc::value::createEmptyArray();
+    fs::path primary_path;  // the first/weights asset — what the engine loads
+
+    for (int i = 0; i < n; ++i) {
+        const auto& it = items[static_cast<size_t>(i)];
+        const fs::path dest = files_dir / filename_of(it.url, model.model_id + ".bin");
+
+        DownloadRequest req;
+        req.url = it.url;
+        req.dest = dest;
+        req.expected_sha256 = it.sha;
+        req.resume = true;
+        for (const auto& h : headers) req.headers.push_back(HttpHeader{h.first, h.second});
+
+        // Aggregate progress so the UI sees one 0→100% bar across all assets; asset i
+        // contributes 1/n of the whole.
+        const int idx = i;
+        // download_file() enforces cancellation via `cancel`; this wrapper only reshapes the
+        // progress into one aggregate 0→100% bar across all assets.
+        auto wrapped = [&on_progress, idx, n](const DownloadProgress& p) -> bool {
+            if (!on_progress) return true;
+            DownloadProgress agg = p;
+            if (p.total > 0) {
+                const double frac = (static_cast<double>(idx) +
+                                     static_cast<double>(p.downloaded) / static_cast<double>(p.total)) /
+                                    static_cast<double>(n);
+                agg.downloaded = static_cast<std::uint64_t>(frac * 1'000'000.0);
+                agg.total = 1'000'000;
+            }
+            return on_progress(agg);
+        };
+
+        const auto dl = download_file(req, wrapped, cancel);
+        if (dl.cancelled) {
+            r.cancelled = true;
+            r.error = "cancelled";
+            return r;
+        }
+        if (!dl.ok) {
+            r.error = dl.error;
+            return r;
+        }
+
+        if (i == 0) {
+            primary_path = dest;
+            r.sha256 = dl.sha256;
+        }
+        auto a = choc::value::createObject("");
+        add_string_member(a, "role", it.role);
+        add_path_member(a, "path", dest);
+        add_string_member(a, "sha256", dl.sha256);
+        assets_obj.addArrayElement(a);
     }
 
-    r.checkpoint_path = dest;
-    r.sha256 = dl.sha256;
+    r.checkpoint_path = primary_path;
     r.metadata_path = model_install_path(subsystem, model.model_id, pulp_home_override);
 
     auto object = choc::value::createObject("");
     add_string_member(object, "model_id", model.model_id);
     add_string_member(object, "backend", model.backend);
     add_string_member(object, "checkpoint_ref", model.checkpoint_ref);
-    add_path_member(object, "resolved_checkpoint_path", dest);
-    add_string_member(object, "sha256", dl.sha256);
+    add_path_member(object, "resolved_checkpoint_path", primary_path);
+    add_string_member(object, "sha256", r.sha256);
+    object.addMember("assets", assets_obj);
 
     std::string error;
     if (!write_text_file(r.metadata_path, choc::json::toString(object, true), error)) {

--- a/test/test_model_download.cpp
+++ b/test/test_model_download.cpp
@@ -187,3 +187,43 @@ TEST_CASE("model store: install_model downloads + records, then remove_model del
 
     fs::remove_all(root);
 }
+
+TEST_CASE("model store: install_model fetches every asset of a multi-asset bundle",
+          "[runtime][model][download]") {
+    const fs::path root = fs::temp_directory_path() / "pulp-mm-multiasset";
+    fs::remove_all(root);
+    fs::create_directories(root / "serve");
+    const std::string weights = make_fixture(root / "serve" / "mrt2.mlxfn", 80'000);
+    const std::string state = make_fixture(root / "serve" / "mrt2_state.safetensors", 50'000);
+
+    LocalServer server(root / "serve");
+    const fs::path home = root / "home";
+
+    ModelEntry model{.model_id = "mrt2", .display_name = "MRT2", .backend = "mlx"};
+    model.assets = {
+        ModelAsset{.role = "weights", .checkpoint_ref = server.url("/mrt2.mlxfn")},
+        ModelAsset{.role = "state", .checkpoint_ref = server.url("/mrt2_state.safetensors")},
+    };
+
+    auto inst = install_model(model, "magenta", /*on_progress=*/{}, /*cancel=*/nullptr,
+                              /*headers=*/{}, home);
+    INFO("install error: " << inst.error);
+    REQUIRE(inst.ok);
+
+    // BOTH assets land on disk in the model directory — not just the primary.
+    const fs::path dir = home / "magenta" / "models" / "mrt2";
+    REQUIRE(fs::exists(dir / "mrt2.mlxfn"));
+    REQUIRE(fs::exists(dir / "mrt2_state.safetensors"));
+    REQUIRE(fs::file_size(dir / "mrt2.mlxfn") == weights.size());
+    REQUIRE(fs::file_size(dir / "mrt2_state.safetensors") == state.size());
+
+    // The engine-facing checkpoint path is the first (weights) asset, and the metadata
+    // records every asset by role.
+    REQUIRE(inst.checkpoint_path == dir / "mrt2.mlxfn");
+    std::ifstream meta_in(inst.metadata_path);
+    const std::string meta((std::istreambuf_iterator<char>(meta_in)), std::istreambuf_iterator<char>());
+    REQUIRE(meta.find("\"weights\"") != std::string::npos);
+    REQUIRE(meta.find("\"state\"") != std::string::npos);
+
+    fs::remove_all(root);
+}


### PR DESCRIPTION
`ModelEntry::assets` documents "the downloader fetches all assets", but `install_model` only pulled the primary checkpoint — so a multi-file model (e.g. Magenta's weights + state `.safetensors`) landed half-downloaded and silently failed to load.

Now it downloads **every** asset into the model dir, reports one aggregate 0→100% progress bar across them, records each by role in the metadata, and exposes the first (weights) asset as the engine-facing `checkpoint_path`. Single-checkpoint models are unchanged.

Foundational slice for in-plugin model download (so a DAW-only install can download a working model).

Test: `install_model fetches every asset of a multi-asset bundle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
install_model now downloads every asset in a multi-asset model bundle so installs are complete and models load correctly. It shows one progress bar across all assets and exposes the first asset as the engine-facing checkpoint_path; single-file models are unchanged.

- **New Features**
  - Fetch all assets (e.g., weights and state) into the model directory; fallback to the primary checkpoint if no assets are listed.
  - Aggregate 0–100% progress across all assets.
  - Metadata records each asset with role, path, and sha256; the first asset becomes checkpoint_path.

- **Bug Fixes**
  - Prevent half-installed multi-asset models that previously failed to load silently.

<sup>Written for commit 29259191c65a8383460e3de9c7950c1bd918298e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes `install_model` to download every asset in a multi-file bundle instead of only the primary checkpoint, resolving silent load failures for models like Magenta that ship weights and state files together.

- `model_store.cpp` iterates `ModelEntry::assets` (falling back to the single-checkpoint path), downloads each file sequentially into the model directory, aggregates progress into a single 0→100% bar, writes per-asset metadata, and exposes the first asset as `checkpoint_path`.
- A new `TEST_CASE` spins up a local HTTP server, installs a two-asset bundle, and asserts both files land on disk with correct sizes and that metadata records both roles.
- `ModelAsset::sha256` is never forwarded to the download request — the SHA256 field from each asset struct is silently dropped, so hash verification is skipped for all bundle assets even when the caller has provided expected hashes.
</details>

<h3>Confidence Score: 3/5</h3>

The download loop is structurally correct and the metadata write is atomic with respect to success/failure, but every multi-asset bundle download skips hash verification entirely because the per-asset sha256 is not wired through.

The `ModelAsset::sha256` field is populated by callers that know the expected hash, but the loop always stores `""` for the sha, so `download_file` receives an empty `expected_sha256` for every bundle asset. A corrupted or tampered asset file would be accepted and recorded as valid. The single-asset fallback path correctly passes `model.sha256`, making the omission in the multi-asset branch easy to miss.

core/runtime/src/model_store.cpp — specifically the line that builds the `items` vector for multi-asset bundles.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| core/runtime/src/model_store.cpp | Core multi-asset download logic added — silently drops `ModelAsset::sha256` for all bundle assets, bypassing hash verification; aggregate progress bar regresses for unknown-length responses. |
| test/test_model_download.cpp | New TEST_CASE verifies both files land on disk, sizes match, primary path is correct, and metadata contains both role strings; does not exercise SHA256 or cancellation mid-bundle. |
| CMakeLists.txt | Version bump 0.354.0 → 0.355.0 only. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant install_model
    participant download_file
    participant Disk

    Caller->>install_model: "ModelEntry (assets=[weights, state])"
    install_model->>install_model: "Build items[]<br/>url from checkpoint_ref<br/>sha = "" (should use a.sha256)"

    loop for each asset i of n
        install_model->>download_file: "req{url, dest, expected_sha256=""}<br/>wrapped progress callback"
        download_file-->>install_model: "DownloadResult {ok, sha256, cancelled}"
        install_model->>Disk: file written to models/id/
        Note over install_model: if i==0: primary_path = dest, r.sha256 = dl.sha256
        install_model->>install_model: "append asset obj {role, path, sha256}"
    end

    install_model->>Disk: write metadata JSON
    install_model-->>Caller: "InstallModelResult {ok, checkpoint_path=primary_path}"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: bump versions"](https://github.com/danielraffel/pulp/commit/29259191c65a8383460e3de9c7950c1bd918298e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36046603)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->