### PR TITLE
ci(release): put Rust toolchain on PATH so build/pulp builds on self-hosted

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -233,6 +233,23 @@ jobs:
       # Pulp's documented JS engine policy (CLAUDE.md) is QuickJS on
       # Linux, so the CLI must not link JSC-GTK at all. Issue #720.
       #
+      # Ensure the Rust toolchain is on PATH before configure. GitHub-hosted
+      # runners ship cargo on PATH; self-hosted runners (the bare-metal Studio
+      # Macs) have it at ~/.cargo/bin but a non-interactive job shell never
+      # sources the profile that adds it. Without cargo on PATH at CONFIGURE
+      # time, CMake's find_program(cargo) fails, the Rust `pulp` target is
+      # never wired up, and `build/pulp` (the user-facing CLI) silently never
+      # builds — it only surfaced downstream as
+      # `package_cli.py: FAIL: binary not at build/pulp`.
+      - name: Ensure Rust toolchain on PATH
+        if: runner.os != 'Windows'
+        run: |
+          if [ -d "$HOME/.cargo/bin" ]; then
+            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+            echo "Added $HOME/.cargo/bin to PATH for cargo discovery"
+          fi
+        shell: bash
+
       # Build the CLI binary WITHOUT WebView; the SDK build below
       # reconfigures with WebView=ON so plugin authors still get the
       # WebView code in the SDK tarball.


### PR DESCRIPTION
v0.400.0's darwin build on the Studio runner produced everything EXCEPT `build/pulp` (the Rust CLI) — cargo wasn't on the runner's job PATH, so CMake skipped the Rust target. package_cli.py caught it ('FAIL: binary not at build/pulp'). Add `$HOME/.cargo/bin` to PATH before Configure; portable (no-op where absent). Last self-hosted-env gap before v0.400.0 publishes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `cargo` is on PATH in the release CLI workflow so the Rust `pulp` binary builds on self-hosted macOS runners. Adds `$HOME/.cargo/bin` to `GITHUB_PATH` before configure; no-op where absent.

- **Bug Fixes**
  - Prevents `CMake` from skipping the Rust target, which caused `package_cli.py` to fail with "binary not at build/pulp".

<sup>Written for commit 52c959e9bbfae91b91eabae1b544da2417169ee2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

