### PR TITLE
docs(format): clean ARA core breadcrumbs

### DIFF
--- a/core/format/include/pulp/format/ara.hpp
+++ b/core/format/include/pulp/format/ara.hpp
@@ -59,7 +59,6 @@ bool host_supports_ara();
 /// + PULP_ARA_SDK_DIR pointing at a valid checkout). Separate from
 /// host_supports_ara(): SDK-compiled-in is a build-time fact; host
 /// support is resolved at load time per format adapter.
-/// Workstream 06 slice 6.1.
 bool ara_sdk_compiled_in();
 
 /// Highest ARA API generation Pulp was compiled against. Returns 0 when
@@ -71,21 +70,20 @@ int ara_sdk_generation();
 /// Well-known extension id for the CLAP-ARA companion factory.
 /// Matches Celemony's convention for identifying the ARA extension
 /// inside a CLAP plugin's `clap_plugin::get_extension` callback.
-/// Workstream 06 slice 6.5 — the adapter surfaces this to CLAP hosts
-/// that know how to pair a CLAP plugin with an ARA document controller.
+/// The CLAP adapter surfaces this to hosts that know how to pair a
+/// CLAP plugin with an ARA document controller.
 constexpr const char* kClapAraFactoryExtension = "com.celemony.ara/clap-factory-v1";
 
 /// VST3 — `IPluginFactory3::setHostContext` attribute key under which
 /// ARA-aware hosts (Cubase, Studio One) advertise their ARA factory
 /// pointer. The VST3 entry reads it in `PulpVst3Processor::initialize`
 /// and calls `ara_companion_factory_for()` to surface the plugin side.
-/// Workstream 06 slice 6.3 — string is stable because hosts match exact.
+/// String is stable because hosts match it exactly.
 constexpr const char* kVst3AraFactoryContextKey = "com.celemony.ara/vst3-host-factory-v1";
 
 /// AU v3 — `AUAudioUnit.audioUnitARAFactory` property key. Logic Pro
 /// and other AU-ARA hosts observe this property to obtain the plugin's
 /// companion factory. Exposed through the PulpAudioUnit subclass.
-/// Workstream 06 slice 6.4.
 constexpr const char* kAuAraFactoryPropertyKey = "audioUnitARAFactory";
 
 /// Return an opaque pointer to an `ARA::ARAFactory`-compatible struct

--- a/core/format/include/pulp/format/ara/types.hpp
+++ b/core/format/include/pulp/format/ara/types.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
-// ARA 2.x core type layer (workstream 06 slice 6.2).
+// ARA 2.x core type layer.
 //
 // SDK-independent mirrors of the ARA concepts a Pulp plugin needs to author
-// against. The companion factory layer (slices 6.3..6.5 — VST3, AU, CLAP)
-// translates between these types and the Celemony ARA SDK's C interface.
-// Plugin authors only ever see the Pulp types; the SDK header is never
-// re-exported from a Pulp public header so that PULP_HAS_ARA gating stays
-// invisible to consumers.
+// against. The companion factory layer translates between these types and the
+// Celemony ARA SDK's C interface for VST3, AU, and CLAP. Plugin authors only
+// ever see the Pulp types; the SDK header is never re-exported from a Pulp
+// public header so that PULP_HAS_ARA gating stays invisible to consumers.
 //
 // All identifiers are opaque integer handles (ARAObjectRef-like): they are
 // minted by the host and Pulp passes them back through callbacks. Pulp
