### PR TITLE
ci(audio): compile JACK in Linux CI + open/start/stop smoke (L5b)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -600,6 +600,7 @@ jobs:
             libfontconfig1-dev \
             libgbm-dev \
             libgl1-mesa-dev \
+            libjack-jackd2-dev \
             libx11-dev \
             libxext-dev \
             libxfixes-dev \

--- a/test/test_jack_device.cpp
+++ b/test/test_jack_device.cpp
@@ -20,6 +20,10 @@
 #include <pulp/audio/device.hpp>
 #include "../core/audio/platform/linux/jack_device.hpp"
 
+#include <atomic>
+#include <chrono>
+#include <thread>
+
 using namespace pulp::audio;
 using namespace pulp::audio::linux_platform;
 
@@ -71,6 +75,49 @@ TEST_CASE("JACK: default in/out devices mirror the enumerated server",
     REQUIRE(in.id == enumerated.front().id);
     REQUIRE(out.is_default_output);
     REQUIRE(in.is_default_input);
+}
+
+// L5b smoke: open + start + stop a JACK device for real, but ONLY when a JACK
+// server is actually reachable. In CI there is usually no jackd, so this skips
+// cleanly (the build.yml Linux lane installs libjack so the TU still compiles +
+// the enumeration contract above always runs — that is the regression guard for
+// the L5a-class build break). On a JACK-enabled host (e.g. the tartci VM with
+// `jackd -d dummy`) it proves the server drives our process callback.
+TEST_CASE("JACK: open/start/stop round-trip when a server is reachable",
+          "[audio][jack][issue-3327]") {
+    if (!jack_is_available()) {
+        SUCCEED("no JACK server reachable — open smoke skipped");
+        return;
+    }
+
+    JackSystem sys;
+    auto dev = sys.create_device("jack");
+    REQUIRE(dev != nullptr);
+
+    DeviceConfig cfg;
+    cfg.output_channels = 2;
+    cfg.input_channels = 0;  // JACK supplies the real SR + buffer size
+    REQUIRE(dev->open(cfg));
+    REQUIRE(dev->is_open());
+    CHECK(dev->sample_rate() > 0.0);
+    CHECK(dev->buffer_size() > 0);
+
+    std::atomic<int> callbacks{0};
+    REQUIRE(dev->start([&](const BufferView<const float>&,
+                           BufferView<float>& out,
+                           const CallbackContext&) {
+        for (std::size_t ch = 0; ch < out.num_channels(); ++ch)
+            for (float& s : out.channel(ch)) s = 0.0f;  // silence
+        callbacks.fetch_add(1, std::memory_order_relaxed);
+    }));
+    REQUIRE(dev->is_running());
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    dev->stop();
+    dev->close();
+    CHECK_FALSE(dev->is_running());
+    CHECK(callbacks.load() > 0);  // the server delivered ≥1 process cycle
 }
 
 #else  // not (Linux && JACK)


### PR DESCRIPTION
**L5b** — the JACK smoke/CI lane (the channel-cap half shipped in L5a, #3495). Closes the L5 JACK item.

## What
- Add `libjack-jackd2-dev` to the Linux `build.yml` deps → pkg-config finds JACK, `PULP_JACK_AVAILABLE` turns on, the JACK TU is compiled and `pulp-test-jack-device` runs in CI. **This is the regression guard for the L5a-class build break** (`enumerate_devices()` wrote non-existent `DeviceInfo` fields — it only failed on a JACK-enabled configure, which CI never had until now).
- Add a server-optional **open/start/stop smoke** to `test_jack_device.cpp`: skips cleanly via `jack_is_available()` when no `jackd` is reachable (the CI case), and on a JACK host proves `create_device → open → start → (server drives the process callback) → stop → close`.

## Verified
On a tartci Linux VM with `jackd -d dummy`: JACK TU compiles against libjack, enumerate contract passes, open smoke runs the full round-trip (`JACK: connected as 'pulp' at 48000 Hz, 2 out`, callback fired) — **25 assertions / 4 cases**. Without a server: 17 / 4 (open smoke skipped) — matching the CI path. `actionlint` clean on `build.yml`.

Part of the Win/Linux platform parity epic (#3329).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiles the JACK backend in Linux CI and adds a server-optional open/start/stop smoke test to catch regressions in the JACK path. This enables JACK TU compilation in CI and verifies the process callback when a server is present.

- **New Features**
  - Install `libjack-jackd2-dev` in the Linux workflow so pkg-config finds JACK; compiles the JACK TU and runs `pulp-test-jack-device`.
  - Add a smoke test that skips cleanly when no JACK server is reachable and, when available, verifies create → open → start → process callback → stop → close.

<sup>Written for commit f320f67a26a95e2160aac61efce6c9421256a7e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

