### PR TITLE
docs: clean inspector zoom comment archaeology

### DIFF
--- a/inspect/src/inspector_overlay_zoom.cpp
+++ b/inspect/src/inspector_overlay_zoom.cpp
@@ -1,11 +1,6 @@
-// inspector_overlay_zoom.cpp — Phase 3e 20× zoom loupe for the visual
-// inspector overlay.
+// Pixel loupe for the visual inspector overlay.
 //
-// Extracted from inspector_overlay.cpp in the 2026-05 refactor (roadmap
-// P10-2). Pure mechanical move — the InspectorOverlay member methods
-// below are byte-identical to their previous definitions in
-// inspector_overlay.cpp; only their translation unit changed. Shared
-// color constants live in inspector_overlay_internal.hpp; the
+// Shared color constants live in inspector_overlay_internal.hpp; the
 // structural zoom constants (kZoomGridCells, kZoomFactorMin/Max,
 // kZoomReadoutH, kZoomPanelMargin) are static-constexpr members of
 // InspectorOverlay reached through the public header.
@@ -24,7 +19,7 @@
 
 namespace pulp::inspect {
 
-// ── Phase 3e — 20× zoom loupe ───────────────────────────────────────────────
+// ── Pixel loupe ─────────────────────────────────────────────────────────────
 //
 // A digital loupe: a fixed-corner panel showing the pixels under the
 // cursor blown up by `zoom_factor_`, with a center crosshair on the


### PR DESCRIPTION
## Summary
- Remove stale Phase 3e / P10-2 extraction breadcrumbs from `inspector_overlay_zoom.cpp` comments.
- Keep the current-behavior notes for shared color constants and zoom structural constants.
- Leave loupe/readback behavior and all executable code unchanged.

## Validation
- `git fetch origin main` (confirmed `origin/main` and branch base at `d26f94f8a53cd177d1595eed0e1bc53668f9abcc`)
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target pulp-test-inspector -j$(sysctl -n hw.ncpu)`
- `build/test/pulp-test-inspector "*loupe*"` (5 test cases, 36 assertions)
- Release flags verified in `build/CMakeCache.txt` and target `flags.make` (`-O3 -DNDEBUG`)
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main --prompt "Review this inspector zoom/loupe comment hygiene patch adversarially. Focus on whether the patch is truly comment-only, whether it removes only stale Phase 3e/P10-2 refactor breadcrumbs, whether it preserves current loupe/readback behavior and structural-constant documentation, whether focused loupe validation is adequate, and whether the slice overlaps open inspector cleanup PRs. Do not request broad cleanup outside this file."` (clean)
- Pre-push gates with `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/inspector-zoom-comment-hygiene`

## Notes
- RepoPrompt analysis was requested, but no RepoPrompt MCP tools were exposed in this Codex session; `tool_search` returned no matching tools. I used direct repo search and open-PR file overlap checks instead.
- Shipyard currently has no draft PR creation flag in `shipyard pr --help`, so this uses `gh pr create --draft` as the draft fallback.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up outdated refactor breadcrumbs in `inspect/src/inspector_overlay_zoom.cpp` comments and clarified loupe naming. Kept docs for shared color constants and zoom structural constants; no code or behavior changes to the loupe or readback.

<sup>Written for commit b8d556f8e007dcad54e80506439c8754893a2b9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

