### PR TITLE
docs(midi): clean device callback comment breadcrumb

### DIFF
--- a/core/midi/include/pulp/midi/device.hpp
+++ b/core/midi/include/pulp/midi/device.hpp
@@ -34,7 +34,7 @@ public:
     /// this as a no-op; callers can still register safely. Backends
     /// that DO support it (Win mmeapi MIM_LONGDATA, future CoreMIDI
     /// reassembly, ALSA SND_SEQ_EVENT_SYSEX) call this BEFORE open()
-    /// to register the receiver. #19 / #239.
+    /// to register the receiver.
     virtual void set_sysex_callback(MidiSysexCallback /*cb*/) {}
 };
 


### PR DESCRIPTION
## Summary
- remove a stale issue breadcrumb from the MIDI input SysEx callback comment
- preserve the current register-before-open contract for backends that support SysEx delivery

## Validation
- rg stale-marker scan over core/midi/include/pulp/midi/device.hpp
- git diff --check
- git diff --check origin/main..HEAD
- python3 tools/scripts/docs_noise_lint.py --mode=report
- PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/midi-device-comment-hygiene
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/midi-device-comment-hygiene

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

Version-Bump: sdk=skip reason="comment-only hygiene; no SDK behavior or API change"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove stale issue references from the MIDI input SysEx callback comment in `core/midi/include/pulp/midi/device.hpp`, keeping the register-before-open contract explicit for backends that deliver SysEx. No behavior or API changes.

<sup>Written for commit 86ccf2f29642a8a42302da427e104600ee84915b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

