### PR TITLE
refactor(local-ci): extract posix validation runner

### DIFF
--- a/tools/local-ci/MODULE_MAP.md
+++ b/tools/local-ci/MODULE_MAP.md
@@ -32,7 +32,7 @@ and the matching contract tests in the same change.
 | `macos_desktop.py` | macOS app bundle detection, Swift window-probe wrappers, window wait/capture/activation/click helpers, app quit, and process termination. | Desktop action orchestration, artifact manifest writing, source preparation, or queue orchestration. |
 | `windows_target.py` | Windows desktop target contracts, path safety, session-agent request payloads, and probe result formatting/readiness helpers. | SSH/PowerShell execution, desktop action execution, queue orchestration, or artifact layout. |
 | `windows_probe.py` | Windows SSH/PowerShell command execution helpers, remote file transfer/read/remove helpers, repo/session/tooling probes, remote tool installation, session-agent bootstrap/start, and CMake generator probing. | Windows target contract formatting, desktop action orchestration, queue orchestration, or artifact layout. |
-| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, optional command log writing, local/POSIX validation command construction, local validation runner orchestration, Windows validation script construction, job/target result construction and ordering, target task construction/execution/result collection, submission config resolution, SSH target execution planning, and target-neutral validation helper policy. | Windows checkout/probe execution, queue mutation, or desktop automation adapters. |
+| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, optional command log writing, local/POSIX validation command construction and runner orchestration, Windows validation script construction, job/target result construction and ordering, target task construction/execution/result collection, submission config resolution, SSH target execution planning, and target-neutral validation helper policy. | Windows checkout/probe execution, queue mutation, or desktop automation adapters. |
 
 ## Remaining `local_ci.py` Clusters
 
@@ -44,7 +44,7 @@ behind the contracts added in this slice.
 | --- | --- | --- |
 | Desktop target probes | Desktop doctor orchestration, launch adapters, and automation adapters. | later `execution.py` |
 | Queue orchestration | Remaining runner-state wrapper calls and other CLI-facing queue updates. | later queue modules |
-| Validation execution | Local, SSH, Windows, Linux, smoke/full validation commands and target status reporting beyond shared command execution and target-neutral helper policy. | `execution.py` |
+| Validation execution | Windows validation runner orchestration, remaining target status reporting, and cross-target validation glue beyond shared command execution and target-neutral helper policy. | `execution.py` |
 | CLI dispatch | Argument parser, subcommand routing, and user-facing command output. | `cli.py` or retained thin entrypoint |
 
 ## Behavior Contracts

--- a/tools/local-ci/execution.py
+++ b/tools/local-ci/execution.py
@@ -2,8 +2,8 @@
 
 This module owns subprocess output capture, progress marker parsing, heartbeat
 updates, optional command log writing, and target-neutral command result
