### PR TITLE
docs: clean React transform comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-transform.test.ts
+++ b/packages/pulp-react/test/prop-applier-transform.test.ts
@@ -1,16 +1,14 @@
-// pulp #1434 Triage #9 — verify the @pulp/react prop-applier walks the
-// RN-style `transform` array and dispatches the consolidated
-// setTranslate / setRotation / setScale bridge calls.
+// The React prop applier walks the RN-style `transform` array and
+// dispatches consolidated setTranslate / setRotation / setScale bridge calls.
 //
 // The walker accumulates a {tx, ty, rotateDeg, scale} snapshot in one
 // pass, then emits ONE call per axis-of-transform that the user
 // specified. Within-array merging means [{translateX:10},{translateY:20}]
 // produces ONE setTranslate(10, 20) — not two clobbering calls.
 //
-// Bridge gaps (silently no-op): skewX/skewY (no setSkew bridge fn),
-// rotateX/rotateY/perspective/matrix (no 3D in pulp's 2D View). Tests
-// guard the silent-drop behavior so a future bridge wiring flagging
-// these as failures is the intended signal to update.
+// Unsupported 3D transforms silently no-op because Pulp's View is a 2D
+// surface. Tests guard that behavior so future bridge wiring has an
+// explicit signal to update expectations.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';
@@ -42,7 +40,7 @@ function callsOf(b: MockBridge, fn: 'setTranslate' | 'setRotation' | 'setScale')
     return b.calls.filter((c) => c.fn === fn);
 }
 
-describe('prop-applier transform array (pulp #1434 Triage #9)', () => {
+describe('React prop forwarding for transform arrays', () => {
     it('translateX-only dispatches one setTranslate(x, 0)', () => {
         applyChangedProps(makeInstance(), {}, { transform: [{ translateX: 10 }] });
         const calls = callsOf(bridge, 'setTranslate');
@@ -171,11 +169,9 @@ describe('prop-applier transform array (pulp #1434 Triage #9)', () => {
         expect(callsOf(bridge, 'setScale')).toHaveLength(0);
     });
 
-    it('skewX + skewY accumulate into ONE setSkew (Triage #9 fan-out)', () => {
-        // pulp #1434 Triage #9 fan-out — setSkew is now a registered
-        // bridge fn; the walker accumulates both axes and emits one
-        // consolidated call. Previously this entry asserted silent
-        // drop because the bridge fn didn't exist.
+    it('skewX + skewY accumulate into ONE setSkew call', () => {
+        // setSkew is a registered bridge function; the walker accumulates
+        // both axes and emits one consolidated call.
         const bcalls = (b: MockBridge, fn: string) => b.calls.filter((c) => c.fn === fn);
         applyChangedProps(makeInstance(), {}, {
             transform: [{ skewX: '10deg' }, { skewY: '5deg' }],


### PR DESCRIPTION
## Summary
- remove issue/triage provenance from the React transform applier test header
- retitle the suite around current transform-array forwarding behavior
- replace the skew fan-out breadcrumb with current bridge behavior wording

## Validation
- `git diff --check`
- focused stale-breadcrumb scan for planning/review/provenance terms
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react`
- `npm run build --prefix packages/pulp-react`
- `npm test --prefix packages/pulp-react`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `git push --dry-run origin feature/react-transform-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-transform-comment-hygiene`

## Notes
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- `npm ci` reported existing dependency warnings (`inflight`, `glob`) and 5 audit findings (2 moderate, 1 high, 2 critical).
- pre-push hook reported optional planning fixture paths skipped because the planning submodule is not initialized in this worktree.
- Diff-coverage was not run; `tools/scripts/gates.sh` explicitly skipped it as slow.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up the React transform applier tests in `pulp-react` by removing outdated triage/provenance comments and aligning language with current bridge behavior. Retitled the test suite to reflect current transform-array forwarding and clarified 2D-only handling and `setSkew` consolidation.

<sup>Written for commit 10075069f1535a7f37207a6f901d075b57d20101. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

