### PR TITLE
chore: clean osc udp comment

### DIFF
--- a/core/osc/src/osc_udp.cpp
+++ b/core/osc/src/osc_udp.cpp
@@ -382,7 +382,7 @@ void Receiver::stop() {
 }
 
 void Receiver::stop_impl(bool destroying) {
-    // Shutdown ordering matters (#490). The receive thread may be
+    // Shutdown ordering matters. The receive thread may be
     // blocked inside recv() on this FD right now. If we close the FD
     // before joining, POSIX kernels are free to recycle that FD number
     // for an unrelated file/socket immediately — the receive thread's


### PR DESCRIPTION
## Summary
- remove a stale issue breadcrumb from the OSC UDP shutdown-ordering comment
- preserve the current receive-thread/socket close ordering invariant in present-tense wording

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

## Validation
- `git diff --check origin/main..HEAD`
- focused stale-marker scan over touched file
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/osc-udp-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/osc-udp-comment-hygiene`

## CI Note
Recent draft comment-hygiene PRs have seen GitHub Actions jobs cancel shortly after prerequisite jobs, leaving required alias jobs false-red. Local runner capacity was checked separately and showed 4/4 free, so a similar cancellation pattern here should be treated as systemic Actions cancellation rather than a code failure unless logs show otherwise.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned the OSC UDP shutdown comment by removing a stale issue reference and clarifying the current ordering between the receive thread and socket close. No behavior changes.

<sup>Written for commit 5f52c2b887532cf2c911835a81b2f0726fa04889. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

