### PR TITLE
refactor: split WidgetBridge shader registrar

### DIFF
--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -407,6 +407,7 @@ target_sources(pulp-view-script PRIVATE
     src/widget_bridge/accessibility_api.cpp
     src/widget_bridge/list_style_api.cpp
     src/widget_bridge/state_binding_api.cpp
+    src/widget_bridge/shader_api.cpp
     src/widget_bridge/svg_api.cpp
     src/widget_bridge/theme_api.cpp
     src/widget_bridge/tokens_api.cpp

--- a/core/view/include/pulp/view/widget_bridge.hpp
+++ b/core/view/include/pulp/view/widget_bridge.hpp
@@ -311,6 +311,8 @@ private:
     void register_list_style_api();
     void register_state_binding_api();
     void register_svg_api(std::function<canvas::Color(const std::string&)> parse_color);
+    void register_shader_widget_api();
+    void register_shader_canvas_api();
     void register_theme_api();
     void register_tokens_api(std::function<canvas::Color(const std::string&)> parse_color);
     void register_widget_schema_api();

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -6175,46 +6175,7 @@ void WidgetBridge::register_api() {
         return choc::value::Value();
     });
 
-    // compileShader(sksl_code) → {success: bool, error: string}
-    // Validates SkSL shader code by actually compiling via SkRuntimeEffect
-    engine_.register_function("compileShader", [](choc::javascript::ArgumentList args) {
-        auto code = args.get<std::string>(0, "");
-        auto result = choc::value::createObject("");
-        if (code.empty()) {
-            result.addMember("success", choc::value::createBool(false));
-            result.addMember("error", choc::value::createString("Empty shader code"));
-            return result;
-        }
-        auto error = canvas::Canvas::compile_sksl(code);
-        result.addMember("success", choc::value::createBool(error.empty()));
-        result.addMember("error", choc::value::createString(error));
-        return result;
-    });
-
-    // setWidgetShader(id, skslCode) → apply custom GPU shader to widget body
-    engine_.register_function("setWidgetShader", [this](choc::javascript::ArgumentList args) {
-        auto id = args.get<std::string>(0, "");
-        auto sksl = args.get<std::string>(1, "");
-        auto* v = widget(id);
-        if (!v) return choc::value::Value();
-        if (auto* k = dynamic_cast<Knob*>(v)) k->set_custom_shader(sksl);
-        else if (auto* f = dynamic_cast<Fader*>(v)) f->set_custom_shader(sksl);
-        else if (auto* t = dynamic_cast<Toggle*>(v)) t->set_custom_shader(sksl);
-        request_repaint();
-        return choc::value::Value();
-    });
-
-    // clearWidgetShader(id) → remove custom shader, restore default paint
-    engine_.register_function("clearWidgetShader", [this](choc::javascript::ArgumentList args) {
-        auto id = args.get<std::string>(0, "");
-        auto* v = widget(id);
-        if (!v) return choc::value::Value();
-        if (auto* k = dynamic_cast<Knob*>(v)) k->clear_custom_shader();
-        else if (auto* f = dynamic_cast<Fader*>(v)) f->clear_custom_shader();
-        else if (auto* t = dynamic_cast<Toggle*>(v)) t->clear_custom_shader();
-        request_repaint();
-        return choc::value::Value();
-    });
+    register_shader_widget_api();
 
     register_widget_schema_api();
 
@@ -7514,24 +7475,7 @@ void WidgetBridge::register_api() {
         return choc::value::createBool(true);
     });
 
