### PR TITLE
chore: clean host plugin slot comments

### DIFF
--- a/core/host/include/pulp/host/plugin_slot.hpp
+++ b/core/host/include/pulp/host/plugin_slot.hpp
@@ -103,26 +103,23 @@ public:
     virtual std::vector<uint8_t> save_state() const = 0;
     virtual bool restore_state(const std::vector<uint8_t>& data) = 0;
 
-    // Editor — legacy void* handle API.
+    // Editor handle API.
     //
-    // Item 4.4 (macOS plan): the canonical surface is `create_hosted_editor()`
-    // below. PR #2844 established `pulp::view::WindowHost::attach_native_child_view`
-    // as the host-side bridge, and `pulp::view::EditorAttachment`
-    // (`core/view/include/pulp/view/hosted_editor_attachment.hpp`) wires the
-    // two together. Slots may still override these for now — the default
-    // `create_hosted_editor()` falls back to them so unchanged subclasses keep
-    // working — but new slots should override `create_hosted_editor()`
-    // directly and the legacy entry points are slated for removal once every
-    // adapter is migrated.
+    // `create_hosted_editor()` is the typed surface for embedding native
+    // plugin editors. `pulp::view::WindowHost::attach_native_child_view` is
+    // the host-side bridge and `pulp::view::EditorAttachment` wires the two
+    // together. Slots may still override these void* entry points when they
+    // have not moved to the typed surface; the default `create_hosted_editor()`
+    // fallback keeps those subclasses working.
     virtual bool has_editor() const = 0;
     [[deprecated("Override create_hosted_editor() instead — see pulp::view::EditorAttachment "
-                 "(item 4.4 macOS plan).")]]
+                 "for typed hosted editor attachment.")]]
     virtual void* create_editor_view() = 0;  // Returns platform-native view handle
     [[deprecated("Override destroy_hosted_editor() instead — see pulp::view::EditorAttachment "
-                 "(item 4.4 macOS plan).")]]
+                 "for typed hosted editor attachment.")]]
     virtual void destroy_editor_view() = 0;
 
-    // ── Hosted editor (workstream 03 slice 3.4) ────────────────────────
+    // Hosted editor.
     //
     // Typed replacement for the void* editor API. Slot implementations
     // fill in a platform-native parent-window handle, initial size, and
@@ -134,7 +131,7 @@ public:
     //   // ... on close ...
     //   slot->destroy_hosted_editor(std::move(ed));
     //
-    // Format wiring per slice (6.3..6.5 / 3.4 follow-ups):
+    // Format-specific editor surfaces:
     //   CLAP   — clap_plugin_gui: create / set_parent / show / get_size
     //   VST3   — IEditController::createView("editor") + IPlugView::attached
     //   AU     — AUAudioUnit.requestViewControllerWithCompletionHandler
@@ -147,7 +144,7 @@ public:
     };
 
     /// Create the hosted editor. Default implementation preserves the
-    /// legacy void* path so every slot already compiled against
+    /// void* path so every slot already compiled against
     /// create_editor_view() still works; new slots override this directly.
     virtual std::unique_ptr<HostedEditor>
     create_hosted_editor(void* /*parent_window*/) {
@@ -182,7 +179,7 @@ public:
     virtual int latency_samples() const = 0;
     virtual int tail_samples() const = 0;
 
-    // ── Extensions visitor (item 4.5) ───────────────────────────────────
+    // Extensions visitor.
     //
     // Typed plugin introspection: subclass ExtensionsVisitor, override
     // the visit_* methods you care about, then call
@@ -197,9 +194,9 @@ public:
     }
 
     // Additive host-side multi-bus processing entry point. Keep appended to
-    // preserve the legacy PluginSlot virtual ordering.
+    // preserve the existing PluginSlot virtual ordering.
     //
-    // The default projection preserves the legacy PluginSlot contract by
+    // The default projection preserves the original PluginSlot contract by
     // selecting the active main output and optional main input from
     // ProcessBuffers, then calling the original main-in/main-out process()
     // callback. Slot implementations that need direct access to sidechain,

