### PR TITLE
refactor(local-ci): extract windows validation script helper

### DIFF
--- a/tools/local-ci/MODULE_MAP.md
+++ b/tools/local-ci/MODULE_MAP.md
@@ -32,7 +32,7 @@ and the matching contract tests in the same change.
 | `macos_desktop.py` | macOS app bundle detection, Swift window-probe wrappers, window wait/capture/activation/click helpers, app quit, and process termination. | Desktop action orchestration, artifact manifest writing, source preparation, or queue orchestration. |
 | `windows_target.py` | Windows desktop target contracts, path safety, session-agent request payloads, and probe result formatting/readiness helpers. | SSH/PowerShell execution, desktop action execution, queue orchestration, or artifact layout. |
 | `windows_probe.py` | Windows SSH/PowerShell command execution helpers, remote file transfer/read/remove helpers, repo/session/tooling probes, remote tool installation, session-agent bootstrap/start, and CMake generator probing. | Windows target contract formatting, desktop action orchestration, queue orchestration, or artifact layout. |
-| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, optional command log writing, local/POSIX validation command construction, and target-neutral validation helper policy. | Windows validation commands, queue mutation, or desktop automation adapters. |
+| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, optional command log writing, local/POSIX validation command construction, Windows validation script construction, and target-neutral validation helper policy. | Windows checkout/probe execution, queue mutation, or desktop automation adapters. |
 
 ## Remaining `local_ci.py` Clusters
 

--- a/tools/local-ci/execution.py
+++ b/tools/local-ci/execution.py
@@ -8,6 +8,7 @@ execution slices.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import queue as queue_module
 import shlex
 import subprocess
