### PR TITLE
docs: clean vector scene comment archaeology

### DIFF
--- a/core/canvas/include/pulp/canvas/scene/scene.hpp
+++ b/core/canvas/include/pulp/canvas/scene/scene.hpp
@@ -1,6 +1,5 @@
 // VectorScene — the root of Pulp's retained vector scene graph.
 //
-// Item 6.1 of `planning/2026-05-24-macos-plugin-authoring-plan.md`.
 // License-lineage note: the Pulp-side primitives use Pulp-native names
 // (`VectorScene`, `SceneNode`, `ScenePath`, `SceneShape`, `SceneImage`,
 // `SceneText`, `SceneGroup`) rather than any reference framework's
@@ -19,11 +18,11 @@
 //     want a one-to-one container per design-node so round-tripping
 //     stays predictable.
 //
-// Acceptance (from the plan):
-//   - SVG loads as a `VectorScene` or `SceneGroup` ✔
+// Current behavior:
+//   - SVG loads as a `VectorScene` or `SceneGroup`.
 //   - Mutating a child's opacity re-paints only that sub-tree's
-//     bounding box ✔ (see `take_dirty_rect()`)
-//   - Renders via existing SkiaCanvas (and CG / RecordingCanvas) ✔
+//     bounding box (see `take_dirty_rect()`).
+//   - Renders through the existing Canvas backends.
 #pragma once
 
 #include <pulp/canvas/scene/scene_group.hpp>

--- a/core/canvas/include/pulp/canvas/scene/scene_node.hpp
+++ b/core/canvas/include/pulp/canvas/scene/scene_node.hpp
@@ -1,6 +1,5 @@
 // SceneNode — abstract base of Pulp's retained vector scene graph.
 //
-// Item 6.1 of `planning/2026-05-24-macos-plugin-authoring-plan.md`.
 // License-lineage note: the Pulp scene-graph primitives use Pulp-native
 // names (`VectorScene`, `SceneNode`, `ScenePath`, `SceneShape`,
 // `SceneImage`, `SceneText`, `SceneGroup`) rather than any reference

--- a/core/canvas/src/scene.cpp
+++ b/core/canvas/src/scene.cpp
@@ -1,7 +1,6 @@
-// VectorScene + SceneNode subtree implementation. Item 6.1 of
-// `planning/2026-05-24-macos-plugin-authoring-plan.md` — see
-// `core/canvas/include/pulp/canvas/scene/scene.hpp` for the
-// license-lineage note and design rationale.
+// VectorScene + SceneNode subtree implementation. See
+// `core/canvas/include/pulp/canvas/scene/scene.hpp` for the API
+// contract, license-lineage note, and design rationale.
 
 #include <pulp/canvas/scene/scene.hpp>
 

--- a/test/test_vector_scene.cpp
+++ b/test/test_vector_scene.cpp
@@ -1,10 +1,9 @@
-// Item 6.1 of `planning/2026-05-24-macos-plugin-authoring-plan.md`:
-// VectorScene retained scene graph. Acceptance criteria:
-//   1. SVG loads as a VectorScene / SceneGroup.
-//   2. Mutating a child's opacity re-paints only that sub-tree's
-//      bounding box.
-//   3. Renders through the existing Canvas API (RecordingCanvas here
-//      exercises the command stream without requiring Skia).
+// VectorScene retained scene graph coverage:
+//   - SVG loads as a VectorScene / SceneGroup.
+//   - Mutating a child's opacity re-paints only that sub-tree's
+//     bounding box.
+//   - Rendering goes through the Canvas API; RecordingCanvas exercises
+//     the command stream without requiring Skia.
 //
 // Pulp-native names — no reference-framework class-name lineage.
 
@@ -36,7 +35,7 @@ size_t count_op(const RecordingCanvas& rc, DrawCommand::Type t) {
 
 }  // namespace
 
