### PR TITLE
feat(view): iOS native drag-and-drop (in + out)

### DIFF
--- a/.agents/skills/ios/SKILL.md
+++ b/.agents/skills/ios/SKILL.md
@@ -351,6 +351,38 @@ xcodebuild test -project ... -scheme AUv3Tests -sdk iphonesimulator
   `dismantleUIViewController(_:coordinator:)` hook, and capture the
   container VC weakly inside the closure as a second layer of safety.
 
+### Native drag-and-drop (UIDrop/UIDrag)
+
+- **iOS drag-and-drop is interaction-based, not the AppKit `NSDraggingSession`
+  model.** `plugin_view_host_ios.mm` installs a `PulpIOSDragDrop` coordinator
+  (conforms to `UIDropInteractionDelegate` + `UIDragInteractionDelegate`) on
+  BOTH host views (`PulpPluginUIView` CPU + `PulpMetalPluginView` GPU), bridging
+  to the same cross-platform dispatch core (`dispatch_drag_*` / `dispatch_drop`)
+  the mac/win/linux hosts use.
+- **`start_file_drag()` ARMS, it does not start.** UIKit begins a drag only from
+  the system long-press lift, which calls
+  `dragInteraction:itemsForBeginningSession:`. So `PluginViewHost::start_file_drag`
+  on iOS stages the `FileDragRequest.file_paths` and returns true; the next lift
+  consumes them (`itemsForBeginningSession` returns `@[]` when nothing is armed,
+  so no stray drags). This differs from AppKit, where `begin_file_drag` starts a
+  drag synchronously inside the mouse handler. A Pulp widget that wants outbound
+  drag must call `start_file_drag` during its own long-press handling.
+- **Drop coordinate transform differs by host.** The drop point
+  (`[session locationInView:hostView]`) is root-space directly on the CPU host
+  (identity transform) but must go through the Metal view's **live**
+  `pointTransform` (the inverse design-viewport map touches use) on the GPU host
+  — pass a block capturing the view weakly, not the transform value, so a
+  design-viewport change between install and drop is honoured.
+- **`performDrop` completion runs on the main queue** (UIKit guarantee), so it
+  touches the view tree safely — but capture the coordinator **weakly** and
+  re-check the root pointer inside the block: an async `loadObjectsOfClass:`
+  completion can outlive the host. The coordinator's `invalidate` (called from
+  both host dtors) nils the root so a late completion is a no-op.
+- **No headless test** — UIKit drag/drop is gesture-driven and can't be exercised
+  by the macOS Catch2 suite; validated by local Simulator compile
+  (`clang -fsyntax-only -target arm64-apple-ios…-simulator`) + manual gesture.
+  Same gesture-untestable category as touch input.
+
 ### Accessibility
 
 - `UIAccessibility` is the iOS equivalent of NSAccessibility. `accessibility_ios.mm`

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.213.0",
+      "version": "0.214.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.213.0"
+  "version": "0.214.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.213.0",
+  "version": "0.214.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.437.1
+    VERSION 0.438.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/platform/ios/plugin_view_host_ios.mm
+++ b/core/view/platform/ios/plugin_view_host_ios.mm
@@ -6,10 +6,141 @@
 #if TARGET_OS_IOS
 
 #include <pulp/canvas/cg_canvas.hpp>
+#include <pulp/view/drag_drop.hpp>
 #import <UIKit/UIKit.h>
 #include <algorithm>
 #include <atomic>
+#include <string>
 #include <unordered_map>
