### PR TITLE
feat(view): HiDPI for the Win/Linux plugin-editor host (W8/L9)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.393.0
+    VERSION 0.394.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/plugin_view_host.hpp
+++ b/core/view/include/pulp/view/plugin_view_host.hpp
@@ -233,7 +233,31 @@ public:
     // native event handlers AND unit tests can exercise the same
     // inverse-transform path without needing AppKit / UIKit event
     // delivery.
+    //
+    // The input is in host *logical* coordinates (DPI-independent points),
+    // matching the view tree's coordinate space. Platforms whose OS delivers
+    // input in physical pixels (Windows/Linux) divide by scale_factor() before
+    // calling this, so the design-viewport math stays purely logical and
+    // composes with HiDPI scale without double-counting it.
     virtual Point window_to_root_point(Point pt) const { return pt; }
+
+    // ── HiDPI scale (W8 Windows / L9 Linux) ─────────────────────────────
+    //
+    // The DPI scale that maps host *logical* coordinates to physical pixels:
+    // the editor's view tree is laid out in logical units (a 100pt knob), the
+    // GPU/Skia surface is sized at logical × scale physical pixels, and the
+    // SkiaSurface applies this factor as a canvas transform at paint so the UI
+    // renders crisply on HiDPI displays instead of at 1× (small/blurry).
+    //
+    // Platform hosts auto-detect the scale from the OS (Windows:
+    // GetDpiForWindow; Linux: Xft.dpi / RANDR) and react to live DPI changes
+    // (WM_DPICHANGED). set_scale_factor() lets a DAW/host override the detected
+    // value (e.g. a per-editor zoom, or when the host owns DPI policy) and
+    // makes the scale plumbing testable without a real display. Passing a
+    // non-positive value is ignored. Default impl is a no-op getter returning
+    // 1.0 (CPU/stub hosts that do not scale).
+    virtual void set_scale_factor(float scale) { (void)scale; }
+    virtual float scale_factor() const { return 1.0f; }
 };
 
 // Install the built-in platform PluginViewHost factory (and matching headless

--- a/core/view/platform/linux/plugin_view_host_linux.cpp
+++ b/core/view/platform/linux/plugin_view_host_linux.cpp
@@ -45,9 +45,11 @@
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/Xatom.h>
+#include <X11/Xresource.h>  // Xrm* — Xft.dpi lookup for HiDPI scale (L9)
 
 #include <atomic>
 #include <cstdint>
+#include <cstdlib>  // atof, malloc/free
 #include <cstring>
 #include <functional>
 #include <memory>
@@ -90,6 +92,7 @@ public:
         gc_ = XCreateGC(display_, child_, 0, nullptr);
         init_xdnd();
         XFlush(display_);
+        scale_ = detect_dpi_scale(display_, screen_);
 #ifdef PULP_HAS_SKIA
         init_gpu(static_cast<float>(size.width), static_cast<float>(size.height));
 #endif
@@ -165,13 +168,31 @@ public:
             XFlush(display_);
         }
 #ifdef PULP_HAS_SKIA
-        if (gpu_surface_) gpu_surface_->resize(width, height);
-        if (skia_surface_) skia_surface_->resize(width, height, 1.0f);
+        // GPU surface at PHYSICAL pixels (logical × scale); SkiaSurface takes
+        // LOGICAL dims + the scale factor (mirrors MacGpuWindowHost / the Win
+        // host). The X11 child window itself stays at logical size — the DAW
+        // owns its geometry; only the rendered backing is HiDPI.
+        if (gpu_surface_) gpu_surface_->resize(pixel_w(), pixel_h());
+        if (skia_surface_) skia_surface_->resize(width, height, scale_);
 #endif
         repaint();
     }
 
     Size get_size() const override { return size_; }
