### PR TITLE
fix(design-import): a single-option stepper paints nothing (no doubled header text)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.370.1
+    VERSION 0.371.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/design_frame_view.cpp
+++ b/core/view/src/design_frame_view.cpp
@@ -447,6 +447,12 @@ const std::string& DesignStepper::current() const {
 void DesignStepper::paint(canvas::Canvas& canvas) {
     const auto b = local_bounds();
     if (options_.empty() || b.width <= 0 || b.height <= 0) return;
+    // A single option has nowhere to step: there is no live value to show beyond
+    // what the design already baked. Painting the chevrons + value here would
+    // double them on top of the baked header (the "doubled header text" bug). Let
+    // the baked SVG show through untouched; the overlay stays as a (no-op) hit
+    // target so a future multi-option list lights it up without re-importing.
+    if (options_.size() <= 1) return;
     const float font = std::min(b.height * 0.5f, 12.0f);
     canvas.set_font("Inter", font);
     const float ty = b.height * 0.5f + font * 0.34f;  // baseline ~vertical center

--- a/test/test_design_frame_view.cpp
+++ b/test/test_design_frame_view.cpp
@@ -347,6 +347,38 @@ TEST_CASE("DesignStepper renders and the value changes with selection",
     CHECK(cmp.similarity < 0.999f);
 }
 
+TEST_CASE("DesignStepper with a single option paints nothing (no double-text over the baked label)",
+          "[view][design-import][frame][overlay][svg]") {
+    // A header stepper detected from a baked `< value >` whose source has only
+    // the one shown value has nowhere to step. Re-drawing its chevrons + value
+    // would double them on top of the design's baked label. So a 1-option
+    // stepper must paint NOTHING (let the baked SVG show through); a multi-option
+    // one paints its live value. Render both on a transparent surface and
+    // compare painted content.
+    DesignStepper one({"Reverb"}, 0);
+    DesignStepper many({"Reverb", "Delay", "Chorus"}, 0);
+    one.set_bounds({0, 0, 80, 24});
+    many.set_bounds({0, 0, 80, 24});
+
+    auto one_png = render_to_png(one, 80, 24, 2.0f, ScreenshotBackend::skia);
+    if (one_png.empty()) SKIP("Skia raster screenshot backend unavailable");
+    auto many_png = render_to_png(many, 80, 24, 2.0f, ScreenshotBackend::skia);
+    REQUIRE_FALSE(many_png.empty());
+
+    const auto one_stats = analyze_screenshot_content(one_png);
+    const auto many_stats = analyze_screenshot_content(many_png);
+    REQUIRE(one_stats.valid);
+    REQUIRE(many_stats.valid);
+    // Multi-option stepper paints text (chevrons + value) → many colors. If even
+    // that is blank, the raster lane no-ops text; skip rather than false-pass.
+    if (many_stats.unique_colors <= 2)
+        SKIP("native raster unavailable in this build");
+    // The single-option stepper drew nothing: a near-uniform (transparent)
+    // frame, strictly fewer colors than the multi-option one.
+    CHECK(one_stats.unique_colors <= 2);
+    CHECK(one_stats.unique_colors < many_stats.unique_colors);
+}
+
 TEST_CASE("suppress_svg_rect removes the baked tab highlight by geometry, not rx/cx",
           "[view][design-import][frame][svg]") {
     // Values from a real exported frame: the selected-tab highlight is a filled


### PR DESCRIPTION
## Bug (#42 from a fresh-import render review)

Imported section headers showed **doubled text** (ENVELOPE / FILTER & EQ / FX
RACK …). A header `< value >` stepper detected from a baked control whose source
has only the one shown value (`option_count <= 1`) has nowhere to step, but
`DesignStepper::paint` still redrew its chevrons + value every frame — on top of
the design's baked header label.

## Fix

Early-return from `DesignStepper::paint` when `option_count <= 1`: let the baked
SVG header show through untouched. The overlay remains as a (no-op) hit target so
a future multi-option list lights it up without re-importing. Multi-option
steppers are unchanged (they still paint the live value as it slides).

Generic — no design-specific constants.

## Test

A 1-option `DesignStepper` renders an empty (near-uniform) frame while a
3-option one paints content, pinned via screenshot content stats. Verified the
test fails against the pre-fix painter (doubled text → extra colors). Full
`pulp-test-design-frame-view` suite green.

## Note on the sibling reports (#41, #43)

Investigated against a fresh import of the live file:
- **#41 (residual baked pill)** — not reproduced on the main tab strip in the
  native render; `suppress_svg_rect` removes the baked highlight cleanly there.
- **#43 (envelope "1 2 3 4")** — the envelope group is the **same "Radio Button"
  component** as the top strip (structurally identical, same parent), so it's not
  a structural misdetection. Deferred — a guard would need a design-specific
  position/overlap rule; flagged for a product decision rather than a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes doubled header text in imported designs by not painting steppers with a single option. Also bumps project version to 0.371.0.

- **Bug Fixes**
  - Early return in `DesignStepper::paint` when `options_.size() <= 1` to avoid drawing chevrons/value; overlay stays as a no-op hit target.
  - Screenshot test asserts single-option renders empty while multi-option renders content (pre-fix would fail).

<sup>Written for commit b914c4c93b4e13e961bb2c9922219b01d88d0ed6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

