### PR TITLE
refactor(local-ci): extract local validation command helper

### DIFF
--- a/tools/local-ci/MODULE_MAP.md
+++ b/tools/local-ci/MODULE_MAP.md
@@ -32,7 +32,7 @@ and the matching contract tests in the same change.
 | `macos_desktop.py` | macOS app bundle detection, Swift window-probe wrappers, window wait/capture/activation/click helpers, app quit, and process termination. | Desktop action orchestration, artifact manifest writing, source preparation, or queue orchestration. |
 | `windows_target.py` | Windows desktop target contracts, path safety, session-agent request payloads, and probe result formatting/readiness helpers. | SSH/PowerShell execution, desktop action execution, queue orchestration, or artifact layout. |
 | `windows_probe.py` | Windows SSH/PowerShell command execution helpers, remote file transfer/read/remove helpers, repo/session/tooling probes, remote tool installation, session-agent bootstrap/start, and CMake generator probing. | Windows target contract formatting, desktop action orchestration, queue orchestration, or artifact layout. |
-| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, optional command log writing, and target-neutral validation helper policy. | Target-specific validation commands, result assembly, queue mutation, or desktop automation adapters. |
+| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, optional command log writing, local validation command construction, and target-neutral validation helper policy. | SSH/Windows validation commands, queue mutation, or desktop automation adapters. |
 
 ## Remaining `local_ci.py` Clusters
 

--- a/tools/local-ci/execution.py
+++ b/tools/local-ci/execution.py
@@ -62,6 +62,33 @@ def should_reuse_prepared_state(job: dict) -> bool:
     return len(job.get("targets", [])) == 1
 
 
