### PR TITLE
docs(format): clean host type breadcrumbs

### DIFF
--- a/core/format/src/host_type.cpp
+++ b/core/format/src/host_type.cpp
@@ -60,10 +60,10 @@ HostType host_type_from_process_name(std::string_view process_name) {
     if (name.find("bitwig") != std::string::npos) return HostType::Bitwig;
     if (name.find("maschine") != std::string::npos) return HostType::Maschine;
     if (name.find("audacity") != std::string::npos || name.find("tenacity") != std::string::npos) return HostType::AudacityTenacity;
-    // MOTU Digital Performer's macOS process is "DP11" / "DP10" /
-    // "Digital Performer"; the Windows build is just "Digital
-    // Performer.exe". Match the canonical name first, then the
-    // short DP-prefixed form. Pulp #3046.
+    // MOTU Digital Performer's macOS process may use a short
+    // DP-prefixed name or "Digital Performer"; the Windows build is
+    // just "Digital Performer.exe". Match the canonical name first,
+    // then the short DP-prefixed form.
     if (name.find("digital performer") != std::string::npos
         || name.find("digitalperformer") != std::string::npos
         || name == "dp11" || name == "dp10" || name == "dp12") return HostType::DigitalPerformer;
@@ -87,9 +87,9 @@ HostType host_type_from_auv3_wrapper(std::string_view wrapper_identifier) {
     std::string id = to_lower(wrapper_identifier);
 
     // Logic Pro family — bundle ids + XPC wrapper names. MainStage
-    // historically shares the Logic Pro DAW-quirk family (auv3 cross-host
-    // row 21 dual-tracked bypass, channel-strip plumbing), so we fold it
-    // into HostType::LogicPro rather than introducing a separate enum.
+    // historically shares the Logic Pro DAW-quirk family (dual-tracked
+    // bypass, channel-strip plumbing), so we fold it into
+    // HostType::LogicPro rather than introducing a separate enum.
     if (id.find("com.apple.logic") != std::string::npos) return HostType::LogicPro;
     if (id.find("com.apple.mainstage") != std::string::npos) return HostType::LogicPro;
     if (id.find("auhostingservicexpc_arrow") != std::string::npos) return HostType::LogicPro;
@@ -115,10 +115,9 @@ std::string current_auv3_wrapper_identifier() { return {}; }
 
 HostType detect_host_type() {
 #ifdef __APPLE__
-    // DAW-quirks row 22 — when running as an AU v3 extension prefer the
-    // wrapper-reported identifier (`detect_host_type` on iOS / sandboxed
-    // macOS extensions will otherwise classify our own `.appex`
-    // executable name as Unknown).
+    // When running as an AU v3 extension, prefer the wrapper-reported
+    // identifier; iOS / sandboxed macOS extensions otherwise classify
+    // their own `.appex` executable name as Unknown.
     auto wrapper_id = current_auv3_wrapper_identifier();
     if (!wrapper_id.empty()) {
         HostType wrapped = host_type_from_auv3_wrapper(wrapper_id);

--- a/core/format/src/host_type_mac.mm
+++ b/core/format/src/host_type_mac.mm
@@ -3,8 +3,7 @@
 // AU v3 plug-ins live in a sandboxed `.appex`. The bundle's own
 // executable name (`PulpAUv3Extension`, `*.AppExtension`, etc.) does
 // NOT classify the host — the wrapping host's bundle id has to come
-// from Apple's host-service framework instead. Item 3.1 / DAW-quirks
-// row 22 / item 5.11.
+// from Apple's host-service framework instead.
 //
 // Order of preference, in approximate reliability:
 //   1. `AU_HOST_BUNDLE_ID` / `AU_HOST_IDENTIFIER` environment variables
@@ -59,7 +58,7 @@ std::string current_auv3_wrapper_identifier() {
         // The previous identifier-suffix check was always false in real
         // AUv3 extension processes, so this function leaked the
         // extension's own bundle id as if it were the host id, breaking
-        // downstream host classification. (Codex #2967 / 3305508749.)
+        // downstream host classification.
         NSBundle* main = [NSBundle mainBundle];
         NSString* main_id = main ? [main bundleIdentifier] : nil;
         NSString* main_path = main ? [main bundlePath] : nil;


### PR DESCRIPTION
## Summary
- Removes stale issue, item, row, and reviewer breadcrumbs from host type comments.
- Keeps the current host-classification rationale for Digital Performer names, AUv3 wrapper identifiers, MainStage handling, and sandboxed extension bundle IDs.
- Comment-only hygiene; no code, API, or behavior changes.

## Validation
- RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.
- git diff --check origin/main..HEAD
- rg stale-marker scan over core/format/src/host_type.cpp and core/format/src/host_type_mac.mm (no matches)
- python3 tools/scripts/docs_noise_lint.py --mode=report
- PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/host-type-comment-hygiene
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/host-type-comment-hygiene

## CI note
Recent comment-hygiene draft PRs are currently hitting fast GitHub Actions cancellations on native workflows even after reruns; local runner capacity is free. This PR includes local validation evidence above.

## Trailers
Version-Bump: sdk=skip reason="comment-only hygiene; no SDK behavior or API change"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale issue/reviewer breadcrumbs from host-type comments and tightened wording for clarity. Kept the current rationale for Digital Performer naming, AUv3 wrapper identifiers, MainStage folding into Logic Pro, and sandboxed `.appex` bundle IDs; no code, API, or behavior changes.

<sup>Written for commit 36f435475f830b0a72e23951e3322fe063b8148e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

