### PR TITLE
fix(runtime): address post-merge review feedback (#3488 sha256/collision + #3492 caret test)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.387.3
+    VERSION 0.387.4
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/runtime/src/model_store.cpp
+++ b/core/runtime/src/model_store.cpp
@@ -359,7 +359,9 @@ InstallModelResult install_model(const ModelEntry& model, std::string_view subsy
                 r.error = "cannot resolve a download URL for asset '" + a.role + "' of " + model.model_id;
                 return r;
             }
-            items.push_back({u, a.role.empty() ? "asset" : a.role, ""});
+            // Carry the per-asset sha256 so download_file verifies each bundled asset
+            // (matches the single-asset path below); empty means "no pin, skip verify".
+            items.push_back({u, a.role.empty() ? "asset" : a.role, a.sha256});
         }
     } else {
         const std::string u =
@@ -382,9 +384,23 @@ InstallModelResult install_model(const ModelEntry& model, std::string_view subsy
     auto assets_obj = choc::value::createEmptyArray();
     fs::path primary_path;  // the first/weights asset — what the engine loads
 
+    // Destinations are the URL basename (the engine finds a bundle's state file as a
+    // <weights-stem>_state.safetensors sibling, so we must keep real names). If two assets
+    // collide on that basename, downloading the second would silently overwrite the first
+    // and the recorded metadata would point at the wrong contents — fail loudly instead.
+    std::vector<fs::path> seen_dests;
+
     for (int i = 0; i < n; ++i) {
         const auto& it = items[static_cast<size_t>(i)];
         const fs::path dest = files_dir / filename_of(it.url, model.model_id + ".bin");
+        for (const auto& prev : seen_dests) {
+            if (prev == dest) {
+                r.error = "two assets of " + model.model_id + " resolve to the same file '" +
+                          dest.filename().string() + "'; give them distinct names";
+                return r;
+            }
+        }
+        seen_dests.push_back(dest);
 
         DownloadRequest req;
         req.url = it.url;
@@ -401,13 +417,18 @@ InstallModelResult install_model(const ModelEntry& model, std::string_view subsy
         auto wrapped = [&on_progress, idx, n](const DownloadProgress& p) -> bool {
             if (!on_progress) return true;
             DownloadProgress agg = p;
-            if (p.total > 0) {
-                const double frac = (static_cast<double>(idx) +
-                                     static_cast<double>(p.downloaded) / static_cast<double>(p.total)) /
-                                    static_cast<double>(n);
-                agg.downloaded = static_cast<std::uint64_t>(frac * 1'000'000.0);
-                agg.total = 1'000'000;
-            }
+            // Map this asset's progress into one monotonic 0→1'000'000 bar across all n
+            // assets. When the server omits Content-Length (p.total == 0) we can't know the
+            // within-asset fraction, so pin to this asset's start boundary — otherwise agg
+            // would carry the raw byte count and the bar would visibly snap back to ~0 at
+            // each asset transition.
+            const double base = static_cast<double>(idx) / static_cast<double>(n);
+            const double frac = p.total > 0
+                                    ? base + (static_cast<double>(p.downloaded) /
+                                              static_cast<double>(p.total)) / static_cast<double>(n)
+                                    : base;
+            agg.downloaded = static_cast<std::uint64_t>(frac * 1'000'000.0);
+            agg.total = 1'000'000;
             return on_progress(agg);
         };
 

--- a/test/test_model_download.cpp
+++ b/test/test_model_download.cpp
@@ -318,10 +318,14 @@ TEST_CASE("model store: install_model fetches every asset of a multi-asset bundl
 
     ModelEntry model{.model_id = "mrt2", .display_name = "MRT2", .backend = "mlx"};
     model.assets = {
-        ModelAsset{.role = "weights", .checkpoint_ref = server.url("/mrt2.mlxfn")},
-        ModelAsset{.role = "state", .checkpoint_ref = server.url("/mrt2_state.safetensors")},
+        ModelAsset{.role = "weights", .checkpoint_ref = server.url("/mrt2.mlxfn"),
+                   .sha256 = sha256_hex(weights)},
+        ModelAsset{.role = "state", .checkpoint_ref = server.url("/mrt2_state.safetensors"),
+                   .sha256 = sha256_hex(state)},
     };
 
+    // Correct per-asset hashes must pass verification (the install must honor them, not
+    // silently skip — see the mismatch test below).
     auto inst = install_model(model, "magenta", /*on_progress=*/{}, /*cancel=*/nullptr,
                               /*headers=*/{}, home);
     INFO("install error: " << inst.error);
@@ -341,6 +345,65 @@ TEST_CASE("model store: install_model fetches every asset of a multi-asset bundl
     const std::string meta((std::istreambuf_iterator<char>(meta_in)), std::istreambuf_iterator<char>());
     REQUIRE(meta.find("\"weights\"") != std::string::npos);
     REQUIRE(meta.find("\"state\"") != std::string::npos);
+
+    meta_in.close();  // release the handle before remove_all (Windows can't unlink an open file)
+    fs::remove_all(root);
+}
+
+TEST_CASE("model store: install_model verifies each bundle asset's sha256",
+          "[runtime][model][download]") {
+    // A pinned-but-wrong hash on a secondary asset must fail the install — the bundle
+    // path must honor ModelAsset::sha256, not silently skip verification.
+    const fs::path root = fs::temp_directory_path() / "pulp-mm-multiasset-badsha";
+    fs::remove_all(root);
+    fs::create_directories(root / "serve");
+    const std::string weights = make_fixture(root / "serve" / "m.mlxfn", 40'000);
+    make_fixture(root / "serve" / "m_state.safetensors", 20'000);
+
+    LocalServer server(root / "serve");
+    const fs::path home = root / "home";
+
+    ModelEntry model{.model_id = "m", .display_name = "M", .backend = "mlx"};
+    model.assets = {
+        ModelAsset{.role = "weights", .checkpoint_ref = server.url("/m.mlxfn"),
+                   .sha256 = sha256_hex(weights)},
+        ModelAsset{.role = "state", .checkpoint_ref = server.url("/m_state.safetensors"),
+                   .sha256 = std::string(64, 'a')},  // wrong on purpose
+    };
+
+    auto inst = install_model(model, "magenta", /*on_progress=*/{}, /*cancel=*/nullptr,
+                              /*headers=*/{}, home);
+    REQUIRE_FALSE(inst.ok);
+    REQUIRE(inst.error.find("mismatch") != std::string::npos);
+
+    fs::remove_all(root);
+}
+
+TEST_CASE("model store: install_model rejects a bundle whose assets collide on filename",
+          "[runtime][model][download]") {
+    // Two assets from different paths but the same leaf name would overwrite each other on
+    // disk (destinations are URL basenames so the engine can find sibling files); the install
+    // must fail loudly rather than report success with one file silently clobbered.
+    const fs::path root = fs::temp_directory_path() / "pulp-mm-multiasset-collide";
+    fs::remove_all(root);
+    fs::create_directories(root / "serve" / "a");
+    fs::create_directories(root / "serve" / "b");
+    make_fixture(root / "serve" / "a" / "model.bin", 1'000);
+    make_fixture(root / "serve" / "b" / "model.bin", 1'000);
+
+    LocalServer server(root / "serve");
+    const fs::path home = root / "home";
+
+    ModelEntry model{.model_id = "dup", .display_name = "Dup", .backend = "mlx"};
+    model.assets = {
+        ModelAsset{.role = "weights", .checkpoint_ref = server.url("/a/model.bin")},
+        ModelAsset{.role = "state", .checkpoint_ref = server.url("/b/model.bin")},
+    };
+
+    auto inst = install_model(model, "magenta", /*on_progress=*/{}, /*cancel=*/nullptr,
+                              /*headers=*/{}, home);
+    REQUIRE_FALSE(inst.ok);
+    REQUIRE(inst.error.find("same file") != std::string::npos);
 
     fs::remove_all(root);
 }

--- a/test/test_text_editor.cpp
+++ b/test/test_text_editor.cpp
@@ -29,6 +29,20 @@ uint16_t main_modifier() {
 #endif
 }
 
+// A canvas whose shaped text_x_for_byte() deliberately diverges from the sum of
+// isolated per-glyph measure_text() widths — the exact gap that kerning/spacing
+// produces with a real shaper. A caret built from shaped offsets lands near 500+;
+// one built by summing glyph widths (the pre-fix path) lands near 16. Used to
+// assert TextEditor::paint feeds caret_rect() from text_x_for_byte, not glyph sums.
+struct ShapedOffsetCanvas : RecordingCanvas {
+    float measure_text(const std::string& text) override {
+        return 8.0f * static_cast<float>(text.size());
+    }
+    float text_x_for_byte(const std::string& text, std::size_t byte_index) override {
+        return 500.0f + static_cast<float>(std::min(byte_index, text.size()));
+    }
+};
+
 } // namespace
 
 TEST_CASE("TextEditor set and get text", "[view][text_editor]") {
@@ -469,6 +483,25 @@ TEST_CASE("TextEditor caret_rect has a fallback before first paint",
     REQUIRE(rect.y == 2.0f);
     REQUIRE(rect.width == 1.5f);
     REQUIRE(rect.height >= 13.0f);
+}
+
+TEST_CASE("TextEditor caret X comes from shaped offsets, not summed glyph widths",
+          "[view][text_editor][paint]") {
+    // Regression guard for the caret/selection-X fix: paint() must populate the layout's
+    // x_offsets from canvas.text_x_for_byte() (which a real shaper kerns), not from summing
+    // isolated measure_text() advances. ShapedOffsetCanvas makes the two paths diverge by
+    // ~500 px so the caret position reveals which one fed it.
+    TextEditor editor;
+    editor.on_focus_changed(true);              // so set_text leaves the caret at the end
+    editor.set_bounds({0, 0, 800, 24});
+    editor.set_text("AV");                      // caret now at byte 2
+
+    ShapedOffsetCanvas canvas;
+    editor.paint(canvas);
+
+    const auto rect = editor.caret_rect();
+    // Shaped offset for byte 2 is 502; the pre-fix glyph-sum path would put it near 16.
+    REQUIRE(rect.x > 400.0f);
 }
 
 TEST_CASE("TextEditor multi-line paint renders placeholder when unfocused",


### PR DESCRIPTION
Addresses the review-bot feedback left on the now-merged #3488 and #3492.

## #3488 — multi-asset `install_model` (Codex / Greptile / cubic)
- **P1 — honor per-asset `ModelAsset::sha256`.** The bundle path stored an empty expected hash, so pinned assets were never verified (the single-asset path already passed `model.sha256`). Now carried through. **Test:** a bundle with a mismatched secondary hash must fail the install.
- **P2 — collision guard.** Destinations are URL basenames (the engine finds a bundle's state file as a sibling), so two assets with the same leaf name would silently overwrite. Now fails loudly. **Test:** a two-asset same-basename bundle.
- **P2 — monotonic progress** when `Content-Length` is unknown (`total==0`) — pin to the asset's start boundary instead of snapping the bar back to ~0 between assets.
- **P2 — test handle leak:** close the metadata `ifstream` before `remove_all` (Windows).

## #3492 — TextEditor caret-X (Greptile)
- **P1 — regression test.** `paint()` must feed `caret_rect()` from `canvas.text_x_for_byte()` (kerning-drift-proof), not summed isolated glyph widths. A canvas that diverges the two paths by ~500px proves which one fed the caret.

## Deferred (tracked, not here)
- `list_models` walking secondary-asset paths for integrity.
- A batch `text_x_for_all_bytes` API to cap shaping at one shape per text change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multi-asset model installs by verifying per-asset `sha256`, rejecting filename collisions, and keeping progress monotonic when `Content-Length` is unknown. Adds a regression test that locks TextEditor caret X to shaped offsets.

- **Bug Fixes**
  - Multi-asset install: carry each asset’s `sha256` for verification; fail on mismatch; reject same-basename collisions to prevent overwrites.
  - Progress: keep the aggregate bar monotonic across assets when `Content-Length` is missing by pinning to each asset’s start boundary.
  - Tests: add caret-X regression using `canvas.text_x_for_byte()`; cover hash-mismatch and filename-collision installs; fix Windows by closing the metadata `ifstream` before cleanup.

<sup>Written for commit 781ef0f2b57ed8ff39bec9b7a5fa9f968cc93172. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

