### PR TITLE
docs: clean skia canvas comment archaeology

### DIFF
--- a/core/canvas/include/pulp/canvas/skia_canvas.hpp
+++ b/core/canvas/include/pulp/canvas/skia_canvas.hpp
@@ -70,9 +70,9 @@ public:
     void set_line_cap(LineCap cap) override;
     void set_line_join(LineJoin join) override;
 
-    // pulp #1434 bridge-thin gap-fill — Canvas2D ctx.miterLimit and
-    // ctx.imageSmoothingEnabled / ctx.imageSmoothingQuality. Sticky paint
-    // state honored by subsequent stroke / drawImage calls.
+    // Canvas2D ctx.miterLimit and ctx.imageSmoothingEnabled /
+    // ctx.imageSmoothingQuality. Sticky paint state honored by subsequent
+    // stroke / drawImage calls.
     void set_miter_limit(float limit) override;
     void set_image_smoothing(bool enabled,
                              ImageSmoothingQuality quality) override;
@@ -97,16 +97,16 @@ public:
     void set_font(const std::string& family, float size) override;
     void set_font_full(const std::string& family, float size,
                        int weight, int slant, float letter_spacing) override;
-    // pulp #1737 — OpenType feature flags via SkShaper Feature API.
+    // OpenType feature flags via SkShaper Feature API.
     // Captured into font_features_ vector and flushed at shape time.
     void set_font_features(std::vector<FontFeature> features) override;
     void clear_font_features() override;
     void set_text_align(TextAlign align) override;
     void fill_text(const std::string& text, float x, float y) override;
-    // pulp #2163 / font v2 Slice 1.2.b — typed anchor variant.
+    // Typed text-anchor variant.
     void fill_text_anchored(const std::string& text, float x, float y,
                             TextAnchor anchor) override;
-    // pulp #1525 — Canvas2D fillText(text,x,y,maxWidth) + strokeText(text,x,y,maxWidth).
+    // Canvas2D fillText(text,x,y,maxWidth) + strokeText(text,x,y,maxWidth).
     void fill_text_with_max_width(const std::string& text,
                                   float x, float y, float max_width) override;
     void stroke_text(const std::string& text, float x, float y,
@@ -115,9 +115,9 @@ public:
                        const SdfAtlas& atlas) override;
     float measure_text(const std::string& text) override;
     TextMetrics measure_text_full(const std::string& text) override;
-    // WYSIWYG caret math — caret x for a byte boundary within the FULL
-    // shaped run (same make_paragraph(...) fill_text uses), so kerned/
-    // letter-spaced text reports the exact painted advance.
+    // Caret x for a byte boundary within the full shaped run (same
+    // make_paragraph(...) fill_text uses), so kerned / letter-spaced text
+    // reports the exact painted advance.
     float text_x_for_byte(const std::string& text,
                           std::size_t byte_index) override;
 
@@ -128,7 +128,7 @@ public:
                                float x, float y, float w, float h) override;
     bool draw_svg(const std::string& svg_document,
                   float x, float y, float w, float h) override;
-    // pulp #1737 — 9-arg drawImage source-rect form: routes through
+    // 9-arg drawImage source-rect form: routes through
     // SkCanvas::drawImageRect(image, src, dst, sampling) so a sub-rect of
     // the decoded SkImage maps onto the destination rect. Supports
     // sprite-sheet slicing without re-decoding the source bitmap.
@@ -150,7 +150,7 @@ public:
     bool draw_skia_image(const sk_sp<SkImage>& image,
                          float x, float y, float w, float h);
 
-    // ── Line dash / pixel manipulation (issue-916) ─────────────────────
+    // ── Line dash / pixel manipulation ─────────────────────────────────
     void set_line_dash(const float* intervals, int count, float phase) override;
     bool read_pixels(int x, int y, int width, int height, uint8_t* out) override;
     bool write_pixels(const uint8_t* data, int width, int height,
@@ -163,7 +163,7 @@ public:
                                    const Color* colors, const float* positions, int count) override;
     void set_fill_gradient_radial(float cx, float cy, float radius,
                                    const Color* colors, const float* positions, int count) override;
-    /// pulp #1524 — true two-circle radial gradient via SkShaders::TwoPointConicalGradient.
+    /// True two-circle radial gradient via SkShaders::TwoPointConicalGradient.
     void set_fill_gradient_radial_two_circles(
         float x0, float y0, float r0,
         float x1, float y1, float r1,
@@ -172,13 +172,12 @@ public:
                                   const Color* colors, const float* positions, int count) override;
     void clear_fill_gradient() override;
 
-    // pulp Wave 3 c2d.7 — Canvas2D `ctx.strokeStyle = createLinearGradient(...)`
-    // (and radial / two-circle / conic counterparts). Routes through
-    // SkShaders::*Gradient and stores the resulting shader on
-    // `stroke_shader_`, which `apply_stroke_state` already attaches to
-    // every stroke paint. Mirrors the fill-side surface so the bridge
-    // can expose `canvasSetStrokeLinearGradient` etc. without inventing
-    // a separate paint pipeline.
+    // Canvas2D `ctx.strokeStyle = createLinearGradient(...)` (and radial /
+    // two-circle / conic counterparts). Routes through SkShaders::*Gradient and
+    // stores the resulting shader on `stroke_shader_`, which
+    // `apply_stroke_state` attaches to every stroke paint. Mirrors the fill-side
+    // surface so the bridge can expose `canvasSetStrokeLinearGradient` etc.
+    // without inventing a separate paint pipeline.
     void set_stroke_gradient_linear(float x0, float y0, float x1, float y1,
                                      const Color* colors, const float* positions, int count) override;
     void set_stroke_gradient_radial(float cx, float cy, float radius,
@@ -191,7 +190,7 @@ public:
                                     const Color* colors, const float* positions, int count) override;
     void clear_stroke_gradient() override;
 
-    // pulp #1434 bridge-thin gap-fill — Canvas2D ctx.createPattern.
+    // Canvas2D ctx.createPattern.
     // Routes through SkShader::MakeImage with SkTileMode per axis.
     // Stored on the same gradient_shader_ field used by gradient fills
     // (the field already represents "active non-solid fill paint"), so
@@ -216,7 +215,7 @@ public:
     void fill_current_path(FillRule rule = FillRule::nonzero) override;
     void stroke_current_path() override;
 
