### PR TITLE
docs: clean signal non-finite comment archaeology

### DIFF
--- a/core/signal/include/pulp/signal/multi_channel_meter.hpp
+++ b/core/signal/include/pulp/signal/multi_channel_meter.hpp
@@ -170,7 +170,7 @@ public:
             for (int ch = 0; ch < num_channels; ++ch) {
                 float s = channels[ch][i];
                 // Non-finite samples (NaN/Inf) would poison RMS/LUFS/integrated
-                // accumulators irrecoverably (#2695). Treat them as silence.
+                // accumulators irrecoverably. Treat them as silence.
                 if (!std::isfinite(s)) s = 0.0f;
                 float abs_s = std::abs(s);
 

--- a/core/signal/include/pulp/signal/spectrogram.hpp
+++ b/core/signal/include/pulp/signal/spectrogram.hpp
@@ -29,9 +29,9 @@ public:
 
     /// Map a normalized value (0 = minimum, 1 = maximum) to a color.
     SpectrogramColor map(float t) const {
-        // std::clamp(NaN, …) returns NaN, which the ramps then cast to uint8_t
-        // (undefined behavior, #2695). Sanitize NaN to 0 first; ±Inf clamp
-        // safely to 1.0 / 0.0 below.
+        // std::clamp(NaN, …) returns NaN, which the ramps then cast to
+        // uint8_t. Sanitize NaN to 0 first; ±Inf clamps safely to 1.0 / 0.0
+        // below.
         if (std::isnan(t)) t = 0.0f;
         t = std::clamp(t, 0.0f, 1.0f);
 


### PR DESCRIPTION
## Summary
- remove stale `#2695` breadcrumbs from signal non-finite-sample comments
- keep the current NaN/Inf sanitization rationale in `MultiChannelMeter` and `ColorMapper` comments

## Validation
- git diff --check
- rg stale-marker scan on touched files
- python3 tools/scripts/docs_noise_lint.py --mode=report
- tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/signal-nan-comment-hygiene

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

## Notes
- Comment-only hygiene; no behavior or API change.
- Commit carries `Version-Bump: sdk=skip reason="comment-only hygiene; no SDK behavior or API change"` for audit clarity, though the fast gate reported no bump needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clean up non-finite sample handling comments by removing stale `#2695` breadcrumbs and clarifying NaN/Inf sanitization in `MultiChannelMeter` and `ColorMapper`.
Comment-only change; no behavior or API impact.

<sup>Written for commit 0b284c7b7f73694c846696ff5a01835eaf1469e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

