### PR TITLE
docs: clean React RN bridge wires comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-rn-wires.test.ts
+++ b/packages/pulp-react/test/prop-applier-rn-wires.test.ts
@@ -1,7 +1,6 @@
-// pulp #1434 rn bridge-wires bundle (sub-agent #27 finding) — verify
-// @pulp/react prop-applier forwards 7 RN-style props to bridge fns
-// that already exist in C++ (widget_bridge.cpp). These were missing
-// JSX dispatch despite the bridge surface being ready.
+// The prop applier forwards these React Native style props to the
+// matching widget bridge functions. This suite protects the JSX
+// dispatch path for bridge surfaces that are implemented natively.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';
@@ -33,7 +32,7 @@ function callOf(b: MockBridge, fn: string) {
     return b.calls.find((c) => c.fn === fn);
 }
 
-describe('rn bridge-wires bundle (pulp #1434 sub-agent #27)', () => {
+describe('React Native bridge prop forwarding', () => {
     it('backfaceVisibility forwards verbatim', () => {
         applyChangedProps(makeInstance(), {}, { backfaceVisibility: 'hidden' });
         expect(callOf(bridge, 'setBackfaceVisibility')?.args).toEqual(['k', 'hidden']);
@@ -44,7 +43,7 @@ describe('rn bridge-wires bundle (pulp #1434 sub-agent #27)', () => {
         expect(callOf(bridge, 'setCursor')?.args).toEqual(['k', 'pointer']);
     });
 
-    it('cursor handles col-resize keyword (post-Triage #7 fan-out)', () => {
+    it('cursor handles col-resize keyword', () => {
         applyChangedProps(makeInstance(), {}, { cursor: 'col-resize' });
         expect(callOf(bridge, 'setCursor')?.args).toEqual(['k', 'col-resize']);
     });


### PR DESCRIPTION
## Summary
- Replaces historical RN bridge-wires issue/sub-agent breadcrumbs with stable prop-forwarding behavior notes.
- Renames the suite label and cursor test label so they describe current dispatch coverage instead of workflow history.

## Validation
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- `git diff --check`
- Targeted breadcrumb scan for stale workflow/issue references in `packages/pulp-react/test/prop-applier-rn-wires.test.ts`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react` (completed with existing deprecation/audit warnings: inflight, glob, 5 vulnerabilities)
- `npm run build --prefix packages/pulp-react`
- `npm test --prefix packages/pulp-react`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `git push --dry-run origin feature/react-rn-wires-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-rn-wires-comment-hygiene`

## Review
- Claude autoreview clean: no accepted/actionable findings reported.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up comments and test names in `packages/pulp-react` to remove old RN bridge issue breadcrumbs and clearly describe current prop-forwarding behavior. No functional changes; tests continue to verify React Native prop forwarding to the native bridge.

<sup>Written for commit 898451481fec59f59ac7587e8a27c0337c52e61e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

