### PR TITLE
feat(view): wire the MusicalTypingKeyboard on-screen controls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.443.0
+    VERSION 0.444.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/design_frame_view.hpp
+++ b/core/view/include/pulp/view/design_frame_view.hpp
@@ -24,7 +24,11 @@ struct DesignFrameElement {
     // `swap` is a SWAP-LINK button: clicking its rect calls set_active_frame
     // (target_frame) — the importer's `swap` link (e.g. a mode toggle). It does
     // not light or emit notes; it changes which frame the view renders.
-    enum class Kind { knob, text_field, dropdown, tab_group, stepper, momentary, swap };
+    // `action` is a momentary command button: clicking its rect fires
+    // on_action(action) — an in-design control (octave −/+, velocity, sustain,
+    // pitch-bend preset). It does not light, emit notes, or swap frames; it
+    // names an action the consumer maps to its own state.
+    enum class Kind { knob, text_field, dropdown, tab_group, stepper, momentary, swap, action };
 
     Kind kind = Kind::knob;
 
@@ -64,6 +68,11 @@ struct DesignFrameElement {
     /// For Kind::swap: the frame index to activate when this button is clicked
     /// (the `swap` link target). -1 = unset.
     int target_frame = -1;
+
+    // ── action (command button) ──────────────────────────────────────────
+    /// For Kind::action: the action id fired (on_action) when clicked, e.g.
+    /// "octave_up". Empty = unset. Uses the x/y/w/h rect as the hit-region.
+    std::string action;
 };
 
 // Remove the first <rect> in `svg` whose x/y/width/height match (within `tol`)
@@ -169,6 +178,10 @@ public:
     std::function<void(int index, float value)> on_element_changed;
     std::function<void(int index)> on_gesture_begin;
     std::function<void(int index)> on_gesture_end;
+    // Fired when a Kind::action command button is clicked — its `action` id. The
+    // consumer (e.g. MusicalTypingKeyboard) maps the id to its own state
+    // (octave/velocity/sustain/pitch-bend). UI thread.
+    std::function<void(const std::string& action)> on_action;
 
     // The panel is the view's natural size — a host should size its window to
     // this aspect so the design fills it with no letterbox (see paint()).

--- a/core/view/include/pulp/view/musical_typing.hpp
+++ b/core/view/include/pulp/view/musical_typing.hpp
@@ -76,6 +76,10 @@ public:
     /// compute the MIDI note a typing key maps to for non-keyboard input (clicks).
     int octave_shift() const { return octave_shift_; }
 
+    /// Set the octave shift directly (clamped to a sane ±4-octave range). Lets an
+    /// on-screen octave −/+ control drive the same state the z/x keys do.
+    void set_octave_shift(int s) { octave_shift_ = std::clamp(s, -4, 4); }
+
     /// Release every held note (focus loss / capture disabled). Safe to call any
     /// time; a no-op when nothing is held.
     void all_notes_off() {

--- a/core/view/include/pulp/view/musical_typing_keyboard.hpp
+++ b/core/view/include/pulp/view/musical_typing_keyboard.hpp
@@ -56,6 +56,20 @@ public:
     // a host can set the base note / velocity or feed keys from its own path.
     MusicalTypingController& controller() { return controller_; }
 
+    // ── On-screen control callbacks ──────────────────────────────────────────
+    // The on-screen octave −/+ and velocity −/+ buttons drive the controller
+    // directly (they change the next note's octave/velocity, no callback needed).
+    // These surface the controls that DON'T map to controller state:
+    //   • on_pitch_bend(0..1) — fired by the 8 pitch-bend preset buttons
+    //     (left→right); the host maps the normalized value to its bend range.
+    //   • on_sustain(bool)    — fired by the sustain pad (toggles).
+    //   • on_modulation(0..1) — defined for the integration contract, but the
+    //     current design has NO modulation control (the "Modulation" label is a
+    //     placeholder), so it is never fired until a design revision adds one.
+    std::function<void(float bend)> on_pitch_bend;
+    std::function<void(bool on)> on_sustain;
+    std::function<void(float amount)> on_modulation;
+
     // ── Host-driven integration (e.g. PulpTempoSampler) ──────────────────────
     // Light keys from an EXTERNAL held-note set — host MIDI, an app-wide QWERTY
     // monitor, clicks elsewhere. Absolute MIDI notes; a note lights every key
@@ -89,6 +103,8 @@ protected:
 private:
     MusicalTypingController controller_;
     bool input_capture_ = true;   // false = host feeds QWERTY; we don't capture keys
+    bool sustain_ = false;        // sustain-pad toggle state (surfaced via on_sustain)
+    static constexpr float kVelStep = 1.0f / 16.0f;  // on-screen velocity −/+ increment
     // Last external held set from set_active_notes; re-applied after a frame swap
     // so the new frame reflects the host's still-held notes.
     std::vector<int> held_notes_;

--- a/core/view/src/design_frame_view.cpp
+++ b/core/view/src/design_frame_view.cpp
@@ -393,7 +393,8 @@ float DesignFrameView::element_value(int i) const {
         case DesignFrameElement::Kind::momentary:
             return e.value;  // pressed/lit flag (0 or 1)
         case DesignFrameElement::Kind::swap:
-            return -1.0f;  // a swap-link button has no value
+        case DesignFrameElement::Kind::action:
+            return -1.0f;  // swap-link / command buttons have no value
     }
     return -1.0f;
 }
@@ -424,7 +425,8 @@ void DesignFrameView::set_element_value(int i, float v) {
             e.value = (v > 0.5f) ? 1.0f : 0.0f;
             break;
         case DesignFrameElement::Kind::swap:
-            return;  // a swap-link button has no value to set
+        case DesignFrameElement::Kind::action:
+            return;  // swap-link / command buttons have no value to set
     }
     request_repaint();
 }
