### PR TITLE
refactor(local-ci): extract command execution helpers

### DIFF
--- a/tools/local-ci/MODULE_MAP.md
+++ b/tools/local-ci/MODULE_MAP.md
@@ -32,6 +32,7 @@ and the matching contract tests in the same change.
 | `macos_desktop.py` | macOS app bundle detection, Swift window-probe wrappers, window wait/capture/activation/click helpers, app quit, and process termination. | Desktop action orchestration, artifact manifest writing, source preparation, or queue orchestration. |
 | `windows_target.py` | Windows desktop target contracts, path safety, session-agent request payloads, and probe result formatting/readiness helpers. | SSH/PowerShell execution, desktop action execution, queue orchestration, or artifact layout. |
 | `windows_probe.py` | Windows SSH/PowerShell command execution helpers, remote file transfer/read/remove helpers, repo/session/tooling probes, remote tool installation, session-agent bootstrap/start, and CMake generator probing. | Windows target contract formatting, desktop action orchestration, queue orchestration, or artifact layout. |
+| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, and optional command log writing. | Target-specific validation commands, result assembly, queue mutation, or desktop automation adapters. |
 
 ## Remaining `local_ci.py` Clusters
 
@@ -43,7 +44,7 @@ behind the contracts added in this slice.
 | --- | --- | --- |
 | Desktop target probes | Desktop doctor orchestration, launch adapters, and automation adapters. | later `execution.py` |
 | Queue orchestration | Remaining runner-state wrapper calls and other CLI-facing queue updates. | later queue modules |
-| Validation execution | Local, SSH, Windows, Linux, smoke/full validation commands and target status reporting. | `execution.py` |
+| Validation execution | Local, SSH, Windows, Linux, smoke/full validation commands and target status reporting beyond shared command execution. | `execution.py` |
 | CLI dispatch | Argument parser, subcommand routing, and user-facing command output. | `cli.py` or retained thin entrypoint |
 
 ## Behavior Contracts

