### PR TITLE
docs: clean command registry comment archaeology

### DIFF
--- a/core/view/include/pulp/view/command_registry.hpp
+++ b/core/view/include/pulp/view/command_registry.hpp
@@ -4,11 +4,10 @@
 /// CommandRegistry + CommandHandler + CommandInfo + ShortcutMap — Pulp-native
 /// command dispatch and keyboard-shortcut routing.
 ///
-/// Pulp-native naming per the license-lineage note in
-/// `planning/2026-05-24-macos-plugin-authoring-plan.md` section 6.4: the
-/// primitives are deliberately *not* named after any reference framework's
-/// classes. The behavior contract is "a key event finds the topmost focused
-/// handler that claims a command and dispatches to it".
+/// The primitives are named for Pulp's command model rather than mirroring
+/// any reference framework's class names. The behavior contract is "a key
+/// event finds the topmost focused handler that claims a command and
+/// dispatches to it".
 ///
 /// ## Architecture
 ///
@@ -44,7 +43,7 @@
 ///   (a) call `dispatch_key_event` BEFORE the normal `on_key_event`
 ///       delivery — global shortcuts win;
 ///   (b) call it AFTER — focused widget wins, with the registry as a
-///       fall-through (the macOS-MVP plan's default).
+///       fall-through after focused-widget handling.
 ///
 /// ## Persistence
 ///

--- a/core/view/include/pulp/view/key_mapping_editor.hpp
+++ b/core/view/include/pulp/view/key_mapping_editor.hpp
@@ -3,11 +3,10 @@
 /// @file key_mapping_editor.hpp
 /// KeyMappingEditor — Pulp-native UI for rebinding command shortcuts.
 ///
-/// Pulp-native naming per planning/2026-05-24-macos-plugin-authoring-plan.md
-/// section 6.4. The editor is a `View` that lists every command registered
-/// with a `CommandRegistry`, shows each command's current chord, and lets
-/// the user pick a row + press a new chord to rebind. Changes are committed
-/// to the registry's `ShortcutMap` and persisted through
+/// The editor is a `View` that lists every command registered with a
+/// `CommandRegistry`, shows each command's current chord, and lets the user
+/// pick a row + press a new chord to rebind. Changes are committed to the
+/// registry's `ShortcutMap` and persisted through
 /// `pulp::state::ApplicationProperties::user_settings()` (or any caller-
 /// supplied `PropertiesFile`).
 ///

--- a/core/view/src/command_registry.cpp
+++ b/core/view/src/command_registry.cpp
@@ -1,8 +1,8 @@
 // command_registry.cpp — Pulp-native command dispatch + shortcut routing.
 //
 // See `core/view/include/pulp/view/command_registry.hpp` for the contract.
-// Pulp-native names per planning/2026-05-24-macos-plugin-authoring-plan.md
-// section 6.4 (license-lineage note).
+// Names stay aligned with Pulp's command model rather than reference
+// framework class names.
 
 #include <pulp/view/command_registry.hpp>
 #include <pulp/state/properties_file.hpp>

--- a/test/test_command_registry.cpp
+++ b/test/test_command_registry.cpp
@@ -1,12 +1,9 @@
 // test_command_registry.cpp — coverage for the Pulp-native CommandRegistry,
 // CommandHandler, CommandInfo, ShortcutMap, and KeyMappingEditor primitives.
 //
