### PR TITLE
feat(plugin): add claude.send_user_file config + SessionStart injection

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -250,6 +250,18 @@ Rust `pulp config`, `pulp status`, the import-design helper, docs, slash
 commands, and the MCP status output aligned whenever these keys change. If
 only `default_mode=baked` is configured, `ir-json` is implied.
 
+**Adding a `pulp config` key:** `cmd_config.cpp` allow-lists every key in three
+places — `is_allowed_key`, `validate_value`, and the `list` dump (plus the
+`usage()` help text). Add the key to all of them or `set` rejects it / `list`
+omits it. Example: `[claude] send_user_file` (`on|off`, default `on`) gates the
+plugin's `SessionStart` hook (`hooks/scripts/inject-claude-prefs.sh`) that tells
+the agent to surface image/file artifacts via `SendUserFile`. A config-only key
+needs no `cli-commands.yaml` subcommand entry (it's not a new command), but do
+update the command `summary` there + `docs/reference/cli.md#config` + a
+`test_cli_shellout.cpp` get/set/validate case. Reading config from a hook (bash)
+means a small TOML scan — scope the read to the right `[section]` so a same-named
+key in another table can't flip it.
+
 **Sidecar output anchoring:** when a CLI command takes `--output
 <path>/main.ext` and also emits sidecar artifacts (e.g.
 `pulp import-design` writes `bridge_handlers.cpp`, `classnames.json`,

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.193.1",
+      "version": "0.194.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.193.1"
+  "version": "0.194.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.193.1",
+  "version": "0.194.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.371.1
+    VERSION 0.372.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/docs/guides/claude-code-plugin.md
+++ b/docs/guides/claude-code-plugin.md
@@ -78,10 +78,11 @@ Skills activate automatically based on context. You don't need to invoke them ex
 
 ### Hooks
 
-The plugin includes two hooks that run automatically:
+The plugin includes hooks that run automatically:
 
 - **docs-reminder** — When you modify files in `core/`, `examples/`, or `tools/cli/`, reminds you to update documentation manifests
 - **cli-plugin-sync** — When you modify the CLI or MCP server, reminds you to check if the plugin commands and skills need matching updates
+- **inject-claude-prefs** (`SessionStart`) — Reads `claude.send_user_file` from `~/.pulp/config.toml` (default **on**) and, when enabled, tells the agent to surface generated image/file artifacts with the `SendUserFile` tool so they embed in the Claude app instead of being printed as a bare path. Toggle with `pulp config set claude.send_user_file off` (and `on` to re-enable).
 
 ### MCP server
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1403,6 +1403,7 @@ pulp config set update.mode manual
 pulp config set update.check_interval_hours 12
 pulp config set import_design.default_mode baked
 pulp config set import_design.default_emit ir-json
+pulp config set claude.send_user_file off
 pulp config list
 ```
 
@@ -1437,6 +1438,16 @@ Supported import-design keys:
   `--emit`. `PULP_IMPORT_DESIGN_DEFAULT_EMIT` overrides this value for one
   environment/session. If the default mode is `baked` and this key is unset,
   Pulp implies `ir-json`.
+
+Supported Claude Code plugin keys:
+
+- `claude.send_user_file` — `on | off` (default `on`). When `on`, the Pulp
+  Claude Code plugin's `SessionStart` hook injects a preference telling the
+  agent to surface generated image/file artifacts (screenshots, rendered
+  designs, diagrams, build outputs) with the `SendUserFile` tool so they embed
+  in the Claude app, instead of only printing a path. Set `off` to suppress the
+  injection. Read at session start by
+  `hooks/scripts/inject-claude-prefs.sh`.
 
 ### clean
 

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -421,12 +421,12 @@ commands:
 
   - name: config
     status: usable
-    summary: Read or write ~/.pulp/config.toml settings. Supports `[pr] workflow`, `[update]` settings, and `[import_design]` defaults for import-design mode/emit. `set update.mode` clears ~/.pulp/update-snooze so the new mode takes effect on the next invocation.
+    summary: Read or write ~/.pulp/config.toml settings. Supports `[pr] workflow`, `[update]` settings, `[import_design]` defaults for import-design mode/emit, and `[claude] send_user_file` (plugin SendUserFile preference). `set update.mode` clears ~/.pulp/update-snooze so the new mode takes effect on the next invocation.
     subcommands:
       - name: get
-        summary: Print the value for a dotted key (e.g. `pr.workflow` or `update.mode`). Empty output if unset.
+        summary: Print the value for a dotted key (e.g. `pr.workflow`, `update.mode`, or `claude.send_user_file`). Empty output if unset.
       - name: set
-        summary: Write a value for a dotted key. Validates PR workflow, update enums, import-design defaults, and integer shapes. Mode changes clear the 24h snooze file.
+        summary: Write a value for a dotted key. Validates PR workflow, update enums, import-design defaults, claude.send_user_file (on|off), and integer shapes. Mode changes clear the 24h snooze file.
       - name: list
         summary: Dump current supported settings with defaults filled in.
     docs: reference/cli.md#config

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -12,6 +12,18 @@
         ]
       }
     ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/inject-claude-prefs.sh",
+            "timeout": 3000
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/hooks/scripts/inject-claude-prefs.sh
+++ b/hooks/scripts/inject-claude-prefs.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# inject-claude-prefs.sh — SessionStart-hook script wired in hooks/hooks.json.
+#
+# Fires once per Claude Code session (matcher: startup|resume). Reads the
+# `[claude] send_user_file` knob from ~/.pulp/config.toml and, when it is on
+# (the DEFAULT — also the value when the file/key is absent), injects a short
+# preference into the agent's context telling it to surface generated image /
+# file artifacts with the SendUserFile tool so they EMBED in the Claude app
+# instead of being printed as a bare path. When the knob is `off`, the hook
+# emits nothing.
+#
+# Mechanism: SessionStart stdout is added to the model's context. We use the
+# documented JSON channel (`hookSpecificOutput.additionalContext`) with
+# suppressOutput so the injection is clean and not echoed to the user's UI.
+# Always exits 0 — this hook is informational and must never block session init.
+#
+# Toggle from the CLI:
+#   pulp config set claude.send_user_file off   # disable
+#   pulp config set claude.send_user_file on    # re-enable (default)
+#
+# Tests override the config path via PULP_CONFIG_FILE so the three states
+# (on / off / unset) run deterministically without touching ~/.pulp.
+
+set -e
+
+# Resolve the config file. PULP_CONFIG_FILE wins (tests); else $PULP_HOME or
+# ~/.pulp, matching the C++ `pulp_home()` / `pulp config` layout.
+if [ -n "${PULP_CONFIG_FILE:-}" ]; then
+    CONFIG="$PULP_CONFIG_FILE"
+elif [ -n "${PULP_HOME:-}" ]; then
+    CONFIG="$PULP_HOME/config.toml"
+else
+    CONFIG="${HOME:-}/.pulp/config.toml"
+fi
+
+# Read [claude] send_user_file. Default "on" when the file or key is missing.
+# Minimal, dependency-free TOML scan: track the current [section] header and
+# return the first matching `key = "value"` (quotes/whitespace stripped) inside
+# the [claude] table.
+read_send_user_file() {
+    local value="on"
+    [ -f "$CONFIG" ] || { printf '%s' "$value"; return; }
+    value=$(awk '
+        /^[[:space:]]*\[/ {
+            section = $0
+            sub(/^[[:space:]]*\[/, "", section)
+            sub(/\][[:space:]]*$/, "", section)
+            gsub(/[[:space:]]/, "", section)
+            next
+        }
+        section == "claude" {
+            line = $0
+            sub(/#.*/, "", line)                       # strip trailing comment
+            if (line ~ /^[[:space:]]*send_user_file[[:space:]]*=/) {
+                v = line
+                sub(/^[^=]*=[[:space:]]*/, "", v)       # keep RHS
+                gsub(/[[:space:]]/, "", v)
+                gsub(/"/, "", v); gsub(/\x27/, "", v)   # strip quotes
+                print tolower(v)
+                exit
+            }
+        }
+    ' "$CONFIG")
+    [ -n "$value" ] || value="on"
+    printf '%s' "$value"
+}
+
+STATE="$(read_send_user_file)"
+
+# Off → no injection. Anything other than an explicit "off" (on / unset /
+# unrecognized) defaults to the enabled behavior, since the feature defaults on.
+if [ "$STATE" = "off" ]; then
+    exit 0
+fi
+
+cat <<'JSON'
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"Pulp plugin preference (claude.send_user_file = on): when you produce an image or file artifact for the user — screenshots, rendered designs, generated diagrams, build outputs, reports — surface it with the SendUserFile tool so it embeds in the Claude app, rather than only printing its path. Skip this for paths the user already has open or for plain text. The user can disable this with: pulp config set claude.send_user_file off"},"suppressOutput":true}
+JSON
+exit 0

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -223,6 +223,14 @@ if(UNIX)
     add_test(NAME check-pulp-cli-hook
         COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_check_pulp_cli_hook.sh)
     set_tests_properties(check-pulp-cli-hook PROPERTIES TIMEOUT 15)
+
+    # inject-claude-prefs.sh — the SessionStart hook that reads
+    # claude.send_user_file from ~/.pulp/config.toml and injects the
+    # SendUserFile preference. Hermetic: each case points PULP_CONFIG_FILE
+    # at a staged config. Like the cli hook it must always exit 0.
+    add_test(NAME inject-claude-prefs-hook
+        COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_inject_claude_prefs_hook.sh)
+    set_tests_properties(inject-claude-prefs-hook PROPERTIES TIMEOUT 15)
 endif()
 
 # pulp #2087 (slice 1) — install.sh must install CLI + matching SDK in one

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -492,6 +492,42 @@ TEST_CASE("pulp config supports pr.workflow",
     REQUIRE(bad.stderr_output.find("pr.workflow must be one of") != std::string::npos);
 }
 
+TEST_CASE("pulp config supports claude.send_user_file",
+          "[cli][shellout][claude]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto tmp_home = unique_temp_dir("pulp-claude-send-user-file");
+    fs::create_directories(tmp_home);
+    pulp_setenv("PULP_HOME", tmp_home.string().c_str(), 1);
+    pulp_setenv("PULP_UPDATE_CHECK_DISABLED", "1", 1);
+
+    // Defaults to "on" in `list` before anything is written.
+    auto list_default = run_pulp({"config", "list"});
+    auto set_off = run_pulp({"config", "set", "claude.send_user_file", "off"});
+    auto get_off = run_pulp({"config", "get", "claude.send_user_file"});
+    auto set_on = run_pulp({"config", "set", "claude.send_user_file", "on"});
+    auto list_on = run_pulp({"config", "list"});
+    auto bad = run_pulp({"config", "set", "claude.send_user_file", "true"});
+
+    pulp_unsetenv("PULP_UPDATE_CHECK_DISABLED");
+    pulp_unsetenv("PULP_HOME");
+    fs::remove_all(tmp_home);
+
+    REQUIRE_FALSE(list_default.timed_out);
+    REQUIRE(list_default.exit_code == 0);
+    REQUIRE(list_default.stdout_output.find("claude.send_user_file = on") != std::string::npos);
+    REQUIRE_FALSE(set_off.timed_out);
+    REQUIRE(set_off.exit_code == 0);
+    REQUIRE_FALSE(get_off.timed_out);
+    REQUIRE(get_off.exit_code == 0);
+    REQUIRE(get_off.stdout_output.find("off") != std::string::npos);
+    REQUIRE(set_on.exit_code == 0);
+    REQUIRE(list_on.stdout_output.find("claude.send_user_file = on") != std::string::npos);
+    REQUIRE_FALSE(bad.timed_out);
+    REQUIRE(bad.exit_code != 0);
+    REQUIRE(bad.stderr_output.find("claude.send_user_file must be one of") != std::string::npos);
+}
+
 TEST_CASE("pulp status reports effective PR workflow",
           "[cli][shellout][pr-workflow]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }

--- a/test/test_inject_claude_prefs_hook.sh
+++ b/test/test_inject_claude_prefs_hook.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Unit test for hooks/scripts/inject-claude-prefs.sh — the SessionStart hook
+# that reads `[claude] send_user_file` from the Pulp config and injects the
+# SendUserFile preference into the agent's context.
+#
+# Mirrors test_check_pulp_cli_hook.sh's case-driven shell-test pattern. Each
+# case stages a config file and points the hook at it via PULP_CONFIG_FILE so
+# the states (default-on / explicit on / off / malformed / unset) run
+# deterministically without touching ~/.pulp.
+#
+# Usage:  bash test/test_inject_claude_prefs_hook.sh
+#
+# The hook is informational and must ALWAYS exit 0 — a non-zero exit would
+# start blocking Claude Code session init, a real regression.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK="$SCRIPT_DIR/hooks/scripts/inject-claude-prefs.sh"
+
+[ -x "$HOOK" ] || { echo "FAIL: hook missing or not executable: $HOOK"; exit 1; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "ok: $*"; }
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# Assert stdout is the injection JSON with a non-empty additionalContext and
+# the enabling hint. Uses python3 (available in CI) for strict JSON parsing.
+assert_injects() {
+    local out="$1" label="$2"
+    [ -n "$out" ] || fail "$label: expected injection output, got empty"
+    printf '%s' "$out" | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+hs = d["hookSpecificOutput"]
+assert hs["hookEventName"] == "SessionStart", hs
+ctx = hs["additionalContext"]
+assert "SendUserFile" in ctx, "missing SendUserFile mention"
+assert "send_user_file" in ctx, "missing toggle hint"
+' || fail "$label: stdout was not the expected SessionStart injection JSON"
+}
+
+run_hook() {  # $1 = config file path (may be nonexistent)
+    PULP_CONFIG_FILE="$1" bash "$HOOK"
+}
+
+# ── Case 1: config file does not exist → default ON (injects) ───────────────
+out=$(run_hook "$tmp/missing.toml") || fail "case1: hook exited non-zero"
+assert_injects "$out" "case1 (unset file)"
+pass "missing config file → defaults to ON and injects"
+
+# ── Case 2: [claude] send_user_file = "off" → no injection ─────────────────
+printf '[claude]\nsend_user_file = "off"\n' > "$tmp/off.toml"
+out=$(run_hook "$tmp/off.toml") || fail "case2: hook exited non-zero"
+[ -z "$out" ] || fail "case2: expected no output when off, got: $out"
+pass "send_user_file = off → no injection"
+
+# ── Case 3: explicit on, with other sections + a trailing comment ──────────
+printf '[pr]\nworkflow = "github"\n\n[claude]\nsend_user_file = "on"  # embed\n' > "$tmp/on.toml"
+out=$(run_hook "$tmp/on.toml") || fail "case3: hook exited non-zero"
+assert_injects "$out" "case3 (explicit on)"
+pass "send_user_file = on (amid other sections/comment) → injects"
+
+# ── Case 4: [claude] present but key absent → default ON ───────────────────
+printf '[claude]\nother_key = "x"\n' > "$tmp/partial.toml"
+out=$(run_hook "$tmp/partial.toml") || fail "case4: hook exited non-zero"
+assert_injects "$out" "case4 (key absent)"
+pass "key absent within [claude] → defaults to ON and injects"
+
+# ── Case 5: key set OFF but in a DIFFERENT section → ignored, default ON ────
+# Guards the section-scoping: a send_user_file under [pr] must not disable it.
+printf '[pr]\nsend_user_file = "off"\n[claude]\nworkflow = "x"\n' > "$tmp/wrongsection.toml"
+out=$(run_hook "$tmp/wrongsection.toml") || fail "case5: hook exited non-zero"
+assert_injects "$out" "case5 (off under wrong section)"
+pass "send_user_file=off under a non-claude section is ignored (stays ON)"
+
+echo "all inject-claude-prefs hook cases passed"

--- a/tools/cli/cmd_config.cpp
+++ b/tools/cli/cmd_config.cpp
@@ -75,6 +75,13 @@ bool is_allowed_key(const std::string& section, const std::string& key) {
     if (section == "import_design") {
         return key == "default_mode" || key == "default_emit";
     }
+    if (section == "claude") {
+        // send_user_file: when on (default), the Claude Code plugin's
+        // SessionStart hook tells the agent to surface generated image /
+        // file artifacts with the SendUserFile tool so they embed in the
+        // Claude app, instead of only printing a path.
+        return key == "send_user_file";
+    }
     return false;
 }
 
@@ -117,6 +124,10 @@ std::string validate_value(const std::string& section,
         if (value == "js" || value == "ir-json" || value == "cpp") return {};
         return "import_design.default_emit must be one of: js, ir-json, cpp";
     }
+    if (section == "claude" && key == "send_user_file") {
+        if (value == "on" || value == "off") return {};
+        return "claude.send_user_file must be one of: on, off";
+    }
     return {};
 }
 
@@ -139,11 +150,16 @@ int usage() {
     std::cout << "  import_design.default_mode    live | baked                  (default: live)\n";
     std::cout << "  import_design.default_emit    js | ir-json | cpp            (default: js)\n";
     std::cout << "                                CLI flags override these; env overrides below.\n";
+    std::cout << "\nSupported keys (claude section):\n";
+    std::cout << "  claude.send_user_file         on | off                      (default: on)\n";
+    std::cout << "                                When on, the Claude Code plugin surfaces generated\n";
+    std::cout << "                                images/files with SendUserFile so they embed in the app.\n";
     std::cout << "\nExamples:\n";
     std::cout << "  pulp config set pr.workflow github\n";
     std::cout << "  pulp config set update.mode manual\n";
     std::cout << "  pulp config set import_design.default_mode baked\n";
     std::cout << "  pulp config set import_design.default_emit ir-json\n";
+    std::cout << "  pulp config set claude.send_user_file off\n";
     std::cout << "  pulp config get update.mode\n";
     std::cout << "\nNotes:\n";
     std::cout << "  Changing update.mode clears the 24h snooze at ~/.pulp/update-snooze\n";
@@ -290,6 +306,7 @@ int cmd_config(const std::vector<std::string>& args) {
         show("update", "bump_projects", "prompt");
         show("import_design", "default_mode", "live");
         show("import_design", "default_emit", "js");
+        show("claude", "send_user_file", "on");
         return 0;
     }
 


### PR DESCRIPTION
## Why

Generated artifacts (screenshots, rendered designs, diagrams, build outputs)
are far more useful when surfaced with the **SendUserFile** tool — they embed
inline in the Claude app — than when printed as a bare path. But nothing told
the agent to prefer it, so it was inconsistent (and in the terminal a path is
all you get).

## What

A `[claude] send_user_file` knob in `~/.pulp/config.toml` (**default on**) plus
a `SessionStart` plugin hook that reads it and injects the preference into the
agent's context once per session.

- **`tools/cli/cmd_config.cpp`** — new `claude.send_user_file` key (`on|off`),
  wired through `is_allowed_key` / `validate_value` / `list` / `usage`.
  Toggle with `pulp config set claude.send_user_file off` (and `on`).
- **`hooks/scripts/inject-claude-prefs.sh`** (+ `hooks/hooks.json` `SessionStart`,
  matcher `startup|resume`) — dependency-free scan of the `[claude]` table;
  defaults **on** when the file/key is absent; emits the documented
  `hookSpecificOutput.additionalContext` JSON (`suppressOutput`) instructing the
  agent to surface image/file artifacts via SendUserFile. `off` emits nothing.
  Always exits 0 — never blocks session init.

Mechanism confirmed against the Claude Code hooks docs: `SessionStart` stdout /
`additionalContext` is injected into the model context (not just shown to the
user); `Setup` is not (debug-log only).

## Tests

- `test_cli_shellout.cpp` — get/set/list/validate for the new key (default `on`
  in `list`, `off` round-trips, `true` rejected).
- `test_inject_claude_prefs_hook.sh` — default-on (unset file), explicit on,
  off → no output, key-absent → on, and section-scoping (a `send_user_file`
  under a non-`[claude]` table is ignored).

Docs: `cli.md#config`, `cli-commands.yaml`, `claude-code-plugin.md`,
`cli-maintenance` SKILL.md. Versions bumped: SDK 0.371.0, plugin 0.194.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `claude.send_user_file` config and a `SessionStart` hook that prefer the SendUserFile tool for generated artifacts. Images and files now embed inline in Claude by default; toggle via config.

- **New Features**
  - CLI: Add `claude.send_user_file` (`on|off`) in `~/.pulp/config.toml`; toggle with `pulp config set claude.send_user_file on|off`. Key is validated and shown in `pulp config list`.
  - Plugin: Add `SessionStart` hook (`hooks/scripts/inject-claude-prefs.sh`, matcher `startup|resume`) that reads `[claude]` and injects `additionalContext` once per session with `suppressOutput`. Defaults to on; when off, emits nothing. Always exits 0.

- **Dependencies**
  - Bump SDK to `0.372.0` and plugin to `0.194.0`.

<sup>Written for commit 4b57b0b47de20e3a6d04ca525bc51dce78a26325. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

