### PR TITLE
docs: clean React overlay comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-overlay.test.ts
+++ b/packages/pulp-react/test/prop-applier-overlay.test.ts
@@ -1,4 +1,4 @@
-// pulp #1148 — generalized overlay-click routing.
+// Generalized overlay-click routing.
 //
 // `<View overlay>` opts a JSX View in as the active click-eligible
 // overlay so the platform window host (window_host_mac.mm and siblings)
@@ -38,7 +38,7 @@ function makeInstance(id: string = 'popover', type: string = 'View'): PulpInstan
     };
 }
 
-describe('@pulp/react prop-applier — overlay routing (pulp #1148)', () => {
+describe('@pulp/react prop-applier — overlay routing', () => {
     it('applyAllProps calls claimOverlay when overlay=true', () => {
         applyAllProps({ ...makeInstance('p1'), props: { overlay: true } });
         const claims = bridge.calls.filter((c) => c.fn === 'claimOverlay');


### PR DESCRIPTION
## Summary
- remove stale `pulp #1148` workflow archaeology from the React overlay routing test comment and describe label
- keep the behavior-focused overlay routing documentation and test coverage unchanged

## Validation
- `git diff --check`
- touched-file workflow-breadcrumb scan: `rg -n 'Workstream|Phase [0-9]|pulp #[0-9]|Pulp #[0-9]|Codex|ChatGPT|roadmap|planning/|Triage|Wave|slice [A-Z0-9]|follow-up work|Created in the 2026' packages/pulp-react/test/prop-applier-overlay.test.ts`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react`
- `npm test --prefix packages/pulp-react`
- `npm run build --prefix packages/pulp-react`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main` (clean, 0.97)
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-overlay-comment-hygiene` (pre-push gates clean)

## Notes
- RepoPrompt requested but unavailable (`tool_search` returned 0); local git/search/build tooling used.
- Manual Shipyard run not used for this docs-only cleanup; local gates and GitHub checks are the validation path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale "pulp #1148" references from the `@pulp/react` overlay routing test comments and describe label to keep docs focused on behavior. No test logic or behavior changed.

<sup>Written for commit cf10c0259b703a1eb1eedf331717e3248f85f87b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

