### PR TITLE
docs: clean React line clamp comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-line-clamp-bg-repeat.test.ts
+++ b/packages/pulp-react/test/prop-applier-line-clamp-bg-repeat.test.ts
@@ -1,7 +1,6 @@
-// pulp #1552 — line-clamp / -webkit-line-clamp / background-repeat
-// JSX dispatch. The C++ bridge fns (setLineClamp, setBackgroundRepeat)
-// landed in the same PR; these tests pin the prop-applier dispatch
-// shape so a future refactor can't silently drop the keys.
+// Line-clamp / -webkit-line-clamp / background-repeat JSX dispatch.
+// These tests pin the prop-applier dispatch shape so a future refactor
+// can't silently drop the keys.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';
@@ -33,7 +32,7 @@ function callOf(b: MockBridge, fn: string) {
     return b.calls.find((c) => c.fn === fn);
 }
 
-describe('line-clamp + background-repeat dispatch (pulp #1552)', () => {
+describe('line-clamp + background-repeat dispatch', () => {
     it('lineClamp forwards numeric count to setLineClamp', () => {
         applyChangedProps(makeInstance(), {}, { lineClamp: 3 });
         expect(callOf(bridge, 'setLineClamp')?.args).toEqual(['k', 3]);


### PR DESCRIPTION
## Summary
- remove stale `pulp #1552` workflow archaeology from the React line-clamp/background-repeat test comment and describe label
- keep the prop-applier dispatch contract documented without changing test logic or expectations

## Validation
- `git diff --check`
- touched-file workflow-breadcrumb scan: `rg -n 'Workstream|Phase [0-9]|pulp #[0-9]|Pulp #[0-9]|Codex|ChatGPT|roadmap|planning/|Triage|Wave|slice [A-Z0-9]|follow-up work|Created in the 2026|2026-[0-9]{2}-[0-9]{2}' packages/pulp-react/test/prop-applier-line-clamp-bg-repeat.test.ts`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react`
- `npm test --prefix packages/pulp-react` (50 files / 540 tests passed)
- `npm run build --prefix packages/pulp-react`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main` (clean, 0.97)
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-line-clamp-comment-hygiene` (pre-push gates clean)

## Notes
- RepoPrompt requested but unavailable (`tool_search` returned 0); local git/search/build tooling used.
- Manual Shipyard run not used for this docs-only cleanup; local gates and GitHub checks are the validation path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale "pulp #1552" references from the line-clamp/background-repeat test comments and describe label, and clarified the dispatch contract. No changes to logic, assertions, or behavior.

<sup>Written for commit 50a7c1d0d7dff9e20ea9db1672cfe8bdb4979a38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

