### PR TITLE
docs: clean React display comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-display.test.ts
+++ b/packages/pulp-react/test/prop-applier-display.test.ts
@@ -1,13 +1,12 @@
-// pulp #1434 (Triage #12) — verify the @pulp/react prop-applier
-// dispatches `display: 'flex' | 'none'` to the right setVisible call.
+// Verify the @pulp/react prop-applier dispatches
+// `display: 'flex' | 'none'` to the right setVisible call.
 //
 // RN exports + Figma / v0.dev / Claude Design HTML routinely emit
 // `style={{ display: 'flex' }}` (the implicit default in pulp, but
 // the prop-applier shouldn't drop it as unknown) or `display: 'none'`
-// to hide a subtree. The yoga / CSS-shim side was wired for the
-// el.style proxy in #1422; this test guards the parallel RN-flavored
-// JSX path so RN consumers don't have to round-trip through el.style
-// (which costs a bridge call + DOM-lite proxy walk).
+// to hide a subtree. This test guards the RN-flavored JSX path so RN
+// consumers don't have to round-trip through el.style, which costs a
+// bridge call plus a DOM-lite proxy walk.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';
@@ -39,7 +38,7 @@ function visibleCalls(b: MockBridge) {
     return b.calls.filter((c) => c.fn === 'setVisible');
 }
 
-describe('prop-applier display: flex / none (pulp #1434 Triage #12)', () => {
+describe('prop-applier display: flex / none', () => {
     it("display: 'none' calls setVisible(id, false)", () => {
         applyChangedProps(makeInstance(), {}, { display: 'none' });
         const calls = visibleCalls(bridge);
@@ -81,12 +80,11 @@ describe('prop-applier display: flex / none (pulp #1434 Triage #12)', () => {
     });
 });
 
-// pulp #1894 — `display: 'flex'` without an explicit `flexDirection`
-// must default to row (CSS spec), not column (Yoga / RN default).
-// Without this fallback, every `style={{ display: 'flex' }}` JSX
-// container imported via the flat-prop path collapses to a vertical
-// stack — first seen in Spectr's editor toolbar post-#1859.
-describe('prop-applier display: flex default direction (pulp #1894)', () => {
+// `display: 'flex'` without an explicit `flexDirection` must default
+// to row (CSS spec), not column (Yoga / RN default). Without this
+// fallback, every `style={{ display: 'flex' }}` JSX container imported
+// via the flat-prop path collapses to a vertical stack.
+describe('prop-applier display: flex default direction', () => {
     function flexDirectionCalls(b: MockBridge) {
         return b.calls.filter(
             (c) => c.fn === 'setFlex' && c.args[1] === 'direction',
@@ -168,11 +166,11 @@ describe('prop-applier display: flex default direction (pulp #1894)', () => {
         expect(flexDirectionCalls(bridge)).toHaveLength(0);
     });
 
-    // pulp #1898 (Codex review P2) — the prop-applier also accepts
-    // `direction` as a flex-direction alias (see the `case 'direction'`
-    // block in src/prop-applier.ts). The default-row suppression must
-    // honor that alias too, otherwise an explicit `direction: 'column'`
-    // gets clobbered by the default-row emit from display:flex.
+    // The prop-applier also accepts `direction` as a flex-direction
+    // alias (see the `case 'direction'` block in src/prop-applier.ts).
+    // The default-row suppression must honor that alias too, otherwise
+    // an explicit `direction: 'column'` gets clobbered by the default-row
+    // emit from display:flex.
     it("explicit direction: 'column' alias suppresses the default", () => {
         applyChangedProps(makeInstance(), {}, {
             display: 'flex',


### PR DESCRIPTION
## Summary
- remove stale issue, triage, and review breadcrumbs from the React display prop-applier tests
- keep the current display visibility and flex default-direction rationale
- simplify describe labels so test names describe behavior, not implementation history

## Validation
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- git diff --check
- rg workflow-breadcrumb scan on packages/pulp-react/test/prop-applier-display.test.ts
- python3 tools/scripts/docs_noise_lint.py --mode=report
- npm ci --prefix packages/pulp-react
- npm run build --prefix packages/pulp-react
- npm test --prefix packages/pulp-react (50 files / 540 tests passed)
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
- git push --dry-run origin feature/react-display-comment-hygiene
- PULP_VIA_SHIPYARD=1 git push -u origin feature/react-display-comment-hygiene

Manual Shipyard run not used for this docs-only cleanup; local gates and GitHub checks are the validation path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up comments and describe labels in `packages/pulp-react/test/prop-applier-display.test.ts` to remove stale issue breadcrumbs and focus names on behavior. Kept the rationale for `display: 'flex' | 'none'` visibility and flex default-direction; no test logic changes.

<sup>Written for commit 4973a57c7222366d7a139d096a54218e352b5154. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

