### PR TITLE
docs(audio): clean focus runtime comment breadcrumbs

### DIFF
--- a/core/audio/include/pulp/audio/audio_focus.hpp
+++ b/core/audio/include/pulp/audio/audio_focus.hpp
@@ -16,8 +16,8 @@
 // but neither is ever called from the audio thread.
 //
 // Shape mirrors pulp::platform::Environment so clients see a consistent
-// observer pattern across system-signal surfaces. iOS support goes
-// through AVAudioSession interruption notifications in a future slice;
+// observer pattern across system-signal surfaces. iOS support uses
+// AVAudioSession interruption notifications when that backend is present;
 // on platforms without an OS-level audio-focus concept (desktop
 // macOS/Linux/Windows) the registry stays idle and reports `gained`.
 

--- a/core/audio/include/pulp/audio/instrument_runtime.hpp
+++ b/core/audio/include/pulp/audio/instrument_runtime.hpp
@@ -19,7 +19,7 @@ public:
     // guaranteed. This currently resolves pool-backed zones only; direct
     // PublishedSampleView zones remain usable through ZoneSelector. Trigger
     // policy only: voice allocation, choke groups, modulation buffers,
-    // streaming, and rendering remain separate runtime slices.
+    // streaming, and rendering remain owned by their dedicated runtime paths.
     static InstrumentTriggerResult trigger(const SampleZoneMap& zone_map,
                                            const SamplePool& sample_pool,
                                            const ZoneSelectionRequest& request) noexcept;


### PR DESCRIPTION
## Summary
- Remove stale slice-oriented wording from audio focus and instrument runtime comments.
- Preserve current ownership and backend-boundary descriptions without changing API or behavior.

## Validation
- `git diff --check origin/main..HEAD`
- `rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/|pulp #[0-9]|#[0-9]|gap doc|gap-doc|slice|codex notes|P[0-9]" <touched files>` (no matches; exit 1 expected)
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/audio-focus-runtime-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/audio-focus-runtime-comment-hygiene`

## Notes
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only hygiene; no runtime behavior or SDK API change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned and clarified runtime comments in `core/audio/include/pulp/audio/audio_focus.hpp` and `core/audio/include/pulp/audio/instrument_runtime.hpp`. Removed stale slice-oriented wording, clarified that iOS uses AVAudioSession interruption notifications when that backend is present, and tightened language around runtime ownership; no API or behavior changes.

<sup>Written for commit 603f87106a66f88d0c005e01f9cd243e9576de46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

