### PR TITLE
docs: clean host scanner comment archaeology

### DIFF
--- a/core/host/include/pulp/host/scanner.hpp
+++ b/core/host/include/pulp/host/scanner.hpp
@@ -40,8 +40,6 @@ struct PluginInfo {
     int num_inputs = 2;
     int num_outputs = 2;
 
-    // ── Richer metadata (workstream 03 slice 3.7) ────────────────────────
-    //
     // Each scanner populates the subset it can cheaply extract. Callers
     // filter plugins on these instead of parsing `name` strings. All
     // fields are additive — older cache blobs that don't carry them
@@ -76,25 +74,20 @@ struct ScanOptions {
     bool scan_lv2 = true;
     std::vector<std::string> extra_paths;  // Additional scan directories
 
-    // Codex 2026-04-21 review on #545: when a test or hermetic tool
-    // supplies explicit extra_paths and wants ONLY those searched (not
-    // the platform defaults that pull in the user's installed plugin
-    // collection), set this to true. Fixes the non-hermetic
-    // test_host_regression scan that otherwise walked every system
-    // VST3/AU/CLAP on the dev's machine and could execute arbitrary
-    // third-party `clap_entry` code during a CI run.
+    // Restrict scanning to `extra_paths`, skipping the platform defaults.
+    // Tests and hermetic tools use this so they never walk a user's installed
+    // plugin collection or execute third-party CLAP entry points.
     bool only_extra_paths = false;
 
     // Callback for progress reporting during scan
     using ProgressCallback = std::function<void(const std::string& current_path, int scanned, int total)>;
     ProgressCallback on_progress;
 
-    // Workstream 03 slice 3.3b (issue #246): optional blacklist of
-    // bundle paths the scanner should skip. Populated by a prior
-    // crash (recorded by the out-of-process pulp-scan-worker). When
-    // non-null, scan() short-circuits any bundle whose path
-    // ScanBlacklist::is_blacklisted reports true and pushes nothing
-    // into the result for it. Caller-owned; must outlive scan().
+    // Optional blacklist of bundle paths the scanner should skip, usually
+    // populated from a prior out-of-process scanner crash. When non-null,
+    // scan() short-circuits any path reported by ScanBlacklist::is_blacklisted
+    // and pushes nothing into the result for it. Caller-owned; must outlive
+    // scan().
     class ScanBlacklist* blacklist = nullptr;
 };
 
@@ -128,7 +121,7 @@ private:
 
 // Clamp an untrusted CLAP plugin count — a malformed bundle's factory can
 // return an absurd value that would make reserve()/iteration throw and abort
-// the whole scan (#2703). Exposed for testing.
+// the whole scan. Exposed for testing.
 uint32_t cap_clap_plugin_count(uint32_t count) noexcept;
 
 } // namespace pulp::host

