### PR TITLE
fix(midi,view): address Codex P2 review on UMP system messages + Linux XDND HiDPI

### DIFF
--- a/.agents/skills/mpe/SKILL.md
+++ b/.agents/skills/mpe/SKILL.md
@@ -227,6 +227,28 @@ API so it stays RT-safe in the audio render block; the
 `feed_collect` convenience wrapper allocates and is meant for
 tests / cold paths only.
 
+**Reassembly state is per-stream → per-UMP-group, not per-port.** UMP
+SysEx7 streams from one endpoint can interleave across the 16 UMP
+groups, so a backend that owns a *single* `UmpSysex7Reassembler` per
+port will let a Start on group 1 reset/corrupt an in-flight stream on
+group 0. Keep one reassembler per group (`std::array<…,16>` indexed by
+`packet.group()`) — the WinRT MIDI 2.0 backend does this; mirror it in
+any new UMP backend.
+
+### UMP ↔ MIDI 1.0 conversion covers System messages (Type 0x1)
+
+`ump_to_midi1_event` / `midi1_event_to_ump2` in
+`core/midi/include/pulp/midi/ump_conversion.hpp` handle **System Real
+Time and System Common** (UMP Type 0x1: clock `0xF8`, start/stop,
+song-position `0xF2`, …) in addition to channel voice — system
+messages encode as Type 0x1 (NOT Type 0x2 MIDI 1.0 Channel Voice,
+which is malformed for them) and decode back to MIDI 1.0 short
+messages. So `ump_to_midi1` flattening a UMP buffer now yields
+clock/transport events, not channel-voice-only — don't assume a
+flattened buffer is note data. (SysEx Type 0x3 still routes through
+`UmpSysex7Reassembler`, above; per-note expression still goes through
+the MpeBuffer sidecar, not these converters.)
+
 ### UMP Session / Endpoint / VirtualEndpoint (post macOS-plan 8.1)
 
 Pulp now exposes a Pulp-native UMP transport surface in

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.202.0",
+      "version": "0.202.1",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.202.0"
+  "version": "0.202.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.202.0",
+  "version": "0.202.1",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.394.0
+    VERSION 0.395.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/midi/include/pulp/midi/ump_conversion.hpp
+++ b/core/midi/include/pulp/midi/ump_conversion.hpp
@@ -94,12 +94,20 @@ inline UmpPacket midi1_event_to_ump2(const MidiEvent& ev, uint8_t group = 0) {
         default:
             break;
     }
-    // Fall back to a MIDI 1.0 UMP (type 0x2) carrying the raw bytes.
+    // Fall back to a "raw bytes" UMP carrying the original status + data.
+    // System messages (status >= 0xF0: real-time clock/start/stop/active-
+    // sensing and system-common like MTC / song-position) are UMP Type 0x1
+    // (System Real Time and System Common). Everything else that reaches
+    // here (program change, channel pressure, …) is a MIDI 1.0 Channel
+    // Voice message and stays Type 0x2. Encoding system messages as Type
+    // 0x2 produced malformed UMP that transport/clock-sync consumers reject.
+    const uint8_t status_byte = ev.data()[0];
+    const uint32_t mt = (status_byte >= 0xF0) ? 0x1u : 0x2u;
     UmpPacket p;
     p.word_count = 1;
-    p.words[0] = (0x2u << 28)
+    p.words[0] = (mt << 28)
                | (uint32_t(group & 0x0F) << 24)
-               | (uint32_t(ev.data()[0]) << 16)
+               | (uint32_t(status_byte) << 16)
                | (uint32_t(ev.size() > 1 ? ev.data()[1] : 0) << 8)
                | uint32_t(ev.size() > 2 ? ev.data()[2] : 0);
     return p;
