### PR TITLE
refactor(local-ci): extract desktop doctor probes

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1773,6 +1773,10 @@ preflight, source-prep, cleanup, and artifact-publishing contracts.
   normalization, latest passing target records, evidence index persistence,
   branch/SHA grouping, and evidence summaries. Queue mutation, runner state,
   result creation, and target execution stay out of this module.
+- `desktop_doctor.py` — owns desktop automation capability derivation,
+  writable-artifact checks, WebDriver status probing, and doctor-check
+  assembly. Keep CLI output formatting, desktop action execution, artifact
+  persistence, and launch-adapter orchestration outside this module.
 
 All original symbols are re-exported from `local_ci.py`, so any old
 `mod.state_dir()` / `mod.normalize_priority()` / `mod.current_sha()` /

--- a/tools/local-ci/MODULE_MAP.md
+++ b/tools/local-ci/MODULE_MAP.md
@@ -22,6 +22,7 @@ and the matching contract tests in the same change.
 | `ssh_bundle.py` | Git bundle naming, local bundle creation, and SSH upload/progress/probe mechanics. | Target validation execution or queue orchestration. |
 | `cleanup.py` | Local-CI artifact cleanup planning/deletion, cleanup-plan line fragments, and stale Windows validator cleanup mechanics. | Lock acquisition, runner ownership, or user-facing cleanup command ordering/output side effects. |
 | `desktop_artifacts.py` | Desktop automation artifact roots and run/publish bundle directory layout. | Report staging, rollup generation, pruning policy, or target execution. |
+| `desktop_doctor.py` | Desktop automation capability derivation, writable-artifact checks, WebDriver status probing, and desktop doctor check assembly. | CLI output formatting, desktop action execution, artifact/report persistence, or launch adapter orchestration. |
 | `reporting.py` | Desktop automation report staging, run/publish rollups, manifest scanning, proof summaries, and pruning selection. | Artifact directory layout, target execution, source preparation, or CLI output. |
 | `source_prep.py` | Exact-SHA desktop source requests, cache keys, launch-command rewriting, prepare manifests, and macOS/Linux/Windows prepared source materialization. | Desktop artifact layout, target execution, queue orchestration, or target probes. |
 | `target_preflight.py` | SSH primary/fallback/UTM/Namespace failover checks, material config drift detection, and submission metadata formatting. | Queue mutation, target validation execution, or desktop automation adapters. |
@@ -42,7 +43,7 @@ behind the contracts added in this slice.
 
 | Cluster | Current responsibility | Extraction target |
 | --- | --- | --- |
-| Desktop target probes | Desktop doctor orchestration, launch adapters, and automation adapters. | later `execution.py` |
+| Desktop action orchestration | Launch adapters, local/remote automation adapters, and desktop action command execution. | later desktop automation module |
 | Queue orchestration | Remaining runner-state wrapper calls and other CLI-facing queue updates. | later queue modules |
 | Validation execution | Thin wrapper calls in `local_ci.py` plus any future execution-specific seams discovered while reducing the entrypoint. | `execution.py` |
 | CLI dispatch | Argument parser, subcommand routing, and user-facing command output. | `cli.py` or retained thin entrypoint |

