### PR TITLE
feat(platform): Windows native file dialogs via IFileDialog (W5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.374.1
+    VERSION 0.375.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/platform/CMakeLists.txt
+++ b/core/platform/CMakeLists.txt
@@ -55,10 +55,13 @@ elseif(IOS)
 elseif(WIN32)
     target_sources(pulp-platform PRIVATE
         platform/win/clipboard_win.cpp
+        platform/win/file_dialog_win.cpp
         platform/win/child_process_win.cpp
         platform/win/environment_win.cpp
     )
-    target_link_libraries(pulp-platform PRIVATE user32 advapi32)
+    # ole32: COM (CoInitializeEx/CoCreateInstance/CoTaskMemFree) for the
+    # IFileDialog file-dialog backend in file_dialog_win.cpp.
+    target_link_libraries(pulp-platform PRIVATE user32 advapi32 ole32)
 elseif(ANDROID)
     # Android platform sources wired via PulpAndroid.cmake → pulp_wire_android_sources()
     # The Android permissions_backend.cpp (picked up by that glob) defines

--- a/core/platform/platform/win/file_dialog_win.cpp
+++ b/core/platform/platform/win/file_dialog_win.cpp
@@ -1,0 +1,169 @@
+// Windows native file dialogs via the Vista+ IFileDialog COM API (#301 / W5).
+//
+// Windows previously had no file_dialog impl — calls fell through to the
+// backend-routed stub and returned "no selection". This provides a real
+// backend (IFileOpenDialog / IFileSaveDialog) installed via
+// FileDialog::install_native_backend() (the standalone host calls that at
+// startup), mirroring the Linux xdg-desktop-portal backend. COM is initialized
+// per call (apartment-threaded) and torn down after, so the dialog works
+// regardless of the caller's COM state.
+//
+// Scope (MVP, matching the Linux portal backend): open one/many, save (with a
+// suggested name), and choose-folder. File-type filters and a preselected
+// folder are a follow-up — the dialog works without them. CLSIDs/IIDs are
+// resolved with __uuidof / IID_PPV_ARGS so we don't depend on the named GUID
+// constants in uuid.lib; only ole32 is linked.
+
+#include <pulp/platform/file_dialog.hpp>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#include <shobjidl.h>   // IFileDialog, IFileOpenDialog, IShellItem(Array)
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace pulp::platform {
+
+namespace {
+
+// Per-call apartment-threaded COM init. RPC_E_CHANGED_MODE means COM was
+// already initialized in another mode on this thread — that's fine, we just
+// must not CoUninitialize in that case.
+struct ComInit {
+    HRESULT hr;
+    ComInit() {
+        hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+    }
+    ~ComInit() {
+        if (SUCCEEDED(hr)) CoUninitialize();
+    }
+    bool usable() const { return SUCCEEDED(hr) || hr == RPC_E_CHANGED_MODE; }
+};
+
+std::wstring utf8_to_utf16(const std::string& s) {
+    if (s.empty()) return std::wstring();
+    int n = MultiByteToWideChar(CP_UTF8, 0, s.data(), static_cast<int>(s.size()), nullptr, 0);
+    if (n <= 0) return std::wstring();
+    std::wstring w(static_cast<size_t>(n), L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, s.data(), static_cast<int>(s.size()), w.data(), n);
+    return w;
+}
+
+std::string utf16_to_utf8(const wchar_t* w) {
+    if (!w) return std::string();
+    int n = WideCharToMultiByte(CP_UTF8, 0, w, -1, nullptr, 0, nullptr, nullptr);
+    if (n <= 1) return std::string();
+    std::string s(static_cast<size_t>(n - 1), '\0');  // n includes the NUL
+    WideCharToMultiByte(CP_UTF8, 0, w, -1, s.data(), n, nullptr, nullptr);
+    return s;
+}
+
+// Filesystem path of a shell item, or nullopt for non-filesystem items.
+std::optional<std::string> item_path(IShellItem* item) {
+    if (!item) return std::nullopt;
+    PWSTR psz = nullptr;
+    if (FAILED(item->GetDisplayName(SIGDN_FILESYSPATH, &psz)) || !psz) return std::nullopt;
+    std::string p = utf16_to_utf8(psz);
+    CoTaskMemFree(psz);
+    if (p.empty()) return std::nullopt;
+    return p;
+}
+
+// Single-result open/save/folder dialog. `extra` adds option flags
+// (e.g. FOS_PICKFOLDERS). `save` selects the Save coclass.
+std::optional<std::string> run_single(bool save,
+                                      const std::string& title,
+                                      FILEOPENDIALOGOPTIONS extra,
+                                      const std::string& default_name) {
+    ComInit com;
+    if (!com.usable()) return std::nullopt;
+
+    IFileDialog* dlg = nullptr;
+    HRESULT hr = save
+        ? CoCreateInstance(__uuidof(FileSaveDialog), nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&dlg))
+        : CoCreateInstance(__uuidof(FileOpenDialog), nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&dlg));
+    if (FAILED(hr) || !dlg) return std::nullopt;
+
+    std::optional<std::string> result;
+    FILEOPENDIALOGOPTIONS opts = 0;
+    dlg->GetOptions(&opts);
+    dlg->SetOptions(opts | extra | FOS_FORCEFILESYSTEM | FOS_NOCHANGEDIR);
+    if (!title.empty()) dlg->SetTitle(utf8_to_utf16(title).c_str());
+    if (!default_name.empty()) dlg->SetFileName(utf8_to_utf16(default_name).c_str());
+
+    if (SUCCEEDED(dlg->Show(nullptr))) {  // S_OK = picked; cancel → non-S_OK
+        IShellItem* item = nullptr;
+        if (SUCCEEDED(dlg->GetResult(&item)) && item) {
+            result = item_path(item);
+            item->Release();
+        }
+    }
+    dlg->Release();
+    return result;
+}
+
+}  // namespace
+
+FileDialog::Backend make_win_file_dialog_backend() {
+    FileDialog::Backend backend;
+
+    backend.open_file = [](const std::string& title,
+                           const std::vector<FileFilter>&,
+                           const std::string&) -> std::optional<std::string> {
+        return run_single(/*save=*/false, title, 0, "");
+    };
+
+    backend.open_files = [](const std::string& title,
+                            const std::vector<FileFilter>&,
+                            const std::string&) -> std::vector<std::string> {
+        ComInit com;
+        if (!com.usable()) return {};
+        IFileOpenDialog* dlg = nullptr;
+        if (FAILED(CoCreateInstance(__uuidof(FileOpenDialog), nullptr, CLSCTX_INPROC_SERVER,
+                                    IID_PPV_ARGS(&dlg))) || !dlg) {
+            return {};
+        }
+        std::vector<std::string> out;
+        FILEOPENDIALOGOPTIONS opts = 0;
+        dlg->GetOptions(&opts);
+        dlg->SetOptions(opts | FOS_ALLOWMULTISELECT | FOS_FORCEFILESYSTEM | FOS_NOCHANGEDIR);
+        if (!title.empty()) dlg->SetTitle(utf8_to_utf16(title).c_str());
+        if (SUCCEEDED(dlg->Show(nullptr))) {
+            IShellItemArray* arr = nullptr;
+            if (SUCCEEDED(dlg->GetResults(&arr)) && arr) {
+                DWORD count = 0;
+                arr->GetCount(&count);
+                for (DWORD i = 0; i < count; ++i) {
+                    IShellItem* item = nullptr;
+                    if (SUCCEEDED(arr->GetItemAt(i, &item)) && item) {
+                        if (auto p = item_path(item)) out.push_back(*p);
+                        item->Release();
+                    }
+                }
+                arr->Release();
+            }
+        }
+        dlg->Release();
+        return out;
+    };
+
+    backend.save_file = [](const std::string& title,
+                           const std::vector<FileFilter>&,
+                           const std::string&,
+                           const std::string& default_name) -> std::optional<std::string> {
+        return run_single(/*save=*/true, title, 0, default_name);
+    };
+
+    backend.choose_folder = [](const std::string& title,
+                               const std::string&) -> std::optional<std::string> {
+        return run_single(/*save=*/false, title, FOS_PICKFOLDERS, "");
+    };
+
+    return backend;
+}
+
+}  // namespace pulp::platform

