### PR TITLE
chore: bump versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.395.0
+    VERSION 0.396.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
Cut **SDK v0.396.0** — the first release to publish since CLI v0.371.1.

The releases page was frozen because `release-cli.yml`'s linux-arm64 leg hard-failed on the missing chrome/m150 linux-arm64 Skia slice (fixed in #3817, now on main). With the manifest pin restored, the v0.396.0 tag will build all CLI platforms and the `release` job will publish.

v0.396.0 bundles the SvgPath work merged at v0.395.0..main into a real, installable release: fillRule (#3794), fillGradient + rect/line live-update + raster proof (#3802), and the JSX-parity contract (#3810).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the SDK to v0.396.0 to cut a release that builds on all CLI platforms and restores publishing after the linux-arm64 fix. This release bundles recent SvgPath work: fillRule, fillGradient, rect/line live updates, raster proof, and the JSX-parity contract.

<sup>Written for commit a2fa3713a473d6d61027501032f928da7b26a96f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

