### PR TITLE
docs: clean view header comment archaeology

### DIFF
--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -26,11 +26,11 @@ struct FileDragRequest;  // pulp/view/drag_drop.hpp
 class View {
 public:
     View();
-    // Defined out-of-line in view.cpp to slim the preprocessed-byte size
-    // of <pulp/view/view.hpp> (Phase 4 R2-2 header-diet first cut).
-    // Stays virtual + public — the vtable slot, calling convention, and
-    // SDK contract are unchanged. Body reaches the active_overlay_ /
-    // focused_input_ statics (clear-on-destroy for pulp #1148 / #1708).
+    // Defined out-of-line in view.cpp to slim the preprocessed-byte size of
+    // <pulp/view/view.hpp>. Stays virtual + public: the vtable slot, calling
+    // convention, and SDK contract are unchanged. Body reaches the
+    // active_overlay_ / focused_input_ statics so destruction clears any global
+    // slot held by this View.
     virtual ~View();
 
     View(const View&) = delete;
@@ -77,7 +77,7 @@ public:
     // Resolve a color: check own theme first, then walk up to parent
     Color resolve_color(const std::string& name, Color fallback = {}) const;
 
-    // ── CSS-style typography inheritance (issue-969) ─────────────────────
+    // ── CSS-style typography inheritance ─────────────────────────────────
     //
     // Mirrors CSS: setting `color: white` on a parent View cascades down
     // to every text descendant unless overridden. These fields are stored
@@ -112,10 +112,9 @@ public:
     void clear_inheritable_font_weight() { inh_font_weight_.reset(); }
     std::optional<int> inheritable_font_weight() const;
 
-    /// pulp #1434 Phase A2-5 — inheritable font-family cascade. Mirrors
-    /// the font-weight pattern; Labels read this when set_font_family
-    /// hasn't been called directly. Final SkFontMgr resolution is
-    /// gated on pulp #932 — the cascade plumbing is independent.
+    /// Inheritable font-family cascade. Mirrors the font-weight pattern;
+    /// Labels read this when set_font_family hasn't been called directly.
+    /// Font-manager resolution is independent from the cascade plumbing.
     void set_inheritable_font_family(std::string f) { inh_font_family_ = std::move(f); }
     void clear_inheritable_font_family() { inh_font_family_.reset(); }
     std::optional<std::string> inheritable_font_family() const;
@@ -145,7 +144,7 @@ public:
     // Paint this view and all children into a canvas
     virtual void paint_all(canvas::Canvas& canvas);
 
-    // Phase 3d (inspector roadmap) — last paint cycle's wall-clock cost.
+    // Last paint cycle's wall-clock cost.
     // Updated by paint_all() at the end of each paint pass. Exposed so
     // the inspector property panel can show per-view timing without
     // adding new instrumentation per query.
@@ -280,8 +279,7 @@ public:
     bool hit_testable() const { return hit_testable_; }
     void set_hit_testable(bool h) { hit_testable_ = h; }
 
-    /// React Native pointerEvents (issue-1026). Four-valued enum that
-    /// mirrors RN's contract:
+    /// React Native pointerEvents. Four-valued enum that mirrors RN's contract:
     ///   auto      — default; this view AND children are interactive.
     ///   none      — neither this view NOR descendants intercept events.
     ///   box_only  — this view receives events; children do NOT.
@@ -294,16 +292,13 @@ public:
     void set_pointer_events(PointerEvents p) { pointer_events_ = p; }
     PointerEvents pointer_events() const { return pointer_events_; }
 
-    /// React Native backfaceVisibility (issue-1026). Stored on the View
-    /// for plumbing parity with `@pulp/react`. The flag is consumed by
-    /// the paint path only when a 3D transform with negative Z is
-    /// active; pulp's transform model is currently 2D-affine, so this
-    /// is reserved for future 3D support and behaves as a no-op for
-    /// painting today.
+    /// React Native backfaceVisibility. Stored on the View for plumbing parity
+    /// with `@pulp/react`. Pulp's transform model is currently 2D-affine, so
+    /// this behaves as a paint-time no-op.
     bool backface_visible() const { return backface_visible_; }
     void set_backface_visible(bool v) { backface_visible_ = v; }
 
-    /// GPU-host capability signal (pulp #2700-followup, GPU-plugin-view-host).
+    /// GPU-host capability signal.
     /// A view that is rendered through the Skia/Dawn/Yoga scripted-UI path —
     /// or any custom `Processor::create_view()` that paints via GPU-backed
     /// widgets (e.g. WebGPU/Three.js canvases, the scripted React UI) — sets
@@ -315,7 +310,7 @@ public:
     /// This lives on the View (not the Processor) because `create_view()` can
     /// return a different view per editor instance and the flag must not touch
     /// the node ABI. Adapters read it via `ViewBridge::view()` after
-    /// `ViewBridge::open()`. See `planning/2026-05-22-gpu-view-host-in-plugins.md`.
+    /// `ViewBridge::open()`.
     bool requires_gpu_host() const { return requires_gpu_host_; }
     void set_requires_gpu_host(bool v) { requires_gpu_host_ = v; }
 
@@ -383,13 +378,10 @@ public:
     void set_access_value(std::string value) { access_value_ = std::move(value); }
     const std::string& access_value() const { return access_value_; }
 
-    // pulp #1737 — ARIA state attributes. Tri-state semantics per the
-    // ARIA 1.2 spec (`true` / `false` / `mixed` / unset). We store the
-    // raw string the JS shim hands us so platform AT bridges can read
-    // it back verbatim (NSAccessibility's `accessibilityValue` for
-    // toggle buttons reads from this slot; Linux AT-SPI / Windows UIA
-    // bridges follow the same pattern when they land — tracked under
-    // pulp #217). Setting the empty string clears the state.
+    // ARIA state attributes. Tri-state semantics per the ARIA 1.2 spec
+    // (`true` / `false` / `mixed` / unset). We store the raw string the JS shim
+    // hands us so platform accessibility bridges can read it back verbatim.
+    // Setting the empty string clears the state.
     void set_access_pressed(std::string s)  { access_pressed_  = std::move(s); }
     void set_access_checked(std::string s)  { access_checked_  = std::move(s); }
     void set_access_disabled(std::string s) { access_disabled_ = std::move(s); }
@@ -408,10 +400,9 @@ public:
     void set_id(std::string id) { id_ = std::move(id); }
     const std::string& id() const { return id_; }
 
-    /// Phase 0b: stable anchor identity from the design-import IR (the
-    /// `// @pulp-anchor <id>` codegen trail from Phase 0a). The
-    /// inspector (Phase 0b PR-C) uses this to key tweaks against the
-    /// originating source element so they survive re-import.
+    /// Stable anchor identity from the design-import IR. The inspector uses
+    /// this to key tweaks against the originating source element so they
+    /// survive re-import.
     ///
     /// Empty by default. Populated by the JS bridge's setAnchor() call
     /// for views constructed from imported designs; user-authored
@@ -427,11 +418,11 @@ public:
         return import_binding_lifetime_token_;
     }
 
-    /// Phase 5.1 (inspector source-jump): authored-source location for
-    /// this view. Populated from React's `__source` prop (file name +
-    /// line + column) by the JS bridge's `setSource()` call when the
-    /// view was created by the `@pulp/react` reconciler from a JSX
-    /// element. Empty for user-authored / non-imported views.
+    /// Authored-source location for this view. Populated from React's
+    /// `__source` prop (file name + line + column) by the JS bridge's
+    /// `setSource()` call when the view was created by the `@pulp/react`
+    /// reconciler from a JSX element. Empty for user-authored / non-imported
+    /// views.
     ///
     /// `line` / `col` are 1-based when present, mirroring the editor
     /// URI convention; `0` means "not recorded". The inspector reads
@@ -467,16 +458,12 @@ public:
     bool has_background_color() const { return has_bg_; }
     Color background_color() const { return bg_color_; }
 
-    /// CSS `background-repeat` keyword (pulp #1552). Storage-only at the
-    /// View level: paint() of solid-color backgrounds (the only currently
-    /// rendered case) is a no-op for repeat semantics, but the value is
-    /// preserved so future paint logic for `background-image: url(...)` /
-    /// repeating gradients can honor it without an API break. Mirrors
-    /// the strategy used for `text-decoration-style` (pulp #1434 batch 3)
-    /// which also stores the keyword and currently degrades to solid in
-    /// paint. Accepted CSS keywords: `repeat`, `repeat-x`, `repeat-y`,
-    /// `no-repeat`, `space`, `round`. Unknown / empty = `repeat` (CSS
-    /// initial value).
+    /// CSS `background-repeat` keyword. Storage-only at the View level:
+    /// paint() of solid-color backgrounds is a no-op for repeat semantics, but
+    /// the value is preserved so image/gradient background paint can honor it
+    /// without an API break. Accepted CSS keywords: `repeat`, `repeat-x`,
+    /// `repeat-y`, `no-repeat`, `space`, `round`. Unknown / empty = `repeat`
+    /// (CSS initial value).
     void set_background_repeat(std::string kw) { background_repeat_ = std::move(kw); }
     const std::string& background_repeat() const { return background_repeat_; }
 
