### PR TITLE
feat(audio): RT output-boundary probe + AudioProbeSnapshot + standalone tap (harness PR 5)

### DIFF
--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -911,3 +911,21 @@ overlay (`View::contains_native_overlay()`), the standalone now routes through
 `capture_native_overlay_png()` (e.g. `WebViewPanel::snapshot_png()` → WKWebView
 takeSnapshot) so WebView editors are self-verifiable headlessly. A plain Skia UI
 falls through to the back-buffer capture unchanged. See the `screenshot` skill.
+
+## Standalone audio-callback probe tap (Phase 5 observability harness)
+
+`StandaloneApp`'s audio callback carries an optional realtime output-boundary
+probe, gated behind the `PULP_ENABLE_AUDIO_PROBES` CMake option (default OFF).
+When ON, `start()` `prepare()`s `output_probe_` (the only place it allocates)
+and the callback calls `output_probe_.analyze_output(...)` immediately after
+`processor_->process(...)` — the "standalone processor-output boundary." This
+is the first wired probe stage for "UI works, no sound" reports. Gotchas:
+
+- It is NOT the input meter bridge. `input_meter_bridge_` is input-oriented and
+  lacks the snapshot's stage/sequence/NaN/clip/silence fields. Don't conflate.
+- The tap is fully `#if PULP_ENABLE_AUDIO_PROBES`-guarded; an OFF build links no
+  `AudioProbe` symbols into `standalone.cpp.o` (verified by `nm`). If you touch
+  the callback, keep the probe strictly inside that guard so OFF builds pay $0.
+- The probe is RT-safe (scalar-only, no FFT/alloc/locks) — `pulp::audio::AudioProbe`.
+  Do NOT model audio-thread work on `pulp::view::VisualizationBridge`, which runs
+  STFT and returns `std::vector` in its callback (explicitly quarantined).

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.203.2",
+      "version": "0.204.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.203.2"
+  "version": "0.204.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.203.2",
+  "version": "0.204.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,16 @@ option(PULP_BENCHMARK "Enable zero-copy benchmark perf counters (Slice 0 of #516
 if(PULP_BENCHMARK)
     add_compile_definitions(PULP_BENCHMARK)
 endif()
+# Audio observability harness (Phase 5). Gates the realtime AudioProbe TAP
+# call sites in runtime code (e.g. the standalone output-boundary probe) so an
+# OFF build pays nothing for live probing. The release-safe AudioStats counter
+# subset and the AudioProbe type itself always compile; only the wiring that
+# calls analyze_output() from a live audio path is behind this flag. Default
+# OFF per the harness plan's build tiers.
+option(PULP_ENABLE_AUDIO_PROBES "Wire realtime AudioProbe taps into live audio paths (dev/debug). Default OFF; release-safe counters stay available without it." OFF)
+if(PULP_ENABLE_AUDIO_PROBES)
+    add_compile_definitions(PULP_ENABLE_AUDIO_PROBES=1)
+endif()
 # Item 4.2 — opt-in suite that drives real third-party plugin binaries
 # (Surge XT / Vital / OB-Xd / Dexed) through the host stack. OFF by default
 # so the public CI matrix never depends on third-party download mirrors;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.403.0
+    VERSION 0.404.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C
@@ -102,16 +102,6 @@ option(PULP_USE_SHARED_FETCHCONTENT_SOURCES "Prefer machine-local shared source 
 option(PULP_BENCHMARK "Enable zero-copy benchmark perf counters (Slice 0 of #516). Tooling-only; OFF by default so production builds see zero overhead." OFF)
 if(PULP_BENCHMARK)
     add_compile_definitions(PULP_BENCHMARK)
-endif()
-# Audio observability harness (Phase 5). Gates the realtime AudioProbe TAP
-# call sites in runtime code (e.g. the standalone output-boundary probe) so an
-# OFF build pays nothing for live probing. The release-safe AudioStats counter
-# subset and the AudioProbe type itself always compile; only the wiring that
-# calls analyze_output() from a live audio path is behind this flag. Default
-# OFF per the harness plan's build tiers.
-option(PULP_ENABLE_AUDIO_PROBES "Wire realtime AudioProbe taps into live audio paths (dev/debug). Default OFF; release-safe counters stay available without it." OFF)
-if(PULP_ENABLE_AUDIO_PROBES)
-    add_compile_definitions(PULP_ENABLE_AUDIO_PROBES=1)
 endif()
 # Item 4.2 — opt-in suite that drives real third-party plugin binaries
 # (Surge XT / Vital / OB-Xd / Dexed) through the host stack. OFF by default

--- a/core/audio/CMakeLists.txt
+++ b/core/audio/CMakeLists.txt
@@ -58,6 +58,8 @@ target_sources(pulp-audio PRIVATE
     src/audio_thumbnail_serialization.cpp
     src/wav_metadata.cpp
     src/audio_device_manager.cpp
+    src/audio_probe.cpp
+    src/audio_boundary_report.cpp
 )
 
 # CoreAudioFormat reader (macOS only — AAC, ALAC, CAF via ExtAudioFile)

--- a/core/audio/include/pulp/audio/audio_boundary_report.hpp
+++ b/core/audio/include/pulp/audio/audio_boundary_report.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+/// @file audio_boundary_report.hpp
+/// Complaint-oriented "no sound" / "sounds wrong" boundary report.
+///
+/// This is a NON-RT consumer-side helper. It takes already-published probe
+/// snapshots (the RT producer side) plus device counters and produces the
+/// stage-by-stage diagnosis the harness plan asks for — distinguishing
+/// processor-output silence, standalone-boundary silence, and device-xrun
+/// problems (harness plan Use-Case 3, "Diagnose No Audio"). It does no audio
+/// analysis itself; it classifies the scalar facts already in each snapshot.
+///
+/// The full multi-stage chain (processor output → standalone boundary → meter
+/// bridge → device callback) lands incrementally. This first version models
+/// the stages that exist today and the device summary, and leaves the others
+/// as explicitly "no probe" rather than faking zeros.
+
+#include <pulp/audio/audio_probe_snapshot.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace pulp::audio {
+
+/// Device-side facts the report mirrors (owned by AudioDeviceManager / the
+/// CoreAudio overload listener — never by the probe).
+struct DeviceStatsView {
+    bool callback_running = false;
+    double sample_rate = 0.0;
+    std::uint32_t buffer_size = 0;
+    std::uint64_t xruns = 0;
+    std::uint64_t cpu_overloads = 0;
+};
+
+/// Coarse classification of where audio was lost (or that it was fine).
+enum class BoundaryDiagnosis {
+    kNoProbeData,            ///< No usable probe snapshot was provided.
+    kSignalPresent,          ///< Audio is flowing at the observed boundary.
+    kProcessorSilent,        ///< Processor-output stage was silent.
+    kStandaloneBoundarySilent,  ///< Processor had signal but the boundary was silent.
+    kDeviceProblem,          ///< Signal present but device shows xruns/not running.
+};
+
+struct BoundaryReport {
+    BoundaryDiagnosis diagnosis = BoundaryDiagnosis::kNoProbeData;
+    /// Human-readable, stage-by-stage text (the plan's "no audio" report).
+    std::string text;
+};
+
+/// Inputs to the report. Each stage snapshot is optional — a missing stage is
+/// reported honestly as "no probe", not as silence.
+struct BoundaryReportInputs {
+    std::optional<AudioProbeSnapshot> processor_output;
+    std::optional<AudioProbeSnapshot> standalone_boundary;
+    std::optional<DeviceStatsView> device;
+    /// A block whose peak is at or below this (linear) counts as silent.
+    float silence_threshold = 3.1622776e-5f;  // ~ -90 dBFS
+};
+
+/// Build the complaint-oriented boundary report from the given inputs.
+BoundaryReport build_boundary_report(const BoundaryReportInputs& inputs);
+
+}  // namespace pulp::audio

--- a/core/audio/include/pulp/audio/audio_probe.hpp
+++ b/core/audio/include/pulp/audio/audio_probe.hpp
@@ -1,0 +1,139 @@
+#pragma once
+
+/// @file audio_probe.hpp
+/// Realtime-safe audio output probe (the RT *producer* in the harness plan's
+/// two-layer split). `AudioProbe::analyze_output()` is callable from the audio
+/// callback and satisfies a strict RT ABI: no allocation, no std::vector
+/// growth, no locks, no file I/O, no logging, no exceptions, no UI/host/package
+/// callbacks, and NO FFT/STFT. It performs only bounded per-block scalar work
+/// (peak, RMS accumulate, clip count, NaN/Inf count, silence-run) and publishes
+/// the latest summary through a `runtime::TripleBuffer<AudioProbeSnapshot>`.
+///
+/// See `planning/2026-06-09-audio-observability-and-validation-harness-plan.md`
+/// Section 4 "Runtime Probe Infrastructure". Do NOT model this on
+/// `pulp::view::VisualizationBridge` — that path runs STFT and returns
+/// std::vector copies inside the callback (it is explicitly quarantined as
+/// non-RT-safe). The RT-safe scalar contract lives here.
+///
+/// Gating: the whole probe lives behind `PULP_ENABLE_AUDIO_PROBES`. The
+/// release-safe counter subset (`AudioStats`) is always available without this
+/// flag. When the flag is OFF, this header still compiles (it is just not
+/// instantiated by any runtime), but probe *call sites* in runtime code are
+/// `#if PULP_ENABLE_AUDIO_PROBES`-guarded so an OFF build pays nothing.
+
+#include <pulp/audio/audio_probe_snapshot.hpp>
+#include <pulp/audio/audio_stats.hpp>
+#include <pulp/audio/buffer.hpp>
+#include <pulp/runtime/abstract_fifo.hpp>
+#include <pulp/runtime/triple_buffer.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace pulp::audio {
+
+/// Configuration for the optional last-N-frames capture ring. When
+/// `capture_frames == 0` (default) no ring is allocated and the probe only
+/// publishes the latest scalar summary. Defined at namespace scope so it can
+/// serve as a default argument to `AudioProbe::prepare()` (a nested type's
+/// default member initializer is not yet usable while the enclosing class is
+/// still incomplete).
+struct AudioProbeCaptureConfig {
+    /// Frames-per-channel of history to retain. 0 disables capture.
+    int capture_frames = 0;
+};
+
+/// Realtime output-boundary probe. Single-producer (audio thread) / single
+/// consumer (UI/worker thread). Sizing and all allocation happen exactly once,
+/// in `prepare()`. After that, `analyze_output()` is allocation-free.
+///
+/// Lifetime: `prepare()` must run on a non-audio thread before the audio
+/// callback starts calling `analyze_output()`. Re-preparing while the audio
+/// thread is live is a programming error (it reallocates).
+class AudioProbe {
+public:
+    AudioProbe() = default;
+
+    /// @copydoc AudioProbeCaptureConfig
+    using CaptureConfig = AudioProbeCaptureConfig;
+
+    /// Allocate fixed-capacity storage. THE ONLY place the probe allocates.
+    ///
+    /// @param max_channels  Upper bound on channels per block. Clamped to
+    ///                       `AudioProbeSnapshot::kMaxChannels`.
+    /// @param max_frames    Upper bound on frames per block (informational /
+    ///                       used to size the capture ring against). Must be > 0
+    ///                       for capture to function.
+    /// @param sample_rate   Stamped onto every published snapshot.
+    /// @param stage         The boundary this probe observes.
+    /// @param capture       Optional last-N-frames capture configuration.
+    void prepare(int max_channels,
+                 int max_frames,
+                 double sample_rate,
+                 AudioProbeStage stage = AudioProbeStage::kStandaloneOutputBoundary,
+                 CaptureConfig capture = {});
+
+    /// Realtime-safe per-block analysis. Callable from the audio callback.
+    ///
+    /// Performs only bounded scalar work over `output` and publishes an updated
+    /// `AudioProbeSnapshot`. Allocation-free, lock-free, no FFT. Channels beyond
+    /// the prepared capacity are ignored (clamped).
+    void analyze_output(const BufferView<const float>& output) noexcept;
+
+    /// Read the latest published snapshot (UI/worker thread). Returns a copy so
+    /// the reader is not racing the TripleBuffer's front buffer.
+    AudioProbeSnapshot latest() { return summary_buf_.read(); }
+
+    /// Release-safe counter subset, derived from the latest snapshot. The
+    /// `device_*` mirror fields are left at zero here — the HOST populates them
+    /// from `AudioDeviceManager` (ownership boundary, see audio_stats.hpp).
+    AudioStats stats();
+
+    /// Copy up to `max_frames` of the most recent captured channel-0 history
+    /// into `dst` (UI/worker thread). Returns the number of frames written.
+    /// Only meaningful when capture was enabled at prepare(). Non-RT; intended
+    /// for the consumer side.
+    int read_capture(float* dst, int max_frames);
+
+    /// Reset all cumulative counters and the capture ring. Not thread-safe
+    /// against a live audio thread; call when playback is stopped.
+    void reset() noexcept;
+
+    int max_channels() const noexcept { return max_channels_; }
+    int max_frames() const noexcept { return max_frames_; }
+    bool capture_enabled() const noexcept { return capture_frames_ > 0; }
+
+    /// Silence threshold (linear). A block whose per-channel peak is at or below
+    /// this is "silent" for the silence-run counter. Default ~ -90 dBFS.
+    void set_silence_threshold(float linear) noexcept { silence_threshold_ = linear; }
+    /// Clip ceiling (linear). Samples with |x| strictly greater are "clipped".
+    void set_clip_ceiling(float linear) noexcept { clip_ceiling_ = linear; }
+
+private:
+    int max_channels_ = 0;
+    int max_frames_ = 0;
+    int capture_frames_ = 0;
+    double sample_rate_ = 0.0;
+    AudioProbeStage stage_ = AudioProbeStage::kUnknown;
+
+    float silence_threshold_ = 3.1622776e-5f;  // ~ -90 dBFS
+    float clip_ceiling_ = 1.0f;
+
+    std::uint64_t sequence_number_ = 0;
+    std::uint64_t clip_count_ = 0;
+    std::uint64_t nan_inf_count_ = 0;
+    std::uint64_t callbacks_ = 0;
+    std::uint64_t silence_run_blocks_ = 0;
+    std::uint64_t dropped_capture_frames_ = 0;
+
+    runtime::TripleBuffer<AudioProbeSnapshot> summary_buf_;
+
+    // Optional last-N capture: AbstractFifo over preallocated, probe-owned
+    // storage (channel-0 only for the first slice). The ring is sized at
+    // prepare(); analyze_output() never resizes it.
+    std::vector<float> capture_storage_;
+    std::unique_ptr<runtime::AbstractFifo> capture_fifo_;
+};
+
+}  // namespace pulp::audio

