### PR TITLE
docs(midi): clean running status comment breadcrumbs

### DIFF
--- a/core/midi/src/running_status.cpp
+++ b/core/midi/src/running_status.cpp
@@ -31,7 +31,7 @@ void RunningStatusParser::emit_short(uint8_t status, uint8_t d1, uint8_t d2) {
 
 void RunningStatusParser::reset() {
     running_status_ = 0;
-    current_system_common_ = 0;   // #202 P2: reset must drop this too
+    current_system_common_ = 0;   // reset also clears one-shot system-common state
     data_count_ = 0;
     data_expected_ = 0;
     in_sysex_ = false;
@@ -117,7 +117,7 @@ void RunningStatusParser::feed(const uint8_t* data, std::size_t size) {
                     // immediately and do NOT retain it as current_system_
                     // common. Otherwise a stray trailing data byte would
                     // pass the guard below and trigger a phantom extra
-                    // emission under the stale status. Fix per #202 P1.
+                    // emission under the stale status.
                     emit_short(b, 0, 0);
                     current_system_common_ = 0;
                 } else {


### PR DESCRIPTION
## Summary
- Remove stale issue breadcrumbs from running-status parser comments.
- Preserve the current reset and one-shot system-common parser invariants.

## Validation
- rg stale-marker scan on touched source: clean
- git diff --check
- git diff --check origin/main..HEAD
- python3 tools/scripts/docs_noise_lint.py --mode=report
- PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/midi-running-status-comment-hygiene
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/midi-running-status-comment-hygiene

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

Version-Bump: sdk=skip reason="comment-only hygiene; no SDK behavior or API change"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale issue breadcrumbs from running-status parser comments and clarified reset and one-shot system-common behavior. No functional or SDK changes.

<sup>Written for commit 7b89094568c2d9a165f1bd6506dbc6718da21b88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

