### PR TITLE
fix(view): MTK feedback — number keys, tap states, gray key, pitch-bend readout, piano windowed range

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.445.0
+    VERSION 0.446.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/musical_typing_keyboard.hpp
+++ b/core/view/include/pulp/view/musical_typing_keyboard.hpp
@@ -161,6 +161,9 @@ private:
     void refresh_mod_lights();
     // Index of the (first) element whose action tag == `tag`, or -1.
     int element_for_action(const std::string& tag) const;
+    // Light (on) or clear (off) every momentary control with `tag` — the tap-flash
+    // for octave/velocity/arrow buttons (mouse press or the z/x·c/v keys).
+    void flash_action(const std::string& tag, bool on);
     // Last external held set from set_active_notes; re-applied after a frame swap
     // so the new frame reflects the host's still-held notes.
     std::vector<int> held_notes_;

--- a/core/view/platform/mac/window_host_mac_geometry.mm
+++ b/core/view/platform/mac/window_host_mac_geometry.mm
@@ -137,6 +137,13 @@ pulp::view::KeyCode key_code_from_ns(unsigned short code) {
         case 32: return KC::u; case 34: return KC::i; case 35: return KC::p;
         case 37: return KC::l; case 38: return KC::j; case 40: return KC::k;
         case 45: return KC::n; case 46: return KC::m;
+        // Number row (ANSI virtual keycodes) — needed for the Musical Typing
+        // Keyboard's 1/2 pitch-bend + 3–8 modulation keys; without these they
+        // arrive as `unknown` and the controls only respond to mouse clicks.
+        case 18: return KC::num1; case 19: return KC::num2; case 20: return KC::num3;
+        case 21: return KC::num4; case 23: return KC::num5; case 22: return KC::num6;
+        case 26: return KC::num7; case 28: return KC::num8; case 25: return KC::num9;
+        case 29: return KC::num0;
         case 36: return KC::enter; case 53: return KC::escape;
         case 48: return KC::tab; case 51: return KC::backspace;
         case 117: return KC::delete_;

--- a/core/view/src/musical_typing_keyboard.cpp
+++ b/core/view/src/musical_typing_keyboard.cpp
@@ -62,27 +62,11 @@ void append_toggle(std::vector<DesignFrameElement>& els) {
 //     overlay and route to control_press/control_release (pitch-bend momentary,
 //     sustain hold, modulation latched), mirroring the number-row keys.
 void append_controls(std::vector<DesignFrameElement>& els) {
-    auto add = [&](std::string id, float x, float y, float w, float h) {
-        DesignFrameElement e;
-        e.kind = DesignFrameElement::Kind::action;
-        e.action = std::move(id);
-        e.x = x; e.y = y; e.w = w; e.h = h;
-        els.push_back(e);
-    };
-    add("octave_down", 114, 205, 32, 32);
-    add("octave_up",   155, 205, 32, 32);
-    // The < > buttons flanking the (now centered) top overview strip step the
-    // octave. After #82 centered the strip, < ≈ chevron 150 → element x=139,
-    // > ≈ chevron 582 → element x=571 (typing).
-    add("octave_down", 139, 17, 22, 24);
-    add("octave_up",   571, 17, 22, 24);
-    add("vel_down",    321, 205, 32, 32);
-    add("vel_up",      362, 205, 32, 32);
-
-    // Pitch bend (buttons 1,2) + sustain are MOMENTARY (press/release, lit while
-    // held) → modelled as momentary elements with an action tag so the existing
-    // key-overlay lights them. Modulation (buttons 3–8) is a LATCHED selector,
-    // also momentary-tagged but re-lit on release to persist the selection.
+    // ALL on-screen controls are MOMENTARY with an action tag, so they light on
+    // press and clear on release (a tap-flash) via the existing key overlay, and
+    // route through control_press/control_release. octave/velocity/< > fire their
+    // step on press; pitch-bend 1/2 are momentary holds; modulation 3–8 latch;
+    // sustain holds. (Tagged momentary carry note == −1 → never play a note.)
     auto add_mom = [&](std::string id, float x, float y, float w, float h) {
         DesignFrameElement e;
         e.kind = DesignFrameElement::Kind::momentary;
@@ -90,6 +74,15 @@ void append_controls(std::vector<DesignFrameElement>& els) {
         e.x = x; e.y = y; e.w = w; e.h = h;
         els.push_back(e);
     };
+    add_mom("octave_down", 114, 205, 32, 32);
+    add_mom("octave_up",   155, 205, 32, 32);
+    // The < > buttons flanking the (now centered) top overview strip step the
+    // octave. After #82 centered the strip, < ≈ chevron 150 → element x=139,
+    // > ≈ chevron 582 → element x=571 (typing).
+    add_mom("octave_down", 139, 17, 22, 24);
+    add_mom("octave_up",   571, 17, 22, 24);
+    add_mom("vel_down",    321, 205, 32, 32);
+    add_mom("vel_up",      362, 205, 32, 32);
     // y shifted −8 vs the pre-#82 export (the toolbar shrank when the top-right
     // readouts were removed, lifting every below-toolbar row by 8px).
     add_mom("sustain", 21, 102, 66, 92);
@@ -193,7 +186,7 @@ std::vector<DesignFrameElement> build_piano_frame() {
     append_toggle(els);
     // The < > buttons flanking the piano overview strip step the octave.
     auto add_oct = [&](std::string id, float x) {
-        DesignFrameElement e; e.kind = DesignFrameElement::Kind::action;
+        DesignFrameElement e; e.kind = DesignFrameElement::Kind::momentary;  // tap-flash
         e.action = std::move(id); e.x = x; e.y = 17; e.w = 22; e.h = 24;
         els.push_back(e);
     };
@@ -243,18 +236,11 @@ MusicalTypingKeyboard::MusicalTypingKeyboard()
         if (n >= 0 && on_note_off) on_note_off(n);
     };
 
-    // On-screen command buttons (Kind::action) → controller state. octave/velocity
-    // drive the SAME controller the z/x·c/v keys do (so the next note reflects
-    // them). Pitch-bend, modulation, and sustain are momentary elements (handled
-    // by the gesture path above), NOT actions.
-    on_action = [this](const std::string& a) {
-        if (a == "octave_down")     controller_.set_octave_shift(controller_.octave_shift() - 1);
-        else if (a == "octave_up")  controller_.set_octave_shift(controller_.octave_shift() + 1);
-        else if (a == "vel_down")   controller_.velocity = std::clamp(controller_.velocity - kVelStep, 0.0f, 1.0f);
-        else if (a == "vel_up")     controller_.velocity = std::clamp(controller_.velocity + kVelStep, 0.0f, 1.0f);
-        update_readouts();    // reflect the new octave / velocity value
-        request_repaint();    // move the overview highlight if the octave changed
-    };
+    // ALL on-screen controls are now tagged momentary (handled by the gesture
+    // path above → control_press/control_release), so there's no Kind::action
+    // element and no on_action handler: octave/velocity steps, the < > arrows,
+    // pitch-bend, modulation, and sustain all route through control_press, which
+    // also gives them a press tap-flash.
 
     controller_.velocity = 98.0f / 127.0f;  // match the design's "VEL 98" default
     refresh_mod_lights();                    // light the default modulation step (off)
@@ -282,9 +268,24 @@ int MusicalTypingKeyboard::element_for_action(const std::string& tag) const {
     return -1;
 }
 
+void MusicalTypingKeyboard::flash_action(const std::string& tag, bool on) {
+    // Light/clear EVERY momentary control with this tag (e.g. octave_down is both
+    // the bottom −/+ button AND the < arrow), so a tap or its key flashes them.
+    for (int i = 0; i < element_count(); ++i)
+        if (element_action(i) == tag) set_element_value(i, on ? 1.0f : 0.0f);
+    request_repaint();
+}
+
 void MusicalTypingKeyboard::control_press(const std::string& tag) {
     const int e = element_for_action(tag);
-    if (tag == "pb_down") {
+    if (tag == "octave_down" || tag == "octave_up") {
+        controller_.set_octave_shift(controller_.octave_shift() + (tag == "octave_up" ? 1 : -1));
+        flash_action(tag, true);   // light every button with this tag (bottom + arrow)
+    } else if (tag == "vel_down" || tag == "vel_up") {
+        controller_.velocity = std::clamp(
+            controller_.velocity + (tag == "vel_up" ? kVelStep : -kVelStep), 0.0f, 1.0f);
+        flash_action(tag, true);
+    } else if (tag == "pb_down") {
         pb_value_ = -kPitchBendMax;
         if (on_pitch_bend) on_pitch_bend(-1.0f);   // bipolar −1 (full bend down)
         if (e >= 0) set_element_value(e, 1.0f);
@@ -308,7 +309,10 @@ void MusicalTypingKeyboard::control_press(const std::string& tag) {
 
 void MusicalTypingKeyboard::control_release(const std::string& tag) {
     const int e = element_for_action(tag);
-    if (tag == "pb_down" || tag == "pb_up") {
+    if (tag == "octave_down" || tag == "octave_up" ||
+        tag == "vel_down" || tag == "vel_up") {
+        flash_action(tag, false);   // end the tap-flash (the step already fired on press)
+    } else if (tag == "pb_down" || tag == "pb_up") {
         pb_value_ = 0;                              // momentary: spring back to centre
         if (on_pitch_bend) on_pitch_bend(0.0f);
         if (e >= 0) set_element_value(e, 0.0f);
@@ -407,6 +411,19 @@ bool MusicalTypingKeyboard::on_key_event(const KeyEvent& event) {
         else               control_release(tag);
         return true;
     }
+    // z/x/c/v drive octave/velocity in the controller — also flash the matching
+    // on-screen button (tap-feedback parity with a mouse press). Held on key-down,
+    // cleared on key-up.
+    const char* btn = nullptr;
+    switch (event.key) {
+        case KeyCode::z: btn = "octave_down"; break;
+        case KeyCode::x: btn = "octave_up";   break;
+        case KeyCode::c: btn = "vel_down";    break;
+        case KeyCode::v: btn = "vel_up";      break;
+        default: break;
+    }
+    if (btn) flash_action(btn, event.is_down);
+
     const bool consumed = controller_.handle_key(event);  // QWERTY→note + z/x octave
     // Light the matching typing key (by relative semitone, octave-independent).
     // No-op in piano mode (the frame has no typing keys), which is correct.

--- a/test/test_musical_typing_keyboard.cpp
+++ b/test/test_musical_typing_keyboard.cpp
@@ -111,10 +111,12 @@ TEST_CASE("MusicalTypingKeyboard: piano frame has the chromatic span C2..B4",
     auto kbp = make_playable_kb(); auto& kb = *kbp;
     kb.set_mode(Mode::piano);
     REQUIRE(kb.mode() == Mode::piano);
-    REQUIRE(momentary_count(kb) == 36);
+    REQUIRE(note_key_count(kb) == 36);              // 36 piano keys
+    REQUIRE(momentary_count(kb) == 36 + 2);         // + the < > octave arrows (tap-flash momentary)
     std::vector<int> piano;
     for (int i = 0; i < kb.element_count(); ++i)
-        if (kb.element_kind(i) == K::momentary) piano.push_back(kb.element_note(i));
+        if (kb.element_kind(i) == K::momentary && kb.element_note(i) >= 0)
+            piano.push_back(kb.element_note(i));   // note keys only (skip arrow momentary)
     std::sort(piano.begin(), piano.end());
     REQUIRE(piano.front() == 48);   // C2
     REQUIRE(piano.back() == 83);    // B4
@@ -379,8 +381,9 @@ TEST_CASE("MusicalTypingKeyboard: no baked-lit demo chord in the embedded SVGs",
 }
 
 // ── On-screen command controls (octave / velocity) ─────────────────────────
-// octave/velocity are Kind::action; sustain / pitch-bend / modulation are tagged
-// Kind::momentary (tested in the Logic-faithful section below).
+// ALL on-screen controls are now tagged Kind::momentary (so they tap-flash on
+// press): octave/velocity steppers, the < > arrows, sustain, pitch-bend, and the
+// modulation selector. There are no Kind::action elements.
 
 TEST_CASE("MusicalTypingKeyboard: typing frame carries the command controls",
           "[view][musical-typing][controls]") {
@@ -388,18 +391,37 @@ TEST_CASE("MusicalTypingKeyboard: typing frame carries the command controls",
     int actions = 0;
     for (int i = 0; i < kb.element_count(); ++i)
         if (kb.element_kind(i) == K::action) ++actions;
-    REQUIRE(actions == 6);   // octave ± (×2: bottom + < > arrows), velocity ±
-    // The pitch-bend / sustain / modulation controls are tagged momentary, not
-    // actions: sustain + pb_down + pb_up + mod_0..mod_5 = 9 control momentary.
+    REQUIRE(actions == 0);   // everything is tap-flash momentary now
+    // 18 note keys + 15 control momentary (octave ±×2 incl. < > arrows = 4,
+    // velocity ± = 2, sustain = 1, pitch-bend ± = 2, modulation ×6).
     REQUIRE(note_key_count(kb) == 18);
-    REQUIRE(momentary_count(kb) == 18 + 9);
-    // Piano frame: keys + the < > octave arrows only, no other controls.
+    REQUIRE(momentary_count(kb) == 18 + 15);
+    // Piano frame: 36 keys + the < > octave arrows.
     kb.set_mode(Mode::piano);
     int piano_actions = 0;
     for (int i = 0; i < kb.element_count(); ++i)
         if (kb.element_kind(i) == K::action) ++piano_actions;
-    REQUIRE(piano_actions == 2);   // < > overview arrows
-    REQUIRE(momentary_count(kb) == 36);   // 36 piano keys, no control momentary
+    REQUIRE(piano_actions == 0);
+    REQUIRE(note_key_count(kb) == 36);
+    REQUIRE(momentary_count(kb) == 36 + 2);   // + < > arrows
+}
+
+TEST_CASE("MusicalTypingKeyboard: z/x/c/v flash the matching on-screen button",
+          "[view][musical-typing][controls]") {
+    auto kbp = make_playable_kb(); auto& kb = *kbp;
+    auto lit = [&](const char* tag) {
+        for (int i = 0; i < kb.element_count(); ++i)
+            if (kb.element_action(i) == tag) return kb.element_value(i) > 0.5f;
+        return false;
+    };
+    KeyEvent z{}; z.key = KeyCode::z; z.is_down = true; kb.on_key_event(z);
+    REQUIRE(lit("octave_down"));                 // held → button lit
+    z.is_down = false; kb.on_key_event(z);
+    REQUIRE_FALSE(lit("octave_down"));           // released → cleared
+    KeyEvent v{}; v.key = KeyCode::v; v.is_down = true; kb.on_key_event(v);
+    REQUIRE(lit("vel_up"));
+    v.is_down = false; kb.on_key_event(v);
+    REQUIRE_FALSE(lit("vel_up"));
 }
 
 TEST_CASE("MusicalTypingKeyboard: on-screen octave −/+ shift the played note",


### PR DESCRIPTION
Addresses the live-app feedback on the Musical Typing Keyboard.

**Typing tab**
- **Number-row keys** (1/2 pitch, 3–8 modulation) were dead live — macOS `key_code_from_ns()` never mapped the number row, so they arrived as `unknown`. Mapped all ten.
- **Tap states** on octave −/+, velocity −/+, and the `< >` arrows (now momentary → flash on mouse press and on `z`/`x`·`c`/`v`).
- **Gray key** (e.g. E4): a neutralization bug left was-lit keys with a 0.26-opacity top stop (translucent over the dark bed). Now solid like the resting keys.
- **Pitch/mod highlight** sat ~8px below the button — aligned the control rects to the baked button.
- **PITCH BEND ±20** overflowed left over the label — added `value_left_align` and left-aligned the readout.

**Piano tab** (Logic-style, design unchanged — shift the keys, not widen)
- The 36 keys are a **window** over the full C-2…G8 range; sliding the overview (or `< >` / `z·x`) **shifts the keys and relabels** them (C-2 reads C-2 … the top reads C6/C7/C8).
- The selection highlight is the **full 3-octave visible span** (wider).
- The top **clamps to end on G8** — a partial top, keys shifting to fit.

Tests: 37 cases / 200 assertions. Skia render proofs for every state. The mac keycode map is verified against the HIToolbox reference (NSEvent isn't synthesizable headlessly — verify live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)