### PR TITLE
docs(midi): clean message collector comment breadcrumbs

### DIFF
--- a/core/midi/include/pulp/midi/message_collector.hpp
+++ b/core/midi/include/pulp/midi/message_collector.hpp
@@ -115,9 +115,9 @@ public:
         // Walk the consumer-owned `pending_` ring first: any deferred-
         // future entry whose timestamp now fits the current block is
         // delivered. Entries that are still in the future stay put so
-        // a later block can consume them. (Pulled out of the queue so
-        // the consumer thread never writes back to the SPSC FIFO —
-        // Codex P1 on #2843.)
+        // a later block can consume them. Keeping these events out of
+        // the producer queue ensures the consumer thread never writes
+        // back to the SPSC FIFO it is draining.
         for (auto& slot : pending_) {
             if (slot.has_value() && slot->timestamp_seconds < block_end_seconds) {
                 deliver(*slot);
@@ -128,10 +128,9 @@ public:
 
         // Drain the queue. Events that fit the current block are
         // delivered immediately; future events are stashed in the
-        // consumer-owned pending ring. We KEEP draining even after a
+        // consumer-owned pending ring. Draining continues after a
         // future event lands so later in-block events still get
-        // delivered this block (Codex P1 on #2856 — earlier
-        // break-after-stash starved out-of-order in-block items).
+        // delivered when producer timestamps arrive out of order.
         //
         // The pending ring is sized (`kPendingSlots`) to absorb the
         // realistic Pulp workloads in one drain: UI clicks, scripting


### PR DESCRIPTION
## Summary
- remove stale Codex review breadcrumbs from MIDI message collector comments
- preserve the current SPSC ownership and out-of-order delivery invariants

## Validation
- rg stale-marker scan over core/midi/include/pulp/midi/message_collector.hpp
- git diff --check
- git diff --check origin/main..HEAD
- python3 tools/scripts/docs_noise_lint.py --mode=report
- PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/midi-message-collector-comment-hygiene
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/midi-message-collector-comment-hygiene

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

Version-Bump: sdk=skip reason="comment-only hygiene; no SDK behavior or API change"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale review breadcrumbs from `core/midi/include/pulp/midi/message_collector.hpp` comments and clarified SPSC consumer ownership and out-of-order delivery behavior. Comment-only; no behavior or API changes.

<sup>Written for commit 61c5a4142b81b85eb4e350c365291dbd170e90cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

