### PR TITLE
chore: bump versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.399.0
+    VERSION 0.400.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
Cut **SDK v0.400.0** from current main — the first release that publishes end-to-end after the linux-arm64 Skia pin (#3814) and release-cli macОС self-hosted routing (#3835). Tags v0.396..v0.399 predate the manifest pin and fail the linux-arm64 release-cli leg; v0.400.0 from main HEAD builds clean on the self-hosted pool.

Bundles all the SvgPath work (fillRule #3794, fillGradient + rect/line live #3802, parity contract #3810) into a publishable release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump version to 0.400.0 to cut SDK v0.400.0. First release that publishes end to end after the linux-arm64 `Skia` asset pin and macOS self-hosted `release-cli` routing; v0.396–v0.399 failed the linux-arm64 leg.

- **New Features**
  - `SvgPath`: fillRule, gradient fills, live rect/line, and parity contract.

<sup>Written for commit a7530c794d28e58bc45ccb097837a73177e806d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

