### PR TITLE
fix(local-ci): preserve stale-running reconciliation

### DIFF
--- a/tools/local-ci/queue_lifecycle.py
+++ b/tools/local-ci/queue_lifecycle.py
@@ -16,19 +16,31 @@ def reconcile_running_jobs_unlocked(
     requeue_stale_running_job_unlocked_fn: Callable[[dict], None],
 ) -> tuple[list[dict], bool]:
     changed = False
-    actions = stale_running_reconciliation_actions_unlocked_fn(
-        queue,
-        stale_running_jobs_unlocked_fn(queue),
-    )
-    for action in actions:
-        job = action["job"]
-        if action["action"] == "supersede":
-            supersede_job_unlocked_fn(job, action["replacement"]["id"], action["reason"])
-            changed = True
-            continue
+    stale_jobs = list(stale_running_jobs_unlocked_fn(queue))
+    while True:
+        current_stale_jobs = [job for job in stale_jobs if job.get("status") == "running"]
+        if not current_stale_jobs:
+            break
+        actions = stale_running_reconciliation_actions_unlocked_fn(queue, current_stale_jobs)
+        if not actions:
+            break
+        action_applied = False
+        for action in actions:
+            job = action["job"]
+            if job.get("status") != "running":
+                continue
+            if action["action"] == "supersede":
+                supersede_job_unlocked_fn(job, action["replacement"]["id"], action["reason"])
+                changed = True
+                action_applied = True
+                break
 
-        requeue_stale_running_job_unlocked_fn(job)
-        changed = True
+            requeue_stale_running_job_unlocked_fn(job)
+            changed = True
+            action_applied = True
+            break
+        if not action_applied:
+            break
 
     return queue, changed
 

--- a/tools/local-ci/test_queue_lifecycle.py
+++ b/tools/local-ci/test_queue_lifecycle.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 
 MODULE_PATH = Path(__file__).with_name("queue_lifecycle.py")
+ORCHESTRATOR_PATH = Path(__file__).with_name("queue_orchestrator.py")
 
 
 def load_module():
@@ -18,6 +19,17 @@ def load_module():
     if script_dir not in sys.path:
         sys.path.insert(0, script_dir)
     spec = importlib.util.spec_from_file_location("pulp_queue_lifecycle", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_orchestrator_module():
+    script_dir = str(ORCHESTRATOR_PATH.parent)
+    if script_dir not in sys.path:
+        sys.path.insert(0, script_dir)
+    spec = importlib.util.spec_from_file_location("pulp_queue_orchestrator_for_lifecycle_tests", ORCHESTRATOR_PATH)
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)
@@ -48,17 +60,20 @@ class QueueLifecycleTests(unittest.TestCase):
 
         def actions(loaded_queue, stale):
             self.assertIs(loaded_queue, queue)
-            self.assertEqual(stale, [superseded_job, requeued_job])
             events.append(("actions", [job["id"] for job in stale]))
-            return [
-                {
-                    "action": "supersede",
-                    "job": superseded_job,
-                    "replacement": replacement,
-                    "reason": "newer_sha",
-                },
-                {"action": "requeue", "job": requeued_job},
-            ]
+            if stale == [superseded_job, requeued_job]:
+                return [
+                    {
+                        "action": "supersede",
+                        "job": superseded_job,
+                        "replacement": replacement,
+                        "reason": "newer_sha",
+                    },
+                    {"action": "requeue", "job": requeued_job},
+                ]
+            if stale == [requeued_job]:
+                return [{"action": "requeue", "job": requeued_job}]
+            self.fail(f"unexpected stale jobs: {stale}")
 
         def supersede(job, replacement_id, reason):
             events.append(("supersede", (job["id"], replacement_id, reason)))
@@ -85,7 +100,58 @@ class QueueLifecycleTests(unittest.TestCase):
                 ("stale", ["old", "retry", "new"]),
                 ("actions", ["old", "retry"]),
                 ("supersede", ("old", "new", "newer_sha")),
