### PR TITLE
refactor(local-ci): extract target task runner helper

### DIFF
--- a/tools/local-ci/MODULE_MAP.md
+++ b/tools/local-ci/MODULE_MAP.md
@@ -32,7 +32,7 @@ and the matching contract tests in the same change.
 | `macos_desktop.py` | macOS app bundle detection, Swift window-probe wrappers, window wait/capture/activation/click helpers, app quit, and process termination. | Desktop action orchestration, artifact manifest writing, source preparation, or queue orchestration. |
 | `windows_target.py` | Windows desktop target contracts, path safety, session-agent request payloads, and probe result formatting/readiness helpers. | SSH/PowerShell execution, desktop action execution, queue orchestration, or artifact layout. |
 | `windows_probe.py` | Windows SSH/PowerShell command execution helpers, remote file transfer/read/remove helpers, repo/session/tooling probes, remote tool installation, session-agent bootstrap/start, and CMake generator probing. | Windows target contract formatting, desktop action orchestration, queue orchestration, or artifact layout. |
-| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, optional command log writing, local/POSIX validation command construction, Windows validation script construction, job/target result construction and ordering, and target-neutral validation helper policy. | Windows checkout/probe execution, queue mutation, or desktop automation adapters. |
+| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, optional command log writing, local/POSIX validation command construction, Windows validation script construction, job/target result construction and ordering, target task execution/result collection, and target-neutral validation helper policy. | Windows checkout/probe execution, queue mutation, or desktop automation adapters. |
 
 ## Remaining `local_ci.py` Clusters
 

--- a/tools/local-ci/execution.py
+++ b/tools/local-ci/execution.py
@@ -9,6 +9,7 @@ execution slices.
 from __future__ import annotations
 
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
 import queue as queue_module
 import shlex
 import subprocess
