### PR TITLE
refactor: split WidgetBridge tokens registrar

### DIFF
--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -407,6 +407,7 @@ target_sources(pulp-view-script PRIVATE
     src/widget_bridge/accessibility_api.cpp
     src/widget_bridge/list_style_api.cpp
     src/widget_bridge/svg_api.cpp
+    src/widget_bridge/tokens_api.cpp
     src/widget_bridge_input.cpp
     src/hot_reload.cpp
     src/scripted_ui.cpp

--- a/core/view/include/pulp/view/widget_bridge.hpp
+++ b/core/view/include/pulp/view/widget_bridge.hpp
@@ -310,6 +310,7 @@ private:
     void register_accessibility_api();
     void register_list_style_api();
     void register_svg_api(std::function<canvas::Color(const std::string&)> parse_color);
+    void register_tokens_api(std::function<canvas::Color(const std::string&)> parse_color);
 };
 
 } // namespace pulp::view

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -2122,54 +2122,6 @@ void WidgetBridge::register_api() {
         return choc::value::Value();
     });
 
-    // setMotionToken(tokenName, value)
-    engine_.register_function("setMotionToken", [this](choc::javascript::ArgumentList args) {
-        auto name = args.get<std::string>(0, "");
-        auto value = static_cast<float>(args.get<double>(1, 0));
-        if (name.empty()) return choc::value::Value();
-        auto theme = root_.theme();
-        theme.dimensions[name] = value;
-        root_.set_theme(theme);
-        return choc::value::Value();
-    });
-
-    // getMotionToken(tokenName) -> value
-    engine_.register_function("getMotionToken", [this](choc::javascript::ArgumentList args) {
-        auto name = args.get<std::string>(0, "");
-        auto d = root_.theme().dimension(name);
-        return choc::value::createFloat64(d.value_or(0.0f));
-    });
-
-    // pulp #1899 (gap #3) — string-valued theme-token lookup.
-    // setStringToken(name, value) / getStringToken(name) parallel the
-    // motion-token / color-token APIs but back onto `theme.strings`
-    // (the same map that already stores design-system font names
-    // imported via Stitch / W3C tokens — see design_import.cpp). The
-    // React-side prop-applier consults this to resolve `var(--mono)`
-    // in `fontFamily` / `color` / `borderColor` etc. before forwarding
-    // to setFontFamily / setTextColor — without this, Skia's font
-    // matcher received the literal string "var(--mono)" as a family
-    // name and fell through to a proportional sans, which is visible
-    // as the Spectr top-bar "faint label" symptom from #1899.
-    engine_.register_function("setStringToken", [this](choc::javascript::ArgumentList args) {
-        auto name = args.get<std::string>(0, "");
-        auto value = args.get<std::string>(1, "");
-        if (name.empty()) return choc::value::Value();
-        auto theme = root_.theme();
-        theme.strings[name] = value;
-        root_.set_theme(theme);
-        return choc::value::Value();
-    });
-
-    // getStringToken(tokenName) -> string. Returns empty string when the
-    // token isn't defined — callers (e.g. prop-applier resolveVar) treat
-    // empty as "miss" and try the next lookup tier.
-    engine_.register_function("getStringToken", [this](choc::javascript::ArgumentList args) {
-        auto name = args.get<std::string>(0, "");
-        auto s = root_.theme().string_token(name);
-        return choc::value::createString(s.value_or(std::string()));
-    });
-
     // setVisible(id, bool)
     engine_.register_function("setVisible", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
@@ -4093,6 +4045,7 @@ void WidgetBridge::register_api() {
     };
     // Alias for backward compatibility
     auto parseHexColor = parseColor;
+    register_tokens_api(parseHexColor);
 
     // setTextRuns(id, [{start,end,fontWeight?,fontSize?,color?,fontStyle?,
     // letterSpacing?}, ...]) — per-range styled text. Builds a
@@ -5205,29 +5158,6 @@ void WidgetBridge::register_api() {
         // Store as a dimension token on root theme
         auto theme = root_.theme();
         theme.dimensions["debug.paint"] = on ? 1.0f : 0.0f;
-        root_.set_theme(theme);
-        return choc::value::Value();
-    });
-
-    // setColorToken(name, color) — set a color token on the root theme
-    engine_.register_function("setColorToken", [this, parseColor](choc::javascript::ArgumentList args) {
-        auto name = args.get<std::string>(0, "");
-        auto color_str = args.get<std::string>(1, "");
-        if (name.empty()) return choc::value::Value();
-        auto theme = root_.theme();
-        auto c = parseColor(color_str);
-        theme.colors[name] = c;
-        root_.set_theme(theme);
-        return choc::value::Value();
-    });
-
-    // setDimensionToken(name, value) — set a dimension token on the root theme
-    engine_.register_function("setDimensionToken", [this](choc::javascript::ArgumentList args) {
-        auto name = args.get<std::string>(0, "");
-        auto val = static_cast<float>(args.get<double>(1, 0));
-        if (name.empty()) return choc::value::Value();
-        auto theme = root_.theme();
-        theme.dimensions[name] = val;
         root_.set_theme(theme);
         return choc::value::Value();
     });

