### PR TITLE
docs(events): clean event API comment breadcrumbs

### DIFF
--- a/core/events/include/pulp/events/in_app_purchase.hpp
+++ b/core/events/include/pulp/events/in_app_purchase.hpp
@@ -2,7 +2,7 @@
 
 // pulp::events::IapClient — cross-platform in-app purchase surface.
 //
-// Scope (this slice):
+// Supported operations:
 //   * Product lookup: `request_products(skus, callback)` resolves an SKU list
 //     into `Product` records (title / description / localized price).
 //   * Purchase: `purchase(sku, callback)` initiates a purchase flow and
@@ -13,7 +13,7 @@
 //     whenever the backend resolves a purchase asynchronously (out-of-band
 //     transactions, subscription renewals, family-sharing grants).
 //
-// Deferred (follow-up work, tracked in the gap doc):
+// Not currently implemented by the built-in backends:
 //   * Real StoreKit2 wiring on Apple platforms (sandbox round-trip).
 //   * Microsoft Store SDK wiring on Windows (currently a runtime-dlopen
 //     scaffold that reports `Unavailable`).
@@ -24,8 +24,8 @@
 //
 // Backends (runtime-detected; build never hard-fails on a missing SDK):
 //   * macOS / iOS: `StoreKit` (StoreKit 2 when available, StoreKit 1 fallback).
-//     This slice ships the interface + a stub that returns `Unavailable`;
-//     the real wiring lives in a follow-up so the build stays MIT-clean and
+//     The built-in backend currently returns `Unavailable`; production
+//     StoreKit wiring stays host-owned so the framework remains MIT-clean and
 //     doesn't pull in any non-public Apple framework headers at configure
 //     time.
 //   * Linux: no IAP surface; `is_available()` returns false.
@@ -115,7 +115,7 @@ public:
     virtual bool is_available() const = 0;
 
     /// Short identifier of the active backend ("storekit2", "winrt-store",
-    /// "test-mock", or "none"). Useful for diagnostics + the gap-doc audit.
+    /// "test-mock", or "none"). Useful for diagnostics and host reports.
     virtual std::string backend_id() const = 0;
 
     /// Ask the backend for metadata + localized pricing of the given SKUs.

--- a/core/events/include/pulp/events/push_notifications.hpp
+++ b/core/events/include/pulp/events/push_notifications.hpp
@@ -2,7 +2,7 @@
 
 // pulp::events::PushNotifications — cross-platform local notification surface.
 //
-// Scope (this slice):
+// Supported operations:
 //   * Local notifications: `post_local_notification(title, body, category)`
 //     posts a notification immediately through the host platform's user-
 //     notification surface.
@@ -11,7 +11,7 @@
 //   * Tap handler: `set_handler(callback)` registers a callback that fires
 //     when the user activates a delivered notification.
 //
-// Deferred (follow-up work, tracked in the gap doc):
+// Not currently implemented by the built-in backends:
 //   * Remote / push notifications via APNs (Apple) and FCM (Android).
 //   * Notification categories with custom action buttons.
 //   * Scheduled / time-triggered notifications.
@@ -77,7 +77,7 @@ public:
     virtual bool is_available() const = 0;
 
     /// Short identifier of the active backend ("user-notifications", "libnotify",
-    /// "winrt-toast", or "none"). Useful for diagnostics + the gap-doc audit.
+    /// "winrt-toast", or "none"). Useful for diagnostics and host reports.
     virtual std::string backend_id() const = 0;
 
     /// Ask the OS for permission to post notifications. The callback fires once

--- a/core/events/include/pulp/events/service_discovery.hpp
+++ b/core/events/include/pulp/events/service_discovery.hpp
@@ -2,8 +2,7 @@
 
 // pulp::events::ServiceBrowser / ServicePublisher — RAII wrappers around
 // NetworkServiceDiscovery for the common single-publish / single-browse
-// shapes called out in the reference-framework gap analysis (Phase 2:
-// "NetworkServiceDiscovery platform backends — Bonjour / Avahi / WinRT").
+// shapes.
 //
 // The underlying NSD object remains the configurable dispatcher when a
 // caller needs install_backend / multiple browses; these wrappers exist
@@ -28,7 +27,7 @@ enum class ServiceDiscoveryAction {
 
 /// Try to install the host platform's default mDNS backend on `nsd`.
 /// Returns true if a real backend was installed (Bonjour on Apple
-/// platforms today; Avahi / WinRT are deferred — see the gap doc).
+/// platforms today; Avahi / WinRT are not built in yet).
 /// Returns false when the build was not compiled with a backend for
 /// this OS, so callers can `install_backend(my_own)` and try again or
 /// log a clear "no mDNS available" message instead of silently

--- a/core/events/include/pulp/events/volume_detector.hpp
+++ b/core/events/include/pulp/events/volume_detector.hpp
@@ -51,16 +51,14 @@ private:
 
 /// mDNS-based network service discovery (Bonjour/DNS-SD).
 ///
-/// **Status — experimental (#302).** The core/events module ships
-/// the API surface but no concrete backend. `browse()` with no
+/// **Status — experimental.** The core/events module ships
+/// the API surface; platform backends are optional. `browse()` with no
 /// backend installed is a no-op (does not claim running); nothing
 /// will ever be discovered until a host application installs a
 /// backend via `install_backend()`. `register_service()` without
 /// a backend returns false.
 ///
-/// A future follow-up will ship per-platform backends
-/// (Bonjour/dns-sd on mac, Avahi on Linux, WinRT on Windows,
-/// NsdManager on Android). Until then consumers that need real
+/// Consumers that need real
 /// mDNS must supply their own backend (e.g., linking an
 /// application-owned Bonjour wrapper and plumbing the callbacks).
 class NetworkServiceDiscovery {
@@ -97,7 +95,7 @@ public:
                                       std::string_view type,
                                       uint16_t port) = 0;
         /// Default implementation drops the TXT records and forwards
-        /// to the legacy 3-arg register_service. Backends with real
+        /// to the base three-argument register_service. Backends with real
         /// TXT support (e.g., Bonjour) override this method.
         virtual bool register_service(std::string_view name,
                                       std::string_view type,


### PR DESCRIPTION
## Summary
- Clean stale workflow breadcrumbs from event API comments in `core/events` headers.
- Replace slice/phase/gap-doc/follow-up/issue-number wording with current behavior and backend-status descriptions.
- Comment-only change; no declarations, signatures, control flow, or runtime behavior changed.

## Validation
- `git diff --check origin/main..HEAD`
- stale-marker scan over touched files: no matches
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/events-api-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/events-api-comment-hygiene`

## Notes
RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

Version-Bump: sdk=skip reason="comment-only hygiene; no SDK behavior or API change"


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up event API header comments to remove stale “slice/phase/gap-doc” breadcrumbs and clarify supported operations and backend status across IAP, push notifications, and service discovery (mDNS). Comment-only change; no declarations, signatures, or behavior changed.

<sup>Written for commit 8dea48d61354a330047c18067c59ae2c7446500f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

