### PR TITLE
refactor: migrate metadata bridge API to registry helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.386.0
+    VERSION 0.386.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/widget_bridge/metadata_api.cpp
+++ b/core/view/src/widget_bridge/metadata_api.cpp
@@ -1,6 +1,7 @@
 // widget_bridge/metadata_api.cpp - metadata registrations for WidgetBridge.
 
 #include <pulp/view/widget_bridge.hpp>
+#include "api_registry.hpp"
 
 #include <string>
 #include <unordered_map>
@@ -27,8 +28,10 @@ void erase_widget_subtree(std::unordered_map<std::string, View*>& widgets, View*
 } // namespace
 
 void WidgetBridge::register_metadata_removal_api() {
+    BridgeApiContext api{engine_};
+
     // removeWidget(id)
-    engine_.register_function("removeWidget", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "removeWidget", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         if (auto* w = widget(id)) {
             View* parent = w->parent();
@@ -42,14 +45,16 @@ void WidgetBridge::register_metadata_removal_api() {
 }
 
 void WidgetBridge::register_metadata_source_api() {
-    engine_.register_function("setAnchor", [this](choc::javascript::ArgumentList args) {
+    BridgeApiContext api{engine_};
+
+    register_bridge_function(api, "setAnchor", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto anchor = args.get<std::string>(1, "");
         if (auto* v = widget(id)) v->set_anchor_id(std::move(anchor));
         return choc::value::Value();
     });
 
-    engine_.register_function("setSource", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setSource", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto file = args.get<std::string>(1, "");
         auto line = static_cast<int>(args.get<double>(2, 0.0));
@@ -62,8 +67,10 @@ void WidgetBridge::register_metadata_source_api() {
 }
 
 void WidgetBridge::register_metadata_computed_api() {
+    BridgeApiContext api{engine_};
+
     // getComputedValue(id, prop) -> string
-    engine_.register_function("getComputedValue", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "getComputedValue", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto prop = args.get<std::string>(1, "");
         auto* v = widget(id);


### PR DESCRIPTION
## Summary
- migrate metadata WidgetBridge APIs to register through BridgeApiContext/register_bridge_function
- keep behavior unchanged for removeWidget, setAnchor, setSource, and getComputedValue
- include Shipyard SDK patch bump to 0.385.1

## Validation
- cmake -S . -B build-gpu-off -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=OFF
- cmake --build build-gpu-off --target pulp-test-widget-bridge-api-contracts pulp-test-widget-bridge pulp-test-widget-bridge-animation pulp-test-web-compat-events -j28
- ./build-gpu-off/test/pulp-test-widget-bridge-api-contracts '[view][widget-bridge][api-contract]'
- ./build-gpu-off/test/pulp-test-widget-bridge '*setAnchor*'
- ./build-gpu-off/test/pulp-test-widget-bridge-animation '*removeWidget*'
- ./build-gpu-off/test/web-compat/pulp-test-web-compat-events '*removeWidget*'
- git diff --check
- python3 tools/scripts/compat_sync_check.py --enforce
- python3 tools/scripts/version_bump_check.py --mode=report

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated WidgetBridge metadata API registration to the registry helper to standardize bridge function wiring. Behavior is unchanged for `removeWidget`, `setAnchor`, `setSource`, and `getComputedValue`.

- **Refactors**
  - Replaced `engine_.register_function(...)` with `register_bridge_function(...)` and included `api_registry.hpp`.
  - Created a local `BridgeApiContext api{engine_}` in each registration method.

- **Dependencies**
  - Bumped project version to 0.386.1.

<sup>Written for commit d546c3ddfd453637f59ab2e4898a8a92ea559651. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

