### PR TITLE
ci(coverage): pass llvm-cov objects via response file (fixes Windows ARG_MAX)

### DIFF
--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -315,16 +315,27 @@ if [[ ${#BINARIES[@]} -eq 0 ]]; then
     exit 1
 fi
 
+# A full build probes 1000+ `-object` entries. Passing them inline overflows
+# the Windows command-line length limit (CreateProcess ~32 KB) — llvm-cov dies
+# with "Argument list too long", filters out every source file, and no
+# Cobertura XML is produced (the os-windows coverage leg's failure mode). Feed
+# the object list through an LLVM response file (`@file`, expanded by every LLVM
+# tool's CommandLine parser) so the OS arg-length limit never applies — on any
+# platform. One token per line; the probed paths never contain spaces.
+OBJ_RSP="${REPORT_DIR}/llvm-cov-objects.rsp"
+printf '%s\n' "${BINARIES[@]}" > "${OBJ_RSP}"
+echo "=== Wrote ${#BINARIES[@]} -object tokens to a response file (avoids Windows ARG_MAX) ==="
+
 echo "=== llvm-cov report (top-level summary) ==="
 llvm-cov report \
-    "${BINARIES[@]}" \
+    "@${OBJ_RSP}" \
     -instr-profile="${PROFDATA}" \
     -ignore-filename-regex="${COVERAGE_IGNORE_REGEX}" \
     | tee "${REPORT_DIR}/summary.txt"
 
 echo "=== llvm-cov show (HTML drilldown) ==="
 llvm-cov show \
-    "${BINARIES[@]}" \
+    "@${OBJ_RSP}" \
     -instr-profile="${PROFDATA}" \
     -ignore-filename-regex="${COVERAGE_IGNORE_REGEX}" \
     -format=html \
@@ -364,7 +375,7 @@ fi
 
 echo "=== llvm-cov export → LCOV ==="
 llvm-cov export --format=lcov \
-    "${BINARIES[@]}" \
+    "@${OBJ_RSP}" \
     -instr-profile="${PROFDATA}" \
     -ignore-filename-regex="${COVERAGE_IGNORE_REGEX}" \
     > "${RAW_LCOV_FILE}"

--- a/tools/scripts/test_run_coverage.py
+++ b/tools/scripts/test_run_coverage.py
@@ -151,6 +151,22 @@ class ObjectDiscoveryTests(unittest.TestCase):
             "maps; production archives are enough for full-surface rows.",
         )
 
+    def test_llvm_cov_objects_passed_via_response_file(self) -> None:
+        # A full build probes 1000+ `-object` entries. Passing them inline
+        # overflows the Windows command-line length limit (CreateProcess
+        # ~32 KB) — llvm-cov dies with "Argument list too long", filters out
+        # every source file, and the os-windows coverage leg produces no
+        # Cobertura XML. report/show/export must all read the object list from
+        # an LLVM @response file instead.
+        text = SCRIPT.read_text()
+        self.assertIn('printf \'%s\\n\' "${BINARIES[@]}" > "${OBJ_RSP}"', text,
+                      "object list must be written to a response file")
+        self.assertGreaterEqual(
+            text.count('"@${OBJ_RSP}"'), 3,
+            "llvm-cov report, show, and export must each pass objects via the "
+            "@response file, not inline ${BINARIES[@]}",
+        )
+
     def test_optional_ctest_args_are_threaded_into_ctest_invocation(self) -> None:
         self.assertTrue(
             _script_contains('PULP_COVERAGE_CTEST_ARGS'),


### PR DESCRIPTION
## The real blocker behind the coverage-stale watchdog (#3947)

The macOS coverage VM lane (#4036) is green, but a *full-green main coverage run* never completes because the **os-windows leg fails deterministically**. Root-caused from the failed run on `2c3f3d0d1`:

```
scripts/run_coverage.sh: line 315: /c/Program Files/LLVM/bin/llvm-cov: Argument list too long
##[error]coverage.cobertura.xml is missing or empty.
```

`run_coverage.sh` probes **1000+ `-object` entries** on a full build and passes them **inline** to `llvm-cov report/show/export`. Windows' `CreateProcess` command-line limit (~32 KB) is far smaller than Linux/macOS, so the call overflows → llvm-cov filters out every source file → no Cobertura XML → Codecov finds nothing → the leg exits 1. (The 17 `ctest` failures in that run are already `windows-pr-quarantine`-tagged and intentionally skipped — not the blocker.)

A self-hosted Windows VM (the #3996 "route Windows to a Tart VM" idea) would hit the **identical** limit — this is a script bug, not an ODR/environment one, so the VM lane is not the right tool here.

## Fix
Write the finalized object list to an **LLVM response file** once and pass `@${OBJ_RSP}` to all three `llvm-cov` invocations. Every LLVM tool's CommandLine parser expands `@file`, so the OS arg-length limit never applies — on any platform (harmless on Linux/macOS, load-bearing on Windows).

## Validation
- Proved locally that `llvm-cov report @rsp …` and the inline form reach the **identical** profile-load stage (so `@file` expansion is equivalent to inline args).
- `python3 tools/scripts/test_run_coverage.py` (19, +1 regression test)
- `bash -n scripts/run_coverage.sh`; pre-push gates green.

After this lands, the next scheduled coverage run should be able to produce a full-green cross-OS upload and let the #3947 watchdog auto-close — and **#3996's Windows half becomes unnecessary**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows coverage failures by passing `llvm-cov` object paths via an LLVM response file. This avoids the command-line limit and restores the os-windows coverage leg for full cross-OS coverage uploads.

- Bug Fixes
  - Write probed objects to `@${OBJ_RSP}` and use it in `llvm-cov report/show/export`.
  - Prevents Windows `CreateProcess` arg limit (“Argument list too long”) that led to empty Cobertura output.
  - Adds a regression test to ensure objects are always passed via the response file.

<sup>Written for commit b4a6aae6ab2320338135c6e570eb0e25ace2d465. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