@@ -635,6 +636,30 @@ def completed_job_result(
 
 def sorted_target_results(results: list[dict]) -> list[dict]:
     return sorted(results, key=lambda item: item["target"])
+
+
+def run_target_tasks(
+    tasks: list[tuple[str, Callable[[], dict]]],
+    *,
+    exception_result_fn: Callable[[str, Exception], dict],
+    on_target_complete: Callable[[str, dict], None],
+) -> list[dict]:
+    if not tasks:
+        return []
+
+    results = []
+    with ThreadPoolExecutor(max_workers=len(tasks)) as pool:
+        futures = {pool.submit(fn): name for name, fn in tasks}
+        for future in as_completed(futures):
+            name = futures[future]
+            try:
+                result = future.result()
+            except Exception as exc:
+                result = exception_result_fn(name, exc)
+
+            results.append(result)
+            on_target_complete(name, result)
+    return results
 
 
 def run_logged_command(

--- a/tools/local-ci/local_ci.py
+++ b/tools/local-ci/local_ci.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import argparse
 from collections import deque
+from collections.abc import Callable
 import fcntl
 import json
 import os
@@ -50,7 +51,6 @@ import uuid
 import urllib.error
 import urllib.parse
 import urllib.request
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from datetime import date, datetime, timezone
 from pathlib import Path
@@ -3234,6 +3234,18 @@ def sorted_target_results(results: list[dict]) -> list[dict]:
     return _execution.sorted_target_results(results)
 
 
+def run_target_tasks(
+    tasks: list[tuple[str, Callable[[], dict]]],
+    *,
+    on_target_complete: Callable[[str, dict], None],
+) -> list[dict]:
+    return _execution.run_target_tasks(
+        tasks,
+        exception_result_fn=target_exception_result,
+        on_target_complete=on_target_complete,
+    )
+
+
 def run_logged_command(
     cmd: list[str],
     *,
@@ -3713,26 +3725,17 @@ def process_job(job: dict, config: dict) -> dict:
         target_states[name] = initial_target_state(job["id"], name, started_at=now_iso())
     flush_target_states()
 
-    results = []
-    with ThreadPoolExecutor(max_workers=len(tasks)) as pool:
-        futures = {pool.submit(fn): name for name, fn in tasks}
-        for future in as_completed(futures):
-            name = futures[future]
-            try:
-                result = future.result()
-            except Exception as exc:
-                result = target_exception_result(name, exc)
+    def record_target_completion(name: str, result: dict) -> None:
+        target_states[name] = completed_target_state(
+            job["id"],
+            name,
+            result,
+            target_states.get(name, {}),
+            completed_at=now_iso(),
+        )
+        flush_target_states()
 
-            results.append(result)
-            target_states[name] = completed_target_state(
-                job["id"],
-                name,
-                result,
-                target_states.get(name, {}),
-                completed_at=now_iso(),
-            )
-            flush_target_states()
-
+    results = run_target_tasks(tasks, on_target_complete=record_target_completion)
     return completed_job_result(job, sorted_target_results(results))
 
 

--- a/tools/local-ci/test_execution.py
+++ b/tools/local-ci/test_execution.py
@@ -159,6 +159,39 @@ class ExecutionTests(unittest.TestCase):
         self.assertEqual([item["target"] for item in sorted_results], ["mac", "ubuntu", "windows"])
         self.assertEqual([item["target"] for item in results], ["windows", "mac", "ubuntu"])
 
+    def test_run_target_tasks_collects_results_and_reports_completion(self) -> None:
+        completed = []
+
+        def failing_task() -> dict:
+            raise RuntimeError("boom")
+
+        results = self.mod.run_target_tasks(
+            [
+                ("mac", lambda: {"target": "mac", "status": "pass"}),
+                ("windows", failing_task),
+            ],
+            exception_result_fn=lambda name, exc: {
+                "target": name,
+                "status": "error",
+                "stderr_tail": str(exc),
+            },
+            on_target_complete=lambda name, result: completed.append((name, result["status"])),
+        )
+
+        self.assertCountEqual(
+            [(item["target"], item["status"]) for item in results],
+            [("mac", "pass"), ("windows", "error")],
+        )
+        self.assertCountEqual(completed, [("mac", "pass"), ("windows", "error")])
+        self.assertEqual(
+            self.mod.run_target_tasks(
+                [],
+                exception_result_fn=lambda name, exc: {},
+                on_target_complete=lambda name, result: None,
+            ),
+            [],
+        )
+
     def test_local_validation_command_builds_full_and_smoke_commands(self) -> None:
         full_cmd, full_validation = self.mod.local_validation_command(
             {"sha": "a" * 40, "targets": ["mac"], "validation": "full"},


### PR DESCRIPTION
## Summary
- move target task ThreadPoolExecutor result collection into `execution.py`
- keep target-state completion updates in `local_ci.py` through a completion callback
- update the local-ci module map and add direct execution coverage

## Validation
- `python3 -m py_compile tools/local-ci/local_ci.py tools/local-ci/execution.py tools/local-ci/test_execution.py`
- `python3 tools/local-ci/test_execution.py`
- `python3 tools/local-ci/test_local_ci.py -k process_job`
- `python3 -m unittest discover -s tools/local-ci -p 'test_*.py'`\n- `PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`\n- `python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat`\n- `python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce`\n- `python3 tools/import-validation/check-source-contracts.py --strict`\n- `python3 tools/import-validation/test_source_contracts.py`\n- `git diff --check HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a reusable target task runner to centralize ThreadPoolExecutor handling and simplify `local_ci` state updates. No behavior change; improves testability and separation.

- **Refactors**
  - Moved target task execution/result collection to `execution.run_target_tasks` with `exception_result_fn` and `on_target_complete` hooks.
  - Kept target-state completion updates in `local_ci` via a simple completion callback.
  - Updated `MODULE_MAP.md` to include target task execution responsibility.
  - Added direct tests for `run_target_tasks` in `test_execution.py`.

<sup>Written for commit 861850bb03355267e2d1e32a6fd145b330068402. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

