### PR TITLE
test(signal): add RT helper contract coverage

### DIFF
--- a/core/signal/include/pulp/signal/ballistics_filter.hpp
+++ b/core/signal/include/pulp/signal/ballistics_filter.hpp
@@ -10,6 +10,10 @@ namespace pulp::signal {
 
 /// Envelope follower with configurable attack and release times.
 ///
+/// RT contract: `process()`, `current()`, and `reset()` allocate no memory.
+/// `prepare()` and parameter setters recompute coefficients and should be run
+/// outside the audio callback unless the caller owns the retiming point.
+///
 /// Tracks the envelope of an input signal using first-order IIR
 /// smoothing with separate attack (rising) and release (falling)
 /// time constants.

--- a/core/signal/include/pulp/signal/biquad.hpp
+++ b/core/signal/include/pulp/signal/biquad.hpp
@@ -4,8 +4,10 @@
 
 namespace pulp::signal {
 
-// Biquad IIR filter — standard second-order section
-// Real-time safe. Supports common filter types via static factory methods.
+// Biquad IIR filter — standard second-order section.
+// RT contract: coefficient calculation and process/reset paths allocate no
+// memory. Retune coefficients at a block boundary if parameter continuity
+// matters.
 class Biquad {
 public:
     enum class Type { lowpass, highpass, bandpass, notch, allpass, peaking, low_shelf, high_shelf };

--- a/core/signal/include/pulp/signal/delay_line.hpp
+++ b/core/signal/include/pulp/signal/delay_line.hpp
@@ -6,8 +6,9 @@
 
 namespace pulp::signal {
 
-// Delay line with linear interpolation for fractional delays
-// Real-time safe after prepare() (allocates buffer)
+// Delay line with linear interpolation for fractional delays.
+// RT contract: prepare() allocates storage; push/read/process/reset allocate no
+// memory after prepare().
 class DelayLine {
 public:
     // Allocate buffer for max delay in samples

--- a/core/signal/include/pulp/signal/fir_filter.hpp
+++ b/core/signal/include/pulp/signal/fir_filter.hpp
@@ -13,6 +13,10 @@ namespace pulp::signal {
 
 /// FIR filter with arbitrary coefficients and efficient circular buffer.
 ///
+/// RT contract: `set_coefficients()` allocates and must run off the audio
+/// thread. `process()` and `reset()` allocate no memory after coefficients are
+/// installed.
+///
 /// @code
 /// FirFilter fir;
 /// fir.set_coefficients({0.25f, 0.5f, 0.25f}); // 3-tap averaging

--- a/core/signal/include/pulp/signal/gain.hpp
+++ b/core/signal/include/pulp/signal/gain.hpp
@@ -5,7 +5,9 @@
 
 namespace pulp::signal {
 
-// Simple gain processor
+// Simple gain processor.
+// RT contract: setters and process paths are scalar-only and allocate no
+// memory.
 class Gain {
 public:
     void set_gain_db(float db) { gain_ = db_to_linear(db); }
@@ -24,8 +26,10 @@ private:
     float gain_ = 1.0f;
 };
 
-// Simple dry/wet mixer (single-sample, no latency compensation)
-// For the full multi-channel version with latency compensation, use dry_wet_mixer.hpp
+// Simple dry/wet mixer (single-sample, no latency compensation).
+// RT contract: setters and process paths are scalar-only and allocate no
+// memory. For the full multi-channel version with latency compensation, use
+// dry_wet_mixer.hpp.
 class SimpleMixer {
 public:
     void set_mix(float mix) { mix_ = std::clamp(mix, 0.0f, 1.0f); }

--- a/core/signal/include/pulp/signal/lookup_table.hpp
+++ b/core/signal/include/pulp/signal/lookup_table.hpp
@@ -12,6 +12,9 @@ namespace pulp::signal {
 
 /// Pre-computed function lookup table with linear interpolation.
 ///
+/// RT contract: construction allocates and runs the generator. `process()`,
+/// `operator[]`, and size queries allocate no memory after construction.
+///
 /// Maps an input range [min, max] to pre-computed output values,
 /// using linear interpolation between table entries for smooth results.
 ///

--- a/core/signal/include/pulp/signal/oscillator.hpp
+++ b/core/signal/include/pulp/signal/oscillator.hpp
@@ -4,8 +4,10 @@
 
 namespace pulp::signal {
 
-// Band-limited oscillator with polyBLEP anti-aliasing
-// Supports sine, saw, square, and triangle waveforms
+// Band-limited oscillator with polyBLEP anti-aliasing.
+// RT contract: setters, reset, and next() allocate no memory. Smooth frequency
+// externally if zipper-free retuning is required.
+// Supports sine, saw, square, and triangle waveforms.
 class Oscillator {
 public:
     enum class Waveform { sine, saw, square, triangle };

--- a/core/signal/include/pulp/signal/phaser.hpp
+++ b/core/signal/include/pulp/signal/phaser.hpp
@@ -6,7 +6,9 @@
 
 namespace pulp::signal {
 
-// Phaser effect using cascaded allpass filters with LFO modulation
+// Phaser effect using cascaded allpass filters with LFO modulation.
+// RT contract: configuration setters, process, and reset use fixed member
+// storage and allocate no memory.
 class Phaser {
 public:
     void set_sample_rate(float sr) { sample_rate_ = sr; }

--- a/core/signal/include/pulp/signal/processor_chain.hpp
+++ b/core/signal/include/pulp/signal/processor_chain.hpp
@@ -11,6 +11,9 @@ namespace pulp::signal {
 /// Chain multiple DSP processors in series. Each processor must have
 /// a `float process(float)` method.
 ///
+/// RT contract: `ProcessorChain` owns processors in a fixed tuple. Its
+/// process/reset paths allocate no memory when the contained processors do not.
+///
 /// @code
 /// ProcessorChain<Gain, Biquad, Compressor> chain;
 /// auto& gain = chain.get<0>();

--- a/core/signal/include/pulp/signal/processor_duplicator.hpp
+++ b/core/signal/include/pulp/signal/processor_duplicator.hpp
@@ -16,6 +16,10 @@ namespace pulp::signal {
 ///   - set_sample_rate(float)
 ///   - process(float) -> float  (single-sample)
 ///   - reset()
+///
+/// RT contract: `prepare()` resizes channel storage and is not audio-callback
+/// safe. `process()`, `process_channel()`, `for_each()`, and `reset()` allocate
+/// no memory after prepare when `P` follows the same contract.
 template<typename P>
 class ProcessorDuplicator {
 public:

--- a/core/signal/include/pulp/signal/svf.hpp
+++ b/core/signal/include/pulp/signal/svf.hpp
@@ -4,9 +4,11 @@
 
 namespace pulp::signal {
 
-// State Variable Filter — Topology Preserving Transform (TPT) design
-// Provides simultaneous lowpass, highpass, bandpass, and notch outputs
-// Numerically stable at all frequencies, no cramping at Nyquist
+// State Variable Filter — Topology Preserving Transform (TPT) design.
+// RT contract: setters recompute scalar coefficients; process/reset allocate no
+// memory. Retune at block boundaries if coefficient continuity matters.
+// Provides simultaneous lowpass, highpass, bandpass, and notch outputs.
+// Numerically stable at all frequencies, no cramping at Nyquist.
 class Svf {
 public:
     enum class Mode { lowpass, highpass, bandpass, notch };

--- a/core/signal/include/pulp/signal/waveshaper.hpp
+++ b/core/signal/include/pulp/signal/waveshaper.hpp
@@ -5,7 +5,9 @@
 
 namespace pulp::signal {
 
-// Waveshaping distortion with multiple curve types
+// Waveshaping distortion with multiple curve types.
+// RT contract: setters and process paths are scalar-only and allocate no
+// memory.
 class WaveShaper {
 public:
     enum class Curve { soft_clip, hard_clip, tanh_clip, fold, sine_fold };

--- a/core/signal/include/pulp/signal/wavetable.hpp
+++ b/core/signal/include/pulp/signal/wavetable.hpp
@@ -36,6 +36,10 @@ struct WavetableEntry {
 
 /// Wavetable oscillator with band-switching.
 ///
+/// RT contract: constructors and factory helpers allocate table storage and
+/// must run off the audio thread. `set_sample_rate()`, `set_frequency()`,
+/// `reset()`, and `next()` allocate no memory after construction.
+///
 /// Construction: supply a pre-sorted list of bands (lowest
 /// `max_frequency_hz` first). `set_frequency` selects the smallest
 /// band whose budget covers the new frequency. When the selection
@@ -202,6 +206,9 @@ private:
 /// Linear-interpolated morph across N `Wavetable`s. Position 0..1
 /// selects the wavetable: 0 = first, 1 = last, with linear
 /// interpolation between adjacent entries.
+///
+/// RT contract: construction and vector ownership changes allocate. Setters and
+/// `next()` allocate no memory once the bank is built.
 class WavetableBank {
 public:
     WavetableBank() = default;

--- a/docs/guides/signal-processing.md
+++ b/docs/guides/signal-processing.md
@@ -1,6 +1,6 @@
 # Signal Processing
 
-The `pulp::signal` namespace provides 20 DSP processors for use inside `Processor::process()`. All are real-time safe after initialization. Include individual headers or use the convenience header:
+The `pulp::signal` namespace provides 30+ DSP processors for use inside `Processor::process()`. Process methods are real-time safe after construction/configuration/`prepare()` as documented per helper; setup methods that allocate tables, delay buffers, coefficient storage, or impulse-response data must run off the audio thread. Include individual headers or use the convenience header:
 
 ```cpp
 #include <pulp/signal/signal.hpp>  // everything

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -365,7 +365,7 @@ send_sysex(inquiry);  // Send over MIDI port
 
 ## signal
 
-30+ real-time-safe DSP processors. All operate on single samples or buffers. All are safe for the audio thread.
+30+ real-time-safe DSP processors. Process methods operate on single samples or buffers and are safe for the audio thread after the helper's documented construction/configuration/`prepare()` step. Setup methods that allocate storage must run off the audio thread.
 
 **Link:** `pulp::signal` · **Include prefix:** `<pulp/signal/...>`
 

--- a/test/test_signal_rt_safety.cpp
+++ b/test/test_signal_rt_safety.cpp
@@ -2,14 +2,36 @@
 
 #include "harness/rt_allocation_probe.hpp"
 
+#include <pulp/signal/processor_duplicator.hpp>
+#include <pulp/signal/signal.hpp>
 #include <pulp/signal/oversampling.hpp>
+#include <pulp/signal/wavetable.hpp>
 
 #include <array>
 #include <cstddef>
+#include <vector>
 
+using namespace pulp::signal;
 using pulp::signal::Oversampler;
 
 namespace {
+
+template <typename Fn>
+void require_allocates_no_memory(Fn&& fn) {
+    pulp::test::RtAllocationProbe probe;
+    fn();
+    REQUIRE(probe.allocation_count() == 0);
+}
+
+struct RtProbeGain {
+    float gain = 1.0f;
+    float sample_rate = 0.0f;
+    int reset_count = 0;
+
+    void set_sample_rate(float sr) { sample_rate = sr; }
+    float process(float input) { return input * gain; }
+    void reset() { ++reset_count; }
+};
 
 void require_process_allocates_no_memory(Oversampler::Kind kind,
                                          Oversampler::Factor factor) {
@@ -75,4 +97,125 @@ TEST_CASE("Oversampler process_block is allocation-free after configuration",
 
     REQUIRE(probe.allocation_count() == 0);
     REQUIRE(callback_hits == static_cast<int>(input.size()) * os.factor_value());
+}
+
+TEST_CASE("Scalar signal helpers are allocation-free after configuration",
+          "[signal][rt-safety]") {
+    Gain gain;
+    gain.set_gain_linear(0.5f);
+
+    SimpleMixer mixer;
+    mixer.set_mix(0.25f);
+
+    Oscillator osc;
+    osc.set_sample_rate(48000.0f);
+    osc.set_frequency(220.0f);
+    osc.set_waveform(Oscillator::Waveform::saw);
+
+    Biquad biquad;
+    biquad.set_coefficients(Biquad::Type::lowpass, 1800.0f, 0.707f, 48000.0f);
+
+    Svf svf;
+    svf.set_sample_rate(48000.0f);
+    svf.set_frequency(900.0f);
+    svf.set_resonance(0.8f);
+    svf.set_mode(Svf::Mode::bandpass);
+
+    Phaser phaser;
+    phaser.set_sample_rate(48000.0f);
+    phaser.set_rate(0.4f);
+    phaser.set_depth(0.6f);
+    phaser.set_stages(4);
+
+    WaveShaper shaper;
+    shaper.set_curve(WaveShaper::Curve::soft_clip);
+    shaper.set_drive(2.0f);
+
+    BallisticsFilter ballistics;
+    ballistics.prepare(48000.0f);
+    ballistics.set_attack_ms(2.0f);
+    ballistics.set_release_ms(80.0f);
+
+    require_allocates_no_memory([&] {
+        std::array<float, 64> samples {};
+        for (std::size_t i = 0; i < samples.size(); ++i) {
+            const float input = static_cast<float>(i % 13) * 0.03f - 0.18f;
+            float value = gain.process(input);
+            value = mixer.process(value, osc.next());
+            value = biquad.process(value);
+            value = svf.process(value);
+            value = phaser.process(value);
+            value = shaper.process(value);
+            samples[i] = ballistics.process(value);
+        }
+
+        gain.process(samples.data(), static_cast<int>(samples.size()));
+        svf.process(samples.data(), static_cast<int>(samples.size()));
+        phaser.process(samples.data(), static_cast<int>(samples.size()));
+        shaper.process(samples.data(), static_cast<int>(samples.size()));
+        ballistics.reset();
+    });
+}
+
+TEST_CASE("Prepared storage-backed signal helpers are allocation-free while processing",
+          "[signal][rt-safety]") {
+    DelayLine delay;
+    delay.prepare(64);
+
+    FirFilter fir;
+    fir.set_coefficients(std::vector<float>{0.25f, 0.5f, 0.25f});
+
+    LookupTable table(64, -1.0f, 1.0f, [](float x) { return x * x * x; });
+
+    ProcessorDuplicator<RtProbeGain> duplicator;
+    duplicator.prepare(2, 48000.0f);
+    duplicator.for_each([](RtProbeGain& g) { g.gain = 0.75f; });
+
+    require_allocates_no_memory([&] {
+        std::array<float, 32> left {};
+        std::array<float, 32> right {};
+        for (std::size_t i = 0; i < left.size(); ++i) {
+            const float input = static_cast<float>(i + 1) * 0.01f;
+            delay.push(input);
+            left[i] = fir.process(delay.read(3.5f));
+            right[i] = table.process(input);
+        }
+
+        float* channels[] = {left.data(), right.data()};
+        duplicator.process(channels, 2, static_cast<int>(left.size()));
+        duplicator.process_channel(right.data(), 1, static_cast<int>(right.size()));
+        duplicator.reset();
+        delay.reset();
+        fir.reset();
+    });
+}
+
+TEST_CASE("ProcessorChain and wavetable playback are allocation-free after setup",
+          "[signal][rt-safety]") {
+    ProcessorChain<Gain, Biquad, WaveShaper> chain;
+    chain.get<0>().set_gain_linear(0.8f);
+    chain.get<1>().set_coefficients(Biquad::Type::highpass, 120.0f, 0.707f, 48000.0f);
+    chain.get<2>().set_curve(WaveShaper::Curve::tanh_clip);
+
+    Wavetable table({
+        WavetableEntry{{0.0f, 1.0f, 0.0f, -1.0f}, 12000.0f},
+        WavetableEntry{{0.0f, 0.5f, 0.0f, -0.5f}, 24000.0f},
+    });
+    table.set_sample_rate(48000.0f);
+    table.set_frequency(440.0f);
+
+    WavetableBank bank({Wavetable::make_sine(64), Wavetable::make_triangle(2, 64)});
+    bank.set_sample_rate(48000.0f);
+    bank.set_frequency(220.0f);
+    bank.set_position(0.4f);
+
+    require_allocates_no_memory([&] {
+        std::array<float, 64> buffer {};
+        for (auto& sample : buffer) {
+            sample = chain.process(table.next() + bank.next());
+        }
+        chain.process(buffer.data(), static_cast<int>(buffer.size()));
+        chain.reset();
+        table.reset();
+    });
 }


### PR DESCRIPTION
## Summary
- add explicit real-time contract comments to representative public signal helpers
- extend `pulp-test-signal-rt-safety` with allocation-probe coverage for scalar helpers, prepared storage-backed helpers, processor chains, and wavetable playback
- update signal module docs to describe setup versus post-setup processing safety

## Validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF`
- `cmake --build build --target pulp-test-signal-rt-safety --parallel`
- `./build/test/pulp-test-signal-rt-safety --reporter compact`
- `tools/scripts/gates.sh`
- structured autoreview: clean
- pre-push gates: clean with `PULP_SKIP_DIFF_COVER=1`

## Note
A direct full local diff-cover run was started first, but it expands to the broader `build-cov` test matrix and hit unrelated spectral primitive assertion failures before this branch's signal tests. I stopped that run and pushed with diff-cover skipped so PR CI remains the authoritative required gate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented real-time (RT) safety contracts across `pulp::signal` helpers and added allocation-probe tests to enforce them. Clarifies what is safe in the audio callback vs. what must run during setup.

- **New Features**
  - Added RT contract comments to key helpers (filters, oscillator, gain/mixer, delay/FIR/LUT, processor chain/duplicator, wavetable).
  - Extended `pulp-test-signal-rt-safety` with allocation probes for scalar helpers, prepared storage-backed helpers, processor chains, and wavetable playback.
  - Updated `docs/guides/signal-processing.md` and `docs/reference/modules.md` to explain setup vs. processing safety. No functional changes.

<sup>Written for commit 34bff81d8ea872d6e67d14c27a4f0d62f4076c8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

