### PR TITLE
docs: clean check-docs comment archaeology

### DIFF
--- a/tools/check-docs.sh
+++ b/tools/check-docs.sh
@@ -219,7 +219,7 @@ if [ -x "$ROOT/tools/check_status_ladder.py" ]; then
     fi
 fi
 
-# ── Generated-table drift check (workstream 08 slice 8.3) ─────────────────────
+# ── Generated-table drift check ───────────────────────────────────────────────
 if [ -x "$ROOT/tools/docs_generate.py" ]; then
     echo "Checking generated-table drift in capabilities.md..."
     if ! python3 "$ROOT/tools/docs_generate.py" check; then


### PR DESCRIPTION
Summary:
- Replace the check-docs generated-table section header's historical workstream breadcrumb with current-purpose wording.
- Preserve generated-table drift checking, docs generator invocation, and error accounting unchanged.

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/" tools/check-docs.sh (no matches)
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.99)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; merge-base --is-ancestor origin/main HEAD -> 0
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (0.99)
- git push --dry-run origin feature/check-docs-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/check-docs-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove outdated workstream breadcrumb from the generated-table drift check comment in tools/check-docs.sh; no functional changes.

<sup>Written for commit 2e5c53b519545b97bbeadc13b02b9e2583e3c095. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

