### PR TITLE
refactor(local-ci): extract posix validation command helper

### DIFF
--- a/tools/local-ci/MODULE_MAP.md
+++ b/tools/local-ci/MODULE_MAP.md
@@ -32,7 +32,7 @@ and the matching contract tests in the same change.
 | `macos_desktop.py` | macOS app bundle detection, Swift window-probe wrappers, window wait/capture/activation/click helpers, app quit, and process termination. | Desktop action orchestration, artifact manifest writing, source preparation, or queue orchestration. |
 | `windows_target.py` | Windows desktop target contracts, path safety, session-agent request payloads, and probe result formatting/readiness helpers. | SSH/PowerShell execution, desktop action execution, queue orchestration, or artifact layout. |
 | `windows_probe.py` | Windows SSH/PowerShell command execution helpers, remote file transfer/read/remove helpers, repo/session/tooling probes, remote tool installation, session-agent bootstrap/start, and CMake generator probing. | Windows target contract formatting, desktop action orchestration, queue orchestration, or artifact layout. |
-| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, optional command log writing, local validation command construction, and target-neutral validation helper policy. | SSH/Windows validation commands, queue mutation, or desktop automation adapters. |
+| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, optional command log writing, local/POSIX validation command construction, and target-neutral validation helper policy. | Windows validation commands, queue mutation, or desktop automation adapters. |
 
 ## Remaining `local_ci.py` Clusters
 

--- a/tools/local-ci/execution.py
+++ b/tools/local-ci/execution.py
@@ -9,6 +9,7 @@ execution slices.
 from __future__ import annotations
 
 import queue as queue_module
+import shlex
 import subprocess
 import threading
 import time
