### PR TITLE
chore: clean events runtime comments

### DIFF
--- a/core/events/src/interprocess_connection.cpp
+++ b/core/events/src/interprocess_connection.cpp
@@ -37,9 +37,8 @@ std::optional<uint16_t> parse_port(std::string_view text) {
     return static_cast<uint16_t>(value);
 }
 
-// Companion-track U-8 (planning/2026-05-17-refactor-roadmap-final.md).
-// Consolidates host:port parsing previously duplicated across
-// connect(), create_server(), server.start(), and server.stop().
+// Shared socket endpoint parser for connect(), create_server(),
+// server.start(), and server.stop().
 //
 // Behavior:
 // - "host:port"  → {host, port}

--- a/core/events/src/plugin_main_thread_mac.mm
+++ b/core/events/src/plugin_main_thread_mac.mm
@@ -1,5 +1,4 @@
-// macOS Cocoa backend registration for MainThreadDispatcher in plugin mode
-// (item 6.4b macOS plan).
+// macOS Cocoa backend registration for MainThreadDispatcher in plugin mode.
 //
 // Adapter code (AU v3 / VST3 / CLAP on macOS) calls register_plugin_backend()
 // at instance construction time and unregister_plugin_backend() at teardown.


### PR DESCRIPTION
## Summary
- remove stale planning item breadcrumbs from event runtime comments
- keep the current MainThreadDispatcher plugin backend lifecycle and shared socket endpoint parser behavior documented in present-tense wording

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

## Validation
- `git diff --check origin/main..HEAD`
- focused stale-marker scan over touched files
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/events-runtime-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/events-runtime-comment-hygiene`

## CI Note
Recent draft comment-hygiene PRs have seen GitHub Actions jobs cancel shortly after prerequisite jobs, leaving required alias jobs false-red. Local runner capacity was checked separately and showed 4/4 free, so a similar cancellation pattern here should be treated as systemic Actions cancellation rather than a code failure unless logs show otherwise.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale planning breadcrumbs from events runtime comments. Clarified present-tense docs for the macOS MainThreadDispatcher plugin backend and the shared socket endpoint parser used by `connect()`, `create_server()`, `server.start()`, and `server.stop()`.

<sup>Written for commit 5738edb3618ce60d00942c475ab67b55376a0b32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

