### PR TITLE
docs: clean setup comment archaeology

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -338,7 +338,7 @@ retry_git() {
 # retry_git around `git clone URL DEST` fails on attempt 2+ with
 # "destination path already exists" instead of actually retrying
 # the network fetch. Wrap clone with a clean-target-between-attempts
-# shim. See #438 P1 Codex review on #425.
+# shim so every retry starts from an empty destination.
 retry_git_clone() {
     local label="$1"
     local target="${@: -1}"   # last positional arg is the destination


### PR DESCRIPTION
Summary:
- Replace the setup clone-retry comment's historical Codex review breadcrumb with current-purpose wording.
- Preserve retry_git_clone behavior, retry count/backoff, partial-target cleanup, and error handling unchanged.

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/" setup.sh (no matches)
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.98)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; merge-base --is-ancestor origin/main HEAD -> 0
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (0.99)
- git push --dry-run origin feature/setup-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/setup-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the `retry_git_clone` comment to focus on why we clean the target between attempts, removing outdated references. No code, behavior, or API changes.

<sup>Written for commit ff09210c44ba5bf2296ded7e370c38d1cb846bb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