--- a/core/audio/include/pulp/audio/audio_probe_snapshot.hpp
+++ b/core/audio/include/pulp/audio/audio_probe_snapshot.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+/// @file audio_probe_snapshot.hpp
+/// The realtime-produced probe summary — the *shared schema* between the RT
+/// producer (`pulp::audio::AudioProbe`, the audio callback) and the non-RT
+/// consumers (UI / offline analysis). Producer and consumers share this data
+/// type only; they NEVER share an implementation path
+/// (`planning/2026-06-09-audio-observability-and-validation-harness-plan.md`,
+/// Section 4, "Two layers, one schema").
+///
+/// `AudioProbeSnapshot` is POD-like and trivially copyable so it can ride a
+/// `runtime::TripleBuffer` (latest-wins summary) without allocation. It is
+/// fixed-capacity: per-channel scalar metrics live in a compile-time-sized
+/// array (`kMaxChannels`). The producer fills only `channel_count` entries; a
+/// `prepare()`-set capacity must be `<= kMaxChannels`.
+///
+/// Carries the identity tuple `{sample_rate, block_size, channel_count,
+/// stage_id, sequence_number}` so a reader can detect stale or mismatched
+/// data, plus explicit stale/drop/overwrite/sequence-gap accounting so a
+/// silently-dropped snapshot is visible, not invisible.
+
+#include <cstdint>
+#include <type_traits>
+
+namespace pulp::audio {
+
+/// Identifies which audio boundary a snapshot was produced at. The first
+/// wired stage is `kStandaloneOutputBoundary` (the post-`process()` output tap
+/// in the standalone host). Other stages follow in later slices.
+enum class AudioProbeStage : std::uint32_t {
+    kUnknown = 0,
+    kProcessorOutput = 1,
+    kStandaloneOutputBoundary = 2,
+    kMeterBridge = 3,
+    kDeviceCallback = 4,
+    kGraphNode = 5,
+};
+
+/// Realtime-produced, fixed-capacity, trivially-copyable probe summary.
+///
+/// Per-channel metrics are stored in fixed arrays sized to `kMaxChannels`.
+/// Only the first `channel_count` entries are meaningful. Aggregate (across
+/// active channels) scalars are also provided for cheap UI consumption.
+struct AudioProbeSnapshot {
+    /// Compile-time channel ceiling. The probe's runtime capacity (set at
+    /// prepare()) must not exceed this. 32 covers ambisonic/surround layouts
+    /// while keeping the snapshot small enough to copy through a TripleBuffer.
+    static constexpr int kMaxChannels = 32;
+
+    // ── Identity tuple (stale/mismatch detection) ──────────────────────────
+    double sample_rate = 0.0;
+    std::uint32_t block_size = 0;
+    std::uint32_t channel_count = 0;
+    AudioProbeStage stage_id = AudioProbeStage::kUnknown;
+    /// Monotonic per-publish counter. A reader stores the last value it saw;
+    /// a gap means snapshots were dropped between reads (TripleBuffer is
+    /// latest-wins). Starts at 0; the first published snapshot is 1.
+    std::uint64_t sequence_number = 0;
+
+    // ── Per-channel scalar metrics (first `channel_count` valid) ────────────
+    /// Peak absolute sample value this block, per channel (linear, >= 0).
+    float peak[kMaxChannels] = {};
+    /// RMS of this block, per channel (linear, >= 0).
+    float rms[kMaxChannels] = {};
+
+    // ── Aggregate scalar metrics (across active channels, this block) ───────
+    /// Max peak across active channels (linear).
+    float peak_max = 0.0f;
+    /// Max RMS across active channels (linear).
+    float rms_max = 0.0f;
+
+    // ── Content event counters (cumulative since prepare()) ─────────────────
+    /// Samples seen with |x| > clip ceiling, summed over all blocks/channels.
+    std::uint64_t clip_count = 0;
+    /// Samples seen as NaN or Inf, summed over all blocks/channels.
+    std::uint64_t nan_inf_count = 0;
+    /// Number of analyzed callbacks (blocks) since prepare().
+    std::uint64_t callbacks = 0;
+    /// Consecutive blocks (most recent run) below the silence threshold. Reset
+    /// to 0 by the first non-silent block. Lets a UI say "silent for N blocks".
+    std::uint64_t silence_run_blocks = 0;
+
+    // ── Drop / overwrite accounting (flight-recorder honesty) ───────────────
+    /// Capture frames the producer could not enqueue because the ring was full
+    /// (only meaningful when last-N capture is enabled). 0 otherwise.
+    std::uint64_t dropped_capture_frames = 0;
+    /// Capture frames overwritten in the ring before a consumer read them
+    /// (only meaningful when overwrite-on-full capture is enabled). 0 otherwise.
+    std::uint64_t overwritten_capture_frames = 0;
+};
+
+static_assert(std::is_trivially_copyable_v<AudioProbeSnapshot>,
+              "AudioProbeSnapshot must be trivially copyable to ride a "
+              "TripleBuffer without allocation");
+static_assert(std::is_trivially_destructible_v<AudioProbeSnapshot>,
+              "AudioProbeSnapshot must be trivially destructible (POD-like)");
+
+}  // namespace pulp::audio

