### PR TITLE
ci(release): restore linux-arm64 Skia asset pin (chrome/m150) to unblock CLI/SDK releases

### DIFF
--- a/tools/deps/manifest.json
+++ b/tools/deps/manifest.json
@@ -655,7 +655,7 @@
       "upstream": { "kind": "none" },
       "documented_in_dependencies_md": true,
       "documented_in_notice_md": true,
-      "notes": "Prebuilt via skia-builder (danielraffel fork: https://github.com/danielraffel/skia-builder) for Pulp rendering. The fork tracks olilarkin/skia-builder's tag pattern and adds iOS device/simulator, visionOS, mac-x86_64, and Skia.xcframework slices the upstream does not ship. The chrome/m150 release does not ship a linux-arm64 slice (m149 did); Linux arm64 stays on the m149 asset or rebuilds from source via tools/build-skia.sh until the fork republishes it. Visual harness determinism locks Skia plus its bundled HarfBuzz and ICU DEPS revisions; regenerate raster goldens only when any pinned Skia asset, bundled text dependency, font file, or sampler/render configuration changes.",
+      "notes": "Prebuilt via skia-builder (danielraffel fork: https://github.com/danielraffel/skia-builder) for Pulp rendering. The fork tracks olilarkin/skia-builder's tag pattern and adds iOS device/simulator, visionOS, mac-x86_64, and Skia.xcframework slices the upstream does not ship. The chrome/m150 release ships all platform slices including linux-arm64 (the linux-arm64 slice was republished after an initial m150 gap that hard-failed release-cli.yml's linux-arm64 leg under PULP_REQUIRE_GPU_FOR_SDK and stalled CLI/SDK publishing). Visual harness determinism locks Skia plus its bundled HarfBuzz and ICU DEPS revisions; regenerate raster goldens only when any pinned Skia asset, bundled text dependency, font file, or sampler/render configuration changes.",
       "determinism": {
         "skia_branch": "chrome/m150",
         "skia_builder_fork": "https://github.com/danielraffel/skia-builder",
@@ -668,6 +668,10 @@
           "ios-simulator-arm64-x86_64": {
             "url": "https://github.com/danielraffel/skia-builder/releases/download/chrome/m150/skia-build-ios-simulator-arm64-x86_64-gpu-release.zip",
             "sha256": "86a60cf963b41da8d30a46e98bb69d24a8bc7f102d8c0908087c9a8be3aa6a75"
+          },
+          "linux-arm64": {
+            "url": "https://github.com/danielraffel/skia-builder/releases/download/chrome/m150/skia-build-linux-arm64-gpu-release.zip",
+            "sha256": "4420a7a0dd040d6e4f07332aea3966d5d7b35cf23b02cb4501b5a877ca305aac"
           },
           "linux-x64": {
             "url": "https://github.com/danielraffel/skia-builder/releases/download/chrome/m150/skia-build-linux-x64-gpu-release.zip",


### PR DESCRIPTION
Restores the `linux-arm64` Skia release-asset pin in `tools/deps/manifest.json`.

**Why releases were stuck:** the skia-builder `chrome/m150` release initially shipped every platform slice *except* `linux-arm64`, so the manifest had no linux-arm64 entry. `release-cli.yml`'s linux-arm64 leg then hard-failed at configure (`PULP_REQUIRE_GPU_FOR_SDK=ON` + `Skia not found`), and because the publish `release` job is gated on every CLI build leg, **no GitHub release published** — freezing the releases page at CLI v0.371.1 while `main` advanced to v0.395.0 (stuck draft).

skia-builder has republished the linux-arm64 slice on `chrome/m150` (sha256 `4420a7a0…ca305aac`). This pins it back so `fetch_skia_for_release.py` resolves it and the linux-arm64 leg builds like every other platform.

After merge: cut the release (re-run release-cli for the current tag with the overlay, or the next bump auto-tags).

Awareness/alerting follow-up so this screams next time: #3815.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the `linux-arm64` Skia `chrome/m150` asset pin so the linux-arm64 CLI build finds Skia and releases can publish again. This unblocks the release pipeline under `PULP_REQUIRE_GPU_FOR_SDK=ON`.

- **Dependencies**
  - Added `linux-arm64` Skia asset for `chrome/m150` with sha256 `4420a7a0dd040d6e4f07332aea3966d5d7b35cf23b02cb4501b5a877ca305aac`.
  - Updated manifest notes; `fetch_skia_for_release.py` now resolves it and the linux-arm64 leg builds with GPU like other platforms.

- **Migration**
  - Re-run the release workflow for the current tag, or wait for the next version bump to auto-publish.

<sup>Written for commit dfef7d3d95735db01fc4a9ea13e0d95d1f01a546. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

