### PR TITLE
feat(midi): WinRT BLE MIDI scan-probe backend + advisory compile-gate (W13 part 1)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -203,6 +203,21 @@ Watch points: the port requires Windows SDK >= 10.0.26100.0 (windows-latest is
 right at that floor), and the drafted backend's API surface may still drift
 from the real `winrt::Microsoft::Windows::Devices::Midi2` namespace.
 
+### Advisory compile-gate: `windows-ble-gate`
+
+`build.yml`'s `windows-ble-gate` job (`continue-on-error: true`, NOT a required
+check, NOT part of the build matrix) compile-verifies Pulp's WinRT Bluetooth-LE
+scan backend (`core/midi/platform/win/ble_midi_win.cpp`). Unlike
+`windows-midi2-gate`, the BLE GATT / advertisement APIs
+(`Windows.Devices.Bluetooth*`) ship in the BASE Windows SDK cppwinrt
+projection, so this gate needs NO vcpkg / out-of-band NuGet provisioning — the
+default Windows build already compiles the backend (it links `WindowsApp` +
+`runtimeobject`). The job is a fast, isolated `cmake --build … --target
+pulp-midi` so a blind (macOS-authored) Windows TU gets a compile signal without
+waiting on the full matrix. Watch point: the backend's
+`winrt::Windows::Devices::Bluetooth::Advertisement` API surface is written
+without a local Windows compiler, so signature drift surfaces here first.
+
 ## PR Review Thread Hygiene
 
 Before opening a follow-up PR or declaring a phase complete, sweep review

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.202.1",
+      "version": "0.203.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.202.1"
+  "version": "0.203.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.202.1",
+  "version": "0.203.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1089,6 +1089,50 @@ jobs:
         shell: pwsh
         run: cmake --build build-midi2 --config Release --target pulp-midi
 
+  # ── Windows BLE MIDI compile-gate (advisory) ─────────────────────────────
+  #
+  # Compile-verifies Pulp's WinRT Bluetooth-LE scan backend
+  # (core/midi/platform/win/ble_midi_win.cpp). Unlike the MIDI 2.0 gate
+  # above, the BLE GATT / advertisement APIs (Windows.Devices.Bluetooth*)
+  # ship in the BASE Windows SDK cppwinrt projection, so this gate needs NO
+  # vcpkg / out-of-band NuGet provisioning — the default Windows build
+  # already compiles the backend. This standalone job exists purely to give
+  # the blind (macOS-authored) Windows TU a fast, isolated compile signal on
+  # the pulp-midi target without waiting on the full build matrix.
+  #
+  # ADVISORY: standalone job, not part of the required build matrix or any
+  # required alias, so it can never block merge.
+  windows-ble-gate:
+    needs: classify
+    if: needs.classify.outputs.native_build_required == 'true'
+    runs-on: windows-latest
+    name: Windows BLE compile-gate (advisory)
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          lfs: true
+
+      - name: Bootstrap repository dependencies
+        run: ./setup.sh --ci --deps-only
+        shell: bash
+
+      # Default Windows configure — no PULP_HAS_WINRT_MIDI, no vcpkg. The BLE
+      # backend compiles on the base SDK projection out of the box.
+      - name: Configure (base Windows SDK — WinRT BLE backend)
+        shell: pwsh
+        run: |
+          cmake -S . -B build-ble `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DPULP_BUILD_TESTS=OFF `
+            -DPULP_BUILD_EXAMPLES=OFF
+
+      # Build only pulp-midi — the WinRT BLE TU lives there and is the whole
+      # point of this gate. Avoids paying for the full tree.
+      - name: Build pulp-midi (compile-verify the WinRT BLE backend)
+        shell: pwsh
+        run: cmake --build build-ble --config Release --target pulp-midi
+
   # ── Stable-name status aliases for advisory platforms ─────────────────────
   # Branch protection requires a context literally named `macos`. Keep it
   # independent of the advisory Linux/Windows matrix legs: this job polls

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.396.0
+    VERSION 0.397.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/midi/CMakeLists.txt
+++ b/core/midi/CMakeLists.txt
@@ -57,14 +57,24 @@ elseif(WIN32)
     target_sources(pulp-midi PRIVATE
         platform/win/winmidi_device.cpp
         platform/win/winrt_midi_device.cpp
-        # BLE MIDI scaffold — WinRT BluetoothLEAdvertisementWatcher
-        # backend not yet wired; the stub central reports
-        # is_available() == false until a follow-up slice lands the
-        # WinRT GATT plumbing.
-        src/ble_midi_stub.cpp
+        # BLE MIDI — WinRT BluetoothLEAdvertisementWatcher scan backend.
+        # Unlike the WinRT MIDI 2.0 backend (winrt_midi_device.cpp), BLE
+        # GATT lives in Windows.Devices.Bluetooth* in the BASE Windows SDK
+        # cppwinrt projection, so no out-of-band vcpkg/NuGet dependency is
+        # needed — just the OS umbrella import libs below. This TU defines
+        # create_ble_midi_central() for Windows, so it REPLACES
+        # src/ble_midi_stub.cpp (linking both would duplicate the symbol).
+        # Scan-only in this slice; GATT connect/notify lands in a follow-up.
+        platform/win/ble_midi_win.cpp
     )
     target_link_libraries(pulp-midi PRIVATE
         winmm
+        # WinRT activation + COM apartment for the BLE advertisement watcher.
+        # WindowsApp is the desktop umbrella import lib (init_apartment,
+        # activation factories, event tokens); runtimeobject provides the
+        # WinRT/COM runtime helpers. Both ship with the base Windows SDK.
+        WindowsApp
+        runtimeobject
     )
     # Opt-in WinRT MIDI 2.0 (UMP) backend — Windows MIDI Services SDK.
     #

