### PR TITLE
docs: clean React flexWrap comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-bundle.test.ts
+++ b/packages/pulp-react/test/prop-applier-bundle.test.ts
@@ -1,6 +1,5 @@
-// pulp #1434 small-wins bundle (Triage #7 + #14) — verify @pulp/react
-// prop-applier forwards the new keyword vocabularies on the cursor and
-// flexWrap surfaces.
+// Verify @pulp/react prop-applier forwards flexWrap keyword values and
+// preserves the legacy boolean routing.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';
@@ -28,7 +27,7 @@ function makeInstance(id: string = 'k', type: string = 'View'): PulpInstance {
     };
 }
 
-describe('flexWrap reverse (Triage #14)', () => {
+describe('prop-applier flexWrap keyword routing', () => {
     it('forwards "wrap-reverse" string verbatim', () => {
         applyChangedProps(makeInstance(), {}, { flexWrap: 'wrap-reverse' });
         const c = bridge.calls.find((x) => x.fn === 'setFlex' && x.args[1] === 'flex_wrap');


### PR DESCRIPTION
## Summary
- remove transient pulp #1434/Triage wording from the flexWrap prop-applier test comment
- correct the header to describe the current flexWrap-only coverage instead of the old bundle wording
- simplify the test suite label by removing the triage reference

## Validation
- `git diff --check`
- `rg -n 'Workstream|Phase [0-9]|pulp #[0-9]|Pulp #[0-9]|Codex|ChatGPT|roadmap|planning/|Triage|Wave|sub-agent|slice [A-Z0-9]|follow-up work|Created in the 2026|2026-[0-9]{2}-[0-9]{2}' packages/pulp-react/test/prop-applier-bundle.test.ts` (no matches)\n- `python3 tools/scripts/docs_noise_lint.py --mode=report`\n- `npm ci --prefix packages/pulp-react`\n- `npm test --prefix packages/pulp-react`\n- `npm run build --prefix packages/pulp-react`\n- `tools/scripts/gates.sh origin/main`\n- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`\n- `git push --dry-run origin feature/react-bundle-comment-hygiene`\n\nRepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.\nManual Shipyard run not used for this docs-only cleanup; local gates and GitHub checks are the validation path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed outdated triage/issue references from the `@pulp/react` prop-applier tests and updated comments to clearly describe `flexWrap` keyword routing and legacy boolean behavior. Simplified the test suite title to reflect flexWrap-only coverage; no functional changes.

<sup>Written for commit b93c2be858fd176e7decbf902a74c040c6305c9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

