### PR TITLE
docs: clean spectral frame engine comment archaeology

### DIFF
--- a/core/signal/include/pulp/signal/spectral_frame_engine.hpp
+++ b/core/signal/include/pulp/signal/spectral_frame_engine.hpp
@@ -76,7 +76,7 @@ public:
         // Steady-state OLA window-energy at a fully-overlapped sample for
         // the analysis hop. Used to floor the per-sample normalization so
         // partial-overlap samples at stream edges taper to zero instead of
-        // being amplified by division by a near-zero coverage (pulp #3975).
+        // being amplified by division by a near-zero coverage.
         // The floor sits far below any real body coverage (down to a 4x
         // sparser synthesis hop), so body samples normalize unchanged.
         double steady = 0.0;
@@ -307,7 +307,7 @@ private:
     int num_bins_ = 0;
     int ring_size_ = 0;
     int ring_mask_ = 0;
-    float min_norm_ = 1e-9f;  // OLA coverage floor for edge taper (#3975)
+    float min_norm_ = 1e-9f;  // OLA coverage floor for stream-edge taper
 
     std::vector<float> input_ring_;     // channels * fft_size
     std::vector<float> output_ring_;    // channels * ring_size


### PR DESCRIPTION
## Summary
- remove stale issue-number breadcrumbs from SpectralFrameEngine OLA edge-floor comments
- keep the current stream-edge taper invariant documented without workflow history

## Validation
- git diff --check
- rg stale-marker scan on core/signal/include/pulp/signal/spectral_frame_engine.hpp
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/spectral-frame-engine-comment-hygiene

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

## Notes
- Comment-only hygiene; no behavior or API change.
- Commit carries `Version-Bump: sdk=skip reason="comment-only hygiene; no SDK behavior or API change"` because the fast gate classifies core/signal touches as SDK-affecting unless explicitly skipped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up `SpectralFrameEngine` comments by removing stale issue references and clarifying the OLA coverage floor as stream-edge taper. Comment-only change with no behavior or API impact.

<sup>Written for commit d8607d91ab43213031beb4582f15ef08d27cc86a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

