### PR TITLE
feat(view): GPU plugin-view embedding hardening

### DIFF
--- a/.agents/skills/ios/SKILL.md
+++ b/.agents/skills/ios/SKILL.md
@@ -321,6 +321,16 @@ xcodebuild test -project ... -scheme AUv3Tests -sdk iphonesimulator
 - **Detach on close** — plugin-editor child views must be explicitly detached
   in `on_view_closed()`/destructors just like standalone window-hosted child
   views; the host clears propagated references when subtrees are removed.
+- **Gate `notify_attached()` on `is_attached()`, never assume attach
+  succeeded** — `PluginViewHost` exposes `is_attached() const noexcept` and
+  `[[nodiscard]] try_attach_to_parent(...)`. The iOS hosts override
+  `is_attached()` with the truthful native check (`view_.superview != nil`,
+  and `metal_view_.superview != nil` for the GPU host). A foreign or
+  AUv3 embedder must call `try_attach_to_parent()` (or check `is_attached()`
+  after `attach_to_parent()`) before firing `ViewBridge::notify_attached()` —
+  firing it when the parent rejected the view leaves the editor open/close
+  lifecycle unbalanced. The base default is conservative (`false`), so a host
+  that has not opted in never reports a phantom attach. Query on the UI thread.
 - **Standalone `WindowHost` now reports live content bounds on iOS** —
   `window_host_ios.mm` exposes `WindowHost::get_content_size()` and
   `set_resize_callback(...)` on both the CPU and Metal hosts, driven from

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.188.1",
+      "version": "0.188.2",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.188.1"
+  "version": "0.188.2"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.188.1",
+  "version": "0.188.2",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.360.2
+    VERSION 0.361.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/plugin_view_host.hpp
+++ b/core/view/include/pulp/view/plugin_view_host.hpp
@@ -66,6 +66,25 @@ public:
     // Attach this view to a parent native view (the DAW's editor window)
     virtual void attach_to_parent(NativeViewHandle parent) = 0;
 
+    // Attempt to attach to `parent` and report whether this host ended up
+    // attached. The default composes the existing `attach_to_parent()` command
+    // with the `is_attached()` query, so every host gets a success signal for
+    // free; a host can override to report a more precise outcome. Foreign-host
+    // embedders (the flat-C embedding SDK) use this to decide whether to fire
+    // `ViewBridge::notify_attached()` — they must NOT fire it when attach failed,
+    // or the editor open/close lifecycle goes unbalanced. Call on the UI thread.
+    [[nodiscard]] virtual bool try_attach_to_parent(NativeViewHandle parent) {
+        attach_to_parent(parent);
+        return is_attached();
+    }
+
+    // True when this host's native view is currently parented (i.e. attach
+    // succeeded and detach has not run). Default is conservative: a host that
+    // has not opted into attachment observability reports false, so callers
+    // never treat an unknown host as attached. Apple hosts override this to
+    // reflect the real native view-hierarchy state. Query on the UI thread.
+    virtual bool is_attached() const noexcept { return false; }
+
     // Detach from parent
     virtual void detach() = 0;
 

--- a/core/view/platform/ios/plugin_view_host_ios.mm
+++ b/core/view/platform/ios/plugin_view_host_ios.mm
@@ -254,6 +254,10 @@ public:
         }
     }
 
