### PR TITLE
fix(release): re-sign macOS CLI ad-hoc after rpath rewrite (fixes SIGKILL)

### DIFF
--- a/tools/scripts/package_cli.py
+++ b/tools/scripts/package_cli.py
@@ -175,6 +175,27 @@ def fix_rpath_macos(binary: Path) -> None:
         check=False,
     )
 
+    # Re-sign ad-hoc. Every install_name_tool write above INVALIDATES the
+    # binary's code signature, and on Apple Silicon a binary with a stale
+    # signature is SIGKILL'd ("killed: 9", exit 137) the instant it launches.
+    # GitHub-hosted never hit this because its cargo build produced no absolute
+    # LC_RPATHs to strip (a no-op rewrite leaves the original signature
+    # intact); the self-hosted Studio build bakes in absolute rpaths, so the
+    # rewrite is real and the unsigned result fails the `pulp help` smoke test
+    # (2026-06-10 release thread). Honor a CODESIGN env override so a
+    # Linux-hosted darwin cross-build can point at the llvm/cctools
+    # equivalent; skip with a clear note when no codesign tool is available.
+    codesign = os.environ.get("CODESIGN", "codesign")
+    if shutil.which(codesign) or os.path.isabs(codesign):
+        print("  re-signing (ad-hoc) after rpath rewrite", flush=True)
+        subprocess.run(
+            [codesign, "--force", "--sign", "-", str(binary)],
+            check=False,
+        )
+    else:
+        print(f"  note: '{codesign}' not found — skipping ad-hoc re-sign; "
+              "the binary may be SIGKILL'd on Apple Silicon", flush=True)
+
     # Also rewrite the install_name on the bundled wgpu dylib to use
     # @rpath/<basename> if it's currently absolute; pulp's load command
     # references @rpath/libwgpu_native.dylib, so the dylib's own


### PR DESCRIPTION
v0.400.0's darwin build is fully green now, but the darwin smoke test failed: `pulp help returned exit 137` (SIGKILL). package_cli.py rewrites LC_RPATHs (install_name_tool), invalidating the code signature, and never re-signed — on Apple Silicon a stale-signature binary is killed on launch. GitHub-hosted never hit it (no absolute rpaths to rewrite → signature stayed valid). Re-sign ad-hoc after each rpath rewrite.

**Verified end-to-end on a real Studio-built binary:** packaged `pulp help` now exits 0 (was 137); `codesign --verify` passes. The darwin smoke test in release-cli.yml is the CI regression guard.

Last gap before v0.400.0 publishes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-sign the macOS CLI ad-hoc after LC_RPATH rewrites to keep the signature valid and prevent SIGKILL on Apple Silicon. This restores the darwin smoke test and unblocks the v0.400.0 release.

- **Bug Fixes**
  - Added ad-hoc re-sign (`codesign --force --sign -`) after each LC_RPATH rewrite in `package_cli.py`.
  - Support `CODESIGN` env override; skip with a clear note when the signer is unavailable (for cross-builds).

<sup>Written for commit ebb5b954096a3f0332c12e2768dc19386d220143. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

