### PR TITLE
docs: clean wav metadata comment archaeology

### DIFF
--- a/core/audio/include/pulp/audio/wav_metadata.hpp
+++ b/core/audio/include/pulp/audio/wav_metadata.hpp
@@ -1,10 +1,9 @@
 // wav_metadata.hpp — read + write WAV ancillary metadata chunks.
 //
-// Implements item 6.11 of the 2026-05-24 macOS plugin authoring plan
-// (BWAV / iXML / ASWG / ACID). Reads metadata from any RIFF-WAVE or
-// RF64-extended WAV file, lets you mutate it in-memory, then writes it
-// back without rewriting the audio payload (the original `fmt ` and
-// `data` chunks are preserved verbatim).
+// Handles BWAV / iXML / ASWG / ACID metadata in RIFF-WAVE and RF64-
+// extended WAV files. Metadata can be mutated in-memory and written back
+// without rewriting the audio payload; the original `fmt ` and `data`
+// chunks are preserved verbatim.
 //
 // Why a hand-rolled chunk codec on top of CHOC: CHOC's WAV reader
 // gives us PCM samples but only surfaces a small subset of metadata

--- a/test/test_wav_metadata.cpp
+++ b/test/test_wav_metadata.cpp
@@ -1,6 +1,5 @@
 // test_wav_metadata.cpp — round-trip tests for BWAV / iXML / ASWG / ACID
-// metadata. Covers item 6.11 of the 2026-05-24 macOS plugin authoring
-// plan.
+// metadata.
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
@@ -82,7 +81,7 @@ bool bwav_eq(const BwavMetadata& a, const BwavMetadata& b) {
 
 } // namespace
 