@@ -567,11 +569,12 @@ int DesignFrameView::hit_element(Point pos) const {
     // Momentary keys first: among rects containing the point, the SMALLEST-AREA
     // wins (a narrow black key beats the white key it overlaps), order-independent
     // so a re-export reorder can't change which key is hit. View-scoped.
-    // Swap-link buttons are always active (not view-scoped) and take precedence
-    // so a toggle never gets masked by an overlapping key region.
+    // Swap-link + action command buttons are always active (not view-scoped) and
+    // take precedence so a toggle/control never gets masked by a key region.
     for (int i = 0; i < static_cast<int>(elements_.size()); ++i) {
         const auto& e = elements_[i];
-        if (e.kind != DesignFrameElement::Kind::swap) continue;
+        if (e.kind != DesignFrameElement::Kind::swap &&
+            e.kind != DesignFrameElement::Kind::action) continue;
         if (sx >= e.x && sx < e.x + e.w && sy >= e.y && sy < e.y + e.h) return i;
     }
 
@@ -605,6 +608,11 @@ void DesignFrameView::on_mouse_down(Point pos) {
     if (hit >= 0 && elements_[hit].kind == DesignFrameElement::Kind::swap) {
         // Swap-link button: change the rendered frame; no drag, no note.
         set_active_frame(elements_[hit].target_frame);
+        return;
+    }
+    if (hit >= 0 && elements_[hit].kind == DesignFrameElement::Kind::action) {
+        // Command button: fire the action; no drag, no note, no frame change.
+        if (on_action) on_action(elements_[hit].action);
         return;
     }
     drag_ = hit;

--- a/core/view/src/musical_typing_keyboard.cpp
+++ b/core/view/src/musical_typing_keyboard.cpp
@@ -1,6 +1,8 @@
 #include <pulp/view/musical_typing_keyboard.hpp>
 #include <pulp/runtime/base64.hpp>
 
+#include <algorithm>
+#include <cstdlib>
 #include <string>
 #include <vector>
 
@@ -37,6 +39,30 @@ void append_toggle(std::vector<DesignFrameElement>& els) {
     add_swap(62, kTypingFrame);  // keyboard icon → typing mode (frame 0)
 }
 
+// The typing frame's on-screen command controls (action elements), in frame-0
+// (732×266) coords from Figma node 187:15: octave −/+ and velocity −/+ (the
+// bottom Z/X · C/V buttons), the sustain pad, and the 8 pitch-bend preset
+// buttons. Clicking one fires on_action(id); MusicalTypingKeyboard maps the id
+// to the controller (octave/velocity) or a callback (sustain/pitch-bend).
+void append_controls(std::vector<DesignFrameElement>& els) {
+    auto add = [&](std::string id, float x, float y, float w, float h) {
+        DesignFrameElement e;
+        e.kind = DesignFrameElement::Kind::action;
+        e.action = std::move(id);
+        e.x = x; e.y = y; e.w = w; e.h = h;
+        els.push_back(e);
+    };
+    add("octave_down", 114, 213, 32, 32);
+    add("octave_up",   155, 213, 32, 32);
+    add("vel_down",    321, 213, 32, 32);
+    add("vel_up",      362, 213, 32, 32);
+    add("sustain",      21, 110, 66, 92);
+    // 8 pitch-bend preset buttons, left→right (the design's "− + off … max" row).
+    static const float pbx[] = {108, 150, 200, 242, 284, 326, 368, 410};
+    for (int i = 0; i < 8; ++i)
+        add("pb_" + std::to_string(i), pbx[i], 63, 36, 38);
+}
+
 // Typing-mode playable keys, frame-0 (732×266) coords extracted from Figma node
 // 187:15. `note` is the relative semitone (0..17) in the Logic-style
 // "a w s e d f t g y h u j k o l p ; '" row. Black keys are narrower/shorter, so
@@ -61,6 +87,7 @@ std::vector<DesignFrameElement> build_typing_frame() {
         els.push_back(e);
     }
     append_toggle(els);
+    append_controls(els);   // octave / velocity / sustain / pitch-bend (typing only)
     return els;
 }
 
@@ -127,6 +154,25 @@ MusicalTypingKeyboard::MusicalTypingKeyboard()
     on_gesture_end = [this](int i) {
         const int n = midi_for_element(i);
         if (n >= 0 && on_note_off) on_note_off(n);
+    };
+
+    // On-screen command buttons (Kind::action) → controller state or a callback.
+    // octave/velocity drive the SAME controller the z/x·c/v keys do (so the next
+    // note reflects them); sustain + pitch-bend are surfaced as callbacks the
+    // host wires. (Modulation has no baked control in this design — the label is
+    // a placeholder — so on_modulation is defined for the contract but unwired.)
+    on_action = [this](const std::string& a) {
+        if (a == "octave_down")     controller_.set_octave_shift(controller_.octave_shift() - 1);
+        else if (a == "octave_up")  controller_.set_octave_shift(controller_.octave_shift() + 1);
+        else if (a == "vel_down")   controller_.velocity = std::clamp(controller_.velocity - kVelStep, 0.0f, 1.0f);
+        else if (a == "vel_up")     controller_.velocity = std::clamp(controller_.velocity + kVelStep, 0.0f, 1.0f);
+        else if (a == "sustain") {  sustain_ = !sustain_; if (on_sustain) on_sustain(sustain_); }
+        else if (a.rfind("pb_", 0) == 0) {
+            // 8 preset buttons, left→right → a normalized 0..1 bend; the host maps
+            // it to its own bend range.
+            const int i = std::clamp(std::atoi(a.c_str() + 3), 0, 7);
+            if (on_pitch_bend) on_pitch_bend(static_cast<float>(i) / 7.0f);
+        }
     };
 }
 

