### PR TITLE
docs: clean React outline comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-outline.test.ts
+++ b/packages/pulp-react/test/prop-applier-outline.test.ts
@@ -1,13 +1,10 @@
-// pulp #1519 — verify the @pulp/react prop-applier forwards the RN
-// outline cluster (outlineColor / outlineOffset / outlineStyle /
-// outlineWidth) verbatim to the matching bridge setOutlineX fns.
+// The prop applier forwards each outline attribute verbatim to its
+// matching bridge setter.
 //
 // Outline is a paint-time ring drawn OUTSIDE the border-box and does
 // NOT take up Yoga layout space (no parent reservation). Each prop
 // must route through its own per-attribute bridge fn so a JSX prop
-// diff that touches one outline-* preserves the others — same shape
-// as the borderColor / borderWidth / borderStyle cluster (#1027 +
-// #1434 Triage #10).
+// diff that touches one outline-* attribute preserves the others.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';
@@ -39,7 +36,7 @@ function callsFor(b: MockBridge, fn: string) {
     return b.calls.filter((c) => c.fn === fn);
 }
 
-describe('prop-applier outline cluster (pulp #1519)', () => {
+describe('outline prop forwarding', () => {
     it('forwards outlineColor verbatim', () => {
         applyChangedProps(makeInstance(), {}, { outlineColor: '#ff8800' });
         const calls = callsFor(bridge, 'setOutlineColor');


### PR DESCRIPTION
## Summary
- Replaces historical outline issue/triage breadcrumbs with stable prop-forwarding behavior notes.
- Renames the outline test suite label so it describes the current forwarding contract instead of workflow history.

## Validation
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- `git diff --check`
- Targeted breadcrumb scan for stale workflow/issue references in `packages/pulp-react/test/prop-applier-outline.test.ts`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react` (completed with existing deprecation/audit warnings: inflight, glob, 5 vulnerabilities)
- `npm run build --prefix packages/pulp-react`
- `npm test --prefix packages/pulp-react`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `git push --dry-run origin feature/react-outline-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-outline-comment-hygiene`

## Review
- Claude autoreview clean: no accepted/actionable findings reported.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up the outline prop-forwarding tests in `pulp-react` by replacing historical issue references with clear behavior notes and renaming the suite to reflect the current contract. No behavior changes.

- **Refactors**
  - Updated test comments to document per-attribute outline forwarding and layout semantics.
  - Renamed suite from “prop-applier outline cluster (pulp #1519)” to “outline prop forwarding.”

<sup>Written for commit 1e99b0abb00e8e191a407c563eb1d14be3000721. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