+    bool is_attached() const noexcept override {
+        return view_ != nil && view_.superview != nil;
+    }
+
     void detach() override {
         @autoreleasepool {
             if (view_) {
@@ -667,6 +671,10 @@ public:
                 needs_repaint_.store(true, std::memory_order_relaxed);
             }
         }
+    }
+
+    bool is_attached() const noexcept override {
+        return metal_view_ != nil && metal_view_.superview != nil;
     }
 
     void detach() override {

--- a/core/view/platform/mac/plugin_view_host_mac.mm
+++ b/core/view/platform/mac/plugin_view_host_mac.mm
@@ -10,8 +10,10 @@
 #include <pulp/view/window_host.hpp>  // compute_design_viewport_transform
 #import <Cocoa/Cocoa.h>
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <cstdio>
+#include <cstdlib>
 #include <exception>
 
 #include <functional>
@@ -683,29 +685,77 @@ private:
 - (instancetype)initWithFrame:(NSRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
-        self.wantsLayer = YES;
         // Follow the host's editor-container resize. AU v2 hosts (and VST3/CLAP
         // when they resize the parent) move our frame; flexible autoresizing
         // makes -setFrameSize: fire, which resizes the surfaces + relays out.
         self.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
-        CAMetalLayer* layer = [CAMetalLayer layer];
-        layer.device = MTLCreateSystemDefaultDevice();
-        layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
-        // framebufferOnly = NO so the embedded back buffer can be read back
-        // for headless capture (`capture_back_buffer_png`) — matches the
-        // standalone MacGpuWindowHost. (Plugin host previously set YES,
-        // which blocked readback.)
-        layer.framebufferOnly = NO;
-        CGFloat scale = self.window ? self.window.backingScaleFactor
-                                    : [NSScreen mainScreen].backingScaleFactor;
-        layer.contentsScale = scale;
-        layer.drawableSize = CGSizeMake(frame.size.width * scale, frame.size.height * scale);
-        layer.opaque = YES;
-        self.layer = layer;
-        _metalLayer = layer;
+
+        // BLACK-SCREEN ROOT CAUSE (pulp foreign-host-embed): a foreign DAW host
+        // that embeds us via juce::NSViewComponent adds our NSView as a subview
+        // of *its own* layer-backed content view. Per Apple's NSView docs,
+        // "Creating a layer-backed view implicitly causes the entire view
+        // hierarchy under that view to become layer-backed." So AppKit forces
+        // THIS view layer-backed and — if we merely assign `self.layer` in init
+        // — wraps our content in an AppKit-owned `NSViewBackingLayer` and demotes
+        // our CAMetalLayer to a *sublayer*. Dawn presents into the CAMetalLayer
+        // every vsync (the GPU renders correct, non-black frames — proven via
+        // the env-gated live-stat readback), but the demoted sublayer's
+        // presented drawable is not what the window server composites → the
+        // editor stays BLACK on screen while headless capture looks perfect.
+        //
+        // The robust fix is to make our CAMetalLayer the view's genuine BACKING
+        // layer by returning it from -makeBackingLayer (the documented hook
+        // AppKit calls to create the backing layer). This survives forced
+        // layer-backing under any foreign parent: our CAMetalLayer IS the
+        // backing layer, never a wrapped sublayer. This is the same mechanism
+        // JUCE itself uses for its Metal peer. Trigger it now by requesting
+        // layer-backing; AppKit calls -makeBackingLayer synchronously.
+        self.wantsLayer = YES;
     }
     return self;
 }
+
+// AppKit calls this to create the view's backing layer (on first
+// `wantsLayer = YES`, and again if the view is forced layer-backed by a
+// layer-backed ancestor). Returning our configured CAMetalLayer guarantees it
+// is the view's real backing layer in every embedding, not a demoted sublayer.
+- (CALayer*)makeBackingLayer {
+    CAMetalLayer* layer = [CAMetalLayer layer];
+    layer.device = MTLCreateSystemDefaultDevice();
+    layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+    // framebufferOnly = NO so the embedded back buffer can be read back for
+    // headless capture (`capture_back_buffer_png`) — matches MacGpuWindowHost.
+    layer.framebufferOnly = NO;
+    CGFloat scale = self.window ? self.window.backingScaleFactor
+                                : [NSScreen mainScreen].backingScaleFactor;
+    layer.contentsScale = scale;
+    layer.drawableSize = CGSizeMake(self.bounds.size.width * scale,
+                                    self.bounds.size.height * scale);
+
+    // pulp #1382 — opaque + seeded dark background (RGB 30,30,46 = 0x1E1E2E),
+    // mirroring the standalone PulpMetalView, so there is no clear/undefined
+    // composite while the foreign host reparents and relayers the view.
+    layer.opaque = YES;
+    const CGFloat dark[4] = { 30.0 / 255.0, 30.0 / 255.0, 46.0 / 255.0, 1.0 };
+    CGColorSpaceRef cs = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
+    layer.backgroundColor = CGColorCreate(cs, dark);
+    CGColorSpaceRelease(cs);
+
+    _metalLayer = layer;
+    return layer;
+}
+
+// pulp #1382 — `wantsUpdateLayer = YES` puts AppKit on the layer-update path
+// (calls -updateLayer instead of -drawRect:) and stops it from auto-clearing
+// the backing layer between updates, so the most-recent Metal frame stays
+// presented until the next display-link tick. Matches PulpMetalView.
+- (BOOL)wantsUpdateLayer { return YES; }
+
+// No-op: Metal frames are produced by MacGpuPluginViewHost::render_frame off
+// the display link, NOT inside AppKit's update cycle. We only need these to
+// exist so AppKit honors wantsUpdateLayer and skips its own paint pipeline.
+- (void)updateLayer {}
+- (void)drawRect:(NSRect)dirtyRect { (void)dirtyRect; }
 
 - (BOOL)isFlipped { return NO; }
 
