### PR TITLE
docs(platform): clean file dialog comment breadcrumbs

### DIFF
--- a/core/platform/include/pulp/platform/file_dialog.hpp
+++ b/core/platform/include/pulp/platform/file_dialog.hpp
@@ -15,7 +15,7 @@ struct FileFilter {
 
 // Native file open/save dialogs.
 //
-// Platform notes (#301):
+// Platform notes:
 //   - macOS/iOS: native NSOpenPanel/NSSavePanel/UIDocumentPicker.
 //   - Windows/Linux/Android: requires a host-registered Backend via
 //     FileDialog::set_backend(). Without one, every call returns
@@ -50,7 +50,7 @@ public:
         const std::string& title = "Choose Folder",
         const std::string& default_path = "");
 
-    // ── Host-registered backend (#301) ──────────────────────────────────
+    // ── Host-registered backend ────────────────────────────────────────
     //
     // On platforms without a native built-in backend (Windows,
     // Linux, Android) the host app can install a backend that

--- a/core/platform/platform/linux/file_dialog_portal_linux.cpp
+++ b/core/platform/platform/linux/file_dialog_portal_linux.cpp
@@ -1,4 +1,4 @@
-// Linux file dialogs via xdg-desktop-portal (#301 / L6).
+// Linux file dialogs via xdg-desktop-portal.
 //
 // The desktop portal (org.freedesktop.portal.Desktop, FileChooser
 // interface) is the toolkit-agnostic way to raise a native file picker on
@@ -9,11 +9,10 @@
 // call honest-fails (nullopt / {}) so the JS bridge can distinguish "user
 // cancelled" from "platform unsupported".
 //
-// Scope (MVP): open one/many files, save (with a suggested name), and choose
-// a folder. File-type filters and a pre-selected folder are intentionally
-// deferred — the portal marshals those as nested (a(sa(us)) / ay) variants
-// the minimal DBus client does not yet emit; the dialog still works without
-// them (it just shows all files / the portal's default folder). See L6 notes.
+// Supported operations: open one/many files, save with a suggested name, and
+// choose a folder. File-type filters and a pre-selected folder are not wired
+// through this minimal DBus client yet; the dialog still works without them
+// and shows all files / the portal's default folder.
 //
 // This is a real built-in backend (like file_dialog_mac.mm), not a
 // host-registered one: make_linux_portal_backend() is referenced from

--- a/core/platform/platform/win/file_dialog_win.cpp
+++ b/core/platform/platform/win/file_dialog_win.cpp
@@ -1,4 +1,4 @@
-// Windows native file dialogs via the Vista+ IFileDialog COM API (#301 / W5).
+// Windows native file dialogs via the Vista+ IFileDialog COM API.
 //
 // Windows previously had no file_dialog impl — calls fell through to the
 // backend-routed stub and returned "no selection". This provides a real
@@ -8,9 +8,9 @@
 // per call (apartment-threaded) and torn down after, so the dialog works
 // regardless of the caller's COM state.
 //
-// Scope (MVP, matching the Linux portal backend): open one/many, save (with a
-// suggested name), and choose-folder. File-type filters and a preselected
-// folder are a follow-up — the dialog works without them. CLSIDs/IIDs are
+// Supported operations, matching the Linux portal backend: open one/many, save
+// with a suggested name, and choose-folder. File-type filters and a preselected
+// folder are not wired yet, but the dialog works without them. CLSIDs/IIDs are
 // resolved with __uuidof / IID_PPV_ARGS so we don't depend on the named GUID
 // constants in uuid.lib; only ole32 is linked.
 

--- a/core/platform/src/file_dialog_stub.cpp
+++ b/core/platform/src/file_dialog_stub.cpp
@@ -6,9 +6,8 @@
 // non-Apple platforms (Windows, Linux, Android) the open/save/folder
 // dialog methods route through
 // the registered backend; without one every call returns an explicit