--- a/core/host/src/scanner.cpp
+++ b/core/host/src/scanner.cpp
@@ -24,7 +24,7 @@ namespace {
 // name. The URI is what `plugin_slot_lv2.cpp` keys against when selecting
 // a descriptor at load time, and it's what graph_serializer rehydration
 // uses to re-find the plugin across sessions (filenames collide; URIs
-// don't). Issue #491 P2.
+// don't).
 //
 // We only support the common manifest.ttl shape:
 //   <URI> a lv2:Plugin ;  ...
@@ -98,8 +98,7 @@ std::string parse_lv2_plugin_uri(const std::string& bundle_dir) {
 // class's CID normalized to a 32-char lowercase hex string. Returns
 // empty string when moduleinfo.json is missing or unparseable — the
 // scanner then falls back to the directory stem. No dlopen, no
-// bundleEntry: safe to call across an entire plugin folder. Issue
-// #491 P2.
+// bundleEntry: safe to call across an entire plugin folder.
 std::string read_vst3_bundle_fuid(const std::string& path);
 
 std::vector<std::string> PluginScanner::default_paths(PluginFormat format) {
@@ -176,13 +175,13 @@ PluginInfo PluginScanner::scan_vst3_bundle(const std::string& path) {
     info.format = PluginFormat::VST3;
     info.name = fs::path(path).stem().string();
 
-    // Issue #491 P2: prefer the real VST3 FUID (`PClassInfo::cid`) over
-    // the display name so graph_serializer rehydration keys against a
-    // stable 32-char plugin identity. Two plugins that happen to share
-    // a display name (e.g. "Compressor.vst3") used to collide when the
-    // graph serialized and reloaded across sessions. We read the CID
-    // from Contents/Resources/moduleinfo.json — Steinberg's declarative
-    // bundle metadata — so we never dlopen the plugin at scan time.
+    // Prefer the real VST3 FUID (`PClassInfo::cid`) over the display name so
+    // graph_serializer rehydration keys against a stable 32-char plugin
+    // identity. Two plugins that happen to share a display name (e.g.
+    // "Compressor.vst3") would otherwise collide when the graph serializes
+    // and reloads across sessions. We read the CID from
+    // Contents/Resources/moduleinfo.json — Steinberg's declarative bundle
+    // metadata — so we never dlopen the plugin at scan time.
     std::string fuid = read_vst3_bundle_fuid(path);
     if (!fuid.empty()) {
         info.unique_id = std::move(fuid);
@@ -218,11 +217,11 @@ PluginInfo PluginScanner::scan_lv2_bundle(const std::string& path) {
     info.format = PluginFormat::LV2;
     info.name = fs::path(path).stem().string();
 
-    // Issue #491 P2: prefer the plugin URI from manifest.ttl. The URI is
-    // what plugin_slot_lv2.cpp uses at load time to select the correct
-    // descriptor, and what graph_serializer rehydration matches against
-    // across sessions. Falls back to the directory stem on parse failure
-    // so the scanner stays best-effort.
+    // Prefer the plugin URI from manifest.ttl. The URI is what
+    // plugin_slot_lv2.cpp uses at load time to select the correct descriptor,
+    // and what graph_serializer rehydration matches against across sessions.
+    // Falls back to the directory stem on parse failure so the scanner stays
+    // best-effort.
     std::string uri = parse_lv2_plugin_uri(path);
     if (!uri.empty()) {
         info.unique_id = std::move(uri);
@@ -248,10 +247,8 @@ std::vector<PluginInfo> PluginScanner::scan_directory(const std::string& dir,
         auto path = entry.path().string();
         if (!is_plugin_bundle(path, format)) continue;
 
-        // #271 Codex P1 follow-up: consult blacklist BEFORE opening the
-        // bundle, so a bundle that crashed us on a previous scan never
-        // gets dlopen'd again. Post-scan filtering (the prior impl) still
-        // opened the bundle and could crash the scanner on every run.
+        // Consult the blacklist before opening the bundle so an entry that
+        // crashed a previous scan is never dlopen'd again.
         if (blacklist && blacklist->is_blacklisted(path)) continue;
 
         switch (format) {
@@ -293,8 +290,7 @@ std::vector<PluginInfo> PluginScanner::scan(const ScanOptions& options) {
     int scanned = 0;
 
     auto scan_format = [&](PluginFormat fmt) {
-        // Codex 2026-04-21 review on #545: honor only_extra_paths so
-        // hermetic lanes (tests, offline tools) don't silently pull in
+        // Hermetic lanes can supply explicit scan roots without also walking
         // the machine's installed plugin collection.
         std::vector<std::string> paths;
         if (!options.only_extra_paths) {
@@ -306,10 +302,8 @@ std::vector<PluginInfo> PluginScanner::scan(const ScanOptions& options) {
             if (options.on_progress) {
                 options.on_progress(dir, scanned++, total_dirs);
             }
-            // Workstream 03 #246: pass the blacklist into scan_directory
-            // so bundles known to crash us never get dlopen'd. (Codex P1
-            // follow-up: old code filtered post-scan, which still
-            // crashed the scanner on the offending bundle every time.)
+            // Keep blacklist filtering inside scan_directory so skipped
+            // bundles are rejected before any format scanner can open them.
             auto found = scan_directory(dir, fmt, options.blacklist);
             all.insert(all.end(), found.begin(), found.end());
         }
@@ -323,7 +317,7 @@ std::vector<PluginInfo> PluginScanner::scan(const ScanOptions& options) {
     // AU enumeration uses CoreAudio's AudioComponentFindNext, which walks
     // the system component registry — `extra_paths` doesn't apply. Honor
     // `only_extra_paths` by skipping AU entirely when the caller wants a
-    // hermetic path-list scan. Codex 2026-04-21 review on #545.
+    // hermetic path-list scan.
     if (options.scan_au && !options.only_extra_paths) {
         auto au_plugins = scan_audio_units();
         all.insert(all.end(), au_plugins.begin(), au_plugins.end());

--- a/core/host/src/scanner_clap.cpp
+++ b/core/host/src/scanner_clap.cpp
@@ -40,7 +40,7 @@ std::string resolve_clap_binary(const std::string& path) {
 
 uint32_t cap_clap_plugin_count(uint32_t count) noexcept {
     // No real CLAP bundle exposes thousands of plugins; clamp an untrusted
-    // count so a malformed factory can't drive an absurd allocation (#2703).
+    // count so a malformed factory can't drive an absurd allocation.
     constexpr uint32_t kMaxClapPluginsPerBundle = 1024;
     return count > kMaxClapPluginsPerBundle ? kMaxClapPluginsPerBundle : count;
 }
@@ -65,16 +65,11 @@ PluginInfo make_filename_fallback(const std::string& path) {
 //
 // EVERY call into the loaded bundle (entry->init, entry->get_factory,
 // factory->get_plugin_count, factory->get_plugin_descriptor) is
-// wrapped in try/catch because the plugin's static init or descriptor
-// accessor can throw arbitrary C++ exceptions across the C ABI of
-// CLAP. Pulp #812 surfaced exactly this: a Pulp-built plugin with a
-// malformed JSON config threw `choc::json::ParseError` from inside
-// its bridge code at dlopen time, the unhandled exception walked up
-// past the C boundary, and `pulp scan` aborted with SIGABRT —
-// killing the entire scan even though all the *other* plugins
-// scanned cleanly. The catch boundary turns those crashes into
-// per-plugin warnings + filename-fallback entries, so one bad
-// neighbor can't take down the whole report.
+// wrapped in try/catch because a plugin's static init or descriptor
+// accessor can throw arbitrary C++ exceptions across the CLAP C ABI.
+// The catch boundary turns those failures into per-plugin warnings +
+// filename-fallback entries, so one bad bundle cannot take down the
+// whole scan.
 //
 // `catch (...)` is the broad sweep deliberately: the throwing plugin
 // might use a different C++ runtime than this binary (e.g. statically-
@@ -88,19 +83,16 @@ std::vector<PluginInfo> scan_clap_bundle_descriptors(const std::string& path) {
     auto binary = resolve_clap_binary(path);
     void* handle = dlopen(binary.c_str(), RTLD_LAZY | RTLD_LOCAL);
     if (!handle) { // LCOV_EXCL_START
-        // Defensive #812 fallback. Triggered only when dlopen itself
-        // fails — a malformed/corrupt CLAP bundle. Same family as the
-        // try/catch blocks below: not reachable from a unit test that
-        // doesn't ship a deliberately-broken CLAP fixture. The user-
-        // visible surface is exercised by `pulp scan --no-load`
-        // (test_cli_shellout.cpp [issue-812]).
+        // Defensive fallback for malformed/corrupt CLAP bundles. Same family
+        // as the try/catch blocks below: not reachable from a unit test that
+        // doesn't ship a deliberately broken CLAP fixture. The user-visible
+        // surface is exercised by `pulp scan --no-load`.
         //
-        // ASan caught (PR #1862 macOS ARM64 lane, 2026-05-12): cache
-        // `dlerror()` in a local before the format call. POSIX
-        // dlerror() clears its internal state after every call, so a
-        // ternary `dlerror() ? dlerror() : "..."` calls it twice and
-        // the SECOND call returns nullptr. std::format's
-        // string_view(nullptr) ctor then runs strlen on null → SEGV.
+        // Cache `dlerror()` in a local before formatting the warning. POSIX
+        // dlerror() clears its internal state after every call, so a ternary
+        // `dlerror() ? dlerror() : "..."` calls it twice and the second call
+        // returns nullptr. std::format's string_view(nullptr) constructor can
+        // then run strlen on null.
         const char* err = dlerror();
         runtime::log_warn("CLAP scan: dlopen failed for '{}': {}",
                           binary, err ? err : "unknown");
@@ -110,8 +102,8 @@ std::vector<PluginInfo> scan_clap_bundle_descriptors(const std::string& path) {
 
     auto* entry = static_cast<const clap_plugin_entry_t*>(dlsym(handle, "clap_entry"));
     if (!entry || !entry->init || !entry->get_factory) { // LCOV_EXCL_START
-        // Defensive #812 fallback — bundle dlopen'd OK but doesn't
-        // expose a valid clap_entry. Same rationale as above.
+        // Defensive fallback: bundle dlopen'd OK but doesn't expose a valid
+        // clap_entry.
         runtime::log_warn("CLAP scan: no clap_entry in '{}'", binary);
         dlclose(handle);
         results.push_back(make_filename_fallback(path));
@@ -122,19 +114,16 @@ std::vector<PluginInfo> scan_clap_bundle_descriptors(const std::string& path) {
     try {
         init_ok = entry->init(path.c_str());
     } catch (const std::exception& e) { // LCOV_EXCL_START
-        // Defensive #812 guard. Triggered only when a plugin's
-        // static-init code throws across the C ABI of clap_entry —
-        // not reachable from a unit test that doesn't ship its own
-        // throwing CLAP fixture, so excluded from coverage. The
-        // user-visible benefit is exercised by `pulp scan --no-load`
-        // (see test_cli_shellout.cpp [issue-812]).
-        runtime::log_warn("CLAP scan: entry->init threw for '{}': {} (#812 guard)",
+        // Defensive boundary for plugins that throw across clap_entry.
+        // Excluded from coverage because it requires a throwing CLAP fixture;
+        // the user-visible benefit is exercised by `pulp scan --no-load`.
+        runtime::log_warn("CLAP scan: entry->init threw for '{}': {}",
                           path, e.what());
         dlclose(handle);
         results.push_back(make_filename_fallback(path));
         return results;
     } catch (...) {
-        runtime::log_warn("CLAP scan: entry->init threw unknown exception for '{}' (#812 guard)",
+        runtime::log_warn("CLAP scan: entry->init threw unknown exception for '{}'",
                           path);
         dlclose(handle);
         results.push_back(make_filename_fallback(path));
@@ -151,17 +140,15 @@ std::vector<PluginInfo> scan_clap_bundle_descriptors(const std::string& path) {
         factory = static_cast<const clap_plugin_factory_t*>(
             entry->get_factory(CLAP_PLUGIN_FACTORY_ID));
     } catch (const std::exception& e) { // LCOV_EXCL_START
-        runtime::log_warn("CLAP scan: get_factory threw for '{}': {} (#812 guard)",
+        runtime::log_warn("CLAP scan: get_factory threw for '{}': {}",
                           path, e.what());
     } catch (...) {
-        runtime::log_warn("CLAP scan: get_factory threw unknown exception for '{}' (#812 guard)",
+        runtime::log_warn("CLAP scan: get_factory threw unknown exception for '{}'",
                           path);
     } // LCOV_EXCL_STOP
 
     if (!factory || !factory->get_plugin_count || !factory->get_plugin_descriptor) { // LCOV_EXCL_START
-        // Defensive #812 fallback — factory pointer or its method
-        // table is unusable. Same rationale as the dlopen / clap_entry
-        // fallbacks above.
+        // Defensive fallback: factory pointer or its method table is unusable.
         try { entry->deinit(); } catch (...) {}
         dlclose(handle);
         if (results.empty()) results.push_back(make_filename_fallback(path));
@@ -172,17 +159,17 @@ std::vector<PluginInfo> scan_clap_bundle_descriptors(const std::string& path) {
     try {
         count = factory->get_plugin_count(factory);
     } catch (const std::exception& e) { // LCOV_EXCL_START
-        runtime::log_warn("CLAP scan: get_plugin_count threw for '{}': {} (#812 guard)",
+        runtime::log_warn("CLAP scan: get_plugin_count threw for '{}': {}",
                           path, e.what());
     } catch (...) {
-        runtime::log_warn("CLAP scan: get_plugin_count threw unknown exception for '{}' (#812 guard)",
+        runtime::log_warn("CLAP scan: get_plugin_count threw unknown exception for '{}'",
                           path);
     } // LCOV_EXCL_STOP
     // A malformed bundle can RETURN (not throw) an absurd count; reserve(count)
     // would then throw bad_alloc/length_error outside the per-bundle fallback
-    // and abort the whole scan (#2703). Cap it before use.
+    // and abort the whole scan. Cap it before use.
     if (uint32_t capped = cap_clap_plugin_count(count); capped != count) {
-        runtime::log_warn("CLAP scan: '{}' reported {} plugins; capping at {} (#2703 guard)",
+        runtime::log_warn("CLAP scan: '{}' reported {} plugins; capping at {}",
                           path, count, capped);
         count = capped;
     }
@@ -192,11 +179,11 @@ std::vector<PluginInfo> scan_clap_bundle_descriptors(const std::string& path) {
         try {
             desc = factory->get_plugin_descriptor(factory, i);
         } catch (const std::exception& e) { // LCOV_EXCL_START
-            runtime::log_warn("CLAP scan: get_plugin_descriptor[{}] threw for '{}': {} (#812 guard)",
+            runtime::log_warn("CLAP scan: get_plugin_descriptor[{}] threw for '{}': {}",
                               i, path, e.what());
             continue;
         } catch (...) {
-            runtime::log_warn("CLAP scan: get_plugin_descriptor[{}] threw unknown for '{}' (#812 guard)",
+            runtime::log_warn("CLAP scan: get_plugin_descriptor[{}] threw unknown for '{}'",
                               i, path);
             continue;
         } // LCOV_EXCL_STOP
@@ -215,7 +202,7 @@ std::vector<PluginInfo> scan_clap_bundle_descriptors(const std::string& path) {
         //
         // Category assignment runs in two passes so a plugin advertising
         // both `audio-effect` and `analyzer` gets the more specific
-        // Analyzer label regardless of feature string order (#198 P2).
+        // Analyzer label regardless of feature string order.
         info.is_instrument = false;
         info.is_effect = true;
         bool has_audio_effect_tag = false;
@@ -231,10 +218,9 @@ std::vector<PluginInfo> scan_clap_bundle_descriptors(const std::string& path) {
                     has_audio_effect_tag = true;
                 } else if (std::strcmp(*f, CLAP_PLUGIN_FEATURE_NOTE_EFFECT) == 0) {
                     info.category = "MidiEffect";
-                    // #198 P2: note-effects are still effects — they process
-                    // MIDI, just with no audio output. Before this fix
-                    // is_effect was cleared here so existing filters that
-                    // grouped by is_effect silently dropped MIDI effects.
+                    // Note-effects are still effects: they process MIDI, just
+                    // with no audio output. Keep them in existing filters that
+                    // group by is_effect.
                     info.is_effect = true;
                     info.is_instrument = false;
                     info.supports_midi_in = true;
@@ -259,7 +245,7 @@ std::vector<PluginInfo> scan_clap_bundle_descriptors(const std::string& path) {
     }
 
     try { entry->deinit(); } catch (...) { // LCOV_EXCL_START
-        runtime::log_warn("CLAP scan: entry->deinit threw for '{}' (#812 guard)", path);
+        runtime::log_warn("CLAP scan: entry->deinit threw for '{}'", path);
     } // LCOV_EXCL_STOP
     dlclose(handle);
     if (results.empty()) results.push_back(make_filename_fallback(path));


### PR DESCRIPTION
Summary:
- Remove stale issue/workstream/review provenance from host scanner comments while preserving scanner invariants.
- Remove `(#812 guard)` / `(#2703 guard)` issue suffixes from user-visible CLAP scanner warning strings.
- Keep behavior unchanged except warning text no longer leaks issue guard suffixes.

Validation:
- Refreshed `origin/main`; merge-base `d26f94f8a53cd177d1595eed0e1bc53668f9abcc`.
- `git diff --check`
- Touched-file stale-comment scan for Codex/Claude/workstream/follow-up/roadmap/planning/issue/PR/P-tier tokens.
- Removed guard-token scan for `#812 guard`, `#2703 guard`, and CLAP guard wording.
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- Release configure/build/test: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build --target pulp-test-host pulp-test-host-regression pulp-test-plugin-info-metadata -j$(sysctl -n hw.ncpu) && build/test/pulp-test-host && build/test/pulp-test-host-regression && build/test/pulp-test-plugin-info-metadata`
- Release test counts: `pulp-test-host` 858 assertions / 25 test cases; `pulp-test-host-regression` 1485 assertions / 24 test cases; `pulp-test-plugin-info-metadata` 123 assertions / 18 test cases.
- Verified Release flags include `-O3 -DNDEBUG` for host/test targets.
- Claude autoreview clean: `autoreview clean: no accepted/actionable findings reported`, overall `patch is correct (0.95)`.
- Pre-push gates clean after policy trailers.

Notes:
- RepoPrompt was requested, but no RepoPrompt MCP tools were available in this Codex session (`tool_search` returned 0); local git/search/build tooling was used.
- Fresh worktree `planning/` was uninitialized, so optional generated-import C++ test targets were skipped during configure.
- Host tests emitted local installed-plugin Objective-C duplicate-class warnings from broad plugin scanning; assertions passed and hermetic scanner coverage passed.
- Push required docs-only trailers for source/hosting-skill touches: `Skill-Update: skip skill=hosting ...` and `Version-Bump: sdk=skip ...`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned host scanner comments and removed internal issue guard suffixes (e.g., "(#812 guard)", "(#2703 guard)") from CLAP warning messages for clearer logs. No behavior changes; scanning logic and safeguards are unchanged.

<sup>Written for commit 3fe8e044f09f253037bfc5503b63f952831e56fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

