### PR TITLE
refactor: migrate border-radius bridge API to registry helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.386.0
+    VERSION 0.386.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/widget_bridge/border_radius_api.cpp
+++ b/core/view/src/widget_bridge/border_radius_api.cpp
@@ -1,6 +1,7 @@
 // widget_bridge/border_radius_api.cpp - border radius style registrations for WidgetBridge.
 
 #include <pulp/view/widget_bridge.hpp>
+#include "api_registry.hpp"
 
 #include <string>
 #include <utility>
@@ -8,6 +9,8 @@
 namespace pulp::view {
 
 void WidgetBridge::register_widget_border_radius_api() {
+    BridgeApiContext api{engine_};
+
     // setBorderRadius(id, radius) - uniform corner radius. Per-corner
     // setters (setBorderTopLeftRadius / TopRight / BottomLeft / BottomRight)
     // override individual corners on top of the uniform value.
@@ -26,7 +29,7 @@ void WidgetBridge::register_widget_border_radius_api() {
         return {static_cast<float>(args.get<double>(idx, 0.0)), 0.0f};
     };
 
-    engine_.register_function("setBorderRadius", [this, parseRadiusArg](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setBorderRadius", [this, parseRadiusArg](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto [px, pct] = parseRadiusArg(args, 1);
         auto* v = id.empty() ? &root_ : widget(id);
@@ -46,7 +49,7 @@ void WidgetBridge::register_widget_border_radius_api() {
     // the View; paint_all() then routes background/border through the
     // per-corner path builder rather than fill_rounded_rect.
     // pulp #1663 - same %-string handling as setBorderRadius.
-    engine_.register_function("setBorderTopLeftRadius", [this, parseRadiusArg](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setBorderTopLeftRadius", [this, parseRadiusArg](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto [px, pct] = parseRadiusArg(args, 1);
         auto* v = id.empty() ? &root_ : widget(id);
@@ -56,7 +59,7 @@ void WidgetBridge::register_widget_border_radius_api() {
         return choc::value::Value();
     });
 
-    engine_.register_function("setBorderTopRightRadius", [this, parseRadiusArg](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setBorderTopRightRadius", [this, parseRadiusArg](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto [px, pct] = parseRadiusArg(args, 1);
         auto* v = id.empty() ? &root_ : widget(id);
@@ -66,7 +69,7 @@ void WidgetBridge::register_widget_border_radius_api() {
         return choc::value::Value();
     });
 
-    engine_.register_function("setBorderBottomLeftRadius", [this, parseRadiusArg](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setBorderBottomLeftRadius", [this, parseRadiusArg](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto [px, pct] = parseRadiusArg(args, 1);
         auto* v = id.empty() ? &root_ : widget(id);
@@ -76,7 +79,7 @@ void WidgetBridge::register_widget_border_radius_api() {
         return choc::value::Value();
     });
 
-    engine_.register_function("setBorderBottomRightRadius", [this, parseRadiusArg](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setBorderBottomRightRadius", [this, parseRadiusArg](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto [px, pct] = parseRadiusArg(args, 1);
         auto* v = id.empty() ? &root_ : widget(id);


### PR DESCRIPTION
## Summary
- migrate border-radius WidgetBridge APIs to register through BridgeApiContext/register_bridge_function
- keep behavior unchanged for uniform and per-corner border-radius setters
- include Shipyard SDK patch bump to 0.385.1

## Validation
- cmake -S . -B build-gpu-off -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=OFF
- cmake --build build-gpu-off --target pulp-test-widget-bridge-api-contracts pulp-test-widget-bridge-rn-style pulp-test-widget-bridge-wave5-css pulp-test-view-corner-radius -j28
- ./build-gpu-off/test/pulp-test-widget-bridge-api-contracts '[view][widget-bridge][api-contract]'
- ./build-gpu-off/test/pulp-test-widget-bridge-rn-style '*BorderRadius*'
- ./build-gpu-off/test/pulp-test-widget-bridge-wave5-css '*borderRadius*'
- ./build-gpu-off/test/pulp-test-view-corner-radius '*corner*'
- git diff --check
- python3 tools/scripts/compat_sync_check.py --enforce
- python3 tools/scripts/version_bump_check.py --mode=report

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated WidgetBridge border-radius APIs to the registry helper using `BridgeApiContext` and `register_bridge_function` to unify registration while keeping behavior for uniform and per-corner setters unchanged. Bumps project version to 0.386.1.

<sup>Written for commit fbf9aefc3ae368722f5981e9226887d664c99f56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