-TEST_CASE("BWAV bext chunk round-trips through encode/decode", "[audio][wav][metadata][bwav][issue-6_11]") {
+TEST_CASE("BWAV bext chunk round-trips through encode/decode", "[audio][wav][metadata][bwav]") {
     auto src = make_bwav_fixture();
     auto bytes = encode_bext_chunk(src);
     // Fixed header (602) + coding_history length.
@@ -93,7 +92,7 @@ TEST_CASE("BWAV bext chunk round-trips through encode/decode", "[audio][wav][met
     REQUIRE(bwav_eq(src, *rt));
 }
 
-TEST_CASE("BWAV bext truncates over-long fixed strings without UB", "[audio][wav][metadata][bwav][issue-6_11]") {
+TEST_CASE("BWAV bext truncates over-long fixed strings without UB", "[audio][wav][metadata][bwav]") {
     BwavMetadata src;
     src.description = std::string(400, 'x'); // overflow 256-byte slot
     src.originator = std::string(60, 'y');   // overflow 32-byte slot
@@ -107,13 +106,13 @@ TEST_CASE("BWAV bext truncates over-long fixed strings without UB", "[audio][wav
     CHECK(rt->origination_date == "2026-05-24");
 }
 
-TEST_CASE("BWAV decode rejects undersized payload", "[audio][wav][metadata][bwav][issue-6_11]") {
+TEST_CASE("BWAV decode rejects undersized payload", "[audio][wav][metadata][bwav]") {
     std::vector<uint8_t> garbage(64, 0xAB);
     auto rt = decode_bext_chunk(garbage.data(), garbage.size());
     REQUIRE_FALSE(rt.has_value());
 }
 
-TEST_CASE("ACID chunk round-trips through encode/decode", "[audio][wav][metadata][acid][issue-6_11]") {
+TEST_CASE("ACID chunk round-trips through encode/decode", "[audio][wav][metadata][acid]") {
     auto src = make_acid_fixture();
     auto bytes = encode_acid_chunk(src);
     REQUIRE(bytes.size() == 24);
@@ -130,13 +129,13 @@ TEST_CASE("ACID chunk round-trips through encode/decode", "[audio][wav][metadata
     CHECK_THAT(rt->tempo_bpm, WithinAbs(src.tempo_bpm, 1e-4f));
 }
 
-TEST_CASE("ACID decode rejects undersized payload", "[audio][wav][metadata][acid][issue-6_11]") {
+TEST_CASE("ACID decode rejects undersized payload", "[audio][wav][metadata][acid]") {
     std::vector<uint8_t> tiny(12, 0);
     auto rt = decode_acid_chunk(tiny.data(), tiny.size());
     REQUIRE_FALSE(rt.has_value());
 }
 
-TEST_CASE("Full WAV metadata file round-trip with all four chunk kinds", "[audio][wav][metadata][issue-6_11]") {
+TEST_CASE("Full WAV metadata file round-trip with all four chunk kinds", "[audio][wav][metadata]") {
     auto path = scratch_file("full");
     WavMetadata src;
     src.bwav = make_bwav_fixture();
@@ -168,7 +167,7 @@ TEST_CASE("Full WAV metadata file round-trip with all four chunk kinds", "[audio
     std::filesystem::remove(path, ec);
 }
 
-TEST_CASE("read_wav_metadata returns empty struct for WAV with no metadata", "[audio][wav][metadata][issue-6_11]") {
+TEST_CASE("read_wav_metadata returns empty struct for WAV with no metadata", "[audio][wav][metadata]") {
     auto path = scratch_file("bare");
     WavMetadata empty; // no bwav/acid/ixml/axml
     REQUIRE(write_wav_metadata(path.string(), empty, 44100, 2, 24));
@@ -184,7 +183,7 @@ TEST_CASE("read_wav_metadata returns empty struct for WAV with no metadata", "[a
     std::filesystem::remove(path, ec);
 }
 
-TEST_CASE("read_wav_metadata fails cleanly on non-existent path", "[audio][wav][metadata][issue-6_11]") {
+TEST_CASE("read_wav_metadata fails cleanly on non-existent path", "[audio][wav][metadata]") {
     auto missing = std::filesystem::temp_directory_path()
                  / "pulp-wav-metadata-this-does-not-exist-xyz.wav";
     std::error_code ec;
@@ -193,7 +192,7 @@ TEST_CASE("read_wav_metadata fails cleanly on non-existent path", "[audio][wav][
     REQUIRE_FALSE(rt.has_value());
 }
 
-TEST_CASE("read_wav_metadata fails on non-RIFF data", "[audio][wav][metadata][issue-6_11]") {
+TEST_CASE("read_wav_metadata fails on non-RIFF data", "[audio][wav][metadata]") {
     auto path = scratch_file("notriff");
     {
         std::ofstream out(path, std::ios::binary);
@@ -205,7 +204,7 @@ TEST_CASE("read_wav_metadata fails on non-RIFF data", "[audio][wav][metadata][is
     std::filesystem::remove(path, ec);
 }
 
-TEST_CASE("replace_metadata_in_file preserves fmt/data and rewrites chunks", "[audio][wav][metadata][issue-6_11]") {
+TEST_CASE("replace_metadata_in_file preserves fmt/data and rewrites chunks", "[audio][wav][metadata]") {
     auto path = scratch_file("inplace");
 
     WavMetadata initial;
@@ -247,7 +246,7 @@ TEST_CASE("replace_metadata_in_file preserves fmt/data and rewrites chunks", "[a
     std::filesystem::remove(path, ec);
 }
 
-TEST_CASE("Unknown chunks survive a read+write round-trip", "[audio][wav][metadata][issue-6_11]") {
+TEST_CASE("Unknown chunks survive a read+write round-trip", "[audio][wav][metadata]") {
     auto path = scratch_file("unknown");
 
     WavMetadata src;


### PR DESCRIPTION
## Summary

- Remove stale item 6.11 / 2026-05 macOS plugin-authoring plan wording from the WAV metadata header and tests.
- Drop the obsolete `[issue-6_11]` Catch2 tags while preserving the useful `[audio][wav][metadata]`, `[bwav]`, and `[acid]` selectors.
- Keep the real `2026-05-24` fixture values because they are encoded BWAV metadata test values, not workflow breadcrumbs.

## Validation

- Refreshed `origin/main`; branch merge-base is `d26f94f8a53cd177d1595eed0e1bc53668f9abcc`.
- `git diff --check`
- Targeted stale scan over `core/audio/include/pulp/audio/wav_metadata.hpp` and `test/test_wav_metadata.cpp` for item 6.11 / macOS plugin authoring plan / issue tag / planning breadcrumbs: clean.
- Repo-wide scan for `issue-6_11` and `[issue-6_11]`: clean.
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target pulp-test-wav-metadata -j$(sysctl -n hw.ncpu)`
- `build/test/pulp-test-wav-metadata` (60 assertions in 11 test cases)
- Verified `CMAKE_BUILD_TYPE:STRING=Release` and `-O3 -DNDEBUG` in `pulp-test-wav-metadata`, `pulp-audio`, and `pulp-runtime` flags.
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main --prompt ...` reported clean with no accepted/actionable findings.
- Pre-push hook gates clean.

## Notes

- RepoPrompt was requested, but RepoPrompt MCP tools are not exposed in this Codex session (`tool_search` returned no matching tools), so this slice used local git/search/build tooling.
- `test/CMakeLists.txt` still has adjacent stale wording but was left untouched to avoid overlap with open cleanup PRs.
- Fresh worktree has the `planning` submodule uninitialized, so optional generated-import targets were skipped during configure/pre-push validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale macOS plan/issue references from the WAV metadata header and tests, and cleaned up obsolete Catch2 tags. No functional changes.

- **Refactors**
  - Rewrote `wav_metadata.hpp` header comment to describe BWAV/iXML/ASWG/ACID support; removed plan wording.
  - Dropped `[issue-6_11]` tags from tests while keeping `[audio][wav][metadata]`, `[bwav]`, and `[acid]`; preserved real `2026-05-24` BWAV fixture values.

<sup>Written for commit e543b7aa9b6c5524c1f5607d45f022d5454b1b64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

