### PR TITLE
feat(view): Linux standalone outbound file drag (XDND source)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.437.1
+    VERSION 0.438.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -736,7 +736,12 @@ elseif(UNIX)
         target_sources(pulp-view-core PRIVATE src/screenshot_skia.cpp)
         find_package(X11)
         if(X11_FOUND)
-            target_sources(pulp-view-core PRIVATE platform/linux/plugin_view_host_linux.cpp)
+            target_sources(pulp-view-core PRIVATE
+                platform/linux/plugin_view_host_linux.cpp
+                # Standalone outbound file-drag backend (free begin_file_drag via
+                # XDND source). Gated with PULP_HAS_X11 so the drag_drop.cpp no-op
+                # drops out only when this real backend is compiled.
+                platform/linux/drag_drop_linux.cpp)
             target_link_libraries(pulp-view-core PRIVATE ${X11_LIBRARIES})
             target_include_directories(pulp-view-core PRIVATE ${X11_INCLUDE_DIR})
             target_compile_definitions(pulp-view-core PRIVATE PULP_HAS_X11=1)

--- a/core/view/platform/linux/drag_drop_linux.cpp
+++ b/core/view/platform/linux/drag_drop_linux.cpp
@@ -1,0 +1,44 @@
+// Linux standalone outbound file-drag backend (XDND source).
+//
+// View::start_file_drag falls through to the free begin_file_drag(native_view, …)
+// when the view tree is owned by a WindowHost (the SDL standalone app) rather
+// than a plugin host. On Linux native_view is the X11 Window id
+// (SdlWindowHostImpl::native_content_view_handle). We open our OWN Display
+// connection — X11 atoms are server-global, and the source only needs to own the
+// XdndSelection + grab the pointer, both of which work for a window id across a
+// second connection (same pattern as the X11 plugin host) — and run the shared
+// XDND source handshake from xdnd_source.hpp.
+//
+// Compiled only where Xlib links (find_package(X11)); otherwise the
+// `#if !defined(__APPLE__) && …` no-op in drag_drop.cpp provides begin_file_drag.
+
+#include "xdnd_source.hpp"
+
+#include <pulp/view/drag_drop.hpp>
+
+#include <chrono>
+#include <cstdint>
+
+namespace pulp::view {
+
+bool begin_file_drag(void* native_view, const FileDragRequest& request) {
+    if (!native_view || request.file_paths.empty()) return false;
+    const Window source =
+        static_cast<Window>(reinterpret_cast<uintptr_t>(native_view));
+    if (!source) return false;
+
+    Display* display = XOpenDisplay(nullptr);
+    if (!display) return false;
+    int screen = DefaultScreen(display);
+    XWindowAttributes wa;
+    if (XGetWindowAttributes(display, source, &wa))
+        screen = XScreenNumberOfScreen(wa.screen);
+
+    const bool ok = xdnd::run_drag_source(display, screen, source,
+                                          request.file_paths,
+                                          std::chrono::seconds(60));
+    XCloseDisplay(display);
+    return ok;
+}
+
+}  // namespace pulp::view