@@ -125,6 +133,19 @@ inline bool ump_to_midi1_event(const UmpPacket& p, MidiEvent& out) {
     if (mt == UmpMessageType::Midi1ChannelVoice) {
         // Byte 1 is status|channel (already in words[0] bits 16-23),
         // Byte 2 in bits 8-15, byte 3 in bits 0-7.
+        const uint8_t s = static_cast<uint8_t>((p.words[0] >> 16) & 0xFF);
+        const uint8_t d1 = static_cast<uint8_t>((p.words[0] >> 8) & 0xFF);
+        const uint8_t d2 = static_cast<uint8_t>(p.words[0] & 0xFF);
+        out = {choc::midi::ShortMessage(s, d1, d2), 0, 0.0};
+        return true;
+    }
+    if (mt == UmpMessageType::System) {
+        // System Real Time (clock 0xF8, start/continue/stop, active sensing)
+        // and System Common (MTC 0xF1, song position 0xF2, …). The UMP carries
+        // the status byte plus up to two data bytes in the same byte layout as
+        // a MIDI 1.0 Channel Voice UMP; ShortMessage derives the correct
+        // length from the status byte. Dropping these (as the prior
+        // channel-voice-only path did) silently loses clock/transport input.
         const uint8_t s = static_cast<uint8_t>((p.words[0] >> 16) & 0xFF);
         const uint8_t d1 = static_cast<uint8_t>((p.words[0] >> 8) & 0xFF);
         const uint8_t d2 = static_cast<uint8_t>(p.words[0] & 0xFF);

--- a/core/midi/platform/win/winrt_midi_device.cpp
+++ b/core/midi/platform/win/winrt_midi_device.cpp
@@ -220,8 +220,15 @@ private:
             // state machine. It emits the raw payload (no F0/F7 framing);
             // we wrap it to F0..F7 to match the other backends' contract
             // (mmeapi MIM_LONGDATA / ALSA deliver framed SysEx).
+            //
+            // SysEx7 reassembly is per-stream state, and UMP SysEx7 streams
+            // can interleave across the 16 UMP groups. Keep one reassembler
+            // per group so a Start on group 1 cannot reset/corrupt an
+            // in-flight stream on group 0. The completion callback fires
+            // synchronously inside feed_packet, so a single last_sysex_ts_
+            // set immediately before the call stays correct.
             last_sysex_ts_ = ts;
-            sysex_reassembler_.feed_packet(
+            sysex_reassemblers_[packet.group() & 0x0F].feed_packet(
                 packet.words[0], packet.words[1],
                 &WinrtMidiInput::on_sysex_complete, this);
             return;
@@ -272,7 +279,9 @@ private:
     ::winrt::event_token       message_token_{};
     MidiInputCallback          callback_;
     MidiSysexCallback          sysex_callback_;
-    UmpSysex7Reassembler       sysex_reassembler_;
+    // One reassembler per UMP group (0..15) — SysEx7 streams interleave
+    // across groups, so a single shared reassembler would corrupt them.
+    std::array<UmpSysex7Reassembler, 16> sysex_reassemblers_{};
     double                     last_sysex_ts_ = 0.0;
     bool                       is_open_ = false;
     bool                       have_origin_ = false;

--- a/core/view/platform/linux/plugin_view_host_linux.cpp
+++ b/core/view/platform/linux/plugin_view_host_linux.cpp
@@ -431,7 +431,11 @@ private:
         int ox = 0, oy = 0;
         child_root_origin(ox, oy);
         Point local = xdnd::root_to_child_local(root_x, root_y, ox, oy);
-        return window_to_root_point(local);
+        // X11 reports physical pixels; window_to_root_point() expects logical
+        // coordinates, so divide by the HiDPI scale first (mirrors the Win
+        // host's ScreenToClient ÷ scale path). At scale 1.0 this is a no-op.
+        const float s = scale_ > 0.0f ? scale_ : 1.0f;
+        return window_to_root_point({local.x / s, local.y / s});
     }
 
     // Read the source's offered types. XdndEnter packs up to 3 types inline

--- a/test/test_ump_buffer_conversion.cpp
+++ b/test/test_ump_buffer_conversion.cpp
@@ -168,6 +168,46 @@ TEST_CASE("midi1_event_to_ump2 handles note-off aliases and raw fallbacks",
     REQUIRE(out.data()[1] == 12);
 }
 
+TEST_CASE("System real-time and common round-trip as UMP Type 0x1",
+          "[midi][ump][pr3781]") {
+    // Codex #3781 P2: system messages (clock/start/stop, song position) must
+    // encode as UMP Type 0x1 (System), not Type 0x2 (MIDI 1.0 Channel Voice),
+    // and must survive UMP→MIDI1 conversion (the WinRT input path was dropping
+    // them via the channel-voice-only decoder).
+    struct Case { uint8_t status, d1, d2; uint32_t len; };
+    const Case cases[] = {
+        {0xF8, 0, 0, 1},   // Timing Clock (real-time, 1 byte)
+        {0xFA, 0, 0, 1},   // Start
+        {0xFC, 0, 0, 1},   // Stop
+        {0xF2, 0x7F, 0x40, 3},  // Song Position Pointer (common, 3 bytes)
+    };
+    for (const auto& c : cases) {
+        MidiEvent ev{choc::midi::ShortMessage(c.status, c.d1, c.d2), 0, 0.0};
+        REQUIRE(ev.size() == c.len);
+
+        const UmpPacket p = midi1_event_to_ump2(ev, 5);
+        REQUIRE(p.message_type() == UmpMessageType::System);  // NOT Midi1ChannelVoice
+        REQUIRE(p.group() == 5);
+        REQUIRE(p.status() == c.status);
+
+        MidiEvent out{};
+        REQUIRE(ump_to_midi1_event(p, out));        // must NOT be dropped
+        REQUIRE(out.size() == c.len);
+        REQUIRE(out.data()[0] == c.status);
+        if (c.len > 1) REQUIRE(out.data()[1] == c.d1);
+        if (c.len > 2) REQUIRE(out.data()[2] == c.d2);
+    }
+
+    // A raw Type 0x1 input packet (as the WinRT backend receives) decodes too.
+    UmpPacket raw{};
+    raw.word_count = 1;
+    raw.words[0] = (0x1u << 28) | (0x00u << 24) | (uint32_t(0xF8) << 16);
+    MidiEvent clock{};
+    REQUIRE(ump_to_midi1_event(raw, clock));
+    REQUIRE(clock.data()[0] == 0xF8);
+    REQUIRE(clock.size() == 1);
+}
+
 TEST_CASE("midi1_to_ump round-trip via ump_to_midi1", "[midi][ump]") {
     MidiBuffer in;
     in.add(MidiEvent::note_on(1, 60, 100));

--- a/test/test_winrt_midi.cpp
+++ b/test/test_winrt_midi.cpp
@@ -21,6 +21,7 @@
 #include <pulp/midi/ump_conversion.hpp>
 #include <pulp/midi/ump_sysex7_reassembler.hpp>
 
+#include <array>
 #include <cstdint>
 #include <vector>
 
@@ -152,6 +153,39 @@ TEST_CASE("WinRT MIDI: sysex7 reassembly framed to F0..F7 for delivery",
         REQUIRE(framed[1] == 0x10);
         REQUIRE(framed[14] == 0x1D);
     }
+}
+
+TEST_CASE("WinRT MIDI: per-group sysex7 reassembly keeps interleaved streams separate",
+          "[midi][ump][sysex][winrt][pr3781]") {
+    // Codex #3781 P2: SysEx7 reassembly is per-stream state, and UMP SysEx7
+    // streams can interleave across the 16 UMP groups. The backend keeps one
+    // reassembler per group so a Start on group 1 cannot reset/corrupt an
+    // in-flight stream on group 0 — which a single shared reassembler would.
+    std::array<UmpSysex7Reassembler, 16> r{};
+
+    auto w0 = [](uint8_t group, uint8_t status, uint8_t nbytes,
+                 uint8_t b1, uint8_t b2) {
+        return (0x3u << 28) | (uint32_t(group) << 24) | (uint32_t(status) << 20)
+             | (uint32_t(nbytes) << 16) | (uint32_t(b1) << 8) | uint32_t(b2);
+    };
+
+    // Group 0: Start with 2 bytes (stream still open).
+    std::vector<uint8_t> g0;
+    REQUIRE(feed_collect(r[0], w0(0, 0x1, 2, 0xA0, 0xA1), 0u, g0)
+            == UmpSysex7Reassembler::Status::start);
+
+    // Group 1: a full single-packet stream arrives in between.
+    std::vector<uint8_t> g1;
+    REQUIRE(feed_collect(r[1], w0(1, 0x0, 3, 0xB0, 0xB1), (0xB2u << 24), g1)
+            == UmpSysex7Reassembler::Status::single_packet);
+    REQUIRE(g1 == std::vector<uint8_t>{0xB0, 0xB1, 0xB2});
+
+    // Group 0: End with 2 bytes — completes the ORIGINAL stream intact,
+    // unaffected by group 1's intervening packet.
+    std::vector<uint8_t> g0done;
+    REQUIRE(feed_collect(r[0], w0(0, 0x3, 2, 0xA2, 0xA3), 0u, g0done)
+            == UmpSysex7Reassembler::Status::ended);
+    REQUIRE(g0done == std::vector<uint8_t>{0xA0, 0xA1, 0xA2, 0xA3});
 }
 
 TEST_CASE("WinRT MIDI: MIDI 1.0 short message promotes to MIDI 2.0 UMP for send",


### PR DESCRIPTION
Follow-up addressing the four Codex P2 review comments left on merged PRs #3781 (WinRT MIDI 2.0) and #3774 (HiDPI).

## Addressed comments

**#3781 — `ump_to_midi1_event` dropped UMP System input** ([comment](https://github.com/danielraffel/pulp/pull/3781#discussion))
UMP Type 0x1 System packets (clock/start/stop) fell through the channel-voice-only decoder and were silently dropped, violating the `MidiInputCallback` contract. Now decoded back to MIDI 1.0 short messages.

**#3781 — `midi1_event_to_ump2` sent System as Type 0x2**
MIDI real-time (0xF8) / Start/Stop encoded as Type 0x2 MIDI 1.0 Channel Voice UMP (malformed for system). Now encoded as UMP Type 0x1 (System Real Time / Common).

Both fixes live in the shared `ump_conversion.hpp`, so **every** UMP backend benefits, not just WinRT.

**#3781 — single SysEx7 reassembler shared across UMP groups**
UMP SysEx7 streams interleave across the 16 groups; a single reassembler let group 1 corrupt an in-flight group 0 stream. Now one reassembler per group (`std::array<…,16>` indexed by `packet.group()`).

**#3774 — Linux XDND points not converted to logical coordinates**
`window_to_root_point()` expects logical coords, but XDND passed physical X11 pixels → doubled hover/drop coords at scale≠1.0. Now divides by scale first, mirroring the Win `ScreenToClient` path.

## Tests
- System real-time/common round-trip (33 assertions) + raw Type 0x1 decode — `test_ump_buffer_conversion.cpp`
- Per-group SysEx7 interleave isolation (5 assertions) — `test_winrt_midi.cpp`
- Both full suites green locally (185 + 38 assertions).
- Linux X11 host TU (XDND change) compile-verified on the GPU-ON Linux VM (no CI lane compiles the GPU+X11 path).

mpe SKILL.md updated (the `ump_conversion` + per-group reassembly gotchas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes UMP system message handling and Linux XDND HiDPI coordinates. Restores MIDI clock/transport events across all UMP backends and corrects drag/drop positions on scaled displays.

- **Bug Fixes**
  - Encode MIDI System messages as UMP Type 0x1 and decode them back to MIDI 1.0; removes silent drops of clock/start/stop in `ump_to_midi1_event` (shared `core/midi/include/pulp/midi/ump_conversion.hpp`).
  - WinRT MIDI: keep one `UmpSysex7Reassembler` per UMP group to prevent interleaved SysEx7 streams from corrupting each other.
  - Linux X11 XDND: convert physical pixels to logical coords (÷ scale) before `window_to_root_point()` to fix HiDPI drag/drop offsets.

- **Dependencies**
  - Bump project version to 0.395.0.
  - Bump `pulp` plugin/marketplace version to 0.202.1.

<sup>Written for commit 774cb6c407c0d908e011e54550f91f8bf244ef42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

