### PR TITLE
docs: clean docs generator comment archaeology

### DIFF
--- a/tools/docs_generate.py
+++ b/tools/docs_generate.py
@@ -14,9 +14,7 @@ Modes:
 
 Registered generators (`id:`):
   - limitations  — renders the `limitations:` block from
-                   docs/status/support-matrix.yaml (workstream 08 slice 8.5)
-
-Part of workstream 08 slice 8.3.
+                   docs/status/support-matrix.yaml
 """
 from __future__ import annotations
 


### PR DESCRIPTION
Summary:
- Replace the docs generator docstring's historical workstream breadcrumbs with current-purpose wording.
- Preserve generated-region parsing, generator registration, check/generate modes, and behavior unchanged.

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/" tools/docs_generate.py (no matches)
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.98)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; merge-base --is-ancestor origin/main HEAD -> 0
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (0.99)
- git push --dry-run origin feature/docs-generate-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/docs-generate-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove obsolete workstream/phase breadcrumbs from the `tools/docs_generate.py` docstring so it reflects current purpose. No behavior changes; parsing, generator registration, and check/generate modes are unchanged.

<sup>Written for commit c966879052ab60b7e696881f42c9ce2654f3a1da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

