### PR TITLE
docs(midi): clean MIDI-CI comment breadcrumbs

### DIFF
--- a/core/midi/src/midi_ci.cpp
+++ b/core/midi/src/midi_ci.cpp
@@ -58,7 +58,6 @@ std::size_t CiDiscovery::notify(std::string_view resource,
     // are emitted — return 0, not `subscribers.size()`. Callers using
     // the return for delivery accounting / retry would otherwise be
     // told everything succeeded when in fact nothing was sent.
-    // Regression: #2959 / Codex comment 3305288220.
     if (!on_pe_notify) return 0;
     std::size_t delivered = 0;
     for (const auto& sub : subscribers) {
@@ -74,7 +73,7 @@ std::vector<uint8_t> CiDiscovery::create_discovery_inquiry() const {
     msg.push_back(0xF0);
     msg.push_back(0x7E);
     msg.push_back(0x7F);  // All devices
-    msg.push_back(0x0D);  // CI sub-ID #1
+    msg.push_back(0x0D);  // MIDI-CI sub-ID byte
     msg.push_back(static_cast<uint8_t>(CiMessageType::DiscoveryInquiry));
 
     // CI version
@@ -394,7 +393,7 @@ void CiDiscovery::handle_notify(const uint8_t* data, size_t size) {
     // PropertyNotify addressed to another peer would still fire local
     // handlers and apply/surface updates for the wrong session/resource.
     // Other handlers (Subscribe, Discovery, InquireProperties, …) gate
-    // identically at data+10. Regression: Codex #2959 comment 3305288207.
+    // identically at data+10.
     MUID source = read_muid(data + 6);
     MUID dest = read_muid(data + 10);
     if (!dest.is_broadcast() && !(dest == local_info_.muid)) return;


### PR DESCRIPTION
## Summary
- remove stale Codex/regression breadcrumbs from MIDI-CI comments
- reword the discovery inquiry sub-ID comment so it describes the current MIDI-CI byte without a cleanup-marker token
- preserve the notify delivery-accounting and destination-MUID routing rationale

## Validation
- focused stale-marker scan on `core/midi/src/midi_ci.cpp`
- `git diff --check`
- `git diff --check origin/main..HEAD`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/midi-ci-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/midi-ci-comment-hygiene`

## Notes
RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned MIDI-CI comments in `core/midi/src/midi_ci.cpp` by removing stale Codex/regression breadcrumbs and clarifying the discovery inquiry sub-ID byte description. Behavior is unchanged; kept notes on notify delivery accounting and destination-MUID gating.

<sup>Written for commit 6f5bf05fe3c37ec4b5d8c08a71d99213c7218aad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

