### PR TITLE
docs(midi): clean byte stream comment breadcrumbs

### DIFF
--- a/core/midi/include/pulp/midi/buffer.hpp
+++ b/core/midi/include/pulp/midi/buffer.hpp
@@ -174,7 +174,6 @@ public:
     /// before process(); plugins opting in to
     /// PluginDescriptor::supports_ump read it via ump(). Ownership stays
     /// with the caller; the buffer must outlive the process() block.
-    /// Workstream 02 slice 2.6.
     void attach_ump(class UmpBuffer* ump) { ump_ = ump; }
 
     /// Attached UmpBuffer or nullptr. A null return means "no UMP events
@@ -183,7 +182,7 @@ public:
     const class UmpBuffer* ump() const { return ump_; }
     class UmpBuffer* ump() { return ump_; }
 
-    // ── SysEx sidecar (workstream 01 — full MIDI vocabulary) ──────────────
+    // ── SysEx sidecar ────────────────────────────────────────────────────
     //
     // choc::midi::ShortMessage is fixed 3 bytes; system-exclusive payloads
     // can run to kilobytes. Sysex therefore travels in a parallel vector

--- a/core/midi/include/pulp/midi/running_status.hpp
+++ b/core/midi/include/pulp/midi/running_status.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-// MIDI 1.0 running-status byte-stream parser (workstream 02 slice 2.5).
+// MIDI 1.0 running-status byte-stream parser.
 //
 // Platform MIDI backends (ALSA raw MIDI, Win32 mmeapi MIM_LONGDATA, BLE
 // MIDI) deliver raw bytes — status bytes may be omitted when they would

--- a/core/midi/platform/android/android_midi.cpp
+++ b/core/midi/platform/android/android_midi.cpp
@@ -133,9 +133,9 @@ bool has_pending() {
     return !midi_fifo().empty();
 }
 
-// Build a MidiEvent from raw bytes. Only handles short (1-3 byte)
-// channel voice messages in Phase 1. SysEx and longer messages are
-// skipped (the FIFO truncated them anyway).
+// Build a MidiEvent from raw bytes. The Android FIFO currently carries
+// short (1-3 byte) channel voice messages; SysEx and longer messages are
+// skipped because the FIFO entry has already truncated them.
 static MidiEvent decode_short(const std::uint8_t* bytes, int count) {
     MidiEvent ev;
     if (count >= 3) {

--- a/core/midi/platform/mac/ble_midi_coremidi.mm
+++ b/core/midi/platform/mac/ble_midi_coremidi.mm
@@ -10,15 +10,15 @@
 // the BLE link as a normal MIDI port (matching the system CoreMIDI
 // behaviour for OS-paired BLE peripherals).
 //
-// Scope of this slice (per planning/2026-05-24 gap-doc row):
+// Current backend scope:
 //   • Scan-and-discover loop with deduplicated peripherals,
 //     RSSI, last_seen, and is_paired snapshots.
 //   • Connect with state-machine callbacks (Connecting → Connected
 //     | Failed, with translated BleMidiError).
 //   • Inbound MIDI byte stream routed through BleMidiPacketDecoder.
-//   • Outbound encode + GATT write helper (used by future
-//     MidiOutput backend; this slice does not yet register the
-//     output port with CoreMIDI).
+//   • Outbound encode + GATT write helper. The output side still
+//     exposes synthesized port ids rather than registered CoreMIDI
+//     virtual output endpoints.
 //
 // Pairing UI is deliberately not surfaced here — Apple ships
 // CABTMIDICentralViewController (iOS) for that flow and the macOS
@@ -270,8 +270,8 @@ public:
             std::lock_guard<std::mutex> lock(mu_);
             auto it = peripherals_.find(id);
             if (it != peripherals_.end()) {
-                // Synthesize the MIDI port ids; future slices will
-                // register CoreMIDI virtual endpoints and use the
+                // Synthesize the MIDI port ids until the output side
+                // registers CoreMIDI virtual endpoints and can use the
                 // assigned MIDIUniqueID instead.
                 it->second.midi_input_port_id  = "ble-midi-in:" + id;
                 it->second.midi_output_port_id = "ble-midi-out:" + id;


### PR DESCRIPTION
## Summary
- Remove stale workstream/slice/phase/planning breadcrumbs from MIDI byte-stream comments.
- Preserve current behavior notes for running-status parsing, UMP/SysEx sidecars, Android short-message decoding, and Apple BLE-MIDI synthesized port ids.

## Validation
- `git diff --check origin/main..HEAD`
- `rg -n "Codex|RepoPrompt|Phase [0-9]|phase [0-9]|Workstream|workstream|roadmap|follow-up|legacy|PR #[0-9]|planning/|pulp #[0-9]|#[0-9]|gap doc|gap-doc|slice|codex notes|P[0-9]|future slices|future slice" <touched files>` (no matches; exit 1 expected)
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/midi-byte-stream-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/midi-byte-stream-comment-hygiene`

## Notes
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- Comment-only hygiene; no runtime behavior or SDK API change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed outdated planning breadcrumbs from MIDI byte-stream comments and clarified wording. Kept behavior notes for running-status parsing, SysEx sidecar, Android short-message decoding, and Apple BLE-MIDI synthesized port IDs; no runtime or API changes.

<sup>Written for commit e92ad7827a35e2f61f1e4deb96c827208da6a882. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

