### PR TITLE
docs: clean root cmake comment archaeology

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,7 @@ message(STATUS "Pulp ${PROJECT_VERSION} — platform: ${PULP_PLATFORM}")
 # (pulp::host, the CLI binary, plugin scanners) that we deliberately skip on
 # mobile. Forcing tests OFF on iOS also prevents downstream example
 # CMakeLists from invoking `catch_discover_tests` when the Catch2 include
-# was never loaded for that target. See 2026-05-24 AUv3 iOS validation plan
-# Phase iOS-A.
+# was never loaded for that target.
 if(CMAKE_SYSTEM_NAME STREQUAL "iOS" OR ANDROID)
     option(PULP_BUILD_TESTS "Build unit tests" OFF)
 else()
@@ -129,7 +128,7 @@ option(PULP_ENABLE_AAX "Enable optional AAX support with a developer-supplied SD
 option(PULP_ENABLE_ARA "Enable optional ARA 2.x support with a developer-supplied Celemony SDK" OFF)
 option(PULP_FETCHCONTENT_UPDATES_DISCONNECTED "Avoid implicit FetchContent updates during configure" ON)
 option(PULP_USE_SHARED_FETCHCONTENT_SOURCES "Prefer machine-local shared source caches for FetchContent dependencies" ON)
-option(PULP_BENCHMARK "Enable zero-copy benchmark perf counters (Slice 0 of #516). Tooling-only; OFF by default so production builds see zero overhead." OFF)
+option(PULP_BENCHMARK "Enable zero-copy benchmark perf counters. Tooling-only; OFF by default so production builds see zero overhead." OFF)
 if(PULP_BENCHMARK)
     add_compile_definitions(PULP_BENCHMARK)
 endif()
@@ -197,8 +196,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpAAX.cmake)
 pulp_configure_aax_sdk()
 
 # ── Third-Party Dependencies ────────────────────────────────────────────────
-# Extracted to tools/cmake/PulpDependencies.cmake in the 2026-05 Phase 3
-# (C2) refactor.
+# Shared dependency setup lives in tools/cmake/PulpDependencies.cmake.
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpDependencies.cmake)
 
 # ── Android NDK Support ───────────────────────────────────────────────────
@@ -321,12 +319,10 @@ if(NOT ANDROID AND NOT IOS AND PULP_ENABLE_GPU)
     add_subdirectory(tools/cli)
 endif()
 
-# ── Rust CLI (Phase 8 binary swap, issues #686 / #767) ────────────────────
+# ── Rust CLI (experimental desktop bridge) ────────────────────────────────
 # Bridges `cargo build` for the experimental Rust CLI port into the
 # CMake build graph. Coexists with pulp-cli (the C++ binary) — both
-# install side-by-side under `${CMAKE_INSTALL_BINDIR}`. PR #2 of the
-# swap pair flips the user-facing default; this file is the no-op
-# build-graph scaffolding (PR #1).
+# install side-by-side under `${CMAKE_INSTALL_BINDIR}`.
 #
 # Mirror the EXACT desktop guard used for tools/cli above — both the
 # `NOT ANDROID AND NOT IOS` mobile-skip AND the `PULP_ENABLE_GPU`
@@ -334,8 +330,7 @@ endif()
 # GPU-off jobs still pull cargo into the default `all` build whenever
 # cargo happens to be on PATH, introducing unrelated Rust-toolchain
 # / network failures (and minutes of cargo build time) in lanes that
-# intentionally disable the CLI/GPU paths. Codex review on PR #778
-# (CMakeLists:523) flagged the missing guard as a P2.
+# intentionally disable the CLI/GPU paths.
 if(NOT ANDROID AND NOT IOS AND PULP_ENABLE_GPU
    AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/experimental/pulp-rs/CMakeLists.txt")
     add_subdirectory(experimental/pulp-rs)
@@ -349,7 +344,7 @@ endif()
 # ── Screenshot Tool ────────────────────────────────────────────────────────
 add_subdirectory(tools/screenshot)
 
-# ── Out-of-process plugin scan worker (workstream 03 slice 3.3b) ──────────
+# ── Out-of-process plugin scan worker ─────────────────────────────────────
 if(NOT IOS AND NOT ANDROID)
     add_subdirectory(tools/scan-worker)
 endif()
@@ -434,8 +429,8 @@ if(ANDROID)
 
     # TalkBack accessibility JNI entry points live in pulp-view
     # (core/view/platform/android/accessibility_android.cpp). pulp-view is
-    # not whole-archived — whole-archiving it pulls in SDL3's JNI_OnLoad
-    # and duplicates ours (see closed PR #148). Instead, force-reference
+    # not whole-archived — doing so pulls in SDL3's JNI_OnLoad and
+    # duplicates ours. Instead, force-reference
     # each Java_com_pulp_accessibility_* symbol so the linker keeps the
     # containing object file. This preserves just the JNI exports without
     # dragging SDL3 into the JNI closure. Without this the app hits
@@ -456,8 +451,7 @@ if(ANDROID)
 endif()
 
 # ── SDK Install Rules ──────────────────────────────────────────────────────
-# Extracted to tools/cmake/PulpInstallRules.cmake in the 2026-05 Phase 3
-# (C2) refactor.
+# Shared SDK install/export rules live in tools/cmake/PulpInstallRules.cmake.
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpInstallRules.cmake)
 
 # ── Linux fontconfig post-pass ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Refresh root `CMakeLists.txt` comments so they describe current build behavior instead of old roadmap phase/workstream/PR chronology.
- Preserve all CMake conditions, includes, target wiring, defaults, and build logic.

## Validation
- `git diff --check`
- `rg -n "Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|slice|follow-up|legacy|PR #[0-9]|Codex review" CMakeLists.txt` (no matches)
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean; overall: patch is correct 0.97)
- `git push --dry-run origin feature/root-cmake-comment-hygiene` (pre-push gates clean; 29 tests passed; no diff-cover build triggered)
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/root-cmake-comment-hygiene` (pre-push gates clean; 29 tests passed)

## Notes
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment/help-text-only change; no build behavior/API change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned and updated comments in the root `CMakeLists.txt` to match current build behavior and remove outdated roadmap/PR references. No build logic, targets, or defaults were changed.

- **Refactors**
  - Simplified iOS/Android test guard and Catch2 context.
  - Clarified dependency and install-rule comments; removed roadmap/PR mentions.
  - Tightened Rust CLI bridge and scan worker notes.
  - Preserved all conditions, includes, targets, and defaults.

<sup>Written for commit 2370d416ec691e92a3b2e14da219d80951375215. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

