### PR TITLE
feat(view): DesignFrameView event-driven binding API (on_element_changed + gestures + uniform value)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.365.0
+    VERSION 0.366.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/design_frame_view.hpp
+++ b/core/view/include/pulp/view/design_frame_view.hpp
@@ -2,6 +2,7 @@
 
 #include <pulp/view/view.hpp>
 
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -59,12 +60,34 @@ public:
     int element_count() const { return static_cast<int>(elements_.size()); }
     float panel_width() const { return panel_w_; }
     float panel_height() const { return panel_h_; }
-    // Value of element `i` (0..1), or -1 if out of range. For tests/bindings.
+    // Kind of element `i` (knob / dropdown / tab_group / stepper / text_field),
+    // or knob if out of range. Lets a binder treat knobs as continuous params
+    // and dropdown/tab/stepper as normalized-index "choice" params.
+    DesignFrameElement::Kind element_kind(int i) const;
+    // Normalized [0,1] value of element `i`, or -1 if out of range / not a
+    // value-bearing control (text_field). For a knob this is its turn; for a
+    // dropdown/tab_group/stepper it is the live selection mapped to
+    // selected_index / max(1, option_count - 1). Reads the live overlay widget
+    // when one exists. For tests/bindings.
     float element_value(int i) const;
+    // Set element `i` from a normalized [0,1] value WITHOUT firing
+    // on_element_changed (a host->view push: knob turn, or choice index =
+    // round(v * (count-1)) applied to the live overlay widget silently). Use for
+    // automation/preset application so it doesn't echo back to the host.
     void set_element_value(int i, float v);
     // The native-overlay child widget for element `i`, or nullptr (e.g. for a
     // knob, or out of range). For tests/bindings.
     View* overlay_widget(int i) const;
+
+    // Fired when the USER changes an element (knob drag, dropdown/tab/stepper
+    // select) — index + the new normalized value. NOT fired by set_element_value
+    // (that's a programmatic host->view push). A foreign-host binder forwards
+    // this to its parameter system. gesture begin/end bracket a knob drag so the
+    // binder can group an undo step; choice controls fire one changed (no
+    // gesture). All on the UI thread.
+    std::function<void(int index, float value)> on_element_changed;
+    std::function<void(int index)> on_gesture_begin;
+    std::function<void(int index)> on_gesture_end;
 
     // The panel is the view's natural size — a host should size its window to
     // this aspect so the design fills it with no letterbox (see paint()).
@@ -75,8 +98,15 @@ public:
     void layout_children() override;
     void on_mouse_down(Point pos) override;
     void on_mouse_drag(Point pos) override;
+    void on_mouse_up(Point pos) override;
 
 private:
+    // Map a choice element's selected index to a normalized [0,1] value and back,
+    // using its option count. Single source of truth for choice<->normalized.
+    float choice_to_norm(int i, int selected) const;
+    int   norm_to_choice(int i, float v) const;
+    // Sync a user choice change (overlay widget -> element + on_element_changed).
+    void  notify_choice(int i, int selected);
     // Build the native-overlay child widgets (TextEditor / ComboBox / tabs) for
     // the non-knob elements; called once from the constructor.
     void build_overlays();
@@ -114,6 +144,11 @@ public:
     DesignTabGroup(std::vector<std::string> labels, int selected);
     int selected() const { return selected_; }
     int tab_count() const { return static_cast<int>(labels_.size()); }
+    // Set selection without firing on_select (programmatic host->view push).
+    void set_selected_silent(int index);
+    // Fired when the USER taps a different tab (index). Not fired by
+    // set_selected_silent.
+    std::function<void(int index)> on_select;
 
     void paint(canvas::Canvas& canvas) override;
     void on_mouse_down(Point pos) override;
@@ -135,6 +170,11 @@ public:
     int selected() const { return selected_; }
     int option_count() const { return static_cast<int>(options_.size()); }
     const std::string& current() const;
+    // Set selection without firing on_select (programmatic host->view push).
+    void set_selected_silent(int index);
+    // Fired when the USER steps to a different option (index). Not fired by
+    // set_selected_silent.
+    std::function<void(int index)> on_select;
 
     void paint(canvas::Canvas& canvas) override;
     void on_mouse_down(Point pos) override;

--- a/core/view/src/design_frame_view.cpp
+++ b/core/view/src/design_frame_view.cpp
@@ -112,21 +112,26 @@ void DesignFrameView::build_overlays() {
                     std::clamp(e.selected_index, 0,
                                static_cast<int>(e.options.size()) - 1));
             }
