### PR TITLE
docs: clean canvas filter-chain test archaeology

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4253,11 +4253,10 @@ if(PULP_HAS_SKIA)
 endif()
 catch_discover_tests(pulp-test-canvas-cg-gradients)
 
-# CSS filter chain coverage (P5-2 follow-up — extracted from
-# test_canvas.cpp). pulp #1434 Phase A2-4: Skia-only pixel readback
-# (contrast / invert / opacity ordering with drop-shadow, set_filter
-# drop-shadow parser) + portable filter-chain matrix math
-# (contrast bias, invert maps, identity, opacity alpha scaling).
+# CSS filter chain coverage: Skia-only pixel readback (contrast /
+# invert / opacity ordering with drop-shadow, set_filter drop-shadow
+# parser) plus portable filter-chain matrix math (contrast bias,
+# invert maps, identity, opacity alpha scaling).
 add_executable(pulp-test-canvas-filter-chain test_canvas_filter_chain.cpp)
 target_link_libraries(pulp-test-canvas-filter-chain PRIVATE pulp::canvas Catch2::Catch2WithMain)
 if(PULP_HAS_SKIA)

--- a/test/test_canvas_filter_chain.cpp
+++ b/test/test_canvas_filter_chain.cpp
@@ -1,8 +1,5 @@
-// test_canvas_filter_chain.cpp — extracted from test_canvas.cpp in the
-// 2026-05 Phase 5 (P5-2 follow-up) refactor.
-//
-// pulp #1434 Phase A2-4 — CSS filter chain coverage, two sub-clusters
-// shipped together since both pin the same backend contract:
+// CSS filter chain coverage has two sub-clusters that pin the same backend
+// contract:
 //
 //   1. Skia-only pixel readback. contrast(0) renders ~mid-gray;
 //      invert(1) maps black → white; opacity ordering with
@@ -40,15 +37,15 @@
 using namespace pulp::canvas;
 
 #ifdef PULP_HAS_SKIA
