### PR TITLE
docs(host): clean scan cache comment breadcrumbs

### DIFF
--- a/core/host/include/pulp/host/background_scanner.hpp
+++ b/core/host/include/pulp/host/background_scanner.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-// Background plugin scanning (workstream 03 slice 3.2).
+// Background plugin scanning.
 //
 // Wraps any scan function in a worker-thread driver with cooperative
 // cancellation and progress callbacks. Settings-panel UIs subscribe to

--- a/core/host/include/pulp/host/isolated_scanner.hpp
+++ b/core/host/include/pulp/host/isolated_scanner.hpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-// Crash-isolated plugin scanner (macOS plan item 4.1).
+// Crash-isolated plugin scanner.
 //
 // Loads a single plugin bundle in a CHILD PROCESS via the canonical
 // `pulp::platform::ChildProcess` API + the pre-existing
@@ -10,8 +10,7 @@
 // `ScanResult` with a structured `ScanStatus` instead of taking down
 // the host.
 //
-// Builds on PR #2815 (ChildProcess) and workstream 03 slice 3.3b
-// (`pulp-scan-worker` binary).
+// Uses the `pulp-scan-worker` binary.
 //
 // Usage:
 //   pulp::host::IsolatedPluginScanner s{worker_path};

--- a/core/host/include/pulp/host/scan_blacklist.hpp
+++ b/core/host/include/pulp/host/scan_blacklist.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-// Scan blacklist (workstream 03 slice 3.3a) — companion to HostScanCache.
+// Scan blacklist companion to HostScanCache.
 //
-// When a plugin crashes the scanner, the out-of-process scan worker
-// (slice 3.3b, lands separately) records the plugin path + its (mtime,
-// size) pair here. Subsequent scans skip blacklisted entries entirely
-// so one bad plugin can't loop the entire scan on every startup.
+// When a plugin crashes the scanner, the out-of-process scan worker records
+// the plugin path + its (mtime, size) pair here. Subsequent scans skip
+// blacklisted entries entirely so one bad plugin can't loop the entire scan
+// on every startup.
 //
 // Format is a newline-delimited text file — one entry per line — so a
 // user can hand-edit if they want to retry a blacklisted plugin. Lines

--- a/core/host/include/pulp/host/scan_cache.hpp
+++ b/core/host/include/pulp/host/scan_cache.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-// Persistent plugin scan cache — workstream 03 slice 3.1.
+// Persistent plugin scan cache.
 //
 // Stores PluginInfo results keyed by (path, mtime, size). On the second scan
 // of an unchanged plugin file, the cache returns the stored PluginInfo

--- a/core/host/src/scan_cache.cpp
+++ b/core/host/src/scan_cache.cpp
@@ -70,9 +70,8 @@ choc::value::Value entry_to_json(const std::string& path,
     obj.addMember("num_inputs", e.info.num_inputs);
     obj.addMember("num_outputs", e.info.num_outputs);
 
-    // Richer metadata (workstream 03 slice 3.7). Emit as additive fields
-    // so older schema-v1 blobs (without them) still parse via defaults
-    // on the reader side.
+    // Emit richer metadata as additive fields so older schema-v1 blobs
+    // without them still parse via defaults on the reader side.
     obj.addMember("category", e.info.category);
     obj.addMember("description", e.info.description);
     obj.addMember("has_editor", e.info.has_editor);
@@ -111,8 +110,8 @@ bool entry_from_json(const choc::value::ValueView& v,
     out_entry.info.num_outputs =
         v.hasObjectMember("num_outputs") ? v["num_outputs"].getInt64() : 2;
 
-    // Richer metadata (workstream 03 slice 3.7). All additive; missing
-    // fields preserve struct defaults for older schema-v1 blobs.
+    // Richer metadata is additive; missing fields preserve struct defaults
+    // for older schema-v1 blobs.
     out_entry.info.category =
         v.hasObjectMember("category") ? v["category"].toString() : "";
     out_entry.info.description =


### PR DESCRIPTION
## Summary
- Remove stale workstream/slice/PR/plan breadcrumbs from host scan cache, blacklist, background scanner, and isolated scanner comments.
- Preserve the current behavior notes for child-process scan isolation, cache additive metadata, and blacklist stamp semantics.

## Validation
- `git diff --check origin/main..HEAD`
- `rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/|pulp #[0-9]|#[0-9]|gap doc|gap-doc|slice|codex notes|P[0-9]" <touched files>` (no matches; exit 1 expected)
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/host-scan-cache-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/host-scan-cache-comment-hygiene`

## Notes
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only hygiene; no runtime behavior or SDK API change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up comments in host scan cache, blacklist, background scanner, and isolated scanner to remove stale breadcrumbs. Runtime behavior and SDK APIs are unchanged; existing notes on child-process isolation, additive cache metadata, and blacklist semantics are preserved.

<sup>Written for commit 85a6055b90c9d2a0ec609ec388c62a2b2e11ff50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

