### PR TITLE
feat(view): cross-platform headless Skia screenshot + Win/Linux PluginViewHost

### DIFF
--- a/.agents/skills/screenshot/SKILL.md
+++ b/.agents/skills/screenshot/SKILL.md
@@ -102,6 +102,18 @@ gradient-heavy design. Treat the % as a smoke signal; **eyeball the montage**
   `import-design` does not load that way (throws). Prefer `--validate` with the
   Skia backend for an imported `ui.js`.
 - **`pulp::view::render_to_file`** in tests — headless view-tree PNGs in CI.
+- **`pulp::view::render_to_rgba`** (`screenshot.hpp`) — raw-pixel sibling of
+  `render_to_png`. Returns the decoded **RGBA8** buffer (R,G,B,A byte order,
+  premultiplied alpha, sRGB, top-to-bottom, stride `*out_width*4`) + the pixel
+  dims, instead of PNG bytes — for callers that composite/upload the frame
+  themselves (e.g. the foreign-host embed SDK's offscreen mode) and don't want a
+  PNG encode+decode round-trip. **macOS-only** (forces the Skia raster path,
+  which is endianness-independent; the non-Apple stub returns empty — the
+  registered `ScreenshotProvider` is PNG-only). The internal `render_to_png_skia`
+  already holds these pixels before encoding; this just exposes them. Note
+  `AssetManager::decode_png` does NOT actually decode (it stores raw PNG bytes +
+  parses IHDR), so you cannot get RGBA by round-tripping a PNG through it — use
+  `render_to_rgba` for raw pixels.
 
 ## Render size: use the design's true root, not the source bbox
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.189.0",
+      "version": "0.190.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.189.0"
+  "version": "0.190.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.189.0",
+  "version": "0.190.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.362.0
+    VERSION 0.363.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/render/include/pulp/render/gpu_surface.hpp
+++ b/core/render/include/pulp/render/gpu_surface.hpp
@@ -50,9 +50,24 @@ public:
         /// Opaque platform-specific handle for on-screen rendering.
         /// On macOS/iOS: CAMetalLayer*
         /// On Windows:   HWND
-        /// On Linux:     platform-dependent (X11 Window, wl_surface*, etc.)
+        /// On Linux:     a pointer to an X11NativeHandle (see below). A bare
+        ///               X11 Window id is NOT enough — Dawn's Xlib surface
+        ///               source needs both the Display* and the Window. Wayland
+        ///               (wl_display*/wl_surface*) is not wired yet.
         /// nullptr = offscreen-only mode (no presentation)
         void* native_surface_handle = nullptr;
+    };
+
+    /// Typed X11 surface handle. Pass a pointer to one of these as
+    /// Config::native_surface_handle on Linux so Dawn can build an
+    /// SurfaceSourceXlibWindow (#3329 Win/Linux parity). `display` is an
+    /// `Display*` and `window` is an X11 `Window` (an `unsigned long`); both are
+    /// kept opaque here so this header stays Xlib-include-free for non-Linux and
+    /// no-X11 consumers. The pointed-to struct only needs to outlive the
+    /// initialize() call.
+    struct X11NativeHandle {
+        void*         display = nullptr;  // Display*
+        unsigned long window  = 0;        // Window
     };
 
     virtual ~GpuSurface() = default;

--- a/core/render/src/gpu_surface_dawn.cpp
+++ b/core/render/src/gpu_surface_dawn.cpp
@@ -397,9 +397,27 @@ private:
             runtime::log_warn("GpuSurface: failed to create Android Vulkan surface");
         }
 #elif defined(__linux__)
-        // Linux: native_layer is platform-dependent.
-        (void)native_handle;
-        runtime::log_warn("GpuSurface: Linux surface creation requires platform-specific handle — use SDL3 integration");
+        // Linux: native_handle is a pointer to a GpuSurface::X11NativeHandle
+        // (Display* + Window). A bare Window id is not enough — Dawn's Xlib
+        // surface source needs both (#3329). Wayland is not wired yet.
+        if (auto* x11 = static_cast<X11NativeHandle*>(native_handle);
+            x11 && x11->display && x11->window) {
+            wgpu::SurfaceDescriptor surface_desc{};
+            wgpu::SurfaceSourceXlibWindow xlib_source{};
+            xlib_source.display = x11->display;
+            xlib_source.window = static_cast<uint64_t>(x11->window);
+            surface_desc.nextInChain = &xlib_source;
+
+            surface_ = instance_.CreateSurface(&surface_desc);
+            if (surface_) {
+                runtime::log_info("GpuSurface: created Vulkan surface from X11 window");
+            } else {
+                runtime::log_warn("GpuSurface: failed to create X11 surface");
+            }
+        } else {
+            runtime::log_warn("GpuSurface: Linux surface needs an X11NativeHandle "
+                              "(Display* + Window); got null/incomplete handle");
+        }
 #else
         (void)native_handle;
 #endif

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -596,6 +596,20 @@ elseif(WIN32)
         platform/win/appearance_win.cpp
         platform/win/motion_preferences_win.cpp
     )
+    # Win/Linux parity (#3329). When Skia is available, add the built-in
+    # Skia raster screenshot backend and the native HWND PluginViewHost.
+    # plugin_view_host_stub.cpp stays (it owns the always-compiled
+    # set_factory/has_factory registration API + the factory-dispatching
+    # create()); the native impl registers ITSELF as the factory via
+    # register_platform_plugin_view_host(). screenshot_skia.cpp self-guards
+    # on PULP_HAS_SKIA and supersedes the stub's render_* fallback (which is
+    # now compiled only when !PULP_HAS_SKIA).
+    if(PULP_HAS_SKIA)
+        target_sources(pulp-view-core PRIVATE
+            src/screenshot_skia.cpp
+            platform/win/plugin_view_host_win.cpp
+        )
+    endif()
     # Workstream 04 #247 phase 1: UIAutomationCore for
     # UiaClientsAreListening and (in phase 2) UiaReturnRawElementProvider +
     # UiaRaiseStructureChangedEvent.
@@ -614,6 +628,23 @@ elseif(UNIX)
         src/window_host_stub.cpp
         platform/linux/accessibility_linux.cpp
     )
+    # Win/Linux parity (#3329). Same split as the WIN32 branch: when Skia is
+    # available add the built-in Skia raster screenshot backend and the native
+    # X11 PluginViewHost (which registers itself via
+    # register_platform_plugin_view_host()). The X11 host links Xlib; missing
+    # X11 dev headers degrade to the headless-render-only path.
+    if(PULP_HAS_SKIA)
+        target_sources(pulp-view-core PRIVATE src/screenshot_skia.cpp)
+        find_package(X11)
+        if(X11_FOUND)
+            target_sources(pulp-view-core PRIVATE platform/linux/plugin_view_host_linux.cpp)
+            target_link_libraries(pulp-view-core PRIVATE ${X11_LIBRARIES})
+            target_include_directories(pulp-view-core PRIVATE ${X11_INCLUDE_DIR})
+            target_compile_definitions(pulp-view-core PRIVATE PULP_HAS_X11=1)
+        else()
+            message(STATUS "Pulp: X11 not found — Linux PluginViewHost limited to headless render")
+        endif()
+    endif()
     # Linux AT-SPI bridge (workstream 04 #248). Optional: linking atk-
     # bridge-2.0 when pkg-config finds it enables screen-reader
     # (Orca) registration via atk_bridge_adaptor_init. Skipped on

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -609,6 +609,10 @@ elseif(WIN32)
             src/screenshot_skia.cpp
             platform/win/plugin_view_host_win.cpp
         )
+        # The native HWND host supplies register_platform_plugin_view_host();
+        # tell the stub not to compile its no-op default (one definition).
+        set_source_files_properties(src/plugin_view_host_stub.cpp PROPERTIES
+            COMPILE_DEFINITIONS PULP_HAS_PLATFORM_PLUGIN_VIEW_HOST=1)
     endif()
     # Workstream 04 #247 phase 1: UIAutomationCore for
     # UiaClientsAreListening and (in phase 2) UiaReturnRawElementProvider +
@@ -641,6 +645,10 @@ elseif(UNIX)
             target_link_libraries(pulp-view-core PRIVATE ${X11_LIBRARIES})
             target_include_directories(pulp-view-core PRIVATE ${X11_INCLUDE_DIR})
             target_compile_definitions(pulp-view-core PRIVATE PULP_HAS_X11=1)
+            # The native X11 host supplies register_platform_plugin_view_host();
+            # tell the stub not to compile its no-op default (one definition).
+            set_source_files_properties(src/plugin_view_host_stub.cpp PROPERTIES
+                COMPILE_DEFINITIONS PULP_HAS_PLATFORM_PLUGIN_VIEW_HOST=1)
         else()
             message(STATUS "Pulp: X11 not found — Linux PluginViewHost limited to headless render")
         endif()

--- a/core/view/include/pulp/view/plugin_view_host.hpp
+++ b/core/view/include/pulp/view/plugin_view_host.hpp
@@ -226,4 +226,27 @@ public:
     virtual Point window_to_root_point(Point pt) const { return pt; }
 };
 
+// Install the built-in platform PluginViewHost factory (and matching headless
+// screenshot provider) on non-Apple platforms (#3329 Win/Linux parity).
+//
+// Idempotent and thread-safe: the first call registers the platform factory via
+// PluginViewHost::set_factory(); subsequent calls are no-ops. A host that wants
+// a custom factory can call PluginViewHost::set_factory() AFTER this and win.
+//
+// Platform behavior:
+//   - Windows (Skia build): registers the native HWND host
+//     (plugin_view_host_win.cpp).
+//   - Linux (Skia + X11 build): registers the native X11 host
+//     (plugin_view_host_linux.cpp).
+//   - Apple: no-op (built-in NSView/UIView hosts; no factory needed).
+//   - Builds without a platform host: no-op (create() still returns nullptr,
+//     but the headless render_to_png/rgba path remains available via Skia).
+//
+// PluginViewHost::create() calls this automatically on non-Apple platforms
+// before consulting the factory, so the foreign-host embed and the VST3/CLAP
+// adapters get a working host without the caller doing anything. Exposed
+// publicly so a host can force-register early (e.g. before its own
+// set_factory()) or in a test.
+void register_platform_plugin_view_host();
+
 } // namespace pulp::view