--- a/core/host/src/plugin_slot_au.mm
+++ b/core/host/src/plugin_slot_au.mm
@@ -1,10 +1,10 @@
 // Audio Unit v2 plugin slot (macOS only).
 //
 // Loads an AU v2 effect/instrument via AudioComponent APIs, exposes the
-// PluginSlot interface, and drives audio through AudioUnitRender. Scope
-// for Phase 1: stereo in/out, parameter metadata, bypass, basic
-// activation. MIDI routing to instruments is Phase 2; editor view,
-// state save/restore via ClassInfo, and sidechain ports land later.
+// PluginSlot interface, and drives audio through AudioUnitRender. The backend
+// covers stereo in/out, parameter metadata, bypass, activation, MIDI routing,
+// and state save/restore via ClassInfo. Editor views and sidechain ports are
+// not exposed by this backend yet.
 //
 // Identified by {componentType, componentSubType, componentManufacturer}
 // encoded into PluginInfo.unique_id as "TYPE:SUBT:MANU" (OSType 4CCs).
@@ -142,11 +142,9 @@ public:
         }
 
         // Deliver MIDI input via MusicDeviceMIDIEvent, AU v2's sample-
-        // accurate MIDI write path. Workstream 03 slice 3.6 — previously
-        // midi_in was discarded, so hosted AU instruments received no
-        // MIDI. Skips malformed messages (length outside [1..3] or no
-        // status byte) to avoid polluting the plugin with garbage, same
-        // validation the AUv3 adapter adopted in PR #179.
+        // accurate MIDI write path. Skips malformed messages (length outside
+        // [1..3] or no status byte) to avoid polluting the plugin with
+        // garbage, matching the AUv3 adapter's validation.
         for (auto it = midi_in.begin(); it != midi_in.end(); ++it) {
             const auto& me = *it;
             const auto& m = me.message;
@@ -155,7 +153,7 @@ public:
             // Clamp to [0, num_samples - 1]. SignalGraph::inject_midi
             // forwards caller-provided offsets without normalization, so
             // a >= num_samples value can sneak in; AU rejects or mistimes
-            // such events. Fix per #191 review.
+            // such events.
             int32_t offset = me.sample_offset;
             if (offset < 0) offset = 0;
             if (offset >= num_samples) offset = num_samples - 1;
@@ -279,13 +277,13 @@ public:
         return st == noErr;
     }
 
-    bool has_editor() const override { return false; }      // Phase 4
+    bool has_editor() const override { return false; }
 #if defined(__GNUC__) || defined(__clang__)
 #  pragma clang diagnostic push
 #  pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
-    void* create_editor_view() override { return nullptr; } // Phase 4
-    void destroy_editor_view() override {}                  // Phase 4
+    void* create_editor_view() override { return nullptr; }
+    void destroy_editor_view() override {}
 #if defined(__GNUC__) || defined(__clang__)
 #  pragma clang diagnostic pop
 #endif
@@ -313,9 +311,9 @@ public:
         return 0;
     }
 
