### PR TITLE
feat(view): wire Audio Inspector into the standalone host + fix panel colors

### DIFF
--- a/.agents/skills/audio-harness/SKILL.md
+++ b/.agents/skills/audio-harness/SKILL.md
@@ -121,6 +121,37 @@ phase/Pearson correlation (the RT snapshot carries no inter-sample L*R term yet)
 This is for *watching what is currently flowing*; controlled-stimulus measurement
 (response/THD/etc.) is the offline Doctor above.
 
+### Launch the Audio Inspector in the standalone host
+
+`StandaloneApp::run_with_editor()` wires the inspector to the host's
+output-boundary probe automatically (behind `PULP_ENABLE_AUDIO_PROBES`, default
+ON for dev/examples). At runtime, toggle it with **Cmd/Ctrl+Shift+A**, or open it
+on launch by setting `PULP_AUDIO_INSPECTOR` in the environment:
+
+```bash
+# Live: feed a test signal so output is non-silent, then open the inspector.
+PULP_AUDIO_INSPECTOR=1 ./build/examples/<app>/pulp-<app>
+```
+
+`PULP_AUDIO_INSPECTOR` also enables the probe's capture ring (sized to the panel
+display width), so the inspector paints a live *waveform* and not just meters —
+the default probe config is summary-only. The toggle routes through a
+shell-owned `CommandRegistry` via `route_global_keys` (the root view's
+`on_global_key`), which is independent of the layout inspector's `on_global_click`
+(Cmd/Ctrl+I) — both tools coexist on one window without clobbering.
+
+Headless proof: a screenshot run with the inspector open also captures the
+inspector's OWN window surface next to the main screenshot:
+
+```bash
+# Writes /tmp/x.png (main) AND /tmp/x.audio-inspector.png (the live panel).
+PULP_AUDIO_INSPECTOR=1 ./build/examples/<app>/pulp-<app> \
+  --screenshot /tmp/x.png --screenshot-frame-delay 90
+```
+
+The sibling `<stem>.audio-inspector.png` is only written when the inspector
+window is visible and the host has GPU capture (`WindowHost::capture_png()`).
+
 ## CLI: `pulp audio validate <verb>` (offline, over WAVs / artifact bundles)
 
 The harness analyzers are also reachable from the shipped CLI, nested under the

--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -932,3 +932,31 @@ is the first wired probe stage for "UI works, no sound" reports. Gotchas:
 - The probe is RT-safe (scalar-only, no FFT/alloc/locks) — `pulp::audio::AudioProbe`.
   Do NOT model audio-thread work on `pulp::view::VisualizationBridge`, which runs
   STFT and returns `std::vector` in its callback (explicitly quarantined).
+
+### Phase 6 — Audio Inspector tool window wired into the host
+
+`run_with_editor()` opens a `pulp::view::AudioInspectorWindow` (a SEPARATE
+floating window, sibling of the layout inspector — not a tab) that observes
+`output_probe_`. It is created only when a real `WindowHost` exists, behind the
+same `#if PULP_ENABLE_AUDIO_PROBES` guard. Wiring gotchas:
+
+- **Key routing must not clobber the layout inspector.** The audio inspector's
+  toggle (Cmd/Ctrl+Shift+A) dispatches through a shell-owned `CommandRegistry`
+  via `route_global_keys(window_root, registry)`, which writes
+  `window_root.on_global_key`. The layout inspector (Cmd+I) uses
+  `on_global_click` (`install_inspector_hooks`). Distinct hooks → they coexist;
+  do not move either onto the other's hook.
+- **Compose the idle callback, don't replace it.** `poll()` must run each tick
+  to refresh meters; capture the existing `pre_screenshot_idle` and call it
+  first, then `audio_inspector_->poll()` — clobbering `set_idle_callback` drops
+  the scripted-ui / settings / overlay paint.
+- **Open + live waveform are env-gated.** `PULP_AUDIO_INSPECTOR` shows the
+  window AND makes `start()` size `output_probe_`'s capture ring (to
+  `AudioWaveformView::kCapacity`); without it the probe stays summary-only (no
+  waveform allocation). Headless `--screenshot` also writes the inspector's own
+  surface to `<stem>.audio-inspector.png` when it is open.
+- **Teardown order:** destroy the window before the `CommandRegistry` (its RAII
+  handler removal targets a live registry) and before `output_probe_`.
+- **Panel colors:** `canvas::Color` channels are floats in `[0,1]` — build panel
+  colors with `Color::rgba8(r,g,b,a)`, NOT `Color{26,26,32,255}` brace-init,
+  which Skia clamps to opaque white (the white-on-white panel bug).

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.207.6",
+      "version": "0.208.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.207.6"
+  "version": "0.208.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.207.6",
+  "version": "0.208.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.411.0
+    VERSION 0.412.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/detail/standalone_editor_chrome.hpp
+++ b/core/format/include/pulp/format/detail/standalone_editor_chrome.hpp
@@ -292,27 +292,32 @@ inline void attach_standalone_editor_bridge(
         });
 }
 
