### PR TITLE
refactor: migrate value controls bridge API to registry helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.387.1
+    VERSION 0.387.2
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/widget_bridge/widget_value_controls_api.cpp
+++ b/core/view/src/widget_bridge/widget_value_controls_api.cpp
@@ -1,17 +1,20 @@
 // widget_bridge/widget_value_controls_api.cpp - scalar control value registrations for WidgetBridge.
 
 #include <pulp/view/widget_bridge.hpp>
+#include "api_registry.hpp"
 
 #include <string>
 
 namespace pulp::view {
 
 void WidgetBridge::register_widget_value_controls_api() {
+    BridgeApiContext api{engine_};
+
     // setValue(id, value) -> set widget value
     // For Knob / Fader / Toggle this is normalised 0..1.
     // For RangeSlider (issue-966) it's the raw value in [min,max]; the
     // widget clamps + quantises against its own configured range.
-    engine_.register_function("setValue", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setValue", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto value = args.get<double>(1, 0);
 
@@ -36,7 +39,7 @@ void WidgetBridge::register_widget_value_controls_api() {
 
     // getValue(id) -> get widget value (normalised for Knob/Fader/Toggle,
     // raw for RangeSlider).
-    engine_.register_function("getValue", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "getValue", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
 
         auto it = widgets_.find(id);
@@ -58,7 +61,7 @@ void WidgetBridge::register_widget_value_controls_api() {
     // setMin/setMax/setStep mirror the HTMLInputElement attributes
     // `min`, `max`, `step`. Each one re-applies the widget's clamp +
     // quantisation pipeline so out-of-range values stay consistent.
-    engine_.register_function("setMin", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setMin", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto v = args.get<double>(1, 0);
         if (auto* range = dynamic_cast<RangeSlider*>(widget(id)))
@@ -66,7 +69,7 @@ void WidgetBridge::register_widget_value_controls_api() {
         return choc::value::Value();
     });
 
-    engine_.register_function("setMax", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setMax", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto v = args.get<double>(1, 1);
         if (auto* range = dynamic_cast<RangeSlider*>(widget(id)))
@@ -74,7 +77,7 @@ void WidgetBridge::register_widget_value_controls_api() {
         return choc::value::Value();
     });
 
-    engine_.register_function("setStep", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setStep", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto v = args.get<double>(1, 0);
         if (auto* range = dynamic_cast<RangeSlider*>(widget(id)))
@@ -85,7 +88,7 @@ void WidgetBridge::register_widget_value_controls_api() {
     // setOrientation(id, "horizontal" | "vertical")
     // Currently only RangeSlider (issue-966); future widgets that need
     // an orientation can extend this dynamic_cast chain.
-    engine_.register_function("setOrientation", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setOrientation", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto orient = args.get<std::string>(1, "horizontal");
         auto* w = widget(id);
@@ -104,7 +107,7 @@ void WidgetBridge::register_widget_value_controls_api() {
     // setAccentColor(id, "#hex" | "rgb(...)" | "")
     // Empty string clears the override and returns to the active theme's
     // `control.fill` / `control.thumb` tokens.
-    engine_.register_function("setAccentColor", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setAccentColor", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto hex = args.get<std::string>(1, "");
         if (auto* range = dynamic_cast<RangeSlider*>(widget(id))) {


### PR DESCRIPTION
Summary
- Route value-control bridge registrations through register_bridge_function.
- Preserve existing behavior for setValue, getValue, setMin, setMax, setStep, setOrientation, and setAccentColor.
- Include the standard SDK/CLI patch version bump.

Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DPULP_BUILD_TESTS=ON
- Verified CMAKE_BUILD_TYPE=Release and CMAKE_CXX_FLAGS_RELEASE=-O3 -DNDEBUG.
- cmake --build build --target pulp-test-widget-bridge-api-contracts pulp-test-widget-bridge pulp-test-web-compat-events --parallel $(sysctl -n hw.ncpu)
- ./build/test/pulp-test-widget-bridge-api-contracts '[view][widget-bridge][api-contract]' --reporter compact\n- ./build/test/pulp-test-widget-bridge 'WidgetBridge creates range slider from JS' --reporter compact\n- ./build/test/pulp-test-widget-bridge 'WidgetBridge range slider setOrientation and setAccentColor' --reporter compact\n- ./build/test/pulp-test-widget-bridge 'WidgetBridge range slider get/setValue round-trip' --reporter compact\n- ./build/test/pulp-test-widget-bridge 'WidgetBridge set/get value from JS' --reporter compact\n- ./build/test/web-compat/pulp-test-web-compat-events 'Element: setValue/getValue via JS' --reporter compact\n- python3 tools/scripts/compat_sync_check.py --enforce\n- python3 tools/scripts/version_bump_check.py --mode=report\n- git diff --check origin/main..HEAD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the WidgetBridge value controls API to a registry helper to centralize registration and reduce duplication. No behavior changes; bumps project version to 0.387.2.

- **Refactors**
  - Routes value-control registrations through `register_bridge_function` with a shared `BridgeApiContext`.
  - Preserves behavior for setValue, getValue, setMin, setMax, setStep, setOrientation, and setAccentColor.

<sup>Written for commit f24b80fd55838923e55530d122ce6f9584632e72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

