### PR TITLE
refactor(local-ci): extract target result ordering helper

### DIFF
--- a/tools/local-ci/MODULE_MAP.md
+++ b/tools/local-ci/MODULE_MAP.md
@@ -32,7 +32,7 @@ and the matching contract tests in the same change.
 | `macos_desktop.py` | macOS app bundle detection, Swift window-probe wrappers, window wait/capture/activation/click helpers, app quit, and process termination. | Desktop action orchestration, artifact manifest writing, source preparation, or queue orchestration. |
 | `windows_target.py` | Windows desktop target contracts, path safety, session-agent request payloads, and probe result formatting/readiness helpers. | SSH/PowerShell execution, desktop action execution, queue orchestration, or artifact layout. |
 | `windows_probe.py` | Windows SSH/PowerShell command execution helpers, remote file transfer/read/remove helpers, repo/session/tooling probes, remote tool installation, session-agent bootstrap/start, and CMake generator probing. | Windows target contract formatting, desktop action orchestration, queue orchestration, or artifact layout. |
-| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, optional command log writing, local/POSIX validation command construction, Windows validation script construction, job/target result construction, and target-neutral validation helper policy. | Windows checkout/probe execution, queue mutation, or desktop automation adapters. |
+| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, optional command log writing, local/POSIX validation command construction, Windows validation script construction, job/target result construction and ordering, and target-neutral validation helper policy. | Windows checkout/probe execution, queue mutation, or desktop automation adapters. |
 
 ## Remaining `local_ci.py` Clusters
 

--- a/tools/local-ci/execution.py
+++ b/tools/local-ci/execution.py
@@ -633,6 +633,10 @@ def completed_job_result(
     return payload
 
 
+def sorted_target_results(results: list[dict]) -> list[dict]:
+    return sorted(results, key=lambda item: item["target"])
+
+
 def run_logged_command(
     cmd: list[str],
     *,

--- a/tools/local-ci/local_ci.py
+++ b/tools/local-ci/local_ci.py
@@ -3230,6 +3230,10 @@ def completed_job_result(job: dict, results: list[dict]) -> dict:
     )
 
 
+def sorted_target_results(results: list[dict]) -> list[dict]:
+    return _execution.sorted_target_results(results)
+
+
 def run_logged_command(
     cmd: list[str],
     *,
@@ -3729,8 +3733,7 @@ def process_job(job: dict, config: dict) -> dict:
             )
             flush_target_states()
 
-    results.sort(key=lambda item: item["target"])
-    return completed_job_result(job, results)
+    return completed_job_result(job, sorted_target_results(results))
 
 
 def save_result(result: dict) -> Path:

--- a/tools/local-ci/test_execution.py
+++ b/tools/local-ci/test_execution.py
@@ -147,6 +147,18 @@ class ExecutionTests(unittest.TestCase):
         self.assertEqual(passing["overall"], "pass")
         self.assertEqual(failing["overall"], "fail")
 
+    def test_sorted_target_results_orders_by_target(self) -> None:
+        results = [
+            {"target": "windows", "status": "pass"},
+            {"target": "mac", "status": "pass"},
+            {"target": "ubuntu", "status": "fail"},
+        ]
+
+        sorted_results = self.mod.sorted_target_results(results)
+
+        self.assertEqual([item["target"] for item in sorted_results], ["mac", "ubuntu", "windows"])
+        self.assertEqual([item["target"] for item in results], ["windows", "mac", "ubuntu"])
+
     def test_local_validation_command_builds_full_and_smoke_commands(self) -> None:
         full_cmd, full_validation = self.mod.local_validation_command(
             {"sha": "a" * 40, "targets": ["mac"], "validation": "full"},


### PR DESCRIPTION
## Summary
- move target result ordering into `execution.py`
- delegate `process_job` final result ordering through the helper
- update the local-ci module map and add direct execution coverage

## Validation
- `python3 -m py_compile tools/local-ci/local_ci.py tools/local-ci/execution.py tools/local-ci/test_execution.py`
- `python3 tools/local-ci/test_execution.py`
- `python3 tools/local-ci/test_local_ci.py -k process_job`
- `python3 -m unittest discover -s tools/local-ci -p 'test_*.py'`\n- `PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`\n- `python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat`\n- `python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce`\n- `python3 tools/import-validation/check-source-contracts.py --strict`\n- `python3 tools/import-validation/test_source_contracts.py`\n- `git diff --check HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted target result ordering into `execution.py` and updated `local_ci.py` to use the shared helper. Added unit tests and updated the module map; behavior is unchanged.

- **Refactors**
  - Introduced `sorted_target_results()` in `execution.py` to order results by `target`.
  - Delegated final result ordering in `local_ci` to the new helper.
  - Updated `MODULE_MAP.md` and added tests for the helper.

<sup>Written for commit af22e3ad9dfd9baeaf363c82c2eb89df5bb4bc77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