@@ -87,6 +88,70 @@ def local_validation_command(job: dict, exclude_tests: str = "") -> tuple[list[s
     if exclude_tests:
         cmd += ["--exclude-regex", exclude_tests]
     return cmd, validation
+
+
+def posix_ssh_validation_command(
+    target_name: str,
+    host: str,
+    repo_path: str,
+    job: dict,
+    *,
+    bundle_name: str,
+    bundle_ref: str,
+    exclude_tests: str = "",
+) -> tuple[list[str], str]:
+    branch_q = shlex.quote(job["branch"])
+    sha_q = shlex.quote(job["sha"])
+    repo_q = shlex.quote(repo_path)
+    bundle_name_q = shlex.quote(bundle_name)
+    bundle_ref_q = shlex.quote(bundle_ref)
+    script_name_q = shlex.quote(f".pulp-ci-validate-{job['id']}.sh")
+    validation = normalize_validation_mode(job.get("validation", "full"))
+    reuse_prepared_q = shlex.quote("1" if should_reuse_prepared_state(job) else "0")
+    remote_cmd = (
+        "set -euo pipefail; "
+        f"branch={branch_q}; "
+        f"sha={sha_q}; "
+        f"bundle_name={bundle_name_q}; "
+        f"bundle_ref={bundle_ref_q}; "
+        f"script_name={script_name_q}; "
+        f"reuse_prepared={reuse_prepared_q}; "
+        "bundle=\"$HOME/$bundle_name\"; "
+        f"prepared_root=\"$HOME/.local/state/pulp/local-ci/prepared/{target_name}/{validation}\"; "
+        "script=''; "
+        "trap 'rm -f \"$bundle\" \"$script\"' EXIT; "
+        "export GIT_LFS_SKIP_SMUDGE=1; "
+        f"cd {repo_q}; "
+        "script=\"$PWD/$script_name\"; "
+        "if [ -f \"$bundle\" ]; then "
+        "printf '__PULP_PHASE__:bundle-sync\n'; "
+        "git fetch \"$bundle\" \"$bundle_ref:refs/remotes/origin/$branch\" >/dev/null 2>&1 || true; "
+        "fi; "
+        "printf '__PULP_PHASE__:fetch\n'; "
+        "git fetch origin >/dev/null 2>&1 || true; "
+        "if ! git cat-file -e \"$sha^{commit}\" 2>/dev/null; then "
+        "git fetch origin \"refs/heads/$branch:refs/remotes/origin/$branch\" >/dev/null 2>&1 || true; "
+        "fi; "
+        "if ! git cat-file -e \"$sha^{commit}\" 2>/dev/null; then "
+        f"echo {shlex.quote(remote_commit_error(target_name, host, job))} >&2; "
+        "exit 2; "
+        "fi; "
+        "printf '__PULP_PHASE__:validate\n'; "
+        "git show \"$sha:validate-build.sh\" > \"$script\"; "
+        "chmod +x \"$script\"; "
+        "PULP_VALIDATE_ROOT_OVERRIDE=\"$prepared_root\" "
+        "PULP_VALIDATE_REUSE_PREPARED=\"$reuse_prepared\" "
+        "PULP_EXPECT_SMOKE=0 "
+        "bash \"$script\" --quiet --keep-worktree --ref \"$sha\""
+    )
+    if validation == "smoke":
+        remote_cmd = remote_cmd.replace("PULP_EXPECT_SMOKE=0", "PULP_EXPECT_SMOKE=1", 1)
+        remote_cmd += " --smoke --no-tests"
+    if exclude_tests:
+        remote_cmd += f" --exclude-regex {shlex.quote(exclude_tests)}"
+
+    remote_cmd = 'export PATH="$HOME/.local/bin:$PATH"; ' + remote_cmd
+    return ["ssh", host, "bash", "-lc", shlex.quote(remote_cmd)], validation
 
 
 def validation_result_from_run(

--- a/tools/local-ci/local_ci.py
+++ b/tools/local-ci/local_ci.py
@@ -3127,6 +3127,27 @@ def local_validation_command(job: dict, exclude_tests: str = "") -> tuple[list[s
     return _execution.local_validation_command(job, exclude_tests)
 
 
+def posix_ssh_validation_command(
+    target_name: str,
+    host: str,
+    repo_path: str,
+    job: dict,
+    *,
+    bundle_name: str,
+    bundle_ref: str,
+    exclude_tests: str = "",
+) -> tuple[list[str], str]:
+    return _execution.posix_ssh_validation_command(
+        target_name,
+        host,
+        repo_path,
+        job,
+        bundle_name=bundle_name,
+        bundle_ref=bundle_ref,
+        exclude_tests=exclude_tests,
+    )
+
+
 def validation_result_from_run(
     target_name: str,
     run: dict,
@@ -3237,58 +3258,15 @@ def run_posix_ssh_validation(
     except RuntimeError as exc:
         return validation_error_result(target_name, str(exc), log_path=log_path, transport_mode="bundle")
 
-    branch_q = shlex.quote(job["branch"])
-    sha_q = shlex.quote(job["sha"])
-    repo_q = shlex.quote(repo_path)
-    bundle_name_q = shlex.quote(bundle_name)
-    bundle_ref_q = shlex.quote(bundle_ref)
-    script_name_q = shlex.quote(f".pulp-ci-validate-{job['id']}.sh")
-    validation = normalize_validation_mode(job.get("validation", "full"))
-    reuse_prepared_q = shlex.quote("1" if should_reuse_prepared_state(job) else "0")
-    remote_cmd = (
-        "set -euo pipefail; "
-        f"branch={branch_q}; "
-        f"sha={sha_q}; "
-        f"bundle_name={bundle_name_q}; "
-        f"bundle_ref={bundle_ref_q}; "
-        f"script_name={script_name_q}; "
-        f"reuse_prepared={reuse_prepared_q}; "
-        "bundle=\"$HOME/$bundle_name\"; "
-        f"prepared_root=\"$HOME/.local/state/pulp/local-ci/prepared/{target_name}/{validation}\"; "
-        "script=''; "
-        "trap 'rm -f \"$bundle\" \"$script\"' EXIT; "
-        "export GIT_LFS_SKIP_SMUDGE=1; "
-        f"cd {repo_q}; "
-        "script=\"$PWD/$script_name\"; "
-        "if [ -f \"$bundle\" ]; then "
-        "printf '__PULP_PHASE__:bundle-sync\n'; "
-        "git fetch \"$bundle\" \"$bundle_ref:refs/remotes/origin/$branch\" >/dev/null 2>&1 || true; "
-        "fi; "
-        "printf '__PULP_PHASE__:fetch\n'; "
-        "git fetch origin >/dev/null 2>&1 || true; "
-        "if ! git cat-file -e \"$sha^{commit}\" 2>/dev/null; then "
-        "git fetch origin \"refs/heads/$branch:refs/remotes/origin/$branch\" >/dev/null 2>&1 || true; "
-        "fi; "
-        "if ! git cat-file -e \"$sha^{commit}\" 2>/dev/null; then "
-        f"echo {shlex.quote(remote_commit_error(target_name, host, job))} >&2; "
-        "exit 2; "
-        "fi; "
-        "printf '__PULP_PHASE__:validate\n'; "
-        "git show \"$sha:validate-build.sh\" > \"$script\"; "
-        "chmod +x \"$script\"; "
-        "PULP_VALIDATE_ROOT_OVERRIDE=\"$prepared_root\" "
-        "PULP_VALIDATE_REUSE_PREPARED=\"$reuse_prepared\" "
-        "PULP_EXPECT_SMOKE=0 "
-        "bash \"$script\" --quiet --keep-worktree --ref \"$sha\""
+    cmd, validation = posix_ssh_validation_command(
+        target_name,
+        host,
+        repo_path,
+        job,
+        bundle_name=bundle_name,
+        bundle_ref=bundle_ref,
+        exclude_tests=exclude_tests,
     )
-    if validation == "smoke":
-        remote_cmd = remote_cmd.replace("PULP_EXPECT_SMOKE=0", "PULP_EXPECT_SMOKE=1", 1)
-        remote_cmd += " --smoke --no-tests"
-    if exclude_tests:
-        remote_cmd += f" --exclude-regex {shlex.quote(exclude_tests)}"
-
-    remote_cmd = 'export PATH="$HOME/.local/bin:$PATH"; ' + remote_cmd
-    cmd = ["ssh", host, "bash", "-lc", shlex.quote(remote_cmd)]
 
     run = run_logged_command(cmd, timeout=3600, log_path=log_path, report_progress=report_progress)
     return validation_result_from_run(

--- a/tools/local-ci/test_execution.py
+++ b/tools/local-ci/test_execution.py
@@ -85,6 +85,61 @@ class ExecutionTests(unittest.TestCase):
         self.assertIn("--smoke", smoke_cmd)
         self.assertIn("--no-tests", smoke_cmd)
 
+    def test_posix_ssh_validation_command_builds_full_command(self) -> None:
+        job = {
+            "id": "job701",
+            "branch": "feature/posix",
+            "sha": "c" * 40,
+            "targets": ["ubuntu"],
+            "validation": "full",
+        }
+
+        cmd, validation = self.mod.posix_ssh_validation_command(
+            "ubuntu",
+            "ubuntu.example.com",
+            "/tmp/pulp repo",
+            job,
+            bundle_name="bundle name.bundle",
+            bundle_ref="refs/pulp-ci/job701",
+            exclude_tests="slow test",
+        )
+        remote_cmd = self.mod.shlex.split(cmd[-1])[0]
+
+        self.assertEqual(validation, "full")
+        self.assertEqual(cmd[:3], ["ssh", "ubuntu.example.com", "bash"])
+        self.assertIn('export PATH="$HOME/.local/bin:$PATH"; set -euo pipefail', remote_cmd)
+        self.assertIn("branch=feature/posix", remote_cmd)
+        self.assertIn("sha=" + "c" * 40, remote_cmd)
+        self.assertIn("git fetch \"$bundle\" \"$bundle_ref:refs/remotes/origin/$branch\"", remote_cmd)
+        self.assertIn("PULP_EXPECT_SMOKE=0", remote_cmd)
+        self.assertIn("bash \"$script\" --quiet --keep-worktree --ref \"$sha\"", remote_cmd)
+        self.assertIn("--exclude-regex 'slow test'", remote_cmd)
+        self.assertIn("ubuntu cannot validate cccccccccccc on ubuntu.example.com", remote_cmd)
+
+    def test_posix_ssh_validation_command_builds_smoke_command(self) -> None:
+        job = {
+            "id": "job702",
+            "branch": "feature/smoke",
+            "sha": "d" * 40,
+            "targets": ["ubuntu"],
+            "validation": "smoke",
+        }
+
+        cmd, validation = self.mod.posix_ssh_validation_command(
+            "ubuntu",
+            "ubuntu.example.com",
+            "/tmp/pulp",
+            job,
+            bundle_name="bundle.bundle",
+            bundle_ref="refs/pulp-ci/job702",
+        )
+        remote_cmd = self.mod.shlex.split(cmd[-1])[0]
+
+        self.assertEqual(validation, "smoke")
+        self.assertIn("prepared/ubuntu/smoke", remote_cmd)
+        self.assertIn("PULP_EXPECT_SMOKE=1", remote_cmd)
+        self.assertIn("--smoke --no-tests", remote_cmd)
+
     def test_validation_result_from_run_reports_timeout(self) -> None:
         result = self.mod.validation_result_from_run(
             "mac",


### PR DESCRIPTION
## Summary
- move POSIX SSH validation command construction into execution.py
- keep run_posix_ssh_validation responsible for logging, bundle upload, command execution, and result assembly
- add focused no-network coverage for full and smoke POSIX command shapes
- update the local-ci module map ownership note

## Tests
- python3 -m py_compile tools/local-ci/local_ci.py tools/local-ci/execution.py tools/local-ci/test_execution.py
- python3 tools/local-ci/test_execution.py
- python3 tools/local-ci/test_local_ci.py -k posix_validation
- python3 -m unittest discover -s tools/local-ci -p 'test_*.py'
- PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat
- python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce
- python3 tools/import-validation/check-source-contracts.py --strict
- python3 tools/import-validation/test_source_contracts.py
- git diff --check HEAD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted POSIX SSH validation command building into `tools/local-ci/execution.py` for clearer separation and easier testing. No behavior changes; added focused tests and updated the module map.

- **Refactors**
  - Added `posix_ssh_validation_command(...)` in `execution.py`.
  - `run_posix_ssh_validation(...)` now calls the helper and keeps logging, bundle upload, execution, and result assembly.
  - Updated `MODULE_MAP.md` to note local/POSIX command construction.

- **Tests**
  - Added no-network tests for full and smoke POSIX command shapes in `test_execution.py`.
  - Verified flags and env setup (smoke toggles, exclude-regex, PATH export, prepared root).

<sup>Written for commit 3786e0cf0389b3e979e9d0fad8b28bc355f96a8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

