### PR TITLE
ci(release): route release-cli macOS leg to self-hosted runners

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -41,16 +41,27 @@ env:
   SHIPYARD_VERSION: "0.59.0"
 
 jobs:
-  # Resolve the macOS runner for the darwin-arm64 matrix legs. When
-  # PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON is set (the same repo
-  # variable build.yml uses for PR macOS routing post-2026-05-18
-  # cutover), route release-cli's macOS leg through Namespace cloud
-  # runners instead of GitHub-hosted macos-15. Falls back to macos-15
-  # when unset so reverting the cutover doesn't break releases.
-  # Background: 2026-05-18 SDK starvation — the GitHub-hosted macos-15
-  # queue backed up for hours and blocked v0.111..v0.134 release-cli
-  # runs from completing (compound with the supersede bug fixed in
-  # pulp #2238 and the Skia gate fix in pulp #2281).
+  # Resolve the macOS runner for the darwin-arm64 matrix legs.
+  #
+  # Priority (first set wins):
+  #   1. PULP_RELEASE_MACOS_RUNS_ON_JSON — dedicated release-cli override
+  #      (the "wire each lane its own runs-on var" pattern from CLAUDE.md).
+  #   2. PULP_LOCAL_MACOS_RUNS_ON_JSON — the self-hosted Studio/M5 pool that
+  #      already backs the required `macos` PR gate (build.yml). release-cli
+  #      is low-volume (tags only) so it won't starve that gate, and the
+  #      `actions/checkout` default `clean: true` (git clean -ffdx) wipes the
+  #      untracked build dirs each run, so a release build on the persistent
+  #      self-hosted disk is clean-by-construction (no warm-dir ODR — release
+  #      also never touches the shared ccache).
+  #   3. PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON — Namespace cloud (off for cost).
+  #   4. GitHub-hosted macos-15 — last-resort fallback.
+  #
+  # Why this changed: the GitHub-hosted macos-15 pool repeatedly starves
+  # release-cli's darwin leg for hours (2026-05-18 blocked v0.111..v0.134;
+  # 2026-06-09 blocked v0.396.0+ for 3h+ while ~6 macos-15 lanes — coverage,
+  # sanitizers — exhausted the hosted concurrency cap and 4 self-hosted Macs
+  # sat idle). Routing the release leg to the idle self-hosted pool by default
+  # removes that single point of failure for publishing.
   resolve-macos-runner:
     runs-on: ubuntu-latest
     outputs:
@@ -58,9 +69,17 @@ jobs:
     steps:
       - id: resolve
         env:
+          RELEASE_JSON: ${{ vars.PULP_RELEASE_MACOS_RUNS_ON_JSON }}
+          LOCAL_JSON: ${{ vars.PULP_LOCAL_MACOS_RUNS_ON_JSON }}
           NAMESPACE_JSON: ${{ vars.PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON }}
         run: |
-          if [ -n "${NAMESPACE_JSON:-}" ]; then
+          if [ -n "${RELEASE_JSON:-}" ]; then
+            echo "runs_on_json=${RELEASE_JSON}" >> "$GITHUB_OUTPUT"
+            echo "Routing macOS release-cli via PULP_RELEASE_MACOS_RUNS_ON_JSON: ${RELEASE_JSON}"
+          elif [ -n "${LOCAL_JSON:-}" ]; then
+            echo "runs_on_json=${LOCAL_JSON}" >> "$GITHUB_OUTPUT"
+            echo "Routing macOS release-cli via self-hosted PULP_LOCAL_MACOS_RUNS_ON_JSON: ${LOCAL_JSON}"
+          elif [ -n "${NAMESPACE_JSON:-}" ]; then
             echo "runs_on_json=${NAMESPACE_JSON}" >> "$GITHUB_OUTPUT"
             echo "Routing macOS release-cli through Namespace: ${NAMESPACE_JSON}"
           else


### PR DESCRIPTION
Stops releases hanging on the GitHub-hosted macos-15 queue (3h+ for v0.396.0 while idle self-hosted Macs sat unused). Routes release-cli's darwin leg to the self-hosted pulp-build pool that already backs the required macos gate, with a dedicated override var + macos-15 last-resort fallback. Clean builds via checkout default clean:true; release never touches the shared ccache. Follow-up to #3815.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reroutes release-cli’s macOS (darwin-arm64) job to self-hosted runners to avoid `macos-15` queue stalls and unblock releases. Adds a priority chain with a dedicated override and a `macos-15` fallback; builds remain clean.

- **Bug Fixes**
  - Runner priority: `PULP_RELEASE_MACOS_RUNS_ON_JSON` > `PULP_LOCAL_MACOS_RUNS_ON_JSON` > `PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON` > `macos-15` fallback.
  - Tag-only workload; `actions/checkout` cleans untracked files; release never uses shared ccache, ensuring clean self-hosted builds.

<sup>Written for commit bb51b976a56e9120a595aa742d15b199a3b3cb91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

