### PR TITLE
docs: clean audio device manager comment archaeology

### DIFF
--- a/core/audio/include/pulp/audio/audio_device_manager.hpp
+++ b/core/audio/include/pulp/audio/audio_device_manager.hpp
@@ -1,27 +1,7 @@
 #pragma once
 
 /// @file audio_device_manager.hpp
-/// AudioDeviceManager — persistence + MIDI hub + lifecycle / recovery.
-///
-/// Phase A (item 1.2a, PR #2936): persistence + MIDI hub + smoothed
-/// CPU-load surface — all backend-agnostic, no platform listeners.
-///
-/// Phase B (item 1.2b, this slice):
-///   - Live device hotplug detection (the manager observes a
-///     `pulp::audio::AudioSystem`'s device-change callback and
-///     republishes a structured `DeviceChangeEvent` to its own
-///     subscribers; tests can inject events without an AudioSystem).
-///   - Default-device-change recovery (subscribers learn when the
-///     system default output/input flipped underneath them).
-///   - Sample-rate-change recovery (subscribers learn when the active
-///     device's sample rate changed).
-///   - xrun counter exposed via `xrun_count()` for UI polling.
-///   - MIDI endpoint lifetime tracking — `set_midi_endpoints()`
-///     records the current input/output endpoint snapshot and
-///     dispatches `MidiEndpointChange` events on add/remove.
-///   - Concurrent-callback shutdown — `latch_close()` blocks until
-///     every in-flight dispatch returns and turns subsequent
-///     dispatches into no-ops.
+/// AudioDeviceManager — persistence, MIDI routing, and lifecycle recovery.
 ///
 /// Responsibilities:
 ///   - Persists the user's selected audio device + sample rate + buffer
@@ -36,6 +16,14 @@
 ///   - Exposes a smoothed CPU-load signal (wraps
 ///     `pulp::audio::AudioProcessLoadMeasurer`) so a host UI can read
 ///     a stable percentage without poking the realtime callback.
+///   - Observes an `AudioSystem` device-change callback and republishes
+///     structured `DeviceChangeEvent` notifications for hotplug,
+///     default-device changes, sample-rate changes, and xruns.
+///   - Tracks MIDI endpoint snapshots with `set_midi_endpoints()` and
+///     dispatches `MidiEndpointChange` events on add/remove.
+///   - Makes shutdown explicit: `latch_close()` waits for in-flight
+///     dispatches to return and turns later dispatch attempts into
+///     no-ops.
 
 #include <pulp/audio/device.hpp>
 #include <pulp/audio/load_measurer.hpp>
@@ -64,7 +52,7 @@ namespace pulp::audio {
 /// `i` is enabled. Channels 64+ collapse onto bit 63 conservatively
 /// (Pulp targets stereo / multichannel-up-to-32, so this is fine for
 /// every shipping audio interface). Zero mask + non-zero channel count
-/// in `DeviceConfig` means "use the first N channels" (legacy default).
+/// in `DeviceConfig` means "use the first N channels".
 struct DeviceSelection {
     std::string output_device;
     std::string input_device;
@@ -431,9 +419,9 @@ private:
     /// unsubscribe path is allowed to probe multiple maps with the
     /// same id, so the id must be globally unique across all maps —
     /// otherwise destroying one subscription token can erase an
-    /// unrelated subscription that happens to share the numeric id
-    /// (see issue #2976 / PR #2970 Codex finding). Atomic so callers
-    /// don't need to hold any particular mutex to allocate one.
+    /// unrelated subscription that happens to share the numeric id.
+    /// Atomic so callers don't need to hold any particular mutex to
+    /// allocate one.
     std::atomic<uint64_t>                        next_token_id_{1};
 
     mutable std::mutex                           midi_mu_;


### PR DESCRIPTION
Summary:
- Replace phase/PR history in the AudioDeviceManager header with current responsibilities.
- Remove transient issue/Codex breadcrumbs from subscription-token comments while preserving the invariant rationale.
- Trim legacy phrasing from channel-mask documentation without changing the documented behavior.

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/|pulp #[0-9]|#[0-9]" core/audio/include/pulp/audio/audio_device_manager.hpp -> no matches
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.97)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; git merge-base --is-ancestor origin/main HEAD -> 0
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (0.97)
- PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/audio-device-manager-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/audio-device-manager-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes `AudioDeviceManager` header comments to reflect current responsibilities and remove obsolete phase history and transient issue/Codex breadcrumbs. Simplifies channel-mask wording and preserves the subscription-token ID uniqueness rationale; no API or behavior changes.

<sup>Written for commit d7827e2a761cbcf5f03e7db88e38cde3291ebd16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

