### PR TITLE
docs: clean CLAP ARA comment archaeology

### DIFF
--- a/test/test_clap_ara_extension.cpp
+++ b/test/test_clap_ara_extension.cpp
@@ -1,8 +1,7 @@
-// End-to-end test for the CLAP → ARA companion-factory path.
-// Workstream 06 slice A2a — exercises the same code path a real CLAP
-// host (Bitwig, REAPER) takes: constructs a PulpClapPlugin, calls
-// clap_adapter::clap_get_extension(kClapAraFactoryExtension), and
-// verifies the result.
+// End-to-end test for the CLAP → ARA companion-factory path. Exercises the
+// same code path a real CLAP host (Bitwig, REAPER) takes: constructs a
+// PulpClapPlugin, calls clap_adapter::clap_get_extension(kClapAraFactoryExtension),
+// and verifies the result.
 //
 // Without PULP_HAS_ARA the factory must be nullptr (no SDK linked in).
 // With PULP_HAS_ARA the factory must be a valid ARA::ARAFactory — the


### PR DESCRIPTION
Summary:
- Replace the CLAP/ARA companion-factory test header's historical workstream breadcrumb with current-purpose wording.
- Preserve the CLAP host path description, PULP_HAS_ARA expectations, and all test behavior unchanged.

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/" test/test_clap_ara_extension.cpp (no matches)
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.97)
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (0.99)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; merge-base --is-ancestor origin/main HEAD -> 0
- git push --dry-run origin feature/clap-ara-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/clap-ara-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.
- Read CLAP and ARA skills before editing because the touched test covers the CLAP to ARA companion-factory path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned the CLAP→ARA companion-factory test header by removing historical “workstream” breadcrumbs and updating the intro for clarity. Test behavior, host path description, and PULP_HAS_ARA expectations are unchanged.

<sup>Written for commit 0b38fb11aaab4bd2a5d2f260d5ce1cf1d030dcef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

