### PR TITLE
fix(audio): adversarial-review followups across the observability harness

### DIFF
--- a/.agents/skills/audio-harness/SKILL.md
+++ b/.agents/skills/audio-harness/SKILL.md
@@ -86,8 +86,8 @@ Measure it like Plugin Doctor (offline Doctor):
 ```cpp
 auto curve = response_relative_to_input(sc, {50.0, 8000.0});
 REQUIRE(curve.attenuation_db_at(8000.0) >= 20.0);   // "drops ≥20 dB at 8 kHz"
-auto thd = measure_thd(/* steady bin-coherent sine through the processor */);
-// thd.thd_percent, thd.thd_plus_n, thd.harmonics[...]
+auto thd = measure_thd(sc, /*fundamental_hz=*/999.0); // steady bin-coherent sine
+// thd.thd_percent(), thd.thd_plus_n, thd.harmonics[...]
 ```
 
 ## Discipline that keeps it trustworthy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.410.0
+    VERSION 0.411.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/audio_inspector_panel.hpp
+++ b/core/view/include/pulp/view/audio_inspector_panel.hpp
@@ -62,6 +62,16 @@ private:
     bool live_ = false;
 };
 
+/// dBFS floor used by the inspector's meter fill (and the empty-bar anchor).
+inline constexpr float kInspectorMeterFloorDb = -60.0f;
+
+/// Map a linear amplitude (1.0 == full scale) to a 0..1 meter fill on the SAME
+/// dBFS scale the panel's text labels print, so a bar and its "… dBFS" label
+/// agree. `kInspectorMeterFloorDb` maps to an empty bar, 0 dBFS to a full bar;
+/// passing the raw linear amplitude to `Meter::set_level` would instead make
+/// the bar read amplitude while the label reads dBFS — two different scales.
+float dbfs_meter_fill(float linear);
+
 /// Audio Inspector content panel. Self-contained: build the widget tree once,
 /// then call `update()` each UI tick with the latest copied snapshot.
 class AudioInspectorPanel : public View {

--- a/core/view/include/pulp/view/audio_inspector_window.hpp
+++ b/core/view/include/pulp/view/audio_inspector_window.hpp
@@ -2,8 +2,8 @@
 
 /// @file audio_inspector_window.hpp
 /// Separate developer Audio Inspector tool window — live signal observability
-/// (meters, probe-stage status, copied waveform, correlation/balance, device
-/// summary) built on the Phase 5 realtime probe.
+/// (meters, probe-stage status, copied waveform, L/R level-match/balance,
+/// device summary) built on the Phase 5 realtime probe.
 ///
 /// This is a SIBLING of `InspectorWindow` (the layout inspector), not a tab
 /// inside it. The two tools share window / command / visual primitives but own

--- a/core/view/src/audio_inspector_panel.cpp
+++ b/core/view/src/audio_inspector_panel.cpp
@@ -33,6 +33,13 @@ const char* stage_name(audio::AudioProbeStage stage) {
 
 }  // namespace
 
+float dbfs_meter_fill(float linear) {
+    if (linear <= 1.0e-6f) return 0.0f;
+    const float db = 20.0f * std::log10(linear);
+    return std::clamp((db - kInspectorMeterFloorDb) / -kInspectorMeterFloorDb,
+                      0.0f, 1.0f);
+}
+
 // ── AudioWaveformView ───────────────────────────────────────────────────────
 
 AudioWaveformView::AudioWaveformView() {
@@ -241,9 +248,14 @@ void AudioInspectorPanel::update(Status status,
     }
 
     // Drive the visual meters with the snapshot levels (instantaneous, no
-    // ballistics decay needed for a live readout).
-    if (peak_meter_) peak_meter_->set_level(snapshot_.rms_max, snapshot_.peak_max);
-    if (rms_meter_) rms_meter_->set_level(snapshot_.rms_max, snapshot_.rms_max);
+    // ballistics decay needed for a live readout). Map amplitude through the
+    // same dBFS transform the labels use so the bar height matches the dBFS text.
+    if (peak_meter_)
+        peak_meter_->set_level(dbfs_meter_fill(snapshot_.rms_max),
+                               dbfs_meter_fill(snapshot_.peak_max));
+    if (rms_meter_)
+        rms_meter_->set_level(dbfs_meter_fill(snapshot_.rms_max),
+                              dbfs_meter_fill(snapshot_.rms_max));
 
     refresh_labels();
 }

--- a/test/support/audio_contracts.cpp
+++ b/test/support/audio_contracts.cpp
@@ -56,15 +56,23 @@ CheckResult AudioContract::verify() const {
         return {true, msg.str()};
     }
 
-    // Leave a machine-readable record of what the signal looked like.
+    // Leave a machine-readable record of what the signal looked like. NOTE:
+    // this artifact always reflects the FULL-render metrics (result_.metrics),
+    // even when the failing check was a windowed / block-partition sub-view
+    // (e.g. expect_tone's held window) — the per-check message names the window
+    // it judged, so read the message for the sub-view and this artifact for the
+    // whole-render context.
     const auto artifact = write_metrics_artifact(result_.metrics,
                                                  result_.scenario);
     for (const auto& check : checks_) {
         if (!check.passed)
             msg << "contract '" << name_ << "': " << check.message << "\n";
     }
-    msg << "  scenario: " << result_.scenario << "\n"
-        << "  artifact: " << artifact.string();
+    msg << "  scenario: " << result_.scenario << "\n";
+    if (!artifact.empty())
+        msg << "  artifact: " << artifact.string();
+    else
+        msg << "  artifact: (write failed)";
     return {false, msg.str()};
 }
 
