### PR TITLE
refactor: split WidgetBridge state binding registrar

### DIFF
--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -406,6 +406,7 @@ target_sources(pulp-view-script PRIVATE
     src/widget_bridge.cpp
     src/widget_bridge/accessibility_api.cpp
     src/widget_bridge/list_style_api.cpp
+    src/widget_bridge/state_binding_api.cpp
     src/widget_bridge/svg_api.cpp
     src/widget_bridge/tokens_api.cpp
     src/widget_bridge_input.cpp

--- a/core/view/include/pulp/view/widget_bridge.hpp
+++ b/core/view/include/pulp/view/widget_bridge.hpp
@@ -309,6 +309,7 @@ private:
     void register_api();
     void register_accessibility_api();
     void register_list_style_api();
+    void register_state_binding_api();
     void register_svg_api(std::function<canvas::Color(const std::string&)> parse_color);
     void register_tokens_api(std::function<canvas::Color(const std::string&)> parse_color);
 };

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -2053,33 +2053,7 @@ void WidgetBridge::register_api() {
         return choc::value::Value();
     });
 
-    // getParam(name) -> get parameter value from store (normalized)
-    engine_.register_function("getParam", [this](choc::javascript::ArgumentList args) {
-        auto name = args.get<std::string>(0, "");
-
-        for (size_t i = 0; i < store_.param_count(); ++i) {
-            auto* info = &store_.all_params()[i];
-            if (info && info->name == name) {
-                return choc::value::createFloat64(store_.get_normalized(info->id));
-            }
-        }
-        return choc::value::createFloat64(0);
-    });
-
-    // setParam(name, normalized_value) -> set parameter in store
-    engine_.register_function("setParam", [this](choc::javascript::ArgumentList args) {
-        auto name = args.get<std::string>(0, "");
-        auto value = args.get<double>(1, 0);
-
-        for (size_t i = 0; i < store_.param_count(); ++i) {
-            auto* info = &store_.all_params()[i];
-            if (info && info->name == name) {
-                store_.set_normalized(info->id, static_cast<float>(value));
-                break;
-            }
-        }
-        return choc::value::Value();
-    });
+    register_state_binding_api();
 
     // ═══════════════════════════════════════════════════════════════════
     // Animation bridge

--- a/core/view/src/widget_bridge/state_binding_api.cpp
+++ b/core/view/src/widget_bridge/state_binding_api.cpp
@@ -1,0 +1,40 @@
+// widget_bridge/state_binding_api.cpp - parameter state registrations for WidgetBridge.
+
+#include <pulp/view/widget_bridge.hpp>
+
+#include <cstddef>
+#include <string>
+
+namespace pulp::view {
+
+void WidgetBridge::register_state_binding_api() {
+    // getParam(name) -> get parameter value from store (normalized)
+    engine_.register_function("getParam", [this](choc::javascript::ArgumentList args) {
+        auto name = args.get<std::string>(0, "");
+
+        for (size_t i = 0; i < store_.param_count(); ++i) {
+            auto* info = &store_.all_params()[i];
+            if (info && info->name == name) {
+                return choc::value::createFloat64(store_.get_normalized(info->id));
+            }
+        }
+        return choc::value::createFloat64(0);
+    });
+
+    // setParam(name, normalized_value) -> set parameter in store
+    engine_.register_function("setParam", [this](choc::javascript::ArgumentList args) {
+        auto name = args.get<std::string>(0, "");
+        auto value = args.get<double>(1, 0);
+
+        for (size_t i = 0; i < store_.param_count(); ++i) {
+            auto* info = &store_.all_params()[i];
+            if (info && info->name == name) {
+                store_.set_normalized(info->id, static_cast<float>(value));
+                break;
+            }
+        }
+        return choc::value::Value();
+    });
+}
+
+} // namespace pulp::view

--- a/core/view/src/widget_bridge_api_manifest.tsv
+++ b/core/view/src/widget_bridge_api_manifest.tsv
@@ -28,8 +28,8 @@ setMax	widget_value	function	core/view/src/widget_bridge.cpp
 setStep	widget_value	function	core/view/src/widget_bridge.cpp
 setOrientation	widget_value	function	core/view/src/widget_bridge.cpp
 setAccentColor	widget_value	function	core/view/src/widget_bridge.cpp
-getParam	state_binding	function	core/view/src/widget_bridge.cpp
-setParam	state_binding	function	core/view/src/widget_bridge.cpp
+getParam	state_binding	function	core/view/src/widget_bridge/state_binding_api.cpp
+setParam	state_binding	function	core/view/src/widget_bridge/state_binding_api.cpp
 animate	animation	function	core/view/src/widget_bridge.cpp
 setMotionToken	tokens	function	core/view/src/widget_bridge/tokens_api.cpp
 getMotionToken	tokens	function	core/view/src/widget_bridge/tokens_api.cpp


### PR DESCRIPTION
## Summary
- move `getParam` / `setParam` native registrations into `core/view/src/widget_bridge/state_binding_api.cpp`
- keep the existing registration order with a registrar call in `WidgetBridge::register_api()`
- update the API manifest and CMake source list

## Validation
- `cmake -S . -B build-widgetbridge -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DPULP_BUILD_NATIVE_COMPONENT_RUST_TESTS=OFF`
- `cmake --build build-widgetbridge --target pulp-test-widget-bridge-api-contracts pulp-test-widget-bridge -j$(sysctl -n hw.ncpu)`
- `./build-widgetbridge/test/pulp-test-widget-bridge-api-contracts --reporter compact`
- `./build-widgetbridge/test/pulp-test-widget-bridge --reporter compact`
- `python3 tools/scripts/compat_sync_check.py --base origin/main --config tools/scripts/compat_path_map.json --mode=report --enforce`
- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report`
- `python3 tools/scripts/hotspot_size_guard.py --base origin/main --config tools/scripts/hotspot_size_guard.json --mode=report`
- verified Release cache and focused target flags contain `-O3 -DNDEBUG`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split WidgetBridge state binding registrations into a dedicated registrar to simplify maintenance. No behavior change; API order is preserved.

- **Refactors**
  - Moved `getParam`/`setParam` registrations to core/view/src/widget_bridge/state_binding_api.cpp.
  - Added `WidgetBridge::register_state_binding_api()` and called it from `register_api()`.
  - Updated API manifest and CMake sources to reference the new file.

<sup>Written for commit d08f225802263ffa37a334be08c6f6fc2a94811b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

