### PR TITLE
feat(plugin): surface the audio observability harness as a discoverable capability

### DIFF
--- a/.agents/skills/audio-harness/SKILL.md
+++ b/.agents/skills/audio-harness/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: audio-harness
+description: Prove and debug what a Pulp processor actually emits — the audio observability harness (signal generators, metrics, assertions, RenderScenario, effect contracts) plus the offline Audio Doctor analyzers (magnitude/frequency response, THD/THD+N). TRIGGER on phrases like "is there sound / no audio / I hear nothing", "does this filter/compressor/synth/delay produce the right signal", "prove the DSP / prove the contract", "measure the frequency response", "what's the THD / is it distorting / aliasing", "render a test tone and assert", "audio regression", "64-frame works but 128 is silent", "sample-rate change pitch-shifted it", "describe what's in this buffer", "audio doctor", "magnitude response curve", "compare before/after a DSP refactor". Test/tool layer over HeadlessHost — deterministic, no audio device, no speakers. Off the realtime thread entirely.
+---
+
+# Audio harness (observability + validation)
+
+Pulp's agent-first way to turn "I can't hear it" / "does this sound right?" into
+**inspectable, deterministic signal evidence** — without a device, speakers, or a
+debugger. You are reading this skill because you need to prove, measure, debug, or
+regression-guard the audio a Pulp `Processor` emits.
+
+Everything here is the **test/tool layer** (`test/support/audio_*`), driven by
+`pulp::format::HeadlessHost`. Nothing in this skill runs on the realtime audio
+thread — measurements analyze buffers that have already left `process()`. The
+realtime probe path is a separate concern (see *Roadmap*).
+
+## When to rope this skill in
+
+- "There's no sound / it sounds wrong" — render the path offline and read the
+  facts (peak/RMS/silence/frequency/NaN) instead of guessing.
+- Building or changing a filter / oscillator / compressor / delay / sampler — state
+  the contract and prove it (frequency response, delay time, decay, bypass-nulls).
+- A regression hunt — "64 frames is fine but 128 is silent", "changing the sample
+  rate chipmunked it", "the test tone toggle produces nothing".
+- A DSP refactor — compare old vs new renders (exact / numeric / spectral).
+- "How distorted is this?" — THD / THD+N and a harmonic breakdown.
+- "What does this lowpass actually do at 8 kHz?" — a magnitude-response curve.
+
+## The layering (each layer builds only on the ones below — no back-edges)
+
+```
+signal generators → metrics → assertions → artifacts → scenarios → contracts → doctor
+```
+
+| Layer | Header (`test/support/`) | What it gives you |
+|-------|--------------------------|-------------------|
+| Generators | `audio_test_signals.hpp`, `audio_signal_generators.hpp` | Deterministic stimulus: sine/square/saw, impulse(+train), step, DC, multi-sine, swept sine, seeded white/pink/brown noise, stepped automation + MIDI note scripts. No clocks, no `random_device`. |
+| Metrics | `audio_metrics.hpp` | `analyze()` → `BufferMetrics`: peak, RMS, DC, NaN/Inf, clip count, silence-run; `estimate_frequency()` (zero-crossing, documented limits); `to_dbfs`; `summarize()` (agent-readable signal description). |
+| Assertions | `audio_assertions.hpp` | `assert_no_nan_inf / not_clipped / silent / not_silent / peak_between / rms_between / frequency_near / null_near / channels_independent` — each returns `CheckResult{passed,message}` with dBFS/Hz/cents messages, never a bare float. |
+| Artifacts | `audio_artifacts.hpp` | `BufferMetrics` → JSON (`schema_version` + provenance) for failing CI/local runs. |
+| Scenarios | `render_scenario.hpp` | `RenderScenario` builder over HeadlessHost (factory, sample rate, block size, channels, duration, input/MIDI/param scripts); `render()` → `ScenarioResult`. `run_matrix()` (SR × block sweeps) + `assert_block_partition_invariant()`. |
+| Contracts | `audio_contracts.hpp` | `AudioContract` — a named claim + scenario + accumulated `CheckResult`s; failures read `contract '<name>': ...`. Family helpers `expect_{passthrough,silence_preserved,tone,finite_and_unclipped}`. |
+| Doctor (offline) | `audio_doctor.hpp`, `audio_doctor_artifacts.hpp` | Plugin-Doctor-style measurements: `response_relative_to_input()` (magnitude/frequency response curve + `attenuation_db_at(hz)`), `measure_thd()` (THD / THD+N + harmonic breakdown), curve JSON artifacts. FFT lives test-side only — never `core/view`/runtime. |
+
+Read `test/support/README.md` for the authoritative layering contract.
+
+## Run the proofs
+
+```bash
+# Build + run the whole harness (Release — Debug is meaningless for DSP timing/levels)
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j$(sysctl -n hw.ncpu) --target \
+  pulp-test-audio-support pulp-test-render-scenario pulp-test-audio-contracts \
+  pulp-test-audio-doctor pulp-test-golden pulp-test-audio-matrix pulp-test-audio-tone-regression
+ctest --test-dir build -R 'audio|golden|render|contract|doctor' --output-on-failure
+```
+
+The `/audio-harness` slash command wraps this. JSON metric/curve artifacts (on failure or
+on demand) land under a temp `pulp-audio-metrics/` dir and are INFO-logged.
+
+## Copy-this patterns
+
+Describe / debug a render (the "no sound" workflow):
+
+```cpp
+auto m = analyze(rendered, 48000.0);
+INFO(summarize(m, estimate_frequency(rendered.channel(0), 48000.0)));
+REQUIRE(assert_not_silent(m, -60.0).passed);   // which stage went silent?
+```
+
+State and prove a DSP contract:
+
+```cpp
+auto sc = RenderScenario(create_my_lowpass)
+    .name("mylp.attenuates_8k").sample_rate(48000.0).block_size(128)
+    .input(Sine{.hz = 8000.0f, .dbfs = -12.0f}).set_param(kCutoff, 200.0f);
+AudioContract c("mylp.attenuates_8k", sc);
+c.expect(expect_finite_and_unclipped(c.result()))
+ .expect(assert_block_partition_invariant(sc, {64,128,256}));
+REQUIRE(c.verify().passed);     // failure says `contract 'mylp.attenuates_8k': ...`
+```
+
+Measure it like Plugin Doctor (offline Doctor):
+
+```cpp
+auto curve = response_relative_to_input(sc, {50.0, 8000.0});
+REQUIRE(curve.attenuation_db_at(8000.0) >= 20.0);   // "drops ≥20 dB at 8 kHz"
+auto thd = measure_thd(/* steady bin-coherent sine through the processor */);
+// thd.thd_percent, thd.thd_plus_n, thd.harmonics[...]
+```
+
+## Discipline that keeps it trustworthy
+
+- **Release only.** A Debug DSP/UI build mismeasures levels and timing.
+- **Analyzer Determinism Contract** — every spectral/estimator assertion declares
+  its stimulus, window (rectangular for a bin-coherent tone or an impulse; Hann
+  for broadband — a Hann window annihilates an impulse at n=0), warm-up trim,
+  estimator, seed, sample rate, and tolerance *class*. State them in the test so a
+  red is a real DSP change, not an analyzer artifact.
+- **Named tolerances**, never magic numbers — see the plan's Threshold Policy.
+- **Layering is one-way.** Doctor may use scenarios + FFT; nothing below may
+  include `audio_doctor`/`audio_contracts`.
+
+## Roadmap (planned — do NOT instruct using these until they land)
+
+The harness plan
+(`planning/2026-06-09-audio-observability-and-validation-harness-plan.md`) adds two
+**runtime/UI** surfaces on top of this offline core, each of which must register
+its own plugin surface when it lands:
+
+- **Live Audio Inspector window** (separate dev tool window; meters / probe-stage
+  status / waveform over a realtime-safe `AudioProbeSnapshot`) — a rebindable
+  command via the existing `CommandRegistry`. Update this skill + add its slash
+  command when it ships.
+- **`pulp audio validate <verb>` CLI** (render / assert / summarize / compare /
+  doctor over these analyzers) — nests under the existing `pulp audio` command.
+  Update the `/audio-harness` command to wrap it when it ships.
+
+Until then, the harness is invoked as C++ test fixtures / `ctest` as above.

