### PR TITLE
docs: clean i18n test tag archaeology

### DIFF
--- a/test/test_i18n.cpp
+++ b/test/test_i18n.cpp
@@ -64,7 +64,7 @@ TEST_CASE("i18n add and translate", "[runtime][i18n]") {
     REQUIRE(strings.count() == 1);
 }
 
-TEST_CASE("i18n duplicate keys overwrite previous values", "[runtime][i18n][coverage][issue-656]") {
+TEST_CASE("i18n duplicate keys overwrite previous values", "[runtime][i18n][coverage]") {
     LocalisedStrings strings;
     strings.add("mode", "old");
     strings.add("mode", "new");
@@ -72,7 +72,7 @@ TEST_CASE("i18n duplicate keys overwrite previous values", "[runtime][i18n][cove
     REQUIRE(strings.translate("mode") == "new");
 }
 
-TEST_CASE("i18n accepts empty in-memory keys", "[runtime][i18n][coverage][phase3-batch742]") {
+TEST_CASE("i18n accepts empty in-memory keys", "[runtime][i18n][coverage]") {
     LocalisedStrings strings;
     strings.add("", "metadata");
     strings.add("normal", "value");
@@ -111,34 +111,34 @@ TEST_CASE("i18n argument substitution leaves unmatched placeholders", "[runtime]
 }
 
 TEST_CASE("i18n argument substitution also applies to missing-key fallback",
-          "[runtime][i18n][issue-641]") {
+          "[runtime][i18n]") {
     LocalisedStrings strings;
     REQUIRE(strings.translate("missing {0}/{1}/{2}", {"a", "b"}) == "missing a/b/{2}");
 }
 
 TEST_CASE("i18n argument substitution handles adjacent placeholders",
-          "[runtime][i18n][coverage][phase3-large]") {
+          "[runtime][i18n][coverage][large]") {
     LocalisedStrings strings;
     strings.add("compact", "{0}{1}{0}");
     REQUIRE(strings.translate("compact", {"A", "B"}) == "ABA");
 }
 
 TEST_CASE("i18n argument substitution treats double braces as literal text",
-          "[runtime][i18n][coverage][phase3-large]") {
+          "[runtime][i18n][coverage][large]") {
     LocalisedStrings strings;
     strings.add("template", "{{0}} {0}");
     REQUIRE(strings.translate("template", {"value"}) == "{value} value");
 }
 
 TEST_CASE("i18n argument substitution applies later indexes after earlier replacements",
-          "[runtime][i18n][coverage][phase3-large]") {
+          "[runtime][i18n][coverage][large]") {
     LocalisedStrings strings;
     strings.add("nested", "{0} {1}");
     REQUIRE(strings.translate("nested", {"{1}", "done"}) == "done done");
 }
 
 TEST_CASE("i18n argument substitution handles multi-digit indexes literally",
-          "[runtime][i18n][coverage][phase3]") {
+          "[runtime][i18n][coverage]") {
     LocalisedStrings strings;
     strings.add("many", "{9}:{10}:{0}");
     std::vector<std::string> args = {
@@ -159,7 +159,7 @@ TEST_CASE("i18n clear removes all translations", "[runtime][i18n]") {
 }
 
 TEST_CASE("i18n clear leaves selected locale intact",
-          "[runtime][i18n][coverage][phase3]") {
+          "[runtime][i18n][coverage]") {
     LocalisedStrings strings;
     strings.set_locale("ja");
     strings.add("hello", "konnichiwa");
@@ -217,7 +217,7 @@ TEST_CASE("i18n .strings parser ignores malformed lines", "[runtime][i18n]") {
 }
 
 TEST_CASE("i18n .strings parser lets later entries replace earlier ones",
-          "[runtime][i18n][coverage][issue-656]") {
+          "[runtime][i18n][coverage]") {
     TemporaryFile tmp(".strings");
     {
         std::ofstream f(tmp.path());
@@ -234,7 +234,7 @@ TEST_CASE("i18n .strings parser lets later entries replace earlier ones",
 }
 
 TEST_CASE("i18n .strings parser accepts keys and values with spaces",
-          "[runtime][i18n][coverage][phase3-large]") {
+          "[runtime][i18n][coverage][large]") {
     TemporaryFile tmp(".strings");
     {
         std::ofstream f(tmp.path());
@@ -249,7 +249,7 @@ TEST_CASE("i18n .strings parser accepts keys and values with spaces",
 }
 
 TEST_CASE("i18n .strings parser keeps entries without semicolons",
-          "[runtime][i18n][coverage][phase3-large]") {
+          "[runtime][i18n][coverage][large]") {
     TemporaryFile tmp(".strings");
     {
         std::ofstream f(tmp.path());
@@ -262,7 +262,7 @@ TEST_CASE("i18n .strings parser keeps entries without semicolons",
 }
 
 TEST_CASE("i18n .strings parser permits empty keys",
-          "[runtime][i18n][coverage][phase3-large]") {
+          "[runtime][i18n][coverage][large]") {
     TemporaryFile tmp(".strings");
     {
         std::ofstream f(tmp.path());
@@ -277,7 +277,7 @@ TEST_CASE("i18n .strings parser permits empty keys",
 }
 
 TEST_CASE("i18n .strings load failure leaves existing translations intact",
-          "[runtime][i18n][coverage][phase3-batch742]") {
+          "[runtime][i18n][coverage]") {
     LocalisedStrings strings;
     strings.add("existing", "kept");
 
@@ -332,7 +332,7 @@ TEST_CASE("i18n .po parser handles continuations and empty entries", "[runtime][
 }
 
 TEST_CASE("i18n .po parser commits previous entry when new msgid starts",
-          "[runtime][i18n][issue-641]") {
+          "[runtime][i18n]") {
     TemporaryFile tmp(".po");
     {
         std::ofstream f(tmp.path());
@@ -350,7 +350,7 @@ TEST_CASE("i18n .po parser commits previous entry when new msgid starts",
 }
 
 TEST_CASE("i18n .po parser replaces duplicate msgids",
-          "[runtime][i18n][coverage][phase3-large]") {
+          "[runtime][i18n][coverage][large]") {
     TemporaryFile tmp(".po");
     {
         std::ofstream f(tmp.path());
@@ -367,7 +367,7 @@ TEST_CASE("i18n .po parser replaces duplicate msgids",
 }
 
 TEST_CASE("i18n .po parser ignores msgids without translations",
-          "[runtime][i18n][coverage][phase3-large]") {
+          "[runtime][i18n][coverage][large]") {
     TemporaryFile tmp(".po");
     {
         std::ofstream f(tmp.path());
@@ -383,7 +383,7 @@ TEST_CASE("i18n .po parser ignores msgids without translations",
 }
 
 TEST_CASE("i18n .po parser accepts empty msgid continuations",
-          "[runtime][i18n][coverage][phase3-large]") {
+          "[runtime][i18n][coverage][large]") {
     TemporaryFile tmp(".po");
     {
         std::ofstream f(tmp.path());
@@ -399,7 +399,7 @@ TEST_CASE("i18n .po parser accepts empty msgid continuations",
 }
 
 TEST_CASE("i18n .po load failure leaves translations intact",
-          "[runtime][i18n][coverage][phase3-batch742]") {
+          "[runtime][i18n][coverage]") {
     LocalisedStrings strings;
     strings.add("existing", "kept");
 
@@ -409,7 +409,7 @@ TEST_CASE("i18n .po load failure leaves translations intact",
 }
 
 TEST_CASE("i18n .po parser ignores orphan msgstr lines",
-          "[runtime][i18n][coverage][phase3]") {
+          "[runtime][i18n][coverage]") {
     TemporaryFile tmp(".po");
     {
         std::ofstream f(tmp.path());
@@ -469,7 +469,7 @@ TEST_CASE("i18n JSON parser handles escapes and keyless entries", "[runtime][i18
 }
 
 TEST_CASE("i18n JSON parser handles standard control escapes",
-          "[runtime][i18n][coverage][phase3]") {
+          "[runtime][i18n][coverage]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -487,7 +487,7 @@ TEST_CASE("i18n JSON parser handles standard control escapes",
     REQUIRE(strings.translate("formfeed") == "page\fbreak");
 }
 
-TEST_CASE("i18n JSON parser accepts commas and duplicate keys", "[runtime][i18n][coverage][issue-656]") {
+TEST_CASE("i18n JSON parser accepts commas and duplicate keys", "[runtime][i18n][coverage]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -527,7 +527,7 @@ TEST_CASE("i18n JSON parser rejects missing object opener", "[runtime][i18n]") {
 }
 
 TEST_CASE("i18n JSON load failure preserves existing translations",
-          "[runtime][i18n][coverage][phase3-batch742]") {
+          "[runtime][i18n][coverage]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -543,7 +543,7 @@ TEST_CASE("i18n JSON load failure preserves existing translations",
 }
 
 TEST_CASE("i18n JSON parser accepts empty objects",
-          "[runtime][i18n][coverage][phase3]") {
+          "[runtime][i18n][coverage]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -559,7 +559,7 @@ TEST_CASE("i18n JSON parser accepts empty objects",
 }
 
 TEST_CASE("i18n JSON parser allows duplicate keys and trailing comma",
-          "[runtime][i18n][issue-641]") {
+          "[runtime][i18n]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -578,7 +578,7 @@ TEST_CASE("i18n JSON parser allows duplicate keys and trailing comma",
 }
 
 TEST_CASE("i18n JSON parser accepts compact objects without whitespace",
-          "[runtime][i18n][coverage][phase3-large]") {
+          "[runtime][i18n][coverage][large]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -592,7 +592,7 @@ TEST_CASE("i18n JSON parser accepts compact objects without whitespace",
 }
 
 TEST_CASE("i18n JSON parser treats unknown escapes as literal escaped char",
-          "[runtime][i18n][coverage][phase3-large]") {
+          "[runtime][i18n][coverage][large]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -606,7 +606,7 @@ TEST_CASE("i18n JSON parser treats unknown escapes as literal escaped char",
 }
 
 TEST_CASE("i18n JSON parser tolerates missing closing brace after entries",
-          "[runtime][i18n][coverage][phase3-large]") {
+          "[runtime][i18n][coverage][large]") {
     TemporaryFile tmp(".json");
     {
         std::ofstream f(tmp.path());
@@ -655,7 +655,7 @@ TEST_CASE("i18n global instance", "[runtime][i18n]") {
     inst.clear();
 }
 
-TEST_CASE("i18n global tr supports argument substitution", "[runtime][i18n][issue-641]") {
+TEST_CASE("i18n global tr supports argument substitution", "[runtime][i18n]") {
     auto& inst = LocalisedStrings::instance();
     inst.clear();
     inst.add("global_args", "{0}:{1}");


### PR DESCRIPTION
## Summary
- Remove historical `[phase3]`, `[phase3-batch742]`, `[issue-641]`, and `[issue-656]` tags from i18n tests.
- Preserve useful grouping tags: `[runtime]`, `[i18n]`, `[coverage]`.
- Convert `[phase3-large]` to `[large]` so the size semantic remains without the phase breadcrumb.

## Validation
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target pulp-test-i18n -j$(sysctl -n hw.ncpu)`
- `build/test/pulp-test-i18n` — 131 assertions / 48 test cases
- Release sanity: `CMAKE_BUILD_TYPE:STRING=Release`; affected target/runtime flags contain `-O3 -DNDEBUG`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main --prompt "Review this i18n Catch2 tag hygiene patch adversarially. Focus on whether removing [phase3], [phase3-batch742], [issue-641], and [issue-656] could break test selection, whether replacing [phase3-large] with [large] preserves useful semantics, whether [runtime], [i18n], and [coverage] grouping remains adequate, and whether the patch accidentally changes behavior outside tags. Do not request broad cleanup outside this slice."` — clean

## Notes
- RepoPrompt MCP tools were requested, but they were not exposed in this Codex session (`tool_search` found no RepoPrompt tools), so this slice used local source inspection plus Claude autoreview.
- PR opened with `gh pr create` as a manual bypass, matching the current cleanup-stack pattern; Shipyard-managed PR state may need reconciliation if required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up i18n test tags to remove obsolete phase/issue markers and standardize size tags for clearer test selection. No test logic or behavior changed.

- **Refactors**
  - Removed `[phase3]`, `[phase3-batch742]`, `[issue-641]`, `[issue-656]`.
  - Kept `[runtime]`, `[i18n]`, `[coverage]`.
  - Replaced `[phase3-large]` with `[large]`.

- **Migration**
  - Update any CI/local tag filters that referenced removed tags; use `[large]` for size-based selection.

<sup>Written for commit 3fa3be9cfa10f57191d7a1784ea12a789c72472a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

