### PR TITLE
docs: clean canvas image shim comment archaeology

### DIFF
--- a/core/view/js/web-compat-canvas-image.js
+++ b/core/view/js/web-compat-canvas-image.js
@@ -1,11 +1,8 @@
 // ═══════════════════════════════════════════════════════════════════════════════
-// Canvas2D API gap closures (issue-916) — image / line-dash / metrics
+// Canvas2D API: image / line-dash / metrics
 // ═══════════════════════════════════════════════════════════════════════════════
 //
-// P5-6 follow-up — extracted from web-compat-canvas.js (1350-1581).
-//
-// Five prototype methods covering the HTML5 Canvas2D surfaces that the
-// catalog flipped from DIVERGE → PASS in Wave 2:
+// Prototype methods and accessors covering HTML5 Canvas2D surfaces:
 //   * measureText — returns a TextMetrics object with width +
 //     actualBoundingBox{Left,Right,Ascent,Descent} +
 //     fontBoundingBox{Ascent,Descent} fields. Falls back to a 0.6em
@@ -14,6 +11,7 @@
 //   * drawImage — handles all three signatures (3/5/9-arg) with the
 //     Image-id ↔ asset-url resolution that the bridge needs.
 //   * setLineDash / getLineDash — round-trips the dash pattern array.
+//   * lineDashOffset — round-trips and flushes the dash phase.
 //   * getImageData / putImageData — Base64 round-trips an ImageData
 //     buffer through the bridge.
 //
@@ -21,7 +19,7 @@
 // CanvasRenderingContext2D constructor is in scope when the prototype
 // installs the per-method overrides.
 
-// ── Canvas2D API gap closures (issue-916) ────────────────────────────
+// ── Canvas2D API methods ─────────────────────────────────────────────
 // measureText returns an HTML5 TextMetrics object — width plus the
 // actualBoundingBox{Left,Right,Ascent,Descent} and
 // fontBoundingBox{Ascent,Descent} fields callers need for proper text
@@ -30,9 +28,9 @@
 CanvasRenderingContext2D.prototype.measureText = function(text) {
     if (typeof canvasMeasureText !== "function") {
         // Coarse estimate — avoids returning undefined/null which would
-        // break callers that destructure the result. pulp #1434 — pull
-        // size out of the parsed shorthand so multi-token strings don't
-        // collapse to 14 by way of `parseFloat("italic bold")`.
+        // break callers that destructure the result. Pull size out of the
+        // parsed shorthand so multi-token strings don't collapse to 14 via
+        // `parseFloat("italic bold")`.
         var fb = CanvasRenderingContext2D._parseFontShorthand(this.font || "14px Inter");
         var px = fb.size || 14;
         var w = String(text == null ? "" : text).length * px * 0.6;
@@ -46,26 +44,26 @@ CanvasRenderingContext2D.prototype.measureText = function(text) {
             fontBoundingBoxDescent: px * 0.25
         };
     }
-    // pulp #1434 — share the full CSS font shorthand parser with
-    // _syncTextState so multi-token strings (`'italic bold 14px Inter'`)
-    // measure with the same size+family the bridge actually rendered.
+    // Share the full CSS font shorthand parser with _syncTextState so
+    // multi-token strings (`'italic bold 14px Inter'`) measure with the
+    // same size+family the bridge actually rendered.
     var parsed = CanvasRenderingContext2D._parseFontShorthand(this.font || "14px Inter");
     return canvasMeasureText(this._id, String(text == null ? "" : text), parsed.family, parsed.size);
 };
 
 // drawImage(img, dx, dy) / drawImage(img, dx, dy, dw, dh) /
 // drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh).