-    // pulp #1521 — native arc subpaths via SkPath::arcTo / SkRRect.
+    // Native arc subpaths via SkPath::arcTo / SkRRect.
     void arc(float cx, float cy, float radius,
              float start_angle, float end_angle,
              bool anticlockwise) override;
@@ -241,26 +240,24 @@ public:
     void save_backdrop_filter(float x, float y, float w, float h,
                               float blur_radius) override;
 
-    // Box shadow (issue-925) — uses SkImageFilters::DropShadowOnly for
-    // outset shadows; inset shadows clip to the box and stroke with a
-    // blurred mask.
+    // Box shadow uses SkImageFilters::DropShadowOnly for outset shadows; inset
+    // shadows clip to the box and stroke with a blurred mask.
     void draw_box_shadow(float x, float y, float w, float h,
                          float dx, float dy, float blur, float spread,
                          Color color, bool inset, float corner_radius) override;
 
-    // Canvas2D drop-shadow state (issue-1434 batch 7). Sticky values that
-    // attach an SkImageFilters::DropShadow to the active fill/stroke
-    // paints until cleared (color alpha == 0 or blur == 0 with both
-    // offsets == 0). See current_fill_paint() / current_stroke_paint()
-    // for the wrapping logic.
+    // Canvas2D drop-shadow state. Sticky values attach an
+    // SkImageFilters::DropShadow to the active fill/stroke paints until cleared
+    // (color alpha == 0 or blur == 0 with both offsets == 0). See
+    // current_fill_paint() and apply_shadow_filter() for the wrapping logic.
     void set_shadow_color(Color color) override;
     void set_shadow_blur(float blur) override;
     void set_shadow_offset_x(float dx) override;
     void set_shadow_offset_y(float dy) override;
 
-    // pulp #1520 — Canvas2D ctx.direction / ctx.filter sticky state.
-    // Direction selects SkShaper's leftToRight flag (and, future-state,
-    // the HarfBuzz buffer direction for proper bidi mixed-script). The
+    // Canvas2D ctx.direction / ctx.filter sticky state.
+    // Direction selects SkShaper's leftToRight flag (and later the HarfBuzz
+    // buffer direction for proper bidi mixed-script). The
     // filter parses a CSS <filter-function-list> string ("blur(5px)
     // sepia(80%) ...") into an SkImageFilter chain that wraps each
     // subsequent paint via current_fill_paint() / apply_stroke_state.
@@ -282,7 +279,7 @@ public:
                                   float w,
                                   float h);
 
-    // Standalone text measurement (issue-916). Returns full HTML5
+    // Standalone text measurement. Returns full HTML5
     // TextMetrics for `text` rendered with `family` at `size` pixels —
     // no canvas instance required. Used by the JS bridge's
     // canvasMeasureText so JS callers can pre-measure text for layout
@@ -294,20 +291,19 @@ public:
     void set_opacity(float alpha) override;
     void save_layer(float x, float y, float w, float h,
                     float opacity, float blur_radius) override;
-    // pulp #1549 — saveLayer with explicit blend mode (CSS / RN
-    // mix-blend-mode). The Skia backend honors the requested blend
-    // mode on the layer-paint so the subtree composites back with
-    // multiply / screen / overlay / etc.
+    // saveLayer with explicit blend mode (CSS / RN mix-blend-mode). The Skia
+    // backend honors the requested blend mode on the layer-paint so the subtree
+    // composites back with multiply / screen / overlay / etc.
     void save_layer_with_blend(float x, float y, float w, float h,
                                float opacity, float blur_radius,
                                Canvas::BlendMode mode) override;
-    // pulp #1434 Phase A2-4 — full CSS filter chain.
+    // Full CSS filter chain.
     void save_layer_with_filters(float x, float y, float w, float h,
                                   float opacity,
                                   const FilterChainEntry* chain,
                                   int count) override;
 
-    // pulp #1737 / #1515 — CSS mask-image + mask-size paint composite.
+    // CSS mask-image + mask-size paint composite.
     // SkiaCanvas implements the 2-saveLayer pattern with kDstIn:
     //   1. open the content layer (saveLayer with opacity)
     //   2. caller paints the subtree
@@ -316,10 +312,9 @@ public:
     //      saveLayer first, then closes the content layer
     // Pending masks are tracked on `pending_masks_` keyed by Skia's
     // internal save count so the restore-side dispatcher knows which
