### PR TITLE
docs(format): clean planning breadcrumbs

### DIFF
--- a/core/format/include/pulp/format/descriptor_validation.hpp
+++ b/core/format/include/pulp/format/descriptor_validation.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-// PluginDescriptor validation (workstream 01 slice 1.9).
+// PluginDescriptor validation.
 //
 // Runs at plugin registration / test time — NEVER on the audio thread.
 // Catches the common descriptor mistakes that otherwise surface as

--- a/core/format/include/pulp/format/gpu_host_select.hpp
+++ b/core/format/include/pulp/format/gpu_host_select.hpp
@@ -18,8 +18,6 @@
 // A developer building a Skia/Dawn/scripted editor gets the GPU host
 // automatically; they never hand-set a flag. Hardcoding `use_gpu=false` is
 // exactly the trap that made the ChainerSynth AU fall back to AutoUi/CPU.
-//
-// See `planning/2026-05-22-gpu-view-host-in-plugins.md`.
 
 namespace pulp::format {
 

--- a/core/format/include/pulp/format/ios_audio_session.h
+++ b/core/format/include/pulp/format/ios_audio_session.h
@@ -1,7 +1,7 @@
 #ifndef PULP_FORMAT_IOS_AUDIO_SESSION_H
 #define PULP_FORMAT_IOS_AUDIO_SESSION_H
 
-// C ABI bridge for iOS AVAudioSession ↔ Pulp C++ (workstream 05 slice 5.2).
+// C ABI bridge for iOS AVAudioSession <-> Pulp C++.
 //
 // The Swift layer (apple/Sources/PulpSwift/PulpAudioSession.swift) observes
 // AVAudioSession notifications and forwards them through this C function

--- a/core/format/include/pulp/format/ios_audio_session.hpp
+++ b/core/format/include/pulp/format/ios_audio_session.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-// C++ adapter over ios_audio_session.h (workstream 05 slice 5.2).
+// C++ adapter over ios_audio_session.h.
 //
 // Wraps the C callback plumbing in a std::function-based subscription so
 // application code can subscribe without juggling raw function pointers

--- a/core/format/include/pulp/format/native_core_processor.hpp
+++ b/core/format/include/pulp/format/native_core_processor.hpp
@@ -2,7 +2,7 @@
 //
 // A C++ `pulp::format::Processor` that owns a native-language DSP core through
 // the language-neutral C ABI (pulp/native_components/native_core.h). This is
-// the SDK seam from Phase 2 of the native-component plan: a Rust / C / Zig core
+// the SDK seam for native-language DSP cores: a Rust / C / Zig core
 // implements the C ABI vtable; this adapter translates Pulp's C++ Processor
 // surface (StateStore params, ParameterEventQueue, BufferView, state blobs)
 // into the POD FFI structs and back.

--- a/core/format/src/placeholder.cpp
+++ b/core/format/src/placeholder.cpp
@@ -1,2 +1,2 @@
-// pulp-format: placeholder — replaced in Phase 2+
+// pulp-format: placeholder translation unit.
 namespace pulp::format {}


### PR DESCRIPTION
## Summary
- Remove stale workstream/slice and phase references from format comments
- Drop the public-source planning-doc pointer from GPU host selection comments
- Keep comments focused on current behavior without changing code

## RepoPrompt
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

## Validation
- git diff --check
- rg stale-marker scan over touched files
- python3 tools/scripts/docs_noise_lint.py --mode=report
- PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/format-session-comment-hygiene
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/format-session-comment-hygiene

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up comment breadcrumbs in `pulp/format` headers by removing stale workstream/phase notes and the GPU host selection planning-doc link. No functional or API changes—just clearer comments focused on current behavior.

<sup>Written for commit eeed8668c119d0a675de1782f6ab1762846ca6b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