@@ -972,6 +1022,7 @@ private:
     // teardown is a no-op (DAW teardown order is not under our control).
     std::shared_ptr<std::atomic<bool>> alive_;
     int frame_ok_count_ = 0;
+    int display_link_ticks_ = 0;  // env-gated diagnostic counter only
     // Design viewport: when (>0, >0) root paints at design size and the
     // Skia canvas applies translate+scale to fit the host bounds. Mouse
     // coords are inverse-mapped via window_to_root_point().
@@ -1098,7 +1149,75 @@ private:
             view_needs_continuous_frames(&root_) || frame_clock_.has_active_subscribers(),
             std::memory_order_relaxed);
 
-        skia_surface_->end_frame();
+        // PULP_EMBED_GPU_FRAME_STAT — env-gated LIVE display-link present-path
+        // pixel proof (NOT the forced capture path). Every Nth on-screen frame,
+        // flush the Graphite recording and read the back buffer back, then log a
+        // coarse luma / non-black stat. This proves the live present cadence is
+        // emitting real, non-black content frame after frame — impossible to
+        // confirm with screencapture in a permission-blocked env. Off by default;
+        // costs a full GPU readback on the sampled frames only.
+        static const int kStatEvery = [] {
+            if (const char* e = std::getenv("PULP_EMBED_GPU_FRAME_STAT")) {
+                int n = std::atoi(e);
+                return n > 0 ? n : 30;
+            }
+            return 0;
+        }();
+        // Once-per-run on-screen geometry/visibility proof. A foreign host that
+        // embeds us can leave the view at 0x0 (its NSViewComponent wrapper is
+        // never sized) or relayer it so the CAMetalLayer is no longer the view's
+        // backing layer — both render the editor black even though the GPU emits
+        // perfect frames. view_size > 0, not hidden, backing==metal confirms the
+        // full on-screen compositing chain is intact (the thing screencapture
+        // would otherwise verify).
+        if (kStatEvery > 0 && !capture_pixels && frame_ok_count_ == 5) {
+            CAMetalLayer* ml = metal_view_.metalLayer;
+            CALayer* backing = metal_view_.layer;
+            NSRect inWin = [metal_view_ convertRect:metal_view_.bounds toView:nil];
+            fprintf(stderr,
+                    "[plugin-gpu-host][onscreen] view_size=%.0fx%.0f "
+                    "frame_in_window=(%.0f,%.0f %.0fx%.0f) backing_is_metal=%d "
+                    "hidden=%d alpha=%.2f has_window=%d\n",
+                    metal_view_.bounds.size.width, metal_view_.bounds.size.height,
+                    inWin.origin.x, inWin.origin.y, inWin.size.width, inWin.size.height,
+                    (backing == ml) ? 1 : 0,
+                    metal_view_.hidden ? 1 : 0,
+                    (double)metal_view_.alphaValue,
+                    metal_view_.window != nil ? 1 : 0);
+        }
+        if (kStatEvery > 0 && !capture_pixels &&
+            (frame_ok_count_ % kStatEvery) == 1) {
+            std::vector<uint8_t> px;
+            uint32_t pw = 0, ph = 0;
+            // read_current_rgba() snaps + submits the in-progress Graphite
+            // recording itself before reading, so the readback sees the painted
+            // frame rather than a blank/cleared backing.
+            if (skia_surface_->read_current_rgba(px, pw, ph) && !px.empty()) {
+                double luma_sum = 0.0;
+                size_t non_black = 0;
+                size_t n = static_cast<size_t>(pw) * ph;
+                // Coarse unique-color estimate via a small bucketed signature
+                // set (top 3 bits per channel → 512 buckets).
+                std::array<bool, 512> seen{};
+                size_t unique = 0;
+                for (size_t i = 0; i < n; ++i) {
+                    uint8_t r = px[i * 4 + 0], g = px[i * 4 + 1], b = px[i * 4 + 2];
+                    double l = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+                    luma_sum += l;
+                    if (r > 8 || g > 8 || b > 8) ++non_black;
+                    int bucket = ((r >> 5) << 6) | ((g >> 5) << 3) | (b >> 5);
+                    if (!seen[bucket]) { seen[bucket] = true; ++unique; }
+                }
+                fprintf(stderr,
+                        "[plugin-gpu-host][live-stat] frame=%d size=%ux%u "
+                        "mean_luma=%.1f non_black=%.1f%% color_buckets=%zu\n",
+                        frame_ok_count_, pw, ph,
+                        luma_sum / static_cast<double>(n),
+                        100.0 * static_cast<double>(non_black) /
+                            static_cast<double>(n),
+                        unique);
+            }
+        }
 
         bool captured = true;
         if (capture_pixels && capture_width && capture_height) {
@@ -1107,6 +1226,7 @@ private:
                                                         *capture_height);
         }
 
