### PR TITLE
refactor: migrate visual style bridge API to registry helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.387.0
+    VERSION 0.387.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/widget_bridge/style_visual_api.cpp
+++ b/core/view/src/widget_bridge/style_visual_api.cpp
@@ -1,5 +1,6 @@
 #include <pulp/view/widget_bridge.hpp>
 #include <pulp/view/css_gradient.hpp>
+#include "api_registry.hpp"
 
 #include <algorithm>
 #include <string>
@@ -8,7 +9,9 @@ namespace pulp::view {
 
 void WidgetBridge::register_widget_style_background_color_api(
     std::function<canvas::Color(const std::string&)> parse_color) {
-    engine_.register_function("setBackground", [this, parse_color](choc::javascript::ArgumentList args) {
+    BridgeApiContext api{engine_};
+
+    register_bridge_function(api, "setBackground", [this, parse_color](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto hex = args.get<std::string>(1, "");
         auto* v = id.empty() ? &root_ : widget(id);
@@ -19,11 +22,13 @@ void WidgetBridge::register_widget_style_background_color_api(
 
 void WidgetBridge::register_widget_style_shadow_api(
     std::function<canvas::Color(const std::string&)> parse_color) {
+    BridgeApiContext api{engine_};
+
     // pulp #1026 - RN-shaped shadow primitive. RN's View style-prop names
     // are { shadowColor, shadowOffset: {x,y}, shadowOpacity, shadowRadius }
     // and do not carry spread or inset. Lower these onto the existing pulp
     // #925 box-shadow primitive while leaving setBoxShadow unchanged.
-    engine_.register_function("setShadow", [this, parse_color](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setShadow", [this, parse_color](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto hex = args.get<std::string>(1, "#000000ff");
         auto ox = static_cast<float>(args.get<double>(2, 0.0));
@@ -42,7 +47,9 @@ void WidgetBridge::register_widget_style_shadow_api(
 }
 
 void WidgetBridge::register_widget_style_opacity_api() {
-    engine_.register_function("setOpacity", [this](choc::javascript::ArgumentList args) {
+    BridgeApiContext api{engine_};
+
+    register_bridge_function(api, "setOpacity", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto alpha = args.get<double>(1, 1.0);
         auto* v = id.empty() ? &root_ : widget(id);
@@ -52,7 +59,9 @@ void WidgetBridge::register_widget_style_opacity_api() {
 }
 
 void WidgetBridge::register_widget_style_overflow_api() {
-    engine_.register_function("setOverflow", [this](choc::javascript::ArgumentList args) {
+    BridgeApiContext api{engine_};
+
+    register_bridge_function(api, "setOverflow", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto mode = args.get<std::string>(1, "hidden");
         auto* v = id.empty() ? &root_ : widget(id);
@@ -66,7 +75,9 @@ void WidgetBridge::register_widget_style_overflow_api() {
 
 void WidgetBridge::register_widget_style_background_gradient_api(
     std::function<canvas::Color(const std::string&)> parse_color) {
-    engine_.register_function("setBackgroundGradient", [this, parse_color](choc::javascript::ArgumentList args) {
+    BridgeApiContext api{engine_};
+
+    register_bridge_function(api, "setBackgroundGradient", [this, parse_color](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto gradient = args.get<std::string>(1, "");
         auto* v = id.empty() ? &root_ : widget(id);
@@ -79,7 +90,9 @@ void WidgetBridge::register_widget_style_background_gradient_api(
 
 void WidgetBridge::register_widget_style_box_shadow_api(
     std::function<canvas::Color(const std::string&)> parse_color) {
-    engine_.register_function("setBoxShadow", [this, parse_color](choc::javascript::ArgumentList args) {
+    BridgeApiContext api{engine_};
+
+    register_bridge_function(api, "setBoxShadow", [this, parse_color](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto ox = static_cast<float>(args.get<double>(1, 0));
         auto oy = static_cast<float>(args.get<double>(2, 2));
@@ -102,7 +115,7 @@ void WidgetBridge::register_widget_style_box_shadow_api(
         return choc::value::Value();
     });
 
-    engine_.register_function("clearBoxShadow", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "clearBoxShadow", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto* v = id.empty() ? &root_ : widget(id);
         if (v) v->clear_box_shadow();


### PR DESCRIPTION
Summary
- Route visual style bridge registrations through register_bridge_function.
- Preserve existing parsing and behavior for setBackground, setShadow, setOpacity, setOverflow, setBackgroundGradient, setBoxShadow, and clearBoxShadow.
- Include the standard SDK/CLI patch version bump.

Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DPULP_BUILD_TESTS=ON
- Verified CMAKE_BUILD_TYPE=Release and CMAKE_CXX_FLAGS_RELEASE=-O3 -DNDEBUG.
- cmake --build build --target pulp-test-widget-bridge-api-contracts pulp-test-widget-bridge pulp-test-widget-bridge-wave5-css pulp-test-web-compat-parser --parallel $(sysctl -n hw.ncpu)
- ./build/test/pulp-test-widget-bridge-api-contracts '[view][widget-bridge][api-contract]' --reporter compact\n- ./build/test/pulp-test-widget-bridge 'WidgetBridge style and layout setters update native view state' --reporter compact\n- ./build/test/pulp-test-widget-bridge '*setBoxShadow*' --reporter compact\n- ./build/test/pulp-test-widget-bridge '*clearBoxShadow*' --reporter compact\n- ./build/test/pulp-test-widget-bridge-wave5-css 'rn/overflow: setOverflow accepts all 3 RN keywords incl. scroll' --reporter compact\n- ./build/test/web-compat/pulp-test-web-compat-parser '*setOpacity*' --reporter compact\n- ./build/test/web-compat/pulp-test-web-compat-parser '*setOverflow*' --reporter compact\n- ./build/test/web-compat/pulp-test-web-compat-parser '[parser][color]' --reporter compact\n- python3 tools/scripts/compat_sync_check.py --enforce\n- python3 tools/scripts/version_bump_check.py --mode=report\n- git diff --check origin/main..HEAD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated visual style WidgetBridge API registrations to the registry helper. No behavior changes; bumps version to 0.387.1.

- **Refactors**
  - Routed setBackground, setShadow, setOpacity, setOverflow, setBackgroundGradient, setBoxShadow, and clearBoxShadow through `register_bridge_function` in `api_registry.hpp` using `BridgeApiContext`.

<sup>Written for commit a643980fabb3920f7a4bb2709ca75996c0e2fb14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

