### PR TITLE
refactor: migrate theme bridge API to registry helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.386.0
+    VERSION 0.386.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/widget_bridge/theme_api.cpp
+++ b/core/view/src/widget_bridge/theme_api.cpp
@@ -2,31 +2,34 @@
 
 #include <pulp/view/widget_bridge.hpp>
 #include <pulp/view/design_tokens.hpp>
+#include "api_registry.hpp"
 
 #include <string>
 
 namespace pulp::view {
 
 void WidgetBridge::register_theme_api() {
+    BridgeApiContext api{engine_};
+
     // Theme control
-    engine_.register_function("setTheme", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setTheme", [this](choc::javascript::ArgumentList args) {
         auto n = args.get<std::string>(0, "dark");
         root_.set_theme(n=="light" ? Theme::light() : n=="pro_audio" ? Theme::pro_audio() : Theme::dark());
         return choc::value::Value();
     });
 
-    engine_.register_function("applyTokenDiff", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "applyTokenDiff", [this](choc::javascript::ArgumentList args) {
         auto json = args.get<std::string>(0, "");
         if (!json.empty()) { auto d = Theme::from_json(json); auto c = root_.theme(); c.apply_overrides(d); root_.set_theme(c); }
         return choc::value::Value();
     });
 
-    engine_.register_function("getThemeJson", [this](choc::javascript::ArgumentList) {
+    register_bridge_function(api, "getThemeJson", [this](choc::javascript::ArgumentList) {
         return choc::value::createString(root_.theme().to_json());
     });
 
     // importDesignTokens(w3cJson) - parse W3C Design Tokens JSON and apply to theme
-    engine_.register_function("importDesignTokens", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "importDesignTokens", [this](choc::javascript::ArgumentList args) {
         auto json = args.get<std::string>(0, "");
         if (!json.empty()) {
             auto imported = parse_w3c_tokens(json);
@@ -38,7 +41,7 @@ void WidgetBridge::register_theme_api() {
     });
 
     // exportDesignTokens() - export current theme as W3C Design Tokens JSON
-    engine_.register_function("exportDesignTokens", [this](choc::javascript::ArgumentList) {
+    register_bridge_function(api, "exportDesignTokens", [this](choc::javascript::ArgumentList) {
         return choc::value::createString(export_w3c_tokens(root_.theme()));
     });
 }


### PR DESCRIPTION
## Summary
- migrate theme WidgetBridge APIs to BridgeApiContext/register_bridge_function
- keep behavior unchanged for setTheme, token diffs, theme JSON, and design-token import/export
- include Shipyard SDK patch bump to 0.385.1

## Validation
- cmake -S . -B build-gpu-off -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=OFF
- cmake --build build-gpu-off --target pulp-test-widget-bridge-api-contracts pulp-test-widget-bridge pulp-test-widget-bridge-animation pulp-test-design-tool-layout -j$(sysctl -n hw.ncpu)
- ./build-gpu-off/test/pulp-test-widget-bridge-api-contracts '[view][widget-bridge][api-contract]'\n- ./build-gpu-off/test/pulp-test-widget-bridge 'WidgetBridge style and layout setters update native view state'\n- ./build-gpu-off/test/pulp-test-widget-bridge-animation 'WidgetBridge ComboBox selection survives applyTokenDiff in select handler'\n- ./build-gpu-off/test/pulp-test-widget-bridge-animation 'WidgetBridge import/export design tokens and AI CLI are scriptable'\n- ./build-gpu-off/test/pulp-test-design-tool-layout 'Design tool: modified tokens expose inline reset affordances'\n- git diff --check\n- python3 tools/scripts/compat_sync_check.py --enforce\n- python3 tools/scripts/version_bump_check.py --mode=report\n- pre-push hooks via git push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the theme WidgetBridge API to the registry helper for consistent registration and easier maintenance. No behavior changes; version bumped to 0.386.1.

- **Refactors**
  - Switched to `BridgeApiContext` and `register_bridge_function`; converted handlers: setTheme, applyTokenDiff, getThemeJson, importDesignTokens, exportDesignTokens.

- **Dependencies**
  - Version bump to 0.386.1.

<sup>Written for commit 9c7602729ca4a8a6f72d8ed9767f4d2bc174e4ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

