### PR TITLE
feat(view): Linux AT-SPI Value interface + focus/value/name event signals (L7c)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.391.0
+    VERSION 0.392.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/platform/atspi_mapping.hpp
+++ b/core/view/include/pulp/view/platform/atspi_mapping.hpp
@@ -79,6 +79,8 @@ constexpr const char* role_to_atspi_role_name(View::AccessRole role) {
 // These are the AtspiStateType bit INDICES Pulp sets today. Helpers below build
 // the two-word representation so the provider and the offline test agree.
 inline constexpr uint32_t kStateEnabled   = 8;    // ATSPI_STATE_ENABLED
+inline constexpr uint32_t kStateFocusable = 11;   // ATSPI_STATE_FOCUSABLE
+inline constexpr uint32_t kStateFocused   = 12;   // ATSPI_STATE_FOCUSED
 inline constexpr uint32_t kStateSensitive = 24;   // ATSPI_STATE_SENSITIVE
 inline constexpr uint32_t kStateShowing   = 26;   // ATSPI_STATE_SHOWING
 inline constexpr uint32_t kStateVisible   = 28;   // ATSPI_STATE_VISIBLE

--- a/core/view/platform/linux/accessibility_linux.cpp
+++ b/core/view/platform/linux/accessibility_linux.cpp
@@ -23,8 +23,14 @@
 //     desktop.
 //
 // The per-widget tree is rebuilt on accessibility_tree_changed(), which also
-// emits org.a11y.atspi.Event.Object.ChildrenChanged. Value + per-object
-// state/focus event signals are L7c — the notify_* hooks stay no-ops here.
+// emits org.a11y.atspi.Event.Object.ChildrenChanged. Slider/meter Views that
+// implement AccessibilityValueInterface additionally export org.a11y.atspi.Value
+// (CurrentValue/Minimum/Maximum/MinimumIncrement, serviced through the Properties
+// interface; CurrentValue is writable and routes back into the value interface's
+// set_current_value, the same path a user adjust takes). The notify_* hooks emit
+// the matching org.a11y.atspi.Event.Object signals (StateChanged "focused",
+// PropertyChange "accessible-value" / "accessible-name") so a listening registry
+// re-reads the changed object (L7c).
 //
 // Tree-walk model (mirrors mac collect_accessible / Windows build_fragment_nodes):
 // depth-first; every View with a non-none AccessRole becomes one accessible
@@ -38,6 +44,7 @@
 
 #if defined(__linux__) && !defined(__ANDROID__)
 
+#include <pulp/view/accessibility.hpp>
 #include <pulp/view/accessibility_provider.hpp>
 #include <pulp/view/view.hpp>
 #include <pulp/view/platform/atspi_mapping.hpp>
@@ -63,6 +70,7 @@ constexpr const char* kRegistryName  = "org.a11y.atspi.Registry";
 constexpr const char* kIfaceAccessible   = "org.a11y.atspi.Accessible";
 constexpr const char* kIfaceApplication  = "org.a11y.atspi.Application";
 constexpr const char* kIfaceComponent    = "org.a11y.atspi.Component";
+constexpr const char* kIfaceValue        = "org.a11y.atspi.Value";
 constexpr const char* kIfaceSocket       = "org.a11y.atspi.Socket";
 constexpr const char* kIfaceEventObject  = "org.a11y.atspi.Event.Object";
 constexpr const char* kIfaceProperties   = "org.freedesktop.DBus.Properties";
@@ -278,6 +286,9 @@ struct AtspiProvider {
                 aw.append_string(kIfaceApplication);
             } else {
                 aw.append_string(kIfaceComponent);
+                // Value only when the View is value-bearing (slider/meter that
+                // implements AccessibilityValueInterface).
+                if (value_iface(index)) aw.append_string(kIfaceValue);
             }
             w.close_container(a);
             return true;
@@ -446,11 +457,23 @@ struct AtspiProvider {
             std::string iface, prop;
             ctx.args().read_string(iface);
             ctx.args().read_string(prop);
-            // Only Application.Id (i) is writable — the registry sets it.
+            // Application.Id (i) is writable — the registry sets it.
             if (index == 0 && iface == kIfaceApplication && prop == "Id") {
                 DBus::Reader var;
                 int v = 0;
                 if (ctx.args().recurse(var) && var.read_int32(v)) app_id = v;
+            }
+            // Value.CurrentValue (d) is writable — an AT-driven adjust (Orca's
+            // "increase/decrease") sets it; route to the View's value interface
+            // along the SAME path a user adjust takes (set_current_value).
+            else if (iface == kIfaceValue && prop == "CurrentValue") {
+                if (AccessibilityValueInterface* vif = value_iface(index)) {
+                    DBus::Reader var;
+                    double v = 0.0;
+                    if (ctx.args().recurse(var) && var.read_double(v)) {
+                        vif->set_current_value(v);
+                    }
+                }
             }
             ctx.reply();  // empty success ack
             return true;
@@ -462,6 +485,17 @@ struct AtspiProvider {
         static const std::string kToolkit = kToolkitName;
         if (index == 0) return kToolkit;
         return nodes_[static_cast<size_t>(index)].view->access_label();
+    }
+
+    // The View→AccessibilityValueInterface accessor, identical to the one
+    // accessibility_win.cpp (W6) uses: a dynamic_cast on the View. mac, Windows,
+    // and Linux must agree on which Views are value-bearing, so all three resolve
+    // it the same way — never via role inspection. Null for the application root
+    // and for any View that does not implement the interface.
+    AccessibilityValueInterface* value_iface(int index) const {
+        if (index <= 0 || index >= static_cast<int>(nodes_.size())) return nullptr;
+        View* v = nodes_[static_cast<size_t>(index)].view;
+        return v ? dynamic_cast<AccessibilityValueInterface*>(v) : nullptr;
     }
 
     bool append_property_variant(DBus::Writer& w, int index,
@@ -494,6 +528,22 @@ struct AtspiProvider {
             if (prop == "AtspiVersion") { return variant_string(w, kAtspiVersion); }
             if (prop == "Id") { return variant_int32(w, app_id); }
         }
+        if (iface == kIfaceValue) {
+            if (AccessibilityValueInterface* vif = value_iface(index)) {
+                if (prop == "CurrentValue") {
+                    return variant_double(w, vif->get_current_value());
+                }
+                if (prop == "MinimumValue") {
+                    return variant_double(w, vif->get_minimum_value());
+                }
+                if (prop == "MaximumValue") {
+                    return variant_double(w, vif->get_maximum_value());
+                }
+                if (prop == "MinimumIncrement") {
+                    return variant_double(w, vif->get_step_size());
+                }
+            }
+        }
         return false;
     }
 
@@ -523,6 +573,21 @@ struct AtspiProvider {
             entry("AtspiVersion",
                   [&](DBus::Writer& ew) { variant_string(ew, kAtspiVersion); });
             entry("Id", [&](DBus::Writer& ew) { variant_int32(ew, app_id); });
+        } else if (iface == kIfaceValue) {
+            if (AccessibilityValueInterface* vif = value_iface(index)) {
+                entry("CurrentValue", [&](DBus::Writer& ew) {
+                    variant_double(ew, vif->get_current_value());
+                });
+                entry("MinimumValue", [&](DBus::Writer& ew) {
+                    variant_double(ew, vif->get_minimum_value());
+                });
+                entry("MaximumValue", [&](DBus::Writer& ew) {
+                    variant_double(ew, vif->get_maximum_value());
+                });
+                entry("MinimumIncrement", [&](DBus::Writer& ew) {
+                    variant_double(ew, vif->get_step_size());
+                });
+            }
         }
     }
 
@@ -536,6 +601,12 @@ struct AtspiProvider {
         auto var = w.open_variant("i");
         DBus::Writer vw = w.sub(var);
         vw.append_int32(v);
+        return w.close_container(var);
+    }
+    static bool variant_double(DBus::Writer& w, double v) {
+        auto var = w.open_variant("d");
+        DBus::Writer vw = w.sub(var);
+        vw.append_double(v);
         return w.close_container(var);
     }
 
@@ -553,17 +624,27 @@ struct AtspiProvider {
             "<interface name=\"org.freedesktop.DBus.Properties\"/>"
             "<interface name=\"org.freedesktop.DBus.Introspectable\"/>"
             "</node>";
-        static const char* kWidgetXml =
+        static const char* kWidgetHead =
             "<!DOCTYPE node PUBLIC "
             "\"-//freedesktop//DTD D-BUS Object Introspection 1.0//EN\" "
             "\"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd\">\n"
             "<node>"
             "<interface name=\"org.a11y.atspi.Accessible\"/>"
-            "<interface name=\"org.a11y.atspi.Component\"/>"
+            "<interface name=\"org.a11y.atspi.Component\"/>";
+        static const char* kWidgetTail =
             "<interface name=\"org.freedesktop.DBus.Properties\"/>"
             "<interface name=\"org.freedesktop.DBus.Introspectable\"/>"
             "</node>";
-        ctx.reply().append_string(index == 0 ? kRootXml : kWidgetXml);
+        if (index == 0) {
+            ctx.reply().append_string(kRootXml);
+        } else {
+            std::string xml = kWidgetHead;
+            if (value_iface(index)) {
+                xml += "<interface name=\"org.a11y.atspi.Value\"/>";
+            }
+            xml += kWidgetTail;
+            ctx.reply().append_string(xml);
+        }
         return true;
     }
 
@@ -627,6 +708,39 @@ struct AtspiProvider {
                 w.close_container(v);
                 append_self_ref(w, 0);          // source application ref (so)
             });
