### PR TITLE
docs: clean plugin main-thread comment archaeology

### DIFF
--- a/core/events/include/pulp/events/plugin_main_thread.hpp
+++ b/core/events/include/pulp/events/plugin_main_thread.hpp
@@ -1,22 +1,21 @@
 #pragma once
 
-// Plugin-mode main-thread cooperation (item 6.4b macOS plan, post-PR-#2825).
+// Plugin-mode main-thread cooperation.
 //
-// PR #2825 delivered the cross-platform `MainThreadDispatcher` contract; on
-// standalone macOS apps `WindowHost::create()` registers a Cocoa backend that
-// posts to `dispatch_get_main_queue()`. In plugin mode (AU v3 / VST3 / CLAP
-// loaded inside a DAW like Logic / Cubase / Bitwig), there is no Pulp window
-// — the DAW owns the main `NSApplication`/`CFRunLoop`. Without an explicit
-// registration, `MainThreadDispatcher::call_async` returns false and any
-// adapter-side code that asks "please run this on the host's main thread"
-// silently no-ops.
+// Standalone macOS apps register a Cocoa `MainThreadDispatcher` backend from
+// `WindowHost::create()` so cross-subsystem work can post to
+// `dispatch_get_main_queue()`. In plugin mode (AU v3 / VST3 / CLAP loaded
+// inside a DAW like Logic / Cubase / Bitwig), there is no Pulp window — the DAW
+// owns the main `NSApplication`/`CFRunLoop`. Without an explicit registration,
+// `MainThreadDispatcher::call_async` returns false and adapter-side code that
+// asks "please run this on the host's main thread" no-ops.
 //
 // The helpers in this header let format adapters and plugin instance owners
 // register a process-wide Cocoa backend at instantiation time and unregister
 // it at teardown. On non-macOS platforms the calls degrade to no-ops so
 // adapter code can call them unconditionally; the dispatcher then simply
 // stays in its "no backend" state on those platforms (Windows / Linux own
-// their own message-loop integration paths — see gap-doc Phase 1).
+// their own message-loop integration paths).
 //
 // Reference-counted under the hood — call register_plugin_backend() once
 // per loaded plugin instance, and `unregister_plugin_backend()` once on

--- a/core/events/src/plugin_main_thread_stub.cpp
+++ b/core/events/src/plugin_main_thread_stub.cpp
@@ -1,6 +1,7 @@
-// No-op plugin-main-thread backend for non-Apple platforms (item 6.4b macOS
-// plan). Windows + Linux have their own message-loop integration paths and
-// will get dedicated backends in gap-doc Phase 1.
+// No-op plugin-main-thread backend for non-Apple platforms. Windows and Linux
+// plugin hosts use their own message-loop integration paths, so this stub keeps
+// adapter code cross-platform while leaving the dispatcher in its no-backend
+// state unless a platform owner registers one.
 
 #include <pulp/events/plugin_main_thread.hpp>
 


### PR DESCRIPTION
## Summary
- Remove stale roadmap/PR/gap-doc breadcrumbs from plugin main-thread comments.
- Keep the comments focused on current Cocoa plugin backend behavior and the non-Apple no-backend dispatcher path.
- No code, signature, or behavior changes.

## Validation
- `git diff --check`
- `rg -n 'gap-doc|Phase|follow-up|planning/|workstream|slice|2026|Codex|roadmap|PR #[0-9]|#[0-9]' core/events/include/pulp/events/plugin_main_thread.hpp core/events/src/plugin_main_thread_stub.cpp || true` (clean)
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- Claude adversarial review via `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean; `overall: patch is correct (0.97)`)
- `git push --dry-run origin feature/plugin-main-thread-comment-hygiene` ran pre-push gates, coverage build, and full local diff-cover validation:
  - `100% tests passed, 0 tests failed out of 10409`
  - Total Test time: `1103.77 sec`
  - slow tail: `cmake-ios-auv3-configure` `356.70 sec`, `cmake-ios-hostapp-links` `357.30 sec`, `cmake-require-gpu-for-sdk` `57.57 sec`
  - diff-cover: no lines with coverage information in this diff; OK at/above 75%
- Actual push used `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/plugin-main-thread-comment-hygiene` after dry-run proof; cheap gates passed.

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up plugin main-thread comments to remove stale roadmap/PR breadcrumbs and clarify current behavior for the Cocoa `MainThreadDispatcher` backend and the non-Apple no-backend stub. No code, API, or runtime changes.

<sup>Written for commit 24fe7caf6e1070599265cc4e503a89d88d70563b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

