### PR TITLE
feat(view): Linux XDND drag-drop on the plugin-host X11 window (#3645)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.392.2
+    VERSION 0.393.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/plugin_view_host.hpp
+++ b/core/view/include/pulp/view/plugin_view_host.hpp
@@ -180,6 +180,16 @@ public:
         (void) child_view;
     }
 
+    // Pump any pending native drag-and-drop (and related) events on a host
+    // that owns its own platform connection. The Linux X11 host overrides this
+    // to drain its X connection and run the XDND target protocol (XdndEnter /
+    // Position / Drop), routing drops into the view tree via the shared
+    // dispatch core. Hosts driven by a host-owned event loop (Apple, the SDL
+    // standalone) do not need it. Default no-op. Call on the UI thread; a
+    // driver (standalone host idle, or a DAW editor idle hook) invokes it
+    // periodically so drags onto the embedded editor are serviced.
+    virtual void pump_x_events() {}
+
     // ── Design viewport (mirrors WindowHost::set_design_viewport) ────────
     //
     // Constrain editor resize to a fixed aspect ratio. Plugin hosts do not

--- a/core/view/platform/linux/plugin_view_host_linux.cpp
+++ b/core/view/platform/linux/plugin_view_host_linux.cpp
@@ -23,6 +23,9 @@
 
 #include <pulp/view/plugin_view_host.hpp>
 #include <pulp/view/window_host.hpp>
+#include <pulp/view/drag_drop.hpp>
+
+#include "xdnd_parse.hpp"
 
 #ifdef PULP_HAS_SKIA
 #include <pulp/render/gpu_surface.hpp>
@@ -41,12 +44,15 @@
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#include <X11/Xatom.h>
 
 #include <atomic>
+#include <cstdint>
 #include <cstring>
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <vector>
 
 namespace pulp::view {
@@ -76,8 +82,13 @@ public:
             runtime::log_warn("X11PluginViewHost: XCreateSimpleWindow failed");
             return;
         }
-        XSelectInput(display_, child_, ExposureMask | StructureNotifyMask);
+        // PropertyChangeMask is needed so the SelectionNotify path can read
+        // back the XdndSelection property the source writes; StructureNotify +
+        // Exposure keep the existing repaint/reparent behavior.
+        XSelectInput(display_, child_,
+                     ExposureMask | StructureNotifyMask | PropertyChangeMask);
         gc_ = XCreateGC(display_, child_, 0, nullptr);
+        init_xdnd();
         XFlush(display_);
 #ifdef PULP_HAS_SKIA
         init_gpu(static_cast<float>(size.width), static_cast<float>(size.height));