--- a/core/view/include/pulp/view/screenshot.hpp
+++ b/core/view/include/pulp/view/screenshot.hpp
@@ -93,6 +93,31 @@ std::vector<uint8_t> render_to_png_gpu(
 // compiled in). Lets capture_view fall back honestly when GPU is unavailable.
 bool has_gpu_capture();
 
+// Raw-RGBA sibling of render_to_png: render a view tree headlessly and hand
+// back the decoded pixel buffer instead of PNG bytes — for callers that want
+// to composite or upload the frame themselves (e.g. a foreign host that draws
+// Pulp's output into its own surface) without paying a PNG encode + decode
+// round-trip. The internal Skia raster path already holds these pixels before
+// encoding, so this exposes them directly.
+//
+// Output: tightly packed RGBA8 (R,G,B,A byte order), premultiplied alpha,
+// sRGB, top-to-bottom rows, stride == out_width * 4. The pixel dimensions are
+// the logical width/height multiplied by `scale`, returned via out_width /
+// out_height so the caller can size its buffer exactly. Returns an empty
+// vector on failure (no Skia backend, surface alloc failed, read-back failed).
+//
+// Backend: forces the Skia raster path when available (the only backend that
+// produces a stable, host-independent RGBA buffer). Without Skia this returns
+// empty (CoreGraphics capture is PNG-only here).
+std::vector<uint8_t> render_to_rgba(
+    View& root,
+    uint32_t width,
+    uint32_t height,
+    float scale,
+    uint32_t* out_width,
+    uint32_t* out_height
+);
+
 // ── Host-registered screenshot provider (#299) ──────────────────────────
 //
 // Non-Apple platforms don't have a built-in screenshot backend in

--- a/core/view/platform/linux/plugin_view_host_linux.cpp
+++ b/core/view/platform/linux/plugin_view_host_linux.cpp
@@ -384,7 +384,9 @@ private:
                                              kPremul_SkAlphaType,
                                              SkColorSpace::MakeSRGB());
         SkPixmap pixmap(info, rgba.data(), static_cast<size_t>(w) * 4u);
-        sk_sp<SkData> png = SkPngEncoder::Encode(nullptr, pixmap, SkPngEncoder::Options{});
+        // 2-arg pixmap overload returns sk_sp<SkData> (the 3-arg SkWStream*
+        // overload returns bool).
+        sk_sp<SkData> png = SkPngEncoder::Encode(pixmap, SkPngEncoder::Options{});
         if (!png || png->isEmpty()) return {};
         const auto* p = static_cast<const uint8_t*>(png->data());
         return std::vector<uint8_t>(p, p + png->size());

--- a/core/view/platform/linux/plugin_view_host_linux.cpp
+++ b/core/view/platform/linux/plugin_view_host_linux.cpp
@@ -1,0 +1,412 @@
+// Linux (X11) PluginViewHost — native child-window editor host for the
+// foreign-host embed SDK + the VST3/CLAP adapters on Linux (#3329 Win/Linux
+// parity). Mirrors the macOS/Windows hosts (NSView/HWND -> X11 child Window).
+//
+// Render paths (one class):
+//   - GPU: a Dawn surface built from the child X11 window via the typed
+//     GpuSurface::X11NativeHandle (Display* + Window), wrapped by SkiaSurface.
+//     Requires a working WebGPU/Vulkan backend; absent one, is_gpu_backed() is
+//     false and the host falls back to:
+//   - CPU raster present: Skia raster -> XImage -> XPutImage, so a live child
+//     window shows real content even with no GPU (llvmpipe-free).
+//   - Headless capture: capture_back_buffer_png() always works via Skia raster
+//     — the VM-verifiable proof that needs no X server at all for the pixels
+//     (the embed's render_to_rgba path is the primary VM proof; this host's
+//     capture is the live-window analog).
+//
+// X11 caveats (Codex review): a bare Window id is not enough for Dawn — we keep
+// a Display*. We open our own connection with XOpenDisplay(nullptr) for the
+// proof-level path; robust DAW interop would take the host's Display from the
+// format adapter. There is no internal event loop here — the host pumps its own
+// X connection; we only create/reparent/map/blit on the UI thread. Visual is
+// CopyFromParent so colormap/depth match the parent.
+
+#include <pulp/view/plugin_view_host.hpp>
+#include <pulp/view/window_host.hpp>
+
+#ifdef PULP_HAS_SKIA
+#include <pulp/render/gpu_surface.hpp>
+#include <pulp/render/skia_surface.hpp>
+#include <pulp/canvas/skia_canvas.hpp>
+#include "include/core/SkCanvas.h"
+#include "include/core/SkColorSpace.h"
+#include "include/core/SkData.h"
+#include "include/core/SkImageInfo.h"
+#include "include/core/SkPixmap.h"
+#include "include/core/SkSurface.h"
+#include "include/encode/SkPngEncoder.h"
+#endif
+
+#include <pulp/runtime/log.hpp>
+
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+
+#include <atomic>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace pulp::view {
+
+namespace {
+
+class X11PluginViewHost : public PluginViewHost {
+public:
+    X11PluginViewHost(View& root, Size size) : root_(root), size_(size) {
+        // Our own X connection (proof-level). Xlib must be touched from a single
+        // thread; this host is created and driven on the UI thread.
+        display_ = XOpenDisplay(nullptr);
+        if (!display_) {
+            runtime::log_warn("X11PluginViewHost: XOpenDisplay(nullptr) failed "
+                              "(no DISPLAY?) — headless capture only");
+            return;
+        }
+        screen_ = DefaultScreen(display_);
+        Window root_win = RootWindow(display_, screen_);
+        // Create the child as a child of the root for now; reparented to the
+        // DAW's editor window in attach_to_parent(). CopyFromParent matches the
+        // parent's visual/depth/colormap.
+        child_ = XCreateSimpleWindow(
+            display_, root_win, 0, 0, size.width, size.height, 0,
+            BlackPixel(display_, screen_), BlackPixel(display_, screen_));
+        if (!child_) {
+            runtime::log_warn("X11PluginViewHost: XCreateSimpleWindow failed");
+            return;
+        }
+        XSelectInput(display_, child_, ExposureMask | StructureNotifyMask);
+        gc_ = XCreateGC(display_, child_, 0, nullptr);
+        XFlush(display_);
+#ifdef PULP_HAS_SKIA
+        init_gpu(static_cast<float>(size.width), static_cast<float>(size.height));
+#endif
+    }
+
+    ~X11PluginViewHost() override {
+        root_.set_plugin_view_host(nullptr);
+#ifdef PULP_HAS_SKIA
+        skia_surface_.reset();
+        gpu_surface_.reset();
+#endif
+        if (display_) {
+            if (gc_) XFreeGC(display_, gc_);
+            if (child_) XDestroyWindow(display_, child_);
+            XFlush(display_);
+            XCloseDisplay(display_);
+            display_ = nullptr;
+        }
+    }
+
+    // native_handle returns the X11 Window id cast to void* (the cross-format
+    // convention used by clap_entry/vst3 on Linux, which pass only the Window).
+    NativeViewHandle native_handle() override {
+        return reinterpret_cast<void*>(static_cast<uintptr_t>(child_));
+    }
+
+    void attach_to_parent(NativeViewHandle parent) override {
+        if (!display_ || !child_) return;
+        Window parent_win = static_cast<Window>(reinterpret_cast<uintptr_t>(parent));
+        if (!parent_win) return;
+        XReparentWindow(display_, child_, parent_win, 0, 0);
+        XResizeWindow(display_, child_, size_.width, size_.height);
+        XMapWindow(display_, child_);
+        XFlush(display_);
+        attached_.store(true, std::memory_order_release);
+        repaint();
+    }
+
+    bool is_attached() const noexcept {
+        return attached_.load(std::memory_order_acquire);
+    }
+
+    void detach() override {
+        if (!display_ || !child_) return;
+        XUnmapWindow(display_, child_);
+        Window root_win = RootWindow(display_, screen_);
+        XReparentWindow(display_, child_, root_win, 0, 0);
+        XFlush(display_);
+        attached_.store(false, std::memory_order_release);
+    }
+
+    void repaint() override {
+#ifdef PULP_HAS_SKIA
+        if (gpu_surface_ && skia_surface_) {
+            render_frame_gpu(nullptr, nullptr, nullptr);
+            return;
+        }
+        // No GPU: present a raster frame into the live window if attached.
+        if (display_ && child_ && attached_.load(std::memory_order_acquire)) {
+            present_raster();
+        }
+#endif
+    }
+
+    void set_size(uint32_t width, uint32_t height) override {
+        size_ = {width, height};
+        if (display_ && child_) {
+            XResizeWindow(display_, child_, width, height);
+            XFlush(display_);
+        }
+#ifdef PULP_HAS_SKIA
+        if (gpu_surface_) gpu_surface_->resize(width, height);
+        if (skia_surface_) skia_surface_->resize(width, height, 1.0f);
+#endif
+        repaint();
+    }
+
+    Size get_size() const override { return size_; }
+
+    bool is_gpu_backed() const override {
+#ifdef PULP_HAS_SKIA
+        return gpu_surface_ != nullptr && skia_surface_ != nullptr &&
+               skia_surface_->is_available();
+#else
+        return false;
+#endif
+    }
+
+#ifdef PULP_HAS_SKIA
+    render::GpuSurface* gpu_surface() const override { return gpu_surface_.get(); }
+#endif
+
+    void set_idle_callback(std::function<void()> cb) override {
+        idle_callback_ = std::move(cb);
+    }
+
+    void set_resize_callback(std::function<void(uint32_t, uint32_t)> cb) override {
+        resize_cb_ = std::move(cb);
+    }
+
+    std::vector<uint8_t> capture_back_buffer_png() override {
+#ifdef PULP_HAS_SKIA
+        if (gpu_surface_ && skia_surface_) {
+            std::vector<uint8_t> pixels;
+            uint32_t pw = 0, ph = 0;
+            if (render_frame_gpu(&pixels, &pw, &ph) && !pixels.empty())
+                return encode_rgba_png(pixels, pw, ph);
+        }
+        uint32_t pw = 0, ph = 0;
+        auto pixels = raster_render(&pw, &ph);
+        if (pixels.empty()) return {};
+        return encode_rgba_png(pixels, pw, ph);
+#else
+        return {};
+#endif
+    }
+
+    void set_design_viewport(float design_w, float design_h) override {
+        design_viewport_w_ = design_w;
+        design_viewport_h_ = design_h;
+        repaint();
+    }
+
+    void set_design_viewport_top_align(bool top_align) override {
+        design_top_align_ = top_align;
+        repaint();
+    }
+
+    void set_fixed_aspect_ratio(float ratio) override { fixed_aspect_ratio_ = ratio; }
+
+    Point window_to_root_point(Point pt) const override {
+        float sx, sy, tx, ty;
+        if (!WindowHost::compute_design_viewport_transform(
+                static_cast<float>(size_.width), static_cast<float>(size_.height),
+                design_viewport_w_, design_viewport_h_, sx, sy, tx, ty,
+                design_top_align_)) {
+            return pt;
+        }
+        if (sx <= 0.0f || sy <= 0.0f) return pt;
+        return {(pt.x - tx) / sx, (pt.y - ty) / sy};
+    }
+
+private:
+    View& root_;
+    Size size_;
+    Display* display_ = nullptr;
+    int screen_ = 0;
+    Window child_ = 0;
+    GC gc_ = nullptr;
+    std::atomic<bool> attached_{false};
+    std::function<void()> idle_callback_;
+    std::function<void(uint32_t, uint32_t)> resize_cb_;
+    float design_viewport_w_ = 0.0f;
+    float design_viewport_h_ = 0.0f;
+    float fixed_aspect_ratio_ = 0.0f;
+    bool design_top_align_ = false;
+
+#ifdef PULP_HAS_SKIA
+    std::unique_ptr<render::GpuSurface> gpu_surface_;
+    std::unique_ptr<render::SkiaSurface> skia_surface_;
+    render::GpuSurface::X11NativeHandle x11_handle_{};
+
+    void init_gpu(float width, float height) {
+        if (!display_ || !child_) return;
+        gpu_surface_ = render::GpuSurface::create_dawn();
+        if (!gpu_surface_) {
+            runtime::log_warn("X11PluginViewHost: gpu create_dawn failed; cpu raster only");
+            return;
+        }
+        x11_handle_.display = display_;
+        x11_handle_.window = static_cast<unsigned long>(child_);
+        render::GpuSurface::Config cfg{};
+        cfg.width = static_cast<uint32_t>(width);
+        cfg.height = static_cast<uint32_t>(height);
+        cfg.native_surface_handle = &x11_handle_;  // typed X11 handle
+        if (!gpu_surface_->initialize(cfg)) {
+            runtime::log_warn("X11PluginViewHost: gpu initialize failed; cpu raster only");
+            gpu_surface_.reset();
+            return;
+        }
+        render::SkiaSurface::Config scfg{};
+        scfg.width = static_cast<uint32_t>(width);
+        scfg.height = static_cast<uint32_t>(height);
+        scfg.scale_factor = 1.0f;
+        skia_surface_ = render::SkiaSurface::create(*gpu_surface_, scfg);
+        if (!skia_surface_) {
+            runtime::log_warn("X11PluginViewHost: skia surface create failed; cpu raster only");
+            gpu_surface_.reset();
+        }
+    }
+
+    void paint_scene(canvas::Canvas& canvas) {
+        const float w = static_cast<float>(size_.width);
+        const float h = static_cast<float>(size_.height);
+        canvas.set_fill_color(pulp::canvas::Color::rgba8(30, 30, 46));
+        canvas.fill_rect(0, 0, w, h);
+
+        float sx, sy, tx, ty;
+        const bool has_viewport =
+            design_viewport_w_ > 0.0f && design_viewport_h_ > 0.0f &&
+            WindowHost::compute_design_viewport_transform(
+                w, h, design_viewport_w_, design_viewport_h_, sx, sy, tx, ty,
+                design_top_align_);
+        if (has_viewport) {
+            root_.set_bounds({0, 0, design_viewport_w_, design_viewport_h_});
+            root_.layout_children();
+            const int saved = canvas.save_count();
+            canvas.save();
+            canvas.translate(tx, ty);
+            canvas.scale(sx, sy);
+            root_.paint_all(canvas);
+            View::paint_overlays(canvas, &root_);
+            canvas.restore_to_count(saved);
+        } else {
+            root_.set_bounds({0, 0, w, h});
+            root_.layout_children();
+            root_.paint_all(canvas);
+            View::paint_overlays(canvas, &root_);
+        }
+    }
+
+    bool render_frame_gpu(std::vector<uint8_t>* cap, uint32_t* cap_w, uint32_t* cap_h) {
+        if (!gpu_surface_ || !skia_surface_) return false;
+        if (idle_callback_) idle_callback_();
+        if (!gpu_surface_->begin_frame()) return false;
+        auto* canvas = skia_surface_->begin_frame();
+        if (!canvas) {
+            gpu_surface_->end_frame();
+            return false;
+        }
+        paint_scene(*canvas);
+        if (cap) {
+            // read_current_rgba finalizes + submits the open frame's recording
+            // before readback (see SkiaSurface contract), so no separate flush.
+            uint32_t pw = 0, ph = 0;
+            skia_surface_->read_current_rgba(*cap, pw, ph);
+            if (cap_w) *cap_w = pw;
+            if (cap_h) *cap_h = ph;
+        }
+        skia_surface_->end_frame();
+        gpu_surface_->end_frame();
+        return true;
+    }
+
+    // Render the scene to RGBA via pure Skia raster (no GPU). out_w/out_h get
+    // the pixel dims. Empty on failure.
+    std::vector<uint8_t> raster_render(uint32_t* out_w, uint32_t* out_h) {
+        const uint32_t w = size_.width, h = size_.height;
+        if (w == 0 || h == 0) return {};
+        if (idle_callback_) idle_callback_();
+        auto cs = SkColorSpace::MakeSRGB();
+        SkImageInfo info = SkImageInfo::Make(w, h, kRGBA_8888_SkColorType,
+                                             kPremul_SkAlphaType, cs);
+        auto surface = SkSurfaces::Raster(info);
+        if (!surface) return {};
+        auto* sk_canvas = surface->getCanvas();
+        if (!sk_canvas) return {};
+        pulp::canvas::SkiaCanvas canvas(sk_canvas);
+        paint_scene(canvas);
+        std::vector<uint8_t> pixels(static_cast<size_t>(w) * h * 4u);
+        SkPixmap pixmap(info, pixels.data(), static_cast<size_t>(w) * 4u);
+        if (!surface->readPixels(pixmap, 0, 0)) return {};
+        if (out_w) *out_w = w;
+        if (out_h) *out_h = h;
+        return pixels;
+    }
+
+    // Live CPU present: raster the scene, convert RGBA -> the X visual's pixel
+    // format (assume 32-bit BGRX TrueColor, the common case), and XPutImage.
+    void present_raster() {
+        uint32_t w = 0, h = 0;
+        auto rgba = raster_render(&w, &h);
+        if (rgba.empty()) return;
+
+        Visual* visual = DefaultVisual(display_, screen_);
+        int depth = DefaultDepth(display_, screen_);
+        // Build a 32-bit BGRA buffer for XImage (X expects BGRX on little-endian
+        // TrueColor visuals). XDestroyImage frees this buffer.
+        auto* buf = static_cast<char*>(malloc(static_cast<size_t>(w) * h * 4u));
+        if (!buf) return;
+        for (size_t i = 0; i < static_cast<size_t>(w) * h; ++i) {
+            uint8_t r = rgba[i * 4 + 0], g = rgba[i * 4 + 1], b = rgba[i * 4 + 2];
+            buf[i * 4 + 0] = static_cast<char>(b);
+            buf[i * 4 + 1] = static_cast<char>(g);
+            buf[i * 4 + 2] = static_cast<char>(r);
+            buf[i * 4 + 3] = 0;
+        }
+        XImage* img = XCreateImage(display_, visual, static_cast<unsigned>(depth),
+                                   ZPixmap, 0, buf, w, h, 32, 0);
+        if (!img) {
+            free(buf);
+            return;
+        }
+        XPutImage(display_, child_, gc_, img, 0, 0, 0, 0, w, h);
+        XFlush(display_);
+        XDestroyImage(img);  // frees buf
+    }
+
+    static std::vector<uint8_t> encode_rgba_png(const std::vector<uint8_t>& rgba,
+                                                uint32_t w, uint32_t h) {
+        if (rgba.empty() || w == 0 || h == 0) return {};
+        SkImageInfo info = SkImageInfo::Make(w, h, kRGBA_8888_SkColorType,
+                                             kPremul_SkAlphaType,
+                                             SkColorSpace::MakeSRGB());
+        SkPixmap pixmap(info, rgba.data(), static_cast<size_t>(w) * 4u);
+        sk_sp<SkData> png = SkPngEncoder::Encode(nullptr, pixmap, SkPngEncoder::Options{});
+        if (!png || png->isEmpty()) return {};
+        const auto* p = static_cast<const uint8_t*>(png->data());
+        return std::vector<uint8_t>(p, p + png->size());
+    }
+#endif  // PULP_HAS_SKIA
+};
+
+}  // namespace
+
+// Strong definition of the registration hook (the stub's no-op default is
+// compiled out via PULP_HAS_PLATFORM_PLUGIN_VIEW_HOST). Idempotent: installs the
+// X11 factory only if no factory is already registered.
+void register_platform_plugin_view_host() {
+    static std::once_flag once;
+    std::call_once(once, [] {
+        if (PluginViewHost::has_factory()) return;
+        PluginViewHost::set_factory(
+            [](View& root, const PluginViewHost::Options& opts)
+                -> std::unique_ptr<PluginViewHost> {
+                return std::make_unique<X11PluginViewHost>(root, opts.size);
+            });
+    });
+}
+
+}  // namespace pulp::view

