### PR TITLE
docs: clean React mask clip-path comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-mask-clip-path.test.ts
+++ b/packages/pulp-react/test/prop-applier-mask-clip-path.test.ts
@@ -1,11 +1,7 @@
-// pulp #1515 — CSS clip-path + mask cluster. Verify @pulp/react
-// prop-applier forwards `clipPath` / `mask` / `maskImage` to the
-// matching bridge fns. The bridge stores the value on the View;
-// Skia paint side honors the `path("...")` form via
-// SkPath::FromSVGString. URL refs / named shape forms (circle / inset
-// / polygon) and the saveLayer + SkBlendMode::kDstIn shader composite
-// for mask painting are deferred — at the prop-applier layer we just
-// confirm the dispatch lands at the right bridge fn.
+// The prop applier forwards `clipPath`, `mask`, and `maskImage`
+// values to the matching bridge functions without parsing them. The
+// native bridge owns storage, clearing, and renderer-specific support
+// for the forwarded syntax forms.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';
@@ -37,7 +33,7 @@ function callOf(b: MockBridge, fn: string) {
     return b.calls.find((c) => c.fn === fn);
 }
 
-describe('clip-path / mask cluster (pulp #1515)', () => {
+describe('clip-path and mask prop forwarding', () => {
     it('clipPath path() form forwards verbatim to setClipPath', () => {
         applyChangedProps(makeInstance(), {}, {
             clipPath: 'path("M 0 0 L 100 0 L 100 100 Z")',


### PR DESCRIPTION
## Summary
- Replaces the historical `pulp #1515` mask/clip-path test header with a stable prop-forwarding ownership note.
- Renames the describe block so the suite label describes behavior instead of the implementation wave/issue breadcrumb.

## Validation
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- `git diff --check`
- Targeted breadcrumb scan for stale workflow/issue references in `packages/pulp-react/test/prop-applier-mask-clip-path.test.ts`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react` (completed with existing deprecation/audit warnings: inflight, glob, 5 vulnerabilities)
- `npm run build --prefix packages/pulp-react`
- `npm test --prefix packages/pulp-react`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `git push --dry-run origin feature/react-mask-clip-path-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-mask-clip-path-comment-hygiene`

## Review
- Claude autoreview clean: no accepted/actionable findings reported.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up comments and test labels for the clip-path/mask prop applier in `packages/pulp-react` to remove issue breadcrumbs and clarify behavior. No runtime or test logic changes.

- **Refactors**
  - Replaced the historical `pulp #1515` header with a clear prop-forwarding ownership note.
  - Renamed the `describe` block to “clip-path and mask prop forwarding” to reflect behavior.

<sup>Written for commit 18c23a4eeb7ecd51068a751a79daf310671632ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

