### PR TITLE
docs: clean audio probe comment archaeology

### DIFF
--- a/core/audio/include/pulp/audio/audio_probe.hpp
+++ b/core/audio/include/pulp/audio/audio_probe.hpp
@@ -1,19 +1,17 @@
 #pragma once
 
 /// @file audio_probe.hpp
-/// Realtime-safe audio output probe (the RT *producer* in the harness plan's
-/// two-layer split). `AudioProbe::analyze_output()` is callable from the audio
-/// callback and satisfies a strict RT ABI: no allocation, no std::vector
-/// growth, no locks, no file I/O, no logging, no exceptions, no UI/host/package
-/// callbacks, and NO FFT/STFT. It performs only bounded per-block scalar work
-/// (peak, RMS accumulate, clip count, NaN/Inf count, silence-run) and publishes
-/// the latest summary through a `runtime::TripleBuffer<AudioProbeSnapshot>`.
+/// Realtime-safe audio output probe. `AudioProbe::analyze_output()` is callable
+/// from the audio callback and satisfies a strict RT ABI: no allocation, no
+/// std::vector growth, no locks, no file I/O, no logging, no exceptions, no
+/// UI/host/package callbacks, and no FFT/STFT. It performs only bounded
+/// per-block scalar work (peak, RMS accumulate, clip count, NaN/Inf count,
+/// silence-run) and publishes the latest summary through a
+/// `runtime::TripleBuffer<AudioProbeSnapshot>`.
 ///
-/// See `planning/2026-06-09-audio-observability-and-validation-harness-plan.md`
-/// Section 4 "Runtime Probe Infrastructure". Do NOT model this on
-/// `pulp::view::VisualizationBridge` — that path runs STFT and returns
-/// std::vector copies inside the callback (it is explicitly quarantined as
-/// non-RT-safe). The RT-safe scalar contract lives here.
+/// Do not model this on `pulp::view::VisualizationBridge`: that path runs STFT
+/// and returns std::vector copies inside the callback, so it is not RT-safe.
+/// The RT-safe scalar contract lives here.
 ///
 /// Gating: the whole probe lives behind `PULP_ENABLE_AUDIO_PROBES`. The
 /// release-safe counter subset (`AudioStats`) is always available without this
@@ -93,8 +91,8 @@ public:
     /// Copy up to `max_frames` of the most recent captured channel-0 history
     /// into `dst` (UI/worker thread). Returns the number of frames written.
     /// Only meaningful when capture was enabled at prepare(). Non-RT; intended
-    /// for the consumer side. Kept as the legacy convenience reader over the
-    /// first channel of the multichannel capture ring.
+    /// for the consumer side. This is the single-channel convenience reader
+    /// over the first channel of the multichannel capture ring.
     int read_capture(float* dst, int max_frames);
 
     /// Copy up to `max_frames` of the most recent captured multichannel history

--- a/core/audio/include/pulp/audio/audio_probe_snapshot.hpp
+++ b/core/audio/include/pulp/audio/audio_probe_snapshot.hpp
@@ -4,9 +4,7 @@
 /// The realtime-produced probe summary — the *shared schema* between the RT
 /// producer (`pulp::audio::AudioProbe`, the audio callback) and the non-RT
 /// consumers (UI / offline analysis). Producer and consumers share this data
-/// type only; they NEVER share an implementation path
-/// (`planning/2026-06-09-audio-observability-and-validation-harness-plan.md`,
-/// Section 4, "Two layers, one schema").
+/// type only; they never share an implementation path.
 ///
 /// `AudioProbeSnapshot` is POD-like and trivially copyable so it can ride a
 /// `runtime::TripleBuffer` (latest-wins summary) without allocation. It is

--- a/core/audio/include/pulp/audio/audio_stats.hpp
+++ b/core/audio/include/pulp/audio/audio_stats.hpp
@@ -3,12 +3,9 @@
 /// @file audio_stats.hpp
 /// Small POD counter struct for release-safe audio observability.
 ///
-/// `AudioStats` is the always-available, minimal counter subset described in
-/// the audio observability harness plan
-/// (`planning/2026-06-09-audio-observability-and-validation-harness-plan.md`,
-/// Section 4 "Runtime Probe Infrastructure", "Release builds" tier). It is a
-/// trivially-copyable aggregate so it can be published lock-free and read on
-/// any thread.
+/// `AudioStats` is the always-available, minimal counter subset for release
+/// builds. It is a trivially-copyable aggregate so it can be published
+/// lock-free and read on any thread.
 ///
 /// OWNERSHIP BOUNDARY (do not relitigate without a code change):
 ///   - Signal-content counters — `callbacks`, `underruns`, `clipped_blocks`,


### PR DESCRIPTION
Summary:
- Remove internal planning-document breadcrumbs from audio probe observability header comments.
- Replace a stale legacy label with current single-channel reader wording.
- Preserve the realtime-safety, ownership-boundary, and API contract comments without behavior changes.

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/|pulp #[0-9]|#[0-9]" core/audio/include/pulp/audio/audio_probe.hpp core/audio/include/pulp/audio/audio_probe_snapshot.hpp core/audio/include/pulp/audio/audio_stats.hpp -> no matches
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.97)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; git merge-base --is-ancestor origin/main HEAD -> 0
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (0.97)
- PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/audio-probe-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/audio-probe-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clean up comments in `audio_probe.hpp`, `audio_probe_snapshot.hpp`, and `audio_stats.hpp`: remove planning breadcrumbs, update wording, and clarify the single‑channel capture reader. RT‑safety notes, ownership boundaries, and the API contract are unchanged; no behavior or API changes.

<sup>Written for commit f4834dad45b828b0a03561de0569c68b18665e6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

