### PR TITLE
feat(platform): D-Bus system-bus + signal subscription + GetManagedObjects (BLE prereq)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.396.0
+    VERSION 0.397.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/platform/include/pulp/platform/dbus.hpp
+++ b/core/platform/include/pulp/platform/dbus.hpp
@@ -48,6 +48,15 @@ public:
     /// when no session bus is reachable. Idempotent (returns true if already
     /// connected).
     bool connect_session();
+
+    /// Connect to the SYSTEM bus. System services (BlueZ / org.bluez, UPower,
+    /// NetworkManager, …) live on the system bus, not the per-login session bus,
+    /// so a client that needs to talk to them connects here instead of
+    /// connect_session(). Returns false off Linux, without libdbus, or when no
+    /// system bus is reachable. Idempotent (returns true if already connected).
+    /// A given DBus connects to exactly one bus — call this XOR connect_session().
+    bool connect_system();
+
     bool connected() const;
 
     /// Switch this DBus over to the desktop accessibility ("a11y") bus.
@@ -259,10 +268,56 @@ public:
                      const std::function<void(Reader&)>& read_reply,
                      int timeout_ms = 5000);
 
+    // ── Signal subscription (broadcast, BYPASSES the object-path vtable) ─────
+    //
+    // D-Bus signals are broadcast messages, not method calls: they never reach
+    // the object-path vtable / trampoline (which only routes method calls).
+    // Receiving them requires (a) an org.freedesktop.DBus match rule so the
+    // broker delivers them to this connection, and (b) a libdbus connection
+    // FILTER that inspects each incoming message. Both are installed here.
+    // Matching signals are routed to handlers during dispatch().
+
+    /// Handler invoked for each matching signal. `args` is a Reader positioned at
+    /// the signal body; it is valid only for the duration of the call.
+    using SignalHandler = std::function<void(const std::string& path,
+                                             const std::string& interface,
+                                             const std::string& member,
+                                             Reader& args)>;
+
+    /// Subscribe to signals matching interface+member (member empty = any member
+    /// of the interface). Adds the org.freedesktop.DBus match rule and routes
+    /// matching signals to `handler` during dispatch(). Returns a token (>0) to
+    /// pass to remove_signal_handler(); returns 0 off Linux / without a connection.
+    unsigned add_signal_handler(const std::string& interface,
+                                const std::string& member,
+                                SignalHandler handler);
+    /// Remove a signal handler previously returned by add_signal_handler().
+    /// Returns false off Linux / for an unknown token. The match rule is left in
+    /// place (harmless extra delivery; removing it precisely would require
+    /// reference-counting identical rules across tokens).
+    bool remove_signal_handler(unsigned token);
+
+    /// Call org.freedesktop.DBus.ObjectManager.GetManagedObjects on
+    /// destination/path and invoke `per_object(object_path, interface_name)` for
+    /// every (object, interface) pair discovered. Property values are skipped
+    /// (callers re-query specific props via call_method as needed). Returns false
+    /// off Linux / on transport error.
+    bool get_managed_objects(const std::string& destination,
+                             const std::string& path,
+                             const std::function<void(const std::string& obj_path,
+                                                      const std::string& interface)>& per_object,
+                             int timeout_ms = 5000);
+
     DBus(const DBus&) = delete;
     DBus& operator=(const DBus&) = delete;
 
 private:
+    /// Shared body of connect_session()/connect_system(): dlopen libdbus, resolve
+    /// symbols, and open a private connection to `bus_type` (DBUS_BUS_SESSION = 0,
+    /// DBUS_BUS_SYSTEM = 1). Idempotent via connected(). Linux-only; the non-Linux
+    /// build never calls it (connect_session/connect_system are no-ops there).
+    bool connect_bus(int bus_type);
+
     struct Impl;
     Impl* impl_ = nullptr;
 };

--- a/core/platform/src/dbus.cpp
+++ b/core/platform/src/dbus.cpp
@@ -54,7 +54,8 @@ constexpr int kTypeStruct  = 'r';   // STRUCT type code (open_container takes 'r
 constexpr int kTypeVariant = 'v';
 constexpr int kTypeDictEnt = 'e';
 constexpr int kTypeInvalid = '\0';
