### PR TITLE
docs: clean text run planner comment archaeology

### DIFF
--- a/core/canvas/include/pulp/canvas/shaped_text.hpp
+++ b/core/canvas/include/pulp/canvas/shaped_text.hpp
@@ -1,25 +1,16 @@
 // shaped_text.hpp
 //
-// Pulp #2163 follow-up — Phase 1 / Slice 1.2.a of the font-subsystem-
-// hardening v2 roadmap (planning/2026-05-17-font-subsystem-hardening-v2.md).
-//
 // `ShapedText` is the canonical artifact produced by `TextRunPlanner::shape`.
-// Both `TextShaper::prepare()` (measurement) and `SkiaCanvas::fill_text`
-// (paint) are intended to consume the SAME `ShapedText` instance — the
-// measurement pipeline computes line layout from the artifact's per-run
-// advances; the paint pipeline walks the same artifact's glyph IDs. They
-// cannot diverge. That's how v2 closes the v1 doc's "measurement ≠ paint"
-// killer gap.
+// Measurement and paint paths are intended to consume this same artifact:
+// measurement uses the per-run advances and line-break opportunities, while
+// paint can walk the same runs, clusters, and eventual glyph buffers. Keeping
+// the text artifact shared prevents layout and rendering from inventing
+// incompatible segmentation rules.
 //
-// Slice 1.2.a (this header) lays down the data structures + planner entry
-// point. The Phase 1 implementation wraps existing TextShaper / SkShaper
-// behind a single-run ShapedText so downstream consumers can be wired
-// without forcing the full bidi/script iterator replacement at the same
-// time. Slice 1.2.a finish (separate commit) swaps the trivial bidi/script
-// iterators for the real `SkShaper::MakeIcuBidiRunIterator` /
-// `MakeHbIcuScriptRunIterator` and emits multiple runs when warranted.
-// The data shape declared here doesn't change between the skeleton and
-// the finish — Phase 2 consumers can target it today.
+// `TextRunPlanner` fills this structure with resolved font traces, bidi/script
+// runs, UAX #29-lite grapheme clusters, heuristic line-break opportunities, and
+// UTF-8 / UTF-16 / cluster index maps. Glyph buffers remain optional until the
+// painting path asks SkShaper for per-glyph output.
 
 #pragma once
 
