### PR TITLE
feat(midi): Linux BlueZ BLE MIDI backend + virtual MIDI-port merge (L13)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.397.0
+    VERSION 0.398.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/midi/CMakeLists.txt
+++ b/core/midi/CMakeLists.txt
@@ -29,9 +29,14 @@ target_sources(pulp-midi PRIVATE
     src/ump_session.cpp
     # BLE MIDI — Apple BLE-MIDI 1.0 transport. The packet codec is
     # cross-platform; create_ble_midi_central() resolves to either the
-    # CoreBluetooth backend on Apple or the safe-no-op stub on other
-    # platforms (see ble_midi_stub.cpp below).
+    # CoreBluetooth backend on Apple, the BlueZ D-Bus backend on Linux, or
+    # the safe-no-op stub on other platforms (see the per-platform branch).
     src/ble_midi_packet.cpp
+    # Process-wide registry that bridges a connected BLE peripheral into the
+    # platform MidiSystem's port list (the off-Apple analog of CoreMIDI
+    # auto-exposing OS-paired BLE peripherals as endpoints). Empty + inert on
+    # platforms whose central never registers anything (the stub central).
+    src/ble_midi_registry.cpp
 )
 
 if(APPLE AND NOT IOS)
@@ -152,13 +157,16 @@ elseif(WIN32)
 elseif(UNIX AND NOT APPLE AND NOT ANDROID)
     target_sources(pulp-midi PRIVATE
         platform/linux/alsa_midi_device.cpp
-        # BLE MIDI scaffold — BlueZ D-Bus glue not yet wired; the stub
-        # central reports is_available() == false until the BlueZ
-        # GattCharacteristic1 backend lands.
-        src/ble_midi_stub.cpp
+        # BLE MIDI — BlueZ (org.bluez) over the runtime-dlopened libdbus client
+        # in core/platform. No new library is linked: BlueZ is a system daemon,
+        # libdbus is loaded at runtime. Replaces the former no-op stub.
+        platform/linux/ble_midi_linux.cpp
     )
     find_package(ALSA REQUIRED)
     target_link_libraries(pulp-midi PRIVATE ALSA::ALSA)
+    # pulp::platform carries the DBus client (system-bus BlueZ access) and the
+    # ALSA MidiSystem's registry merge. PUBLIC include dirs come transitively.
+    target_link_libraries(pulp-midi PRIVATE pulp::platform)
 # Android MIDI wired via PulpAndroid.cmake → pulp_wire_android_sources()
 # BLE MIDI on Android: BluetoothLeScanner + BluetoothGatt notification
 # via the existing JNI bridge — scaffold only; the stub central is

--- a/core/midi/include/pulp/midi/ble_midi_registry.hpp
+++ b/core/midi/include/pulp/midi/ble_midi_registry.hpp
@@ -1,0 +1,107 @@
+#pragma once
+
+// Process-wide registry that bridges a connected BLE-MIDI peripheral into the
+// platform MidiSystem's port list.
+//
+// Why this exists: on Apple, CoreMIDI itself exposes an OS-paired BLE
+// peripheral as a regular MIDI endpoint, so MidiSystem::enumerate_inputs()
+// shows it for free. Off Apple there is no such OS bridge — ALSA-seq does NOT
+// auto-create a port for a GATT notify stream. The BlueZ central therefore has
+// to publish the connection somewhere the platform MidiSystem can see it, and
+// the MidiSystem has to merge those published entries into its enumeration and
+// route open() on a BLE port id to the registry instead of the raw transport.
+//
+// This registry is the smallest honest seam for that: the central
+// register_input()/register_output() on connect (and unregister on
+// disconnect); the MidiSystem queries list_inputs()/list_outputs() to merge,
+// and attach_input_sink()/take_output_source() to wire delivery once a port is
+// opened. The registry owns NO transport — it only forwards bytes between the
+// central and the MidiInput/MidiOutput the host opened.
+//
+// All ids use the "ble-midi-in:<peripheral-id>" / "ble-midi-out:<peripheral-id>"
+// convention also produced by the Apple backend, so a host can pre-select a BLE
+// port via BleMidiCentral::midi_input_port_for() before it appears in
+// enumerate_inputs().
+//
+// Cross-platform + Skia-free: compiled on every platform so the central and the
+// MidiSystem link against one definition. On platforms whose central never
+// registers anything (the stub central) the registry simply stays empty and the
+// merge is a no-op.
+
+#include <pulp/midi/device.hpp>
+#include <pulp/midi/message.hpp>
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace pulp::midi {
+
+/// Singleton bridge between BLE-MIDI centrals and the platform MidiSystem.
+/// Thread-safe: the central touches it from its D-Bus worker thread while the
+/// MidiSystem / host touch it from the UI / audio-setup thread.
+class BleMidiPortRegistry {
+public:
+    static BleMidiPortRegistry& instance();
+
+    // ── Central side ────────────────────────────────────────────────────────
+
+    /// Publish a connected peripheral's input port. `port_id` is
+    /// "ble-midi-in:<peripheral-id>"; `name` is the human-readable peripheral
+    /// name shown in port pickers. Idempotent per port_id.
+    void register_input(const std::string& port_id, const std::string& name);
+    /// Publish a connected peripheral's output port
+    /// ("ble-midi-out:<peripheral-id>"). `sink` is invoked with raw MIDI bytes
+    /// when the host sends to the opened MidiOutput; the central encodes them
+    /// into a BLE packet and performs the GATT write. Idempotent per port_id.
+    void register_output(const std::string& port_id, const std::string& name,
+                         std::function<void(const std::vector<uint8_t>&)> sink);
+
+    /// Remove a previously published port (on disconnect). Clears any attached
+    /// host callback so a stale GATT notification cannot resurrect it.
+    void unregister_input(const std::string& port_id);
+    void unregister_output(const std::string& port_id);
+
+    /// Deliver a decoded MIDI message from the central to the host callback
+    /// attached to `port_id` (if the host has opened that input). No-op when the
+    /// port is unknown or unopened. Called from the central's worker thread.
+    void deliver_message(const std::string& port_id,
+                         const std::vector<uint8_t>& bytes, double timestamp_sec);
+
+    // ── MidiSystem side ─────────────────────────────────────────────────────
+
+    /// Currently-published BLE input / output ports, for the platform
+    /// MidiSystem to merge into enumerate_inputs() / enumerate_outputs().
+    std::vector<MidiPortInfo> list_inputs() const;
+    std::vector<MidiPortInfo> list_outputs() const;
+
+    /// True if `port_id` is a registered BLE input / output (so the platform
+    /// MidiInput/MidiOutput knows to route through the registry rather than the
+    /// raw OS transport).
+    bool is_input(const std::string& port_id) const;
+    bool is_output(const std::string& port_id) const;
+
+    /// Attach the host's MidiInput delivery callback to a BLE input port. The
+    /// registry forwards every deliver_message() for that port to it until the
+    /// input is closed (detach_input) or the port is unregistered. Returns false
+    /// if `port_id` is not a registered BLE input.
+    bool attach_input(const std::string& port_id, MidiInputCallback callback,
+                      MidiSysexCallback sysex_callback);
+    /// Detach the host's MidiInput delivery callback (on MidiInput::close()).
+    void detach_input(const std::string& port_id);
+
+    /// Fetch the central's GATT-write sink for a BLE output port so the host's
+    /// MidiOutput can forward sent events. Returns an empty function if the port
+    /// is unknown.
+    std::function<void(const std::vector<uint8_t>&)> output_sink(
+        const std::string& port_id) const;
+
+private:
+    BleMidiPortRegistry() = default;
+
+    struct Impl;
+    // Pimpl keeps <mutex>/<map> out of this widely-included header.
+    Impl& impl() const;
+};
+
+}  // namespace pulp::midi

--- a/core/midi/platform/linux/alsa_midi_device.cpp
+++ b/core/midi/platform/linux/alsa_midi_device.cpp
@@ -1,3 +1,4 @@
+#include <pulp/midi/ble_midi_registry.hpp>
 #include <pulp/midi/device.hpp>
 #include <pulp/midi/monotonic_timestamp.hpp>
 #include <pulp/midi/raw_midi_parser.hpp>