--- a/core/view/platform/mac/screenshot_mac.mm
+++ b/core/view/platform/mac/screenshot_mac.mm
@@ -163,6 +163,47 @@ std::vector<uint8_t> render_to_png_skia(View& root,
     return encode_rgba_to_png(pixels.data(), pixel_w, pixel_h,
                               static_cast<size_t>(pixel_w) * 4u);
 }
+
+// Raw-RGBA producer (no PNG encode). Forces R,G,B,A byte order via an explicit
+// kRGBA_8888 read-back so the output is endianness-independent (kN32 is BGRA on
+// Apple), premultiplied sRGB, stride == pixel_w * 4. Writes the pixel
+// dimensions to out_width/out_height. Empty on failure.
+std::vector<uint8_t> render_to_rgba_skia(View& root,
+                                         uint32_t width,
+                                         uint32_t height,
+                                         float scale,
+                                         uint32_t* out_width,
+                                         uint32_t* out_height) {
+    uint32_t pixel_w = static_cast<uint32_t>(width * scale);
+    uint32_t pixel_h = static_cast<uint32_t>(height * scale);
+    if (pixel_w == 0 || pixel_h == 0) return {};
+    auto color_space = SkColorSpace::MakeSRGB();
+    SkImageInfo info = SkImageInfo::Make(pixel_w, pixel_h, kRGBA_8888_SkColorType,
+                                         kPremul_SkAlphaType, color_space);
+    auto surface = SkSurfaces::Raster(info);
+    if (!surface) return {};
+
+    auto* sk_canvas = surface->getCanvas();
+    if (!sk_canvas) return {};
+    if (scale != 1.0f) sk_canvas->scale(scale, scale);
+
+    pulp::canvas::SkiaCanvas canvas(sk_canvas);
+    canvas.set_fill_color(pulp::canvas::Color::rgba8(30, 30, 46));
+    canvas.fill_rect(0, 0, static_cast<float>(width), static_cast<float>(height));
+
+    root.set_bounds({0, 0, static_cast<float>(width), static_cast<float>(height)});
+    root.layout_children();
+    root.paint_all(canvas);
+    pulp::view::View::paint_overlays(canvas, &root);
+
+    std::vector<uint8_t> pixels(static_cast<size_t>(pixel_w) * pixel_h * 4u);
+    SkPixmap pixmap(info, pixels.data(), static_cast<size_t>(pixel_w) * 4u);
+    if (!surface->readPixels(pixmap, 0, 0)) return {};
+
+    if (out_width) *out_width = pixel_w;
+    if (out_height) *out_height = pixel_h;
+    return pixels;
+}
 #endif
 
 } // namespace
@@ -199,6 +240,19 @@ bool render_to_file(View& root, uint32_t width, uint32_t height,
     }
 }
 
