### PR TITLE
docs: clean React logical edges comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-logical-edges.test.ts
+++ b/packages/pulp-react/test/prop-applier-logical-edges.test.ts
@@ -1,6 +1,5 @@
-// pulp #1434 rn logical-edge bundle (sub-agent #27 finding) — verify
-// the LTR-only fast path: Start → Left, End → Right, inset / insetBlock
-// / insetInline shorthand fan-out.
+// Verify the LTR-only fast path: Start -> Left, End -> Right, and
+// inset / insetBlock / insetInline shorthand fan-out.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';
@@ -32,7 +31,7 @@ function setFlexCalls(b: MockBridge, key: string) {
     return b.calls.filter((c) => c.fn === 'setFlex' && c.args[1] === key);
 }
 
-describe('rn logical-edge bundle (pulp #1434 sub-agent #27)', () => {
+describe('prop-applier logical-edge bundle', () => {
     it('marginStart routes to margin_left (LTR)', () => {
         applyChangedProps(makeInstance(), {}, { marginStart: 8 });
         expect(setFlexCalls(bridge, 'margin_left')[0].args).toEqual(['k', 'margin_left', 8]);


### PR DESCRIPTION
## Summary
- remove stale issue and sub-agent breadcrumbs from the React logical-edge prop-applier test
- keep the LTR Start/End and inset shorthand routing contract clear
- simplify the describe label so it describes behavior, not implementation history

## Validation
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- git diff --check
- rg workflow-breadcrumb scan on packages/pulp-react/test/prop-applier-logical-edges.test.ts
- python3 tools/scripts/docs_noise_lint.py --mode=report
- npm ci --prefix packages/pulp-react
- npm run build --prefix packages/pulp-react
- npm test --prefix packages/pulp-react (50 files / 540 tests passed)
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
- git push --dry-run origin feature/react-logical-edges-comment-hygiene
- PULP_VIA_SHIPYARD=1 git push -u origin feature/react-logical-edges-comment-hygiene

Manual Shipyard run not used for this docs-only cleanup; local gates and GitHub checks are the validation path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up comments and test labels in `pulp-react` logical-edge prop-applier tests to remove stale issue breadcrumbs and focus on behavior. Clarifies the LTR routing contract (Start -> Left, End -> Right) and inset shorthand fan-out.

<sup>Written for commit 4e0972801f23103f2bac63673960f0fb76b9543e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

