### PR TITLE
docs: clean React dimensions comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-dimensions.test.ts
+++ b/packages/pulp-react/test/prop-applier-dimensions.test.ts
@@ -1,14 +1,12 @@
-// pulp #1434 (rn batch C) — verify the @pulp/react prop-applier
-// forwards dimension props as `number | string` so percent strings
-// (`'50%'`) and the `'auto'` keyword (flexBasis) reach the bridge
-// verbatim. The bridge's setFlex case for each dimension key
-// dispatches percent values to Yoga's
+// Verify the @pulp/react prop-applier forwards dimension props as
+// `number | string` so percent strings (`'50%'`) and the `'auto'`
+// keyword for flexBasis reach the bridge verbatim. The bridge's setFlex
+// case for each dimension key dispatches percent values to Yoga's
 // `YGNodeStyleSet{Width,Height,Min*,Max*,FlexBasis}Percent` API and
 // `'auto'` to `YGNodeStyleSetFlexBasisAuto`.
 //
-// Before this batch, the prop-applier cast `value as number` for these
-// keys, which silently coerced strings to NaN at the bridge boundary
-// and dropped the percent / auto signal entirely.
+// Numeric-only forwarding silently coerced strings to NaN at the bridge
+// boundary and dropped the percent / auto signal entirely.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';
@@ -40,7 +38,7 @@ function flexCalls(b: MockBridge, slot: string) {
     return b.calls.filter((c) => c.fn === 'setFlex' && c.args[1] === slot);
 }
 
-describe('prop-applier dimension percent strings (pulp #1434 batch C)', () => {
+describe('prop-applier dimension percent strings', () => {
     it.each([
         ['width',     'width'],
         ['height',    'height'],


### PR DESCRIPTION
## Summary
- remove stale Pulp issue/batch breadcrumbs from the React dimensions prop-applier test header
- keep the behavioral explanation for percent dimensions and flexBasis auto forwarding
- simplify the describe label so the long-lived test name describes behavior, not implementation history

## Validation
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- git diff --check
- rg workflow-breadcrumb scan on packages/pulp-react/test/prop-applier-dimensions.test.ts
- python3 tools/scripts/docs_noise_lint.py --mode=report
- npm ci --prefix packages/pulp-react
- npm run build --prefix packages/pulp-react
- npm test --prefix packages/pulp-react
  - first run before build failed only because fresh worktree lacked packages/pulp-react/dist/index.mjs for build-output-externals.test.ts
  - after build, 50 files / 540 tests passed
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
- git push --dry-run origin feature/react-dimensions-comment-hygiene
- PULP_VIA_SHIPYARD=1 git push -u origin feature/react-dimensions-comment-hygiene

Manual Shipyard run not used for this docs-only cleanup; local gates and GitHub checks are the validation path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up the `@pulp/react` dimensions prop‑applier test by removing historical breadcrumbs and making the suite name describe behavior. Improves readability with no behavior changes.

- **Refactors**
  - Replaced stale issue/batch notes with a concise explanation of number|string forwarding, percent strings, and `'auto'` handling to the bridge/Yoga.
  - Shortened the Vitest suite name by removing the "(pulp #1434 batch C)" suffix.

<sup>Written for commit fb63b2341a55653237f35fa60ab45a9b703e186f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

