### PR TITLE
feat(midi): Windows WinRT GATT BLE MIDI connect/notify + MidiSystem port merge (W13 — completes BLE epic)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.398.0
+    VERSION 0.399.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/midi/CMakeLists.txt
+++ b/core/midi/CMakeLists.txt
@@ -62,14 +62,19 @@ elseif(WIN32)
     target_sources(pulp-midi PRIVATE
         platform/win/winmidi_device.cpp
         platform/win/winrt_midi_device.cpp
-        # BLE MIDI — WinRT BluetoothLEAdvertisementWatcher scan backend.
-        # Unlike the WinRT MIDI 2.0 backend (winrt_midi_device.cpp), BLE
-        # GATT lives in Windows.Devices.Bluetooth* in the BASE Windows SDK
-        # cppwinrt projection, so no out-of-band vcpkg/NuGet dependency is
-        # needed — just the OS umbrella import libs below. This TU defines
+        # BLE MIDI — WinRT BluetoothLEAdvertisementWatcher scan +
+        # GATT connect/notify backend. Unlike the WinRT MIDI 2.0 backend
+        # (winrt_midi_device.cpp), BLE GATT lives in
+        # Windows.Devices.Bluetooth* / Windows.Devices.Bluetooth.
+        # GenericAttributeProfile and the byte-buffer helpers in
+        # Windows.Storage.Streams, all in the BASE Windows SDK cppwinrt
+        # projection — so no out-of-band vcpkg/NuGet dependency is needed,
+        # just the OS umbrella import libs below. This TU defines
         # create_ble_midi_central() for Windows, so it REPLACES
         # src/ble_midi_stub.cpp (linking both would duplicate the symbol).
-        # Scan-only in this slice; GATT connect/notify lands in a follow-up.
+        # Connected peripherals are published into the BleMidiPortRegistry,
+        # which winmidi_device.cpp / winrt_midi_device.cpp merge into the
+        # platform MidiSystem's port list.
         platform/win/ble_midi_win.cpp
     )
     target_link_libraries(pulp-midi PRIVATE

--- a/core/midi/include/pulp/midi/ble_midi.hpp
+++ b/core/midi/include/pulp/midi/ble_midi.hpp
@@ -14,8 +14,10 @@
 //   Linux:        BlueZ (org.bluez.GattCharacteristic1 notifications) +
 //                 ALSA virtual port for output. Scaffold only in this
 //                 slice — the BlueZ D-Bus glue lands in a follow-up.
-//   Windows:      WinRT BluetoothLEAdvertisementWatcher +
-//                 GattCharacteristic.ValueChanged. Scaffold only.
+//   Windows:      WinRT BluetoothLEAdvertisementWatcher scan +
+//                 GATT FromBluetoothAddressAsync connect +
+//                 GattCharacteristic.ValueChanged notify, bridged into the
+//                 MidiSystem via the BleMidiPortRegistry.
 //   Android:      BluetoothLeScanner + BluetoothGatt notification
 //                 via the existing JNI bridge. Scaffold only.
 //

--- a/core/midi/platform/win/ble_midi_win.cpp
+++ b/core/midi/platform/win/ble_midi_win.cpp
@@ -1,29 +1,48 @@
-// BLE MIDI backend — Windows using WinRT Bluetooth-LE advertisement scan.
+// BLE MIDI backend — Windows using WinRT Bluetooth-LE advertisement scan
+// + GATT connect/notify.
 //
-// Implements pulp::midi::BleMidiCentral on Windows. This slice is the
-// *scan probe* half: a BluetoothLEAdvertisementWatcher filtered to the
-// BLE-MIDI 1.0 service UUID (03B80E5A-EDE8-4B33-A751-6CE34EC4C700)
-// surfaces advertising peripherals through the scan callback. GATT
-// connect + characteristic notification (the inbound MIDI byte stream)
-// lands in a follow-up slice — see the "PR4: connect/notify" markers.
+// Implements pulp::midi::BleMidiCentral on Windows.
+//
+//   • Scan: a BluetoothLEAdvertisementWatcher filtered to the BLE-MIDI 1.0
+//     service UUID (03B80E5A-EDE8-4B33-A751-6CE34EC4C700) surfaces
+//     advertising peripherals through the scan callback.
+//   • Connect: FromBluetoothAddressAsync resolves the peripheral, we locate
+//     the BLE-MIDI service + characteristic, write the CCCD to enable Notify,
+//     and subscribe ValueChanged. The notify bytes feed a per-connection
+//     BleMidiPacketDecoder whose decoded messages are published to the
+//     BleMidiPortRegistry, which the Windows MidiSystem (winmidi_device.cpp)
+//     merges into its port list. Output: encode_ble_midi_packet →
+//     GattCharacteristic.WriteValueAsync.
 //
 // Why the base Windows SDK is enough here (unlike the WinRT MIDI 2.0
 // backend in winrt_midi_device.cpp): BLE GATT lives in
-// Windows.Devices.Bluetooth / Windows.Devices.Bluetooth.Advertisement,
-// which ship in the BASE Windows SDK cppwinrt projection. There is no
-// out-of-band NuGet / vcpkg dependency — we link the OS umbrella import
-// library (WindowsApp) and include the stock winrt headers.
+// Windows.Devices.Bluetooth / Windows.Devices.Bluetooth.Advertisement /
+// Windows.Devices.Bluetooth.GenericAttributeProfile and the byte-buffer
+// helpers in Windows.Storage.Streams, all of which ship in the BASE Windows
+// SDK cppwinrt projection. There is no out-of-band NuGet / vcpkg
+// dependency — we link the OS umbrella import library (WindowsApp) and
+// include the stock winrt headers.
 //
-// Threading: the watcher's Received event fires on a WinRT thread-pool
-// thread. The BleMidiScanCallback contract already permits invocation
-// from a backend thread, so we forward directly under a short mutex hold
-// that protects the dedup map + the stored callback (matching the
-// CoreBluetooth backend's discipline). Apartment init is lazy + MTA, the
-// same pattern winrt_midi_device.cpp uses.
+// Pairing: this backend never drives pairing
+// (DeviceInformationPairing.PairAsync is unsupported in desktop apps and
+// rejected for packaged identity); BLE-MIDI peripherals pair through the OS
+// Settings/Swift-pair flow. Inside a DAW the process identity is the host's,
+// so any pairing prompt is attributed to the host, not Pulp.
+//
+// Threading: the watcher's Received event and the characteristic's
+// ValueChanged event fire on WinRT thread-pool threads. The BleMidiScanCallback
+// / decoder-delivery contract already permits invocation from a backend
+// thread, so we forward directly under a short mutex hold that protects the
+// peripheral map + the stored callbacks (matching the CoreBluetooth /
+// winrt_midi_device.cpp discipline). The async GATT chain is co_awaited via
+// blocking `.get()` because connect() runs on a caller worker thread, not a
+// UI/STA thread. Apartment init is lazy + MTA, the same pattern
+// winrt_midi_device.cpp uses.
 
 #if defined(_WIN32)
 
 #include <pulp/midi/ble_midi.hpp>
+#include <pulp/midi/ble_midi_registry.hpp>
 #include <pulp/runtime/log.hpp>
 
 #include <array>
@@ -41,12 +60,17 @@
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Devices.Bluetooth.h>
 #include <winrt/Windows.Devices.Bluetooth.Advertisement.h>
+#include <winrt/Windows.Devices.Bluetooth.GenericAttributeProfile.h>
+#include <winrt/Windows.Storage.Streams.h>
 
 namespace pulp::midi {
 namespace {
 
-namespace wf  = ::winrt::Windows::Foundation;
-namespace wda = ::winrt::Windows::Devices::Bluetooth::Advertisement;
+namespace wf   = ::winrt::Windows::Foundation;
+namespace wda  = ::winrt::Windows::Devices::Bluetooth::Advertisement;
+namespace wdb  = ::winrt::Windows::Devices::Bluetooth;
+namespace gatt = ::winrt::Windows::Devices::Bluetooth::GenericAttributeProfile;
+namespace wss  = ::winrt::Windows::Storage::Streams;
 
 // Lazy, idempotent MTA apartment init. WinRT reference-counts init/uninit
 // per thread; calling init_apartment more than once on the same thread is
@@ -105,11 +129,81 @@ std::string address_to_id(uint64_t address) {
     return std::string(buf);
 }
 
+// Parse the 12-hex peripheral id produced by address_to_id() back into the
+// 48-bit Bluetooth address WinRT's FromBluetoothAddressAsync expects. Returns
+// false if the id is not a clean run of hex nibbles (defends connect() against
+// an id that never came from a scan).
+bool address_from_id(const std::string& id, uint64_t& out) {
+    if (id.empty() || id.size() > 16) return false;
+    uint64_t value = 0;
+    for (char c : id) {
+        int nibble;
+        if (c >= '0' && c <= '9') nibble = c - '0';
+        else if (c >= 'a' && c <= 'f') nibble = c - 'a' + 10;
+        else if (c >= 'A' && c <= 'F') nibble = c - 'A' + 10;
+        else return false;
+        value = (value << 4) | static_cast<uint64_t>(nibble);
+    }
+    out = value;
+    return true;
+}
+
+// Registry port-ids — same "ble-midi-in:" / "ble-midi-out:<peripheral-id>"
+// convention the Apple + BlueZ backends use, so a host can pre-select the
+// port via midi_input_port_for() before enumerate_inputs() shows it.
+std::string input_port_id(const std::string& peripheral_id) {
+    return "ble-midi-in:" + peripheral_id;
+}
+std::string output_port_id(const std::string& peripheral_id) {
+    return "ble-midi-out:" + peripheral_id;
+}
+
+// Translate a WinRT GATT failure into the neutral BleMidiError enum so
+// cross-platform callers never see an HRESULT. Reached independently from the
+// public WinRT GATT documentation (GattCommunicationStatus + the common
+// HRESULT facilities), not transcribed from another framework.
+BleMidiError gatt_status_to_ble(gatt::GattCommunicationStatus status) {
+    switch (status) {
+        case gatt::GattCommunicationStatus::Unreachable:
+            return BleMidiError::ConnectFailed;
+        case gatt::GattCommunicationStatus::ProtocolError:
+            return BleMidiError::ServiceNotFound;
+        case gatt::GattCommunicationStatus::AccessDenied:
+            return BleMidiError::PermissionDenied;
+        default:
+            return BleMidiError::ConnectFailed;
+    }
+}
+
+BleMidiError hresult_to_ble(const ::winrt::hresult_error& e) {
+    // E_ACCESSDENIED → permission; RPC_E_DISCONNECTED / adapter-off surface as
+    // a generic connect failure. Keep the mapping conservative; the precise
+    // facility codes are not part of the cross-platform contract.
+    const auto code = static_cast<uint32_t>(e.code());
+    if (code == 0x80070005u /* E_ACCESSDENIED */) {
+        return BleMidiError::PermissionDenied;
+    }
+    return BleMidiError::ConnectFailed;
+}
+
 class WinBleMidiCentral final : public BleMidiCentral {
 public:
     WinBleMidiCentral() { ensure_winrt_init(); }
 
-    ~WinBleMidiCentral() override { stop_scan(); }
+    ~WinBleMidiCentral() override {
+        stop_scan();
+        // Tear down every live GATT link so the registry's output sink (which
+        // captures `this`) and the inbound decoder are dropped before the
+        // central is destroyed. Snapshot the ids under the lock, then call the
+        // public disconnect() path (which re-locks) for each.
+        std::vector<std::string> ids;
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            ids.reserve(connections_.size());
+            for (const auto& [id, conn] : connections_) ids.push_back(id);
+        }
+        for (const auto& id : ids) disconnect(id);
+    }
 
     // True if the WinRT BLE advertisement API is usable on this machine.
     // Constructing a BluetoothLEAdvertisementWatcher does not require an
@@ -174,36 +268,200 @@ public:
         return out;
     }
 
-    // PR4: connect/notify. The scan probe does not yet open a GATT link.
-    // Report Failed/Unsupported so the contract stays honest and the host
-    // does not wait forever for a Connected that will not arrive.
+    // Open a GATT link to a peripheral seen in a scan, enable BLE-MIDI
+    // characteristic notifications, and publish the connection into the
+    // BleMidiPortRegistry so the Windows MidiSystem enumerates it.
     bool connect(const std::string& id) override {
-        BleMidiStateCallback cb_copy;
+        ensure_winrt_init();
+
+        // Scan-before-connect is mandatory: FromBluetoothAddressAsync returns
+        // null for an unpaired device unless the advertisement cache is warm.
+        // Require the id to have come from a scan (it is in peripherals_).
+        uint64_t address = 0;
         {
             std::lock_guard<std::mutex> lock(mu_);
-            cb_copy = state_cb_;
+            if (peripherals_.find(id) == peripherals_.end() ||
+                !address_from_id(id, address)) {
+                fire_state_locked(id, BleMidiConnectionState::Failed,
+                                  BleMidiError::PeripheralNotFound);
+                return false;
+            }
+            if (connections_.find(id) != connections_.end()) {
+                return true;  // already connected — no-op.
+            }
         }
-        if (cb_copy) {
-            cb_copy(id, BleMidiConnectionState::Failed,
-                    BleMidiError::Unsupported);
+
+        fire_state(id, BleMidiConnectionState::Connecting, BleMidiError::None);
+
+        try {
+            // Resolve the peripheral from the cached advertisement.
+            wdb::BluetoothLEDevice device =
+                wdb::BluetoothLEDevice::FromBluetoothAddressAsync(address).get();
+            if (!device) {
+                fire_state(id, BleMidiConnectionState::Failed,
+                           BleMidiError::PeripheralNotFound);
+                return false;
+            }
+
+            // Discover the BLE-MIDI service.
+            const ::winrt::guid service_guid =
+                guid_from_uuid_string(BleMidiUuids::kService);
+            gatt::GattDeviceServicesResult services =
+                device.GetGattServicesForUuidAsync(service_guid).get();
+            if (services.Status() != gatt::GattCommunicationStatus::Success ||
+                services.Services().Size() == 0) {
+                fire_state(id, BleMidiConnectionState::Failed,
+                           services.Status() ==
+                                   gatt::GattCommunicationStatus::Success
+                               ? BleMidiError::ServiceNotFound
+                               : gatt_status_to_ble(services.Status()));
+                return false;
+            }
+            gatt::GattDeviceService service = services.Services().GetAt(0);
+
+            // Discover the BLE-MIDI characteristic.
+            const ::winrt::guid char_guid =
+                guid_from_uuid_string(BleMidiUuids::kCharacteristic);
+            gatt::GattCharacteristicsResult chars =
+                service.GetCharacteristicsForUuidAsync(char_guid).get();
+            if (chars.Status() != gatt::GattCommunicationStatus::Success ||
+                chars.Characteristics().Size() == 0) {
+                fire_state(id, BleMidiConnectionState::Failed,
+                           chars.Status() ==
+                                   gatt::GattCommunicationStatus::Success
+                               ? BleMidiError::ServiceNotFound
+                               : gatt_status_to_ble(chars.Status()));
+                return false;
+            }
+            gatt::GattCharacteristic characteristic =
+                chars.Characteristics().GetAt(0);
+
+            // Enable notifications by writing the Client Characteristic
+            // Configuration Descriptor (CCCD).
+            gatt::GattCommunicationStatus cccd =
+                characteristic
+                    .WriteClientCharacteristicConfigurationDescriptorAsync(
+                        gatt::GattClientCharacteristicConfigurationDescriptorValue::
+                            Notify)
+                    .get();
+            if (cccd != gatt::GattCommunicationStatus::Success) {
+                fire_state(id, BleMidiConnectionState::Failed,
+                           gatt_status_to_ble(cccd));
+                return false;
+            }
+
+            // Build the connection state (decoder + WinRT object lifetimes).
+            auto conn = std::make_unique<Connection>();
+            conn->device = device;
+            conn->service = service;
+            conn->characteristic = characteristic;
+            conn->decoder = std::make_unique<BleMidiPacketDecoder>();
+            conn->input_port = input_port_id(id);
+            conn->output_port = output_port_id(id);
+            conn->decoder->set_message_callback(
+                [this, port = conn->input_port](
+                    const std::vector<uint8_t>& bytes, uint32_t ts_ms) {
+                    BleMidiPortRegistry::instance().deliver_message(
+                        port, bytes, static_cast<double>(ts_ms) / 1000.0);
+                });
+
+            // ValueChanged carries the GATT notify bytes (the inbound MIDI
+            // stream). Fires on a WinRT thread-pool thread.
+            conn->value_token = characteristic.ValueChanged(
+                { this, &WinBleMidiCentral::on_value_changed });
+
+            // ConnectionStatusChanged surfaces an unexpected link drop so the
+            // host sees Disconnected rather than a silently dead port.
+            conn->status_token = device.ConnectionStatusChanged(
+                { this, &WinBleMidiCentral::on_connection_status_changed });
+
+            const std::string name = peripheral_name(id);
+            {
+                std::lock_guard<std::mutex> lock(mu_);
+                char_to_id_[char_key(characteristic)] = id;
+                device_to_id_[device_key(device)] = id;
+                connections_[id] = std::move(conn);
+            }
+
+            // Publish into the registry so the Windows MidiSystem enumerates
+            // the port and routes open() through the registry.
+            auto& reg = BleMidiPortRegistry::instance();
+            reg.register_input(input_port_id(id), name);
+            reg.register_output(
+                output_port_id(id), name,
+                [this, id](const std::vector<uint8_t>& bytes) {
+                    gatt_write(id, bytes);
+                });
+
+            fire_state(id, BleMidiConnectionState::Connected,
+                       BleMidiError::None);
+            return true;
+        } catch (const ::winrt::hresult_error& e) {
+            runtime::log_error("WinRT BLE MIDI: connect failed: {}",
+                               ::winrt::to_string(e.message()));
+            fire_state(id, BleMidiConnectionState::Failed, hresult_to_ble(e));
+            return false;
         }
-        return false;
     }
 
-    // PR4: connect/notify.
-    void disconnect(const std::string&) override {}
+    void disconnect(const std::string& id) override {
+        std::unique_ptr<Connection> conn;
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            auto it = connections_.find(id);
+            if (it == connections_.end()) return;
+            conn = std::move(it->second);
+            connections_.erase(it);
+            if (conn) {
+                char_to_id_.erase(char_key(conn->characteristic));
+                device_to_id_.erase(device_key(conn->device));
+            }
+        }
+
+        // Stop delivery first so a notify in flight cannot resurrect a stale
+        // decoder, then drop the registry ports.
+        auto& reg = BleMidiPortRegistry::instance();
+        reg.unregister_input(input_port_id(id));
+        reg.unregister_output(output_port_id(id));
+
+        if (conn) {
+            try {
+                if (conn->value_token && conn->characteristic) {
+                    conn->characteristic.ValueChanged(conn->value_token);
+                }
+                if (conn->status_token && conn->device) {
+                    conn->device.ConnectionStatusChanged(conn->status_token);
+                }
+            } catch (const ::winrt::hresult_error&) {
+                // Best-effort — the peripheral may already be gone.
+            }
+            // Releasing the BluetoothLEDevice (and service/characteristic) drops
+            // the GATT link; closing the GattSession is implicit on the device's
+            // last release.
+            conn->characteristic = nullptr;
+            conn->service = nullptr;
+            conn->device = nullptr;
+        }
+
+        fire_state(id, BleMidiConnectionState::Disconnected, BleMidiError::None);
+    }
 
     void set_state_callback(BleMidiStateCallback cb) override {
         std::lock_guard<std::mutex> lock(mu_);
         state_cb_ = std::move(cb);
     }
 
-    // PR4: connect/notify. No GATT link yet, so no MIDI port mapping.
-    std::string midi_input_port_for(const std::string&) const override {
-        return {};
+    std::string midi_input_port_for(const std::string& id) const override {
+        std::lock_guard<std::mutex> lock(mu_);
+        auto it = connections_.find(id);
+        if (it == connections_.end()) return {};
+        return it->second->input_port;
     }
-    std::string midi_output_port_for(const std::string&) const override {
-        return {};
+    std::string midi_output_port_for(const std::string& id) const override {
+        std::lock_guard<std::mutex> lock(mu_);
+        auto it = connections_.find(id);
+        if (it == connections_.end()) return {};
+        return it->second->output_port;
     }
 
 private:
@@ -216,8 +474,9 @@ private:
             snapshot.name = ::winrt::to_string(args.Advertisement().LocalName());
             snapshot.rssi = args.RawSignalStrengthInDBm();
             snapshot.last_seen = std::chrono::steady_clock::now();
-            // The OS pairing/bond state is a GATT-side query; the scan probe
-            // does not resolve it, so report false until PR4 wires connect.
+            // The OS pairing/bond state is a separate DeviceInformation query;
+            // the advertisement does not carry it, so the scan snapshot reports
+            // false. Pairing is driven by the OS, not this backend.
             snapshot.is_paired = false;
 
             BleMidiScanCallback cb_copy;
@@ -246,8 +505,161 @@ private:
         watcher_ = nullptr;
     }
 
+    // ── GATT notify (inbound MIDI) ───────────────────────────────────────────
+
+    // Fired on a WinRT thread-pool thread for each characteristic notification.
+    // Reads the IBuffer payload into bytes and feeds the per-connection decoder,
+    // which delivers decoded MIDI through the registry. Bounced under mu_ to
+    // match the winrt_midi_device.cpp / CoreBluetooth discipline.
+    void on_value_changed(const gatt::GattCharacteristic& characteristic,
+                          const gatt::GattValueChangedEventArgs& args) {
+        try {
+            wss::IBuffer buffer = args.CharacteristicValue();
+            if (!buffer || buffer.Length() == 0) return;
+
+            // DataReader::FromBuffer copies the bytes out of projection memory
+            // so we never touch the IBuffer after the event returns.
+            wss::DataReader reader = wss::DataReader::FromBuffer(buffer);
+            const uint32_t len = buffer.Length();
+            std::vector<uint8_t> bytes(len);
+            reader.ReadBytes(::winrt::array_view<uint8_t>(
+                bytes.data(), bytes.data() + len));
+
+            std::lock_guard<std::mutex> lock(mu_);
+            auto cit = char_to_id_.find(char_key(characteristic));
+            if (cit == char_to_id_.end()) return;
+            auto pit = connections_.find(cit->second);
+            if (pit == connections_.end() || !pit->second->decoder) return;
+            // decode() under the lock is safe: it only forwards into the
+            // registry, which copies callbacks out under its own lock before
+            // invoking them.
+            pit->second->decoder->decode(bytes.data(), bytes.size());
+        } catch (const ::winrt::hresult_error&) {
+            // Drop a malformed notification rather than tear down the link.
+        }
+    }
+
+    // Fired when the OS link state flips. Surface an unexpected drop as
+    // Disconnected; the registry ports are torn down on the explicit
+    // disconnect() path so a transient flap does not desync the port list.
+    void on_connection_status_changed(const wdb::BluetoothLEDevice& device,
+                                      const wf::IInspectable&) {
+        try {
+            if (device.ConnectionStatus() !=
+                wdb::BluetoothConnectionStatus::Disconnected) {
+                return;
+            }
+        } catch (const ::winrt::hresult_error&) {
+            return;
+        }
+        std::string id;
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            auto it = device_to_id_.find(device_key(device));
+            if (it == device_to_id_.end()) return;
+            id = it->second;
+        }
+        // Only surface state; full teardown happens when the host calls
+        // disconnect(). Reconnect attempts are the host's policy.
+        fire_state(id, BleMidiConnectionState::Disconnected,
+                   BleMidiError::None);
+    }
+
+    // ── GATT write (outbound MIDI) ───────────────────────────────────────────
+
+    void gatt_write(const std::string& id,
+                    const std::vector<uint8_t>& midi_bytes) {
+        if (midi_bytes.empty()) return;
+        gatt::GattCharacteristic characteristic{nullptr};
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            auto it = connections_.find(id);
+            if (it == connections_.end() || !it->second) return;
+            characteristic = it->second->characteristic;
+        }
+        if (!characteristic) return;
+
+        // Encode to a single timestamped BLE-MIDI packet. A 20-byte minimum
+        // ATT MTU accommodates a short message + 2-byte BLE-MIDI header, so a
+        // single write is the common path; larger sysex is pre-chunked by the
+        // caller. Outbound timestamp 0 is acceptable (the wire is not re-timed).
+        std::vector<uint8_t> packet = encode_ble_midi_packet(
+            midi_bytes.data(), midi_bytes.size(), /*timestamp_ms=*/0);
+        if (packet.empty()) return;
+
+        try {
+            wss::DataWriter writer;
+            writer.WriteBytes(::winrt::array_view<const uint8_t>(
+                packet.data(), packet.data() + packet.size()));
+            // WriteWithoutResponse matches the BLE-MIDI spec's low-latency,
+            // un-acked write; fall back is the OS default if the characteristic
+            // lacks the property.
+            characteristic.WriteValueAsync(
+                writer.DetachBuffer(),
+                gatt::GattWriteOption::WriteWithoutResponse).get();
+        } catch (const ::winrt::hresult_error& e) {
+            runtime::log_error("WinRT BLE MIDI: GATT write failed: {}",
+                               ::winrt::to_string(e.message()));
+        }
+    }
+
+    // ── State callback helpers ───────────────────────────────────────────────
+
+    void fire_state(const std::string& id, BleMidiConnectionState state,
+                    BleMidiError err) {
+        BleMidiStateCallback cb;
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            cb = state_cb_;
+        }
+        if (cb) cb(id, state, err);
+    }
+    void fire_state_locked(const std::string& id, BleMidiConnectionState state,
+                           BleMidiError err) {
+        // Caller already holds mu_.
+        if (state_cb_) state_cb_(id, state, err);
+    }
+
+    std::string peripheral_name(const std::string& id) const {
+        std::lock_guard<std::mutex> lock(mu_);
+        auto it = peripherals_.find(id);
+        if (it == peripherals_.end() || it->second.name.empty()) return id;
+        return it->second.name;
+    }
+
+    // Stable string keys for the WinRT object → peripheral-id reverse maps. The
+    // characteristic's AttributeHandle is unique within a connected device, and
+    // the device's BluetoothAddress is the same 48-bit handle the id derives
+    // from — using them avoids comparing projection object identity.
+    static std::string char_key(const gatt::GattCharacteristic& c) {
+        if (!c) return {};
+        return std::to_string(c.Service().Device().BluetoothAddress()) + ":" +
+               std::to_string(c.AttributeHandle());
+    }
+    static std::string device_key(const wdb::BluetoothLEDevice& d) {
+        if (!d) return {};
+        return std::to_string(d.BluetoothAddress());
+    }
+
+    // One live GATT connection. The BluetoothLEDevice / service / characteristic
+    // MUST be held for the connection's lifetime — releasing the device drops
+    // the link. The event tokens are unsubscribed on disconnect.
+    struct Connection {
+        wdb::BluetoothLEDevice device{nullptr};
+        gatt::GattDeviceService service{nullptr};
+        gatt::GattCharacteristic characteristic{nullptr};
+        ::winrt::event_token value_token{};
+        ::winrt::event_token status_token{};
+        std::unique_ptr<BleMidiPacketDecoder> decoder;
+        std::string input_port;
+        std::string output_port;
+    };
+
     mutable std::mutex mu_;
     std::map<std::string, BleMidiPeripheral> peripherals_;