--- a/test/test_musical_typing_keyboard.cpp
+++ b/test/test_musical_typing_keyboard.cpp
@@ -357,3 +357,81 @@ TEST_CASE("MusicalTypingKeyboard: no baked-lit demo chord in the embedded SVGs",
     REQUIRE(count_teal(detail::musical_typing_typing_svg_b64()) <= 4);
     REQUIRE(count_teal(detail::musical_typing_piano_svg_b64()) <= 4);
 }
+
+// ── On-screen command controls (octave / velocity / sustain / pitch-bend) ───
+
+TEST_CASE("MusicalTypingKeyboard: typing frame carries the command controls",
+          "[view][musical-typing][controls]") {
+    auto kbp = make_playable_kb(); auto& kb = *kbp;
+    int actions = 0;
+    for (int i = 0; i < kb.element_count(); ++i)
+        if (kb.element_kind(i) == K::action) ++actions;
+    REQUIRE(actions == 13);   // octave±, velocity±, sustain, 8 pitch-bend presets
+    // Piano frame has no command controls (just keys + the toggle).
+    kb.set_mode(Mode::piano);
+    int piano_actions = 0;
+    for (int i = 0; i < kb.element_count(); ++i)
+        if (kb.element_kind(i) == K::action) ++piano_actions;
+    REQUIRE(piano_actions == 0);
+}
+
+TEST_CASE("MusicalTypingKeyboard: on-screen octave −/+ shift the played note",
+          "[view][musical-typing][controls]") {
+    auto kbp = make_playable_kb(); auto& kb = *kbp;
+    std::vector<int> ons;
+    kb.on_note_on = [&](int n, float) { ons.push_back(n); };
+    auto tap_a = [&] { KeyEvent e{}; e.key = KeyCode::a; e.is_down = true; kb.on_key_event(e);
+                       e.is_down = false; kb.on_key_event(e); };
+
+    kb.on_mouse_down({171, 229}); kb.on_mouse_up({171, 229});  // octave_up (155,213)
+    tap_a();
+    REQUIRE(ons.back() == 60);   // C3
+    kb.on_mouse_down({130, 229}); kb.on_mouse_up({130, 229});  // octave_down (114,213)
+    kb.on_mouse_down({130, 229}); kb.on_mouse_up({130, 229});
+    tap_a();
+    REQUIRE(ons.back() == 36);   // C1
+    REQUIRE(kb.controller().octave_shift() == -1);
+}
+
+TEST_CASE("MusicalTypingKeyboard: on-screen velocity −/+ adjust the controller",
+          "[view][musical-typing][controls]") {
+    auto kbp = make_playable_kb(); auto& kb = *kbp;
+    const float v0 = kb.controller().velocity;
+    kb.on_mouse_down({378, 229}); kb.on_mouse_up({378, 229});  // vel_up (362,213)
+    REQUIRE(kb.controller().velocity > v0);
+    const float v1 = kb.controller().velocity;
+    kb.on_mouse_down({337, 229}); kb.on_mouse_up({337, 229});  // vel_down (321,213)
+    REQUIRE(kb.controller().velocity < v1);
+}
+
+TEST_CASE("MusicalTypingKeyboard: sustain pad toggles and reports on_sustain",
+          "[view][musical-typing][controls]") {
+    auto kbp = make_playable_kb(); auto& kb = *kbp;
+    std::vector<bool> states;
+    kb.on_sustain = [&](bool on) { states.push_back(on); };
+    kb.on_mouse_down({54, 156}); kb.on_mouse_up({54, 156});  // sustain (21,110,66,92)
+    kb.on_mouse_down({54, 156}); kb.on_mouse_up({54, 156});
+    REQUIRE(states == std::vector<bool>{true, false});
+}
+
+TEST_CASE("MusicalTypingKeyboard: pitch-bend presets emit a normalized bend",
+          "[view][musical-typing][controls]") {
+    auto kbp = make_playable_kb(); auto& kb = *kbp;
+    std::vector<float> bends;
+    kb.on_pitch_bend = [&](float b) { bends.push_back(b); };
+    kb.on_mouse_down({126, 82}); kb.on_mouse_up({126, 82});  // pb_0 (108,63) → 0.0
+    kb.on_mouse_down({428, 82}); kb.on_mouse_up({428, 82});  // pb_7 (410,63) → 1.0
+    REQUIRE(bends.size() == 2);
+    REQUIRE(bends[0] == 0.0f);
+    REQUIRE(bends[1] == 1.0f);
+}
+
+TEST_CASE("MusicalTypingKeyboard: a command-button click plays no note",
+          "[view][musical-typing][controls]") {
+    auto kbp = make_playable_kb(); auto& kb = *kbp;
+    std::vector<int> ons;
+    kb.on_note_on = [&](int n, float) { ons.push_back(n); };
+    kb.on_mouse_down({171, 229}); kb.on_mouse_up({171, 229});  // octave_up
+    kb.on_mouse_down({54, 156});  kb.on_mouse_up({54, 156});   // sustain
+    REQUIRE(ons.empty());
+}


