### PR TITLE
refactor: migrate shader bridge API to registry helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.386.0
+    VERSION 0.386.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/widget_bridge/shader_api.cpp
+++ b/core/view/src/widget_bridge/shader_api.cpp
@@ -1,15 +1,18 @@
 // widget_bridge/shader_api.cpp - shader registrations for WidgetBridge.
 
 #include <pulp/view/widget_bridge.hpp>
+#include "api_registry.hpp"
 
 #include <string>
 
 namespace pulp::view {
 
 void WidgetBridge::register_shader_widget_api() {
+    BridgeApiContext api{engine_};
+
     // compileShader(sksl_code) -> {success: bool, error: string}
     // Validates SkSL shader code by actually compiling via SkRuntimeEffect.
-    engine_.register_function("compileShader", [](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "compileShader", [](choc::javascript::ArgumentList args) {
         auto code = args.get<std::string>(0, "");
         auto result = choc::value::createObject("");
         if (code.empty()) {
@@ -24,7 +27,7 @@ void WidgetBridge::register_shader_widget_api() {
     });
 
     // setWidgetShader(id, skslCode) -> apply custom GPU shader to widget body.
-    engine_.register_function("setWidgetShader", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setWidgetShader", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto sksl = args.get<std::string>(1, "");
         auto* v = widget(id);
@@ -37,7 +40,7 @@ void WidgetBridge::register_shader_widget_api() {
     });
 
     // clearWidgetShader(id) -> remove custom shader, restore default paint.
-    engine_.register_function("clearWidgetShader", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "clearWidgetShader", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto* v = widget(id);
         if (!v) return choc::value::Value();
@@ -51,9 +54,11 @@ void WidgetBridge::register_shader_widget_api() {
 }
 
 void WidgetBridge::register_shader_canvas_api() {
+    BridgeApiContext api{engine_};
+
     // WebGPU shader: applyShader(canvasId, skslCode) -> applies a custom shader to canvas.
     // Uses the existing Skia/Dawn pipeline; SkSL shaders compile at runtime.
-    engine_.register_function("applyShader", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "applyShader", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto code = args.get<std::string>(1, "");
         auto* v = widget(id);


### PR DESCRIPTION
## Summary
- migrate the shader WidgetBridge registrations to the shared API registry helper
- keep bridge names, manifest entries, and handler behavior unchanged
- include the SDK version bump generated by Shipyard

## Validation
- cmake -S . -B build-gpu-off -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=OFF
- cmake --build build-gpu-off --target pulp-test-widget-bridge-api-contracts pulp-test-widget-bridge pulp-test-widget-bridge-animation
- ./build-gpu-off/test/pulp-test-widget-bridge-api-contracts '[view][widget-bridge][api-contract]'\n- ./build-gpu-off/test/pulp-test-widget-bridge '*applyShader*'\n- ./build-gpu-off/test/pulp-test-widget-bridge-animation '*Shader*'\n- git diff --check\n- python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce\n- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report\n\n## Shipping note\nShipyard applied and committed the version bump, then stopped because all local/SSH targets were deliberately skipped on this machine; the normal local mac target enters a GPU/examples validation path that is not usable from this fresh worktree without the Skia/Three.js cache. The branch was pushed directly after focused Release validation and clean pre-push gates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated shader bridge APIs to the shared registry helper (`BridgeApiContext` + `register_bridge_function`) to unify registration and reduce boilerplate. Kept names and behavior unchanged for `compileShader`, `setWidgetShader`, `clearWidgetShader`, and `applyShader`; bumped version to 0.386.1.

<sup>Written for commit 4e147e45ab0eb783a7ed64539580d27699bfd575. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

