### PR TITLE
fix(format): preserve inbound CLAP SysEx on RT path

### DIFF
--- a/.agents/skills/aax/SKILL.md
+++ b/.agents/skills/aax/SKILL.md
@@ -138,6 +138,9 @@ int32_t sysex_start_offset = 0;
 This matches the shape used for CLAP/VST3/AU/CoreMIDI/ALSA sysex (#239).
 See `core/format/src/aax_runtime.cpp::decode_midi_node` for the canonical
 implementation landed in #408.
+The AAX bypass MIDI-thru helper must copy sidecar payloads with
+`MidiBuffer::add_sysex_copy()`; `MidiBuffer::SysexPayload` is deliberately
+not a movable raw `std::vector`.
 
 When adding or changing any AAX MIDI input path, exercise this against a
 multi-packet sysex vector (at least one packet across the 4-byte boundary

--- a/.agents/skills/clap/SKILL.md
+++ b/.agents/skills/clap/SKILL.md
@@ -169,8 +169,8 @@ CLAP_EVENT_NOTE_ON / _NOTE_OFF → MidiEvent::note_on / note_off
 CLAP_EVENT_MIDI                → MidiEvent::from_bytes(data[0..2])
                                  — CC, pitch bend, channel AT,
                                    poly AT, program change
-CLAP_EVENT_MIDI_SYSEX          → dropped on the realtime-limited path
-                                 until a preallocated payload arena exists
+CLAP_EVENT_MIDI_SYSEX          → midi_in.add_sysex_copy(bytes, time, 0.0)
+                                 backed by a preallocated payload pool
 CLAP_EVENT_NOTE_EXPRESSION     → synthesised MIDI 1.0 (see table)
 CLAP_EVENT_NOTE_CHOKE          → note_off(channel, key, velocity=0)
 CLAP_EVENT_MIDI2               → self->ump_buffer.add(packet)
@@ -211,20 +211,24 @@ the reserved capacity, appends must drop and increment the relevant drop
 counters; they must not grow vectors under the process no-allocation
 guard.
 
-Inbound CLAP SysEx is the exception: the host gives the adapter a
-non-owning payload pointer, so accepting it requires copying bytes into
-owned storage. In the current realtime-limited path,
-`MidiBuffer::add_sysex_copy()` drops and increments the sysex drop count
-instead. Move-based, prebuilt outbound SysEx remains supported. If you
-add a preallocated inbound payload arena later, cover that path and its
-overflow case in `test_clap_midi_events.cpp`.
+Inbound CLAP SysEx is the exception to the move-based adapter pattern:
+the host gives the adapter a non-owning payload pointer, so accepting it
+requires copying bytes into owned storage. `clap_activate()` reserves a
+bounded payload pool on `midi_in`; `MidiBuffer::add_sysex_copy()` copies
+into that pool on the realtime-limited process path and drops only when
+the sidecar count or per-payload capacity is exceeded. Keep the happy
+path and overflow case covered in `test_clap_midi_events.cpp`.
 
 If you add a new inbound/outbound MIDI path, cover the overflow case in
 `test_clap_midi_events.cpp`. If you add a test processor that
 captures/forwards sysex while behind the CLAP no-alloc guard, preallocate
-in `prepare()` and move prebuilt sysex events into `MidiBuffer`; copying
-a vector payload inside `process()` will trip the RT allocation trap
-under ASan/TSan/debug test builds.
+destination SysEx payload storage in `prepare()` and call
+`MidiBuffer::add_sysex_copy()` for explicit captures. Whole-event
+forwarding with `midi_out.add_sysex(std::move(sx))` is supported because
+pool-backed input events copy into the destination's prepared payload
+pool; moving only `sx.data` out of `midi_in` is intentionally not
+supported. Copying a vector payload inside `process()` will trip the RT
+allocation trap under ASan/TSan/debug test builds.
 
 ### State save / restore
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.409.0
+    VERSION 0.410.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/src/aax_runtime.cpp
+++ b/core/format/src/aax_runtime.cpp
@@ -190,7 +190,10 @@ void copy_midi(const midi::MidiBuffer& in, midi::MidiBuffer& out) {
     // bulk dumps and MIDI-CI workflows in bypass mode specifically.
     // See #438 P2 Codex review on #408.
     for (const auto& sx : in.sysex()) {
-        out.add_sysex(sx.data, sx.sample_offset, sx.timestamp);
+        out.add_sysex_copy(sx.data.data(),
+                           sx.data.size(),
+                           sx.sample_offset,
+                           sx.timestamp);
     }
 }
 

--- a/core/format/src/clap_adapter.cpp
+++ b/core/format/src/clap_adapter.cpp
@@ -19,10 +19,18 @@ namespace pulp::format::clap_adapter {
 namespace {
 constexpr std::size_t kRealtimeMidiEventCapacity = state::ParameterEventQueue::kCapacity;
 constexpr std::size_t kRealtimeMidiSysexCapacity = 128;
+constexpr std::size_t kRealtimeMidiSysexPayloadCapacity = 4096;
 }
 
 static PulpClapPlugin* get_self(const clap_plugin_t* plugin) {
     return static_cast<PulpClapPlugin*>(plugin->plugin_data);
+}
+
+static void clear_midi_event_buffers(PulpClapPlugin& self) {
+    self.midi_in.clear();
+    self.midi_in.clear_sysex();
+    self.midi_out.clear();
+    self.midi_out.clear_sysex();
 }
 
 // Read a CLAP event by value from the (possibly-misaligned) header
@@ -120,8 +128,13 @@ bool clap_activate(const clap_plugin_t* plugin, double sr, uint32_t, uint32_t ma
     auto* self = get_self(plugin);
     self->sample_rate = sr;
     self->max_buffer_size = static_cast<int>(max_frames);
-    self->midi_in.reserve(kRealtimeMidiEventCapacity, kRealtimeMidiSysexCapacity);
-    self->midi_out.reserve(kRealtimeMidiEventCapacity, kRealtimeMidiSysexCapacity);
+    clear_midi_event_buffers(*self);
+    self->midi_in.reserve(kRealtimeMidiEventCapacity,
+                          kRealtimeMidiSysexCapacity,
+                          kRealtimeMidiSysexPayloadCapacity);
+    self->midi_out.reserve(kRealtimeMidiEventCapacity,
+                           kRealtimeMidiSysexCapacity,
+                           kRealtimeMidiSysexPayloadCapacity);
     self->midi_in.set_realtime_capacity_limit(true);
     self->midi_out.set_realtime_capacity_limit(true);
     self->mpe_buffer.reserve(kRealtimeMidiEventCapacity);
@@ -151,6 +164,7 @@ bool clap_activate(const clap_plugin_t* plugin, double sr, uint32_t, uint32_t ma
 void clap_deactivate(const clap_plugin_t* plugin) {
     auto* self = get_self(plugin);
     self->processor->release();
+    clear_midi_event_buffers(*self);
     self->playhead_prev = {};
 }
 
@@ -158,6 +172,7 @@ bool clap_start_processing(const clap_plugin_t*) { return true; }
 void clap_stop_processing(const clap_plugin_t*) {}
 void clap_reset(const clap_plugin_t* plugin) {
     auto* self = get_self(plugin);
+    clear_midi_event_buffers(*self);
     self->playhead_prev = {};
 }
 
@@ -280,10 +295,7 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
     // Build MIDI from CLAP note events
     auto& midi_in = self->midi_in;
     auto& midi_out = self->midi_out;
-    midi_in.clear();
-    midi_in.clear_sysex();
-    midi_out.clear();
-    midi_out.clear_sysex();
+    clear_midi_event_buffers(*self);
     // Track whether any native CLAP_EVENT_MIDI2 packet was delivered so we
     // can skip the MIDI 1.0 → UMP synthesis path when the host is speaking
     // UMP natively. The host still sends CLAP_EVENT_NOTE_* in parallel for
@@ -449,9 +461,9 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
                     0.0};
                 midi_in.add(me);
             } else if (hdr->type == CLAP_EVENT_MIDI_SYSEX) {
-                // CLAP gives us a host-owned payload pointer. The current
-                // realtime-limited MidiBuffer drops copy-based SysEx rather
-                // than allocating payload storage on the process path.
+                // CLAP gives us a host-owned payload pointer. midi_in owns a
+                // preallocated payload pool so the copy below does not allocate
+                // on the process path.
                 const auto ev = load_event<clap_event_midi_sysex_t>(hdr);
                 if (ev.buffer && ev.size > 0) {
                     midi_in.add_sysex_copy(

--- a/core/midi/include/pulp/midi/buffer.hpp
+++ b/core/midi/include/pulp/midi/buffer.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <vector>
 #include <algorithm>
+#include <initializer_list>
 #include <limits>
 
 namespace pulp::midi {
@@ -23,6 +24,64 @@ namespace pulp::midi {
 class MidiBuffer {
 public:
     MidiBuffer() = default;
+    MidiBuffer(const MidiBuffer& other)
+        : ump_(other.ump_),
+          sysex_copy_payload_capacity_(other.sysex_copy_payload_capacity_),
+          limit_to_reserved_capacity_(other.limit_to_reserved_capacity_),
+          dropped_events_(other.dropped_events_),
+          dropped_sysex_events_(other.dropped_sysex_events_) {
+        copy_event_storage(other);
+        reserve_copied_sysex_payloads(other);
+    }
+    MidiBuffer& operator=(const MidiBuffer& other) {
+        if (this != &other) {
+            sysex_.clear();
+            ump_ = other.ump_;
+            sysex_copy_payload_capacity_ = other.sysex_copy_payload_capacity_;
+            limit_to_reserved_capacity_ = other.limit_to_reserved_capacity_;
+            dropped_events_ = other.dropped_events_;
+            dropped_sysex_events_ = other.dropped_sysex_events_;
+            copy_event_storage(other);
+            reserve_copied_sysex_payloads(other);
+        }
+        return *this;
+    }
+    MidiBuffer(MidiBuffer&& other) noexcept
+        : events_(std::move(other.events_)),
+          sysex_copy_payload_pool_(std::move(other.sysex_copy_payload_pool_)),
+          sysex_(std::move(other.sysex_)),
+          ump_(other.ump_),
+          sysex_copy_payload_capacity_(other.sysex_copy_payload_capacity_),
+          limit_to_reserved_capacity_(other.limit_to_reserved_capacity_),
+          dropped_events_(other.dropped_events_),
+          dropped_sysex_events_(other.dropped_sysex_events_) {
+        rebind_sysex_payloads_to_pool();
+        other.ump_ = nullptr;
+        other.sysex_copy_payload_capacity_ = 0;
+        other.limit_to_reserved_capacity_ = false;
+        other.dropped_events_ = 0;
+        other.dropped_sysex_events_ = 0;
+    }
+    MidiBuffer& operator=(MidiBuffer&& other) noexcept {
+        if (this != &other) {
+            sysex_.clear();
+            events_ = std::move(other.events_);
+            sysex_copy_payload_pool_ = std::move(other.sysex_copy_payload_pool_);
+            sysex_ = std::move(other.sysex_);
+            ump_ = other.ump_;
+            sysex_copy_payload_capacity_ = other.sysex_copy_payload_capacity_;
+            limit_to_reserved_capacity_ = other.limit_to_reserved_capacity_;
+            dropped_events_ = other.dropped_events_;
+            dropped_sysex_events_ = other.dropped_sysex_events_;
+            rebind_sysex_payloads_to_pool();
+            other.ump_ = nullptr;
+            other.sysex_copy_payload_capacity_ = 0;
+            other.limit_to_reserved_capacity_ = false;
+            other.dropped_events_ = 0;
+            other.dropped_sysex_events_ = 0;
+        }
+        return *this;
+    }
 
     /// Append a MIDI event to the buffer.
     bool add(const MidiEvent& event) {
@@ -53,21 +112,31 @@ public:
     std::size_t size() const { return events_.size(); }
 
     /// Preallocate storage for realtime callers that append during process().
-    void reserve(std::size_t event_capacity, std::size_t sysex_capacity = 0) {
+    void reserve(std::size_t event_capacity,
+                 std::size_t sysex_capacity = 0,
+                 std::size_t sysex_copy_payload_capacity = 0) {
         events_.reserve(event_capacity);
         sysex_.reserve(sysex_capacity);
+        if (sysex_copy_payload_capacity > 0) {
+            reserve_sysex_copy_payloads(sysex_capacity,
+                                        sysex_copy_payload_capacity);
+        }
     }
 
     /// When enabled, add() and move-based add_sysex() drop once reserved
-    /// capacity is full instead of growing vectors. add_sysex_copy() always
-    /// drops in this mode because copying host-owned payload bytes would
-    /// allocate on the realtime path. Intended for adapter-owned buffers.
+    /// capacity is full instead of growing vectors. add_sysex_copy() uses
+    /// reserve_sysex_copy_payloads() storage in this mode and drops when no
+    /// reserved payload slot can hold the event. Intended for adapter-owned
+    /// buffers.
     void set_realtime_capacity_limit(bool enabled = true) {
         limit_to_reserved_capacity_ = enabled;
     }
     bool realtime_capacity_limited() const { return limit_to_reserved_capacity_; }
     std::size_t event_capacity() const { return events_.capacity(); }
     std::size_t sysex_capacity() const { return sysex_.capacity(); }
+    std::size_t sysex_copy_payload_capacity() const {
+        return sysex_copy_payload_capacity_;
+    }
     std::uint32_t dropped_event_count() const { return dropped_events_; }
     std::uint32_t dropped_sysex_count() const { return dropped_sysex_events_; }
 
@@ -114,8 +183,125 @@ public:
     // list with kData type, CLAP CLAP_EVENT_MIDI_SYSEX) populate this
     // alongside the short-message stream; plugins that don't care can
     // ignore it.
+    class SysexPayload {
+    public:
+        SysexPayload() = default;
+        SysexPayload(std::initializer_list<uint8_t> values) : bytes_(values) {}
+        SysexPayload(std::vector<uint8_t> bytes)
+            : bytes_(std::move(bytes)) {}
+
+        SysexPayload(const SysexPayload& other)
+            : bytes_(other.bytes_),
+              realtime_pool_backed_(other.realtime_pool_backed_) {}
+        SysexPayload& operator=(const SysexPayload& other) {
+            if (this != &other) {
+                recycle_now();
+                bytes_ = other.bytes_;
+                realtime_pool_backed_ = other.realtime_pool_backed_;
+                recycle_pool_ = nullptr;
+                recycle_capacity_ = 0;
+            }
+            return *this;
+        }
+
+        ~SysexPayload() { recycle_now(); }
+
+        SysexPayload(SysexPayload&&) = delete;
+        SysexPayload& operator=(SysexPayload&&) = delete;
+
+        SysexPayload& operator=(std::initializer_list<uint8_t> values) {
+            mutable_bytes().assign(values.begin(), values.end());
+            return *this;
+        }
+        SysexPayload& operator=(std::vector<uint8_t> bytes) {
+            recycle_now();
+            bytes_ = std::move(bytes);
+            realtime_pool_backed_ = false;
+            return *this;
+        }
+
+        std::size_t size() const { return view().size(); }
+        bool empty() const { return view().empty(); }
+        std::size_t capacity() const { return view().capacity(); }
+        const uint8_t* data() const { return view().data(); }
+        uint8_t* data() { return mutable_bytes().data(); }
+        const uint8_t& front() const { return view().front(); }
+        uint8_t& front() { return mutable_bytes().front(); }
+        const uint8_t& back() const { return view().back(); }
+        uint8_t& back() { return mutable_bytes().back(); }
+        const uint8_t& operator[](std::size_t index) const {
+            return view()[index];
+        }
+        uint8_t& operator[](std::size_t index) {
+            return mutable_bytes()[index];
+        }
+        auto begin() const { return view().begin(); }
+        auto end() const { return view().end(); }
+        auto begin() { return mutable_bytes().begin(); }
+        auto end() { return mutable_bytes().end(); }
+        void reserve(std::size_t capacity) { mutable_bytes().reserve(capacity); }
+        void resize(std::size_t size) { mutable_bytes().resize(size); }
+        void clear() { mutable_bytes().clear(); }
+        void push_back(uint8_t byte) { mutable_bytes().push_back(byte); }
+
+        std::vector<uint8_t> to_vector() const { return view(); }
+
+        friend bool operator==(const SysexPayload& lhs,
+                               const std::vector<uint8_t>& rhs) {
+            return lhs.view() == rhs;
+        }
+        friend bool operator==(const std::vector<uint8_t>& lhs,
+                               const SysexPayload& rhs) {
+            return lhs == rhs.view();
+        }
+        friend bool operator!=(const SysexPayload& lhs,
+                               const std::vector<uint8_t>& rhs) {
+            return !(lhs == rhs);
+        }
+        friend bool operator!=(const std::vector<uint8_t>& lhs,
+                               const SysexPayload& rhs) {
+            return !(lhs == rhs);
+        }
+
+    private:
+        friend class MidiBuffer;
+
+        const std::vector<uint8_t>& view() const { return bytes_; }
+        std::vector<uint8_t>& mutable_bytes() { return bytes_; }
+        std::vector<uint8_t> release_owned_vector() {
+            recycle_pool_ = nullptr;
+            realtime_pool_backed_ = false;
+            return std::move(bytes_);
+        }
+        bool realtime_pool_backed() const { return realtime_pool_backed_; }
+        void set_realtime_pool_backed(
+            bool backed,
+            std::vector<std::vector<uint8_t>>* recycle_pool = nullptr,
+            std::size_t recycle_capacity = 0) {
+            realtime_pool_backed_ = backed;
+            recycle_pool_ = backed ? recycle_pool : nullptr;
+            recycle_capacity_ = backed ? recycle_capacity : 0;
+        }
+        void recycle_now() {
+            if (recycle_pool_ != nullptr && recycle_capacity_ > 0
+                && bytes_.capacity() >= recycle_capacity_
+                && recycle_pool_->size() < recycle_pool_->capacity()) {
+                bytes_.clear();
+                recycle_pool_->push_back(std::move(bytes_));
+            }
+            recycle_pool_ = nullptr;
+            recycle_capacity_ = 0;
+            realtime_pool_backed_ = false;
+        }
+
+        std::vector<uint8_t> bytes_;
+        std::vector<std::vector<uint8_t>>* recycle_pool_ = nullptr;
+        std::size_t recycle_capacity_ = 0;
+        bool realtime_pool_backed_ = false;
+    };
+
     struct SysexEvent {
-        std::vector<uint8_t> data;   ///< full F0 .. F7 payload
+        SysexPayload data;           ///< full F0 .. F7 payload
         int32_t sample_offset = 0;   ///< sample position within the block
         double  timestamp = 0.0;     ///< absolute time in seconds
     };
@@ -125,15 +311,29 @@ public:
             record_sysex_drop();
             return false;
         }
-        sysex_.push_back({std::move(data), sample_offset, ts});
+        sysex_.emplace_back();
+        auto& event = sysex_.back();
+        event.data = std::move(data);
+        event.sample_offset = sample_offset;
+        event.timestamp = ts;
         return true;
     }
     bool add_sysex(SysexEvent&& event) {
+        if (event.data.realtime_pool_backed()) {
+            return add_sysex_copy(event.data.data(),
+                                  event.data.size(),
+                                  event.sample_offset,
+                                  event.timestamp);
+        }
         if (!can_append_sysex()) {
             record_sysex_drop();
             return false;
         }
-        sysex_.push_back(std::move(event));
+        sysex_.emplace_back();
+        auto& dst = sysex_.back();
+        dst.data = event.data.release_owned_vector();
+        dst.sample_offset = event.sample_offset;
+        dst.timestamp = event.timestamp;
         return true;
     }
     bool add_sysex_copy(const uint8_t* data,
@@ -141,21 +341,31 @@ public:
                         int32_t sample_offset = 0,
                         double ts = 0.0) {
         if (limit_to_reserved_capacity_) {
-            record_sysex_drop();
-            return false;
+            return add_sysex_copy_realtime(data, size, sample_offset, ts);
         }
         if (!can_append_sysex()) {
             record_sysex_drop();
             return false;
         }
-        sysex_.push_back({
-            std::vector<uint8_t>(data, data + size),
-            sample_offset,
-            ts,
-        });
-        return true;
+        return add_sysex(std::vector<uint8_t>(data, data + size),
+                         sample_offset,
+                         ts);
+    }
+    void reserve_sysex_copy_payloads(std::size_t payload_count,
+                                     std::size_t payload_capacity) {
+        sysex_copy_payload_capacity_ = payload_capacity;
+        sysex_copy_payload_pool_.clear();
+        sysex_copy_payload_pool_.reserve(payload_count);
+        for (std::size_t i = 0; i < payload_count; ++i) {
+            std::vector<uint8_t> payload;
+            payload.reserve(payload_capacity);
+            sysex_copy_payload_pool_.push_back(std::move(payload));
+        }
     }
     void clear_sysex() {
+        for (auto& event : sysex_) {
+            recycle_sysex_payload(event.data.release_owned_vector());
+        }
         sysex_.clear();
         dropped_sysex_events_ = 0;
     }
@@ -170,6 +380,82 @@ private:
     bool can_append_sysex() const {
         return !limit_to_reserved_capacity_ || sysex_.size() < sysex_.capacity();
     }
+    bool add_sysex_copy_realtime(const uint8_t* data,
+                                 std::size_t size,
+                                 int32_t sample_offset,
+                                 double ts) {
+        if (!can_append_sysex() || sysex_copy_payload_pool_.empty()
+            || size > sysex_copy_payload_capacity_) {
+            record_sysex_drop();
+            return false;
+        }
+        auto payload = std::move(sysex_copy_payload_pool_.back());
+        sysex_copy_payload_pool_.pop_back();
+        payload.resize(size);
+        std::copy(data, data + size, payload.begin());
+        sysex_.emplace_back();
+        auto& event = sysex_.back();
+        event.data = std::move(payload);
+        event.data.set_realtime_pool_backed(true,
+                                            &sysex_copy_payload_pool_,
+                                            sysex_copy_payload_capacity_);
+        event.sample_offset = sample_offset;
+        event.timestamp = ts;
+        return true;
+    }
+    void recycle_sysex_payload(std::vector<uint8_t>&& payload) {
+        if (sysex_copy_payload_capacity_ == 0
+            || payload.capacity() < sysex_copy_payload_capacity_
+            || sysex_copy_payload_pool_.size()
+                   >= sysex_copy_payload_pool_.capacity()) {
+            return;
+        }
+        payload.clear();
+        sysex_copy_payload_pool_.push_back(std::move(payload));
+    }
+    void copy_event_storage(const MidiBuffer& other) {
+        events_.clear();
+        events_.reserve(other.events_.capacity());
+        events_ = other.events_;
+        sysex_.clear();
+        sysex_.reserve(other.sysex_.capacity());
+        sysex_ = other.sysex_;
+    }
+    void reserve_copied_sysex_payloads(const MidiBuffer& other) {
+        sysex_copy_payload_pool_.clear();
+        if (sysex_copy_payload_capacity_ == 0) {
+            return;
+        }
+        for (auto& event : sysex_) {
+            if (event.data.size() <= sysex_copy_payload_capacity_) {
+                event.data.reserve(sysex_copy_payload_capacity_);
+                event.data.set_realtime_pool_backed(
+                    event.data.realtime_pool_backed(),
+                    event.data.realtime_pool_backed()
+                        ? &sysex_copy_payload_pool_
+                        : nullptr,
+                    event.data.realtime_pool_backed()
+                        ? sysex_copy_payload_capacity_
+                        : 0);
+            }
+        }
+        sysex_copy_payload_pool_.reserve(
+            other.sysex_copy_payload_pool_.capacity());
+        for (std::size_t i = 0; i < other.sysex_copy_payload_pool_.size(); ++i) {
+            std::vector<uint8_t> payload;
+            payload.reserve(sysex_copy_payload_capacity_);
+            sysex_copy_payload_pool_.push_back(std::move(payload));
+        }
+    }
+    void rebind_sysex_payloads_to_pool() {
+        for (auto& event : sysex_) {
+            if (event.data.realtime_pool_backed()) {
+                event.data.set_realtime_pool_backed(true,
+                                                    &sysex_copy_payload_pool_,
+                                                    sysex_copy_payload_capacity_);
+            }
+        }
+    }
     static void saturating_increment(std::uint32_t& value) {
         if (value < std::numeric_limits<std::uint32_t>::max()) {
             ++value;
@@ -179,8 +465,10 @@ private:
     void record_sysex_drop() { saturating_increment(dropped_sysex_events_); }
 
     std::vector<MidiEvent> events_;
+    std::vector<std::vector<uint8_t>> sysex_copy_payload_pool_;
     std::vector<SysexEvent> sysex_;
     class UmpBuffer* ump_ = nullptr;
+    std::size_t sysex_copy_payload_capacity_ = 0;
     bool limit_to_reserved_capacity_ = false;
     std::uint32_t dropped_events_ = 0;
     std::uint32_t dropped_sysex_events_ = 0;

--- a/docs/guides/formats.md
+++ b/docs/guides/formats.md
@@ -61,9 +61,10 @@ CLAP note and MIDI events are converted into Pulp's block event surfaces:
 - `CLAP_EVENT_NOTE_CHOKE` becomes a zero-velocity note-off
 - `CLAP_EVENT_MIDI` carries raw MIDI 1.0 channel messages such as CC, pitch
   bend, channel pressure, poly pressure, and program change
-- `CLAP_EVENT_MIDI_SYSEX` is dropped on the realtime-limited inbound path
-  until a preallocated payload arena exists; outbound processor-owned SysEx
-  still emits as `CLAP_EVENT_MIDI_SYSEX`
+- `CLAP_EVENT_MIDI_SYSEX` is copied into a preallocated inbound payload arena
+  (128 events per block, 4096 bytes per event); overflow or larger payloads are
+  dropped and counted. Outbound processor-owned SysEx emits as
+  `CLAP_EVENT_MIDI_SYSEX`
 - `CLAP_EVENT_MIDI2` is routed through `ump_input()` when the plugin opts into
   UMP
 - `CLAP_EVENT_NOTE_EXPRESSION` feeds the MPE sidecar when the plugin opts into

--- a/test/test_clap_midi_events.cpp
+++ b/test/test_clap_midi_events.cpp
@@ -16,9 +16,8 @@
 //     - CLAP_EVENT_MIDI2    — routed straight to the UMP sidecar when
 //                             the plugin opted in to UMP.
 //     - CLAP_EVENT_MIDI_SYSEX
-//                           — dropped on the realtime-limited inbound path
-//                             because accepting host-owned payload bytes
-//                             requires a copy.
+//                           — copied into MidiBuffer's preallocated SysEx
+//                             sidecar.
 //   Outbound:
 //     - midi_out → CLAP_EVENT_MIDI on out_events.
 //     - midi_out sysex → CLAP_EVENT_MIDI_SYSEX on out_events.
@@ -45,6 +44,7 @@
 #include <clap/ext/preset-load.h>
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstring>
 #include <memory>
@@ -218,7 +218,8 @@ public:
     }
     void prepare(const PrepareContext& context) override {
         captured_prepare = context;
-        captured_midi.reserve(64, 16);
+        captured_midi.reserve(64, 16, 4096);
+        captured_midi.set_realtime_capacity_limit(true);
         captured_ump.reserve(64);
         captured_param_events.reserve(64);
         ++prepare_count;
@@ -255,9 +256,10 @@ public:
         for (const auto& ev : midi_in) captured_midi.add(ev);
         for (auto& se : midi_in.sysex()) {
             // This test processor runs behind the CLAP adapter's no-alloc
-            // process guard; steal the adapter-owned sysex payload rather
-            // than allocating a copy while capturing assertions.
-            captured_midi.add_sysex(std::move(se.data), se.sample_offset, se.timestamp);
+            // process guard, so capture into this processor's own prepared
+            // SysEx payload pool rather than moving adapter-owned storage.
+            captured_midi.add_sysex_copy(
+                se.data.data(), se.data.size(), se.sample_offset, se.timestamp);
         }
         had_mpe_input = (mpe_input() != nullptr);
         had_ump_input = (ump_input() != nullptr);
@@ -312,6 +314,10 @@ public:
     std::size_t observed_event_capacity = 0;
     std::size_t observed_sysex_count = 0;
     std::size_t observed_sysex_capacity = 0;
+    std::size_t observed_sysex_payload_capacity = 0;
+    std::size_t observed_first_sysex_size = 0;
+    int32_t observed_first_sysex_offset = -1;
+    std::array<uint8_t, 8> observed_first_sysex_prefix{};
     std::uint32_t observed_event_drops = 0;
     std::uint32_t observed_sysex_drops = 0;
 
@@ -335,6 +341,17 @@ public:
         observed_event_capacity = midi_in.event_capacity();
         observed_sysex_count = midi_in.sysex_size();
         observed_sysex_capacity = midi_in.sysex_capacity();
+        observed_sysex_payload_capacity = midi_in.sysex_copy_payload_capacity();
+        if (!midi_in.sysex().empty()) {
+            const auto& sx = midi_in.sysex().front();
+            observed_first_sysex_size = sx.data.size();
+            observed_first_sysex_offset = sx.sample_offset;
+            for (std::size_t i = 0;
+                 i < sx.data.size() && i < observed_first_sysex_prefix.size();
+                 ++i) {
+                observed_first_sysex_prefix[i] = sx.data[i];
+            }
+        }
         observed_event_drops = midi_in.dropped_event_count();
         observed_sysex_drops = midi_in.dropped_sysex_count();
     }
@@ -415,7 +432,7 @@ public:
                 midi::MidiBuffer::SysexEvent se;
                 se.data = {0xF0, 0x7D, static_cast<uint8_t>(i & 0x7F), 0xF7};
                 se.sample_offset = static_cast<int32_t>(i);
-                sysex_to_emit.push_back(std::move(se));
+                sysex_to_emit.push_back(se);
             }
         }
     }
@@ -443,6 +460,40 @@ public:
     }
 };
 
+class ForwardingSysexProcessor : public Processor {
+public:
+    std::size_t observed_input_sysex_count = 0;
+    std::size_t observed_output_sysex_count = 0;
+    std::uint32_t observed_input_sysex_drops = 0;
+    std::uint32_t observed_output_sysex_drops = 0;
+
+    PluginDescriptor descriptor() const override {
+        PluginDescriptor d;
+        d.name = "ForwardingSysexCLAP";
+        d.manufacturer = "PulpTest";
+        d.bundle_id = "com.pulp.test.clap.forwarding-sysex";
+        d.version = "1.0.0";
+        d.accepts_midi = true;
+        d.produces_midi = true;
+        return d;
+    }
+    void define_parameters(state::StateStore&) override {}
+    void prepare(const PrepareContext&) override {}
+    void process(audio::BufferView<float>&,
+                 const audio::BufferView<const float>&,
+                 midi::MidiBuffer& midi_in,
+                 midi::MidiBuffer& midi_out,
+                 const ProcessContext&) override {
+        for (auto& sx : midi_in.sysex()) {
+            midi_out.add_sysex(std::move(sx));
+        }
+        observed_input_sysex_count = midi_in.sysex_size();
+        observed_output_sysex_count = midi_out.sysex_size();
+        observed_input_sysex_drops = midi_in.dropped_sysex_count();
+        observed_output_sysex_drops = midi_out.dropped_sysex_count();
+    }
+};
+
 // Processor factory hooks have to be raw function pointers. Route through
 // singletons so the tests can configure the active processor before the
 // adapter instantiates one.
@@ -451,6 +502,7 @@ EmittingProcessor*  g_emitting  = nullptr;
 ObservingMidiInProcessor* g_observing_midi_in = nullptr;
 ObservingSidecarProcessor* g_observing_sidecar = nullptr;
 OverflowingMidiOutProcessor* g_overflowing_midi_out = nullptr;
+ForwardingSysexProcessor* g_forwarding_sysex = nullptr;
 bool g_pending_opts_mpe = false;
 bool g_pending_opts_ump = false;
 bool g_pending_opts_node_mpe = false;
@@ -504,6 +556,12 @@ std::unique_ptr<Processor> make_overflowing_midi_out() {
     g_overflowing_midi_out = up.get();
     up->emit_sysex = g_pending_overflow_sysex;
     g_pending_overflow_sysex = false;
+    return up;
+}
+
+std::unique_ptr<Processor> make_forwarding_sysex() {
+    auto up = std::make_unique<ForwardingSysexProcessor>();
+    g_forwarding_sysex = up.get();
     return up;
 }
 
@@ -1534,7 +1592,7 @@ TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION vibrato / expression dropped silently when
 
 // ── Inbound: CLAP_EVENT_MIDI_SYSEX ──────────────────────────────────────
 
-TEST_CASE("CLAP_EVENT_MIDI_SYSEX drops copy payload in realtime-limited path",
+TEST_CASE("CLAP_EVENT_MIDI_SYSEX decodes into realtime-owned MidiBuffer sidecar",
           "[clap][midi][issue-pending]") {
     g_pending_opts_mpe = false;
     g_pending_opts_ump = false;
@@ -1550,10 +1608,109 @@ TEST_CASE("CLAP_EVENT_MIDI_SYSEX drops copy payload in realtime-limited path",
     events.push(ev);
 
     REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+#if PULP_CLAP_PROCESS_RT_TRAP_TESTS
+    clap_process_status status = CLAP_PROCESS_ERROR;
+    {
+        native_components::test::RtNoAllocScope guard;
+        status = h.run(events);
+    }
+    REQUIRE(status == CLAP_PROCESS_CONTINUE);
+#endif
     REQUIRE(g_observing_midi_in != nullptr);
     REQUIRE(g_observing_midi_in->observed_sysex_capacity == 128);
-    REQUIRE(g_observing_midi_in->observed_sysex_count == 0);
-    REQUIRE(g_observing_midi_in->observed_sysex_drops == 1);
+    REQUIRE(g_observing_midi_in->observed_sysex_payload_capacity >= sizeof(kPayload));
+    REQUIRE(g_observing_midi_in->observed_sysex_count == 1);
+    REQUIRE(g_observing_midi_in->observed_first_sysex_size == sizeof(kPayload));
+    REQUIRE(g_observing_midi_in->observed_first_sysex_offset == 21);
+    REQUIRE(g_observing_midi_in->observed_first_sysex_prefix[0] == 0xF0);
+    REQUIRE(g_observing_midi_in->observed_first_sysex_prefix[1] == 0x7E);
+    REQUIRE(g_observing_midi_in->observed_first_sysex_prefix[5] == 0xF7);
+    REQUIRE(g_observing_midi_in->observed_sysex_drops == 0);
+}
+
+TEST_CASE("CLAP_EVENT_MIDI_SYSEX sidecar is cleared off-thread across reactivation",
+          "[clap][midi][realtime][sysex]") {
+    Harness h(make_observing_midi_in);
+
+    static const uint8_t kPayload[] = {0xF0, 0x7E, 0x7F, 0x06, 0x01, 0xF7};
+    InputEventList events;
+    clap_event_midi_sysex_t ev{};
+    ev.header = make_header(sizeof(ev), CLAP_EVENT_MIDI_SYSEX, 11);
+    ev.port_index = 0;
+    ev.buffer = kPayload;
+    ev.size = sizeof(kPayload);
+    events.push(ev);
+
+    REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+    REQUIRE(h.plugin.midi_in.sysex_size() == 1);
+
+    h.deactivate();
+    REQUIRE(h.plugin.midi_in.sysex_size() == 0);
+    REQUIRE(clap_adapter::clap_activate(&h.plugin.plugin, 48000.0, 32,
+                                         Harness::kFrames));
+    h.active = true;
+    REQUIRE(h.plugin.midi_in.sysex_size() == 0);
+
+    REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+    REQUIRE(g_observing_midi_in != nullptr);
+    REQUIRE(g_observing_midi_in->observed_sysex_count == 1);
+    REQUIRE(g_observing_midi_in->observed_sysex_drops == 0);
+}
+
+TEST_CASE("CLAP_EVENT_MIDI_SYSEX prepared capture does not drain realtime payload pool",
+          "[clap][midi][realtime][sysex]") {
+    Harness h(make_capturing);
+
+    static const uint8_t kPayload[] = {0xF0, 0x7D, 0x44, 0xF7};
+    const std::vector<uint8_t> expected(kPayload, kPayload + sizeof(kPayload));
+
+    for (std::size_t i = 0; i < state::ParameterEventQueue::kCapacity + 2; ++i) {
+        InputEventList events;
+        clap_event_midi_sysex_t ev{};
+        ev.header = make_header(sizeof(ev), CLAP_EVENT_MIDI_SYSEX,
+                                static_cast<uint32_t>(i % Harness::kFrames));
+        ev.port_index = 0;
+        ev.buffer = kPayload;
+        ev.size = sizeof(kPayload);
+        events.push(ev);
+
+        REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+        REQUIRE(g_capturing->captured_midi.sysex_size() == 1);
+        REQUIRE(g_capturing->captured_midi.sysex()[0].data == expected);
+        REQUIRE(h.plugin.midi_in.dropped_sysex_count() == 0);
+    }
+}
+
+TEST_CASE("CLAP_EVENT_MIDI_SYSEX forwarding does not drain realtime payload pools",
+          "[clap][midi][realtime][sysex]") {
+    Harness h(make_forwarding_sysex);
+
+    static const uint8_t kPayload[] = {0xF0, 0x7D, 0x55, 0xF7};
+    for (std::size_t i = 0; i < state::ParameterEventQueue::kCapacity + 2; ++i) {
+        InputEventList events;
+        OutputEventList out;
+        clap_event_midi_sysex_t ev{};
+        ev.header = make_header(sizeof(ev), CLAP_EVENT_MIDI_SYSEX,
+                                static_cast<uint32_t>(i % Harness::kFrames));
+        ev.port_index = 0;
+        ev.buffer = kPayload;
+        ev.size = sizeof(kPayload);
+        events.push(ev);
+
+        REQUIRE(h.run(events, &out) == CLAP_PROCESS_CONTINUE);
+        REQUIRE(g_forwarding_sysex != nullptr);
+        REQUIRE(g_forwarding_sysex->observed_input_sysex_count == 1);
+        REQUIRE(g_forwarding_sysex->observed_output_sysex_count == 1);
+        REQUIRE(g_forwarding_sysex->observed_input_sysex_drops == 0);
+        REQUIRE(g_forwarding_sysex->observed_output_sysex_drops == 0);
+
+        auto sysexes = out.by_type<clap_event_midi_sysex_t>(CLAP_EVENT_MIDI_SYSEX);
+        REQUIRE(sysexes.size() == 1);
+        REQUIRE(sysexes[0]->size == sizeof(kPayload));
+        REQUIRE(sysexes[0]->buffer[0] == 0xF0);
+        REQUIRE(sysexes[0]->buffer[2] == 0x55);
+        REQUIRE(sysexes[0]->buffer[3] == 0xF7);
+    }
 }
 
 TEST_CASE("CLAP_EVENT_MIDI_SYSEX with empty payload is dropped",
@@ -1968,6 +2125,51 @@ TEST_CASE("CLAP inbound MIDI drops past realtime event capacity without growing"
     REQUIRE(g_observing_midi_in->observed_event_count ==
             state::ParameterEventQueue::kCapacity);
     REQUIRE(g_observing_midi_in->observed_event_drops == 1);
+}
+
+TEST_CASE("CLAP inbound SysEx drops past realtime sidecar capacity without growing",
+          "[clap][midi][realtime][sysex]") {
+    Harness h(make_observing_midi_in);
+    InputEventList in;
+    static const uint8_t kPayload[] = {0xF0, 0x7D, 0x01, 0xF7};
+    for (std::size_t i = 0; i < 129; ++i) {
+        clap_event_midi_sysex_t ev{};
+        ev.header = make_header(sizeof(ev), CLAP_EVENT_MIDI_SYSEX,
+                                static_cast<uint32_t>(i % Harness::kFrames));
+        ev.port_index = 0;
+        ev.buffer = kPayload;
+        ev.size = sizeof(kPayload);
+        in.push(ev);
+    }
+
+    REQUIRE(h.run(in) == CLAP_PROCESS_CONTINUE);
+    REQUIRE(g_observing_midi_in != nullptr);
+    REQUIRE(g_observing_midi_in->observed_sysex_capacity == 128);
+    REQUIRE(g_observing_midi_in->observed_sysex_count == 128);
+    REQUIRE(g_observing_midi_in->observed_sysex_drops == 1);
+}
+
+TEST_CASE("CLAP inbound SysEx drops payloads larger than realtime sidecar storage",
+          "[clap][midi][realtime][sysex]") {
+    Harness h(make_observing_midi_in);
+    InputEventList in;
+    std::vector<uint8_t> payload(4097, 0x7D);
+    payload.front() = 0xF0;
+    payload.back() = 0xF7;
+
+    clap_event_midi_sysex_t ev{};
+    ev.header = make_header(sizeof(ev), CLAP_EVENT_MIDI_SYSEX, 9);
+    ev.port_index = 0;
+    ev.buffer = payload.data();
+    ev.size = payload.size();
+    in.push(ev);
+
+    REQUIRE(h.run(in) == CLAP_PROCESS_CONTINUE);
+    REQUIRE(g_observing_midi_in != nullptr);
+    REQUIRE(g_observing_midi_in->observed_sysex_capacity == 128);
+    REQUIRE(g_observing_midi_in->observed_sysex_payload_capacity == 4096);
+    REQUIRE(g_observing_midi_in->observed_sysex_count == 0);
+    REQUIRE(g_observing_midi_in->observed_sysex_drops == 1);
 }
 
 TEST_CASE("CLAP outbound MIDI drops past realtime event capacity without growing",

--- a/test/test_midi_buffer_sysex.cpp
+++ b/test/test_midi_buffer_sysex.cpp
@@ -4,6 +4,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/midi/buffer.hpp>
+#include <type_traits>
 
 using namespace pulp::midi;
 
@@ -67,6 +68,96 @@ TEST_CASE("realtime capacity limit drops copy-based sysex without allocating",
     REQUIRE(buf.sysex_size() == 0);
     REQUIRE(buf.sysex_capacity() == 1);
     REQUIRE(buf.dropped_sysex_count() == 1);
+}
+
+static_assert(!std::is_move_constructible_v<MidiBuffer::SysexPayload>);
+static_assert(!std::is_move_assignable_v<MidiBuffer::SysexPayload>);
+
+TEST_CASE("realtime copy-based sysex can be copied into prepared storage",
+          "[midi][buffer][sysex][realtime]") {
+    MidiBuffer buf;
+    buf.reserve(1, 1, 8);
+    buf.set_realtime_capacity_limit(true);
+    MidiBuffer captured;
+    captured.reserve(1, 1, 8);
+    captured.set_realtime_capacity_limit(true);
+
+    const uint8_t first[] = {0xF0, 0x7D, 0x01, 0xF7};
+    REQUIRE(buf.add_sysex_copy(first, sizeof(first), 12, 0.25));
+    REQUIRE(buf.sysex_size() == 1);
+
+    REQUIRE(captured.add_sysex_copy(
+        buf.sysex()[0].data.data(),
+        buf.sysex()[0].data.size(),
+        buf.sysex()[0].sample_offset,
+        buf.sysex()[0].timestamp));
+    REQUIRE(captured.sysex()[0].data
+            == std::vector<uint8_t>{0xF0, 0x7D, 0x01, 0xF7});
+    REQUIRE(buf.sysex()[0].data
+            == std::vector<uint8_t>{0xF0, 0x7D, 0x01, 0xF7});
+
+    buf.clear_sysex();
+    REQUIRE(buf.dropped_sysex_count() == 0);
+    REQUIRE(captured.sysex()[0].data
+            == std::vector<uint8_t>{0xF0, 0x7D, 0x01, 0xF7});
+
+    const uint8_t second[] = {0xF0, 0x7D, 0x02, 0xF7};
+    REQUIRE(buf.add_sysex_copy(second, sizeof(second), 24, 0.5));
+    REQUIRE(buf.sysex_size() == 1);
+    REQUIRE(buf.sysex()[0].data
+            == std::vector<uint8_t>{0xF0, 0x7D, 0x02, 0xF7});
+    REQUIRE(buf.dropped_sysex_count() == 0);
+}
+
+TEST_CASE("failed rvalue sysex append leaves caller payload intact",
+          "[midi][buffer][sysex][realtime]") {
+    MidiBuffer buf;
+    buf.reserve(1, 0);
+    buf.set_realtime_capacity_limit(true);
+
+    MidiBuffer::SysexEvent event;
+    event.data = {0xF0, 0x7D, 0x03, 0xF7};
+    event.sample_offset = 32;
+
+    REQUIRE_FALSE(buf.add_sysex(std::move(event)));
+    REQUIRE(event.data == std::vector<uint8_t>{0xF0, 0x7D, 0x03, 0xF7});
+    REQUIRE(event.sample_offset == 32);
+    REQUIRE(buf.dropped_sysex_count() == 1);
+}
+
+TEST_CASE("copied realtime sysex payload pool preserves reserved capacity",
+          "[midi][buffer][sysex][realtime]") {
+    MidiBuffer prepared;
+    prepared.reserve(1, 1, 8);
+    prepared.set_realtime_capacity_limit(true);
+
+    MidiBuffer copy = prepared;
+    const uint8_t payload[] = {0xF0, 0x7D, 0x04, 0xF7};
+    REQUIRE(copy.add_sysex_copy(payload, sizeof(payload), 48, 0.75));
+    REQUIRE(copy.sysex_size() == 1);
+    REQUIRE(copy.sysex()[0].data == std::vector<uint8_t>{0xF0, 0x7D, 0x04, 0xF7});
+    REQUIRE(copy.sysex()[0].data.capacity() >= 8);
+}
+
+TEST_CASE("direct sysex vector clear recycles realtime payloads",
+          "[midi][buffer][sysex][realtime]") {
+    MidiBuffer buf;
+    buf.reserve(1, 1, 8);
+    buf.set_realtime_capacity_limit(true);
+
+    const uint8_t first[] = {0xF0, 0x7D, 0x05, 0xF7};
+    REQUIRE(buf.add_sysex_copy(first, sizeof(first), 12, 0.25));
+    REQUIRE(buf.sysex_size() == 1);
+
+    buf.sysex().clear();
+    REQUIRE(buf.sysex_size() == 0);
+
+    const uint8_t second[] = {0xF0, 0x7D, 0x06, 0xF7};
+    REQUIRE(buf.add_sysex_copy(second, sizeof(second), 24, 0.5));
+    REQUIRE(buf.sysex_size() == 1);
+    REQUIRE(buf.sysex()[0].data
+            == std::vector<uint8_t>{0xF0, 0x7D, 0x06, 0xF7});
+    REQUIRE(buf.dropped_sysex_count() == 0);
 }
 
 TEST_CASE("clear_sysex removes sidecar events but leaves short messages alone",

--- a/test/test_vst3_plugin_state.cpp
+++ b/test/test_vst3_plugin_state.cpp
@@ -185,7 +185,7 @@ void TestVst3Processor::process(
     last_midi_in_size = midi_in.size();
     last_sysex_size = midi_in.sysex_size();
     if (last_sysex_size > 0) {
-        last_sysex_payload = midi_in.sysex()[0].data;
+        last_sysex_payload = midi_in.sysex()[0].data.to_vector();
     }
     had_param_events = (param_events() != nullptr);
     last_param_events.clear();


### PR DESCRIPTION
## Summary
- copy inbound `CLAP_EVENT_MIDI_SYSEX` into bounded `MidiBuffer` realtime payload storage instead of dropping host-owned payloads
- make `MidiBuffer::SysexPayload` non-movable and add pool-backed forwarding/copy safeguards so input pools are not drained by capture or MIDI-thru paths
- reserve CLAP `midi_out` SysEx payload storage for RT-safe forwarding and update AAX/VST3 test call sites for the explicit payload wrapper
- update CLAP/AAX skill notes for the new prepared-storage SysEx contract

## Validation
- `cmake --build build-clap --target pulp-test-clap-midi-events pulp-test-midi-buffer-sysex --parallel`
- `./build-clap/test/pulp-test-clap-midi-events --reporter compact`
- `./build-clap/test/pulp-test-midi-buffer-sysex --reporter compact`
- `tools/scripts/gates.sh`
- `git diff --check origin/main...HEAD`
- `/Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean

## Notes
- AAX and VST3 SDK-backed targets are not generated in this local configure; AAX/VST3 changes are limited to explicit payload-copy call-site compatibility and are covered by source review plus skill-sync.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves inbound `CLAP_EVENT_MIDI_SYSEX` on the realtime path by copying bytes into a preallocated `MidiBuffer` pool (128 events, 4096 bytes each). Fixes dropped SysEx and enables safe capture, forwarding, and bypass without RT allocations.

- **Bug Fixes**
  - Copy inbound CLAP SysEx into bounded storage via `MidiBuffer::add_sysex_copy()`; stop dropping host-owned payloads.
  - Reserve a realtime SysEx payload pool in `clap_activate()` and clear it on activate/reset/deactivate; enforce count/size limits and track drops.
  - Make `MidiBuffer::SysexPayload` non-movable and add pool-backed copy/forward safeguards; pool-backed input events are re-copied on forward.
  - AAX bypass MIDI‑thru now uses `add_sysex_copy()`; CLAP/AAX docs updated; tests cover capture, forwarding, clearing across reactivation, and overflow by count/size.

- **Migration**
  - When capturing or thru-ing SysEx behind a no-alloc guard, preallocate with `MidiBuffer::reserve(events, sysex, payload_capacity)` and use `add_sysex_copy()`; do not move raw vectors out of `midi_in`.
  - Update call sites that assumed a `std::vector<uint8_t>` to use `SysexPayload` accessors (e.g., `.data()/.size()` or `.to_vector()` when needed).

<sup>Written for commit 6c2c2de11bb33f15236f08ae7bc67d5ec9e060b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

