### PR TITLE
fix(examples): component-shots creates its --out directory

### DIFF
--- a/examples/component-shots/main.cpp
+++ b/examples/component-shots/main.cpp
@@ -14,6 +14,8 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <filesystem>
+#include <system_error>
 #include <functional>
 #include <memory>
 #include <string>
@@ -204,6 +206,17 @@ int main(int argc, char** argv) {
             if (b == "skia") backend = ScreenshotBackend::skia;
             else if (b == "coregraphics") backend = ScreenshotBackend::coregraphics;
         }
+    }
+
+    // Create the output directory up front. Without this, render_to_file's
+    // ofstream silently fails to open and every cell reports "FAILED" — which
+    // reads as a render/Skia failure when it's just a missing directory.
+    std::error_code ec;
+    std::filesystem::create_directories(out, ec);
+    if (ec) {
+        std::fprintf(stderr, "could not create output dir '%s': %s\n",
+                     out.c_str(), ec.message().c_str());
+        return 1;
     }
 
     bool ok = true;


### PR DESCRIPTION
render_to_file's ofstream silently fails when the `--out` dir doesn't exist, so every cell prints `FAILED` — which reads exactly like a Skia/render failure. Now `std::filesystem::create_directories` up front. (Surfaced while provisioning Skia to visually verify the MTK toggle frames.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `component-shots` creates the `--out` directory before rendering to prevent silent `ofstream` failures and misleading "FAILED" output.

- **Bug Fixes**
  - Create the output dir with `std::filesystem::create_directories` before rendering.
  - If creation fails, print a clear error and exit with code 1.

<sup>Written for commit 9574514309f316a29d36f5a1449ef2c08793f4fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

