### PR TITLE
docs: clean React align content comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-aligncontent.test.ts
+++ b/packages/pulp-react/test/prop-applier-aligncontent.test.ts
@@ -1,5 +1,5 @@
-// pulp #1434 (sub-agent #12 follow-up) — verify the @pulp/react
-// prop-applier forwards `alignContent` to the bridge.
+// Verify the @pulp/react prop-applier forwards `alignContent` to the
+// bridge.
 //
 // align-content is multi-line flex cross-axis distribution. Yoga
 // supports it natively via YGNodeStyleSetAlignContent; before this
@@ -44,7 +44,7 @@ function flexCalls(b: MockBridge, slot: string) {
     return b.calls.filter((c) => c.fn === 'setFlex' && c.args[1] === slot);
 }
 
-describe('prop-applier alignContent (pulp #1434 sub-agent #12 follow-up)', () => {
+describe('prop-applier alignContent', () => {
     it.each([
         'start',
         'flex-start',


### PR DESCRIPTION
## Summary
- remove stale `pulp #1434` / `sub-agent #12 follow-up` workflow archaeology from the React alignContent test comment and describe label
- keep the current alignContent bridge-forwarding contract documented without changing test logic or expectations

## Validation
- `git diff --check`
- touched-file workflow-breadcrumb scan: `rg -n 'Workstream|Phase [0-9]|pulp #[0-9]|Pulp #[0-9]|Codex|ChatGPT|roadmap|planning/|Triage|Wave|sub-agent|slice [A-Z0-9]|follow-up work|Created in the 2026|2026-[0-9]{2}-[0-9]{2}' packages/pulp-react/test/prop-applier-aligncontent.test.ts`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react`
- `npm test --prefix packages/pulp-react` twice: each run completed 50 files / 540 tests passed, then local Node 26 crashed after completion with `v8::ToLocalChecked Empty MaybeLocal`
- package-local `npm exec -- vitest run --pool forks` from `packages/pulp-react`: 50 files / 540 tests passed, exit 0
- `npm run build --prefix packages/pulp-react`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main` (clean, 0.97)
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-aligncontent-comment-hygiene` (pre-push gates clean)

## Notes
- RepoPrompt requested but unavailable (`tool_search` returned 0); local git/search/build tooling used.
- Manual Shipyard run not used for this docs-only cleanup; local gates and GitHub checks are the validation path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale issue/workflow references from the `alignContent` test and clarified that `@pulp/react` forwards `alignContent` to the bridge. No test logic or expectations changed; only the test name and header comment were updated.

<sup>Written for commit e7ffcd5085047a168c26453a144d2dd5389a0682. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

