### PR TITLE
docs: clean bidi comment archaeology

### DIFF
--- a/core/canvas/include/pulp/canvas/bidi.hpp
+++ b/core/canvas/include/pulp/canvas/bidi.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-// Pulp item 6.8 / 2026-05-24 macOS plugin-authoring plan.
-//
 // BidiAnalyzer — paragraph-level Unicode Bidirectional Algorithm
 // implementation backed by SheenBidi (Apache-2.0). Produces logical-
 // to-visual run segmentation for Arabic / Hebrew / mixed-direction
@@ -78,9 +76,8 @@ public:
     /// Re-order `runs` (in logical order, as returned by analyze) into
     /// visual / paint order via UBA rules L1-L2. The implementation is
     /// a simplified L2 reverse-on-odd-level pass — sufficient for
-    /// single-line label paint, which is the consumer the 6.8 slice
-    /// targets. (TextEditor's multi-line wrap path stays on the
-    /// SkShaper / ICU iterator route in text_run_planner.cpp.)
+    /// single-line label paint. TextEditor's multi-line wrap path stays on the
+    /// SkShaper / ICU iterator route in text_run_planner.cpp.
     static std::vector<BidiRun> visual_order(const std::vector<BidiRun>& runs);
 
     /// True when the build links SheenBidi. Tests that need the real

--- a/core/canvas/src/bidi.cpp
+++ b/core/canvas/src/bidi.cpp
@@ -1,5 +1,3 @@
-// bidi.cpp — Pulp item 6.8 / 2026-05-24 macOS plugin-authoring plan.
-//
 // SheenBidi-backed paragraph bidi analyser. See bidi.hpp for the API
 // contract. The Skia / SkShaper path in text_run_planner.cpp keeps its
 // existing ICU-iterator route; this file provides the canonical
