### PR TITLE
docs: clean runtime stream comment archaeology

### DIFF
--- a/.agents/skills/streams/SKILL.md
+++ b/.agents/skills/streams/SKILL.md
@@ -109,7 +109,7 @@ To add WebSocket, S3, or any other transport:
    document it so callers know to always wrap in `AsyncStream` with
    `auto_read = true`.
 
-## Message channels (Phase 4)
+## Message channels
 
 `MessageChannel` is the structured-message layer: one `send()` = one
 delivered message. Use it when the peer protocol doesn't tolerate
@@ -139,4 +139,4 @@ Patterns that are easy to get wrong:
 - Example: `examples/stream-demo/main.cpp`
 - Tests: `test/test_{stream,async_stream,network_stream,websocket_channel,osc_channel,json_rpc}.cpp` — copy these
   patterns for new transport tests
-- Feature plan: `planning/next-features-plan.md` § Feature 3 (Phase 1–4 landed)
+- Feature plan: `planning/next-features-plan.md` stream feature background

--- a/core/runtime/include/pulp/runtime/network_stream.hpp
+++ b/core/runtime/include/pulp/runtime/network_stream.hpp
@@ -56,9 +56,8 @@ private:
 /// buffer; `status_code()` and `headers()` are available once construction
 /// completes.
 ///
