### PR TITLE
fix(design-import): skip overlay controls occluded by a later opaque node

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -691,6 +691,24 @@ GPU-safe, and DOES render the open ComboBox popup (it paints its list inline).
   (figma_rest_export.py) finds a node named ~`search` (skipping the
   `ic:round-search` icon; ELYSIUM names the placeholder TEXT "Search" with the
   field as its parent group). The plugin lane must mirror this when wired.
+- **OCCLUSION GUARD — skip controls painted over by a later opaque node.** A
+  design can carry a leftover/under-layer control that is fully covered by a
+  panel drawn on top (e.g. a stray "Radio Button" 1/2/3/4 buried under the
+  envelope graph). The baked SVG hides it, but a naive detector resurfaces it as
+  a live overlay floating ON TOP. Guard: in detection, drop any candidate whose
+  bbox is fully contained by a node painted AFTER its entire subtree (document
+  preorder = paint order) that has an opaque fill. Key invariants that took a
+  round to get right: (1) key the paint-index/subtree maps on OBJECT IDENTITY,
+  not the figma `id` string (absent/dup ids collide); (2) compare against the
+  candidate's `subtree_end`, NOT its own index — else the control's OWN
+  background `<rect>` (a descendant that fills it) looks like an occluder and
+  drops the control (this nuked the search field on the first cut); (3) "opaque"
+  must accept GRADIENT fills, not just SOLID — ELYSIUM's occluding panel is a
+  radial gradient. REST: `_opaque_cover` checks SOLID `a>=.99` or GRADIENT with
+  all stops `a>=.99` + node opacity. TS (`faithful-vector.ts`): proxies opacity
+  via `style.background_color` presence (the extractor sets it for SOLID and the
+  flat fallback of GRADIENT) + the node `opacity` field; `Map<OverlayNode>` keys
+  give object identity for free. KEEP both lanes' guards in sync.
 - **COORDINATE GOTCHA (cost me real time):** the Figma node tree is frame-local
   (root at abs origin, 1000×600 for ELYSIUM) but the SVG export adds the
   drop-shadow margin (1146×746, panel at (73,50)). Node coords are NOT SVG

--- a/test/test_figma_rest_export.py
+++ b/test/test_figma_rest_export.py
@@ -390,6 +390,57 @@ class FaithfulVectorTest(unittest.TestCase):
                 "children": [{"name": "Knob", "absoluteBoundingBox": {"x": 0, "y": 0, "width": 4, "height": 4}}]}
         self.assertEqual(frx.detect_overlay_controls(root, (0.0, 0.0), (0.0, 0.0)), [])
 
