### PR TITLE
Fix AU v2 editor state sync and key fallthrough

### DIFF
--- a/.agents/skills/auv2/SKILL.md
+++ b/.agents/skills/auv2/SKILL.md
@@ -82,6 +82,18 @@ The instrument adapter (`core/format/src/au_v2_instrument.cpp`) uses the same `p
 
 ## Recent changes
 
+### Custom editor parameter writes vs host-global pulls
+
+AU v2 custom editors write `StateStore` first, then mirror the value into the
+host's AU parameter storage through a main-thread listener. If the render path
+blindly pulls every `GetParameter()` / `Globals()->GetParameter()` value into
+the store at the top of each block, a just-clicked UI value can be overwritten
+by the host's stale value until another UI event drains that listener. The AU
+effect and instrument adapters therefore keep a `host_param_snapshot_`: pull a
+host value into `StateStore` only when the host value changed since the last
+render block, and after `process()` publish any store value that differs from
+either the pre-process store snapshot or the last host snapshot.
+
 ### Param-events sidecar + RT-safety guard (native-components Phase 3)
 
 `ProcessBufferLists()` now `set_param_events(&param_events_)` before

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.208.5",
+      "version": "0.208.6",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.208.5"
+  "version": "0.208.6"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.208.5",
+  "version": "0.208.6",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.422.0
+    VERSION 0.423.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/include/pulp/canvas/canvas.hpp
+++ b/core/canvas/include/pulp/canvas/canvas.hpp
@@ -1,5 +1,5 @@
 #pragma once
-
+#include <pulp/canvas/text_utf8.hpp>
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
@@ -10,7 +10,6 @@
 #include <functional>
 
 namespace pulp::canvas {
-
 // ── Color ────────────────────────────────────────────────────────────────────
 
 struct Color {
@@ -744,7 +743,7 @@ public:
     /// Skia backend overrides this to query the shaped paragraph directly.
     virtual float text_x_for_byte(const std::string& text,
                                   std::size_t byte_index) {
-        return measure_text(text.substr(0, std::min(byte_index, text.size())));
+        return measure_text(text.substr(0, safe_utf8_prefix_size(text, byte_index)));
     }
 
     /// pulp #2163 / font v2 Slice 1.2.b — explicit, typed vertical-anchor

--- a/core/canvas/include/pulp/canvas/cg_canvas.hpp
+++ b/core/canvas/include/pulp/canvas/cg_canvas.hpp
@@ -180,6 +180,8 @@ public:
                      float max_width = 0.0f) override;
     float measure_text(const std::string& text) override;
     TextMetrics measure_text_full(const std::string& text) override;
+    float text_x_for_byte(const std::string& text,
+                          std::size_t byte_index) override;
 
     // Canvas2D drop-shadow state (issue-1434 batch 7). CGContext exposes
     // sticky shadow state directly via CGContextSetShadowWithColor — we

--- a/core/canvas/include/pulp/canvas/text_utf8.hpp
+++ b/core/canvas/include/pulp/canvas/text_utf8.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+
+namespace pulp::canvas {
+
+/// Return the largest prefix length <= byte_index that ends on a valid UTF-8
+/// scalar boundary. This is intentionally conservative: malformed/truncated
+/// input stops at the last known-good boundary so platform text APIs never see
+/// an invalid substring while computing caret offsets.
+inline std::size_t safe_utf8_prefix_size(const std::string& text,
+                                         std::size_t byte_index) noexcept {
+    const std::size_t limit = std::min(byte_index, text.size());
+    std::size_t i = 0;
+    std::size_t last_good = 0;
+
+    auto cont = [](unsigned char b) noexcept { return (b & 0xC0) == 0x80; };
+    while (i < limit) {
+        const auto b0 = static_cast<unsigned char>(text[i]);
+        std::size_t len = 0;
+        if (b0 < 0x80) {
+            len = 1;
+        } else if (b0 >= 0xC2 && b0 <= 0xDF) {
+            len = 2;
+        } else if (b0 >= 0xE0 && b0 <= 0xEF) {
+            len = 3;
+        } else if (b0 >= 0xF0 && b0 <= 0xF4) {
+            len = 4;
+        } else {
+            break;
+        }
+
+        if (i + len > limit) break;
+        if (len >= 2 && !cont(static_cast<unsigned char>(text[i + 1]))) break;
+        if (len >= 3 && !cont(static_cast<unsigned char>(text[i + 2]))) break;
+        if (len >= 4 && !cont(static_cast<unsigned char>(text[i + 3]))) break;
+        if (len == 3) {
+            const auto b1 = static_cast<unsigned char>(text[i + 1]);
+            if ((b0 == 0xE0 && b1 < 0xA0) || (b0 == 0xED && b1 >= 0xA0)) break;
+        } else if (len == 4) {
+            const auto b1 = static_cast<unsigned char>(text[i + 1]);
+            if ((b0 == 0xF0 && b1 < 0x90) || (b0 == 0xF4 && b1 >= 0x90)) break;
+        }
+
+        i += len;
+        last_good = i;
+    }
+    return last_good;
+}
+
+} // namespace pulp::canvas

--- a/core/canvas/platform/mac/cg_canvas.mm
+++ b/core/canvas/platform/mac/cg_canvas.mm
@@ -552,8 +552,19 @@ void CoreGraphicsCanvas::set_text_align(TextAlign align) {
 }
 
 static CTFontRef create_font_with_fallback(const std::string& family, float size) {
-    NSString* ns_font = [NSString stringWithUTF8String:family.c_str()];
+    bool owns_ns_font = false;
+    NSString* ns_font = [[NSString alloc] initWithBytes:family.data()
+                                                 length:family.size()
+                                               encoding:NSUTF8StringEncoding];
+    if (ns_font) {
+        owns_ns_font = true;
+    } else {
+        ns_font = @"Helvetica";
+    }
     CTFontRef font = CTFontCreateWithName((__bridge CFStringRef)ns_font, size, NULL);
+#if !__has_feature(objc_arc)
+    if (owns_ns_font) [ns_font release];
+#endif
     if (!font) {
         // Requested family not available — fall back to system font
         font = CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, size, NULL);
@@ -561,12 +572,43 @@ static CTFontRef create_font_with_fallback(const std::string& family, float size
     return font;
 }
 
+static NSString* create_lossy_ns_string(const std::string& text) {
+    NSString* ns_text = [[NSString alloc] initWithBytes:text.data()
+                                                 length:text.size()
+                                               encoding:NSUTF8StringEncoding];
+    if (ns_text) return ns_text;
+
+    std::string sanitized;
+    sanitized.reserve(text.size());
+    for (unsigned char c : text) {
+        if (c >= 0x20 && c < 0x7f) {
+            sanitized.push_back(static_cast<char>(c));
+        } else {
+            sanitized += "\xEF\xBF\xBD";
+        }
+    }
+    ns_text = [[NSString alloc] initWithBytes:sanitized.data()
+                                       length:sanitized.size()
+                                     encoding:NSUTF8StringEncoding];
+    if (ns_text) return ns_text;
+#if !__has_feature(objc_arc)
+    return [@"" retain];
+#else
+    return @"";
+#endif
+}
+
 void CoreGraphicsCanvas::fill_text(const std::string& text, float x, float y) {
     @autoreleasepool {
-        NSString* ns_text = [NSString stringWithUTF8String:text.c_str()];
+        NSString* ns_text = create_lossy_ns_string(text);
 
         CTFontRef font = create_font_with_fallback(font_family_, font_size_);
-        if (!font) return;
+        if (!font) {
+#if !__has_feature(objc_arc)
+            [ns_text release];
+#endif
+            return;
+        }
 
         NSDictionary* attrs = @{
             (__bridge id)kCTFontAttributeName: (__bridge id)font,
@@ -618,6 +660,9 @@ void CoreGraphicsCanvas::fill_text(const std::string& text, float x, float y) {
 
         CFRelease(line);
         CFRelease(font);
+#if !__has_feature(objc_arc)
+        [ns_text release];
+#endif
     }
 }
 
@@ -657,10 +702,15 @@ void CoreGraphicsCanvas::stroke_text(const std::string& text, float x, float y,
     // strokeStyle as the fill colour.
     @autoreleasepool {
         if (text.empty()) return;
-        NSString* ns_text = [NSString stringWithUTF8String:text.c_str()];
+        NSString* ns_text = create_lossy_ns_string(text);
 
         CTFontRef font = create_font_with_fallback(font_family_, font_size_);
-        if (!font) return;
+        if (!font) {
+#if !__has_feature(objc_arc)
+            [ns_text release];
+#endif
+            return;
+        }
 
         NSDictionary* attrs = @{
             (__bridge id)kCTFontAttributeName: (__bridge id)font,
@@ -777,15 +827,23 @@ void CoreGraphicsCanvas::stroke_text(const std::string& text, float x, float y,
 
         CFRelease(line);
         CFRelease(font);
+#if !__has_feature(objc_arc)
+        [ns_text release];
+#endif
     }
 }
 
 float CoreGraphicsCanvas::measure_text(const std::string& text) {
     @autoreleasepool {
-        NSString* ns_text = [NSString stringWithUTF8String:text.c_str()];
+        NSString* ns_text = create_lossy_ns_string(text);
 
         CTFontRef font = create_font_with_fallback(font_family_, font_size_);
-        if (!font) return 0;
+        if (!font) {
+#if !__has_feature(objc_arc)
+            [ns_text release];
+#endif
+            return 0;
+        }
 
         NSDictionary* attrs = @{
             (__bridge id)kCTFontAttributeName: (__bridge id)font
@@ -799,16 +857,24 @@ float CoreGraphicsCanvas::measure_text(const std::string& text) {
         CGFloat width = CTLineGetTypographicBounds(line, NULL, NULL, NULL);
         CFRelease(line);
         CFRelease(font);
+#if !__has_feature(objc_arc)
+        [ns_text release];
+#endif
         return static_cast<float>(width);
     }
 }
 
 Canvas::TextMetrics CoreGraphicsCanvas::measure_text_full(const std::string& text) {
     @autoreleasepool {
-        NSString* ns_text = [NSString stringWithUTF8String:text.c_str()];
+        NSString* ns_text = create_lossy_ns_string(text);
 
         CTFontRef font = create_font_with_fallback(font_family_, font_size_);
-        if (!font) return {};
+        if (!font) {
+#if !__has_feature(objc_arc)
+            [ns_text release];
+#endif
+            return {};
+        }
 
         NSDictionary* attrs = @{
             (__bridge id)kCTFontAttributeName: (__bridge id)font
@@ -830,8 +896,17 @@ Canvas::TextMetrics CoreGraphicsCanvas::measure_text_full(const std::string& tex
 
         CFRelease(line);
         CFRelease(font);
+#if !__has_feature(objc_arc)
+        [ns_text release];
+#endif
         return m;
     }
+}
+
+float CoreGraphicsCanvas::text_x_for_byte(const std::string& text,
+                                          std::size_t byte_index) {
+    const auto prefix_len = safe_utf8_prefix_size(text, byte_index);
+    return measure_text(text.substr(0, prefix_len));
 }
 
 // ── Canvas2D path builder (pulp #1322) ───────────────────────────────────────

--- a/core/format/include/pulp/format/au_v2_adapter.hpp
+++ b/core/format/include/pulp/format/au_v2_adapter.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#if __has_include(<AudioUnitSDK/AUMIDIEffectBase.h>)
+#define PULP_FORMAT_HAS_AUV2_EFFECT 1
+
 #include <AudioUnitSDK/AUMIDIEffectBase.h>
 
 #include <pulp/format/processor.hpp>
@@ -7,6 +10,7 @@
 #include <pulp/format/detail/playhead_diff.hpp>
 #include <pulp/midi/buffer.hpp>
 #include <pulp/midi/message.hpp>
+#include <pulp/state/listener_token.hpp>
 #include <pulp/state/parameter_event_queue.hpp>
 
 #include <memory>
@@ -137,8 +141,11 @@ protected:
     OSStatus HandleSysEx(const UInt8* inData, UInt32 inLength) override;
 
 private:
+    void publish_parameter_change_to_host(state::ParamID id, float value);
+
     std::unique_ptr<Processor> processor_;
     state::StateStore store_;
+    state::ListenerToken param_listener_token_;
 
     // Sample-accurate parameter-event sidecar, set on the Processor each block
     // so the param-events contract is uniform across formats (VST3/CLAP/AUv3
@@ -163,6 +170,11 @@ private:
     // Pre-process snapshot of parameter values; used to diff plugin-side
     // changes back to the host's parameter system (workstream 01 slice 1.3).
     std::vector<float> param_snapshot_;
+    // Last host-global values observed at the render boundary. This prevents a
+    // stale AU global from overwriting a just-clicked custom-editor StateStore
+    // value before the main-thread host mirror callback has drained.
+    std::vector<float> host_param_snapshot_;
+    bool host_param_snapshot_valid_ = false;
 
     // Item 1.3 — previous-block transport snapshot used to derive the
     // change flags (tempo_changed / time_sig_changed /
@@ -184,3 +196,7 @@ private:
 };
 
 } // namespace pulp::format::au
+
+#else
+#define PULP_FORMAT_HAS_AUV2_EFFECT 0
+#endif

--- a/core/format/include/pulp/format/au_v2_entry.hpp
+++ b/core/format/include/pulp/format/au_v2_entry.hpp
@@ -18,6 +18,8 @@
 //   - Plugin registration via PULP_REGISTER_PLUGIN
 
 #include <pulp/format/au_v2_adapter.hpp>
+
+#if PULP_FORMAT_HAS_AUV2_EFFECT
 #include <pulp/format/registry.hpp>
 #include <AudioUnitSDK/AUPlugInDispatch.h>
 #include <AudioUnitSDK/ComponentBase.h>
@@ -32,3 +34,7 @@
         explicit ClassName(AudioComponentInstance ci) : PulpAUEffect(ci) {} \
     }; \
     AUSDK_COMPONENT_ENTRY(ausdk::AUBaseFactory, ClassName)
+#else
+#define PULP_AU_PLUGIN(ClassName, factory_fn) \
+    static_assert(false, "PULP_AU_PLUGIN requires AudioUnitSDK headers")
+#endif

--- a/core/format/include/pulp/format/au_v2_instrument.hpp
+++ b/core/format/include/pulp/format/au_v2_instrument.hpp
@@ -1,10 +1,15 @@
 #pragma once
 
+#if __has_include(<AudioUnitSDK/MusicDeviceBase.h>)
+#define PULP_FORMAT_HAS_AUV2_INSTRUMENT 1
+
 #include <AudioUnitSDK/MusicDeviceBase.h>
 
 #include <pulp/format/processor.hpp>
 #include <pulp/format/host_quirks.hpp>
 #include <pulp/format/detail/playhead_diff.hpp>
+#include <pulp/state/listener_token.hpp>
+#include <pulp/state/parameter_event_queue.hpp>
 
 #include <memory>
 #include <mutex>
@@ -57,12 +62,24 @@ public:
     Float64 GetLatency() override;
 
 private:
+    void publish_parameter_change_to_host(state::ParamID id, float value);
+
     std::unique_ptr<Processor> processor_;
     state::StateStore store_;
+    state::ListenerToken param_listener_token_;
+
+    // Sample-accurate parameter-event sidecar. AU v2 does not expose a
+    // scheduled/ramped parameter source through MusicDeviceBase today, so this
+    // queue is empty, but setting it each render keeps the Processor contract
+    // uniform with the effect adapter.
+    state::ParameterEventQueue param_events_;
 
     // Host accommodations, resolved once at init (host-quirks plan, P3).
     HostQuirks host_quirks_{};
     std::vector<float*> output_ptrs_;
+    std::vector<float> param_snapshot_;
+    std::vector<float> host_param_snapshot_;
+    bool host_param_snapshot_valid_ = false;
     std::mutex midi_mutex_;
     midi::MidiBuffer pending_midi_;
 
@@ -73,3 +90,7 @@ private:
 };
 
 } // namespace pulp::format::au
+
+#else
+#define PULP_FORMAT_HAS_AUV2_INSTRUMENT 0
+#endif

--- a/core/format/include/pulp/format/au_v2_instrument_entry.hpp
+++ b/core/format/include/pulp/format/au_v2_instrument_entry.hpp
@@ -9,6 +9,8 @@
 //   PULP_AU_INSTRUMENT(MySynthAU, my_namespace::create_my_synth)
 
 #include <pulp/format/au_v2_instrument.hpp>
+
+#if PULP_FORMAT_HAS_AUV2_INSTRUMENT
 #include <pulp/format/registry.hpp>
 #include <AudioUnitSDK/AUPlugInDispatch.h>
 #include <AudioUnitSDK/ComponentBase.h>
@@ -23,3 +25,7 @@
         explicit ClassName(AudioComponentInstance ci) : PulpAUInstrument(ci) {} \
     }; \
     AUSDK_COMPONENT_ENTRY(ausdk::AUMusicDeviceFactory, ClassName)
+#else
+#define PULP_AU_INSTRUMENT(ClassName, factory_fn) \
+    static_assert(false, "PULP_AU_INSTRUMENT requires AudioUnitSDK headers")
+#endif

--- a/core/format/include/pulp/format/detail/standalone_editor_chrome.hpp
+++ b/core/format/include/pulp/format/detail/standalone_editor_chrome.hpp
@@ -21,17 +21,17 @@ inline bool standalone_env_truthy(std::string_view name) {
     return environment_flag_truthy(name);
 }
 
-inline bool parse_positive_frame_delay(std::string_view value, int& frames) {
+inline bool parse_positive_int(std::string_view value, int& parsed) {
     if (value.empty() || value.front() == '+') return false;
 
-    int parsed = 0;
+    int value_int = 0;
     const char* first = value.data();
     const char* last = first + value.size();
-    auto result = std::from_chars(first, last, parsed);
-    if (result.ec != std::errc{} || result.ptr != last || parsed <= 0)
+    auto result = std::from_chars(first, last, value_int);
+    if (result.ec != std::errc{} || result.ptr != last || value_int <= 0)
         return false;
 
-    frames = parsed;
+    parsed = value_int;
     return true;
 }
 
@@ -49,8 +49,19 @@ inline StandaloneConfig standalone_config_from_environment(StandaloneConfig conf
 
     if (auto frames = runtime::get_env("PULP_FRAMES")) {
         int parsed = 0;
-        if (parse_positive_frame_delay(*frames, parsed))
+        if (parse_positive_int(*frames, parsed))
             config.screenshot_frame_delay = parsed;
+    }
+
+    if (standalone_env_truthy("PULP_STANDALONE_PACKAGE_AUDIT")) {
+        config.package_audit = true;
+        config.headless = true;
+    }
+
+    if (auto seconds = runtime::get_env("PULP_STANDALONE_PACKAGE_AUDIT_SECONDS")) {
+        int parsed = 0;
+        if (parse_positive_int(*seconds, parsed))
+            config.package_audit_timeout_seconds = parsed;
     }
 
     if (!config.screenshot_path.empty())
@@ -60,7 +71,7 @@ inline StandaloneConfig standalone_config_from_environment(StandaloneConfig conf
 }
 
 inline bool standalone_headless_requires_screenshot(const StandaloneConfig& config) {
-    return config.headless && config.screenshot_path.empty();
+    return config.headless && !config.package_audit && config.screenshot_path.empty();
 }
 
 struct StandaloneSettingsActions {

--- a/core/format/include/pulp/format/standalone.hpp
+++ b/core/format/include/pulp/format/standalone.hpp
@@ -49,6 +49,11 @@ struct StandaloneConfig {
     // When true, run_with_editor() avoids showing/activating the native
     // window. Use with screenshot_path for CI/test smoke runs.
     bool headless = false;
+    // Starts the standalone audio/MIDI runtime without constructing an editor
+    // window. Intended for packaged-app audits that need to prove the bundle
+    // launches from its shipped location without flashing UI.
+    bool package_audit = false;
+    int package_audit_timeout_seconds = 30;
     // When false, run_with_editor() hosts the editor directly and omits the
     // built-in Settings tab.
     bool show_settings_tab = true;

--- a/core/format/src/au_v2_adapter.cpp
+++ b/core/format/src/au_v2_adapter.cpp
@@ -116,6 +116,16 @@ PulpAUEffect::PulpAUEffect(AudioComponentInstance ci)
                     AUEventListenerNotify(nullptr, nullptr, &event);
                 });
 
+            // Custom AU editors mutate Pulp's StateStore directly. Mirror those
+            // UI-side writes into the AU parameter system immediately so the
+            // next render block does not pull an older host value back over the
+            // edited StateStore value.
+            param_listener_token_ = store_.add_listener(
+                [this](state::ParamID id, float value) {
+                    publish_parameter_change_to_host(id, value);
+                },
+                state::ListenerThread::Main);
+
             // Set defaults in AU parameter system at construction time so hosts
             // can inspect them before Initialize() is called.
             for (const auto& param : store_.all_params()) {
@@ -254,6 +264,24 @@ OSStatus PulpAUEffect::GetProperty(AudioUnitPropertyID inID, AudioUnitScope inSc
     return AUMIDIEffectBase::GetProperty(inID, inScope, inElement, outData);
 }
 
+void PulpAUEffect::publish_parameter_change_to_host(state::ParamID id, float value)
+{
+    auto au_id = static_cast<AudioUnitParameterID>(id);
+    SetParameter(au_id, value);
+
+    auto instance = GetComponentInstance();
+    if (instance == nullptr) return;
+
+    AudioUnitEvent event;
+    std::memset(&event, 0, sizeof(event));
+    event.mEventType = kAudioUnitEvent_ParameterValueChange;
+    event.mArgument.mParameter.mAudioUnit = instance;
+    event.mArgument.mParameter.mParameterID = au_id;
+    event.mArgument.mParameter.mScope = kAudioUnitScope_Global;
+    event.mArgument.mParameter.mElement = 0;
+    AUEventListenerNotify(nullptr, nullptr, &event);
+}
+
 OSStatus PulpAUEffect::Initialize()
 {
     auto result = AUEffectBase::Initialize();
@@ -324,17 +352,30 @@ OSStatus PulpAUEffect::ProcessBufferLists(AudioUnitRenderActionFlags& ioActionFl
         return noErr;
     }
 
-    // Host → plugin: pull current parameter values into the store before
-    // processing. Also snapshot them so we can detect plugin-driven changes
-    // after process() returns.
+    // Host → plugin: pull current parameter values into the store only when the
+    // host value changed since the last block. Custom editors write StateStore
+    // first and mirror to the AU globals via a main-thread listener; blindly
+    // pulling every block can otherwise stomp a just-clicked UI value with the
+    // host's stale value until another UI event drains that listener.
     auto params = store_.all_params();
     param_snapshot_.resize(params.size());
+    const bool reset_host_snapshot =
+        !host_param_snapshot_valid_ || host_param_snapshot_.size() != params.size();
+    host_param_snapshot_.resize(params.size());
     for (std::size_t i = 0; i < params.size(); ++i) {
         auto au_id = static_cast<AudioUnitParameterID>(params[i].id);
-        float value = GetParameter(au_id);
-        store_.set_value(params[i].id, value);
+        const float host_value = GetParameter(au_id);
+        const float previous_host =
+            reset_host_snapshot ? host_value : host_param_snapshot_[i];
+        float value = store_.get_value(params[i].id);
+        if (reset_host_snapshot || host_value != previous_host) {
+            store_.set_value_rt(params[i].id, host_value);
+            value = host_value;
+        }
         param_snapshot_[i] = value;
+        host_param_snapshot_[i] = host_value;
     }
+    host_param_snapshot_valid_ = true;
 
     UInt32 in_channels = inBuffer.mNumberBuffers;
     UInt32 out_channels = outBuffer.mNumberBuffers;
@@ -495,17 +536,9 @@ OSStatus PulpAUEffect::ProcessBufferLists(AudioUnitRenderActionFlags& ioActionFl
     // 01 slice 1.3.
     for (std::size_t i = 0; i < params.size(); ++i) {
         float post = store_.get_value(params[i].id);
-        if (post == param_snapshot_[i]) continue;
-        auto au_id = static_cast<AudioUnitParameterID>(params[i].id);
-        SetParameter(au_id, post);
-        AudioUnitEvent event;
-        std::memset(&event, 0, sizeof(event));
-        event.mEventType = kAudioUnitEvent_ParameterValueChange;
-        event.mArgument.mParameter.mAudioUnit = GetComponentInstance();
-        event.mArgument.mParameter.mParameterID = au_id;
-        event.mArgument.mParameter.mScope = kAudioUnitScope_Global;
-        event.mArgument.mParameter.mElement = 0;
-        AUEventListenerNotify(nullptr, nullptr, &event);
+        if (post == param_snapshot_[i] && post == host_param_snapshot_[i]) continue;
+        publish_parameter_change_to_host(params[i].id, post);
+        host_param_snapshot_[i] = post;
     }
 
     // Item 3.11 — push latency / tail change notifications the processor

--- a/core/format/src/au_v2_instrument.cpp
+++ b/core/format/src/au_v2_instrument.cpp
@@ -5,6 +5,7 @@
 #include <AudioUnitSDK/AUPlugInDispatch.h>
 #include <AudioUnitSDK/AUOutputElement.h>
 #include <AudioToolbox/AudioToolbox.h>  // kAudioUnitProperty_CocoaUI, AudioUnitCocoaViewInfo
+#include <AudioToolbox/AudioUnitUtilities.h>
 #include <mach/mach_time.h>
 
 #include <pulp/format/au_v2_instrument.hpp>
@@ -13,6 +14,7 @@
 #include <pulp/format/plugin_state_io.hpp>
 #include <pulp/format/registry.hpp>
 #include <pulp/runtime/log.hpp>
+#include <pulp/runtime/scoped_no_alloc.hpp>
 
 #include <cstring>
 
@@ -33,6 +35,41 @@ PulpAUInstrument::PulpAUInstrument(AudioComponentInstance ci)
             // effect adapter (Codex review on #3226 — instrument was missed).
             const auto host_info = detect_host_info();
             host_quirks_ = resolved_quirks(host_info.type, host_info.version);
+
+            // Wire gesture callbacks for undo grouping support.
+            store_.set_gesture_callbacks(
+                [this](state::ParamID id) {
+                    AudioUnitEvent event;
+                    std::memset(&event, 0, sizeof(event));
+                    event.mEventType = kAudioUnitEvent_BeginParameterChangeGesture;
+                    event.mArgument.mParameter.mAudioUnit = GetComponentInstance();
+                    event.mArgument.mParameter.mParameterID =
+                        static_cast<AudioUnitParameterID>(id);
+                    event.mArgument.mParameter.mScope = kAudioUnitScope_Global;
+                    event.mArgument.mParameter.mElement = 0;
+                    AUEventListenerNotify(nullptr, nullptr, &event);
+                },
+                [this](state::ParamID id) {
+                    AudioUnitEvent event;
+                    std::memset(&event, 0, sizeof(event));
+                    event.mEventType = kAudioUnitEvent_EndParameterChangeGesture;
+                    event.mArgument.mParameter.mAudioUnit = GetComponentInstance();
+                    event.mArgument.mParameter.mParameterID =
+                        static_cast<AudioUnitParameterID>(id);
+                    event.mArgument.mParameter.mScope = kAudioUnitScope_Global;
+                    event.mArgument.mParameter.mElement = 0;
+                    AUEventListenerNotify(nullptr, nullptr, &event);
+                });
+
+            // Custom AU editors mutate Pulp's StateStore directly. Mirror those
+            // UI-side writes into the AU parameter system immediately so the
+            // next render block does not pull an older host value back over the
+            // edited StateStore value.
+            param_listener_token_ = store_.add_listener(
+                [this](state::ParamID id, float value) {
+                    publish_parameter_change_to_host(id, value);
+                },
+                state::ListenerThread::Main);
 
             for (const auto& param : store_.all_params()) {
                 Globals()->SetParameter(
@@ -134,6 +171,24 @@ OSStatus PulpAUInstrument::GetProperty(AudioUnitPropertyID inID, AudioUnitScope 
     return MusicDeviceBase::GetProperty(inID, inScope, inElement, outData);
 }
 
+void PulpAUInstrument::publish_parameter_change_to_host(state::ParamID id, float value)
+{
+    auto au_id = static_cast<AudioUnitParameterID>(id);
+    Globals()->SetParameter(au_id, value);
+
+    auto instance = GetComponentInstance();
+    if (instance == nullptr) return;
+
+    AudioUnitEvent event;
+    std::memset(&event, 0, sizeof(event));
+    event.mEventType = kAudioUnitEvent_ParameterValueChange;
+    event.mArgument.mParameter.mAudioUnit = instance;
+    event.mArgument.mParameter.mParameterID = au_id;
+    event.mArgument.mParameter.mScope = kAudioUnitScope_Global;
+    event.mArgument.mParameter.mElement = 0;
+    AUEventListenerNotify(nullptr, nullptr, &event);
+}
+
 OSStatus PulpAUInstrument::Initialize()
 {
     auto result = MusicDeviceBase::Initialize();
@@ -206,17 +261,31 @@ OSStatus PulpAUInstrument::Render(AudioUnitRenderActionFlags& ioActionFlags,
 
     if (!processor_) return noErr;
 
-    for (const auto& param : store_.all_params()) {
+    auto params = store_.all_params();
+    param_snapshot_.resize(params.size());
+    const bool reset_host_snapshot =
+        !host_param_snapshot_valid_ || host_param_snapshot_.size() != params.size();
+    host_param_snapshot_.resize(params.size());
+    for (std::size_t i = 0; i < params.size(); ++i) {
         // AudioUnitSDK 1.4 renamed the RT-safe parameter read to
         // GetParameterRT; 1.3.0 uses GetParameter and is equivalent
         // (inline atomic load of a float). We pin to 1.3.0 on this
         // branch because AppleClang/libc++ on the GitHub-hosted macOS
         // runner doesn't ship std::expected yet — see issue #155. Flip
         // back to GetParameterRT when we can adopt 1.4+ again.
-        float value = Globals()->GetParameter(
-            static_cast<AudioUnitParameterID>(param.id));
-        store_.set_value(param.id, value);
+        const float host_value = Globals()->GetParameter(
+            static_cast<AudioUnitParameterID>(params[i].id));
+        const float previous_host =
+            reset_host_snapshot ? host_value : host_param_snapshot_[i];
+        float value = store_.get_value(params[i].id);
+        if (reset_host_snapshot || host_value != previous_host) {
+            store_.set_value_rt(params[i].id, host_value);
+            value = host_value;
+        }
+        param_snapshot_[i] = value;
+        host_param_snapshot_[i] = host_value;
     }
+    host_param_snapshot_valid_ = true;
 
     auto* output = GetOutput(0);
     AudioBufferList& outBL = output->PrepareBuffer(inNumberFrames);
@@ -237,6 +306,7 @@ OSStatus PulpAUInstrument::Render(AudioUnitRenderActionFlags& ioActionFlags,
         midi_in = std::move(pending_midi_);
         pending_midi_ = midi::MidiBuffer{};
     }
+    midi_in.sort();
 
     ProcessContext ctx;
     ctx.sample_rate = GetOutput(0)->GetStreamFormat().mSampleRate;
@@ -296,7 +366,28 @@ OSStatus PulpAUInstrument::Render(AudioUnitRenderActionFlags& ioActionFlags,
     }
     pulp::format::detail::compute_playhead_changes(ctx, playhead_prev_);
 
-    processor_->process(output_view, input_view, midi_in, midi_out, ctx);
+    param_events_.clear();
+    processor_->set_param_events(&param_events_);
+    {
+        pulp::runtime::ScopedNoAlloc no_alloc_guard;
+        processor_->process(output_view, input_view, midi_in, midi_out, ctx);
+    }
+
+    for (std::size_t i = 0; i < params.size(); ++i) {
+        float post = store_.get_value(params[i].id);
+        if (post == param_snapshot_[i] && post == host_param_snapshot_[i]) continue;
+        publish_parameter_change_to_host(params[i].id, post);
+        host_param_snapshot_[i] = post;
+    }
+
+    if (processor_->consume_latency_changed_flag()) {
+        PropertyChanged(kAudioUnitProperty_Latency,
+                        kAudioUnitScope_Global, 0);
+    }
+    if (processor_->consume_tail_changed_flag()) {
+        PropertyChanged(kAudioUnitProperty_TailTime,
+                        kAudioUnitScope_Global, 0);
+    }
 
     return noErr;
 }

--- a/core/format/src/settings_panel.cpp
+++ b/core/format/src/settings_panel.cpp
@@ -153,6 +153,15 @@ void SettingsPanel::build_audio_tab() {
     };
     audio_tab->add_child(std::move(out_combo));
 
+    audio_tab->add_child(make_section_label("Output Level"));
+    auto out_meter = std::make_unique<view::MultiMeter>();
+    output_meter_ = out_meter.get();
+    out_meter->set_channel_count(2);
+    out_meter->set_layout(view::MultiMeter::Layout::horizontal);
+    out_meter->set_display_style(view::MultiMeter::DisplayStyle::segmented);
+    out_meter->flex().preferred_height = 48.0f;
+    audio_tab->add_child(std::move(out_meter));
+
     // Input device
     auto input_label = make_section_label("Input Device");
     input_device_label_ = input_label.get();
@@ -162,6 +171,16 @@ void SettingsPanel::build_audio_tab() {
     in_combo->flex().preferred_height = 28.0f;
     in_combo->on_change = [this](int) { apply_config(); };
     audio_tab->add_child(std::move(in_combo));
+
+    // Input level meter
+    audio_tab->add_child(make_section_label("Input Level"));
+    auto meter = std::make_unique<view::MultiMeter>();
+    input_meter_ = meter.get();
+    meter->set_channel_count(2);
+    meter->set_layout(view::MultiMeter::Layout::horizontal);
+    meter->set_display_style(view::MultiMeter::DisplayStyle::segmented);
+    meter->flex().preferred_height = 48.0f;
+    audio_tab->add_child(std::move(meter));
 
     // Sample rate
     audio_tab->add_child(make_section_label("Sample Rate"));
@@ -189,25 +208,6 @@ void SettingsPanel::build_audio_tab() {
     auto lat = make_info_label("Latency: —");
     latency_label_ = lat.get();
     audio_tab->add_child(std::move(lat));
-
-    // Input level meter
-    audio_tab->add_child(make_section_label("Input Level"));
-    auto meter = std::make_unique<view::MultiMeter>();
-    input_meter_ = meter.get();
-    meter->set_channel_count(2);
-    meter->set_layout(view::MultiMeter::Layout::horizontal);
-    meter->set_display_style(view::MultiMeter::DisplayStyle::segmented);
-    meter->flex().preferred_height = 48.0f;
-    audio_tab->add_child(std::move(meter));
-
-    audio_tab->add_child(make_section_label("Output Level"));
-    auto out_meter = std::make_unique<view::MultiMeter>();
-    output_meter_ = out_meter.get();
-    out_meter->set_channel_count(2);
-    out_meter->set_layout(view::MultiMeter::Layout::horizontal);
-    out_meter->set_display_style(view::MultiMeter::DisplayStyle::segmented);
-    out_meter->flex().preferred_height = 48.0f;
-    audio_tab->add_child(std::move(out_meter));
 
     // Test tone section. Header line: "Test Signal" on the left, the "Sine Tone" switch on
     // the right; the frequency dropdown sits full-width on its own line below so it never

--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -11,10 +11,12 @@
 
 #include <algorithm>
 #include <charconv>
+#include <chrono>
 #include <cmath>
 #include <filesystem>
 #include <fstream>
 #include <string_view>
+#include <thread>
 
 // WYSIWYG P6 FIX 5 — the dev inspector (Cmd+I overlay) is gated behind the
 // PULP_ENABLE_INSPECTOR compile flag (root CMake option, default ON for
@@ -412,6 +414,21 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
     }
 
     if (!start()) return false;
+
+    if (effective_config.package_audit) {
+        const int timeout_seconds = std::max(1, effective_config.package_audit_timeout_seconds);
+        runtime::log_info("Standalone: package audit running for up to {} seconds",
+                          timeout_seconds);
+        const auto deadline = std::chrono::steady_clock::now() +
+                              std::chrono::seconds(timeout_seconds);
+        while (running_.load(std::memory_order_acquire) &&
+               std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+        runtime::log_info("Standalone: package audit complete");
+        stop();
+        return true;
+    }
 
     if (!processor_ || !processor_->has_editor()) {
         runtime::log_error("Standalone: processor has no editor");

--- a/core/view/include/pulp/view/text_editor.hpp
+++ b/core/view/include/pulp/view/text_editor.hpp
@@ -106,6 +106,9 @@ public:
     // ── Event handling ────────────────────────────────────────────────────
 
     void on_mouse_event(const MouseEvent& event) override;
+    void on_mouse_down(Point pos) override;
+    void on_mouse_drag(Point pos) override;
+    void on_mouse_up(Point pos) override;
     bool on_key_event(const KeyEvent& event) override;
     void on_text_input(const TextInputEvent& event) override;
     void on_focus_changed(bool gained) override;
@@ -160,6 +163,9 @@ private:
     float content_inset_left_ = 0.0f; ///< Extra left inset to clear a leading icon
     float scroll_offset_ = 0.0f; ///< Horizontal scroll for single-line
     float caret_blink_time_ = 0.0f; ///< Accumulated time for caret blinking
+    bool selection_drag_active_ = false;
+    int selection_drag_anchor_ = 0;
+    bool suppress_next_legacy_mouse_down_ = false;
     int caret_blink_sub_ = -1;      ///< Frame-clock subscription that drives blink repaints while focused
     FrameClock* caret_blink_clock_ = nullptr;  ///< Clock the subscription lives on; cached so we can
                                                ///< always unsubscribe even after the editor is detached

--- a/core/view/platform/mac/plugin_view_host_mac.mm
+++ b/core/view/platform/mac/plugin_view_host_mac.mm
@@ -5,6 +5,7 @@
 
 #include <pulp/canvas/cg_canvas.hpp>
 #include <pulp/view/input_events.hpp>
+#include <pulp/view/script_event_dispatch.hpp>
 #include <pulp/view/widgets.hpp>
 #include <pulp/view/ui_components.hpp>
 #include <pulp/view/window_host.hpp>  // compute_design_viewport_transform
@@ -134,7 +135,19 @@ void pulp_plugin_mouse_down(pulp::view::View* root, NSEvent* event,
     if (!*drag_target) return;
     using namespace pulp::view::mac_geometry;
     auto local = to_local(pt, *drag_target, root);
-    if ((*drag_target)->focusable()) (*drag_target)->claim_input_focus();
+    if ((*drag_target)->focusable()) {
+        auto* focused = pulp::view::View::focused_input_;
+        if (focused != *drag_target) {
+            if (focused && view_is_in_tree(focused, root))
+                focused->on_focus_changed(false);
+            (*drag_target)->on_focus_changed(true);
+        }
+        (*drag_target)->claim_input_focus();
+    } else if (auto* focused = pulp::view::View::focused_input_;
+               focused && view_is_in_tree(focused, root)) {
+        focused->on_focus_changed(false);
+        focused->release_input_focus();
+    }
 
     pulp::view::MouseEvent me;
     me.position = local;
@@ -142,6 +155,7 @@ void pulp_plugin_mouse_down(pulp::view::View* root, NSEvent* event,
     me.button = pulp::view::MouseButton::left;
     me.modifiers = modifiers_from_ns_flags(event.modifierFlags);
     me.is_down = true;
+    me.phase = pulp::view::MousePhase::press;
     me.click_count = static_cast<int>(event.clickCount);
     (*drag_target)->on_mouse_event(me);
     (*drag_target)->on_mouse_down(local);
@@ -198,6 +212,7 @@ void pulp_plugin_mouse_up(pulp::view::View* root, NSEvent* event,
     up.button = pulp::view::MouseButton::left;
     up.modifiers = modifiers_from_ns_flags(event.modifierFlags);
     up.is_down = false;
+    up.phase = pulp::view::MousePhase::release;
     up.click_count = static_cast<int>(event.clickCount);
     (*drag_target)->on_mouse_event(up);
     for (auto* b = (*drag_target)->parent(); b; b = b->parent()) {
@@ -244,39 +259,59 @@ void pulp_plugin_wheel(pulp::view::View* root, pulp::view::Point pt, NSEvent* ev
   }
 }
 
-// Route a keyDown to the currently focused input widget — the embedded analog of
-// the standalone PulpView's key handling (window_host_mac.mm). Without this an
-// embedded TextEditor (e.g. an imported search field) never receives typing: the
-// host NSView is first responder but had no keyDown:, so characters were dropped.
-// A click already sets focus (claim_input_focus in mouseDown). Returns true when
-// a focused input consumed the event, so the caller only falls through to
-// [super keyDown:] (host menu shortcuts etc.) when nothing was focused.
-bool pulp_plugin_key_down(pulp::view::View* root, NSEvent* event) {
+bool pulp_plugin_event_has_text_input_modifier(const pulp::view::KeyEvent& event) {
+    return event.isMainModifier() || event.isCtrlDown() || event.isAltDown();
+}
+
+pulp::view::KeyEvent pulp_plugin_key_event_from_ns(NSEvent* event) {
+    pulp::view::KeyEvent ke;
+    ke.key = pulp::view::mac_geometry::key_code_from_ns(event.keyCode);
+    ke.modifiers = pulp::view::mac_geometry::modifiers_from_ns_flags(event.modifierFlags);
+    ke.is_down = true;
+    ke.is_repeat = event.isARepeat;
+    return ke;
+}
+
+// Route a native key event to the currently focused input widget. The embedded
+// plugin views are shared by AU/VST3/CLAP editors, so keyboard parity belongs
+// here rather than in individual examples. Returns true only when the focused
+// widget consumed the key or accepted printable text.
+bool pulp_plugin_dispatch_focused_key(pulp::view::View* root,
+                                      NSEvent* event,
+                                      bool allow_text_input) {
   try {
     if (!root) return false;
     // Auto-clearing static: cleared by ~View when the focused widget is freed,
     // so this never derefs freed memory (pulp #1708 rationale).
     auto* fv = pulp::view::View::focused_input_;
     if (!fv) return false;
-    pulp::view::KeyEvent ke;
-    ke.key = pulp::view::mac_geometry::key_code_from_ns(event.keyCode);
-    ke.modifiers = pulp::view::mac_geometry::modifiers_from_ns_flags(event.modifierFlags);
-    ke.is_down = true;
-    ke.is_repeat = event.isARepeat;
-    fv->on_key_event(ke);  // backspace / arrows / enter (TextEditor handles these)
-    // Printable characters → text insertion. (Full IME / marked-text via
-    // NSTextInputClient is a follow-up; this covers ASCII + most Latin typing.)
-    NSString* chars = event.characters;
-    if (chars.length > 0) {
-        unichar c0 = [chars characterAtIndex:0];
-        if (c0 >= 0x20 && c0 != 0x7f) {
-            pulp::view::TextInputEvent te;
-            te.text = chars.UTF8String;
-            fv->on_text_input(te);
+    using namespace pulp::view::mac_geometry;
+    if (!view_is_in_tree(fv, root)) return false;
+
+    const auto ke = pulp_plugin_key_event_from_ns(event);
+    if (fv->on_key_event(ke)) {
+        root->request_repaint();
+        return true;
+    }
+
+    if (allow_text_input && fv->accepts_text_input()
+        && !pulp_plugin_event_has_text_input_modifier(ke)) {
+        // Printable characters → text insertion. (Full IME / marked-text via
+        // NSTextInputClient is a follow-up; this covers ASCII + most Latin typing.)
+        NSString* chars = event.characters;
+        if (chars.length > 0) {
+            unichar c0 = [chars characterAtIndex:0];
+            if (c0 >= 0x20 && c0 != 0x7f) {
+                pulp::view::TextInputEvent te;
+                te.text = chars.UTF8String;
+                fv->on_text_input(te);
+                root->request_repaint();
+                return true;
+            }
         }
     }
-    root->request_repaint();
-    return true;
+
+    return false;
   } catch (const std::exception& e) {
     std::fprintf(stderr, "[plugin-view-host] keyDown handler threw: %s\n", e.what());
     return true;  // swallow; don't beep/propagate a half-handled key
@@ -284,6 +319,42 @@ bool pulp_plugin_key_down(pulp::view::View* root, NSEvent* event) {
     std::fprintf(stderr, "[plugin-view-host] keyDown handler threw (unknown)\n");
     return true;
   }
+}
+
+bool pulp_plugin_key_down(pulp::view::View* root, NSEvent* event) {
+    if (pulp_plugin_dispatch_focused_key(root, event, /*allow_text_input=*/true)) {
+        return true;
+    }
+    if (!root) return false;
+    const auto ke = pulp_plugin_key_event_from_ns(event);
+    if (pulp::view::View::call_inspector_key_hook(ke)) {
+        root->request_repaint();
+        return true;
+    }
+    if (root->on_global_key && root->on_global_key(ke)) {
+        root->request_repaint();
+        return true;
+    }
+    pulp::view::script_events::dispatch_global_key(static_cast<int>(ke.key),
+                                                   ke.modifiers,
+                                                   /*is_down=*/true);
+    return false;
+}
+
+bool pulp_plugin_perform_key_equivalent(pulp::view::View* root, NSEvent* event) {
+    if (pulp_plugin_dispatch_focused_key(root, event, /*allow_text_input=*/false)) {
+        return true;
+    }
+    if (!root) return false;
+    const auto ke = pulp_plugin_key_event_from_ns(event);
+    if (root->on_global_key && root->on_global_key(ke)) {
+        root->request_repaint();
+        return true;
+    }
+    pulp::view::script_events::dispatch_global_key(static_cast<int>(ke.key),
+                                                   ke.modifiers,
+                                                   /*is_down=*/true);
+    return false;
 }
 
 } // namespace
@@ -294,6 +365,10 @@ bool pulp_plugin_key_down(pulp::view::View* root, NSEvent* event) {
 
 - (BOOL)isFlipped { return NO; }
 - (BOOL)acceptsFirstResponder { return YES; }
+- (BOOL)acceptsFirstMouse:(NSEvent*)event { (void)event; return YES; }
+- (BOOL)performKeyEquivalent:(NSEvent*)event {
+    return pulp_plugin_perform_key_equivalent(self.rootView, event) ? YES : NO;
+}
 - (void)keyDown:(NSEvent*)event {
     if (!pulp_plugin_key_down(self.rootView, event)) [super keyDown:event];
 }
@@ -307,6 +382,7 @@ bool pulp_plugin_key_down(pulp::view::View* root, NSEvent* event) {
 }
 - (void)mouseDown:(NSEvent*)event {
     if (!self.rootView) return;
+    if (self.window.firstResponder != self) [self.window makeFirstResponder:self];
     pulp_plugin_mouse_down(self.rootView, event, [self localPoint:event], &_dragTarget);
     [self setNeedsDisplay:YES];
 }
@@ -701,6 +777,10 @@ private:
 }
 
 - (BOOL)acceptsFirstResponder { return YES; }
+- (BOOL)acceptsFirstMouse:(NSEvent*)event { (void)event; return YES; }
+- (BOOL)performKeyEquivalent:(NSEvent*)event {
+    return pulp_plugin_perform_key_equivalent(self.rootView, event) ? YES : NO;
+}
 - (void)keyDown:(NSEvent*)event {
     if (!pulp_plugin_key_down(self.rootView, event)) [super keyDown:event];
 }
@@ -713,6 +793,7 @@ private:
 }
 - (void)mouseDown:(NSEvent*)event {
     if (!self.rootView) return;
+    if (self.window.firstResponder != self) [self.window makeFirstResponder:self];
     pulp_plugin_mouse_down(self.rootView, event, [self localPoint:event], &_dragTarget);
     if (self.rootView) self.rootView->request_repaint();
 }

--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -463,8 +463,7 @@ static void install_app_menu(NSString* appName) {
             pulp::view::MouseEvent me;
             me.position = {pt.x, pt.y};
             me.modifiers = mods;
-            me.is_down = true;
-            me.phase = pulp::view::MousePhase::press;
+            me.is_down = true; me.phase = pulp::view::MousePhase::press;
             // WYSIWYG P4 FIX 1 — pass this window's root so the installed hook
             // gates to the inspected canvas root; events in a secondary window
             // (the floating InspectorWindow) must not touch the canvas overlay.
@@ -495,7 +494,7 @@ static void install_app_menu(NSString* appName) {
                 me.position = local;
                 me.window_position = pt;
                 me.button = pulp::view::MouseButton::left;
-                me.is_down = true;
+                me.is_down = true; me.phase = pulp::view::MousePhase::press;
                 me.click_count = 1;
                 combo->on_mouse_event(me);
                 [self setNeedsDisplay:YES];
@@ -556,7 +555,7 @@ static void install_app_menu(NSString* appName) {
                     me.window_position = pt;
                     me.button = pulp::view::MouseButton::left;
                     me.modifiers = modifiers_from_ns_flags(event.modifierFlags);
-                    me.is_down = true;
+                    me.is_down = true; me.phase = pulp::view::MousePhase::press;
                     me.click_count = static_cast<int>(event.clickCount);
                     _dragTarget->on_mouse_event(me);
                     _dragTarget->on_mouse_down(local);
@@ -607,7 +606,7 @@ static void install_app_menu(NSString* appName) {
             me.window_position = pt;
             me.button = pulp::view::MouseButton::left;
             me.modifiers = modifiers_from_ns_flags(event.modifierFlags);
-            me.is_down = true;
+            me.is_down = true; me.phase = pulp::view::MousePhase::press;
             me.click_count = static_cast<int>(event.clickCount);
             _dragTarget->on_mouse_event(me);
             _dragTarget->on_mouse_down(local);
@@ -790,7 +789,7 @@ static void install_app_menu(NSString* appName) {
                 up_me.window_position = pt;
                 up_me.button = pulp::view::MouseButton::left;
                 up_me.modifiers = modifiers;
-                up_me.is_down = false;
+                up_me.is_down = false; up_me.phase = pulp::view::MousePhase::release;
                 up_me.click_count = static_cast<int>(event.clickCount);
                 _dragTarget->on_mouse_event(up_me);
                 for (auto* bubble = _dragTarget->parent(); bubble; bubble = bubble->parent()) {

--- a/core/view/src/text_editor.cpp
+++ b/core/view/src/text_editor.cpp
@@ -253,7 +253,26 @@ void TextEditor::on_mouse_event(const MouseEvent& event) {
         scroll_offset_ = std::max(0.0f, scroll_offset_ + event.scroll_delta_y);
         return;
     }
-    if (!event.is_down) return;
+
+    if (event.isRelease()) {
+        selection_drag_active_ = false;
+        suppress_next_legacy_mouse_down_ = false;
+        return;
+    }
+
+    if (event.isDrag()) {
+        suppress_next_legacy_mouse_down_ = false;
+        if (!selection_drag_active_) return;
+        const int pos = char_index_at_point(event.position.x, event.position.y);
+        caret_position_ = pos;
+        selection_start_ = selection_drag_anchor_;
+        selection_end_ = pos;
+        request_repaint();
+        return;
+    }
+
+    if (!event.isPress()) return;
+    suppress_next_legacy_mouse_down_ = event.hasExplicitPhase();
 
     // char_index_at_point reads from the cached LayoutSnapshot; for
     // single-line that snapshot is one row of measured advances, so
@@ -264,6 +283,7 @@ void TextEditor::on_mouse_event(const MouseEvent& event) {
     if (event.click_count == 3) {
         // Triple-click: select all (line in multi-line)
         select_all();
+        selection_drag_active_ = false;
     } else if (event.click_count == 2) {
         // Double-click: select word
         int start = pos, end = pos;
@@ -272,15 +292,50 @@ void TextEditor::on_mouse_event(const MouseEvent& event) {
         selection_start_ = start;
         selection_end_ = end;
         caret_position_ = end;
+        selection_drag_active_ = false;
     } else if (event.isShiftDown()) {
         // Shift-click: extend selection
+        if (!has_selection()) selection_start_ = caret_position_;
+        selection_drag_anchor_ = selection_start_;
         selection_end_ = pos;
         caret_position_ = pos;
+        selection_drag_active_ = true;
     } else {
         // Single click: place caret
         caret_position_ = pos;
         selection_start_ = selection_end_ = pos;
+        selection_drag_anchor_ = pos;
+        selection_drag_active_ = true;
     }
+    request_repaint();
+}
+
+void TextEditor::on_mouse_down(Point pos) {
+    if (suppress_next_legacy_mouse_down_) {
+        suppress_next_legacy_mouse_down_ = false;
+        return;
+    }
+    MouseEvent event;
+    event.position = pos;
+    event.is_down = true;
+    event.phase = MousePhase::press;
+    on_mouse_event(event);
+}
+
+void TextEditor::on_mouse_drag(Point pos) {
+    MouseEvent event;
+    event.position = pos;
+    event.is_down = true;
+    event.phase = MousePhase::drag;
+    on_mouse_event(event);
+}
+
+void TextEditor::on_mouse_up(Point pos) {
+    MouseEvent event;
+    event.position = pos;
+    event.is_down = false;
+    event.phase = MousePhase::release;
+    on_mouse_event(event);
 }
 
 bool TextEditor::on_key_event(const KeyEvent& event) {
@@ -520,7 +575,11 @@ void TextEditor::paint(canvas::Canvas& canvas) {
             }
 
             std::string candidate = current + c;
-            if (!current.empty() && canvas.measure_text(candidate) > inner_w) {
+            const bool candidate_is_utf8_boundary =
+                canvas::safe_utf8_prefix_size(candidate, candidate.size()) ==
+                candidate.size();
+            if (candidate_is_utf8_boundary && !current.empty() &&
+                canvas.measure_text(candidate) > inner_w) {
                 flush_line(i);
                 current_start = i;
             }
@@ -588,17 +647,13 @@ void TextEditor::paint(canvas::Canvas& canvas) {
                 dst.baseline_y = dst.top_y + font_size_;
                 dst.inner_x = inner_x;
                 dst.line_height = line_h;
-                // O(N) single-char accumulation. Loses inter-glyph
-                // kerning vs full-prefix shaping, but the legacy
-                // substr-measure loop was O(N²) Skia-paragraph builds
-                // per paint — unshippable on the hot path.
+                // Use text_x_for_byte for every byte boundary so multi-byte
+                // UTF-8 prefixes are never measured as invalid one-byte slices.
+                // Backends with real shaping can return in-context cluster
+                // offsets; fallback backends snap to safe UTF-8 prefixes.
                 dst.x_offsets.resize(src.text.size() + 1);
-                dst.x_offsets[0] = 0.f;
-                float cum = 0.f;
-                for (size_t j = 0; j < src.text.size(); ++j) {
-                    cum += canvas.measure_text(std::string(1, src.text[j]));
-                    dst.x_offsets[j + 1] = cum;
-                }
+                for (size_t j = 0; j <= src.text.size(); ++j)
+                    dst.x_offsets[j] = canvas.text_x_for_byte(src.text, j);
                 last_layout_.lines.push_back(std::move(dst));
             }
             last_layout_key_ = key;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6002,7 +6002,9 @@ if(APPLE AND NOT PULP_IOS AND PULP_HAS_SKIA)
     target_compile_definitions(pulp-test-mac-platform-harness PRIVATE
         PULP_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
     catch_discover_tests(pulp-test-mac-platform-harness)
+endif()
 
+if(APPLE AND NOT PULP_IOS)
     # pulp #2088 — pin the invariant -[PulpView liveFocusedView] depends on:
     # ~View() must auto-clear focused_input_ (#1708 contract) so the
     # accessor can safely re-sync the ivar to nullptr before any deref.
@@ -6027,13 +6029,11 @@ if(APPLE AND NOT PULP_IOS AND PULP_HAS_SKIA)
         Catch2::Catch2WithMain
         "-framework AppKit"
     )
-    # PulpView's Obj-C class metadata only registers when the linker keeps
-    # window_host_mac.mm.o — but no C++ symbol the test references lives in
-    # that .o, so static-lib pruning drops it. Force-load the one specific
-    # object to register the class without dragging in every other .mm
-    # (which would duplicate-symbol on PulpAccessibilityElement).
+    # Force-load the specific host objects that register PulpView/PulpPluginView;
+    # static-lib pruning drops them because the test references no C++ symbol.
     target_link_options(pulp-test-mac-perform-key-equivalent PRIVATE
         "LINKER:-force_load,${CMAKE_BINARY_DIR}/core/view/CMakeFiles/pulp-view-core.dir/platform/mac/window_host_mac.mm.o"
+        "LINKER:-force_load,${CMAKE_BINARY_DIR}/core/view/CMakeFiles/pulp-view-core.dir/platform/mac/plugin_view_host_mac.mm.o"
     )
     catch_discover_tests(pulp-test-mac-perform-key-equivalent)
 endif()

--- a/test/test_au_plugin_state.mm
+++ b/test/test_au_plugin_state.mm
@@ -241,6 +241,36 @@ TEST_CASE("AU v2 instrument SaveState/RestoreState round-trips plugin-owned payl
     CFRelease(saved);
 }
 
+TEST_CASE("AU v2 effect mirrors custom-editor StateStore writes to AU parameter storage",
+          "[au][auv2][state][editor]") {
+    ScopedFactoryRegistration registration(create_effect_processor);
+
+    pulp::format::au::PulpAUEffect effect(nullptr);
+    auto* processor = g_last_effect_processor;
+    REQUIRE(processor != nullptr);
+
+    processor->state().set_value(1, -18.0f);
+
+    AudioUnitParameterValue au_value = 0.0f;
+    REQUIRE(effect.GetParameter(1, kAudioUnitScope_Global, 0, au_value) == noErr);
+    REQUIRE_THAT(au_value, WithinAbs(-18.0, 0.01));
+}
+
+TEST_CASE("AU v2 instrument mirrors custom-editor StateStore writes to AU parameter storage",
+          "[au][auv2][instrument][state][editor]") {
+    ScopedFactoryRegistration registration(create_instrument_processor);
+
+    pulp::format::au::PulpAUInstrument instrument(nullptr);
+    auto* processor = g_last_instrument_processor;
+    REQUIRE(processor != nullptr);
+
+    processor->state().set_value(1, 1760.0f);
+
+    AudioUnitParameterValue au_value = 0.0f;
+    REQUIRE(instrument.GetParameter(1, kAudioUnitScope_Global, 0, au_value) == noErr);
+    REQUIRE_THAT(au_value, WithinAbs(1760.0, 0.01));
+}
+
 TEST_CASE("AU v3 fullState round-trips plugin-owned payload",
           "[au][auv3][state]") {
     @autoreleasepool {

--- a/test/test_canvas.cpp
+++ b/test/test_canvas.cpp
@@ -1169,6 +1169,35 @@ TEST_CASE("CoreGraphicsCanvas::clear_rect zeroes destination pixels",
         REQUIRE(pixels[i] == 0);
     }
 }
+
+TEST_CASE("CoreGraphicsCanvas text measurement tolerates invalid UTF-8",
+          "[canvas][cg][text][plugin]") {
+    constexpr int W = 32;
+    constexpr int H = 32;
+    std::vector<uint8_t> pixels(static_cast<size_t>(W) * H * 4u, 0u);
+    auto cs = CGColorSpaceCreateDeviceRGB();
+    REQUIRE(cs != nullptr);
+    const uint32_t bitmap_info =
+        static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) |
+        static_cast<uint32_t>(kCGBitmapByteOrder32Big);
+    CGContextRef ctx = CGBitmapContextCreate(
+        pixels.data(), W, H, 8, W * 4u, cs, bitmap_info);
+    CGColorSpaceRelease(cs);
+    REQUIRE(ctx != nullptr);
+
+    {
+        CoreGraphicsCanvas canvas(ctx, static_cast<float>(W),
+                                  static_cast<float>(H));
+        canvas.set_font("Inter", 13.0f);
+        const std::string invalid_utf8 = std::string("bad") + char(0xff) + "text";
+        REQUIRE_NOTHROW(canvas.measure_text(invalid_utf8));
+        REQUIRE_NOTHROW(canvas.measure_text_full(invalid_utf8));
+        REQUIRE_NOTHROW(canvas.fill_text(invalid_utf8, 2.0f, 18.0f));
+        REQUIRE(canvas.measure_text(invalid_utf8) > 0.0f);
+    }
+
+    CGContextRelease(ctx);
+}
 #endif  // __APPLE__
 
 // ── pulp #1737 — CSS font-variant → SkShaper Feature plumbing ─────────────

--- a/test/test_mac_perform_key_equivalent.mm
+++ b/test/test_mac_perform_key_equivalent.mm
@@ -30,6 +30,7 @@
 #include <pulp/view/view.hpp>
 #include <pulp/view/input_events.hpp>
 #include <pulp/view/script_event_dispatch.hpp>
+#include <memory>
 
 // PulpView interface — the Obj-C class window_host_mac.mm declares.
 // We don't link against it directly (it's bundled into pulp::view); the
@@ -38,11 +39,37 @@
 @property (nonatomic, assign) pulp::view::View* rootView;
 @end
 
+@interface PulpPluginView : NSView
+@property (nonatomic, assign) pulp::view::View* rootView;
+@end
+
 namespace {
 
 class TestRoot : public pulp::view::View {
 public:
     void paint(pulp::canvas::Canvas&) override {}
+};
+
+class TextSinkView : public pulp::view::View {
+public:
+    explicit TextSinkView(bool accepts_text) : accepts_text_(accepts_text) {
+        set_focusable(true);
+    }
+
+    bool accepts_text_input() const override { return accepts_text_; }
+    bool on_key_event(const pulp::view::KeyEvent&) override {
+        ++key_hits;
+        return false;
+    }
+    void on_text_input(const pulp::view::TextInputEvent&) override {
+        ++text_hits;
+    }
+
+    int key_hits = 0;
+    int text_hits = 0;
+
+private:
+    bool accepts_text_ = false;
 };
 
 // GlobalKeyDispatcher is a plain function pointer, so the script-dispatch
@@ -68,6 +95,19 @@ NSEvent* make_cmd_comma_event() {
                              keyCode:43];
 }
 
+NSEvent* make_plain_a_event() {
+    return [NSEvent keyEventWithType:NSEventTypeKeyDown
+                            location:NSZeroPoint
+                       modifierFlags:0
+                           timestamp:0
+                        windowNumber:0
+                             context:nil
+                          characters:@"a"
+         charactersIgnoringModifiers:@"a"
+                           isARepeat:NO
+                             keyCode:0];
+}
+
 PulpView* make_pulp_view(pulp::view::View* root) {
     // Instantiate PulpView at runtime (class is registered by the static
     // initializer in window_host_mac.mm — pulp::view static linkage pulls
@@ -77,6 +117,15 @@ PulpView* make_pulp_view(pulp::view::View* root) {
     if (cls == nil) return nil;
     PulpView* view =
         [[(PulpView*)[cls alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)] autorelease];
+    view.rootView = root;
+    return view;
+}
+
+PulpPluginView* make_pulp_plugin_view(pulp::view::View* root) {
+    Class cls = NSClassFromString(@"PulpPluginView");
+    if (cls == nil) return nil;
+    PulpPluginView* view =
+        [[(PulpPluginView*)[cls alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)] autorelease];
     view.rootView = root;
     return view;
 }
@@ -182,4 +231,73 @@ TEST_CASE("performKeyEquivalent: no-op when rootView->on_global_key is null",
     script_events::set_global_key_dispatcher(nullptr);
     REQUIRE(handled == NO);
     REQUIRE(g_script_hits == 1);
+}
+
+TEST_CASE("PulpPluginView keyDown: focused non-text control does not swallow printable keys",
+          "[mac][platform][keyboard][plugin][musical-typing]") {
+    using namespace pulp::view;
+
+    TestRoot root;
+    int root_hits = 0;
+    root.on_global_key = [&](const KeyEvent&) -> bool {
+        ++root_hits;
+        return false;
+    };
+
+    auto sink = std::make_unique<TextSinkView>(false);
+    auto* sink_ptr = sink.get();
+    root.add_child(std::move(sink));
+    sink_ptr->claim_input_focus();
+
+    PulpPluginView* view = make_pulp_plugin_view(&root);
+    if (view == nil) {
+        sink_ptr->release_input_focus();
+        WARN("PulpPluginView class not registered — skipping platform test");
+        return;
+    }
+
+    g_script_hits = 0;
+    script_events::set_global_key_dispatcher(&counting_script_dispatcher);
+    [view keyDown:make_plain_a_event()];
+    script_events::set_global_key_dispatcher(nullptr);
+    sink_ptr->release_input_focus();
+
+    REQUIRE(sink_ptr->key_hits == 1);
+    REQUIRE(sink_ptr->text_hits == 0);
+    REQUIRE(root_hits == 1);
+    REQUIRE(g_script_hits == 1);
+}
+
+TEST_CASE("PulpPluginView keyDown: focused text-capable control receives printable keys",
+          "[mac][platform][keyboard][plugin][text]") {
+    using namespace pulp::view;
+
+    TestRoot root;
+    int root_hits = 0;
+    root.on_global_key = [&](const KeyEvent&) -> bool {
+        ++root_hits;
+        return false;
+    };
+
+    auto sink = std::make_unique<TextSinkView>(true);
+    auto* sink_ptr = sink.get();
+    root.add_child(std::move(sink));
+    sink_ptr->claim_input_focus();
+
+    PulpPluginView* view = make_pulp_plugin_view(&root);
+    if (view == nil) {
+        sink_ptr->release_input_focus();
+        return;
+    }
+
+    g_script_hits = 0;
+    script_events::set_global_key_dispatcher(&counting_script_dispatcher);
+    [view keyDown:make_plain_a_event()];
+    script_events::set_global_key_dispatcher(nullptr);
+    sink_ptr->release_input_focus();
+
+    REQUIRE(sink_ptr->key_hits == 1);
+    REQUIRE(sink_ptr->text_hits == 1);
+    REQUIRE(root_hits == 0);
+    REQUIRE(g_script_hits == 0);
 }

--- a/test/test_settings_sections.cpp
+++ b/test/test_settings_sections.cpp
@@ -10,6 +10,7 @@
 #include <pulp/view/widgets.hpp>
 #include <pulp/view/screenshot.hpp>
 
+#include <algorithm>
 #include <fstream>
 #include <memory>
 #include <string>
@@ -50,6 +51,31 @@ std::unique_ptr<pulp::view::View> label(const std::string& t) {
     return std::make_unique<pulp::view::Label>(t);
 }
 
+pulp::view::TabPanel& settings_tabs(SettingsPanel& panel) {
+    for (std::size_t i = 0; i < panel.child_count(); ++i)
+        if (auto* tabs = dynamic_cast<pulp::view::TabPanel*>(panel.child_at(i)))
+            return *tabs;
+    REQUIRE(false);
+    static pulp::view::TabPanel never;
+    return never;
+}
+
+std::vector<std::string> direct_audio_child_signature(SettingsPanel& panel) {
+    auto& tabs = settings_tabs(panel);
+    auto* audio_tab = tabs.child_at(0);
+    REQUIRE(audio_tab != nullptr);
+
+    std::vector<std::string> out;
+    for (std::size_t i = 0; i < audio_tab->child_count(); ++i) {
+        auto* child = audio_tab->child_at(i);
+        if (auto* label = dynamic_cast<pulp::view::Label*>(child))
+            out.push_back(label->text());
+        else if (dynamic_cast<pulp::view::MultiMeter*>(child))
+            out.push_back("<meter>");
+    }
+    return out;
+}
+
 }  // namespace
 
 TEST_CASE("Processor::settings_sections defaults to none", "[format][settings]") {
@@ -72,6 +98,24 @@ TEST_CASE("A plugin contributes named settings sections with views", "[format][s
 TEST_CASE("SettingsPanel starts with host-owned Audio + MIDI tabs", "[format][settings]") {
     SettingsPanel panel;
     REQUIRE(panel.tab_count() == 2);  // Audio + MIDI
+}
+
+TEST_CASE("SettingsPanel Audio tab keeps meters next to their device selectors", "[format][settings]") {
+    SettingsPanel panel;
+    const auto signature = direct_audio_child_signature(panel);
+    const std::vector<std::string> expected_prefix = {
+        "Output Device",
+        "Output Level",
+        "<meter>",
+        "Input Device",
+        "Input Level",
+        "<meter>",
+        "Sample Rate",
+        "Buffer Size",
+        "Latency: \xE2\x80\x94",
+    };
+    REQUIRE(signature.size() >= expected_prefix.size());
+    REQUIRE(std::equal(expected_prefix.begin(), expected_prefix.end(), signature.begin()));
 }
 
 TEST_CASE("add_section appends plugin tabs after Audio/MIDI", "[format][settings]") {

--- a/test/test_standalone_editor_chrome.cpp
+++ b/test/test_standalone_editor_chrome.cpp
@@ -657,11 +657,11 @@ TEST_CASE("SettingsPanel updates input and output meters from audio bridges",
 
     panel.poll();
 
-    REQUIRE(meters[0]->channel_count() == 1);
+    REQUIRE(meters[0]->channel_count() == 2);
     REQUIRE(meters[0]->ballistics().channels[0].display_peak > 0.0f);
-    REQUIRE(meters[1]->channel_count() == 2);
+    REQUIRE(meters[0]->ballistics().channels[1].display_peak > 0.0f);
+    REQUIRE(meters[1]->channel_count() == 1);
     REQUIRE(meters[1]->ballistics().channels[0].display_peak > 0.0f);
-    REQUIRE(meters[1]->ballistics().channels[1].display_peak > 0.0f);
 }
 
 TEST_CASE("SettingsPanel refreshes hotplug lists and test tone callbacks",
@@ -1106,6 +1106,30 @@ TEST_CASE("Standalone headless CI without screenshot is rejected before launch",
     REQUIRE(config.screenshot_path.empty());
     REQUIRE(config.screenshot_frame_delay == 9);
     REQUIRE(standalone_headless_requires_screenshot(config));
+}
+
+TEST_CASE("Standalone package audit runs hidden without requiring a screenshot",
+          "[standalone][chrome][package-audit]") {
+    ScopedEnv headless("PULP_HEADLESS");
+    ScopedEnv test_mode("PULP_TEST_MODE");
+    ScopedEnv ci("CI");
+    ScopedEnv screenshot("PULP_SCREENSHOT");
+    ScopedEnv audit("PULP_STANDALONE_PACKAGE_AUDIT");
+    ScopedEnv audit_seconds("PULP_STANDALONE_PACKAGE_AUDIT_SECONDS");
+    headless.unset();
+    test_mode.unset();
+    ci.unset();
+    screenshot.unset();
+    audit.set("1");
+    audit_seconds.set("7");
+
+    auto config = standalone_config_from_environment(StandaloneConfig{});
+
+    REQUIRE(config.package_audit);
+    REQUIRE(config.headless);
+    REQUIRE(config.package_audit_timeout_seconds == 7);
+    REQUIRE(config.screenshot_path.empty());
+    REQUIRE_FALSE(standalone_headless_requires_screenshot(config));
 }
 
 TEST_CASE("Standalone empty headless env vars are ignored",

--- a/test/test_text_editor.cpp
+++ b/test/test_text_editor.cpp
@@ -7,6 +7,7 @@
 #include <pulp/canvas/canvas.hpp>
 
 #include <memory>
+#include <stdexcept>
 
 using namespace pulp::view;
 using namespace pulp::canvas;
@@ -40,6 +41,14 @@ struct ShapedOffsetCanvas : RecordingCanvas {
     }
     float text_x_for_byte(const std::string& text, std::size_t byte_index) override {
         return 500.0f + static_cast<float>(std::min(byte_index, text.size()));
+    }
+};
+
+struct Utf8StrictCanvas : RecordingCanvas {
+    float measure_text(const std::string& text) override {
+        if (safe_utf8_prefix_size(text, text.size()) != text.size())
+            throw std::runtime_error("invalid utf8 text measured");
+        return 8.0f * static_cast<float>(text.size());
     }
 };
 
@@ -504,6 +513,30 @@ TEST_CASE("TextEditor caret X comes from shaped offsets, not summed glyph widths
     REQUIRE(rect.x > 400.0f);
 }
 
+TEST_CASE("TextEditor paint never measures split UTF-8 byte prefixes",
+          "[view][text_editor][paint][utf8]") {
+    TextEditor editor;
+    editor.on_focus_changed(true);
+    editor.set_bounds({0, 0, 800, 30});
+    editor.set_text("cafe\xCC\x81 synth"); // "cafe" + combining acute
+
+    Utf8StrictCanvas canvas;
+    REQUIRE_NOTHROW(editor.paint(canvas));
+    REQUIRE_NOTHROW(canvas.text_x_for_byte(editor.text(), 5));
+}
+
+TEST_CASE("TextEditor multi-line offsets never measure split UTF-8 bytes",
+          "[view][text_editor][paint][utf8]") {
+    TextEditor editor;
+    editor.multi_line = true;
+    editor.on_focus_changed(true);
+    editor.set_bounds({0, 0, 800, 80});
+    editor.set_text("pad\ncafe\xCC\x81 arp");
+
+    Utf8StrictCanvas canvas;
+    REQUIRE_NOTHROW(editor.paint(canvas));
+}
+
 TEST_CASE("TextEditor multi-line paint renders placeholder when unfocused",
           "[view][text_editor][paint][issue-493]") {
     TextEditor editor;
@@ -677,6 +710,78 @@ TEST_CASE("TextEditor mouse shift-click extends selection from the caret",
     key_up.position = {9.0f, 15};
     editor.on_mouse_event(key_up);
     REQUIRE(editor.selected_text() == "llo");
+}
+
+TEST_CASE("TextEditor mouse drag selects text",
+          "[view][text_editor][selection][drag]") {
+    TextEditor editor;
+    editor.set_text("hello world");
+    editor.set_bounds({0, 0, 200, 30});
+
+    constexpr float char_w = 13.0f * 0.6f;
+    MouseEvent press;
+    press.position = {9.0f + 2.0f * char_w, 15.0f};
+    press.is_down = true;
+    press.phase = MousePhase::press;
+    editor.on_mouse_event(press);
+    REQUIRE_FALSE(editor.has_selection());
+
+    MouseEvent drag = press;
+    drag.position = {9.0f + 7.0f * char_w, 15.0f};
+    drag.is_down = true;
+    drag.phase = MousePhase::drag;
+    editor.on_mouse_event(drag);
+
+    REQUIRE(editor.has_selection());
+    REQUIRE(editor.selected_text() == "llo w");
+
+    MouseEvent release = drag;
+    release.is_down = false;
+    release.phase = MousePhase::release;
+    editor.on_mouse_event(release);
+
+    drag.position = {9.0f + 10.0f * char_w, 15.0f};
+    editor.on_mouse_event(drag);
+    REQUIRE(editor.selected_text() == "llo w");
+}
+
+TEST_CASE("TextEditor legacy mouse drag selects text",
+          "[view][text_editor][selection][drag]") {
+    TextEditor editor;
+    editor.set_text("hello world");
+    editor.set_bounds({0, 0, 200, 30});
+
+    constexpr float char_w = 13.0f * 0.6f;
+    editor.simulate_drag({9.0f + 2.0f * char_w, 15.0f},
+                         {9.0f + 7.0f * char_w, 15.0f},
+                         2);
+
+    REQUIRE(editor.has_selection());
+    REQUIRE(editor.selected_text() == "llo w");
+}
+
+TEST_CASE("TextEditor host mouse press plus legacy drag selects text",
+          "[view][text_editor][selection][drag][plugin-host]") {
+    TextEditor editor;
+    editor.set_text("hello world");
+    editor.set_bounds({0, 0, 200, 30});
+
+    constexpr float char_w = 13.0f * 0.6f;
+    const Point press_pos{9.0f + 2.0f * char_w, 15.0f};
+    const Point drag_pos{9.0f + 7.0f * char_w, 15.0f};
+
+    // macOS WindowHost and PluginViewHost dispatch a rich press event, then
+    // the legacy widget callback. Drag ticks arrive through the legacy path.
+    MouseEvent press;
+    press.position = press_pos;
+    press.is_down = true;
+    press.phase = MousePhase::press;
+    editor.on_mouse_event(press);
+    editor.on_mouse_down(press_pos);
+    editor.on_mouse_drag(drag_pos);
+
+    REQUIRE(editor.has_selection());
+    REQUIRE(editor.selected_text() == "llo w");
 }
 
 TEST_CASE("TextEditor mouse double-click selects the exact word under the cursor",


### PR DESCRIPTION
## Summary
- keep AU v2 render-time host parameter pulls from overwriting fresh custom-editor StateStore writes
- let printable key events fall through from non-text plugin controls so host musical typing keeps working
- add mac plugin key-dispatch coverage and AU parameter-state regression coverage

## Root Cause
The AU v2 render path pulled every host global value into StateStore every block. In Logic, a clicked custom editor value such as Freeze could be written to the store, then immediately overwritten by the host stale value before the main-thread AU listener had mirrored the new value back to the host. Separately, focused non-text plugin controls consumed printable key events, which could suppress host musical typing until the user clicked blank plugin space.

## Verification
- `rg "^CMAKE_BUILD_TYPE:|^CMAKE_CXX_FLAGS_RELEASE:|^CMAKE_CXX_FLAGS:" build/CMakeCache.txt` -> `Release`, `-O3 -DNDEBUG`
- `cmake --build build --target pulp-test-mac-perform-key-equivalent pulp-test-au-plugin-state pulp-test-au-v2-effect -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-mac-perform-key-equivalent --reporter compact`
- `./build/test/pulp-test-au-plugin-state --reporter compact`
- `./build/test/pulp-test-au-v2-effect --reporter compact`

Note: local push used `PULP_SKIP_DIFF_COVER=1` because this checkout lacks the Skia design-tool dependency required by the local coverage configuration; pre-push skill/version/compat/node-ABI/hotspot/docs gates passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AU v2 editor-to-host state sync and keyboard handling so UI changes persist and DAW musical typing keeps working. Adds safer UTF‑8 text measurement and an optional headless package-audit mode.

- **Bug Fixes**
  - AU v2 effect and instrument: mirror editor `StateStore` writes to AU parameter storage on the main thread, only pull host globals when they changed (host snapshot), and publish diffs after render; the instrument also sends begin/end gesture callbacks for undo and keeps a param-events sidecar. Prevents overwrite races in Logic.
  - Plugin views: route `keyDown:` and `performKeyEquivalent:` through a focused path so printable keys from non‑text controls fall through to the host, while text-capable controls still receive characters; improved focus/first‑responder and `acceptsFirstMouse`.
  - Text input and rendering: add `safe_utf8_prefix_size`, lossy UTF‑8 sanitization, and a CG override of `text_x_for_byte`; update `TextEditor` to use press/drag/release phases and drag‑selection without measuring split UTF‑8 bytes.
  - Settings panel: place input/output meters next to their device selectors and correct channel expectations.

- **New Features**
  - Standalone package audit mode: run headless without a screenshot via `PULP_STANDALONE_PACKAGE_AUDIT` and optional `PULP_STANDALONE_PACKAGE_AUDIT_SECONDS`.

<sup>Written for commit ce52e05585b45f0f9b025b118038c8504fc00450. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/3991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