--- a/tools/local-ci/execution.py
+++ b/tools/local-ci/execution.py
@@ -1,0 +1,203 @@
+"""Validation command execution helpers for local CI.
+
+This module owns subprocess output capture, progress marker parsing, heartbeat
+updates, and optional command log writing. Higher-level target validation and
+result assembly stay in local_ci.py until later execution slices.
+"""
+
+from __future__ import annotations
+
+import queue as queue_module
+import subprocess
+import threading
+import time
+from pathlib import Path
+
+from git_helpers import now_iso
+from io_utils import trim_line
+
+
+HEARTBEAT_INTERVAL_SECS = 15.0
+STUCK_IDLE_SECS = 90.0
+
+
+def parse_progress_marker(line: str) -> dict:
+    stripped = line.strip()
+    if stripped.startswith("__PULP_PHASE__:"):
+        return {"phase": stripped.split(":", 1)[1]}
+    if stripped.startswith("__PULP_WAIT__:"):
+        return {"wait_reason": stripped.split(":", 1)[1]}
+    if stripped.startswith("__PULP_VALIDATION__:"):
+        return {"validation_mode": stripped.split(":", 1)[1]}
+    if stripped.startswith("__PULP_TEST_POLICY__:"):
+        return {"test_policy": stripped.split(":", 1)[1]}
+    if stripped.startswith("__PULP_PREPARED__:"):
+        return {"prepared_state": stripped.split(":", 1)[1]}
+    if stripped.startswith("__PULP_VALIDATOR_PID__:"):
+        value = stripped.split(":", 1)[1]
+        try:
+            return {"validator_pid": int(value)}
+        except ValueError:
+            return {"validator_pid": value}
+    if stripped.startswith("__PULP_VALIDATOR_STARTED__:"):
+        return {"validator_started_at": stripped.split(":", 1)[1]}
+    return {}
+
+
+def run_logged_command(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    input_text: str | None = None,
+    timeout: int = 3600,
+    log_path: Path | None = None,
+    report_progress=None,
+    heartbeat_interval_secs: float = HEARTBEAT_INTERVAL_SECS,
+    stuck_idle_secs: float = STUCK_IDLE_SECS,
+) -> dict:
+    start = time.time()
+    proc = subprocess.Popen(
+        cmd,
+        cwd=cwd,
+        stdin=subprocess.PIPE if input_text is not None else None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        bufsize=1,
+    )
+
+    output_queue: queue_module.Queue[str | None] = queue_module.Queue()
+    input_error: list[BaseException] = []
+    input_done = threading.Event()
+
+    def reader() -> None:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            output_queue.put(line)
+        output_queue.put(None)
+
+    threading.Thread(target=reader, daemon=True).start()
+
+    def writer() -> None:
+        try:
+            if input_text is not None and proc.stdin is not None:
+                proc.stdin.write(input_text)
+        except BaseException as exc:  # pragma: no cover - surfaced through polling loop
+            input_error.append(exc)
+        finally:
+            if proc.stdin is not None:
+                try:
+                    proc.stdin.close()
+                except OSError:
+                    pass
+            input_done.set()
+
+    threading.Thread(target=writer, daemon=True).start()
+
+    combined: list[str] = []
+    saw_eof = False
+    last_output_ts = start
+    last_heartbeat_ts = start
+    log_handle = log_path.open("a", errors="replace") if log_path else None
+    try:
+        while True:
+            remaining = timeout - (time.time() - start)
+            if remaining <= 0:
+                proc.kill()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    pass
+                return {
+                    "timed_out": True,
+                    "returncode": -1,
+                    "output": "".join(combined),
+                    "duration_secs": round(time.time() - start, 1),
+                }
+
+            if input_error:
+                proc.kill()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    pass
+                raise input_error[0]
+
+            try:
+                poll_timeout = 0.25
+                if heartbeat_interval_secs > 0:
+                    poll_timeout = min(poll_timeout, max(heartbeat_interval_secs / 2.0, 0.01))
+                item = output_queue.get(timeout=min(poll_timeout, max(remaining, 0.01)))
+            except queue_module.Empty:
+                if proc.poll() is not None and saw_eof and input_done.is_set():
+                    break
+                now = time.time()
+                quiet_for_secs_raw = now - last_output_ts
+                quiet_for_secs = int(round(quiet_for_secs_raw))
+                if (
+                    report_progress
+                    and proc.poll() is None
+                    and (now - last_heartbeat_ts) >= heartbeat_interval_secs
+                ):
+                    report_progress(
+                        last_heartbeat_at=now_iso(),
+                        quiet_for_secs=quiet_for_secs,
+                        liveness="stuck" if quiet_for_secs_raw >= stuck_idle_secs else "quiet",
+                    )
+                    last_heartbeat_ts = now
+                continue
+
+            if item is None:
+                saw_eof = True
+                if proc.poll() is not None and input_done.is_set():
+                    break
+                continue
+
+            progress = parse_progress_marker(item)
+            if progress:
+                combined.append(item)
+                if log_handle is not None:
+                    log_handle.write(item)
+                    log_handle.flush()
+                last_output_ts = time.time()
+                last_heartbeat_ts = last_output_ts
+                progress["last_output_at"] = now_iso()
+                progress["last_heartbeat_at"] = None
+                progress["quiet_for_secs"] = None
+                progress["liveness"] = None
+                if report_progress:
+                    report_progress(**progress)
+                continue
+
+            combined.append(item)
+            if log_handle is not None:
+                log_handle.write(item)
+                log_handle.flush()
+
+            stripped = item.strip()
+            if report_progress:
+                last_output_ts = time.time()
+                last_heartbeat_ts = last_output_ts
+                fields = {
+                    "last_output_at": now_iso(),
+                    "last_heartbeat_at": None,
+                    "quiet_for_secs": None,
+                    "liveness": None,
+                }
+                if stripped:
+                    fields["last_line"] = trim_line(stripped)
+                report_progress(**fields)
+
+        return {
+            "timed_out": False,
+            "returncode": proc.wait(),
+            "output": "".join(combined),
+            "duration_secs": round(time.time() - start, 1),
+        }
+    finally:
+        if proc.stdout is not None:
+            proc.stdout.close()
+        if log_handle is not None:
+            log_handle.close()

