### PR TITLE
docs: add local CI routing profile

### DIFF
--- a/.shipyard/ci-profiles/normal-local-fast.toml
+++ b/.shipyard/ci-profiles/normal-local-fast.toml
@@ -1,0 +1,87 @@
+# Pulp CI routing profile.
+#
+# PR: fast pull-request/default validation.
+# Release: conservative release workflows.
+# Coverage: coverage-producing workflows; local coverage must use clean
+#     ephemeral VM labels, not warm bare-metal build pools.
+# Scheduled: periodic main validation. GitHub-hosted Intel Linux/Windows remains
+#     authoritative for x64 compatibility.
+# issue_on_failure: scheduled jobs may create/update deduped issues. PR failures
+#     should stay on the PR.
+#
+# This file mirrors the tartci `normal-local-fast` profile vocabulary so
+# Shipyard/agents can explain or apply the same policy from the Pulp checkout.
+
+name = "normal-local-fast"
+description = "Fast PRs on local ARM64 VMs; nightly GitHub Intel validation."
+
+[repo."danielraffel/pulp".pr.macos]
+strategy = "ordered-fallback"
+targets = ["macstudio.macos-arm64-vm", "m5.macos-arm64-vm", "github.macos-arm64"]
+github_variable = "PULP_LOCAL_MACOS_RUNS_ON_JSON"
+
+[repo."danielraffel/pulp".pr.linux]
+strategy = "ordered-fallback"
+targets = ["macstudio.linux-arm64-vm", "m5.linux-arm64-vm", "github.linux-x64"]
+github_variable = "PULP_LOCAL_LINUX_RUNS_ON_JSON"
+
+[repo."danielraffel/pulp".pr.windows]
+strategy = "ordered-fallback"
+targets = ["macstudio.windows-arm64-qemu", "github.windows-x64"]
+github_variable = "PULP_LOCAL_WINDOWS_RUNS_ON_JSON"
+
+[repo."danielraffel/pulp".release.macos]
+strategy = "ordered-fallback"
+targets = ["macstudio.macos-arm64-release-vm", "github.macos-arm64"]
+github_variable = "PULP_RELEASE_MACOS_RUNS_ON_JSON"
+
+[repo."danielraffel/pulp".coverage.macos]
+strategy = "ordered-fallback"
+targets = ["macstudio.macos-arm64-coverage-vm", "github.macos-arm64"]
+github_variable = "PULP_COVERAGE_MACOS_RUNS_ON_JSON"
+ephemeral_required = true
+
+[repo."danielraffel/pulp".coverage.windows]
+strategy = "github-only"
+targets = ["github.windows-x64"]
+github_variable = "PULP_COVERAGE_WINDOWS_RUNS_ON_JSON"
+
+[repo."danielraffel/pulp".scheduled.nightly_intel]
+enabled = true
+branch = "main"
+workflow = "cross-platform-check.yml"
+targets = ["github.linux-x64", "github.windows-x64"]
+issue_on_failure = true
+
+[targets."macstudio.macos-arm64-vm"]
+runs_on_json = ["self-hosted", "macOS", "ARM64", "pulp-build", "pulp-build-vm"]
+
+[targets."m5.macos-arm64-vm"]
+runs_on_json = ["self-hosted", "macOS", "ARM64", "pulp-build", "pulp-build-vm"]
+
+[targets."macstudio.linux-arm64-vm"]
+runs_on_json = ["self-hosted", "Linux", "ARM64", "pulp-build-linux"]
+
+[targets."m5.linux-arm64-vm"]
+runs_on_json = ["self-hosted", "Linux", "ARM64", "pulp-build-linux"]
+
+[targets."macstudio.windows-arm64-qemu"]
+runs_on_json = ["self-hosted", "Windows", "ARM64", "pulp-build-windows"]
+
+[targets."macstudio.macos-arm64-release-vm"]
+runs_on_json = ["self-hosted", "macOS", "ARM64", "pulp-build-vm-release"]
+
+[targets."macstudio.macos-arm64-coverage-vm"]
+runs_on_json = ["self-hosted", "macOS", "ARM64", "pulp-coverage-vm-macos"]
+ephemeral = true
+
+[targets."github.macos-arm64"]
+runs_on_json = "macos-15"
+
+[targets."github.linux-x64"]
+runs_on_json = "ubuntu-latest"
+authoritative_for = ["linux-x64"]
+
+[targets."github.windows-x64"]
+runs_on_json = "windows-latest"
+authoritative_for = ["windows-x64"]

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -663,14 +663,32 @@ one job. Nothing more.
 | `PULP_NAMESPACE_BUILD_LINUX_RUNS_ON_JSON` | Namespace | `gh variable set PULP_NAMESPACE_BUILD_LINUX_RUNS_ON_JSON --body '["namespace-profile-generouscorp"]'` |
 | `PULP_NAMESPACE_BUILD_WINDOWS_RUNS_ON_JSON` | Namespace | `gh variable set PULP_NAMESPACE_BUILD_WINDOWS_RUNS_ON_JSON --body '["namespace-profile-generouscorp-windows"]'` |
 | `PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON` | Namespace (optional) | `gh variable set PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON --body '"namespace-profile-generouscorp-macos"'` |