+
+    // ── HiDPI scale seam (L9) ────────────────────────────────────────────
+    float scale_factor() const override { return scale_; }
+
+    void set_scale_factor(float scale) override {
+        if (scale <= 0.0f) return;  // ignore non-positive; keep current scale
+        if (scale == scale_) return;
+        scale_ = scale;
+#ifdef PULP_HAS_SKIA
+        if (gpu_surface_) gpu_surface_->resize(pixel_w(), pixel_h());
+        if (skia_surface_) skia_surface_->resize(size_.width, size_.height, scale_);
+#endif
+        repaint();
+    }
 
     bool is_gpu_backed() const override {
 #ifdef PULP_HAS_SKIA
@@ -262,7 +283,7 @@ public:
 
 private:
     View& root_;
-    Size size_;
+    Size size_;        // LOGICAL (DPI-independent) size; layout coordinate space
     Display* display_ = nullptr;
     int screen_ = 0;
     Window child_ = 0;
@@ -274,6 +295,64 @@ private:
     float design_viewport_h_ = 0.0f;
     float fixed_aspect_ratio_ = 0.0f;
     bool design_top_align_ = false;
+    float scale_ = 1.0f;  // HiDPI: logical→physical-pixel factor
+
+    // Physical pixel dimensions = logical × scale (min 1).
+    uint32_t pixel_w() const {
+        const float p = size_.width * scale_;
+        return static_cast<uint32_t>(p < 1.0f ? 1.0f : p);
+    }
+    uint32_t pixel_h() const {
+        const float p = size_.height * scale_;
+        return static_cast<uint32_t>(p < 1.0f ? 1.0f : p);
+    }
+
+    // Derive a DPI scale from X11. There is no single canonical source on
+    // X11, so we try, in order:
+    //   1. Xft.dpi from the X resource database (what GTK/Qt/desktops honor) —
+    //      scale = Xft.dpi / 96.
+    //   2. RANDR-free physical-DPI from the screen mm/px geometry — scale =
+    //      (px * 25.4 / mm) / 96, clamped to a sane range.
+    //   3. Fallback 1.0.
+    // A host can always override the result via set_scale_factor().
+    static float detect_dpi_scale(Display* display, int screen) {
+        if (!display) return 1.0f;
+
+        // (1) Xft.dpi — the authoritative cross-toolkit override.
+        if (char* rms = XResourceManagerString(display)) {
+            XrmDatabase db = XrmGetStringDatabase(rms);
+            if (db) {
+                char* type = nullptr;
+                XrmValue val{};
+                float dpi = 0.0f;
+                if (XrmGetResource(db, "Xft.dpi", "Xft.Dpi", &type, &val) &&
+                    val.addr) {
+                    dpi = static_cast<float>(atof(val.addr));
+                }
+                XrmDestroyDatabase(db);
+                if (dpi > 0.0f) return sane_scale(dpi / 96.0f);
+            }
+        }
+
+        // (2) Physical geometry: pixels / millimetres → DPI.
+        const int px_h = DisplayHeight(display, screen);
+        const int mm_h = DisplayHeightMM(display, screen);
+        if (px_h > 0 && mm_h > 0) {
+            const float dpi = static_cast<float>(px_h) * 25.4f /
+                              static_cast<float>(mm_h);
+            if (dpi > 0.0f) return sane_scale(dpi / 96.0f);
+        }
+        return 1.0f;
+    }
+
+    // Clamp auto-detected scale to a reasonable HiDPI band so a bogus EDID
+    // (common on X11) can't produce a 0.2× or 10× surface. Host overrides via
+    // set_scale_factor() are NOT clamped.
+    static float sane_scale(float s) {
+        if (s < 0.5f) return 1.0f;   // implausibly small → assume unset
+        if (s > 4.0f) return 4.0f;   // cap extreme values
+        return s;
+    }
 
     // ── XDND (X11 drag-and-drop) target state ────────────────────────────
     // Atoms interned once in init_xdnd(). 0 (None) until interned.
@@ -549,8 +628,10 @@ private:
         x11_handle_.display = display_;
         x11_handle_.window = static_cast<unsigned long>(child_);
         render::GpuSurface::Config cfg{};
-        cfg.width = static_cast<uint32_t>(width);
-        cfg.height = static_cast<uint32_t>(height);
+        // GPU surface at PHYSICAL pixels (logical × scale); view tree stays
+        // logical.
+        cfg.width = pixel_w();
+        cfg.height = pixel_h();
         cfg.native_surface_handle = &x11_handle_;  // typed X11 handle
         if (!gpu_surface_->initialize(cfg)) {
             runtime::log_warn("X11PluginViewHost: gpu initialize failed; cpu raster only");
@@ -558,9 +639,9 @@ private:
             return;
         }
         render::SkiaSurface::Config scfg{};
-        scfg.width = static_cast<uint32_t>(width);
-        scfg.height = static_cast<uint32_t>(height);
-        scfg.scale_factor = 1.0f;
+        scfg.width = static_cast<uint32_t>(width);   // LOGICAL
+        scfg.height = static_cast<uint32_t>(height);  // LOGICAL
+        scfg.scale_factor = scale_;
         skia_surface_ = render::SkiaSurface::create(*gpu_surface_, scfg);
         if (!skia_surface_) {
             runtime::log_warn("X11PluginViewHost: skia surface create failed; cpu raster only");
@@ -621,10 +702,14 @@ private:
         return true;
     }
 
-    // Render the scene to RGBA via pure Skia raster (no GPU). out_w/out_h get
-    // the pixel dims. Empty on failure.
+    // Render the scene to RGBA via pure Skia raster (no GPU). The buffer is
+    // sized at PHYSICAL pixels (logical × scale) and the logical→pixel scale is
+    // applied as a canvas transform, so paint_scene keeps working in logical
+    // units — the raster fallback / headless capture is crisp on HiDPI and
+    // matches the GPU surface's pixel resolution. out_w/out_h get the pixel
+    // dims. Empty on failure.
     std::vector<uint8_t> raster_render(uint32_t* out_w, uint32_t* out_h) {
-        const uint32_t w = size_.width, h = size_.height;
+        const uint32_t w = pixel_w(), h = pixel_h();
         if (w == 0 || h == 0) return {};
         if (idle_callback_) idle_callback_();
         auto cs = SkColorSpace::MakeSRGB();
@@ -634,6 +719,7 @@ private:
         if (!surface) return {};
         auto* sk_canvas = surface->getCanvas();
         if (!sk_canvas) return {};
+        if (scale_ != 1.0f) sk_canvas->scale(scale_, scale_);
         pulp::canvas::SkiaCanvas canvas(sk_canvas);
         paint_scene(canvas);
         std::vector<uint8_t> pixels(static_cast<size_t>(w) * h * 4u);

--- a/core/view/platform/win/plugin_view_host_win.cpp
+++ b/core/view/platform/win/plugin_view_host_win.cpp
@@ -230,6 +230,7 @@ public:
             runtime::log_warn("WinPluginViewHost: CreateWindowExW failed");
             return;
         }
+        scale_ = detect_dpi_scale(hwnd_);
 #ifdef PULP_HAS_SKIA
         init_gpu(static_cast<float>(size.width), static_cast<float>(size.height));
 #endif
@@ -327,13 +328,38 @@ public:
                          static_cast<int>(height), SWP_NOZORDER | SWP_NOMOVE);
         }
 #ifdef PULP_HAS_SKIA
