### PR TITLE
refactor: split WidgetBridge metadata registrar

### DIFF
--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -406,6 +406,7 @@ target_sources(pulp-view-script PRIVATE
     src/widget_bridge.cpp
     src/widget_bridge/accessibility_api.cpp
     src/widget_bridge/list_style_api.cpp
+    src/widget_bridge/metadata_api.cpp
     src/widget_bridge/state_binding_api.cpp
     src/widget_bridge/shader_api.cpp
     src/widget_bridge/svg_api.cpp

--- a/core/view/include/pulp/view/widget_bridge.hpp
+++ b/core/view/include/pulp/view/widget_bridge.hpp
@@ -309,6 +309,9 @@ private:
     void register_api();
     void register_accessibility_api();
     void register_list_style_api();
+    void register_metadata_removal_api();
+    void register_metadata_source_api();
+    void register_metadata_computed_api();
     void register_state_binding_api();
     void register_svg_api(std::function<canvas::Color(const std::string&)> parse_color);
     void register_shader_widget_api();

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -2077,18 +2077,7 @@ void WidgetBridge::register_api() {
         return choc::value::Value();
     });
 
-    // removeWidget(id)
-    engine_.register_function("removeWidget", [this](choc::javascript::ArgumentList args) {
-        auto id = args.get<std::string>(0, "");
-        if (auto* w = widget(id)) {
-            View* parent = w->parent();
-            if (parent) {
-                auto removed = parent->remove_child(w);
-                erase_widget_subtree(widgets_, removed.get());
-            }
-        }
-        return choc::value::Value();
-    });
+    register_metadata_removal_api();
 
     // ═══════════════════════════════════════════════════════════════
     // Extended API: containers, layout, all widgets, themes, canvas
@@ -3034,36 +3023,7 @@ void WidgetBridge::register_api() {
         return choc::value::Value();
     });
 
