### PR TITLE
refactor: split WidgetBridge list-style registrar

### DIFF
--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -405,6 +405,7 @@ target_sources(pulp-view-script PRIVATE
     src/js_engine_recommend.cpp
     src/widget_bridge.cpp
     src/widget_bridge/accessibility_api.cpp
+    src/widget_bridge/list_style_api.cpp
     src/widget_bridge_input.cpp
     src/hot_reload.cpp
     src/scripted_ui.cpp

--- a/core/view/include/pulp/view/widget_bridge.hpp
+++ b/core/view/include/pulp/view/widget_bridge.hpp
@@ -308,6 +308,7 @@ private:
 
     void register_api();
     void register_accessibility_api();
+    void register_list_style_api();
 };
 
 } // namespace pulp::view

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -4424,68 +4424,7 @@ void WidgetBridge::register_api() {
         return choc::value::Value();
     });
 
-    // pulp #1514 — list-style cluster (listStyle / listStyleType /
-    // listStyleImage / listStylePosition). Pulp doesn't model
-    // <li>/<ul>/<ol> semantics, so the bridge stores the values
-    // verbatim on the View so a later paint pass (or a future
-    // semantic-list surface) can honor them. Marker glyph rendering
-    // is the follow-up; this PR flips the catalog out of `missing`
-    // by wiring the round-trip + JS shorthand parsing.
-    //
-    // setListStyleType(id, "disc"|"circle"|"square"|"decimal"|"none"
-    //                       |"decimal-leading-zero"|"lower-roman"|"upper-roman"
-    //                       |"lower-alpha"|"upper-alpha"|"lower-latin"|"upper-latin"
-    //                       |"lower-greek"|"armenian"|"georgian").
-    //
-    // The counter-style keywords (lower-roman, etc.) are stored verbatim
-    // on the View::ListStyleType enum today; paint-side glyph rendering
-    // is the follow-up (pulp #1514). Unknown keywords fall back to `disc`
-    // to match the longstanding default.
-    engine_.register_function("setListStyleType", [this](choc::javascript::ArgumentList args) {
-        auto id = args.get<std::string>(0, "");
-        auto s = args.get<std::string>(1, "disc");
-        auto* v = id.empty() ? &root_ : widget(id);
-        if (!v) return choc::value::Value();
-        if (s == "none")                       v->set_list_style_type(View::ListStyleType::none);
-        else if (s == "circle")                v->set_list_style_type(View::ListStyleType::circle);
-        else if (s == "square")                v->set_list_style_type(View::ListStyleType::square);
-        else if (s == "decimal")               v->set_list_style_type(View::ListStyleType::decimal);
-        else if (s == "decimal-leading-zero")  v->set_list_style_type(View::ListStyleType::decimal_leading_zero);
-        else if (s == "lower-roman")           v->set_list_style_type(View::ListStyleType::lower_roman);
-        else if (s == "upper-roman")           v->set_list_style_type(View::ListStyleType::upper_roman);
-        else if (s == "lower-alpha")           v->set_list_style_type(View::ListStyleType::lower_alpha);
-        else if (s == "upper-alpha")           v->set_list_style_type(View::ListStyleType::upper_alpha);
-        else if (s == "lower-latin")           v->set_list_style_type(View::ListStyleType::lower_latin);
-        else if (s == "upper-latin")           v->set_list_style_type(View::ListStyleType::upper_latin);
-        else if (s == "lower-greek")           v->set_list_style_type(View::ListStyleType::lower_greek);
-        else if (s == "armenian")              v->set_list_style_type(View::ListStyleType::armenian);
-        else if (s == "georgian")              v->set_list_style_type(View::ListStyleType::georgian);
-        else                                   v->set_list_style_type(View::ListStyleType::disc);
-        return choc::value::Value();
-    });
-
-    // setListStyleImage(id, "url(...)" or "none"). Stored verbatim;
-    // bullet-image rendering is deferred (same caveat as backgroundImage).
-    engine_.register_function("setListStyleImage", [this](choc::javascript::ArgumentList args) {
-        auto id = args.get<std::string>(0, "");
-        auto url = args.get<std::string>(1, "");
-        auto* v = id.empty() ? &root_ : widget(id);
-        if (!v) return choc::value::Value();
-        if (url == "none") v->set_list_style_image("");
-        else               v->set_list_style_image(url);
-        return choc::value::Value();
-    });
-
-    // setListStylePosition(id, "outside"|"inside").
-    engine_.register_function("setListStylePosition", [this](choc::javascript::ArgumentList args) {
-        auto id = args.get<std::string>(0, "");
-        auto s = args.get<std::string>(1, "outside");
-        auto* v = id.empty() ? &root_ : widget(id);
-        if (!v) return choc::value::Value();
-        if (s == "inside") v->set_list_style_position(View::ListStylePosition::inside);
-        else               v->set_list_style_position(View::ListStylePosition::outside);
-        return choc::value::Value();
-    });
+    register_list_style_api();
 
     // pulp #1519 — CSS / RN outline cluster. Outline is paint-time only:
     // it does NOT take up Yoga layout space (parent never reserves room

