### PR TITLE
fix(ci): guard self-hosted macOS build dir against interrupted-build ODR

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1000,6 +1000,25 @@ Pair with launchd / systemd so the watchdog survives reboots. JSON
 contract: `runner.watch` envelopes with `event=auto_kill_worker`,
 `phase ∈ {attempt, killed, failed, no-pid-found}`.
 
+### Prevent: build-dir ODR guard (interrupted-build sentinel)
+
+The self-hosted macОS lane uses `clean: false` (warm `build-<key>` dir for
+fast incremental builds). A build that is **cancelled/interrupted** mid-compile
+leaves partial object files; the next incremental build then mixes object
+layouts → heap corruption / **SEGFAULTs in unrelated tests** (HttpStream,
+model_store, Theme dtor) while a clean github-hosted build passes. This bit
+every open PR on 2026-06-07 after heavy branch churn + many cancelled runs.
+
+`build.yml`'s macОS Configure step writes a `.pulp-build-incomplete` sentinel
+into `$PULP_BUILD_DIR` after configure; the Build step removes it on success.
+If a new job's Configure finds the sentinel still present, the previous build
+did not finish cleanly, so it `rm -rf`s the dir for a pristine rebuild (ccache
+keeps the recompile fast; Skia at `external/skia-build` is untouched). This is
+the durable complement to `--kill-hung-workers`: the watchdog kills the hung
+worker, the sentinel ensures the *next* build doesn't inherit its corruption.
+For an already-corrupted dir (no sentinel yet), clean it once with the personal
+`pulp-runner-ops` skill / `ssh macstudio … rm -rf … build-macos`.
+
 Pulp's local macOS runner runs through `actions-runner` (PIDs surfaced
 via `ps aux | grep Runner.Listener`); the daemon co-exists with the
 existing service.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -736,6 +736,18 @@ jobs:
           if [ "${RUNNER_OS}" = "macOS" ]; then
             command -v ninja >/dev/null 2>&1 || brew install ninja
             gen=(-G Ninja)
+            # ODR guard (see ~/.claude/skills/pulp-runner-ops): an interrupted
+            # or cancelled prior build can leave partial object files in the warm
+            # self-hosted build dir, mixing object layouts on the next
+            # incremental build → heap corruption / SEGFAULTs in unrelated tests
+            # (HttpStream, model_store, etc.). A sentinel marks a build
+            # in-progress; if it survived from last time, the prior build did not
+            # finish cleanly, so recreate the dir for a pristine rebuild (ccache
+            # keeps the recompile fast; Skia at external/skia-build is untouched).
+            if [ -f "$PULP_BUILD_DIR/.pulp-build-incomplete" ]; then
+              echo "macOS Configure: prior build did not finish cleanly → recreating $PULP_BUILD_DIR"
+              rm -rf "$PULP_BUILD_DIR"
+            fi
             cache="$PULP_BUILD_DIR/CMakeCache.txt"
             if [ -f "$cache" ] && ! grep -q '^CMAKE_GENERATOR:INTERNAL=Ninja$' "$cache"; then
               echo "macOS Configure: build-dir generator changed → recreating $PULP_BUILD_DIR"
@@ -747,11 +759,20 @@ jobs:
           else
             cmake -S . -B "$PULP_BUILD_DIR" "${gen[@]}" -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF
           fi
+          # Mark the build in-progress; the Build step clears it on success, so a
+          # build interrupted/cancelled before completion is detected next run
+          # (ODR guard above). Harmless on github-hosted (fresh dir each run).
+          if [ "${RUNNER_OS}" = "macOS" ]; then
+            mkdir -p "$PULP_BUILD_DIR" && : > "$PULP_BUILD_DIR/.pulp-build-incomplete"
+          fi
         shell: bash
 
       - name: Build
         shell: bash
-        run: cmake --build "$PULP_BUILD_DIR" --config Release
+        run: |
+          cmake --build "$PULP_BUILD_DIR" --config Release
+          # Build finished cleanly → clear the in-progress sentinel (ODR guard).
+          rm -f "$PULP_BUILD_DIR/.pulp-build-incomplete"
 
       - name: Ccache stats
         if: always()


### PR DESCRIPTION
## Problem
Self-hosted macOS lane uses `clean: false` (warm build dir). A cancelled/interrupted build leaves partial objects → next incremental build mixes object layouts → **heap corruption / SEGFAULTs in unrelated tests** (HttpStream, model_store, Theme dtor) while clean github-hosted builds pass. This blocked **every open PR on 2026-06-07** after heavy branch churn + many cancelled runs (the macos required gate kept failing with shifting symptoms).

## Fix
A `.pulp-build-incomplete` sentinel in `$PULP_BUILD_DIR`: written after configure, removed on successful build. If a new job's Configure finds it still present, the prior build didn't finish cleanly → `rm -rf` the dir for a pristine rebuild. ccache keeps the recompile fast; Skia (`external/skia-build`) is untouched (unlike `clean: true` which would nuke it). Durable complement to `shipyard runner --kill-hung-workers`.

No code change — CI workflow + ci skill doc only. (For an already-corrupted dir with no sentinel yet, clean once via the `pulp-runner-ops` recipe.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `.pulp-build-incomplete` sentinel to the self-hosted macOS CI build dir to detect interrupted builds and auto-clean before the next run. Prevents mixed object layouts that caused heap corruption and SEGFAULTs in unrelated tests.

- **Bug Fixes**
  - In `build.yml` (macOS): if `$PULP_BUILD_DIR/.pulp-build-incomplete` exists at Configure, `rm -rf` the dir for a clean rebuild; write the sentinel after configure; clear it after a successful build.
  - Preserves `ccache` and `external/skia-build`; GitHub-hosted runners are unaffected.
  - Documented in `.agents/skills/ci/SKILL.md`; complements the runner watchdog by ensuring the next run starts clean.

<sup>Written for commit 24368f2465f964268fd1882e86e44630e9635b32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

