### PR TITLE
docs: clean React public instance comment archaeology

### DIFF
--- a/packages/pulp-react/test/get-public-instance.test.ts
+++ b/packages/pulp-react/test/get-public-instance.test.ts
@@ -1,14 +1,13 @@
-// Pulp #468 — getPublicInstance returns a DOM-shim Element bound to
-// the native widget id. Imported React bundles call DOM-style methods
-// on ref.current (e.g. canvasRef.current.getContext('2d'),
-// wrapRef.current.getBoundingClientRect()). Without this shim, ref.current
-// is a plain Instance descriptor → methods like .getContext don't exist
-// → bundle's useEffect throws → infinite re-render loop.
+// getPublicInstance returns a DOM-shim Element bound to the native widget
+// id. Imported React bundles call DOM-style methods on ref.current (e.g.
+// canvasRef.current.getContext('2d'), wrapRef.current.getBoundingClientRect()).
+// Without this shim, ref.current is a plain Instance descriptor, methods like
+// .getContext do not exist, and bundle effects can enter a re-render loop.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { PulpHostConfig } from '../src/host-config.js';
 
-describe('getPublicInstance returns DOM-shim Element (pulp #468)', () => {
+describe('getPublicInstance returns DOM-shim Element', () => {
     const g = globalThis as Record<string, unknown>;
     let savedElement: unknown;
 
@@ -64,10 +63,10 @@ describe('getPublicInstance returns DOM-shim Element (pulp #468)', () => {
         expect(inst._dom).toBeDefined();
         expect((inst._dom as Record<string, unknown>)._nativeCreated).toBe(true);
         expect((inst._dom as Record<string, unknown>).__pulpId).toBe('k1');
-        // Codex P2 follow-up on #1859: the public .id property must be set
-        // on the shim — Element constructor seeds internal `_id` but the
-        // public `.id` getter is gated on `_userIdSet`, which only flips
-        // through the setter. ref.current.id should match the native id.
+        // The public .id property must be set on the shim. Element constructor
+        // seeds internal `_id`, but the public `.id` getter is gated on
+        // `_userIdSet`, which only flips through the setter. ref.current.id
+        // should match the native id.
         expect((inst._dom as Record<string, unknown>).id).toBe('k1');
     });
 


### PR DESCRIPTION
## Summary
- remove stale issue/Codex breadcrumbs from the getPublicInstance DOM-shim regression test comments
- keep the DOM-shim and public `.id` behavior rationale intact
- leave all assertions, imports, and setup unchanged

## Validation
- `git diff --check`
- touched-file stale breadcrumb scan
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react` (existing lockfile advisories remain: 5 vulnerabilities; no dependency changes)
- `npm test --prefix packages/pulp-react` (50 files / 540 tests passed; expected shortcut clash warnings emitted)
- `npm run build --prefix packages/pulp-react` (`dist/index.mjs 124.4kb`)
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main` (clean, 0.97)
- pre-push hook via `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/react-public-instance-comment-hygiene`

## Notes
- RepoPrompt requested but unavailable (`tool_search` returned 0); local git/search/build tooling used.
- Opened manually with `gh pr create --draft`; please route through Shipyard if required before merge.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up comments in `packages/pulp-react/test/get-public-instance.test.ts` by removing stale issue/Codex breadcrumbs and clarifying the DOM-shim and public `.id` rationale. No code, assertions, or test behavior changed.

<sup>Written for commit 6ec431b4ac014d35f35dfda1acb41d5c03fab834. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