@@ -490,24 +477,22 @@ public:
     float border_width() const { return border_width_; }
     float corner_radius() const { return corner_radius_; }
 
-    /// Standalone border setters (issue-1026, RN parity). Each setter
-    /// flips the has_border_ flag on so paint_all() actually emits the
-    /// stroke even when set_border() was never called.
+    /// Standalone border setters for RN parity. Each setter flips the
+    /// has_border_ flag on so paint_all() actually emits the stroke even when
+    /// set_border() was never called.
     void set_border_color(Color c) { border_color_ = c; has_border_ = true; }
     void set_border_width(float w) { border_width_ = w; has_border_ = true; }
     void set_border_radius(float r) { corner_radius_ = r; corner_radius_pct_ = 0; }
-    /// pulp #1663 — set corner radius as percent of min(width,height).
-    /// Resolved at paint time. Pass 0 to clear the percent and revert
-    /// to the plain px slot.
+    /// Set corner radius as percent of min(width,height). Resolved at paint
+    /// time. Pass 0 to clear the percent and revert to the plain px slot.
     void set_border_radius_pct(float pct) { corner_radius_pct_ = pct; }
     float corner_radius_pct() const { return corner_radius_pct_; }
 
-    /// pulp #1737 RN-OOS-fixup (#1812) — RN's `borderCurve`: corner
-    /// shape selection. `circular` (default) is the standard quarter-
-    /// circle rounded corner; `continuous` is the iOS-style super-
-    /// ellipse / squircle approximation. View::paint_all picks the
-    /// appropriate path generator based on this slot. Slot has no
-    /// effect when border-radius is 0.
+    /// RN's `borderCurve`: corner shape selection. `circular` (default) is the
+    /// standard quarter-circle rounded corner; `continuous` is the iOS-style
+    /// super-ellipse / squircle approximation. View::paint_all picks the
+    /// appropriate path generator based on this slot. Slot has no effect when
+    /// border-radius is 0.
     enum class BorderCurve { circular, continuous };
     void set_border_curve(BorderCurve c) { border_curve_ = c; }
     BorderCurve border_curve() const     { return border_curve_; }
@@ -520,13 +505,11 @@ public:
         return corner_radius_;
     }
 