--- a/tools/local-ci/desktop_doctor.py
+++ b/tools/local-ci/desktop_doctor.py
@@ -1,0 +1,386 @@
+"""Desktop automation doctor and optional probe helpers for local CI."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+
+import linux_target
+from normalize import normalize_desktop_optional_config
+import windows_target
+
+
+def desktop_optional_capabilities(optional_cfg: dict | None) -> list[str]:
+    optional = normalize_desktop_optional_config(optional_cfg)
+    caps: list[str] = []
+    if optional.get("webview_driver"):
+        caps.extend(["webview_dom", "semantic_click", "semantic_type", "script_eval", "element_screenshot"])
+    if optional.get("debug_attach"):
+        caps.extend(["debug_attach", "debug_command"])
+    if optional.get("video_capture"):
+        caps.append("video_capture")
+    if optional.get("frame_stats"):
+        caps.append("frame_stats")
+    return caps
+
+
+def desktop_capabilities_for(adapter: str, tier: str, optional_cfg: dict | None = None) -> list[str]:
+    base = ["launch_app", "wait_ready", "window_screenshot", "collect_logs", "crash_artifacts"]
+    if tier in {"v2", "v3"}:
+        if adapter == "linux-xvfb":
+            base.extend(["coordinate_click", "before_after_capture", "image_diff"])
+        else:
+            base.extend(["ui_snapshot", "coordinate_click", "view_target_click", "before_after_capture", "image_diff"])
+            if adapter in {"macos-local", "windows-session-agent"}:
+                base.append("pulp_app_automation")
+    if tier == "v3":
+        base.extend(["type_text", "wheel", "desktop_screenshot", "record_video", "debug_attach"])
+    base.extend(desktop_optional_capabilities(optional_cfg))
+    return list(dict.fromkeys(base))
+
+
+def desktop_check(name: str, ok: bool, detail: str, *, required: bool = True) -> dict:
+    return {"name": name, "ok": ok, "detail": detail, "required": required}
+
+
+def check_writable_dir(path: Path) -> tuple[bool, str]:
+    probe = None
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        probe = path / f".write-check-{uuid.uuid4().hex}"
+        probe.write_text("ok\n")
+        return True, str(path)
+    except OSError as exc:
+        return False, str(exc)
+    finally:
+        if probe is not None:
+            try:
+                probe.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def desktop_doctor_checks(
+    config: dict,
+    target_name: str,
+    *,
+    resolve_desktop_target_fn: Callable[[dict, str], dict],
+    desktop_target_contract_fn: Callable[[str, dict], dict],
+    desktop_receipt_for_fn: Callable[[str], dict | None],
+    macos_accessibility_trusted_fn: Callable[[], bool],
+    ssh_reachable_fn: Callable[[str, int], bool],
+    ssh_failure_detail_fn: Callable[[str, int], str],
+    probe_linux_launch_backend_fn: Callable[[str], dict],
+    probe_linux_remote_tooling_fn: Callable[[str], dict],
+    probe_windows_session_agent_fn: Callable[[str, dict], dict],
+    probe_windows_remote_tooling_fn: Callable[[str], dict],
+    probe_windows_repo_checkout_fn: Callable[[str, str | None], dict],
+    platform: str | None = None,
+    which_fn: Callable[[str], str | None] | None = None,
+    probe_webdriver_endpoint_fn: Callable[..., dict] | None = None,
+) -> list[dict]:
+    platform = platform or sys.platform
+    which_fn = which_fn or shutil.which
+    desktop_cfg = config["desktop_automation"]
+    target = resolve_desktop_target_fn(config, target_name)
+    contract = desktop_target_contract_fn(target_name, target)
+    checks: list[dict] = []
+
+    ok, detail = check_writable_dir(Path(desktop_cfg["artifact_root"]))
+    checks.append(desktop_check("artifact_root", ok, detail))
+
+    receipt = desktop_receipt_for_fn(target_name)
+    checks.append(
+        desktop_check(
+            "receipt",
+            receipt is not None,
+            "installed" if receipt else f"not installed; run `pulp ci-local desktop install {target_name}`",
+        )
+    )
+
+    adapter = target["adapter"]
+    if adapter == "macos-local":
+        checks.append(desktop_check("platform", platform == "darwin", f"running on {platform}"))
+        checks.append(
+            desktop_check(
+                "screencapture",
+                which_fn("screencapture") is not None,
+                which_fn("screencapture") or "missing",
+            )
+        )
+        checks.append(
+            desktop_check(
+                "osascript",
+                which_fn("osascript") is not None,
+                which_fn("osascript") or "missing",
+            )
+        )
+        try:
+            trusted = macos_accessibility_trusted_fn()
+            checks.append(
+                desktop_check(
+                    "accessibility",
+                    trusted,
+                    "trusted" if trusted else "not trusted; desktop-event click is unavailable but Pulp app automation still works",
+                    required=False,
+                )
+            )
+        except (subprocess.SubprocessError, json.JSONDecodeError) as exc:
+            checks.append(desktop_check("accessibility", False, str(exc), required=False))
+    elif target["target_type"] == "ssh":
+        host = target.get("host")
+        checks.append(desktop_check("host", bool(host), host or "missing"))
+        ssh_ok = False
+        if host:
+            ssh_ok = ssh_reachable_fn(host, 5)
+            ssh_detail = host if ssh_ok else ssh_failure_detail_fn(host, 5)
+            checks.append(desktop_check("ssh", ssh_ok, ssh_detail))
+            if ssh_ok and adapter == "linux-xvfb":
+                try:
+                    backend = probe_linux_launch_backend_fn(host)
+                    if backend.get("mode") == "xvfb":
+                        detail = backend.get("path") or "xvfb-run"
+                    elif backend.get("mode") == "display":
+                        detail = f"existing display {backend.get('display') or ':0'}"
+                    else:
+                        detail = "missing; install xvfb and xauth (for example: sudo apt-get install xvfb xauth)"
+                    checks.append(desktop_check("launch_backend", backend.get("mode") != "missing", detail))
+                except (subprocess.SubprocessError, OSError, RuntimeError) as exc:
+                    checks.append(desktop_check("launch_backend", False, str(exc)))
+                try:
+                    tooling = probe_linux_remote_tooling_fn(host)
+                    for tool_name, spec in linux_target.LINUX_REQUIRED_REMOTE_TOOLS.items():
+                        checks.append(
+                            desktop_check(
+                                spec["display_name"],
+                                bool(tooling.get(f"{tool_name}_found")),
+                                linux_target.linux_tooling_detail(tooling, tool_name, missing_hint=f"missing; {spec['package_hint']}"),
+                            )
+                        )
+                    for tool_name, spec in linux_target.LINUX_OPTIONAL_REMOTE_TOOLS.items():
+                        checks.append(
+                            desktop_check(
+                                spec["display_name"],
+                                bool(tooling.get(f"{tool_name}_found")),
+                                linux_target.linux_tooling_detail(tooling, tool_name, missing_hint=f"missing; {spec['package_hint']}"),
+                                required=False,
+                            )
+                        )
+                except (subprocess.SubprocessError, OSError, RuntimeError) as exc:
+                    checks.append(desktop_check("remote_tooling", False, str(exc)))
+            if ssh_ok and adapter == "windows-session-agent":
+                bootstrap_required = bool(receipt and receipt.get("remote_bootstrap_ready"))
+                checks.append(desktop_check("task_name", bool(contract.get("task_name")), contract.get("task_name") or "missing", required=False))
+                try:
+                    probe = probe_windows_session_agent_fn(host, contract)
+                    checks.append(
+                        desktop_check(
+                            "scheduled_task",
+                            bool(probe.get("task_present")),
+                            f"{probe.get('task_name') or contract.get('task_name')} ({probe.get('task_state') or 'missing'})",
+                            required=bootstrap_required,
+                        )
+                    )
+                    desktop_session_user = windows_target.windows_desktop_session_user(probe)
+                    desktop_session_state = windows_target.windows_desktop_session_state(probe)
+                    if desktop_session_user:
+                        session_detail = desktop_session_user
+                        if desktop_session_state:
+                            session_detail = f"{session_detail} ({desktop_session_state})"
+                    else:
+                        session_detail = "no logged-in desktop session detected; log into the Windows desktop, then retry"
+                    checks.append(desktop_check("interactive_user", bool(desktop_session_user), session_detail, required=False))
+                    checks.append(desktop_check("agent_root", bool(probe.get("agent_root_exists")), probe.get("remote_root") or contract.get("remote_root") or "missing", required=bootstrap_required))
+                    checks.append(desktop_check("jobs_dir", bool(probe.get("jobs_dir_exists")), probe.get("jobs_dir") or "missing", required=bootstrap_required))
+                    checks.append(desktop_check("results_dir", bool(probe.get("results_dir_exists")), probe.get("results_dir") or "missing", required=bootstrap_required))
+                    checks.append(desktop_check("script_path", bool(probe.get("script_exists")), probe.get("script_path") or contract.get("script_path") or "missing", required=bootstrap_required))
+                    tooling = probe_windows_remote_tooling_fn(host)
+                    checks.append(
+                        desktop_check(
+                            "git",
+                            bool(tooling.get("git_found")),
+                            windows_target.windows_tooling_detail(
+                                tooling,
+                                "git",
+                                missing_hint="missing; `desktop install windows` will provision Git via winget when available",
+                            ),
+                        )
+                    )
+                    checks.append(
+                        desktop_check(
+                            "winget",
+                            bool(tooling.get("winget_found")),
+                            windows_target.windows_tooling_detail(
+                                tooling,
+                                "winget",
+                                missing_hint="missing; install App Installer/winget or install Git manually",
+                            ),
+                            required=False,
+                        )
+                    )
+                    checks.append(
+                        desktop_check(
+                            "gh",
+                            bool(tooling.get("gh_found")),
+                            windows_target.windows_tooling_detail(
+                                tooling,
+                                "gh",
+                                missing_hint="missing; optional for remote GitHub workflows on the Windows target",
+                            ),
+                            required=False,
+                        )
+                    )
+                    gh_auth_ready = tooling.get("gh_auth_ready")
+                    if tooling.get("gh_found"):
+                        auth_detail = tooling.get("gh_auth_detail") or "authenticated"
+                    else:
+                        auth_detail = "not applicable until gh is installed"
+                    checks.append(
+                        desktop_check(
+                            "gh_auth",
+                            bool(gh_auth_ready) if gh_auth_ready is not None else False,
+                            auth_detail,
+                            required=False,
+                        )
+                    )
+                    try:
+                        repo_probe = probe_windows_repo_checkout_fn(host, target.get("repo_path"))
+                        repo_ready = windows_target.windows_repo_checkout_ready(repo_probe)
+                        repo_detail = windows_target.windows_repo_checkout_detail(repo_probe, fallback_path=target.get("repo_path"))
+                        if repo_probe.get("repo_path_unsafe"):
+                            repo_detail = f"{repo_detail}; unsafe repo root, run `pulp ci-local desktop install {target_name}`"
+                        checks.append(
+                            desktop_check(
+                                "repo_checkout",
+                                repo_ready,
+                                repo_detail,
+                                required=bootstrap_required,
+                            )
+                        )
+                    except (subprocess.SubprocessError, OSError, RuntimeError) as exc:
+                        checks.append(desktop_check("repo_checkout", False, str(exc), required=bootstrap_required))
+                except (subprocess.SubprocessError, OSError, RuntimeError) as exc:
+                    checks.append(desktop_check("scheduled_task", False, str(exc), required=bootstrap_required))
+        checks.append(desktop_check("bootstrap", True, target.get("bootstrap", "manual")))
+    else:
+        checks.append(desktop_check("adapter", adapter != "unknown", adapter))
+
+    probe_webdriver_endpoint_fn = probe_webdriver_endpoint_fn or probe_webdriver_endpoint
+    optional = normalize_desktop_optional_config(target.get("optional"))
+    if optional.get("webview_driver"):
+        webdriver_url = optional.get("webdriver_url")
+        if not webdriver_url:
+            checks.append(desktop_check("webview_driver", False, "enabled but webdriver_url is not set", required=False))
+        else:
+            try:
+                probe = probe_webdriver_endpoint_fn(webdriver_url)
+                ready = probe.get("ready")
+                ready_text = "" if ready is None else f" (ready={str(ready).lower()})"
+                message = probe.get("message")
+                detail = f"reachable at {probe['status_url']}{ready_text}"
+                if message:
+                    detail = f"{detail}: {message}"
+                checks.append(desktop_check("webview_driver", ready is not False, detail, required=False))
+            except (RuntimeError, ValueError) as exc:
+                checks.append(desktop_check("webview_driver", False, str(exc), required=False))
+    if optional.get("debug_attach"):
+        debugger_command = optional.get("debugger_command")
+        if target["target_type"] == "local":
+            debugger = debugger_command or "lldb"
+            debugger_path = which_fn(debugger)
+            checks.append(
+                desktop_check(
+                    "debug_attach",
+                    debugger_path is not None,
+                    debugger_path or f"{debugger} not found on PATH",
+                    required=False,
+                )
+            )
+        else:
+            detail = debugger_command or "enabled; remote debugger validation deferred to target tooling"
+            checks.append(desktop_check("debug_attach", True, detail, required=False))
+    if optional.get("video_capture"):
+        if target["target_type"] == "local":
+            ffmpeg_path = which_fn("ffmpeg")
+            checks.append(
+                desktop_check(
+                    "video_capture",
+                    ffmpeg_path is not None,
+                    ffmpeg_path or "ffmpeg not found on PATH",
+                    required=False,
+                )
+            )
+        else:
+            checks.append(
+                desktop_check(
+                    "video_capture",
+                    True,
+                    "enabled; remote video tooling validation deferred to target tooling",
+                    required=False,
+                )
+            )
+    if optional.get("frame_stats"):
+        checks.append(desktop_check("frame_stats", True, "enabled", required=False))
+
+    return checks
+
+
+def webdriver_status_url(base_url: str) -> str:
+    parsed = urllib.parse.urlparse((base_url or "").strip())
+    if not parsed.scheme or not parsed.netloc:
+        raise ValueError("webdriver_url must include a scheme and host, for example http://127.0.0.1:4444")
+    path = parsed.path or ""
+    if not path or path == "/":
+        path = "/status"
+    elif not path.rstrip("/").endswith("/status"):
+        path = f"{path.rstrip('/')}/status"
+    return urllib.parse.urlunparse(parsed._replace(path=path, params="", query="", fragment=""))
+
+
+def probe_webdriver_endpoint(
+    base_url: str,
+    *,
+    timeout: float = 5.0,
+    request_cls: Callable[..., urllib.request.Request] | None = None,
+    urlopen_fn: Callable[..., object] | None = None,
+) -> dict:
+    request_cls = request_cls or urllib.request.Request
+    urlopen_fn = urlopen_fn or urllib.request.urlopen
+    status_url = webdriver_status_url(base_url)
+    request = request_cls(status_url, headers={"Accept": "application/json"})
+    try:
+        with urlopen_fn(request, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8") or "{}")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace").strip()
+        detail = f"HTTP {exc.code}"
+        if body:
+            detail = f"{detail}: {body[:200]}"
+        raise RuntimeError(detail) from exc
+    except urllib.error.URLError as exc:
+        reason = getattr(exc, "reason", exc)
+        raise RuntimeError(str(reason)) from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"invalid JSON response: {exc}") from exc
+
+    value = payload.get("value") if isinstance(payload, dict) else None
+    if isinstance(value, dict):
+        ready = value.get("ready")
+        message = value.get("message")
+    else:
+        ready = payload.get("ready") if isinstance(payload, dict) else None
+        message = payload.get("message") if isinstance(payload, dict) else None
+    return {
+        "status_url": status_url,
+        "ready": ready,
+        "message": str(message).strip() if message is not None else "",
+        "payload": payload,
+    }

--- a/tools/local-ci/local_ci.py
+++ b/tools/local-ci/local_ci.py
@@ -144,6 +144,7 @@ from footprint import (  # noqa: E402  -- re-exported for in-file consumers
 
 import cleanup as _cleanup  # noqa: E402
 import desktop_artifacts as _desktop_artifacts  # noqa: E402
+import desktop_doctor as _desktop_doctor  # noqa: E402
 import linux_target as _linux_target  # noqa: E402
 import macos_desktop as _macos_desktop  # noqa: E402
 import queue_lifecycle as _queue_lifecycle  # noqa: E402
@@ -628,53 +629,19 @@ def resolve_desktop_target(config: dict, target_name: str) -> dict:
 
 
 def desktop_optional_capabilities(optional_cfg: dict | None) -> list[str]:
-    optional = normalize_desktop_optional_config(optional_cfg)
-    caps: list[str] = []
-    if optional.get("webview_driver"):
-        caps.extend(["webview_dom", "semantic_click", "semantic_type", "script_eval", "element_screenshot"])
-    if optional.get("debug_attach"):
-        caps.extend(["debug_attach", "debug_command"])
-    if optional.get("video_capture"):
-        caps.append("video_capture")
-    if optional.get("frame_stats"):
-        caps.append("frame_stats")
-    return caps
+    return _desktop_doctor.desktop_optional_capabilities(optional_cfg)
 
 
 def desktop_capabilities_for(adapter: str, tier: str, optional_cfg: dict | None = None) -> list[str]:
-    base = ["launch_app", "wait_ready", "window_screenshot", "collect_logs", "crash_artifacts"]
-    if tier in {"v2", "v3"}:
-        if adapter == "linux-xvfb":
-            base.extend(["coordinate_click", "before_after_capture", "image_diff"])
-        else:
-            base.extend(["ui_snapshot", "coordinate_click", "view_target_click", "before_after_capture", "image_diff"])
-            if adapter in {"macos-local", "windows-session-agent"}:
-                base.append("pulp_app_automation")
-    if tier == "v3":
-        base.extend(["type_text", "wheel", "desktop_screenshot", "record_video", "debug_attach"])
-    base.extend(desktop_optional_capabilities(optional_cfg))
-    return list(dict.fromkeys(base))
+    return _desktop_doctor.desktop_capabilities_for(adapter, tier, optional_cfg)
 
 
 def _desktop_check(name: str, ok: bool, detail: str, *, required: bool = True) -> dict:
-    return {"name": name, "ok": ok, "detail": detail, "required": required}
+    return _desktop_doctor.desktop_check(name, ok, detail, required=required)
 
 
 def _check_writable_dir(path: Path) -> tuple[bool, str]:
-    probe = None
-    try:
-        path.mkdir(parents=True, exist_ok=True)
-        probe = path / f".write-check-{uuid.uuid4().hex}"
-        probe.write_text("ok\n")
-        return True, str(path)
-    except OSError as exc:
-        return False, str(exc)
-    finally:
-        if probe is not None:
-            try:
-                probe.unlink(missing_ok=True)
-            except OSError:
-                pass
+    return _desktop_doctor.check_writable_dir(path)
 
 
 def probe_windows_session_agent(host: str, contract: dict) -> dict:
@@ -726,292 +693,37 @@ def windows_remote_tooling_ready(probe: dict) -> bool:
 
 
 def desktop_doctor_checks(config: dict, target_name: str) -> list[dict]:
-    desktop_cfg = config["desktop_automation"]
-    target = resolve_desktop_target(config, target_name)
-    contract = desktop_target_contract(target_name, target)
-    checks: list[dict] = []
-
-    ok, detail = _check_writable_dir(Path(desktop_cfg["artifact_root"]))
-    checks.append(_desktop_check("artifact_root", ok, detail))
-
-    receipt = desktop_receipt_for(target_name)
-    checks.append(
-        _desktop_check(
-            "receipt",
-            receipt is not None,
-            "installed" if receipt else f"not installed; run `pulp ci-local desktop install {target_name}`",
-        )
+    return _desktop_doctor.desktop_doctor_checks(
+        config,
+        target_name,
+        resolve_desktop_target_fn=resolve_desktop_target,
+        desktop_target_contract_fn=desktop_target_contract,
+        desktop_receipt_for_fn=desktop_receipt_for,
+        macos_accessibility_trusted_fn=macos_accessibility_trusted,
+        ssh_reachable_fn=ssh_reachable,
+        ssh_failure_detail_fn=ssh_failure_detail,
+        probe_linux_launch_backend_fn=probe_linux_launch_backend,
+        probe_linux_remote_tooling_fn=probe_linux_remote_tooling,
+        probe_windows_session_agent_fn=probe_windows_session_agent,
+        probe_windows_remote_tooling_fn=probe_windows_remote_tooling,
+        probe_windows_repo_checkout_fn=probe_windows_repo_checkout,
+        platform=sys.platform,
+        which_fn=shutil.which,
+        probe_webdriver_endpoint_fn=probe_webdriver_endpoint,
     )
-
-    adapter = target["adapter"]
-    if adapter == "macos-local":
-        checks.append(_desktop_check("platform", sys.platform == "darwin", f"running on {sys.platform}"))
-        checks.append(
-            _desktop_check(
-                "screencapture",
-                shutil.which("screencapture") is not None,
-                shutil.which("screencapture") or "missing",
-            )
-        )
-        checks.append(
-            _desktop_check(
-                "osascript",
-                shutil.which("osascript") is not None,
-                shutil.which("osascript") or "missing",
-            )
-        )
-        try:
-            trusted = macos_accessibility_trusted()
-            checks.append(
-                _desktop_check(
-                    "accessibility",
-                    trusted,
-                    "trusted" if trusted else "not trusted; desktop-event click is unavailable but Pulp app automation still works",
-                    required=False,
-                )
-            )
-        except (subprocess.SubprocessError, json.JSONDecodeError) as exc:
-            checks.append(_desktop_check("accessibility", False, str(exc), required=False))
-    elif target["target_type"] == "ssh":
-        host = target.get("host")
-        checks.append(_desktop_check("host", bool(host), host or "missing"))
-        ssh_ok = False
-        if host:
-            ssh_ok = ssh_reachable(host, 5)
-            ssh_detail = host if ssh_ok else ssh_failure_detail(host, 5)
-            checks.append(_desktop_check("ssh", ssh_ok, ssh_detail))
-            if ssh_ok and adapter == "linux-xvfb":
-                try:
-                    backend = probe_linux_launch_backend(host)
-                    if backend.get("mode") == "xvfb":
-                        detail = backend.get("path") or "xvfb-run"
-                    elif backend.get("mode") == "display":
-                        detail = f"existing display {backend.get('display') or ':0'}"
-                    else:
-                        detail = "missing; install xvfb and xauth (for example: sudo apt-get install xvfb xauth)"
-                    checks.append(_desktop_check("launch_backend", backend.get("mode") != "missing", detail))
-                except (subprocess.SubprocessError, OSError, RuntimeError) as exc:
-                    checks.append(_desktop_check("launch_backend", False, str(exc)))
-                try:
-                    tooling = probe_linux_remote_tooling(host)
-                    for tool_name, spec in LINUX_REQUIRED_REMOTE_TOOLS.items():
-                        checks.append(
-                            _desktop_check(
-                                spec["display_name"],
-                                bool(tooling.get(f"{tool_name}_found")),
-                                linux_tooling_detail(tooling, tool_name, missing_hint=f"missing; {spec['package_hint']}"),
-                            )
-                        )
-                    for tool_name, spec in LINUX_OPTIONAL_REMOTE_TOOLS.items():
-                        checks.append(
-                            _desktop_check(
-                                spec["display_name"],
-                                bool(tooling.get(f"{tool_name}_found")),
-                                linux_tooling_detail(tooling, tool_name, missing_hint=f"missing; {spec['package_hint']}"),
-                                required=False,
-                            )
-                        )
-                except (subprocess.SubprocessError, OSError, RuntimeError) as exc:
-                    checks.append(_desktop_check("remote_tooling", False, str(exc)))
-            if ssh_ok and adapter == "windows-session-agent":
-                bootstrap_required = bool(receipt and receipt.get("remote_bootstrap_ready"))
-                checks.append(_desktop_check("task_name", bool(contract.get("task_name")), contract.get("task_name") or "missing", required=False))
-                try:
-                    probe = probe_windows_session_agent(host, contract)
-                    checks.append(
-                        _desktop_check(
-                            "scheduled_task",
-                            bool(probe.get("task_present")),
-                            f"{probe.get('task_name') or contract.get('task_name')} ({probe.get('task_state') or 'missing'})",
-                            required=bootstrap_required,
-                        )
-                    )
-                    desktop_session_user = windows_desktop_session_user(probe)
-                    desktop_session_state = windows_desktop_session_state(probe)
-                    if desktop_session_user:
-                        session_detail = desktop_session_user
-                        if desktop_session_state:
-                            session_detail = f"{session_detail} ({desktop_session_state})"
-                    else:
-                        session_detail = "no logged-in desktop session detected; log into the Windows desktop, then retry"
-                    checks.append(_desktop_check("interactive_user", bool(desktop_session_user), session_detail, required=False))
-                    checks.append(_desktop_check("agent_root", bool(probe.get("agent_root_exists")), probe.get("remote_root") or contract.get("remote_root") or "missing", required=bootstrap_required))
-                    checks.append(_desktop_check("jobs_dir", bool(probe.get("jobs_dir_exists")), probe.get("jobs_dir") or "missing", required=bootstrap_required))
-                    checks.append(_desktop_check("results_dir", bool(probe.get("results_dir_exists")), probe.get("results_dir") or "missing", required=bootstrap_required))
-                    checks.append(_desktop_check("script_path", bool(probe.get("script_exists")), probe.get("script_path") or contract.get("script_path") or "missing", required=bootstrap_required))
-                    tooling = probe_windows_remote_tooling(host)
-                    checks.append(
-                        _desktop_check(
-                            "git",
-                            bool(tooling.get("git_found")),
-                            windows_tooling_detail(
-                                tooling,
-                                "git",
-                                missing_hint="missing; `desktop install windows` will provision Git via winget when available",
-                            ),
-                        )
-                    )
-                    checks.append(
-                        _desktop_check(
-                            "winget",
-                            bool(tooling.get("winget_found")),
-                            windows_tooling_detail(
-                                tooling,
-                                "winget",
-                                missing_hint="missing; install App Installer/winget or install Git manually",
-                            ),
-                            required=False,
-                        )
-                    )
-                    checks.append(
-                        _desktop_check(
-                            "gh",
-                            bool(tooling.get("gh_found")),
-                            windows_tooling_detail(
-                                tooling,
-                                "gh",
-                                missing_hint="missing; optional for remote GitHub workflows on the Windows target",
-                            ),
-                            required=False,
-                        )
-                    )
-                    gh_auth_ready = tooling.get("gh_auth_ready")
-                    if tooling.get("gh_found"):
-                        auth_detail = tooling.get("gh_auth_detail") or "authenticated"
-                    else:
-                        auth_detail = "not applicable until gh is installed"
-                    checks.append(
-                        _desktop_check(
-                            "gh_auth",
-                            bool(gh_auth_ready) if gh_auth_ready is not None else False,
-                            auth_detail,
-                            required=False,
-                        )
-                    )
-                    try:
-                        repo_probe = probe_windows_repo_checkout(host, target.get("repo_path"))
-                        repo_ready = windows_repo_checkout_ready(repo_probe)
-                        repo_detail = windows_repo_checkout_detail(repo_probe, fallback_path=target.get("repo_path"))
-                        if repo_probe.get("repo_path_unsafe"):
-                            repo_detail = f"{repo_detail}; unsafe repo root, run `pulp ci-local desktop install {target_name}`"
-                        checks.append(
-                            _desktop_check(
-                                "repo_checkout",
-                                repo_ready,
-                                repo_detail,
-                                required=bootstrap_required,
-                            )
-                        )
-                    except (subprocess.SubprocessError, OSError, RuntimeError) as exc:
-                        checks.append(_desktop_check("repo_checkout", False, str(exc), required=bootstrap_required))
-                except (subprocess.SubprocessError, OSError, RuntimeError) as exc:
-                    checks.append(_desktop_check("scheduled_task", False, str(exc), required=bootstrap_required))
-        checks.append(_desktop_check("bootstrap", True, target.get("bootstrap", "manual")))
-    else:
-        checks.append(_desktop_check("adapter", adapter != "unknown", adapter))
-
-    optional = normalize_desktop_optional_config(target.get("optional"))
-    if optional.get("webview_driver"):
-        webdriver_url = optional.get("webdriver_url")
-        if not webdriver_url:
-            checks.append(_desktop_check("webview_driver", False, "enabled but webdriver_url is not set", required=False))
-        else:
-            try:
-                probe = probe_webdriver_endpoint(webdriver_url)
-                ready = probe.get("ready")
-                ready_text = "" if ready is None else f" (ready={str(ready).lower()})"
-                message = probe.get("message")
-                detail = f"reachable at {probe['status_url']}{ready_text}"
-                if message:
-                    detail = f"{detail}: {message}"
-                checks.append(_desktop_check("webview_driver", ready is not False, detail, required=False))
-            except (RuntimeError, ValueError) as exc:
-                checks.append(_desktop_check("webview_driver", False, str(exc), required=False))
-    if optional.get("debug_attach"):
-        debugger_command = optional.get("debugger_command")
-        if target["target_type"] == "local":
-            debugger = debugger_command or "lldb"
-            debugger_path = shutil.which(debugger)
-            checks.append(
-                _desktop_check(
-                    "debug_attach",
-                    debugger_path is not None,
-                    debugger_path or f"{debugger} not found on PATH",
-                    required=False,
-                )
-            )
-        else:
-            detail = debugger_command or "enabled; remote debugger validation deferred to target tooling"
-            checks.append(_desktop_check("debug_attach", True, detail, required=False))
-    if optional.get("video_capture"):
-        if target["target_type"] == "local":
-            ffmpeg_path = shutil.which("ffmpeg")
-            checks.append(
-                _desktop_check(
-                    "video_capture",
-                    ffmpeg_path is not None,
-                    ffmpeg_path or "ffmpeg not found on PATH",
-                    required=False,
-                )
-            )
-        else:
-            checks.append(
-                _desktop_check(
-                    "video_capture",
-                    True,
-                    "enabled; remote video tooling validation deferred to target tooling",
-                    required=False,
-                )
-            )
-    if optional.get("frame_stats"):
-        checks.append(_desktop_check("frame_stats", True, "enabled", required=False))
-
-    return checks
 
 
 def webdriver_status_url(base_url: str) -> str:
-    parsed = urllib.parse.urlparse((base_url or "").strip())
-    if not parsed.scheme or not parsed.netloc:
-        raise ValueError("webdriver_url must include a scheme and host, for example http://127.0.0.1:4444")
-    path = parsed.path or ""
-    if not path or path == "/":
-        path = "/status"
-    elif not path.rstrip("/").endswith("/status"):
-        path = f"{path.rstrip('/')}/status"
-    return urllib.parse.urlunparse(parsed._replace(path=path, params="", query="", fragment=""))
+    return _desktop_doctor.webdriver_status_url(base_url)
 
 
 def probe_webdriver_endpoint(base_url: str, *, timeout: float = 5.0) -> dict:
-    status_url = webdriver_status_url(base_url)
-    request = urllib.request.Request(status_url, headers={"Accept": "application/json"})
-    try:
-        with urllib.request.urlopen(request, timeout=timeout) as response:
-            payload = json.loads(response.read().decode("utf-8") or "{}")
-    except urllib.error.HTTPError as exc:
-        body = exc.read().decode("utf-8", errors="replace").strip()
-        detail = f"HTTP {exc.code}"
-        if body:
-            detail = f"{detail}: {body[:200]}"
-        raise RuntimeError(detail) from exc
-    except urllib.error.URLError as exc:
-        reason = getattr(exc, "reason", exc)
-        raise RuntimeError(str(reason)) from exc
-    except json.JSONDecodeError as exc:
-        raise RuntimeError(f"invalid JSON response: {exc}") from exc
-
-    value = payload.get("value") if isinstance(payload, dict) else None
-    if isinstance(value, dict):
-        ready = value.get("ready")
-        message = value.get("message")
-    else:
-        ready = payload.get("ready") if isinstance(payload, dict) else None
-        message = payload.get("message") if isinstance(payload, dict) else None
-    return {
-        "status_url": status_url,
-        "ready": ready,
-        "message": str(message).strip() if message is not None else "",
-        "payload": payload,
-    }
+    return _desktop_doctor.probe_webdriver_endpoint(
+        base_url,
+        timeout=timeout,
+        request_cls=urllib.request.Request,
+        urlopen_fn=urllib.request.urlopen,
+    )
 
 
 def desktop_artifact_root(config: dict) -> Path:


### PR DESCRIPTION
## Summary
- add `desktop_doctor.py` for desktop capability derivation, writable-artifact checks, WebDriver status probing, and desktop doctor check assembly
- keep `local_ci.py` compatibility wrappers for existing CLI/tests and monkeypatch surfaces
- update `tools/local-ci/MODULE_MAP.md` ownership notes

## Validation
- `python3 -m py_compile tools/local-ci/local_ci.py tools/local-ci/desktop_doctor.py`
- `python3 tools/local-ci/test_local_ci.py -k desktop_doctor`
- `python3 tools/local-ci/test_local_ci_extra.py -k webdriver`
- `python3 tools/local-ci/test_local_ci_extra.py -k desktop_doctor`
- `python3 -m unittest discover -s tools/local-ci -p 'test_*.py'` (458 tests OK)\n- `python3 tools/import-validation/check-source-contracts.py --strict`\n- `python3 tools/import-validation/test_source_contracts.py`\n- `tools/scripts/gates.sh`\n- `git diff --check`\n\n## Local adversarial review\n- `autoreview --mode local` clean: no accepted/actionable findings.\n- Final reviewer summary: wrappers preserve `sys.platform`, `shutil.which`, `urllib` request/urlopen, desktop/Linux/Windows/WebDriver probe surfaces; doctor/status output, capability ordering/deduping, WebDriver behavior, and remote Linux/Windows checks match the moved implementation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted desktop doctor logic and WebDriver probes into `desktop_doctor.py`, slimming `local_ci.py` and making probes fully injectable for tests. CLI output and doctor results are unchanged.

- **Refactors**
  - Added `tools/local-ci/desktop_doctor.py` for capability derivation, writable-dir checks, WebDriver status URL/probe, and cross-platform `desktop_doctor_checks` (macOS, Linux `xvfb`, Windows session agent).
  - Updated `local_ci.py` to delegate and re-export `desktop_optional_capabilities`, `desktop_capabilities_for`, `webdriver_status_url`, `probe_webdriver_endpoint`, and `desktop_doctor_checks`.
  - Expanded injectables: target/contract/receipt resolvers, `platform`/`which`, macOS accessibility, SSH reachability/detail, Linux/Windows tooling and repo checkout probes, and WebDriver `Request`/`urlopen`.
  - Updated `tools/local-ci/MODULE_MAP.md` and `.agents/skills/ci/SKILL.md` to document ownership and rename the future extraction to “desktop action orchestration.”

<sup>Written for commit f0fbbc7f8c37ea2b25188c44227d10df7e8397ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

