### PR TITLE
refactor: split WidgetBridge list value registrar

### DIFF
--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -417,6 +417,7 @@ target_sources(pulp-view-script PRIVATE
     src/widget_bridge/widget_schema_api.cpp
     src/widget_bridge/factory_api.cpp
     src/widget_bridge/widget_value_controls_api.cpp
+    src/widget_bridge/widget_value_list_api.cpp
     src/widget_bridge_input.cpp
     src/hot_reload.cpp
     src/scripted_ui.cpp

--- a/core/view/include/pulp/view/widget_bridge.hpp
+++ b/core/view/include/pulp/view/widget_bridge.hpp
@@ -329,6 +329,7 @@ private:
     void register_widget_factory_form_api();
     void register_widget_factory_container_api();
     void register_widget_factory_composite_api();
+    void register_widget_value_list_api();
     void register_widget_factory_text_editor_api();
 };
 

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -2823,38 +2823,7 @@ void WidgetBridge::register_api() {
 
     register_widget_factory_composite_api();
 
-    engine_.register_function("setListItems", [this](choc::javascript::ArgumentList args) {
-        auto id = args.get<std::string>(0, "");
-        auto* v = widget(id); if (!v) return choc::value::Value{};
-        if (auto* lb = dynamic_cast<ListBox*>(v)) {
-            std::vector<std::string> items;
-            if (args.numArgs > 1 && args[1]) {
-                auto& arr = *args[1];
-                for (uint32_t i = 0; i < arr.size(); ++i)
-                    items.push_back(std::string(arr[i].getString()));
-            }
-            lb->set_items(std::move(items));
-        }
-        return choc::value::Value{};
-    });
-
-    engine_.register_function("setListSelected", [this](choc::javascript::ArgumentList args) {
-        auto id = args.get<std::string>(0, "");
-        auto* v = widget(id); if (!v) return choc::value::Value{};
-        if (auto* lb = dynamic_cast<ListBox*>(v)) {
-            lb->set_selected(args.get<int>(1, 0));
-            lb->ensure_visible(lb->selected());
-        }
-        return choc::value::Value{};
-    });
-
-    engine_.register_function("setListRowHeight", [this](choc::javascript::ArgumentList args) {
-        auto id = args.get<std::string>(0, "");
-        auto* v = widget(id); if (!v) return choc::value::Value{};
-        if (auto* lb = dynamic_cast<ListBox*>(v))
-            lb->set_row_height(static_cast<float>(args.get<double>(1, 24.0)));
-        return choc::value::Value{};
-    });
+    register_widget_value_list_api();
 
     register_widget_factory_text_editor_api();
 

--- a/core/view/src/widget_bridge/widget_value_list_api.cpp
+++ b/core/view/src/widget_bridge/widget_value_list_api.cpp
@@ -1,0 +1,48 @@
+// widget_bridge/widget_value_list_api.cpp - list value registrations for WidgetBridge.
+
+#include <pulp/view/widget_bridge.hpp>
+
+#include <pulp/view/ui_components.hpp>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace pulp::view {
+
+void WidgetBridge::register_widget_value_list_api() {
+    engine_.register_function("setListItems", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto* v = widget(id); if (!v) return choc::value::Value{};
+        if (auto* lb = dynamic_cast<ListBox*>(v)) {
+            std::vector<std::string> items;
+            if (args.numArgs > 1 && args[1]) {
+                auto& arr = *args[1];
+                for (uint32_t i = 0; i < arr.size(); ++i)
+                    items.push_back(std::string(arr[i].getString()));
+            }
+            lb->set_items(std::move(items));
+        }
+        return choc::value::Value{};
+    });
+
+    engine_.register_function("setListSelected", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto* v = widget(id); if (!v) return choc::value::Value{};
+        if (auto* lb = dynamic_cast<ListBox*>(v)) {
+            lb->set_selected(args.get<int>(1, 0));
+            lb->ensure_visible(lb->selected());
+        }
+        return choc::value::Value{};
+    });
+
+    engine_.register_function("setListRowHeight", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto* v = widget(id); if (!v) return choc::value::Value{};
+        if (auto* lb = dynamic_cast<ListBox*>(v))
+            lb->set_row_height(static_cast<float>(args.get<double>(1, 24.0)));
+        return choc::value::Value{};
+    });
+}
+
+} // namespace pulp::view

