### PR TITLE
ci(release): fail loud when a release binary is missing before strip

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -391,6 +391,15 @@ jobs:
         # MCP launcher can resolve it on $PATH after install.
         run: |
           for bin in build/pulp build/tools/cli/pulp-cpp build/tools/mcp/pulp-mcp; do
+            # Fail LOUD if a binary is missing. The strip itself is best-effort
+            # on macOS (below), which would otherwise SILENTLY swallow an
+            # absent binary — exactly how a skipped Rust `build/pulp` target hid
+            # until package_cli.py reported it a step later (2026-06-10). Catch
+            # it here with a clear message instead.
+            if [ ! -f "$bin" ]; then
+              echo "::error::expected release binary '$bin' is missing — the build did not produce it (e.g. 'build/pulp' means the Rust CLI target was skipped, usually a missing/broken cargo). Refusing to package an incomplete tarball." >&2
+              exit 1
+            fi
             if [ "${RUNNER_OS}" = "macOS" ]; then
               strip -x "$bin" 2>/dev/null || strip "$bin" 2>/dev/null || \
                 echo "note: strip skipped for $bin (non-fatal)"


### PR DESCRIPTION
Adversarial-review follow-up. The macOS strip step is best-effort to tolerate the ad-hoc-signature quirk, but that silently swallowed an absent binary — how a skipped Rust build/pulp hid this session until package_cli.py caught it a step later. Add a [ -f $bin ] guard that fails with a clear ::error:: naming the missing binary. package_cli.py stays the backstop.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail fast in the release workflow if any expected binary is missing before the strip step. This surfaces skipped builds early and prevents packaging incomplete artifacts.

- **Bug Fixes**
  - Added `[ -f "$bin" ]` check for `build/pulp`, `build/tools/cli/pulp-cpp`, and `build/tools/mcp/pulp-mcp`; on missing file, emit `::error::` with the path and exit 1.
  - Kept macOS `strip` as best-effort; `package_cli.py` remains the backstop.

<sup>Written for commit 467e49a67f0e437b3c44c730dd21a0b03ff0b4fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

