### PR TITLE
fix(view): round the TextButton border to match its rounded fill

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.431.1
+    VERSION 0.431.2
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/buttons.cpp
+++ b/core/view/src/buttons.cpp
@@ -20,10 +20,12 @@ void TextButton::paint(canvas::Canvas& canvas) {
     canvas.set_fill_color(bg);
     canvas.fill_rounded_rect(0, 0, w, h, r);
 
-    // Border
+    // Border — rounded to match the filled background above (a square
+    // stroke_rect over a rounded fill left visible 90° corners, e.g. the
+    // standalone Settings/Done buttons looked square next to rounded controls).
     canvas.set_stroke_color(canvas::Color::rgba8(100, 100, 110));
     canvas.set_line_width(1.0f);
-    canvas.stroke_rect(0, 0, w, h);
+    canvas.stroke_rounded_rect(0, 0, w, h, r);
 
     // Label — pulp #1407 honors CSS text-overflow: ellipsis when set on
     // the button via setTextOverflow(id, "ellipsis"). Reserves a small

--- a/test/test_gui_components.cpp
+++ b/test/test_gui_components.cpp
@@ -453,7 +453,7 @@ TEST_CASE("TextButton disabled state suppresses click and still paints",
     RecordingCanvas canvas;
     button.paint(canvas);
     REQUIRE(canvas.count(DrawCommand::Type::fill_rounded_rect) == 1);
-    REQUIRE(canvas.count(DrawCommand::Type::stroke_rect) == 1);
+    REQUIRE(canvas.count(DrawCommand::Type::stroke_rounded_rect) == 1);
     REQUIRE(canvas.count(DrawCommand::Type::fill_text) == 1);
 }
 
@@ -933,7 +933,7 @@ TEST_CASE("TextButton paint covers enabled hover and disabled states",
     RecordingCanvas canvas;
     btn.paint(canvas);
     REQUIRE(canvas.count(DrawCommand::Type::fill_rounded_rect) == 1);
-    REQUIRE(canvas.count(DrawCommand::Type::stroke_rect) == 1);
+    REQUIRE(canvas.count(DrawCommand::Type::stroke_rounded_rect) == 1);
     REQUIRE(canvas.count(DrawCommand::Type::fill_text) == 1);
 
     canvas.clear();


### PR DESCRIPTION
TextButton fills a rounded-rect background but stroked a **square** border over it, leaving visible 90° corners — the standalone Settings **Done** button and Audio/MIDI tab buttons looked square next to the rounded controls (and next to the editor's rounded ⚙ Settings gear). Round the border with the same radius as the fill so every TextButton is consistently rounded.

One-line paint fix in `core/view/src/buttons.cpp` (`stroke_rect` → `stroke_rounded_rect`). Follow-up to #4041 (the gear/settings work) — auto-merge fired on #4041 before this commit landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rounded the `TextButton` border to match its rounded fill, removing square corner artifacts and keeping buttons consistent (e.g., Settings Done and Audio/MIDI tabs).

- **Bug Fixes**
  - Switched `stroke_rect` to `stroke_rounded_rect(..., r)` in `core/view/src/buttons.cpp`; updated `test/test_gui_components.cpp` expectations to `stroke_rounded_rect`; bumped version to `0.431.2`.

<sup>Written for commit 022529a6a96dfebd011884dbebe7f20098802f41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

