### PR TITLE
docs: clean waveform editor comment archaeology

### DIFF
--- a/core/view/include/pulp/view/waveform_editor.hpp
+++ b/core/view/include/pulp/view/waveform_editor.hpp
@@ -26,7 +26,7 @@ struct WaveformRegion {
 
 /// Interactive waveform editor for audio file editing and sample selection.
 ///
-/// Extends WaveformView with:
+/// Provides:
 /// - Click-drag selection
 /// - Zoom in/out (horizontal)
 /// - Scroll (horizontal)
@@ -232,7 +232,7 @@ public:
         if (event.key == KeyCode::left) { scroll(-visible_length() / 10); return true; }
         if (event.key == KeyCode::right) { scroll(visible_length() / 10); return true; }
 
-        // +/- for zoom
+        // Main-modifier + 0 zooms to fit.
         if (event.key == KeyCode::num0 && event.isMainModifier()) { zoom_to_fit(); return true; }
 
         return false;
@@ -276,8 +276,8 @@ private:
 
 protected:
     // Viewport-aware sample<->pixel mapping, shared with subclasses so custom
-    // overlays (playheads, hit-testing) stay aligned with the rendered waveform
-    // under zoom/scroll. (PulpTempoSampler's WaveformDropView uses these.)
+    // overlays (playheads, hit-testing, drag targets) stay aligned with the
+    // rendered waveform under zoom/scroll.
     WaveformViewport viewport_for_bounds(const Rect& b) const {
         auto viewport = viewport_;
         viewport.set_bounds(b);

--- a/test/test_waveform_editor.cpp
+++ b/test/test_waveform_editor.cpp
@@ -245,7 +245,7 @@ TEST_CASE("WaveformEditor regions", "[view][waveform_editor]") {
     REQUIRE(editor.regions().empty());
 }
 
-TEST_CASE("WaveformRegion reports signed length", "[view][waveform_editor][coverage][phase3]") {
+TEST_CASE("WaveformRegion reports signed length", "[view][waveform_editor]") {
     WaveformRegion forward{100, 180, "Forward"};
     REQUIRE(forward.length() == 80);
 
@@ -253,7 +253,7 @@ TEST_CASE("WaveformRegion reports signed length", "[view][waveform_editor][cover
     REQUIRE(reversed.length() == -70);
 }
 
-TEST_CASE("WaveformEditor paint skips empty audio", "[view][waveform_editor][coverage][phase3]") {
+TEST_CASE("WaveformEditor paint skips empty audio", "[view][waveform_editor]") {
     WaveformEditor editor;
     editor.set_bounds({0, 0, 400, 150});
 
@@ -333,7 +333,7 @@ TEST_CASE("WaveformEditor key scrolls and release events are ignored", "[view][w
     REQUIRE(editor.visible_start() == 200);
 }
 
-TEST_CASE("WaveformEditor key Cmd+0 zooms to fit", "[view][waveform_editor][coverage][phase3]") {
+TEST_CASE("WaveformEditor key Cmd+0 zooms to fit", "[view][waveform_editor]") {
     WaveformEditor editor;
     auto data = make_sine(1000);
     editor.set_audio_data(data.data(), 1000, 44100.0f);
@@ -386,7 +386,7 @@ TEST_CASE("WaveformEditor mouse click and shift extend selection", "[view][wavef
     REQUIRE(cb_end == 500);
 }
 
-TEST_CASE("WaveformEditor mouse drag extends selection and release finalizes", "[view][waveform_editor][coverage][phase3]") {
+TEST_CASE("WaveformEditor mouse drag extends selection and release finalizes", "[view][waveform_editor]") {
     WaveformEditor editor;
     auto data = make_sine(1000);
     editor.set_audio_data(data.data(), 1000, 44100.0f);


### PR DESCRIPTION
## Summary
- replace stale WaveformEditor public-header prose that referenced the wrong base type
- update a misleading zoom comment to match Cmd/Ctrl+0 zoom-to-fit behavior
- remove old `[coverage][phase3]` campaign tags from waveform editor tests while keeping semantic `[view][waveform_editor]` grouping
- generalize a named downstream-consumer parenthetical into stable overlay/drag-target rationale

## Validation
- RepoPrompt pre-edit adversarial review
- RepoPrompt post-edit adversarial review: Clean
- Claude adversarial review: Clean
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target pulp-test-waveform-editor`
- `build/test/pulp-test-waveform-editor` (275 assertions in 42 test cases)
- pre-push cheap gates + 29 Python tests

## Notes
- The selector grep across `.github`, `.shipyard`, `ci`, `CMakeLists.txt`, `test/CMakeLists.txt`, `tools/scripts`, `tools/import-validation`, and `tools/local-ci` found no CI/script dependency on `[coverage]` or `[phase3]` tags.
- Diff-coverage build was skipped on push with `PULP_SKIP_DIFF_COVER=1`; this slice changes comments and Catch2 tags only, and the focused waveform editor binary was run locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clean up WaveformEditor docs and test tags to match current behavior.
Replaced the stale base-type reference and clarified the feature list, updated the zoom comment to reflect Cmd/Ctrl+0 (Main-modifier + 0) zoom-to-fit, generalized the overlay/drag-target rationale, and removed old `[coverage][phase3]` tags while keeping `[view][waveform_editor]`.

<sup>Written for commit da6b2fbf669b7ff0902aed31f4d95c285c495433. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

