### PR TITLE
docs: clean React var resolution comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-var-resolve.test.ts
+++ b/packages/pulp-react/test/prop-applier-var-resolve.test.ts
@@ -1,10 +1,8 @@
-// pulp #1899 (gap #3) — `var(--name)` references in string-valued
-// style props must be resolved BEFORE the value reaches the bridge.
+// `var(--name)` references in string-valued style props must be
+// resolved before the value reaches the bridge.
 // The raw string "var(--mono)" gives Skia's font matcher nothing to
 // match against, so the literal flows through silently and the rendered
-// text falls back to a proportional sans (Spectr top-bar "faint label"
-// symptom, compounded by the opacity-layer LCD AA degradation handled
-// on the C++ side).
+// text falls back to a proportional sans.
 //
 // Resolution tiers (first hit wins): __pulpCssVars registry →
 // getStringToken bridge → getMotionToken bridge → explicit fallback →
@@ -41,7 +39,7 @@ function callsOf(name: string) {
     return bridge.calls.filter((c) => c.fn === name);
 }
 
-describe('prop-applier var() resolution (pulp #1899 gap #3)', () => {
+describe('React prop forwarding for var() token resolution', () => {
     it('fontFamily: var(--mono) resolves via __pulpCssVars registry', () => {
         (globalThis as Record<string, unknown>).__pulpCssVars = {
             mono: 'JetBrains Mono',


### PR DESCRIPTION
## Summary
- remove issue/gap provenance from the React var() resolution test header
- retitle the suite around current token-resolution behavior
- keep the resolution tiers and assertions unchanged

## Validation
- `git diff --check`
- focused stale-breadcrumb scan for planning/review/provenance terms
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react`
- `npm run build --prefix packages/pulp-react`
- `npm test --prefix packages/pulp-react`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `git push --dry-run origin feature/react-var-resolve-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-var-resolve-comment-hygiene`

## Notes
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- `npm ci` reported existing dependency warnings (`inflight`, `glob`) and 5 audit findings (2 moderate, 1 high, 2 critical).
- pre-push hook reported optional planning fixture paths skipped because the planning submodule is not initialized in this worktree.
- Diff-coverage was not run; `tools/scripts/gates.sh` explicitly skipped it as slow.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned outdated provenance comments and renamed the test suite to "React prop forwarding for var() token resolution" in `packages/pulp-react`. No test logic, assertions, or resolution tiers changed.

<sup>Written for commit 407d31e957c2861cdbb6cfcb648fc80788b42f70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

