### PR TITLE
docs: clean React design system comment archaeology

### DIFF
--- a/packages/pulp-react/test/design-system.test.ts
+++ b/packages/pulp-react/test/design-system.test.ts
@@ -1,6 +1,6 @@
-// Tests for the Ink & Signal design-system catalog (Phase 8c). Verifies the
-// catalog is well-formed and that every jsxTag it names is a real exported
-// @pulp/react intrinsic — so the metadata can't drift from the actual bindings.
+// Tests for the Ink & Signal design-system catalog. Verifies the catalog is
+// well-formed and that every jsxTag it names is a real exported @pulp/react
+// intrinsic, so the metadata can't drift from the actual bindings.
 
 import { describe, it, expect } from 'vitest';
 import {
@@ -58,7 +58,7 @@ describe('Ink & Signal design-system catalog', () => {
         expect(FIGMA_FILE_KEY).toBe('q9iDYZzg86YrOQKr6I3bY0');
     });
 
-    it('the three Phase-8c gap widgets are JS-bound', () => {
+    it('Badge, Stepper, and Pan are JS-bound', () => {
         for (const name of ['Badge', 'Stepper', 'Pan']) {
             const c = findComponent(name);
             expect(c, name).toBeDefined();


### PR DESCRIPTION
## Summary
- remove stale Phase-8c wording from the Ink & Signal catalog test header
- rename the Badge/Stepper/Pan test to describe the current contract directly
- leave all catalog assertions and behavior unchanged

## Validation
- `git diff --check`
- stale breadcrumb scan for the touched file
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `npm ci --prefix packages/pulp-react` (passes; known deprecated `inflight`/`glob` warnings and 5 audit findings)
- `npm run build --prefix packages/pulp-react`
- `npm test --prefix packages/pulp-react` (50 files / 540 tests)
- `tools/scripts/gates.sh origin/main` (passes; diff-coverage not run)
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean)
- `git push --dry-run origin feature/react-design-system-comment-hygiene` (passes; expected direct-push warning and optional planning-submodule notices)
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/react-design-system-comment-hygiene` (pre-push gates clean; expected optional planning-submodule notices)

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed outdated "Phase-8c" wording and renamed the Badge/Stepper/Pan test to reflect the current contract in the Ink & Signal design-system catalog tests for `@pulp/react`. Assertions and behavior are unchanged.

<sup>Written for commit 6ba4c08ee5b21436b23e95311c82277b6e71f1cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