--- a/core/midi/platform/win/ble_midi_win.cpp
+++ b/core/midi/platform/win/ble_midi_win.cpp
@@ -1,0 +1,267 @@
+// BLE MIDI backend — Windows using WinRT Bluetooth-LE advertisement scan.
+//
+// Implements pulp::midi::BleMidiCentral on Windows. This slice is the
+// *scan probe* half: a BluetoothLEAdvertisementWatcher filtered to the
+// BLE-MIDI 1.0 service UUID (03B80E5A-EDE8-4B33-A751-6CE34EC4C700)
+// surfaces advertising peripherals through the scan callback. GATT
+// connect + characteristic notification (the inbound MIDI byte stream)
+// lands in a follow-up slice — see the "PR4: connect/notify" markers.
+//
+// Why the base Windows SDK is enough here (unlike the WinRT MIDI 2.0
+// backend in winrt_midi_device.cpp): BLE GATT lives in
+// Windows.Devices.Bluetooth / Windows.Devices.Bluetooth.Advertisement,
+// which ship in the BASE Windows SDK cppwinrt projection. There is no
+// out-of-band NuGet / vcpkg dependency — we link the OS umbrella import
+// library (WindowsApp) and include the stock winrt headers.
+//
+// Threading: the watcher's Received event fires on a WinRT thread-pool
+// thread. The BleMidiScanCallback contract already permits invocation
+// from a backend thread, so we forward directly under a short mutex hold
+// that protects the dedup map + the stored callback (matching the
+// CoreBluetooth backend's discipline). Apartment init is lazy + MTA, the
+// same pattern winrt_midi_device.cpp uses.
+
+#if defined(_WIN32)
+
+#include <pulp/midi/ble_midi.hpp>
+#include <pulp/runtime/log.hpp>
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Devices.Bluetooth.h>
+#include <winrt/Windows.Devices.Bluetooth.Advertisement.h>
+
+namespace pulp::midi {
+namespace {
+
+namespace wf  = ::winrt::Windows::Foundation;
+namespace wda = ::winrt::Windows::Devices::Bluetooth::Advertisement;
+
+// Lazy, idempotent MTA apartment init. WinRT reference-counts init/uninit
+// per thread; calling init_apartment more than once on the same thread is
+// benign. We init lazily so merely linking the backend does not force
+// apartment creation on hosts that never scan for BLE peripherals.
+void ensure_winrt_init() {
+    static std::once_flag once;
+    std::call_once(once, [] {
+        try {
+            ::winrt::init_apartment(::winrt::apartment_type::multi_threaded);
+        } catch (const ::winrt::hresult_error&) {
+            // Already initialised on this thread with a different model, or
+            // COM already up — both are fine for our consumer-only usage.
+        }
+    });
+}
+
+// Parse the canonical 8-4-4-4-12 UUID string used by BleMidiUuids into a
+// winrt::guid. The advertisement-filter ServiceUuids list and the
+// per-advertisement ServiceUuids comparison both work in winrt::guid.
+::winrt::guid guid_from_uuid_string(const char* uuid) {
+    // Strip hyphens into 32 hex nibbles.
+    char hex[33] = {};
+    int n = 0;
+    for (const char* p = uuid; *p && n < 32; ++p) {
+        if (*p == '-') continue;
+        hex[n++] = *p;
+    }
+
+    auto take = [&](int offset, int count) -> uint64_t {
+        char buf[17] = {};
+        for (int i = 0; i < count; ++i) buf[i] = hex[offset + i];
+        return std::strtoull(buf, nullptr, 16);
+    };
+
+    ::winrt::guid g{};
+    g.Data1 = static_cast<uint32_t>(take(0, 8));
+    g.Data2 = static_cast<uint16_t>(take(8, 4));
+    g.Data3 = static_cast<uint16_t>(take(12, 4));
+    // Data4 is the final 8 bytes (clock-seq + node), big-endian in the
+    // string form. hex[16..31] = 16 nibbles = 8 bytes.
+    for (int i = 0; i < 8; ++i) {
+        g.Data4[i] = static_cast<uint8_t>(take(16 + i * 2, 2));
+    }
+    return g;
+}
+
+// Format a 48-bit Bluetooth address (as delivered by WinRT) into a stable
+// hex id string. The address is the cross-scan handle the host passes back
+// to connect(); the format mirrors the colon-free hex other backends use
+// for their device ids so the UI can treat it opaquely.
+std::string address_to_id(uint64_t address) {
+    char buf[16] = {};
+    std::snprintf(buf, sizeof(buf), "%012llx",
+                  static_cast<unsigned long long>(address));
+    return std::string(buf);
+}
+
+class WinBleMidiCentral final : public BleMidiCentral {
+public:
+    WinBleMidiCentral() { ensure_winrt_init(); }
+
+    ~WinBleMidiCentral() override { stop_scan(); }
+
+    // True if the WinRT BLE advertisement API is usable on this machine.
+    // Constructing a BluetoothLEAdvertisementWatcher does not require an
+    // adapter to be present, but a missing Bluetooth stack throws an
+    // hresult_error here — treat any throw as "unavailable" so callers
+    // degrade gracefully (matching the stub central's contract).
+    bool is_available() const override {
+        try {
+            wda::BluetoothLEAdvertisementWatcher probe{};
+            (void)probe;
+            return true;
+        } catch (const ::winrt::hresult_error&) {
+            return false;
+        }
+    }
+
+    bool start_scan(BleMidiScanCallback cb) override {
+        if (scanning_.load()) return true;  // start while scanning == no-op
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            scan_cb_ = std::move(cb);
+        }
+        try {
+            watcher_ = wda::BluetoothLEAdvertisementWatcher{};
+            // Active scanning solicits the scan-response payload, which is
+            // where the human-readable local name usually rides.
+            watcher_.ScanningMode(wda::BluetoothLEScanningMode::Active);
+
+            // Filter to BLE-MIDI advertisements only. The watcher matches
+            // when the advertised ServiceUuids list contains our service.
+            const ::winrt::guid service_guid =
+                guid_from_uuid_string(BleMidiUuids::kService);
+            watcher_.AdvertisementFilter().Advertisement()
+                .ServiceUuids().Append(service_guid);
+
+            received_token_ = watcher_.Received(
+                { this, &WinBleMidiCentral::on_received });
+
+            watcher_.Start();
+        } catch (const ::winrt::hresult_error& e) {
+            runtime::log_error("WinRT BLE MIDI: failed to start scan: {}",
+                               ::winrt::to_string(e.message()));
+            teardown_watcher();
+            return false;
+        }
+        scanning_.store(true);
+        return true;
+    }
+
+    void stop_scan() override {
+        if (!scanning_.exchange(false)) return;
+        teardown_watcher();
+    }
+
+    bool is_scanning() const override { return scanning_.load(); }
+
+    std::vector<BleMidiPeripheral> known_peripherals() const override {
+        std::lock_guard<std::mutex> lock(mu_);
+        std::vector<BleMidiPeripheral> out;
+        out.reserve(peripherals_.size());
+        for (const auto& [id, snap] : peripherals_) out.push_back(snap);
+        return out;
+    }
+
+    // PR4: connect/notify. The scan probe does not yet open a GATT link.
+    // Report Failed/Unsupported so the contract stays honest and the host
+    // does not wait forever for a Connected that will not arrive.
+    bool connect(const std::string& id) override {
+        BleMidiStateCallback cb_copy;
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            cb_copy = state_cb_;
+        }
+        if (cb_copy) {
+            cb_copy(id, BleMidiConnectionState::Failed,
+                    BleMidiError::Unsupported);
+        }
+        return false;
+    }
+
+    // PR4: connect/notify.
+    void disconnect(const std::string&) override {}
+
+    void set_state_callback(BleMidiStateCallback cb) override {
+        std::lock_guard<std::mutex> lock(mu_);
+        state_cb_ = std::move(cb);
+    }
+
+    // PR4: connect/notify. No GATT link yet, so no MIDI port mapping.
+    std::string midi_input_port_for(const std::string&) const override {
+        return {};
+    }
+    std::string midi_output_port_for(const std::string&) const override {
+        return {};
+    }
+
+private:
+    // Fired on a WinRT thread-pool thread for each filtered advertisement.
+    void on_received(const wda::BluetoothLEAdvertisementWatcher&,
+                     const wda::BluetoothLEAdvertisementReceivedEventArgs& args) {
+        try {
+            BleMidiPeripheral snapshot;
+            snapshot.id = address_to_id(args.BluetoothAddress());
+            snapshot.name = ::winrt::to_string(args.Advertisement().LocalName());
+            snapshot.rssi = args.RawSignalStrengthInDBm();
+            snapshot.last_seen = std::chrono::steady_clock::now();
+            // The OS pairing/bond state is a GATT-side query; the scan probe
+            // does not resolve it, so report false until PR4 wires connect.
+            snapshot.is_paired = false;
+
+            BleMidiScanCallback cb_copy;
+            {
+                std::lock_guard<std::mutex> lock(mu_);
+                peripherals_[snapshot.id] = snapshot;
+                cb_copy = scan_cb_;
+            }
+            if (cb_copy) cb_copy(snapshot);
+        } catch (const ::winrt::hresult_error&) {
+            // Drop a malformed advertisement rather than tear down the watcher.
+        }
+    }
+
+    void teardown_watcher() {
+        if (!watcher_) return;
+        try {
+            if (received_token_) {
+                watcher_.Received(received_token_);
+                received_token_ = {};
+            }
+            watcher_.Stop();
+        } catch (const ::winrt::hresult_error&) {
+            // Best-effort — the stack may already be gone.
+        }
+        watcher_ = nullptr;
+    }
+
+    mutable std::mutex mu_;
+    std::map<std::string, BleMidiPeripheral> peripherals_;
+    BleMidiScanCallback scan_cb_;
+    BleMidiStateCallback state_cb_;
+    std::atomic<bool> scanning_{false};
+
+    wda::BluetoothLEAdvertisementWatcher watcher_{nullptr};
+    ::winrt::event_token received_token_{};
+};
+
+}  // namespace
+
+std::unique_ptr<BleMidiCentral> create_ble_midi_central() {
+    return std::make_unique<WinBleMidiCentral>();
+}
+
+}  // namespace pulp::midi
+
+#endif  // _WIN32

