### PR TITLE
refactor: migrate border-box bridge API to registry helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.386.1
+    VERSION 0.386.2
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/widget_bridge/border_box_api.cpp
+++ b/core/view/src/widget_bridge/border_box_api.cpp
@@ -1,6 +1,7 @@
 // widget_bridge/border_box_api.cpp - border-box style registrations for WidgetBridge.
 
 #include <pulp/view/widget_bridge.hpp>
+#include "api_registry.hpp"
 
 #include <functional>
 #include <string>
@@ -9,9 +10,10 @@
 namespace pulp::view {
 
 void WidgetBridge::register_widget_border_box_api(std::function<canvas::Color(const std::string&)> parse_color) {
+    BridgeApiContext api{engine_};
     auto parseHexColor = std::move(parse_color);
 
-    engine_.register_function("setBorder", [this, parseHexColor](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setBorder", [this, parseHexColor](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto hex = args.get<std::string>(1, "");
         auto width = args.get<double>(2, 1.0);
@@ -22,7 +24,7 @@ void WidgetBridge::register_widget_border_box_api(std::function<canvas::Color(co
     });
 
     // setBorderSide(id, side, width, color) — per-side border
-    engine_.register_function("setBorderSide", [this, parseHexColor](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setBorderSide", [this, parseHexColor](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto side = args.get<std::string>(1, "");
         auto width = static_cast<float>(args.get<double>(2, 1.0));
@@ -44,7 +46,7 @@ void WidgetBridge::register_widget_border_box_api(std::function<canvas::Color(co
     // are emitted only when a frame has asymmetric radii. Without the
     // "All" branch, the figma-plugin lane's setCornerRadius calls fell
     // through silently and panel corners stayed sharp.
-    engine_.register_function("setCornerRadius", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setCornerRadius", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto corner = args.get<std::string>(1, "");
         auto r = static_cast<float>(args.get<double>(2, 0));
@@ -66,7 +68,7 @@ void WidgetBridge::register_widget_border_box_api(std::function<canvas::Color(co
     // `borderRadius`) can update without recomputing the others.
     //
     // setBorderColor(id, hex)
-    engine_.register_function("setBorderColor", [this, parseHexColor](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setBorderColor", [this, parseHexColor](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto hex = args.get<std::string>(1, "");
         auto* v = id.empty() ? &root_ : widget(id);
@@ -75,7 +77,7 @@ void WidgetBridge::register_widget_border_box_api(std::function<canvas::Color(co
     });
 
     // setBorderWidth(id, width)
-    engine_.register_function("setBorderWidth", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setBorderWidth", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto width = static_cast<float>(args.get<double>(1, 1.0));
         auto* v = id.empty() ? &root_ : widget(id);
@@ -89,7 +91,7 @@ void WidgetBridge::register_widget_border_box_api(std::function<canvas::Color(co
     // time; double / groove / ridge / inset / outset currently degrade
     // to solid (paint-side gap, tracked for follow-up). none / hidden
     // short-circuit the stroke entirely.
-    engine_.register_function("setBorderStyle", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setBorderStyle", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto s = args.get<std::string>(1, "solid");
         auto* v = id.empty() ? &root_ : widget(id);


### PR DESCRIPTION
## Summary
- Migrate border-box WidgetBridge API registrations to BridgeApiContext/register_bridge_function.
- Preserve the existing setBorder, setBorderSide, setCornerRadius, setBorderColor, setBorderWidth, and setBorderStyle behavior unchanged.
- Include the required SDK patch version bump.

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DPULP_BUILD_TESTS=ON
- verified CMAKE_BUILD_TYPE=Release and CMAKE_CXX_FLAGS_RELEASE=-O3 -DNDEBUG
- cmake --build build --target pulp-test-widget-bridge-api-contracts pulp-test-widget-bridge pulp-test-widget-bridge-rn-style pulp-test-widget-bridge-yoga-border pulp-test-widget-bridge-wave5-css --parallel $(sysctl -n hw.ncpu)
- ./build/test/pulp-test-widget-bridge-api-contracts "[view][widget-bridge][api-contract]" --reporter compact
- ./build/test/pulp-test-widget-bridge "WidgetBridge style and layout setters update native view state" --reporter compact
- ./build/test/pulp-test-widget-bridge "setBorderStyle*" --reporter compact
- ./build/test/pulp-test-widget-bridge-rn-style "*setBorder*" --reporter compact
- ./build/test/pulp-test-widget-bridge-yoga-border --reporter compact
- ./build/test/pulp-test-widget-bridge-wave5-css "*border*" --reporter compact
- python3 tools/scripts/compat_sync_check.py --enforce
- python3 tools/scripts/version_bump_check.py --mode=report
- git diff --check origin/main..HEAD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated border-box `WidgetBridge` API registrations to the registry helper to centralize bridge function wiring. No behavior changes.

- **Refactors**
  - Replaced `engine_.register_function` with `register_bridge_function` via `BridgeApiContext` for `setBorder`, `setBorderSide`, `setCornerRadius`, `setBorderColor`, `setBorderWidth`, and `setBorderStyle`.

- **Dependencies**
  - Bumped project version to `0.386.2`.

<sup>Written for commit a368729491d5e7363fade0f8f42c37e32832623f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