--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -46,7 +46,9 @@ requires:
 audio, cache, clean, export-tokens, ci-local, design-debug, harness, help, projects, project
 
 **Commands that DO have slash commands** (list for cross-reference, not exhaustive — `ls .claude/commands/` is authoritative):
-build, test, run, validate, ship, version, doctor, create, docs, status, design, import-design, inspect, pr, ci, ci-host, upgrade, prototype-loop, motion
+build, test, run, validate, ship, version, doctor, create, docs, status, design, import-design, inspect, pr, ci, ci-host, upgrade, prototype-loop, motion, audio-harness
+
+`audio-harness` is a workflow slash command (wraps the audio observability harness `ctest` targets + the `audio-harness` skill) — it is NOT a `pulp` CLI subcommand. Note the distinction from the `pulp audio` CLI (model/bundle tooling, intentionally no slash command, above). The `pulp audio validate …` harness CLI is a later phase; when it lands, upgrade `/audio-harness` to wrap it and add `/audio-inspect` for the live Audio Inspector window.
 
 ### 4. Update docs
 - [ ] Add/update section in `docs/reference/cli.md`

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.204.0",
+      "version": "0.205.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.204.0"
+  "version": "0.205.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.204.0",
+  "version": "0.205.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/.claude/commands/audio-harness.md
+++ b/.claude/commands/audio-harness.md
@@ -1,0 +1,37 @@
+---
+name: audio-harness
+description: Prove and inspect what a Pulp processor emits — run the audio observability harness (metrics, scenarios, contracts) and the offline Audio Doctor analyzers (frequency response, THD)
+---
+
+Turn "is there sound / does this sound right?" into deterministic signal evidence,
+offline — no audio device, no speakers. This wraps the **audio-harness** skill;
+read it (`.agents/skills/audio-harness/SKILL.md`) for the full vocabulary and the
+copy-this patterns.
+
+Build Release (Debug mismeasures DSP levels/timing) and run the proofs:
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j$(sysctl -n hw.ncpu) --target \
+  pulp-test-audio-support pulp-test-render-scenario pulp-test-audio-contracts \
+  pulp-test-audio-doctor pulp-test-golden pulp-test-audio-matrix pulp-test-audio-tone-regression
+ctest --test-dir build -R 'audio|golden|render|contract|doctor' --output-on-failure
+```
+
+What you get:
+
+- **Signal facts** — `analyze()` + `summarize()`: peak/RMS/DC/NaN/clip/silence-run
+  and a dominant-pitch estimate, so "no sound" becomes "which stage went silent".
+- **Scenarios + contracts** — `RenderScenario` renders a processor deterministically
+  across sample rates / block sizes; `AudioContract` states a named claim and a
+  failure reads `contract '<name>': expected … actual …`, never a raw sample index.
+- **Audio Doctor (offline)** — `response_relative_to_input()` for a magnitude /
+  frequency-response curve (`attenuation_db_at(hz)`), `measure_thd()` for THD /
+  THD+N + harmonic breakdown. Curves serialize to schema-versioned JSON.
+
+To add coverage for a new effect, copy the nearest contract fixture in
+`test/test_audio_contracts.cpp` (or a Doctor case in `test/test_audio_doctor.cpp`)
+and adjust the expectations — don't hand-roll sample loops.
+
+> Live in-app inspection (the Audio Inspector window) and a `pulp audio validate`
+> CLI are planned phases of the harness; until they land, use the fixtures above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -941,6 +941,7 @@ Alphabetical. One line of purpose per skill. Each directory at `.agents/skills/<
 |-------|---------|
 | `aax` | Optional AAX format: developer-supplied Avid SDK, CMake enablement, DigiShell/AAX Validator workflows |
 | `android` | Android NDK builds, Oboe audio, Dawn/Skia GPU, JNI bridge, emulator smoke, platform gotchas |
