### PR TITLE
docs: clean React box shadow comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-box-shadow.test.ts
+++ b/packages/pulp-react/test/prop-applier-box-shadow.test.ts
@@ -1,13 +1,12 @@
-// pulp #1434 Triage #15 — verify the @pulp/react prop-applier forwards
-// `boxShadow` to the existing `setBoxShadow` bridge (or `clearBoxShadow`
-// on `null` / `undefined` / `'none'`). Three input shapes:
+// Verify the @pulp/react prop-applier forwards `boxShadow` to the
+// `setBoxShadow` bridge, or `clearBoxShadow` for clear sentinels. Three
+// input shapes are covered here:
 //
 //   1. CSS-spec single-shadow string: `'2px 4px 8px rgba(0,0,0,0.3)'`
 //   2. Object form (RN-style): `{ offsetX, offsetY, blur, color, ... }`
 //   3. Sentinel clear: `null` / `'none'` → `clearBoxShadow`
 //
-// Multi-shadow comma-separated lists are deferred — single-shadow path
-// lands first.
+// These cases pin the single-shadow path and clear behavior.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';
@@ -39,7 +38,7 @@ function shadowCalls(b: MockBridge, fn: 'setBoxShadow' | 'clearBoxShadow') {
     return b.calls.filter((c) => c.fn === fn);
 }
 
-describe('prop-applier boxShadow (pulp #1434 Triage #15)', () => {
+describe('prop-applier boxShadow', () => {
     it('parses CSS string: dx dy blur color', () => {
         applyChangedProps(makeInstance(), {}, { boxShadow: '2px 4px 8px rgba(0,0,0,0.3)' });
         const calls = shadowCalls(bridge, 'setBoxShadow');


### PR DESCRIPTION
## Summary
- remove transient pulp #1434/Triage wording from the boxShadow prop-applier test comment
- preserve the current single-shadow and clear-sentinel behavior notes
- simplify the test suite label by removing the issue/triage reference

## Validation
- `git diff --check`
- `rg -n 'Workstream|Phase [0-9]|pulp #[0-9]|Pulp #[0-9]|Codex|ChatGPT|roadmap|planning/|Triage|Wave|sub-agent|slice [A-Z0-9]|follow-up work|Created in the 2026|2026-[0-9]{2}-[0-9]{2}' packages/pulp-react/test/prop-applier-box-shadow.test.ts` (no matches)\n- `python3 tools/scripts/docs_noise_lint.py --mode=report`\n- `npm ci --prefix packages/pulp-react`\n- `npm test --prefix packages/pulp-react`\n- `npm run build --prefix packages/pulp-react`\n- `tools/scripts/gates.sh origin/main`\n- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`\n- `git push --dry-run origin feature/react-box-shadow-comment-hygiene`\n\nRepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.\nManual Shipyard run not used for this docs-only cleanup; local gates and GitHub checks are the validation path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up comment noise in `@pulp/react` boxShadow prop-applier test. Removed triage/issue references, kept single-shadow and clear-sentinel behavior notes, and simplified the suite name; no logic changes.

<sup>Written for commit 12d896545828cc7f170c0b06729406ccca7e10cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

