### PR TITLE
docs: clean React fontWeight comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-fontweight.test.ts
+++ b/packages/pulp-react/test/prop-applier-fontweight.test.ts
@@ -1,13 +1,13 @@
-// pulp #1434 batch 3 — verify the @pulp/react prop-applier translates
-// CSS / RN fontWeight keyword forms (`'normal'`, `'bold'`, `'lighter'`,
-// `'bolder'`) to numeric weights before reaching the bridge.
+// Verify the @pulp/react prop-applier translates CSS / RN fontWeight
+// keyword forms (`'normal'`, `'bold'`, `'lighter'`, `'bolder'`) to
+// numeric weights before reaching the bridge.
 //
-// Pre-fix: `Number('bold')` returned NaN, the bridge then defaulted to
-// 400 — silently mapping bold to normal. This drift is recorded in
-// compat.json (`css/fontWeight`) and mirrored on the JS CSS shim
-// (`web-compat-style-decl.js`). Both paths must agree so design-tool
-// exports (Figma, Stitch, v0, Claude Design) and React-Native style
-// objects produce the same Label::font_weight() result.
+// Raw Number(...) coercion would turn keyword weights into NaN before
+// the bridge's defensive default maps them back to 400. This translation
+// must stay aligned with compat.json (`css/fontWeight`) and the JS CSS
+// shim (`web-compat-style-decl.js`) so design-tool exports (Figma,
+// Stitch, v0, Claude Design) and React-Native style objects produce the
+// same Label::font_weight() result.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';
@@ -39,7 +39,7 @@ function fontWeightCall(): { fn: string; args: unknown[] } | undefined {
     return bridge.calls.find((c) => c.fn === 'setFontWeight');
 }
 
-describe("prop-applier fontWeight keyword translation (pulp #1434 batch 3)", () => {
+describe("prop-applier fontWeight keyword translation", () => {
     it("'normal' keyword maps to 400", () => {
         applyChangedProps(makeInstance(), {}, { fontWeight: 'normal' });
         expect(fontWeightCall()?.args).toEqual(['k', 400]);


### PR DESCRIPTION
## Summary
- remove stale issue and batch breadcrumbs from the React fontWeight keyword prop-applier test
- rephrase historical pre-fix wording as a current behavior invariant
- simplify the describe label so it describes behavior, not implementation history

## Validation
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- git diff --check
- rg workflow-breadcrumb scan on packages/pulp-react/test/prop-applier-fontweight.test.ts
- python3 tools/scripts/docs_noise_lint.py --mode=report
- npm ci --prefix packages/pulp-react
- npm run build --prefix packages/pulp-react
- npm test --prefix packages/pulp-react (50 files / 540 tests passed)
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
- git push --dry-run origin feature/react-fontweight-comment-hygiene
- PULP_VIA_SHIPYARD=1 git push -u origin feature/react-fontweight-comment-hygiene

Manual Shipyard run not used for this docs-only cleanup; local gates and GitHub checks are the validation path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up comments in the `@pulp/react` fontWeight keyword translation test by removing stale issue breadcrumbs and restating the current invariant (keywords map to numeric weights before the bridge, aligned with `compat.json` and `web-compat-style-decl.js`). Simplified the test’s describe label; no behavior changes.

<sup>Written for commit 426e335fa4539994d462d4c5970ebf2bc931b0de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

