### PR TITLE
refactor(local-ci): extract cleanup display lines

### DIFF
--- a/tools/local-ci/MODULE_MAP.md
+++ b/tools/local-ci/MODULE_MAP.md
@@ -20,7 +20,7 @@ and the matching contract tests in the same change.
 | `footprint.py` | Local-CI state-size accounting, cleanup entry descriptions, and state-footprint line fragments. | Cleanup candidate selection or deletion. |
 | `evidence_index.py` | Result-to-evidence normalization, latest passing target evidence, evidence index persistence, and evidence summaries. | Queue mutation, runner state, result creation, or target execution. |
 | `ssh_bundle.py` | Git bundle naming, local bundle creation, and SSH upload/progress/probe mechanics. | Target validation execution or queue orchestration. |
-| `cleanup.py` | Local-CI artifact cleanup planning/deletion and stale Windows validator cleanup mechanics. | Lock acquisition, runner ownership, or user-facing cleanup command output. |
+| `cleanup.py` | Local-CI artifact cleanup planning/deletion, cleanup-plan line fragments, and stale Windows validator cleanup mechanics. | Lock acquisition, runner ownership, or user-facing cleanup command ordering/output side effects. |
 | `desktop_artifacts.py` | Desktop automation artifact roots and run/publish bundle directory layout. | Report staging, rollup generation, pruning policy, or target execution. |
 | `reporting.py` | Desktop automation report staging, run/publish rollups, manifest scanning, proof summaries, and pruning selection. | Artifact directory layout, target execution, source preparation, or CLI output. |
 | `source_prep.py` | Exact-SHA desktop source requests, cache keys, launch-command rewriting, prepare manifests, and macOS/Linux/Windows prepared source materialization. | Desktop artifact layout, target execution, queue orchestration, or target probes. |

--- a/tools/local-ci/cleanup.py
+++ b/tools/local-ci/cleanup.py
@@ -181,6 +181,51 @@ def apply_local_ci_cleanup_plan(plan: dict) -> dict:
     }
 
 
