### PR TITLE
docs(midi): clean ALSA MIDI parser comment breadcrumb

### DIFF
--- a/core/midi/platform/linux/alsa_midi_device.cpp
+++ b/core/midi/platform/linux/alsa_midi_device.cpp
@@ -100,7 +100,7 @@ private:
 
             // Parse raw MIDI bytes. Shared helper keeps the accumulator
             // logic testable across ALSA and any future raw-byte MIDI
-            // transport (see raw_midi_parser.hpp). #239 / #406.
+            // transport (see raw_midi_parser.hpp).
             parse_raw_midi_bytes(
                 reinterpret_cast<const uint8_t*>(buf),
                 static_cast<std::size_t>(n),


### PR DESCRIPTION
## Summary
- Remove stale issue breadcrumbs from the ALSA raw-byte parser comment.
- Preserve the current shared-parser rationale and raw_midi_parser.hpp reference.

## Validation
- rg stale-marker scan on touched source: clean
- git diff --check
- git diff --check origin/main..HEAD
- python3 tools/scripts/docs_noise_lint.py --mode=report
- PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/linux-alsa-midi-comment-hygiene
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/linux-alsa-midi-comment-hygiene

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

Version-Bump: sdk=skip reason="comment-only hygiene; no SDK behavior or API change"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clean ALSA MIDI parser comment by removing stale issue breadcrumbs while keeping the shared-parser rationale and `raw_midi_parser.hpp` reference. No behavior or API changes.

<sup>Written for commit af33c0dd52dc1d1eee9b297b643b1436683db2b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

