### PR TITLE
docs: clean coregraphics canvas comment archaeology

### DIFF
--- a/core/canvas/include/pulp/canvas/cg_canvas.hpp
+++ b/core/canvas/include/pulp/canvas/cg_canvas.hpp
@@ -43,20 +43,17 @@ public:
     void set_line_cap(LineCap cap) override;
     void set_line_join(LineJoin join) override;
 
-    // pulp #1898 — Canvas2D ctx.setLineDash() / lineDashOffset on the CG
-    // backend. The base Canvas default is a no-op `(void)`, which silently
-    // dropped every dashed-stroke draw on the macOS CPU paint path — most
-    // visibly Spectr's 0 dB rail rendered solid instead of dashed, plus
-    // ~5 other callsites (TextEditor caret guides, ResizeHandle dashed
-    // hint, etc.). Mirrors SkiaCanvas::set_line_dash; the actual CG state
-    // mutation happens via CGContextSetLineDash inside apply_line_dash_to_ctx()
-    // immediately before each stroke draw, then is reset to solid afterwards
-    // so the dash pattern doesn't leak into untracked CG callers.
+    // Canvas2D ctx.setLineDash() / lineDashOffset on the CG backend. The base
+    // Canvas default is a no-op, so without this override dashed strokes draw
+    // solid on the macOS CPU paint path. Mirrors SkiaCanvas::set_line_dash; the
+    // actual CG state mutation happens via CGContextSetLineDash inside
+    // apply_line_dash_to_ctx() immediately before each stroke draw, then is
+    // reset to solid afterwards so the dash pattern doesn't leak into
+    // untracked CG callers.
     void set_line_dash(const float* intervals, int count, float phase) override;
 
-    // pulp #1434 bridge-thin gap-fill — Canvas2D ctx.miterLimit and
-    // imageSmoothingEnabled / Quality. Stored on the canvas; CGContext's
-    // CGContextSetMiterLimit / CGContextSetInterpolationQuality apply
+    // Canvas2D ctx.miterLimit and imageSmoothingEnabled / Quality. Stored on the
+    // canvas; CGContextSetMiterLimit / CGContextSetInterpolationQuality apply
     // immediately (no per-draw re-push needed since they hang off the
     // current GState).
     void set_miter_limit(float limit) override;
@@ -69,9 +66,9 @@ public:
     void set_fill_gradient_radial(float cx, float cy, float radius,
                                    const Color* colors, const float* positions,
                                    int count) override;
-    /// pulp #1524 — true two-circle radial gradient via
+    /// True two-circle radial gradient via
     /// CGContextDrawRadialGradient(inner_center, inner_r, outer_center, outer_r).
-    /// The single-circle override silently dropped (x0,y0,r0); this honours both.
+    /// Unlike the single-circle override, this honours both endpoint circles.
     void set_fill_gradient_radial_two_circles(
         float x0, float y0, float r0,
         float x1, float y1, float r1,
@@ -81,12 +78,11 @@ public:
                                   int count) override;
     void clear_fill_gradient() override;
 
-    // pulp #1666 — stroke-side gradient overrides. Parallel to fill-side
-    // GradientKind state so stroke calls can route through
-    // stroke_with_active_paint() when a gradient is active. Without these
-    // overrides the base no-op meant stroke draws collapsed to first-stop
-    // color even when the JS shim set createLinearGradient() as
-    // strokeStyle.
+    // Stroke-side gradient overrides. Parallel to fill-side GradientKind state
+    // so stroke calls can route through stroke_with_active_paint() when a
+    // gradient is active. Without these overrides the base no-op makes stroke
+    // draws collapse to first-stop color even when the JS shim sets
+    // createLinearGradient() as strokeStyle.
     void set_stroke_gradient_linear(float x0, float y0, float x1, float y1,
                                      const Color* colors, const float* positions,
                                      int count) override;
@@ -102,13 +98,11 @@ public:
                                     int count) override;
     void clear_stroke_gradient() override;
 
-    // pulp #1434 bridge-thin gap-fill — Canvas2D ctx.createPattern. CG
-    // has no first-class pattern shader (CGPattern requires a custom
-    // CGPatternRef + tiling closure dance), so degrade silently to the
-    // active fill / stroke colour. Same shape as the conic-gradient
-    // fallback: the call records the intent, but visually the canvas
-    // continues with the previous solid paint. File a follow-up if a
-    // CG-targeted plugin actually needs tiled image patterns.
+    // Canvas2D ctx.createPattern. CG has no first-class pattern shader
+    // (CGPattern requires a custom CGPatternRef + tiling closure dance), so
+    // degrade silently to the active fill / stroke colour. Same shape as the
+    // conic-gradient fallback: the call records the intent, but visually the
+    // canvas continues with the previous solid paint.
     void set_fill_pattern(const std::string& image_src,
                           PatternTileMode tile_x,
                           PatternTileMode tile_y) override;
@@ -129,7 +123,7 @@ public:
     void stroke_path(const Point2D* points, size_t count) override;
     void fill_path(const Point2D* points, size_t count) override;
 
-    // Canvas2D-style path building (pulp #1322).
+    // Canvas2D-style path building.
     void begin_path() override;
     void move_to(float x, float y) override;
     void line_to(float x, float y) override;
@@ -140,7 +134,7 @@ public:
     void fill_current_path(FillRule rule = FillRule::nonzero) override;
     void stroke_current_path() override;
 