+    std::map<std::string, std::unique_ptr<Connection>> connections_;
+    std::map<std::string, std::string> char_to_id_;    // char key → peripheral id
+    std::map<std::string, std::string> device_to_id_;  // device key → peripheral id
     BleMidiScanCallback scan_cb_;
     BleMidiStateCallback state_cb_;
     std::atomic<bool> scanning_{false};

--- a/core/midi/platform/win/winmidi_device.cpp
+++ b/core/midi/platform/win/winmidi_device.cpp
@@ -1,3 +1,4 @@
+#include <pulp/midi/ble_midi_registry.hpp>
 #include <pulp/midi/device.hpp>
 #include <pulp/runtime/log.hpp>
 
@@ -9,6 +10,7 @@
 #include <mmeapi.h>
 
 #include <atomic>
+#include <functional>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -38,6 +40,19 @@ public:
 
     bool open(const std::string& port_id, MidiInputCallback callback) override {
         callback_ = std::move(callback);
+
+        // BLE-MIDI ports are not mmeapi devices: a connected BLE peripheral is
+        // published into the process-wide BleMidiPortRegistry by the WinRT BLE
+        // central, and its MIDI bytes arrive via the central's GATT-notify
+        // decoder. Route open() to the registry instead of midiInOpen. This is
+        // the Windows analog of the ALSA backend's registry merge.
+        if (BleMidiPortRegistry::instance().is_input(port_id)) {
+            ble_port_id_ = port_id;
+            const bool attached = BleMidiPortRegistry::instance().attach_input(
+                port_id, callback_, sysex_callback_);
+            is_open_ = attached;
+            return attached;
+        }
 
         UINT device_id = 0;
         if (!port_id.empty()) {
@@ -101,6 +116,13 @@ public:
     }
 
     void close() override {
+        // BLE-MIDI input: detach from the registry; there is no mmeapi handle.
+        if (!ble_port_id_.empty()) {
+            BleMidiPortRegistry::instance().detach_input(ble_port_id_);
+            ble_port_id_.clear();
+            is_open_ = false;
+            return;
+        }
         if (handle_) {
             // Set the closing flag BEFORE midiInReset so any
             // MIM_LONGDATA callback fired during reset (or already in
@@ -217,6 +239,9 @@ private:
     // during close() so a callback racing with midiInReset doesn't add
     // a buffer that's about to be unprepared. See #438 P1 / #388.
     std::atomic<bool>  closing_{false};
+    // Non-empty when this input is a BLE-MIDI port routed through the
+    // BleMidiPortRegistry rather than an mmeapi device.
+    std::string        ble_port_id_;
 };
 
 // ── WinMidiOutput ────────────────────────────────────────────────────────
@@ -226,6 +251,14 @@ public:
     ~WinMidiOutput() override { close(); }
 
     bool open(const std::string& port_id) override {
+        // BLE-MIDI output ports route through the registry's GATT-write sink
+        // published by the WinRT BLE central, not midiOut.
+        if (BleMidiPortRegistry::instance().is_output(port_id)) {
+            ble_sink_ = BleMidiPortRegistry::instance().output_sink(port_id);
+            is_open_ = static_cast<bool>(ble_sink_);
+            return is_open_;
+        }
+
         UINT device_id = 0;
         if (!port_id.empty()) {
             device_id = static_cast<UINT>(std::stoul(port_id));
@@ -249,6 +282,12 @@ public:
     }
 
     void close() override {
+        // BLE-MIDI output: drop the registry sink; there is no mmeapi handle.
+        if (ble_sink_) {
+            ble_sink_ = nullptr;
+            is_open_ = false;
+            return;
+        }
         if (handle_) {
             midiOutReset(handle_);
             midiOutClose(handle_);
@@ -260,9 +299,17 @@ public:
     bool is_open() const override { return is_open_; }
 
     void send(const MidiEvent& event) override {
+        const auto* d = event.data();
+        // BLE-MIDI: forward the raw message bytes to the central's GATT-write
+        // sink, which encodes a BLE-MIDI packet and performs WriteValueAsync.
+        if (ble_sink_) {
+            int len = 3;
+            if ((d[0] & 0xF0) == 0xC0 || (d[0] & 0xF0) == 0xD0) len = 2;
+            ble_sink_(std::vector<uint8_t>(d, d + len));
+            return;
+        }
         if (!handle_) return;
 
-        const auto* d = event.data();
         // Pack the MIDI message into a DWORD (little-endian: status | data1<<8 | data2<<16)
         DWORD msg = static_cast<DWORD>(d[0])
                   | (static_cast<DWORD>(d[1]) << 8)
@@ -274,6 +321,9 @@ public:
 private:
     HMIDIOUT handle_ = nullptr;
     bool is_open_ = false;
+    // Non-empty when this output is a BLE-MIDI port routed through the
+    // BleMidiPortRegistry's GATT-write sink rather than an mmeapi device.
+    std::function<void(const std::vector<uint8_t>&)> ble_sink_;
 };
 
 // ── WinMidiSystem ────────────────────────────────────────────────────────
@@ -293,6 +343,12 @@ public:
                 ports.push_back(std::move(info));
             }
         }
+        // Merge connected BLE-MIDI peripherals — Windows has no OS bridge that
+        // auto-exposes a GATT notify stream as an mmeapi port, so the WinRT BLE
+        // central publishes them into the process-wide registry and we surface
+        // them here (the Windows analog of the ALSA backend's merge).
+        auto ble = BleMidiPortRegistry::instance().list_inputs();
+        ports.insert(ports.end(), ble.begin(), ble.end());
         return ports;
     }
 
@@ -309,6 +365,8 @@ public:
                 ports.push_back(std::move(info));
             }
         }