+#include <vector>
+
+// ── PulpIOSDragDrop: UIDrop/UIDrag interaction delegate ──────────────────────
+//
+// Bridges UIKit's interaction-based drag-and-drop to Pulp's cross-platform
+// dispatch core (the same dispatch_drag_*/dispatch_drop used by the mac, win,
+// and linux hosts). INBOUND: a UIDropInteraction routes dropped file URLs into
+// dispatch_drop() at the drop point. OUTBOUND: a UIDragInteraction starts a
+// system drag carrying the files staged by PluginViewHost::start_file_drag().
+//
+// Paradigm note: UIKit drags are GESTURE-initiated (the system long-press lift
+// asks the delegate for items), so unlike AppKit's synchronous
+// NSDraggingSession, start_file_drag() cannot begin a drag itself — it ARMS the
+// payload that the next lift consumes. hostView + pointTransform convert a
+// UIView-space point to Pulp root space: identity for the CPU host, the inverse
+// design-viewport map for the GPU (Metal) host.
+@interface PulpIOSDragDrop : NSObject <UIDropInteractionDelegate, UIDragInteractionDelegate>
+- (instancetype)initWithRoot:(pulp::view::View*)root
+                    hostView:(UIView*)hostView
+              pointTransform:(pulp::view::Point (^)(pulp::view::Point))xform;
+// Arm an outbound drag with these absolute file paths; consumed by the next
+// UIKit drag lift. Returns YES if a non-empty payload was staged.
+- (BOOL)armOutboundDrag:(const std::vector<std::string>&)paths;
+// Drop the root pointer when the host tears down, so an in-flight async drop
+// completion never dereferences a destroyed view tree.
+- (void)invalidate;
+@end
+
+@implementation PulpIOSDragDrop {
+    pulp::view::View* _root;                       // not owned
+    __weak UIView* _hostView;
+    pulp::view::Point (^_xform)(pulp::view::Point);
+    pulp::view::DragSession _session;              // hover state for dispatch_drag_*
+    NSMutableArray<NSString*>* _pendingPaths;      // staged outbound payload
+}
+
+- (instancetype)initWithRoot:(pulp::view::View*)root
+                    hostView:(UIView*)hostView
+              pointTransform:(pulp::view::Point (^)(pulp::view::Point))xform {
+    if (self = [super init]) {
+        _root = root;
+        _hostView = hostView;
+        _xform = xform;
+        _pendingPaths = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (void)invalidate { _root = nullptr; }
+
+- (pulp::view::Point)rootPointFor:(id<UIDropSession>)session {
+    CGPoint loc = [session locationInView:_hostView];
+    pulp::view::Point pt{static_cast<float>(loc.x), static_cast<float>(loc.y)};
+    if (_xform) pt = _xform(pt);
+    return pt;
+}
+
+- (BOOL)armOutboundDrag:(const std::vector<std::string>&)paths {
+    [_pendingPaths removeAllObjects];
+    for (const auto& p : paths)
+        if (!p.empty())
+            [_pendingPaths addObject:[NSString stringWithUTF8String:p.c_str()]];
+    return _pendingPaths.count > 0;
+}
+
+// ── UIDropInteractionDelegate (inbound) ──────────────────────────────────────
+
+- (BOOL)dropInteraction:(UIDropInteraction *)interaction
+       canHandleSession:(id<UIDropSession>)session {
+    return [session canLoadObjectsOfClass:[NSURL class]];
+}
+
+- (UIDropProposal *)dropInteraction:(UIDropInteraction *)interaction
+                   sessionDidUpdate:(id<UIDropSession>)session {
+    if (_root) {
+        pulp::view::DropData data;
+        data.type = pulp::view::DropData::Type::files;
+        pulp::view::dispatch_drag_move(*_root, _session, data, [self rootPointFor:session]);
+    }
+    return [[UIDropProposal alloc] initWithDropOperation:UIDropOperationCopy];
+}
+
+- (void)dropInteraction:(UIDropInteraction *)interaction
+         sessionDidExit:(id<UIDropSession>)session {
+    if (_root) pulp::view::dispatch_drag_exit(*_root, _session);
+}
+
+- (void)dropInteraction:(UIDropInteraction *)interaction
+            performDrop:(id<UIDropSession>)session {
+    if (!_root) return;
+    const pulp::view::Point pt = [self rootPointFor:session];
+    __weak PulpIOSDragDrop* weakSelf = self;
+    // Completion is delivered on the main queue (UIKit guarantee), so touching
+    // the view tree here is thread-safe.
+    [session loadObjectsOfClass:[NSURL class]
+                     completion:^(NSArray<__kindof id<NSItemProviderReading>> *objects) {
+        PulpIOSDragDrop* strongSelf = weakSelf;
+        if (!strongSelf || !strongSelf->_root) return;
+        pulp::view::DropData data;
+        data.type = pulp::view::DropData::Type::files;
+        for (id obj in objects) {
+            if (![obj isKindOfClass:[NSURL class]]) continue;
+            NSURL* url = (NSURL*)obj;
+            if (!url.isFileURL) continue;
+            if (const char* fs = url.fileSystemRepresentation)
+                data.file_paths.emplace_back(fs);
+        }
+        if (!data.file_paths.empty())
+            pulp::view::dispatch_drop(*strongSelf->_root, strongSelf->_session, data, pt);
+    }];
+}
+
+// ── UIDragInteractionDelegate (outbound) ─────────────────────────────────────
+
+- (NSArray<UIDragItem *> *)dragInteraction:(UIDragInteraction *)interaction
+                  itemsForBeginningSession:(id<UIDragSession>)session {
+    if (_pendingPaths.count == 0) return @[];  // nothing armed → no drag begins
+    NSMutableArray<UIDragItem*>* items = [NSMutableArray array];
+    for (NSString* path in _pendingPaths) {
+        NSURL* url = [NSURL fileURLWithPath:path];
+        NSItemProvider* provider = [[NSItemProvider alloc] initWithContentsOfURL:url];
+        if (!provider) continue;
+        [items addObject:[[UIDragItem alloc] initWithItemProvider:provider]];
+    }
+    [_pendingPaths removeAllObjects];  // consume the staged payload
+    return items;
+}
+
+@end
 
 // ── PulpPluginUIView: UIView subclass for DAW embedding on iOS ──────────────
 
@@ -232,12 +363,32 @@ public:
             CGRect frame = CGRectMake(0, 0, size.width, size.height);
             view_ = [[PulpPluginUIView alloc] initWithFrame:frame];
             view_.rootView = &root_;
+            // Native drag-and-drop. The CPU view paints at logical 1:1, so a
+            // drop point in view space IS root space — no transform needed.
+            drag_drop_ = [[PulpIOSDragDrop alloc] initWithRoot:&root_
+                                                      hostView:view_
+                                                pointTransform:nil];
+            [view_ addInteraction:[[UIDropInteraction alloc] initWithDelegate:drag_drop_]];
+            UIDragInteraction* drag =
+                [[UIDragInteraction alloc] initWithDelegate:drag_drop_];
+            drag.enabled = YES;
+            [view_ addInteraction:drag];
         }
     }
 
     ~IOSPluginViewHost() override {
         root_.set_plugin_view_host(nullptr);
+        [drag_drop_ invalidate];
         detach();
+    }
+
+    // Arm an outbound file drag (drag audio out to Files / another app). On iOS
+    // the UIKit drag begins from the user's lift gesture, so this stages the
+    // payload for the next UIDragInteraction lift rather than starting a drag
+    // synchronously (see PulpIOSDragDrop). Returns false if no files are given.
+    bool start_file_drag(const FileDragRequest& request) override {
+        if (request.file_paths.empty()) return false;
+        return [drag_drop_ armOutboundDrag:request.file_paths] == YES;
     }
 
     NativeViewHandle native_handle() override {
@@ -308,6 +459,7 @@ private:
     View& root_;
     Size size_;
     PulpPluginUIView* view_ = nil;
+    PulpIOSDragDrop* drag_drop_ = nil;
 };
 
 // ── GPU-accelerated iOS plugin view host ─────────────────────────────────