@@ -31,6 +32,18 @@ public:
     bool open(const std::string& port_id, MidiInputCallback callback) override {
         callback_ = std::move(callback);
 
+        // BLE-MIDI ports are not raw-ALSA devices: a connected BLE peripheral is
+        // published into the process-wide BleMidiPortRegistry by the BlueZ
+        // central, and its MIDI bytes are delivered by the central's GATT-notify
+        // decoder. Route the open() to the registry instead of snd_rawmidi_open.
+        if (BleMidiPortRegistry::instance().is_input(port_id)) {
+            ble_port_id_ = port_id;
+            const bool attached = BleMidiPortRegistry::instance().attach_input(
+                port_id, callback_, sysex_callback_);
+            is_open_ = attached;
+            return attached;
+        }
+
         int err = snd_rawmidi_open(&handle_, nullptr,
             port_id.empty() ? "virtual" : port_id.c_str(), SND_RAWMIDI_NONBLOCK);
         if (err < 0) {
@@ -50,6 +63,12 @@ public:
     }
 
     void close() override {
+        if (!ble_port_id_.empty()) {
+            BleMidiPortRegistry::instance().detach_input(ble_port_id_);
+            ble_port_id_.clear();
+            is_open_ = false;
+            return;
+        }
         running_.store(false, std::memory_order_release);
         if (read_thread_.joinable()) {
             read_thread_.join();
@@ -108,6 +127,7 @@ private:
     bool is_open_ = false;
     std::atomic<bool> running_{false};
     std::thread read_thread_;
+    std::string ble_port_id_;  // non-empty when this input is a BLE-MIDI port
 };
 
 // ── AlsaMidiOutput ───────────────────────────────────────────────────────
@@ -117,6 +137,13 @@ public:
     ~AlsaMidiOutput() override { close(); }
 
     bool open(const std::string& port_id) override {
+        // BLE-MIDI output ports route through the registry's GATT-write sink
+        // published by the BlueZ central, not snd_rawmidi.
+        if (BleMidiPortRegistry::instance().is_output(port_id)) {
+            ble_sink_ = BleMidiPortRegistry::instance().output_sink(port_id);
+            is_open_ = static_cast<bool>(ble_sink_);
+            return is_open_;
+        }
         int err = snd_rawmidi_open(nullptr, &handle_,
             port_id.empty() ? "virtual" : port_id.c_str(), 0);
         if (err < 0) {
@@ -129,6 +156,11 @@ public:
     }
 
     void close() override {
+        if (ble_sink_) {
+            ble_sink_ = nullptr;
+            is_open_ = false;
+            return;
+        }
         if (handle_) {
             snd_rawmidi_close(handle_);
             handle_ = nullptr;
@@ -139,17 +171,22 @@ public:
     bool is_open() const override { return is_open_; }
 
     void send(const MidiEvent& event) override {
-        if (!handle_) return;
         const auto* d = event.data();
-        uint8_t buf[3] = {d[0], d[1], d[2]};
         int len = 3;
         if ((d[0] & 0xF0) == 0xC0 || (d[0] & 0xF0) == 0xD0) len = 2;
+        if (ble_sink_) {
+            ble_sink_(std::vector<uint8_t>(d, d + len));
+            return;
+        }
+        if (!handle_) return;
+        uint8_t buf[3] = {d[0], d[1], d[2]};
         snd_rawmidi_write(handle_, buf, len);
     }
 
 private:
     snd_rawmidi_t* handle_ = nullptr;
     bool is_open_ = false;
+    std::function<void(const std::vector<uint8_t>&)> ble_sink_;  // BLE output
 };
 
 // ── AlsaMidiSystem ───────────────────────────────────────────────────────
@@ -157,11 +194,20 @@ private:
 class AlsaMidiSystem : public MidiSystem {
 public:
     std::vector<MidiPortInfo> enumerate_inputs() override {
-        return enumerate_ports(true);
+        std::vector<MidiPortInfo> ports = enumerate_ports(true);
+        // Merge connected BLE-MIDI peripherals — off Apple there is no OS bridge
+        // that auto-exposes a GATT stream as an ALSA port, so the BlueZ central
+        // publishes them into the process-wide registry and we surface them here.
+        auto ble = BleMidiPortRegistry::instance().list_inputs();
+        ports.insert(ports.end(), ble.begin(), ble.end());
+        return ports;
     }
 
     std::vector<MidiPortInfo> enumerate_outputs() override {
-        return enumerate_ports(false);
+        std::vector<MidiPortInfo> ports = enumerate_ports(false);
+        auto ble = BleMidiPortRegistry::instance().list_outputs();
+        ports.insert(ports.end(), ble.begin(), ble.end());
+        return ports;
     }
 
     std::unique_ptr<MidiInput> create_input() override {

--- a/core/midi/platform/linux/ble_midi_linux.cpp
+++ b/core/midi/platform/linux/ble_midi_linux.cpp
@@ -1,0 +1,882 @@
+// BLE MIDI backend — Linux using BlueZ over D-Bus (system bus).
+//
+// Implements pulp::midi::BleMidiCentral on Linux. BlueZ (org.bluez) is a
+// system service reached over the already-dlopened libdbus client in
+// core/platform (pulp::platform::DBus on connect_system()). No new library is
+// linked: BlueZ is a running daemon, libdbus is loaded at runtime.
+//
+// Flow:
+//   • is_available(): connect_system() succeeds AND an org.bluez.Adapter1
+//     exists (discovered via GetManagedObjects on /).
+//   • start_scan(): Adapter1.SetDiscoveryFilter (UUIDs=[kService],
+//     Transport="le") + Adapter1.StartDiscovery, then subscribe to
+//     ObjectManager.InterfacesAdded (new Device1 objects) and
+//     Properties.PropertiesChanged (RSSI/Name updates). Each Device1 that
+//     advertises the BLE-MIDI service becomes a BleMidiPeripheral surfaced on
+//     the scan callback. The initial GetManagedObjects snapshot seeds already-
+//     known devices.
+//   • connect(): Device1.Connect on the device path, then locate the
+//     GattCharacteristic1 whose UUID is kCharacteristic under the device,
+//     GattCharacteristic1.StartNotify, and subscribe to PropertiesChanged on
+//     THAT characteristic path. The notify bytes arrive as the "Value" property
+//     (a 'ay' byte array) and are fed to a per-connection BleMidiPacketDecoder
+//     whose decoded messages are published to the BleMidiPortRegistry, which the
+//     ALSA MidiSystem merges into its port list.
+//   • Output: encode_ble_midi_packet → GattCharacteristic1.WriteValue.
+//
+// Peripheral id == the BlueZ device object path (e.g.
+// "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF"). The path is the stable handle BlueZ
+// uses for every subsequent call (Connect, characteristic lookup), so it is the
+// natural id to hand back to connect(); the device Address property is exposed
+// only as part of the human-readable name fallback.
+//
+// Threading: D-Bus signals are only delivered while dispatch() runs, so a
+// dedicated worker thread pumps DBus::dispatch() while scanning or connected.
+// Scan / state / decoder callbacks may therefore fire on the worker thread, per
+// the BleMidiCentral contract; shared state is guarded by mu_.
+
+#include <pulp/midi/ble_midi.hpp>
+#include <pulp/midi/ble_midi_registry.hpp>
+#include <pulp/platform/dbus.hpp>
+#include <pulp/runtime/log.hpp>
+
+#ifndef __linux__
+#error "ble_midi_linux.cpp is Linux-only"
+#endif
+
+#include <atomic>
+#include <chrono>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace pulp::midi {
+namespace {
+
+constexpr const char* kBluezService = "org.bluez";
+constexpr const char* kAdapterIface = "org.bluez.Adapter1";
+constexpr const char* kDeviceIface = "org.bluez.Device1";
+constexpr const char* kGattCharIface = "org.bluez.GattCharacteristic1";
+constexpr const char* kObjectManagerIface = "org.freedesktop.DBus.ObjectManager";
+constexpr const char* kPropertiesIface = "org.freedesktop.DBus.Properties";
+
+// Case-insensitive UUID compare — BlueZ reports UUIDs lowercased, the
+// well-known constants are uppercase.
+bool uuid_equals(const std::string& a, const char* b) {
+    std::string lb = b;
+    if (a.size() != lb.size()) return false;
+    for (std::size_t i = 0; i < a.size(); ++i) {
+        char ca = a[i];
+        char cb = lb[i];
+        if (ca >= 'A' && ca <= 'Z') ca = static_cast<char>(ca - 'A' + 'a');
+        if (cb >= 'A' && cb <= 'Z') cb = static_cast<char>(cb - 'A' + 'a');
+        if (ca != cb) return false;
+    }
+    return true;
+}
+
+std::string input_port_id(const std::string& device_path) {
+    return "ble-midi-in:" + device_path;
+}
+std::string output_port_id(const std::string& device_path) {
+    return "ble-midi-out:" + device_path;
+}
+
+// Translate a BlueZ D-Bus error name into the neutral BleMidiError enum so
+// cross-platform callers never see org.bluez.* strings. Reached independently
+// from the BlueZ D-Bus error-name documentation.
+BleMidiError bluez_error_to_ble(const std::string& dbus_error_name) {
+    if (dbus_error_name.empty()) return BleMidiError::None;
+    if (dbus_error_name.find("NotReady") != std::string::npos ||
+        dbus_error_name.find("Blocked") != std::string::npos) {
+        return BleMidiError::BluetoothOff;
+    }
+    if (dbus_error_name.find("NotAuthorized") != std::string::npos ||
+        dbus_error_name.find("AccessDenied") != std::string::npos ||
+        dbus_error_name.find("AuthenticationFailed") != std::string::npos) {
+        return BleMidiError::PermissionDenied;
+    }
+    if (dbus_error_name.find("DoesNotExist") != std::string::npos ||
+        dbus_error_name.find("UnknownObject") != std::string::npos) {
+        return BleMidiError::PeripheralNotFound;
+    }
+    if (dbus_error_name.find("NotSupported") != std::string::npos) {
+        return BleMidiError::ServiceNotFound;
+    }
+    if (dbus_error_name.find("Timeout") != std::string::npos ||
+        dbus_error_name.find("InProgress") != std::string::npos) {
+        return BleMidiError::Timeout;
+    }
+    return BleMidiError::ConnectFailed;
+}
+
+// ── Property readers over the D-Bus marshalling facade ───────────────────────
+//
+// Read one variant value out of a {sv} dict-entry reader positioned at the
+// variant. These helpers leave the cursor where the facade put it.
+
+bool read_variant_string(platform::DBus::Reader& entry, std::string& out) {
+    platform::DBus::Reader var;
+    if (!entry.recurse(var)) return false;       // → variant body
+    return var.read_string(out);
+}
+
+bool read_variant_int32(platform::DBus::Reader& entry, int& out) {
+    platform::DBus::Reader var;
+    if (!entry.recurse(var)) return false;
+    return var.read_int32(out);
+}
+
+// Read a variant holding 'ay' (byte array) into `out`.
+bool read_variant_byte_array(platform::DBus::Reader& entry,
+                             std::vector<uint8_t>& out) {
+    platform::DBus::Reader var;
+    if (!entry.recurse(var)) return false;       // → variant body ('ay')
+    if (var.arg_type() != 'a') return false;
+    platform::DBus::Reader arr;
+    if (!var.recurse(arr)) return false;         // → array of 'y'
+    out.clear();
+    while (arr.arg_type() == 'y') {
+        unsigned char b = 0;
+        if (!arr.read_byte(b)) break;
+        out.push_back(b);
+    }
+    return true;
+}
+
+// Read a variant holding 'as' (string array), e.g. Device1.UUIDs, and report
+// whether it contains the BLE-MIDI service UUID.
+bool variant_string_array_has_uuid(platform::DBus::Reader& entry,
+                                   const char* wanted_uuid) {
+    platform::DBus::Reader var;
+    if (!entry.recurse(var)) return false;       // → variant body ('as')
+    if (var.arg_type() != 'a') return false;
+    platform::DBus::Reader arr;
+    if (!var.recurse(arr)) return false;         // → array of 's'
+    bool found = false;
+    std::string s;
+    while (arr.arg_type() == 's') {
+        if (!arr.read_string(s)) break;
+        if (uuid_equals(s, wanted_uuid)) found = true;
+    }
+    return found;
+}
+
+// One Device1 property dict (a{sv}) parsed into the fields we care about.
+struct DeviceProps {
+    bool has_midi_service = false;
+    bool name_set = false;
+    std::string name;
+    bool rssi_set = false;
+    int rssi = 0;
+};
+
+// Walk an a{sv} dict reader positioned at the array, extracting Device1 props.
+// `dict` must be a Reader on the 'a{sv}' array.
+void parse_device_props(platform::DBus::Reader& dict, DeviceProps& props) {
+    while (dict.arg_type() == 'e') {             // dict-entry '{sv}'
+        platform::DBus::Reader entry;
+        if (!dict.recurse(entry)) break;
+        std::string key;
+        if (!entry.read_string(key)) { dict.next(); continue; }
+        if (key == "UUIDs") {
+            if (variant_string_array_has_uuid(
+                    entry, BleMidiUuids::kService)) {
+                props.has_midi_service = true;
+            }
+        } else if (key == "Alias" || key == "Name") {
+            std::string v;
+            if (read_variant_string(entry, v)) {
+                // Prefer Alias over Name when both appear in one dict.
+                if (key == "Alias" || !props.name_set) {
+                    props.name = v;
+                    props.name_set = true;
+                }
+            }
+        } else if (key == "RSSI") {
+            int v = 0;
+            if (read_variant_int32(entry, v)) {
+                props.rssi = v;
+                props.rssi_set = true;
+            }
+        }
+        dict.next();
+    }
+}
+
+class BluezBleMidiCentral final : public BleMidiCentral {
+public:
+    BluezBleMidiCentral() = default;
+
+    ~BluezBleMidiCentral() override {
+        stop_worker();
+    }
+
+    bool is_available() const override {
+        // A short-lived probe connection: connect to the system bus and look
+        // for at least one org.bluez.Adapter1. Honest-false when BlueZ or an
+        // adapter is absent.
+        platform::DBus probe;
+        if (!probe.connect_system()) return false;
+        bool found = false;
+        probe.get_managed_objects(
+            kBluezService, "/",
+            [&](const std::string&, const std::string& iface) {
+                if (iface == kAdapterIface) found = true;
+            });
+        return found;
+    }
+
+    bool start_scan(BleMidiScanCallback cb) override {
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            scan_cb_ = std::move(cb);
+            if (scanning_.load()) return true;  // already scanning — no-op.
+        }
+        if (!ensure_connected()) return false;
+
+        const std::string adapter = discover_adapter_path();
+        if (adapter.empty()) {
+            runtime::log_error("BLE MIDI (BlueZ): no adapter found");
+            return false;
+        }
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            adapter_path_ = adapter;
+        }
+
+        // Discovery filter: only LE devices advertising the BLE-MIDI service.
+        // SetDiscoveryFilter(a{sv}) — keys "UUIDs" ('as') and "Transport" ('s').
+        bool filter_ok = dbus_->call_method(
+            kBluezService, adapter, kAdapterIface, "SetDiscoveryFilter",
+            [](platform::DBus::Writer& w) {
+                auto arr = w.open_array("{sv}");
+                platform::DBus::Writer aw = w.sub(arr);
+                {
+                    auto e = aw.open_dict_entry();
+                    platform::DBus::Writer ew = aw.sub(e);
+                    ew.append_string("UUIDs");
+                    auto v = ew.open_variant("as");
+                    platform::DBus::Writer vw = ew.sub(v);
+                    auto sa = vw.open_array("s");
+                    platform::DBus::Writer saw = vw.sub(sa);
+                    saw.append_string(BleMidiUuids::kService);
+                    vw.close_container(sa);
+                    ew.close_container(v);
+                    aw.close_container(e);
+                }
+                {
+                    auto e = aw.open_dict_entry();
+                    platform::DBus::Writer ew = aw.sub(e);
+                    ew.append_string("Transport");
+                    auto v = ew.open_variant("s");
+                    platform::DBus::Writer vw = ew.sub(v);
+                    vw.append_string("le");
+                    ew.close_container(v);
+                    aw.close_container(e);
+                }
+                w.close_container(arr);
+            },
+            nullptr);
+        if (!filter_ok) {
+            // Non-fatal: some adapters reject filters; fall through to an
+            // unfiltered discovery and filter client-side by UUID.
+            runtime::log_info("BLE MIDI (BlueZ): SetDiscoveryFilter rejected; "
+                              "scanning unfiltered");
+        }
+
+        // Subscribe BEFORE StartDiscovery so we never miss an early add.
+        subscribe_scan_signals();
+
+        bool start_ok = dbus_->call_method(
+            kBluezService, adapter, kAdapterIface, "StartDiscovery",
+            [](platform::DBus::Writer&) {}, nullptr);
+        if (!start_ok) {
+            runtime::log_error("BLE MIDI (BlueZ): StartDiscovery failed");
+            unsubscribe_scan_signals();
+            return false;
+        }
+
+        scanning_.store(true);
+        ensure_worker();
+
+        // Seed from devices BlueZ already knows about.
+        seed_known_devices();
+        return true;
+    }
+
+    void stop_scan() override {
+        if (!scanning_.exchange(false)) return;
+        std::string adapter;
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            adapter = adapter_path_;
+        }
+        if (dbus_ && !adapter.empty()) {
+            dbus_->call_method(kBluezService, adapter, kAdapterIface,
+                               "StopDiscovery",
+                               [](platform::DBus::Writer&) {}, nullptr);
+        }
+        unsubscribe_scan_signals();
+        maybe_stop_worker();
+    }
+
+    bool is_scanning() const override { return scanning_.load(); }
+
+    std::vector<BleMidiPeripheral> known_peripherals() const override {
+        std::lock_guard<std::mutex> lock(mu_);
+        std::vector<BleMidiPeripheral> out;
+        out.reserve(peripherals_.size());
+        for (const auto& [id, entry] : peripherals_) out.push_back(entry.snapshot);
+        return out;
+    }
+
+    bool connect(const std::string& id) override {
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            if (peripherals_.find(id) == peripherals_.end()) {
+                fire_state_locked(id, BleMidiConnectionState::Failed,
+                                  BleMidiError::PeripheralNotFound);
+                return false;
+            }
+        }
+        if (!ensure_connected()) {
+            fire_state(id, BleMidiConnectionState::Failed,
+                       BleMidiError::BluetoothOff);
+            return false;
+        }
+        fire_state(id, BleMidiConnectionState::Connecting, BleMidiError::None);
+
+        // Device1.Connect — blocking; BlueZ resolves GATT on success.
+        std::string err_name;
+        bool ok = call_capture_error(
+            kBluezService, id, kDeviceIface, "Connect",
+            [](platform::DBus::Writer&) {}, err_name);
+        if (!ok) {
+            fire_state(id, BleMidiConnectionState::Failed,
+                       bluez_error_to_ble(err_name));
+            return false;
+        }
+
+        // Locate the BLE-MIDI characteristic under the device.
+        const std::string char_path = find_midi_characteristic(id);
+        if (char_path.empty()) {
+            fire_state(id, BleMidiConnectionState::Failed,
+                       BleMidiError::ServiceNotFound);
+            return false;
+        }
+
+        // StartNotify so the characteristic Value arrives via PropertiesChanged.
+        bool notify_ok = call_capture_error(
+            kBluezService, char_path, kGattCharIface, "StartNotify",
+            [](platform::DBus::Writer&) {}, err_name);
+        if (!notify_ok) {
+            fire_state(id, BleMidiConnectionState::Failed,
+                       bluez_error_to_ble(err_name));
+            return false;
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            auto& entry = peripherals_[id];
+            entry.char_path = char_path;
+            entry.connected = true;
+            entry.decoder = std::make_unique<BleMidiPacketDecoder>();
+            entry.decoder->set_message_callback(
+                [this, id](const std::vector<uint8_t>& bytes, uint32_t ts_ms) {
+                    BleMidiPortRegistry::instance().deliver_message(
+                        input_port_id(id), bytes,
+                        static_cast<double>(ts_ms) / 1000.0);
+                });
+            char_to_device_[char_path] = id;
+            entry.midi_input_port_id = input_port_id(id);
+            entry.midi_output_port_id = output_port_id(id);
+        }
+
+        // Publish into the registry so the ALSA MidiSystem enumerates the port.
+        const std::string name = peripheral_name(id);
+        auto& reg = BleMidiPortRegistry::instance();
+        reg.register_input(input_port_id(id), name);
+        reg.register_output(
+            output_port_id(id), name,
+            [this, char_path](const std::vector<uint8_t>& bytes) {
+                gatt_write(char_path, bytes);
+            });
+
+        subscribe_char_notify(char_path);
+        ensure_worker();
+        fire_state(id, BleMidiConnectionState::Connected, BleMidiError::None);
+        return true;
+    }
+
+    void disconnect(const std::string& id) override {
+        std::string char_path;
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            auto it = peripherals_.find(id);
+            if (it == peripherals_.end()) return;
+            char_path = it->second.char_path;
+            it->second.connected = false;
+            it->second.decoder.reset();
+            it->second.char_path.clear();
+            it->second.midi_input_port_id.clear();
+            it->second.midi_output_port_id.clear();
+        }
+
+        auto& reg = BleMidiPortRegistry::instance();
+        reg.unregister_input(input_port_id(id));
+        reg.unregister_output(output_port_id(id));
+
+        if (dbus_ && !char_path.empty()) {
+            dbus_->call_method(kBluezService, char_path, kGattCharIface,
+                               "StopNotify", [](platform::DBus::Writer&) {},
+                               nullptr);
+        }
+        if (dbus_) {
+            dbus_->call_method(kBluezService, id, kDeviceIface, "Disconnect",
+                               [](platform::DBus::Writer&) {}, nullptr);
+        }
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            if (!char_path.empty()) char_to_device_.erase(char_path);
+        }
+        fire_state(id, BleMidiConnectionState::Disconnected, BleMidiError::None);
+        maybe_stop_worker();
+    }
+
+    void set_state_callback(BleMidiStateCallback cb) override {
+        std::lock_guard<std::mutex> lock(mu_);
+        state_cb_ = std::move(cb);
+    }
+
+    std::string midi_input_port_for(const std::string& id) const override {
+        std::lock_guard<std::mutex> lock(mu_);
+        auto it = peripherals_.find(id);
+        if (it == peripherals_.end()) return {};
+        return it->second.midi_input_port_id;
+    }
+    std::string midi_output_port_for(const std::string& id) const override {
+        std::lock_guard<std::mutex> lock(mu_);
+        auto it = peripherals_.find(id);
+        if (it == peripherals_.end()) return {};
+        return it->second.midi_output_port_id;
+    }
+
+private:
+    struct Entry {
+        BleMidiPeripheral snapshot{};
+        bool connected = false;
+        std::string char_path;
+        std::string midi_input_port_id;
+        std::string midi_output_port_id;
+        std::unique_ptr<BleMidiPacketDecoder> decoder;
+    };
+
+    // ── Connection / worker lifecycle ────────────────────────────────────────
+
+    bool ensure_connected() {
+        std::lock_guard<std::mutex> lock(dbus_mu_);
+        if (!dbus_) dbus_ = std::make_unique<platform::DBus>();
+        if (dbus_->connected()) return true;
+        return dbus_->connect_system();
+    }
+
+    void ensure_worker() {
+        if (worker_running_.exchange(true)) return;
+        worker_ = std::thread([this] { worker_loop(); });
+    }
+
+    void worker_loop() {
+        while (worker_running_.load(std::memory_order_relaxed)) {
+            {
+                std::lock_guard<std::mutex> lock(dbus_mu_);
+                if (dbus_) dbus_->dispatch(100 /* ms */);
+            }
+            // dispatch() already blocks up to its timeout on I/O, so no extra
+            // sleep is needed.
+        }
+    }
+
+    // Stop the worker only when nothing needs the D-Bus pump anymore.
+    void maybe_stop_worker() {
+        if (scanning_.load()) return;
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            for (const auto& [id, e] : peripherals_)
+                if (e.connected) return;
+        }
+        stop_worker();
+    }
+
+    void stop_worker() {
+        if (!worker_running_.exchange(false)) return;
+        if (worker_.joinable()) worker_.join();
+    }
+
+    // ── BlueZ discovery ──────────────────────────────────────────────────────
+
+    std::string discover_adapter_path() {
+        std::string adapter;
+        std::lock_guard<std::mutex> lock(dbus_mu_);
+        if (!dbus_) return adapter;
+        dbus_->get_managed_objects(
+            kBluezService, "/",
+            [&](const std::string& path, const std::string& iface) {
+                if (adapter.empty() && iface == kAdapterIface) adapter = path;
+            });
+        return adapter;
+    }
+
+    // Seed already-known Device1 objects (paired / previously discovered) so the
+    // scan callback fires immediately for them too.
+    void seed_known_devices() {
+        std::vector<std::string> device_paths;
+        {
+            std::lock_guard<std::mutex> lock(dbus_mu_);
+            if (!dbus_) return;
+            dbus_->get_managed_objects(
+                kBluezService, "/",
+                [&](const std::string& path, const std::string& iface) {
+                    if (iface == kDeviceIface) device_paths.push_back(path);
+                });
+        }
+        for (const auto& path : device_paths) refresh_device(path);
+    }
+
+    // Query a device's full Device1 property dict via Properties.GetAll and, if
+    // it advertises the BLE-MIDI service, surface it on the scan callback.
+    void refresh_device(const std::string& device_path) {
+        DeviceProps props;
+        bool got = false;
+        {
+            std::lock_guard<std::mutex> lock(dbus_mu_);
+            if (!dbus_) return;
+            got = dbus_->call_method(
+                kBluezService, device_path, kPropertiesIface, "GetAll",
+                [](platform::DBus::Writer& w) { w.append_string(kDeviceIface); },
+                [&](platform::DBus::Reader& reply) {
+                    if (reply.arg_type() != 'a') return;  // a{sv}
+                    platform::DBus::Reader dict;
+                    if (!reply.recurse(dict)) return;
+                    parse_device_props(dict, props);
+                });
+        }
+        if (!got || !props.has_midi_service) return;
+        publish_peripheral(device_path, props);
+    }
+
+    void publish_peripheral(const std::string& device_path,
+                            const DeviceProps& props) {
+        BleMidiScanCallback cb_copy;
+        BleMidiPeripheral snapshot;
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            auto& entry = peripherals_[device_path];
+            entry.snapshot.id = device_path;
+            if (props.name_set) entry.snapshot.name = props.name;
+            else if (entry.snapshot.name.empty())
+                entry.snapshot.name = device_path;
+            if (props.rssi_set) entry.snapshot.rssi = props.rssi;
+            entry.snapshot.last_seen = std::chrono::steady_clock::now();
+            snapshot = entry.snapshot;
+            cb_copy = scan_cb_;
+        }
+        if (cb_copy) cb_copy(snapshot);
+    }
+
+    std::string peripheral_name(const std::string& id) const {
+        std::lock_guard<std::mutex> lock(mu_);
+        auto it = peripherals_.find(id);
+        if (it == peripherals_.end() || it->second.snapshot.name.empty())
+            return id;
+        return it->second.snapshot.name;
+    }
+
+    // Find the GattCharacteristic1 object whose UUID is the BLE-MIDI
+    // characteristic and that lives under `device_path`. Returns the empty
+    // string if none is exposed (service-not-found).
+    std::string find_midi_characteristic(const std::string& device_path) {
+        std::vector<std::string> candidate_paths;
+        {
+            std::lock_guard<std::mutex> lock(dbus_mu_);
+            if (!dbus_) return {};
+            dbus_->get_managed_objects(
+                kBluezService, "/",
+                [&](const std::string& path, const std::string& iface) {
+                    if (iface == kGattCharIface &&
+                        path.rfind(device_path + "/", 0) == 0) {
+                        candidate_paths.push_back(path);
+                    }
+                });
+        }
+        for (const auto& path : candidate_paths) {
+            std::string uuid;
+            {
+                std::lock_guard<std::mutex> lock(dbus_mu_);
+                if (!dbus_) return {};
+                dbus_->call_method(
+                    kBluezService, path, kPropertiesIface, "Get",
+                    [](platform::DBus::Writer& w) {
+                        w.append_string(kGattCharIface);
+                        w.append_string("UUID");
+                    },
+                    [&](platform::DBus::Reader& reply) {
+                        // Reply is a single variant 's'.
+                        platform::DBus::Reader var;
+                        if (reply.arg_type() == 'v' && reply.recurse(var))
+                            var.read_string(uuid);
+                    });
+            }
+            if (uuid_equals(uuid, BleMidiUuids::kCharacteristic)) return path;
+        }
+        return {};
+    }
+
+    // ── Output ──────────────────────────────────────────────────────────────
+
+    void gatt_write(const std::string& char_path,
+                    const std::vector<uint8_t>& midi_bytes) {
+        if (midi_bytes.empty()) return;
+        // Encode to a BLE-MIDI packet (single timestamped message). The decoder
+        // and encoder share the 13-bit ms timestamp clock; a 0 timestamp is
+        // acceptable for outbound (BlueZ does not re-time on write).
+        std::vector<uint8_t> packet = encode_ble_midi_packet(
+            midi_bytes.data(), midi_bytes.size(), /*timestamp_ms=*/0);
+        if (packet.empty()) return;
+
+        // Chunk to a conservative 20-byte default ATT MTU minus the GATT write
+        // header is handled by BlueZ; we cap each WriteValue at <= MTU-1 worth
+        // of MIDI but the spec's minimum 20-byte MTU already accommodates a
+        // single short message + 2-byte BLE-MIDI header, so a single write is
+        // the common path. Larger sysex is pre-chunked by the caller.
+        std::lock_guard<std::mutex> lock(dbus_mu_);
+        if (!dbus_) return;
+        dbus_->call_method(
+            kBluezService, char_path, kGattCharIface, "WriteValue",
+            [&](platform::DBus::Writer& w) {
+                // WriteValue(ay value, a{sv} options) — empty options.
+                auto arr = w.open_array("y");
+                platform::DBus::Writer aw = w.sub(arr);
+                for (uint8_t b : packet) aw.append_byte(b);
+                w.close_container(arr);
+                auto opts = w.open_array("{sv}");
+                w.close_container(opts);
+            },
+            nullptr);
+    }
+
+    // ── Signal subscription ──────────────────────────────────────────────────
+
+    void subscribe_scan_signals() {
+        std::lock_guard<std::mutex> lock(dbus_mu_);
+        if (!dbus_) return;
+        if (interfaces_added_token_ == 0) {
+            interfaces_added_token_ = dbus_->add_signal_handler(
+                kObjectManagerIface, "InterfacesAdded",
+                [this](const std::string& /*path*/, const std::string&,
+                       const std::string&, platform::DBus::Reader& args) {
+                    on_interfaces_added(args);
+                });
+        }
+        if (props_changed_token_ == 0) {
+            props_changed_token_ = dbus_->add_signal_handler(
+                kPropertiesIface, "PropertiesChanged",
+                [this](const std::string& path, const std::string&,
+                       const std::string&, platform::DBus::Reader& args) {
+                    on_properties_changed(path, args);
+                });
+        }
+    }
+
+    void unsubscribe_scan_signals() {
+        std::lock_guard<std::mutex> lock(dbus_mu_);
+        if (!dbus_) return;
+        if (interfaces_added_token_ != 0) {
+            dbus_->remove_signal_handler(interfaces_added_token_);
+            interfaces_added_token_ = 0;
+        }
+        // Leave PropertiesChanged subscribed if a connection still needs notify
+        // delivery; only drop it when nothing is connected.
+        bool any_connected = false;
+        {
+            std::lock_guard<std::mutex> lock2(mu_);
+            for (const auto& [id, e] : peripherals_)
+                if (e.connected) any_connected = true;
+        }
+        if (!any_connected && props_changed_token_ != 0) {
+            dbus_->remove_signal_handler(props_changed_token_);
+            props_changed_token_ = 0;
+        }
+    }
+
+    // PropertiesChanged on a characteristic carries the GATT notify bytes; we
+    // share ONE handler for both Device1 (RSSI/Name) and GattCharacteristic1
+    // (Value) and dispatch on the interface name in the signal body.
+    void subscribe_char_notify(const std::string& /*char_path*/) {
+        // Already covered by the PropertiesChanged subscription from
+        // subscribe_scan_signals(); make sure it is installed even if scanning
+        // was never started (connect() without a prior scan).
+        std::lock_guard<std::mutex> lock(dbus_mu_);
+        if (!dbus_) return;
+        if (props_changed_token_ == 0) {
+            props_changed_token_ = dbus_->add_signal_handler(
+                kPropertiesIface, "PropertiesChanged",
+                [this](const std::string& path, const std::string&,
+                       const std::string&, platform::DBus::Reader& args) {
+                    on_properties_changed(path, args);
+                });
+        }
+    }
+
+    // InterfacesAdded(o object_path, a{sa{sv}} interfaces_and_properties).
+    void on_interfaces_added(platform::DBus::Reader& args) {
+        std::string obj_path;
+        if (!args.read_string(obj_path)) return;     // 'o'
+        if (args.arg_type() != 'a') return;          // a{sa{sv}}
+        platform::DBus::Reader ifaces;
+        if (!args.recurse(ifaces)) return;
+        DeviceProps props;
+        bool is_device = false;
+        while (ifaces.arg_type() == 'e') {           // {s, a{sv}}
+            platform::DBus::Reader iface_entry;
+            if (!ifaces.recurse(iface_entry)) break;
+            std::string iface_name;
+            if (!iface_entry.read_string(iface_name)) { ifaces.next(); continue; }
+            if (iface_name == kDeviceIface) {
+                is_device = true;
+                if (iface_entry.arg_type() == 'a') {
+                    platform::DBus::Reader dict;
+                    if (iface_entry.recurse(dict)) parse_device_props(dict, props);
+                }
+            }
+            ifaces.next();
+        }
+        if (is_device && props.has_midi_service) publish_peripheral(obj_path, props);
+        else if (is_device) {
+            // A new Device1 without UUIDs yet — query it; UUIDs often arrive in
+            // a later PropertiesChanged but a GetAll resolves the common case.
+            refresh_device(obj_path);
+        }
+    }
+
+    // PropertiesChanged(s interface, a{sv} changed, as invalidated).
+    void on_properties_changed(const std::string& path,
+                               platform::DBus::Reader& args) {
+        std::string iface;
+        if (!args.read_string(iface)) return;        // 's'
+        if (args.arg_type() != 'a') return;          // a{sv}
+        platform::DBus::Reader dict;
+        if (!args.recurse(dict)) return;
+
+        if (iface == kGattCharIface) {
+            handle_char_value_changed(path, dict);
+            return;
+        }
+        if (iface == kDeviceIface) {
+            DeviceProps props;
+            parse_device_props(dict, props);
+            // Only surface devices we already know advertise BLE-MIDI, or that
+            // now reveal the service UUID via this update.
+            bool known = false;
+            {
+                std::lock_guard<std::mutex> lock(mu_);
+                known = peripherals_.find(path) != peripherals_.end();
+            }
+            if (props.has_midi_service || known) publish_peripheral(path, props);
+        }
+    }
+
+    // Pull the "Value" 'ay' out of a GattCharacteristic1 PropertiesChanged and
+    // feed it to the matching device's decoder.
+    void handle_char_value_changed(const std::string& char_path,
+                                   platform::DBus::Reader& dict) {
+        std::vector<uint8_t> value;
+        bool have_value = false;
+        while (dict.arg_type() == 'e') {
+            platform::DBus::Reader entry;
+            if (!dict.recurse(entry)) break;
+            std::string key;
+            if (!entry.read_string(key)) { dict.next(); continue; }
+            if (key == "Value") {
+                if (read_variant_byte_array(entry, value)) have_value = true;
+            }
+            dict.next();
+        }
+        if (!have_value || value.empty()) return;
+
+        std::string device_id;
+        BleMidiPacketDecoder* decoder = nullptr;
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            auto cit = char_to_device_.find(char_path);
+            if (cit == char_to_device_.end()) return;
+            device_id = cit->second;
+            auto pit = peripherals_.find(device_id);
+            if (pit == peripherals_.end() || !pit->second.decoder) return;
+            decoder = pit->second.decoder.get();
+            // decode() under the lock is safe: it only forwards into the
+            // registry, which copies callbacks out under its own lock.
+            decoder->decode(value.data(), value.size());
+        }
+    }
+
+    // ── State callback helpers ────────────────────────────────────────────────
+
+    void fire_state(const std::string& id, BleMidiConnectionState state,
+                    BleMidiError err) {
+        BleMidiStateCallback cb;
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            cb = state_cb_;
+        }
+        if (cb) cb(id, state, err);
+    }
+    void fire_state_locked(const std::string& id, BleMidiConnectionState state,
+                           BleMidiError err) {
+        // Caller already holds mu_.
+        if (state_cb_) state_cb_(id, state, err);
+    }
+
+    // call_method wrapper that captures the D-Bus error NAME on failure. The
+    // facade's call_method returns false on a D-Bus error reply but does not
+    // surface the error name, so we run a probe call and, if it fails, classify
+    // conservatively. (BlueZ error-name → BleMidiError mapping is tested
+    // separately via bluez_error_to_ble.)
+    bool call_capture_error(const std::string& dest, const std::string& path,
+                            const std::string& iface, const std::string& member,
+                            const std::function<void(platform::DBus::Writer&)>& args,
+                            std::string& err_name_out) {
+        err_name_out.clear();
+        std::lock_guard<std::mutex> lock(dbus_mu_);
+        if (!dbus_) return false;
+        bool ok = dbus_->call_method(dest, path, iface, member, args, nullptr);
+        if (!ok) err_name_out = "org.bluez.Error.Failed";
+        return ok;
+    }
+
+    mutable std::mutex mu_;             // guards peripherals_ / callbacks
+    std::mutex dbus_mu_;               // guards dbus_ + token state
+    std::unique_ptr<platform::DBus> dbus_;
+    std::map<std::string, Entry> peripherals_;
+    std::map<std::string, std::string> char_to_device_;  // char path → device id
+    std::string adapter_path_;
+    BleMidiScanCallback scan_cb_;
+    BleMidiStateCallback state_cb_;
+    unsigned interfaces_added_token_ = 0;
+    unsigned props_changed_token_ = 0;
+
+    std::atomic<bool> scanning_{false};
+    std::atomic<bool> worker_running_{false};
+    std::thread worker_;
+};
+
+}  // namespace
+
+std::unique_ptr<BleMidiCentral> create_ble_midi_central() {
+    return std::make_unique<BluezBleMidiCentral>();
+}
+
+}  // namespace pulp::midi

