### PR TITLE
refactor(format): add dense ProcessBlock modulation contract

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.415.0
+    VERSION 0.416.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/process_block.hpp
+++ b/core/format/include/pulp/format/process_block.hpp
@@ -226,16 +226,32 @@ struct EventDropCounters {
     std::uint32_t ump_packets = 0;
     std::uint32_t mpe_events = 0;
     std::uint32_t graph_events = 0;
+    std::uint32_t audio_rate_modulations = 0;
 
     bool any() const noexcept {
-        return parameter_events != 0 || midi_events != 0 || sysex_events != 0 ||
-               ump_packets != 0 || mpe_events != 0 || graph_events != 0;
+        return parameter_events != 0 || audio_rate_modulations != 0 ||
+               midi_events != 0 || sysex_events != 0 || ump_packets != 0 ||
+               mpe_events != 0 || graph_events != 0;
     }
 
     std::uint32_t total() const noexcept {
-        return parameter_events + midi_events + sysex_events + ump_packets +
-               mpe_events + graph_events;
+        return parameter_events + audio_rate_modulations + midi_events +
+               sysex_events + ump_packets + mpe_events + graph_events;
     }
+};
+
+/// Non-owning dense per-sample parameter-modulation lane.
+///
+/// Values are already in the destination parameter's plain value domain, one
+/// value per process frame. ProcessBlock-native runtimes can consume these
+/// without expanding audio-rate modulation into sparse ParameterEventQueue
+/// entries. The pointed-to sample storage is caller-owned.
+struct AudioRateModulationView {
+    std::uint32_t param_id = 0;
+    std::span<const float> values;
+
+    bool empty() const noexcept { return values.empty(); }
+    std::size_t size() const noexcept { return values.size(); }
 };
 
 /// Non-owning view of all sparse events visible to one process block.