@@ -607,6 +759,22 @@ public:
             metal_view_.onWindowChange = ^{ this->handle_window_change(); };
             metal_view_.onLayout = ^{ this->handle_layout(); };
 
+            // Native drag-and-drop. Map a drop point through the Metal view's
+            // LIVE pointTransform (the inverse design-viewport map touches use),
+            // captured weakly so a drop never resurrects a torn-down view.
+            __weak PulpMetalPluginView* weak_view = metal_view_;
+            drag_drop_ = [[PulpIOSDragDrop alloc] initWithRoot:&root_
+                                                      hostView:metal_view_
+                                                pointTransform:^pulp::view::Point(pulp::view::Point p) {
+                PulpMetalPluginView* v = weak_view;
+                return (v && v.pointTransform) ? v.pointTransform(p) : p;
+            }];
+            [metal_view_ addInteraction:[[UIDropInteraction alloc] initWithDelegate:drag_drop_]];
+            UIDragInteraction* drag =
+                [[UIDragInteraction alloc] initWithDelegate:drag_drop_];
+            drag.enabled = YES;
+            [metal_view_ addInteraction:drag];
+
             scale_ = current_scale();
             uint32_t pw = static_cast<uint32_t>(opts.size.width * scale_);
             uint32_t ph = static_cast<uint32_t>(opts.size.height * scale_);
