### PR TITLE
ci(release): make macOS binary strip signature-safe (best-effort + re-sign)

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -274,12 +274,24 @@ jobs:
       # `tools/cli/`. The release tarball must include both.
       - name: Strip binaries (Unix)
         if: runner.os != 'Windows'
+        # Linux: GNU strip works directly. macOS (Apple Silicon): binaries are
+        # ad-hoc code-signed at link time, and `strip` invalidates that
+        # signature — on the self-hosted Macs that surfaces as a hard `strip`
+        # failure (GitHub-hosted tolerated it). Strip is only a size
+        # optimization, so on macOS we strip best-effort and re-apply the
+        # ad-hoc signature; a functional binary must never block the release.
+        # #2067: pulp-mcp ships in the CLI tarball so the Claude Code plugin's
+        # MCP launcher can resolve it on $PATH after install.
         run: |
-          strip build/pulp
-          strip build/tools/cli/pulp-cpp
-          # #2067: pulp-mcp ships in the CLI tarball so the Claude Code
-          # plugin's MCP launcher can resolve it on $PATH after install.
-          strip build/tools/mcp/pulp-mcp
+          for bin in build/pulp build/tools/cli/pulp-cpp build/tools/mcp/pulp-mcp; do
+            if [ "${RUNNER_OS}" = "macOS" ]; then
+              strip -x "$bin" 2>/dev/null || strip "$bin" 2>/dev/null || \
+                echo "note: strip skipped for $bin (non-fatal)"
+              codesign --force --sign - "$bin" 2>/dev/null || true
+            else
+              strip "$bin"
+            fi
+          done
 
       - name: Install Linux rpath helper
         if: runner.os == 'Linux'


### PR DESCRIPTION
v0.400.0 darwin-arm64 builds fully on self-hosted now (after #3835 routing + #3843 lfs); only the strip step fails because macOS strip invalidates the ad-hoc arm64 signature. Strip best-effort + re-sign on macOS; Linux unchanged. Last gap before the release publishes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the macOS strip step signature-safe by running best‑effort `strip` and re‑applying an ad‑hoc `codesign`, preventing failures on self‑hosted runners. Unblocks v0.400.0 darwin‑arm64 artifacts (`pulp`, `pulp-cpp`, `pulp-mcp`); Linux is unchanged.

<sup>Written for commit 22ab0ac0bee5ed7c8638b7fa4c8b6887405eded3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