-    // Phase 0b: bind a design-import anchor (the `// @pulp-anchor`
-    // codegen trail from Phase 0a) to a live widget. The inspector
-    // (Phase 0b PR-C) reads anchor_id back to key tweaks against the
-    // originating source element. Silent no-op on unknown widget id —
-    // matches the rest of the bridge's tolerance for unmounted ids.
-    engine_.register_function("setAnchor", [this](choc::javascript::ArgumentList args) {
-        auto id = args.get<std::string>(0, "");
-        auto anchor = args.get<std::string>(1, "");
-        if (auto* v = widget(id)) v->set_anchor_id(std::move(anchor));
-        return choc::value::Value();
-    });
-
-    // Phase 5.1 (inspector source-jump): bind the authored-source
-    // location for a widget. The `@pulp/react` reconciler reads React's
-    // `__source` prop ({fileName, lineNumber, columnNumber}) inside
-    // `createInstance` and forwards it here. The inspector later reads
-    // this back via `Inspector.jumpToSource` to open the user's editor
-    // at the originating JSX file:line. Silent no-op on unknown widget
-    // id and on an empty file path — matches setAnchor's tolerance for
-    // unmounted ids and views authored outside the JSX path.
-    engine_.register_function("setSource", [this](choc::javascript::ArgumentList args) {
-        auto id = args.get<std::string>(0, "");
-        auto file = args.get<std::string>(1, "");
-        auto line = static_cast<int>(args.get<double>(2, 0.0));
-        auto col = static_cast<int>(args.get<double>(3, 0.0));
-        if (file.empty()) return choc::value::Value();
-        if (auto* v = widget(id))
-            v->set_source_loc({std::move(file), line, col});
-        return choc::value::Value();
-    });
+    register_metadata_source_api();
 
     // setStyle — placeholder until KnobStyle/ToggleStyle enums added to main widgets
     engine_.register_function("setStyle", [](choc::javascript::ArgumentList) {
@@ -5985,19 +5945,7 @@ void WidgetBridge::register_api() {
         return choc::value::createString(ai_cli_command_);
     });
 
-    // getComputedValue(id, prop) → string
-    engine_.register_function("getComputedValue", [this](choc::javascript::ArgumentList args) {
-        auto id = args.get<std::string>(0, "");
-        auto prop = args.get<std::string>(1, "");
-        auto* v = widget(id);
-        if (!v) return choc::value::createString("");
-        if (prop == "width") return choc::value::createString(std::to_string(v->bounds().width) + "px");
-        if (prop == "height") return choc::value::createString(std::to_string(v->bounds().height) + "px");
-        if (prop == "opacity") return choc::value::createString(std::to_string(v->opacity()));
-        if (prop == "display") return choc::value::createString(v->visible() ? "flex" : "none");
-        if (prop == "visibility") return choc::value::createString(v->visible() ? "visible" : "hidden");
-        return choc::value::createString("");
-    });
+    register_metadata_computed_api();
 
     // Shell exec
     // Ensures PATH includes common tool locations (homebrew, npm global, etc.)

--- a/core/view/src/widget_bridge/metadata_api.cpp
+++ b/core/view/src/widget_bridge/metadata_api.cpp
@@ -1,0 +1,80 @@
+// widget_bridge/metadata_api.cpp - metadata registrations for WidgetBridge.
+
+#include <pulp/view/widget_bridge.hpp>
+
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+namespace pulp::view {
+
+namespace {
+
+void erase_widget_subtree(std::unordered_map<std::string, View*>& widgets, View* node) {
+    if (node == nullptr) {
+        return;
+    }
+
+    for (size_t i = 0; i < node->child_count(); ++i) {
+        erase_widget_subtree(widgets, node->child_at(i));
+    }
+
+    if (!node->id().empty()) {
+        widgets.erase(node->id());
+    }
+}
+
+} // namespace
+
+void WidgetBridge::register_metadata_removal_api() {
+    // removeWidget(id)
+    engine_.register_function("removeWidget", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        if (auto* w = widget(id)) {
+            View* parent = w->parent();
+            if (parent) {
+                auto removed = parent->remove_child(w);
+                erase_widget_subtree(widgets_, removed.get());
+            }
+        }
+        return choc::value::Value();
+    });
+}
+
+void WidgetBridge::register_metadata_source_api() {
+    engine_.register_function("setAnchor", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto anchor = args.get<std::string>(1, "");
+        if (auto* v = widget(id)) v->set_anchor_id(std::move(anchor));
+        return choc::value::Value();
+    });
+
+    engine_.register_function("setSource", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto file = args.get<std::string>(1, "");
+        auto line = static_cast<int>(args.get<double>(2, 0.0));
+        auto col = static_cast<int>(args.get<double>(3, 0.0));
+        if (file.empty()) return choc::value::Value();
+        if (auto* v = widget(id))
+            v->set_source_loc({std::move(file), line, col});
+        return choc::value::Value();
+    });
+}
+
+void WidgetBridge::register_metadata_computed_api() {
+    // getComputedValue(id, prop) -> string
+    engine_.register_function("getComputedValue", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto prop = args.get<std::string>(1, "");
+        auto* v = widget(id);
+        if (!v) return choc::value::createString("");
+        if (prop == "width") return choc::value::createString(std::to_string(v->bounds().width) + "px");
+        if (prop == "height") return choc::value::createString(std::to_string(v->bounds().height) + "px");
+        if (prop == "opacity") return choc::value::createString(std::to_string(v->opacity()));
+        if (prop == "display") return choc::value::createString(v->visible() ? "flex" : "none");
+        if (prop == "visibility") return choc::value::createString(v->visible() ? "visible" : "hidden");
+        return choc::value::createString("");
+    });
+}
+
+} // namespace pulp::view

--- a/core/view/src/widget_bridge_api_manifest.tsv
+++ b/core/view/src/widget_bridge_api_manifest.tsv
@@ -50,7 +50,7 @@ registerGesture	events	function	core/view/src/widget_bridge.cpp
 nativeSetPointerCapture	events	function	core/view/src/widget_bridge.cpp
 nativeReleasePointerCapture	events	function	core/view/src/widget_bridge.cpp
 enableInspectClick	events	function	core/view/src/widget_bridge.cpp
-removeWidget	metadata	function	core/view/src/widget_bridge.cpp
+removeWidget	metadata	function	core/view/src/widget_bridge/metadata_api.cpp
 createRow	widget_factory	function	core/view/src/widget_bridge/factory_api.cpp
 createCol	widget_factory	function	core/view/src/widget_bridge/factory_api.cpp
 createModal	widget_factory	function	core/view/src/widget_bridge/factory_api.cpp