-// pulp #1737 — 9-arg source-rect form is now wired. The JS shim
-// passes sx,sy,sw,sh as args[6..9] and the bridge routes through
-// Canvas::draw_image_from_*_rect (Skia: SkCanvas::drawImageRect with
-// src+dst rects). Sprite-sheet slicing without re-decoding.
+// 9-arg source-rect form: the JS shim passes sx,sy,sw,sh as args[6..9]
+// and the bridge routes through Canvas::draw_image_from_*_rect (Skia:
+// SkCanvas::drawImageRect with src+dst rects) for sprite-sheet slicing
+// without re-decoding.
 CanvasRenderingContext2D.prototype.drawImage = function(img, a, b, c, d, e, f, g, h) {
     if (typeof canvasDrawImage !== "function") return;
-    // pulp #1434 — flush imageSmoothing state so Skia / CG honour the
-    // current ctx.imageSmoothingEnabled + Quality on this draw.
+    // Flush imageSmoothing state so Skia / CG honour the current
+    // ctx.imageSmoothingEnabled + Quality on this draw.
     this._syncImageSmoothingState();
-    // pulp #1520 — flush filter state so the chosen image filter
-    // (blur, grayscale, …) wraps this drawImage too.
+    // Flush filter state so the chosen image filter (blur, grayscale, …)
+    // wraps this drawImage too.
     this._syncFilterState();
     var src = "";
     if (typeof img === "string") src = img;
@@ -111,12 +109,11 @@ CanvasRenderingContext2D.prototype.getLineDash = function() {
     return this._lineDash ? this._lineDash.slice() : [];
 };
 
-// pulp Wave 4 c2d cleanup — lineDashOffset getter/setter pair. Mutating
-// between draws now re-pushes the dash pattern with the new phase so the
-// next stroke picks up the shift. Spec: HTML5 Canvas2D
-// `lineDashOffset` is the only sticky line-dash phase property; assigning
-// to it must be observable on subsequent stroke() calls without
-// re-issuing setLineDash.
+// lineDashOffset getter/setter pair. Mutating between draws re-pushes the
+// dash pattern with the new phase so the next stroke picks up the shift.
+// Spec: HTML5 Canvas2D `lineDashOffset` is the only sticky line-dash phase
+// property; assigning to it must be observable on subsequent stroke() calls
+// without re-issuing setLineDash.
 Object.defineProperty(CanvasRenderingContext2D.prototype, "lineDashOffset", {
     configurable: true,
     enumerable: true,
@@ -174,14 +171,14 @@ CanvasRenderingContext2D.prototype.getImageData = function(x, y, w, h) {
 // Encodes the Uint8ClampedArray as base64 and hands it to the bridge for
 // rasterization on the next paint.
 //
-// pulp #1737 — 7-arg sub-rect form: only the (dirtyX, dirtyY, dirtyW,
-// dirtyH) sub-rectangle of the source ImageData is written, at
-// destination (dx + dirtyX, dy + dirtyY). Per HTML5 spec the dirty rect
-// is clamped to the ImageData bounds; if it ends up empty the call is
-// a no-op. We slice the source pixels row-by-row in JS so the bridge
-// contract stays the no-rect form (smaller buffer + adjusted dst+
-// dimensions), which avoids passing a sub-rect across the bridge or
-// rewriting the C++ paint path.
+// 7-arg sub-rect form: only the (dirtyX, dirtyY, dirtyW, dirtyH)
+// sub-rectangle of the source ImageData is written at destination
+// (dx + dirtyX, dy + dirtyY). Per HTML5 spec the dirty rect is clamped
+// to the ImageData bounds; if it ends up empty the call is a no-op. We
+// slice the source pixels row-by-row in JS so the bridge contract stays
+// the no-rect form (smaller buffer + adjusted dst+ dimensions), which
+// avoids passing a sub-rect across the bridge or rewriting the C++ paint
+// path.
 CanvasRenderingContext2D.prototype.putImageData = function(imageData, dx, dy,
                                                             dirtyX, dirtyY,
                                                             dirtyW, dirtyH) {


### PR DESCRIPTION
## Summary
- remove stale issue/P-label/catalog/Wave/pulp-number archaeology from `web-compat-canvas-image.js` comments
- preserve Canvas2D/HTML5 spec rationale, bridge call shapes, fallback behavior, lineDashOffset semantics, ImageData/base64 layout, and dirty-rect normalization
- fix the touched header summary to include the `lineDashOffset` accessor

## Review / analysis
- RepoPrompt Oracle reviewed the selected canvas-image JS shim and related bridge/test context
- Claude adversarial review verdict: Clean; optional pre-existing header count nit was addressed

## Validation
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py core/view/js/web-compat-canvas-image.js`
- strict archaeology grep over `core/view/js/web-compat-canvas-image.js`
- `tools/scripts/gates.sh origin/main`
- pre-push gates via `PULP_SKIP_DIFF_COVER=1 PULP_VIA_SHIPYARD=1 git push origin feature/canvas-image-js-comment-hygiene` (29 tests)

## Trailers
- `Version-Bump: sdk=skip reason="comment-only source documentation cleanup"`
- `Skill-Update: skip skill=engine reason="comment-only source documentation cleanup"`

## Shipyard note
- attempted `shipyard pr --base main --json --no-apply-bumps --skip-target ubuntu --skip-target windows`; it entered `shipyard ship` and stayed silent for multiple bounded waits, so it was interrupted before creating a PR


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned and simplified comments in `core/view/js/web-compat-canvas-image.js` by removing stale issue/Wave references and tightening explanations. Preserved Canvas2D spec rationale and behavior notes, clarified `measureText`, `drawImage` (including smoothing/filter flush), `putImageData` sub-rect handling, and updated the header summary to include the `lineDashOffset` accessor.

<sup>Written for commit 15c43ab90116a099192c7c403006729f48b8d818. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

