### PR TITLE
docs: clean React flex direction comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-flex-direction.test.ts
+++ b/packages/pulp-react/test/prop-applier-flex-direction.test.ts
@@ -1,8 +1,7 @@
-// pulp #108 — verify @pulp/react prop-applier forwards `flexDirection`
-// (camelCase, the canonical RN/React JSX key) to the bridge. Without
-// this case, the prop fell through as unknown and Yoga's column default
-// remained — collapsing CSS-imported flex rows into vertical stacks
-// (2026-05-11 Spectr regression where header items piled at 0,0).
+// Verify @pulp/react prop-applier forwards `flexDirection` (camelCase,
+// the canonical RN/React JSX key) to the bridge. Without this routing,
+// Yoga's column default collapses CSS-imported flex rows into vertical
+// stacks.
 // `col` and `col-reverse` aliases normalize to the bridge vocabulary
 // `column` / `column-reverse`.
 
@@ -34,7 +33,7 @@ function makeInstance(id: string = 'k'): PulpInstance {
 
 const callsOf = (b: MockBridge, fn: string) => b.calls.filter((c) => c.fn === fn);
 
-describe('prop-applier flexDirection (pulp #108)', () => {
+describe('prop-applier flexDirection', () => {
     it('flexDirection=row dispatches setFlex(direction, row)', () => {
         applyChangedProps(makeInstance(), {}, { flexDirection: 'row' });
         const c = callsOf(bridge, 'setFlex');
@@ -54,7 +53,7 @@ describe('prop-applier flexDirection (pulp #108)', () => {
         expect(callsOf(bridge, 'setFlex')[0].args).toEqual(['k', 'direction', 'row-reverse']);
     });
 
-    it('flexDirection=col (RN/pulp historic alias) normalizes to column', () => {
+    it('flexDirection=col normalizes to column', () => {
         applyChangedProps(makeInstance(), {}, { flexDirection: 'col' });
         expect(callsOf(bridge, 'setFlex')[0].args).toEqual(['k', 'direction', 'column']);
     });


### PR DESCRIPTION
## Summary
- remove stale `pulp #108` and dated regression archaeology from the React flexDirection test comment and describe label
- keep the current flexDirection bridge-routing and alias-normalization contract documented without changing test logic

## Validation
- `git diff --check`
- touched-file workflow-breadcrumb scan: `rg -n 'Workstream|Phase [0-9]|pulp #[0-9]|Pulp #[0-9]|Codex|ChatGPT|roadmap|planning/|Triage|Wave|slice [A-Z0-9]|follow-up work|Created in the 2026|2026-[0-9]{2}-[0-9]{2}' packages/pulp-react/test/prop-applier-flex-direction.test.ts`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react`
- `npm test --prefix packages/pulp-react` (50 files / 540 tests passed)
- `npm run build --prefix packages/pulp-react`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main` (clean, 0.97)
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-flex-direction-comment-hygiene` (pre-push gates clean)

## Notes
- RepoPrompt requested but unavailable (`tool_search` returned 0); local git/search/build tooling used.
- Manual Shipyard run not used for this docs-only cleanup; local gates and GitHub checks are the validation path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned outdated comments and test titles in `packages/pulp-react` flexDirection test by removing stale `pulp #108` and old regression notes. Clarified the current `@pulp/react` contract—forwarding `flexDirection` to the bridge and normalizing `col`/`col-reverse`—with no test logic changes.

<sup>Written for commit 1c0d11379d9504e9afc986d7f5835de0cb1a9484. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