--- a/core/view/platform/linux/xdnd_source.hpp
+++ b/core/view/platform/linux/xdnd_source.hpp
@@ -1,0 +1,182 @@
+#pragma once
+
+// Self-contained XDND drag-SOURCE handshake for the standalone window-host
+// outbound path (drag_drop_linux.cpp). Given a Display* and an XDND-aware
+// `source` window, it owns the XdndSelection, grabs the pointer, drives
+// XdndEnter/Position/Drop toward whatever XdndAware window is under the pointer,
+// serves the `text/uri-list` payload on request, and returns true if a target
+// accepted the drop. Bounded by a wall-clock deadline so an unresponsive target
+// can never wedge the grabbed pointer. X11-only (compiled where Xlib links).
+//
+// NOTE: the X11 plugin view host (plugin_view_host_linux.cpp) carries a parallel
+// member-function implementation (run_xdnd_source) bound to its own window. The
+// two are intentionally kept separate for now so the standalone path can't
+// regress the merged plugin-host path; a future refactor should have the host
+// delegate here. Keep the two in sync if the protocol changes.
+
+#include "xdnd_parse.hpp"  // build_uri_list
+
+#include <X11/Xlib.h>
+#include <X11/Xatom.h>
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+#include <unistd.h>  // usleep
+
+namespace pulp::view::xdnd {
+
+inline bool run_drag_source(Display* display, int screen, Window source,
+                            const std::vector<std::string>& paths,
+                            std::chrono::milliseconds timeout) {
+    if (!display || !source || paths.empty()) return false;
+    const std::string uri_list = build_uri_list(paths);
+    if (uri_list.empty()) return false;
+
+    // X11 atoms are a server-global namespace, so interning on this connection
+    // yields the same ids any target uses.
+    const Atom xa_XdndAware = XInternAtom(display, "XdndAware", False);
+    const Atom xa_XdndEnter = XInternAtom(display, "XdndEnter", False);
+    const Atom xa_XdndPosition = XInternAtom(display, "XdndPosition", False);
+    const Atom xa_XdndStatus = XInternAtom(display, "XdndStatus", False);
+    const Atom xa_XdndLeave = XInternAtom(display, "XdndLeave", False);
+    const Atom xa_XdndDrop = XInternAtom(display, "XdndDrop", False);
+    const Atom xa_XdndFinished = XInternAtom(display, "XdndFinished", False);
+    const Atom xa_XdndSelection = XInternAtom(display, "XdndSelection", False);
+    const Atom xa_XdndActionCopy = XInternAtom(display, "XdndActionCopy", False);
+    const Atom xa_text_uri_list = XInternAtom(display, "text/uri-list", False);
+
+    auto aware_version = [&](Window w) -> int {
+        Atom type = None; int fmt = 0; unsigned long n = 0, after = 0;
+        unsigned char* data = nullptr; int ver = 0;
+        if (XGetWindowProperty(display, w, xa_XdndAware, 0, 1, False, AnyPropertyType,
+                               &type, &fmt, &n, &after, &data) == Success) {
+            if (data && type != None && fmt == 32 && n >= 1)
+                ver = static_cast<int>(reinterpret_cast<long*>(data)[0]);
+        }
+        if (data) XFree(data);
+        return ver;
+    };
+    // The XdndAware window under a root-space pointer: descend to the deepest
+    // window, then walk up to the first XdndAware ancestor.
+    auto target_at = [&](int rx, int ry, int* version_out) -> Window {
+        Window root = RootWindow(display, screen);
+        Window cur = root, child = root; int wx = 0, wy = 0;
+        while (child != None &&
+               XTranslateCoordinates(display, root, cur, rx, ry, &wx, &wy, &child)) {
+            if (child == None) break;
+            cur = child;
+        }
+        for (Window w = cur; w != None;) {
+            int ver = aware_version(w);
+            if (ver > 0) { if (version_out) *version_out = ver < 5 ? ver : 5; return w; }
+            Window r = 0, parent = 0, *kids = nullptr; unsigned int nk = 0;
+            if (!XQueryTree(display, w, &r, &parent, &kids, &nk)) break;
+            if (kids) XFree(kids);
+            if (w == r || parent == None) break;
+            w = parent;
+        }
+        return None;
+    };
+    auto send = [&](Window target, Atom message, long d0, long d1, long d2,
+                    long d3, long d4) {
+        XEvent e{};
+        e.xclient.type = ClientMessage;
+        e.xclient.display = display;
+        e.xclient.window = target;
+        e.xclient.message_type = message;
+        e.xclient.format = 32;
+        e.xclient.data.l[0] = d0; e.xclient.data.l[1] = d1; e.xclient.data.l[2] = d2;
+        e.xclient.data.l[3] = d3; e.xclient.data.l[4] = d4;
+        XSendEvent(display, target, False, NoEventMask, &e);
+    };
+    auto serve = [&](const XSelectionRequestEvent& req) {
+        XEvent note{};
+        note.xselection.type = SelectionNotify;
+        note.xselection.display = req.display;
+        note.xselection.requestor = req.requestor;
+        note.xselection.selection = req.selection;
+        note.xselection.target = req.target;
+        note.xselection.time = req.time;
+        note.xselection.property = None;
+        if (req.target == xa_text_uri_list && req.property != None) {
+            XChangeProperty(display, req.requestor, req.property, req.target, 8,
+                            PropModeReplace,
+                            reinterpret_cast<const unsigned char*>(uri_list.data()),
+                            static_cast<int>(uri_list.size()));
+            note.xselection.property = req.property;
+        }
+        XSendEvent(display, req.requestor, False, NoEventMask, &note);
+    };
+
+    XSetSelectionOwner(display, xa_XdndSelection, source, CurrentTime);
+    if (XGetSelectionOwner(display, xa_XdndSelection) != source) return false;
+    if (XGrabPointer(display, source, True, ButtonReleaseMask | PointerMotionMask,
+                     GrabModeAsync, GrabModeAsync, None, None,
+                     CurrentTime) != GrabSuccess) {
+        return false;
+    }
+
+    Window target = None;
+    int target_ver = 0;
+    bool accepted = false;  // last XdndStatus accept bit
+    bool dropped = false;   // we have sent XdndDrop
+    bool result = false;
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+
+    XEvent ev;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (XPending(display) == 0) { usleep(2000); continue; }
+        XNextEvent(display, &ev);
+
+        if (ev.type == MotionNotify && !dropped) {
+            const int rx = ev.xmotion.x_root, ry = ev.xmotion.y_root;
+            int ver = 0;
+            const Window t = target_at(rx, ry, &ver);
+            if (t != target) {
+                if (target != None)
+                    send(target, xa_XdndLeave, static_cast<long>(source), 0, 0, 0, 0);
+                target = t; target_ver = ver; accepted = false;
+                if (target != None)
+                    send(target, xa_XdndEnter, static_cast<long>(source),
+                         (static_cast<long>(target_ver) << 24),
+                         static_cast<long>(xa_text_uri_list), 0, 0);
+            }
+            if (target != None)
+                send(target, xa_XdndPosition, static_cast<long>(source), 0,
+                     (rx << 16) | (ry & 0xFFFF),
+                     static_cast<long>(ev.xmotion.time),
+                     static_cast<long>(xa_XdndActionCopy));
+        } else if (ev.type == ClientMessage) {
+            if (ev.xclient.message_type == xa_XdndStatus) {
+                accepted = (ev.xclient.data.l[1] & 1L) != 0;
+            } else if (ev.xclient.message_type == xa_XdndFinished) {
+                result = dropped && (ev.xclient.data.l[1] & 1L) != 0;
+                break;
+            }
+        } else if (ev.type == SelectionRequest) {
+            if (ev.xselectionrequest.selection == xa_XdndSelection)
+                serve(ev.xselectionrequest);
+        } else if (ev.type == ButtonRelease && ev.xbutton.button == Button1) {
+            if (target != None && accepted) {
+                send(target, xa_XdndDrop, static_cast<long>(source), 0,
+                     static_cast<long>(ev.xbutton.time), 0, 0);
+                dropped = true;  // keep pumping for the serve + XdndFinished
+            } else {
+                if (target != None)
+                    send(target, xa_XdndLeave, static_cast<long>(source), 0, 0, 0, 0);
+                break;
+            }
+        }
+    }
+
+    XUngrabPointer(display, CurrentTime);
+    // Relinquish XdndSelection ownership now the drag is over (mirrors the plugin
+    // host's hardening — the timeout/cancel paths must not leak ownership).
+    XSetSelectionOwner(display, xa_XdndSelection, None, CurrentTime);
+    XFlush(display);
+    return result;
+}
+
+}  // namespace pulp::view::xdnd

