### PR TITLE
docs: clean React animation comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-animation.test.ts
+++ b/packages/pulp-react/test/prop-applier-animation.test.ts
@@ -1,11 +1,8 @@
-// pulp #1508 Codex audit (P1 #2) — animation* props must dispatch to
-// the animation API, not to the transition equivalents. The original
-// prop-applier wired `animationDuration` to `setTransitionDuration`,
-// which mutated *transition* timing on the same View. The fix routes
-// every animation* longhand through the legacy 2-arg `setAnimation`
-// control-token form — which the C++ bridge stages on the View's
-// pending-animation slot until the `name` token arrives and resolves
-// against the keyframes registry.
+// animation* props must dispatch to the animation API, not to the
+// transition equivalents. Every animation* longhand routes through the
+// legacy 2-arg `setAnimation` control-token form, which the native bridge
+// stages on the View's pending-animation slot until the `name` token arrives
+// and resolves against the keyframes registry.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';
@@ -37,7 +34,7 @@ function callsOf(b: MockBridge, fn: string) {
     return b.calls.filter((c) => c.fn === fn);
 }
 
-describe('animation* props dispatch to setAnimation (pulp #1508 P1)', () => {
+describe('animation* props dispatch to setAnimation', () => {
     it('animationDuration goes to setAnimation, NOT setTransitionDuration', () => {
         applyChangedProps(makeInstance(), {}, { animationDuration: '250ms' });
         // Wrong dispatch — must NOT happen post-fix.
@@ -105,11 +102,8 @@ describe('animation* props dispatch to setAnimation (pulp #1508 P1)', () => {
         expect(anim[0].args).toEqual(['k', 'fade-in', 1.0, 1, 'normal']);
     });
 
-    // pulp #1434 Wave 3 css.3 — animationPlayState routing. The case
-    // was previously missing from prop-applier.ts (only the JS shim
-    // path forwarded the keyword), so React-side `animationPlayState`
-    // changes never reached the bridge at all. Now routed through the
-    // legacy 2-arg setAnimation control-token form.
+    // animationPlayState uses the same legacy 2-arg setAnimation
+    // control-token form as the other animation longhands.
     it('animationPlayState routes to setAnimation/play_state (paused)', () => {
         applyChangedProps(makeInstance(), {}, { animationPlayState: 'paused' });
         const anim = callsOf(bridge, 'setAnimation');


### PR DESCRIPTION
## Summary
- Reword the animation prop-applier test header around the current setAnimation contract.
- Remove stale issue/Codex/Wave/P1 breadcrumbs from comments and the suite label.

## Validation
- `git diff --check`
- `rg -n 'Workstream|Phase [0-9]|pulp #[0-9]|Pulp #[0-9]|Codex|ChatGPT|roadmap|planning/|Triage|Wave|wave|DIVERGE|sub-agent|slice [A-Z0-9]|follow-up work|Created in the 2026|2026-[0-9]{2}-[0-9]{2}|NOT-IMPL|feature branch|batch [0-9]|PR #[0-9]|Closes Spectr|P1|P2' packages/pulp-react/test/prop-applier-animation.test.ts || true`\n- `python3 tools/scripts/docs_noise_lint.py --mode=report`\n- `npm ci --prefix packages/pulp-react`\n- `npm run build --prefix packages/pulp-react`\n- `npm test --prefix packages/pulp-react`\n- `tools/scripts/gates.sh origin/main`\n- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`\n- `git push --dry-run origin feature/react-animation-comment-hygiene`\n- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-animation-comment-hygiene`\n\n## Notes\n- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.\n- `npm ci` reports the existing npm warnings: deprecated `inflight`, deprecated `glob`, and 5 audit vulnerabilities.\n- Push hooks report the expected optional planning-submodule missing notices in this isolated worktree.\n- Diff coverage was not run.\n- Claude autoreview: clean; no accepted/actionable findings reported.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up React animation test comments to match the current `setAnimation` contract and removes stale cross-references. No runtime or test logic changes.

- **Refactors**
  - Reworded the test header in `packages/pulp-react/test/prop-applier-animation.test.ts` to reflect the current `setAnimation` contract.
  - Removed stale issue/Codex/Wave/P1 references from comments and the suite label.

<sup>Written for commit fcef078d7cee7ad35c19af695a383e612c157882. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

