### PR TITLE
docs(render): remove stale headless surface plan breadcrumb

### DIFF
--- a/core/render/include/pulp/render/headless_surface.hpp
+++ b/core/render/include/pulp/render/headless_surface.hpp
@@ -46,8 +46,8 @@ public:
         float scale_factor = 1.0f;
         /// Background fill applied before the user paint callback runs.
         /// Defaults to opaque black so a no-op paint still produces a
-        /// deterministic frame (read-back uninitialized GPU memory is
-        /// not reproducible — see plan §6.7 acceptance).
+        /// deterministic frame; read-back uninitialized GPU memory is
+        /// not reproducible.
         uint8_t clear_r = 0;
         uint8_t clear_g = 0;
         uint8_t clear_b = 0;

--- a/core/render/src/headless_surface.cpp
+++ b/core/render/src/headless_surface.cpp
@@ -76,7 +76,7 @@ public:
 
         // Deterministic background fill. Without this the GPU texture
         // we read back may contain uninitialized memory and the PNG
-        // bytes won't be reproducible across reruns (plan §6.7 acceptance).
+        // bytes won't be reproducible across reruns.
         canvas->set_fill_color(canvas::Color::rgba8(
             config_.clear_r, config_.clear_g, config_.clear_b, config_.clear_a));
         canvas->fill_rect(0.0f, 0.0f,


### PR DESCRIPTION
Follow-up to #4433 after auto-merge raced the amended review fix. Removes the two remaining `plan §6.7` breadcrumbs from HeadlessSurface comments while preserving the deterministic background-fill rationale.

Validation:
- git diff --check
- rg -n "plan §|plan [§#]" core/render/include/pulp/render/headless_surface.hpp core/render/src/headless_surface.cpp
- python3 tools/scripts/docs_noise_lint.py --base origin/main --mode=report
- python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report
- python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce
- python3 tools/scripts/hotspot_size_guard.py --base origin/main --config tools/scripts/hotspot_size_guard.json --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report
- autoreview --mode local --reviewers codex,claude

Note: the identical two-line fix also passed the full local pre-push hook while amending #4433: 10,410/10,410 CTest entries passed; diff coverage OK. #4433 merged before that amended push completed, so this PR carries only the missed review fix.

Version-Bump: sdk=skip reason="comment-only cleanup; no SDK or generated-output behavior change"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed outdated “plan §6.7” references from `HeadlessSurface` comments while keeping the explanation for deterministic background fill. Behavior unchanged; docs-only cleanup.

<sup>Written for commit 8625bfd894d39d742b1eb0cd386e035e7f60eed0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