--- a/test/test_ble_midi.cpp
+++ b/test/test_ble_midi.cpp
@@ -206,3 +206,30 @@ TEST_CASE("create_ble_midi_central always returns a usable instance",
     REQUIRE((observed_err == BleMidiError::Unsupported ||
              observed_err == BleMidiError::PeripheralNotFound));
 }
+
+TEST_CASE("create_ble_midi_central is_available() is callable and honest",
+          "[ble-midi]") {
+    // is_available() must never crash and must report a definite bool on
+    // every platform. On macOS CI without a granted Bluetooth permission /
+    // powered adapter the CoreBluetooth backend reports false; the Windows
+    // WinRT scan backend reports true only when the BLE advertisement API
+    // is usable; the stub reports false. The contract under test is simply
+    // that the call is safe and that an unavailable backend keeps its
+    // scan / port surface as honest no-ops.
+    auto central = create_ble_midi_central();
+    REQUIRE(central != nullptr);
+    const bool available = central->is_available();
+    if (!available) {
+        // An unavailable backend must keep the scan surface inert: starting
+        // a scan must not flip is_scanning() on, and there are no known
+        // peripherals or port mappings to surface.
+        REQUIRE_FALSE(central->start_scan([](const BleMidiPeripheral&) {}));
+        REQUIRE_FALSE(central->is_scanning());
+        REQUIRE(central->known_peripherals().empty());
+        REQUIRE(central->midi_input_port_for("any-id").empty());
+        REQUIRE(central->midi_output_port_for("any-id").empty());
+    }
+    // stop_scan() is always safe, scanning or not.
+    central->stop_scan();
+    REQUIRE_FALSE(central->is_scanning());
+}