-constexpr int kBusSession  = 0;
+constexpr int kBusSession  = 0;   // DBUS_BUS_SESSION
+constexpr int kBusSystem   = 1;   // DBUS_BUS_SYSTEM
 
 // DBusHandlerResult values (dbus-shared.h).
 constexpr int kHandlerHandled       = 0;   // DBUS_HANDLER_RESULT_HANDLED
@@ -176,6 +177,24 @@ struct DBus::Impl {
     fn_open_private open_private = nullptr;
     fn_bus_register bus_register = nullptr;
 
+    // ── signal-subscription additions ──
+    // DBusHandleMessageFunction: DBusHandlerResult (*)(conn, msg, user_data)
+    using fn_filter_func  = int (*)(void*, void*, void*);
+    // dbus_connection_add_filter(conn, filter_fn, user_data, free_fn) → dbus_bool_t
+    using fn_add_filter   = unsigned (*)(void*, void*, void*, void*);
+    // dbus_connection_remove_filter(conn, filter_fn, user_data)
+    using fn_remove_filter = void (*)(void*, void*, void*);
+    fn_add_filter    add_filter = nullptr;
+    fn_remove_filter remove_filter = nullptr;
+
+    // Registered signal subscriptions. The filter trampoline walks these on each
+    // incoming signal and invokes every handler whose interface matches and whose
+    // member matches (or is empty = any member of the interface).
+    struct SignalSub { std::string interface; std::string member; SignalHandler handler; };
+    std::map<unsigned, SignalSub> signal_subs;
+    unsigned next_signal_token = 0;
+    bool filter_installed = false;   // the connection filter is lazily added once
+
     template <typename Fn>
     Fn sym(const char* name) { return reinterpret_cast<Fn>(dlsym(handle, name)); }
 
@@ -223,6 +242,10 @@ struct DBus::Impl {
         open_private = sym<fn_open_private>("dbus_connection_open_private");
         bus_register = sym<fn_bus_register>("dbus_bus_register");
 
+        // Signal-subscription symbols (connection message filter).
+        add_filter = sym<fn_add_filter>("dbus_connection_add_filter");
+        remove_filter = sym<fn_remove_filter>("dbus_connection_remove_filter");
+
         return error_init && error_free && error_is_set && bus_get_private &&
                conn_close && conn_unref && set_exit_on_disconnect && add_match &&
                read_write && pop_message && send_with_reply_and_block &&
@@ -234,7 +257,8 @@ struct DBus::Impl {
                msg_new_method_return && msg_new_signal && msg_new_error &&
                conn_send && conn_flush && read_write_dispatch &&
                msg_get_interface && msg_get_member && msg_get_sender &&
-               get_unique_name && open_private && bus_register;
+               get_unique_name && open_private && bus_register &&
+               add_filter && remove_filter;
     }
 
     // Append one a{sv} entry: key (string) → variant of `vtype` holding `val`.
@@ -310,6 +334,53 @@ struct DBus::Impl {
         self->conn_flush(self->conn);
         owner_view.impl_ = nullptr;  // do NOT free the borrowed Impl on dtor
         return result;
+    }
+
+    // Connection-wide message FILTER for incoming signals. Unlike the object-path
+    // trampoline above (method calls only), the filter sees every message —
+    // including broadcast signals, which never hit the vtable. We route matching
+    // signals to subscribed handlers and ALWAYS return NOT_YET_HANDLED so the
+    // normal object-path dispatch (method-call routing) is unaffected.
+    static int signal_filter(void* /*conn*/, void* msg, void* user_data) {
+        auto* self = static_cast<Impl*>(user_data);
+        if (!self || !msg) return kHandlerNotYetHandled;
+        if (self->signal_subs.empty()) return kHandlerNotYetHandled;
+
+        // Only consider signals. msg_is_signal(msg, iface, member) returns true
+        // when both match; pass the message's own interface/member so it reduces
+        // to a "is this a signal at all?" probe.
+        const char* iface  = self->msg_get_interface(msg);
+        const char* member = self->msg_get_member(msg);
+        if (!iface || !member) return kHandlerNotYetHandled;
+        if (!self->msg_is_signal(msg, iface, member)) return kHandlerNotYetHandled;
+
+        const char* path = self->msg_get_path(msg);
+        const std::string path_s   = path ? path : "";
+        const std::string iface_s  = iface;
+        const std::string member_s = member;
+
+        // Snapshot the matching subscriptions before invoking any handler: a
+        // handler may add/remove subscriptions, which would invalidate iterators
+        // over signal_subs.
+        std::vector<SignalHandler> to_invoke;
+        for (auto& [token, sub] : self->signal_subs) {
+            (void)token;
+            if (sub.interface != iface_s) continue;
+            if (!sub.member.empty() && sub.member != member_s) continue;
+            if (sub.handler) to_invoke.push_back(sub.handler);
+        }
+        if (to_invoke.empty()) return kHandlerNotYetHandled;
+
+        DBus owner_view;             // lightweight non-owning DBus to host Reader
+        owner_view.impl_ = self;
+        for (auto& h : to_invoke) {
+            IterBuf args_iter;
+            const bool has_args = self->iter_init(msg, &args_iter) != 0;
+            Reader r(&owner_view, has_args ? &args_iter : nullptr);
+            h(path_s, iface_s, member_s, r);
+        }
+        owner_view.impl_ = nullptr;  // borrowed; do NOT free on dtor
+        return kHandlerNotYetHandled;  // never claim the message
     }
 };
 
@@ -473,7 +544,17 @@ DBus::DBus() = default;
 
 DBus::~DBus() {
     if (impl_) {
-        if (impl_->conn) { impl_->conn_close(impl_->conn); impl_->conn_unref(impl_->conn); }
+        if (impl_->conn) {
+            // Drop the signal filter before tearing the connection down so its
+            // user_data (this Impl) is never dereferenced after free.
+            if (impl_->filter_installed && impl_->remove_filter) {
+                impl_->remove_filter(impl_->conn,
+                                     reinterpret_cast<void*>(&Impl::signal_filter),
+                                     impl_);
+            }
+            impl_->conn_close(impl_->conn);
+            impl_->conn_unref(impl_->conn);
+        }
         if (impl_->handle) dlclose(impl_->handle);
         delete impl_;
     }
@@ -487,7 +568,7 @@ std::string DBus::unique_name() const {
     return n ? std::string(n) : std::string();
 }
 
-bool DBus::connect_session() {
+bool DBus::connect_bus(int bus_type) {
     if (connected()) return true;
     auto impl = new Impl();
     impl->handle = dlopen("libdbus-1.so.3", RTLD_LAZY | RTLD_LOCAL);
@@ -496,7 +577,7 @@ bool DBus::connect_session() {
 
     Impl::ErrBuf err;
     impl->error_init(&err);
-    impl->conn = impl->bus_get_private(kBusSession, &err);
+    impl->conn = impl->bus_get_private(bus_type, &err);
     if (!impl->conn || impl->error_is_set(&err)) {
         if (impl->conn) { impl->conn_close(impl->conn); impl->conn_unref(impl->conn); }
         impl->error_free(&err);
@@ -509,6 +590,9 @@ bool DBus::connect_session() {
     impl_ = impl;
     return true;
 }
+
+bool DBus::connect_session() { return connect_bus(kBusSession); }
+bool DBus::connect_system() { return connect_bus(kBusSystem); }
 
 bool DBus::a11y_connected() const { return impl_ && impl_->conn && impl_->on_a11y; }
 
@@ -690,6 +774,95 @@ bool DBus::call_method(const std::string& destination, const std::string& path,
     return true;
 }
 
+unsigned DBus::add_signal_handler(const std::string& interface,
+                                  const std::string& member,
+                                  SignalHandler handler) {
+    if (!connected() || !handler) return 0;
+    Impl& d = *impl_;
+
+    // Install the connection filter once, on the first subscription.
+    if (!d.filter_installed) {
+        if (d.add_filter(d.conn, reinterpret_cast<void*>(&Impl::signal_filter),
+                         &d /*user_data*/, nullptr /*free_fn*/) == 0) {
+            return 0;  // OOM adding the filter → honest-fail
+        }
+        d.filter_installed = true;
+    }
+
+    // Tell the broker to deliver matching signals to this connection.
+    std::string rule = "type='signal',interface='" + interface + "'";
+    if (!member.empty()) rule += ",member='" + member + "'";
+    Impl::ErrBuf err;
+    d.error_init(&err);
+    d.add_match(d.conn, rule.c_str(), &err);
+    const bool match_failed = d.error_is_set(&err) != 0;
+    d.error_free(&err);
+    if (match_failed) return 0;
+
+    const unsigned token = ++d.next_signal_token;
+    d.signal_subs[token] = Impl::SignalSub{interface, member, std::move(handler)};
+    return token;
+}
+
+bool DBus::remove_signal_handler(unsigned token) {
+    if (!connected()) return false;
+    Impl& d = *impl_;
+    auto it = d.signal_subs.find(token);
+    if (it == d.signal_subs.end()) return false;
+    d.signal_subs.erase(it);
+    // The org.freedesktop.DBus match rule is intentionally left in place: removing
+    // it precisely would require ref-counting identical rules across tokens, and a
+    // surplus rule only costs a few unmatched deliveries that the filter ignores.
+    return true;
+}
+
+bool DBus::get_managed_objects(
+    const std::string& destination, const std::string& path,
+    const std::function<void(const std::string&, const std::string&)>& per_object,
+    int timeout_ms) {
+    if (!connected()) return false;
+    // GetManagedObjects() -> a{oa{sa{sv}}}: a dict of object-path → (dict of
+    // interface-name → (dict of property-name → variant)). We walk the outer
+    // array of dict-entries, then each object's inner array of interface
+    // dict-entries, reporting (object-path, interface-name). Property values are
+    // skipped — callers re-query specific props via call_method as needed.
+    return call_method(
+        destination, path, "org.freedesktop.DBus.ObjectManager",
+        "GetManagedObjects", /*build_args=*/nullptr,
+        [&](Reader& reply) {
+            if (reply.arg_type() != kTypeArray) return;
+            Reader objects;
+            if (!reply.recurse(objects)) return;          // → outer a{o...}
+            while (objects.arg_type() == kTypeDictEnt) {
+                Reader obj_entry;
+                if (!objects.recurse(obj_entry)) break;    // → {o, a{sa{sv}}}
+                std::string obj_path;
+                if (!obj_entry.read_string(obj_path)) {    // object path 'o'
+                    objects.next();
+                    continue;
+                }
+                // obj_entry cursor now on the inner a{sa{sv}} (interfaces).
+                if (obj_entry.arg_type() == kTypeArray) {
+                    Reader ifaces;
+                    if (obj_entry.recurse(ifaces)) {
+                        while (ifaces.arg_type() == kTypeDictEnt) {
+                            Reader iface_entry;
+                            if (!ifaces.recurse(iface_entry)) break;  // → {s, a{sv}}
+                            std::string iface_name;
+                            if (iface_entry.read_string(iface_name) && per_object) {
+                                per_object(obj_path, iface_name);
+                            }
+                            // The remaining a{sv} of props is skipped.
+                            ifaces.next();
+                        }
+                    }
+                }
+                objects.next();
+            }
+        },
+        timeout_ms);
+}
+
 std::optional<DBus::PortalResult> DBus::file_chooser(
     const std::string& method, const std::string& title,
     const std::map<std::string, std::string>& options,
@@ -848,7 +1021,9 @@ DBus::DBus() = default;
 DBus::~DBus() = default;
 bool DBus::connected() const { return false; }
 std::string DBus::unique_name() const { return {}; }
+bool DBus::connect_bus(int) { return false; }
 bool DBus::connect_session() { return false; }
+bool DBus::connect_system() { return false; }
 bool DBus::connect_a11y_bus() { return false; }
 bool DBus::a11y_connected() const { return false; }
 bool DBus::register_object(const std::string&, IncomingHandler) { return false; }
@@ -859,6 +1034,13 @@ bool DBus::dispatch(int) { return false; }
 bool DBus::call_method(const std::string&, const std::string&, const std::string&,
                        const std::string&, const std::function<void(Writer&)>&,
                        const std::function<void(Reader&)>&, int) { return false; }
+unsigned DBus::add_signal_handler(const std::string&, const std::string&,
+                                  SignalHandler) { return 0; }
+bool DBus::remove_signal_handler(unsigned) { return false; }
+bool DBus::get_managed_objects(
+    const std::string&, const std::string&,
+    const std::function<void(const std::string&, const std::string&)>&,
+    int) { return false; }
 std::optional<DBus::PortalResult> DBus::file_chooser(
     const std::string&, const std::string&,
     const std::map<std::string, std::string>&,

--- a/test/test_dbus.cpp
+++ b/test/test_dbus.cpp
@@ -18,10 +18,13 @@
 #include <pulp/platform/dbus.hpp>
 #include <pulp/platform/file_dialog.hpp>
 
+#include <algorithm>
 #include <atomic>
 #include <cstdlib>
 #include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 #if defined(__linux__)
 #include <dlfcn.h>
@@ -73,6 +76,44 @@ TEST_CASE("DBus availability + connect honest-fail contract", "[platform][dbus][
     REQUIRE_FALSE(connected);
     REQUIRE_FALSE(bus.connected());
 #endif
+}
+
+TEST_CASE("DBus connect_system honest-fail contract",
+          "[platform][dbus][system][issue-3801]") {
+    const bool avail = DBus::library_available();
+
+    DBus bus;
+    REQUIRE_FALSE(bus.connected());
+    const bool connected = bus.connect_system();
+
+#if defined(__linux__)
+    // On Linux connect_system can only succeed if libdbus loaded; it may still
+    // fail (no system bus reachable in a bare CI container), which is fine.
+    if (connected) {
+        REQUIRE(avail);
+        REQUIRE(bus.connected());
+        REQUIRE(bus.connect_system());  // idempotent
+    } else {
+        REQUIRE_FALSE(bus.connected());
+    }
+#else
+    // Off Linux every call is an honest no-op.
+    REQUIRE_FALSE(avail);
+    REQUIRE_FALSE(connected);
+    REQUIRE_FALSE(bus.connected());
+#endif
+}
+
+TEST_CASE("DBus signal subscription honest-fails without a bus",
+          "[platform][dbus][system][signal][issue-3801]") {
+    DBus bus;  // never connected
+    REQUIRE_FALSE(bus.connected());
+    REQUIRE(bus.add_signal_handler("pulp.Test", "Pinged",
+                                   [](const std::string&, const std::string&,
+                                      const std::string&, DBus::Reader&) {}) == 0u);
+    REQUIRE_FALSE(bus.remove_signal_handler(1u));
+    REQUIRE_FALSE(bus.get_managed_objects(
+        "org.example", "/", [](const std::string&, const std::string&) {}));
 }
 
 TEST_CASE("FileDialog::install_native_backend honest-fail + idempotency",
@@ -355,6 +396,187 @@ TEST_CASE("DBus object-server loopback round-trips a method call",
 #endif
 
 #if defined(__linux__)
+// Signal subscription loopback (PR1 / #3801): one DBus emits a signal, a SECOND
+// DBus subscribed to the same interface+member receives it via the connection
+// filter during dispatch(). Two connections on the same session bus prove the
+// broker actually delivers the broadcast (a same-connection self-signal is not
+// guaranteed to loop back). Runs under `dbus-run-session -- ctest`.
+TEST_CASE("DBus signal subscription receives a matching broadcast",
+          "[platform][dbus][system][signal][issue-3801][linux]") {
+    if (!DBus::library_available()) {
+        SUCCEED("skipped: libdbus not available");
+        return;
+    }
+
+    DBus subscriber;
+    DBus emitter;
+    if (!subscriber.connect_session() || !emitter.connect_session()) {
+        SUCCEED("skipped: no session bus (run under dbus-run-session)");
+        return;
+    }
+    REQUIRE(subscriber.connected());
+    REQUIRE(emitter.connected());
+
+    std::atomic<bool> fired{false};
+    std::string got_path, got_iface, got_member, got_arg;
+    int got_int = 0;
+
+    const unsigned token = subscriber.add_signal_handler(
+        "pulp.Test.Signal", "Pinged",
+        [&](const std::string& path, const std::string& iface,
+            const std::string& member, DBus::Reader& args) {
+            got_path = path;
+            got_iface = iface;
+            got_member = member;
+            std::string s;
+            if (args.read_string(s)) got_arg = s;
+            int n = 0;
+            if (args.read_int32(n)) got_int = n;
+            fired = true;
+        });
+    REQUIRE(token != 0u);
+
+    // A non-matching subscription on the same interface (different member) must
+    // NOT fire for the Pinged signal.
+    std::atomic<bool> wrong_member_fired{false};
+    const unsigned token2 = subscriber.add_signal_handler(
+        "pulp.Test.Signal", "Ponged",
+        [&](const std::string&, const std::string&, const std::string&,
+            DBus::Reader&) { wrong_member_fired = true; });
+    REQUIRE(token2 != 0u);
+
+    REQUIRE(emitter.emit_signal(
+        "/pulp/test/signal", "pulp.Test.Signal", "Pinged",
+        [](DBus::Writer& w) { w.append_string("hi"); w.append_int32(42); }));
+
+    // Pump the subscriber until the signal is observed (bounded so a wedge fails
+    // the test instead of hanging).
+    for (int i = 0; i < 200 && !fired.load(); ++i) {
+        subscriber.dispatch(25);
+    }
+
+    REQUIRE(fired.load());
+    REQUIRE(got_path == "/pulp/test/signal");
+    REQUIRE(got_iface == "pulp.Test.Signal");
+    REQUIRE(got_member == "Pinged");
+    REQUIRE(got_arg == "hi");
+    REQUIRE(got_int == 42);
+    REQUIRE_FALSE(wrong_member_fired.load());
+
+    REQUIRE(subscriber.remove_signal_handler(token));
+    REQUIRE(subscriber.remove_signal_handler(token2));
+    REQUIRE_FALSE(subscriber.remove_signal_handler(token));  // already removed
+
+    // After removal a fresh broadcast is no longer routed to the handler.
+    fired = false;
+    REQUIRE(emitter.emit_signal(
+        "/pulp/test/signal", "pulp.Test.Signal", "Pinged",
+        [](DBus::Writer& w) { w.append_string("again"); w.append_int32(7); }));
+    for (int i = 0; i < 40; ++i) subscriber.dispatch(25);
+    REQUIRE_FALSE(fired.load());
+}
+
+// get_managed_objects shape (PR1 / #3801): export a mock ObjectManager that
+// answers GetManagedObjects()->a{oa{sa{sv}}}, then drive get_managed_objects()
+// from a SECOND connection and assert every (object, interface) pair is reported
+// and that property values are correctly skipped during the walk.
+TEST_CASE("DBus get_managed_objects walks a mock ObjectManager reply",
+          "[platform][dbus][system][objectmanager][issue-3801][linux]") {
+    if (!DBus::library_available()) {
+        SUCCEED("skipped: libdbus not available");
+        return;
+    }
+
+    DBus server;
+    DBus client;
+    if (!server.connect_session() || !client.connect_session()) {
+        SUCCEED("skipped: no session bus (run under dbus-run-session)");
+        return;
+    }
+    const std::string server_name = server.unique_name();
+    REQUIRE_FALSE(server_name.empty());
+
+    // Export /pulp/om answering ObjectManager.GetManagedObjects with two objects:
+    //   /pulp/om/dev1 → { "pulp.Device": { "Name": <string "alpha"> },
+    //                     "pulp.Battery": {} }
+    //   /pulp/om/dev2 → { "pulp.Device": {} }
+    REQUIRE(server.register_object(
+        "/pulp/om", [&](DBus::CallContext& ctx) -> bool {
+            if (ctx.interface() != "org.freedesktop.DBus.ObjectManager" ||
+                ctx.member() != "GetManagedObjects") {
+                return false;
+            }
+            DBus::Writer w = ctx.reply();
+            // a{oa{sa{sv}}}
+            auto objs = w.open_array("{oa{sa{sv}}}");
+            DBus::Writer ow = w.sub(objs);
+
+            auto add_object =
+                [&](const char* path,
+                    const std::vector<std::pair<std::string, bool>>& ifaces) {
+                    auto oe = ow.open_dict_entry();
+                    DBus::Writer oew = ow.sub(oe);
+                    oew.append_object_path(path);
+                    auto ifarr = oew.open_array("{sa{sv}}");
+                    DBus::Writer iw = oew.sub(ifarr);
+                    for (const auto& [iface, with_prop] : ifaces) {
+                        auto ie = iw.open_dict_entry();
+                        DBus::Writer iew = iw.sub(ie);
+                        iew.append_string(iface);
+                        auto props = iew.open_array("{sv}");
+                        DBus::Writer pw = iew.sub(props);
+                        if (with_prop) {
+                            auto pe = pw.open_dict_entry();
+                            DBus::Writer pew = pw.sub(pe);
+                            pew.append_string("Name");
+                            auto var = pew.open_variant("s");
+                            pew.sub(var).append_string("alpha");
+                            pew.close_container(var);
+                            pw.close_container(pe);
+                        }
+                        iew.close_container(props);
+                        iw.close_container(ie);
+                    }
+                    oew.close_container(ifarr);
+                    ow.close_container(oe);
+                };
+
+            add_object("/pulp/om/dev1",
+                       {{"pulp.Device", true}, {"pulp.Battery", false}});
+            add_object("/pulp/om/dev2", {{"pulp.Device", false}});
+
+            w.close_container(objs);
+            return true;
+        }));
+
+    std::vector<std::pair<std::string, std::string>> pairs;
+    std::atomic<bool> call_done{false};
+    std::atomic<bool> call_ok{false};
+    std::thread worker([&] {
+        call_ok = client.get_managed_objects(
+            server_name, "/pulp/om",
+            [&](const std::string& obj, const std::string& iface) {
+                pairs.emplace_back(obj, iface);
+            });
+        call_done = true;
+    });
+    for (int i = 0; i < 200 && !call_done.load(); ++i) server.dispatch(25);
+    worker.join();
+
+    REQUIRE(call_ok.load());
+    // Three (object, interface) pairs, properties skipped without disrupting the walk.
+    REQUIRE(pairs.size() == 3u);
+    auto has = [&](const std::string& o, const std::string& i) {
+        return std::find(pairs.begin(), pairs.end(),
+                         std::make_pair(o, i)) != pairs.end();
+    };
+    REQUIRE(has("/pulp/om/dev1", "pulp.Device"));
+    REQUIRE(has("/pulp/om/dev1", "pulp.Battery"));
+    REQUIRE(has("/pulp/om/dev2", "pulp.Device"));
+
+    REQUIRE(server.unregister_object("/pulp/om"));
+}
+
 TEST_CASE("Linux portal backend honest-fails when no portal is running",
           "[platform][dbus][file-dialog][issue-301][linux]") {
     // Gated on PULP_TEST_LINUX_PORTAL_ABSENT so we never raise a real (blocking)


### PR DESCRIPTION
PR1 of the BLE-MIDI-off-Apple epic (#3801). Plan: `planning/2026-06-09-ble-midi-off-apple-plan.md` (PR1). Generic `pulp::platform::DBus` primitives the Linux BlueZ BLE-MIDI backend (PR2) needs.

## What's here
- **`connect_system()`** — connect the D-Bus SYSTEM bus (BlueZ lives there; the client was session-only). `connect_session()`/`connect_system()` now delegate to a private `connect_bus(int)`.
- **Signal subscription** — `add_signal_handler(interface, member, handler) → token` + `remove_signal_handler(token)`. Installs a lazy connection filter (`dbus_connection_add_filter`) that routes signals to matching handlers and returns NOT_YET_HANDLED so method-call routing is untouched; per-subscription match rules. Reentrancy-safe (snapshots subs before invoking). Filter removed in the dtor before the connection is freed.
- **`get_managed_objects(dest, path, per_object)`** — thin wrapper over the existing `call_method` for `org.freedesktop.DBus.ObjectManager.GetManagedObjects`, walking `a{oa{sa{sv}}}` and reporting each (object_path, interface).
- Non-Linux no-op impls for all three.

## Dependencies / NOTICE
No new software — same runtime-dlopened `libdbus-1` already used by the portal dialogs (L6a) + AT-SPI (L7).

## Verification
- **Linux VM (the authoritative path — this FFI compiles only on Linux):** builds clean; under `dbus-run-session` the new round-trip tests pass — signal subscription delivers a matching broadcast (+ non-match doesn't fire, + removal stops delivery), and `get_managed_objects` walks a mock ObjectManager. Caught + fixed one bug the agent's macOS-only build missed: a bare `iter_init(...)` in the static signal filter needed `self->`.
- macOS: `pulp-test-dbus` 31 assertions / 8 cases (no-op path); the Linux-only round-trips compile out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds D‑Bus system-bus support, signal subscriptions, and a `GetManagedObjects` helper to prepare the BlueZ BLE‑MIDI backend. Linux uses runtime‑loaded `libdbus-1`; non‑Linux is a no‑op. Part of #3801 (BLE‑MIDI off Apple).

- **New Features**
  - `connect_system()` — connect to the system bus where `org.bluez` runs. Idempotent. `connect_session()`/`connect_system()` now share a private `connect_bus(int)`.
  - Signal subscription — `add_signal_handler` / `remove_signal_handler`; per-subscription match rules; connection filter via `dbus_connection_add_filter`; handlers run during dispatch and are safe to add/remove reentrantly; filter removed in the destructor.
  - `get_managed_objects(dest, path, per_object)` — wraps `org.freedesktop.DBus.ObjectManager.GetManagedObjects`; reports each (object, interface) and skips properties.

<sup>Written for commit 8ae0f62dba151de740eaf879d9ad662332ab4c84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

