### PR TITLE
chore: clean runtime utility comments

### DIFF
--- a/core/runtime/include/pulp/runtime/scoped_no_alloc.hpp
+++ b/core/runtime/include/pulp/runtime/scoped_no_alloc.hpp
@@ -15,10 +15,9 @@ namespace pulp::runtime {
 /// * Pulp's audio (@c Processor::process) and paint
 ///   (@c View::paint_all) paths are wrapped in @c ScopedNoAlloc, so
 ///   the contract is enforced uniformly.
-/// * Sanitizers / debug allocator hooks query
+/// * Sanitizers / debug allocator hooks can query
 ///   @c is_in_no_alloc_scope() and abort / log if an allocation
-///   sneaks into the scope. We provide an opt-in hook library for
-///   that in a follow-up; today the class is the contract surface.
+///   sneaks into the scope. This class is the contract surface.
 /// * The guard is a no-op in @c NDEBUG so it costs nothing in
 ///   release builds — same shape as @c PULP_DBG_ASSERT.
 ///
@@ -35,7 +34,6 @@ public:
     // calls to symbols the Release archive didn't ship). The body of
     // each ctor/dtor is conditional on NDEBUG inside scoped_no_alloc.cpp
     // — the symbol exists in both modes but does nothing in Release.
-    // Codex P1 on PR #2316.
     ScopedNoAlloc() noexcept;
     ~ScopedNoAlloc() noexcept;
 

--- a/core/runtime/src/scoped_no_alloc.cpp
+++ b/core/runtime/src/scoped_no_alloc.cpp
@@ -9,7 +9,7 @@ thread_local int g_depth = 0;
 // Symbol always defined so mixed-mode linking (Release SDK + Debug
 // downstream consumer, or vice versa) doesn't see a header that
 // emits a call to a symbol the archive omits. The body is the
-// no-op variant under NDEBUG. Codex P1 on PR #2316.
+// no-op variant under NDEBUG.
 ScopedNoAlloc::ScopedNoAlloc() noexcept {
 #ifndef NDEBUG
     ++g_depth;

--- a/core/runtime/src/url.cpp
+++ b/core/runtime/src/url.cpp
@@ -12,8 +12,7 @@ namespace {
 
 // Parse an all-digits port. Returns nullopt on empty, non-digit, leading
 // sign, or > 65535. strtol() alone accepts trailing junk like "80abc",
-// which would silently parse as a valid URL — pinned by the Codex P2
-// review comment "Reject non-numeric URL ports".
+// which would silently parse as a valid URL.
 std::optional<uint16_t> parse_port(std::string_view text) {
     if (text.empty()) return std::nullopt;
     uint32_t value = 0;

--- a/core/runtime/src/zip.cpp
+++ b/core/runtime/src/zip.cpp
@@ -112,8 +112,8 @@ std::optional<std::vector<uint8_t>> inflate_raw(const uint8_t* data, size_t size
 // Like inflate_raw, but for a deflate stream that may be followed by trailing
 // bytes (e.g. a gzip trailer + the next member's header). Reports how many
 // input bytes were consumed up to and including MZ_STREAM_END so the caller
-// can continue past the stream. Codex P2 on PR #747 — required for
-// concatenated RFC 1952 gzip members.
+// can continue past the stream. Required for concatenated RFC 1952 gzip
+// members.
 std::optional<std::vector<uint8_t>> inflate_raw_consumed(
         const uint8_t* data, size_t size, size_t* consumed_in) {
     if (data == nullptr || size == 0)
@@ -201,8 +201,8 @@ std::optional<std::vector<uint8_t>> gzip_compress(const uint8_t* data, size_t si
 std::optional<std::vector<uint8_t>> gzip_decompress(const uint8_t* data, size_t size) {
     // RFC 1952 gzip path — detect via magic bytes 0x1f 0x8b.
     //
-    // Loop over concatenated members (Codex P2 on PR #747). RFC 1952 §2.2
-    // permits a gzip file to contain multiple members back-to-back; tools
+    // Loop over concatenated members. RFC 1952 §2.2 permits a gzip file to
+    // contain multiple members back-to-back; tools
     // like `pigz`, `cat a.gz b.gz`, and gzip producers that split streams
     // emit them. Each member has its own header + deflate stream + 8-byte
     // trailer (CRC32 + ISIZE). The output is the concatenation of every


### PR DESCRIPTION
## Summary
- remove stale review/PR breadcrumbs from runtime utility comments
- preserve the current no-allocation ABI, URL port parsing, and gzip concatenated-member rationale in present-tense wording

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

## Validation
- `git diff --check origin/main..HEAD`
- focused stale-marker scan over touched files
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/runtime-utility-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/runtime-utility-comment-hygiene`

## CI Note
Recent draft comment-hygiene PRs have seen GitHub Actions jobs cancel shortly after prerequisite jobs, leaving required alias jobs false-red. Local runner capacity was checked separately and showed 4/4 free, so a similar cancellation pattern here should be treated as systemic Actions cancellation rather than a code failure unless logs show otherwise.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned runtime utility comments by removing stale PR/review breadcrumbs and tightening wording. No behavior changes; keeps clear rationale for the no-allocation ABI in `ScopedNoAlloc`, strict numeric URL port parsing, and support for concatenated RFC 1952 gzip members.

<sup>Written for commit 6979ac4c702df73ab2054d4376aab827e8439cba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

