### PR TITLE
docs: clean React hover comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-hover.test.ts
+++ b/packages/pulp-react/test/prop-applier-hover.test.ts
@@ -1,7 +1,7 @@
-// Test for pulp #1149 — prop-applier must call registerHover(id) when a
-// hover-class event handler (onMouseEnter / onMouseLeave / pointer aliases)
-// is set, otherwise the native bridge never fires the corresponding
-// events even though the JS listener is installed.
+// prop-applier must call registerHover(id) when a hover-class event handler
+// (onMouseEnter / onMouseLeave / pointer aliases) is set, otherwise the
+// native bridge never fires the corresponding events even though the JS
+// listener is installed.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createMockBridge, type MockBridge } from '../src/bridge.js';
@@ -12,7 +12,7 @@ function instance(id: string, type: string, props: Record<string, unknown>): Pul
     return { id, type, props } as PulpInstance;
 }
 
-describe('@pulp/react prop-applier — hover registration (pulp #1149)', () => {
+describe('@pulp/react prop-applier — hover registration', () => {
     let bridge: MockBridge;
     beforeEach(() => {
         bridge = createMockBridge();


### PR DESCRIPTION
## Summary
- remove the stale issue-number breadcrumb from the hover registration regression test comment
- remove the matching issue suffix from the test suite label
- keep the registerHover invariant and all assertions unchanged

## Validation
- `git diff --check`
- touched-file stale breadcrumb scan
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react` (existing lockfile advisories remain: 5 vulnerabilities; no dependency changes)
- `npm test --prefix packages/pulp-react` (50 files / 540 tests passed; expected shortcut clash warnings emitted)
- `npm run build --prefix packages/pulp-react` (`dist/index.mjs 124.4kb`)
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main` (clean, 0.98)
- pre-push hook via `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/react-hover-comment-hygiene`

## Notes
- RepoPrompt requested but unavailable (`tool_search` returned 0); local git/search/build tooling used.
- Opened manually with `gh pr create --draft`; please route through Shipyard if required before merge.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up stale issue references in `@pulp/react` hover registration tests. Removed the "pulp #1149" note from comments and the test suite label; behavior and assertions remain unchanged.

<sup>Written for commit 0c53f8383c41d6f4e53e8c3108c730bae18552eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