--- a/core/view/src/widget_bridge_api_manifest.tsv
+++ b/core/view/src/widget_bridge_api_manifest.tsv
@@ -75,9 +75,9 @@ createCombo	widget_factory	function	core/view/src/widget_bridge/factory_api.cpp
 createProgress	widget_factory	function	core/view/src/widget_bridge/factory_api.cpp
 createScrollView	widget_factory	function	core/view/src/widget_bridge/factory_api.cpp
 createListBox	widget_factory	function	core/view/src/widget_bridge/factory_api.cpp
-setListItems	widget_value	function	core/view/src/widget_bridge.cpp
-setListSelected	widget_value	function	core/view/src/widget_bridge.cpp
-setListRowHeight	widget_value	function	core/view/src/widget_bridge.cpp
+setListItems	widget_value	function	core/view/src/widget_bridge/widget_value_list_api.cpp
+setListSelected	widget_value	function	core/view/src/widget_bridge/widget_value_list_api.cpp
+setListRowHeight	widget_value	function	core/view/src/widget_bridge/widget_value_list_api.cpp
 createTextEditor	widget_factory	function	core/view/src/widget_bridge/factory_api.cpp
 createCanvas	canvas2d	function	core/view/src/widget_bridge.cpp
 setLabel	widget_value	function	core/view/src/widget_bridge.cpp


### PR DESCRIPTION
## Summary
- move ListBox value bridge registrations into a dedicated WidgetBridge registrar translation unit
- preserve registration order by replacing the original contiguous list-value block with a single registrar call
- update the bridge API manifest source ownership for moved widget_value list entries

## Validation
- cmake -S . -B build-widgetbridge -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DPULP_BUILD_NATIVE_COMPONENT_RUST_TESTS=OFF
- cmake --build build-widgetbridge --target pulp-test-widget-bridge-api-contracts pulp-test-widget-bridge pulp-test-widget-bridge-animation pulp-test-design-tool-layout -j28
- ./build-widgetbridge/test/pulp-test-widget-bridge-api-contracts --reporter compact
- ./build-widgetbridge/test/pulp-test-widget-bridge --reporter compact
- ./build-widgetbridge/test/pulp-test-widget-bridge-animation --reporter compact
- ./build-widgetbridge/test/pulp-test-design-tool-layout --reporter compact
- Release proof: CMAKE_BUILD_TYPE=Release and target flags include -O3 -DNDEBUG
- python3 tools/scripts/compat_sync_check.py --base origin/main --config tools/scripts/compat_path_map.json --mode=report --enforce
- python3 tools/scripts/version_bump_check.py --base origin/main --mode=report
- python3 tools/scripts/hotspot_size_guard.py --base origin/main --config tools/scripts/hotspot_size_guard.json --mode=report
- git diff --check origin/main..HEAD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split ListBox widget value registrations into a dedicated `WidgetBridge` registrar to simplify the code and preserve registration order. No API or runtime behavior changes.

- **Refactors**
  - Moved `setListItems`, `setListSelected`, and `setListRowHeight` to core/view/src/widget_bridge/widget_value_list_api.cpp.
  - Added `register_widget_value_list_api()` to `WidgetBridge` and call it from `register_api()`.
  - Updated build to include the new translation unit.
  - Updated API manifest to point moved entries to the new file.

<sup>Written for commit b96b52675107cfbcae66d6a9016bbff788fca5bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

