### PR TITLE
docs(render): clean canvas/render comment breadcrumbs

### DIFF
--- a/core/canvas/include/pulp/canvas/scene/scene.hpp
+++ b/core/canvas/include/pulp/canvas/scene/scene.hpp
@@ -14,9 +14,8 @@
 //     wants a structured destination so the host can address individual
 //     shapes — toggle visibility, swap a fill, animate a transform —
 //     without re-parsing.
-//   - Future design-tool import paths (`tools/cli/import-design` family)
-//     want a one-to-one container per design-node so round-tripping
-//     stays predictable.
+//   - Design-tool imports need a one-to-one container per design node so
+//     round-tripping stays predictable.
 //
 // Current behavior:
 //   - SVG loads as a `VectorScene` or `SceneGroup`.

--- a/core/canvas/platform/mac/cg_canvas_gradients.mm
+++ b/core/canvas/platform/mac/cg_canvas_gradients.mm
@@ -1,9 +1,8 @@
 // cg_canvas_gradients.mm — CoreGraphics gradient + pattern paint slice.
 //
-// Extracted from cg_canvas.mm in the 2026-05 Phase 4 (R2-3 mirror)
-// refactor. Pairs with core/canvas/src/skia_canvas_gradients.cpp on
-// the Skia side. Covers fill + stroke gradient builders (linear,
-// radial, conic, two-circles) for the CoreGraphics CPU path.
+// Pairs with core/canvas/src/skia_canvas_gradients.cpp on the Skia side.
+// Covers fill + stroke gradient builders (linear, radial, conic,
+// two-circles) for the CoreGraphics CPU path.
 //
 // `stroke_with_active_paint` and `fill_with_active_paint` remain in
 // cg_canvas.mm because they are the central dispatch points shared
