### PR TITLE
docs: clean React image src comment archaeology

### DIFF
--- a/packages/pulp-react/test/prop-applier-image-src.test.ts
+++ b/packages/pulp-react/test/prop-applier-image-src.test.ts
@@ -1,21 +1,14 @@
-// pulp parity-found (framework-importer #18) — the @pulp/react
-// prop-applier created the Image widget (host-config createImage) and
-// declared the bridge surface, but never dispatched the `src` prop to
-// setImageSource. The emitted bundle had createImage calls and ZERO
-// setImageSource calls, so every <img>/<Image> rendered as the empty
-// "IMG" placeholder (in the design-import path AND the framework
-// importer). This mirrors the non-React fix in
-// core/view/js/web-compat-element.js (pulp #1658).
+// Verify that Image src props reach the ImageView bridge surface.
 //
 // These tests assert:
-//   1. applyAllProps(<Image src=…>) dispatches setImageSource with the
+//   1. applyAllProps(<Image src=...>) dispatches setImageSource with the
 //      resolved (verbatim, absolute) path.
 //   2. Changing `src` re-dispatches setImageSource with the new path.
 //   3. Removing `src` clears the ImageView (empty-string sentinel).
-//   4. The path is forwarded verbatim — absolute paths (design-import /
-//      importer convention) pass through untouched.
-//   5. A stray `src` on a non-Image widget does NOT reach the
-//      ImageView-only setter (the `type === 'Image'` gate).
+//   4. The path is forwarded verbatim: absolute paths from import flows pass
+//      through untouched.
+//   5. A stray `src` on a non-Image widget does not reach the ImageView-only
+//      setter.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createMockBridge, type MockBridge } from '../src/bridge.js';
@@ -30,7 +23,7 @@ function imageSourceCalls(b: MockBridge) {
     return b.calls.filter((c) => c.fn === 'setImageSource');
 }
 
-describe('@pulp/react prop-applier — <Image src> → setImageSource (#18)', () => {
+describe('@pulp/react prop-applier - <Image src> to setImageSource', () => {
     let bridge: MockBridge;
     beforeEach(() => {
         bridge = createMockBridge();
@@ -103,10 +96,10 @@ describe('@pulp/react prop-applier — <Image src> → setImageSource (#18)', ()
         expect(imageSourceCalls(bridge)).toHaveLength(0);
     });
 
-    // host-config maps BOTH the lowercase `<img>` intrinsic AND the `<Image>`
+    // host-config maps both the lowercase `<img>` intrinsic and the `<Image>`
     // component to createImage, so the prop-applier must accept both element
-    // types. The #18 parity capture proved gating on `'Image'` alone dropped
-    // every real `<img>` (runtime type `'img'`).
+    // types. Gating only on `'Image'` would drop real `<img>` elements because
+    // their runtime type is `'img'`.
     it('dispatches setImageSource for both the img intrinsic and the Image component', () => {
         applyAllProps(instance('imgLower', 'img', { src: '/abs/a.png' }));
         applyAllProps(instance('imgUpper', 'Image', { src: '/abs/b.png' }));


### PR DESCRIPTION
## Summary
- clean stale image-src test archaeology around the original framework-importer/parity issue references
- keep the ImageView bridge contract comments focused on current behavior
- rename the describe label to avoid stale issue numbering and symbolic arrows

## Validation
- `git diff --check`
- stale breadcrumb scan for the touched file
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react` (passes; known deprecated `inflight`/`glob` warnings and 5 audit findings)
- `npm run build --prefix packages/pulp-react`
- `npm test --prefix packages/pulp-react` (50 files / 540 tests)
- `tools/scripts/gates.sh origin/main` (passes; diff-coverage not run)
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean)
- `git push --dry-run origin feature/react-image-src-comment-hygiene` (passes; expected direct-push warning and optional planning-submodule notices)
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-image-src-comment-hygiene` (pre-push gates clean; expected optional planning-submodule notices)

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale issue references and historical notes from the `Image src` prop-applier test in `packages/pulp-react` to keep comments focused on current behavior. Renamed the `describe` label to a neutral title; no test assertions or runtime behavior changed.

<sup>Written for commit 3ccbf88f24d4089a5f7817ef0741c334efcb6cf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

