### PR TITLE
ci(release): self-heal Rust toolchain discovery so build/pulp can't silently drop

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -233,21 +233,41 @@ jobs:
       # Pulp's documented JS engine policy (CLAUDE.md) is QuickJS on
       # Linux, so the CLI must not link JSC-GTK at all. Issue #720.
       #
-      # Ensure the Rust toolchain is on PATH before configure. GitHub-hosted
-      # runners ship cargo on PATH; self-hosted runners (the bare-metal Studio
-      # Macs) have it at ~/.cargo/bin but a non-interactive job shell never
-      # sources the profile that adds it. Without cargo on PATH at CONFIGURE
-      # time, CMake's find_program(cargo) fails, the Rust `pulp` target is
-      # never wired up, and `build/pulp` (the user-facing CLI) silently never
-      # builds — it only surfaced downstream as
+      # Ensure a WORKING Rust toolchain is on PATH before configure. The
+      # user-facing `pulp` binary is the Rust CLI (experimental/pulp-rs);
+      # CMake only wires that target up when find_program(cargo) succeeds at
+      # CONFIGURE time, and the pulp-rs CMakeLists fail-SOFTs (STATUS, not
+      # FATAL) when cargo is missing — so a broken toolchain silently drops
+      # build/pulp and only surfaces far downstream as
       # `package_cli.py: FAIL: binary not at build/pulp`.
-      - name: Ensure Rust toolchain on PATH
+      #
+      # Failure modes seen on self-hosted Macs (2026-06-10, v0.400.0):
+      #   - cargo not on the non-interactive job PATH (lives at ~/.cargo/bin);
+      #   - a BROKEN rustup install — ~/.cargo/bin/rustup proxy missing, so the
+      #     cargo/rustc shims are dangling symlinks and won't execute even
+      #     though ~/.rustup/toolchains/<tc>/bin/cargo is a perfectly good
+      #     binary.
+      # GitHub-hosted runners already ship a working cargo on PATH, so this
+      # step is a fast no-op there. Self-heal by finding a cargo that actually
+      # RUNS (PATH → ~/.cargo/bin → the toolchain's own bin, which bypasses a
+      # broken proxy) and prepending its dir to GITHUB_PATH. Fail LOUD if none
+      # works, so a runner without Rust never silently ships a CLI-less tarball.
+      - name: Ensure a working Rust toolchain on PATH
         if: runner.os != 'Windows'
         run: |
-          if [ -d "$HOME/.cargo/bin" ]; then
-            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-            echo "Added $HOME/.cargo/bin to PATH for cargo discovery"
+          runs() { "$1/cargo" --version >/dev/null 2>&1; }
+          use() { echo "$1" >> "$GITHUB_PATH"; echo "rust: using cargo at $1 ($("$1/cargo" --version))"; }
+          if command -v cargo >/dev/null 2>&1 && cargo --version >/dev/null 2>&1; then
+            echo "rust: cargo already works on PATH ($(cargo --version))"; exit 0
           fi
