### PR TITLE
docs(format): clean LV2 adapter breadcrumbs

### DIFF
--- a/core/format/include/pulp/format/lv2_adapter.hpp
+++ b/core/format/include/pulp/format/lv2_adapter.hpp
@@ -25,10 +25,10 @@ static constexpr int kMaxChannels = 8;
 struct PulpLv2Instance {
     std::unique_ptr<Processor> processor;
     state::StateStore store;
-    // Phase 3 — param-events sidecar, set on the Processor each run() so the
-    // contract is uniform across formats. LV2 control-port values are applied
-    // through `store` as before; this queue carries no events yet (atom-based
-    // sample-accurate param events are a follow-up), but it gives the Processor
+    // Param-events sidecar, set on the Processor each run() so the contract is
+    // uniform across formats. LV2 control-port values are applied through
+    // `store` as before; this queue carries no events yet (atom-based
+    // sample-accurate param events are future work), but it gives the Processor
     // a non-null queue and pairs with the RT-safety guard around process().
     state::ParameterEventQueue param_events;
     ProcessorFactory factory;
@@ -48,32 +48,27 @@ struct PulpLv2Instance {
     int num_params = 0;
     std::vector<state::ParamID> param_ids;  // Maps control port index → ParamID
 
-    // URID feature resolution (workstream 01 slice 1.5). The LV2 host passes
-    // an LV2_URID_Map feature in instantiate(); we cache the map function
-    // plus the URIDs we need at runtime so inner-loop code does not call
-    // map() on hot paths. All fields are 0 when the feature is absent —
-    // instantiate() returns nullptr in that case, so real plugin code
-    // always sees non-zero values here.
+    // URID feature resolution. The LV2 host passes an LV2_URID_Map feature in
+    // instantiate(); we cache the map function plus the URIDs we need at
+    // runtime so inner-loop code does not call map() on hot paths. All fields
+    // are 0 when the feature is absent; instantiate() returns nullptr in that
+    // case, so real plugin code always sees non-zero values here.
     LV2_URID_Map* urid_map = nullptr;
     LV2_URID urid_midi_event = 0;      // LV2_MIDI__MidiEvent
     LV2_URID urid_atom_sequence = 0;   // LV2_ATOM__Sequence
     LV2_URID urid_atom_chunk = 0;      // LV2_ATOM__Chunk
 
-    // Workstream 01 #241: atom-port MIDI. When the plug-in declares
-    // accepts_midi, the host connects an LV2_Atom_Sequence buffer to
-    // the port after the control ports. run() iterates it, extracts
-    // MIDI events whose atom `type` field is urid_midi_event, and
-    // feeds them to the Processor.
+    // Atom-port MIDI input. When the plug-in declares accepts_midi, the host
+    // connects an LV2_Atom_Sequence buffer to the port after the control
+    // ports. run() iterates it, extracts MIDI events whose atom `type` field is
+    // urid_midi_event, and feeds them to the Processor.
     bool accepts_midi = false;
     void* midi_in_atom = nullptr;
 
-    // #491: parallel output-atom port for plugins that emit MIDI. The
-    // TTL manifest already declared this port when produces_midi was
-    // set, but run() never serialized the Processor's midi_out buffer
-    // into it — silently dropping every outgoing event. The host pre-
-    // sizes the buffer via lv2:minimumSize and signals capacity in the
-    // atom.size field on entry to run(); the plugin overwrites the
-    // sequence using the lv2_atom_sequence_clear + append_event helpers.
+    // Parallel output-atom port for plugins that emit MIDI. The host pre-sizes
+    // the buffer via lv2:minimumSize and signals capacity in the atom.size
+    // field on entry to run(); the plugin overwrites the sequence using the
+    // lv2_atom_sequence_clear + append_event helpers.
     bool produces_midi = false;
     void* midi_out_atom = nullptr;
 };

--- a/core/format/include/pulp/format/lv2_entry.hpp
+++ b/core/format/include/pulp/format/lv2_entry.hpp
@@ -40,11 +40,9 @@ inline LV2_Handle instantiate(
 {
     if (!g_factory) return nullptr;
 
-    // Resolve LV2_URID_Map — required by any real LV2 host. Pre-production
-    // fix (workstream 01 slice 1.5): we previously ignored the features
-    // array entirely, which would cause real hosts to fail to load the
-    // plugin in surprising ways. Now we fail instantiation loudly and
-    // return nullptr so the host surfaces a clear error.
+    // Resolve LV2_URID_Map, required by any real LV2 host. Fail instantiation
+    // loudly and return nullptr when the feature is absent so the host surfaces
+    // a clear error.
     LV2_URID_Map* urid_map = lv2_adapter::find_urid_map(features);
     if (!urid_map) {
         pulp::runtime::log_warn(
@@ -107,11 +105,11 @@ inline void connect_port(LV2_Handle handle, uint32_t port, void* data) {
     int audio_in_end = inst->num_audio_inputs;
     int audio_out_end = audio_in_end + inst->num_audio_outputs;
     int control_end = audio_out_end + inst->num_params;
-    // MIDI atom ports follow control ports. A plug-in with accepts_midi
-    // gets one atom input port at index control_end. Workstream 01 #241.
+    // MIDI atom ports follow control ports. A plug-in with accepts_midi gets
+    // one atom input port at index control_end.
     int atom_in_end = control_end + (inst->accepts_midi ? 1 : 0);
-    // #491: plug-ins with produces_midi get one atom output port right
-    // after the (optional) input. TTL emits these in the same order in
+    // Plug-ins with produces_midi get one atom output port right after the
+    // (optional) input. TTL emits these in the same order in
     // generate_plugin_ttl(), so the host's port index matches.
     int atom_out_end = atom_in_end + (inst->produces_midi ? 1 : 0);
 
@@ -138,13 +136,13 @@ inline void activate(LV2_Handle) {
     // Nothing needed — processor is prepared at instantiation
 }
 
-// #491: write a MidiBuffer into an LV2_Atom_Sequence output port. Uses
-// the standard lv2_atom_sequence_clear + append_event helpers. On entry
-// the host's out_seq->atom.size carries the buffer capacity; clear()
-// resets it to sizeof(body) and append_event() increments it per event.
-// Events that don't fit are dropped, not truncated — matches every
-// other format adapter's overflow behavior. Exposed non-static for unit
-// testing; all arguments validated so missing URIDs are a no-op.
+// Write a MidiBuffer into an LV2_Atom_Sequence output port. Uses the standard
+// lv2_atom_sequence_clear + append_event helpers. On entry the host's
+// out_seq->atom.size carries the buffer capacity; clear() resets it to
+// sizeof(body) and append_event() increments it per event. Events that don't
+// fit are dropped, not truncated, matching every other format adapter's
+// overflow behavior. Exposed non-static for unit testing; all arguments
+// validated so missing URIDs are a no-op.
 inline void write_midi_out_to_sequence(
     LV2_Atom_Sequence* out_seq,
     LV2_URID urid_atom_sequence,
@@ -225,10 +223,9 @@ inline void run(LV2_Handle handle, uint32_t n_samples) {
         .outputs = ProcessBusBufferSet<float>(output_buses),
     };
 
-    // MIDI: parse the connected LV2_Atom_Sequence (if any) and promote
-    // each MidiEvent into the Processor's MidiBuffer. Sysex atoms are
-    // currently ignored here; the CLAP/VST3/AU sysex sidecar wiring in
-    // issue #239 is the in-progress path for variable-length events.
+    // MIDI: parse the connected LV2_Atom_Sequence (if any) and promote each
+    // MidiEvent into the Processor's MidiBuffer. Sysex atoms are currently
+    // ignored here; LV2 variable-length event support is not wired yet.
     midi::MidiBuffer midi_in, midi_out;
     if (inst->midi_in_atom && inst->urid_atom_sequence && inst->urid_midi_event) {
         const auto* seq = static_cast<const LV2_Atom_Sequence*>(inst->midi_in_atom);
@@ -256,9 +253,9 @@ inline void run(LV2_Handle handle, uint32_t n_samples) {
     proc_ctx.process_mode = format::ProcessMode::Realtime;
     proc_ctx.render_speed_hint = format::RenderSpeedHint::Realtime;
 
-    // Phase 3 — uniform param-events contract + RT-safety guard (mirrors VST3).
-    // The queue carries no atom-sourced events yet; control-port params still
-    // flow via store. Wrap only the process call in ScopedNoAlloc.
+    // Uniform param-events contract + RT-safety guard. The queue carries no
+    // atom-sourced events yet; control-port params still flow via store. Wrap
+    // only the process call in ScopedNoAlloc.
     inst->param_events.clear();
     inst->processor->set_param_events(&inst->param_events);
     {
@@ -266,10 +263,7 @@ inline void run(LV2_Handle handle, uint32_t n_samples) {
         inst->processor->process(process_buffers, midi_in, midi_out, proc_ctx);
     }
 
-    // #491: serialize outgoing MIDI back to the LV2 atom output port.
-    // Prior to this, any Processor that populated midi_out (arpeggiator,
-    // note generator, MIDI-effect passthrough) had its events silently
-    // dropped when hosted via LV2.
+    // Serialize outgoing MIDI back to the LV2 atom output port.
     write_midi_out_to_sequence(
         static_cast<LV2_Atom_Sequence*>(inst->midi_out_atom),
         inst->urid_atom_sequence,

--- a/core/format/src/lv2_adapter.cpp
+++ b/core/format/src/lv2_adapter.cpp
@@ -11,7 +11,7 @@
 
 namespace pulp::format::lv2_adapter {
 
-// ── URID feature resolution (workstream 01 slice 1.5) ────────────────────
+// ── URID feature resolution ───────────────────────────────────────────────
 
 LV2_URID_Map* find_urid_map(const LV2_Feature* const* features) {
     if (!features) return nullptr;
@@ -52,11 +52,10 @@ std::string generate_plugin_ttl(const PluginDescriptor& desc,
             // Effects don't need a specific subclass
             break;
         case PluginCategory::MidiEffect:
-            // MIDI processors are not format/unit converters; mapping to
-            // lv2:ConverterPlugin (#276) misled hosts that group by LV2
-            // class. lv2:UtilityPlugin + a more specific MIDIPlugin
-            // marker is the conventional placement for MIDI effects in
-            // the LV2 taxonomy.
+            // MIDI processors are not format/unit converters; hosts group by
+            // LV2 class. lv2:UtilityPlugin + a more specific MIDIPlugin
+            // marker is the conventional placement for MIDI effects in the
+            // LV2 taxonomy.
             ttl << " , lv2:UtilityPlugin , lv2:MIDIPlugin";
             break;
     }


### PR DESCRIPTION
## Summary
- Remove stale workstream/phase/issue breadcrumbs from LV2 adapter comments
- Keep comments focused on current URID, atom MIDI, output MIDI, and RT-safety behavior
- Preserve LV2 technical explanations without code changes

## RepoPrompt
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

## Validation
- git diff --check
- rg stale-marker scan over touched LV2 files
- python3 tools/scripts/docs_noise_lint.py --mode=report
- PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/lv2-adapter-comment-hygiene
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/lv2-adapter-comment-hygiene

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned LV2 adapter comments, removing stale workstream/issue breadcrumbs and clarifying URID feature resolution, atom MIDI input/output handling, RT-safety, and LV2 taxonomy notes for MIDI effects. No behavior or API changes.

<sup>Written for commit 3f765068d10e6143a1ab2ad792fb128aaed1bbf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