-/// HttpStream is currently read-only. Writing to an HttpStream is a
-/// Phase 4 feature (request-body streaming) and returns `Invalid` until
-/// then.
+/// HttpStream is currently read-only. Request bodies are provided up front
+/// by `post()`, so `write()` returns `Invalid`.
 class HttpStream : public Stream {
 public:
     struct Request {

--- a/core/runtime/src/async_stream.cpp
+++ b/core/runtime/src/async_stream.cpp
@@ -181,7 +181,7 @@ void AsyncStream::write_loop() {
 
         // Update accounting and collect drain callback under the lock; fire
         // it *outside* the lock so callers can re-enter write_async() from
-        // on_drain without deadlocking (issue #134 P1).
+        // on_drain without deadlocking.
         AsyncCloseCallback drain_cb;
         {
             std::lock_guard<std::mutex> lock(mutex_);

--- a/core/runtime/src/network_stream.cpp
+++ b/core/runtime/src/network_stream.cpp
@@ -126,8 +126,8 @@ StreamResult HttpStream::read(std::uint8_t* buffer, std::size_t size) {
 }
 
 StreamResult HttpStream::write(const std::uint8_t*, std::size_t) {
-    // HttpStream is read-only (response body). Request-body streaming is
-    // Phase 4 of the stream feature plan.
+    // HttpStream exposes response bodies as read-only streams; request bodies
+    // are provided up front by post().
     return StreamResult::fail(StreamError::Invalid);
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1149,15 +1149,15 @@ pulp_add_test_suite(pulp-test-ble-midi LIBRARIES pulp::midi)
 # suite runs on every platform via the virtual-endpoint half.
 pulp_add_test_suite(pulp-test-ump-session LIBRARIES pulp::midi)
 
-# AsyncStream tests (Phase 2)
+# AsyncStream tests
 pulp_add_test_suite(pulp-test-async-stream LIBRARIES pulp::runtime)
 
-# Network Stream tests (Phase 3)
+# Network Stream tests
 pulp_add_test_suite(pulp-test-network-stream
     LIBRARIES pulp::runtime pulp-cpp-httplib
     PROPERTIES RESOURCE_LOCK network-stream)
 
-# MessageChannel tests (Phase 4)
+# MessageChannel tests
 pulp_add_test_suite(pulp-test-memory-message-channel LIBRARIES pulp::runtime)
 
 pulp_add_test_suite(pulp-test-websocket-channel LIBRARIES pulp::runtime)

--- a/test/test_async_stream.cpp
+++ b/test/test_async_stream.cpp
@@ -232,7 +232,7 @@ TEST_CASE("AsyncStream cancel drains pending writes with Closed", "[async_stream
 }
 
 TEST_CASE("AsyncStream write on pre-closed stream completes without queuing",
-          "[async_stream][coverage][phase3]") {
+          "[async_stream][coverage]") {
     auto backing = std::make_unique<TestStream>();
     backing->close();
 
@@ -325,7 +325,7 @@ TEST_CASE("AsyncStream zero-byte write dispatches completion without worker", "[
 }
 
 TEST_CASE("AsyncStream rejects null non-empty writes via callback",
-          "[async_stream][coverage][phase3]") {
+          "[async_stream][coverage]") {
     auto backing = std::make_unique<TestStream>();
 
     AsyncStream::Options opts;
@@ -349,7 +349,7 @@ TEST_CASE("AsyncStream rejects null non-empty writes via callback",
 }
 
 TEST_CASE("AsyncStream start after stop refreshes cancellation state",
-          "[async_stream][coverage][phase3]") {
+          "[async_stream][coverage]") {
     auto backing = std::make_unique<TestStream>();
     auto* raw = backing.get();
 
@@ -381,7 +381,7 @@ TEST_CASE("AsyncStream start after stop refreshes cancellation state",
 }
 
 TEST_CASE("AsyncStream write on a closed backing stream completes without queueing",
-          "[async_stream][coverage][phase3]") {
+          "[async_stream][coverage]") {
     auto backing = std::make_unique<TestStream>();
     auto* raw = backing.get();
     raw->close();
@@ -409,7 +409,7 @@ TEST_CASE("AsyncStream write on a closed backing stream completes without queuei
 }
 
 TEST_CASE("AsyncStream write without a backing stream completes as closed",
-          "[async_stream][coverage][phase3]") {
+          "[async_stream][coverage]") {
     AsyncStream::Options opts;
     opts.auto_read = false;
     AsyncStream stream(nullptr, opts);
@@ -450,7 +450,7 @@ TEST_CASE("CancellationToken sharing and idempotent cancel", "[async_stream]") {
 }
 
 TEST_CASE("AsyncStream cancellation token mirrors stream cancellation",
-          "[async_stream][coverage][phase3]") {
+          "[async_stream][coverage]") {
     auto backing = std::make_unique<TestStream>();
     AsyncStream::Options opts;
     opts.auto_read = false;
@@ -505,7 +505,7 @@ TEST_CASE("AsyncStream executor routes callbacks off worker", "[async_stream]") 
 }
 
 TEST_CASE("AsyncStream repeated start and stop keep close callback single-shot",
-          "[async_stream][coverage][phase3]") {
+          "[async_stream][coverage]") {
     auto backing = std::make_unique<TestStream>();
 
     AsyncStream::Options opts;
@@ -527,7 +527,7 @@ TEST_CASE("AsyncStream repeated start and stop keep close callback single-shot",
 }
 
 TEST_CASE("AsyncStream retries WouldBlock and partial writes before draining",
-          "[async_stream][coverage][phase3]") {
+          "[async_stream][coverage]") {
     auto backing = std::make_unique<TestStream>();
     auto* raw = backing.get();
     raw->set_write_chunk_limit(2);
@@ -574,7 +574,7 @@ TEST_CASE("AsyncStream retries WouldBlock and partial writes before draining",
 }
 
 TEST_CASE("AsyncStream reports partial write errors and stops writer",
-          "[async_stream][coverage][phase3]") {
+          "[async_stream][coverage]") {
     auto backing = std::make_unique<TestStream>();
     auto* raw = backing.get();
     raw->set_write_chunk_limit(2);
@@ -615,7 +615,7 @@ TEST_CASE("AsyncStream reports partial write errors and stops writer",
 }
 
 TEST_CASE("AsyncStream read loop backs off on zero-byte reads before data",
-          "[async_stream][coverage][phase3]") {
+          "[async_stream][coverage]") {
     auto backing = std::make_unique<TestStream>();
     auto* raw = backing.get();
     raw->set_read_zero_ok_count(3);
@@ -644,7 +644,7 @@ TEST_CASE("AsyncStream read loop backs off on zero-byte reads before data",
 }
 
 TEST_CASE("AsyncStream read errors fire on_error and close fires once on stop",
-          "[async_stream][coverage][phase3]") {
+          "[async_stream][coverage]") {
     auto backing = std::make_unique<TestStream>();
     auto* raw = backing.get();
     raw->set_read_io_error(true);

--- a/test/test_memory_message_channel.cpp
+++ b/test/test_memory_message_channel.cpp
@@ -30,7 +30,7 @@ public:
 } // namespace
 
 TEST_CASE("MessageChannel default text send uses binary send",
-          "[runtime][message_channel][coverage][phase3]") {
+          "[runtime][message_channel][coverage]") {
     BinaryOnlyMessageChannel channel;
     MessageChannel& base = channel;
 
@@ -116,7 +116,7 @@ TEST_CASE("MemoryMessageChannel replaces message callbacks",
 }
 
 TEST_CASE("MemoryMessageChannel clears message callbacks",
-          "[runtime][message_channel][coverage][phase3]") {
+          "[runtime][message_channel][coverage]") {
     auto [left, right] = MemoryMessageChannel::make_pair();
 
     int deliveries = 0;
@@ -175,7 +175,7 @@ TEST_CASE("MemoryMessageChannel rejects nonempty null binary sends",
 }
 
 TEST_CASE("MemoryMessageChannel accepts empty null binary sends",
-          "[runtime][message_channel][coverage][phase3]") {
+          "[runtime][message_channel][coverage]") {
     auto [left, right] = MemoryMessageChannel::make_pair();
 
     std::vector<Message> received;
@@ -294,7 +294,7 @@ TEST_CASE("MemoryMessageChannel peer destruction closes the survivor",
 }
 
 TEST_CASE("MemoryMessageChannel close callback can send no further messages",
-          "[runtime][message_channel][coverage][phase3]") {
+          "[runtime][message_channel][coverage]") {
     auto [left, right] = MemoryMessageChannel::make_pair();
 
     int left_closed = 0;
@@ -313,7 +313,7 @@ TEST_CASE("MemoryMessageChannel close callback can send no further messages",
 }
 
 TEST_CASE("MemoryMessageChannel sender observes peer callback replacement during delivery",
-          "[runtime][message_channel][coverage][phase3]") {
+          "[runtime][message_channel][coverage]") {
     auto [left, right] = MemoryMessageChannel::make_pair();
 
     int first_calls = 0;
@@ -333,7 +333,7 @@ TEST_CASE("MemoryMessageChannel sender observes peer callback replacement during
 }
 
 TEST_CASE("MemoryMessageChannel supports reentrant replies during delivery",
-          "[runtime][message_channel][coverage][phase3]") {
+          "[runtime][message_channel][coverage]") {
     auto [left, right] = MemoryMessageChannel::make_pair();
 
     std::vector<std::string> seen;
@@ -350,7 +350,7 @@ TEST_CASE("MemoryMessageChannel supports reentrant replies during delivery",
 }
 
 TEST_CASE("MemoryMessageChannel self close does not invoke a late replacement callback",
-          "[runtime][message_channel][coverage][phase3]") {
+          "[runtime][message_channel][coverage]") {
     auto [left, right] = MemoryMessageChannel::make_pair();
 
     int closed = 0;

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -165,7 +165,7 @@ TEST_CASE("IPv4 validation rejects malformed addresses",
 }
 
 TEST_CASE("IPv4 validation rejects decorated dotted quads",
-          "[network_stream][ip-address][phase3]") {
+          "[network_stream][ip-address]") {
     REQUIRE_FALSE(is_valid_ipv4("127.0.0.1:80"));
     REQUIRE_FALSE(is_valid_ipv4("127.0.0.1/32"));
     REQUIRE_FALSE(is_valid_ipv4("127.0.0.1\n"));
@@ -174,7 +174,7 @@ TEST_CASE("IPv4 validation rejects decorated dotted quads",
 }
 
 TEST_CASE("IPv4 validation accepts private network examples",
-          "[network_stream][ip-address][phase3]") {
+          "[network_stream][ip-address]") {
     REQUIRE(is_valid_ipv4("10.0.0.1"));
     REQUIRE(is_valid_ipv4("172.16.0.1"));
     REQUIRE(is_valid_ipv4("192.168.0.1"));
@@ -182,7 +182,7 @@ TEST_CASE("IPv4 validation accepts private network examples",
 }
 
 TEST_CASE("IPv4 validation rejects non-canonical numeric address forms",
-          "[network_stream][ip-address][coverage][phase3]") {
+          "[network_stream][ip-address][coverage]") {
     REQUIRE_FALSE(is_valid_ipv4("127.1"));
     REQUIRE_FALSE(is_valid_ipv4("127.0.1"));
     REQUIRE_FALSE(is_valid_ipv4("0300.0250.0001.0001"));
@@ -191,7 +191,7 @@ TEST_CASE("IPv4 validation rejects non-canonical numeric address forms",
 }
 
 TEST_CASE("IPv4 validation accepts canonical public resolver examples",
-          "[network_stream][ip-address][coverage][phase3]") {
+          "[network_stream][ip-address][coverage]") {
     REQUIRE(is_valid_ipv4("1.1.1.1"));
     REQUIRE(is_valid_ipv4("8.8.8.8"));
     REQUIRE(is_valid_ipv4("9.9.9.9"));
@@ -397,7 +397,7 @@ TEST_CASE("TcpStream detects peer-close on the next read",
 // ── Socket edge cases ───────────────────────────────────────────────────
 
 TEST_CASE("Socket reports failures before create",
-          "[network_stream][socket][phase3]") {
+          "[network_stream][socket]") {
     Socket socket;
     std::array<std::uint8_t, 4> buffer{1, 2, 3, 4};
     std::string from = "unchanged";
@@ -417,7 +417,7 @@ TEST_CASE("Socket reports failures before create",
 }
 
 TEST_CASE("Socket create close and recreate toggles open state",
-          "[network_stream][socket][phase3]") {
+          "[network_stream][socket]") {
     Socket socket;
     REQUIRE(socket.create(SocketType::UDP));
     REQUIRE(socket.is_open());
@@ -432,7 +432,7 @@ TEST_CASE("Socket create close and recreate toggles open state",
 }
 
 TEST_CASE("UDP socket round-trips datagrams on loopback",
-          "[network_stream][socket][udp][phase3]") {
+          "[network_stream][socket][udp]") {
     Socket receiver;
     REQUIRE(receiver.create(SocketType::UDP));
     auto port = try_bind_udp(receiver, 45601);
@@ -458,7 +458,7 @@ TEST_CASE("UDP socket round-trips datagrams on loopback",
 }
 
 TEST_CASE("UDP bind accepts empty address as wildcard",
-          "[network_stream][socket][udp][phase3]") {
+          "[network_stream][socket][udp]") {
     Socket receiver;
     REQUIRE(receiver.create(SocketType::UDP));
     auto port = try_bind_udp(receiver, 45731, "");
@@ -482,7 +482,7 @@ TEST_CASE("UDP bind accepts empty address as wildcard",
 }
 
 TEST_CASE("UDP socket move construction transfers the descriptor",
-          "[network_stream][socket][udp][phase3]") {
+          "[network_stream][socket][udp]") {
     Socket receiver;
     REQUIRE(receiver.create(SocketType::UDP));
     auto port = try_bind_udp(receiver, 45861);
@@ -509,7 +509,7 @@ TEST_CASE("UDP socket move construction transfers the descriptor",
 }
 
 TEST_CASE("UDP socket move assignment transfers the descriptor",
-          "[network_stream][socket][udp][phase3]") {
+          "[network_stream][socket][udp]") {
     Socket receiver;
     REQUIRE(receiver.create(SocketType::UDP));
     auto port = try_bind_udp(receiver, 45991);
@@ -540,7 +540,7 @@ TEST_CASE("UDP socket move assignment transfers the descriptor",
 }
 
 TEST_CASE("UDP socket self move assignment preserves descriptor",
-          "[network_stream][socket][udp][phase3]") {
+          "[network_stream][socket][udp]") {
     Socket receiver;
     REQUIRE(receiver.create(SocketType::UDP));
     auto port = try_bind_udp(receiver, 46121);
@@ -567,7 +567,7 @@ TEST_CASE("UDP socket self move assignment preserves descriptor",
 }
 
 TEST_CASE("UDP socket rejects TCP-only listen and accept",
-          "[network_stream][socket][udp][phase3]") {
+          "[network_stream][socket][udp]") {
     Socket socket;
     REQUIRE(socket.create(SocketType::UDP));
     REQUIRE_FALSE(socket.listen());
@@ -575,7 +575,7 @@ TEST_CASE("UDP socket rejects TCP-only listen and accept",
 }
 
 TEST_CASE("TcpStream can wrap an accepted Socket",
-          "[network_stream][tcp][socket][phase3]") {
+          "[network_stream][tcp][socket]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
 
@@ -639,7 +639,7 @@ TEST_CASE("TcpStream can wrap an accepted Socket",
 }
 
 TEST_CASE("TcpStream zero-byte I/O succeeds while connected",
-          "[network_stream][tcp][phase3]") {
+          "[network_stream][tcp]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
 
@@ -687,7 +687,7 @@ TEST_CASE("TcpStream zero-byte I/O succeeds while connected",
 }
 
 TEST_CASE("TcpStream rejects null buffers while connected",
-          "[network_stream][tcp][coverage][phase3]") {
+          "[network_stream][tcp][coverage]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
 
@@ -724,7 +724,7 @@ TEST_CASE("TcpStream rejects null buffers while connected",
 // ── Socket edge cases ───────────────────────────────────────────────────
 
 TEST_CASE("Socket UDP loopback send_to receive_from reports peer address",
-          "[network_stream][socket][coverage][phase3]") {
+          "[network_stream][socket][coverage]") {
     Socket receiver;
     REQUIRE(receiver.create(SocketType::UDP));
     auto port = try_bind_udp_ephemeral(receiver);
@@ -748,7 +748,7 @@ TEST_CASE("Socket UDP loopback send_to receive_from reports peer address",
 }
 
 TEST_CASE("Socket UDP send_to and receive_from fail before create",
-          "[network_stream][socket][coverage][phase3]") {
+          "[network_stream][socket][coverage]") {
     Socket socket;
     std::array<std::uint8_t, 4> buffer{};
     std::string from_address = "unchanged";
@@ -761,7 +761,7 @@ TEST_CASE("Socket UDP send_to and receive_from fail before create",
 }
 
 TEST_CASE("Socket local_port reports bound UDP ephemeral port",
-          "[network_stream][socket][coverage][phase3]") {
+          "[network_stream][socket][coverage]") {
     Socket socket;
     REQUIRE(socket.local_port() == 0);
     REQUIRE(socket.create(SocketType::UDP));
@@ -771,7 +771,7 @@ TEST_CASE("Socket local_port reports bound UDP ephemeral port",
 }
 
 TEST_CASE("Socket TCP loopback send receive and close",
-          "[network_stream][socket][coverage][phase3]") {
+          "[network_stream][socket][coverage]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
 
@@ -815,7 +815,7 @@ TEST_CASE("Socket TCP loopback send receive and close",
 }
 
 TEST_CASE("Socket move construction transfers open UDP handle",
-          "[network_stream][socket][coverage][phase3]") {
+          "[network_stream][socket][coverage]") {
     Socket original;
     REQUIRE(original.create(SocketType::UDP));
     REQUIRE(original.is_open());
@@ -829,7 +829,7 @@ TEST_CASE("Socket move construction transfers open UDP handle",
 }
 
 TEST_CASE("Socket move assignment closes old handle and adopts new one",
-          "[network_stream][socket][coverage][phase3]") {
+          "[network_stream][socket][coverage]") {
     Socket old_socket;
     REQUIRE(old_socket.create(SocketType::UDP));
     REQUIRE(old_socket.bind("127.0.0.1", 0));
@@ -877,7 +877,7 @@ TEST_CASE("HttpStream status_code is 0 before fetch",
 }
 
 TEST_CASE("HttpStream reads a successful local response body in chunks",
-          "[network_stream][http][coverage][phase3]") {
+          "[network_stream][http][coverage]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
     auto port = try_bind_loopback_ephemeral(listener);
@@ -936,7 +936,7 @@ TEST_CASE("HttpStream reads a successful local response body in chunks",
 }
 
 TEST_CASE("http_get defaults missing URL path to slash",
-          "[network_stream][http][coverage][phase3]") {
+          "[network_stream][http][coverage]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
     auto port = try_bind_loopback_ephemeral(listener);
@@ -973,7 +973,7 @@ TEST_CASE("http_get defaults missing URL path to slash",
 }
 
 TEST_CASE("HttpStream post factory reads a successful local response",
-          "[network_stream][http][coverage][phase3]") {
+          "[network_stream][http][coverage]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
     auto port = try_bind_loopback_ephemeral(listener);
@@ -1019,7 +1019,7 @@ TEST_CASE("HttpStream post factory reads a successful local response",
 }
 
 TEST_CASE("http_download writes a successful local response to disk",
-          "[network_stream][http][coverage][phase3]") {
+          "[network_stream][http][coverage]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
     auto port = try_bind_loopback_ephemeral(listener);
@@ -1064,7 +1064,7 @@ TEST_CASE("http_download writes a successful local response to disk",
 }
 
 TEST_CASE("HttpStream default state supports zero reads and idempotent close",
-          "[network_stream][http][coverage][phase3]") {
+          "[network_stream][http][coverage]") {
     HttpStream stream;
     REQUIRE_FALSE(stream.is_open());
     REQUIRE(stream.eof());
@@ -1090,7 +1090,7 @@ TEST_CASE("HttpStream default state supports zero reads and idempotent close",
 }
 
 TEST_CASE("HttpStream rejects null read buffers before transport errors",
-          "[network_stream][http][coverage][phase3]") {
+          "[network_stream][http][coverage]") {
     HttpStream::Request req;
     req.url = "ftp://127.0.0.1/nope";
     req.timeout_seconds = 1;
@@ -1134,7 +1134,7 @@ TEST_CASE("HttpStream factories and refetch reset closed state to request result
 }
 
 TEST_CASE("http helpers reject invalid explicit ports",
-          "[network_stream][http][coverage][phase3]") {
+          "[network_stream][http][coverage]") {
     const auto zero_port = http_get("http://127.0.0.1:0/path", 1);
     REQUIRE(zero_port.status_code == 0);
     REQUIRE(zero_port.body.empty());
@@ -1159,7 +1159,7 @@ TEST_CASE("http helpers reject invalid explicit ports",
 }
 
 TEST_CASE("http helpers parse default ports without explicit port text",
-          "[network_stream][http][coverage][phase3]") {
+          "[network_stream][http][coverage]") {
     const auto default_http = http_get("http://127.0.0.1", 1);
     REQUIRE(default_http.body.find('\0') == std::string::npos);
     REQUIRE(default_http.error.find('\0') == std::string::npos);
@@ -1177,7 +1177,7 @@ TEST_CASE("http helpers parse default ports without explicit port text",
 }
 
 TEST_CASE("http_post reports connection failure on refused loopback port",
-          "[network_stream][http][coverage][phase3]") {
+          "[network_stream][http][coverage]") {
     const auto response = http_post("http://127.0.0.1:1/post",
                                     R"({"ok":false})",
                                     "application/json",
@@ -1190,7 +1190,7 @@ TEST_CASE("http_post reports connection failure on refused loopback port",
 }
 
 TEST_CASE("HttpResponse ok accepts only successful status codes",
-          "[network_stream][http][coverage][phase3]") {
+          "[network_stream][http][coverage]") {
     HttpResponse response;
     response.status_code = 199;
     REQUIRE_FALSE(response.ok());
@@ -1205,7 +1205,7 @@ TEST_CASE("HttpResponse ok accepts only successful status codes",
 }
 
 TEST_CASE("http_download returns false for non-ok responses and unwritable paths",
-          "[network_stream][http][coverage][phase3]") {
+          "[network_stream][http][coverage]") {
     REQUIRE_FALSE(http_download("http://127.0.0.1:0/artifact",
                                 (std::filesystem::temp_directory_path() /
                                  "pulp-invalid-download.bin").string(),
@@ -1244,7 +1244,7 @@ TEST_CASE("http_download returns false for non-ok responses and unwritable paths
 }
 
 TEST_CASE("HttpStream reads successful GET responses in chunks",
-          "[network_stream][http][coverage][phase3]") {
+          "[network_stream][http][coverage]") {
     httplib::Server server;
     server.Get("/__ready", [](const httplib::Request&, httplib::Response& response) {
         response.status = 204;
@@ -1288,7 +1288,7 @@ TEST_CASE("HttpStream reads successful GET responses in chunks",
 }
 
 TEST_CASE("HttpStream POST factory exposes successful response bodies",
-          "[network_stream][http][coverage][phase3]") {
+          "[network_stream][http][coverage]") {
     httplib::Server server;
     server.Get("/__ready", [](const httplib::Request&, httplib::Response& response) {
         response.status = 204;


### PR DESCRIPTION
## Summary
- remove stale phase/issue breadcrumbs from runtime stream comments
- remove `[phase3]` workflow tags from async/network/message-channel Catch tests while preserving functional grouping tags
- update stream test CMake headings and the streams skill wording to use stable names instead of phase markers

## Validation
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target pulp-test-async-stream pulp-test-network-stream pulp-test-memory-message-channel -j$(sysctl -n hw.ncpu)`
- `build/test/pulp-test-async-stream`
- `build/test/pulp-test-network-stream`
- `build/test/pulp-test-memory-message-channel`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main --prompt ...`

## Review
- RepoPrompt MCP tools were requested for analysis but were not exposed in this Codex tool session; tool discovery returned no RepoPrompt tools. Scope was selected from live repo/PR/search evidence instead.
- Claude/autoreview returned clean: no accepted/actionable findings reported.

## Notes
- `origin/main` was refreshed before validation and remained at `d26f94f8a53cd177d1595eed0e1bc53668f9abcc`.
- This was a fresh worktree; the first configure/build spent most of its time on CMake dependency setup and runtime test prerequisites.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale phase/issue breadcrumbs from runtime stream comments and tests, switching to stable names. Clarifies `HttpStream` write behavior; functional test tags remain; no behavior changes.

- **Refactors**
  - Stripped `[phase3]` from Catch tags in `async_stream`, `network_stream`, and `message_channel` tests; kept functional tags like `[coverage]` and `[tcp]`.
  - Replaced "Phase N" labels in test `CMakeLists.txt` with stable suite names.
  - Updated `HttpStream` comments to state the stream is read-only and `write()` returns `Invalid`; request bodies are provided via `post()`.
  - Removed stale issue reference from an `AsyncStream` drain comment.
  - Simplified `.agents/skills/streams/SKILL.md` by dropping phase labels and using stable stream feature wording.

<sup>Written for commit fd3ff7c258fa63ddb822da8601b9ee534edac0dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

