### PR TITLE
docs: clean PulpDrums comment archaeology

### DIFF
--- a/examples/PulpDrums/CMakeLists.txt
+++ b/examples/PulpDrums/CMakeLists.txt
@@ -1,5 +1,5 @@
 # PulpDrums — generative drum sequencer MIDI effect
-# Validates: MIDI output, pattern sequencing, Phase 6 GPU UI
+# Validates: MIDI output, pattern sequencing, and plugin packaging
 
 if(PULP_BUILD_TESTS)
     add_executable(pulp-drums-test test_pulp_drums.cpp)

--- a/examples/PulpDrums/pulp_drums.hpp
+++ b/examples/PulpDrums/pulp_drums.hpp
@@ -2,7 +2,7 @@
 
 // PulpDrums — generative drum sequencer MIDI effect
 // Validates: MIDI output, pattern sequencing, parameter system
-// Phase 6 validation example from the roadmap
+// Demonstrates the MIDI-effect path with scheduled note output.
 
 #include <pulp/format/processor.hpp>
 #include <array>

--- a/examples/PulpDrums/test_pulp_drums.cpp
+++ b/examples/PulpDrums/test_pulp_drums.cpp
@@ -141,11 +141,11 @@ TEST_CASE("PulpDrums golden: tempo change changes MIDI density",
 // sequencer fires. Regression guard against a future change that
 // accidentally reads/writes the audio buffer in the MIDI path.
 //
-// Codex P2 on PR #379: the old single-block version never fired a
-// step event (samples_per_step ≈ 3600 at 200 BPM 48 kHz, block=512),
-// so the "while sequencing" promise wasn't exercised. We now loop
-// blocks until midi_out has non-zero size at least once — and keep
-// asserting bit-exact pass-through on every block.
+// A single block can finish before the next sequencer step
+// (samples_per_step ≈ 3600 at 200 BPM 48 kHz, block=512), so the
+// "while sequencing" promise is only exercised after looping until
+// midi_out has non-zero size at least once. Keep asserting bit-exact
+// pass-through on every block.
 TEST_CASE("PulpDrums golden: audio is bit-exact pass-through while sequencing",
           "[examples][drums][golden][issue-356]") {
     HeadlessHost host(create_pulp_drums);


### PR DESCRIPTION
## Summary
- Refresh PulpDrums comments so they describe current MIDI-effect and packaging behavior instead of old roadmap phase / PR-review chronology.
- Preserve all CMake behavior, processor code, and test assertions.

## Validation
- `git diff --check`
- `rg -n "Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|slice|follow-up|legacy|PR #[0-9]|Codex review|planning/" examples/PulpDrums` (no matches)
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean; overall: patch is correct 0.95)
- `git push --dry-run origin feature/pulpdrums-comment-hygiene` (pre-push gates clean; 29 tests passed; no diff-cover build triggered)
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/pulpdrums-comment-hygiene` (pre-push gates clean; 29 tests passed)

## Notes
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no build behavior/API/test behavior change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh PulpDrums comments to reflect current MIDI-effect behavior and plugin packaging, removing roadmap/phase/PR-review references. No code, build, API, or test behavior changes.

<sup>Written for commit b3902ee5f84e2f50f581f125d3aa6143fa8ab872. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