-    // pulp #1521 — native arc subpaths via CGPath APIs.
+    // Native arc subpaths via CGPath APIs.
     void arc(float cx, float cy, float radius,
              float start_angle, float end_angle,
              bool anticlockwise) override;
@@ -160,20 +154,19 @@ public:
     void save_layer(float x, float y, float w, float h,
                     float opacity, float blur_radius) override;
 
-    // pulp #1371 — Canvas2D globalCompositeOperation parity. Without this
-    // override the base Canvas no-op default silently dropped every blend
-    // request on the CPU paint path, so JS bundles using
-    // ctx.globalCompositeOperation = 'lighter'/'multiply'/etc. drew with the
-    // default SrcOver — Spectr's filterbank rainbow gradient is the canonical
-    // repro. CG's GState stack matches Canvas2D save()/restore() blend-mode
-    // semantics, so we just push the chosen CGBlendMode into the current GState
-    // and let CG carry it across draws + save/restore frames.
+    // Canvas2D globalCompositeOperation parity. Without this override the base
+    // Canvas no-op default drops blend requests on the CPU paint path, so JS
+    // bundles using ctx.globalCompositeOperation = 'lighter'/'multiply'/etc.
+    // draw with the default SrcOver. CG's GState stack matches Canvas2D
+    // save()/restore() blend-mode semantics, so we push the chosen CGBlendMode
+    // into the current GState and let CG carry it across draws + save/restore
+    // frames.
     void set_blend_mode(BlendMode mode) override;
 
     void set_font(const std::string& family, float size) override;
     void set_text_align(TextAlign align) override;
     void fill_text(const std::string& text, float x, float y) override;
