### PR TITLE
feat(audio): WASAPI shared low-latency (IAudioClient3) + device-invalidation recovery (W4b)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.388.0
+    VERSION 0.389.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/audio/include/pulp/audio/device.hpp
+++ b/core/audio/include/pulp/audio/device.hpp
@@ -37,6 +37,16 @@ struct DeviceConfig {
     int input_channels = 0;
     int output_channels = 2;
     ShareMode share_mode = ShareMode::shared;  // Windows WASAPI only; see above
+
+    // Windows WASAPI only: opt into the shared-mode low-latency path
+    // (IAudioClient3::InitializeSharedAudioStream at the engine's minimum
+    // period). Only honored when `share_mode == ShareMode::shared`; ignored
+    // in exclusive mode (which already drives at the device minimum period)
+    // and on every non-Windows backend. Defaults false so existing callers
+    // and other backends are unaffected. If IAudioClient3 is unavailable or
+    // the low-latency init fails, the backend honestly degrades to the
+    // standard shared-mode Initialize at the requested buffer size.
+    bool low_latency = false;
 };
 
 // Audio callback context — passed to the render function

--- a/core/audio/platform/win/wasapi_device.cpp
+++ b/core/audio/platform/win/wasapi_device.cpp
@@ -83,13 +83,32 @@ bool WasapiDevice::open(const DeviceConfig& config) {
     if (config_.share_mode == ShareMode::exclusive) {
         hr = initialize_exclusive_(mix_format);
     } else {
-        hr = audio_client_->Initialize(
-            AUDCLNT_SHAREMODE_SHARED,
-            AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_NOPERSIST,
-            requested_duration,
-            0,  // periodicity (must be 0 for shared mode)
-            mix_format,
-            nullptr);  // session GUID
+        // Shared mode. When the caller opted into low latency, try the
+        // IAudioClient3 engine-minimum-period path first (W4b); if it can't be
+        // taken (no IAudioClient3, unsupported format/period, or the call
+        // fails), honestly degrade to the standard shared Initialize below.
+        bool low_latency_ok = false;
+        if (config_.low_latency) {
+            HRESULT ll_hr = initialize_shared_low_latency_(mix_format);
+            if (SUCCEEDED(ll_hr)) {
+                low_latency_ok = true;
+                hr = ll_hr;
+            } else {
+                runtime::log_warn(
+                    "WASAPI: shared low-latency (IAudioClient3) unavailable "
+                    "(0x{:08x}); falling back to standard shared init",
+                    static_cast<unsigned>(ll_hr));
+            }
+        }
+        if (!low_latency_ok) {
+            hr = audio_client_->Initialize(
+                AUDCLNT_SHAREMODE_SHARED,
+                AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_NOPERSIST,
+                requested_duration,
+                0,  // periodicity (must be 0 for shared mode)
+                mix_format,
+                nullptr);  // session GUID
+        }
     }
 
     CoTaskMemFree(mix_format);
@@ -209,6 +228,55 @@ HRESULT WasapiDevice::initialize_exclusive_(WAVEFORMATEX* fmt) {
     return hr;
 }
 
+HRESULT WasapiDevice::initialize_shared_low_latency_(WAVEFORMATEX* fmt) {
+    // IAudioClient3 (Win10+) exposes the engine's glitch-free period range for a
+    // given shared-mode format. We drive the stream at the MINIMUM period so the
+    // shared engine buffer is as small as the driver permits. If the interface
+    // or any of its calls is unavailable, the caller falls back to the standard
+    // shared Initialize.
+    IAudioClient3* client3 = nullptr;
+    HRESULT hr = audio_client_->QueryInterface(
+        __uuidof(IAudioClient3), reinterpret_cast<void**>(&client3));
+    if (FAILED(hr) || client3 == nullptr) {
+        return FAILED(hr) ? hr : E_NOINTERFACE;
+    }
+
+    // Query the supported shared-mode engine period range for this format.
+    // Periods are expressed in frames at the format's sample rate.
+    UINT32 default_period = 0, fundamental = 0, min_period = 0, max_period = 0;
+    hr = client3->GetSharedModeEnginePeriod(
+        fmt, &default_period, &fundamental, &min_period, &max_period);
+    if (FAILED(hr)) {
+        client3->Release();
+        return hr;
+    }
+
+    // InitializeSharedAudioStream requires the requested period to be a valid
+    // value in [min_period, max_period]. We want the lowest latency, so use the
+    // minimum the engine reported. AUTOCONVERTPCM is NOT set: we already opened
+    // at the device mix format, so no resampling is required.
+    hr = client3->InitializeSharedAudioStream(
+        AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_NOPERSIST,
+        min_period,
+        fmt,
+        nullptr);  // session GUID
+
+    client3->Release();  // audio_client_ still holds the initialized stream
+    return hr;
+}
+
+void WasapiDevice::on_device_invalidated_() {
+    runtime::log_warn(
+        "WASAPI: device invalidated ({} stream); stopping and notifying host",
+        flow_ == eCapture ? "capture" : "render");
+    // Stop the loop. The thread is about to break; stop()/close() called from
+    // the host (in response to the notification) will join us and release COM.
+    is_running_.store(false, std::memory_order_release);
+    // Notify the host so it can re-open the device. We do NOT attempt a
+    // transparent in-place reopen — clean-stop + notify is the contract.
+    if (owner_) owner_->fire_device_change();
+}
+
 void WasapiDevice::close() {
     if (render_client_)  { render_client_->Release();  render_client_  = nullptr; }
     if (capture_client_) { capture_client_->Release(); capture_client_ = nullptr; }
@@ -308,6 +376,7 @@ void WasapiDevice::render_thread_func() {
         // How many frames are available in the buffer?
         UINT32 padding = 0;
         HRESULT hr = audio_client_->GetCurrentPadding(&padding);
+        if (hr == AUDCLNT_E_DEVICE_INVALIDATED) { on_device_invalidated_(); break; }
         if (FAILED(hr)) continue;
 
         UINT32 available = buffer_frames_ - padding;
@@ -316,6 +385,7 @@ void WasapiDevice::render_thread_func() {
         // Get the output buffer from WASAPI
         BYTE* data = nullptr;
         hr = render_client_->GetBuffer(available, &data);
+        if (hr == AUDCLNT_E_DEVICE_INVALIDATED) { on_device_invalidated_(); break; }
         if (FAILED(hr)) continue;
 
         auto* interleaved = reinterpret_cast<float*>(data);
@@ -390,6 +460,7 @@ void WasapiDevice::capture_thread_func() {
         // GetNextPacketSize == 0.
         UINT32 packet_frames = 0;
         HRESULT hr = capture_client_->GetNextPacketSize(&packet_frames);
+        if (hr == AUDCLNT_E_DEVICE_INVALIDATED) { on_device_invalidated_(); break; }
         if (FAILED(hr)) continue;
 
         while (packet_frames > 0 && is_running_.load(std::memory_order_relaxed)) {
@@ -398,6 +469,7 @@ void WasapiDevice::capture_thread_func() {
             DWORD  flags        = 0;
 
             hr = capture_client_->GetBuffer(&data, &frames, &flags, nullptr, nullptr);
+            if (hr == AUDCLNT_E_DEVICE_INVALIDATED) { on_device_invalidated_(); break; }
             if (FAILED(hr) || frames == 0) {
                 if (SUCCEEDED(hr)) capture_client_->ReleaseBuffer(frames);
                 break;
@@ -458,6 +530,7 @@ void WasapiDevice::capture_thread_func() {
             sample_position_ += frames;
 
             hr = capture_client_->GetNextPacketSize(&packet_frames);
+            if (hr == AUDCLNT_E_DEVICE_INVALIDATED) { on_device_invalidated_(); break; }
             if (FAILED(hr)) break;
         }
     }
@@ -717,7 +790,13 @@ std::unique_ptr<AudioDevice> WasapiSystem::create_device(const std::string& devi
         endpoint->Release();
     }
 
-    return std::make_unique<WasapiDevice>(device, flow);
+    auto wasapi_device = std::make_unique<WasapiDevice>(device, flow);
+    // Wire the back-pointer so the I/O thread can fire device-change on
+    // AUDCLNT_E_DEVICE_INVALIDATED (W4b). WasapiSystem outlives the devices it
+    // creates in normal usage; the device clears nothing on its side, it just
+    // calls fire_device_change() through this pointer.
+    wasapi_device->set_owner(this);
+    return wasapi_device;
 }
 
 DeviceInfo WasapiSystem::default_output_device() {

--- a/core/audio/platform/win/wasapi_device.hpp
+++ b/core/audio/platform/win/wasapi_device.hpp
@@ -44,15 +44,35 @@ namespace pulp::audio::win {
 // period for low latency, with the documented AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED
 // re-activation retry. Shared mode stays the default.
 //
-// Still deferred (W4b follow-up):
-//   * `AUDCLNT_SHAREMODE_SHARED` low-latency variant
-//       (IAudioClient3::InitializeSharedAudioStream at the engine min period).
-//   * Transparent sample-rate-change / AUDCLNT_E_DEVICE_INVALIDATED recovery
-//       (today an invalidated stream stops cleanly; the host re-opens).
+// `AUDCLNT_SHAREMODE_SHARED` low-latency (W4b) is supported via IAudioClient3:
+// when `DeviceConfig::low_latency` is set on a shared-mode open we query
+// `GetSharedModeEnginePeriod` and call `InitializeSharedAudioStream` at the
+// engine's MINIMUM period (so the engine glitch-free buffer is as small as the
+// driver allows). If IAudioClient3 cannot be obtained, the format is rejected
+// by `IsFormatSupported`, the min period is out of the supported range, or
+// `InitializeSharedAudioStream` fails for any reason, we honestly degrade to
+// the standard shared-mode `Initialize` at the requested buffer size — never a
+// half-open stream.
+//
+// Device-invalidation / sample-rate-change recovery (W4b): the render/capture
+// threads watch for `AUDCLNT_E_DEVICE_INVALIDATED` (the HRESULT WASAPI returns
+// from GetBuffer / GetCurrentPadding / GetNextPacketSize when the endpoint
+// disappears, is reconfigured, or its mix format / sample rate changes under
+// us). On that error the thread stops cleanly (sets is_running_ false, breaks
+// its loop) and fires the AudioSystem device-change notification so the host
+// can re-open the device at the new format. Transparent in-place reopen is
+// deliberately NOT attempted — clean-stop + notify is the contract, matching
+// the hotplug notifier (issue #243).
 class WasapiDevice : public AudioDevice {
 public:
     explicit WasapiDevice(IMMDevice* device, EDataFlow flow = eRender);
     ~WasapiDevice() override;
+
+    // Set the owning AudioSystem so the I/O thread can fire device-change
+    // notifications on AUDCLNT_E_DEVICE_INVALIDATED (W4b). WasapiSystem wires
+    // this in create_device(). May be nullptr; if so, invalidation still stops
+    // the stream cleanly but no notification is dispatched.
+    void set_owner(AudioSystem* owner) { owner_ = owner; }
 
     bool open(const DeviceConfig& config) override;
     void close() override;
@@ -82,8 +102,23 @@ private:
     // HRESULT; on success audio_client_ is initialized and event-driven.
     HRESULT initialize_exclusive_(WAVEFORMATEX* fmt);
 
+    // Shared-mode low-latency Initialize via IAudioClient3 (W4b). Queries
+    // GetSharedModeEnginePeriod and calls InitializeSharedAudioStream at the
+    // engine's minimum supported period. Returns the HRESULT from
+    // InitializeSharedAudioStream on success, or a failure HRESULT if
+    // IAudioClient3 is unavailable / the format or period is unsupported — in
+    // which case the caller falls back to the standard shared Initialize.
+    HRESULT initialize_shared_low_latency_(WAVEFORMATEX* fmt);
+
+    // Handle AUDCLNT_E_DEVICE_INVALIDATED from an I/O thread (W4b): mark the
+    // stream not-running and fire the owning AudioSystem's device-change
+    // notification so the host can re-open. Idempotent-safe to call once per
+    // invalidation; the caller breaks its loop afterwards.
+    void on_device_invalidated_();
+
     IMMDevice*           device_         = nullptr;
     EDataFlow            flow_           = eRender;
+    AudioSystem*         owner_          = nullptr;  // for device-change notify (W4b)
     IAudioClient*        audio_client_   = nullptr;
     IAudioRenderClient*  render_client_  = nullptr;  // populated when flow_ == eRender
     IAudioCaptureClient* capture_client_ = nullptr;  // populated when flow_ == eCapture

--- a/docs/guides/platforms/windows.md
+++ b/docs/guides/platforms/windows.md
@@ -61,14 +61,17 @@ cmake --build build
 
 ## Audio I/O (WASAPI)
 
-Pulp uses WASAPI (Windows Audio Session API) for low-latency audio on Windows. The implementation uses shared mode with event-driven buffering.
+Pulp uses WASAPI (Windows Audio Session API) for low-latency audio on Windows. The implementation defaults to shared mode with event-driven buffering, and also supports exclusive mode and a shared low-latency path.
 
 ### How It Works
 
-- **Shared mode**: audio is mixed with other applications (no exclusive device lock)
+- **Shared mode** (default): audio is mixed with other applications (no exclusive device lock)
+- **Exclusive mode**: `DeviceConfig::share_mode = ShareMode::exclusive` takes sole ownership of the endpoint and drives it at the device's minimum period for the lowest latency. If the endpoint disallows exclusive access or the mix format is unsupported there, `open()` honest-fails so the caller can fall back to shared.
+- **Shared low-latency**: `DeviceConfig::low_latency = true` (shared mode only) uses `IAudioClient3::InitializeSharedAudioStream` at the engine's minimum period. If `IAudioClient3` is unavailable or the call fails, Pulp degrades to the standard shared `Initialize` at the requested buffer size — never a half-open stream.
 - **Event-driven**: a background thread waits on buffer events, minimizing latency
 - **Float32 non-interleaved**: Pulp's callback receives per-channel buffers; interleaving to/from WASAPI's format is handled internally
 - **Thread priority**: the render thread runs at `THREAD_PRIORITY_TIME_CRITICAL`
+- **Device-invalidation recovery**: if the endpoint is removed or its sample rate / mix format changes (`AUDCLNT_E_DEVICE_INVALIDATED`), the I/O thread stops the stream cleanly and fires the `AudioSystem` device-change notification so the host can re-open at the new format. Pulp does not attempt a transparent in-place reopen.
 
 ### Device Enumeration
 

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -13,7 +13,7 @@ See [docs/guides/status-ladder.md](../guides/status-ladder.md) for the evidence 
 The following section is auto-generated from the `limitations:` block of `docs/status/support-matrix.yaml`. Run `python3 tools/docs_generate.py generate` to refresh.
 
 <!-- generated:start id=limitations -->
-### Known limitations (21 items across 13 capabilities)
+### Known limitations (20 items across 13 capabilities)
 
 | Capability | Limitation | Tracked in |
 |---|---|---|
@@ -28,7 +28,6 @@ The following section is auto-generated from the `limitations:` block of `docs/s
 | `formats.auv3` | MIDI arrives as raw bytes; no type dispatch to note/CC/pitchbend/aftertouch. | [link](planning/production-readiness/01-format-adapters.md#1.4) |
 | `formats.auv3` | iOS validation is stale — no on-device example or AVAudioSession ↔ C++ bridge. | [link](planning/production-readiness/05-auv3-mobile.md) |
 | `formats.lv2` | Atom sysex events are not routed — only 1–3-byte short MIDI messages in the atom input sequence reach Processor::process(). | [link](planning/production-readiness/01-format-adapters.md#1.5) |
-| `audio_io.wasapi` | Shared mode only; no exclusive mode. | [link](planning/production-readiness/02-audio-midi-io.md#2.1) |
 | `audio_io.wasapi` | Input capture not wired — input_view is always empty. | [link](planning/production-readiness/02-audio-midi-io.md#2.1) |
 | `audio_io.alsa` | No input capture path. | [link](planning/production-readiness/02-audio-midi-io.md#2.2) |
 | `audio_io.alsa` | Hardcoded sample-rate list; no real enumeration. | [link](planning/production-readiness/02-audio-midi-io.md#2.2) |

--- a/docs/status/support-matrix.yaml
+++ b/docs/status/support-matrix.yaml
@@ -153,8 +153,10 @@ audio_io:
     status: experimental
     platform: windows
     notes: >-
-      Shared-mode playback with IMMNotificationClient hotplug. Input
-      capture + exclusive-mode paths remain pending.
+      Shared-mode and exclusive-mode playback (DeviceConfig::share_mode),
+      a shared low-latency path via IAudioClient3 (DeviceConfig::low_latency),
+      IMMNotificationClient hotplug, and AUDCLNT_E_DEVICE_INVALIDATED recovery
+      (clean-stop + device-change notify; host re-opens).
   alsa:
     status: experimental
     platform: linux
@@ -867,8 +869,6 @@ limitations:
     - text: "Atom sysex events are not routed — only 1–3-byte short MIDI messages in the atom input sequence reach Processor::process()."
       tracked_in: "planning/production-readiness/01-format-adapters.md#1.5"
   audio_io.wasapi:
-    - text: "Shared mode only; no exclusive mode."
-      tracked_in: "planning/production-readiness/02-audio-midi-io.md#2.1"
     - text: "Input capture not wired — input_view is always empty."
       tracked_in: "planning/production-readiness/02-audio-midi-io.md#2.1"
     # Hotplug: IMMNotificationClient device-change callbacks are wired;

--- a/test/test_wasapi_share_modes.cpp
+++ b/test/test_wasapi_share_modes.cpp
@@ -103,24 +103,61 @@ TEST_CASE("WASAPI mode coverage: AUDCLNT_SHAREMODE_SHARED is implemented",
 }
 
 TEST_CASE("WASAPI mode coverage: share_mode selector exists; exclusive is a "
-          "ShareMode value (W4)",
+          "ShareMode value; low_latency opts into shared low-latency (W4/W4b)",
           "[audio][wasapi][share-mode][gap-doc][issue-302]") {
     // W4 added the opt-in: DeviceConfig::share_mode selects shared (default) or
-    // exclusive. There is deliberately no separate `exclusive` bool, and
-    // shared-low-latency (`low_latency` + IAudioClient3) is deferred to W4b.
+    // exclusive. There is deliberately no separate `exclusive` bool. W4b added
+    // DeviceConfig::low_latency, the shared-mode IAudioClient3 opt-in.
     using cfg_t = pulp::audio::DeviceConfig;
     static_assert(has_share_mode_v<cfg_t>,
                   "W4: DeviceConfig::share_mode is the selector");
     static_assert(!has_exclusive_v<cfg_t>,
                   "exclusive is a ShareMode value, not a bool field");
-    static_assert(!has_low_latency_v<cfg_t>,
-                  "shared-low-latency is deferred to W4b (IAudioClient3)");
+    static_assert(has_low_latency_v<cfg_t>,
+                  "W4b: DeviceConfig::low_latency is the shared low-latency "
+                  "(IAudioClient3) opt-in");
 
     DeviceConfig cfg;
     CHECK(cfg.share_mode == ShareMode::shared);  // default preserved
+    CHECK_FALSE(cfg.low_latency);                 // default off
     cfg.share_mode = ShareMode::exclusive;
     CHECK(cfg.share_mode == ShareMode::exclusive);
-    SUCCEED("DeviceConfig::share_mode opts into AUDCLNT_SHAREMODE_EXCLUSIVE");
+    cfg.low_latency = true;
+    CHECK(cfg.low_latency);
+    SUCCEED("DeviceConfig::share_mode opts into AUDCLNT_SHAREMODE_EXCLUSIVE; "
+            "DeviceConfig::low_latency opts into IAudioClient3 shared low-latency");
+}
+
+TEST_CASE("WASAPI mode coverage: shared low-latency open succeeds or honest-"
+          "fails back to standard shared (never half-opens)",
+          "[audio][wasapi][share-mode][gap-doc][issue-302]") {
+    // W4b: DeviceConfig::low_latency on a shared-mode open tries
+    // IAudioClient3::InitializeSharedAudioStream at the engine minimum period.
+    // If IAudioClient3 is unavailable or the call fails, open() honestly
+    // degrades to the standard shared Initialize. Either way the contract is the
+    // same as every other open path: fully open (is_open + positive
+    // rate/buffer) or fully closed — never a half-initialised device.
+    WasapiSystem sys;
+    if (!has_default_render(sys)) {
+        SUCCEED("no default render endpoint on this host; skipping");
+        return;
+    }
+    auto device = sys.create_device("");
+    REQUIRE(device != nullptr);
+
+    DeviceConfig cfg;
+    cfg.output_channels = 2;
+    cfg.share_mode = ShareMode::shared;
+    cfg.low_latency = true;
+
+    // Shared mode always has a viable fallback, so on a real render endpoint
+    // open() must succeed whether or not IAudioClient3 took the low-latency path.
+    REQUIRE(device->open(cfg));
+    CHECK(device->is_open());
+    CHECK(device->buffer_size() > 0);
+    CHECK(device->sample_rate() > 0.0);
+    device->close();
+    CHECK_FALSE(device->is_open());
 }
 
 TEST_CASE("WASAPI mode coverage: exclusive open succeeds or honest-fails "
@@ -259,23 +296,29 @@ TEST_CASE("WASAPI share-mode coverage: DeviceConfig exposes share_mode "
     using cfg_t = pulp::audio::DeviceConfig;
     // W4: DeviceConfig::share_mode now exists (shared default + exclusive). The
     // selector is a single enum field; there is intentionally NO separate
-    // `exclusive` bool or `low_latency` field — exclusive is a ShareMode value,
-    // and shared-low-latency (IAudioClient3) is a deferred W4b follow-up.
+    // `exclusive` bool — exclusive is a ShareMode value. W4b added
+    // DeviceConfig::low_latency, the shared-mode IAudioClient3 opt-in (default
+    // false). Non-Windows backends ignore both fields.
     static_assert(has_share_mode_v<cfg_t>,
                   "WASAPI W4: DeviceConfig::share_mode is the share-mode "
                   "selector; keep this test in lockstep with the API");
     static_assert(!has_exclusive_v<cfg_t>,
                   "WASAPI: exclusive is a ShareMode enum value, not a "
                   "DeviceConfig::exclusive field — do not add a bool");
-    static_assert(!has_low_latency_v<cfg_t>,
-                  "WASAPI: shared-low-latency (DeviceConfig::low_latency) is "
-                  "deferred to W4b; add it alongside the IAudioClient3 path");
+    static_assert(has_low_latency_v<cfg_t>,
+                  "WASAPI W4b: DeviceConfig::low_latency is the shared "
+                  "low-latency (IAudioClient3) opt-in; keep this test in "
+                  "lockstep with the API");
     static_assert(cfg_t{}.share_mode == pulp::audio::ShareMode::shared,
                   "shared must remain the default so non-Windows backends and "
                   "existing callers are unaffected");
+    static_assert(cfg_t{}.low_latency == false,
+                  "low_latency must default false so non-Windows backends and "
+                  "existing callers are unaffected");
 
-    SUCCEED("DeviceConfig::share_mode defaults to shared on every platform; "
-            "exclusive is honored only by the Windows WASAPI backend");
+    SUCCEED("DeviceConfig::share_mode defaults to shared and low_latency "
+            "defaults false on every platform; both are honored only by the "
+            "Windows WASAPI backend");
 }
 
 #endif


### PR DESCRIPTION
Follow-up to W4a (#3676), completing W4. Adds the two deferred halves:

- `DeviceConfig::low_latency` → `IAudioClient3::InitializeSharedAudioStream` at the engine minimum period (shared mode only); honest-degrades to standard shared Initialize if IAudioClient3 is unavailable / fails.
- render+capture threads detect `AUDCLNT_E_DEVICE_INVALIDATED` → clean-stop + fire the device-change notification (host re-opens; no transparent reopen).

`low_latency` is additive (default false). Contract test flipped (both branches) + a Windows runtime test. Docs synced.

**Verification:** DeviceConfig + the cross-platform contract test build+pass on macOS (pulp-audio + pulp-test-wasapi-share-modes); the IAudioClient3 + invalidation code is Windows-only, compile-verified on the **Windows MSVC gate** (gating merge on it). Drafted via a parallel subagent, then I rebased the net delta onto post-W4a main + reviewed.

Closes W4. Part of #3329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds WASAPI shared low-latency via `IAudioClient3` and automatic recovery on device invalidation to improve latency and robustness on Windows. The change is opt-in and does not affect other platforms.

- New Features
  - Shared low-latency: `DeviceConfig::low_latency = true` uses `IAudioClient3::InitializeSharedAudioStream` at the engine’s minimum period (shared mode only); cleanly falls back to standard shared `Initialize` if unavailable.
  - Device invalidation recovery: render/capture threads detect `AUDCLNT_E_DEVICE_INVALIDATED`, stop cleanly, and fire the `AudioSystem` device-change notification (host re-opens; no transparent reopen). `WasapiDevice::set_owner` wires the callback.
  - Tests and docs updated; support matrix reflects the new capabilities.

- Migration
  - No breaking changes.
  - To opt in, set `DeviceConfig::low_latency = true` when `share_mode == ShareMode::shared`.
  - Exclusive mode and non-Windows backends are unaffected (flag is ignored there).

<sup>Written for commit f4042e584ed3db037c9c8a02a6e8d2938aef6176. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

