### PR TITLE
ci(release): claim GitHub 'latest release' pointer (make_latest: true)

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -816,3 +816,9 @@ jobs:
             artifacts/**/*
           draft: false
           prerelease: false
+          # Explicitly claim GitHub's "latest release" pointer. Without this,
+          # releases published after v0.395.0 (v0.397..v0.406) stayed off
+          # `releases/latest` — so `pulp upgrade`, the install script, and the
+          # repo's "Latest" badge all kept pointing at v0.395.0 while newer
+          # CLIs shipped. `make_latest: true` is the durable fix (2026-06-10).
+          make_latest: true


### PR DESCRIPTION
Releases after v0.395.0 published but never claimed GitHub's releases/latest pointer, so pulp upgrade / install script / Latest badge stayed on v0.395.0 while newer CLIs shipped. Set make_latest: true on the publish action so every future release self-promotes. v0.406.0 promoted manually as the one-off.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Claim GitHub's "latest release" pointer in the release workflow by setting `make_latest: true` in `softprops/action-gh-release`. This ensures new releases become "latest" so `pulp upgrade`, the install script, and the repo badge point to the newest version; `v0.406.0` was promoted manually as a one-off.

<sup>Written for commit 50cd3dad2f686708d64ab19337ee89055c041885. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