@@ -59,7 +58,7 @@ struct AraAudioModification {
 
 /// Tempo + meter context shared by one or more region sequences. Pulp
 /// surfaces only the fields plugins commonly read — chord/key/scale
-/// readers can be added when a slice needs them.
+/// readers can be added when plugins need them.
 struct AraTempoEntry {
     double position_seconds = 0.0;
     double position_quarters = 0.0;
@@ -85,12 +84,12 @@ struct AraRegionSequence {
     int colour_argb = 0;          ///< Track colour, AARRGGBB; 0 if unset
 };
 
-/// A playback region maps a slice of an audio modification onto the
+/// A playback region maps a span of an audio modification onto the
 /// host's timeline. All four time fields are in seconds, matching ARA's
 /// ARAPlaybackRegionProperties contract. Earlier drafts modelled the
 /// modification-time pair as int64 samples, which would have forced
 /// sample-rate-dependent conversion in every adapter and dropped
-/// fractional-time precision (#185 review).
+/// fractional-time precision.
 struct AraPlaybackRegion {
     PlaybackRegionId id = 0;
     AudioModificationId modification_id = 0;

--- a/core/format/src/ara.cpp
+++ b/core/format/src/ara.cpp
@@ -10,8 +10,8 @@ namespace pulp::format {
 bool host_supports_ara() {
 #ifdef PULP_HAS_ARA
     // SDK is compiled in; actual host-query lives in the format-adapter
-    // companion factories (VST3 / AU / CLAP). Pulp-side availability is
-    // gated by those slices landing — workstream 06 slices 6.3..6.5.
+    // companion factories (VST3 / AU / CLAP). This Pulp-side helper stays
+    // conservative until adapters can query the active host.
     return false;
 #else
     return false;
@@ -55,4 +55,3 @@ const void* ara_companion_factory_for(AraDocumentController* /*controller*/) {
 #endif
 
 }  // namespace pulp::format
-

--- a/core/format/src/ara_factory.cpp
+++ b/core/format/src/ara_factory.cpp
@@ -1,5 +1,4 @@
-// Real ARA::ARAFactory construction (workstream 06 slice 6 — follow-up
-// to the stub that 6.5 landed). Active only when PULP_HAS_ARA is set;
+// Real ARA::ARAFactory construction. Active only when PULP_HAS_ARA is set;
 // non-ARA builds compile to an empty TU.
 //
 // This file publishes a static ARAFactory whose strings come from the
@@ -31,8 +30,7 @@ namespace {
 // Every ARA controller call gets a safe no-op implementation so a host
 // calling through the factory never lands on a null pointer. Plug-ins
 // that want real ARA behaviour override the corresponding method on
-// their AraDocumentController subclass; a future slice wires those
-// overrides into the interface table.
+// their AraDocumentController subclass.
 
 using ARA::ARADocumentControllerRef;
 using ARA::ARADocumentControllerInstance;
@@ -47,12 +45,10 @@ void ARA_CALL stub_begin_editing(ARADocumentControllerRef) {}
 void ARA_CALL stub_end_editing(ARADocumentControllerRef) {}
 void ARA_CALL stub_notify_model_updates(ARADocumentControllerRef) {}
 
-// ── Batch 2: document / musical-context / audio-source management (#253).
-// These are the next-most-called callbacks after the five above.
-// Stubs are no-ops that return opaque *unique* refs when the SDK
-// expects one — ARA treats the ref as a runtime identity token, so
-// returning the same pointer for two live objects would make them
-// indistinguishable to hosts.
+// ── Document / musical-context / audio-source management ─────────────────
+// Stubs are no-ops that return opaque *unique* refs when the SDK expects one:
+// ARA treats the ref as a runtime identity token, so returning the same pointer
+// for two live objects would make them indistinguishable to hosts.
 //
 // We mint unique refs by handing out distinct integer ticks cast to
 // the ref type. Atomicity covers the case where the host calls create
@@ -123,9 +119,9 @@ ARA::ARAAudioModificationRef ARA_CALL stub_create_audio_modification(
 {
     return mint_unique_ref<ARA::ARAAudioModificationRef>();
 }
-// Codex P1 follow-up: hosts that created a modification expect the
-// clone + undo-history callbacks to exist once create succeeds.
-// Stubs still, just non-null. A real clone mints a new ref.
+// Hosts that created a modification expect the clone + undo-history callbacks
+// to exist once create succeeds. These are still stubs, just non-null. A real
+// clone mints a new ref.
 ARA::ARAAudioModificationRef ARA_CALL stub_clone_audio_modification(
     ARADocumentControllerRef,
     ARA::ARAAudioModificationRef,
@@ -191,7 +187,7 @@ ARADocumentControllerInterface build_controller_interface() {
     iface.deactivateAudioSourceForUndoHistory = stub_deactivate_audio_source_for_undo_history;
     iface.destroyAudioSource                  = stub_destroy_audio_source;
 
-    // Audio modification (5 — clone + undo-history added per Codex P1)
+    // Audio modification (5, including clone + undo-history callbacks)
     iface.createAudioModification                = stub_create_audio_modification;
     iface.cloneAudioModification                 = stub_clone_audio_modification;
     iface.updateAudioModificationProperties      = stub_update_audio_modification_properties;


### PR DESCRIPTION
## Summary
- Remove stale workstream/slice/issue/Codex breadcrumbs from ARA core comments
- Keep comments focused on current ARA SDK, companion factory, and stub behavior
- Preserve public constants and ARA runtime behavior without code changes

## RepoPrompt
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

## Validation
- git diff --check
- rg stale-marker scan over touched ARA files
- python3 tools/scripts/docs_noise_lint.py --mode=report
- PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/ara-core-comment-hygiene
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/ara-core-comment-hygiene

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up ARA core comments by removing stale workstream/slice/Codex breadcrumbs and clarifying SDK and companion factory wording. No code or behavior changes; public constants and ARA runtime remain unchanged.

<sup>Written for commit 54be6daa2bf2bd0603495c57b8d9ba439414d46b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