### PR DESCRIPTION
Resolves the integration gap the sampler agent flagged: the keyboard's in-design octave/velocity/sustain/pitch-bend controls are now live (the primitive's domain).

**New reusable primitive:** `DesignFrameView::Kind::action` — a command button whose click fires `on_action(id)` (alongside `momentary` keys and `swap` toggle).

**MusicalTypingKeyboard wiring (typing frame, from Figma node 187:15 geometry):**
- octave −/+ → `controller_.set_octave_shift` (shifts the next played note; new controller setter)
- velocity −/+ → `controller_.velocity` (±1/16, clamped)
- sustain pad → new `on_sustain(bool)` (toggles)
- 8 pitch-bend presets (left→right) → new `on_pitch_bend(0..1)`; host maps to its bend range
- `on_modulation(0..1)` defined for the contract, but the current design has no modulation control (label-only placeholder), so it's unwired until a design revision adds one

Octave/velocity readouts aren't yet live-updated (a follow-up); the functional behavior + callback API are complete. Piano frame has no command controls.

**Tests:** 26 cases / 136 assertions (control presence, octave-shift, velocity, sustain toggle, pitch-bend, no-note-on-command-click). Generic design-frame tests still green.

**Sampler agent:** wire `on_pitch_bend` / `on_sustain` (and `on_modulation` when a control exists); octave/velocity need no wiring — they fold into the emitted note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the `MusicalTypingKeyboard` on-screen controls using a new `DesignFrameView::Kind::action` primitive. Octave/velocity now update controller state; sustain and pitch-bend emit host callbacks.

- **New Features**
  - New `DesignFrameView::Kind::action` command buttons; clicks call `on_action(id)` and do not emit notes or swap frames.
  - Typing frame controls: octave −/+ → `controller_.set_octave_shift`; velocity −/+ (±1/16, clamped); sustain pad → `on_sustain(bool)`; 8 pitch-bend presets → `on_pitch_bend(0..1)`.
  - Added `MusicalTypingController::set_octave_shift(int)`; `on_modulation(0..1)` defined but unused (no UI yet). Piano frame unchanged.
  - Tests cover control presence, octave shift, velocity, sustain toggle, pitch-bend, and no-note-on command clicks.

- **Migration**
  - Hosts: wire `on_pitch_bend` and `on_sustain` on `MusicalTypingKeyboard` (leave `on_modulation` unset until UI exists).
  - No changes needed for octave/velocity; they modify controller state directly. Readouts will be live-updated in a follow-up.

<sup>Written for commit c5ae6ef180ddf2d112441bdd66f8886ed8176a6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

