### PR TITLE
docs: clean coverage targets comment archaeology

### DIFF
--- a/ci/coverage-targets.yaml
+++ b/ci/coverage-targets.yaml
@@ -23,11 +23,11 @@
 # Consumed by `tools/scripts/coverage_tier_check.py`, invoked from the
 # `coverage-diff-gate` job alongside the existing diff-cover invocation.
 #
-# Coverage scope (#1056, #1886):
+# Coverage scope:
 #   This file gates two Cobertura lanes that share one per-tier YAML:
 #     1. The Clang-instrumented native diff lane (C / C++ / Obj-C).
 #     2. The vitest v8 JS/TS lane in `packages/pulp-react/**`
-#        (pulp #1886 Phase 1 — measure-only at first).
+#        (currently measured before enforcement).
 #   `coverage_tier_check.py::is_instrumented_source` filters non-Cobertura
 #   files at aggregate time, so Kotlin (`.kt`) and Swift (`.swift`)
 #   sources never bias a tier score even if their paths match a glob.
@@ -39,7 +39,7 @@
 #
 #   Tier completeness is locked in structurally by
 #   `tools/scripts/test_coverage_tier_check.py::TierCoverageCompleteness`
-#   per the audit pattern in #1049 / #841 / #1056.
+#   so new first-party source paths must be assigned deliberately.
 
 version: 1
 
@@ -65,19 +65,19 @@ tiers:
       - core/scene/**
       - inspect/**
       - tools/cli/**
-      # pulp #1886 Phase 1 — JS/TS sources in @pulp/react are user-visible
-      # SDK surface. Coverage data comes from the vitest v8 → Cobertura
-      # pipeline in `.github/workflows/pulp-react-build.yml`, not from
+      # JS/TS sources in @pulp/react are user-visible SDK surface.
+      # Coverage data comes from the vitest v8 → Cobertura pipeline in
+      # `.github/workflows/pulp-react-build.yml`, not from
       # scripts/run_coverage.sh. The per-tier gate runs continue-on-error
-      # in coverage.yml so this entry is measure-only at first; Phase 2
-      # flips enforcement once a stable baseline is observed.
+      # in coverage.yml so this entry remains measure-only until a stable
+      # baseline supports enforcement.
       - packages/pulp-react/**
 
   - name: infrastructure
     line_target: 50
     paths:
       - core/events/**
-      - core/dsl/**          # pulp #1056 — DSL processor scaffolding (Faust wrapper headers)
+      - core/dsl/**          # DSL processor scaffolding (Faust wrapper headers)
       - core/runtime/**
       - core/state/**
       - core/canvas/**


### PR DESCRIPTION
Summary:
- Replace coverage-target comments' historical phase and issue breadcrumbs with current-purpose coverage wording.
- Preserve per-tier targets, path globs, coverage lane classification, and gate behavior unchanged.

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/|pulp #[0-9]|#[0-9]" ci/coverage-targets.yaml -> no matches
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main -> clean; ci skill-sync bypass honored
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.97)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; merge-base --is-ancestor origin/main HEAD -> 0
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (0.97)
- git push --dry-run origin feature/coverage-targets-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/coverage-targets-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.
- CI skill was read; no CI workflow behavior changed.
- Commit carries: Skill-Update: skip skill=ci reason="comment-only cleanup; no ci workflow change"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned outdated comments in `ci/coverage-targets.yaml`, removing phase/issue breadcrumbs and clarifying current coverage purpose. No functional changes; tier targets, path globs, Cobertura lanes, and gate behavior are unchanged.

<sup>Written for commit 0c6bc66a6b43fcf7b5d7f43cbe4d41df0e6cf17a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