+inline std::function<void()> make_standalone_idle_callback(
+    std::function<void()> poll_scripted_ui,
+    std::function<void()> poll_settings) {
+    if (poll_scripted_ui) {
+        return [poll_scripted_ui = std::move(poll_scripted_ui),
+                poll_settings = std::move(poll_settings)] {
+            poll_scripted_ui();
+            if (poll_settings) {
+                poll_settings();
+            }
+        };
+    }
+
+    return [poll_settings = std::move(poll_settings)] {
+        if (poll_settings) {
+            poll_settings();
+        }
+    };
+}
+
 inline void install_standalone_idle_callback(
     view::WindowHost& window,
     std::function<void()> poll_scripted_ui,
     std::function<void()> poll_settings) {
-    if (poll_scripted_ui) {
-        window.set_idle_callback(
-            [poll_scripted_ui = std::move(poll_scripted_ui),
-             poll_settings = std::move(poll_settings)] {
-                poll_scripted_ui();
-                if (poll_settings) {
-                    poll_settings();
-                }
-            });
-        return;
-    }
-
-    window.set_idle_callback([poll_settings = std::move(poll_settings)] {
-        if (poll_settings) {
-            poll_settings();
-        }
-    });
+    window.set_idle_callback(make_standalone_idle_callback(
+        std::move(poll_scripted_ui), std::move(poll_settings)));
 }
 
 template <typename ScriptedUi>

--- a/core/format/include/pulp/format/standalone.hpp
+++ b/core/format/include/pulp/format/standalone.hpp
@@ -18,6 +18,11 @@
 #include <string>
 #include <vector>
 
