### PR TITLE
docs: clean React border style comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-border-style.test.ts
+++ b/packages/pulp-react/test/prop-applier-border-style.test.ts
@@ -1,8 +1,7 @@
-// pulp #1434 Triage #10 — verify the @pulp/react prop-applier forwards
-// `borderStyle` keyword strings verbatim to the bridge's setBorderStyle.
-// Bridge maps to View::BorderStyle and Skia honors dashed / dotted via
-// SkDashPathEffect at stroke time. Other named styles currently degrade
-// to solid (paint-side gap, tracked for follow-up).
+// Verify the @pulp/react prop-applier forwards `borderStyle` keyword strings
+// verbatim to the bridge's setBorderStyle. Bridge maps to View::BorderStyle
+// and Skia honors dashed / dotted via SkDashPathEffect at stroke time. Other
+// named styles currently degrade to solid.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';
@@ -34,7 +33,7 @@ function styleCalls(b: MockBridge) {
     return b.calls.filter((c) => c.fn === 'setBorderStyle');
 }
 
-describe('prop-applier borderStyle (pulp #1434 Triage #10)', () => {
+describe('prop-applier borderStyle', () => {
     it('forwards "solid" verbatim', () => {
         applyChangedProps(makeInstance(), {}, { borderStyle: 'solid' });
         expect(styleCalls(bridge)).toHaveLength(1);


### PR DESCRIPTION
## Summary
- remove transient pulp #1434/Triage wording from the borderStyle prop-applier test comment
- preserve the current bridge behavior notes for `setBorderStyle`, View::BorderStyle, and dashed/dotted Skia rendering
- simplify the test suite label by removing the issue/triage reference

## Validation
- `git diff --check`
- `rg -n 'Workstream|Phase [0-9]|pulp #[0-9]|Pulp #[0-9]|Codex|ChatGPT|roadmap|planning/|Triage|Wave|sub-agent|slice [A-Z0-9]|follow-up work|Created in the 2026|2026-[0-9]{2}-[0-9]{2}' packages/pulp-react/test/prop-applier-border-style.test.ts` (no matches)\n- `python3 tools/scripts/docs_noise_lint.py --mode=report`\n- `npm ci --prefix packages/pulp-react`\n- `npm test --prefix packages/pulp-react`\n- `npm run build --prefix packages/pulp-react`\n- `tools/scripts/gates.sh origin/main`\n- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`\n- `git push --dry-run origin feature/react-border-style-comment-hygiene`\n\nRepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.\nManual Shipyard run not used for this docs-only cleanup; local gates and GitHub checks are the validation path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up the `borderStyle` test comments in `packages/pulp-react` to remove transient triage references and simplify the suite label, while keeping accurate notes on current bridge and Skia behavior.

- **Refactors**
  - Removed issue/triage tags from comments and `describe` name.
  - Kept behavior notes: `@pulp/react` forwards `borderStyle` verbatim to `setBorderStyle`, maps to `View::BorderStyle`, Skia honors dashed/dotted via `SkDashPathEffect`, others degrade to solid.

<sup>Written for commit 29e9a4a7942421f19d0ffaa39f8385d05379008c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

