### PR TITLE
feat(view): standalone outbound file drag — Windows (OLE) + SDL native handles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.461.0
+    VERSION 0.462.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -744,6 +744,10 @@ elseif(WIN32)
         platform/win/accessibility_win.cpp
         platform/win/appearance_win.cpp
         platform/win/motion_preferences_win.cpp
+        # Standalone outbound file-drag backend (free begin_file_drag via OLE).
+        # Unconditional — DoDragDrop has no Skia/GPU dependency, so a non-GPU
+        # standalone build still drags files out. ole32 is linked below.
+        platform/win/drag_drop_win.cpp
     )
     # Win/Linux parity. When Skia is available, add the built-in Skia raster
     # screenshot backend and the native HWND PluginViewHost.

--- a/core/view/include/pulp/view/sdl_window_host.hpp
+++ b/core/view/include/pulp/view/sdl_window_host.hpp
@@ -33,6 +33,12 @@ public:
     // Run the event loop (blocks until window closed)
     virtual void run_event_loop() = 0;
 
+    // Native content-view handle for outbound file drag (mirrors
+    // WindowHost::native_content_view_handle). X11 Window id on Linux, HWND on
+    // Windows; nullptr where unsupported so the drag degrades to false. The SDL
+    // backend overrides this; the default keeps non-drag SDL hosts buildable.
+    virtual void* native_content_view_handle() const { return nullptr; }
+
     // Set close callback
     virtual void set_close_callback(std::function<void()> cb) = 0;
 };

--- a/core/view/platform/win/drag_drop_win.cpp
+++ b/core/view/platform/win/drag_drop_win.cpp
@@ -1,0 +1,39 @@
+// Windows standalone outbound file-drag backend.
+//
+// View::start_file_drag() reaches a plugin view host via the host's
+// start_file_drag() virtual, but a standalone app's tree is owned by a
+// WindowHost — there start_file_drag() falls through to the free function
+// begin_file_drag(native_view, request) declared in drag_drop.hpp. On macOS
+// that free function is the NSDraggingSession backend (drag_drop_mac.mm); this
+// file is its Windows peer, so a standalone Pulp app can drag a file out to
+// Explorer / another app, not just a plugin editor.
+//
+// Compiled on EVERY Windows build (OLE/DoDragDrop has no Skia/GPU dependency),
+// so the `#if !defined(__APPLE__) && !defined(_WIN32)` no-op in drag_drop.cpp
+// drops out for _WIN32 and this definition wins. The OLE source itself is the
+// shared header win_file_drag.hpp, identical to the plugin-host path.
+
+#include "win_file_drag.hpp"
+
+#include <pulp/view/drag_drop.hpp>
+
+#include <objbase.h>  // OleInitialize / OleUninitialize
+
+namespace pulp::view {
+
+bool begin_file_drag(void* /*native_view*/, const FileDragRequest& request) {
+    if (request.file_paths.empty()) return false;
+    // DoDragDrop requires the calling thread to be an OLE-initialized STA. A
+    // standalone app's UI thread usually already is (SDL initializes OLE for its
+    // own drag-drop), but OleInitialize is ref-counted — S_FALSE when already
+    // initialized — and the paired OleUninitialize merely decrements, so this is
+    // safe whether or not the host set it up. native_view (the HWND) is unused:
+    // DoDragDrop tracks the live mouse itself and needs no source window.
+    const HRESULT oi = OleInitialize(nullptr);
+    const bool did_init = (oi == S_OK || oi == S_FALSE);
+    const bool ok = win_drag::win_run_file_drag(request);
+    if (did_init) OleUninitialize();
+    return ok;
+}
+
+}  // namespace pulp::view

--- a/core/view/platform/win/plugin_view_host_win.cpp
+++ b/core/view/platform/win/plugin_view_host_win.cpp
@@ -42,6 +42,7 @@
 #include <ole2.h>        // OleInitialize, RegisterDragDrop, IDropTarget, DoDragDrop
 #include <shellapi.h>    // DragQueryFileW, HDROP, CF_HDROP, DROPFILES
 #include <shlobj.h>      // SHCreateStdEnumFmtEtc (outbound IDataObject enum)