+    }
+
+    // ── Per-object Event.Object signals (L7c) ─────────────────────────────────
+    //
+    // AT-SPI's object events all share the body signature (siiva{sv}): a detail
+    // string, two int32 details, an any_data variant, and a trailing a{sv}
+    // properties map (always empty here — the registry re-reads the source via
+    // Properties.Get). The signal is emitted FROM the changed object's own path
+    // so a listener knows which accessible changed; `member` is the event class
+    // ("StateChanged" / "PropertyChange"). `fill_variant` writes the any_data
+    // value (the new state/value/name); the helper frames the rest.
+    void emit_object_event(int index, const char* member,
+                           const std::string& detail, int detail1, int detail2,
+                           const std::function<void(DBus::Writer&)>& fill_variant) {
+        if (index < 0 || index >= static_cast<int>(nodes_.size())) return;
+        bus.emit_signal(
+            path_for_index(index), kIfaceEventObject, member,
+            [&](DBus::Writer& w) {
+                w.append_string(detail);
+                w.append_int32(detail1);
+                w.append_int32(detail2);
+                fill_variant(w);                  // any_data (v)
+                auto a = w.open_array("{sv}");     // properties a{sv} — empty
+                w.close_container(a);
+            });
+    }
+
+    // Resolve a target View to its exported object index, or -1 if the View is
+    // not part of the exported tree (e.g. an AccessRole::none container, or a
+    // View built after the last rebuild).
+    int index_for_view(const View* v) const {
+        auto it = view_to_index_.find(v);
+        return it == view_to_index_.end() ? -1 : it->second;
     }
 
     // ── Socket.Embed handshake (links the app up to the registry) ─────────────
