### PR TITLE
fix(audio,canvas): post-review hardening + test coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.442.0
+    VERSION 0.443.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/audio/src/streaming_sample_source.cpp
+++ b/core/audio/src/streaming_sample_source.cpp
@@ -328,6 +328,12 @@ void StreamingSampleSource::reader_loop() noexcept {
 void StreamingSampleSource::notify_reader() noexcept { cv_.notify_all(); }
 
 bool StreamingSampleSource::finished() const noexcept {
+    // A zero-length source is immediately finished — there is nothing to play or
+    // loop over. This happens when a looping voice's preload read yields 0 frames
+    // (total_frames_ shrinks to 0); without this guard the resident-loop branch
+    // below would loop silence forever and never report finished, leaking the
+    // voice. (total_frames_ is immutable after prepare(), so this read is safe.)
+    if (total_frames_ == 0) return true;
     if (loop_ && fully_resident_) return false;  // resident loop never ends
     // Compare against the effective end so a stream that ended early (reader
     // returned 0 mid-tail) still reports finished once its realized frames have

--- a/core/canvas/include/pulp/canvas/box_shadow_cache.hpp
+++ b/core/canvas/include/pulp/canvas/box_shadow_cache.hpp
@@ -60,7 +60,7 @@ struct BoxShadowKey {
         // a parsed/animated shadow param can reach inf/NaN. Map non-finite to a
         // fixed bucket and clamp so the *4 and the cast can't overflow int32.
         if (!std::isfinite(v)) return 0;
-        constexpr float kLimit = 4.0e8f;  // /4 ≈ 1e8, well inside int32 range
+        constexpr float kLimit = 4.0e8f;  // *4 ≈ 1.6e9, well inside int32 range
         if (v > kLimit) v = kLimit;
         else if (v < -kLimit) v = -kLimit;
         return static_cast<std::int32_t>(v * 4.0f + (v < 0 ? -0.5f : 0.5f));

--- a/test/test_box_shadow_cache.cpp
+++ b/test/test_box_shadow_cache.cpp
@@ -11,6 +11,7 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <limits>
 #include <vector>
 
 using pulp::canvas::BoxShadowCache;
@@ -121,6 +122,47 @@ TEST_CASE("geometry change triggers a re-blur", "[canvas][shadow][cache]") {
     const auto s = cache.stats();
     CAPTURE(s.renders, s.hits);
     REQUIRE(s.renders == 2);
+}
+
+TEST_CASE("box shadow cache skips an oversized shadow (falls through to direct path)",
+          "[canvas][shadow][cache]") {
+    // Regression: a shadow whose device extent exceeds Skia's 16384px max must NOT
+    // be cached. The old code clamped the coverage surface to the max and stretched
+    // it across the destination (squished shadow); the fix returns nullptr from the
+    // render lambda so the caller falls through to the direct (uncached) path.
+    // Assert nothing gets cached (the lambda returned null → no entry stored).
+    auto& cache = BoxShadowCache::instance();
+    cache.clear();
+    cache.set_enabled(true);
+    cache.reset_stats();
+
+    const Color col = Color::rgba(0.0f, 0.0f, 0.0f, 0.5f);
+    // scale 240 * ~100px local extent ≈ 24000 device px > 16384 → oversized.
+    render_box_shadow_to_rgba(256, 256, 240.0f, 40, 40, 90, 70, 0, 6, 18, 2, col, 14,
+                              false);
+    REQUIRE(cache.stats().size == 0);  // oversized → not cached, no squished entry
+}
+
+TEST_CASE("BoxShadowKey::q handles non-finite and out-of-range inputs",
+          "[canvas][shadow][cache]") {
+    using pulp::canvas::BoxShadowKey;
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+    const float inf = std::numeric_limits<float>::infinity();
+
+    // Non-finite → a fixed bucket (0), never UB in the int cast.
+    REQUIRE(BoxShadowKey::q(nan) == 0);
+    REQUIRE(BoxShadowKey::q(inf) == 0);
+    REQUIRE(BoxShadowKey::q(-inf) == 0);
+
+    // Huge finite values are clamped to ±kLimit before the *4 and cast (no int32
+    // overflow / UB) — they map to the same bucket as the clamp boundary.
+    REQUIRE(BoxShadowKey::q(1.0e30f) == BoxShadowKey::q(4.0e8f));
+    REQUIRE(BoxShadowKey::q(-1.0e30f) == BoxShadowKey::q(-4.0e8f));
+
+    // Normal quantization is unaffected (1/4-unit buckets).
+    REQUIRE(BoxShadowKey::q(0.0f) == 0);
+    REQUIRE(BoxShadowKey::q(1.0f) == 4);
+    REQUIRE(BoxShadowKey::q(-1.0f) == -4);
 }
 
 #endif  // PULP_HAS_SKIA

--- a/test/test_streaming_sample_source.cpp
+++ b/test/test_streaming_sample_source.cpp
@@ -435,3 +435,30 @@ TEST_CASE("StreamingSampleSource zero-fills surplus destination channels",
         REQUIRE(out.channel(1)[f] == 0.0f);                         // zeroed surplus
     }
 }
+
+TEST_CASE("StreamingSampleSource finishes a looping source that yields no frames",
+          "[audio][streaming][issue-streaming]") {
+    // Regression: a LOOPING voice whose preload read returns 0 frames (empty or
+    // failed source) shrinks total_frames_ to 0 and becomes resident. Without the
+    // zero-length guard, the resident-loop path would emit silence forever and
+    // finished() would never fire — leaking the voice. A zero-length source must
+    // report finished immediately, loop flag notwithstanding.
+    const std::uint32_t channels = 1;
+
+    StreamingSampleSourceConfig cfg;
+    cfg.channels = channels;
+    cfg.total_frames = 8000;
+    cfg.preload_frames = 8000;            // would be fully resident
+    cfg.loop = true;                       // looping
+    cfg.start_background_thread = false;
+
+    StreamingSampleSource src;
+    // Reader's realized length is 0 → preload read yields nothing.
+    REQUIRE(src.prepare(cfg, make_synth_reader(channels, 0)));
+    REQUIRE(src.total_frames() == 0);
+    REQUIRE(src.finished());  // the bug: looped silence forever before the fix
+
+    Buffer<float> out(channels, 256);
+    REQUIRE(src.pull(out.view(), 256) == 0);  // nothing to emit
+    REQUIRE(src.finished());                  // still finished after a pull
+}


### PR DESCRIPTION
Follow-up to the adversarial **re-review** of the merged batch (#4077–#4080). The re-review (focused on the fixes themselves) found no P0/P1; these are the two legitimate items it surfaced, bundled.

## 1. #4077 follow-up — looping empty source leaked the voice (P2)
A **looping** `StreamingSampleSource` whose preload read yields 0 frames shrinks `total_frames_` to 0 and becomes resident → the resident-loop path emits silence forever and `finished()` never fires (voice leak). `finished()` now treats a zero-length source as finished regardless of the loop flag. Regression test added.

## 2. #4079 follow-up — missing direct tests for the hardened shadow paths
The oversize→fallback and `q()` non-finite guards had no *direct* coverage (only the mean/worst parity case). Added:
- oversized shadow (device extent > 16384px) falls through to the direct path and is **not** cached (`stats().size == 0`) — guards against the old clamp-and-squish.
- `BoxShadowKey::q()` unit test: non-finite → fixed bucket, huge finite → clamped (no int32 UB), normal quantization intact.

Also fixed a stale comment (the bound is the `*4` product, not `/4`).

Local: `pulp-test-streaming-sample-source` (12 cases) and `pulp-test-box-shadow-cache` (6 cases) green; all version/skill/hotspot gates pass. SDK patch→minor bump to 0.442.0 (plugin untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a voice leak when a looping audio source preloads 0 frames, and hardens the canvas shadow cache with direct tests. Oversized shadows now bypass caching, and non‑finite/huge values are safely clamped.

- **Bug Fixes**
  - Audio: treat zero-length `StreamingSampleSource` as finished even when looping; regression test added.
  - Canvas: skip caching for oversized shadows; clamp `BoxShadowKey::q()` non‑finite/huge inputs; unit tests added.

- **Dependencies**
  - Bump project version to 0.443.0.

<sup>Written for commit 717d2497781291cf9a2d0a0b14878f48e9dc0ae1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

