### PR TITLE
docs: clean status ladder comment archaeology

### DIFF
--- a/tools/check_status_ladder.py
+++ b/tools/check_status_ladder.py
@@ -2,7 +2,7 @@
 """
 Enforce the Pulp status ladder on docs/status/support-matrix.yaml.
 
-Ladder rule (production-readiness workstream 08 sub-deliverable 8.4):
+Ladder rule for production readiness:
 A capability may be labeled `usable` only if it has ONE OF:
   (a) cross-platform validation — evidenced by either being nested under a
       platform-scoped parent (e.g. `platform_maturity.accessibility.macos`)


### PR DESCRIPTION
Summary:
- Refresh the status ladder helper docstring so it describes the current production-readiness rule.
- Remove the stale workstream/sub-deliverable breadcrumb from `tools/check_status_ladder.py`; no executable logic or behavior changed.

Validation:
- `git diff --check`
- focused stale-marker scan for planning/roadmap/PR breadcrumb terms in `tools/check_status_ladder.py`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `python3 -m py_compile tools/check_status_ladder.py`
- `python3 tools/check_status_ladder.py --mode=warn`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (first attempt hit temporary Claude 529 overload; retry was clean)
- `git push --dry-run origin feature/status-ladder-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 git push -u origin feature/status-ladder-comment-hygiene`

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.
- `python3 tools/check_status_ladder.py --mode=report` currently fails on 18 support-matrix entries; the same 18 failures reproduce from an `origin/main` snapshot, so they are pre-existing and unrelated to this docstring cleanup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the status ladder helper docstring to reflect the current production-readiness rule and removed a stale workstream/sub-deliverable breadcrumb in `tools/check_status_ladder.py`. Comment-only change; no executable logic, API, or CI behavior modified.

<sup>Written for commit 0de2d87b2c42ec28cb64e72687a4e1e474cd47d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

