### PR TITLE
refactor: migrate basic value bridge API to registry helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.386.0
+    VERSION 0.386.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/widget_bridge/widget_value_basic_api.cpp
+++ b/core/view/src/widget_bridge/widget_value_basic_api.cpp
@@ -1,6 +1,7 @@
 // widget_bridge/widget_value_basic_api.cpp - basic widget value registrations for WidgetBridge.
 
 #include <pulp/view/widget_bridge.hpp>
+#include "api_registry.hpp"
 
 #include <pulp/view/ui_components.hpp>
 
@@ -12,8 +13,10 @@
 namespace pulp::view {
 
 void WidgetBridge::register_widget_value_label_api() {
+    BridgeApiContext api{engine_};
+
     // Property setters
-    engine_.register_function("setLabel", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setLabel", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto text = args.get<std::string>(1, "");
         auto* v = widget(id);
@@ -27,15 +30,17 @@ void WidgetBridge::register_widget_value_label_api() {
 }
 
 void WidgetBridge::register_widget_value_basic_api() {
+    BridgeApiContext api{engine_};
+
     // setStyle — placeholder until KnobStyle/ToggleStyle enums added to main widgets
-    engine_.register_function("setStyle", [](choc::javascript::ArgumentList) {
+    register_bridge_function(api, "setStyle", [](choc::javascript::ArgumentList) {
         return choc::value::Value();
     });
 
     // setWidgetStyle(id, "standard"|"minimal"|"silver") — switch rendering mode
     // "minimal" draws simple shapes matching design tools (circles, thin tracks)
     // "silver" draws a skeuomorphic chrome-body knob (figma-import alt path)
-    engine_.register_function("setWidgetStyle", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setWidgetStyle", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto style_str = args.get<std::string>(1, "standard");
         WidgetRenderStyle style;
@@ -49,7 +54,7 @@ void WidgetBridge::register_widget_value_basic_api() {
         return choc::value::Value();
     });
 
-    engine_.register_function("setItems", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setItems", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         if (auto* c = dynamic_cast<ComboBox*>(widget(id))) {
             std::vector<std::string> items;
@@ -64,7 +69,7 @@ void WidgetBridge::register_widget_value_basic_api() {
     });
 
     // setSelected(id, index) — set ComboBox selected index without firing on_change
-    engine_.register_function("setSelected", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setSelected", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto idx = args.get<int>(1, 0);
         if (auto* c = dynamic_cast<ComboBox*>(widget(id))) {


### PR DESCRIPTION
## Summary
- Migrate basic WidgetBridge value registrations to BridgeApiContext/register_bridge_function.
- Preserve setLabel, setStyle, setWidgetStyle, setItems, and setSelected behavior unchanged.
- Include the required SDK patch version bump.

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DPULP_BUILD_TESTS=ON
- verified CMAKE_BUILD_TYPE=Release and CMAKE_CXX_FLAGS_RELEASE=-O3 -DNDEBUG
- cmake --build build --target pulp-test-widget-bridge-api-contracts pulp-test-widget-bridge pulp-test-widget-bridge-animation pulp-test-combo-dropdown --parallel $(sysctl -n hw.ncpu)
- ./build/test/pulp-test-widget-bridge-api-contracts "[view][widget-bridge][api-contract]" --reporter compact
- ./build/test/pulp-test-widget-bridge "WidgetBridge extended controls and visualization APIs round-trip JS to native state" --reporter compact
- ./build/test/pulp-test-widget-bridge-animation "*ComboBox*" --reporter compact
- ./build/test/pulp-test-combo-dropdown --reporter compact
- cmake --build build --target pulp-test-web-compat-events --parallel $(sysctl -n hw.ncpu)
- ./build/test/web-compat/pulp-test-web-compat-events "Element: setLabel via JS" --reporter compact
- python3 tools/scripts/compat_sync_check.py --enforce
- python3 tools/scripts/version_bump_check.py --mode=report
- git diff --check origin/main..HEAD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored basic WidgetBridge value API registration to use the registry helper for consistent binding. No behavior changes to setLabel, setStyle, setWidgetStyle, setItems, or setSelected. Bumps patch version to 0.386.1.

- **Refactors**
  - Switched to BridgeApiContext + register_bridge_function for: setLabel, setStyle, setWidgetStyle, setItems, setSelected.
  - Updated project version to 0.386.1.

<sup>Written for commit 06de6485ab630686ae8e73523d1bf8133b6800bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

