### PR TITLE
docs: clean streaming sample source comment archaeology

### DIFF
--- a/core/audio/include/pulp/audio/streaming_sample_source.hpp
+++ b/core/audio/include/pulp/audio/streaming_sample_source.hpp
@@ -76,9 +76,8 @@ struct StreamingSampleSourceConfig {
     /// refill step). Clamped to the ring capacity. Ignored when fully resident.
     std::uint64_t read_chunk_frames = 8192;
 
-    /// Loop the playback. Honored only for fully-resident sources in this
-    /// version; streamed sources play once and then report finished(). (Streamed
-    /// looping is a documented follow-up — see the guide.)
+    /// Loop the playback. Honored only for fully-resident sources; streamed
+    /// sources play once and then report finished().
     bool loop = false;
     std::uint64_t loop_start = 0;        ///< Loop start frame (resident-loop only).
     std::uint64_t loop_end = 0;          ///< Loop end frame, exclusive; 0 means total_frames.


### PR DESCRIPTION
Summary:
- Remove follow-up/version-history phrasing from the StreamingSampleSource loop comment.
- Preserve the current behavior contract: looping is resident-only and streamed sources play once before finished().

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/|pulp #[0-9]|#[0-9]" core/audio/include/pulp/audio/streaming_sample_source.hpp -> no matches
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.98)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; git merge-base --is-ancestor origin/main HEAD -> 0
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (0.98)
- PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/streaming-sample-source-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/streaming-sample-source-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned the loop behavior comment in `StreamingSampleSourceConfig` (in `core/audio/include/pulp/audio/streaming_sample_source.hpp`) to remove follow-up/version-history wording and clarify the contract. Looping is honored only for fully resident sources; streamed sources play once and then report finished().

<sup>Written for commit 20fc8837a482deac773b9089ff257423e05dfe9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

