### PR TITLE
refactor(local-ci): extract validation result helper

### DIFF
--- a/tools/local-ci/execution.py
+++ b/tools/local-ci/execution.py
@@ -1,8 +1,9 @@
 """Validation command execution helpers for local CI.
 
 This module owns subprocess output capture, progress marker parsing, heartbeat
-updates, and optional command log writing. Higher-level target validation and
-result assembly stay in local_ci.py until later execution slices.
+updates, optional command log writing, and target-neutral command result
+assembly. Higher-level target validation stays in local_ci.py until later
+execution slices.
 """
 
 from __future__ import annotations
@@ -59,6 +60,53 @@ def prepared_state_root(target_name: str, validation: str) -> Path:
 
 def should_reuse_prepared_state(job: dict) -> bool:
     return len(job.get("targets", [])) == 1
+
+
+def validation_result_from_run(
+    target_name: str,
+    run: dict,
+    *,
+    log_path: Path,
+    validation: str,
+    transport_mode: str,
+    timeout_secs: int = 3600,
+) -> dict:
+    if run["timed_out"]:
+        return {
+            "target": target_name,
+            "status": "timeout",
+            "exit_code": -1,
+            "duration_secs": run["duration_secs"],
+            "stdout_tail": "",
+            "stderr_tail": f"Validation timed out after {timeout_secs}s",
+            "log_file": str(log_path),
+            "transport_mode": transport_mode,
+        }
+
+    tail = run["output"][-2000:] if run["output"] else ""
+    if validation == "smoke":
+        if "__PULP_VALIDATION__:smoke" not in run["output"] or "__PULP_TEST_POLICY__:skip" not in run["output"]:
+            failed = True
+            tail = (
+                "Smoke validation contract violated: expected validation=smoke and test_policy=skip markers.\n"
+                + tail
+            )[-2000:]
+        else:
+            failed = run["returncode"] != 0
+    else:
+        failed = run["returncode"] != 0
+
+    return {
+        "target": target_name,
+        "status": "pass" if not failed else "fail",
+        "exit_code": run["returncode"],
+        "duration_secs": run["duration_secs"],
+        "stdout_tail": "" if failed else tail,
+        "stderr_tail": tail if failed else "",
+        "log_file": str(log_path),
+        "validation": validation,
+        "transport_mode": transport_mode,
+    }
 
 
 def run_logged_command(

--- a/tools/local-ci/local_ci.py
+++ b/tools/local-ci/local_ci.py
@@ -3123,6 +3123,25 @@ def should_reuse_prepared_state(job: dict) -> bool:
     return _execution.should_reuse_prepared_state(job)
 
 
+def validation_result_from_run(
+    target_name: str,
+    run: dict,
+    *,
+    log_path: Path,
+    validation: str,
+    transport_mode: str,
+    timeout_secs: int = 3600,
+) -> dict:
+    return _execution.validation_result_from_run(
+        target_name,
+        run,
+        log_path=log_path,
+        validation=validation,
+        transport_mode=transport_mode,
+        timeout_secs=timeout_secs,
+    )
+
+
 def run_logged_command(
     cmd: list[str],
     *,
@@ -3182,40 +3201,13 @@ def run_local_validation(job: dict, exclude_tests: str = "", report_progress=Non
         cmd += ["--exclude-regex", exclude_tests]
 
     run = run_logged_command(cmd, cwd=ROOT, timeout=3600, log_path=log_path, report_progress=report_progress)
-    if run["timed_out"]:
-        return {
-            "target": "mac",
-            "status": "timeout",
-            "exit_code": -1,
-            "duration_secs": run["duration_secs"],
-            "stdout_tail": "",
-            "stderr_tail": "Validation timed out after 3600s",
-            "log_file": str(log_path),
-            "transport_mode": "local",
-        }
-    tail = run["output"][-2000:] if run["output"] else ""
-    if validation == "smoke":
-        if "__PULP_VALIDATION__:smoke" not in run["output"] or "__PULP_TEST_POLICY__:skip" not in run["output"]:
-            failed = True
-            tail = (
-                "Smoke validation contract violated: expected validation=smoke and test_policy=skip markers.\n"
-                + tail
-            )[-2000:]
-        else:
-            failed = run["returncode"] != 0
-    else:
-        failed = run["returncode"] != 0
-    return {
-        "target": "mac",
-        "status": "pass" if not failed else "fail",
-        "exit_code": run["returncode"],
-        "duration_secs": run["duration_secs"],
-        "stdout_tail": "" if failed else tail,
-        "stderr_tail": tail if failed else "",
-        "log_file": str(log_path),
-        "validation": validation,
-        "transport_mode": "local",
-    }
+    return validation_result_from_run(
+        "mac",
+        run,
+        log_path=log_path,
+        validation=validation,
+        transport_mode="local",
+    )
 
 
 def run_posix_ssh_validation(
@@ -3311,40 +3303,13 @@ def run_posix_ssh_validation(
     cmd = ["ssh", host, "bash", "-lc", shlex.quote(remote_cmd)]
 
     run = run_logged_command(cmd, timeout=3600, log_path=log_path, report_progress=report_progress)
-    if run["timed_out"]:
-        return {
-            "target": target_name,
-            "status": "timeout",
-            "exit_code": -1,
-            "duration_secs": run["duration_secs"],
-            "stdout_tail": "",
-            "stderr_tail": "Validation timed out after 3600s",
-            "log_file": str(log_path),
-            "transport_mode": "bundle",
-        }
-    tail = run["output"][-2000:] if run["output"] else ""
-    if validation == "smoke":
-        if "__PULP_VALIDATION__:smoke" not in run["output"] or "__PULP_TEST_POLICY__:skip" not in run["output"]:
-            failed = True
-            tail = (
-                "Smoke validation contract violated: expected validation=smoke and test_policy=skip markers.\n"
-                + tail
-            )[-2000:]
-        else:
-            failed = run["returncode"] != 0
-    else:
-        failed = run["returncode"] != 0
-    return {
-        "target": target_name,
-        "status": "pass" if not failed else "fail",
-        "exit_code": run["returncode"],
-        "duration_secs": run["duration_secs"],
-        "stdout_tail": "" if failed else tail,
-        "stderr_tail": tail if failed else "",
-        "log_file": str(log_path),
-        "validation": validation,
-        "transport_mode": "bundle",
-    }
+    return validation_result_from_run(
+        target_name,
+        run,
+        log_path=log_path,
+        validation=validation,
+        transport_mode="bundle",
+    )
 
 
 def ps_literal(value: str) -> str:
@@ -3914,41 +3879,14 @@ target_link_libraries(smoke INTERFACE Pulp::format Pulp::standalone)
         log_path=log_path,
         report_progress=report_progress,
     )
-    if run["timed_out"]:
-        return {
-            "target": target_name,
-            "status": "timeout",
-            "exit_code": -1,
-            "duration_secs": run["duration_secs"],
-            "stdout_tail": "",
-            "stderr_tail": "Validation timed out after 3600s",
-            "log_file": str(log_path),
-            "transport_mode": "bundle",
-        }
-    tail = run["output"][-2000:] if run["output"] else ""
     validation = job.get("validation", "full")
-    if validation == "smoke":
-        if "__PULP_VALIDATION__:smoke" not in run["output"] or "__PULP_TEST_POLICY__:skip" not in run["output"]:
-            failed = True
-            tail = (
-                "Smoke validation contract violated: expected validation=smoke and test_policy=skip markers.\n"
-                + tail
-            )[-2000:]
-        else:
-            failed = run["returncode"] != 0
-    else:
-        failed = run["returncode"] != 0
-    return {
-        "target": target_name,
-        "status": "pass" if not failed else "fail",
-        "exit_code": run["returncode"],
-        "duration_secs": run["duration_secs"],
-        "stdout_tail": "" if failed else tail,
-        "stderr_tail": tail if failed else "",
-        "log_file": str(log_path),
-        "validation": validation,
-        "transport_mode": "bundle",
-    }
+    return validation_result_from_run(
+        target_name,
+        run,
+        log_path=log_path,
+        validation=validation,
+        transport_mode="bundle",
+    )
 
 
 # ── Job Processing ───────────────────────────────────────────────────────────

--- a/tools/local-ci/test_execution.py
+++ b/tools/local-ci/test_execution.py
@@ -62,6 +62,65 @@ class ExecutionTests(unittest.TestCase):
         self.assertTrue(self.mod.should_reuse_prepared_state({"targets": ["mac"]}))
         self.assertFalse(self.mod.should_reuse_prepared_state({"targets": ["mac", "ubuntu"]}))
 
+    def test_validation_result_from_run_reports_timeout(self) -> None:
+        result = self.mod.validation_result_from_run(
+            "mac",
+            {"timed_out": True, "duration_secs": 3600.0},
+            log_path=Path("mac.log"),
+            validation="full",
+            transport_mode="local",
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "target": "mac",
+                "status": "timeout",
+                "exit_code": -1,
+                "duration_secs": 3600.0,
+                "stdout_tail": "",
+                "stderr_tail": "Validation timed out after 3600s",
+                "log_file": "mac.log",
+                "transport_mode": "local",
+            },
+        )
+
+    def test_validation_result_from_run_splits_pass_and_fail_tails(self) -> None:
+        passed = self.mod.validation_result_from_run(
+            "ubuntu",
+            {"timed_out": False, "returncode": 0, "output": "ok\n", "duration_secs": 1.2},
+            log_path=Path("ubuntu.log"),
+            validation="full",
+            transport_mode="bundle",
+        )
+        failed = self.mod.validation_result_from_run(
+            "ubuntu",
+            {"timed_out": False, "returncode": 7, "output": "boom\n", "duration_secs": 1.3},
+            log_path=Path("ubuntu.log"),
+            validation="full",
+            transport_mode="bundle",
+        )
+
+        self.assertEqual(passed["status"], "pass")
+        self.assertEqual(passed["stdout_tail"], "ok\n")
+        self.assertEqual(passed["stderr_tail"], "")
+        self.assertEqual(failed["status"], "fail")
+        self.assertEqual(failed["stdout_tail"], "")
+        self.assertEqual(failed["stderr_tail"], "boom\n")
+
+    def test_validation_result_from_run_enforces_smoke_contract(self) -> None:
+        result = self.mod.validation_result_from_run(
+            "windows",
+            {"timed_out": False, "returncode": 0, "output": "ok\n", "duration_secs": 1.2},
+            log_path=Path("windows.log"),
+            validation="smoke",
+            transport_mode="bundle",
+        )
+
+        self.assertEqual(result["status"], "fail")
+        self.assertIn("Smoke validation contract violated", result["stderr_tail"])
+        self.assertEqual(result["stdout_tail"], "")
+
     def test_run_logged_command_starts_reader_before_writing_input(self) -> None:
         read_started = threading.Event()
         read_finished = threading.Event()


### PR DESCRIPTION
## Summary
- move target-neutral validation command result assembly into `tools/local-ci/execution.py`
- keep platform command construction in `local_ci.py` while delegating timeout, tail, and smoke-contract result shaping
- add direct coverage for timeout, pass/fail tails, and smoke marker enforcement

## Local validation
- `python3 -m py_compile tools/local-ci/local_ci.py tools/local-ci/execution.py tools/local-ci/test_execution.py`
- `python3 tools/local-ci/test_execution.py`
- `python3 -m unittest discover -s tools/local-ci -p 'test_*.py'`\n- `python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`\n- `python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat`\n- `python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce`\n- `python3 tools/import-validation/check-source-contracts.py --strict`\n- `python3 tools/import-validation/test_source_contracts.py`\n- `git diff --check HEAD~1..HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted target-neutral validation result assembly into `tools/local-ci/execution.py` and updated local/SSH runners to use it. This removes duplicated logic and standardizes result shaping across platforms.

- **Refactors**
  - Added validation_result_from_run helper handling timeouts, stdout/stderr tail split, and smoke-marker enforcement.
  - Switched local, POSIX SSH, and Windows SSH validations to delegate result shaping to the helper; kept command construction in `local_ci.py`.
  - Added unit tests for timeouts, pass/fail tails, and smoke contract; no behavior change expected.

<sup>Written for commit 08ffe5f684e1eb18421e0a98902075692abc4e34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