+def local_validation_command(job: dict, exclude_tests: str = "") -> tuple[list[str], str]:
+    validation = job.get("validation", "full")
+    prepared_root = prepared_state_root("mac", validation)
+    reuse_prepared = should_reuse_prepared_state(job)
+    env_args = [
+        f"PULP_VALIDATE_ROOT_OVERRIDE={prepared_root}",
+        f"PULP_VALIDATE_REUSE_PREPARED={'1' if reuse_prepared else '0'}",
+    ]
+    cmd = ["env", *env_args, "./validate-build.sh", "--quiet", "--keep-worktree", "--ref", job["sha"]]
+    if validation == "smoke":
+        cmd = [
+            "env",
+            *env_args,
+            "PULP_EXPECT_SMOKE=1",
+            "./validate-build.sh",
+            "--quiet",
+            "--keep-worktree",
+            "--ref",
+            job["sha"],
+            "--smoke",
+            "--no-tests",
+        ]
+    if exclude_tests:
+        cmd += ["--exclude-regex", exclude_tests]
+    return cmd, validation
+
+
 def validation_result_from_run(
     target_name: str,
     run: dict,

--- a/tools/local-ci/local_ci.py
+++ b/tools/local-ci/local_ci.py
@@ -3123,6 +3123,10 @@ def should_reuse_prepared_state(job: dict) -> bool:
     return _execution.should_reuse_prepared_state(job)
 
 
+def local_validation_command(job: dict, exclude_tests: str = "") -> tuple[list[str], str]:
+    return _execution.local_validation_command(job, exclude_tests)
+
+
 def validation_result_from_run(
     target_name: str,
     run: dict,
@@ -3191,29 +3195,7 @@ def run_local_validation(job: dict, exclude_tests: str = "", report_progress=Non
             transport_mode="local",
         )
 
-    validation = job.get("validation", "full")
-    prepared_root = prepared_state_root("mac", validation)
-    reuse_prepared = should_reuse_prepared_state(job)
-    env_args = [
-        f"PULP_VALIDATE_ROOT_OVERRIDE={prepared_root}",
-        f"PULP_VALIDATE_REUSE_PREPARED={'1' if reuse_prepared else '0'}",
-    ]
-    cmd = ["env", *env_args, "./validate-build.sh", "--quiet", "--keep-worktree", "--ref", job["sha"]]
-    if validation == "smoke":
-        cmd = [
-            "env",
-            *env_args,
-            "PULP_EXPECT_SMOKE=1",
-            "./validate-build.sh",
-            "--quiet",
-            "--keep-worktree",
-            "--ref",
-            job["sha"],
-            "--smoke",
-            "--no-tests",
-        ]
-    if exclude_tests:
-        cmd += ["--exclude-regex", exclude_tests]
+    cmd, validation = local_validation_command(job, exclude_tests)
 
     run = run_logged_command(cmd, cwd=ROOT, timeout=3600, log_path=log_path, report_progress=report_progress)
     return validation_result_from_run(

--- a/tools/local-ci/test_execution.py
+++ b/tools/local-ci/test_execution.py
@@ -62,6 +62,29 @@ class ExecutionTests(unittest.TestCase):
         self.assertTrue(self.mod.should_reuse_prepared_state({"targets": ["mac"]}))
         self.assertFalse(self.mod.should_reuse_prepared_state({"targets": ["mac", "ubuntu"]}))
 
+    def test_local_validation_command_builds_full_and_smoke_commands(self) -> None:
+        full_cmd, full_validation = self.mod.local_validation_command(
+            {"sha": "a" * 40, "targets": ["mac"], "validation": "full"},
+            exclude_tests="slow",
+        )
+        smoke_cmd, smoke_validation = self.mod.local_validation_command(
+            {"sha": "b" * 40, "targets": ["mac"], "validation": "smoke"}
+        )
+
+        self.assertEqual(full_validation, "full")
+        self.assertEqual(full_cmd[0], "env")
+        self.assertIn("PULP_VALIDATE_REUSE_PREPARED=1", full_cmd)
+        self.assertIn("./validate-build.sh", full_cmd)
+        self.assertIn("--keep-worktree", full_cmd)
+        self.assertIn("--exclude-regex", full_cmd)
+        self.assertIn("slow", full_cmd)
+        self.assertNotIn("PULP_EXPECT_SMOKE=1", full_cmd)
+
+        self.assertEqual(smoke_validation, "smoke")
+        self.assertIn("PULP_EXPECT_SMOKE=1", smoke_cmd)
+        self.assertIn("--smoke", smoke_cmd)
+        self.assertIn("--no-tests", smoke_cmd)
+
     def test_validation_result_from_run_reports_timeout(self) -> None:
         result = self.mod.validation_result_from_run(
             "mac",


### PR DESCRIPTION
## Summary
- move local mac validation command construction into execution.py
- keep run_local_validation responsible for logging, progress reporting, execution, and result assembly
- add focused no-network coverage for full and smoke command shapes
- update the local-ci module map ownership note

## Tests
- python3 -m py_compile tools/local-ci/local_ci.py tools/local-ci/execution.py tools/local-ci/test_execution.py
- python3 tools/local-ci/test_execution.py
- python3 tools/local-ci/test_local_ci.py -k run_local_validation
- python3 -m unittest discover -s tools/local-ci -p 'test_*.py'
- python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat
- python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce
- python3 tools/import-validation/check-source-contracts.py --strict
- python3 tools/import-validation/test_source_contracts.py
- git diff --check HEAD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted local validation command construction into `execution.py` as `local_validation_command` to decouple it from `run_local_validation` and improve testability. No behavior change; adds unit tests for full/smoke command shapes and updates `MODULE_MAP.md`.

- **Refactors**
  - Added `local_validation_command(job, exclude_tests="")` in `execution.py` (returns command and validation type).
  - `run_local_validation` now only handles logging, progress, execution, and result assembly.
  - Re-exported `local_validation_command` in `local_ci.py`; updated `MODULE_MAP.md` to reflect ownership.

<sup>Written for commit ff3d768d2d069d320a91025a4c3d8495cb7895e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