--- a/core/view/src/widget_bridge/tokens_api.cpp
+++ b/core/view/src/widget_bridge/tokens_api.cpp
@@ -1,0 +1,86 @@
+// widget_bridge/tokens_api.cpp - theme-token registrations for WidgetBridge.
+
+#include <pulp/view/widget_bridge.hpp>
+
+#include <functional>
+#include <string>
+#include <utility>
+
+namespace pulp::view {
+
+void WidgetBridge::register_tokens_api(std::function<canvas::Color(const std::string&)> parse_color) {
+    auto parseColor = std::move(parse_color);
+
+    // setMotionToken(tokenName, value)
+    engine_.register_function("setMotionToken", [this](choc::javascript::ArgumentList args) {
+        auto name = args.get<std::string>(0, "");
+        auto value = static_cast<float>(args.get<double>(1, 0));
+        if (name.empty()) return choc::value::Value();
+        auto theme = root_.theme();
+        theme.dimensions[name] = value;
+        root_.set_theme(theme);
+        return choc::value::Value();
+    });
+
+    // getMotionToken(tokenName) -> value
+    engine_.register_function("getMotionToken", [this](choc::javascript::ArgumentList args) {
+        auto name = args.get<std::string>(0, "");
+        auto d = root_.theme().dimension(name);
+        return choc::value::createFloat64(d.value_or(0.0f));
+    });
+
+    // pulp #1899 (gap #3) - string-valued theme-token lookup.
+    // setStringToken(name, value) / getStringToken(name) parallel the
+    // motion-token / color-token APIs but back onto `theme.strings`
+    // (the same map that already stores design-system font names
+    // imported via Stitch / W3C tokens - see design_import.cpp). The
+    // React-side prop-applier consults this to resolve `var(--mono)`
+    // in `fontFamily` / `color` / `borderColor` etc. before forwarding
+    // to setFontFamily / setTextColor - without this, Skia's font
+    // matcher received the literal string "var(--mono)" as a family
+    // name and fell through to a proportional sans, which is visible
+    // as the Spectr top-bar "faint label" symptom from #1899.
+    engine_.register_function("setStringToken", [this](choc::javascript::ArgumentList args) {
+        auto name = args.get<std::string>(0, "");
+        auto value = args.get<std::string>(1, "");
+        if (name.empty()) return choc::value::Value();
+        auto theme = root_.theme();
+        theme.strings[name] = value;
+        root_.set_theme(theme);
+        return choc::value::Value();
+    });
+
+    // getStringToken(tokenName) -> string. Returns empty string when the
+    // token isn't defined - callers (e.g. prop-applier resolveVar) treat
+    // empty as "miss" and try the next lookup tier.
+    engine_.register_function("getStringToken", [this](choc::javascript::ArgumentList args) {
+        auto name = args.get<std::string>(0, "");
+        auto s = root_.theme().string_token(name);
+        return choc::value::createString(s.value_or(std::string()));
+    });
+
+    // setColorToken(name, color) - set a color token on the root theme
+    engine_.register_function("setColorToken", [this, parseColor](choc::javascript::ArgumentList args) {
+        auto name = args.get<std::string>(0, "");
+        auto color_str = args.get<std::string>(1, "");
+        if (name.empty()) return choc::value::Value();
+        auto theme = root_.theme();
+        auto c = parseColor(color_str);
+        theme.colors[name] = c;
+        root_.set_theme(theme);
+        return choc::value::Value();
+    });
+
+    // setDimensionToken(name, value) - set a dimension token on the root theme
+    engine_.register_function("setDimensionToken", [this](choc::javascript::ArgumentList args) {
+        auto name = args.get<std::string>(0, "");
+        auto val = static_cast<float>(args.get<double>(1, 0));
+        if (name.empty()) return choc::value::Value();
+        auto theme = root_.theme();
+        theme.dimensions[name] = val;
+        root_.set_theme(theme);
+        return choc::value::Value();
+    });
+}
+
+} // namespace pulp::view

--- a/core/view/src/widget_bridge_api_manifest.tsv
+++ b/core/view/src/widget_bridge_api_manifest.tsv
@@ -31,10 +31,10 @@ setAccentColor	widget_value	function	core/view/src/widget_bridge.cpp
 getParam	state_binding	function	core/view/src/widget_bridge.cpp
 setParam	state_binding	function	core/view/src/widget_bridge.cpp
 animate	animation	function	core/view/src/widget_bridge.cpp
