### PR TITLE
docs: explain CI runtime metrics for agents

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -12,6 +12,31 @@ requires:
 
 Validate branches and ship code safely. This skill handles all CI workflows for Pulp across local machines and VMs.
 
+## Runner timing metrics
+
+When asked whether Pulp's local runners are fast, stuck, regressing, or worth
+monitoring, query Shipyard's metrics surface before guessing. Pulp does not
+mirror these records into `pulp` CLI or `pulp-mcp`; Shipyard is the metrics
+store and tartci is an optional VM runtime emitter.
+
+Use these commands as the normal agent loop:
+
+```bash
+shipyard metrics import github --repo danielraffel/pulp --limit 50 --json
+tartci runtime export --repo danielraffel/pulp --since-days 14 \
+  | shipyard metrics import tartci --json
+shipyard metrics summary --project pulp --json
+shipyard metrics watch --project pulp --since 14d --json
+shipyard metrics advise --project pulp --json
+```
+
+Read `watch` as a triage signal, not as a hard failure. `insufficient_samples`
+means the lane does not have enough history yet; drift, failure-rate, or slowest
+findings are the useful prompts to inspect runner logs, VM boot behavior, cache
+state, or GitHub queue time. If tartci is not installed for a repo, skip the
+`tartci runtime export` import and still use the GitHub import plus Shipyard
+summary/watch commands.
+
 > **If a PR's required `macos` check has been queued >30 min** or the
 > repo's PRs are all in `mergeable_state=blocked` with no movement,
 > jump to **"Self-hosted runner ops"** near the end of this file.

--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -19,6 +19,12 @@ monitoring, query Shipyard's metrics surface before guessing. Pulp does not
 mirror these records into `pulp` CLI or `pulp-mcp`; Shipyard is the metrics
 store and tartci is an optional VM runtime emitter.
 
+This metrics surface requires a Shipyard build that includes the
+`shipyard metrics` subcommand. Pulp's current pinned source-checkout Shipyard in
+`tools/shipyard.toml` is `v0.68.0`, which does not include it yet. If a checkout
+only has the pinned binary, use a newer Shipyard binary or source checkout for
+the optional metrics workflow, or skip metrics and inspect live jobs directly.
+
 Use these commands as the normal agent loop:
 
 ```bash

--- a/.agents/skills/tart-ci/SKILL.md
+++ b/.agents/skills/tart-ci/SKILL.md
@@ -31,6 +31,10 @@ The reusable runner path is now the sibling `tartci` repo:
 - `tartci observe macos --json [--runner <name>]` ties GitHub job, local VM,
   guest process, ctest tail, and runner log together.
 - `tartci doctor --reap --json` is the local cleanup/health digest.
+- `TARTCI_RUNTIME_MEASURE=1 tartci serve ...` records per-job VM timings; use
+  `tartci runtime recent|summary|export --repo danielraffel/pulp --json` and
+  pipe exports into `shipyard metrics import tartci` for long-term agent
+  baselines.
 - `shipyard --json runner fleet-status --target macos` is the cross-host pool
   view for macOS VM slots and supervisor freshness.
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ shipyard run                              # validate current branch
 shipyard pr                               # create, track, validate, and merge on green
 ```
 
