### PR TITLE
docs: clean node pack comment archaeology

### DIFF
--- a/test/test_node_pack.cpp
+++ b/test/test_node_pack.cpp
@@ -1,4 +1,4 @@
-// Phase 7 — signed node-pack loader. Builds a manifest for a real loadable node
+// Signed node-pack loader tests. Builds a manifest for a real loadable node
 // MODULE, signs it with a test Ed25519 key, and asserts the loader accepts the
 // trusted/intact pack and rejects every tampering: untrusted signer, bad
 // signature, hash mismatch, ABI mismatch, and a missing binary. The dlopen path


### PR DESCRIPTION
Summary:
- Replace the signed node-pack test header's historical phase breadcrumb with current-purpose wording.
- Preserve node-pack loader test logic, assertions, manifest setup, and dlopen coverage unchanged.

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/" test/test_node_pack.cpp (no matches)
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.99)
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (0.99)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; merge-base --is-ancestor origin/main HEAD -> 0
- git push --dry-run origin feature/node-pack-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/node-pack-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the header comment in the node-pack loader tests by removing the "Phase 7" breadcrumb and describing the test’s current purpose. Test logic and coverage are unchanged.

<sup>Written for commit 9226af76517e54fe5f763039b479ca7ca3f82d89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