-// ── pulp #1434 Phase A2-4 — CSS filter chain pixel readback ────────────
-// Codex P1 #3195880597: SkColorFilters::Matrix translation column is in
-// 0..255 space. `contrast(0)` must produce mid-gray (~128) and
-// `invert(1)` must map black to white pixel-for-pixel.
-// Codex P2 #3195880608: opacity() must remain in the composed chain at
-// its source-order position so subsequent filters (drop-shadow) see the
+// ── CSS filter chain pixel readback ────────────────────────────────────
+// Regression: SkColorFilters::Matrix translation column is in 0..255
+// space. `contrast(0)` must produce mid-gray (~128) and `invert(1)`
+// must map black to white pixel-for-pixel.
+// Regression: opacity() must remain in the composed chain at its
+// source-order position so subsequent filters (drop-shadow) see the
 // reduced alpha as their input.
 TEST_CASE("SkiaCanvas filter chain: contrast(0) renders ~mid-gray",
-          "[canvas][skia][filter-chain][issue-1434][!mayfail]") {
+          "[canvas][skia][filter-chain][!mayfail]") {
     constexpr int kW = 16;
     constexpr int kH = 16;
     SkImageInfo info = SkImageInfo::Make(kW, kH, kN32_SkColorType,
@@ -87,7 +84,7 @@ TEST_CASE("SkiaCanvas filter chain: contrast(0) renders ~mid-gray",
 }
 
 TEST_CASE("SkiaCanvas filter chain: invert(1) maps black to white",
-          "[canvas][skia][filter-chain][issue-1434]") {
+          "[canvas][skia][filter-chain]") {
     constexpr int kW = 16;
     constexpr int kH = 16;
     SkImageInfo info = SkImageInfo::Make(kW, kH, kN32_SkColorType,
@@ -122,7 +119,7 @@ TEST_CASE("SkiaCanvas filter chain: invert(1) maps black to white",
 
 TEST_CASE("SkiaCanvas filter chain: opacity ordering changes pixel output "
           "with drop-shadow",
-          "[canvas][skia][filter-chain][issue-1434]") {
+          "[canvas][skia][filter-chain]") {
     // CSS spec: filters apply in source order. `opacity(0.5) drop-shadow(...)`
     // must reduce the source alpha BEFORE the shadow generates, while
     // `drop-shadow(...) opacity(0.5)` reduces the alpha of the already-
@@ -189,7 +186,7 @@ TEST_CASE("SkiaCanvas filter chain: opacity ordering changes pixel output "
 // must return non-null and the resulting SkImageFilter must produce a
 // visible offset shadow when rendered through SkiaCanvas::set_filter().
 TEST_CASE("SkiaCanvas set_filter parses drop-shadow and renders shadow",
-          "[canvas][skia][filter-chain][drop-shadow][wave6-canvas2d][!mayfail]") {
+          "[canvas][skia][filter-chain][drop-shadow][!mayfail]") {
     constexpr int kW = 32;
     constexpr int kH = 32;
     SkImageInfo info = SkImageInfo::Make(kW, kH, kN32_SkColorType,
@@ -230,7 +227,7 @@ TEST_CASE("SkiaCanvas set_filter parses drop-shadow and renders shadow",
 }
 
 TEST_CASE("SkiaCanvas set_filter parsers drop-shadow with hex color",
-          "[canvas][skia][filter-chain][drop-shadow][wave6-canvas2d]") {
+          "[canvas][skia][filter-chain][drop-shadow]") {
     constexpr int kW = 32;
     constexpr int kH = 32;
     SkImageInfo info = SkImageInfo::Make(kW, kH, kN32_SkColorType,
@@ -251,7 +248,7 @@ TEST_CASE("SkiaCanvas set_filter parsers drop-shadow with hex color",
 }
 
 TEST_CASE("SkiaCanvas set_filter non-existent filter returns null",
-          "[canvas][skia][filter-chain][wave6-canvas2d]") {
+          "[canvas][skia][filter-chain]") {
     SkiaCanvas canvas(nullptr);  // null canvas for this test
     canvas.set_filter("none");
     SkPaint paint;
@@ -261,14 +258,14 @@ TEST_CASE("SkiaCanvas set_filter non-existent filter returns null",
 
 #endif  // PULP_HAS_SKIA
 
-// ── pulp #1434 Phase A2-4 — portable filter-chain matrix math ──────────
+// ── Portable filter-chain matrix math ──────────────────────────────────
 // These tests run on every platform (no Skia required) and dry-run the
 // SAME float math the production save_layer_with_filters() switch uses
-// to populate SkColorMatrix entries. They guard against the two Codex
+// to populate SkColorMatrix entries. They guard against the two
 // regressions independently of whether Skia is linked into the test
 // binary:
-//   - P1 #3195880597: contrast / invert bias must be in 0..255 space.
-//   - P2 #3195880608: opacity() must be a per-position color matrix.
+//   - contrast / invert bias must be in 0..255 space.
+//   - opacity() must be a per-position color matrix.
 //
 // Helpers below mirror the matrix construction in
 // core/canvas/src/skia_canvas.cpp; if those formulas drift here without
@@ -338,7 +335,7 @@ void build_opacity_matrix(float amount, float m[20]) {
 } // namespace
 
 TEST_CASE("Filter chain: contrast(0) bias lands at mid-gray (~128)",
-          "[canvas][filter-chain][issue-1434]") {
+          "[canvas][filter-chain]") {
     float m[20];
     build_contrast_matrix(0.0f, m);
     // Any input -> 128 because slope=0, intercept=128.
@@ -363,7 +360,7 @@ TEST_CASE("Filter chain: contrast(0) bias lands at mid-gray (~128)",
 }
 
 TEST_CASE("Filter chain: invert(1) maps black->white via the matrix",
-          "[canvas][filter-chain][issue-1434]") {
+          "[canvas][filter-chain]") {
     float m[20];
     build_invert_matrix(1.0f, m);
     Px black{0, 0, 0, 255};
@@ -384,7 +381,7 @@ TEST_CASE("Filter chain: invert(1) maps black->white via the matrix",
 }
 
 TEST_CASE("Filter chain: invert(0) is identity",
-          "[canvas][filter-chain][issue-1434]") {
+          "[canvas][filter-chain]") {
     float m[20];
     build_invert_matrix(0.0f, m);
     Px in{42, 137, 200, 255};
@@ -396,10 +393,10 @@ TEST_CASE("Filter chain: invert(0) is identity",
 }
 
 TEST_CASE("Filter chain: opacity(a) scales alpha and preserves RGB",
-          "[canvas][filter-chain][issue-1434]") {
-    // P2 fix: opacity is a color matrix in the chain (alpha *= a),
-    // not a final-layer alpha multiplier. RGB channels pass through
-    // unchanged so subsequent filters operate on the same color.
+          "[canvas][filter-chain]") {
+    // Opacity is a color matrix in the chain (alpha *= a), not a
+    // final-layer alpha multiplier. RGB channels pass through unchanged
+    // so subsequent filters operate on the same color.
     float m[20];
     build_opacity_matrix(0.5f, m);
     Px in{200, 100, 50, 255};

--- a/tools/scripts/hotspot_size_guard.json
+++ b/tools/scripts/hotspot_size_guard.json
@@ -32,7 +32,7 @@
     },
     {
       "path": "test/CMakeLists.txt",
-      "max_loc": 6152,
+      "max_loc": 6151,
       "note": "shared test registration hotspot"
     },
     {


### PR DESCRIPTION
## Summary
- Remove stale phase/issue/Codex/wave breadcrumbs from canvas filter-chain test comments and Catch2 tags.
- Keep the load-bearing regression context for Skia color-matrix 0..255 bias and opacity source-order behavior.
- Clean the adjacent CMake target comment and ratchet `test/CMakeLists.txt` hotspot ceiling from 6152 to 6151 after the comment shrink.

## Validation
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target pulp-test-canvas-filter-chain -j$(sysctl -n hw.ncpu)`
- `build/test/pulp-test-canvas-filter-chain` (exited 0; 8 passed, 2 `[!mayfail]` failed as expected)
- Release verification: `CMAKE_BUILD_TYPE:STRING=Release`; `-O3 -DNDEBUG` present in `pulp-test-canvas-filter-chain`, `pulp-canvas`, and `pulp-runtime` flags.
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --prompt ...` (clean: no accepted/actionable findings)

## Notes
- RepoPrompt MCP tools were requested but are not exposed in this session (`tool_search` found 0 RepoPrompt tools), so analysis used local repo commands.
- `shipyard pr` has no draft mode; this draft PR was opened through `gh pr create` as the same manual fallback used by the cleanup stack, so it may not appear in Shipyard-managed state until reconciled.
- Fresh worktree configure reported `planning/` submodule not initialized and skipped generated-import C++ targets; this slice does not touch those targets.
- Direct push used `PULP_SKIP_DIFF_COVER=1`; fast gates and focused Release target/test were run locally.

## Gate trailers
- Tip commit carries `Skill-Update: skip skill=ci reason="hotspot ceiling ratchet only; existing ci skill documents lowering ceilings after shrinks"`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned canvas filter-chain tests by removing stale breadcrumbs from comments and Catch2 tags while keeping the key regression notes on Skia 0..255 bias and opacity ordering. Also tightened the CMake target comment and lowered the `test/CMakeLists.txt` hotspot ceiling from 6152 to 6151.

- **Refactors**
  - Simplified comments and tags in `test/test_canvas_filter_chain.cpp` (e.g., removed `[issue-1434]`, `wave6-canvas2d`).
  - Kept regression context for SkColorMatrix 0..255 translation and opacity-in-chain source order.
  - Updated the CMake target comment and `tools/scripts/hotspot_size_guard.json` ceiling to 6151.

<sup>Written for commit 3ceb5e484e07b986efec39c1e80e2c686116318a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

