### PR TITLE
docs(midi): clean synth voice comment breadcrumb

### DIFF
--- a/core/midi/include/pulp/midi/synthesiser.hpp
+++ b/core/midi/include/pulp/midi/synthesiser.hpp
@@ -114,8 +114,7 @@ public:
     /// here; when the envelope tail completes they should call
     /// `mark_inactive()` so the synth's free-voice scan can reclaim
     /// the slot. Keeps `note_.releasing` in sync with the `releasing_`
-    /// member so subclasses reading either path see the same state
-    /// (Codex P2 on #2870).
+    /// member so subclasses reading either path see the same state.
     virtual void on_note_off() {
         releasing_ = true;
         note_.releasing = true;


### PR DESCRIPTION
## Summary
- remove a stale Codex review breadcrumb from the synth voice release comment
- preserve the current `note_.releasing` / `releasing_` state-sync invariant

## Validation
- rg stale-marker scan over core/midi/include/pulp/midi/synthesiser.hpp
- git diff --check
- git diff --check origin/main..HEAD
- python3 tools/scripts/docs_noise_lint.py --mode=report
- PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/midi-synth-comment-hygiene
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/midi-synth-comment-hygiene

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

Version-Bump: sdk=skip reason="comment-only hygiene; no SDK behavior or API change"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a stale review breadcrumb from the `SynthesiserVoice::on_note_off` comment and clarified the `note_.releasing`/`releasing_` state-sync note. Docs-only cleanup with no SDK or behavior changes.

<sup>Written for commit e2c507c348df843f1cf07a193a37cbf670167598. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

