### PR TITLE
fix(state): honor parameter ramp durations in ParamCursor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.405.0
+    VERSION 0.406.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/state/include/pulp/state/param_cursor.hpp
+++ b/core/state/include/pulp/state/param_cursor.hpp
@@ -44,16 +44,30 @@ public:
 
         while (next_event_ < events_.size() &&
                events_[next_event_].sample_offset <= sample_offset) {
+            update_ramps_to(events_[next_event_].sample_offset);
             apply_event(events_[next_event_]);
             ++next_event_;
         }
 
+        update_ramps_to(sample_offset);
         position_ = sample_offset;
     }
 
     float value(ParamID id) const {
         if (const auto* entry = find_entry(id)) return entry->value;
         return store_ ? store_->get_value(id) : 0.0f;
+    }
+
+    float value_at(ParamID id, int32_t sample_offset) const {
+        if (const auto* entry = find_entry(id)) {
+            return value_for_entry_at(*entry, sample_offset);
+        }
+        return store_ ? store_->get_value(id) : 0.0f;
+    }
+
+    bool is_ramping(ParamID id) const {
+        if (const auto* entry = find_entry(id)) return entry->ramping;
+        return false;
     }
 
     bool is_tracked(ParamID id) const {
@@ -67,6 +81,11 @@ private:
     struct Entry {
         ParamID param_id = 0;
         float value = 0.0f;
+        float ramp_start_value = 0.0f;
+        float ramp_target_value = 0.0f;
+        int32_t ramp_start_sample_offset = 0;
+        int32_t ramp_end_sample_offset = 0;
+        bool ramping = false;
     };
 
     Entry* find_entry(ParamID id) {
@@ -100,10 +119,17 @@ private:
         if (!allow_unregistered && !is_registered(id)) return;
         if (auto* entry = find_entry(id)) {
             entry->value = clamp_value(id, value);
+            entry->ramping = false;
             return;
         }
         if (entry_count_ >= entries_.size()) return;
-        entries_[entry_count_++] = Entry{id, clamp_value(id, value)};
+        const float clamped = clamp_value(id, value);
+        entries_[entry_count_++] = Entry{
+            .param_id = id,
+            .value = clamped,
+            .ramp_start_value = clamped,
+            .ramp_target_value = clamped,
+        };
     }
 
     void ensure_event_entry(ParamID id) {
@@ -112,11 +138,62 @@ private:
         add_or_update(id, store_->get_value(id), false);
     }
 
+    float value_for_entry_at(const Entry& entry, int32_t sample_offset) const {
+        if (!entry.ramping) return entry.value;
+        if (sample_offset <= entry.ramp_start_sample_offset) {
+            return entry.ramp_start_value;
+        }
+        if (sample_offset >= entry.ramp_end_sample_offset) {
+            return entry.ramp_target_value;
+        }
+
+        const auto elapsed = static_cast<float>(sample_offset - entry.ramp_start_sample_offset);
+        const auto duration = static_cast<float>(entry.ramp_end_sample_offset
+                                                 - entry.ramp_start_sample_offset);
+        const float t = duration > 0.0f ? (elapsed / duration) : 1.0f;
+        return entry.ramp_start_value + (entry.ramp_target_value - entry.ramp_start_value) * t;
+    }
+
+    void update_ramps_to(int32_t sample_offset) {
+        for (std::size_t i = 0; i < entry_count_; ++i) {
+            auto& entry = entries_[i];
+            if (!entry.ramping) continue;
+            entry.value = value_for_entry_at(entry, sample_offset);
+            if (sample_offset >= entry.ramp_end_sample_offset) {
+                entry.value = entry.ramp_target_value;
+                entry.ramping = false;
+            }
+        }
+    }
+
+    int32_t ramp_end_for(const ParameterEvent& event) const {
+        if (event.ramp_duration_sample_frames <= 0) return event.sample_offset;
+        const auto max = std::numeric_limits<int32_t>::max();
+        if (event.sample_offset > max - event.ramp_duration_sample_frames) return max;
+        return event.sample_offset + event.ramp_duration_sample_frames;
+    }
+
     void apply_event(const ParameterEvent& event) {
-        if (find_entry(event.param_id) == nullptr && !is_registered(event.param_id)) {
+        if (!is_registered(event.param_id)) return;
+        ensure_event_entry(event.param_id);
+        auto* entry = find_entry(event.param_id);
+        if (!entry) return;
+
+        const float target = clamp_value(event.param_id, event.value);
+        if (event.ramp_duration_sample_frames <= 0) {
+            entry->value = target;
+            entry->ramping = false;
             return;
         }
-        add_or_update(event.param_id, event.value, false);
+
+        entry->ramp_start_value = entry->value;
+        entry->ramp_target_value = target;
+        entry->ramp_start_sample_offset = event.sample_offset;
+        entry->ramp_end_sample_offset = ramp_end_for(event);
+        entry->ramping = entry->ramp_end_sample_offset > entry->ramp_start_sample_offset;
+        if (!entry->ramping) {
+            entry->value = target;
+        }
     }
 
     const StateStore* store_ = nullptr;

--- a/docs/guides/dsp-threading.md
+++ b/docs/guides/dsp-threading.md
@@ -108,7 +108,8 @@ instead of polling atomics inside the loop:
 
 * `param_events()` exposes the host-delivered `ParameterEventQueue`
   for the current block.
-* `format::ParamCursor` advances parameter values at sample offsets.
+* `format::ParamCursor` advances parameter values at sample offsets and
+  interpolates active `ramp_duration_sample_frames` events.
 * `format::for_each_subblock()` slices the audio block at parameter
   event boundaries so your DSP can render each stable span.
 * `format::ControlRateParamSmoother` follows the parameter's configured

--- a/docs/guides/parameters.md
+++ b/docs/guides/parameters.md
@@ -170,7 +170,10 @@ previous_gain_ = state().get_value(kGain);
 ```
 
 `for_each_subblock` never mutates `StateStore`; it advances a block-local
-cursor as event offsets are crossed. `ParamInfo::smoothing_ramp_seconds` and
+cursor as event offsets are crossed. `ParamCursor` honors
+`ParameterEvent::ramp_duration_sample_frames` when you advance it to
+intermediate sample offsets, and `value_at(id, sample_offset)` can query an
+active ramp without moving the cursor. `ParamInfo::smoothing_ramp_seconds` and
 `format::ControlRateParamSmoother` provide an opt-in ramp for processors that
 want click-free block-rate changes without splitting into sub-blocks.
 

--- a/test/test_state.cpp
+++ b/test/test_state.cpp
@@ -264,6 +264,108 @@ TEST_CASE("ParamCursor is monotonic and null event queues fall back to StateStor
     REQUIRE(cursor.value(7) == 0.75f);
 }
 
+TEST_CASE("ParamCursor interpolates ramp-duration parameter events",
+          "[state][params][cursor][ramp]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "Gain", "", {0.0f, 1.0f, 0.0f}));
+    store.set_value(1, 0.0f);
+
+    ParameterEventQueue events;
+    REQUIRE(events.push(ParameterEvent{.param_id = 1,
+                                       .sample_offset = 4,
+                                       .value = 1.0f,
+                                       .ramp_duration_sample_frames = 4}));
+    events.sort();
+
+    ParamCursor cursor(store, &events);
+    REQUIRE(cursor.is_tracked(1));
+
+    cursor.advance_to(3);
+    REQUIRE_FALSE(cursor.is_ramping(1));
+    REQUIRE_THAT(cursor.value(1), WithinAbs(0.0f, 1e-6f));
+
+    cursor.advance_to(4);
+    REQUIRE(cursor.is_ramping(1));
+    REQUIRE_THAT(cursor.value(1), WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(cursor.value_at(1, 6), WithinAbs(0.5f, 1e-6f));
+
+    cursor.advance_to(5);
+    REQUIRE_THAT(cursor.value(1), WithinAbs(0.25f, 1e-6f));
+
+    cursor.advance_to(6);
+    REQUIRE_THAT(cursor.value(1), WithinAbs(0.5f, 1e-6f));
+
+    cursor.advance_to(7);
+    REQUIRE_THAT(cursor.value(1), WithinAbs(0.75f, 1e-6f));
+
+    cursor.advance_to(8);
+    REQUIRE_FALSE(cursor.is_ramping(1));
+    REQUIRE_THAT(cursor.value(1), WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(store.get_value(1), WithinAbs(0.0f, 1e-6f));
+}
+
+TEST_CASE("ParamCursor ramps from the current interpolated value when events overlap",
+          "[state][params][cursor][ramp]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "Gain", "", {0.0f, 1.0f, 0.0f}));
+    store.set_value(1, 0.0f);
+
+    ParameterEventQueue events;
+    REQUIRE(events.push(ParameterEvent{.param_id = 1,
+                                       .sample_offset = 0,
+                                       .value = 1.0f,
+                                       .ramp_duration_sample_frames = 8}));
+    REQUIRE(events.push(ParameterEvent{.param_id = 1,
+                                       .sample_offset = 4,
+                                       .value = 0.0f,
+                                       .ramp_duration_sample_frames = 4}));
+    events.sort();
+
+    ParamCursor cursor(store, &events);
+    cursor.advance_to(2);
+    REQUIRE_THAT(cursor.value(1), WithinAbs(0.25f, 1e-6f));
+
+    cursor.advance_to(4);
+    REQUIRE(cursor.is_ramping(1));
+    REQUIRE_THAT(cursor.value(1), WithinAbs(0.5f, 1e-6f));
+
+    cursor.advance_to(6);
+    REQUIRE_THAT(cursor.value(1), WithinAbs(0.25f, 1e-6f));
+
+    cursor.advance_to(8);
+    REQUIRE_FALSE(cursor.is_ramping(1));
+    REQUIRE_THAT(cursor.value(1), WithinAbs(0.0f, 1e-6f));
+}
+
+TEST_CASE("ParamCursor clamps ramp targets and treats non-positive durations as immediate",
+          "[state][params][cursor][ramp]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "Gain", "", {0.0f, 1.0f, 0.0f}));
+    store.set_value(1, 0.25f);
+
+    ParameterEventQueue events;
+    REQUIRE(events.push(ParameterEvent{.param_id = 1,
+                                       .sample_offset = 0,
+                                       .value = 2.0f,
+                                       .ramp_duration_sample_frames = 4}));
+    REQUIRE(events.push(ParameterEvent{.param_id = 1,
+                                       .sample_offset = 8,
+                                       .value = -1.0f,
+                                       .ramp_duration_sample_frames = -1}));
+    events.sort();
+
+    ParamCursor cursor(store, &events);
+    cursor.advance_to(2);
+    REQUIRE_THAT(cursor.value(1), WithinAbs(0.625f, 1e-6f));
+
+    cursor.advance_to(4);
+    REQUIRE_THAT(cursor.value(1), WithinAbs(1.0f, 1e-6f));
+
+    cursor.advance_to(8);
+    REQUIRE_FALSE(cursor.is_ramping(1));
+    REQUIRE_THAT(cursor.value(1), WithinAbs(0.0f, 1e-6f));
+}
+
 TEST_CASE("ParameterEventQueue exposes mutable and const iteration over active events",
           "[state][params][events][coverage][phase3-state]") {
     ParameterEventQueue queue;

--- a/test/test_state.cpp
+++ b/test/test_state.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/events/event_loop.hpp>
+#include <pulp/runtime/scoped_no_alloc.hpp>
 #include <pulp/state/binding.hpp>
 #include <pulp/state/state.hpp>
 #include <pulp/state/state_migration.hpp>
@@ -335,6 +336,46 @@ TEST_CASE("ParamCursor ramps from the current interpolated value when events ove
     cursor.advance_to(8);
     REQUIRE_FALSE(cursor.is_ramping(1));
     REQUIRE_THAT(cursor.value(1), WithinAbs(0.0f, 1e-6f));
+}
+
+TEST_CASE("ParamCursor ramp interpolation stays inside the no-allocation contract",
+          "[state][params][cursor][ramp][rt]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "Gain", "", {0.0f, 1.0f, 0.5f}));
+    store.set_value(1, 0.5f);
+
+    ParameterEventQueue events;
+    REQUIRE(events.push(ParameterEvent{.param_id = 1,
+                                       .sample_offset = 0,
+                                       .value = 1.0f,
+                                       .ramp_duration_sample_frames = 4}));
+    REQUIRE(events.push(ParameterEvent{.param_id = 1,
+                                       .sample_offset = 4,
+                                       .value = 0.0f,
+                                       .ramp_duration_sample_frames = 4}));
+    events.sort();
+
+    std::array<float, 5> sampled{};
+    {
+        pulp::runtime::ScopedNoAlloc guard;
+        ParamCursor cursor(store, &events);
+        cursor.advance_to(0);
+        sampled[0] = cursor.value(1);
+        sampled[1] = cursor.value_at(1, 2);
+        cursor.advance_to(2);
+        sampled[2] = cursor.value(1);
+        cursor.advance_to(6);
+        sampled[3] = cursor.value(1);
+        cursor.advance_to(8);
+        sampled[4] = cursor.value(1);
+    }
+
+    REQUIRE_THAT(sampled[0], WithinAbs(0.5f, 1e-6f));
+    REQUIRE_THAT(sampled[1], WithinAbs(0.75f, 1e-6f));
+    REQUIRE_THAT(sampled[2], WithinAbs(0.75f, 1e-6f));
+    REQUIRE_THAT(sampled[3], WithinAbs(0.5f, 1e-6f));
+    REQUIRE_THAT(sampled[4], WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(store.get_value(1), WithinAbs(0.5f, 1e-6f));
 }
 
 TEST_CASE("ParamCursor clamps ramp targets and treats non-positive durations as immediate",


### PR DESCRIPTION
## Summary

- teach `ParamCursor` to honor `ParameterEvent::ramp_duration_sample_frames` with fixed-size, block-local linear interpolation
- add `value_at()` and `is_ramping()` for active ramp queries without advancing the cursor
- preserve unregistered-event behavior caught during validation, so unknown events do not mutate explicit snapshots
- document the ramp contract and bump the SDK/CLI version to 0.406.0

## Validation

- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF`
- `cmake --build build --target pulp-test-state pulp-test-processor-defaults --parallel`
- `./build/test/pulp-test-state --reporter compact`
- `./build/test/pulp-test-processor-defaults --reporter compact`
- `grep '^CMAKE_BUILD_TYPE' build/CMakeCache.txt`
- `grep '^CXX_FLAGS ' build/test/CMakeFiles/pulp-test-state.dir/flags.make`
- `grep '^CXX_FLAGS ' build/test/CMakeFiles/pulp-test-processor-defaults.dir/flags.make`
- `python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat --pr-title "fix(state): honor parameter ramp durations in ParamCursor"`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
ParamCursor now honors `ParameterEvent::ramp_duration_sample_frames` with block-local linear interpolation, so parameter changes ramp smoothly within a block without touching `StateStore`. Added `value_at()` and `is_ramping()` to query active ramps without advancing.

- New Features
  - Linear ramp interpolation between event offsets; overlapping ramps start from the current interpolated value; targets are clamped; non-positive durations are immediate.
  - `value_at(id, sample_offset)` and `is_ramping(id)` helpers for precise, no-alloc queries.
  - Unregistered/unknown parameter events are ignored and no longer mutate explicit snapshots.
  - Updated docs and ramp examples; added no-allocation ramp tests; bumped version to 0.406.0.

<sup>Written for commit d5bcd536075183577a007cab19f4f04357978617. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