@@ -654,6 +822,7 @@ public:
             metal_view_.rootView = nullptr;
             metal_view_.onWindowChange = nil;
             metal_view_.onLayout = nil;
+            [drag_drop_ invalidate];
         }
         skia_surface_.reset();
         gpu_surface_.reset();
@@ -661,6 +830,13 @@ public:
     }
 
     NativeViewHandle native_handle() override { return (__bridge void*)metal_view_; }
+
+    // Arm an outbound file drag — consumed by the next UIKit drag lift (UIKit
+    // drags are gesture-initiated; see PulpIOSDragDrop). Returns false if empty.
+    bool start_file_drag(const FileDragRequest& request) override {
+        if (request.file_paths.empty()) return false;
+        return [drag_drop_ armOutboundDrag:request.file_paths] == YES;
+    }
 
     void attach_to_parent(NativeViewHandle parent) override {
         @autoreleasepool {
@@ -815,6 +991,7 @@ private:
     View& root_;
     Size size_;
     PulpMetalPluginView* metal_view_ = nil;
+    PulpIOSDragDrop* drag_drop_ = nil;
     std::unique_ptr<render::GpuSurface> gpu_surface_;
     std::unique_ptr<render::SkiaSurface> skia_surface_;
     FrameClock frame_clock_;

--- a/core/view/platform/ios/plugin_view_host_ios.mm
+++ b/core/view/platform/ios/plugin_view_host_ios.mm
@@ -46,6 +46,7 @@
     pulp::view::Point (^_xform)(pulp::view::Point);
     pulp::view::DragSession _session;              // hover state for dispatch_drag_*
     NSMutableArray<NSString*>* _pendingPaths;      // staged outbound payload
+    NSTimeInterval _armTime;                       // when _pendingPaths was staged
 }
 
 - (instancetype)initWithRoot:(pulp::view::View*)root
@@ -71,9 +72,15 @@
 
 - (BOOL)armOutboundDrag:(const std::vector<std::string>&)paths {
     [_pendingPaths removeAllObjects];
-    for (const auto& p : paths)
-        if (!p.empty())
-            [_pendingPaths addObject:[NSString stringWithUTF8String:p.c_str()]];
+    NSFileManager* fm = [NSFileManager defaultManager];
+    for (const auto& p : paths) {
+        if (p.empty()) continue;
+        // Use the filesystem-representation inverse, not stringWithUTF8String:
+        // (which returns nil for a non-UTF8 path and would crash addObject:).
+        NSString* s = [fm stringWithFileSystemRepresentation:p.c_str() length:p.size()];
+        if (s) [_pendingPaths addObject:s];
+    }
+    _armTime = [NSProcessInfo processInfo].systemUptime;
     return _pendingPaths.count > 0;
 }
 
@@ -86,12 +93,21 @@
 
 - (UIDropProposal *)dropInteraction:(UIDropInteraction *)interaction
                    sessionDidUpdate:(id<UIDropSession>)session {
+    // Only advertise Copy when a DropReceiver / on_drop actually accepts the
+    // point — otherwise the whole view looks droppable and performDrop loads the
+    // files just to discard them. dispatch_drag_move forwards to the idempotent
+    // dispatch_drag_enter, which returns whether a receiver claimed the hover.
+    BOOL accepted = NO;
     if (_root) {
         pulp::view::DropData data;
         data.type = pulp::view::DropData::Type::files;
-        pulp::view::dispatch_drag_move(*_root, _session, data, [self rootPointFor:session]);
+        // dispatch_drag_enter is idempotent (safe to call on every update) and
+        // returns whether a receiver claimed the hover.
+        accepted = pulp::view::dispatch_drag_enter(*_root, _session, data,
+                                                   [self rootPointFor:session]);
     }
-    return [[UIDropProposal alloc] initWithDropOperation:UIDropOperationCopy];
+    return [[UIDropProposal alloc]
+        initWithDropOperation:accepted ? UIDropOperationCopy : UIDropOperationCancel];
 }
 
 - (void)dropInteraction:(UIDropInteraction *)interaction
@@ -128,6 +144,14 @@
 
 - (NSArray<UIDragItem *> *)dragInteraction:(UIDragInteraction *)interaction
                   itemsForBeginningSession:(id<UIDragSession>)session {
+    // Expire a stale arm: start_file_drag stages paths for the NEXT lift, but if
+    // that lift never comes (tap instead of drag, gesture cancelled), the payload
+    // must not silently attach to a later unrelated drag. Bound the window so a
+    // drag only carries freshly-armed files.
+    if (_pendingPaths.count > 0 &&
+        [NSProcessInfo processInfo].systemUptime - _armTime > 2.0) {
+        [_pendingPaths removeAllObjects];
+    }
     if (_pendingPaths.count == 0) return @[];  // nothing armed → no drag begins
     NSMutableArray<UIDragItem*>* items = [NSMutableArray array];
     for (NSString* path in _pendingPaths) {


### PR DESCRIPTION
## What

iOS was the one Apple platform with **no** drag-and-drop (`plugin_view_host_ios.mm` had zero UIDrop/UIDrag code — dropped files ignored, nothing draggable out). Adds a `PulpIOSDragDrop` coordinator (`UIDropInteractionDelegate` + `UIDragInteractionDelegate`) on **both** host views (CPU `PulpPluginUIView` + GPU `PulpMetalPluginView`), bridging UIKit DnD to the same cross-platform `dispatch_drag_*`/`dispatch_drop` core the mac/win/linux hosts use.

- **Inbound:** `UIDropInteraction` → file URLs → `dispatch_drop` at the drop point (hover via `dispatch_drag_move`).
- **Outbound:** `UIDragInteraction`. UIKit drags are **gesture-initiated**, so `start_file_drag` *arms* the payload for the next lift (returns `@[]` when unarmed → no stray drags) rather than starting synchronously like AppKit.
- **Coords:** identity on CPU host; Metal view's live `pointTransform` (inverse design-viewport) on GPU host, captured weakly.
- **Lifetime:** async completion re-checks a weakly-captured coordinator; both dtors `-invalidate`.

## Validation
- **Compile-validated for the iOS Simulator** locally: `clang -fsyntax-only -target arm64-apple-ios16.0-simulator` → EXIT 0, zero errors (CPU path + coordinator; GPU path mirrors it and the `pointTransform` block type matches the property).
- **No headless test** — UIKit drag/drop is gesture-driven, not exercisable by the macOS Catch2 suite (same category as touch input). `ios` SKILL.md records the paradigm + gotchas.

Follow-up to the drag-and-drop platform sweep (#4073 desktop, #4083 Linux gesture proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native iOS drag-and-drop to both host views (CPU and Metal) so files can be dropped in and dragged out via the cross‑platform dispatch; on iOS, call `start_file_drag` during a long press to arm outbound drags. Also bumps project to 0.438.0 and `pulp` plugin to 0.214.0.

- **New Features**
  - Adds `PulpIOSDragDrop` to `PulpPluginUIView` and `PulpMetalPluginView`, bridging `UIDropInteraction`/`UIDragInteraction` to `dispatch_drag_*`/`dispatch_drop`.
  - Inbound: loads file `NSURL`s; hover uses `dispatch_drag_enter`; drop dispatches `dispatch_drop`.
  - Outbound: `start_file_drag` arms file paths for the next lift; CPU uses identity coords, Metal uses live `pointTransform`; weak captures with `invalidate` on teardown.

- **Bug Fixes**
  - Expires staged outbound payloads after 2s to avoid stale drags.
  - Uses `-stringWithFileSystemRepresentation:length:` for path conversion; skips unconvertible paths.
  - Advertises Copy only when `dispatch_drag_enter` accepts; otherwise returns Cancel.

<sup>Written for commit 83f0b2c068f39edeea77165f7eb0af13637759e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

