### PR TITLE
docs(midi): clean BLE MIDI packet comment breadcrumb

### DIFF
--- a/core/midi/src/ble_midi_packet.cpp
+++ b/core/midi/src/ble_midi_packet.cpp
@@ -75,7 +75,7 @@ bool BleMidiPacketDecoder::decode(const uint8_t* data, std::size_t size) {
     // packets would let a leading data byte in the next packet be
     // mis-emitted as a fabricated channel-voice event using the prior
     // packet's status. Sysex is the only state explicitly defined to
-    // span packets — we leave `sysex_buffer_` alone. Codex PR #3017 P2.
+    // span packets, so the in-flight `sysex_buffer_` is preserved.
     last_status_ = 0;
 
     std::size_t i = 1;


### PR DESCRIPTION
## Summary
- remove a stale Codex PR breadcrumb from the BLE MIDI packet decoder comment
- keep the current packet-scoped running-status and SysEx preservation invariant documented

## Validation
- rg stale-marker scan over core/midi/src/ble_midi_packet.cpp
- git diff --check
- git diff --check origin/main..HEAD
- python3 tools/scripts/docs_noise_lint.py --mode=report
- PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/ble-midi-comment-hygiene
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/ble-midi-comment-hygiene

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

Version-Bump: sdk=skip reason="comment-only hygiene; no SDK behavior or API change"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a stale breadcrumb from the BLE MIDI packet decoder comment and clarified invariants: running status resets per packet, but the in-flight `sysex_buffer_` is preserved. No behavior or API changes.

<sup>Written for commit e3f551ce80e9f65b1994baf905ed8156d6baaa37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

