### PR TITLE
test(validation): require host matrix capability evidence

### DIFF
--- a/docs/guides/host-matrix.md
+++ b/docs/guides/host-matrix.md
@@ -111,8 +111,10 @@ host session; speculative accommodations belong in the host-quirks catalog until
 bench evidence exists.
 
 Current checked-in matrix state has one usable REAPER VST3 row backed by the
-dated DAW-bench evidence above. Do not promote any additional row out of `—`
-until the matching evidence manifest validates.
+dated DAW-bench evidence above and one usable REAPER CLAP row backed by the
+same dated evidence folder. Do not promote any additional row or capability
+cell out of `—` until the matching evidence manifest validates and confirms
+that capability.
 
 ## See also
 

--- a/docs/validation/daw-bench/results/2026-06-12/06-reaper-vst3.md
+++ b/docs/validation/daw-bench/results/2026-06-12/06-reaper-vst3.md
@@ -20,6 +20,15 @@ The run produced `session_start`, `define_parameters`, repeated
 `process_without_prepare`, `sidechain_edge`, `view_opened`, `view_resized`, and
 `serialize_plugin_state` events.
 
+## Capability Evidence
+
+| Capability | Observed | Notes |
+|------------|----------|-------|
+| Load | Confirmed | Log contains `session_start`, `define_parameters`, and `prepare` events. |
+| Params | Confirmed | Log contains `define_parameters` and `serialize_plugin_state` events. |
+| Sidechain | Confirmed | Log contains a `sidechain_edge` event. |
+| Multi-bus | Confirmed | Log contains repeated `bus_layout_proposal` events with a multi-input arrangement. |
+
 ## Result
 
 | Quirk flag | Row | Observed | Notes |

--- a/docs/validation/daw-bench/results/2026-06-12/07-reaper-clap.md
+++ b/docs/validation/daw-bench/results/2026-06-12/07-reaper-clap.md
@@ -22,6 +22,14 @@ The run produced `session_start`, `define_parameters`, `prepare`,
 sample-rate-drift rendering, FX-chain reload/deserialization, MIDI input, or
 editor UI behavior.
 
+## Capability Evidence
+
+| Capability | Observed | Notes |
+|------------|----------|-------|
+| Load | Confirmed | Log contains `session_start`, `define_parameters`, and `prepare` events. |
+| Params | Confirmed | Log contains `define_parameters` and `serialize_plugin_state` events. |
+| Sidechain | Confirmed | Log contains a `sidechain_edge` event. |
+
 ## Result
 
 | Quirk flag | Row | Observed | Notes |

--- a/docs/validation/daw-bench/results/2026-06-12/reaper-clap.daw-bench.json
+++ b/docs/validation/daw-bench/results/2026-06-12/reaper-clap.daw-bench.json
@@ -10,6 +10,23 @@
   "plugin_version": "1.0.0",
   "result_markdown": "07-reaper-clap.md",
   "logs": ["logs/REAPER-CLAP-20260612T211307Z-pid73106.log"],
