### PR TITLE
feat(view): Android native file drop (inbound)

### DIFF
--- a/.agents/skills/android/SKILL.md
+++ b/.agents/skills/android/SKILL.md
@@ -390,11 +390,19 @@ use). The wiring mirrors touch:
   `g_display_density`, like touch) and calls `dispatch_drop(*g_root_view, …)`.
 
 **Architecture note:** Android has NO `WindowHost`/`PluginViewHost` — the tree
-is the global `g_root_view` in `gpu_surface_android.cpp`. So inbound routes
-directly through `g_root_view`. **Outbound** (`View::start_file_drag` →
-`startDragAndDrop`) is NOT wired: it needs a host-owned drag path / a JNI
-up-call to Kotlin, since `View::start_file_drag` requires a host pointer that
-Android's bare `g_root_view` doesn't have. (Follow-up.)
+is the global `g_root_view` in `gpu_surface_android.cpp`, so `View::start_file_drag`
+has no host pointer to dispatch through. **Outbound** is therefore wired via a
+**process-global drag backend**: `drag_drop.hpp`'s `set_file_drag_backend()` /
+`invoke_file_drag_backend()` — `View::start_file_drag` calls the registered
+backend as a last resort when no host handles the drag. The Android JNI bridge
+caches the `PulpSurfaceView` (`GlobalRef`) at `surfaceCreated` and registers a
+backend that **up-calls** Kotlin `startFileDrag(String[]): Boolean` (via
+`get_env()` + `CallBooleanMethod`), which builds a `ClipData` of **FileProvider**
+`content://` URIs (`${applicationId}.fileprovider`, declared in the manifest +
+`res/xml/file_paths.xml`) and runs `View.startDragAndDrop` with
+`DRAG_FLAG_GLOBAL | DRAG_FLAG_GLOBAL_URI_READ`. Call `start_file_drag` from a
+touch handler (UI thread); off-thread it posts and reports optimistic success.
+JNI namespace is `pulp::android` (NOT `pulp::platform::android`).
 
 Emulator gesture test: drag a file from the Files app onto the Pulp window;
 watch `adb logcat -s Pulp` for the drop. The headless test suites can't exercise

--- a/.agents/skills/android/SKILL.md
+++ b/.agents/skills/android/SKILL.md
@@ -288,6 +288,24 @@ cmake -S . -B build-android \
 cmake --build build-android -j$(sysctl -n hw.ncpu)
 ```
 
+**Android Skia must be built from source — there is NO prebuilt slice.** The
+`danielraffel/skia-builder` release fork ships ios / linux / mac slices but no
+`android` asset (verified at `chrome/m150` + `m149`). So unlike the other
+platforms (which `fetch_skia_for_release.py` downloads), Android Skia comes from:
+
+```bash
+export ANDROID_HOME=$HOME/Library/Android/sdk
+export ANDROID_NDK_HOME=$ANDROID_HOME/ndk/<version>
+SKIA_BRANCH=chrome/m150 bash tools/build-skia-android.sh   # needs `ninja` on PATH
+# -> external/skia-build/android-gpu/lib/Release/*.a (gitignored; headers under
+#    external/skia-build/include/android/** ARE tracked). For the x86_64 emulator
+#    set ANDROID_ABI=x86_64 and FindSkia.cmake picks android-gpu-x86_64/.
+```
+
+`ninja: command not found` is the usual first failure (`brew install ninja`);
+`gn` is fetched by the script. `libdawn_combined.a` may come out as a tiny stub
+(WebGPU/Dawn for Android is a separate concern from the Skia raster libs).
+
 ### Build the APK
 
 ```bash