-    // pulp #1525 — Canvas2D fillText(text,x,y,maxWidth) + strokeText(text,x,y,maxWidth).
+    // Canvas2D fillText(text,x,y,maxWidth) + strokeText(text,x,y,maxWidth).
     void fill_text_with_max_width(const std::string& text,
                                   float x, float y, float max_width) override;
     void stroke_text(const std::string& text, float x, float y,
@@ -183,11 +176,11 @@ public:
     float text_x_for_byte(const std::string& text,
                           std::size_t byte_index) override;
 
-    // Canvas2D drop-shadow state (issue-1434 batch 7). CGContext exposes
-    // sticky shadow state directly via CGContextSetShadowWithColor — we
-    // mirror Canvas2D's sticky `ctx.shadow*` semantics by translating
-    // each setter into a CG state mutation that hangs off the current
-    // GState (so save/restore correctly snapshots and pops the shadow).
+    // Canvas2D drop-shadow state. CGContext exposes sticky shadow state
+    // directly via CGContextSetShadowWithColor; we mirror Canvas2D's sticky
+    // `ctx.shadow*` semantics by translating each setter into a CG state
+    // mutation that hangs off the current GState (so save/restore correctly
+    // snapshots and pops the shadow).
     void set_shadow_color(Color color) override;
     void set_shadow_blur(float blur) override;
     void set_shadow_offset_x(float dx) override;
@@ -203,8 +196,8 @@ private:
     float font_size_ = 14.0f;
     TextAlign text_align_ = TextAlign::left;
 
-    // Canvas2D path-building state (pulp #1322). Owned, retained CG mutable
-    // path; null until the first begin_path() call.
+    // Canvas2D path-building state. Owned, retained CG mutable path; null until
+    // the first begin_path() call.
     CGMutablePathRef path_ = nullptr;
 
     // Linear/radial gradient state used as the fill paint when
@@ -212,24 +205,23 @@ private:
     // fill and shader-based fill so JS-driven gradient fills paint instead
     // of falling back to a single color.
     //
-    // pulp #1524 — gradient_kind_ identifies which Draw* call to issue from
+    // gradient_kind_ identifies which Draw* call to issue from
     // fill_with_active_paint(). `radial_two_circles` is the spec-correct
     // two-circle form (inner + outer centres, inner_r in grad_radius_inner_,
-    // outer_r in grad_radius_); `conic_image` is a software-rasterised
-    // CGImage that we paint via CGContextDrawImage inside the active clip.
+    // outer_r in grad_radius_); `conic_image` is a software-rasterised CGImage
+    // that we paint via CGContextDrawImage inside the active clip.
     enum class GradientKind { none, linear, radial, radial_two_circles, conic_image };
     bool has_gradient_ = false;
     GradientKind gradient_kind_ = GradientKind::none;
     bool gradient_is_radial_ = false;  // legacy mirror of (kind == radial), kept for older inline checks
     float grad_x0_ = 0, grad_y0_ = 0, grad_x1_ = 0, grad_y1_ = 0;
     float grad_radius_ = 0;        // outer / single radius
-    float grad_radius_inner_ = 0;  // pulp #1524 — inner radius for two-circle radial
+    float grad_radius_inner_ = 0;  // inner radius for two-circle radial
     std::vector<Color> grad_colors_;
     std::vector<float> grad_positions_;
 
-    // pulp #1666 — parallel stroke-side state. Same shape as the fill
-    // gradient slots; checked by stroke_with_active_paint() at every
-    // stroke site that previously called apply_stroke_color directly.
+    // Parallel stroke-side state. Same shape as the fill gradient slots;
+    // checked by stroke_with_active_paint() at each gradient-aware stroke site.
     bool has_stroke_gradient_ = false;
     GradientKind stroke_gradient_kind_ = GradientKind::none;
     float stroke_grad_x0_ = 0, stroke_grad_y0_ = 0, stroke_grad_x1_ = 0, stroke_grad_y1_ = 0;
@@ -238,22 +230,22 @@ private:
     std::vector<Color> stroke_grad_colors_;
     std::vector<float> stroke_grad_positions_;
 
-    // pulp #1524 — software-rasterised conic gradient. CG has no native
-    // conic shader, so set_fill_gradient_conic walks every pixel of a
-    // bounding-box bitmap, computes the angle from the centre, interpolates
-    // the colour stops, and stores the resulting CGImage here. fill_with_active_paint
-    // paints it via CGContextDrawImage inside the active clip. The image is
-    // released in clear_fill_gradient / dtor / on next gradient set.
+    // Software-rasterised conic gradient. CG has no native conic shader, so
+    // set_fill_gradient_conic walks every pixel of a bounding-box bitmap,
+    // computes the angle from the centre, interpolates the colour stops, and
+    // stores the resulting CGImage here. fill_with_active_paint paints it via
+    // CGContextDrawImage inside the active clip. The image is released in
+    // clear_fill_gradient / dtor / on next gradient set.
     CGImageRef conic_image_ = nullptr;
     float conic_image_x_ = 0, conic_image_y_ = 0;
     float conic_image_w_ = 0, conic_image_h_ = 0;
     void release_conic_image();
 
-    // pulp #1524 — tiled-pattern fill state. CG exposes patterns via
-    // CGPatternCreate + a draw callback; we hold the decoded image (so
-    // the callback can render a tile) and the tile dimensions / repetition
-    // mode here. has_pattern_ short-circuits fill_with_active_paint onto
-    // CGContextSetFillPattern + CGContextFillRect/CGContextFillPath.
+    // Tiled-pattern fill state. CG exposes patterns via CGPatternCreate + a
+    // draw callback; we hold the decoded image (so the callback can render a
+    // tile) and the tile dimensions / repetition mode here. has_pattern_
+    // short-circuits fill_with_active_paint onto CGContextSetFillPattern +
+    // CGContextFillRect/CGContextFillPath.
     bool has_pattern_ = false;
     CGImageRef pattern_image_ = nullptr;
     PatternTileMode pattern_tile_x_ = PatternTileMode::repeat;
@@ -269,31 +261,30 @@ private:
     //   [a, b, c, d, tx, ty] (CGAffineTransform memory layout).
     double baseline_xform_[6] = {1, 0, 0, 1, 0, 0};
 
-    // pulp #1368 — manual GState depth tracking. CG doesn't expose a
-    // saveCount() API, so save() increments and restore() decrements
-    // this counter; restore_to_count() pops repeatedly until depth
-    // matches the requested target. CanvasWidget::paint() snapshots the
-    // depth at entry and pops back to it at exit so an unbalanced JS
-    // ctx.save() can't leak GState into the parent View's paint scope.
+    // Manual GState depth tracking. CG doesn't expose a saveCount() API, so
+    // save() increments and restore() decrements this counter;
+    // restore_to_count() pops repeatedly until depth matches the requested
+    // target. CanvasWidget::paint() snapshots the depth at entry and pops back
+    // to it at exit so an unbalanced JS ctx.save() can't leak GState into the
+    // parent View's paint scope.
     int save_depth_ = 0;
 
-    // Canvas2D shadow* state (issue-1434 batch 7). CGContext owns the
-    // sticky shadow via its GState stack, so save()/restore() naturally
-    // snapshots both ours and CG's. We hold the values here so a
-    // setter mutation re-pushes the combined state through
-    // CGContextSetShadowWithColor.
+    // Canvas2D shadow* state. CGContext owns the sticky shadow via its GState
+    // stack, so save()/restore() naturally snapshots both ours and CG's. We
+    // hold the values here so a setter mutation re-pushes the combined state
+    // through CGContextSetShadowWithColor.
     Color shadow_color_ = Color::rgba(0.0f, 0.0f, 0.0f, 0.0f);
     float shadow_blur_     = 0.0f;
     float shadow_offset_x_ = 0.0f;
     float shadow_offset_y_ = 0.0f;
     void apply_shadow_to_context();
 
-    // pulp #1898 — line-dash state. CG's CGContextSetLineDash mutates the
-    // current GState so we cannot just push it once at setter time and
-    // forget; the JS bridge may toggle dash on/off between strokes within
-    // a single GState frame. We instead store the intervals + phase here
-    // and apply via apply_line_dash_to_ctx() immediately before every
-    // stroke call, then reset to solid afterwards.
+    // Line-dash state. CG's CGContextSetLineDash mutates the current GState so
+    // we cannot just push it once at setter time and forget; the JS bridge may
+    // toggle dash on/off between strokes within a single GState frame. We
+    // instead store the intervals + phase here and apply via
+    // apply_line_dash_to_ctx() immediately before every stroke call, then reset
+    // to solid afterwards.
     std::vector<float> line_dash_;
     float line_dash_phase_ = 0.0f;
     void apply_line_dash_to_ctx();

--- a/core/canvas/platform/mac/cg_canvas.mm
+++ b/core/canvas/platform/mac/cg_canvas.mm
@@ -66,7 +66,7 @@ void CoreGraphicsCanvas::restore() {
     if (save_depth_ > 0) --save_depth_;
 }
 
-// pulp #1368 — pop GState frames repeatedly until depth matches `target`.
+// Pop GState frames repeatedly until depth matches `target`.
 // CanvasWidget::paint() captures save_count() at entry and calls this at
 // exit so an unbalanced JS draw script (one that emitted a `ctx.save()`
 // but never reached its `ctx.restore()` due to an early-return path)
@@ -96,8 +96,8 @@ void CoreGraphicsCanvas::rotate(float radians) {
     CGContextRotateCTM(ctx_, radians);
 }
 
-// pulp #943 (#933 P1) — concat the supplied affine onto the current CTM, do
-// NOT replace it. View::paint_all() routes JS-supplied setTransform(id, ...)
+// Concat the supplied affine onto the current CTM, do NOT replace it.
+// View::paint_all() routes JS-supplied setTransform(id, ...)
 // through Canvas::concat_transform so the View's transform composes with the
 // parent View's transform (the bounds translate, outer transforms, etc.)
 // rather than wiping it. Mirrors SkCanvas::concat / SkiaCanvas::concat_transform.
@@ -116,8 +116,8 @@ void CoreGraphicsCanvas::concat_transform(float a, float b, float c,
     CGContextConcatCTM(ctx_, CGAffineTransformMake(a, b, c, d, e, f));
 }
 
-// pulp #1322 — JS-driven setTransform must compose onto the paint baseline
-// captured at CanvasWidget::paint() entry, mirroring SkiaCanvas's behavior.
+// JS-driven setTransform composes onto the paint baseline captured at
+// CanvasWidget::paint() entry, mirroring SkiaCanvas's behavior.
 // Without this override, the base-class no-op silently drops every JS
 // setTransform call on the CPU paint path (which is what standalone uses
 // when use_gpu=false), so any subsequent fill/stroke draws at the wrong
@@ -163,7 +163,7 @@ void CoreGraphicsCanvas::capture_paint_baseline_transform() {
     has_baseline_ = true;
 }
 
-// pulp #1368 round 2 — diagnostic CTM snapshot for `PULP_LOG_CANVAS_PAINT=1`.
+// Diagnostic CTM snapshot for `PULP_LOG_CANVAS_PAINT=1`.
 // Returns the current device matrix in CanvasRenderingContext2D affine order
 // (a, b, c, d, e, f) so the env-gated CanvasWidget::paint logging can record
 // what transform the inbound canvas has when paint() runs. CGAffineTransform
@@ -185,18 +185,17 @@ void CoreGraphicsCanvas::clip_rect(float x, float y, float w, float h) {
     CGContextClipToRect(ctx_, CGRectMake(x, y, w, h));
 }
 
-// pulp #1322 — clip() intersects the current clip region with the path
-// being built via begin_path/move_to/line_to/etc. Mirrors
+// clip() intersects the current clip region with the path being built via
+// begin_path/move_to/line_to/etc. Mirrors
 // CanvasRenderingContext2D.clip() and SkiaCanvas::clip(). Without the
 // override, the base-class no-op silently leaves the clip region wide open
 // so subsequent draws spill over their intended bounds.
 void CoreGraphicsCanvas::clip(FillRule rule) {
     if (!path_) return;
     CGContextAddPath(ctx_, path_);
-    // pulp Wave 2 cheap wiring — honour the JS-supplied fillRule arg
-    // (`ctx.clip('evenodd')`). CG distinguishes between CGContextClip
-    // (nonzero winding) and CGContextEOClip (even-odd) at the API
-    // surface; pre-Wave-2 the bridge always called CGContextClip.
+    // Honour the JS-supplied fillRule arg (`ctx.clip('evenodd')`). CG
+    // distinguishes between CGContextClip (nonzero winding) and
+    // CGContextEOClip (even-odd) at the API surface.
     if (rule == FillRule::evenodd) {
         CGContextEOClip(ctx_);
     } else {
@@ -243,13 +242,13 @@ void CoreGraphicsCanvas::set_line_join(LineJoin join) {
     CGContextSetLineJoin(ctx_, cg_join);
 }
 
-// pulp #1898 — Canvas2D ctx.setLineDash() / lineDashOffset on the CG backend.
+// Canvas2D ctx.setLineDash() / lineDashOffset on the CG backend.
 //
-// Background. The base Canvas virtual is a no-op `(void)`, so before this
-// override every dashed stroke on the macOS CPU paint path drew solid.
+// The base Canvas virtual is a no-op, so without this override dashed strokes
+// draw solid on the CG CPU path.
 // SkiaCanvas applies the pattern via SkDashPathEffect on the per-call
-// SkPaint (skia_canvas.cpp:1132-1209); CG has no per-paint dash state,
-// only the GState-resident pair set by CGContextSetLineDash. We therefore
+// SkPaint; CG has no per-paint dash state, only the GState-resident pair
+// set by CGContextSetLineDash. We therefore
 // store the intervals + phase on the canvas (mirroring Skia's fields) and
 // push/clear the CG dash phase around each stroke draw via
 // apply_line_dash_to_ctx() / reset_line_dash_on_ctx().
@@ -292,8 +291,8 @@ void CoreGraphicsCanvas::reset_line_dash_on_ctx() {
     CGContextSetLineDash(ctx_, 0.0, nullptr, 0);
 }
 
-// pulp #1371 — map every BlendMode value to its CGBlendMode counterpart and
-// push it into the current GState. The base Canvas default for set_blend_mode
+// Map every BlendMode value to its CGBlendMode counterpart and push it into
+// the current GState. The base Canvas default for set_blend_mode
 // is a no-op `(void)mode;`, so without this override every CG-backed CPU paint
 // silently lost the requested compositing op. SkiaCanvas::set_blend_mode in
 // core/canvas/src/skia_canvas.cpp is the working reference implementation —
@@ -325,7 +324,7 @@ static CGBlendMode to_cg_blend_mode(pulp::canvas::Canvas::BlendMode mode) {
         case BM::saturation:    return kCGBlendModeSaturation;
         case BM::color:         return kCGBlendModeColor;
         case BM::luminosity:    return kCGBlendModeLuminosity;
-        // Indices 16..26 — Porter-Duff compositing modes (issue-896).
+        // Indices 16..26 — Porter-Duff compositing modes.
         case BM::source_over:        return kCGBlendModeNormal;
         case BM::destination_over:   return kCGBlendModeDestinationOver;
         case BM::source_in:          return kCGBlendModeSourceIn;
@@ -358,8 +357,8 @@ void CoreGraphicsCanvas::fill_rect(float x, float y, float w, float h) {
     CGContextFillRect(ctx_, CGRectMake(x, y, w, h));
 }
 
-// pulp #929 — clearRect must replace destination pixels with transparent
-// black, not SrcOver-blend a transparent fill (which CoreGraphics would
+// clearRect must replace destination pixels with transparent black, not
+// SrcOver-blend a transparent fill (which CoreGraphics would
 // treat as a no-op the same way Skia does). CGContextClearRect zeroes
 // the alpha channel of the destination region directly, mirroring the
 // CanvasRenderingContext2D.clearRect spec for the CoreGraphics-backed
@@ -398,10 +397,8 @@ void CoreGraphicsCanvas::add_rounded_rect_path(float x, float y, float w, float 
 
 void CoreGraphicsCanvas::fill_rounded_rect(float x, float y, float w, float h, float radius) {
     add_rounded_rect_path(x, y, w, h, radius);
-    // pulp #1359 — gate on has_gradient_ so the active gradient paints the
-    // rounded rect, mirroring fill_rect / fill_current_path. Without this,
-    // a gradient set via set_fill_gradient_linear/_radial silently dropped
-    // back to apply_fill_color() (Spectr's CPU-mode FilterBank backplate).
+    // Gate on has_gradient_ so the active gradient paints the rounded rect,
+    // mirroring fill_rect / fill_current_path.
     if (has_gradient_) {
         CGContextSaveGState(ctx_);
         CGContextClip(ctx_);  // clip to the path we just built
@@ -427,9 +424,9 @@ void CoreGraphicsCanvas::stroke_rounded_rect(float x, float y, float w, float h,
 
 void CoreGraphicsCanvas::fill_circle(float cx, float cy, float radius) {
     const CGRect bounds = CGRectMake(cx - radius, cy - radius, radius * 2, radius * 2);
-    // pulp #1359 — when a gradient is active, build an ellipse path and clip
-    // to it so fill_with_active_paint() paints the gradient inside the circle.
-    // Mirrors fill_rect / fill_rounded_rect / fill_current_path.
+    // When a gradient is active, build an ellipse path and clip to it so
+    // fill_with_active_paint() paints the gradient inside the circle. Mirrors
+    // fill_rect / fill_rounded_rect / fill_current_path.
     if (has_gradient_) {
         CGContextSaveGState(ctx_);
         CGContextBeginPath(ctx_);
@@ -511,9 +508,8 @@ void CoreGraphicsCanvas::fill_path(const Point2D* points, size_t count) {
     for (size_t i = 1; i < count; ++i)
         CGContextAddLineToPoint(ctx_, points[i].x, points[i].y);
     CGContextClosePath(ctx_);
-    // pulp #1359 — honor active gradient on closed point-array fills, the
-    // direct CG parallel of SkiaCanvas::fill_path (#1353). Without this,
-    // shapes drawn via the Point2D* overload silently dropped the gradient.
+    // Honor active gradient on closed point-array fills, the direct CG
+    // parallel of SkiaCanvas::fill_path.
     if (has_gradient_) {
         CGContextSaveGState(ctx_);
         CGContextClip(ctx_);  // clip to the path we just built
@@ -607,11 +603,10 @@ void CoreGraphicsCanvas::fill_text(const std::string& text, float x, float y) {
         // Need to flip text back to render correctly.
         CGContextSaveGState(ctx_);
         if (has_gradient_) {
-            // pulp #1643/#1666 followup — gradient text on CG. Use the
-            // glyph silhouette as a clip mask, then paint the gradient
-            // through fill_with_active_paint(). Mirrors Skia's
-            // shader-based glyph fill via CGContextSetTextDrawingMode
-            // kCGTextClip + Draw* gradient call.
+            // Gradient text on CG uses the glyph silhouette as a clip mask,
+            // then paints the gradient through fill_with_active_paint().
+            // Mirrors Skia's shader-based glyph fill via
+            // CGContextSetTextDrawingMode kCGTextClip + Draw* gradient call.
             CGContextTranslateCTM(ctx_, draw_x, y);
             CGContextScaleCTM(ctx_, 1.0, -1.0);
             CGContextSetTextPosition(ctx_, 0, 0);
@@ -640,12 +635,11 @@ void CoreGraphicsCanvas::fill_text(const std::string& text, float x, float y) {
 void CoreGraphicsCanvas::fill_text_with_max_width(const std::string& text,
                                                    float x, float y,
                                                    float max_width) {
-    // pulp #1525 — Canvas2D `fillText(text, x, y, maxWidth)`. Same
-    // horizontal-squeeze approach as SkiaCanvas: measure naturally, and
-    // if the advance exceeds `max_width`, scale around the text origin
-    // before delegating to the unconstrained `fill_text` path. CoreText's
-    // glyph clusters are atomic CTRun units, so horizontal scaling
-    // preserves cluster integrity (matches the spec's HarfBuzz contract).
+    // Canvas2D `fillText(text, x, y, maxWidth)`. Same horizontal-squeeze
+    // approach as SkiaCanvas: measure naturally, and if the advance exceeds
+    // `max_width`, scale around the text origin before delegating to the
+    // unconstrained `fill_text` path. CoreText's glyph clusters are atomic
+    // CTRun units, so horizontal scaling preserves cluster integrity.
     if (max_width <= 0.0f || text.empty()) {
         fill_text(text, x, y);
         return;
@@ -666,11 +660,9 @@ void CoreGraphicsCanvas::fill_text_with_max_width(const std::string& text,
 
 void CoreGraphicsCanvas::stroke_text(const std::string& text, float x, float y,
                                       float max_width) {
-    // pulp #1525 — true outlined-glyph rendering via CoreText. We swap
-    // the text drawing mode to `kCGTextStroke` so each glyph outline is
-    // honoured with the active stroke colour + line width, instead of
-    // the pre-#1525 approximation that re-routed through fillText with
-    // strokeStyle as the fill colour.
+    // True outlined-glyph rendering via CoreText. We swap the text drawing
+    // mode to `kCGTextStroke` so each glyph outline is honoured with the
+    // active stroke colour + line width.
     @autoreleasepool {
         if (text.empty()) return;
         NSString* ns_text = ns_string_never_nil(text);
@@ -698,7 +690,7 @@ void CoreGraphicsCanvas::stroke_text(const std::string& text, float x, float y,
 
         CGContextSaveGState(ctx_);
 
-        // pulp #1525 — apply maxWidth squeeze around (x, y).
+        // Apply maxWidth squeeze around (x, y).
         if (max_width > 0.0f && text_width > max_width && text_width > 0) {
             const CGFloat scale = max_width / static_cast<CGFloat>(text_width);
             CGContextTranslateCTM(ctx_, x, y);
@@ -707,23 +699,17 @@ void CoreGraphicsCanvas::stroke_text(const std::string& text, float x, float y,
         }
 
         if (has_stroke_gradient_) {
-            // pulp #1666 — stroke gradient on glyph outlines: build a
-            // CGPath of every glyph in the line, route through
-            // stroke_with_active_paint() (which clips to the stroked
-            // outline + draws the gradient).
+            // Stroke gradient on glyph outlines: build a CGPath of every
+            // glyph in the line, route through stroke_with_active_paint()
+            // (which clips to the stroked outline + draws the gradient).
             //
-            // pulp #1747 (P1 Codex review on #1736) — the per-glyph
-            // CGAffineTransform must bake in BOTH the glyph offset AND
-            // the text-rendering transform (translate(draw_x, y) +
-            // scale(1, -1) to flip from CT's bottom-up glyph space into
-            // canvas-down space). Pre-fix the CTM was modified instead,
-            // which left the gradient endpoints evaluated in text-local
-            // space — same createLinearGradient stops produced different
-            // colors as text x-position changed, and vertical gradients
-            // rendered upside-down. With the transform baked into the
-            // path itself, the CTM stays the canvas-space identity (or
-            // whatever the caller had) and gradient endpoints land where
-            // the caller meant them to land.
+            // The per-glyph CGAffineTransform must bake in both the glyph
+            // offset and the text-rendering transform (translate(draw_x, y)
+            // + scale(1, -1) to flip from CT's bottom-up glyph space into
+            // canvas-down space). With the transform baked into the path
+            // itself, the CTM stays the canvas-space identity (or whatever
+            // the caller had) and gradient endpoints land where the caller
+            // meant them to land.
             CGMutablePathRef glyph_path = CGPathCreateMutable();
             CFArrayRef runs = CTLineGetGlyphRuns(line);
             CFIndex run_count = CFArrayGetCount(runs);
@@ -770,8 +756,8 @@ void CoreGraphicsCanvas::stroke_text(const std::string& text, float x, float y,
                                        stroke_color_.b, stroke_color_.a);
             CGContextSetTextDrawingMode(ctx_, kCGTextStroke);
 
-            // pulp #1898 — apply the active dash pattern around the glyph
-            // outline stroke. CTLineDraw in kCGTextStroke mode strokes each
+            // Apply the active dash pattern around the glyph outline stroke.
+            // CTLineDraw in kCGTextStroke mode strokes each
             // glyph's silhouette using the current GState dash, so this is
             // the correct injection point. The enclosing CGContextSaveGState
             // (above) snapshots the dash for us, but we still call the
@@ -856,17 +842,14 @@ float CoreGraphicsCanvas::text_x_for_byte(const std::string& text,
     return measure_text(text.substr(0, prefix_len));
 }
 
-// ── Canvas2D path builder (pulp #1322) ───────────────────────────────────────
+// ── Canvas2D path builder ────────────────────────────────────────────────────
 //
-// Background. CanvasWidget JS code drives draw via the HTML5 Canvas2D-style
-// path API: beginPath, moveTo, lineTo, quadTo, cubicTo, closePath, then
+// CanvasWidget JS code drives draw via the HTML5 Canvas2D-style path API:
+// beginPath, moveTo, lineTo, quadTo, cubicTo, closePath, then
 // fill() / stroke(). The base Canvas class default-implements every one of
 // these as a no-op so backends that don't have a real path builder still
 // compile, but it means the CoreGraphics CPU paint path used by Pulp's
-// standalone host (when use_gpu=false) silently dropped the entire JS draw
-// program. Spectr's FilterBank canvas issues 1800+ such commands per frame
-// and the result was a fully-white window — see the issue thread for the
-// full repro.
+// standalone host (when use_gpu=false) needs this concrete path storage.
 //
 // Implementation: mirror SkiaCanvas's approach but with CGMutablePath.
 // We hold a CGMutablePathRef per begin_path() call, append segments as
@@ -913,11 +896,9 @@ void CoreGraphicsCanvas::close_path() {
 
 void CoreGraphicsCanvas::fill_current_path(FillRule rule) {
     if (!path_) return;
-    // pulp Wave 2 cheap wiring — honour the JS-supplied fillRule arg
-    // (`ctx.fill('evenodd')`). CG splits nonzero (CGContextFillPath /
-    // CGContextClip) and even-odd (CGContextEOFillPath /
-    // CGContextEOClip) at the API surface; pre-Wave-2 the bridge
-    // unconditionally used the nonzero variant.
+    // Honour the JS-supplied fillRule arg (`ctx.fill('evenodd')`). CG splits
+    // nonzero (CGContextFillPath / CGContextClip) and even-odd
+    // (CGContextEOFillPath / CGContextEOClip) at the API surface.
     const bool eo = (rule == FillRule::evenodd);
     if (has_gradient_) {
         // Clip to the path, then draw the gradient; restore the clip.
@@ -939,12 +920,10 @@ void CoreGraphicsCanvas::fill_current_path(FillRule rule) {
             CGContextFillPath(ctx_);
         }
     }
-    // pulp #1806 — Canvas2D spec: `ctx.fill()` preserves the scratch path
-    // so a subsequent `ctx.stroke()` paints the outlined version of the
-    // filled shape. Previously this destroyed `path_` via `release_path()`,
-    // which silently dropped strokes after fills (SvgPathWidget compound
-    // paths, common JS canvas idiom). `begin_path()` correctly resets the
-    // path for callers that intend a fresh build.
+    // Canvas2D spec: `ctx.fill()` preserves the scratch path so a subsequent
+    // `ctx.stroke()` paints the outlined version of the filled shape.
+    // `begin_path()` correctly resets the path for callers that intend a
+    // fresh build.
 }
 
 void CoreGraphicsCanvas::stroke_current_path() {
@@ -952,17 +931,17 @@ void CoreGraphicsCanvas::stroke_current_path() {
     CGContextAddPath(ctx_, path_);
     if (has_stroke_gradient_) {
         stroke_with_active_paint();
-        // pulp #1806 — preserve path; see fill_current_path comment.
+        // Preserve path; see fill_current_path comment.
         return;
     }
     apply_stroke_color();
     apply_line_dash_to_ctx();
     CGContextStrokePath(ctx_);
     reset_line_dash_on_ctx();
-    // pulp #1806 — preserve path; see fill_current_path comment.
+    // Preserve path; see fill_current_path comment.
 }
 
-// ── pulp #1521 — native arc / arcTo / ellipse / roundRect path builders ──
+// ── Native arc / arcTo / ellipse / roundRect path builders ───────────────────
 //
 // Replaces the JS shim's bezier approximation with CG's native arc APIs:
 //   - CGPathAddArc          — cx/cy/r/start/end + clockwise flag
@@ -1073,8 +1052,8 @@ void CoreGraphicsCanvas::stroke_with_active_paint() {
     }
     // Convert path to its stroked outline + clip to it. Then draw gradient.
     CGContextSaveGState(ctx_);
-    // pulp #1898 — push the dash pattern before CGContextReplacePathWithStrokedPath
-    // so the stroked outline reflects the dash gaps. The Save/Restore frame
+    // Push the dash pattern before CGContextReplacePathWithStrokedPath so the
+    // stroked outline reflects the dash gaps. The Save/Restore frame
     // we just opened snapshots the dash and pops it on Restore, so this only
     // affects the stroked-path build itself (and the gradient draw inside the
     // clip is rect-fill semantics that ignore dash anyway).
@@ -1132,7 +1111,7 @@ void CoreGraphicsCanvas::stroke_with_active_paint() {
     CGContextRestoreGState(ctx_);
 }
 
-// pulp #1524 — Canvas2D ctx.createPattern on the CG backend.
+// Canvas2D ctx.createPattern on the CG backend.
 //
 // We decode the source image via ImageIO (CGImageSource) and stash the
 // CGImageRef. fill_with_active_paint() builds a CGPattern via
@@ -1207,12 +1186,11 @@ void CoreGraphicsCanvas::set_stroke_pattern(const std::string& image_src,
                                              PatternTileMode tile_x,
                                              PatternTileMode tile_y) {
     (void)image_src; (void)tile_x; (void)tile_y;
-    // Stroke patterns aren't wired through stroke_with_active_paint yet —
-    // strokes continue with the existing stroke_color_. File a follow-up
-    // if a CG-targeted plugin needs tiled stroke patterns.
+    // Stroke patterns are not wired through stroke_with_active_paint yet;
+    // strokes continue with the existing stroke_color_.
 }
 
-// pulp #1434 bridge-thin gap-fill — Canvas2D ctx.miterLimit.
+// Canvas2D ctx.miterLimit.
 // CGContextSetMiterLimit attaches the value to the current GState, so
 // save()/restore() snapshots and pops it naturally. Spec: non-positive
 // or non-finite values are silently ignored (matches CG behaviour for
@@ -1225,8 +1203,7 @@ void CoreGraphicsCanvas::set_miter_limit(float limit) {
     }
 }
 
-// pulp #1434 bridge-thin gap-fill — Canvas2D
-// imageSmoothingEnabled / imageSmoothingQuality. CG exposes the same
+// Canvas2D imageSmoothingEnabled / imageSmoothingQuality. CG exposes the same
 // concept via CGContextSetInterpolationQuality on the current GState.
 // We translate the spec's three quality levels onto CG's enum:
 //   low    = kCGInterpolationLow     (cheap bilinear)
@@ -1250,7 +1227,7 @@ void CoreGraphicsCanvas::set_image_smoothing(bool enabled,
     CGContextSetInterpolationQuality(ctx_, cg_q);
 }
 
-// pulp #1524 — sample the active conic colour stops at angle `t` in [0, 1],
+// Sample the active conic colour stops at angle `t` in [0, 1],
 // where t=0 corresponds to start_angle and t=1 wraps back to start_angle + 2π.
 // Returns four CGFloat RGBA components in straight (un-premultiplied) space.
 static void sample_conic_stops(const std::vector<pulp::canvas::Color>& colors,
@@ -1298,7 +1275,7 @@ static void sample_conic_stops(const std::vector<pulp::canvas::Color>& colors,
     out_rgba[3] = colors[n - 1].a;
 }
 
-// pulp #1524 — software-rasterise a conic (sweep) gradient image covering the
+// Software-rasterise a conic (sweep) gradient image covering the
 // supplied bounding rectangle. Each pixel's angle is computed as
 // atan2(y - cy, x - cx) - start_angle (mod 2π) and divided by 2π to give the
 // stop position. Returns nullptr on allocation failure.
@@ -1358,7 +1335,7 @@ static CGImageRef build_conic_gradient_image(
     return img;
 }
 
-// pulp #1524 — CGPattern draw callback. The `info` field is the CGImageRef
+// CGPattern draw callback. The `info` field is the CGImageRef
 // of the tile bitmap; CG will invoke this once per tile and we paint the
 // image filling the tile rect. CG owns the pattern's draw lifetime.
 static void cg_canvas_pattern_draw_tile(void* info, CGContextRef ctx) {
@@ -1488,8 +1465,8 @@ void CoreGraphicsCanvas::fill_with_active_paint() {
     const CGGradientDrawingOptions opts =
         kCGGradientDrawsBeforeStartLocation | kCGGradientDrawsAfterEndLocation;
     if (gradient_kind_ == GradientKind::radial_two_circles) {
-        // pulp #1524 — full two-circle form. (x0,y0,r0) is the start /
-        // inner circle; (x1,y1,r1) is the end / outer circle.
+        // Full two-circle form. (x0,y0,r0) is the start / inner circle;
+        // (x1,y1,r1) is the end / outer circle.
         CGContextDrawRadialGradient(ctx_,
             gradient,
             CGPointMake(grad_x0_, grad_y0_), grad_radius_inner_,


### PR DESCRIPTION
## Summary
- remove issue/phase/Codex/follow-up archaeology from the CoreGraphics canvas implementation and header comments
- preserve the current Canvas2D/CoreGraphics rationale for CTM composition, fill rules, gradients, paths, text, dash state, blend modes, patterns, shadows, and save/restore depth
- add an explicit `Version-Bump: sdk=skip` trailer because this is comment-only SDK-owned source hygiene

## Review
- RepoPrompt pre-edit review identified the line-oriented cleanup plan and no stale behavior comments
- RepoPrompt post-edit review: Clean; no non-comment changes, no lost load-bearing rationale, no remaining in-scope archaeology
- Claude adversarial review: Clean; verified the only non-pure-comment diff line changes a trailing inline comment with identical code tokens

## Validation
- targeted archaeology grep over `cg_canvas.mm` and `cg_canvas.hpp`: clean
- normalized comment-stripped comparison against `HEAD`: clean
- `git diff --check`: clean
- `python3 tools/scripts/docs_noise_lint.py --mode=report`: clean
- `tools/scripts/gates.sh origin/main`: pass
- pre-push gates with `PULP_SKIP_DIFF_COVER=1 PULP_VIA_SHIPYARD=1 git push`: pass

Version-Bump: sdk=skip reason="comment-only CoreGraphics canvas hygiene"


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up the CoreGraphics canvas comments by removing stale issue/phase archaeology and tightening explanations while preserving the current rationale for CTM composition, fill rules, gradients (including two-circle), paths, text, dash state, blend modes, patterns, shadows, and save/restore depth; behavior is unchanged. Added `Version-Bump: sdk=skip` since this is comment-only hygiene.

<sup>Written for commit 6b52a12e315e728288a72d6b76ba1ef7d543fcdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