@@ -90,9 +88,9 @@ BidiParagraph BidiAnalyzer::analyze(std::string_view text,
 
     // SBLine applies UBA rules L1-L2 over a paragraph range and returns
     // contiguous runs grouped by embedding level. We treat the entire
-    // paragraph as one line (consistent with the Phase-1 single-line
-    // label paint target for slice 6.8). Multi-line callers can call
-    // analyze() per wrapped line themselves once line breaking is fixed.
+    // paragraph as one line, which matches the current single-line label
+    // paint path. Multi-line callers can call analyze() per wrapped line
+    // themselves once line breaking is fixed.
     SBLineRef line = SBParagraphCreateLine(
         paragraph,
         /*lineOffset=*/0,

--- a/test/test_bidi_text.cpp
+++ b/test/test_bidi_text.cpp
@@ -1,5 +1,3 @@
-// test_bidi_text.cpp — Pulp item 6.8 / 2026-05-24 macOS plugin-authoring plan.
-//
 // Exercises core/canvas::BidiAnalyzer (SheenBidi-backed paragraph
 // Unicode Bidirectional Algorithm) and verifies that the
 // TextRunPlanner non-ICU fallback path emits correct bidi runs for
@@ -60,12 +58,12 @@ std::string concat3(std::string_view a, std::string_view b, std::string_view c) 
 
 }  // namespace
 
-TEST_CASE("BidiAnalyzer empty input is empty", "[bidi][issue-6.8]") {
+TEST_CASE("BidiAnalyzer empty input is empty", "[bidi]") {
     auto bp = BidiAnalyzer::analyze("", BidiBaseDirection::Auto);
     REQUIRE(bp.runs.empty());
 }
 
-TEST_CASE("BidiAnalyzer pure-Latin is one LTR run", "[bidi][issue-6.8]") {
+TEST_CASE("BidiAnalyzer pure-Latin is one LTR run", "[bidi]") {
     auto bp = BidiAnalyzer::analyze("Hello, world!", BidiBaseDirection::Auto);
     REQUIRE(bp.runs.size() == 1);
     REQUIRE(bp.runs[0].level == 0);
@@ -74,7 +72,7 @@ TEST_CASE("BidiAnalyzer pure-Latin is one LTR run", "[bidi][issue-6.8]") {
 }
 
 TEST_CASE("BidiAnalyzer pure-Hebrew has base level 1 and an RTL run",
-          "[bidi][issue-6.8]") {
+          "[bidi]") {
     auto bp = BidiAnalyzer::analyze(kHebrewShalom, BidiBaseDirection::Auto);
     REQUIRE_FALSE(bp.runs.empty());
 
@@ -96,7 +94,7 @@ TEST_CASE("BidiAnalyzer pure-Hebrew has base level 1 and an RTL run",
 }
 
 TEST_CASE("BidiAnalyzer pure-Arabic has base level 1 and an RTL run",
-          "[bidi][issue-6.8]") {
+          "[bidi]") {
     auto bp = BidiAnalyzer::analyze(kArabicMarhaba, BidiBaseDirection::Auto);
     REQUIRE_FALSE(bp.runs.empty());
 
@@ -111,7 +109,7 @@ TEST_CASE("BidiAnalyzer pure-Arabic has base level 1 and an RTL run",
 }
 
 TEST_CASE("BidiAnalyzer mixed Latin + Arabic emits multiple runs",
-          "[bidi][issue-6.8]") {
+          "[bidi]") {
     // "Hello مرحبا world" — Latin prefix, Arabic middle, Latin suffix.
     const std::string mixed = concat3(kLatinHello, kArabicMarhaba, kLatinWorld);
     auto bp = BidiAnalyzer::analyze(mixed, BidiBaseDirection::Auto);
@@ -155,7 +153,7 @@ TEST_CASE("BidiAnalyzer mixed Latin + Arabic emits multiple runs",
 }
 
 TEST_CASE("BidiAnalyzer Latin + Hebrew emits multiple runs",
-          "[bidi][issue-6.8]") {
+          "[bidi]") {
     const std::string mixed = concat3(kLatinHello, kHebrewShalom, kLatinWorld);
     auto bp = BidiAnalyzer::analyze(mixed, BidiBaseDirection::Auto);
 
@@ -179,7 +177,7 @@ TEST_CASE("BidiAnalyzer Latin + Hebrew emits multiple runs",
     }
 }
 
-TEST_CASE("BidiAnalyzer respects forced base direction", "[bidi][issue-6.8]") {
+TEST_CASE("BidiAnalyzer respects forced base direction", "[bidi]") {
     // Forcing RTL on a Latin-only string still gives base_level = 1
     // even though all individual runs are LTR (level 0). This is the
     // UBA rule P3 surface — useful for an editor where the user picked
@@ -199,7 +197,7 @@ TEST_CASE("BidiAnalyzer respects forced base direction", "[bidi][issue-6.8]") {
 }
 
 TEST_CASE("BidiAnalyzer visual_order reverses RTL-only paragraph",
-          "[bidi][issue-6.8]") {
+          "[bidi]") {
     // Three runs at level 1 (all RTL) — visual order should reverse
     // them so the rightmost logical run paints first.
     std::vector<BidiRun> runs = {
@@ -215,7 +213,7 @@ TEST_CASE("BidiAnalyzer visual_order reverses RTL-only paragraph",
 }
 
 TEST_CASE("BidiAnalyzer visual_order leaves LTR runs alone",
-          "[bidi][issue-6.8]") {
+          "[bidi]") {
     std::vector<BidiRun> runs = {
         {0,  4, 0},
         {4,  6, 0},
@@ -227,7 +225,7 @@ TEST_CASE("BidiAnalyzer visual_order leaves LTR runs alone",
 }
 
 TEST_CASE("BidiAnalyzer visual_order reverses RTL island inside LTR",
-          "[bidi][issue-6.8]") {
+          "[bidi]") {
     // Mixed Latin-Hebrew-Latin: logical order is L0, L1, L0; visual
     // order keeps L0 runs in place but the L1 run stays in the middle
     // (single RTL run reverses trivially to itself). The interesting
@@ -247,7 +245,7 @@ TEST_CASE("BidiAnalyzer visual_order reverses RTL island inside LTR",
 }
 
 TEST_CASE("TextRunPlanner emits multiple runs for mixed Latin+Arabic",
-          "[bidi][issue-6.8][planner]") {
+          "[bidi][planner]") {
     // Even on builds without Skia (non-ICU path), the new SheenBidi
     // fallback should let the planner emit more than one run for
     // mixed-direction text. Under PULP_HAS_SKIA the ICU path also


### PR DESCRIPTION
## Summary
- removed stale item 6.8 / 2026-05 planning breadcrumbs from the Bidi analyzer header, implementation, and focused tests
- reworded Bidi comments so they describe the current SheenBidi / single-line label paint behavior without roadmap phrasing
- dropped obsolete Catch2 `[issue-6.8]` tags while preserving `[bidi]` and `[planner]` selection tags

## Validation
- `git fetch origin main` -> `origin/main` = `d26f94f8a53cd177d1595eed0e1bc53668f9abcc`; branch merge-base matched
- `git diff --check`
- targeted stale-marker scan over touched Bidi files for item/date/roadmap/Codex/follow-up markers and `[issue-6.8]` tags
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target pulp-test-bidi-text -j$(sysctl -n hw.ncpu)`
- `build/test/pulp-test-bidi-text` -> 43 assertions in 11 test cases
- Release flag check confirmed `CMAKE_BUILD_TYPE=Release` and `-O3 -DNDEBUG` for `pulp-test-bidi-text`, `pulp-canvas`, and `pulp-runtime`
- Claude adversarial autoreview: first pass found a dangling comment parenthesis, fixed; second pass clean with no accepted/actionable findings
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/bidi-comment-hygiene` -> pre-push gates clean

## Notes
- RepoPrompt MCP tools were requested for analysis, but no RepoPrompt tools are available in this Codex session (`tool_search` returned zero matches), so local git/search/tooling was used instead.
- I avoided `test/CMakeLists.txt` because open cleanup PRs already touch it; nearby stale item 6.8 breadcrumbs outside this slice remain for a later non-overlapping cleanup.
- Fresh worktree has the optional `planning/` submodule uninitialized, so generated-import optional checks reported skipped planning fixtures during pre-push.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale 6.8 planning breadcrumbs and roadmap phrasing from Bidi analyzer comments and tests to match current `SheenBidi` single-line label behavior. Dropped obsolete `[issue-6.8]` tags while keeping `[bidi]` and `[planner]`; no functional changes.

<sup>Written for commit a1fb58ae1d8c0277f2decc13c4a5ae0fb1c19979. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

