### PR TITLE
docs(platform): clean environment comment breadcrumbs

### DIFF
--- a/core/platform/include/pulp/platform/environment.hpp
+++ b/core/platform/include/pulp/platform/environment.hpp
@@ -218,7 +218,6 @@ private:
     // either by another listener during the same dispatch or by a
     // different thread calling `Token::reset()`. Using shared_ptr so
     // the copy in `publish` and the live list share the same flag.
-    // See #403 Codex P1 review.
     struct Entry {
         uint64_t id;
         Listener fn;
@@ -252,7 +251,6 @@ void start_environment_observer_linux();
 #if defined(_WIN32)
 void start_environment_observer_win();
 #endif
-// void start_environment_observer_android(); // follow-up
 
 // Use Apple's TargetConditionals.h macro rather than the CMake-defined
 // PULP_IOS variable — the CMake iOS branch adds environment_ios.mm to
@@ -261,7 +259,6 @@ void start_environment_observer_win();
 // try to link start_environment_observer_mac() (which is not in the
 // iOS source set). TARGET_OS_IPHONE is always defined on Apple via
 // TargetConditionals.h and is 1 only for iOS/tvOS/watchOS.
-// See #438 P1 Codex review on #445.
 inline void start_environment_observer() {
 #if defined(__APPLE__) && TARGET_OS_IPHONE
     start_environment_observer_ios();
@@ -272,8 +269,7 @@ inline void start_environment_observer() {
 #elif defined(_WIN32)
     start_environment_observer_win();
 #endif
-    // Other platforms wire their adapters in follow-up PRs; until then
-    // their hosts simply see the EnvironmentState defaults.
+    // Platforms without an observer keep the EnvironmentState defaults.
 }
 
 } // namespace pulp::platform

--- a/core/platform/platform/linux/environment_linux.cpp
+++ b/core/platform/platform/linux/environment_linux.cpp
@@ -1,4 +1,4 @@
-// Linux adapter for the unified Environment API (#342).
+// Linux adapter for the unified Environment API.
 //
 // Linux desktop has no single OS-level "environment changed" channel
 // the way macOS (NSApp), Windows (WM_*) and the mobile platforms do.
@@ -23,8 +23,8 @@
 // This is a minimal adapter — pure-stdlib + libX11/Xrandr where
 // available. It's deliberately heuristic: full XSettings would pull
 // in libxsettings-client; full Wayland output info needs the
-// wl_registry dance. Both can land in a follow-up if a real desktop
-// integration needs more fidelity.
+// wl_registry dance; this minimal adapter intentionally avoids that extra
+// dependency until a real desktop integration needs more fidelity.
 
 #if defined(__linux__) && !defined(__ANDROID__)
 
@@ -177,7 +177,7 @@ public:
         // (or an unloaded plugin module) doesn't destroy a still-
         // joinable std::thread — which calls std::terminate(). The
         // 5 s sleep means worst-case we block for 5 s at shutdown;
-        // acceptable for a singleton observer. See #438 P1 / #444.
+        // acceptable for a singleton observer.
         running_.store(false, std::memory_order_release);
         if (poll_thread_.joinable()) {
             poll_thread_.join();

--- a/core/platform/platform/win/environment_win.cpp
+++ b/core/platform/platform/win/environment_win.cpp
@@ -1,4 +1,4 @@
-// Windows adapter for the unified Environment API (#342).
+// Windows adapter for the unified Environment API.
 //
 // Pure Win32 — no UWP/WinRT — so this works in every plugin host
 // (DAW process, standalone, AAX wrapper) regardless of WinRT init.

--- a/core/platform/src/environment.cpp
+++ b/core/platform/src/environment.cpp
@@ -117,7 +117,6 @@ void Environment::publish(const EnvironmentState& next) {
         // Token::reset() between the snapshot and now, entry.active
         // is false and we must skip — otherwise the callback fires
         // against captures whose owner has already been destroyed.
-        // See #403 Codex P1.
         if (entry.active
             && !entry.active->load(std::memory_order_acquire)) {
             continue;


### PR DESCRIPTION
## Summary
- Clean stale issue/PR/review breadcrumbs from platform environment observer comments.
- Preserve the useful current-behavior notes: listener active-flag dispatch safety, Apple target-condition selection, Linux heuristic observer tradeoffs, and default EnvironmentState behavior on platforms without an observer.
- Comment-only change; no declarations, preprocessor guards, control flow, or runtime behavior changed.

## Validation
- `git diff --check origin/main..HEAD`
- stale-marker scan over touched files: no matches
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/platform-environment-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/platform-environment-comment-hygiene`

## Notes
RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

Version-Bump: sdk=skip reason="comment-only hygiene; no SDK behavior or API change"


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale issue/PR breadcrumbs from platform environment comments to improve clarity. Kept notes on listener active-flag safety, Apple `TargetConditionals` selection, Linux heuristic tradeoffs, and default behavior when no observer exists; no code or runtime changes.

<sup>Written for commit 7f662f5768c32ee37dd29e77d546029d9f89504d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