@@ -353,6 +371,34 @@ adb shell input swipe 200 400 200 300 300
 # Take screenshot after to verify state changed
 sleep 0.5 && adb exec-out screencap -p > /tmp/after-tap.png
 ```
+
+### Native drag-and-drop (inbound)
+
+`PulpSurfaceView` accepts dropped files and routes them into the C++ view
+tree's shared `dispatch_drop` core (the same core the mac/win/linux/iOS hosts
+use). The wiring mirrors touch:
+
+- **Kotlin** (`PulpSurfaceView.kt`): `setOnDragListener` → `ACTION_DRAG_STARTED`
+  accepts any drag with items; `ACTION_DROP` calls
+  `requestDragAndDropPermissions(event)` (needed to read another app's
+  `content://` URIs), copies each ClipData URI into `cacheDir/dropped/` via
+  `ContentResolver.openInputStream` (the C++ side needs filesystem paths —
+  `content://` URIs are not openable by path), then `nativeOnDrop(paths, x, y)`.
+- **JNI** (`gpu_surface_android_jni.cpp`): `nativeOnDrop` marshals the
+  `jobjectArray` of paths → `std::vector<std::string>` → `android_on_drop`.
+- **C++** (`gpu_surface_android.cpp`): `android_on_drop` converts px→dp (÷
+  `g_display_density`, like touch) and calls `dispatch_drop(*g_root_view, …)`.
+
+**Architecture note:** Android has NO `WindowHost`/`PluginViewHost` — the tree
+is the global `g_root_view` in `gpu_surface_android.cpp`. So inbound routes
+directly through `g_root_view`. **Outbound** (`View::start_file_drag` →
+`startDragAndDrop`) is NOT wired: it needs a host-owned drag path / a JNI
+up-call to Kotlin, since `View::start_file_drag` requires a host pointer that
+Android's bare `g_root_view` doesn't have. (Follow-up.)
+
+Emulator gesture test: drag a file from the Files app onto the Pulp window;
+watch `adb logcat -s Pulp` for the drop. The headless test suites can't exercise
+the OS drag gesture (same as touch).
 
 ### Logcat
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.212.0",
+      "version": "0.213.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.212.0"
+  "version": "0.213.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.212.0",
+  "version": "0.213.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.436.0
+    VERSION 0.437.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -65,5 +65,17 @@
                 android:resource="@xml/midi_device_info"/>
         </service>
 
+        <!-- FileProvider for outbound native file drag: hands dragged files to
+             other apps as content:// URIs (DRAG_FLAG_GLOBAL_URI_READ). -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
     </application>
 </manifest>

--- a/android/app/src/main/kotlin/com/pulp/render/PulpSurfaceView.kt
+++ b/android/app/src/main/kotlin/com/pulp/render/PulpSurfaceView.kt
@@ -1,11 +1,16 @@
 package com.pulp.render
 
+import android.app.Activity
 import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
 import android.util.Log
+import android.view.DragEvent
 import android.view.MotionEvent
 import android.view.Surface
 import android.view.SurfaceHolder
 import android.view.SurfaceView
+import java.io.File
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import com.pulp.PulpApplication
@@ -53,6 +58,11 @@ class PulpSurfaceView(context: Context) : SurfaceView(context), SurfaceHolder.Ca
             }
             insets
         }
+
+        // Native file drag-and-drop (inbound): accept dropped files and route
+        // their resolved paths into the C++ view tree's dispatch_drop core —
+        // the same core the mac/win/linux/iOS hosts use.
+        setOnDragListener { _, event -> handleDragEvent(event) }
     }
 
     // ── Surface Lifecycle ─────────────────────────────────────────────────
@@ -153,6 +163,75 @@ class PulpSurfaceView(context: Context) : SurfaceView(context), SurfaceHolder.Ca
         return true
     }
 
