### PR TITLE
docs: clean sdf text comment archaeology

### DIFF
--- a/core/canvas/include/pulp/canvas/sdf_atlas.hpp
+++ b/core/canvas/include/pulp/canvas/sdf_atlas.hpp
@@ -1,23 +1,18 @@
 #pragma once
 
-// Signed Distance Field glyph atlas — exploration prototype for #76.
+// Signed Distance Field glyph atlas.
 //
 // The goal is resolution-independent text rendering: rasterize each
 // glyph once into a fixed-size SDF tile, then sample the atlas at
 // runtime with a smoothstep shader to produce a crisp edge at any
 // scale. Replaces the per-pixel-size bitmap atlas approach.
 //
-// This header defines the API. The implementation in sdf_atlas.cpp
-// produces SDF tiles by rasterizing the glyph at high resolution and
-// running a Euclidean distance transform (Felzenszwalb & Huttenlocher,
-// 2004) over the resulting mask. A future iteration will replace this
-// with FreeType's FT_RENDER_MODE_SDF for higher quality, or with a
-// multi-channel SDF (Chlumsky 2015) for sharper corners at extreme
-// magnifications.
-//
-// Status: exploration. The atlas is built and the SDF data is correct,
-// but the GPU sampling shader / canvas integration is not wired in
-// yet. See planning/android-sdf-glyph-atlas-76.md for the design.
+// This header defines the API. The implementation in sdf_atlas.cpp produces
+// SDF tiles by rasterizing the glyph at high resolution and running a
+// Euclidean distance transform (Felzenszwalb & Huttenlocher, 2004) over the
+// resulting mask. Canvas samples the atlas directly; software-renderer and
+// demo paths use the shared SDF text-quad helpers, and SkSL shaders share the
+// same sampler contract.
 
 #include <cstdint>
 #include <memory>

--- a/core/canvas/include/pulp/canvas/sdf_text.hpp
+++ b/core/canvas/include/pulp/canvas/sdf_text.hpp
@@ -3,10 +3,10 @@
 // Shared SDF/MSDF text rendering options and pen-position helpers.
 //
 // These live in a dedicated header (not sdf_atlas.hpp) because both the
-// single-channel SdfAtlas path and the multi-channel MsdfAtlas path in
-// Phase 2 share the same sampler uniforms and the same pen-snapping
-// policy. Keeping them here avoids a circular include between the atlas
-// headers and the canvas text entry points.
+// single-channel SdfAtlas path and the multi-channel MsdfAtlas path share
+// the same sampler uniforms and the same pen-snapping policy. Keeping them
+// here avoids a circular include between the atlas headers and the canvas
+// text entry points.
 
 #include <cmath>
 #include <string>
