### PR TITLE
fix(view): keep selected glyphs in place when selecting across a space

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.369.0
+    VERSION 0.370.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/text_editor.cpp
+++ b/core/view/src/text_editor.cpp
@@ -740,11 +740,14 @@ void TextEditor::paint(canvas::Canvas& canvas) {
         return xoff[i];
     };
 
+    // Selection rect + selected-glyph x-range, from the SHAPED full-string
+    // offsets (the same the painter draws), so the highlight aligns exactly.
+    float sel_x = 0.0f, sel_w = 0.0f;
     if (has_selection()) {
-        int start = std::min(selection_start_, selection_end_);
-        int end = std::max(selection_start_, selection_end_);
-        float sel_x = text_x + x_at(start);
-        float sel_w = x_at(end) - x_at(start);
+        const int start = std::min(selection_start_, selection_end_);
+        const int end = std::max(selection_start_, selection_end_);
+        sel_x = text_x + x_at(start);
+        sel_w = x_at(end) - x_at(start);
         canvas.set_fill_color(selection_fill);
         canvas.fill_rect(sel_x, b.y + 2, sel_w, b.height - 4);
     }
@@ -752,26 +755,34 @@ void TextEditor::paint(canvas::Canvas& canvas) {
     if (display.empty() && !placeholder.empty() && !has_focus()) {
         canvas.set_fill_color(text_secondary);
         canvas.fill_text(placeholder, text_x, text_y);
-    } else {
-        if (has_selection()) {
-            int start = std::min(selection_start_, selection_end_);
-            int end = std::max(selection_start_, selection_end_);
-            auto before = display.substr(0, static_cast<size_t>(start));
-            auto selected = display.substr(static_cast<size_t>(start), static_cast<size_t>(end - start));
-            auto after = display.substr(static_cast<size_t>(end));
-            float selected_x = text_x + x_at(start);
-            float after_x = text_x + x_at(end);
-
-            canvas.set_fill_color(text_primary);
-            if (!before.empty()) canvas.fill_text(before, text_x, text_y);
-            canvas.set_fill_color(selected_text_color);
-            if (!selected.empty()) canvas.fill_text(selected, selected_x, text_y);
-            canvas.set_fill_color(text_primary);
-            if (!after.empty()) canvas.fill_text(after, after_x, text_y);
-        } else {
-            canvas.set_fill_color(text_primary);
+    } else if (has_selection() && sel_w > 0.0f) {
+        // Paint the WHOLE string as ONE shaped run, re-colored per region by
+        // clipping. The three clip rects tile the editor width edge-to-edge and
+        // are disjoint, so every pixel is painted exactly once and a glyph never
+        // moves just because part of it became selected — a glyph straddling the
+        // selection boundary is simply split between the two colors at the same x.
+        //
+        // The previous painter re-shaped before/selected/after as three separate
+        // runs positioned by full-string offsets; a piece shaped in isolation
+        // lost its in-context kerning/side-bearing, so selected glyphs drifted —
+        // the "gap between the letters" a user sees dragging a selection across a
+        // space into a word.
+        const float band_l = sel_x;
+        const float band_r = sel_x + sel_w;
+        auto paint_clipped = [&](float clip_x, float clip_w, canvas::Color color) {
+            if (clip_w <= 0.0f) return;
+            canvas.save();
+            canvas.clip_rect(clip_x, b.y, clip_w, b.height);
+            canvas.set_fill_color(color);
             canvas.fill_text(display, text_x, text_y);
-        }
+            canvas.restore();
+        };
+        paint_clipped(b.x, band_l - b.x, text_primary);                       // before
+        paint_clipped(band_l, band_r - band_l, selected_text_color);          // selected
+        paint_clipped(band_r, (b.x + b.width) - band_r, text_primary);        // after
+    } else {
+        canvas.set_fill_color(text_primary);
+        canvas.fill_text(display, text_x, text_y);
     }
 
     // Caret with blinking (530ms on, 530ms off)

--- a/test/test_text_editor.cpp
+++ b/test/test_text_editor.cpp
@@ -1,6 +1,9 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/view/text_editor.hpp>
 #include <pulp/view/frame_clock.hpp>
+#include <pulp/view/screenshot.hpp>
+#include <pulp/view/screenshot_compare.hpp>
+#include <pulp/view/theme.hpp>
 #include <pulp/canvas/canvas.hpp>
 
 #include <memory>
@@ -741,4 +744,85 @@ TEST_CASE("TextEditor caret-blink subscription is removed even after detach", "[
     REQUIRE_FALSE(clock.has_active_subscribers());  // subscription cleaned up
     clock.tick(0.016f);                             // must not touch freed memory
     SUCCEED("tick after destruction did not use freed memory");
+}
+
+// Regression: a selection must recolor glyphs in place — never move them.
+//
+// The painter used to draw a selection as three independently-shaped runs
+// (before / selected / after). Re-shaping a substring in isolation loses the
+// kerning/left-side-bearing context it had inside the full string, so the
+// selected glyphs landed at the wrong x — the "gap between the letters in the
+// 2nd word" a user sees when dragging a selection across a space and into a
+// word. The fix paints the whole string as ONE shaped run, then overlays the
+// selected color clipped to the selection rect, so a glyph cannot move just
+// because it became selected.
+//
+// The invariant under test is text-engine-level and design-agnostic. We
+// neutralize every selection color (selection fill and selected-text color both
+// resolve to colors that paint identically over the background) so that the
+// ONLY thing that could change pixels between the unselected and selected
+// renders is a glyph moving. A correct painter therefore yields two identical
+// frames; the old three-run painter shifts the mid-word selected glyphs and the
+// frames diverge.
+TEST_CASE("TextEditor selecting mid-word recolors in place without moving glyphs",
+          "[view][text_editor][selection][svg]") {
+    const std::string kText = "WAVE table mix";   // strong W-A kern; spaces
+    constexpr int kW = 240, kH = 30;
+    constexpr float kScale = 2.0f;
+
+    // White page, black text. selected-text color resolves from "bg.primary"
+    // (black, == text) and the selection fill from "accent.primary" (white, ==
+    // page, alpha-blended to a no-op). So selection changes no color — only a
+    // moved glyph can change a pixel.
+    Theme neutral;
+    neutral.colors["text.primary"]   = Color::rgba8(0, 0, 0, 255);
+    neutral.colors["bg.primary"]     = Color::rgba8(0, 0, 0, 255);
+    neutral.colors["accent.primary"] = Color::rgba8(255, 255, 255, 255);
+
+    auto render = [&](bool select_mid_word) {
+        TextEditor editor;
+        editor.set_theme(neutral);
+        editor.set_background_color(Color::rgba8(255, 255, 255, 255));
+        editor.set_bounds({0, 0, float(kW), float(kH)});
+        editor.set_text(kText);
+        if (select_mid_word) {
+            editor.on_focus_changed(true);
+            editor.on_key_event(key_event(KeyCode::home));         // caret -> 0
+            editor.on_key_event(key_event(KeyCode::right));        // caret -> 1 (after 'W')
+            auto shift_right = key_event(KeyCode::right, kModShift);
+            for (int i = 0; i < 3; ++i) editor.on_key_event(shift_right);  // select "AVE"
+            editor.on_focus_changed(false);   // drop the caret; selection persists
+        }
+        // Both frames render unfocused: no caret, identical background.
+        return render_to_png(editor, kW, kH, kScale, ScreenshotBackend::skia);
+    };
+
+    const auto base = render(false);
+    if (base.empty()) SKIP("Skia raster screenshot backend unavailable");
+    const auto selected = render(true);
+    REQUIRE_FALSE(selected.empty());
+
+    // Some partial-Skia lanes no-op raster text; skip rather than false-fail.
+    const auto stats = analyze_screenshot_content(base);
+    if (!stats.passes_content_floor()) SKIP("native raster unavailable in this build");
+
+    // With colors neutralized, the only source of difference is a moving glyph.
+    // Concentrate the signal on the first word ("WAVE", left ~25% of the strip)
+    // where the mid-word selection lives; the global frame is mostly the stable
+    // tail, which dilutes the metric.
+    const uint32_t png_w = static_cast<uint32_t>(kW * kScale);
+    const uint32_t png_h = static_cast<uint32_t>(kH * kScale);
+    const uint32_t band_w = png_w / 4;   // left quarter: comfortably covers "WAVE"
+    const auto base_band = crop_png(base, 0, 0, band_w, png_h);
+    const auto sel_band = crop_png(selected, 0, 0, band_w, png_h);
+    REQUIRE_FALSE(base_band.empty());
+    REQUIRE_FALSE(sel_band.empty());
+    const auto cmp = compare_screenshots(base_band, sel_band, /*tolerance=*/4);
+    REQUIRE(cmp.valid);
+    INFO("band similarity = " << cmp.similarity);
+    // A correct painter tiles the width with disjoint clips, so neutralized
+    // selection leaves the band pixel-identical. The old three-run painter
+    // shifted the selected glyphs, dropping the band well below this floor
+    // (~0.95 at the time of the fix).
+    CHECK(cmp.similarity >= 0.99f);
 }


### PR DESCRIPTION
## What

A `TextEditor` selection was painted as three independently-shaped runs
(before / selected / after), each positioned by the full string's shaped
offsets. A substring re-shaped in isolation loses the in-context kerning
and side-bearing it had inside the whole string, so the **selected glyphs
drifted** — the visible "gap between the letters in the 2nd word" when
dragging a selection across a space into a word, plus the slight shift
when a selection starts mid-word.

## Fix

Paint the whole string as **one shaped run** and recolor per region by
clipping: three disjoint clip rects tile the editor width edge-to-edge, so
every pixel is painted exactly once and a glyph can never move just because
part of it became selected. A glyph straddling the selection boundary is
split between the two colors at the same x — correct partial highlighting,
no double-draw, no drift.

This is a text-engine-level SDK fix, independent of any design import or
specific font.

## Test

`test_text_editor.cpp` gains a render regression that neutralizes every
selection color (the fill and the selected-text color both paint as no-ops
over the background) so the **only** thing that can change pixels between an
unselected and a mid-word-selected frame is a moving glyph. The new clipped
painter keeps the selection band pixel-identical (≈1.0 band similarity);
the old three-run painter dropped it to ~0.95. Full `pulp-test-text-editor`,
`-multiline`, and `-text-input` suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `TextEditor` selection drift by painting one shaped run and recoloring via clipping. Keeps glyphs in place when selecting across spaces or mid-word, eliminating visible gaps and shifts.

- **Bug Fixes**
  - Draw the full string once; recolor regions using three disjoint clip rects.
  - Split boundary glyphs across the selection at the same x to avoid double-draw and movement.
  - Add render regression that neutralizes selection colors and verifies pixel-identical output (band similarity ≥ 0.99).

<sup>Written for commit 920dc3ef96c1474bdd9408f8fafe15cc38297b60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

