### PR TITLE
docs: clean example format comment archaeology

### DIFF
--- a/examples/pulp-effect/pulp_effect.hpp
+++ b/examples/pulp-effect/pulp_effect.hpp
@@ -3,7 +3,7 @@
 // PulpEffect — biquad filter effect with multiple parameter types
 // Validates: frequency parameter (wide range), resonance, stepped enum (filter type),
 // dry/wet mix, and more complex DSP than PulpGain.
-// Phase 5 validation: demonstrates parameter diversity across format adapters.
+// Demonstrates parameter diversity across format adapters.
 
 #include <pulp/format/processor.hpp>
 #include <cmath>

--- a/examples/pulp-tone/pulp_tone.hpp
+++ b/examples/pulp-tone/pulp_tone.hpp
@@ -2,7 +2,7 @@
 
 // PulpTone — simple oscillator synth with MIDI input
 // Validates: audio output, MIDI input, note handling, parameter system
-// Phase 4 validation example from the roadmap
+// Demonstrates the instrument format path used by format-adapter smoke tests.
 
 #include <pulp/format/processor.hpp>
 #include <cmath>


### PR DESCRIPTION
## Summary
- Refresh PulpTone/PulpEffect header comments so they describe current example purpose rather than old roadmap phase chronology.
- No code, declarations, DSP, parameter metadata, API, or behavior changed.

## Validation
- `git diff --check`
- `rg -n "Phase [0-9]|phase [0-9]|Workstream|roadmap|slice|follow-up|future|legacy" examples/pulp-effect/pulp_effect.hpp examples/pulp-tone/pulp_tone.hpp` (no matches)
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean; overall: patch is correct 0.99)
- `git push --dry-run origin feature/examples-format-comment-hygiene` (pre-push gates clean; 29 tests passed; no diff-cover build triggered)
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/examples-format-comment-hygiene` (pre-push gates clean; 29 tests passed)

## Notes
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Ad hoc header compile smoke was attempted, but this fresh worktree does not materialize CHOC outside CMake build-time dependencies, so it was not a useful standalone check.
- Comment-only change; no behavior/API change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update example header comments in `examples/pulp-effect/pulp_effect.hpp` and `examples/pulp-tone/pulp_tone.hpp` to describe current purpose and remove legacy roadmap/phase wording. Comment-only change with no code, API, or behavior impact.

<sup>Written for commit 69ec895d80ecb243cba62134d216f429530b3ead. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

