### PR TITLE
docs(midi): clean raw parser comment breadcrumb

### DIFF
--- a/core/midi/include/pulp/midi/raw_midi_parser.hpp
+++ b/core/midi/include/pulp/midi/raw_midi_parser.hpp
@@ -23,7 +23,7 @@
 // F0 stream without sending F7 — common on disconnect or firmware
 // glitches. We drop the partial buffer and parse that status byte
 // as the start of a new message, rather than silently consuming the
-// next real message as sysex payload (#406 Codex P2).
+// next real message as SysEx payload.
 //
 // RT-safety contract:
 //


### PR DESCRIPTION
## Summary
- remove a stale Codex review breadcrumb from the raw MIDI parser design note
- preserve the current aborted-SysEx behavior description

## Validation
- rg stale-marker scan over core/midi/include/pulp/midi/raw_midi_parser.hpp
- git diff --check
- git diff --check origin/main..HEAD
- python3 tools/scripts/docs_noise_lint.py --mode=report
- PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/raw-midi-parser-comment-hygiene
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/raw-midi-parser-comment-hygiene

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

Version-Bump: sdk=skip reason="comment-only hygiene; no SDK behavior or API change"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a stale review breadcrumb from the raw MIDI parser header comment and clarified the aborted SysEx behavior wording. No functional changes; parser behavior is unchanged.

<sup>Written for commit a7d3d60d5f78e272a8f5236fb1d4492e69508b17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

