### PR TITLE
refactor(local-ci): extract job result helpers

### DIFF
--- a/tools/local-ci/MODULE_MAP.md
+++ b/tools/local-ci/MODULE_MAP.md
@@ -32,7 +32,7 @@ and the matching contract tests in the same change.
 | `macos_desktop.py` | macOS app bundle detection, Swift window-probe wrappers, window wait/capture/activation/click helpers, app quit, and process termination. | Desktop action orchestration, artifact manifest writing, source preparation, or queue orchestration. |
 | `windows_target.py` | Windows desktop target contracts, path safety, session-agent request payloads, and probe result formatting/readiness helpers. | SSH/PowerShell execution, desktop action execution, queue orchestration, or artifact layout. |
 | `windows_probe.py` | Windows SSH/PowerShell command execution helpers, remote file transfer/read/remove helpers, repo/session/tooling probes, remote tool installation, session-agent bootstrap/start, and CMake generator probing. | Windows target contract formatting, desktop action orchestration, queue orchestration, or artifact layout. |
-| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, optional command log writing, local/POSIX validation command construction, Windows validation script construction, unreachable-target result construction, and target-neutral validation helper policy. | Windows checkout/probe execution, queue mutation, or desktop automation adapters. |
+| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, optional command log writing, local/POSIX validation command construction, Windows validation script construction, job/target result construction, and target-neutral validation helper policy. | Windows checkout/probe execution, queue mutation, or desktop automation adapters. |
 
 ## Remaining `local_ci.py` Clusters
 

--- a/tools/local-ci/execution.py
+++ b/tools/local-ci/execution.py
@@ -597,6 +597,42 @@ def unreachable_target_result(target_name: str, detail: str = "Host unreachable"
     }
 
 