@@ -730,12 +844,60 @@ void accessibility_tree_changed(void* handle) {
     p->emit_children_changed();
 }
 
-// L7c event-raising surface. These will emit org.a11y.atspi.Event.Object
-// signals (StateChanged / PropertyChange) per-object once value/state events
-// land. No-op for L7b (structural tree only).
-void notify_accessibility_value_changed(void* /*handle*/, View& /*target*/) {}
-void notify_accessibility_focus_changed(void* /*handle*/, View& /*target*/) {}
-void notify_accessibility_name_changed(void* /*handle*/, View& /*target*/) {}
+// L7c event-raising surface. Each emits the matching org.a11y.atspi.Event.Object
+// signal FROM the changed object's path so a listening registry/Orca re-reads it.
+// No-op when there is no live provider (the benign sentinel handle / honest-fail
+// path) or when the target View is not part of the exported tree.
+
+void notify_accessibility_focus_changed(void* handle, View& target) {
+    if (handle == reinterpret_cast<void*>(static_cast<uintptr_t>(1)) || !handle) return;
+    auto* p = static_cast<AtspiProvider*>(handle);
+    int index = p->index_for_view(&target);
+    if (index < 0) return;
+    // StateChanged: detail = state name ("focused"), detail1 = new value (1),
+    // detail2 = 0, any_data = unused (variant<i>(0)). A blur would emit detail1=0;
+    // the View hook fires on focus acquisition, so report focused=true.
+    p->emit_object_event(index, "StateChanged", "focused", 1, 0,
+                         [](DBus::Writer& w) {
+                             auto v = w.open_variant("i");
+                             DBus::Writer vw = w.sub(v);
+                             vw.append_int32(0);
+                             w.close_container(v);
+                         });
+}
+
+void notify_accessibility_value_changed(void* handle, View& target) {
+    if (handle == reinterpret_cast<void*>(static_cast<uintptr_t>(1)) || !handle) return;
+    auto* p = static_cast<AtspiProvider*>(handle);
+    int index = p->index_for_view(&target);
+    if (index < 0) return;
+    // PropertyChange: detail = "accessible-value", any_data = the new current
+    // value (variant<d>). Resolve through the value interface; if the target is
+    // not value-bearing, fall back to 0.0 (the event still tells the registry to
+    // re-read).
+    double current = 0.0;
+    if (AccessibilityValueInterface* vif = p->value_iface(index)) {
+        current = vif->get_current_value();
+    }
+    p->emit_object_event(index, "PropertyChange", "accessible-value", 0, 0,
+                         [current](DBus::Writer& w) {
+                             AtspiProvider::variant_double(w, current);
+                         });
+}
+
+void notify_accessibility_name_changed(void* handle, View& target) {
+    if (handle == reinterpret_cast<void*>(static_cast<uintptr_t>(1)) || !handle) return;
+    auto* p = static_cast<AtspiProvider*>(handle);
+    int index = p->index_for_view(&target);
+    if (index < 0) return;
+    // PropertyChange: detail = "accessible-name", any_data = the new name
+    // (variant<s>).
+    const std::string label = target.access_label();
+    p->emit_object_event(index, "PropertyChange", "accessible-name", 0, 0,
+                         [label](DBus::Writer& w) {
+                             AtspiProvider::variant_string(w, label);
+                         });
+}
 
 // ── Test-only seam ───────────────────────────────────────────────────────────
 //