--- a/core/audio/include/pulp/audio/audio_stats.hpp
+++ b/core/audio/include/pulp/audio/audio_stats.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+/// @file audio_stats.hpp
+/// Small POD counter struct for release-safe audio observability.
+///
+/// `AudioStats` is the always-available, minimal counter subset described in
+/// the audio observability harness plan
+/// (`planning/2026-06-09-audio-observability-and-validation-harness-plan.md`,
+/// Section 4 "Runtime Probe Infrastructure", "Release builds" tier). It is a
+/// trivially-copyable aggregate so it can be published lock-free and read on
+/// any thread.
+///
+/// OWNERSHIP BOUNDARY (do not relitigate without a code change):
+///   - Signal-content counters — `callbacks`, `underruns`, `clipped_blocks`,
+///     `nan_blocks` — are owned by the probe / host audio path and reflect the
+///     content of rendered blocks.
+///   - Device/backend counters — `device_xruns`, `cpu_overloads` — are MIRRORS.
+///     They are populated by the HOST from `AudioDeviceManager::xrun_count()`
+///     and the CoreAudio overload listener, which already own that accounting.
+///     `pulp::audio::AudioProbe` MUST NOT increment `device_xruns` or
+///     `cpu_overloads` and must not shadow the device's own counters; doing so
+///     creates a second copy that silently diverges from the device owner.
+///
+/// This struct is intentionally tiny and has no behavior. It carries no
+/// std::vector, no per-channel data, and no FFT/spectrum fields. Richer
+/// per-stage signal facts (NaN/Inf counts, exact clip counts, silence runs,
+/// sequence/stale accounting, stage metadata) live on
+/// `pulp::audio::AudioProbeSnapshot`, not here.
+
+#include <cstdint>
+
+namespace pulp::audio {
+
+/// Minimal release-safe audio counter aggregate. POD; trivially copyable.
+///
+/// All counters are monotonic, free-running totals (never reset per block).
+/// The host is free to publish this through a `runtime::TripleBuffer` for a
+/// UI to poll; nothing here allocates or locks.
+struct AudioStats {
+    /// Number of audio callbacks observed at this stage.
+    std::uint64_t callbacks = 0;
+
+    /// Blocks where the source-backed audio path underran (e.g. a streaming
+    /// handoff had to zero-fill). Owned by the audio path, not the device.
+    std::uint64_t underruns = 0;
+
+    /// Blocks that contained at least one clipped sample (|x| > ceiling).
+    std::uint64_t clipped_blocks = 0;
+
+    /// Blocks that contained at least one NaN or Inf sample.
+    std::uint64_t nan_blocks = 0;
+
+    /// MIRROR of `AudioDeviceManager::xrun_count()`. Populated by the host from
+    /// the device owner — never incremented by the probe.
+    std::uint64_t device_xruns = 0;
+
+    /// MIRROR of the CoreAudio overload listener's count. Populated by the host
+    /// from the device owner — never incremented by the probe.
+    std::uint64_t cpu_overloads = 0;
+};
+
+static_assert(sizeof(AudioStats) == 6 * sizeof(std::uint64_t),
+              "AudioStats must stay a tight POD counter aggregate");
+
+}  // namespace pulp::audio