--- a/core/platform/src/file_dialog_stub.cpp
+++ b/core/platform/src/file_dialog_stub.cpp
@@ -39,6 +39,9 @@ namespace pulp::platform {
 // forces that TU to link (static-lib object files with only static
 // initializers can otherwise be dropped).
 FileDialog::Backend make_linux_portal_backend();
+#elif defined(_WIN32)
+// Defined in platform/win/file_dialog_win.cpp (IFileDialog COM backend).
+FileDialog::Backend make_win_file_dialog_backend();
 #endif
 
 namespace {
@@ -64,6 +67,12 @@ bool FileDialog::install_native_backend() {
     if (g_backend_installed) return true;
     if (!DBus::library_available()) return false;
     g_backend = make_linux_portal_backend();
+    g_backend_installed = true;
+    return true;
+#elif defined(_WIN32)
+    std::lock_guard lock(g_backend_mu);
+    if (g_backend_installed) return true;   // leave a host-set backend in place
+    g_backend = make_win_file_dialog_backend();
     g_backend_installed = true;
     return true;
 #else

--- a/test/test_file_dialog.cpp
+++ b/test/test_file_dialog.cpp
@@ -311,3 +311,38 @@ TEST_CASE("FileDialog backend registration is safe to call on any platform",
     REQUIRE_FALSE(FileDialog::has_backend());
 #endif
 }
+
+#if defined(_WIN32)
+// W5: Windows ships a built-in IFileDialog backend (file_dialog_win.cpp),
+// installed opt-in via install_native_backend() — mirroring the Linux portal
+// backend. We verify the install wiring (has_backend() flips true, idempotent,
+// host backend preserved) WITHOUT calling a native dialog method, since
+// IFileDialog is interactive and would block CI. The COM dialog code itself is
+// compile-verified by the Windows build lanes.
+TEST_CASE("FileDialog Windows: install_native_backend installs the IFileDialog backend",
+          "[platform][file-dialog][windows][issue-301]") {
+    FileDialog::clear_backend();
+    REQUIRE_FALSE(FileDialog::has_backend());
+
+    REQUIRE(FileDialog::install_native_backend());
+    REQUIRE(FileDialog::has_backend());
+    // Idempotent — a second call leaves it installed.
+    REQUIRE(FileDialog::install_native_backend());
+    REQUIRE(FileDialog::has_backend());
+
+    // A host-registered backend is preserved (install must not clobber it).
+    FileDialog::clear_backend();
+    FileDialog::Backend host;
+    host.open_file = [](const std::string&, const std::vector<FileFilter>&,
+                        const std::string&) {
+        return std::optional<std::string>("C:/host/picked.wav");
+    };
+    FileDialog::set_backend(host);
+    REQUIRE(FileDialog::install_native_backend());
+    auto picked = FileDialog::open_file("t", {}, "");  // routes to host, no native dialog
+    REQUIRE(picked.has_value());
+    REQUIRE(*picked == "C:/host/picked.wav");
+
+    FileDialog::clear_backend();
+}
+#endif  // _WIN32


### PR DESCRIPTION
Windows had no file_dialog impl — calls fell through to the backend-routed stub and returned "no selection". This adds a real Vista+ `IFileDialog` backend (open / open-many / save / choose-folder), installed opt-in via `FileDialog::install_native_backend()`, mirroring the Linux xdg-desktop-portal backend (L6a). COM is per-call apartment-threaded; cancel/non-filesystem items honest-fail. `__uuidof`/`IID_PPV_ARGS` avoid a uuid.lib GUID-symbol dependency — only `ole32` is linked.

Verification: the COM dialog code is interactive (not headlessly testable, same ceiling as the L6a portal); it is **compile-verified by the Windows build lanes** (the required macOS lane does not compile Windows TUs). A Windows-guarded unit test covers the install wiring (has_backend flips, idempotent, host backend preserved) without invoking a dialog.

Part of W5. Filters + preselected folder deferred (matches the Linux portal MVP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native Windows file dialogs via Vista+ `IFileDialog`, so apps can open, save, and pick folders on Windows. Installed opt-in via `FileDialog::install_native_backend()` with per-call COM; addresses W5.

- New Features
  - Windows backend via `IFileOpenDialog`/`IFileSaveDialog`: open one/many, save (suggested name), choose-folder.
  - Per-call COM init; cancel and non-filesystem items return no selection.
  - Mirrors the Linux portal MVP; filters and initial folder are deferred.
  - `install_native_backend()` adds a Windows arm; idempotent and preserves a host-set backend (Windows-only test covers this).

- Dependencies
  - Add `platform/win/file_dialog_win.cpp`; link `ole32`.
  - Avoid `uuid.lib` by using `__uuidof`/`IID_PPV_ARGS`.

<sup>Written for commit c87ec951461427b96558f73788fac7431be40edc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

