### PR TITLE
fix(design-import): suppress the baked selected-tab highlight (no double-pill)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.368.0
+    VERSION 0.369.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/design_frame_view.hpp
+++ b/core/view/include/pulp/view/design_frame_view.hpp
@@ -44,6 +44,13 @@ struct DesignFrameElement {
     std::string bg_color;
 };
 
+// Remove the first <rect> in `svg` whose x/y/width/height match (within `tol`)
+// the given box, returning true if one was erased. Used to suppress a design's
+// BAKED selected-tab highlight so the live overlay's pill is the only one shown
+// (no double-pill when the selection moves). Pure geometry — no per-design data.
+bool suppress_svg_rect(std::string& svg, float x, float y, float w, float h,
+                       float tol = 2.0f);
+
 // Renders a design's own SVG document pixel-faithfully via Canvas::draw_svg
 // (Skia SkSVGDOM), cropped to its panel, and overlays native interaction from a
 // typed element list. This is the faithful-vector design-import lane's view: the

--- a/core/view/src/design_frame_view.cpp
+++ b/core/view/src/design_frame_view.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <cstdlib>
 #include <limits>
 #include <memory>
 
@@ -72,6 +73,36 @@ constexpr float kSweepDeg = 270.0f;  // value 0->-135, 0.5->0 (up), 1->+135
 
 }  // namespace
 
