### PR TITLE
docs: clean widget gallery comment archaeology

### DIFF
--- a/examples/widget-gallery/main.cpp
+++ b/examples/widget-gallery/main.cpp
@@ -1,7 +1,7 @@
 // Widget Gallery — renders the Ink & Signal component gallery (every supported
 // primitive in one board) to PNG, headless. It triples as living documentation,
-// a reskin-preview surface, and the visual-regression corpus (Phase 6 diffs
-// these renders). Swap --preset / --theme to preview a reskin.
+// a reskin-preview surface, and the visual-regression corpus used to compare
+// theme/rendering changes. Swap --preset / --theme to preview a reskin.
 //
 //   pulp-widget-gallery --out /tmp/gallery [--theme light|dark|both] [--preset ink-signal]
 //


### PR DESCRIPTION
## Summary
- Refresh the widget-gallery header comment so it describes the current visual-regression corpus instead of old phase chronology.
- Preserve the gallery renderer behavior, CLI flags, output paths, and screenshot backend unchanged.

## Validation
- `git diff --check`
- `rg -n "Codex|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|slice|follow-up|legacy|PR #[0-9]|planning/" examples/widget-gallery/main.cpp` (no matches)
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, `overall: patch is correct (0.99)`
- `git push --dry-run origin feature/widget-gallery-comment-hygiene` — pre-push gates clean, 29 tests passed
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/widget-gallery-comment-hygiene` — pre-push gates clean, 29 tests passed

## Notes
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the header comment in `examples/widget-gallery/main.cpp` to describe the current visual-regression corpus and remove outdated phase references. No changes to behavior, CLI flags, or outputs.

<sup>Written for commit 6ff167271142910ba46669babb2adb3e6547f51c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