+#include "win_file_drag.hpp"  // shared OLE drag source (win_drag::win_run_file_drag)
 
 #include <pulp/view/drag_drop.hpp>
 
@@ -215,160 +216,10 @@ private:
 };
 
 // ── Outbound file drag (source side) ────────────────────────────────────────
-// The native plugin host owns its child HWND, so it can be a standard OLE drag
-// SOURCE (DoDragDrop) — the macOS NSDraggingSession analogue. This is what was
-// missing on Windows: inbound (IDropTarget above) worked, outbound returned the
-// base no-op. No composition-hosting dependency (that only blocked the WebView).
-
-inline std::wstring utf8_to_wide(const std::string& s) {
-    if (s.empty()) return {};
-    int n = MultiByteToWideChar(CP_UTF8, 0, s.data(), static_cast<int>(s.size()),
-                                nullptr, 0);
-    if (n <= 0) return {};
-    std::wstring out(static_cast<size_t>(n), L'\0');
-    MultiByteToWideChar(CP_UTF8, 0, s.data(), static_cast<int>(s.size()),
-                        out.data(), n);
-    return out;
-}
-
-// Build a CF_HDROP global: a DROPFILES header followed by the wide file paths,
-// each NUL-terminated, with a final extra NUL (double-NUL list terminator).
-inline HGLOBAL make_hdrop_global(const std::vector<std::string>& paths) {
-    std::wstring buf;
-    for (const auto& p : paths) {
-        if (p.empty()) continue;
-        buf += utf8_to_wide(p);
-        buf.push_back(L'\0');
-    }
-    if (buf.empty()) return nullptr;
-    buf.push_back(L'\0');  // double-NUL terminate the list
-
-    const SIZE_T bytes = sizeof(DROPFILES) + buf.size() * sizeof(wchar_t);
-    HGLOBAL h = GlobalAlloc(GHND, bytes);
-    if (!h) return nullptr;
-    auto* df = static_cast<DROPFILES*>(GlobalLock(h));
-    if (!df) { GlobalFree(h); return nullptr; }
-    df->pFiles = sizeof(DROPFILES);
-    df->fWide = TRUE;  // paths are wide (UTF-16)
-    std::memcpy(reinterpret_cast<BYTE*>(df) + sizeof(DROPFILES), buf.data(),
-                buf.size() * sizeof(wchar_t));
-    GlobalUnlock(h);
-    return h;
-}
-
-// Minimal IDataObject exposing a single CF_HDROP / TYMED_HGLOBAL payload. Owns
-// the HGLOBAL and frees it on release; GetData hands callers a duplicate they
-// free via ReleaseStgMedium (standard OLE ownership).
-class PulpWinFileDataObject : public IDataObject {
-public:
-    explicit PulpWinFileDataObject(HGLOBAL hdrop) : hdrop_(hdrop) {
-        fmt_ = FORMATETC{static_cast<CLIPFORMAT>(CF_HDROP), nullptr, DVASPECT_CONTENT,
-                         -1, TYMED_HGLOBAL};
-    }
-    ~PulpWinFileDataObject() { if (hdrop_) GlobalFree(hdrop_); }
-
-    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppv) override {
-        if (riid == IID_IUnknown || riid == IID_IDataObject) {
-            *ppv = static_cast<IDataObject*>(this);
-            AddRef();
-            return S_OK;
-        }
-        *ppv = nullptr;
-        return E_NOINTERFACE;
-    }
-    ULONG STDMETHODCALLTYPE AddRef() override { return static_cast<ULONG>(++ref_); }
-    ULONG STDMETHODCALLTYPE Release() override {
-        const long r = --ref_;
-        if (r == 0) delete this;
-        return static_cast<ULONG>(r);
-    }
-
-    HRESULT STDMETHODCALLTYPE GetData(FORMATETC* fmt, STGMEDIUM* med) override {
-        if (!fmt || !med) return E_INVALIDARG;
-        if (QueryGetData(fmt) != S_OK) return DV_E_FORMATETC;
-        HGLOBAL dup = OleDuplicateData(hdrop_, CF_HDROP, GMEM_MOVEABLE);
-        if (!dup) return E_OUTOFMEMORY;
-        med->tymed = TYMED_HGLOBAL;
-        med->hGlobal = dup;
-        med->pUnkForRelease = nullptr;  // caller frees via ReleaseStgMedium
-        return S_OK;
-    }
-    HRESULT STDMETHODCALLTYPE QueryGetData(FORMATETC* fmt) override {
-        if (!fmt) return E_INVALIDARG;
-        return (fmt->cfFormat == CF_HDROP && (fmt->tymed & TYMED_HGLOBAL) &&
-                fmt->dwAspect == DVASPECT_CONTENT)
-                   ? S_OK : DV_E_FORMATETC;
-    }
-    HRESULT STDMETHODCALLTYPE EnumFormatEtc(DWORD dir, IEnumFORMATETC** out) override {
-        if (dir != DATADIR_GET || !out) return E_NOTIMPL;
-        return SHCreateStdEnumFmtEtc(1, &fmt_, out);
-    }
-    // Unsupported optional surface (a drag-source data object needs none of it).
-    HRESULT STDMETHODCALLTYPE GetDataHere(FORMATETC*, STGMEDIUM*) override { return E_NOTIMPL; }
-    HRESULT STDMETHODCALLTYPE GetCanonicalFormatEtc(FORMATETC*, FORMATETC* o) override {
-        if (o) o->ptd = nullptr;
-        return E_NOTIMPL;
-    }
-    HRESULT STDMETHODCALLTYPE SetData(FORMATETC*, STGMEDIUM*, BOOL) override { return E_NOTIMPL; }
-    HRESULT STDMETHODCALLTYPE DAdvise(FORMATETC*, DWORD, IAdviseSink*, DWORD*) override {
-        return OLE_E_ADVISENOTSUPPORTED;
-    }
-    HRESULT STDMETHODCALLTYPE DUnadvise(DWORD) override { return OLE_E_ADVISENOTSUPPORTED; }
-    HRESULT STDMETHODCALLTYPE EnumDAdvise(IEnumSTATDATA**) override { return OLE_E_ADVISENOTSUPPORTED; }
-
-private:
-    HGLOBAL hdrop_ = nullptr;
-    FORMATETC fmt_{};
-    long ref_ = 1;
-};
-
-// Standard left-button file drag source: commit on button-up, cancel on Esc.
-class PulpWinDropSource : public IDropSource {
-public:
-    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppv) override {
-        if (riid == IID_IUnknown || riid == IID_IDropSource) {
-            *ppv = static_cast<IDropSource*>(this);
-            AddRef();
-            return S_OK;
-        }
-        *ppv = nullptr;
-        return E_NOINTERFACE;
-    }
-    ULONG STDMETHODCALLTYPE AddRef() override { return static_cast<ULONG>(++ref_); }
-    ULONG STDMETHODCALLTYPE Release() override {
-        const long r = --ref_;
-        if (r == 0) delete this;
-        return static_cast<ULONG>(r);
-    }
-    HRESULT STDMETHODCALLTYPE QueryContinueDrag(BOOL escape, DWORD key) override {
-        if (escape) return DRAGDROP_S_CANCEL;
-        if (!(key & MK_LBUTTON)) return DRAGDROP_S_DROP;  // button released → drop
-        return S_OK;
-    }
-    HRESULT STDMETHODCALLTYPE GiveFeedback(DWORD) override {
-        return DRAGDROP_S_USEDEFAULTCURSORS;
-    }
-
-private:
-    long ref_ = 1;
-};
-
-// Run an outbound file drag on the calling (UI) thread. Returns true if the OS
-// completed a copy/link drop. Blocks until the drag ends (standard DoDragDrop).
-inline bool win_start_file_drag(const FileDragRequest& request) {
-    if (request.file_paths.empty()) return false;
-    HGLOBAL hdrop = make_hdrop_global(request.file_paths);
-    if (!hdrop) return false;
-
-    auto* data = new PulpWinFileDataObject(hdrop);  // takes ownership of hdrop
-    auto* source = new PulpWinDropSource();
-    DWORD effect = 0;
-    const HRESULT hr = DoDragDrop(data, source,
-                                  DROPEFFECT_COPY | DROPEFFECT_LINK, &effect);
-    data->Release();
-    source->Release();
-    return hr == DRAGDROP_S_DROP && effect != DROPEFFECT_NONE;
-}
+// The OLE drag SOURCE (CF_HDROP IDataObject + IDropSource + DoDragDrop) now
+// lives in the Skia-free shared header win_file_drag.hpp so the standalone
+// window-host path (drag_drop_win.cpp) reuses the exact same backend. The plugin
+// host calls win_drag::win_run_file_drag() from its start_file_drag() override.
 
 class WinPluginViewHost : public PluginViewHost {
 public:
@@ -414,7 +265,7 @@ public:
     // The host owns its HWND, so this is a plain OLE drag source — no WebView
     // composition dependency. Mirrors the macOS NSDraggingSession override.
     bool start_file_drag(const FileDragRequest& request) override {
-        return win_start_file_drag(request);
+        return win_drag::win_run_file_drag(request);
     }
 
     void attach_to_parent(NativeViewHandle parent) override {

--- a/core/view/platform/win/win_file_drag.hpp
+++ b/core/view/platform/win/win_file_drag.hpp
@@ -1,0 +1,173 @@
+#pragma once
+
+// Windows OLE outbound file-drag source — shared by the plugin view host
+// (plugin_view_host_win.cpp, which owns a child HWND) and the standalone window
+// host path (drag_drop_win.cpp, which serves View::start_file_drag's free
+// begin_file_drag backend). DoDragDrop is self-contained — it needs no HWND —
+// so this header has NO Skia/render dependency and compiles on every Windows
+// build, GPU or not. The CF_HDROP IDataObject + IDropSource below are the OLE
+// analogue of macOS's NSDraggingSession and Linux's XDND source.
+
+#include <pulp/view/drag_drop.hpp>
+
+#include <windows.h>
+#include <shlobj.h>
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace pulp::view::win_drag {
+
+inline std::wstring utf8_to_wide(const std::string& s) {
+    if (s.empty()) return {};
+    int n = MultiByteToWideChar(CP_UTF8, 0, s.data(), static_cast<int>(s.size()),
+                                nullptr, 0);
+    if (n <= 0) return {};
+    std::wstring out(static_cast<size_t>(n), L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, s.data(), static_cast<int>(s.size()),
+                        out.data(), n);
+    return out;
+}
+
+// Build a CF_HDROP global: a DROPFILES header followed by the wide file paths,
+// each NUL-terminated, with a final extra NUL (double-NUL list terminator).
+inline HGLOBAL make_hdrop_global(const std::vector<std::string>& paths) {
+    std::wstring buf;
+    for (const auto& p : paths) {
+        if (p.empty()) continue;
+        buf += utf8_to_wide(p);
+        buf.push_back(L'\0');
+    }
+    if (buf.empty()) return nullptr;
+    buf.push_back(L'\0');  // double-NUL terminate the list
+
+    const SIZE_T bytes = sizeof(DROPFILES) + buf.size() * sizeof(wchar_t);
+    HGLOBAL h = GlobalAlloc(GHND, bytes);
+    if (!h) return nullptr;
+    auto* df = static_cast<DROPFILES*>(GlobalLock(h));
+    if (!df) { GlobalFree(h); return nullptr; }
+    df->pFiles = sizeof(DROPFILES);
+    df->fWide = TRUE;  // paths are wide (UTF-16)
+    std::memcpy(reinterpret_cast<BYTE*>(df) + sizeof(DROPFILES), buf.data(),
+                buf.size() * sizeof(wchar_t));
+    GlobalUnlock(h);
+    return h;
+}
+
+// Minimal IDataObject exposing a single CF_HDROP / TYMED_HGLOBAL payload. Owns
+// the HGLOBAL and frees it on release; GetData hands callers a duplicate they
+// free via ReleaseStgMedium (standard OLE ownership).
+class PulpWinFileDataObject : public IDataObject {
+public:
+    explicit PulpWinFileDataObject(HGLOBAL hdrop) : hdrop_(hdrop) {
+        fmt_ = FORMATETC{static_cast<CLIPFORMAT>(CF_HDROP), nullptr, DVASPECT_CONTENT,
+                         -1, TYMED_HGLOBAL};
+    }
+    ~PulpWinFileDataObject() { if (hdrop_) GlobalFree(hdrop_); }
+
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppv) override {
+        if (riid == IID_IUnknown || riid == IID_IDataObject) {
+            *ppv = static_cast<IDataObject*>(this);
+            AddRef();
+            return S_OK;
+        }
+        *ppv = nullptr;
+        return E_NOINTERFACE;
+    }
+    ULONG STDMETHODCALLTYPE AddRef() override { return static_cast<ULONG>(++ref_); }
+    ULONG STDMETHODCALLTYPE Release() override {
+        const long r = --ref_;
+        if (r == 0) delete this;
+        return static_cast<ULONG>(r);
+    }
+
+    HRESULT STDMETHODCALLTYPE GetData(FORMATETC* fmt, STGMEDIUM* med) override {
+        if (!fmt || !med) return E_INVALIDARG;
+        if (QueryGetData(fmt) != S_OK) return DV_E_FORMATETC;
+        HGLOBAL dup = OleDuplicateData(hdrop_, CF_HDROP, GMEM_MOVEABLE);
+        if (!dup) return E_OUTOFMEMORY;
+        med->tymed = TYMED_HGLOBAL;
+        med->hGlobal = dup;
+        med->pUnkForRelease = nullptr;  // caller frees via ReleaseStgMedium
+        return S_OK;
+    }
+    HRESULT STDMETHODCALLTYPE QueryGetData(FORMATETC* fmt) override {
+        if (!fmt) return E_INVALIDARG;
+        return (fmt->cfFormat == CF_HDROP && (fmt->tymed & TYMED_HGLOBAL) &&
+                fmt->dwAspect == DVASPECT_CONTENT)
+                   ? S_OK : DV_E_FORMATETC;
+    }
+    HRESULT STDMETHODCALLTYPE EnumFormatEtc(DWORD dir, IEnumFORMATETC** out) override {
+        if (dir != DATADIR_GET || !out) return E_NOTIMPL;
+        return SHCreateStdEnumFmtEtc(1, &fmt_, out);
+    }
+    // Unsupported optional surface (a drag-source data object needs none of it).
+    HRESULT STDMETHODCALLTYPE GetDataHere(FORMATETC*, STGMEDIUM*) override { return E_NOTIMPL; }
+    HRESULT STDMETHODCALLTYPE GetCanonicalFormatEtc(FORMATETC*, FORMATETC* o) override {
+        if (o) o->ptd = nullptr;
+        return E_NOTIMPL;
+    }
+    HRESULT STDMETHODCALLTYPE SetData(FORMATETC*, STGMEDIUM*, BOOL) override { return E_NOTIMPL; }
+    HRESULT STDMETHODCALLTYPE DAdvise(FORMATETC*, DWORD, IAdviseSink*, DWORD*) override {
+        return OLE_E_ADVISENOTSUPPORTED;
+    }
+    HRESULT STDMETHODCALLTYPE DUnadvise(DWORD) override { return OLE_E_ADVISENOTSUPPORTED; }
+    HRESULT STDMETHODCALLTYPE EnumDAdvise(IEnumSTATDATA**) override { return OLE_E_ADVISENOTSUPPORTED; }
+
+private:
+    HGLOBAL hdrop_ = nullptr;
+    FORMATETC fmt_{};
+    long ref_ = 1;
+};
+
+// Standard left-button file drag source: commit on button-up, cancel on Esc.
+class PulpWinDropSource : public IDropSource {
+public:
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppv) override {
+        if (riid == IID_IUnknown || riid == IID_IDropSource) {
+            *ppv = static_cast<IDropSource*>(this);
+            AddRef();
+            return S_OK;
+        }
+        *ppv = nullptr;
+        return E_NOINTERFACE;
+    }
+    ULONG STDMETHODCALLTYPE AddRef() override { return static_cast<ULONG>(++ref_); }
+    ULONG STDMETHODCALLTYPE Release() override {
+        const long r = --ref_;
+        if (r == 0) delete this;
+        return static_cast<ULONG>(r);
+    }
+    HRESULT STDMETHODCALLTYPE QueryContinueDrag(BOOL escape, DWORD key) override {
+        if (escape) return DRAGDROP_S_CANCEL;
+        if (!(key & MK_LBUTTON)) return DRAGDROP_S_DROP;  // button released → drop
+        return S_OK;
+    }
+    HRESULT STDMETHODCALLTYPE GiveFeedback(DWORD) override {
+        return DRAGDROP_S_USEDEFAULTCURSORS;
+    }
+
+private:
+    long ref_ = 1;
+};
+
+// Run an outbound file drag on the calling (UI) thread. Returns true if the OS
+// completed a copy/link drop. Blocks until the drag ends (standard DoDragDrop).
+// Self-contained: DoDragDrop tracks the live mouse itself, so no HWND is needed.
+inline bool win_run_file_drag(const FileDragRequest& request) {
+    if (request.file_paths.empty()) return false;
+    HGLOBAL hdrop = make_hdrop_global(request.file_paths);
+    if (!hdrop) return false;
+
+    auto* data = new PulpWinFileDataObject(hdrop);  // takes ownership of hdrop
+    auto* source = new PulpWinDropSource();
+    DWORD effect = 0;
+    const HRESULT hr = DoDragDrop(data, source,
+                                  DROPEFFECT_COPY | DROPEFFECT_LINK, &effect);
+    data->Release();
+    source->Release();
+    return hr == DRAGDROP_S_DROP && effect != DROPEFFECT_NONE;
+}
+
+}  // namespace pulp::view::win_drag

