### PR TITLE
docs(midi): clean UMP sysex reassembler comment breadcrumbs

### DIFF
--- a/core/midi/include/pulp/midi/ump_sysex7_reassembler.hpp
+++ b/core/midi/include/pulp/midi/ump_sysex7_reassembler.hpp
@@ -38,14 +38,14 @@
 // Pulp historically open-coded the same state machine inline in both
 // `core/format/src/au_adapter.mm` (AUv3 MIDIEventList path) and
 // `core/midi/platform/mac/coremidi_device.mm` (CoreMIDI 2.0 input
-// callback). Both implementations carry the same regression notes
-// (#239 / #292) and the same edge-case handling for orphaned
-// continue/end packets. Extracting the state machine here:
+// callback). Both implementations needed the same cursor-advance guard
+// and the same edge-case handling for orphaned continue/end packets.
+// Extracting the state machine here:
 //
 //   1. Eliminates duplicated state and bit-twiddling.
-//   2. Centralises the regression test for the #292 P1 bug ("second
-//      word's top nibble can masquerade as a new message header") and
-//      the #292 P2 boundary-preservation property.
+//   2. Centralises test coverage for the second word's top nibble not
+//      masquerading as a new message header, plus preservation of an
+//      unrelated in-progress stream when a complete packet interleaves.
 //   3. Gives future UMP-aware backends (WinRT MIDI 2.0, ALSA UMP,
 //      iOS CoreMIDI 2.0) a drop-in dependency.
 //
@@ -89,7 +89,7 @@ namespace pulp::midi {
 /// end span). Orphaned continue/end packets (i.e. arrival without a
 /// preceding start) are dropped silently — corrupting the downstream
 /// sink with a partial payload is worse than dropping one malformed
-/// sysex (#292 P2).
+/// sysex.
 using Sysex7EmitFn = void(*)(const std::vector<std::uint8_t>& payload,
                              void* user);
 
@@ -143,11 +143,10 @@ public:
         case 0x0: {
             // Complete single-packet sysex. Use a scratch vector so
             // the call doesn't disturb any partial in-progress state
-            // (per #292 P2 — an interleaved single-packet sysex must
-            // not eat a separate in-progress accumulator). This is
-            // genuinely possible: the UMP spec permits independent
-            // sysex streams on different groups to interleave through
-            // a single endpoint.
+            // when a complete packet interleaves with another stream's
+            // accumulator. This is genuinely possible: the UMP spec
+            // permits independent sysex streams on different groups to
+            // interleave through a single endpoint.
             scratch_.clear();
             extract_bytes(word0, word1, size, scratch_);
             if (!scratch_.empty() && emit) {
@@ -170,7 +169,7 @@ public:
                 extract_bytes(word0, word1, size, payload_);
                 return Status::continued;
             }
-            // Orphan continue — drop. See #292 P2.
+            // Orphan continue — drop.
             return Status::dropped;
         case 0x3:
             if (in_progress_) {
@@ -182,7 +181,7 @@ public:
                 in_progress_ = false;
                 return Status::ended;
             }
-            // Orphan end — drop. See #292 P2.
+            // Orphan end — drop.
             return Status::dropped;
         default:
             // Reserved / unknown status nibble. Per the spec, type-0x3


### PR DESCRIPTION
## Summary
- remove stale issue/regression breadcrumbs from the UMP sysex7 reassembler comments
- keep the comments focused on current state-machine behavior and invariants
- preserve the documented cursor-advance guard, interleaved complete-packet handling, and orphan packet drops

## Validation
- focused stale-marker scan on `core/midi/include/pulp/midi/ump_sysex7_reassembler.hpp`
- `git diff --check`
- `git diff --check origin/main..HEAD`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/ump-sysex-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/ump-sysex-comment-hygiene`

## Notes
RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

Skill-sync note: the touched header maps to `mpe`; the commit uses `Skill-Update: skip skill=mpe` because this is comment-only hygiene with no skill behavior or gotcha change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned comments in the UMP SysEx7 reassembler to remove stale issue breadcrumbs and clarify the current state machine and invariants. No code, behavior, or API changes; comments now document the cursor-advance guard, interleaved complete-packet handling, and dropping orphan packets.

<sup>Written for commit 8b52fc4dc5e30e590c9d00da227d7e87d498e220. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