-setMotionToken	tokens	function	core/view/src/widget_bridge.cpp
-getMotionToken	tokens	function	core/view/src/widget_bridge.cpp
-setStringToken	tokens	function	core/view/src/widget_bridge.cpp
-getStringToken	tokens	function	core/view/src/widget_bridge.cpp
+setMotionToken	tokens	function	core/view/src/widget_bridge/tokens_api.cpp
+getMotionToken	tokens	function	core/view/src/widget_bridge/tokens_api.cpp
+setStringToken	tokens	function	core/view/src/widget_bridge/tokens_api.cpp
+getStringToken	tokens	function	core/view/src/widget_bridge/tokens_api.cpp
 setVisible	css_style	function	core/view/src/widget_bridge.cpp
 setAccessibilityLabel	accessibility	function	core/view/src/widget_bridge/accessibility_api.cpp
 setAccessibilityRole	accessibility	function	core/view/src/widget_bridge/accessibility_api.cpp
@@ -183,8 +183,8 @@ canvasRotate	canvas2d	function	core/view/src/widget_bridge.cpp
 setStateStyle	css_style	function	core/view/src/widget_bridge.cpp
 setEnabled	css_style	function	core/view/src/widget_bridge.cpp
 setDebugPaint	css_style	function	core/view/src/widget_bridge.cpp
-setColorToken	tokens	function	core/view/src/widget_bridge.cpp
-setDimensionToken	tokens	function	core/view/src/widget_bridge.cpp
+setColorToken	tokens	function	core/view/src/widget_bridge/tokens_api.cpp
+setDimensionToken	tokens	function	core/view/src/widget_bridge/tokens_api.cpp
 setTextTransform	typography	function	core/view/src/widget_bridge.cpp
 setTextDecoration	typography	function	core/view/src/widget_bridge.cpp
 setTextDecorationColor	typography	function	core/view/src/widget_bridge.cpp

--- a/tools/scripts/compat_path_map.json
+++ b/tools/scripts/compat_path_map.json
@@ -28,6 +28,11 @@
       {"kind": "doc", "path": "docs/reference/compat/rn.md"},
       {"kind": "test", "glob": "test/test_widget_bridge*.cpp"}
     ],
+    "core/view/src/widget_bridge/tokens_api.cpp": [
+      {"kind": "compat-json", "prefix": "css"},
+      {"kind": "doc", "path": "docs/reference/compat/css.md"},
+      {"kind": "test", "glob": "test/test_widget_bridge*.cpp"}
+    ],
     "core/view/include/pulp/view/widget_bridge.hpp": [
       {"kind": "compat-json", "prefix": "*"},
       {"kind": "doc", "path": "docs/reference/compat/{prefix}.md"},


### PR DESCRIPTION
## Summary
- move WidgetBridge theme-token native registrations into `core/view/src/widget_bridge/tokens_api.cpp`
- pass the existing color parser into the registrar for `setColorToken`
- update the API manifest, CMake source list, and compat path map

## Validation
- `cmake -S . -B build-widgetbridge -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DPULP_BUILD_NATIVE_COMPONENT_RUST_TESTS=OFF`
- `cmake --build build-widgetbridge --target pulp-test-widget-bridge-api-contracts pulp-test-widget-bridge pulp-test-widget-bridge-animation pulp-test-web-compat-prelude -j$(sysctl -n hw.ncpu)`
- `./build-widgetbridge/test/pulp-test-widget-bridge-api-contracts --reporter compact`
- `./build-widgetbridge/test/pulp-test-widget-bridge --reporter compact`
- `./build-widgetbridge/test/pulp-test-widget-bridge-animation --reporter compact`
- `./build-widgetbridge/test/web-compat/pulp-test-web-compat-prelude --reporter compact`
- `python3 tools/scripts/compat_sync_check.py --base origin/main --config tools/scripts/compat_path_map.json --mode=report --enforce`
- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report`
- `python3 tools/scripts/hotspot_size_guard.py --base origin/main --config tools/scripts/hotspot_size_guard.json --mode=report`
- verified Release cache and focused target flags contain `-O3 -DNDEBUG`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split WidgetBridge theme-token JS registrations into a dedicated registrar and wire it to the existing color parser. This reduces widget_bridge.cpp size with no behavior or compat changes.

- **Refactors**
  - Moved token functions to core/view/src/widget_bridge/tokens_api.cpp (`setMotionToken`, `getMotionToken`, `setStringToken`, `getStringToken`, `setColorToken`, `setDimensionToken`).
  - Added `WidgetBridge::register_tokens_api(parse_color)` and invoked it from `register_api`; passes existing color parser.
  - Updated API manifest paths and CMake sources; declared the new registrar in widget_bridge.hpp.
  - Updated compat_path_map for the new file; no compat surface change.

<sup>Written for commit 855cf00067e6ba2b691f92585ed6b63172678a32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

