### PR TITLE
docs: clean React edges comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-edges.test.ts
+++ b/packages/pulp-react/test/prop-applier-edges.test.ts
@@ -1,8 +1,7 @@
-// pulp #1434 (cross-surface mega-batch) — verify @pulp/react prop-applier
-// forwards per-edge margin/padding values verbatim (number, percent string,
-// or 'auto' for margin only). Bridge + Yoga path is covered by the
-// Catch2 round-trip tests; this file covers the JS-side type-narrowing
-// + bridge-call shape.
+// Verify @pulp/react prop-applier forwards per-edge margin/padding
+// values verbatim (number, percent string, or 'auto' for margin only).
+// Bridge + Yoga path is covered by the Catch2 round-trip tests; this
+// file covers the JS-side type-narrowing + bridge-call shape.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';
@@ -34,7 +33,7 @@ function setFlexCalls(b: MockBridge, key: string) {
     return b.calls.filter((c) => c.fn === 'setFlex' && c.args[1] === key);
 }
 
-describe('prop-applier per-edge margin / padding (pulp #1434 cross-surface mega-batch)', () => {
+describe('prop-applier per-edge margin / padding', () => {
     it('paddingTop accepts numeric (px) and forwards verbatim', () => {
         applyChangedProps(makeInstance(), {}, { paddingTop: 12 });
         expect(setFlexCalls(bridge, 'padding_top')[0].args).toEqual(['k', 'padding_top', 12]);


### PR DESCRIPTION
## Summary
- remove stale issue and batch breadcrumbs from the React per-edge margin/padding prop-applier test
- keep the JS-side type-narrowing and bridge-call rationale intact
- simplify the describe label so it describes behavior, not implementation history

## Validation
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- git diff --check
- rg workflow-breadcrumb scan on packages/pulp-react/test/prop-applier-edges.test.ts
- python3 tools/scripts/docs_noise_lint.py --mode=report
- npm ci --prefix packages/pulp-react
- npm run build --prefix packages/pulp-react
- npm test --prefix packages/pulp-react (50 files / 540 tests passed)
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
- git push --dry-run origin feature/react-edges-comment-hygiene
- PULP_VIA_SHIPYARD=1 git push -u origin feature/react-edges-comment-hygiene

Manual Shipyard run not used for this docs-only cleanup; local gates and GitHub checks are the validation path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clean up per-edge margin/padding test in `@pulp/react`: remove stale issue/batch breadcrumbs, keep JS-side type-narrowing and bridge-call rationale, and simplify the describe label. No behavior or coverage changes.

<sup>Written for commit 0f7192d81722cd60602c9b465f7f31c07012bd6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

