### PR TITLE
docs(midi): clean SysEx accumulator comment breadcrumbs

### DIFF
--- a/core/midi/include/pulp/midi/sysex_accumulator.hpp
+++ b/core/midi/include/pulp/midi/sysex_accumulator.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-// SysExAccumulator (#86) — shared MIDI SysEx aggregation state machine.
+// SysExAccumulator — shared MIDI SysEx aggregation state machine.
 //
 // MIDI SysEx messages (F0 ... F7) can span multiple transport packets:
 // Android's MIDI API delivers raw bytes whenever they arrive, BLE MIDI
@@ -9,7 +9,7 @@
 // delivery. This accumulator buffers until F7 or an abort, then emits
 // the complete payload.
 //
-// State machine (per #406 + ALSA reference):
+// State machine:
 //
 //   Idle     --[F0]-->   Buffering
 //   Buffering --[data]->  Buffering (append)
@@ -159,7 +159,7 @@ private:
         // in 0xF8-0xFF *except F7* passes through without disturbing
         // the SysEx state machine. Treating 0xF9/0xFD as generic
         // status bytes aborted otherwise-valid SysEx on devices that
-        // forwarded the reserved codes (Codex P2 on PR #484 / #500).
+        // forward the reserved codes.
         //
         // Pass-through is safe because the accumulator only classifies
         // the byte — the caller's normal short-message path decides


### PR DESCRIPTION
## Summary
- Remove stale issue/PR/Codex breadcrumbs from SysEx accumulator comments.
- Preserve the current state-machine, realtime pass-through, and reserved-code rationale.

## Validation
- rg stale-marker scan on touched header: clean
- git diff --check
- git diff --check origin/main..HEAD
- python3 tools/scripts/docs_noise_lint.py --mode=report
- PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/midi-sysex-accumulator-comment-hygiene
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/midi-sysex-accumulator-comment-hygiene

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

Version-Bump: sdk=skip reason="comment-only hygiene; no SDK behavior or API change"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove stale issue/PR/Codex references from SysEx accumulator comments to reduce noise and keep docs clear. State-machine docs and realtime pass-through rationale are preserved; no behavior or API changes.

<sup>Written for commit c2e2ffc528e5c63edb4591d7a8a17e0d1b779c6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

