### PR TITLE
docs: clean React border comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-border.test.ts
+++ b/packages/pulp-react/test/prop-applier-border.test.ts
@@ -1,7 +1,6 @@
-// pulp #1027 (audit PR #1166 finding #4) — verify the prop-applier routes
-// borderColor / borderWidth / borderRadius (and per-side flat props) to the
-// per-attribute bridge setters that preserve unset siblings, not the unified
-// setBorder(id, color, width, radius) that clobbers everything.
+// Verify that flat border props route to per-attribute bridge setters that
+// preserve unset siblings, not the unified setBorder(id, color, width, radius)
+// path used by the object-shape shorthand.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';


### PR DESCRIPTION
## Summary
- Reword the border prop-applier test header around the current bridge-setter invariant.
- Remove stale issue/PR/finding breadcrumbs from the long-lived comment.

## Validation
- `git diff --check`
- `rg -n 'Workstream|Phase [0-9]|pulp #[0-9]|Pulp #[0-9]|Codex|ChatGPT|roadmap|planning/|Triage|Wave|wave|DIVERGE|sub-agent|slice [A-Z0-9]|follow-up work|Created in the 2026|2026-[0-9]{2}-[0-9]{2}|NOT-IMPL|feature branch|batch [0-9]|PR #[0-9]|Closes Spectr|P1|P2' packages/pulp-react/test/prop-applier-border.test.ts || true`\n- `python3 tools/scripts/docs_noise_lint.py --mode=report`\n- `npm ci --prefix packages/pulp-react`\n- `npm run build --prefix packages/pulp-react`\n- `npm test --prefix packages/pulp-react`\n- `tools/scripts/gates.sh origin/main`\n- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`\n- `git push --dry-run origin feature/react-border-comment-hygiene`\n- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-border-comment-hygiene`\n\n## Notes\n- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.\n- `npm ci` reports the existing npm warnings: deprecated `inflight`, deprecated `glob`, and 5 audit vulnerabilities.\n- Push hooks report the expected optional planning-submodule missing notices in this isolated worktree.\n- Diff coverage was not run.\n- Claude autoreview: clean; no accepted/actionable findings reported.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the border prop-applier test header in `packages/pulp-react/test/prop-applier-border.test.ts` to state that flat border props use per-attribute bridge setters (preserving unset siblings) instead of the unified setBorder path used by the object-shape shorthand. Removed stale issue/PR breadcrumbs; no code or test behavior changes.

<sup>Written for commit b3c24b41ff64fd19de0598a21d3e8cca001d2aa8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

