### PR TITLE
refactor: migrate storage style bridge API to registry helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.387.2
+    VERSION 0.387.3
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/widget_bridge/style_storage_api.cpp
+++ b/core/view/src/widget_bridge/style_storage_api.cpp
@@ -1,12 +1,15 @@
 // widget_bridge/style_storage_api.cpp - storage-only CSS style registrations for WidgetBridge.
 
 #include <pulp/view/widget_bridge.hpp>
+#include "api_registry.hpp"
 
 #include <string>
 
 namespace pulp::view {
 
 void WidgetBridge::register_widget_style_background_repeat_api() {
+    BridgeApiContext api{engine_};
+
     // setBackgroundRepeat(id, kw) - CSS background-repeat keyword. Storage-
     // only on the View (no-op for solid-color backgrounds, which is the
     // only currently rendered case). Future paint work for
@@ -16,7 +19,7 @@ void WidgetBridge::register_widget_style_background_repeat_api() {
     // Accepts: `repeat` / `repeat-x` / `repeat-y` / `no-repeat` /
     // `space` / `round`. Unknown / empty resets to "" (paint defaults to
     // CSS initial `repeat`).
-    engine_.register_function("setBackgroundRepeat", [this](choc::javascript::ArgumentList args) {
+    register_bridge_function(api, "setBackgroundRepeat", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto kw = args.get<std::string>(1, "");
         auto* v = id.empty() ? &root_ : widget(id);
@@ -26,12 +29,14 @@ void WidgetBridge::register_widget_style_background_repeat_api() {
 }
 
 void WidgetBridge::register_widget_style_mask_object_api() {
+    BridgeApiContext api{engine_};
+
     // setMaskImage(id, value) - CSS `mask-image` (pulp #1515).
     // Storage-only today; the saveLayer + SkBlendMode::kDstIn shader
     // composite is a follow-up paint slice. The slot round-trips
     // through View::mask_image() so harness tests can assert the
     // bridge accepted the value.
-    engine_.register_function("setMaskImage",
+    register_bridge_function(api, "setMaskImage",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
             auto value = args.get<std::string>(1, "");
@@ -44,7 +49,7 @@ void WidgetBridge::register_widget_style_mask_object_api() {
     // Stores the verbatim shorthand on the View; the JS shim
     // (web-compat-style-decl.js) is responsible for fanning out into
     // the maskImage longhand. Storage-only today.
-    engine_.register_function("setMask",
+    register_bridge_function(api, "setMask",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
             auto value = args.get<std::string>(1, "");
@@ -56,7 +61,7 @@ void WidgetBridge::register_widget_style_mask_object_api() {
     // setMaskSize(id, value) - CSS `mask-size`, pairs with mask-image
     // (pulp #1515 followup). Storage-only; consumed by the same
     // future paint slice that wires the mask shader.
-    engine_.register_function("setMaskSize",
+    register_bridge_function(api, "setMaskSize",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
             auto value = args.get<std::string>(1, "");
@@ -71,7 +76,7 @@ void WidgetBridge::register_widget_style_mask_object_api() {
     // every Pulp View regardless of what the slot says. The slot
     // exists so authors who set `appearance: none` for reset-style
     // consistency see a no-op (not an unsupported drop).
-    engine_.register_function("setAppearance",
+    register_bridge_function(api, "setAppearance",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
             auto value = args.get<std::string>(1, "");
@@ -83,7 +88,7 @@ void WidgetBridge::register_widget_style_mask_object_api() {
     // setObjectFit(id, value) - CSS `object-fit`. Storage-only today;
     // the ImageView paint slice that consumes this needs access to
     // the decoded image's natural size (planned follow-up).
-    engine_.register_function("setObjectFit",
+    register_bridge_function(api, "setObjectFit",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
             auto value = args.get<std::string>(1, "");
@@ -94,7 +99,7 @@ void WidgetBridge::register_widget_style_mask_object_api() {
 
     // setObjectPosition(id, value) - CSS `object-position`. Pairs
     // with object-fit. Storage-only today.
-    engine_.register_function("setObjectPosition",
+    register_bridge_function(api, "setObjectPosition",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
             auto value = args.get<std::string>(1, "");
@@ -105,12 +110,14 @@ void WidgetBridge::register_widget_style_mask_object_api() {
 }
 
 void WidgetBridge::register_widget_style_background_subproperty_api() {
+    BridgeApiContext api{engine_};
+
     // pulp #1517 - background sub-property setters. Storage-only today;
     // see View::set_background_{attachment,clip,origin}() doc for the
     // partial-vs-noop semantics. Wiring them here unblocks the JS shim
     // path and lets the catalog honestly report `noop` / `partial`
     // instead of `missing`.
-    engine_.register_function("setBackgroundAttachment",
+    register_bridge_function(api, "setBackgroundAttachment",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
             auto kw = args.get<std::string>(1, "");
@@ -118,7 +125,7 @@ void WidgetBridge::register_widget_style_background_subproperty_api() {
             if (v) v->set_background_attachment(kw);
             return choc::value::Value();
         });
-    engine_.register_function("setBackgroundClip",
+    register_bridge_function(api, "setBackgroundClip",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
             auto kw = args.get<std::string>(1, "");
@@ -126,7 +133,7 @@ void WidgetBridge::register_widget_style_background_subproperty_api() {
             if (v) v->set_background_clip(kw);
             return choc::value::Value();
         });
-    engine_.register_function("setBackgroundOrigin",
+    register_bridge_function(api, "setBackgroundOrigin",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
             auto kw = args.get<std::string>(1, "");
@@ -144,7 +151,7 @@ void WidgetBridge::register_widget_style_background_subproperty_api() {
     // -> View slot -> get_attribute pulls it back) and unblocks a future
     // raster background-image paint slice - see View::set_background_*
     // doc for the architectural caveat.
-    engine_.register_function("setBackgroundPosition",
+    register_bridge_function(api, "setBackgroundPosition",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
             auto kw = args.get<std::string>(1, "");
@@ -152,7 +159,7 @@ void WidgetBridge::register_widget_style_background_subproperty_api() {
             if (v) v->set_background_position(kw);
             return choc::value::Value();
         });
-    engine_.register_function("setBackgroundSize",
+    register_bridge_function(api, "setBackgroundSize",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
             auto kw = args.get<std::string>(1, "");


### PR DESCRIPTION
## Summary
- migrate storage-style WidgetBridge registrations to `register_bridge_function`
- cover background repeat, mask/object-fit/object-position, and background sub-property setters
- keep handler bodies unchanged while adding registry manifest coverage for this API group

## Validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DPULP_BUILD_TESTS=ON`
- verified `CMAKE_BUILD_TYPE=Release` and `CMAKE_CXX_FLAGS_RELEASE=-O3 -DNDEBUG`
- `cmake --build build --target pulp-test-widget-bridge-api-contracts pulp-test-widget-bridge-css-misc pulp-test-widget-bridge-clip-mask pulp-test-widget-bridge-wave5-css pulp-test-widget-bridge --parallel $(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-widget-bridge-api-contracts '[view][widget-bridge][api-contract]' --reporter compact`
- `./build/test/pulp-test-widget-bridge-css-misc 'WidgetBridge setBackgroundRepeat round-trips keyword on View' --reporter compact`
- `./build/test/pulp-test-widget-bridge-clip-mask 'WidgetBridge setMaskImage / setMask round-trip on the View' --reporter compact`
- `./build/test/pulp-test-widget-bridge-clip-mask 'WidgetBridge setMaskSize round-trips on the View' --reporter compact`
- `./build/test/pulp-test-widget-bridge-clip-mask 'WidgetBridge setAppearance round-trips on the View' --reporter compact`
- `./build/test/pulp-test-widget-bridge-clip-mask 'WidgetBridge setObjectFit round-trips on the View' --reporter compact`
- `./build/test/pulp-test-widget-bridge-clip-mask 'WidgetBridge setObjectPosition round-trips on the View' --reporter compact`
- `./build/test/pulp-test-widget-bridge-wave5-css 'Wave5 css/backgroundPosition wires JS → bridge → View slot' --reporter compact`
- `./build/test/pulp-test-widget-bridge-wave5-css 'Wave5 css/backgroundSize wires JS → bridge → View slot' --reporter compact`
- `./build/test/pulp-test-widget-bridge 'WidgetBridge background sub-properties round-trip onto View slots' --reporter compact`
- `./build/test/pulp-test-widget-bridge 'CSSStyleDeclaration forwards background sub-props to bridge' --reporter compact`
- `python3 tools/scripts/compat_sync_check.py --enforce`
- `python3 tools/scripts/version_bump_check.py --mode=report`
- `git diff --check origin/main..HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated storage-only WidgetBridge style APIs to a registry helper to centralize manifest tracking and simplify wiring. No behavior changes; covers background-repeat, mask-image/mask/mask-size, appearance, object-fit/object-position, and background attachment/clip/origin/position/size.

- **Refactors**
  - Replaced engine-level registrations with the registry helper for: background-repeat; mask-image/mask/mask-size; appearance; object-fit/object-position; background attachment/clip/origin/position/size.
  - Kept handler bodies the same; only the registration path changed.
  - Ensures these APIs are included in the registry manifest.

- **Dependencies**
  - Bump project version to 0.387.3.

<sup>Written for commit ec438c1f4aa58a465ae3ba52fde9f40b433e5675. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

