### PR TITLE
feat(runtime): Windows high-resolution OS timer-queue backend (W9)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.376.0
+    VERSION 0.377.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/runtime/src/high_resolution_timer.cpp
+++ b/core/runtime/src/high_resolution_timer.cpp
@@ -6,6 +6,11 @@
 #elif defined(__linux__)
 #include <sched.h>
 #include <pthread.h>
+#elif defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
 #endif
 
 namespace pulp::runtime {
@@ -14,6 +19,18 @@ struct HighResolutionTimer::TimerState {
     std::atomic<bool> running{false};
     std::atomic<bool> thread_ready{false};
     std::function<void()> callback;
+#if defined(_WIN32)
+    // Windows OsTimerQueue handles. Owned here so their lifetime tracks the last
+    // shared_ptr reference — the worker thread and stop() both hold the state, so
+    // whichever drops last closes the handles, avoiding a close-while-in-use race
+    // when a callback stops its own timer.
+    void* win_timer = nullptr;       // HANDLE — high-resolution waitable timer
+    void* win_stop_event = nullptr;  // HANDLE — manual-reset stop event
+    ~TimerState() {
+        if (win_timer) CloseHandle(static_cast<HANDLE>(win_timer));
+        if (win_stop_event) CloseHandle(static_cast<HANDLE>(win_stop_event));
+    }
+#endif
 };
 
 HighResolutionTimer::~HighResolutionTimer() {
@@ -73,8 +90,57 @@ void HighResolutionTimer::start(std::chrono::microseconds interval,
         dispatch_resume(source);
         return;
     }
+#elif defined(_WIN32)
+    if (mode == TimerMode::OsTimerQueue) {
+        // High-resolution waitable timer (Win10 1803+). If the high-res flag
+        // isn't supported, fall through to DedicatedThread so the contract holds.
+        HANDLE timer = CreateWaitableTimerExW(
+            nullptr, nullptr, CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
+        HANDLE stop_ev = timer ? CreateEventW(nullptr, TRUE, FALSE, nullptr) : nullptr;
+        if (timer && stop_ev) {
+            auto state = std::make_shared<TimerState>();
+            state->callback = std::move(callback);
+            state->win_timer = timer;
+            state->win_stop_event = stop_ev;
+            state->running.store(true, std::memory_order_release);
+
+            // microseconds → 100-ns ticks; clamp to >=1 so SetWaitableTimer never
+            // gets a 0 relative due (which would spin).
+            LONGLONG period_100ns = static_cast<LONGLONG>(interval.count()) * 10;
+            if (period_100ns < 1) period_100ns = 1;
+
+            std::thread thread([state, period_100ns]() {
+                SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
+                HANDLE t = static_cast<HANDLE>(state->win_timer);
+                HANDLE s = static_cast<HANDLE>(state->win_stop_event);
+                HANDLE handles[2] = {s, t};  // stop event first → wins ties
+                while (state->running.load(std::memory_order_acquire)) {
+                    LARGE_INTEGER due;
+                    due.QuadPart = -period_100ns;  // negative = relative
+                    if (!SetWaitableTimer(t, &due, 0, nullptr, nullptr, FALSE)) break;
+                    DWORD r = WaitForMultipleObjects(2, handles, FALSE, INFINITE);
+                    if (r != WAIT_OBJECT_0 + 1) break;  // stop event / error → exit
+                    if (state->running.load(std::memory_order_acquire) && state->callback)
+                        state->callback();
+                }
+                CancelWaitableTimer(t);
+            });
+
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                state_ = state;
+                thread_ = std::move(thread);
+                active_mode_ = TimerMode::OsTimerQueue;
+                running_.store(true, std::memory_order_release);
+            }
+            return;
+        }
+        // Couldn't create the high-res timer — clean up and fall through.
+        if (stop_ev) CloseHandle(stop_ev);
+        if (timer) CloseHandle(timer);
+    }
 #else
-    (void) mode; // OsTimerQueue falls through to DedicatedThread off-Apple.
+    (void) mode; // OsTimerQueue falls through to DedicatedThread off-Apple/Windows.
 #endif
 
     active_mode_ = TimerMode::DedicatedThread;
@@ -143,6 +209,11 @@ void HighResolutionTimer::stop() {
             state->running.store(false, std::memory_order_release);
             state->thread_ready.store(true, std::memory_order_release);
             state->thread_ready.notify_one();
+#if defined(_WIN32)
+            // Wake the OsTimerQueue worker out of its blocking wait promptly.
+            if (state->win_stop_event)
+                SetEvent(static_cast<HANDLE>(state->win_stop_event));
+#endif
         }
 
         if (thread_.joinable()) {

--- a/test/test_high_resolution_timer.cpp
+++ b/test/test_high_resolution_timer.cpp
@@ -24,9 +24,11 @@ TEST_CASE("HighResolutionTimer DedicatedThread mode fires callbacks", "[runtime]
     REQUIRE(ticks.load() >= 5);
 }
 
-#ifdef __APPLE__
-TEST_CASE("HighResolutionTimer OsTimerQueue mode fires callbacks on Apple",
-          "[runtime][hrt][apple]") {
+// Apple (dispatch_source) and Windows (high-resolution waitable timer) both back
+// OsTimerQueue with a real OS timer; the path runs on the respective CI lane.
+#if defined(__APPLE__) || defined(_WIN32)
+TEST_CASE("HighResolutionTimer OsTimerQueue mode fires callbacks",
+          "[runtime][hrt][os-timer]") {
     HighResolutionTimer timer;
     std::atomic<int> ticks{0};
     timer.start(std::chrono::milliseconds(2),
@@ -43,7 +45,7 @@ TEST_CASE("HighResolutionTimer OsTimerQueue mode fires callbacks on Apple",
 }
 
 TEST_CASE("HighResolutionTimer OS queue cleans up on destruction",
-          "[runtime][hrt][apple]") {
+          "[runtime][hrt][os-timer]") {
     std::atomic<int> ticks{0};
     {
         HighResolutionTimer timer;
@@ -59,7 +61,8 @@ TEST_CASE("HighResolutionTimer OS queue cleans up on destruction",
 }
 #endif
 
-TEST_CASE("HighResolutionTimer OS queue falls back to dedicated thread off-Apple",
+TEST_CASE("HighResolutionTimer OS queue falls back to dedicated thread "
+          "on platforms without an OS timer queue",
           "[runtime][hrt]") {
     HighResolutionTimer timer;
     std::atomic<int> ticks{0};
@@ -68,7 +71,9 @@ TEST_CASE("HighResolutionTimer OS queue falls back to dedicated thread off-Apple
                 TimerMode::OsTimerQueue);
     REQUIRE(timer.is_running());
 
-#ifndef __APPLE__
+    // Only Linux (and any other platform without an OsTimerQueue backend) falls
+    // back to DedicatedThread; Apple and Windows take their real OS-timer path.
+#if !defined(__APPLE__) && !defined(_WIN32)
     REQUIRE(timer.active_mode() == TimerMode::DedicatedThread);
 #endif
 


### PR DESCRIPTION
`TimerMode::OsTimerQueue` was Apple-only (dispatch_source); off-Apple it fell through to `DedicatedThread`. This adds the Windows backend via `CreateWaitableTimerExW(CREATE_WAITABLE_TIMER_HIGH_RESOLUTION)` driven by a TIME_CRITICAL worker, with a clean fall-through to `DedicatedThread` if the high-res timer can't be created. Handles live in the shared `TimerState` (destructor-closed) so lifetime tracks the last `shared_ptr` ref — race-free when a callback stops its own timer.

Unlike the W5 clipboard/dialogs (interactive / ctest-excluded), the timer tests **run on the Windows CI lane**, so the waitable-timer path gets real runtime coverage. Verified locally on macOS (12 assertions / 5 cases) + compile-clean.

Part of W9. No new link deps (kernel32).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Windows high‑resolution OS timer‑queue backend using waitable timers so `TimerMode::OsTimerQueue` uses the OS on Windows too. Falls back to DedicatedThread if the high‑res timer can’t be created to keep behavior consistent.

- **New Features**
  - Implemented Windows backend via CreateWaitableTimerExW with the high‑resolution flag, driven by a TIME_CRITICAL worker that re‑arms a relative one‑shot each tick.
  - Made handle lifetime race‑free: the timer and stop‑event live in shared TimerState; stop() signals the event to wake the worker promptly.
  - Updated tests so the OS‑timer path runs on the Windows CI lane; the fallback assertion only applies on platforms without an OS timer queue (e.g., Linux).

<sup>Written for commit b3d8b0270afb0f36e8ce46c2bca88589dc42f520. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