-// "no selection" (#301 P1 — replaces the old silent-nullopt stubs
-// so the JS bridge can distinguish "user cancelled" from "platform
-// unsupported").
+// "no selection" so the JS bridge can distinguish "user cancelled" from
+// "platform unsupported".
 
 #include <pulp/platform/file_dialog.hpp>
 
@@ -27,7 +26,7 @@
 
 // TargetConditionals provides TARGET_OS_OSX / TARGET_OS_IOS macros
 // so has_backend() can narrow its unconditional-true to macOS only
-// (Apple has no built-in file_dialog impl on iOS yet — #316 P2).
+// (Apple has no built-in file_dialog impl on iOS yet).
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
 #endif
@@ -106,13 +105,11 @@ bool file_dialog_open_file_via_backend(const std::string& title,
 }  // namespace detail
 
 bool FileDialog::has_backend() {
-    // #312 + #316 Codex P2s: report "true" only on platforms where a
-    // real native dialog impl is compiled in. macOS ships
-    // file_dialog_mac.mm; iOS does NOT have a built-in file_dialog
-    // impl yet (UIDocumentPicker wiring is a follow-up). Narrow the
-    // unconditional-true to macOS only; iOS and everyone else
-    // reflect the host-registered state so callers get honest
-    // "unsupported" signaling until the iOS impl lands.
+    // Report "true" only on platforms where a real native dialog impl is
+    // compiled in. macOS ships file_dialog_mac.mm; iOS does not have a
+    // built-in file_dialog impl yet. Narrow the unconditional-true to macOS
+    // only; iOS and everyone else reflect the host-registered state so callers
+    // get honest "unsupported" signaling until a backend is installed.
 #if defined(__APPLE__) && TARGET_OS_OSX
     return true;
 #else
@@ -121,13 +118,12 @@ bool FileDialog::has_backend() {
 #endif
 }
 
-// iOS has no built-in file_dialog backend (no `file_dialog_ios.mm` yet —
-// #316 P2). Without these definitions the link step for any iOS bundle
-// that pulls pulp-view-core fails on Undefined symbols for
-// FileDialog::{open_file, save_file, choose_folder}. Provide the same
-// backend-routed fallback that the non-Apple stub uses so the symbols
-// exist; until a real UIDocumentPicker impl lands callers get an honest
-// "no backend installed" nullopt instead of a link error.
+// iOS has no built-in file_dialog backend (no `file_dialog_ios.mm` yet).
+// Without these definitions the link step for any iOS bundle that pulls
+// pulp-view-core fails on undefined symbols for FileDialog::{open_file,
+// save_file, choose_folder}. Provide the same backend-routed fallback that the
+// non-Apple stub uses so the symbols exist; until a backend is installed
+// callers get an honest "no backend installed" nullopt instead of a link error.
 #if !defined(__APPLE__) || (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
 
 std::optional<std::string> FileDialog::open_file(


### PR DESCRIPTION
## Summary
- Clean stale issue/wave/MVP/follow-up breadcrumbs from file-dialog comments in `core/platform`.
- Preserve the current backend contract notes: backend-routed fallbacks, unsupported-vs-cancel distinction, macOS-only built-in availability, and unwired filter/default-folder behavior.
- Comment-only change; no declarations, preprocessor guards, control flow, or runtime behavior changed.

## Validation
- `git diff --check origin/main..HEAD`
- stale-marker scan over touched files: no matches
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/platform-file-dialog-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/platform-file-dialog-comment-hygiene`

## Notes
RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

Version-Bump: sdk=skip reason="comment-only hygiene; no SDK behavior or API change"


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned stale issue references and breadcrumbs in file dialog comments across `core/platform`. Clarifies current behavior (backend fallbacks, cancel vs unsupported, macOS-only built-in, filters/default folder not wired) with comment-only changes; no API or runtime changes.

<sup>Written for commit 8e102b7fff72b79913e8bfd937adbf44b0230b91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