-    /// CSS / RN border-style. pulp #1434 Triage #10 — Skia path effect
-    /// dispatches on style at paint time. CG falls through to solid
-    /// (the cg_canvas.mm path inherits the canvas-base no-op
-    /// set_line_dash). Values that pulp doesn't render natively
-    /// (`double` / `groove` / `ridge` / `inset` / `outset`) degrade to
-    /// solid — documented as a paint-time gap in the catalog. `none` /
-    /// `hidden` skip the stroke entirely (paint() short-circuits).
+    /// CSS / RN border-style. Skia path effect dispatches on style at paint
+    /// time. CG falls through to solid (the cg_canvas.mm path inherits the
+    /// canvas-base no-op set_line_dash). Values that Pulp doesn't render
+    /// natively (`double` / `groove` / `ridge` / `inset` / `outset`) degrade
+    /// to solid. `none` / `hidden` skip the stroke entirely.
     enum class BorderStyle {
         solid,    ///< Default — single continuous line.
         dashed,   ///< SkDashPathEffect with 3w/3w on/off pattern.
@@ -542,23 +525,21 @@ public:
     void set_border_style(BorderStyle s) { border_style_ = s; }
     BorderStyle border_style() const { return border_style_; }
 
-    /// CSS / RN list-style cluster (pulp #1514). Pulp doesn't model
-    /// HTML <li>/<ul>/<ol> semantics — these slots store the values
-    /// the consumer set so an external paint pass (or future <li>
-    /// semantic surface) can honor them. The bridge round-trips the
-    /// keyword/url; paint-time marker rendering is the follow-up.
+    /// CSS / RN list-style cluster. Pulp doesn't model HTML <li>/<ul>/<ol>
+    /// semantics; these slots store the values the consumer set so a list
+    /// semantic surface can honor them. The bridge round-trips the keyword/url;
+    /// View itself does not paint markers.
     enum class ListStyleType {
         none,     ///< No marker.
         disc,     ///< Filled circle (default for <ul>).
         circle,   ///< Hollow circle.
         square,   ///< Filled square.
         decimal,  ///< Numeric (default for <ol>) — needs sibling-index, not painted yet.
-        // CSS Counter Styles Level 3 keywords (pulp #1514). Storage-only
-        // today; paint-side glyph rendering is the follow-up. The slots
-        // exist so the bridge can round-trip the consumer's keyword
-        // honestly and the catalog can flip from `missing` to
-        // `supported-with-gaps`. Underscored C++ identifiers map to
-        // hyphenated CSS keywords (e.g. lower_roman ↔ "lower-roman").
+        // CSS Counter Styles Level 3 keywords. Storage-only today; View itself
+        // does not paint the marker glyphs. The slots exist so the bridge can
+        // round-trip the consumer's keyword honestly. Underscored C++
+        // identifiers map to hyphenated CSS keywords (e.g. lower_roman ↔
+        // "lower-roman").
         decimal_leading_zero,  ///< 01, 02, ... 09, 10, 11.
         lower_roman,           ///< i, ii, iii, iv, v.
         upper_roman,           ///< I, II, III, IV, V.
@@ -581,16 +562,13 @@ public:
     void set_list_style_position(ListStylePosition p) { list_style_position_ = p; }
     ListStylePosition list_style_position() const { return list_style_position_; }
 
-    /// CSS / RN outline cluster (pulp #1519). Outline is a paint-time
-    /// ring drawn OUTSIDE the border-box; it does NOT affect Yoga layout
-    /// (no parent space reserved). Slotting mirrors border-* but lives
-    /// in its own quartet of fields so a JSX prop diff that touches one
-    /// outline-* prop preserves the others. Reuses View::BorderStyle for
-    /// the line-style enum since CSS keyword sets are identical (solid /
-    /// dashed / dotted / double / groove / ridge / inset / outset / none /
-    /// hidden). The Skia paint inflates the box by `outline_offset_ +
-    /// outline_width_ / 2` and strokes; CG falls through (set_line_dash
-    /// canvas-base no-op) for dashed/dotted same as border-style.
+    /// CSS / RN outline cluster. Outline is a paint-time ring drawn outside
+    /// the border-box; it does not affect Yoga layout. Slotting mirrors
+    /// border-* but lives in its own quartet of fields so a JSX prop diff that
+    /// touches one outline-* prop preserves the others. Reuses
+    /// View::BorderStyle for the line-style enum since CSS keyword sets are
+    /// identical. Skia inflates the box by `outline_offset_ + outline_width_ /
+    /// 2` and strokes; CG falls through for dashed/dotted same as border-style.
     void set_outline_color(Color c) { outline_color_ = c; }
     void set_outline_offset(float px) { outline_offset_ = px; }
     void set_outline_style(BorderStyle s) { outline_style_ = s; }
@@ -601,38 +579,34 @@ public:
     float outline_width() const { return outline_width_; }
 
 
-    /// Per-side borders (CSS border-top, border-right, etc.)
-    /// pulp #1566 (Codex P2 follow-up to #1543) — track an explicit
-    /// per-edge "set" flag so a width of 0 on one edge can override
-    /// the uniform shorthand. CSS / RN semantics: `borderWidth: 10`
-    /// followed by `borderTopWidth: 0` must yield a 0-px top border,
-    /// not the 10-px shorthand. Without a per-edge `set` bit, the
-    /// stored 0 was indistinguishable from "unset" in
-    /// `apply_border_widths` and the shorthand leaked through.
+    /// Per-side borders (CSS border-top, border-right, etc.). Track an explicit
+    /// per-edge "set" flag so a width of 0 on one edge can override the
+    /// uniform shorthand. CSS / RN semantics: `borderWidth: 10` followed by
+    /// `borderTopWidth: 0` must yield a 0-px top border, not the 10-px
+    /// shorthand. Without a per-edge `set` bit, the stored 0 is
+    /// indistinguishable from "unset" in `apply_border_widths`.
     void set_border_top(Color c, float w) { border_top_ = {c, w}; border_top_set_ = true; has_border_sides_ = true; }
     void set_border_right(Color c, float w) { border_right_ = {c, w}; border_right_set_ = true; has_border_sides_ = true; }
     void set_border_bottom(Color c, float w) { border_bottom_ = {c, w}; border_bottom_set_ = true; has_border_sides_ = true; }
     void set_border_left(Color c, float w) { border_left_ = {c, w}; border_left_set_ = true; has_border_sides_ = true; }
-    /// Color-only setters (pulp #1566). Setting `borderTopColor` alone
-    /// must NOT mark the top edge's WIDTH as explicitly set — that
-    /// would let a stale 0 override the uniform `borderWidth` shorthand.
-    /// Mirrors CSS, where `border-top-color` and `border-top-width` are
-    /// independent longhands.
+    /// Color-only setters. Setting `borderTopColor` alone must not mark the
+    /// top edge's width as explicitly set; that would let a stale 0 override
+    /// the uniform `borderWidth` shorthand. Mirrors CSS, where
+    /// `border-top-color` and `border-top-width` are independent longhands.
     void set_border_top_color(Color c)    { border_top_.color = c;    has_border_sides_ = true; }
     void set_border_right_color(Color c)  { border_right_.color = c;  has_border_sides_ = true; }
     void set_border_bottom_color(Color c) { border_bottom_.color = c; has_border_sides_ = true; }
     void set_border_left_color(Color c)   { border_left_.color = c;   has_border_sides_ = true; }
-    /// Width-only setters (pulp #1566). Setting `borderTopWidth` alone
-    /// preserves the existing per-edge color and explicitly marks the
-    /// width as set — including a width of 0, which then overrides any
-    /// uniform shorthand on that edge.
+    /// Width-only setters. Setting `borderTopWidth` alone preserves the
+    /// existing per-edge color and explicitly marks the width as set, including
+    /// a width of 0, which then overrides any uniform shorthand on that edge.
     void set_border_top_width(float w)    { border_top_.width = w;    border_top_set_ = true;    has_border_sides_ = true; }
     void set_border_right_width(float w)  { border_right_.width = w;  border_right_set_ = true;  has_border_sides_ = true; }
     void set_border_bottom_width(float w) { border_bottom_.width = w; border_bottom_set_ = true; has_border_sides_ = true; }
     void set_border_left_width(float w)   { border_left_.width = w;   border_left_set_ = true;   has_border_sides_ = true; }
-    /// Per-side getters (issue-1026). The standalone setBorderTop/Right/...
-    /// {Color,Width} bridge calls need to preserve the unrelated attribute
-    /// when only one is being changed by a JSX prop diff.
+    /// Per-side getters. The standalone setBorderTop/Right/... {Color,Width}
+    /// bridge calls need to preserve the unrelated attribute when only one is
+    /// being changed by a JSX prop diff.
     Color border_top_color() const { return border_top_.color; }
     float border_top_width() const { return border_top_.width; }
     Color border_right_color() const { return border_right_.color; }
@@ -642,29 +616,25 @@ public:
     Color border_left_color() const { return border_left_.color; }
     float border_left_width() const { return border_left_.width; }
     bool has_border_sides() const { return has_border_sides_; }
-    /// pulp #1566 — per-edge "explicitly set" probes. Yoga wiring uses
-    /// these to distinguish "not set on this edge" (fall back to uniform
-    /// `border_width()`) from "explicitly set to 0" (zero wins, even if
-    /// the shorthand says 10).
+    /// Per-edge "explicitly set" probes. Yoga wiring uses these to distinguish
+    /// "not set on this edge" (fall back to uniform `border_width()`) from
+    /// "explicitly set to 0" (zero wins, even if the shorthand says 10).
     bool has_border_top_set() const { return border_top_set_; }
     bool has_border_right_set() const { return border_right_set_; }
     bool has_border_bottom_set() const { return border_bottom_set_; }
     bool has_border_left_set() const { return border_left_set_; }
 
-    /// Per-corner border-radius (CSS border-top-left-radius, etc.)
-    /// pulp #1171 (Codex P2 on #1044) — when transitioning from uniform
-    /// `corner_radius_` to per-corner mode, seed the un-overridden
-    /// corners from the uniform value so a sequence like
+    /// Per-corner border-radius (CSS border-top-left-radius, etc.). When
+    /// transitioning from uniform `corner_radius_` to per-corner mode, seed
+    /// the un-overridden corners from the uniform value so a sequence like
     /// `set_border_radius(10); set_corner_radius_tl(2);` renders as
-    /// {2, 10, 10, 10} instead of {2, 0, 0, 0} (which silently
-    /// discarded the uniform radius).
+    /// {2, 10, 10, 10} instead of {2, 0, 0, 0}.
     void set_corner_radius_tl(float r) { promote_uniform_to_per_corner(); corner_radii_[0] = r; corner_radii_pct_[0] = 0; has_corner_radii_ = true; }
     void set_corner_radius_tr(float r) { promote_uniform_to_per_corner(); corner_radii_[1] = r; corner_radii_pct_[1] = 0; has_corner_radii_ = true; }
     void set_corner_radius_bl(float r) { promote_uniform_to_per_corner(); corner_radii_[2] = r; corner_radii_pct_[2] = 0; has_corner_radii_ = true; }
     void set_corner_radius_br(float r) { promote_uniform_to_per_corner(); corner_radii_[3] = r; corner_radii_pct_[3] = 0; has_corner_radii_ = true; }
-    /// pulp #1663 — per-corner percent setters. Same semantics as
-    /// set_border_radius_pct: paint time resolves to
-    /// `pct * 0.01 * min(width, height)`.
+    /// Per-corner percent setters. Same semantics as set_border_radius_pct:
+    /// paint time resolves to `pct * 0.01 * min(width, height)`.
     void set_corner_radius_tl_pct(float pct) { promote_uniform_to_per_corner(); corner_radii_pct_[0] = pct; has_corner_radii_ = true; }
     void set_corner_radius_tr_pct(float pct) { promote_uniform_to_per_corner(); corner_radii_pct_[1] = pct; has_corner_radii_ = true; }
     void set_corner_radius_bl_pct(float pct) { promote_uniform_to_per_corner(); corner_radii_pct_[2] = pct; has_corner_radii_ = true; }
@@ -703,15 +673,12 @@ public:
     bool has_box_shadow() const { return has_shadow_; }
     const BoxShadow& box_shadow() const { return shadow_; }
 
-    /// pulp #1737 RN-OOS-fixup (audit 2026-05-11) — RN iOS-legacy
-    /// shadow* longhand setters. RN 0.71+ added `boxShadow` as the
-    /// cross-platform path (which Pulp fully supports), but the four
-    /// per-attribute setters still appear in legacy code + the React
-    /// Native API surface. Pulp mirrors the per-attribute pattern the
-    /// text-shadow longhand uses (set_text_shadow_color / _offset /
-    /// _radius — see widget_bridge.cpp:5368-5392): each setter mutates
-    /// ONE field of the shared BoxShadow struct so a JSX prop diff
-    /// that touches one prop doesn't clobber the others.
+    /// RN iOS-legacy shadow* longhand setters. RN 0.71+ added `boxShadow` as
+    /// the cross-platform path, but the four per-attribute setters still appear
+    /// in legacy code and the React Native API surface. Pulp mirrors the
+    /// per-attribute pattern the text-shadow longhand uses: each setter mutates
+    /// one field of the shared BoxShadow struct so a JSX prop diff that touches
+    /// one prop doesn't clobber the others.
     ///
     /// Any of these turns has_shadow_ on (matches React Native's
     /// behavior — setting any shadow prop activates the shadow paint).
@@ -722,10 +689,8 @@ public:
         shadow_.offset_x = ox; shadow_.offset_y = oy; has_shadow_ = true;
     }
     void set_box_shadow_opacity(float a) {
-        // RN's shadowOpacity is 0..1; multiply into the color's alpha
-        // channel (preserves any explicit color alpha the author set
-        // via shadowColor + still respects the 0..1 opacity slider).
-        // Pulp Color stores alpha as 0..255 internally.
+        // RN's shadowOpacity is 0..1; overwrite the shadow color's normalized
+        // alpha channel while preserving the existing RGB channels.
         shadow_.color.a = a; has_shadow_ = true;
     }
     void set_box_shadow_radius(float r) {
@@ -768,8 +733,8 @@ public:
     static std::vector<OverlayRequest>& overlay_queue();
     /// Paint queued overlays + the inspector paint hook. `painting_root` is the
     /// root View whose tree was just painted into `canvas` — it is forwarded to
-    /// the inspector paint hook so the hook can gate (WYSIWYG P2e). When a host
-    /// paints multiple roots into separate surfaces (e.g. the floating
+    /// the inspector paint hook so the hook can gate. When a host paints
+    /// multiple roots into separate surfaces (e.g. the floating
     /// InspectorWindow's own root vs. the main canvas root), the inspector
     /// overlay's selection box / handles / drop indicators must paint ONLY on
     /// the inspected root, never leak into the inspector window at the overlay's
@@ -790,8 +755,8 @@ public:
 
     /// Inspector mouse hook. Like the paint hook, the call carries the event's
     /// root View (`event_root`) so the installed hook can gate to the inspected
-    /// canvas root (WYSIWYG P4 FIX 1). Without the gate a secondary window's
-    /// events (the floating InspectorWindow) leak into the canvas overlay:
+    /// canvas root. Without the gate, a secondary window's events (the floating
+    /// InspectorWindow) leak into the canvas overlay:
     /// hovering/clicking/scrolling inside the inspector window would
     /// highlight/affect the canvas. The platform host passes the window's own
     /// root (the same source the paint hook uses for that host); the installed
@@ -803,21 +768,21 @@ public:
     static bool call_inspector_mouse_hook(const MouseEvent& e,
                                           View* event_root = nullptr);
 
-    /// Inspector text-input hook (WYSIWYG P3 — inline Text-tool editing).
+    /// Inspector text-input hook for inline Text-tool editing.
     /// The platform host routes UTF-8 character input here BEFORE the
     /// focused view so the inspector's inline text edit can consume it
     /// while the Text tool is active. Returns true when the inspector
     /// consumed the text (an inline edit is in progress); false otherwise,
     /// so normal text-input delivery to the focused widget proceeds.
     ///
-    /// WYSIWYG P4 FIX 1 — carries the event's root View so the installed hook
-    /// gates to the inspected canvas root, matching the mouse + paint hooks.
+    /// Carries the event's root View so the installed hook gates to the
+    /// inspected canvas root, matching the mouse + paint hooks.
     static void set_inspector_text_hook(
         std::function<bool(const TextInputEvent&, View* event_root)> hook);
     static bool call_inspector_text_hook(const TextInputEvent& e,
                                          View* event_root = nullptr);
 
-    /// Inspector cursor-affordance hook (WYSIWYG P2d). The inspector overlay
+    /// Inspector cursor-affordance hook. The inspector overlay
     /// intercepts mouse-move before normal hit-testing, so the platform host
     /// cannot rely on the hit view's own `cursor()` to show move/resize
     /// affordances over a selected element. This hook lets the overlay
@@ -828,8 +793,8 @@ public:
     /// `call_inspector_cursor_hook` in its mouse-move handler and applies the
     /// returned style when it is >= 0. No-op (returns -1) when no hook is set.
     ///
-    /// WYSIWYG P4 FIX 1 — carries the event's root View so the installed hook
-    /// gates to the inspected canvas root, matching the mouse + paint hooks.
+    /// Carries the event's root View so the installed hook gates to the
+    /// inspected canvas root, matching the mouse + paint hooks.
     /// Without the gate a mouse-move inside the floating InspectorWindow would
     /// drive the canvas overlay's cursor affordance.
     static void set_inspector_cursor_hook(
@@ -837,7 +802,7 @@ public:
     static int call_inspector_cursor_hook(const MouseEvent& e,
                                           View* event_root = nullptr);
 
-    // ── Generalized overlay-click routing (pulp #1148) ───────────────────
+    // ── Generalized overlay-click routing ────────────────────────────────
     //
     // ComboBox already uses a `static ComboBox* active_popup_` pointer so
     // the platform window-host layer can short-circuit hit-testing for
@@ -860,14 +825,12 @@ public:
     // The ComboBox path remains untouched and has its own state.
     static View* active_overlay_;
     void claim_overlay() { active_overlay_ = this; }
-    /// pulp #1708 — global input-focus slot. The platform window host
-    /// (PulpView on mac, equivalent on other platforms) calls
-    /// `claim_input_focus()` when a click sets focus to a widget, and
-    /// reads `focused_input_` for text-input dispatch. The View destructor
-    /// auto-clears the slot if the focused widget is destroyed before
-    /// focus is moved off it (e.g., React unmount of an open modal).
-    /// Without this, the host's raw View* pointer dangles and the next
-    /// keypress segfaults inside dynamic_cast<TextEditor*>(focused).
+    /// Global input-focus slot. The platform window host calls
+    /// `claim_input_focus()` when a click sets focus to a widget, and reads
+    /// `focused_input_` for text-input dispatch. The View destructor auto-clears
+    /// the slot if the focused widget is destroyed before focus is moved off it.
+    /// Without this, the host's raw View* pointer dangles and the next keypress
+    /// segfaults inside dynamic_cast<TextEditor*>(focused).
     static View* focused_input_;
     void claim_input_focus() { focused_input_ = this; }
     void release_input_focus() {
@@ -880,16 +843,16 @@ public:
     void release_overlay() {
         if (active_overlay_ == this) active_overlay_ = nullptr;
     }
-    /// pulp #1361 — dismiss-path release. Releases the active overlay
-    /// (if any) AND fires its `on_overlay_dismissed` callback so React
-    /// state can flip `setOpen(false)` to keep the JSX tree in sync.
-    /// Called by the platform window host from the ESC keypath and the
-    /// outside-click path. No-op if nothing claimed the slot.
+    /// Dismiss-path release. Releases the active overlay (if any) and fires its
+    /// `on_overlay_dismissed` callback so React state can flip `setOpen(false)`
+    /// to keep the JSX tree in sync. Called by the platform window host from
+    /// the ESC keypath and the outside-click path. No-op if nothing claimed the
+    /// slot.
     static void dismiss_active_overlay();
-    /// pulp #1361 — fired when the active overlay is dismissed via a
-    /// framework auto-dismissal path (ESC / outside-click). NOT fired
-    /// for `release_overlay()` (JSX unmount / destructor). The bridge
-    /// uses this to dispatch `__dispatch__(id, 'dismiss', 0)` so React
+    /// Fired when the active overlay is dismissed via a framework
+    /// auto-dismissal path (ESC / outside-click). Not fired for
+    /// `release_overlay()` (JSX unmount / destructor). The bridge uses this to
+    /// dispatch `__dispatch__(id, 'dismiss', 0)` so React
     /// `<View overlay onDismissed>` consumers can sync state.
     std::function<void()> on_overlay_dismissed;
     /// Bounds-test in window (root) coordinates. Walks the parent chain
@@ -909,12 +872,11 @@ public:
     void set_position(Position p) { position_ = p; }
     Position position() const { return position_; }
 
-    // pulp #1434 batch 6 — top/right/bottom/left accept either a px
-     // value (the historical path, single-arg setter) or a percent value
-     // (new, two-arg setter that records the unit). The Yoga adapter
-     // dispatches on `top_unit_` / etc. and routes percent values through
-     // YGNodeStyleSetPositionPercent. Mirrors the FlexStyle::dim_width
-     // pattern from pulp #1423 (PR #1426) for the View positional fields.
+    // top/right/bottom/left accept either a px value (the single-arg setter) or
+    // a percent value (the two-arg setter that records the unit). The Yoga
+    // adapter dispatches on `top_unit_` / etc. and routes percent values through
+    // YGNodeStyleSetPositionPercent, mirroring the FlexStyle::dim_width pattern
+    // for the View positional fields.
     void set_top(float v) { top_ = v; has_top_ = true; top_unit_ = DimensionUnit::px; }
     void set_right(float v) { right_ = v; has_right_ = true; right_unit_ = DimensionUnit::px; }
     void set_bottom(float v) { bottom_ = v; has_bottom_ = true; bottom_unit_ = DimensionUnit::px; }
@@ -938,7 +900,7 @@ public:
     void set_z_index(int z) { z_index_ = z; }
     int z_index() const { return z_index_; }
 
-    /// pulp #972 — return children stably sorted by z_index() ascending.
+    /// Return children stably sorted by z_index() ascending.
     /// paint_all paints in this order so higher-z siblings render on top;
     /// hit_test walks the same order in reverse. Exposed so tests can
     /// assert ordering directly without piping through the paint pipeline.
@@ -968,10 +930,10 @@ public:
     void set_skew(float x_deg, float y_deg) { skew_x_ = x_deg; skew_y_ = y_deg; }
 
     /// Transform origin (0-1 normalized, default 0.5,0.5 = center).
-    /// pulp #1026 — also tracks an "explicitly set" flag so the affine
-    /// matrix path (issue-930 setTransform) only honors the origin when
-    /// the caller has actively chosen one. Without this, every existing
-    /// setTransform() call site would silently start anchoring at center.
+    /// Also tracks an "explicitly set" flag so the affine matrix path only
+    /// honors the origin when the caller has actively chosen one. Without this,
+    /// setTransform() call sites that never set an origin would silently start
+    /// anchoring at center.
     void set_transform_origin(float x, float y) {
         origin_x_ = x; origin_y_ = y; origin_explicit_ = true;
     }
@@ -979,7 +941,7 @@ public:
     float transform_origin_y() const { return origin_y_; }
     bool transform_origin_explicit() const { return origin_explicit_; }
 
-    /// Full 2D affine transform matrix on the View (issue-930). Mirrors the
+    /// Full 2D affine transform matrix on the View. Mirrors the
     /// CanvasRenderingContext2D.setTransform contract:
     ///   [ a c e ]
     ///   [ b d f ]
@@ -1010,15 +972,15 @@ public:
         d = transform_matrix_d_; e = transform_matrix_e_; f = transform_matrix_f_;
     }
 
-    /// CSS filter: blur(px) — per-element blur. Legacy single-blur slot
-    /// kept for API compatibility; the richer filter chain (Phase A2-4)
-    /// lives in `filter_chain_` below and supersedes this when non-empty.
+    /// CSS filter: blur(px) — per-element blur. Legacy single-blur slot kept
+    /// for API compatibility; the richer filter chain lives in `filter_chain_`
+    /// below and supersedes this when non-empty.
     void set_filter_blur(float radius) { filter_blur_ = radius; }
     float filter_blur() const { return filter_blur_; }
 
-    /// pulp #1434 Phase A2-4 — full CSS filter chain. Each entry is one
-    /// filter function (blur / brightness / contrast / grayscale /
-    /// hue-rotate / invert / opacity / saturate / sepia / drop-shadow).
+    /// Full CSS filter chain. Each entry is one filter function (blur /
+    /// brightness / contrast / grayscale / hue-rotate / invert / opacity /
+    /// saturate / sepia / drop-shadow).
     /// The Skia path walks the chain and composes via
     /// `SkImageFilters::Compose` + color-matrix wraps; CG falls back to
     /// blur-only. When the chain is empty, the legacy `filter_blur_`
@@ -1051,14 +1013,10 @@ public:
     const std::vector<FilterOp>& filter_chain() const { return filter_chain_; }
     bool has_filter_chain() const { return !filter_chain_.empty(); }
 
-    /// pulp #1434 Phase A2-1 — CSS transitions + animations.
-    /// `set_transitions` accepts the parsed shorthand; `transitions()`
-    /// returns the slice for the dispatcher to consult when a property
-    /// changes. Per the CSS spec, the matching is a linear walk —
-    /// later entries win when properties overlap (CSS cascade order).
-    /// PR 2 of the ladder hooks the dispatcher to the rAF idle pump
-    /// and starts driving Animation instances; PR 1 establishes the
-    /// storage shape so downstream PRs can land independently.
+    /// CSS transitions + animations. `set_transitions` accepts the parsed
+    /// shorthand; `transitions()` returns the slice for the dispatcher to
+    /// consult when a property changes. Per the CSS spec, matching is a linear
+    /// walk; later entries win when properties overlap (CSS cascade order).
     void set_transitions(std::vector<TransitionSpec> ts) { transitions_ = std::move(ts); }
     void clear_transitions() { transitions_.clear(); }
     const std::vector<TransitionSpec>& transitions() const { return transitions_; }
@@ -1077,15 +1035,13 @@ public:
         return match;
     }
 
-    /// Active running animations on this View. Owned here so the
-    /// per-View lifetime matches the View's. PR 2 wires the
-    /// dispatcher to mutate this list; PR 1 establishes ownership.
+    /// Active running animations on this View. Owned here so the per-View
+    /// lifetime matches the View's.
     std::vector<CssAnimation>& active_animations() { return active_animations_; }
     const std::vector<CssAnimation>& active_animations() const { return active_animations_; }
 
-    /// Advance every active CSS animation by `dt` seconds (pulp #1434
-    /// Wave 3 css.3 — animation-play-state playback driver pause /
-    /// resume). When `animation_play_state_ == "paused"`, the call is
+    /// Advance every active CSS animation by `dt` seconds. When
+    /// `animation_play_state_ == "paused"`, the call is
     /// a no-op so the animations' `elapsed_seconds` does not advance —
     /// the spec semantic of `animation-play-state: paused`. The default
     /// keyword is `running`; any value other than `paused` advances.
@@ -1105,8 +1061,7 @@ public:
         return finished;
     }
 
-    /// Staged CSS animation control tokens (pulp #1434 — Codex audit on
-    /// PR #1508). The web-compat-style-decl shim invokes
+    /// Staged CSS animation control tokens. The web-compat-style-decl shim invokes
     /// `setAnimation(id, "name"|"duration"|"easing"|..., value)` one
     /// control-token at a time — one CSS longhand per call. We
     /// accumulate that state here; when the `name` token resolves
@@ -1127,13 +1082,13 @@ public:
     const StagedAnimation& staged_animation() const { return staged_animation_; }
 
     /// CSS backdrop-filter: blur(px) — frosted-glass blur applied to whatever
-    /// is behind this View when it paints (issue-926). Zero == no backdrop
+    /// is behind this View when it paints. Zero == no backdrop
     /// filter. Skia maps to `saveLayer(SaveLayerRec{ .fBackdrop = Blur })`.
     void set_backdrop_blur(float radius) { backdrop_blur_ = radius; }
     float backdrop_blur() const { return backdrop_blur_; }
 
-    /// CSS `clip-path: path("...")` (pulp #1515). Stores an SVG-path-d
-    /// string; paint_all() installs it as a canvas clip via
+    /// CSS `clip-path: path("...")`. Stores an SVG-path-d string; paint_all()
+    /// installs it as a canvas clip via
     /// `Canvas::clip_path_svg` before painting children. Empty string
     /// clears the slot. URL refs (`url(#id)`) and named shape forms
     /// (`circle()`, `inset()`, `polygon()`) are deferred — only the
@@ -1142,23 +1097,21 @@ public:
     const std::string& clip_path() const { return clip_path_; }
     bool has_clip_path() const { return !clip_path_.empty(); }
 
-    /// CSS `mask-image: ...` (pulp #1515). Storage-only today; the
-    /// paint pipeline does not yet composite a shader mask onto a
-    /// saveLayer (image-URL fetch + SkBlendMode::kDstIn is the
-    /// follow-up paint slice). Solid-color and `none` are tracked so
-    /// the value round-trips through View slots and the bridge.
+    /// CSS `mask-image: ...`. View opens a masked compositing layer when this
+    /// slot is set to a non-`none` value. Backends without mask support route
+    /// through the default save_layer path and preserve the value for bridge
+    /// round-tripping.
     void set_mask_image(const std::string& value) { mask_image_ = value; }
     const std::string& mask_image() const { return mask_image_; }
 
-    /// CSS `mask` shorthand (pulp #1515). Stored verbatim alongside
-    /// `mask_image_`; the longhand fan-out in the JS shim populates
-    /// the image slot from this string. Storage-only today.
+    /// CSS `mask` shorthand. Stored verbatim alongside `mask_image_`; the
+    /// longhand fan-out in the JS shim populates the image slot from this
+    /// string.
     void set_mask(const std::string& value) { mask_ = value; }
     const std::string& mask() const { return mask_; }
 
-    /// CSS `mask-size` (pairs with mask-image — pulp #1515 followup).
-    /// Stored alongside mask_image_; consumed by the paint slice that
-    /// composites the mask shader. Honored values: `auto` (default),
+    /// CSS `mask-size` (pairs with mask-image). Stored alongside mask_image_
+    /// and passed to the canvas mask layer. Honored values: `auto` (default),
     /// `cover`, `contain`, `<length>`, `<length> <length>`.
     void set_mask_size(const std::string& value) { mask_size_ = value; }
     const std::string& mask_size() const { return mask_size_; }
@@ -1173,13 +1126,11 @@ public:
     void set_appearance(const std::string& value) { appearance_ = value; }
     const std::string& appearance() const { return appearance_; }
 
-    /// CSS `object-fit` — controls how an `<img>` content's intrinsic
-    /// size is fitted into its layout box. Storage-only today; the
-    /// ImageView paint slice that consumes this needs access to the
-    /// decoded image's natural size (planned follow-up). Honored
-    /// values in the future paint slice: `fill` (default — current
-    /// behavior of stretching to bounds), `contain`, `cover`, `none`,
-    /// `scale-down`.
+    /// CSS `object-fit` — controls how an `<img>` content's intrinsic size is
+    /// fitted into its layout box. Storage-only today; ImageView currently
+    /// stretches to bounds and does not consult the decoded image's natural
+    /// size. Honored values once the image paint path consumes this slot:
+    /// `fill` (default), `contain`, `cover`, `none`, `scale-down`.
     void set_object_fit(const std::string& value) { object_fit_ = value; }
     const std::string& object_fit() const { return object_fit_; }
 
@@ -1189,14 +1140,14 @@ public:
     void set_object_position(const std::string& value) { object_position_ = value; }
     const std::string& object_position() const { return object_position_; }
 
-    /// CSS background sub-properties (pulp #1517). These slots store the
-    /// keyword for round-tripping; paint impact is partial — see notes:
+    /// CSS background sub-properties. These slots store the keyword for
+    /// round-tripping; paint impact is partial — see notes:
     ///   • background-attachment: only `scroll` is conformant in pulp's
     ///     non-scrolling layout model. `fixed` / `local` need a scroll-
     ///     context coupling we don't have. Catalog: noop.
     ///   • background-clip: `text` would clip the bg paint to text glyphs
-    ///     via SkBlendMode::kSrcIn — deferred to a later PR. Other values
-    ///     are no-ops on solid bg. Catalog: partial.
+    ///     via SkBlendMode::kSrcIn. Other values are no-ops on solid bg.
+    ///     Catalog: partial.
     ///   • background-origin: relevant only for repeating gradients (which
     ///     we don't paint per-tile). Catalog: noop.
     void set_background_attachment(std::string kw) { background_attachment_ = std::move(kw); }
@@ -1206,51 +1157,44 @@ public:
     void set_background_origin(std::string kw)     { background_origin_ = std::move(kw); }
     const std::string& background_origin() const   { return background_origin_; }
 
-    /// CSS background-position / background-size (Wave 5 css.5). Both are
-    /// storage-only slots today: pulp's solid-bg paint path doesn't honor
-    /// position or size offsets (these only matter for url()/image-set()
-    /// raster backgrounds, which are deferred to the image-loader slice
-    /// — see backgroundImage catalog notes). Storing the keyword keeps
-    /// the round-trip honest (set → get returns the literal string the
-    /// CSS author wrote) so a future image-pipeline PR can honor the
-    /// existing value without a JS-side change.
+    /// CSS background-position / background-size. Both are storage-only slots
+    /// today: Pulp's solid-bg paint path doesn't honor position or size offsets
+    /// (these only matter for url()/image-set() raster backgrounds). Storing
+    /// the keyword keeps the round-trip honest so the image pipeline can honor
+    /// the existing value without a JS-side change.
     void set_background_position(std::string kw)   { background_position_ = std::move(kw); }
     const std::string& background_position() const { return background_position_; }
     void set_background_size(std::string kw)       { background_size_ = std::move(kw); }
     const std::string& background_size() const     { return background_size_; }
 
-    // pulp #1434 A4 Bundles 5–7 closure — storage-only slots for CSS
-    // properties closed in the css NOT-IMPL sweep. Each slot is round-
-    // trippable so harness tests can verify the bridge accepts the
-    // value, and so a future paint-time slice can honor it without a
-    // JS-side change. Catalog status documents the implementation
-    // depth (`partial` / `noop` / `wontfix`).
+    // Storage-only slots for CSS properties that the bridge accepts but View
+    // does not fully consume. Each slot is round-trippable so harness tests can
+    // verify the bridge accepts the value, and so a paint path can honor it
+    // later without a JS-side change. Catalog status documents the
+    // implementation depth (`partial` / `noop` / `wontfix`).
     void set_text_indent(float v)                  { text_indent_ = v; }
     float text_indent() const                      { return text_indent_; }
     void set_word_break(std::string kw)            { word_break_ = std::move(kw); }
     const std::string& word_break() const          { return word_break_; }
 
-    /// pulp #1737 RN-OOS-fixup (audit 2026-05-11) — CSS scroll-behavior
-    /// + overscroll-behavior. Slot storage on every View; consumed by
-    /// ScrollView::scroll_by + clamp_scroll_targets (`auto` triggers
-    /// instant scroll, `smooth` enables animated scroll; `contain`/
-    /// `none` for overscroll match Pulp's existing "clamp at content
-    /// bounds, no scroll chaining" behavior). Non-ScrollView views
-    /// round-trip the value but the paint pipeline doesn't act on it
-    /// — matches CSS semantics: a non-scrollable element ignores
-    /// scroll-related properties.
+    /// CSS scroll-behavior + overscroll-behavior. Slot storage on every View;
+    /// consumed by ScrollView::scroll_by + clamp_scroll_targets (`auto`
+    /// triggers instant scroll, `smooth` enables animated scroll; `contain` /
+    /// `none` for overscroll match Pulp's existing "clamp at content bounds, no
+    /// scroll chaining" behavior). Non-ScrollView views round-trip the value
+    /// but the paint pipeline doesn't act on it, matching CSS semantics for
+    /// non-scrollable elements.
     void set_scroll_behavior(std::string kw)       { scroll_behavior_ = std::move(kw); }
     const std::string& scroll_behavior() const     { return scroll_behavior_; }
     void set_overscroll_behavior(std::string kw)   { overscroll_behavior_ = std::move(kw); }
     const std::string& overscroll_behavior() const { return overscroll_behavior_; }
 
-    /// pulp #1737 RN-OOS-fixup (final sweep) — RN's Android-only
-    /// `includeFontPadding`. Pure round-trip storage: Pulp's text-
-    /// shaping pipeline doesn't add Android's vestigial vertical
-    /// padding regardless of this value, so the bridge accepts the
-    /// keyword + stores it (`el.style.includeFontPadding === false`
-    /// reads back) and the paint pipeline ignores it. See compat.json
-    /// rn/includeFontPadding notes for the honest CSS-subset rationale.
+    /// RN's Android-only `includeFontPadding`. Pure round-trip storage: Pulp's
+    /// text-shaping pipeline doesn't add Android's vestigial vertical padding
+    /// regardless of this value, so the bridge accepts the keyword + stores it
+    /// (`el.style.includeFontPadding === false` reads back) and the paint
+    /// pipeline ignores it. See compat.json rn/includeFontPadding notes for the
+    /// honest CSS-subset rationale.
     void set_include_font_padding(bool v) { include_font_padding_ = v; }
     bool include_font_padding() const     { return include_font_padding_; }
 
@@ -1273,13 +1217,11 @@ public:
     void set_continuous_repaint(bool on) { wants_continuous_repaint_ = on; }
     bool wants_continuous_repaint() const { return wants_continuous_repaint_; }
 
-    /// pulp #1548 — RN textShadow per-attribute storage. Storage-only;
-    /// SkPaint shadow integration is the deferred paint-time slice.
-    /// Each slot is round-trippable so a commitUpdate that touches only
-    /// one of the three preserves the others (mirrors the per-side
-    /// border slot pattern). A future combined `set_text_shadow`
-    /// helper for the CSS shorthand path can write all three slots
-    /// atomically.
+    /// RN textShadow per-attribute storage. Storage-only; SkPaint shadow
+    /// integration is not wired here. Each slot is round-trippable so a
+    /// commitUpdate that touches only one of the three preserves the others
+    /// (mirrors the per-side border slot pattern). A combined CSS shorthand
+    /// helper can write all three slots atomically.
     void set_text_shadow_color(std::string c)      { text_shadow_color_ = std::move(c); }
     const std::string& text_shadow_color() const   { return text_shadow_color_; }
     void set_text_shadow_offset(float dx, float dy){ text_shadow_dx_ = dx; text_shadow_dy_ = dy; }
@@ -1351,15 +1293,12 @@ public:
     void set_text_overflow_ellipsis(bool e) { text_ellipsis_ = e; }
     bool text_overflow_ellipsis() const { return text_ellipsis_; }
 
-    /// pulp #1434 Phase A2-3 — writing direction (CSS `direction` /
-    /// RN `writingDirection`). LTR is the default; RTL flips text
-    /// shaping (Skia paragraph_style.setTextDirection), Yoga's flow
-    /// (YGDirectionRTL — flexDirection 'row' visually reverses), and
-    /// textAlign 'auto' resolution at paint time. The View::direction_
-    /// state propagates inheritance only when the caller plumbs it
-    /// through the tree (Phase A2-3 keeps inheritance opt-in;
-    /// automatic-cascade is a follow-up). Enum is tri-state — `auto_`
-    /// defers to parent / first-strong-character heuristic.
+    /// Writing direction (CSS `direction` / RN `writingDirection`). LTR is the
+    /// default; RTL flips text shaping (Skia paragraph_style.setTextDirection),
+    /// Yoga's flow (YGDirectionRTL — flexDirection 'row' visually reverses),
+    /// and textAlign 'auto' resolution at paint time. The View::direction_
+    /// state propagates inheritance only when the caller plumbs it through the
+    /// tree. Enum is tri-state; `auto_` currently resolves to the LTR fallback.
     enum class WritingDirection { ltr, rtl, auto_ };
     void set_direction(WritingDirection d) { direction_ = d; }
     WritingDirection direction() const { return direction_; }
@@ -1370,14 +1309,14 @@ public:
         return direction_ == WritingDirection::auto_ ? WritingDirection::ltr : direction_;
     }
 