+std::vector<uint8_t> render_to_rgba(View& root, uint32_t width, uint32_t height,
+                                    float scale, uint32_t* out_width,
+                                    uint32_t* out_height) {
+    if (out_width) *out_width = 0;
+    if (out_height) *out_height = 0;
+#ifdef PULP_HAS_SKIA
+    return render_to_rgba_skia(root, width, height, scale, out_width, out_height);
+#else
+    (void)root; (void)width; (void)height; (void)scale;
+    return {};
+#endif
+}
+
 } // namespace pulp::view
 
 #else
@@ -206,6 +260,9 @@ bool render_to_file(View& root, uint32_t width, uint32_t height,
 namespace pulp::view {
 std::vector<uint8_t> render_to_png(View&, uint32_t, uint32_t, float, ScreenshotBackend) { return {}; }
 bool render_to_file(View&, uint32_t, uint32_t, const std::string&, float, ScreenshotBackend) { return false; }
+std::vector<uint8_t> render_to_rgba(View&, uint32_t, uint32_t, float, uint32_t* ow, uint32_t* oh) {
+    if (ow) *ow = 0; if (oh) *oh = 0; return {};
+}
 }
 
 #endif

--- a/core/view/platform/win/plugin_view_host_win.cpp
+++ b/core/view/platform/win/plugin_view_host_win.cpp
@@ -1,0 +1,378 @@
+// Windows (HWND) PluginViewHost — native child-window editor host for the
+// foreign-host embed SDK + the VST3/CLAP adapters on Windows (#3329 Win/Linux
+// parity). Mirrors the macOS MacGpuPluginViewHost shape (NSView -> child HWND,
+// CAMetalLayer -> HWND-backed Dawn surface).
+//
+// Two render paths share one class:
+//   - GPU: a Dawn surface created from the child HWND, wrapped by SkiaSurface,
+//     painted on demand (repaint()/WM_PAINT). Requires a working WebGPU backend
+//     (D3D12/Vulkan). On a GPU-less host the Dawn init fails and is_gpu_backed()
+//     reports false; the host still attaches and serves deterministic frames
+//     via the Skia raster path in capture_back_buffer_png().
+//   - Headless capture: capture_back_buffer_png() always works (raster), so the
+//     embed's hidden-window smoke can verify a real non-black frame even with no
+//     GPU — the VM-verifiable proof.
+//
+// Threading: all window ops run on the calling (UI) thread. There is no internal
+// message loop — the host that owns the parent HWND pumps messages; repaint()
+// invalidates and a WM_PAINT triggers render_frame(). For embed callers that
+// drive frames explicitly (pulp_embed_tick), repaint() renders synchronously.
+
+#include <pulp/view/plugin_view_host.hpp>
+#include <pulp/view/window_host.hpp>
+
+#ifdef PULP_HAS_SKIA
+#include <pulp/render/gpu_surface.hpp>
+#include <pulp/render/skia_surface.hpp>
+#include <pulp/canvas/skia_canvas.hpp>
+#include "include/core/SkCanvas.h"
+#include "include/core/SkColorSpace.h"
+#include "include/core/SkData.h"
+#include "include/core/SkImageInfo.h"
+#include "include/core/SkPixmap.h"
+#include "include/core/SkSurface.h"
+#include "include/encode/SkPngEncoder.h"
+#endif
+
+#include <pulp/runtime/log.hpp>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace pulp::view {
+
+namespace {
+
+constexpr const wchar_t* kChildClassName = L"PulpPluginViewHostChild";
+
+// Register the child window class once per process.
+ATOM ensure_window_class() {
+    static std::once_flag once;
+    static ATOM atom = 0;
+    std::call_once(once, [] {
+        WNDCLASSEXW wc{};
+        wc.cbSize = sizeof(wc);
+        // CS_OWNDC: give the child its own device context (matches a GPU surface
+        // backing). CS_HREDRAW/VREDRAW: repaint on resize.
+        wc.style = CS_OWNDC | CS_HREDRAW | CS_VREDRAW;
+        wc.lpfnWndProc = DefWindowProcW;  // we drive paint explicitly via render_frame
+        wc.hInstance = GetModuleHandleW(nullptr);
+        wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
+        wc.lpszClassName = kChildClassName;
+        atom = RegisterClassExW(&wc);
+        if (!atom) {
+            runtime::log_warn("WinPluginViewHost: RegisterClassExW failed");
+        }
+    });
+    return atom;
+}
+
+class WinPluginViewHost : public PluginViewHost {
+public:
+    WinPluginViewHost(View& root, Size size) : root_(root), size_(size) {
+        ensure_window_class();
+        // Create a hidden child window not yet parented. It is reparented to the
+        // DAW's editor HWND in attach_to_parent(). WS_CHILD without a parent is
+        // legal at creation; SetParent fixes it up on attach.
+        hwnd_ = CreateWindowExW(
+            0, kChildClassName, L"", WS_CHILD | WS_CLIPSIBLINGS | WS_CLIPCHILDREN,
+            0, 0, static_cast<int>(size.width), static_cast<int>(size.height),
+            /*parent*/ nullptr, nullptr, GetModuleHandleW(nullptr), nullptr);
+        if (!hwnd_) {
+            runtime::log_warn("WinPluginViewHost: CreateWindowExW failed");
+            return;
+        }
+#ifdef PULP_HAS_SKIA
+        init_gpu(static_cast<float>(size.width), static_cast<float>(size.height));
+#endif
+    }
+
+    ~WinPluginViewHost() override {
+        root_.set_plugin_view_host(nullptr);
+#ifdef PULP_HAS_SKIA
+        skia_surface_.reset();
+        gpu_surface_.reset();
+#endif
+        if (hwnd_) {
+            DestroyWindow(hwnd_);
+            hwnd_ = nullptr;
+        }
+    }
+
+    NativeViewHandle native_handle() override { return static_cast<void*>(hwnd_); }
+
+    void attach_to_parent(NativeViewHandle parent) override {
+        if (!hwnd_) return;
+        HWND parent_hwnd = static_cast<HWND>(parent);
+        if (!parent_hwnd) return;
+        // Re-parent and ensure WS_CHILD style is set (SetParent on a top-level
+        // window does not implicitly add it).
+        LONG_PTR style = GetWindowLongPtrW(hwnd_, GWL_STYLE);
+        SetWindowLongPtrW(hwnd_, GWL_STYLE, style | WS_CHILD);
+        SetParent(hwnd_, parent_hwnd);
+        SetWindowPos(hwnd_, nullptr, 0, 0,
+                     static_cast<int>(size_.width), static_cast<int>(size_.height),
+                     SWP_NOZORDER | SWP_SHOWWINDOW);
+        ShowWindow(hwnd_, SW_SHOW);
+        attached_.store(true, std::memory_order_release);
+        repaint();
+    }
+
+    bool is_attached() const noexcept {
+        if (!hwnd_) return false;
+        // Authoritative check: do we currently have a parent? (Survives a host
+        // that detaches us behind our back.)
+        return GetParent(hwnd_) != nullptr &&
+               attached_.load(std::memory_order_acquire);
+    }
+
+    void detach() override {
+        if (!hwnd_) return;
+        ShowWindow(hwnd_, SW_HIDE);
+        SetParent(hwnd_, nullptr);
+        attached_.store(false, std::memory_order_release);
+    }
+
+    void repaint() override {
+#ifdef PULP_HAS_SKIA
+        if (gpu_surface_ && skia_surface_) {
+            render_frame(nullptr, nullptr, nullptr);
+            return;
+        }
+#endif
+        if (hwnd_) InvalidateRect(hwnd_, nullptr, FALSE);
+    }
+
+    void set_size(uint32_t width, uint32_t height) override {
+        size_ = {width, height};
+        if (hwnd_) {
+            SetWindowPos(hwnd_, nullptr, 0, 0, static_cast<int>(width),
+                         static_cast<int>(height), SWP_NOZORDER | SWP_NOMOVE);
+        }
+#ifdef PULP_HAS_SKIA
+        if (gpu_surface_) gpu_surface_->resize(width, height);
+        if (skia_surface_) skia_surface_->resize(width, height, 1.0f);
+#endif
+        repaint();
+    }
+
+    Size get_size() const override { return size_; }
+
+    bool is_gpu_backed() const override {
+#ifdef PULP_HAS_SKIA
+        return gpu_surface_ != nullptr && skia_surface_ != nullptr &&
+               skia_surface_->is_available();
+#else
+        return false;
+#endif
+    }
+
+#ifdef PULP_HAS_SKIA
+    render::GpuSurface* gpu_surface() const override { return gpu_surface_.get(); }
+#endif
+
+    void set_idle_callback(std::function<void()> cb) override {
+        idle_callback_ = std::move(cb);
+    }
+
+    void set_resize_callback(std::function<void(uint32_t, uint32_t)> cb) override {
+        resize_cb_ = std::move(cb);
+    }
+
+    // Deterministic capture. Prefers the GPU back-buffer readback when the GPU
+    // path is live; otherwise falls back to a pure Skia raster render so a
+    // GPU-less host (CI VM) still produces a real, non-black frame.
+    std::vector<uint8_t> capture_back_buffer_png() override {
+#ifdef PULP_HAS_SKIA
+        if (gpu_surface_ && skia_surface_) {
+            std::vector<uint8_t> pixels;
+            uint32_t pw = 0, ph = 0;
+            if (render_frame(&pixels, &pw, &ph) && !pixels.empty())
+                return encode_rgba_png(pixels, pw, ph);
+        }
+        return raster_capture_png();
+#else
+        return {};
+#endif
+    }
+
+    void set_design_viewport(float design_w, float design_h) override {
+        design_viewport_w_ = design_w;
+        design_viewport_h_ = design_h;
+        repaint();
+    }
+
+    void set_design_viewport_top_align(bool top_align) override {
+        design_top_align_ = top_align;
+        repaint();
+    }
+
+    void set_fixed_aspect_ratio(float ratio) override { fixed_aspect_ratio_ = ratio; }
+
+    Point window_to_root_point(Point pt) const override {
+        float sx, sy, tx, ty;
+        if (!WindowHost::compute_design_viewport_transform(
+                static_cast<float>(size_.width), static_cast<float>(size_.height),
+                design_viewport_w_, design_viewport_h_, sx, sy, tx, ty,
+                design_top_align_)) {
+            return pt;
+        }
+        if (sx <= 0.0f || sy <= 0.0f) return pt;
+        return {(pt.x - tx) / sx, (pt.y - ty) / sy};
+    }
+
+private:
+    View& root_;
+    Size size_;
+    HWND hwnd_ = nullptr;
+    std::atomic<bool> attached_{false};
+    std::function<void()> idle_callback_;
+    std::function<void(uint32_t, uint32_t)> resize_cb_;
+    float design_viewport_w_ = 0.0f;
+    float design_viewport_h_ = 0.0f;
+    float fixed_aspect_ratio_ = 0.0f;
+    bool design_top_align_ = false;
+
+#ifdef PULP_HAS_SKIA
+    std::unique_ptr<render::GpuSurface> gpu_surface_;
+    std::unique_ptr<render::SkiaSurface> skia_surface_;
+
+    void init_gpu(float width, float height) {
+        gpu_surface_ = render::GpuSurface::create_dawn();
+        if (!gpu_surface_) {
+            runtime::log_warn("WinPluginViewHost: gpu create_dawn failed; cpu-capture only");
+            return;
+        }
+        render::GpuSurface::Config cfg{};
+        cfg.width = static_cast<uint32_t>(width);
+        cfg.height = static_cast<uint32_t>(height);
+        cfg.native_surface_handle = static_cast<void*>(hwnd_);  // HWND
+        if (!gpu_surface_->initialize(cfg)) {
+            runtime::log_warn("WinPluginViewHost: gpu initialize failed; cpu-capture only");
+            gpu_surface_.reset();
+            return;
+        }
+        render::SkiaSurface::Config scfg{};
+        scfg.width = static_cast<uint32_t>(width);
+        scfg.height = static_cast<uint32_t>(height);
+        scfg.scale_factor = 1.0f;
+        skia_surface_ = render::SkiaSurface::create(*gpu_surface_, scfg);
+        if (!skia_surface_) {
+            runtime::log_warn("WinPluginViewHost: skia surface create failed; cpu-capture only");
+            gpu_surface_.reset();
+        }
+    }
+
+    // Shared scene paint (matches the macOS plugin GPU host).
+    void paint_scene(canvas::Canvas& canvas) {
+        const float w = static_cast<float>(size_.width);
+        const float h = static_cast<float>(size_.height);
+        canvas.set_fill_color(pulp::canvas::Color::rgba8(30, 30, 46));
+        canvas.fill_rect(0, 0, w, h);
+
+        float sx, sy, tx, ty;
+        const bool has_viewport =
+            design_viewport_w_ > 0.0f && design_viewport_h_ > 0.0f &&
+            WindowHost::compute_design_viewport_transform(
+                w, h, design_viewport_w_, design_viewport_h_, sx, sy, tx, ty,
+                design_top_align_);
+        if (has_viewport) {
+            root_.set_bounds({0, 0, design_viewport_w_, design_viewport_h_});
+            root_.layout_children();
+            const int saved = canvas.save_count();
+            canvas.save();
+            canvas.translate(tx, ty);
+            canvas.scale(sx, sy);
+            root_.paint_all(canvas);
+            View::paint_overlays(canvas, &root_);
+            canvas.restore_to_count(saved);
+        } else {
+            root_.set_bounds({0, 0, w, h});
+            root_.layout_children();
+            root_.paint_all(canvas);
+            View::paint_overlays(canvas, &root_);
+        }
+    }
+
+    bool render_frame(std::vector<uint8_t>* cap, uint32_t* cap_w, uint32_t* cap_h) {
+        if (!gpu_surface_ || !skia_surface_) return false;
+        if (idle_callback_) idle_callback_();
+        if (!gpu_surface_->begin_frame()) return false;
+        auto* canvas = skia_surface_->begin_frame();
+        if (!canvas) {
+            gpu_surface_->end_frame();
+            return false;
+        }
+        paint_scene(*canvas);
+        if (cap) {
+            // read_current_rgba finalizes + submits the open frame's recording
+            // before readback (see SkiaSurface contract), so no separate flush.
+            uint32_t pw = 0, ph = 0;
+            skia_surface_->read_current_rgba(*cap, pw, ph);
+            if (cap_w) *cap_w = pw;
+            if (cap_h) *cap_h = ph;
+        }
+        skia_surface_->end_frame();
+        gpu_surface_->end_frame();
+        return true;
+    }
+
+    // Pure-CPU raster capture, GPU-independent — the VM proof path.
+    std::vector<uint8_t> raster_capture_png() {
+        const uint32_t w = size_.width, h = size_.height;
+        if (w == 0 || h == 0) return {};
+        auto cs = SkColorSpace::MakeSRGB();
+        SkImageInfo info = SkImageInfo::Make(w, h, kRGBA_8888_SkColorType,
+                                             kPremul_SkAlphaType, cs);
+        auto surface = SkSurfaces::Raster(info);
+        if (!surface) return {};
+        auto* sk_canvas = surface->getCanvas();
+        if (!sk_canvas) return {};
+        pulp::canvas::SkiaCanvas canvas(sk_canvas);
+        paint_scene(canvas);
+        std::vector<uint8_t> pixels(static_cast<size_t>(w) * h * 4u);
+        SkPixmap pixmap(info, pixels.data(), static_cast<size_t>(w) * 4u);
+        if (!surface->readPixels(pixmap, 0, 0)) return {};
+        return encode_rgba_png(pixels, w, h);
+    }
+
+    static std::vector<uint8_t> encode_rgba_png(const std::vector<uint8_t>& rgba,
+                                                uint32_t w, uint32_t h) {
+        if (rgba.empty() || w == 0 || h == 0) return {};
+        SkImageInfo info = SkImageInfo::Make(w, h, kRGBA_8888_SkColorType,
+                                             kPremul_SkAlphaType,
+                                             SkColorSpace::MakeSRGB());
+        SkPixmap pixmap(info, rgba.data(), static_cast<size_t>(w) * 4u);
+        sk_sp<SkData> png = SkPngEncoder::Encode(nullptr, pixmap, SkPngEncoder::Options{});
+        if (!png || png->isEmpty()) return {};
+        const auto* p = static_cast<const uint8_t*>(png->data());
+        return std::vector<uint8_t>(p, p + png->size());
+    }
+#endif  // PULP_HAS_SKIA
+};
+
+}  // namespace
+
+// Strong definition of the registration hook (the stub's no-op default is
+// compiled out via PULP_HAS_PLATFORM_PLUGIN_VIEW_HOST). Idempotent: installs the
+// HWND factory only if no factory is already registered, so a host that called
+// set_factory() first keeps control.
+void register_platform_plugin_view_host() {
+    static std::once_flag once;
+    std::call_once(once, [] {
+        if (PluginViewHost::has_factory()) return;
+        PluginViewHost::set_factory(
+            [](View& root, const PluginViewHost::Options& opts)
+                -> std::unique_ptr<PluginViewHost> {
+                return std::make_unique<WinPluginViewHost>(root, opts.size);
+            });
+    });
+}
+
+}  // namespace pulp::view