--- a/test/test_accessibility_tree.cpp
+++ b/test/test_accessibility_tree.cpp
@@ -371,6 +371,8 @@ using pulp::platform::DBus;
 constexpr const char* kRootPath = "/org/a11y/atspi/accessible/root";
 constexpr const char* kIfaceAccessible = "org.a11y.atspi.Accessible";
 constexpr const char* kIfaceComponent  = "org.a11y.atspi.Component";
+constexpr const char* kIfaceValue      = "org.a11y.atspi.Value";
+constexpr const char* kIfaceProperties = "org.freedesktop.DBus.Properties";
 
 // One node read back over the wire from an Accessible object.
 struct WireNode {
@@ -601,9 +603,225 @@ TEST_CASE("Linux AT-SPI exports a per-widget Accessible + Component tree",
 
     shutdown_accessibility(handle);
 }
+
+// ── Linux AT-SPI Value interface + event signals loopback (slice L7c) ────────
+//
+// Builds a value-bearing widget (RangeProbe implements AccessibilityValueInterface
+// — the SAME interface the Windows W6 provider dynamic_casts to), exports it on
+// the session bus via the test seam, then acts as an AT-SPI client:
+//   * Properties.Get(Value, CurrentValue/MinimumValue/MaximumValue/
+//     MinimumIncrement) — assert the doubles match the View's value interface.
+//   * Properties.Set(Value, CurrentValue, X) — assert it routes back into the
+//     View's set_current_value (same path a user adjust takes), then re-Get to
+//     confirm the new value is reported.
+//   * Accessible.GetInterfaces — assert "org.a11y.atspi.Value" is advertised on
+//     the value-bearing node and ABSENT on a plain (non-value) label node.
+//   * Trigger notify_accessibility_value_changed and pump — assert the emit path
+//     runs without disturbing a subsequent Property read (signal RECEIPT needs a
+//     real registry / a client signal-subscription API the object-server layer
+//     does not expose, so this is the CI-verifiable surface; receipt is a
+//     VM-only proof under accerciser/Orca).
+
+namespace {
+
+// Read a single double-typed property via org.freedesktop.DBus.Properties.Get
+// over a fresh client connection. Returns false on transport error.
+bool get_double_property(const std::string& server_name, const std::string& path,
+                         const std::string& iface, const std::string& prop,
+                         double& out) {
+    DBus client;
+    if (!client.connect_session()) return false;
+    return client.call_method(
+        server_name, path, kIfaceProperties, "Get",
+        [&](DBus::Writer& w) {
+            w.append_string(iface);
+            w.append_string(prop);
+        },
+        [&](DBus::Reader& r) {
+            // reply: v (a variant wrapping the double).
+            DBus::Reader var;
+            if (r.recurse(var)) var.read_double(out);
+        });
+}
+
+// Set a double-typed property via Properties.Set (the variant body is d).
+bool set_double_property(const std::string& server_name, const std::string& path,
+                         const std::string& iface, const std::string& prop,
+                         double value) {
+    DBus client;
+    if (!client.connect_session()) return false;
+    // Properties.Set takes (ssv); the DBus::Writer has no direct variant-at-top
+    // helper for the value, so open the variant explicitly.
+    return client.call_method(
+        server_name, path, kIfaceProperties, "Set",
+        [&](DBus::Writer& w) {
+            w.append_string(iface);
+            w.append_string(prop);
+            auto v = w.open_variant("d");
+            DBus::Writer vw = w.sub(v);
+            vw.append_double(value);
+            w.close_container(v);
+        },
+        [](DBus::Reader&) {});
+}
+
+// Read Accessible.GetInterfaces (reply: as) into a vector of strings.
+bool get_interfaces(const std::string& server_name, const std::string& path,
+                    std::vector<std::string>& out) {
+    DBus client;
+    if (!client.connect_session()) return false;
+    return client.call_method(
+        server_name, path, kIfaceAccessible, "GetInterfaces",
+        [](DBus::Writer&) {},
+        [&](DBus::Reader& r) {
+            DBus::Reader arr;
+            if (!r.recurse(arr)) return;
+            while (arr.arg_type() != 0) {
+                std::string s;
+                if (arr.read_string(s)) out.push_back(s);
+                if (!arr.next()) break;
+            }
+        });
+}
+
+bool contains(const std::vector<std::string>& v, const std::string& s) {
+    for (const auto& e : v) if (e == s) return true;
+    return false;
+}
+
+}  // namespace
+
+TEST_CASE("Linux AT-SPI exposes Value interface + routes Set + event hooks",
+          "[view][accessibility][atspi][linux][issue-L7c]") {
+    if (!DBus::library_available()) {
+        SUCCEED("skipped: libdbus not available");
+        return;
+    }
+    {
+        DBus probe;
+        if (!probe.connect_session()) {
+            SUCCEED("skipped: no session bus (run under dbus-run-session)");
+            return;
+        }
+    }
+
+    // root (none)
+    //   ├─ "Gain" (slider, RangeProbe ⇒ AccessibilityValueInterface, [-12,12]=6)
+    //   └─ "Title" (label, plain View ⇒ NOT value-bearing)
+    Probe root;
+    root.set_bounds({0, 0, 400, 300});
+
+    auto gain = std::make_unique<RangeProbe>(6.0);
+    gain->set_access_role(View::AccessRole::slider);
+    gain->set_access_label("Gain");
+    gain->set_bounds({20, 30, 200, 24});
+    RangeProbe* gain_raw = gain.get();
+
+    auto title = std::make_unique<Probe>();
+    title->set_access_role(View::AccessRole::label);
+    title->set_access_label("Title");
+    title->set_bounds({10, 10, 100, 20});
+
+    root.add_child(std::move(gain));
+    root.add_child(std::move(title));
+
+    std::string server_name;
+    void* handle =
+        init_accessibility_on_session_bus_for_test(root, &server_name);
+    if (!handle) {
+        SUCCEED("skipped: could not export on session bus");
+        return;
+    }
+    REQUIRE_FALSE(server_name.empty());
+
+    // Resolve object paths from the root's GetChildren (DFS order: Gain, Title).
+    WireNode root_node;
+    bool got_tree = run_client_call(handle, [&] {
+        return read_node(server_name, kRootPath, root_node);
+    });
+    REQUIRE(got_tree);
+    REQUIRE(root_node.child_paths.size() == 2);
+    const std::string gain_path = root_node.child_paths[0];
+    const std::string title_path = root_node.child_paths[1];
+
+    // ── Value properties report the View's value interface ──────────────────
+    double cur = 0, lo = 0, hi = 0, inc = 0;
+    bool got_props = run_client_call(handle, [&] {
+        bool ok = true;
+        ok = get_double_property(server_name, gain_path, kIfaceValue,
+                                 "CurrentValue", cur) && ok;
+        ok = get_double_property(server_name, gain_path, kIfaceValue,
+                                 "MinimumValue", lo) && ok;
+        ok = get_double_property(server_name, gain_path, kIfaceValue,
+                                 "MaximumValue", hi) && ok;
+        ok = get_double_property(server_name, gain_path, kIfaceValue,
+                                 "MinimumIncrement", inc) && ok;
+        return ok;
+    });
+    REQUIRE(got_props);
+    REQUIRE(cur == 6.0);
+    REQUIRE(lo == -12.0);
+    REQUIRE(hi == 12.0);
+    REQUIRE(inc == gain_raw->get_step_size());  // (12 - -12)/100 = 0.24
+
+    // ── Set CurrentValue routes back into the View's value interface ─────────
+    bool did_set = run_client_call(handle, [&] {
+        return set_double_property(server_name, gain_path, kIfaceValue,
+                                   "CurrentValue", -3.5);
+    });
+    REQUIRE(did_set);
+    REQUIRE(gain_raw->get_current_value() == -3.5);  // user-adjust path taken
+
+    // Re-Get confirms the provider now reports the updated value.
+    double cur2 = 0;
+    bool got_again = run_client_call(handle, [&] {
+        return get_double_property(server_name, gain_path, kIfaceValue,
+                                   "CurrentValue", cur2);
+    });
+    REQUIRE(got_again);
+    REQUIRE(cur2 == -3.5);
+
+    // ── GetInterfaces gates Value to value-bearing nodes only ───────────────
+    std::vector<std::string> gain_ifaces, title_ifaces;
+    bool got_ifaces = run_client_call(handle, [&] {
+        return get_interfaces(server_name, gain_path, gain_ifaces) &&
+               get_interfaces(server_name, title_path, title_ifaces);
+    });
+    REQUIRE(got_ifaces);
+    REQUIRE(contains(gain_ifaces, kIfaceAccessible));
+    REQUIRE(contains(gain_ifaces, kIfaceComponent));
+    REQUIRE(contains(gain_ifaces, kIfaceValue));     // slider IS value-bearing
+    REQUIRE(contains(title_ifaces, kIfaceAccessible));
+    REQUIRE(contains(title_ifaces, kIfaceComponent));
+    REQUIRE_FALSE(contains(title_ifaces, kIfaceValue));  // label is NOT
+
+    // ── Event hooks run the emit path without disrupting later reads ─────────
+    // Receipt of the PropertyChange / StateChanged signal requires a real
+    // registry (VM-only); here we assert the emit path executes cleanly and the
+    // object remains queryable afterward (a marshalling fault would throw / wedge
+    // the dispatcher and the follow-up Get would fail).
+    notify_accessibility_value_changed(handle, *gain_raw);
+    notify_accessibility_focus_changed(handle, *gain_raw);
+    notify_accessibility_name_changed(handle, *gain_raw);
+    accessibility_pump(handle);
+
+    double cur3 = 0;
+    bool still_alive = run_client_call(handle, [&] {
+        return get_double_property(server_name, gain_path, kIfaceValue,
+                                   "CurrentValue", cur3);
+    });
+    REQUIRE(still_alive);
+    REQUIRE(cur3 == -3.5);
+
+    shutdown_accessibility(handle);
+}
 #else
 TEST_CASE("Linux AT-SPI exports a per-widget Accessible + Component tree",
           "[view][accessibility][atspi][issue-L7b]") {
+    SUCCEED("Linux AT-SPI provider is a Linux-only runtime backend");
+}
+TEST_CASE("Linux AT-SPI exposes Value interface + routes Set + event hooks",
+          "[view][accessibility][atspi][issue-L7c]") {
     SUCCEED("Linux AT-SPI provider is a Linux-only runtime backend");
 }
 #endif


### PR DESCRIPTION
Final L7 slice. Completes Linux AT-SPI accessibility (object server #3698 + registration #3732 + per-widget tree #3737 + this).

- `org.a11y.atspi.Value` (CurrentValue rw / Min / Max / MinimumIncrement) on value-bearing Views, reusing the exact W6 `dynamic_cast<AccessibilityValueInterface*>` accessor; added to GetInterfaces only when present; Set routes into the View.
- The three `notify_accessibility_*` hooks emit `org.a11y.atspi.Event.Object` signals (focus StateChanged / value+name PropertyChange).

**VM-verified under dbus-run-session: 77 assertions / 12 cases** (Value Get/Set round-trip, Set→View, GetInterfaces gating). Builds on the VM-proven L7a-1/L7b foundation. Signal receipt needs a real registry (object-server has no client subscription — matches test_dbus precedent). 3 files, in-scope. Part of #3329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Linux AT-SPI `org.a11y.atspi.Value` for value-bearing views and per-object `Event.Object` signals for focus/value/name changes. Completes the L7 slice of the per-widget accessibility provider.

- **New Features**
  - Export `org.a11y.atspi.Value` only for Views that implement `AccessibilityValueInterface`; serve `CurrentValue`, `MinimumValue`, `MaximumValue`, `MinimumIncrement` via `org.freedesktop.DBus.Properties`. `CurrentValue` is writable and routes to `set_current_value`.
  - Emit `Event.Object` signals from the changed object's path: `StateChanged` ("focused") and `PropertyChange` ("accessible-value", "accessible-name").
  - Include `Value` in `Accessible.GetInterfaces` and introspection only when present.
  - Add loopback tests for Value Get/Set round-trip and interface gating; exercise signal emit path. 
  - Bump version to 0.392.0.

<sup>Written for commit 50bcaca56f99477bcbdc605b6b98aef55642913d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

