### PR TITLE
refactor(local-ci): extract windows validation runner

### DIFF
--- a/tools/local-ci/MODULE_MAP.md
+++ b/tools/local-ci/MODULE_MAP.md
@@ -32,7 +32,7 @@ and the matching contract tests in the same change.
 | `macos_desktop.py` | macOS app bundle detection, Swift window-probe wrappers, window wait/capture/activation/click helpers, app quit, and process termination. | Desktop action orchestration, artifact manifest writing, source preparation, or queue orchestration. |
 | `windows_target.py` | Windows desktop target contracts, path safety, session-agent request payloads, and probe result formatting/readiness helpers. | SSH/PowerShell execution, desktop action execution, queue orchestration, or artifact layout. |
 | `windows_probe.py` | Windows SSH/PowerShell command execution helpers, remote file transfer/read/remove helpers, repo/session/tooling probes, remote tool installation, session-agent bootstrap/start, and CMake generator probing. | Windows target contract formatting, desktop action orchestration, queue orchestration, or artifact layout. |
-| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, optional command log writing, local/POSIX validation command construction and runner orchestration, Windows validation script construction, job/target result construction and ordering, target task construction/execution/result collection, submission config resolution, SSH target execution planning, and target-neutral validation helper policy. | Windows checkout/probe execution, queue mutation, or desktop automation adapters. |
+| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, optional command log writing, local/POSIX validation command construction and local/POSIX/Windows runner orchestration, Windows validation script construction, job/target result construction and ordering, target task construction/execution/result collection, submission config resolution, SSH target execution planning, and target-neutral validation helper policy. | Windows checkout/probe helper internals, queue mutation, or desktop automation adapters. |
 
 ## Remaining `local_ci.py` Clusters
 
@@ -44,7 +44,7 @@ behind the contracts added in this slice.
 | --- | --- | --- |
 | Desktop target probes | Desktop doctor orchestration, launch adapters, and automation adapters. | later `execution.py` |
 | Queue orchestration | Remaining runner-state wrapper calls and other CLI-facing queue updates. | later queue modules |
-| Validation execution | Windows validation runner orchestration, remaining target status reporting, and cross-target validation glue beyond shared command execution and target-neutral helper policy. | `execution.py` |
+| Validation execution | Remaining target status reporting and cross-target validation glue beyond shared command execution and target-neutral helper policy. | `execution.py` |
 | CLI dispatch | Argument parser, subcommand routing, and user-facing command output. | `cli.py` or retained thin entrypoint |
 
 ## Behavior Contracts

--- a/tools/local-ci/execution.py
+++ b/tools/local-ci/execution.py
@@ -2,8 +2,7 @@
 
 This module owns subprocess output capture, progress marker parsing, heartbeat
 updates, optional command log writing, and target-neutral command result
