### PR TITLE
docs: clean iir design comment archaeology

### DIFF
--- a/core/signal/include/pulp/signal/iir_design.hpp
+++ b/core/signal/include/pulp/signal/iir_design.hpp
@@ -365,7 +365,7 @@ private:
     // ── Elliptic (Cauer) implementation ──────────────────────────────────
     //
     // Real-modulus Jacobi machinery is provided by `special_functions.hpp`
-    // (Pulp's shared analytic toolbox, shipped in #2958):
+    // (Pulp's shared analytic toolbox):
     //   • special::elliptic_K(m)          AGM
     //   • special::jacobi_sncndn(u, m, …) NR §6.12 AGM back-substitution
     //   • special::jacobi_asn(x, m)       Carlson R_F inverse
@@ -449,8 +449,7 @@ private:
         // but `jacobi_asn` clamps its input to [−1, 1]. For any reasonable
         // ripple spec (Rp < ~3 dB ⇒ ε < 1 ⇒ 1/ε > 1), the input was
         // silently clamped to 1 and v0 collapsed to a constant independent
-        // of the user-supplied passband_ripple_db — i.e. the API stopped
-        // honoring its main ripple parameter (#2964, Codex 3305447117).
+        // of the user-supplied passband_ripple_db.
         //
         // The real `sc⁻¹(w, m')` for w ≥ 0, m' ∈ (0,1) can be reduced to a
         // domain-safe asn call. From sc² = sn²/cn² = sn²/(1−sn²):


### PR DESCRIPTION
Summary:
- Remove transient issue/review breadcrumbs from IIR elliptic-design comments.
- Preserve the current special-functions, SciPy ellipap, and ripple-parameter rationale unchanged.

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/|pulp #[0-9]|#[0-9]" core/signal/include/pulp/signal/iir_design.hpp -> no matches
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.97)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; git merge-base --is-ancestor origin/main HEAD -> 0
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (0.99)
- PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/iir-design-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/iir-design-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale issue/PR breadcrumbs and internal tool references from the IIR elliptic-design comments in `core/signal/include/pulp/signal/iir_design.hpp`. Kept the `special_functions.hpp` pointers and SciPy `ellipap`/ripple-parameter rationale; no code or API changes.

<sup>Written for commit f9b8ff3a1d453438e8968cc71c51b04a9bea64a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

