### PR TITLE
feat(ship): Windows installer Start-menu shortcuts + signtool failure contract (W7)

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -274,6 +274,30 @@ still define every public notarization symbol from
 `pulp-test-codesign` links on Windows and the cross-platform API surface
 stays in lockstep with macOS/Linux.
 
+**signtool failure contract (W7, #295 lesson).** `codesign()` on Windows
+must never report success for an unusable signature: it rejects an empty
+identity/path up front (no `signtool sign /n ""`), and after signing it runs
+`signtool verify /pa` and returns false if verification fails — so a sign that
+exits 0 but leaves the artifact unverifiable still fails. The empty-input
+reject is covered by the `[windows]`-guarded case in `test_codesign.cpp`
+(runs without signtool present); the verify-after-sign path is compile-verified
+on the Windows lane (a real round-trip needs a cert).
+
+**NSIS installer (W7).** `generate_nsis_script()` is a pure function — assert
+its output in `test_nsis_installer.cpp` (cross-platform, real verification, no
+NSIS/Windows needed). It places VST3/CLAP under `$COMMONFILES\{VST3,CLAP}`
+(or `$LOCALAPPDATA\Programs\Common\...` for `--per-user`), and **standalone
+apps get a Start-menu shortcut** under `$SMPROGRAMS\<publisher>` (removed on
+uninstall); plugins get none. When you touch the generator, add/extend the
+pure-output assertions.
+
+**Auto-update decision (W7): DEFERRED.** No WinSparkle/auto-update is wired on
+Windows. Rationale: Pulp targets developers shipping their own apps/plugins,
+who pick their own update channel (DAW-scanned plugins don't self-update at
+all); pulling WinSparkle in would add a dependency for a story the SDK doesn't
+own. macOS Sparkle appcast generation stays available for those who want it.
+Revisit if a first-party standalone-app updater becomes a requirement.
+
 ## Android-Specific
 
 ### ABI Selection

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.195.0",
+      "version": "0.196.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.195.0"
+  "version": "0.196.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.195.0",
+  "version": "0.196.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/ship/platform/win/codesign_win.cpp
+++ b/ship/platform/win/codesign_win.cpp
@@ -40,9 +40,19 @@ bool check_notarization(const std::string&) { return false; }
 bool codesign(const std::string& path, const std::string& identity,
               const std::string& entitlements) {
     (void)entitlements; // Not used on Windows
+    // Reject an empty identity (or path) up front. `signtool sign /n ""` can
+    // otherwise latch onto an unintended cert or appear to no-op "successfully"
+    // — the #295 lesson: never emit an unusable/empty signature silently.
+    if (identity.empty() || path.empty()) return false;
+
     std::string cmd = "signtool sign /n \"" + identity + "\" /t http://timestamp.digicert.com"
         " /fd sha256 \"" + path + "\" >nul 2>&1";
-    return exec_status(cmd) == 0;
+    if (exec_status(cmd) != 0) return false;
+
+    // Failure contract: a sign that exits 0 but left the artifact unverifiable
+    // must still fail. Verify the produced signature before reporting success,
+    // so callers never ship a "signed" binary that signtool itself rejects.
+    return exec_status("signtool verify /pa \"" + path + "\" >nul 2>&1") == 0;
 }
 
 std::optional<std::string> notarize_submit(const std::string&, const std::string&,

--- a/ship/platform/win/installer_win.cpp
+++ b/ship/platform/win/installer_win.cpp
@@ -70,10 +70,18 @@ std::string generate_nsis_script(const InstallerConfig& config) {
     // Language
     nsi << "!insertmacro MUI_LANGUAGE \"English\"\n\n";
 
+    // Start-menu shortcuts live under $SMPROGRAMS\<publisher>. Created for
+    // standalone apps so users get a launchable entry; plugins (VST3/CLAP) are
+    // loaded by a DAW and get none. Tracked so the uninstaller can remove the
+    // folder when at least one standalone shortcut was written.
+    const std::string smprograms_dir = "$SMPROGRAMS\\" + config.publisher;
+    bool has_start_menu = false;
+
     // Sections for each plugin format
     for (const auto& plugin : config.plugins) {
         std::string section_name;
         std::string out_dir;
+        const bool is_standalone = (plugin.format == "standalone");
 
         if (plugin.format == "vst3") {
             section_name = config.product_name + " (VST3)";
@@ -81,7 +89,7 @@ std::string generate_nsis_script(const InstallerConfig& config) {
         } else if (plugin.format == "clap") {
             section_name = config.product_name + " (CLAP)";
             out_dir = clap_dir;
-        } else if (plugin.format == "standalone") {
+        } else if (is_standalone) {
             section_name = config.product_name + " (Standalone)";
             out_dir = "$INSTDIR";
         } else {
@@ -98,6 +106,15 @@ std::string generate_nsis_script(const InstallerConfig& config) {
             nsi << "  File /r \"" << plugin.source_path << "\"\n";
         } else {
             nsi << "  File \"" << plugin.source_path << "\"\n";
+        }
+
+        // Standalone apps get a Start-menu shortcut to the installed executable.
+        if (is_standalone) {
+            auto exe = fs::path(plugin.source_path).filename().string();
+            nsi << "  CreateDirectory \"" << smprograms_dir << "\"\n";
+            nsi << "  CreateShortcut \"" << smprograms_dir << "\\" << config.product_name
+                << ".lnk\" \"$INSTDIR\\" << exe << "\"\n";
+            has_start_menu = true;
         }
 
         nsi << "SectionEnd\n\n";
@@ -118,6 +135,10 @@ std::string generate_nsis_script(const InstallerConfig& config) {
         namespace fs = std::filesystem;
         auto filename = fs::path(plugin.source_path).filename().string();
         nsi << "  RMDir /r \"" << out_dir << "\\" << filename << "\"\n";
+    }
+    if (has_start_menu) {
+        nsi << "  Delete \"" << smprograms_dir << "\\" << config.product_name << ".lnk\"\n";
+        nsi << "  RMDir \"" << smprograms_dir << "\"\n";  // only removes if now empty
     }
     nsi << "  Delete \"$INSTDIR\\uninstall.exe\"\n";
     nsi << "  RMDir \"$INSTDIR\"\n";

--- a/test/test_codesign.cpp
+++ b/test/test_codesign.cpp
@@ -82,6 +82,19 @@ TEST_CASE("codesign includes entitlements path on failure path",
                            "/nonexistent/entitlements.plist"));
 }
 
+#if defined(_WIN32)
+// W7 signtool failure contract (#295 lesson): an empty identity or path must be
+// rejected up front rather than invoking signtool with `/n ""` (which could
+// latch onto an unintended cert or no-op "successfully"). This guard runs
+// without signtool present, so it's exercised on the Windows CI lane.
+TEST_CASE("codesign (Windows) rejects empty identity and empty path before signing",
+          "[ship][codesign][windows]") {
+    REQUIRE_FALSE(codesign("C:/some/app.exe", ""));        // empty identity
+    REQUIRE_FALSE(codesign("", "Some Cert"));               // empty path
+    REQUIRE_FALSE(codesign("", ""));                        // both empty
+}
+#endif
+
 TEST_CASE("notarization staple on nonexistent path is false",
           "[ship][codesign][coverage][issue-644]") {
     REQUIRE_FALSE(notarize_staple("/nonexistent/binary"));

--- a/test/test_nsis_installer.cpp
+++ b/test/test_nsis_installer.cpp
@@ -57,6 +57,30 @@ TEST_CASE("NSIS script has VST3 and CLAP sections", "[ship][installer]") {
     REQUIRE_THAT(script, ContainsSubstring("CLAP"));
 }
 
+TEST_CASE("NSIS script creates a Start-menu shortcut for standalone apps "
+          "and removes it on uninstall", "[ship][installer]") {
+    auto config = make_test_config();
+    config.plugins = {{"/path/to/TestPlugin.exe", "", "standalone"}};
+    auto script = generate_nsis_script(config);
+
+    // Shortcut under $SMPROGRAMS\<publisher>, pointing at the installed exe.
+    REQUIRE_THAT(script, ContainsSubstring("CreateDirectory \"$SMPROGRAMS\\TestCorp\""));
+    REQUIRE_THAT(script, ContainsSubstring(
+        "CreateShortcut \"$SMPROGRAMS\\TestCorp\\TestPlugin.lnk\" \"$INSTDIR\\TestPlugin.exe\""));
+    // Uninstaller removes the shortcut and the (now-empty) publisher folder.
+    REQUIRE_THAT(script, ContainsSubstring("Delete \"$SMPROGRAMS\\TestCorp\\TestPlugin.lnk\""));
+    REQUIRE_THAT(script, ContainsSubstring("RMDir \"$SMPROGRAMS\\TestCorp\""));
+}
+
+TEST_CASE("NSIS script creates no Start-menu shortcut for plugin-only installs",
+          "[ship][installer]") {
+    auto config = make_test_config();  // VST3 + CLAP only — no standalone
+    auto script = generate_nsis_script(config);
+
+    REQUIRE_THAT(script, !ContainsSubstring("CreateShortcut"));
+    REQUIRE_THAT(script, !ContainsSubstring("$SMPROGRAMS"));
+}
+
 TEST_CASE("NSIS script includes uninstaller", "[ship][installer]") {
     auto config = make_test_config();
     auto script = generate_nsis_script(config);


### PR DESCRIPTION
Completes the self-contained parts of W7 (Windows packaging/signing).

- **NSIS:** standalone apps get a Start-menu shortcut under `$SMPROGRAMS\<publisher>` (removed on uninstall); plugins get none. `generate_nsis_script()` is pure → asserted in `test_nsis_installer.cpp` (cross-platform, **real verification** on the macOS lane).
- **signtool failure contract (#295 lesson):** `codesign()` rejects empty identity/path up front and runs `signtool verify /pa` after signing, returning false if verification fails (no silent "signed-but-unverifiable"). Empty-input reject covered by a Windows-guarded `test_codesign.cpp` case; verify-after-sign is compile-verified on the Windows lane.
- **Auto-update decision: DEFERRED** (no WinSparkle) — documented in the ship skill (developer-distributed apps pick their own channel; DAW-scanned plugins don't self-update). macOS Sparkle appcast stays available.

Verified locally on macOS: `pulp-test-nsis-installer` (63 assertions / 21 cases) + `pulp-test-codesign` (143 / 24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Start-menu shortcuts to the Windows NSIS installer for standalone apps and enforces a strict `signtool` failure contract by rejecting empty inputs and verifying signatures. Also documents that Windows auto-update is deferred (no WinSparkle).

- **New Features**
  - NSIS: Standalone apps get a Start-menu shortcut under $SMPROGRAMS\<publisher>, removed on uninstall; VST3/CLAP get none. Covered by pure `generate_nsis_script()` tests.

- **Bug Fixes**
  - `codesign()` (Windows): rejects empty identity/path up front and runs `signtool verify /pa` after signing; returns false if verification fails. Guarded by new Windows tests.

<sup>Written for commit a4963b4d0a2d372561beb95d6077d032c95c1290. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