--- a/core/audio/src/audio_boundary_report.cpp
+++ b/core/audio/src/audio_boundary_report.cpp
@@ -1,0 +1,109 @@
+#include <pulp/audio/audio_boundary_report.hpp>
+
+namespace pulp::audio {
+namespace {
+
+bool snapshot_has_signal(const AudioProbeSnapshot& s, float silence_threshold) {
+    // "Signal" means the most recent block was not in a silence run AND the
+    // observed aggregate peak exceeds the silence threshold.
+    return s.silence_run_blocks == 0 && s.peak_max > silence_threshold;
+}
+
+void append_stage_line(std::string& out,
+                       const char* label,
+                       const std::optional<AudioProbeSnapshot>& snap,
+                       float silence_threshold) {
+    out += label;
+    if (!snap.has_value()) {
+        out += ": no probe\n";
+        return;
+    }
+    const AudioProbeSnapshot& s = *snap;
+    if (snapshot_has_signal(s, silence_threshold)) {
+        out += ": nonzero, peak_max ";
+    } else {
+        out += ": silent (";
+        out += std::to_string(s.silence_run_blocks);
+        out += " blocks), peak_max ";
+    }
+    out += std::to_string(s.peak_max);
+    out += ", clip ";
+    out += std::to_string(s.clip_count);
+    out += ", nan/inf ";
+    out += std::to_string(s.nan_inf_count);
+    out += "\n";
+}
+
+}  // namespace
+
+BoundaryReport build_boundary_report(const BoundaryReportInputs& inputs) {
+    BoundaryReport report;
+    std::string& out = report.text;
+
+    append_stage_line(out, "Processor output", inputs.processor_output,
+                      inputs.silence_threshold);
+    append_stage_line(out, "Standalone boundary", inputs.standalone_boundary,
+                      inputs.silence_threshold);
+
+    if (inputs.device.has_value()) {
+        const DeviceStatsView& d = *inputs.device;
+        out += "Device: ";
+        out += d.callback_running ? "callback running, " : "callback NOT running, ";
+        out += std::to_string(static_cast<long long>(d.sample_rate));
+        out += " Hz / ";
+        out += std::to_string(d.buffer_size);
+        out += " frames, ";
+        out += std::to_string(d.xruns);
+        out += " xruns, ";
+        out += std::to_string(d.cpu_overloads);
+        out += " overloads\n";
+    } else {
+        out += "Device: no stats\n";
+    }
+
+    // Diagnosis precedence: pick the earliest boundary that explains the
+    // missing/odd audio so the next code search is obvious.
+    const bool have_any =
+        inputs.processor_output.has_value() ||
+        inputs.standalone_boundary.has_value();
+    if (!have_any) {
+        report.diagnosis = BoundaryDiagnosis::kNoProbeData;
+        out += "Likely issue: no probe data captured\n";
+        return report;
+    }
+
+    const bool proc_signal =
+        inputs.processor_output.has_value() &&
+        snapshot_has_signal(*inputs.processor_output, inputs.silence_threshold);
+    const bool boundary_signal =
+        inputs.standalone_boundary.has_value() &&
+        snapshot_has_signal(*inputs.standalone_boundary, inputs.silence_threshold);
+
+    if (inputs.processor_output.has_value() && !proc_signal) {
+        report.diagnosis = BoundaryDiagnosis::kProcessorSilent;
+        out += "Likely issue: processor rendered silence\n";
+        return report;
+    }
+
+    if (inputs.standalone_boundary.has_value() && proc_signal && !boundary_signal) {
+        report.diagnosis = BoundaryDiagnosis::kStandaloneBoundarySilent;
+        out += "Likely issue: output buffer not copied after processor render\n";
+        return report;
+    }
+
+    // Signal reached the observed boundary. If the device shows trouble, flag it.
+    if (inputs.device.has_value()) {
+        const DeviceStatsView& d = *inputs.device;
+        if (!d.callback_running || d.xruns > 0) {
+            report.diagnosis = BoundaryDiagnosis::kDeviceProblem;
+            out += "Likely issue: device path (callback stopped or xruns)\n";
+            return report;
+        }
+    }
+
+    report.diagnosis = BoundaryDiagnosis::kSignalPresent;
+    out += "Likely issue: none — signal present at observed boundary\n";
+    return report;
+}
+
+}  // namespace pulp::audio

--- a/core/audio/src/audio_probe.cpp
+++ b/core/audio/src/audio_probe.cpp
@@ -1,0 +1,163 @@
+#include <pulp/audio/audio_probe.hpp>
+
+#include <algorithm>
+#include <cmath>
+
+namespace pulp::audio {
+
+void AudioProbe::prepare(int max_channels,
+                         int max_frames,
+                         double sample_rate,
+                         AudioProbeStage stage,
+                         CaptureConfig capture) {
+    max_channels_ = std::clamp(max_channels, 0, AudioProbeSnapshot::kMaxChannels);
+    max_frames_ = max_frames < 0 ? 0 : max_frames;
+    sample_rate_ = sample_rate;
+    stage_ = stage;
+
+    capture_frames_ = capture.capture_frames < 0 ? 0 : capture.capture_frames;
+    capture_storage_.clear();
+    capture_fifo_.reset();
+    if (capture_frames_ > 0) {
+        // AbstractFifo reserves one sentinel slot, so allocate capacity+1 so
+        // the worst-case queue depth is exactly `capture_frames_`.
+        const int cap = capture_frames_ + 1;
+        capture_storage_.assign(static_cast<std::size_t>(cap), 0.0f);
+        capture_fifo_ = std::make_unique<runtime::AbstractFifo>(cap);
+    }
+
+    sequence_number_ = 0;
+    clip_count_ = 0;
+    nan_inf_count_ = 0;
+    callbacks_ = 0;
+    silence_run_blocks_ = 0;
+    dropped_capture_frames_ = 0;
+
+    // Publish an initial empty snapshot so a reader before the first callback
+    // sees coherent identity fields instead of a default-constructed sequence 0
+    // that looks like live data.
+    AudioProbeSnapshot init{};
+    init.sample_rate = sample_rate_;
+    init.channel_count = 0;
+    init.stage_id = stage_;
+    init.sequence_number = 0;
+    summary_buf_.write(init);
+}
+
+void AudioProbe::analyze_output(const BufferView<const float>& output) noexcept {
+    // RT-SAFE BODY. No allocation, no locks, no FFT, no logging, no exceptions,
+    // no vector growth. Only bounded scalar arithmetic over the block.
+    const int channels =
+        std::min<int>(static_cast<int>(output.num_channels()), max_channels_);
+    const int frames = static_cast<int>(output.num_samples());
+
+    AudioProbeSnapshot snap{};
+    snap.sample_rate = sample_rate_;
+    snap.block_size = static_cast<std::uint32_t>(frames < 0 ? 0 : frames);
+    snap.channel_count = static_cast<std::uint32_t>(channels < 0 ? 0 : channels);
+    snap.stage_id = stage_;
+
+    bool block_silent = true;
+
+    for (int ch = 0; ch < channels; ++ch) {
+        const float* samples = output.channel_ptr(static_cast<std::size_t>(ch));
+        float peak = 0.0f;
+        double sum_sq = 0.0;
+        for (int i = 0; i < frames; ++i) {
+            const float x = samples[i];
+            // NaN/Inf detection without exceptions or allocation.
+            if (!std::isfinite(x)) {
+                ++nan_inf_count_;
+                continue;  // do not fold a non-finite value into peak/RMS
+            }
+            const float ax = std::fabs(x);
+            if (ax > peak) peak = ax;
+            if (ax > clip_ceiling_) ++clip_count_;
+            sum_sq += static_cast<double>(x) * static_cast<double>(x);
+        }
+        const float rms = frames > 0
+            ? static_cast<float>(std::sqrt(sum_sq / static_cast<double>(frames)))
+            : 0.0f;
+        snap.peak[ch] = peak;
+        snap.rms[ch] = rms;
+        if (peak > snap.peak_max) snap.peak_max = peak;
+        if (rms > snap.rms_max) snap.rms_max = rms;
+        if (peak > silence_threshold_) block_silent = false;
+    }
+
+    if (channels == 0 || frames == 0) block_silent = true;
+
+    ++callbacks_;
+    if (block_silent) {
+        ++silence_run_blocks_;
+    } else {
+        silence_run_blocks_ = 0;
+    }
+
+    // Optional last-N channel-0 capture. SPSC: producer (here) only writes; the
+    // consumer drains via read_capture(). When the ring is full, frames that do
+    // not fit are dropped and counted — never silently lost.
+    if (capture_fifo_ && channels > 0 && frames > 0) {
+        const float* ch0 = output.channel_ptr(0);
+        int s1 = 0, n1 = 0, s2 = 0, n2 = 0;
+        capture_fifo_->prepare_to_write(frames, s1, n1, s2, n2);
+        const int written = n1 + n2;
+        for (int i = 0; i < n1; ++i)
+            capture_storage_[static_cast<std::size_t>(s1 + i)] = ch0[i];
+        for (int i = 0; i < n2; ++i)
+            capture_storage_[static_cast<std::size_t>(s2 + i)] = ch0[n1 + i];
+        capture_fifo_->finish_write(written);
+        if (written < frames) {
+            dropped_capture_frames_ +=
+                static_cast<std::uint64_t>(frames - written);
+        }
+    }
+
+    ++sequence_number_;
+    snap.sequence_number = sequence_number_;
+    snap.clip_count = clip_count_;
+    snap.nan_inf_count = nan_inf_count_;
+    snap.callbacks = callbacks_;
+    snap.silence_run_blocks = silence_run_blocks_;
+    snap.dropped_capture_frames = dropped_capture_frames_;
+    snap.overwritten_capture_frames = 0;  // drop-on-full policy: no overwrite
+
+    summary_buf_.write(snap);
+}
+
+AudioStats AudioProbe::stats() {
+    const AudioProbeSnapshot snap = summary_buf_.read();
+    AudioStats out;
+    out.callbacks = snap.callbacks;
+    out.underruns = 0;  // not tracked by the output-boundary probe itself
+    out.clipped_blocks = snap.clip_count > 0 ? snap.clip_count : 0;
+    out.nan_blocks = snap.nan_inf_count;
+    // device_xruns / cpu_overloads are MIRRORS owned by the device — the host
+    // populates them, the probe never does. Leave at zero here.
+    return out;
+}
+
+int AudioProbe::read_capture(float* dst, int max_frames) {
+    if (!capture_fifo_ || dst == nullptr || max_frames <= 0) return 0;
+    int s1 = 0, n1 = 0, s2 = 0, n2 = 0;
+    capture_fifo_->prepare_to_read(max_frames, s1, n1, s2, n2);
+    const int total = n1 + n2;
+    for (int i = 0; i < n1; ++i)
+        dst[i] = capture_storage_[static_cast<std::size_t>(s1 + i)];
+    for (int i = 0; i < n2; ++i)
+        dst[n1 + i] = capture_storage_[static_cast<std::size_t>(s2 + i)];
+    capture_fifo_->finish_read(total);
+    return total;
+}
+
+void AudioProbe::reset() noexcept {
+    sequence_number_ = 0;
+    clip_count_ = 0;
+    nan_inf_count_ = 0;
+    callbacks_ = 0;
+    silence_run_blocks_ = 0;
+    dropped_capture_frames_ = 0;
+    if (capture_fifo_) capture_fifo_->reset();
+}
+
+}  // namespace pulp::audio