+def cleanup_plan_lines(
+    plan: dict,
+    *,
+    dry_run: bool,
+    format_size_fn: Callable[[int], str],
+    describe_path_fn: Callable[[Path], str],
+    entry_limit: int = 10,
+) -> list[str]:
+    lines = [
+        "Local CI cleanup:",
+        "",
+        f"  reclaimable: {format_size_fn(plan.get('total_bytes', 0))} "
+        f"across {plan.get('total_paths', 0)} path(s)",
+    ]
+    for category in ("bundles", "logs", "results", "prepared"):
+        entries = (plan.get("categories") or {}).get(category) or []
+        if not entries:
+            continue
+        category_bytes = sum(int(entry.get("size_bytes", 0)) for entry in entries)
+        lines.extend(
+            [
+                "",
+                f"  {category}: {format_size_fn(category_bytes)} "
+                f"across {len(entries)} path(s)",
+            ]
+        )
+        for entry in entries[:entry_limit]:
+            lines.append(
+                f"    {describe_path_fn(Path(entry['path']))} "
+                f"({format_size_fn(entry.get('size_bytes', 0))})"
+            )
+        if len(entries) > entry_limit:
+            lines.append(f"    ... {len(entries) - entry_limit} more")
+
+    lines.extend(
+        [
+            "",
+            "  dry run only; re-run with --apply to delete these paths"
+            if dry_run
+            else "  applying cleanup now",
+        ]
+    )
+    return lines
+
+
 def collect_stale_windows_cleanup_candidates_unlocked(
     queue: list[dict],
     *,

--- a/tools/local-ci/local_ci.py
+++ b/tools/local-ci/local_ci.py
@@ -2706,6 +2706,15 @@ def apply_local_ci_cleanup_plan(plan: dict) -> dict:
     return _cleanup.apply_local_ci_cleanup_plan(plan)
 
 
+def cleanup_plan_lines(plan: dict, *, dry_run: bool) -> list[str]:
+    return _cleanup.cleanup_plan_lines(
+        plan,
+        dry_run=dry_run,
+        format_size_fn=format_size_bytes,
+        describe_path_fn=describe_path_for_cleanup,
+    )
+
+
 def job_sort_key(job: dict) -> tuple[int, str, str]:
     return _queue_orchestrator.job_sort_key(job)
 
@@ -4341,26 +4350,8 @@ def print_local_ci_state_footprint(*, indent: str = "") -> None:
 
 
 def print_local_ci_cleanup_plan(plan: dict, *, dry_run: bool) -> None:
-    print("Local CI cleanup:\n")
-    print(
-        f"  reclaimable: {format_size_bytes(plan.get('total_bytes', 0))} "
-        f"across {plan.get('total_paths', 0)} path(s)"
-    )
-    for category in ("bundles", "logs", "results", "prepared"):
-        entries = (plan.get("categories") or {}).get(category) or []
-        if not entries:
-            continue
-        category_bytes = sum(int(entry.get("size_bytes", 0)) for entry in entries)
-        print(f"\n  {category}: {format_size_bytes(category_bytes)} across {len(entries)} path(s)")
-        for entry in entries[:10]:
-            print(f"    {describe_path_for_cleanup(Path(entry['path']))} ({format_size_bytes(entry.get('size_bytes', 0))})")
-        if len(entries) > 10:
-            print(f"    ... {len(entries) - 10} more")
-
-    if dry_run:
-        print("\n  dry run only; re-run with --apply to delete these paths")
-    else:
-        print("\n  applying cleanup now")
+    for line in cleanup_plan_lines(plan, dry_run=dry_run):
+        print(line)
 
 
 def cmd_cleanup(args: argparse.Namespace) -> int:

--- a/tools/local-ci/test_cleanup.py
+++ b/tools/local-ci/test_cleanup.py
@@ -113,6 +113,45 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(result["removed_bytes"], 6)
         self.assertEqual(result["failed"], [])
 
+    def test_cleanup_plan_lines_formats_summary_and_entries(self) -> None:
+        entries = [
+            {"path": self.bundles / f"old-{idx}.bundle", "size_bytes": idx + 1}
+            for idx in range(12)
+        ]
+        plan = {
+            "categories": {"bundles": entries},
+            "total_bytes": 78,
+            "total_paths": 12,
+        }
+
+        lines = self.mod.cleanup_plan_lines(
+            plan,
+            dry_run=True,
+            format_size_fn=lambda value: f"{value} B",
+            describe_path_fn=lambda path: path.name,
+        )
+
+        self.assertEqual(
+            lines[0:4],
+            ["Local CI cleanup:", "", "  reclaimable: 78 B across 12 path(s)", ""],
+        )
+        self.assertEqual(lines[4], "  bundles: 78 B across 12 path(s)")
+        self.assertEqual(lines[5], "    old-0.bundle (1 B)")
+        self.assertEqual(lines[14], "    old-9.bundle (10 B)")
+        self.assertEqual(lines[15], "    ... 2 more")
+        self.assertEqual(
+            lines[-2:],
+            ["", "  dry run only; re-run with --apply to delete these paths"],
+        )
+
+        apply_lines = self.mod.cleanup_plan_lines(
+            {"categories": {}, "total_bytes": 0, "total_paths": 0},
+            dry_run=False,
+            format_size_fn=lambda value: f"{value} B",
+            describe_path_fn=lambda path: path.name,
+        )
+        self.assertEqual(apply_lines[-1], "  applying cleanup now")
+
     def test_collect_stale_windows_cleanup_candidates_marks_queue_state(self) -> None:
         queue = [
             {


### PR DESCRIPTION
## Summary
- move cleanup-plan display line construction into `cleanup.py`
- keep `local_ci.py` responsible for CLI print ordering and command flow
- cover the extracted helper and update the local-ci module map

## Validation
- `python3 -m py_compile tools/local-ci/local_ci.py tools/local-ci/cleanup.py tools/local-ci/test_cleanup.py`
- `python3 tools/local-ci/test_cleanup.py`
- `python3 tools/local-ci/test_local_ci.py -k cleanup`
- `python3 tools/local-ci/test_local_ci.py`
- `python3 tools/local-ci/test_local_ci_extra.py`
- `python3 tools/local-ci/test_local_ci_contracts.py`
- `python3 -m unittest discover -s tools/local-ci -p 'test_*.py'`\n- `python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`\n- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report`\n- `python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce`\n- `python3 tools/import-validation/check-source-contracts.py --strict`\n- `python3 tools/import-validation/test_source_contracts.py`\n- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted cleanup-plan display line construction into `tools/local-ci/cleanup.py` and routed `local_ci.py` to use it. No behavior change; `sdk` and `plugin` version bumps skipped; CI skill update skipped.

- **Refactors**
  - Added `cleanup_plan_lines(plan, *, dry_run, format_size_fn, describe_path_fn, entry_limit=10)` to build formatted output.
  - `local_ci.print_local_ci_cleanup_plan` now prints lines from this helper; added a thin `local_ci.cleanup_plan_lines(...)` wrapper.
  - Updated `MODULE_MAP.md` to note cleanup-plan line fragments.
  - Added unit tests for summary and entry formatting in `test_cleanup.py`.

<sup>Written for commit 76ed24efba45e9eac1253fb1ed6ed5521fa755bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