-    // restore call belongs to which mask layer. The matching restore()
-    // override (declared once at line ~45) handles the deferred mask
-    // composite — it walks pending_masks_ for a matching save count
-    // before delegating to canvas_->restore().
+    // restore call belongs to which mask layer. SkiaCanvas::restore() handles
+    // the deferred mask composite: it walks pending_masks_ for a matching save
+    // count before delegating to canvas_->restore().
     void save_layer_with_mask(float x, float y, float w, float h,
                                float opacity,
                                const std::string& mask_image,
@@ -328,10 +323,10 @@ public:
 private:
     // Build the active fill paint, honoring `gradient_shader_` when set
     // so shape fills (rect / rrect / circle / arc / oval / polygon) render
-    // gradients consistently with `fill_current_path()` (#1350).
+    // gradients consistently with `fill_current_path()`.
     SkPaint current_fill_paint() const;
 
-    // issue-1434 batch 7 — apply the sticky Canvas2D shadow* state to an
+    // Apply the sticky Canvas2D shadow* state to an
     // arbitrary paint (typically a stroke paint built via the free
     // `make_stroke_paint` helper). Members can't be reached from the
     // free helper, so the call sites that build a stroke paint apply
@@ -343,16 +338,14 @@ private:
     // so the gating logic stays in one place.
     bool shadow_is_active() const;
 
-    // pulp #1434 bridge-thin gap-fill — apply sticky stroke join + miter
-    // limit to a freshly-constructed stroke paint. Called from the
-    // stroke_* paths after make_stroke_paint() but before any paint
-    // submit. Centralises the policy so future stroke-state setters
-    // (lineCap and friends) can join here without touching every site.
+    // Apply sticky stroke join + miter limit to a freshly-constructed stroke
+    // paint. Called from the stroke_* paths after make_stroke_paint() but
+    // before any paint submit. Centralises the policy so future stroke-state
+    // setters can join here without touching every site.
     void apply_stroke_state(SkPaint& paint) const;
 
-    // pulp #1434 bridge-thin gap-fill — translate the sticky
-    // imageSmoothingEnabled / imageSmoothingQuality state into an
-    // SkSamplingOptions for drawImageRect. Spec defaults match Skia
+    // Translate the sticky imageSmoothingEnabled / imageSmoothingQuality state
+    // into an SkSamplingOptions for drawImageRect. Spec defaults match Skia
     // defaults so non-set callers keep getting kLinear.
     SkSamplingOptions sampling_options_for_image_smoothing() const;
 
@@ -369,19 +362,19 @@ private:
     float line_width_ = 1.0f;
     LineCap line_cap_ = LineCap::butt;
     LineJoin line_join_ = LineJoin::miter;
-    // pulp #1434 bridge-thin gap-fill — Canvas2D ctx.miterLimit. Spec
-    // default is 10 (matches Skia's SkPaint default).
+    // Canvas2D ctx.miterLimit. Spec default is 10 (matches Skia's SkPaint
+    // default).
     float miter_limit_ = 10.0f;
-    // pulp #1434 bridge-thin gap-fill — Canvas2D ctx.imageSmoothingEnabled
-    // / ctx.imageSmoothingQuality. Defaults match the spec (`true`,
-    // `"low"`). Honored by draw_image_from_data / draw_image_from_file.
+    // Canvas2D ctx.imageSmoothingEnabled / ctx.imageSmoothingQuality. Defaults
+    // match the spec (`true`, `"low"`). Honored by draw_image_from_data /
+    // draw_image_from_file.
     bool image_smoothing_enabled_ = true;
     ImageSmoothingQuality image_smoothing_quality_ = ImageSmoothingQuality::low;
     std::string font_family_ = "sans-serif";
-    int font_weight_ = 400;             ///< CSS weight 100..900 (pulp #927)
-    int font_slant_ = 0;                ///< 0=upright, 1=italic (pulp #927)
-    float letter_spacing_ = 0.0f;       ///< Extra advance per glyph in px (pulp #927)
-    // pulp #1737 — OpenType feature flags (e.g. tnum / smcp / onum /
+    int font_weight_ = 400;             ///< CSS weight 100..900
+    int font_slant_ = 0;                ///< 0=upright, 1=italic
+    float letter_spacing_ = 0.0f;       ///< Extra advance per glyph in px
+    // OpenType feature flags (e.g. tnum / smcp / onum /
     // lnum / pnum) for CSS font-variant. Captured by set_font_features
     // / cleared by clear_font_features. Applied via
     // `TextStyle::addFontFeature` in `make_paragraph()` at
@@ -389,7 +382,7 @@ private:
     // OpenType features set.
     std::vector<FontFeature> font_features_;
 
-    // pulp #1737 / #1515 — pending mask state for save_layer_with_mask.
+    // Pending mask state for save_layer_with_mask.
     // Each entry is the deferred mask composite to apply when the
     // matching restore() fires. Tracked by Skia's getSaveCount() so
     // restore() can look up "is the layer I'm about to close a
@@ -403,26 +396,24 @@ private:
     std::vector<PendingMask> pending_masks_;
 
 public:
-    // pulp #1899 (gap #3 — text edging in opacity layers) — returns true
-    // when at least one currently-open save_layer* has alpha < 1 on its
-    // layer-paint. Text paint paths (fill_text, stroke_text) consult
-    // this at paint time and select greyscale AA over LCD subpixel AA
-    // — Skia's LCD subpixel patterns can't antialias correctly into a
-    // partially transparent pixel, so glyphs render faint inside
-    // CSS-opacity layers without this flip. Browsers (Blink / WebKit)
-    // do the same. Exposed publicly so tests can assert the stack-
-    // tracking around nested save_layer / restore / restore_to_count.
+    // Returns true when at least one currently-open save_layer* has alpha < 1
+    // on its layer-paint. Text paint paths (fill_text, stroke_text) consult this
+    // at paint time and select greyscale AA over LCD subpixel AA: Skia's LCD
+    // subpixel patterns can't antialias correctly into a partially transparent
+    // pixel, so glyphs render faint inside CSS-opacity layers without this flip.
+    // Browsers (Blink / WebKit) do the same. Exposed publicly so tests can
+    // assert the stack-tracking around nested save_layer / restore /
+    // restore_to_count.
     bool inside_non_opaque_layer() const {
         return !non_opaque_layer_stack_.empty();
     }
 
 private:
-    // pulp #1899 (gap #3) — each entry is Skia's getSaveCount() AFTER
-    // the layer was opened. restore() pops the top entry if its save
-    // count matches the canvas's current save count; restore_to_count()
-    // pops any entries strictly above the target (mirrors
-    // SkCanvas::restoreToCount). Plain save() / save_layer with
-    // opacity == 1 do not push.
+    // Each entry is Skia's getSaveCount() after the layer was opened.
+    // restore() pops the top entry if its save count matches the canvas's
+    // current save count; restore_to_count() pops any entries strictly above
+    // the target (mirrors SkCanvas::restoreToCount). Plain save() / save_layer
+    // with opacity == 1 do not push.
     std::vector<int> non_opaque_layer_stack_;
 
     TextAlign text_align_ = TextAlign::left;
@@ -431,10 +422,9 @@ private:
     bool has_gradient_ = false;
     sk_sp<SkShader> gradient_shader_;
 
-    // pulp #1434 bridge-thin gap-fill — Canvas2D ctx.createPattern stroke
-    // shader (rare: most plugins set patterns on fillStyle, not strokeStyle).
-    // Lives separately from gradient_shader_ so stroke paths can opt in
-    // via apply_stroke_state without disturbing fill state.
+    // Canvas2D ctx.createPattern stroke shader. Lives separately from
+    // gradient_shader_ so stroke paths can opt in via apply_stroke_state without
+    // disturbing fill state.
     sk_sp<SkShader> stroke_shader_;
 
     // Path building state
@@ -450,13 +440,13 @@ private:
     // CanvasWidget — there setTransform behaves per the HTML spec literally.
     SkMatrix paint_baseline_ = SkMatrix::I();
 
-    // Line-dash pattern (issue-916). Empty == solid stroke (no dashing).
+    // Line-dash pattern. Empty == solid stroke (no dashing).
     // Held as floats so the stroke-paint helper can rebuild the SkDashPathEffect
     // each time stroke_color/line_width change.
     std::vector<float> line_dash_;
     float line_dash_phase_ = 0.0f;
 
-    // Canvas2D drop-shadow state (issue-1434 batch 7). Sticky — every
+    // Canvas2D drop-shadow state. Sticky: every
     // draw helper queries `make_shadow_filter()` and, when a shadow is
     // active, wraps its paint via `SkPaint::setImageFilter`. The shadow
     // is gated on color.a > 0 AND (blur > 0 OR dx != 0 OR dy != 0) to
@@ -468,13 +458,12 @@ private:
     float shadow_offset_x_ = 0.0f;
     float shadow_offset_y_ = 0.0f;
 
-    // pulp #1520 — Canvas2D ctx.direction sticky state. Defaults to ltr
-    // (matches the previous hard-coded SkShaper leftToRight=true). rtl
-    // flips the shaper flag; inherit currently behaves as ltr until a
-    // per-View writing-direction lookup lands (#1506).
+    // Canvas2D ctx.direction sticky state. Defaults to ltr, rtl flips the
+    // shaper flag, and inherit currently behaves as ltr until a per-View
+    // writing-direction lookup lands.
     TextDirection direction_ = TextDirection::ltr;
 
-    // pulp #1520 — Canvas2D ctx.filter sticky state. Stored as the raw
+    // Canvas2D ctx.filter sticky state. Stored as the raw
     // CSS string for round-trip diagnostics; the parsed SkImageFilter
     // chain caches alongside so we don't re-parse on every draw. Both
     // are reset together by set_filter(). When `filter_image_filter_`
@@ -483,13 +472,13 @@ private:
     sk_sp<SkImageFilter> filter_image_filter_;
 
 public:
-    // pulp #1520 — wrap an arbitrary paint with the active ctx.filter
+    // Wrap an arbitrary paint with the active ctx.filter
     // SkImageFilter chain (no-op when filter is "none" or unparsable).
     // Centralised so fill / stroke / text / image draws can opt in
     // without touching every call site.
-    // Public for test_canvas.cpp filter-pipeline tests added in #1791;
-    // the implementation is a pure paint-state mutation, no class
-    // invariant gets violated by external callers.
+    // Public for test_canvas.cpp filter-pipeline tests; the implementation is a
+    // pure paint-state mutation, no class invariant gets violated by external
+    // callers.
     void apply_filter(SkPaint& paint) const;
 };
 

