### PR TITLE
refactor: migrate tokens bridge API to registry helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.386.0
+    VERSION 0.386.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/widget_bridge/tokens_api.cpp
+++ b/core/view/src/widget_bridge/tokens_api.cpp
@@ -1,6 +1,7 @@
 // widget_bridge/tokens_api.cpp - theme-token registrations for WidgetBridge.
 
 #include <pulp/view/widget_bridge.hpp>
+#include "api_registry.hpp"
 
 #include <functional>
 #include <string>
@@ -9,10 +10,11 @@
 namespace pulp::view {
 
 void WidgetBridge::register_tokens_api(std::function<canvas::Color(const std::string&)> parse_color) {
+    BridgeApiContext api{engine_};
     auto parseColor = std::move(parse_color);
 
     // setMotionToken(tokenName, value)
-    engine_.register_function("setMotionToken", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setMotionToken", [this](choc::javascript::ArgumentList args) {
         auto name = args.get<std::string>(0, "");
         auto value = static_cast<float>(args.get<double>(1, 0));
         if (name.empty()) return choc::value::Value();
@@ -23,7 +25,7 @@ void WidgetBridge::register_tokens_api(std::function<canvas::Color(const std::st
     });
 
     // getMotionToken(tokenName) -> value
-    engine_.register_function("getMotionToken", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "getMotionToken", [this](choc::javascript::ArgumentList args) {
         auto name = args.get<std::string>(0, "");
         auto d = root_.theme().dimension(name);
         return choc::value::createFloat64(d.value_or(0.0f));
@@ -40,7 +42,7 @@ void WidgetBridge::register_tokens_api(std::function<canvas::Color(const std::st
     // matcher received the literal string "var(--mono)" as a family
     // name and fell through to a proportional sans, which is visible
     // as the Spectr top-bar "faint label" symptom from #1899.
-    engine_.register_function("setStringToken", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setStringToken", [this](choc::javascript::ArgumentList args) {
         auto name = args.get<std::string>(0, "");
         auto value = args.get<std::string>(1, "");
         if (name.empty()) return choc::value::Value();
@@ -53,14 +55,14 @@ void WidgetBridge::register_tokens_api(std::function<canvas::Color(const std::st
     // getStringToken(tokenName) -> string. Returns empty string when the
     // token isn't defined - callers (e.g. prop-applier resolveVar) treat
     // empty as "miss" and try the next lookup tier.
-    engine_.register_function("getStringToken", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "getStringToken", [this](choc::javascript::ArgumentList args) {
         auto name = args.get<std::string>(0, "");
         auto s = root_.theme().string_token(name);
         return choc::value::createString(s.value_or(std::string()));
     });
 
     // setColorToken(name, color) - set a color token on the root theme
-    engine_.register_function("setColorToken", [this, parseColor](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setColorToken", [this, parseColor](choc::javascript::ArgumentList args) {
         auto name = args.get<std::string>(0, "");
         auto color_str = args.get<std::string>(1, "");
         if (name.empty()) return choc::value::Value();
@@ -72,7 +74,7 @@ void WidgetBridge::register_tokens_api(std::function<canvas::Color(const std::st
     });
 
     // setDimensionToken(name, value) - set a dimension token on the root theme
-    engine_.register_function("setDimensionToken", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setDimensionToken", [this](choc::javascript::ArgumentList args) {
         auto name = args.get<std::string>(0, "");
         auto val = static_cast<float>(args.get<double>(1, 0));
         if (name.empty()) return choc::value::Value();


### PR DESCRIPTION
## Summary
- migrate token WidgetBridge APIs to BridgeApiContext/register_bridge_function
- keep behavior unchanged for motion, string, color, and dimension token setters/getters
- include Shipyard SDK patch bump to 0.385.1

## Validation
- cmake -S . -B build-gpu-off -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=OFF
- cmake --build build-gpu-off --target pulp-test-widget-bridge-api-contracts pulp-test-widget-bridge pulp-test-widget-bridge-animation pulp-test-web-compat-prelude -j$(sysctl -n hw.ncpu)
- ./build-gpu-off/test/pulp-test-widget-bridge-api-contracts '[view][widget-bridge][api-contract]'\n- ./build-gpu-off/test/pulp-test-widget-bridge 'WidgetBridge style and layout setters update native view state'\n- ./build-gpu-off/test/pulp-test-widget-bridge-animation '*MotionToken*'\n- ./build-gpu-off/test/web-compat/pulp-test-web-compat-prelude '[css-var]'\n- git diff --check\n- python3 tools/scripts/compat_sync_check.py --enforce\n- python3 tools/scripts/version_bump_check.py --mode=report\n- pre-push hooks via git push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated WidgetBridge token APIs to the `BridgeApiContext`/`register_bridge_function` helper for consistent registration; no behavior changes to motion, string, color, or dimension token getters/setters.

- **Refactors**
  - Replaced `engine_.register_function` with `register_bridge_function` scoped by `BridgeApiContext` for: `setMotionToken`, `getMotionToken`, `setStringToken`, `getStringToken`, `setColorToken`, `setDimensionToken`.

- **Dependencies**
  - Bumped project version to 0.386.1.

<sup>Written for commit 83935b035f3f08f7256060487ff8729ca092cfd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