--- a/core/view/src/widget_bridge/list_style_api.cpp
+++ b/core/view/src/widget_bridge/list_style_api.cpp
@@ -1,0 +1,74 @@
+// widget_bridge/list_style_api.cpp - list-style CSS registrations for WidgetBridge.
+
+#include <pulp/view/widget_bridge.hpp>
+
+#include <string>
+
+namespace pulp::view {
+
+void WidgetBridge::register_list_style_api() {
+    // pulp #1514 - list-style cluster (listStyle / listStyleType /
+    // listStyleImage / listStylePosition). Pulp doesn't model
+    // <li>/<ul>/<ol> semantics, so the bridge stores the values
+    // verbatim on the View so a later paint pass (or a future
+    // semantic-list surface) can honor them. Marker glyph rendering
+    // is the follow-up; this PR flips the catalog out of `missing`
+    // by wiring the round-trip + JS shorthand parsing.
+    //
+    // setListStyleType(id, "disc"|"circle"|"square"|"decimal"|"none"
+    //                       |"decimal-leading-zero"|"lower-roman"|"upper-roman"
+    //                       |"lower-alpha"|"upper-alpha"|"lower-latin"|"upper-latin"
+    //                       |"lower-greek"|"armenian"|"georgian").
+    //
+    // The counter-style keywords (lower-roman, etc.) are stored verbatim
+    // on the View::ListStyleType enum today; paint-side glyph rendering
+    // is the follow-up (pulp #1514). Unknown keywords fall back to `disc`
+    // to match the longstanding default.
+    engine_.register_function("setListStyleType", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto s = args.get<std::string>(1, "disc");
+        auto* v = id.empty() ? &root_ : widget(id);
+        if (!v) return choc::value::Value();
+        if (s == "none")                       v->set_list_style_type(View::ListStyleType::none);
+        else if (s == "circle")                v->set_list_style_type(View::ListStyleType::circle);
+        else if (s == "square")                v->set_list_style_type(View::ListStyleType::square);
+        else if (s == "decimal")               v->set_list_style_type(View::ListStyleType::decimal);
+        else if (s == "decimal-leading-zero")  v->set_list_style_type(View::ListStyleType::decimal_leading_zero);
+        else if (s == "lower-roman")           v->set_list_style_type(View::ListStyleType::lower_roman);
+        else if (s == "upper-roman")           v->set_list_style_type(View::ListStyleType::upper_roman);
+        else if (s == "lower-alpha")           v->set_list_style_type(View::ListStyleType::lower_alpha);
+        else if (s == "upper-alpha")           v->set_list_style_type(View::ListStyleType::upper_alpha);
+        else if (s == "lower-latin")           v->set_list_style_type(View::ListStyleType::lower_latin);
+        else if (s == "upper-latin")           v->set_list_style_type(View::ListStyleType::upper_latin);
+        else if (s == "lower-greek")           v->set_list_style_type(View::ListStyleType::lower_greek);
+        else if (s == "armenian")              v->set_list_style_type(View::ListStyleType::armenian);
+        else if (s == "georgian")              v->set_list_style_type(View::ListStyleType::georgian);
+        else                                   v->set_list_style_type(View::ListStyleType::disc);
+        return choc::value::Value();
+    });
+
+    // setListStyleImage(id, "url(...)" or "none"). Stored verbatim;
+    // bullet-image rendering is deferred (same caveat as backgroundImage).
+    engine_.register_function("setListStyleImage", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto url = args.get<std::string>(1, "");
+        auto* v = id.empty() ? &root_ : widget(id);
+        if (!v) return choc::value::Value();
+        if (url == "none") v->set_list_style_image("");
+        else               v->set_list_style_image(url);
+        return choc::value::Value();
+    });
+
+    // setListStylePosition(id, "outside"|"inside").
+    engine_.register_function("setListStylePosition", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto s = args.get<std::string>(1, "outside");
+        auto* v = id.empty() ? &root_ : widget(id);
+        if (!v) return choc::value::Value();
+        if (s == "inside") v->set_list_style_position(View::ListStylePosition::inside);
+        else               v->set_list_style_position(View::ListStylePosition::outside);
+        return choc::value::Value();
+    });
+}
+
+} // namespace pulp::view