@@ -81,8 +81,8 @@ setListRowHeight	widget_value	function	core/view/src/widget_bridge.cpp
 createTextEditor	widget_factory	function	core/view/src/widget_bridge/factory_api.cpp
 createCanvas	canvas2d	function	core/view/src/widget_bridge.cpp
 setLabel	widget_value	function	core/view/src/widget_bridge.cpp
-setAnchor	metadata	function	core/view/src/widget_bridge.cpp
-setSource	metadata	function	core/view/src/widget_bridge.cpp
+setAnchor	metadata	function	core/view/src/widget_bridge/metadata_api.cpp
+setSource	metadata	function	core/view/src/widget_bridge/metadata_api.cpp
 setStyle	widget_value	function	core/view/src/widget_bridge.cpp
 setWidgetStyle	widget_value	function	core/view/src/widget_bridge.cpp
 setItems	widget_value	function	core/view/src/widget_bridge.cpp
@@ -269,7 +269,7 @@ importDesignTokens	theme	function	core/view/src/widget_bridge/theme_api.cpp
 exportDesignTokens	theme	function	core/view/src/widget_bridge/theme_api.cpp
 setAICli	platform_services	function	core/view/src/widget_bridge.cpp
 getAICli	platform_services	function	core/view/src/widget_bridge.cpp
-getComputedValue	metadata	function	core/view/src/widget_bridge.cpp
+getComputedValue	metadata	function	core/view/src/widget_bridge/metadata_api.cpp
 exec	platform_services	function	core/view/src/widget_bridge.cpp
 execAsync	platform_services	function	core/view/src/widget_bridge.cpp
 registerContextMenu	events	function	core/view/src/widget_bridge.cpp


### PR DESCRIPTION
## Summary
- Move metadata-related WidgetBridge native API registrations into `core/view/src/widget_bridge/metadata_api.cpp`.
- Preserve original registration order with separate removal/source/computed registrar calls.
- Update the API manifest paths for `removeWidget`, `setAnchor`, `setSource`, and `getComputedValue`.

## Validation
- `cmake -S . -B build-widgetbridge -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DPULP_BUILD_NATIVE_COMPONENT_RUST_TESTS=OFF`
- `cmake --build build-widgetbridge --target pulp-test-widget-bridge-api-contracts pulp-test-widget-bridge pulp-test-widget-bridge-animation pulp-test-design-tool-layout -j$(sysctl -n hw.ncpu)`
- `./build-widgetbridge/test/pulp-test-widget-bridge-api-contracts --reporter compact`
- `./build-widgetbridge/test/pulp-test-widget-bridge --reporter compact`
- `./build-widgetbridge/test/pulp-test-widget-bridge-animation --reporter compact`
- `./build-widgetbridge/test/pulp-test-design-tool-layout --reporter compact`
- Release proof: `CMAKE_BUILD_TYPE:STRING=Release`; `pulp-view-script` and focused test target flags contain `-O3 -DNDEBUG`.
- `python3 tools/scripts/compat_sync_check.py --base origin/main --config tools/scripts/compat_path_map.json --mode=report --enforce`
- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report`
- `python3 tools/scripts/hotspot_size_guard.py --base origin/main --config tools/scripts/hotspot_size_guard.json --mode=report`
- `git diff --check origin/main..HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split `WidgetBridge` metadata API registrations into `src/widget_bridge/metadata_api.cpp` with dedicated registrar methods to keep call order clear. No behavior or API changes.

- **Refactors**
  - Added `register_metadata_removal_api`, `register_metadata_source_api`, `register_metadata_computed_api`; wired them into `register_api`.
  - Moved registrations for `removeWidget`, `setAnchor`, `setSource`, `getComputedValue` to `metadata_api.cpp`.
  - Updated header to declare the new registrar methods.
  - Updated `CMakeLists.txt` and `widget_bridge_api_manifest.tsv` paths to point to the new file.

<sup>Written for commit 2371c07c3e885230d539a0620c4fa291434010cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

