### PR TITLE
docs: clean React dimensions auto comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-dimensions-auto.test.ts
+++ b/packages/pulp-react/test/prop-applier-dimensions-auto.test.ts
@@ -1,16 +1,14 @@
-// pulp #1434 (sub-agent #12 follow-up) — verify the @pulp/react
-// prop-applier forwards `'auto'` for width/height verbatim to the
-// bridge so Yoga's YGNodeStyleSetWidthAuto / SetHeightAuto path is
-// reached.
+// Verify the @pulp/react prop-applier forwards `'auto'` for width/height
+// verbatim to the bridge so Yoga's YGNodeStyleSetWidthAuto /
+// SetHeightAuto path is reached.
 //
 // Figma auto-layout "hug contents" frames, v0.dev intrinsic-sizing
 // cards, and Claude Design responsive containers all emit `width:
 // 'auto'` / `height: 'auto'`. Before this batch the bridge had no
 // 'auto' branch on setFlex(width|height); strings reached `(float)val`
 // = NaN/0 and the node was effectively pinned to 0×0. The TS surface
-// already typed width/height as `number | string` from the percent
-// follow-up (#1434 batch C), so this test only exercises the
-// 'auto' string path through the existing code shape.
+// already types width/height as `number | string`, so this test only
+// exercises the 'auto' string path through the existing code shape.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';
@@ -42,7 +40,7 @@ function flexCalls(b: MockBridge, slot: string) {
     return b.calls.filter((c) => c.fn === 'setFlex' && c.args[1] === slot);
 }
 
-describe("prop-applier width/height 'auto' (pulp #1434 sub-agent #12 follow-up)", () => {
+describe("prop-applier width/height 'auto'", () => {
     it("forwards width: 'auto' verbatim to setFlex(width)", () => {
         applyChangedProps(makeInstance(), {}, { width: 'auto' });
         const calls = flexCalls(bridge, 'width');


### PR DESCRIPTION
## Summary
- remove transient pulp #1434/sub-agent/follow-up wording from the width/height auto prop-applier test
- keep the current behavior notes for Yoga auto sizing and design-export `auto` dimensions
- simplify the test suite label by removing issue/provenance text

## Validation
- `git diff --check`
- `rg -n 'Workstream|Phase [0-9]|pulp #[0-9]|Pulp #[0-9]|Codex|ChatGPT|roadmap|planning/|Triage|Wave|sub-agent|slice [A-Z0-9]|follow-up work|Created in the 2026|2026-[0-9]{2}-[0-9]{2}' packages/pulp-react/test/prop-applier-dimensions-auto.test.ts` (no matches)\n- `python3 tools/scripts/docs_noise_lint.py --mode=report`\n- `npm ci --prefix packages/pulp-react`\n- `npm test --prefix packages/pulp-react` (50 files / 540 tests passed, then Node 26 crashed after completion with `v8::ToLocalChecked Empty MaybeLocal`)\n- `npm exec -- vitest run --pool forks` from `packages/pulp-react` (50 files / 540 tests passed, clean exit)\n- `npm run build --prefix packages/pulp-react`\n- `tools/scripts/gates.sh origin/main`\n- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`\n- `git push --dry-run origin feature/react-dimensions-auto-comment-hygiene`\n\nRepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.\nManual Shipyard run not used for this docs-only cleanup; local gates and GitHub checks are the validation path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up comments and the test name for the width/height 'auto' case in `packages/pulp-react` to improve clarity. No functional changes.

- **Refactors**
  - Removed transient issue/provenance references from comments.
  - Kept concise notes on Yoga auto sizing and design-export `auto` dimensions.
  - Simplified the test suite label to “prop-applier width/height 'auto'”.

<sup>Written for commit e8044aa189afd492ff784150d4b53b446646efdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

