### PR TITLE
docs: clean React disappearing style comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-disappearing-style.test.ts
+++ b/packages/pulp-react/test/prop-applier-disappearing-style.test.ts
@@ -1,8 +1,8 @@
-// pulp #1925 — disappearing-style-key resets in applyChangedProps.
+// Disappearing-style-key resets in applyChangedProps.
 //
-// Pre-#1925, applyChangedProps only reset visible/opacity/overlay when a
-// key fell out of newProps; the rest of the visual cluster (background,
-// border, textColor, per-side borders) silently kept their last value.
+// When a style key falls out of newProps, applyChangedProps must clear
+// the corresponding bridge state instead of leaving the previous visual
+// value painted.
 //
 // This bites the conditional-spread idiom that Spectr's Settings Manager
 // Preset chips, PatternRow rows, and most imported designs (Stitch / v0
@@ -48,7 +48,7 @@ function makeInstance(id: string = 'chip', type: string = 'View'): PulpInstance 
     };
 }
 
-describe('@pulp/react prop-applier — disappearing style keys (pulp #1925)', () => {
+describe('@pulp/react prop-applier — disappearing style keys', () => {
     it('clears background when the key falls out of newProps', () => {
         applyChangedProps(
             makeInstance('c1'),


### PR DESCRIPTION
## Summary
- remove stale `pulp #1925` workflow archaeology from the React disappearing-style-key test header and describe label
- keep the current behavior contract documented without changing test logic, assertions, or fixtures

## Validation
- `git diff --check`
- touched-file workflow-breadcrumb scan: `rg -n 'Workstream|Phase [0-9]|pulp #[0-9]|Pulp #[0-9]|Codex|ChatGPT|roadmap|planning/|Triage|Wave|slice [A-Z0-9]|follow-up work|Created in the 2026' packages/pulp-react/test/prop-applier-disappearing-style.test.ts`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react`
- `npm test --prefix packages/pulp-react` first run: all 50 files / 540 tests passed, then local Node 26 crashed after completion with `v8::ToLocalChecked Empty MaybeLocal`
- `npm test --prefix packages/pulp-react` rerun: 50 files / 540 tests passed, exit 0
- `npm run build --prefix packages/pulp-react`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main` (clean, 0.96)
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-disappearing-style-comment-hygiene` (pre-push gates clean)

## Notes
- RepoPrompt requested but unavailable (`tool_search` returned 0); local git/search/build tooling used.
- Manual Shipyard run not used for this docs-only cleanup; local gates and GitHub checks are the validation path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned comments and test name in `packages/pulp-react/test/prop-applier-disappearing-style.test.ts` to remove stale `pulp #1925` references and clarify the contract: when a style key falls out of `newProps`, `applyChangedProps` must clear the previous value. No test logic, assertions, or fixtures changed.

<sup>Written for commit 9bddae735ff31f0e3b9c9acf31ce835485b0f316. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

