### PR TITLE
docs: clean React list style comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-list-style.test.ts
+++ b/packages/pulp-react/test/prop-applier-list-style.test.ts
@@ -1,6 +1,6 @@
-// pulp #1514 — verify the @pulp/react prop-applier dispatches the
-// list-style cluster (listStyle / listStyleType / listStyleImage /
-// listStylePosition) to the correct bridge fns. Pulp doesn't model
+// Verify the @pulp/react prop-applier dispatches the list-style cluster
+// (listStyle / listStyleType / listStyleImage / listStylePosition) to
+// the correct bridge fns. Pulp doesn't model
 // HTML <li>/<ul>/<ol> semantics; the bridge stores the values
 // verbatim on the View so a future paint pass (or future
 // semantic-list surface) can honor them. The catalog status is
@@ -36,7 +36,7 @@ function callsFor(b: MockBridge, fn: string) {
     return b.calls.filter((c) => c.fn === fn);
 }
 
-describe('prop-applier list-style cluster (pulp #1514)', () => {
+describe('prop-applier list-style cluster', () => {
     it('listStyleType forwards each keyword verbatim', () => {
         for (const t of ['none', 'disc', 'circle', 'square', 'decimal'] as const) {
             const inst = makeInstance(t, 'View');


### PR DESCRIPTION
## Summary
- remove stale `pulp #1514` workflow archaeology from the React list-style test comment and describe label
- keep the stored-not-painted list-style dispatch contract documented without changing test logic or expectations

## Validation
- `git diff --check`
- touched-file workflow-breadcrumb scan: `rg -n 'Workstream|Phase [0-9]|pulp #[0-9]|Pulp #[0-9]|Codex|ChatGPT|roadmap|planning/|Triage|Wave|slice [A-Z0-9]|follow-up work|Created in the 2026|2026-[0-9]{2}-[0-9]{2}' packages/pulp-react/test/prop-applier-list-style.test.ts`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react`
- `npm test --prefix packages/pulp-react` (50 files / 540 tests passed)
- `npm run build --prefix packages/pulp-react`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main` (clean, 0.99)
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-list-style-comment-hygiene` (pre-push gates clean)

## Notes
- RepoPrompt requested but unavailable (`tool_search` returned 0); local git/search/build tooling used.
- Manual Shipyard run not used for this docs-only cleanup; local gates and GitHub checks are the validation path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up test comments in `packages/pulp-react/test/prop-applier-list-style.test.ts` to remove stale `pulp #1514` references and clarify how `@pulp/react` dispatches the list-style cluster. No test logic, behavior, or expectations changed.

<sup>Written for commit 4d2f006f16d603af0bd6d7b02169ffcb72ebd803. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

