### PR TITLE
docs: clean tempo sampler comment archaeology

### DIFF
--- a/examples/PulpTempoSampler/CMakeLists.txt
+++ b/examples/PulpTempoSampler/CMakeLists.txt
@@ -18,7 +18,7 @@ pulp_add_plugin(PulpTempoSampler
     ACCEPTS_MIDI
 )
 
-# Headless editor screenshot (Phase 5 UX). macOS-only dev tool: it uses the
+# Headless editor screenshot. macOS-only dev tool: it uses the
 # CoreGraphics/Skia raster capture path and would otherwise pull the Linux
 # windowing stack (SDL3/X11/Wayland) into the advisory Linux lane.
 if(APPLE AND (TARGET pulp::view OR TARGET Pulp::view))

--- a/examples/PulpTempoSampler/screenshot.cpp
+++ b/examples/PulpTempoSampler/screenshot.cpp
@@ -1,4 +1,4 @@
-// Headless screenshot of the PulpTempoSampler editor (Phase 5 Ink & Signal UX).
+// Headless screenshot capture for the PulpTempoSampler editor.
 // Loads a synthetic multi-onset loop, builds the editor via create_view(), and
 // renders to a PNG with no GPU window and no audio device.
 //

--- a/examples/PulpTempoSampler/test_pulp_tempo_sampler.cpp
+++ b/examples/PulpTempoSampler/test_pulp_tempo_sampler.cpp
@@ -1,4 +1,5 @@
-// PulpTempoSampler — headless integration tests (Phase 4.11).
+// PulpTempoSampler — headless integration tests for loop analysis, slicing,
+// tempo matching, and editor/audio interaction.
 //
 // Exercises the full instrument pipeline without a host: load loop -> detect
 // BPM + slices -> background OfflineStretch render to host tempo (generation-


### PR DESCRIPTION
Summary:
- Refresh PulpTempoSampler test/screenshot comments so they describe the current integration and screenshot surfaces instead of old phase chronology.
- Preserve all sampler behavior, screenshot tooling, CMake targets, and test code unchanged.

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/" examples/PulpTempoSampler (no matches)
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.99)
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (0.98)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; merge-base --is-ancestor origin/main HEAD -> 0
- git push --dry-run origin feature/tempo-sampler-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/tempo-sampler-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up comments in `examples/PulpTempoSampler` to reflect the current headless screenshot tool and test coverage, removing outdated phase/roadmap references. No changes to behavior, API, tests, or CMake targets.

<sup>Written for commit f03226c2ec46deb34115bbd708977fbabc4f74b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

