### PR TITLE
fix(release): guard codesign discovery; document coverage-watchdog proxy limit

### DIFF
--- a/.github/workflows/coverage-staleness-check.yml
+++ b/.github/workflows/coverage-staleness-check.yml
@@ -17,6 +17,18 @@ name: Coverage staleness check
 # issue. It does NOT inspect Codecov directly (no API token needed); a green
 # main coverage run is the proxy for "the dashboard got fresh C++ data."
 #
+# PROXY LIMITATION (deliberate): coverage.yml's per-OS Codecov upload steps run
+# `if: always()` with `fail_ci_if_error: false`, and the matrix is
+# `fail-fast: false`, so a run can conclude SUCCESS while one OS leg's upload
+# silently failed. This watchdog therefore catches the failure mode that
+# actually bit us — runs never COMPLETING on main (superseded/cancelled, the
+# 2026-05/06 incident) — but NOT a completed-but-upload-dropped run. Detecting
+# the latter would require querying Codecov's API for per-flag freshness (a
+# token + scope we intentionally avoid here); a dropped upload also self-heals
+# on the next 8h scheduled refresh. If false-green ever becomes a real problem,
+# the right fix is a separate Codecov-API freshness probe, not flipping
+# fail_ci_if_error (which would make coverage red on transient Codecov outages).
+#
 # Closes automatically on the next sweep once a fresh success exists.
 
 on:

--- a/tools/scripts/package_cli.py
+++ b/tools/scripts/package_cli.py
@@ -186,7 +186,14 @@ def fix_rpath_macos(binary: Path) -> None:
     # Linux-hosted darwin cross-build can point at the llvm/cctools
     # equivalent; skip with a clear note when no codesign tool is available.
     codesign = os.environ.get("CODESIGN", "codesign")
-    if shutil.which(codesign) or os.path.isabs(codesign):
+    # shutil.which() resolves both a bare command on PATH AND an absolute path
+    # (returning None if that absolute path doesn't exist or isn't executable),
+    # so it is the complete guard. A prior `or os.path.isabs(codesign)` made a
+    # NON-EXISTENT absolute CODESIGN look usable, then `subprocess.run(...,
+    # check=False)` raised an uncaught FileNotFoundError (check=False suppresses
+    # only non-zero exits, not a missing executable) — crashing the packager
+    # instead of taking the intended skip-with-note path.
+    if shutil.which(codesign):
         print("  re-signing (ad-hoc) after rpath rewrite", flush=True)
         subprocess.run(
             [codesign, "--force", "--sign", "-", str(binary)],


### PR DESCRIPTION
Two adversarial-review follow-ups (this session's CI sweep, both flagged MED by independent reviewers):

1. **package_cli.py codesign guard** — `shutil.which(codesign) or os.path.isabs(codesign)` crashed the packager with an uncaught FileNotFoundError when $CODESIGN was a non-existent absolute path (check=False suppresses non-zero exits, not a missing executable). shutil.which() already resolves absolute paths, so the `or os.path.isabs` was both redundant and the bug.
2. **coverage-staleness-check.yml** — document the deliberate proxy limitation: a green coverage run can still have a silently-dropped per-OS Codecov upload (fail_ci_if_error:false). The watchdog catches the real incident (runs never completing); upload-drop would need a Codecov-API probe (out of scope, self-heals on next refresh).