### PR TITLE
docs: clean fft backend comment archaeology

### DIFF
--- a/core/signal/src/fft_backend.cpp
+++ b/core/signal/src/fft_backend.cpp
@@ -152,7 +152,6 @@ using fn_create  = MKL_LONG (*)(DFTI_DESCRIPTOR_HANDLE*, int, int, MKL_LONG, MKL
 // (mismatched ABI, no default-argument promotion guarantees). We MUST keep
 // the variadic prototype on the function pointer we call through, and let
 // the compiler handle argument promotion at the call site (float → double).
-// Regression: Codex PR #3021 review.
 using fn_set     = MKL_LONG (*)(DFTI_DESCRIPTOR_HANDLE, int, ...);
 using fn_commit  = MKL_LONG (*)(DFTI_DESCRIPTOR_HANDLE);
 using fn_compute = MKL_LONG (*)(DFTI_DESCRIPTOR_HANDLE, void*);
@@ -346,7 +345,7 @@ struct MultiBackendFft::Impl {
         // the variadic interface; the compiler emits the right ABI dance
         // (varargs promote float → double, MKL recovers it via va_arg). The
         // standalone `fn_set_f` typed alias that previously aliased the
-        // same dlsym handle was undefined behavior (Codex PR #3021 review).
+        // same dlsym handle was undefined behavior.
         b.set(mkl_desc, mkl_dyn::DFTI_BACKWARD_SCALE,
               1.0f / static_cast<float>(size));
         if (b.commit(mkl_desc) != 0)


### PR DESCRIPTION
Summary:
- Remove transient Codex review breadcrumbs from FFT backend MKL variadic-ABI comments.
- Preserve the current technical rationale for keeping DftiSetValue bound as a variadic function pointer.

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/|pulp #[0-9]|#[0-9]" core/signal/src/fft_backend.cpp -> no matches
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.99)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; git merge-base --is-ancestor origin/main HEAD -> 0
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (0.99)
- PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/fft-backend-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/fft-backend-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up FFT backend comments by removing internal review breadcrumbs and tightening the explanation around the MKL variadic ABI. Kept the rationale for binding `DftiSetValue` as a variadic function pointer; no behavior or API changes.

<sup>Written for commit 801697f4fd9ab3302bf14eeb2633f9ab1d5ec8f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

