### PR TITLE
docs: clean React Spectr gaps comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-spectr-gaps-batch2.test.ts
+++ b/packages/pulp-react/test/prop-applier-spectr-gaps-batch2.test.ts
@@ -1,9 +1,7 @@
-// 6 React-applier gaps surfaced by the runtime-import coverage sub-agent
-// (planning/runtime-import-spectr-coverage-2026-05-11.md). Each prop is
-// marked `supported` in compat.json (wired via web-compat-style-decl.js)
-// but the @pulp/react applier was missing the `case`, so JSX `style={{…}}`
-// silently dropped: outline (3 Spectr occurrences), overflowX/Y (3),
-// whiteSpace (2), textOverflow (1), backdropFilter (12), backgroundImage (1).
+// These props are supported by both the DOM-lite style adapter and
+// the React prop applier. This suite protects JSX style dispatch for
+// outline, overflow axes, text wrapping/overflow, backdrop filters,
+// and background gradients.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';
@@ -33,7 +31,7 @@ function makeInstance(id: string = 'k'): PulpInstance {
 
 const callsOf = (b: MockBridge, fn: string) => b.calls.filter((c) => c.fn === fn);
 
-describe('prop-applier Spectr-gap batch 2 (6 React-applier gaps)', () => {
+describe('React prop forwarding for supported style gaps', () => {
     it('outline shorthand fans out to setOutlineWidth/Style/Color', () => {
         applyChangedProps(makeInstance(), {}, { outline: '2px solid #ff0000' });
         expect(callsOf(bridge, 'setOutlineWidth')[0].args).toEqual(['k', 2]);
@@ -94,8 +92,7 @@ describe('prop-applier Spectr-gap batch 2 (6 React-applier gaps)', () => {
         applyChangedProps(makeInstance(), {}, {
             backgroundImage: 'linear-gradient(90deg, red, blue)',
         });
-        // Codex P1 on #1831: setBackground only parses color tokens, so
-        // gradient strings must route to setBackgroundGradient.
+        // Gradients must route to setBackgroundGradient because setBackground handles color tokens.
         const sg = callsOf(bridge, 'setBackgroundGradient');
         expect(sg).toHaveLength(1);
         expect(sg[0].args[1]).toMatch(/^linear-gradient/);
@@ -119,9 +116,7 @@ describe('prop-applier Spectr-gap batch 2 (6 React-applier gaps)', () => {
     });
 
     it('background shorthand with gradient routes to setBackgroundGradient', () => {
-        // Same fix as backgroundImage — `background: linear-gradient(...)`
-        // was previously sent to setBackground (color-only) producing a
-        // bogus white background. Caught visually in Spectr's chip strip.
+        // Match backgroundImage routing so gradient shorthands do not clobber the color slot.
         applyChangedProps(makeInstance(), {}, {
             background: 'linear-gradient(to bottom, #111, #222)',
         });


### PR DESCRIPTION
## Summary
- remove stale planning/sub-agent provenance from the React Spectr gaps applier test header
- retitle the suite around current prop-forwarding behavior
- replace Codex/issue/visual-triage breadcrumbs with current behavior comments for gradient routing

## Validation
- `git diff --check`
- focused stale-breadcrumb scan for planning/review/provenance terms
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react`
- `npm run build --prefix packages/pulp-react`
- `npm test --prefix packages/pulp-react`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `git push --dry-run origin feature/react-spectr-gaps-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-spectr-gaps-comment-hygiene`

## Notes
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- `npm ci` reported existing dependency warnings (`inflight`, `glob`) and 5 audit findings (2 moderate, 1 high, 2 critical).
- pre-push hook reported optional planning fixture paths skipped because the planning submodule is not initialized in this worktree.
- Diff-coverage was not run; `tools/scripts/gates.sh` explicitly skipped it as slow.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up outdated planning/provenance comments in `packages/pulp-react` Spectr gaps test and aligned wording with current behavior. Renames the suite to highlight React prop forwarding and updates inline notes to document gradient routing to `setBackgroundGradient`.

<sup>Written for commit c324c139c83b030f1a5baaaa49bd90e7cb24378b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

