### PR TITLE
refactor(local-ci): extract process job runner

### DIFF
--- a/tools/local-ci/MODULE_MAP.md
+++ b/tools/local-ci/MODULE_MAP.md
@@ -32,7 +32,7 @@ and the matching contract tests in the same change.
 | `macos_desktop.py` | macOS app bundle detection, Swift window-probe wrappers, window wait/capture/activation/click helpers, app quit, and process termination. | Desktop action orchestration, artifact manifest writing, source preparation, or queue orchestration. |
 | `windows_target.py` | Windows desktop target contracts, path safety, session-agent request payloads, and probe result formatting/readiness helpers. | SSH/PowerShell execution, desktop action execution, queue orchestration, or artifact layout. |
 | `windows_probe.py` | Windows SSH/PowerShell command execution helpers, remote file transfer/read/remove helpers, repo/session/tooling probes, remote tool installation, session-agent bootstrap/start, and CMake generator probing. | Windows target contract formatting, desktop action orchestration, queue orchestration, or artifact layout. |
-| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, optional command log writing, local/POSIX validation command construction and local/POSIX/Windows runner orchestration, Windows validation script construction, job/target result construction and ordering, target task construction/execution/result collection, submission config resolution, SSH target execution planning, and target-neutral validation helper policy. | Windows checkout/probe helper internals, queue mutation, or desktop automation adapters. |
+| `execution.py` | Subprocess output capture, progress marker parsing, heartbeat updates, optional command log writing, local/POSIX validation command construction and local/POSIX/Windows runner orchestration, Windows validation script construction, job/target result construction and ordering, target task construction/execution/result collection, submission config resolution, SSH target execution planning, cross-target validation/status orchestration, and target-neutral validation helper policy. | Windows checkout/probe helper internals, queue mutation, runner-info persistence, or desktop automation adapters. |
 
 ## Remaining `local_ci.py` Clusters
 
@@ -44,7 +44,7 @@ behind the contracts added in this slice.
 | --- | --- | --- |
 | Desktop target probes | Desktop doctor orchestration, launch adapters, and automation adapters. | later `execution.py` |
 | Queue orchestration | Remaining runner-state wrapper calls and other CLI-facing queue updates. | later queue modules |
-| Validation execution | Remaining target status reporting and cross-target validation glue beyond shared command execution and target-neutral helper policy. | `execution.py` |
+| Validation execution | Thin wrapper calls in `local_ci.py` plus any future execution-specific seams discovered while reducing the entrypoint. | `execution.py` |
 | CLI dispatch | Argument parser, subcommand routing, and user-facing command output. | `cli.py` or retained thin entrypoint |
 
 ## Behavior Contracts

--- a/tools/local-ci/execution.py
+++ b/tools/local-ci/execution.py
@@ -962,6 +962,70 @@ def run_windows_ssh_validation(
     )
 
 
