### PR TITLE
docs: clean React wave4 comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-wave4.test.ts
+++ b/packages/pulp-react/test/prop-applier-wave4.test.ts
@@ -1,12 +1,11 @@
-// pulp Wave 4 rn extensive DIVERGE sweep — verifies the wiring landed
-// for the harness rn surface drift bundle (16 DIVERGE → 0 DIVERGE):
+// The React prop applier forwards these React Native-compatible shadow
+// forms to the bridge:
 //
 //   • RN Fabric `BoxShadowValue[]` array form on `boxShadow`
 //   • textShadow* per-attribute setters now register on the bridge
 //
-// Other entries in the sweep flipped via catalog reclassification only
-// (gotcha-ifying paint-side gaps that were over-reported as
-// `unsupportedValues`); those don't need new prop-applier behavior tests.
+// Paint-only compatibility notes are handled in the catalog; this file
+// stays focused on prop-applier behavior with bridge-visible effects.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';
@@ -38,7 +37,7 @@ function callsOf(b: MockBridge, fn: string) {
     return b.calls.filter((c) => c.fn === fn);
 }
 
-describe('Wave 4 rn — boxShadow BoxShadowValue[] array form', () => {
+describe('React prop forwarding for BoxShadowValue[] arrays', () => {
     it('dispatches one setBoxShadow per element + clearBoxShadow first', () => {
         applyChangedProps(makeInstance(), {}, {
             boxShadow: [
@@ -105,7 +104,7 @@ describe('Wave 4 rn — boxShadow BoxShadowValue[] array form', () => {
     });
 });
 
-describe('Wave 4 rn — textShadow* per-attribute dispatch (#1548)', () => {
+describe('React prop forwarding for textShadow attributes', () => {
     it('dispatches setTextShadowColor with the color string', () => {
         applyChangedProps(makeInstance(), {}, { textShadowColor: '#ff00aa' } as any);
         const calls = callsOf(bridge, 'setTextShadowColor');


### PR DESCRIPTION
## Summary
- remove Wave 4 / DIVERGE sweep provenance from the React shadow applier test header
- retitle the Vitest groups around current prop-forwarding behavior
- keep the bridge assertions, inputs, and test bodies unchanged

## Validation
- `git diff --check`
- focused stale-breadcrumb scan for planning/review/provenance terms
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react`
- `npm run build --prefix packages/pulp-react`
- `npm test --prefix packages/pulp-react`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `git push --dry-run origin feature/react-wave4-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-wave4-comment-hygiene`

## Notes
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- `npm ci` reported existing dependency warnings (`inflight`, `glob`) and 5 audit findings (2 moderate, 1 high, 2 critical).
- pre-push hook reported optional planning fixture paths skipped because the planning submodule is not initialized in this worktree.
- Diff-coverage was not run; `tools/scripts/gates.sh` explicitly skipped it as slow.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed outdated Wave 4/DIVERGE comments and retitled Vitest `describe` groups in `packages/pulp-react/test/prop-applier-wave4.test.ts` to reflect current React prop-forwarding behavior (`BoxShadowValue[]` and `textShadow*`). No behavior or assertions changed; this is a comment/naming cleanup for clarity.

<sup>Written for commit cfe948034718d0a2227d51753248a462b2464daa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