--- a/core/view/src/drag_drop.cpp
+++ b/core/view/src/drag_drop.cpp
@@ -166,14 +166,14 @@ bool invoke_file_drag_backend(const FileDragRequest& request) {
     return backend ? backend(request) : false;
 }
 
-#if !defined(__APPLE__)
-// Outbound file drag is macOS-only today — the NSDraggingSession backend lives
-// in platform/mac/drag_drop_mac.mm, which is compiled only on macOS. On every
-// other platform View::start_file_drag (cross-platform, in view.cpp) still
-// references begin_file_drag, so provide a no-op here so it links and degrades
-// gracefully. Windows (IDataObject/DoDragDrop) and Linux (XDND) backends can
-// supply a real implementation in their own platform TU when they land; this
-// definition then drops out via the same __APPLE__-style guard.
+#if !defined(__APPLE__) && !(defined(__linux__) && defined(PULP_HAS_X11))
+// Outbound file drag free-function backend, used by View::start_file_drag when
+// the tree is owned by a WindowHost (standalone app) rather than a plugin host.
+// Real backends live per platform: macOS NSDraggingSession (drag_drop_mac.mm)
+// and Linux XDND (drag_drop_linux.cpp, compiled when Xlib links — PULP_HAS_X11).
+// This no-op covers the platforms without one yet (Windows standalone, headless
+// Linux) so the cross-platform call site links and degrades gracefully; each new
+// backend extends the guard above as it lands.
 bool begin_file_drag(void* /*native_view*/, const FileDragRequest& /*request*/) {
     return false;
 }


