### PR TITLE
docs(format): clean AU v2 adapter breadcrumbs

### DIFF
--- a/core/format/include/pulp/format/au_v2_adapter.hpp
+++ b/core/format/include/pulp/format/au_v2_adapter.hpp
@@ -244,32 +244,27 @@ private:
     // param writes/notifications never run on the render thread. See ctor.
     state::ListenerToken ui_push_listener_;
 
-    // Sample-accurate parameter-event sidecar, set on the Processor each block
-    // so the param-events contract is uniform across formats (VST3/CLAP/AUv3
-    // already provide it). AU v2's AUEffectBase has no scheduled/ramped
-    // parameter event source today, so this queue is empty: host parameter
-    // changes still reach the Processor through `store_` (StateStore) exactly as
-    // before — this adds the uniform API + the RT-safety guard without changing
-    // existing behaviour. Sample-accurate AU v2 param sourcing is a follow-up
-    // (AUv3 has the AURenderEventParameter model).
+    // Parameter-event sidecar, set on the Processor each block so the
+    // param-events contract is uniform across formats. AU v2's AUEffectBase
+    // has no scheduled/ramped parameter event source today, so this queue is
+    // empty: host parameter changes still reach the Processor through `store_`
+    // exactly as before.
     state::ParameterEventQueue param_events_;
 
     // Host accommodations, resolved once in the constructor via the
-    // runtime policy (host-quirks plan, P3).
+    // runtime policy.
     HostQuirks host_quirks_{};
 
     // Cached ParamID of the "Bypass" parameter (plugin-declared or
-    // synthesized via synthesize_bypass_parameter, host-quirks P3d). 0 when
-    // none — ProcessBufferLists then never short-circuits to pass-through.
+    // synthesized by host-quirk policy). 0 when none is available, so
+    // ProcessBufferLists never short-circuits to pass-through.
     state::ParamID bypass_param_id_ = 0;
     std::vector<const float*> input_ptrs_;
     std::vector<float*> output_ptrs_;
 
-    // Item 1.3 — previous-block transport snapshot used to derive the
-    // change flags (tempo_changed / time_sig_changed /
-    // transport_changed) on `ProcessContext`. Default-constructed (no
-    // previous block) so the first process() call after init reports
-    // no changes.
+    // Previous-block transport snapshot used to derive change flags on
+    // `ProcessContext`. Default-constructed so the first process() call
+    // after init reports no changes.
     detail::PlayheadSnapshot playhead_prev_{};
 
     // MIDI input path — AU v2 effects that declare accepts_midi are packaged as

--- a/core/format/include/pulp/format/au_v2_instrument.hpp
+++ b/core/format/include/pulp/format/au_v2_instrument.hpp
@@ -76,7 +76,7 @@ private:
     std::unique_ptr<Processor> processor_;
     state::StateStore store_;
 
-    // Host accommodations, resolved once at init (host-quirks plan, P3).
+    // Host accommodations, resolved once at init via the runtime policy.
     HostQuirks host_quirks_{};
     std::vector<float*> output_ptrs_;
 
@@ -88,9 +88,9 @@ private:
     // HandleNoteOn/Off; single consumer = Render). No audio-thread mutex.
     runtime::SpscQueue<midi::MidiEvent, 1024> midi_in_queue_;
 
-    // Item 1.3 — previous-block transport snapshot used to derive the
-    // change flags on `ProcessContext`. Default-constructed so the
-    // first Render() call after Initialize() reports no changes.
+    // Previous-block transport snapshot used to derive change flags on
+    // `ProcessContext`. Default-constructed so the first Render() call
+    // after Initialize() reports no changes.
     detail::PlayheadSnapshot playhead_prev_{};
 };
 