+    def _tab_group_node(self, nid, x, y):
+        def tab(tx, label):
+            return {"name": "Button", "type": "FRAME",
+                    "absoluteBoundingBox": {"x": tx, "y": y, "width": 29, "height": 20},
+                    "children": [{"type": "TEXT", "characters": label}]}
+        return {"name": "Radio Button", "id": nid, "type": "FRAME",
+                "absoluteBoundingBox": {"x": x, "y": y, "width": 120, "height": 20},
+                "children": [tab(x, "1"), tab(x + 29, "2"), tab(x + 58, "3"), tab(x + 87, "4")]}
+
+    def test_detect_overlay_controls_drops_occluded_control(self):
+        # A tab group fully painted over by a LATER opaque sibling (an envelope
+        # graph panel drawn on top) is not visible → must NOT be surfaced. This
+        # is the "spurious envelope 1/2/3/4" guard: the leftover radio layer sits
+        # under an opaque panel, so the importer must skip it.
+        tg = self._tab_group_node("buried", 50, 530)
+        cover = {"name": "Graph Panel", "id": "cover", "type": "FRAME",
+                 "absoluteBoundingBox": {"x": 0, "y": 434, "width": 1000, "height": 142},
+                 "fills": [{"type": "GRADIENT_RADIAL", "visible": True,
+                            "gradientStops": [{"color": {"a": 1.0}}, {"color": {"a": 1.0}}]}],
+                 "children": []}
+        root = {"id": "root", "absoluteBoundingBox": {"x": 0, "y": 0, "width": 1000, "height": 600},
+                "children": [tg, cover]}              # tg painted BEFORE the cover
+        els = frx.detect_overlay_controls(root, (0.0, 0.0), (0.0, 0.0))
+        self.assertEqual([e for e in els if e["kind"] == "tab_group"], [])
+
+    def test_detect_overlay_controls_keeps_visible_control(self):
+        # Same tab group, but the opaque panel is painted BEFORE it (lower z) —
+        # so the tab group is on top and visible. It must be surfaced.
+        cover = {"name": "Graph Panel", "id": "cover", "type": "FRAME",
+                 "absoluteBoundingBox": {"x": 0, "y": 434, "width": 1000, "height": 142},
+                 "fills": [{"type": "SOLID", "visible": True, "color": {"a": 1.0}}],
+                 "children": []}
+        tg = self._tab_group_node("ontop", 50, 530)
+        root = {"id": "root", "absoluteBoundingBox": {"x": 0, "y": 0, "width": 1000, "height": 600},
+                "children": [cover, tg]}              # tg painted AFTER the cover
+        els = frx.detect_overlay_controls(root, (0.0, 0.0), (0.0, 0.0))
+        self.assertEqual(len([e for e in els if e["kind"] == "tab_group"]), 1)
+
+    def test_detect_overlay_controls_own_background_is_not_an_occluder(self):
+        # A control whose OWN background <rect> fills it (a descendant painted
+        # after the group) must NOT be treated as occluding itself.
+        tg = self._tab_group_node("self", 50, 530)
+        tg["children"].insert(0, {  # background rect spanning the whole group, drawn first child
+            "name": "bg", "id": "selfbg", "type": "RECTANGLE",
+            "absoluteBoundingBox": {"x": 50, "y": 530, "width": 120, "height": 20},
+            "fills": [{"type": "SOLID", "visible": True, "color": {"a": 1.0}}]})
+        root = {"id": "root", "absoluteBoundingBox": {"x": 0, "y": 0, "width": 1000, "height": 600},
+                "children": [tg]}
+        els = frx.detect_overlay_controls(root, (0.0, 0.0), (0.0, 0.0))
+        self.assertEqual(len([e for e in els if e["kind"] == "tab_group"]), 1)
+
 
 class FaithfulVectorDefaultTest(unittest.TestCase):
     """The faithful-vector lane (interactive overlays) must be the DEFAULT — a

--- a/tools/figma-plugin/src/faithful-vector.ts
+++ b/tools/figma-plugin/src/faithful-vector.ts
@@ -41,6 +41,7 @@ export interface OverlayNode {
   figma_node_id: string;
   absolute_bounds: { x: number; y: number; w: number; h: number };
   content?: string;            // the node's own text characters, if any
+  opacity?: number;            // node opacity (1 when absent) — for the occlusion guard
   style?: { background_color?: string };
   children: OverlayNode[];
 }
@@ -213,6 +214,51 @@ export function detectOverlayControls(
 
   const out: InteractiveElement[] = [];
 
+  // ── Occlusion guard (lockstep with figma_rest_export.py) ──────────────────
+  // A control fully painted over by a later (higher-z) OPAQUE node is not
+  // visible and must NOT become an overlay (else a buried layer — e.g. a
+  // leftover radio strip under an envelope graph — gets resurfaced). Paint order
+  // = document preorder; only a node painted AFTER the candidate's ENTIRE
+  // subtree can occlude it (so a node's own background rect / descendants never
+  // count). Opaque proxy: the node has a resolved background_color (the
+  // extractor sets this for SOLID and the flat fallback of GRADIENT fills) and
+  // is not itself faded. This mirrors the REST detector's _opaque_cover.
+  function opaqueCover(n: OverlayNode): boolean {
+    if (n.opacity != null && n.opacity < 0.99) return false;
+    return !!(n.style && n.style.background_color);
+  }
+  const paintIndex = new Map<OverlayNode, number>();
+  const subtreeEnd = new Map<OverlayNode, number>();
+  const occluders: Array<[number, number, number, number, number]> = [];
+  let _counter = 0;
+  function scan(n: OverlayNode): number {
+    const idx = _counter++;
+    paintIndex.set(n, idx);
+    const b = n.absolute_bounds;
+    if (b && opaqueCover(n)) occluders.push([idx, b.x, b.y, b.x + b.w, b.y + b.h]);
+    let last = idx;
+    const kids = n.children || [];
+    for (let i = 0; i < kids.length; i++) last = scan(kids[i]);
+    subtreeEnd.set(n, last);
+    return last;
+  }
+  scan(root);
+  function occluded(n: OverlayNode): boolean {
+    const b = n.absolute_bounds;
+    if (!b) return false;
+    const after = subtreeEnd.has(n) ? subtreeEnd.get(n)!
+                                    : (paintIndex.has(n) ? paintIndex.get(n)! : -1);
+    const cx0 = b.x, cy0 = b.y, cx1 = b.x + b.w, cy1 = b.y + b.h, eps = 0.5;
+    for (let i = 0; i < occluders.length; i++) {
+      const o = occluders[i];
+      if (o[0] <= after) continue;
+      if (o[1] - eps <= cx0 && o[2] - eps <= cy0 && o[3] + eps >= cx1 && o[4] + eps >= cy1) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   // A tab/segmented control = a horizontal row of >=3 container children, each
   // with a short text label, of similar width; the selected tab carries a
   // visible SOLID fill (here: a resolved background_color).
@@ -271,6 +317,9 @@ export function detectOverlayControls(
   }
 
   function visit(n: OverlayNode, parent: OverlayNode | null): void {
+    // Painted-over (occluded) subtrees hold no visible controls — skip the whole
+    // subtree so a buried layer never becomes an interactive overlay.
+    if (occluded(n)) return;
     const name = (n.name || "").toLowerCase();
     const ntype = n.figma_type || "";
     const bb = n.absolute_bounds;

--- a/tools/import-design/figma_rest_export.py
+++ b/tools/import-design/figma_rest_export.py
@@ -678,6 +678,73 @@ def detect_overlay_controls(figma_root, root_abs, panel_origin):
 
     out = []
 
+    # ── Occlusion guard ──────────────────────────────────────────────────────
+    # A control that is fully painted over by a later (higher-z) OPAQUE node is
+    # not actually visible — it must NOT become an interactive overlay, or we
+    # resurface a layer the design hides (e.g. a leftover radio strip buried
+    # under an envelope graph). Paint order = document preorder (children after
+    # parent, siblings in order); a node is occluded when some node painted AFTER
+    # it (greater preorder index — which naturally excludes its own ancestors and
+    # itself, since they paint earlier) has an opaque fill and a bbox containing
+    # it. A node nested INSIDE the occluder is a descendant of it and so paints
+    # later (higher index) → not flagged, so real controls inside an opaque panel
+    # are kept.
+    def _opaque_cover(nd):
+        if nd.get("opacity", 1.0) < 0.99:
+            return False
+        for f in (nd.get("fills") or []):
+            if not f.get("visible", True) or f.get("opacity", 1.0) < 0.99:
+                continue
+            t = f.get("type", "")
+            if t == "SOLID":
+                if f.get("color", {}).get("a", 1.0) >= 0.99:
+                    return True
+            elif t.startswith("GRADIENT"):
+                stops = f.get("gradientStops") or []
+                if stops and all(s.get("color", {}).get("a", 1.0) >= 0.99 for s in stops):
+                    return True
+        return False
+
+    # Key on Python object identity (id(node)), NOT the figma "id" string — the
+    # latter can be absent or duplicated, which would collide nodes in the maps.
+    _paint_index = {}
+    _subtree_end = {}  # last preorder index within a node's own subtree
+    _occluders = []    # (paint_index, x0, y0, x1, y1)
+
+    def _scan(nd, counter):
+        idx = counter[0]
+        counter[0] += 1
+        _paint_index[id(nd)] = idx
+        b = nd.get("absoluteBoundingBox")
+        if b and _opaque_cover(nd):
+            _occluders.append((idx, b["x"], b["y"],
+                               b["x"] + b.get("width", 0.0), b["y"] + b.get("height", 0.0)))
+        last = idx
+        for c in nd.get("children", []) or []:
+            last = _scan(c, counter)
+        _subtree_end[id(nd)] = last
+        return last
+
+    _scan(figma_root, [0])
+
+    def _occluded(nd):
+        b = nd.get("absoluteBoundingBox")
+        if not b:
+            return False
+        # Only nodes painted AFTER this node's ENTIRE subtree can occlude it.
+        # That excludes the node's own descendants (e.g. its background <rect>,
+        # which fills it and would otherwise look like an occluder of its parent).
+        after = _subtree_end.get(id(nd), _paint_index.get(id(nd), -1))
+        cx0, cy0 = b["x"], b["y"]
+        cx1, cy1 = b["x"] + b.get("width", 0.0), b["y"] + b.get("height", 0.0)
+        eps = 0.5
+        for oi, ox0, oy0, ox1, oy1 in _occluders:
+            if oi <= after:
+                continue
+            if ox0 - eps <= cx0 and oy0 - eps <= cy0 and ox1 + eps >= cx1 and oy1 + eps >= cy1:
+                return True
+        return False
+
     _CONTAINER_TYPES = ("FRAME", "INSTANCE", "COMPONENT", "GROUP")
 
     def detect_tab_group(n):
@@ -723,6 +790,10 @@ def detect_overlay_controls(figma_root, root_abs, panel_origin):
         }
 
     def visit(n, parent):
+        # Painted-over (occluded) subtrees hold no visible controls — skip the
+        # whole subtree so a buried layer never becomes an interactive overlay.
+        if _occluded(n):
+            return
         name = (n.get("name") or "").lower()
         ntype = n.get("type", "")
         bb = n.get("absoluteBoundingBox")


### PR DESCRIPTION
## Bug (#43)

A fresh import surfaced a phantom **"1/2/3/4" tab strip floating over the
envelope graph** — something the designer doesn't see in Figma:

| Figma (envelope) | Import before | Import after |
|---|---|---|
| clean ADSR graph | "1 2 3 4" pill over the graph | clean ADSR graph |

Root cause: the file carries a leftover **"Radio Button" layer** at (47,527)
that is fully painted over by the envelope panel ("Frame 482", a later/on-top
sibling with an opaque radial-gradient fill). The baked SVG hides it correctly,
but overlay detection resurfaced it as a live widget drawn on top. It's *not* a
duplicate of the top strip — it's a buried layer.

## Fix

Add an **occlusion guard** to both detector lanes (REST `figma_rest_export.py`
+ Figma plugin `faithful-vector.ts`, in lockstep): drop any candidate whose
bbox is fully contained by a node painted **after its entire subtree** (document
preorder = paint order) that has an **opaque fill**. Generic and structural — no
design-specific constants.

Verified against the live file: detection drops **23 → 22** overlays — the
buried envelope radio is gone; the real top tab strip, search field, 2
dropdowns, 3 steppers, and 15 knobs all remain. GPU render confirms the
envelope is the clean ADSR graph.

## Subtle invariants (each cost a round)

- key the paint-index / subtree maps on **object identity**, not the figma `id`
  string (absent/duplicate ids collide);
- compare against the candidate's **`subtree_end`**, not its own index — else
  the control's OWN background `<rect>` (a descendant filling it) reads as an
  occluder and drops the control (this initially nuked the search field);
- **"opaque" must accept GRADIENT fills**, not just SOLID — the occluder here is
  a radial gradient.

## Tests

`drops-occluded`, `keeps-visible` (occluder painted before), and
`own-background-is-not-an-occluder`, plus existing search/tab cases still pass
(33 total). `import-design` SKILL.md documents the guard. No version surface
touched (importer `.py`/`.ts` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip overlay controls that are fully occluded by a later opaque node, preventing buried layers from resurfacing as widgets. Fixes the phantom "1/2/3/4" tab strip over the envelope graph while keeping real controls.

- **Bug Fixes**
  - Added an occlusion guard to both detectors (REST and plugin): drop a candidate if its bbox is fully inside a node painted after its subtree with an opaque fill (SOLID or GRADIENT; respects node opacity).
  - Keyed paint order maps by object identity and compared against `subtree_end` to avoid self-occlusion from a control’s own background.
  - Added tests for occluded, visible, and self-background cases; updated `SKILL.md` with the rule and invariants.

<sup>Written for commit f2c5b92b5c921b59415f5c1b466d120c3c103dff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