+    // ── Drag-and-Drop (inbound) ───────────────────────────────────────────
+
+    private fun handleDragEvent(event: DragEvent): Boolean {
+        return when (event.action) {
+            // Accept drags that carry at least one item; URIs are resolved at
+            // drop time (we can't read them until we hold drop permission).
+            DragEvent.ACTION_DRAG_STARTED ->
+                (event.clipDescription?.mimeTypeCount ?: 0) > 0
+            DragEvent.ACTION_DROP -> onDrop(event)
+            DragEvent.ACTION_DRAG_ENTERED,
+            DragEvent.ACTION_DRAG_EXITED,
+            DragEvent.ACTION_DRAG_LOCATION,
+            DragEvent.ACTION_DRAG_ENDED -> true
+            else -> false
+        }
+    }
+
+    private fun onDrop(event: DragEvent): Boolean {
+        if (!PulpApplication.nativeLoaded) return false
+        val clip = event.clipData ?: return false
+        // Reading another app's content:// URIs requires drop permission (API 24+).
+        val perms = (context as? Activity)?.requestDragAndDropPermissions(event)
+        try {
+            val paths = ArrayList<String>(clip.itemCount)
+            for (i in 0 until clip.itemCount) {
+                val uri = clip.getItemAt(i).uri ?: continue
+                resolveUriToCacheFile(uri)?.let { paths.add(it) }
+            }
+            if (paths.isEmpty()) return false
+            nativeOnDrop(paths.toTypedArray(), event.x, event.y)
+            return true
+        } finally {
+            perms?.release()
+        }
+    }
+
+    // Copy a dropped content URI into the app cache and return its absolute
+    // path: the C++ side consumes filesystem paths, and content:// URIs are not
+    // openable by path. Best-effort — returns null on any failure.
+    private fun resolveUriToCacheFile(uri: Uri): String? {
+        return try {
+            val name = queryDisplayName(uri) ?: "drop_${System.nanoTime()}"
+            val out = File(context.cacheDir, "dropped/$name").apply { parentFile?.mkdirs() }
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                out.outputStream().use { input.copyTo(it) }
+            } ?: return null
+            out.absolutePath
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to resolve dropped URI $uri: ${e.message}")
+            null
+        }
+    }
+
+    private fun queryDisplayName(uri: Uri): String? {
+        if (uri.scheme == "file") return uri.path?.let { File(it).name }
+        return try {
+            context.contentResolver.query(
+                uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null
+            )?.use { c ->
+                if (c.moveToFirst()) {
+                    val idx = c.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                    if (idx >= 0) c.getString(idx) else null
+                } else null
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
     // ── Native Methods ────────────────────────────────────────────────────
 
     // Display density — called once in init, before surface lifecycle
@@ -170,6 +249,9 @@ class PulpSurfaceView(context: Context) : SurfaceView(context), SurfaceHolder.Ca
     private external fun nativeOnTouchMove(pointerId: Int, x: Float, y: Float, pressure: Float)
     private external fun nativeOnTouchUp(pointerId: Int, x: Float, y: Float)
     private external fun nativeOnTouchCancel()
+
+    // File drop — absolute cache-file paths resolved from the drag's ClipData
+    private external fun nativeOnDrop(paths: Array<String>, x: Float, y: Float)
 
     companion object {
         private const val TAG = PulpApplication.LOG_TAG

--- a/android/app/src/main/kotlin/com/pulp/render/PulpSurfaceView.kt
+++ b/android/app/src/main/kotlin/com/pulp/render/PulpSurfaceView.kt
@@ -206,8 +206,19 @@ class PulpSurfaceView(context: Context) : SurfaceView(context), SurfaceHolder.Ca
     // openable by path. Best-effort — returns null on any failure.
     private fun resolveUriToCacheFile(uri: Uri): String? {
         return try {
-            val name = queryDisplayName(uri) ?: "drop_${System.nanoTime()}"
-            val out = File(context.cacheDir, "dropped/$name").apply { parentFile?.mkdirs() }
+            // The display name comes from an EXTERNAL (source-app) content URI, so
+            // it is attacker-controlled: a name like "../databases/x" would escape
+            // cacheDir/dropped and let a malicious drag overwrite our private files.
+            // File(raw).name strips every path segment (and "..") to a bare leaf.
+            val raw = queryDisplayName(uri) ?: "drop_${System.nanoTime()}"
+            val name = File(raw).name.ifBlank { "drop_${System.nanoTime()}" }
+            val droppedDir = File(context.cacheDir, "dropped").apply { mkdirs() }
+            val out = File(droppedDir, name)
+            // Defence in depth: refuse anything that still resolves outside the dir.
+            if (!out.canonicalPath.startsWith(droppedDir.canonicalPath + File.separator)) {
+                Log.w(TAG, "Refusing dropped file outside cache: $raw")
+                return null
+            }
             context.contentResolver.openInputStream(uri)?.use { input ->
                 out.outputStream().use { input.copyTo(it) }
             } ?: return null

--- a/android/app/src/main/kotlin/com/pulp/render/PulpSurfaceView.kt
+++ b/android/app/src/main/kotlin/com/pulp/render/PulpSurfaceView.kt
@@ -1,6 +1,7 @@
 package com.pulp.render
 
 import android.app.Activity
+import android.content.ClipData
 import android.content.Context
 import android.net.Uri
 import android.provider.OpenableColumns
@@ -10,6 +11,7 @@ import android.view.MotionEvent
 import android.view.Surface
 import android.view.SurfaceHolder
 import android.view.SurfaceView
+import androidx.core.content.FileProvider
 import java.io.File
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -230,6 +232,48 @@ class PulpSurfaceView(context: Context) : SurfaceView(context), SurfaceHolder.Ca
         } catch (e: Exception) {
             null
         }
+    }
+
+    // ── Drag-and-Drop (outbound) ──────────────────────────────────────────
+
+    // Invoked from C++ (JNI up-call via the registered global file-drag backend)
+    // when View::start_file_drag runs on hostless Android. Builds a ClipData of
+    // FileProvider content URIs and runs startDragAndDrop. Returns true if the
+    // drag started (off the UI thread it posts and reports optimistic success).
+    @Suppress("unused")  // called via JNI
+    fun startFileDrag(paths: Array<String>): Boolean {
+        if (paths.isEmpty()) return false
+        val clip = buildDragClip(paths) ?: return false
+        val flags = DRAG_FLAG_GLOBAL or DRAG_FLAG_GLOBAL_URI_READ
+        return if (android.os.Looper.myLooper() == android.os.Looper.getMainLooper()) {
+            startDragAndDrop(clip, DragShadowBuilder(this), null, flags)
+        } else {
+            post { startDragAndDrop(clip, DragShadowBuilder(this), null, flags) }
+            true
+        }
+    }
+
+    private fun buildDragClip(paths: Array<String>): ClipData? {
+        val authority = "${context.packageName}.fileprovider"
+        var clip: ClipData? = null
+        for (p in paths) {
+            val file = File(p)
+            if (!file.exists()) continue
+            val uri: Uri = try {
+                FileProvider.getUriForFile(context, authority, file)
+            } catch (e: IllegalArgumentException) {
+                // File lives outside the FileProvider's configured roots.
+                Log.w(TAG, "Not shareable via FileProvider: $p (${e.message})")
+                continue
+            }
+            val item = ClipData.Item(uri)
+            if (clip == null) {
+                clip = ClipData(file.name, arrayOf("application/octet-stream"), item)
+            } else {
+                clip.addItem(item)
+            }
+        }
+        return clip
     }
 
     // ── Native Methods ────────────────────────────────────────────────────

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Paths the androidx FileProvider may hand out as content:// URIs for outbound
+     native file drag (View.startDragAndDrop). cache-path/dropped mirrors where
+     inbound drops are staged; files-path covers app-private documents. -->
+<paths>
+    <cache-path name="dropped" path="dropped/" />
+    <cache-path name="cache" path="." />
+    <files-path name="files" path="." />
+</paths>

--- a/core/render/platform/android/gpu_surface_android.cpp
+++ b/core/render/platform/android/gpu_surface_android.cpp
@@ -8,6 +8,7 @@
 #include <pulp/view/widgets.hpp>
 #include <pulp/view/theme.hpp>
 #include <pulp/view/input_events.hpp>
+#include <pulp/view/drag_drop.hpp>
 #include <pulp/view/script_engine.hpp>
 #include <pulp/view/widget_bridge.hpp>
 #include <pulp/view/accessibility.hpp>
@@ -991,6 +992,20 @@ void android_touch_up(int pointer_id, float px_x, float px_y) {
     g_captured_view->on_mouse_event(ev);
     g_captured_view->on_mouse_up(local);
     g_captured_view = nullptr;
+}
+
+void android_on_drop(const std::vector<std::string>& paths, float px_x, float px_y) {
+    if (!g_root_view || paths.empty()) return;
+    float dp_x = px_x / g_display_density;
+    float dp_y = px_y / g_display_density;
+    view::DropData data;
+    data.type = view::DropData::Type::files;
+    data.file_paths = paths;
+    // Android delivers one completed drop per gesture (no incremental hover
+    // routing here), so a function-local session is sufficient. dispatch_drop
+    // hit-tests g_root_view and routes to the first DropReceiver / View::on_drop.
+    static view::DragSession session;
+    view::dispatch_drop(*g_root_view, session, data, {dp_x, dp_y});
 }
 
 void android_surface_destroyed() {

--- a/core/render/platform/android/gpu_surface_android_internal.hpp
+++ b/core/render/platform/android/gpu_surface_android_internal.hpp
@@ -18,6 +18,9 @@
 
 #if defined(__ANDROID__)
 
+#include <string>
+#include <vector>
+
 struct ANativeWindow;
 
 namespace pulp::view {
@@ -46,6 +49,13 @@ void android_surface_destroyed();
 void android_touch_down(int pointer_id, float px_x, float px_y, float pressure);
 void android_touch_move(int pointer_id, float px_x, float px_y, float pressure);
 void android_touch_up(int pointer_id, float px_x, float px_y);
+
+// Native file drop into the View hierarchy. `paths` are absolute filesystem
+// paths the Kotlin layer resolved from the drag's ClipData content URIs
+// (copied into the app cache); `px_x/px_y` are the drop point in physical
+// pixels (converted to dp here, like touch). Routes through the shared
+// dispatch core (dispatch_drop) — the same path the mac/win/linux/iOS hosts use.
+void android_on_drop(const std::vector<std::string>& paths, float px_x, float px_y);
 
 // Shared touch-capture pointer. Defined in gpu_surface_android.cpp; cleared
 // directly by the nativeOnTouchCancel JNI export. Non-owning — valid only

--- a/core/render/platform/android/gpu_surface_android_jni.cpp
+++ b/core/render/platform/android/gpu_surface_android_jni.cpp
@@ -17,6 +17,7 @@
 #include <android/native_window.h>
 #include <android/native_window_jni.h>
 #include <android/log.h>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -38,10 +39,19 @@
 
 namespace {
 
+// g_surface_view is written on the render thread (nativeOnSurfaceCreated) and
+// cleared on the UI thread (nativeOnSurfaceDestroyed) while a drag may read it
+// on the UI thread — guard all three with a mutex.
+std::mutex g_surface_view_mutex;
 pulp::android::GlobalRef g_surface_view;  // PulpSurfaceView
 
 bool android_start_file_drag(const std::vector<std::string>& paths) {
-    if (paths.empty() || !g_surface_view) return false;
+    if (paths.empty()) return false;
+    // Hold the lock for the whole up-call so the GlobalRef can't be deleted by a
+    // concurrent surfaceDestroyed mid-use. The call is short (Kotlin posts the
+    // actual startDragAndDrop to the UI loop).
+    std::lock_guard<std::mutex> lock(g_surface_view_mutex);
+    if (!g_surface_view) return false;
     JNIEnv* env = pulp::android::get_env();
     jobject view = g_surface_view.get();
     jclass cls = env->GetObjectClass(view);
@@ -54,6 +64,12 @@ bool android_start_file_drag(const std::vector<std::string>& paths) {
         env->NewObjectArray(static_cast<jsize>(paths.size()), str_cls, nullptr);
     for (jsize i = 0; i < static_cast<jsize>(paths.size()); ++i) {
         jstring s = env->NewStringUTF(paths[static_cast<size_t>(i)].c_str());
+        if (!s) {  // OOM → a pending exception; bail before the next JNI call aborts
+            env->ExceptionClear();
+            env->DeleteLocalRef(arr);
+            env->DeleteLocalRef(str_cls);
+            return false;
+        }
         env->SetObjectArrayElement(arr, i, s);
         env->DeleteLocalRef(s);
     }
@@ -91,7 +107,10 @@ Java_com_pulp_render_PulpSurfaceView_nativeOnSurfaceCreated(
     try {
         // Cache the PulpSurfaceView for outbound-drag up-calls and register the
         // process-global drag backend View::start_file_drag falls back to.
-        g_surface_view = pulp::android::GlobalRef(env, thiz);
+        {
+            std::lock_guard<std::mutex> lock(g_surface_view_mutex);
+            g_surface_view = pulp::android::GlobalRef(env, thiz);
+        }
         pulp::view::set_file_drag_backend([](const pulp::view::FileDragRequest& req) {
             return android_start_file_drag(req.file_paths);
         });
@@ -128,6 +147,15 @@ JNIEXPORT void JNICALL
 Java_com_pulp_render_PulpSurfaceView_nativeOnSurfaceDestroyed(
     JNIEnv* env, jobject thiz) {
     try {
+        // Drop the outbound-drag backend + cached view: the surface (and the
+        // view it up-calls) is going away. Symmetric with the surfaceCreated
+        // registration; avoids a post-destroy up-call into a detached view and
+        // leaving a stale GlobalRef whose dtor would DeleteGlobalRef at teardown.
+        pulp::view::set_file_drag_backend(nullptr);
+        {
+            std::lock_guard<std::mutex> lock(g_surface_view_mutex);
+            g_surface_view = pulp::android::GlobalRef{};
+        }
         pulp::render::android_surface_destroyed();
     } catch (const std::exception& e) {
         env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());

--- a/core/render/platform/android/gpu_surface_android_jni.cpp
+++ b/core/render/platform/android/gpu_surface_android_jni.cpp
@@ -17,6 +17,8 @@
 #include <android/native_window_jni.h>
 #include <android/log.h>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 #define PULP_LOG_TAG "Pulp"
 #define PULP_LOGI(...) __android_log_print(ANDROID_LOG_INFO, PULP_LOG_TAG, __VA_ARGS__)
@@ -108,6 +110,35 @@ Java_com_pulp_render_PulpSurfaceView_nativeOnTouchUp(
 JNIEXPORT void JNICALL
 Java_com_pulp_render_PulpSurfaceView_nativeOnTouchCancel(JNIEnv*, jobject) {
     pulp::render::g_captured_view = nullptr;
+}
+
+// Native file drop — Kotlin's OnDragListener resolved the drag's ClipData
+// content URIs into absolute cache-file paths and passes them here with the
+// drop point (physical px). Forwards into the shared dispatch core.
+JNIEXPORT void JNICALL
+Java_com_pulp_render_PulpSurfaceView_nativeOnDrop(
+    JNIEnv* env, jobject, jobjectArray jpaths, jfloat x, jfloat y) {
+    std::vector<std::string> paths;
+    if (jpaths) {
+        const jsize n = env->GetArrayLength(jpaths);
+        paths.reserve(static_cast<size_t>(n));
+        for (jsize i = 0; i < n; ++i) {
+            auto js = static_cast<jstring>(env->GetObjectArrayElement(jpaths, i));
+            if (!js) continue;
+            if (const char* c = env->GetStringUTFChars(js, nullptr)) {
+                paths.emplace_back(c);
+                env->ReleaseStringUTFChars(js, c);
+            }
+            env->DeleteLocalRef(js);
+        }
+    }
+    try {
+        pulp::render::android_on_drop(paths, x, y);
+    } catch (const std::exception& e) {
+        PULP_LOGE("nativeOnDrop threw: %s", e.what());
+    } catch (...) {
+        PULP_LOGE("Unknown C++ exception in nativeOnDrop");
+    }
 }
 
 // ── Accessibility (TalkBack) ─────────────────────────────────────────────

--- a/core/render/platform/android/gpu_surface_android_jni.cpp
+++ b/core/render/platform/android/gpu_surface_android_jni.cpp
@@ -13,6 +13,7 @@
 #include "gpu_surface_android_internal.hpp"
 
 #include <pulp/platform/android/jni.hpp>
+#include <pulp/view/drag_drop.hpp>
 #include <android/native_window.h>
 #include <android/native_window_jni.h>
 #include <android/log.h>
@@ -24,6 +25,47 @@
 #define PULP_LOGI(...) __android_log_print(ANDROID_LOG_INFO, PULP_LOG_TAG, __VA_ARGS__)
 #define PULP_LOGW(...) __android_log_print(ANDROID_LOG_WARN, PULP_LOG_TAG, __VA_ARGS__)
 #define PULP_LOGE(...) __android_log_print(ANDROID_LOG_ERROR, PULP_LOG_TAG, __VA_ARGS__)
+
+// ── Outbound file drag (host-less Android: JNI up-call into Kotlin) ──────────
+//
+// Android's view tree is the bare global g_root_view with no Window/PluginView
+// host, so View::start_file_drag() falls back to the process-global drag
+// backend (drag_drop.hpp). We register a backend that up-calls the cached
+// PulpSurfaceView's `startFileDrag(String[]): Boolean`, which builds a ClipData
+// of FileProvider content URIs and runs View.startDragAndDrop. The surface ref
+// is cached at surfaceCreated; the up-call runs on whichever thread initiated
+// the drag (touch dispatch → UI thread), and Kotlin re-posts to the UI thread.
+
+namespace {
+
+pulp::android::GlobalRef g_surface_view;  // PulpSurfaceView
+
+bool android_start_file_drag(const std::vector<std::string>& paths) {
+    if (paths.empty() || !g_surface_view) return false;
+    JNIEnv* env = pulp::android::get_env();
+    jobject view = g_surface_view.get();
+    jclass cls = env->GetObjectClass(view);
+    jmethodID mid = env->GetMethodID(cls, "startFileDrag", "([Ljava/lang/String;)Z");
+    env->DeleteLocalRef(cls);
+    if (!mid) { env->ExceptionClear(); return false; }
+
+    jclass str_cls = env->FindClass("java/lang/String");
+    jobjectArray arr =
+        env->NewObjectArray(static_cast<jsize>(paths.size()), str_cls, nullptr);
+    for (jsize i = 0; i < static_cast<jsize>(paths.size()); ++i) {
+        jstring s = env->NewStringUTF(paths[static_cast<size_t>(i)].c_str());
+        env->SetObjectArrayElement(arr, i, s);
+        env->DeleteLocalRef(s);
+    }
+    env->DeleteLocalRef(str_cls);
+
+    const jboolean ok = env->CallBooleanMethod(view, mid, arr);
+    env->DeleteLocalRef(arr);
+    if (env->ExceptionCheck()) { env->ExceptionDescribe(); env->ExceptionClear(); return false; }
+    return ok == JNI_TRUE;
+}
+
+}  // namespace
 
 // ── JNI Exports ───────────────────────────────────────────────────────────
 
@@ -47,6 +89,13 @@ JNIEXPORT void JNICALL
 Java_com_pulp_render_PulpSurfaceView_nativeOnSurfaceCreated(
     JNIEnv* env, jobject thiz, jobject surface) {
     try {
+        // Cache the PulpSurfaceView for outbound-drag up-calls and register the
+        // process-global drag backend View::start_file_drag falls back to.
+        g_surface_view = pulp::android::GlobalRef(env, thiz);
+        pulp::view::set_file_drag_backend([](const pulp::view::FileDragRequest& req) {
+            return android_start_file_drag(req.file_paths);
+        });
+
         ANativeWindow* window = ANativeWindow_fromSurface(env, surface);
         if (window) {
             pulp::render::android_surface_created(window);

--- a/core/view/include/pulp/view/drag_drop.hpp
+++ b/core/view/include/pulp/view/drag_drop.hpp
@@ -121,6 +121,20 @@ struct FileDragRequest {
 // register_drop_target (macOS today; a no-op stub elsewhere).
 bool begin_file_drag(void* native_view, const FileDragRequest& request);
 
+// Process-global outbound file-drag backend for HOSTLESS platforms — Android,
+// where the view tree is a bare root View with no WindowHost / PluginViewHost,
+// so neither the host virtual nor the native-handle free function above can be
+// reached. The platform layer registers a backend (Android: a JNI up-call into
+// Kotlin's View.startDragAndDrop); View::start_file_drag() invokes it only as a
+// last resort, after the host paths decline. Returns the previous backend so a
+// caller can restore it. Pass nullptr to clear.
+using FileDragBackend = std::function<bool(const FileDragRequest&)>;
+FileDragBackend set_file_drag_backend(FileDragBackend backend);
+
+// Invoke the registered global backend; returns false if none is set. Used by
+// View::start_file_drag() — application code should call View::start_file_drag.
+bool invoke_file_drag_backend(const FileDragRequest& request);
+
 // ── Drag-drop registration ──────────────────────────────────────────────────
 
 // Register/unregister a native view for file drops (macOS NSView). See the

--- a/core/view/src/drag_drop.cpp
+++ b/core/view/src/drag_drop.cpp
@@ -135,6 +135,22 @@ bool dispatch_drop(View& root, DragSession& session, const DropData& data,
     return false;
 }
 
+// ── Process-global outbound drag backend (hostless platforms; Android) ───────
+
+namespace {
+FileDragBackend g_file_drag_backend;
+}  // namespace
+
+FileDragBackend set_file_drag_backend(FileDragBackend backend) {
+    FileDragBackend prev = std::move(g_file_drag_backend);
+    g_file_drag_backend = std::move(backend);
+    return prev;
+}
+
+bool invoke_file_drag_backend(const FileDragRequest& request) {
+    return g_file_drag_backend ? g_file_drag_backend(request) : false;
+}
+
 #if !defined(__APPLE__)
 // Outbound file drag is macOS-only today — the NSDraggingSession backend lives
 // in platform/mac/drag_drop_mac.mm, which is compiled only on macOS. On every

--- a/core/view/src/drag_drop.cpp
+++ b/core/view/src/drag_drop.cpp
@@ -16,6 +16,8 @@
 
 #include <pulp/view/view.hpp>
 
+#include <mutex>
+
 namespace pulp::view {
 
 namespace {
@@ -138,17 +140,30 @@ bool dispatch_drop(View& root, DragSession& session, const DropData& data,
 // ── Process-global outbound drag backend (hostless platforms; Android) ───────
 
 namespace {
+// Guards g_file_drag_backend: it is set on the platform's surface/render thread
+// (Android registers it from nativeOnSurfaceCreated) but invoked from the UI
+// thread during a drag, so an unsynchronised std::function read could tear.
+std::mutex g_file_drag_backend_mutex;
 FileDragBackend g_file_drag_backend;
 }  // namespace
 
 FileDragBackend set_file_drag_backend(FileDragBackend backend) {
+    std::lock_guard<std::mutex> lock(g_file_drag_backend_mutex);
     FileDragBackend prev = std::move(g_file_drag_backend);
     g_file_drag_backend = std::move(backend);
     return prev;
 }
 
 bool invoke_file_drag_backend(const FileDragRequest& request) {
-    return g_file_drag_backend ? g_file_drag_backend(request) : false;
+    // Copy under the lock, then invoke unlocked — the backend may up-call into
+    // platform code (Android: a JNI call into Kotlin) and must not run holding
+    // the lock.
+    FileDragBackend backend;
+    {
+        std::lock_guard<std::mutex> lock(g_file_drag_backend_mutex);
+        backend = g_file_drag_backend;
+    }
+    return backend ? backend(request) : false;
 }
 
 #if !defined(__APPLE__)

--- a/core/view/src/view.cpp
+++ b/core/view/src/view.cpp
@@ -1218,9 +1218,13 @@ bool View::start_file_drag(const FileDragRequest& request) {
     } else if (plugin_view_host_) {
         native_view = plugin_view_host_->native_handle();
     }
-    if (!native_view) return false;
+    if (native_view) return begin_file_drag(native_view, request);
 
-    return begin_file_drag(native_view, request);
+    // Hostless platforms (Android: the tree is a bare root View with no
+    // Window/PluginViewHost) fall back to the process-global drag backend the
+    // platform layer registered — Android's is a JNI up-call into Kotlin's
+    // View.startDragAndDrop. Returns false when no backend is registered.
+    return invoke_file_drag_backend(request);
 }
 
 void View::simulate_hover(Point root_pos) {


### PR DESCRIPTION
## What

Android had **no** drag-and-drop. Wires **inbound**: `PulpSurfaceView` accepts dropped files and routes them into the C++ view tree's shared `dispatch_drop` core (same core mac/win/linux/iOS use), mirroring the existing touch path.

- **Kotlin** (`PulpSurfaceView.kt`): `setOnDragListener` accepts drags with items; `ACTION_DROP` requests drag-drop permission, copies each ClipData `content://` URI into `cacheDir/dropped/` via `ContentResolver` (C++ needs filesystem paths), then `nativeOnDrop(paths, x, y)`.
- **JNI** (`gpu_surface_android_jni.cpp`): marshals the `jobjectArray` → `std::vector<std::string>` → `android_on_drop`.
- **C++** (`gpu_surface_android.cpp`): `android_on_drop` converts px→dp and calls `dispatch_drop(*g_root_view, …)`.

## Validation (locally — Android isn't in this repo's main PR build matrix)
- ✅ Android arm64 native build (`pulp-render`) compiles with the new Skia.
- ✅ `./gradlew :app:compileDebugKotlin` **BUILD SUCCESSFUL** (Kotlin + JNI symbol match).
- Android Skia built from source (`tools/build-skia-android.sh`) since the `skia-builder` fork ships **no** android slice. The OS drag gesture is emulator-only (not headless-testable, same as touch).

## Scope
**Inbound only.** Outbound (`View::start_file_drag` → `startDragAndDrop`) is a follow-up: Android's tree is the bare global `g_root_view` with no `WindowHost`/`PluginViewHost`, so `start_file_drag` has no host pointer to dispatch through — that needs a host-owned drag path + JNI up-call to Kotlin.

Completes the cross-platform drag sweep's inbound coverage (mac/win/linux/iOS/**android**). Part of #4073 / #4083 / #4085 / #4092.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full Android native drag-and-drop: inbound file drops and outbound file drags, routed through the shared C++ `dispatch_drop` with a new hostless drag backend. Brings Android to parity and hardens URI handling and threading.

- **New Features**
  - Kotlin inbound: `setOnDragListener` → `requestDragAndDropPermissions`, copy `content://` URIs to `cacheDir/dropped/`, then `nativeOnDrop(paths, x, y)`.
  - Kotlin outbound: `startFileDrag` builds `ClipData` from `androidx.core.content.FileProvider` URIs and calls `startDragAndDrop` with global URI read flags.
  - JNI: cache `PulpSurfaceView` at `surfaceCreated`; register a global backend (`set_file_drag_backend`) that up-calls `startFileDrag(String[])`; marshal dropped paths to `android_on_drop`.
  - C++: add process-global outbound drag seam (`set_file_drag_backend`/`invoke_file_drag_backend`); `View::start_file_drag` falls back to it when no host; `android_on_drop` converts px→dp and calls `dispatch_drop`.
  - Manifest/config: add `<provider>` for `${applicationId}.fileprovider` and `res/xml/file_paths.xml` for outbound drags.

- **Bug Fixes**
  - Block path traversal on inbound drops: strip display names to a leaf (`File(raw).name`) and verify canonical paths stay under `cacheDir/dropped/`.
  - Guard global drag backend and cached `PulpSurfaceView` with a mutex; clear both on `nativeOnSurfaceDestroyed` to avoid stale up-calls.
  - JNI safety: handle `NewStringUTF` OOM and clear exceptions during up-calls.

<sup>Written for commit f7a18f1c348837b05e4173ffa14c53ddf15e686b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

