### PR TITLE
refactor: split WidgetBridge text runs registrar

### DIFF
--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -429,6 +429,7 @@ target_sources(pulp-view-script PRIVATE
     src/widget_bridge/widget_value_controls_api.cpp
     src/widget_bridge/widget_value_basic_api.cpp
     src/widget_bridge/typography_api.cpp
+    src/widget_bridge/text_runs_api.cpp
     src/widget_bridge/widget_value_list_api.cpp
     src/widget_bridge/widget_value_content_api.cpp
     src/widget_bridge_input.cpp

--- a/core/view/include/pulp/view/widget_bridge.hpp
+++ b/core/view/include/pulp/view/widget_bridge.hpp
@@ -356,6 +356,7 @@ private:
     void register_widget_value_basic_api();
     void register_widget_typography_api();
     void register_widget_value_content_api();
+    void register_widget_text_runs_api(std::function<canvas::Color(const std::string&)> parse_color);
 };
 
 } // namespace pulp::view

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -2244,69 +2244,7 @@ void WidgetBridge::register_api() {
     auto parseHexColor = parseColor;
     register_tokens_api(parseHexColor);
 
-    // setTextRuns(id, [{start,end,fontWeight?,fontSize?,color?,fontStyle?,
-    // letterSpacing?}, ...]) — per-range styled text. Builds a
-    // canvas::AttributedString over the Label's text (offsets are UTF-8 BYTE
-    // offsets) so single-line mixed text renders each run with its own style
-    // (the native equivalent of the web nested-<span> path). The dominant style
-    // is read from the Label (codegen emits the single-style setters first).
-    engine_.register_function("setTextRuns", [this, parseHexColor](choc::javascript::ArgumentList args) {
-        auto id = args.get<std::string>(0, "");
-        auto* l = dynamic_cast<Label*>(widget(id));
-        if (!l || args.numArgs < 2 || !args[1] || !args[1]->isArray())
-            return choc::value::Value();
-        const std::string& text = l->text();
-        const int n = static_cast<int>(text.size());
-
-        canvas::TextSpan base;
-        if (!l->font_family().empty()) base.font_family = l->font_family();
-        if (l->font_size() > 0.0f)     base.font_size = l->font_size();
-        base.font_weight = l->font_weight();
-        base.italic = (l->font_style() == 1);
-        if (l->has_own_text_color()) base.color = l->text_color();
-
-        struct Run { int s, e; canvas::TextSpan span; };
-        std::vector<Run> runs;
-        auto& arr = *args[1];
-        for (uint32_t i = 0; i < arr.size(); ++i) {
-            auto r = arr[i];
-            if (!r.isObject()) continue;
-            int s = static_cast<int>(r["start"].getWithDefault<int64_t>(0));
-            int e = static_cast<int>(r["end"].getWithDefault<int64_t>(0));
-            if (e <= s || s >= n) continue;
-            canvas::TextSpan span = base;  // inherit dominant, override below
-            if (r.hasObjectMember("fontWeight"))
-                span.font_weight = static_cast<int>(r["fontWeight"].getWithDefault<int64_t>(span.font_weight));
-            if (r.hasObjectMember("fontSize"))
-                span.font_size = static_cast<float>(r["fontSize"].getWithDefault<double>(span.font_size));
-            if (r.hasObjectMember("color"))
-                span.color = parseHexColor(std::string(r["color"].toString()));
-            if (r.hasObjectMember("fontStyle"))
-                span.italic = (std::string(r["fontStyle"].toString()) == "italic");
-            if (r.hasObjectMember("letterSpacing"))
-                span.letter_spacing = static_cast<float>(r["letterSpacing"].getWithDefault<double>(span.letter_spacing));
-            runs.push_back({std::max(0, s), std::min(n, e), span});
-        }
-        std::sort(runs.begin(), runs.end(), [](const Run& a, const Run& b) { return a.s < b.s; });
-
-        canvas::AttributedString attr;
-        auto add = [&](int a, int b, const canvas::TextSpan& proto) {
-            if (b <= a) return;
-            canvas::TextSpan sp = proto; sp.text = text.substr(a, b - a); attr.append(sp);
-        };
-        int cursor = 0;
-        for (auto& rn : runs) {
-            int s = rn.s, e = rn.e;
-            if (e <= cursor) continue;
-            if (s < cursor) s = cursor;
-            add(cursor, s, base);     // gap inherits the dominant style
-            add(s, e, rn.span);       // styled run
-            cursor = e;
-        }
-        add(cursor, n, base);         // trailing
-        l->set_attributed_string(std::move(attr));
-        return choc::value::Value();
-    });
+    register_widget_text_runs_api(parseHexColor);
 
     engine_.register_function("setBackground", [this, parseHexColor](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");

--- a/core/view/src/widget_bridge/text_runs_api.cpp
+++ b/core/view/src/widget_bridge/text_runs_api.cpp
@@ -1,0 +1,84 @@
+// widget_bridge/text_runs_api.cpp - text-run typography registrations for WidgetBridge.
+
+#include <pulp/view/widget_bridge.hpp>
+
+#include <pulp/canvas/attributed_string.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace pulp::view {
+
+void WidgetBridge::register_widget_text_runs_api(std::function<canvas::Color(const std::string&)> parse_color) {
+    auto parseHexColor = std::move(parse_color);
+
+    // setTextRuns(id, [{start,end,fontWeight?,fontSize?,color?,fontStyle?,
+    // letterSpacing?}, ...]) — per-range styled text. Builds a
+    // canvas::AttributedString over the Label's text (offsets are UTF-8 BYTE
+    // offsets) so single-line mixed text renders each run with its own style
+    // (the native equivalent of the web nested-<span> path). The dominant style
+    // is read from the Label (codegen emits the single-style setters first).
+    engine_.register_function("setTextRuns", [this, parseHexColor](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto* l = dynamic_cast<Label*>(widget(id));
+        if (!l || args.numArgs < 2 || !args[1] || !args[1]->isArray())
+            return choc::value::Value();
+        const std::string& text = l->text();
+        const int n = static_cast<int>(text.size());
+
+        canvas::TextSpan base;
+        if (!l->font_family().empty()) base.font_family = l->font_family();
+        if (l->font_size() > 0.0f)     base.font_size = l->font_size();
+        base.font_weight = l->font_weight();
+        base.italic = (l->font_style() == 1);
+        if (l->has_own_text_color()) base.color = l->text_color();
+
+        struct Run { int s, e; canvas::TextSpan span; };
+        std::vector<Run> runs;
+        auto& arr = *args[1];
+        for (uint32_t i = 0; i < arr.size(); ++i) {
+            auto r = arr[i];
+            if (!r.isObject()) continue;
+            int s = static_cast<int>(r["start"].getWithDefault<int64_t>(0));
+            int e = static_cast<int>(r["end"].getWithDefault<int64_t>(0));
+            if (e <= s || s >= n) continue;
+            canvas::TextSpan span = base;  // inherit dominant, override below
+            if (r.hasObjectMember("fontWeight"))
+                span.font_weight = static_cast<int>(r["fontWeight"].getWithDefault<int64_t>(span.font_weight));
+            if (r.hasObjectMember("fontSize"))
+                span.font_size = static_cast<float>(r["fontSize"].getWithDefault<double>(span.font_size));
+            if (r.hasObjectMember("color"))
+                span.color = parseHexColor(std::string(r["color"].toString()));
+            if (r.hasObjectMember("fontStyle"))
+                span.italic = (std::string(r["fontStyle"].toString()) == "italic");
+            if (r.hasObjectMember("letterSpacing"))
+                span.letter_spacing = static_cast<float>(r["letterSpacing"].getWithDefault<double>(span.letter_spacing));
+            runs.push_back({std::max(0, s), std::min(n, e), span});
+        }
+        std::sort(runs.begin(), runs.end(), [](const Run& a, const Run& b) { return a.s < b.s; });
+
+        canvas::AttributedString attr;
+        auto add = [&](int a, int b, const canvas::TextSpan& proto) {
+            if (b <= a) return;
+            canvas::TextSpan sp = proto; sp.text = text.substr(a, b - a); attr.append(sp);
+        };
+        int cursor = 0;
+        for (auto& rn : runs) {
+            int s = rn.s, e = rn.e;
+            if (e <= cursor) continue;
+            if (s < cursor) s = cursor;
+            add(cursor, s, base);     // gap inherits the dominant style
+            add(s, e, rn.span);       // styled run
+            cursor = e;
+        }
+        add(cursor, n, base);         // trailing
+        l->set_attributed_string(std::move(attr));
+        return choc::value::Value();
+    });
+}
+
+} // namespace pulp::view

--- a/core/view/src/widget_bridge_api_manifest.tsv
+++ b/core/view/src/widget_bridge_api_manifest.tsv
@@ -105,7 +105,7 @@ setText	widget_value	function	core/view/src/widget_bridge/widget_value_content_a
 getText	widget_value	function	core/view/src/widget_bridge/widget_value_content_api.cpp
 setPanelStyle	widget_value	function	core/view/src/widget_bridge/widget_value_content_api.cpp
 setScrollContentSize	widget_value	function	core/view/src/widget_bridge/widget_value_content_api.cpp
-setTextRuns	typography	function	core/view/src/widget_bridge.cpp
+setTextRuns	typography	function	core/view/src/widget_bridge/text_runs_api.cpp
 setBackground	css_style	function	core/view/src/widget_bridge.cpp
 createSvgPath	svg	function	core/view/src/widget_bridge/svg_api.cpp
 setSvgPath	svg	function	core/view/src/widget_bridge/svg_api.cpp


### PR DESCRIPTION
## Summary
- move the `setTextRuns` WidgetBridge registration into `core/view/src/widget_bridge/text_runs_api.cpp`
- preserve the existing runtime registration order by passing the existing CSS color parser into the new registrar
- update the WidgetBridge API manifest and CMake source list

## Validation
- `cmake -S . -B build-widgetbridge-text-runs -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DPULP_BUILD_NATIVE_COMPONENT_RUST_TESTS=OFF`
- `cmake --build build-widgetbridge-text-runs --target pulp-test-widget-bridge-api-contracts pulp-test-widget-bridge pulp-test-typography-inheritance pulp-test-text-overflow pulp-test-widget-bridge-css-animations pulp-test-widget-bridge-wave5-css pulp-test-widget-bridge-wave2-cheap -j$(sysctl -n hw.ncpu)`
- `./build-widgetbridge-text-runs/test/pulp-test-widget-bridge-api-contracts`
- `./build-widgetbridge-text-runs/test/pulp-test-widget-bridge --reporter compact`
- `./build-widgetbridge-text-runs/test/pulp-test-typography-inheritance --reporter compact`
- `./build-widgetbridge-text-runs/test/pulp-test-text-overflow --reporter compact`
- `./build-widgetbridge-text-runs/test/pulp-test-widget-bridge-css-animations --reporter compact`
- `./build-widgetbridge-text-runs/test/pulp-test-widget-bridge-wave5-css --reporter compact`
- `./build-widgetbridge-text-runs/test/pulp-test-widget-bridge-wave2-cheap --reporter compact`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`
- `python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce`
- `python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat`
- `python3 tools/scripts/hotspot_size_guard.py --base origin/main --config tools/scripts/hotspot_size_guard.json --mode=report`
- `python3 tools/import-validation/check-source-contracts.py --strict`
- `python3 tools/import-validation/test_source_contracts.py`
- `git diff --check`
- Release verified with `CMAKE_BUILD_TYPE:STRING=Release` and `-O3 -DNDEBUG` in `pulp-view-script` / WidgetBridge test flags

Note: `ctest --test-dir build-widgetbridge-text-runs -R ...` reported no tests in this pared-down build directory, so the focused Catch2 binaries were run directly.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the WidgetBridge text-runs registrar by moving `setTextRuns` into `core/view/src/widget_bridge/text_runs_api.cpp` to isolate typography logic and keep registration order intact. No behavior or API changes.

- **Refactors**
  - Added `register_widget_text_runs_api(std::function<canvas::Color(const std::string&)>)` and moved `setTextRuns` implementation to `text_runs_api.cpp`.
  - Replaced inline registration in `widget_bridge.cpp` with a call to the new registrar, threading the CSS color parser through; updated `widget_bridge_api_manifest.tsv` and added the new source in `CMakeLists.txt`.

<sup>Written for commit 5fda207344729443f661f74d1ba00f049a646ab6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