--- a/tools/local-ci/local_ci.py
+++ b/tools/local-ci/local_ci.py
@@ -38,7 +38,6 @@ import fcntl
 import json
 import os
 import plistlib
-import queue as queue_module
 import re
 import shlex
 import shutil
@@ -64,8 +63,6 @@ if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 WAIT_POLL_SECS = 3
 KEEP_COMPLETED_JOBS = 25
-HEARTBEAT_INTERVAL_SECS = 15.0
-STUCK_IDLE_SECS = 90.0
 _BUNDLE_BUILD_LOCK = threading.Lock()
 _SSH_TRANSIENT_PATTERNS = (
     "Connection reset by peer",
@@ -151,6 +148,10 @@ import linux_target as _linux_target  # noqa: E402
 import macos_desktop as _macos_desktop  # noqa: E402
 import queue_lifecycle as _queue_lifecycle  # noqa: E402
 import queue_orchestrator as _queue_orchestrator  # noqa: E402
+import execution as _execution  # noqa: E402
+
+HEARTBEAT_INTERVAL_SECS = _execution.HEARTBEAT_INTERVAL_SECS
+STUCK_IDLE_SECS = _execution.STUCK_IDLE_SECS
 import reporting as _reporting  # noqa: E402
 import runner_state as _runner_state  # noqa: E402
 import source_prep as _source_prep  # noqa: E402
@@ -3114,26 +3115,7 @@ def remote_commit_error(target_name: str, host: str, job: dict) -> str:
 
 
 def parse_progress_marker(line: str) -> dict:
-    stripped = line.strip()
-    if stripped.startswith("__PULP_PHASE__:"):
-        return {"phase": stripped.split(":", 1)[1]}
-    if stripped.startswith("__PULP_WAIT__:"):
-        return {"wait_reason": stripped.split(":", 1)[1]}
-    if stripped.startswith("__PULP_VALIDATION__:"):
-        return {"validation_mode": stripped.split(":", 1)[1]}
-    if stripped.startswith("__PULP_TEST_POLICY__:"):
-        return {"test_policy": stripped.split(":", 1)[1]}
-    if stripped.startswith("__PULP_PREPARED__:"):
-        return {"prepared_state": stripped.split(":", 1)[1]}
-    if stripped.startswith("__PULP_VALIDATOR_PID__:"):
-        value = stripped.split(":", 1)[1]
-        try:
-            return {"validator_pid": int(value)}
-        except ValueError:
-            return {"validator_pid": value}
-    if stripped.startswith("__PULP_VALIDATOR_STARTED__:"):
-        return {"validator_started_at": stripped.split(":", 1)[1]}
-    return {}
+    return _execution.parse_progress_marker(line)
 
 
 def prepared_state_root(target_name: str, validation: str) -> Path:
@@ -3155,152 +3137,16 @@ def run_logged_command(
     heartbeat_interval_secs: float = HEARTBEAT_INTERVAL_SECS,
     stuck_idle_secs: float = STUCK_IDLE_SECS,
 ) -> dict:
-    start = time.time()
-    proc = subprocess.Popen(
+    return _execution.run_logged_command(
         cmd,
         cwd=cwd,
-        stdin=subprocess.PIPE if input_text is not None else None,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        bufsize=1,
+        input_text=input_text,
+        timeout=timeout,
+        log_path=log_path,
+        report_progress=report_progress,
+        heartbeat_interval_secs=heartbeat_interval_secs,
+        stuck_idle_secs=stuck_idle_secs,
     )
-
-    output_queue: queue_module.Queue[str | None] = queue_module.Queue()
-    input_error: list[BaseException] = []
-    input_done = threading.Event()
-
-    def reader() -> None:
-        assert proc.stdout is not None
-        for line in proc.stdout:
-            output_queue.put(line)
-        output_queue.put(None)
-
-    threading.Thread(target=reader, daemon=True).start()
-
-    def writer() -> None:
-        try:
-            if input_text is not None and proc.stdin is not None:
-                proc.stdin.write(input_text)
-        except BaseException as exc:  # pragma: no cover - surfaced through polling loop
-            input_error.append(exc)
-        finally:
-            if proc.stdin is not None:
-                try:
-                    proc.stdin.close()
-                except OSError:
-                    pass
-            input_done.set()
-
-    threading.Thread(target=writer, daemon=True).start()
-
-    combined: list[str] = []
-    saw_eof = False
-    last_output_ts = start
-    last_heartbeat_ts = start
-    log_handle = log_path.open("a", errors="replace") if log_path else None
-    try:
-        while True:
-            remaining = timeout - (time.time() - start)
-            if remaining <= 0:
-                proc.kill()
-                try:
-                    proc.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    pass
-                return {
-                    "timed_out": True,
-                    "returncode": -1,
-                    "output": "".join(combined),
-                    "duration_secs": round(time.time() - start, 1),
-                }
-
-            if input_error:
-                proc.kill()
-                try:
-                    proc.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    pass
-                raise input_error[0]
-
-            try:
-                poll_timeout = 0.25
-                if heartbeat_interval_secs > 0:
-                    poll_timeout = min(poll_timeout, max(heartbeat_interval_secs / 2.0, 0.01))
-                item = output_queue.get(timeout=min(poll_timeout, max(remaining, 0.01)))
-            except queue_module.Empty:
-                if proc.poll() is not None and saw_eof and input_done.is_set():
-                    break
-                now = time.time()
-                quiet_for_secs_raw = now - last_output_ts
-                quiet_for_secs = int(round(quiet_for_secs_raw))
-                if (
-                    report_progress
-                    and proc.poll() is None
-                    and (now - last_heartbeat_ts) >= heartbeat_interval_secs
-                ):
-                    report_progress(
-                        last_heartbeat_at=now_iso(),
-                        quiet_for_secs=quiet_for_secs,
-                        liveness="stuck" if quiet_for_secs_raw >= stuck_idle_secs else "quiet",
-                    )
-                    last_heartbeat_ts = now
-                continue
-
-            if item is None:
-                saw_eof = True
-                if proc.poll() is not None and input_done.is_set():
-                    break
-                continue
-
-            progress = parse_progress_marker(item)
-            if progress:
-                combined.append(item)
-                if log_handle is not None:
-                    log_handle.write(item)
-                    log_handle.flush()
-                last_output_ts = time.time()
-                last_heartbeat_ts = last_output_ts
-                progress["last_output_at"] = now_iso()
-                progress["last_heartbeat_at"] = None
-                progress["quiet_for_secs"] = None
-                progress["liveness"] = None
-                if report_progress:
-                    report_progress(**progress)
-                continue
-
-            combined.append(item)
-            if log_handle is not None:
-                log_handle.write(item)
-                log_handle.flush()
-
-            stripped = item.strip()
-            if report_progress:
-                last_output_ts = time.time()
-                last_heartbeat_ts = last_output_ts
-                fields = {
-                    "last_output_at": now_iso(),
-                    "last_heartbeat_at": None,
-                    "quiet_for_secs": None,
-                    "liveness": None,
-                }
-                if stripped:
-                    fields["last_line"] = trim_line(stripped)
-                report_progress(**fields)
-
-        return {
-            "timed_out": False,
-            "returncode": proc.wait(),
-            "output": "".join(combined),
-            "duration_secs": round(time.time() - start, 1),
-        }
-    finally:
-        if proc.stdout is not None:
-            proc.stdout.close()
-        if log_handle is not None:
-            log_handle.close()
 
 
 def run_local_validation(job: dict, exclude_tests: str = "", report_progress=None) -> dict:

--- a/tools/local-ci/test_execution.py
+++ b/tools/local-ci/test_execution.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Tests for local CI command execution helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("execution.py")
+MODULE_DIR = MODULE_PATH.parent
+
+
+def load_module():
+    sys.path.insert(0, str(MODULE_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location("pulp_local_ci_execution", MODULE_PATH)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.pop(0)
+
+
+class ExecutionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = load_module()
+
+    def test_parse_progress_marker_detects_progress_contract(self) -> None:
+        self.assertEqual(self.mod.parse_progress_marker("__PULP_PHASE__:build\n"), {"phase": "build"})
+        self.assertEqual(self.mod.parse_progress_marker("__PULP_WAIT__:host-lock\n"), {"wait_reason": "host-lock"})
+        self.assertEqual(self.mod.parse_progress_marker("__PULP_VALIDATION__:smoke\n"), {"validation_mode": "smoke"})
+        self.assertEqual(self.mod.parse_progress_marker("__PULP_TEST_POLICY__:skip\n"), {"test_policy": "skip"})
+        self.assertEqual(self.mod.parse_progress_marker("__PULP_PREPARED__:reused\n"), {"prepared_state": "reused"})
+        self.assertEqual(self.mod.parse_progress_marker("__PULP_VALIDATOR_PID__:4321\n"), {"validator_pid": 4321})
+        self.assertEqual(
+            self.mod.parse_progress_marker("__PULP_VALIDATOR_STARTED__:2026-04-02T04:00:00+00:00\n"),
+            {"validator_started_at": "2026-04-02T04:00:00+00:00"},
+        )
+        self.assertEqual(self.mod.parse_progress_marker("normal output\n"), {})
+
+    def test_run_logged_command_starts_reader_before_writing_input(self) -> None:
+        read_started = threading.Event()
+        read_finished = threading.Event()
+        writes = []
+
+        class FakeStdout:
+            def __iter__(self):
+                read_started.set()
+                yield "ready\n"
+                read_finished.set()
+
+            def close(self):
+                read_finished.set()
+
+        class FakeStdin:
+            def write(self, text):
+                if not read_started.wait(timeout=1):
+                    raise TimeoutError("reader did not start before stdin write")
+                writes.append(text)
+
+            def close(self):
+                writes.append("<closed>")
+
+        class FakeProc:
+            def __init__(self):
+                self.stdin = FakeStdin()
+                self.stdout = FakeStdout()
+
+            def poll(self):
+                return 0 if read_finished.is_set() else None
+
+            def wait(self, timeout=None):
+                self.poll()
+                read_finished.wait(timeout=timeout)
+                return 0
+
+            def kill(self):
+                read_finished.set()
+
+        original_popen = self.mod.subprocess.Popen
+        self.mod.subprocess.Popen = lambda *args, **kwargs: FakeProc()
+        try:
+            result = self.mod.run_logged_command(["ssh", "win2"], input_text="payload", timeout=5)
+        finally:
+            self.mod.subprocess.Popen = original_popen
+
+        self.assertFalse(result["timed_out"])
+        self.assertEqual(result["returncode"], 0)
+        self.assertEqual(result["output"], "ready\n")
+        self.assertEqual(writes, ["payload", "<closed>"])
+
+    def test_run_logged_command_keeps_markers_logs_and_reports_progress(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "marker.log"
+            seen = {}
+
+            def report_progress(**fields):
+                seen.update(fields)
+
+            result = self.mod.run_logged_command(
+                [
+                    "python3",
+                    "-c",
+                    (
+                        "print('__PULP_VALIDATION__:smoke');"
+                        "print('__PULP_TEST_POLICY__:skip');"
+                        "print('__PULP_PHASE__:build');"
+                        "print('done')"
+                    ),
+                ],
+                log_path=log_path,
+                report_progress=report_progress,
+            )
+
+            self.assertEqual(result["returncode"], 0)
+            self.assertIn("__PULP_VALIDATION__:smoke", result["output"])
+            self.assertIn("__PULP_TEST_POLICY__:skip", result["output"])
+            self.assertIn("__PULP_PHASE__:build", result["output"])
+            self.assertIn("done", result["output"])
+            logged = log_path.read_text()
+            self.assertIn("__PULP_VALIDATION__:smoke", logged)
+            self.assertIn("__PULP_TEST_POLICY__:skip", logged)
+            self.assertEqual(seen["validation_mode"], "smoke")
+            self.assertEqual(seen["test_policy"], "skip")
+            self.assertEqual(seen["phase"], "build")
+
+    def test_run_logged_command_emits_quiet_heartbeat_and_stuck_state(self) -> None:
+        seen: list[dict] = []
+
+        def report_progress(**fields):
+            seen.append(dict(fields))
+
+        result = self.mod.run_logged_command(
+            [
+                "python3",
+                "-c",
+                "import time; time.sleep(0.18); print('done')",
+            ],
+            report_progress=report_progress,
+            heartbeat_interval_secs=0.05,
+            stuck_idle_secs=0.1,
+        )
+
+        self.assertEqual(result["returncode"], 0)
+        heartbeat_events = [item for item in seen if item.get("last_heartbeat_at")]
+        self.assertTrue(heartbeat_events, msg=f"missing heartbeat events in {seen}")
+        liveness_values = {item.get("liveness") for item in heartbeat_events}
+        self.assertTrue(liveness_values <= {"quiet", "stuck"}, msg=f"unexpected heartbeat states in {heartbeat_events}")
+        self.assertTrue("stuck" in liveness_values, msg=f"missing stuck heartbeat in {heartbeat_events}")
+        self.assertTrue(any(item.get("last_output_at") for item in seen))
+
+    def test_run_logged_command_replaces_invalid_utf8_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "nonutf8.log"
+
+            result = self.mod.run_logged_command(
+                [
+                    "python3",
+                    "-c",
+                    (
+                        "import sys; "
+                        "sys.stdout.buffer.write(b'prefix\\xe5suffix\\\\n'); "
+                        "sys.stdout.flush()"
+                    ),
+                ],
+                log_path=log_path,
+            )
+
+            self.assertEqual(result["returncode"], 0)
+            self.assertIn("prefix", result["output"])
+            self.assertIn("suffix", result["output"])
+            self.assertIn("\ufffd", result["output"])
+            logged = log_path.read_text()
+            self.assertIn("prefix", logged)
+            self.assertIn("suffix", logged)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/local-ci/test_local_ci.py
+++ b/tools/local-ci/test_local_ci.py
@@ -5853,12 +5853,12 @@ class LocalCiTests(unittest.TestCase):
             def kill(self):
                 read_finished.set()
 
-        original_popen = self.mod.subprocess.Popen
-        self.mod.subprocess.Popen = lambda *args, **kwargs: FakeProc()
+        original_popen = self.mod._execution.subprocess.Popen
+        self.mod._execution.subprocess.Popen = lambda *args, **kwargs: FakeProc()
         try:
             result = self.mod.run_logged_command(["ssh", "win2"], input_text="payload", timeout=5)
         finally:
-            self.mod.subprocess.Popen = original_popen
+            self.mod._execution.subprocess.Popen = original_popen
 
         self.assertFalse(result["timed_out"])
         self.assertEqual(result["returncode"], 0)


### PR DESCRIPTION
## Summary
- add execution.py for local-ci command output capture, progress marker parsing, heartbeat reporting, and log writing
- keep local_ci.py wrapper functions for the existing surface while delegating to execution.py
- update MODULE_MAP.md and add focused execution helper tests

## Validation
- python3 -m py_compile tools/local-ci/local_ci.py tools/local-ci/execution.py tools/local-ci/test_execution.py tools/local-ci/test_local_ci.py
- python3 tools/local-ci/test_execution.py
- python3 tools/local-ci/test_local_ci.py -k run_logged_command
- python3 tools/local-ci/test_local_ci_extra.py
- python3 -m unittest discover -s tools/local-ci -p 'test_*.py'
- python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat
- python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce
- python3 tools/import-validation/check-source-contracts.py --strict
- python3 tools/import-validation/test_source_contracts.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted local CI command execution into a new `execution.py` module to centralize subprocess handling and progress reporting without changing behavior. Existing `local_ci` APIs remain stable and delegate to the new helpers.

- **Refactors**
  - Added `tools/local-ci/execution.py` for output capture, progress marker parsing, heartbeat updates, and optional command log writing.
  - `local_ci.py` now delegates `run_logged_command` and `parse_progress_marker`; `HEARTBEAT_INTERVAL_SECS` and `STUCK_IDLE_SECS` sourced from `execution`.
  - Updated `MODULE_MAP.md` to document `execution.py`.
  - Added `test_execution.py`; updated `test_local_ci.py` to patch `_execution.Popen`.
  - No CLI or workflow changes; logs and progress events are unchanged.

<sup>Written for commit 169fe4cdb9a93bb3118de9d3a18c5e73ef27ef4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