+        auto ble = BleMidiPortRegistry::instance().list_outputs();
+        ports.insert(ports.end(), ble.begin(), ble.end());
         return ports;
     }
 

--- a/core/midi/platform/win/winrt_midi_device.cpp
+++ b/core/midi/platform/win/winrt_midi_device.cpp
@@ -22,6 +22,7 @@
 
 #if defined(_WIN32) && defined(PULP_HAS_WINRT_MIDI)
 
+#include <pulp/midi/ble_midi_registry.hpp>
 #include <pulp/midi/device.hpp>
 #include <pulp/midi/ump.hpp>
 #include <pulp/midi/ump_conversion.hpp>
@@ -30,6 +31,7 @@
 
 #include <array>
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -122,8 +124,20 @@ public:
     }
 
     bool open(const std::string& port_id, MidiInputCallback callback) override {
-        ensure_winrt_init();
         callback_ = std::move(callback);
+
+        // BLE-MIDI ports route through the BleMidiPortRegistry, not the Midi2
+        // endpoint API — a connected BLE peripheral's bytes come from the WinRT
+        // BLE central's GATT-notify decoder. Same merge as the mmeapi backend.
+        if (BleMidiPortRegistry::instance().is_input(port_id)) {
+            ble_port_id_ = port_id;
+            const bool attached = BleMidiPortRegistry::instance().attach_input(
+                port_id, callback_, sysex_callback_);
+            is_open_ = attached;
+            return attached;
+        }
+
+        ensure_winrt_init();
 
         try {
             session_ = m2::MidiSession::Create(L"Pulp MIDI Input");
@@ -161,6 +175,13 @@ public:
     }
 
     void close() override {
+        // BLE-MIDI input: detach from the registry; there is no Midi2 endpoint.
+        if (!ble_port_id_.empty()) {
+            BleMidiPortRegistry::instance().detach_input(ble_port_id_);
+            ble_port_id_.clear();
+            is_open_ = false;
+            return;
+        }
         try {
             if (connection_) {
                 if (message_token_) {
@@ -286,6 +307,9 @@ private:
     bool                       is_open_ = false;
     bool                       have_origin_ = false;
     uint64_t                   origin_ticks_ = 0;
+    // Non-empty when this input is a BLE-MIDI port routed through the
+    // BleMidiPortRegistry rather than a Midi2 endpoint connection.
+    std::string                ble_port_id_;
 };
 
 // ── WinrtMidiOutput ──────────────────────────────────────────────────────
@@ -295,6 +319,14 @@ public:
     ~WinrtMidiOutput() override { close(); }
 
     bool open(const std::string& port_id) override {
+        // BLE-MIDI output ports route through the registry's GATT-write sink,
+        // not the Midi2 endpoint API.
+        if (BleMidiPortRegistry::instance().is_output(port_id)) {
+            ble_sink_ = BleMidiPortRegistry::instance().output_sink(port_id);
+            is_open_ = static_cast<bool>(ble_sink_);
+            return is_open_;
+        }
+
         ensure_winrt_init();
         try {
             session_ = m2::MidiSession::Create(L"Pulp MIDI Output");
@@ -320,6 +352,12 @@ public:
     }
 
     void close() override {
+        // BLE-MIDI output: drop the registry sink; there is no Midi2 endpoint.
+        if (ble_sink_) {
+            ble_sink_ = nullptr;
+            is_open_ = false;
+            return;
+        }
         try {
             if (connection_ && session_) {
                 session_.DisconnectEndpointConnection(connection_.ConnectionId());
@@ -335,6 +373,15 @@ public:
     bool is_open() const override { return is_open_; }
 
     void send(const MidiEvent& event) override {
+        // BLE-MIDI: forward the raw message bytes to the central's GATT-write
+        // sink, which encodes a BLE-MIDI packet and performs WriteValueAsync.
+        if (ble_sink_) {
+            const auto* d = event.data();
+            int len = 3;
+            if ((d[0] & 0xF0) == 0xC0 || (d[0] & 0xF0) == 0xD0) len = 2;
+            ble_sink_(std::vector<uint8_t>(d, d + len));
+            return;
+        }
         if (!connection_) return;
         try {
             // Promote the MIDI 1.0 short message to a MIDI 2.0 channel-voice
@@ -359,6 +406,9 @@ private:
     m2::MidiSession            session_{nullptr};
     m2::MidiEndpointConnection connection_{nullptr};
     bool                       is_open_ = false;
+    // Non-empty when this output is a BLE-MIDI port routed through the
+    // BleMidiPortRegistry's GATT-write sink rather than a Midi2 endpoint.
+    std::function<void(const std::vector<uint8_t>&)> ble_sink_;
 };
 
 // ── WinrtMidiSystem ──────────────────────────────────────────────────────
@@ -373,11 +423,20 @@ public:
     }
 
     std::vector<MidiPortInfo> enumerate_inputs() override {
-        return enumerate_endpoints(/*want_input=*/true);
+        std::vector<MidiPortInfo> ports = enumerate_endpoints(/*want_input=*/true);
+        // Merge connected BLE-MIDI peripherals published by the WinRT BLE
+        // central — Windows MIDI Services does not auto-expose a GATT notify
+        // stream as a Midi2 endpoint, so the registry is the bridge.
+        auto ble = BleMidiPortRegistry::instance().list_inputs();
+        ports.insert(ports.end(), ble.begin(), ble.end());
+        return ports;
     }
 
     std::vector<MidiPortInfo> enumerate_outputs() override {
-        return enumerate_endpoints(/*want_input=*/false);
+        std::vector<MidiPortInfo> ports = enumerate_endpoints(/*want_input=*/false);
+        auto ble = BleMidiPortRegistry::instance().list_outputs();
+        ports.insert(ports.end(), ble.begin(), ble.end());
+        return ports;
     }
 
     std::unique_ptr<MidiInput> create_input() override {

--- a/test/test_ble_midi.cpp
+++ b/test/test_ble_midi.cpp
@@ -370,3 +370,94 @@ TEST_CASE("BleMidiPortRegistry attach_input rejects an unregistered port",
         "ble-midi-in:/test/never-registered-attach",
         [](const MidiEvent&) {}, [](const std::vector<uint8_t>&, double) {}));
 }
+
+// ── Windows port-merge contract (transport-free) ─────────────────────────────
+//
+// The WinRT BLE central registers a connected peripheral with the
+// BleMidiPortRegistry using the "ble-midi-in:<12-hex-address>" /
+// "ble-midi-out:<12-hex-address>" id convention (the 12-hex form is the
+// Windows peripheral id produced by address_to_id() from the 48-bit Bluetooth
+// address). The Windows MidiSystem (winmidi_device.cpp / winrt_midi_device.cpp)
+// then merges those ports and routes open() through the registry. The real
+// GATT connect/notify path needs BLE hardware and is QA-gated; these tests pin
+// the cross-platform seam the Windows backend drives, exactly the way the ALSA
+// tests above pin it for Linux. They run on every host.
+
+TEST_CASE("BleMidiPortRegistry round-trips a Windows-style BLE connection "
+          "(decoder in / GATT-write sink out)", "[ble-midi][registry][windows]") {
+    auto& reg = BleMidiPortRegistry::instance();
+    // 12-hex peripheral id == the Windows address_to_id() form.
+    const std::string peripheral = "aabbccddeeff";
+    const std::string in_id = "ble-midi-in:" + peripheral;
+    const std::string out_id = "ble-midi-out:" + peripheral;
+    const std::string name = "WinBLE Keyboard";
+
+    // What the WinRT central does on Connected: register input (decoder
+    // delivery target) + output (GATT-write sink). The sink encodes the bytes
+    // into a BLE-MIDI packet exactly as gatt_write() does on Windows.
+    std::vector<std::vector<uint8_t>> gatt_writes;
+    reg.register_input(in_id, name);
+    reg.register_output(out_id, name,
+        [&](const std::vector<uint8_t>& bytes) {
+            auto packet = encode_ble_midi_packet(bytes.data(), bytes.size(),
+                                                 /*timestamp_ms=*/0);
+            gatt_writes.push_back(packet);
+        });
+
+    // Both ports surface in the merged enumeration (what the MidiSystem
+    // insert()s into enumerate_inputs/outputs).
+    REQUIRE(reg.is_input(in_id));
+    REQUIRE(reg.is_output(out_id));
+    REQUIRE(find_port(reg.list_inputs(), in_id) != nullptr);
+    REQUIRE(find_port(reg.list_outputs(), out_id) != nullptr);
+
+    // Host opens the input (WinMidiInput::open → attach_input).
+    std::vector<MidiEvent> events;
+    REQUIRE(reg.attach_input(
+        in_id,
+        [&](const MidiEvent& e) { events.push_back(e); },
+        [&](const std::vector<uint8_t>&, double) {}));
+
+    // Inbound: the ValueChanged handler feeds the per-connection decoder, which
+    // delivers through deliver_message(). Drive the real decoder with a real
+    // BLE-MIDI notify packet (header + ts + Note On) to prove the wire path the
+    // Windows on_value_changed → decoder → registry chain uses.
+    const uint8_t notify_packet[] = { 0x80, 0x80, 0x90, 60, 100 };
+    BleMidiPacketDecoder decoder;
+    decoder.set_message_callback(
+        [&](const std::vector<uint8_t>& bytes, uint32_t ts_ms) {
+            reg.deliver_message(in_id, bytes,
+                                static_cast<double>(ts_ms) / 1000.0);
+        });
+    REQUIRE(decoder.decode(notify_packet, sizeof(notify_packet)));
+    REQUIRE(events.size() == 1);
+    REQUIRE(events[0].is_note_on());
+    REQUIRE(events[0].note() == 60);
+    REQUIRE(events[0].velocity() == 100);
+
+    // Outbound: host sends through WinMidiOutput::send → registry sink →
+    // encode_ble_midi_packet → WriteValueAsync. Assert the encoded packet
+    // round-trips back to the original message through the decoder.
+    auto sink = reg.output_sink(out_id);
+    REQUIRE(static_cast<bool>(sink));
+    sink({0xB0, 7, 64});  // CC#7 volume = 64
+    REQUIRE(gatt_writes.size() == 1);
+
+    std::vector<std::vector<uint8_t>> decoded_out;
+    BleMidiPacketDecoder out_dec;
+    out_dec.set_message_callback(
+        [&](const std::vector<uint8_t>& bytes, uint32_t) {
+            decoded_out.push_back(bytes);
+        });
+    REQUIRE(out_dec.decode(gatt_writes[0].data(), gatt_writes[0].size()));
+    REQUIRE(decoded_out.size() == 1);
+    REQUIRE(decoded_out[0] == std::vector<uint8_t>{0xB0, 7, 64});
+
+    // Disconnect tears the ports down (WinRT disconnect() → unregister_*).
+    reg.detach_input(in_id);
+    reg.unregister_input(in_id);
+    reg.unregister_output(out_id);
+    REQUIRE_FALSE(reg.is_input(in_id));
+    REQUIRE_FALSE(reg.is_output(out_id));
+    REQUIRE_FALSE(static_cast<bool>(reg.output_sink(out_id)));
+}


### PR DESCRIPTION
PR4 (final) of the BLE-MIDI-off-Apple epic (#3801). Plan: `planning/2026-06-09-ble-midi-off-apple-plan.md` (PR4). Fills PR3's scan-probe stubs with real GATT connect/notify and merges connected BLE peripherals into the Windows MidiSystem, reusing PR2's cross-platform `BleMidiPortRegistry`.

## What's here
- **`ble_midi_win.cpp` connect/notify** — scan-before-connect guard → `FromBluetoothAddressAsync` → `GetGattServicesForUuidAsync` → `GetCharacteristicsForUuidAsync` → `WriteClientCharacteristicConfigurationDescriptorAsync(Notify)` → `ValueChanged`/`ConnectionStatusChanged` subscriptions. ValueChanged reads the `IBuffer` via `DataReader::FromBuffer` → per-connection `BleMidiPacketDecoder`. Output via `WriteValueAsync(WriteWithoutResponse)`. Device/service/characteristic/tokens/decoder held as members for the link lifetime; dtor tears down every live link. HRESULT/`GattCommunicationStatus` → `BleMidiError`. Pairing stays OS-driven (no `PairAsync`).
- **Windows MidiSystem port merge** — in BOTH `winmidi_device.cpp` (mmeapi) and `winrt_midi_device.cpp` (MIDI 2.0, `#if PULP_HAS_WINRT_MIDI`), since either can be the active backend: `ble-midi-*` ids route through `BleMidiPortRegistry` (decoder callback in / `WriteValueAsync` sink out) and merge into `enumerate_inputs/outputs`. Reuses the shared registry — no new seam.
- Includes `GenericAttributeProfile` + `Storage.Streams` (base SDK); no new link/dep (PR3 already links `WindowsApp`/`runtimeobject`).

## Dependencies / NOTICE
**No new bundled software** — base Windows SDK GATT/Storage.Streams only.

## Verification
- macOS sanity: `pulp-test-ble-midi` 93 assertions / 19 cases pass (incl. a new transport-free registry round-trip with the Windows `ble-midi-{in,out}:<12hex>` id convention); `pulp-test-midi` + `pulp-test-raw-midi-parser` green (no shared-header regression).
- Windows compilation verified by TWO advisory gates: **windows-ble-gate** (`ble_midi_win.cpp` + mmeapi port-merge) and **midi2-gate** (`winrt_midi_device.cpp` port-merge, `#if PULP_HAS_WINRT_MIDI`). WinRT GATT API reviewed against the SDK.
- Real GATT connect/notify needs BLE hardware → QA-hardware-gated.

Closes the W13/L13 BLE-MIDI-off-Apple epic (#3801): macOS (#3017) + Linux BlueZ (#3824) + Windows WinRT all shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Windows WinRT BLE-MIDI GATT connect/notify and merges connected peripherals into the Windows `MidiSystem` via `BleMidiPortRegistry`. Completes the BLE-MIDI rollout on Windows with no new dependencies.

- New Features
  - WinRT GATT connect/notify: resolve device, find BLE-MIDI service/characteristic, enable CCCD Notify, subscribe `ValueChanged`, and write via `WriteWithoutResponse`. Inbound bytes decode through a per-connection `BleMidiPacketDecoder`.
  - Scan-before-connect guard and OS-driven pairing. Clean teardown on `disconnect()` with event unsubscription and link release. Maps `GattCommunicationStatus`/HRESULT to `BleMidiError`.
  - Publishes ports to `BleMidiPortRegistry` using `ble-midi-in:<12hex>` / `ble-midi-out:<12hex>` IDs; delivers messages in, and exposes a GATT-write sink out.
  - Merges BLE-MIDI ports into both Windows backends (`winmidi_device.cpp` and `winrt_midi_device.cpp`): `enumerate_*` includes registry ports; `open`/`close`/`send` route through the registry for `ble-midi-*` IDs.
  - Adds a transport-free test that round-trips a Windows-style BLE connection using the real encoder/decoder; live GATT remains hardware-gated.

- Dependencies
  - No new deps. Uses base Windows SDK WinRT APIs: `Windows.Devices.Bluetooth`, `Windows.Devices.Bluetooth.Advertisement`, `Windows.Devices.Bluetooth.GenericAttributeProfile`, and `Windows.Storage.Streams`.

<sup>Written for commit 98f670116eb45b8c146631255f482bb4920174b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