-Pulp uses [Shipyard](https://github.com/danielraffel/Shipyard) for cross-platform CI — it validates on macOS (local), Linux (SSH), and Windows (SSH), and gates merges on per-SHA evidence across all three platforms. Public Pulp installs include the Pulp CLI only. Source-checkout contributors install the pinned Shipyard tool with `./tools/install-shipyard.sh` for the first install, then use `shipyard update` (Shipyard v0.55.0+) as the preferred in-tool upgrade path; GitHub CLI (`gh`) is only needed for GitHub-facing contributor workflows. See [docs/guides/local-ci.md](docs/guides/local-ci.md) for setup and [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor expectations.
+Pulp uses [Shipyard](https://github.com/danielraffel/Shipyard) for cross-platform CI — it validates on macOS (local), Linux (SSH), and Windows (SSH), and gates merges on per-SHA evidence across all three platforms. Public Pulp installs include the Pulp CLI only. Source-checkout contributors install the pinned Shipyard tool with `./tools/install-shipyard.sh` for the first install, then use `shipyard update` (Shipyard v0.55.0+) as the preferred in-tool upgrade path; GitHub CLI (`gh`) is only needed for GitHub-facing contributor workflows. See [docs/guides/local-ci.md](docs/guides/local-ci.md) for setup, optional Shipyard/tartci runner timing metrics, and [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor expectations.
 
 ### Security & CI policy
 

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -42,6 +42,12 @@ regress?", "which lane should I monitor next?", and "is this worth
 investigating or just within the usual range?" Humans can use the same commands
 for high-level platform comparisons, but no observability service is required.
 
+The `shipyard metrics` commands require a Shipyard build that includes the
+metrics subcommand. Pulp's current pinned source-checkout version in
+`tools/shipyard.toml` is `v0.68.0`, which does not include that surface yet. Use
+a newer Shipyard binary or source checkout for this optional metrics workflow
+until the Pulp pin is bumped.
+
 ```bash
 # Enable VM runtime records on tartci hosts or LaunchAgents.
 export TARTCI_RUNTIME_MEASURE=1

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -22,6 +22,52 @@ shipyard runner watch --kill-hung-workers # prevent self-hosted runner wedges
 shipyard update --check --json            # report installed vs latest
 ```
 
+### Runner timing metrics
+
+Pulp does not store CI timing history in the Pulp CLI or MCP server. When a
+checkout uses Shipyard, and optionally tartci for disposable local VMs,
+Shipyard owns the timing database and query surface:
+
+- Shipyard can import GitHub Actions job timings and local command evidence.
+- tartci can optionally emit per-VM runtime records for macOS, Linux, and
+  Windows VM lanes: boot/setup/run/cleanup durations, labels, host, provider,
+  golden/cache hints, outcome, and failure class.
+- Shipyard imports those tartci records into its local metrics store and exposes
+  agent-readable summaries, slowest lanes, trend/drift checks, comparisons, and
+  placement advice.
+
+This is mainly for agents watching Pulp CI over time. It gives them enough
+history to answer "is this runner behaving normally?", "did boot/build time
+regress?", "which lane should I monitor next?", and "is this worth
+investigating or just within the usual range?" Humans can use the same commands
+for high-level platform comparisons, but no observability service is required.
+
+```bash
+# Enable VM runtime records on tartci hosts or LaunchAgents.
+export TARTCI_RUNTIME_MEASURE=1
+export TARTCI_RUNTIME_GH_ENRICH=1
+
+# Inspect tartci's local VM timing records.
+tartci runtime recent --repo danielraffel/pulp --limit 20 --json
+tartci runtime summary --repo danielraffel/pulp --json
+
+# Import both GitHub Actions and tartci VM timing into Shipyard's metrics store.
+shipyard metrics import github --repo danielraffel/pulp --limit 50 --json
+tartci runtime export --repo danielraffel/pulp --since-days 14 \
+  | shipyard metrics import tartci --json
+
+# Agent-friendly queries.
+shipyard metrics summary --project pulp --json
+shipyard metrics slowest --project pulp --limit 20 --json
+shipyard metrics watch --project pulp --since 14d --json
+shipyard metrics advise --project pulp --json
+```
+
+Use the Shipyard and tartci docs for setup details; this guide only records how
+Pulp expects agents and contributors to consume the optional integration.
+Without tartci, `shipyard metrics import github` and manual/command metrics
+still work for GitHub-hosted or SSH-backed CI lanes.
+
 Pulp intentionally pins Shipyard in `tools/shipyard.toml` even if your daily
 global `shipyard` is newer. Use `shipyard pin bump --to vX.Y.Z` for pin
 updates instead of hand-editing the file; newer Rust Shipyard releases changed


### PR DESCRIPTION
## Summary
- document how Pulp agents should use Shipyard/tartci runner timing metrics
- clarify that Pulp CLI/MCP do not mirror the metrics store
- add CI and tart-ci skill guidance for JSON metrics queries

## Validation
- python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main
- python3 tools/scripts/version_bump_check.py --mode=report --base origin/main
- git diff --check
- pre-push gates on branch push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents how agents use `shipyard` metrics and optional `tartci` runtime records to track CI runner timing and catch regressions. Clarifies that `pulp` CLI and `pulp-mcp` don’t store metrics.

- **New Features**
  - Added runner timing metrics guidance to CI and `tart-ci` skills, and expanded the local CI guide with setup and commands (`TARTCI_RUNTIME_MEASURE`, `TARTCI_RUNTIME_GH_ENRICH`, GitHub import, `tartci runtime export`, `shipyard metrics summary/slowest/watch/advise`). Notes that the `shipyard metrics` subcommand is required; the pinned `shipyard` `v0.68.0` doesn’t include it yet, so use a newer binary/source checkout for this optional workflow.
  - Updated `README` to mention optional `shipyard`/`tartci` timing metrics.

<sup>Written for commit d199a3cafb593dbabb784a5fd4757976ed5f8c16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

