### PR TITLE
ci(release): drop lfs:true from release-cli checkout (breaks self-hosted macOS)

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -115,7 +115,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          lfs: true
+          # lfs: false — release-cli fetches the Skia binaries explicitly via
+          # fetch_skia_for_release.py (see "Fetch Skia prebuilt binaries" below;
+          # the LFS pull does NOT populate them). Pulling LFS here is redundant
+          # AND fails the checkout on the self-hosted macOS runners (git-lfs not
+          # configured there — the working main `macos` gate in build.yml also
+          # uses lfs: false). This was an 8-second checkout failure on
+          # pulp-studio-01 that blocked v0.400.0's darwin-arm64 leg.
+          lfs: false
           # On `workflow_dispatch`, prefer `source_ref` if the user supplied
           # one; otherwise check out the `version` tag they typed. On
           # push-tag triggers, fall through to the default (the tag ref).


### PR DESCRIPTION
Completes #3835: with release-cli's macОС leg now on self-hosted runners, its `lfs: true` checkout fails in 8s (git-lfs not configured on the Macs). The LFS pull is redundant anyway — release-cli fetches Skia via fetch_skia_for_release.py, and the working main macos gate uses lfs:false. Unblocks v0.400.0's darwin-arm64 leg.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turn off LFS in the `actions/checkout` step of the `release-cli` workflow to stop 8s checkout failures on self-hosted macOS runners without `git-lfs`. LFS is redundant (Skia comes from `fetch_skia_for_release.py`), matches the main `macos` gate, and unblocks the darwin-arm64 release leg; completes #3835.

<sup>Written for commit 7c6ace28bf2c3e7ed1d685926abfaf0e2fdfda7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