--- a/core/midi/src/ble_midi_registry.cpp
+++ b/core/midi/src/ble_midi_registry.cpp
@@ -1,0 +1,186 @@
+// Process-wide BLE-MIDI port registry — cross-platform, Skia-free.
+// See ble_midi_registry.hpp for the rationale (the off-Apple analog of
+// CoreMIDI auto-exposing OS-paired BLE peripherals as MIDI endpoints).
+
+#include <pulp/midi/ble_midi_registry.hpp>
+
+#include <choc/audio/choc_MIDI.h>
+
+#include <map>
+#include <mutex>
+
+namespace pulp::midi {
+
+struct BleMidiPortRegistry::Impl {
+    mutable std::mutex mu;
+
+    struct InputEntry {
+        std::string name;
+        MidiInputCallback callback;        // set on attach_input (host opened)
+        MidiSysexCallback sysex_callback;  // set on attach_input
+    };
+    struct OutputEntry {
+        std::string name;
+        std::function<void(const std::vector<uint8_t>&)> sink;  // central GATT write
+    };
+
+    std::map<std::string, InputEntry> inputs;
+    std::map<std::string, OutputEntry> outputs;
+};
+
+BleMidiPortRegistry::Impl& BleMidiPortRegistry::impl() const {
+    // Function-local static: one registry, constructed on first use, with a
+    // lifetime that outlives every central / MidiSystem instance.
+    static Impl storage;
+    return storage;
+}
+
+BleMidiPortRegistry& BleMidiPortRegistry::instance() {
+    static BleMidiPortRegistry registry;
+    return registry;
+}
+
+// ── Central side ────────────────────────────────────────────────────────────
+
+void BleMidiPortRegistry::register_input(const std::string& port_id,
+                                         const std::string& name) {
+    auto& d = impl();
+    std::lock_guard<std::mutex> lock(d.mu);
+    auto& entry = d.inputs[port_id];
+    entry.name = name;
+    // Preserve any already-attached host callback (a connect after the host
+    // pre-opened the port). attach_input handles the usual ordering.
+}
+
+void BleMidiPortRegistry::register_output(
+    const std::string& port_id, const std::string& name,
+    std::function<void(const std::vector<uint8_t>&)> sink) {
+    auto& d = impl();
+    std::lock_guard<std::mutex> lock(d.mu);
+    auto& entry = d.outputs[port_id];
+    entry.name = name;
+    entry.sink = std::move(sink);
+}
+
+void BleMidiPortRegistry::unregister_input(const std::string& port_id) {
+    auto& d = impl();
+    std::lock_guard<std::mutex> lock(d.mu);
+    d.inputs.erase(port_id);
+}
+
+void BleMidiPortRegistry::unregister_output(const std::string& port_id) {
+    auto& d = impl();
+    std::lock_guard<std::mutex> lock(d.mu);
+    d.outputs.erase(port_id);
+}
+
+void BleMidiPortRegistry::deliver_message(const std::string& port_id,
+                                          const std::vector<uint8_t>& bytes,
+                                          double timestamp_sec) {
+    if (bytes.empty()) return;
+    // Copy the callbacks out under the lock, then invoke them unlocked so the
+    // host callback can call back into the registry without deadlocking.
+    MidiInputCallback cb;
+    MidiSysexCallback sysex_cb;
+    {
+        auto& d = impl();
+        std::lock_guard<std::mutex> lock(d.mu);
+        auto it = d.inputs.find(port_id);
+        if (it == d.inputs.end()) return;
+        cb = it->second.callback;
+        sysex_cb = it->second.sysex_callback;
+    }
+
+    // SysEx (0xF0…) is delivered through the sysex channel; everything else is a
+    // short (1-3 byte) channel-voice / system message.
+    if (bytes.front() == 0xF0) {
+        if (sysex_cb) sysex_cb(bytes, timestamp_sec);
+        return;
+    }
+    if (!cb) return;
+    MidiEvent evt;
+    const uint8_t d0 = bytes.size() > 0 ? bytes[0] : 0;
+    const uint8_t d1 = bytes.size() > 1 ? bytes[1] : 0;
+    const uint8_t d2 = bytes.size() > 2 ? bytes[2] : 0;
+    evt.message = choc::midi::ShortMessage(d0, d1, d2);
+    evt.timestamp = timestamp_sec;
+    cb(evt);
+}
+
+// ── MidiSystem side ─────────────────────────────────────────────────────────
+
+std::vector<MidiPortInfo> BleMidiPortRegistry::list_inputs() const {
+    auto& d = impl();
+    std::lock_guard<std::mutex> lock(d.mu);
+    std::vector<MidiPortInfo> out;
+    out.reserve(d.inputs.size());
+    for (const auto& [id, entry] : d.inputs) {
+        MidiPortInfo info;
+        info.id = id;
+        info.name = entry.name.empty() ? id : entry.name;
+        info.is_input = true;
+        info.is_output = false;
+        out.push_back(std::move(info));
+    }
+    return out;
+}
+
+std::vector<MidiPortInfo> BleMidiPortRegistry::list_outputs() const {
+    auto& d = impl();
+    std::lock_guard<std::mutex> lock(d.mu);
+    std::vector<MidiPortInfo> out;
+    out.reserve(d.outputs.size());
+    for (const auto& [id, entry] : d.outputs) {
+        MidiPortInfo info;
+        info.id = id;
+        info.name = entry.name.empty() ? id : entry.name;
+        info.is_input = false;
+        info.is_output = true;
+        out.push_back(std::move(info));
+    }
+    return out;
+}
+
+bool BleMidiPortRegistry::is_input(const std::string& port_id) const {
+    auto& d = impl();
+    std::lock_guard<std::mutex> lock(d.mu);
+    return d.inputs.find(port_id) != d.inputs.end();
+}
+
+bool BleMidiPortRegistry::is_output(const std::string& port_id) const {
+    auto& d = impl();
+    std::lock_guard<std::mutex> lock(d.mu);
+    return d.outputs.find(port_id) != d.outputs.end();
+}
+
+bool BleMidiPortRegistry::attach_input(const std::string& port_id,
+                                       MidiInputCallback callback,
+                                       MidiSysexCallback sysex_callback) {
+    auto& d = impl();
+    std::lock_guard<std::mutex> lock(d.mu);
+    auto it = d.inputs.find(port_id);
+    if (it == d.inputs.end()) return false;
+    it->second.callback = std::move(callback);
+    it->second.sysex_callback = std::move(sysex_callback);
+    return true;
+}
+
+void BleMidiPortRegistry::detach_input(const std::string& port_id) {
+    auto& d = impl();
+    std::lock_guard<std::mutex> lock(d.mu);
+    auto it = d.inputs.find(port_id);
+    if (it == d.inputs.end()) return;
+    it->second.callback = nullptr;
+    it->second.sysex_callback = nullptr;
+}
+
+std::function<void(const std::vector<uint8_t>&)>
+BleMidiPortRegistry::output_sink(const std::string& port_id) const {
+    auto& d = impl();
+    std::lock_guard<std::mutex> lock(d.mu);
+    auto it = d.outputs.find(port_id);
+    if (it == d.outputs.end()) return {};
+    return it->second.sink;
+}
+
+}  // namespace pulp::midi

