### PR TITLE
feat(view): deliver macOS native drops into the dispatch core (#3645)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.382.1
+    VERSION 0.383.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/platform/mac/drag_drop_mac.mm
+++ b/core/view/platform/mac/drag_drop_mac.mm
@@ -4,33 +4,30 @@
 #import <Cocoa/Cocoa.h>
 #include <unordered_map>
 
-// Store active drop targets
+// macOS native drag-drop delivery.
+//
+// Two layers live here, both for the macOS NSView host:
+//   1. The legacy register_drop_target / DropTarget registration API (kept for
+//      source compatibility; see the note in drag_drop.hpp).
+//   2. The real delivery path: an NSDraggingDestination category on PulpView
+//      (the host's content NSView) that extracts the pasteboard payload and
+//      routes it into the cross-platform view-tree dispatch core
+//      (dispatch_drag_*/dispatch_drop in drag_drop.cpp) — the same core the SDL
+//      standalone host uses. PulpView registers for dragged types in its init
+//      (window_host_mac.mm); this file implements what happens when a drag
+//      arrives.
+
+// Store active legacy drop targets (DropTarget registration path).
 static std::unordered_map<void*, pulp::view::DropTarget*> g_drop_targets;
-
-// ── PulpDropView: handles NSDraggingDestination ──────────────────────────────
-
-@interface PulpDropHelper : NSObject
-+ (void)registerView:(NSView*)view;
-@end
-
-@implementation PulpDropHelper
-
-+ (void)registerView:(NSView*)view {
-    [view registerForDraggedTypes:@[
-        NSPasteboardTypeFileURL,
-        NSPasteboardTypeString
-    ]];
-}
-
-@end
 
 namespace pulp::view {
 
+// Translate an NSDraggingInfo pasteboard into a DropData (files take priority
+// over text, matching the SDL producer's file/text split).
 static DropData extract_drop_data(id<NSDraggingInfo> info) {
     DropData data;
     NSPasteboard* pb = [info draggingPasteboard];
 
-    // Check for file URLs
     NSArray<NSURL*>* urls = [pb readObjectsForClasses:@[[NSURL class]]
                              options:@{NSPasteboardURLReadingFileURLsOnlyKey: @YES}];
     if (urls.count > 0) {
@@ -41,7 +38,6 @@ static DropData extract_drop_data(id<NSDraggingInfo> info) {
         return data;
     }
 
-    // Check for text
     NSString* text = [pb stringForType:NSPasteboardTypeString];
     if (text) {
         data.type = DropData::Type::text;
@@ -52,12 +48,105 @@ static DropData extract_drop_data(id<NSDraggingInfo> info) {
     return data;
 }
 
+// Per-view hover state for an in-flight drag (one active pointer per window).
+// Keyed by the PulpView pointer; entries are tiny and bounded by window count.
+static DragSession& mac_drag_session(const void* view) {
+    static std::unordered_map<const void*, DragSession> sessions;
+    return sessions[view];
+}
+
+}  // namespace pulp::view
+
+// PulpView's full @interface is private to window_host_mac.mm; redeclare the
+// slice this category needs. These property declarations must match that file
+// exactly (rootView + the design-viewport pointTransform used for input).
+@interface PulpView : NSView
+@property (nonatomic, assign) pulp::view::View* rootView;
+@property (nonatomic, copy) pulp::view::Point (^pointTransform)(pulp::view::Point);
+@end
+
+@interface PulpView (PulpDragDrop) <NSDraggingDestination>
+@end
+
+@implementation PulpView (PulpDragDrop)
+
+// Register the content view for file + text drags once it joins a window. Done
+// here (a category override of NSView's no-op) rather than in PulpView's init so
+// the host file (window_host_mac.mm) needs no change. PulpView does not define
+// this method, so this is the class's sole implementation; PulpMetalView inherits
+// it. Safe to call repeatedly — AppKit treats re-registration idempotently.
+- (void)viewDidMoveToWindow {
+    [super viewDidMoveToWindow];
+    if (self.window) {
+        [self registerForDraggedTypes:@[
+            NSPasteboardTypeFileURL,
+            NSPasteboardTypeString
+        ]];
+    }
+}
+
+// Convert a drag's window-space location into root-view coordinates, mirroring
+// PulpView's -localPoint: (NSView is not flipped → flip Y; then apply the
+// inverse design-viewport transform when one is set).
+- (pulp::view::Point)pulpDropPoint:(id<NSDraggingInfo>)sender {
+    NSPoint p = [self convertPoint:[sender draggingLocation] fromView:nil];
+    float viewHeight = static_cast<float>(self.bounds.size.height);
+    pulp::view::Point pt{static_cast<float>(p.x), viewHeight - static_cast<float>(p.y)};
+    if (self.pointTransform) pt = self.pointTransform(pt);
+    return pt;
+}
+
+- (NSDragOperation)draggingEntered:(id<NSDraggingInfo>)sender {
+    return [self draggingUpdated:sender];
+}
+
+- (NSDragOperation)draggingUpdated:(id<NSDraggingInfo>)sender {
+    if (!self.rootView) return NSDragOperationNone;
+    @autoreleasepool {
+        auto& session = pulp::view::mac_drag_session((__bridge void*)self);
+        auto data = pulp::view::extract_drop_data(sender);
+        bool accepted = pulp::view::dispatch_drag_enter(
+            *self.rootView, session, data, [self pulpDropPoint:sender]);
+        return accepted ? NSDragOperationCopy : NSDragOperationNone;
+    }
+}
+
+- (void)draggingExited:(id<NSDraggingInfo>)sender {
+    (void)sender;
+    if (!self.rootView) return;
+    pulp::view::dispatch_drag_exit(
+        *self.rootView, pulp::view::mac_drag_session((__bridge void*)self));
+}
+
+- (BOOL)prepareForDragOperation:(id<NSDraggingInfo>)sender {
+    (void)sender;
+    return YES;
+}
+
+- (BOOL)performDragOperation:(id<NSDraggingInfo>)sender {
+    if (!self.rootView) return NO;
+    @autoreleasepool {
+        auto& session = pulp::view::mac_drag_session((__bridge void*)self);
+        auto data = pulp::view::extract_drop_data(sender);
+        return pulp::view::dispatch_drop(*self.rootView, session, data,
+                                         [self pulpDropPoint:sender])
+                   ? YES
+                   : NO;
+    }
+}
+
+@end
+
+namespace pulp::view {
+
 bool register_drop_target(void* native_view, DropTarget& target) {
     @autoreleasepool {
         NSView* view = (__bridge NSView*)native_view;
         if (!view) return false;
-
-        [PulpDropHelper registerView:view];
+        [view registerForDraggedTypes:@[
+            NSPasteboardTypeFileURL,
+            NSPasteboardTypeString
+        ]];
         g_drop_targets[native_view] = &target;
         return true;
     }


### PR DESCRIPTION
macOS previously registered the content NSView for dragged types but **never delivered** — `extract_drop_data` was dead and `DropTarget::on_drop` was never called. This wires the real path so macOS uses the *same* cross-platform routing core as the SDL Win/Linux producer.

## What
- An `NSDraggingDestination` category on `PulpView` (the host content view) extracts the pasteboard payload and routes it through `dispatch_drag_*` / `dispatch_drop` (the shared core from #3638/#3647).
- **Zero changes to `window_host_mac.mm`** (which is hotspot-frozen at its ceiling): dragged-type registration lives in the category's `viewDidMoveToWindow` override (PulpView defines no such method).
- Coordinate conversion mirrors `PulpView::localPoint:` (Y-flip + inverse design-viewport `pointTransform`) so drops land under the cursor.
- Per-window hover via a `DragSession` keyed by the view (not a global). Legacy `register_drop_target`/`DropTarget` retained for source compat.

## Verification
Compiles + links on macOS. The ObjC `NSDraggingInfo` runtime path is manual-drag-only (not headless-testable); the routing logic it drives is covered by `pulp-test-dnd` (17 cases / 63 assertions, green). Closes the macOS half of #3645.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables macOS native drag-and-drop delivery by routing `NSView` drags through the shared dispatch core, matching Win/Linux behavior. Fixes drops not firing and ensures accurate cursor-aligned coordinates. Addresses #3645 (macOS).

- **New Features**
  - `NSDraggingDestination` category on `PulpView` extracts pasteboard and routes via `dispatch_drag_*` / `dispatch_drop`.
  - Drag-type registration in `viewDidMoveToWindow`; no changes to `window_host_mac.mm`.
  - Correct coordinate conversion (Y-flip + inverse design-viewport `pointTransform`).
  - Per-view `DragSession`; legacy `register_drop_target` / `DropTarget` retained.

<sup>Written for commit 314524fa04d904de44de5bd84702125ccd67de59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

