### PR TITLE
refactor(local-ci): extract footprint display lines

### DIFF
--- a/tools/local-ci/MODULE_MAP.md
+++ b/tools/local-ci/MODULE_MAP.md
@@ -17,7 +17,7 @@ and the matching contract tests in the same change.
 | `targets.py` | Enabled-target discovery, `--targets` parsing, and configured target resolution. | Transport-specific preflight, SSH probes, fallback routing. |
 | `github_workflows.py` | Pure GitHub Actions workflow/default/provider resolution. | `gh` subprocess calls, workflow dispatch, or polling. |
 | `cloud.py` | GitHub/Namespace cloud-run records, cost/history helpers, dispatch wrappers, and formatting. | Local/SSH validation execution. |
-| `footprint.py` | Local-CI state-size accounting and cleanup entry descriptions. | Cleanup candidate selection or deletion. |
+| `footprint.py` | Local-CI state-size accounting, cleanup entry descriptions, and state-footprint line fragments. | Cleanup candidate selection or deletion. |
 | `evidence_index.py` | Result-to-evidence normalization, latest passing target evidence, evidence index persistence, and evidence summaries. | Queue mutation, runner state, result creation, or target execution. |
 | `ssh_bundle.py` | Git bundle naming, local bundle creation, and SSH upload/progress/probe mechanics. | Target validation execution or queue orchestration. |
 | `cleanup.py` | Local-CI artifact cleanup planning/deletion and stale Windows validator cleanup mechanics. | Lock acquisition, runner ownership, or user-facing cleanup command output. |

--- a/tools/local-ci/footprint.py
+++ b/tools/local-ci/footprint.py
@@ -80,6 +80,19 @@ def local_ci_state_footprint() -> dict:
     }
 
 
+def state_footprint_lines(footprint: dict, *, indent: str = "") -> list[str]:
+    lines = [
+        f"{indent}Local CI footprint: total={format_size_bytes(footprint.get('total_bytes', 0))}",
+    ]
+    for label in ("bundles", "prepared", "logs", "results", "cloud-runs"):
+        entry = (footprint.get("entries") or {}).get(label) or {}
+        lines.append(
+            f"{indent}  {label}: {format_size_bytes(entry.get('size_bytes', 0))} "
+            f"({describe_path_for_cleanup(entry.get('path', state_dir()))})"
+        )
+    return lines
+
+
 def describe_path_for_cleanup(path: Path) -> str:
     try:
         return str(path.relative_to(state_dir()))

--- a/tools/local-ci/local_ci.py
+++ b/tools/local-ci/local_ci.py
@@ -141,6 +141,7 @@ from footprint import (  # noqa: E402  -- re-exported for in-file consumers
     format_size_bytes,
     path_size_bytes,
     local_ci_state_footprint,
+    state_footprint_lines,
     describe_path_for_cleanup,
 )
 
@@ -4335,14 +4336,8 @@ def drain_pending_jobs(config: dict, *, blocking: bool) -> tuple[bool, bool]:
 
 
 def print_local_ci_state_footprint(*, indent: str = "") -> None:
-    footprint = local_ci_state_footprint()
-    print(f"{indent}Local CI footprint: total={format_size_bytes(footprint.get('total_bytes', 0))}")
-    for label in ("bundles", "prepared", "logs", "results", "cloud-runs"):
-        entry = (footprint.get("entries") or {}).get(label) or {}
-        print(
-            f"{indent}  {label}: {format_size_bytes(entry.get('size_bytes', 0))} "
-            f"({describe_path_for_cleanup(entry.get('path', state_dir()))})"
-        )
+    for line in state_footprint_lines(local_ci_state_footprint(), indent=indent):
+        print(line)
 
 
 def print_local_ci_cleanup_plan(plan: dict, *, dry_run: bool) -> None:

--- a/tools/local-ci/test_footprint.py
+++ b/tools/local-ci/test_footprint.py
@@ -142,6 +142,17 @@ class FootprintTests(unittest.TestCase):
         footprint = self.mod.local_ci_state_footprint()
         self.assertEqual(footprint["entries"]["bundles"]["size_bytes"], 7)
         self.assertEqual(footprint["total_bytes"], 7)
+        self.assertEqual(
+            self.mod.state_footprint_lines(footprint, indent="  "),
+            [
+                "  Local CI footprint: total=7 B",
+                "    bundles: 7 B (bundles)",
+                "    prepared: 0 B (prepared)",
+                "    logs: 0 B (logs)",
+                "    results: 0 B (results)",
+                "    cloud-runs: 0 B (cloud-runs)",
+            ],
+        )
         self.assertEqual(self.mod.describe_path_for_cleanup(bundle_dir), "bundles")
         outside = Path(self.tmpdir.name) / "outside"
         self.assertEqual(self.mod.describe_path_for_cleanup(outside), str(outside))


### PR DESCRIPTION
## Summary
- move local-ci footprint display-line construction into `footprint.py`
- keep `local_ci.py` responsible only for printing those lines
- cover the extracted helper and update the local-ci module map

## Validation
- `python3 -m py_compile tools/local-ci/local_ci.py tools/local-ci/footprint.py tools/local-ci/test_footprint.py`
- `python3 tools/local-ci/test_local_ci.py`
- `python3 tools/local-ci/test_local_ci_contracts.py`
- `python3 -m unittest discover -s tools/local-ci -p 'test_*.py'`\n- `python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`\n- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report`\n- `python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce`\n- `python3 tools/import-validation/check-source-contracts.py --strict`\n- `python3 tools/import-validation/test_source_contracts.py`\n- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted Local CI footprint display-line construction into `tools/local-ci/footprint.py` as `state_footprint_lines` to keep `local_ci.py` focused on printing. Output stays the same.

- Refactors
  - Added `state_footprint_lines(footprint, indent)` in `footprint.py`; `print_local_ci_state_footprint` now just prints those lines.
  - Updated `MODULE_MAP.md` to note the new responsibility.
  - Added unit tests for the helper in `test_footprint.py`.

<sup>Written for commit 556c2359665b3a9404d1f41d9f3e93f82efd9b4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

