### PR TITLE
refactor(local-ci): extract unreachable target result helper

### DIFF
--- a/tools/local-ci/MODULE_MAP.md
+++ b/tools/local-ci/MODULE_MAP.md
@@ -32,7 +32,7 @@ and the matching contract tests in the same change.
 | `macos_desktop.py` | macOS app bundle detection, Swift window-probe wrappers, window wait/capture/activation/click helpers, app quit, and process termination. | Desktop action orchestration, artifact manifest writing, source preparation, or queue orchestration. |
 | `windows_target.py` | Windows desktop target contracts, path safety, session-agent request payloads, and probe result formatting/readiness helpers. | SSH/PowerShell execution, desktop action execution, queue orchestration, or artifact layout. |
 | `windows_probe.py` | Windows SSH/PowerShell command execution helpers, remote file transfer/read/remove helpers, repo/session/tooling probes, remote tool installation, session-agent bootstrap/start, and CMake generator probing. | Windows target contract formatting, desktop action orchestration, queue orchestration, or artifact layout. |
-| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, optional command log writing, local/POSIX validation command construction, Windows validation script construction, and target-neutral validation helper policy. | Windows checkout/probe execution, queue mutation, or desktop automation adapters. |
+| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, optional command log writing, local/POSIX validation command construction, Windows validation script construction, unreachable-target result construction, and target-neutral validation helper policy. | Windows checkout/probe execution, queue mutation, or desktop automation adapters. |
 
 ## Remaining `local_ci.py` Clusters
 

--- a/tools/local-ci/execution.py
+++ b/tools/local-ci/execution.py
@@ -586,6 +586,17 @@ def validation_error_result(
     }
 
 
+def unreachable_target_result(target_name: str, detail: str = "Host unreachable") -> dict:
+    return {
+        "target": target_name,
+        "status": "unreachable",
+        "exit_code": -1,
+        "duration_secs": 0,
+        "stdout_tail": "",
+        "stderr_tail": detail,
+    }
+
+
 def run_logged_command(
     cmd: list[str],
     *,

--- a/tools/local-ci/local_ci.py
+++ b/tools/local-ci/local_ci.py
@@ -3182,6 +3182,10 @@ def validation_error_result(
     )
 
 
+def unreachable_target_result(target_name: str, detail: str = "Host unreachable") -> dict:
+    return _execution.unreachable_target_result(target_name, detail)
+
+
 def run_logged_command(
     cmd: list[str],
     *,
@@ -3595,19 +3599,7 @@ def _build_target_tasks(job: dict, config: dict, progress_factory=None) -> list[
                 )
             )
         else:
-            tasks.append(
-                (
-                    "ubuntu",
-                    lambda: {
-                        "target": "ubuntu",
-                        "status": "unreachable",
-                        "exit_code": -1,
-                        "duration_secs": 0,
-                        "stdout_tail": "",
-                        "stderr_tail": "Host unreachable",
-                    },
-                )
-            )
+            tasks.append(("ubuntu", lambda: unreachable_target_result("ubuntu")))
 
     win_cfg = targets.get("windows")
     if "windows" in requested and win_cfg and win_cfg.get("enabled", True):
@@ -3636,19 +3628,7 @@ def _build_target_tasks(job: dict, config: dict, progress_factory=None) -> list[
                 )
             )
         else:
-            tasks.append(
-                (
-                    "windows",
-                    lambda: {
-                        "target": "windows",
-                        "status": "unreachable",
-                        "exit_code": -1,
-                        "duration_secs": 0,
-                        "stdout_tail": "",
-                        "stderr_tail": "Host unreachable",
-                    },
-                )
-            )
+            tasks.append(("windows", lambda: unreachable_target_result("windows")))
 
     return tasks
 

--- a/tools/local-ci/test_execution.py
+++ b/tools/local-ci/test_execution.py
@@ -62,6 +62,23 @@ class ExecutionTests(unittest.TestCase):
         self.assertTrue(self.mod.should_reuse_prepared_state({"targets": ["mac"]}))
         self.assertFalse(self.mod.should_reuse_prepared_state({"targets": ["mac", "ubuntu"]}))
 
+    def test_unreachable_target_result_matches_queue_contract(self) -> None:
+        self.assertEqual(
+            self.mod.unreachable_target_result("ubuntu"),
+            {
+                "target": "ubuntu",
+                "status": "unreachable",
+                "exit_code": -1,
+                "duration_secs": 0,
+                "stdout_tail": "",
+                "stderr_tail": "Host unreachable",
+            },
+        )
+        self.assertEqual(
+            self.mod.unreachable_target_result("windows", "VM unavailable")["stderr_tail"],
+            "VM unavailable",
+        )
+
     def test_local_validation_command_builds_full_and_smoke_commands(self) -> None:
         full_cmd, full_validation = self.mod.local_validation_command(
             {"sha": "a" * 40, "targets": ["mac"], "validation": "full"},


### PR DESCRIPTION
## Summary
- move duplicated unreachable target result payload construction into `execution.py`
- route `_build_target_tasks` unreachable ubuntu/windows branches through the shared helper
- update the local-ci module map and add direct helper coverage

## Validation
- `python3 -m py_compile tools/local-ci/local_ci.py tools/local-ci/execution.py tools/local-ci/test_execution.py`
- `python3 tools/local-ci/test_execution.py`
- `python3 tools/local-ci/test_local_ci.py -k build_target_tasks`
- `python3 -m unittest discover -s tools/local-ci -p 'test_*.py'`\n- `PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`\n- `python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat`\n- `python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce`\n- `python3 tools/import-validation/check-source-contracts.py --strict`\n- `python3 tools/import-validation/test_source_contracts.py`\n- `git diff --check HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted unreachable-target result construction into a shared helper in `tools/local-ci/execution.py`. This removes duplication and keeps queue payloads consistent without changing behavior.

- **Refactors**
  - Added `unreachable_target_result(target_name, detail="Host unreachable")` in `execution.py`.
  - Routed Ubuntu/Windows unreachable branches in `_build_target_tasks` to the helper.
  - Updated `MODULE_MAP.md` to include unreachable-target result construction.
  - Added tests in `test_execution.py` to verify queue contract and custom detail support.

<sup>Written for commit 113cf22c18938be848ec191fdba165ded9f90e9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

