### PR TITLE
docs: clean React mixBlendMode comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-mix-blend-mode.test.ts
+++ b/packages/pulp-react/test/prop-applier-mix-blend-mode.test.ts
@@ -1,9 +1,6 @@
-// pulp #1549 — RN `mixBlendMode` (RN 0.76 New Architecture). Verify the
-// `@pulp/react` prop-applier forwards the 16 W3C blend-mode keywords to
-// the matching bridge fn `setMixBlendMode`. The bridge keyword→
-// canvas::Canvas::BlendMode mapping itself is exercised by C++ tests; this
-// test guarantees the JSX dispatch is wired and routes the string through
-// verbatim.
+// The prop applier forwards supported `mixBlendMode` keywords to the
+// bridge verbatim. Native-side tests cover keyword-to-renderer mapping;
+// this suite protects the JSX dispatch path.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';
@@ -42,7 +39,7 @@ const W3C_BLEND_KEYWORDS = [
     'hue', 'saturation', 'color', 'luminosity',
 ] as const;
 
-describe('rn mixBlendMode (pulp #1549)', () => {
+describe('mixBlendMode prop forwarding', () => {
     it('multiply forwards verbatim', () => {
         applyChangedProps(makeInstance(), {}, { mixBlendMode: 'multiply' });
         expect(callOf(bridge, 'setMixBlendMode')?.args).toEqual(['m', 'multiply']);


### PR DESCRIPTION
## Summary
- Replaces the historical `pulp #1549` / RN-version test header with a stable `mixBlendMode` forwarding ownership note.
- Renames the describe block so the suite label describes behavior instead of implementation-wave history.

## Validation
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- `git diff --check`
- Targeted breadcrumb scan for stale workflow/issue references in `packages/pulp-react/test/prop-applier-mix-blend-mode.test.ts`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react` (completed with existing deprecation/audit warnings: inflight, glob, 5 vulnerabilities)
- `npm run build --prefix packages/pulp-react`
- `npm test --prefix packages/pulp-react`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `git push --dry-run origin feature/react-mix-blend-mode-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-mix-blend-mode-comment-hygiene`

## Review
- Claude autoreview clean: no accepted/actionable findings reported.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up the `mixBlendMode` test by removing RN/version issue archaeology and adding a clear ownership note, then renamed the suite to describe behavior (prop forwarding). No behavior changes; the test still verifies supported keywords are forwarded verbatim to the bridge.

<sup>Written for commit b4ad7e34d1ac69a4037f3c9b9d9c42e058bde201. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

