### PR TITLE
docs: clean mcp comment archaeology

### DIFF
--- a/tools/mcp/mcp_compat.cpp
+++ b/tools/mcp/mcp_compat.cpp
@@ -1,9 +1,8 @@
 // mcp_compat.cpp — project SDK-compatibility resolution for pulp-mcp.
 //
-// Extracted from tools/mcp/pulp_mcp.cpp in the 2026-05 Phase 6 (B4)
-// refactor. See mcp_compat.hpp for the public surface; the SDK-version
-// parsing internals (pulp.toml / CMakeLists scanners, semver triple
-// parser, per-tool min-SDK table) stay file-local (static) here.
+// See mcp_compat.hpp for the public surface; the SDK-version parsing
+// internals (pulp.toml / CMakeLists scanners, semver triple parser,
+// per-tool min-SDK table) stay file-local here.
 
 #include "mcp_compat.hpp"
 #include "mcp_json.hpp"

--- a/tools/mcp/mcp_compat.hpp
+++ b/tools/mcp/mcp_compat.hpp
@@ -1,9 +1,6 @@
 // mcp_compat.hpp — project SDK-compatibility resolution for the
 // pulp-mcp server.
 //
-// Extracted from tools/mcp/pulp_mcp.cpp in the 2026-05 Phase 6 (B4)
-// refactor — second cut of the MCP typed-registry split.
-//
 // pulp-mcp ships independently of any given Pulp project. Before
 // dispatching a tool that touches a project, the server resolves the
 // project's pinned SDK version and refuses tools whose min-SDK floor

--- a/tools/mcp/mcp_json.hpp
+++ b/tools/mcp/mcp_json.hpp
@@ -1,15 +1,13 @@
 // mcp_json.hpp — JSON-RPC 2.0 framing + minimal JSON field extraction
 // for the pulp-mcp server.
 //
-// Extracted from tools/mcp/pulp_mcp.cpp in the 2026-05 Phase 6 (B4)
-// refactor — first cut of the MCP typed-registry split. The pulp-mcp
-// server deliberately avoids an external JSON dependency; these are the
-// minimal building blocks for emitting JSON-RPC envelopes and pulling
-// scalar fields out of an incoming request.
+// The pulp-mcp server deliberately avoids an external JSON dependency;
+// these are the minimal building blocks for emitting JSON-RPC envelopes
+// and pulling scalar fields out of an incoming request.
 //
 // Helpers are header-inline so the framing layer can be shared by the
-// protocol handler and (in later B4 cuts) the per-domain tool modules
-// without an extra TU or ODR concern.
+// protocol handler and per-domain tool modules without an extra TU or
+// ODR concern.
 
 #pragma once
 

--- a/tools/mcp/mcp_shell.hpp
+++ b/tools/mcp/mcp_shell.hpp
@@ -1,10 +1,9 @@
 // mcp_shell.hpp — shell-execution + project-root helpers for pulp-mcp.
 //
-// Extracted from tools/mcp/pulp_mcp.cpp in the 2026-05 Phase 6 (B4)
-// refactor. Both the tool handlers (mcp_tools.cpp) and the protocol
-// dispatcher (pulp_mcp.cpp) shell out to the `pulp` CLI and need to
-// locate the enclosing project root, so these two helpers live in a
-// shared header rather than being duplicated.
+// Both the tool handlers (mcp_tools.cpp) and the protocol dispatcher
+// (pulp_mcp.cpp) shell out to the `pulp` CLI and need to locate the
+// enclosing project root, so these helpers live in a shared header
+// rather than being duplicated.
 
 #pragma once
 

--- a/tools/mcp/mcp_tools.cpp
+++ b/tools/mcp/mcp_tools.cpp
@@ -1,10 +1,9 @@
 // mcp_tools.cpp — MCP tool-call handlers for pulp-mcp.
 //
-// Extracted from tools/mcp/pulp_mcp.cpp in the 2026-05 Phase 6 (B4)
-// refactor. See mcp_tools.hpp for the dispatch surface. Each handler
-// shells out to the `pulp` CLI (build/test/validate) or queries the
-// bundled audio services (model store, excerpt service), then wraps
-// the result via json_tool_payload.
+// See mcp_tools.hpp for the dispatch surface. Each handler shells out
+// to the `pulp` CLI (build/test/validate) or queries the bundled audio
+// services (model store, excerpt service), then wraps the result via
+// json_tool_payload.
 
 #include "mcp_tools.hpp"
 #include "mcp_json.hpp"

--- a/tools/mcp/mcp_tools.hpp
+++ b/tools/mcp/mcp_tools.hpp
@@ -1,9 +1,8 @@
 // mcp_tools.hpp — MCP tool-call handlers for pulp-mcp.
 //
