### PR TITLE
chore: clean signal graph comments

### DIFF
--- a/core/host/include/pulp/host/extensions_visitor.hpp
+++ b/core/host/include/pulp/host/extensions_visitor.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-// ExtensionsVisitor — typed plugin introspection (item 4.5).
+// ExtensionsVisitor — typed plugin introspection.
 //
 // PluginSlot intentionally abstracts the format (VST3, AU, CLAP, LV2) so that
 // host code can drive any plugin through a single interface. Sometimes,

--- a/core/host/include/pulp/host/graph_serializer.hpp
+++ b/core/host/include/pulp/host/graph_serializer.hpp
@@ -12,7 +12,8 @@
 // error. Plugin binaries are NEVER embedded — that breaks signing,
 // notarization, and AU/AUv3 component-manager registration.
 //
-// Phase 3 of planning/signal-graph-followups-plan.md.
+// Schema changes must go through registered migrations so older saved graphs
+// either upgrade deterministically or fail with an explicit load error.
 
 #include <pulp/host/signal_graph.hpp>
 #include <functional>

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -58,7 +58,7 @@ struct CustomNodeType {
     std::string default_name;
     CustomNodeProcessFn process;  // stateless (used when `create` is empty)
 
-    // ── Optional stateful lifecycle (Phase 5) ──────────────────────────────
+    // Optional stateful lifecycle.
     // When `create` is set, the graph owns ONE opaque instance per node (RAII
     // via `destroy`). `process_instance` runs instead of `process`, and
     // prepare/release/reset/save_state/load_state operate on that instance. All
@@ -104,7 +104,7 @@ struct Connection {
     bool audio_rate_modulation = false; // dense CV edge into an AudioRate param.
     bool sidechain = false;   // sidechain-edge: like a normal audio edge, but
                               // routes into one of the destination plugin's
-                              // sidechain-bus input ports (item 4.7). The
+                              // sidechain-bus input ports. The
                               // topological-sort + PDC treat sidechain as a
                               // hard edge — it is not a back-edge.
 
@@ -113,7 +113,7 @@ struct Connection {
     uint32_t automation_param_id  = 0;
     float automation_range_lo     = 0.0f;  // plain param domain
     float automation_range_hi     = 1.0f;  // plain param domain
-    float automation_smoothing_ms = 0.0f;  // per-source pre-mix slew (item 4.6)
+    float automation_smoothing_ms = 0.0f;  // per-source pre-mix slew
     AutomationMix automation_mix  = AutomationMix::Replace;
 
     bool operator==(const Connection& o) const {
@@ -157,8 +157,8 @@ struct GraphNode {
     std::string custom_type_id;
     int custom_type_version = 0;
 
-    // Phase 5 — opaque state for a stateful custom node. `custom_instance` is
-    // the live per-node object (RAII via the type's destroy), created on the UI
+    // Opaque state for a stateful custom node. `custom_instance` is the live
+    // per-node object (RAII via the type's destroy), created on the UI
     // thread in prepare() and captured into each compiled snapshot like a
     // plugin shared_ptr so old audio snapshots stay alive. `custom_state_blob`
     // is the serialized form, preserved even when the type is unresolved (so a
@@ -264,7 +264,7 @@ public:
                                       int num_outputs,
                                       const std::string& name);
 
-    // Phase 5 — opaque per-node state for stateful custom nodes.
+    // Opaque per-node state for stateful custom nodes.
     // custom_node_state() returns the live instance's save_state() when the node
     // is resolved + stateful, else the last-loaded blob (preserved for
     // unresolved nodes). Empty when `id` is not a custom node or has no state.
@@ -294,8 +294,8 @@ public:
     // audio connections.
     bool connect_midi(NodeId source, NodeId dest);
 
-    // Sidechain connection (item 4.7): routes a source's audio output port
-    // into the destination plugin's sidechain bus port. The destination
+    // Sidechain connection: routes a source's audio output port into the
+    // destination plugin's sidechain bus port. The destination
     // port is `dest_sidechain_port` — the caller supplies the absolute
     // port index on the destination node (the host knows how many main
     // input ports a plugin exposes via PluginInfo::num_inputs; sidechain
@@ -411,11 +411,11 @@ public:
     // the node is unknown or the graph is not prepared.
     int node_latency_samples(NodeId id) const;
 
-    // Set a parameter on a Plugin node at the graph level. The call is
-    // forwarded to PluginSlot::set_parameter(). Returns false if the node
-    // is not a Plugin node or has no loaded slot. This is the single-value
-    // knob — full automation-curve routing (one node's output driving
-    // another node's parameter over a block) is follow-up work.
+    // Set a single parameter value on a Plugin node at the graph level. The
+    // call is forwarded to PluginSlot::set_parameter(). Returns false if the
+    // node is not a Plugin node or has no loaded slot. For block-rate routing
+    // from graph audio into parameters, use connect_automation() or
+    // connect_audio_rate_modulation().
     bool set_node_parameter(NodeId id, uint32_t param_id, float value);
 
     // Read a parameter's current value from a Plugin node (returns 0.0f if
@@ -504,7 +504,7 @@ private:
         uint64_t midi_input_sequence_seen = 0;
 
         // Audio-rate modulation scratch. Each listed param gets one
-        // max-block-sized slice in audio_rate_param_data, filled immediately
+        // max-block-sized region in audio_rate_param_data, filled immediately
         // before the destination plugin processes.
         struct DenseAutomationAccum {
             float lo = 0.0f;
@@ -530,7 +530,7 @@ private:
         // destination can read it before the source writes the current block.
         std::vector<float> feedback_prev;  // size = max_block_size_
 
-        // Item 4.6 — per-source automation slew state. Holds the value
+        // Per-source automation slew state. Holds the value
         // we last delivered to the destination (post-slew, post range-
         // map) so the next block can resume ramping toward a new target
         // instead of snapping. `primed` tracks whether `last_value` has
@@ -577,8 +577,8 @@ private:
         std::unordered_map<NodeId, NodeShape> shapes;
         std::vector<OrderedRuntime> ordered_runtime;
         int max_block_size = 0;
-        double sample_rate = 0.0;  // item 4.6 — needed to convert
-                                   // automation_smoothing_ms into samples.
+        double sample_rate = 0.0;  // needed to convert automation_smoothing_ms
+                                   // into samples.
         int64_t total_latency_samples = 0;
         MidiBlockSnapshot midi_publish_scratch;
     };
@@ -620,7 +620,7 @@ private:
                                        const std::vector<Connection>& connections);
 };
 
-// ── Drag-add helper (item 4.3) ──────────────────────────────────────────
+// Drag-add helper.
 //
 // `add_plugin_node_from_drop` is the host-side companion to
 // `pulp::view::PluginManagerPanel::on_row_drag_start`. It attempts to

--- a/core/host/src/graph_serializer.cpp
+++ b/core/host/src/graph_serializer.cpp
@@ -422,8 +422,8 @@ std::string GraphSerializer::to_json(
             custom_obj.addMember(
                 "version",
                 (int64_t)(n.custom_type_version > 0 ? n.custom_type_version : 1));
-            // Phase 5 — opaque custom-node state (live instance's save_state, or
-            // the preserved blob for unresolved nodes). Omitted when empty so
+            // Opaque custom-node state: the live instance's save_state(), or
+            // the preserved blob for unresolved nodes. Omitted when empty so
             // stateless process-only nodes serialize byte-for-byte as before.
             if (auto state = graph.custom_node_state(n.id); !state.empty()) {
                 custom_obj.addMember("state_b64", b64_encode(state));
@@ -453,7 +453,7 @@ std::string GraphSerializer::to_json(
         co.addMember("midi",        c.midi);
         co.addMember("automation",  c.automation);
         co.addMember("audio_rate_modulation", c.audio_rate_modulation);
-        // Item 4.7 — sidechain flag is additive; absent in older blobs.
+        // Sidechain flag is additive; absent in older blobs.
         co.addMember("sidechain",   c.sidechain);
         if (c.automation || c.audio_rate_modulation) {
             co.addMember("auto_param_id",  (int64_t)c.automation_param_id);
@@ -550,9 +550,9 @@ GraphSerializer::LoadResult GraphSerializer::from_json(SignalGraph& graph, const
                         new_id = graph.add_unresolved_custom_node(
                             type_id, version, in_ch, out_ch, name);
                     }
-                    // Phase 5 — restore opaque custom-node state. Applied to a
-                    // resolved node's instance on its next prepare(); for an
-                    // unresolved node the blob is preserved so a re-save keeps it.
+                    // Restore opaque custom-node state. Applied to a resolved
+                    // node's instance on its next prepare(); for an unresolved
+                    // node the blob is preserved so a re-save keeps it.
                     if (new_id != 0 && nv.hasObjectMember("custom")) {
                         const auto& cv2 = nv["custom"];
                         if (cv2.hasObjectMember("state_b64")) {

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -1,11 +1,11 @@
 // Signal Graph implementation.
 //
-// Phase 0B: audio-thread reads happen against a CompiledGraph snapshot,
-// published via an atomic raw pointer. UI-thread topology mutations (add_*,
-// connect*, disconnect, remove_node) invalidate the snapshot; prepare()
-// rebuilds and publishes a fresh snapshot. Control-thread shared_ptr owners
-// keep retired snapshots alive until active process readers drain, avoiding
-// libstdc++'s lock-taking atomic shared_ptr path in process().
+// Audio-thread reads happen against a CompiledGraph snapshot published via an
+// atomic raw pointer. UI-thread topology mutations (add_*, connect*,
+// disconnect, remove_node) invalidate the snapshot; prepare() rebuilds and
+// publishes a fresh snapshot. Control-thread shared_ptr owners keep retired
+// snapshots alive until active process readers drain, avoiding libstdc++'s
+// lock-taking atomic shared_ptr path in process().
 // See signal_graph.hpp for the mutation protocol details.
 
 #include <pulp/host/signal_graph.hpp>
@@ -180,9 +180,9 @@ std::string custom_node_key(std::string_view type_id, int version) {
     return key;
 }
 
-// Phase 5 — make a per-node opaque instance owned via shared_ptr, with the
-// type's destroy callback as the deleter (RAII). Returns nullptr for stateless
-// types (no `create`).
+// Make a per-node opaque instance owned via shared_ptr, with the type's destroy
+// callback as the deleter (RAII). Returns nullptr for stateless types (no
+// `create`).
 std::shared_ptr<void> make_custom_instance(const CustomNodeType& type) {
     if (!type.create) return nullptr;
     void* raw = type.create();
@@ -1017,11 +1017,11 @@ SignalGraph::compile_(double sample_rate, int max_block_size) {
                                                     n.custom_type_version);
                 type && custom_type_matches_node_shape(*type, n)) {
                 if (n.custom_instance && type->process_instance) {
-                    // Phase 5 — bind the stateful processor. The lambda captures
-                    // the instance shared_ptr BY VALUE, so this snapshot keeps
-                    // the instance alive for its whole audio-thread lifetime
-                    // (same guarantee as cg->plugins[...] for plugin nodes). No
-                    // raw pointer into GraphNode is stored.
+                    // Bind the stateful processor. The lambda captures the
+                    // instance shared_ptr BY VALUE, so this snapshot keeps the
+                    // instance alive for its whole audio-thread lifetime (same
+                    // guarantee as cg->plugins[...] for plugin nodes). No raw
+                    // pointer into GraphNode is stored.
                     auto inst = n.custom_instance;
                     auto fn = type->process_instance;
                     cg->custom_processors[n.id] =
@@ -1175,9 +1175,9 @@ bool SignalGraph::prepare(double sample_rate, int max_block_size) {
         }
     }
 
-    // Phase 5 — create/prepare stateful custom-node instances on this (UI)
-    // thread before the snapshot is published, mirroring the plugin step above.
-    // A freshly-loaded state blob is applied exactly once via load_state.
+    // Create/prepare stateful custom-node instances on this UI thread before
+    // the snapshot is published, mirroring the plugin step above. A
+    // freshly-loaded state blob is applied exactly once via load_state.
     for (auto& n : nodes_) {
         if (n.type != NodeType::Custom) continue;
         const CustomNodeType* type =
@@ -1309,9 +1309,9 @@ void SignalGraph::release() {
     wait_for_retired_snapshots_();
 
     for (auto& n : nodes_) if (n.plugin) n.plugin->release();
-    // Phase 5 — release stateful custom instances (UI thread), mirroring the
-    // plugin release above. The instance object stays alive until its snapshots
-    // also drop; release() just lets the type free scratch.
+    // Release stateful custom instances on the UI thread, mirroring the plugin
+    // release above. The instance object stays alive until its snapshots also
+    // drop; release() just lets the type free scratch.
     for (auto& n : nodes_) {
         if (n.type != NodeType::Custom || !n.custom_instance) continue;
         if (const auto* type =
@@ -1491,12 +1491,12 @@ void SignalGraph::process(audio::BufferView<float>& output,
             case NodeType::Plugin: {
                 auto pit = cg->plugins.find(id);
                 if (pit == cg->plugins.end() || !pit->second) {
-                    // Issue #491 P2 bonus: graph_serializer rehydration
-                    // creates a "placeholder" Plugin node when the saved
-                    // plugin can't be resolved (missing / moved / wrong
-                    // format). Without an explicit branch here, output
-                    // scratch keeps whatever stale data it carried —
-                    // audible artifacts on the next AudioOutput gather.
+                    // GraphSerializer rehydration creates a placeholder Plugin
+                    // node when the saved plugin can't be resolved (missing,
+                    // moved, or wrong format). Without an explicit branch
+                    // here, output scratch keeps whatever stale data it
+                    // carried, causing audible artifacts on the next
+                    // AudioOutput gather.
                     // Deterministic fallback: pass input → output when
                     // channel counts match, zero-fill when they don't.
                     pass_through_or_zero(rt);
@@ -1557,12 +1557,12 @@ void SignalGraph::process(audio::BufferView<float>& output,
                         float mN = c.automation_range_lo
                             + sN * (c.automation_range_hi - c.automation_range_lo);
 
-                        // Item 4.6 — per-source linear slew. The user
-                        // declares automation_smoothing_ms; we limit how
-                        // far the delivered value can move per sample at
-                        // that ramp speed. State (last_value/primed)
-                        // lives on the parallel ConnectionDelay so it
-                        // survives the next block.
+                        // Per-source linear slew. The user declares
+                        // automation_smoothing_ms; we limit how far the
+                        // delivered value can move per sample at that ramp
+                        // speed. State (last_value/primed) lives on the
+                        // parallel ConnectionDelay so it survives the next
+                        // block.
                         if (c.automation_smoothing_ms > 0.0f
                             && cg->sample_rate > 0.0
                             && ci < cg->connection_delays.size()) {
@@ -1896,7 +1896,7 @@ float SignalGraph::node_gain(NodeId id) const {
     return n->gain;
 }
 
-// ── Drag-add helper (item 4.3) ──────────────────────────────────────────
+// Drag-add helper.
 NodeId add_plugin_node_from_drop(SignalGraph& graph,
                                  const PluginInfo& info,
                                  bool* loaded_out)


### PR DESCRIPTION
## Summary
- remove stale planning phase, item, and issue breadcrumbs from SignalGraph, GraphSerializer, and ExtensionsVisitor comments
- preserve present-tense descriptions of snapshot publishing, custom-node state, sidechain metadata, automation slew, and drag-add fallback behavior
- correct the set_node_parameter comment to point at the existing automation routing APIs instead of describing that path as future work

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

## Validation
- `git diff --check origin/main..HEAD`
- focused stale-marker scan over touched files
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/signal-graph-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/signal-graph-comment-hygiene`

## CI Note
Recent draft comment-hygiene PRs have seen GitHub Actions jobs cancel shortly after prerequisite jobs, leaving required alias jobs false-red. Local runner capacity was checked separately and showed 4/4 free, so a similar cancellation pattern here should be treated as systemic Actions cancellation rather than a code failure unless logs show otherwise.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up comment docs across the signal graph to remove stale planning/issue breadcrumbs and clarify current behavior and APIs. No code, API, or runtime behavior changes.

- **Refactors**
  - Rewrote comments in `signal_graph.hpp/.cpp`, `graph_serializer.hpp/.cpp`, and `extensions_visitor.hpp` to present tense; clarified snapshot publishing, custom-node lifecycle/state, sidechain flag, automation slew, and drag‑add fallback.
  - Updated `set_node_parameter` docs to point to existing `connect_automation()` and `connect_audio_rate_modulation()` APIs.
  - Tightened GraphSerializer notes on schema migrations and custom-node state (serialize/restore).

<sup>Written for commit 0b2f4286c8ab171bf12a2c571b032152ef219a65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