+| `audio-harness` | Prove/debug what a Processor emits: signal generators, metrics, assertions, RenderScenario, contracts + offline Audio Doctor (response, THD) |
 | `ara` | Optional ARA support: developer-supplied SDK, companion APIs, adapter wiring, validation |
 | `auv2` | AU v2 adapter: aufx/aumf/aumi/aumu component types, MIDI input wiring, DAW cache gotchas |
 | `auv3` | AU v3 adapter: AUAudioUnit render block, parameter tree, UMP / sysex, sidechain, iOS extension |
@@ -968,11 +969,11 @@ Alphabetical. One line of purpose per skill. Each directory at `.agents/skills/<
 | `vst3` | VST3 adapter: SingleComponentEffect, bus arrangement, param/MIDI routing, state, Steinberg SDK traps |
 | `webview-ui` | WebView UI: native bridge, embedded assets, directory-backed dev resources, WebView validation |
 
-27 skills as of 2026-06-02. When adding a new skill, append its row here and register the subsystem in `tools/scripts/skill_path_map.json`.
+28 skills as of 2026-06-10. When adding a new skill, append its row here and register the subsystem in `tools/scripts/skill_path_map.json`.
 
 ### Claude Code Plugin
 
-Pulp ships as a Claude Code plugin with slash commands (`/build`, `/test`, `/create`, `/status`, `/validate`, `/design`, `/ship`, `/import-design`), skills, and hooks. The plugin manifest is at `.claude-plugin/plugin.json`. See `docs/guides/claude-code-plugin.md` for installation and full details.
+Pulp ships as a Claude Code plugin with slash commands (`/build`, `/test`, `/create`, `/status`, `/validate`, `/design`, `/ship`, `/import-design`, `/audio-harness`), skills, and hooks. The plugin manifest is at `.claude-plugin/plugin.json`. See `docs/guides/claude-code-plugin.md` for installation and full details.
 
 ### CI Workflow
 

--- a/tools/scripts/skill_path_map.json
+++ b/tools/scripts/skill_path_map.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./skill_path_map.schema.json",
   "schema_version": 1,
-  "_comment": "Skill name -> glob patterns. When a diff touches any pattern, the corresponding SKILL.md must be updated in the same diff or a Skill-Update: skip trailer must appear on the tip commit. Paired with tools/scripts/versioning.json. Every subdir under .agents/skills/ MUST have an entry here; skill_sync_check.py fails if one is missing. Dual/triple ownership is permitted — and expected — for files that span multiple domains: e.g. core/format/src/au_adapter.mm is owned by both `auv3` (the adapter) and `view-bridge` (editor attach lifecycle), because a change to that file reasonably requires guidance updates on both sides. Dual ownership is not a mistake to collapse; use it when a single file legitimately teaches two skills.",
+  "_comment": "Skill name -> glob patterns. When a diff touches any pattern, the corresponding SKILL.md must be updated in the same diff or a Skill-Update: skip trailer must appear on the tip commit. Paired with tools/scripts/versioning.json. Every subdir under .agents/skills/ MUST have an entry here; skill_sync_check.py fails if one is missing. Dual/triple ownership is permitted \u2014 and expected \u2014 for files that span multiple domains: e.g. core/format/src/au_adapter.mm is owned by both `auv3` (the adapter) and `view-bridge` (editor attach lifecycle), because a change to that file reasonably requires guidance updates on both sides. Dual ownership is not a mistake to collapse; use it when a single file legitimately teaches two skills.",
   "skills": {
     "aax": {
       "paths": [
@@ -11,7 +11,7 @@
         "tools/cmake/PulpAAX.cmake"
       ],
       "_doc": {
-        "empty-ok": "external/AAX-SDK/** intentionally empty — AAX SDK is developer-supplied per docs/guides/ship.md and the aax skill"
+        "empty-ok": "external/AAX-SDK/** intentionally empty \u2014 AAX SDK is developer-supplied per docs/guides/ship.md and the aax skill"
       }
     },
     "ara": {
@@ -22,8 +22,22 @@
         "external/ara-sdk/**"
       ],
       "_doc": {
-        "empty-ok": "external/ara-sdk/** intentionally empty — ARA SDK is developer-supplied per the ara skill"
+        "empty-ok": "external/ara-sdk/** intentionally empty \u2014 ARA SDK is developer-supplied per the ara skill"
       }
+    },
+    "audio-harness": {
+      "paths": [
+        "test/support/audio_metrics.*",
+        "test/support/audio_assertions.*",
+        "test/support/audio_signal_generators.*",
+        "test/support/audio_test_signals.*",
+        "test/support/audio_artifacts.*",
+        "test/support/render_scenario.*",
+        "test/support/audio_contracts.*",
+        "test/support/audio_doctor.*",
+        "test/support/audio_doctor_artifacts.*",
+        "test/support/README.md"
+      ]
     },
     "auv3": {
       "paths": [
@@ -122,7 +136,7 @@
         "external/quickjs*/**"
       ],
       "_doc": {
-        "empty-ok": "external/quickjs*/** intentionally empty — QuickJS is fetched at configure time, not vendored"
+        "empty-ok": "external/quickjs*/** intentionally empty \u2014 QuickJS is fetched at configure time, not vendored"
       }
     },
     "faust": {


### PR DESCRIPTION
Makes the audio observability harness + offline Audio Doctor **obviously available to the Pulp Claude Code plugin**.

## What
- **`.agents/skills/audio-harness/SKILL.md`** — a trigger-rich skill (matched on 'no audio' / 'does this DSP sound right' / 'measure response/THD' / 'audio doctor') documenting the whole stack: generators → metrics → assertions → artifacts → scenarios → contracts → offline Audio Doctor (response, THD), with copy-this C++ fixture examples and the determinism-contract discipline.
- **`.claude/commands/audio-harness.md`** — `/audio-harness` slash command wrapping the harness `ctest` targets + pointing at the skill. Named to avoid colliding with the existing `pulp audio` (model/bundle) CLI.
- **`tools/scripts/skill_path_map.json`** — maps `audio-harness` → `test/support/audio_*` so future edits keep it in sync.
- **`.agents/skills/cli-maintenance/SKILL.md`** — cross-references the new command; documents the `/audio-harness` vs `pulp audio` distinction and the planned `/audio-inspect` (Phase 6) + `pulp audio validate` CLI (Phase 7).
- **CLAUDE.md** — skills table row (28 skills), `/audio-harness` in the plugin command list.

## Roadmap (flagged, not yet instructed)
The live Audio Inspector window (`/audio-inspect`) and `pulp audio validate` CLI register their own plugin surfaces when they land (Phases 6 / 7); this PR's plan-side deliverable requirement keeps them plugin-visible.

Docs/skill-only (no source under core/**, test/**); plugin version bump 0.204→0.205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the audio observability harness and offline Audio Doctor in the Pulp Claude Code plugin via a new `audio-harness` skill and `/audio-harness` command, enabling offline DSP validation and “no audio” triage from the plugin.

- **New Features**
  - Added `.agents/skills/audio-harness/SKILL.md` covering generators → metrics → assertions → artifacts → scenarios → contracts → offline Audio Doctor (response, THD/THD+N), with copy/paste fixtures.
  - Introduced `.claude/commands/audio-harness.md` to build and run Release `ctest` harness targets; separate from the `pulp audio` CLI.
  - Mapped `audio-harness` to `test/support/audio_*` in `tools/scripts/skill_path_map.json`.
  - Updated `.agents/skills/cli-maintenance/SKILL.md` and `CLAUDE.md` to list the new command/skill, bump the skills count to 28, and note future `/audio-inspect` and `pulp audio validate`.

- **Dependencies**
  - Bumped plugin version to `0.205.0` in `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`.

<sup>Written for commit 0b4753dec40275063c4d4f1e64f121d6bb250f08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