+def process_job(
+    job: dict,
+    config: dict,
+    *,
+    print_fn: Callable[[str], None],
+    short_sha_fn: Callable[[str], str],
+    config_for_job_execution_fn: Callable[[dict, dict], dict],
+    build_target_tasks_fn: Callable[..., list[tuple[str, Callable[[], dict]]]],
+    target_state_snapshot_fn: Callable[[dict[str, dict]], dict[str, dict]],
+    update_runner_active_targets_fn: Callable[[str, dict[str, dict]], None],
+    update_job_active_targets_fn: Callable[[str, dict[str, dict]], None],
+    updated_target_state_fn: Callable[[dict | None, dict], dict],
+    initial_target_state_fn: Callable[..., dict],
+    completed_target_state_fn: Callable[..., dict],
+    now_iso_fn: Callable[[], str],
+    run_target_tasks_fn: Callable[..., list[dict]],
+    completed_job_result_fn: Callable[[dict, list[dict]], dict],
+    sorted_target_results_fn: Callable[[list[dict]], list[dict]],
+) -> dict:
+    print_fn(
+        f"\n=== Validating [{job['id']}] {job['branch']} @ {short_sha_fn(job['sha'])} "
+        f"priority={job['priority']} ===\n"
+    )
+    config = config_for_job_execution_fn(job, config)
+
+    target_states: dict[str, dict] = {}
+    state_lock = threading.Lock()
+
+    def flush_target_states() -> None:
+        with state_lock:
+            snapshot = target_state_snapshot_fn(target_states)
+        update_runner_active_targets_fn(job["id"], snapshot)
+        update_job_active_targets_fn(job["id"], snapshot)
+
+    def progress_factory(name: str):
+        def report(**fields) -> None:
+            with state_lock:
+                target_states[name] = updated_target_state_fn(target_states.get(name), fields)
+            flush_target_states()
+
+        return report
+
+    tasks = build_target_tasks_fn(job, config, progress_factory=progress_factory)
+    if not tasks:
+        return completed_job_result_fn(job, [])
+
+    for name, _fn in tasks:
+        target_states[name] = initial_target_state_fn(job["id"], name, started_at=now_iso_fn())
+    flush_target_states()
+
+    def record_target_completion(name: str, result: dict) -> None:
+        target_states[name] = completed_target_state_fn(
+            job["id"],
+            name,
+            result,
+            target_states.get(name, {}),
+            completed_at=now_iso_fn(),
+        )
+        flush_target_states()
+
+    results = run_target_tasks_fn(tasks, on_target_complete=record_target_completion)
+    return completed_job_result_fn(job, sorted_target_results_fn(results))
+
+
 def run_target_tasks(
     tasks: list[tuple[str, Callable[[], dict]]],
     *,

--- a/tools/local-ci/local_ci.py
+++ b/tools/local-ci/local_ci.py
@@ -3552,49 +3552,24 @@ def _build_target_tasks(job: dict, config: dict, progress_factory=None) -> list[
 
 
 def process_job(job: dict, config: dict) -> dict:
-    print(
-        f"\n=== Validating [{job['id']}] {job['branch']} @ {short_sha(job['sha'])} "
-        f"priority={job['priority']} ===\n"
+    return _execution.process_job(
+        job,
+        config,
+        print_fn=print,
+        short_sha_fn=short_sha,
+        config_for_job_execution_fn=config_for_job_execution,
+        build_target_tasks_fn=_build_target_tasks,
+        target_state_snapshot_fn=target_state_snapshot,
+        update_runner_active_targets_fn=update_runner_active_targets,
+        update_job_active_targets_fn=update_job_active_targets,
+        updated_target_state_fn=updated_target_state,
+        initial_target_state_fn=initial_target_state,
+        completed_target_state_fn=completed_target_state,
+        now_iso_fn=now_iso,
+        run_target_tasks_fn=run_target_tasks,
+        completed_job_result_fn=completed_job_result,
+        sorted_target_results_fn=sorted_target_results,
     )
-    config = config_for_job_execution(job, config)
-
-    target_states: dict[str, dict] = {}
-    state_lock = threading.Lock()
-
-    def flush_target_states() -> None:
-        with state_lock:
-            snapshot = target_state_snapshot(target_states)
-        update_runner_active_targets(job["id"], snapshot)
-        update_job_active_targets(job["id"], snapshot)
-
-    def progress_factory(name: str):
-        def report(**fields) -> None:
-            with state_lock:
-                target_states[name] = updated_target_state(target_states.get(name), fields)
-            flush_target_states()
-
-        return report
-
-    tasks = _build_target_tasks(job, config, progress_factory=progress_factory)
-    if not tasks:
-        return completed_job_result(job, [])
-
-    for name, _fn in tasks:
-        target_states[name] = initial_target_state(job["id"], name, started_at=now_iso())
-    flush_target_states()
-
-    def record_target_completion(name: str, result: dict) -> None:
-        target_states[name] = completed_target_state(
-            job["id"],
-            name,
-            result,
-            target_states.get(name, {}),
-            completed_at=now_iso(),
-        )
-        flush_target_states()
-
-    results = run_target_tasks(tasks, on_target_complete=record_target_completion)
-    return completed_job_result(job, sorted_target_results(results))
 
 
 def save_result(result: dict) -> Path:

--- a/tools/local-ci/test_execution.py
+++ b/tools/local-ci/test_execution.py
@@ -15,13 +15,14 @@ from pathlib import Path
 
 
 MODULE_PATH = Path(__file__).with_name("execution.py")
+QUEUE_MODULE_PATH = Path(__file__).with_name("queue_orchestrator.py")
 MODULE_DIR = MODULE_PATH.parent
 
 
-def load_module():
+def load_module(path: Path = MODULE_PATH, name: str = "pulp_local_ci_execution"):
     sys.path.insert(0, str(MODULE_DIR))
     try:
-        spec = importlib.util.spec_from_file_location("pulp_local_ci_execution", MODULE_PATH)
+        spec = importlib.util.spec_from_file_location(name, path)
         module = importlib.util.module_from_spec(spec)
         assert spec.loader is not None
         spec.loader.exec_module(module)
@@ -33,6 +34,7 @@ def load_module():
 class ExecutionTests(unittest.TestCase):
     def setUp(self) -> None:
         self.mod = load_module()
+        self.queue = load_module(QUEUE_MODULE_PATH, "pulp_local_ci_queue_orchestrator")
 
     def test_parse_progress_marker_detects_progress_contract(self) -> None:
         self.assertEqual(self.mod.parse_progress_marker("__PULP_PHASE__:build\n"), {"phase": "build"})
@@ -419,6 +421,290 @@ class ExecutionTests(unittest.TestCase):
             ),
             [],
         )
+
+    def test_process_job_returns_empty_result_without_target_tasks(self) -> None:
+        job = {
+            "id": "job-empty",
+            "branch": "feature/empty",
+            "sha": "a" * 40,
+            "priority": "low",
+        }
+        messages = []
+        completed = {}
+
+        result = self.mod.process_job(
+            job,
+            {"targets": {}},
+            print_fn=messages.append,
+            short_sha_fn=lambda sha: sha[:12],
+            config_for_job_execution_fn=lambda queued_job, config: {"resolved": config, "job": queued_job["id"]},
+            build_target_tasks_fn=lambda queued_job, config, progress_factory=None: [],
+            target_state_snapshot_fn=lambda states: dict(states),
+            update_runner_active_targets_fn=lambda *_args: self.fail("unexpected runner active-target update"),
+            update_job_active_targets_fn=lambda *_args: self.fail("unexpected job active-target update"),
+            updated_target_state_fn=self.queue.updated_target_state,
+            initial_target_state_fn=lambda job_id, target_name, *, started_at: {
+                "status": "running",
+                "started_at": started_at,
+                "phase": "starting",
+                "log_path": f"{job_id}-{target_name}.log",
+            },
+            completed_target_state_fn=lambda job_id, target_name, result, previous_state, *, completed_at: {
+                **dict(previous_state or {}),
+                "status": result["status"],
+                "exit_code": result["exit_code"],
+                "duration_secs": result["duration_secs"],
+                "completed_at": completed_at,
+                "phase": "done",
+                "log_path": result.get("log_file", f"{job_id}-{target_name}.log"),
+            },
+            now_iso_fn=lambda: "2026-06-10T00:00:00Z",
+            run_target_tasks_fn=lambda *_args, **_kwargs: self.fail("unexpected target runner"),
+            completed_job_result_fn=lambda queued_job, results: completed.setdefault(
+                "result",
+                {"job_id": queued_job["id"], "results": results, "overall": "pass"},
+            ),
+            sorted_target_results_fn=self.mod.sorted_target_results,
+        )
+
+        self.assertEqual(result, {"job_id": "job-empty", "results": [], "overall": "pass"})
+        self.assertEqual(
+            messages,
+            ["\n=== Validating [job-empty] feature/empty @ aaaaaaaaaaaa priority=low ===\n"],
+        )
+        self.assertEqual(completed["result"]["results"], [])
+
+    def test_process_job_tracks_target_progress_and_completion(self) -> None:
+        job = {
+            "id": "job-process",
+            "branch": "feature/process",
+            "sha": "b" * 40,
+            "priority": "normal",
+        }
+        snapshots = []
+        messages = []
+        build_seen = {}
+        now_values = iter(
+            [
+                "2026-06-10T00:00:00Z",
+                "2026-06-10T00:00:01Z",
+            ]
+        )
+
+        def snapshot(states: dict[str, dict]) -> dict[str, dict]:
+            return {target: dict(state) for target, state in states.items()}
+
+        def build_tasks(queued_job: dict, config: dict, progress_factory=None):
+            build_seen["job_id"] = queued_job["id"]
+            build_seen["config"] = config
+            reporter = progress_factory("mac")
+
+            def run_mac() -> dict:
+                reporter(phase="validate", log_path="mac.log", transport_mode="local")
+                return {
+                    "target": "mac",
+                    "status": "pass",
+                    "exit_code": 0,
+                    "duration_secs": 1.0,
+                }
+
+            return [("mac", run_mac)]
+
+        def run_tasks(tasks, *, on_target_complete):
+            results = []
+            for name, task in tasks:
+                result = task()
+                on_target_complete(name, result)
+                results.append(result)
+            return results
+
+        result = self.mod.process_job(
+            job,
+            {"targets": {"mac": {}}},
+            print_fn=messages.append,
+            short_sha_fn=lambda sha: sha[:12],
+            config_for_job_execution_fn=lambda queued_job, config: {"resolved_for": queued_job["id"], **config},
+            build_target_tasks_fn=build_tasks,
+            target_state_snapshot_fn=snapshot,
+            update_runner_active_targets_fn=lambda job_id, states: snapshots.append(("runner", job_id, states)),
+            update_job_active_targets_fn=lambda job_id, states: snapshots.append(("job", job_id, states)),
+            updated_target_state_fn=self.queue.updated_target_state,
+            initial_target_state_fn=lambda job_id, target_name, *, started_at: {
+                "status": "running",
+                "started_at": started_at,
+                "phase": "starting",
+                "log_path": f"{job_id}-{target_name}.log",
+            },
+            completed_target_state_fn=lambda job_id, target_name, result, previous_state, *, completed_at: {
+                **dict(previous_state or {}),
+                "status": result["status"],
+                "exit_code": result["exit_code"],
+                "duration_secs": result["duration_secs"],
+                "completed_at": completed_at,
+                "phase": "done",
+                "log_path": result.get("log_file", f"{job_id}-{target_name}.log"),
+            },
+            now_iso_fn=lambda: next(now_values),
+            run_target_tasks_fn=run_tasks,
+            completed_job_result_fn=lambda queued_job, results: {
+                "job_id": queued_job["id"],
+                "results": results,
+                "overall": "pass" if all(result["status"] == "pass" for result in results) else "fail",
+            },
+            sorted_target_results_fn=self.mod.sorted_target_results,
+        )
+
+        self.assertEqual(build_seen["job_id"], "job-process")
+        self.assertEqual(build_seen["config"]["resolved_for"], "job-process")
+        self.assertEqual(result["overall"], "pass")
+        self.assertEqual(result["results"], [{"target": "mac", "status": "pass", "exit_code": 0, "duration_secs": 1.0}])
+        self.assertEqual(len(snapshots), 6)
+        initial_state = snapshots[0][2]["mac"]
+        progress_state = snapshots[2][2]["mac"]
+        completed_state = snapshots[4][2]["mac"]
+        self.assertEqual(snapshots[0][0], "runner")
+        self.assertEqual(snapshots[1][0], "job")
+        self.assertEqual(initial_state["status"], "running")
+        self.assertEqual(initial_state["started_at"], "2026-06-10T00:00:00Z")
+        self.assertEqual(progress_state["phase"], "validate")
+        self.assertEqual(progress_state["log_path"], "mac.log")
+        self.assertEqual(completed_state["status"], "pass")
+        self.assertEqual(completed_state["completed_at"], "2026-06-10T00:00:01Z")
+
+    def test_process_job_keeps_multi_target_snapshots_consistent_when_completion_order_varies(self) -> None:
+        job = {
+            "id": "job-multi",
+            "branch": "feature/multi",
+            "sha": "c" * 40,
+            "priority": "normal",
+        }
+        snapshots = []
+        now_values = iter(
+            [
+                "2026-06-10T00:00:00Z",
+                "2026-06-10T00:00:01Z",
+                "2026-06-10T00:00:02Z",
+                "2026-06-10T00:00:03Z",
+                "2026-06-10T00:00:04Z",
+                "2026-06-10T00:00:05Z",
+            ]
+        )
+
+        def initial_state(job_id: str, target_name: str, *, started_at: str) -> dict:
+            return {
+                "status": "running",
+                "started_at": started_at,
+                "phase": "starting",
+                "log_path": f"{job_id}-{target_name}.log",
+            }
+
+        def completed_state(
+            job_id: str,
+            target_name: str,
+            result: dict,
+            previous_state: dict | None,
+            *,
+            completed_at: str,
+        ) -> dict:
+            return {
+                **dict(previous_state or {}),
+                "status": result["status"],
+                "exit_code": result["exit_code"],
+                "duration_secs": result["duration_secs"],
+                "completed_at": completed_at,
+                "phase": "done",
+                "log_path": result.get("log_file", f"{job_id}-{target_name}.log"),
+                "transport_mode": result.get("transport_mode", (previous_state or {}).get("transport_mode")),
+            }
+
+        def snapshot(states: dict[str, dict]) -> dict[str, dict]:
+            return {target: dict(state) for target, state in states.items()}
+
+        def record_snapshot(kind: str, job_id: str, states: dict[str, dict]) -> None:
+            snapshots.append((kind, job_id, snapshot(states)))
+
+        reporters = {}
+
+        def build_tasks(_queued_job: dict, _config: dict, progress_factory=None):
+            def make_task(target: str, status: str, transport_mode: str):
+                reporter = progress_factory(target)
+                reporters[target] = reporter
+
+                def run_target() -> dict:
+                    reporter(phase=f"validate-{target}", log_path=f"{target}.log", transport_mode=transport_mode)
+                    return {
+                        "target": target,
+                        "status": status,
+                        "exit_code": 0 if status == "pass" else 1,
+                        "duration_secs": {"mac": 1.0, "ubuntu": 2.0, "windows": 3.0}[target],
+                        "log_file": f"{target}.log",
+                        "transport_mode": transport_mode,
+                    }
+
+                return run_target
+
+            return [
+                ("mac", make_task("mac", "pass", "local")),
+                ("ubuntu", make_task("ubuntu", "fail", "bundle")),
+                ("windows", make_task("windows", "pass", "bundle")),
+            ]
+
+        def run_tasks(tasks, *, on_target_complete):
+            by_name = dict(tasks)
+            results = []
+            for name in ["windows", "mac", "ubuntu"]:
+                result = by_name[name]()
+                on_target_complete(name, result)
+                results.append(result)
+            return results
+
+        result = self.mod.process_job(
+            job,
+            {"targets": {"mac": {}, "ubuntu": {}, "windows": {}}},
+            print_fn=lambda _message: None,
+            short_sha_fn=lambda sha: sha[:12],
+            config_for_job_execution_fn=lambda _queued_job, config: config,
+            build_target_tasks_fn=build_tasks,
+            target_state_snapshot_fn=snapshot,
+            update_runner_active_targets_fn=lambda job_id, states: record_snapshot("runner", job_id, states),
+            update_job_active_targets_fn=lambda job_id, states: record_snapshot("job", job_id, states),
+            updated_target_state_fn=self.queue.updated_target_state,
+            initial_target_state_fn=initial_state,
+            completed_target_state_fn=completed_state,
+            now_iso_fn=lambda: next(now_values),
+            run_target_tasks_fn=run_tasks,
+            completed_job_result_fn=lambda queued_job, results: {
+                "job_id": queued_job["id"],
+                "results": results,
+                "overall": "pass" if all(item["status"] == "pass" for item in results) else "fail",
+            },
+            sorted_target_results_fn=self.mod.sorted_target_results,
+        )
+
+        self.assertEqual([item["target"] for item in result["results"]], ["mac", "ubuntu", "windows"])
+        self.assertEqual(result["overall"], "fail")
+        self.assertEqual(len(snapshots), 14)
+        for index in range(0, len(snapshots), 2):
+            runner = snapshots[index]
+            queued_job = snapshots[index + 1]
+            self.assertEqual(runner[0], "runner")
+            self.assertEqual(queued_job[0], "job")
+            self.assertEqual(runner[1], "job-multi")
+            self.assertEqual(queued_job[1], "job-multi")
+            self.assertEqual(runner[2], queued_job[2])
+
+        initial_snapshot = snapshots[0][2]
+        self.assertEqual(set(initial_snapshot), {"mac", "ubuntu", "windows"})
+        self.assertTrue(all(state["status"] == "running" for state in initial_snapshot.values()))
+        windows_done_snapshot = snapshots[4][2]
+        self.assertEqual(windows_done_snapshot["windows"]["status"], "pass")
+        self.assertEqual(windows_done_snapshot["mac"]["status"], "running")
+        self.assertEqual(windows_done_snapshot["ubuntu"]["status"], "running")
+        final_snapshot = snapshots[-2][2]
+        self.assertEqual(final_snapshot["mac"]["status"], "pass")
+        self.assertEqual(final_snapshot["ubuntu"]["status"], "fail")
+        self.assertEqual(final_snapshot["windows"]["status"], "pass")
+        self.assertEqual(final_snapshot["ubuntu"]["completed_at"], "2026-06-10T00:00:05Z")
 
     def test_local_validation_command_builds_full_and_smoke_commands(self) -> None:
         full_cmd, full_validation = self.mod.local_validation_command(


### PR DESCRIPTION
## Summary
- move process_job target orchestration into execution.py behind injected persistence/status helpers
- keep local_ci.py as the stable wrapper so existing monkeypatch-style tests still patch local_ci functions
- add direct execution tests for empty, single-target, and multi-target progress/completion ordering
- update MODULE_MAP.md to record cross-target validation/status orchestration ownership

## Validation
- python3 -m py_compile tools/local-ci/local_ci.py tools/local-ci/execution.py tools/local-ci/test_execution.py
- python3 tools/local-ci/test_execution.py
- python3 tools/local-ci/test_local_ci.py -k process_job
- python3 -m unittest discover -s tools/local-ci -p 'test_*.py'
- python3 tools/import-validation/check-source-contracts.py --strict
- python3 tools/import-validation/test_source_contracts.py
- PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat
- python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce
- git diff --check HEAD

## Local review
- /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --prompt 'Review this local-ci refactor as an adversarial diff review...'
- Result: clean; no accepted/actionable findings