### PR TITLE
chore: bump versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.405.0
+    VERSION 0.406.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
Cut **SDK v0.406.0** from main HEAD — the first tag whose *source* carries the full release-pipeline fix set. The version-race tagged v0.400..405 before the latest fix merged each time, so each rebuilt a stale package_cli.py and SIGKILL'd the darwin `pulp help` smoke. v0.406.0 has all of it in source: Skia linux-arm64 pin (#3814), release-cli self-hosted routing + lfs:false + signature-safe strip + Rust self-heal (#3835/#3843/#3846/#3865), and the post-rpath ad-hoc re-sign (#3894). Runners (macstudio + blackbook) rustup also repaired. Should publish end-to-end.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update project version to 0.406.0 to cut the SDK release from main with all release-pipeline fixes. This resolves the earlier tag race and stale CLI rebuilds, restoring end-to-end publish and macOS `pulp help` smoke tests.

<sup>Written for commit c3014a0acce7835b4ec9b06812ed13d33a46e76f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