-| `PULP_LOCAL_MAC_RUNS_ON_JSON` | Local (reserved for a follow-up PR) | `gh variable set PULP_LOCAL_MAC_RUNS_ON_JSON --body '["self-hosted","macos","arm64","build"]'` |
-| `PULP_LOCAL_LINUX_RUNS_ON_JSON` | Local (reserved for a follow-up PR) | `gh variable set PULP_LOCAL_LINUX_RUNS_ON_JSON --body '["self-hosted","linux","arm64","build"]'` |
-| `PULP_LOCAL_WINDOWS_RUNS_ON_JSON` | Local (reserved for a follow-up PR) | `gh variable set PULP_LOCAL_WINDOWS_RUNS_ON_JSON --body '["self-hosted","windows","x64","build"]'` |
+| `PULP_LOCAL_MACOS_RUNS_ON_JSON` | Local macOS ARM64 VM pool | `gh variable set PULP_LOCAL_MACOS_RUNS_ON_JSON --body '["self-hosted","macOS","ARM64","pulp-build","pulp-build-vm"]'` |
+| `PULP_LOCAL_LINUX_RUNS_ON_JSON` | Local Linux ARM64 VM pool | `gh variable set PULP_LOCAL_LINUX_RUNS_ON_JSON --body '["self-hosted","Linux","ARM64","pulp-build-linux"]'` |
+| `PULP_LOCAL_WINDOWS_RUNS_ON_JSON` | Local Windows ARM64 QEMU pool | `gh variable set PULP_LOCAL_WINDOWS_RUNS_ON_JSON --body '["self-hosted","Windows","ARM64","pulp-build-windows"]'` |
 
-The `PULP_LOCAL_*_RUNS_ON_JSON` family is recognized by the shared
-resolver, but `build.yml` currently does not pass a `--local-env` for
-those legs. Wiring `local` into `build.yml`'s Linux/Windows legs is a
-separate follow-up; call that out in the PR that does it.
+`.shipyard/ci-profiles/normal-local-fast.toml` is the repo-local profile that documents the
+intended default policy: PR macOS, Linux, and Windows prefer local ARM64 VMs
+where available, while GitHub-hosted x64 Linux/Windows remains the scheduled
+compatibility safety net. Use `shipyard ci profile plan normal-local-fast --repo
+danielraffel/pulp --json` from the Pulp checkout to see the concrete variable
+values before changing repository variables.
+
+Do not put ordered fallback chains directly into GitHub Actions. GitHub receives
+one `runs-on` selector per job; Shipyard/tartci must resolve "Mac Studio, then
+M5/blackbook, then GitHub" before dispatch or variable application.
+
+Windows local QEMU is Windows ARM64. An x64 MSVC/Prism smoke can be useful, but
+it is not a replacement for the GitHub-hosted `windows-latest` Intel/x64 signal
+until explicitly proven.
+
+### Nightly GitHub Intel validation
+
+`.github/workflows/cross-platform-check.yml` is the scheduled Linux/Windows
+Intel safety net for this profile. It runs GitHub-hosted `ubuntu-latest` and
+`windows-latest`, files or updates one deduped issue per broken platform, and
+auto-closes the tracker when the platform recovers. Do not add a duplicate
+nightly Intel workflow unless this one is deliberately retired.
 
 ### `sanitizers.yml` — per-sanitizer target selection
 


### PR DESCRIPTION
## Summary\n- add `.shipyard/ci-profiles/normal-local-fast.toml` for Pulp local/GitHub CI routing\n- document local ARM64 PR lanes vs nightly GitHub Intel Linux/Windows validation\n- clarify that fallback chains are resolved before dispatch and GitHub receives one concrete `runs-on` selector\n\n## Validation\n- parsed `.shipyard/ci-profiles/normal-local-fast.toml` with Python `tomllib`\n- `shipyard ci profile plan normal-local-fast --repo danielraffel/pulp --json` from the clean Shipyard branch\n- Pulp pre-push gates passed with `PULP_VIA_SHIPYARD=1 git push`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a repo-local CI routing profile that mirrors `tartci` to speed up PRs by preferring local ARM64 VMs, with nightly GitHub Intel Linux/Windows as the x64 safety net. Updates the local CI guide with variable examples, fallback rules, and scheduled checks with deduped issue tracking.

- New Features
  - Added `.shipyard/ci-profiles/normal-local-fast.toml` with ordered fallbacks for PR macOS/Linux/Windows, release, and coverage lanes; macOS coverage uses ephemeral VMs; Windows coverage is GitHub-only. Includes a nightly `cross-platform-check.yml` on `ubuntu-latest` and `windows-latest` that files and auto-closes deduped issues.
  - Documented `PULP_LOCAL_*_RUNS_ON_JSON` values and how to preview plans via `shipyard ci profile plan normal-local-fast --repo `danielraffel/pulp` --json`. Clarified that Shipyard resolves fallback chains before dispatch so GitHub gets one `runs-on`.
  - Noted that Windows local is ARM64; GitHub `windows-latest` is the authoritative x64 signal.

<sup>Written for commit 96692673a97b9c072fdb3ce1ba82b96f434a2f4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

