### PR TITLE
docs: clean normalize host props test archaeology

### DIFF
--- a/packages/pulp-react/test/normalize-host-props.test.ts
+++ b/packages/pulp-react/test/normalize-host-props.test.ts
@@ -1,7 +1,5 @@
-// Phase 6.1 — unit tests for the prop-applier's normalizeHostProps +
-// classRulesProvider surface. The full @pulp/react/runtime-import API
-// (installBindings, installHostReact, renderFromDesign, etc.) ships in
-// Phase 6.3; this file pins only the 6.1 contract.
+// Unit tests for the prop-applier's normalizeHostProps and
+// classRulesProvider surface.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
@@ -14,7 +12,7 @@ afterEach(() => {
     setClassRulesProvider(null);
 });
 
-describe('normalizeHostProps (Phase 6.1)', () => {
+describe('normalizeHostProps', () => {
     it('returns input unchanged when no style + no className (fast path)', () => {
         const flat = { width: 100, color: 'red' };
         expect(normalizeHostProps('div', flat)).toBe(flat);
@@ -75,7 +73,7 @@ describe('normalizeHostProps (Phase 6.1)', () => {
         expect(out.className).toBeUndefined();
     });
 
-    // Codex P2 (Phase 6.1 review) — prototype-pollution guard.
+    // Class-rule output must not be able to mutate Object.prototype.
     it('class-rules provider returning __proto__ key does not poison Object.prototype', () => {
         setClassRulesProvider(() => ({ __proto__: { polluted: 'yes' } } as Record<string, unknown>));
         normalizeHostProps('div', { className: 'attacker' });
@@ -97,7 +95,7 @@ describe('normalizeHostProps (Phase 6.1)', () => {
     });
 });
 
-describe('classRulesProvider (Phase 6.1)', () => {
+describe('classRulesProvider', () => {
     it('setClassRulesProvider null clears the provider', () => {
         setClassRulesProvider((cls) => ({ width: 100 }));
         expect(getClassRulesProvider()).not.toBeNull();


### PR DESCRIPTION
## Summary

- remove stale phase/Codex-review breadcrumbs from the normalizeHostProps test comments
- keep the comments focused on the current normalizeHostProps/classRulesProvider contract
- update describe labels only; assertions and test behavior are unchanged

## Validation

- `git diff --check`
- touched-file stale breadcrumb scan
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react`
  - existing lockfile advisories remain: 5 vulnerabilities (2 moderate, 1 high, 2 critical); no dependency changes made
- `npm test --prefix packages/pulp-react` (50 files / 540 tests passed; expected shortcut clash warnings emitted by shortcut tests)
- `npm run build --prefix packages/pulp-react` (`dist/index.mjs 124.4kb`)
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main` (clean, 0.97)
- pre-push hook with `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/react-normalize-host-props-comment-hygiene`

## Notes

- RepoPrompt requested but unavailable (`tool_search` returned 0); local git/search/build tooling used.
- Draft PR opened manually with `gh pr create` to match the existing cleanup-slice flow; Shipyard state may need reconciliation if this is later moved through the Shipyard-managed path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale phase/Codex references in the normalizeHostProps tests and updated describe labels to match the current contract. No assertions or behavior changed; comments now focus on the normalizeHostProps/classRulesProvider surface.

<sup>Written for commit 2737027009f9aebabc5c7e74802269b0cf14fc11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

