### PR TITLE
docs: clean inspector field edit comment archaeology

### DIFF
--- a/inspect/src/inspector_overlay_field_edit.cpp
+++ b/inspect/src/inspector_overlay_field_edit.cpp
@@ -1,11 +1,6 @@
-// inspector_overlay_field_edit.cpp — Phase 3b live-editable box-model
-// fields for the visual inspector overlay.
+// Live-editable box-model fields for the visual inspector overlay.
 //
-// Extracted from inspector_overlay.cpp in the 2026-05 refactor (roadmap
-// P10-2). Pure mechanical move — the InspectorOverlay member methods
-// below are byte-identical to their previous definitions in
-// inspector_overlay.cpp; only their translation unit changed. Shared
-// color constants live in inspector_overlay_internal.hpp; the
+// Shared color constants live in inspector_overlay_internal.hpp; the
 // structural layout constants are static-constexpr members of
 // InspectorOverlay reached through the public header.
 
@@ -23,16 +18,15 @@
 
 namespace pulp::inspect {
 
-// ── Phase 3b — Live-editable box-model fields ───────────────────────────────
+// ── Live-editable box-model fields ──────────────────────────────────────────
 //
 // Click on a numeric value in the property panel → enter edit mode.
 // Typed digits / decimal / sign extend the buffer; arrows nudge (±1
 // plain, ±10 Shift, ±100 Cmd matching Figma); Enter commits (tweak
 // + persisted); Esc cancels (revert); Tab commits + moves to the
-// next editable field. The tweak is emitted via the SAME
-// emit_tweak_for_selection() path Phase 3a drag-handles use, so
-// downstream persistence (Phase 1 disk write) gets both gestures for
-// free.
+// next editable field. The tweak is emitted through the same
+// emit_tweak_for_selection() path used by pointer-driven layout edits, so
+// downstream persistence receives both gestures through one store path.
 //
 // Real-time preview: we write to the underlying View (flex().padding
 // = N etc.) on every keystroke + arrow nudge so Yoga reflows live —
@@ -173,10 +167,9 @@ static char key_to_char(KeyCode k, bool shift) {
     // We treat the keys as both their unshifted and shifted symbols
     // for "." and "-" because Pulp's KeyCode enum doesn't define
     // separate "period" / "minus" entries — platform code dispatches
-    // them via text-input. Phase 3b accepts numeric editing only;
-    // digits cover 99% of use. Decimal entry on platforms without a
-    // text-input path can be added by extending KeyCode (filed as a
-    // follow-up in the PR body if it becomes a real ask).
+    // them via text-input. Numeric editing accepts digits through this
+    // keyboard path; decimal entry on platforms without a text-input
+    // path can be added by extending KeyCode.
     (void)shift;
     return 0;
 }


### PR DESCRIPTION
## Summary
- Clean stale Phase 3b / P10-2 / 2026 refactor breadcrumbs from inspector field-edit comments.
- Keep the comments focused on current keyboard-edit, pointer-edit, persistence, and layout invalidation behavior.
- Leave executable code untouched.

## Validation
- git fetch origin main (origin/main and merge-base: d26f94f8a53cd177d1595eed0e1bc53668f9abcc)
- git diff --check
- rg stale-marker scan on inspect/src/inspector_overlay_field_edit.cpp
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
- cmake --build build --target pulp-test-inspector-field-edit -j$(sysctl -n hw.ncpu)
- build/test/pulp-test-inspector-field-edit (96 assertions in 20 test cases)
- Release flag check: CMAKE_BUILD_TYPE=Release and -O3 -DNDEBUG present for pulp-test-inspector-field-edit, pulp-inspect, and pulp-view
- AUTOREVIEW_ENGINE=claude autoreview --mode local --base origin/main: clean, no accepted/actionable findings
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/inspector-field-edit-comment-hygiene (pre-push gates clean)

## Notes
- RepoPrompt analysis was requested, but no RepoPrompt MCP/tool is available in this Codex session; I used local git/rg inspection and Claude autoreview instead.
- Shipyard does not expose draft PR creation here, so I used gh pr create --draft for the PR shell.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up inspector field-edit comments to remove stale phase/roadmap notes and clarify current keyboard/pointer edit, persistence path, and live reflow behavior. No functional changes; comment-only update in `inspect/src/inspector_overlay_field_edit.cpp`.

<sup>Written for commit 87aa8128f0b7e108179861c07ebd5300a87f636a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

