### PR TITLE
docs: clean audio device comment archaeology

### DIFF
--- a/core/audio/include/pulp/audio/device.hpp
+++ b/core/audio/include/pulp/audio/device.hpp
@@ -123,11 +123,10 @@ public:
     using DeviceChangeCallback = std::function<void()>;
 
     /// Default implementation stores the callback in a base-class slot.
-    /// Non-macOS backends that gain real hotplug probing in later slices
-    /// (workstream 02 — WASAPI IMMNotificationClient, ALSA udev monitor,
-    /// Win32 MIDI DeviceWatcher, ALSA seq monitor) call `fire_device_change()`
-    /// when a change is detected. Backends with richer semantics can still
-    /// override this entirely.
+    /// Platform hotplug notifiers such as WASAPI IMMNotificationClient,
+    /// ALSA udev monitors, Win32 MIDI DeviceWatcher, and ALSA seq monitors
+    /// call `fire_device_change()` when a change is detected. Backends with
+    /// richer semantics can still override this entirely.
     virtual void set_device_change_callback(DeviceChangeCallback cb) {
         std::lock_guard<std::mutex> lock(device_change_callback_mutex_);
         if (cb) {
@@ -149,12 +148,8 @@ public:
     /// a pointer to an AudioSystem and invoke this method from an
     /// OS callback thread. C++ `protected` would require the access
     /// to go through the notifier's own derived-class `this`, which
-    /// doesn't apply here. MSVC enforces this strictly and failed
-    /// to build #281's WASAPI hotplug path (C2248 in
-    /// wasapi_device.cpp:339–341), silently breaking release-cli.yml
-    /// on Windows x64 for v0.15.0 and v0.16.0 tags. Clang/GCC were
-    /// lenient; making this public matches the design intent the
-    /// doc comment always described.
+    /// doesn't apply here. MSVC enforces this strictly; making this public
+    /// matches the design intent of the platform notifier callbacks.
     void fire_device_change() {
         std::shared_ptr<DeviceChangeCallback> callback;
         {


### PR DESCRIPTION
Summary:
- Remove workstream and issue-history breadcrumbs from the audio device hotplug comments.
- Preserve the current platform notifier and public fire_device_change() access rationale.

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/|pulp #[0-9]|#[0-9]" core/audio/include/pulp/audio/device.hpp -> no matches
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.97)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; git merge-base --is-ancestor origin/main HEAD -> 0
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (0.97)
- PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/device-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/device-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up audio device hotplug comments by removing historical breadcrumbs and clarifying how platform notifiers call `fire_device_change()`, and why it remains public. No behavior or API changes.

<sup>Written for commit 6bd8370cbf2f2e04910ea1beb6b685266a0b973b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

