### PR TITLE
feat(view): ScriptedUiSession explicit reload() / reload_from() (on-demand, last-good)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.366.0
+    VERSION 0.367.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/scripted_ui.hpp
+++ b/core/view/include/pulp/view/scripted_ui.hpp
@@ -38,6 +38,17 @@ public:
     bool load(std::string* error = nullptr);
     bool poll(std::string* error = nullptr);
 
+    // Explicitly reload the current script in place: rebuilds the widget bridge
+    // under the SAME root + GPU surface, preserving widget state, and probes the
+    // new code first so a bad reload keeps the last-good UI. The on-demand
+    // counterpart to enable_hot_reload's file-watched poll() — for a host/editor
+    // that wants to reload a just-edited bundle without a file watcher.
+    bool reload(std::string* error = nullptr);
+    // Repoint at a different script file and reload it (e.g. swap to another
+    // design bundle's ui.js). Updates script_path()/theme_path(); same in-place,
+    // last-good semantics as reload(). Does not re-arm the hot-reload watcher.
+    bool reload_from(std::filesystem::path script_path, std::string* error = nullptr);
+
     void set_repaint_callback(std::function<void()> cb);
     WidgetBridge* bridge() const { return bridge_.get(); }
 

--- a/core/view/src/scripted_ui.cpp
+++ b/core/view/src/scripted_ui.cpp
@@ -77,6 +77,26 @@ bool ScriptedUiSession::load(std::string* error) {
     return true;
 }
 
+bool ScriptedUiSession::reload(std::string* error) {
+    auto code = read_text_file(script_path_);
+    if (code.empty()) {
+        if (error) *error = "could not read script file: " + script_path_.string();
+        return false;
+    }
+    // preserve_state=true: keep widget values across the rebuild; rebuild_from_code
+    // probes the new code on a throwaway tree first, so a bad reload leaves the
+    // current UI intact.
+    return rebuild_from_code(code, /*preserve_state=*/true, error);
+}
+
+bool ScriptedUiSession::reload_from(std::filesystem::path script_path, std::string* error) {
+    script_path_ = std::move(script_path);
+    theme_path_ = script_path_.parent_path() / "theme.json";
+    last_theme_exists_ = std::filesystem::exists(theme_path_);
+    last_theme_write_time_ = last_theme_exists_ ? safe_last_write_time(theme_path_) : std::nullopt;
+    return reload(error);
+}
+
 bool ScriptedUiSession::poll(std::string* error) {
     bool changed = false;
     if (bridge_) {

--- a/test/test_scripted_ui.cpp
+++ b/test/test_scripted_ui.cpp
@@ -386,3 +386,57 @@ TEST_CASE("ScriptedUiSession::attach_gpu_surface forwards to bridge",
 
     fs::remove_all(tmp_dir);
 }
+
+TEST_CASE("ScriptedUiSession explicit reload() rebuilds without a watcher, preserving state + last-good",
+          "[view][scripted-ui][reload]") {
+    const auto temp_dir = make_temp_dir("pulp-scripted-ui");
+    const auto script_path = temp_dir / "main.js";
+    write_text(script_path, "createKnob('gain', 10, 10, 48, 48);\ncreateLabel('status', 'v1', '');\n");
+
+    View root;
+    root.set_bounds({0, 0, 320, 240});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    // No hot-reload watcher: reload() is the on-demand path.
+    ScriptedUiSession session(root, store, {.script_path = script_path,
+                                            .enable_hot_reload = false,
+                                            .enable_theme_reload = false});
+    std::string error;
+    REQUIRE(session.load(&error));
+    REQUIRE(error.empty());
+
+    auto* knob = dynamic_cast<Knob*>(session.bridge()->widget("gain"));
+    REQUIRE(knob != nullptr);
+    knob->set_value(0.66f);
+
+    // Edit + explicit reload (no poll/watcher). State preserved, new widget present.
+    write_text(script_path,
+               "createKnob('gain', 10, 10, 48, 48);\n"
+               "createLabel('status', 'v2', '');\n"
+               "createLabel('added', 'yes', '');\n");
+    REQUIRE(session.reload(&error));
+    REQUIRE(error.empty());
+
+    auto* knob2 = dynamic_cast<Knob*>(session.bridge()->widget("gain"));
+    REQUIRE(knob2 != nullptr);
+    REQUIRE_THAT(knob2->value(), WithinAbs(0.66f, 0.001f));   // state preserved
+    auto* added = dynamic_cast<Label*>(session.bridge()->widget("added"));
+    REQUIRE(added != nullptr);                                 // new code applied
+    REQUIRE(added->text() == "yes");
+
+    // Last-good: a broken reload keeps the current UI and reports the error.
+    write_text(script_path, "this is not valid javascript {{{");
+    std::string bad_error;
+    REQUIRE_FALSE(session.reload(&bad_error));
+    REQUIRE_FALSE(bad_error.empty());
+    REQUIRE(session.bridge()->widget("added") != nullptr);     // old UI intact
+
+    // reload_from(): swap to a different bundle's script.
+    const auto other = temp_dir / "other.js";
+    write_text(other, "createLabel('only-here', 'B', '');\n");
+    REQUIRE(session.reload_from(other, &error));
+    REQUIRE(session.script_path() == other);
+    REQUIRE(session.bridge()->widget("only-here") != nullptr);
+
+    fs::remove_all(temp_dir);
+}


### PR DESCRIPTION
## What

`enable_hot_reload` reloads a scripted UI via a file watcher consumed by `poll()`. A host/editor that wants to reload a just-edited bundle **on demand** (no watcher thread) had no entry point. This exposes the existing in-place rebuild:

- **`reload(error)`** — re-read the current script and rebuild the widget bridge under the **same root + GPU surface**, preserving widget state; **probe-first** so a bad reload keeps the **last-good** UI.
- **`reload_from(path, error)`** — repoint at a different bundle's script and reload.

Both are thin wrappers over the proven `rebuild_from_code()` that hot reload already uses.

## Why

Foundation for the `pulp-view-embed` `pulp_embed_reload_bundle()` ABI (an in-host editor swapping/reloading a bundle), complementing the file-watched `PULP_EMBED_HOT_RELOAD` dev loop.

## Tests

`test_scripted_ui.cpp`: state preserved across an explicit `reload()`, new code applied, a broken reload rejected with the old UI intact (last-good), `reload_from` swaps bundles. Full suite green (6 cases / 70 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add on-demand reload APIs to `ScriptedUiSession` so hosts can rebuild the scripted UI without a file watcher, preserving state and keeping the last-good UI on errors. This enables programmatic bundle swap/reload and supports the `pulp-view-embed` `pulp_embed_reload_bundle()` ABI.

- **New Features**
  - `reload(error)`: Re-reads the current script and rebuilds under the same root and GPU surface; preserves widget state; probe-first keeps last-good on failure.
  - `reload_from(path, error)`: Points to a new script path and reloads; updates script/theme paths; same last-good and state-preserving behavior.

<sup>Written for commit 66c864c9293c70429916d6b46aea33b85f29247f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