-assembly, and local/POSIX validation runner orchestration. Higher-level
-Windows target validation stays in local_ci.py until later execution slices.
+assembly, and local/POSIX/Windows validation runner orchestration.
 """
 
 from __future__ import annotations
@@ -849,6 +848,111 @@ def run_posix_ssh_validation(
     )
 
     run = run_logged_command_fn(cmd, timeout=3600, log_path=log_path, report_progress=report_progress)
+    return validation_result_from_run_fn(
+        target_name,
+        run,
+        log_path=log_path,
+        validation=validation,
+        transport_mode="bundle",
+    )
+
+
+def run_windows_ssh_validation(
+    target_name: str,
+    host: str,
+    repo_path: str,
+    job: dict,
+    exclude_tests: str = "",
+    cmake_generator: str = "Visual Studio 17 2022",
+    cmake_platform: str = "",
+    cmake_generator_instance: str = "",
+    config: dict | None = None,
+    report_progress=None,
+    *,
+    root: Path,
+    prepare_target_log_fn: Callable[[str, str], Path],
+    sync_job_bundle_to_ssh_host_fn: Callable[..., tuple[str, str]],
+    validation_error_result_fn: Callable[..., dict],
+    ensure_windows_remote_repo_checkout_fn: Callable[..., dict | None],
+    git_origin_clone_url_fn: Callable[[Path], str | None],
+    print_fn: Callable[[str], None],
+    short_sha_fn: Callable[[str], str],
+    now_iso_fn: Callable[[], str],
+    probe_windows_ssh_cmake_settings_fn: Callable[[str, str, str, str], tuple[str, str]],
+    windows_validation_script_fn: Callable[..., tuple[str, str]],
+    windows_ssh_powershell_command_fn: Callable[[str], list[str]],
+    run_logged_command_fn: Callable[..., dict],
+    validation_result_from_run_fn: Callable[..., dict],
+) -> dict:
+    log_path = prepare_target_log_fn(job["id"], target_name)
+    try:
+        bundle_name, bundle_ref = sync_job_bundle_to_ssh_host_fn(
+            host,
+            job,
+            report_progress=report_progress,
+            config=config,
+        )
+    except RuntimeError as exc:
+        return validation_error_result_fn(target_name, str(exc), log_path=log_path, transport_mode="bundle")
+    try:
+        repo_probe = ensure_windows_remote_repo_checkout_fn(
+            host,
+            repo_path,
+            remote_url=git_origin_clone_url_fn(root),
+            bundle_name=bundle_name,
+            bundle_ref=bundle_ref,
+        )
+    except RuntimeError as exc:
+        return validation_error_result_fn(target_name, str(exc), log_path=log_path, transport_mode="bundle")
+
+    if not isinstance(repo_probe, dict):
+        return validation_error_result_fn(
+            target_name,
+            "Windows repo checkout probe returned no structured payload",
+            log_path=log_path,
+            transport_mode="bundle",
+        )
+
+    effective_repo_path = repo_probe.get("repo_path") or repo_path
+    print_fn(f"  [{target_name}] Running validation on {host}:{effective_repo_path} @ {short_sha_fn(job['sha'])}...")
+    if report_progress:
+        report_progress(
+            phase="connect",
+            host=host,
+            log_path=str(log_path),
+            last_output_at=now_iso_fn(),
+            transport_mode="bundle",
+        )
+
+    resolved_platform, resolved_generator_instance = probe_windows_ssh_cmake_settings_fn(
+        host,
+        cmake_generator,
+        cmake_platform,
+        cmake_generator_instance,
+    )
+
+    ps_script, validation = windows_validation_script_fn(
+        target_name,
+        host,
+        effective_repo_path,
+        job,
+        bundle_name=bundle_name,
+        bundle_ref=bundle_ref,
+        exclude_tests=exclude_tests,
+        cmake_generator=cmake_generator,
+        resolved_platform=resolved_platform,
+        resolved_generator_instance=resolved_generator_instance,
+    )
+
+    cmd = windows_ssh_powershell_command_fn(host)
+
+    run = run_logged_command_fn(
+        cmd,
+        input_text=ps_script,
+        timeout=3600,
+        log_path=log_path,
+        report_progress=report_progress,
+    )
     return validation_result_from_run_fn(
         target_name,
         run,

--- a/tools/local-ci/local_ci.py
+++ b/tools/local-ci/local_ci.py
@@ -3484,81 +3484,31 @@ def run_windows_ssh_validation(
     config: dict | None = None,
     report_progress=None,
 ) -> dict:
-    log_path = prepare_target_log(job["id"], target_name)
-    try:
-        bundle_name, bundle_ref = sync_job_bundle_to_ssh_host(
-            host,
-            job,
-            report_progress=report_progress,
-            config=config,
-        )
-    except RuntimeError as exc:
-        return validation_error_result(target_name, str(exc), log_path=log_path, transport_mode="bundle")
-    try:
-        repo_probe = ensure_windows_remote_repo_checkout(
-            host,
-            repo_path,
-            remote_url=git_origin_clone_url(ROOT),
-            bundle_name=bundle_name,
-            bundle_ref=bundle_ref,
-        )
-    except RuntimeError as exc:
-        return validation_error_result(target_name, str(exc), log_path=log_path, transport_mode="bundle")
-
-    if not isinstance(repo_probe, dict):
-        return validation_error_result(
-            target_name,
-            "Windows repo checkout probe returned no structured payload",
-            log_path=log_path,
-            transport_mode="bundle",
-        )
-
-    effective_repo_path = repo_probe.get("repo_path") or repo_path
-    print(f"  [{target_name}] Running validation on {host}:{effective_repo_path} @ {short_sha(job['sha'])}...")
-    if report_progress:
-        report_progress(
-            phase="connect",
-            host=host,
-            log_path=str(log_path),
-            last_output_at=now_iso(),
-            transport_mode="bundle",
-        )
-
-    resolved_platform, resolved_generator_instance = probe_windows_ssh_cmake_settings(
+    return _execution.run_windows_ssh_validation(
+        target_name,
         host,
+        repo_path,
+        job,
+        exclude_tests,
         cmake_generator,
         cmake_platform,
         cmake_generator_instance,
-    )
-
-    ps_script, validation = windows_validation_script(
-        target_name,
-        host,
-        effective_repo_path,
-        job,
-        bundle_name=bundle_name,
-        bundle_ref=bundle_ref,
-        exclude_tests=exclude_tests,
-        cmake_generator=cmake_generator,
-        resolved_platform=resolved_platform,
-        resolved_generator_instance=resolved_generator_instance,
-    )
-
-    cmd = windows_ssh_powershell_command(host)
-
-    run = run_logged_command(
-        cmd,
-        input_text=ps_script,
-        timeout=3600,
-        log_path=log_path,
-        report_progress=report_progress,
-    )
-    return validation_result_from_run(
-        target_name,
-        run,
-        log_path=log_path,
-        validation=validation,
-        transport_mode="bundle",
+        config,
+        report_progress,
+        root=ROOT,
+        prepare_target_log_fn=prepare_target_log,
+        sync_job_bundle_to_ssh_host_fn=sync_job_bundle_to_ssh_host,
+        validation_error_result_fn=validation_error_result,
+        ensure_windows_remote_repo_checkout_fn=ensure_windows_remote_repo_checkout,
+        git_origin_clone_url_fn=git_origin_clone_url,
+        print_fn=print,
+        short_sha_fn=short_sha,
+        now_iso_fn=now_iso,
+        probe_windows_ssh_cmake_settings_fn=probe_windows_ssh_cmake_settings,
+        windows_validation_script_fn=windows_validation_script,
+        windows_ssh_powershell_command_fn=windows_ssh_powershell_command,
+        run_logged_command_fn=run_logged_command,
+        validation_result_from_run_fn=validation_result_from_run,
     )
 
 

--- a/tools/local-ci/test_execution.py
+++ b/tools/local-ci/test_execution.py
@@ -641,6 +641,156 @@ class ExecutionTests(unittest.TestCase):
         self.assertEqual(result["log_file"], str(log_path))
         self.assertEqual(result["transport_mode"], "bundle")
 
+    def test_run_windows_ssh_validation_probes_checkout_and_runs_powershell(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            log_path = Path(tmp) / "windows.log"
+            progress = []
+            messages = []
+            captured = {}
+
+            def report_progress(**fields) -> None:
+                progress.append(fields)
+
+            def sync_bundle(host: str, job: dict, **kwargs) -> tuple[str, str]:
+                captured["sync"] = (host, job["id"], kwargs["report_progress"], kwargs["config"])
+                return "pulp-ci-job-windows.bundle", "refs/pulp-ci-bundles/job-windows"
+
+            def ensure_repo(host: str, repo_path: str, **kwargs) -> dict:
+                captured["repo"] = (host, repo_path, kwargs)
+                return {"repo_path": r"C:\Prepared\Pulp"}
+
+            def probe_cmake(host: str, generator: str, platform: str, instance: str) -> tuple[str, str]:
+                captured["probe"] = (host, generator, platform, instance)
+                return "ARM64", r"C:\VS"
+
+            def windows_script(
+                target_name: str,
+                host: str,
+                effective_repo_path: str,
+                job: dict,
+                **kwargs,
+            ) -> tuple[str, str]:
+                captured["script"] = (target_name, host, effective_repo_path, job["id"], kwargs)
+                return "Write-Host ok", "full"
+
+            def run_logged_command(cmd: list[str], **kwargs) -> dict:
+                captured["run"] = (cmd, kwargs)
+                return {
+                    "timed_out": False,
+                    "returncode": 0,
+                    "output": "ok\n",
+                    "duration_secs": 1.0,
+                }
+
+            result = self.mod.run_windows_ssh_validation(
+                "windows",
+                "win.example.com",
+                r"C:\Pulp",
+                {"id": "job-windows", "branch": "feature/windows", "sha": "f" * 40},
+                "slow",
+                "Visual Studio 17 2022",
+                "ARM64",
+                r"C:\RequestedVS",
+                {"targets": {"windows": {}}},
+                report_progress,
+                root=root,
+                prepare_target_log_fn=lambda job_id, target_name: log_path,
+                sync_job_bundle_to_ssh_host_fn=sync_bundle,
+                validation_error_result_fn=self.mod.validation_error_result,
+                ensure_windows_remote_repo_checkout_fn=ensure_repo,
+                git_origin_clone_url_fn=lambda repo_root: f"https://example.invalid/{repo_root.name}.git",
+                print_fn=messages.append,
+                short_sha_fn=lambda sha: sha[:12],
+                now_iso_fn=lambda: "2026-06-10T00:00:00Z",
+                probe_windows_ssh_cmake_settings_fn=probe_cmake,
+                windows_validation_script_fn=windows_script,
+                windows_ssh_powershell_command_fn=lambda host: ["ssh", host, "powershell"],
+                run_logged_command_fn=run_logged_command,
+                validation_result_from_run_fn=self.mod.validation_result_from_run,
+            )
+
+        self.assertEqual(messages, [r"  [windows] Running validation on win.example.com:C:\Prepared\Pulp @ ffffffffffff..."])
+        self.assertEqual(captured["sync"], ("win.example.com", "job-windows", report_progress, {"targets": {"windows": {}}}))
+        self.assertEqual(captured["repo"][0], "win.example.com")
+        self.assertEqual(captured["repo"][1], r"C:\Pulp")
+        self.assertEqual(captured["repo"][2]["remote_url"], "https://example.invalid/repo.git")
+        self.assertEqual(captured["repo"][2]["bundle_name"], "pulp-ci-job-windows.bundle")
+        self.assertEqual(captured["repo"][2]["bundle_ref"], "refs/pulp-ci-bundles/job-windows")
+        self.assertEqual(captured["probe"], ("win.example.com", "Visual Studio 17 2022", "ARM64", r"C:\RequestedVS"))
+        self.assertEqual(
+            captured["script"],
+            (
+                "windows",
+                "win.example.com",
+                r"C:\Prepared\Pulp",
+                "job-windows",
+                {
+                    "bundle_name": "pulp-ci-job-windows.bundle",
+                    "bundle_ref": "refs/pulp-ci-bundles/job-windows",
+                    "exclude_tests": "slow",
+                    "cmake_generator": "Visual Studio 17 2022",
+                    "resolved_platform": "ARM64",
+                    "resolved_generator_instance": r"C:\VS",
+                },
+            ),
+        )
+        self.assertEqual(captured["run"][0], ["ssh", "win.example.com", "powershell"])
+        self.assertEqual(captured["run"][1]["input_text"], "Write-Host ok")
+        self.assertEqual(captured["run"][1]["timeout"], 3600)
+        self.assertEqual(captured["run"][1]["log_path"], log_path)
+        self.assertIs(captured["run"][1]["report_progress"], report_progress)
+        self.assertEqual(
+            progress,
+            [
+                {
+                    "phase": "connect",
+                    "host": "win.example.com",
+                    "log_path": str(log_path),
+                    "last_output_at": "2026-06-10T00:00:00Z",
+                    "transport_mode": "bundle",
+                }
+            ],
+        )
+        self.assertEqual(result["target"], "windows")
+        self.assertEqual(result["status"], "pass")
+        self.assertEqual(result["validation"], "full")
+        self.assertEqual(result["transport_mode"], "bundle")
+
+    def test_run_windows_ssh_validation_returns_missing_repo_probe_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            log_path = Path(tmp) / "windows.log"
+
+            result = self.mod.run_windows_ssh_validation(
+                "windows",
+                "win.example.com",
+                r"C:\Pulp",
+                {"id": "job-windows-error", "branch": "feature/windows", "sha": "a" * 40},
+                root=root,
+                prepare_target_log_fn=lambda _job_id, _target_name: log_path,
+                sync_job_bundle_to_ssh_host_fn=lambda *_args, **_kwargs: ("bundle", "ref"),
+                validation_error_result_fn=self.mod.validation_error_result,
+                ensure_windows_remote_repo_checkout_fn=lambda *_args, **_kwargs: None,
+                git_origin_clone_url_fn=lambda _repo_root: "https://example.invalid/repo.git",
+                print_fn=lambda _message: None,
+                short_sha_fn=lambda sha: sha[:12],
+                now_iso_fn=lambda: "2026-06-10T00:00:00Z",
+                probe_windows_ssh_cmake_settings_fn=lambda *_args, **_kwargs: self.fail("unexpected cmake probe"),
+                windows_validation_script_fn=lambda *_args, **_kwargs: self.fail("unexpected script build"),
+                windows_ssh_powershell_command_fn=lambda _host: self.fail("unexpected command build"),
+                run_logged_command_fn=lambda *_args, **_kwargs: self.fail("unexpected command run"),
+                validation_result_from_run_fn=self.mod.validation_result_from_run,
+            )
+
+        self.assertEqual(result["target"], "windows")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("no structured payload", result["stderr_tail"])
+        self.assertEqual(result["log_file"], str(log_path))
+        self.assertEqual(result["transport_mode"], "bundle")
+
     def test_posix_ssh_validation_command_builds_full_command(self) -> None:
         job = {
             "id": "job701",


### PR DESCRIPTION
## Summary
- move Windows SSH validation runner orchestration into execution.py behind injected side-effect helpers
- keep local_ci.py as the stable wrapper for existing call sites and monkeypatch-style tests
- update the local-ci module map and add direct execution-module coverage for success/error paths

## Validation
- python3 -m py_compile tools/local-ci/local_ci.py tools/local-ci/execution.py tools/local-ci/test_execution.py
- python3 tools/local-ci/test_execution.py
- python3 tools/local-ci/test_local_ci.py -k windows_validation
- python3 -m unittest discover -s tools/local-ci -p 'test_*.py'
- python3 tools/import-validation/check-source-contracts.py --strict
- python3 tools/import-validation/test_source_contracts.py
- PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat
- python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce
- git diff --check HEAD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the Windows SSH validation runner into `execution.py` with injected helpers, and kept `local_ci.py` as a thin delegator. No behavior changes; this clarifies ownership and improves test coverage.

- **Refactors**
  - Added `run_windows_ssh_validation(...)` to `execution.py` to handle bundle sync, repo checkout probe, CMake probe, PowerShell run, and result mapping.
  - Rewired `local_ci.run_windows_ssh_validation` to delegate to `execution.py` with injected collaborators and `root`.
  - Added direct execution tests for Windows success and missing repo-probe error paths.
  - Updated `MODULE_MAP.md` to reflect Windows runner orchestration now in `execution.py`.

<sup>Written for commit 3d597749b5ee5aab9a1370cc25edc6b2fab68f0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

