### PR TITLE
fix(install): ship Skia static libs in the installed SDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.360.1
+    VERSION 0.360.2
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/tools/cmake/PulpInstallRules.cmake
+++ b/tools/cmake/PulpInstallRules.cmake
@@ -401,7 +401,17 @@ if(PULP_HAS_WEBGPU AND DEFINED WEBGPU_RUNTIME_LIB AND TARGET webgpu)
 endif()
 
 if(PULP_HAS_SKIA)
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/external/skia-build"
-        DESTINATION external
-    )
+    # Ship the Skia tree the build actually linked against — including the
+    # prebuilt static libs (build/<plat>-gpu/lib/Release/*.a) consumers need to
+    # link Pulp::view/render. FindSkia sets SKIA_DIR to the in-tree default on a
+    # normal checkout, or to an out-of-tree cache when -DSKIA_DIR/$SKIA_DIR is
+    # used (e.g. a worktree whose external/skia-build holds only headers). Using
+    # the resolved SKIA_DIR makes the installed SDK self-contained either way.
+    if(SKIA_DIR AND EXISTS "${SKIA_DIR}")
+        install(DIRECTORY "${SKIA_DIR}/" DESTINATION external/skia-build)
+    else()
+        install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/external/skia-build"
+            DESTINATION external
+        )
+    endif()
 endif()


### PR DESCRIPTION
## What

`fix(install): ship Skia static libs in the installed SDK` — generalized extract from the foreign-host embedding experiment (`explore/foreign-host-embed`).

The install rule previously installed `${CMAKE_CURRENT_SOURCE_DIR}/external/skia-build`, which on a fresh worktree (or any build that linked Skia from an out-of-tree cache via `-DSKIA_DIR` / `$SKIA_DIR`) holds only headers — no `build/<plat>-gpu/lib/Release/*.a`. Consumers then failed `find_package(Pulp)` with `target skia::skia not found`.

This installs the Skia tree the build **actually linked against**: `FindSkia` resolves `SKIA_DIR` (in-tree default on a normal checkout, or the out-of-tree cache when overridden), so the installed SDK is self-contained and linkable either way. No change for a normal in-tree checkout (the `else` branch preserves the old behavior when `SKIA_DIR` is unset).

```cmake
if(SKIA_DIR AND EXISTS "${SKIA_DIR}")
    install(DIRECTORY "${SKIA_DIR}/" DESTINATION external/skia-build)
else()
    install(DIRECTORY ".../external/skia-build" DESTINATION external)
endif()
```

## Verification

In the experiment, an external repo (`pulp-view-embed`) `find_package(Pulp CONFIG)`s the installed SDK and links `Pulp::view` + `skia::skia` into a working binary. CMake-only change; configure validated with `SKIA_DIR` set.

## Gates

skill-sync ✓ (no mapped paths). version-bump ✓ — `tools/cmake/**` is not a versioned SDK trigger path, but this is a consumer-reachable install fix, so per the stranded-fix policy it carries a manual SDK patch bump (0.356.0 → 0.356.1) + `chore: bump versions` marker. node-ABI ✓, deps-audit ✓.

Draft — leaving open for review + CI. Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ship Skia static libs with the installed SDK by installing the Skia tree the build actually linked against (`SKIA_DIR` when set). Fixes `find_package(Pulp)` failures and makes the SDK self-contained; version bumped to 0.360.2.

- **Bug Fixes**
  - If `SKIA_DIR` exists, install `${SKIA_DIR}/` to `external/skia-build`; otherwise install from in-tree `external/skia-build` to `external/`. Ensures required static `.a` libs are included.
  - Verified an external consumer can `find_package(Pulp)` and link `Pulp::view` + `skia::skia`. No change for normal in-tree checkouts.

<sup>Written for commit 4b71d1470af836c5007037efffd0a0057e6cf954. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

