### PR TITLE
docs: clean React RN aliases comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-rn-aliases.test.ts
+++ b/packages/pulp-react/test/prop-applier-rn-aliases.test.ts
@@ -1,20 +1,16 @@
-// pulp #1434 batch 4 — verify the @pulp/react prop-applier fans out
-// React Native shorthand aliases (marginHorizontal, marginVertical,
-// paddingHorizontal, paddingVertical) to the per-edge bridge setters.
+// The prop applier fans out React Native shorthand aliases
+// (marginHorizontal, marginVertical, paddingHorizontal, paddingVertical)
+// to the per-edge bridge setters.
 //
-// Pulp's value is broad import-readiness from {Figma, Pencil.dev, v0,
-// Claude Design HTML, RN, generic HTML/CSS/React}. RN code commonly
-// writes `style={{ marginHorizontal: 8 }}` and expects the framework to
-// decompose the shorthand to marginLeft + marginRight on the underlying
-// layout. Without a fan-out path the alias was silently dropped at the
-// JSX entry point, so RN snippets ported verbatim lost their padding /
-// margin information. The fan-out lands at two layers:
+// React Native code commonly writes `style={{ marginHorizontal: 8 }}`
+// and expects the framework to decompose the shorthand to marginLeft +
+// marginRight on the underlying layout. Pulp supports that import path
+// by fanning out aliases at two layers:
 //
 //   - core/view/js/web-compat-style-decl.js — DOM-lite el.style adapter
-//     (covered by harness coverage on the css/* surface).
+//     covered by harness coverage on the css/* surface.
 //   - packages/pulp-react/src/prop-applier.ts — @pulp/react JSX
-//     intrinsic (covered by *this* test file plus the harness rn/*
-//     surface adapter).
+//     intrinsic covered by this test file plus the harness rn/* surface.
 //
 // Each test asserts that ONE alias triggers exactly TWO setFlex calls
 // targeting the matching per-edge slots with the supplied value.
@@ -49,7 +45,7 @@ function flexCalls(b: MockBridge, slot: string) {
     return b.calls.filter((c) => c.fn === 'setFlex' && c.args[1] === slot);
 }
 
-describe('prop-applier RN shorthand aliases (pulp #1434 batch 4)', () => {
+describe('React Native shorthand alias forwarding', () => {
     it('marginHorizontal fans out to margin_left + margin_right', () => {
         applyChangedProps(makeInstance(), {}, { marginHorizontal: 8 });
 


### PR DESCRIPTION
## Summary
- Replaces the historical `pulp #1434 batch 4` RN alias test header with stable alias fan-out behavior notes.
- Renames the suite label so it describes the current React Native shorthand forwarding contract instead of batch history.

## Validation
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- `git diff --check`
- Targeted breadcrumb scan for stale workflow/issue references in `packages/pulp-react/test/prop-applier-rn-aliases.test.ts`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react` (completed with existing deprecation/audit warnings: inflight, glob, 5 vulnerabilities)
- `npm run build --prefix packages/pulp-react`
- `npm test --prefix packages/pulp-react`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `git push --dry-run origin feature/react-rn-aliases-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-rn-aliases-comment-hygiene`

## Review
- Claude autoreview clean: no accepted/actionable findings reported.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up the React Native alias test in `@pulp/react` by replacing the old “pulp #1434 batch 4” header with clear notes on current alias fan-out behavior and renaming the suite to reflect the shorthand forwarding contract. No functional changes to code or tests.

<sup>Written for commit 46f5073af19bfb394408fafcd4c35b0d02d4b72e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