-// Section 6.4 of planning/2026-05-24-macos-plugin-authoring-plan.md:
-//   "a Pulp app registers commands + key bindings; keypress routes to the
-//    focused command handler; rebind UI persists via
-//    pulp::state::ApplicationProperties."
-//
-// Each test below pins one row of that contract.
+// A Pulp app registers commands + key bindings; keypresses route to the
+// focused command handler; the rebind UI persists through
+// pulp::state::ApplicationProperties.
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -61,7 +58,7 @@ std::string temp_props_path(const char* suffix) {
 } // namespace
 
 TEST_CASE("CommandRegistry registers commands and binds default chords",
-          "[view][command_registry][issue-6.4]") {
+          "[view][command_registry]") {
     CommandRegistry reg;
 
     CommandInfo open{kCmdOpen, "Open File", "File", KeyCode::o, kModCmd};
@@ -80,7 +77,7 @@ TEST_CASE("CommandRegistry registers commands and binds default chords",
 }
 
 TEST_CASE("CommandRegistry re-registration replaces existing info",
-          "[view][command_registry][issue-6.4]") {
+          "[view][command_registry]") {
     CommandRegistry reg;
     reg.register_command({kCmdOpen, "Open", "File"});
     reg.register_command({kCmdOpen, "Open File…", "File"});
@@ -89,7 +86,7 @@ TEST_CASE("CommandRegistry re-registration replaces existing info",
 }
 
 TEST_CASE("CommandRegistry dispatch walks handler chain top-to-bottom",
-          "[view][command_registry][issue-6.4]") {
+          "[view][command_registry]") {
     CommandRegistry reg;
     reg.register_command({kCmdOpen, "Open", "File"});
 
@@ -113,7 +110,7 @@ TEST_CASE("CommandRegistry dispatch walks handler chain top-to-bottom",
 }
 
 TEST_CASE("CommandRegistry::dispatch_key_event routes through ShortcutMap",
-          "[view][command_registry][issue-6.4]") {
+          "[view][command_registry]") {
     CommandRegistry reg;
     reg.register_command({kCmdOpen, "Open", "File", KeyCode::o, kModCmd});
 
@@ -140,7 +137,7 @@ TEST_CASE("CommandRegistry::dispatch_key_event routes through ShortcutMap",
 }
 
 TEST_CASE("CommandRegistry remove_handler stops dispatching to it",
-          "[view][command_registry][issue-6.4]") {
+          "[view][command_registry]") {
     CommandRegistry reg;
     reg.register_command({kCmdOpen, "Open", "File"});
 
@@ -160,7 +157,7 @@ TEST_CASE("CommandRegistry remove_handler stops dispatching to it",
 }
 
 TEST_CASE("ShortcutMap binds, unbinds, and lists chords",
-          "[view][command_registry][issue-6.4]") {
+          "[view][command_registry]") {
     ShortcutMap map;
     map.bind(KeyCode::o, kModCmd, kCmdOpen);
     map.bind(KeyCode::f5, 0, kCmdOpen);   // two chords → same command
@@ -192,7 +189,7 @@ TEST_CASE("ShortcutMap binds, unbinds, and lists chords",
 }
 
 TEST_CASE("ShortcutMap rebinding replaces the previous owner",
-          "[view][command_registry][issue-6.4]") {
+          "[view][command_registry]") {
     ShortcutMap map;
     map.bind(KeyCode::o, kModCmd, kCmdOpen);
     map.bind(KeyCode::o, kModCmd, kCmdSave);   // steal the chord
@@ -200,7 +197,7 @@ TEST_CASE("ShortcutMap rebinding replaces the previous owner",
 }
 
 TEST_CASE("ShortcutMap persists through PropertiesFile round-trip",
-          "[view][command_registry][issue-6.4]") {
+          "[view][command_registry]") {
     ShortcutMap map;
     map.bind(KeyCode::o, kModCmd, kCmdOpen);
     map.bind(KeyCode::s, kModCmd, kCmdSave);
@@ -229,7 +226,7 @@ TEST_CASE("ShortcutMap persists through PropertiesFile round-trip",
 }
 
 TEST_CASE("CommandRegistry loaded ShortcutMap takes priority over defaults",
-          "[view][command_registry][issue-6.4]") {
+          "[view][command_registry]") {
     // The header documents: "load() before register_command so user
     // rebindings take priority." This pins that ordering.
     pulp::state::PropertiesFile props;
@@ -249,7 +246,7 @@ TEST_CASE("CommandRegistry loaded ShortcutMap takes priority over defaults",
 }
 
 TEST_CASE("KeyMappingEditor: click row + press chord rebinds and persists",
-          "[view][command_registry][issue-6.4]") {
+          "[view][command_registry]") {
     CommandRegistry reg;
     reg.register_command({kCmdOpen, "Open", "File", KeyCode::o, kModCmd});
     reg.register_command({kCmdSave, "Save", "File", KeyCode::s, kModCmd});
@@ -293,7 +290,7 @@ TEST_CASE("KeyMappingEditor: click row + press chord rebinds and persists",
 }
 
 TEST_CASE("KeyMappingEditor::rebind() bypasses capture",
-          "[view][command_registry][issue-6.4]") {
+          "[view][command_registry]") {
     CommandRegistry reg;
     reg.register_command({kCmdOpen, "Open", "File", KeyCode::o, kModCmd});
     KeyMappingEditor editor(reg);
@@ -316,7 +313,7 @@ TEST_CASE("KeyMappingEditor::rebind() bypasses capture",
 }
 
 TEST_CASE("KeyMappingEditor accepts_text_input toggles with capture",
-          "[view][command_registry][issue-6.4]") {
+          "[view][command_registry]") {
     CommandRegistry reg;
     reg.register_command({kCmdOpen, "Open", "File"});
     KeyMappingEditor editor(reg);
@@ -328,7 +325,7 @@ TEST_CASE("KeyMappingEditor accepts_text_input toggles with capture",
 }
 
 TEST_CASE("format_chord renders modifiers in canonical order",
-          "[view][command_registry][issue-6.4]") {
+          "[view][command_registry]") {
     REQUIRE(format_chord(KeyCode::s, kModCmd) == "Cmd+S");
     REQUIRE(format_chord(KeyCode::o, kModCmd | kModShift) == "Shift+Cmd+O");
     REQUIRE(format_chord(KeyCode::f5, 0) == "F5");


### PR DESCRIPTION
## Summary

- Remove stale planning/2026-05-24 macOS plugin-authoring plan section 6.4 references from command registry and key mapping docs.
- Drop obsolete `[issue-6.4]` Catch2 tags while preserving the current `[view][command_registry]` coverage grouping.
- Keep the current behavior contract documented; no executable code changes.

## Validation

- Refreshed `origin/main`; merge-base is `d26f94f8a53cd177d1595eed0e1bc53668f9abcc`.
- `git diff --check`
- Touched-file stale-comment scan for `6.4`, `planning/2026-05-24`, `issue-6.4`, `roadmap`, `Codex`, `Claude`, `follow-up`, `backfill`: clean.
- Repo-wide `[issue-6.4]` scan across source/docs/test roots: clean.
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build --target pulp-test-command-registry -j$(sysctl -n hw.ncpu) && build/test/pulp-test-command-registry`
- `pulp-test-command-registry`: all tests passed, 97 assertions in 15 test cases.
- Release flags verified in `build/test/CMakeFiles/pulp-test-command-registry.dir/flags.make`, `build/core/view/CMakeFiles/pulp-view-core.dir/flags.make`, and `build/core/state/CMakeFiles/pulp-state.dir/flags.make` (`-O3 -DNDEBUG`).
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main --prompt ...`: clean, no accepted/actionable findings.
- Pre-push gates clean.

## Notes

- RepoPrompt was requested, but no RepoPrompt MCP tools are available in this session (`tool_search` returned 0); I used local git/search/build tooling instead.
- I intentionally left `test/CMakeLists.txt` untouched because multiple open cleanup PRs overlap that file.
- This fresh worktree has `planning/` uninitialized, so optional generated-import C++ targets/fixtures were skipped by configure and pre-push gates.
- The focused test emitted `InspectorWindow: WindowHost::create returned nullptr`; the suite still passed and this is the expected unsupported WindowHost path for this command-registry run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale references to the planning doc (section 6.4) and cleaned comments to clarify that names follow Pulp’s command model, not external frameworks. Dropped `[issue-6.4]` tags from Catch2 tests; no functional changes.

<sup>Written for commit b7e5ea59b3a26a031cbea5523aa2413527c96caf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

