### PR TITLE
docs: clean JACK device comment archaeology

### DIFF
--- a/core/audio/platform/linux/jack_device.cpp
+++ b/core/audio/platform/linux/jack_device.cpp
@@ -225,7 +225,7 @@ bool jack_is_available() {
     return false;
 }
 
-// ── JackSystem (workstream 02 slice 2.2) ───────────────────────────────
+// ── JackSystem device enumeration ─────────────────────────────────────
 
 std::vector<DeviceInfo> JackSystem::enumerate_devices() {
     // JACK exposes a single logical "server" as the device. Sample rate


### PR DESCRIPTION
## Summary
- remove stale workstream/slice wording from the JACK system section comment
- replace it with a current device-enumeration section label
- no code or behavior changes

## Validation
- git diff --check
- focused stale breadcrumb scan for core/audio/platform/linux/jack_device.cpp
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- Claude autoreview clean via AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- git push --dry-run origin feature/jack-device-comment-hygiene: pre-push gates clean; local diff-cover built build-cov, ran 10,409 tests with 100% passing, then accepted the comment-only diff as having no coverage lines
- actual push used PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 to avoid duplicating the already-passed dry-run diff-cover suite; cheap pre-push gates still passed

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated a stale JACK system comment to use a clear "device enumeration" label. Comment-only change in core/audio/platform/linux/jack_device.cpp; no code or behavior changes.

<sup>Written for commit 52f187da0331a5cf5cccb7d9ba858f62a8aabbe6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