@@ -152,6 +153,371 @@ def posix_ssh_validation_command(
 
     remote_cmd = 'export PATH="$HOME/.local/bin:$PATH"; ' + remote_cmd
     return ["ssh", host, "bash", "-lc", shlex.quote(remote_cmd)], validation
+
+
+def windows_validation_script(
+    target_name: str,
+    host: str,
+    effective_repo_path: str,
+    job: dict,
+    *,
+    bundle_name: str,
+    bundle_ref: str,
+    exclude_tests: str,
+    cmake_generator: str,
+    resolved_platform: str,
+    resolved_generator_instance: str,
+    ps_literal_fn: Callable[[str], str],
+) -> tuple[str, str]:
+    ps_literal = ps_literal_fn
+    validation = job.get("validation", "full")
+    ps_script = f"""
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Native {{
+    param([string]$File, [string[]]$Arguments)
+    & $File @Arguments
+    if ($LASTEXITCODE -ne 0) {{
+        throw "$File exited with code $LASTEXITCODE"
+    }}
+}}
+
+function Test-CommitRef {{
+    param([string]$Ref)
+    & git rev-parse --verify --quiet "$Ref`^{{commit}}" 1> $null 2> $null
+    return $LASTEXITCODE -eq 0
+}}
+
+function Remove-DirectoryTreeRobust {{
+    param([string]$Path)
+
+    if (-not (Test-Path $Path)) {{
+        return
+    }}
+    try {{
+        cmd.exe /d /c ('rmdir /s /q "{{0}}"' -f $Path) | Out-Null
+    }} catch {{
+    }}
+    if (Test-Path $Path) {{
+        try {{
+            $LongPath = if ($Path.StartsWith('\\\\?\\')) {{ $Path }} else {{ '\\\\?\\' + $Path }}
+            Remove-Item -LiteralPath $LongPath -Recurse -Force -ErrorAction Stop
+        }} catch {{
+        }}
+    }}
+    if (Test-Path $Path) {{
+        try {{
+            Remove-Item -Recurse -Force -ErrorAction Stop $Path
+        }} catch {{
+        }}
+    }}
+}}
+
+function Remove-WorktreeSafe {{
+    param([string]$RepoRoot, [string]$Path)
+    try {{
+        Invoke-Native git @('-C', $RepoRoot, 'worktree', 'remove', '--force', '--force', $Path)
+    }} catch {{
+    }}
+    Remove-DirectoryTreeRobust $Path
+    try {{
+        Invoke-Native git @('-C', $RepoRoot, 'worktree', 'prune', '--expire', 'now')
+    }} catch {{
+    }}
+}}
+
+function Remove-PreparedRoot {{
+    param([string]$RepoRoot, [string]$PreparedRoot)
+
+    $PreparedSrc = Join-Path $PreparedRoot 'src'
+    if (Test-Path $PreparedSrc) {{
+        Remove-WorktreeSafe $RepoRoot $PreparedSrc
+    }}
+    if (Test-Path $PreparedRoot) {{
+        Remove-DirectoryTreeRobust $PreparedRoot
+    }}
+}}
+
+function Test-PreparedStateMatches {{
+    param(
+        [string]$StatePath,
+        [string]$ExpectedSha,
+        [string]$ExpectedValidation,
+        [string]$ExpectedGenerator,
+        [string]$ExpectedPlatform,
+        [string]$ExpectedGeneratorInstance
+    )
+
+    if (-not (Test-Path $StatePath)) {{
+        return $false
+    }}
+
+    try {{
+        $state = Get-Content $StatePath -Raw | ConvertFrom-Json
+    }} catch {{
+        return $false
+    }}
+
+    if (
+        $state.sha -ne $ExpectedSha -or
+        $state.validation -ne $ExpectedValidation -or
+        $state.generator -ne $ExpectedGenerator -or
+        $state.platform -ne $ExpectedPlatform -or
+        $state.generator_instance -ne $ExpectedGeneratorInstance
+    ) {{
+        return $false
+    }}
+
+    $PreparedRoot = Split-Path $StatePath -Parent
+    $PreparedSrc = Join-Path $PreparedRoot 'src'
+    $PreparedBuild = Join-Path $PreparedRoot 'build'
+    $PreparedInstall = Join-Path $PreparedRoot 'install'
+    if (-not (Test-Path $PreparedSrc) -or -not (Test-Path $PreparedBuild) -or -not (Test-Path $PreparedInstall)) {{
+        return $false
+    }}
+
+    $preparedHead = ((& git -C $PreparedSrc rev-parse HEAD 2>$null) | Select-Object -Last 1).Trim()
+    if ($LASTEXITCODE -ne 0) {{
+        return $false
+    }}
+    return $preparedHead -eq $ExpectedSha
+}}
+
+function Write-PreparedState {{
+    param(
+        [string]$StatePath,
+        [string]$Sha,
+        [string]$Validation,
+        [string]$Generator,
+        [string]$Platform,
+        [string]$GeneratorInstance
+    )
+
+    $payload = @{{
+        sha = $Sha
+        validation = $Validation
+        generator = $Generator
+        platform = $Platform
+        generator_instance = $GeneratorInstance
+        updated_at = (Get-Date).ToString('o')
+    }}
+    $payload | ConvertTo-Json | Set-Content -Path $StatePath
+}}
+
+function Wait-HostMutex {{
+    param(
+        [System.Threading.Mutex]$Mutex,
+        [bool]$Immediate
+    )
+
+    try {{
+        if ($Immediate) {{
+            return $Mutex.WaitOne(0)
+        }}
+        $null = $Mutex.WaitOne()
+        return $true
+    }} catch [System.Threading.AbandonedMutexException] {{
+        Write-Host "Recovered abandoned host validation lock: $MutexName"
+        return $true
+    }}
+}}
+
+$Repo = '{ps_literal(effective_repo_path)}'
+$RepoDrive = Split-Path -Path $Repo -Qualifier
+if (-not $RepoDrive) {{
+    $RepoDrive = 'C:'
+}}
+$env:GIT_LFS_SKIP_SMUDGE = '1'
+$CiRoot = Join-Path $RepoDrive 'pulp-ci'
+$Branch = '{ps_literal(job['branch'])}'
+$Sha = '{ps_literal(job['sha'])}'
+$BundleName = '{ps_literal(bundle_name)}'
+$BundleRef = '{ps_literal(bundle_ref)}'
+$Bundle = if ($BundleName) {{ Join-Path $HOME $BundleName }} else {{ '' }}
+$BundleGit = $Bundle.Replace('\\', '/')
+$ExcludeRegex = '{ps_literal(exclude_tests)}'
+$Generator = '{ps_literal(cmake_generator)}'
+$Platform = '{ps_literal(resolved_platform)}'
+$GeneratorInstance = '{ps_literal(resolved_generator_instance)}'
+$ValidationMode = '{ps_literal(job.get("validation", "full"))}'
+$PreparedRoot = Join-Path $CiRoot 'prepared\\{ps_literal(target_name)}'
+$PreparedRoot = Join-Path $PreparedRoot $ValidationMode
+$PreparedState = Join-Path $PreparedRoot 'state.json'
+$Src = Join-Path $PreparedRoot 'src'
+$Build = Join-Path $PreparedRoot 'build'
+$Install = Join-Path $PreparedRoot 'install'
+$Smoke = Join-Path $PreparedRoot 'smoke'
+$ReusePrepared = {'$true' if should_reuse_prepared_state(job) else '$false'}
+$UsePrepared = $false
+$MutexName = 'Global\\PulpLocalCIValidate'
+$Mutex = New-Object System.Threading.Mutex($false, $MutexName)
+$LockAcquired = $false
+$ValidatorStartedAt = (Get-Process -Id $PID).StartTime.ToUniversalTime().ToString('o')
+
+try {{
+    Write-Host "__PULP_VALIDATOR_PID__:$PID"
+    Write-Host "__PULP_VALIDATOR_STARTED__:$ValidatorStartedAt"
+    Write-Host "__PULP_VALIDATION__:$ValidationMode"
+    if ($ValidationMode -eq 'smoke') {{
+        Write-Host "__PULP_TEST_POLICY__:skip"
+    }} else {{
+        Write-Host "__PULP_TEST_POLICY__:run"
+    }}
+    if (-not (Wait-HostMutex -Mutex $Mutex -Immediate $true)) {{
+        Write-Host "__PULP_WAIT__:host-lock"
+        Write-Host "__PULP_PHASE__:waiting-lock"
+        Write-Host "Waiting for host validation lock: $MutexName"
+        $LockAcquired = Wait-HostMutex -Mutex $Mutex -Immediate $false
+    }} else {{
+        $LockAcquired = $true
+    }}
+
+    Write-Host "__PULP_PHASE__:fetch"
+    New-Item -ItemType Directory -Force -Path $PreparedRoot | Out-Null
+    Set-Location $Repo
+    if (Test-Path $Bundle) {{
+        Write-Host "__PULP_PHASE__:bundle-sync"
+        try {{
+            Invoke-Native git @(
+                'fetch',
+                $BundleGit,
+                "$BundleRef`:refs/pulp-ci-bundles/{job['id']}"
+            )
+        }} finally {{
+            Remove-Item -Force -ErrorAction SilentlyContinue $Bundle
+        }}
+    }}
+    if (-not (Test-CommitRef $Sha)) {{
+        try {{
+            Invoke-Native git @('fetch', 'origin')
+        }} catch {{
+        }}
+    }}
+
+    if (-not (Test-CommitRef $Sha)) {{
+        try {{
+            Invoke-Native git @(
+                'fetch',
+                'origin',
+                "refs/heads/$Branch`:refs/remotes/origin/$Branch"
+            )
+        }} catch {{
+        }}
+    }}
+
+    if (-not (Test-CommitRef $Sha)) {{
+        throw '{ps_literal(remote_commit_error(target_name, host, job))}'
+    }}
+
+    if ($ReusePrepared -and (Test-PreparedStateMatches `
+        -StatePath $PreparedState `
+        -ExpectedSha $Sha `
+        -ExpectedValidation $ValidationMode `
+        -ExpectedGenerator $Generator `
+        -ExpectedPlatform $Platform `
+        -ExpectedGeneratorInstance $GeneratorInstance)) {{
+        $UsePrepared = $true
+        Write-Host "__PULP_PREPARED__:reused"
+    }} else {{
+        Write-Host "__PULP_PREPARED__:clean"
+        Remove-PreparedRoot $Repo $PreparedRoot
+        New-Item -ItemType Directory -Force -Path $PreparedRoot | Out-Null
+        Write-Host "__PULP_PHASE__:worktree"
+        Invoke-Native git @('worktree', 'add', '--force', '--detach', $Src, $Sha)
+    }}
+
+    try {{
+        Write-Host "__PULP_PHASE__:configure"
+        Write-Host "CMake platform: $Platform"
+        if ($GeneratorInstance) {{
+            Write-Host "CMake generator instance: $GeneratorInstance"
+        }}
+        $configureArgs = @('-S', $Src, '-B', $Build)
+        if ($Generator) {{
+            $configureArgs += @('-G', $Generator)
+        }}
+        if ($Platform) {{
+            $configureArgs += @('-A', $Platform)
+        }}
+        if ($GeneratorInstance) {{
+            $configureArgs += @("-DCMAKE_GENERATOR_INSTANCE=$GeneratorInstance")
+        }}
+        $configureArgs += @('-DCMAKE_BUILD_TYPE=Release')
+        if ($ValidationMode -eq 'smoke') {{
+            $configureArgs += @(
+                '-DPULP_BUILD_TESTS=OFF',
+                '-DPULP_BUILD_EXAMPLES=OFF',
+                '-DPULP_ENABLE_GPU=OFF'
+            )
+        }}
+        Invoke-Native cmake $configureArgs
+        Write-Host "__PULP_PHASE__:build"
+        Invoke-Native cmake @('--build', $Build, '--config', 'Release')
+        if ($ValidationMode -eq 'smoke') {{
+            Write-Host "__PULP_PHASE__:install"
+            Invoke-Native cmake @('--install', $Build, '--prefix', $Install, '--config', 'Release')
+            New-Item -ItemType Directory -Force -Path $Smoke | Out-Null
+            @"
+cmake_minimum_required(VERSION 3.24)
+project(PulpSDKSmoke LANGUAGES CXX)
+
+find_package(Pulp REQUIRED CONFIG)
+
+add_library(smoke INTERFACE)
+target_link_libraries(smoke INTERFACE Pulp::format Pulp::standalone)
+"@ | Set-Content -Path (Join-Path $Smoke 'CMakeLists.txt')
+            Write-Host "__PULP_PHASE__:smoke"
+            $smokeConfigureArgs = @('-S', $Smoke, '-B', (Join-Path $Smoke 'build'))
+            if ($Generator) {{
+                $smokeConfigureArgs += @('-G', $Generator)
+            }}
+            if ($Platform) {{
+                $smokeConfigureArgs += @('-A', $Platform)
+            }}
+            if ($GeneratorInstance) {{
+                $smokeConfigureArgs += @("-DCMAKE_GENERATOR_INSTANCE=$GeneratorInstance")
+            }}
+            $smokeConfigureArgs += @("-DCMAKE_PREFIX_PATH=$Install")
+            Invoke-Native cmake $smokeConfigureArgs
+            Write-PreparedState `
+                -StatePath $PreparedState `
+                -Sha $Sha `
+                -Validation $ValidationMode `
+                -Generator $Generator `
+                -Platform $Platform `
+                -GeneratorInstance $GeneratorInstance
+        }} else {{
+            Write-PreparedState `
+                -StatePath $PreparedState `
+                -Sha $Sha `
+                -Validation $ValidationMode `
+                -Generator $Generator `
+                -Platform $Platform `
+                -GeneratorInstance $GeneratorInstance
+            Write-Host "__PULP_PHASE__:test"
+            $ctestArgs = @('--test-dir', $Build, '--output-on-failure', '-C', 'Release')
+            if ($ExcludeRegex) {{
+                $ctestArgs += @('--exclude-regex', $ExcludeRegex)
+            }}
+            Invoke-Native ctest $ctestArgs
+        }}
+    }} finally {{
+        Write-Host "__PULP_PHASE__:cleanup"
+        if (-not (Test-Path $PreparedState)) {{
+            Remove-PreparedRoot $Repo $PreparedRoot
+        }}
+    }}
+}} finally {{
+    if ($LockAcquired) {{
+        try {{
+            $Mutex.ReleaseMutex() | Out-Null
+        }} catch [System.ApplicationException] {{
+        }}
+    }}
+    $Mutex.Dispose()
+}}
+""".strip()
+    return ps_script, validation
 
 
 def validation_result_from_run(

--- a/tools/local-ci/local_ci.py
+++ b/tools/local-ci/local_ci.py
@@ -3282,6 +3282,34 @@ def ps_literal(value: str) -> str:
     return _windows_probe.ps_literal(value)
 
 
+def windows_validation_script(
+    target_name: str,
+    host: str,
+    effective_repo_path: str,
+    job: dict,
+    *,
+    bundle_name: str,
+    bundle_ref: str,
+    exclude_tests: str,
+    cmake_generator: str,
+    resolved_platform: str,
+    resolved_generator_instance: str,
+) -> tuple[str, str]:
+    return _execution.windows_validation_script(
+        target_name,
+        host,
+        effective_repo_path,
+        job,
+        bundle_name=bundle_name,
+        bundle_ref=bundle_ref,
+        exclude_tests=exclude_tests,
+        cmake_generator=cmake_generator,
+        resolved_platform=resolved_platform,
+        resolved_generator_instance=resolved_generator_instance,
+        ps_literal_fn=ps_literal,
+    )
+
+
 def validate_ci_branch_name(branch: str) -> str:
     return _queue_orchestrator.validate_ci_branch_name(branch)
 
@@ -3467,352 +3495,18 @@ def run_windows_ssh_validation(
         cmake_generator_instance,
     )
 
-    ps_script = f"""
-$ErrorActionPreference = 'Stop'
-
-function Invoke-Native {{
-    param([string]$File, [string[]]$Arguments)
-    & $File @Arguments
-    if ($LASTEXITCODE -ne 0) {{
-        throw "$File exited with code $LASTEXITCODE"
-    }}
-}}
-
-function Test-CommitRef {{
-    param([string]$Ref)
-    & git rev-parse --verify --quiet "$Ref`^{{commit}}" 1> $null 2> $null
-    return $LASTEXITCODE -eq 0
-}}
-
-function Remove-DirectoryTreeRobust {{
-    param([string]$Path)
-
-    if (-not (Test-Path $Path)) {{
-        return
-    }}
-    try {{
-        cmd.exe /d /c ('rmdir /s /q "{{0}}"' -f $Path) | Out-Null
-    }} catch {{
-    }}
-    if (Test-Path $Path) {{
-        try {{
-            $LongPath = if ($Path.StartsWith('\\\\?\\')) {{ $Path }} else {{ '\\\\?\\' + $Path }}
-            Remove-Item -LiteralPath $LongPath -Recurse -Force -ErrorAction Stop
-        }} catch {{
-        }}
-    }}
-    if (Test-Path $Path) {{
-        try {{
-            Remove-Item -Recurse -Force -ErrorAction Stop $Path
-        }} catch {{
-        }}
-    }}
-}}
-
-function Remove-WorktreeSafe {{
-    param([string]$RepoRoot, [string]$Path)
-    try {{
-        Invoke-Native git @('-C', $RepoRoot, 'worktree', 'remove', '--force', '--force', $Path)
-    }} catch {{
-    }}
-    Remove-DirectoryTreeRobust $Path
-    try {{
-        Invoke-Native git @('-C', $RepoRoot, 'worktree', 'prune', '--expire', 'now')
-    }} catch {{
-    }}
-}}
-
-function Remove-PreparedRoot {{
-    param([string]$RepoRoot, [string]$PreparedRoot)
-
-    $PreparedSrc = Join-Path $PreparedRoot 'src'
-    if (Test-Path $PreparedSrc) {{
-        Remove-WorktreeSafe $RepoRoot $PreparedSrc
-    }}
-    if (Test-Path $PreparedRoot) {{
-        Remove-DirectoryTreeRobust $PreparedRoot
-    }}
-}}
-
-function Test-PreparedStateMatches {{
-    param(
-        [string]$StatePath,
-        [string]$ExpectedSha,
-        [string]$ExpectedValidation,
-        [string]$ExpectedGenerator,
-        [string]$ExpectedPlatform,
-        [string]$ExpectedGeneratorInstance
+    ps_script, validation = windows_validation_script(
+        target_name,
+        host,
+        effective_repo_path,
+        job,
+        bundle_name=bundle_name,
+        bundle_ref=bundle_ref,
+        exclude_tests=exclude_tests,
+        cmake_generator=cmake_generator,
+        resolved_platform=resolved_platform,
+        resolved_generator_instance=resolved_generator_instance,
     )
-
-    if (-not (Test-Path $StatePath)) {{
-        return $false
-    }}
-
-    try {{
-        $state = Get-Content $StatePath -Raw | ConvertFrom-Json
-    }} catch {{
-        return $false
-    }}
-
-    if (
-        $state.sha -ne $ExpectedSha -or
-        $state.validation -ne $ExpectedValidation -or
-        $state.generator -ne $ExpectedGenerator -or
-        $state.platform -ne $ExpectedPlatform -or
-        $state.generator_instance -ne $ExpectedGeneratorInstance
-    ) {{
-        return $false
-    }}
-
-    $PreparedRoot = Split-Path $StatePath -Parent
-    $PreparedSrc = Join-Path $PreparedRoot 'src'
-    $PreparedBuild = Join-Path $PreparedRoot 'build'
-    $PreparedInstall = Join-Path $PreparedRoot 'install'
-    if (-not (Test-Path $PreparedSrc) -or -not (Test-Path $PreparedBuild) -or -not (Test-Path $PreparedInstall)) {{
-        return $false
-    }}
-
-    $preparedHead = ((& git -C $PreparedSrc rev-parse HEAD 2>$null) | Select-Object -Last 1).Trim()
-    if ($LASTEXITCODE -ne 0) {{
-        return $false
-    }}
-    return $preparedHead -eq $ExpectedSha
-}}
-
-function Write-PreparedState {{
-    param(
-        [string]$StatePath,
-        [string]$Sha,
-        [string]$Validation,
-        [string]$Generator,
-        [string]$Platform,
-        [string]$GeneratorInstance
-    )
-
-    $payload = @{{
-        sha = $Sha
-        validation = $Validation
-        generator = $Generator
-        platform = $Platform
-        generator_instance = $GeneratorInstance
-        updated_at = (Get-Date).ToString('o')
-    }}
-    $payload | ConvertTo-Json | Set-Content -Path $StatePath
-}}
-
-function Wait-HostMutex {{
-    param(
-        [System.Threading.Mutex]$Mutex,
-        [bool]$Immediate
-    )
-
-    try {{
-        if ($Immediate) {{
-            return $Mutex.WaitOne(0)
-        }}
-        $null = $Mutex.WaitOne()
-        return $true
-    }} catch [System.Threading.AbandonedMutexException] {{
-        Write-Host "Recovered abandoned host validation lock: $MutexName"
-        return $true
-    }}
-}}
-
-$Repo = '{ps_literal(effective_repo_path)}'
-$RepoDrive = Split-Path -Path $Repo -Qualifier
-if (-not $RepoDrive) {{
-    $RepoDrive = 'C:'
-}}
-$env:GIT_LFS_SKIP_SMUDGE = '1'
-$CiRoot = Join-Path $RepoDrive 'pulp-ci'
-$Branch = '{ps_literal(job['branch'])}'
-$Sha = '{ps_literal(job['sha'])}'
-$BundleName = '{ps_literal(bundle_name)}'
-$BundleRef = '{ps_literal(bundle_ref)}'
-$Bundle = if ($BundleName) {{ Join-Path $HOME $BundleName }} else {{ '' }}
-$BundleGit = $Bundle.Replace('\\', '/')
-$ExcludeRegex = '{ps_literal(exclude_tests)}'
-$Generator = '{ps_literal(cmake_generator)}'
-$Platform = '{ps_literal(resolved_platform)}'
-$GeneratorInstance = '{ps_literal(resolved_generator_instance)}'
-$ValidationMode = '{ps_literal(job.get("validation", "full"))}'
-$PreparedRoot = Join-Path $CiRoot 'prepared\\{ps_literal(target_name)}'
-$PreparedRoot = Join-Path $PreparedRoot $ValidationMode
-$PreparedState = Join-Path $PreparedRoot 'state.json'
-$Src = Join-Path $PreparedRoot 'src'
-$Build = Join-Path $PreparedRoot 'build'
-$Install = Join-Path $PreparedRoot 'install'
-$Smoke = Join-Path $PreparedRoot 'smoke'
-$ReusePrepared = {'$true' if should_reuse_prepared_state(job) else '$false'}
-$UsePrepared = $false
-$MutexName = 'Global\\PulpLocalCIValidate'
-$Mutex = New-Object System.Threading.Mutex($false, $MutexName)
-$LockAcquired = $false
-$ValidatorStartedAt = (Get-Process -Id $PID).StartTime.ToUniversalTime().ToString('o')
-
-try {{
-    Write-Host "__PULP_VALIDATOR_PID__:$PID"
-    Write-Host "__PULP_VALIDATOR_STARTED__:$ValidatorStartedAt"
-    Write-Host "__PULP_VALIDATION__:$ValidationMode"
-    if ($ValidationMode -eq 'smoke') {{
-        Write-Host "__PULP_TEST_POLICY__:skip"
-    }} else {{
-        Write-Host "__PULP_TEST_POLICY__:run"
-    }}
-    if (-not (Wait-HostMutex -Mutex $Mutex -Immediate $true)) {{
-        Write-Host "__PULP_WAIT__:host-lock"
-        Write-Host "__PULP_PHASE__:waiting-lock"
-        Write-Host "Waiting for host validation lock: $MutexName"
-        $LockAcquired = Wait-HostMutex -Mutex $Mutex -Immediate $false
-    }} else {{
-        $LockAcquired = $true
-    }}
-
-    Write-Host "__PULP_PHASE__:fetch"
-    New-Item -ItemType Directory -Force -Path $PreparedRoot | Out-Null
-    Set-Location $Repo
-    if (Test-Path $Bundle) {{
-        Write-Host "__PULP_PHASE__:bundle-sync"
-        try {{
-            Invoke-Native git @(
-                'fetch',
-                $BundleGit,
-                "$BundleRef`:refs/pulp-ci-bundles/{job['id']}"
-            )
-        }} finally {{
-            Remove-Item -Force -ErrorAction SilentlyContinue $Bundle
-        }}
-    }}
-    if (-not (Test-CommitRef $Sha)) {{
-        try {{
-            Invoke-Native git @('fetch', 'origin')
-        }} catch {{
-        }}
-    }}
-
-    if (-not (Test-CommitRef $Sha)) {{
-        try {{
-            Invoke-Native git @(
-                'fetch',
-                'origin',
-                "refs/heads/$Branch`:refs/remotes/origin/$Branch"
-            )
-        }} catch {{
-        }}
-    }}
-
-    if (-not (Test-CommitRef $Sha)) {{
-        throw '{ps_literal(remote_commit_error(target_name, host, job))}'
-    }}
-
-    if ($ReusePrepared -and (Test-PreparedStateMatches `
-        -StatePath $PreparedState `
-        -ExpectedSha $Sha `
-        -ExpectedValidation $ValidationMode `
-        -ExpectedGenerator $Generator `
-        -ExpectedPlatform $Platform `
-        -ExpectedGeneratorInstance $GeneratorInstance)) {{
-        $UsePrepared = $true
-        Write-Host "__PULP_PREPARED__:reused"
-    }} else {{
-        Write-Host "__PULP_PREPARED__:clean"
-        Remove-PreparedRoot $Repo $PreparedRoot
-        New-Item -ItemType Directory -Force -Path $PreparedRoot | Out-Null
-        Write-Host "__PULP_PHASE__:worktree"
-        Invoke-Native git @('worktree', 'add', '--force', '--detach', $Src, $Sha)
-    }}
-
-    try {{
-        Write-Host "__PULP_PHASE__:configure"
-        Write-Host "CMake platform: $Platform"
-        if ($GeneratorInstance) {{
-            Write-Host "CMake generator instance: $GeneratorInstance"
-        }}
-        $configureArgs = @('-S', $Src, '-B', $Build)
-        if ($Generator) {{
-            $configureArgs += @('-G', $Generator)
-        }}
-        if ($Platform) {{
-            $configureArgs += @('-A', $Platform)
-        }}
-        if ($GeneratorInstance) {{
-            $configureArgs += @("-DCMAKE_GENERATOR_INSTANCE=$GeneratorInstance")
-        }}
-        $configureArgs += @('-DCMAKE_BUILD_TYPE=Release')
-        if ($ValidationMode -eq 'smoke') {{
-            $configureArgs += @(
-                '-DPULP_BUILD_TESTS=OFF',
-                '-DPULP_BUILD_EXAMPLES=OFF',
-                '-DPULP_ENABLE_GPU=OFF'
-            )
-        }}
-        Invoke-Native cmake $configureArgs
-        Write-Host "__PULP_PHASE__:build"
-        Invoke-Native cmake @('--build', $Build, '--config', 'Release')
-        if ($ValidationMode -eq 'smoke') {{
-            Write-Host "__PULP_PHASE__:install"
-            Invoke-Native cmake @('--install', $Build, '--prefix', $Install, '--config', 'Release')
-            New-Item -ItemType Directory -Force -Path $Smoke | Out-Null
-            @"
-cmake_minimum_required(VERSION 3.24)
-project(PulpSDKSmoke LANGUAGES CXX)
-
-find_package(Pulp REQUIRED CONFIG)
-
-add_library(smoke INTERFACE)
-target_link_libraries(smoke INTERFACE Pulp::format Pulp::standalone)
-"@ | Set-Content -Path (Join-Path $Smoke 'CMakeLists.txt')
-            Write-Host "__PULP_PHASE__:smoke"
-            $smokeConfigureArgs = @('-S', $Smoke, '-B', (Join-Path $Smoke 'build'))
-            if ($Generator) {{
-                $smokeConfigureArgs += @('-G', $Generator)
-            }}
-            if ($Platform) {{
-                $smokeConfigureArgs += @('-A', $Platform)
-            }}
-            if ($GeneratorInstance) {{
-                $smokeConfigureArgs += @("-DCMAKE_GENERATOR_INSTANCE=$GeneratorInstance")
-            }}
-            $smokeConfigureArgs += @("-DCMAKE_PREFIX_PATH=$Install")
-            Invoke-Native cmake $smokeConfigureArgs
-            Write-PreparedState `
-                -StatePath $PreparedState `
-                -Sha $Sha `
-                -Validation $ValidationMode `
-                -Generator $Generator `
-                -Platform $Platform `
-                -GeneratorInstance $GeneratorInstance
-        }} else {{
-            Write-PreparedState `
-                -StatePath $PreparedState `
-                -Sha $Sha `
-                -Validation $ValidationMode `
-                -Generator $Generator `
-                -Platform $Platform `
-                -GeneratorInstance $GeneratorInstance
-            Write-Host "__PULP_PHASE__:test"
-            $ctestArgs = @('--test-dir', $Build, '--output-on-failure', '-C', 'Release')
-            if ($ExcludeRegex) {{
-                $ctestArgs += @('--exclude-regex', $ExcludeRegex)
-            }}
-            Invoke-Native ctest $ctestArgs
-        }}
-    }} finally {{
-        Write-Host "__PULP_PHASE__:cleanup"
-        if (-not (Test-Path $PreparedState)) {{
-            Remove-PreparedRoot $Repo $PreparedRoot
-        }}
-    }}
-}} finally {{
-    if ($LockAcquired) {{
-        try {{
-            $Mutex.ReleaseMutex() | Out-Null
-        }} catch [System.ApplicationException] {{
-        }}
-    }}
-    $Mutex.Dispose()
-}}
-""".strip()
 
     cmd = windows_ssh_powershell_command(host)
 
@@ -3823,7 +3517,6 @@ target_link_libraries(smoke INTERFACE Pulp::format Pulp::standalone)
         log_path=log_path,
         report_progress=report_progress,
     )
-    validation = job.get("validation", "full")
     return validation_result_from_run(
         target_name,
         run,

--- a/tools/local-ci/test_execution.py
+++ b/tools/local-ci/test_execution.py
@@ -140,6 +140,78 @@ class ExecutionTests(unittest.TestCase):
         self.assertIn("PULP_EXPECT_SMOKE=1", remote_cmd)
         self.assertIn("--smoke --no-tests", remote_cmd)
 
+    def test_windows_validation_script_builds_full_script(self) -> None:
+        job = {
+            "id": "job801",
+            "branch": "feature/windows",
+            "sha": "e" * 40,
+            "targets": ["windows"],
+            "validation": "full",
+        }
+
+        script, validation = self.mod.windows_validation_script(
+            "windows",
+            "win.example.com",
+            r"C:\Pulp's Repo",
+            job,
+            bundle_name="pulp-ci-job801.bundle",
+            bundle_ref="refs/pulp-ci-bundles/job801",
+            exclude_tests="slow windows",
+            cmake_generator="Visual Studio 17 2022",
+            resolved_platform="ARM64",
+            resolved_generator_instance=r"C:\VS\2022",
+            ps_literal_fn=lambda value: value.replace("'", "''"),
+        )
+
+        self.assertEqual(validation, "full")
+        self.assertIn(r"$Repo = 'C:\Pulp''s Repo'", script)
+        self.assertIn("$Branch = 'feature/windows'", script)
+        self.assertIn("$Sha = '" + "e" * 40 + "'", script)
+        self.assertIn("$BundleName = 'pulp-ci-job801.bundle'", script)
+        self.assertIn("$BundleRef`:refs/pulp-ci-bundles/job801", script)
+        self.assertIn("$ExcludeRegex = 'slow windows'", script)
+        self.assertIn("$Generator = 'Visual Studio 17 2022'", script)
+        self.assertIn("$Platform = 'ARM64'", script)
+        self.assertIn(r"$GeneratorInstance = 'C:\VS\2022'", script)
+        self.assertIn("$ValidationMode = 'full'", script)
+        self.assertIn("$PreparedRoot = Join-Path $CiRoot 'prepared\\windows'", script)
+        self.assertIn("$ReusePrepared = $true", script)
+        self.assertIn('Write-Host "__PULP_TEST_POLICY__:run"', script)
+        self.assertIn("windows cannot validate eeeeeeeeeeee on win.example.com", script)
+
+    def test_windows_validation_script_builds_smoke_script(self) -> None:
+        job = {
+            "id": "job802",
+            "branch": "feature/smoke",
+            "sha": "f" * 40,
+            "targets": ["mac", "windows"],
+            "validation": "smoke",
+        }
+
+        script, validation = self.mod.windows_validation_script(
+            "windows",
+            "win.example.com",
+            r"C:\Pulp",
+            job,
+            bundle_name="pulp-ci-job802.bundle",
+            bundle_ref="refs/pulp-ci-bundles/job802",
+            exclude_tests="",
+            cmake_generator="Visual Studio 17 2022",
+            resolved_platform="",
+            resolved_generator_instance="",
+            ps_literal_fn=lambda value: value.replace("'", "''"),
+        )
+
+        self.assertEqual(validation, "smoke")
+        self.assertIn("$ValidationMode = 'smoke'", script)
+        self.assertIn("$ReusePrepared = $false", script)
+        self.assertIn('Write-Host "__PULP_TEST_POLICY__:skip"', script)
+        self.assertIn("-DPULP_BUILD_TESTS=OFF", script)
+        self.assertIn("-DPULP_BUILD_EXAMPLES=OFF", script)
+        self.assertIn("-DPULP_ENABLE_GPU=OFF", script)
+        self.assertIn("Invoke-Native cmake @('--install', $Build, '--prefix', $Install, '--config', 'Release')", script)
+        self.assertIn('Write-Host "__PULP_PHASE__:smoke"', script)
+
     def test_validation_result_from_run_reports_timeout(self) -> None:
         result = self.mod.validation_result_from_run(
             "mac",


### PR DESCRIPTION
## Summary
- move Windows validation PowerShell script construction into execution.py
- keep run_windows_ssh_validation responsible for bundle upload, repo checkout/probing, command execution, and result assembly
- add focused no-network coverage for full and smoke Windows script shapes
- update the local-ci module map ownership note

## Tests
- python3 -m py_compile tools/local-ci/local_ci.py tools/local-ci/execution.py tools/local-ci/test_execution.py
- python3 tools/local-ci/test_execution.py
- python3 tools/local-ci/test_local_ci.py -k windows_validation
- python3 -m unittest discover -s tools/local-ci -p 'test_*.py'
- PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat
- python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce
- python3 tools/import-validation/check-source-contracts.py --strict
- python3 tools/import-validation/test_source_contracts.py
- git diff --check HEAD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted Windows validation PowerShell script construction into `tools/local-ci/execution.py` to make it reusable and easier to test. `tools/local-ci/local_ci.py` now focuses on orchestration with no behavior changes.

- **Refactors**
  - Added `windows_validation_script(...)` in `execution.py`; `local_ci.py` delegates script building to it.
  - Kept `run_windows_ssh_validation` responsible for bundle upload, repo checkout/probing, command execution, and result assembly.
  - Added focused, no-network tests for full and smoke script shapes in `test_execution.py`.
  - Updated `MODULE_MAP.md` to reflect the new responsibility split.

<sup>Written for commit 44d012115c316a19cb72f3cdeceaf25413c521c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