@@ -101,9 +109,12 @@ CheckResult expect_tone(const ScenarioResult& result, const ToneClaim& claim) {
     std::ostringstream label;
     label << "tone over held window [" << claim.window_start << ", "
           << claim.window_start + claim.window_frames << ")";
+    // assert_rms_between requires EVERY channel ≥ min_rms_dbfs, which already
+    // subsumes assert_not_silent (≥ min on at least one channel), so the
+    // not-silent check would be redundant here — the range claim is strictly
+    // stronger.
     return combine(label.str(),
-                   {assert_not_silent(metrics, claim.min_rms_dbfs),
-                    assert_rms_between(metrics, claim.min_rms_dbfs,
+                   {assert_rms_between(metrics, claim.min_rms_dbfs,
                                        claim.max_rms_dbfs),
                     assert_frequency_near(window.channel(0),
                                           result.sample_rate,

--- a/test/support/audio_signal_generators.cpp
+++ b/test/support/audio_signal_generators.cpp
@@ -23,12 +23,20 @@ std::uint64_t mix_seed(std::uint64_t seed, std::uint64_t channel) {
 }
 
 // xorshift64* step; returns uniform double in [-1.0, 1.0).
+//
+// Uses the top 53 bits (the double mantissa width): `u >> 11` is an integer in
+// [0, 2^53) that maps EXACTLY into a double, so `(u >> 11) / 2^53` is in [0, 1)
+// with no rounding, and `* 2 - 1` is provably in [-1, 1). Dividing the full
+// 64-bit `u` by 2^63 instead would double-round near the top of the range
+// (values close to 2^64 round up to 2^64 exactly), yielding 1.0 and breaking
+// the half-open contract.
 double next_uniform(std::uint64_t& state) {
     state ^= state >> 12;
     state ^= state << 25;
     state ^= state >> 27;
     const std::uint64_t u = state * 0x2545F4914F6CDD1DULL;
-    return static_cast<double>(u) / 9223372036854775808.0 - 1.0; // u/2^63 − 1
+    const double unit = static_cast<double>(u >> 11) / 9007199254740992.0; // /2^53
+    return unit * 2.0 - 1.0; // [-1.0, 1.0)
 }
 
 void require(bool ok, const char* what) {

--- a/test/support/audio_signal_generators.hpp
+++ b/test/support/audio_signal_generators.hpp
@@ -77,10 +77,11 @@ pulp::audio::Buffer<float> make_swept_sine(int channels, int frames,
 /// Deterministic uniform white noise in [-amplitude, amplitude).
 ///
 /// PRNG (the whole determinism contract): xorshift64* seeded through one
-/// SplitMix64 scramble of `seed ^ channel-index mixing` so channel 0 and
+/// SplitMix64 scramble of `seed + 0x9E3779B97F4A7C15 * (channel + 1)` — an
+/// additive golden-ratio per-channel offset (NOT an XOR) — so channel 0 and
 /// channel 1 are decorrelated but each is fully reproducible from `seed`.
 /// Expression per sample: `x ^= x >> 12; x ^= x << 25; x ^= x >> 27;
-/// u = x * 0x2545F4914F6CDD1D; sample = amplitude * (u / 2^63 - 1.0)`.
+/// u = x * 0x2545F4914F6CDD1D; sample = amplitude * ((u >> 11) / 2^53 * 2 - 1)`.
 /// A zero-state lock is impossible because SplitMix64 never yields 0 for
 /// distinct inputs mapped through its finalizer (we also OR in 1).
 pulp::audio::Buffer<float> make_white_noise(int channels, int frames,

--- a/test/support/audio_test_signals.hpp
+++ b/test/support/audio_test_signals.hpp
@@ -36,6 +36,28 @@ inline pulp::audio::Buffer<float> make_sine(int channels, int samples,
     return buf;
 }
 
+/// Sine-wave Buffer computed in **all-float** arithmetic (index and sample
+/// rate narrowed to float before the division, so the whole phase expression
+/// stays single-precision). Matches the local helper that `test_audio_support`
+/// originally used, whose stimulus differs bit-for-bit from `make_sine`'s
+/// double-promoted phase. Both are preserved verbatim so each converted suite
+/// keeps byte-identical stimulus.
+inline pulp::audio::Buffer<float> make_sine_f(int channels, int samples,
+                                              float freq = 440.0f,
+                                              double sample_rate = 48000.0,
+                                              float amplitude = 1.0f) {
+    pulp::audio::Buffer<float> buf(channels, samples);
+    for (int ch = 0; ch < channels; ++ch) {
+        for (int i = 0; i < samples; ++i) {
+            buf.channel(ch)[i] = amplitude *
+                std::sin(2.0f * std::numbers::pi_v<float> * freq *
+                         static_cast<float>(i) /
+                         static_cast<float>(sample_rate));
+        }
+    }
+    return buf;
+}
+
 /// Sine-wave vector. Same all-float expression as the determinism matrix's
 /// local helper (note: NOT bit-identical to make_sine, which promotes to
 /// double — both are preserved verbatim so converted suites keep their

--- a/test/test_audio_doctor.cpp
+++ b/test/test_audio_doctor.cpp
@@ -253,3 +253,55 @@ TEST_CASE("Doctor: curve artifact round-trips", "[audio][doctor]") {
     REQUIRE(thd_parsed["harmonics"].isArray());
     CHECK(thd_parsed["harmonics"].size() >= 2);
 }
+
+TEST_CASE("Doctor: response guards an empty impulse reference window",
+          "[audio][doctor]") {
+    // The default reference is an impulse at frame 0. At offset 0 the input
+    // window contains it and the transfer curve is well-defined; at offset > 0
+    // the window misses the impulse, in_mag ≈ 0, and the bin-by-bin division
+    // would produce garbage. The buffer-level analyzer must reject that rather
+    // than silently return a meaningless curve.
+    constexpr int kFft = 1024;
+    constexpr int kRenderLen = kFft * 2; // room for an offset window.
+    auto impulse = make_impulse(/*channels=*/2, kRenderLen, 1.0f, /*position=*/0);
+    const double checkpoints[] = {1000.0};
+
+    ResponseOptions opts;
+    opts.fft_length = kFft;
+
+    // offset 0: the impulse is in the window, so the curve is computed.
+    opts.analysis_offset = 0;
+    REQUIRE_NOTHROW(response_relative_to_input(
+        std::as_const(impulse).view(), std::as_const(impulse).view(),
+        kSampleRate, checkpoints, opts));
+
+    // offset > 0: the impulse has fallen out of the reference window → guard.
+    opts.analysis_offset = kFft;
+    REQUIRE_THROWS_AS(
+        response_relative_to_input(std::as_const(impulse).view(),
+                                   std::as_const(impulse).view(), kSampleRate,
+                                   checkpoints, opts),
+        std::invalid_argument);
+}
+
+TEST_CASE("Doctor: THD rejects a DC-bin fundamental", "[audio][doctor]") {
+    // A fundamental that resolves to bin 0 has no energy after DC removal and
+    // would divide thd/thd+n by a near-zero floor. The analyzer must reject it.
+    constexpr int kFft = 1024;
+    const double tone = coherent_tone(64, kFft, kSampleRate);
+    auto signal = make_sine(/*channels=*/1, kFft, static_cast<float>(tone),
+                            kSampleRate, 0.5f);
+
+    ThdOptions topts;
+    topts.fft_length = kFft;
+
+    // A normal coherent tone resolves to a real bin and measures fine.
+    REQUIRE_NOTHROW(measure_thd(std::as_const(signal).view(), tone, kSampleRate,
+                                topts));
+
+    // A near-DC "fundamental" rounds to bin 0 and must be rejected.
+    const double dc_like = kSampleRate / kFft / 4.0; // < half a bin → bin 0.
+    REQUIRE_THROWS_AS(measure_thd(std::as_const(signal).view(), dc_like,
+                                  kSampleRate, topts),
+                      std::invalid_argument);
+}

--- a/test/test_audio_inspector_window.cpp
+++ b/test/test_audio_inspector_window.cpp
@@ -17,6 +17,7 @@
 //   * Cmd+I (layout inspector) still works alongside Cmd+Shift+A (audio
 //     inspector) — no chord clobber.
 
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include <pulp/audio/audio_probe.hpp>
@@ -137,6 +138,25 @@ TEST_CASE("AudioInspectorWindow meters reflect the probe snapshot",
     REQUIRE(panel.balance() < 0.0f);
     // Both channels carry energy → positive L/R level-match.
     REQUIRE(panel.lr_match() > 0.0f);
+}
+
+TEST_CASE("Audio Inspector meter fill is on the dBFS scale, not linear",
+          "[view][audio-inspector][audio-harness]") {
+    // The meter bar and its "… dBFS" label must agree: the fill maps linear
+    // amplitude through the same dBFS transform the label uses (−60 dBFS floor
+    // → empty bar, 0 dBFS → full bar), not the raw linear amplitude.
+    REQUIRE(dbfs_meter_fill(1.0f) == Catch::Approx(1.0f));   // 0 dBFS → full.
+    REQUIRE(dbfs_meter_fill(0.0f) == 0.0f);                  // silence → empty.
+    REQUIRE(dbfs_meter_fill(0.001f) == 0.0f);                // −60 dBFS → empty.
+
+    // Half amplitude is ≈ −6 dBFS, which on a −60..0 scale is 0.9, NOT the 0.5
+    // a linear meter would show — the assertion that distinguishes the two.
+    REQUIRE(dbfs_meter_fill(0.5f) == Catch::Approx(0.9f).margin(0.005f));
+    REQUIRE(dbfs_meter_fill(0.5f) > 0.6f); // decisively above the linear 0.5.
+
+    // Monotonic and clamped above full scale.
+    REQUIRE(dbfs_meter_fill(0.25f) < dbfs_meter_fill(0.5f));
+    REQUIRE(dbfs_meter_fill(2.0f) == Catch::Approx(1.0f)); // > 0 dBFS clamps to 1.
 }
 
 TEST_CASE("AudioInspectorWindow goes stale when the sequence stops advancing",

--- a/test/test_audio_support.cpp
+++ b/test/test_audio_support.cpp
@@ -40,7 +40,7 @@ TEST_CASE("audio_metrics: full-scale sine has known peak/RMS/DC",
           "[audio-support][harness-1a]") {
     // 440 Hz @ 48 kHz, 4800 frames = exactly 44 cycles, so RMS is the ideal
     // 1/sqrt(2) and DC is ~0 without partial-cycle bias.
-    auto buf = make_sine(2, 4800, 440.0f, 48000.0);
+    auto buf = make_sine_f(2, 4800, 440.0f, 48000.0);
     auto m = analyze(buf, 48000.0);
 
     REQUIRE(m.num_channels == 2);
@@ -79,7 +79,7 @@ TEST_CASE("audio_metrics: DC offset is reported",
 
 TEST_CASE("audio_metrics: NaN and Inf samples are counted, not propagated",
           "[audio-support][harness-1a]") {
-    auto buf = make_sine(1, 1024, 440.0f, 48000.0, 0.5f);
+    auto buf = make_sine_f(1, 1024, 440.0f, 48000.0, 0.5f);
     buf.channel(0)[10] = std::numeric_limits<float>::quiet_NaN();
     buf.channel(0)[20] = std::numeric_limits<float>::infinity();
     buf.channel(0)[30] = -std::numeric_limits<float>::infinity();
@@ -116,7 +116,7 @@ TEST_CASE("audio_metrics: clipped samples are counted at the threshold",
 
 TEST_CASE("audio_metrics: silence runs are measured",
           "[audio-support][harness-1a]") {
-    auto buf = make_sine(1, 1000, 440.0f, 48000.0, 0.5f);
+    auto buf = make_sine_f(1, 1000, 440.0f, 48000.0, 0.5f);
     // Insert a 200-sample dropout (the plan's "standalone boundary went
     // silent for N consecutive blocks" signature, in miniature).
     for (int i = 300; i < 500; ++i) buf.channel(0)[i] = 0.0f;
@@ -140,7 +140,7 @@ TEST_CASE("audio_assertions: silence and non-silence",
     REQUIRE_FALSE(not_silent_check.passed);
     REQUIRE(not_silent_check.message.find("-inf dBFS") != std::string::npos);
 
-    auto tone = make_sine(2, 512, 440.0f, 48000.0, 0.5f);
+    auto tone = make_sine_f(2, 512, 440.0f, 48000.0, 0.5f);
     auto tone_m = analyze(tone, 48000.0);
     REQUIRE(assert_not_silent(tone_m, -60.0).passed);
     REQUIRE_FALSE(assert_silent(tone_m, -90.0).passed);
@@ -149,7 +149,7 @@ TEST_CASE("audio_assertions: silence and non-silence",
 TEST_CASE("audio_assertions: peak and RMS ranges",
           "[audio-support][harness-1a]") {
     // -6 dBFS sine: peak ≈ -6 dBFS, RMS ≈ -9 dBFS.
-    auto buf = make_sine(1, 4800, 440.0f, 48000.0, 0.501187f);
+    auto buf = make_sine_f(1, 4800, 440.0f, 48000.0, 0.501187f);
     auto m = analyze(buf, 48000.0);
 
     REQUIRE(assert_peak_between(m, -7.0, -5.0).passed);
@@ -165,7 +165,7 @@ TEST_CASE("audio_assertions: frequency estimate within cents tolerance",
     // Tolerance class: numeric. The zero-crossing estimator on a clean
     // 440 Hz sine over 9600 frames (88 cycles) should land well inside
     // ±5 cents.
-    auto buf = make_sine(1, 9600, 440.0f, 48000.0, 0.8f);
+    auto buf = make_sine_f(1, 9600, 440.0f, 48000.0, 0.8f);
     auto check = assert_frequency_near(buf.channel(0), 48000.0, 440.0, 5.0);
     INFO(check.message);
     REQUIRE(check.passed);
@@ -195,7 +195,7 @@ TEST_CASE("audio_assertions: sample-rate mismatch shows as pitch shift",
     // The plan's "chipmunk" regression: a 440 Hz tone rendered at 48 kHz but
     // played/analyzed as 96 kHz reads as 880 Hz. The helpers must make that
     // visible rather than vaguely "different".
-    auto buf = make_sine(1, 9600, 440.0f, 48000.0);
+    auto buf = make_sine_f(1, 9600, 440.0f, 48000.0);
     auto est = estimate_frequency(buf.channel(0), 96000.0);
     REQUIRE_THAT(est.hz, WithinRel(880.0, 0.01));
 }
@@ -204,8 +204,8 @@ TEST_CASE("audio_assertions: sample-rate mismatch shows as pitch shift",
 
 TEST_CASE("audio_assertions: null test detects exact and near matches",
           "[audio-support][harness-1a]") {
-    auto a = make_sine(2, 1024, 440.0f, 48000.0, 0.5f);
-    auto b = make_sine(2, 1024, 440.0f, 48000.0, 0.5f);
+    auto a = make_sine_f(2, 1024, 440.0f, 48000.0, 0.5f);
+    auto b = make_sine_f(2, 1024, 440.0f, 48000.0, 0.5f);
 
     REQUIRE(assert_null_near(a, b, -120.0).passed);
 
@@ -221,8 +221,8 @@ TEST_CASE("audio_assertions: null test detects exact and near matches",
 
 TEST_CASE("audio_assertions: null test rejects shape mismatch",
           "[audio-support][harness-1a]") {
-    auto a = make_sine(2, 512, 440.0f, 48000.0);
-    auto b = make_sine(1, 512, 440.0f, 48000.0);
+    auto a = make_sine_f(2, 512, 440.0f, 48000.0);
+    auto b = make_sine_f(1, 512, 440.0f, 48000.0);
     auto check = assert_null_near(a, b, -120.0);
     REQUIRE_FALSE(check.passed);
     REQUIRE(check.message.find("shape mismatch") != std::string::npos);
@@ -245,11 +245,37 @@ TEST_CASE("audio_assertions: duplicated channels are flagged",
     REQUIRE(assert_channels_independent(buf).passed);
 }
 
+TEST_CASE("audio_assertions: two silent channels are not flagged as duplicated",
+          "[audio-support][harness-1a]") {
+    // Two channels that are both silent are trivially sample-identical, but
+    // there is no signal to duplicate — that is not a routing bug.
+    pulp::audio::Buffer<float> silent(2, 512); // zero-initialized.
+    REQUIRE(assert_channels_independent(silent).passed);
+
+    // An identical near-zero constant on both channels is also not a duplication.
+    pulp::audio::Buffer<float> quiet_const(2, 512);
+    for (std::size_t i = 0; i < 512; ++i) {
+        quiet_const.channel(0)[i] = 1e-7f;
+        quiet_const.channel(1)[i] = 1e-7f;
+    }
+    REQUIRE(assert_channels_independent(quiet_const).passed);
+
+    // But two genuinely loud, identical channels still fire.
+    pulp::audio::Buffer<float> loud_dup(2, 512);
+    for (std::size_t i = 0; i < 512; ++i) {
+        const float v = std::sin(2.0f * std::numbers::pi_v<float> * 440.0f *
+                                 static_cast<float>(i) / 48000.0f);
+        loud_dup.channel(0)[i] = v;
+        loud_dup.channel(1)[i] = v;
+    }
+    REQUIRE_FALSE(assert_channels_independent(loud_dup).passed);
+}
+
 // ── signal summary ──────────────────────────────────────────────────────
 
 TEST_CASE("audio_metrics: summarize renders the agent-readable report",
           "[audio-support][harness-1a]") {
-    auto buf = make_sine(2, 9600, 220.0f, 48000.0, 0.5f);
+    auto buf = make_sine_f(2, 9600, 220.0f, 48000.0, 0.5f);
     auto m = analyze(buf, 48000.0);
     auto est = estimate_frequency(buf.channel(0), 48000.0);
     auto text = summarize(m, est);
@@ -272,7 +298,7 @@ TEST_CASE("audio_support: HeadlessHost render analyzed by the helpers",
     pulp::format::HeadlessHost host(pulp::examples::create_pulp_gain);
     host.prepare(48000.0, 1024);
 
-    auto in = make_sine(2, 1024, 440.0f, 48000.0, 0.5f);
+    auto in = make_sine_f(2, 1024, 440.0f, 48000.0, 0.5f);
     pulp::audio::Buffer<float> out(2, 1024);
     const float* in_ptrs[2] = {in.channel(0).data(), in.channel(1).data()};
     pulp::audio::BufferView<const float> in_view(in_ptrs, 2, 1024);

--- a/test/test_audio_tone_regression.cpp
+++ b/test/test_audio_tone_regression.cpp
@@ -143,8 +143,10 @@ TEST_CASE("Tone regression: metrics artifact JSON carries schema and facts",
     REQUIRE(parsed["num_channels"].getInt64() == 2);
     REQUIRE(parsed["channels"].size() == 2);
     const auto ch0 = parsed["channels"][0];
-    REQUIRE(ch0["peak"].getFloat64() > 0.0);
-    REQUIRE(ch0["rms"].getFloat64() > 0.0);
+    // choc drops a redundant ".0", so a whole-number peak/rms parses back as
+    // int64 and getFloat64() would throw — use the coercing get<double>().
+    REQUIRE(ch0["peak"].get<double>() > 0.0);
+    REQUIRE(ch0["rms"].get<double>() > 0.0);
     REQUIRE(ch0["nan_samples"].getInt64() == 0);
     REQUIRE(ch0["clipped_samples"].getInt64() == 0);
 

--- a/tools/audio/analysis/include/pulp/audio/analysis/audio_artifacts.hpp
+++ b/tools/audio/analysis/include/pulp/audio/analysis/audio_artifacts.hpp
@@ -32,6 +32,9 @@ std::string metrics_to_json(const BufferMetrics& metrics,
 /// `<temp>/pulp-audio-metrics/<sanitized-scenario>.json` (overwriting any
 /// previous run's artifact for the same scenario) and return the path.
 /// Scenario names are sanitized to [A-Za-z0-9._-] for the filename only.
+/// Returns an empty path if the temp dir is unavailable or the open/write
+/// fails — callers should treat an empty path as "no artifact written" rather
+/// than reporting a phantom successful write.
 std::filesystem::path write_metrics_artifact(const BufferMetrics& metrics,
                                              std::string_view scenario);
 

--- a/tools/audio/analysis/src/audio_artifacts.cpp
+++ b/tools/audio/analysis/src/audio_artifacts.cpp
@@ -53,14 +53,21 @@ std::filesystem::path write_metrics_artifact(const BufferMetrics& metrics,
     if (name.empty())
         name = "scenario";
 
-    const auto dir =
-        std::filesystem::temp_directory_path() / "pulp-audio-metrics";
     std::error_code ec;
-    std::filesystem::create_directories(dir, ec); // best-effort; open() reports
+    const auto dir =
+        std::filesystem::temp_directory_path(ec) / "pulp-audio-metrics";
+    if (ec)
+        return {}; // no temp dir → nowhere to write.
+    std::filesystem::create_directories(dir, ec);
+    if (ec)
+        return {}; // could not create the artifact dir.
 
     const auto path = dir / (name + ".json");
     std::ofstream out(path, std::ios::binary | std::ios::trunc);
     out << metrics_to_json(metrics, scenario);
+    out.flush();
+    if (!out)
+        return {}; // open/write/flush failed — report no artifact, not a phantom.
     return path;
 }
 

--- a/tools/audio/analysis/src/audio_assertions.cpp
+++ b/tools/audio/analysis/src/audio_assertions.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iomanip>
+#include <span>
 #include <sstream>
 
 namespace pulp::test::audio {
@@ -242,6 +243,17 @@ CheckResult assert_channels_independent(
     CheckResult result;
     result.passed = true;
     constexpr double kIdenticalEpsilon = 1e-9;
+    // Two channels that are both effectively silent (or both an identical
+    // constant near zero) are trivially "sample-identical" but carry no signal
+    // to duplicate — that is not a routing bug, so it must not be flagged. Only
+    // identical content that carries real energy is a genuine duplication.
+    constexpr double kSilenceFloor = 1e-6; // ≈ -120 dBFS peak.
+    const auto channel_peak = [](std::span<const float> s) {
+        double peak = 0.0;
+        for (float v : s)
+            peak = std::max(peak, std::abs(static_cast<double>(v)));
+        return peak;
+    };
     std::ostringstream msg;
     for (std::size_t ch_a = 0; ch_a < buffer.num_channels(); ++ch_a) {
         for (std::size_t ch_b = ch_a + 1; ch_b < buffer.num_channels(); ++ch_b) {
@@ -255,7 +267,11 @@ CheckResult assert_channels_independent(
                     break;
                 }
             }
-            if (identical) {
+            // Skip the verdict for two silent channels: identical-but-empty is
+            // not a duplication.
+            const bool both_silent = channel_peak(sa) < kSilenceFloor &&
+                                     channel_peak(sb) < kSilenceFloor;
+            if (identical && !both_silent) {
                 result.passed = false;
                 msg << "ch" << ch_a << " and ch" << ch_b
                     << " are sample-identical (within 1e-9) across "

--- a/tools/audio/analysis/src/audio_metrics.cpp
+++ b/tools/audio/analysis/src/audio_metrics.cpp
@@ -68,12 +68,18 @@ BufferMetrics analyze(const pulp::audio::BufferView<const float>& buffer,
         std::uint64_t current_silence_run = 0;
 
         for (float sample : span) {
+            // A non-finite sample is a defect, not silence: it breaks any
+            // running silence stretch so two silent runs separated by a NaN/Inf
+            // glitch are not merged into one longer "silence" run. Count it,
+            // reset the run, and skip the accumulators it would poison.
             if (std::isnan(sample)) {
                 ++out.nan_samples;
-                continue; // NaN poisons accumulators; count it, skip it.
+                current_silence_run = 0;
+                continue;
             }
             if (std::isinf(sample)) {
                 ++out.inf_samples;
+                current_silence_run = 0;
                 continue;
             }
             const double s = sample;

--- a/tools/audio/analysis/src/audio_spectrum.cpp
+++ b/tools/audio/analysis/src/audio_spectrum.cpp
@@ -143,6 +143,21 @@ ResponseCurve response_relative_to_input(
     const auto in_mag = spectrum_magnitude(in_seg);
     const auto out_mag = spectrum_magnitude(out_seg);
 
+    // Guard a near-silent reference window. The default stimulus is an impulse
+    // at frame 0, so with analysis_offset > 0 the input window [offset, offset+N)
+    // no longer contains the impulse → in_mag ≈ 0, and the bin-by-bin division
+    // would yield garbage (huge +dB). Require the reference window to carry real
+    // energy so a caller can't silently get a meaningless transfer curve. A
+    // non-impulse reference (e.g. a decoded WAV) with offset > 0 is fine as long
+    // as its window is not empty.
+    double in_energy = 0.0;
+    for (double m : in_mag)
+        in_energy += m * m;
+    require(in_energy > kLinearFloor,
+            "reference (input) analysis window is effectively silent — an "
+            "impulse reference requires analysis_offset == 0; use "
+            "magnitude_spectrum_curve for an offset self-spectrum");
+
     ResponseCurve curve;
     curve.stimulus = "impulse";
     curve.window = options.window;
@@ -267,6 +282,9 @@ ThdResult measure_thd(const pulp::audio::BufferView<const float>& signal,
     thd.num_harmonics = options.num_harmonics;
 
     const int fund_bin = nearest_bin(fundamental_hz, bin_hz, bins);
+    // DC was removed, so a fundamental that resolves to bin 0 has no signal to
+    // measure against and would make thd/thd+n divide by a near-zero floor.
+    require(fund_bin >= 1, "fundamental_hz must resolve to a non-DC bin");
     const double fund_mag = mag[static_cast<std::size_t>(fund_bin)];
     thd.harmonics.push_back({1, fundamental_hz, fund_mag, 0.0});
 


### PR DESCRIPTION
Batch of confirmed findings from a local adversarial review of the audio observability harness (the cloud reviewer was out of quota; false-positives were filtered by an adversarial verify pass). Each behavioral fix ships with a test.

**HIGH** — `response_relative_to_input` now guards a near-silent reference window (impulse-at-frame-0 + `analysis_offset>0` silently produced garbage +dB).
**MEDIUM** — `assert_channels_independent` no longer false-flags silent/equal-constant channels; `make_sine_f` restores byte-identical float stimulus for `test_audio_support`.
**LOW** — silence-run resets on NaN/Inf; tone-regression uses coercing `get<double>()`; `write_metrics_artifact` detects write failure; white-noise uses the top 53 bits (provably half-open) + `mix_seed` doc matches code; `measure_thd` guards a DC-bin fundamental; drop redundant `assert_not_silent`; Audio Inspector meters map through the same dBFS transform as their labels; fix the window `@file` 'correlation' comment.

Tests: audio-doctor 37/5, audio-support 73/17, tone-regression 26/2, render-scenario 371/8, audio-inspector-window 54/9 — all green. Completes the adversarial-review sweep (after #3941 critical + #3954 host wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes several correctness gaps in the audio observability harness to prevent bogus transfer curves, align meters with dBFS labels, and avoid false “duplicated channels” flags. Each change includes targeted tests.

- Bug Fixes
  - Transfer response: guard empty/near-silent input windows (impulse ref + offset) to prevent bogus +dB curves.
  - THD: reject fundamentals that resolve to the DC bin.
  - Channel independence: do not flag identical silent or near-constant channels as duplicates.
  - Audio Inspector: meter fill now maps amplitude to the same dBFS scale as labels.
  - White noise: use the top 53 bits for a provably half-open range; `mix_seed` docs match behavior.
  - Metrics/IO: reset silence runs on NaN/Inf; artifact writer returns an empty path on write failure; tone-regression JSON uses coercing `get<double>()`.
  - Tests/docs: restore byte-identical float stimulus via `make_sine_f`; clarify comments and SKILL examples.

<sup>Written for commit c4dd4243d6693035cfb2429fb8e94629f288e227. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