@@ -63,7 +62,7 @@ void CoreGraphicsCanvas::set_fill_gradient_radial(float cx, float cy,
     gradient_kind_ = GradientKind::radial;
     gradient_is_radial_ = true;
     // Single-circle form: inner circle collapses to the centre with radius 0,
-    // outer circle is (cx, cy, radius). Matches the JS shim's pre-#1524
+    // outer circle is (cx, cy, radius). Matches the legacy single-circle
     // contract where createRadialGradient routed only the outer circle.
     grad_x0_ = cx; grad_y0_ = cy; grad_x1_ = cx; grad_y1_ = cy;
     grad_radius_inner_ = 0.0f;
@@ -72,12 +71,12 @@ void CoreGraphicsCanvas::set_fill_gradient_radial(float cx, float cy,
     grad_positions_.assign(positions, positions + count);
 }
 
-// pulp #1524 — true two-circle radial gradient. CGContextDrawRadialGradient
-// accepts (start_centre, start_radius, end_centre, end_radius), so we wire
-// both circles through unmodified. The previous bridge dropped (x0,y0,r0)
-// and used only the outer circle, which silently degraded centre-bloom-
-// only fills (Skia rendered the real two-point conical via MakeTwoPointConical;
-// CG produced a visibly different shape).
+// True two-circle radial gradient. CGContextDrawRadialGradient accepts
+// (start_centre, start_radius, end_centre, end_radius), so we wire both circles
+// through unmodified. The legacy single-circle bridge dropped (x0,y0,r0) and
+// used only the outer circle, which silently degraded centre-bloom-only fills
+// (Skia rendered the real two-point conical via MakeTwoPointConical; CG
+// produced a visibly different shape).
 void CoreGraphicsCanvas::set_fill_gradient_radial_two_circles(
         float x0, float y0, float r0,
         float x1, float y1, float r1,
@@ -97,12 +96,12 @@ void CoreGraphicsCanvas::set_fill_gradient_radial_two_circles(
     grad_positions_.assign(positions, positions + count);
 }
 
-// pulp #1524 — Canvas2D ctx.createConicGradient on the CG backend.
-// CoreGraphics has no native conic / sweep shader, so we record the conic
-// parameters here and software-rasterise a CGImage at fill time
-// (paint_conic_into_clip), interpolating colour stops by atan2 angle from
-// (cx, cy). The Skia backend uses SkShaders::SweepGradient — same
-// visual result, real two-stop+ sweep gradient.
+// Canvas2D ctx.createConicGradient on the CG backend. CoreGraphics has no
+// native conic / sweep shader, so we record the conic parameters here and
+// software-rasterise a CGImage at fill time (paint_conic_into_clip),
+// interpolating colour stops by atan2 angle from (cx, cy). The Skia backend
+// uses SkShaders::SweepGradient — same visual result, real two-stop+ sweep
+// gradient.
 void CoreGraphicsCanvas::set_fill_gradient_conic(float cx, float cy,
                                                   float start_angle,
                                                   const Color* colors,
@@ -136,10 +135,10 @@ void CoreGraphicsCanvas::clear_fill_gradient() {
     release_pattern_image();
 }
 
-// pulp #1666 — stroke gradient setters mirror the fill gradient ones
-// 1:1, populating the parallel `stroke_*` slots. The gradient itself is
-// painted at stroke time by stroke_with_active_paint() which clips to
-// the path and routes through the same CGGradientRef draw calls.
+// Stroke gradient setters mirror the fill gradient ones 1:1, populating the
+// parallel `stroke_*` slots. The gradient itself is painted at stroke time by
+// stroke_with_active_paint() which clips to the path and routes through the
+// same CGGradientRef draw calls.
 void CoreGraphicsCanvas::set_stroke_gradient_linear(float x0, float y0,
                                                      float x1, float y1,
                                                      const Color* colors,
@@ -206,14 +205,13 @@ void CoreGraphicsCanvas::clear_stroke_gradient() {
     stroke_grad_positions_.clear();
 }
 
-// pulp #1666 — paint a stroke through the active stroke gradient. Uses
-// the same approach as fill: create CGGradientRef from stroke_grad_colors_,
-// clip the context to the stroked path's outline (replace path mode), then
-// call CGContextDrawLinearGradient / CGContextDrawRadialGradient over the
-// clip's bounding rect. Conic falls back to apply_stroke_color (CG has no
-// native sweep; the rasterised conic image isn't worth the complexity for
-// stroked outlines which would need the conic image clipped to the stroke
-// silhouette).
+// Paint a stroke through the active stroke gradient. Uses the same approach as
+// fill: create CGGradientRef from stroke_grad_colors_, clip the context to the
+// stroked path's outline (replace path mode), then call
+// CGContextDrawLinearGradient / CGContextDrawRadialGradient over the clip's
+// bounding rect. Conic falls back to apply_stroke_color (CG has no native
+// sweep; the rasterised conic image isn't worth the complexity for stroked
+// outlines which would need the conic image clipped to the stroke silhouette).
 
 }  // namespace pulp::canvas
 

--- a/core/canvas/platform/mac/cg_canvas_shadow.mm
+++ b/core/canvas/platform/mac/cg_canvas_shadow.mm
@@ -1,15 +1,14 @@
 // cg_canvas_shadow.mm — CoreGraphics drop-shadow state slice.
 //
-// Extracted from cg_canvas.mm in the 2026-05 Phase 4 (R2-3 mirror)
-// refactor. Pairs with core/canvas/src/skia_canvas_box_shadow.cpp on
-// the Skia side. Covers the four Canvas2D `ctx.shadow*` setters plus
-// the apply_shadow_to_context() rebuild helper.
+// Pairs with core/canvas/src/skia_canvas_box_shadow.cpp on the Skia side.
+// Covers the four Canvas2D `ctx.shadow*` setters plus the
+// apply_shadow_to_context() rebuild helper.
 //
 // CG owns the sticky shadow state via its GState stack —
 // CGContextSetShadowWithColor snapshots into the current GState, and a
 // later CGContextRestoreGState restores whatever shadow was active in
 // the parent frame. This matches Canvas2D save()/restore() semantics
-// for `ctx.shadow*` exactly (issue-1434 batch 7).
+// for `ctx.shadow*` exactly.
 
 #include <pulp/canvas/cg_canvas.hpp>
 

--- a/core/canvas/src/recording_canvas.cpp
+++ b/core/canvas/src/recording_canvas.cpp
@@ -50,11 +50,10 @@ void RecordingCanvas::restore() {
 }
 
 void RecordingCanvas::restore_to_count(int target) {
-    // pulp #1368 — pop saves until depth matches `target`. Mirrors
-    // SkCanvas::restoreToCount semantics so CanvasWidget::paint() can
-    // defend against an unbalanced JS draw script. We record one
-    // DrawCommand::Type::restore per popped level so tests can assert
-    // on the count.
+    // Pop saves until depth matches `target`. Mirrors SkCanvas::restoreToCount
+    // semantics so CanvasWidget::paint() can defend against an unbalanced JS
+    // draw script. We record one DrawCommand::Type::restore per popped level
+    // so tests can assert on the count.
     if (target < 0) target = 0;
     while (save_depth_ > target) {
         commands_.push_back({DrawCommand::Type::restore});
@@ -126,9 +125,9 @@ void RecordingCanvas::clip_rect(float x, float y, float w, float h) {
 }
 
 void RecordingCanvas::clip(FillRule rule) {
-    // pulp Wave 2 cheap wiring — capture the JS-supplied fillRule arg in
-    // f[0] (0 = nonzero, 1 = evenodd) so [wave2-canvas2d] band tests can
-    // assert the bridge plumbed `ctx.clip('evenodd')` end-to-end.
+    // Capture the JS-supplied fillRule in f[0] (0 = nonzero, 1 = evenodd)
+    // so bridge tests can assert `ctx.clip('evenodd')` reaches the command
+    // stream end-to-end.
     DrawCommand cmd{DrawCommand::Type::clip};
     cmd.f[0] = (rule == FillRule::evenodd) ? 1.0f : 0.0f;
     commands_.push_back(cmd);
@@ -182,7 +181,7 @@ void RecordingCanvas::fill_rect(float x, float y, float w, float h) {
     commands_.push_back(cmd);
 }
 
-// pulp #929 — record clearRect distinctly from fill_rect so tests can assert
+// Record clearRect distinctly from fill_rect so tests can assert
 // CanvasWidget::paint() does not pre-fill its bounds with a solid background.
 void RecordingCanvas::clear_rect(float x, float y, float w, float h) {
     DrawCommand cmd{DrawCommand::Type::clear_rect};
@@ -246,8 +245,8 @@ void RecordingCanvas::set_font_full(const std::string& family, float size,
                                     int weight, int slant, float letter_spacing) {
     font_size_ = size;
     // Record both the legacy set_font (for back-compat with existing tests
-    // that count fonts) and the rich set_font_full so callers can assert
-    // on the propagated weight / slant / letter_spacing. pulp #927.
+    // that count fonts) and the rich set_font_full so callers can assert on
+    // the propagated weight / slant / letter_spacing.
     {
         DrawCommand cmd{DrawCommand::Type::set_font};
         cmd.text = family;
@@ -273,17 +272,16 @@ void RecordingCanvas::fill_text(const std::string& text, float x, float y) {
     DrawCommand cmd{DrawCommand::Type::fill_text};
     cmd.text = text;
     cmd.f[0] = x; cmd.f[1] = y;
-    // pulp #1525 — legacy 3-arg form: f[2]=0 means "no maxWidth constraint".
+    // Legacy 3-arg form: f[2]=0 means "no maxWidth constraint".
     cmd.f[2] = 0.0f;
     commands_.push_back(cmd);
 }
 
 void RecordingCanvas::fill_text_with_max_width(const std::string& text,
                                                 float x, float y, float max_width) {
-    // pulp #1525 — capture the maxWidth so harness tests can assert the
-    // bridge plumbed the optional fourth arg through. Negative / zero is
-    // the "no constraint" sentinel; f[2] preserves the raw value as
-    // received from the bridge.
+    // Capture the maxWidth so harness tests can assert the bridge plumbed the
+    // optional fourth arg through. Negative / zero is the "no constraint"
+    // sentinel; f[2] preserves the raw value as received from the bridge.
     DrawCommand cmd{DrawCommand::Type::fill_text};
     cmd.text = text;
     cmd.f[0] = x; cmd.f[1] = y;
@@ -305,7 +303,7 @@ float RecordingCanvas::measure_text(const std::string& text) {
     return static_cast<float>(text.size()) * 7.0f;
 }
 
-// ── issue-916: Canvas2D API gap closures ────────────────────────────────────
+// ── Canvas2D API command-stream coverage ────────────────────────────────────
 
 void RecordingCanvas::set_line_dash(const float* intervals, int count, float phase) {
     DrawCommand cmd{DrawCommand::Type::set_line_dash};
@@ -334,10 +332,9 @@ bool RecordingCanvas::draw_image_from_file(const std::string& path,
     return true;
 }
 
-// pulp #1737 — 9-arg drawImage source-rect form. Dst rect stays in
-// f[0..3] (matches the 5-arg test path); source rect (sx, sy, sw, sh)
-// goes into floats[0..3] so harness tests can assert sprite-sheet
-// slicing was plumbed end-to-end.
+// 9-arg drawImage source-rect form. Dst rect stays in f[0..3] (matches the
+// 5-arg test path); source rect (sx, sy, sw, sh) goes into floats[0..3] so
+// harness tests can assert sprite-sheet slicing was plumbed end-to-end.
 bool RecordingCanvas::draw_image_from_file_rect(const std::string& path,
                                                  float sx, float sy, float sw, float sh,
                                                  float dx, float dy, float dw, float dh) {
@@ -383,7 +380,7 @@ void RecordingCanvas::save_backdrop_filter(float x, float y, float w, float h,
     commands_.push_back(cmd);
 }
 
-// ── issue-925: box-shadow primitive ─────────────────────────────────────────
+// ── Box-shadow primitive ────────────────────────────────────────────────────
 
 void Canvas::draw_box_shadow(float x, float y, float w, float h,
                               float dx, float dy, float blur, float spread,
@@ -443,7 +440,7 @@ void RecordingCanvas::draw_box_shadow(float x, float y, float w, float h,
     commands_.push_back(std::move(cmd));
 }
 
-// ── issue-1434 batch 7: Canvas2D shadow* sticky state ──────────────────────
+// ── Canvas2D shadow* sticky state ───────────────────────────────────────────
 // Each setter records one command so widget-level tests can assert that the
 // bridge flushed the JS-side `ctx.shadowColor` / `ctx.shadowBlur` /
 // `ctx.shadowOffsetX` / `ctx.shadowOffsetY` writes through to the canvas
@@ -477,7 +474,7 @@ void RecordingCanvas::set_shadow_offset_y(float dy) {
     commands_.push_back(std::move(cmd));
 }
 
-// ── issue-1434 bridge-thin gap-fill: Canvas2D state setters ─────────────────
+// ── Canvas2D state setters ──────────────────────────────────────────────────
 // Mirror the shadow-state recording shape — one cmd per setter so the
 // canvas2d bridge harness can assert flush order without rasterizing.
 void RecordingCanvas::set_miter_limit(float limit) {
@@ -494,31 +491,30 @@ void RecordingCanvas::set_image_smoothing(bool enabled,
     commands_.push_back(cmd);
 }
 
-// pulp #1520 — capture Canvas2D ctx.direction. Enum packed into f[0]
-// (0=ltr, 1=rtl, 2=inherit). RecordingCanvas doesn't shape text — it
-// models the bridge intent so tests can assert the JS shim flushed
-// the direction setter at the right point in the command stream.
+// Capture Canvas2D ctx.direction. Enum packed into f[0] (0=ltr, 1=rtl,
+// 2=inherit). RecordingCanvas doesn't shape text — it models the bridge intent
+// so tests can assert the JS shim flushed the direction setter at the right
+// point in the command stream.
 void RecordingCanvas::set_direction(TextDirection direction) {
     DrawCommand cmd{DrawCommand::Type::set_direction};
     cmd.f[0] = static_cast<float>(direction);
     commands_.push_back(cmd);
 }
 
-// pulp #1520 — capture Canvas2D ctx.filter raw CSS string. The Skia
-// backend parses this into an SkImageFilter chain at draw time;
-// RecordingCanvas stores the source string verbatim so harness tests
-// can round-trip the bridge value without depending on a parser.
+// Capture Canvas2D ctx.filter raw CSS string. The Skia backend parses this
+// into an SkImageFilter chain at draw time; RecordingCanvas stores the source
+// string verbatim so harness tests can round-trip the bridge value without
+// depending on a parser.
 void RecordingCanvas::set_filter(const std::string& filter) {
     DrawCommand cmd{DrawCommand::Type::set_filter};
     cmd.text = filter;
     commands_.push_back(std::move(cmd));
 }
 
-// pulp #1434 bridge-thin gap-fill — capture Canvas2D ctx.createPattern
-// flushes. Image source string lives in `text`; tile modes go in
-// f[0] (x) and f[1] (y) as 0 = repeat, 1 = no_repeat. RecordingCanvas
-// doesn't decode the image — it models intent only, so the canvas2d
-// adapter can assert that the bridge issued the right setter at the
+// Capture Canvas2D ctx.createPattern flushes. Image source string lives in
+// `text`; tile modes go in f[0] (x) and f[1] (y) as 0 = repeat, 1 = no_repeat.
+// RecordingCanvas doesn't decode the image — it models intent only, so the
+// canvas2d adapter can assert that the bridge issued the right setter at the
 // right point in the command stream.
 void RecordingCanvas::set_fill_pattern(const std::string& image_src,
                                         PatternTileMode tile_x,
@@ -540,7 +536,7 @@ void RecordingCanvas::set_stroke_pattern(const std::string& image_src,
     commands_.push_back(std::move(cmd));
 }
 
-// ── Stroke gradients (pulp Wave 3 c2d.7) ────────────────────────────────────
+// ── Stroke gradients ────────────────────────────────────────────────────────
 //
 // Capture intent only — RecordingCanvas doesn't render. Tests assert on
 // the recorded command type + geometry to prove the bridge plumbed the
@@ -608,7 +604,7 @@ void RecordingCanvas::clear_stroke_gradient() {
     commands_.push_back({DrawCommand::Type::clear_stroke_gradient});
 }
 
-// ── issue-965: Canvas2D path API recording ──────────────────────────────────
+// ── Canvas2D path API recording ─────────────────────────────────────────────
 void RecordingCanvas::begin_path() {
     commands_.push_back({DrawCommand::Type::begin_path});
 }
@@ -646,9 +642,9 @@ void RecordingCanvas::close_path() {
 }
 
 void RecordingCanvas::fill_current_path(FillRule rule) {
-    // pulp Wave 2 cheap wiring — capture the JS-supplied fillRule arg in
-    // f[0] (0 = nonzero, 1 = evenodd) so [wave2-canvas2d] band tests can
-    // assert the bridge plumbed `ctx.fill('evenodd')` end-to-end.
+    // Capture the JS-supplied fillRule in f[0] (0 = nonzero, 1 = evenodd)
+    // so bridge tests can assert `ctx.fill('evenodd')` reaches the command
+    // stream end-to-end.
     DrawCommand cmd{DrawCommand::Type::fill_current_path};
     cmd.f[0] = (rule == FillRule::evenodd) ? 1.0f : 0.0f;
     commands_.push_back(cmd);
@@ -658,7 +654,7 @@ void RecordingCanvas::stroke_current_path() {
     commands_.push_back({DrawCommand::Type::stroke_current_path});
 }
 
-// ── pulp #1521: native arc subpath recording ────────────────────────────────
+// ── Native arc subpath recording ────────────────────────────────────────────
 //
 // These mirror the Skia / CG implementations as a pure capture so widget
 // tests can assert on the emitted command stream without a raster surface.

--- a/core/canvas/src/skia_canvas_box_shadow.cpp
+++ b/core/canvas/src/skia_canvas_box_shadow.cpp
@@ -1,14 +1,13 @@
 // skia_canvas_box_shadow.cpp — Canvas2D / CSS box-shadow paint slice.
 //
-// Extracted from skia_canvas.cpp in the 2026-05 Phase 4 (R2-3 follow-up)
-// refactor. Implements `draw_box_shadow(x, y, w, h, dx, dy, blur, spread,
-// color, inset, corner_radius)` matching the CSS box-shadow spec —
-// outset (default) shadows paint outside the rect via mask-filter blur;
-// inset shadows paint inside via clip + reverse-difference. Issue-925.
+// Implements `draw_box_shadow(x, y, w, h, dx, dy, blur, spread, color,
+// inset, corner_radius)` for CSS-compatible shadows: outset shadows paint
+// outside the rect via mask-filter blur; inset shadows paint inside via
+// clip + reverse-difference.
 //
-// pulp #1737 (Codex P2 sweep on #1791) — Skia headers MUST be included
-// BEFORE pulp/canvas/skia_canvas.hpp. See skia_canvas.cpp head-of-file
-// comment for the C++ name-lookup rule that forces this ordering.
+// Skia headers MUST be included BEFORE pulp/canvas/skia_canvas.hpp. See
+// skia_canvas.cpp's head-of-file comment for the C++ name-lookup rule that
+// forces this ordering.
 
 #include <algorithm>
 #include <cmath>
@@ -28,8 +27,7 @@
 #include "include/core/SkRect.h"
 #include "include/core/SkSamplingOptions.h"
 #include "include/core/SkSurface.h"
-// pulp #2183 hot-fix: box-shadow uses SkImageFilters::DropShadowOnly +
-// SkImageFilters::Blur; missing from the original split.
+// Box-shadow uses SkImageFilters::DropShadowOnly + SkImageFilters::Blur.
 #include "include/effects/SkImageFilters.h"
 
 #endif  // PULP_HAS_SKIA
@@ -44,7 +42,7 @@
 
 namespace pulp::canvas {
 
-// ── Box shadow (issue-925) ──────────────────────────────────────────────────
+// ── Box shadow ──────────────────────────────────────────────────────────────
 
 void SkiaCanvas::draw_box_shadow(float x, float y, float w, float h,
                                   float dx, float dy, float blur, float spread,
@@ -53,8 +51,8 @@ void SkiaCanvas::draw_box_shadow(float x, float y, float w, float h,
     if (color.a <= 0.0f || (w <= 0.0f && h <= 0.0f)) return;
 
     // Skia's drop-shadow blur sigma is roughly half the CSS blur radius;
-    // matching the WebView 1:1 within ~5px is the acceptance criterion
-    // (#925) so we use blur/2.0 the way Chromium's compositor does.
+    // matching the WebView 1:1 within ~5px is the acceptance criterion, so
+    // we use blur/2.0 the way Chromium's compositor does.
     const float sigma = std::max(0.0f, blur * 0.5f);
 
     if (!inset) {
@@ -152,8 +150,7 @@ void SkiaCanvas::draw_box_shadow(float x, float y, float w, float h,
         // Outset drop shadow (direct path): render the inflated rounded-rect
         // silhouette through SkImageFilters::DropShadowOnly so only the shadow
         // remains (no source pixels). This is exactly what Chromium uses
-        // for `box-shadow` and matches the WebView reference within ~5px
-        // (#925 acceptance criterion).
+        // for `box-shadow` and matches the WebView reference within ~5px.
         SkRect occluder = SkRect::MakeXYWH(x - spread,
                                            y - spread,
                                            w + spread * 2.0f,

--- a/core/canvas/src/skia_canvas_gradients.cpp
+++ b/core/canvas/src/skia_canvas_gradients.cpp
@@ -1,12 +1,12 @@
 // skia_canvas_gradients.cpp — Canvas2D gradient + pattern fillStyle/strokeStyle slice.
 //
-// Extracted from skia_canvas.cpp in the 2026-05 Phase 4 (R2-3 follow-up)
-// refactor. Covers linear / radial / conic / two-circles gradient
-// builders for fill + stroke, plus image-pattern repeat-mode plumbing.
+// Owns the Skia implementations for Canvas2D fill/stroke gradients
+// (linear, radial, conic, and two-circles) plus image-pattern repeat-mode
+// plumbing.
 //
-// pulp #1737 (Codex P2 sweep on #1791) — Skia headers MUST be included
-// BEFORE pulp/canvas/skia_canvas.hpp. See skia_canvas.cpp head-of-file
-// comment for the C++ name-lookup rule that forces this ordering.
+// Skia headers MUST be included BEFORE pulp/canvas/skia_canvas.hpp. See
+// skia_canvas.cpp's head-of-file comment for the C++ name-lookup rule that
+// forces this ordering.
 //
 // Skia's gradient API moved during the m149 window. This TU routes through
 // skia_gradient_compat.hpp so Pulp uses the public packaged header surface
@@ -81,8 +81,8 @@ void SkiaCanvas::set_fill_gradient_conic(float cx, float cy, float start_angle,
     has_gradient_ = gradient_shader_ != nullptr;
 }
 
-// pulp #1524 — Canvas2D `ctx.createRadialGradient(x0,y0,r0,x1,y1,r1)` two-circle
-// form. Skia renders the real two-point-conical gradient via
+// Canvas2D `ctx.createRadialGradient(x0,y0,r0,x1,y1,r1)` two-circle form.
+// Skia renders the real two-point-conical gradient via
 // SkShaders::TwoPointConicalGradient, honouring an offset / sized inner
 // circle (the existing single-circle path silently dropped (x0,y0,r0)).
 void SkiaCanvas::set_fill_gradient_radial_two_circles(
@@ -102,7 +102,7 @@ void SkiaCanvas::clear_fill_gradient() {
     has_gradient_ = false;
 }
 
-// ── Stroke gradients (pulp Wave 3 c2d.7) ────────────────────────────────────
+// ── Stroke gradients ────────────────────────────────────────────────────────
 //
 // Mirror of the fill-gradient setters above, targeting `stroke_shader_`.
 // `apply_stroke_state` already attaches `stroke_shader_` to the active
@@ -156,7 +156,7 @@ void SkiaCanvas::clear_stroke_gradient() {
     stroke_shader_ = nullptr;
 }
 
-// ── Patterns (pulp #1434 bridge-thin gap-fill) ──────────────────────────────
+// ── Patterns ────────────────────────────────────────────────────────────────
 //
 // Canvas2D `ctx.createPattern(image, repetition)` returns a CanvasPattern
 // the shim assigns to fillStyle / strokeStyle. The shim then invokes

--- a/core/canvas/src/skia_canvas_internal.hpp
+++ b/core/canvas/src/skia_canvas_internal.hpp
@@ -4,12 +4,9 @@
 // skia_canvas_mask). Internal to core/canvas/src; not part of the public
 // API.
 //
-// Background: PR #2183 (Phase 4 R2-3 follow-up) split skia_canvas.cpp
-// into per-feature TUs but left the shared static helpers
-// (`to_sk_color4f`, `skia_blend_mode_for`, the webgpu→SkColorType /
-// SkColorSpace mappers) only in skia_canvas.cpp. The split files
-// referenced them and failed to link. This header consolidates the
-// helpers as `inline` so every split TU sees the same definition.
+// Per-feature Skia canvas TUs share helpers such as `to_sk_color4f`,
+// `skia_blend_mode_for`, and the webgpu→SkColorType / SkColorSpace
+// mappers. Keep them inline here so every split TU sees the same definition.
 
 #pragma once
 

--- a/core/canvas/src/skia_canvas_mask.cpp
+++ b/core/canvas/src/skia_canvas_mask.cpp
@@ -1,24 +1,20 @@
 // skia_canvas_mask.cpp — CSS mask-image / mask-size paint slice.
 //
-// Extracted from skia_canvas.cpp in the 2026-05 Phase 4 (R2-3 first cut)
-// refactor. The 3,586-line monolith has been the source of repeated
-// merge conflicts (40 touches/60 days) — pulling the bottom-of-file
-// mask section into its own TU isolates mask-specific edits.
+// Owns Skia-backed CSS mask-image / mask-size painting so mask-specific
+// parsing and composition stay isolated from the rest of the Canvas2D
+// backend.
 //
-// Phase 1 ships linear-gradient + radial-gradient mask shapes. url() and
-// other shapes fall through to the no-mask path (save_layer) — content
-// renders unchanged, mask is silently bypassed (matches pre-#1737
-// behavior where the catalog claim was storage-only). Phase 2 (followup)
-// can add url(<file_path>) via image_cache and url(#elementRef) via the
-// SVG-defs registry that pulp #932 PR-2 also needs.
+// Supported mask inputs are parsed into a shader and applied on restore()
+// with the CSS kDstIn composite. Unsupported or unparseable forms fall
+// through to the no-mask path: content still renders, but no mask is applied.
 //
 // CSS Masking Module Level 1 §5 specifies the kDstIn composite — see
 // SkiaCanvas::restore() in skia_canvas.cpp for the matching close-side
 // composite.
 
-// pulp #1737 (Codex P2 sweep on #1791) — Skia headers MUST be included
-// BEFORE pulp/canvas/skia_canvas.hpp. See skia_canvas.cpp head-of-file
-// comment for the C++ name-lookup rule that forces this ordering.
+// Skia headers MUST be included BEFORE pulp/canvas/skia_canvas.hpp. See
+// skia_canvas.cpp's head-of-file comment for the C++ name-lookup rule that
+// forces this ordering.
 
 #include <algorithm>
 #include <cctype>
@@ -58,14 +54,11 @@
 
 namespace pulp::canvas {
 
-// ── pulp #1737 / #1515 — CSS mask-image + mask-size paint slice ─────────
+// ── CSS mask-image + mask-size paint slice ──────────────────────────────
 //
-// Phase 1 ships linear-gradient + radial-gradient mask shapes. url() and
-// other shapes fall through to the no-mask path (save_layer) — content
-// renders unchanged, mask is silently bypassed (matches pre-#1737
-// behavior where the catalog claim was storage-only). Phase 2 (followup)
-// can add url(<file_path>) via image_cache and url(#elementRef) via the
-// SVG-defs registry that pulp #932 PR-2 also needs.
+// Supported mask inputs are parsed into a shader and applied on restore()
+// with the CSS kDstIn composite. Unsupported or unparseable forms fall
+// through to the no-mask path: content still renders, but no mask is applied.
 //
 // CSS Masking Module Level 1 §5 specifies the kDstIn composite — see
 // SkiaCanvas::restore() for the matching close-side composite.
@@ -167,7 +160,7 @@ std::optional<SkColor> parse_color_token(const std::string& s, size_t& i) {
 // shader sized to the bounds (x,y,w,h). Returns nullptr for unparseable
 // input — caller falls back to the no-mask path.
 //
-// Phase 1 supports a deliberately narrow subset:
+// Supports a deliberately narrow subset:
 //   linear-gradient(<dir>, <color> [, <color>]+)
 // where <dir> is one of: `to top`, `to bottom`, `to left`, `to right`,
 // or an angle like `<n>deg`. Defaults to `to bottom` if no direction
@@ -237,8 +230,8 @@ sk_sp<SkShader> parse_linear_gradient_mask(const std::string& value,
         if (!col) return nullptr;
         colors.push_back(SkColor4f::FromColor(*col));
         mask_skip_ws(inner, k);
-        // Skip optional position (we ignore explicit positions in
-        // Phase 1 — CSS even-distribution is the default fallback).
+        // Skip optional position; CSS even-distribution is the default
+        // fallback.
         while (k < inner.size() && inner[k] != ',' && inner[k] != ')') ++k;
         if (k < inner.size() && inner[k] == ',') { ++k; mask_skip_ws(inner, k); }
     }
@@ -265,8 +258,8 @@ sk_sp<SkShader> parse_linear_gradient_mask(const std::string& value,
 //   `auto`        → (1, 1)
 //   `cover`       → (1, 1) — for a single shader fill, "cover" and the
 //                  default both fill the box. (Non-square mask images
-//                  would diverge here, but for the gradient-only Phase 1
-//                  the simplification is safe — see notes.)
+//                  diverge here, but for shader masks that already fill
+//                  the box the simplification is safe.)
 //   `contain`     → (1, 1) — same simplification rationale.
 //   `<n>%`        → (n/100, n/100)
 //   `<n>% <m>%`   → (n/100, m/100)
@@ -376,11 +369,10 @@ void SkiaCanvas::save_layer_with_mask(float x, float y, float w, float h,
                                       const std::string& mask_size) {
     if (!canvas_) { save(); return; }
 
-    // pulp #1737 / #1515 — apply mask-size by scaling the effective
-    // box passed to the gradient parser. mask-size = "50% 100%" makes
-    // the gradient cover half the width but the full height; the mask
-    // alpha outside that scaled region is zero (kClamp on the shader
-    // edges — content there gets clipped by kDstIn).
+    // Apply mask-size by scaling the effective box passed to the mask shader
+    // parser. mask-size = "50% 100%" makes the mask cover half the width but
+    // the full height; alpha outside that scaled region is zero, so content
+    // there gets clipped by kDstIn.
     const auto [wf, hf] = parse_mask_size(mask_size, w, h);
     const float scaled_w = w * wf;
     const float scaled_h = h * hf;
@@ -394,16 +386,15 @@ void SkiaCanvas::save_layer_with_mask(float x, float y, float w, float h,
     }
     // Other forms (radial-gradient / none / unparseable) drop to the
     // no-mask path: the layer opens with content opacity, restore() sees
-    // no pending mask shader and just closes plainly. Net behavior =
-    // pre-#1737 (no mask applied) — safe regression-free fallback.
+    // no pending mask shader and just closes plainly. Net behavior is the
+    // no-mask fallback.
 
     SkRect bounds = SkRect::MakeXYWH(x, y, w, h);
     SkPaint outer_paint;
     if (opacity < 1.0f) outer_paint.setAlphaf(opacity);
     canvas_->saveLayer(&bounds, &outer_paint);
 
-    // pulp #1899 (gap #3) — non-opaque text-edging tracking, mirrors
-    // the other save_layer* variants.
+    // Non-opaque text-edging tracking mirrors the other save_layer* variants.
     if (opacity < 1.0f) {
         non_opaque_layer_stack_.push_back(canvas_->getSaveCount());
     }

--- a/core/canvas/src/skia_canvas_opacity.cpp
+++ b/core/canvas/src/skia_canvas_opacity.cpp
@@ -1,8 +1,7 @@
 // skia_canvas_opacity.cpp — Canvas2D save_layer + filter composition slice.
 //
-// Extracted from skia_canvas.cpp in the 2026-05 Phase 4 (R2-3 follow-up)
-// refactor. Covers the offscreen-layer / CSS opacity / CSS filter
-// composition surface:
+// Owns the Skia offscreen-layer / CSS opacity / CSS filter composition
+// surface:
 //
 //   - set_opacity(alpha) — per-draw alpha shim (full opacity uses
 //     save_layer instead).
@@ -19,8 +18,9 @@
 //     blur — pushes a layer whose source is the parent-canvas content
 //     pre-filtered, so subsequent draws composite over the blurred backdrop.
 //
-// pulp #1737 (Codex P2 sweep on #1791) — Skia headers MUST be included
-// BEFORE pulp/canvas/skia_canvas.hpp.
+// Skia headers MUST be included BEFORE pulp/canvas/skia_canvas.hpp. See
+// skia_canvas.cpp's head-of-file comment for the C++ name-lookup rule that
+// forces this ordering.
 
 #include <algorithm>
 #include <cmath>
@@ -81,17 +81,17 @@ void SkiaCanvas::save_layer(float x, float y, float w, float h,
 
     canvas_->saveLayer(&bounds, &layer_paint);
 
-    // pulp #1899 (gap #3) — record that this layer's destination is
-    // non-opaque so text-paint paths inside it use greyscale AA.
+    // Record that this layer's destination is non-opaque so text-paint paths
+    // inside it use greyscale AA.
     if (opacity < 1.0f) {
         non_opaque_layer_stack_.push_back(canvas_->getSaveCount());
     }
 }
 
-// pulp #1549 — saveLayer with explicit blend mode. The layer-paint's blend
-// mode is the one Skia uses when compositing the layer back onto its
-// parent at restore() time, which is exactly the CSS / RN
-// `mix-blend-mode` semantic ("isolate the subtree, then blend it back").
+// saveLayer with explicit blend mode. The layer-paint's blend mode is the one
+// Skia uses when compositing the layer back onto its parent at restore() time,
+// which is exactly the CSS / RN `mix-blend-mode` semantic ("isolate the
+// subtree, then blend it back").
 void SkiaCanvas::save_layer_with_blend(float x, float y, float w, float h,
                                        float opacity, float blur_radius,
                                        Canvas::BlendMode mode) {
@@ -113,15 +113,15 @@ void SkiaCanvas::save_layer_with_blend(float x, float y, float w, float h,
 
     canvas_->saveLayer(&bounds, &layer_paint);
 
-    // pulp #1899 (gap #3) — mirror save_layer(): track non-opaque layer
-    // so text inside it picks greyscale AA over LCD subpixel AA.
+    // Mirror save_layer(): track non-opaque layers so text inside them picks
+    // greyscale AA over LCD subpixel AA.
     if (opacity < 1.0f) {
         non_opaque_layer_stack_.push_back(canvas_->getSaveCount());
     }
 }
 
 
-// pulp #1434 Phase A2-4 — full CSS filter chain composition.
+// Full CSS filter chain composition.
 //
 // Builds an SkImageFilter chain from the structured FilterChainEntry
 // list. Color-matrix-based filters (brightness / contrast / grayscale
@@ -163,13 +163,12 @@ void SkiaCanvas::save_layer_with_filters(float x, float y, float w, float h,
             }
             case FilterChainEntry::Kind::opacity: {
                 // Per CSS — opacity(a) multiplies the alpha channel by
-                // a (0..1). Codex P2 #3195880608: this MUST remain in
-                // the composed chain at its original source-order
-                // position, because subsequent filters (e.g. drop-shadow)
-                // depend on the reduced alpha as their input. Folding
-                // it into the layer alpha would apply opacity AFTER the
-                // shadow was generated, which produces a different and
-                // incorrect result for `opacity(0.5) drop-shadow(...)`.
+                // a (0..1). This MUST remain in the composed chain at its
+                // original source-order position, because subsequent filters
+                // (e.g. drop-shadow) depend on the reduced alpha as their
+                // input. Folding it into the layer alpha would apply opacity
+                // AFTER the shadow was generated, which produces a different
+                // and incorrect result for `opacity(0.5) drop-shadow(...)`.
                 const float a = std::min(std::max(f.amount, 0.0f), 1.0f);
                 float m[20] = {
                     1, 0, 0, 0, 0,
@@ -196,10 +195,10 @@ void SkiaCanvas::save_layer_with_filters(float x, float y, float w, float h,
             }
             case FilterChainEntry::Kind::contrast: {
                 // Per CSS — c=amount, slope=c, intercept=0.5*(1-c).
-                // SkColorFilters::Matrix expects the translation column
-                // in 0..255 space (Codex P1 #3195880597), so the bias
-                // term is multiplied by 255 to land at mid-gray for
-                // contrast(0). The slope multipliers stay normalized.
+                // SkColorFilters::Matrix expects the translation column in
+                // 0..255 space, so the bias term is multiplied by 255 to land
+                // at mid-gray for contrast(0). The slope multipliers stay
+                // normalized.
                 const float c = f.amount;
                 const float t = 0.5f * (1.0f - c) * 255.0f;
                 float m[20] = {
@@ -246,8 +245,8 @@ void SkiaCanvas::save_layer_with_filters(float x, float y, float w, float h,
             case FilterChainEntry::Kind::invert: {
                 // Per CSS spec — amount=1 fully inverts, amount=0 is identity.
                 // SkColorFilters::Matrix expects the translation column in
-                // 0..255 space (Codex P1 #3195880597), so the bias term `a`
-                // is multiplied by 255 to map black->white at invert(1).
+                // 0..255 space, so the bias term `a` is multiplied by 255 to
+                // map black->white at invert(1).
                 const float a = std::min(std::max(f.amount, 0.0f), 1.0f);
                 const float k = 1.0f - 2.0f * a;
                 const float t = a * 255.0f;
@@ -333,7 +332,7 @@ void SkiaCanvas::save_layer_with_filters(float x, float y, float w, float h,
 
     canvas_->saveLayer(&bounds, &layer_paint);
 
-    // pulp #1899 (gap #3) — track non-opaque destination for text-edging.
+    // Track non-opaque destination for text-edging.
     if (opacity < 1.0f) {
         non_opaque_layer_stack_.push_back(canvas_->getSaveCount());
     }
@@ -341,9 +340,9 @@ void SkiaCanvas::save_layer_with_filters(float x, float y, float w, float h,
 
 void SkiaCanvas::save_backdrop_filter(float x, float y, float w, float h,
                                        float blur_radius) {
-    // CSS `backdrop-filter: blur(N)` (issue-926). Push a layer whose initial
-    // contents are the parent surface filtered through a Gaussian blur, so
-    // subsequent draws into this layer composite over the blurred backdrop.
+    // CSS `backdrop-filter: blur(N)`. Push a layer whose initial contents are
+    // the parent surface filtered through a Gaussian blur, so subsequent draws
+    // into this layer composite over the blurred backdrop.
     if (!canvas_) { save(); return; }
     if (blur_radius <= 0.0f) {
         // Degenerate: behave like a plain save() so the matching restore()

--- a/core/canvas/src/skia_canvas_shaders.cpp
+++ b/core/canvas/src/skia_canvas_shaders.cpp
@@ -1,7 +1,6 @@
 // skia_canvas_shaders.cpp — GPU shader-driven paint slices.
 //
-// Extracted from skia_canvas.cpp in the 2026-05 Phase 4 (R2-3 follow-up)
-// refactor. Bundles four GPU/SkSL-driven concerns into one TU:
+// Owns four GPU/SkSL-driven Canvas paint paths:
 //
 //   - GPU SDF Shape Primitives — kSDFShapeSkSL runtime effect + the
 //     draw_sdf_shape / draw_sdf_ring / draw_sdf_rect family.
@@ -12,8 +11,9 @@
 //   - GPU Waveform — kWaveformSkSL + draw_waveform() / draw_spectrum_bars()
 //     for shader-driven 1D-texture waveform rendering.
 //
-// pulp #1737 (Codex P2 sweep on #1791) — Skia headers MUST be included
-// BEFORE pulp/canvas/skia_canvas.hpp.
+// Skia headers MUST be included BEFORE pulp/canvas/skia_canvas.hpp. See
+// skia_canvas.cpp's head-of-file comment for the C++ name-lookup rule that
+// forces this ordering.
 
 #include <algorithm>
 #include <cmath>
@@ -41,8 +41,7 @@
 #include "include/core/SkTileMode.h"
 #include "include/effects/SkImageFilters.h"
 #include "include/effects/SkRuntimeEffect.h"
-// pulp #2183 hot-fix: WebGPU/Graphite native-texture wrap path was
-// missing these heavy includes after the split.
+// WebGPU/Graphite native-texture wrapping needs these Graphite/Dawn includes.
 #include "include/gpu/GpuTypes.h"                  // skgpu::Origin
 #include "include/gpu/graphite/BackendTexture.h"
 #include "include/gpu/graphite/Image.h"            // SkImages::WrapTexture
@@ -335,14 +334,10 @@ bool SkiaCanvas::draw_native_dawn_texture(void* texture_handle,
                                           float y,
                                           float w,
                                           float h) {
-    // iOS-D.3c (#3217): implement the WebGPU canvas → Skia blit. The
-    // bridge gives canvas widgets a `wgpu::Texture*` provider (see
-    // widget_bridge.cpp:1027-1029 and :3265/:3666); CanvasWidget::paint()
-    // routes through here. Until this function returned `true` the
-    // Three.js cube rendered to an invisible offscreen texture; the
-    // CAMetalLayer surface stayed blank. Codex's plan in issue #3217:
-    // wrap the Dawn texture as a graphite::BackendTexture, materialize
-    // as an SkImage, draw into the current canvas.
+    // WebGPU canvas widgets provide a `wgpu::Texture*` that must be wrapped
+    // as a Graphite backend texture, materialized as an SkImage, and drawn
+    // into the current Skia canvas. Returning true tells the widget paint path
+    // that the offscreen Dawn texture reached the presentable surface.
     if (!canvas_ || !recorder_ || !texture_handle || width == 0 || height == 0) {
         return false;
     }

--- a/core/render/CMakeLists.txt
+++ b/core/render/CMakeLists.txt
@@ -51,7 +51,7 @@ if(NOT ANDROID)
     target_sources(pulp-render PRIVATE src/sdl3_surface.cpp)
 endif()
 
-# Slice 16 — VBlank-locked RenderLoop platform backends.
+# VBlank-locked RenderLoop platform backends.
 # iOS uses CADisplayLink; Android uses AChoreographer. macOS (CVDisplayLink),
 # Windows (DwmFlush) and the Linux/timer fallback all live in render_loop.cpp.
 if(PULP_IOS)
@@ -102,7 +102,7 @@ if(PULP_HAS_SDL3)
     target_compile_definitions(pulp-render PRIVATE PULP_HAS_SDL3=1)
 endif()
 
-# RenderLoop vblank sources (Slice 16):
+# RenderLoop vblank sources:
 #   macOS — CVDisplayLink (CoreVideo)
 #   iOS   — CADisplayLink (QuartzCore, already linked above for Metal)
 #   Win   — DwmFlush (dwmapi)

--- a/core/render/include/pulp/render/atlas_inventory.hpp
+++ b/core/render/include/pulp/render/atlas_inventory.hpp
@@ -2,9 +2,6 @@
 
 // atlas_inventory.hpp — read-only GPU texture-atlas inventory.
 //
-// Phase 6.2 of the inspector GPU-perf roadmap
-// (planning/2026-05-19-inspector-phase6-gpu-perf-spike.md § Phase 6.2).
-//
 // The render layer owns several shelf-packed texture atlases — the
 // glyph atlas (SDF text), the image atlas, the gradient ramp atlas,
 // and the path atlas (texture_atlas.hpp). Each one is a GPU texture

--- a/core/render/include/pulp/render/bench/perf_counters.hpp
+++ b/core/render/include/pulp/render/bench/perf_counters.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
 /// @file perf_counters.hpp
-/// Zero-copy benchmark perf counters (Slice 0 of the zero-copy ralph loop).
+/// Benchmark perf counters for copy/upload/readback costs.
 ///
-/// Part of the zero-copy initiative (#516 / #517). This header is
-/// compiled out entirely when `PULP_BENCHMARK` is not defined, so the
-/// production audio/UI paths see zero overhead by default.
+/// This header is compiled out entirely when `PULP_BENCHMARK` is not defined,
+/// so the production audio/UI paths see zero overhead by default.
 ///
 /// Counters accumulate microseconds (or byte counts) via
 /// `std::atomic<double>::fetch_add`. Writers on different threads (audio
@@ -60,15 +59,12 @@ struct PerfCounters {
     // Number of samples (frames) rolled into the above totals.
     std::atomic<double> sample_count{0.0};
 
-    // Slice 0.5 additions — real JS→GPU upload instrumentation (#516).
-    // Captures the JS-driven WebGPU resource setup path in
-    // `core/view/src/widget_bridge.cpp`: base64 decode cost (for the
-    // __gpuComputeDispatchImpl bufferDataBase64 path added in #535),
-    // the number of WriteBuffer calls (so per-upload cost is derivable
-    // from `gpu_upload_total_us / gpu_buffer_upload_count`), and the
-    // peak resident GPU-buffer memory so we can tell whether a workload
-    // actually stresses the bridge (vs. the oscilloscope/spectrogram
-    // paths that allocate effectively nothing).
+    // JS→GPU upload instrumentation. Captures the JS-driven WebGPU resource
+    // setup path in `core/view/src/widget_bridge.cpp`: base64 decode cost,
+    // the number of WriteBuffer calls (so per-upload cost is derivable from
+    // `gpu_upload_total_us / gpu_buffer_upload_count`), and the peak resident
+    // GPU-buffer memory so we can tell whether a workload actually stresses
+    // the bridge.
     //
     // The peak is tracked via a `compare_exchange` loop in
     // `observe_resident_peak` so concurrent writers stay monotonic

--- a/core/render/include/pulp/render/gpu_compute.hpp
+++ b/core/render/include/pulp/render/gpu_compute.hpp
@@ -16,8 +16,8 @@ namespace pulp::render {
 
 /// GPU compute pipeline for non-rendering workloads (e.g. spectral processing).
 ///
-/// This is an EXPERIMENTAL exploration API for Phase 11 feasibility testing.
-/// It operates on a Dawn wgpu::Device shared with GpuSurface/SkiaSurface.
+/// Experimental API for background GPU compute work. It operates on a Dawn
+/// wgpu::Device shared with GpuSurface/SkiaSurface.
 ///
 /// Design constraints:
 /// - Never runs in the audio callback (upload/readback latency is too high)
@@ -61,7 +61,7 @@ public:
     virtual bool batch_magnitude(const float* complex_frames, float* magnitude_frames,
                                  uint32_t bins_per_frame, uint32_t num_frames) = 0;
 
-    // ── Device sharing verification (Phase 13 forward compatibility) ────
+    // ── Device sharing verification ──────────────────────────────────────
 
     struct DeviceSharingReport {
         bool device_obtained = false;

--- a/core/render/include/pulp/render/gpu_render_time.hpp
+++ b/core/render/include/pulp/render/gpu_render_time.hpp
@@ -6,15 +6,14 @@
 
 namespace pulp::render {
 
-/// Phase 6.5 (re-scoped) — whole-recording GPU *render* time.
+/// Whole-recording GPU *render* time.
 ///
 /// True per-pass GPU timing tied to Pulp's logical render passes is
 /// architecturally blocked: Skia Graphite owns the Dawn command encoder and
 /// every render-pass descriptor, so Pulp cannot inject per-pass
 /// `timestampWrites`, and the encoder-level `WriteTimestamp` is gated behind
 /// Dawn's `allow_unsafe_apis` toggle and disabled by Skia's `DawnCaps` on
-/// Metal/Apple-silicon (Pulp's primary platform). See
-/// `planning/2026-05-21-gpu-timestamp-readback-proposal.md`.
+/// Metal/Apple-silicon (Pulp's primary platform).
 ///
 /// What IS available — and correct on every backend — is Skia Graphite's own
 /// GPU-stats API: `InsertRecordingInfo::fGpuStatsFlags = kElapsedTime` plus a

--- a/core/render/include/pulp/render/gpu_surface.hpp
+++ b/core/render/include/pulp/render/gpu_surface.hpp
@@ -60,11 +60,10 @@ public:
 
     /// Typed X11 surface handle. Pass a pointer to one of these as
     /// Config::native_surface_handle on Linux so Dawn can build an
-    /// SurfaceSourceXlibWindow (#3329 Win/Linux parity). `display` is an
-    /// `Display*` and `window` is an X11 `Window` (an `unsigned long`); both are
-    /// kept opaque here so this header stays Xlib-include-free for non-Linux and
-    /// no-X11 consumers. The pointed-to struct only needs to outlive the
-    /// initialize() call.
+    /// SurfaceSourceXlibWindow. `display` is an `Display*` and `window` is an
+    /// X11 `Window` (an `unsigned long`); both are kept opaque here so this
+    /// header stays Xlib-include-free for non-Linux and no-X11 consumers. The
+    /// pointed-to struct only needs to outlive the initialize() call.
     struct X11NativeHandle {
         void*         display = nullptr;  // Display*
         unsigned long window  = 0;        // Window

--- a/core/render/include/pulp/render/gpu_timestamps.hpp
+++ b/core/render/include/pulp/render/gpu_timestamps.hpp
@@ -10,7 +10,7 @@
 
 namespace pulp::render {
 
-/// Phase 6.5 — Dawn GPU timestamp queries.
+/// Dawn GPU timestamp queries.
 ///
 /// WebGPU exposes GPU-side timing through a `wgpu::QuerySet` of
 /// `QueryType::Timestamp`. The pure conversion helpers below are live;
@@ -199,8 +199,7 @@ enum class GpuTimestampSupport {
 ///   4. `read_back()` returns the resolved ticks `resolve()` populated;
 ///      feed them through `resolve_pass_timings` + `apply_pass_timings`.
 ///
-/// The 1-frame readback lag is inherent to GPU timestamp queries and is
-/// accepted by the spike spec (Phase 6.5, "1-frame lag is unavoidable").
+/// The 1-frame readback lag is inherent to GPU timestamp queries.
 class GpuTimestamps {
 public:
     GpuTimestamps();

--- a/core/render/include/pulp/render/headless_surface.hpp
+++ b/core/render/include/pulp/render/headless_surface.hpp
@@ -17,7 +17,7 @@ namespace pulp::render {
 /// (`GpuSurface::create_dawn() + native_surface_handle=nullptr` +
 /// `SkiaSurface::create`). Intended for CI golden tests and any other
 /// callsite that wants "render this scene to an RGBA / PNG buffer with
-/// no window". Spec: planning/2026-05-24-macos-plugin-authoring-plan.md §6.7.
+/// no window".
 ///
 /// The wrapper does NOT introduce a new render path — it just hides
 /// the begin_frame/end_frame ceremony and the GPU readback dance so a

--- a/core/render/include/pulp/render/render_loop.hpp
+++ b/core/render/include/pulp/render/render_loop.hpp
@@ -17,9 +17,8 @@
 //             same factory seam when available; see render_loop.cpp)
 //   Other   : timer fallback                      (~60 Hz)
 //
-// Slice 16 (planning/2026-05-18-rt-safety-and-debug-dx.md) — the VBlank-
-// locked safe-repaint pattern. The dirty-flag coalescer itself lives in
-// RenderLoopState (render_loop_state.hpp) and is platform-agnostic and
+// The VBlank-locked safe-repaint pattern keeps dirty-frame coalescing in
+// RenderLoopState (render_loop_state.hpp), which is platform-agnostic and
 // unit-tested; each platform subclass only owns the native vsync source.
 
 #include <functional>

--- a/core/render/include/pulp/render/render_pass.hpp
+++ b/core/render/include/pulp/render/render_pass.hpp
@@ -20,9 +20,8 @@ enum class RenderPassType {
 /// Statistics for a single render pass.
 ///
 /// `time_ms` is CPU wall-time measured around the pass's draw-call
-/// submission — it is what the inspector Performance tab has always
-/// shown. Phase 6.5 adds `gpu_time_ms`: the *true* GPU-side execution
-/// time of the pass, sampled via Dawn timestamp queries
+/// submission. `gpu_time_ms` is the true GPU-side execution time of the pass,
+/// sampled via Dawn timestamp queries
 /// (`pulp::render::GpuTimestamps`). The two numbers diverge exactly
 /// where perf bugs hide — a pass cheap on the CPU but expensive on the
 /// GPU (overdraw, expensive shaders) is invisible without the GPU clock.
@@ -38,9 +37,9 @@ struct PassStats {
     float gpu_time_ms = 0;    ///< True GPU execution time (ms); see gpu_time_valid.
     bool  gpu_time_valid = false;  ///< Whether gpu_time_ms holds a real sample.
 
-    /// Explicit alias for the CPU number. Phase 6.5 introduced the
-    /// CPU-vs-GPU split; `cpu_time_ms()` makes call sites that want the
-    /// CPU clock self-documenting without changing the wire field name.
+    /// Explicit alias for the CPU number. `cpu_time_ms()` makes call sites
+    /// that want the CPU clock self-documenting without changing the wire
+    /// field name.
     float cpu_time_ms() const { return time_ms; }
 };
 
@@ -83,7 +82,7 @@ public:
         over_budget_ = (budget_ms_ > 0 && total_time_ms_ > budget_ms_);
     }
 
-    /// Phase 6.5: feed a resolved GPU-side duration into a pass.
+    /// Feed a resolved GPU-side duration into a pass.
     ///
     /// GPU timestamp queries are resolved one frame after the pass that
     /// wrote them was submitted, so this is called by the GPU-timestamp
@@ -117,8 +116,7 @@ public:
     /// render clock is whole-recording, not per-pass, so this is the honest
     /// place to record it. `valid` should reflect
     /// `WindowHost::gpu_render_timing_available()`. Negative durations are
-    /// clamped to "invalid". See
-    /// `planning/2026-05-21-gpu-timestamp-readback-proposal.md`.
+    /// clamped to "invalid".
     void set_gpu_render_time_ms(float ms, bool valid) {
         if (valid && ms >= 0.0f) {
             gpu_render_time_ms_ = ms;

--- a/core/render/include/pulp/render/skia_surface.hpp
+++ b/core/render/include/pulp/render/skia_surface.hpp
@@ -71,13 +71,12 @@ public:
     /// silently dropping them. The pointer is owned by the SkiaSurface.
     virtual skgpu::graphite::Context* graphite_context() const = 0;
 
-    /// Phase 6.5 (re-scoped) — most recent whole-recording GPU *render* time
-    /// in milliseconds, sampled from Skia Graphite's GpuStats(kElapsedTime)
-    /// finished-with-stats callback. Returns 0 until the first sample lands or
-    /// when timing is unavailable. This is render-recording time, not total
-    /// frame time (on the Metal fallback it excludes non-pass uploads/copies
-    /// and present). See `gpu_render_time.hpp` and
-    /// `planning/2026-05-21-gpu-timestamp-readback-proposal.md`.
+    /// Most recent whole-recording GPU *render* time in milliseconds, sampled
+    /// from Skia Graphite's GpuStats(kElapsedTime) finished-with-stats
+    /// callback. Returns 0 until the first sample lands or when timing is
+    /// unavailable. This is render-recording time, not total frame time (on the
+    /// Metal fallback it excludes non-pass uploads/copies and present). See
+    /// `gpu_render_time.hpp`.
     virtual double gpu_render_time_ms() const = 0;
 
     /// Whether GPU render timing is available this run — the adapter offered

--- a/core/render/include/pulp/render/skp_capture.hpp
+++ b/core/render/include/pulp/render/skp_capture.hpp
@@ -2,15 +2,12 @@
 
 // skp_capture.hpp — Skia `.skp` (SkPicture) frame capture.
 //
-// Phase 6.4 of the inspector GPU-perf roadmap
-// (planning/2026-05-19-inspector-phase6-gpu-perf-spike.md § Phase 6.4).
-//
 // The capture writes a rendered frame as a Skia `.skp` artifact that
 // Skia's own `skiadebugger` can replay op-by-op. This is the bridge
 // from "a frame looked weird in Pulp" to the best-in-class external
 // frame-debugging tool — for free, because Skia ships the format.
 //
-// Design (from the Phase 6.4 spike, which de-risked this in PR #2506):
+// Design:
 //
 //   * `.skp` is the legacy `SkPicture` serialization format. It is
 //     fully backend-independent — an `SkPictureRecorder` records draw

--- a/core/render/src/gpu_compute.cpp
+++ b/core/render/src/gpu_compute.cpp
@@ -209,24 +209,20 @@ public:
 
         // Register OnSubmittedWorkDone to release the storage buffers once the
         // GPU confirms the dispatch+copy submission completed. The readback
-        // buffer is still live (it's about to be MapAsync'd) — we release it
-        // synchronously after read_back() has Unmap'd it. See design doc
-        // planning/zero-copy-slice-1-design-2026-04-20.md "GPU-in-flight".
+        // buffer is still live (it's about to be MapAsync'd), so it is
+        // released synchronously after read_back() has Unmap'd it.
         schedule_pool_release({input_buf, output_buf});
 
         const bool ok = read_back(readback_buf, magnitudes, output_bytes);
 
-        // Codex 2026-04-21 review on #536 P1: only recycle on SUCCESS.
-        // On MapAsync timeout the GPU may still be mapping the buffer
-        // when this function returns; handing it back to the pool lets
-        // a subsequent call re-acquire and reuse it while the prior map
-        // is still in flight — a validation error / silent corruption
-        // risk under slow GPU workloads.
+        // Only recycle readback buffers on success. On MapAsync timeout the
+        // GPU may still be mapping the buffer when this function returns;
+        // handing it back to the pool could let a subsequent call re-acquire
+        // and reuse it while the prior map is still in flight.
         //
-        // Codex 2026-04-21 review on #560 (wave 2) P1: on failure we
-        // still must drop the pool's in_flight_ reference via discard(),
-        // otherwise repeated timeouts accumulate tracked handles and
-        // grow the pool without bound. discard() is a release() that
+        // On failure we still must drop the pool's in_flight_ reference via
+        // discard(), otherwise repeated timeouts accumulate tracked handles
+        // and grow the pool without bound. discard() is a release() that
         // skips the free-list recycle step.
         if (ok) {
             pool_->release(readback_buf);
@@ -293,13 +289,12 @@ public:
         schedule_pool_release({buf_a, buf_b, buf_result});
 
         const bool ok = read_back(readback_buf, result, bytes);
-        // Codex 2026-04-21 review on #536 P1 — matched to the magnitude
-        // path: only recycle on success. On read_back failure the GPU
-        // may still hold a mapping on this buffer.
+        // Match the magnitude path: only recycle on success. On read_back
+        // failure the GPU may still hold a mapping on this buffer.
         //
-        // Codex 2026-04-21 wave 2 P1 on #560: use discard() on failure
-        // so repeated timeouts don't accumulate tracked handles in
-        // in_flight_ — see compute_magnitude() for the full rationale.
+        // Use discard() on failure so repeated timeouts don't accumulate
+        // tracked handles in in_flight_; see compute_magnitude() for the full
+        // rationale.
         if (ok) {
             pool_->release(readback_buf);
         } else {
@@ -399,7 +394,7 @@ public:
         notes << "Backend: " << report.backend_name
               << ". Device sharing verified: compute buffers and command submission "
               << "work on the same Dawn device used by Skia Graphite. "
-              << "Phase 13 can proceed with shared-device Three.js bridge.";
+              << "Shared-device Three.js bridge prerequisites are satisfied.";
         report.notes = notes.str();
 
         return report;
@@ -619,14 +614,11 @@ private:
     // Pool of persistent staging buffers, keyed by usage bitmask. Replaces
     // per-call device_.CreateBuffer() in compute_magnitude / complex_multiply
     // to eliminate allocator churn. Created lazily in create_pipelines().
-    // Codex 2026-04-21 review on #536: the OnSubmittedWorkDone callback
-    // captures the pool pointer to return buffers post-submission. The
-    // callback can fire after `~DawnGpuCompute()` resets the pool in
-    // shared-device mode (where event processing continues outside this
-    // object). Owning the pool via `shared_ptr` and handing the callback
-    // a `weak_ptr` means a stale callback just drops its buffers (RAII
-    // dtor handles the wgpu::Buffer side) instead of dereferencing a
-    // dangling `pool_raw` pointer.
+    // OnSubmittedWorkDone callbacks can fire after `~DawnGpuCompute()` resets
+    // the pool in shared-device mode, where event processing continues outside
+    // this object. Owning the pool via `shared_ptr` and handing callbacks a
+    // `weak_ptr` means stale callbacks just drop their buffers (RAII dtor
+    // handles the wgpu::Buffer side) instead of dereferencing freed state.
     std::shared_ptr<detail::StagingBufferPool> pool_;
 
     bool create_pipelines() {
@@ -638,10 +630,9 @@ private:
 
         // Staging buffer pool: pre-allocated ring of persistent wgpu::Buffer
         // objects that replaces per-call device_.CreateBuffer() in the compute
-        // hot path. Planning reference:
-        // planning/zero-copy-slice-1-design-2026-04-20.md. Default cap of 8
-        // covers typical GPU dispatch depth (3–4 in flight) × per-call buffer
-        // count (2–3 inputs + output) with headroom.
+        // hot path. Default cap of 8 covers typical GPU dispatch depth (3-4 in
+        // flight) times per-call buffer count (2-3 inputs + output), with
+        // headroom.
         pool_ = std::make_shared<detail::StagingBufferPool>(device_, 8);
 
         initialized_ = true;
@@ -712,7 +703,7 @@ private:
     // (which are wgpu::Buffer ref-counted handles) to keep them alive until
     // the callback fires, and a weak_ptr to the pool so a callback that
     // outlives ~DawnGpuCompute() cleanly no-ops instead of dereferencing
-    // a dangling raw pointer. Codex 2026-04-21 review on #536 P1.
+    // freed state.
     void schedule_pool_release(std::vector<wgpu::Buffer> bufs) {
         if (!pool_ || bufs.empty()) return;
 

--- a/core/render/src/gpu_compute_pool.hpp
+++ b/core/render/src/gpu_compute_pool.hpp
@@ -5,8 +5,6 @@
 // creation in DawnGpuCompute to eliminate allocator churn on Dawn backends
 // (Metal / D3D12 / Vulkan).
 //
-// Design reference: planning/zero-copy-slice-1-design-2026-04-20.md
-//
 // Threading: acquire() / release() are mutex-guarded. The mutex is only
 // held for pool bookkeeping — no GPU calls are made under the lock, so
 // contention is minimal in the audio/compute hot path.
@@ -169,12 +167,11 @@ public:
     // reclaim its in_flight_ slot so subsequent acquire()s don't
     // accumulate tracked handles and grow the pool unboundedly.
     //
-    // Codex 2026-04-21 review on #560: the previous fix for #536
-    // skipped release() on timeout but left the buffer tracked in
-    // in_flight_ forever; over a long run of timeouts (the exact
-    // scenario #536 targets) the map grew without bound. discard()
-    // drops the pool's reference so the wgpu::Buffer lands on the
-    // normal refcounted teardown path once the GPU stops mapping it.
+    // A timeout path must not call release(), because the GPU may still hold
+    // the mapping, but it also must not leave the buffer tracked in
+    // in_flight_ forever. discard() drops the pool's reference so the
+    // wgpu::Buffer lands on the normal refcounted teardown path once the GPU
+    // stops mapping it.
     void discard(const wgpu::Buffer& buf) {
         if (!buf) return;
         const std::uint64_t key = usage_key(buf.GetUsage());

--- a/core/render/src/gpu_surface_dawn.cpp
+++ b/core/render/src/gpu_surface_dawn.cpp
@@ -137,16 +137,13 @@ public:
         // it does (same scope).
         //
         // - TimestampQuery: lets Skia Graphite report per-recording GPU
-        //   render time via GpuStats(kElapsedTime). Phase 6.5.
+        //   render time via GpuStats(kElapsedTime).
         // - IndirectFirstInstance: lets WebGPU consumers (notably
         //   Three.js's WebGPURenderer) issue drawIndexed / draw calls
         //   with non-zero firstInstance. Without this the Three.js
         //   render path validates as "First instance must be zero" and
-        //   every command buffer is dropped — every frame paints
-        //   nothing. iOS-D.3c proved this empirically by surfacing the
-        //   exact validation message via the JS-side
-        //   unhandledrejection tracker (issue #3206). Apple Metal
-        //   supports the feature; iOS Sim with the Metal backend
+        //   every command buffer is dropped — every frame paints nothing.
+        //   Apple Metal supports the feature; iOS Sim with the Metal backend
         //   typically advertises it.
         std::vector<wgpu::FeatureName> required_device_features;
         if (adapter_.HasFeature(wgpu::FeatureName::TimestampQuery)) {
@@ -162,20 +159,20 @@ public:
             device_desc.requiredFeatures = required_device_features.data();
         }
 
-        // iOS-D.3c (#3217): enable Dawn's `skip_validation` +
-        // `allow_unsafe_apis` toggles on iOS Simulator only. The Sim's Metal
-        // SoftwareRenderer advertises IndirectFirstInstance but Dawn's spec
-        // validator still rejects Skia/Graphite's per-frame instanced draws
-        // every frame; the rejected CommandBuffer poisons the queue and the
-        // visible CAMetalLayer never gets painted. The toggle bypasses the
-        // spec validator so the actual Metal draw runs. Production iPad keeps
-        // validation on — Apple GPU honors the feature natively.
+        // Enable Dawn's `skip_validation` + `allow_unsafe_apis` toggles on iOS
+        // Simulator only. The Sim's Metal SoftwareRenderer advertises
+        // IndirectFirstInstance but Dawn's spec validator still rejects
+        // Skia/Graphite's per-frame instanced draws every frame; the rejected
+        // CommandBuffer poisons the queue and the visible CAMetalLayer never
+        // gets painted. The toggle bypasses the spec validator so the actual
+        // Metal draw runs. Production iPad keeps validation on because Apple
+        // GPU honors the feature natively.
         std::vector<const char*> enabled_toggles;
         wgpu::DawnTogglesDescriptor toggles_desc{};
 #if defined(TARGET_OS_SIMULATOR) && TARGET_OS_SIMULATOR
         enabled_toggles.push_back("skip_validation");
         enabled_toggles.push_back("allow_unsafe_apis");
-        runtime::log_info("GpuSurface: iOS Sim — enabling skip_validation + allow_unsafe_apis Dawn toggles (#3217)");
+        runtime::log_info("GpuSurface: iOS Sim — enabling skip_validation + allow_unsafe_apis Dawn toggles");
         toggles_desc.enabledToggleCount = enabled_toggles.size();
         toggles_desc.enabledToggles = enabled_toggles.data();
         device_desc.nextInChain = &toggles_desc;
@@ -184,14 +181,12 @@ public:
         device_desc.SetUncapturedErrorCallback(
             [](const wgpu::Device&, wgpu::ErrorType type, wgpu::StringView message) {
                 std::string msg(message.data, message.length);
-                // iOS-D.3c (#3217): filter known-benign Dawn first-frame /
-                // per-frame instanced-draw noise. Skia Graphite emits
-                // firstInstance>0 instanced draws every frame on iOS Sim;
-                // Dawn validates as a warning but the underlying Metal draw
-                // still runs (planning/2026-05-29-ios-d3b-threejs-webgpu-program.md:316
-                // documents `First instance (1) must be zero` as expected
-                // first-frame noise per iOS-D.1). Pre-filter so the noise
-                // doesn't drown out real WebGPU errors in the runtime log.
+                // Filter known-benign Dawn first-frame / per-frame
+                // instanced-draw noise. Skia Graphite emits firstInstance>0
+                // instanced draws every frame on iOS Sim; Dawn validates as a
+                // warning but the underlying Metal draw still runs. Pre-filter
+                // so the noise doesn't drown out real WebGPU errors in the
+                // runtime log.
                 if (msg.find("First instance") != std::string::npos &&
                     msg.find("must be zero") != std::string::npos) {
                     return;
@@ -229,14 +224,12 @@ public:
         runtime::log_info("GpuSurface: Dawn initialized (surface: {})",
             surface_ ? "presentable" : "offscreen-only");
 
-        // Phase iOS-D.1 hard-fail gate
-        // (planning/2026-05-28-ios-d-gpu-auv3-crosscheck.md): log the Dawn
-        // backend type that actually came up. Tests / CI scrape this line
-        // to assert `backend_type=Metal` on Apple platforms; a missing or
-        // unexpected backend means GPU init silently fell back to a
-        // different adapter (Null, OpenGL emulation, etc.) and the editor
-        // is rendering through CPU. The adapter info is queried after
-        // device creation so the result reflects the real selection.
+        // Log the Dawn backend type that actually came up. Tests / CI scrape
+        // this line to assert `backend_type=Metal` on Apple platforms; a
+        // missing or unexpected backend means GPU init silently fell back to a
+        // different adapter (Null, OpenGL emulation, etc.) and the editor is
+        // rendering through CPU. The adapter info is queried after device
+        // creation so the result reflects the real selection.
         if (adapter_) {
             wgpu::AdapterInfo dawn_info{};
             adapter_.GetInfo(&dawn_info);
@@ -399,7 +392,7 @@ private:
 #elif defined(__linux__)
         // Linux: native_handle is a pointer to a GpuSurface::X11NativeHandle
         // (Display* + Window). A bare Window id is not enough — Dawn's Xlib
-        // surface source needs both (#3329). Wayland is not wired yet.
+        // surface source needs both. Wayland is not wired yet.
         if (auto* x11 = static_cast<X11NativeHandle*>(native_handle);
             x11 && x11->display && x11->window) {
             wgpu::SurfaceDescriptor surface_desc{};

--- a/core/render/src/gpu_timestamps.cpp
+++ b/core/render/src/gpu_timestamps.cpp
@@ -8,7 +8,7 @@
 #include <memory>
 #include <thread>
 
-// Phase 6.5 — Dawn GPU timestamp queries.
+// Dawn GPU timestamp queries.
 //
 // The header (`gpu_timestamps.hpp`) carries the pure tick→ms conversion
 // math and the `decode_resolved_ticks` byte-decode seam, both unit-

--- a/core/render/src/headless_surface.cpp
+++ b/core/render/src/headless_surface.cpp
@@ -1,7 +1,5 @@
-// headless_surface.cpp — CI-friendly wrapper around the existing
-// offscreen Dawn/Skia path. Spec: planning/2026-05-24-macos-plugin-
-// authoring-plan.md §6.7 ("upgrade Headless GpuSurface from Partial →
-// Full — capability already exists; this is wrapping").
+// headless_surface.cpp — CI-friendly wrapper around the existing offscreen
+// Dawn/Skia path.
 //
 // We deliberately do NOT introduce a new render path here. All of the
 // real GPU work continues to live in `GpuSurface::create_dawn()` +

--- a/core/render/src/render_loop.cpp
+++ b/core/render/src/render_loop.cpp
@@ -11,7 +11,8 @@
 //   Windows — WindowsRenderLoop  : DwmFlush vblank wait    (this file)
 //   Linux   — TimerRenderLoop    : conscious timer fallback (this file)
 //
-// Slice 16, planning/2026-05-18-rt-safety-and-debug-dx.md.
+// RenderLoopState owns the shared coalescing behavior; native subclasses only
+// provide the pacing source.
 
 #include <pulp/render/render_loop.hpp>
 #include <pulp/runtime/log.hpp>
@@ -157,7 +158,7 @@ public:
     bool is_running() const override { return state_.is_running(); }
 
     // Reports timer once DwmFlush() has failed, so callers using
-    // render_loop_backend_is_vsync() can detect the fallback (Codex P2 #2580).
+    // render_loop_backend_is_vsync() can detect the fallback.
     RenderLoopBackend backend() const override {
         return backend_tracker_.effective_backend();
     }

--- a/core/render/src/render_loop_android.cpp
+++ b/core/render/src/render_loop_android.cpp
@@ -1,9 +1,8 @@
 // Android RenderLoop — AChoreographer-backed vblank source.
 //
-// Slice 16, planning/2026-05-18-rt-safety-and-debug-dx.md. AChoreographer
-// is Android's native vsync callback (API 24+); it pumps cleanly on
-// 60/90/120 Hz and VRR displays. The existing standalone Choreographer
-// pacer lives in core/render/platform/android/choreographer_android.cpp;
+// AChoreographer is Android's native vsync callback (API 24+); it pumps
+// cleanly on 60/90/120 Hz and VRR displays. The existing standalone
+// Choreographer pacer lives in core/render/platform/android/choreographer_android.cpp;
 // this is the RenderLoop-shaped wrapper wired into RenderLoop::create().
 //
 // AChoreographer_getInstance() is thread/looper-sensitive: it must be

--- a/core/render/src/render_loop_apple.mm
+++ b/core/render/src/render_loop_apple.mm
@@ -1,8 +1,8 @@
 // iOS RenderLoop — CADisplayLink-backed vblank source.
 //
-// Slice 16, planning/2026-05-18-rt-safety-and-debug-dx.md. Mirrors the
-// macOS CVDisplayLink path in render_loop.cpp but uses CADisplayLink,
-// which is the iOS-native vsync callback (CVDisplayLink is macOS-only).
+// Mirrors the macOS CVDisplayLink path in render_loop.cpp but uses
+// CADisplayLink, which is the iOS-native vsync callback (CVDisplayLink is
+// macOS-only).
 //
 // The CADisplayLink is added to the main run loop in NSRunLoopCommonModes
 // so it keeps ticking during scroll/track tracking. Its target fires on

--- a/core/render/src/render_loop_state.hpp
+++ b/core/render/src/render_loop_state.hpp
@@ -6,8 +6,8 @@
 
 namespace pulp::render {
 
-// Slice 16 — tracks whether a compositor-vblank wait (Windows DwmFlush) has
-// degraded to the timer fallback so backend() reports the effective backend.
+// Tracks whether a compositor-vblank wait (Windows DwmFlush) has degraded to
+// the timer fallback so backend() reports the effective backend.
 //
 // The Windows loop waits on DwmFlush() for vblank pacing; when DWM is
 // unavailable (Server Core, remote session, headless) DwmFlush() fails and

--- a/core/render/src/skia_surface.cpp
+++ b/core/render/src/skia_surface.cpp
@@ -81,12 +81,12 @@ public:
             return false;
         }
 
-        // Phase 6.5 (re-scoped) — probe whether Graphite can report
-        // per-recording GPU render time on this device. Graphite backs
-        // kElapsedTime with Dawn timestamp queries, so it only advertises the
-        // stat when the shared device enabled `timestamp-query` (GpuSurface
-        // requests it when the adapter offers it). GpuStatsFlags has no
-        // bitmask operators, so test via the underlying uint32_t.
+        // Probe whether Graphite can report per-recording GPU render time on
+        // this device. Graphite backs kElapsedTime with Dawn timestamp queries,
+        // so it only advertises the stat when the shared device enabled
+        // `timestamp-query` (GpuSurface requests it when the adapter offers it).
+        // GpuStatsFlags has no bitmask operators, so test via the underlying
+        // uint32_t.
         gpu_elapsed_supported_ =
             (static_cast<std::uint32_t>(context_->supportedGpuStats()) &
              static_cast<std::uint32_t>(skgpu::GpuStatsFlags::kElapsedTime)) != 0;
@@ -171,11 +171,10 @@ public:
             skgpu::graphite::InsertRecordingInfo info;
             info.fRecording = recording.get();
 
-            // Phase 6.5 (re-scoped) — request GPU render time for this
-            // recording. The callback fires on a later submit/completion (so
-            // the value lags ~1 frame); it captures `this`, which is kept
-            // alive by the destructor drain. Only request when supported so
-            // unsupported devices pay nothing.
+            // Request GPU render time for this recording. The callback fires
+            // on a later submit/completion (so the value lags ~1 frame); it
+            // captures `this`, which is kept alive by the destructor drain.
+            // Only request when supported so unsupported devices pay nothing.
             if (gpu_elapsed_supported_) {
                 info.fGpuStatsFlags = skgpu::GpuStatsFlags::kElapsedTime;
                 info.fFinishedContext = this;
@@ -325,11 +324,11 @@ public:
     }
 
 private:
-    // Graphite finished-with-stats callback (Phase 6.5 re-scoped). Fires on
-    // the thread pumping GPU completion (render thread, via Context::submit)
-    // once the GPU finishes the recording. Stores the elapsed time (ns) into
-    // the cross-thread tracker; treats a failed callback or zero elapsed as
-    // "no sample" so the last good value is retained.
+    // Graphite finished-with-stats callback. Fires on the thread pumping GPU
+    // completion (render thread, via Context::submit) once the GPU finishes
+    // the recording. Stores the elapsed time (ns) into the cross-thread
+    // tracker; treats a failed callback or zero elapsed as "no sample" so the
+    // last good value is retained.
     static void on_gpu_stats(skgpu::graphite::GpuFinishedContext ctx,
                              skgpu::CallbackResult result,
                              const skgpu::GpuStats& stats) {
@@ -343,7 +342,7 @@ private:
     uint32_t width_ = 0, height_ = 0;
     float scale_ = 1.0f;
 
-    // Phase 6.5 (re-scoped) — GPU render time via Graphite GpuStats.
+    // GPU render time via Graphite GpuStats.
     bool gpu_elapsed_supported_ = false;  ///< Set once in init() from supportedGpuStats().
     GpuRenderTimeTracker gpu_render_tracker_;  ///< Latest sample; written by on_gpu_stats().
 

--- a/core/render/src/skp_capture.cpp
+++ b/core/render/src/skp_capture.cpp
@@ -92,8 +92,7 @@ sk_sp<SkImage> rasterize_texture_image(SkImage* image,
 
 // Serialize-side image proc. SkPicture::serialize() drops embedded
 // SkImages to nullptr by default (documented in SkPicture.h); this
-// PNG-encodes them so atlas/image draws survive into the .skp. This is
-// the contract the Phase 6.4 spike pinned in test_skia_surface.cpp.
+// PNG-encodes them so atlas/image draws survive into the .skp.
 //
 // Raster images PNG-encode directly. A GPU-texture-backed image cannot:
 // SkPngEncoder must read its pixels off the GPU first. We rasterize it


### PR DESCRIPTION
## Summary

Batch canvas/render comment-hygiene cleanup into one PR, covering 33 files across `core/canvas` and `core/render`.

This removes stale issue/phase/slice/planning/Codex breadcrumbs while preserving live technical rationale around Canvas2D command recording, Skia/CG gradient behavior, masks, GPU timing, RenderLoop pacing, and Dawn compute/surface invariants.

## Validation

- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py --base origin/main --mode=report`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`
- `python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce`
- `python3 tools/scripts/hotspot_size_guard.py --base origin/main --config tools/scripts/hotspot_size_guard.json --mode=report`
- `python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_BUILD_EXAMPLES=OFF`
- `cmake --build build --target pulp-canvas pulp-render -j28`
- RepoPrompt selected the current worktree and all changed files; Oracle review was blocked because `ask_oracle` is only available during discovery/agent mode
- `autoreview --mode local --reviewers codex,claude` clean
- pre-push hook: 10,410/10,410 CTest entries passed; local diff coverage OK

Version-Bump: sdk=skip reason="comment-only cleanup; no SDK or generated-output behavior change"


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes stale issue/phase/slice/planning breadcrumbs across canvas and render comments, while keeping accurate technical notes on gradients, masks, opacity, shaders, GPU timing, RenderLoop pacing, and Dawn compute/surface behavior. Comment-only; no logic or SDK behavior changes.

- **Refactors**
  - Simplified and clarified comments in canvas: Canvas2D command recording, Skia/CoreGraphics gradients (linear/radial/two-circle/conic), box-shadow, masks, opacity/filters, patterns, and GPU shader paths.
  - Tightened render-layer docs: RenderLoop pacing (vsync/fallback), GPU timestamps and whole-recording render time, Dawn `GpuSurface` feature toggles, compute buffer pool/release rules, headless surface, and X11 handle notes.
  - Removed outdated planning breadcrumbs and issue tags; preserved current implementation rationale and invariants.
  - No functional changes; builds/tests unchanged; SDK bump skipped.

<sup>Written for commit 0a2255a6ed9f9ff17dc733c19b70a83dd48a1150. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