+namespace pulp::view {
+class AudioInspectorWindow;
+class CommandRegistry;
+}  // namespace pulp::view
+
 namespace pulp::format {
 
 struct StandaloneConfig {
@@ -174,6 +179,22 @@ private:
     // Pre-allocated channel-pointer array for the probe view (no audio-thread
     // allocation). Sized in start() to the output channel count.
     std::vector<const float*> output_probe_ptrs_;
+
+    // Developer Audio Inspector tool window (Phase 6). A separate floating
+    // window that reads `output_probe_.latest()` each UI tick and renders the
+    // live meters / waveform / probe-stage status. Lives on the app so it
+    // outlives the idle callback that polls it; `output_probe_` is declared
+    // before it so the probe outlives the window on teardown (the window holds
+    // a raw probe pointer). Constructed in run_with_editor() only when a real
+    // window exists, behind a shared CommandRegistry routed by
+    // `route_global_keys` (Cmd/Ctrl+Shift+A). Opened when PULP_AUDIO_INSPECTOR
+    // is set in the environment.
+    std::unique_ptr<view::CommandRegistry> command_registry_;
+    std::unique_ptr<view::AudioInspectorWindow> audio_inspector_;
+    // True when the probe was prepared with a capture ring (so the inspector
+    // can show a waveform, not just meters). Enabled when PULP_AUDIO_INSPECTOR
+    // is set at start() time.
+    bool audio_inspector_capture_ = false;
 #endif
     audio::Buffer<float> test_buffer_;        // Pre-allocated for audio callback
     audio::Buffer<float> silence_buffer_;    // Pre-allocated silence for missing input

--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -12,6 +12,8 @@
 #include <algorithm>
 #include <charconv>
 #include <cmath>
+#include <filesystem>
+#include <fstream>
 #include <string_view>
 
 // WYSIWYG P6 FIX 5 — the dev inspector (Cmd+I overlay) is gated behind the
@@ -32,6 +34,10 @@
 
 #if PULP_STANDALONE_INSPECTOR
 #include <pulp/inspect/inspector_overlay.hpp>
+#endif
+#if PULP_ENABLE_AUDIO_PROBES
+#include <pulp/view/audio_inspector_window.hpp>
+#include <pulp/view/command_registry.hpp>
 #endif
 #include <pulp/runtime/log.hpp>
 #include <pulp/runtime/system.hpp>
@@ -162,11 +168,18 @@ bool StandaloneApp::start() {
 #if PULP_ENABLE_AUDIO_PROBES
     // Phase 5 — prepare the realtime output-boundary probe BEFORE the audio
     // callback starts. This is the only place it allocates. Capture is left
-    // off here (latest-summary only); a debug/support build can opt into the
-    // last-N ring via output_probe().prepare(...) with a CaptureConfig.
+    // off by default (latest-summary only); the Phase 6 Audio Inspector window
+    // (PULP_AUDIO_INSPECTOR) and debug/support builds opt into the last-N ring
+    // so the inspector can paint a live waveform, not just meters. The ring is
+    // sized to the panel's display capacity so a tick fills the trace.
+    audio::AudioProbe::CaptureConfig probe_capture;
+    audio_inspector_capture_ = runtime::get_env("PULP_AUDIO_INSPECTOR").has_value();
+    if (audio_inspector_capture_)
+        probe_capture.capture_frames = view::AudioWaveformView::kCapacity;
     output_probe_.prepare(config_.output_channels, config_.buffer_size,
                           config_.sample_rate,
-                          audio::AudioProbeStage::kStandaloneOutputBoundary);
+                          audio::AudioProbeStage::kStandaloneOutputBoundary,
+                          probe_capture);
     output_probe_ptrs_.assign(static_cast<size_t>(std::max(config_.output_channels, 0)),
                               nullptr);
 #endif
@@ -504,6 +517,30 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
     inspect::install_inspector_hooks(*inspector);
 #endif
 
+#if PULP_ENABLE_AUDIO_PROBES
+    // Phase 6 — Audio Inspector tool window. A SEPARATE floating window (sibling
+    // of the layout inspector, not a tab in it) that observes `output_probe_`.
+    // It dispatches its toggle (Cmd/Ctrl+Shift+A) through a shell-owned
+    // CommandRegistry routed via `route_global_keys` — that writes
+    // `window_root.on_global_key`, which is distinct from the layout inspector's
+    // `on_global_click` (Cmd+I), so the two coexist without clobbering. Only
+    // wired when a real WindowHost exists (the show() path needs one).
+    view::AudioInspectorWindow* audio_inspector_ptr = nullptr;
+    if (window) {
+        // Fresh registry + window per run (a prior run's window referenced an
+        // already-destroyed root view). Destroy the window before the registry
+        // so its RAII handler removal targets a live registry.
+        audio_inspector_.reset();
+        command_registry_ = std::make_unique<view::CommandRegistry>();
+        audio_inspector_ = std::make_unique<view::AudioInspectorWindow>(
+            nullptr, window.get());
+        audio_inspector_->set_probe(&output_probe_);
+        audio_inspector_->register_command_handler(*command_registry_);
+        view::route_global_keys(window_root, *command_registry_);
+        audio_inspector_ptr = audio_inspector_.get();
+    }
+#endif
+
     // Wire inspector into the idle callback to push overlay paint each frame.
     // The inspector uses View::overlay_queue() for rendering and intercepts
     // key events through the root view's on_global_click callback for Cmd+I.
@@ -548,7 +585,40 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
         runtime::log_info("Standalone: inspector enabled via PULP_INSPECTOR env var");
     }
 #else
-    detail::install_standalone_idle_callback(*window, scripted_ui_ptr, settings_ptr);
+    pre_screenshot_idle = detail::make_standalone_idle_callback(
+        scripted_ui_ptr
+            ? std::function<void()>{[scripted_ui_ptr] { scripted_ui_ptr->poll(); }}
+            : std::function<void()>{},
+        settings_ptr
+            ? std::function<void()>{[settings_ptr] { settings_ptr->poll(); }}
+            : std::function<void()>{});
+    window->set_idle_callback(pre_screenshot_idle);
+#endif
+
+#if PULP_ENABLE_AUDIO_PROBES
+    // Refresh the Audio Inspector from `output_probe_` every UI tick. Compose
+    // with whatever idle work is already wired (inspector overlay / scripted_ui
+    // / settings poll) rather than clobbering it: capture the current
+    // `pre_screenshot_idle` (empty in the inspector-off build, where the
+    // standalone idle callback is installed directly) and call it first.
+    // poll() is cheap and safe when the window is hidden or no probe is set.
+    if (audio_inspector_ptr) {
+        auto prior_idle = pre_screenshot_idle;
+        pre_screenshot_idle = [prior_idle, audio_inspector_ptr] {
+            if (prior_idle) prior_idle();
+            audio_inspector_ptr->poll();
+        };
+        window->set_idle_callback(pre_screenshot_idle);
+    }
+
+    // Open the Audio Inspector when PULP_AUDIO_INSPECTOR is set (mirrors the
+    // PULP_INSPECTOR layout-inspector block above). The capture ring was sized
+    // in start() under the same env, so the window paints a live waveform.
+    if (audio_inspector_ptr && runtime::get_env("PULP_AUDIO_INSPECTOR")) {
+        audio_inspector_ptr->show();
+        runtime::log_info(
+            "Standalone: audio inspector enabled via PULP_AUDIO_INSPECTOR env var");
+    }
 #endif
 
     if (!opts.initially_hidden)
@@ -571,7 +641,42 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
             ? effective_config.screenshot_frame_delay : 30;
         cap.path = effective_config.screenshot_path;
         auto* editor_view = bridge->view();
-        cap.capture_fn = [host, editor_view, w, h] {
+#if PULP_ENABLE_AUDIO_PROBES
+        // Sibling capture of the Audio Inspector's OWN window surface, written
+        // next to the main screenshot as "<stem>.audio-inspector.png" when the
+        // inspector is open. Lets a headless run prove the live panel loaded
+        // (PULP_AUDIO_INSPECTOR=1 --screenshot X.png yields X.audio-inspector.png).
+        const std::string inspector_png_path = [&] {
+            std::filesystem::path p(effective_config.screenshot_path);
+            return (p.parent_path() /
+                    (p.stem().string() + ".audio-inspector" +
+                     p.extension().string()))
+                .string();
+        }();
+#endif
+        cap.capture_fn = [host, editor_view, w, h
+#if PULP_ENABLE_AUDIO_PROBES
+                          , audio_inspector_ptr, inspector_png_path
+#endif
+        ] {
+#if PULP_ENABLE_AUDIO_PROBES
+            // Side-effect: capture the inspector window's own surface at the
+            // same frame, before the main window closes. capture_png() returns
+            // empty on hosts without GPU capture — skip the write in that case.
+            if (audio_inspector_ptr && audio_inspector_ptr->is_visible()) {
+                if (auto* ihost = audio_inspector_ptr->window_host()) {
+                    auto ipng = ihost->capture_png();
+                    if (!ipng.empty()) {
+                        std::ofstream out(inspector_png_path, std::ios::binary);
+                        out.write(reinterpret_cast<const char*>(ipng.data()),
+                                  static_cast<std::streamsize>(ipng.size()));
+                        runtime::log_info(
+                            "Standalone: audio inspector screenshot written to {}",
+                            inspector_png_path);
+                    }
+                }
+            }
+#endif
             // If the editor hosts a native overlay (a WebView), use its in-process
             // snapshot (WKWebView takeSnapshot) — capture_back_buffer_png() reads the
             // Skia back buffer and can't see an OS-composited native overlay. For a
@@ -626,6 +731,14 @@ void StandaloneApp::stop_audio_keep_processor() {
 
 void StandaloneApp::stop() {
     stop_audio_keep_processor();
+#if PULP_ENABLE_AUDIO_PROBES
+    // Tear the Audio Inspector down before the processor / probe so its raw
+    // `output_probe_` pointer never dangles. Destroying the window first also
+    // removes its handler from `command_registry_` (RAII in its destructor);
+    // destroy the registry after, so the removal has a live registry to target.
+    audio_inspector_.reset();
+    command_registry_.reset();
+#endif
     if (processor_) {
         processor_->release();
         processor_.reset();

--- a/core/view/include/pulp/view/audio_inspector_panel.hpp
+++ b/core/view/include/pulp/view/audio_inspector_panel.hpp
@@ -121,6 +121,19 @@ public:
 
     const AudioWaveformView& waveform() const { return *waveform_view_; }
 
+    // ── Rendered-text accessors (for headless tests) ────────────────────────
+    // The exact strings the labels paint. A test can assert these are
+    // populated (e.g. the status reads "live", the level reads "dBFS") so a
+    // regression that leaves the panel visually blank is caught in CI, not
+    // only by eye.
+    const std::string& status_text() const { return status_label_->text(); }
+    const std::string& level_text() const { return level_label_->text(); }
+    /// Color the status heading paints with. A test can assert its channels
+    /// are in the valid [0,1] range — the white-on-white regression that hid
+    /// every label came from feeding 0-255 values into the [0,1] Color ctor,
+    /// which Skia clamps to white. Guards that specific class of bug.
+    canvas::Color status_color() const { return status_label_->text_color(); }
+
 private:
     void build_ui();
     void refresh_labels();

--- a/core/view/include/pulp/view/audio_inspector_window.hpp
+++ b/core/view/include/pulp/view/audio_inspector_window.hpp
@@ -98,6 +98,14 @@ public:
     /// Panel accessor — for headless state assertions.
     const AudioInspectorPanel& panel() const { return *panel_; }
 
+    /// The window's own `WindowHost`, or null until `show()` has created one
+    /// (and after a host_factory that returned null). Exposed so a headless
+    /// host can `capture_png()` the inspector's surface for a screenshot proof,
+    /// the same way the standalone host captures its main window. Ownership
+    /// stays with this window — the caller must not retain the pointer past the
+    /// window's lifetime.
+    WindowHost* window_host() const { return window_host_.get(); }
+
 private:
     // CommandHandler (private base) — registry dispatch entry points.
     std::vector<CommandID> commands() const override;

--- a/core/view/src/audio_inspector_panel.cpp
+++ b/core/view/src/audio_inspector_panel.cpp
@@ -63,14 +63,14 @@ void AudioWaveformView::paint(canvas::Canvas& canvas) {
     if (b.width <= 0 || b.height <= 0) return;
 
     // Housing.
-    canvas.set_fill_color(canvas::Color{18, 18, 22, 255});
+    canvas.set_fill_color(canvas::Color::rgba8(18, 18, 22, 255));
     canvas.fill_rect(b.x, b.y, b.width, b.height);
 
     const float mid = b.y + b.height * 0.5f;
 
     // Zero-line: bright when live, dim when stale / no probe.
-    canvas.set_stroke_color(live_ ? canvas::Color{70, 80, 95, 255}
-                                  : canvas::Color{45, 45, 52, 255});
+    canvas.set_stroke_color(live_ ? canvas::Color::rgba8(70, 80, 95, 255)
+                                  : canvas::Color::rgba8(45, 45, 52, 255));
     canvas.set_line_width(1.0f);
     canvas.stroke_line(b.x, mid, b.x + b.width, mid);
 
@@ -87,7 +87,7 @@ void AudioWaveformView::paint(canvas::Canvas& canvas) {
                                             mid - s * half};
     }
 
-    canvas.set_stroke_color(canvas::Color{90, 200, 140, 255});
+    canvas.set_stroke_color(canvas::Color::rgba8(90, 200, 140, 255));
     canvas.set_line_width(1.25f);
     canvas.stroke_path(pts.data(), static_cast<std::size_t>(count_));
 }
@@ -103,7 +103,7 @@ AudioInspectorPanel::AudioInspectorPanel() {
 void AudioInspectorPanel::build_ui() {
     flex().direction = FlexDirection::column;
     flex().padding = 10;
-    set_background_color(canvas::Color{26, 26, 32, 255});
+    set_background_color(canvas::Color::rgba8(26, 26, 32, 255));
 
     auto make_label = [](const std::string& text, float size, int weight,
                          canvas::Color color) {
@@ -114,9 +114,9 @@ void AudioInspectorPanel::build_ui() {
         return l;
     };
 
-    const canvas::Color heading{210, 215, 225, 255};
-    const canvas::Color body{170, 176, 188, 255};
-    const canvas::Color muted{120, 126, 138, 255};
+    const canvas::Color heading = canvas::Color::rgba8(210, 215, 225, 255);
+    const canvas::Color body = canvas::Color::rgba8(170, 176, 188, 255);
+    const canvas::Color muted = canvas::Color::rgba8(120, 126, 138, 255);
 
     // Status / availability line.
     {
@@ -265,15 +265,15 @@ void AudioInspectorPanel::refresh_labels() {
         switch (status_) {
             case Status::kNoProbe:
                 status_label_->set_text("Audio Inspector — no probe");
-                status_label_->set_text_color(canvas::Color{200, 150, 90, 255});
+                status_label_->set_text_color(canvas::Color::rgba8(200, 150, 90, 255));
                 break;
             case Status::kStale:
                 status_label_->set_text("Audio Inspector — stale (probe idle)");
-                status_label_->set_text_color(canvas::Color{200, 150, 90, 255});
+                status_label_->set_text_color(canvas::Color::rgba8(200, 150, 90, 255));
                 break;
             case Status::kLive:
                 status_label_->set_text("Audio Inspector — live");
-                status_label_->set_text_color(canvas::Color{120, 200, 150, 255});
+                status_label_->set_text_color(canvas::Color::rgba8(120, 200, 150, 255));
                 break;
         }
     }

--- a/core/view/src/audio_inspector_window.cpp
+++ b/core/view/src/audio_inspector_window.cpp
@@ -35,7 +35,7 @@ void AudioInspectorWindow::build_ui() {
     root_ = std::make_unique<View>();
     root_->set_id("audio-inspector-window-root");
     root_->flex().direction = FlexDirection::column;
-    root_->set_background_color(canvas::Color{26, 26, 32, 255});
+    root_->set_background_color(canvas::Color::rgba8(26, 26, 32, 255));
 
     auto panel = std::make_unique<AudioInspectorPanel>();
     panel->flex().flex_grow = 1;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1930,11 +1930,11 @@ pulp_add_test_suite(pulp-test-standalone-apply-config LIBRARIES pulp::standalone
     PROPERTIES PROCESSORS 8)
 pulp_add_test_suite(pulp-test-standalone-transport-midi LIBRARIES pulp::standalone
     PROPERTIES PROCESSORS 8)
-
+pulp_add_test_suite(pulp-test-standalone-audio-inspector
+    LIBRARIES pulp::standalone pulp::view PROPERTIES PROCESSORS 8)
 # Headless screenshot capture state machine (pulp #468)
 pulp_add_test_suite(pulp-test-screenshot-capture LIBRARIES pulp::standalone
     PROPERTIES PROCESSORS 8)
-
 # STFT and audio visualization signal tests
 pulp_add_test_suite(pulp-test-stft LIBRARIES pulp::signal)
 

--- a/test/test_audio_inspector_window.cpp
+++ b/test/test_audio_inspector_window.cpp
@@ -27,11 +27,14 @@
 #include <pulp/view/inspector_window.hpp>
 #include <pulp/view/input_events.hpp>
 #include <pulp/view/screenshot.hpp>
+#include <pulp/view/screenshot_compare.hpp>
 #include <pulp/view/view.hpp>
 
 #include <cmath>
 #include <memory>
 #include <vector>
+#include <filesystem>
+#include <fstream>
 
 using namespace pulp::view;
 using pulp::audio::AudioProbe;
@@ -245,42 +248,87 @@ TEST_CASE("AudioInspectorWindow copies a fixed-capacity waveform off the probe",
 TEST_CASE("AudioInspectorPanel renders a non-empty headless snapshot",
           "[view][audio-inspector][audio-harness]") {
     // Visual proof the panel paints end-to-end (meters + waveform + labels)
-    // without a window. Asserts a non-trivial PNG; skips honestly when the
-    // build has no screenshot provider (CPU-only / headless CI without Skia).
-    if (!has_screenshot_provider()) {
-        SUCCEED("no screenshot provider in this build — render proof skipped");
+    // through the offscreen GPU surface (Dawn + Skia). Skips honestly when this
+    // build has no GPU capture (CPU-only / no Skia / headless CI without GPU).
+    if (!has_gpu_capture()) {
+        SUCCEED("no GPU capture in this build — render proof skipped");
         return;
     }
 
     AudioProbe probe;
     AudioProbe::CaptureConfig cap;
-    cap.capture_frames = 256;
+    cap.capture_frames = AudioWaveformView::kCapacity;
     probe.prepare(2, 128, 48000.0, AudioProbeStage::kStandaloneOutputBoundary, cap);
+    // Several blocks of a 440 Hz sine so the meters read a real level and the
+    // capture ring fills with a visible waveform (one block of 128 frames is
+    // less than the display width — feed enough to populate the trace).
     StereoBlock block(128);
     for (std::size_t i = 0; i < block.left.size(); ++i) {
-        block.left[i] = 0.5f * std::sin(static_cast<float>(i) * 0.2f);
-        block.right[i] = 0.25f * std::sin(static_cast<float>(i) * 0.2f);
+        const float s = std::sin(2.0f * 3.14159265f * 440.0f *
+                                 static_cast<float>(i) / 48000.0f);
+        block.left[i] = 0.6f * s;
+        block.right[i] = 0.45f * s;
     }
-    probe.analyze_output(block.view());
+    for (int b = 0; b < 8; ++b) probe.analyze_output(block.view());
 
-    AudioInspectorPanel panel;
-    panel.set_bounds({0, 0, 300, 440});
-    {
-        AudioInspectorWindow window;
-        window.set_probe(&probe);
-        window.poll();
-        REQUIRE(window.panel().status() == AudioInspectorPanel::Status::kLive);
-    }
-    // Drive the standalone panel directly so it owns the render tree.
+    // Read the snapshot + captured waveform DIRECTLY (no intervening window
+    // poll() — poll() drains the single-consumer capture FIFO, which would
+    // leave the panel's waveform silently empty).
     const auto snap = probe.latest();
     std::vector<float> wf(AudioWaveformView::kCapacity);
     const int n = probe.read_capture(wf.data(), static_cast<int>(wf.size()));
-    panel.update(AudioInspectorPanel::Status::kLive, snap, {}, wf.data(), n);
+    REQUIRE(n > 0);  // the waveform the panel renders is genuinely non-empty
 
-    // Skia backend composites the meters + waveform correctly (CoreGraphics
-    // is fine here too — no file images — but Skia is the faithful default).
-    auto png = render_to_png(panel, 300, 440, 2.0f, ScreenshotBackend::skia);
+    AudioInspectorPanel panel;
+    panel.set_bounds({0, 0, 300, 440});
+    panel.update(AudioInspectorPanel::Status::kLive, snap, {}, wf.data(), n);
+    REQUIRE(panel.status() == AudioInspectorPanel::Status::kLive);
+    REQUIRE(panel.waveform().sample_count() == n);
+
+    // The labels actually carry the live readout text — the panel is not
+    // silently blank. (The text strings were always set; this guards the data
+    // path, the pixel assertion below guards that they actually render.)
+    REQUIRE(panel.status_text().find("live") != std::string::npos);
+    REQUIRE(panel.level_text().find("dBFS") != std::string::npos);
+    // The heading color must be a valid [0,1] Color. The white-on-white bug
+    // that hid every label fed 0-255 values into the [0,1] ctor, so the
+    // channels read >1 and Skia clamped them to white. Assert they're in range.
+    const auto sc = panel.status_color();
+    REQUIRE(sc.r <= 1.0f);
+    REQUIRE(sc.g <= 1.0f);
+    REQUIRE(sc.b <= 1.0f);
+    REQUIRE(sc.a <= 1.0f);
+
+    // Render through the offscreen GPU surface. `has_gpu_capture()` only proves
+    // the GPU backend is COMPILED in — the Dawn/Metal device can still fail to
+    // initialize at RUNTIME (e.g. a headless CI session with no GPU access), in
+    // which case render_to_png_gpu returns an empty buffer. Skip the pixel
+    // assertions honestly there; the white-on-white regression is already caught
+    // GPU-independently by the status_color() channel-range check above.
+    auto png = render_to_png_gpu(panel, 300, 440, 2.0f);
+    if (png.empty()) {
+        SUCCEED("offscreen GPU device unavailable at runtime — pixel proof skipped");
+        return;
+    }
     REQUIRE(png.size() > 100);  // a real PNG, not an empty/blank buffer
+    const auto out =
+        (std::filesystem::temp_directory_path() / "pulp-audio-inspector-live.png")
+            .string();
+    std::ofstream(out, std::ios::binary)
+        .write(reinterpret_cast<const char*>(png.data()),
+               static_cast<std::streamsize>(png.size()));
+
+    // Pixel-level guard against the white-on-white regression: the panel paints
+    // a dark UI background ({26,26,32}), so a correctly-rendered frame is
+    // predominantly dark. The bug clamped every fill/text/trace to white, which
+    // makes the frame predominantly bright — a high luminance mean. Assert the
+    // frame is dark AND has real content variation (text + waveform pixels).
+    // luminance_mean / stddev are on a 0-255 scale. A correct dark UI sits well
+    // under mid-gray (~30 here); the white-clamped bug pushed it toward 255.
+    const ScreenshotContentStats stats = analyze_screenshot_content(png);
+    REQUIRE(stats.valid);
+    REQUIRE(stats.luminance_mean < 128.0);   // dark UI, not a white-clamped frame
+    REQUIRE(stats.luminance_stddev > 1.0);   // real content (text + trace), not flat
 }
 
 TEST_CASE("AudioInspectorWindow toggle command opens via the registry and does "
@@ -288,10 +336,18 @@ TEST_CASE("AudioInspectorWindow toggle command opens via the registry and does "
           "[view][audio-inspector][audio-harness]") {
     CommandRegistry reg;
     int factory_calls = 0;
+    bool captured_root_background = false;
+    pulp::canvas::Color root_background;
 
     {
-        AudioInspectorWindow window(nullptr, nullptr,
-                                    null_host_factory(&factory_calls));
+        AudioInspectorWindow window(
+            nullptr, nullptr,
+            [&](View& root, const WindowOptions&) -> std::unique_ptr<WindowHost> {
+                ++factory_calls;
+                captured_root_background = root.has_background_color();
+                root_background = root.background_color();
+                return nullptr;
+            });
         window.register_command_handler(reg);
 
         // The registry path must not clobber any raw global-key hook.
@@ -308,6 +364,11 @@ TEST_CASE("AudioInspectorWindow toggle command opens via the registry and does "
         // Toggle chord routes to the window's handler → show() → host factory.
         REQUIRE(reg.dispatch_key_event(audio_toggle_chord()));
         REQUIRE(factory_calls == 1);
+        REQUIRE(captured_root_background);
+        REQUIRE(root_background.r <= 1.0f);
+        REQUIRE(root_background.g <= 1.0f);
+        REQUIRE(root_background.b <= 1.0f);
+        REQUIRE(root_background.a <= 1.0f);
 
         // Re-registering with the same registry must not double-add.
         window.register_command_handler(reg);

--- a/test/test_standalone_audio_inspector.cpp
+++ b/test/test_standalone_audio_inspector.cpp
@@ -1,0 +1,190 @@
+// test_standalone_audio_inspector.cpp — the standalone-host wiring proof for
+// the developer Audio Inspector (audio observability harness Phase 6,
+// planning/2026-06-09-audio-inspector-separate-tool-window-proposal.md).
+//
+// The window tests in test_audio_inspector_window.cpp prove the window in
+// isolation. This file proves the SEAM the standalone host owns: the exact
+// `AudioInspectorWindow::set_probe(&StandaloneApp::output_probe())` +
+// `poll()` contract that `run_with_editor()` wires. Driving the full GPU host
+// headlessly (device callback → analyze_output) is impractical in a unit test,
+// so we observe the same `output_probe()` reference the host hands the window,
+// feed it the way the audio callback would, and assert the window reflects it.
+//
+// Without a GPU WindowHost the window never creates a native surface, but the
+// data path (probe → snapshot → panel state) is fully exercised window-side.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/format/standalone.hpp>
+#include <pulp/format/processor.hpp>
+#include <pulp/view/audio_inspector_window.hpp>
+#include <pulp/view/audio_inspector_panel.hpp>
+
+#include <cmath>
+#include <memory>
+#include <vector>
+
+#if PULP_ENABLE_AUDIO_PROBES
+
+using namespace pulp::format;
+using pulp::audio::AudioProbe;
+using pulp::audio::AudioProbeStage;
+using pulp::audio::BufferView;
+using pulp::view::AudioInspectorPanel;
+using pulp::view::AudioInspectorWindow;
+using pulp::view::AudioWaveformView;
+
+namespace {
+
+// Minimal pass-through processor; the test feeds the probe directly, so the
+// processor body is never exercised — it exists only so StandaloneApp::start()
+// has something to prepare.
+class SilentProc : public Processor {
+public:
+    PluginDescriptor descriptor() const override {
+        PluginDescriptor d;
+        d.name = "StandaloneAudioInspectorProc";
+        d.manufacturer = "Pulp";
+        return d;
+    }
+    void define_parameters(pulp::state::StateStore&) override {}
+    void prepare(const PrepareContext&) override {}
+    void process(pulp::audio::BufferView<float>&,
+                 const pulp::audio::BufferView<const float>&,
+                 pulp::midi::MidiBuffer&,
+                 pulp::midi::MidiBuffer&,
+                 const ProcessContext&) override {}
+};
+
+std::unique_ptr<Processor> make_silent_proc() {
+    return std::make_unique<SilentProc>();
+}
+
+// Fixed-capacity stereo block over stable storage; channel pointers built once.
+struct StereoBlock {
+    std::vector<float> left;
+    std::vector<float> right;
+    std::vector<const float*> ptrs;
+
+    explicit StereoBlock(std::size_t frames)
+        : left(frames, 0.0f), right(frames, 0.0f) {
+        ptrs = {left.data(), right.data()};
+    }
+    BufferView<const float> view() const {
+        return BufferView<const float>(ptrs.data(), 2, left.size());
+    }
+};
+
+}  // namespace
+
+TEST_CASE("StandaloneApp wires its output probe into the Audio Inspector window",
+          "[format][standalone][audio-inspector][audio-harness]") {
+    StandaloneApp app(&make_silent_proc);
+
+    StandaloneConfig cfg;
+    cfg.headless = true;
+    cfg.output_channels = 2;
+    cfg.buffer_size = 128;
+    cfg.sample_rate = 48000.0;
+    app.set_config(cfg);
+
+    if (!app.start()) {
+        // No usable audio device (headless CI without an output device). The
+        // probe is only prepare()d inside start(); skip honestly rather than
+        // assert on an un-prepared probe.
+        SUCCEED("no audio device available — standalone wiring check skipped");
+        return;
+    }
+
+    // start() opens AND starts a real output device, whose callback runs
+    // output_probe_.analyze_output() on the audio thread. Stop it BEFORE we feed
+    // the probe manually below — otherwise the live (silent) callback is a
+    // second producer racing our tone snapshot, and the window could poll() a
+    // silence frame (peak == 0). stop() halts the device but leaves the probe
+    // prepared (it is a StandaloneApp member, not torn down here), so the
+    // wiring reference stays valid.
+    auto& probe = app.output_probe();
+    app.stop();
+
+    // The window consumes the SAME reference the host hands it in
+    // run_with_editor(): app.output_probe(). No host factory → no native
+    // surface, but the probe → panel data path is fully exercised.
+    AudioInspectorWindow window;
+    window.set_probe(&probe);
+    REQUIRE(window.probe() == &probe);
+
+    // Feed the probe the way the audio callback would (analyze_output on the
+    // output boundary) with a 440 Hz tone, then poll: the window must read Live.
+    // (No "idle before feed" assertion here: the now-stopped device may have
+    // already published silent snapshots, so the first poll would legitimately
+    // read Live-but-silent. The idle / no-probe states are covered by the
+    // window-only tests in test_audio_inspector_window.cpp.)
+    probe.reset();  // clear any snapshot the live device published before stop()
+    StereoBlock block(static_cast<std::size_t>(cfg.buffer_size));
+    for (std::size_t i = 0; i < block.left.size(); ++i) {
+        const float s = std::sin(2.0f * 3.14159265f * 440.0f *
+                                 static_cast<float>(i) / 48000.0f);
+        block.left[i] = 0.6f * s;
+        block.right[i] = 0.45f * s;
+    }
+    probe.analyze_output(block.view());
+
+    window.poll();
+    REQUIRE(window.panel().status() == AudioInspectorPanel::Status::kLive);
+    REQUIRE(window.panel().observed_stage() ==
+            AudioProbeStage::kStandaloneOutputBoundary);
+    REQUIRE(window.panel().peak() > 0.0f);
+    REQUIRE(window.panel().rms() > 0.0f);
+
+    // The panel surfaces the live readout as visible text (not a blank panel):
+    // the status reads "live", the level carries a "dBFS" readout, and the
+    // heading color is a valid [0,1] Color (the white-on-white bug fed 0-255
+    // into the [0,1] ctor, leaving every channel >1 and clamped to white).
+    REQUIRE(window.panel().status_text().find("live") != std::string::npos);
+    REQUIRE(window.panel().level_text().find("dBFS") != std::string::npos);
+    REQUIRE(window.panel().status_color().r <= 1.0f);
+    REQUIRE(window.panel().status_color().g <= 1.0f);
+    REQUIRE(window.panel().status_color().b <= 1.0f);
+}
+
+TEST_CASE("Standalone-style capture ring lets the inspector show a live waveform",
+          "[format][standalone][audio-inspector][audio-harness]") {
+    // run_with_editor() enables a capture ring sized to the panel's display
+    // capacity when PULP_AUDIO_INSPECTOR is set, so the inspector paints a
+    // waveform and not just meters. Reproduce that prepare() shape directly
+    // (start() leaves capture off by default) and assert the window copies a
+    // non-empty trace off the probe.
+    AudioProbe probe;
+    AudioProbe::CaptureConfig cap;
+    cap.capture_frames = AudioWaveformView::kCapacity;
+    probe.prepare(2, 128, 48000.0,
+                  AudioProbeStage::kStandaloneOutputBoundary, cap);
+
+    StereoBlock block(128);
+    for (std::size_t i = 0; i < block.left.size(); ++i) {
+        const float s = std::sin(2.0f * 3.14159265f * 440.0f *
+                                 static_cast<float>(i) / 48000.0f);
+        block.left[i] = 0.6f * s;
+        block.right[i] = 0.45f * s;
+    }
+    // Several blocks so the ring fills past one buffer of frames.
+    for (int b = 0; b < 8; ++b) probe.analyze_output(block.view());
+
+    AudioInspectorWindow window;
+    window.set_probe(&probe);
+    window.poll();
+
+    REQUIRE(window.panel().status() == AudioInspectorPanel::Status::kLive);
+    // The waveform the panel renders is genuinely non-empty — the standalone
+    // capture ring is what makes the inspector's trace visible.
+    REQUIRE(window.panel().waveform().sample_count() > 0);
+}
+
+#else  // PULP_ENABLE_AUDIO_PROBES
+
+TEST_CASE("Standalone audio inspector wiring requires PULP_ENABLE_AUDIO_PROBES",
+          "[format][standalone][audio-inspector][audio-harness]") {
+    SUCCEED("audio probes disabled in this build — standalone wiring not present");
+}
+
+#endif  // PULP_ENABLE_AUDIO_PROBES

--- a/test/test_standalone_editor_chrome.cpp
+++ b/test/test_standalone_editor_chrome.cpp
@@ -861,6 +861,23 @@ TEST_CASE("Standalone idle callback still polls settings without scripted UI",
     REQUIRE(settings_polled);
 }
 
+TEST_CASE("Standalone idle callback can be composed by tool windows",
+          "[standalone][chrome]") {
+    std::vector<std::string> calls;
+
+    auto prior = make_standalone_idle_callback(
+        [&] { calls.push_back("scripted"); },
+        [&] { calls.push_back("settings"); });
+    auto composed = [prior, &calls] {
+        prior();
+        calls.push_back("audio-inspector");
+    };
+
+    composed();
+    REQUIRE(calls == std::vector<std::string>{
+        "scripted", "settings", "audio-inspector"});
+}
+
 TEST_CASE("Standalone repaint helper routes scripted UI repaint through the window",
           "[standalone][chrome]") {
     StubWindowHost window;


### PR DESCRIPTION
The `AudioInspectorWindow` (Phase 6) existed only in tests — no runnable app opened it, so a developer couldn't launch and SEE live probe data. This wires it into the standalone host and fixes a panel-render bug that made everything but the meters invisible.

**Host wiring** (`run_with_editor`, `#if PULP_ENABLE_AUDIO_PROBES`):
- `set_probe(&output_probe_)` + a shell-owned `CommandRegistry` + `route_global_keys` so Cmd/Ctrl+Shift+A toggles it. That writes `on_global_key`, distinct from the layout inspector's `on_global_click` (Cmd+I) — they coexist, no clobber.
- `poll()` **composed** into the existing idle callback (prior work runs first).
- Opens on `PULP_AUDIO_INSPECTOR`; under that env `start()` sizes the probe's capture ring so the inspector paints a live waveform. Default builds stay summary-only (no waveform allocation).
- Headless `--screenshot` also captures the inspector's own window to `<stem>.audio-inspector.png`.

**Panel-render fix:** `AudioInspectorPanel` built colors with `Color{26,26,32,255}` (0–255 ints), but `canvas::Color` channels are floats in `[0,1]` — Skia clamped every channel to 1.0 (opaque white), so labels + waveform painted white-on-white. Switched all sites to `Color::rgba8()`. Tests now assert the rendered frame is dark with real content (luminance) and channels stay ≤ 1.0 — catching the bug class.

**Validated** by launching a GPU standalone host headless with `PULP_AUDIO_INSPECTOR=1`: the inspector renders status/stage/Peak+RMS dBFS/L-R meters/a live sine waveform/clip+NaN+silence/L-R match+balance/device stats.

Tests: `pulp-test-standalone-audio-inspector` (new) + `pulp-test-audio-inspector-window` green. Follows the dead-probe-macro fix (#3941).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired the Audio Inspector into the standalone host as a floating tool window with a global toggle, plus optional headless capture of its own window; also fixed a color bug that hid labels and the waveform.

- **New Features**
  - Integrates `AudioInspectorWindow` into `StandaloneApp::run_with_editor()` as a sibling floating window bound to `output_probe_`; created only with a real `WindowHost`.
  - Adds a shell-owned `CommandRegistry` and routes keys via `route_global_keys`; Cmd/Ctrl+Shift+A toggles the inspector without clobbering the layout inspector (Cmd+I).
  - Composes `poll()` with existing idle work using `make_standalone_idle_callback` so overlay/scripted UI/settings run first; safe teardown ensures the window/registry are destroyed before the probe.
  - `PULP_AUDIO_INSPECTOR` opens the window and enables a capture ring sized to `AudioWaveformView::kCapacity` for a live waveform; headless `--screenshot` also writes `<stem>.audio-inspector.png` when visible and GPU capture is available.
  - Tests: new `pulp-test-standalone-audio-inspector`; window tests assert live text, waveform, dark-frame stats, and valid color ranges; added idle-callback composition test. Exposes `status_text()`, `level_text()`, `status_color()`, and `AudioInspectorWindow::window_host()` for assertions and capture.

- **Bug Fixes**
  - Switched panel colors to `canvas::Color::rgba8(...)` to avoid white-on-white labels/waveform from 0–255 brace-init; tests guard luminance and channel ranges.

<sup>Written for commit ac015ec5ad5eb882df0ae1a1d639774102597666. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