-    /// White-space: nowrap (CSS `white-space: nowrap`). Pulp #1410. Generic
+    /// White-space: nowrap (CSS `white-space: nowrap`). Generic
     /// flag so non-Label widgets (Button, custom text-bearing views) and
     /// text-shaper consumers can react to nowrap without dynamic_casting
     /// to a specific widget type. Label keeps its `multi_line_` flag in
     /// lock-step via WidgetBridge::setWhiteSpace, so existing callers keep
     /// working.
-    // pulp #1737 — full CSS `white-space` enum. Replaces the
-    // nowrap-only bool with the spec's 6 keywords. Per CSS Text
+    // Full CSS `white-space` enum. Replaces the nowrap-only bool with the
+    // spec's 6 keywords. Per CSS Text
     // Module Level 3 §3:
     //   normal       collapse  drop_nl   wrap
     //   nowrap       collapse  drop_nl   nowrap
@@ -1388,12 +1327,11 @@ public:
     enum class WhiteSpaceMode {
         normal, nowrap, pre, pre_wrap, pre_line, break_spaces
     };
-    // pulp #1737 (Codex P2 followup on #1786): set_white_space_nowrap()
-    // also keeps the WhiteSpaceMode enum in sync so callers using the
-    // legacy setter don't leave white_space_mode() stale. The enum is
-    // pinned to nowrap (true) or normal (false) — we can't infer
-    // pre/pre-wrap/etc. from a bool, so the legacy setter only ever
-    // produces these two modes.
+    // set_white_space_nowrap() also keeps the WhiteSpaceMode enum in sync so
+    // callers using the legacy setter don't leave white_space_mode() stale.
+    // The enum is pinned to nowrap (true) or normal (false); we can't infer
+    // pre/pre-wrap/etc. from a bool, so the legacy setter only ever produces
+    // these two modes.
     void set_white_space_nowrap(bool n) {
         white_space_nowrap_ = n;
         white_space_mode_ = n ? WhiteSpaceMode::nowrap : WhiteSpaceMode::normal;
@@ -1406,7 +1344,7 @@ public:
     }
     WhiteSpaceMode white_space_mode() const { return white_space_mode_; }
 
