### PR TITLE
feat(view): register Linux AT-SPI root over direct D-Bus (L7a-2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.389.0
+    VERSION 0.390.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/platform/include/pulp/platform/dbus.hpp
+++ b/core/platform/include/pulp/platform/dbus.hpp
@@ -28,6 +28,7 @@
 
 #include <functional>
 #include <map>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
@@ -48,6 +49,30 @@ public:
     /// connected).
     bool connect_session();
     bool connected() const;
+
+    /// Switch this DBus over to the desktop accessibility ("a11y") bus.
+    ///
+    /// The a11y bus is a SECOND D-Bus daemon, separate from the session bus:
+    /// its address is discovered by calling org.a11y.Bus.GetAddress on the
+    /// session bus, then a fresh private connection is opened to that address.
+    /// AT-SPI (Orca and friends) lives entirely on this bus — the registry, the
+    /// app's exported accessible objects, and the event traffic all flow over
+    /// it, never the session bus.
+    ///
+    /// After this returns true, the connection backing register_object /
+    /// unregister_object / emit_signal / dispatch / unique_name is the a11y
+    /// connection (the session connection used to discover the address is
+    /// closed). connect_session() must have succeeded first.
+    ///
+    /// Returns false off Linux, without libdbus, when there is no session bus,
+    /// when org.a11y.Bus is absent (a headless host with no a11y daemon), or
+    /// when the returned address cannot be opened — i.e. honest-fail, so a
+    /// non-accessibility desktop simply yields a no-op provider.
+    bool connect_a11y_bus();
+
+    /// True iff this DBus is currently backed by the a11y bus connection (i.e.
+    /// connect_a11y_bus() succeeded). False on the plain session connection.
+    bool a11y_connected() const;
 
     /// This connection's unique bus name (e.g. ":1.42"), assigned by the broker
     /// at connect time. Empty when not connected / off Linux. Needed so a peer
@@ -85,6 +110,10 @@ public:
     /// list. The cursor advances on each successful read.
     class Reader {
     public:
+        /// Default-constructed inert Reader — every read returns false. Useful
+        /// as the out-parameter passed to recurse().
+        Reader() = default;
+
         /// Read a string ('s') or object-path ('o') at the cursor into `out` and
         /// advance. Returns false (leaving the cursor put) on type mismatch / end.
         bool read_string(std::string& out);
@@ -96,11 +125,22 @@ public:
         /// Advance to the next argument. Returns false when there is no next.
         bool next();
 
+        /// Descend into the container (struct / array / variant / dict-entry)
+        /// at the cursor, returning a sub-Reader over its elements. The cursor
+        /// is NOT advanced — call next() afterwards to step past the container.
+        /// `out_sub` receives the sub-Reader; returns false if the cursor is not
+        /// on a container (or at end). The sub-Reader is valid only while this
+        /// Reader and the underlying message live.
+        bool recurse(Reader& out_sub);
+
     private:
         friend class DBus;
         Reader(DBus* owner, void* iter) : owner_(owner), iter_(iter) {}
+        // A recurse() sub-iterator owns its DBusMessageIter buffer; the parent
+        // hands ownership to the sub-Reader so it outlives the call returning it.
         DBus* owner_ = nullptr;
-        void* iter_ = nullptr;   // DBusMessageIter*
+        void* iter_ = nullptr;   // DBusMessageIter* (non-owning view)
+        std::shared_ptr<void> owned_iter_;  // set only for recurse() sub-readers
     };
 
     /// Appends values to an outgoing message (reply or signal). Container open/
@@ -203,6 +243,20 @@ public:
     /// This is the object-server consumption model; do NOT interleave it with
     /// the portal file_chooser pop_message pump on the same pending traffic.
     bool dispatch(int timeout_ms = 0);
+
+    /// Generic blocking method call (object-server companion to register_object).
+    /// Sends `member` on `destination`/`path`/`interface`, marshalling the body
+    /// via `build_args`, and blocks up to `timeout_ms` for the reply; the reply
+    /// arguments are handed to `read_reply` (may be null to ignore the body).
+    /// Returns false off Linux / without a connection / on transport or D-Bus
+    /// error (e.g. the peer returned an error reply). This is the call needed to
+    /// drive a handshake such as AT-SPI's Socket.Embed where the app both
+    /// exports objects AND calls out to a registry.
+    bool call_method(const std::string& destination, const std::string& path,
+                     const std::string& interface, const std::string& member,
+                     const std::function<void(Writer&)>& build_args,
+                     const std::function<void(Reader&)>& read_reply,
+                     int timeout_ms = 5000);
 
     DBus(const DBus&) = delete;
     DBus& operator=(const DBus&) = delete;

--- a/core/platform/src/dbus.cpp
+++ b/core/platform/src/dbus.cpp
@@ -66,7 +66,9 @@ constexpr int kHandlerNotYetHandled = 1;   // DBUS_HANDLER_RESULT_NOT_YET_HANDLE
 // stack struct; we over-allocate a buffer to hold it across ABI versions.
 struct DBus::Impl {
     void* handle = nullptr;       // dlopen handle
-    void* conn = nullptr;         // DBusConnection*
+    void* conn = nullptr;         // DBusConnection* (session or, after
+                                  // connect_a11y_bus(), the a11y bus)
+    bool on_a11y = false;         // true once switched to the a11y bus
 
     // Path → handler routing table for exported objects. The trampoline recovers
     // `this` from the vtable user_data and looks the path up here.
@@ -166,6 +168,14 @@ struct DBus::Impl {
     fn_msg_get_sender msg_get_sender = nullptr;
     fn_get_unique     get_unique_name = nullptr;
 
+    // ── a11y-bus additions ──
+    // dbus_connection_open_private(const char* address, DBusError*) → DBusConnection*
+    using fn_open_private = void* (*)(const char*, void*);
+    // dbus_bus_register(DBusConnection*, DBusError*) → dbus_bool_t
+    using fn_bus_register = unsigned (*)(void*, void*);
+    fn_open_private open_private = nullptr;
+    fn_bus_register bus_register = nullptr;
+
     template <typename Fn>
     Fn sym(const char* name) { return reinterpret_cast<Fn>(dlsym(handle, name)); }
 
@@ -209,6 +219,10 @@ struct DBus::Impl {
         msg_get_sender = sym<fn_msg_get_sender>("dbus_message_get_sender");
         get_unique_name = sym<fn_get_unique>("dbus_connection_get_unique_name");
 
+        // a11y-bus symbols (needed to open the separate accessibility daemon).
+        open_private = sym<fn_open_private>("dbus_connection_open_private");
+        bus_register = sym<fn_bus_register>("dbus_bus_register");
+
         return error_init && error_free && error_is_set && bus_get_private &&
                conn_close && conn_unref && set_exit_on_disconnect && add_match &&
                read_write && pop_message && send_with_reply_and_block &&
@@ -220,7 +234,7 @@ struct DBus::Impl {
                msg_new_method_return && msg_new_signal && msg_new_error &&
                conn_send && conn_flush && read_write_dispatch &&
                msg_get_interface && msg_get_member && msg_get_sender &&
-               get_unique_name;
+               get_unique_name && open_private && bus_register;
     }
 
     // Append one a{sv} entry: key (string) → variant of `vtype` holding `val`.
@@ -336,6 +350,21 @@ int DBus::Reader::arg_type() const {
 bool DBus::Reader::next() {
     if (!owner_ || !owner_->impl_ || !iter_) return false;
     return owner_->impl_->iter_next(iter_) != 0;
+}
+bool DBus::Reader::recurse(Reader& out_sub) {
+    if (!owner_ || !owner_->impl_ || !iter_) return false;
+    auto& d = *owner_->impl_;
+    const int t = d.iter_get_arg_type(iter_);
+    if (t != kTypeStruct && t != kTypeArray && t != kTypeVariant &&
+        t != kTypeDictEnt) {
+        return false;
+    }
+    auto buf = std::make_shared<Impl::IterBuf>();
+    d.iter_recurse(iter_, buf.get());
+    out_sub.owner_ = owner_;
+    out_sub.iter_ = buf.get();
+    out_sub.owned_iter_ = buf;   // keep the sub-iterator alive with the Reader
+    return true;
 }
 
 // ── Writer facade ───────────────────────────────────────────────────────────
@@ -476,6 +505,68 @@ bool DBus::connect_session() {
     return true;
 }
 
+bool DBus::a11y_connected() const { return impl_ && impl_->conn && impl_->on_a11y; }
+
+bool DBus::connect_a11y_bus() {
+    if (a11y_connected()) return true;        // already switched over
+    if (!connect_session()) return false;     // need the session bus to ask
+    Impl& d = *impl_;
+
+    // 1. Ask the session bus for the accessibility bus address:
+    //    org.a11y.Bus . GetAddress() -> s   (on /org/a11y/bus).
+    void* msg = d.msg_new_method_call(
+        "org.a11y.Bus", "/org/a11y/bus", "org.a11y.Bus", "GetAddress");
+    if (!msg) return false;
+
+    Impl::ErrBuf err;
+    d.error_init(&err);
+    void* reply = d.send_with_reply_and_block(d.conn, msg, 5000, &err);
+    d.msg_unref(msg);
+    std::string address;
+    if (reply && !d.error_is_set(&err)) {
+        Impl::IterBuf it;
+        if (d.iter_init(reply, &it) && d.iter_get_arg_type(&it) == kTypeString) {
+            const char* a = nullptr;
+            d.iter_get_basic(&it, &a);
+            if (a) address = a;
+        }
+    }
+    if (reply) d.msg_unref(reply);
+    d.error_free(&err);
+    if (address.empty()) return false;   // no a11y daemon (headless) → honest-fail
+
+    // 2. Open a NEW private connection to that address and register with it.
+    d.error_init(&err);
+    void* a11y = d.open_private(address.c_str(), &err);
+    if (!a11y || d.error_is_set(&err)) {
+        if (a11y) { d.conn_close(a11y); d.conn_unref(a11y); }
+        d.error_free(&err);
+        return false;
+    }
+    d.error_free(&err);
+
+    d.error_init(&err);
+    const unsigned registered = d.bus_register(a11y, &err);
+    if (!registered || d.error_is_set(&err)) {
+        d.error_free(&err);
+        d.conn_close(a11y);
+        d.conn_unref(a11y);
+        return false;
+    }
+    d.error_free(&err);
+    d.set_exit_on_disconnect(a11y, 0u);
+
+    // 3. Swap the active connection over to the a11y bus. Any objects registered
+    //    on the session connection are dropped (none are at switch time — the
+    //    AT-SPI provider exports onto the a11y bus only). The session connection
+    //    served only to discover the address; close it.
+    d.conn_close(d.conn);
+    d.conn_unref(d.conn);
+    d.conn = a11y;
+    d.on_a11y = true;
+    return true;
+}
+
 bool DBus::register_object(const std::string& path, IncomingHandler handler) {
     if (!connect_session()) return false;
     Impl& d = *impl_;
@@ -548,6 +639,50 @@ bool DBus::dispatch(int timeout_ms) {
     // which removes messages BEFORE the dispatcher would route them. Do not
     // interleave the two on the same pending traffic.
     return impl_->read_write_dispatch(impl_->conn, timeout_ms) != 0;
+}
+
+bool DBus::call_method(const std::string& destination, const std::string& path,
+                       const std::string& interface, const std::string& member,
+                       const std::function<void(Writer&)>& build_args,
+                       const std::function<void(Reader&)>& read_reply,
+                       int timeout_ms) {
+    if (!connected()) return false;
+    Impl& d = *impl_;
+
+    void* msg = d.msg_new_method_call(destination.c_str(), path.c_str(),
+                                      interface.c_str(), member.c_str());
+    if (!msg) return false;
+
+    Impl::IterBuf args;
+    d.iter_init_append(msg, &args);
+    if (build_args) {
+        Writer w(this, &args);
+        build_args(w);
+    }
+
+    Impl::ErrBuf err;
+    d.error_init(&err);
+    void* reply = d.send_with_reply_and_block(d.conn, msg, timeout_ms, &err);
+    d.msg_unref(msg);
+    if (!reply || d.error_is_set(&err)) {
+        if (reply) d.msg_unref(reply);
+        d.error_free(&err);
+        return false;
+    }
+    d.error_free(&err);
+
+    if (read_reply) {
+        Impl::IterBuf it;
+        if (d.iter_init(reply, &it)) {
+            Reader r(this, &it);
+            read_reply(r);
+        } else {
+            Reader r(this, nullptr);
+            read_reply(r);  // no body: a Reader over null returns false on reads
+        }
+    }
+    d.msg_unref(reply);
+    return true;
 }
 
 std::optional<DBus::PortalResult> DBus::file_chooser(
@@ -685,6 +820,7 @@ bool DBus::Reader::read_uint32(unsigned&) { return false; }
 bool DBus::Reader::read_double(double&) { return false; }
 int  DBus::Reader::arg_type() const { return 0; }
 bool DBus::Reader::next() { return false; }
+bool DBus::Reader::recurse(Reader&) { return false; }
 
 bool DBus::Writer::append_string(const std::string&) { return false; }
 bool DBus::Writer::append_object_path(const std::string&) { return false; }
@@ -707,11 +843,16 @@ DBus::~DBus() = default;
 bool DBus::connected() const { return false; }
 std::string DBus::unique_name() const { return {}; }
 bool DBus::connect_session() { return false; }
+bool DBus::connect_a11y_bus() { return false; }
+bool DBus::a11y_connected() const { return false; }
 bool DBus::register_object(const std::string&, IncomingHandler) { return false; }
 bool DBus::unregister_object(const std::string&) { return false; }
 bool DBus::emit_signal(const std::string&, const std::string&, const std::string&,
                        const std::function<void(Writer&)>&) { return false; }
 bool DBus::dispatch(int) { return false; }
+bool DBus::call_method(const std::string&, const std::string&, const std::string&,
+                       const std::string&, const std::function<void(Writer&)>&,
+                       const std::function<void(Reader&)>&, int) { return false; }
 std::optional<DBus::PortalResult> DBus::file_chooser(
     const std::string&, const std::string&,
     const std::map<std::string, std::string>&,

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -465,37 +465,18 @@ target_sources(pulp-view-script PRIVATE
 # AU/VST3/CLAP plugins.
 # The ObjC runtime loads WebKit on dylib load if any WKWebView references exist,
 # which crashes Logic Pro's sandboxed AUHostingServiceXPC process.
-# ── Linux ATK accessibility (#18 phase 1) ───────────────────────────────────
+# ── Linux AT-SPI accessibility (workstream 04, L7) ──────────────────────────
 #
-# Pulp publishes accessibility info to Linux screen readers (Orca) via
-# ATK + the at-spi2-atk bridge. This slice only wires the ATK headers
-# into the build so accessibility_linux.cpp can use the real AtkRole
-# enum instead of hard-coded integer constants. The full AtkObject
-# vtable + at-spi2 bridge runtime is a follow-up PR that needs
-# screen-reader validation on a real Linux desktop.
-#
-# Without libatk-dev, accessibility_linux.cpp keeps the pre-existing
-# fallback constants so contributors on minimal images still build.
-#
-# Install on Debian/Ubuntu: sudo apt install -y libatk1.0-dev
-if(UNIX AND NOT APPLE AND NOT ANDROID)
-    find_package(PkgConfig QUIET)
-    if(PkgConfig_FOUND)
-        pkg_check_modules(PULP_ATK QUIET IMPORTED_TARGET atk)
-        if(PULP_ATK_FOUND)
-            target_compile_definitions(pulp-view-core PRIVATE PULP_HAS_ATK=1)
-            target_link_libraries(pulp-view-core PRIVATE PkgConfig::PULP_ATK)
-            message(STATUS
-                "Pulp: Linux ATK ${PULP_ATK_VERSION} found — "
-                "accessibility_linux.cpp will use real AtkRole enum")
-        else()
-            message(STATUS
-                "Pulp: Linux ATK dev headers not found "
-                "(install: sudo apt install libatk1.0-dev) — "
-                "accessibility_linux.cpp will use stub constants")
-        endif()
-    endif()
-endif()
+# Pulp publishes accessibility info to Linux screen readers (Orca) by
+# implementing the AT-SPI2 *wire protocol* directly over D-Bus
+# (pulp::platform::DBus, libdbus-1 dlopen'd, honest-fail). There is NO
+# build-time or link-time dependency on libatk / libatspi / atk-bridge-2.0 —
+# the protocol numbers live in core/view/include/pulp/view/platform/atspi_mapping.hpp
+# and accessibility_linux.cpp exports the objects. Roles/states are unit-tested
+# offline; the live AT stack is exercised in the Linux VM lane. This also keeps
+# the build MIT-clean (the ATK runtime is LGPL-adjacent). PkgConfig is still
+# discovered below for X11 / WebView.
+find_package(PkgConfig QUIET)
 
 option(PULP_BUILD_WEBVIEW "Include native WebView support (WebKit / WebView2 / WebKitGTK)" OFF)
 if(PULP_BUILD_WEBVIEW)
@@ -751,18 +732,9 @@ elseif(UNIX)
             message(STATUS "Pulp: X11 not found — Linux PluginViewHost limited to headless render")
         endif()
     endif()
-    # Linux AT-SPI bridge (workstream 04 #248). Optional: linking atk-
-    # bridge-2.0 when pkg-config finds it enables screen-reader
-    # (Orca) registration via atk_bridge_adaptor_init. Skipped on
-    # minimal/headless distros so the library still loads.
-    if(PkgConfig_FOUND OR PKG_CONFIG_FOUND)
-        pkg_check_modules(ATK_BRIDGE IMPORTED_TARGET atk-bridge-2.0)
-        if(ATK_BRIDGE_FOUND)
-            target_compile_definitions(pulp-view-core PRIVATE PULP_HAS_ATSPI=1)
-            target_link_libraries(pulp-view-core PRIVATE PkgConfig::ATK_BRIDGE)
-            message(STATUS "Pulp: AT-SPI bridge enabled (atk-bridge-2.0)")
-        endif()
-    endif()
+    # Linux AT-SPI (workstream 04, L7) needs no link deps: accessibility_linux.cpp
+    # speaks the AT-SPI2 wire protocol directly over pulp::platform::DBus
+    # (libdbus-1 dlopen'd). No atk-bridge-2.0 / libatspi at build time.
 endif()
 
 # Link against render for native GPU bridge (Three.js, WebGPU canvas).

--- a/core/view/include/pulp/view/accessibility_provider.hpp
+++ b/core/view/include/pulp/view/accessibility_provider.hpp
@@ -43,6 +43,16 @@ void shutdown_accessibility(void* handle);
 /// value updates don't need this — those fire per-property events.
 void accessibility_tree_changed(void* handle);
 
+/// Service any pending accessibility IPC for this handle. On Linux AT-SPI the
+/// registry / screen reader calls methods on the exported objects over D-Bus;
+/// those calls hang the assistive tech unless the host pumps periodically. A
+/// host with an event loop should call this each frame or on a short timer.
+///
+/// No-op on platforms whose accessibility runs callback-driven on the OS side
+/// (macOS / iOS NSAccessibility, Windows UIA, Android TalkBack) and on a null /
+/// sentinel handle. Cheap when no assistive tech is connected.
+void accessibility_pump(void* handle);
+
 // ── Phase 2 event-raising surface (#247) ────────────────────────────────
 //
 // Widgets call these when their accessibility-relevant state changes so

--- a/core/view/include/pulp/view/platform/atspi_mapping.hpp
+++ b/core/view/include/pulp/view/platform/atspi_mapping.hpp
@@ -1,0 +1,99 @@
+#pragma once
+
+// Linux AT-SPI2 mapping for Pulp AccessRole (workstream 04 slice L7a-2).
+//
+// Pure-constant header — no AT-SPI / ATK runtime dependency — so the same
+// mapping compiles on every platform and can be unit-tested offline. The Linux
+// accessibility provider (accessibility_linux.cpp) consumes these constants
+// when it answers org.a11y.atspi.Accessible.GetRole over D-Bus.
+//
+// AT-SPI exports roles as plain `uint32` enum NUMBERS on the wire (the
+// AtspiRole / Atspi_Role enumeration in the published AT-SPI2 IDL). They are
+// part of the wire protocol — a screen reader (Orca) reads the number and looks
+// up its own label — so they are stable and safe to hard-code without pulling
+// in libatspi headers. They DIFFER from the legacy ATK AtkRole numbers the
+// pre-L7 stub hard-coded (AtkRole and AtspiRole are distinct enumerations);
+// the table test locks the AT-SPI numbers so a future edit can't silently
+// regress to the ATK values.
+//
+// Reference: AT-SPI2 `Accessible.GetRole` returns `u`; the AtspiRole values
+// below are from the freedesktop AT-SPI2 enumeration (xml/Accessible role list).
+
+#include <pulp/view/view.hpp>
+
+#include <cstdint>
+
+namespace pulp::view::atspi {
+
+// ── AtspiRole values (subset Pulp exposes) ───────────────────────────────────
+// The full enumeration lives in the AT-SPI2 IDL. These are the AtspiRole
+// numbers (NOT AtkRole) for the roles Pulp declares today. Additional roles
+// land as widgets need them.
+inline constexpr uint32_t kRoleImage       = 27;   // ATSPI_ROLE_IMAGE
+inline constexpr uint32_t kRoleLabel       = 29;   // ATSPI_ROLE_LABEL
+inline constexpr uint32_t kRolePanel       = 54;   // ATSPI_ROLE_PANEL
+inline constexpr uint32_t kRoleProgressBar = 51;   // ATSPI_ROLE_PROGRESS_BAR
+inline constexpr uint32_t kRoleSlider      = 71;   // ATSPI_ROLE_SLIDER
+inline constexpr uint32_t kRoleToggleButton = 79;  // ATSPI_ROLE_TOGGLE_BUTTON
+inline constexpr uint32_t kRoleApplication = 75;   // ATSPI_ROLE_APPLICATION
+inline constexpr uint32_t kRoleInvalid     = 0;    // ATSPI_ROLE_INVALID
+
+/// Map a Pulp AccessRole to the best-fit AtspiRole number. Unknown / none →
+/// PANEL (a generic container — AT-SPI has no "custom" escape hatch the way
+/// UIA does, and PANEL is the conventional neutral grouping role).
+constexpr uint32_t role_to_atspi_role(View::AccessRole role) {
+    switch (role) {
+        case View::AccessRole::slider: return kRoleSlider;
+        case View::AccessRole::toggle: return kRoleToggleButton;
+        case View::AccessRole::label:  return kRoleLabel;
+        case View::AccessRole::group:  return kRolePanel;
+        case View::AccessRole::meter:  return kRoleProgressBar;
+        case View::AccessRole::image:  return kRoleImage;
+        case View::AccessRole::none:   return kRolePanel;
+    }
+    return kRolePanel;
+}
+
+// ── AtspiStateType values (subset) ───────────────────────────────────────────
+// AT-SPI's GetState returns a 64-bit state bitfield marshalled as two uint32
+// words (au of length 2: low word = states 0..31, high word = states 32..63).
+// These are the AtspiStateType bit INDICES Pulp sets today. Helpers below build
+// the two-word representation so the provider and the offline test agree.
+inline constexpr uint32_t kStateEnabled   = 8;    // ATSPI_STATE_ENABLED
+inline constexpr uint32_t kStateSensitive = 24;   // ATSPI_STATE_SENSITIVE
+inline constexpr uint32_t kStateShowing   = 26;   // ATSPI_STATE_SHOWING
+inline constexpr uint32_t kStateVisible   = 28;   // ATSPI_STATE_VISIBLE
+
+/// Two-word AT-SPI state bitfield (the `au` GetState returns: [low, high]).
+struct StateSet {
+    uint32_t low = 0;
+    uint32_t high = 0;
+};
+
+/// Set the bit for AtspiStateType `index` (0..63) in a two-word StateSet.
+constexpr void set_state(StateSet& s, uint32_t index) {
+    if (index < 32) {
+        s.low |= (1u << index);
+    } else {
+        s.high |= (1u << (index - 32));
+    }
+}
+
+/// True if AtspiStateType `index` is set in `s`.
+constexpr bool has_state(const StateSet& s, uint32_t index) {
+    if (index < 32) return (s.low & (1u << index)) != 0;
+    return (s.high & (1u << (index - 32))) != 0;
+}
+
+/// The default state for an enabled, visible, showing accessible object — the
+/// baseline every Pulp accessible (including the application root) reports.
+constexpr StateSet default_states() {
+    StateSet s{};
+    set_state(s, kStateEnabled);
+    set_state(s, kStateSensitive);
+    set_state(s, kStateShowing);
+    set_state(s, kStateVisible);
+    return s;
+}
+
+}  // namespace pulp::view::atspi

--- a/core/view/platform/linux/accessibility_linux.cpp
+++ b/core/view/platform/linux/accessibility_linux.cpp
@@ -1,127 +1,431 @@
-// Linux AT-SPI accessibility provider
-// Stub implementation — provides the interface surface for future implementation.
+// Linux AT-SPI2 accessibility provider — direct D-Bus (no libatk).
 //
-// When fully implemented, this will:
-// - Use AT-SPI2 (Assistive Technology Service Provider Interface) via D-Bus
-// - Register each View with an AccessRole as an AT-SPI accessible object
-// - Map AccessRole to ATK roles (ATK_ROLE_SLIDER, ATK_ROLE_TOGGLE_BUTTON, etc.)
-// - Expose access_label as accessible name, access_value as accessible value
-// - Emit state-change and value-change signals for screen readers (Orca)
+// AT-SPI2 is a *wire protocol* over D-Bus: the application EXPORTS accessible
+// objects, and the registry / screen reader (Orca) calls methods ON them
+// (Accessible.GetRole, Accessible.GetChildren, Component.GetExtents, …). This
+// TU implements that protocol directly over pulp::platform::DBus (libdbus-1
+// dlopen'd, honest-fail), the same pattern the L6a portal client uses — so
+// there is NO build-time dependency on libatk / libatspi and no LGPL-adjacent
+// ATK runtime. Roles are mapped through the offline-tested atspi_mapping.hpp.
 //
-// Dependencies: libatspi2 (AT-SPI2), libdbus-1
-// Install: apt install libatspi2.0-dev on Debian/Ubuntu
+// AT-SPI lives on a SEPARATE "a11y" bus (org.a11y.Bus.GetAddress on the session
+// bus → a fresh private connection). DBus::connect_a11y_bus() handles the
+// discovery + switch; everything below talks to that connection.
+//
+// This slice (L7a-2) registers the process with the registry:
+//   1. connect to the a11y bus,
+//   2. export /org/a11y/atspi/accessible/root implementing
+//      org.a11y.atspi.Accessible + org.a11y.atspi.Application (+ the mandatory
+//      Introspectable + Properties interfaces),
+//   3. perform the org.a11y.atspi.Socket.Embed handshake against the registry
+//      so Orca discovers the process.
+// The per-widget object tree (Accessible per View, Component extents) is L7b;
+// Value + event signals are L7c — the notify_* hooks stay no-ops here.
+//
+// Run-loop requirement: the registry calls methods on us asynchronously, so the
+// host must pump DBus::dispatch() periodically or those calls hang the AT. The
+// handle exposes pump(); see init_accessibility()'s tail comment for the seam.
 
 #if defined(__linux__) && !defined(__ANDROID__)
 
 #include <pulp/view/accessibility_provider.hpp>
 #include <pulp/view/view.hpp>
+#include <pulp/view/platform/atspi_mapping.hpp>
+#include <pulp/platform/dbus.hpp>
 #include <pulp/runtime/log.hpp>
 
-// PULP_HAS_ATK is set by CMake when atk is found via pkg-config; this
-// gives us the real AtkRole enum so the role mapping below survives any
-// future renumbering by GNOME. PULP_HAS_ATSPI is set when the at-spi2
-// bridge runtime is also linkable — that path is currently a stub and
-// is filled in by the follow-up PR that adds AtkObject implementations.
-#ifdef PULP_HAS_ATK
-#include <atk/atk.h>
-#endif
-#ifdef PULP_HAS_ATSPI
-extern "C" {
-int  atk_bridge_adaptor_init(int* argc, char*** argv);
-void atk_bridge_adaptor_cleanup(void);
-}
-#endif
+#include <memory>
+#include <string>
 
 namespace pulp::view {
 
-// Map Pulp AccessRole to ATK role values. With PULP_HAS_ATK we use the
-// AtkRole enum directly; without it we fall back to the integer values
-// from ATK 2.52 so headless CI images without libatk-dev still link.
-static int access_role_to_atk_role(View::AccessRole role) {
-#ifdef PULP_HAS_ATK
-    switch (role) {
-        case View::AccessRole::slider: return ATK_ROLE_SLIDER;
-        case View::AccessRole::toggle: return ATK_ROLE_TOGGLE_BUTTON;
-        case View::AccessRole::label:  return ATK_ROLE_LABEL;
-        case View::AccessRole::group:  return ATK_ROLE_PANEL;
-        case View::AccessRole::meter:  return ATK_ROLE_PROGRESS_BAR;
-        case View::AccessRole::image:  return ATK_ROLE_IMAGE;
-        default:                       return ATK_ROLE_UNKNOWN;
+namespace {
+
+using pulp::platform::DBus;
+
+// AT-SPI well-known names / paths (the published wire constants).
+constexpr const char* kRootPath      = "/org/a11y/atspi/accessible/root";
+constexpr const char* kNullPath      = "/org/a11y/atspi/null";
+constexpr const char* kRegistryName  = "org.a11y.atspi.Registry";
+constexpr const char* kIfaceAccessible   = "org.a11y.atspi.Accessible";
+constexpr const char* kIfaceApplication  = "org.a11y.atspi.Application";
+constexpr const char* kIfaceSocket       = "org.a11y.atspi.Socket";
+constexpr const char* kIfaceProperties   = "org.freedesktop.DBus.Properties";
+constexpr const char* kIfaceIntrospect   = "org.freedesktop.DBus.Introspectable";
+
+// Pulp's toolkit identity reported via Application properties.
+constexpr const char* kToolkitName    = "Pulp";
+constexpr const char* kToolkitVersion = "1.0";
+constexpr const char* kAtspiVersion   = "2.1";
+
+// The exported root accessible + its owning a11y connection. Stored as the
+// opaque handle returned by init_accessibility(). One per window/root.
+struct AtspiProvider {
+    DBus bus;                       // owns the a11y-bus connection
+    View* root = nullptr;           // the View tree this root maps (children = L7b)
+
+    // The registry's root accessible, captured from Socket.Embed: (bus_name,
+    // object_path). Reported as this app root's Parent so the tree connects up.
+    std::string registry_parent_name;
+    std::string registry_parent_path;
+
+    // Application.Id, assigned by the registry via Properties.Set during/after
+    // Embed. -1 until set.
+    int app_id = -1;
+
+    // Append an AT-SPI object reference (so) = (bus_name, object_path) into a
+    // reply. AT-SPI addresses every accessible as this struct.
+    void append_object_ref(DBus::Writer& w, const std::string& name,
+                           const std::string& path) {
+        auto s = w.open_struct();
+        DBus::Writer sw = w.sub(s);
+        sw.append_string(name);
+        sw.append_object_path(path.empty() ? kNullPath : path);
+        w.close_container(s);
     }
-#else
-    switch (role) {
-        case View::AccessRole::slider: return 34;  // ATK_ROLE_SLIDER
-        case View::AccessRole::toggle: return 42;  // ATK_ROLE_TOGGLE_BUTTON
-        case View::AccessRole::label:  return 24;  // ATK_ROLE_LABEL
-        case View::AccessRole::group:  return 35;  // ATK_ROLE_PANEL
-        case View::AccessRole::meter:  return 33;  // ATK_ROLE_PROGRESS_BAR
-        case View::AccessRole::image:  return 21;  // ATK_ROLE_IMAGE
-        default:                       return 66;  // ATK_ROLE_UNKNOWN
+
+    // GetState returns au (array of two uint32 = the 64-bit state bitfield).
+    void append_state(DBus::Writer& w) {
+        const atspi::StateSet st = atspi::default_states();
+        auto a = w.open_array("u");
+        DBus::Writer aw = w.sub(a);
+        aw.append_uint32(st.low);
+        aw.append_uint32(st.high);
+        w.close_container(a);
     }
-#endif
+
+    // org.a11y.atspi.Accessible methods on the root.
+    bool handle_accessible(DBus::CallContext& ctx) {
+        const std::string& m = ctx.member();
+        if (m == "GetRole") {
+            // The root accessible is the APPLICATION.
+            ctx.reply().append_uint32(atspi::kRoleApplication);
+            return true;
+        }
+        if (m == "GetRoleName") {
+            ctx.reply().append_string("application");
+            return true;
+        }
+        if (m == "GetChildCount") {
+            // L7a-2 exports only the root; the View subtree lands in L7b.
+            ctx.reply().append_int32(0);
+            return true;
+        }
+        if (m == "GetChildren") {
+            // a(so) — empty for this slice.
+            DBus::Writer w = ctx.reply();
+            auto a = w.open_array("(so)");
+            w.close_container(a);
+            return true;
+        }
+        if (m == "GetState") {
+            DBus::Writer w = ctx.reply();
+            append_state(w);
+            return true;
+        }
+        if (m == "GetInterfaces") {
+            DBus::Writer w = ctx.reply();
+            auto a = w.open_array("s");
+            DBus::Writer aw = w.sub(a);
+            aw.append_string(kIfaceAccessible);
+            aw.append_string(kIfaceApplication);
+            w.close_container(a);
+            return true;
+        }
+        if (m == "GetAttributes") {
+            // a{ss} — none.
+            DBus::Writer w = ctx.reply();
+            auto a = w.open_array("{ss}");
+            w.close_container(a);
+            return true;
+        }
+        return false;  // decline → UnknownMethod
+    }
+
+    // org.a11y.atspi.Application methods (Id is also a property; some clients
+    // call GetApplicationBusAddress etc., not needed for discovery).
+    bool handle_application(DBus::CallContext& ctx) {
+        const std::string& m = ctx.member();
+        if (m == "GetLocale") {
+            // (u lc_category) -> s. Ignore the category; report the C locale.
+            ctx.reply().append_string("C");
+            return true;
+        }
+        if (m == "RegisterEventListener" || m == "DeregisterEventListener") {
+            ctx.reply();  // empty ack
+            return true;
+        }
+        return false;
+    }
+
+    // org.a11y.atspi.Socket.Embed handshake reply is initiated by US (a method
+    // call out to the registry), not serviced here. But the registry may also
+    // call Embed back / Unembed on us in some flows — ack benignly.
+    bool handle_socket(DBus::CallContext& ctx) {
+        const std::string& m = ctx.member();
+        if (m == "Embed" || m == "Unembed") {
+            // Reply with our own (so) root reference.
+            DBus::Writer w = ctx.reply();
+            append_object_ref(w, bus.unique_name(), kRootPath);
+            return true;
+        }
+        return false;
+    }
+
+    // org.freedesktop.DBus.Properties for the root's Accessible + Application
+    // interface properties. Get(iface, prop) -> v; GetAll(iface) -> a{sv};
+    // Set(iface, prop, v) -> () (the registry sets Application.Id this way).
+    bool handle_properties(DBus::CallContext& ctx) {
+        const std::string& m = ctx.member();
+        if (m == "Get") {
+            std::string iface, prop;
+            ctx.args().read_string(iface);
+            ctx.args().read_string(prop);
+            DBus::Writer w = ctx.reply();
+            return append_property_variant(w, iface, prop);
+        }
+        if (m == "GetAll") {
+            std::string iface;
+            ctx.args().read_string(iface);
+            DBus::Writer w = ctx.reply();
+            auto a = w.open_array("{sv}");
+            append_all_properties(w, a, iface);
+            w.close_container(a);
+            return true;
+        }
+        if (m == "Set") {
+            std::string iface, prop;
+            ctx.args().read_string(iface);
+            ctx.args().read_string(prop);
+            // The third arg is a variant holding the value; recurse into it.
+            // Only Application.Id (i) is writable — the registry sets it to
+            // assign this app's slot.
+            if (iface == kIfaceApplication && prop == "Id") {
+                DBus::Reader var;
+                int v = 0;
+                if (ctx.args().recurse(var) && var.read_int32(v)) app_id = v;
+            }
+            ctx.reply();  // empty success ack
+            return true;
+        }
+        return false;
+    }
+
+    // Append a single property as a variant into `w`. Returns false (decline)
+    // for unknown property so the trampoline replies UnknownMethod.
+    bool append_property_variant(DBus::Writer& w, const std::string& iface,
+                                 const std::string& prop) {
+        if (iface == kIfaceAccessible) {
+            if (prop == "Name") { return variant_string(w, kToolkitName); }
+            if (prop == "Description") { return variant_string(w, ""); }
+            if (prop == "Parent") {
+                auto v = w.open_variant("(so)");
+                DBus::Writer vw = w.sub(v);
+                append_object_ref(vw, registry_parent_name, registry_parent_path);
+                w.close_container(v);
+                return true;
+            }
+            if (prop == "ChildCount") { return variant_int32(w, 0); }
+        }
+        if (iface == kIfaceApplication) {
+            if (prop == "ToolkitName") { return variant_string(w, kToolkitName); }
+            if (prop == "Version") { return variant_string(w, kToolkitVersion); }
+            if (prop == "AtspiVersion") { return variant_string(w, kAtspiVersion); }
+            if (prop == "Id") { return variant_int32(w, app_id); }
+        }
+        return false;
+    }
+
+    void append_all_properties(DBus::Writer& w, DBus::Writer::Container& arr,
+                               const std::string& iface) {
+        DBus::Writer aw = w.sub(arr);
+        auto entry = [&](const char* key, auto appender) {
+            auto e = aw.open_dict_entry();
+            DBus::Writer ew = aw.sub(e);
+            ew.append_string(key);
+            appender(ew);
+            aw.close_container(e);
+        };
+        if (iface == kIfaceAccessible) {
+            entry("Name", [&](DBus::Writer& ew) { variant_string(ew, kToolkitName); });
+            entry("ChildCount", [&](DBus::Writer& ew) { variant_int32(ew, 0); });
+        } else if (iface == kIfaceApplication) {
+            entry("ToolkitName",
+                  [&](DBus::Writer& ew) { variant_string(ew, kToolkitName); });
+            entry("Version",
+                  [&](DBus::Writer& ew) { variant_string(ew, kToolkitVersion); });
+            entry("AtspiVersion",
+                  [&](DBus::Writer& ew) { variant_string(ew, kAtspiVersion); });
+            entry("Id", [&](DBus::Writer& ew) { variant_int32(ew, app_id); });
+        }
+    }
+
+    static bool variant_string(DBus::Writer& w, const std::string& s) {
+        auto v = w.open_variant("s");
+        DBus::Writer vw = w.sub(v);
+        vw.append_string(s);
+        return w.close_container(v);
+    }
+    static bool variant_int32(DBus::Writer& w, int v) {
+        auto var = w.open_variant("i");
+        DBus::Writer vw = w.sub(var);
+        vw.append_int32(v);
+        return w.close_container(var);
+    }
+
+    // org.freedesktop.DBus.Introspectable.Introspect -> s (XML). A minimal but
+    // valid document advertising the interfaces we answer; the registry uses it
+    // to know which interfaces to query.
+    bool handle_introspect(DBus::CallContext& ctx) {
+        if (ctx.member() != "Introspect") return false;
+        static const char* kXml =
+            "<!DOCTYPE node PUBLIC "
+            "\"-//freedesktop//DTD D-BUS Object Introspection 1.0//EN\" "
+            "\"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd\">\n"
+            "<node>"
+            "<interface name=\"org.a11y.atspi.Accessible\"/>"
+            "<interface name=\"org.a11y.atspi.Application\"/>"
+            "<interface name=\"org.freedesktop.DBus.Properties\"/>"
+            "<interface name=\"org.freedesktop.DBus.Introspectable\"/>"
+            "</node>";
+        ctx.reply().append_string(kXml);
+        return true;
+    }
+
+    // Single registered handler for the root path — dispatches by interface.
+    bool dispatch_root(DBus::CallContext& ctx) {
+        const std::string& iface = ctx.interface();
+        if (iface == kIfaceAccessible)  return handle_accessible(ctx);
+        if (iface == kIfaceApplication) return handle_application(ctx);
+        if (iface == kIfaceSocket)      return handle_socket(ctx);
+        if (iface == kIfaceProperties)  return handle_properties(ctx);
+        if (iface == kIfaceIntrospect)  return handle_introspect(ctx);
+        // Some clients send method calls with no interface (legacy). Try the
+        // Accessible set as a best-effort fallback.
+        if (iface.empty()) return handle_accessible(ctx);
+        return false;
+    }
+
+    // Perform the Socket.Embed handshake: tell the registry "here is my root";
+    // it returns ITS root reference (so) which becomes our Parent. Returns true
+    // on a well-formed reply.
+    //
+    //   org.a11y.atspi.Socket.Embed(plug (so)) -> socket (so)
+    //
+    // We pass our own (unique_name, /…/root); the registry replies with its
+    // root accessible reference, which we record as this app root's Parent so
+    // the accessible tree links up to the desktop. The registry typically also
+    // sets Application.Id via Properties.Set afterwards (serviced by dispatch()).
+    bool embed_with_registry() {
+        const std::string my_name = bus.unique_name();
+        bool ok = bus.call_method(
+            kRegistryName, kRootPath, kIfaceSocket, "Embed",
+            [&](DBus::Writer& w) {
+                // arg: plug (so)
+                auto s = w.open_struct();
+                DBus::Writer sw = w.sub(s);
+                sw.append_string(my_name);
+                sw.append_object_path(kRootPath);
+                w.close_container(s);
+            },
+            [&](DBus::Reader& r) {
+                // reply: socket (so)
+                DBus::Reader sub;
+                if (r.recurse(sub)) {
+                    std::string name, path;
+                    sub.read_string(name);
+                    sub.read_string(path);
+                    registry_parent_name = name;
+                    registry_parent_path = path;
+                }
+            });
+        return ok;
+    }
+};
+
+}  // namespace
+
+void* init_accessibility(View& root, void* /*native_window*/) {
+    // Honest-fail ladder: no libdbus, no session bus, or no a11y daemon → return
+    // a benign non-null handle (matching the historic stub) so callers can
+    // unconditionally pair it with shutdown_accessibility(), but do no work.
+    if (!DBus::library_available()) {
+        runtime::log_info("Linux AT-SPI: libdbus unavailable; accessibility disabled");
+        return reinterpret_cast<void*>(static_cast<uintptr_t>(1));
+    }
+
+    auto provider = std::make_unique<AtspiProvider>();
+    provider->root = &root;
+
+    if (!provider->bus.connect_session() || !provider->bus.connect_a11y_bus()) {
+        runtime::log_info("Linux AT-SPI: no a11y bus (headless?); accessibility disabled");
+        return reinterpret_cast<void*>(static_cast<uintptr_t>(1));
+    }
+
+    AtspiProvider* p = provider.get();
+    const bool exported = provider->bus.register_object(
+        kRootPath, [p](DBus::CallContext& ctx) { return p->dispatch_root(ctx); });
+    if (!exported) {
+        runtime::log_warn("Linux AT-SPI: failed to export root accessible");
+        return reinterpret_cast<void*>(static_cast<uintptr_t>(1));
+    }
+
+    // Embed our root with the registry (Socket.Embed (so)->(so)); the registry's
+    // returned reference becomes our Parent and it assigns Application.Id via a
+    // Properties.Set that dispatch() services. A failed Embed (registry absent /
+    // slow) is non-fatal: the root stays exported and the registry can still
+    // discover + query us once it appears.
+    if (!provider->embed_with_registry()) {
+        runtime::log_info("Linux AT-SPI: Socket.Embed not completed "
+                          "(registry absent?); root remains exported");
+    }
+
+    runtime::log_info("Linux AT-SPI: registered root accessible on a11y bus");
+
+    // Run-loop seam: the registry/Orca call methods on the exported root
+    // asynchronously. The host MUST pump DBus::dispatch() periodically or those
+    // calls hang the AT (and Orca shows nothing). The handle exposes pump();
+    // a host with an event loop should call pump() each frame / on a timer.
+    //
+    // Wiring point: the X11 plugin-view host (plugin_view_host_linux.cpp) has no
+    // internal loop (the DAW pumps), and the standalone SDL host
+    // (sdl_window_host.cpp run_event_loop) does — the parent wires pump() into
+    // whichever host owns this handle. Left to the host so this TU stays
+    // loop-agnostic.
+    return provider.release();
 }
 
-// Stub: Initialize AT-SPI accessibility for a view tree
-void init_atspi_accessibility(View& /*root*/) {
-    runtime::log_info("Linux AT-SPI: stub initialized");
-    // TODO: implement AtkObject for each accessible View
-    // TODO: register with AT-SPI2 registry via D-Bus
-    // TODO: emit state-change signals on focus/value changes
-    // TODO: support AtkText for TextEditor widgets
-    // TODO: support AtkValue for Knob/Fader/Slider widgets
-}
-
-// Cross-platform entry — see accessibility_provider.hpp.
-//
-// Phase 1 (this commit, issue #248): when CMake finds atk-bridge-2.0
-// via pkg-config we register the bridge with D-Bus so Orca + other
-// AT-SPI clients can discover the process at all. AtkObject-per-widget
-// creation lands when an AtkObject subclass for View is added next.
-// Without PULP_HAS_ATSPI we keep the pre-#248 no-op so headless/minimal
-// Linux installations still load pulp-view.
-void* init_accessibility(View& root, void* /*gdk_surface*/) {
-    init_atspi_accessibility(root);
-#ifdef PULP_HAS_ATSPI
-    // atk_bridge_adaptor_init takes argc/argv the same way glib does
-    // for main-thread bootstrap; pass nullptrs so it uses the process's
-    // existing GLib main context. Safe to call twice — the bridge
-    // refuses re-init with a warning rather than crashing.
-    int argc = 0;
-    char** argv = nullptr;
-    if (atk_bridge_adaptor_init(&argc, &argv) != 0) {
-        runtime::log_warn("Linux AT-SPI: atk_bridge_adaptor_init failed; "
-                          "screen readers may not see this process");
-    } else {
-        runtime::log_info("Linux AT-SPI: bridge registered with D-Bus");
+void shutdown_accessibility(void* handle) {
+    // Distinguish the benign sentinel (uintptr 1) from a real provider pointer.
+    if (handle == reinterpret_cast<void*>(static_cast<uintptr_t>(1)) || !handle) {
+        runtime::log_info("Linux AT-SPI: shutdown (no provider)");
+        return;
     }
-    return reinterpret_cast<void*>(static_cast<uintptr_t>(1));
-#else
-    return reinterpret_cast<void*>(static_cast<uintptr_t>(1));
-#endif
+    auto* p = static_cast<AtspiProvider*>(handle);
+    p->bus.unregister_object(kRootPath);
+    delete p;  // closes the a11y connection via DBus dtor
+    runtime::log_info("Linux AT-SPI: root accessible torn down");
 }
 
-void shutdown_accessibility(void* /*handle*/) {
-#ifdef PULP_HAS_ATSPI
-    atk_bridge_adaptor_cleanup();
-    runtime::log_info("Linux AT-SPI: bridge cleaned up");
-#else
-    runtime::log_info("Linux AT-SPI: shutdown (stub)");
-#endif
+// Pump the a11y connection so the registry's inbound method calls are serviced.
+// The host calls this from its event loop / timer. Safe on the sentinel handle.
+void accessibility_pump(void* handle) {
+    if (handle == reinterpret_cast<void*>(static_cast<uintptr_t>(1)) || !handle) return;
+    static_cast<AtspiProvider*>(handle)->bus.dispatch(0);
 }
 
 void accessibility_tree_changed(void* /*handle*/) {
-    // TODO: g_signal_emit_by_name(root, "children-changed::add", ...)
+    // L7b: structural change → re-export the per-widget subtree and emit
+    // children-changed on the root. No-op until the View subtree is exported.
 }
 
-// Phase 2 (#247): cross-platform notification API. Linux AT-SPI will
-// eventually emit object::property-change and object::state-changed on
-// the per-widget AtkObjects; currently no-op until Phase 2 per-widget
-// providers land (#217 follow-up). Keeping the API surface present so
-// widget code can call these unconditionally.
+// L7c event-raising surface. These emit org.a11y.atspi.Event.Object signals
+// (StateChanged / PropertyChange) once the per-widget objects exist. No-op for
+// L7a-2 (registration only).
 void notify_accessibility_value_changed(void* /*handle*/, View& /*target*/) {}
 void notify_accessibility_focus_changed(void* /*handle*/, View& /*target*/) {}
 void notify_accessibility_name_changed(void* /*handle*/, View& /*target*/) {}
 
-} // namespace pulp::view
+}  // namespace pulp::view
 
 #endif // __linux__

--- a/core/view/src/accessibility.cpp
+++ b/core/view/src/accessibility.cpp
@@ -8,6 +8,7 @@
 // the vtables here is the standard fix.
 
 #include <pulp/view/accessibility.hpp>
+#include <pulp/view/accessibility_provider.hpp>
 #include <pulp/runtime/log.hpp>
 
 #include <sstream>
@@ -66,5 +67,15 @@ void announce_accessibility(std::string_view text,
     pulp::runtime::log_info("a11y announce ({}): {}", pol,
                             std::string(text));
 }
+
+// Default accessibility_pump(): a no-op for every platform whose provider runs
+// callback-driven on the OS side (macOS / iOS / Windows / Android). The Linux
+// AT-SPI provider needs to service inbound D-Bus calls, so it supplies its own
+// definition in platform/linux/accessibility_linux.cpp — excluded here on the
+// Linux *desktop* build to avoid a duplicate symbol. Android is __linux__ but
+// uses the TalkBack provider (no D-Bus pump), so it keeps this no-op.
+#if !defined(__linux__) || defined(__ANDROID__)
+void accessibility_pump(void* /*handle*/) {}
+#endif
 
 } // namespace pulp::view

--- a/docs/status/support-matrix.yaml
+++ b/docs/status/support-matrix.yaml
@@ -532,7 +532,7 @@ platform_maturity:
       notes: UIA stub — role mapping defined, IRawElementProviderSimple/WM_GETOBJECT/event firing pending. See production-readiness workstream 04.
     linux:
       status: partial
-      notes: AT-SPI stub — role mapping defined, D-Bus registration pending. See production-readiness workstream 04.
+      notes: AT-SPI2 over direct D-Bus (no libatk) — a11y-bus connect, root Accessible/Application export, and Socket.Embed registration done; per-widget tree + value/events pending. See core/view/platform/linux/accessibility_linux.cpp and production-readiness workstream 04.
   ime_composition:
     status: usable
     platform: macos

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1434,9 +1434,9 @@ pulp_add_test_suite(pulp-test-accessibility-provider LIBRARIES pulp::view)
 pulp_add_test_suite(pulp-test-descriptor-validation LIBRARIES pulp::format)
 # PluginInfo metadata shape (workstream 03 slice 3.7)
 pulp_add_test_suite(pulp-test-plugin-info-metadata LIBRARIES pulp::host)
-# UIA mapping (workstream 04 slice 4.1a)
+# A11y role mapping tables — UIA (slice 4.1a) + AT-SPI (slice L7a-2)
 pulp_add_test_suite(pulp-test-uia-mapping LIBRARIES pulp::view)
-
+pulp_add_test_suite(pulp-test-atspi-mapping LIBRARIES pulp::view)
 # AudioSystem hotplug base plumbing (workstream 02 slice 2.7)
 pulp_add_test_suite(pulp-test-audio-system-hotplug LIBRARIES pulp::audio)
 

--- a/test/test_atspi_mapping.cpp
+++ b/test/test_atspi_mapping.cpp
@@ -1,0 +1,76 @@
+// Tests for the Pulp → Linux AT-SPI2 mapping table
+// (workstream 04 slice L7a-2). Pure-constant checks — the actual AT-SPI
+// provider lives in core/view/platform/linux/accessibility_linux.cpp and
+// is validated per platform (real AT stack) by VM integration tests.
+//
+// These lock the AtspiRole NUMBERS so a future edit can't silently regress
+// to the legacy ATK AtkRole values the pre-L7 stub hard-coded (AtkRole and
+// AtspiRole are distinct enumerations with different numeric values).
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/view/platform/atspi_mapping.hpp>
+
+using namespace pulp::view;
+using namespace pulp::view::atspi;
+
+TEST_CASE("role_to_atspi_role returns stable AtspiRole numbers", "[a11y][atspi]") {
+    REQUIRE(role_to_atspi_role(View::AccessRole::slider) == kRoleSlider);
+    REQUIRE(role_to_atspi_role(View::AccessRole::toggle) == kRoleToggleButton);
+    REQUIRE(role_to_atspi_role(View::AccessRole::label)  == kRoleLabel);
+    REQUIRE(role_to_atspi_role(View::AccessRole::group)  == kRolePanel);
+    REQUIRE(role_to_atspi_role(View::AccessRole::meter)  == kRoleProgressBar);
+    REQUIRE(role_to_atspi_role(View::AccessRole::image)  == kRoleImage);
+    REQUIRE(role_to_atspi_role(View::AccessRole::none)   == kRolePanel);
+}
+
+TEST_CASE("AtspiRole numbers match the published AT-SPI2 enumeration",
+          "[a11y][atspi]") {
+    // These are AtspiRole values (the wire numbers Accessible.GetRole returns),
+    // NOT the legacy AtkRole values. They are part of the AT-SPI2 protocol.
+    REQUIRE(kRoleImage        == 27);
+    REQUIRE(kRoleLabel        == 29);
+    REQUIRE(kRoleProgressBar  == 51);
+    REQUIRE(kRolePanel        == 54);
+    REQUIRE(kRoleSlider       == 71);
+    REQUIRE(kRoleApplication  == 75);
+    REQUIRE(kRoleToggleButton == 79);
+
+    // Guard against a regression back to the old ATK numbers (slider was 34,
+    // toggle 42, label 24, panel 35, progress 33, image 21 under AtkRole).
+    REQUIRE(kRoleSlider != 34u);
+    REQUIRE(kRoleToggleButton != 42u);
+    REQUIRE(kRoleLabel != 24u);
+}
+
+TEST_CASE("AT-SPI mapping is total for unknown role values", "[a11y][atspi]") {
+    auto unknown = static_cast<View::AccessRole>(999);
+    REQUIRE(role_to_atspi_role(unknown) == kRolePanel);
+}
+
+TEST_CASE("AT-SPI state set packs into two 32-bit words", "[a11y][atspi]") {
+    StateSet s{};
+    REQUIRE(s.low == 0u);
+    REQUIRE(s.high == 0u);
+
+    // Low-word bit (index < 32).
+    set_state(s, kStateEnabled);  // 8
+    REQUIRE(has_state(s, kStateEnabled));
+    REQUIRE((s.low & (1u << 8)) != 0u);
+    REQUIRE(s.high == 0u);
+
+    // High-word bit (index >= 32) lands in the high word, offset by 32.
+    set_state(s, /*index*/ 40);
+    REQUIRE(has_state(s, 40));
+    REQUIRE((s.high & (1u << 8)) != 0u);
+}
+
+TEST_CASE("default AT-SPI states report enabled/visible/showing/sensitive",
+          "[a11y][atspi]") {
+    const StateSet s = default_states();
+    REQUIRE(has_state(s, kStateEnabled));
+    REQUIRE(has_state(s, kStateSensitive));
+    REQUIRE(has_state(s, kStateShowing));
+    REQUIRE(has_state(s, kStateVisible));
+    // All four are low-word states; high word stays clear.
+    REQUIRE(s.high == 0u);
+}

--- a/test/test_dbus.cpp
+++ b/test/test_dbus.cpp
@@ -146,6 +146,43 @@ TEST_CASE("DBus object-server honest-fails without a bus",
     REQUIRE_FALSE(bus.emit_signal("/pulp/test", "pulp.Test", "Ping",
                                   [](DBus::Writer&) {}));
     REQUIRE_FALSE(bus.dispatch(0));
+    // a11y-bus switch (L7a-2): honest-fails without any bus at all.
+    REQUIRE_FALSE(bus.a11y_connected());
+    REQUIRE_FALSE(bus.connect_a11y_bus());
+}
+
+// L7a-2: switching a connected session DBus over to the accessibility bus.
+// CI-verifiable shape: on a headless session bus (dbus-run-session) there is no
+// org.a11y.Bus daemon, so connect_a11y_bus() must honest-fail (return false)
+// WITHOUT tearing down the usable session connection. A real desktop with
+// at-spi2-core running is the VM lane that exercises the success path.
+TEST_CASE("DBus connect_a11y_bus honest-fails without an a11y daemon",
+          "[platform][dbus][objectserver][a11y][issue-L7a2]") {
+    if (!DBus::library_available()) {
+        SUCCEED("skipped: libdbus not available");
+        return;
+    }
+    DBus bus;
+    if (!bus.connect_session()) {
+        SUCCEED("skipped: no session bus (run under dbus-run-session)");
+        return;
+    }
+    REQUIRE(bus.connected());
+    REQUIRE_FALSE(bus.a11y_connected());
+
+    // Under dbus-run-session there is no org.a11y.Bus; GetAddress fails and the
+    // switch is declined. (On a desktop with at-spi2-core this would return
+    // true and a11y_connected() would flip — the VM lane covers that.)
+    if (bus.connect_a11y_bus()) {
+        // An a11y daemon happened to be reachable (developer desktop): the
+        // contract still holds — the active connection is now the a11y bus.
+        REQUIRE(bus.a11y_connected());
+        REQUIRE(bus.connected());
+        SUCCEED("a11y bus reachable: switched over");
+        return;
+    }
+    // Honest-fail path: declined, but the session connection is untouched.
+    REQUIRE_FALSE(bus.a11y_connected());
 }
 
 #if defined(__linux__)

--- a/tools/cmake/PulpPkgConfigImports.cmake
+++ b/tools/cmake/PulpPkgConfigImports.cmake
@@ -33,9 +33,8 @@ find_dependency(PkgConfig QUIET)
 if(PkgConfig_FOUND)
     # core/canvas: fontconfig — m144 Skia uses it for font enumeration.
     pkg_check_modules(FONTCONFIG QUIET IMPORTED_TARGET fontconfig)
-    # core/view accessibility_linux.cpp — AtkRole + AtkObject bridge.
-    pkg_check_modules(PULP_ATK QUIET IMPORTED_TARGET atk)
-    pkg_check_modules(ATK_BRIDGE QUIET IMPORTED_TARGET atk-bridge-2.0)
+    # core/view accessibility: Linux AT-SPI speaks the wire protocol directly
+    # over libdbus-1 (dlopen'd) — no atk / atk-bridge-2.0 pkg-config probe.
     # core/view WebView (PULP_BUILD_WEBVIEW=ON) — only relevant when
     # the SDK was built with WebView. Probe with QUIET; if the
     # consumer doesn't have the libs, find_package degrades the


### PR DESCRIPTION
Second L7 slice (after L7a-1's object server, #3698). Makes a Pulp process discoverable to AT-SPI screen readers (Orca) over direct D-Bus — replacing the libatk/atk-bridge stub.

## What
- `pulp::platform::DBus`: `connect_a11y_bus()` (org.a11y.Bus.GetAddress → open the separate a11y bus connection) + `a11y_connected()` + `call_method` + `Reader::recurse`.
- `accessibility_linux.cpp`: direct-D-Bus path replacing libatk — exports `/org/a11y/atspi/accessible/root` (`org.a11y.atspi.Accessible` [APPLICATION role, empty children this slice], `Application`, `Socket`, `Introspectable`, `Properties`) + the `Socket.Embed` handshake. `notify_*` are no-ops until L7b/L7c. Handle exposes `accessibility_pump()` for the host run-loop to drive `dispatch()`.
- New `atspi_mapping.hpp` (role/state table, mirrors `uia_mapping.hpp`) + offline test. CMake drops atk/atk-bridge pkg-config (no new link deps — libdbus dlopen'd).

## Verification
- macOS (required) + this host: mapping test **30 assertions / 5 cases**; dbus + accessibility non-Linux stubs build clean.
- **VM-verified on real Linux**: `pulp-view` builds (rc=0) — `accessibility_linux.cpp` (Embed/root handlers) + `connect_a11y_bus` compile against real libdbus. Builds on the VM-loopback-proven L7a-1 object server.
- Deferred to L7b: wiring `accessibility_pump()` into a host run loop + the live-registry accerciser/Orca smoke (needs a windowed app driving dispatch).

Drafted via parallel subagent, reviewed (dropped a stray #3726 revert the subagent's pre-#3726 base carried), VM-verified. Part of #3329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers the Linux AT‑SPI root over direct D‑Bus using `pulp::platform::DBus`, replacing the `libatk`/`atk-bridge-2.0` stub so Orca can discover the process. Exports `/org/a11y/atspi/accessible/root` and completes the `Socket.Embed` handshake; per‑widget tree and events land in L7b/L7c.

- **New Features**
  - `DBus`: `connect_a11y_bus()`, `a11y_connected()`, `call_method()`, and `Reader::recurse()`; discovers the a11y bus via `org.a11y.Bus.GetAddress` and switches to a private connection.
  - Linux provider: direct AT‑SPI2 over D‑Bus; exports `Accessible`/`Application` on the root and performs `Socket.Embed`; adds `accessibility_pump()` to service inbound calls.
  - `atspi_mapping.hpp`: role/state constants and a unit test; support matrix updated.

- **Migration**
  - On Linux, call `accessibility_pump(handle)` each frame or on a short timer to avoid hanging AT‑SPI calls.
  - No `atk`/`atk-bridge-2.0` link needed; `libdbus-1` is loaded at runtime.
  - Other platforms are unchanged.

<sup>Written for commit ba7172b4216e6b7f40fc0af637a797594e91fbbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

