### PR TITLE
docs: clean Ink Signal comment archaeology

### DIFF
--- a/examples/ink-signal-sampler/CMakeLists.txt
+++ b/examples/ink-signal-sampler/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Ink & Signal Sampler — headless renderer for the Phase 8d starter sampler UI
-# (built from the pulp::design component catalog). Desktop only; uses the
+# Ink & Signal Sampler — headless renderer for the starter sampler UI built
+# from the pulp::design component catalog. Desktop only; uses the
 # built-in CoreGraphics screenshot provider on Apple (no GPU/Skia required — the
 # widgets paint via the 2D canvas). On platforms without a screenshot provider
 # the binary still builds and exits with a clear "no provider" message.

--- a/examples/ink-signal-sampler/main.cpp
+++ b/examples/ink-signal-sampler/main.cpp
@@ -1,7 +1,7 @@
 // Ink & Signal Sampler — a starter sampler UI assembled entirely from the
-// pulp::design component catalog (Design-System-Import-Plan Phase 8d). It is the
-// end-to-end proof that the ingested design system is usable: knobs, waveform,
-// stepper, pan, meter, badge, and buttons, all token-driven and reskinnable.
+// pulp::design component catalog. It proves the design system is usable
+// end-to-end: knobs, waveform, stepper, pan, meter, badge, and buttons,
+// all token-driven and reskinnable.
 //
 //   pulp-ink-signal-sampler --out /tmp/sampler [--theme light|dark|both]
 //

--- a/packages/pulp-react/src/intrinsics.ts
+++ b/packages/pulp-react/src/intrinsics.ts
@@ -43,7 +43,7 @@ export const Checkbox = (props: CheckboxProps): ReactElement => createElement('C
 export const Toggle = (props: ToggleProps): ReactElement => createElement('Toggle' as unknown as 'div', props as unknown as object);
 export const Combo = (props: ComboProps): ReactElement => createElement('Combo' as unknown as 'div', props as unknown as object);
 
-// Ink & Signal design-system widgets (Phase 8c).
+// Ink & Signal design-system widgets.
 export const Badge = (props: BadgeProps): ReactElement => createElement('Badge' as unknown as 'div', props as unknown as object);
 export const Stepper = (props: StepperProps): ReactElement => createElement('Stepper' as unknown as 'div', props as unknown as object);
 export const Pan = (props: PanProps): ReactElement => createElement('Pan' as unknown as 'div', props as unknown as object);

--- a/packages/pulp-react/test/widget-routing-parity.test.ts
+++ b/packages/pulp-react/test/widget-routing-parity.test.ts
@@ -1,5 +1,4 @@
-// Routing-parity sweep for the @pulp/react widget intrinsics
-// (pulp routing-parity sweep 2026-06-08).
+// Routing-parity coverage for the @pulp/react widget intrinsics.
 //
 // This sweep verifies routing BREADTH: every widget intrinsic, both in
 // its CAPITALIZED canonical form (e.g. `Knob`) AND its lowercase HTML-
@@ -31,13 +30,13 @@ const WIDGET_ROUTING: ReadonlyArray<readonly [capitalized: string, expectedCreat
     ['XYPad', 'createXYPad'],
     ['ListBox', 'createListBox'],
     ['Icon', 'createIcon'],
-    // Ink & Signal design-system widgets (Phase 8c).
+    // Ink & Signal design-system widgets.
     ['Badge', 'createBadge'],
     ['Stepper', 'createStepper'],
     ['Pan', 'createPan'],
 ];
 
-describe('@pulp/react widget routing parity sweep (2026-06-08)', () => {
+describe('@pulp/react widget routing parity', () => {
     let bridge: MockBridge;
     beforeEach(() => {
         bridge = createMockBridge();


### PR DESCRIPTION
## Summary

- remove stale phase/date breadcrumbs from Ink & Signal sampler and React intrinsic routing comments
- keep the comments focused on current behavior: sampler catalog usage and widget routing parity
- update the routing-parity test describe label without changing assertions or routing tables

## Validation

- `git diff --check`
- touched-file stale breadcrumb scan
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react`
  - existing lockfile advisories remain: 5 vulnerabilities (2 moderate, 1 high, 2 critical); no dependency changes made
- `npm test --prefix packages/pulp-react` (50 files / 540 tests passed; expected shortcut clash warnings emitted by shortcut tests)
- `npm run build --prefix packages/pulp-react` (`dist/index.mjs 124.4kb`)
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main` (clean, 0.98)
- pre-push hook with `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/ink-signal-comment-hygiene`

## Notes

- RepoPrompt requested but unavailable (`tool_search` returned 0); local git/search/build tooling used.
- Draft PR opened manually with `gh pr create` to match the existing cleanup-slice flow; Shipyard state may need reconciliation if this is later moved through the Shipyard-managed path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale phase/date breadcrumbs from Ink & Signal sampler comments and `@pulp/react` intrinsics/tests to keep docs focused on current behavior. Updated the routing‑parity test description label only; no assertions, routing tables, or runtime behavior changed.

<sup>Written for commit 2325273b4d6c246251393882bd784effadeef7de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

