### PR TITLE
docs: clean SDK smoke comment archaeology

### DIFF
--- a/tools/validation/sdk-smoke/CMakeLists.txt
+++ b/tools/validation/sdk-smoke/CMakeLists.txt
@@ -7,8 +7,8 @@ cmake_minimum_required(VERSION 3.24)
 # format the installed SDK advertises and builds a single probe plugin
 # (PulpSDKSmokeProbe) against them.
 #
-# Two opt-in tightenings for the Linux/macOS Chainer gap-closure plan
-# (planning/2026-05-24-linux-macos-chainer-gap-closure-plan.md, Phase 3):
+# Two opt-in tightenings keep production SDK packaging checks from
+# silently passing when a consumer-required format is missing:
 #
 #   PULP_SDK_SMOKE_REQUIRE_FORMATS — semicolon-separated list of formats
 #       that MUST be present in the installed SDK. Configure-time


### PR DESCRIPTION
Summary:
- Refresh the SDK smoke validation CMake header comment so it describes the current production packaging invariant.
- Remove the stale private planning path and Phase label from `tools/validation/sdk-smoke/CMakeLists.txt`; no CMake logic or behavior changed.

Validation:
- `git diff --check`
- focused stale-marker scan for planning/roadmap/PR breadcrumb terms in `tools/validation/sdk-smoke/CMakeLists.txt`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `git push --dry-run origin feature/sdk-smoke-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/sdk-smoke-comment-hygiene`

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.
- A focused `ctest --test-dir build -R '^cmake-pulp-install' --output-on-failure` was attempted, but this fresh worktree has no `build/` directory. The pre-push hooks still ran the cheap gates and 29 hook tests cleanly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the header comment in tools/validation/sdk-smoke/CMakeLists.txt to reflect current production SDK packaging checks and clarify required format behavior. Removed a stale planning reference; no CMake logic changed.

<sup>Written for commit 89d02b71a18a68323d8e05a2077d99a09181f4fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

