### PR TITLE
ci(coverage): make the best-effort budget kill unconditional (adversarial-review fix)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -260,10 +260,16 @@ coverage suite step self-terminates at an **internal budget (135 min) below the
 job cap**, turning the would-be cancellation into a normal non-zero exit that
 the job-level `continue-on-error: matrix.os=='windows'` then absorbs → the run
 concludes `success`. Don't "simplify" this to bare `continue-on-error`; it will
-silently stop closing the watchdog. Real os-windows *correctness* bugs are
-still worth fixing (the ARG_MAX response-file + vanished-`-object`
-existence-filter + mass-drop guard in `run_coverage.sh` were real); only the
-runtime/timeout is accepted as best-effort.
+silently stop closing the watchdog. **And the watchdog that enforces the budget
+must separate its steps with `;`, NOT `&&`** — if the kill is `&&`-gated behind
+a `: > marker` write (which can fail on a Windows `RUNNER_TEMP` backslash path),
+a failed marker write short-circuits the chain and the suite is never killed,
+so the job hits the 150-min cap and is *cancelled* anyway. The kill is
+mandatory; the marker is best-effort (cleanup of any partial Cobertura also
+triggers on a 143/137 signal-kill exit, not just the marker). Real os-windows
+*correctness* bugs are still worth fixing (the ARG_MAX response-file +
+vanished-`-object` existence-filter + mass-drop guard in `run_coverage.sh` were
+real); only the runtime/timeout is accepted as best-effort.
 
 ### Advisory cross-lane workflow: `macos-cross-advisory.yml`
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -541,25 +541,33 @@ jobs:
         run: |
           budget=$(( 135 * 60 ))   # 135 min < 150-min job cap
           budget_hit="${RUNNER_TEMP:-/tmp}/coverage-budget-hit"
-          rm -f "${budget_hit}"
+          rm -f "${budget_hit}" 2>/dev/null || true
           scripts/run_coverage.sh & cov=$!
-          ( sleep "${budget}" \
-              && echo "::warning::coverage suite hit the ${budget}s best-effort budget (expected on os-windows); terminating — leg is non-fatal." \
-              && : > "${budget_hit}" \
-              && kill -TERM "${cov}" 2>/dev/null \
-              && sleep 15 && kill -KILL "${cov}" 2>/dev/null ) & watch=$!
+          # Watchdog. Steps are separated by ';' (NOT '&&') so a failed marker
+          # write or warning echo can NEVER skip the kill — terminating the suite
+          # before the job cap is the entire point. The marker is best-effort; the
+          # kill is mandatory.
+          ( sleep "${budget}"
+            echo "::warning::coverage suite hit the ${budget}s best-effort budget (expected on os-windows); terminating — leg is non-fatal."
+            : > "${budget_hit}" 2>/dev/null || true
+            kill -TERM "${cov}" 2>/dev/null || true
+            sleep 15
+            kill -KILL "${cov}" 2>/dev/null || true ) & watch=$!
           set +e; wait "${cov}"; rc=$?; set -e
           kill -TERM "${watch}" 2>/dev/null || true
           wait "${watch}" 2>/dev/null || true
-          if [ -f "${budget_hit}" ]; then
-            # Best-effort timeout: drop any PARTIAL Cobertura/LCOV that the
-            # interrupted llvm-cov export may have left behind, so the verify +
-            # Codecov upload steps publish NOTHING for os-windows rather than a
-            # truncated, valid-looking number. A clean miss beats a wrong number.
+          # Best-effort timeout cleanup. Trigger on EITHER the marker OR a
+          # signal-kill exit (143=SIGTERM, 137=SIGKILL — our watchdog's signals),
+          # so a marker-write that failed on a Windows RUNNER_TEMP path can't
+          # leave a PARTIAL Cobertura/LCOV for the verify + Codecov upload steps
+          # to publish as a truncated, valid-looking number. A clean miss beats a
+          # wrong number.
+          if [ -f "${budget_hit}" ] || [ "${rc}" -eq 143 ] || [ "${rc}" -eq 137 ]; then
+            echo "::warning::dropping any partial Cobertura/LCOV from the interrupted coverage run (best-effort os-windows)."
             rm -f build-coverage/coverage.cobertura.xml \
                   build-coverage/coverage/coverage.lcov 2>/dev/null || true
-            rm -f "${budget_hit}"
           fi
+          rm -f "${budget_hit}" 2>/dev/null || true
           exit "${rc}"
 
       - name: Install Python coverage tooling


### PR DESCRIPTION
Adversarial review of #4088's *own* landed wrapper caught a real bug.

The os-windows best-effort watchdog chained its steps with `&&`:
```bash
( sleep $budget && echo ... && : > $budget_hit && kill -TERM $cov && sleep 15 && kill -KILL $cov )
```
If the marker write (`: > $budget_hit`) fails — most plausible on **Windows** Git Bash with a `RUNNER_TEMP` backslash path — the `&&` short-circuits and **the kill never runs**. `run_coverage.sh` then survives to the 150-min `timeout-minutes` cap → the job is **cancelled** → the exact failure the budget exists to prevent, recurring on the very platform it targets (and a cancellation is *not* neutralised by `continue-on-error`, so the run would conclude `cancelled` and never close #3947).

## Fix
- Separate the watchdog steps with `;` so the **kill is unconditional** (marker best-effort, kill mandatory).
- Trigger the partial-Cobertura cleanup on **either** the marker **or** a signal-kill exit (`143`/`137`), so a failed marker write can't leave a truncated report to upload.

## Validation
- Reproduced locally: under `&&` a failed marker write skips the kill (suite survives); with `;` the kill **fires** (`rc=143`) despite the marker write failing, and the cleanup still triggers via the signal-exit fallback.
- coverage.yml YAML valid; embedded `bash -n` clean; gates green; `ci` skill updated with the `;`-not-`&&` gotcha.

Follow-up to #4088 (no behavior change on Linux/macOS — they finish ~1h, far under the budget, so the watchdog never reaches the chain there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Windows coverage watchdog always terminate the suite before the job cap. Replace the chained '&&' with ';' so a failed marker write can’t skip the kill, and add cleanup on signal exit to avoid uploading partial reports.

- **Bug Fixes**
  - Watchdog steps now use ';' so the kill runs even if the marker write or warning echo fails.
  - Cleanup triggers on the marker or rc 143/137 to drop partial Cobertura/LCOV and prevent truncated uploads on Windows.
  - Updated CI skill docs to note the '; not &&' requirement.

<sup>Written for commit a0fc33248ed680859c16a389e3f68e9d5f29efae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

