### PR TITLE
ci(coverage): fix launchd template TCC shape + invert label gate

### DIFF
--- a/tools/ci/tart-runner.sh
+++ b/tools/ci/tart-runner.sh
@@ -190,7 +190,13 @@ for line in sys.stdin:
         labels = {s.lower() for s in json.loads(line)}
     except Exception:
         continue
-    if want.issubset(labels):
+    # GitHub assigns a job to a runner iff the runner advertises EVERY label
+    # the job requests; the runner may carry extra labels. So this VM, which
+    # registers with `want`, can serve a queued job iff the requested job
+    # labels are a subset of `want`. The reverse direction (want as a subset
+    # of the job labels) silently fails to boot when the runner carries an
+    # extra label such as a per-host pulp-build-vm-secondary.
+    if labels.issubset(want):
         n += 1
 print(n)
 '

--- a/tools/ci/test_tart_runner.py
+++ b/tools/ci/test_tart_runner.py
@@ -18,7 +18,9 @@ Run:  python3 tools/ci/test_tart_runner.py
 """
 from __future__ import annotations
 
+import json
 import os
+import re
 import subprocess
 import unittest
 from pathlib import Path
@@ -158,7 +160,13 @@ class ReuseSafetyTests(unittest.TestCase):
     def test_queue_gate_can_require_matching_labels(self) -> None:
         self.assertIn('MATCH_LABELS="${PULP_RUNNER_QUEUE_MATCH_LABELS:-0}"', self.body)
         self.assertIn("--queue-match-labels)", self.body)
-        self.assertIn("want.issubset(labels)", self.body)
+        # A VM that registers with `want` can serve a queued job iff the job's
+        # requested labels are a SUBSET of `want` (GitHub's matching rule —
+        # the runner may advertise extra labels). The reverse, want ⊆ labels,
+        # silently fails to boot whenever the runner carries an extra label
+        # (e.g. a per-host pulp-build-vm-secondary), so guard against it.
+        self.assertIn("labels.issubset(want)", self.body)
+        self.assertNotIn("want.issubset(labels)", self.body)
 
     def test_label_matched_queue_scan_covers_in_progress_runs(self) -> None:
         # A workflow whose early GitHub-hosted resolver/classify job runs first
@@ -168,6 +176,63 @@ class ReuseSafetyTests(unittest.TestCase):
         # statuses (mirrors the tartci macOS provider's loop).
         self.assertIn("for st in queued in_progress;", self.body)
         self.assertIn("runs?status=$st", self.body)
+
+
+class LabelMatchSemanticsTests(unittest.TestCase):
+    """Behavioral test of the --queue-match-labels matcher.
+
+    The label-matched queue gate embeds an inline Python snippet that decides,
+    for each queued job, whether THIS VM (which registers with the runner's
+    advertised labels) is allowed to serve it. We extract that exact snippet
+    from the script and run it so the assertion can't drift from the source,
+    and so an inverted subset check (the bug fixed alongside this test) is
+    caught by behavior, not just by grepping for a string.
+    """
+
+    def setUp(self) -> None:
+        body = SCRIPT.read_text(encoding="utf-8")
+        m = re.search(r"(import json, os, sys\nwant = \{.*?print\(n\)\n)",
+                      body, re.S)
+        self.assertIsNotNone(m, "label-match snippet not found in tart-runner.sh")
+        self.snippet = m.group(1)
+
+    def _count(self, runner_labels: list[str], jobs: list[list[str]]) -> int:
+        env = {**os.environ, "LABEL_JSON": json.dumps(runner_labels)}
+        stdin = "".join(json.dumps(j) + "\n" for j in jobs)
+        r = subprocess.run(["python3", "-c", self.snippet], input=stdin,
+                           capture_output=True, text=True, check=True, env=env)
+        return int(r.stdout.strip())
+
+    def test_extra_runner_label_still_matches_pool_label_job(self) -> None:
+        # The regression: a host that advertises the shared pool label PLUS a
+        # per-host label must still wake for a job requesting only the pool set.
+        runner = ["self-hosted", "macOS", "ARM64", "pulp-build",
+                  "pulp-build-vm", "pulp-build-vm-secondary"]
+        job = ["self-hosted", "macOS", "ARM64", "pulp-build", "pulp-build-vm"]
+        self.assertEqual(self._count(runner, [job]), 1)
+
+    def test_exact_match_counts(self) -> None:
+        labels = ["self-hosted", "macOS", "ARM64", "pulp-coverage-vm-macos"]
+        self.assertEqual(self._count(labels, [labels]), 1)
+
+    def test_job_needing_unavailable_label_does_not_match(self) -> None:
+        runner = ["self-hosted", "macOS", "ARM64", "pulp-coverage-vm-macos"]
+        job = ["self-hosted", "macOS", "ARM64", "pulp-build", "pulp-build-vm"]
+        self.assertEqual(self._count(runner, [job]), 0)
+
+    def test_match_is_case_insensitive(self) -> None:
+        runner = ["self-hosted", "macos", "arm64", "pulp-coverage-vm-macos"]
+        job = ["self-hosted", "macOS", "ARM64", "pulp-coverage-vm-macos"]
+        self.assertEqual(self._count(runner, [job]), 1)
+
+    def test_malformed_lines_are_skipped_not_counted(self) -> None:
+        runner = ["self-hosted", "macOS", "ARM64", "pulp-coverage-vm-macos"]
+        good = runner
+        env = {**os.environ, "LABEL_JSON": json.dumps(runner)}
+        stdin = "not json\n" + json.dumps(good) + "\n{ bad\n"
+        r = subprocess.run(["python3", "-c", self.snippet], input=stdin,
+                           capture_output=True, text=True, check=True, env=env)
+        self.assertEqual(int(r.stdout.strip()), 1)
 
 
 if __name__ == "__main__":

--- a/tools/launchd/pulp-tart-runner-coverage-macos.plist.template
+++ b/tools/launchd/pulp-tart-runner-coverage-macos.plist.template
@@ -2,23 +2,32 @@
 <!--
   Dedicated Tart macOS Coverage supervisor.
 
-  This is intentionally separate from the build/gate Tart runner:
+  Mirrors the working build/gate runner (com.danielraffel.pulp.tart-runner):
+  it drives the home-installed `tartci serve macos` tool with everything under
+  $HOME so launchd (macOS TCC) can read it. An earlier shape pointed
+  ProgramArguments + WorkingDirectory + TART_HOME at a repo worktree on
+  /Volumes/Workshop and launchd was denied ("Operation not permitted"); never
+  point a macOS LaunchAgent at /Volumes without a signed Full Disk Access helper.
+
+  Intentionally separate from the build/gate runner:
   - labels use pulp-coverage-vm-macos, never pulp-build or pulp-build-vm
-  - the queue gate wakes for the Coverage workflow, not Build and Test
+  - the queue gate wakes for the Coverage workflow, not "Build and Test"
   - repo routing uses PULP_COVERAGE_MACOS_RUNS_ON_JSON, not Namespace vars
+  - TARTCI_MACOS_VM_CAP=1: coverage runs one VM so it never consumes the
+    second slot the required `macos` gate may need on a shared host.
 
-  Install like the build runner template, replacing $PULP_REPO and $HOME with
-  absolute paths because launchd does not expand shell variables:
+  Prereq: install tartci into $HOME (tartci provides a $HOME/.local/bin/tartci
+  wrapper) and keep macOS goldens under $HOME/VMs — same as the build runner.
 
-    sed -e "s|\$PULP_REPO|$PWD|g" -e "s|\$HOME|$HOME|g" \
+  Install (launchd does not expand shell variables, so the install sed must
+  write absolute paths):
+
+    sed -e "s|\$HOME|$HOME|g" \
       tools/launchd/pulp-tart-runner-coverage-macos.plist.template \
       > ~/Library/LaunchAgents/com.danielraffel.pulp.tart-runner-coverage-macos.plist
 
-  Load:
-    launchctl load ~/Library/LaunchAgents/com.danielraffel.pulp.tart-runner-coverage-macos.plist
-
-  Stop:
-    launchctl unload ~/Library/LaunchAgents/com.danielraffel.pulp.tart-runner-coverage-macos.plist
+  Load:   launchctl load   ~/Library/LaunchAgents/com.danielraffel.pulp.tart-runner-coverage-macos.plist
+  Stop:   launchctl unload ~/Library/LaunchAgents/com.danielraffel.pulp.tart-runner-coverage-macos.plist
 -->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
   "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -30,21 +39,16 @@
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
-        <string>$PULP_REPO/tools/ci/tart-runner.sh</string>
+        <string>$HOME/.local/bin/tartci</string>
+        <string>serve</string>
+        <string>macos</string>
         <string>--loop</string>
-        <string>--workflow-name</string>
-        <string>Coverage</string>
         <string>--labels</string>
         <string>self-hosted,macOS,ARM64,pulp-coverage-vm-macos</string>
-        <string>--queue-match-labels</string>
-        <string>--name-prefix</string>
-        <string>pulp-coverage-macos</string>
-        <string>--slot</string>
-        <string>1</string>
     </array>
 
     <key>WorkingDirectory</key>
-    <string>$PULP_REPO</string>
+    <string>$HOME</string>
 
     <key>RunAtLoad</key>
     <true/>
@@ -53,17 +57,35 @@
     <true/>
 
     <key>StandardOutPath</key>
-    <string>$HOME/Library/Logs/pulp/tart-runner-coverage-macos.log</string>
+    <string>$HOME/Library/Logs/tartci/tart-runner-coverage-macos.log</string>
 
     <key>StandardErrorPath</key>
-    <string>$HOME/Library/Logs/pulp/tart-runner-coverage-macos.log</string>
+    <string>$HOME/Library/Logs/tartci/tart-runner-coverage-macos.log</string>
 
     <key>EnvironmentVariables</key>
     <dict>
+        <key>HOME</key>
+        <string>$HOME</string>
         <key>PATH</key>
-        <string>/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:/usr/bin:/bin</string>
+        <string>/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
         <key>TART_HOME</key>
-        <string>/Volumes/Workshop/VMs</string>
+        <string>$HOME/VMs</string>
+        <key>TARTCI_CI_CACHE</key>
+        <string>$HOME/.cache/pulp-ci</string>
+        <key>TARTCI_HOME</key>
+        <string>$HOME/.tartci</string>
+        <key>TARTCI_MACOS_GOLDEN</key>
+        <string>pulp-build-runner:latest</string>
+        <key>TARTCI_MACOS_VM_CAP</key>
+        <string>1</string>
+        <key>TARTCI_RUNNER_LABELS</key>
+        <string>self-hosted,macOS,ARM64,pulp-coverage-vm-macos</string>
+        <key>TARTCI_RUNNER_REPO</key>
+        <string>danielraffel/pulp</string>
+        <key>TARTCI_RUNNER_WORKFLOW_NAME</key>
+        <string>Coverage</string>
+        <key>TARTCI_RUNNER_QUEUE_MATCH_LABELS</key>
+        <string>1</string>
     </dict>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
Two follow-ups from an adversarial review of the merged #4036 / #4066. Repo-hygiene only — no live host change needed (active lanes already run `tartci serve macos`; the on-disk macstudio coverage plist was hand-fixed earlier).

### 1. Coverage launchd template still shipped the broken `/Volumes` shape
`tools/launchd/pulp-tart-runner-coverage-macos.plist.template` still pointed `ProgramArguments` at `$PULP_REPO/tools/ci/tart-runner.sh`, `WorkingDirectory=$PULP_REPO`, and `TART_HOME=/Volumes/Workshop/VMs`. launchd (macOS TCC) cannot read scripts or a VM store under `/Volumes`, so a **fresh install from this template crash-loops with `Operation not permitted`** — the exact failure already hand-fixed on the live host. #4066 documented the requirement in `coverage.md` but never updated the template.

Rewritten to mirror the working build runner: drive `$HOME/.local/bin/tartci serve macos`, `WorkingDirectory=$HOME`, `TART_HOME=$HOME/VMs`, with Coverage gating via `TARTCI_RUNNER_WORKFLOW_NAME` / `TARTCI_RUNNER_QUEUE_MATCH_LABELS` / `TARTCI_MACOS_VM_CAP=1`.

### 2. `tart-runner.sh` queue gate inverted the label match
The `--queue-match-labels` gate used `want.issubset(labels)` (runner_labels ⊆ job_labels) — the **reverse** of GitHub's rule (a runner serves a job iff `job_labels ⊆ runner_labels`, runner may carry extra labels). Exact-match configs masked it, but the documented "pool label + per-host label" pattern (e.g. an extra `pulp-build-vm-secondary`) made the gate miss the job and **never boot the VM**. Now `labels.issubset(want)`, matching the correct tartci providers.

The old test only asserted the source *contained* the (buggy) string. Replaced with a **behavioral test** that extracts and runs the actual matcher snippet — covering the extra-runner-label regression, exact match, an unavailable label, case-insensitivity, and malformed input.

## Validation
- `bash -n tools/ci/tart-runner.sh`
- `python3 tools/ci/test_tart_runner.py` → 22 passed (17 + 5 new behavioral)
- `plutil -lint` on the template rendered through the install `sed` → OK; verified rendered `ProgramArguments` / `WorkingDirectory` / `TART_HOME` resolve under `$HOME`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the macOS coverage launchd template to run under $HOME with `tartci serve macos`, and corrects the label gate in `tart-runner.sh` so runners boot for jobs that request a subset of their labels. Fresh installs no longer crash-loop under macOS TCC, and label-gated queues now behave correctly.

- **Bug Fixes**
  - Launchd template: drive `$HOME/.local/bin/tartci serve macos` with `WorkingDirectory=$HOME`; move logs to `$HOME/Library/Logs/tartci`; set env `HOME`, `PATH` (adds `/usr/sbin:/sbin`), `TART_HOME=$HOME/VMs`, `TARTCI_HOME=$HOME/.tartci`, `TARTCI_CI_CACHE=$HOME/.cache/pulp-ci`, `TARTCI_MACOS_GOLDEN=pulp-build-runner:latest`, `TARTCI_RUNNER_LABELS=self-hosted,macOS,ARM64,pulp-coverage-vm-macos`, `TARTCI_RUNNER_REPO=danielraffel/pulp`, `TARTCI_RUNNER_WORKFLOW_NAME=Coverage`, `TARTCI_RUNNER_QUEUE_MATCH_LABELS=1`, `TARTCI_MACOS_VM_CAP=1`.
  - Queue gate: invert subset check to `labels.issubset(want)` in `tart-runner.sh`; replace fragile grep test with behavioral tests for extra runner labels, exact match, missing labels, case-insensitivity, and malformed input.

<sup>Written for commit d411a6b36420ec9e6e503b15cbd44301dfc50c44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