+          if runs "$HOME/.cargo/bin"; then use "$HOME/.cargo/bin"; exit 0; fi
+          # Broken rustup proxy / dangling shim — fall back to a toolchain's
+          # direct bin (a real cargo binary, no proxy needed).
+          for tc in "$HOME"/.rustup/toolchains/*/bin; do
+            if runs "$tc"; then use "$tc"; exit 0; fi
+          done
+          echo "::error::No working cargo found (broken rustup? run 'rustup default stable' on this runner). release-cli needs Rust to build the user-facing build/pulp CLI — refusing to ship a CLI-less tarball." >&2
+          exit 1
         shell: bash
 
       # Build the CLI binary WITHOUT WebView; the SDK build below

--- a/.github/workflows/release-path-pr-gate.yml
+++ b/.github/workflows/release-path-pr-gate.yml
@@ -99,7 +99,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          lfs: true
+          # Release-path Skia artifacts are fetched explicitly below. Keep LFS
+          # off to match release-cli.yml and avoid requiring git-lfs on the
+          # persistent Studio release runners.
+          lfs: false
 
       # Mirror release-cli.yml's Linux deps step verbatim. If this list
       # ever drifts from release-cli.yml, the gate is lying — keep them

--- a/.github/workflows/release-path-pr-gate.yml
+++ b/.github/workflows/release-path-pr-gate.yml
@@ -53,7 +53,37 @@ permissions:
   contents: read
 
 jobs:
+  # Keep the PR-time release-path darwin leg on the same macOS runner policy as
+  # release-cli.yml. The gate exercises the same release build path, so routing
+  # it through raw GitHub-hosted macos-15 recreates the same hosted-queue
+  # starvation this workflow is meant to catch before tags.
+  resolve-macos-runner:
+    runs-on: ubuntu-latest
+    outputs:
+      runs_on_json: ${{ steps.resolve.outputs.runs_on_json }}
+    steps:
+      - id: resolve
+        env:
+          RELEASE_JSON: ${{ vars.PULP_RELEASE_MACOS_RUNS_ON_JSON }}
+          LOCAL_JSON: ${{ vars.PULP_LOCAL_MACOS_RUNS_ON_JSON }}
+          NAMESPACE_JSON: ${{ vars.PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON }}
+        run: |
+          if [ -n "${RELEASE_JSON:-}" ]; then
+            echo "runs_on_json=${RELEASE_JSON}" >> "$GITHUB_OUTPUT"
+            echo "Routing macOS release-path PR gate via PULP_RELEASE_MACOS_RUNS_ON_JSON: ${RELEASE_JSON}"
+          elif [ -n "${LOCAL_JSON:-}" ]; then
+            echo "runs_on_json=${LOCAL_JSON}" >> "$GITHUB_OUTPUT"
+            echo "Routing macOS release-path PR gate via self-hosted PULP_LOCAL_MACOS_RUNS_ON_JSON: ${LOCAL_JSON}"
+          elif [ -n "${NAMESPACE_JSON:-}" ]; then
+            echo "runs_on_json=${NAMESPACE_JSON}" >> "$GITHUB_OUTPUT"
+            echo "Routing macOS release-path PR gate through Namespace: ${NAMESPACE_JSON}"
+          else
+            echo 'runs_on_json=["macos-15"]' >> "$GITHUB_OUTPUT"
+            echo "Routing macOS release-path PR gate through GitHub-hosted macos-15"
+          fi
+
   release-build:
+    needs: resolve-macos-runner
     name: Release-path build (${{ matrix.platform }})
     strategy:
       fail-fast: false
@@ -64,7 +94,7 @@ jobs:
           - os: macos-15
             platform: darwin-arm64
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os == 'macos-15' && fromJSON(needs.resolve-macos-runner.outputs.runs_on_json) || matrix.os }}
 
     steps:
       - uses: actions/checkout@v5

--- a/tools/scripts/test_release_workflow_test_step.py
+++ b/tools/scripts/test_release_workflow_test_step.py
@@ -51,6 +51,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 SIGN_AND_RELEASE = REPO_ROOT / ".github" / "workflows" / "sign-and-release.yml"
 RELEASE_CLI = REPO_ROOT / ".github" / "workflows" / "release-cli.yml"
+RELEASE_PATH_PR_GATE = REPO_ROOT / ".github" / "workflows" / "release-path-pr-gate.yml"
 BUILD_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "build.yml"
 
 
@@ -201,6 +202,26 @@ class BuildWorkflowReleaseGate(unittest.TestCase):
         self.assertNotIn(
             "Path(r'sdk-staging/lib/pulp-view.lib').read_bytes(); "
             "assert b'WebViewPanel'",
+            self.text,
+        )
+
+
+class ReleasePathPrGateMacosRouting(unittest.TestCase):
+    """release-path-pr-gate.yml must route darwin via the release macOS var."""
+
+    def setUp(self) -> None:
+        self.assertTrue(
+            RELEASE_PATH_PR_GATE.exists(),
+            f"missing workflow file: {RELEASE_PATH_PR_GATE}",
+        )
+        self.text = RELEASE_PATH_PR_GATE.read_text()
+
+    def test_darwin_leg_uses_release_macos_runner_resolver(self) -> None:
+        self.assertIn("resolve-macos-runner:", self.text)
+        self.assertIn("PULP_RELEASE_MACOS_RUNS_ON_JSON", self.text)
+        self.assertIn("needs: resolve-macos-runner", self.text)
+        self.assertIn(
+            "matrix.os == 'macos-15' && fromJSON(needs.resolve-macos-runner.outputs.runs_on_json) || matrix.os",
             self.text,
         )
 

--- a/tools/scripts/test_release_workflow_test_step.py
+++ b/tools/scripts/test_release_workflow_test_step.py
@@ -225,6 +225,10 @@ class ReleasePathPrGateMacosRouting(unittest.TestCase):
             self.text,
         )
 
+    def test_checkout_does_not_require_git_lfs(self) -> None:
+        self.assertIn("lfs: false", self.text)
+        self.assertNotIn("lfs: true", self.text)
+
 
 class ReleaseCliDualBinaryPackaging(unittest.TestCase):
     """release-cli.yml must keep `pulp` and `pulp-cpp` bundled and smoked.


### PR DESCRIPTION
Codifies the v0.400.0 root cause. The Studio/M5 runners had a broken rustup (missing proxy → dangling cargo shim), so CMake skipped the Rust target and `build/pulp` silently never built — surfacing only as `package_cli.py: FAIL: binary not at build/pulp`. This step now finds a cargo that actually RUNS (falls back to the toolchain's own bin past a broken proxy) and fails LOUD if Rust is truly absent, instead of shipping a CLI-less tarball. Runners (macstudio + blackbook) also manually repaired.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Self-heals Rust toolchain discovery in `release-cli` so the Rust `pulp` CLI always builds, and updates the release-path PR gate to use the same macOS runner policy. Fails fast when no working toolchain is available and avoids hosted-queue backlogs.

- **Bug Fixes**
  - Find a working `cargo` in order: PATH → `~/.cargo/bin` → `~/.rustup/toolchains/*/bin`; prepend its dir to `GITHUB_PATH`, or exit with an error if none works.
  - Prevents silent drops from broken `rustup` proxies on self-hosted macOS; no-op on GitHub-hosted runners.
  - Route the release-path PR gate’s darwin leg through the same macOS runner resolver as `release-cli`, and set checkout to `lfs: false`; tests enforce both.

<sup>Written for commit bacf33fda50e604def1fbf1b64770b3fda6ffc95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

