### PR TITLE
docs: clean React writing direction comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-direction.test.ts
+++ b/packages/pulp-react/test/prop-applier-direction.test.ts
@@ -1,10 +1,10 @@
-// pulp #1434 Phase A2-3 — verify @pulp/react prop-applier forwards
-// `writingDirection` keyword strings verbatim to the setDirection
-// bridge fn. The CSS spec name `direction` already routes through
-// FlexProps in this codebase (`FlexDirection` shorthand) — JSX
-// surfaces only `writingDirection` to avoid the type-name conflict.
-// The CSS-string-form path (`style.direction = 'rtl'`) goes through
-// the el.style adapter and reaches setDirection separately.
+// Verify @pulp/react prop-applier forwards `writingDirection` keyword
+// strings verbatim to the setDirection bridge fn. The CSS spec name
+// `direction` already routes through FlexProps in this codebase
+// (`FlexDirection` shorthand), so JSX surfaces only `writingDirection`
+// to avoid the type-name conflict. The CSS-string-form path
+// (`style.direction = 'rtl'`) goes through the el.style adapter and
+// reaches setDirection separately.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';
@@ -32,7 +32,7 @@ function makeInstance(id: string = 'k', type: string = 'View'): PulpInstance {
     };
 }
 
-describe('prop-applier writingDirection (pulp #1434 Phase A2-3)', () => {
+describe('prop-applier writingDirection', () => {
     it('writingDirection "ltr" forwards verbatim', () => {
         applyChangedProps(makeInstance(), {}, { writingDirection: 'ltr' });
         expect(bridge.calls.find((x) => x.fn === 'setDirection')?.args).toEqual(['k', 'ltr']);
@@ -54,9 +54,8 @@ describe('prop-applier writingDirection (pulp #1434 Phase A2-3)', () => {
     });
 
     it('does NOT shadow FlexProps `direction` — that prop still routes to setFlex', () => {
-        // FlexProps.direction (FlexDirection: 'row' | 'col') was wired
-        // long before A2-3. Confirm it still goes to setFlex(direction)
-        // and is NOT misrouted to setDirection.
+        // FlexProps.direction (FlexDirection: 'row' | 'col') still goes
+        // to setFlex(direction) and is NOT misrouted to setDirection.
         applyChangedProps(makeInstance(), {}, { direction: 'row' });
         expect(
             bridge.calls.find((x) => x.fn === 'setFlex' && x.args[1] === 'direction')?.args,


### PR DESCRIPTION
## Summary
- remove stale Pulp issue/phase breadcrumbs from the React writingDirection prop-applier test header
- keep the current setDirection versus setFlex routing rationale
- simplify the describe label and inline invariant comment so they describe behavior, not implementation history

## Validation
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- git diff --check
- rg workflow-breadcrumb scan on packages/pulp-react/test/prop-applier-direction.test.ts
- python3 tools/scripts/docs_noise_lint.py --mode=report
- npm ci --prefix packages/pulp-react
- npm run build --prefix packages/pulp-react
- npm test --prefix packages/pulp-react (50 files / 540 tests passed)
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
- git push --dry-run origin feature/react-direction-comment-hygiene
- PULP_VIA_SHIPYARD=1 git push -u origin feature/react-direction-comment-hygiene

Manual Shipyard run not used for this docs-only cleanup; local gates and GitHub checks are the validation path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned the `writingDirection` test comments in `@pulp/react` to remove stale breadcrumbs and clarify current behavior. No functional changes.

- **Refactors**
  - Simplified the describe label and inline comments to explain behavior (setDirection vs setFlex; JSX `writingDirection` vs CSS `style.direction`).
  - Removed references to old issue/phase notes.

<sup>Written for commit 1bd95967f66f506d10696af821040676dd167d02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

