### PR TITLE
docs: clean non-uniform convolver comment archaeology

### DIFF
--- a/core/signal/include/pulp/signal/convolver_non_uniform.hpp
+++ b/core/signal/include/pulp/signal/convolver_non_uniform.hpp
@@ -34,9 +34,9 @@
 ///   • short noise burst through a 4 096-tap IR matches the
 ///     direct-convolution reference within float epsilon.
 ///
-/// Background IR swap: a follow-up will mirror the uniform
-/// convolver's `ConvolverIrSwapper` for non-uniform IRs. Today,
-/// `load_ir()` rebuilds both stages inline (off-RT-thread).
+/// IR loading: unlike the uniform convolver, this class does not provide a
+/// background swapper. `load_ir()` rebuilds both stages inline and must be
+/// called off the audio thread.
 
 #include <pulp/signal/convolver.hpp>
 #include <pulp/signal/convolver_messages.hpp>


### PR DESCRIPTION
Summary:
- Replace the non-uniform convolver future follow-up breadcrumb with a current-state IR-loading limitation.
- Preserve the off-audio-thread load_ir() contract without behavior changes.

Validation:
- git diff --check
- rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/|pulp #[0-9]|#[0-9]" core/signal/include/pulp/signal/convolver_non_uniform.hpp -> no matches
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main -> clean, overall: patch is correct (0.97)
- git fetch origin main --prune; origin/main=d26f94f8a53cd177d1595eed0e1bc53668f9abcc; git merge-base --is-ancestor origin/main HEAD -> 0
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main -> clean, overall: patch is correct (0.97)
- PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/convolver-non-uniform-comment-hygiene -> pre-push gates clean, 29 tests
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/convolver-non-uniform-comment-hygiene -> pre-push gates clean, 29 tests

Notes:
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only change; no behavior/API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified non-uniform convolver docs by removing an outdated follow-up note and documenting the current IR-loading behavior. No code or API changes; there is no background swapper—`load_ir()` rebuilds both stages inline and must be called off the audio thread.

<sup>Written for commit 7d8604065e82e312bfe7b7a7dfb317f431c0165f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

