### PR TITLE
fix(design-import): tab-strip glow + digit doubling + dropdown label fit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.373.0
+    VERSION 0.374.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/design_frame_view.hpp
+++ b/core/view/include/pulp/view/design_frame_view.hpp
@@ -51,6 +51,15 @@ struct DesignFrameElement {
 bool suppress_svg_rect(std::string& svg, float x, float y, float w, float h,
                        float tol = 2.0f);
 
+// Remove a filtered group (`<g filter="url(#...)">…</g>`) whose first drawn
+// coordinate falls inside the box [x, x+w] × [y, y+h], returning true if one was
+// erased. Figma bakes the SELECTED tab's digit with a soft glow (a large-blur
+// drop-shadow filter); the live pill moves on click but that baked glow stays
+// stuck on the originally-selected digit. Removing the filtered group at the
+// originally-selected cell lets the live overlay own the digit cleanly. Pure
+// geometry — no per-design data.
+bool suppress_svg_glow_at(std::string& svg, float x, float y, float w, float h);
+
 // Renders a design's own SVG document pixel-faithfully via Canvas::draw_svg
 // (Skia SkSVGDOM), cropped to its panel, and overlays native interaction from a
 // typed element list. This is the faithful-vector design-import lane's view: the

--- a/core/view/include/pulp/view/design_frame_view.hpp
+++ b/core/view/include/pulp/view/design_frame_view.hpp
@@ -60,6 +60,13 @@ bool suppress_svg_rect(std::string& svg, float x, float y, float w, float h,
 // geometry — no per-design data.
 bool suppress_svg_glow_at(std::string& svg, float x, float y, float w, float h);
 
+// Remove the first standalone `<path …/>` whose first drawn coordinate falls
+// inside the box [x, x+w] × [y, y+h], returning true if one was erased. Used to
+// drop a BAKED tab digit glyph so the live DesignTabGroup is the sole renderer
+// of the digits (no faint "doubled" glyph where the live label paints over the
+// baked one). Pure geometry — no per-design data.
+bool suppress_svg_glyph_at(std::string& svg, float x, float y, float w, float h);
+
 // Renders a design's own SVG document pixel-faithfully via Canvas::draw_svg
 // (Skia SkSVGDOM), cropped to its panel, and overlays native interaction from a
 // typed element list. This is the faithful-vector design-import lane's view: the

--- a/core/view/include/pulp/view/ui_components.hpp
+++ b/core/view/include/pulp/view/ui_components.hpp
@@ -15,6 +15,16 @@
 
 namespace pulp::view {
 
+// Fit a label into `avail` px. Prefer SHRINKING the font from `base` toward
+// `min` to show the full text; only ellipsize (in-place, with "...") if it still
+// overflows at `min`. `width_at(s, f)` returns the rendered width of `s` at font
+// size `f` (e.g. a canvas set_font + measure_text). Returns the chosen font
+// size and rewrites `text` to the string to draw. Pure logic — unit-tested
+// independently of any canvas (a ComboBox box is often sized tight to a design's
+// own label, so truncating reads worse than a slightly smaller full label).
+float fit_combo_label(std::string& text, float avail, float base, float min,
+                      const std::function<float(const std::string&, float)>& width_at);
+
 // ── ComboBox ─────────────────────────────────────────────────────────────
 
 /// Drop-down selector for enumerated parameters.

--- a/core/view/src/design_frame_view.cpp
+++ b/core/view/src/design_frame_view.cpp
@@ -150,6 +150,38 @@ bool suppress_svg_glow_at(std::string& svg, float x, float y, float w, float h) 
     return false;
 }
 
+bool suppress_svg_glyph_at(std::string& svg, float x, float y, float w, float h) {
+    const float x0 = x, y0 = y, x1 = x + w, y1 = y + h;
+    std::size_t pos = 0;
+    while ((pos = svg.find("<path", pos)) != std::string::npos) {
+        const auto end = svg.find("/>", pos);
+        if (end == std::string::npos) break;
+        const auto dp = svg.find("d=\"M", pos);
+        float fx = std::numeric_limits<float>::quiet_NaN(), fy = fx;
+        if (dp != std::string::npos && dp < end) {
+            const char* p = svg.c_str() + dp + 4;
+            while (*p == ' ') ++p;
+            char* endp = nullptr;
+            fx = std::strtof(p, &endp);
+            if (endp != p) {
+                p = endp;
+                while (*p == ' ' || *p == ',') ++p;
+                fy = std::strtof(p, &endp);
+                if (endp == p) fy = std::numeric_limits<float>::quiet_NaN();
+            } else {
+                fx = std::numeric_limits<float>::quiet_NaN();
+            }
+        }
+        if (!std::isnan(fx) && !std::isnan(fy) &&
+            fx >= x0 && fx <= x1 && fy >= y0 && fy <= y1) {
+            svg.erase(pos, end - pos + 2);
+            return true;
+        }
+        pos = end + 2;
+    }
+    return false;
+}
+
 DesignFrameView::DesignFrameView(std::string svg, std::vector<DesignFrameElement> elements,
                                  float panel_x, float panel_y, float panel_w, float panel_h)
     : svg_(std::move(svg)), elements_(std::move(elements)) {
@@ -177,12 +209,20 @@ DesignFrameView::DesignFrameView(std::string svg, std::vector<DesignFrameElement
         const int n = static_cast<int>(e.options.size());
         const float slot_w = e.w / static_cast<float>(n);
         const int sel = std::clamp(e.selected_index, 0, n - 1);
-        const float cell_x = e.x + static_cast<float>(sel) * slot_w;
-        suppress_svg_rect(svg_, cell_x, e.y, slot_w, e.h);
-        // Also drop the baked GLOW the design paints on the selected digit (a
-        // big-blur drop-shadow filter group): the live pill moves on click but
-        // that glow would otherwise stay stuck on the originally-selected number.
-        suppress_svg_glow_at(svg_, cell_x, e.y, slot_w, e.h);
+        suppress_svg_rect(svg_, e.x + static_cast<float>(sel) * slot_w, e.y,
+                          slot_w, e.h);
+        // Drop the BAKED tab digits so the live DesignTabGroup is the sole,
+        // consistent renderer of them. Otherwise the live labels paint over the
+        // baked ones — two slightly different glyphs (the design font vs the
+        // overlay font) → a faint "doubled" look — and the baked SELECTED digit
+        // keeps its glow + bright colour stuck in place when the live pill moves.
+        // Per slot, remove the baked glyph: the selected one is a glow filter
+        // group, the rest are plain <path>s; try the group first, then the path.
+        for (int slot = 0; slot < n; ++slot) {
+            const float cx = e.x + static_cast<float>(slot) * slot_w;
+            if (!suppress_svg_glow_at(svg_, cx, e.y, slot_w, e.h))
+                suppress_svg_glyph_at(svg_, cx, e.y, slot_w, e.h);
+        }
     }
 }
 

--- a/core/view/src/design_frame_view.cpp
+++ b/core/view/src/design_frame_view.cpp
@@ -103,6 +103,53 @@ bool suppress_svg_rect(std::string& svg, float x, float y, float w, float h,
     return false;
 }
 
+bool suppress_svg_glow_at(std::string& svg, float x, float y, float w, float h) {
+    const float x0 = x, y0 = y, x1 = x + w, y1 = y + h;
+    const char* kOpen = "<g filter=\"url(#";
+    std::size_t pos = 0;
+    while ((pos = svg.find(kOpen, pos)) != std::string::npos) {
+        const auto gt = svg.find('>', pos);
+        if (gt == std::string::npos) break;
+        // First drawn coordinate of the group: the "d=\"M x y" of its first path.
+        // A glyph glow's first point sits on the digit, inside the tab cell.
+        float fx = std::numeric_limits<float>::quiet_NaN(), fy = fx;
+        const auto dp = svg.find("d=\"M", gt);
+        if (dp != std::string::npos && dp < gt + 600) {
+            const char* p = svg.c_str() + dp + 4;
+            while (*p == ' ') ++p;
+            char* endp = nullptr;
+            fx = std::strtof(p, &endp);
+            if (endp != p) {
+                p = endp;
+                while (*p == ' ' || *p == ',') ++p;
+                fy = std::strtof(p, &endp);
+                if (endp == p) fy = std::numeric_limits<float>::quiet_NaN();
+            } else {
+                fx = std::numeric_limits<float>::quiet_NaN();
+            }
+        }
+        if (!std::isnan(fx) && !std::isnan(fy) &&
+            fx >= x0 && fx <= x1 && fy >= y0 && fy <= y1) {
+            // Erase the whole group, depth-matching nested <g>…</g>.
+            std::size_t i = gt + 1;
+            int depth = 1;
+            while (i < svg.size() && depth > 0) {
+                const auto ng = svg.find("<g", i);
+                const auto cg = svg.find("</g>", i);
+                if (cg == std::string::npos) break;
+                if (ng != std::string::npos && ng < cg) { depth++; i = ng + 2; }
+                else { depth--; i = cg + 4; }
+            }
+            if (depth == 0) {
+                svg.erase(pos, i - pos);
+                return true;
+            }
+        }
+        pos = gt + 1;
+    }
+    return false;
+}
+
 DesignFrameView::DesignFrameView(std::string svg, std::vector<DesignFrameElement> elements,
                                  float panel_x, float panel_y, float panel_w, float panel_h)
     : svg_(std::move(svg)), elements_(std::move(elements)) {
@@ -130,8 +177,12 @@ DesignFrameView::DesignFrameView(std::string svg, std::vector<DesignFrameElement
         const int n = static_cast<int>(e.options.size());
         const float slot_w = e.w / static_cast<float>(n);
         const int sel = std::clamp(e.selected_index, 0, n - 1);
-        suppress_svg_rect(svg_, e.x + static_cast<float>(sel) * slot_w, e.y,
-                          slot_w, e.h);
+        const float cell_x = e.x + static_cast<float>(sel) * slot_w;
+        suppress_svg_rect(svg_, cell_x, e.y, slot_w, e.h);
+        // Also drop the baked GLOW the design paints on the selected digit (a
+        // big-blur drop-shadow filter group): the live pill moves on click but
+        // that glow would otherwise stay stuck on the originally-selected number.
+        suppress_svg_glow_at(svg_, cell_x, e.y, slot_w, e.h);
     }
 }
 

--- a/core/view/src/ui_components.cpp
+++ b/core/view/src/ui_components.cpp
@@ -13,6 +13,24 @@ bool is_separator_item(const std::string& item) {
 }
 }  // namespace
 
+float fit_combo_label(std::string& text, float avail, float base, float min,
+                      const std::function<float(const std::string&, float)>& width_at) {
+    if (avail <= 0.0f) return base;
+    float font = base;
+    // Shrink the font (in 0.5px steps) until the FULL text fits or we hit `min`.
+    while (font > min && width_at(text, font) > avail) {
+        font = std::max(min, font - 0.5f);
+    }
+    // Still overflowing at the floor → ellipsize, trimming until "text..." fits.
+    if (width_at(text, font) > avail && text.size() > 1) {
+        while (text.size() > 1) {
+            text.pop_back();
+            if (width_at(text + "...", font) <= avail) { text += "..."; break; }
+        }
+    }
+    return font;
+}
+
 // ── ComboBox ─────────────────────────────────────────────────────────────
 
 void ComboBox::set_selected_impl(int index, bool notify) {
@@ -63,22 +81,25 @@ void ComboBox::paint(canvas::Canvas& canvas) {
     canvas.set_line_width(1);
     canvas.stroke_rounded_rect(0, 0, b.width, base_h, 4);
 
-    // Selected text
+    // Selected text. The box width often comes straight from a design (a Figma
+    // dropdown sized tight to its own label), so prefer SHRINKING the font to fit
+    // the full text over truncating it — a short label like "1/4 Delay" should
+    // read in full, just a touch smaller, not "1/4 De…". fit_combo_label measures
+    // with the font actually used (the old inline code measured in the default
+    // font, so truncation was wrong at any window size) and only ellipsizes as a
+    // last resort once the font hits its floor.
     std::string display_text = selected_text();
-    float avail = std::max(0.0f, b.width - 30.0f);
-    if (canvas.measure_text(display_text) > avail && display_text.size() > 3) {
-        while (display_text.size() > 1) {
-            display_text.pop_back();
-            if (canvas.measure_text(display_text + "...") <= avail) {
-                display_text += "...";
-                break;
-            }
-        }
-    }
-    canvas.set_font("Inter", 12);
+    const float avail = std::max(0.0f, b.width - 22.0f);  // 8px left pad + ~14px arrow
+    const float font_size = fit_combo_label(
+        display_text, avail, /*base=*/12.0f, /*min=*/9.0f,
+        [&canvas](const std::string& s, float f) {
+            canvas.set_font("Inter", f);
+            return canvas.measure_text(s);
+        });
+    canvas.set_font("Inter", font_size);
     canvas.set_fill_color(text_c);
     canvas.set_text_align(canvas::TextAlign::left);
-    canvas.fill_text(display_text, 8, base_h * 0.5f + 4);
+    canvas.fill_text(display_text, 8, base_h * 0.5f + font_size * 0.34f);
 
     // Dropdown arrow
     float ax = b.width - 16;

--- a/test/test_combo_dropdown.cpp
+++ b/test/test_combo_dropdown.cpp
@@ -66,6 +66,37 @@ TEST_CASE("ComboBox: paints with correct tokens", "[combo]") {
     REQUIRE(rc.commands().size() > 0);
 }
 
+TEST_CASE("fit_combo_label shrinks the font to fit, ellipsizes only at the floor", "[combo]") {
+    // Font-scaling width model: width = chars * font * 0.5 (the real Skia
+    // measure scales with font; RecordingCanvas's does not, which is why this is
+    // a pure-logic test). "1/4 Delay" is 9 chars.
+    auto width_at = [](const std::string& s, float f) {
+        return static_cast<float>(s.size()) * f * 0.5f;
+    };
+
+    // Wide box: fits at the base font, full text, no shrink.
+    std::string t1 = "1/4 Delay";
+    float f1 = pulp::view::fit_combo_label(t1, 100.0f, 12.0f, 9.0f, width_at);
+    CHECK(t1 == "1/4 Delay");
+    CHECK(f1 == 12.0f);
+
+    // Snug box: too wide at 12 (54px) but fits when shrunk — full text, smaller
+    // font, NO ellipsis (this is the "1/4 Delay" truncation the user hit).
+    std::string t2 = "1/4 Delay";
+    float f2 = pulp::view::fit_combo_label(t2, 50.0f, 12.0f, 9.0f, width_at);
+    CHECK(t2 == "1/4 Delay");
+    CHECK(f2 < 12.0f);
+    CHECK(f2 >= 9.0f);
+    CHECK(width_at(t2, f2) <= 50.0f);
+
+    // Tiny box: even the floor font overflows → ellipsize, clamped to min font.
+    std::string t3 = "1/4 Delay";
+    float f3 = pulp::view::fit_combo_label(t3, 30.0f, 12.0f, 9.0f, width_at);
+    CHECK(f3 == 9.0f);
+    CHECK(t3.size() >= 3);
+    CHECK(t3.substr(t3.size() - 3) == "...");
+}
+
 TEST_CASE("ComboBox: keyboard up/down changes selection", "[combo]") {
     ComboBox combo;
     combo.set_items({"A", "B", "C"});

--- a/test/test_design_frame_view.cpp
+++ b/test/test_design_frame_view.cpp
@@ -400,6 +400,30 @@ TEST_CASE("suppress_svg_rect removes the baked tab highlight by geometry, not rx
     CHECK_FALSE(suppress_svg_rect(svg, 10.0f, 20.0f, 999.0f, 40.0f));   // size mismatch
 }
 
+TEST_CASE("suppress_svg_glow_at removes the selected digit's baked glow group",
+          "[view][design-import][frame][svg]") {
+    // Figma bakes the selected tab digit with a glow = a big-blur drop-shadow
+    // filter group wrapping the glyph. The live pill moves on click but the baked
+    // glow stays stuck on the original digit. Suppress the filtered group whose
+    // first drawn point sits inside the selected cell (x=352..381.5, y=126..146,
+    // matching the highlight rect above). A nested <g> inside it must be
+    // depth-matched so the whole glow group is erased.
+    std::string svg =
+        "<svg>"
+        "<g filter=\"url(#glowSel)\"><g><path d=\"M366.78 138.58L370 132\" fill=\"#fff\"/></g></g>"
+        "<g filter=\"url(#glowElsewhere)\"><path d=\"M12 600L20 610\" fill=\"#fff\"/></g>"
+        "<path d=\"M360 140L362 142\" fill=\"#aaa\"/>"   // a plain (unfiltered) glyph stays
+        "</svg>";
+    REQUIRE(suppress_svg_glow_at(svg, 352.0f, 126.0f, 29.5f, 20.0f));
+    CHECK(svg.find("#glowSel") == std::string::npos);        // selected-cell glow removed...
+    CHECK(svg.find("M366.78 138.58") == std::string::npos);  // ...including its glyph + nested <g>
+    CHECK(svg.find("#glowElsewhere") != std::string::npos);  // glow outside the cell kept
+    CHECK(svg.find("M360 140") != std::string::npos);        // plain unfiltered glyph kept
+    CHECK_FALSE(suppress_svg_glow_at(svg, 352.0f, 126.0f, 29.5f, 20.0f));  // no 2nd match
+    // A cell with no filtered group inside reports no removal.
+    CHECK_FALSE(suppress_svg_glow_at(svg, 0.0f, 0.0f, 5.0f, 5.0f));
+}
+
 TEST_CASE("DesignFrameView suppresses the baked selected-tab highlight (no double-pill)",
           "[view][design-import][frame][svg]") {
     // An SVG whose tab strip has a baked highlight at the selected slot (2). The

--- a/test/test_design_frame_view.cpp
+++ b/test/test_design_frame_view.cpp
@@ -424,6 +424,26 @@ TEST_CASE("suppress_svg_glow_at removes the selected digit's baked glow group",
     CHECK_FALSE(suppress_svg_glow_at(svg, 0.0f, 0.0f, 5.0f, 5.0f));
 }
 
+TEST_CASE("suppress_svg_glyph_at removes a baked digit glyph in the cell",
+          "[view][design-import][frame][svg]") {
+    // Non-selected tab digits are plain <path> glyphs. We drop each so the live
+    // overlay is the sole renderer of the digits (no faint doubled glyph). Only
+    // the path whose first point is inside the cell is removed; glyphs in other
+    // cells, and the strip <rect>, stay.
+    std::string svg =
+        "<svg>"
+        "<rect x=\"290\" y=\"123\" width=\"124\" height=\"26\" fill=\"#252626\"/>"
+        "<path d=\"M308.6 138.5L310 132\" fill=\"#ABABAB\"/>"   // digit "1" in slot 0
+        "<path d=\"M339.2 138.5L341 132\" fill=\"#ABABAB\"/>"   // digit "2" in slot 1
+        "</svg>";
+    // Slot 0 cell: x=293..322.5, y=126..146. Removes "1" only.
+    REQUIRE(suppress_svg_glyph_at(svg, 293.0f, 126.0f, 29.5f, 20.0f));
+    CHECK(svg.find("M308.6 138.5") == std::string::npos);  // slot-0 digit removed
+    CHECK(svg.find("M339.2 138.5") != std::string::npos);  // slot-1 digit kept
+    CHECK(svg.find("#252626") != std::string::npos);       // strip rect kept (not a <path>)
+    CHECK_FALSE(suppress_svg_glyph_at(svg, 293.0f, 126.0f, 29.5f, 20.0f));  // no 2nd match in cell
+}
+
 TEST_CASE("DesignFrameView suppresses the baked selected-tab highlight (no double-pill)",
           "[view][design-import][frame][svg]") {
     // An SVG whose tab strip has a baked highlight at the selected slot (2). The


### PR DESCRIPTION
Three design-import **overlay-fidelity** fixes found while viewing a live import
of the ELYSIUM Figma file in the standalone. All generic (pure geometry / pure
logic, no per-design constants) and in the view (single consumer), so both
import lanes inherit them.

### 1. Stuck glow on the originally-selected tab digit
Figma bakes the selected tab's digit with a glow (a large-blur drop-shadow
`<g filter>` group). The live pill moved on click but the baked glow stayed
stuck on "3". `suppress_svg_glow_at` removes the filtered group whose first
drawn point is inside the originally-selected cell (depth-matching nested `<g>`).

### 2. Faint "doubled" tab digits
The live `DesignTabGroup` painted its labels over the BAKED ones — two slightly
different glyphs (design font vs overlay font). Suppress **all** baked tab digits
(`suppress_svg_glyph_at` for the plain glyphs, plus the glow-group removal for
the selected one) so the live overlay is the sole, consistent renderer.

### 3. Dropdown label truncation ("1/4 De…")
A ComboBox box often comes straight from a design, sized tight to its label. The
painter measured the text in the **default** font (before `set_font`) and
reserved a fixed 30px → ellipsized at any window size. `fit_combo_label` measures
with the real font, **shrinks** the font toward a floor to show the full label,
and ellipsizes only as a last resort. "1/4 Delay" now reads in full.

## Tests
- `suppress_svg_glow_at` — removes the selected-cell glow group (incl. nested
  `<g>`/glyph), keeps a glow outside the cell + a plain unfiltered glyph.
- `suppress_svg_glyph_at` — removes the in-cell baked glyph, keeps others + the
  strip rect.
- `fit_combo_label` — shrink-to-fit, ellipsize-only-at-floor, with a
  font-scaling width model.

Full combo, design-frame-view, and native-materializer suites green. Verified in
a live standalone render: no stuck glow, clean un-doubled digits, full
"1/4 Delay". SDK 0.374.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)