### PR TITLE
docs: clean events cmake comment archaeology

### DIFF
--- a/core/events/CMakeLists.txt
+++ b/core/events/CMakeLists.txt
@@ -25,16 +25,15 @@ target_sources(pulp-events PRIVATE
 # (`dispatch_get_main_queue`) backend so plugin adapters can opt the
 # process into MainThreadDispatcher without owning a Pulp WindowHost.
 # Other platforms get a no-op stub; their own message-loop integration
-# lands later (gap-doc Phase 1).
+# paths live outside this dispatcher shim.
 if(APPLE)
     target_sources(pulp-events PRIVATE src/plugin_main_thread_mac.mm)
 else()
     target_sources(pulp-events PRIVATE src/plugin_main_thread_stub.cpp)
 endif()
 
-# Phase 2 (gap-doc 2026-05-24): platform mDNS backends for
-# NetworkServiceDiscovery. macOS / iOS get a real Bonjour backend
-# linked against the system DNS-SD APIs (exported from CoreServices
+# Platform mDNS backends for NetworkServiceDiscovery. macOS / iOS get a
+# Bonjour backend linked against the system DNS-SD APIs (exported from CoreServices
 # on macOS, libsystem on iOS). Linux + Windows resolve their stacks
 # at run-time via `pulp::runtime::DynamicLibrary` so the build never
 # hard-fails on machines that don't have avahi-daemon / the Bonjour


### PR DESCRIPTION
## Summary
- Replace stale `gap-doc` / `Phase` labels in `core/events/CMakeLists.txt` comments with current subsystem descriptions.
- Keep the plugin main-thread dispatcher and mDNS backend notes behavior-focused instead of roadmap-focused.
- No CMake logic, source lists, link libraries, options, or conditionals changed.

## Validation
- `git diff --check`
- Focused stale breadcrumb scan: `rg -n 'gap-doc|Phase|follow-up|planning/|workstream|slice|2026|Codex|roadmap|PR #[0-9]|#[0-9]' core/events/CMakeLists.txt || true`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- Claude autoreview via `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` reported clean.
- `git push --dry-run origin feature/events-cmake-comment-hygiene` ran pre-push gates, coverage build, `10,409` CTest tests, and diff-cover: `100% tests passed, 0 tests failed`; diff-cover reported no covered lines in this comment-only diff and passed.
- Slow dry-run tail checks included `cmake-ios-auv3-configure` (`351.51 sec`) and `cmake-ios-hostapp-links` (`342.71 sec`).
- Actual push used `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1` to skip duplicate diff-cover after the dry-run proof; cheap gates passed.

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned comments in core/events/CMakeLists.txt to replace stale “gap-doc”/“Phase” labels with current subsystem descriptions and clarify notes for the plugin main-thread dispatcher and mDNS backends. No CMake logic, sources, link libraries, or conditionals changed.

<sup>Written for commit d3730f37b98c7f2ad11efd7234231f78edb069fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