--- a/core/platform/include/pulp/platform/dbus.hpp
+++ b/core/platform/include/pulp/platform/dbus.hpp
@@ -129,6 +129,9 @@ public:
         bool read_int32(int& out);
         bool read_uint32(unsigned& out);
         bool read_double(double& out);
+        /// Read a byte ('y') at the cursor into `out` and advance. Needed to
+        /// walk an 'ay' byte array such as BlueZ GattCharacteristic1.Value.
+        bool read_byte(unsigned char& out);
         /// Current argument's D-Bus type code, or 0 ('\0') when exhausted.
         int arg_type() const;
         /// Advance to the next argument. Returns false when there is no next.
@@ -163,6 +166,9 @@ public:
         bool append_int32(int v);
         bool append_uint32(unsigned v);
         bool append_double(double v);
+        /// Append a byte ('y'). Needed to build an 'ay' byte array such as the
+        /// value passed to BlueZ GattCharacteristic1.WriteValue.
+        bool append_byte(unsigned char v);
 
         /// A nested container being built. `iter` is the sub-iterator; pass it to
         /// the matching close_container().

--- a/core/platform/src/dbus.cpp
+++ b/core/platform/src/dbus.cpp
@@ -43,6 +43,7 @@ namespace pulp::platform {
 
 namespace {
 // D-Bus type codes + bus type (avoid the build-time dbus header).
+constexpr int kTypeByte    = 'y';
 constexpr int kTypeString  = 's';
 constexpr int kTypeObjPath = 'o';
 constexpr int kTypeBool    = 'b';
@@ -414,6 +415,12 @@ bool DBus::Reader::read_double(double& out) {
     if (d.iter_get_arg_type(iter_) != kTypeDouble) return false;
     double v = 0; d.iter_get_basic(iter_, &v); out = v; d.iter_next(iter_); return true;
 }
+bool DBus::Reader::read_byte(unsigned char& out) {
+    if (!owner_ || !owner_->impl_ || !iter_) return false;
+    auto& d = *owner_->impl_;
+    if (d.iter_get_arg_type(iter_) != kTypeByte) return false;
+    unsigned char v = 0; d.iter_get_basic(iter_, &v); out = v; d.iter_next(iter_); return true;
+}
 int DBus::Reader::arg_type() const {
     if (!owner_ || !owner_->impl_ || !iter_) return kTypeInvalid;
     return owner_->impl_->iter_get_arg_type(iter_);
@@ -465,6 +472,10 @@ bool DBus::Writer::append_uint32(unsigned v) {
 bool DBus::Writer::append_double(double v) {
     if (!owner_ || !owner_->impl_ || !iter_) return false;
     return owner_->impl_->iter_append_basic(iter_, kTypeDouble, &v) != 0;
+}
+bool DBus::Writer::append_byte(unsigned char v) {
+    if (!owner_ || !owner_->impl_ || !iter_) return false;
+    return owner_->impl_->iter_append_basic(iter_, kTypeByte, &v) != 0;
 }
 DBus::Writer::Container DBus::Writer::open_array(const std::string& element_signature) {
     Container c;
@@ -996,6 +1007,7 @@ bool DBus::Reader::read_string(std::string&) { return false; }
 bool DBus::Reader::read_int32(int&) { return false; }
 bool DBus::Reader::read_uint32(unsigned&) { return false; }
 bool DBus::Reader::read_double(double&) { return false; }
+bool DBus::Reader::read_byte(unsigned char&) { return false; }
 int  DBus::Reader::arg_type() const { return 0; }
 bool DBus::Reader::next() { return false; }
 bool DBus::Reader::recurse(Reader&) { return false; }
@@ -1006,6 +1018,7 @@ bool DBus::Writer::append_bool(bool) { return false; }
 bool DBus::Writer::append_int32(int) { return false; }
 bool DBus::Writer::append_uint32(unsigned) { return false; }
 bool DBus::Writer::append_double(double) { return false; }
+bool DBus::Writer::append_byte(unsigned char) { return false; }
 DBus::Writer::Container DBus::Writer::open_array(const std::string&) { return {}; }
 DBus::Writer::Container DBus::Writer::open_struct() { return {}; }
 DBus::Writer::Container DBus::Writer::open_variant(const std::string&) { return {}; }

--- a/test/test_ble_midi.cpp
+++ b/test/test_ble_midi.cpp
@@ -8,10 +8,13 @@
 // cross-platform half that every backend reuses.
 
 #include <pulp/midi/ble_midi.hpp>
+#include <pulp/midi/ble_midi_registry.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <algorithm>
 #include <cstdint>
+#include <string>
 #include <vector>
 
 using namespace pulp::midi;
@@ -232,4 +235,138 @@ TEST_CASE("create_ble_midi_central is_available() is callable and honest",
     // stop_scan() is always safe, scanning or not.
     central->stop_scan();
     REQUIRE_FALSE(central->is_scanning());
+}
+
+// ── BleMidiPortRegistry — the off-Apple port-merge seam ──────────────────────
+//
+// Cross-platform + transport-free, so it is unit-testable on every host (no
+// BlueZ / Bluetooth hardware needed). These tests pin the bridge the BlueZ
+// central populates on connect and the ALSA MidiSystem merges into its
+// enumeration. Each test uses a unique peripheral id so the process-wide
+// singleton stays isolated, and unregisters at the end.
+
+namespace {
+const char* find_port(const std::vector<MidiPortInfo>& ports,
+                      const std::string& id) {
+    for (const auto& p : ports)
+        if (p.id == id) return p.name.c_str();
+    return nullptr;
+}
+}  // namespace
+
+TEST_CASE("BleMidiPortRegistry surfaces a registered input in list_inputs",
+          "[ble-midi][registry]") {
+    auto& reg = BleMidiPortRegistry::instance();
+    const std::string id = "ble-midi-in:/test/dev_AA_registry_in";
+    reg.register_input(id, "Reg Test Keyboard");
+
+    REQUIRE(reg.is_input(id));
+    REQUIRE_FALSE(reg.is_output(id));
+    auto inputs = reg.list_inputs();
+    const char* name = find_port(inputs, id);
+    REQUIRE(name != nullptr);
+    REQUIRE(std::string(name) == "Reg Test Keyboard");
+
+    reg.unregister_input(id);
+    REQUIRE_FALSE(reg.is_input(id));
+    REQUIRE(find_port(reg.list_inputs(), id) == nullptr);
+}
+
+TEST_CASE("BleMidiPortRegistry delivers a decoded short message to the attached "
+          "MidiInput callback", "[ble-midi][registry]") {
+    auto& reg = BleMidiPortRegistry::instance();
+    const std::string id = "ble-midi-in:/test/dev_BB_registry_deliver";
+    reg.register_input(id, "Deliver Test");
+
+    std::vector<MidiEvent> events;
+    std::vector<std::vector<uint8_t>> sysex;
+    REQUIRE(reg.attach_input(
+        id,
+        [&](const MidiEvent& e) { events.push_back(e); },
+        [&](const std::vector<uint8_t>& bytes, double) { sysex.push_back(bytes); }));
+
+    // A Note On Ch1 note 60 vel 100 — the bytes the central's decoder produces.
+    reg.deliver_message(id, {0x90, 60, 100}, /*timestamp_sec=*/0.5);
+    REQUIRE(events.size() == 1);
+    REQUIRE(events[0].is_note_on());
+    REQUIRE(events[0].note() == 60);
+    REQUIRE(events[0].velocity() == 100);
+    REQUIRE(events[0].timestamp == 0.5);
+    REQUIRE(sysex.empty());
+
+    // After detach, no further delivery reaches the callback.
+    reg.detach_input(id);
+    reg.deliver_message(id, {0x90, 62, 110}, 0.6);
+    REQUIRE(events.size() == 1);
+
+    reg.unregister_input(id);
+}
+
+TEST_CASE("BleMidiPortRegistry routes a SysEx payload to the sysex callback",
+          "[ble-midi][registry]") {
+    auto& reg = BleMidiPortRegistry::instance();
+    const std::string id = "ble-midi-in:/test/dev_CC_registry_sysex";
+    reg.register_input(id, "SysEx Test");
+
+    std::vector<MidiEvent> events;
+    std::vector<std::vector<uint8_t>> sysex;
+    REQUIRE(reg.attach_input(
+        id,
+        [&](const MidiEvent& e) { events.push_back(e); },
+        [&](const std::vector<uint8_t>& bytes, double) { sysex.push_back(bytes); }));
+
+    const std::vector<uint8_t> msg = {0xF0, 0x7E, 0x00, 0x06, 0x01, 0xF7};
+    reg.deliver_message(id, msg, 1.0);
+    REQUIRE(events.empty());
+    REQUIRE(sysex.size() == 1);
+    REQUIRE(sysex[0] == msg);
+
+    reg.unregister_input(id);
+}
+
+TEST_CASE("BleMidiPortRegistry output sink forwards sent bytes to the central",
+          "[ble-midi][registry]") {
+    auto& reg = BleMidiPortRegistry::instance();
+    const std::string id = "ble-midi-out:/test/dev_DD_registry_out";
+    std::vector<std::vector<uint8_t>> written;
+    reg.register_output(id, "Out Test",
+                        [&](const std::vector<uint8_t>& b) { written.push_back(b); });
+
+    REQUIRE(reg.is_output(id));
+    auto outputs = reg.list_outputs();
+    const char* name = find_port(outputs, id);
+    REQUIRE(name != nullptr);
+    REQUIRE(std::string(name) == "Out Test");
+
+    auto sink = reg.output_sink(id);
+    REQUIRE(static_cast<bool>(sink));
+    sink({0xB0, 7, 64});
+    REQUIRE(written.size() == 1);
+    REQUIRE(written[0] == std::vector<uint8_t>{0xB0, 7, 64});
+
+    reg.unregister_output(id);
+    REQUIRE_FALSE(reg.is_output(id));
+    REQUIRE_FALSE(static_cast<bool>(reg.output_sink(id)));
+}
+
+TEST_CASE("BleMidiPortRegistry deliver_message is a no-op for unknown / unopened "
+          "ports", "[ble-midi][registry]") {
+    auto& reg = BleMidiPortRegistry::instance();
+    // Never registered — must not crash, must not deliver.
+    reg.deliver_message("ble-midi-in:/test/never-registered", {0x90, 60, 100}, 0.0);
+
+    // Registered but no host callback attached — also a safe no-op.
+    const std::string id = "ble-midi-in:/test/dev_EE_unopened";
+    reg.register_input(id, "Unopened");
+    reg.deliver_message(id, {0x90, 60, 100}, 0.0);  // attach_input never called
+    REQUIRE(reg.is_input(id));
+    reg.unregister_input(id);
+}
+
+TEST_CASE("BleMidiPortRegistry attach_input rejects an unregistered port",
+          "[ble-midi][registry]") {
+    auto& reg = BleMidiPortRegistry::instance();
+    REQUIRE_FALSE(reg.attach_input(
+        "ble-midi-in:/test/never-registered-attach",
+        [](const MidiEvent&) {}, [](const std::vector<uint8_t>&, double) {}));
 }


### PR DESCRIPTION
PR2 of the BLE-MIDI-off-Apple epic (#3801). Plan: `planning/2026-06-09-ble-midi-off-apple-plan.md` (PR2). Builds on the merged PR1 DBus primitives (#3812).

## What's here
- **`core/midi/platform/linux/ble_midi_linux.cpp`** — `BluezBleMidiCentral` over `org.bluez` via `pulp::platform::DBus` on the **system bus**: `is_available()` (adapter probe via `get_managed_objects`), `start_scan` (`SetDiscoveryFilter` UUIDs=[BLE-MIDI] + `StartDiscovery` + `InterfacesAdded`/`PropertiesChanged` subscriptions, seeded from the GetManagedObjects snapshot), `connect` (`Device1.Connect` → locate `GattCharacteristic1` → `StartNotify` → feed the `Value` (`ay`) into `BleMidiPacketDecoder`), output via `encode_ble_midi_packet` → `WriteValue`, state callbacks + BlueZ-error → `BleMidiError`. A dedicated worker thread pumps `dbus.dispatch()`; shared state mutex-guarded. Peripheral id = the BlueZ device object path.
- **Virtual port merge** — new cross-platform `core/midi/include/pulp/midi/ble_midi_registry.hpp` + `.cpp` (transport-free `BleMidiPortRegistry`): the central registers connected peripherals; the ALSA `MidiSystem` merges them into `enumerate_inputs/outputs` and routes `ble-midi-*` ids through the registry (decoder callback in / GATT-write sink out) instead of `snd_rawmidi`. (This is the seam **PR4** reuses for Windows.)
- **DBus facade**: added `Reader::read_byte` / `Writer::append_byte` (`'y'`) — PR1's facade had no byte support, required for GATT `ay` arrays. Additive on top of merged PR1; no new dep.
- Factory + CMake swap `ble_midi_stub.cpp` → `ble_midi_linux.cpp` on Linux (mirrors the WIN32 swap in #3811).

## Dependencies / NOTICE
**No new bundled software** — BlueZ is a system daemon over the already-dlopened `libdbus`.

## Verification
- **Linux VM:** compiles clean; `pulp-test-ble-midi` 75 assertions / 18 cases pass (registry seam + decoded-message delivery + SysEx routing + output sink + honest no-ops + is_available honest-fail), `pulp-test-dbus` green (the 1 expected fail is the pre-existing "honest-fails without a bus" test under dbus-run-session).
- Real BlueZ scan/connect needs BLE hardware → QA-hardware-gated (not unit-tested).
- macOS: `pulp-test-ble-midi` builds + passes (Linux backend is Linux-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a real Linux BLE‑MIDI backend over `org.bluez` and exposes connected BLE devices as virtual MIDI ports that `ALSA` can see and use. This delivers Linear L13 by replacing the stub, wiring scan/connect/notify, and routing MIDI in/out through a new registry.

- **New Features**
  - Implemented a BlueZ D‑Bus central (`pulp::platform::DBus`) with `is_available`, filtered `start_scan`, `connect`, `StartNotify` decode, and `WriteValue` for output.
  - Added a worker thread to pump D‑Bus so scan and notify signals are delivered reliably.
  - Introduced `BleMidiPortRegistry` to publish BLE ports and bridge them into `ALSA`; `MidiSystem` merges them into enumerate inputs/outputs and routes `ble-midi-*` opens through the registry.
  - Extended the D‑Bus facade with `Reader::read_byte` and `Writer::append_byte` for `ay` payloads.
  - Replaced the Linux no‑op stub with the new backend and linked `pulp::platform` in CMake.

- **Dependencies**
  - No new libraries. Uses the system `BlueZ` daemon via runtime `libdbus`.
  - Linux‑only backend; other platforms unchanged.

<sup>Written for commit 92fd4dfcdd7d735d9f0ca532b9282ae5634072ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

