### PR TITLE
refactor(local-ci): extract PR list display lines

### DIFF
--- a/tools/local-ci/MODULE_MAP.md
+++ b/tools/local-ci/MODULE_MAP.md
@@ -16,7 +16,7 @@ and the matching contract tests in the same change.
 | `job_queue.py` | Queue entry normalization and unlocked queue load/save. | Lock acquisition, stale-running reconciliation, supersedence side effects. |
 | `targets.py` | Enabled-target discovery, `--targets` parsing, and configured target resolution. | Transport-specific preflight, SSH probes, fallback routing. |
 | `github_workflows.py` | Pure GitHub Actions workflow/default/provider resolution. | `gh` subprocess calls, workflow dispatch, or polling. |
-| `cloud.py` | GitHub/Namespace cloud-run records, cost/history helpers, dispatch wrappers, and formatting. | Local/SSH validation execution. |
+| `cloud.py` | GitHub/Namespace cloud-run records, cost/history helpers, dispatch wrappers, PR-list line fragments, and formatting. | Local/SSH validation execution. |
 | `footprint.py` | Local-CI state-size accounting, cleanup entry descriptions, and state-footprint line fragments. | Cleanup candidate selection or deletion. |
 | `evidence_index.py` | Result-to-evidence normalization, latest passing target evidence, evidence index persistence, evidence summaries, and evidence-command line fragments. | Queue mutation, runner state, result creation, or target execution. |
 | `ssh_bundle.py` | Git bundle naming, local bundle creation, and SSH upload/progress/probe mechanics. | Target validation execution or queue orchestration. |

--- a/tools/local-ci/cloud.py
+++ b/tools/local-ci/cloud.py
@@ -1366,6 +1366,34 @@ def gh_pr_list_open() -> list[dict]:
     return json.loads(result.stdout)
 
 
+def no_open_prs_line() -> str:
+    return "No open PRs."
+
+
+def open_prs_header_line(count: int) -> str:
+    return f"Open PRs ({count}):"
+
+
+def open_pr_list_entry_lines(pr: dict) -> list[str]:
+    author = pr.get("author", {}).get("login", "?")
+    labels = ", ".join(label.get("name", "") for label in pr.get("labels", []))
+    label_str = f" [{labels}]" if labels else ""
+    return [
+        f"  #{pr['number']:4d}  {pr['title']}",
+        f"         {pr['headRefName']} by {author}{label_str}",
+    ]
+
+
+def open_pr_list_lines(prs: list[dict]) -> list[str]:
+    if not prs:
+        return [no_open_prs_line()]
+
+    lines = [open_prs_header_line(len(prs)), ""]
+    for pr in prs:
+        lines.extend(open_pr_list_entry_lines(pr))
+    return lines
+
+
 def gh_pr_head(pr_ref: str) -> tuple[int, str, str] | None:
     if pr_ref == "latest":
         prs = gh_pr_list_open()
@@ -2020,5 +2048,4 @@ def cmd_cloud_status(args: argparse.Namespace) -> int:
             detail = f" duration={job_duration}" if job_duration else ""
             print(f"    {job.get('name', '?')}: {status}{suffix}{detail}")
     return 0
-
 

--- a/tools/local-ci/local_ci.py
+++ b/tools/local-ci/local_ci.py
@@ -498,6 +498,7 @@ from cloud import (  # noqa: E402  -- re-exported for in-file consumers (R2-1 #2
     summarize_namespace_usage,
     summarize_runner_selector,
     update_cloud_record_from_run,
+    open_pr_list_lines,
 )
 
 
@@ -4675,17 +4676,8 @@ def cmd_list(_args: argparse.Namespace) -> int:
         return 1
 
     prs = gh_pr_list_open()
-    if not prs:
-        print("No open PRs.")
-        return 0
-
-    print(f"Open PRs ({len(prs)}):\n")
-    for pr in prs:
-        author = pr.get("author", {}).get("login", "?")
-        labels = ", ".join(label.get("name", "") for label in pr.get("labels", []))
-        label_str = f" [{labels}]" if labels else ""
-        print(f"  #{pr['number']:4d}  {pr['title']}")
-        print(f"         {pr['headRefName']} by {author}{label_str}")
+    for line in open_pr_list_lines(prs):
+        print(line)
     return 0
 
 

--- a/tools/local-ci/test_cloud.py
+++ b/tools/local-ci/test_cloud.py
@@ -212,6 +212,29 @@ class CloudCliHelperTests(unittest.TestCase):
         ):
             self.assertIsNone(self.mod.gh_run_view("danielraffel/pulp", 2))
 
+    def test_open_pr_list_lines_match_cli_display(self):
+        self.assertEqual(self.mod.open_pr_list_lines([]), ["No open PRs."])
+
+        prs = [
+            {
+                "number": 7,
+                "title": "Refactor local CI",
+                "headRefName": "feature/local-ci",
+                "author": {"login": "dev"},
+                "labels": [{"name": "ci"}, {"name": "refactor"}],
+            }
+        ]
+
+        self.assertEqual(
+            self.mod.open_pr_list_lines(prs),
+            [
+                "Open PRs (1):",
+                "",
+                "  #   7  Refactor local CI",
+                "         feature/local-ci by dev [ci, refactor]",
+            ],
+        )
+
     def test_cloud_record_storage_and_refresh_edges(self):
         with tempfile.TemporaryDirectory() as tmp:
             cloud_dir = Path(tmp)


### PR DESCRIPTION
## Summary
- move ci-local list display line fragments into cloud.py beside the PR-list GitHub helper
- keep cmd_list as a thin gh availability/fetch/print orchestrator
- update MODULE_MAP.md and add focused cloud helper coverage

## Validation
- python3 -m py_compile tools/local-ci/local_ci.py tools/local-ci/cloud.py tools/local-ci/test_cloud.py
- python3 tools/local-ci/test_cloud.py
- python3 tools/local-ci/test_local_ci_extra.py
- python3 -m unittest discover -s tools/local-ci -p 'test_*.py'
- python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat
- python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce
- python3 tools/import-validation/check-source-contracts.py --strict
- python3 tools/import-validation/test_source_contracts.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted PR list display formatting into `cloud.py` and wired `cmd_list` to use it for a thinner, testable CLI flow. No behavior changes; this is a pure internal refactor with unit tests.

- **Refactors**
  - Added `no_open_prs_line`, `open_prs_header_line`, `open_pr_list_entry_lines`, and `open_pr_list_lines` in `cloud.py` next to the GitHub PR list helper.
  - `cmd_list` now delegates to `open_pr_list_lines` and only orchestrates gh availability, fetch, and print.
  - Updated `MODULE_MAP.md` and added focused coverage in `test_cloud.py` for the display lines.

<sup>Written for commit 759bc4eb025876c4baec4311f987344d0c4291ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

