### PR TITLE
docs: clean SwiftUI host template comment archaeology

### DIFF
--- a/templates/swiftui-design-host/DesignHostApp.swift
+++ b/templates/swiftui-design-host/DesignHostApp.swift
@@ -1,5 +1,4 @@
-// Generic SwiftUI host scaffold for a Pulp design-imported view (Workstream B5
-// of planning/2026-06-02-design-token-export-and-swiftui-path.md).
+// Generic SwiftUI host scaffold for a Pulp design-imported view.
 //
 // `pulp import-design --mode baked --emit swiftui` writes three files:
 //   - <RootView>.swift          — the generated `ImportedPulpView` (a `View`


### PR DESCRIPTION
Summary:
- Replace the SwiftUI design-host template header's historical workstream/planning breadcrumb with current-purpose wording.
- Preserve the generated-view scaffold, parameter-store wiring, and SwiftUI behavior unchanged.

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/" templates/swiftui-design-host/DesignHostApp.swift (no matches)
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.97)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; merge-base --is-ancestor origin/main HEAD -> 0
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (0.99)
- git push --dry-run origin feature/swiftui-host-template-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/swiftui-host-template-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned the header comment in `templates/swiftui-design-host/DesignHostApp.swift` to remove outdated workstream/planning references and clearly state the template’s current purpose. No code or behavior changes.

<sup>Written for commit bb2c1f5c674c5bced477ad6dca72293d4cf67fc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

