### PR TITLE
ci(release): tolerate pre-swap CLI backfills

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -284,6 +284,39 @@ jobs:
         run: cmake --build build --config Release
         shell: bash
 
+      - name: Normalize CLI binary layout (Unix)
+        if: runner.os != 'Windows'
+        # Backfill compatibility: tags before the Rust CLI swap only build the
+        # C++ CLI delegate (`build/tools/cli/pulp-cpp`) and have no top-level
+        # `build/pulp`. Package those trees under the stable user-facing
+        # `pulp` name without changing current releases, where `build/pulp`
+        # already exists and remains the primary binary.
+        run: |
+          set -euo pipefail
+          if [ ! -e build/pulp ] && [ -x build/tools/cli/pulp-cpp ]; then
+            echo "Pre-swap CLI layout detected; copying pulp-cpp to build/pulp for packaging"
+            cp -p build/tools/cli/pulp-cpp build/pulp
+          fi
+          test -x build/pulp
+        shell: bash
+
+      - name: Normalize CLI binary layout (Windows)
+        if: runner.os == 'Windows'
+        # Same backfill compatibility as Unix, adjusted for Visual Studio's
+        # multi-config output directory.
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $primary = 'build/pulp.exe'
+          $cpp = 'build/tools/cli/Release/pulp-cpp.exe'
+          if (!(Test-Path $primary) -and (Test-Path $cpp)) {
+              Write-Host 'Pre-swap CLI layout detected; copying pulp-cpp.exe to build/pulp.exe for packaging'
+              Copy-Item -Path $cpp -Destination $primary
+          }
+          if (!(Test-Path $primary)) {
+              throw "Primary CLI binary missing after normalization: $primary"
+          }
+        shell: pwsh
+
       # Phase 8: post-swap there are TWO CLI binaries shipping side by
       # side — `pulp` (Rust, the user-facing default) at the top of
       # the build dir, and `pulp-cpp` (C++, the fallthrough delegate

--- a/tools/scripts/test_release_workflow_test_step.py
+++ b/tools/scripts/test_release_workflow_test_step.py
@@ -244,6 +244,20 @@ class ReleaseCliDualBinaryPackaging(unittest.TestCase):
         self.assertRegex(run_block, r"--mcp-binary\s+build/tools/mcp/Release/pulp-mcp\.exe")
         self.assertRegex(run_block, r"--out\s+pulp-\$\{\{\s*matrix\.platform\s*\}\}\.zip")
 
+    def test_unix_preswap_backfills_alias_cpp_cli_to_primary_binary(self) -> None:
+        run_block = self._find_step_run("Normalize CLI binary layout (Unix)")
+        self.assertIn("[ ! -e build/pulp ]", run_block)
+        self.assertIn("[ -x build/tools/cli/pulp-cpp ]", run_block)
+        self.assertIn("cp -p build/tools/cli/pulp-cpp build/pulp", run_block)
+        self.assertIn("test -x build/pulp", run_block)
+
+    def test_windows_preswap_backfills_alias_cpp_cli_to_primary_binary(self) -> None:
+        run_block = self._find_step_run("Normalize CLI binary layout (Windows)")
+        self.assertIn("$primary = 'build/pulp.exe'", run_block)
+        self.assertIn("$cpp = 'build/tools/cli/Release/pulp-cpp.exe'", run_block)
+        self.assertIn("Copy-Item -Path $cpp -Destination $primary", run_block)
+        self.assertIn("Primary CLI binary missing after normalization", run_block)
+
     def test_unix_smoke_step_exercises_all_cli_binaries(self) -> None:
         run_block = self._find_step_run(
             "Smoke `pulp help` + `pulp-cpp help` + `pulp-mcp --version` (Unix)"


### PR DESCRIPTION
## Summary
- add a release-cli normalization step that copies the legacy C++ CLI from `build/tools/cli/pulp-cpp` to `build/pulp` only when the Rust primary CLI is absent
- add Windows equivalent for pre-swap tags that only produce `pulp-cpp.exe`
- cover both paths in the release workflow contract test

## Why
The v0.395.0 backfill checks out a pre-Rust-swap tag. That tag builds `pulp-cpp` and `pulp-mcp`, but not top-level `build/pulp`. The current release workflow packages `build/pulp`, so Darwin failed after a successful build with `FAIL: binary not at build/pulp`. A fixed-branch dispatch proved Darwin passes once the layout is normalized.

## Tests
- `python3 -m unittest tools.scripts.test_release_workflow_test_step`
- `python3 tools/scripts/test_release_cli_gpu_asset_coverage.py`
- `python3 tools/import-validation/test_source_contracts.py`
- `python3 tools/scripts/skill_sync_check.py && python3 tools/scripts/version_bump_check.py`
- pre-push gates clean with `PULP_SKIP_DIFF_COVER=1`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the release workflow tolerate pre-Rust-swap tags by normalizing the CLI binary layout so packaging always finds `build/pulp`. Prevents failures when only the legacy C++ CLI is built.

- **Bug Fixes**
  - Add a normalization step: if `build/pulp` is missing and `build/tools/cli/pulp-cpp` exists, copy it to `build/pulp`; Windows equivalent copies `build/tools/cli/Release/pulp-cpp.exe` to `build/pulp.exe` (no-op when `build/pulp*` exists).
  - Update workflow contract tests to cover both pre-swap and current layouts.

<sup>Written for commit ee95b637c61cde08d9231d929177ab01c793cda0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