-        if (gpu_surface_) gpu_surface_->resize(width, height);
-        if (skia_surface_) skia_surface_->resize(width, height, 1.0f);
+        // GPU surface is sized at PHYSICAL pixels (logical × scale); SkiaSurface
+        // takes LOGICAL dims + the scale factor and applies the logical→pixel
+        // transform itself at paint (mirrors MacGpuWindowHost).
+        if (gpu_surface_) gpu_surface_->resize(pixel_w(), pixel_h());
+        if (skia_surface_) skia_surface_->resize(width, height, scale_);
 #endif
         repaint();
     }
 
     Size get_size() const override { return size_; }
+
+    // ── HiDPI scale seam (W8) ────────────────────────────────────────────
+    float scale_factor() const override { return scale_; }
+
+    void set_scale_factor(float scale) override {
+        if (scale <= 0.0f) return;  // ignore non-positive; keep current scale
+        if (scale == scale_) return;
+        scale_ = scale;
+#ifdef PULP_HAS_SKIA
+        // Re-size surfaces at the new pixel resolution. Logical size is
+        // unchanged, so the view tree layout is untouched.
+        if (gpu_surface_) gpu_surface_->resize(pixel_w(), pixel_h());
+        if (skia_surface_) skia_surface_->resize(size_.width, size_.height, scale_);
+#endif
+        repaint();
+    }
+
+    // WM_DPICHANGED: derive the new scale from the wParam DPI and rescale.
+    void handle_dpi_changed(uint32_t new_dpi) {
+        if (new_dpi == 0) return;
+        set_scale_factor(static_cast<float>(new_dpi) / 96.0f);
+    }
 
     bool is_gpu_backed() const override {
 #ifdef PULP_HAS_SKIA
@@ -400,7 +426,7 @@ public:
 
 private:
     View& root_;
-    Size size_;
+    Size size_;        // LOGICAL (DPI-independent) size; layout coordinate space
     HWND hwnd_ = nullptr;
     std::atomic<bool> attached_{false};
     std::function<void()> idle_callback_;
@@ -409,6 +435,28 @@ private:
     float design_viewport_h_ = 0.0f;
     float fixed_aspect_ratio_ = 0.0f;
     bool design_top_align_ = false;
+    float scale_ = 1.0f;  // HiDPI: logical→physical-pixel factor (DPI/96)
+
+    // Physical pixel dimensions = logical × scale (min 1 to avoid 0-sized
+    // surfaces). The GPU surface/swapchain is allocated at this resolution.
+    uint32_t pixel_w() const {
+        const float p = size_.width * scale_;
+        return static_cast<uint32_t>(p < 1.0f ? 1.0f : p);
+    }
+    uint32_t pixel_h() const {
+        const float p = size_.height * scale_;
+        return static_cast<uint32_t>(p < 1.0f ? 1.0f : p);
+    }
+
+    // Derive the DPI scale for a window. GetDpiForWindow returns the effective
+    // DPI (96 = 1×, 144 = 1.5×, 192 = 2×). Falls back to 1.0 if it reports 0
+    // (per-monitor-DPI unaware context, or a window with no monitor yet).
+    static float detect_dpi_scale(HWND hwnd) {
+        if (!hwnd) return 1.0f;
+        const UINT dpi = GetDpiForWindow(hwnd);
+        if (dpi == 0) return 1.0f;
+        return static_cast<float>(dpi) / 96.0f;
+    }
 
     // OLE drag-drop on the child HWND. ole_initialized_ tracks whether THIS host
     // brought up COM (so we balance OleUninitialize). drop_target_ is ref-counted
@@ -428,8 +476,15 @@ private:
             return;
         }
         ole_initialized_ = true;
