### PR TITLE
docs: clean graph serializer comment archaeology

### DIFF
--- a/test/test_graph_serializer.cpp
+++ b/test/test_graph_serializer.cpp
@@ -880,8 +880,8 @@ TEST_CASE("GraphSerializer round-trips registered custom node identity",
 }
 
 namespace {
-// A stateful custom type (Phase 5): instance holds a `level` serialized as 4
-// little-endian bytes via save/load_state.
+// A stateful custom type: instance holds a `level` serialized as 4 little-endian
+// bytes via save/load_state.
 struct SerLevel {
     float level = 1.0f;
 };


### PR DESCRIPTION
Summary:
- Replace the graph-serializer stateful custom-node test comment's historical phase breadcrumb with current-purpose wording.
- Preserve serializer test logic, custom-node state setup, and save/load_state behavior unchanged.

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/" test/test_graph_serializer.cpp (no matches)
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.99)
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (0.99)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; merge-base --is-ancestor origin/main HEAD -> 0
- git push --dry-run origin feature/graph-serializer-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/graph-serializer-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up a graph serializer test comment by removing legacy “Phase 5” wording and clarifying the custom node’s purpose. No code, behavior, or API changes; tests and save/load_state logic remain the same.

<sup>Written for commit fc8b249ef15dc676fc6385cdaab100dbe5508df0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

