### PR TITLE
docs: clean React positional percent comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-tblr-percent.test.ts
+++ b/packages/pulp-react/test/prop-applier-tblr-percent.test.ts
@@ -1,15 +1,12 @@
-// pulp #1434 batch 6 — verify the @pulp/react prop-applier forwards
-// percent strings ('50%') verbatim to the bridge for the four View
-// positional fields (top/right/bottom/left). The bridge inspects
-// arg index 1 as a string, detects the '%' suffix, and routes through
-// Yoga's YGNodeStyleSetPositionPercent path.
+// The React prop applier forwards percent strings ('50%') verbatim
+// to the bridge for the four View positional fields (top/right/bottom/left).
+// The bridge inspects arg index 1 as a string, detects the '%' suffix,
+// and routes through Yoga's YGNodeStyleSetPositionPercent path.
 //
-// This is the JSX-side counterpart to PR #1426 (which routed width/height
-// percent through to Yoga). Figma absolute-positioned overlays, v0.dev
-// hero anchors, and Claude Design sticky elements all emit `top:'50%'`
-// etc. routinely; without this forwarding the layout collapses to numeric
-// 0 silently because `value as number` would coerce '50%' → NaN at the
-// bridge boundary.
+// Design imports and hand-authored JSX routinely use positional percent
+// anchors such as `top: '50%'`; without this forwarding the layout collapses
+// to numeric 0 silently because `value as number` would coerce '50%' to NaN
+// at the bridge boundary.
 //
 // Each test asserts that ONE positional prop emits ONE matching bridge
 // call, with the value forwarded as either a number (px path) or a
@@ -45,7 +42,7 @@ function callsFor(b: MockBridge, fn: string) {
     return b.calls.filter((c) => c.fn === fn);
 }
 
-describe('prop-applier top/right/bottom/left percent (pulp #1434 batch 6)', () => {
+describe('React prop forwarding for positional percent edges', () => {
     it("top: '50%' lands as a percent string on setTop", () => {
         applyChangedProps(makeInstance(), {}, { top: '50%' });
         const c = callsFor(bridge, 'setTop');
@@ -92,8 +89,7 @@ describe('prop-applier top/right/bottom/left percent (pulp #1434 batch 6)', () =
         //   <View style={{ position:'absolute', top:'50%', left:'50%',
         //                  transform:[{translateX:-50%}, {translateY:-50%}] }} />
         // We assert the four positional bridge calls fire — the transform
-        // legs are out of scope for this test (translateX/Y percent is
-        // a separate batch).
+        // legs are covered by transform-specific tests.
         applyChangedProps(makeInstance(), {}, {
             position: 'absolute',
             top: '50%',
@@ -109,8 +105,8 @@ describe('prop-applier top/right/bottom/left percent (pulp #1434 batch 6)', () =
     });
 
     it('zero is a real value (not a no-op) for both numeric and percent', () => {
-        // Spectr / Figma exports legitimately use top:0 to anchor an
-        // overlay at the top edge. Truthiness gating would drop it.
+        // Exports and hand-authored layouts legitimately use top:0 to
+        // anchor an overlay at the top edge. Truthiness gating would drop it.
         applyChangedProps(makeInstance('a'), {}, { top: 0 });
         expect(callsFor(bridge, 'setTop')[0].args).toEqual(['a', 0]);
 


### PR DESCRIPTION
## Summary
- remove issue/PR/batch provenance from the positional percent React applier test header
- retitle the suite around current prop-forwarding behavior
- replace design-source and batch breadcrumbs with current behavior comments for percent edge forwarding

## Validation
- `git diff --check`
- focused stale-breadcrumb scan for planning/review/provenance terms
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react`
- `npm run build --prefix packages/pulp-react`
- `npm test --prefix packages/pulp-react`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `git push --dry-run origin feature/react-tblr-percent-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-tblr-percent-comment-hygiene`

## Notes
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- `npm ci` reported existing dependency warnings (`inflight`, `glob`) and 5 audit findings (2 moderate, 1 high, 2 critical).
- pre-push hook reported optional planning fixture paths skipped because the planning submodule is not initialized in this worktree.
- Diff-coverage was not run; `tools/scripts/gates.sh` explicitly skipped it as slow.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up comments and test names in `packages/pulp-react` positional percent tests to reflect current React prop forwarding behavior and remove stale provenance breadcrumbs. No logic changes; tests now clearly describe how percent strings for top/right/bottom/left are forwarded to the bridge.

<sup>Written for commit b8b97e2e925eed196ff329d5287f92bb2c1ef15b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

