### PR TITLE
fix(test): widen child-process test timeouts for self-hosted runner contention

### DIFF
--- a/test/test_ipc.cpp
+++ b/test/test_ipc.cpp
@@ -82,7 +82,7 @@ void wait_for_named_pipe_server_ready(const std::string& pipe_name,
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
 #else
     const auto reply = std::filesystem::path(pipe_name + ".reply");
-    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(20);
     while ((!std::filesystem::exists(pipe_name) || !std::filesystem::exists(reply)) &&
            std::chrono::steady_clock::now() < deadline) {
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -235,7 +235,7 @@ TEST_CASE("IPC named pipe exchanges framed messages without self-consuming",
     REQUIRE(client.send_message("client-to-server"));
     {
         std::unique_lock<std::mutex> lock(mutex);
-        REQUIRE(cv.wait_for(lock, std::chrono::seconds(2), [&] {
+        REQUIRE(cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return server_text == "client-to-server";
         }));
     }
@@ -243,7 +243,7 @@ TEST_CASE("IPC named pipe exchanges framed messages without self-consuming",
     REQUIRE(server.send_message("server-to-client"));
     {
         std::unique_lock<std::mutex> lock(mutex);
-        REQUIRE(cv.wait_for(lock, std::chrono::seconds(2), [&] {
+        REQUIRE(cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return client_text == "server-to-client";
         }));
     }
@@ -296,7 +296,7 @@ TEST_CASE("IPC named pipe observes graceful peer disconnect",
     client.disconnect();
     {
         std::unique_lock<std::mutex> lock(mutex);
-        REQUIRE(cv.wait_for(lock, std::chrono::seconds(2), [&] {
+        REQUIRE(cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return server_disconnected;
         }));
     }
@@ -362,7 +362,7 @@ TEST_CASE("IPC named pipe observes abrupt peer death",
 
     {
         std::unique_lock<std::mutex> lock(mutex);
-        REQUIRE(cv.wait_for(lock, std::chrono::seconds(5), [&] {
+        REQUIRE(cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return ready;
         }));
     }
@@ -372,7 +372,7 @@ TEST_CASE("IPC named pipe observes abrupt peer death",
 
     {
         std::unique_lock<std::mutex> lock(mutex);
-        REQUIRE(cv.wait_for(lock, std::chrono::seconds(5), [&] {
+        REQUIRE(cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return disconnected;
         }));
     }
@@ -445,7 +445,7 @@ TEST_CASE("ConnectedChildProcess reports real child exit code",
 
     {
         std::unique_lock<std::mutex> lock(mutex);
-        REQUIRE(cv.wait_for(lock, std::chrono::seconds(5), [&] {
+        REQUIRE(cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return message == "ready";
         }));
     }
@@ -491,7 +491,7 @@ TEST_CASE("ConnectedChildProcess kill terminates child process",
     REQUIRE(child.launch(fixture, {"--hold-ms", "5000"}));
     {
         std::unique_lock<std::mutex> lock(mutex);
-        REQUIRE(cv.wait_for(lock, std::chrono::seconds(5), [&] { return ready; }));
+        REQUIRE(cv.wait_for(lock, std::chrono::seconds(20), [&] { return ready; }));
     }
 
     REQUIRE(child.is_running());
@@ -521,7 +521,7 @@ TEST_CASE("ConnectedChildProcess concurrent kill joins once",
     REQUIRE(child.launch(fixture, {"--hold-ms", "5000"}));
     {
         std::unique_lock<std::mutex> lock(mutex);
-        REQUIRE(cv.wait_for(lock, std::chrono::seconds(5), [&] { return ready; }));
+        REQUIRE(cv.wait_for(lock, std::chrono::seconds(20), [&] { return ready; }));
     }
 
     std::thread first([&] { child.kill(); });
@@ -553,7 +553,7 @@ TEST_CASE("ConnectedChildProcess can relaunch after async completion",
     REQUIRE(child.launch(fixture, {"--exit-code", "5"}));
     {
         std::unique_lock<std::mutex> lock(mutex);
-        REQUIRE(cv.wait_for(lock, std::chrono::seconds(5), [&] {
+        REQUIRE(cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return exits == 1 && last_exit_code == 5;
         }));
     }
@@ -602,7 +602,7 @@ TEST_CASE("ConnectedChildProcess wait_for_exit is safe from exit callback",
     REQUIRE(child.launch(fixture, {"--exit-code", "32"}));
     {
         std::unique_lock<std::mutex> lock(mutex);
-        REQUIRE(cv.wait_for(lock, std::chrono::seconds(5), [&] {
+        REQUIRE(cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return callback_done;
         }));
     }
@@ -640,7 +640,7 @@ TEST_CASE("ConnectedChildProcess wait_for_exit is safe from message callback kil
     REQUIRE(child.launch(fixture, {"--hold-ms", "5000"}));
     {
         std::unique_lock<std::mutex> lock(mutex);
-        REQUIRE(cv.wait_for(lock, std::chrono::seconds(5), [&] {
+        REQUIRE(cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return callback_done;
         }));
     }
@@ -699,7 +699,7 @@ TEST_CASE("ConnectedChildProcess can relaunch after message callback kill",
     REQUIRE(child.launch(fixture, {"--hold-ms", "5000"}));
     {
         std::unique_lock<std::mutex> lock(mutex);
-        REQUIRE(cv.wait_for(lock, std::chrono::seconds(5), [&] {
+        REQUIRE(cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return callback_done;
         }));
     }
@@ -739,7 +739,7 @@ TEST_CASE("ConnectedChildProcess destructor waits for active message callback",
     REQUIRE(child->launch(fixture, {"--hold-ms", "5000"}));
     {
         std::unique_lock<std::mutex> lock(mutex);
-        REQUIRE(cv.wait_for(lock, std::chrono::seconds(5), [&] {
+        REQUIRE(cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return callback_entered;
         }));
     }
@@ -762,7 +762,7 @@ TEST_CASE("ConnectedChildProcess destructor waits for active message callback",
 
     {
         std::unique_lock<std::mutex> lock(mutex);
-        REQUIRE(cv.wait_for(lock, std::chrono::seconds(5), [&] {
+        REQUIRE(cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return destructor_started;
         }));
         REQUIRE_FALSE(cv.wait_for(lock, std::chrono::milliseconds(100), [&] {
@@ -835,7 +835,7 @@ TEST_CASE("ChildProcessManager wait_all waits for active connected children",
         {
             std::unique_lock<std::mutex> lock(mutex);
             saw_first_before_second_release =
-                cv.wait_for(lock, std::chrono::seconds(5), [&] {
+                cv.wait_for(lock, std::chrono::seconds(20), [&] {
                     return saw_first;
                 });
         }
@@ -894,7 +894,7 @@ TEST_CASE("ChildProcessManager cleanup is safe from exit callback",
 
     {
         std::unique_lock<std::mutex> lock(mutex);
-        REQUIRE(cv.wait_for(lock, std::chrono::seconds(5), [&] {
+        REQUIRE(cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return callback_done;
         }));
     }
@@ -1025,7 +1025,7 @@ TEST_CASE("IPC socket server accepts client and exchanges framed messages",
 
     {
         std::unique_lock<std::mutex> lock(mutex);
-        REQUIRE(cv.wait_for(lock, std::chrono::seconds(2), [&] {
+        REQUIRE(cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return client_connected && accepted_connected;
         }));
     }
@@ -1034,7 +1034,7 @@ TEST_CASE("IPC socket server accepts client and exchanges framed messages",
 
     {
         std::unique_lock<std::mutex> lock(mutex);
-        REQUIRE(cv.wait_for(lock, std::chrono::seconds(2), [&] {
+        REQUIRE(cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return server_received;
         }));
         REQUIRE(server_text == "client-to-server");
@@ -1048,7 +1048,7 @@ TEST_CASE("IPC socket server accepts client and exchanges framed messages",
 
     {
         std::unique_lock<std::mutex> lock(mutex);
-        REQUIRE(cv.wait_for(lock, std::chrono::seconds(2), [&] {
+        REQUIRE(cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return client_received;
         }));
         REQUIRE(client_text == "server-to-client");
@@ -1074,7 +1074,7 @@ TEST_CASE("IPC socket server virtual callback accepts empty frames",
 
     {
         std::unique_lock<std::mutex> lock(server.mutex);
-        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(2), [&] {
+        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return server.accepted != nullptr;
         }));
     }
@@ -1083,7 +1083,7 @@ TEST_CASE("IPC socket server virtual callback accepts empty frames",
 
     {
         std::unique_lock<std::mutex> lock(server.mutex);
-        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(2), [&] {
+        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return server.binary_messages == 1 && server.text_messages == 1;
         }));
         REQUIRE(server.last_binary_size == 0);
@@ -1107,7 +1107,7 @@ TEST_CASE("IPC socket server receives binary payload frames",
 
     {
         std::unique_lock<std::mutex> lock(server.mutex);
-        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(2), [&] {
+        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return server.accepted != nullptr;
         }));
     }
@@ -1117,7 +1117,7 @@ TEST_CASE("IPC socket server receives binary payload frames",
 
     {
         std::unique_lock<std::mutex> lock(server.mutex);
-        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(2), [&] {
+        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return server.binary_messages == 1 && server.text_messages == 1;
         }));
         REQUIRE(server.last_binary_size == payload.size());
@@ -1141,7 +1141,7 @@ TEST_CASE("IPC socket server observes client disconnect",
 
     {
         std::unique_lock<std::mutex> lock(server.mutex);
-        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(2), [&] {
+        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return server.accepted != nullptr;
         }));
     }
@@ -1149,7 +1149,7 @@ TEST_CASE("IPC socket server observes client disconnect",
     client.disconnect();
     {
         std::unique_lock<std::mutex> lock(server.mutex);
-        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(2), [&] {
+        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return server.disconnects == 1;
         }));
     }
@@ -1172,7 +1172,7 @@ TEST_CASE("IPC socket client reports disconnect callback once",
 
     {
         std::unique_lock<std::mutex> lock(server.mutex);
-        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(2), [&] {
+        REQUIRE(server.cv.wait_for(lock, std::chrono::seconds(20), [&] {
             return server.accepted != nullptr;
         }));
     }

--- a/test/test_isolated_scanner.cpp
+++ b/test/test_isolated_scanner.cpp
@@ -75,7 +75,7 @@ TEST_CASE("IsolatedPluginScanner returns Ok for a parseable VST3 bundle",
     fs::create_directories(bundle / "Contents" / "Resources");
 
     IsolatedPluginScanner scanner{PULP_ISOLATED_SCANNER_REAL_WORKER};
-    auto result = scanner.scan(bundle.string(), /*timeout_ms=*/5000);
+    auto result = scanner.scan(bundle.string(), /*timeout_ms=*/30000);
 
     REQUIRE(result.status == ScanStatus::Ok);
     REQUIRE(result.descriptor.has_value());
@@ -92,7 +92,7 @@ TEST_CASE("IsolatedPluginScanner returns FormatError for an unknown extension",
     write_file(file, "this is not a plugin");
 
     IsolatedPluginScanner scanner{PULP_ISOLATED_SCANNER_REAL_WORKER};
-    auto result = scanner.scan(file.string(), /*timeout_ms=*/5000);
+    auto result = scanner.scan(file.string(), /*timeout_ms=*/30000);
 
     REQUIRE(result.status == ScanStatus::FormatError);
     REQUIRE(result.exit_code == 3);
@@ -142,12 +142,12 @@ TEST_CASE("pulp-scan-worker preserves requested-alias identity for symlinks",
 
     IsolatedPluginScanner scanner{PULP_ISOLATED_SCANNER_REAL_WORKER};
 
-    auto real_result = scanner.scan(real_bundle.string(), /*timeout_ms=*/5000);
+    auto real_result = scanner.scan(real_bundle.string(), /*timeout_ms=*/30000);
     REQUIRE(real_result.status == ScanStatus::Ok);
     REQUIRE(real_result.descriptor.has_value());
     REQUIRE(real_result.descriptor->path == real_bundle.string());
 
-    auto alias_result = scanner.scan(alias_bundle.string(), /*timeout_ms=*/5000);
+    auto alias_result = scanner.scan(alias_bundle.string(), /*timeout_ms=*/30000);
     REQUIRE(alias_result.status == ScanStatus::Ok);
     REQUIRE(alias_result.descriptor.has_value());
     REQUIRE(alias_result.descriptor->path == alias_bundle.string());
@@ -158,7 +158,7 @@ TEST_CASE("pulp-scan-worker preserves requested-alias identity for symlinks",
 TEST_CASE("IsolatedPluginScanner classifies a worker SIGSEGV as Crash",
           "[host][isolated-scanner][item-4.1][crash]") {
     IsolatedPluginScanner scanner{PULP_ISOLATED_SCANNER_CRASH_HELPER};
-    auto result = scanner.scan("crash", /*timeout_ms=*/5000);
+    auto result = scanner.scan("crash", /*timeout_ms=*/30000);
 
     REQUIRE(result.status == ScanStatus::Crash);
     REQUIRE_FALSE(result.descriptor.has_value());
@@ -181,7 +181,7 @@ TEST_CASE("IsolatedPluginScanner classifies a hung worker as Timeout",
 TEST_CASE("IsolatedPluginScanner classifies unparseable worker output as Crash",
           "[host][isolated-scanner][item-4.1][crash]") {
     IsolatedPluginScanner scanner{PULP_ISOLATED_SCANNER_CRASH_HELPER};
-    auto result = scanner.scan("garbage", /*timeout_ms=*/5000);
+    auto result = scanner.scan("garbage", /*timeout_ms=*/30000);
 
     // exit 0 + non-JSON stdout — we don't trust that and report Crash.
     REQUIRE(result.status == ScanStatus::Crash);
@@ -192,7 +192,7 @@ TEST_CASE("IsolatedPluginScanner classifies unparseable worker output as Crash",
 TEST_CASE("IsolatedPluginScanner returns NotPlugin when worker exits clean with no output",
           "[host][isolated-scanner][item-4.1]") {
     IsolatedPluginScanner scanner{PULP_ISOLATED_SCANNER_CRASH_HELPER};
-    auto result = scanner.scan("silent", /*timeout_ms=*/5000);
+    auto result = scanner.scan("silent", /*timeout_ms=*/30000);
 
     REQUIRE(result.status == ScanStatus::NotPlugin);
     REQUIRE_FALSE(result.descriptor.has_value());


### PR DESCRIPTION
## Problem
The `macos` required gate has been flaking across **every open PR** (#3481, #3485, #3486, #3459). Root cause: `IsolatedPluginScanner` and `ConnectedChildProcess` tests pass an **app-level timeout** to `scanner.scan()` (5s) / `cv.wait_for()` (2–5s). The self-hosted macOS pool runs **3 runners on one physical Mac**, so concurrent PR builds oversubscribe the box → child-process spawn+parse exceeds those windows → scan returns `Timeout` / cv wait expires → assertion fails → ctest **exit 8**.

Confirmed environmental: these tests pass **19/19 in ~1.5s locally**; they only fail under runner contention.

## Fix
Widen the *success-wait* bounds (they're all "wait up to N for success", so larger N only adds headroom and cannot change pass/fail semantics for correct code):
- `test_isolated_scanner.cpp`: happy-path scans 5s → 30s (the intentional **250ms** hung-worker→Timeout and **1000ms** missing-worker cases are left as-is)
- `test_ipc.cpp`: all `REQUIRE(cv.wait_for(... success))` waits 2s/5s → 20s

## Why merge this first
Self-applying — this PR's own macOS run uses the widened timeouts, so it greens under load. Once merged, the other open PRs rebase onto it and inherit the robustness, unblocking the gate for all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widened child-process and IPC test timeouts to handle self-hosted macOS runner contention, eliminating flaky timeouts in the required macOS gate. Only increases success-wait bounds; test semantics unchanged.

- **Bug Fixes**
  - test_isolated_scanner.cpp: scan timeouts 5s → 30s across Ok/FormatError/Crash/NotPlugin paths; intentional 250ms (hung) and 1000ms (missing worker) cases unchanged.
  - test_ipc.cpp: named-pipe readiness and all condition-variable waits 2–5s → 20s across named pipe, socket, ConnectedChildProcess, and manager tests.

<sup>Written for commit 9366403214cbcfb484ee7b8918a69b0fe27c7cbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Widens success-path wait bounds in two test files to prevent flaky timeouts on the oversubscribed self-hosted macOS runner pool. No semantics change: all intentional failure-condition timeouts (250 ms hung-worker, 100 ms negative `wait_for`, 1 000 ms missing-worker) are preserved.

- **`test_ipc.cpp`**: Seventeen `cv.wait_for` success waits and the named-pipe server-ready deadline increased from 2–5 s to 20 s.
- **`test_isolated_scanner.cpp`**: Eight `scanner.scan()` happy-path calls increased from 5 000 ms to 30 000 ms; intentional `Timeout`/failure cases unchanged.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — only timeout constants in test files are changed, with no risk to production code or test correctness.

Both files touch only wait-bound constants for success paths. Intentional failure timeouts (the 250 ms hung-worker, 100 ms negative REQUIRE_FALSE, and 1 000 ms missing-worker cases) are confirmed untouched in the diff, so test semantics are fully preserved. There is no production code in the changeset.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| test/test_ipc.cpp | All success-path cv.wait_for calls (and the named-pipe server-ready helper deadline) widened from 2–5 s to 20 s; intentional negative checks (e.g., the 100 ms REQUIRE_FALSE wait) are untouched. |
| test/test_isolated_scanner.cpp | Happy-path scanner.scan() timeouts widened from 5 000 ms to 30 000 ms; the intentional hung-worker (250 ms) and missing-worker (1 000 ms) failure cases are left unchanged. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Test starts] --> B{Is this a success-path wait?}
    B -- Yes --> C["wait_for up to 20s (was 2–5s)\nor scan() up to 30s (was 5s)"]
    C --> D{Event arrives?}
    D -- Yes, quickly --> E[Test passes ✓]
    D -- No, timeout --> F[Test fails ✗]
    B -- No, intentional failure case --> G["Keep original short timeout\n(250ms / 100ms / 1000ms)"]
    G --> H{Timeout fires as expected?}
    H -- Yes --> I[Test passes ✓ – correct Timeout/Crash result]
    H -- No --> J[Test fails ✗]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): widen child-process test time..."](https://github.com/danielraffel/pulp/commit/9366403214cbcfb484ee7b8918a69b0fe27c7cbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36047449)</sub>

<!-- /greptile_comment -->