### PR TITLE
docs(platform): clean clipboard comment breadcrumbs

### DIFF
--- a/core/platform/include/pulp/platform/clipboard.hpp
+++ b/core/platform/include/pulp/platform/clipboard.hpp
@@ -10,7 +10,7 @@ namespace pulp::platform {
 
 // Cross-platform clipboard access.
 //
-// Platform notes (#300):
+// Platform notes:
 //   - macOS/iOS: real NSPasteboard / UIPasteboard integration.
 //   - Windows: real OpenClipboard/SetClipboardData integration.
 //   - Linux: shells out to wl-copy/wl-paste (Wayland) or xclip/xsel
@@ -33,10 +33,9 @@ public:
     static bool set_data(const std::string& type, const std::vector<uint8_t>& data);
     static std::optional<std::vector<uint8_t>> get_data(const std::string& type);
 
-    // Android JNI bridge (#300). The Android app registers a bridge
-    // backed by Kotlin ClipboardManager calls; without one, the
-    // Android impl fails closed (returns false/nullopt) rather than
-    // fake-succeeding.
+    // Android JNI bridge. The Android app registers a bridge backed by
+    // Kotlin ClipboardManager calls; without one, the Android impl fails
+    // closed (returns false/nullopt) rather than fake-succeeding.
     struct AndroidBridge {
         std::function<bool(const std::string&)>       set_text;
         std::function<std::optional<std::string>()>   get_text;

--- a/core/platform/platform/linux/clipboard_linux.cpp
+++ b/core/platform/platform/linux/clipboard_linux.cpp
@@ -1,13 +1,9 @@
 // Linux clipboard implementation — shells out to system clipboard
 // utilities (`wl-copy`/`wl-paste` on Wayland, `xclip`/`xsel` on X11).
 //
-// #300: the old implementation returned `true` for set_text without
-// touching the OS clipboard, which was fake-success — copy/paste
-// looked to work inside Pulp but didn't reach other applications on
-// the user's desktop. This impl either really writes to the system
-// clipboard OR returns false so callers can detect the unsupported
-// case. No in-process shadow storage: if the tool is missing we say
-// so honestly.
+// This implementation either really writes to the system clipboard or returns
+// false so callers can detect the unsupported case. No in-process shadow
+// storage: if the tool is missing we say so honestly.
 //
 // Tooling detection is lazy (first-call stat) and cached. The tool
 // chosen at startup is the one used for the lifetime of the process —
@@ -57,10 +53,9 @@ const Tools& resolve_tools() {
         // fall back to X11 tools otherwise.
         const char* wayland = std::getenv("WAYLAND_DISPLAY");
         if (wayland && *wayland && which_exists("wl-copy") && which_exists("wl-paste")) {
-            // #320 Codex P1: wl-paste appends a newline by default.
-            // Pass -n so get_text() returns the exact bytes
-            // wl-copy received. xclip/xsel preserve bytes without
-            // a flag; only Wayland needs this.
+            // wl-paste appends a newline by default. Pass -n so get_text()
+            // returns the exact bytes wl-copy received. xclip/xsel preserve
+            // bytes without a flag; only Wayland needs this.
             return {Backend::wl_clipboard, "wl-copy", "wl-paste -n"};
         }
         if (which_exists("xclip")) {
@@ -134,23 +129,17 @@ std::optional<std::string> Clipboard::get_text() {
     std::lock_guard lock(mutex());
     const auto& tools = resolve_tools();
     if (tools.backend == Backend::none) return std::nullopt;
+    // Do not strip a trailing '\n'. xclip/wl-paste preserve the selection
+    // bytes as-is; content that legitimately ends with '\n' would lose a byte
+    // on round-trip if we stripped it.
     return capture_command(tools.paste_cmd);
-    // #309 Codex P2: do NOT strip a trailing '\n'. xclip/wl-paste
-    // preserve the selection bytes as-is — they don't synthesize a
-    // newline. Content that legitimately ends with '\n' would lose a
-    // byte on round-trip if we stripped. The previous comment in
-    // this function was wrong; preserving the byte stream is the
-    // correct round-trip for set_text/get_text.
 }
 
 bool Clipboard::has_text() {
-    // #309 Codex P2: "text present" must include the empty string,
-    // not treat it as absent. An application that set "" should
-    // observe has_text() == true. Report true iff the paste command
-    // succeeded — the pasted value's length is orthogonal to whether
-    // a text selection exists. On platforms where paste always
-    // succeeds (wl-paste -l / xclip -o return cleanly for empty
-    // selections), this tracks the native clipboard API semantics.
+    // "Text present" includes the empty string. An application that set ""
+    // should observe has_text() == true. Report true iff the paste command
+    // succeeded; the pasted value's length is orthogonal to whether a text
+    // selection exists.
     std::lock_guard lock(mutex());
     const auto& tools = resolve_tools();
     if (tools.backend == Backend::none) return false;

--- a/core/platform/platform/win/clipboard_win.cpp
+++ b/core/platform/platform/win/clipboard_win.cpp
@@ -3,10 +3,9 @@
 // The previous implementation stored text/data in process-local maps
 // (`g_text`/`g_data`), which fake-succeeded: copy/paste looked to work inside
 // Pulp but never reached the system clipboard, so other applications saw
-// nothing (the #300 anti-pattern this file now fixes for Windows, mirroring
-// the Linux clipboard's honest wl-copy/xclip path). This impl talks to the OS
-// clipboard or returns false/nullopt so callers can detect the unsupported
-// case (e.g. a session with no window station). No in-process shadow storage.
+// nothing. This implementation talks to the OS clipboard or returns
+// false/nullopt so callers can detect the unsupported case (e.g. a session with
+// no window station). No in-process shadow storage.
 //
 // Text is exchanged as CF_UNICODETEXT (UTF-16), converted to/from UTF-8 at the
 // boundary. Binary blobs use a per-type registered clipboard format

--- a/core/platform/src/clipboard_common.cpp
+++ b/core/platform/src/clipboard_common.cpp
@@ -1,4 +1,4 @@
-// Clipboard bridge no-op on non-Android platforms (#300).
+// Clipboard bridge no-op on non-Android platforms.
 //
 // The Android bridge API on Clipboard::set_android_bridge /
 // clear_android_bridge is public so callers don't need to guard


### PR DESCRIPTION
## Summary
- Clean stale issue/Codex breadcrumbs from clipboard comments in `core/platform`.
- Preserve the useful current-behavior notes: real OS clipboard or fail-closed, Wayland byte preservation, trailing newline preservation, and empty-string `has_text()` semantics.
- Comment-only change; no declarations, signatures, control flow, or runtime behavior changed.

## Validation
- `git diff --check origin/main..HEAD`
- stale-marker scan over touched files: no matches
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/platform-clipboard-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/platform-clipboard-comment-hygiene`

## Notes
RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

Version-Bump: sdk=skip reason="comment-only hygiene; no SDK behavior or API change"


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale issue/Codex breadcrumbs from clipboard comments across `core/platform`. Clarifies current behavior (real OS clipboard or fail-closed, Wayland `wl-paste -n` byte preservation, trailing newline preserved, and `has_text()` includes empty string) with no API or runtime changes.

<sup>Written for commit 969f5911fee25c06512a220013ab5908ded97731. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