@@ -131,6 +142,10 @@ public:
     }
 
     void repaint() override {
+        // Service drag-and-drop on our own X connection. The standalone host
+        // repaints ~each frame, so this is the steady-state XDND pump; a
+        // DAW-embedded driver can also call pump_x_events() directly.
+        pump_x_events();
 #ifdef PULP_HAS_SKIA
         if (gpu_surface_ && skia_surface_) {
             render_frame_gpu(nullptr, nullptr, nullptr);
@@ -209,6 +224,30 @@ public:
 
     void set_fixed_aspect_ratio(float ratio) override { fixed_aspect_ratio_ = ratio; }
 
+    // Drain pending X events on our own connection and run the XDND target
+    // protocol (drag-and-drop from another X client onto the editor child
+    // window). There is no internal event loop in this host, so a driver must
+    // call this — the standalone Linux GPU host pumps it each frame via
+    // repaint(), and a DAW-embedded host can call it from its editor idle hook.
+    // Honest no-op when display_/child_ are null (headless capture mode).
+    void pump_x_events() override {
+        if (!display_ || !child_) return;
+        while (XPending(display_) > 0) {
+            XEvent ev;
+            XNextEvent(display_, &ev);
+            switch (ev.type) {
+                case ClientMessage:
+                    handle_client_message(ev.xclient);
+                    break;
+                case SelectionNotify:
+                    handle_selection_notify(ev.xselection);
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
     Point window_to_root_point(Point pt) const override {
         float sx, sy, tx, ty;
         if (!WindowHost::compute_design_viewport_transform(
@@ -235,6 +274,265 @@ private:
     float design_viewport_h_ = 0.0f;
     float fixed_aspect_ratio_ = 0.0f;
     bool design_top_align_ = false;
+
+    // ── XDND (X11 drag-and-drop) target state ────────────────────────────
+    // Atoms interned once in init_xdnd(). 0 (None) until interned.
+    Atom xa_XdndAware_ = 0;
+    Atom xa_XdndEnter_ = 0;
+    Atom xa_XdndPosition_ = 0;
+    Atom xa_XdndStatus_ = 0;
+    Atom xa_XdndLeave_ = 0;
+    Atom xa_XdndDrop_ = 0;
+    Atom xa_XdndFinished_ = 0;
+    Atom xa_XdndSelection_ = 0;
+    Atom xa_XdndActionCopy_ = 0;
+    Atom xa_XdndTypeList_ = 0;
+    Atom xa_text_uri_list_ = 0;
+    Atom xa_UTF8_STRING_ = 0;
+    Atom xa_pulp_xdnd_prop_ = 0;  // our property the selection lands in
+
+    // Per-drag hover state owned by this host (one in-flight pointer), routed
+    // through the shared dispatch core — never a process global.
+    DragSession drag_session_;
+
+    // In-flight XDND source/transfer state, valid between XdndEnter and the
+    // XdndFinished we send after a drop. Reset on Leave / after Finished.
+    Window xdnd_source_ = 0;          // the source client's window
+    int xdnd_source_version_ = 0;     // min(our v5, source's advertised version)
+    Atom xdnd_chosen_type_ = 0;       // type we asked the source to convert to
+    int xdnd_drop_root_x_ = 0;        // last XdndPosition pointer (root coords)
+    int xdnd_drop_root_y_ = 0;
+    bool xdnd_drop_pending_ = false;  // awaiting SelectionNotify after XdndDrop
+
+    // Intern the XDND atoms and advertise the child window as an XDND-aware
+    // target (version 5). Safe no-op without display_/child_.
+    void init_xdnd() {
+        if (!display_ || !child_) return;
+        xa_XdndAware_ = XInternAtom(display_, "XdndAware", False);
+        xa_XdndEnter_ = XInternAtom(display_, "XdndEnter", False);
+        xa_XdndPosition_ = XInternAtom(display_, "XdndPosition", False);
+        xa_XdndStatus_ = XInternAtom(display_, "XdndStatus", False);
+        xa_XdndLeave_ = XInternAtom(display_, "XdndLeave", False);
+        xa_XdndDrop_ = XInternAtom(display_, "XdndDrop", False);
+        xa_XdndFinished_ = XInternAtom(display_, "XdndFinished", False);
+        xa_XdndSelection_ = XInternAtom(display_, "XdndSelection", False);
+        xa_XdndActionCopy_ = XInternAtom(display_, "XdndActionCopy", False);
+        xa_XdndTypeList_ = XInternAtom(display_, "XdndTypeList", False);
+        xa_text_uri_list_ = XInternAtom(display_, "text/uri-list", False);
+        xa_UTF8_STRING_ = XInternAtom(display_, "UTF8_STRING", False);
+        xa_pulp_xdnd_prop_ = XInternAtom(display_, "PULP_XDND_SELECTION", False);
+
+        // Advertise XDND v5 support on the child window.
+        const long version = 5;
+        XChangeProperty(display_, child_, xa_XdndAware_, XA_ATOM, 32,
+                        PropModeReplace,
+                        reinterpret_cast<const unsigned char*>(&version), 1);
+    }
+
+    // Read the absolute (root-window) origin of the child window so XdndPosition
+    // root coordinates can be converted to child-local coordinates.
+    void child_root_origin(int& x, int& y) const {
+        x = 0;
+        y = 0;
+        if (!display_ || !child_) return;
+        Window root_win = RootWindow(display_, screen_);
+        Window dummy_child = 0;
+        int rx = 0, ry = 0;
+        if (XTranslateCoordinates(display_, child_, root_win, 0, 0, &rx, &ry,
+                                  &dummy_child)) {
+            x = rx;
+            y = ry;
+        }
+    }
+
+    // Map an XdndPosition root point to the root-view coordinate space the
+    // dispatch core expects: root → child-local (subtract child origin) →
+    // window_to_root_point (design-viewport inverse). Mirrors the mac producer.
+    Point xdnd_root_to_view(int root_x, int root_y) const {
+        int ox = 0, oy = 0;
+        child_root_origin(ox, oy);
+        Point local = xdnd::root_to_child_local(root_x, root_y, ox, oy);
+        return window_to_root_point(local);
+    }
+
+    // Read the source's offered types. XdndEnter packs up to 3 types inline
+    // (data.l[2..4]); when the low bit of data.l[1] is set, the full list lives
+    // in the XdndTypeList property on the source window.
+    std::vector<Atom> read_offered_types(const XClientMessageEvent& msg) {
+        std::vector<Atom> types;
+        const bool more = (msg.data.l[1] & 1) != 0;
+        if (more) {
+            Window source = static_cast<Window>(msg.data.l[0]);
+            Atom actual_type = 0;
+            int actual_format = 0;
+            unsigned long nitems = 0, bytes_after = 0;
+            unsigned char* prop = nullptr;
+            if (XGetWindowProperty(display_, source, xa_XdndTypeList_, 0, 1024,
+                                   False, XA_ATOM, &actual_type, &actual_format,
+                                   &nitems, &bytes_after, &prop) == Success &&
+                prop) {
+                const Atom* atoms = reinterpret_cast<const Atom*>(prop);
+                for (unsigned long i = 0; i < nitems; ++i) types.push_back(atoms[i]);
+                XFree(prop);
+            }
+        } else {
+            for (int i = 2; i <= 4; ++i) {
+                Atom a = static_cast<Atom>(msg.data.l[i]);
+                if (a != None) types.push_back(a);
+            }
+        }
+        return types;
+    }
+
+    // Pick the best target type from the offered list: prefer files
+    // (text/uri-list), fall back to UTF8 text. None (0) if neither is offered.
+    Atom choose_type(const std::vector<Atom>& offered) const {
+        for (Atom a : offered)
+            if (a == xa_text_uri_list_) return xa_text_uri_list_;
+        for (Atom a : offered)
+            if (a == xa_UTF8_STRING_) return xa_UTF8_STRING_;
+        return None;
+    }
+
+    void send_xdnd_status(Window source, bool accept) {
+        XEvent reply;
+        std::memset(&reply, 0, sizeof(reply));
+        reply.xclient.type = ClientMessage;
+        reply.xclient.display = display_;
+        reply.xclient.window = source;
+        reply.xclient.message_type = xa_XdndStatus_;
+        reply.xclient.format = 32;
+        reply.xclient.data.l[0] = static_cast<long>(child_);
+        // bit0: accept; bit1: send XdndPosition for every motion (we set it so
+        // we keep getting position updates for hover feedback).
+        reply.xclient.data.l[1] = accept ? 3 : 0;
+        reply.xclient.data.l[2] = 0;  // empty rect → always send Position
+        reply.xclient.data.l[3] = 0;
+        reply.xclient.data.l[4] =
+            accept ? static_cast<long>(xa_XdndActionCopy_) : 0;
+        XSendEvent(display_, source, False, NoEventMask, &reply);
+        XFlush(display_);
+    }
+
+    void send_xdnd_finished(Window source, bool accepted) {
+        XEvent reply;
+        std::memset(&reply, 0, sizeof(reply));
+        reply.xclient.type = ClientMessage;
+        reply.xclient.display = display_;
+        reply.xclient.window = source;
+        reply.xclient.message_type = xa_XdndFinished_;
+        reply.xclient.format = 32;
+        reply.xclient.data.l[0] = static_cast<long>(child_);
+        // v5: bit0 = accepted; data.l[2] = action performed.
+        reply.xclient.data.l[1] = accepted ? 1 : 0;
+        reply.xclient.data.l[2] =
+            accepted ? static_cast<long>(xa_XdndActionCopy_) : 0;
+        XSendEvent(display_, source, False, NoEventMask, &reply);
+        XFlush(display_);
+    }
+
+    void reset_xdnd_drag() {
+        xdnd_source_ = 0;
+        xdnd_source_version_ = 0;
+        xdnd_chosen_type_ = 0;
+        xdnd_drop_pending_ = false;
+        dispatch_drag_exit(root_, drag_session_);
+    }
+
+    void handle_client_message(const XClientMessageEvent& msg) {
+        if (msg.message_type == xa_XdndEnter_) {
+            xdnd_source_ = static_cast<Window>(msg.data.l[0]);
+            xdnd_source_version_ =
+                static_cast<int>((msg.data.l[1] >> 24) & 0xff);
+            auto offered = read_offered_types(msg);
+            xdnd_chosen_type_ = choose_type(offered);
+            return;
+        }
+        if (msg.message_type == xa_XdndPosition_) {
+            Window source = static_cast<Window>(msg.data.l[0]);
+            xdnd_drop_root_x_ = static_cast<int>((msg.data.l[2] >> 16) & 0xffff);
+            xdnd_drop_root_y_ = static_cast<int>(msg.data.l[2] & 0xffff);
+            const bool can_accept = xdnd_chosen_type_ != None;
+            if (can_accept) {
+                // Hover feedback through the shared dispatch core. The data's
+                // concrete payload isn't known until the drop, so feed a typed
+                // shell (files vs text) so DropReceivers can highlight.
+                DropData hover;
+                hover.type = (xdnd_chosen_type_ == xa_text_uri_list_)
+                                 ? DropData::Type::files
+                                 : DropData::Type::text;
+                dispatch_drag_move(root_, drag_session_, hover,
+                                   xdnd_root_to_view(xdnd_drop_root_x_,
+                                                     xdnd_drop_root_y_));
+            }
+            send_xdnd_status(source, can_accept);
+            return;
+        }
+        if (msg.message_type == xa_XdndLeave_) {
+            reset_xdnd_drag();
+            return;
+        }
+        if (msg.message_type == xa_XdndDrop_) {
+            Window source = static_cast<Window>(msg.data.l[0]);
+            if (xdnd_chosen_type_ == None) {
+                // Nothing droppable was offered — finish without accepting.
+                send_xdnd_finished(source, false);
+                reset_xdnd_drag();
+                return;
+            }
+            xdnd_drop_pending_ = true;
+            Time t = (xdnd_source_version_ >= 1)
+                         ? static_cast<Time>(msg.data.l[2])
+                         : CurrentTime;
+            // Ask the source to convert the selection to our chosen type; the
+            // payload arrives later as a SelectionNotify.
+            XConvertSelection(display_, xa_XdndSelection_, xdnd_chosen_type_,
+                              xa_pulp_xdnd_prop_, child_, t);
+            XFlush(display_);
+            return;
+        }
+    }
+
+    void handle_selection_notify(const XSelectionEvent& sel) {
+        if (!xdnd_drop_pending_) return;
+        if (sel.property == None) {
+            // Source failed to convert — finish unaccepted.
+            if (xdnd_source_) send_xdnd_finished(xdnd_source_, false);
+            reset_xdnd_drag();
+            return;
+        }
+
+        Atom actual_type = 0;
+        int actual_format = 0;
+        unsigned long nitems = 0, bytes_after = 0;
+        unsigned char* prop = nullptr;
+        std::string payload;
+        if (XGetWindowProperty(display_, child_, sel.property, 0, 0x7fffffff,
+                               True /* delete */, AnyPropertyType, &actual_type,
+                               &actual_format, &nitems, &bytes_after,
+                               &prop) == Success &&
+            prop) {
+            payload.assign(reinterpret_cast<const char*>(prop),
+                           static_cast<size_t>(nitems));
+            XFree(prop);
+        }
+
+        DropData data;
+        if (xdnd_chosen_type_ == xa_text_uri_list_) {
+            data.type = DropData::Type::files;
+            data.file_paths = xdnd::parse_uri_list(payload);
+        } else {
+            data.type = DropData::Type::text;
+            data.text = payload;
+        }
+
+        const bool consumed = dispatch_drop(
+            root_, drag_session_, data,
+            xdnd_root_to_view(xdnd_drop_root_x_, xdnd_drop_root_y_));
+
+        if (xdnd_source_) send_xdnd_finished(xdnd_source_, consumed);
+        reset_xdnd_drag();
+    }
 
 #ifdef PULP_HAS_SKIA
     std::unique_ptr<render::GpuSurface> gpu_surface_;

--- a/core/view/platform/linux/xdnd_parse.hpp
+++ b/core/view/platform/linux/xdnd_parse.hpp
@@ -1,0 +1,119 @@
+#pragma once
+
+// Pure (X11-free) helpers for the Linux XDND target on the plugin-host child
+// window. The XDND protocol machinery (atoms, ClientMessage handshake,
+// XConvertSelection) lives in plugin_view_host_linux.cpp and needs Xlib; the
+// payload parsing and coordinate mapping below are pure arithmetic / string
+// work, so they live here as header-only free functions that compile on every
+// platform. That lets the cross-platform drag-drop test suite exercise them
+// without an X server or Xlib link — the handshake itself needs xvfb (see
+// test_plugin_view_host_factory.cpp).
+
+#include <pulp/view/geometry.hpp>
+
+#include <string>
+#include <vector>
+
+namespace pulp::view::xdnd {
+
+// Decode percent-encoded octets in a `file://` URI path component (RFC 3986).
+// XDND `text/uri-list` payloads percent-encode reserved + non-ASCII bytes, so a
+// path with a space arrives as `%20`. Unknown / malformed `%` escapes are left
+// verbatim rather than dropped, so a stray `%` never silently truncates a path.
+inline std::string percent_decode(const std::string& in) {
+    std::string out;
+    out.reserve(in.size());
+    auto hex_val = [](char c) -> int {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+        return -1;
+    };
+    for (size_t i = 0; i < in.size(); ++i) {
+        if (in[i] == '%' && i + 2 < in.size()) {
+            int hi = hex_val(in[i + 1]);
+            int lo = hex_val(in[i + 2]);
+            if (hi >= 0 && lo >= 0) {
+                out.push_back(static_cast<char>((hi << 4) | lo));
+                i += 2;
+                continue;
+            }
+        }
+        out.push_back(in[i]);
+    }
+    return out;
+}
+
+// Convert a single `file://` URI to a filesystem path. Mirrors the macOS
+// producer's [[url path] UTF8String] result: the local path with the scheme +
+// (optional) authority stripped and percent-escapes decoded. Forms handled:
+//   file:///abs/path        -> /abs/path           (empty authority)
+//   file://host/abs/path    -> /abs/path           (named authority dropped)
+//   file:/abs/path          -> /abs/path           (no `//`, lenient)
+//   /abs/path               -> /abs/path           (bare path, passthrough)
+// A non-file scheme (http://, data:) returns empty — XDND file drops should
+// only ever carry file URIs, and we refuse to hand a URL to a file consumer.
+inline std::string file_uri_to_path(const std::string& uri) {
+    constexpr const char* kScheme = "file:";
+    constexpr size_t kSchemeLen = 5;  // strlen("file:")
+    std::string s = uri;
+    if (s.rfind(kScheme, 0) == 0) {
+        s = s.substr(kSchemeLen);
+        if (s.rfind("//", 0) == 0) {
+            // Strip the authority component up to the first '/' of the path.
+            size_t path_start = s.find('/', 2);
+            if (path_start == std::string::npos) return {};  // authority only
+            s = s.substr(path_start);
+        }
+        // else `file:/abs` (no authority) — s already begins with '/'.
+    } else if (!s.empty() && s.front() == '/') {
+        // Bare absolute path (tolerated; some sources omit the scheme).
+    } else {
+        return {};  // non-file scheme or relative junk
+    }
+    return percent_decode(s);
+}
+
+// Parse an XDND `text/uri-list` payload into filesystem paths. The format
+// (RFC 2483) is CRLF-separated URIs; lines beginning with '#' are comments and
+// blank lines are ignored. Lenient on the line ending: handles CRLF, lone LF,
+// and a missing trailing newline. Non-file URIs are skipped (see
+// file_uri_to_path), so a mixed payload keeps only the droppable files.
+inline std::vector<std::string> parse_uri_list(const std::string& payload) {
+    std::vector<std::string> paths;
+    size_t start = 0;
+    const size_t n = payload.size();
+    while (start <= n) {
+        size_t end = payload.find('\n', start);
+        std::string line = payload.substr(
+            start, end == std::string::npos ? std::string::npos : end - start);
+        // Trim a trailing '\r' (CRLF) and any surrounding whitespace.
+        while (!line.empty() &&
+               (line.back() == '\r' || line.back() == ' ' || line.back() == '\t'))
+            line.pop_back();
+        size_t first = line.find_first_not_of(" \t");
+        if (first != std::string::npos) line = line.substr(first);
+
+        if (!line.empty() && line.front() != '#') {
+            std::string path = file_uri_to_path(line);
+            if (!path.empty()) paths.push_back(std::move(path));
+        }
+        if (end == std::string::npos) break;
+        start = end + 1;
+    }
+    return paths;
+}
+
+// Map an XDND root-space drop point to the plugin-host child window's local
+// coordinates. XDND XdndPosition carries the pointer position in ROOT-window
+// coordinates; the host knows the child window's absolute origin on the root
+// (from XTranslateCoordinates). Subtracting it yields the child-local point that
+// then feeds window_to_root_point() (the design-viewport inverse) before
+// dispatch — exactly mirroring how the mac producer converts draggingLocation.
+inline Point root_to_child_local(int root_x, int root_y, int child_origin_x,
+                                 int child_origin_y) {
+    return {static_cast<float>(root_x - child_origin_x),
+            static_cast<float>(root_y - child_origin_y)};
+}
+
+}  // namespace pulp::view::xdnd

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4087,25 +4087,32 @@ if(APPLE OR PULP_HAS_SKIA)
 endif()
 
 # #3329 — native PluginViewHost factory + headless-capture proof on non-Apple.
-# Built only where core/view actually compiled a platform host: Windows with
-# Skia, or non-Android UNIX with Skia + X11. Mirrors the core/view/CMakeLists
-# conditions. The host degrades to capture-only when no display server is
-# present (headless CI VM), and capture_back_buffer_png() still yields a frame.
+# Built where core/view compiled a platform host: Windows+Skia or non-Android
+# UNIX+Skia+X11. Degrades to capture-only with no display server (headless VM);
+# capture_back_buffer_png() still yields a frame. On Linux+X11 the same binary
+# also runs the XDND synthetic-source handshake under xvfb (#3645): it links
+# Xlib directly to act as an XDND source against the host's child window, gated
+# by PULP_TEST_HAS_X11 so the handshake TEST_CASE is compiled only there.
 if(PULP_HAS_SKIA AND NOT APPLE AND NOT ANDROID)
     set(_pulp_has_platform_pvh OFF)
+    set(_pulp_pvh_x11 OFF)
     if(WIN32)
         set(_pulp_has_platform_pvh ON)
     elseif(UNIX)
         find_package(X11 QUIET)
         if(X11_FOUND)
             set(_pulp_has_platform_pvh ON)
+            set(_pulp_pvh_x11 ON)
         endif()
     endif()
     if(_pulp_has_platform_pvh)
-        add_executable(pulp-test-plugin-view-host-factory
-            test_plugin_view_host_factory.cpp)
-        target_link_libraries(pulp-test-plugin-view-host-factory
-            PRIVATE pulp::view Catch2::Catch2WithMain)
+        add_executable(pulp-test-plugin-view-host-factory test_plugin_view_host_factory.cpp)
+        target_link_libraries(pulp-test-plugin-view-host-factory PRIVATE pulp::view Catch2::Catch2WithMain)
+        if(_pulp_pvh_x11)
+            target_link_libraries(pulp-test-plugin-view-host-factory PRIVATE ${X11_LIBRARIES})
+            target_include_directories(pulp-test-plugin-view-host-factory PRIVATE ${X11_INCLUDE_DIR})
+            target_compile_definitions(pulp-test-plugin-view-host-factory PRIVATE PULP_TEST_HAS_X11=1)
+        endif()
         catch_discover_tests(pulp-test-plugin-view-host-factory)
     endif()
 endif()
@@ -4134,11 +4141,7 @@ if(APPLE)
     # verify CGContextClearRect actually clears destination pixels.
     # pulp #1524 adds ImageIO for CGImageDestinationCreateWithURL (PNG
     # encode of a pattern fixture) and CoreServices for the public.png UTI.
-    target_link_libraries(pulp-test-canvas PRIVATE
-        "-framework CoreGraphics"
-        "-framework ImageIO"
-        "-framework CoreServices"
-    )
+    target_link_libraries(pulp-test-canvas PRIVATE "-framework CoreGraphics" "-framework ImageIO" "-framework CoreServices")
 endif()
 # pulp #1150 — public font-registration API tests use a bundled .ttf as a
 # fixture. external/fonts/Inter-Regular.ttf is the canonical "always
@@ -4159,11 +4162,7 @@ catch_discover_tests(pulp-test-canvas)
 add_executable(pulp-test-canvas-cg-paths test_canvas_cg_paths.cpp)
 target_link_libraries(pulp-test-canvas-cg-paths PRIVATE pulp::canvas Catch2::Catch2WithMain)
 if(APPLE)
-    target_link_libraries(pulp-test-canvas-cg-paths PRIVATE
-        "-framework CoreGraphics"
-        "-framework ImageIO"
-        "-framework CoreServices"
-    )
+    target_link_libraries(pulp-test-canvas-cg-paths PRIVATE "-framework CoreGraphics" "-framework ImageIO" "-framework CoreServices")
 endif()
 catch_discover_tests(pulp-test-canvas-cg-paths)
 

--- a/test/test_drag_drop.cpp
+++ b/test/test_drag_drop.cpp
@@ -3,6 +3,14 @@
 #include <pulp/view/file_drop_zone.hpp>
 #include <pulp/view/view.hpp>
 
+// XDND payload-parsing + coordinate-mapping helpers (Linux X11 producer). These
+// are pure (X11-free) free functions, so the cross-platform dnd suite exercises
+// them on every platform; the X11 ClientMessage handshake itself needs xvfb and
+// is covered in test_plugin_view_host_factory.cpp. Relative include keeps the
+// header off the public include path (it is a platform-private helper) without
+// adding a CMake include-dir line to the frozen test/CMakeLists.txt.
+#include "../core/view/platform/linux/xdnd_parse.hpp"
+
 #include <string>
 #include <vector>
 
@@ -356,4 +364,69 @@ TEST_CASE("a drop a DropReceiver declines bubbles to View::on_drop",
     REQUIRE(dispatch_drop(root, session, make_text("hi"), {10, 10}));
     CHECK_FALSE(zone_fired);     // zone declines text
     CHECK(got_type == "text");   // bubbled to the ancestor on_drop
+}
+
+// ── XDND payload parsing + coordinate mapping (Linux X11 producer) ───────────
+
+TEST_CASE("XDND file_uri_to_path handles file:// forms", "[view][dnd][xdnd]") {
+    using namespace pulp::view::xdnd;
+    CHECK(file_uri_to_path("file:///home/u/a.wav") == "/home/u/a.wav");
+    // Named authority is dropped (matches macOS [[url path]]).
+    CHECK(file_uri_to_path("file://localhost/home/u/a.wav") == "/home/u/a.wav");
+    // No-authority lenient form.
+    CHECK(file_uri_to_path("file:/home/u/a.wav") == "/home/u/a.wav");
+    // Bare absolute path passes through.
+    CHECK(file_uri_to_path("/home/u/a.wav") == "/home/u/a.wav");
+    // Percent-escapes decode (space, parens).
+    CHECK(file_uri_to_path("file:///home/u/my%20preset%20(1).json") ==
+          "/home/u/my preset (1).json");
+    // Non-file schemes are refused.
+    CHECK(file_uri_to_path("http://example.com/x").empty());
+    CHECK(file_uri_to_path("data:text/plain,hi").empty());
+    // Authority-only file URI has no path → empty.
+    CHECK(file_uri_to_path("file://host").empty());
+}
+
+TEST_CASE("XDND parse_uri_list splits CRLF and skips comments/blanks/non-file",
+          "[view][dnd][xdnd]") {
+    using namespace pulp::view::xdnd;
+    // Canonical CRLF-separated list with a comment and a blank line.
+    const std::string payload =
+        "#comment\r\n"
+        "file:///a.wav\r\n"
+        "\r\n"
+        "file:///b%20c.json\r\n"
+        "http://skip.me/x\r\n";
+    auto paths = parse_uri_list(payload);
+    REQUIRE(paths.size() == 2);
+    CHECK(paths[0] == "/a.wav");
+    CHECK(paths[1] == "/b c.json");
+}
+
+TEST_CASE("XDND parse_uri_list tolerates lone LF and no trailing newline",
+          "[view][dnd][xdnd]") {
+    using namespace pulp::view::xdnd;
+    auto paths = parse_uri_list("file:///x.wav\nfile:///y.wav");
+    REQUIRE(paths.size() == 2);
+    CHECK(paths[0] == "/x.wav");
+    CHECK(paths[1] == "/y.wav");
+    // A single URI with no newline at all.
+    auto one = parse_uri_list("file:///only.wav");
+    REQUIRE(one.size() == 1);
+    CHECK(one[0] == "/only.wav");
+    // Empty payload → empty list (no spurious entry).
+    CHECK(parse_uri_list("").empty());
+}
+
+TEST_CASE("XDND root_to_child_local subtracts the child window origin",
+          "[view][dnd][xdnd]") {
+    using namespace pulp::view::xdnd;
+    // Pointer at root (130,170); child window origin at (100,150) on root.
+    Point p = root_to_child_local(130, 170, 100, 150);
+    CHECK(p.x == 30.0f);
+    CHECK(p.y == 20.0f);
+    // Origin at the root corner is an identity map.
+    Point q = root_to_child_local(5, 7, 0, 0);
+    CHECK(q.x == 5.0f);
+    CHECK(q.y == 7.0f);
 }

--- a/test/test_plugin_view_host_factory.cpp
+++ b/test/test_plugin_view_host_factory.cpp
@@ -11,10 +11,21 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <pulp/view/drag_drop.hpp>
 #include <pulp/view/plugin_view_host.hpp>
 #include <pulp/view/theme.hpp>
 #include <pulp/view/view.hpp>
 #include <pulp/view/widgets.hpp>
+
+#if defined(PULP_TEST_HAS_X11)
+#include <X11/Xlib.h>
+#include <X11/Xatom.h>
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+#endif
 
 using namespace pulp::view;
 
@@ -51,3 +62,215 @@ TEST_CASE("PluginViewHost::create returns a native host with headless capture",
     REQUIRE(png[0] == 0x89);  // PNG magic
     REQUIRE(png[1] == 'P');
 }
+
+#if defined(PULP_TEST_HAS_X11)
+
+// ── XDND synthetic-source handshake (Linux X11 target, #3645) ────────────────
+//
+// The X11 plugin host advertises an XDND target on its child window and runs the
+// XdndEnter / XdndPosition / XdndDrop protocol in pump_x_events(), routing the
+// resolved payload into the shared dispatch core (dispatch_drop). This test acts
+// as an XDND *source* from a second X connection: it owns the XdndSelection with
+// a `text/uri-list` payload, sends the protocol ClientMessages to the host's
+// child window, services the host's XConvertSelection (SelectionRequest), and
+// asserts the host fired dispatch_drop with the expected path AND sent back an
+// XdndFinished. Requires a display server (xvfb-run); skips cleanly otherwise.
+
+namespace {
+
+// A DropReceiver that records the last accepted drop so the test can assert the
+// host routed the XDND payload through the dispatch core.
+class RecordingDropZone : public pulp::view::View, public pulp::view::DropReceiver {
+public:
+    bool accept_drop(const pulp::view::DropData& data, pulp::view::Point) override {
+        last = data;
+        drops += 1;
+        return true;  // consume
+    }
+    pulp::view::DropData last;
+    int drops = 0;
+};
+
+void send_client_message(Display* dpy, Window target, Window source, Atom type,
+                         long d0, long d1, long d2, long d3, long d4) {
+    XEvent ev;
+    std::memset(&ev, 0, sizeof(ev));
+    ev.xclient.type = ClientMessage;
+    ev.xclient.display = dpy;
+    ev.xclient.window = target;
+    ev.xclient.message_type = type;
+    ev.xclient.format = 32;
+    ev.xclient.data.l[0] = source ? static_cast<long>(source) : d0;
+    ev.xclient.data.l[1] = d1;
+    ev.xclient.data.l[2] = d2;
+    ev.xclient.data.l[3] = d3;
+    ev.xclient.data.l[4] = d4;
+    XSendEvent(dpy, target, False, NoEventMask, &ev);
+    XFlush(dpy);
+}
+
+}  // namespace
+
+TEST_CASE("X11 plugin host runs the XDND target handshake into dispatch_drop",
+          "[view][plugin-view-host][xdnd][linux]") {
+    Display* src = XOpenDisplay(nullptr);
+    if (!src) {
+        WARN("no X display (run under xvfb-run) — XDND handshake skipped");
+        return;
+    }
+
+    // Build the host with a recording drop zone covering the whole surface.
+    pulp::view::View root;
+    root.set_bounds({0, 0, 200, 150});
+    auto zone_owned = std::make_unique<RecordingDropZone>();
+    RecordingDropZone* zone = zone_owned.get();
+    zone->set_bounds({0, 0, 200, 150});
+    root.add_child(std::move(zone_owned));
+
+    pulp::view::register_platform_plugin_view_host();
+    pulp::view::PluginViewHost::Options opts;
+    opts.size = {200, 150};
+    opts.use_gpu = false;
+    auto host = pulp::view::PluginViewHost::create(root, opts);
+    REQUIRE(host != nullptr);
+
+    // Parent the child onto the X11 root so it has a real on-screen origin the
+    // source can target. After this, child-local == root coords (origin 0,0).
+    Window x_root = DefaultRootWindow(src);
+    host->attach_to_parent(reinterpret_cast<void*>(static_cast<uintptr_t>(x_root)));
+    Window child = static_cast<Window>(reinterpret_cast<uintptr_t>(host->native_handle()));
+    REQUIRE(child != 0);
+
+    // Verify the host advertised XdndAware on the child window.
+    Atom xa_aware = XInternAtom(src, "XdndAware", False);
+    {
+        Atom actual = 0; int fmt = 0; unsigned long n = 0, after = 0;
+        unsigned char* prop = nullptr;
+        // Poll briefly: the host sets the property on its own connection.
+        int version = 0;
+        for (int i = 0; i < 50 && version == 0; ++i) {
+            if (XGetWindowProperty(src, child, xa_aware, 0, 1, False, XA_ATOM,
+                                   &actual, &fmt, &n, &after, &prop) == Success &&
+                prop && n >= 1) {
+                version = static_cast<int>(reinterpret_cast<unsigned long*>(prop)[0]);
+            }
+            if (prop) { XFree(prop); prop = nullptr; }
+            if (version == 0) std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+        REQUIRE(version >= 5);
+    }
+
+    // Source window that owns the XdndSelection and carries the uri-list.
+    Window source = XCreateSimpleWindow(src, x_root, 0, 0, 1, 1, 0, 0, 0);
+    Atom xa_selection = XInternAtom(src, "XdndSelection", False);
+    Atom xa_uri_list = XInternAtom(src, "text/uri-list", False);
+    Atom xa_enter = XInternAtom(src, "XdndEnter", False);
+    Atom xa_position = XInternAtom(src, "XdndPosition", False);
+    Atom xa_drop = XInternAtom(src, "XdndDrop", False);
+    Atom xa_status = XInternAtom(src, "XdndStatus", False);
+    Atom xa_finished = XInternAtom(src, "XdndFinished", False);
+    const std::string payload = "file:///tmp/dropped%20sample.wav\r\n";
+
+    XSetSelectionOwner(src, xa_selection, source, CurrentTime);
+    REQUIRE(XGetSelectionOwner(src, xa_selection) == source);
+
+    // XdndEnter: version 5 in the top byte of data.l[1], single inline type.
+    send_client_message(src, child, source, xa_enter,
+                        0, (5L << 24), static_cast<long>(xa_uri_list), 0, 0);
+    // XdndPosition: pointer at root (40,30); packed (x<<16)|y in data.l[2].
+    send_client_message(src, child, source, xa_position,
+                        0, 0, (40L << 16) | 30L, CurrentTime,
+                        static_cast<long>(XInternAtom(src, "XdndActionCopy", False)));
+
+    // Drive the host until it replies XdndStatus (accept) for the position.
+    bool got_status = false;
+    auto pump_both = [&](int rounds) {
+        for (int i = 0; i < rounds; ++i) {
+            host->pump_x_events();
+            while (XPending(src) > 0) {
+                XEvent ev; XNextEvent(src, &ev);
+                if (ev.type == ClientMessage && ev.xclient.message_type == xa_status &&
+                    (ev.xclient.data.l[1] & 1)) {
+                    got_status = true;
+                } else if (ev.type == ClientMessage &&
+                           ev.xclient.message_type == xa_finished) {
+                    // recorded below
+                } else if (ev.type == SelectionRequest) {
+                    // Service the host's XConvertSelection: write the payload to
+                    // the requested property, then notify.
+                    XSelectionRequestEvent& rq = ev.xselectionrequest;
+                    XChangeProperty(src, rq.requestor, rq.property, rq.target, 8,
+                                    PropModeReplace,
+                                    reinterpret_cast<const unsigned char*>(payload.data()),
+                                    static_cast<int>(payload.size()));
+                    XEvent note;
+                    std::memset(&note, 0, sizeof(note));
+                    note.xselection.type = SelectionNotify;
+                    note.xselection.requestor = rq.requestor;
+                    note.xselection.selection = rq.selection;
+                    note.xselection.target = rq.target;
+                    note.xselection.property = rq.property;
+                    note.xselection.time = rq.time;
+                    XSendEvent(src, rq.requestor, False, NoEventMask, &note);
+                    XFlush(src);
+                }
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+    };
+    pump_both(40);
+    CHECK(got_status);
+
+    // XdndDrop: triggers the host's XConvertSelection. data.l[2] is the time.
+    bool got_finished = false;
+    send_client_message(src, child, source, xa_drop, 0, 0, CurrentTime, 0, 0);
+    for (int i = 0; i < 60 && zone->drops == 0; ++i) {
+        host->pump_x_events();
+        while (XPending(src) > 0) {
+            XEvent ev; XNextEvent(src, &ev);
+            if (ev.type == SelectionRequest) {
+                XSelectionRequestEvent& rq = ev.xselectionrequest;
+                XChangeProperty(src, rq.requestor, rq.property, rq.target, 8,
+                                PropModeReplace,
+                                reinterpret_cast<const unsigned char*>(payload.data()),
+                                static_cast<int>(payload.size()));
+                XEvent note;
+                std::memset(&note, 0, sizeof(note));
+                note.xselection.type = SelectionNotify;
+                note.xselection.requestor = rq.requestor;
+                note.xselection.selection = rq.selection;
+                note.xselection.target = rq.target;
+                note.xselection.property = rq.property;
+                note.xselection.time = rq.time;
+                XSendEvent(src, rq.requestor, False, NoEventMask, &note);
+                XFlush(src);
+            } else if (ev.type == ClientMessage &&
+                       ev.xclient.message_type == xa_finished) {
+                got_finished = true;
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    // Drain any trailing XdndFinished.
+    for (int i = 0; i < 20 && !got_finished; ++i) {
+        host->pump_x_events();
+        while (XPending(src) > 0) {
+            XEvent ev; XNextEvent(src, &ev);
+            if (ev.type == ClientMessage && ev.xclient.message_type == xa_finished)
+                got_finished = true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+
+    REQUIRE(zone->drops == 1);
+    REQUIRE(zone->last.type == pulp::view::DropData::Type::files);
+    REQUIRE(zone->last.file_paths.size() == 1);
+    CHECK(zone->last.file_paths[0] == "/tmp/dropped sample.wav");
+    CHECK(got_finished);
+
+    XDestroyWindow(src, source);
+    XCloseDisplay(src);
+}
+
+#endif  // PULP_TEST_HAS_X11
+

--- a/test/test_plugin_view_host_factory.cpp
+++ b/test/test_plugin_view_host_factory.cpp
@@ -120,11 +120,18 @@ TEST_CASE("X11 plugin host runs the XDND target handshake into dispatch_drop",
     }
 
     // Build the host with a recording drop zone covering the whole surface.
+    // The host re-runs a Yoga layout pass on every paint (attach_to_parent ->
+    // repaint -> paint_scene -> layout_children), so a manually-set bounds on a
+    // child does NOT survive — a default flex child with no sizing collapses to
+    // zero on the main axis. Give the zone flex_grow:1 so Yoga sizes it to fill
+    // the root's 200x150; otherwise the drop point hit-tests the (zero-height)
+    // zone, misses it, and dispatch_drop never reaches the receiver.
     pulp::view::View root;
     root.set_bounds({0, 0, 200, 150});
     auto zone_owned = std::make_unique<RecordingDropZone>();
     RecordingDropZone* zone = zone_owned.get();
     zone->set_bounds({0, 0, 200, 150});
+    zone->flex().flex_grow = 1.0f;  // fill the root's column main axis after layout
     root.add_child(std::move(zone_owned));
 
     pulp::view::register_platform_plugin_view_host();


### PR DESCRIPTION
The last drag-drop producer — previously (wrongly) thought blocked. X11PluginViewHost owns its own Display, so it CAN run an X event pump; this adds XDND target support routing into the existing dispatch core (#3638).

## What
- XDND target on the plugin-host child window: advertises `XdndAware` v5, interns the XDND atoms, adds an event pump (`pump_x_events()`, driven from `repaint()`) that runs the full protocol — XdndEnter (offered types) → XdndPosition (→ `dispatch_drag_move` + XdndStatus reply) → XdndDrop (`XConvertSelection` → SelectionNotify → parse `text/uri-list`/UTF8 → `dispatch_drop` → XdndFinished).
- Pure parse/coord helpers in `xdnd_parse.hpp` (file:// decode, uri-list split, root→child-local).

## Verification
- **VM-verified on real Linux+X11 under xvfb: full synthetic-source handshake, 18/18 assertions** — Enter/Position/Status/Drop, the `text/uri-list` selection transfer, `dispatch_drop` receiving `/tmp/dropped sample.wav`, and XdndFinished. Pure helpers also 84/84 on macOS.
- Note: the host is GPU+X11-gated and the GH Linux lane builds GPU-OFF, so this code is verified by the **VM run** (the established path for the Linux GPU host), not a CI lane.

Closes #3645 (the last DnD producer; drag-drop now complete on every platform: SDL standalone, macOS native, Windows IDropTarget, Linux XDND). The flex_grow fix is a test-only correction (the host code was correct; the test's drop zone collapsed under the host's Yoga relayout). Part of #3329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Linux XDND drag-and-drop to the plugin-host X11 child window, routing file and text drops into the existing dispatch core. This completes drag-and-drop support across platforms and includes a small test-only layout fix.

- **New Features**
  - Linux: XDND target on the X11 child window with `XdndAware` v5 and an event pump via a new virtual `pump_x_events()` (driven from `repaint()`).
  - Full XDND flow (Enter → Position → Drop): selects best target, converts `XdndSelection`, parses `text/uri-list` and UTF-8 text, maps root coords to view, calls `dispatch_drag_move`/`dispatch_drop`, replies with XdndStatus/XdndFinished.
  - New pure helpers in `core/view/platform/linux/xdnd_parse.hpp` for URI decoding and coordinate mapping, with unit tests; adds an X11-gated synthetic XDND source test under xvfb. Updated X input mask to include PropertyChangeMask. Version bumped to 0.393.0.

- **Migration**
  - If embedding the Linux host in a DAW/editor loop, call `pump_x_events()` periodically to service drags onto the embedded editor.

<sup>Written for commit c2eadce1ce264eecef22313438de105eaa8b7260. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

