### PR TITLE
ci(release): include manifest in backfill overlay

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -173,6 +173,9 @@ jobs:
         #     (left-to-right archive resolution; the chrome/m144 Skia
         #     archive references Fc* symbols that ld won't resolve from
         #     an earlier-positioned -lfontconfig). #1962 follow-up.
+        #   - tools/deps/manifest.json: release asset inventory must
+        #     include all require_gpu release Skia binaries, including
+        #     linux-arm64, when backfilling older tags.
         run: |
           set -euo pipefail
           repo='${{ github.repository }}'
@@ -180,6 +183,7 @@ jobs:
               tools/scripts/fetch_skia_for_release.py \
               core/canvas/CMakeLists.txt \
               tools/cli/CMakeLists.txt \
+              tools/deps/manifest.json \
               ; do
             url="https://raw.githubusercontent.com/${repo}/main/${path}"
             echo "Overlaying ${path} from ${url}"


### PR DESCRIPTION
## Summary
- overlay `tools/deps/manifest.json` from main during `release-cli.yml` workflow-dispatch backfills
- document why the manifest joins the existing release-pipeline overlay set

## Validation
- `python3 tools/scripts/test_release_cli_gpu_asset_coverage.py`
- `python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat --pr-title 'ci(release): include manifest in release-cli backfill overlay'`\n- `python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`\n- `python3 tools/import-validation/test_source_contracts.py`\n- pre-push gates clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `tools/deps/manifest.json` to the backfill overlay in `release-cli.yml` so workflow-dispatch backfills use the manifest from `main`. This ensures backfilled releases include all required GPU Skia binaries, including linux-arm64.

<sup>Written for commit 842c56fa97b2083f45fb753b6825cb3a8802762e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

