### PR TITLE
docs: clean React flex shorthand comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-flex.test.ts
+++ b/packages/pulp-react/test/prop-applier-flex.test.ts
@@ -1,7 +1,7 @@
-// pulp #1434 (#1518) — RN-style `flex: <number>` shorthand. RN spec
-// flattens a bare numeric `flex` to `{flexGrow: n, flexShrink: 1,
-// flexBasis: 0}` for positive `n`, distinct shapes for `0` and
-// negatives. CSS bare-number shorthand (`flex: 1` ≡ `flex: 1 1 0`)
+// RN-style `flex: <number>` shorthand. RN spec flattens a bare numeric
+// `flex` to `{flexGrow: n, flexShrink: 1, flexBasis: 0}` for positive
+// `n`, with distinct shapes for `0` and negatives. CSS bare-number
+// shorthand (`flex: 1` ≡ `flex: 1 1 0`)
 // is the same as RN's positive case, which is what consumers passing
 // JSX `flex={1}` overwhelmingly expect; our adapter is RN-flavored
 // so we honor RN semantics directly here. The `0` and negative cases
@@ -38,7 +38,7 @@ function flexCalls(b: MockBridge, slot: string) {
     return b.calls.filter((c) => c.fn === 'setFlex' && c.args[1] === slot);
 }
 
-describe('prop-applier flex shorthand (pulp #1518)', () => {
+describe('prop-applier flex shorthand', () => {
     it('flex={1} fans out to flex_grow=1 / flex_shrink=1 / flex_basis=0', () => {
         applyChangedProps(makeInstance(), {}, { flex: 1 } as never);
         expect(flexCalls(bridge, 'flex_grow')[0].args[2]).toBe(1);


### PR DESCRIPTION
## Summary
- remove stale `pulp #1434` / `#1518` workflow archaeology from the React flex shorthand test comment and describe label
- keep the RN numeric `flex` shorthand contract documented without changing test logic or expectations

## Validation
- `git diff --check`
- touched-file workflow-breadcrumb scan: `rg -n 'Workstream|Phase [0-9]|pulp #[0-9]|Pulp #[0-9]|Codex|ChatGPT|roadmap|planning/|Triage|Wave|slice [A-Z0-9]|follow-up work|Created in the 2026|2026-[0-9]{2}-[0-9]{2}' packages/pulp-react/test/prop-applier-flex.test.ts`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react`
- `npm test --prefix packages/pulp-react` (50 files / 540 tests passed)
- `npm run build --prefix packages/pulp-react`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main` (clean, 0.96)
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-flex-shorthand-comment-hygiene` (pre-push gates clean)

## Notes
- RepoPrompt requested but unavailable (`tool_search` returned 0); local git/search/build tooling used.
- Manual Shipyard run not used for this docs-only cleanup; local gates and GitHub checks are the validation path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale `pulp #1434`/`#1518` references from the React flex shorthand test comments and the `describe` label, clarifying the RN numeric `flex` shorthand contract. No test logic or expectations changed.

<sup>Written for commit 6d594c5b78d6e6b3f4682b59d5a53d3f13d7446a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

