### PR TITLE
docs: clean native components comment archaeology

### DIFF
--- a/core/native-components/include/pulp/native_components/native_core.h
+++ b/core/native-components/include/pulp/native_components/native_core.h
@@ -16,8 +16,8 @@
  *
  * This is the *Processor-level* FFI. It is deliberately independent of
  * `SignalGraph` (contract decision 6): no graph, node, or host-chaining types
- * appear here. The future `pulp_node_v1` C ABI (Phase 6) reuses these
- * primitives but does not share this header.
+ * appear here. The `pulp_node_v1` C ABI reuses these primitives but does not
+ * share this header.
  *
  * ── Contract decisions encoded here (see the spec) ──
  *   1  ABI-shaped: every struct leads with `size` + `abi_version`.

--- a/core/native-components/include/pulp/native_components/pulp_node_v1.h
+++ b/core/native-components/include/pulp/native_components/pulp_node_v1.h
@@ -2,8 +2,8 @@
  * pulp/native_components/pulp_node_v1.h — Pulp public node ABI, generation 1.
  *
  * The stable, language-neutral C contract a precompiled custom `SignalGraph`
- * node implements (Rust, C, Zig, generated DSP). Derived from the Phase 5
- * source-level `CustomNodeType` experience (lifecycle + opaque state +
+ * node implements (Rust, C, Zig, generated DSP). Derived from the
+ * source-level `CustomNodeType` contract (lifecycle + opaque state +
  * serialization) and frozen here as `pulp_node_v1`.
  *
  * SCOPE: custom `SignalGraph` nodes only. This is NOT the Processor-level FFI


### PR DESCRIPTION
Summary:
- Refresh native component ABI header comments so they describe current ABI relationships rather than old Phase 5/6 chronology.
- Remove stale phase breadcrumbs from `pulp_node_v1.h` and `native_core.h`; no code, declarations, macros, API, or behavior changed.

Validation:
- `git diff --check`
- focused stale-marker scan in `core/native-components/include/pulp/native_components`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- C header include smoke: `cc -std=c11 -I. -fsyntax-only /tmp/pulp_native_components_header_smoke.c`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `git push --dry-run origin feature/native-components-comment-hygiene`
  - `100% tests passed, 0 tests failed out of 10409`
  - `Total Test time (real) = 1150.32 sec`
  - diff coverage OK; no covered lines in this comment-only diff
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/native-components-comment-hygiene`

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up ABI header comments for native components to remove outdated Phase 5/6 references and clarify the current relationship between `native_core.h` and `pulp_node_v1.h`. Comment-only change with no code, API, or behavior impact.

<sup>Written for commit 0c087495f698c42dda3805d2d3b234610b69f303. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

