### PR TITLE
docs(events): clean discovery backend comment breadcrumbs

### DIFF
--- a/core/events/platform/mac/bonjour_backend.cpp
+++ b/core/events/platform/mac/bonjour_backend.cpp
@@ -13,11 +13,10 @@
 //     owning NetworkServiceDiscovery via notify_service_found /
 //     notify_service_lost, which mutate the dispatcher's cache and
 //     fire the user's std::function handlers.
-//   - The dispatcher itself is single-threaded (see the existing
-//     #310/#314 codex notes in volume_detector.cpp); ServiceBrowser /
-//     ServicePublisher own one NSD each, so there's no shared-state
-//     race here. Apps that share an NSD across threads must serialize
-//     externally — same contract as the rest of the dispatcher API.
+//   - The dispatcher itself expects serialized access. ServiceBrowser /
+//     ServicePublisher own one NSD each, so there's no shared-state race
+//     here. Apps that share an NSD across threads must serialize externally
+//     — same contract as the rest of the dispatcher API.
 //
 // Lifecycle:
 //   - stop() / unregister_service() call DNSServiceRefDeallocate on

--- a/core/events/platform/win/winrt_toast_backend.cpp
+++ b/core/events/platform/win/winrt_toast_backend.cpp
@@ -11,20 +11,19 @@
 //     (`SHGetPropertyStoreForWindow` + `IApplicationActivationManager`).
 //
 // Both of those impose significant packaging requirements on plugin
-// hosts that simply embed Pulp as a library, so the gap-doc scoping
-// for this slice is *local notifications only* with the Windows path
-// landing as a runtime-detected scaffold:
+// hosts that simply embed Pulp as a library, so the Windows backend is
+// currently a runtime-detected scaffold:
 //
 //   * At process start we attempt to LoadLibrary `combase.dll`. If the
 //     OS resolves it, we register a backend that reports
-//     `is_available() == false` (no real toast surface yet) but with
-//     `backend_id() == "winrt-toast-scaffold"` so the gap-doc audit
-//     can confirm the platform was probed.
-//   * Calling `post_local_notification` returns 0 and the gap-doc row
-//     stays "Partial" until the full COM-activator integration ships.
+//     `is_available() == false` because there is no real toast surface yet,
+//     but exposes `backend_id() == "winrt-toast-scaffold"` so diagnostics can
+//     confirm the platform was probed.
+//   * Calling `post_local_notification` returns 0 until full COM-activator
+//     integration is available.
 //
 // This keeps the Windows build green without lying about delivered
-// notifications, and gives the follow-up work a clearly-named
+// notifications, and gives the eventual WinRT implementation a clearly-named
 // extension point.
 
 #include <pulp/events/push_notifications.hpp>

--- a/core/events/src/volume_detector.cpp
+++ b/core/events/src/volume_detector.cpp
@@ -77,25 +77,22 @@ std::vector<std::string> MountedVolumeListChangeDetector::get_mounted_volumes() 
 
 // ── NetworkServiceDiscovery ─────────────────────────────────────────────
 //
-// #302: the core is a dispatcher that delegates to an installed
-// Backend. Without a backend, every op is an honest no-op — browse()
-// does NOT set running_=true (that was the pre-#302 stub's silent-
-// success bug), register_service() returns false. A future follow-up
-// ships concrete backends (dns-sd on mac, Avahi on linux, etc.).
+// The core is a dispatcher that delegates to an installed Backend.
+// Without a backend, every operation is an honest no-op: browse()
+// does not set running_=true, and register_service() returns false.
+// Concrete platform backends are installed by platform-specific code.
 
 NetworkServiceDiscovery::~NetworkServiceDiscovery() { stop(); }
 
 void NetworkServiceDiscovery::install_backend(std::unique_ptr<Backend> backend) {
-    // Codex P2 on #310: swapping backends clears the cached
-    // discoveries so stale services from the previous backend don't
-    // leak into queries against the new one.
+    // Swapping backends clears the cached discoveries so stale services
+    // from the previous backend don't leak into queries against the new one.
     //
-    // Codex P2 follow-up on #314: assign backend_ BEFORE emitting
-    // on_service_lost, not after. If a subscriber's on_service_lost
-    // handler re-enters the NSD API (has_backend(), register_service(),
-    // etc.) while we're evicting, it must see the NEW backend state,
-    // not the old one we just tore down via stop(). Swap first, then
-    // drain lost-callbacks.
+    // Assign backend_ before emitting on_service_lost, not after. If a
+    // subscriber's on_service_lost handler re-enters the NSD API
+    // (has_backend(), register_service(), etc.) while we're evicting, it
+    // must see the new backend state, not the old one we just tore down via
+    // stop(). Swap first, then drain lost-callbacks.
     stop();
     backend_ = std::move(backend);
     if (!services_.empty()) {
@@ -148,12 +145,11 @@ void NetworkServiceDiscovery::unregister_service() {
 }
 
 void NetworkServiceDiscovery::notify_service_found(const Service& svc) {
-    // Codex P2 on #310: re-announces from the same backend must
-    // refresh the cached entry (hostname/address/port can change
-    // when a service restarts on a new port or moves to a new IP)
-    // instead of silently dropping. Match by (name, type); replace
-    // the entry if anything else differs and fire on_service_found
-    // so subscribers learn about the change.
+    // Re-announces from the same backend refresh the cached entry:
+    // hostname/address/port can change when a service restarts on a new
+    // port or moves to a new IP. Match by (name, type); replace the entry
+    // if anything else differs and fire on_service_found so subscribers
+    // learn about the change.
     for (auto& existing : services_) {
         if (existing.name == svc.name && existing.type == svc.type) {
             const bool changed =


### PR DESCRIPTION
## Summary
- Clean stale issue/PR/Codex/gap-doc breadcrumbs from event discovery backend comments.
- Preserve the useful current-behavior content: serialized dispatcher access, backend-swap ordering, re-announce refresh semantics, and Windows toast scaffold behavior.
- Comment-only change; no declarations, signatures, control flow, or runtime behavior changed.

## Validation
- `git diff --check origin/main..HEAD`
- stale-marker scan over touched files: no matches
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/events-discovery-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/events-discovery-comment-hygiene`

## Notes
RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

Version-Bump: sdk=skip reason="comment-only hygiene; no SDK behavior or API change"


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned event discovery backend comments to remove stale issue/PR/Codex/gap-doc breadcrumbs and clarify current behavior across macOS, Windows, and the core dispatcher; no code or runtime changes.
Preserves key notes on serialized dispatcher access, backend swap ordering, re-announce refresh semantics, and the Windows `winrt-toast-scaffold` behavior.

<sup>Written for commit 06268f3a130a51d25b09136225025043f421c554. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