+        skia_surface_->end_frame();
         gpu_surface_->end_frame();
 
         needs_repaint_.store(continuous_frames_.load(std::memory_order_relaxed),
@@ -1123,6 +1243,19 @@ private:
         // races this callback.
         auto alive = self->alive_;
         if (!alive->load(std::memory_order_acquire)) return kCVReturnSuccess;
+
+        // PULP_EMBED_GPU_FRAME_STAT — env-gated proof that the CVDisplayLink is
+        // actually ticking in the embedded case. Logs every ~120 vsyncs.
+        if (std::getenv("PULP_EMBED_GPU_FRAME_STAT")) {
+            int n = ++self->display_link_ticks_;
+            if (n == 1 || (n % 120) == 0) {
+                fprintf(stderr, "[plugin-gpu-host][dl] display-link tick=%d "
+                                "needs_repaint=%d continuous=%d\n",
+                        n,
+                        self->needs_repaint_.load(std::memory_order_relaxed) ? 1 : 0,
+                        self->continuous_frames_.load(std::memory_order_relaxed) ? 1 : 0);
+            }
+        }
 
         const bool has_idle = self->has_idle_callback_.load(std::memory_order_acquire);
         if (self->needs_repaint_.load(std::memory_order_relaxed) ||

--- a/core/view/platform/mac/plugin_view_host_mac.mm
+++ b/core/view/platform/mac/plugin_view_host_mac.mm
@@ -503,6 +503,13 @@ public:
         }
     }
 
