### PR TITLE
docs: clean Swift motion comment archaeology

### DIFF
--- a/apple/Sources/PulpSwift/PulpMotion.swift
+++ b/apple/Sources/PulpSwift/PulpMotion.swift
@@ -160,7 +160,7 @@ public enum PulpMotionRuntime {
     /// Separate ambient-provenance lock so SwiftUI `PulpMotionProbe`
     /// attaches that briefly set + clear the C-side ambient slot can
     /// serialize without contending with backend installation. See
-    /// `withAmbientProvenance(...)` below — issue #2150.
+    /// `withAmbientProvenance(...)` below.
     private static let ambientLock = NSLock()
     private static var _backend = PulpMotionBackend()
 
@@ -185,7 +185,7 @@ public enum PulpMotionRuntime {
     /// (`kind`, `id`, `file`, `line`) and unconditionally cleared on
     /// exit. The set / body / clear triple runs under a dedicated lock
     /// so two SwiftUI view bodies in the same runloop tick can't
-    /// interleave ambient slot mutations (issue #2150). The body should
+    /// interleave ambient slot mutations. The body should
     /// be short — typically just the publish calls that need the
     /// ambient stamp. The C ABI ambient slot is itself unsynchronized
     /// across runtimes, so this guard only protects Swift-side

--- a/apple/Sources/PulpSwift/PulpMotionProbe.swift
+++ b/apple/Sources/PulpSwift/PulpMotionProbe.swift
@@ -58,7 +58,7 @@ public struct PulpMotionTraceModifier: ViewModifier {
         // `pulpMotionTrace` attaches would otherwise race the global
         // ambient provenance slot. Serialize the set / publish / clear
         // triple under `PulpMotionRuntime.withAmbientProvenance` so
-        // each attach sees its own provenance stamp (issue #2150).
+        // each attach sees its own provenance stamp.
         PulpMotionRuntime.withAmbientProvenance(kind: "swiftui", id: name) {
             for metric in metrics {
                 switch metric.kind {
@@ -139,8 +139,8 @@ public final class PulpMotionGeometryProbe {
         self.name = name
         self.metricName = metric
         if PulpMotion.isTracingEnabled {
-            // Same race surface as `PulpMotionTraceModifier.attachIfNeeded`
-            // (issue #2150): serialize the set / register / clear under
+            // Same race surface as `PulpMotionTraceModifier.attachIfNeeded`:
+            // serialize the set / register / clear under
             // the runtime's ambient lock so concurrent UIKit / AppKit
             // probe constructions can't interleave ambient slot
             // mutations.


### PR DESCRIPTION
Summary:
- Remove stale `issue #2150` breadcrumbs from Swift motion ambient-provenance comments.
- Preserve the current synchronization rationale for the ambient provenance lock and set/publish/clear scope.
- Leave behavior unchanged; this is comment/documentation hygiene only.

Validation:
- Refreshed `origin/main`; merge-base `d26f94f8a53cd177d1595eed0e1bc53668f9abcc`.
- `git diff --check`
- Touched-file stale-comment scan for Codex/Claude/workstream/follow-up/roadmap/planning/issue/PR/P-tier tokens.
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `swift test --package-path apple` — 38 tests passed.
- `tools/scripts/gates.sh origin/main`
- Claude autoreview clean: `autoreview clean: no accepted/actionable findings reported`, overall `patch is correct (0.95)`.
- Pre-push gates clean with `PULP_SKIP_DIFF_COVER=1`.

Notes:
- RepoPrompt was requested, but no RepoPrompt MCP tools were available in this Codex session (`tool_search` returned 0); local git/search/build tooling was used.
- `apple/.build/` was generated by SwiftPM during validation and removed before commit.
- Commit carries `Skill-Update: skip skill=motion reason="docs-only comment cleanup; no motion workflow or gotcha changed"` because the edited Swift files map to the motion skill.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale `issue #2150` references from Swift motion ambient-provenance comments and clarified the dedicated lock rationale for the set/publish/clear sequence. Behavior unchanged; docs-only cleanup in `PulpMotionRuntime` and `PulpMotionProbe`.

<sup>Written for commit 330da2dbd190a832fdeec5e446210f74cc063d4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

