### PR TITLE
docs(midi): clean CoreMIDI UMP comment breadcrumbs

### DIFF
--- a/core/midi/platform/mac/coremidi_device.mm
+++ b/core/midi/platform/mac/coremidi_device.mm
@@ -24,10 +24,9 @@ public:
             kMIDIProtocol_1_0, &port_,
             ^(const MIDIEventList* evtlist, void* __nullable) {
                 // Walk UMP messages by their declared word size (MIDI 2.0
-                // spec M2-104-UM). Workstream 01 slice 1.6 — previously
-                // we incremented one word at a time and only handled type
-                // 0x02, so a type-0x04 packet's second word would have
-                // been mis-parsed as a new message header.
+                // spec M2-104-UM) so multi-word packets advance the cursor
+                // as a single message. Otherwise a type-0x04 packet's
+                // second word can be mis-parsed as a new message header.
                 static constexpr uint8_t kWordsByType[16] = {
                     1, 1, 1, 2, 2, 4, 4, 1,
                     2, 2, 2, 3, 3, 4, 4, 4
@@ -63,13 +62,11 @@ public:
                         } else if (type == 0x03) {
                             // SysEx7 (UMP type 3) — reassemble multi-
                             // packet payloads via the shared
-                            // UmpSysex7Reassembler. macOS plan 8.2
-                            // extracted the previously inline #292 fix
-                            // to a single, tested class shared with
-                            // the AUv3 adapter; reassembler state
-                            // lives on this CoreMidiInput so a
-                            // multi-packet sysex spanning callback
-                            // invocations accumulates correctly.
+                            // UmpSysex7Reassembler. The reassembler state
+                            // lives on this CoreMidiInput so a multi-packet
+                            // sysex spanning callback invocations accumulates
+                            // correctly and shares the tested state machine
+                            // with the AUv3 adapter.
                             const uint32_t word1 =
                                 packet->words[wordIdx + 1];
                             struct EmitCtx {
@@ -87,7 +84,8 @@ public:
                                 word, word1, emit, &ctx);
                         }
                         // Other UMP types (utility, system, SysEx8,
-                        // stream, flex) intentionally skipped this slice.
+                        // stream, flex) are ignored by this MIDI 1.0 input
+                        // adapter for now.
                         wordIdx += words_in_message;
                     }
                     packet = MIDIEventPacketNext(packet);


### PR DESCRIPTION
## Summary
- remove stale workstream/plan/slice breadcrumbs from CoreMIDI UMP input comments
- keep the comments focused on current cursor-advance and SysEx7 reassembly behavior
- preserve the rationale for ignored UMP message classes in the MIDI 1.0 input adapter

## Validation
- focused stale-marker scan on `core/midi/platform/mac/coremidi_device.mm`
- `git diff --check`
- `git diff --check origin/main..HEAD`
- `python3 tools/scripts/docs_noise_lint.py --mode=report`
- `PULP_SKIP_DIFF_COVER=1 tools/scripts/gates.sh origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `AUTOREVIEW_ENGINE=claude /Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push --dry-run origin feature/coremidi-comment-hygiene`
- `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push -u origin feature/coremidi-comment-hygiene`

## Notes
RepoPrompt requested but unavailable (tool_search returned 0); local git/search/build tooling used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned CoreMIDI UMP input comments in `core/midi/platform/mac/coremidi_device.mm` by removing stale breadcrumbs and clarifying multi-word cursor advance, SysEx7 reassembly, and the rationale for ignoring other UMP types; no behavior changes.

<sup>Written for commit fb864912d33c2bfe4259be1c27cd54384bef92bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

