### PR TITLE
feat(view): native drag-drop dispatch core + SDL standalone producer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.379.0
+    VERSION 0.380.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -388,6 +388,7 @@ target_sources(pulp-view-core PRIVATE
     src/color_picker.cpp
     src/theme_editor.cpp
     src/file_drop_zone.cpp
+    src/drag_drop.cpp
     src/split_view.cpp
     src/property_list.cpp
     src/breadcrumb.cpp

--- a/core/view/include/pulp/view/drag_drop.hpp
+++ b/core/view/include/pulp/view/drag_drop.hpp
@@ -8,6 +8,7 @@
 namespace pulp::view {
 
 class View;
+class FileDropZone;
 
 // ── Drop data types ──────────────────────────────────────────────────────────
 
@@ -76,18 +77,30 @@ void unregister_drop_target(void* native_view);
 // the platform backend is responsible for any window→root viewport transform
 // (e.g. PluginViewHost::window_to_root_point) before calling in.
 //
-// Threading: UI thread only (mirrors the rest of the view input path). A single
-// hover target is tracked across a drag (one pointer at a time); the backend must
-// bracket a drag with enter … (move)* … exit|drop so the tracked pointer never
-// outlives the view.
+// Threading: UI thread only (mirrors the rest of the view input path).
+//
+// Hover state is held in a DragSession the *caller* owns — one per platform
+// backend / window, NOT a process global — so concurrent drags on separate
+// windows can't corrupt each other and the tracked pointer's lifetime is scoped
+// to the backend that brackets the drag (enter … (move)* … exit|drop).
+
+// Per-drag hover state owned by the platform backend (a member of the window
+// host / drop target). Opaque to callers beyond construction; reset between
+// drags happens automatically via exit/drop.
+struct DragSession {
+    FileDropZone* hover_zone = nullptr;  // currently-highlighted zone, or null
+};
 
 // Hover lifecycle for visual feedback (FileDropZone highlight). Returns true if a
 // drop zone / handler is under the point and would accept the drag.
-bool dispatch_drag_enter(View& root, const DropData& data, Point root_pos);
-void dispatch_drag_move(View& root, const DropData& data, Point root_pos);
-void dispatch_drag_exit(View& root);
+bool dispatch_drag_enter(View& root, DragSession& session, const DropData& data,
+                         Point root_pos);
+void dispatch_drag_move(View& root, DragSession& session, const DropData& data,
+                        Point root_pos);
+void dispatch_drag_exit(View& root, DragSession& session);
 
 // Commit a drop. Returns true if a view handled it. Also clears any hover state.
-bool dispatch_drop(View& root, const DropData& data, Point root_pos);
+bool dispatch_drop(View& root, DragSession& session, const DropData& data,
+                   Point root_pos);
 
 } // namespace pulp::view

--- a/core/view/include/pulp/view/drag_drop.hpp
+++ b/core/view/include/pulp/view/drag_drop.hpp
@@ -7,6 +7,8 @@
 
 namespace pulp::view {
 
+class View;
+
 // ── Drop data types ──────────────────────────────────────────────────────────
 
 struct DropData {
@@ -53,5 +55,39 @@ struct DragSource {
 // Register/unregister a native view for file drops (macOS NSView)
 bool register_drop_target(void* native_view, DropTarget& target);
 void unregister_drop_target(void* native_view);
+
+// ── Native → view-tree drop dispatch ─────────────────────────────────────────
+//
+// The bridge a platform drag-drop backend (SDL3 standalone drop events, Windows
+// IDropTarget, Linux XDND, macOS NSDraggingDestination) calls to route a native
+// drop into a Pulp view tree. Each function hit-tests `root` at the given
+// root-space point, finds the deepest View with a drop handler — bubbling up the
+// parent chain bounded by `root`, exactly like View::simulate_click resolves a
+// click target — and invokes it.
+//
+// Two handler surfaces are driven (a view may use either):
+//   • View::on_drop(type, data, x, y) — the generic callback the JS bridge wires.
+//     `type` is "file" / "text" / "custom"; for a multi-file drop it fires once
+//     per path. x/y are in the handler view's local coordinates.
+//   • FileDropZone — receives the typed paths via drag_enter/drag_leave/drop so
+//     its extension validation + hover visuals work.
+//
+// Coordinate space: `root_pos` is in `root`'s local (window/root) coordinates;
+// the platform backend is responsible for any window→root viewport transform
+// (e.g. PluginViewHost::window_to_root_point) before calling in.
+//
+// Threading: UI thread only (mirrors the rest of the view input path). A single
+// hover target is tracked across a drag (one pointer at a time); the backend must
+// bracket a drag with enter … (move)* … exit|drop so the tracked pointer never
+// outlives the view.
+
+// Hover lifecycle for visual feedback (FileDropZone highlight). Returns true if a
+// drop zone / handler is under the point and would accept the drag.
+bool dispatch_drag_enter(View& root, const DropData& data, Point root_pos);
+void dispatch_drag_move(View& root, const DropData& data, Point root_pos);
+void dispatch_drag_exit(View& root);
+
+// Commit a drop. Returns true if a view handled it. Also clears any hover state.
+bool dispatch_drop(View& root, const DropData& data, Point root_pos);
 
 } // namespace pulp::view

--- a/core/view/src/drag_drop.cpp
+++ b/core/view/src/drag_drop.cpp
@@ -19,12 +19,6 @@ namespace pulp::view {
 
 namespace {
 
-// The single drop zone currently highlighted by an in-flight drag. One pointer
-// drags at a time, so a single raw pointer suffices; it is cleared on exit/drop,
-// and the backend always brackets a drag (enter … exit|drop), so it never
-// outlives the view. UI thread only — no synchronization.
-FileDropZone* g_hover_zone = nullptr;
-
 // Walk a root-space point down into `target`'s local coordinates by subtracting
 // each ancestor's origin up to (but not including) `root`. Mirrors the local
 // conversion in View::simulate_click.
@@ -82,19 +76,20 @@ void fire_view_on_drop(View& root, View* handler, const DropData& data,
     }
 }
 
-void clear_hover() {
-    if (g_hover_zone) {
-        g_hover_zone->drag_leave();
-        g_hover_zone = nullptr;
+void clear_hover(DragSession& session) {
+    if (session.hover_zone) {
+        session.hover_zone->drag_leave();
+        session.hover_zone = nullptr;
     }
 }
 
 }  // namespace
 
-bool dispatch_drag_enter(View& root, const DropData& data, Point root_pos) {
+bool dispatch_drag_enter(View& root, DragSession& session, const DropData& data,
+                         Point root_pos) {
     View* target = root.hit_test(root_pos);
     if (!target) {  // outside the window entirely
-        clear_hover();
+        clear_hover(session);
         return false;
     }
 
@@ -102,25 +97,29 @@ bool dispatch_drag_enter(View& root, const DropData& data, Point root_pos) {
     FileDropZone* zone = (data.type == DropData::Type::files)
                              ? find_drop_zone(root, target)
                              : nullptr;
-    if (zone != g_hover_zone) {
-        clear_hover();
-        g_hover_zone = zone;
-        if (g_hover_zone) g_hover_zone->drag_enter(data.file_paths);
+    if (zone != session.hover_zone) {
+        clear_hover(session);
+        session.hover_zone = zone;
+        if (session.hover_zone) session.hover_zone->drag_enter(data.file_paths);
     }
 
     return zone != nullptr || find_drop_handler(root, target) != nullptr;
 }
 
-void dispatch_drag_move(View& root, const DropData& data, Point root_pos) {
+void dispatch_drag_move(View& root, DragSession& session, const DropData& data,
+                        Point root_pos) {
     // A move is an enter against the (possibly new) target; enter already handles
     // the leave-old / enter-new transition.
-    dispatch_drag_enter(root, data, root_pos);
+    dispatch_drag_enter(root, session, data, root_pos);
 }
 
-void dispatch_drag_exit(View& /*root*/) { clear_hover(); }
+void dispatch_drag_exit(View& /*root*/, DragSession& session) {
+    clear_hover(session);
+}
 
-bool dispatch_drop(View& root, const DropData& data, Point root_pos) {
-    clear_hover();
+bool dispatch_drop(View& root, DragSession& session, const DropData& data,
+                   Point root_pos) {
+    clear_hover(session);
 
     View* target = root.hit_test(root_pos);
     if (!target) return false;  // dropped outside the window

--- a/core/view/src/drag_drop.cpp
+++ b/core/view/src/drag_drop.cpp
@@ -1,0 +1,149 @@
+// Cross-platform native → view-tree drop dispatch (declared in drag_drop.hpp).
+//
+// Platform backends (SDL3 standalone drop events, Windows IDropTarget, Linux
+// XDND, macOS NSDraggingDestination) extract the dropped payload into a DropData
+// and a root-space point, then call these to route it into the view tree. The
+// target-resolution + local-coordinate walk + handler-bubble mirror
+// View::simulate_click (core/view/src/view.cpp) so drops land on the same view a
+// click at that point would.
+//
+// Platform-specific *capture* lives in the per-OS backends; this file is the one
+// shared place that understands the Pulp view tree, so it compiles everywhere.
+
+#include <pulp/view/drag_drop.hpp>
+
+#include <pulp/view/file_drop_zone.hpp>
+#include <pulp/view/view.hpp>
+
+namespace pulp::view {
+
+namespace {
+
+// The single drop zone currently highlighted by an in-flight drag. One pointer
+// drags at a time, so a single raw pointer suffices; it is cleared on exit/drop,
+// and the backend always brackets a drag (enter … exit|drop), so it never
+// outlives the view. UI thread only — no synchronization.
+FileDropZone* g_hover_zone = nullptr;
+
+// Walk a root-space point down into `target`'s local coordinates by subtracting
+// each ancestor's origin up to (but not including) `root`. Mirrors the local
+// conversion in View::simulate_click.
+Point to_local(View& root, View* target, Point root_pos) {
+    Point local = root_pos;
+    View* v = target;
+    while (v && v != &root) {
+        local.x -= v->bounds().x;
+        local.y -= v->bounds().y;
+        v = v->parent();
+    }
+    return local;
+}
+
+// Nearest ancestor (inclusive of `target`, bounded by `root`) with a generic
+// View::on_drop handler. nullptr if none.
+View* find_drop_handler(View& root, View* target) {
+    View* v = target;
+    while (v) {
+        if (v->on_drop) return v;
+        if (v == &root) break;
+        v = v->parent();
+    }
+    return nullptr;
+}
+
+// Nearest FileDropZone ancestor (inclusive of `target`, bounded by `root`).
+FileDropZone* find_drop_zone(View& root, View* target) {
+    View* v = target;
+    while (v) {
+        if (auto* zone = dynamic_cast<FileDropZone*>(v)) return zone;
+        if (v == &root) break;
+        v = v->parent();
+    }
+    return nullptr;
+}
+
+// Fire View::on_drop with the (type, data, x, y) string contract. A multi-file
+// drop fires once per path (matches the JS-bridge expectation of one callback
+// invocation per dropped item).
+void fire_view_on_drop(View& root, View* handler, const DropData& data,
+                       Point root_pos) {
+    const Point local = to_local(root, handler, root_pos);
+    switch (data.type) {
+        case DropData::Type::files:
+            for (const auto& path : data.file_paths)
+                handler->on_drop("file", path, local.x, local.y);
+            break;
+        case DropData::Type::text:
+            handler->on_drop("text", data.text, local.x, local.y);
+            break;
+        case DropData::Type::custom:
+            handler->on_drop("custom", data.custom_type, local.x, local.y);
+            break;
+    }
+}
+
+void clear_hover() {
+    if (g_hover_zone) {
+        g_hover_zone->drag_leave();
+        g_hover_zone = nullptr;
+    }
+}
+
+}  // namespace
+
+bool dispatch_drag_enter(View& root, const DropData& data, Point root_pos) {
+    View* target = root.hit_test(root_pos);
+    if (!target) {  // outside the window entirely
+        clear_hover();
+        return false;
+    }
+
+    // Hover visuals only apply to file drags over a FileDropZone.
+    FileDropZone* zone = (data.type == DropData::Type::files)
+                             ? find_drop_zone(root, target)
+                             : nullptr;
+    if (zone != g_hover_zone) {
+        clear_hover();
+        g_hover_zone = zone;
+        if (g_hover_zone) g_hover_zone->drag_enter(data.file_paths);
+    }
+
+    return zone != nullptr || find_drop_handler(root, target) != nullptr;
+}
+
+void dispatch_drag_move(View& root, const DropData& data, Point root_pos) {
+    // A move is an enter against the (possibly new) target; enter already handles
+    // the leave-old / enter-new transition.
+    dispatch_drag_enter(root, data, root_pos);
+}
+
+void dispatch_drag_exit(View& /*root*/) { clear_hover(); }
+
+bool dispatch_drop(View& root, const DropData& data, Point root_pos) {
+    clear_hover();
+
+    View* target = root.hit_test(root_pos);
+    if (!target) return false;  // dropped outside the window
+
+    bool handled = false;
+
+    // FileDropZone gets the typed paths (extension validation + visual reset live
+    // in FileDropZone::drop) for file drops.
+    if (data.type == DropData::Type::files) {
+        if (auto* zone = find_drop_zone(root, target)) {
+            zone->drop(data.file_paths);
+            handled = true;
+        }
+    }
+
+    // Generic View::on_drop — the surface the JS bridge wires. A view can carry
+    // both (a FileDropZone subclass with its own on_drop), so fire both.
+    if (auto* handler = find_drop_handler(root, target)) {
+        fire_view_on_drop(root, handler, data, root_pos);
+        handled = true;
+    }
+
+    return handled;
+}
+
+}  // namespace pulp::view

--- a/core/view/src/sdl_window_host.cpp
+++ b/core/view/src/sdl_window_host.cpp
@@ -114,7 +114,8 @@ public:
                             DropData d;
                             d.type = DropData::Type::text;
                             d.text = event.drop.data;
-                            dispatch_drop(root_, d, {event.drop.x, event.drop.y});
+                            dispatch_drop(root_, drag_session_, d,
+                                          {event.drop.x, event.drop.y});
                             needs_repaint_ = true;
                         }
                         break;
@@ -126,7 +127,8 @@ public:
                             DropData d;
                             d.type = DropData::Type::files;
                             d.file_paths = pending_drop_files_;
-                            dispatch_drag_move(root_, d, {event.drop.x, event.drop.y});
+                            dispatch_drag_move(root_, drag_session_, d,
+                                               {event.drop.x, event.drop.y});
                             needs_repaint_ = true;
                         }
                         break;
@@ -135,11 +137,11 @@ public:
                             DropData d;
                             d.type = DropData::Type::files;
                             d.file_paths = std::move(pending_drop_files_);
-                            dispatch_drop(root_, d, pending_drop_pos_);
+                            dispatch_drop(root_, drag_session_, d, pending_drop_pos_);
                             pending_drop_files_.clear();
                             needs_repaint_ = true;
                         } else {
-                            dispatch_drag_exit(root_);
+                            dispatch_drag_exit(root_, drag_session_);
                         }
                         break;
                     default:
@@ -205,6 +207,8 @@ private:
     // drop position, both in window coordinates (== root coords here).
     std::vector<std::string> pending_drop_files_;
     Point pending_drop_pos_{0, 0};
+    // Per-window drop hover state (owned here, not a process global).
+    DragSession drag_session_;
 
     struct DispatcherQueueState {
         mutable std::mutex mutex;

--- a/core/view/src/sdl_window_host.cpp
+++ b/core/view/src/sdl_window_host.cpp
@@ -4,7 +4,10 @@
 
 #include <pulp/canvas/canvas.hpp>
 #include <pulp/events/main_thread_dispatcher.hpp>
+#include <pulp/view/drag_drop.hpp>
 #include <SDL3/SDL.h>
+#include <string>
+#include <vector>
 #include <deque>
 #include <iostream>
 #include <memory>
@@ -92,6 +95,53 @@ public:
                     case SDL_EVENT_WINDOW_EXPOSED:
                         needs_repaint_ = true;
                         break;
+                    // Native drag-and-drop. SDL3 abstracts Win OLE / Linux XDND
+                    // (and macOS) into normalized drop events and delivers each
+                    // dropped file as its own SDL_EVENT_DROP_FILE, bracketed by
+                    // BEGIN/COMPLETE. We accumulate the files across the sequence
+                    // and route the batch into the view tree via the shared
+                    // dispatch core (drag_drop.cpp).
+                    case SDL_EVENT_DROP_BEGIN:
+                        pending_drop_files_.clear();
+                        pending_drop_pos_ = {event.drop.x, event.drop.y};
+                        break;
+                    case SDL_EVENT_DROP_FILE:
+                        if (event.drop.data) pending_drop_files_.emplace_back(event.drop.data);
+                        pending_drop_pos_ = {event.drop.x, event.drop.y};
+                        break;
+                    case SDL_EVENT_DROP_TEXT:
+                        if (event.drop.data) {
+                            DropData d;
+                            d.type = DropData::Type::text;
+                            d.text = event.drop.data;
+                            dispatch_drop(root_, d, {event.drop.x, event.drop.y});
+                            needs_repaint_ = true;
+                        }
+                        break;
+                    case SDL_EVENT_DROP_POSITION:
+                        // Hover feedback while dragging over the window. The file
+                        // list is only known once DROP_FILE events arrive, so this
+                        // updates highlight state only when we already have paths.
+                        if (!pending_drop_files_.empty()) {
+                            DropData d;
+                            d.type = DropData::Type::files;
+                            d.file_paths = pending_drop_files_;
+                            dispatch_drag_move(root_, d, {event.drop.x, event.drop.y});
+                            needs_repaint_ = true;
+                        }
+                        break;
+                    case SDL_EVENT_DROP_COMPLETE:
+                        if (!pending_drop_files_.empty()) {
+                            DropData d;
+                            d.type = DropData::Type::files;
+                            d.file_paths = std::move(pending_drop_files_);
+                            dispatch_drop(root_, d, pending_drop_pos_);
+                            pending_drop_files_.clear();
+                            needs_repaint_ = true;
+                        } else {
+                            dispatch_drag_exit(root_);
+                        }
+                        break;
                     default:
                         break;
                 }
@@ -149,6 +199,12 @@ private:
     SDL_Renderer* renderer_ = nullptr;
     std::function<void()> close_callback_;
     bool needs_repaint_ = false;
+
+    // Files accumulated across an in-flight native drag-drop sequence
+    // (SDL_EVENT_DROP_BEGIN … DROP_FILE* … DROP_COMPLETE) and the last reported
+    // drop position, both in window coordinates (== root coords here).
+    std::vector<std::string> pending_drop_files_;
+    Point pending_drop_pos_{0, 0};
 
     struct DispatcherQueueState {
         mutable std::mutex mutex;

--- a/test/test_drag_drop.cpp
+++ b/test/test_drag_drop.cpp
@@ -118,7 +118,8 @@ TEST_CASE("dispatch_drop routes a file drop to View::on_drop", "[view][dnd]") {
     root.on_drop = [&](const std::string& type, const std::string& data, float x,
                        float y) { recs.push_back({type, data, x, y}); };
 
-    REQUIRE(dispatch_drop(root, make_files({"/tmp/a.wav"}), {50, 60}));
+    DragSession session;
+    REQUIRE(dispatch_drop(root, session, make_files({"/tmp/a.wav"}), {50, 60}));
     REQUIRE(recs.size() == 1);
     CHECK(recs[0].type == "file");
     CHECK(recs[0].data == "/tmp/a.wav");
@@ -133,7 +134,8 @@ TEST_CASE("multi-file drop fires View::on_drop once per path", "[view][dnd]") {
     root.on_drop = [&](const std::string& t, const std::string& d, float x,
                        float y) { recs.push_back({t, d, x, y}); };
 
-    REQUIRE(dispatch_drop(root, make_files({"/a.txt", "/b.txt", "/c.txt"}),
+    DragSession session;
+    REQUIRE(dispatch_drop(root, session, make_files({"/a.txt", "/b.txt", "/c.txt"}),
                           {10, 10}));
     REQUIRE(recs.size() == 3);
     CHECK(recs[0].data == "/a.txt");
@@ -149,7 +151,8 @@ TEST_CASE("text drop carries the text type + payload", "[view][dnd]") {
     root.on_drop = [&](const std::string& t, const std::string& d, float x,
                        float y) { got = {t, d, x, y}; ++n; };
 
-    REQUIRE(dispatch_drop(root, make_text("hello world"), {5, 5}));
+    DragSession session;
+    REQUIRE(dispatch_drop(root, session, make_text("hello world"), {5, 5}));
     CHECK(n == 1);
     CHECK(got.type == "text");
     CHECK(got.data == "hello world");
@@ -175,7 +178,8 @@ TEST_CASE("drop bubbles to the nearest ancestor handler with local coords",
 
     // Drop at root (130,70): inside leaf; leaf has no handler → bubble to child.
     // child-local coords = 130-100, 70-50.
-    REQUIRE(dispatch_drop(root, make_files({"/x"}), {130, 70}));
+    DragSession session;
+    REQUIRE(dispatch_drop(root, session, make_files({"/x"}), {130, 70}));
     REQUIRE(recs.size() == 1);
     CHECK(recs[0].x == 30.0f);
     CHECK(recs[0].y == 20.0f);
@@ -188,7 +192,8 @@ TEST_CASE("drop outside the root bounds is not handled", "[view][dnd]") {
     root.on_drop = [&](const std::string&, const std::string&, float, float) {
         fired = true;
     };
-    CHECK_FALSE(dispatch_drop(root, make_files({"/x"}), {500, 500}));
+    DragSession session;
+    CHECK_FALSE(dispatch_drop(root, session, make_files({"/x"}), {500, 500}));
     CHECK_FALSE(fired);
 }
 
@@ -208,7 +213,8 @@ TEST_CASE("FileDropZone receives typed paths with extension filtering",
     };
 
     // .wav accepted, .mp3 filtered out by the zone.
-    REQUIRE(dispatch_drop(root, make_files({"/a.wav", "/b.mp3"}), {10, 10}));
+    DragSession session;
+    REQUIRE(dispatch_drop(root, session, make_files({"/a.wav", "/b.mp3"}), {10, 10}));
     REQUIRE(dropped.size() == 1);
     CHECK(dropped[0] == "/a.wav");
 }
@@ -222,11 +228,12 @@ TEST_CASE("drag enter/exit toggles FileDropZone hover state", "[view][dnd]") {
     zone->set_accepted_extensions({".wav"});
     root.add_child(std::move(zone_owned));
 
+    DragSession session;
     CHECK_FALSE(zone->is_drag_over());
-    REQUIRE(dispatch_drag_enter(root, make_files({"/a.wav"}), {10, 10}));
+    REQUIRE(dispatch_drag_enter(root, session, make_files({"/a.wav"}), {10, 10}));
     CHECK(zone->is_drag_over());
     CHECK(zone->is_drag_valid());
-    dispatch_drag_exit(root);
+    dispatch_drag_exit(root, session);
     CHECK_FALSE(zone->is_drag_over());
 }
 
@@ -240,11 +247,12 @@ TEST_CASE("drag enter over an invalid extension marks the zone invalid",
     zone->set_accepted_extensions({".wav"});
     root.add_child(std::move(zone_owned));
 
-    dispatch_drag_enter(root, make_files({"/a.mp3"}), {10, 10});
+    DragSession session;
+    dispatch_drag_enter(root, session, make_files({"/a.mp3"}), {10, 10});
     CHECK(zone->is_drag_over());
     CHECK_FALSE(zone->is_drag_valid());
 
-    dispatch_drop(root, make_files({"/a.mp3"}), {10, 10});  // clears hover
+    dispatch_drop(root, session, make_files({"/a.mp3"}), {10, 10});  // clears hover
     CHECK_FALSE(zone->is_drag_over());
 }
 
@@ -262,14 +270,43 @@ TEST_CASE("drag move from one zone to another transfers hover", "[view][dnd]") {
     z2->set_bounds({200, 0, 200, 200});
     root.add_child(std::move(z2_owned));
 
-    dispatch_drag_enter(root, make_files({"/a.wav"}), {50, 50});
+    DragSession session;
+    dispatch_drag_enter(root, session, make_files({"/a.wav"}), {50, 50});
     CHECK(z1->is_drag_over());
     CHECK_FALSE(z2->is_drag_over());
 
-    dispatch_drag_move(root, make_files({"/a.wav"}), {300, 50});
+    dispatch_drag_move(root, session, make_files({"/a.wav"}), {300, 50});
     CHECK_FALSE(z1->is_drag_over());
     CHECK(z2->is_drag_over());
 
-    dispatch_drag_exit(root);
+    dispatch_drag_exit(root, session);
     CHECK_FALSE(z2->is_drag_over());
+}
+
+TEST_CASE("independent DragSessions do not share hover state", "[view][dnd]") {
+    // Two windows / two backends each own their own DragSession; a drag in one
+    // must not be cleared or hijacked by the other (the reason hover state is
+    // caller-owned, not a process global).
+    View root_a, root_b;
+    root_a.set_bounds({0, 0, 200, 200});
+    root_b.set_bounds({0, 0, 200, 200});
+    auto za_owned = std::make_unique<FileDropZone>();
+    FileDropZone* za = za_owned.get();
+    za->set_bounds({0, 0, 200, 200});
+    root_a.add_child(std::move(za_owned));
+    auto zb_owned = std::make_unique<FileDropZone>();
+    FileDropZone* zb = zb_owned.get();
+    zb->set_bounds({0, 0, 200, 200});
+    root_b.add_child(std::move(zb_owned));
+
+    DragSession sa, sb;
+    dispatch_drag_enter(root_a, sa, make_files({"/a.wav"}), {10, 10});
+    dispatch_drag_enter(root_b, sb, make_files({"/b.wav"}), {10, 10});
+    CHECK(za->is_drag_over());
+    CHECK(zb->is_drag_over());
+
+    // Exiting B's drag leaves A's hover intact.
+    dispatch_drag_exit(root_b, sb);
+    CHECK(za->is_drag_over());
+    CHECK_FALSE(zb->is_drag_over());
 }

--- a/test/test_drag_drop.cpp
+++ b/test/test_drag_drop.cpp
@@ -1,5 +1,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/view/drag_drop.hpp>
+#include <pulp/view/file_drop_zone.hpp>
+#include <pulp/view/view.hpp>
+
+#include <string>
+#include <vector>
 
 using namespace pulp::view;
 
@@ -73,4 +78,198 @@ TEST_CASE("DropTarget accepts files", "[view][dnd]") {
     REQUIRE(acceptor.on_drop(data, {50, 50}));
     REQUIRE(acceptor.dropped_files.size() == 1);
     REQUIRE(acceptor.dropped_files[0] == "/audio/kick.wav");
+}
+
+// ── Native → view-tree drop dispatch (drag_drop.cpp) ─────────────────────────
+// The shared core every platform backend (SDL3, Win IDropTarget, Linux XDND,
+// mac) routes through. Headless: build a view tree, hand dispatch_* a DropData +
+// root-space point, assert the right view's handler fired with the right payload
+// and local coordinates. Mirrors View::simulate_click's target+bubble logic.
+
+namespace {
+
+struct DispatchRec {
+    std::string type;
+    std::string data;
+    float x = 0;
+    float y = 0;
+};
+
+DropData make_files(std::vector<std::string> paths) {
+    DropData d;
+    d.type = DropData::Type::files;
+    d.file_paths = std::move(paths);
+    return d;
+}
+
+DropData make_text(std::string t) {
+    DropData d;
+    d.type = DropData::Type::text;
+    d.text = std::move(t);
+    return d;
+}
+
+}  // namespace
+
+TEST_CASE("dispatch_drop routes a file drop to View::on_drop", "[view][dnd]") {
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    std::vector<DispatchRec> recs;
+    root.on_drop = [&](const std::string& type, const std::string& data, float x,
+                       float y) { recs.push_back({type, data, x, y}); };
+
+    REQUIRE(dispatch_drop(root, make_files({"/tmp/a.wav"}), {50, 60}));
+    REQUIRE(recs.size() == 1);
+    CHECK(recs[0].type == "file");
+    CHECK(recs[0].data == "/tmp/a.wav");
+    CHECK(recs[0].x == 50.0f);
+    CHECK(recs[0].y == 60.0f);
+}
+
+TEST_CASE("multi-file drop fires View::on_drop once per path", "[view][dnd]") {
+    View root;
+    root.set_bounds({0, 0, 200, 200});
+    std::vector<DispatchRec> recs;
+    root.on_drop = [&](const std::string& t, const std::string& d, float x,
+                       float y) { recs.push_back({t, d, x, y}); };
+
+    REQUIRE(dispatch_drop(root, make_files({"/a.txt", "/b.txt", "/c.txt"}),
+                          {10, 10}));
+    REQUIRE(recs.size() == 3);
+    CHECK(recs[0].data == "/a.txt");
+    CHECK(recs[1].data == "/b.txt");
+    CHECK(recs[2].data == "/c.txt");
+}
+
+TEST_CASE("text drop carries the text type + payload", "[view][dnd]") {
+    View root;
+    root.set_bounds({0, 0, 200, 200});
+    DispatchRec got;
+    int n = 0;
+    root.on_drop = [&](const std::string& t, const std::string& d, float x,
+                       float y) { got = {t, d, x, y}; ++n; };
+
+    REQUIRE(dispatch_drop(root, make_text("hello world"), {5, 5}));
+    CHECK(n == 1);
+    CHECK(got.type == "text");
+    CHECK(got.data == "hello world");
+}
+
+TEST_CASE("drop bubbles to the nearest ancestor handler with local coords",
+          "[view][dnd]") {
+    View root;
+    root.set_bounds({0, 0, 400, 400});
+
+    auto child_owned = std::make_unique<View>();
+    View* child = child_owned.get();
+    child->set_bounds({100, 50, 200, 200});  // offset within root
+    auto leaf_owned = std::make_unique<View>();
+    View* leaf = leaf_owned.get();
+    leaf->set_bounds({20, 10, 50, 50});  // offset within child; NO handler
+    child->add_child(std::move(leaf_owned));
+    root.add_child(std::move(child_owned));
+
+    std::vector<DispatchRec> recs;
+    child->on_drop = [&](const std::string& t, const std::string& d, float x,
+                         float y) { recs.push_back({t, d, x, y}); };
+
+    // Drop at root (130,70): inside leaf; leaf has no handler → bubble to child.
+    // child-local coords = 130-100, 70-50.
+    REQUIRE(dispatch_drop(root, make_files({"/x"}), {130, 70}));
+    REQUIRE(recs.size() == 1);
+    CHECK(recs[0].x == 30.0f);
+    CHECK(recs[0].y == 20.0f);
+}
+
+TEST_CASE("drop outside the root bounds is not handled", "[view][dnd]") {
+    View root;
+    root.set_bounds({0, 0, 100, 100});
+    bool fired = false;
+    root.on_drop = [&](const std::string&, const std::string&, float, float) {
+        fired = true;
+    };
+    CHECK_FALSE(dispatch_drop(root, make_files({"/x"}), {500, 500}));
+    CHECK_FALSE(fired);
+}
+
+TEST_CASE("FileDropZone receives typed paths with extension filtering",
+          "[view][dnd]") {
+    View root;
+    root.set_bounds({0, 0, 300, 300});
+    auto zone_owned = std::make_unique<FileDropZone>();
+    FileDropZone* zone = zone_owned.get();
+    zone->set_bounds({0, 0, 300, 300});
+    zone->set_accepted_extensions({".wav", ".aiff"});
+    root.add_child(std::move(zone_owned));
+
+    std::vector<std::string> dropped;
+    zone->on_drop = [&](const std::vector<std::string>& paths) {
+        dropped = paths;
+    };
+
+    // .wav accepted, .mp3 filtered out by the zone.
+    REQUIRE(dispatch_drop(root, make_files({"/a.wav", "/b.mp3"}), {10, 10}));
+    REQUIRE(dropped.size() == 1);
+    CHECK(dropped[0] == "/a.wav");
+}
+
+TEST_CASE("drag enter/exit toggles FileDropZone hover state", "[view][dnd]") {
+    View root;
+    root.set_bounds({0, 0, 300, 300});
+    auto zone_owned = std::make_unique<FileDropZone>();
+    FileDropZone* zone = zone_owned.get();
+    zone->set_bounds({0, 0, 300, 300});
+    zone->set_accepted_extensions({".wav"});
+    root.add_child(std::move(zone_owned));
+
+    CHECK_FALSE(zone->is_drag_over());
+    REQUIRE(dispatch_drag_enter(root, make_files({"/a.wav"}), {10, 10}));
+    CHECK(zone->is_drag_over());
+    CHECK(zone->is_drag_valid());
+    dispatch_drag_exit(root);
+    CHECK_FALSE(zone->is_drag_over());
+}
+
+TEST_CASE("drag enter over an invalid extension marks the zone invalid",
+          "[view][dnd]") {
+    View root;
+    root.set_bounds({0, 0, 300, 300});
+    auto zone_owned = std::make_unique<FileDropZone>();
+    FileDropZone* zone = zone_owned.get();
+    zone->set_bounds({0, 0, 300, 300});
+    zone->set_accepted_extensions({".wav"});
+    root.add_child(std::move(zone_owned));
+
+    dispatch_drag_enter(root, make_files({"/a.mp3"}), {10, 10});
+    CHECK(zone->is_drag_over());
+    CHECK_FALSE(zone->is_drag_valid());
+
+    dispatch_drop(root, make_files({"/a.mp3"}), {10, 10});  // clears hover
+    CHECK_FALSE(zone->is_drag_over());
+}
+
+TEST_CASE("drag move from one zone to another transfers hover", "[view][dnd]") {
+    View root;
+    root.set_bounds({0, 0, 400, 200});
+
+    auto z1_owned = std::make_unique<FileDropZone>();
+    FileDropZone* z1 = z1_owned.get();
+    z1->set_bounds({0, 0, 200, 200});
+    root.add_child(std::move(z1_owned));
+
+    auto z2_owned = std::make_unique<FileDropZone>();
+    FileDropZone* z2 = z2_owned.get();
+    z2->set_bounds({200, 0, 200, 200});
+    root.add_child(std::move(z2_owned));
+
+    dispatch_drag_enter(root, make_files({"/a.wav"}), {50, 50});
+    CHECK(z1->is_drag_over());
+    CHECK_FALSE(z2->is_drag_over());
+
+    dispatch_drag_move(root, make_files({"/a.wav"}), {300, 50});
+    CHECK_FALSE(z1->is_drag_over());
+    CHECK(z2->is_drag_over());
+
+    dispatch_drag_exit(root);
+    CHECK_FALSE(z2->is_drag_over());
 }


### PR DESCRIPTION
## What

Wires native drag-and-drop (file + text) end-to-end for Win/Linux GPU windows — part of the platform parity epic (#3329, the GPU-UI drag-drop item un-gated by the #3500 PluginViewHost spine).

The native→view drop pipeline was **unwired on every platform**: `View::on_drop`, `FileDropZone`, and the `DropTarget` interface all existed but nothing connected a real OS drop to them (even macOS registered NSView dragged types but never delivered). This adds the missing shared link plus the first real producer.

## Changes

**Dispatch core** (`core/view/src/drag_drop.cpp`, new):
- `dispatch_drop` / `dispatch_drag_enter` / `dispatch_drag_move` / `dispatch_drag_exit` — hit-test the view tree at a root-space point, resolve the deepest `View` with a drop handler bubbling up to root (mirrors `View::simulate_click`'s target+bubble), translate `DropData` into the `View::on_drop(type,data,x,y)` contract, and drive `FileDropZone` enter/leave/drop (extension validation + hover visuals).
- Pure C++, headless-testable, the one place that understands the view tree → compiles on every platform.

**SDL standalone producer** (`core/view/src/sdl_window_host.cpp`):
- SDL3 normalizes Win OLE / Linux XDND / macOS into `SDL_EVENT_DROP_*` and delivers each file as its own event bracketed by BEGIN/COMPLETE. We accumulate the batch and route it through the dispatch core — **one code path gives real drag-drop on both Windows and Linux standalone** with no per-platform OLE/XDND code.

## Deferred follow-ups
- Per-platform plugin-editor-host backends: Win `IDropTarget` on the child HWND; Linux XDND (needs an event loop `X11PluginViewHost` does not yet have).
- macOS `NSDraggingDestination` delivery into the dispatch core (the mac host registers types today but never delivers).

## Tests
10 new headless cases in `test_drag_drop.cpp` (`pulp-test-dnd`, 14 total / 53 assertions): file/text/multi-file routing, ancestor bubbling with local-coordinate correctness, out-of-bounds rejection, FileDropZone extension filtering, drag enter/move/exit hover transitions. Runs on every lane incl. the required macOS gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native drag-and-drop dispatch for GPU windows and wires SDL3 events into the view tree, enabling file and text drops on Windows and Linux standalone. Moves drag-hover state to a per-window `DragSession` for safer multi-backend use.

- **New Features**
  - Drag-and-drop dispatch core: hit-tests the view tree, bubbles to the nearest handler, calls View::on_drop(type, data, x, y), and drives FileDropZone enter/leave/drop.
  - SDL3 producer: batches `SDL_EVENT_DROP_*` (files and text) and routes them through the dispatch core, enabling drops on Windows and Linux standalone.

- **Refactors**
  - Replaced process-global hover tracking with a caller-owned `DragSession` scoped per window/backend; the SDL host now holds its own session to avoid cross-window collisions and dangling pointers.

<sup>Written for commit 15f1c4830814a32589ec4ecbe46457daff6c833f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