-assembly. Higher-level target validation stays in local_ci.py until later
-execution slices.
+assembly, and local/POSIX validation runner orchestration. Higher-level
+Windows target validation stays in local_ci.py until later execution slices.
 """
 
 from __future__ import annotations
@@ -795,6 +795,66 @@ def run_local_validation(
         log_path=log_path,
         validation=validation,
         transport_mode="local",
+    )
+
+
+def run_posix_ssh_validation(
+    target_name: str,
+    host: str,
+    repo_path: str,
+    job: dict,
+    exclude_tests: str = "",
+    config: dict | None = None,
+    report_progress=None,
+    *,
+    print_fn: Callable[[str], None],
+    short_sha_fn: Callable[[str], str],
+    prepare_target_log_fn: Callable[[str, str], Path],
+    now_iso_fn: Callable[[], str],
+    sync_job_bundle_to_ssh_host_fn: Callable[..., tuple[str, str]],
+    posix_ssh_validation_command_fn: Callable[..., tuple[list[str], str]],
+    run_logged_command_fn: Callable[..., dict],
+    validation_result_from_run_fn: Callable[..., dict],
+    validation_error_result_fn: Callable[..., dict],
+) -> dict:
+    print_fn(f"  [{target_name}] Running validation on {host}:{repo_path} @ {short_sha_fn(job['sha'])}...")
+    log_path = prepare_target_log_fn(job["id"], target_name)
+    if report_progress:
+        report_progress(
+            phase="connect",
+            host=host,
+            log_path=str(log_path),
+            last_output_at=now_iso_fn(),
+            transport_mode="bundle",
+        )
+
+    try:
+        bundle_name, bundle_ref = sync_job_bundle_to_ssh_host_fn(
+            host,
+            job,
+            report_progress=report_progress,
+            config=config,
+        )
+    except RuntimeError as exc:
+        return validation_error_result_fn(target_name, str(exc), log_path=log_path, transport_mode="bundle")
+
+    cmd, validation = posix_ssh_validation_command_fn(
+        target_name,
+        host,
+        repo_path,
+        job,
+        bundle_name=bundle_name,
+        bundle_ref=bundle_ref,
+        exclude_tests=exclude_tests,
+    )
+
+    run = run_logged_command_fn(cmd, timeout=3600, log_path=log_path, report_progress=report_progress)
+    return validation_result_from_run_fn(
+        target_name,
+        run,
+        log_path=log_path,
+        validation=validation,
+        transport_mode="bundle",
     )
 
 

--- a/tools/local-ci/local_ci.py
+++ b/tools/local-ci/local_ci.py
@@ -3294,44 +3294,23 @@ def run_posix_ssh_validation(
     config: dict | None = None,
     report_progress=None,
 ) -> dict:
-    print(f"  [{target_name}] Running validation on {host}:{repo_path} @ {short_sha(job['sha'])}...")
-    log_path = prepare_target_log(job["id"], target_name)
-    if report_progress:
-        report_progress(
-            phase="connect",
-            host=host,
-            log_path=str(log_path),
-            last_output_at=now_iso(),
-            transport_mode="bundle",
-        )
-
-    try:
-        bundle_name, bundle_ref = sync_job_bundle_to_ssh_host(
-            host,
-            job,
-            report_progress=report_progress,
-            config=config,
-        )
-    except RuntimeError as exc:
-        return validation_error_result(target_name, str(exc), log_path=log_path, transport_mode="bundle")
-
-    cmd, validation = posix_ssh_validation_command(
+    return _execution.run_posix_ssh_validation(
         target_name,
         host,
         repo_path,
         job,
-        bundle_name=bundle_name,
-        bundle_ref=bundle_ref,
-        exclude_tests=exclude_tests,
-    )
-
-    run = run_logged_command(cmd, timeout=3600, log_path=log_path, report_progress=report_progress)
-    return validation_result_from_run(
-        target_name,
-        run,
-        log_path=log_path,
-        validation=validation,
-        transport_mode="bundle",
+        exclude_tests,
+        config,
+        report_progress,
+        print_fn=print,
+        short_sha_fn=short_sha,
+        prepare_target_log_fn=prepare_target_log,
+        now_iso_fn=now_iso,
+        sync_job_bundle_to_ssh_host_fn=sync_job_bundle_to_ssh_host,
+        posix_ssh_validation_command_fn=posix_ssh_validation_command,
+        run_logged_command_fn=run_logged_command,
+        validation_result_from_run_fn=validation_result_from_run,
+        validation_error_result_fn=validation_error_result,
     )
 
 

--- a/tools/local-ci/test_execution.py
+++ b/tools/local-ci/test_execution.py
@@ -517,6 +517,130 @@ class ExecutionTests(unittest.TestCase):
         self.assertEqual(result["validation"], "full")
         self.assertEqual(result["transport_mode"], "local")
 
+    def test_run_posix_ssh_validation_syncs_bundle_reports_progress_and_returns_result(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "ubuntu.log"
+            progress = []
+            messages = []
+            captured = {}
+
+            def report_progress(**fields) -> None:
+                progress.append(fields)
+
+            def prepare_target_log(job_id: str, target_name: str) -> Path:
+                captured["prepared"] = (job_id, target_name)
+                return log_path
+
+            def sync_bundle(host: str, job: dict, **kwargs) -> tuple[str, str]:
+                captured["sync"] = (host, job["id"], kwargs["report_progress"], kwargs["config"])
+                return "pulp-ci-job-posix.bundle", "refs/pulp-ci-bundles/job-posix"
+
+            def posix_command(
+                target_name: str,
+                host: str,
+                repo_path: str,
+                job: dict,
+                **kwargs,
+            ) -> tuple[list[str], str]:
+                captured["command"] = (target_name, host, repo_path, job["id"], kwargs)
+                return ["ssh", host, "validate"], "smoke"
+
+            def run_logged_command(cmd: list[str], **kwargs) -> dict:
+                captured["run"] = (cmd, kwargs)
+                return {
+                    "timed_out": False,
+                    "returncode": 0,
+                    "output": "__PULP_VALIDATION__:smoke\n__PULP_TEST_POLICY__:skip\nok\n",
+                    "duration_secs": 1.0,
+                }
+
+            result = self.mod.run_posix_ssh_validation(
+                "ubuntu",
+                "ubuntu.example.com",
+                "/tmp/pulp",
+                {"id": "job-posix", "branch": "feature/posix", "sha": "d" * 40},
+                "slow",
+                {"ssh": {"ubuntu": {}}},
+                report_progress,
+                print_fn=messages.append,
+                short_sha_fn=lambda sha: sha[:12],
+                prepare_target_log_fn=prepare_target_log,
+                now_iso_fn=lambda: "2026-06-10T00:00:00Z",
+                sync_job_bundle_to_ssh_host_fn=sync_bundle,
+                posix_ssh_validation_command_fn=posix_command,
+                run_logged_command_fn=run_logged_command,
+                validation_result_from_run_fn=self.mod.validation_result_from_run,
+                validation_error_result_fn=self.mod.validation_error_result,
+            )
+
+        self.assertEqual(messages, ["  [ubuntu] Running validation on ubuntu.example.com:/tmp/pulp @ dddddddddddd..."])
+        self.assertEqual(captured["prepared"], ("job-posix", "ubuntu"))
+        self.assertEqual(captured["sync"], ("ubuntu.example.com", "job-posix", report_progress, {"ssh": {"ubuntu": {}}}))
+        self.assertEqual(
+            captured["command"],
+            (
+                "ubuntu",
+                "ubuntu.example.com",
+                "/tmp/pulp",
+                "job-posix",
+                {
+                    "bundle_name": "pulp-ci-job-posix.bundle",
+                    "bundle_ref": "refs/pulp-ci-bundles/job-posix",
+                    "exclude_tests": "slow",
+                },
+            ),
+        )
+        self.assertEqual(captured["run"][0], ["ssh", "ubuntu.example.com", "validate"])
+        self.assertEqual(captured["run"][1]["timeout"], 3600)
+        self.assertEqual(captured["run"][1]["log_path"], log_path)
+        self.assertIs(captured["run"][1]["report_progress"], report_progress)
+        self.assertEqual(
+            progress,
+            [
+                {
+                    "phase": "connect",
+                    "host": "ubuntu.example.com",
+                    "log_path": str(log_path),
+                    "last_output_at": "2026-06-10T00:00:00Z",
+                    "transport_mode": "bundle",
+                }
+            ],
+        )
+        self.assertEqual(result["target"], "ubuntu")
+        self.assertEqual(result["status"], "pass")
+        self.assertEqual(result["log_file"], str(log_path))
+        self.assertEqual(result["validation"], "smoke")
+        self.assertEqual(result["transport_mode"], "bundle")
+
+    def test_run_posix_ssh_validation_returns_bundle_sync_error_result(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "ubuntu.log"
+
+            def sync_bundle(*_args, **_kwargs) -> tuple[str, str]:
+                raise RuntimeError("upload failed")
+
+            result = self.mod.run_posix_ssh_validation(
+                "ubuntu",
+                "ubuntu.example.com",
+                "/tmp/pulp",
+                {"id": "job-posix-error", "branch": "feature/posix", "sha": "e" * 40},
+                print_fn=lambda _message: None,
+                short_sha_fn=lambda sha: sha[:12],
+                prepare_target_log_fn=lambda _job_id, _target_name: log_path,
+                now_iso_fn=lambda: "2026-06-10T00:00:00Z",
+                sync_job_bundle_to_ssh_host_fn=sync_bundle,
+                posix_ssh_validation_command_fn=lambda *_args, **_kwargs: self.fail("unexpected command build"),
+                run_logged_command_fn=lambda *_args, **_kwargs: self.fail("unexpected command run"),
+                validation_result_from_run_fn=self.mod.validation_result_from_run,
+                validation_error_result_fn=self.mod.validation_error_result,
+            )
+
+        self.assertEqual(result["target"], "ubuntu")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["stderr_tail"], "upload failed")
+        self.assertEqual(result["log_file"], str(log_path))
+        self.assertEqual(result["transport_mode"], "bundle")
+
     def test_posix_ssh_validation_command_builds_full_command(self) -> None:
         job = {
             "id": "job701",


### PR DESCRIPTION
## Summary
- move POSIX SSH validation runner orchestration into execution.py behind injected side-effect helpers
- keep local_ci.py as a stable wrapper for existing call sites and tests
- update the local-ci module map and add direct execution-module coverage for success/error paths

## Validation
- python3 -m py_compile tools/local-ci/local_ci.py tools/local-ci/execution.py tools/local-ci/test_execution.py
- python3 tools/local-ci/test_execution.py
- python3 tools/local-ci/test_local_ci.py -k posix
- python3 -m unittest discover -s tools/local-ci -p 'test_*.py'
- python3 tools/import-validation/check-source-contracts.py --strict
- python3 tools/import-validation/test_source_contracts.py
- PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat
- python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce
- git diff --check HEAD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the POSIX SSH validation runner into `execution.py` with dependency-injected helpers. `local_ci.py` now delegates to keep behavior and call sites stable, and tests cover success and error paths.

- **Refactors**
  - Added `run_posix_ssh_validation` to `execution.py` with injected I/O and orchestration helpers.
  - Updated `local_ci.run_posix_ssh_validation` to delegate to the new function.
  - Adjusted `MODULE_MAP.md` to reflect POSIX runner orchestration living in `execution.py`.
  - Added `test_execution.py` coverage for happy path and bundle sync failure; kept existing `local_ci` tests unchanged.

<sup>Written for commit 1788235b48d1f2ad49a3842d7a3ba4a6c00fa72f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

