### PR TITLE
feat(audio): WASAPI exclusive-mode output via DeviceConfig::share_mode (W4a)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.387.4
+    VERSION 0.388.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/audio/include/pulp/audio/device.hpp
+++ b/core/audio/include/pulp/audio/device.hpp
@@ -23,6 +23,12 @@ struct DeviceInfo {
     bool is_default_output = false;
 };
 
+// WASAPI (Windows) sharing model. `shared` routes through the system audio
+// engine (default — coexists with other apps); `exclusive` takes sole ownership
+// of the endpoint for lower latency. Non-Windows backends (CoreAudio / ALSA /
+// JACK) ignore this and always use their native path.
+enum class ShareMode { shared, exclusive };
+
 // Configuration for opening a device
 struct DeviceConfig {
     std::string device_id;       // Empty = default device
@@ -30,6 +36,7 @@ struct DeviceConfig {
     int buffer_size = 256;
     int input_channels = 0;
     int output_channels = 2;
+    ShareMode share_mode = ShareMode::shared;  // Windows WASAPI only; see above
 };
 
 // Audio callback context — passed to the render function

--- a/core/audio/platform/win/wasapi_device.cpp
+++ b/core/audio/platform/win/wasapi_device.cpp
@@ -78,19 +78,26 @@ bool WasapiDevice::open(const DeviceConfig& config) {
         return false;
     }
 
-    // Initialize audio client in shared mode with event-driven buffering
-    hr = audio_client_->Initialize(
-        AUDCLNT_SHAREMODE_SHARED,
-        AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_NOPERSIST,
-        requested_duration,
-        0,  // periodicity (must be 0 for shared mode)
-        mix_format,
-        nullptr);  // session GUID
+    // Initialize: shared (system mixer) or exclusive (sole endpoint owner) per
+    // DeviceConfig::share_mode. Both run event-driven at the mix format.
+    if (config_.share_mode == ShareMode::exclusive) {
+        hr = initialize_exclusive_(mix_format);
+    } else {
+        hr = audio_client_->Initialize(
+            AUDCLNT_SHAREMODE_SHARED,
+            AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_NOPERSIST,
+            requested_duration,
+            0,  // periodicity (must be 0 for shared mode)
+            mix_format,
+            nullptr);  // session GUID
+    }
 
     CoTaskMemFree(mix_format);
 
     if (FAILED(hr)) {
-        runtime::log_error("WASAPI: could not initialize audio client (0x{:08x})", static_cast<unsigned>(hr));
+        runtime::log_error("WASAPI: could not initialize audio client ({} mode, 0x{:08x})",
+                           config_.share_mode == ShareMode::exclusive ? "exclusive" : "shared",
+                           static_cast<unsigned>(hr));
         close();
         return false;
     }
@@ -153,6 +160,53 @@ bool WasapiDevice::open(const DeviceConfig& config) {
         flow_ == eCapture ? "capture" : "render",
         info().name, config_.sample_rate, buffer_frames_, actual_channels_);
     return true;
+}
+
+HRESULT WasapiDevice::initialize_exclusive_(WAVEFORMATEX* fmt) {
+    // The device must accept this exact format exclusively (S_OK). A closest-
+    // match (S_FALSE) or unsupported result means the mix format can't be taken
+    // exclusively here — honest-fail so the caller can fall back to shared.
+    HRESULT hr = audio_client_->IsFormatSupported(
+        AUDCLNT_SHAREMODE_EXCLUSIVE, fmt, nullptr);
+    if (hr != S_OK) {
+        runtime::log_warn("WASAPI: mix format unsupported in exclusive mode "
+                          "(0x{:08x}); use shared mode", static_cast<unsigned>(hr));
+        return FAILED(hr) ? hr : AUDCLNT_E_UNSUPPORTED_FORMAT;
+    }
+
+    // Drive at the device's MINIMUM period for the lowest exclusive latency.
+    REFERENCE_TIME default_period = 0, min_period = 0;
+    hr = audio_client_->GetDevicePeriod(&default_period, &min_period);
+    if (FAILED(hr)) return hr;
+
+    REFERENCE_TIME period = min_period;
+    hr = audio_client_->Initialize(
+        AUDCLNT_SHAREMODE_EXCLUSIVE,
+        AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_NOPERSIST,
+        period, period, fmt, nullptr);
+
+    // MSDN-documented retry: an unaligned buffer size means we must read back
+    // the aligned frame count, recompute the period, and re-Activate a FRESH
+    // client (the failed one cannot be reused for a second Initialize).
+    if (hr == AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED) {
+        UINT32 aligned_frames = 0;
+        if (SUCCEEDED(audio_client_->GetBufferSize(&aligned_frames)) &&
+            aligned_frames > 0 && fmt->nSamplesPerSec > 0) {
+            period = static_cast<REFERENCE_TIME>(
+                static_cast<double>(REFTIMES_PER_SEC) / fmt->nSamplesPerSec *
+                    aligned_frames + 0.5);
+            audio_client_->Release();
+            audio_client_ = nullptr;
+            hr = device_->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
+                                   reinterpret_cast<void**>(&audio_client_));
+            if (FAILED(hr)) return hr;
+            hr = audio_client_->Initialize(
+                AUDCLNT_SHAREMODE_EXCLUSIVE,
+                AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_NOPERSIST,
+                period, period, fmt, nullptr);
+        }
+    }
+    return hr;
 }
 
 void WasapiDevice::close() {

--- a/core/audio/platform/win/wasapi_device.hpp
+++ b/core/audio/platform/win/wasapi_device.hpp
@@ -37,21 +37,18 @@ namespace pulp::audio::win {
 // Windows audio engine mixes; buffer size is requested in REFERENCE_TIME
 // units and rounded up to the engine's period.
 //
-// Modes **not** implemented today (intentionally deferred — see
-// planning/2026-05-24-reference-framework-gap-analysis.md row #302):
+// `AUDCLNT_SHAREMODE_EXCLUSIVE` is now also supported (W4), selected via
+// `DeviceConfig::share_mode == ShareMode::exclusive`: the endpoint is taken
+// exclusively at the device mix format (so the render/capture threads' existing
+// planar↔interleaved conversion still applies), driven at the device's minimum
+// period for low latency, with the documented AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED
+// re-activation retry. Shared mode stays the default.
 //
+// Still deferred (W4b follow-up):
 //   * `AUDCLNT_SHAREMODE_SHARED` low-latency variant
-//       (RATEADJUST + small periodicity via `IAudioClient3::InitializeSharedAudioStream`
-//        or AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM + AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY).
-//   * `AUDCLNT_SHAREMODE_EXCLUSIVE`
-//       (bypasses the engine; requires explicit format negotiation, lower
-//        latency, but conflicts with other applications and DAW workflows).
-//
-// Adding either mode means new public API surface
-// (`DeviceConfig::share_mode`, `DeviceConfig::exclusive`, etc.) and is
-// out of scope for the gap-doc audit slice. The fixture below pins the
-// current contract so a future "we added exclusive" change is forced to
-// update both code and tests in lockstep.
+//       (IAudioClient3::InitializeSharedAudioStream at the engine min period).
+//   * Transparent sample-rate-change / AUDCLNT_E_DEVICE_INVALIDATED recovery
+//       (today an invalidated stream stops cleanly; the host re-opens).
 class WasapiDevice : public AudioDevice {
 public:
     explicit WasapiDevice(IMMDevice* device, EDataFlow flow = eRender);
@@ -78,6 +75,12 @@ public:
 private:
     void render_thread_func();
     void capture_thread_func();
+
+    // Exclusive-mode Initialize on audio_client_ at `fmt`, driven at the device
+    // minimum period. Handles the AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED dance
+    // (re-Activate audio_client_ with the aligned period). Returns the final
+    // HRESULT; on success audio_client_ is initialized and event-driven.
+    HRESULT initialize_exclusive_(WAVEFORMATEX* fmt);
 
     IMMDevice*           device_         = nullptr;
     EDataFlow            flow_           = eRender;

--- a/test/test_wasapi_share_modes.cpp
+++ b/test/test_wasapi_share_modes.cpp
@@ -102,43 +102,57 @@ TEST_CASE("WASAPI mode coverage: AUDCLNT_SHAREMODE_SHARED is implemented",
     REQUIRE_FALSE(device->is_open());
 }
 
-TEST_CASE("WASAPI mode coverage: exclusive + low-latency are deferred — "
-          "no public API exposes them",
+TEST_CASE("WASAPI mode coverage: share_mode selector exists; exclusive is a "
+          "ShareMode value (W4)",
           "[audio][wasapi][share-mode][gap-doc][issue-302]") {
-    // The contract under audit: DeviceConfig today is share-mode-agnostic
-    // and the Windows backend hard-codes AUDCLNT_SHAREMODE_SHARED. If a
-    // future change adds an exclusive or shared-low-latency path, it
-    // must (a) extend DeviceConfig with the mode field and (b) update
-    // both this assertion and the wasapi_device.hpp header documentation.
-    //
-    // We pin the "no opt-in" contract by enumerating DeviceConfig's
-    // member set at compile-time-equivalent runtime — there is no
-    // `share_mode`, `exclusive`, or `low_latency` selector today, so the
-    // only mode the WASAPI backend can possibly use is shared.
-    DeviceConfig cfg;
-    cfg.sample_rate = 48000.0;
-    cfg.buffer_size = 256;
-
-    // These static_asserts pin the "no mode field" contract via SFINAE
-    // detection helpers. Adding such a field is the explicit signal to
-    // revisit this audit; the build fails until the assertion is
-    // updated alongside the new API.
+    // W4 added the opt-in: DeviceConfig::share_mode selects shared (default) or
+    // exclusive. There is deliberately no separate `exclusive` bool, and
+    // shared-low-latency (`low_latency` + IAudioClient3) is deferred to W4b.
     using cfg_t = pulp::audio::DeviceConfig;
-    static_assert(!has_share_mode_v<cfg_t>,
-                  "WASAPI gap-doc audit: DeviceConfig::share_mode added "
-                  "— extend the share-mode coverage test alongside the "
-                  "new API surface");
+    static_assert(has_share_mode_v<cfg_t>,
+                  "W4: DeviceConfig::share_mode is the selector");
     static_assert(!has_exclusive_v<cfg_t>,
-                  "WASAPI gap-doc audit: DeviceConfig::exclusive added "
-                  "— extend the share-mode coverage test alongside the "
-                  "new API surface");
+                  "exclusive is a ShareMode value, not a bool field");
     static_assert(!has_low_latency_v<cfg_t>,
-                  "WASAPI gap-doc audit: DeviceConfig::low_latency added "
-                  "— extend the share-mode coverage test alongside the "
-                  "new API surface");
+                  "shared-low-latency is deferred to W4b (IAudioClient3)");
 
-    SUCCEED("DeviceConfig exposes no share-mode/exclusive/low-latency "
-            "selector; WASAPI backend uses AUDCLNT_SHAREMODE_SHARED only");
+    DeviceConfig cfg;
+    CHECK(cfg.share_mode == ShareMode::shared);  // default preserved
+    cfg.share_mode = ShareMode::exclusive;
+    CHECK(cfg.share_mode == ShareMode::exclusive);
+    SUCCEED("DeviceConfig::share_mode opts into AUDCLNT_SHAREMODE_EXCLUSIVE");
+}
+
+TEST_CASE("WASAPI mode coverage: exclusive open succeeds or honest-fails "
+          "(never half-opens)",
+          "[audio][wasapi][share-mode][gap-doc][issue-302]") {
+    // Exclusive mode depends on the endpoint allowing it (the device's
+    // "Allow applications to take exclusive control" setting + format support).
+    // We can't guarantee it on an arbitrary CI host, so the contract we pin is:
+    // open() either fully succeeds (is_open + positive rate/buffer) or fully
+    // fails (NOT is_open) — it never leaves a half-initialised device.
+    WasapiSystem sys;
+    if (!has_default_render(sys)) {
+        SUCCEED("no default render endpoint on this host; skipping");
+        return;
+    }
+    auto device = sys.create_device("");
+    REQUIRE(device != nullptr);
+
+    DeviceConfig cfg;
+    cfg.output_channels = 2;
+    cfg.share_mode = ShareMode::exclusive;
+
+    if (device->open(cfg)) {
+        CHECK(device->is_open());
+        CHECK(device->buffer_size() > 0);
+        CHECK(device->sample_rate() > 0.0);
+        device->close();
+        CHECK_FALSE(device->is_open());
+    } else {
+        // Honest-fail path: exclusive disallowed / unsupported format here.
+        CHECK_FALSE(device->is_open());
+    }
 }
 
 TEST_CASE("WASAPI mode coverage: AUDCLNT_SHAREMODE_EXCLUSIVE on the same "
@@ -239,25 +253,29 @@ TEST_CASE("WASAPI mode coverage: AUDCLNT_SHAREMODE_EXCLUSIVE on the same "
 // on every platform — a stray member added on Windows will still trip
 // this test on macOS / Linux CI.
 
-TEST_CASE("WASAPI share-mode coverage: DeviceConfig API surface stays "
-          "share-mode-agnostic (cross-platform compile-time check)",
+TEST_CASE("WASAPI share-mode coverage: DeviceConfig exposes share_mode "
+          "(cross-platform compile-time check)",
           "[audio][wasapi][share-mode][gap-doc][issue-302]") {
     using cfg_t = pulp::audio::DeviceConfig;
-    static_assert(!has_share_mode_v<cfg_t>,
-                  "WASAPI gap-doc audit: DeviceConfig::share_mode added "
-                  "— extend the share-mode coverage test alongside the "
-                  "new API surface");
+    // W4: DeviceConfig::share_mode now exists (shared default + exclusive). The
+    // selector is a single enum field; there is intentionally NO separate
+    // `exclusive` bool or `low_latency` field — exclusive is a ShareMode value,
+    // and shared-low-latency (IAudioClient3) is a deferred W4b follow-up.
+    static_assert(has_share_mode_v<cfg_t>,
+                  "WASAPI W4: DeviceConfig::share_mode is the share-mode "
+                  "selector; keep this test in lockstep with the API");
     static_assert(!has_exclusive_v<cfg_t>,
-                  "WASAPI gap-doc audit: DeviceConfig::exclusive added "
-                  "— extend the share-mode coverage test alongside the "
-                  "new API surface");
+                  "WASAPI: exclusive is a ShareMode enum value, not a "
+                  "DeviceConfig::exclusive field — do not add a bool");
     static_assert(!has_low_latency_v<cfg_t>,
-                  "WASAPI gap-doc audit: DeviceConfig::low_latency added "
-                  "— extend the share-mode coverage test alongside the "
-                  "new API surface");
+                  "WASAPI: shared-low-latency (DeviceConfig::low_latency) is "
+                  "deferred to W4b; add it alongside the IAudioClient3 path");
+    static_assert(cfg_t{}.share_mode == pulp::audio::ShareMode::shared,
+                  "shared must remain the default so non-Windows backends and "
+                  "existing callers are unaffected");
 
-    SUCCEED("WASAPI runtime probes are Windows-only; DeviceConfig stays "
-            "share-mode-agnostic on every platform (shared mode only)");
+    SUCCEED("DeviceConfig::share_mode defaults to shared on every platform; "
+            "exclusive is honored only by the Windows WASAPI backend");
 }
 
 #endif


### PR DESCRIPTION
Adds the opt-in **exclusive WASAPI** path — the headline W4 gap (low-latency, sole endpoint ownership). Shared mode stays the default, so CoreAudio/ALSA/JACK and existing callers are unaffected.

## What
- `DeviceConfig` gains `ShareMode share_mode = ShareMode::shared` (cross-platform enum; non-Windows backends ignore it). Exclusive is a `ShareMode` value — no separate bool.
- WASAPI `open()` dispatches to `initialize_exclusive_()` when selected: takes the endpoint at the device mix format (so the render/capture threads' existing planar↔interleaved conversion still applies), drives at the device **minimum period** for low latency, and performs the MSDN `AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED` retry (read aligned frames → recompute period → re-Activate a fresh client). **Honest-fail** (returns false, device stays closed) when exclusive is disallowed / format unsupported — caller falls back to shared.

## Deferred to W4b
Shared low-latency (`IAudioClient3::InitializeSharedAudioStream`) + transparent `AUDCLNT_E_DEVICE_INVALIDATED` / sample-rate-change recovery.

## Verification
The `DeviceConfig` API + the cross-platform contract test (flipped from "no share_mode" to "share_mode present, shared default") **build + pass on macOS**; `pulp-audio` builds clean. The exclusive `Initialize` path is Windows-only — compile-verified on the **Windows MSVC gate** (I'm gating merge on it); a Windows runtime test pins the open-or-honest-fail contract (skips when no endpoint allows exclusive).

Part of #3329 (#3328 audio parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in WASAPI exclusive-mode output on Windows via `DeviceConfig::share_mode` for lower-latency playback with sole endpoint ownership. Shared mode stays the default; non-Windows backends are unchanged.

- **New Features**
  - Added `enum class ShareMode { shared, exclusive }` and `DeviceConfig::share_mode` (default `shared`); ignored by non-Windows backends.
  - WASAPI `open()` routes to `initialize_exclusive_()` when requested: uses the device mix format, drives at the device minimum period, and performs the MSDN `AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED` re-activation retry. Exclusive open honest-fails (returns false; device stays closed) when unsupported. Tests cover the selector default and the open-or-honest-fail contract.

- **Migration**
  - No changes required; shared mode remains the default.
  - To opt in on Windows: set `cfg.share_mode = ShareMode::exclusive`. Handle a possible false return from `open()` and fall back to shared.

<sup>Written for commit 5882fec72de2297489d9ceafec12c204507b8472. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

