### PR TITLE
feat(platform): generic D-Bus object-server layer (L7a-1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.388.0
+    VERSION 0.389.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/platform/include/pulp/platform/dbus.hpp
+++ b/core/platform/include/pulp/platform/dbus.hpp
@@ -7,7 +7,26 @@
 // core/platform — the lowest layer — so any subsystem can use it for
 // session-bus IPC (xdg-desktop-portal file chooser / screenshot / notifications,
 // etc.) without a build-time dependency or a layering cycle.
+//
+// Two consumption models live side by side here, deliberately kept separate:
+//
+//   * Portal CLIENT (file_chooser): a method call is sent and the reply / a
+//     matching signal is awaited by *popping* messages off the incoming queue
+//     (read_write + pop_message). pop_message removes a message BEFORE the
+//     libdbus object-path dispatcher would ever see it.
+//
+//   * Object SERVER (register_object / emit_signal / dispatch): the app EXPORTS
+//     objects and answers incoming method calls. This requires the libdbus
+//     *dispatcher* to run so registered handlers fire — driven by dispatch(),
+//     which calls dbus_connection_read_write_dispatch(). It must NOT be mixed
+//     with the portal pop_message pump on the same pending traffic: pop_message
+//     would steal the very method call a registered handler is meant to answer.
+//
+// The object-server layer is AT-SPI-agnostic generic infrastructure: it answers
+// any registered object path, and is independently useful for MPRIS, desktop
+// notifications, or AT-SPI accessibility export.
 
+#include <functional>
 #include <map>
 #include <optional>
 #include <string>
@@ -30,6 +49,11 @@ public:
     bool connect_session();
     bool connected() const;
 
+    /// This connection's unique bus name (e.g. ":1.42"), assigned by the broker
+    /// at connect time. Empty when not connected / off Linux. Needed so a peer
+    /// (or this same process, in a loopback test) can address method calls at us.
+    std::string unique_name() const;
+
     /// Reply value for an xdg-desktop-portal request: the response code
     /// (0 = success, 1 = user cancelled, 2 = other) plus any returned URIs.
     struct PortalResult {
@@ -49,6 +73,136 @@ public:
         const std::map<std::string, std::string>& options,
         const std::map<std::string, bool>& bool_options,
         int timeout_ms = 120000);
+
+    // ── Object-server layer (generic, AT-SPI-agnostic) ──────────────────────
+    //
+    // A thin facade over the libdbus marshalling iterator. Reader walks an
+    // incoming message's arguments; Writer appends arguments to a reply or a
+    // signal. Both are non-owning views over the underlying DBusMessageIter and
+    // are only valid for the duration of the call that produced them.
+
+    /// Reads basic + container values out of an incoming message's argument
+    /// list. The cursor advances on each successful read.
+    class Reader {
+    public:
+        /// Read a string ('s') or object-path ('o') at the cursor into `out` and
+        /// advance. Returns false (leaving the cursor put) on type mismatch / end.
+        bool read_string(std::string& out);
+        bool read_int32(int& out);
+        bool read_uint32(unsigned& out);
+        bool read_double(double& out);
+        /// Current argument's D-Bus type code, or 0 ('\0') when exhausted.
+        int arg_type() const;
+        /// Advance to the next argument. Returns false when there is no next.
+        bool next();
+
+    private:
+        friend class DBus;
+        Reader(DBus* owner, void* iter) : owner_(owner), iter_(iter) {}
+        DBus* owner_ = nullptr;
+        void* iter_ = nullptr;   // DBusMessageIter*
+    };
+
+    /// Appends values to an outgoing message (reply or signal). Container open/
+    /// close calls must be balanced; the matching close uses the cursor handed
+    /// back by the open.
+    class Writer {
+    public:
+        bool append_string(const std::string& s);
+        bool append_object_path(const std::string& p);
+        bool append_int32(int v);
+        bool append_uint32(unsigned v);
+        bool append_double(double v);
+
+        /// A nested container being built. `iter` is the sub-iterator; pass it to
+        /// the matching close_container().
+        struct Container { void* iter = nullptr; bool open = false; };
+
+        /// Open an array. `element_signature` is the D-Bus signature of the
+        /// element type (e.g. "s", "(so)", "{sv}"). The returned Container's
+        /// own writer methods append into the array.
+        Container open_array(const std::string& element_signature);
+        /// Open a struct ("(...)" — no signature string for libdbus structs).
+        Container open_struct();
+        /// Open a variant holding a single value of `value_signature` (e.g. "s").
+        Container open_variant(const std::string& value_signature);
+        /// Open a dict-entry (only valid inside an a{..} array).
+        Container open_dict_entry();
+        bool close_container(Container& c);
+
+        /// Append into an already-open container instead of the top level.
+        Writer sub(Container& c);
+
+    private:
+        friend class DBus;
+        Writer(DBus* owner, void* iter) : owner_(owner), iter_(iter) {}
+        DBus* owner_ = nullptr;
+        void* iter_ = nullptr;   // DBusMessageIter*
+    };
+
+    /// Context for one incoming method call against a registered object. The
+    /// handler reads arguments via args(), and answers with EXACTLY ONE of
+    /// reply() (success) or error() (failure). A handler that returns true
+    /// without calling either yields an empty success reply; returning false
+    /// makes the server emit org.freedesktop.DBus.Error.UnknownMethod.
+    class CallContext {
+    public:
+        const std::string& path() const { return path_; }
+        const std::string& interface() const { return interface_; }
+        const std::string& member() const { return member_; }
+        const std::string& sender() const { return sender_; }
+
+        /// Argument reader over the incoming call.
+        Reader& args() { return reader_; }
+
+        /// Begin a success reply. Returns a Writer to append return values into.
+        /// Calling reply() marks the call answered; the server sends it after the
+        /// handler returns. May only be called once per call.
+        Writer reply();
+        /// Answer with a D-Bus error (e.g. "org.freedesktop.DBus.Error.Failed").
+        /// Marks the call answered. Mutually exclusive with reply().
+        void error(const std::string& name, const std::string& message);
+
+    private:
+        friend class DBus;
+        CallContext(DBus* owner, void* msg, void* args_iter)
+            : owner_(owner), msg_(msg), reader_(owner, args_iter) {}
+        DBus* owner_ = nullptr;
+        void* msg_ = nullptr;          // incoming DBusMessage*
+        void* reply_msg_ = nullptr;    // DBusMessage* built by reply()/error()
+        void* reply_iter_ = nullptr;   // heap append-iterator for reply(), freed
+                                       // by the server after the message is sent
+        bool answered_ = false;
+        std::string path_, interface_, member_, sender_;
+        Reader reader_;
+    };
+
+    /// Handler for incoming method calls on a registered object path. Return
+    /// true if the call was recognised + answered (via ctx.reply()/error()),
+    /// false to decline — the server then replies UnknownMethod. A call is
+    /// NEVER dropped silently.
+    using IncomingHandler = std::function<bool(CallContext& ctx)>;
+
+    /// Export an object at `path`; `handler` answers method calls routed to it.
+    /// Re-registering a path replaces its handler. Returns false off Linux /
+    /// without a connection / if libdbus rejects the path.
+    bool register_object(const std::string& path, IncomingHandler handler);
+    /// Remove a previously registered object. Returns false if not registered.
+    bool unregister_object(const std::string& path);
+
+    /// Emit a signal from `path`/`interface`/`member`. `build_args` appends the
+    /// signal body via the Writer. Returns false off Linux / without a
+    /// connection / on marshalling or send failure.
+    bool emit_signal(const std::string& path, const std::string& interface,
+                     const std::string& member,
+                     const std::function<void(Writer&)>& build_args);
+
+    /// Run the libdbus dispatcher once so registered object handlers fire and
+    /// outgoing traffic flushes. Blocks up to `timeout_ms` waiting for I/O
+    /// (0 = non-blocking poll). Returns false off Linux / without a connection.
+    /// This is the object-server consumption model; do NOT interleave it with
+    /// the portal file_chooser pop_message pump on the same pending traffic.
+    bool dispatch(int timeout_ms = 0);
 
     DBus(const DBus&) = delete;
     DBus& operator=(const DBus&) = delete;

--- a/core/platform/src/dbus.cpp
+++ b/core/platform/src/dbus.cpp
@@ -46,11 +46,19 @@ namespace {
 constexpr int kTypeString  = 's';
 constexpr int kTypeObjPath = 'o';
 constexpr int kTypeBool    = 'b';
+constexpr int kTypeInt32   = 'i';
+constexpr int kTypeUInt32  = 'u';
+constexpr int kTypeDouble  = 'd';
 constexpr int kTypeArray   = 'a';
+constexpr int kTypeStruct  = 'r';   // STRUCT type code (open_container takes 'r')
 constexpr int kTypeVariant = 'v';
 constexpr int kTypeDictEnt = 'e';
 constexpr int kTypeInvalid = '\0';
 constexpr int kBusSession  = 0;
+
+// DBusHandlerResult values (dbus-shared.h).
+constexpr int kHandlerHandled       = 0;   // DBUS_HANDLER_RESULT_HANDLED
+constexpr int kHandlerNotYetHandled = 1;   // DBUS_HANDLER_RESULT_NOT_YET_HANDLED
 }  // namespace
 
 // libdbus entry points resolved at runtime. Opaque structs as void*; the
@@ -60,11 +68,21 @@ struct DBus::Impl {
     void* handle = nullptr;       // dlopen handle
     void* conn = nullptr;         // DBusConnection*
 
+    // Path → handler routing table for exported objects. The trampoline recovers
+    // `this` from the vtable user_data and looks the path up here.
+    std::map<std::string, IncomingHandler> handlers;
+
     // Errors are a {const char* name; const char* message; ...} struct; we only
     // need to init/free/check it, so a generous opaque buffer suffices.
     struct ErrBuf { unsigned char bytes[64]; };
     // Iterators are documented as opaque; libdbus's is ~80-96 bytes. Over-size it.
     struct IterBuf { unsigned char bytes[128]; };
+    // DBusObjectPathVTable is { unregister_fn; message_fn; void* pad1..4 } —
+    // two function pointers + four reserved void*. Over-allocate generously to
+    // be robust across libdbus ABI versions (same discipline as the iter/err
+    // buffers above).
+    struct VTableBuf { unsigned char bytes[128]; };
+    VTableBuf vtable{};   // single shared vtable; user_data discriminates by `this`
 
     using fn_error_init   = void (*)(void*);
     using fn_error_free   = void (*)(void*);
@@ -91,6 +109,25 @@ struct DBus::Impl {
     using fn_iter_getbasic = void (*)(void*, void*);
     using fn_iter_next    = unsigned (*)(void*);
 
+    // ── object-server additions ──
+    // DBusObjectPathMessageFunction: DBusHandlerResult (*)(conn, msg, user_data)
+    using fn_msg_func     = int (*)(void*, void*, void*);
+    // DBusObjectPathVTable layout we fill in by hand (no build-time header).
+    struct VTable { void* unregister_function; fn_msg_func message_function;
+                    void* pad1; void* pad2; void* pad3; void* pad4; };
+    using fn_try_register = unsigned (*)(void*, const char*, const void*, void*, void*);
+    using fn_unregister   = unsigned (*)(void*, const char*);
+    using fn_msg_new_ret  = void* (*)(void*);
+    using fn_msg_new_sig  = void* (*)(const char*, const char*, const char*);
+    using fn_msg_new_err  = void* (*)(void*, const char*, const char*);
+    using fn_conn_send    = unsigned (*)(void*, void*, void*);
+    using fn_conn_flush   = void (*)(void*);
+    using fn_read_write_dispatch = unsigned (*)(void*, int);
+    using fn_msg_get_iface = const char* (*)(void*);
+    using fn_msg_get_member = const char* (*)(void*);
+    using fn_msg_get_sender = const char* (*)(void*);
+    using fn_get_unique   = const char* (*)(void*);
+
     fn_error_init   error_init = nullptr;
     fn_error_free   error_free = nullptr;
     fn_error_is_set error_is_set = nullptr;
@@ -115,6 +152,19 @@ struct DBus::Impl {
     fn_iter_recurse iter_recurse = nullptr;
     fn_iter_getbasic iter_get_basic = nullptr;
     fn_iter_next    iter_next = nullptr;
+
+    fn_try_register try_register_object_path = nullptr;
+    fn_unregister   unregister_object_path = nullptr;
+    fn_msg_new_ret  msg_new_method_return = nullptr;
+    fn_msg_new_sig  msg_new_signal = nullptr;
+    fn_msg_new_err  msg_new_error = nullptr;
+    fn_conn_send    conn_send = nullptr;
+    fn_conn_flush   conn_flush = nullptr;
+    fn_read_write_dispatch read_write_dispatch = nullptr;
+    fn_msg_get_iface  msg_get_interface = nullptr;
+    fn_msg_get_member msg_get_member = nullptr;
+    fn_msg_get_sender msg_get_sender = nullptr;
+    fn_get_unique     get_unique_name = nullptr;
 
     template <typename Fn>
     Fn sym(const char* name) { return reinterpret_cast<Fn>(dlsym(handle, name)); }
@@ -144,13 +194,33 @@ struct DBus::Impl {
         iter_recurse = sym<fn_iter_recurse>("dbus_message_iter_recurse");
         iter_get_basic = sym<fn_iter_getbasic>("dbus_message_iter_get_basic");
         iter_next = sym<fn_iter_next>("dbus_message_iter_next");
+
+        // Object-server symbols.
+        try_register_object_path = sym<fn_try_register>("dbus_connection_try_register_object_path");
+        unregister_object_path = sym<fn_unregister>("dbus_connection_unregister_object_path");
+        msg_new_method_return = sym<fn_msg_new_ret>("dbus_message_new_method_return");
+        msg_new_signal = sym<fn_msg_new_sig>("dbus_message_new_signal");
+        msg_new_error = sym<fn_msg_new_err>("dbus_message_new_error");
+        conn_send = sym<fn_conn_send>("dbus_connection_send");
+        conn_flush = sym<fn_conn_flush>("dbus_connection_flush");
+        read_write_dispatch = sym<fn_read_write_dispatch>("dbus_connection_read_write_dispatch");
+        msg_get_interface = sym<fn_msg_get_iface>("dbus_message_get_interface");
+        msg_get_member = sym<fn_msg_get_member>("dbus_message_get_member");
+        msg_get_sender = sym<fn_msg_get_sender>("dbus_message_get_sender");
+        get_unique_name = sym<fn_get_unique>("dbus_connection_get_unique_name");
+
         return error_init && error_free && error_is_set && bus_get_private &&
                conn_close && conn_unref && set_exit_on_disconnect && add_match &&
                read_write && pop_message && send_with_reply_and_block &&
                msg_new_method_call && msg_unref && msg_is_signal && msg_get_path &&
                iter_init_append && iter_append_basic && iter_open_container &&
                iter_close_container && iter_init && iter_get_arg_type &&
-               iter_recurse && iter_get_basic && iter_next;
+               iter_recurse && iter_get_basic && iter_next &&
+               try_register_object_path && unregister_object_path &&
+               msg_new_method_return && msg_new_signal && msg_new_error &&
+               conn_send && conn_flush && read_write_dispatch &&
+               msg_get_interface && msg_get_member && msg_get_sender &&
+               get_unique_name;
     }
 
     // Append one a{sv} entry: key (string) → variant of `vtype` holding `val`.
@@ -164,7 +234,198 @@ struct DBus::Impl {
         iter_close_container(&entry, &var);
         iter_close_container(arr_iter, &entry);
     }
+
+    // The single trampoline registered as DBusObjectPathVTable.message_function.
+    // user_data is the Impl*; route the incoming method call to the handler
+    // registered for the message's object path. Always reply or error — never
+    // drop a call silently (an unanswered method call hangs the caller).
+    static int trampoline(void* /*conn*/, void* msg, void* user_data) {
+        auto* self = static_cast<Impl*>(user_data);
+        if (!self || !msg) return kHandlerNotYetHandled;
+
+        const char* path = self->msg_get_path(msg);
+        if (!path) return kHandlerNotYetHandled;
+        auto it = self->handlers.find(path);
+        if (it == self->handlers.end()) return kHandlerNotYetHandled;
+
+        // Build the argument reader over the incoming message.
+        IterBuf args_iter;
+        const bool has_args = self->iter_init(msg, &args_iter) != 0;
+
+        DBus owner_view;             // lightweight non-owning DBus to host facades
+        owner_view.impl_ = self;     // borrow; cleared before destruction below
+        CallContext ctx(&owner_view, msg, has_args ? &args_iter : nullptr);
+        const char* iface  = self->msg_get_interface(msg);
+        const char* member = self->msg_get_member(msg);
+        const char* sender = self->msg_get_sender(msg);
+        ctx.path_      = path;
+        ctx.interface_ = iface ? iface : "";
+        ctx.member_    = member ? member : "";
+        ctx.sender_    = sender ? sender : "";
+
+        const bool recognised = it->second ? it->second(ctx) : false;
+
+        int result = kHandlerHandled;
+        if (!recognised) {
+            // Decline → UnknownMethod error reply.
+            void* err = self->msg_new_error(
+                msg, "org.freedesktop.DBus.Error.UnknownMethod",
+                "No such method");
+            if (err) {
+                self->conn_send(self->conn, err, nullptr);
+                self->msg_unref(err);
+            }
+        } else if (ctx.reply_msg_) {
+            // Handler built a reply (success or error) message.
+            self->conn_send(self->conn, ctx.reply_msg_, nullptr);
+            self->msg_unref(ctx.reply_msg_);
+            ctx.reply_msg_ = nullptr;
+        } else {
+            // Recognised but produced no body → empty success reply.
+            void* ret = self->msg_new_method_return(msg);
+            if (ret) {
+                self->conn_send(self->conn, ret, nullptr);
+                self->msg_unref(ret);
+            }
+        }
+        // Free the heap append-iterator reply() may have allocated.
+        if (ctx.reply_iter_) {
+            delete static_cast<IterBuf*>(ctx.reply_iter_);
+            ctx.reply_iter_ = nullptr;
+        }
+        self->conn_flush(self->conn);
+        owner_view.impl_ = nullptr;  // do NOT free the borrowed Impl on dtor
+        return result;
+    }
 };
+
+// ── Reader facade ───────────────────────────────────────────────────────────
+bool DBus::Reader::read_string(std::string& out) {
+    if (!owner_ || !owner_->impl_ || !iter_) return false;
+    auto& d = *owner_->impl_;
+    const int t = d.iter_get_arg_type(iter_);
+    if (t != kTypeString && t != kTypeObjPath) return false;
+    const char* s = nullptr;
+    d.iter_get_basic(iter_, &s);
+    out = s ? s : "";
+    d.iter_next(iter_);
+    return true;
+}
+bool DBus::Reader::read_int32(int& out) {
+    if (!owner_ || !owner_->impl_ || !iter_) return false;
+    auto& d = *owner_->impl_;
+    if (d.iter_get_arg_type(iter_) != kTypeInt32) return false;
+    int v = 0; d.iter_get_basic(iter_, &v); out = v; d.iter_next(iter_); return true;
+}
+bool DBus::Reader::read_uint32(unsigned& out) {
+    if (!owner_ || !owner_->impl_ || !iter_) return false;
+    auto& d = *owner_->impl_;
+    if (d.iter_get_arg_type(iter_) != kTypeUInt32) return false;
+    unsigned v = 0; d.iter_get_basic(iter_, &v); out = v; d.iter_next(iter_); return true;
+}
+bool DBus::Reader::read_double(double& out) {
+    if (!owner_ || !owner_->impl_ || !iter_) return false;
+    auto& d = *owner_->impl_;
+    if (d.iter_get_arg_type(iter_) != kTypeDouble) return false;
+    double v = 0; d.iter_get_basic(iter_, &v); out = v; d.iter_next(iter_); return true;
+}
+int DBus::Reader::arg_type() const {
+    if (!owner_ || !owner_->impl_ || !iter_) return kTypeInvalid;
+    return owner_->impl_->iter_get_arg_type(iter_);
+}
+bool DBus::Reader::next() {
+    if (!owner_ || !owner_->impl_ || !iter_) return false;
+    return owner_->impl_->iter_next(iter_) != 0;
+}
+
+// ── Writer facade ───────────────────────────────────────────────────────────
+bool DBus::Writer::append_string(const std::string& s) {
+    if (!owner_ || !owner_->impl_ || !iter_) return false;
+    const char* c = s.c_str();
+    return owner_->impl_->iter_append_basic(iter_, kTypeString, &c) != 0;
+}
+bool DBus::Writer::append_object_path(const std::string& p) {
+    if (!owner_ || !owner_->impl_ || !iter_) return false;
+    const char* c = p.c_str();
+    return owner_->impl_->iter_append_basic(iter_, kTypeObjPath, &c) != 0;
+}
+bool DBus::Writer::append_int32(int v) {
+    if (!owner_ || !owner_->impl_ || !iter_) return false;
+    return owner_->impl_->iter_append_basic(iter_, kTypeInt32, &v) != 0;
+}
+bool DBus::Writer::append_uint32(unsigned v) {
+    if (!owner_ || !owner_->impl_ || !iter_) return false;
+    return owner_->impl_->iter_append_basic(iter_, kTypeUInt32, &v) != 0;
+}
+bool DBus::Writer::append_double(double v) {
+    if (!owner_ || !owner_->impl_ || !iter_) return false;
+    return owner_->impl_->iter_append_basic(iter_, kTypeDouble, &v) != 0;
+}
+DBus::Writer::Container DBus::Writer::open_array(const std::string& element_signature) {
+    Container c;
+    if (!owner_ || !owner_->impl_ || !iter_) return c;
+    c.iter = new Impl::IterBuf();
+    c.open = owner_->impl_->iter_open_container(
+        iter_, kTypeArray, element_signature.c_str(), c.iter) != 0;
+    if (!c.open) { delete static_cast<Impl::IterBuf*>(c.iter); c.iter = nullptr; }
+    return c;
+}
+DBus::Writer::Container DBus::Writer::open_struct() {
+    Container c;
+    if (!owner_ || !owner_->impl_ || !iter_) return c;
+    c.iter = new Impl::IterBuf();
+    c.open = owner_->impl_->iter_open_container(iter_, kTypeStruct, nullptr, c.iter) != 0;
+    if (!c.open) { delete static_cast<Impl::IterBuf*>(c.iter); c.iter = nullptr; }
+    return c;
+}
+DBus::Writer::Container DBus::Writer::open_variant(const std::string& value_signature) {
+    Container c;
+    if (!owner_ || !owner_->impl_ || !iter_) return c;
+    c.iter = new Impl::IterBuf();
+    c.open = owner_->impl_->iter_open_container(
+        iter_, kTypeVariant, value_signature.c_str(), c.iter) != 0;
+    if (!c.open) { delete static_cast<Impl::IterBuf*>(c.iter); c.iter = nullptr; }
+    return c;
+}
+DBus::Writer::Container DBus::Writer::open_dict_entry() {
+    Container c;
+    if (!owner_ || !owner_->impl_ || !iter_) return c;
+    c.iter = new Impl::IterBuf();
+    c.open = owner_->impl_->iter_open_container(iter_, kTypeDictEnt, nullptr, c.iter) != 0;
+    if (!c.open) { delete static_cast<Impl::IterBuf*>(c.iter); c.iter = nullptr; }
+    return c;
+}
+bool DBus::Writer::close_container(Container& c) {
+    if (!owner_ || !owner_->impl_ || !iter_ || !c.open || !c.iter) return false;
+    const bool ok = owner_->impl_->iter_close_container(iter_, c.iter) != 0;
+    delete static_cast<Impl::IterBuf*>(c.iter);
+    c.iter = nullptr;
+    c.open = false;
+    return ok;
+}
+DBus::Writer DBus::Writer::sub(Container& c) {
+    return Writer(owner_, c.iter);
+}
+
+// ── CallContext ─────────────────────────────────────────────────────────────
+DBus::Writer DBus::CallContext::reply() {
+    if (!owner_ || !owner_->impl_ || answered_) return Writer(owner_, nullptr);
+    answered_ = true;
+    reply_msg_ = owner_->impl_->msg_new_method_return(msg_);
+    if (!reply_msg_) return Writer(owner_, nullptr);
+    // Append-iterator lives for the duration of the reply build. Stash it on the
+    // heap so the returned Writer (and any sub-Writers) stay valid until the
+    // trampoline sends the message. Freed in the trampoline after send.
+    auto* it = new Impl::IterBuf();
+    owner_->impl_->iter_init_append(reply_msg_, it);
+    reply_iter_ = it;
+    return Writer(owner_, it);
+}
+void DBus::CallContext::error(const std::string& name, const std::string& message) {
+    if (!owner_ || !owner_->impl_ || answered_) return;
+    answered_ = true;
+    reply_msg_ = owner_->impl_->msg_new_error(msg_, name.c_str(), message.c_str());
+}
 
 bool DBus::library_available() {
     void* h = dlopen("libdbus-1.so.3", RTLD_LAZY | RTLD_LOCAL);
@@ -185,6 +446,12 @@ DBus::~DBus() {
 }
 
 bool DBus::connected() const { return impl_ && impl_->conn; }
+
+std::string DBus::unique_name() const {
+    if (!connected() || !impl_->get_unique_name) return {};
+    const char* n = impl_->get_unique_name(impl_->conn);
+    return n ? std::string(n) : std::string();
+}
 
 bool DBus::connect_session() {
     if (connected()) return true;
@@ -207,6 +474,80 @@ bool DBus::connect_session() {
     impl->set_exit_on_disconnect(impl->conn, 0u);
     impl_ = impl;
     return true;
+}
+
+bool DBus::register_object(const std::string& path, IncomingHandler handler) {
+    if (!connect_session()) return false;
+    Impl& d = *impl_;
+
+    // Fill the shared vtable in place: only message_function is needed (the
+    // unregister hook is optional; we route everything through the trampoline).
+    auto* vt = reinterpret_cast<Impl::VTable*>(&d.vtable);
+    vt->unregister_function = nullptr;
+    vt->message_function = &Impl::trampoline;
+    vt->pad1 = vt->pad2 = vt->pad3 = vt->pad4 = nullptr;
+
+    // A path already in the table is registered with libdbus already; updating
+    // the handler is a pure in-table replace (the trampoline looks the path up
+    // per call), so skip the libdbus registration in that case.
+    const bool already_registered = d.handlers.count(path) != 0;
+    d.handlers[path] = std::move(handler);
+    if (already_registered) return true;
+
+    Impl::ErrBuf err;
+    d.error_init(&err);
+    const unsigned ok = d.try_register_object_path(
+        d.conn, path.c_str(), &d.vtable, &d /*user_data*/, &err);
+    const bool failed = (ok == 0) || d.error_is_set(&err);
+    d.error_free(&err);
+    if (failed) {
+        // First-time registration failed (OOM or libdbus rejected the path).
+        // Honest-fail and drop the handler we speculatively inserted.
+        d.handlers.erase(path);
+        return false;
+    }
+    return true;
+}
+
+bool DBus::unregister_object(const std::string& path) {
+    if (!connected()) return false;
+    Impl& d = *impl_;
+    auto it = d.handlers.find(path);
+    if (it == d.handlers.end()) return false;
+    d.handlers.erase(it);
+    return d.unregister_object_path(d.conn, path.c_str()) != 0;
+}
+
+bool DBus::emit_signal(const std::string& path, const std::string& interface,
+                       const std::string& member,
+                       const std::function<void(Writer&)>& build_args) {
+    if (!connect_session()) return false;
+    Impl& d = *impl_;
+
+    void* msg = d.msg_new_signal(path.c_str(), interface.c_str(), member.c_str());
+    if (!msg) return false;
+
+    Impl::IterBuf args;
+    d.iter_init_append(msg, &args);
+    if (build_args) {
+        Writer w(this, &args);
+        build_args(w);
+    }
+
+    const bool sent = d.conn_send(d.conn, msg, nullptr) != 0;
+    d.msg_unref(msg);
+    if (sent) d.conn_flush(d.conn);
+    return sent;
+}
+
+bool DBus::dispatch(int timeout_ms) {
+    if (!connected()) return false;
+    // read_write_dispatch runs the libdbus dispatcher so registered object-path
+    // handlers (the trampoline) actually fire. This is the object-server
+    // consumption model; the portal file_chooser pump uses pop_message instead,
+    // which removes messages BEFORE the dispatcher would route them. Do not
+    // interleave the two on the same pending traffic.
+    return impl_->read_write_dispatch(impl_->conn, timeout_ms) != 0;
 }
 
 std::optional<DBus::PortalResult> DBus::file_chooser(
@@ -334,11 +675,43 @@ std::optional<DBus::PortalResult> DBus::file_chooser(
 
 namespace pulp::platform {
 struct DBus::Impl {};
+
+// Reader / Writer / CallContext facades are never constructed off Linux (no
+// handler ever fires, emit_signal returns early), but their member functions
+// must still link. Provide inert stubs.
+bool DBus::Reader::read_string(std::string&) { return false; }
+bool DBus::Reader::read_int32(int&) { return false; }
+bool DBus::Reader::read_uint32(unsigned&) { return false; }
+bool DBus::Reader::read_double(double&) { return false; }
+int  DBus::Reader::arg_type() const { return 0; }
+bool DBus::Reader::next() { return false; }
+
+bool DBus::Writer::append_string(const std::string&) { return false; }
+bool DBus::Writer::append_object_path(const std::string&) { return false; }
+bool DBus::Writer::append_int32(int) { return false; }
+bool DBus::Writer::append_uint32(unsigned) { return false; }
+bool DBus::Writer::append_double(double) { return false; }
+DBus::Writer::Container DBus::Writer::open_array(const std::string&) { return {}; }
+DBus::Writer::Container DBus::Writer::open_struct() { return {}; }
+DBus::Writer::Container DBus::Writer::open_variant(const std::string&) { return {}; }
+DBus::Writer::Container DBus::Writer::open_dict_entry() { return {}; }
+bool DBus::Writer::close_container(Container&) { return false; }
+DBus::Writer DBus::Writer::sub(Container& c) { return Writer(owner_, c.iter); }
+
+DBus::Writer DBus::CallContext::reply() { return Writer(owner_, nullptr); }
+void DBus::CallContext::error(const std::string&, const std::string&) {}
+
 bool DBus::library_available() { return false; }
 DBus::DBus() = default;
 DBus::~DBus() = default;
 bool DBus::connected() const { return false; }
+std::string DBus::unique_name() const { return {}; }
 bool DBus::connect_session() { return false; }
+bool DBus::register_object(const std::string&, IncomingHandler) { return false; }
+bool DBus::unregister_object(const std::string&) { return false; }
+bool DBus::emit_signal(const std::string&, const std::string&, const std::string&,
+                       const std::function<void(Writer&)>&) { return false; }
+bool DBus::dispatch(int) { return false; }
 std::optional<DBus::PortalResult> DBus::file_chooser(
     const std::string&, const std::string&,
     const std::map<std::string, std::string>&,

--- a/test/test_dbus.cpp
+++ b/test/test_dbus.cpp
@@ -18,8 +18,14 @@
 #include <pulp/platform/dbus.hpp>
 #include <pulp/platform/file_dialog.hpp>
 
+#include <atomic>
 #include <cstdlib>
 #include <string>
+#include <thread>
+
+#if defined(__linux__)
+#include <dlfcn.h>
+#endif
 
 using pulp::platform::DBus;
 using pulp::platform::FileDialog;
@@ -120,6 +126,196 @@ TEST_CASE("FileDialog::install_native_backend preserves a host-set backend",
     FileDialog::clear_backend();
 }
 #endif // !defined(__APPLE__)
+
+// ── Object-server layer (L7a-1) ─────────────────────────────────────────────
+//
+// Generic, AT-SPI-agnostic D-Bus object server. The CI-verifiable proof is a
+// same-process loopback: register an object that answers Echo(s)->s, then make a
+// blocking method call to our OWN unique bus name + path, dispatch() to service
+// the incoming call, and assert the reply round-tripped. Runs under
+// `dbus-run-session -- ctest` (ephemeral private session bus, headless). Off
+// Linux / without a bus, every object-server method honest-fails (false/empty).
+
+TEST_CASE("DBus object-server honest-fails without a bus",
+          "[platform][dbus][objectserver][issue-L7a1]") {
+    DBus bus;  // never connected
+    REQUIRE_FALSE(bus.connected());
+    REQUIRE(bus.unique_name().empty());
+    REQUIRE_FALSE(bus.register_object("/pulp/test", [](DBus::CallContext&) { return true; }));
+    REQUIRE_FALSE(bus.unregister_object("/pulp/test"));
+    REQUIRE_FALSE(bus.emit_signal("/pulp/test", "pulp.Test", "Ping",
+                                  [](DBus::Writer&) {}));
+    REQUIRE_FALSE(bus.dispatch(0));
+}
+
+#if defined(__linux__)
+namespace {
+// Minimal raw-libdbus client used ONLY by the loopback test to issue a blocking
+// Echo(s)->s call at an arbitrary bus name. The production DBus facade exposes
+// only the object-SERVER surface for L7a-1 (a generic client call is a later
+// concern), so the test drives the client half through dlopen'd libdbus
+// directly — proving a genuine cross-connection round-trip over the session bus.
+struct RawClient {
+    void* h = nullptr;
+    void* (*bus_get_private)(int, void*) = nullptr;
+    void (*conn_close)(void*) = nullptr;
+    void (*conn_unref)(void*) = nullptr;
+    void (*set_exit)(void*, unsigned) = nullptr;
+    void (*error_init)(void*) = nullptr;
+    void (*error_free)(void*) = nullptr;
+    unsigned (*error_is_set)(void*) = nullptr;
+    void* (*new_call)(const char*, const char*, const char*, const char*) = nullptr;
+    void (*msg_unref)(void*) = nullptr;
+    void (*iter_init_append)(void*, void*) = nullptr;
+    unsigned (*iter_append)(void*, int, const void*) = nullptr;
+    unsigned (*iter_init)(void*, void*) = nullptr;
+    int (*iter_argtype)(void*) = nullptr;
+    void (*iter_getbasic)(void*, void*) = nullptr;
+    void* (*send_block)(void*, void*, int, void*) = nullptr;
+
+    template <typename Fn> Fn sym(const char* n) { return reinterpret_cast<Fn>(dlsym(h, n)); }
+
+    bool load() {
+        h = dlopen("libdbus-1.so.3", RTLD_LAZY | RTLD_LOCAL);
+        if (!h) h = dlopen("libdbus-1.so", RTLD_LAZY | RTLD_LOCAL);
+        if (!h) return false;
+        bus_get_private = sym<decltype(bus_get_private)>("dbus_bus_get_private");
+        conn_close = sym<decltype(conn_close)>("dbus_connection_close");
+        conn_unref = sym<decltype(conn_unref)>("dbus_connection_unref");
+        set_exit = sym<decltype(set_exit)>("dbus_connection_set_exit_on_disconnect");
+        error_init = sym<decltype(error_init)>("dbus_error_init");
+        error_free = sym<decltype(error_free)>("dbus_error_free");
+        error_is_set = sym<decltype(error_is_set)>("dbus_error_is_set");
+        new_call = sym<decltype(new_call)>("dbus_message_new_method_call");
+        msg_unref = sym<decltype(msg_unref)>("dbus_message_unref");
+        iter_init_append = sym<decltype(iter_init_append)>("dbus_message_iter_init_append");
+        iter_append = sym<decltype(iter_append)>("dbus_message_iter_append_basic");
+        iter_init = sym<decltype(iter_init)>("dbus_message_iter_init");
+        iter_argtype = sym<decltype(iter_argtype)>("dbus_message_iter_get_arg_type");
+        iter_getbasic = sym<decltype(iter_getbasic)>("dbus_message_iter_get_basic");
+        send_block = sym<decltype(send_block)>("dbus_connection_send_with_reply_and_block");
+        return bus_get_private && conn_close && conn_unref && set_exit && error_init &&
+               error_free && error_is_set && new_call && msg_unref && iter_init_append &&
+               iter_append && iter_init && iter_argtype && iter_getbasic && send_block;
+    }
+};
+}  // namespace
+
+TEST_CASE("DBus object-server loopback round-trips a method call",
+          "[platform][dbus][objectserver][issue-L7a1][linux]") {
+    if (!DBus::library_available()) {
+        SUCCEED("skipped: libdbus not available");
+        return;
+    }
+
+    // Server connection: exports /pulp/test answering Echo(s)->s and Fail()->error.
+    DBus server;
+    if (!server.connect_session()) {
+        SUCCEED("skipped: no session bus (run under dbus-run-session)");
+        return;
+    }
+    REQUIRE(server.connected());
+    const std::string server_name = server.unique_name();
+    REQUIRE_FALSE(server_name.empty());
+
+    std::atomic<bool> handler_saw_call{false};
+    REQUIRE(server.register_object(
+        "/pulp/test",
+        [&](DBus::CallContext& ctx) -> bool {
+            handler_saw_call = true;
+            if (ctx.member() == "Echo") {
+                std::string in;
+                if (!ctx.args().read_string(in)) {
+                    ctx.error("org.freedesktop.DBus.Error.InvalidArgs", "expected s");
+                    return true;
+                }
+                DBus::Writer w = ctx.reply();
+                w.append_string(in + ":echoed");
+                return true;
+            }
+            if (ctx.member() == "Fail") {
+                ctx.error("pulp.Test.Error.Boom", "kaboom");
+                return true;
+            }
+            return false;  // decline → server replies UnknownMethod
+        }));
+
+    // emit_signal builds + sends (no subscriber needed to prove marshalling).
+    REQUIRE(server.emit_signal(
+        "/pulp/test", "pulp.Test", "Pinged",
+        [](DBus::Writer& w) { w.append_string("hello"); }));
+
+    RawClient rc;
+    REQUIRE(rc.load());
+
+    // The blocking call (worker thread) and the server dispatcher (main thread)
+    // run concurrently: send_with_reply_and_block pumps only the CLIENT
+    // connection, so the SERVER connection must dispatch() to route + answer the
+    // incoming call. Without the concurrent dispatch the call would time out.
+    std::string echoed;
+    std::atomic<bool> call_done{false};
+    std::atomic<bool> call_ok{false};
+
+    std::thread worker([&] {
+        unsigned char errbuf[64];
+        unsigned char itbuf[128];
+        rc.error_init(errbuf);
+        void* conn = rc.bus_get_private(/*DBUS_BUS_SESSION*/ 0, errbuf);
+        if (!conn || rc.error_is_set(errbuf)) {
+            if (conn) { rc.conn_close(conn); rc.conn_unref(conn); }
+            rc.error_free(errbuf);
+            call_done = true;
+            return;
+        }
+        rc.set_exit(conn, 0u);
+
+        void* msg = rc.new_call(server_name.c_str(), "/pulp/test",
+                                "pulp.Test", "Echo");
+        const char* arg = "ping";
+        rc.iter_init_append(msg, itbuf);
+        rc.iter_append(itbuf, /*'s'*/ 's', &arg);
+
+        rc.error_init(errbuf);
+        void* reply = rc.send_block(conn, msg, 5000, errbuf);
+        rc.msg_unref(msg);
+        if (reply && !rc.error_is_set(errbuf)) {
+            unsigned char rit[128];
+            if (rc.iter_init(reply, rit) && rc.iter_argtype(rit) == /*'s'*/ 's') {
+                const char* s = nullptr;
+                rc.iter_getbasic(rit, &s);
+                if (s) { echoed = s; call_ok = true; }
+            }
+        }
+        if (reply) rc.msg_unref(reply);
+        rc.error_free(errbuf);
+        rc.conn_close(conn);
+        rc.conn_unref(conn);
+        call_done = true;
+    });
+
+    // Service the incoming call on the server connection until the worker
+    // observes its reply (bounded so a wedge fails the test instead of hanging).
+    for (int i = 0; i < 200 && !call_done.load(); ++i) {
+        server.dispatch(25);
+    }
+    worker.join();
+
+    REQUIRE(call_ok.load());
+    REQUIRE(echoed == "ping:echoed");
+    REQUIRE(handler_saw_call.load());
+
+    REQUIRE(server.unregister_object("/pulp/test"));
+    // Re-registration after teardown works (handler-replace contract).
+    REQUIRE(server.register_object("/pulp/test",
+                                   [](DBus::CallContext&) { return true; }));
+    REQUIRE(server.unregister_object("/pulp/test"));
+}
+#else  // ── object-server loopback: Linux-only runtime; stub elsewhere ────────
+TEST_CASE("DBus object-server loopback round-trips a method call",
+          "[platform][dbus][objectserver][issue-L7a1]") {
+    SUCCEED("D-Bus object server is a Linux-only runtime backend");
+}
+#endif
 
 #if defined(__linux__)
 TEST_CASE("Linux portal backend honest-fails when no portal is running",


### PR DESCRIPTION
First slice of L7 (AT-SPI direct-D-Bus, see `planning/2026-06-09-L7-atspi-direct-dbus-plan.md`). Adds a **generic, AT-SPI-agnostic D-Bus object-server** to `pulp::platform::DBus`, which was portal-client-only (couldn't export objects / answer incoming calls / emit signals) — the prerequisite for AT-SPI and reusable for future MPRIS/notifications.

## What
- `register_object(path, IncomingHandler)` / `unregister_object`, `emit_signal(...)`, `dispatch(timeout)`, `unique_name()`, plus `CallContext` (path/interface/member/sender + `Reader`/`Writer` facades over `DBusMessageIter`).
- One static trampoline via `DBusObjectPathVTable.message_function`; routes by path; **always** replies (handler reply/error, empty return, or `org.freedesktop.DBus.Error.UnknownMethod` on decline — never a silent drop that would hang a caller).
- Uses `dbus_connection_read_write_dispatch` (kept strictly separate from the portal client's `read_write`+`pop_message` pump). Runtime-dlopen libdbus, honest-fail off Linux / without a bus.

## Verification
- macOS (required lane) + this host: the header API + non-Linux honest-fail stubs **build clean** (`pulp-platform`).
- **VM-verified on a real Linux box**: builds against libdbus, and the loopback test under `dbus-run-session` passes **24 assertions / 7 cases** — `register_object` → trampoline → handler → reply round-trip, `emit_signal`, and honest-fail without a bus. (Plain CI runs the test green via the honest-fail path; the bus-backed loopback is the VM proof. Wiring `dbus-run-session` into the Linux lane is a follow-up.)

Part of #3329. Next: L7a-2 (AT-SPI registration) → L7b (per-widget tree) → L7c (value+events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a generic D-Bus object-server to `pulp::platform::DBus` so apps can export objects, handle incoming method calls, and emit signals on Linux. This is L7a‑1 for AT‑SPI and reusable for MPRIS/notifications. Part of #3329.

- **New Features**
  - API: `register_object(...)`/`unregister_object(...)`, `emit_signal(...)`, `dispatch(timeout_ms)`, and `unique_name()`.
  - Call handling: `CallContext` (path/interface/member/sender + `Reader` over args) with `reply()`/`error(...)`; every call gets a reply or `org.freedesktop.DBus.Error.UnknownMethod`.
  - Marshalling: `Reader`/`Writer` for strings/object-paths/int32/uint32/double and containers (array/struct/variant/dict-entry).
  - Dispatcher: uses `dbus_connection_read_write_dispatch`; kept separate from the portal `pop_message` pump.

- **Dependencies**
  - Runtime `libdbus-1` via `dlopen`; off Linux or without a bus these APIs honest-fail (no-ops/false).

<sup>Written for commit 95c2ae553ef343a1465b8bbcd7d8af6f5b4b068f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

