### PR TITLE
docs: link public shipping guide from migration notes

### DIFF
--- a/docs/guides/coming-from-juce.md
+++ b/docs/guides/coming-from-juce.md
@@ -64,7 +64,7 @@ pulp ⏵  `pulp validate`. Discovers installed validators, reports
 the host environment and reports which validators ran, were missing,
 or were broken. There is also a *hard*
 "no install without validation" policy in `pulp ship` — see
-[plugin-install-policy](../../CLAUDE.md#plugin-install-policy).
+[Shipping Guide](shipping.md).
 
 If you were running pluginval manually and patching for `strictness=10`
 mismatches: that's `--strict` in Pulp.


### PR DESCRIPTION
## Summary
- replace the migration guide's internal CLAUDE.md plugin-install-policy link with the public Shipping Guide

## Validation
- git diff --check origin/main...HEAD
- stale CLAUDE.md link scan over docs/guides/coming-from-juce.md and docs/guides/shipping.md
- tools/check-docs.sh (passed with existing warning-mode docs-index/status-ladder warnings)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the JUCE migration guide to link the public Shipping Guide instead of the internal CLAUDE.md plugin-install-policy anchor. Fixes the stale link and directs users to the correct policy docs.

<sup>Written for commit 17144dfe2c657c653787fc877e1aa6c6f1be8d80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

