### PR TITLE
docs: clean format validation comment archaeology

### DIFF
--- a/tools/check_format_validation.py
+++ b/tools/check_format_validation.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
-Adapter-vs-production split (workstream 08 slice 8.6).
+Validate that supported adapter/platform pairs have matching production-host
+coverage entries.
 
 Reads `docs/status/support-matrix.yaml` and reports on two things:
 


### PR DESCRIPTION
Summary:
- Replace the format-validation tool's historical workstream breadcrumb with a current-purpose docstring.
- Preserve validator parsing, modes, exit codes, and support-matrix behavior unchanged.

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/" tools/check_format_validation.py (no matches)
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.99)
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (0.98)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; merge-base --is-ancestor origin/main HEAD -> 0
- git push --dry-run origin feature/format-validation-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/format-validation-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the docstring in `tools/check_format_validation.py` to replace a legacy workstream note with a clear purpose: the validator ensures supported adapter/platform pairs have matching production-host coverage entries in `docs/status/support-matrix.yaml`. No behavior or CLI changes; parsing, modes, exit codes, and checks are unchanged.

<sup>Written for commit 9f0c8fb1aadf1c20b5f16402fedd95085bb9b4b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