--- a/core/format/include/pulp/format/standalone.hpp
+++ b/core/format/include/pulp/format/standalone.hpp
@@ -2,6 +2,9 @@
 
 #include <pulp/audio/buffer.hpp>
 #include <pulp/audio/device.hpp>
+#if PULP_ENABLE_AUDIO_PROBES
+#include <pulp/audio/audio_probe.hpp>
+#endif
 #include <pulp/format/processor.hpp>
 #include <pulp/format/test_signal.hpp>
 #include <pulp/midi/device.hpp>
@@ -97,6 +100,17 @@ public:
     TestSignalSource& test_signal() { return test_signal_; }
     view::AudioBridge& input_meter_bridge() { return input_meter_bridge_; }
     view::AudioBridge& output_meter_bridge() { return output_meter_bridge_; }
+
+#if PULP_ENABLE_AUDIO_PROBES
+    /// Realtime output-boundary probe (Phase 5). Observes the processor output
+    /// at the "standalone processor-output boundary" — immediately after
+    /// `processor_->process(...)` and before the device callback returns. This
+    /// is the first wired probe stage for the "UI works, no sound" report. A
+    /// consumer (UI/test) reads the latest snapshot via
+    /// `output_probe().latest()`. Distinct from `input_meter_bridge_`, which is
+    /// input-oriented and lacks the snapshot's stage/sequence/NaN/clip fields.
+    audio::AudioProbe& output_probe() { return output_probe_; }
+#endif
     audio::AudioSystem* audio_system() { return audio_system_.get(); }
     midi::MidiSystem* midi_system() { return midi_system_.get(); }
 
@@ -152,6 +166,15 @@ private:
     TestSignalSource test_signal_;
     view::AudioBridge input_meter_bridge_;
     view::AudioBridge output_meter_bridge_;
+#if PULP_ENABLE_AUDIO_PROBES
+    // Phase 5 realtime output-boundary probe. prepare()d in start() with the
+    // device's channel/buffer/rate; analyze_output() is called from the audio
+    // callback right after processor render. RT-safe (scalar-only).
+    audio::AudioProbe output_probe_;
+    // Pre-allocated channel-pointer array for the probe view (no audio-thread
+    // allocation). Sized in start() to the output channel count.
+    std::vector<const float*> output_probe_ptrs_;
+#endif
     audio::Buffer<float> test_buffer_;        // Pre-allocated for audio callback
     audio::Buffer<float> silence_buffer_;    // Pre-allocated silence for missing input
     std::vector<float*> test_ptrs_;           // Pre-allocated channel pointers

