### PR TITLE
test(import-design): revive cli-import-design suite + guard the baked figma-plugin lane

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5287,6 +5287,12 @@ target_compile_definitions(pulp-test-cli-import-design PRIVATE
 if(TARGET pulp-cli)
     add_dependencies(pulp-test-cli-import-design pulp-cli)
 endif()
+# The `import-design` command delegates to the standalone pulp-import-design
+# helper; without it the revived shell-out cases fail (exit 1) instead of
+# exercising the real path, so build it alongside this suite.
+if(TARGET pulp-import-design)
+    add_dependencies(pulp-test-cli-import-design pulp-import-design)
+endif()
 catch_discover_tests(pulp-test-cli-import-design
     PROPERTIES
         ENVIRONMENT "PULP_REPO_ROOT=${CMAKE_SOURCE_DIR}"

--- a/test/test_cli_import_design.cpp
+++ b/test/test_cli_import_design.cpp
@@ -68,14 +68,27 @@ bool json_structurally_equal(const std::string& a, const std::string& b) {
     return choc::json::toString(va, false) == choc::json::toString(vb, false);
 }
 
-// The pulp CLI binary lands at <build>/tools/cli/pulp once `pulp-cli`
-// has been built. The test runner's working directory at invocation
-// is <build>/test, so "../tools/cli/pulp" is the relative path.
+// Locate a runnable CLI that implements `import-design`. The C++ delegate
+// target `pulp-cli` emits `pulp-cpp` (CMake OUTPUT_NAME) in <build>/tools/cli;
+// the Rust front-end lands at <build>/pulp and forwards import-design to that
+// delegate. The test runner's working directory at invocation is <build>/test.
+// Prefer an explicit override, then the C++ delegate (the real implementation
+// of this command), then the legacy/Rust names. Returning a non-existent path
+// makes binary_exists() false so the case skips when nothing is built.
 fs::path pulp_binary() {
     if (const char* env = std::getenv("PULP_CLI_PATH"); env && *env) {
         return fs::path(env);
     }
-    return fs::current_path() / ".." / "tools" / "cli" / "pulp";
+    const auto build = fs::current_path() / "..";
+    for (const auto& candidate : {
+             build / "tools" / "cli" / "pulp-cpp",  // C++ delegate (current name)
+             build / "tools" / "cli" / "pulp",      // legacy name
+             build / "pulp",                         // Rust front-end
+         }) {
+        std::error_code ec;
+        if (fs::is_regular_file(candidate, ec)) return candidate;
+    }
+    return build / "tools" / "cli" / "pulp-cpp";
 }
 
 bool binary_exists() { return fs::exists(pulp_binary()); }
@@ -466,9 +479,10 @@ TEST_CASE("pulp import-design --from figma auto-routes a figma-plugin envelope",
                        "--no-tokens"});
     REQUIRE_FALSE(r.timed_out);
     REQUIRE(r.exit_code == 0);
-    // Guardrail fired: routed to the plugin parser with a notice.
+    // Guardrail fired: routed to the plugin parser with a notice. (The note
+    // names the format with a capital F: "Figma-plugin export envelope".)
     const auto combined = r.stdout_output + r.stderr_output;
-    REQUIRE(combined.find("figma-plugin export envelope") != std::string::npos);
+    REQUIRE(combined.find("Figma-plugin export envelope") != std::string::npos);
     // Children were actually parsed (NOT the empty root-only output): the
     // text node's content reaches the generated JS.
     REQUIRE(fs::exists(js_out));
@@ -542,6 +556,40 @@ TEST_CASE("pulp import-design --knob-style sprite keeps a child-art knob interac
     REQUIRE(js.find(", 100, 100)") != std::string::npos);
     // Sprite mode does NOT apply the silver vector style.
     REQUIRE(js.find("setWidgetStyle('GainKnob") == std::string::npos);
+}
+
+// ── baked ir-json lane preserves the figma-plugin tree + assets ──────────
+// Two bugs used to silently gut the `--emit ir-json` (and cpp/swiftui) lane for
+// figma-plugin envelopes while `--emit js` worked:
+//   1) looks_like_serialized_design_ir() false-matched the envelope (it has a
+//      top-level "root" and nested "version" keys), short-circuiting to the
+//      bare-node DesignIR parser, which dropped every child.
+//   2) refresh_design_ir_asset_manifest() rebuilt the manifest from a node-URI
+//      scan that does not recognize figma-plugin `asset_ref` attributes, so the
+//      parsed asset_manifest was discarded.
+// This guards the baked lane: children survive AND the parsed manifest is kept.
+TEST_CASE("pulp import-design --emit ir-json keeps a figma-plugin tree + assets",
+          "[cli][import-design][ir-json][figma-plugin][shellout]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto tmp = unique_temp_dir("pulp-irjson-figma-plugin");
+    auto scene = write_sprite_knob_fixture(tmp);  // 1 asset (knob_body) + nested GainKnob
+    auto ir_out = tmp / "design.ir.json";
+    auto r = run_pulp({"import-design", "--from", "figma-plugin",
+                       "--file", scene.string(), "--emit", "ir-json",
+                       "--mode", "baked", "--output", ir_out.string(),
+                       "--no-tokens"});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code == 0);
+    REQUIRE(fs::exists(ir_out));
+    const auto ir = read_text(ir_out);
+
+    // Bug 1 guard: NOT the empty bare-node fallback, and the child survived.
+    REQUIRE(ir.find("parsed legacy bare-node DesignIR JSON") == std::string::npos);
+    REQUIRE(ir.find("GainKnob") != std::string::npos);
+    // Bug 2 guard: the parsed asset_manifest is preserved (not scanned away).
+    REQUIRE(ir.find("\"assetManifest\"") != std::string::npos);
+    REQUIRE(ir.find("knob_body") != std::string::npos);
 }
 
 TEST_CASE("pulp import-design normalizes + emits a Figma blend mode (end-to-end)",


### PR DESCRIPTION
## What

Generalized extract from the foreign-host embedding experiment (`explore/foreign-host-embed`).

The original commit fixed two source bugs that silently gutted the `--emit ir-json` / `cpp` / `swiftui` baked lane for figma-plugin envelopes (while `--emit js` worked):
1. `looks_like_serialized_design_ir()` false-matched the envelope (top-level `root` + nested `version` keys), short-circuiting to the bare-node parser, which dropped every child.
2. `refresh_design_ir_asset_manifest()` rebuilt the manifest from a node-URI scan that does not recognize figma-plugin `asset_ref` attributes, discarding the parsed `asset_manifest`.

**Both source fixes have since landed on `main`** — the baked fast path is now guarded by `!looks_like_figma_plugin_export(...)` in `pulp_import_design.cpp`, and `refresh_design_ir_asset_manifest()` now preserves embedded figma-plugin assets via `preserve_all_embedded_assets`. So this PR is correctly scoped to the **test coverage that was still missing** to guard those behaviors:

- **Revive the silently-skipping suite** — `pulp_binary()` looked for `<build>/tools/cli/pulp`, but the C++ delegate target emits `pulp-cpp` (CMake `OUTPUT_NAME`), so the entire `[shellout]` cli-import-design suite had been skipping. Now searches `pulp-cpp`, then legacy `pulp`, then the Rust front-end, each guarded by `is_regular_file` so a sibling `pulp/` checkout dir can't be mistaken for the binary.
- **Fix a stale assertion** surfaced by the revival — `main`'s CLI emits the notice with a capital F (`"Figma-plugin export envelope"`, `pulp_import_design.cpp:2250`); the test asserted lowercase.
- **Add an `--emit ir-json` baked regression guard** — asserts the figma-plugin tree (`GainKnob` child) AND the parsed asset_manifest (`knob_body`) survive the baked lane, locking in both fixes above.

## Tests

Built `pulp-cli` (→ `pulp-cpp`), `pulp-import-design`, and the suite. **All 24 cases / 106 assertions pass** against current `main` source — confirming the suite is no longer skipping and the regression guards hold.

## Gates

skill-sync ✓ (no mapped paths — only `test/test_cli_import_design.cpp` changed). version-bump ✓ (`test:` title, no surface moved). node-ABI ✓, deps-audit ✓.

Draft — leaving open for review + CI. Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revives the `cli-import-design` test suite by building the `pulp-import-design` helper with the suite and fixing CLI discovery to prefer `pulp-cpp` (fallbacks to legacy `pulp` and the Rust front end) using `is_regular_file` checks. Updates the notice assertion to "Figma-plugin export envelope" and adds a baked `--emit ir-json` regression to guard figma-plugin envelopes: child nodes survive (e.g., GainKnob) and the parsed asset manifest is preserved (`knob_body`).

<sup>Written for commit cec509d08c16a5e45393fa74b4232f2a9de061d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

