### PR TITLE
fix(standalone): size audio callback for device's max block, not nominal buffer

### DIFF
--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -976,6 +976,44 @@ overlay (`View::contains_native_overlay()`), the standalone now routes through
 takeSnapshot) so WebView editors are self-verifiable headlessly. A plain Skia UI
 falls through to the back-buffer capture unchanged. See the `screenshot` skill.
 
+## Standalone audio callback: size for the device's MAX block, NOT the nominal buffer
+
+`StandaloneApp::start()` reads `audio_device_->buffer_size()` into
+`config_.buffer_size` and it is tempting to size the processor + every scratch
+buffer to that. **Don't.** The device's nominal buffer is not the largest block
+the render callback can deliver: when the hardware sample rate differs from the
+app's configured rate, CoreAudio (and other backends) splice in a resampler
+(`AudioConverter…fillComplexBuffer` in the crash stack) that pulls the callback
+in *variable, larger-than-nominal* blocks — up to the host's
+`MaximumFramesPerSlice` (4096 by default on macOS). A user simply selecting an
+output device at a different rate is enough to trigger it.
+
+The 2026-06 symptom: a standalone SIGABRT on `com.apple.audio.IOThread.client`,
+~85 min in, in `RealtimePitchTimeProcessor::process` →
+`assert(num_samples <= config_.max_block)`. The processor had been
+`prepare()`d for the nominal buffer; an oversized resampler pull blew the
+assert (and, in NDEBUG, would have overflowed the pre-allocated scratch).
+
+The contract (`core/format/src/standalone.cpp`, `start()` + the audio lambda):
+
+- Compute `max_callback_block_ = std::max(config_.buffer_size, 4096)` once, and
+  use it for `PrepareContext::max_buffer_size`, `test_buffer_`,
+  `silence_buffer_`, and `output_probe_.prepare(...)` — every buffer the
+  callback can write, sized to the MAX, not the nominal.
+- Guard the callback head: if `ctx.buffer_size > max_callback_block_`, fill the
+  output with silence, `log_error` once, and `return` — never let an
+  over-max block reach `process()`. A backend that ignores
+  `MaximumFramesPerSlice` degrades to a one-time warning, not a crash on a real
+  user's machine.
+- The member lives in `standalone.hpp` (`int max_callback_block_`). The audio
+  device's `CallbackContext::buffer_size` is the *actual* frames this block
+  (it can exceed the nominal), so the guard compares against it, not
+  `config_.buffer_size`.
+
+Rule of thumb for any RT host you write: prepare for the worst-case block the
+backend may hand you, then assert/guard against anything larger. Nominal buffer
+size is a hint, not a ceiling.
+
 ## Standalone audio-callback probe tap (Phase 5 observability harness)
 
 `StandaloneApp`'s audio callback carries an optional realtime output-boundary

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.211.0",
+      "version": "0.211.1",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.211.0"
+  "version": "0.211.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.211.0",
+  "version": "0.211.1",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.430.0
+    VERSION 0.431.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/standalone.hpp
+++ b/core/format/include/pulp/format/standalone.hpp
@@ -211,6 +211,15 @@ private:
     std::unique_ptr<view::CommandRegistry> command_registry_;
     std::unique_ptr<view::AudioInspectorWindow> audio_inspector_;
 #endif
+    // The MAXIMUM frames the audio callback may deliver in one block. This is
+    // NOT the nominal buffer_size: when the device runs at a different sample
+    // rate than the app, CoreAudio (and other backends) insert a resampler that
+    // pulls the render callback in variable, larger-than-nominal blocks. The
+    // processor and every scratch buffer are sized to THIS, and the callback
+    // guards against any block beyond it, so an oversized pull can never trip
+    // Processor::process()'s `num_samples <= max_block` assert or overflow the
+    // pre-allocated buffers.
+    int max_callback_block_ = 0;
     audio::Buffer<float> test_buffer_;        // Pre-allocated for audio callback
     audio::Buffer<float> silence_buffer_;    // Pre-allocated silence for missing input
     std::vector<float*> test_ptrs_;           // Pre-allocated channel pointers

