### PR TITLE
fix(standalone): advance transport clock when dropping an oversize block

### DIFF
--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -1005,6 +1005,11 @@ The contract (`core/format/src/standalone.cpp`, `start()` + the audio lambda):
   over-max block reach `process()`. A backend that ignores
   `MaximumFramesPerSlice` degrades to a one-time warning, not a crash on a real
   user's machine.
+- The silence early-return must STILL advance the transport clock
+  (`transport_position_samples_.fetch_add(ctx.buffer_size, ...)` when
+  `transport_playing`) before returning. The normal path advances after
+  `process()`; an early `return` that skips it lags the transport position —
+  and the MIDI timeline derived from it — by exactly the dropped frames.
 - The member lives in `standalone.hpp` (`int max_callback_block_`). The audio
   device's `CallbackContext::buffer_size` is the *actual* frames this block
   (it can exceed the nominal), so the guard compares against it, not

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.211.1",
+      "version": "0.211.2",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.211.1"
+  "version": "0.211.2"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.211.1",
+  "version": "0.211.2",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.431.0
+    VERSION 0.431.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -248,6 +248,14 @@ bool StandaloneApp::start() {
                     "emitting silence (report this device)",
                     ctx.buffer_size, max_callback_block_);
             }
+            // Keep the transport clock monotonic across the dropped block.
+            // The normal path advances by ctx.buffer_size after process();
+            // skipping it here would lag transport position (and the MIDI
+            // timeline derived from it) by exactly the silenced frames.
+            if (config_.transport_playing) {
+                transport_position_samples_.fetch_add(
+                    ctx.buffer_size, std::memory_order_relaxed);
+            }
             return;
         }
 


### PR DESCRIPTION
## Problem

Follow-up to #4049. The oversize-block safety guard added there returns *before* the audio callback's transport-position advance:

```cpp
if (ctx.buffer_size > max_callback_block_) {
    // … fill silence, warn once …
    return;   // ← skips the post-process() transport advance
}
```

So whenever an over-max block is silenced, the rolling sample clock (`transport_position_samples_`) — and the MIDI timeline derived from it — lags by exactly the dropped frames. cubic flagged this as **P2** on #4049.

## Fix

Advance `transport_position_samples_` by `ctx.buffer_size` (when transport is playing) inside the guard before the early return, mirroring the normal post-`process()` advance, so the clock stays monotonic across a silenced block. Skill note added to `view-bridge`.

## Test note

Same coverage gap as #4049: the guard lives in the audio render lambda, which needs a live device with no headless stub-injection seam today. Verified by recompiling `pulp-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the transport clock advances when an oversize audio block is silenced, keeping timing and MIDI in sync across dropped frames. Also bumps `pulp` plugin and project versions.

- **Bug Fixes**
  - In the standalone audio callback, advance `transport_position_samples_` by `ctx.buffer_size` on the oversize-block early return when transport is playing.
  - Documented this requirement in `view-bridge` skill notes.

- **Dependencies**
  - Bumped `pulp` plugin manifests to 0.211.2 and project version to 0.431.1.

<sup>Written for commit 0d43364a3c3d2e7538bb64ef090725093ef472ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