+bool suppress_svg_rect(std::string& svg, float x, float y, float w, float h,
+                       float tol) {
+    // Read a numeric attribute by its space-delimited key (" x=\"") so we don't
+    // mistake rx=/cx=/ry= for x=/y=. Returns NaN when absent.
+    auto attr = [](const std::string& tag, const char* spaced_key) -> float {
+        const auto p = tag.find(spaced_key);
+        if (p == std::string::npos) return std::numeric_limits<float>::quiet_NaN();
+        const auto vs = p + std::string(spaced_key).size();
+        const auto ve = tag.find('"', vs);
+        if (ve == std::string::npos) return std::numeric_limits<float>::quiet_NaN();
+        return std::strtof(tag.substr(vs, ve - vs).c_str(), nullptr);
+    };
+    std::size_t pos = 0;
+    while ((pos = svg.find("<rect", pos)) != std::string::npos) {
+        const auto end = svg.find('>', pos);
+        if (end == std::string::npos) break;
+        const std::string tag = svg.substr(pos, end - pos + 1);
+        const float rx = attr(tag, " x=\""), ry = attr(tag, " y=\"");
+        const float rw = attr(tag, " width=\""), rh = attr(tag, " height=\"");
+        if (!std::isnan(rx) && !std::isnan(ry) && !std::isnan(rw) && !std::isnan(rh) &&
+            std::fabs(rx - x) <= tol && std::fabs(ry - y) <= tol &&
+            std::fabs(rw - w) <= tol && std::fabs(rh - h) <= tol) {
+            svg.erase(pos, end - pos + 1);
+            return true;
+        }
+        pos = end + 1;
+    }
+    return false;
+}
+
 DesignFrameView::DesignFrameView(std::string svg, std::vector<DesignFrameElement> elements,
                                  float panel_x, float panel_y, float panel_w, float panel_h)
     : svg_(std::move(svg)), elements_(std::move(elements)) {
@@ -85,6 +116,23 @@ DesignFrameView::DesignFrameView(std::string svg, std::vector<DesignFrameElement
         panel_x_ = 0; panel_y_ = 0; panel_w_ = svg_w_; panel_h_ = svg_h_;
     }
     build_overlays();
+
+    // Suppress each design's BAKED selected-tab highlight so the live
+    // DesignTabGroup pill is the ONLY highlight ever shown — otherwise switching
+    // tabs leaves the baked pill behind at the original slot (a double-pill). The
+    // baked highlight is a filled <rect> occupying the originally-selected slot;
+    // remove it by geometry computed from the tab_group element (general — no
+    // per-design constant). The strip background behind it remains, so the slot
+    // reads as unselected until the live pill lands there.
+    for (const auto& e : elements_) {
+        if (e.kind != DesignFrameElement::Kind::tab_group || e.options.empty())
+            continue;
+        const int n = static_cast<int>(e.options.size());
+        const float slot_w = e.w / static_cast<float>(n);
+        const int sel = std::clamp(e.selected_index, 0, n - 1);
+        suppress_svg_rect(svg_, e.x + static_cast<float>(sel) * slot_w, e.y,
+                          slot_w, e.h);
+    }
 }
 
 void DesignFrameView::build_overlays() {

--- a/test/test_design_frame_view.cpp
+++ b/test/test_design_frame_view.cpp
@@ -347,6 +347,53 @@ TEST_CASE("DesignStepper renders and the value changes with selection",
     CHECK(cmp.similarity < 0.999f);
 }
 
+TEST_CASE("suppress_svg_rect removes the baked tab highlight by geometry, not rx/cx",
+          "[view][design-import][frame][svg]") {
+    // Values from a real exported frame: the selected-tab highlight is a filled
+    // <rect> at the slot, sitting on top of the wider strip background.
+    std::string svg =
+        "<svg>"
+        "<rect x=\"10\" y=\"20\" width=\"30\" height=\"40\" fill=\"#111111\"/>"
+        "<rect x=\"290\" y=\"123\" width=\"124\" height=\"26\" rx=\"2\" fill=\"#252626\"/>"
+        "<rect x=\"352\" y=\"126\" width=\"29.5\" height=\"20\" rx=\"2\" fill=\"#2C2D2D\"/>"
+        "</svg>";
+    // Removes exactly the baked highlight (tab group x=293,w=118,4 tabs,sel=2 →
+    // slot 2 at x=352,w=29.5), leaving the strip + the unrelated rect. The rx="2"
+    // attribute must NOT be mistaken for x=.
+    REQUIRE(suppress_svg_rect(svg, 352.0f, 126.0f, 29.5f, 20.0f));
+    CHECK(svg.find("#2C2D2D") == std::string::npos);   // baked highlight removed
+    CHECK(svg.find("#252626") != std::string::npos);   // wider strip kept
+    CHECK(svg.find("#111111") != std::string::npos);   // unrelated rect kept
+    CHECK_FALSE(suppress_svg_rect(svg, 352.0f, 126.0f, 29.5f, 20.0f));  // no 2nd match
+    CHECK_FALSE(suppress_svg_rect(svg, 10.0f, 20.0f, 999.0f, 40.0f));   // size mismatch
+}
+
+TEST_CASE("DesignFrameView suppresses the baked selected-tab highlight (no double-pill)",
+          "[view][design-import][frame][svg]") {
+    // An SVG whose tab strip has a baked highlight at the selected slot (2). The
+    // DesignFrameView constructor must strip it so only the live pill shows.
+    const std::string strip =
+        "<rect x=\"10\" y=\"10\" width=\"60\" height=\"60\" rx=\"2\" fill=\"#1c1d1d\"/>"
+        "<rect x=\"20\" y=\"14\" width=\"56\" height=\"14\" rx=\"2\" fill=\"#252626\"/>"
+        // baked highlight on slot 2: tab group x=20,w=56,4 tabs → slot_w=14, slot2 x=48
+        "<rect x=\"48\" y=\"14\" width=\"14\" height=\"14\" rx=\"2\" fill=\"#3c3d3d\"/>";
+    const std::string svg =
+        "<svg width=\"80\" height=\"80\" xmlns=\"http://www.w3.org/2000/svg\">" + strip + "</svg>";
+    DesignFrameElement tg;
+    tg.kind = DesignFrameElement::Kind::tab_group;
+    tg.x = 20; tg.y = 14; tg.w = 56; tg.h = 14;
+    tg.options = {"1", "2", "3", "4"};
+    tg.selected_index = 2;
+    // The view should construct without the baked highlight surviving. We can't
+    // read svg_ directly, so prove the mechanism via the helper on the same data:
+    std::string check = svg;
+    REQUIRE(suppress_svg_rect(check, tg.x + 2 * (tg.w / 4), tg.y, tg.w / 4, tg.h));
+    CHECK(check.find("#3c3d3d") == std::string::npos);  // baked slot-2 pill gone
+    CHECK(check.find("#252626") != std::string::npos);  // strip kept
+    DesignFrameView v(svg, {tg});                        // exercises the ctor path
+    CHECK(v.element_count() == 1);
+}
+
 TEST_CASE("DesignFrameView is fail-safe on an empty/garbage SVG",
           "[view][design-import][frame][svg]") {
     DesignFrameView empty("", {});


### PR DESCRIPTION
DesignTabGroup paints a live selection pill, but the exported SVG still has the design's baked highlight on the originally-selected tab — switching tabs left a double-pill. The DesignFrameView constructor now removes the baked highlight `<rect>` by geometry computed from the tab_group element (new `suppress_svg_rect` helper) — pure geometry, no per-design constant or producer/lockstep change. Tests: direct helper coverage + constructor path; full design-frame-view suite green (93 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the double-pill in design-import tab groups by removing the baked selected-tab highlight from the SVG. The view now erases the matched `<rect>` so the live pill is the only highlight.

- **Bug Fixes**
  - In `DesignFrameView` constructor, compute the selected slot from `tab_group` geometry and erase the matching SVG `<rect>`; pure geometry, ignores `rx`/`cx`/`ry`, and keeps the strip background.

- **New Features**
  - Added `suppress_svg_rect(svg, x, y, w, h, tol = 2.0f)` helper; bumped project version to `0.369.0`.

<sup>Written for commit fc97de5b04a1481ea9d4306ee787e13221bb91a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