@@ -51,10 +42,9 @@ struct RunMetrics {
 
 /// One run inside a `ShapedText` — a maximal slice of the input text
 /// that shares (bidi level × script × language × resolved typeface ×
-/// applied features × applied variation axes). Slice 1.2.a skeleton
-/// emits one or more runs; the planner only splits when fallback
-/// changes the typeface mid-text (Latin + emoji within one input).
-/// The real bidi/script/cluster split arrives in Slice 1.2.a finish.
+/// applied features × applied variation axes). The current planner splits
+/// on bidi/script iterator boundaries when Skia's ICU-backed iterators are
+/// available, or on the fallback bidi analyzer when they are not.
 struct ShapedRun {
     ResolvedFont font;            ///< Resolved typeface + trace.
     RunMetrics   metrics;
@@ -84,24 +74,21 @@ struct ShapedRun {
 
 // ── Clusters + line breaks ───────────────────────────────────────────────
 
-/// One grapheme cluster in the input. Slice 1.2.a skeleton produces a
-/// simple per-codepoint cluster table; UAX #29 + ZWJ + RI-pair correct
-/// clustering arrives in 1.2.a finish (the multilingual torture corpus
-/// at `test/text_corpus/corpus.json` documents the discrepancy in
-/// `SCHEMA_NOTES.md`).
+/// One grapheme cluster in the input. The planner builds these with the
+/// shared `cluster_step()` walker so editor movement, selection, and text
+/// measurement use the same UTF-8 cluster ranges.
 struct ClusterEntry {
     std::uint32_t utf8_start  = 0;  ///< UTF-8 byte offset (start, inclusive).
     std::uint32_t utf8_end    = 0;  ///< UTF-8 byte offset (end, exclusive).
     std::uint32_t run_index   = 0;  ///< Index into `ShapedText::runs`.
-    std::uint32_t glyph_start = 0;  ///< First glyph in that run.
-    std::uint32_t glyph_count = 0;  ///< Number of glyphs belonging to this cluster.
+    std::uint32_t glyph_start = 0;  ///< First glyph in that run; 0 until glyph buffers are populated.
+    std::uint32_t glyph_count = 0;  ///< Glyph count for this cluster; 0 until glyph buffers are populated.
 };
 
-/// Line-break opportunity emitted by ICU's `BreakIterator`. Used by the
-/// line layout step (Slice 1.2.a finish + Phase 2 / Slice 2.4 locale-
-/// aware line breaking). Slice 1.2.a skeleton populates only the obvious
-/// whitespace + hard-newline breaks; ICU dictionary breaks for Thai /
-/// Japanese arrive in Phase 2.
+/// Line-break opportunity used by the line layout step. The planner currently
+/// emits hard-newline and whitespace break opportunities; a future ICU
+/// BreakIterator path can add locale-aware dictionary breaks without changing
+/// this data shape.
 struct LineBreakOpportunity {
     std::uint32_t utf8_offset = 0;
     enum class Kind : std::uint8_t {
@@ -112,16 +99,10 @@ struct LineBreakOpportunity {
 
 // ── Unicode index map ────────────────────────────────────────────────────
 
-/// Per the v2 plan tar pit #3: "Unicode indexing is a tax everywhere."
-/// JS counts UTF-16, ICU counts UTF-16-or-scalar-depending-on-API,
-/// HarfBuzz counts cluster, a11y APIs vary by platform, Pulp's internal
-/// storage is UTF-8. This index map is the single computed structure
-/// every consumer can convert through without re-computing offsets ad
-/// hoc.
-///
-/// Slice 1.2.a skeleton populates UTF-8 ↔ Unicode-scalar-offset only;
-/// UTF-16 (for JS / IME / macOS+Windows a11y) and cluster ↔ glyph
-/// range arrives in 1.2.a finish.
+/// JS counts UTF-16, ICU APIs vary between UTF-16 and scalar offsets,
+/// HarfBuzz reports cluster indices, accessibility APIs vary by platform,
+/// and Pulp's internal storage is UTF-8. This index map gives consumers a
+/// shared conversion table instead of making each path recompute offsets.
 struct UnicodeIndexMap {
     /// scalar_offsets[i] = UTF-8 byte index of the i-th Unicode
     /// scalar value (codepoint). One entry per codepoint plus a
@@ -129,11 +110,12 @@ struct UnicodeIndexMap {
     std::vector<std::uint32_t> scalar_offsets;
 
     /// utf16_offsets[i] = UTF-16 code-unit index of the i-th Unicode
-    /// scalar. Empty in the skeleton; populated in 1.2.a finish.
+    /// scalar. One entry per codepoint plus a sentinel equal to the total
+    /// UTF-16 code-unit count.
     std::vector<std::uint32_t> utf16_offsets;
 
-    /// utf8_byte → cluster index. One entry per UTF-8 byte. Empty in
-    /// the skeleton; populated in 1.2.a finish.
+    /// utf8_byte → cluster index. One entry per UTF-8 byte plus a trailing
+    /// sentinel equal to `clusters.size()`.
     std::vector<std::uint32_t> byte_to_cluster;
 
     std::size_t scalar_count() const noexcept {
@@ -158,14 +140,12 @@ struct ShapedText {
 
     /// Sum of per-run `advance_total`. The width the painter will
     /// produce when this `ShapedText` is rendered on a single line
-    /// without wrapping. Slice 1.3 parity harness asserts this
-    /// matches the painted pixel bbox within ±0.5 px.
+    /// without wrapping.
     float total_width = 0.0f;
 
     /// Worst-case ascent / descent / leading across all runs on a
     /// single notional line. Used for mixed-fontSize line layout
-    /// (max ascent + max descent) — the property v2 calls out
-    /// as Phase 1 / P0 (it's parity, not polish).
+    /// (max ascent + max descent).
     RunMetrics overall_metrics;
 
     bool empty() const noexcept { return runs.empty(); }

--- a/core/canvas/include/pulp/canvas/text_run_planner.hpp
+++ b/core/canvas/include/pulp/canvas/text_run_planner.hpp
@@ -1,19 +1,13 @@
 // text_run_planner.hpp
 //
-// Pulp #2163 follow-up — Phase 1 / Slice 1.2.a of the font-subsystem-
-// hardening v2 roadmap.
-//
 // `TextRunPlanner` is the entry point that converts an input string +
 // `FontOptions` into a `ShapedText` artifact. Both measurement and paint
-// pipelines consume the same artifact; that's how v2 closes the v1 doc's
-// "measurement ≠ paint" killer gap.
-//
-// Slice 1.2.a skeleton (this file): the planner is a thin wrapper over
-// the existing TextShaper / SkShaper path. It emits one ShapedRun for
-// the input (no real bidi/script split) and a per-codepoint cluster
-// table (no UAX #29 grouping yet). Downstream consumers can target the
-// declared API today; the bidi/script/cluster correctness work happens
-// in 1.2.a finish without changing the API surface.
+// pipelines are intended to consume the same artifact, keeping text metrics,
+// run segmentation, and cluster boundaries aligned across layout and rendering.
+// The planner resolves the font cascade, splits text into bidi/script runs when
+// ICU-backed SkShaper iterators are available, builds grapheme-cluster and
+// Unicode index maps, and falls back to a single compatible run on non-Skia
+// builds.
 
 #pragma once
 
@@ -48,14 +42,12 @@ public:
     /// because `options.registry_generation` is part of the key.
     ShapedText shape(std::string_view text, const FontOptions& options);
 
-    /// pulp #2163 / font v2 Slice 3.7 — parallel shaping (opportunistic).
     /// Shape N independent inputs in parallel and return the artifacts
     /// in input order. Same output as N sequential `shape()` calls.
     /// Uses `std::async(launch::async, ...)` to fan out work; the
-    /// resolver, FontShapedTextResult, and FontFlightRecorder are all
-    /// thread-safe (internal mutexes). The cache lookup happens once
-    /// per future, so duplicate inputs across the batch coalesce as
-    /// expected.
+    /// resolver, FontFlightRecorder, and per-planner cache are all
+    /// synchronized internally. The cache lookup happens once per future,
+    /// so duplicate inputs across the batch coalesce as expected.
     ///
     /// The serial `shape()` API is preferred for one-off labels; this
     /// batch entry point is intended for design-tool panels, docs

--- a/core/canvas/src/text_run_planner.cpp
+++ b/core/canvas/src/text_run_planner.cpp
@@ -1,14 +1,11 @@
-// text_run_planner.cpp — Pulp #2163 follow-up, Phase 1 / Slice 1.2.a.
+// text_run_planner.cpp
 //
-// Slice 1.2.a finish: real ICU/HarfBuzz iterators replace the trivial
-// single-run skeleton. Bidi level + script tag are computed per run via
+// Bidi level + script tag are computed per run via
 // `SkShaper::MakeIcuBiDiRunIterator` + `SkShaper::MakeHbIcuScriptRunIterator`
-// (available because `external/skia-build/build/mac-gpu/lib/Release/libskshaper.a`
-// statically links the ICU-backed builders — verified with `nm` at
-// implementation time). When Skia is not linked (PULP_HAS_SKIA undefined),
-// the planner falls back to a single run with bidi level / script tag
-// inferred from `FontOptions::direction`. The data shape produced is the
-// same in both paths; only the run count varies.
+// when Skia exposes the ICU-backed builders. When Skia is not linked
+// (PULP_HAS_SKIA undefined), the planner falls back to the lightweight
+// BidiAnalyzer path and emits compatible run records with script tags set to
+// Common.
 //
 // Cluster construction: the public `cluster_step()` walker
 // (font_registry_stubs.cpp) is UAX #29-lite — it knows ZWJ, regional-
@@ -16,8 +13,7 @@
 // modifiers, and Hangul T jamo. The planner walks it forward through
 // every run-spanning region to build `ShapedText::clusters` and the
 // `byte_to_cluster` index map. This is the same walker `TextEditor`'s
-// caret-motion uses (Slice 3.6) so the cluster boundaries the painter
-// and editor see are identical.
+// caret-motion uses, so editing and measurement share cluster boundaries.
 //
 // UnicodeIndexMap: scalar_offsets (per-codepoint UTF-8 byte offsets +
 // trailing sentinel), utf16_offsets (per-codepoint UTF-16 code unit
@@ -43,9 +39,7 @@
 #ifdef PULP_HAS_SKIA
 // The bundled Skia archive ships `libskshaper.a` + `libskunicode_icu.a`
 // with the ICU-backed bidi + HarfBuzz/ICU-backed script run-iterator
-// builders linked in (verified at impl time with
-// `nm libskshaper.a | grep MakeIcuBiDi`). The corresponding
-// declarations in `SkShaper.h` are gated by
+// builders linked in. The corresponding declarations in `SkShaper.h` are gated by
 // `SK_SHAPER_UNICODE_AVAILABLE` / `SK_SHAPER_HARFBUZZ_AVAILABLE`, which
 // upstream's prebuilt distribution doesn't pre-define for downstream
 // consumers. We define both *before* including the header so the
@@ -166,15 +160,15 @@ void populate_codepoint_offsets(std::string_view text, UnicodeIndexMap& map) {
     map.utf16_offsets.push_back(utf16_idx);
 }
 
-// Walk the public UAX #29 `cluster_step` (Slice 3.6) forward through
+// Walk the public UAX #29-lite `cluster_step` forward through
 // `text`, emitting one `ClusterEntry` per grapheme cluster. The walker
 // honors ZWJ, RI parity, virama+consonant, combining marks, skin-tone
 // modifiers, Hangul T jamo, and variation selectors. Each cluster
 // stores its UTF-8 byte range plus the run index it belongs to; glyph
-// counts and starts are intentionally left at 0 in this slice — the
+// counts and starts are intentionally left at 0 for now — the
 // painter does not consume them yet, and populating them requires
-// driving SkShaper end-to-end which is the Phase-2 follow-on. The
-// run index is computed by binary-searching `run_starts`.
+// driving SkShaper end-to-end. The run index is computed by searching
+// `run_starts`.
 void populate_clusters(std::string_view text,
                        const std::vector<std::size_t>& run_starts,
                        std::vector<ClusterEntry>& clusters,
@@ -226,9 +220,8 @@ void populate_clusters(std::string_view text,
 void populate_line_breaks(std::string_view text,
                           std::vector<LineBreakOpportunity>& out) {
     out.clear();
-    // Slice 1.2.a finish keeps the heuristic break opportunities; the
-    // ICU BreakIterator-driven path is Slice 2.4 (locale-aware line
-    // breaking) and consumes the same out array.
+    // Keep the current heuristic break opportunities in the same array an
+    // ICU BreakIterator-driven path can populate later.
     for (std::size_t i = 0; i < text.size(); ++i) {
         char c = text[i];
         if (c == '\n') {
@@ -305,7 +298,6 @@ segment_with_icu(std::string_view text, std::uint8_t base_level) {
         // remain valid for the just-consumed run. Substituting
         // base_level / 0 here would shape pure-RTL text as LTR and
         // drop the script tag for any final or single-script run.
-        // See Codex review on PR #2311.
         seg.bidi_level = bidi->currentLevel();
         seg.script_tag = scr->currentScript();
 
@@ -430,19 +422,15 @@ ShapedText TextRunPlanner::shape(std::string_view text,
     populate_codepoint_offsets(text, out.index_map);
     populate_line_breaks(text, out.line_breaks);
 
-    // Resolve the typeface via FontResolver (same path
-    // SkiaCanvas/TextShaper use post-Slice-1.1.a). The resolved
-    // ResolvedFont carries the trace + scope + generation we record
-    // on every run we emit.
+    // Resolve the typeface via FontResolver, matching the path used by
+    // SkiaCanvas/TextShaper. The resolved ResolvedFont carries the trace,
+    // scope, and generation we record on every run we emit.
     ResolvedFont resolved = FontResolver::instance().resolve_family_list(opts);
 
     if (text.empty()) {
-        // Preserve the pre-1.2.a-finish contract: even empty input
-        // yields exactly one zero-width run so callers can rely on
-        // `out.runs[0]` existing for ascender/leading queries on an
-        // empty label without branching on size. The test target
-        // pulp-test-font-options (TextRunPlanner handles empty text)
-        // asserts this shape.
+        // Even empty input yields exactly one zero-width run so callers can
+        // read `out.runs[0]` for ascender/leading queries on an empty label
+        // without branching on size.
         ShapedRun run;
         run.font          = std::move(resolved);
         run.logical_start = 0;
@@ -466,12 +454,10 @@ ShapedText TextRunPlanner::shape(std::string_view text,
     segments = segment_with_icu(text, base_level);
 #endif
     if (segments.empty()) {
-        // Non-Skia / ICU-iterator-construction-failed path. Item 6.8
-        // wires SheenBidi in here so Arabic / Hebrew / mixed-direction
-        // text still gets a paragraph-level bidi pass without ICU. The
-        // script tag stays 0 (script-iterator integration tracks
-        // separately — Pulp #2163 finish); what we gain is correct
-        // per-run embedding levels feeding the rest of the pipeline.
+        // Non-Skia / ICU-iterator-construction-failed path. BidiAnalyzer
+        // still gives Arabic / Hebrew / mixed-direction text paragraph-level
+        // embedding runs without ICU. Script tags stay 0 in this path because
+        // there is no non-Skia script iterator here.
         const auto bidi_dir =
             (opts.direction == BaseDirection::RTL)
                 ? BidiBaseDirection::RTL
@@ -540,12 +526,10 @@ ShapedText TextRunPlanner::shape(std::string_view text,
 
         std::string_view segment_view = text.substr(seg.start, seg.end - seg.start);
 
-        // Measurement uses the existing TextShaper path — the SkShaper
-        // glyph buffers + per-glyph advances are downstream consumers'
-        // job (Phase 2 / Slice 2.4 locale-aware line breaking exercises
-        // them). What matters here is that each run reports its own
-        // sub-string width so `total_width` is the sum of run widths,
-        // not a re-measurement of the whole input.
+        // Measurement uses the existing TextShaper path. Per-glyph buffers are
+        // populated by downstream consumers when they need glyph output; this
+        // pass only needs each run's sub-string width so `total_width` is the
+        // sum of run widths, not a re-measurement of the whole input.
         auto prepared = shaper.prepare(segment_view, family_str, opts.size);
         run.advance_total  = prepared.total_width();
         run.metrics.ascent  = prepared.ascent();
@@ -576,7 +560,6 @@ ShapedText TextRunPlanner::shape(std::string_view text,
     return out;
 }
 
-// pulp #2163 / font v2 Slice 3.7 — parallel shaping.
 // Fans shape() calls out via std::async(launch::async). Resolver,
 // FontFlightRecorder, and the per-planner cache are all thread-safe
 // (internal mutexes); ShapedText is owned-by-value so moving it out


### PR DESCRIPTION
## Summary
- remove stale issue/phase/slice/Codex markers from the text run planner and shaped text comments
- rewrite outdated skeleton-era comments to describe current ICU/HarfBuzz bidi/script segmentation, UAX #29-lite clustering, Unicode index maps, and heuristic line-break behavior
- preserve load-bearing rationale around SkShaper availability, empty-text runs, fallback bidi behavior, cluster sentinels, and async batch shaping

## Validation
- RepoPrompt analysis over `text_run_planner.cpp`, `text_run_planner.hpp`, and `shaped_text.hpp`
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/docs_noise_lint.py core/canvas/include/pulp/canvas/text_run_planner.hpp core/canvas/include/pulp/canvas/shaped_text.hpp core/canvas/src/text_run_planner.cpp`
- strict stale-marker grep over the touched files: no matches
- `tools/scripts/gates.sh origin/main`
- pre-push gates with `PULP_SKIP_DIFF_COVER=1 PULP_VIA_SHIPYARD=1`
- Claude adversarial review: found one redundant replacement sentence; fixed it; otherwise confirmed rewritten comments match the code


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned and updated comments for the text run planner and shaped text to reflect the current shaping pipeline. Removed stale roadmap markers and clarified `ICU`/`HarfBuzz` run segmentation, UAX #29‑lite clustering, Unicode index maps, and heuristic line breaks; no behavior changes.

- **Refactors**
  - Rewrote docs around `SkShaper`-based bidi/script runs and the non-Skia fallback.
  - Clarified cluster entries, optional glyph fields, and the shared cluster walker used by editing.
  - Expanded `UnicodeIndexMap` notes for UTF‑8, UTF‑16, and byte→cluster tables.
  - Documented break opportunities and future `BreakIterator` path; kept rationale for empty-text runs and batch shaping/thread-safety.

<sup>Written for commit 81021cbc281e393922d27b0469f2d60e02fd47fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