-    /// CSS / RN `mix-blend-mode` (pulp #1549). The blend mode applied when
+    /// CSS / RN `mix-blend-mode`. The blend mode applied when
     /// this View's compositing layer composites back onto its parent. Stored
     /// as the canvas BlendMode enum so the paint path can pass it straight
     /// through to the layer-paint without a string lookup. Default
@@ -1431,11 +1369,9 @@ public:
         bottom_left_resize,       ///< ↗↙ Diagonal resize (alias for top_right)
         bottom_right_resize,      ///< ↖↘ Diagonal resize (alias for top_left)
         multi_directional_resize, ///< ✥ All-direction move/resize
-        // CSS cursor keywords with native macOS NSCursor mappings
-        // (pulp #1550 Tier-4 macOS partial 2026-05-12). Other CSS
-        // keywords without dedicated visuals (wait / help / progress /
-        // cell) stay catalog-unsupported because no native cursor
-        // exists on macOS.
+        // CSS cursor keywords with native macOS NSCursor mappings. Other CSS
+        // keywords without dedicated visuals (wait / help / progress / cell)
+        // stay catalog-unsupported because no native cursor exists on macOS.
         alias,                    ///< CSS `alias` → NSCursor.dragLinkCursor
         copy,                     ///< CSS `copy` → NSCursor.dragCopyCursor
         zoom_in,                  ///< CSS `zoom-in` → NSCursor.zoomInCursor (macOS 10.15+)