+                ("actions", ["retry"]),
                 ("requeue", "retry"),
+            ],
+        )
+
+    def test_reconcile_running_jobs_recomputes_against_current_queue(self) -> None:
+        orchestrator = load_orchestrator_module()
+        older = {
+            "id": "older",
+            "branch": "feature/q",
+            "sha": "a" * 40,
+            "fingerprint": "older",
+            "targets": ["mac"],
+            "priority": "normal",
+            "validation": "full",
+            "queued_at": "2026-06-09T00:00:00+00:00",
+            "status": "running",
+        }
+        newer = dict(
+            older,
+            id="newer",
+            sha="b" * 40,
+            fingerprint="newer",
+            queued_at="2026-06-09T00:01:00+00:00",
+        )
+        queue = [older, newer]
+        events: list[tuple[str, object]] = []
+
+        def supersede(job, replacement_id, reason):
+            events.append(("supersede", (job["id"], replacement_id, reason)))
+            job["status"] = "completed"
+
+        def requeue(job):
+            events.append(("requeue", job["id"]))
+            job["status"] = "pending"
+
+        result = self.mod.reconcile_running_jobs_unlocked(
+            queue,
+            stale_running_jobs_unlocked_fn=lambda loaded_queue: list(loaded_queue),
+            stale_running_reconciliation_actions_unlocked_fn=orchestrator.stale_running_reconciliation_actions_unlocked,
+            supersede_job_unlocked_fn=supersede,
+            requeue_stale_running_job_unlocked_fn=requeue,
+        )
+
+        self.assertEqual(result, (queue, True))
+        self.assertEqual(older["status"], "completed")
+        self.assertEqual(newer["status"], "pending")
+        self.assertEqual(
+            events,
+            [
+                ("supersede", ("older", "newer", "newer_sha_queued")),
+                ("requeue", "newer"),
             ],
         )
 


### PR DESCRIPTION
## Summary
- fix stale-running reconciliation to recompute actions against the current mutated queue after each applied action
- preserve the callback list-of-actions contract while avoiding mutual supersedence between stale running jobs
- add regression coverage for two stale running jobs in the same supersedence scope

## Why
Retroactive local adversarial review of the last-24h queue-lifecycle refactor cluster found that batching stale-running decisions against the original queue could complete every recoverable job when two stale running jobs superseded each other.

## Validation
- `python3 -m py_compile tools/local-ci/queue_lifecycle.py tools/local-ci/test_queue_lifecycle.py`
- `python3 tools/local-ci/test_queue_lifecycle.py`
- `python3 tools/local-ci/test_queue_orchestrator.py -k stale_running`
- `python3 -m unittest discover -s tools/local-ci -p 'test_*.py'` (459 tests OK)\n- `python3 tools/import-validation/check-source-contracts.py --strict`\n- `python3 tools/import-validation/test_source_contracts.py`\n- `tools/scripts/gates.sh`\n- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report --require-bump-for-fix-feat --pr-title "fix(local-ci): preserve stale-running reconciliation"`\n- `git diff --check HEAD~1..HEAD`\n\n## Local adversarial review\n- Initial retro review found the stale-running mutual-supersedence bug.\n- First hotfix review caught a dropped multi-action contract; fixed before push.\n- Final hotfix review clean: no accepted/actionable findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale-running reconciliation to apply one action at a time and recompute against the current queue, preventing mutual supersedence from completing all recoverable jobs. Adds regression tests to lock the expected behavior with two running jobs in the same supersedence scope.

- **Bug Fixes**
  - Switch from batch processing to a loop that recalculates actions after each applied change.
  - Ignore actions for jobs no longer running to avoid stale decisions and ensure proper supersede-then-requeue.
  - Add regression tests for two stale-running jobs; preserve the list-of-actions callback contract.

<sup>Written for commit 0e806e48ca8511abdc98928e044ccd5b47d412d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

