### PR TITLE
refactor: migrate outline bridge API to registry helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.386.0
+    VERSION 0.386.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/widget_bridge/outline_api.cpp
+++ b/core/view/src/widget_bridge/outline_api.cpp
@@ -1,6 +1,7 @@
 // widget_bridge/outline_api.cpp - outline style registrations for WidgetBridge.
 
 #include <pulp/view/widget_bridge.hpp>
+#include "api_registry.hpp"
 
 #include <cctype>
 #include <functional>
@@ -10,6 +11,7 @@
 namespace pulp::view {
 
 void WidgetBridge::register_widget_outline_api(std::function<canvas::Color(const std::string&)> parse_color) {
+    BridgeApiContext api{engine_};
     auto parseHexColor = std::move(parse_color);
 
     // pulp #1519 - CSS / RN outline cluster. Outline is paint-time only:
@@ -25,7 +27,7 @@ void WidgetBridge::register_widget_outline_api(std::function<canvas::Color(const
     // setBackground / setBorderColor (#hex / rgb() / named), plus the
     // CSS `currentColor` keyword which resolves to the View's text
     // color via the inheritable cascade (#1710).
-    engine_.register_function("setOutlineColor", [this, parseHexColor](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setOutlineColor", [this, parseHexColor](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto hex = args.get<std::string>(1, "");
         auto* v = id.empty() ? &root_ : widget(id);
@@ -58,7 +60,7 @@ void WidgetBridge::register_widget_outline_api(std::function<canvas::Color(const
     });
 
     // setOutlineOffset(id, px) - gap between border-box edge and outline.
-    engine_.register_function("setOutlineOffset", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setOutlineOffset", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto offset = static_cast<float>(args.get<double>(1, 0.0));
         auto* v = id.empty() ? &root_ : widget(id);
@@ -69,7 +71,7 @@ void WidgetBridge::register_widget_outline_api(std::function<canvas::Color(const
     // setOutlineStyle(id, "solid"|"dashed"|...) - same keyword set as
     // setBorderStyle. Reuses View::BorderStyle since the CSS spec lists
     // the same line-style values for both properties.
-    engine_.register_function("setOutlineStyle", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setOutlineStyle", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto s = args.get<std::string>(1, "solid");
         auto* v = id.empty() ? &root_ : widget(id);
@@ -89,7 +91,7 @@ void WidgetBridge::register_widget_outline_api(std::function<canvas::Color(const
 
     // setOutlineWidth(id, px) - outline stroke thickness. width<=0 or
     // outline_style==none/hidden short-circuits the paint.
-    engine_.register_function("setOutlineWidth", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setOutlineWidth", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto width = static_cast<float>(args.get<double>(1, 0.0));
         auto* v = id.empty() ? &root_ : widget(id);


### PR DESCRIPTION
## Summary
- migrate outline WidgetBridge APIs to register through BridgeApiContext/register_bridge_function
- keep behavior unchanged for setOutlineColor, setOutlineOffset, setOutlineStyle, and setOutlineWidth
- include Shipyard SDK patch bump to 0.385.1

## Validation
- cmake -S . -B build-gpu-off -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=OFF
- cmake --build build-gpu-off --target pulp-test-widget-bridge-api-contracts pulp-test-widget-bridge-rn-outline pulp-test-widget-bridge-wave5-css pulp-test-view-corner-radius -j28
- ./build-gpu-off/test/pulp-test-widget-bridge-api-contracts '[view][widget-bridge][api-contract]'
- ./build-gpu-off/test/pulp-test-widget-bridge-rn-outline
- ./build-gpu-off/test/pulp-test-widget-bridge-wave5-css '*outline*'
- ./build-gpu-off/test/pulp-test-view-corner-radius '*outline*'
- git diff --check
- python3 tools/scripts/compat_sync_check.py --enforce
- python3 tools/scripts/version_bump_check.py --mode=report

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated WidgetBridge outline API registration to the registry helper for consistent bridge function handling. Behavior is unchanged for outline methods; project version bumped to 0.386.1.

- **Refactors**
  - Switched to `BridgeApiContext` and `register_bridge_function` for `setOutlineColor`, `setOutlineOffset`, `setOutlineStyle`, and `setOutlineWidth`.
  - Added `api_registry.hpp` and initialized `BridgeApiContext api{engine_};`.

- **Dependencies**
  - Bumped `Pulp` to `0.386.1`.

<sup>Written for commit 6a37c7019ad332b42a8d2182c60ed0c144058e7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