@@ -1445,20 +1381,18 @@ public:
     void set_cursor(CursorStyle c) { cursor_ = c; }
     CursorStyle cursor() const { return cursor_; }
 
-    /// CSS `user-select` (pulp #1538 / #1656 / Tier-2 follow-up).
-    /// Stored slot for the keyword the JS shim resolves to. Read by
-    /// interactive widgets (TextEditor, Label) that participate in
-    /// text selection. `auto_` is the spec default (resolves per-widget
-    /// to whatever its native selectability is).
+    /// CSS `user-select`. Stored slot for the keyword the JS shim resolves to.
+    /// Read by interactive widgets (TextEditor, Label) that participate in text
+    /// selection. `auto_` is the spec default and resolves per-widget to
+    /// whatever its native selectability is.
     enum class UserSelect { auto_, none, text, all, contain };
     void set_user_select(UserSelect s) { user_select_ = s; }
     UserSelect user_select() const { return user_select_; }
 
 private:
     /// Seed corner_radii_ from the uniform corner_radius_ on the first
-    /// transition into per-corner mode (pulp #1171 Codex P2 on #1044).
-    /// Idempotent: subsequent calls (when has_corner_radii_ is already
-    /// true) are no-ops.
+    /// transition into per-corner mode. Idempotent: subsequent calls (when
+    /// has_corner_radii_ is already true) are no-ops.
     void promote_uniform_to_per_corner() {
         if (!has_corner_radii_ && corner_radius_ > 0.0f) {
             corner_radii_[0] = corner_radius_;
@@ -1476,22 +1410,22 @@ private:
     View* parent_ = nullptr;
     std::vector<std::unique_ptr<View>> children_;
     std::string id_;
-    // Phase 0b: design-import anchor identity. Empty for views not
-    // constructed from an imported tree. See set_anchor_id().
+    // Design-import anchor identity. Empty for views not constructed from an
+    // imported tree. See set_anchor_id().
     std::string anchor_id_;
     std::uint64_t import_binding_instance_id_ = 0;
     std::shared_ptr<const std::uint64_t> import_binding_lifetime_token_;
-    // Phase 5.1: authored-source location (JSX file:line:col) from the
-    // React reconciler's `__source` prop. Unset for non-imported views.
+    // Authored-source location (JSX file:line:col) from the React reconciler's
+    // `__source` prop. Unset for non-imported views.
     std::optional<SourceLocation> source_loc_;
-    // Phase 3d (inspector roadmap): last-paint-cycle timing. Both 0
-    // until paint_all() has executed at least once.
+    // Last-paint-cycle timing. Both 0 until paint_all() has executed at least
+    // once.
     std::uint32_t last_paint_self_ns_ = 0;
     std::uint32_t last_paint_with_children_ns_ = 0;
     AccessRole access_role_ = AccessRole::none;
     std::string access_label_;
     std::string access_value_;
-    // pulp #1737 — ARIA state attributes (tri-state per spec).
+    // ARIA state attributes (tri-state per spec).
     std::string access_pressed_;
     std::string access_checked_;
     std::string access_disabled_;
@@ -1516,22 +1450,22 @@ private:
     Color border_color_{};
     float border_width_ = 0;
     float corner_radius_ = 0;
-    // pulp #1663 — borderRadius % support. When > 0, paint code resolves
+    // borderRadius % support. When > 0, paint code resolves
     // effective radius as `corner_radius_pct_ * 0.01 * min(width, height)`.
     // 0 means "use plain corner_radius_ in px". Same pattern for the
     // per-corner radii_pct_ slots below.
     float corner_radius_pct_ = 0;
-    // pulp #1737 RN-OOS-fixup (#1812) — RN `borderCurve` corner shape.
+    // RN `borderCurve` corner shape.
     BorderCurve border_curve_ = BorderCurve::circular;
     bool has_border_ = false;
     BorderStyle border_style_ = BorderStyle::solid;
-    // pulp #1514 — list-style cluster slots. Stored verbatim; paint-
+    // list-style cluster slots. Stored verbatim; paint-
     // time marker rendering is deferred. Defaults match CSS spec
     // (`disc` for the type, `outside` for the position, empty image).
     ListStyleType list_style_type_ = ListStyleType::disc;
     std::string list_style_image_{};
     ListStylePosition list_style_position_ = ListStylePosition::outside;
-    // CSS / RN outline cluster (pulp #1519). Defaults: outline_style_
+    // CSS / RN outline cluster. Defaults: outline_style_
     // is `none` so paint short-circuits unless JS opts in via
     // setOutlineStyle. width=0 also short-circuits as a belt-and-braces
     // guard. Color defaults to fully-transparent black; bridge writes
@@ -1544,7 +1478,7 @@ private:
     struct BorderSide { Color color{}; float width = 0; };
     BorderSide border_top_{}, border_right_{}, border_bottom_{}, border_left_{};
     bool has_border_sides_ = false;
-    // pulp #1566 — per-edge "explicitly set" flags, parallel to has_top_
+    // Per-edge "explicitly set" flags, parallel to has_top_
     // / has_right_ / etc. for inset edges. Required so an explicit
     // borderTopWidth=0 overrides the uniform borderWidth=10 shorthand
     // (CSS / RN semantics). Plain `width == 0` is ambiguous because the
@@ -1555,23 +1489,22 @@ private:
     bool border_left_set_ = false;
     // Per-corner radii
     float corner_radii_[4] = {0, 0, 0, 0}; // TL, TR, BL, BR
-    // pulp #1663 — % support paired with corner_radii_. >0 means use pct
+    // % support paired with corner_radii_. >0 means use pct
     // resolution, 0 means use the px slot above. Sized 4 (TL, TR, BL, BR).
     float corner_radii_pct_[4] = {0, 0, 0, 0};
     bool has_corner_radii_ = false;
     Position position_ = Position::static_;
     float top_ = 0, right_ = 0, bottom_ = 0, left_ = 0;
     bool has_top_ = false, has_right_ = false, has_bottom_ = false, has_left_ = false;
-    // pulp #1434 batch 6 — per-edge inset unit. `px` is the historical
-    // default; `percent` flows through to YGNodeStyleSetPositionPercent
-    // in yoga_layout.cpp. Other DimensionUnit values (vw/vh/etc.) round
-    // down to px at the bridge boundary today (no consumer demand).
+    // Per-edge inset unit. `px` is the default; `percent` flows through to
+    // YGNodeStyleSetPositionPercent in yoga_layout.cpp. Other DimensionUnit
+    // values (vw/vh/etc.) round down to px at the bridge boundary today.
     DimensionUnit top_unit_ = DimensionUnit::px;
     DimensionUnit right_unit_ = DimensionUnit::px;
     DimensionUnit bottom_unit_ = DimensionUnit::px;
     DimensionUnit left_unit_ = DimensionUnit::px;
     int z_index_ = 0;
-    // pulp #972 — default is `visible` to match CSS. Pulp previously
+    // Default is `visible` to match CSS. Pulp previously
     // defaulted to `hidden`, which clipped absolutely-positioned children
     // (popovers, dropdowns, tooltips) to the parent's content bounds and
     // made them invisible whenever they extended outside. Plugins that
@@ -1585,8 +1518,8 @@ private:
     float rotation_deg_ = 0;
     float skew_x_ = 0, skew_y_ = 0;
     float origin_x_ = 0.5f, origin_y_ = 0.5f;  // transform-origin (normalized)
-    bool origin_explicit_ = false;  // pulp #1026 — has set_transform_origin been called?
-    // Full 2D affine matrix (issue-930). Identity by default; only applied
+    bool origin_explicit_ = false;  // has set_transform_origin been called?
+    // Full 2D affine matrix. Identity by default; only applied
     // when has_transform_matrix_ is true. Stored in CanvasRenderingContext2D
     // (a,b,c,d,e,f) order:  [a c e / b d f / 0 0 1].
     float transform_matrix_a_ = 1.0f, transform_matrix_b_ = 0.0f,
@@ -1596,42 +1529,41 @@ private:
     float filter_blur_ = 0;
     std::vector<FilterOp> filter_chain_{};
     float backdrop_blur_ = 0;
-    // pulp #1515 — CSS clip-path / mask storage. Paint-time consumption
-    // for clip_path_ via Canvas::clip_path_svg (SkPath::FromSVGString
-    // on Skia, no-op fallback elsewhere). mask_image_ / mask_ are
-    // storage-only today; the saveLayer + SkBlendMode::kDstIn shader
-    // composite is a follow-up paint slice.
+    // CSS clip-path / mask storage. Paint-time consumption for clip_path_ via
+    // Canvas::clip_path_svg (SkPath::FromSVGString on Skia, no-op fallback
+    // elsewhere). mask_image_ / mask_ are consumed by mask-capable backends and
+    // round-trip through storage elsewhere.
     std::string clip_path_;
     std::string mask_image_;
     std::string mask_;
-    std::string mask_size_;     // pulp #1515 followup
+    std::string mask_size_;     // CSS mask-size paired with mask_image_
     std::string appearance_;    // CSS appearance — storage-only no-op for Pulp custom widgets
-    std::string object_fit_;    // CSS object-fit — storage; ImageView paint follow-up
+    std::string object_fit_;    // CSS object-fit — storage-only today
     std::string object_position_; // CSS object-position — storage; pairs with object-fit
-    /// pulp #1434 Phase A2-1 — transition specs + active animations.
+    /// Transition specs + active animations.
     std::vector<TransitionSpec> transitions_{};
     std::vector<CssAnimation> active_animations_{};
     StagedAnimation staged_animation_{};
-    std::string background_attachment_;  // pulp #1517 — noop today
-    std::string background_clip_;        // pulp #1517 — partial (text deferred)
-    std::string background_origin_;      // pulp #1517 — noop today
-    std::string background_position_;    // Wave 5 css.5 — storage-only (raster bg deferred)
-    std::string background_size_;        // Wave 5 css.5 — storage-only (raster bg deferred)
+    std::string background_attachment_;  // noop today
+    std::string background_clip_;        // partial (text deferred)
+    std::string background_origin_;      // noop today
+    std::string background_position_;    // storage-only (raster bg deferred)
+    std::string background_size_;        // storage-only (raster bg deferred)
 
-    // pulp #1434 A4 Bundles 5–7 closure — storage-only catalog slots.
+    // Storage-only catalog slots.
     float       text_indent_ = 0.0f;       // partial (paint deferred)
     std::string word_break_;               // partial (HarfBuzz feature deferred)
-    std::string scroll_behavior_;          // pulp #1737 RN-OOS-fixup — ScrollView consumes
-    std::string overscroll_behavior_;      // pulp #1737 RN-OOS-fixup — ScrollView clamp consumes
-    bool        include_font_padding_ = true;  // pulp #1737 — Android legacy round-trip slot (paint ignores)
+    std::string scroll_behavior_;          // ScrollView consumes
+    std::string overscroll_behavior_;      // ScrollView clamp consumes
+    bool        include_font_padding_ = true;  // Android legacy round-trip slot (paint ignores)
     std::string font_variant_;             // partial (HarfBuzz feature deferred)
     std::string writing_mode_;             // noop (Pulp horizontal-only)
     std::string isolation_;                // wontfix (no z-buffer)
     std::string resize_;                   // noop (no resize handles)
     std::string animation_play_state_;     // partial (storage only)
     bool wants_continuous_repaint_ = false; // opt-in per-vsync repaint
-    // pulp #1548 — RN textShadow* per-attribute storage slots. SkPaint
-    // shadow integration deferred; storage path is round-trippable.
+    // RN textShadow* per-attribute storage slots. SkPaint shadow integration
+    // deferred; storage path is round-trippable.
     std::string text_shadow_color_;
     float       text_shadow_dx_ = 0.0f;
     float       text_shadow_dy_ = 0.0f;
@@ -1646,14 +1578,14 @@ private:
     float bg_grad_angle_ = 0.0f;      // conic: start angle in radians
     std::vector<Color> bg_gradient_colors_;
     std::vector<float> bg_gradient_positions_;
-    std::string background_repeat_;  ///< pulp #1552: CSS background-repeat keyword (storage-only)
+    std::string background_repeat_;  ///< CSS background-repeat keyword (storage-only)
     bool text_ellipsis_ = false;
-    bool white_space_nowrap_ = false;  // pulp #1410
-    WhiteSpaceMode white_space_mode_ = WhiteSpaceMode::normal;  // pulp #1737
+    bool white_space_nowrap_ = false;
+    WhiteSpaceMode white_space_mode_ = WhiteSpaceMode::normal;
     CursorStyle cursor_ = CursorStyle::default_;
-    UserSelect user_select_ = UserSelect::auto_;  // pulp #1538 / #1656 follow-up
-    WritingDirection direction_ = WritingDirection::auto_;  // pulp #1434 A2-3
-    // pulp #1549 — CSS / RN mix-blend-mode. Default kSrcOver (canvas
+    UserSelect user_select_ = UserSelect::auto_;
+    WritingDirection direction_ = WritingDirection::auto_;
+    // CSS / RN mix-blend-mode. Default kSrcOver (canvas
     // BlendMode::normal) is a paint-time no-op; any non-default value
     // forces a saveLayer() at paint time so the subtree composites back
     // through the requested blend mode.
@@ -1662,7 +1594,7 @@ private:
     // Pointer capture: pointer_id → this view receives all events for that pointer
     std::vector<int> captured_pointers_;
 
-    // CSS-style typography inheritance (issue-969). Unset by default; only
+    // CSS-style typography inheritance. Unset by default; only
     // populated when the bridge / app calls a set_inheritable_* setter.
     // These do not affect the View's own paint — only descendant Labels
     // (and other text widgets) consult them.
@@ -1671,7 +1603,7 @@ private:
     std::optional<float> inh_letter_spacing_;
     std::optional<int>   inh_font_weight_;
     std::optional<int>   inh_text_align_;
-    std::optional<std::string> inh_font_family_;  // pulp #1434 Phase A2-5
+    std::optional<std::string> inh_font_family_;
 };
 
 } // namespace pulp::view