--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -159,6 +159,18 @@ bool StandaloneApp::start() {
     for (int c = 0; c < silence_ch; ++c)
         silence_ptrs_[static_cast<size_t>(c)] = silence_buffer_.view().channel_ptr(static_cast<size_t>(c));
 
+#if PULP_ENABLE_AUDIO_PROBES
+    // Phase 5 — prepare the realtime output-boundary probe BEFORE the audio
+    // callback starts. This is the only place it allocates. Capture is left
+    // off here (latest-summary only); a debug/support build can opt into the
+    // last-N ring via output_probe().prepare(...) with a CaptureConfig.
+    output_probe_.prepare(config_.output_channels, config_.buffer_size,
+                          config_.sample_rate,
+                          audio::AudioProbeStage::kStandaloneOutputBoundary);
+    output_probe_ptrs_.assign(static_cast<size_t>(std::max(config_.output_channels, 0)),
+                              nullptr);
+#endif
+
     // Set up MIDI input (optional)
     if (desc.accepts_midi) {
         midi_system_ = midi::create_midi_system();
@@ -312,6 +324,23 @@ bool StandaloneApp::start() {
                 static_cast<int>(out_ch),
                 ctx.buffer_size);
         }
+#if PULP_ENABLE_AUDIO_PROBES
+        // Phase 5 — standalone processor-output boundary probe. Tap the
+        // processor's output immediately after render and before returning to
+        // the device callback. RT-safe: scalar-only, no allocation, no FFT.
+        // This is the boundary where "UI works, no sound" reports separate
+        // processor silence from output-boundary silence. Fill the
+        // pre-allocated const pointer array (no audio-thread allocation), then
+        // wrap it in a const view for analyze_output().
+        {
+            const size_t out_ch = output.num_channels();
+            for (size_t c = 0; c < out_ch && c < output_probe_ptrs_.size(); ++c)
+                output_probe_ptrs_[c] = output.channel_ptr(c);
+            const size_t probe_ch = std::min(out_ch, output_probe_ptrs_.size());
+            output_probe_.analyze_output(audio::BufferView<const float>(
+                output_probe_ptrs_.data(), probe_ch, output.num_samples()));
+        }
+#endif
 
         // Advance the rolling sample clock so the next block reads a
         // monotonic timeline. Done after process() so the in-block

--- a/core/view/include/pulp/view/visualization_bridge.hpp
+++ b/core/view/include/pulp/view/visualization_bridge.hpp
@@ -5,8 +5,28 @@
 /// metering, and waveform capture. Manages all audio→UI publication paths
 /// for visualization through a single configuration point.
 ///
+/// NOT A REALTIME-SAFE GENERIC AUDIO PROBE.
+/// =========================================
+/// Despite running from the audio callback, `VisualizationBridge::process()`
+/// is **not** an RT-safe probe and must not be copied as the model for one.
+/// Its body runs a full STFT and calls `Stft::latest_magnitude_db()`, which
+/// returns a `std::vector` — i.e. it performs FFT work and (potentially)
+/// heap allocation on the audio thread. That is acceptable here only because
+/// this bridge is an opt-in visualization path for examples/demos, not a
+/// general-purpose boundary probe, and because callers accept the cost.
+///
+/// The realtime-safe, allocation-free, scalar-only probe path is
+/// `pulp::audio::AudioProbe` (header `pulp/audio/audio_probe.hpp`). Use that
+/// — never this class — when you need an output-boundary probe that satisfies
+/// the strict RT ABI (no allocation, no FFT/STFT, no locks, no vector growth).
+/// Reuse this bridge's UI-side rendering if you like, but never its
+/// callback-side analysis. See the harness plan
+/// (`planning/2026-06-09-audio-observability-and-validation-harness-plan.md`,
+/// Section 4 "Runtime Probe Infrastructure").
+///
 /// Audio thread calls process(). UI thread reads latest data.
-/// All transport uses TripleBuffer (latest-value, no blocking, no allocation).
+/// Spectrum/meter/waveform publication uses TripleBuffer (latest-value), but
+/// the *analysis* feeding it (STFT) is not allocation-free — see above.
 ///
 /// Forward-compatible with Phase 13 Three.js bridge: the same data published
 /// here is accessible from JS via AudioBridge → widget_bridge.cpp bindings.
@@ -72,6 +92,10 @@ struct VisualizationConfig {
 /// visualization data. Wraps STFT, multi-channel metering, and waveform
 /// capture with lock-free TripleBuffer publication.
 ///
+/// NOT an RT-safe probe — see the file-level comment. `process()` runs STFT
+/// and a vector-returning spectrum path on the audio thread. For an
+/// allocation-free output-boundary probe, use `pulp::audio::AudioProbe`.
+///
 /// Thread model:
 ///   - Audio thread: calls process() from the audio callback
 ///   - UI thread: calls read_spectrum(), read_meter(), read_waveform()
@@ -105,6 +129,11 @@ public:
 
     /// Process audio from the audio callback. Computes STFT, metering,
     /// and waveform capture, then publishes results lock-free.
+    ///
+    /// WARNING: this is NOT allocation-free. The STFT path calls
+    /// `Stft::latest_magnitude_db()` (vector-returning) on the audio thread.
+    /// Do not treat this as the RT-safe probe contract — use
+    /// `pulp::audio::AudioProbe::analyze_output()` for that.
     ///
     /// @param channels  Array of channel buffer pointers.
     /// @param num_channels  Number of channels.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5661,7 +5661,10 @@ add_executable(pulp-test-audio-doctor test_audio_doctor.cpp)
 target_link_libraries(pulp-test-audio-doctor PRIVATE pulp-audio-test-support Catch2::Catch2WithMain)
 target_include_directories(pulp-test-audio-doctor PRIVATE ${CMAKE_SOURCE_DIR}/examples/pulp-effect)
 catch_discover_tests(pulp-test-audio-doctor)
-
+# Phase 5 RT output-boundary probe — allocation-counting acceptance + counters.
+add_executable(pulp-test-audio-probe test_audio_probe.cpp harness/rt_allocation_probe.cpp)
+target_link_libraries(pulp-test-audio-probe PRIVATE pulp::audio pulp::runtime Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-audio-probe)
 # Audio determinism matrix (#48 / #356): SR × block sweep, framework invariants (pass-through, silence, block invariance, re-prepare).
 add_executable(pulp-test-audio-matrix test_audio_determinism_matrix.cpp)
 target_link_libraries(pulp-test-audio-matrix PRIVATE pulp::format pulp::signal Catch2::Catch2WithMain)
@@ -5682,16 +5685,13 @@ add_executable(pulp-test-negative-path test_negative_path.cpp)
 target_link_libraries(pulp-test-negative-path PRIVATE pulp::format Catch2::Catch2WithMain)
 target_include_directories(pulp-test-negative-path PRIVATE ${CMAKE_SOURCE_DIR}/examples/pulp-gain ${CMAKE_SOURCE_DIR}/examples/pulp-tone)
 catch_discover_tests(pulp-test-negative-path)
-
 # iOS foundation tests (platform detection, safe area geometry, touch events,
 # AUv3 HostApp template shape).
 pulp_add_test_suite(pulp-test-ios-foundation LIBRARIES pulp::view pulp::platform)
 target_compile_definitions(pulp-test-ios-foundation PRIVATE
     PULP_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
-
 # Identity/UUID tests
 pulp_add_test_suite(pulp-test-identity LIBRARIES pulp::runtime)
-
 # WebView tests (requires PULP_BUILD_WEBVIEW — WebViewPanel::create is only compiled when ON)
 if(PULP_BUILD_WEBVIEW)
     add_executable(pulp-test-webview test_web_view.cpp)

--- a/test/test_audio_probe.cpp
+++ b/test/test_audio_probe.cpp
@@ -1,0 +1,383 @@
+// test_audio_probe.cpp — Phase 5 RT-probe acceptance.
+//
+// GATE 2: an allocation-counting test (RtAllocationProbe) asserting ZERO
+// allocations across N analyze_output() calls after prepare(). Plus correctness
+// for peak/RMS/clip/NaN/silence counting, snapshot sequence monotonicity +
+// stale/drop detection, TripleBuffer publish/read coherence, the capture
+// AbstractFifo's drop accounting, AudioStats device-counter mirroring, and the
+// complaint-oriented boundary report.
+
+#include "harness/rt_allocation_probe.hpp"
+
+#include <pulp/audio/audio_boundary_report.hpp>
+#include <pulp/audio/audio_probe.hpp>
+#include <pulp/audio/audio_probe_snapshot.hpp>
+#include <pulp/audio/audio_stats.hpp>
+#include <pulp/audio/buffer.hpp>
+#include <pulp/runtime/scoped_no_alloc.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <cmath>
+#include <limits>
+#include <vector>
+
+using Catch::Matchers::WithinAbs;
+using namespace pulp::audio;
+
+namespace {
+
+// A fixed-capacity stereo block backed by stable storage. Channel pointers are
+// allocated ONCE so building the view never allocates on the audio path.
+struct StereoBlock {
+    std::vector<float> left;
+    std::vector<float> right;
+    std::vector<const float*> ptrs;
+
+    explicit StereoBlock(std::size_t frames)
+        : left(frames, 0.0f), right(frames, 0.0f) {
+        ptrs = {left.data(), right.data()};
+    }
+
+    BufferView<const float> view() const {
+        return BufferView<const float>(ptrs.data(), 2, left.size());
+    }
+
+    void fill(float l, float r) {
+        std::fill(left.begin(), left.end(), l);
+        std::fill(right.begin(), right.end(), r);
+    }
+};
+
+}  // namespace
+
+TEST_CASE("AudioProbe::analyze_output does not allocate after prepare",
+          "[rt-safety][audio-probe][issue-290]") {
+    AudioProbe probe;
+    probe.prepare(/*max_channels=*/2, /*max_frames=*/256, /*sample_rate=*/48000.0);
+
+    constexpr std::size_t kFrames = 256;
+    StereoBlock block(kFrames);
+    // A non-trivial signal so every counting branch runs: clipping, a NaN, and
+    // ordinary samples — exercising the widest RT path inside the no-alloc scope.
+    block.fill(0.5f, -0.5f);
+    block.left[10] = 2.0f;   // clip
+    block.right[20] = std::numeric_limits<float>::quiet_NaN();  // nan
+
+    const auto v = block.view();
+
+    std::size_t allocation_count = 0;
+    std::size_t allocated_bytes = 0;
+    {
+        pulp::test::RtAllocationProbe alloc_probe;
+        pulp::runtime::ScopedNoAlloc no_alloc;
+        for (int i = 0; i < 1000; ++i) {
+            probe.analyze_output(v);
+        }
+        allocation_count = alloc_probe.allocation_count();
+        allocated_bytes = alloc_probe.allocated_bytes();
+    }
+
+    REQUIRE(allocation_count == 0);
+    REQUIRE(allocated_bytes == 0);
+}
+
+TEST_CASE("AudioProbe::analyze_output with capture ring does not allocate",
+          "[rt-safety][audio-probe][issue-290]") {
+    AudioProbe probe;
+    AudioProbe::CaptureConfig cap;
+    cap.capture_frames = 1024;
+    probe.prepare(2, 256, 48000.0, AudioProbeStage::kStandaloneOutputBoundary, cap);
+    REQUIRE(probe.capture_enabled());
+
+    StereoBlock block(256);
+    block.fill(0.25f, 0.25f);
+    const auto v = block.view();
+
+    std::size_t allocation_count = 0;
+    {
+        pulp::test::RtAllocationProbe alloc_probe;
+        pulp::runtime::ScopedNoAlloc no_alloc;
+        for (int i = 0; i < 500; ++i) probe.analyze_output(v);
+        allocation_count = alloc_probe.allocation_count();
+    }
+    REQUIRE(allocation_count == 0);
+}
+
+TEST_CASE("AudioProbe counts peak, RMS, clip, NaN, silence correctly",
+          "[audio-probe]") {
+    AudioProbe probe;
+    probe.prepare(2, 64, 48000.0);
+
+    SECTION("known DC level → exact peak and RMS") {
+        StereoBlock block(64);
+        block.fill(0.5f, -0.25f);
+        probe.analyze_output(block.view());
+        const auto snap = probe.latest();
+        REQUIRE(snap.channel_count == 2);
+        REQUIRE(snap.block_size == 64);
+        REQUIRE_THAT(snap.peak[0], WithinAbs(0.5f, 1e-6f));
+        REQUIRE_THAT(snap.peak[1], WithinAbs(0.25f, 1e-6f));
+        REQUIRE_THAT(snap.rms[0], WithinAbs(0.5f, 1e-5f));
+        REQUIRE_THAT(snap.rms[1], WithinAbs(0.25f, 1e-5f));
+        REQUIRE_THAT(snap.peak_max, WithinAbs(0.5f, 1e-6f));
+        REQUIRE(snap.clip_count == 0);
+        REQUIRE(snap.nan_inf_count == 0);
+        REQUIRE(snap.silence_run_blocks == 0);  // 0.5 > silence threshold
+    }
+
+    SECTION("clipping is counted per-sample, not per-block") {
+        StereoBlock block(64);
+        block.fill(0.1f, 0.1f);
+        block.left[0] = 1.5f;   // clip
+        block.left[1] = -2.0f;  // clip
+        probe.analyze_output(block.view());
+        const auto snap = probe.latest();
+        REQUIRE(snap.clip_count == 2);
+    }
+
+    SECTION("NaN and Inf are counted and excluded from peak/RMS") {
+        StereoBlock block(64);
+        block.fill(0.0f, 0.0f);
+        block.left[0] = std::numeric_limits<float>::quiet_NaN();
+        block.left[1] = std::numeric_limits<float>::infinity();
+        probe.analyze_output(block.view());
+        const auto snap = probe.latest();
+        REQUIRE(snap.nan_inf_count == 2);
+        REQUIRE_THAT(snap.peak[0], WithinAbs(0.0f, 1e-6f));  // non-finite skipped
+    }
+
+    SECTION("silence run accumulates then resets on signal") {
+        StereoBlock quiet(64);
+        quiet.fill(0.0f, 0.0f);
+        probe.analyze_output(quiet.view());
+        probe.analyze_output(quiet.view());
+        probe.analyze_output(quiet.view());
+        REQUIRE(probe.latest().silence_run_blocks == 3);
+
+        StereoBlock loud(64);
+        loud.fill(0.3f, 0.3f);
+        probe.analyze_output(loud.view());
+        REQUIRE(probe.latest().silence_run_blocks == 0);
+    }
+}
+
+TEST_CASE("AudioProbe snapshot sequence number is monotonic and gaps detectable",
+          "[audio-probe]") {
+    AudioProbe probe;
+    probe.prepare(1, 32, 44100.0);
+
+    StereoBlock block(32);
+    block.fill(0.2f, 0.2f);
+
+    // prepare() publishes sequence 0; the first analyze_output() makes it 1.
+    REQUIRE(probe.latest().sequence_number == 0);
+
+    std::uint64_t last = 0;
+    for (int i = 0; i < 10; ++i) {
+        probe.analyze_output(block.view());
+        const auto snap = probe.latest();
+        REQUIRE(snap.sequence_number > last);  // strictly monotonic
+        last = snap.sequence_number;
+    }
+
+    // TripleBuffer is latest-wins: producing several blocks between reads
+    // advances the sequence by more than one — a reader sees the gap.
+    const std::uint64_t before = last;
+    probe.analyze_output(block.view());
+    probe.analyze_output(block.view());
+    probe.analyze_output(block.view());
+    const auto after = probe.latest();
+    REQUIRE(after.sequence_number == before + 3);  // gap of 3 is visible
+}
+
+TEST_CASE("AudioProbe TripleBuffer publish/read coherence",
+          "[audio-probe]") {
+    AudioProbe probe;
+    probe.prepare(2, 16, 48000.0);
+
+    StereoBlock a(16);
+    a.fill(0.1f, 0.1f);
+    StereoBlock b(16);
+    b.fill(0.8f, 0.8f);
+
+    probe.analyze_output(a.view());
+    const auto snap_a = probe.latest();
+    REQUIRE_THAT(snap_a.peak_max, WithinAbs(0.1f, 1e-6f));
+
+    probe.analyze_output(b.view());
+    const auto snap_b = probe.latest();
+    REQUIRE_THAT(snap_b.peak_max, WithinAbs(0.8f, 1e-6f));
+
+    // Re-reading without a new write returns the same coherent value.
+    const auto snap_b2 = probe.latest();
+    REQUIRE(snap_b2.sequence_number == snap_b.sequence_number);
+    REQUIRE_THAT(snap_b2.peak_max, WithinAbs(0.8f, 1e-6f));
+}
+
+TEST_CASE("AudioProbe capture ring drains and accounts for drops",
+          "[audio-probe]") {
+    AudioProbe probe;
+    AudioProbe::CaptureConfig cap;
+    cap.capture_frames = 100;  // small ring to force overflow
+    probe.prepare(1, 64, 48000.0, AudioProbeStage::kStandaloneOutputBoundary, cap);
+
+    StereoBlock block(64);
+    block.fill(0.5f, 0.5f);
+
+    // First block (64 frames) fits in the 100-frame ring.
+    probe.analyze_output(block.view());
+    REQUIRE(probe.latest().dropped_capture_frames == 0);
+
+    // Second block: only 36 of 64 fit before the ring is full → 28 dropped,
+    // counted (never silently lost).
+    probe.analyze_output(block.view());
+    REQUIRE(probe.latest().dropped_capture_frames == 28);
+
+    // Consumer drains everything available.
+    std::vector<float> out(200, -1.0f);
+    const int read = probe.read_capture(out.data(), static_cast<int>(out.size()));
+    REQUIRE(read == 100);  // ring held its full capacity
+    for (int i = 0; i < read; ++i)
+        REQUIRE_THAT(out[static_cast<std::size_t>(i)], WithinAbs(0.5f, 1e-6f));
+
+    // After draining, new writes fit again.
+    probe.analyze_output(block.view());
+    REQUIRE(probe.latest().dropped_capture_frames == 28);  // unchanged: this block fit
+}
+
+TEST_CASE("AudioStats mirrors device counters without shadowing",
+          "[audio-probe][audio-stats]") {
+    // The probe owns signal-content counters and NEVER touches device_xruns /
+    // cpu_overloads — those are mirrors the host fills from the device owner.
+    AudioProbe probe;
+    probe.prepare(2, 64, 48000.0);
+
+    StereoBlock block(64);
+    block.fill(0.1f, 0.1f);
+    block.left[0] = 2.0f;  // clip
+    block.left[1] = std::numeric_limits<float>::quiet_NaN();
+    probe.analyze_output(block.view());
+
+    AudioStats s = probe.stats();
+    REQUIRE(s.callbacks == 1);
+    REQUIRE(s.nan_blocks >= 1);
+    REQUIRE(s.clipped_blocks >= 1);
+    // Probe leaves device mirrors at zero — the host populates them.
+    REQUIRE(s.device_xruns == 0);
+    REQUIRE(s.cpu_overloads == 0);
+
+    // The host mirrors device-owned counters in afterward; the probe call
+    // above did not invent them.
+    s.device_xruns = 7;      // e.g. AudioDeviceManager::xrun_count()
+    s.cpu_overloads = 3;     // e.g. CoreAudio overload listener
+    REQUIRE(s.device_xruns == 7);
+    REQUIRE(s.cpu_overloads == 3);
+    // Re-querying the probe still reports zero — it does not shadow the host's
+    // mirror values.
+    REQUIRE(probe.stats().device_xruns == 0);
+}
+
+TEST_CASE("AudioProbe reset clears cumulative counters",
+          "[audio-probe]") {
+    AudioProbe probe;
+    probe.prepare(1, 32, 48000.0);
+    StereoBlock block(32);
+    block.fill(2.0f, 2.0f);  // clips every sample
+    probe.analyze_output(block.view());
+    REQUIRE(probe.latest().clip_count > 0);
+    probe.reset();
+    probe.analyze_output(StereoBlock(32).view());  // silence
+    const auto snap = probe.latest();
+    REQUIRE(snap.clip_count == 0);
+    REQUIRE(snap.callbacks == 1);
+}
+
+TEST_CASE("AudioProbeSnapshot is a trivially-copyable shared schema",
+          "[audio-probe]") {
+    STATIC_REQUIRE(std::is_trivially_copyable_v<AudioProbeSnapshot>);
+    STATIC_REQUIRE(std::is_trivially_copyable_v<AudioStats>);
+}
+
+// ── Complaint-oriented boundary report ─────────────────────────────────────
+
+namespace {
+
+AudioProbeSnapshot make_snap(AudioProbeStage stage, float peak_max,
+                             std::uint64_t silence_run) {
+    AudioProbeSnapshot s{};
+    s.stage_id = stage;
+    s.peak_max = peak_max;
+    s.silence_run_blocks = silence_run;
+    s.sequence_number = 1;
+    return s;
+}
+
+}  // namespace
+
+TEST_CASE("Boundary report distinguishes processor / boundary / device faults",
+          "[audio-probe][boundary-report]") {
+    SECTION("processor silent → processor diagnosis") {
+        BoundaryReportInputs in;
+        in.processor_output =
+            make_snap(AudioProbeStage::kProcessorOutput, 0.0f, 40);
+        in.standalone_boundary =
+            make_snap(AudioProbeStage::kStandaloneOutputBoundary, 0.0f, 40);
+        const auto report = build_boundary_report(in);
+        REQUIRE(report.diagnosis == BoundaryDiagnosis::kProcessorSilent);
+        REQUIRE(report.text.find("processor rendered silence") != std::string::npos);
+    }
+
+    SECTION("processor signal but boundary silent → boundary diagnosis") {
+        BoundaryReportInputs in;
+        in.processor_output =
+            make_snap(AudioProbeStage::kProcessorOutput, 0.3f, 0);
+        in.standalone_boundary =
+            make_snap(AudioProbeStage::kStandaloneOutputBoundary, 0.0f, 38);
+        const auto report = build_boundary_report(in);
+        REQUIRE(report.diagnosis == BoundaryDiagnosis::kStandaloneBoundarySilent);
+        REQUIRE(report.text.find("output buffer not copied") != std::string::npos);
+    }
+
+    SECTION("signal present but device xruns → device diagnosis") {
+        BoundaryReportInputs in;
+        in.processor_output =
+            make_snap(AudioProbeStage::kProcessorOutput, 0.3f, 0);
+        in.standalone_boundary =
+            make_snap(AudioProbeStage::kStandaloneOutputBoundary, 0.3f, 0);
+        DeviceStatsView dev;
+        dev.callback_running = true;
+        dev.sample_rate = 48000.0;
+        dev.buffer_size = 128;
+        dev.xruns = 12;
+        in.device = dev;
+        const auto report = build_boundary_report(in);
+        REQUIRE(report.diagnosis == BoundaryDiagnosis::kDeviceProblem);
+        REQUIRE(report.text.find("12 xruns") != std::string::npos);
+    }
+
+    SECTION("everything healthy → signal present") {
+        BoundaryReportInputs in;
+        in.processor_output =
+            make_snap(AudioProbeStage::kProcessorOutput, 0.3f, 0);
+        in.standalone_boundary =
+            make_snap(AudioProbeStage::kStandaloneOutputBoundary, 0.3f, 0);
+        DeviceStatsView dev;
+        dev.callback_running = true;
+        dev.sample_rate = 48000.0;
+        dev.buffer_size = 128;
+        dev.xruns = 0;
+        in.device = dev;
+        const auto report = build_boundary_report(in);
+        REQUIRE(report.diagnosis == BoundaryDiagnosis::kSignalPresent);
+    }
+
+    SECTION("missing stage reported as no-probe, not faked silence") {
+        BoundaryReportInputs in;  // nothing populated
+        const auto report = build_boundary_report(in);
+        REQUIRE(report.diagnosis == BoundaryDiagnosis::kNoProbeData);
+        REQUIRE(report.text.find("Processor output: no probe") != std::string::npos);
+        REQUIRE(report.text.find("Standalone boundary: no probe") != std::string::npos);
+    }
+}


### PR DESCRIPTION
Phase 5 of the audio observability harness. Adds the realtime-safe probe layer (gates 1+2 of the plan folded in).

## Gates
- **Gate 1** — `VisualizationBridge` quarantined (docs) as NOT an RT-safe probe model; points at `pulp::audio::AudioProbe`.
- **Gate 2** — allocation-counting acceptance: `RtAllocationProbe` asserts **0 allocations / 0 bytes** across 1000 `analyze_output()` calls (and 500 with capture).
- Gate 3 (macOS Cmd consumption) already landed in #3847.

## What's added (all behind `PULP_ENABLE_AUDIO_PROBES`, default OFF)
- `core/audio`: `AudioStats` (POD; device counters are host-populated mirrors, not shadowed), `AudioProbeSnapshot` (fixed-capacity, `static_assert(trivially_copyable)`, identity tuple + scalar metrics + stale/drop/seq-gap counters), `AudioProbe` (RT producer: TripleBuffer summary + optional AbstractFifo last-N capture), `AudioBoundaryReport` (consumer-side 'no sound' stage report).
- `core/format/standalone`: probe tap immediately after `processor_->process(...)` — the standalone output boundary; pre-allocated pointer array, no callback allocation. Does not reuse `input_meter_bridge_`.
- `test/test_audio_probe.cpp`: 162 assertions / 10 cases (allocation hammer, scalar-metric correctness, sequence monotonicity + drop accounting, TripleBuffer coherence, AudioStats mirror-not-shadow).

## Verification
- RT ABI: no alloc/lock/FFT/IO/logging/exceptions/UI in `analyze_output()`, proven by the allocation hammer.
- **OFF build genuinely free of probe cost** — `nm`: `standalone.cpp.o` has 2 AudioProbe refs ON, **0** OFF.
- All existing harness suites pass unchanged; diff-coverage 97% (probe 99.2%, boundary report 100%).
- Release `-O3 -DNDEBUG` verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a realtime-safe audio output probe at the standalone processor-output boundary to diagnose “no sound” with zero-allocation analysis, plus a consumer-side boundary report. Gated by `PULP_ENABLE_AUDIO_PROBES` (OFF by default); `pulp::view::VisualizationBridge` is explicitly quarantined as non-RT-safe.

- **New Features**
  - `core/audio`: `pulp::audio::AudioProbe` (RT producer), `AudioProbeSnapshot` (trivially copyable), `AudioStats` (POD), and `build_boundary_report(...)` with `DeviceStatsView`.
  - Standalone host: post-`process()` probe tap using a pre-allocated pointer array; accessor `StandaloneApp::output_probe()`; fully `#if PULP_ENABLE_AUDIO_PROBES`-guarded so OFF builds link no probe symbols.
  - Tests: `pulp-test-audio-probe` checks zero-allocation RT behavior, capture-ring drop accounting, sequence gaps, TripleBuffer coherence, and boundary reporting.
  - Docs: `pulp::view::VisualizationBridge` header/class/method comments now clearly mark it non-RT-safe and point to `pulp::audio::AudioProbe`; SKILL notes cover the standalone tap and guard usage.

- **Migration**
  - To enable probes: build with `-DPULP_ENABLE_AUDIO_PROBES=ON`, then read snapshots via `StandaloneApp::output_probe().latest()` and build reports with `pulp::audio::build_boundary_report(...)`. No changes needed if left OFF.

<sup>Written for commit 3c075707f3895477efc5b1031b2a1304ccab13dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

