### PR TITLE
docs(midi): clean WinMM backend comment breadcrumbs

### DIFF
--- a/core/midi/platform/win/winmidi_device.cpp
+++ b/core/midi/platform/win/winmidi_device.cpp
@@ -81,7 +81,7 @@ public:
             return false;
         }
 
-        // Prepare and queue SysEx receive buffers (#19 / #239).
+        // Prepare and queue SysEx receive buffers.
         // Four 4 KB buffers — enough headroom for typical device
         // dumps without flooding the driver. Driver returns each
         // via MIM_LONGDATA when full or when an F7 arrives; we
@@ -124,14 +124,12 @@ public:
             return;
         }
         if (handle_) {
-            // Set the closing flag BEFORE midiInReset so any
-            // MIM_LONGDATA callback fired during reset (or already in
-            // flight when stop() races with an arriving SysEx) skips
-            // the midiInAddBuffer re-queue. Without this, a re-queued
-            // header collides with the unprepare/close sequence and
-            // either leaks (MIDIERR_STILLPLAYING) or invalidates
-            // memory the callback's still walking. See #438 P1
-            // Codex review on #388.
+            // Set the closing flag before midiInReset so callbacks
+            // fired during reset, or already in flight while stop()
+            // races with an arriving SysEx, skip the midiInAddBuffer
+            // re-queue. Without this, a re-queued header collides
+            // with unprepare/close and can stay in MIDIERR_STILLPLAYING
+            // or invalidate memory the callback is still walking.
             closing_.store(true, std::memory_order_release);
             midiInStop(handle_);
             // midiInReset returns any pending SysEx buffers via
@@ -196,11 +194,11 @@ private:
                     self->qpc_seconds_since_open());
             }
 
-            // Re-arm the buffer for the next packet — but skip if the
+            // Re-arm the buffer for the next packet, but skip if the
             // device is closing. midiInReset can deliver the last
             // batch of buffers with non-zero dwBytesRecorded; re-queuing
-            // them races with the unprepare/close sequence and can
-            // leave headers MIDIERR_STILLPLAYING. See #438 P1 / #388.
+            // them races with unprepare/close and can leave headers
+            // MIDIERR_STILLPLAYING.
             if (self->closing_.load(std::memory_order_acquire)) return;
             hdr->dwBytesRecorded = 0;
             midiInAddBuffer(self->handle_, hdr, sizeof(*hdr));
@@ -237,7 +235,7 @@ private:
     SysexSlot          sysex_slots_[kSysexSlots]{};
     // closing_ guards the MIM_LONGDATA / MIM_LONGERROR re-queue paths
     // during close() so a callback racing with midiInReset doesn't add
-    // a buffer that's about to be unprepared. See #438 P1 / #388.
+    // a buffer that's about to be unprepared.
     std::atomic<bool>  closing_{false};
     // Non-empty when this input is a BLE-MIDI port routed through the
     // BleMidiPortRegistry rather than an mmeapi device.


### PR DESCRIPTION
## Summary
- remove stale issue/PR/Codex breadcrumbs from WinMM MIDI input comments
- keep the SysEx close/requeue invariant documented as current behavior

## Validation
- focused stale-marker scan on `core/midi/platform/win/winmidi_device.cpp`
- `git diff --check`
- `git diff --check origin/main..HEAD`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/winmidi-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/winmidi-comment-hygiene`

## Notes
RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned WinMM MIDI input comments to remove stale issue/PR breadcrumbs and clarify the SysEx buffer close-and-requeue behavior. Comments-only change; no code or runtime behavior changes.

<sup>Written for commit 6af6762ea34785acc31b8044f86a75ce6fa2865e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

