### PR TITLE
docs: clean events timer comment archaeology

### DIFF
--- a/core/events/include/pulp/events/timer.hpp
+++ b/core/events/include/pulp/events/timer.hpp
@@ -10,16 +10,16 @@ namespace pulp::events {
 
 // Timer bound to an EventLoop. Supports one-shot and repeating.
 //
-// Thread-safety + lifetime design (#414 / #687 / #716):
+// Thread-safety + lifetime design:
 //
 // - Mutable state (active, generation, callback, interval, loop ref) lives
 //   in a `shared_ptr<TimerImpl>` assigned exactly once at construction and
-//   never reassigned. That single-assignment avoids the #414 TSan race on
-//   the shared_ptr slot.
+//   never reassigned. That single-assignment avoids racing on the
+//   shared_ptr slot.
 // - Dispatch lambdas capture the shared_ptr by value. If the user-visible
 //   Timer is destroyed while the EventLoop still has a queued dispatch,
 //   the lambda's captured shared_ptr keeps TimerImpl alive until the
-//   lambda finishes. No UAF. (#716 — Codex P1 on #689.)
+//   lambda finishes.
 // - stop() bumps `generation` so any in-flight dispatch whose captured gen
 //   no longer matches returns early before calling the user callback.
 class Timer {

--- a/core/events/src/placeholder.cpp
+++ b/core/events/src/placeholder.cpp
@@ -1,2 +1,2 @@
-// pulp-events: placeholder — replaced in Phase 2+
+// Minimal translation unit anchoring the pulp-events namespace.
 namespace pulp::events {}

--- a/core/events/src/timer.cpp
+++ b/core/events/src/timer.cpp
@@ -12,7 +12,7 @@ struct Timer::Impl {
     // lambdas scheduled before stop() return early when they fire. Cheap
     // replacement for the previous shared_ptr<atomic<bool>> sentinel
     // which raced on the shared_ptr slot between start() (main thread)
-    // and schedule_next() (event-loop thread). See #687 / #414.
+    // and schedule_next() (event-loop thread).
     std::atomic<std::uint64_t> generation{0};
 
     Impl(EventLoop& l, Duration i, Callback cb, bool rep)
@@ -28,12 +28,12 @@ Timer::~Timer() {
     // Flip active + bump generation so any already-queued dispatch lambda
     // short-circuits. The lambdas hold their own shared_ptr<Impl> copies,
     // so Impl stays alive until they finish even though *our* impl_ is
-    // about to drop its reference — no UAF. See #716.
+    // about to drop its reference.
     stop();
 }
 
 void Timer::start() {
-    // Idempotent when already running. See #438 P1 Codex review on #428.
+    // Idempotent when already running.
     if (impl_->active.load(std::memory_order_acquire)) {
         return;
     }
@@ -65,7 +65,7 @@ void Timer::schedule_next(std::shared_ptr<Impl> impl, std::uint64_t gen) {
     // Capture the shared_ptr by value. If the owning Timer is destroyed
     // before this lambda fires, `impl` keeps the state alive until we
     // finish — the atomics return "inactive + generation moved on" and
-    // we exit without touching freed memory. #716 fix.
+    // we exit without touching freed memory.
     loop.dispatch_after(interval, [impl, gen]() {
         if (!impl->active.load(std::memory_order_acquire))
             return;


### PR DESCRIPTION
Summary:
- Replace events timer comments historical issue/review/phase breadcrumbs with current-purpose lifetime and thread-safety wording.
- Preserve Timer implementation, memory ordering, generation handling, and the events namespace translation unit unchanged.

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/|pulp #[0-9]|#[0-9]" core/events/src/placeholder.cpp core/events/include/pulp/events/timer.hpp core/events/src/timer.cpp -> no matches
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.97)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; git merge-base --is-ancestor origin/main HEAD -> 0
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (0.98)
- git push --dry-run origin feature/events-timer-comment-hygiene without PULP_SKIP_DIFF_COVER accidentally entered full diff-cover; relevant build targets passed and the run was intentionally interrupted at 6898/10409 tests to avoid wasting the machine on a comment-only slice.
- PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/events-timer-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/events-timer-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up events timer comments to remove historical breadcrumbs and explain lifetime and thread-safety more clearly. No behavior or API changes.

- **Refactors**
  - Clarified lifetime and thread-safety comments in core/events/include/pulp/events/timer.hpp and core/events/src/timer.cpp.
  - Replaced the placeholder namespace comment in core/events/src/placeholder.cpp with a concise description.

<sup>Written for commit 37ad3f1216da8720c87ca1559dc1130465662004. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

