### PR TITLE
docs: clean React SVG path comment archaeology

### DIFF
--- a/packages/pulp-react/test/svgpath-intrinsic.test.ts
+++ b/packages/pulp-react/test/svgpath-intrinsic.test.ts
@@ -1,9 +1,8 @@
-// Test for pulp #994 — @pulp/react SvgPath intrinsic.
+// Tests the @pulp/react SvgPath intrinsic bridge contract.
 //
-// The C++ side has shipped SvgPathWidget + bridge handlers (createSvgPath,
-// setSvgPath, setSvgViewBox, setSvgFill, setSvgFillRule, setSvgStroke,
-// setSvgStrokeWidth) since v0.61.0 (#965/#991; fillRule added in #3656).
-// This wires the React-side intrinsic so JSX
+// The native side exposes SvgPathWidget and the bridge handlers used here:
+// createSvgPath, setSvgPath, setSvgViewBox, setSvgFill, setSvgFillRule,
+// setSvgStroke, and setSvgStrokeWidth. React JSX such as
 // `<SvgPath d="..." viewBox={[w,h]} fill="#fff" fillRule="evenodd" stroke="#000" strokeWidth={1} />`
 // reaches the bridge.
 
@@ -17,7 +16,7 @@ function instance(id: string, type: string, props: Record<string, unknown>): Pul
     return { id, type, props } as PulpInstance;
 }
 
-describe('@pulp/react SvgPath intrinsic (pulp #994)', () => {
+describe('@pulp/react SvgPath intrinsic', () => {
     let bridge: MockBridge;
     beforeEach(() => {
         bridge = createMockBridge();
@@ -100,7 +99,7 @@ describe('@pulp/react SvgPath intrinsic (pulp #994)', () => {
         ]);
     });
 
-    it('forwards fillRule to setSvgFillRule (pulp #3656)', () => {
+    it('forwards fillRule to setSvgFillRule', () => {
         applyAllProps(instance('icon7b', 'SvgPath', {
             d: 'M0 0 L10 0 L10 10 Z M2 2 L8 2 L8 8 Z',
             fillRule: 'evenodd',
@@ -110,7 +109,7 @@ describe('@pulp/react SvgPath intrinsic (pulp #994)', () => {
         expect(setFR[0].args).toEqual(['icon7b', 'evenodd']);
     });
 
-    it('re-applies fillRule on commitUpdate when it changes (pulp #3656)', () => {
+    it('re-applies fillRule on commitUpdate when it changes', () => {
         applyChangedProps(
             instance('icon7c', 'SvgPath', {}),
             { d: 'M0 0 L1 1', fillRule: 'nonzero' },


### PR DESCRIPTION
## Summary
- Reword the SvgPath intrinsic test header around the current bridge contract.
- Remove stale issue/PR/version breadcrumbs from the suite and fillRule test names.

## Validation
- `git diff --check`
- `rg -n 'Workstream|Phase [0-9]|pulp #[0-9]|Pulp #[0-9]|Codex|ChatGPT|roadmap|planning/|Triage|Wave|wave|DIVERGE|sub-agent|slice [A-Z0-9]|follow-up work|Created in the 2026|2026-[0-9]{2}-[0-9]{2}|NOT-IMPL|feature branch|batch [0-9]|PR #[0-9]' packages/pulp-react/test/svgpath-intrinsic.test.ts || true`\n- `python3 tools/scripts/docs_noise_lint.py --mode=report`\n- `npm ci --prefix packages/pulp-react`\n- `npm run build --prefix packages/pulp-react`\n- `npm test --prefix packages/pulp-react`\n- `tools/scripts/gates.sh origin/main`\n- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`\n- `git push --dry-run origin feature/react-svgpath-comment-hygiene`\n- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-svgpath-comment-hygiene`\n\n## Notes\n- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.\n- `npm ci` reports the existing npm warnings: deprecated `inflight`, deprecated `glob`, and 5 audit vulnerabilities.\n- Push hooks report the expected optional planning-submodule missing notices in this isolated worktree.\n- Diff coverage was not run.\n- Claude autoreview: clean; no accepted/actionable findings reported.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up `@pulp/react` SvgPath intrinsic tests by updating the header to the current bridge contract and removing stale issue/PR/version breadcrumbs from suite and fillRule test names. This clarifies intent and reduces noise without changing behavior.

<sup>Written for commit 22d008d5cb1f47bbc0e74b6b7f4697895d54d3ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

