### PR TITLE
ci(release): overlay package cli for backfills

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -197,6 +197,8 @@ jobs:
         #   - tools/deps/manifest.json: release asset inventory must
         #     include all require_gpu release Skia binaries, including
         #     linux-arm64, when backfilling older tags.
+        #   - tools/scripts/package_cli.py: release packaging/rpath fixes,
+        #     including macOS ad-hoc re-signing after install_name_tool rewrites.
         #
         # Do NOT wholesale-overlay tools/cli/CMakeLists.txt. That file's
         # source list drifts as CLI features land on main, and an older tag may
@@ -207,6 +209,7 @@ jobs:
           repo='${{ github.repository }}'
           for path in \
               tools/scripts/fetch_skia_for_release.py \
+              tools/scripts/package_cli.py \
               core/canvas/CMakeLists.txt \
               tools/deps/manifest.json \
               ; do

--- a/tools/scripts/test_release_workflow_test_step.py
+++ b/tools/scripts/test_release_workflow_test_step.py
@@ -335,6 +335,7 @@ class ReleaseCliBackfillOverlay(unittest.TestCase):
         self.assertIsNotNone(loop_match, "could not locate overlay file loop")
         overlay_paths = loop_match.group("body")
         self.assertIn("tools/scripts/fetch_skia_for_release.py", overlay_paths)
+        self.assertIn("tools/scripts/package_cli.py", overlay_paths)
         self.assertIn("core/canvas/CMakeLists.txt", overlay_paths)
         self.assertIn("tools/deps/manifest.json", overlay_paths)
         self.assertNotIn(


### PR DESCRIPTION
Backfill dispatches check out old tags, so any release-pipeline helper that lives in the source tree must be overlaid when the helper itself is the fix. PR #3894 fixed macOS package re-signing in tools/scripts/package_cli.py, but old-tag workflow_dispatch runs still used the tag copy.

This adds tools/scripts/package_cli.py to the workflow_dispatch backfill overlay and asserts it in the release workflow regression test.

Verified:
- python3 -m unittest tools.scripts.test_release_workflow_test_step
- python3 tools/scripts/test_release_cli_gpu_asset_coverage.py
- python3 tools/import-validation/test_source_contracts.py
- python3 tools/scripts/skill_sync_check.py && python3 tools/scripts/version_bump_check.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfill release runs now overlay the CLI packaging helper so they use the fixed script instead of the tag copy. This ensures macOS ad‑hoc re-signing and rpath fixes apply during backfills.

- **Bug Fixes**
  - Added `tools/scripts/package_cli.py` to the workflow_dispatch backfill overlay in `.github/workflows/release-cli.yml`.
  - Updated the release workflow test to assert the overlay includes this script.

<sup>Written for commit 9d99e5d1c2af10dd7598481b037610112a1e439e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