@@ -58,7 +58,7 @@ struct SdfTextOptions {
 // Apply the pen-snapping policy to a fractional pen position. The
 // returned coordinate is the "effective" pen position that glyph quads
 // should be built from. Separated from the canvas because demos, tests,
-// and Phase 2 MSDF sites all share the same rule.
+// and SDF/MSDF call sites all share the same rule.
 inline float snap_pen_x(float x, SdfPenSnap policy) {
     switch (policy) {
         case SdfPenSnap::Free:
@@ -103,8 +103,9 @@ struct SdfTextQuad {
 //
 // `AtlasT` must expose: `glyph(c) → const Glyph*`, `base_size()`, and
 // `Glyph` must carry atlas_x/atlas_y/width/height/bearing_x/bearing_y/advance.
-// Both `SdfAtlas` and `MsdfAtlas` (and `PsdfAtlas` via inheritance) satisfy
-// this structural contract without further adaptation.
+// `SdfAtlas`, `MsdfAtlas`, and `PsdfAtlas` satisfy this structural contract
+// without further adaptation; `PsdfAtlas` inherits the contract from
+// `SdfAtlas`.
 template <typename AtlasT>
 inline std::vector<SdfTextQuad> build_text_quads(const AtlasT& atlas,
                                                  const std::u32string& text,
@@ -148,12 +149,11 @@ inline std::vector<SdfTextQuad> build_text_quads(const AtlasT& atlas,
 // families have distinct, type-checked entry points even though the
 // quad-building math is shared. Neither touches a GPU context directly;
 // adapters consume the returned quads through their own textured-quad
-// submission path. This is the Phase 2 completion of the
-// "`fill_text_msdf()` in Canvas" checkbox in the plan.
+// submission path.
 
 // Single templated entry point; callers include the concrete atlas
 // header (`sdf_atlas.hpp`, `msdf_atlas.hpp`, `psdf_atlas.hpp`) before
-// calling. Named aliases below keep call sites self-documenting while
+// calling. Named wrappers below keep call sites self-documenting while
 // the template below does the actual work.
 template <typename AtlasT>
 inline std::vector<SdfTextQuad>

--- a/core/canvas/src/sdf_atlas.cpp
+++ b/core/canvas/src/sdf_atlas.cpp
@@ -1,4 +1,4 @@
-// SDF glyph atlas — exploration implementation for #76.
+// SDF glyph atlas.
 //
 // Algorithm:
 //   1. For each requested codepoint, rasterize a binary mask at
@@ -167,19 +167,16 @@ std::vector<std::uint8_t> rasterize_placeholder(char32_t codepoint, int w, int h
 }
 
 #if PULP_HAS_SKIA
-// pulp #2163 / font v2 Slice 1.1.a — platform font manager comes from
-// the single canonical helper in bundled_fonts.cpp; this TU-local shim
-// preserves the existing call sites until the broader caller-migration
-// pass routes them through the resolver.
+// Platform font managers come from the shared canvas helper so SDF atlas
+// fallback resolution uses the same OS-specific construction as canvas text.
 sk_sp<SkFontMgr> make_font_mgr() {
     return platform_font_manager();
 }
 
 sk_sp<SkTypeface> resolve_typeface(const std::string& font_family) {
-    // pulp #2163 / font v2 Slice 1.1.a — was a platform-only
-    // matchFamilyStyle (ignored plugin-registered + bundled). Now
-    // routes through FontResolver so the SDF atlas path sees the
-    // same cascade as Skia text rendering. Closes v1 doc gap §1.6.
+    // Route through FontResolver so the SDF atlas path sees the same
+    // plugin-registered, bundled, and platform cascade as Skia text
+    // rendering.
     FontOptions opts;
     if (!font_family.empty()) opts.family_stack.push_back(font_family);
     auto resolved = FontResolver::instance().resolve_family_list(opts);
@@ -211,15 +208,15 @@ GlyphMetrics glyph_metrics_skia(const sk_sp<SkTypeface>& face,
         // Use the SkSpan-taking overload: it is always available in
         // chrome/m144 and newer Skia, whereas the (ptr, count) overload
         // is gated behind SK_SUPPORT_UNSPANNED_APIS and disappears on
-        // Skia builds that compile with that macro undefined. See #543.
+        // Skia builds that compile with that macro undefined.
         font.unicharsToGlyphs(SkSpan<const SkUnichar>(&uni, 1),
                               SkSpan<SkGlyphID>(&gid, 1));
     }
-    if (gid == 0) return m;  // .notdef — still emit advance below
+    if (gid == 0) return m;  // .notdef
 
     SkScalar advance = 0;
     SkRect bounds{};
-    // Same SkSpan migration for getWidthsBounds — see #543.
+    // Same SkSpan portability constraint for getWidthsBounds.
     font.getWidthsBounds(SkSpan<const SkGlyphID>(&gid, 1),
                          SkSpan<SkScalar>(&advance, 1),
                          SkSpan<SkRect>(&bounds, 1),
@@ -236,7 +233,7 @@ GlyphMetrics glyph_metrics_skia(const sk_sp<SkTypeface>& face,
 
 // Skia-backed glyph rasterizer.
 //
-// Builds a temporary SkBitmap of size w × h, paints the requested
+// Builds a scratch SkBitmap of size w × h, paints the requested
 // codepoint into the centre using the requested font, and reads back
 // the alpha channel as a binary mask. Returns an empty vector if the
 // font cannot be loaded so the caller can fall back to the
@@ -245,9 +242,8 @@ std::vector<std::uint8_t> rasterize_skia(const std::string& font_family,
                                           char32_t codepoint,
                                           int base_size,
                                           int w, int h, int padding) {
-    // pulp #2163 / font v2 Slice 1.1.a — same migration as
-    // resolve_typeface above: use FontResolver so plugin-registered
-    // and bundled fonts are honored by the SDF rasterizer path.
+    // Use FontResolver so plugin-registered and bundled fonts are honored by
+    // the SDF rasterizer path.
     sk_sp<SkTypeface> face;
     {
         FontOptions opts;


### PR DESCRIPTION
## Summary
- remove stale issue/phase/slice archaeology from SDF text and atlas comments
- update the SDF atlas status comment to reflect current canvas/software/shader integration
- correct stale wording around .notdef glyph metrics, PsdfAtlas inheritance, and SDF/MSDF helper wrappers

## Validation
- RepoPrompt/rp-cli review over SDF text/atlas files and nearby resolver context
- Claude adversarial review; fixed its canvas-path overclaim and spot-check returned Clean
- git diff --check
- python3 tools/scripts/docs_noise_lint.py core/canvas/include/pulp/canvas/sdf_text.hpp core/canvas/include/pulp/canvas/sdf_atlas.hpp core/canvas/src/sdf_atlas.cpp
- strict archaeology grep over the three changed files
- tools/scripts/gates.sh origin/main
- PULP_SKIP_DIFF_COVER=1 PULP_VIA_SHIPYARD=1 git push origin feature/sdf-text-comment-hygiene (pre-push gates + 29 tests)

Version-Bump: sdk=skip reason="comment-only source documentation cleanup"
Skill-Update: skip skill=sdf-text reason="comment-only source documentation cleanup"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned and clarified SDF text/atlas comments to remove stale references and document the current canvas/shader integration. No functional changes.

- **Refactors**
  - Removed issue/phase archaeology from `sdf_atlas.hpp`, `sdf_text.hpp`, and `sdf_atlas.cpp`.
  - Updated status to reflect direct canvas sampling and shared SkSL sampler contract.
  - Clarified `.notdef` glyph metrics wording and Skia API portability notes.
  - Noted `PsdfAtlas` inherits the atlas contract; renamed “aliases” to “wrappers”.
  - Aligned comments on font resolution to use `FontResolver` and the shared platform font manager.

<sup>Written for commit 2599a91426bd7abd308b603a3853210040b18368. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