+def target_exception_result(target_name: str, exc: Exception) -> dict:
+    return {
+        "target": target_name,
+        "status": "error",
+        "exit_code": -1,
+        "duration_secs": 0,
+        "stdout_tail": "",
+        "stderr_tail": str(exc),
+    }
+
+
+def completed_job_result(
+    job: dict,
+    results: list[dict],
+    *,
+    completed_at: str,
+    provenance: dict,
+) -> dict:
+    payload = {
+        "job_id": job["id"],
+        "branch": job["branch"],
+        "sha": job["sha"],
+        "priority": job["priority"],
+        "submission": job.get("submission"),
+        "provenance": provenance,
+        "targets": job.get("targets", []),
+        "queued_at": job.get("queued_at", ""),
+        "completed_at": completed_at,
+        "results": results,
+        "overall": "pass" if all(result["status"] == "pass" for result in results) else "fail",
+    }
+    if results:
+        payload["validation"] = job.get("validation", "full")
+    return payload
+
+
 def run_logged_command(
     cmd: list[str],
     *,

--- a/tools/local-ci/local_ci.py
+++ b/tools/local-ci/local_ci.py
@@ -3186,6 +3186,19 @@ def unreachable_target_result(target_name: str, detail: str = "Host unreachable"
     return _execution.unreachable_target_result(target_name, detail)
 
 
+def target_exception_result(target_name: str, exc: Exception) -> dict:
+    return _execution.target_exception_result(target_name, exc)
+
+
+def completed_job_result(job: dict, results: list[dict]) -> dict:
+    return _execution.completed_job_result(
+        job,
+        results,
+        completed_at=now_iso(),
+        provenance=normalize_provenance(job.get("provenance")),
+    )
+
+
 def run_logged_command(
     cmd: list[str],
     *,
@@ -3665,19 +3678,7 @@ def process_job(job: dict, config: dict) -> dict:
 
     tasks = _build_target_tasks(job, config, progress_factory=progress_factory)
     if not tasks:
-        return {
-            "job_id": job["id"],
-            "branch": job["branch"],
-            "sha": job["sha"],
-            "priority": job["priority"],
-            "submission": job.get("submission"),
-            "provenance": normalize_provenance(job.get("provenance")),
-            "targets": job.get("targets", []),
-            "queued_at": job.get("queued_at", ""),
-            "completed_at": now_iso(),
-            "results": [],
-            "overall": "pass",
-        }
+        return completed_job_result(job, [])
 
     for name, _fn in tasks:
         target_states[name] = {
@@ -3696,14 +3697,7 @@ def process_job(job: dict, config: dict) -> dict:
             try:
                 result = future.result()
             except Exception as exc:
-                result = {
-                    "target": name,
-                    "status": "error",
-                    "exit_code": -1,
-                    "duration_secs": 0,
-                    "stdout_tail": "",
-                    "stderr_tail": str(exc),
-                }
+                result = target_exception_result(name, exc)
 
             results.append(result)
             target_states[name] = {
@@ -3722,20 +3716,7 @@ def process_job(job: dict, config: dict) -> dict:
             flush_target_states()
 
     results.sort(key=lambda item: item["target"])
-    return {
-        "job_id": job["id"],
-        "branch": job["branch"],
-        "sha": job["sha"],
-        "priority": job["priority"],
-        "validation": job.get("validation", "full"),
-        "submission": job.get("submission"),
-        "provenance": normalize_provenance(job.get("provenance")),
-        "targets": job.get("targets", []),
-        "queued_at": job.get("queued_at", ""),
-        "completed_at": now_iso(),
-        "results": results,
-        "overall": "pass" if all(result["status"] == "pass" for result in results) else "fail",
-    }
+    return completed_job_result(job, results)
 
 
 def save_result(result: dict) -> Path:

--- a/tools/local-ci/test_execution.py
+++ b/tools/local-ci/test_execution.py
@@ -79,6 +79,74 @@ class ExecutionTests(unittest.TestCase):
             "VM unavailable",
         )
 
+    def test_target_exception_result_matches_queue_contract(self) -> None:
+        result = self.mod.target_exception_result("windows", RuntimeError("boom"))
+
+        self.assertEqual(
+            result,
+            {
+                "target": "windows",
+                "status": "error",
+                "exit_code": -1,
+                "duration_secs": 0,
+                "stdout_tail": "",
+                "stderr_tail": "boom",
+            },
+        )
+
+    def test_completed_job_result_preserves_empty_job_contract(self) -> None:
+        job = {
+            "id": "job-empty",
+            "branch": "feature/empty",
+            "sha": "1" * 40,
+            "priority": "low",
+            "targets": [],
+            "queued_at": "2026-04-01T00:00:00+00:00",
+            "validation": "smoke",
+            "submission": {"target_hosts": {}},
+        }
+
+        result = self.mod.completed_job_result(
+            job,
+            [],
+            completed_at="2026-04-01T00:01:00+00:00",
+            provenance={"kind": "direct"},
+        )
+
+        self.assertEqual(result["job_id"], "job-empty")
+        self.assertEqual(result["results"], [])
+        self.assertEqual(result["overall"], "pass")
+        self.assertNotIn("validation", result)
+        self.assertEqual(result["submission"], {"target_hosts": {}})
+        self.assertEqual(result["provenance"], {"kind": "direct"})
+
+    def test_completed_job_result_summarizes_target_results(self) -> None:
+        job = {
+            "id": "job-results",
+            "branch": "feature/results",
+            "sha": "2" * 40,
+            "priority": "normal",
+            "targets": ["mac", "windows"],
+            "validation": "smoke",
+        }
+
+        passing = self.mod.completed_job_result(
+            job,
+            [{"target": "mac", "status": "pass"}, {"target": "windows", "status": "pass"}],
+            completed_at="2026-04-01T00:02:00+00:00",
+            provenance={},
+        )
+        failing = self.mod.completed_job_result(
+            job,
+            [{"target": "mac", "status": "pass"}, {"target": "windows", "status": "fail"}],
+            completed_at="2026-04-01T00:03:00+00:00",
+            provenance={},
+        )
+
+        self.assertEqual(passing["validation"], "smoke")
+        self.assertEqual(passing["overall"], "pass")
+        self.assertEqual(failing["overall"], "fail")
+
     def test_local_validation_command_builds_full_and_smoke_commands(self) -> None:
         full_cmd, full_validation = self.mod.local_validation_command(
             {"sha": "a" * 40, "targets": ["mac"], "validation": "full"},


### PR DESCRIPTION
## Summary
- move target exception and completed job result payload construction into `execution.py`
- delegate `process_job` empty-job, exception, and completed-result assembly through shared helpers
- update the local-ci module map and add direct helper coverage

## Validation
- `python3 -m py_compile tools/local-ci/local_ci.py tools/local-ci/execution.py tools/local-ci/test_execution.py`
- `python3 tools/local-ci/test_execution.py`
- `python3 tools/local-ci/test_local_ci.py -k process_job`
- `python3 -m unittest discover -s tools/local-ci -p 'test_*.py'`\n- `PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`\n- `python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat`\n- `python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce`\n- `python3 tools/import-validation/check-source-contracts.py --strict`\n- `python3 tools/import-validation/test_source_contracts.py`\n- `git diff --check HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted job and target result construction into `execution.py` and updated local CI to use shared helpers. Centralizes payload logic with tests; behavior is unchanged.

- **Refactors**
  - Added `target_exception_result` and `completed_job_result` in `execution.py` and updated module map.
  - `local_ci.report()` now delegates empty-job, per-target exception, and final payload assembly to these helpers.
  - Preserves queue contract: omits `validation` for empty jobs; computes `overall` from target statuses.
  - Added unit tests for the new helpers and result summaries.

<sup>Written for commit c04f2fedc2bab983c39d38c072f458d7491aa162. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

