### PR TITLE
refactor(local-ci): extract evidence command display lines

### DIFF
--- a/tools/local-ci/MODULE_MAP.md
+++ b/tools/local-ci/MODULE_MAP.md
@@ -18,7 +18,7 @@ and the matching contract tests in the same change.
 | `github_workflows.py` | Pure GitHub Actions workflow/default/provider resolution. | `gh` subprocess calls, workflow dispatch, or polling. |
 | `cloud.py` | GitHub/Namespace cloud-run records, cost/history helpers, dispatch wrappers, and formatting. | Local/SSH validation execution. |
 | `footprint.py` | Local-CI state-size accounting, cleanup entry descriptions, and state-footprint line fragments. | Cleanup candidate selection or deletion. |
-| `evidence_index.py` | Result-to-evidence normalization, latest passing target evidence, evidence index persistence, and evidence summaries. | Queue mutation, runner state, result creation, or target execution. |
+| `evidence_index.py` | Result-to-evidence normalization, latest passing target evidence, evidence index persistence, evidence summaries, and evidence-command line fragments. | Queue mutation, runner state, result creation, or target execution. |
 | `ssh_bundle.py` | Git bundle naming, local bundle creation, and SSH upload/progress/probe mechanics. | Target validation execution or queue orchestration. |
 | `cleanup.py` | Local-CI artifact cleanup planning/deletion, cleanup-plan line fragments, and stale Windows validator cleanup mechanics. | Lock acquisition, runner ownership, or user-facing cleanup command ordering/output side effects. |
 | `desktop_artifacts.py` | Desktop automation artifact roots and run/publish bundle directory layout. | Report staging, rollup generation, pruning policy, or target execution. |

--- a/tools/local-ci/evidence_index.py
+++ b/tools/local-ci/evidence_index.py
@@ -195,3 +195,17 @@ def print_evidence_summary(
         limit=limit,
         indent=indent,
     )
+
+
+def evidence_scope_header_line(branch: str | None, sha: str | None) -> str | None:
+    if branch:
+        return f"Evidence for branch `{branch}`:"
+    if sha:
+        return f"Evidence for sha `{short_sha(sha)}`:"
+    return None
+
+
+def evidence_empty_line(*, has_header: bool) -> str:
+    if has_header:
+        return "  (none)"
+    return "No local CI evidence recorded."

--- a/tools/local-ci/local_ci.py
+++ b/tools/local-ci/local_ci.py
@@ -381,6 +381,14 @@ def print_evidence_summary(
     )
 
 
+def evidence_scope_header_line(branch: str | None, sha: str | None) -> str | None:
+    return evidence_index_module.evidence_scope_header_line(branch, sha)
+
+
+def evidence_empty_line(*, has_header: bool) -> str:
+    return evidence_index_module.evidence_empty_line(has_header=has_header)
+
+
 def save_config(config: dict) -> None:
     atomic_write_text(config_path(), json.dumps(config, indent=2) + "\n")
 
@@ -4726,21 +4734,13 @@ def cmd_logs(args: argparse.Namespace) -> int:
 
 def cmd_evidence(args: argparse.Namespace) -> int:
     branch = args.branch or current_branch()
-    printed_header = False
-
-    if branch:
-        print(f"Evidence for branch `{branch}`:")
-        printed_header = True
-    elif args.sha:
-        print(f"Evidence for sha `{short_sha(args.sha)}`:")
-        printed_header = True
+    header = evidence_scope_header_line(branch, args.sha)
+    if header:
+        print(header)
 
     found = print_evidence_summary(branch=branch, sha=args.sha, limit=args.limit)
     if not found:
-        if printed_header:
-            print("  (none)")
-        else:
-            print("No local CI evidence recorded.")
+        print(evidence_empty_line(has_header=header is not None))
         return 1
     return 0
 

--- a/tools/local-ci/test_evidence_index.py
+++ b/tools/local-ci/test_evidence_index.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Tests for evidence-index display helpers."""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("local_ci.py")
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("pulp_local_ci", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class EvidenceIndexTests(unittest.TestCase):
+    def setUp(self):
+        self.mod = load_module()
+
+    def test_evidence_command_line_fragments(self) -> None:
+        self.assertEqual(
+            self.mod.evidence_scope_header_line("feature/evidence", None),
+            "Evidence for branch `feature/evidence`:",
+        )
+        self.assertEqual(
+            self.mod.evidence_scope_header_line(None, "f" * 40),
+            "Evidence for sha `ffffffffffff`:",
+        )
+        self.assertIsNone(self.mod.evidence_scope_header_line(None, None))
+        self.assertEqual(self.mod.evidence_empty_line(has_header=True), "  (none)")
+        self.assertEqual(
+            self.mod.evidence_empty_line(has_header=False),
+            "No local CI evidence recorded.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Extract fixed cmd_evidence display strings into evidence_index.py
- Keep branch resolution, summary lookup, and command flow unchanged
- Add focused evidence-index tests and update the local-ci module map

## Validation
- python3 -m py_compile tools/local-ci/local_ci.py tools/local-ci/evidence_index.py tools/local-ci/test_evidence_index.py
- python3 tools/local-ci/test_evidence_index.py
- python3 tools/local-ci/test_local_ci_extra.py
- python3 -m unittest discover -s tools/local-ci -p 'test_*.py'
- python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat
- python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce
- python3 tools/import-validation/check-source-contracts.py --strict
- python3 tools/import-validation/test_source_contracts.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the evidence command display lines into `evidence_index.py` to centralize UI fragments and improve testability. No behavior changes to `local-ci` output.

- **Refactors**
  - Moved header/empty-line helpers to `evidence_index.py` (`evidence_scope_header_line`, `evidence_empty_line`).
  - Updated `local_ci.py` to delegate to `evidence_index`.
  - Added focused tests for the helpers and updated `MODULE_MAP.md`.

<sup>Written for commit c672dce2bbb0b7deff3c462b589546057a010142. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