-TEST_CASE("SceneRect united / map_rect math", "[canvas][scene][issue-2700]") {
+TEST_CASE("SceneRect united / map_rect math", "[canvas][scene]") {
     SceneRect empty{};
     REQUIRE(empty.empty());
 
@@ -69,7 +68,7 @@ TEST_CASE("SceneRect united / map_rect math", "[canvas][scene][issue-2700]") {
 }
 
 TEST_CASE("SceneShape local_bounds for each kind",
-          "[canvas][scene][issue-2700]") {
+          "[canvas][scene]") {
     auto rect = SceneShape::make_rect(5, 10, 30, 40);
     REQUIRE(approx_eq(rect->local_bounds(), SceneRect{5, 10, 30, 40}));
 
@@ -92,7 +91,7 @@ TEST_CASE("SceneShape local_bounds for each kind",
 }
 
 TEST_CASE("ScenePath bounds and command playback",
-          "[canvas][scene][issue-2700]") {
+          "[canvas][scene]") {
     ScenePath path;
     path.move_to(0, 0);
     path.line_to(100, 0);
@@ -116,7 +115,7 @@ TEST_CASE("ScenePath bounds and command playback",
 }
 
 TEST_CASE("SceneGroup union of child bounds + visibility",
-          "[canvas][scene][issue-2700]") {
+          "[canvas][scene]") {
     SceneGroup g;
     auto* a = static_cast<SceneShape*>(g.add_child(SceneShape::make_rect(0, 0, 10, 10)));
     auto* b = static_cast<SceneShape*>(g.add_child(SceneShape::make_rect(50, 60, 5, 5)));
@@ -134,8 +133,8 @@ TEST_CASE("SceneGroup union of child bounds + visibility",
 }
 
 TEST_CASE("VectorScene::from_svg_string populates a SceneGroup",
-          "[canvas][scene][issue-2700]") {
-    // Acceptance criterion #1: "an SVG loads as a VectorScene (or SceneGroup)".
+          "[canvas][scene]") {
+    // SVG input should populate the retained scene graph.
     const char* svg = R"(
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"
      width="100" height="100">
@@ -169,9 +168,9 @@ TEST_CASE("VectorScene::from_svg_string populates a SceneGroup",
 }
 
 TEST_CASE("Mutating a child's opacity yields a sub-tree-sized dirty rect",
-          "[canvas][scene][issue-2700]") {
-    // Acceptance criterion #2: "mutating one child's opacity re-paints
-    // only that sub-tree's bounding box".
+          "[canvas][scene]") {
+    // Mutating one child's opacity should repaint only that sub-tree's
+    // bounding box.
     VectorScene scene;
     auto* group = &scene.root();
 
@@ -213,7 +212,7 @@ TEST_CASE("Mutating a child's opacity yields a sub-tree-sized dirty rect",
 }
 
 TEST_CASE("Translating a child shifts the dirty rect to cover old + new",
-          "[canvas][scene][issue-2700]") {
+          "[canvas][scene]") {
     // The "old + new" union is what a host actually needs to clear the
     // previous pixels AND paint the new ones. Make sure we capture both.
     VectorScene scene;
@@ -235,7 +234,7 @@ TEST_CASE("Translating a child shifts the dirty rect to cover old + new",
 }
 
 TEST_CASE("SceneGroup add/remove child keeps parent pointer correct",
-          "[canvas][scene][issue-2700]") {
+          "[canvas][scene]") {
     SceneGroup g;
     auto* a = static_cast<SceneShape*>(
         g.add_child(SceneShape::make_rect(0, 0, 10, 10)));
@@ -247,7 +246,7 @@ TEST_CASE("SceneGroup add/remove child keeps parent pointer correct",
 }
 
 TEST_CASE("SceneText emits set_font + fill_text",
-          "[canvas][scene][issue-2700]") {
+          "[canvas][scene]") {
     SceneText text;
     text.set_text("hello");
     text.set_position(10, 20);
@@ -265,7 +264,7 @@ TEST_CASE("SceneText emits set_font + fill_text",
 }
 
 TEST_CASE("SceneImage emits draw_image_from_file when given a path",
-          "[canvas][scene][issue-2700]") {
+          "[canvas][scene]") {
     SceneImage img;
     img.set_file_path("/nonexistent.png");  // RecordingCanvas just records.
     img.set_rect(10, 10, 50, 50);
@@ -276,7 +275,7 @@ TEST_CASE("SceneImage emits draw_image_from_file when given a path",
 }
 
 TEST_CASE("Nested groups walk in depth-first order during paint",
-          "[canvas][scene][issue-2700]") {
+          "[canvas][scene]") {
     // Walker contract: child group with one rect paints inside parent
     // group's transform. We verify by counting fill_rect commands.
     VectorScene scene;
@@ -292,7 +291,7 @@ TEST_CASE("Nested groups walk in depth-first order during paint",
 }
 
 TEST_CASE("paint clears dirty + snapshots last_painted_bounds",
-          "[canvas][scene][issue-2700]") {
+          "[canvas][scene]") {
     VectorScene scene;
     auto* shape = static_cast<SceneShape*>(
         scene.root().add_child(SceneShape::make_rect(5, 5, 10, 10)));


### PR DESCRIPTION
## Summary
- removed stale Item 6.1 / 2026-05 planning breadcrumbs from the retained VectorScene header, SceneNode header, implementation, and focused tests
- reworded plan-era acceptance comments as current retained scene graph behavior and test coverage notes
- dropped obsolete Catch2 `[issue-2700]` tags while preserving `[canvas][scene]` selection tags

## Validation
- `git fetch origin main` -> `origin/main` = `d26f94f8a53cd177d1595eed0e1bc53668f9abcc`; branch merge-base matched
- `git diff --check`
- targeted stale-marker scan over touched scene files and `test/test_vector_scene.cpp` for item/date/planning/acceptance/Codex/follow-up markers and `[issue-2700]` tags
- repo tag-reference scan found no `[issue-2700]` / `issue-2700]` selectors after the test tag cleanup
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target pulp-test-vector-scene -j$(sysctl -n hw.ncpu)`
- `build/test/pulp-test-vector-scene` -> 57 assertions in 12 test cases
- Release flag check confirmed `CMAKE_BUILD_TYPE=Release` and `-O3 -DNDEBUG` for `pulp-test-vector-scene`, `pulp-canvas`, and `pulp-runtime`
- Claude adversarial autoreview clean with no accepted/actionable findings
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/scene-comment-hygiene` -> pre-push gates clean

## Notes
- RepoPrompt MCP tools were requested for analysis, but no RepoPrompt tools are available in this Codex session (`tool_search` returned zero matches), so local git/search/tooling was used instead.
- I avoided `test/CMakeLists.txt` because open cleanup PRs already touch it; its nearby retained-scene comment remains for a later non-overlapping cleanup.
- Fresh worktree has the optional `planning/` submodule uninitialized, so generated-import optional checks reported skipped planning fixtures during configure/pre-push.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up VectorScene/SceneNode docs and tests by removing stale 2026-05 planning notes and rewriting comments to describe current retained-scene behavior. Dropped obsolete [issue-2700] test tags; no functional changes.

- **Refactors**
  - Removed plan-era breadcrumbs from `scene.hpp`, `scene_node.hpp`, and `scene.cpp`.
  - Reworded comments to document current behavior (SVG load, dirty rects, Canvas backends).
  - Simplified test annotations: kept [canvas][scene], removed [issue-2700], and clarified test comments.

<sup>Written for commit f18713c14437bd8dbbaa32f7b705affb65483306. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

