### PR TITLE
refactor(local-ci): extract validation helper policy

### DIFF
--- a/tools/local-ci/MODULE_MAP.md
+++ b/tools/local-ci/MODULE_MAP.md
@@ -32,7 +32,7 @@ and the matching contract tests in the same change.
 | `macos_desktop.py` | macOS app bundle detection, Swift window-probe wrappers, window wait/capture/activation/click helpers, app quit, and process termination. | Desktop action orchestration, artifact manifest writing, source preparation, or queue orchestration. |
 | `windows_target.py` | Windows desktop target contracts, path safety, session-agent request payloads, and probe result formatting/readiness helpers. | SSH/PowerShell execution, desktop action execution, queue orchestration, or artifact layout. |
 | `windows_probe.py` | Windows SSH/PowerShell command execution helpers, remote file transfer/read/remove helpers, repo/session/tooling probes, remote tool installation, session-agent bootstrap/start, and CMake generator probing. | Windows target contract formatting, desktop action orchestration, queue orchestration, or artifact layout. |
-| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, and optional command log writing. | Target-specific validation commands, result assembly, queue mutation, or desktop automation adapters. |
+| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, optional command log writing, and target-neutral validation helper policy. | Target-specific validation commands, result assembly, queue mutation, or desktop automation adapters. |
 
 ## Remaining `local_ci.py` Clusters
 
@@ -44,7 +44,7 @@ behind the contracts added in this slice.
 | --- | --- | --- |
 | Desktop target probes | Desktop doctor orchestration, launch adapters, and automation adapters. | later `execution.py` |
 | Queue orchestration | Remaining runner-state wrapper calls and other CLI-facing queue updates. | later queue modules |
-| Validation execution | Local, SSH, Windows, Linux, smoke/full validation commands and target status reporting beyond shared command execution. | `execution.py` |
+| Validation execution | Local, SSH, Windows, Linux, smoke/full validation commands and target status reporting beyond shared command execution and target-neutral helper policy. | `execution.py` |
 | CLI dispatch | Argument parser, subcommand routing, and user-facing command output. | `cli.py` or retained thin entrypoint |
 
 ## Behavior Contracts

--- a/tools/local-ci/execution.py
+++ b/tools/local-ci/execution.py
@@ -13,12 +13,21 @@ import threading
 import time
 from pathlib import Path
 
-from git_helpers import now_iso
+from git_helpers import now_iso, short_sha
 from io_utils import trim_line
+from normalize import normalize_validation_mode
+from state_paths import state_dir
 
 
 HEARTBEAT_INTERVAL_SECS = 15.0
 STUCK_IDLE_SECS = 90.0
+
+
+def remote_commit_error(target_name: str, host: str, job: dict) -> str:
+    return (
+        f"{target_name} cannot validate {short_sha(job['sha'])} on {host}: "
+        f"commit is not available on origin. Push the branch first or use --targets mac."
+    )
 
 
 def parse_progress_marker(line: str) -> dict:
@@ -42,6 +51,14 @@ def parse_progress_marker(line: str) -> dict:
     if stripped.startswith("__PULP_VALIDATOR_STARTED__:"):
         return {"validator_started_at": stripped.split(":", 1)[1]}
     return {}
+
+
+def prepared_state_root(target_name: str, validation: str) -> Path:
+    return state_dir() / "prepared" / target_name / normalize_validation_mode(validation)
+
+
+def should_reuse_prepared_state(job: dict) -> bool:
+    return len(job.get("targets", [])) == 1
 
 
 def run_logged_command(

--- a/tools/local-ci/local_ci.py
+++ b/tools/local-ci/local_ci.py
@@ -3108,10 +3108,7 @@ def print_submission_metadata(metadata: dict) -> None:
 
 
 def remote_commit_error(target_name: str, host: str, job: dict) -> str:
-    return (
-        f"{target_name} cannot validate {short_sha(job['sha'])} on {host}: "
-        f"commit is not available on origin. Push the branch first or use --targets mac."
-    )
+    return _execution.remote_commit_error(target_name, host, job)
 
 
 def parse_progress_marker(line: str) -> dict:
@@ -3119,11 +3116,11 @@ def parse_progress_marker(line: str) -> dict:
 
 
 def prepared_state_root(target_name: str, validation: str) -> Path:
-    return state_dir() / "prepared" / target_name / normalize_validation_mode(validation)
+    return _execution.prepared_state_root(target_name, validation)
 
 
 def should_reuse_prepared_state(job: dict) -> bool:
-    return len(job.get("targets", [])) == 1
+    return _execution.should_reuse_prepared_state(job)
 
 
 def run_logged_command(

--- a/tools/local-ci/test_execution.py
+++ b/tools/local-ci/test_execution.py
@@ -46,6 +46,22 @@ class ExecutionTests(unittest.TestCase):
         )
         self.assertEqual(self.mod.parse_progress_marker("normal output\n"), {})
 
+    def test_validation_helper_policy_matches_contract(self) -> None:
+        job = {"sha": "abcdef1234567890", "targets": ["mac"]}
+        self.assertEqual(
+            self.mod.remote_commit_error("ubuntu", "ubuntu.local", job),
+            (
+                "ubuntu cannot validate abcdef123456 on ubuntu.local: "
+                "commit is not available on origin. Push the branch first or use --targets mac."
+            ),
+        )
+        self.assertEqual(
+            self.mod.prepared_state_root("mac", " SMOKE "),
+            self.mod.state_dir() / "prepared" / "mac" / "smoke",
+        )
+        self.assertTrue(self.mod.should_reuse_prepared_state({"targets": ["mac"]}))
+        self.assertFalse(self.mod.should_reuse_prepared_state({"targets": ["mac", "ubuntu"]}))
+
     def test_run_logged_command_starts_reader_before_writing_input(self) -> None:
         read_started = threading.Event()
         read_finished = threading.Event()


### PR DESCRIPTION
## Summary
- move target-neutral validation helper policy into execution.py
- keep local_ci.py wrapper functions for existing callers/tests
- update MODULE_MAP.md and add focused execution helper coverage

## Validation
- python3 -m py_compile tools/local-ci/local_ci.py tools/local-ci/execution.py tools/local-ci/test_execution.py tools/local-ci/test_local_ci_contracts.py
- python3 tools/local-ci/test_execution.py
- python3 tools/local-ci/test_local_ci_contracts.py
- python3 tools/local-ci/test_local_ci_extra.py
- python3 -m unittest discover -s tools/local-ci -p 'test_*.py'
- python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat
- python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce
- python3 tools/import-validation/check-source-contracts.py --strict
- python3 tools/import-validation/test_source_contracts.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted target-neutral validation helper policy into execution.py to centralize logic and simplify reuse. Kept thin wrappers in local_ci.py for compatibility and added focused tests.

- **Refactors**
  - Moved `remote_commit_error`, `prepared_state_root`, and `should_reuse_prepared_state` into execution.py.
  - Updated local_ci.py to delegate to execution.py to avoid breaking callers/tests.
  - Added tests for the helper policy in test_execution.py.
  - Updated MODULE_MAP.md to reflect the new location.

<sup>Written for commit b3afeacc8d1bdd89d8e9067093e69392dd5a4187. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

