### PR TITLE
docs(format): clean AUv3 view breadcrumbs

### DIFF
--- a/core/format/src/au_audio_unit.h
+++ b/core/format/src/au_audio_unit.h
@@ -2,15 +2,13 @@
 
 // Forward declaration of the Pulp AUAudioUnit subclass.
 // Defined in `au_adapter.mm`. Used by:
-//   - `au_entry.mm`                            (iOS factory entry)
-//   - `au_view_controller_mac.mm` (Phase 3.5)  (macOS factory + view)
-//   - `au_view_controller_ios.mm` (Phase 3.5)  (iOS factory + view)
-//   - `test/test_au_plugin_state.mm`           (parameter-event tests)
+//   - `au_entry.mm`                   (iOS factory entry)
+//   - `au_view_controller_mac.mm`     (macOS factory + view)
+//   - `au_view_controller_ios.mm`     (iOS factory + view)
+//   - `test/test_au_plugin_state.mm`  (parameter-event tests)
 //
-// Phase 3.5 unified what was briefly a second `pulp_audio_unit_fwd.h`
-// header into this single canonical declaration. Don't reintroduce a
-// parallel forward decl — duplicate `@interface PulpAudioUnit : AUAudioUnit`
-// declarations in the same TU break compilation.
+// Keep this as the single canonical declaration. A parallel forward declaration
+// of `@interface PulpAudioUnit : AUAudioUnit` in the same TU breaks compilation.
 
 #import <AudioToolbox/AudioToolbox.h>
 
@@ -36,7 +34,7 @@ class StateStore;
 // chose to route the AUv3 `shouldBypassEffect` surface to, or 0 when no
 // plugin-declared "Bypass" parameter matched (in which case the
 // AUAudioUnit's bypass AUValue is tracked in an internal atomic).
-// Used by tests that pin item 3.1 (AU v3 hardening: dual-tracked bypass).
+// Used by tests that pin the AUv3 dual-tracked bypass contract.
 - (uint32_t)pulpBypassParameterId;
 
 // Parameter-event introspection. Used by `test_au_plugin_state.mm` to

--- a/core/format/src/au_view_controller_ios.mm
+++ b/core/format/src/au_view_controller_ios.mm
@@ -82,8 +82,7 @@
     // AU. Returning self.audioUnit unconditionally (as this method previously
     // did) left the AU nil and the host opened a generic-view editor over a
     // dead AU. Apple's docs and the AUViewController sample both create the
-    // AU here. See planning/2026-05-23-auv3-macos-ui-phase35.md
-    // "P0: AudioUnit instance ownership".
+    // AU here so the host receives a live unit before the editor is built.
     PulpAudioUnit *au = [[PulpAudioUnit alloc] initWithComponentDescription:desc
                                                                        error:error];
     if (!au) return nil;
@@ -164,9 +163,8 @@
 
     self.preferredContentSize = CGSizeMake(w, h);
 
-    // Auto-select the GPU host for a scripted / GPU-backed editor (P5) via the
-    // shared decision helper, using the Options overload. The preview/fallback
-    // case (no bridge) stays on the default CPU host.
+    // Auto-select the GPU host for scripted / GPU-backed editors via the shared
+    // decision helper. The preview/fallback case stays on the default CPU host.
     pulp::view::PluginViewHost::Options opts;
     opts.size = {w, h};
     const char* mode = "fallback";