-    // WebGPU shader: applyShader(canvasId, skslCode) → applies custom shader to canvas
-    // Uses the existing Skia/Dawn pipeline — SkSL shaders compiled at runtime
-    engine_.register_function("applyShader", [this](choc::javascript::ArgumentList args) {
-        auto id = args.get<std::string>(0, "");
-        auto code = args.get<std::string>(1, "");
-        auto* v = widget(id);
-        if (v) {
-            // Store shader code on the view for the render pipeline to pick up
-            auto theme = v->theme();
-            theme.dimensions["shader.active"] = 1;
-            v->set_theme(theme);
-        }
-        // Compilation validation
-        auto result = choc::value::createObject("");
-        result.addMember("success", choc::value::createBool(!code.empty()));
-        result.addMember("error", choc::value::createString(""));
-        return result;
-    });
+    register_shader_canvas_api();
 
     // WebGPU: getGPUInfo() → device capabilities
     engine_.register_function("getGPUInfo", [this](choc::javascript::ArgumentList) {

--- a/core/view/src/widget_bridge/shader_api.cpp
+++ b/core/view/src/widget_bridge/shader_api.cpp
@@ -1,0 +1,73 @@
+// widget_bridge/shader_api.cpp - shader registrations for WidgetBridge.
+
+#include <pulp/view/widget_bridge.hpp>
+
+#include <string>
+
+namespace pulp::view {
+
+void WidgetBridge::register_shader_widget_api() {
+    // compileShader(sksl_code) -> {success: bool, error: string}
+    // Validates SkSL shader code by actually compiling via SkRuntimeEffect.
+    engine_.register_function("compileShader", [](choc::javascript::ArgumentList args) {
+        auto code = args.get<std::string>(0, "");
+        auto result = choc::value::createObject("");
+        if (code.empty()) {
+            result.addMember("success", choc::value::createBool(false));
+            result.addMember("error", choc::value::createString("Empty shader code"));
+            return result;
+        }
+        auto error = canvas::Canvas::compile_sksl(code);
+        result.addMember("success", choc::value::createBool(error.empty()));
+        result.addMember("error", choc::value::createString(error));
+        return result;
+    });
+
+    // setWidgetShader(id, skslCode) -> apply custom GPU shader to widget body.
+    engine_.register_function("setWidgetShader", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto sksl = args.get<std::string>(1, "");
+        auto* v = widget(id);
+        if (!v) return choc::value::Value();
+        if (auto* k = dynamic_cast<Knob*>(v)) k->set_custom_shader(sksl);
+        else if (auto* f = dynamic_cast<Fader*>(v)) f->set_custom_shader(sksl);
+        else if (auto* t = dynamic_cast<Toggle*>(v)) t->set_custom_shader(sksl);
+        request_repaint();
+        return choc::value::Value();
+    });
+
+    // clearWidgetShader(id) -> remove custom shader, restore default paint.
+    engine_.register_function("clearWidgetShader", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto* v = widget(id);
+        if (!v) return choc::value::Value();
+        if (auto* k = dynamic_cast<Knob*>(v)) k->clear_custom_shader();
+        else if (auto* f = dynamic_cast<Fader*>(v)) f->clear_custom_shader();
+        else if (auto* t = dynamic_cast<Toggle*>(v)) t->clear_custom_shader();
+        request_repaint();
+        return choc::value::Value();
+    });
+
+}
+
+void WidgetBridge::register_shader_canvas_api() {
+    // WebGPU shader: applyShader(canvasId, skslCode) -> applies a custom shader to canvas.
+    // Uses the existing Skia/Dawn pipeline; SkSL shaders compile at runtime.
+    engine_.register_function("applyShader", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto code = args.get<std::string>(1, "");
+        auto* v = widget(id);
+        if (v) {
+            // Store shader state on the view for the render pipeline to pick up.
+            auto theme = v->theme();
+            theme.dimensions["shader.active"] = 1;
+            v->set_theme(theme);
+        }
+        auto result = choc::value::createObject("");
+        result.addMember("success", choc::value::createBool(!code.empty()));
+        result.addMember("error", choc::value::createString(""));
+        return result;
+    });
+}
+
+} // namespace pulp::view

--- a/core/view/src/widget_bridge_api_manifest.tsv
+++ b/core/view/src/widget_bridge_api_manifest.tsv
@@ -252,9 +252,9 @@ setBoxShadow	css_style	function	core/view/src/widget_bridge.cpp
 clearBoxShadow	css_style	function	core/view/src/widget_bridge.cpp
 beginPath	canvas2d	function	core/view/src/widget_bridge.cpp
 drawPath	canvas2d	function	core/view/src/widget_bridge.cpp
