### PR TITLE
fix(audio): make PULP_ENABLE_AUDIO_PROBES a real (ODR-safe) build option + per-block AudioStats

### DIFF
--- a/.agents/skills/android/SKILL.md
+++ b/.agents/skills/android/SKILL.md
@@ -152,6 +152,10 @@ install command on supported hosts where the binary is absent.
   CLI is a build accelerator; it isn't.
 - **Release / signing** — Gradle through `pulp ship` is the only
   store-grade path. The CLI's `run` is debug-install only.
+- **Audio probe defaults** — generated Android app templates pass
+  `-DPULP_ENABLE_AUDIO_PROBES=OFF`; the standalone audio probes are a
+  dev/examples diagnostic surface, not something generated app builds
+  should ship accidentally.
 - **CI** — Pulp's CI runs on mixed-arch hosts (Linux ARM64 via
   `ssh ubuntu`, Windows ARM64 via `ssh win2`) where the CLI binary
   doesn't exist. CI scripts use `adb` / `gradle` directly.

--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -54,6 +54,13 @@ Slice 6 (#551).
   build with `-DPULP_BUILD_EXAMPLES=OFF` (matching `build.yml`). If you add a
   new release/packaging workflow, configure with examples OFF (or a populated
   `SKIA_DIR`), or the design-tool Skia gate will block it.
+- **Release/SDK builds must pass `-DPULP_ENABLE_AUDIO_PROBES=OFF`.** The
+  standalone audio probe is a dev/example inspection surface and defaults ON
+  for local development, but shipped CLI, standalone, and SDK artifacts must
+  not export it. Keep `release-cli.yml`, `release-path-pr-gate.yml`,
+  `release-dry-run.yml`, `sign-and-release.yml`, `release-cli-local.sh`, and
+  checkout-backed SDK configure paths aligned when touching release CMake
+  flags.
 - **Hooks inherit `GIT_DIR` — tests that shell out to git can corrupt the live
   worktree.** Git exports `GIT_DIR`/`GIT_WORK_TREE` into hook environments, and
   a set `GIT_DIR` *overrides* `git -C <dir>` discovery. So when the pre-push

--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -1535,6 +1535,10 @@ Gotchas:
   fall-through to `pulp-cpp sdk install` (see `pulp-rs/src/cmd/sdk.rs`);
   the C++ `cmd_sdk` is a different code path with its own per-version
   `~/.pulp/sdk/<version>/` layout. #1814 fix lives only in `cmd_cache`.
+- **Checkout-backed SDK builds force dev probes off.** `ensure_checkout_sdk`
+  configures local SDK builds with `-DPULP_ENABLE_AUDIO_PROBES=OFF` so
+  `pulp sdk install --local` and checkout-backed standalone resolution do not
+  export the dev standalone audio-probe surface in cached SDK artifacts.
 - **If you bump `PULP_SDK_VERSION`, you do NOT need to manually
   invalidate `~/.pulp/cache`.** The new version means the filename
   misses on the old cache and the user gets a fresh download

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -529,6 +529,12 @@ This applies to both `.github/workflows/release-cli.yml` and the local
 helper `tools/scripts/release-cli-local.sh`. If one changes without the
 other, GitHub releases and local release drills diverge.
 
+Release/SDK builds also pass `-DPULP_ENABLE_AUDIO_PROBES=OFF` so SDK and
+standalone artifacts do not ship the dev audio-probe surface. Keep
+`.github/workflows/release-cli.yml`, `.github/workflows/sign-and-release.yml`,
+and `tools/scripts/release-cli-local.sh` in sync when changing release
+configure flags.
+
 ### Shipyard pin drift between local tooling and release workflows
 
 Pulp's release automation depends on the pinned Shipyard CLI in two places:

--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -915,9 +915,12 @@ falls through to the back-buffer capture unchanged. See the `screenshot` skill.
 ## Standalone audio-callback probe tap (Phase 5 observability harness)
 
 `StandaloneApp`'s audio callback carries an optional realtime output-boundary
-probe, gated behind the `PULP_ENABLE_AUDIO_PROBES` CMake option (default OFF).
-When ON, `start()` `prepare()`s `output_probe_` (the only place it allocates)
-and the callback calls `output_probe_.analyze_output(...)` immediately after
+probe, gated behind the `PULP_ENABLE_AUDIO_PROBES` CMake option. The default is
+ON for dev/example builds; release and SDK build paths pass
+`-DPULP_ENABLE_AUDIO_PROBES=OFF` so shipped standalone artifacts do not export
+the dev probe surface unless a developer opts in. When ON, `start()`
+`prepare()`s `output_probe_` (the only place it allocates) and the callback
+calls `output_probe_.analyze_output(...)` immediately after
 `processor_->process(...)` — the "standalone processor-output boundary." This
 is the first wired probe stage for "UI works, no sound" reports. Gotchas:
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.207.0",
+      "version": "0.207.1",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.207.0"
+  "version": "0.207.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.207.0",
+  "version": "0.207.1",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1009,6 +1009,7 @@ jobs:
           cmake -S . -B build `
             -DCMAKE_BUILD_TYPE=Release `
             -DPULP_BUILD_TESTS=OFF `
+            -DPULP_ENABLE_AUDIO_PROBES=OFF `
             -DPULP_BUILD_WEBVIEW=ON
         shell: pwsh
 

--- a/.github/workflows/install-consumer-smoke.yml
+++ b/.github/workflows/install-consumer-smoke.yml
@@ -99,7 +99,8 @@ jobs:
           cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DPULP_BUILD_TESTS=OFF \
-            -DPULP_BUILD_EXAMPLES=OFF
+            -DPULP_BUILD_EXAMPLES=OFF \
+            -DPULP_ENABLE_AUDIO_PROBES=OFF
           cmake --build build --config Release
         shell: bash
 

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -329,6 +329,7 @@ jobs:
           cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DPULP_BUILD_TESTS=OFF \
+            -DPULP_ENABLE_AUDIO_PROBES=OFF \
             $REQUIRE_GPU \
             ${{ runner.os == 'Linux' && '-DPULP_BUILD_WEBVIEW=OFF' || '-DPULP_BUILD_WEBVIEW=ON' }}
         shell: bash
@@ -479,6 +480,7 @@ jobs:
           cmake -S . -B build-sdk \
             -DCMAKE_BUILD_TYPE=Release \
             -DPULP_BUILD_TESTS=OFF \
+            -DPULP_ENABLE_AUDIO_PROBES=OFF \
             $REQUIRE_GPU \
             -DPULP_BUILD_WEBVIEW=ON
           # Build everything the SDK install step needs. This is a full

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -42,6 +42,7 @@ jobs:
           cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DPULP_BUILD_TESTS=OFF \
+            -DPULP_ENABLE_AUDIO_PROBES=OFF \
             -DPULP_REQUIRE_GPU_FOR_SDK=ON \
             -DPULP_BUILD_WEBVIEW=ON
         shell: bash

--- a/.github/workflows/release-path-pr-gate.yml
+++ b/.github/workflows/release-path-pr-gate.yml
@@ -146,6 +146,7 @@ jobs:
           cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DPULP_BUILD_TESTS=OFF \
+            -DPULP_ENABLE_AUDIO_PROBES=OFF \
             $REQUIRE_GPU \
             ${{ runner.os == 'Linux' && '-DPULP_BUILD_WEBVIEW=OFF' || '-DPULP_BUILD_WEBVIEW=ON' }}
         shell: bash

--- a/.github/workflows/sign-and-release.yml
+++ b/.github/workflows/sign-and-release.yml
@@ -111,7 +111,7 @@ jobs:
         # FALSE (this runner has no Skia), so building examples here aborts the
         # whole sign-and-release run and no GitHub Release is published. Skip
         # examples to match build.yml's release legs.
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DPULP_BUILD_EXAMPLES=OFF
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DPULP_BUILD_EXAMPLES=OFF -DPULP_ENABLE_AUDIO_PROBES=OFF
 
       - name: Build
         run: cmake --build build --config ${{ env.BUILD_TYPE }} -j$(sysctl -n hw.ncpu)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,15 @@ option(PULP_ENABLE_SWIFT "Enable Swift layer (Apple only)" OFF)
 # GPU + desktop (PULP_HAS_INSPECT), which gates linking; this flag gates
 # the source-side wiring on top of that.
 option(PULP_ENABLE_INSPECTOR "Wire the dev inspector into the standalone host (dev/examples ON, release-ship OFF)" ON)
+# RT output-boundary audio probe in the standalone host — the data source for
+# the dev Audio Inspector window. Default ON for dev/examples; release /
+# standalone-ship builds configure -DPULP_ENABLE_AUDIO_PROBES=OFF. The probe's
+# analyze_output() is RT-safe (no alloc/lock/FFT); plugin formats never link
+# the standalone tap. NOTE: it gates MEMBER declarations in the public
+# standalone.hpp, so core/format defines it PUBLIC (consistent for every
+# includer) — a PRIVATE def would give the library and its consumers a
+# different sizeof(StandaloneApp) (ODR).
+option(PULP_ENABLE_AUDIO_PROBES "Wire the RT output-boundary probe into the standalone host (dev/examples ON, release-ship OFF)" ON)
 option(PULP_ENABLE_AAX "Enable optional AAX support with a developer-supplied SDK" OFF)
 option(PULP_ENABLE_ARA "Enable optional ARA 2.x support with a developer-supplied Celemony SDK" OFF)
 option(PULP_FETCHCONTENT_UPDATES_DISCONNECTED "Avoid implicit FetchContent updates during configure" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.408.0
+    VERSION 0.409.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/audio/include/pulp/audio/audio_probe.hpp
+++ b/core/audio/include/pulp/audio/audio_probe.hpp
@@ -121,8 +121,10 @@ private:
     float clip_ceiling_ = 1.0f;
 
     std::uint64_t sequence_number_ = 0;
-    std::uint64_t clip_count_ = 0;
-    std::uint64_t nan_inf_count_ = 0;
+    std::uint64_t clip_count_ = 0;      // per-sample
+    std::uint64_t nan_inf_count_ = 0;   // per-sample
+    std::uint64_t clipped_blocks_ = 0;  // per-block: blocks with >=1 clip
+    std::uint64_t nan_blocks_ = 0;      // per-block: blocks with >=1 NaN/Inf
     std::uint64_t callbacks_ = 0;
     std::uint64_t silence_run_blocks_ = 0;
     std::uint64_t dropped_capture_frames_ = 0;

--- a/core/audio/include/pulp/audio/audio_probe.hpp
+++ b/core/audio/include/pulp/audio/audio_probe.hpp
@@ -111,6 +111,8 @@ public:
     void set_clip_ceiling(float linear) noexcept { clip_ceiling_ = linear; }
 
 private:
+    void publish_empty_snapshot() noexcept;
+
     int max_channels_ = 0;
     int max_frames_ = 0;
     int capture_frames_ = 0;

--- a/core/audio/include/pulp/audio/audio_probe_snapshot.hpp
+++ b/core/audio/include/pulp/audio/audio_probe_snapshot.hpp
@@ -74,6 +74,13 @@ struct AudioProbeSnapshot {
     std::uint64_t clip_count = 0;
     /// Samples seen as NaN or Inf, summed over all blocks/channels.
     std::uint64_t nan_inf_count = 0;
+    /// BLOCKS that contained at least one clipped sample (per-block tally, not
+    /// the per-sample `clip_count`). This is what `AudioStats::clipped_blocks`
+    /// mirrors.
+    std::uint64_t clipped_blocks = 0;
+    /// BLOCKS that contained at least one NaN/Inf sample (per-block tally, not
+    /// the per-sample `nan_inf_count`). Mirrored by `AudioStats::nan_blocks`.
+    std::uint64_t nan_blocks = 0;
     /// Number of analyzed callbacks (blocks) since prepare().
     std::uint64_t callbacks = 0;
     /// Consecutive blocks (most recent run) below the silence threshold. Reset

--- a/core/audio/src/audio_probe.cpp
+++ b/core/audio/src/audio_probe.cpp
@@ -58,6 +58,8 @@ void AudioProbe::analyze_output(const BufferView<const float>& output) noexcept 
     snap.stage_id = stage_;
 
     bool block_silent = true;
+    bool block_had_clip = false;       // this block had >=1 clipped sample
+    bool block_had_nonfinite = false;  // this block had >=1 NaN/Inf sample
 
     for (int ch = 0; ch < channels; ++ch) {
         const float* samples = output.channel_ptr(static_cast<std::size_t>(ch));
@@ -67,12 +69,16 @@ void AudioProbe::analyze_output(const BufferView<const float>& output) noexcept 
             const float x = samples[i];
             // NaN/Inf detection without exceptions or allocation.
             if (!std::isfinite(x)) {
-                ++nan_inf_count_;
+                ++nan_inf_count_;          // per-sample
+                block_had_nonfinite = true;
                 continue;  // do not fold a non-finite value into peak/RMS
             }
             const float ax = std::fabs(x);
             if (ax > peak) peak = ax;
-            if (ax > clip_ceiling_) ++clip_count_;
+            if (ax > clip_ceiling_) {
+                ++clip_count_;             // per-sample
+                block_had_clip = true;
+            }
             sum_sq += static_cast<double>(x) * static_cast<double>(x);
         }
         const float rms = frames > 0
@@ -88,6 +94,8 @@ void AudioProbe::analyze_output(const BufferView<const float>& output) noexcept 
     if (channels == 0 || frames == 0) block_silent = true;
 
     ++callbacks_;
+    if (block_had_clip) ++clipped_blocks_;
+    if (block_had_nonfinite) ++nan_blocks_;
     if (block_silent) {
         ++silence_run_blocks_;
     } else {
@@ -117,6 +125,8 @@ void AudioProbe::analyze_output(const BufferView<const float>& output) noexcept 
     snap.sequence_number = sequence_number_;
     snap.clip_count = clip_count_;
     snap.nan_inf_count = nan_inf_count_;
+    snap.clipped_blocks = clipped_blocks_;
+    snap.nan_blocks = nan_blocks_;
     snap.callbacks = callbacks_;
     snap.silence_run_blocks = silence_run_blocks_;
     snap.dropped_capture_frames = dropped_capture_frames_;
@@ -130,8 +140,10 @@ AudioStats AudioProbe::stats() {
     AudioStats out;
     out.callbacks = snap.callbacks;
     out.underruns = 0;  // not tracked by the output-boundary probe itself
-    out.clipped_blocks = snap.clip_count > 0 ? snap.clip_count : 0;
-    out.nan_blocks = snap.nan_inf_count;
+    // Per-BLOCK tallies (a block with >=1 clipped/non-finite sample counts
+    // once) — NOT the per-sample clip_count / nan_inf_count totals.
+    out.clipped_blocks = snap.clipped_blocks;
+    out.nan_blocks = snap.nan_blocks;
     // device_xruns / cpu_overloads are MIRRORS owned by the device — the host
     // populates them, the probe never does. Leave at zero here.
     return out;

--- a/core/audio/src/audio_probe.cpp
+++ b/core/audio/src/audio_probe.cpp
@@ -29,19 +29,13 @@ void AudioProbe::prepare(int max_channels,
     sequence_number_ = 0;
     clip_count_ = 0;
     nan_inf_count_ = 0;
+    clipped_blocks_ = 0;
+    nan_blocks_ = 0;
     callbacks_ = 0;
     silence_run_blocks_ = 0;
     dropped_capture_frames_ = 0;
 
-    // Publish an initial empty snapshot so a reader before the first callback
-    // sees coherent identity fields instead of a default-constructed sequence 0
-    // that looks like live data.
-    AudioProbeSnapshot init{};
-    init.sample_rate = sample_rate_;
-    init.channel_count = 0;
-    init.stage_id = stage_;
-    init.sequence_number = 0;
-    summary_buf_.write(init);
+    publish_empty_snapshot();
 }
 
 void AudioProbe::analyze_output(const BufferView<const float>& output) noexcept {
@@ -166,10 +160,25 @@ void AudioProbe::reset() noexcept {
     sequence_number_ = 0;
     clip_count_ = 0;
     nan_inf_count_ = 0;
+    clipped_blocks_ = 0;
+    nan_blocks_ = 0;
     callbacks_ = 0;
     silence_run_blocks_ = 0;
     dropped_capture_frames_ = 0;
     if (capture_fifo_) capture_fifo_->reset();
+    publish_empty_snapshot();
+}
+
+void AudioProbe::publish_empty_snapshot() noexcept {
+    // Publish an empty snapshot so a reader before the first callback, or
+    // immediately after reset(), sees coherent identity fields and cleared
+    // counters instead of stale triple-buffer data.
+    AudioProbeSnapshot snap{};
+    snap.sample_rate = sample_rate_;
+    snap.channel_count = 0;
+    snap.stage_id = stage_;
+    snap.sequence_number = 0;
+    summary_buf_.write(snap);
 }
 
 }  // namespace pulp::audio

--- a/core/format/CMakeLists.txt
+++ b/core/format/CMakeLists.txt
@@ -79,6 +79,20 @@ else()
     target_compile_definitions(pulp-format PRIVATE PULP_ENABLE_INSPECTOR=0)
 endif()
 
+# PULP_ENABLE_AUDIO_PROBES wires the RT output-boundary probe into the
+# standalone host (the dev Audio Inspector's data source). Unlike the
+# inspector flag, this one gates MEMBER declarations in the PUBLIC
+# standalone.hpp (output_probe_ / output_probe_ptrs_ / output_probe()), so it
+# is defined PUBLIC — every target that includes standalone.hpp must see the
+# same value or sizeof(StandaloneApp) diverges (ODR). Defined unconditionally
+# as 0/1 so source can `#if PULP_ENABLE_AUDIO_PROBES`. Default ON for
+# dev/examples; release/standalone-ship builds configure OFF.
+if(PULP_ENABLE_AUDIO_PROBES)
+    target_compile_definitions(pulp-format PUBLIC PULP_ENABLE_AUDIO_PROBES=1)
+else()
+    target_compile_definitions(pulp-format PUBLIC PULP_ENABLE_AUDIO_PROBES=0)
+endif()
+
 # Host-quirks default policy (host-quirks enforcement plan).
 #
 # Selects the baseline tier filter detect_quirks() / resolved_quirks() apply

--- a/test/test_audio_probe.cpp
+++ b/test/test_audio_probe.cpp
@@ -279,6 +279,41 @@ TEST_CASE("AudioStats mirrors device counters without shadowing",
     REQUIRE(probe.stats().device_xruns == 0);
 }
 
+TEST_CASE("AudioStats clipped_blocks / nan_blocks are per-BLOCK, not per-sample",
+          "[audio-probe][audio-stats]") {
+    // The bug this guards: clipped_blocks/nan_blocks were populated with the
+    // per-SAMPLE clip_count / nan_inf_count. A single block with many clipped
+    // (or many NaN) samples must count as exactly ONE block.
+    AudioProbe probe;
+    probe.prepare(2, 64, 48000.0);
+
+    // Block 1: 10 clipped samples + 5 NaN samples — but it is ONE block.
+    StereoBlock b1(64);
+    b1.fill(0.1f, 0.1f);
+    for (int i = 0; i < 10; ++i) b1.left[i] = 2.0f;                       // clips
+    for (int i = 10; i < 15; ++i)
+        b1.right[i] = std::numeric_limits<float>::quiet_NaN();            // NaN
+    probe.analyze_output(b1.view());
+
+    AudioStats s1 = probe.stats();
+    REQUIRE(s1.clipped_blocks == 1);  // ONE block, not 10
+    REQUIRE(s1.nan_blocks == 1);      // ONE block, not 5
+    // The per-sample totals on the snapshot remain the raw sample counts.
+    REQUIRE(probe.latest().clip_count == 10);
+    REQUIRE(probe.latest().nan_inf_count == 5);
+
+    // Block 2: clean → block tallies unchanged. Block 3: clipped → +1 block.
+    StereoBlock clean(64); clean.fill(0.1f, 0.1f);
+    probe.analyze_output(clean.view());
+    StereoBlock b3(64); b3.fill(0.1f, 0.1f); b3.left[0] = 2.0f;
+    probe.analyze_output(b3.view());
+
+    AudioStats s3 = probe.stats();
+    REQUIRE(s3.clipped_blocks == 2);  // blocks 1 and 3
+    REQUIRE(s3.nan_blocks == 1);      // only block 1
+    REQUIRE(s3.callbacks == 3);
+}
+
 TEST_CASE("AudioProbe reset clears cumulative counters",
           "[audio-probe]") {
     AudioProbe probe;

--- a/test/test_audio_probe.cpp
+++ b/test/test_audio_probe.cpp
@@ -320,12 +320,42 @@ TEST_CASE("AudioProbe reset clears cumulative counters",
     probe.prepare(1, 32, 48000.0);
     StereoBlock block(32);
     block.fill(2.0f, 2.0f);  // clips every sample
+    block.left[0] = std::numeric_limits<float>::quiet_NaN();
     probe.analyze_output(block.view());
     REQUIRE(probe.latest().clip_count > 0);
+    REQUIRE(probe.latest().nan_inf_count > 0);
+    REQUIRE(probe.latest().clipped_blocks > 0);
+    REQUIRE(probe.latest().nan_blocks > 0);
+
     probe.reset();
-    probe.analyze_output(StereoBlock(32).view());  // silence
-    const auto snap = probe.latest();
+    auto snap = probe.latest();
     REQUIRE(snap.clip_count == 0);
+    REQUIRE(snap.nan_inf_count == 0);
+    REQUIRE(snap.clipped_blocks == 0);
+    REQUIRE(snap.nan_blocks == 0);
+    REQUIRE(snap.callbacks == 0);
+    REQUIRE(probe.stats().clipped_blocks == 0);
+    REQUIRE(probe.stats().nan_blocks == 0);
+
+    probe.analyze_output(StereoBlock(32).view());  // silence
+    snap = probe.latest();
+    REQUIRE(snap.clip_count == 0);
+    REQUIRE(snap.nan_inf_count == 0);
+    REQUIRE(snap.clipped_blocks == 0);
+    REQUIRE(snap.nan_blocks == 0);
+    REQUIRE(snap.callbacks == 1);
+
+    probe.analyze_output(block.view());
+    REQUIRE(probe.latest().clipped_blocks > 0);
+    REQUIRE(probe.latest().nan_blocks > 0);
+
+    probe.prepare(1, 32, 48000.0);
+    probe.analyze_output(StereoBlock(32).view());  // silence after re-prepare
+    snap = probe.latest();
+    REQUIRE(snap.clip_count == 0);
+    REQUIRE(snap.nan_inf_count == 0);
+    REQUIRE(snap.clipped_blocks == 0);
+    REQUIRE(snap.nan_blocks == 0);
     REQUIRE(snap.callbacks == 1);
 }
 

--- a/tools/cli/cli_sdk.cpp
+++ b/tools/cli/cli_sdk.cpp
@@ -352,6 +352,7 @@ fs::path ensure_checkout_sdk(const fs::path& repo_root, const std::string& versi
         + " -DCMAKE_INSTALL_PREFIX=" + sdk_dir.string()
         + " -DPULP_BUILD_TESTS=OFF"
         + " -DPULP_BUILD_EXAMPLES=OFF"
+        + " -DPULP_ENABLE_AUDIO_PROBES=OFF"
         + " -DPULP_ENABLE_GPU=OFF";
     append_windows_visual_studio_generator_args(configure_cmd);
     if (run_with_spinner(configure_cmd, "Configuring local SDK") != 0) {

--- a/tools/scripts/release-cli-local.sh
+++ b/tools/scripts/release-cli-local.sh
@@ -34,6 +34,7 @@ step "Building macOS arm64"
 cmake -S "$REPO_ROOT" -B "$MAC_BUILD_DIR" \
     -DCMAKE_BUILD_TYPE=Release \
     -DPULP_BUILD_TESTS=OFF \
+    -DPULP_ENABLE_AUDIO_PROBES=OFF \
     -DPULP_BUILD_WEBVIEW=ON 2>&1 | tail -5
 cmake --build "$MAC_BUILD_DIR" --target pulp-cli --config Release 2>&1 | tail -3
 if [ ! -f "$MAC_BUILD_DIR/tools/cli/pulp" ]; then
@@ -83,6 +84,7 @@ if ssh -o ConnectTimeout=5 -o BatchMode=yes ubuntu "echo ok" &>/dev/null; then
     ssh ubuntu "cd ~/pulp && \
         cmake -S . -B build-cli -DCMAKE_BUILD_TYPE=Release \
             -DPULP_BUILD_TESTS=OFF -DPULP_ENABLE_GPU=OFF \
+            -DPULP_ENABLE_AUDIO_PROBES=OFF \
             -DPULP_BUILD_WEBVIEW=ON" 2>&1 | tail -5
 
     # Build
@@ -113,7 +115,7 @@ if ssh -o ConnectTimeout=5 -o BatchMode=yes win2 "echo ok" &>/dev/null; then
             --exclude='dist' --exclude='planning' \
             "$REPO_ROOT/" win2:~/pulp/
 
-        ssh win2 "cd ~/pulp && cmake -S . -B build-cli -DCMAKE_BUILD_TYPE=Release -DPULP_BUILD_TESTS=OFF -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_WEBVIEW=ON 2>&1 | tail -5"
+        ssh win2 "cd ~/pulp && cmake -S . -B build-cli -DCMAKE_BUILD_TYPE=Release -DPULP_BUILD_TESTS=OFF -DPULP_ENABLE_GPU=OFF -DPULP_ENABLE_AUDIO_PROBES=OFF -DPULP_BUILD_WEBVIEW=ON 2>&1 | tail -5"
         ssh win2 "cd ~/pulp && cmake --build build-cli --target pulp-cli --config Release 2>&1 | tail -5"
 
         if ssh win2 "if exist ~/pulp/build-cli/tools/cli/Release/pulp.exe (echo ok)" | grep -q ok; then

--- a/tools/scripts/test_release_workflow_test_step.py
+++ b/tools/scripts/test_release_workflow_test_step.py
@@ -185,9 +185,17 @@ class ReleaseCliLinuxNoWebView(unittest.TestCase):
             self.text,
         )
 
+    def test_cli_and_sdk_build_disable_audio_probes(self) -> None:
+        self.assertGreaterEqual(
+            self.text.count("-DPULP_ENABLE_AUDIO_PROBES=OFF"),
+            2,
+            "release-cli.yml must keep audio probes disabled for both the "
+            "CLI and SDK release configure steps.",
+        )
+
 
 class BuildWorkflowReleaseGate(unittest.TestCase):
-    """build.yml release-path PR gate must match the split SDK archives."""
+    """build.yml release-path PR gate must match release-cli.yml invariants."""
 
     def setUp(self) -> None:
         self.assertTrue(
@@ -195,6 +203,17 @@ class BuildWorkflowReleaseGate(unittest.TestCase):
             f"missing workflow file: {BUILD_WORKFLOW}",
         )
         self.text = BUILD_WORKFLOW.read_text()
+
+    def _find_step_run(self, step_name: str) -> str:
+        pattern = re.compile(
+            rf"-\s*name:\s*{re.escape(step_name)}\s*\n"
+            r"(?:(?!\n\s*-\s*name:).)*?"
+            r"\s*run:\s*(.+?)(?=\n\s*-\s*name:|\Z)",
+            re.DOTALL,
+        )
+        match = pattern.search(self.text)
+        self.assertIsNotNone(match, f"could not locate `{step_name}` step")
+        return match.group(1)
 
     def test_windows_release_gate_checks_view_core_archive(self) -> None:
         self.assertIn("sdk-staging/lib/pulp-view.lib", self.text)
@@ -204,6 +223,10 @@ class BuildWorkflowReleaseGate(unittest.TestCase):
             "assert b'WebViewPanel'",
             self.text,
         )
+
+    def test_windows_release_gate_disables_audio_probes(self) -> None:
+        run_block = self._find_step_run("Configure (matches release-cli.yml)")
+        self.assertIn("-DPULP_ENABLE_AUDIO_PROBES=OFF", run_block)
 
 
 class ReleasePathPrGateMacosRouting(unittest.TestCase):

--- a/tools/scripts/test_verify_create_templates.py
+++ b/tools/scripts/test_verify_create_templates.py
@@ -152,6 +152,21 @@ class TestMain(unittest.TestCase):
         rc = vct.main(["--templates-root", str(templates_root)])
         self.assertEqual(rc, 0, "verify_create_templates must pass at HEAD")
 
+    def test_android_template_disables_audio_probes(self) -> None:
+        template = (
+            _HERE.parent
+            / "templates"
+            / "android"
+            / "app"
+            / "build.gradle.kts.template"
+        )
+        if not template.is_file():
+            self.skipTest(f"Android template missing at {template}")
+        self.assertIn(
+            "-DPULP_ENABLE_AUDIO_PROBES=OFF",
+            template.read_text(encoding="utf-8"),
+        )
+
     def test_fails_on_missing_root(self) -> None:
         rc = vct.main(["--templates-root", "/nonexistent/path/xyz"])
         self.assertEqual(rc, 1)

--- a/tools/templates/android/app/build.gradle.kts.template
+++ b/tools/templates/android/app/build.gradle.kts.template
@@ -29,6 +29,7 @@ android {
                     "-DANDROID_ARM_NEON=TRUE",
                     "-DPULP_BUILD_TESTS=OFF",
                     "-DPULP_BUILD_EXAMPLES=OFF",
+                    "-DPULP_ENABLE_AUDIO_PROBES=OFF",
                     "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
                 )
             }


### PR DESCRIPTION
Adversarial-review **CRITICAL** follow-up to PR #3864. The standalone output-boundary probe (the dev Audio Inspector's data source) was gated behind `PULP_ENABLE_AUDIO_PROBES`, but **no CMakeLists defined that macro** — so the `#if` was 0 in every build and the tap was dead code that couldn't even be turned on. The probe unit tests link `AudioProbe` directly, which masked it (the repo's own 'CI green is not a test' gap).

- Add `option(PULP_ENABLE_AUDIO_PROBES … ON)` mirroring `PULP_ENABLE_INSPECTOR` (dev/examples ON, release-ship OFF) so the tap is wired into every dev build.
- Define it **PUBLIC** on pulp-format (NOT private like the inspector): it gates **member declarations in the public `standalone.hpp`**, so a private def would give the library and its consumers a different `sizeof(StandaloneApp)` — an ODR bug (a second defect avoided).

Also (review medium/low): `AudioStats::clipped_blocks/nan_blocks` were populated with the per-SAMPLE counts. Added real per-block tallies (published through the snapshot TripleBuffer), dropped the dead `x>0?x:0` ternary, and a test proving the semantics (10 clipped samples in one block ⇒ 1 block; 2 across blocks).

Verified: probe 169/11, inspector-window 47/8, standalone-transport-midi 33/3; snapshot still trivially-copyable.

NOTE: the runtime standalone→probe **end-to-end** wiring test (drive a block, assert the probe sees it) needs a small headless-render seam on StandaloneApp and lands as an immediate follow-up (PR A2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `PULP_ENABLE_AUDIO_PROBES` a real, ODR-safe build option and fix per-block `AudioStats`. Dev builds feed the Audio Inspector; release/SDK builds and templates keep the probe off, with CI tests to enforce it.

- **Bug Fixes**
  - Added `PULP_ENABLE_AUDIO_PROBES` CMake option (dev/examples ON), defined PUBLIC on `pulp-format`, and ensured the standalone output-boundary probe is compiled in so the inspector receives data.
  - Corrected per-block tallies: added `clipped_blocks`/`nan_blocks` to `AudioProbeSnapshot`, mapped `stats()` to these counters, publish an empty snapshot on prepare/reset, and added tests for per-block and reset behavior.
  - Ensured probes are OFF for shipped artifacts: passed `-DPULP_ENABLE_AUDIO_PROBES=OFF` in all release/SDK/consumer-smoke workflows, the release gate in `build.yml`, local release scripts, checkout-backed SDK builds, and the Android template; added CI tests to guard these flags.

<sup>Written for commit 600936081c17d4581ec469b44abf091186b9b6f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

