### PR TITLE
docs: clean wavetable comment archaeology

### DIFF
--- a/core/signal/include/pulp/signal/wavetable.hpp
+++ b/core/signal/include/pulp/signal/wavetable.hpp
@@ -13,11 +13,11 @@
 /// "wavetable evolution" patches where a 0..1 position knob sweeps
 /// between several base waveforms.
 ///
-/// Built-in factories (`make_sine`, `make_saw`, `make_square`,
-/// `make_triangle`) generate fully bandlimited stacks across the
-/// audible range using direct harmonic synthesis: each band caps
-/// harmonics at `sample_rate / 2 / max_freq` so alias energy stays
-/// below the band's playback ceiling.
+/// Built-in factories (`make_saw`, `make_square`, `make_triangle`)
+/// generate fully bandlimited stacks across the audible range using
+/// direct harmonic synthesis: each band caps harmonics so the top
+/// harmonic at that band's playback ceiling stays at or below Nyquist
+/// (`sample_rate / 2`). `make_sine` is the degenerate single-band case.
 
 #include <algorithm>
 #include <cmath>
@@ -48,7 +48,7 @@ struct WavetableEntry {
 /// long enough to keep transitions click-free.
 class Wavetable {
 public:
-    /// Length of the band-switch crossfade in samples. ~3 ms at
+    /// Length of the band-switch crossfade in samples. ~2.7 ms at
     /// 48 kHz — well below the cycle of even the lowest audible
     /// frequency, so it does not smear transients.
     static constexpr std::size_t kCrossfadeSamples = 128;
@@ -82,9 +82,9 @@ public:
             // Begin a crossfade. If a previous fade is still in flight,
             // capture its current source + target + remaining samples
             // so the new fade can blend FROM the actually-audible mix
-            // rather than jumping back to the previous target (Codex P1
-            // on #2865 — rapid retunes lost continuity, producing the
-            // click the crossfade was meant to prevent).
+            // rather than jumping back to the previous target. Rapid
+            // retunes must preserve continuity so the crossfade does
+            // not introduce the click it is meant to prevent.
             if (crossfade_samples_remaining_ > 0) {
                 in_flight_source_ = crossfade_source_;
                 in_flight_target_ = target_band_;
@@ -120,8 +120,7 @@ public:
             // Source for the new fade. If a previous fade was still
             // in flight when this one started, sample the in-flight
             // blend at its progress ratio so the new fade begins from
-            // the actually-audible mix instead of the in-flight target
-            // (Codex P1 on #2865).
+            // the actually-audible mix instead of the in-flight target.
             float source_sample;
             if (has_in_flight_ && in_flight_remaining_ > 0) {
                 const float old_t = 1.0f
@@ -196,7 +195,7 @@ private:
     int crossfade_source_ = 0;
     std::size_t crossfade_samples_remaining_ = 0;
     // Captured in-flight fade state so rapid retunes blend FROM the
-    // actually-audible mix (Codex P1 on #2865).
+    // actually-audible mix.
     bool has_in_flight_ = false;
     int in_flight_source_ = 0;
     int in_flight_target_ = 0;
@@ -295,10 +294,9 @@ inline std::vector<WavetableEntry> build_wavetable_band_stack(
         float reference_sample_rate,
         HarmonicAmp&& harmonic_amp) {
     if (num_bands == 0) return {};
-    // Codex P2 on #2865 — non-positive sample rates produce
-    // clamped_ceiling <= 0 and then a NaN/-inf in the std::floor →
-    // size_t cast (UB). Public factories accept arbitrary inputs, so
-    // short-circuit on invalid sample rates here.
+    // Non-positive sample rates produce clamped_ceiling <= 0 and then
+    // a NaN/-inf in the std::floor -> size_t cast (UB). Public factories
+    // accept arbitrary inputs, so short-circuit on invalid sample rates here.
     if (!(reference_sample_rate > 0.0f)) return {};
     const float nyquist = reference_sample_rate * 0.5f;
     constexpr float kBaseFreq = 20.0f;
@@ -325,9 +323,8 @@ inline std::vector<WavetableEntry> build_wavetable_band_stack(
 
 inline Wavetable Wavetable::make_sine(std::size_t table_length,
                                        float reference_sample_rate) {
-    // Codex P2 on #2865 — guard against non-positive sample rates so
-    // the returned Wavetable has a well-defined (empty) band stack
-    // rather than a band with a negative ceiling.
+    // Guard against non-positive sample rates so the returned Wavetable has a
+    // well-defined empty band stack rather than a band with a negative ceiling.
     if (!(reference_sample_rate > 0.0f)) return Wavetable();
     std::vector<WavetableEntry> bands;
     bands.push_back(WavetableEntry{


### PR DESCRIPTION
## Summary
- Removes stale Codex/issue references from wavetable crossfade and sample-rate guard comments.
- Tightens the bandlimiting header comment so it states the actual Nyquist invariant and notes `make_sine` as the single-band case.
- Updates the crossfade duration note from ~3 ms to ~2.7 ms at 48 kHz.

## Validation
- RepoPrompt search/context pass over core/signal/include/pulp/signal/wavetable.hpp
- git diff --check
- python3 tools/scripts/docs_noise_lint.py core/signal/include/pulp/signal/wavetable.hpp
- strict archaeology grep over core/signal/include/pulp/signal/wavetable.hpp
- normalized comment-stripped code comparison against HEAD
- RepoPrompt adversarial review twice; first findings patched, second Clean
- Claude adversarial review: Clean
- tools/scripts/gates.sh origin/main
- PULP_SKIP_DIFF_COVER=1 PULP_VIA_SHIPYARD=1 git push origin feature/wavetable-comment-hygiene (pre-push hooks, 29 tests)

## Notes
- Tried `shipyard pr --base main --json --no-apply-bumps --skip-target ubuntu --skip-target windows`; it hung at `Handing off to shipyard ship`, so this PR was created with gh as manual fallback. Shipyard tracking may not include it until reconciled.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up `wavetable.hpp` comments by removing stale issue references and tightening technical notes; behavior is unchanged. Clarifies the Nyquist invariant for band stacks (notes `make_sine` as the single-band case), updates the crossfade note to ~2.7 ms at 48 kHz, and simplifies sample-rate guard comments.

<sup>Written for commit 208f50734156f80f0595f0c274405d2626bc7601. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