--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -142,10 +142,23 @@ bool StandaloneApp::start() {
     config_.sample_rate = audio_device_->sample_rate();
     config_.buffer_size = audio_device_->buffer_size();
 
+    // The device's nominal buffer_size is NOT the largest block the audio
+    // callback can deliver. When the hardware runs at a different sample rate
+    // than the app, CoreAudio (and other backends) insert a resampler that
+    // pulls the render callback in variable, larger-than-nominal blocks — up to
+    // the host's MaximumFramesPerSlice (4096 by default on macOS). Size the
+    // processor and every scratch buffer to this MAX, not the nominal buffer,
+    // so an oversized pull can never trip Processor::process()'s
+    // `num_samples <= max_block` assert or overflow a pre-allocated buffer.
+    // (Diagnosed from a standalone SIGABRT in RealtimePitchTimeProcessor::process
+    // when the output device's rate differed from the app's configured rate.)
+    constexpr int kMaxCallbackBlockFloor = 4096;
+    max_callback_block_ = std::max(config_.buffer_size, kMaxCallbackBlockFloor);
+
     // Prepare processor
     PrepareContext prep;
     prep.sample_rate = config_.sample_rate;
-    prep.max_buffer_size = config_.buffer_size;
+    prep.max_buffer_size = max_callback_block_;
     prep.input_channels = config_.input_channels;
     prep.output_channels = config_.output_channels;
     processor_->prepare(prep);
@@ -154,7 +167,7 @@ bool StandaloneApp::start() {
     test_signal_.set_sample_rate(config_.sample_rate);
     int test_ch = std::max(config_.input_channels, config_.output_channels);
     if (test_ch < 2) test_ch = 2;
-    test_buffer_.resize(static_cast<size_t>(test_ch), static_cast<size_t>(config_.buffer_size));
+    test_buffer_.resize(static_cast<size_t>(test_ch), static_cast<size_t>(max_callback_block_));
     test_ptrs_.resize(static_cast<size_t>(test_ch));
     for (int c = 0; c < test_ch; ++c)
         test_ptrs_[static_cast<size_t>(c)] = test_buffer_.view().channel_ptr(static_cast<size_t>(c));
@@ -164,7 +177,7 @@ bool StandaloneApp::start() {
 
     // Pre-allocate silence buffer for when no input device is available
     int silence_ch = std::max(config_.output_channels, 2);
-    silence_buffer_.resize(static_cast<size_t>(silence_ch), static_cast<size_t>(config_.buffer_size));
+    silence_buffer_.resize(static_cast<size_t>(silence_ch), static_cast<size_t>(max_callback_block_));
     silence_ptrs_.resize(static_cast<size_t>(silence_ch));
     for (int c = 0; c < silence_ch; ++c)
         silence_ptrs_[static_cast<size_t>(c)] = silence_buffer_.view().channel_ptr(static_cast<size_t>(c));
@@ -183,7 +196,7 @@ bool StandaloneApp::start() {
         : std::clamp(config_.audio_scope_window_samples, 1, kMaxScopeWindowSamples);
     probe_capture.capture_frames = std::max(view::AudioWaveformView::kCapacity,
                                             scope_capture_frames);
-    output_probe_.prepare(config_.output_channels, config_.buffer_size,
+    output_probe_.prepare(config_.output_channels, max_callback_block_,
                           config_.sample_rate,
                           audio::AudioProbeStage::kStandaloneOutputBoundary,
                           probe_capture);
@@ -216,6 +229,28 @@ bool StandaloneApp::start() {
         audio::BufferView<float>& output,
         const audio::CallbackContext& ctx)
     {
+        // Hard guard: the processor and all scratch buffers were prepared for at
+        // most `max_callback_block_` frames (see start()). A block beyond that —
+        // which would indicate a backend not honoring MaximumFramesPerSlice —
+        // must never reach process(), or it trips the `num_samples <= max_block`
+        // assert / overflows the buffers. Emit silence and warn once rather than
+        // crash the audio device on a real user's machine.
+        if (ctx.buffer_size > max_callback_block_) {
+            for (size_t c = 0; c < output.num_channels(); ++c) {
+                float* dst = output.channel_ptr(c);
+                std::fill(dst, dst + output.num_samples(), 0.0f);
+            }
+            static bool warned = false;
+            if (!warned) {
+                warned = true;
+                runtime::log_error(
+                    "Standalone: audio block {} exceeds prepared max {} — "
+                    "emitting silence (report this device)",
+                    ctx.buffer_size, max_callback_block_);
+            }
+            return;
+        }
+
         // Collect pending MIDI from the hardware input thread (mutex-guarded
         // accumulator). UI / virtual-keyboard / scripting MIDI is delivered
         // separately via `ui_midi_collector_` (item 3.5 — pulp::midi::


### PR DESCRIPTION
## Problem

The standalone host (`StandaloneApp::start()`) prepared the processor and every scratch buffer to the device's **nominal** `buffer_size`. That is not the largest block the render callback can deliver: when the hardware sample rate differs from the app's configured rate, CoreAudio (and other backends) splice in a resampler that pulls the callback in **variable, larger-than-nominal** blocks — up to the host's `MaximumFramesPerSlice` (4096 default on macOS). A user merely selecting an output device at a different rate is enough to trigger it.

Symptom (2026-06): a standalone **SIGABRT** on `com.apple.audio.IOThread.client`, in `RealtimePitchTimeProcessor::process` → `assert(num_samples <= config_.max_block)` (stack went through `AudioConverter…fillComplexBuffer`). The processor was prepared for the nominal buffer; an oversized resampler pull blew the assert, and in NDEBUG would have overflowed the pre-allocated scratch.

## Fix

- Compute `max_callback_block_ = std::max(config_.buffer_size, 4096)` once in `start()` and use it for `PrepareContext::max_buffer_size`, `test_buffer_`, `silence_buffer_`, and `output_probe_.prepare(...)` — every buffer the callback can write, sized to the MAX.
- Guard the callback head: if `ctx.buffer_size > max_callback_block_`, fill the output with silence, `log_error` once, and `return` — a backend that ignores `MaximumFramesPerSlice` degrades to a one-time warning instead of crashing the audio device on a real user's machine.
- Capture the lesson in the `view-bridge` skill ("size for the device's MAX block, NOT the nominal buffer").

## Test note

The new lines live inside `start()` and the audio render lambda, which require a live audio device; there is no stub-device injection point to exercise them headlessly today. Tracking as a known coverage gap (per the testing policy's pre-existing-gap carve-out) — the change is a crash-safety guard verified by rebuilding the standalone and confirming the prior repro no longer aborts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Size the standalone audio callback for the device’s max block, not the nominal buffer, and add a guard to stop oversized pulls from crashing the IO thread. Fixes the SIGABRT seen when CoreAudio resampling requests blocks larger than nominal.

- **Bug Fixes**
  - Compute `max_callback_block_ = max(buffer_size, 4096)` in `StandaloneApp::start()`.
  - Prepare the processor and buffers to this max: `PrepareContext::max_buffer_size`, `test_buffer_`, `silence_buffer_`, and `output_probe_`.
  - Add a callback guard: if `ctx.buffer_size > max_callback_block_`, emit silence, `log_error` once, and return.
  - Document the rule in the `view-bridge` skill; added `max_callback_block_` to `standalone.hpp`.

- **Dependencies**
  - Bump framework version in `CMakeLists.txt` to `0.431.0`.
  - Bump plugin manifests in `.claude-plugin/*` to `0.211.1`.

<sup>Written for commit 0377ec241b6a2e3bd90993a7ecb87dafb61d64c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

