### PR TITLE
docs: clean message loop comment archaeology

### DIFF
--- a/core/events/include/pulp/events/message_loop_integration.hpp
+++ b/core/events/include/pulp/events/message_loop_integration.hpp
@@ -8,9 +8,9 @@
 // or X11/Wayland event sources).
 //
 // Background:
-//   PR #2825 shipped `MainThreadDispatcher` — a process-wide bridge that
-//   lets any Pulp subsystem post work to whatever native main-thread queue
-//   a platform owner has registered. The macOS plugin-mode helper
+//   `MainThreadDispatcher` is a process-wide bridge that lets any Pulp
+//   subsystem post work to whatever native main-thread queue a platform
+//   owner has registered. The macOS plugin-mode helper
 //   (`plugin_main_thread.hpp`) adds a refcounted Cocoa backend so format
 //   adapters can register at instantiation time. This header sits one
 //   level up: it exposes the *kind* of native loop that's currently
@@ -33,19 +33,14 @@
 //     introspection* surface, not a re-implementation of every native
 //     loop API.
 //
-// Platform coverage (as of 2026-05-26):
-//   - macOS / iOS  — Cocoa NSRunLoop backend (shipped via #2825 + plugin
-//     helper in `plugin_main_thread.hpp`).
+// Platform coverage:
+//   - macOS / iOS  — Cocoa NSRunLoop backend via the plugin-mode helper
+//     in `plugin_main_thread.hpp`.
 //   - Windows      — MsgWaitForMultipleObjects backend pending; the
 //     dispatcher will report `MainLoopKind::None` until the standalone
 //     Win32 host or VST3 editor registers one.
 //   - Linux        — GLib / X11 / Wayland backends pending; same
 //     `MainLoopKind::None` story until a backend lands.
-//
-// The gap-doc rows that track per-OS backend implementations live in
-// `planning/2026-05-24-reference-framework-gap-analysis.md`. This header
-// is the long-promised *cross-platform API surface* — callers can adopt
-// it today and the OS-side backends light up as they ship.
 
 #include <pulp/events/main_thread_dispatcher.hpp>
 


### PR DESCRIPTION
Summary:
- Refresh message loop integration comments so they describe current behavior instead of the old roadmap/PR landing path.
- Remove stale dated planning references from `message_loop_integration.hpp`; no code, API, or behavior changed.

Validation:
- `git diff --check`
- focused stale-marker scan for planning/roadmap/PR breadcrumb terms in `core/events/include/pulp/events/message_loop_integration.hpp`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `git push --dry-run origin feature/message-loop-comment-hygiene` (full local diff coverage path): 100% tests passed, 0 tests failed out of 10409; total test time 1109.32 sec; diff coverage reported no covered lines in this comment-only diff and passed the 75% gate.
- Actual push used `PULP_SKIP_DIFF_COVER=1` after the clean dry-run to avoid repeating the expensive coverage run; cheap gates and 29 hook tests passed.

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshed comments in `core/events/include/pulp/events/message_loop_integration.hpp` to describe current behavior and platform coverage; removed stale PR/roadmap references. No code, API, or behavior changes.

<sup>Written for commit 6ba0a3fc0eaabfdfc05161c42068d8d9746b6782. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

