### PR TITLE
docs: clean React aspect ratio comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-aspect-ratio.test.ts
+++ b/packages/pulp-react/test/prop-applier-aspect-ratio.test.ts
@@ -1,7 +1,6 @@
-// pulp #1434 batch 5 — verify the @pulp/react prop-applier routes
-// `aspectRatio` through `setFlex(id, "aspect_ratio", value)`. Mirrors RN's
-// flex-prop surface so design-tool exports (Figma fixed-ratio frames,
-// v0/Claude Design hero images, RN image cards) reach the bridge.
+// Verify the @pulp/react prop-applier routes `aspectRatio` through
+// `setFlex(id, "aspect_ratio", value)`. Mirrors RN's flex-prop surface so
+// design-tool exports with fixed-ratio frames and image cards reach the bridge.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';
@@ -29,7 +28,7 @@ function makeInstance(id: string = 'k', type: string = 'View'): PulpInstance {
     };
 }
 
-describe('prop-applier aspectRatio (pulp #1434)', () => {
+describe('prop-applier aspectRatio', () => {
     it('aspectRatio number routes through setFlex with snake-case key', () => {
         applyChangedProps(makeInstance(), {}, { aspectRatio: 1.5 });
         const call = bridge.calls.find(


### PR DESCRIPTION
## Summary
- remove transient pulp #1434/batch wording from the aspectRatio prop-applier test comment
- keep the current behavior invariant around `setFlex(id, "aspect_ratio", value)` and fixed-ratio design exports
- simplify the test suite label by removing the issue reference

## Validation
- `git diff --check`
- `rg -n 'Workstream|Phase [0-9]|pulp #[0-9]|Pulp #[0-9]|Codex|ChatGPT|roadmap|planning/|Triage|Wave|sub-agent|slice [A-Z0-9]|follow-up work|Created in the 2026|2026-[0-9]{2}-[0-9]{2}' packages/pulp-react/test/prop-applier-aspect-ratio.test.ts` (no matches)\n- `python3 tools/scripts/docs_noise_lint.py --mode=report`\n- `npm ci --prefix packages/pulp-react`\n- `npm test --prefix packages/pulp-react` (50 files / 540 tests passed, then Node 26 crashed after completion with `v8::ToLocalChecked Empty MaybeLocal`)\n- `npm exec -- vitest run --pool forks` from `packages/pulp-react` (50 files / 540 tests passed, clean exit)\n- `npm run build --prefix packages/pulp-react`\n- `tools/scripts/gates.sh origin/main`\n- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`\n- `git push --dry-run origin feature/react-aspect-ratio-comment-hygiene`\n\nRepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.\nManual Shipyard run not used for this docs-only cleanup; local gates and GitHub checks are the validation path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up comments in the `prop-applier` aspectRatio test in `@pulp/react` by removing transient issue references and clarifying behavior. No functional changes; tests still verify routing via `setFlex(id, "aspect_ratio", value)` for fixed‑ratio exports.

<sup>Written for commit 8b948f531829a19b98b1e6abd97266b000573ce4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

