### PR TITLE
docs(format): clean validation harness breadcrumbs

### DIFF
--- a/core/format/include/pulp/format/detail/screenshot_capture.hpp
+++ b/core/format/include/pulp/format/detail/screenshot_capture.hpp
@@ -1,4 +1,4 @@
-// pulp #468 — headless screenshot capture helper for StandaloneApp.
+// Headless screenshot capture helper for StandaloneApp.
 //
 // Factored out of standalone.cpp so the capture state machine (frame
 // counter + one-shot guard + capture/write/close composition) is

--- a/core/format/include/pulp/format/validation_harness.hpp
+++ b/core/format/include/pulp/format/validation_harness.hpp
@@ -125,7 +125,7 @@ public:
     //
     // Screenshot and inspector capture are delegated to an external
     // provider callback so the harness stays free of a direct view-
-    // library dependency (#298). Register a provider before calling
+    // library dependency. Register a provider before calling
     // capture_screenshot()/capture_inspector() — without one, the
     // entry is reported as `skip` with a clear "no provider attached"
     // message. Callers must never confuse skip with pass.
@@ -155,9 +155,8 @@ public:
 
     /// Compare two screenshot files and generate a diff entry.
     /// Today this does a byte-level file comparison — pixel-level
-    /// diffing (with a tolerance) is a follow-up once a PNG codec
-    /// is available to the format layer. A real pixel diff always
-    /// produces pass/fail, never skip.
+    /// diffing (with a tolerance) requires a PNG codec in the format
+    /// layer. A real pixel diff always produces pass/fail, never skip.
     ReportEntry compare_screenshots(const std::filesystem::path& reference,
                                      const std::filesystem::path& rendered);
 
@@ -226,9 +225,9 @@ private:
     midi::MidiBuffer pending_midi_in_;
     bool prepared_ = false;
 
-    // #298 capture delegation. Unset by default; callers register a
-    // provider backed by the view layer (or a test fake) before
-    // invoking capture_screenshot / capture_inspector.
+    // Capture delegation is unset by default; callers register a provider
+    // backed by the view layer (or a test fake) before invoking
+    // capture_screenshot / capture_inspector.
     CaptureScreenshotProvider screenshot_provider_;
     CaptureInspectorProvider  inspector_provider_;
 


### PR DESCRIPTION
## Summary
- Removes stale issue breadcrumbs from validation harness and screenshot capture comments.
- Keeps the current behavior notes for provider-based capture delegation, skip-vs-pass reporting, and byte-level screenshot comparison.

## Validation
- `git diff --check origin/main..HEAD`
- focused stale-marker scan over touched files
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/format-validation-harness-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/format-validation-harness-comment-hygiene`

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up validation harness docs by removing stale issue breadcrumbs in comments. Keeps and clarifies notes on provider-based capture, skip-vs-pass reporting, and screenshot diff behavior; no code or API changes.

- **Refactors**
  - Removed stale issue references in screenshot capture and validation harness headers.
  - Clarified wording on provider delegation and byte-level vs pixel-level screenshot comparison.

<sup>Written for commit 4c29a74dd9178a353e4ea72bffc938d45ab20a41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