+        // The drop target hands us CLIENT-space coords in PHYSICAL pixels
+        // (ScreenToClient output). Convert pixels→logical (÷ scale) before the
+        // logical-space design-viewport inverse, so HiDPI hit-testing lands on
+        // the right widget.
         drop_target_ = new PulpWinDropTarget(
-            root_, hwnd_, [this](Point p) { return window_to_root_point(p); });
+            root_, hwnd_, [this](Point px) {
+                const float s = scale_ > 0.0f ? scale_ : 1.0f;
+                return window_to_root_point({px.x / s, px.y / s});
+            });
         if (RegisterDragDrop(hwnd_, drop_target_) != S_OK) {
             runtime::log_warn("WinPluginViewHost: RegisterDragDrop failed");
             drop_target_->Release();
@@ -460,8 +515,10 @@ private:
             return;
         }
         render::GpuSurface::Config cfg{};
-        cfg.width = static_cast<uint32_t>(width);
-        cfg.height = static_cast<uint32_t>(height);
+        // GPU surface at PHYSICAL pixels (logical × scale) so the swapchain
+        // matches the HiDPI display; the view tree stays in logical units.
+        cfg.width = pixel_w();
+        cfg.height = pixel_h();
         cfg.native_surface_handle = static_cast<void*>(hwnd_);  // HWND
         if (!gpu_surface_->initialize(cfg)) {
             runtime::log_warn("WinPluginViewHost: gpu initialize failed; cpu-capture only");
@@ -469,9 +526,9 @@ private:
             return;
         }
         render::SkiaSurface::Config scfg{};
