### PR TITLE
docs: clean image codecs comment archaeology

### DIFF
--- a/core/canvas/include/pulp/canvas/image_codecs.hpp
+++ b/core/canvas/include/pulp/canvas/image_codecs.hpp
@@ -5,10 +5,8 @@
 // Skia (the default Pulp decode path via SkImages::DeferredFromEncodedData)
 // covers PNG / JPEG / WebP / BMP / ICO in the m144 prebuilt that Pulp pins,
 // but does NOT compile in the GIF decoder by default and ships no TIFF
-// codec at all. The planning gap-doc row
-//   "PNG / JPEG / GIF codecs — GIF/TIFF/SVG/PDF image codecs missing"
-// in planning/2026-05-24-reference-framework-gap-analysis.md (P2) calls for
-// dedicated reader/writer entry points.
+// codec at all. This header fills that gap with dedicated reader/writer
+// entry points.
 //
 // This header provides a Skia-free public surface that:
 //   • Decodes GIF87a / GIF89a (single frame + animation frames + LZW + LCT)
@@ -19,7 +17,7 @@
 //     8-bit Grayscale / RGB / RGBA, BitsPerSample=8) into RGBA8. Wider
 //     TIFF coverage (LZW, JPEG-in-TIFF, multi-strip stitching) would
 //     require libtiff which is heavyweight and only ~MIT-compatible
-//     under its custom permissive licence; not pulled in for this slice.
+//     under its custom permissive licence; not pulled in here.
 //   • Encodes uncompressed Baseline TIFF (RGB / RGBA) and a static
 //     GIF89a (single global palette, 256-colour quantisation via simple
 //     median-cut). Writer paths are intended for editor / asset export
@@ -32,8 +30,8 @@
 // Animation: GifReader::decode_first() decodes a single frame for
 // callers that only want the cover image (matches existing
 // SkImages::DeferredFromEncodedData behaviour). GifReader::decode_all()
-// returns every frame in order plus per-frame delays (centi-seconds
-// per the GIF89a spec) for animated UI elements.
+// returns every frame in order plus per-frame delays in milliseconds;
+// the GIF89a wire format stores centi-seconds, which the codec converts.
 
 #include <cstddef>
 #include <cstdint>
@@ -86,7 +84,7 @@ public:
 /// global colour table built via median-cut quantisation. Useful
 /// for editor exports and tests; runtime callers that want
 /// animation should compose multiple frames via a higher-level
-/// helper (not provided in this slice).
+/// helper (not provided here).
 class GifWriter {
 public:
     /// Encode the raster as a standalone GIF89a file. Returns the
@@ -105,7 +103,7 @@ public:
 /// Returns nullopt for anything outside that envelope. Callers that
 /// need broader coverage should integrate libtiff at the application
 /// layer (Pulp does not bundle libtiff to keep the dependency
-/// footprint small — see planning gap-doc for rationale).
+/// footprint small).
 class TiffReader {
 public:
     static std::optional<DecodedRaster> decode(const uint8_t* data,

--- a/core/canvas/src/image_codecs_gif.cpp
+++ b/core/canvas/src/image_codecs_gif.cpp
@@ -9,9 +9,9 @@
 // but produces files round-trippable through the in-tree decoder, any
 // browser, and ImageMagick/identify.
 //
-// Acceptance test for the planning gap-doc row: encode → decode round
-// trip yields bit-identical RGBA8 buffers (within the palette
-// quantisation error for the writer case; the decoder is exact).
+// Round-trip invariant: encode → decode yields bit-identical RGBA8
+// buffers within the writer's palette-quantisation error; the decoder
+// is exact.
 
 #include <pulp/canvas/image_codecs.hpp>
 
@@ -233,7 +233,7 @@ void apply_disposal(GifState& state,
             // screen background index resolved against the GLOBAL color
             // table. If a transparent index was active, the cleared region
             // becomes transparent. Otherwise it becomes the global
-            // background color, NOT transparent black (Codex PR #3017 P2).
+            // background color, not transparent black.
             uint8_t br = 0, bg = 0, bb = 0, ba = 0;
             const bool transparent_active =
                 (state.transparent_index >= 0) &&

--- a/core/canvas/src/image_codecs_tiff.cpp
+++ b/core/canvas/src/image_codecs_tiff.cpp
@@ -76,10 +76,9 @@ uint32_t ifd_short(const Ifd& e, const ByteOrder& bo) {
     // In little-endian files the low 2 bytes hold the value; in big-endian
     // files the high 2 bytes hold it. We already byte-swapped the full
     // 32-bit field through bo.u32() on read, so the SHORT now occupies the
-    // high half on big-endian and the low half on little-endian.
-    //
-    // Regression: Codex PR #3017 review — the previous `& 0xFFFF` returned
-    // 0 for big-endian inline SHORT values, breaking baseline MM TIFFs.
+    // high half on big-endian and the low half on little-endian. A plain
+    // `& 0xFFFF` would drop big-endian inline SHORTs to 0 and break baseline
+    // MM TIFFs.
     if (bo.little) {
         return e.value_or_offset & 0xFFFF;
     }


### PR DESCRIPTION
## Summary
- remove stale planning gap-doc / slice / Codex PR archaeology from image-codec comments
- preserve load-bearing GIF89a, TIFF 6.0, Skia codec coverage, LZW patent, and libtiff dependency rationale
- correct the header wording for GIF frame delays: returned values are milliseconds after converting GIF centi-seconds

## Review / analysis
- RepoPrompt Oracle reviewed the selected image-codecs files and recommended this scoped cleanup
- Claude adversarial review verdict: Clean

## Validation
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py core/canvas/include/pulp/canvas/image_codecs.hpp core/canvas/src/image_codecs_gif.cpp core/canvas/src/image_codecs_tiff.cpp`
- strict archaeology grep over touched files (only false-positive `finish` symbols before regex refinement)
- `tools/scripts/gates.sh origin/main`
- pre-push gates via `PULP_SKIP_DIFF_COVER=1 PULP_VIA_SHIPYARD=1 git push origin feature/image-codecs-comment-hygiene` (29 tests)

## Shipyard note
- attempted `shipyard pr --base main --json --no-apply-bumps`; first run failed because this fresh worktree had no Ubuntu/Windows SSH targets configured
- retry with `--skip-target ubuntu --skip-target windows` entered `shipyard ship` but stayed silent for several minutes and was interrupted before creating a PR


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up image codec comments to remove stale planning/PR references and tighten wording. Clarifies GIF frame delay docs and keeps essential spec notes. No behavior changes.

- **Refactors**
  - Removed planning gap-doc and PR archaeology; simplified language.
  - Clarified GIF delays are returned in milliseconds (converted from centiseconds).
  - Improved TIFF SHORT endian explanation; removed misleading bitmask example.
  - Kept rationale on Skia codec coverage and not bundling `libtiff` (dependency footprint).

<sup>Written for commit b00281df38a08dd9e75b40739076be16b2fbeca3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