--- a/core/canvas/src/skia_canvas.cpp
+++ b/core/canvas/src/skia_canvas.cpp
@@ -80,7 +80,7 @@ static SkColor4f to_sk_color4f(Color c) {
 }
 
 // Solid-color fill paint. For shape fills that should honor an active
-// gradient, prefer SkiaCanvas::current_fill_paint() — see #1350.
+// gradient, prefer SkiaCanvas::current_fill_paint().
 static SkPaint make_solid_fill_paint(Color c) {
     SkPaint paint;
     paint.setColor4f(to_sk_color4f(c));
@@ -98,9 +98,6 @@ SkPaint make_stroke_paint(Color c, float width) {
     return paint;
 }
 
-// Cached typeface loaded directly from a known path — bypasses family name
-// matching for deterministic metrics (Visage-style approach). Cache key
-// pulp #1737 (#932 followup) — comma-separated CSS family list walker.
 // Splits a CSS `font-family` value (e.g. `"SF Pro, system-ui, sans-serif"`)
 // into individual family names, stripping outer quotes and whitespace.
 // Used by get_cached_typeface to walk the fallback chain — each family
@@ -131,9 +128,9 @@ static std::vector<std::string> split_font_family_list(const std::string& list) 
 static sk_sp<SkTypeface> get_cached_typeface_single(const std::string& family,
                                                     int weight, int slant);
 
-// pulp #1737 (#932 followup) — public entry point: walks a comma-separated
-// CSS family list and returns the first typeface that resolves. A single-
-// family input (no comma) just delegates to get_cached_typeface_single.
+// Walks a comma-separated CSS family list and returns the first typeface that
+// resolves. A single-family input (no comma) just delegates to
+// get_cached_typeface_single.
 // Empty string or all-fail returns the default typeface (last fallback in
 // get_cached_typeface_single's chain).
 static sk_sp<SkTypeface> get_cached_typeface(const std::string& family,
@@ -180,25 +177,17 @@ static sk_sp<SkTypeface> get_cached_typeface(const std::string& family,
     return get_cached_typeface_single("", weight, slant);
 }
 
-// includes weight + slant so setFontWeight(700) actually returns a bold
-// typeface rather than the same Regular blob (pulp #927).
-//
-// Cache is gated on `pulp::canvas::font_registration_generation()` so that
-// calling `register_font(...)` or `register_emoji_fallback(...)` mid-process
-// flushes stale `SkTypeface`s — the registration header documents this
-// idempotent-with-invalidation contract, but the cache never honored it
-// before this fix (Codex review on emoji-parity branch).
+// Includes weight + slant so setFontWeight(700) resolves a bold typeface
+// rather than the same Regular blob.
 static sk_sp<SkTypeface> get_cached_typeface_single(const std::string& family,
                                              int weight, int slant) {
-    // pulp #2163 / font v2 Slice 1.1.a (caller migration) — routes through
-    // FontResolver so registered / bundled / platform cascade and the
-    // typeface cache live in one place. FontResolver keys on the full
-    // FontOptions hash including registry_generation, so registration
-    // changes invalidate automatically — replaces the
-    // font_registration_generation()-watching cache that lived here.
+    // Route through FontResolver so registered / bundled / platform cascade
+    // and the typeface cache live in one place. FontResolver keys on the full
+    // FontOptions hash including registry_generation, so registration changes
+    // invalidate automatically.
     // The Android Roboto direct-file load is preserved as a pre-resolver
     // fast path (the resolver doesn't yet honor platform-specific file
-    // overrides; restored in Slice 1.1.a finish).
+    // overrides).
 #if defined(__ANDROID__)
     if (weight == 400 && slant == 0 &&
         (family == "sans-serif" || family == "Roboto" || family.empty())) {
@@ -230,21 +219,17 @@ SkFont make_font(const std::string& family, float size,
                         int slant = 0,
                         bool non_opaque_dst = false) {
     SkFont font;
-    // pulp #1899 — Spectr's drawSpectrum() can fire ctx.fillText calls
-    // before the ctx.font setter has propagated through the JS shim
-    // (race between React useEffect commit and canvas command replay).
-    // If size is 0 here, fill_text would record commands but produce
-    // zero-height glyphs — clamp to a minimal visible default so labels
-    // render even when the JS-side font sync raced the paint.
+    // If size is 0 here, fill_text records commands but produces zero-height
+    // glyphs; clamp to a minimal visible default so labels render even when the
+    // JS-side font sync races the paint.
     if (!(size > 0.0f)) size = 14.0f;
     font.setSize(size);
     font.setSubpixel(true);                               // Subpixel glyph positioning
-    // pulp #1899 (gap #3) — LCD subpixel AA visibly degrades when the
-    // destination surface isn't opaque: Skia's documented behavior is
-    // that subpixel patterns can't antialias correctly into a partially
-    // transparent pixel, so glyphs come out faint inside save_layer
-    // contexts that carry alpha < 1 (e.g. an ancestor View opens
-    // saveLayer(opacity = 0.6) for CSS opacity). Browsers
+    // LCD subpixel AA visibly degrades when the destination surface isn't
+    // opaque: Skia's documented behavior is that subpixel patterns can't
+    // antialias correctly into a partially transparent pixel, so glyphs come
+    // out faint inside save_layer contexts that carry alpha < 1 (e.g. an
+    // ancestor View opens saveLayer(opacity = 0.6) for CSS opacity). Browsers
     // (Blink / WebKit) flip the same way — greyscale AA inside
     // non-opaque layers. Callers pass `non_opaque_dst=true` when any
     // currently-open SkiaCanvas layer was opened with alpha < 1.
@@ -256,14 +241,9 @@ SkFont make_font(const std::string& family, float size,
 
     auto typeface = get_cached_typeface(family, weight, slant);
     if (!typeface) {
-        // pulp #1899 — when no typeface resolves (empty family, missing
-        // font, or pulp-screenshot's headless context missing the JS-side
-        // ctx.font sync), fall back to the SkFontMgr default rather than
-        // letting fill_text silently no-op. The previous behavior caused
-        // all canvas text (dB axis labels, frequency labels, IIR·analog
-        // sub-label) to render as nothing in Spectr's native runtime-
-        // import path — bars + grid rendered fine because they don't
-        // need typeface, but every fillText call silently dropped.
+        // When no typeface resolves (empty family, missing font, or a
+        // headless context missing the JS-side ctx.font sync), fall back to the
+        // SkFontMgr default rather than letting fill_text no-op.
         auto mgr = get_font_manager();
         if (mgr) {
             SkFontStyle sk_style{
@@ -298,12 +278,11 @@ SkiaCanvas::~SkiaCanvas() = default;
 
 void SkiaCanvas::save() { GUARD_CANVAS; canvas_->save(); }
 
-// pulp #1737 / #1515 — restore() override applies any pending mask
-// composite for the layer being restored before delegating to Skia's
-// restore. Detects the matching mask layer via the save count we
-// captured at save_layer_with_mask time. If no mask is pending for
-// this restore (the common case — non-mask save / save_layer / etc.),
-// behaves identically to the legacy `canvas_->restore()` one-liner.
+// restore() applies any pending mask composite for the layer being restored
+// before delegating to Skia's restore. Detects the matching mask layer via the
+// save count we captured at save_layer_with_mask time. If no mask is pending
+// for this restore (the common case: non-mask save / save_layer / etc.), it
+// behaves identically to `canvas_->restore()`.
 //
 // The mask paint pattern (see CSS Masking Module Level 1 §5):
 //   1. saveLayer(content, opacity)   <- already happened at open time
@@ -336,8 +315,8 @@ void SkiaCanvas::restore() {
         }
         // Falls through to the outer restore() below.
     }
-    // pulp #1899 (gap #3) — pop the non-opaque layer stack if the
-    // layer we're about to close was tracked. Save count is captured
+    // Pop the non-opaque layer stack if the layer we're about to close was
+    // tracked. Save count is captured
     // before delegating to canvas_->restore() so it matches the depth
     // recorded at push time.
     if (!non_opaque_layer_stack_.empty() &&
@@ -347,12 +326,11 @@ void SkiaCanvas::restore() {
     canvas_->restore();
 }
 
-// pulp #1368 — expose Skia's save-stack depth so CanvasWidget::paint()
-// can snapshot it at entry and `restore_to_count()` back to baseline at
-// exit. Without this defense an unbalanced JS draw script (e.g. a
-// `ctx.save()` whose matching `ctx.restore()` is skipped on an
-// early-return path) leaks GState onto the parent View's paint scope
-// and silently corrupts subsequent siblings' transform/clip.
+// Expose Skia's save-stack depth so CanvasWidget::paint() can snapshot it at
+// entry and `restore_to_count()` back to baseline at exit. Without this defense
+// an unbalanced JS draw script (e.g. a `ctx.save()` whose matching
+// `ctx.restore()` is skipped on an early-return path) leaks GState onto the
+// parent View's paint scope and corrupts subsequent siblings' transform/clip.
 int SkiaCanvas::save_count() const {
     if (!canvas_) return 0;
     return canvas_->getSaveCount();
@@ -365,9 +343,8 @@ void SkiaCanvas::restore_to_count(int target) {
     // == 4 at entry and got back depth 7 (three leaked saves) returns
     // to exactly 4 at exit. SkCanvas guards target == 0 internally.
     const int safe_target = target < 1 ? 1 : target;
-    // pulp #1899 (gap #3) — drop any tracked non-opaque layers whose
-    // save count is strictly above the target, since SkCanvas is about
-    // to close all of them in one shot.
+    // Drop any tracked non-opaque layers whose save count is strictly above the
+    // target, since SkCanvas is about to close all of them in one shot.
     while (!non_opaque_layer_stack_.empty() &&
            non_opaque_layer_stack_.back() > safe_target) {
         non_opaque_layer_stack_.pop_back();
@@ -420,7 +397,7 @@ void SkiaCanvas::concat_transform(float a, float b, float c,
     canvas_->concat(m);
 }
 
-// pulp #1368 round 2 — diagnostic CTM snapshot for `PULP_LOG_CANVAS_PAINT=1`.
+// Diagnostic CTM snapshot for `PULP_LOG_CANVAS_PAINT=1`.
 // Returns the current device matrix in CanvasRenderingContext2D affine order
 // so the env-gated CanvasWidget::paint logging can record what transform the
 // inbound canvas actually has when paint() runs.
@@ -449,10 +426,9 @@ void SkiaCanvas::clip(FillRule rule) {
     if (!path_builder_) return;
     // Snapshot the path (don't detach — Canvas2D allows continued use of
     // the same path after clip()) and intersect with the current clip.
-    // pulp Wave 2 cheap wiring — honour the JS-supplied fillRule arg
-    // (`ctx.clip('evenodd')`) by stamping the path's fill type before
-    // SkCanvas::clipPath consumes it. Default 'nonzero' matches the
-    // pre-Wave-2 behaviour (SkPathFillType::kWinding).
+    // Honour the JS-supplied fillRule arg (`ctx.clip('evenodd')`) by stamping
+    // the path's fill type before SkCanvas::clipPath consumes it. Default
+    // 'nonzero' maps to SkPathFillType::kWinding.
     SkPath p = path_builder_->snapshot();
     p.setFillType(rule == FillRule::evenodd
                       ? SkPathFillType::kEvenOdd
@@ -461,11 +437,10 @@ void SkiaCanvas::clip(FillRule rule) {
 }
 
 void SkiaCanvas::clip_path_svg(const std::string& svg_path_d) {
-    // CSS `clip-path: path("...")` (pulp #1515). Parse the SVG-path-d
-    // string via Skia's SVG path parser and install it as the canvas
-    // clip. Caller owns save()/restore() balancing; we install the
-    // clip on the current Skia clip stack so a paired restore() lifts
-    // it. Unparseable / empty strings are silently ignored — same
+    // CSS `clip-path: path("...")`: parse the SVG-path-d string via Skia's SVG
+    // path parser and install it as the canvas clip. Caller owns save()/restore()
+    // balancing; we install the clip on the current Skia clip stack so a paired
+    // restore() lifts it. Unparseable / empty strings are silently ignored: same
     // graceful-degrade contract as the other paint-time clip helpers.
     GUARD_CANVAS;
     if (svg_path_d.empty()) return;
@@ -474,12 +449,12 @@ void SkiaCanvas::clip_path_svg(const std::string& svg_path_d) {
     canvas_->clipPath(path, /*doAntiAlias=*/true);
 }
 
-// pulp #1350 — single source of truth for shape-fill paints. Mirrors
+// Single source of truth for shape-fill paints. Mirrors
 // `fill_current_path()` so a gradient set via `set_fill_gradient_*`
 // is honored by every shape helper (rect / rrect / circle / arc /
 // oval / polygon), not just path fills. The free `make_solid_fill_paint`
 // remains for paths that intentionally want a solid color regardless
-// of the active gradient (text glyphs today).
+// of the active gradient (text glyphs intentionally use solid color).
 SkPaint SkiaCanvas::current_fill_paint() const {
     SkPaint paint;
     paint.setStyle(SkPaint::kFill_Style);
@@ -495,16 +470,14 @@ SkPaint SkiaCanvas::current_fill_paint() const {
     return paint;
 }
 
-// ── Canvas2D shadow* state (issue-1434 batch 7) ──────────────────────────────
+// ── Canvas2D shadow* state ───────────────────────────────────────────────────
 //
 // Sticky values set via `ctx.shadowColor` / `shadowBlur` /
 // `shadowOffsetX` / `shadowOffsetY`. Every subsequent fill/stroke draw
 // queries `apply_shadow_filter` and, when active, attaches an
 // `SkImageFilters::DropShadow` so the geometry emits both itself and a
 // blurred shadow underneath — mirroring WebKit / Blink. Sigma mapping is
-// the same `sigma = blur / 2` Chromium's Canvas2D implementation uses
-// (third_party/blink/.../canvas_rendering_context_2d.cc) and matches the
-// WebView reference within ~5px (same acceptance bar as #925).
+// the same `sigma = blur / 2` Chromium's Canvas2D implementation uses.
 
 bool SkiaCanvas::shadow_is_active() const {
     return shadow_color_.a > 0.0f &&
@@ -540,11 +513,10 @@ void SkiaCanvas::set_line_join(LineJoin join) {
     line_join_ = join;
 }
 
-// pulp #1434 bridge-thin gap-fill — wire ctx.miterLimit through to
-// SkPaint::setStrokeMiter. The current stroke helpers build a fresh
-// SkPaint per draw via make_stroke_paint(); we apply the miter limit
-// at draw-time in stroke_current_path / stroke_rect / etc., so this
-// setter just stores the value and lets the apply_* helper read it.
+// Wire ctx.miterLimit through to SkPaint::setStrokeMiter. The current stroke
+// helpers build a fresh SkPaint per draw via make_stroke_paint(); we apply the
+// miter limit at draw-time in stroke_current_path / stroke_rect / etc., so this
+// setter stores the value and lets the apply_* helper read it.
 // Spec: non-positive / non-finite values are silently ignored.
 void SkiaCanvas::set_miter_limit(float limit) {
     if (std::isfinite(limit) && limit > 0.0f) {
@@ -552,23 +524,22 @@ void SkiaCanvas::set_miter_limit(float limit) {
     }
 }
 
-// pulp #1434 bridge-thin gap-fill — wire ctx.imageSmoothingEnabled and
-// ctx.imageSmoothingQuality through. The flag is read at drawImage
-// time by sampling_options_for_image_smoothing() below; we just store
-// the chosen state here so it sticks across draws.
+// Wire ctx.imageSmoothingEnabled and ctx.imageSmoothingQuality through. The flag
+// is read at drawImage time by sampling_options_for_image_smoothing() below; we
+// store the chosen state here so it sticks across draws.
 void SkiaCanvas::set_image_smoothing(bool enabled,
                                      ImageSmoothingQuality quality) {
     image_smoothing_enabled_ = enabled;
     image_smoothing_quality_ = quality;
 }
 
-// ── pulp #1520 — Canvas2D ctx.direction / ctx.filter ─────────────────────
+// ── Canvas2D ctx.direction / ctx.filter ──────────────────────────────────────
 // Direction is stored on the canvas state and read at fill_text() time
 // to choose the SkShaper leftToRight flag. RTL flips the flag, which is
 // the correct first step for proper Arabic / Hebrew shaping; full bidi
 // (mixed-script paragraphs requiring the Unicode Bidi Algorithm) needs
-// SkParagraph plumbing tracked under #1506. inherit currently behaves
-// as ltr until per-View writing-direction lookup lands.
+// SkParagraph plumbing. inherit currently behaves as ltr until per-View
+// writing-direction lookup lands.
 void SkiaCanvas::set_direction(TextDirection direction) {
     direction_ = direction;
 }
@@ -597,13 +568,9 @@ void SkiaCanvas::apply_filter(SkPaint& paint) const {
     }
 }
 
-// pulp #1434 bridge-thin gap-fill — apply sticky stroke-paint state. The
-// existing stroke paths constructed an SkPaint via make_stroke_paint()
-// but never propagated the JS-side line_join / miter_limit state. The
-// canvas2d harness flagged miterLimit as silently dropped; setStrokeJoin
-// and setStrokeMiter close that gap without touching every call site.
-// line_cap_ is plumbed here too so the existing line_cap_ field finally
-// reaches the GPU paint — matches Canvas2D ctx.lineCap semantics.
+// Apply sticky stroke-paint state. Stroke paths construct an SkPaint via
+// make_stroke_paint(), then this helper propagates JS-side line_join,
+// miter_limit, and line_cap_ state to match Canvas2D stroke semantics.
 void SkiaCanvas::apply_stroke_state(SkPaint& paint) const {
     SkPaint::Cap sk_cap = SkPaint::kButt_Cap;
     switch (line_cap_) {
@@ -621,15 +588,15 @@ void SkiaCanvas::apply_stroke_state(SkPaint& paint) const {
     }
     paint.setStrokeJoin(sk_join);
     paint.setStrokeMiter(miter_limit_);
-    // pulp #1434 bridge-thin gap-fill — Canvas2D ctx.createPattern on
-    // strokeStyle. Wins over the solid stroke colour when present.
+    // Canvas2D ctx.createPattern on strokeStyle wins over the solid stroke
+    // colour when present.
     if (stroke_shader_) {
         paint.setShader(stroke_shader_);
     }
 }
 
-// pulp #1434 bridge-thin gap-fill — translate Canvas2D
-// imageSmoothingEnabled / imageSmoothingQuality into Skia sampling.
+// Translate Canvas2D imageSmoothingEnabled / imageSmoothingQuality into Skia
+// sampling.
 // `enabled = false` => nearest (pixel-art preservation). `enabled = true`
 // honours the quality enum: low = bilinear (matches the existing default),
 // medium = mipmap-aware bilinear, high = cubic Mitchell. Falls through
@@ -655,13 +622,10 @@ void SkiaCanvas::fill_rect(float x, float y, float w, float h) {
     GUARD_CANVAS; canvas_->drawRect(SkRect::MakeXYWH(x, y, w, h), current_fill_paint());
 }
 
-// pulp #929 — clearRect must actually clear pixels rather than compose a
+// clearRect must actually clear pixels rather than compose a
 // transparent SrcOver fill (which is a visual no-op). Use SkBlendMode::kClear
 // so the destination texels become transparent black, mirroring the HTML
-// CanvasRenderingContext2D.clearRect semantics. Without this, the canvas
-// widget sat over whatever the parent had previously painted (or the
-// undefined swapchain-texture pixels), which on FilterBank looked like a
-// stuck white inner area.
+// CanvasRenderingContext2D.clearRect semantics.
 void SkiaCanvas::clear_rect(float x, float y, float w, float h) {
     GUARD_CANVAS;
     SkPaint paint;
@@ -670,7 +634,7 @@ void SkiaCanvas::clear_rect(float x, float y, float w, float h) {
     canvas_->drawRect(SkRect::MakeXYWH(x, y, w, h), paint);
 }
 
-// Apply the active line-dash pattern to a stroke paint (issue-916).
+// Apply the active line-dash pattern to a stroke paint.
 // Skia's SkDashPathEffect requires an even-length pattern with
 // nonnegative entries; the JS bridge ensures both, so we treat any
 // validation failure as "no dash" rather than silently dropping it.
@@ -773,7 +737,7 @@ void SkiaCanvas::set_font_full(const std::string& family, float size,
     letter_spacing_ = letter_spacing;
 }
 
-// pulp #1737 — capture OpenType feature flags (e.g. tnum / smcp) for
+// Capture OpenType feature flags (e.g. tnum / smcp) for
 // SkShaper's 8-arg shape() overload. Empty vector clears the active
 // features. Per-feature semantics:
 //   value = 0 → disable the feature
@@ -812,7 +776,7 @@ bool SkiaCanvas::draw_image_from_data(const uint8_t* data, size_t size,
     if (!image) return false;
     image = ensure_gpu_image(std::move(image));
 
-    // pulp #1434 — honour the sticky imageSmoothingEnabled / Quality state.
+    // Honour the sticky imageSmoothingEnabled / Quality state.
     canvas_->drawImageRect(image, SkRect::MakeXYWH(x, y, w, h),
                            sampling_options_for_image_smoothing());
     return true;
@@ -829,7 +793,7 @@ bool SkiaCanvas::draw_image_from_file(const std::string& path,
     if (!image) return false;
     image = ensure_gpu_image(std::move(image));
 
-    // pulp #1434 — honour the sticky imageSmoothingEnabled / Quality state.
+    // Honour the sticky imageSmoothingEnabled / Quality state.
     canvas_->drawImageRect(image, SkRect::MakeXYWH(x, y, w, h),
                            sampling_options_for_image_smoothing());
     return true;
@@ -864,7 +828,7 @@ bool SkiaCanvas::draw_skia_image(const sk_sp<SkImage>& image,
     return true;
 }
 
-// pulp #1737 — 9-arg drawImage source-rect form. Skia's drawImageRect has
+// 9-arg drawImage source-rect form. Skia's drawImageRect has
 // a four-rect overload that maps `src` (in image coords) onto `dst` (in
 // canvas coords) with the active sampling. Used by sprite-sheet slicing.
 bool SkiaCanvas::draw_image_from_data_rect(const uint8_t* data, size_t size,
@@ -907,7 +871,7 @@ bool SkiaCanvas::draw_image_from_file_rect(const std::string& path,
     return true;
 }
 
-// pulp #1737 — peek-only image dimensions for ImageView object-fit /
+// Peek-only image dimensions for ImageView object-fit /
 // object-position layout. Decode is deferred until first paint, so this
 // just builds the SkImage header to read width()/height() — Skia caches
 // the SkImageInfo so the next draw_image_from_file in the same paint
@@ -928,7 +892,7 @@ bool SkiaCanvas::measure_image_from_file(const std::string& path,
 
 // ── Blend modes ─────────────────────────────────────────────────────────────
 
-// pulp #1549 — shared canvas BlendMode -> SkBlendMode lookup. Used by
+// Shared canvas BlendMode -> SkBlendMode lookup. Used by
 // set_blend_mode() and save_layer_with_blend() so the two paths can never
 // drift on the keyword set.
 static SkBlendMode skia_blend_mode_for(Canvas::BlendMode mode) {
@@ -961,7 +925,7 @@ static SkBlendMode skia_blend_mode_for(Canvas::BlendMode mode) {
 void SkiaCanvas::set_blend_mode(BlendMode mode) {
     // Indices 0..15 — advanced/W3C blend modes (must stay in sync with
     // canvas.hpp BlendMode enum).
-    // Indices 16..26 — Porter-Duff compositing modes (issue-896).
+    // Indices 16..26 — Porter-Duff compositing modes.
     blend_mode_ = skia_blend_mode_for(mode);
 }
 
@@ -991,7 +955,7 @@ void SkiaCanvas::close_path() {
     if (path_builder_) path_builder_->close();
 }
 
-// ── pulp #1521 — native arc / arcTo / ellipse / roundRect path builders ──
+// ── Native arc / arcTo / ellipse / roundRect path builders ───────────────────
 //
 // Replaces the JS shim's bezier approximation with Skia's native arc APIs.
 // Skia ships a closed-form arc-to-cubic implementation behind SkPath::arcTo;
@@ -1092,13 +1056,11 @@ void SkiaCanvas::ellipse(float cx, float cy, float rx, float ry,
     SkPath rotated = tmp.detach();
     // Append rotated path into the live builder, preserving the current
     // subpath. kExtend connects the rotated arc's first point to the
-    // existing pen position with an implicit lineTo (matching CSS
-    // Canvas2D semantics for ellipse: "If the current point is not at
-    // the start of the arc, a straight line is added."). The earlier
-    // kAppend default replaced that with a moveTo, breaking contour
-    // continuity for fills (Codex #1616 P1 on #1556). When the builder
-    // is empty kExtend degrades to kAppend, so unrotated standalone
-    // ellipses still work.
+    // existing pen position with an implicit lineTo (matching CSS Canvas2D
+    // semantics for ellipse: "If the current point is not at the start of the
+    // arc, a straight line is added."). Do not use kAppend here: it emits a
+    // moveTo and breaks contour continuity for fills. When the builder is empty
+    // kExtend degrades to kAppend, so unrotated standalone ellipses still work.
     path_builder_->addPath(rotated, SkPath::kExtend_AddPathMode);
 }
 
@@ -1130,12 +1092,9 @@ void SkiaCanvas::fill_current_path(FillRule rule) {
     paint.setBlendMode(blend_mode_);
     apply_shadow_filter(paint);
     apply_filter(paint);
-    // pulp #1806 — snapshot, not detach. Canvas2D spec: `ctx.fill()` and
-    // `ctx.stroke()` paint the scratch path WITHOUT consuming it. A
-    // subsequent `stroke()` on the same path must produce the outlined
-    // version of the filled shape. `detach()` was leaving the builder
-    // empty, so any caller doing `fill → stroke` (SvgPathWidget compound
-    // paths, common JS canvas idiom) silently dropped the second op.
+    // Snapshot, not detach. Canvas2D spec: `ctx.fill()` and `ctx.stroke()` paint
+    // the scratch path without consuming it. A subsequent `stroke()` on the same
+    // path must produce the outlined version of the filled shape.
     // Stamp the JS-supplied fillRule (`ctx.fill('evenodd')`) onto the
     // snapshot so Skia honours it when computing the filled area;
     // default 'nonzero' keeps the SkPathFillType::kWinding behaviour.
@@ -1158,7 +1117,7 @@ void SkiaCanvas::stroke_current_path() {
     apply_line_dash(paint, line_dash_, line_dash_phase_);
     apply_shadow_filter(paint);
     apply_filter(paint);
-    // pulp #1806 — snapshot (preserve), not detach. See fill_current_path.
+    // Snapshot (preserve), not detach. See fill_current_path.
     canvas_->drawPath(path_builder_->snapshot(), paint);
 }
 

--- a/tools/scripts/hotspot_size_guard.json
+++ b/tools/scripts/hotspot_size_guard.json
@@ -167,7 +167,7 @@
     },
     {
       "path": "core/canvas/src/skia_canvas.cpp",
-      "max_loc": 1197,
+      "max_loc": 1136,
       "note": "Skia canvas split stabilization candidate"
     }
   ]


### PR DESCRIPTION
## Summary
- remove issue/phase/Wave/Codex/repro archaeology from the Skia canvas implementation and header comments
- fix stale/misplaced comments while preserving current Skia/Canvas2D rationale for fonts, masks, transforms, fill rules, shadows, image smoothing, blend modes, paths, gradients, and text rendering
- lower the hotspot ceiling for `core/canvas/src/skia_canvas.cpp` after the comment cleanup shrank the file from 1177 to 1136 LOC

## Review
- RepoPrompt pre-edit review identified a stale font-cache contract, an orphaned splitter comment, brittle restore line anchors, and the line-oriented cleanup plan
- RepoPrompt final review: Clean; confirmed comment-only diff, fixed `current_stroke_paint()` stale reference, no remaining in-scope archaeology, no lost load-bearing rationale
- Claude adversarial review: Clean; mechanically verified code prefixes for inline-comment edits and found no behavior changes or inaccurate comments

## Validation
- targeted archaeology grep over `skia_canvas.cpp` and `skia_canvas.hpp`: clean
- normalized comment-stripped comparison against `HEAD`: clean
- `git diff --check`: clean
- `python3 tools/scripts/docs_noise_lint.py --mode=report`: clean
- `tools/scripts/gates.sh origin/main`: pass
- pre-push gates with `PULP_SKIP_DIFF_COVER=1 PULP_VIA_SHIPYARD=1 git push`: pass

Version-Bump: sdk=skip reason="comment-only Skia canvas hygiene"
Skill-Update: skip skill=ci reason="hotspot ceiling reduction only"


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up outdated, issue-specific comments in the Skia canvas backend while preserving current rationale; no behavior changes. Reduced `skia_canvas.cpp` LOC and lowered the hotspot ceiling accordingly.

- **Refactors**
  - Removed archaeology and clarified comments in `core/canvas/include/pulp/canvas/skia_canvas.hpp` and `core/canvas/src/skia_canvas.cpp` (fonts, masks, gradients, shadows, transforms, fill rules, image smoothing, blend modes, paths, text).
  - Fixed a stale comment to reference `apply_shadow_filter()` and made terminology consistent.
  - Updated `tools/scripts/hotspot_size_guard.json` to set `core/canvas/src/skia_canvas.cpp` `max_loc` to 1136.

<sup>Written for commit 11ac7f44f6c93346a719deff62453c3cf677950c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