+    bool is_attached() const noexcept override {
+        // Truthful native check: the view is parented iff it sits in a view
+        // hierarchy. `attach_to_parent` only ever adds `view_` to the supplied
+        // parent, so a non-nil superview means the attach took.
+        return view_ != nil && view_.superview != nil;
+    }
+
     void detach() override {
         @autoreleasepool {
             if (view_) {
@@ -807,6 +814,10 @@ public:
                 needs_repaint_.store(true, std::memory_order_relaxed);
             }
         }
+    }
+
+    bool is_attached() const noexcept override {
+        return metal_view_ != nil && metal_view_.superview != nil;
     }
 
     void detach() override {

--- a/test/test_plugin_editor_host_smoke_mac.mm
+++ b/test/test_plugin_editor_host_smoke_mac.mm
@@ -149,7 +149,11 @@ TEST_CASE("embedded GPU plugin host attaches + paints first frame (mac)",
         }
 
         host->set_idle_callback(format::make_scripted_idle_pump(bridge));
-        host->attach_to_parent((__bridge void*)window.contentView);
+        // Attach seam: a real parent must report attached so a foreign embedder
+        // knows it is safe to fire notify_attached().
+        REQUIRE_FALSE(host->is_attached());
+        REQUIRE(host->try_attach_to_parent((__bridge void*)window.contentView));
+        REQUIRE(host->is_attached());
         bridge.notify_attached();
         smoke::pump_run_loop(5);
 
@@ -167,6 +171,7 @@ TEST_CASE("embedded GPU plugin host attaches + paints first frame (mac)",
         REQUIRE(smoke::looks_like_png(png2));
 
         host->detach();
+        REQUIRE_FALSE(host->is_attached());
         host.reset();
         bridge.close();
         [window close];

--- a/test/test_view_host_bridge.cpp
+++ b/test/test_view_host_bridge.cpp
@@ -142,6 +142,27 @@ private:
     bool attached_ = false;
 };
 
+// Host that opts into attachment observability (is_attached) the way the real
+// Apple hosts do: attach succeeds only for a non-null parent, and is_attached()
+// reflects the live parent. Used to exercise the try_attach_to_parent() seam.
+class AttachAwarePluginViewHost final : public PluginViewHost {
+public:
+    NativeViewHandle native_handle() override { return &sentinel_; }
+    void attach_to_parent(NativeViewHandle parent) override {
+        if (parent) parent_ = parent;  // mirror real hosts: null parent no-ops
+    }
+    bool is_attached() const noexcept override { return parent_ != nullptr; }
+    void detach() override { parent_ = nullptr; }
+    void repaint() override {}
+    void set_size(uint32_t w, uint32_t h) override { size_ = {w, h}; }
+    Size get_size() const override { return size_; }
+
+private:
+    int sentinel_ = 0;
+    NativeViewHandle parent_ = nullptr;
+    Size size_{400, 300};
+};
+
 } // namespace
 
 TEST_CASE("View host bridges: registration APIs are safe on all platforms",
@@ -204,6 +225,38 @@ TEST_CASE("Host child embedding contract is implementable by concrete hosts",
     REQUIRE(plugin_host.bounds().height == 16.0f);
     plugin_host.detach_native_child_view(plugin_child);
     REQUIRE_FALSE(plugin_host.attached());
+}
+
+TEST_CASE("PluginViewHost attach seam: try_attach_to_parent + is_attached",
+          "[view][hosts][embed]") {
+    SECTION("default base contract is conservative (reports not-attached)") {
+        // A host that has not opted into attachment observability must report
+        // false so foreign embedders never fire notify_attached() blindly.
+        EmbeddingPluginViewHost host;  // overrides attach_to_parent, not is_attached
+        int parent_sentinel = 0;
+        REQUIRE_FALSE(host.is_attached());
+        REQUIRE_FALSE(host.try_attach_to_parent(
+            static_cast<NativeViewHandle>(&parent_sentinel)));
+        REQUIRE_FALSE(host.is_attached());
+    }
+
+    SECTION("attachment-aware host reports success and tracks detach") {
+        AttachAwarePluginViewHost host;
+        int parent_sentinel = 0;
+        auto parent = static_cast<NativeViewHandle>(&parent_sentinel);
+
+        REQUIRE_FALSE(host.is_attached());
+        // A null parent must not report attached (matches Apple host no-op).
+        REQUIRE_FALSE(host.try_attach_to_parent(nullptr));
+        REQUIRE_FALSE(host.is_attached());
+
+        // A real parent attaches and is observable.
+        REQUIRE(host.try_attach_to_parent(parent));
+        REQUIRE(host.is_attached());
+
+        host.detach();
+        REQUIRE_FALSE(host.is_attached());
+    }
 }
 
 TEST_CASE("InspectorWindow show is safe when host creation returns nullptr",


### PR DESCRIPTION
## What

Generalized GPU plugin-view embedding hardening, extracted from the foreign-host embedding experiment (`explore/foreign-host-embed`). Two independent, complementary fixes:

1. **`feat(view)`: PluginViewHost attach-observability seam** — adds a non-breaking lifecycle seam so a caller can learn whether attaching the host's native view to a foreign parent actually succeeded:
   - `is_attached() const noexcept` — default `false`; Apple (mac + iOS) hosts override with the truthful native check (`view.superview != nil`).
   - `[[nodiscard]] try_attach_to_parent(...)` — composes the existing `attach_to_parent()` command with `is_attached()` and returns the outcome.
   - `attach_to_parent()` keeps its `void` signature, so every existing in-tree and out-of-tree host/override/caller compiles unchanged. A foreign-host embedder gates `ViewBridge::notify_attached()` on a real attach to keep the editor open/close lifecycle balanced.

2. **`fix(view)`: make the GPU plugin view a real layer-hosting Metal view under a foreign parent** — overrides `-makeBackingLayer` to return the configured `CAMetalLayer` so it is the view's genuine backing layer in every embedding, not a demoted sublayer. A foreign DAW host (e.g. `juce::NSViewComponent`) forces our view layer-backed; without this, AppKit wraps our content in an `NSViewBackingLayer` and demotes the `CAMetalLayer` to a sublayer whose presented drawable the window server does not composite — the editor renders black on screen while headless capture looks perfect. Mirrors the standalone `PulpMetalView` mechanism (`wantsLayer`, `wantsUpdateLayer`, opaque seeded dark background). Includes an env-gated (`PULP_EMBED_GPU_FRAME_STAT`, off by default) live-present-path pixel/geometry proof for debugging foreign embeds.

## Reconciliation with current `main`

The experiment branch also carried a `flush(recording)-before-readback` render fix. **`main` has since independently fixed the same blank-readback bug inside `SkiaSurface::read_current_rgba()`** (it snaps + submits the in-progress Graphite recording before reading). The redundant public `flush_recording()` seam from the experiment is therefore intentionally **dropped** from this PR — callers just use `read_current_rgba()`, which already flushes. (Confirmed via Codex review.)

## Tests

- `pulp-test-view-host-bridge` — headless attach-observability contract (default + attachment-aware fakes); my added `*attach*` cases pass (9 assertions).
- `pulp-test-plugin-editor-host-smoke-mac` — real macOS GPU attach + nonblank first-frame capture through the makeBackingLayer path: **all passed (51 assertions, 3 cases)**.

Pre-existing, unrelated flake: `test_view_host_bridge_mac.mm`'s "deferred click cancelled when bridge/engine torn down first" SIGSEGVs only when run in-suite (passes 3/3 in isolation); not touched by this PR.

## Gates

skill-sync ✓ (ios SKILL.md gotcha added), version-bump ✓ (SDK minor 0.356.0→0.357.0, plugin patch 0.187.0→0.187.1), node-ABI ✓, deps-audit ✓. Diff-cover: substantive changed source is in the native `plugin_view_host_mac.mm` exclusion + the header seam covered by the passing cross-platform test.

Draft — leaving open for review + CI. Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens GPU plugin-view embedding on macOS and iOS. Adds attach observability to `PluginViewHost` and makes the macOS GPU view a true layer-hosting `CAMetalLayer` to prevent black screens under layer-backed parents.

- **New Features**
  - `PluginViewHost`: `is_attached() const noexcept` (defaults to false) and `try_attach_to_parent(...)`.
  - Apple hosts (macOS/iOS) override `is_attached()` with the native check (`view_.superview != nil`, `metal_view_.superview != nil`).
  - Embedders should gate `ViewBridge::notify_attached()` on a true attach.

- **Bug Fixes**
  - macOS: GPU view now returns its `CAMetalLayer` from `-makeBackingLayer`, sets `wantsUpdateLayer`, and uses an opaque seeded background; fixes black screens under layer-backed parents (e.g. `juce::NSViewComponent`).
  - Env-gated live-present diagnostics `PULP_EMBED_GPU_FRAME_STAT` (display-link ticks, geometry, and sampled luma) to verify on-screen presents.
  - Dropped the experimental flush seam; `read_current_rgba()` already flushes.

<sup>Written for commit 37a986e98c87a684bcc603354f7605c2b408ae61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

