### PR TITLE
ci(release): keep backfill CLI CMake source-compatible

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -194,21 +194,20 @@ jobs:
         #   - core/canvas/CMakeLists.txt: fontconfig propagation from
         #     pulp-canvas STATIC lib via PkgConfig::FONTCONFIG IMPORTED
         #     target (#1962 follow-up).
-        #   - tools/cli/CMakeLists.txt: re-link fontconfig in pulp-cli
-        #     so it appears AFTER libskia.a in the GNU ld link line
-        #     (left-to-right archive resolution; the chrome/m144 Skia
-        #     archive references Fc* symbols that ld won't resolve from
-        #     an earlier-positioned -lfontconfig). #1962 follow-up.
         #   - tools/deps/manifest.json: release asset inventory must
         #     include all require_gpu release Skia binaries, including
         #     linux-arm64, when backfilling older tags.
+        #
+        # Do NOT wholesale-overlay tools/cli/CMakeLists.txt. That file's
+        # source list drifts as CLI features land on main, and an older tag may
+        # not contain newly referenced .cpp files. Patch only the fontconfig
+        # tail-link block below so the tag keeps its own source list.
         run: |
           set -euo pipefail
           repo='${{ github.repository }}'
           for path in \
               tools/scripts/fetch_skia_for_release.py \
               core/canvas/CMakeLists.txt \
-              tools/cli/CMakeLists.txt \
               tools/deps/manifest.json \
               ; do
             url="https://raw.githubusercontent.com/${repo}/main/${path}"
@@ -216,6 +215,41 @@ jobs:
             curl -fsSL "$url" -o "$path"
             wc -c "$path"
           done
+
+          python3 - <<'PY'
+          import re
+          from pathlib import Path
+
+          path = Path("tools/cli/CMakeLists.txt")
+          text = path.read_text(encoding="utf-8")
+          if "_PULP_CLI_FONTCONFIG" in text:
+              print("tools/cli/CMakeLists.txt already has the fontconfig tail-link block")
+              raise SystemExit(0)
+
+          match = re.search(r"(?m)^target_link_libraries\(pulp-cli PRIVATE[^\n]*\)\n", text)
+          if not match:
+              raise SystemExit("FAIL: cannot find single-line pulp-cli target_link_libraries block")
+
+          block = """
+
+          # Link-order fix for libskia.a -> fontconfig on Linux+GNU ld (#1962).
+          # Keep this as a targeted backfill patch instead of overlaying this
+          # whole CMake file from main: old tags may not have new CLI source
+          # files referenced by main's add_executable() list.
+          if(UNIX AND NOT APPLE AND NOT ANDROID)
+              find_package(PkgConfig)
+              if(PkgConfig_FOUND)
+                  pkg_check_modules(_PULP_CLI_FONTCONFIG IMPORTED_TARGET fontconfig)
+                  if(_PULP_CLI_FONTCONFIG_FOUND)
+                      target_link_libraries(pulp-cli PRIVATE PkgConfig::_PULP_CLI_FONTCONFIG)
+                  endif()
+              endif()
+          endif()
+          """
+          text = text[: match.end()] + block + text[match.end() :]
+          path.write_text(text, encoding="utf-8")
+          print("Patched tools/cli/CMakeLists.txt with the fontconfig tail-link block")
+          PY
 
       - name: Fetch Skia binaries
         run: python3 tools/scripts/fetch_skia_for_release.py ${{ matrix.platform }}

--- a/tools/scripts/test_release_workflow_test_step.py
+++ b/tools/scripts/test_release_workflow_test_step.py
@@ -280,6 +280,57 @@ class ReleaseCliDualBinaryPackaging(unittest.TestCase):
         self.assertIn("missing.*\\.dll", run_block)
 
 