-compileShader	shader	function	core/view/src/widget_bridge.cpp
-setWidgetShader	shader	function	core/view/src/widget_bridge.cpp
-clearWidgetShader	shader	function	core/view/src/widget_bridge.cpp
+compileShader	shader	function	core/view/src/widget_bridge/shader_api.cpp
+setWidgetShader	shader	function	core/view/src/widget_bridge/shader_api.cpp
+clearWidgetShader	shader	function	core/view/src/widget_bridge/shader_api.cpp
 setWidgetSchema	widget_schema	function	core/view/src/widget_bridge/widget_schema_api.cpp
 setWidgetLottie	widget_schema	function	core/view/src/widget_bridge/widget_schema_api.cpp
 seekWidgetLottie	widget_schema	function	core/view/src/widget_bridge/widget_schema_api.cpp
@@ -337,7 +337,7 @@ canvasPutImageData	canvas2d	function	core/view/src/widget_bridge.cpp
 registerDrop	events	function	core/view/src/widget_bridge.cpp
 loadFont	storage_assets	function	core/view/src/widget_bridge.cpp
 registerFont	storage_assets	function	core/view/src/widget_bridge.cpp
-applyShader	shader	function	core/view/src/widget_bridge.cpp
+applyShader	shader	function	core/view/src/widget_bridge/shader_api.cpp
 getGPUInfo	gpu	function	core/view/src/widget_bridge.cpp
 navigatorGPU	gpu	host_object	core/view/src/widget_bridge.cpp
 __describeNativeAdapterImpl	gpu	function	core/view/src/widget_bridge.cpp


### PR DESCRIPTION
## Summary
- Move shader-related WidgetBridge native API registrations into `core/view/src/widget_bridge/shader_api.cpp`.
- Wire `register_shader_api()` through the private WidgetBridge registrar surface and CMake.
- Update the API manifest paths for `compileShader`, `setWidgetShader`, `clearWidgetShader`, and `applyShader`.

## Validation
- `cmake -S . -B build-widgetbridge -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DPULP_BUILD_NATIVE_COMPONENT_RUST_TESTS=OFF`
- `cmake --build build-widgetbridge --target pulp-test-widget-bridge-api-contracts pulp-test-widget-bridge pulp-test-widget-bridge-animation pulp-test-design-tool-layout -j$(sysctl -n hw.ncpu)`
- `./build-widgetbridge/test/pulp-test-widget-bridge-api-contracts --reporter compact`
- `./build-widgetbridge/test/pulp-test-widget-bridge --reporter compact`
- `./build-widgetbridge/test/pulp-test-widget-bridge-animation --reporter compact`
- `./build-widgetbridge/test/pulp-test-design-tool-layout --reporter compact`
- Release proof: `CMAKE_BUILD_TYPE:STRING=Release`; `pulp-view-script` and focused test target flags contain `-O3 -DNDEBUG`.
- `python3 tools/scripts/compat_sync_check.py --base origin/main --config tools/scripts/compat_path_map.json --mode=report --enforce`
- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report`
- `python3 tools/scripts/hotspot_size_guard.py --base origin/main --config tools/scripts/hotspot_size_guard.json --mode=report`
- `git diff --check origin/main..HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split WidgetBridge shader API registration into `shader_api.cpp` with separate widget and canvas registrars. No behavior or API changes.

- **Refactors**
  - Added `WidgetBridge::register_shader_widget_api()` and `register_shader_canvas_api()`; invoked from `register_api()`. Moved `compileShader`, `setWidgetShader`, `clearWidgetShader`, and `applyShader` to `core/view/src/widget_bridge/shader_api.cpp`.
  - Updated `widget_bridge.hpp`, `core/view/CMakeLists.txt`, and `widget_bridge_api_manifest.tsv` to reference the new file.

<sup>Written for commit 2c814f222110b62029267a391bdd949e48e056c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

