### PR TITLE
fix(local-ci): emit review.md + review-package.json from desktop publish

### DIFF
--- a/tools/local-ci/reporting_publish_stage.py
+++ b/tools/local-ci/reporting_publish_stage.py
@@ -55,6 +55,9 @@ def stage_desktop_publish_report(
     if not manifests:
         raise ValueError("Desktop publish requires at least one run manifest.")
 
+    # Lazy import avoids a reporting_publish <-> reporting_video import cycle.
+    from reporting_video import _proof_notes_from_manifest
+
     publish_dir = output_dir.expanduser() if output_dir else create_desktop_publish_bundle_fn(config)
     publish_dir.mkdir(parents=True, exist_ok=True)
     assets_root = publish_dir / "assets"
@@ -103,6 +106,8 @@ def stage_desktop_publish_report(
                 "completed_at": manifest.get("completed_at"),
                 "bundle_dir": manifest.get("artifacts", {}).get("bundle_dir"),
                 "interaction_mode": (manifest.get("interaction") or {}).get("mode"),
+                "video_proof_composition": manifest.get("video_proof_composition"),
+                "video_proof_notes": _proof_notes_from_manifest(manifest),
                 "artifacts": copied_artifacts,
             }
         )
@@ -122,6 +127,17 @@ def stage_desktop_publish_report(
     index_html = publish_dir / "index.html"
     atomic_write_text_fn(index_html, desktop_publish_index_html(index_payload))
 
+    # Video-proof review loop: emit the human review markdown + the
+    # review-package.json that `desktop review-issue` consumes. Imported lazily
+    # to avoid a reporting_publish <-> reporting_video import cycle.
+    from reporting_review import desktop_review_issue_body, desktop_review_package
+
+    review_markdown = publish_dir / "review.md"
+    atomic_write_text_fn(review_markdown, desktop_review_issue_body(index_payload, publish_dir=publish_dir))
+    review_package = publish_dir / "review-package.json"
+    review_package_payload = desktop_review_package(index_payload, publish_dir=publish_dir)
+    atomic_write_text_fn(review_package, json.dumps(review_package_payload, indent=2) + "\n")
+
     report = {
         "generated_at": index_payload["generated_at"],
         "label": index_payload["label"],
@@ -130,6 +146,8 @@ def stage_desktop_publish_report(
         "output_dir": str(publish_dir),
         "index_html": str(index_html),
         "index_json": str(index_json),
+        "review_markdown": str(review_markdown),
+        "review_package": str(review_package),
         "run_count": len(published_runs),
         "runs": published_runs,
     }

--- a/tools/local-ci/test_reporting_publish_stage.py
+++ b/tools/local-ci/test_reporting_publish_stage.py
@@ -108,6 +108,49 @@ class ReportingPublishStageTests(unittest.TestCase):
         self.assertIn("Gallery &lt;One&gt;", html_text)
         self.assertIn("mac&lt;&gt;/inspect", html_text)
 
+    def test_stage_writes_review_package_and_enriches_video_proof_runs(self) -> None:
+        bundle = self.root / "vbundle"
+        bundle.mkdir()
+        (bundle / "manifest.json").write_text('{"label":"video"}\n')
+        manifest = {
+            "target": "mac",
+            "action": "click",
+            "label": "video proof",
+            "completed_at": "2026-06-16T12:00:00+00:00",
+            "artifacts": {"bundle_dir": str(bundle)},
+            "interaction": {"mode": "desktop-event"},
+            "video_proof_notes": ["toggle flips"],
+            "video_proof_composition": {
+                "template": "component-zoom",
+                "focus": {"label": "Bypass"},
+            },
+        }
+        output_dir = self.publish_root() / "20260616-proof"
+
+        report = self.mod.stage_desktop_publish_report(
+            self.config,
+            [manifest],
+            output_dir=output_dir,
+            label="Proof",
+            create_desktop_publish_bundle_fn=lambda _config: output_dir,
+            now_iso_fn=lambda: "2026-06-16T12:01:00+00:00",
+            atomic_write_text_fn=self.atomic_write,
+            write_desktop_publish_rollups_fn=lambda _config: None,
+            publish_report_to_branch_fn=lambda _config, _report: {},
+        )
+
+        review_package_path = output_dir / "review-package.json"
+        review_markdown_path = output_dir / "review.md"
+        self.assertTrue(review_package_path.exists(), "publish must write review-package.json")
+        self.assertTrue(review_markdown_path.exists(), "publish must write review.md")
+        self.assertEqual(report["review_package"], str(review_package_path))
+        self.assertEqual(report["review_markdown"], str(review_markdown_path))
+        package = json.loads(review_package_path.read_text())
+        self.assertIsInstance(package, dict)
+        run = json.loads((output_dir / "index.json").read_text())["runs"][0]
+        self.assertEqual(run["video_proof_composition"]["focus"]["label"], "Bypass")
+        self.assertEqual(run["video_proof_notes"], ["toggle flips"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Adversarial-review follow-up to #4084.**

The video-proof reland ported `reporting_review.desktop_review_package` /
`desktop_review_issue_body` (with tests) but never wired them into
`stage_desktop_publish_report`. Result: `desktop publish` produced a report that
`desktop review-issue` couldn't consume — it reads `<report>/review-package.json`,
which was never written — breaking the publish→review loop. The video-proof
SKILL.md already documents that published reports contain `review.md` +
`review-package.json`, so this aligns code with the documented (and tested-in-
isolation) behavior.

## Fix
`stage_desktop_publish_report` now:
- enriches each published run with `video_proof_composition` + `video_proof_notes`;
- writes `review.md` (via `desktop_review_issue_body`) and `review-package.json`
  (via `desktop_review_package`), and surfaces both paths in the report dict.

Imports are function-level to avoid the `reporting_publish` ↔ `reporting_video`
cycle. New `test_reporting_publish_stage` case asserts both files are written, the
package is valid JSON, and the run carries the composition/notes. Full
`tools/local-ci` sweep green (1823).

Verified by the same adversarial pass that confirmed: `run_macos_local_smoke` is
byte-identical to the validated branch, and all ~12 video subcommands dispatch
cleanly through the real facade (no wiring KeyErrors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken desktop publish → review loop by writing `review.md` and `review-package.json` so `desktop review-issue` can consume published bundles. Also enriches published runs with video-proof metadata.

- **Bug Fixes**
  - `stage_desktop_publish_report` now writes `review.md` and `review-package.json` via `reporting_review.desktop_review_issue_body` and `reporting_review.desktop_review_package`, and includes their paths in the report.
  - Each run now includes `video_proof_composition` and `video_proof_notes` (notes via `reporting_video._proof_notes_from_manifest`).
  - Uses function-level imports to avoid the `reporting_publish` ↔ `reporting_video` cycle, and adds a test to verify files are written and JSON is valid.

<sup>Written for commit f0f453fe9273f55725f21b52776251416a69bd53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

