### PR TITLE
refactor: migrate visibility bridge API to registry helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.386.2
+    VERSION 0.386.3
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/widget_bridge/style_visibility_api.cpp
+++ b/core/view/src/widget_bridge/style_visibility_api.cpp
@@ -1,14 +1,17 @@
 // widget_bridge/style_visibility_api.cpp - visibility and interaction style registrations for WidgetBridge.
 
 #include <pulp/view/widget_bridge.hpp>
+#include "api_registry.hpp"
 
 #include <string>
 
 namespace pulp::view {
 
 void WidgetBridge::register_widget_style_visibility_api() {
+    BridgeApiContext api{engine_};
+
     // setVisible(id, bool)
-    engine_.register_function("setVisible", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setVisible", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto vis = args.get<double>(1, 1) > 0.5;
         auto it = widgets_.find(id);
@@ -18,6 +21,8 @@ void WidgetBridge::register_widget_style_visibility_api() {
 }
 
 void WidgetBridge::register_widget_style_interaction_api() {
+    BridgeApiContext api{engine_};
+
     // setPointerEvents(id, "none"|"auto") - CSS pointer-events: skip in hit_test
     // pulp #1026 - RN-shaped 4-valued pointerEvents:
     //   "auto"     - default, this view + children intercept events.
@@ -28,7 +33,7 @@ void WidgetBridge::register_widget_style_interaction_api() {
     // set_hit_testable(); we keep that mapping for the binary cases for
     // back-compat with existing scripts and additionally route the new
     // four-valued enum via View::set_pointer_events().
-    engine_.register_function("setPointerEvents", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setPointerEvents", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto mode = args.get<std::string>(1, "auto");
         auto* v = id.empty() ? &root_ : widget(id);
@@ -54,7 +59,7 @@ void WidgetBridge::register_widget_style_interaction_api() {
     // by the paint path only when a 3D transform with negative Z is
     // active; pulp's transform model is currently 2D-affine, so this is
     // a no-op for painting today and reserved for future 3D support.
-    engine_.register_function("setBackfaceVisibility", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setBackfaceVisibility", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto mode = args.get<std::string>(1, "visible");
         auto* v = id.empty() ? &root_ : widget(id);
@@ -63,7 +68,7 @@ void WidgetBridge::register_widget_style_interaction_api() {
     });
 
     // setVisibility(id, "visible"|"hidden") - hidden preserves layout space
-    engine_.register_function("setVisibility", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setVisibility", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto vis = args.get<std::string>(1, "visible");
         auto* v = id.empty() ? &root_ : widget(id);
@@ -85,7 +90,7 @@ void WidgetBridge::register_widget_style_interaction_api() {
     // Label::set_multi_line side-effect stays in lock-step so existing
     // single-line Label paint paths (incl. #1407 ellipsis truncation)
     // keep working when only one of the flags is set.
-    engine_.register_function("setWhiteSpace", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setWhiteSpace", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto ws = args.get<std::string>(1, "normal");
         auto* v = id.empty() ? &root_ : widget(id);
@@ -131,7 +136,7 @@ void WidgetBridge::register_widget_style_interaction_api() {
     // Now stores the keyword on View::user_select_ so widgets that
     // participate in selection can read it. Unknown keywords map to
     // the spec default (auto).
-    engine_.register_function("setUserSelect", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setUserSelect", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto kw = args.get<std::string>(1, "auto");
         auto* v = id.empty() ? &root_ : widget(id);


### PR DESCRIPTION
Summary
- Route visibility/style interaction bridge registrations through register_bridge_function.
- Keep setVisible widget lookup behavior and setWhiteSpace Label multi_line side effect unchanged.
- Include the standard SDK/CLI patch version bump.

Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DPULP_BUILD_TESTS=ON
- Verified CMAKE_BUILD_TYPE=Release and CMAKE_CXX_FLAGS_RELEASE=-O3 -DNDEBUG.
- cmake --build build --target pulp-test-widget-bridge-api-contracts pulp-test-widget-bridge pulp-test-widget-bridge-rn-style pulp-test-widget-bridge-svg pulp-test-widget-bridge-clip-mask pulp-test-widget-bridge-animation pulp-test-web-compat-parser pulp-test-web-compat-events --parallel $(sysctl -n hw.ncpu)
- ./build/test/pulp-test-widget-bridge-api-contracts '[view][widget-bridge][api-contract]' --reporter compact\n- ./build/test/pulp-test-widget-bridge 'WidgetBridge style and layout setters update native view state' --reporter compact\n- ./build/test/pulp-test-widget-bridge-rn-style '*setBackfaceVisibility*' --reporter compact\n- ./build/test/pulp-test-widget-bridge-rn-style '*setPointerEvents*' --reporter compact\n- ./build/test/pulp-test-widget-bridge-animation 'WidgetBridge setVisible from JS' --reporter compact\n- ./build/test/pulp-test-widget-bridge-svg '*setWhiteSpace*' --reporter compact\n- ./build/test/pulp-test-widget-bridge-clip-mask '*setUserSelect*' --reporter compact\n- ./build/test/web-compat/pulp-test-web-compat-parser '*setVisible*' --reporter compact\n- ./build/test/web-compat/pulp-test-web-compat-events 'Element: setVisible via JS' --reporter compact\n- python3 tools/scripts/compat_sync_check.py --enforce\n- python3 tools/scripts/version_bump_check.py --mode=report\n- git diff --check origin/main..HEAD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized WidgetBridge registration by routing visibility and interaction style APIs through `register_bridge_function` with `BridgeApiContext`. Preserves existing behavior (including `setVisible` lookup and Label white-space/multi-line coupling) and bumps version to `0.386.3`.

- **Refactors**
  - Migrated registrations for: `setVisible`, `setPointerEvents`, `setBackfaceVisibility`, `setVisibility`, `setWhiteSpace`, `setUserSelect`.

<sup>Written for commit fdb020102c37d1c9f25504b9ee257064b47a7a83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

