### PR TITLE
docs: clean inspector pass viewer comment archaeology

### DIFF
--- a/inspect/src/inspector_overlay_pass_viewer.cpp
+++ b/inspect/src/inspector_overlay_pass_viewer.cpp
@@ -1,15 +1,10 @@
-// inspector_overlay_pass_viewer.cpp — Phase 6.1 per-pass GPU/render
-// attribution viewer for the visual inspector overlay.
+// Per-pass render attribution viewer for the visual inspector overlay.
 //
-// Extracted from inspector_overlay.cpp in the 2026-05 refactor (roadmap
-// P10-2). Pure mechanical move — the InspectorOverlay member methods
-// below are byte-identical to their previous definitions in
-// inspector_overlay.cpp; only their translation unit changed. The
-// file-local kPassTypeNames / kPassTypeColors tables stay private to
-// this TU. Shared color constants live in
-// inspector_overlay_internal.hpp; the structural constants
-// (kPassTypeCount, kPassHistoryFrames) are static-constexpr members of
-// InspectorOverlay reached through the public header.
+// The file-local kPassTypeNames / kPassTypeColors tables stay private to
+// this TU. Shared color constants live in inspector_overlay_internal.hpp;
+// the structural constants (kPassTypeCount, kPassHistoryFrames) are
+// static-constexpr members of InspectorOverlay reached through the public
+// header.
 
 #include "inspector_overlay_internal.hpp"
 
@@ -26,13 +21,12 @@
 
 namespace pulp::inspect {
 
-// ── Phase 6.1 — Per-pass GPU/render attribution viewer ──────────────────────
+// ── Per-pass render attribution viewer ──────────────────────────────────────
 //
 // Surfaces where render time goes, broken down by render pass, over a
 // rolling 60-frame window. Reads RenderPassManager's existing per-pass
-// PassStats — CPU wall-time + draw-call counts. True GPU timestamps are
-// deferred to Phase 6.5 (Dawn timestamp queries); the panel labels its
-// numbers "cpu" so the distinction is honest and explicit.
+// PassStats: CPU wall-time and draw-call counts. The panel labels its
+// numbers "cpu" so it does not imply GPU timestamp availability.
 
 namespace {
 


### PR DESCRIPTION
## Summary
- Remove stale Phase 6.1 / P10-2 extraction breadcrumbs from `inspector_overlay_pass_viewer.cpp` comments.
- Keep the stable ownership notes for file-local pass tables, shared color constants, and `InspectorOverlay` structural constants.
- Preserve the runtime `"cpu time · GPU timestamps: Phase 6.5"` label intentionally; it is visible UI text, not comment archaeology, and `test_inspector_gpu_passes.cpp` asserts it.

## Validation
- `git fetch origin main` (confirmed `origin/main` and branch base at `d26f94f8a53cd177d1595eed0e1bc53668f9abcc`)
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target pulp-test-inspector-gpu-passes -j$(sysctl -n hw.ncpu)`
- `build/test/pulp-test-inspector-gpu-passes` (11 test cases, 144 assertions)
- Release flags verified in `build/CMakeCache.txt` and target `flags.make` (`-O3 -DNDEBUG`)
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main --prompt "Review this inspector pass-viewer comment hygiene patch adversarially. Focus on whether the patch is truly comment-only, whether it preserves the current CPU-vs-GPU timing semantics, whether the visible 'Phase 6.5' runtime label and tests are intentionally unchanged, whether removing Phase 6.1/P10-2 extraction breadcrumbs loses any load-bearing information, and whether the slice overlaps open cleanup PRs. Do not request broad cleanup outside this file."` (clean)
- Pre-push gates with `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/inspector-pass-viewer-comment-hygiene`

## Notes
- RepoPrompt analysis was requested, but no RepoPrompt MCP tools were exposed in this Codex session; `tool_search` returned no matching tools. I used direct repo search and open-PR file overlap checks instead.
- Shipyard currently has no draft PR creation flag in `shipyard pr --help`, so this uses `gh pr create --draft` as the draft fallback.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned outdated Phase 6.1/P10-2 breadcrumbs from comments in inspector_overlay_pass_viewer.cpp and clarified the CPU-vs-GPU timing wording. No functional changes; kept ownership notes for pass tables/colors/constants and retained the visible "cpu" label and "Phase 6.5" UI text.

<sup>Written for commit d19a2145ed9678ce866853849788c9adbb747cd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