--- a/core/view/platform/win/plugin_view_host_win.cpp
+++ b/core/view/platform/win/plugin_view_host_win.cpp
@@ -36,8 +36,9 @@
 
 #include <pulp/runtime/log.hpp>
 
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+// WIN32_LEAN_AND_MEAN + NOMINMAX, guarded, before <windows.h> so the min/max
+// macros don't collide with std::min/std::max or Skia (#384).
+#include <pulp/platform/win32_sane.hpp>
 
 #include <atomic>
 #include <functional>
@@ -51,6 +52,13 @@ namespace {
 
 constexpr const wchar_t* kChildClassName = L"PulpPluginViewHostChild";
 
+class WinPluginViewHost;
+
+// WndProc: routes WM_PAINT to the host's render path. `this` is stashed in
+// GWLP_USERDATA at WM_NCCREATE so ordinary host-driven invalidations
+// (InvalidateRect) actually render, not just the synchronous repaint() path.
+LRESULT CALLBACK pulp_pvh_wndproc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp);
+
 // Register the child window class once per process.
 ATOM ensure_window_class() {
     static std::once_flag once;
@@ -61,7 +69,7 @@ ATOM ensure_window_class() {
         // CS_OWNDC: give the child its own device context (matches a GPU surface
         // backing). CS_HREDRAW/VREDRAW: repaint on resize.
         wc.style = CS_OWNDC | CS_HREDRAW | CS_VREDRAW;
-        wc.lpfnWndProc = DefWindowProcW;  // we drive paint explicitly via render_frame
+        wc.lpfnWndProc = pulp_pvh_wndproc;
         wc.hInstance = GetModuleHandleW(nullptr);
         wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
         wc.lpszClassName = kChildClassName;
@@ -77,13 +85,16 @@ class WinPluginViewHost : public PluginViewHost {
 public:
     WinPluginViewHost(View& root, Size size) : root_(root), size_(size) {
         ensure_window_class();
-        // Create a hidden child window not yet parented. It is reparented to the
-        // DAW's editor HWND in attach_to_parent(). WS_CHILD without a parent is
-        // legal at creation; SetParent fixes it up on attach.
+        // Create a hidden TOP-LEVEL window first (WS_POPUP). A WS_CHILD window
+        // with a null parent is not a valid creation shape; we flip the style to
+        // WS_CHILD and SetParent() in attach_to_parent(). `this` is passed as
+        // lpParam so the wndproc can stash it at WM_NCCREATE.
         hwnd_ = CreateWindowExW(
-            0, kChildClassName, L"", WS_CHILD | WS_CLIPSIBLINGS | WS_CLIPCHILDREN,
+            0, kChildClassName, L"",
+            WS_POPUP | WS_CLIPSIBLINGS | WS_CLIPCHILDREN,
             0, 0, static_cast<int>(size.width), static_cast<int>(size.height),
-            /*parent*/ nullptr, nullptr, GetModuleHandleW(nullptr), nullptr);
+            /*parent*/ nullptr, nullptr, GetModuleHandleW(nullptr),
+            /*lpParam*/ this);
         if (!hwnd_) {
             runtime::log_warn("WinPluginViewHost: CreateWindowExW failed");
             return;
@@ -111,14 +122,24 @@ public:
         if (!hwnd_) return;
         HWND parent_hwnd = static_cast<HWND>(parent);
         if (!parent_hwnd) return;
-        // Re-parent and ensure WS_CHILD style is set (SetParent on a top-level
-        // window does not implicitly add it).
+        // Switch WS_POPUP -> WS_CHILD before reparenting (SetParent does not add
+        // the style itself); SWP_FRAMECHANGED makes the style edit take effect.
         LONG_PTR style = GetWindowLongPtrW(hwnd_, GWL_STYLE);
-        SetWindowLongPtrW(hwnd_, GWL_STYLE, style | WS_CHILD);
-        SetParent(hwnd_, parent_hwnd);
+        style = (style & ~static_cast<LONG_PTR>(WS_POPUP)) | WS_CHILD;
+        SetWindowLongPtrW(hwnd_, GWL_STYLE, style);
+        if (SetParent(hwnd_, parent_hwnd) == nullptr) {
+            runtime::log_warn("WinPluginViewHost: SetParent failed (err {})",
+                              static_cast<unsigned>(GetLastError()));
+            // Restore top-level style so we don't leave a parentless WS_CHILD.
+            SetWindowLongPtrW(hwnd_, GWL_STYLE,
+                              (style & ~static_cast<LONG_PTR>(WS_CHILD)) | WS_POPUP);
+            SetWindowPos(hwnd_, nullptr, 0, 0, 0, 0,
+                         SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+            return;  // attached_ stays false; try_attach_to_parent reports failure
+        }
         SetWindowPos(hwnd_, nullptr, 0, 0,
                      static_cast<int>(size_.width), static_cast<int>(size_.height),
-                     SWP_NOZORDER | SWP_SHOWWINDOW);
+                     SWP_NOZORDER | SWP_FRAMECHANGED | SWP_SHOWWINDOW);
         ShowWindow(hwnd_, SW_SHOW);
         attached_.store(true, std::memory_order_release);
         repaint();
@@ -136,7 +157,24 @@ public:
         if (!hwnd_) return;
         ShowWindow(hwnd_, SW_HIDE);
         SetParent(hwnd_, nullptr);
+        // Restore the top-level style so the detached window is a valid
+        // WS_POPUP again (not a parentless WS_CHILD).
+        LONG_PTR style = GetWindowLongPtrW(hwnd_, GWL_STYLE);
+        style = (style & ~static_cast<LONG_PTR>(WS_CHILD)) | WS_POPUP;
+        SetWindowLongPtrW(hwnd_, GWL_STYLE, style);
+        SetWindowPos(hwnd_, nullptr, 0, 0, 0, 0,
+                     SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
         attached_.store(false, std::memory_order_release);
+    }
+
+    // Called from the wndproc on WM_PAINT (host-driven invalidation path).
+    void handle_wm_paint() {
+        PAINTSTRUCT ps;
+        BeginPaint(hwnd_, &ps);
+#ifdef PULP_HAS_SKIA
+        if (gpu_surface_ && skia_surface_) render_frame(nullptr, nullptr, nullptr);
+#endif
+        EndPaint(hwnd_, &ps);
     }
 
     void repaint() override {
@@ -310,17 +348,21 @@ private:
             return false;
         }
         paint_scene(*canvas);
+        bool readback_ok = true;
         if (cap) {
             // read_current_rgba finalizes + submits the open frame's recording
             // before readback (see SkiaSurface contract), so no separate flush.
             uint32_t pw = 0, ph = 0;
-            skia_surface_->read_current_rgba(*cap, pw, ph);
+            readback_ok = skia_surface_->read_current_rgba(*cap, pw, ph) &&
+                          !cap->empty() && pw > 0 && ph > 0;
             if (cap_w) *cap_w = pw;
             if (cap_h) *cap_h = ph;
         }
         skia_surface_->end_frame();
         gpu_surface_->end_frame();
-        return true;
+        // A failed/empty readback must report false so capture_back_buffer_png()
+        // falls back to the raster path instead of returning a blank frame.
+        return cap ? readback_ok : true;
     }
 
     // Pure-CPU raster capture, GPU-independent — the VM proof path.
@@ -358,6 +400,23 @@ private:
     }
 #endif  // PULP_HAS_SKIA
 };
+
+LRESULT CALLBACK pulp_pvh_wndproc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
+    if (msg == WM_NCCREATE) {
+        // Stash the host pointer passed via CreateWindowEx lpParam.
+        auto* cs = reinterpret_cast<CREATESTRUCTW*>(lp);
+        SetWindowLongPtrW(hwnd, GWLP_USERDATA,
+                          reinterpret_cast<LONG_PTR>(cs->lpCreateParams));
+        return DefWindowProcW(hwnd, msg, wp, lp);
+    }
+    auto* host = reinterpret_cast<WinPluginViewHost*>(
+        GetWindowLongPtrW(hwnd, GWLP_USERDATA));
+    if (host && msg == WM_PAINT) {
+        host->handle_wm_paint();
+        return 0;
+    }
+    return DefWindowProcW(hwnd, msg, wp, lp);
+}
 
 }  // namespace
 

