### PR TITLE
fix(view): embedded plugin-view host routes keyDown to the focused input

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.370.0
+    VERSION 0.370.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/platform/mac/plugin_view_host_mac.mm
+++ b/core/view/platform/mac/plugin_view_host_mac.mm
@@ -244,6 +244,48 @@ void pulp_plugin_wheel(pulp::view::View* root, pulp::view::Point pt, NSEvent* ev
   }
 }
 
+// Route a keyDown to the currently focused input widget — the embedded analog of
+// the standalone PulpView's key handling (window_host_mac.mm). Without this an
+// embedded TextEditor (e.g. an imported search field) never receives typing: the
+// host NSView is first responder but had no keyDown:, so characters were dropped.
+// A click already sets focus (claim_input_focus in mouseDown). Returns true when
+// a focused input consumed the event, so the caller only falls through to
+// [super keyDown:] (host menu shortcuts etc.) when nothing was focused.
+bool pulp_plugin_key_down(pulp::view::View* root, NSEvent* event) {
+  try {
+    if (!root) return false;
+    // Auto-clearing static: cleared by ~View when the focused widget is freed,
+    // so this never derefs freed memory (pulp #1708 rationale).
+    auto* fv = pulp::view::View::focused_input_;
+    if (!fv) return false;
+    pulp::view::KeyEvent ke;
+    ke.key = pulp::view::mac_geometry::key_code_from_ns(event.keyCode);
+    ke.modifiers = pulp::view::mac_geometry::modifiers_from_ns_flags(event.modifierFlags);
+    ke.is_down = true;
+    ke.is_repeat = event.isARepeat;
+    fv->on_key_event(ke);  // backspace / arrows / enter (TextEditor handles these)
+    // Printable characters → text insertion. (Full IME / marked-text via
+    // NSTextInputClient is a follow-up; this covers ASCII + most Latin typing.)
+    NSString* chars = event.characters;
+    if (chars.length > 0) {
+        unichar c0 = [chars characterAtIndex:0];
+        if (c0 >= 0x20 && c0 != 0x7f) {
+            pulp::view::TextInputEvent te;
+            te.text = chars.UTF8String;
+            fv->on_text_input(te);
+        }
+    }
+    root->request_repaint();
+    return true;
+  } catch (const std::exception& e) {
+    std::fprintf(stderr, "[plugin-view-host] keyDown handler threw: %s\n", e.what());
+    return true;  // swallow; don't beep/propagate a half-handled key
+  } catch (...) {
+    std::fprintf(stderr, "[plugin-view-host] keyDown handler threw (unknown)\n");
+    return true;
+  }
+}
+
 } // namespace
 
 @implementation PulpPluginView {
@@ -252,6 +294,9 @@ void pulp_plugin_wheel(pulp::view::View* root, pulp::view::Point pt, NSEvent* ev
 
 - (BOOL)isFlipped { return NO; }
 - (BOOL)acceptsFirstResponder { return YES; }
+- (void)keyDown:(NSEvent*)event {
+    if (!pulp_plugin_key_down(self.rootView, event)) [super keyDown:event];
+}
 // Resolve a window-space event into root-view coords, applying the inverse
 // design-viewport transform when set so hit_test runs against design-space
 // coords. Identity when pointTransform is nil.
@@ -656,6 +701,9 @@ private:
 }
 
 - (BOOL)acceptsFirstResponder { return YES; }
+- (void)keyDown:(NSEvent*)event {
+    if (!pulp_plugin_key_down(self.rootView, event)) [super keyDown:event];
+}
 // Resolve a window-space event into root-view coords, applying the inverse
 // design-viewport transform when set.
 - (pulp::view::Point)localPoint:(NSEvent*)event {


### PR DESCRIPTION
## What

An embedded `TextEditor` (e.g. an imported faithful-vector **search field**) never received typing in a plugin/embed host: the plugin-view `NSView` is `acceptsFirstResponder=YES` but had no `keyDown:`, so characters were dropped. (It works in the standalone window host, which implements the full key path.) A click already focuses the widget (`claim_input_focus` in `mouseDown`) — the missing half was key delivery.

## Fix

Add `keyDown:` to both the CPU (`PulpPluginView`) and GPU (`PulpGpuPluginView`) plugin-view hosts, routing through a shared `pulp_plugin_key_down`:
- special keys → `on_key_event` (backspace / arrows / enter)
- printable characters → `on_text_input`

dispatched to `View::focused_input_` (the auto-clearing static — no use-after-free). Falls through to `[super keyDown:]` when nothing is focused so host menu shortcuts still work. Mirrors the standalone `PulpView`; reuses the shared `mac_geometry` key map. Full IME / marked-text (`NSTextInputClient`) is a follow-up; this covers typing.

## Test

Routing reuses unit-tested primitives (`on_text_input`/`on_key_event` via `focused_input_`, covered by widget + `design_frame_view` tests); the ObjC `keyDown` bridge mirrors the (also unit-test-exempt) standalone key path and is verified live in the embedded editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost typing in embedded plugin views by routing keyDown events to the focused input, so embedded text fields (e.g. search) receive characters. Preserves host shortcuts when no input is focused.

- **Bug Fixes**
  - Added `keyDown:` to `PulpPluginView` and `PulpGpuPluginView`, routed through `pulp_plugin_key_down`.
  - Mapped special keys to `on_key_event` and printable chars to `on_text_input` via `View::focused_input_`.
  - Mirrors standalone `PulpView`; IME/marked-text via `NSTextInputClient` is a follow-up.

- **Dependencies**
  - Bumped framework version to 0.370.1.

<sup>Written for commit a160348cf390820495ff5a482093258cf9eafd16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

