### PR TITLE
ci(coverage): drop -object entries that vanish after the pre-flight probe

### DIFF
--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -323,8 +323,38 @@ fi
 # tool's CommandLine parser) so the OS arg-length limit never applies — on any
 # platform. One token per line; the probed paths never contain spaces.
 OBJ_RSP="${REPORT_DIR}/llvm-cov-objects.rsp"
-printf '%s\n' "${BINARIES[@]}" > "${OBJ_RSP}"
-echo "=== Wrote ${#BINARIES[@]} -object tokens to a response file (avoids Windows ARG_MAX) ==="
+# Final existence filter while materializing the response file. An -object can
+# vanish between the pre-flight probe above and this point — the observed
+# Windows case is a late-cleaned test-fixture executable (e.g.
+# `test/pulp-cli-run-fixture.exe`) that is still present when the probe loads it
+# but gone by report time. llvm-cov hard-fails the ENTIRE run on a single
+# missing -object ("failed to load coverage: '…': no such file or directory"),
+# so one disappearing fixture would blackhole the whole os-windows leg. Drop any
+# that are no longer present instead.
+: > "${OBJ_RSP}"
+KEPT_OBJECTS=0
+VANISHED_OBJECTS=0
+prev=""
+for tok in "${BINARIES[@]}"; do
+    if [[ "${prev}" == "-object" ]]; then
+        if [[ -f "${tok}" ]]; then
+            printf -- '-object\n%s\n' "${tok}" >> "${OBJ_RSP}"
+            KEPT_OBJECTS=$((KEPT_OBJECTS + 1))
+        else
+            VANISHED_OBJECTS=$((VANISHED_OBJECTS + 1))
+            echo "  ✗ dropping object that vanished after pre-flight: ${tok}" >&2
+        fi
+    fi
+    prev="${tok}"
+done
+if [[ "${VANISHED_OBJECTS}" -gt 0 ]]; then
+    echo "=== Dropped ${VANISHED_OBJECTS} object(s) that vanished after the pre-flight probe ==="
+fi
+if [[ "${KEPT_OBJECTS}" -eq 0 ]]; then
+    echo "run_coverage.sh: existence filter left zero -object entries" >&2
+    exit 1
+fi
+echo "=== Wrote ${KEPT_OBJECTS} -object tokens to a response file (avoids Windows ARG_MAX) ==="
 
 echo "=== llvm-cov report (top-level summary) ==="
 llvm-cov report \

--- a/tools/scripts/test_run_coverage.py
+++ b/tools/scripts/test_run_coverage.py
@@ -159,13 +159,27 @@ class ObjectDiscoveryTests(unittest.TestCase):
         # Cobertura XML. report/show/export must all read the object list from
         # an LLVM @response file instead.
         text = SCRIPT.read_text()
-        self.assertIn('printf \'%s\\n\' "${BINARIES[@]}" > "${OBJ_RSP}"', text,
+        self.assertIn('OBJ_RSP=', text,
                       "object list must be written to a response file")
+        self.assertIn('printf -- \'-object\\n%s\\n\' "${tok}" >> "${OBJ_RSP}"', text,
+                      "response file must be built one -object/path pair at a time")
         self.assertGreaterEqual(
             text.count('"@${OBJ_RSP}"'), 3,
             "llvm-cov report, show, and export must each pass objects via the "
             "@response file, not inline ${BINARIES[@]}",
         )
+
+    def test_objects_that_vanished_after_probe_are_dropped(self) -> None:
+        # An -object can disappear between the pre-flight probe and the report
+        # (a late-cleaned test-fixture .exe on Windows is the observed case).
+        # llvm-cov hard-fails the whole run on one missing -object, so the
+        # response-file builder must existence-check each path and drop the
+        # vanished ones rather than blackhole the os-windows leg.
+        text = SCRIPT.read_text()
+        self.assertIn('if [[ -f "${tok}" ]]; then', text,
+                      "response-file builder must drop objects that no longer exist")
+        self.assertIn("existence filter left zero -object entries", text,
+                      "an empty post-filter object set must fail loudly")
 
     def test_optional_ctest_args_are_threaded_into_ctest_invocation(self) -> None:
         self.assertTrue(


### PR DESCRIPTION
## Next layer of the os-windows coverage fix

After #4070 fixed the `llvm-cov: Argument list too long` (ARG_MAX) failure, the scheduled coverage run on `main` (`27587977783`) confirmed the response file works (`Wrote 1228 -object tokens…`, no more ARG_MAX) — and the os-windows leg advanced to the **next** failure:

```
error: failed to load coverage:
  '.../build-coverage/test/pulp-cli-run-fixture.exe': no such file or directory
##[error]coverage.cobertura.xml is missing or empty.
```

`llvm-cov` hard-fails the **entire** run on one missing `-object`. The pre-flight probe loads each object ~tens of seconds before the report; the late-cleaned test fixture `pulp-cli-run-fixture.exe` passes the probe but is **gone (ENOENT) by report time**, blackholing the whole leg.

## Fix
Existence-check each path while materializing the response file (immediately before `llvm-cov` runs) and drop any that vanished — so one disappearing fixture can't fail the leg. Fails loudly only if the filter empties the set.

## Validation
- `python3 tools/scripts/test_run_coverage.py` (20, +1 regression)
- `bash -n scripts/run_coverage.sh`
- Filter logic functionally verified (keeps a real object, drops a missing one).
- Other coverage legs in that run were already green (macOS-on-VM, Linux, Android, Vitest) — this is the last red leg blocking a full-green main run and #3947's auto-close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a final existence check when building the `llvm-cov` objects response file to drop binaries that vanish after the pre-flight probe. This prevents the Windows coverage leg from failing the entire run on a single missing `-object` and preserves Cobertura output.

- **Bug Fixes**
  - `scripts/run_coverage.sh`: build `@response` file one `-object/path` pair at a time; drop paths that no longer exist; log drops; fail if the post-filter set is empty.
  - `tools/scripts/test_run_coverage.py`: add assertions for the existence filter and the one-pair-at-a-time response file format; keep checks that `report/show/export` use `"@${OBJ_RSP}"`.

<sup>Written for commit 3aea20b4a869ef4bf731d1c25f869e78d5a39580. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

