### PR TITLE
docs: clean buffer ops comment archaeology

### DIFF
--- a/core/audio/src/buffer_ops.cpp
+++ b/core/audio/src/buffer_ops.cpp
@@ -42,9 +42,9 @@ void apply_gain_ramp(BufferView<float> buffer, float start_gain, float end_gain)
 
 void clip(std::span<float> samples, float lo, float hi) {
     if (samples.empty()) return;
-    // Codex P1 on #2864 — `std::clamp` (Highway's clamp + simd_clamp's
-    // scalar tail) propagates NaN through the ordered comparisons, so
-    // delegating directly would leak NaN into downstream audio.
+    // `std::clamp` and `simd_clamp` scalar tails propagate NaN through
+    // ordered comparisons, so delegating directly would leak NaN into
+    // downstream audio.
     // Sanitize NaN → `lo` ourselves first, then delegate the clamp.
     for (auto& s : samples) {
         if (std::isnan(s)) s = lo;


### PR DESCRIPTION
Summary:
- Remove transient issue/Codex provenance from the buffer clipping NaN-sanitization comment.
- Preserve the current rationale for sanitizing NaN before delegating to simd_clamp.

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/|pulp #[0-9]|#[0-9]" core/audio/src/buffer_ops.cpp -> no matches
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.97)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; git merge-base --is-ancestor origin/main HEAD -> 0
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (0.97)
- PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/buffer-ops-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/buffer-ops-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned the NaN-sanitization comment in buffer_ops.cpp’s clip() by removing transient provenance and clarifying why we sanitize NaN before delegating to std::clamp/simd_clamp. Comment-only change; no behavior or API changes.

<sup>Written for commit 8ffac206fbd3cc88a65b98cd981308a0d2afd35e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

