### PR TITLE
fix(audio): keep standalone output probe on test-signal output

### DIFF
--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -221,6 +221,17 @@ bool StandaloneApp::start() {
         ui_midi_collector_.drain_into(midi_in, block_start_seconds,
                                       ctx.buffer_size, ctx.sample_rate);
 
+#if PULP_ENABLE_AUDIO_PROBES
+        auto analyze_output_probe = [&]() noexcept {
+            const size_t out_ch = output.num_channels();
+            for (size_t c = 0; c < out_ch && c < output_probe_ptrs_.size(); ++c)
+                output_probe_ptrs_[c] = output.channel_ptr(c);
+            const size_t probe_ch = std::min(out_ch, output_probe_ptrs_.size());
+            output_probe_.analyze_output(audio::BufferView<const float>(
+                output_probe_ptrs_.data(), probe_ch, output.num_samples()));
+        };
+#endif
+
         if (test_signal_.is_active() && config_.route_test_signal_to_output) {
             const size_t out_ch = std::min(output.num_channels(), direct_output_ptrs_.size());
             for (size_t c = 0; c < out_ch; ++c)
@@ -236,6 +247,9 @@ bool StandaloneApp::start() {
                     static_cast<int>(out_ch),
                     ctx.buffer_size);
             }
+#if PULP_ENABLE_AUDIO_PROBES
+            analyze_output_probe();
+#endif
             if (config_.transport_playing) {
                 transport_position_samples_.fetch_add(
                     ctx.buffer_size, std::memory_order_relaxed);
@@ -332,14 +346,7 @@ bool StandaloneApp::start() {
         // processor silence from output-boundary silence. Fill the
         // pre-allocated const pointer array (no audio-thread allocation), then
         // wrap it in a const view for analyze_output().
-        {
-            const size_t out_ch = output.num_channels();
-            for (size_t c = 0; c < out_ch && c < output_probe_ptrs_.size(); ++c)
-                output_probe_ptrs_[c] = output.channel_ptr(c);
-            const size_t probe_ch = std::min(out_ch, output_probe_ptrs_.size());
-            output_probe_.analyze_output(audio::BufferView<const float>(
-                output_probe_ptrs_.data(), probe_ch, output.num_samples()));
-        }
+        analyze_output_probe();
 #endif
 
         // Advance the rolling sample clock so the next block reads a

--- a/tools/local-ci/execution.py
+++ b/tools/local-ci/execution.py
@@ -448,6 +448,7 @@ try {{
             $configureArgs += @(
                 '-DPULP_BUILD_TESTS=OFF',
                 '-DPULP_BUILD_EXAMPLES=OFF',
+                '-DPULP_ENABLE_AUDIO_PROBES=OFF',
                 '-DPULP_ENABLE_GPU=OFF'
             )
         }}

--- a/tools/local-ci/test_execution.py
+++ b/tools/local-ci/test_execution.py
@@ -1200,6 +1200,7 @@ class ExecutionTests(unittest.TestCase):
         self.assertIn('Write-Host "__PULP_TEST_POLICY__:skip"', script)
         self.assertIn("-DPULP_BUILD_TESTS=OFF", script)
         self.assertIn("-DPULP_BUILD_EXAMPLES=OFF", script)
+        self.assertIn("-DPULP_ENABLE_AUDIO_PROBES=OFF", script)
         self.assertIn("-DPULP_ENABLE_GPU=OFF", script)
         self.assertIn("Invoke-Native cmake @('--install', $Build, '--prefix', $Install, '--config', 'Release')", script)
         self.assertIn('Write-Host "__PULP_PHASE__:smoke"', script)


### PR DESCRIPTION
Follow-up from the recent PR sweep.

What changed:
- Disable PULP_ENABLE_AUDIO_PROBES in generated smoke SDK CMake configs, matching the release/SDK artifact invariant.
- Assert that flag in the Windows validation-script smoke test.
- Reuse the standalone output-boundary probe tap on the direct test-signal output path before the early return.

Validation:
- python3 tools/local-ci/test_execution.py ExecutionTests.test_windows_validation_script_builds_smoke_script
- cmake -S . -B build-followup -DCMAKE_BUILD_TYPE=Release -DPULP_BUILD_TESTS=OFF -DPULP_BUILD_EXAMPLES=OFF -DPULP_ENABLE_GPU=OFF
- cmake --build build-followup --target pulp-standalone --parallel
- PULP_PR_TITLE="fix(audio): keep standalone output probe on test-signal output" tools/scripts/gates.sh
- git diff --check origin/main...HEAD
- autoreview --mode branch --base origin/main: clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the standalone output probe active when the built‑in test signal routes directly to output, and enforces probe-disabled settings in smoke SDK builds to match release behavior.

- **Bug Fixes**
  - Reuse the output-boundary probe on the direct test-signal path so output is still analyzed.
  - Add `-DPULP_ENABLE_AUDIO_PROBES=OFF` to the Windows validation script’s CMake args and assert it in tests.

<sup>Written for commit e325a8bd7c658c6cc66e5acabdf28a6c4be69de7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

