### PR TITLE
feat(view): Pulp-drawn ContextMenu (view-layer GPU popup menu)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.378.0
+    VERSION 0.379.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -347,6 +347,7 @@ target_sources(pulp-view-core PRIVATE
     src/auto_ui.cpp
     src/text_editor.cpp
     src/ui_components.cpp
+    src/context_menu.cpp
     src/scroll_bar.cpp
     src/anchor_strategy.cpp
     src/relative_point.cpp

--- a/core/view/include/pulp/view/context_menu.hpp
+++ b/core/view/include/pulp/view/context_menu.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+/// @file context_menu.hpp
+/// Pulp-drawn (Canvas/Skia) popup / context menu rendered in the view tree.
+///
+/// Unlike a native OS / GTK popup menu, ContextMenu is a plain View subclass:
+/// a full-window transparent overlay that draws a menu box at an anchor point.
+/// It works identically on every platform and pulls in no new dependencies.
+/// Rows are selectable; selection fires a callback; outside-click and Escape
+/// dismiss the menu. It mirrors the ComboBox dropdown idioms (24px rows, hover
+/// highlight, separators, checkmarks, keyboard nav skipping separators) and the
+/// ModalOverlay full-window overlay pattern (minus the dimmed backdrop — a
+/// context menu does not darken what is behind it).
+
+#include <pulp/view/view.hpp>
+#include <pulp/view/input_events.hpp>
+#include <pulp/canvas/canvas.hpp>
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace pulp::view {
+
+/// Floating, view-tree-drawn context / popup menu.
+///
+/// @code
+/// ContextMenu::show(root, {x, y},
+///     {{1, "Cut"}, {2, "Copy"}, ContextMenu::Item::make_separator(), {3, "Paste"}},
+///     [&](std::optional<int> id) { if (id) handle_command(*id); });
+/// @endcode
+class ContextMenu : public View {
+public:
+    struct Item {
+        int id = 0;
+        std::string label;
+        bool enabled = true;
+        bool checked = false;
+        bool separator = false;
+        static Item make_separator() { return Item{0, "", true, false, true}; }
+    };
+
+    ContextMenu() { set_focusable(true); }
+
+    void set_items(std::vector<Item> items) { items_ = std::move(items); }
+    const std::vector<Item>& items() const { return items_; }
+
+    /// Fired with the chosen item id on select, or with std::nullopt on dismiss
+    /// (Escape / outside-click). Called exactly once per show lifecycle: the
+    /// first fire latches `closed_` so subsequent input is ignored.
+    std::function<void(std::optional<int>)> on_close;
+
+    /// Anchor (in the overlay/root LOCAL coordinate space) where the menu's
+    /// top-left should appear; flips left/up if it would spill past bounds.
+    void set_anchor(Point anchor) { anchor_ = anchor; }
+
+    int hovered_index() const { return hover_index_; }  ///< for tests; -1 = none
+
+    /// Mount `items` as a full-window overlay child of `root` at `pos`, returning
+    /// a raw pointer to the live ContextMenu (root owns it). The wrapped on_close
+    /// removes the menu from `root` after firing the caller's callback.
+    static ContextMenu* show(View* root, Point pos, std::vector<Item> items,
+                             std::function<void(std::optional<int>)> on_close);
+
+    void paint(canvas::Canvas& canvas) override;
+    void on_mouse_event(const MouseEvent& event) override;
+    bool on_key_event(const KeyEvent& event) override;
+    View* hit_test(Point local_point) override;  // whole overlay is hit (catch outside clicks)
+
+private:
+    // Computed menu-box geometry in this view's LOCAL coords. Shared by paint,
+    // hit_test, and mouse hover so they always agree.
+    Rect menu_box(const canvas::Canvas* canvas = nullptr) const;
+    float measured_width() const;  // cached label-driven width (set in paint)
+    // Row index under a local point, or -1 if outside the box / on a non-row.
+    int row_at(Point local_point, const Rect& box) const;
+    void move_hover(int delta);    // keyboard nav, skipping separators + disabled
+    void fire_close(std::optional<int> result);
+
+    std::vector<Item> items_;
+    Point anchor_{0, 0};
+    int hover_index_ = -1;
+    bool closed_ = false;
+    // Width measured during paint (depends on a canvas/font); cached so geometry
+    // is stable for headless hit-testing before the first paint. Defaults to the
+    // minimum width until paint runs.
+    mutable float cached_width_ = 120.0f;
+
+    static constexpr float kRowHeight = 24.0f;
+    static constexpr float kHPad = 34.0f;   // total horizontal label padding
+    static constexpr float kMinWidth = 120.0f;
+    static constexpr float kRadius = 4.0f;
+};
+
+} // namespace pulp::view

--- a/core/view/src/context_menu.cpp
+++ b/core/view/src/context_menu.cpp
@@ -1,0 +1,239 @@
+#include <pulp/view/context_menu.hpp>
+
+#include <algorithm>
+
+namespace pulp::view {
+
+namespace {
+
+bool is_selectable(const ContextMenu::Item& it) {
+    return !it.separator && it.enabled;
+}
+
+}  // namespace
+
+float ContextMenu::measured_width() const {
+    return cached_width_;
+}
+
+Rect ContextMenu::menu_box(const canvas::Canvas* canvas) const {
+    // Width: max measured label width + padding, clamped to a minimum. When a
+    // canvas is available (during paint) measure with the real font; otherwise
+    // fall back to the cached width so headless hit-testing is stable.
+    float width = kMinWidth;
+    if (canvas) {
+        // const_cast: measure_text/set_font are non-const on the canvas, but
+        // measuring text is logically a read for our geometry. We never mutate
+        // pixels here.
+        auto* c = const_cast<canvas::Canvas*>(canvas);
+        c->set_font("Inter", 12);
+        for (const auto& it : items_) {
+            if (it.separator) continue;
+            width = std::max(width, c->measure_text(it.label) + kHPad);
+        }
+        cached_width_ = width;
+    } else {
+        width = cached_width_;
+    }
+
+    float height = static_cast<float>(items_.size()) * kRowHeight;
+
+    auto b = local_bounds();
+    float x = anchor_.x;
+    float y = anchor_.y;
+    // Flip left / up if the box would spill past the overlay bounds.
+    if (b.width > 0.0f && x + width > b.width) x = anchor_.x - width;
+    if (b.height > 0.0f && y + height > b.height) y = anchor_.y - height;
+    x = std::max(0.0f, x);
+    y = std::max(0.0f, y);
+    return {x, y, width, height};
+}
+
+int ContextMenu::row_at(Point local_point, const Rect& box) const {
+    if (local_point.x < box.x || local_point.x > box.x + box.width ||
+        local_point.y < box.y || local_point.y > box.y + box.height)
+        return -1;
+    int idx = static_cast<int>((local_point.y - box.y) / kRowHeight);
+    if (idx < 0 || idx >= static_cast<int>(items_.size())) return -1;
+    return idx;
+}
+
+void ContextMenu::move_hover(int delta) {
+    if (items_.empty()) return;
+    const int n = static_cast<int>(items_.size());
+    int idx = hover_index_;
+    for (int step = 0; step < n; ++step) {
+        int next = idx + delta;
+        if (next < 0 || next >= n) {
+            // No selectable row found yet but we ran off the end: if we have no
+            // current hover, seed from the appropriate end on the next pass.
+            if (idx < 0) {
+                next = (delta > 0) ? 0 : n - 1;
+            } else {
+                break;  // stay put at the edge
+            }
+        }
+        idx = next;
+        if (is_selectable(items_[static_cast<size_t>(idx)])) {
+            hover_index_ = idx;
+            request_repaint();
+            return;
+        }
+    }
+}
+
+void ContextMenu::fire_close(std::optional<int> result) {
+    if (closed_) return;
+    closed_ = true;
+    if (on_close) on_close(result);  // may delete `this` (removes from root)
+}
+
+void ContextMenu::paint(canvas::Canvas& canvas) {
+    if (items_.empty()) return;
+
+    const Rect box = menu_box(&canvas);
+
+    auto bg = resolve_color("bg.elevated", canvas::Color::rgba8(45, 45, 60));
+    auto border_c = resolve_color("control.border", canvas::Color::rgba8(80, 80, 100));
+    auto text_c = resolve_color("text.primary", canvas::Color::rgba8(220, 220, 230));
+    auto text_dim = resolve_color("text.secondary", canvas::Color::rgba8(150, 150, 170));
+    auto accent_c = resolve_color("accent.primary", canvas::Color::rgba8(100, 150, 255));
+
+    canvas.save();
+
+    // Menu box background + 1px rounded border.
+    canvas.set_fill_color(bg);
+    canvas.fill_rounded_rect(box.x, box.y, box.width, box.height, kRadius);
+    canvas.set_stroke_color(border_c);
+    canvas.set_line_width(1);
+    canvas.stroke_rounded_rect(box.x, box.y, box.width, box.height, kRadius);
+
+    canvas.set_font("Inter", 12);
+    for (int i = 0; i < static_cast<int>(items_.size()); ++i) {
+        const auto& it = items_[static_cast<size_t>(i)];
+        float iy = box.y + static_cast<float>(i) * kRowHeight;
+
+        if (it.separator) {
+            canvas.set_stroke_color(border_c);
+            canvas.set_line_width(0.5f);
+            canvas.stroke_line(box.x + 4, iy + kRowHeight * 0.5f,
+                               box.x + box.width - 4, iy + kRowHeight * 0.5f);
+            continue;
+        }
+
+        // Hover highlight only on enabled rows.
+        if (i == hover_index_ && it.enabled) {
+            canvas.set_fill_color(accent_c);
+            canvas.fill_rect(box.x + 1, iy, box.width - 2, kRowHeight);
+        }
+
+        // Checkmark glyph for checked items.
+        if (it.checked) {
+            auto check_color = (i == hover_index_ && it.enabled)
+                                   ? canvas::Color::rgba8(255, 255, 255)
+                                   : accent_c;
+            canvas.set_fill_color(check_color);
+            canvas.fill_text("\xe2\x9c\x93", box.x + 6, iy + 16);
+        }
+
+        // Dim disabled rows; white text on the hovered row.
+        canvas::Color row_text = text_c;
+        if (!it.enabled) row_text = text_dim;
+        else if (i == hover_index_) row_text = canvas::Color::rgba8(255, 255, 255);
+        canvas.set_fill_color(row_text);
+        canvas.set_text_align(canvas::TextAlign::left);
+        canvas.fill_text(it.label, box.x + 22, iy + 16);
+    }
+
+    canvas.restore();
+}
+
+void ContextMenu::on_mouse_event(const MouseEvent& event) {
+    if (closed_ || items_.empty()) return;
+    if (event.is_wheel) return;
+
+    const Rect box = menu_box();  // headless geometry (cached width)
+    const int row = row_at(event.position, box);
+
+    if (!event.is_down) {
+        // Hover: only over enabled, non-separator rows.
+        if (row >= 0 && is_selectable(items_[static_cast<size_t>(row)]))
+            hover_index_ = row;
+        else
+            hover_index_ = -1;
+        request_repaint();
+        return;
+    }
+
+    // Mouse-down.
+    if (row < 0) {
+        // Click outside the menu box → dismiss.
+        fire_close(std::nullopt);
+        return;
+    }
+    const auto& it = items_[static_cast<size_t>(row)];
+    if (is_selectable(it)) {
+        fire_close(it.id);  // commit selection
+    }
+    // Click on a disabled row or separator: ignore (menu stays open).
+}
+
+bool ContextMenu::on_key_event(const KeyEvent& event) {
+    if (!event.is_down || closed_) return false;
+    switch (event.key) {
+        case KeyCode::up:   move_hover(-1); return true;
+        case KeyCode::down: move_hover(+1); return true;
+        case KeyCode::escape:
+            fire_close(std::nullopt);
+            return true;
+        case KeyCode::enter:
+        case KeyCode::space:
+            if (hover_index_ >= 0 &&
+                hover_index_ < static_cast<int>(items_.size()) &&
+                is_selectable(items_[static_cast<size_t>(hover_index_)]))
+                fire_close(items_[static_cast<size_t>(hover_index_)].id);
+            return true;
+        default:
+            return false;
+    }
+}
+
+View* ContextMenu::hit_test(Point local_point) {
+    // The whole overlay is hit-testable so clicks anywhere (inside or outside
+    // the menu box) reach us — outside clicks must dismiss.
+    if (!visible() || !enabled() || !hit_testable()) return nullptr;
+    auto b = local_bounds();
+    if (local_point.x >= 0.0f && local_point.x <= b.width &&
+        local_point.y >= 0.0f && local_point.y <= b.height)
+        return this;
+    return nullptr;
+}
+
+ContextMenu* ContextMenu::show(View* root, Point pos, std::vector<Item> items,
+                               std::function<void(std::optional<int>)> on_close) {
+    if (!root) return nullptr;
+
+    auto menu = std::make_unique<ContextMenu>();
+    ContextMenu* raw = menu.get();
+    raw->set_items(std::move(items));
+    raw->set_anchor(pos);
+    raw->set_bounds(root->local_bounds());
+    raw->set_focusable(true);
+
+    // Wrap the caller's callback so it ALSO removes the menu from root. The
+    // user callback fires first (so it can read state), then we detach. Capture
+    // `root` and `raw` by value; `raw` stays valid until remove_child runs.
+    raw->on_close = [root, raw, cb = std::move(on_close)](std::optional<int> result) {
+        if (cb) cb(result);
+        // Detach from the tree; this destroys the ContextMenu (and its closure,
+        // so nothing else may touch `raw` after this line).
+        root->remove_child(raw);
+    };
+
+    root->add_child(std::move(menu));  // last child → painted/hit-tested on top
+    raw->set_focus(true);
+    raw->claim_input_focus();
+    return raw;
+}
+
+}  // namespace pulp::view

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4861,6 +4861,9 @@ pulp_add_test_suite(pulp-test-graph-editor-view LIBRARIES pulp::view)
 # Modal overlay tests
 pulp_add_test_suite(pulp-test-modal LIBRARIES pulp::view)
 
+# ContextMenu (view-drawn popup menu) tests
+pulp_add_test_suite(pulp-test-context-menu LIBRARIES pulp::view)
+
 # Design export tests
 add_executable(pulp-test-design-export test_design_export.cpp)
 target_link_libraries(pulp-test-design-export PRIVATE pulp::view Catch2::Catch2WithMain)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4858,12 +4858,9 @@ pulp_add_test_suite(pulp-test-ui-components LIBRARIES pulp::view)
 # GraphEditorView tests
 pulp_add_test_suite(pulp-test-graph-editor-view LIBRARIES pulp::view)
 
-# Modal overlay tests
+# Modal overlay + ContextMenu (view-drawn popup menu) tests
 pulp_add_test_suite(pulp-test-modal LIBRARIES pulp::view)
-
-# ContextMenu (view-drawn popup menu) tests
 pulp_add_test_suite(pulp-test-context-menu LIBRARIES pulp::view)
-
 # Design export tests
 add_executable(pulp-test-design-export test_design_export.cpp)
 target_link_libraries(pulp-test-design-export PRIVATE pulp::view Catch2::Catch2WithMain)

--- a/test/test_context_menu.cpp
+++ b/test/test_context_menu.cpp
@@ -1,0 +1,245 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/view/context_menu.hpp>
+#include <pulp/canvas/canvas.hpp>
+
+#include <optional>
+
+using namespace pulp::view;
+using namespace pulp::canvas;
+
+namespace {
+
+// A root big enough that the menu never flips, anchored at (10,10).
+std::unique_ptr<View> make_root() {
+    auto root = std::make_unique<View>();
+    root->set_bounds({0, 0, 400, 400});
+    return root;
+}
+
+using Item = ContextMenu::Item;
+
+// Row 0 top is at anchor.y (10). Row i center y == 10 + i*24 + 12.
+constexpr float kAnchorX = 10.0f, kAnchorY = 10.0f;
+float row_center_y(int i) { return kAnchorY + static_cast<float>(i) * 24.0f + 12.0f; }
+constexpr float kInsideX = 50.0f;  // well within the >=120px-wide box at x=10
+
+MouseEvent down_at(float x, float y) {
+    MouseEvent e;
+    e.position = {x, y};
+    e.is_down = true;
+    return e;
+}
+
+KeyEvent key_down(KeyCode k) {
+    KeyEvent e;
+    e.key = k;
+    e.is_down = true;
+    return e;
+}
+
+}  // namespace
+
+TEST_CASE("ContextMenu show mounts as last child and set_items round-trips",
+          "[view][context-menu]") {
+    auto root = make_root();
+    auto* menu = ContextMenu::show(root.get(), {kAnchorX, kAnchorY},
+                                   {{1, "Cut"}, {2, "Copy"}}, {});
+    REQUIRE(menu != nullptr);
+    REQUIRE(menu->items().size() == 2);
+    REQUIRE(menu->parent() == root.get());
+    REQUIRE(menu->bounds().width == 400);
+    REQUIRE(menu->bounds().height == 400);
+}
+
+TEST_CASE("ContextMenu click on a row selects and removes the menu",
+          "[view][context-menu]") {
+    auto root = make_root();
+    std::optional<int> got;
+    bool fired = false;
+
+    auto* menu = ContextMenu::show(
+        root.get(), {kAnchorX, kAnchorY},
+        {{10, "Cut"}, {20, "Copy"}, {30, "Paste"}},
+        [&](std::optional<int> id) { fired = true; got = id; });
+
+    // Click row 1 ("Copy", id=20).
+    menu->on_mouse_event(down_at(kInsideX, row_center_y(1)));
+
+    REQUIRE(fired);
+    REQUIRE(got.has_value());
+    REQUIRE(*got == 20);
+    // The wrapped on_close detached the menu from root.
+    REQUIRE(root->child_count() == 0);
+}
+
+TEST_CASE("ContextMenu click outside the box dismisses with nullopt",
+          "[view][context-menu]") {
+    auto root = make_root();
+    std::optional<int> got = 99;  // sentinel
+    bool fired = false;
+
+    auto* menu = ContextMenu::show(
+        root.get(), {kAnchorX, kAnchorY},
+        {{1, "One"}, {2, "Two"}},
+        [&](std::optional<int> id) { fired = true; got = id; });
+
+    // Click far outside the menu box (bottom-right corner of the root).
+    menu->on_mouse_event(down_at(380.0f, 380.0f));
+
+    REQUIRE(fired);
+    REQUIRE_FALSE(got.has_value());
+    REQUIRE(root->child_count() == 0);
+}
+
+TEST_CASE("ContextMenu keyboard down+enter selects, skipping separators",
+          "[view][context-menu]") {
+    auto root = make_root();
+    std::optional<int> got;
+
+    auto* menu = ContextMenu::show(
+        root.get(), {kAnchorX, kAnchorY},
+        {{1, "First"}, Item::make_separator(), {3, "Third"}},
+        [&](std::optional<int> id) { got = id; });
+
+    // No hover yet → first Down lands on row 0 ("First").
+    REQUIRE(menu->hovered_index() == -1);
+    REQUIRE(menu->on_key_event(key_down(KeyCode::down)));
+    REQUIRE(menu->hovered_index() == 0);
+
+    // Next Down must SKIP the separator (row 1) and land on row 2 ("Third").
+    REQUIRE(menu->on_key_event(key_down(KeyCode::down)));
+    REQUIRE(menu->hovered_index() == 2);
+
+    REQUIRE(menu->on_key_event(key_down(KeyCode::enter)));
+    REQUIRE(got.has_value());
+    REQUIRE(*got == 3);
+    REQUIRE(root->child_count() == 0);
+}
+
+TEST_CASE("ContextMenu keyboard skips disabled rows",
+          "[view][context-menu]") {
+    auto root = make_root();
+    std::optional<int> got;
+
+    auto* menu = ContextMenu::show(
+        root.get(), {kAnchorX, kAnchorY},
+        {{1, "Enabled"}, {2, "Disabled", /*enabled=*/false}, {3, "AlsoEnabled"}},
+        [&](std::optional<int> id) { got = id; });
+
+    REQUIRE(menu->on_key_event(key_down(KeyCode::down)));  // row 0
+    REQUIRE(menu->hovered_index() == 0);
+    REQUIRE(menu->on_key_event(key_down(KeyCode::down)));  // skip disabled row 1
+    REQUIRE(menu->hovered_index() == 2);
+    REQUIRE(menu->on_key_event(key_down(KeyCode::enter)));
+    REQUIRE(got.has_value());
+    REQUIRE(*got == 3);
+}
+
+TEST_CASE("ContextMenu Escape dismisses with nullopt",
+          "[view][context-menu]") {
+    auto root = make_root();
+    std::optional<int> got = 99;
+    bool fired = false;
+
+    auto* menu = ContextMenu::show(
+        root.get(), {kAnchorX, kAnchorY},
+        {{1, "One"}},
+        [&](std::optional<int> id) { fired = true; got = id; });
+
+    REQUIRE(menu->on_key_event(key_down(KeyCode::escape)));
+    REQUIRE(fired);
+    REQUIRE_FALSE(got.has_value());
+    REQUIRE(root->child_count() == 0);
+}
+
+TEST_CASE("ContextMenu click on a disabled row does not select",
+          "[view][context-menu]") {
+    auto root = make_root();
+    std::optional<int> got;
+    bool fired = false;
+
+    auto* menu = ContextMenu::show(
+        root.get(), {kAnchorX, kAnchorY},
+        {{1, "Enabled"}, {2, "Disabled", /*enabled=*/false}, {3, "Third"}},
+        [&](std::optional<int> id) { fired = true; got = id; });
+
+    // Click the disabled row (row 1) — must NOT fire, menu stays open.
+    menu->on_mouse_event(down_at(kInsideX, row_center_y(1)));
+    REQUIRE_FALSE(fired);
+    REQUIRE(root->child_count() == 1);  // still mounted
+
+    // A subsequent click on an enabled row still works.
+    menu->on_mouse_event(down_at(kInsideX, row_center_y(2)));
+    REQUIRE(fired);
+    REQUIRE(got.has_value());
+    REQUIRE(*got == 3);
+}
+
+TEST_CASE("ContextMenu click on a separator does not select",
+          "[view][context-menu]") {
+    auto root = make_root();
+    bool fired = false;
+
+    auto* menu = ContextMenu::show(
+        root.get(), {kAnchorX, kAnchorY},
+        {{1, "One"}, Item::make_separator(), {3, "Three"}},
+        [&](std::optional<int>) { fired = true; });
+
+    // Click the separator (row 1) — not selectable, menu stays open.
+    menu->on_mouse_event(down_at(kInsideX, row_center_y(1)));
+    REQUIRE_FALSE(fired);
+    REQUIRE(root->child_count() == 1);
+}
+
+TEST_CASE("ContextMenu hover only highlights enabled non-separator rows",
+          "[view][context-menu]") {
+    auto root = make_root();
+    auto* menu = ContextMenu::show(
+        root.get(), {kAnchorX, kAnchorY},
+        {{1, "One"}, Item::make_separator(), {3, "Three", /*enabled=*/false}},
+        {});
+
+    MouseEvent hover;  // move (not down) over the separator row
+    hover.position = {kInsideX, row_center_y(1)};
+    hover.is_down = false;
+    menu->on_mouse_event(hover);
+    REQUIRE(menu->hovered_index() == -1);
+
+    hover.position = {kInsideX, row_center_y(2)};  // disabled row
+    menu->on_mouse_event(hover);
+    REQUIRE(menu->hovered_index() == -1);
+
+    hover.position = {kInsideX, row_center_y(0)};  // enabled row
+    menu->on_mouse_event(hover);
+    REQUIRE(menu->hovered_index() == 0);
+}
+
+TEST_CASE("ContextMenu on_close fires exactly once per lifecycle",
+          "[view][context-menu]") {
+    auto root = make_root();
+    int calls = 0;
+    auto* menu = ContextMenu::show(
+        root.get(), {kAnchorX, kAnchorY}, {{1, "One"}},
+        [&](std::optional<int>) { ++calls; });
+
+    menu->on_key_event(key_down(KeyCode::escape));
+    REQUIRE(calls == 1);
+    // The menu is detached now; no further input is delivered in practice, but
+    // a stray late event must never re-fire the callback (latched by closed_).
+    // (menu pointer is dangling after removal, so we don't touch it again.)
+    REQUIRE(root->child_count() == 0);
+}
+
+TEST_CASE("ContextMenu paint renders without a window", "[view][context-menu]") {
+    auto root = make_root();
+    auto* menu = ContextMenu::show(
+        root.get(), {kAnchorX, kAnchorY},
+        {{1, "Cut"}, {2, "Copy", true, /*checked=*/true},
+         Item::make_separator(), {3, "Paste", /*enabled=*/false}},
+        {});
+
+    RecordingCanvas canvas;
+    auto before = canvas.command_count();
+    menu->paint(canvas);
+    REQUIRE(canvas.command_count() > before);
+}


### PR DESCRIPTION
Adds `pulp::view::ContextMenu` — a GPU-rendered (Canvas/Skia) context/popup menu that lives in the view tree, so it works on **every platform with no native-menu dependency** (no GTK/Xlib). This is the lean, GPU-first answer to native popup menus off-Apple (per the agreed design): the platform `PopupMenu` stays a stub off-mac; apps draw context menus in the view layer.

- Full-window transparent overlay (top child of root); menu box anchored at a point, flips left/up + clamps on-screen. Reuses the `ComboBox` dropdown idioms (hover highlight, checkmark, dimmed-disabled, separators).
- Mouse hover/click-to-commit/outside-dismiss; keyboard up/down (skip separators+disabled) / enter / Escape. `on_close` fires once; `ContextMenu::show(root, pos, items, on_close)` is the entry point.

**Verification:** headless `test_context_menu.cpp` — 45 assertions / 11 cases (selection, keyboard nav, dismiss, disabled/separator no-ops, single on_close, paint smoke). Pure view code; built + tested on macOS, and the macOS CI lane runs the test (real verification, not compile-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GPU-rendered `pulp::view::ContextMenu` that draws popup/context menus in the view tree for consistent cross‑platform behavior without native menu dependencies. Supports anchored positioning with flip/clamp and full keyboard/mouse interaction; closes once and auto-detaches from the root.

- **New Features**
  - View-drawn, full-window overlay anchored at a point; flips left/up and clamps on-screen; matches ComboBox dropdown styles (hover highlight, checkmarks, separators, disabled).
  - Input: hover/click to select; outside click and Escape dismiss; Up/Down skip separators and disabled; Enter/Space select; overlay hit-tests the full window and claims focus; `on_close` fires once.
  - API and tests: `ContextMenu::show(root, pos, items, on_close)` with `ContextMenu::Item` (`separator`, `enabled`, `checked`); adds headless suite `pulp-test-context-menu` in `test/CMakeLists.txt` without increasing the hotspot ceiling; bumps project version to `0.379.0`.

<sup>Written for commit 53d60d23f8f2f563c5375db023c8bfa17e1285e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