--- a/tools/scripts/hotspot_size_guard.json
+++ b/tools/scripts/hotspot_size_guard.json
@@ -117,7 +117,7 @@
     },
     {
       "path": "core/view/include/pulp/view/view.hpp",
-      "max_loc": 1677,
+      "max_loc": 1609,
       "note": "public view header trim candidate (+7 for View::start_file_drag outbound-drag public API + FileDragRequest fwd-decl; +7 from design-system branch additions)"
     },
     {


### PR DESCRIPTION
## Summary
- Cleans stale issue/PR/phase/wave/Codex/internal-ticket archaeology from core/view/include/pulp/view/view.hpp.
- Preserves current API behavior rationale for typography inheritance, pointer events, GPU host selection, accessibility slots, overlays/focus, inspector hooks, border/list/outline semantics, transforms, filters, animations, masks, backgrounds, writing direction, white-space, cursor, user-select, and storage-only slots.
- Lowers the hotspot-size ceiling for view.hpp from 1677 to 1609 after the comment cleanup shrink.

## Validation
- git diff --check
- python3 tools/scripts/docs_noise_lint.py core/view/include/pulp/view/view.hpp
- strict archaeology grep over core/view/include/pulp/view/view.hpp
- normalized comment-stripped code comparison against HEAD
- RepoPrompt planning pass and adversarial file review; fixed set_box_shadow_opacity comment
- tools/scripts/gates.sh origin/main
- Claude adversarial review; fixed two cosmetic wrap findings
- PULP_SKIP_DIFF_COVER=1 PULP_VIA_SHIPYARD=1 git push origin feature/view-header-comment-hygiene (pre-push hooks, 29 tests)

## Notes
- Tried shipyard pr --base main --json --no-apply-bumps --skip-target ubuntu --skip-target windows after sourcing cli_version_check.sh; it passed preflight but hung at `Handing off to shipyard ship`, so this PR was created with gh as a manual fallback. Shipyard tracking may not include it until reconciled.

Version-Bump: sdk=skip reason="comment-only source documentation cleanup"
Skill-Update: skip skill=ci reason="hotspot ceiling reduction for comment-only source documentation cleanup"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Condensed and cleaned comments in `core/view/include/pulp/view/view.hpp` to remove stale archaeology. No code or behavior changes.

- **Refactors**
  - Preserved concise rationale for existing APIs (typography inheritance, pointer events, GPU host, accessibility, overlays/focus, inspector hooks, borders/outline/list, transforms/filters/animations, masks/backgrounds, writing direction/white-space, cursor/user-select).
  - Lowered `view.hpp` hotspot cap to 1609 in `tools/scripts/hotspot_size_guard.json`.

<sup>Written for commit 7322140ceffe1a68c9b99fca0b864d60a83a28c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

