### PR TITLE
fix(release): fail the build if codesign re-sign fails (don't lean on the smoke gate)

### DIFF
--- a/tools/scripts/package_cli.py
+++ b/tools/scripts/package_cli.py
@@ -195,10 +195,21 @@ def fix_rpath_macos(binary: Path) -> None:
     # instead of taking the intended skip-with-note path.
     if shutil.which(codesign):
         print("  re-signing (ad-hoc) after rpath rewrite", flush=True)
-        subprocess.run(
-            [codesign, "--force", "--sign", "-", str(binary)],
-            check=False,
-        )
+        result = subprocess.run(
+            [codesign, "--force", "--sign", "-", str(binary)])
+        if result.returncode != 0:
+            # FATAL, not swallowed. When codesign IS available the ad-hoc
+            # re-sign is expected to succeed; a failure leaves the binary with
+            # the install_name_tool-invalidated signature, which is SIGKILL'd on
+            # launch (Apple Silicon today, and any future non-arm64 darwin lane
+            # where the downstream `pulp help` smoke gate would NOT catch it —
+            # the gate only reproduces SIGKILL on arm64). Fail here so a broken,
+            # unsigned release binary can never ship regardless of the smoke
+            # lane's architecture.
+            raise SystemExit(
+                f"FAIL: codesign re-sign of {binary} failed "
+                f"(exit {result.returncode}); refusing to ship a binary that "
+                "will be SIGKILL'd on launch.")
     else:
         print(f"  note: '{codesign}' not found — skipping ad-hoc re-sign; "
               "the binary may be SIGKILL'd on Apple Silicon", flush=True)


### PR DESCRIPTION
Adversarial-review defense-in-depth. The codesign re-sign in package_cli.py used check=False, swallowing a real signing failure that was only caught by the arm64 SIGKILL smoke gate — load-bearing protection that wouldn't catch it on a non-arm64 darwin lane. Make it FATAL when codesign is present (ad-hoc signing doesn't spuriously fail, so zero-risk). Pulp ships no darwin-x64 today, so this is hardening, not a live bug. The codesign-not-found cross-build branch is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail the build if macOS ad-hoc re-sign with `codesign` fails during the rpath fix in `tools/scripts/package_cli.py`. This prevents shipping a SIGKILL-bound binary and removes reliance on the arm64 smoke gate; behavior is unchanged when `codesign` is not found.

<sup>Written for commit a1da1170155c6d3b5005c682506e31b1739513b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

