### PR TITLE
docs(format): clean AU v2 Cocoa view breadcrumbs

### DIFF
--- a/core/format/src/au_v2_cocoa_view.mm
+++ b/core/format/src/au_v2_cocoa_view.mm
@@ -41,8 +41,7 @@ static const char* const kPulpAUCocoaViewClassName = PULP_STRINGIFY(PULP_AU_COCO
 // fetched from the host's PulpAUEffect via the private
 // `kPulpEditorContextProperty`. Creating a second Processor for the
 // view (the pre-ViewBridge behavior) silently desynchronized parameter
-// state between the audio thread and the UI; see the plan for Feature 1
-// Phase 3 and au_v2_adapter.{hpp,cpp}.
+// state between the audio thread and the UI; the live adapter owns both.
 
 struct PulpAUEditorOwnership {
     std::unique_ptr<pulp::format::ViewBridge> bridge;
@@ -63,8 +62,7 @@ struct PulpAUEditorOwnership {
 }
 - (void)dealloc {
     if (_ownership) {
-        // Destruction-order contract (Codex P1 review on PR #653):
-        //
+        // Destruction-order contract:
         // PulpAUEditorOwnership declares `bridge` first, then `host`.
         // C++ destroys members in REVERSE declaration order, so:
         //   1. ~unique_ptr<PluginViewHost> runs first. Its destructor
@@ -161,9 +159,8 @@ static const char kOwnershipKey = 0;
     // below); the wrapper destroys host (stops the display link) before bridge.
     host->set_idle_callback(format::make_scripted_idle_pump(*bridge));
 
-    // Phase iOS-D.3b Slice 1 — route navigator.gpu / canvas.getContext
-    // ('webgpu') through the host's live GpuSurface. See
-    // planning/2026-05-29-ios-d3b-threejs-webgpu-program.md § Slice 1.
+    // Route navigator.gpu / canvas.getContext('webgpu') through the host's
+    // live GpuSurface.
     if (auto* scripted = bridge->scripted_ui()) {
         scripted->attach_gpu_surface(host->gpu_surface());
         if (host->gpu_surface()) {


### PR DESCRIPTION
## Summary
- Remove stale planning and review breadcrumbs from AU v2 Cocoa view comments.
- Preserve current-behavior notes for live adapter ownership, destruction ordering, and scripted UI GPU-surface routing.

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

## Validation
- `git diff --check`
- `git diff --check origin/main..HEAD`
- touched-file stale-marker `rg` scan
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/auv2-cocoa-view-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/auv2-cocoa-view-comment-hygiene`

## Notes
- Comment-only hygiene; no SDK behavior or API change.
- Claude local and branch autoreviews reported no accepted/actionable findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale planning/review breadcrumbs in the AU v2 Cocoa view comments and clarified current behavior for live adapter ownership, destruction order, and routing of navigator.gpu/canvas.getContext('webgpu') to the host GpuSurface. Comment-only cleanup with no SDK, API, or runtime behavior changes.

<sup>Written for commit 4e60931e5fd9f2ad03bae8ef0e866a77b0fb4f72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