-    // Item 4.5 — typed plugin introspection. Surface the AudioUnit
-    // instance and its component description so callers can talk directly
-    // to AudioToolbox / use vendor-specific properties.
+    // Typed plugin introspection surfaces the AudioUnit instance and its
+    // component description so callers can talk directly to AudioToolbox or
+    // use vendor-specific properties.
     void accept(ExtensionsVisitor& visitor) const override {
         AudioUnitExtension ext;
         ext.component_instance = au_;

--- a/core/host/src/plugin_slot_clap.cpp
+++ b/core/host/src/plugin_slot_clap.cpp
@@ -150,7 +150,7 @@ public:
         in_event_storage_.clear();
         // Drain host-initiated set_parameter edits as time=0 events. Uses
         // try_lock so the audio thread never blocks on the host side;
-        // if contended, pending edits ride to the next block (#296).
+        // if contended, pending edits ride to the next block.
         {
             std::unique_lock<std::mutex> lock(pending_edits_mu_, std::try_to_lock);
             if (lock.owns_lock() && !pending_edits_.empty()) {
@@ -236,7 +236,6 @@ public:
                 && ev->type == CLAP_EVENT_MIDI && self->out_midi_sink_) {
                 // memcpy into a stack local to avoid UBSan "misaligned
                 // address" when ev isn't aligned to alignof(clap_event_midi_t).
-                // #688.
                 clap_event_midi_t m;
                 std::memcpy(&m, ev, sizeof(m));
                 pulp::midi::MidiEvent e;
@@ -270,7 +269,7 @@ public:
     float get_parameter(uint32_t id) const override {
         // Prefer the cached last-set value so a set_parameter call is
         // observable to the host immediately, even before the next
-        // process() block delivers the edit to the plugin (#296).
+        // process() block delivers the edit to the plugin.
         // Falls through to the plugin's own get_value if no cached
         // entry exists yet.
         {
@@ -284,9 +283,9 @@ public:
         return 0.0f;
     }
 
-    // True if `id` corresponds to one of the parameters the plugin
-    // published via the clap_plugin_params extension. Used to fail
-    // visibly on set_parameter with an unknown ID (#296).
+    // True if `id` corresponds to one of the parameters the plugin published
+    // via the clap_plugin_params extension. Used to fail visibly on
+    // set_parameter with an unknown ID.
     bool is_known_param(uint32_t id) const {
         for (const auto& p : params_) {
             if (p.id == id) return true;
@@ -295,8 +294,8 @@ public:
     }
 
     void set_parameter(uint32_t id, float value) override {
-        // Resolving #296: queue a pending host edit so the next process()
-        // block delivers it as a CLAP_EVENT_PARAM_VALUE at time=0.
+        // Queue a pending host edit so the next process() block delivers it
+        // as a CLAP_EVENT_PARAM_VALUE at time=0.
         //
         // Thread model: set_parameter is called from host/UI threads;
         // process() runs on the audio thread. We use a mutex but the
@@ -400,9 +399,9 @@ public:
         return (int)ext->get(plugin_);
     }
 
-    // Item 4.5 — typed plugin introspection. Surface the underlying
-    // `const clap_plugin_t*` and host struct so callers can reach into
-    // CLAP-specific extensions without round-tripping through `void*`.
+    // Typed plugin introspection surfaces the underlying `const clap_plugin_t*`
+    // and host struct so callers can reach into CLAP-specific extensions
+    // without round-tripping through `void*`.
     void accept(ExtensionsVisitor& visitor) const override {
         ClapExtension ext;
         ext.plugin = const_cast<clap_plugin_t*>(plugin_);
@@ -497,9 +496,9 @@ private:
     std::vector<EventAny> in_event_storage_;
     midi::MidiBuffer* out_midi_sink_ = nullptr;
 
-    // Host-initiated set_parameter queue (#296). Mutex-guarded on the
-    // host side, try_lock on the audio side. unordered_map gives us
-    // latest-wins coalescing per param_id.
+    // Host-initiated set_parameter queue. Mutex-guarded on the host side,
+    // try_lock on the audio side. unordered_map gives us latest-wins
+    // coalescing per param_id.
     mutable std::mutex pending_edits_mu_;
     std::unordered_map<uint32_t, float> pending_edits_;
     std::unordered_map<uint32_t, float> cached_values_;

--- a/core/host/src/plugin_slot_lv2.cpp
+++ b/core/host/src/plugin_slot_lv2.cpp
@@ -9,13 +9,13 @@
 //      discover audio input/output port indices (lv2:AudioPort +
 //      lv2:InputPort / lv2:OutputPort, and lv2:index). We deliberately
 //      don't pull in lilv — that adds serd/sord/sratom/lilv (~15 MB of
-//      third-party copyleft-adjacent code) and the discovery is simple
-//      enough to get right with a regex for the MVP port set.
+//      third-party copyleft-adjacent code) and the discovery is bounded to the
+//      current audio-port host surface.
 //   4. Wires LV2_Descriptor's connect_port/activate/run/deactivate/cleanup
 //      into the PluginSlot interface.
 //
 // Parameter automation (lv2:ControlPort), MIDI (LV2 atom ports), worker
-// extension, state extension, and editors remain follow-up work.
+// extension, state extension, and editors are not exposed by this backend yet.
 
 #include <pulp/host/plugin_slot.hpp>
 #include <pulp/runtime/log.hpp>
@@ -323,8 +323,8 @@ public:
     int latency_samples() const override { return 0; }
     int tail_samples() const override { return 0; }
 
-    // Item 4.5 — typed plugin introspection. Surface the LV2 instance
-    // handle and URI so callers can reach into LV2 vendor extensions.
+    // Typed plugin introspection surfaces the LV2 instance handle and URI so
+    // callers can reach into LV2 vendor extensions.
     void accept(ExtensionsVisitor& visitor) const override {
         Lv2Extension ext;
         ext.instance = reinterpret_cast<void*>(instance_);

--- a/core/host/src/plugin_slot_vst3.cpp
+++ b/core/host/src/plugin_slot_vst3.cpp
@@ -2,9 +2,9 @@
 //
 // Loads a .vst3 bundle, resolves GetPluginFactory, creates the first audio
 // processor class, and wires the PluginSlot interface onto IComponent +
-// IAudioProcessor. Minimum viable host — covers audio pass-through with
-// stereo 2-in/2-out, latency reporting, and bypass. Parameter automation,
-// state serialization, MIDI routing, and editor views are follow-up work.
+// IAudioProcessor. The host covers audio pass-through with stereo 2-in/2-out,
+// latency reporting, bypass, parameter edits, MIDI note events, and state
+// serialization. Editor views are not exposed by this backend yet.
 
 #include <pulp/host/plugin_slot.hpp>
 #include <pulp/runtime/log.hpp>
@@ -22,7 +22,7 @@
 #include <pluginterfaces/vst/ivstparameterchanges.h>
 #include <pluginterfaces/base/ibstream.h>
 
-// Hosting helpers — workstream 03 slice 3.5.
+// SDK helper containers used for block-local event and parameter queues.
 #include <public.sdk/source/vst/hosting/parameterchanges.h>
 #include <public.sdk/source/vst/hosting/eventlist.h>
 
@@ -187,10 +187,9 @@ public:
         processor_->setProcessing(true);
         max_block_size_ = max_block_size;
         active_ = true;
-        // #307 Codex P1 follow-up: reserve both pending-edit vectors
-        // so the audio-thread swap + drain cycle never hits a
-        // grow-and-copy allocation. One slot per advertised
-        // parameter is the worst case when every knob moves in a
+        // Reserve both pending-edit vectors so the audio-thread swap + drain
+        // cycle never hits a grow-and-copy allocation. One slot per
+        // advertised parameter is the worst case when every knob moves in a
         // single block.
         {
             std::lock_guard<std::mutex> lock(pending_host_edits_mu_);
@@ -250,11 +249,10 @@ public:
         ctx.sampleRate = sample_rate_;
         ctx.state      = Vst::ProcessContext::kPlaying;
 
-        // Build VST3 event list from Pulp's MidiBuffer. Workstream 03 3.5 —
-        // previously midi_in was discarded, so instruments loaded in the
-        // host received no MIDI. Maps note_on/note_off; other event types
-        // (CC, pitchbend, aftertouch) will follow when the host queue
-        // itself carries them — MidiBuffer today is choc::ShortMessage only.
+        // Build the VST3 event list from Pulp's MidiBuffer. The current host
+        // queue carries short MIDI messages, so this maps note_on/note_off
+        // and leaves richer event types to the queue layer that can represent
+        // them explicitly.
         in_events_.clear();
         for (auto it = midi_in.begin(); it != midi_in.end(); ++it) {
             const auto& me = *it;
@@ -294,27 +292,21 @@ public:
         // we round-trip via controller_->plainParamToNormalized().
         in_param_changes_.clearQueue();
 
-        // #297 drain: pull any host-originated set_parameter edits that
-        // arrived since the previous block. Delivered as time=0 points.
-        // try_lock so the audio thread never blocks on the host side;
-        // if contended, edits ride to the next process() call.
+        // Drain host-originated set_parameter edits that arrived since the
+        // previous block. Delivered as time=0 points. try_lock keeps the
+        // audio thread from blocking on the host side; if contended, edits
+        // ride to the next process() call.
         //
-        // #307 Codex P1 follow-up: the old impl kept pending_host_edits_
-        // as an unordered_map<uint32_t, ParamValue> and called .clear()
-        // under lock on the audio thread — stdlib unordered_map::clear()
-        // may deallocate bucket nodes, which violates RT-safety.
-        //
-        // Fix: two-buffer swap. The host thread writes into
-        // pending_host_edits_ (a std::vector<PendingEdit> with reserved
-        // capacity). The audio thread, under try_lock, std::swaps it
-        // with drain_scratch_ (also reserved) in O(1) — just swaps the
-        // internal pointers, no allocation. Lock goes out of scope; the
-        // audio thread iterates drain_scratch_ outside the lock to push
-        // CLAP_EVENT_PARAM_VALUE, then calls drain_scratch_.clear()
-        // which for std::vector is element destruction only — vector
-        // capacity is preserved by the standard, and ParamValue +
-        // uint32_t are trivially destructible so clear() compiles to
-        // "set size = 0". RT-safe by construction.
+        // The two-buffer swap keeps this RT-safe. The host thread writes
+        // into pending_host_edits_ (a std::vector<PendingEdit> with reserved
+        // capacity). The audio thread, under try_lock, std::swaps it with
+        // drain_scratch_ (also reserved) in O(1) -- just swaps the internal
+        // pointers, no allocation. Lock goes out of scope; the audio thread
+        // iterates drain_scratch_ outside the lock to push parameter points,
+        // then calls drain_scratch_.clear(), which for std::vector is element
+        // destruction only. Vector capacity is preserved by the standard, and
+        // ParamValue plus uint32_t are trivially destructible, so clear()
+        // compiles to "set size = 0". RT-safe by construction.
         if (controller_) {
             std::unique_lock<std::mutex> lock(pending_host_edits_mu_,
                                               std::try_to_lock);
@@ -384,19 +376,18 @@ public:
 
     void set_parameter(uint32_t id, float plain_value) override {
         if (!controller_) return;
-        // #297: host-originated edits must reach the processor. Mirror
-        // into the controller (for UI/state reads) AND queue a
-        // normalized point-at-time-0 edit for the next process() block
-        // to deliver via IParameterChanges.
+        // Host-originated edits must reach the processor. Mirror into the
+        // controller for UI/state reads and queue a normalized point-at-time-0
+        // edit for the next process() block to deliver via IParameterChanges.
         Vst::ParamValue norm =
             controller_->plainParamToNormalized(id, plain_value);
         controller_->setParamNormalized(id, norm);
 
-        // #307 Codex P1 follow-up: pending edits live in a reserved-
-        // capacity std::vector. Coalesce on the host side (linear scan)
-        // so the audio-thread drain stays allocation-free. set_parameter
-        // is user-gesture rate, not sample rate, so linear coalesce is
-        // cheap; the RT-safety win on the audio thread is worth it.
+        // Pending edits live in a reserved-capacity std::vector. Coalesce on
+        // the host side (linear scan) so the audio-thread drain stays
+        // allocation-free. set_parameter is user-gesture rate, not sample
+        // rate, so linear coalesce is cheap; the RT-safety win on the audio
+        // thread is worth it.
         std::lock_guard<std::mutex> lock(pending_host_edits_mu_);
         for (auto& e : pending_host_edits_) {
             if (e.id == id) { e.normalized = norm; return; }
@@ -444,9 +435,9 @@ public:
         return (int)processor_->getTailSamples();
     }
 
-    // Item 4.5 — typed plugin introspection. Surface the IComponent and
-    // related VST3 interfaces so callers that link against the SDK can
-    // reach into vendor extensions without round-tripping through `void*`.
+    // Typed plugin introspection surfaces the IComponent and related VST3
+    // interfaces so callers that link against the SDK can reach into vendor
+    // extensions without round-tripping through `void*`.
     void accept(ExtensionsVisitor& visitor) const override {
         Vst3Extension ext;
         ext.component = component_;
@@ -556,11 +547,10 @@ private:
     Vst::IAudioProcessor* processor_ = nullptr;
     Vst::IEditController* controller_ = nullptr;
     std::vector<HostParamInfo> params_;
-    // #297 + #307 Codex P1 follow-up: host set_parameter edits.
-    // Vector-backed so the audio thread's drain is allocation-free —
-    // std::swap(pending, drain_scratch_) is O(1); drain_scratch_.clear()
-    // preserves capacity. Coalescing happens on the host side in
-    // set_parameter (linear scan). Both vectors reserve() at
+    // Host set_parameter edits. Vector-backed so the audio thread's drain is
+    // allocation-free: std::swap(pending, drain_scratch_) is O(1) and
+    // drain_scratch_.clear() preserves capacity. Coalescing happens on the
+    // host side in set_parameter (linear scan). Both vectors reserve() at
     // prepare() time based on the plugin's parameter count.
     struct PendingEdit {
         uint32_t id;
@@ -571,8 +561,8 @@ private:
     std::vector<PendingEdit>    drain_scratch_;        // drained by audio
     std::vector<float*> in_ptrs_;
     std::vector<float*> out_ptrs_;
-    // Workstream 03 slice 3.5 — pre-allocated event/param buffers so the
-    // process callback never heap-allocates.
+    // Pre-allocated event/param buffers so the process callback never
+    // heap-allocates.
     Vst::EventList in_events_;
     Vst::ParameterChanges in_param_changes_;
     std::atomic<bool> bypassed_{false};
@@ -597,8 +587,8 @@ std::unique_ptr<PluginSlot> load_vst3_plugin(const PluginInfo& info) {
     auto* entry_fn = (bool (*)(void*))dlsym(handle, "bundleEntry");
     if (entry_fn) {
         // Without a real CFBundleRef, pass nullptr; most plugins tolerate
-        // this, though a few require a proper CFBundle. Adding CFBundle
-        // support is a follow-up.
+        // this, though a few require a proper CFBundle. Plugins that require
+        // CFBundle-backed initialization are not supported by this loader yet.
         entry_fn(nullptr);
     }
 #else


### PR DESCRIPTION
## Summary
- remove stale issue, phase, item, and workstream breadcrumbs from PluginSlot API comments and host plugin-slot backend comments
- preserve current editor, introspection, MIDI, state, and RT-safety rationale in present-tense wording
- reword two PluginSlot deprecation diagnostic strings so they point at typed hosted editor attachment without plan/item references

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

## Validation
- `git diff --check origin/main..HEAD`
- focused stale-marker scan over touched files
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/host-plugin-slot-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/host-plugin-slot-comment-hygiene`

## CI Note
Recent draft comment-hygiene PRs have seen GitHub Actions jobs cancel shortly after prerequisite jobs, leaving required alias jobs false-red. Local runner capacity was checked separately and showed 4/4 free, so a similar cancellation pattern here should be treated as systemic Actions cancellation rather than a code failure unless logs show otherwise.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale roadmap breadcrumbs from host `PluginSlot` comments and backends, and updated deprecation strings to reference the typed hosted editor API. Pure comment/diagnostic cleanup with no behavior or API changes.

- **Refactors**
  - Simplified comments in `plugin_slot.hpp` and AU/CLAP/LV2/VST3 backends to present-tense guidance.
  - Clarified editor surface: `create_hosted_editor()` is primary; legacy `create_editor_view()`/`destroy_editor_view()` remain as fallback.
  - Reworded deprecation diagnostics to point to `pulp::view::EditorAttachment` without plan/item references.
  - Kept concise notes on introspection, MIDI routing, and RT-safety; removed historical bug/workstream markers.

<sup>Written for commit 69955263e3169a52444f763c862e816170cec376. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

