### PR TITLE
docs: clean React pointer comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-pointer.test.ts
+++ b/packages/pulp-react/test/prop-applier-pointer.test.ts
@@ -1,6 +1,6 @@
-// Test for pulp #1381 — prop-applier must call registerPointer(id) when a
-// pointer-class event handler (onPointerDown / Move / Up / Cancel / Wheel)
-// is set, parallel to the existing registerHover call for hover events.
+// prop-applier must call registerPointer(id) when a pointer-class event handler
+// (onPointerDown / Move / Up / Cancel / Wheel) is set, parallel to the existing
+// registerHover call for hover events.
 //
 // Without registerPointer, the bridge keeps the JS listener in its dispatch
 // table but the View's on_pointer_event callback is never armed by the
@@ -17,7 +17,7 @@ function instance(id: string, type: string, props: Record<string, unknown>): Pul
     return { id, type, props } as PulpInstance;
 }
 
-describe('@pulp/react prop-applier — pointer registration (pulp #1381)', () => {
+describe('@pulp/react prop-applier — pointer registration', () => {
     let bridge: MockBridge;
     beforeEach(() => {
         bridge = createMockBridge();
@@ -65,8 +65,7 @@ describe('@pulp/react prop-applier — pointer registration (pulp #1381)', () =>
 
     it('calls registerWheel (NOT registerPointer) when onWheel is set', () => {
         // Wheel goes through a separate bridge call because the
-        // registerPointer lambda filters out is_wheel events. See pulp
-        // #1387 gap #4 (Spectr's zoom doesn't fire).
+        // registerPointer lambda filters out is_wheel events.
         applyAllProps(instance('w5', 'View', {
             onWheel: () => {},
         }));
@@ -159,7 +158,7 @@ describe('@pulp/react prop-applier — pointer registration (pulp #1381)', () =>
         expect(reg.length).toBe(0);
     });
 
-    it('routes style.overflow through setOverflow (pulp #1387 gap #1)', () => {
+    it('routes style.overflow through setOverflow', () => {
         applyAllProps(instance('row1', 'View', {
             overflow: 'hidden',
         }));


### PR DESCRIPTION
## Summary
- remove stale issue-number breadcrumbs from the pointer registration regression test comments
- remove matching issue suffixes from the suite/test labels
- keep registerPointer/registerWheel behavior rationale and all assertions unchanged

## Validation
- `git diff --check`
- touched-file stale breadcrumb scan
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react` (existing lockfile advisories remain: 5 vulnerabilities; no dependency changes)
- `npm test --prefix packages/pulp-react` (50 files / 540 tests passed; expected shortcut clash warnings emitted)
- `npm run build --prefix packages/pulp-react` (`dist/index.mjs 124.4kb`)
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main` (clean, 0.97)
- pre-push hook via `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/react-pointer-comment-hygiene`

## Notes
- RepoPrompt requested but unavailable (`tool_search` returned 0); local git/search/build tooling used.
- Opened manually with `gh pr create --draft`; please route through Shipyard if required before merge.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale issue references from comments and test names in `@pulp/react` pointer registration tests to reduce noise and keep labels clean. All test behavior and assertions remain unchanged.

<sup>Written for commit 4d5967da641c4710c7301942b8fcaa2d41799c32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

