### PR TITLE
refactor: migrate border-side bridge API to registry helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.386.0
+    VERSION 0.386.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/widget_bridge/border_side_api.cpp
+++ b/core/view/src/widget_bridge/border_side_api.cpp
@@ -1,6 +1,7 @@
 // widget_bridge/border_side_api.cpp - per-side border style registrations for WidgetBridge.
 
 #include <pulp/view/widget_bridge.hpp>
+#include "api_registry.hpp"
 
 #include <functional>
 #include <optional>
@@ -10,6 +11,7 @@
 namespace pulp::view {
 
 void WidgetBridge::register_widget_border_side_api(std::function<canvas::Color(const std::string&)> parse_color) {
+    BridgeApiContext api{engine_};
     auto parseHexColor = std::move(parse_color);
 
     // pulp #1026 - Per-side border color/width shorthands (RN parity).
@@ -46,7 +48,7 @@ void WidgetBridge::register_widget_border_side_api(std::function<canvas::Color(c
         }
     };
 
-    engine_.register_function("setBorderTopColor", [this, parseHexColor, applyBorderSide](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setBorderTopColor", [this, parseHexColor, applyBorderSide](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto hex = args.get<std::string>(1, "");
         auto* v = id.empty() ? &root_ : widget(id);
@@ -54,7 +56,7 @@ void WidgetBridge::register_widget_border_side_api(std::function<canvas::Color(c
         return choc::value::Value();
     });
 
-    engine_.register_function("setBorderRightColor", [this, parseHexColor, applyBorderSide](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setBorderRightColor", [this, parseHexColor, applyBorderSide](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto hex = args.get<std::string>(1, "");
         auto* v = id.empty() ? &root_ : widget(id);
@@ -62,7 +64,7 @@ void WidgetBridge::register_widget_border_side_api(std::function<canvas::Color(c
         return choc::value::Value();
     });
 
-    engine_.register_function("setBorderBottomColor", [this, parseHexColor, applyBorderSide](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setBorderBottomColor", [this, parseHexColor, applyBorderSide](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto hex = args.get<std::string>(1, "");
         auto* v = id.empty() ? &root_ : widget(id);
@@ -70,7 +72,7 @@ void WidgetBridge::register_widget_border_side_api(std::function<canvas::Color(c
         return choc::value::Value();
     });
 
-    engine_.register_function("setBorderLeftColor", [this, parseHexColor, applyBorderSide](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setBorderLeftColor", [this, parseHexColor, applyBorderSide](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto hex = args.get<std::string>(1, "");
         auto* v = id.empty() ? &root_ : widget(id);
@@ -78,7 +80,7 @@ void WidgetBridge::register_widget_border_side_api(std::function<canvas::Color(c
         return choc::value::Value();
     });
 
-    engine_.register_function("setBorderTopWidth", [this, applyBorderSide](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setBorderTopWidth", [this, applyBorderSide](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto w = static_cast<float>(args.get<double>(1, 1.0));
         auto* v = id.empty() ? &root_ : widget(id);
@@ -86,7 +88,7 @@ void WidgetBridge::register_widget_border_side_api(std::function<canvas::Color(c
         return choc::value::Value();
     });
 
-    engine_.register_function("setBorderRightWidth", [this, applyBorderSide](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setBorderRightWidth", [this, applyBorderSide](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto w = static_cast<float>(args.get<double>(1, 1.0));
         auto* v = id.empty() ? &root_ : widget(id);
@@ -94,7 +96,7 @@ void WidgetBridge::register_widget_border_side_api(std::function<canvas::Color(c
         return choc::value::Value();
     });
 
-    engine_.register_function("setBorderBottomWidth", [this, applyBorderSide](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setBorderBottomWidth", [this, applyBorderSide](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto w = static_cast<float>(args.get<double>(1, 1.0));
         auto* v = id.empty() ? &root_ : widget(id);
@@ -102,7 +104,7 @@ void WidgetBridge::register_widget_border_side_api(std::function<canvas::Color(c
         return choc::value::Value();
     });
 
-    engine_.register_function("setBorderLeftWidth", [this, applyBorderSide](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setBorderLeftWidth", [this, applyBorderSide](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto w = static_cast<float>(args.get<double>(1, 1.0));
         auto* v = id.empty() ? &root_ : widget(id);


### PR DESCRIPTION
## Summary
- migrate per-side border color/width WidgetBridge APIs to BridgeApiContext/register_bridge_function
- keep behavior unchanged for the eight border-side setters
- include Shipyard SDK patch bump to 0.385.1

## Validation
- cmake -S . -B build-gpu-off -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=OFF
- cmake --build build-gpu-off --target pulp-test-widget-bridge-api-contracts pulp-test-widget-bridge-rn-style pulp-test-widget-bridge-wave5-css pulp-test-widget-bridge-yoga-border -j$(sysctl -n hw.ncpu)
- ./build-gpu-off/test/pulp-test-widget-bridge-api-contracts '[view][widget-bridge][api-contract]'\n- ./build-gpu-off/test/pulp-test-widget-bridge-rn-style '*per-side*'\n- ./build-gpu-off/test/pulp-test-widget-bridge-wave5-css '*borderTop*'\n- ./build-gpu-off/test/pulp-test-widget-bridge-yoga-border '*borderTop*'\n- git diff --check\n- python3 tools/scripts/compat_sync_check.py --enforce\n- python3 tools/scripts/version_bump_check.py --mode=report\n- pre-push hooks via git push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated per-side border color/width WidgetBridge APIs to the registry helper (`BridgeApiContext` + `register_bridge_function`) for simpler, consistent wiring. Behavior is unchanged for all eight border-side setters.

- **Refactors**
  - Switched from `engine_.register_function` to `register_bridge_function` with a `BridgeApiContext` in `border_side_api.cpp`.

- **Dependencies**
  - Bumped project version to 0.386.1.

<sup>Written for commit e903e05aeb7e674c00f865f4b42bedff7675a8e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