+  "capabilities": [
+    {
+      "capability": "load",
+      "observed": "Confirmed",
+      "notes": "The checked-in log contains session_start, define_parameters, and prepare events for the CLAP instance."
+    },
+    {
+      "capability": "params",
+      "observed": "Confirmed",
+      "notes": "The checked-in log contains define_parameters and serialize_plugin_state events."
+    },
+    {
+      "capability": "sidechain",
+      "observed": "Confirmed",
+      "notes": "The checked-in log contains a sidechain_edge event."
+    }
+  ],
   "quirks": [
     {
       "flag": "reaper_process_while_bypassed",

--- a/docs/validation/daw-bench/results/2026-06-12/reaper-vst3.daw-bench.json
+++ b/docs/validation/daw-bench/results/2026-06-12/reaper-vst3.daw-bench.json
@@ -10,6 +10,28 @@
   "plugin_version": "1.0.0",
   "result_markdown": "06-reaper-vst3.md",
   "logs": ["logs/REAPER-VST3-20260612T172051Z-pid5104.log"],
+  "capabilities": [
+    {
+      "capability": "load",
+      "observed": "Confirmed",
+      "notes": "The checked-in log contains session_start, define_parameters, and prepare events for the VST3 instance."
+    },
+    {
+      "capability": "params",
+      "observed": "Confirmed",
+      "notes": "The checked-in log contains define_parameters and serialize_plugin_state events."
+    },
+    {
+      "capability": "sidechain",
+      "observed": "Confirmed",
+      "notes": "The checked-in log contains a sidechain_edge event."
+    },
+    {
+      "capability": "multi-bus",
+      "observed": "Confirmed",
+      "notes": "The checked-in log contains repeated bus_layout_proposal events with a multi-input arrangement."
+    }
+  ],
   "quirks": [
     {
       "flag": "reaper_vst3_gesture_ordering",

--- a/docs/validation/daw-bench/results/README.md
+++ b/docs/validation/daw-bench/results/README.md
@@ -57,6 +57,13 @@ contradict the listed logs.
   "plugin_version": "0.395.0",
   "result_markdown": "06-reaper-vst3.md",
   "logs": ["logs/Reaper-VST3-20260612T120000Z-pid42.log"],
+  "capabilities": [
+    {
+      "capability": "load",
+      "observed": "Confirmed",
+      "notes": "session_start and prepare events appeared in the checked-in log"
+    }
+  ],
   "quirks": [
     {
       "flag": "reaper_process_while_bypassed",
@@ -71,3 +78,11 @@ contradict the listed logs.
 Allowed `format` values: `AU`, `AUv3`, `CLAP`, `Standalone`, `VST3`.
 
 Allowed `quirks[].observed` values: `Confirmed`, `Refuted`, `Not Triggered`.
+
+`capabilities` is optional for historical manifests but required for any
+host-matrix cell promotion. Use lowercase capability identifiers matching the
+matrix column names after normalization, such as `load`, `params`, `midi`,
+`sidechain`, `multi-bus`, and `ara`. A promoted matrix cell must have a matching
+manifest for the host/format lane and a `Confirmed` capability entry. The
+validator cross-checks known capabilities against checked-in log events when
+logs are present.

--- a/tools/scripts/check_daw_bench_evidence.py
+++ b/tools/scripts/check_daw_bench_evidence.py
@@ -69,6 +69,16 @@ FLAG_LOG_EVENTS: dict[str, tuple[str, ...]] = {
     "logic_au_tail_time_conversion": ("prepare",),
 }
 
+CAPABILITY_RE = re.compile(r"^[a-z][a-z0-9_-]*$")
+CAPABILITY_LOG_EVENTS: dict[str, tuple[str, ...]] = {
+    "ara": ("begin_editing",),
+    "load": ("session_start", "prepare"),
+    "midi": ("midi_in",),
+    "multi-bus": ("bus_layout_proposal",),
+    "params": ("define_parameters", "serialize_plugin_state"),
+    "sidechain": ("sidechain_edge",),
+}
+
 
 @dataclass(frozen=True)
 class ValidationResult:
@@ -148,6 +158,38 @@ def _validate_quirks(data: dict[str, Any]) -> list[str]:
     return errors
 
 
+def _validate_capabilities(data: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    capabilities = data.get("capabilities")
+    if capabilities is None:
+        return []
+    if not isinstance(capabilities, list):
+        return ["capabilities must be an array when present"]
+
+    seen: set[str] = set()
+    for index, capability in enumerate(capabilities):
+        prefix = f"capabilities[{index}]"
+        if not isinstance(capability, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+        name = capability.get("capability")
+        observed = capability.get("observed")
+        notes = capability.get("notes")
+        if not isinstance(name, str) or not CAPABILITY_RE.match(name):
+            errors.append(f"{prefix}.capability must be a capability identifier")
+        elif name in seen:
+            errors.append(f"{prefix}.capability duplicates {name}")
+        else:
+            seen.add(name)
+        if observed not in ALLOWED_RESULTS:
+            errors.append(
+                f"{prefix}.observed must be one of: {', '.join(sorted(ALLOWED_RESULTS))}"
+            )
+        if not isinstance(notes, str) or not notes.strip() or _is_placeholder(notes):
+            errors.append(f"{prefix}.notes must describe the observed evidence")
+    return errors
+
+
 def _events_in_log(path: pathlib.Path) -> set[str]:
     events: set[str] = set()
     try:
@@ -197,6 +239,33 @@ def _validate_claimed_log_events(
         elif observed == "Not Triggered" and found:
             errors.append(
                 f"quirks[{index}] {flag} is Not Triggered but checked-in logs "
+                f"contain expected event(s): {', '.join(found)}"
+            )
+
+    capabilities = data.get("capabilities")
+    if not isinstance(capabilities, list):
+        return errors
+
+    for index, capability in enumerate(capabilities):
+        if not isinstance(capability, dict):
+            continue
+        name = capability.get("capability")
+        observed = capability.get("observed")
+        if not isinstance(name, str):
+            continue
+        expected_events = CAPABILITY_LOG_EVENTS.get(name)
+        if not expected_events:
+            continue
+        found = sorted(set(expected_events).intersection(observed_events))
+        expected = ", ".join(expected_events)
+        if observed == "Confirmed" and not found:
+            errors.append(
+                f"capabilities[{index}] {name} is Confirmed but checked-in logs "
+                f"do not contain expected event(s): {expected}"
+            )
+        elif observed == "Not Triggered" and found:
+            errors.append(
+                f"capabilities[{index}] {name} is Not Triggered but checked-in logs "
                 f"contain expected event(s): {', '.join(found)}"
             )
     return errors
@@ -271,6 +340,7 @@ def validate_manifest(path: pathlib.Path, *, repo_root: pathlib.Path = REPO_ROOT
         errors.append("provide at least one checked-in log or external_log_url")
 
     errors.extend(_validate_quirks(data))
+    errors.extend(_validate_capabilities(data))
     errors.extend(_validate_claimed_log_events(data, log_paths))
     return ValidationResult(path, tuple(errors))
 

--- a/tools/scripts/check_daw_bench_evidence.py
+++ b/tools/scripts/check_daw_bench_evidence.py
@@ -78,6 +78,7 @@ CAPABILITY_LOG_EVENTS: dict[str, tuple[str, ...]] = {
     "params": ("define_parameters", "serialize_plugin_state"),
     "sidechain": ("sidechain_edge",),
 }
+CAPABILITY_EVENT_MATCH_ALL = {"params"}
 
 
 @dataclass(frozen=True)
@@ -258,11 +259,19 @@ def _validate_claimed_log_events(
             continue
         found = sorted(set(expected_events).intersection(observed_events))
         expected = ", ".join(expected_events)
-        if observed == "Confirmed" and not found:
-            errors.append(
-                f"capabilities[{index}] {name} is Confirmed but checked-in logs "
-                f"do not contain expected event(s): {expected}"
-            )
+        if observed == "Confirmed":
+            if name in CAPABILITY_EVENT_MATCH_ALL:
+                missing = [event for event in expected_events if event not in observed_events]
+                if missing:
+                    errors.append(
+                        f"capabilities[{index}] {name} is Confirmed but checked-in logs "
+                        f"do not contain required event(s): {', '.join(missing)}"
+                    )
+            elif not found:
+                errors.append(
+                    f"capabilities[{index}] {name} is Confirmed but checked-in logs "
+                    f"do not contain expected event(s): {expected}"
+                )
         elif observed == "Not Triggered" and found:
             errors.append(
                 f"capabilities[{index}] {name} is Not Triggered but checked-in logs "

--- a/tools/scripts/check_host_matrix_evidence.py
+++ b/tools/scripts/check_host_matrix_evidence.py
@@ -119,7 +119,7 @@ def _manifest_matches_lane(path: pathlib.Path, *, host: str, fmt: str) -> bool:
     )
 
 
-def _manifest_confirms_capability(path: pathlib.Path, capability: str) -> bool:
+def _manifest_observes_capability(path: pathlib.Path, capability: str, observed: str) -> bool:
     try:
         data: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
@@ -132,9 +132,9 @@ def _manifest_confirms_capability(path: pathlib.Path, capability: str) -> bool:
         if not isinstance(item, dict):
             continue
         name = item.get("capability")
-        observed = item.get("observed")
+        actual = item.get("observed")
         if isinstance(name, str) and _normalize(name) == expected:
-            return observed == "Confirmed"
+            return actual == observed
     return False
 
 
@@ -193,10 +193,14 @@ def validate_matrix(
         for capability, status in row.capabilities.items():
             if status not in PROMOTED_STATUSES:
                 continue
-            if not any(_manifest_confirms_capability(path, capability) for path in matching_manifests):
+            required_observed = "Refuted" if status == "🔴" else "Confirmed"
+            if not any(
+                _manifest_observes_capability(path, capability, required_observed)
+                for path in matching_manifests
+            ):
                 errors.append(
                     f"{matrix_path}:{row.line} no valid DAW-bench manifest confirms "
-                    f"{row.format}/{row.host} capability {capability}"
+                    f"{row.format}/{row.host} capability {capability} as {required_observed}"
                 )
 
     return MatrixCheck(matrix_path, tuple(errors))

--- a/tools/scripts/check_host_matrix_evidence.py
+++ b/tools/scripts/check_host_matrix_evidence.py
@@ -26,12 +26,12 @@ class MatrixRow:
     line: int
     format: str
     host: str
-    statuses: tuple[str, ...]
+    capabilities: dict[str, str]
     notes: str
 
     @property
     def promoted(self) -> bool:
-        return any(status in PROMOTED_STATUSES for status in self.statuses)
+        return any(status in PROMOTED_STATUSES for status in self.capabilities.values())
 
 
 @dataclass(frozen=True)
@@ -89,16 +89,16 @@ def parse_matrix(path: pathlib.Path = DEFAULT_MATRIX) -> list[MatrixRow]:
         row = dict(zip(headers, cells))
         host = row.get("Host", "")
         notes = row.get("Notes", "")
-        statuses = tuple(
-            value
+        capabilities = {
+            key: value
             for key, value in row.items()
             if key not in {"Host", "Version", "Notes"} and value not in UNVALIDATED_STATUSES
-        )
+        }
         rows.append(MatrixRow(
             line=lineno,
             format=current_format,
             host=host,
-            statuses=statuses,
+            capabilities=capabilities,
             notes=notes,
         ))
 
@@ -117,6 +117,25 @@ def _manifest_matches_lane(path: pathlib.Path, *, host: str, fmt: str) -> bool:
     return _normalize(str(data.get("host", ""))) == _normalize(host) and (
         _normalize(str(data.get("format", ""))) == _normalize(fmt)
     )
+
+
+def _manifest_confirms_capability(path: pathlib.Path, capability: str) -> bool:
+    try:
+        data: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    capabilities = data.get("capabilities")
+    if not isinstance(capabilities, list):
+        return False
+    expected = _normalize(capability)
+    for item in capabilities:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("capability")
+        observed = item.get("observed")
+        if isinstance(name, str) and _normalize(name) == expected:
+            return observed == "Confirmed"
+    return False
 
 
 def validate_matrix(
@@ -138,7 +157,7 @@ def validate_matrix(
             )
             continue
 
-        lane_matched = False
+        matching_manifests: list[pathlib.Path] = []
         for citation in citations:
             result_dir = (repo_root / citation).resolve()
             if not result_dir.is_dir():
@@ -159,14 +178,26 @@ def validate_matrix(
                     errors.append(f"{matrix_path}:{row.line} invalid evidence {result.path}: {rendered}")
             if any(not result.ok for result in results):
                 continue
-            if any(_manifest_matches_lane(path, host=row.host, fmt=row.format) for path in manifests):
-                lane_matched = True
+            matching_manifests.extend(
+                path for path in manifests
+                if _manifest_matches_lane(path, host=row.host, fmt=row.format)
+            )
 
-        if not lane_matched:
+        if not matching_manifests:
             errors.append(
                 f"{matrix_path}:{row.line} no valid DAW-bench manifest matches "
                 f"{row.format}/{row.host}"
             )
+            continue
+
+        for capability, status in row.capabilities.items():
+            if status not in PROMOTED_STATUSES:
+                continue
+            if not any(_manifest_confirms_capability(path, capability) for path in matching_manifests):
+                errors.append(
+                    f"{matrix_path}:{row.line} no valid DAW-bench manifest confirms "
+                    f"{row.format}/{row.host} capability {capability}"
+                )
 
     return MatrixCheck(matrix_path, tuple(errors))
 

--- a/tools/scripts/summarize_daw_bench_results.py
+++ b/tools/scripts/summarize_daw_bench_results.py
@@ -35,6 +35,7 @@ class ResultSummary:
     confirmed: tuple[str, ...]
     refuted: tuple[str, ...]
     not_triggered: tuple[str, ...]
+    confirmed_capabilities: tuple[str, ...]
 
 
 def _load_manifest(path: pathlib.Path) -> dict[str, Any]:
@@ -58,6 +59,19 @@ def _quirk_flags(data: dict[str, Any], observed: str) -> tuple[str, ...]:
             flag = quirk.get("flag")
             if isinstance(flag, str):
                 out.append(flag)
+    return tuple(sorted(out))
+
+
+def _capability_names(data: dict[str, Any], observed: str) -> tuple[str, ...]:
+    capabilities = data.get("capabilities")
+    if not isinstance(capabilities, list):
+        return ()
+    out: list[str] = []
+    for capability in capabilities:
+        if isinstance(capability, dict) and capability.get("observed") == observed:
+            name = capability.get("capability")
+            if isinstance(name, str):
+                out.append(name)
     return tuple(sorted(out))
 
 
@@ -90,6 +104,7 @@ def load_summaries(
             confirmed=_quirk_flags(data, "Confirmed"),
             refuted=_quirk_flags(data, "Refuted"),
             not_triggered=_quirk_flags(data, "Not Triggered"),
+            confirmed_capabilities=_capability_names(data, "Confirmed"),
         ))
 
     summaries.sort(key=lambda item: (item.date, item.host.casefold(), item.format.casefold()))
@@ -109,22 +124,25 @@ def render_markdown(summaries: list[ResultSummary], *, repo_root: pathlib.Path =
     hosts = sorted({f"{item.host} {item.format}" for item in summaries})
     latest = max(item.date for item in summaries)
     confirmed_total = sum(len(item.confirmed) for item in summaries)
+    capability_total = sum(len(item.confirmed_capabilities) for item in summaries)
     lines.extend([
         f"- Manifests: {len(summaries)}",
         f"- Host/format lanes: {len(hosts)}",
         f"- Latest result date: {latest}",
         f"- Confirmed quirk observations: {confirmed_total}",
+        f"- Confirmed capability observations: {capability_total}",
         "",
         "## Runs",
         "",
-        "| Date | Host | Format | DAW Version | OS | Confirmed | Refuted | Not Triggered | Evidence |",
-        "|------|------|--------|-------------|----|-----------|---------|---------------|----------|",
+        "| Date | Host | Format | DAW Version | OS | Capabilities | Confirmed | Refuted | Not Triggered | Evidence |",
+        "|------|------|--------|-------------|----|--------------|-----------|---------|---------------|----------|",
     ])
 
     for item in summaries:
         lines.append(
             f"| {item.date} | {item.host} | {item.format} | {item.daw_version} | "
-            f"{item.os} | {_join_flags(item.confirmed)} | {_join_flags(item.refuted)} | "
+            f"{item.os} | {_join_flags(item.confirmed_capabilities)} | "
+            f"{_join_flags(item.confirmed)} | {_join_flags(item.refuted)} | "
             f"{_join_flags(item.not_triggered)} | `{item.result_markdown}` |"
         )
 
@@ -157,6 +175,9 @@ def render_json(summaries: list[ResultSummary], *, repo_root: pathlib.Path = REP
         "host_format_count": len({(item.host, item.format) for item in summaries}),
         "latest_result_date": max((item.date for item in summaries), default=None),
         "confirmed_quirk_observations": sum(len(item.confirmed) for item in summaries),
+        "confirmed_capability_observations": sum(
+            len(item.confirmed_capabilities) for item in summaries
+        ),
         "runs": [
             {
                 "date": item.date,
@@ -165,6 +186,7 @@ def render_json(summaries: list[ResultSummary], *, repo_root: pathlib.Path = REP
                 "daw_version": item.daw_version,
                 "os": item.os,
                 "confirmed": list(item.confirmed),
+                "confirmed_capabilities": list(item.confirmed_capabilities),
                 "refuted": list(item.refuted),
                 "not_triggered": list(item.not_triggered),
                 "manifest": _relative(item.manifest, repo_root=repo_root),

--- a/tools/scripts/test_check_daw_bench_evidence.py
+++ b/tools/scripts/test_check_daw_bench_evidence.py
@@ -69,6 +69,7 @@ class DawBenchEvidenceTests(unittest.TestCase):
                "# Filled REAPER result\n")
         _write(result_dir / "logs" / "Reaper-VST3-20260612T120000Z-pid42.log",
                "2026-06-12T12:00:00Z\tsession_start\n"
+               "2026-06-12T12:00:00Z\tserialize_plugin_state\n"
                "2026-06-12T12:00:00Z\tprocess_without_prepare\n")
         return tmp_ctx, root, result_dir
 
@@ -211,6 +212,31 @@ class DawBenchEvidenceTests(unittest.TestCase):
             )
             errors = checker.validate_manifest(path, repo_root=root).errors
             self.assertTrue(any("midi is Confirmed" in error for error in errors))
+
+    def test_params_capability_requires_definition_and_state_events(self) -> None:
+        tmp_ctx, root, result_dir = self._repo()
+        with tmp_ctx:
+            _write(
+                result_dir / "logs" / "Reaper-VST3-20260612T120000Z-pid42.log",
+                "2026-06-12T12:00:00Z\tsession_start\n"
+                "2026-06-12T12:00:00Z\tdefine_parameters\n"
+                "2026-06-12T12:00:00Z\tprocess_without_prepare\n",
+            )
+            path = result_dir / "params-missing-state.daw-bench.json"
+            path.write_text(
+                json.dumps(_manifest(
+                    capabilities=[
+                        {
+                            "capability": "params",
+                            "observed": "Confirmed",
+                            "notes": "Parameter list alone is not enough for params coverage.",
+                        }
+                    ]
+                )),
+                encoding="utf-8",
+            )
+            errors = checker.validate_manifest(path, repo_root=root).errors
+            self.assertTrue(any("serialize_plugin_state" in error for error in errors))
 
     def test_directory_scan_finds_only_manifest_suffix(self) -> None:
         tmp_ctx, _root, result_dir = self._repo()

--- a/tools/scripts/test_check_daw_bench_evidence.py
+++ b/tools/scripts/test_check_daw_bench_evidence.py
@@ -38,6 +38,13 @@ def _manifest(**overrides: object) -> dict[str, object]:
         "plugin_version": "0.395.0",
         "result_markdown": "06-reaper-vst3.md",
         "logs": ["logs/Reaper-VST3-20260612T120000Z-pid42.log"],
+        "capabilities": [
+            {
+                "capability": "load",
+                "observed": "Confirmed",
+                "notes": "session_start appeared in the checked-in log.",
+            }
+        ],
         "quirks": [
             {
                 "flag": "reaper_process_while_bypassed",
@@ -61,6 +68,7 @@ class DawBenchEvidenceTests(unittest.TestCase):
         _write(result_dir / "06-reaper-vst3.md",
                "# Filled REAPER result\n")
         _write(result_dir / "logs" / "Reaper-VST3-20260612T120000Z-pid42.log",
+               "2026-06-12T12:00:00Z\tsession_start\n"
                "2026-06-12T12:00:00Z\tprocess_without_prepare\n")
         return tmp_ctx, root, result_dir
 
@@ -158,6 +166,7 @@ class DawBenchEvidenceTests(unittest.TestCase):
         with tmp_ctx:
             _write(
                 result_dir / "logs" / "Reaper-CLAP-20260612T120000Z-pid43.log",
+                "2026-06-12T12:00:00Z\tsession_start\n"
                 "2026-06-12T12:00:00Z\tprocess_is_playing_edge\tis_playing=true\n",
             )
             _write(root / "docs" / "validation" / "daw-bench" / "07-reaper-clap.md",
@@ -183,6 +192,25 @@ class DawBenchEvidenceTests(unittest.TestCase):
                 encoding="utf-8",
             )
             self.assertEqual(checker.validate_manifest(path, repo_root=root).errors, ())
+
+    def test_confirmed_capability_requires_matching_log_event(self) -> None:
+        tmp_ctx, root, result_dir = self._repo()
+        with tmp_ctx:
+            path = result_dir / "bad-capability.daw-bench.json"
+            path.write_text(
+                json.dumps(_manifest(
+                    capabilities=[
+                        {
+                            "capability": "midi",
+                            "observed": "Confirmed",
+                            "notes": "MIDI was claimed but no midi_in event exists.",
+                        }
+                    ]
+                )),
+                encoding="utf-8",
+            )
+            errors = checker.validate_manifest(path, repo_root=root).errors
+            self.assertTrue(any("midi is Confirmed" in error for error in errors))
 
     def test_directory_scan_finds_only_manifest_suffix(self) -> None:
         tmp_ctx, _root, result_dir = self._repo()

--- a/tools/scripts/test_check_host_matrix_evidence.py
+++ b/tools/scripts/test_check_host_matrix_evidence.py
@@ -87,6 +87,7 @@ class HostMatrixEvidenceTests(unittest.TestCase):
         _write(result_dir / "logs" / "Reaper-VST3-20260612T120000Z-pid42.log",
                "2026-06-12T12:00:00Z\tsession_start\n"
                "2026-06-12T12:00:00Z\tdefine_parameters\n"
+               "2026-06-12T12:00:00Z\tserialize_plugin_state\n"
                "2026-06-12T12:00:00Z\tprocess_without_prepare\n")
         (result_dir / "reaper-vst3.daw-bench.json").write_text(
             json.dumps(_manifest()),
@@ -160,6 +161,34 @@ class HostMatrixEvidenceTests(unittest.TestCase):
                 """))
             errors = matrix_checker.validate_matrix(matrix, repo_root=root).errors
             self.assertTrue(any("capability MIDI" in error for error in errors))
+
+    def test_broken_promoted_cell_accepts_refuted_capability_evidence(self) -> None:
+        tmp_ctx, root, matrix = self._repo()
+        with tmp_ctx:
+            result_dir = root / "docs" / "validation" / "daw-bench" / "results" / "2026-06-12"
+            manifest = _manifest()
+            manifest["capabilities"] = [
+                {
+                    "capability": "midi",
+                    "observed": "Refuted",
+                    "notes": "MIDI was exercised but did not reach the plugin.",
+                }
+            ]
+            (result_dir / "reaper-vst3.daw-bench.json").write_text(
+                json.dumps(manifest),
+                encoding="utf-8",
+            )
+            _write(matrix, textwrap.dedent("""\
+                # Host Compatibility Matrix
+
+                ## VST3
+
+                | Host | Version | MIDI | Notes |
+                |------|---------|------|-------|
+                | Reaper | 7.74 | 🔴 | VST3 bench evidence: `docs/validation/daw-bench/results/2026-06-12/` |
+                """))
+            check = matrix_checker.validate_matrix(matrix, repo_root=root)
+            self.assertEqual(check.errors, ())
 
 
 if __name__ == "__main__":

--- a/tools/scripts/test_check_host_matrix_evidence.py
+++ b/tools/scripts/test_check_host_matrix_evidence.py
@@ -52,6 +52,18 @@ def _manifest(*, host: str = "REAPER", fmt: str = "VST3") -> dict[str, object]:
         "plugin_version": "1.0.0",
         "result_markdown": "06-reaper-vst3.md",
         "logs": ["logs/Reaper-VST3-20260612T120000Z-pid42.log"],
+        "capabilities": [
+            {
+                "capability": "load",
+                "observed": "Confirmed",
+                "notes": "session_start appeared in the checked-in log.",
+            },
+            {
+                "capability": "params",
+                "observed": "Confirmed",
+                "notes": "define_parameters appeared in the checked-in log.",
+            },
+        ],
         "quirks": [
             {
                 "flag": "reaper_process_while_bypassed",
@@ -73,6 +85,8 @@ class HostMatrixEvidenceTests(unittest.TestCase):
         _write(result_dir / "06-reaper-vst3.md",
                "# Filled REAPER result\n")
         _write(result_dir / "logs" / "Reaper-VST3-20260612T120000Z-pid42.log",
+               "2026-06-12T12:00:00Z\tsession_start\n"
+               "2026-06-12T12:00:00Z\tdefine_parameters\n"
                "2026-06-12T12:00:00Z\tprocess_without_prepare\n")
         (result_dir / "reaper-vst3.daw-bench.json").write_text(
             json.dumps(_manifest()),
@@ -131,6 +145,21 @@ class HostMatrixEvidenceTests(unittest.TestCase):
                 """))
             errors = matrix_checker.validate_matrix(matrix, repo_root=root).errors
             self.assertTrue(any("no valid DAW-bench manifest matches VST3/Reaper" in error for error in errors))
+
+    def test_promoted_cell_requires_matching_capability_evidence(self) -> None:
+        tmp_ctx, root, matrix = self._repo()
+        with tmp_ctx:
+            _write(matrix, textwrap.dedent("""\
+                # Host Compatibility Matrix
+
+                ## VST3
+
+                | Host | Version | Load | Params | MIDI | Notes |
+                |------|---------|------|--------|------|-------|
+                | Reaper | 7.74 | 🟡 | 🟡 | 🟡 | VST3 bench evidence: `docs/validation/daw-bench/results/2026-06-12/` |
+                """))
+            errors = matrix_checker.validate_matrix(matrix, repo_root=root).errors
+            self.assertTrue(any("capability MIDI" in error for error in errors))
 
 
 if __name__ == "__main__":

--- a/tools/scripts/test_summarize_daw_bench_results.py
+++ b/tools/scripts/test_summarize_daw_bench_results.py
@@ -51,6 +51,18 @@ def _manifest(**overrides: object) -> dict[str, object]:
         "plugin_version": "1.0.0",
         "result_markdown": "06-reaper-vst3.md",
         "logs": ["logs/Reaper-VST3-20260612T120000Z-pid42.log"],
+        "capabilities": [
+            {
+                "capability": "load",
+                "observed": "Confirmed",
+                "notes": "session_start appeared in the checked-in log.",
+            },
+            {
+                "capability": "params",
+                "observed": "Confirmed",
+                "notes": "define_parameters appeared in the checked-in log.",
+            },
+        ],
         "quirks": [
             {
                 "flag": "reaper_process_while_bypassed",
@@ -80,6 +92,8 @@ class DawBenchSummaryTests(unittest.TestCase):
         _write(result_dir / "06-reaper-vst3.md",
                "# Filled REAPER result\n")
         _write(result_dir / "logs" / "Reaper-VST3-20260612T120000Z-pid42.log",
+               "2026-06-12T12:00:00Z\tsession_start\n"
+               "2026-06-12T12:00:00Z\tdefine_parameters\n"
                "2026-06-12T12:00:00Z\tprocess_without_prepare\n")
         return tmp_ctx, root, result_dir
 
@@ -95,6 +109,7 @@ class DawBenchSummaryTests(unittest.TestCase):
             self.assertEqual(summaries[0].format, "VST3")
             self.assertEqual(summaries[0].confirmed, ("reaper_process_while_bypassed",))
             self.assertEqual(summaries[0].not_triggered, ("reaper_midsession_setstate",))
+            self.assertEqual(summaries[0].confirmed_capabilities, ("load", "params"))
 
     def test_markdown_report_includes_run_and_confirmed_quirk_table(self) -> None:
         tmp_ctx, root, result_dir = self._repo()
@@ -104,7 +119,9 @@ class DawBenchSummaryTests(unittest.TestCase):
             summaries, _results = summary.load_summaries([result_dir], repo_root=root)
             markdown = summary.render_markdown(summaries, repo_root=root)
             self.assertIn("- Manifests: 1", markdown)
+            self.assertIn("- Confirmed capability observations: 2", markdown)
             self.assertIn("| 2026-06-12 | REAPER | VST3 |", markdown)
+            self.assertIn("`load`, `params`", markdown)
             self.assertIn("`reaper_process_while_bypassed`", markdown)
             self.assertIn("docs/validation/daw-bench/results/2026-06-12/reaper-vst3.daw-bench.json", markdown)
 
@@ -119,7 +136,9 @@ class DawBenchSummaryTests(unittest.TestCase):
             self.assertEqual(data["host_format_count"], 1)
             self.assertEqual(data["latest_result_date"], "2026-06-12")
             self.assertEqual(data["confirmed_quirk_observations"], 1)
+            self.assertEqual(data["confirmed_capability_observations"], 2)
             self.assertEqual(data["runs"][0]["confirmed"], ["reaper_process_while_bypassed"])
+            self.assertEqual(data["runs"][0]["confirmed_capabilities"], ["load", "params"])
 
     def test_invalid_manifest_blocks_summary(self) -> None:
         tmp_ctx, root, result_dir = self._repo()

--- a/tools/scripts/test_summarize_daw_bench_results.py
+++ b/tools/scripts/test_summarize_daw_bench_results.py
@@ -94,6 +94,7 @@ class DawBenchSummaryTests(unittest.TestCase):
         _write(result_dir / "logs" / "Reaper-VST3-20260612T120000Z-pid42.log",
                "2026-06-12T12:00:00Z\tsession_start\n"
                "2026-06-12T12:00:00Z\tdefine_parameters\n"
+               "2026-06-12T12:00:00Z\tserialize_plugin_state\n"
                "2026-06-12T12:00:00Z\tprocess_without_prepare\n")
         return tmp_ctx, root, result_dir
 


### PR DESCRIPTION
## Summary
- add machine-readable DAW-bench capability observations for the checked-in REAPER VST3 and CLAP runs
- require promoted host-matrix capability cells to have matching confirmed manifest evidence
- include capability counts in the recurring DAW-bench summary output

## Validation
- python3 tools/scripts/test_check_daw_bench_evidence.py
- python3 tools/scripts/test_check_host_matrix_evidence.py
- python3 tools/scripts/test_summarize_daw_bench_results.py
- python3 tools/scripts/check_daw_bench_evidence.py docs/validation/daw-bench/results/2026-06-12 --require-any
- python3 tools/scripts/check_host_matrix_evidence.py
- python3 tools/scripts/summarize_daw_bench_results.py docs/validation/daw-bench/results --require-any --format json
- git diff --check
- python3 tools/scripts/version_bump_check.py --mode=report
- python3 tools/scripts/docs_sync_check.py --mode=report
- python3 tools/scripts/skill_sync_check.py --mode=report

## Notes
This tightens the remaining Phase 4 host-lab coverage evidence contract without claiming new DAW behavior. The current checked-in evidence now proves 7 capability observations across REAPER VST3 and CLAP.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces capability evidence for host matrix promotions with stricter log checks. Adds machine-readable capability observations to DAW-bench manifests for REAPER VST3 and CLAP; the summary now counts and lists confirmed capabilities per run.

- **New Features**
  - Added a `capabilities` array to DAW-bench manifests with schema validation and log cross-checks for `load`, `params`, `sidechain`, `multi-bus`, `midi`, and `ara` (e.g., `params` requires both `define_parameters` and `serialize_plugin_state`).
  - Host matrix validation now requires each promoted capability cell to have matching evidence in a valid lane-matched manifest: `🟡/🟢` → `Observed: "Confirmed"`, `🔴` → `Observed: "Refuted"`.
  - Updated reports and docs: capability counts, a Capabilities column/table, and clearer rules for promotion; REAPER VST3/CLAP manifests and run pages include confirmed capability evidence.

- **Migration**
  - To promote a matrix cell, ensure a manifest exists for that host/format with the normalized capability name and the required `observed` value (`"Confirmed"` or `"Refuted"` for red cells).
  - Include logs with the expected events for claimed capabilities and run the validators to verify.

<sup>Written for commit 45294a7f2d02975a4e941ddef562c39c255a2edb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