--- a/core/view/src/widget_bridge_api_manifest.tsv
+++ b/core/view/src/widget_bridge_api_manifest.tsv
@@ -124,9 +124,9 @@ setCornerRadius	css_style	function	core/view/src/widget_bridge.cpp
 setBorderColor	css_style	function	core/view/src/widget_bridge.cpp
 setBorderWidth	css_style	function	core/view/src/widget_bridge.cpp
 setBorderStyle	css_style	function	core/view/src/widget_bridge.cpp
-setListStyleType	css_style	function	core/view/src/widget_bridge.cpp
-setListStyleImage	css_style	function	core/view/src/widget_bridge.cpp
-setListStylePosition	css_style	function	core/view/src/widget_bridge.cpp
+setListStyleType	css_style	function	core/view/src/widget_bridge/list_style_api.cpp
+setListStyleImage	css_style	function	core/view/src/widget_bridge/list_style_api.cpp
+setListStylePosition	css_style	function	core/view/src/widget_bridge/list_style_api.cpp
 setOutlineColor	css_style	function	core/view/src/widget_bridge.cpp
 setOutlineOffset	css_style	function	core/view/src/widget_bridge.cpp
 setOutlineStyle	css_style	function	core/view/src/widget_bridge.cpp

--- a/tools/scripts/compat_path_map.json
+++ b/tools/scripts/compat_path_map.json
@@ -18,6 +18,11 @@
       {"kind": "doc", "path": "docs/reference/compat/html.md"},
       {"kind": "test", "glob": "test/test_widget_bridge*.cpp"}
     ],
+    "core/view/src/widget_bridge/list_style_api.cpp": [
+      {"kind": "compat-json", "prefix": "css"},
+      {"kind": "doc", "path": "docs/reference/compat/css.md"},
+      {"kind": "test", "glob": "test/test_widget_bridge*.cpp"}
+    ],
     "core/view/include/pulp/view/widget_bridge.hpp": [
       {"kind": "compat-json", "prefix": "*"},
       {"kind": "doc", "path": "docs/reference/compat/{prefix}.md"},


### PR DESCRIPTION
## Summary
- move list-style CSS native registrations into `core/view/src/widget_bridge/list_style_api.cpp`
- update the WidgetBridge API manifest source paths for the moved functions
- wire the registrar into `pulp-view-script` and compat path mapping

## Validation
- `cmake -S . -B build-widgetbridge -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DPULP_BUILD_NATIVE_COMPONENT_RUST_TESTS=OFF`
- `cmake --build build-widgetbridge --target pulp-test-widget-bridge-api-contracts pulp-test-widget-bridge pulp-test-widget-bridge-wave5-css -j"$(sysctl -n hw.ncpu)"`
- `./build-widgetbridge/test/pulp-test-widget-bridge-api-contracts --reporter compact`
- `./build-widgetbridge/test/pulp-test-widget-bridge --reporter compact`
- `./build-widgetbridge/test/pulp-test-widget-bridge-wave5-css --reporter compact`
- `ctest --test-dir build-widgetbridge -R "WidgetBridge JS native API manifest matches registrar sources|setListStyle|listStyle shorthand|Wave5 css/listStyle" --output-on-failure`
- `git diff --check`
- `python3 tools/scripts/hotspot_size_guard.py --base origin/main --config tools/scripts/hotspot_size_guard.json --mode=report`
- pre-push gates clean

Release verified with `CMAKE_BUILD_TYPE:STRING=Release` and `-O3 -DNDEBUG` in target flags.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the list-style CSS JS registrations out of `WidgetBridge` into `core/view/src/widget_bridge/list_style_api.cpp` and wired it into the build and API manifest. No behavior changes; internal refactor only.

- **Refactors**
  - Added `register_list_style_api()` and moved `setListStyleType`, `setListStyleImage`, `setListStylePosition` to `list_style_api.cpp`.
  - Updated `WidgetBridge::register_api()` to call the new registrar and added the file to `pulp-view-script` in `CMakeLists.txt`.
  - Updated `widget_bridge_api_manifest.tsv` to reference the new source path.
  - Added the new path to `tools/scripts/compat_path_map.json` for compat and docs mapping.

<sup>Written for commit 6ce07f12dfdb0783edfea479cecd83ac2afd460e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