--- a/core/view/src/drag_drop.cpp
+++ b/core/view/src/drag_drop.cpp
@@ -166,13 +166,14 @@ bool invoke_file_drag_backend(const FileDragRequest& request) {
     return backend ? backend(request) : false;
 }
 
-#if !defined(__APPLE__) && !(defined(__linux__) && defined(PULP_HAS_X11))
+#if !defined(__APPLE__) && !(defined(__linux__) && defined(PULP_HAS_X11)) && !defined(_WIN32)
 // Outbound file drag free-function backend, used by View::start_file_drag when
 // the tree is owned by a WindowHost (standalone app) rather than a plugin host.
-// Real backends live per platform: macOS NSDraggingSession (drag_drop_mac.mm)
-// and Linux XDND (drag_drop_linux.cpp, compiled when Xlib links — PULP_HAS_X11).
-// This no-op covers the platforms without one yet (Windows standalone, headless
-// Linux) so the cross-platform call site links and degrades gracefully; each new
+// Real backends live per platform: macOS NSDraggingSession (drag_drop_mac.mm),
+// Linux XDND (drag_drop_linux.cpp, compiled when Xlib links — PULP_HAS_X11), and
+// Windows OLE DoDragDrop (drag_drop_win.cpp, compiled unconditionally on _WIN32).
+// This no-op covers the platforms without one yet (headless Linux, etc.) so the
+// cross-platform call site links and degrades gracefully; each new
 // backend extends the guard above as it lands.
 bool begin_file_drag(void* /*native_view*/, const FileDragRequest& /*request*/) {
     return false;

--- a/core/view/src/sdl_window_host.cpp
+++ b/core/view/src/sdl_window_host.cpp
@@ -7,6 +7,7 @@
 #include <pulp/view/accessibility_provider.hpp>
 #include <pulp/view/drag_drop.hpp>
 #include <SDL3/SDL.h>
+#include <cstdint>  // uintptr_t (X11 Window id for outbound file drag)
 #include <string>
 #include <vector>
 #include <deque>
@@ -183,6 +184,25 @@ public:
     }
 
     // ── Platform feature overrides (SDL3, Linux/Windows) ──────────────
