### PR TITLE
docs: clean scan worker comment archaeology

### DIFF
--- a/tools/scan-worker/CMakeLists.txt
+++ b/tools/scan-worker/CMakeLists.txt
@@ -2,11 +2,9 @@
 #
 # The parent PluginScanner launches this binary per plugin bundle; if the
 # child crashes (SIGSEGV, abort, etc.) the parent records the bundle in
-# its ScanBlacklist (workstream 03 slice 3.3a) and continues with the
-# next candidate. The worker itself just links against pulp::host and
-# prints the scanned metadata as JSON on stdout.
-#
-# Workstream 03 slice 3.3b.
+# its ScanBlacklist and continues with the next candidate. The worker
+# itself just links against pulp::host and prints the scanned metadata
+# as JSON on stdout.
 if(IOS OR ANDROID)
     # Sandboxed platforms can't fork/exec a helper binary. Skip.
     return()

--- a/tools/scan-worker/scan_worker_main.cpp
+++ b/tools/scan-worker/scan_worker_main.cpp
@@ -10,10 +10,6 @@
 // it can add the bundle to its ScanBlacklist — see
 // core/host/include/pulp/host/scan_blacklist.hpp.
 //
-// Workstream 03 slice 3.3b. This first commit ships the binary skeleton;
-// the parent-side `ChildProcessManager` wiring that actually spawns the
-// worker and the JSON schema negotiation land in follow-up slices.
-
 #include <pulp/host/scanner.hpp>
 #include <pulp/runtime/log.hpp>
 
@@ -110,9 +106,8 @@ int main(int argc, char** argv) {
     }
     const std::string path = argv[1];
 
-    // Pick the scanner by file extension. Extending to heuristic
-    // detection is a follow-up; this first pass keeps the parent in
-    // charge of format routing.
+    // Pick the scanner by file extension and keep the parent in charge of
+    // format routing.
     // Route through the public scan() API with the containing folder
     // added to extra_paths. Filtering to the exact bundle keeps us from
     // reporting other plug-ins that happen to live alongside it.


### PR DESCRIPTION
## Summary
- Remove stale workstream/slice breadcrumbs from scan-worker comments.
- Keep the comments focused on the current out-of-process scan worker contract, ScanBlacklist behavior, and extension-based routing.
- No code, CMake target, signature, or behavior changes.

## Validation
- `git diff --check`
- `rg -n 'gap-doc|Phase|follow-up|planning/|workstream|Workstream|slice|2026|Codex|roadmap|PR #[0-9]|#[0-9]' tools/scan-worker/CMakeLists.txt tools/scan-worker/scan_worker_main.cpp || true` (clean)
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- Claude adversarial review via `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean; `overall: patch is correct (0.97)`)
- `git push --dry-run origin feature/scan-worker-comment-hygiene` (pre-push gates clean; 29 hook tests passed; no diff-cover build required by the hook for this comment-only tooling slice)
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/scan-worker-comment-hygiene` (pre-push gates clean; 29 hook tests passed)

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up scan-worker comments to remove stale workstream/slice notes and clarify the current contract: out-of-process worker, ScanBlacklist handling, and extension-based routing. Comments-only change; no code, signatures, or behavior modified.

<sup>Written for commit 66f62d6b83cf50c44655242fc10f33ec1d21384b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

