### PR TITLE
docs: clean React event comment archaeology

### DIFF
--- a/packages/pulp-react/src/index.ts
+++ b/packages/pulp-react/src/index.ts
@@ -101,7 +101,7 @@ export type {
     PulpContainer,
 } from './types.js';
 
-// ── Ink & Signal design-system catalog (Phase 8c) ──────────────────
+// ── Ink & Signal design-system catalog ─────────────────────────────
 export {
     inkSignalCatalog, findComponent, componentsByCategory, FIGMA_FILE_KEY,
 } from './design-system.js';
@@ -111,7 +111,7 @@ export type { DesignComponent, DesignCategory } from './design-system.js';
 export { createMockBridge } from './bridge.js';
 export type { MockBridge, MockBridgeCall } from './bridge.js';
 
-// ── Keyboard shortcuts (pulp #135 Phase B) ─────────────────────────
+// ── Keyboard shortcuts ─────────────────────────────────────────────
 export {
     useShortcut,
     registerShortcut,

--- a/packages/pulp-react/src/shortcuts.ts
+++ b/packages/pulp-react/src/shortcuts.ts
@@ -1,12 +1,11 @@
-// @pulp/react keyboard shortcut runtime injection (pulp #135 Phase B).
+// @pulp/react keyboard shortcut runtime injection.
 //
 // Counterpart to the pulp-import-design CLI's static codegen path
-// (pulp #2128). That path emits `registerShortcut(key, mod, cbName)`
-// + a separate top-level callback function into the generated ui.js.
-// This module gives React app authors the same surface at runtime via
-// a hook, plus clash detection so two parts of the app (or one app +
-// the import-design path) registering the same chord can be surfaced
-// instead of silently overwriting.
+// that emits `registerShortcut(key, mod, cbName)` + a separate top-level
+// callback function into the generated ui.js. This module gives React app
+// authors the same surface at runtime via a hook, plus clash detection so
+// two parts of the app (or one app + the import-design path) registering
+// the same chord can be surfaced instead of silently overwriting.
 //
 // Architecture: one dispatcher callback per unique (keyCode, modMask)
 // pair is registered C++-side. The dispatcher consults a JS-side

--- a/packages/pulp-react/src/synthetic-event.ts
+++ b/packages/pulp-react/src/synthetic-event.ts
@@ -1,4 +1,4 @@
-// synthetic-event.ts — pulp #1352
+// Synthetic event bridge for JSX handlers.
 //
 // JSX consumers expect React-DOM-style SyntheticEvent objects with
 // `currentTarget`, `target`, `preventDefault`, etc. The bridge's
@@ -19,10 +19,10 @@
 // the web-compat `__elements__` map (they bypass `document.createElement`),
 // so we cannot reuse the web-compat Element class here.
 //
-// Coexistence with #1345's CSS `:hover` translation: that path already
-// synthesizes proper events via web-compat-element's `_makeEvent` +
-// `_dispatchEvent`. JSX-direct handlers bypass that pipeline entirely;
-// this module is the matching synthesis for the prop-applier `on()` lane.
+// Coexistence with CSS `:hover` translation: that path already synthesizes
+// proper events via web-compat-element's `_makeEvent` + `_dispatchEvent`.
+// JSX-direct handlers bypass that pipeline entirely; this module is the
+// matching synthesis for the prop-applier `on()` lane.
 
 type AnyFn = (...args: unknown[]) => unknown;
 
@@ -47,16 +47,16 @@ function makeStyleProxy(id: string): Record<string, unknown> {
         // visibility: 'hidden' | 'visible' — matches CSS, not the inverse `hidden`.
         visibility: (v) => callBridge('setVisible', id, String(v) !== 'hidden'),
         // Border shorthands route to the per-attribute bridge setters
-        // that preserve unset siblings (pulp #1027).
+        // that preserve unset siblings.
         borderColor: (v) => callBridge('setBorderColor', id, String(v)),
         borderWidth: (v) => callBridge('setBorderWidth', id, Number(v)),
         borderRadius: (v) => callBridge('setBorderRadius', id, Number(v)),
         // Text
         color: (v) => callBridge('setTextColor', id, String(v)),
         fontSize: (v) => callBridge('setFontSize', id, Number(v)),
-        // pulp #1434 Phase A2-5 — bridge forwards comma-separated CSS
-        // family lists; first non-empty wins. Whole-list resolution is
-        // gated on pulp #932.
+        // The bridge forwards comma-separated CSS family lists; first
+        // non-empty family wins. Whole-list resolution belongs to the
+        // font resolver, not this event-time style proxy.
         fontFamily: (v) => callBridge('setFontFamily', id, String(v)),
         // Layout — minimal subset; matches what setFlex accepts.
         width: (v) => callBridge('setFlex', id, 'width', Number(v)),
@@ -97,10 +97,10 @@ function makeElementWrapper(id: string): SyntheticElementWrapper {
         id,
         _id: id, // mirrors web-compat Element naming for cross-compat consumers
         style: makeStyleProxy(id),
-        // pulp #1352: setAttribute/getAttribute are common in DOM-shaped
-        // code; we accept the writes but don't persist them — there is
-        // no HTML attribute layer in Pulp. JSX prop-applier is the
-        // canonical write path.
+        // setAttribute/getAttribute are common in DOM-shaped code; we
+        // accept the writes but don't persist them — there is no HTML
+        // attribute layer in Pulp. JSX prop-applier is the canonical
+        // write path.
         setAttribute(_name: string, _value: string): void { /* no-op */ },
         getAttribute(_name: string): string | null { return null; },
     };
@@ -162,10 +162,8 @@ export interface SyntheticEvent {
     scale: number;
     rotation: number;
     // Wheel event — bridge sends {deltaX, deltaY, clientX, clientY}
-    // as an object (since SDK 0.78.4). Without these fields the
-    // wheel handler in React JSX (`e.deltaY > 0 ? zoomOut() : zoomIn()`)
-    // reads NaN. See pulp #1XXX (Spectr trackpad-zoom regression
-    // post-GPU-path migration).
+    // as an object. Without these fields React JSX wheel handlers such
+    // as `e.deltaY > 0 ? zoomOut() : zoomIn()` read NaN.
     deltaX: number;
     deltaY: number;
     deltaZ: number;
@@ -230,8 +228,8 @@ export function makeSyntheticEvent(
         if (typeof d.clientY === 'number') evt.clientY = d.clientY;
         if (typeof d.offsetX === 'number') evt.offsetX = d.offsetX;
         if (typeof d.offsetY === 'number') evt.offsetY = d.offsetY;
-        // pulp #1XXX — wheel events arrive as {deltaX, deltaY, clientX, clientY}.
-        // Surface the deltas so JSX `onWheel` handlers (`e.deltaY > 0 …`) work.
+        // Wheel events arrive as {deltaX, deltaY, clientX, clientY}. Surface
+        // the deltas so JSX `onWheel` handlers (`e.deltaY > 0 ...`) work.
         if (typeof d.deltaX === 'number') evt.deltaX = d.deltaX;
         if (typeof d.deltaY === 'number') evt.deltaY = d.deltaY;
         if (typeof d.deltaZ === 'number') evt.deltaZ = d.deltaZ;

--- a/packages/pulp-react/test/build-output-externals.test.ts
+++ b/packages/pulp-react/test/build-output-externals.test.ts
@@ -1,4 +1,4 @@
-// Regression test for pulp #1292 — the React-dispatcher-null crash.
+// Regression test for the React-dispatcher-null crash.
 //
 // Root cause: when @pulp/react was published with React (and friends)
 // inlined inside dist/index.mjs, downstream consumers (esbuild bundling
@@ -31,7 +31,7 @@ import { resolve } from 'node:path';
 
 const distMjs = resolve(__dirname, '..', 'dist', 'index.mjs');
 
-describe('@pulp/react build output (pulp #1292)', () => {
+describe('@pulp/react build output', () => {
   it('dist/index.mjs exists and is small (no React inlined)', () => {
     const st = statSync(distMjs);
     // After externalizing react / react-reconciler / scheduler the bundle
@@ -48,7 +48,7 @@ describe('@pulp/react build output (pulp #1292)', () => {
     // No copy of react.production.min.js shipped inside the bundle.
     expect(src).not.toMatch(/react\.production\.min\.js/);
     // No ReactCurrentDispatcher object literal — that's the React
-    // module-internal singleton that pulp #1292 was creating two of.
+    // module-internal singleton that breaks when bundled twice.
     expect(src).not.toMatch(/ReactCurrentDispatcher\s*[:=]\s*\{/);
   });
 

--- a/packages/pulp-react/test/prop-applier-synthetic-event.test.ts
+++ b/packages/pulp-react/test/prop-applier-synthetic-event.test.ts
@@ -1,8 +1,8 @@
-// Test for pulp #1352 — prop-applier must wrap JSX event handlers in a
-// synthetic-event factory so consumers see a React-DOM-shaped event
-// object (with `currentTarget`, `target`, `preventDefault`, etc.) and
-// event-type-specific fields (`clientX/Y`, `e.target.value`, `key`)
-// instead of the bridge's raw positional args.
+// Prop-applier must wrap JSX event handlers in a synthetic-event factory so
+// consumers see a React-DOM-shaped event object (with `currentTarget`,
+// `target`, `preventDefault`, etc.) and event-type-specific fields
+// (`clientX/Y`, `e.target.value`, `key`) instead of the bridge's raw
+// positional args.
 //
 // The bridge dispatches `__dispatch__('btn1', 'mouseenter', 0)` for
 // hover; idiomatic JSX handlers (`e => e.currentTarget.style.background = ...`)
@@ -30,7 +30,7 @@ function dispatch(bridge: MockBridge, id: string, eventName: string, ...rawArgs:
     return wrapper(...rawArgs);
 }
 
-describe('@pulp/react prop-applier — synthetic event factory (pulp #1352)', () => {
+describe('@pulp/react prop-applier — synthetic event factory', () => {
     let bridge: MockBridge;
     beforeEach(() => {
         bridge = createMockBridge();

--- a/packages/pulp-react/test/shortcuts.test.ts
+++ b/packages/pulp-react/test/shortcuts.test.ts
@@ -1,4 +1,4 @@
-// pulp #135 Phase B — runtime keyboard shortcut injection tests.
+// Runtime keyboard shortcut injection tests.
 //
 // Pins the parser, the C++-bridge call shape, and the clash-detection
 // contract. The hook itself is tested by mounting a real React tree


### PR DESCRIPTION
Summary:
- Remove issue/phase breadcrumbs from @pulp/react synthetic-event and keyboard-shortcut comments while preserving the bridge/event-shape rationale.
- Clean matching Vitest describe/header comments for synthetic events, shortcuts, and React externalization build-output coverage.
- Keep behavior unchanged; this is comment/test-description hygiene only.

Validation:
- Refreshed `origin/main`; merge-base `d26f94f8a53cd177d1595eed0e1bc53668f9abcc`.
- `git diff --check`
- Touched-file stale-comment scan for Codex/Claude/workstream/follow-up/roadmap/planning/issue/PR/P-tier/phase tokens.
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react`
- `npm test --prefix packages/pulp-react` — 50 files / 540 tests passed.
- `npm run build --prefix packages/pulp-react`
- `tools/scripts/gates.sh origin/main`
- Claude autoreview clean: `autoreview clean: no accepted/actionable findings reported`, overall `patch is correct (0.9)`.
- Pre-push gates clean with `PULP_SKIP_DIFF_COVER=1`.

Notes:
- RepoPrompt was requested, but no RepoPrompt MCP tools were available in this Codex session (`tool_search` returned 0); local git/search/build tooling was used.
- `npm ci` reported existing dependency advisories from the package lock; this PR does not change dependencies.
- `node_modules/` was generated locally for validation and is ignored, not committed.
- I intentionally left `packages/pulp-react/src/bridge.ts` and `src/prop-applier.ts` alone because existing open cleanup PRs own those files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed issue/phase breadcrumbs from `@pulp/react` comments for synthetic events and keyboard shortcuts while keeping the event-shape/bridge rationale. Aligned related Vitest describe headers and build-output coverage comments; no behavior or API changes.

<sup>Written for commit 9a12fa76d41f978bb6c4057d2549e6b7065e8445. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