-// Extracted from tools/mcp/pulp_mcp.cpp in the 2026-05 Phase 6 (B4)
-// refactor — third cut of the MCP typed-registry split. Each handler
-// takes the raw `params` JSON of a tools/call request and returns the
-// tool result payload (json_tool_payload-wrapped structured content).
+// Each handler takes the raw `params` JSON of a tools/call request and
+// returns the tool result payload (json_tool_payload-wrapped structured
+// content).
 //
 // pulp_mcp.cpp's protocol dispatcher routes tool names to these.
 

--- a/tools/mcp/pulp_mcp.cpp
+++ b/tools/mcp/pulp_mcp.cpp
@@ -26,10 +26,10 @@
 
 namespace fs = std::filesystem;
 
-// JSON-RPC framing + field extraction extracted to mcp_json.hpp, and
-// project SDK-compat resolution to mcp_compat.hpp, in the Phase 6 (B4)
-// refactor. Pull the helpers into file scope so the rest of this TU
-// keeps its existing unqualified call sites.
+// JSON-RPC framing + field extraction live in mcp_json.hpp, and project
+// SDK-compat resolution lives in mcp_compat.hpp. Pull the helpers into
+// file scope so the rest of this TU keeps its existing unqualified call
+// sites.
 using pulp_mcp::json_string;
 using pulp_mcp::json_error;
 using pulp_mcp::json_result;
@@ -44,8 +44,8 @@ using pulp_mcp::resolve_project_sdk_version;
 using pulp_mcp::compare_semver;
 using pulp_mcp::compat_error_payload;
 using pulp_mcp::handle_compat;
-// Shell-execution + tool handlers extracted to mcp_shell.hpp /
-// mcp_tools.{hpp,cpp} in the Phase 6 (B4) refactor.
+// Shell-execution + tool handlers live in mcp_shell.hpp /
+// mcp_tools.{hpp,cpp}.
 using pulp_mcp::exec;
 using pulp_mcp::find_project_root;
 using pulp_mcp::shell_quote;
