### PR TITLE
docs: clean aiff reader comment archaeology

### DIFF
--- a/core/audio/src/aiff_reader.cpp
+++ b/core/audio/src/aiff_reader.cpp
@@ -244,7 +244,7 @@ public:
                     sample = static_cast<float>(v) / 32768.0f;
                 } else if (bits_per_sample == 24) {
                     // Build the 24-bit word with unsigned arithmetic; a signed
-                    // left-shift of a byte >= 0x80 into bit 31 is UB (#2694).
+                    // left-shift of a byte >= 0x80 into bit 31 is undefined.
                     uint32_t raw = (static_cast<uint32_t>(p[0]) << 24) |
                                    (static_cast<uint32_t>(p[1]) << 16) |
                                    (static_cast<uint32_t>(p[2]) << 8);


### PR DESCRIPTION
Summary:
- Remove a transient issue breadcrumb from the AIFF 24-bit decode UB comment.
- Preserve the current unsigned-arithmetic rationale unchanged.

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/|pulp #[0-9]|#[0-9]" core/audio/src/aiff_reader.cpp -> no matches
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.99)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; git merge-base --is-ancestor origin/main HEAD -> 0
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (1)
- PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/aiff-reader-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/aiff-reader-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned the AIFF 24-bit decode comment by removing a stale issue reference and clarifying that a signed left shift into bit 31 is undefined. No behavior or API changes.

<sup>Written for commit 984fbc6668f6509090f3e36295879a21c2f107f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

