### PR TITLE
docs: clean React SVG rect line comment archaeology

### DIFF
--- a/packages/pulp-react/test/svgrect-svgline-intrinsic.test.ts
+++ b/packages/pulp-react/test/svgrect-svgline-intrinsic.test.ts
@@ -1,18 +1,14 @@
-// Test for pulp #1416 — @pulp/react SvgRect + SvgLine intrinsics.
+// Tests the @pulp/react SvgRect and SvgLine intrinsic bridge contracts.
 //
-// The C++ side ships SvgRectWidget + SvgLineWidget + bridge handlers
-// (createSvgRect / setSvgRect / createSvgLine / setSvgLine, plus the
-// shared setSvgFill / setSvgStroke / setSvgStrokeWidth setters made
-// polymorphic across all three SVG-primitive widget types). This wires
-// the React-side intrinsics so JSX
+// The native side exposes SvgRectWidget and SvgLineWidget plus the bridge
+// handlers used here: createSvgRect, setSvgRect, createSvgLine, setSvgLine,
+// setSvgFill, setSvgStroke, and setSvgStrokeWidth. React JSX such as
 //   <SvgRect x={10} y={20} width={50} height={30} fill="#f00" />
 //   <SvgLine x1={0} y1={0} x2={100} y2={100} stroke="#0f0" />
 // reach the bridge.
 //
-// Closes Spectr [G] (preset manager band-shape thumbnails currently
-// blank — MiniPreview renders <svg><rect> per band + <line>, dom-adapter
-// maps to <View>, and without these intrinsics the geometry props are
-// dropped silently).
+// SVG primitive intrinsics must preserve geometry props so design imports and
+// native previews can render rect and line shapes instead of dropping them.
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createMockBridge, type MockBridge } from '../src/bridge.js';
@@ -24,7 +20,7 @@ function instance(id: string, type: string, props: Record<string, unknown>): Pul
     return { id, type, props } as PulpInstance;
 }
 
-describe('@pulp/react SvgRect intrinsic (pulp #1416)', () => {
+describe('@pulp/react SvgRect intrinsic', () => {
     let bridge: MockBridge;
     beforeEach(() => {
         bridge = createMockBridge();
@@ -141,7 +137,7 @@ describe('@pulp/react SvgRect intrinsic (pulp #1416)', () => {
     });
 });
 
-describe('@pulp/react SvgLine intrinsic (pulp #1416)', () => {
+describe('@pulp/react SvgLine intrinsic', () => {
     let bridge: MockBridge;
     beforeEach(() => {
         bridge = createMockBridge();
@@ -227,7 +223,7 @@ describe('@pulp/react SvgLine intrinsic (pulp #1416)', () => {
     });
 });
 
-describe('@pulp/react SvgRect/SvgLine host-config attachment (pulp #1416)', () => {
+describe('@pulp/react SvgRect/SvgLine host-config attachment', () => {
     let bridge: MockBridge;
     beforeEach(() => {
         bridge = createMockBridge();


### PR DESCRIPTION
## Summary
- Reword the SvgRect/SvgLine intrinsic test header around the current bridge contract.
- Remove stale issue/Spectr breadcrumbs from comments and suite labels.

## Validation
- `git diff --check`
- `rg -n 'Workstream|Phase [0-9]|pulp #[0-9]|Pulp #[0-9]|Codex|ChatGPT|roadmap|planning/|Triage|Wave|wave|DIVERGE|sub-agent|slice [A-Z0-9]|follow-up work|Created in the 2026|2026-[0-9]{2}-[0-9]{2}|NOT-IMPL|feature branch|batch [0-9]|PR #[0-9]|Closes Spectr' packages/pulp-react/test/svgrect-svgline-intrinsic.test.ts || true`\n- `python3 tools/scripts/docs_noise_lint.py --mode=report`\n- `npm ci --prefix packages/pulp-react`\n- `npm run build --prefix packages/pulp-react`\n- `npm test --prefix packages/pulp-react`\n- `tools/scripts/gates.sh origin/main`\n- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`\n- `git push --dry-run origin feature/react-svgrect-svgline-comment-hygiene`\n- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-svgrect-svgline-comment-hygiene`\n\n## Notes\n- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.\n- First `npm test --prefix packages/pulp-react` run completed all 50 files / 540 tests, then Node 26 crashed during teardown with `v8::ToLocalChecked Empty MaybeLocal`; immediate rerun passed cleanly.\n- `npm ci` reports the existing npm warnings: deprecated `inflight`, deprecated `glob`, and 5 audit vulnerabilities.\n- Push hooks report the expected optional planning-submodule missing notices in this isolated worktree.\n- Diff coverage was not run.\n- Claude autoreview: clean; no accepted/actionable findings reported.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshed comments and suite titles in `packages/pulp-react/test/svgrect-svgline-intrinsic.test.ts` to reflect the current `@pulp/react` bridge for `SvgRect`/`SvgLine`, removing stale issue breadcrumbs. No behavior or test logic changes.

<sup>Written for commit d9f9a4a7cd0368f8e3948c27d62c3747252144d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