@@ -100,7 +100,7 @@ static std::string tools_list_json() {
 {"name":"pulp_kit_remove","description":"Remove an installed kit using only constrained lock-recorded kit paths under pulp-kits/<kit-id>/ plus known generated lock/CMake files. Requires yes=true.","inputSchema":{"type":"object","required":["id","yes"],"properties":{"id":{"type":"string","description":"Installed kit id"},"yes":{"type":"boolean","description":"Must be true after ownership review"}}}},
 {"name":"pulp_kit_pack","description":"Pack a local kit/content manifest directory into a .pulpkit or .pulpcontent archive with files.sha256.json.","inputSchema":{"type":"object","required":["path"],"properties":{"path":{"type":"string","description":"Path to a kit directory or pulp.package.json"},"output":{"type":"string","description":"Archive output path"}}}},
 {"name":"pulp_kit_publish_check","description":"Run the metadata-only kit publish dry-run gate for a local kit directory, manifest, or .pulpkit archive. Rejects content-pack manifests; enforces strict manifest validation, license inventory, NOTICE-compatible license files via exports.licenses, human review, validation profiles, kind-specific evidence, and optional signed registry-manifest verification. Does not publish remotely.","inputSchema":{"type":"object","required":["path"],"properties":{"path":{"type":"string","description":"Path to a kit directory, pulp.package.json, or .pulpkit archive"},"registry_manifest":{"type":"string","description":"Optional local pulp-registry-manifest-v1 JSON to verify against the package manifest"}}}},
-{"name":"pulp_kit_init","description":"Scaffold a local developer kit manifest. Phase 1 only writes metadata; it does not install or apply anything.","inputSchema":{"type":"object","required":["kind","id"],"properties":{"kind":{"type":"string","enum":["source","ui-kit","template"],"description":"Developer fixture manifest kind"},"id":{"type":"string","description":"Package id"},"name":{"type":"string","description":"Display name"},"dir":{"type":"string","description":"Directory to write pulp.package.json into"},"force":{"type":"boolean","description":"Overwrite an existing manifest"}}}},
+{"name":"pulp_kit_init","description":"Scaffold a local developer kit manifest. Writes metadata only; it does not install or apply anything.","inputSchema":{"type":"object","required":["kind","id"],"properties":{"kind":{"type":"string","enum":["source","ui-kit","template"],"description":"Developer fixture manifest kind"},"id":{"type":"string","description":"Package id"},"name":{"type":"string","description":"Display name"},"dir":{"type":"string","description":"Directory to write pulp.package.json into"},"force":{"type":"boolean","description":"Overwrite an existing manifest"}}}},
 {"name":"pulp_content","description":"Umbrella wrapper for data-only content-pack subcommands. .pulpcontent archives must include files.sha256.json. Use validate/preview/list/reveal/rescan freely; install/update/remove require yes=true after review.","inputSchema":{"type":"object","required":["subcommand"],"properties":{"subcommand":{"type":"string","enum":["validate","preview","install","update","list","rescan","remove","uninstall","reveal"],"description":"Content subcommand to run"},"path":{"type":"string","description":"Path for validate/preview/install/update"},"plugin_runtime":{"type":"string","description":"Path to trusted pulp.plugin-runtime.json for preview"},"plugin":{"type":"string","description":"Target plugin id"},"id":{"type":"string","description":"Installed content package id for remove/reveal"},"package_id":{"type":"string","description":"Installed content package id for remove/reveal"},"version":{"type":"string","description":"Optional content package version"},"root":{"type":"string","description":"Optional content data root override"},"yes":{"type":"boolean","description":"Required for install/update/remove after review"}}}},
 {"name":"pulp_content_validate","description":"Validate a local .pulpcontent archive or content-pack directory without executing package code. Archives must include files.sha256.json, every payload file must be listed there, and hashes must match.","inputSchema":{"type":"object","required":["path"],"properties":{"path":{"type":"string","description":"Path to .pulpcontent archive or content-pack directory"}}}},
 {"name":"pulp_content_preview","description":"Preview content-pack compatibility and reload policy against a trusted plugin runtime manifest without installing anything. Archives must include files.sha256.json.","inputSchema":{"type":"object","required":["path","plugin_runtime"],"properties":{"path":{"type":"string","description":"Path to .pulpcontent archive or content-pack directory"},"plugin_runtime":{"type":"string","description":"Path to trusted pulp.plugin-runtime.json"},"plugin":{"type":"string","description":"Optional expected target plugin id"}}}},
@@ -148,10 +148,8 @@ static std::string tools_list_json() {
 // contain embedded `\n` or `\r`. Several response builders use
 // multi-line R"JSON(...)" raw strings for readability. Strip those
 // here so every wire-bound response is a single line.
-//
-// B4 (2026-05): moved out of main()'s I/O loop into a free function +
-// applied at the bottom of handle_request, so the contract holds for
-// every caller — not just main's stdio path. Pinned by
+// The function is applied at the bottom of handle_request, so the
+// contract holds for every caller, not just main's stdio path. Pinned by
 // `test/test_mcp_server.cpp` "MCP wire output never contains embedded
 // newlines" [issue-2091].
 static std::string compact_for_wire(std::string s) {
@@ -507,8 +505,8 @@ int main(int argc, char* argv[]) {
 
     // MCP spec: messages on the stdio transport are delimited by
     // newlines and MUST NOT contain embedded `\n` or `\r`. The
-    // newline-stripping contract now lives inside `handle_request`
-    // itself (B4 2026-05), so callers here just pass through.
+    // newline-stripping contract lives inside `handle_request` itself,
+    // so callers here just pass through.
 
     std::string line;
     while (std::getline(std::cin, line)) {


### PR DESCRIPTION
## Summary
- Remove stale Phase/B4/refactor breadcrumbs from pulp-mcp comments.
- Keep comments focused on current MCP helper ownership: JSON framing, SDK compat, shell helpers, and tool-handler dispatch.
- Reword `pulp_kit_init`'s tool description to describe current metadata-only behavior without a phase label.
- No code, schema, signature, or behavior changes.

## Validation
- `git diff --check`
- `rg -n 'gap-doc|Phase|follow-up|planning/|workstream|Workstream|slice|2026|Codex|roadmap|B4|refactor' tools/mcp/pulp_mcp.cpp tools/mcp/mcp_compat.cpp tools/mcp/mcp_compat.hpp tools/mcp/mcp_shell.hpp tools/mcp/mcp_json.hpp tools/mcp/mcp_tools.hpp tools/mcp/mcp_tools.cpp || true` (clean)
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- Claude adversarial review via `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean; `overall: patch is correct (0.97)`)
- `git push --dry-run origin feature/mcp-comment-hygiene` (pre-push gates clean; 29 hook tests passed; `cli-maintenance` skill-sync bypass recognized for comment-only MCP cleanup)
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/mcp-comment-hygiene` (pre-push gates clean; 29 hook tests passed)

Commit trailer:
- `Skill-Update: skip skill=cli-maintenance reason="comment-only cleanup removes stale refactor breadcrumbs; no CLI or MCP workflow behavior changed"`

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale refactor breadcrumbs from `pulp-mcp` comments and clarified what the current MCP helpers do. Updated the `pulp_kit_init` tool description to state it only writes metadata; no API or behavior changes.

<sup>Written for commit 732dabd92b0338caa6f27d21fca967c232f4bf38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