+
+    // Native window handle for outbound file drag (View::start_file_drag's free
+    // begin_file_drag backend). HWND on Windows — the OLE DoDragDrop backend
+    // ignores its value, but the cross-platform call site guards on non-null;
+    // the X11 Window id on Linux (the XDND source backend opens its own Display
+    // from it). Wayland / unsupported → nullptr, so the drag degrades to false.
+    void* native_content_view_handle() const override {
+        if (!window_) return nullptr;
+        SDL_PropertiesID props = SDL_GetWindowProperties(window_);
+#if defined(_WIN32)
+        return SDL_GetPointerProperty(props, SDL_PROP_WINDOW_WIN32_HWND_POINTER,
+                                      nullptr);
+#elif defined(__linux__)
+        return reinterpret_cast<void*>(static_cast<uintptr_t>(
+            SDL_GetNumberProperty(props, SDL_PROP_WINDOW_X11_WINDOW_NUMBER, 0)));
+#else
+        return nullptr;
+#endif
+    }
 
     void set_mouse_relative_mode(bool enabled) {
         if (window_) SDL_SetWindowRelativeMouseMode(window_, enabled);


### PR DESCRIPTION
## What

Standalone Pulp apps (tree owned by a `WindowHost`, not a plugin host) couldn't drag files **out** — `View::start_file_drag` falls through to the free `begin_file_drag(native_view, request)`, a no-op everywhere except macOS. Closes the Windows gap:

1. **SDL native handle** — `SdlWindowHostImpl::native_content_view_handle()` now returns the `HWND` (Windows) / X11 `Window` (Linux) via SDL3 window properties, so `start_file_drag` clears its null-handle guard.
2. **Free `begin_file_drag` for Windows** — extracted the OLE drag source (`CF_HDROP` `IDataObject`/`IDropSource`/`DoDragDrop`) from `plugin_view_host_win.cpp` into the **Skia-free** shared header `win_file_drag.hpp`; `drag_drop_win.cpp` provides `begin_file_drag`, compiled unconditionally on `_WIN32`. The `drag_drop.cpp` no-op now guards `!__APPLE__ && !_WIN32`. Plugin host + standalone share one backend.

## Scope / follow-up
- **Windows standalone: done.** **Linux standalone: next** — the X11 handle is already plumbed, but its `begin_file_drag` needs the XDND source extracted out of `run_xdnd_source`, so Linux stays the no-op here (returns false, **no regression**).
- CI-compile-only from this machine (no Windows box); validated by the Windows lane + release-path gates.

Part of the cross-platform drag sweep (#4073 desktop, #4083 Linux gesture proof, #4085 iOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds outbound file drag for standalone Windows apps by sharing the OLE `DoDragDrop` backend with the plugin host, and exposes SDL native window handles on Windows/Linux. Linux remains a no-op; version bumped to 0.462.0.

- **New Features**
  - Standalone Windows apps can drag files out (CF_HDROP via `DoDragDrop`), using a shared backend in `win_file_drag.hpp` with `drag_drop_win.cpp`.
  - `SdlWindowHostImpl::native_content_view_handle()` returns `HWND` (Windows) or X11 `Window` (Linux); Wayland/unsupported returns null.

- **Bug Fixes**
  - Declared `native_content_view_handle()` on the `SdlWindowHost` base (default `nullptr`) to fix the macOS/SDL build.

<sup>Written for commit f69e0b6775b67f4674b4766f951ee73ed203ef44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

