### PR TITLE
docs: clean audio placeholder comment archaeology

### DIFF
--- a/core/audio/src/placeholder.cpp
+++ b/core/audio/src/placeholder.cpp
@@ -1,2 +1,1 @@
-// pulp-audio: placeholder — replaced in Phase 2+
 namespace pulp::audio {}


### PR DESCRIPTION
Summary:
- Remove a stale phase placeholder breadcrumb from the audio placeholder translation unit.
- Leave the empty pulp::audio namespace in place so the source file remains a valid placeholder TU.

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/|pulp #[0-9]|#[0-9]" core/audio/src/placeholder.cpp -> no matches
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.98)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; git merge-base --is-ancestor origin/main HEAD -> 0
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (0.99)
- PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/audio-placeholder-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/audio-placeholder-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a stale phase breadcrumb comment from `core/audio/src/placeholder.cpp`. Kept the empty `pulp::audio` namespace so the file remains a valid placeholder translation unit; no behavior or API changes.

<sup>Written for commit 2af851db12c947763805b308fa6419480a8a6c58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

