### PR TITLE
docs: clean runtime message protocol comment archaeology

### DIFF
--- a/core/runtime/include/pulp/runtime/websocket_channel.hpp
+++ b/core/runtime/include/pulp/runtime/websocket_channel.hpp
@@ -2,7 +2,7 @@
 
 // WebSocketChannel — RFC 6455 MessageChannel over TcpStream.
 //
-// Scope (Phase 4 of the Stream feature plan):
+// Scope:
 //   - Client handshake: `Upgrade: websocket`, Sec-WebSocket-Key / Accept
 //     validation (SHA-1 + base64 via pulp::runtime::crypto).
 //   - Server handshake: parse client upgrade, echo a 101 Switching

--- a/core/runtime/src/json_rpc.cpp
+++ b/core/runtime/src/json_rpc.cpp
@@ -112,8 +112,8 @@ void JsonRpcPeer::handle_message(const Message& msg) {
     std::string_view text(
         reinterpret_cast<const char*>(msg.payload.data()),
         msg.payload.size());
-    // JSON-RPC supports batching (top-level array) but we accept only
-    // single objects for Phase 4. A simple sniff: find first non-space.
+    // JSON-RPC supports batching (top-level array), but this peer accepts
+    // only single objects. A simple sniff finds the first non-space byte.
     std::size_t i = 0;
     while (i < text.size() && std::isspace(static_cast<unsigned char>(text[i]))) ++i;
     if (i >= text.size()) return;

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -61,8 +61,7 @@ TEST_CASE("JsonRpcPeer request/response over an in-memory channel", "[json_rpc]"
 
     server.register_method("add", [](std::string_view params) {
         // params is expected to be a JSON array like [2,3]
-        // For the Phase 4 smoke test we just echo back a sum of two ints
-        // via a trivial regex-free parse.
+        // Echo back a sum of two ints via a trivial regex-free parse.
         int a = 0, b = 0;
         std::sscanf(std::string(params).c_str(), "[%d,%d]", &a, &b);
         return JsonRpcResult::ok(std::to_string(a + b));
@@ -87,7 +86,7 @@ TEST_CASE("JsonRpcPeer request/response over an in-memory channel", "[json_rpc]"
 }
 
 TEST_CASE("JsonRpcError factories expose spec codes and messages",
-          "[json_rpc][coverage][phase3]") {
+          "[json_rpc][coverage]") {
     const auto parse = JsonRpcError::parse_error();
     const auto invalid = JsonRpcError::invalid_request();
     const auto params = JsonRpcError::invalid_params();
@@ -105,7 +104,7 @@ TEST_CASE("JsonRpcError factories expose spec codes and messages",
 }
 
 TEST_CASE("JsonRpcResult factories separate success payloads from failures",
-          "[json_rpc][coverage][phase3]") {
+          "[json_rpc][coverage]") {
     const auto ok = JsonRpcResult::ok(R"({"ready":true})");
     REQUIRE(ok.result_json == R"({"ready":true})");
     REQUIRE_FALSE(ok.error.has_value());
@@ -174,7 +173,7 @@ TEST_CASE("JsonRpcPeer fires notification handler and expects no response", "[js
 }
 
 TEST_CASE("JsonRpcPeer delivers empty notification params when omitted",
-          "[json_rpc][coverage][phase3]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
     JsonRpcPeer server(*pair.second);
 
@@ -246,7 +245,7 @@ TEST_CASE("JsonRpcPeer unregisters methods and notifications", "[json_rpc]") {
 }
 
 TEST_CASE("JsonRpcPeer preserves string request ids and omits missing params",
-          "[json_rpc][coverage][phase3]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string reply;
@@ -270,7 +269,7 @@ TEST_CASE("JsonRpcPeer preserves string request ids and omits missing params",
 }
 
 TEST_CASE("JsonRpcPeer destruction clears the channel message callback",
-          "[json_rpc][coverage][phase3]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string reply;
@@ -391,7 +390,7 @@ TEST_CASE("JsonRpcPeer reports closed and failed sends", "[json_rpc]") {
 }
 
 TEST_CASE("JsonRpcPeer rejects sends after direct channel close",
-          "[json_rpc][coverage][phase3-batch742]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
     JsonRpcPeer client(*pair.first);
 
@@ -406,7 +405,7 @@ TEST_CASE("JsonRpcPeer rejects sends after direct channel close",
 }
 
 TEST_CASE("JsonRpcPeer destructor detaches its message callback",
-          "[json_rpc][coverage][phase3-batch742]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
     std::string reply;
     pair.second->on_message([&](const Message& message) {
@@ -422,7 +421,7 @@ TEST_CASE("JsonRpcPeer destructor detaches its message callback",
 }
 
 TEST_CASE("JsonRpcPeer omits params for empty request payloads",
-          "[json_rpc][coverage][issue-641]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string outbound_request;
@@ -448,7 +447,7 @@ TEST_CASE("JsonRpcPeer omits params for empty request payloads",
 }
 
 TEST_CASE("JsonRpcPeer preserves string request ids in responses",
-          "[json_rpc][coverage][issue-641]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string reply;
@@ -470,7 +469,7 @@ TEST_CASE("JsonRpcPeer preserves string request ids in responses",
 }
 
 TEST_CASE("JsonRpcPeer dispatches incoming error responses with data",
-          "[json_rpc][coverage][issue-641]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string outbound_request;
@@ -500,7 +499,7 @@ TEST_CASE("JsonRpcPeer dispatches incoming error responses with data",
 }
 
 TEST_CASE("JsonRpcPeer defaults missing incoming error fields",
-          "[json_rpc][coverage][phase3]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string outbound_request;
@@ -528,7 +527,7 @@ TEST_CASE("JsonRpcPeer defaults missing incoming error fields",
 }
 
 TEST_CASE("JsonRpcPeer replies to null id requests and notification gaps",
-          "[json_rpc][coverage][phase3]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::vector<std::string> replies;
@@ -554,7 +553,7 @@ TEST_CASE("JsonRpcPeer replies to null id requests and notification gaps",
 }
 
 TEST_CASE("JsonRpcPeer rejects requests with non-string method names",
-          "[json_rpc][coverage][phase3]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::vector<std::string> replies;
@@ -579,7 +578,7 @@ TEST_CASE("JsonRpcPeer rejects requests with non-string method names",
 }
 
 TEST_CASE("JsonRpcPeer ignores notifications with non-string method names",
-          "[json_rpc][coverage][phase3]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::vector<std::string> replies;
@@ -601,7 +600,7 @@ TEST_CASE("JsonRpcPeer ignores notifications with non-string method names",
 }
 
 TEST_CASE("JsonRpcPeer unregisters a replacement handler cleanly",
-          "[json_rpc][coverage][phase3]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
     JsonRpcPeer client(*pair.first);
     JsonRpcPeer server(*pair.second);
@@ -634,7 +633,7 @@ TEST_CASE("JsonRpcPeer unregisters a replacement handler cleanly",
 }
 
 TEST_CASE("JsonRpcPeer ignores malformed response payloads without firing callbacks",
-          "[json_rpc][coverage][phase3]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string outbound_request;
@@ -659,7 +658,7 @@ TEST_CASE("JsonRpcPeer ignores malformed response payloads without firing callba
 }
 
 TEST_CASE("JsonRpcPeer forwards scalar and object params unchanged",
-          "[json_rpc][coverage][phase3-large]") {
+          "[json_rpc][coverage][large]") {
     auto pair = MemoryMessageChannel::make_pair();
     JsonRpcPeer client(*pair.first);
     JsonRpcPeer server(*pair.second);
@@ -690,7 +689,7 @@ TEST_CASE("JsonRpcPeer forwards scalar and object params unchanged",
 }
 
 TEST_CASE("JsonRpcPeer ignores inert objects and unknown notifications without replies",
-          "[json_rpc][coverage][phase3-large]") {
+          "[json_rpc][coverage][large]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::vector<std::string> replies;
@@ -708,7 +707,7 @@ TEST_CASE("JsonRpcPeer ignores inert objects and unknown notifications without r
 }
 
 TEST_CASE("JsonRpcPeer rejects invalid request envelopes before dispatch",
-          "[json_rpc][coverage][phase3][batch-704]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::vector<std::string> replies;
@@ -737,7 +736,7 @@ TEST_CASE("JsonRpcPeer rejects invalid request envelopes before dispatch",
 }
 
 TEST_CASE("JsonRpcPeer destructor releases the channel callback",
-          "[json_rpc][coverage][phase3]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string reply;
@@ -770,7 +769,7 @@ TEST_CASE("JsonRpcPeer destructor releases the channel callback",
 }
 
 TEST_CASE("JsonRpcPeer consumes pending callbacks after the first response",
-          "[json_rpc][coverage][phase3]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string outbound_request;
@@ -816,7 +815,7 @@ TEST_CASE("JsonRpcPeer destructor clears the channel message callback",
 }
 
 TEST_CASE("JsonRpcPeer tolerates sparse error responses",
-          "[json_rpc][coverage][phase3]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string outbound_request;
@@ -844,7 +843,7 @@ TEST_CASE("JsonRpcPeer tolerates sparse error responses",
 }
 
 TEST_CASE("JsonRpcPeer notification handlers replace and clear cleanly",
-          "[json_rpc][coverage][phase3]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
     JsonRpcPeer client(*pair.first);
     JsonRpcPeer server(*pair.second);
@@ -873,7 +872,7 @@ TEST_CASE("JsonRpcPeer notification handlers replace and clear cleanly",
 }
 
 TEST_CASE("JsonRpcPeer destructor clears the channel message handler",
-          "[json_rpc][coverage][phase3]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::vector<std::string> replies;
@@ -900,7 +899,7 @@ TEST_CASE("JsonRpcPeer destructor clears the channel message handler",
 }
 
 TEST_CASE("JsonRpcPeer accepts binary JSON and default error envelopes",
-          "[json_rpc][coverage][phase3]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
     JsonRpcPeer client(*pair.first);
     JsonRpcPeer server(*pair.second);
@@ -947,7 +946,7 @@ TEST_CASE("JsonRpcPeer accepts binary JSON and default error envelopes",
 }
 
 TEST_CASE("JsonRpcPeer consumes responses for requests without callbacks",
-          "[json_rpc][coverage][phase3]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::vector<std::string> outbound;
@@ -977,7 +976,7 @@ TEST_CASE("JsonRpcPeer consumes responses for requests without callbacks",
 }
 
 TEST_CASE("JsonRpcPeer escapes outbound method and notification names",
-          "[json_rpc][coverage][phase3]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
     JsonRpcPeer client(*pair.first);
     JsonRpcPeer server(*pair.second);
@@ -1011,7 +1010,7 @@ TEST_CASE("JsonRpcPeer escapes outbound method and notification names",
 }
 
 TEST_CASE("JsonRpcPeer drops invalid notifications without invoking handlers",
-          "[json_rpc][coverage][phase3][batch-704]") {
+          "[json_rpc][coverage]") {
     auto pair = MemoryMessageChannel::make_pair();
 
     std::string unexpected_reply;

--- a/test/test_websocket_channel.cpp
+++ b/test/test_websocket_channel.cpp
@@ -250,7 +250,7 @@ TEST_CASE("WebSocket accept_key rejects empty input gracefully",
 }
 
 TEST_CASE("WebSocketChannel rejects null and closed streams before handshake",
-          "[websocket][handshake][coverage][phase3]") {
+          "[websocket][handshake][coverage]") {
     REQUIRE(WebSocketChannel::connect(nullptr, "127.0.0.1", "/") == nullptr);
     REQUIRE(WebSocketChannel::accept(nullptr) == nullptr);
 
@@ -296,7 +296,7 @@ TEST_CASE("WebSocketChannel connect fails gracefully on non-WS peer",
 }
 
 TEST_CASE("WebSocketChannel rejects incorrect accept key",
-          "[websocket][handshake][issue-641]") {
+          "[websocket][handshake]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
     auto port = bind_loopback(listener, 47301);
@@ -425,7 +425,7 @@ TEST_CASE("WebSocketChannel echoes a >126-byte message (16-bit payload length)",
 }
 
 TEST_CASE("WebSocketChannel delivers binary send as binary message",
-          "[websocket][frame-kind][issue-641]") {
+          "[websocket][frame-kind]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
     auto port = bind_loopback(listener, 47401);
@@ -478,7 +478,7 @@ TEST_CASE("WebSocketChannel delivers binary send as binary message",
 }
 
 TEST_CASE("WebSocketChannel assembles fragmented text frames",
-          "[websocket][frame-kind][coverage][phase3]") {
+          "[websocket][frame-kind][coverage]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
     auto port = bind_loopback(listener, 47701);
@@ -541,7 +541,7 @@ TEST_CASE("WebSocketChannel assembles fragmented text frames",
 }
 
 TEST_CASE("WebSocketChannel reports unknown frame opcodes",
-          "[websocket][frame-kind][coverage][phase3]") {
+          "[websocket][frame-kind][coverage]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
     auto port = bind_loopback(listener, 47801);
@@ -598,7 +598,7 @@ TEST_CASE("WebSocketChannel reports unknown frame opcodes",
 }
 
 TEST_CASE("WebSocketChannel replies to ping frames with pong",
-          "[websocket][frame-kind][coverage][phase3]") {
+          "[websocket][frame-kind][coverage]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
     auto port = bind_loopback(listener, 47901);
@@ -647,7 +647,7 @@ TEST_CASE("WebSocketChannel replies to ping frames with pong",
 }
 
 TEST_CASE("WebSocketChannel echoes close frames and closes",
-          "[websocket][frame-kind][coverage][phase3]") {
+          "[websocket][frame-kind][coverage]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
     auto port = bind_loopback(listener, 48001);
@@ -702,7 +702,7 @@ TEST_CASE("WebSocketChannel echoes close frames and closes",
 }
 
 TEST_CASE("WebSocketChannel receives 64-bit payload length frames",
-          "[websocket][frame-length][issue-641]") {
+          "[websocket][frame-length]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
     auto port = bind_loopback(listener, 47501);
@@ -763,7 +763,7 @@ TEST_CASE("WebSocketChannel receives 64-bit payload length frames",
 }
 
 TEST_CASE("WebSocketChannel rejects frames above max_payload",
-          "[websocket][frame-length][issue-641]") {
+          "[websocket][frame-length]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
     auto port = bind_loopback(listener, 47601);


### PR DESCRIPTION
## Summary
- Remove stale Phase 4 wording from JSON-RPC/WebSocket source comments while preserving current behavior notes.
- Remove historical `[phase3]`, batch, and issue-only Catch2 tags from JSON-RPC/WebSocket tests.
- Preserve semantic test grouping tags such as `[json_rpc]`, `[websocket]`, `[coverage]`, `[handshake]`, `[frame-kind]`, `[frame-length]`, and `[large]`.

## Validation
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target pulp-test-json-rpc pulp-test-websocket-channel -j$(sysctl -n hw.ncpu)`
- `build/test/pulp-test-json-rpc` — 214 assertions / 38 test cases
- `build/test/pulp-test-websocket-channel` — 109 assertions / 16 test cases
- Release sanity: `CMAKE_BUILD_TYPE:STRING=Release`; affected target flags contain `-O3 -DNDEBUG`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main --prompt "Review this runtime message protocol comment/test-tag hygiene patch adversarially. Focus on whether removing [phase3]/batch/issue tags could break test selection, whether retained functional tags still group tests usefully, whether [large] is preserved if semantically needed, and whether comments lost load-bearing behavioral context. Do not request broad cleanup outside this slice."` — clean

## Notes
- RepoPrompt MCP tools were requested, but they were not exposed in this Codex session (`tool_search` found no RepoPrompt tools), so this slice used local source inspection plus Claude autoreview.
- Open PR #4284 already touches `test/CMakeLists.txt`, so this branch intentionally avoids the remaining nearby `MessageChannel tests (Phase 4)` CMake comment to prevent overlap; that should be handled after #4284 lands or in its own non-conflicting pass.
- PR opened with `gh pr create` as a manual bypass, matching the prior cleanup slices; Shipyard-managed PR state may need reconciliation if required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale "Phase 4" wording and cleaned issue/batch test tags across JSON-RPC and WebSocket comments/tests, with no behavior changes. Kept grouping tags (e.g., [json_rpc], [websocket], [coverage], [handshake], [frame-kind], [frame-length], [large]) and clarified that the JSON-RPC peer accepts only single-object requests.

<sup>Written for commit 5b9b560ae8ff27e370aadba198bdaeb600b4c79a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

