### PR TITLE
docs(midi): clarify WinRT backend comment

### DIFF
--- a/core/midi/platform/win/winrt_midi_device.cpp
+++ b/core/midi/platform/win/winrt_midi_device.cpp
@@ -3,7 +3,7 @@
 // The Windows MIDI Services SDK's `Microsoft.Windows.Devices.Midi2`
 // projection exposes native MIDI 2.0 endpoints (Universal MIDI Packets),
 // `MidiEndpointDeviceWatcher` hotplug, and high-resolution `MidiClock`
-// timestamps. The legacy mmeapi backend in winmidi_device.cpp truncates
+// timestamps. The WinMM mmeapi backend in winmidi_device.cpp truncates
 // MIDI 2.0 UMP, has no hotplug, and requires manual SysEx reassembly. This
 // TU is the real WinRT consumer.
 //


### PR DESCRIPTION
## Summary
- Replace stale backend wording with the concrete WinMM mmeapi backend name.
- Preserve the current WinRT MIDI 2.0 comparison and opt-in rationale.

## Validation
- rg stale-marker scan on touched source: clean
- git diff --check
- git diff --check origin/main..HEAD
- python3 tools/scripts/docs_noise_lint.py --mode=report
- PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
- AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/winrt-midi-comment-hygiene
- PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/winrt-midi-comment-hygiene

RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

Version-Bump: sdk=skip reason="comment-only hygiene; no SDK behavior or API change"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the WinRT MIDI file comment to name the concrete WinMM mmeapi backend while keeping the MIDI 2.0 comparison and opt-in rationale. No behavior, API, or build changes.

<sup>Written for commit 3e8ec01efe38eab3672c860238acf6e01a8b7dcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