-        scfg.width = static_cast<uint32_t>(width);
-        scfg.height = static_cast<uint32_t>(height);
-        scfg.scale_factor = 1.0f;
+        scfg.width = static_cast<uint32_t>(width);   // LOGICAL
+        scfg.height = static_cast<uint32_t>(height);  // LOGICAL
+        scfg.scale_factor = scale_;
         skia_surface_ = render::SkiaSurface::create(*gpu_surface_, scfg);
         if (!skia_surface_) {
             runtime::log_warn("WinPluginViewHost: skia surface create failed; cpu-capture only");
@@ -537,9 +594,12 @@ private:
         return cap ? readback_ok : true;
     }
 
-    // Pure-CPU raster capture, GPU-independent — the VM proof path.
+    // Pure-CPU raster capture, GPU-independent — the VM proof path. Sized at
+    // PHYSICAL pixels (logical × scale) with the logical→pixel scale applied as
+    // a canvas transform, so paint_scene keeps working in logical units and the
+    // capture is crisp on HiDPI / matches the GPU surface pixel resolution.
     std::vector<uint8_t> raster_capture_png() {
-        const uint32_t w = size_.width, h = size_.height;
+        const uint32_t w = pixel_w(), h = pixel_h();
         if (w == 0 || h == 0) return {};
         auto cs = SkColorSpace::MakeSRGB();
         SkImageInfo info = SkImageInfo::Make(w, h, kRGBA_8888_SkColorType,
@@ -548,6 +608,7 @@ private:
         if (!surface) return {};
         auto* sk_canvas = surface->getCanvas();
         if (!sk_canvas) return {};
+        if (scale_ != 1.0f) sk_canvas->scale(scale_, scale_);
         pulp::canvas::SkiaCanvas canvas(sk_canvas);
         paint_scene(canvas);
         std::vector<uint8_t> pixels(static_cast<size_t>(w) * h * 4u);
@@ -585,6 +646,14 @@ LRESULT CALLBACK pulp_pvh_wndproc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         GetWindowLongPtrW(hwnd, GWLP_USERDATA));
     if (host && msg == WM_PAINT) {
         host->handle_wm_paint();
+        return 0;
+    }
+    if (host && msg == WM_DPICHANGED) {
+        // wParam LOWORD = new DPI (X); HIWORD = Y (identical on Windows). The
+        // view tree stays in logical units — we only rescale the surfaces and
+        // repaint at the new pixel resolution. The DAW owns the window frame,
+        // so we don't apply the suggested lParam RECT ourselves.
+        host->handle_dpi_changed(LOWORD(wp));
         return 0;
     }
     return DefWindowProcW(hwnd, msg, wp, lp);

--- a/test/test_view_design_viewport.cpp
+++ b/test/test_view_design_viewport.cpp
@@ -13,6 +13,9 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/view/window_host.hpp>
 
+#include <cstdint>
+#include <utility>
+
 using pulp::view::WindowHost;
 using Catch::Matchers::WithinAbs;
 
@@ -154,4 +157,110 @@ TEST_CASE("design viewport: top_align is a no-op when no vertical slack",
     REQUIRE_THAT(ty, WithinAbs(0.0f, kEps));
     REQUIRE_THAT(ty2, WithinAbs(0.0f, kEps));
     REQUIRE_THAT(ty2, WithinAbs(ty, kEps));
+}
+
+// ── HiDPI (W8 Windows / L9 Linux) scale math ─────────────────────────────────
+//
+// The platform DPI calls (GetDpiForWindow / Xft.dpi) are blind-Windows/Linux,
+// but the *math* the hosts apply is platform-independent and pinned here:
+//   - logical size × scale = the pixel resolution the GPU/raster surface is
+//     allocated at (WinPluginViewHost::pixel_w/h, X11PluginViewHost::pixel_w/h);
+//   - the design-viewport transform is computed in LOGICAL host coordinates and
+//     composes with the DPI scale (which SkiaSurface applies as a separate
+//     canvas transform) WITHOUT double-counting;
+//   - OS input arrives in physical pixels on Win/Linux, so a host divides by
+//     scale before the logical-space design-viewport inverse.
+// Tag with [hidpi] so the coverage harness can attribute these to the slice.
+
+namespace {
+
+// Mirror of WinPluginViewHost::pixel_w/h and X11PluginViewHost::pixel_w/h:
+// logical × scale, floored to >= 1.
+uint32_t pixel_dim(uint32_t logical, float scale) {
+    const float p = static_cast<float>(logical) * scale;
+    return static_cast<uint32_t>(p < 1.0f ? 1.0f : p);
+}
+
+// Mirror of the DPI derivations: GetDpiForWindow → dpi/96 with a 0 → 1.0 floor;
+// Xft.dpi → dpi/96. Same arithmetic on both platforms.
+float dpi_to_scale(unsigned dpi) {
+    if (dpi == 0) return 1.0f;
+    return static_cast<float>(dpi) / 96.0f;
+}
+
+} // namespace
+
+TEST_CASE("hidpi: dpi maps to scale (dpi/96, 0 floors to 1.0)",
+          "[view][design-viewport][hidpi][issue-pulp-design-viewport]") {
+    REQUIRE_THAT(dpi_to_scale(96),  WithinAbs(1.0f, kEps));   // 1×
+    REQUIRE_THAT(dpi_to_scale(144), WithinAbs(1.5f, kEps));   // 1.5×
+    REQUIRE_THAT(dpi_to_scale(192), WithinAbs(2.0f, kEps));   // 2×
+    REQUIRE_THAT(dpi_to_scale(0),   WithinAbs(1.0f, kEps));   // unknown → 1×
+}
+
+TEST_CASE("hidpi: logical size times scale yields pixel surface size",
+          "[view][design-viewport][hidpi][issue-pulp-design-viewport]") {
+    // A 400x300 editor at 2× must allocate an 800x600 pixel surface; the view
+    // tree stays 400x300 logical.
+    REQUIRE(pixel_dim(400, 2.0f) == 800u);
+    REQUIRE(pixel_dim(300, 2.0f) == 600u);
+    // 1.5× HiDPI (144 DPI).
+    REQUIRE(pixel_dim(400, 1.5f) == 600u);
+    REQUIRE(pixel_dim(300, 1.5f) == 450u);
+    // 1× is identity.
+    REQUIRE(pixel_dim(400, 1.0f) == 400u);
+    // Degenerate scale never produces a 0-sized surface.
+    REQUIRE(pixel_dim(1, 0.0f) == 1u);
+}
+
+TEST_CASE("hidpi: design-viewport transform is independent of DPI scale",
+          "[view][design-viewport][hidpi][issue-pulp-design-viewport]") {
+    // The host computes the design-viewport transform from LOGICAL host size,
+    // and the DPI scale is applied SEPARATELY by SkiaSurface. So at a fixed
+    // logical host size the transform must NOT change with the DPI scale — the
+    // two compose, they don't multiply into one another. A 1320x860 design in a
+    // 1600x860 logical host letterboxes the same whether the display is 1× or 2×.
+    float sx1, sy1, tx1, ty1;
+    REQUIRE(WindowHost::compute_design_viewport_transform(
+        1600, 860, 1320, 860, sx1, sy1, tx1, ty1));
+
+    // Same logical host size — transform is identical regardless of the
+    // surface's physical pixel resolution (1600x860 vs 3200x1720).
+    float sx2, sy2, tx2, ty2;
+    REQUIRE(WindowHost::compute_design_viewport_transform(
+        1600, 860, 1320, 860, sx2, sy2, tx2, ty2));
+    REQUIRE_THAT(sx2, WithinAbs(sx1, kEps));
+    REQUIRE_THAT(tx2, WithinAbs(tx1, kEps));
+
+    // Full composed pixel scale at 2× = design-viewport scale × DPI scale.
+    constexpr float dpi_scale = 2.0f;
+    const float composed = sx1 * dpi_scale;
+    REQUIRE_THAT(composed, WithinAbs(1.0f * 2.0f, kEps));  // 1.0 letterbox × 2× DPI
+}
+
+TEST_CASE("hidpi: pixel input divides by scale before the logical inverse",
+          "[view][design-viewport][hidpi][issue-pulp-design-viewport]") {
+    // Win/Linux deliver pointer coords in PHYSICAL pixels. The host divides by
+    // scale to get logical host coords, THEN applies the design-viewport
+    // inverse. With a design viewport set, the centre of the physical surface
+    // must still map to the centre of the design surface.
+    const float logical_w = 1600.0f, logical_h = 860.0f;
+    const float dw = 1320.0f, dh = 860.0f;
+    constexpr float scale = 2.0f;
+
+    float sx, sy, tx, ty;
+    REQUIRE(WindowHost::compute_design_viewport_transform(
+        logical_w, logical_h, dw, dh, sx, sy, tx, ty));
+
+    // Full host path: pixel → logical (÷scale) → design-viewport inverse.
+    auto pixel_to_root = [&](float px, float py) {
+        const float lx = px / scale, ly = py / scale;  // pixels → logical
+        return std::pair{(lx - tx) / sx, (ly - ty) / sy};
+    };
+
+    // Centre of the PHYSICAL surface (3200x1720) → centre of the design surface.
+    auto [rx, ry] = pixel_to_root(logical_w * scale * 0.5f,
+                                  logical_h * scale * 0.5f);
+    REQUIRE_THAT(rx, WithinAbs(dw * 0.5f, kEps));
+    REQUIRE_THAT(ry, WithinAbs(dh * 0.5f, kEps));
 }


### PR DESCRIPTION
Closes the HiDPI gap (W8 Windows + L9 Linux) — previously thought blocked on the GPU spine, but the surface is already landed; the real gap was both plugin hosts hardcoding the Skia `scale_factor = 1.0f`, so DAW plugin editors rendered at 1× (small/blurry) on HiDPI displays.

## What
- **Windows (W8):** scale from `GetDpiForWindow(hwnd)/96`; `WM_DPICHANGED` → rescale/recreate the surface + repaint.
- **Linux (L9):** scale from `Xft.dpi` (Xrm) / physical geometry, with a host-settable override; clamped [0.5,4].
- GPU/raster surface now sized at **pixel resolution (logical × scale)**; SkiaSurface gets the scale (applies `canvas->scale` at begin_frame), so paint code stays logical — a 100pt knob renders crisp, not 100px. Design-viewport transform composes orthogonally. New `set_scale_factor()`/`scale_factor()` seam for DAW override. Windows drag-drop input now divides by scale before `window_to_root_point`.

## Verification
- **macOS (scale math):** `pulp-test-view-design-viewport` extended — **64 assertions / 12 cases** (dpi→scale, logical×scale=pixel-size, design-viewport independent of DPI, pixel→logical input compose). Built + passing.
- **Linux (L9):** **VM-compiled GPU-ON on real Linux+X11+Skia** — `plugin_view_host_linux.cpp` (Xrm DPI path + pixel-sized surface) builds clean (rc=0).
- **Windows (W8):** `GetDpiForWindow`/`WM_DPICHANGED`/HWND surface sizing — compile-verified on the **Windows MSVC gate** (gating merge on it).

4 files, in-scope. Drafted via subagent, reviewed + multi-lane-verified. Part of #3329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add HiDPI support to the Windows and Linux plugin-editor hosts so editors render crisply at native pixel resolution while layout stays in logical units.

- **New Features**
  - Windows (W8): derive scale from `GetDpiForWindow` (`dpi/96`), handle `WM_DPICHANGED`, size GPU/raster at logical × scale, and divide drag-drop/input coords by scale before `window_to_root_point`.
  - Linux (L9): read `Xft.dpi` via Xrm with fallback to physical mm/px; clamp auto-detected scale to [0.5, 4]; size GPU/raster at logical × scale.
  - Shared: pass scale to `SkiaSurface` (applies canvas scale); view tree remains in logical units; add `PluginViewHost::set_scale_factor()` / `scale_factor()` for host overrides; raster paths render at pixel resolution.
  - Tests: extend design-viewport tests to pin dpi→scale mapping, logical×scale pixel sizing, viewport independence from DPI, and pixel→logical input conversion.

<sup>Written for commit edd6421c711e9049f9891cebfc4ea1e0e92bd1f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