+            combo->on_change = [this, i](int idx) { notify_choice(i, idx); };
             widget = std::move(combo);
         } else if (e.kind == DesignFrameElement::Kind::tab_group &&
                    !e.options.empty()) {
             // Opaque segmented control over the design's tab strip; clicking a tab
             // moves the selection highlight (real selection state).
-            widget = std::make_unique<DesignTabGroup>(
+            auto tabs = std::make_unique<DesignTabGroup>(
                 e.options, std::clamp(e.selected_index, 0,
                                       static_cast<int>(e.options.size()) - 1));
+            tabs->on_select = [this, i](int idx) { notify_choice(i, idx); };
+            widget = std::move(tabs);
         } else if (e.kind == DesignFrameElement::Kind::stepper &&
                    !e.options.empty()) {
             // `< >` stepper over the design's header preset selector: the value
             // text slides as the chevrons step through the options in place.
-            widget = std::make_unique<DesignStepper>(
+            auto stepper = std::make_unique<DesignStepper>(
                 e.options, std::clamp(e.selected_index, 0,
                                       static_cast<int>(e.options.size()) - 1));
+            stepper->on_select = [this, i](int idx) { notify_choice(i, idx); };
+            widget = std::move(stepper);
         }
         if (widget) {
             View* raw = widget.get();
@@ -136,14 +141,78 @@ void DesignFrameView::build_overlays() {
     }
 }
 
+DesignFrameElement::Kind DesignFrameView::element_kind(int i) const {
+    if (i < 0 || i >= static_cast<int>(elements_.size()))
+        return DesignFrameElement::Kind::knob;
+    return elements_[i].kind;
+}
+
+float DesignFrameView::choice_to_norm(int i, int selected) const {
+    if (i < 0 || i >= static_cast<int>(elements_.size())) return 0.0f;
+    const int n = static_cast<int>(elements_[i].options.size());
+    if (n <= 1) return 0.0f;
+    return std::clamp(selected, 0, n - 1) / static_cast<float>(n - 1);
+}
+
+int DesignFrameView::norm_to_choice(int i, float v) const {
+    if (i < 0 || i >= static_cast<int>(elements_.size())) return 0;
+    const int n = static_cast<int>(elements_[i].options.size());
+    if (n <= 1) return 0;
+    return std::clamp(static_cast<int>(std::clamp(v, 0.0f, 1.0f) * (n - 1) + 0.5f),
+                      0, n - 1);
+}
+
+void DesignFrameView::notify_choice(int i, int selected) {
+    if (i >= 0 && i < static_cast<int>(elements_.size()))
+        elements_[i].selected_index = selected;
+    if (on_element_changed) on_element_changed(i, choice_to_norm(i, selected));
+}
+
 float DesignFrameView::element_value(int i) const {
     if (i < 0 || i >= static_cast<int>(elements_.size())) return -1.0f;
-    return elements_[i].value;
+    const auto& e = elements_[i];
+    switch (e.kind) {
+        case DesignFrameElement::Kind::knob:
+            return e.value;
+        case DesignFrameElement::Kind::dropdown:
+        case DesignFrameElement::Kind::tab_group:
+        case DesignFrameElement::Kind::stepper: {
+            int sel = e.selected_index;  // live widget wins when present
+            if (View* w = overlay_widget(i)) {
+                if (auto* c = dynamic_cast<ComboBox*>(w)) sel = c->selected();
+                else if (auto* t = dynamic_cast<DesignTabGroup*>(w)) sel = t->selected();
+                else if (auto* s = dynamic_cast<DesignStepper*>(w)) sel = s->selected();
+            }
+            return choice_to_norm(i, sel);
+        }
+        case DesignFrameElement::Kind::text_field:
+            return -1.0f;  // text is not a normalized value
+    }
+    return -1.0f;
 }
 
 void DesignFrameView::set_element_value(int i, float v) {
     if (i < 0 || i >= static_cast<int>(elements_.size())) return;
-    elements_[i].value = std::clamp(v, 0.0f, 1.0f);
+    auto& e = elements_[i];
+    switch (e.kind) {
+        case DesignFrameElement::Kind::knob:
+            e.value = std::clamp(v, 0.0f, 1.0f);
+            break;
+        case DesignFrameElement::Kind::dropdown:
+        case DesignFrameElement::Kind::tab_group:
+        case DesignFrameElement::Kind::stepper: {
+            const int idx = norm_to_choice(i, v);
+            e.selected_index = idx;
+            if (View* w = overlay_widget(i)) {  // silent: host->view push, no echo
+                if (auto* c = dynamic_cast<ComboBox*>(w)) c->set_selected_silent(idx);
+                else if (auto* t = dynamic_cast<DesignTabGroup*>(w)) t->set_selected_silent(idx);
+                else if (auto* s = dynamic_cast<DesignStepper*>(w)) s->set_selected_silent(idx);
+            }
+            break;
+        }
+        case DesignFrameElement::Kind::text_field:
+            return;  // not a normalized value
+    }
     request_repaint();
 }
 
@@ -215,7 +284,11 @@ int DesignFrameView::hit_element(Point pos) const {
 
 void DesignFrameView::on_mouse_down(Point pos) {
     drag_ = hit_element(pos);
-    if (drag_ >= 0) { drag_start_y_ = pos.y; drag_start_value_ = elements_[drag_].value; }
+    if (drag_ >= 0) {
+        drag_start_y_ = pos.y;
+        drag_start_value_ = elements_[drag_].value;
+        if (on_gesture_begin) on_gesture_begin(drag_);  // bracket the undo step
+    }
 }
 
 void DesignFrameView::on_mouse_drag(Point pos) {
@@ -227,6 +300,13 @@ void DesignFrameView::on_mouse_drag(Point pos) {
     elements_[drag_].value =
         std::clamp(drag_start_value_ + dy_design * 0.005f, 0.0f, 1.0f);
     request_repaint();
+    // User-driven turn -> notify the binder (knob is value-bearing).
+    if (on_element_changed) on_element_changed(drag_, elements_[drag_].value);
+}
+
+void DesignFrameView::on_mouse_up(Point /*pos*/) {
+    if (drag_ >= 0 && on_gesture_end) on_gesture_end(drag_);
+    drag_ = -1;
 }
 
 // ── DesignTabGroup ──────────────────────────────────────────────────────────
@@ -269,13 +349,23 @@ void DesignTabGroup::paint(canvas::Canvas& canvas) {
     }
 }
 
+void DesignTabGroup::set_selected_silent(int index) {
+    if (labels_.empty()) return;
+    const int idx = std::clamp(index, 0, static_cast<int>(labels_.size()) - 1);
+    if (idx != selected_) { selected_ = idx; request_repaint(); }
+}
+
 void DesignTabGroup::on_mouse_down(Point pos) {
     const auto b = local_bounds();
     if (labels_.empty() || b.width <= 0) return;
     const int n = static_cast<int>(labels_.size());
     int idx = static_cast<int>(pos.x / (b.width / static_cast<float>(n)));
     idx = std::clamp(idx, 0, n - 1);
-    if (idx != selected_) { selected_ = idx; request_repaint(); }
+    if (idx != selected_) {
+        selected_ = idx;
+        request_repaint();
+        if (on_select) on_select(idx);  // user tap
+    }
 }
 
 // ── DesignStepper ─────────────────────────────────────────────────────────
@@ -319,6 +409,12 @@ void DesignStepper::paint(canvas::Canvas& canvas) {
     canvas.fill_text(val, (b.width - tw) * 0.5f, ty);
 }
 
+void DesignStepper::set_selected_silent(int index) {
+    if (options_.empty()) return;
+    const int idx = std::clamp(index, 0, static_cast<int>(options_.size()) - 1);
+    if (idx != selected_) { selected_ = idx; request_repaint(); }
+}
+
 void DesignStepper::on_mouse_down(Point pos) {
     const auto b = local_bounds();
     if (options_.empty() || b.width <= 0) return;
@@ -327,7 +423,11 @@ void DesignStepper::on_mouse_down(Point pos) {
     if (pos.x < b.width * 0.5f) next = selected_ - 1;  // left half: previous
     else                        next = selected_ + 1;  // right half: next
     next = std::clamp(next, 0, n - 1);
-    if (next != selected_) { selected_ = next; request_repaint(); }
+    if (next != selected_) {
+        selected_ = next;
+        request_repaint();
+        if (on_select) on_select(next);  // user step
+    }
 }
 
 }  // namespace pulp::view

--- a/test/test_design_frame_view.cpp
+++ b/test/test_design_frame_view.cpp
@@ -7,6 +7,7 @@
 // rendered output, and fail-safe behavior — with no design-import dependency.
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 
 #include <pulp/view/design_frame_view.hpp>
 #include <pulp/view/input_events.hpp>
@@ -355,4 +356,67 @@ TEST_CASE("DesignFrameView is fail-safe on an empty/garbage SVG",
     // out). Render path returns an empty/uniform image; the call must be safe.
     auto png = render_to_png(empty, 40, 40, 1.0f, ScreenshotBackend::skia);
     SUCCEED("paint with empty SVG did not crash");
+}
+
+// ── v2: event-driven binding (on_element_changed + gestures) + uniform value ──
+
+namespace {
+// A dropdown element with three options, initially on index 1.
+DesignFrameElement make_dropdown() {
+    DesignFrameElement d;
+    d.kind = DesignFrameElement::Kind::dropdown;
+    d.x = 12; d.y = 12; d.w = 60; d.h = 16;
+    d.options = {"A", "B", "C"};
+    d.selected_index = 1;
+    return d;
+}
+}  // namespace
+
+TEST_CASE("DesignFrameView knob drag fires on_element_changed + gesture begin/end",
+          "[view][design-import][frame][binding]") {
+    DesignFrameView v(make_design_svg(), {make_knob()});
+    v.set_bounds({0, 0, 100, 100});
+
+    int begins = 0, ends = 0, changes = 0;
+    float last = -1.0f;
+    v.on_gesture_begin   = [&](int i) { CHECK(i == 0); ++begins; };
+    v.on_gesture_end     = [&](int i) { CHECK(i == 0); ++ends; };
+    v.on_element_changed = [&](int i, float val) { CHECK(i == 0); last = val; ++changes; };
+
+    v.on_mouse_down({40, 40});   // on the knob
+    v.on_mouse_drag({40, 10});   // turn up
+    v.on_mouse_up({40, 10});
+
+    CHECK(begins == 1);
+    CHECK(ends == 1);
+    CHECK(changes >= 1);
+    CHECK(last > 0.5f);                       // the reported value tracked the turn
+    CHECK(v.element_value(0) == last);        // accessor agrees with the callback
+
+    // set_element_value is a programmatic push: it must NOT fire on_element_changed.
+    const int before = changes;
+    v.set_element_value(0, 0.25f);
+    CHECK(changes == before);
+    CHECK(v.element_value(0) == 0.25f);
+}
+
+TEST_CASE("DesignFrameView exposes a choice control as a normalized param",
+          "[view][design-import][frame][binding]") {
+    DesignFrameView v(make_design_svg(), {make_dropdown()});
+    v.set_bounds({0, 0, 100, 100});
+
+    REQUIRE(v.element_kind(0) == DesignFrameElement::Kind::dropdown);
+    // 3 options -> indices 0,1,2 map to 0, 0.5, 1.0. Initial index 1 -> 0.5.
+    CHECK(v.element_value(0) == Catch::Approx(0.5f));
+
+    // Host push: 1.0 -> last option (index 2), silently (no on_element_changed).
+    int changes = 0;
+    v.on_element_changed = [&](int, float) { ++changes; };
+    v.set_element_value(0, 1.0f);
+    CHECK(v.element_value(0) == Catch::Approx(1.0f));
+    CHECK(changes == 0);
+
+    // 0.0 -> first option (index 0).
+    v.set_element_value(0, 0.0f);
+    CHECK(v.element_value(0) == Catch::Approx(0.0f));
 }


### PR DESCRIPTION
## What

Adds the binding surface `DesignFrameView` (the faithful-vector design-import view) was missing, so a foreign-host embedder (and any binder) can drive its native controls event-driven:

- **`on_element_changed(index, value)`** — fired on **user** changes only (knob drag, dropdown/tab/stepper select); **not** by `set_element_value` (a programmatic host→view push).
- **`on_gesture_begin/end(index)`** — bracket a knob drag for undo grouping.
- **`element_kind(i)` + uniform `element_value`/`set_element_value`** across kinds — knob turn, or a choice control mapped to `selected_index / max(1, count-1)`. `set_*` applies the choice **silently** (no echo) for automation/preset.
- **`DesignTabGroup`/`DesignStepper`**: `on_select` + `set_selected_silent`; `ComboBox`'s `on_change` wired through; `on_mouse_up` added for gesture end.

## Why

The faithful-vector lane renders native knobs + overlay controls, but they had no observable change signal and no uniform value accessor — so a host could only poll knobs, and couldn't bind dropdown/tab/stepper or get real gestures. This is the clean, event-driven foundation the `pulp-view-embed` SDK uses to host-bind faithful-vector controls (replacing a per-tick poll).

## Tests

`test_design_frame_view.cpp`: callback + gesture firing on a knob drag, `set_element_value` stays silent, and a choice control round-trips as a normalized param. Full suite green (16 cases / 85 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an event-driven binding API to DesignFrameView so hosts can observe user changes, bracket knob drags as gestures, and read/write control values uniformly without polling.
Enables binding of knobs and choice controls (dropdown/tab/stepper) as normalized params.

- New Features
  - on_element_changed(index, value) fires on user changes only; set_element_value is silent.
  - on_gesture_begin/on_gesture_end bracket knob drags for undo grouping.
  - element_kind plus normalized element_value/set_element_value across knobs and choice controls (index mapped over count-1).
  - DesignTabGroup and DesignStepper expose on_select and set_selected_silent; ComboBox on_change wired; on_mouse_up added to end gestures.

- Dependencies
  - Bump project version to 0.366.0.

<sup>Written for commit 0154f459071f74ba7b73b3670c95bbec6e7c6970. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

