### PR TITLE
docs(view): clean widget/codegen comment breadcrumbs

### DIFF
--- a/core/view/include/pulp/view/widgets.hpp
+++ b/core/view/include/pulp/view/widgets.hpp
@@ -24,14 +24,14 @@ namespace pulp::view {
 // Static or dynamic text display
 
 /// Text alignment for Label.
-/// pulp #1434 — `auto_` resolves at paint time to left (LTR) or right
-/// (RTL); pulp doesn't model RTL yet so `auto_` currently degrades to
+/// `auto_` resolves at paint time to left (LTR) or right (RTL);
+/// pulp doesn't model RTL yet so `auto_` currently degrades to
 /// `left`. `justify` wires through to the canvas `TextAlign::justify`
 /// enum value; SkParagraph kJustify rendering lands in a follow-up —
 /// existing canvas backends treat it as `left` until then. Both values
 /// are claimed in the rn/css catalog (Figma exports + Tailwind classes
 /// emit `auto` and `justify` routinely).
-/// `match_parent` (pulp #1434 follow-up) resolves at paint time by
+/// `match_parent` resolves at paint time by
 /// walking the View parent chain (via `inheritable_text_align()`) and
 /// adopting the first ancestor's resolved value. If no ancestor set
 /// one, falls back to `left` (the CSS spec default for `text-align`).
@@ -121,16 +121,15 @@ public:
     void set_multi_line(bool ml) { multi_line_ = ml; }
     bool multi_line() const { return multi_line_; }
 
-    /// CSS `line-clamp` / `-webkit-line-clamp` (pulp #1552). Maximum number
-    /// of visible text lines for a multi-line label; 0 disables clamping.
+    /// CSS `line-clamp` / `-webkit-line-clamp`. Maximum number of visible
+    /// text lines for a multi-line label; 0 disables clamping.
     /// When set on a `multi_line_` Label, paint() emits at most N lines
     /// (newline- or wrap-broken) and appends the U+2026 ellipsis to the
     /// trailing visible line if any source lines were dropped. Matches the
     /// CSS spec's "block-axis line clamp" behavior at the keyword level
     /// (no `none` token — set 0 to clear). Wiring is shared between
     /// `line-clamp` and `-webkit-line-clamp` in the JS shim and the
-    /// @pulp/react prop-applier (pulp #1434 catalog: both keys funnel
-    /// through the same case).
+    /// @pulp/react prop-applier; both keys funnel through the same case.
     void set_line_clamp(int n) { line_clamp_ = (n < 0) ? 0 : n; }
     int line_clamp() const { return line_clamp_; }
 
@@ -148,11 +147,11 @@ public:
     bool has_text_decoration_color() const { return has_decoration_color_; }
 
     /// CSS text-decoration-style: solid, double, dotted, dashed, wavy.
-    /// pulp #1434 — accepted via the JS CSS shim and the bridge so authors
-    /// can express the per-style longhand. Today the paint path always
-    /// renders as `solid`; the value is stored so future paint logic can
-    /// honor it without an API break (matches the spec's optional fallback
-    /// to solid for renderers that don't implement non-solid styles).
+    /// Accepted via the JS CSS shim and the bridge so authors can express
+    /// the per-style longhand. Today the paint path always renders as
+    /// `solid`; the value is stored so future paint logic can honor it
+    /// without an API break (matches the spec's optional fallback to solid
+    /// for renderers that don't implement non-solid styles).
     enum class TextDecorationStyle { solid, double_, dotted, dashed, wavy };
     void set_text_decoration_style(TextDecorationStyle s) { text_decoration_style_ = s; }
     TextDecorationStyle text_decoration_style() const { return text_decoration_style_; }
@@ -179,18 +178,17 @@ public:
 
     /// Width-aware height: shaper-true line count × line-height for a
     /// multi_line Label given the parent's available content width.
-    /// pulp-internal #74 — invoked by the Yoga measure callback when a
-    /// multi-line Label is laid out in a bounded-width parent (CSS
+    /// Invoked by the Yoga measure callback when a multi-line Label is laid
+    /// out in a bounded-width parent (CSS
     /// `flex: 1`, `width: 100%`, fixed-width section subtitles). Falls
     /// back to `intrinsic_height()` when `multi_line_` is false or
     /// `available_width <= 0`, so single-line labels and unbounded
     /// containers keep the legacy one-line metric.
     float measured_height(float available_width) const;
 
-    /// pulp #2163 / font-v2 Slice 1.1.b — baseline offset from the top
-    /// of the Label's measured box, used by Yoga's
+    /// Baseline offset from the top of the Label's measured box, used by Yoga's
     /// `YGNodeSetBaselineFunc` to honor `align-items: baseline` on
-    /// flex containers (CHAIN INFO baseline-alignment canary). Returns
+    /// flex containers. Returns
     /// `ascent + (leading / 2)` from `TextShaper::measure_metrics` so
     /// the value tracks the same per-(family, size) cache the painter
     /// uses; mixed-size text in a row therefore aligns on its true
@@ -257,7 +255,7 @@ private:
     float line_height_ = 0;       ///< 0=auto (font_size * 1.4)
     LabelAlign text_align_ = LabelAlign::left;
     bool multi_line_ = false;
-    int line_clamp_ = 0;          ///< pulp #1552: 0=no clamp, >=1=max lines
+    int line_clamp_ = 0;          ///< 0=no clamp, >=1=max lines
     TextTransform text_transform_ = TextTransform::none;
     TextDecoration text_decoration_ = TextDecoration::none;
     canvas::Color decoration_color_{};
@@ -308,19 +306,16 @@ public:
     void set_render_style(WidgetRenderStyle s) { render_style_ = s; }
     WidgetRenderStyle render_style() const { return render_style_; }
 
-    // pulp #73 — programmatic set_value MUST request_repaint() WHEN the
-    // value actually changes. The host's mouseDown handler invalidates
-    // after every input event, so user drags repaint correctly via that
-    // side channel; preset application (or any other JS-driven mutation
-    // through the bridge's setValue) goes through THIS code path and
-    // would otherwise leave the painted state stale until the next user
-    // input.
+    // Programmatic set_value() must request_repaint() when the value actually
+    // changes. The host's mouseDown handler invalidates after every input event,
+    // so user drags repaint correctly via that side channel; preset application
+    // and other JS-driven bridge mutations go through this code path and would
+    // otherwise leave the painted state stale until the next user input.
     //
-    // Codex P2 on PR #2013 — gate the invalidate on a real change.
-    // WidgetBridge::sync_from_store() and restore_values(...) call
-    // set_value()/set_on() in tight loops during sync/reload; firing a
-    // host repaint per call (even when the value is unchanged) burns
-    // wall-clock on large widget trees with no visible benefit.
+    // Gate the invalidation on a real change. WidgetBridge::sync_from_store()
+    // and restore_values(...) call set_value()/set_on() in tight loops during
+    // sync/reload; firing a host repaint per call when the value is unchanged
+    // burns wall-clock on large widget trees with no visible benefit.
     void set_value(float v) {
         float clamped = std::clamp(v, 0.0f, 1.0f);
         if (clamped == value_) return;
@@ -548,8 +543,8 @@ public:
     void set_render_style(WidgetRenderStyle s) { render_style_ = s; }
     WidgetRenderStyle render_style() const { return render_style_; }
 
-    // pulp #73 — see Knob::set_value rationale (incl. the no-change
-    // guard added per Codex P2 on PR #2013).
+    // Same programmatic repaint contract as Knob::set_value(), including the
+    // no-change guard for bridge sync/reload loops.
     void set_value(float v) {
         float clamped = std::clamp(v, 0.0f, 1.0f);
         if (clamped == value_) return;
@@ -677,13 +672,13 @@ public:
     void set_skin_fill_color(canvas::Color c)  { fill_color_  = c; has_skin_fill_  = true; request_repaint(); }
     void set_skin_thumb_color(canvas::Color c) { thumb_color_ = c; has_skin_thumb_ = true; request_repaint(); }
     void set_skin_thumb_border_color(canvas::Color c) { thumb_border_color_ = c; has_skin_thumb_border_ = true; request_repaint(); }
-    // pulp #3192 — outline of the empty track (the lighter edge the captured
-    // art draws around the dark channel). When set, the skinned fader strokes
-    // the track rect so it doesn't read as a flat dark slab.
+    // Outline of the empty track: the lighter edge the captured art draws
+    // around the dark channel. When set, the skinned fader strokes the track
+    // rect so it doesn't read as a flat dark slab.
     void set_skin_track_border_color(canvas::Color c) { track_border_color_ = c; has_skin_track_border_ = true; request_repaint(); }
-    // pulp #3191 — derived thin track width (logical px). When set, the skinned
-    // fader draws its track / fill at exactly this width (centred) instead of a
-    // fraction of the widget box, matching the captured art's narrow track.
+    // Derived thin track width (logical px). When set, the skinned fader draws
+    // its track / fill at exactly this width (centred) instead of a fraction of
+    // the widget box, matching the captured art's narrow track.
     void set_skin_track_width(float w) {
         if (w > 0.0f) { skin_track_width_ = w; has_skin_track_width_ = true; request_repaint(); }
     }
@@ -736,8 +731,6 @@ private:
 // not preprocess them. Quantisation happens inside the widget so JS-side
 // callers see the same value the renderer paints.
 //
-// pulp issue-966.
-
 class RangeSlider : public View {
 public:
     enum class Orientation { horizontal, vertical };
@@ -766,10 +759,9 @@ public:
     /// Set the current value. The value is clamped to [min,max] and
     /// quantised to the nearest step if step > 0.
     ///
-    /// pulp #73 — request_repaint() so programmatic preset application
-    /// reaches the screen, not just the next user-input event.
-    /// Codex P2 on PR #2013 — gate on actual change to avoid redundant
-    /// invalidations during sync_from_store / restore_values loops.
+    /// request_repaint() lets programmatic preset application reach the screen,
+    /// not just the next user-input event. Gate on actual changes to avoid
+    /// redundant invalidations during sync_from_store / restore_values loops.
     void set_value(float v) {
         float prev = value_;
         value_ = v;
@@ -923,8 +915,8 @@ class Checkbox : public View {
 public:
     Checkbox() { set_access_role(AccessRole::toggle); set_focusable(true); }
 
-    // pulp #73 — see Knob::set_value (incl. no-change guard from Codex
-    // P2 on PR #2013).
+    // Same programmatic repaint contract as Knob::set_value(), including the
+    // no-change guard for bridge sync/reload loops.
     void set_checked(bool v) {
         if (checked_ == v) return;
         checked_ = v;
@@ -948,8 +940,8 @@ class ToggleButton : public View {
 public:
     ToggleButton() { set_access_role(AccessRole::toggle); set_focusable(true); }
 
-    // pulp #73 — see Knob::set_value (incl. no-change guard from Codex
-    // P2 on PR #2013).
+    // Same programmatic repaint contract as Knob::set_value(), including the
+    // no-change guard for bridge sync/reload loops.
     void set_on(bool v) {
         if (on_ == v) return;
         on_ = v;
@@ -1170,7 +1162,7 @@ public:
     // wider dark housing slot; this ratio reproduces that inset so the rendered
     // bar isn't edge-to-edge paint. Derived from the captured asset
     // (colored-bar width / housing width); defaults to 1.0 (full width) when the
-    // importer didn't supply it. pulp #3191 follow-up.
+    // importer didn't supply it.
     void set_bar_fill_ratio(float r) {
         bar_fill_ratio_ = std::clamp(r, 0.05f, 1.0f);
         request_repaint();
@@ -1366,9 +1358,8 @@ public:
 
     void set_background_token(std::string token) { bg_token_ = std::move(token); }
     void set_border_token(std::string token) { border_token_ = std::move(token); }
-    // pulp #1731 Codex P1 — route through View::set_border_radius so the
-    // px slot painter actually reads is updated (and the pct slot is
-    // cleared, matching documented semantics).
+    // Route through View::set_border_radius so the px slot the painter reads is
+    // updated and the pct slot is cleared, matching documented semantics.
     void set_corner_radius(float r) { View::set_border_radius(r); }
     void set_border_width(float w) { border_width_ = w; }
 

--- a/core/view/src/design_codegen.cpp
+++ b/core/view/src/design_codegen.cpp
@@ -27,7 +27,7 @@
 namespace pulp::view {
 
 /// Escape a string for emission inside a JavaScript single-quoted literal
-/// (pulp #81). The codegen backends emit calls like
+/// The codegen backends emit calls like
 /// `createLabel('<id>', '<text>', '<parent>')` where the middle arg is
 /// arbitrary user text. A multi-line `<style>` block imported from a
 /// Claude Design HTML file would otherwise emit raw newlines into the JS
@@ -280,10 +280,10 @@ static void generate_node(std::ostringstream& ss, const IRNode& node,
     // Apply visual styles
     auto& s = node.style;
     auto emit_str = [&](const char* prop, const std::optional<std::string>& val) {
-        // Escape the value — raw CSS (esp. clip-path / mask, which can carry
-        // url("...") with quotes) must not break out of the JS string literal
-        // (#3288 P2). js_single_quote_escape is a no-op for the common
-        // quote-free keyword/color values, so this is regression-safe.
+        // Escape raw CSS values. clip-path and mask can carry url("...") with
+        // quotes, and must not break out of the JS string literal.
+        // js_single_quote_escape is a no-op for the common quote-free
+        // keyword/color values, so this is regression-safe.
         if (val) ss << ind << var << ".style." << prop << " = '"
                     << js_single_quote_escape(*val) << "';\n";
     };
@@ -362,7 +362,7 @@ static void generate_node(std::ostringstream& ss, const IRNode& node,
     if (!node.text_runs.empty() && !node.text_content.empty())
         emit_web_text_runs(ss, ind, var, node);
     else if (!node.text_content.empty())
-        ss << ind << var << ".textContent = '" << js_single_quote_escape(node.text_content) << "';\n";  // pulp #81
+        ss << ind << var << ".textContent = '" << js_single_quote_escape(node.text_content) << "';\n";
 
     // Append to parent
     if (!parent_var.empty())
@@ -612,7 +612,7 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
     // clip-path, and the mask shorthand / image / size (View::set_clip_path /
     // set_mask / set_mask_image / set_mask_size). mix-blend-mode is
     // parse-normalized (normal / pass-through dropped); the clip/mask values
-    // are raw CSS the bridge parses (pulp #1515).
+    // are raw CSS the bridge parses.
     auto emit_node_visual_overrides = [&](const std::string& target_id) {
         const auto& st = node.style;
         if (st.mix_blend_mode && !st.mix_blend_mode->empty())
@@ -1002,19 +1002,19 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
                 float lo = node.audio_min, hi = node.audio_max;
                 if (hi > lo) fader_norm = std::clamp((node.audio_default - lo) / (hi - lo), 0.0f, 1.0f);
             }
-            // Prefer the captured thumb position when the sampler recovered it
-            // (#3191): an audio fader's value→position map is non-linear, so the
+            // Prefer the captured thumb position when the sampler recovered it:
+            // an audio fader's value→position map is non-linear, so the
             // linear seed above lands the thumb wrong; the captured position
             // reproduces where the design drew it.
             if (auto pit = node.attributes.find("skin_thumb_position");
                 pit != node.attributes.end() && !pit->second.empty())
                 fader_norm = std::clamp(std::stof(pit->second), 0.0f, 1.0f);
             ss << ind << "setValue('" << id << "', " << fader_norm << ");\n";
-            // pulp #3191 — value-driven skin derived from the captured asset.
-            // The importer sampled the PNG's track/fill/thumb colours; emit
-            // setFaderSkin so the native fader renders the captured look while
-            // the thumb still moves with setValue(). No per-instance hardcoding
-            // — every value comes from node.attributes stamped by the sampler.
+            // Value-driven skin derived from the captured asset. The importer
+            // sampled the PNG's track/fill/thumb colours; emit setFaderSkin so
+            // the native fader renders the captured look while the thumb still
+            // moves with setValue(). No per-instance hardcoding: every value
+            // comes from node.attributes stamped by the sampler.
             if (opts.skin_faders) {
                 auto attr = [&](const char* k) -> std::string {
                     auto it = node.attributes.find(k);
@@ -1028,16 +1028,16 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
                     ss << ind << "setFaderSkin('" << id << "', '"
                        << tc << "', '" << fc << "', '" << thc << "', '" << tbc << "');\n";
                 }
-                // pulp #3191 — derived thin track width (logical px). Drives the
-                // fader's track/fill thickness so it draws the narrow captured
-                // line instead of a fraction of the (wide) widget box.
+                // Derived thin track width (logical px). Drives the fader's
+                // track/fill thickness so it draws the narrow captured line
+                // instead of a fraction of the wide widget box.
                 if (node.attributes.count("skin_track_width")) {
                     ss << ind << "setFaderTrackWidth('" << id << "', "
                        << node.attributes.at("skin_track_width") << ");\n";
                 }
-                // pulp #3192 — derived empty-track outline colour. Strokes the
-                // track rect so the empty channel above the thumb shows the
-                // captured edge instead of a flat dark slab.
+                // Derived empty-track outline colour. Strokes the track rect
+                // so the empty channel above the thumb shows the captured edge
+                // instead of a flat dark slab.
                 std::string tbo = attr("skin_track_border_color");
                 if (!tbo.empty()) {
                     ss << ind << "setFaderTrackBorder('" << id << "', '" << tbo << "');\n";
@@ -1080,16 +1080,16 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
                 float lo = node.audio_min, hi = node.audio_max;
                 if (hi > lo) meter_norm = std::clamp((node.audio_default - lo) / (hi - lo), 0.0f, 1.0f);
             }
-            // Prefer the captured fill level when recovered (#3191) — matches
-            // where the design filled the meter rather than a linear dB map.
+            // Prefer the captured fill level when recovered; it matches where
+            // the design filled the meter rather than a linear dB map.
             if (auto lit = node.attributes.find("skin_fill_level");
                 lit != node.attributes.end() && !lit->second.empty())
                 meter_norm = std::clamp(std::stof(lit->second), 0.0f, 1.0f);
             ss << ind << "setMeterLevel('" << id << "', " << meter_norm << ", " << meter_norm << ");\n";
-            // pulp #3191 — value-driven gradient skin sampled from the captured
-            // meter PNG. setMeterColors hands the meter the recovered gradient
-            // stops (low→high); the meter redraws them CLIPPED to the level so
-            // the fill still animates with setMeterLevel(). No hardcoding.
+            // Value-driven gradient skin sampled from the captured meter PNG.
+            // setMeterColors hands the meter the recovered gradient stops
+            // (low→high); the meter redraws them CLIPPED to the level so the
+            // fill still animates with setMeterLevel(). No hardcoding.
             if (opts.skin_meters) {
                 auto grad_it = node.attributes.find("skin_meter_gradient");
                 if (grad_it != node.attributes.end() && !grad_it->second.empty()) {
@@ -1100,9 +1100,9 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
                     ss << ind << "setMeterColors('" << id << "', '" << bg << "', '"
                        << grad_it->second << "');\n";
                 }
-                // pulp #3191 — colored-bar/housing width ratio. Insets
-                // the gradient bar so it reads as a recessed fill in the wider
-                // dark housing, matching the captured meter's structure.
+                // Colored-bar/housing width ratio. Insets the gradient bar so
+                // it reads as a recessed fill in the wider dark housing,
+                // matching the captured meter's structure.
                 if (node.attributes.count("skin_meter_bar_ratio")) {
                     ss << ind << "setMeterBarRatio('" << id << "', "
                        << node.attributes.at("skin_meter_bar_ratio") << ");\n";
@@ -1348,7 +1348,7 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
 
     if (is_text) {
         // Text node → createLabel with explicit height (Yoga requirement)
-        ss << ind << "createLabel('" << id << "', '" << js_single_quote_escape(node.text_content) << "', " << pid << ");\n";  // pulp #81
+        ss << ind << "createLabel('" << id << "', '" << js_single_quote_escape(node.text_content) << "', " << pid << ");\n";
         emit_position_if_absolute(id);
         emit_node_visual_overrides(id);
 
@@ -1620,7 +1620,7 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
                << *node.style.border_width << ", " << br << ");\n";
         }
         if (!node.style.box_shadow.empty()) {
-            // The IR carries parsed CSS box-shadow layers (pulp #41). The bridge's
+            // The IR carries parsed CSS box-shadow layers. The bridge's
             // setBoxShadow(id, ox, oy, blur, spread, color, inset?) takes a
             // single drop shadow; emit the first layer (CSS paints the first
             // layer on top). An omitted color falls back to the bridge's
@@ -1780,7 +1780,7 @@ std::string generate_pulp_js(const DesignIR& ir, const CodeGenOptions& opts) {
 
     ss << "setTheme('dark');\n\n";
 
-    // Register bundled (non-system) fonts (#43b) BEFORE any setFontFamily, so a
+    // Register bundled (non-system) fonts BEFORE any setFontFamily, so a
     // family like "Clash Grotesk" / "Inter" resolves to the shipped face
     // instead of silently falling back to a same-named system font (or a
     // generic). resolved_path is the absolute .ttf/.otf path stamped by the
@@ -1830,7 +1830,7 @@ std::string generate_pulp_js(const DesignIR& ir, const CodeGenOptions& opts) {
     // semantics each stay in their natural home.
     if (!opts.shortcuts.empty()) {
         if (opts.include_comments) {
-            ss << "// Auto-imported keyboard shortcuts (pulp #2116). Each\n"
+            ss << "// Auto-imported keyboard shortcuts. Each\n"
                << "// registerShortcut binds a native chord intercept; the\n"
                << "// __pulpShortcutHandler_N thunk re-dispatches the\n"
                << "// synthetic keydown so the original React handler in\n"


### PR DESCRIPTION
## Summary
- Clean stale issue/PR/Codex breadcrumbs from `widgets.hpp` while keeping the repaint, line-clamp, baseline, skinning, and panel-radius rationale intact.
- Clean matching breadcrumbs in `design_codegen.cpp` without changing generated output.
- Keep this as a single scoped source comment-hygiene batch rather than reopening micro-PRs.

## Validation
- `rp-cli` RepoPrompt review: clean except verifying the earlier color-literal experiment; final diff is comment-only and does not include that code change.
- `autoreview --mode local --engine claude`: clean, no actionable findings.
- `cmake --build build --target pulp-view -j$(sysctl -n hw.ncpu)`: passed.
- `tools/scripts/gates.sh` with `GITHUB_PR_TITLE="docs(view): clean widget/codegen comment breadcrumbs"`: passed.
- Pre-push gates passed with `PULP_SKIP_DIFF_COVER=1`; skipped only the slow local diff-cover build for this comment-only cleanup.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up stale issue/PR breadcrumbs in `core/view/include/pulp/view/widgets.hpp` and `core/view/src/design_codegen.cpp`, preserving the repaint, line-clamp, baseline, and skinning rationale. No functional changes; code behavior and generated output remain the same.

<sup>Written for commit 09de54315ce6aec846aee79a2de0fc7f18ec9d2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

