### PR TITLE
refactor(view): unify drag-drop on DropReceiver + fix header self-containment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.380.0
+    VERSION 0.381.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/drag_drop.hpp
+++ b/core/view/include/pulp/view/drag_drop.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <pulp/view/geometry.hpp>
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <functional>
@@ -8,7 +9,6 @@
 namespace pulp::view {
 
 class View;
-class FileDropZone;
 
 // ── Drop data types ──────────────────────────────────────────────────────────
 
@@ -22,9 +22,52 @@ struct DropData {
     std::vector<uint8_t> custom_data;      // For custom binary data
 };
 
-// ── Drop target interface ────────────────────────────────────────────────────
+// ── Drop receiver (view-tree drop handler) ───────────────────────────────────
+//
+// The extensible interface a View subclass mixes in to accept native drops
+// routed by the dispatch_* functions below:
+//
+//     class MyZone : public View, public DropReceiver { ... };
+//
+// The dispatch core finds receivers via dynamic_cast as it walks the view tree,
+// so a new drop-aware widget needs NO change to the dispatch core — that is the
+// extension point. This is the rich, typed surface (FileDropZone implements it).
+// For lightweight cases a view can instead set the View::on_drop std::function
+// (the JS-bridge convenience surface). See the dispatch contract below for how
+// the two interact.
+class DropReceiver {
+public:
+    virtual ~DropReceiver() = default;
 
-// Views implement this to accept drops
+    // A drag carrying `data` is hovering at `local` (this receiver's local
+    // coordinates). Return true to claim the hover (drives highlight state).
+    // Called on enter and on each move while over this receiver, so it must be
+    // idempotent. Default: decline.
+    virtual bool accept_drag(const DropData& data, Point local) {
+        (void)data;
+        (void)local;
+        return false;
+    }
+
+    // The drag left this receiver (moved away, exited the window, or dropped).
+    // Clear any highlight set by accept_drag.
+    virtual void leave_drag() {}
+
+    // Commit a drop at `local`. Return true if handled — a true return CONSUMES
+    // the drop (dispatch stops bubbling); false lets it fall through to an outer
+    // receiver / View::on_drop.
+    virtual bool accept_drop(const DropData& data, Point local) = 0;
+};
+
+// ── Legacy platform-registration drop target (macOS NSView) ──────────────────
+//
+// SEPARATE CONCERN from DropReceiver above. This is the platform-side
+// registration layer: register_drop_target() tells a native OS view (today only
+// the macOS NSView path in drag_drop_mac.mm) to advertise dragged types. It does
+// NOT route into the Pulp view tree. When macOS NSDraggingDestination delivery
+// is wired, this layer will feed the dispatch_* functions below and converge
+// with DropReceiver (tracked in the drag-drop hardening follow-up). New code
+// should implement DropReceiver, not DropTarget.
 class DropTarget {
 public:
     virtual ~DropTarget() = default;
@@ -53,7 +96,9 @@ struct DragSource {
 
 // ── Drag-drop registration ──────────────────────────────────────────────────
 
-// Register/unregister a native view for file drops (macOS NSView)
+// Register/unregister a native view for file drops (macOS NSView). See the
+// DropTarget note above — this is the platform-registration layer, not the
+// view-tree dispatch.
 bool register_drop_target(void* native_view, DropTarget& target);
 void unregister_drop_target(void* native_view);
 
@@ -62,44 +107,45 @@ void unregister_drop_target(void* native_view);
 // The bridge a platform drag-drop backend (SDL3 standalone drop events, Windows
 // IDropTarget, Linux XDND, macOS NSDraggingDestination) calls to route a native
 // drop into a Pulp view tree. Each function hit-tests `root` at the given
-// root-space point, finds the deepest View with a drop handler — bubbling up the
-// parent chain bounded by `root`, exactly like View::simulate_click resolves a
-// click target — and invokes it.
+// root-space point, then walks from the hit target up to `root` — exactly like
+// View::simulate_click resolves a click target.
 //
-// Two handler surfaces are driven (a view may use either):
-//   • View::on_drop(type, data, x, y) — the generic callback the JS bridge wires.
-//     `type` is "file" / "text" / "custom"; for a multi-file drop it fires once
-//     per path. x/y are in the handler view's local coordinates.
-//   • FileDropZone — receives the typed paths via drag_enter/drag_leave/drop so
-//     its extension validation + hover visuals work.
+// Dispatch contract (first-handler-wins, no double-dispatch): at each view from
+// the deepest hit up to the root, in order:
+//   1. if the view is a DropReceiver and accept_drop() returns true → consumed.
+//   2. else if the view has a View::on_drop std::function set → fire it,
+//      consumed. on_drop is the JS-bridge convenience surface; `type` is
+//      "file"/"text"/"custom" and a multi-file drop fires it once per path,
+//      with x/y in that view's local coordinates.
+// The first view that consumes the drop ends the walk; a view never receives the
+// drop through both surfaces.
 //
 // Coordinate space: `root_pos` is in `root`'s local (window/root) coordinates;
-// the platform backend is responsible for any window→root viewport transform
-// (e.g. PluginViewHost::window_to_root_point) before calling in.
+// the platform backend owns any window→root viewport transform (e.g. HiDPI /
+// design-viewport scale) before calling in.
 //
 // Threading: UI thread only (mirrors the rest of the view input path).
 //
-// Hover state is held in a DragSession the *caller* owns — one per platform
+// Hover state lives in a DragSession the *caller* owns — one per platform
 // backend / window, NOT a process global — so concurrent drags on separate
 // windows can't corrupt each other and the tracked pointer's lifetime is scoped
 // to the backend that brackets the drag (enter … (move)* … exit|drop).
 
 // Per-drag hover state owned by the platform backend (a member of the window
-// host / drop target). Opaque to callers beyond construction; reset between
-// drags happens automatically via exit/drop.
+// host / drop target). Reset between drags happens automatically via exit/drop.
 struct DragSession {
-    FileDropZone* hover_zone = nullptr;  // currently-highlighted zone, or null
+    DropReceiver* hover = nullptr;  // receiver currently claiming hover, or null
 };
 
-// Hover lifecycle for visual feedback (FileDropZone highlight). Returns true if a
-// drop zone / handler is under the point and would accept the drag.
+// Hover lifecycle for visual feedback (DropReceiver highlight). Returns true if a
+// receiver claims the drag, or a View::on_drop handler is under the point.
 bool dispatch_drag_enter(View& root, DragSession& session, const DropData& data,
                          Point root_pos);
 void dispatch_drag_move(View& root, DragSession& session, const DropData& data,
                         Point root_pos);
 void dispatch_drag_exit(View& root, DragSession& session);
 
-// Commit a drop. Returns true if a view handled it. Also clears any hover state.
+// Commit a drop. Returns true if a view consumed it. Also clears any hover state.
 bool dispatch_drop(View& root, DragSession& session, const DropData& data,
                    Point root_pos);
 

--- a/core/view/include/pulp/view/file_drop_zone.hpp
+++ b/core/view/include/pulp/view/file_drop_zone.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <pulp/view/drag_drop.hpp>
 #include <pulp/view/view.hpp>
 #include <functional>
 #include <vector>
@@ -8,9 +9,11 @@
 namespace pulp::view {
 
 // ── FileDropZone ────────────────────────────────────────────────────────────
-// Drag-and-drop file target with visual feedback.
+// Drag-and-drop file target with visual feedback. Implements DropReceiver so the
+// native drop-dispatch core (drag_drop.cpp) routes file drops here without
+// knowing the concrete type.
 
-class FileDropZone : public View {
+class FileDropZone : public View, public DropReceiver {
 public:
     FileDropZone();
 
@@ -43,6 +46,13 @@ public:
     void drag_enter(const std::vector<std::string>& paths);
     void drag_leave();
     void drop(const std::vector<std::string>& paths);
+
+    // DropReceiver — the dispatch core drives these; they delegate to the typed
+    // drag_enter/drag_leave/drop above. A FileDropZone consumes file drops in its
+    // region (returns true) and ignores text/custom (lets them bubble).
+    bool accept_drag(const DropData& data, Point local) override;
+    void leave_drag() override;
+    bool accept_drop(const DropData& data, Point local) override;
 
     float intrinsic_height() const override { return 120.0f; }
 

--- a/core/view/src/drag_drop.cpp
+++ b/core/view/src/drag_drop.cpp
@@ -3,16 +3,17 @@
 // Platform backends (SDL3 standalone drop events, Windows IDropTarget, Linux
 // XDND, macOS NSDraggingDestination) extract the dropped payload into a DropData
 // and a root-space point, then call these to route it into the view tree. The
-// target-resolution + local-coordinate walk + handler-bubble mirror
-// View::simulate_click (core/view/src/view.cpp) so drops land on the same view a
-// click at that point would.
+// target-resolution + local-coordinate walk mirror View::simulate_click
+// (core/view/src/view.cpp) so drops land on the same view a click would.
 //
-// Platform-specific *capture* lives in the per-OS backends; this file is the one
-// shared place that understands the Pulp view tree, so it compiles everywhere.
+// Resolution is generic: it knows about the DropReceiver interface and the
+// View::on_drop std::function, never a concrete widget — so new drop-aware
+// widgets just implement DropReceiver. Platform-specific *capture* lives in the
+// per-OS backends; this file is the one shared place that understands the view
+// tree, so it compiles everywhere.
 
 #include <pulp/view/drag_drop.hpp>
 
-#include <pulp/view/file_drop_zone.hpp>
 #include <pulp/view/view.hpp>
 
 namespace pulp::view {
@@ -33,35 +34,10 @@ Point to_local(View& root, View* target, Point root_pos) {
     return local;
 }
 
-// Nearest ancestor (inclusive of `target`, bounded by `root`) with a generic
-// View::on_drop handler. nullptr if none.
-View* find_drop_handler(View& root, View* target) {
-    View* v = target;
-    while (v) {
-        if (v->on_drop) return v;
-        if (v == &root) break;
-        v = v->parent();
-    }
-    return nullptr;
-}
-
-// Nearest FileDropZone ancestor (inclusive of `target`, bounded by `root`).
-FileDropZone* find_drop_zone(View& root, View* target) {
-    View* v = target;
-    while (v) {
-        if (auto* zone = dynamic_cast<FileDropZone*>(v)) return zone;
-        if (v == &root) break;
-        v = v->parent();
-    }
-    return nullptr;
-}
-
 // Fire View::on_drop with the (type, data, x, y) string contract. A multi-file
 // drop fires once per path (matches the JS-bridge expectation of one callback
 // invocation per dropped item).
-void fire_view_on_drop(View& root, View* handler, const DropData& data,
-                       Point root_pos) {
-    const Point local = to_local(root, handler, root_pos);
+void fire_view_on_drop(Point local, View* handler, const DropData& data) {
     switch (data.type) {
         case DropData::Type::files:
             for (const auto& path : data.file_paths)
@@ -77,10 +53,31 @@ void fire_view_on_drop(View& root, View* handler, const DropData& data,
 }
 
 void clear_hover(DragSession& session) {
-    if (session.hover_zone) {
-        session.hover_zone->drag_leave();
-        session.hover_zone = nullptr;
+    if (session.hover) {
+        session.hover->leave_drag();
+        session.hover = nullptr;
     }
+}
+
+// Walk from the hit target up to `root` and return the first DropReceiver that
+// claims the drag via accept_drag (idempotent; sets its own highlight). nullptr
+// if none. `target` must be non-null.
+DropReceiver* find_drag_receiver(View& root, View* target, const DropData& data,
+                                 Point root_pos) {
+    for (View* v = target; v; v = (v == &root ? nullptr : v->parent())) {
+        if (auto* r = dynamic_cast<DropReceiver*>(v)) {
+            if (r->accept_drag(data, to_local(root, v, root_pos))) return r;
+        }
+    }
+    return nullptr;
+}
+
+// True if some View::on_drop handler sits at or above `target` (bounded by root).
+bool has_on_drop_handler(View& root, View* target) {
+    for (View* v = target; v; v = (v == &root ? nullptr : v->parent())) {
+        if (v->on_drop) return true;
+    }
+    return false;
 }
 
 }  // namespace
@@ -93,17 +90,15 @@ bool dispatch_drag_enter(View& root, DragSession& session, const DropData& data,
         return false;
     }
 
-    // Hover visuals only apply to file drags over a FileDropZone.
-    FileDropZone* zone = (data.type == DropData::Type::files)
-                             ? find_drop_zone(root, target)
-                             : nullptr;
-    if (zone != session.hover_zone) {
-        clear_hover(session);
-        session.hover_zone = zone;
-        if (session.hover_zone) session.hover_zone->drag_enter(data.file_paths);
+    DropReceiver* found = find_drag_receiver(root, target, data, root_pos);
+    if (found != session.hover) {
+        // leave the previously-highlighted receiver; `found` (if any) already
+        // highlighted itself via accept_drag during the search.
+        if (session.hover) session.hover->leave_drag();
+        session.hover = found;
     }
 
-    return zone != nullptr || find_drop_handler(root, target) != nullptr;
+    return found != nullptr || has_on_drop_handler(root, target);
 }
 
 void dispatch_drag_move(View& root, DragSession& session, const DropData& data,
@@ -124,25 +119,20 @@ bool dispatch_drop(View& root, DragSession& session, const DropData& data,
     View* target = root.hit_test(root_pos);
     if (!target) return false;  // dropped outside the window
 
-    bool handled = false;
-
-    // FileDropZone gets the typed paths (extension validation + visual reset live
-    // in FileDropZone::drop) for file drops.
-    if (data.type == DropData::Type::files) {
-        if (auto* zone = find_drop_zone(root, target)) {
-            zone->drop(data.file_paths);
-            handled = true;
+    // First-handler-wins: walk deepest→root; at each view try the DropReceiver
+    // surface first, then the View::on_drop convenience surface. The first that
+    // consumes the drop ends the walk (no double-dispatch).
+    for (View* v = target; v; v = (v == &root ? nullptr : v->parent())) {
+        const Point local = to_local(root, v, root_pos);
+        if (auto* r = dynamic_cast<DropReceiver*>(v)) {
+            if (r->accept_drop(data, local)) return true;
+        }
+        if (v->on_drop) {
+            fire_view_on_drop(local, v, data);
+            return true;
         }
     }
-
-    // Generic View::on_drop — the surface the JS bridge wires. A view can carry
-    // both (a FileDropZone subclass with its own on_drop), so fire both.
-    if (auto* handler = find_drop_handler(root, target)) {
-        fire_view_on_drop(root, handler, data, root_pos);
-        handled = true;
-    }
-
-    return handled;
+    return false;
 }
 
 }  // namespace pulp::view

--- a/core/view/src/file_drop_zone.cpp
+++ b/core/view/src/file_drop_zone.cpp
@@ -54,6 +54,22 @@ void FileDropZone::drop(const std::vector<std::string>& paths) {
     if (!valid.empty() && on_drop) on_drop(valid);
 }
 
+// ── DropReceiver (drop-dispatch core routes through these) ────────────────────
+
+bool FileDropZone::accept_drag(const DropData& data, Point /*local*/) {
+    if (data.type != DropData::Type::files) return false;  // let text/custom bubble
+    drag_enter(data.file_paths);
+    return true;  // claim the hover (drives highlight)
+}
+
+void FileDropZone::leave_drag() { drag_leave(); }
+
+bool FileDropZone::accept_drop(const DropData& data, Point /*local*/) {
+    if (data.type != DropData::Type::files) return false;  // let text/custom bubble
+    drop(data.file_paths);
+    return true;  // the zone owns file drops in its region (consumes the drop)
+}
+
 void FileDropZone::paint(canvas::Canvas& canvas) {
     auto b = local_bounds();
 

--- a/core/view/src/sdl_window_host.cpp
+++ b/core/view/src/sdl_window_host.cpp
@@ -103,11 +103,11 @@ public:
                     // dispatch core (drag_drop.cpp).
                     case SDL_EVENT_DROP_BEGIN:
                         pending_drop_files_.clear();
-                        pending_drop_pos_ = {event.drop.x, event.drop.y};
+                        pending_drop_pos_ = window_to_root(event.drop.x, event.drop.y);
                         break;
                     case SDL_EVENT_DROP_FILE:
                         if (event.drop.data) pending_drop_files_.emplace_back(event.drop.data);
-                        pending_drop_pos_ = {event.drop.x, event.drop.y};
+                        pending_drop_pos_ = window_to_root(event.drop.x, event.drop.y);
                         break;
                     case SDL_EVENT_DROP_TEXT:
                         if (event.drop.data) {
@@ -115,7 +115,7 @@ public:
                             d.type = DropData::Type::text;
                             d.text = event.drop.data;
                             dispatch_drop(root_, drag_session_, d,
-                                          {event.drop.x, event.drop.y});
+                                          window_to_root(event.drop.x, event.drop.y));
                             needs_repaint_ = true;
                         }
                         break;
@@ -128,7 +128,7 @@ public:
                             d.type = DropData::Type::files;
                             d.file_paths = pending_drop_files_;
                             dispatch_drag_move(root_, drag_session_, d,
-                                               {event.drop.x, event.drop.y});
+                                               window_to_root(event.drop.x, event.drop.y));
                             needs_repaint_ = true;
                         }
                         break;
@@ -218,6 +218,16 @@ private:
 
     std::shared_ptr<DispatcherQueueState> dispatcher_queue_;
     events::MainThreadDispatcher::Token dispatcher_token_ = 0;
+
+    // Map SDL window coordinates → root-view coordinates. The single chokepoint
+    // for all drop-event coords. render_frame() lays the root tree out at the
+    // full window size with no design-viewport / HiDPI scale, so this is identity
+    // today. When the SDL host gains a design-viewport or per-monitor scale
+    // (W8/L9 HiDPI), apply that inverse transform HERE — and route mouse events
+    // through the same helper — so drops keep landing under the cursor.
+    Point window_to_root(float window_x, float window_y) const {
+        return {window_x, window_y};
+    }
 
     void register_dispatcher() {
         shutdown_dispatcher();

--- a/test/test_drag_drop.cpp
+++ b/test/test_drag_drop.cpp
@@ -310,3 +310,50 @@ TEST_CASE("independent DragSessions do not share hover state", "[view][dnd]") {
     CHECK(za->is_drag_over());
     CHECK_FALSE(zb->is_drag_over());
 }
+
+TEST_CASE("first-handler-wins: a DropReceiver consumes the drop, ancestor "
+          "on_drop does not also fire", "[view][dnd]") {
+    // A FileDropZone nested inside a View with on_drop set: the zone (a
+    // DropReceiver) consumes the file drop, so the ancestor's on_drop must NOT
+    // also fire (no double-dispatch).
+    View root;
+    root.set_bounds({0, 0, 300, 300});
+    int ancestor_fires = 0;
+    root.on_drop = [&](const std::string&, const std::string&, float, float) {
+        ++ancestor_fires;
+    };
+    auto zone_owned = std::make_unique<FileDropZone>();
+    FileDropZone* zone = zone_owned.get();
+    zone->set_bounds({0, 0, 300, 300});
+    int zone_fires = 0;
+    zone->on_drop = [&](const std::vector<std::string>&) { ++zone_fires; };
+    root.add_child(std::move(zone_owned));
+
+    DragSession session;
+    REQUIRE(dispatch_drop(root, session, make_files({"/a.wav"}), {10, 10}));
+    CHECK(zone_fires == 1);
+    CHECK(ancestor_fires == 0);  // consumed by the zone, did not bubble
+}
+
+TEST_CASE("a drop a DropReceiver declines bubbles to View::on_drop",
+          "[view][dnd]") {
+    // FileDropZone declines text drops (accept_drop returns false for non-file),
+    // so a text drop over the zone falls through to the ancestor's on_drop.
+    View root;
+    root.set_bounds({0, 0, 300, 300});
+    std::string got_type;
+    root.on_drop = [&](const std::string& t, const std::string&, float, float) {
+        got_type = t;
+    };
+    auto zone_owned = std::make_unique<FileDropZone>();
+    FileDropZone* zone = zone_owned.get();
+    zone->set_bounds({0, 0, 300, 300});
+    bool zone_fired = false;
+    zone->on_drop = [&](const std::vector<std::string>&) { zone_fired = true; };
+    root.add_child(std::move(zone_owned));
+
+    DragSession session;
+    REQUIRE(dispatch_drop(root, session, make_text("hi"), {10, 10}));
+    CHECK_FALSE(zone_fired);     // zone declines text
+    CHECK(got_type == "text");   // bubbled to the ancestor on_drop
+}


### PR DESCRIPTION
Code-health follow-up to #3638 (native drag-drop dispatch core), implementing all four should-fix items from the architectural review (tracked in #3645) plus a must-fix the Linux standalone-header lane caught right after #3638 merged.

## must-fix (Linux advisory lane was red on main after #3638)
- `drag_drop.hpp` used `std::vector<uint8_t>` (`DropData::custom_data`) without `<cstdint>`; the "Public headers compile standalone (Linux Clang)" lane flagged it. Added the include; verified the header compiles standalone.

## #2 + #1 — decouple the core from the concrete widget / unify the surfaces
- New **`DropReceiver`** interface (`accept_drag` / `leave_drag` / `accept_drop`). The dispatch core now finds receivers via `dynamic_cast` to the **interface**, so a new drop-aware widget needs **no change to the core** — that's the extension point.
- `FileDropZone` implements `DropReceiver` (delegating to its existing typed `drag_enter`/`drag_leave`/`drop`). The `dynamic_cast<FileDropZone*>` special-case is gone.
- `View::on_drop` stays the lightweight JS-bridge convenience surface; `DropTarget`/`register_drop_target` is now clearly documented as the **separate platform-NSView-registration layer** (converges into dispatch when macOS delivery lands — deferred).

## #3 — define the dispatch contract (no more double-dispatch)
- **First-handler-wins**: a single deepest→root pass; at each view, `DropReceiver` is tried before `View::on_drop`; the first consumer ends the walk. A zone consuming a file drop no longer *also* fires an ancestor `on_drop`. A drop a receiver declines (e.g. text over a FileDropZone) bubbles to `on_drop`. Locked by two new tests.

## #4 — coordinate-transform seam
- All SDL drop coords now route through a single `window_to_root()` helper (identity today; documented as the one place to apply the inverse transform when W8/L9 HiDPI / design-viewport scale lands, alongside mouse routing).

`DragSession` now tracks a `DropReceiver*` (was `FileDropZone*`). `pulp-test-dnd`: **17 cases / 63 assertions**, green; `pulp-view` builds clean; `drag_drop.hpp` verified self-contained.

Part of the Win/Linux platform parity epic (#3329). Closes the review items in #3645.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies native drag-and-drop on a new `DropReceiver` interface with a first-handler-wins dispatch, and fixes Linux header self-containment in `drag_drop.hpp`. SDL drop coordinates now go through a single `window_to_root()` seam; tests lock receiver vs `on_drop` behavior.

- **Refactors**
  - Introduced `DropReceiver` (`accept_drag`/`leave_drag`/`accept_drop`); `FileDropZone` implements it, and `DragSession` now tracks a `DropReceiver*`.
  - Defined dispatch: walk deepest→root; try `DropReceiver` first, then `View::on_drop`; first consumer wins (no double-dispatch). Added tests for consume and bubble-on-decline.
  - Routed all SDL `SDL_EVENT_DROP_*` coords through `window_to_root()` for a single drop-coordinate seam.
  - Documented `DropTarget`/`register_drop_target` as the platform-registration layer, separate from view-tree dispatch.

- **Bug Fixes**
  - Added `<cstdint>` to `drag_drop.hpp` to keep public headers self-contained on Linux (Clang).

<sup>Written for commit 1358bb7f7de9720891001b9e7f8c4e15193a5abf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