### PR DESCRIPTION
PR3 of the BLE-MIDI-off-Apple epic (#3801). Plan: `planning/2026-06-09-ble-midi-off-apple-plan.md` (PR3).

Scaffolds a **real** Windows BLE scan backend behind the existing `BleMidiCentral` interface, plus the CI gate that compiles the blind WinRT code (this is the compile-probe slice; GATT connect/notify is PR4).

## What's here
- `core/midi/platform/win/ble_midi_win.cpp` — `WinBleMidiCentral` (`#if _WIN32`): lazy MTA init; `is_available()` probes by constructing a `BluetoothLEAdvertisementWatcher`; `start_scan()` builds an Active-mode watcher filtered to the BLE-MIDI service UUID, subscribes `Received`, and surfaces each advertisement as a `BleMidiPeripheral` (address→id, local name, RSSI, last_seen). `connect`/notify/port-mapping are honest `// PR4` stubs.
- Factory `create_ble_midi_central()` returns the WinRT backend on Windows; CMake swaps `ble_midi_win.cpp` in for `ble_midi_stub.cpp` on WIN32 (one symbol definition) and links base-SDK `WindowsApp` + `runtimeobject` — **no vcpkg/NuGet** (unlike the MIDI 2.0 backend; BLE GATT is in the base Windows SDK).
- Advisory **`windows-ble-gate`** in `build.yml` (continue-on-error) compiles `pulp-midi` with the WinRT BLE path, base SDK only. `ci` SKILL.md updated.

## Dependencies / NOTICE
**No new bundled/redistributed software** — base Windows SDK system APIs only. (Per the epic guardrail: any vendored BLE lib would require `DEPENDENCIES.md` + `NOTICE.md`. None added.)

## Verification
- macOS sanity build green (CoreBluetooth backend unaffected; the `_WIN32` TU isn't compiled off-Windows): `pulp-test-ble-midi` 47 assertions / 12 cases.
- Windows compilation verified by the advisory `windows-ble-gate` (+ the standard Windows MSVC gate, which now also compiles the backend). WinRT API usage reviewed against the SDK by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Windows WinRT BLE‑MIDI scan backend behind `BleMidiCentral` and an advisory CI compile gate to verify it builds on the base Windows SDK. Scanning now discovers BLE‑MIDI peripherals on Windows; GATT connect/notify will follow in the next PR.

- **New Features**
  - Implemented `WinBleMidiCentral` using `BluetoothLEAdvertisementWatcher` filtered to the BLE‑MIDI service UUID; surfaces `BleMidiPeripheral` (id = Bluetooth address hex, name, RSSI, last_seen). `is_available()` probes the WinRT BLE API. `connect`/disconnect/port mapping are stubbed (report Unsupported).
  - CMake wires in `core/midi/platform/win/ble_midi_win.cpp` on Windows; factory returns the WinRT backend. Links `WindowsApp` and `runtimeobject` (replaces the stub TU).
  - Added advisory `windows-ble-gate` job to compile‑verify `pulp-midi` on the base Windows SDK (no vcpkg/NuGet), non‑blocking. Tests cover `is_available()` safety and unavailable no‑op behavior; CI skill docs updated.

- **Dependencies**
  - No new vendored deps. Uses base Windows SDK WinRT BLE APIs only; links `WindowsApp` and `runtimeobject`.

<sup>Written for commit 8d59875e755f18a1fb39a198b2bec34713d79e39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