@@ -178,10 +176,9 @@
         if (_viewHost) {
             pulp::format::warn_if_unexpected_cpu_fallback(gpu, _viewHost.get());
             _viewHost->set_idle_callback(pulp::format::make_scripted_idle_pump(*_bridge));
-            // Phase iOS-D.3b Slice 1: hand the host's live GpuSurface to the
-            // scripted-UI session so JS navigator.gpu / canvas.getContext
-            // ('webgpu') routes through Pulp's Dawn instance instead of mocks.
-            // See planning/2026-05-29-ios-d3b-threejs-webgpu-program.md § Slice 1.
+            // Hand the host's live GpuSurface to the scripted-UI session so
+            // JS navigator.gpu / canvas.getContext('webgpu') routes through
+            // Pulp's Dawn instance instead of mocks.
             if (auto* scripted = _bridge->scripted_ui()) {
                 scripted->attach_gpu_surface(_viewHost->gpu_surface());
                 if (_viewHost->gpu_surface()) {
@@ -209,7 +206,6 @@
     // pane bounds (resizeEditorToViewBounds drives set_size + bridge resize)
     // lets a responsive scene fill edge-to-edge. A fixed-design editor that
     // genuinely needs letterboxing can call set_design_viewport itself.
-    // (#3286 follow-up — full-width responsive editor.)
 
     _viewHost->attach_to_parent((__bridge void*)self.view);
     if (_bridge) _bridge->notify_attached();
@@ -248,8 +244,7 @@
 }
 
 - (void)dealloc {
-    // Destruction-order contract (Codex P1 review on PR #653; fallback-path
-    // UAF fix, GPU-plugin-view-host):
+    // Destruction-order contract:
     //
     // PulpAUViewController declares its ivars in order:
     //     _bridge       (ViewBridge — owns the View tree on the success path)

--- a/core/format/src/au_view_controller_mac.mm
+++ b/core/format/src/au_view_controller_mac.mm
@@ -6,8 +6,7 @@
 // open a `ViewBridge` against the same Processor / StateStore the audio
 // render block runs against, and attach a `PluginViewHost` to the platform
 // view. `set_design_viewport` + `set_fixed_aspect_ratio` deliver the same
-// proportional / aspect-locked resize behavior Phase 3 added for standalone,
-// VST3, and CLAP.
+// proportional / aspect-locked resize behavior as standalone, VST3, and CLAP.
 
 #if defined(__APPLE__)
 #import <TargetConditionals.h>
@@ -345,9 +344,9 @@ static constexpr int64_t kInitialSizeSyncIntervalMs = 60;
         if (_viewHost) {
             pulp::format::warn_if_unexpected_cpu_fallback(gpu, _viewHost.get());
             _viewHost->set_idle_callback(pulp::format::make_scripted_idle_pump(*_bridge));
-            // Phase iOS-D.3b Slice 1: hand the host's live GpuSurface to the
-            // scripted-UI session so JS navigator.gpu / canvas.getContext(
-            // 'webgpu') routes through Pulp's Dawn instance instead of mocks.
+            // Hand the host's live GpuSurface to the scripted-UI session so
+            // JS navigator.gpu / canvas.getContext('webgpu') routes through
+            // Pulp's Dawn instance instead of mocks.
             if (auto* scripted = _bridge->scripted_ui()) {
                 scripted->attach_gpu_surface(_viewHost->gpu_surface());
                 if (_viewHost->gpu_surface()) {
@@ -367,7 +366,7 @@ static constexpr int64_t kInitialSizeSyncIntervalMs = 60;
         return;
     }
 
-    // Phase 3 viewport pin + aspect lock: paint the design at the host size.
+    // Viewport pin + aspect lock: paint the design at the host size.
     if (w > 0 && h > 0) {
         _viewHost->set_design_viewport(w, h);
         _viewHost->set_fixed_aspect_ratio(static_cast<float>(w) /
@@ -407,8 +406,8 @@ static constexpr int64_t kInitialSizeSyncIntervalMs = 60;
     // Settle driver / fallback for hosts that size us late: builds the deferred
     // GPU host once the view's bounds settle (or, on the final attempt, at
     // whatever size we have). We let the host own the window — no forced
-    // window resize here (Codex: forcing Logic's window fights its restore
-    // behavior). Once the host exists, just re-fit the design viewport.
+    // window resize here; forcing Logic's window fights its restore behavior.
+    // Once the host exists, just re-fit the design viewport.
     [self createViewHostIfReady];
     if (_viewHost) {
         [self resizeEditorToViewBounds];


### PR DESCRIPTION
## Summary
- Removes stale planning/phase/PR/review breadcrumbs from AUv3 shared header and macOS/iOS view controller comments.
- Preserves the current technical contracts for the single AUAudioUnit declaration, factory ownership, GPU surface handoff, responsive iOS sizing, deferred macOS first paint, and teardown ordering.

## Validation
- `git diff --check origin/main..HEAD`
- focused stale-marker scan over touched files
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/auv3-view-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/auv3-view-comment-hygiene`

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale planning/phase/PR breadcrumbs from the AUv3 shared header and iOS/macOS view controller comments, clarifying AU creation timing, GPU surface handoff, responsive sizing, deferred macOS first paint, and teardown order.
No behavior or API changes.

<sup>Written for commit 884f1e50bc4532b646be339b416ad870f8d08ce3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