--- a/core/view/platform/win/plugin_view_host_win.cpp
+++ b/core/view/platform/win/plugin_view_host_win.cpp
@@ -349,7 +349,9 @@ private:
                                              kPremul_SkAlphaType,
                                              SkColorSpace::MakeSRGB());
         SkPixmap pixmap(info, rgba.data(), static_cast<size_t>(w) * 4u);
-        sk_sp<SkData> png = SkPngEncoder::Encode(nullptr, pixmap, SkPngEncoder::Options{});
+        // 2-arg pixmap overload returns sk_sp<SkData> (the 3-arg SkWStream*
+        // overload returns bool).
+        sk_sp<SkData> png = SkPngEncoder::Encode(pixmap, SkPngEncoder::Options{});
         if (!png || png->isEmpty()) return {};
         const auto* p = static_cast<const uint8_t*>(png->data());
         return std::vector<uint8_t>(p, p + png->size());

--- a/core/view/src/plugin_view_host_stub.cpp
+++ b/core/view/src/plugin_view_host_stub.cpp
@@ -33,6 +33,16 @@ bool PluginViewHost::has_factory() {
     return g_factory_installed;
 }
 
+#if !defined(PULP_HAS_PLATFORM_PLUGIN_VIEW_HOST)
+// Default no-op registration. A build with a native platform host
+// (plugin_view_host_win.cpp / plugin_view_host_linux.cpp) defines
+// PULP_HAS_PLATFORM_PLUGIN_VIEW_HOST and supplies the real implementation, so
+// this stub is compiled only when there is no platform host (Apple — which
+// has built-in hosts and needs no factory — Android, or a Skia/X11-less Linux
+// build). See register_platform_plugin_view_host() docs in the header.
+void register_platform_plugin_view_host() {}
+#endif
+
 #if !defined(__APPLE__)
 
 std::unique_ptr<PluginViewHost> PluginViewHost::create(View& root, Size size) {
@@ -43,6 +53,13 @@ std::unique_ptr<PluginViewHost> PluginViewHost::create(View& root, Size size) {
 
 std::unique_ptr<PluginViewHost> PluginViewHost::create(View& root,
                                                        const Options& options) {
+    // #3329: install the built-in platform factory (HWND on Windows, X11 on
+    // Linux) on first use, so the embed / VST3 / CLAP adapters get a working
+    // host without the caller registering one. Idempotent and a no-op if a host
+    // already called set_factory() (it stays installed) or on a build with no
+    // platform host. A custom factory set AFTER this call still wins.
+    register_platform_plugin_view_host();
+
     // #313 Codex P2: copy the factory out, release the lock, then
     // invoke. Instantiating a plugin view involves attaching to a
     // DAW's editor window — can block; definitely shouldn't hold a

--- a/core/view/src/screenshot_skia.cpp
+++ b/core/view/src/screenshot_skia.cpp
@@ -1,0 +1,152 @@
+// Cross-platform Skia raster screenshot backend (#3329 Win/Linux parity).
+//
+// Apple has a native CoreGraphics + Skia screenshot path in
+// platform/mac/screenshot_mac.mm. On Windows/Linux there was previously NO
+// built-in render backend — render_to_png/file/rgba returned empty unless a
+// host registered a ScreenshotProvider (screenshot_stub.cpp). That left the
+// foreign-host embed SDK (pulp_embed_render_frame_rgba / _png) unable to
+// produce a deterministic frame on non-Apple platforms out of the box.
+//
+// This file provides the missing built-in backend using Skia's portable raster
+// surface (SkSurfaces::Raster — pure CPU, no GPU/llvmpipe required, so it works
+// in a headless VM) and SkPngEncoder for the PNG encode. It is the exact same
+// raster shape as render_*_skia in screenshot_mac.mm, lifted to a platform-
+// neutral C++ TU so Linux + Windows share one implementation.
+//
+// Compilation: only on non-Apple builds that have Skia (PULP_HAS_SKIA). The
+// provider-registration API (set/clear/has_screenshot_provider) stays in
+// screenshot_stub.cpp and is always compiled; the stub's render_* fallback
+// impls are gated OFF when this file is present (see screenshot_stub.cpp and
+// core/view/CMakeLists.txt) so there is exactly one definition.
+
+#include <pulp/view/screenshot.hpp>
+
+#if !defined(__APPLE__) && defined(PULP_HAS_SKIA)
+
+#include <pulp/canvas/skia_canvas.hpp>
+
+#include "include/core/SkCanvas.h"
+#include "include/core/SkColorSpace.h"
+#include "include/core/SkData.h"
+#include "include/core/SkImageInfo.h"
+#include "include/core/SkPixmap.h"
+#include "include/core/SkSurface.h"
+#include "include/encode/SkPngEncoder.h"
+
+#include <fstream>
+#include <mutex>
+#include <utility>
+
+namespace pulp::view {
+
+// Defined in screenshot_stub.cpp — the host-registered provider lookup. We
+// declare it here so the built-in Skia backend can still honor an explicit
+// host provider (e.g. a GPU-accurate capture the host wants to override with),
+// preserving the pre-existing contract that a registered provider wins.
+std::vector<uint8_t> invoke_screenshot_provider(View& root, uint32_t width,
+                                                uint32_t height, float scale,
+                                                ScreenshotBackend backend,
+                                                bool* had_provider);
+
+namespace {
+
+// Paint the view tree into an already-configured SkCanvas. Mirrors the macOS
+// raster path: dark fill, lay out at logical size, paint widgets + overlays.
+void paint_root(SkCanvas* sk_canvas, View& root, uint32_t width,
+                uint32_t height, float scale) {
+    if (scale != 1.0f) sk_canvas->scale(scale, scale);
+
+    pulp::canvas::SkiaCanvas canvas(sk_canvas);
+    canvas.set_fill_color(pulp::canvas::Color::rgba8(30, 30, 46));
+    canvas.fill_rect(0, 0, static_cast<float>(width), static_cast<float>(height));
+
+    root.set_bounds({0, 0, static_cast<float>(width), static_cast<float>(height)});
+    root.layout_children();
+    root.paint_all(canvas);
+    pulp::view::View::paint_overlays(canvas, &root);
+}
+
+// Raster-render `root` into a tightly packed pixel buffer of `color_type`.
+// Returns empty on failure; writes pixel dims to out_w/out_h on success.
+std::vector<uint8_t> raster_render(View& root, uint32_t width, uint32_t height,
+                                   float scale, SkColorType color_type,
+                                   uint32_t* out_w, uint32_t* out_h) {
+    const uint32_t pixel_w = static_cast<uint32_t>(width * scale);
+    const uint32_t pixel_h = static_cast<uint32_t>(height * scale);
+    if (pixel_w == 0 || pixel_h == 0) return {};
+
+    auto color_space = SkColorSpace::MakeSRGB();
+    SkImageInfo info = SkImageInfo::Make(pixel_w, pixel_h, color_type,
+                                         kPremul_SkAlphaType, color_space);
+    auto surface = SkSurfaces::Raster(info);
+    if (!surface) return {};
+    auto* sk_canvas = surface->getCanvas();
+    if (!sk_canvas) return {};
+
+    paint_root(sk_canvas, root, width, height, scale);
+
+    std::vector<uint8_t> pixels(static_cast<size_t>(pixel_w) * pixel_h * 4u);
+    SkPixmap pixmap(info, pixels.data(), static_cast<size_t>(pixel_w) * 4u);
+    if (!surface->readPixels(pixmap, 0, 0)) return {};
+
+    if (out_w) *out_w = pixel_w;
+    if (out_h) *out_h = pixel_h;
+    return pixels;
+}
+
+}  // namespace
+
+std::vector<uint8_t> render_to_png(View& root, uint32_t width, uint32_t height,
+                                   float scale, ScreenshotBackend backend) {
+    // Honor an explicit host-registered provider first (parity with the
+    // pre-built-in-backend contract: a host that installed a provider expects
+    // it to be used). Falls through to the built-in Skia raster otherwise.
+    bool had_provider = false;
+    auto via_provider = invoke_screenshot_provider(root, width, height, scale,
+                                                   backend, &had_provider);
+    if (had_provider) return via_provider;
+
+    // The only built-in non-Apple backend is Skia raster; coregraphics is
+    // Apple-only, so any requested backend maps to the Skia path here.
+    uint32_t pw = 0, ph = 0;
+    auto pixels = raster_render(root, width, height, scale, kRGBA_8888_SkColorType,
+                                &pw, &ph);
+    if (pixels.empty()) return {};
+
+    SkImageInfo info = SkImageInfo::Make(pw, ph, kRGBA_8888_SkColorType,
+                                         kPremul_SkAlphaType,
+                                         SkColorSpace::MakeSRGB());
+    SkPixmap pixmap(info, pixels.data(), static_cast<size_t>(pw) * 4u);
+    sk_sp<SkData> png = SkPngEncoder::Encode(nullptr, pixmap, SkPngEncoder::Options{});
+    if (!png || png->isEmpty()) return {};
+
+    const auto* bytes = static_cast<const uint8_t*>(png->data());
+    return std::vector<uint8_t>(bytes, bytes + png->size());
+}
+
+bool render_to_file(View& root, uint32_t width, uint32_t height,
+                    const std::string& output_path, float scale,
+                    ScreenshotBackend backend) {
+    auto png = render_to_png(root, width, height, scale, backend);
+    if (png.empty()) return false;
+    std::ofstream out(output_path, std::ios::binary);
+    if (!out) return false;
+    out.write(reinterpret_cast<const char*>(png.data()),
+              static_cast<std::streamsize>(png.size()));
+    return out.good();
+}
+
+std::vector<uint8_t> render_to_rgba(View& root, uint32_t width, uint32_t height,
+                                    float scale, uint32_t* out_width,
+                                    uint32_t* out_height) {
+    if (out_width) *out_width = 0;
+    if (out_height) *out_height = 0;
+    // Explicit RGBA byte order (R,G,B,A) so the buffer is endianness-
+    // independent and host-uploadable, matching render_to_rgba_skia on macOS.
+    return raster_render(root, width, height, scale, kRGBA_8888_SkColorType,
+                         out_width, out_height);
+}
+
+}  // namespace pulp::view
+
+#endif  // !defined(__APPLE__) && defined(PULP_HAS_SKIA)

--- a/core/view/src/screenshot_skia.cpp
+++ b/core/view/src/screenshot_skia.cpp
@@ -117,7 +117,10 @@ std::vector<uint8_t> render_to_png(View& root, uint32_t width, uint32_t height,
                                          kPremul_SkAlphaType,
                                          SkColorSpace::MakeSRGB());
     SkPixmap pixmap(info, pixels.data(), static_cast<size_t>(pw) * 4u);
-    sk_sp<SkData> png = SkPngEncoder::Encode(nullptr, pixmap, SkPngEncoder::Options{});
+    // 2-arg pixmap overload (returns sk_sp<SkData>); the 3-arg
+    // Encode(SkWStream*, ...) returns bool, so a null first arg there is the
+    // wrong overload (matches headless_surface.cpp).
+    sk_sp<SkData> png = SkPngEncoder::Encode(pixmap, SkPngEncoder::Options{});
     if (!png || png->isEmpty()) return {};
 
     const auto* bytes = static_cast<const uint8_t*>(png->data());

--- a/core/view/src/screenshot_stub.cpp
+++ b/core/view/src/screenshot_stub.cpp
@@ -87,6 +87,18 @@ bool render_to_file(
     return out.good();
 }
 
+// Raw-RGBA render is unsupported on platforms without a native raster path.
+// The registered ScreenshotProvider is PNG-only (no raw-pixel contract), so
+// there is no portable producer here yet — return empty explicitly.
+std::vector<uint8_t> render_to_rgba(
+    View& /*root*/, uint32_t /*width*/, uint32_t /*height*/, float /*scale*/,
+    uint32_t* out_width, uint32_t* out_height)
+{
+    if (out_width) *out_width = 0;
+    if (out_height) *out_height = 0;
+    return {};
+}
+
 #endif // !defined(__APPLE__) || TARGET_OS_IOS
 
 } // namespace pulp::view

--- a/core/view/src/screenshot_stub.cpp
+++ b/core/view/src/screenshot_stub.cpp
@@ -53,24 +53,46 @@ bool has_screenshot_provider() {
     return g_provider_installed;
 }
 
-// Compile render impls when no native impl takes precedence.
-// macOS has native screenshot_mac.mm; iOS does NOT yet have native,
-// so include the stub on iOS too.
-#if !defined(__APPLE__) || TARGET_OS_IOS
+// Shared provider-invocation helper. Copies the registered provider out under
+// the lock (#313 Codex P2: never call it while holding the mutex), releases,
+// then invokes. `*had_provider` reports whether a provider was installed so
+// callers can distinguish "no provider, fall back" from "provider returned
+// empty (render failed)". Used by both the no-Skia fallback render path below
+// AND the built-in Skia backend (screenshot_skia.cpp), so a host that installs
+// a provider still wins on every non-Apple build.
+std::vector<uint8_t> invoke_screenshot_provider(View& root, uint32_t width,
+                                                uint32_t height, float scale,
+                                                ScreenshotBackend backend,
+                                                bool* had_provider) {
+    ScreenshotProvider local;
+    {
+        std::lock_guard lock(g_provider_mu);
+        if (!g_provider_installed || !g_provider) {
+            if (had_provider) *had_provider = false;
+            return {};
+        }
+        local = g_provider;
+    }
+    if (had_provider) *had_provider = true;
+    return local(root, width, height, scale, backend);
+}
+
+// Compile the fallback render impls only when no built-in render backend takes
+// precedence:
+//   - macOS:  native screenshot_mac.mm provides render_*; not compiled here.
+//   - iOS:    no iOS-native render impl yet, so the provider-backed fallback
+//             below is what iOS uses (compiled even when Skia is present).
+//   - Linux/Windows WITH Skia: screenshot_skia.cpp provides a built-in raster
+//             backend; the fallback below is NOT compiled (would collide).
+//   - Linux/Windows WITHOUT Skia / Android: provider-backed fallback below.
+#if (!defined(__APPLE__) && !defined(PULP_HAS_SKIA)) || (defined(__APPLE__) && TARGET_OS_IOS)
 
 std::vector<uint8_t> render_to_png(
     View& root, uint32_t width, uint32_t height, float scale,
     ScreenshotBackend backend)
 {
-    // #313 Codex P2: copy the provider out, release the lock, then
-    // invoke. The provider can be long-running or re-enter the API.
-    ScreenshotProvider local;
-    {
-        std::lock_guard lock(g_provider_mu);
-        if (!g_provider_installed || !g_provider) return {};
-        local = g_provider;
-    }
-    return local(root, width, height, scale, backend);
+    bool had = false;
+    return invoke_screenshot_provider(root, width, height, scale, backend, &had);
 }
 
 bool render_to_file(
@@ -99,6 +121,6 @@ std::vector<uint8_t> render_to_rgba(
     return {};
 }
 
-#endif // !defined(__APPLE__) || TARGET_OS_IOS
+#endif // (!__APPLE__ && !PULP_HAS_SKIA) || (__APPLE__ && TARGET_OS_IOS)
 
 } // namespace pulp::view

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3981,6 +3981,30 @@ if(APPLE OR PULP_HAS_SKIA)
     catch_discover_tests(pulp-test-screenshot)
 endif()
 
+# #3329 — native PluginViewHost factory + headless-capture proof on non-Apple.
+# Built only where core/view actually compiled a platform host: Windows with
+# Skia, or non-Android UNIX with Skia + X11. Mirrors the core/view/CMakeLists
+# conditions. The host degrades to capture-only when no display server is
+# present (headless CI VM), and capture_back_buffer_png() still yields a frame.
+if(PULP_HAS_SKIA AND NOT APPLE AND NOT ANDROID)
+    set(_pulp_has_platform_pvh OFF)
+    if(WIN32)
+        set(_pulp_has_platform_pvh ON)
+    elseif(UNIX)
+        find_package(X11 QUIET)
+        if(X11_FOUND)
+            set(_pulp_has_platform_pvh ON)
+        endif()
+    endif()
+    if(_pulp_has_platform_pvh)
+        add_executable(pulp-test-plugin-view-host-factory
+            test_plugin_view_host_factory.cpp)
+        target_link_libraries(pulp-test-plugin-view-host-factory
+            PRIVATE pulp::view Catch2::Catch2WithMain)
+        catch_discover_tests(pulp-test-plugin-view-host-factory)
+    endif()
+endif()
+
 if(APPLE)
     # P1 — smart capture (capture_view) + offscreen-GPU path (render_to_png_gpu).
     add_executable(pulp-test-screenshot-gpu test_screenshot_gpu.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3970,12 +3970,18 @@ if(_PULP_NODE_FOR_TESTS)
         LABELS "ios-d3b;node;threejs")
 endif()
 
-# Screenshot tests (macOS only — uses CoreGraphics bitmap context)
-if(APPLE)
+# Screenshot tests. macOS uses the CoreGraphics bitmap context; non-Apple
+# builds with Skia use the built-in cross-platform Skia raster backend
+# (#3329 Win/Linux parity), so the test runs there too and proves the
+# headless render_to_png/rgba path the foreign-host embed depends on. A
+# non-Apple build WITHOUT Skia has no backend, so skip there.
+if(APPLE OR PULP_HAS_SKIA)
     add_executable(pulp-test-screenshot test_screenshot.cpp)
     target_link_libraries(pulp-test-screenshot PRIVATE pulp::view Catch2::Catch2WithMain)
     catch_discover_tests(pulp-test-screenshot)
+endif()
 
+if(APPLE)
     # P1 — smart capture (capture_view) + offscreen-GPU path (render_to_png_gpu).
     add_executable(pulp-test-screenshot-gpu test_screenshot_gpu.cpp)
     target_link_libraries(pulp-test-screenshot-gpu PRIVATE pulp::view Catch2::Catch2WithMain)

--- a/test/test_plugin_view_host_factory.cpp
+++ b/test/test_plugin_view_host_factory.cpp
@@ -1,0 +1,53 @@
+// Non-Apple PluginViewHost factory registration + headless capture proof
+// (#3329 Win/Linux parity). On Windows/Linux the platform host registers itself
+// via register_platform_plugin_view_host(), so PluginViewHost::create() returns
+// a real host without the caller installing a factory. Even with no display
+// server (headless CI VM), the host degrades to a capture-only mode whose
+// capture_back_buffer_png() still produces a valid frame via Skia raster.
+//
+// This test is built only on a non-Apple build that has a native platform host
+// (PULP_TEST_HAS_PLATFORM_PLUGIN_VIEW_HOST, set from CMake). Apple has built-in
+// NSView/UIView hosts and a different capture contract, so it is excluded.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/view/plugin_view_host.hpp>
+#include <pulp/view/theme.hpp>
+#include <pulp/view/view.hpp>
+#include <pulp/view/widgets.hpp>
+
+using namespace pulp::view;
+
+TEST_CASE("register_platform_plugin_view_host installs a factory",
+          "[view][plugin-view-host][factory]") {
+    register_platform_plugin_view_host();
+    REQUIRE(PluginViewHost::has_factory());
+}
+
+TEST_CASE("PluginViewHost::create returns a native host with headless capture",
+          "[view][plugin-view-host][create]") {
+    View root;
+    root.set_theme(Theme::dark());
+    auto knob = std::make_unique<Knob>();
+    knob->set_bounds({8, 8, 48, 48});
+    knob->set_value(0.5f);
+    root.add_child(std::move(knob));
+
+    PluginViewHost::Options opts;
+    opts.size = {64, 64};
+    opts.use_gpu = true;  // host falls back to raster capture if GPU/display absent
+    auto host = PluginViewHost::create(root, opts);
+    REQUIRE(host != nullptr);
+
+    auto size = host->get_size();
+    REQUIRE(size.width == 64);
+    REQUIRE(size.height == 64);
+
+    // Headless capture must yield a valid PNG even with no display server /
+    // no GPU — the deterministic frame the foreign-host embed smoke relies on.
+    auto png = host->capture_back_buffer_png();
+    REQUIRE_FALSE(png.empty());
+    REQUIRE(png.size() > 8);
+    REQUIRE(png[0] == 0x89);  // PNG magic
+    REQUIRE(png[1] == 'P');
+}

--- a/test/test_screenshot.cpp
+++ b/test/test_screenshot.cpp
@@ -33,7 +33,10 @@ TEST_CASE("Screenshot renders to PNG buffer", "[view][screenshot]") {
 
     auto png = render_to_png(root, 200, 80, 1.0f);
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(PULP_HAS_SKIA)
+    // Apple has a native CoreGraphics backend; non-Apple builds with Skia get
+    // the built-in cross-platform Skia raster backend (#3329 Win/Linux parity,
+    // screenshot_skia.cpp). Either way a valid PNG comes back.
     REQUIRE_FALSE(png.empty());
     // PNG magic bytes: 0x89 P N G
     REQUIRE(png.size() > 8);
@@ -42,7 +45,7 @@ TEST_CASE("Screenshot renders to PNG buffer", "[view][screenshot]") {
     REQUIRE(png[2] == 'N');
     REQUIRE(png[3] == 'G');
 #else
-    // Non-Apple platforms return empty (no CoreGraphics)
+    // Non-Apple WITHOUT Skia and no host provider: explicitly empty.
     REQUIRE(png.empty());
 #endif
 }
@@ -60,7 +63,7 @@ TEST_CASE("Screenshot renders to file", "[view][screenshot]") {
 
     bool ok = render_to_file(root, 60, 120, output_path.string(), 1.0f);
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(PULP_HAS_SKIA)
     REQUIRE(ok);
     REQUIRE(std::filesystem::exists(output_path));
     REQUIRE(std::filesystem::file_size(output_path) > 100); // Not empty
@@ -74,19 +77,54 @@ TEST_CASE("Screenshot renders to file", "[view][screenshot]") {
 
 // ── Edge cases: non-Apple, scale, malformed output path ─────────────────
 
-TEST_CASE("Screenshot on non-Apple reports unsupported honestly",
+TEST_CASE("Screenshot backend availability is honest per build",
           "[view][screenshot][edge]") {
-    // The doc contract on every non-Apple platform is "return empty
-    // PNG bytes, return false from render_to_file" — never silently
-    // fake-success. Pin it against an empty view tree too, so a
-    // future refactor doesn't start fake-succeeding when there's
-    // nothing to render.
+    // Contract: render_* must never silently fake-success. On a build with a
+    // real backend (Apple CoreGraphics, or non-Apple Skia raster — #3329) it
+    // returns valid PNG bytes even for an empty view tree (a solid background
+    // frame). On a no-backend build (non-Apple, no Skia, no host provider) it
+    // returns empty rather than lying. Pin it against an empty tree so a future
+    // refactor can't start fake-succeeding with nothing to render.
     View root;
     auto png = render_to_png(root, 32, 32, 1.0f);
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(PULP_HAS_SKIA)
     REQUIRE_FALSE(png.empty());
+    REQUIRE(png.size() > 8);
+    REQUIRE(png[0] == 0x89);  // PNG magic
 #else
     REQUIRE(png.empty());
+#endif
+}
+
+// #3329 — the built-in Skia raster backend on non-Apple must produce a real,
+// non-black RGBA buffer via render_to_rgba (the foreign-host embed's
+// pulp_embed_render_frame_rgba path). This is the headless render proof that
+// works in a GPU-less CI VM (Skia raster is pure CPU).
+TEST_CASE("Screenshot render_to_rgba produces non-black pixels (Skia raster)",
+          "[view][screenshot][rgba]") {
+#if defined(__APPLE__) || defined(PULP_HAS_SKIA)
+    View root;
+    root.set_theme(Theme::dark());
+    auto knob = std::make_unique<Knob>();
+    knob->set_bounds({8, 8, 48, 48});
+    knob->set_value(0.5f);
+    root.add_child(std::move(knob));
+
+    uint32_t pw = 0, ph = 0;
+    auto rgba = render_to_rgba(root, 64, 64, 1.0f, &pw, &ph);
+    REQUIRE_FALSE(rgba.empty());
+    REQUIRE(pw == 64);
+    REQUIRE(ph == 64);
+    REQUIRE(rgba.size() == static_cast<size_t>(pw) * ph * 4u);
+    // The dark background fill (30,30,46) is itself non-black, so every pixel
+    // must have a non-zero channel — proves the raster path actually painted.
+    bool any_nonzero = false;
+    for (size_t i = 0; i < rgba.size(); ++i) {
+        if (rgba[i] != 0) { any_nonzero = true; break; }
+    }
+    REQUIRE(any_nonzero);
+#else
+    SUCCEED("render_to_rgba unsupported without a Skia/native backend");
 #endif
 }
 
@@ -176,7 +214,9 @@ TEST_CASE("Screenshot: backend dispatch — Skia and CoreGraphics both produce v
 
 TEST_CASE("Screenshot of an empty root view still produces a valid PNG",
           "[view][screenshot][empty]") {
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(PULP_HAS_SKIA)
+    // A backend-backed build (Apple CoreGraphics, or non-Apple Skia raster —
+    // #3329) renders the background-filled frame even for an empty tree.
     View root;
     auto png = render_to_png(root, 8, 8, 1.0f);
     REQUIRE_FALSE(png.empty());


### PR DESCRIPTION
## What

Cross-platform headless rendering + Win/Linux plugin-view parity, generalized from the foreign-host embedding experiment (`explore/foreign-host-embed`). Seven commits:

1. **`feat(view)`: `render_to_rgba` raw-pixel headless render seam** — returns raw RGBA bytes (not just a PNG), the primitive a foreign host needs to composite a Pulp view into its own surface. macOS (`screenshot_mac.mm`) + stub fallback.
2. **`docs(skill)`: note `render_to_rgba` in the screenshot skill.**
3. **`view/render`: cross-platform Skia raster screenshot + Dawn X11 surface scaffold** — `screenshot_skia.cpp` gives a platform-independent Skia raster backend (the non-Apple analog of `screenshot_mac.mm`); `gpu_surface_dawn.cpp` gains the X11 surface descriptor path; `plugin_view_host_stub.cpp` + a CMake factory seam.
4. **`view`: native HWND + X11 PluginViewHost implementations (Win/Linux)** — real `plugin_view_host_win.cpp` (child HWND) and `plugin_view_host_linux.cpp` (X11) so a plugin editor view can attach to a foreign parent on those platforms.
5. **`test/view`: fix SkPngEncoder overload; run the screenshot test on non-Apple+Skia.**
6. **`test`: PluginViewHost factory + headless-capture proof (non-Apple)** — `test_plugin_view_host_factory.cpp` (built on Windows+Skia or UNIX+Skia+X11).
7. **`view(win)`: fix HWND host per Codex review** — child-window shape, wndproc, NOMINMAX.

The factory auto-registration wires `WindowHost::create()`-style selection for the new native hosts.

## Tests

- macOS lane: `pulp-test-screenshot` — **all 9 cases / 60 assertions pass**, exercising `render_to_rgba` + the cross-platform screenshot seam. `pulp-view` rebuilds clean; Win/Linux host files are CMake-gated out of the macOS build (verified: only `plugin_view_host_mac.mm` + `_stub.cpp` compile here).
- Win/Linux native hosts + `pulp-test-plugin-view-host-factory` are platform-gated (Windows+Skia / UNIX+Skia+X11) and validated by the GitHub-hosted Linux/Windows advisory CI lanes — they cannot be compiled on the macOS lane.

## Gates

skill-sync ✓ (screenshot SKILL.md updated for `render_to_rgba`). version-bump ✓ (SDK minor 0.356.0→0.357.0 for the new public seams, plugin patch 0.187.0→0.187.1, `chore: bump versions` marker). node-ABI ✓, deps-audit ✓.

Draft — leaving open for review + CI (the Win/Linux compile + factory test land on the cross-platform lanes). Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cross-platform headless `Skia` screenshot backend on non-Apple builds and a new `render_to_rgba` API, plus native `PluginViewHost` for Windows (HWND) and Linux (X11) with auto-registered factories and `Dawn` X11 surface support. This enables deterministic, GPU-free screenshots and native child-window hosts on Win/Linux.

- **New Features**
  - `render_to_rgba`: returns tightly packed RGBA8 (premultiplied sRGB) and pixel dims; available on Apple and on non-Apple builds with `Skia`; empty on builds without a raster backend.
  - Built-in `Skia` raster screenshot on non-Apple + `Skia`: `render_to_png`/`render_to_file`/`render_to_rgba` work headless (no GPU/display); a registered `ScreenshotProvider` still wins.
  - Windows/Linux `PluginViewHost`: child HWND/X11 window, GPU via `Dawn` + `SkiaSurface`, CPU raster fallback and deterministic headless capture; `PluginViewHost::create()` auto-calls `register_platform_plugin_view_host()`.
  - Linux `Dawn` surface: `GpuSurface::X11NativeHandle` (Display* + Window) and Xlib surface creation.

- **Migration**
  - Linux GPU surface init now requires a `GpuSurface::X11NativeHandle*` as `Config::native_surface_handle` (Window alone is insufficient); Wayland not yet supported.
  - No action needed to obtain a host on Win/Linux: the platform factory installs automatically; custom factories can still override later via `PluginViewHost::set_factory()`.
  - Version bump: SDK 0.362.0 → 0.363.0; plugin `pulp` 0.189.0 → 0.190.0.

<sup>Written for commit e1f651acd0202ab5b807d3ebda68cd559b2d2d2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