+class ReleaseCliBackfillOverlay(unittest.TestCase):
+    """Backfill overlays must not import current source lists into old tags."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = RELEASE_CLI.read_text(encoding="utf-8")
+
+    def _find_step_run(self, step_name: str) -> str:
+        pattern = re.compile(
+            rf"-\s*name:\s*{re.escape(step_name)}\s*\n"
+            r"(?:(?!\n\s*-\s*name:).)*?"
+            r"\s*run:\s*(.+?)(?=\n\s*-\s*name:|\Z)",
+            re.DOTALL,
+        )
+        match = pattern.search(self.text)
+        self.assertIsNotNone(match, f"could not locate `{step_name}` step")
+        return match.group(1)
+
+    def test_backfill_overlay_keeps_cli_cmake_source_list_from_tag(self) -> None:
+        run_block = self._find_step_run(
+            "Overlay latest release-pipeline files (workflow_dispatch backfill)"
+        )
+        loop_match = re.search(
+            r"for path in\s+\\\n(?P<body>.*?)\n\s+; do",
+            run_block,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(loop_match, "could not locate overlay file loop")
+        overlay_paths = loop_match.group("body")
+        self.assertIn("tools/scripts/fetch_skia_for_release.py", overlay_paths)
+        self.assertIn("core/canvas/CMakeLists.txt", overlay_paths)
+        self.assertIn("tools/deps/manifest.json", overlay_paths)
+        self.assertNotIn(
+            "tools/cli/CMakeLists.txt",
+            overlay_paths,
+            "Backfills must not wholesale-overlay tools/cli/CMakeLists.txt: "
+            "main's add_executable() source list can reference .cpp files that "
+            "do not exist in older tags.",
+        )
+
+    def test_backfill_patches_only_cli_fontconfig_tail_link(self) -> None:
+        run_block = self._find_step_run(
+            "Overlay latest release-pipeline files (workflow_dispatch backfill)"
+        )
+        self.assertIn('Path("tools/cli/CMakeLists.txt")', run_block)
+        self.assertIn("target_link_libraries\\(pulp-cli PRIVATE", run_block)
+        self.assertIn("_PULP_CLI_FONTCONFIG", run_block)
+        self.assertIn("path.write_text(text", run_block)
+        self.assertNotIn("package_analyzer_descriptors.cpp", run_block)
+
+
 class SignAndReleaseContentsWriteTest(unittest.TestCase):
     """#724: sign-and-release.yml must declare `contents: write` on its
     macOS job so the final `Create GitHub Release` step can call the


### PR DESCRIPTION
## Summary
- stop workflow_dispatch backfills from wholesale-overlaying `tools/cli/CMakeLists.txt` from current `main`
- patch only the Linux fontconfig tail-link block into the checked-out tag copy when it is missing
- add a workflow regression test so future overlays do not import current CLI source lists into old release tags

## Why
The `v0.395.0` Release CLI backfill failed at configure because current `tools/cli/CMakeLists.txt` references `package_analyzer_descriptors.cpp`, which does not exist in the old tag source tree.

## Tests
- `python3 -m unittest tools.scripts.test_release_workflow_test_step`
- `python3 tools/scripts/test_release_cli_gpu_asset_coverage.py`
- `python3 tools/import-validation/test_source_contracts.py`
- `python3 tools/scripts/skill_sync_check.py && python3 tools/scripts/version_bump_check.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop release backfills from overlaying `tools/cli/CMakeLists.txt` from `main`; instead, patch only the Linux fontconfig tail-link when missing to keep older tags source-compatible and avoid configure failures.

- **Bug Fixes**
  - Replace the full-file overlay with a targeted Python patch that injects the fontconfig tail-link after `target_link_libraries(pulp-cli PRIVATE)` on Linux.
  - Skip patching if `_PULP_CLI_FONTCONFIG` already exists.
  - Add a workflow regression test to ensure backfills do not overlay `tools/cli/CMakeLists.txt` and only apply the fontconfig patch.

<sup>Written for commit bbd3c374031e17cc7090eca9f5daa08442f69f17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

