### PR TITLE
refactor(local-ci): extract validation error result helper

### DIFF
--- a/tools/local-ci/execution.py
+++ b/tools/local-ci/execution.py
@@ -109,6 +109,25 @@ def validation_result_from_run(
     }
 
 
+def validation_error_result(
+    target_name: str,
+    detail: str,
+    *,
+    log_path: Path,
+    transport_mode: str,
+) -> dict:
+    return {
+        "target": target_name,
+        "status": "error",
+        "exit_code": -1,
+        "duration_secs": 0.0,
+        "stdout_tail": "",
+        "stderr_tail": detail,
+        "log_file": str(log_path),
+        "transport_mode": transport_mode,
+    }
+
+
 def run_logged_command(
     cmd: list[str],
     *,

--- a/tools/local-ci/local_ci.py
+++ b/tools/local-ci/local_ci.py
@@ -3142,6 +3142,21 @@ def validation_result_from_run(
     )
 
 
+def validation_error_result(
+    target_name: str,
+    detail: str,
+    *,
+    log_path: Path,
+    transport_mode: str,
+) -> dict:
+    return _execution.validation_error_result(
+        target_name,
+        detail,
+        log_path=log_path,
+        transport_mode=transport_mode,
+    )
+
+
 def run_logged_command(
     cmd: list[str],
     *,
@@ -3238,16 +3253,7 @@ def run_posix_ssh_validation(
             config=config,
         )
     except RuntimeError as exc:
-        return {
-            "target": target_name,
-            "status": "error",
-            "exit_code": -1,
-            "duration_secs": 0.0,
-            "stdout_tail": "",
-            "stderr_tail": str(exc),
-            "log_file": str(log_path),
-            "transport_mode": "bundle",
-        }
+        return validation_error_result(target_name, str(exc), log_path=log_path, transport_mode="bundle")
 
     branch_q = shlex.quote(job["branch"])
     sha_q = shlex.quote(job["sha"])
@@ -3463,16 +3469,7 @@ def run_windows_ssh_validation(
             config=config,
         )
     except RuntimeError as exc:
-        return {
-            "target": target_name,
-            "status": "error",
-            "exit_code": -1,
-            "duration_secs": 0.0,
-            "stdout_tail": "",
-            "stderr_tail": str(exc),
-            "log_file": str(log_path),
-            "transport_mode": "bundle",
-        }
+        return validation_error_result(target_name, str(exc), log_path=log_path, transport_mode="bundle")
     try:
         repo_probe = ensure_windows_remote_repo_checkout(
             host,
@@ -3482,28 +3479,15 @@ def run_windows_ssh_validation(
             bundle_ref=bundle_ref,
         )
     except RuntimeError as exc:
-        return {
-            "target": target_name,
-            "status": "error",
-            "exit_code": -1,
-            "duration_secs": 0.0,
-            "stdout_tail": "",
-            "stderr_tail": str(exc),
-            "log_file": str(log_path),
-            "transport_mode": "bundle",
-        }
+        return validation_error_result(target_name, str(exc), log_path=log_path, transport_mode="bundle")
 
     if not isinstance(repo_probe, dict):
-        return {
-            "target": target_name,
-            "status": "error",
-            "exit_code": -1,
-            "duration_secs": 0.0,
-            "stdout_tail": "",
-            "stderr_tail": "Windows repo checkout probe returned no structured payload",
-            "log_file": str(log_path),
-            "transport_mode": "bundle",
-        }
+        return validation_error_result(
+            target_name,
+            "Windows repo checkout probe returned no structured payload",
+            log_path=log_path,
+            transport_mode="bundle",
+        )
 
     effective_repo_path = repo_probe.get("repo_path") or repo_path
     print(f"  [{target_name}] Running validation on {host}:{effective_repo_path} @ {short_sha(job['sha'])}...")

--- a/tools/local-ci/test_execution.py
+++ b/tools/local-ci/test_execution.py
@@ -121,6 +121,28 @@ class ExecutionTests(unittest.TestCase):
         self.assertIn("Smoke validation contract violated", result["stderr_tail"])
         self.assertEqual(result["stdout_tail"], "")
 
+    def test_validation_error_result_matches_validation_contract(self) -> None:
+        result = self.mod.validation_error_result(
+            "windows",
+            "probe failed",
+            log_path=Path("windows.log"),
+            transport_mode="bundle",
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "target": "windows",
+                "status": "error",
+                "exit_code": -1,
+                "duration_secs": 0.0,
+                "stdout_tail": "",
+                "stderr_tail": "probe failed",
+                "log_file": "windows.log",
+                "transport_mode": "bundle",
+            },
+        )
+
     def test_run_logged_command_starts_reader_before_writing_input(self) -> None:
         read_started = threading.Event()
         read_finished = threading.Event()


### PR DESCRIPTION
## Summary
- move target-neutral validation startup error result assembly into `tools/local-ci/execution.py`
- reuse the helper from POSIX SSH and Windows validation setup failure paths
- add direct coverage for the error result contract

## Local validation
- `python3 -m py_compile tools/local-ci/local_ci.py tools/local-ci/execution.py tools/local-ci/test_execution.py`
- `python3 tools/local-ci/test_execution.py`
- `python3 -m unittest discover -s tools/local-ci -p 'test_*.py'`\n- `python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`\n- `python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat`\n- `python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce`\n- `python3 tools/import-validation/check-source-contracts.py --strict`\n- `python3 tools/import-validation/test_source_contracts.py`\n- `git diff --check HEAD~1..HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared helper to build validation error results in local CI. This removes duplicate code in POSIX SSH and Windows paths and keeps the error contract consistent.

- **Refactors**
  - Moved target-agnostic error result builder to tools/local-ci/execution.py and reused in POSIX SSH and Windows setup failure paths.
  - Added a unit test to enforce the error result contract.

<sup>Written for commit 7e19a8d2388a490a7f2f2e04457f72933229761e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

