### PR TITLE
refactor: split WidgetBridge theme registrar

### DIFF
--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -408,6 +408,7 @@ target_sources(pulp-view-script PRIVATE
     src/widget_bridge/list_style_api.cpp
     src/widget_bridge/state_binding_api.cpp
     src/widget_bridge/svg_api.cpp
+    src/widget_bridge/theme_api.cpp
     src/widget_bridge/tokens_api.cpp
     src/widget_bridge/widget_schema_api.cpp
     src/widget_bridge_input.cpp

--- a/core/view/include/pulp/view/widget_bridge.hpp
+++ b/core/view/include/pulp/view/widget_bridge.hpp
@@ -311,6 +311,7 @@ private:
     void register_list_style_api();
     void register_state_binding_api();
     void register_svg_api(std::function<canvas::Color(const std::string&)> parse_color);
+    void register_theme_api();
     void register_tokens_api(std::function<canvas::Color(const std::string&)> parse_color);
     void register_widget_schema_api();
 };

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -6568,39 +6568,7 @@ void WidgetBridge::register_api() {
         return result;
     });
 
-    // Theme control
-    engine_.register_function("setTheme", [this](choc::javascript::ArgumentList args) {
-        auto n = args.get<std::string>(0, "dark");
-        root_.set_theme(n=="light" ? Theme::light() : n=="pro_audio" ? Theme::pro_audio() : Theme::dark());
-        return choc::value::Value();
-    });
-
-    engine_.register_function("applyTokenDiff", [this](choc::javascript::ArgumentList args) {
-        auto json = args.get<std::string>(0, "");
-        if (!json.empty()) { auto d = Theme::from_json(json); auto c = root_.theme(); c.apply_overrides(d); root_.set_theme(c); }
-        return choc::value::Value();
-    });
-
-    engine_.register_function("getThemeJson", [this](choc::javascript::ArgumentList) {
-        return choc::value::createString(root_.theme().to_json());
-    });
-
-    // importDesignTokens(w3cJson) — parse W3C Design Tokens JSON and apply to theme
-    engine_.register_function("importDesignTokens", [this](choc::javascript::ArgumentList args) {
-        auto json = args.get<std::string>(0, "");
-        if (!json.empty()) {
-            auto imported = parse_w3c_tokens(json);
-            auto current = root_.theme();
-            current.apply_overrides(imported);
-            root_.set_theme(current);
-        }
-        return choc::value::Value();
-    });
-
-    // exportDesignTokens() — export current theme as W3C Design Tokens JSON
-    engine_.register_function("exportDesignTokens", [this](choc::javascript::ArgumentList) {
-        return choc::value::createString(export_w3c_tokens(root_.theme()));
-    });
+    register_theme_api();
 
     // Model-agnostic AI CLI: configurable command for chat integration
     engine_.register_function("setAICli", [this](choc::javascript::ArgumentList args) {

--- a/core/view/src/widget_bridge/theme_api.cpp
+++ b/core/view/src/widget_bridge/theme_api.cpp
@@ -1,0 +1,46 @@
+// widget_bridge/theme_api.cpp - theme registrations for WidgetBridge.
+
+#include <pulp/view/widget_bridge.hpp>
+#include <pulp/view/design_tokens.hpp>
+
+#include <string>
+
+namespace pulp::view {
+
+void WidgetBridge::register_theme_api() {
+    // Theme control
+    engine_.register_function("setTheme", [this](choc::javascript::ArgumentList args) {
+        auto n = args.get<std::string>(0, "dark");
+        root_.set_theme(n=="light" ? Theme::light() : n=="pro_audio" ? Theme::pro_audio() : Theme::dark());
+        return choc::value::Value();
+    });
+
+    engine_.register_function("applyTokenDiff", [this](choc::javascript::ArgumentList args) {
+        auto json = args.get<std::string>(0, "");
+        if (!json.empty()) { auto d = Theme::from_json(json); auto c = root_.theme(); c.apply_overrides(d); root_.set_theme(c); }
+        return choc::value::Value();
+    });
+
+    engine_.register_function("getThemeJson", [this](choc::javascript::ArgumentList) {
+        return choc::value::createString(root_.theme().to_json());
+    });
+
+    // importDesignTokens(w3cJson) - parse W3C Design Tokens JSON and apply to theme
+    engine_.register_function("importDesignTokens", [this](choc::javascript::ArgumentList args) {
+        auto json = args.get<std::string>(0, "");
+        if (!json.empty()) {
+            auto imported = parse_w3c_tokens(json);
+            auto current = root_.theme();
+            current.apply_overrides(imported);
+            root_.set_theme(current);
+        }
+        return choc::value::Value();
+    });
+
+    // exportDesignTokens() - export current theme as W3C Design Tokens JSON
+    engine_.register_function("exportDesignTokens", [this](choc::javascript::ArgumentList) {
+        return choc::value::createString(export_w3c_tokens(root_.theme()));
+    });
+}
+
+} // namespace pulp::view

--- a/core/view/src/widget_bridge_api_manifest.tsv
+++ b/core/view/src/widget_bridge_api_manifest.tsv
@@ -262,11 +262,11 @@ clearWidgetSchema	widget_schema	function	core/view/src/widget_bridge/widget_sche
 saveStylePreset	widget_schema	function	core/view/src/widget_bridge/widget_schema_api.cpp
 loadStylePreset	widget_schema	function	core/view/src/widget_bridge/widget_schema_api.cpp
 measureText	canvas2d	function	core/view/src/widget_bridge.cpp
-setTheme	theme	function	core/view/src/widget_bridge.cpp
-applyTokenDiff	theme	function	core/view/src/widget_bridge.cpp
-getThemeJson	theme	function	core/view/src/widget_bridge.cpp
-importDesignTokens	theme	function	core/view/src/widget_bridge.cpp
-exportDesignTokens	theme	function	core/view/src/widget_bridge.cpp
+setTheme	theme	function	core/view/src/widget_bridge/theme_api.cpp
+applyTokenDiff	theme	function	core/view/src/widget_bridge/theme_api.cpp
+getThemeJson	theme	function	core/view/src/widget_bridge/theme_api.cpp
+importDesignTokens	theme	function	core/view/src/widget_bridge/theme_api.cpp
+exportDesignTokens	theme	function	core/view/src/widget_bridge/theme_api.cpp
 setAICli	platform_services	function	core/view/src/widget_bridge.cpp
 getAICli	platform_services	function	core/view/src/widget_bridge.cpp
 getComputedValue	metadata	function	core/view/src/widget_bridge.cpp

--- a/tools/scripts/compat_path_map.json
+++ b/tools/scripts/compat_path_map.json
@@ -28,6 +28,11 @@
       {"kind": "doc", "path": "docs/reference/compat/rn.md"},
       {"kind": "test", "glob": "test/test_widget_bridge*.cpp"}
     ],
+    "core/view/src/widget_bridge/theme_api.cpp": [
+      {"kind": "compat-json", "prefix": "css"},
+      {"kind": "doc", "path": "docs/reference/compat/css.md"},
+      {"kind": "test", "glob": "test/test_widget_bridge*.cpp"}
+    ],
     "core/view/src/widget_bridge/tokens_api.cpp": [
       {"kind": "compat-json", "prefix": "css"},
       {"kind": "doc", "path": "docs/reference/compat/css.md"},


### PR DESCRIPTION
## Summary
- move theme and design-token native registrations into `core/view/src/widget_bridge/theme_api.cpp`
- keep registration order with `register_theme_api()` in `WidgetBridge::register_api()`
- update CMake, API manifest, and compat path map for the new CSS-related registrar file

## Validation
- `cmake -S . -B build-widgetbridge -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DPULP_BUILD_NATIVE_COMPONENT_RUST_TESTS=OFF`
- `cmake --build build-widgetbridge --target pulp-test-widget-bridge-api-contracts pulp-test-widget-bridge pulp-test-widget-bridge-animation pulp-test-design-tool-layout -j$(sysctl -n hw.ncpu)`
- `./build-widgetbridge/test/pulp-test-widget-bridge-api-contracts --reporter compact`
- `./build-widgetbridge/test/pulp-test-widget-bridge --reporter compact`
- `./build-widgetbridge/test/pulp-test-widget-bridge-animation --reporter compact`
- `./build-widgetbridge/test/pulp-test-design-tool-layout --reporter compact`
- `python3 tools/scripts/compat_sync_check.py --base origin/main --config tools/scripts/compat_path_map.json --mode=report --enforce`
- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report`
- `python3 tools/scripts/hotspot_size_guard.py --base origin/main --config tools/scripts/hotspot_size_guard.json --mode=report`
- verified Release cache and focused target flags contain `-O3 -DNDEBUG`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split WidgetBridge theme and design-token registrations into a dedicated registrar to simplify `widget_bridge.cpp` while keeping registration order and behavior unchanged.

- **Refactors**
  - Moved `setTheme`, `applyTokenDiff`, `getThemeJson`, `importDesignTokens`, and `exportDesignTokens` to `core/view/src/widget_bridge/theme_api.cpp`; added `WidgetBridge::register_theme_api()`.
  - Call `register_theme_api()` from `WidgetBridge::register_api()` to preserve init order.
  - Updated `core/view/CMakeLists.txt`, `core/view/src/widget_bridge_api_manifest.tsv`, and `tools/scripts/compat_path_map.json`.
  - No SDK or compat surface changes.

<sup>Written for commit c5d3eaecc0ed5f49d97b3819a605effdb981d954. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