@@ -255,6 +271,7 @@ struct EventBlock {
     const midi::MpeBuffer* mpe_input = nullptr;
     const midi::UmpBuffer* ump_input = nullptr;
     EventDropCounters drops;
+    std::span<const AudioRateModulationView> audio_rate_modulations;
 
     std::span<const state::ParameterEvent> parameters() const noexcept {
         return parameter_events ? parameter_events->events()
@@ -273,6 +290,10 @@ struct EventBlock {
         return midi_out ? midi_out->size() : 0;
     }
 
+    std::size_t audio_rate_modulation_count() const noexcept {
+        return audio_rate_modulations.size();
+    }
+
     std::size_t sysex_event_count() const noexcept {
         return midi_in ? midi_in->sysex_size() : 0;
     }
@@ -280,7 +301,8 @@ struct EventBlock {
     bool empty() const noexcept {
         return parameter_event_count() == 0 && midi_input_event_count() == 0 &&
                midi_output_event_count() == 0 && sysex_event_count() == 0 &&
-               mpe_input == nullptr && ump_input == nullptr && !drops.any();
+               mpe_input == nullptr && ump_input == nullptr &&
+               audio_rate_modulations.empty() && !drops.any();
     }
 };
 
@@ -307,9 +329,15 @@ struct ProcessBlock {
     bool has_scratch() const noexcept { return scratch != nullptr; }
 
     bool validate() const noexcept {
+        if (mode != ProcessMode::Realtime && mode != ProcessMode::Offline) return false;
         if (sample_rate <= 0.0 || !std::isfinite(sample_rate) || frame_count == 0) return false;
         if (render_speed <= 0.0 || !std::isfinite(render_speed)) return false;
         if (buses && !buses->validate_frame_count(frame_count)) return false;
+        if (events) {
+            for (const auto& lane : events->audio_rate_modulations) {
+                if (lane.values.size() != frame_count) return false;
+            }
+        }
         if (transport) {
             if (transport->num_samples != 0 &&
                 transport->num_samples != static_cast<int>(frame_count)) {

--- a/docs/guides/dsp-threading.md
+++ b/docs/guides/dsp-threading.md
@@ -106,10 +106,14 @@ If you want the parameter change to take effect *within* a block
 (automation splits, smooth ramps), use the parameter-event helpers
 instead of polling atomics inside the loop:
 
-* `param_events()` exposes the host-delivered `ParameterEventQueue`
-  for the current block.
+* `param_events()` exposes the host-delivered sparse
+  `ParameterEventQueue` for the current block.
 * `ParameterEventQueue` is fixed-capacity; excess events are dropped,
   counted for the current block, and never trigger audio-thread allocation.
+* `format::EventBlock::audio_rate_modulations` carries dense
+  per-sample audio-rate parameter lanes for ProcessBlock-native runtimes.
+  These lanes are separate from `ParameterEventQueue`; do not expand a
+  dense lane into one event per sample.
 * `format::ParamCursor` advances parameter values at sample offsets and
   interpolates active `ramp_duration_sample_frames` events.
 * `format::for_each_subblock()` slices the audio block at parameter
@@ -124,7 +128,9 @@ new graph, offline-render, sampler, and generated-audio paths. It does
 not replace `Processor::process()` yet. It packages the existing
 `ProcessContext` with fixed-capacity `BusBufferSet`, non-owning
 `EventBlock`, caller-owned `BlockScratch`, explicit `ProcessMode`,
-render speed, and reset/bypass/tail/transport-jump flags.
+render speed, and reset/bypass/tail/transport-jump flags. `EventBlock`
+keeps sparse `ParameterEventQueue` automation and dense
+`AudioRateModulationView` lanes as separate borrowed views.
 
 The contract is deliberately non-owning: bus audio is borrowed from the
 host or renderer, event containers are owned by adapters, and scratch
@@ -173,8 +179,9 @@ publication/lifetime policy, audio-buffer routing, feedback delay storage, and
 active main output bus, allows output-only instrument blocks, publishes
 EventBlock sidecars for the duration of the call, restores any previous
 Processor sidecar pointers, and preserves the distinction between no EventBlock
-and an EventBlock with an empty parameter queue. It does not change the
-Processor vtable.
+and an EventBlock with an empty parameter queue. Dense audio-rate modulation
+lanes are not collapsed into legacy `Processor::param_events()`. It does not
+change the Processor vtable.
 
 `pulp::audio::rt_safety_contract.hpp` is the machine-checkable sampler/looper
 RT-safety label table. It classifies representative public DSP helpers as

--- a/docs/guides/parameters.md
+++ b/docs/guides/parameters.md
@@ -133,7 +133,7 @@ multiple modulation sources in its own processing layer.
 
 ## Sample-Accurate Automation
 
-Format adapters preserve host automation points in a per-block
+Format adapters preserve sparse host automation points in a per-block
 `ParameterEventQueue` and expose it during `Processor::process()`:
 
 ```cpp
@@ -184,6 +184,14 @@ events already queued, and records the drop count for that block via
 resets the overflow counters. Format adapters drop excess events instead of
 allocating or resizing on the audio thread; legacy block-end `StateStore`
 writes still reflect the host's latest value.
+
+Dense audio-rate modulation is a separate ProcessBlock-native contract:
+`format::EventBlock::audio_rate_modulations` holds borrowed
+`AudioRateModulationView` lanes with one plain-domain value per frame. Do not
+encode those lanes as one `ParameterEventQueue` entry per sample. The legacy
+`process_processor_block()` adapter leaves dense lanes out of
+`Processor::param_events()` until a processor opts into a ProcessBlock-native
+path.
 
 ## Binding (UI Integration)
 

--- a/test/test_dsp_runtime_no_alloc.cpp
+++ b/test/test_dsp_runtime_no_alloc.cpp
@@ -147,6 +147,13 @@ TEST_CASE("ProcessBlock event and bus hot views do not allocate",
     pulp::state::ParameterEventQueue parameter_events;
     REQUIRE(parameter_events.push({2, 21, 0.25f, 0}));
     REQUIRE(parameter_events.push({1, 3, 0.75f, 8}));
+    std::array<float, 64> dense_values{};
+    for (std::size_t i = 0; i < dense_values.size(); ++i) {
+        dense_values[i] = static_cast<float>(i) / static_cast<float>(dense_values.size());
+    }
+    std::array<pulp::format::AudioRateModulationView, 1> dense_lanes{{
+        {2, std::span<const float>(dense_values.data(), dense_values.size())},
+    }};
 
     pulp::midi::MidiBuffer midi_in;
     auto note = pulp::midi::MidiEvent::note_on(0, 60, 100);
@@ -167,6 +174,8 @@ TEST_CASE("ProcessBlock event and bus hot views do not allocate",
     events.midi_out = &midi_out;
     events.mpe_input = &mpe_input;
     events.ump_input = &ump_input;
+    events.audio_rate_modulations = std::span<const pulp::format::AudioRateModulationView>(
+        dense_lanes.data(), dense_lanes.size());
 
     parameter_events.sort();
     midi_in.sort();
@@ -176,6 +185,8 @@ TEST_CASE("ProcessBlock event and bus hot views do not allocate",
 
     bool block_valid = false;
     std::size_t parameter_count = 0;
+    std::size_t audio_rate_modulation_count = 0;
+    std::size_t dense_sample_count = 0;
     std::size_t midi_count = 0;
     std::size_t sysex_count = 0;
     bool events_empty = true;
@@ -190,6 +201,10 @@ TEST_CASE("ProcessBlock event and bus hot views do not allocate",
         block.events = &events;
         block_valid = block.validate();
         parameter_count = events.parameter_event_count();
+        audio_rate_modulation_count = events.audio_rate_modulation_count();
+        for (const auto& lane : events.audio_rate_modulations) {
+            dense_sample_count += lane.size();
+        }
         midi_count = events.midi_input_event_count();
         sysex_count = events.sysex_event_count();
         events_empty = events.empty();
@@ -199,6 +214,8 @@ TEST_CASE("ProcessBlock event and bus hot views do not allocate",
     require_no_alloc(allocations);
     REQUIRE(block_valid);
     REQUIRE(parameter_count == 2);
+    REQUIRE(audio_rate_modulation_count == 1);
+    REQUIRE(dense_sample_count == 64);
     REQUIRE(midi_count == 2);
     REQUIRE(sysex_count == 1);
     REQUIRE_FALSE(events_empty);

--- a/test/test_process_block.cpp
+++ b/test/test_process_block.cpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <span>
 #include <type_traits>
 
 using namespace pulp;
@@ -17,7 +18,12 @@ static_assert(!std::is_copy_constructible_v<format::BlockScratch>);
 static_assert(!std::is_copy_assignable_v<format::BlockScratch>);
 static_assert(!std::is_copy_constructible_v<format::PrepareScratch>);
 static_assert(format::BusBufferSet::kMaxBuses == 16);
+static_assert(std::is_trivially_copyable_v<format::AudioRateModulationView>);
 static_assert(std::is_trivially_copyable_v<format::ProcessBlock>);
+static_assert(offsetof(format::EventDropCounters, graph_events) <
+              offsetof(format::EventDropCounters, audio_rate_modulations));
+static_assert(offsetof(format::EventBlock, drops) <
+              offsetof(format::EventBlock, audio_rate_modulations));
 
 namespace {
 
@@ -82,24 +88,45 @@ TEST_CASE("EventBlock is a non-owning view with explicit drop counters", "[forma
     midi_in.add_sysex({0xF0, 0x7D, 0x01, 0xF7}, 16, 0.0);
 
     midi::MidiBuffer midi_out;
+    std::array<float, 4> audio_rate_values{-1.0f, -0.5f, 0.0f, 1.0f};
+    std::array<format::AudioRateModulationView, 1> audio_rate_modulations{{
+        {42, std::span<const float>(audio_rate_values.data(), audio_rate_values.size())},
+    }};
     format::EventBlock events;
     events.parameter_events = &params;
     events.midi_in = &midi_in;
     events.midi_out = &midi_out;
+    events.audio_rate_modulations = std::span<const format::AudioRateModulationView>(
+        audio_rate_modulations.data(), audio_rate_modulations.size());
+    events.drops.audio_rate_modulations = 1;
     events.drops.midi_events = 2;
     events.drops.graph_events = 1;
 
     REQUIRE(events.parameter_event_count() == 2);
     REQUIRE(events.parameters().front().sample_offset == 0);
+    REQUIRE(events.audio_rate_modulation_count() == 1);
+    REQUIRE(events.audio_rate_modulations.front().param_id == 42);
+    REQUIRE(events.audio_rate_modulations.front().size() == 4);
+    REQUIRE(events.audio_rate_modulations.front().values[3] == 1.0f);
     REQUIRE(events.midi_input_event_count() == 1);
     REQUIRE(events.midi_output_event_count() == 0);
     REQUIRE(events.sysex_event_count() == 1);
     REQUIRE(events.drops.any());
-    REQUIRE(events.drops.total() == 3);
+    REQUIRE(events.drops.total() == 4);
     REQUIRE_FALSE(events.empty());
 
     format::EventBlock empty;
     REQUIRE(empty.empty());
+
+    format::EventDropCounters legacy_counters{1, 2, 3, 4, 5, 6};
+    REQUIRE(legacy_counters.parameter_events == 1);
+    REQUIRE(legacy_counters.midi_events == 2);
+    REQUIRE(legacy_counters.sysex_events == 3);
+    REQUIRE(legacy_counters.ump_packets == 4);
+    REQUIRE(legacy_counters.mpe_events == 5);
+    REQUIRE(legacy_counters.graph_events == 6);
+    REQUIRE(legacy_counters.audio_rate_modulations == 0);
+
 }
 
 TEST_CASE("BlockScratch and PrepareScratch allocate from caller-owned memory only", "[format][process-block]") {
@@ -168,6 +195,21 @@ TEST_CASE("ProcessBlock validates mode, timing, buses, and transport frame count
     REQUIRE(block.validate());
     REQUIRE(block.is_offline());
     REQUIRE(block.flags.tail_drain);
+
+    block.mode = static_cast<format::ProcessMode>(0xFF);
+    REQUIRE_FALSE(block.validate());
+    block.mode = format::ProcessMode::Realtime;
+
+    std::array<float, 2> short_dense_values{};
+    std::array<format::AudioRateModulationView, 1> short_dense_lanes{{
+        {1, std::span<const float>(short_dense_values.data(), short_dense_values.size())},
+    }};
+    format::EventBlock dense_events;
+    dense_events.audio_rate_modulations = short_dense_lanes;
+    block.events = &dense_events;
+    REQUIRE_FALSE(block.validate());
+    dense_events.audio_rate_modulations = {};
+    block.events = nullptr;
 
     block.render_speed = 0.0;
     REQUIRE_FALSE(block.validate());

--- a/test/test_processor_block_adapter.cpp
+++ b/test/test_processor_block_adapter.cpp
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <cstddef>
+#include <span>
 #include <stdexcept>
 
 namespace {
@@ -213,6 +214,32 @@ TEST_CASE("process_processor_block preserves EventBlock parameter fallback seman
     REQUIRE(buses.add_output("main", output.view()));
 
     pulp::format::EventBlock events;
+    auto block = block_with_buses(buses);
+    block.events = &events;
+
+    RecordingProcessor processor;
+    pulp::format::ProcessorBlockAdapterScratch scratch;
+    REQUIRE(pulp::format::process_processor_block(processor, block, scratch));
+    REQUIRE(processor.observed_params == &scratch.empty_parameter_events);
+    REQUIRE(processor.observed_params->empty());
+}
+
+TEST_CASE("process_processor_block keeps dense modulation out of legacy param events",
+          "[format][process-block][processor-adapter]") {
+    pulp::audio::Buffer<float> output(2, 64);
+    pulp::format::BusBufferSet buses;
+    REQUIRE(buses.add_output("main", output.view()));
+
+    std::array<float, 64> dense_values{};
+    dense_values[0] = 0.25f;
+    dense_values[63] = 0.75f;
+    std::array<pulp::format::AudioRateModulationView, 1> dense_lanes{{
+        {99, std::span<const float>(dense_values.data(), dense_values.size())},
+    }};
+
+    pulp::format::EventBlock events;
+    events.audio_rate_modulations = std::span<const pulp::format::AudioRateModulationView>(
+        dense_lanes.data(), dense_lanes.size());
     auto block = block_with_buses(buses);
     block.events = &events;
 


### PR DESCRIPTION
Summary:
- Add a borrowed AudioRateModulationView lane to the ProcessBlock/EventBlock contract.
- Keep dense audio-rate modulation separate from sparse ParameterEventQueue and legacy Processor::param_events().
- Validate dense lane frame counts, preserve public aggregate field order, update docs/tests, and bump SDK version to 0.416.0.

Validation:
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF
- cmake --build build --target pulp-test-process-block pulp-test-processor-block-adapter pulp-test-dsp-runtime-no-alloc --parallel
- ./build/test/pulp-test-process-block --reporter compact
- ./build/test/pulp-test-processor-block-adapter --reporter compact
- ./build/test/pulp-test-dsp-runtime-no-alloc --reporter compact
- git diff --check origin/main...HEAD
- tools/scripts/gates.sh
- autoreview --mode branch --base origin/main: clean, no accepted/actionable findings

Notes:
- Local diff-cover was skipped on push with PULP_SKIP_DIFF_COVER=1 after focused tests and gates passed; CI will run the full required checks.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a dense audio-rate modulation lane to `ProcessBlock`/`EventBlock`, separate from sparse `ParameterEventQueue`, so DSP runtimes can consume per-sample parameter values without expanding events. Validates lane sizes per block, updates docs/tests, and bumps the SDK to 0.416.0.

- **New Features**
  - Introduced `AudioRateModulationView` and `EventBlock::audio_rate_modulations` with `EventDropCounters::audio_rate_modulations`.
  - Kept dense lanes separate from `ParameterEventQueue` and legacy `Processor::param_events()`; `process_processor_block` does not expose dense lanes to legacy processors.
  - Extended `ProcessBlock::validate()` to enforce lane size equals `frame_count` and restrict `ProcessMode` to realtime/offline.
  - Updated guides to clarify sparse vs. dense modulation; added tests for validation and no-alloc; SDK version set to 0.416.0.

<sup>Written for commit 07bd8b04944e0e8e649039d2d5f5c3700c70e5b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

