### PR TITLE
docs: clean font flight recorder comment archaeology

### DIFF
--- a/core/canvas/include/pulp/canvas/font_flight_recorder.hpp
+++ b/core/canvas/include/pulp/canvas/font_flight_recorder.hpp
@@ -1,11 +1,10 @@
 // font_flight_recorder.hpp
 //
-// Pulp #2163 — font v2 Slice 2.2. The FontFlightRecorder is the
-// process-global sink for FallbackTraceRecord events produced by
-// FontResolver every time a typeface resolves. It's a bounded
-// ring buffer; callers (the --font-trace CLI flag, the import-
-// missing-font-advisor, a developer's debug overlay) can drain it
-// to see exactly which font cascade step produced each glyph.
+// FontFlightRecorder is the process-global sink for FallbackTraceRecord
+// events produced by FontResolver every time a typeface resolves. It's a
+// bounded ring buffer; callers (the --font-trace CLI flag, the
+// import-missing-font-advisor, a developer's debug overlay) can drain it to
+// see exactly which font cascade step produced each glyph.
 //
 // The recorder runs always-on with a reasonable default capacity
 // (1024 records) — there's no measurable overhead at typical UI
@@ -70,9 +69,9 @@ private:
 };
 
 /// Convenience: drain the global recorder and emit one JSON object per
-/// record to `out`. Used by `pulp-ui-preview --font-trace --format=json`
-/// (Slice 2.2.b CLI wiring lands separately) + the import-missing-font-
-/// advisor.
+/// record to `out`. Intended drain path for a future
+/// `pulp-ui-preview --font-trace --format=json` flag and the
+/// import-missing-font-advisor.
 std::string flight_recorder_drain_json();
 
 } // namespace pulp::canvas

--- a/core/canvas/src/font_flight_recorder.cpp
+++ b/core/canvas/src/font_flight_recorder.cpp
@@ -1,4 +1,4 @@
-// font_flight_recorder.cpp — Pulp #2163, font v2 Slice 2.2.
+// font_flight_recorder.cpp
 
 #include "pulp/canvas/font_flight_recorder.hpp"
 


### PR DESCRIPTION
## Summary
- remove stale font-v2 issue/slice markers from the font flight recorder comments
- keep the process-global recorder, bounded ring buffer, future CLI drain path, and import-missing-font-advisor rationale intact
- avoid claiming that the future `pulp-ui-preview --font-trace --format=json` path is wired today

## Validation
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/docs_noise_lint.py core/canvas/include/pulp/canvas/font_flight_recorder.hpp core/canvas/src/font_flight_recorder.cpp`
- strict stale-marker grep over the touched files: no matches
- `tools/scripts/gates.sh origin/main`
- pre-push gates with `PULP_SKIP_DIFF_COVER=1 PULP_VIA_SHIPYARD=1`
- Claude adversarial review: Clean after fixing the future CLI wording and preserving canonical `import-missing-font-advisor` naming


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned and clarified comments for `FontFlightRecorder`, removing stale font-v2 issue/slice markers. Clarifies the future-only `pulp-ui-preview --font-trace --format=json` drain path and keeps docs on the process-global recorder, bounded ring buffer, and `import-missing-font-advisor`; no behavior changes.

<sup>Written for commit 1eb695dce51bbfa792a59808f854c15fb6d3ac78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

