### PR TITLE
fix(view): release XdndSelection when an XDND outbound drag ends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.437.0
+    VERSION 0.437.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/platform/linux/plugin_view_host_linux.cpp
+++ b/core/view/platform/linux/plugin_view_host_linux.cpp
@@ -542,6 +542,13 @@ private:
         }
 
         XUngrabPointer(display_, CurrentTime);
+        // Relinquish XdndSelection ownership now the drag is over. The success
+        // path has already served the requestor before XdndFinished arrives, so
+        // dropping ownership here is safe; the timeout/cancel paths would
+        // otherwise leak ownership until the next drag re-claims it. (xdnd_target_at
+        // already validates XdndAware before XdndEnter, so no stray enter reaches
+        // a non-XDND app.)
+        XSetSelectionOwner(display_, xa_XdndSelection_, None, CurrentTime);
         XFlush(display_);
         return result;
     }


### PR DESCRIPTION
## What

Follow-up to #4073 (native Win/Linux outbound file drag), addressing the **Linux gesture-proof** + **XDND hygiene** items from an adversarial review.

1. **Outbound XDND gesture test** (`test_plugin_view_host_factory.cpp`) — the mirror of the existing inbound XDND xvfb test. A worker thread runs the real `PluginViewHost::start_file_drag` → `run_xdnd_source` grab loop; the test plays a synthetic XdndAware **target** on a second X connection and drives the host's grabbed pointer via **XTEST**, replying `XdndStatus(accept)`, servicing the `XConvertSelection` round-trip, and asserting the host returned success + served the expected `text/uri-list` (percent-encoded path with a space).
2. **Hardening** (`run_xdnd_source`) — relinquish `XdndSelection` ownership on every exit path (success/timeout/cancel); previously the timeout/cancel paths leaked ownership until the next drag.

## Honest limitations

- **Pulp CI has no `xvfb`**, so this test (like the pre-existing inbound XDND test) **skips in CI** and only executes on a Linux box with a display + `libXtst`. Gated on `PULP_TEST_HAS_XTEST` (FindX11's `X11_XTest_FOUND`) → compiles out cleanly where `libXtst` is absent; never breaks a build.
- A button release always exits `run_xdnd_source`, so a stalled handshake can never wedge on the host's 60s deadline.
- The adversarial review's "no XdndAware check in `xdnd_target_at`" was inaccurate — it already validates; noted in the commit.

## Tests
- New: `[xdnd][linux]` outbound source handshake (runs on Linux+X+libXtst).
- Unchanged inbound XDND handshake test still covers the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases `XdndSelection` when a Linux XDND outbound drag ends, and adds an outbound drag test that validates the XTEST-driven handshake and a percent‑encoded `text/uri-list`.

- **Bug Fixes**
  - Drop `XdndSelection` ownership (`owner = None`) on all exit paths right after `XUngrabPointer` to prevent lingering ownership between drags.

- **Dependencies**
  - Outbound XDND test links against `libXtst` only when `X11_XTest_FOUND` (`PULP_TEST_HAS_XTEST`); skipped without a display.
  - Bump project version to 0.437.1.

<sup>Written for commit 47b78bde1c5f1907ab240f313489c53465351b93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

