### PR TITLE
docs: clean convolver comment archaeology

### DIFF
--- a/core/signal/include/pulp/signal/convolver.hpp
+++ b/core/signal/include/pulp/signal/convolver.hpp
@@ -66,13 +66,10 @@ public:
     bool try_swap_ir(ConvolverIrSwapper& swapper) {
         // Gate the swap on retire-ring capacity FIRST so the audio
         // thread never has to free the displaced IR inline if the
-        // ring is saturated (Codex P1 on #2881 — single-slot retired_
-        // would let the audio thread deallocate when 2+ swaps
-        // happened between drain_old() calls). Refusing the swap
-        // when the ring is full is RT-safe: pending stays in the
-        // swapper for the next try_swap_ir attempt; in-flight state_
-        // continues uninterrupted; worker thread catches up on its
-        // next drain tick.
+        // ring is saturated. Refusing the swap when the ring is full
+        // is RT-safe: pending stays in the swapper for the next
+        // try_swap_ir attempt; in-flight state_ continues uninterrupted;
+        // worker thread catches up on its next drain tick.
         if (state_ && !swapper.has_retire_capacity()) {
             return false;
         }

--- a/core/signal/include/pulp/signal/convolver_messages.hpp
+++ b/core/signal/include/pulp/signal/convolver_messages.hpp
@@ -176,7 +176,7 @@ public:
     /// True if there's room in the retire ring for one more displaced
     /// IR. Audio thread checks this before consuming pending so a
     /// swap never strands a displaced IR without an off-thread free
-    /// path (Codex P1 on #2881).
+    /// path.
     bool has_retire_capacity() const {
         return retired_queue_.size_approx() < kRetireRingCapacity;
     }
@@ -226,8 +226,8 @@ private:
     std::atomic<ConvolverIrState*> pending_{nullptr};
     // Consumer → producer: ring of displaced IRs awaiting off-thread
     // deletion. Replaces the single-slot atomic the original impl used
-    // (Codex P1 #2881 — single slot starved on rapid IR automation,
-    // forcing audio-thread frees when the slot was full).
+    // so rapid IR automation can queue multiple displaced states
+    // without forcing audio-thread frees when one drain tick is missed.
     pulp::runtime::SpscQueue<ConvolverIrState*, kRetireRingCapacity> retired_queue_;
 
     ConvolverIrState* pop_retired_raw() {


### PR DESCRIPTION
Summary:
- Remove transient Codex review breadcrumbs from convolver IR-swap comments.
- Preserve the current real-time safety rationale for retire-ring capacity, pending IR retention, and off-thread reclamation.

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/|pulp #[0-9]|#[0-9]" core/signal/include/pulp/signal/convolver_messages.hpp core/signal/include/pulp/signal/convolver.hpp -> no matches
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.97)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; git merge-base --is-ancestor origin/main HEAD -> 0
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (0.97)
- PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/convolver-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/convolver-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed transient review breadcrumbs from convolver comments and clarified the real-time safety rationale for IR swapping, retire-ring capacity checks, and off-thread reclamation. No behavior or API changes.

<sup>Written for commit 5eb7e3653265cbdf9a1052a2a958c0a4a85e8a7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