### PR DESCRIPTION
## What

Completes the **standalone-app** outbound drag on Linux (plugin-host Linux outbound already shipped in #4073). `View::start_file_drag` falls through to the free `begin_file_drag(native_view, …)` when the tree is owned by a `WindowHost` (SDL standalone); this adds that Linux backend.

- **`xdnd_source.hpp`** — self-contained XDND drag-source handshake (own `XdndSelection`, grab pointer, drive `XdndEnter/Position/Drop`, serve `text/uri-list`, deadline-bounded, release selection on exit). Deliberately **separate** from the plugin host's `run_xdnd_source` so the standalone path can't regress the merged host (a follow-up can unify).
- **`drag_drop_linux.cpp`** — `begin_file_drag` opens its own Display from the SDL X11 Window and runs the handshake. Compiled only when Xlib links (`PULP_HAS_X11`); the `drag_drop.cpp` no-op drops out for linux+X11.

## Dependency / scope
Activates once `SdlWindowHostImpl::native_content_view_handle()` returns the X11 Window — that lands via the **Windows-standalone PR #4092**. Until then `begin_file_drag` is present but gets no window, so it **safely returns false (no regression)**. CI's release-path-linux lane compiles the real backend. The merged X11 **plugin host is untouched** (zero regression risk). Live drag gesture is emulator/VM-only (no local Linux + Pulp CI has no xvfb).

Final piece of the cross-platform drag sweep (#4073/#4083/#4085/#4092/#4094).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Linux standalone outbound file drag using XDND for the SDL window host. Lets users drag files from the standalone app to XDND-aware targets, with a safe fallback when no window handle is available.

- **New Features**
  - `xdnd_source.hpp`: self-contained XDND source; owns `XdndSelection`, grabs pointer, drives `XdndEnter/Position/Drop`, serves `text/uri-list`, deadline-bounded, releases on exit.
  - `drag_drop_linux.cpp`: implements `begin_file_drag` by opening its own X11 `Display` and running the XDND handshake for the SDL X11 `Window`.
  - Activates when `SdlWindowHostImpl::native_content_view_handle()` returns an X11 `Window`; otherwise returns false. Plugin-host path unchanged.

- **Dependencies**
  - Built only when `X11` is found; defines `PULP_HAS_X11` so the `drag_drop.cpp` no-op drops out on Linux+X11. Other platforms keep the no-op.
  - Version bumped to 0.438.0.

<sup>Written for commit c452068b2a8d353429a55a454f112e775c0a7695. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