--- a/core/format/src/au_v2_adapter.cpp
+++ b/core/format/src/au_v2_adapter.cpp
@@ -59,11 +59,10 @@ midi::MidiEvent decode_midi_event(uint8_t inStatus,
     // low nibble carries the system-message subtype rather than a channel,
     // but the bit-layout reassembly is identical: status = top | low.
     //
-    // The previous "is_system → return inStatus unchanged" special case
-    // turned every system message into 0xF0 (sysex start), so MIDI clock
-    // / start / stop / continue / song-position / quarter-frame all
-    // arrived at the Processor with the wrong status byte. Codex review
-    // on PR #638 caught this; the unit test in test_au_v2_effect.cpp now
+    // Returning inStatus unchanged for system messages would turn every
+    // system message into 0xF0 (sysex start), so MIDI clock / start / stop /
+    // continue / song-position / quarter-frame would arrive at the Processor
+    // with the wrong status byte. The unit test in test_au_v2_effect.cpp
     // mirrors the SDK splitting so the regression cannot reappear.
     const uint8_t status_byte =
         static_cast<uint8_t>((inStatus & 0xF0) | (inChannel & 0x0F));
@@ -85,14 +84,13 @@ PulpAUEffect::PulpAUEffect(AudioComponentInstance ci)
             processor_->set_state_store(&store_);
             processor_->define_parameters(store_);
 
-            // Resolve host accommodations once (host-quirks plan, P3) via
-            // the runtime policy (PULP_HOST_QUIRKS env / API).
+            // Resolve host accommodations once via the runtime policy.
             const auto host_info = detect_host_info();
             host_quirks_ = resolved_quirks(host_info.type, host_info.version);
 
-            // synthesize_bypass_parameter (host-quirks P3d): inject an
-            // automatable Bypass when the plugin declared none (before the
-            // AU param list is built from the store), then detect it so
+            // Inject an automatable Bypass when host-quirk policy requests
+            // one and the plugin declared none. Do this before the AU param
+            // list is built from the store, then detect it so
             // ProcessBufferLists can honor it with a pass-through.
             maybe_synthesize_bypass(store_, host_quirks_);
             for (const auto& p : store_.all_params()) {
@@ -425,11 +423,10 @@ OSStatus PulpAUEffect::ProcessBufferLists(AudioUnitRenderActionFlags& ioActionFl
         output_ptrs_[i] = static_cast<float*>(outBuffer.mBuffers[i].mData);
     }
 
-    // synthesize_bypass_parameter (host-quirks P3d): when the Bypass param
-    // (declared or synthesized) is engaged, copy main input → main output
+    // When the Bypass param is engaged, copy main input to main output
     // (null-guarded), zero any output channel without a matching input, and
-    // skip the Processor — mirrors the VST3/CLAP pass-through. The value was
-    // pulled into the store from GetParameter() above.
+    // skip the Processor. The value was pulled into the store from
+    // GetParameter() above.
     if (bypass_param_id_ != 0 && store_.get_value(bypass_param_id_) >= 0.5f) {
         for (UInt32 ch = 0; ch < out_channels; ++ch) {
             float* dst = output_ptrs_[ch];
@@ -440,12 +437,11 @@ OSStatus PulpAUEffect::ProcessBufferLists(AudioUnitRenderActionFlags& ioActionFl
                 std::memset(dst, 0, sizeof(float) * inFramesToProcess);
             }
         }
-        // Drain + DISCARD any MIDI queued by HandleMIDIEvent/HandleSysEx
-        // while bypassed. Without this the queue grows for the whole bypass
+        // Drain and discard any MIDI queued by HandleMIDIEvent/HandleSysEx
+        // while bypassed. Otherwise the queue grows for the whole bypass
         // window and floods the processor with stale notes/CCs the instant
-        // bypass turns off (Codex review on #3246). A bypassed plugin is a
-        // wire — inbound MIDI is dropped with the block, matching the VST3
-        // path (which leaves MIDI buffers empty on the bypass short-circuit).
+        // bypass turns off. A bypassed plugin is a wire, so inbound MIDI is
+        // dropped with the block.
         while (midi_in_queue_.try_pop()) {}
         while (sysex_in_queue_.try_pop()) {}
         return noErr;
@@ -473,11 +469,10 @@ OSStatus PulpAUEffect::ProcessBufferLists(AudioUnitRenderActionFlags& ioActionFl
 
     apply_host_callbacks_to_process_context(ctx, *this, playhead_prev_);
 
-    // Phase 3 — uniform param-events contract + RT-safety guard. AU v2 has no
-    // scheduled-parameter event source, so the queue is empty (host params flow
-    // via store_ as before); set it anyway so a Processor always sees a non-null
-    // queue. Wrap ONLY the process call in ScopedNoAlloc — the preamble above
-    // (param snapshot, pointer-vector resizes) legitimately allocates.
+    // AU v2 has no scheduled-parameter event source, so this queue is empty
+    // and host params flow via store_ as before. Set it anyway so a Processor
+    // always sees a non-null queue. Wrap only the process call in
+    // ScopedNoAlloc; the preamble above legitimately allocates.
     param_events_.clear();
     processor_->set_param_events(&param_events_);
     std::array<ProcessBusBufferView<const float>, 1> input_buses{{
@@ -524,12 +519,11 @@ OSStatus PulpAUEffect::ProcessBufferLists(AudioUnitRenderActionFlags& ioActionFl
     // notification, would be done from a main-thread pump, never a render-thread
     // notify; no current plugin drives parameters from process().)
 
-    // Item 3.11 — push latency / tail change notifications the processor
-    // flagged during process(). AU v2 hosts watch
-    // kAudioUnitProperty_Latency and kAudioUnitProperty_TailTime via
-    // PropertyListeners; PropertyChanged is the canonical SDK call
-    // that wakes them. Safe to call from the render callback (AU SDK
-    // marshals through the host's property-listener queue).
+    // Push latency / tail change notifications the processor flagged during
+    // process(). AU v2 hosts watch kAudioUnitProperty_Latency and
+    // kAudioUnitProperty_TailTime via PropertyListeners; PropertyChanged is
+    // the canonical SDK call that wakes them. Safe to call from the render
+    // callback because the AU SDK marshals through the host's listener queue.
     if (processor_->consume_latency_changed_flag()) {
         PropertyChanged(kAudioUnitProperty_Latency,
                         kAudioUnitScope_Global, 0);
@@ -620,8 +614,8 @@ Float64 PulpAUEffect::GetTailTime()
 Float64 PulpAUEffect::GetLatency()
 {
     if (!processor_) return 0.0;
-    // clamp_latency_to_nonneg (host-quirks P3): route the existing clamp
-    // through the quirk so PULP_HOST_QUIRKS=off reports raw latency too.
+    // Route the non-negative latency clamp through host-quirk policy so
+    // disabling host quirks reports raw latency too.
     int latency = reported_latency_samples(processor_->latency_samples(), host_quirks_);
     return GetSampleRate() > 0 ? static_cast<Float64>(latency) / GetSampleRate() : 0.0;
 }

--- a/core/format/src/au_v2_instrument.cpp
+++ b/core/format/src/au_v2_instrument.cpp
@@ -33,9 +33,8 @@ PulpAUInstrument::PulpAUInstrument(AudioComponentInstance ci)
             processor_->set_state_store(&store_);
             processor_->define_parameters(store_);
 
-            // Resolve host accommodations once (host-quirks plan, P3) so
-            // GetLatency() can clamp via reported_latency_samples like the
-            // effect adapter (Codex review on #3226 — instrument was missed).
+            // Resolve host accommodations once so GetLatency() can apply
+            // the same policy-gated clamp as the effect adapter.
             const auto host_info = detect_host_info();
             host_quirks_ = resolved_quirks(host_info.type, host_info.version);
 
@@ -427,10 +426,9 @@ Float64 PulpAUInstrument::GetTailTime()
 Float64 PulpAUInstrument::GetLatency()
 {
     if (!processor_) return 0.0;
-    // clamp_latency_to_nonneg (host-quirks): report the processor's latency
-    // (e.g. lookahead) for host PDC, clamped non-negative unless the quirk
-    // is filtered out. Previously hardcoded 0.0, so instruments with
-    // latency got no delay compensation (Codex review on #3226).
+    // Report the processor's latency for host PDC, clamped non-negative
+    // unless the host quirk is filtered out. Instruments with lookahead
+    // should get the same delay compensation as effects.
     // MusicDeviceBase has no GetSampleRate(); read it from the output
     // stream format like the render path, guarded for pre-config queries.
     int latency = reported_latency_samples(processor_->latency_samples(), host_quirks_);


### PR DESCRIPTION
## Summary
- Remove stale implementation-plan, issue, PR, and review breadcrumbs from AU v2 effect/instrument adapter comments.
- Preserve current-behavior notes for MIDI status reassembly, bypass pass-through, MIDI draining while bypassed, param-event sidecar behavior, latency/tail notifications, and host-quirk latency policy.

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

## Validation
- `git diff --check`
- `git diff --check origin/main..HEAD`
- touched-file stale-marker `rg` scan
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/auv2-adapter-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/auv2-adapter-comment-hygiene`

## Notes
- Comment-only hygiene; no SDK behavior or API change.
- Claude local and branch autoreviews reported no accepted/actionable findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up AU v2 effect/instrument adapter comments by removing stale implementation-plan/review breadcrumbs and documenting current behavior and host invariants. Clarifies MIDI status reassembly, bypass pass-through with MIDI draining, param-event sidecar, latency/tail notifications, and host-quirk latency policy; no SDK behavior or API changes.

<sup>Written for commit 04dc069fe10e2bbd9300cf81336b019b0f98b617. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

