### PR TITLE
docs(view): clean web-compat JS comment breadcrumbs

### DIFF
--- a/core/view/js/css-parser.js
+++ b/core/view/js/css-parser.js
@@ -75,12 +75,11 @@ function parseCSSColor(str) {
         return "#" + _hex2(rgb[0]) + _hex2(rgb[1]) + _hex2(rgb[2]) + (a2 < 255 ? _hex2(a2) : "");
     }
 
-    // pulp #1434 Triage #8 — modern CSS color spaces. Figma copy-CSS
-    // emits oklch(...) since 2024; v0 / Tailwind ship lab() and lch();
-    // Claude Design transition states emit color-mix(...). Spike-quality
-    // conversion: oklch / oklab / lch / lab / color() → sRGB hex. Deep
-    // wide-gamut path (Skia SkColor4f) tracked separately; this slice
-    // keeps the existing hex pipeline for downstream consumers.
+    // Modern CSS color spaces. Figma copy-CSS emits oklch(...) since
+    // 2024; v0 / Tailwind ship lab() and lch(); Claude Design transition
+    // states emit color-mix(...). This converts oklch / oklab / lch /
+    // lab / color() to sRGB hex and keeps the existing hex pipeline for
+    // downstream consumers until an HDR-aware SkColor4f path exists.
     //
     // CSS 4 syntax: space-separated components, optional `/ <alpha>`.
     //   oklch(0.7 0.18 240 / 50%)
@@ -102,11 +101,10 @@ function parseCSSColor(str) {
     return null;
 }
 
-// pulp #1434 Triage #8 — modern color-space dispatcher. Returns
-// `{ r, g, b, a }` in linear-output [0, 1] sRGB coordinates (gamma-
-// encoded), or null on parse failure. The conversion math mirrors the
-// CSS Color Module Level 4 reference algorithms (with D50→D65
-// chromatic adaptation for CIE Lab/Lch).
+// Modern color-space dispatcher. Returns `{ r, g, b, a }` in [0, 1]
+// gamma-encoded sRGB coordinates, or null on parse failure. The
+// conversion math mirrors the CSS Color Module Level 4 reference
+// algorithms, including D50→D65 chromatic adaptation for CIE Lab/Lch.
 function _parseModernColor(str) {
     // Consume leading function name + interior; alpha isolated by `/`.
     var fnMatch = str.match(/^(oklch|oklab|lch|lab|color)\(\s*(.+?)\s*\)$/);
@@ -377,9 +375,9 @@ function parseTransform(str) {
         var fn = m[1];
         var rawArgs = m[2].split(",").map(function(s) { return s.trim(); });
         var args = rawArgs.map(function(a) {
-            // pulp #1434 Triage #9 — handle rad / turn / grad alongside
-            // deg. Plain numbers in rotate-family functions are degrees;
-            // numeric scale-family / matrix args pass through.
+            // Handle rad / turn / grad alongside deg. Plain numbers in
+            // rotate-family functions are degrees; numeric scale-family
+            // / matrix args pass through.
             var ang = _parseTransformAngle(a);
             if (ang !== null) return ang;
             var l = parseCSSLength(a);
@@ -434,17 +432,16 @@ function parseTransition(str) {
 // pathological self-referential tokens like `--a: var(--a)`; when the
 // cap is hit, the walker returns the input string unmodified
 // (graceful unresolved passthrough, not silent truncation). Named so
-// the cap behavior is grep-able from tests + Codex review on PR C.
+// the cap behavior is grep-able from tests.
 var _VAR_RESOLVE_MAX_DEPTH = 8;
 
 // Resolve var(--name) or var(--name, fallback) against theme tokens.
 //
-// pulp-internal coverage-gap (`css/__var`): the original single-pass regex
-// couldn't handle nested parens because regex isn't context-free — the
-// `[^)]+` for the fallback would stop at the FIRST `)` (the inner one)
-// and leave the outer `)` as part of the surrounding text, producing
-// garbage on `var(--a, var(--b, 0))` and similar nested-fallback shapes
-// that real design systems emit constantly.
+// The original single-pass regex couldn't handle nested parens because
+// regex isn't context-free: the fallback would stop at the FIRST `)`
+// (the inner one) and leave the outer `)` as part of the surrounding
+// text, producing garbage on `var(--a, var(--b, 0))` and similar
+// nested-fallback shapes that real design systems emit constantly.
 //
 // Replaced with a manual balanced-paren walker so:
 //   var(--a, var(--b, 0))    →  resolves correctly through fallback chain
@@ -501,11 +498,10 @@ function _resolveVar(str, depth) {
         }
         if (name.indexOf("--") === 0) name = name.slice(2);
 
-        // pulp #1899 (gap #3) — consult the string-token map first so
-        // font-family-shaped tokens (`--mono: "JetBrains Mono"`)
-        // resolve to the registered string rather than zero. Falls
-        // through to the motion-token (numeric) lookup for legacy
-        // length/spacing tokens.
+        // Consult the string-token map first so font-family-shaped
+        // tokens (`--mono: "JetBrains Mono"`) resolve to the registered
+        // string rather than zero. Falls through to the motion-token
+        // numeric lookup for legacy length/spacing tokens.
         var strVal = (typeof getStringToken === 'function') ? getStringToken(name) : '';
         if (strVal) {
             out += String(strVal);
@@ -551,7 +547,7 @@ function resolveLength(parsed, ctx) {
 
 // Resolve a CSS length string into the same {value, unit} shape that
 // parseCSSLength returns, but with calc() / min() / max() / clamp()
-// support. pulp #1553 — drop-in replacement for parseCSSLength so call
+// support. This is a drop-in replacement for parseCSSLength so call
 // sites in web-compat-style-decl.js gain calc-family expression support
 // without each per-property branch having to special-case the function
 // syntax.
@@ -562,13 +558,13 @@ function resolveLength(parsed, ctx) {
 //
 // Per-input behaviour:
 //   - calc-family with all-percent operands  →  { value, unit: "%" }
-//     so the bridge routes through the percent path (Codex P2 on #1576).
+//     so the bridge routes through the percent path.
 //   - calc-family otherwise                   →  { value: <px>, unit: "px" }
 //     (evaluateCalc resolves mixed-unit operands inline against ctx).
 //   - non-calc-family                         →  parseCSSLength passthrough.
 //   - malformed calc-family (empty parens,
 //     unbalanced parens, no operands)          →  null
-//     (Codex P1 on #1576 — was infinite-recursing through evaluateCalc).
+//     instead of infinite-recursing through evaluateCalc.
 function resolveCSSLength(str, ctx) {
     if (str === undefined || str === null || str === "") return null;
     var s = String(str).trim();
@@ -579,11 +575,10 @@ function resolveCSSLength(str, ctx) {
         s.indexOf("clamp(") === 0;
 
     if (isCalcFamily) {
-        // P1 guard: reject malformed calc-family inputs before delegating
-        // to evaluateCalc. `min()` / `max()` / `clamp()` with empty parens
-        // would otherwise infinite-recurse through evaluateCalc's nested-
-        // function regex (line ~598: /(calc|min|max|clamp)\([^)]*\)/g
-        // matches zero-char inner content).
+        // Reject malformed calc-family inputs before delegating to
+        // evaluateCalc. `min()` / `max()` / `clamp()` with empty parens
+        // would otherwise infinite-recurse through evaluateCalc's nested
+        // function replacement.
         var inner = _calcFamilyInner(s);
         if (inner === null) return null;
 
@@ -595,8 +590,7 @@ function resolveCSSLength(str, ctx) {
         // (e.g. `calc(50% + 10px)`) fall through to evaluateCalc, which
         // resolves them to px against ctx — Pulp has no deferred-
         // resolution layer, so cross-unit arithmetic resolves at the JS
-        // boundary. Closes Codex P2 on #1576 (% preservation) and the
-        // follow-up P1 on #1862 (vh/vw/em/rem preservation).
+        // boundary.
         var single = _calcFamilySingleUnit(s);
         if (single !== null) return single;
 
@@ -618,7 +612,7 @@ function resolveCSSLengthPx(str, ctx) {
 
 // Internal: returns the trimmed contents inside a calc-family's outer
 // parens, or null if the input is malformed (no opening paren, no
-// matching closing paren, or empty operands). Codex P1 guard.
+// matching closing paren, or empty operands).
 function _calcFamilyInner(s) {
     var open = s.indexOf("(");
     if (open < 0 || s.charAt(s.length - 1) !== ")") return null;
@@ -631,22 +625,20 @@ function _calcFamilyInner(s) {
 // resolved `{value, unit}` so the caller can preserve that unit
 // through to the bridge instead of losing it in px-resolution.
 //
-// Closes BOTH Codex P-tier findings on PR #1576 and its follow-up
-// P1 on PR #1862:
-//   - PR #1576 P2: `calc(50%)` → {value: 50, unit: '%'} so the
-//     bridge routes through the percent layout path.
-//   - PR #1862 P1: `calc(10vh)` / `min(1em, 2em)` etc. — unit
-//     preservation extended to every unit parseCSSLength
-//     recognises (px, em, rem, %, vw, vh, vmin, vmax). Units
-//     outside that set (ch, pt, in, cm, etc.) fall through to
-//     px resolution rather than introducing helper-only support
-//     that would diverge from `parseCSSLength` (Codex P2 review).
+// Supported preservation examples:
+//   - `calc(50%)` → {value: 50, unit: '%'} so the bridge routes
+//     through the percent layout path.
+//   - `calc(10vh)` / `min(1em, 2em)` etc. preserve every unit
+//     parseCSSLength recognises: px, em, rem, %, vw, vh, vmin,
+//     and vmax. Units outside that set (ch, pt, in, cm, etc.) fall
+//     through to px resolution rather than introducing helper-only
+//     support that would diverge from `parseCSSLength`.
 //
 // Expressions with operators (`calc(50% + 10px)`) or mixed units
 // (`min(10vh, 20px)`) return null so they fall through to
 // evaluateCalc's px resolution — Pulp has no deferred-resolution
-// layer, so a mixed-unit arithmetic gets resolved at the JS layer
-// using the supplied ctx. Documented in [issue-1576][fallback-behaviour].
+// layer, so mixed-unit arithmetic gets resolved at the JS layer using
+// the supplied ctx.
 //
 // Examples:
 //   calc(50%)               → {value: 50, unit: '%'}
@@ -674,8 +666,7 @@ function _calcFamilySingleUnit(s) {
     // set is intentionally kept aligned with `parseCSSLength` so a
     // bare `3em` and `calc(3em)` resolve the same way (no
     // helper-only units). Number pattern is strict — accepts
-    // `12`, `1.5`, `.5`, `-2`, `-.25` but rejects `.`, `1.2.3`, `..`
-    // (Codex P2 review on PR #1862).
+    // `12`, `1.5`, `.5`, `-2`, `-.25` but rejects `.`, `1.2.3`, `..`.
     var bareRe = /^(-?(?:\d+(?:\.\d+)?|\.\d+))(px|em|rem|%|vw|vh|vmin|vmax)$/;
 
     function parseOperand(tok) {
@@ -753,13 +744,12 @@ function evaluateCalc(expr, ctx) {
     }
 
     // Evaluate arithmetic expression: supports +, -, *, /
-    // First resolve nested function calls. Codex P1 defense-in-depth on
-    // PR #1576: require AT LEAST ONE char inside the inner function
-    // parens. `[^)]*` (zero-or-more) would otherwise match `min()` and
-    // re-enter evaluateCalc with the same empty token, causing
-    // RangeError: maximum call stack size exceeded. `[^)]+` (one-or-
-    // more) means malformed calls fall through to the tokenizer below
-    // where they cleanly evaluate to 0 instead of crashing the engine.
+    // First resolve nested function calls. Require at least one char
+    // inside the inner function parens: `[^)]*` would also match `min()`
+    // and re-enter evaluateCalc with the same empty token, causing
+    // RangeError: maximum call stack size exceeded. `[^)]+` means
+    // malformed calls fall through to the tokenizer below where they
+    // cleanly evaluate to 0 instead of crashing the engine.
     expr = expr.replace(/(calc|min|max|clamp)\([^)]+\)/g, function(match) {
         return String(evaluateCalc(match, ctx));
     });

--- a/core/view/js/web-compat-canvas-matrix.js
+++ b/core/view/js/web-compat-canvas-matrix.js
@@ -2,7 +2,8 @@
 // _PulpCanvasMatrix — Canvas2D DOMMatrix-compat helper
 // ═══════════════════════════════════════════════════════════════════════════════
 //
-// P5-6 follow-up — extracted from web-compat-canvas.js (164-289).
+// Extracted from web-compat-canvas.js to keep DOMMatrix compatibility
+// isolated from the canvas drawing surface.
 //
 // 2D affine + 3D-padded matrix with the snapshot-mutator semantics
 // HTML5 Canvas requires:
@@ -11,7 +12,7 @@
 //   * toFloat32Array / toFloat64Array / toJSON serialization
 //   * multiplySelf / scaleSelf / rotateSelf / translateSelf mutators
 //   * inverse() returns a new matrix (NaN-filled + is2D=false on
-//     singular input, per Codex P2 follow-up on #1754).
+//     singular input).
 //
 // CanvasRenderingContext2D.getTransform() returns a new instance of
 // this class — the only external reference, resolved lazily at call
@@ -40,16 +41,15 @@ _PulpCanvasMatrix.prototype.toFloat64Array = function() {
     return this.toFloat32Array();
 };
 _PulpCanvasMatrix.prototype.toJSON = function() {
-    // Codex P2 follow-up on #1754: honor the actual is2D state. A
-    // singular-inverse result has is2D=false; if toJSON hardcodes
-    // true, JSON consumers can't distinguish inversion failure from
-    // a successful 2D inverse.
+    // Honor the actual is2D state. A singular-inverse result has
+    // is2D=false; if toJSON hardcodes true, JSON consumers can't
+    // distinguish inversion failure from a successful 2D inverse.
     return { a: this.a, b: this.b, c: this.c, d: this.d,
              e: this.e, f: this.f, is2D: this.is2D !== false,
              isIdentity: this.isIdentity };
 };
 
-// pulp #1527 — DOMMatrix mutator methods. Snapshot semantics
+// DOMMatrix mutator methods. Snapshot semantics
 // (mutating the returned matrix does NOT affect the live ctx — that
 // matches HTML5 Canvas spec). The mutators are useful for offline
 // transform calculations like
@@ -57,7 +57,7 @@ _PulpCanvasMatrix.prototype.toJSON = function() {
 // used in plugin code adapted from web canvas libraries (Three.js
 // canvas adapter, Skia-canvas, etc.). Each *Self method mutates this
 // matrix in place and returns this for chaining; inverse() returns a
-// NEW matrix (or throws on singular).
+// NEW matrix (NaN-filled, is2D=false, on singular input).
 _PulpCanvasMatrix.prototype._refreshAliases = function() {
     this.m11 = this.a; this.m12 = this.b;
     this.m21 = this.c; this.m22 = this.d;
@@ -78,7 +78,7 @@ _PulpCanvasMatrix.prototype.multiplySelf = function(other) {
     return this;
 };
 _PulpCanvasMatrix.prototype.scaleSelf = function(sx, sy) {
-    // Codex P2 on #1730: spec says scaleX defaults to 1 when omitted,
+    // The spec says scaleX defaults to 1 when omitted,
     // and scaleY defaults to scaleX when omitted. Without this, the
     // bare scaleSelf() call multiplies by undefined and produces NaN.
     if (sx === undefined) sx = 1;
@@ -91,7 +91,7 @@ _PulpCanvasMatrix.prototype.scaleSelf = function(sx, sy) {
     return this;
 };
 _PulpCanvasMatrix.prototype.rotateSelf = function(angle) {
-    // Codex P1 on #1730: DOMMatrix.rotateSelf() takes degrees per spec
+    // DOMMatrix.rotateSelf() takes degrees per spec
     // (https://drafts.fxtf.org/geometry/#dom-dommatrix-rotateself). The
     // previous implementation fed `angle` directly into Math.cos/sin
     // (radians), so callers ported from browsers (e.g. rotateSelf(90)
@@ -116,16 +116,16 @@ _PulpCanvasMatrix.prototype.translateSelf = function(tx, ty) {
     return this;
 };
 _PulpCanvasMatrix.prototype.inverse = function() {
-    // Codex P1 on #1730: spec says non-invertible matrices yield a
-    // matrix with NaN components and `is2D = false` — they do NOT
-    // throw. Throwing here breaks compat for callers that rely on
-    // the standard non-throwing inverse contract.
+    // The spec says non-invertible matrices yield a matrix with NaN
+    // components and `is2D = false` — they do NOT throw. Throwing here
+    // breaks compat for callers that rely on the standard non-throwing
+    // inverse contract.
     // https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-inverse
     var a = this.a, b = this.b, c = this.c, d = this.d, e = this.e, f = this.f;
     var det = a * d - b * c;
     if (det === 0 || !isFinite(det)) {
-        // Codex P2 follow-up: spec says ALL 16 components become NaN
-        // for a non-invertible matrix. The constructor only NaNs the
+        // The spec says ALL 16 components become NaN for a
+        // non-invertible matrix. The constructor only NaNs the
         // 2D aliases (m11..m22, m41..m42); m13, m14, m23, m24,
         // m31..m34, m43, m44 stay at constructor-default identity.
         // toFloat32Array() / toFloat64Array() would then return

--- a/core/view/js/web-compat-document-gpu-mock.js
+++ b/core/view/js/web-compat-document-gpu-mock.js
@@ -1,18 +1,17 @@
 // ═══════════════════════════════════════════════════════════════════════════════
-// WebGPU mock factories (P5-7 follow-up — extracted from web-compat-document.js)
+// WebGPU mock factories extracted from web-compat-document.js
 // ═══════════════════════════════════════════════════════════════════════════════
 //
 // The entire WebGPU mock surface used by the headless test harness +
 // fallback adapter path. Originally lived inline in
-// web-compat-document.js, but at 563 lines it was the biggest
-// self-contained sub-system in that file. Extracted to keep the
-// document TU around the 1k-line maintainability target.
+// web-compat-document.js. It was the biggest self-contained subsystem
+// in that file, so extracting it keeps the document prelude focused.
 //
 // Embed order: loaded AFTER web-compat-document.js because
 //   * GPUTextureUsage / GPUBufferUsage / GPUShaderStage / GPUColorWrite
-//     / GPUMapMode are installed at the top of web-compat-document.js
-//     (lines 522-560), and the mock factory bodies reference those
-//     constants;
+//     / GPUMapMode are installed by the `__installGlobalIfMissing` calls
+//     in web-compat-document.js, and the mock factory bodies reference
+//     those constants;
 //   * `window.pulp.gpu` (which uses `__mockGpuInfo` /
 //     `__createMockGPUAdapter` / `__createMockGPUDevice` /
 //     `__createGPUAdapter`) is defined further down in
@@ -148,9 +147,9 @@ function __createMockGPUBuffer(init) {
     // silently dropped. Three.js's WebGPUBackend uploads geometry through exactly this
     // path (`createBuffer({mappedAtCreation:true})` → `new T(getMappedRange())
     // .set(attr.array)` → `unmap()`), so vertex/index buffers arrived all-zero
-    // at the native bridge and the cube collapsed to a degenerate point
-    // (#3217). Uniforms survived only because they use queue.writeBuffer, which
-    // writes _bytes directly. Fix: hand back a standalone range seeded from the
+    // at the native bridge and the cube collapsed to a degenerate point.
+    // Uniforms survived only because they use queue.writeBuffer, which writes
+    // _bytes directly. Fix: hand back a standalone range seeded from the
     // current backing bytes, record it, and copy each recorded range back into
     // _bytes on unmap().
     buffer.getMappedRange = function(offset, size) {
@@ -189,13 +188,12 @@ function __createMockGPUTextureView(init) {
         dimension: init.dimension || "2d",
         aspect: init.aspect || "all",
         texture: init.texture || null,
-        // iOS-D.3c (#3217): propagate native-bridge identity from the
-        // owning texture so encoder.draw's createBufferedDrawPayload check
-        // (web-compat-gpu-buffered.js:194) sees attachmentView._nativeBridge
-        // and routes the draw through the native bridge instead of the mock
-        // no-op. Without this, Three.js's WebGPURenderer renders to a JS-
-        // side mock that drops every command, and the offscreen wgpu::Texture
-        // we hand Skia stays blank → invisible cube.
+        // Propagate native-bridge identity from the owning texture so
+        // encoder.draw's createBufferedDrawPayload check sees
+        // attachmentView._nativeBridge and routes the draw through the native
+        // bridge instead of the mock no-op. Without this, Three.js's
+        // WebGPURenderer renders to a JS-side mock that drops every command,
+        // and the offscreen wgpu::Texture we hand Skia stays blank.
         _nativeBridge: !!init._nativeBridge,
         _nativeCanvasId: init._nativeCanvasId || "",
         _nativeTextureId: init._nativeTextureId || ""
@@ -226,8 +224,8 @@ function __createMockGPUTexture(init) {
             dimension: descriptor.dimension || texture.dimension,
             aspect: descriptor.aspect || "all",
             texture: texture,
-            // iOS-D.3c (#3217): forward the texture's native-bridge ids so
-            // the resulting view can route encoder.draw through the native
+            // Forward the texture's native-bridge ids so the resulting
+            // view can route encoder.draw through the native
             // bridge path (see __createMockGPUTextureView above).
             _nativeBridge: !!texture._nativeBridge,
             _nativeCanvasId: texture._nativeCanvasId || "",
@@ -308,15 +306,16 @@ function __createMockGPUComputePassEncoder(init) {
 function __createMockGPUCommandEncoder(init) {
     init = init || {};
     var computePasses = [];
-    // iOS-D.3c (#3217): collect render-pass commands here so they survive
-    // into the command buffer's `_commands` array. Without this, the
+    // Collect render-pass commands here so they survive into the command
+    // buffer's `_commands` array. Without this, the
     // canvas-gpu / buffered shims would push commands into a per-encoder
-    // `passCommands` and `encoder.end` would have nowhere to forward them
-    // (init.onEnd was never wired), and queue.submit would see
+    // `passCommands` and the wrapped render-pass end() would have nowhere
+    // to forward them; queue.submit would see
     // `commandBuffer._commands.length === 0` even though Three.js had
-    // issued draws. Wiring onEnd → renderCommands.push lets the native
-    // queue.submit dispatcher route each draw through
-    // __gpuQueueDrawBufferedImpl / __gpuQueueDrawImpl.
+    // issued draws. Passing onEnd through lets the buffered shim forward
+    // captured draws into renderCommands, which the native queue.submit
+    // dispatcher routes through __gpuQueueDrawBufferedImpl /
+    // __gpuQueueDrawImpl.
     var renderCommands = [];
     var collectRenderCommand = function(cmd) {
         if (cmd) renderCommands.push(cmd);
@@ -344,8 +343,8 @@ function __createMockGPUCommandEncoder(init) {
             var cmdBuf = __createMockGPUCommandBuffer({ label: descriptor && descriptor.label ? descriptor.label : "" });
             // Attach compute pass commands to the command buffer for native dispatch
             cmdBuf._computePasses = computePasses;
-            // iOS-D.3c (#3217): hand the captured render-pass commands to
-            // the command buffer so queue.submit can iterate them and call
+            // Hand the captured render-pass commands to the command buffer
+            // so queue.submit can iterate them and call
             // the per-command native dispatcher.
             cmdBuf._commands = renderCommands.slice();
             return cmdBuf;
@@ -423,7 +422,7 @@ function __createMockGPUQueue(init) {
     var queue = {
         _objectName: "GPUQueue",
         label: init.label || "",
-        // pulp #2101 — bridge flag the buffered-draw augmentation
+        // bridge flag the buffered-draw augmentation
         // (web-compat-gpu-buffered.js) reads to decide whether to forward
         // command buffers to Dawn. That file wraps queue.submit with the
         // actual __gpuQueueSubmitImpl / __gpuQueueDrawBufferedImpl
@@ -438,8 +437,8 @@ function __createMockGPUQueue(init) {
         if (!buffer || buffer._objectName !== "GPUBuffer") return;
         var source = __toUint8Array(data);
         var begin = bufferOffset || 0;
-        // iOS-D.3c (#3217): WebGPU spec — when `data` is a TypedArray,
-        // `dataOffset` and `size` are measured in ELEMENTS of that array,
+        // WebGPU spec: when `data` is a TypedArray, `dataOffset` and
+        // `size` are measured in ELEMENTS of that array,
         // not bytes (only ArrayBuffer/DataView use byte units). The old
         // code treated both as bytes, so Three.js's
         // `writeBuffer(buf, dst, Float32Array(16), 0, 16)` — meaning 16
@@ -528,7 +527,7 @@ function __pickDeviceFeatures(adapter, descriptor) {
 }
 
 function __createMockGPUDevice(adapter, descriptor, init) {
-    // pulp #2101 — third `init` arg carries the bridge descriptor returned by
+    // third `init` arg carries the bridge descriptor returned by
     // `__describeNativeDeviceImpl`. When `init.nativeBridge` is true, the
     // device is wired so `createTexture` mints a native Dawn texture handle
     // (via `__gpuCreateTextureImpl`) instead of a pure mock. Without this
@@ -606,7 +605,7 @@ function __createMockGPUDevice(adapter, descriptor, init) {
     };
     device.createCommandEncoder = function(commandDescriptor) { return __createMockGPUCommandEncoder(commandDescriptor || {}); };
     device.destroy = function() { device._destroyed = true; };
-    // pulp #2101 — Three.js WebGPUPipelineUtils calls pushErrorScope/popErrorScope
+    // Three.js WebGPUPipelineUtils calls pushErrorScope/popErrorScope
     // around every pipeline create. The async-executor pattern swallows throws
     // when these are missing, so a `TypeError: device.pushErrorScope is not a
     // function` becomes a silently-empty mock canvas. Provide no-op error scopes
@@ -618,7 +617,7 @@ function __createMockGPUDevice(adapter, descriptor, init) {
     return device;
 }
 
-// pulp #2101 — bridge-aware adapter factory. When `init.nativeBridge` is true,
+// bridge-aware adapter factory. When `init.nativeBridge` is true,
 // `requestDevice` asks the host for a device descriptor (`__describeNativeDeviceImpl`)
 // and forwards `init.nativeBridge` into `__createMockGPUDevice` so the device's
 // `createTexture` mints real Dawn handles. The legacy `__createMockGPUAdapter`

--- a/core/view/js/web-compat-document-selectors.js
+++ b/core/view/js/web-compat-document-selectors.js
@@ -1,9 +1,8 @@
 // ═══════════════════════════════════════════════════════════════════════════════
-// CSS selector engine (P5-7 first cut — extracted from web-compat-document.js)
+// CSS selector engine extracted from web-compat-document.js
 // ═══════════════════════════════════════════════════════════════════════════════
 //
-// Per the U-2 export map, web-compat-document.js (1,820 lines) splits
-// naturally into four concerns:
+// web-compat-document.js splits naturally into four concerns:
 //   1. StyleSheet + style application (stays in parent)
 //   2. CSS parser (~150 lines, stays in parent for now)
 //   3. **Selector engine** (this file)
@@ -17,7 +16,8 @@
 //     selector, honoring tag / id / class / attribute / pseudo /
 //     descendant + direct-child combinators
 //   - _matchesPseudoClass(el, pseudo) — :hover, :focus, :active,
-//     :nth-child, :first-child, :last-child, :not, :is, :where
+//     :disabled, :enabled, :checked, :root, :empty, :nth-child,
+//     :nth-last-child, :first-child, :last-child, :only-child, :not
 //   - _matchesNth(pos, arg) — :nth-child(an+b) parser
 //   - _querySelector / _querySelectorAll — top-level entry points
 //   - _findMatch(root, parsed, findAll) — DOM walker shared by both
@@ -31,7 +31,7 @@
 // Selector parsing and matching
 // ═══════════════════════════════════════════════════════════════════════════════
 
-// pulp Wave 3 html.3 — minimal CSS selector parser.
+// Minimal CSS selector parser.
 //
 // Supports the subset that React / Three.js helper code actually uses
 // in practice:
@@ -67,7 +67,7 @@ function _parseSelector(str) {
     // level so a real-world selector like `div.foo:hover` still
     // matches `div.foo` instead of refusing to parse.
     //
-    // pulp #1641 followup: scan for `:` at bracket depth 0 only, so
+    // Scan for `:` at bracket depth 0 only, so
     // colons inside attribute selectors like `[href="http://x"]` or
     // `[data-time="12:30"]` aren't misinterpreted as pseudo-class
     // boundaries (which would truncate the selector mid-bracket).
@@ -102,9 +102,9 @@ function _parseSelector(str) {
         else if (depth === 0 && ch === " " && ci < mainPart.length - 1 &&
                  mainPart[ci + 1] !== ">" && (ci === 0 || mainPart[ci - 1] !== ">")) {
             splitIdx = ci; splitDirect = false;
-            // Don't break — keep walking left to find the *rightmost*
-            // descendant boundary so the parent selector accumulates
-            // correctly for `a b c` -> parent=`a b`, child=`c`.
+            // Break on the first match. We scan right-to-left, so this is
+            // the rightmost descendant boundary (`a b c` -> parent=`a b`,
+            // child=`c`).
             break;
         }
     }
@@ -181,7 +181,7 @@ function _matchesSelector(el, parsed) {
         if (!el.classList.contains(parsed.classes[i])) return false;
     }
 
-    // pulp Wave 3 html.3 — attribute selectors.
+    // Attribute selectors.
     if (parsed.attrs && parsed.attrs.length) {
         for (var ai = 0; ai < parsed.attrs.length; ai++) {
             var a = parsed.attrs[ai];
@@ -239,17 +239,18 @@ function _matchesSelector(el, parsed) {
         }
     }
 
-    // pulp #1737 — pseudo-class state matching for querySelector. The
+    // Pseudo-class state matching for querySelector. The
     // parser stored parsed.pseudo (e.g. `disabled`, `checked`, `nth-child(2)`)
-    // but pre-fix _matchesSelector ignored it, so `div:disabled` matched
-    // every `div` (catalog DIVERGE on html/document_querySelector).
+    // but the old _matchesSelector path ignored it, so `div:disabled`
+    // matched every `div`.
     //
     // Implemented here: state-on-element pseudo-classes (`:disabled`,
-    // `:checked`, `:enabled`, `:hover`, `:focus`) read directly from the
-    // matching el._* slot the bridge already maintains. DOM-position
-    // pseudo-classes (`:first-child`, `:last-child`, `:nth-child(N)`,
-    // `:nth-of-type(N)`) walk the parent's children. `:not(<simple>)`
-    // recursively dispatches to _matchesSelector with the negated selector.
+    // `:checked`, `:enabled`, `:hover`, `:focus`, `:active`) read directly
+    // from the matching el._* slot the bridge already maintains.
+    // DOM-position pseudo-classes (`:first-child`, `:last-child`,
+    // `:only-child`, `:nth-child(N)`, `:nth-last-child(N)`) walk the
+    // parent's children. `:not(<simple>)` recursively dispatches to
+    // _matchesSelector with the negated selector.
     //
     // Pseudo-classes that require the full CSS Selectors Level 4 cascade
     // engine (`:has()`, `:is()`, `:where()`, attribute-namespace forms)
@@ -263,13 +264,13 @@ function _matchesSelector(el, parsed) {
     return true;
 }
 
-// pulp #1737 — pseudo-class evaluator. Returns true if `el` matches the
+// Pseudo-class evaluator. Returns true if `el` matches the
 // pseudo-class string (e.g. `disabled`, `checked`, `nth-child(2n+1)`,
 // `not(.foo)`). Unknown / unimplemented forms return false (the broader
 // catalog claim is "no-match rather than throw" — same precedent as the
-// pre-#1737 parser-tolerates-but-matcher-ignores behaviour, except now
-// the matcher explicitly rejects so `div:nth-child(2)` no longer leaks
-// to all `div`).
+// earlier parser-tolerates-but-matcher-ignores behaviour, except now the
+// matcher explicitly rejects so `div:nth-child(2)` no longer leaks to all
+// `div`).
 function _matchesPseudoClass(el, pseudo) {
     if (!pseudo) return true;
     var lower = pseudo.toLowerCase();
@@ -295,7 +296,7 @@ function _matchesPseudoClass(el, pseudo) {
         return !!parent && parent._children && parent._children.length === 1
             && parent._children[0] === el;
     }
-    // pulp #1737 (Codex P2 followup #3 on #1779): `:root` matches the
+    // `:root` matches the
     // document root element specifically (`__bodyElement__`), not any
     // element with no parent. The previous `!el._parentElement` check
     // also matched DETACHED elements (createElement before appendChild),
@@ -352,7 +353,7 @@ function _matchesPseudoClass(el, pseudo) {
     return false;
 }
 
-// pulp #1737 — :nth-child(N) argument parser. Accepts:
+// :nth-child(N) argument parser. Accepts:
 //   * `odd` / `even` (case-insensitive)
 //   * a positive integer literal (`2`, `5`)
 //   * `An+B` / `An-B` formula (e.g. `2n`, `2n+1`, `3n-1`, `-n+3`).
@@ -408,4 +409,3 @@ function _findMatch(root, parsed, findAll) {
 
     return findAll ? results : null;
 }
-

--- a/core/view/js/web-compat-document.js
+++ b/core/view/js/web-compat-document.js
@@ -47,11 +47,10 @@ StyleSheet.prototype._applyTo = function(el) {
         // match, not the live state. The live state check is then either
         // (a) deferred to the event-handler wiring (`:hover` / `:focus` /
         // `:active`), or (b) done explicitly here (`:disabled` reads
-        // `el._disabled` after the structural match). The new
-        // querySelector-side _matchesSelector pseudo evaluator (pulp
-        // #1737) honours pseudo when present, but is bypassed here so
-        // the wire-up still sees structural matches before the user has
-        // moused over anything.
+        // `el._disabled` after the structural match). The querySelector-
+        // side _matchesSelector pseudo evaluator honours pseudo when
+        // present, but is bypassed here so the wire-up still sees
+        // structural matches before the user has moused over anything.
         var parsedNoPseudo = parsed;
         if (parsed.pseudo) {
             parsedNoPseudo = {
@@ -92,8 +91,8 @@ function _applyStyles(el, props) {
 }
 
 function _setupPseudoHover(el, props) {
-    // pulp #1323 — multiple `:hover` rules on the same element layer
-    // their property maps. We keep a per-element list so `mouseleave`
+    // Multiple `:hover` rules on the same element layer merge their
+    // property maps. We keep a per-element list so `mouseleave`
     // restores the union of all hover-touched properties to their
     // pre-hover values, even when a later rule introduced a new key.
     // The list is keyed on the props *object identity* so repeated
@@ -115,7 +114,7 @@ function _setupPseudoHover(el, props) {
     }
     if (!alreadyHave) hoverState.propsList.push(props);
 
-    // pulp #1173 — registerHover(id) arms the native dispatcher. The C++
+    // registerHover(id) arms the native dispatcher. The C++
     // side requires the widget to exist before the call lands, so we
     // defer wiring until _nativeCreated. _applyTo() runs again from
     // appendChild's _reapplyStylesheets() after _nativeCreated flips,
@@ -165,7 +164,7 @@ function _setupPseudoHover(el, props) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// CSS text → StyleSheet translator (pulp #1323)
+// CSS text → StyleSheet translator
 // ═══════════════════════════════════════════════════════════════════════════════
 //
 // Converts the contents of a `<style>` element into a StyleSheet so the
@@ -178,11 +177,10 @@ function _setupPseudoHover(el, props) {
 //   - Descendant / child / sibling combinators in the CSS-text input
 //     (the underlying matcher supports them via `_parseSelector` but
 //     bringing them through the text parser opens a larger correctness
-//     surface — Spectr's editor.js sticks to flat selectors).
+//     surface).
 //   - At-rules (@media, @keyframes, @supports, @import).
 //   - CSS variable resolution at parse time (handled by the existing
 //     style-decl path on apply).
-//   - `:active` pseudo-class wiring (#1149 part b explicit non-goal).
 
 function _stripCssComments(text) {
     return text.replace(/\/\*[\s\S]*?\*\//g, "");
@@ -370,8 +368,8 @@ var document = {
     createTextNode: function(text) {
         // Backed by an Element (`<span>`) so renderers handle text uniformly,
         // but flagged as a DOM-spec text node so reconcilers (React 18, etc.)
-        // see `node.nodeType === 3` and `node.nodeName === "#text"`. Per
-        // pulp #468 — React's reconciler reads both on every node it walks.
+        // see `node.nodeType === 3` and `node.nodeName === "#text"`.
+        // React's reconciler reads both on every node it walks.
         var el = new Element("span");
         el._textContent = text;
         el._isTextNode = true;
@@ -436,16 +434,15 @@ var document = {
         return el;
     },
 
-    // pulp #2128 follow-up — document-level EventTarget with real fan-out.
+    // document-level EventTarget with real fan-out.
     //
-    // Previously these were no-ops (pulp #2101), kept that way so Three.js
+    // Previously these were no-ops, kept that way so Three.js
     // OrbitControls' `ownerDocument.removeEventListener` didn't throw on
     // cleanup. That cleanup story is preserved (removeEventListener still
     // doesn't throw on unknown handlers) but listeners now actually fire,
     // which is needed so React "click-outside" patterns that hook
-    // `document.addEventListener('mousedown', onDoc)` work — Spectr's
-    // PickerDropdown, ContextMenu close-on-outside-click, and every
-    // React popover that uses this pattern were silently dead before.
+    // `document.addEventListener('mousedown', onDoc)` work. Popovers and
+    // context menus using this pattern were silently dead before.
     //
     // The bridge dispatches into this map via `__dispatch__('document',
     // eventName, eventObj)` from C++ (see widget_bridge.cpp __dispatch__
@@ -564,7 +561,7 @@ var navigator = globalThis.navigator || {};
 if (typeof navigatorGPU !== "undefined" && navigatorGPU) {
     navigator.gpu = navigatorGPU;
     navigator.gpu.requestAdapter = function() {
-        // pulp #2101 — prefer the native Dawn adapter when the host advertises one
+        // prefer the native Dawn adapter when the host advertises one
         // via __describeNativeAdapterImpl. Falls back to the pure-mock adapter so
         // headless test paths (no host bridge) still resolve cleanly.
         var descriptor = null;
@@ -624,7 +621,7 @@ globalThis.localStorage = localStorage;
 window.sessionStorage = localStorage;
 globalThis.sessionStorage = localStorage;
 
-// pulp #3206 — `self` alias for the window object.
+// `self` alias for the window object.
 //
 // Browser/WebGPU spec: `self`, `window`, and `globalThis` all reference the
 // same object in a page context. Three.js's `Animation` class (and many
@@ -1015,7 +1012,7 @@ window.pulp.gpu = {
         descriptor = descriptor || {};
         return __createMockGPUDevice(adapter, descriptor);
     },
-    // pulp #2101 — explicit accessors for the native Dawn adapter so test
+    // explicit accessors for the native Dawn adapter so test
     // harnesses and demos can opt into the bridge path without relying on
     // requestAdapter's auto-detection.
     describeNativeAdapter: function() {

--- a/core/view/js/web-compat-dom-ops.js
+++ b/core/view/js/web-compat-dom-ops.js
@@ -1,17 +1,16 @@
 // DOM manipulation methods (small file for QuickJS compilation limit).
 //
-// pulp #745 — single source of truth for the prototype methods that
-// underpin web-compat DOM mutation. Earlier the same code lived twice:
-// in this file (embedded into web_compat_preludes_gen.hpp via embed_js.py)
-// AND inline in widget_bridge.cpp as `kDomOpsInit`. The two had drifted
-// — the inline copy carried DocumentFragment flatten paths from #468
-// Codex P1 that were never backported here, and the inline version was
-// the one actually evaluated, so this file was dead code that the build
-// happily included anyway. Now the file is the only copy.
+// Single source of truth for the prototype methods that underpin
+// web-compat DOM mutation. Earlier the same code lived twice: in this
+// file (embedded into web_compat_preludes_gen.hpp via embed_js.py) and
+// inline in widget_bridge.cpp as `kDomOpsInit`. The two had drifted,
+// and the inline version was the one actually evaluated, so this file
+// was dead code that the build still included. Now the file is the only
+// copy.
 //
 // Idempotency guard: callers may eval this script more than once
-// (constructor + manual reload, or the future #468 deferred-init
-// transition). The flag-on-prototype check makes a second eval a no-op
+// (constructor + manual reload, or a deferred-init transition). The
+// flag-on-prototype check makes a second eval a no-op
 // instead of re-defining the methods (which would also re-publish the
 // same logic but re-trigger any global side effects readers attach via
 // Object.defineProperty / proxies).
@@ -21,10 +20,10 @@ if (!Element.prototype.appendChild ||
 
     Element.prototype.appendChild = function(child) {
         if (!(child instanceof Element)) return child;
-        // DocumentFragment flatten (pulp #468 Codex P1): a fragment must
-        // splice its children into the parent — the fragment node itself
-        // never enters the tree. React 18's reconciler stages commits
-        // inside fragments; without this they show up as phantom wrappers.
+        // DocumentFragment flatten: a fragment must splice its children
+        // into the parent, and the fragment node itself never enters the
+        // tree. React 18's reconciler stages commits inside fragments;
+        // without this they show up as phantom wrappers.
         if (child._isDocumentFragment) {
             var kids = child._children.slice(0);
             child._children.length = 0;
@@ -35,11 +34,11 @@ if (!Element.prototype.appendChild ||
         child._parentElement = this;
         this._children.push(child);
         this._ensureNative();
-        // pulp #1899 — pass an optional widget-type hint to the C++
-        // __domAppend fast path so it can route `<input>` to the right
-        // native widget (Fader for type=range, Checkbox for type=checkbox).
-        // Computing the hint here is cheaper than re-entering JS from C++
-        // and avoids the QuickJS stack-overflow risk that motivated the
+        // Pass an optional widget-type hint to the C++ __domAppend fast
+        // path so it can route `<input>` to the right native widget
+        // (Fader for type=range, Checkbox for type=checkbox). Computing
+        // the hint here is cheaper than re-entering JS from C++ and
+        // avoids the QuickJS stack-overflow risk that motivated the
         // __domAppend fast path in the first place.
         var __domAppendHint = "";
         if (child.tagName === "INPUT") {
@@ -51,13 +50,11 @@ if (!Element.prototype.appendChild ||
             } else if (child._type === "checkbox") {
                 __domAppendHint = "checkbox";
             } else {
-                // pulp jsx-instrument-import (2026-05-17) — plain
-                // `<input>` (the default `_type` is "text") and the
-                // text-input subtypes (text/search/email/url/tel/password)
-                // route to a TextEditor on the C++ side. Pre-fix, all
-                // non-range/non-checkbox inputs fell through to a plain
-                // View, leaving Chainer's preset-name field (and any
-                // generic React `<input>`) non-editable.
+                // Plain `<input>` (the default `_type` is "text") and
+                // the text-input subtypes (text/search/email/url/tel/
+                // password) route to a TextEditor on the C++ side.
+                // Other non-range/non-checkbox inputs fall through to a
+                // plain View.
                 var t = child._type || "text";
                 if (t === "text" || t === "search" || t === "email" ||
                     t === "url"  || t === "tel"    || t === "password") {
@@ -68,26 +65,26 @@ if (!Element.prototype.appendChild ||
         __domAppend(this._id, child._id, child.tagName.toLowerCase(), __domAppendHint);
         child._nativeCreated = true;
         if (child._textContent) setText(child._id, child._textContent);
-        // pulp #1147 — replay presentational `width`/`height` HTML
-        // attributes that were captured before mount. React/JSX commits
-        // setAttribute() before appendChild(), and the C++ __domAppend
-        // path doesn't see those attributes — so a fresh SVG arrives
-        // here as 0×0 and the row collapses. Style flushAll() doesn't
-        // cover attribute paths, only `style.*`. Apply only to layout-
-        // leaf media tags so semantic block elements aren't surprised
-        // by stale presentational hints.
+        // Replay presentational `width`/`height` HTML attributes that
+        // were captured before mount. React/JSX commits setAttribute()
+        // before appendChild(), and the C++ __domAppend path doesn't
+        // see those attributes, so a fresh SVG arrives here as 0×0 and
+        // the row collapses. Style flushAll() doesn't cover attribute
+        // paths, only `style.*`. Apply only to layout-leaf media tags so
+        // semantic block elements aren't surprised by stale
+        // presentational hints.
         if (typeof __replayMediaAttributes__ === "function") {
             __replayMediaAttributes__(child);
         }
-        // pulp Wave 3 html.2 / #1476 — same flush for ARIA attributes
-        // (`aria-label` / `role`) captured before mount. Without this
-        // the React commit order (setAttribute -> appendChild) leaves
-        // the access slots empty even though _attributes carries them.
+        // Same flush for ARIA attributes (`aria-label` / `role`) captured
+        // before mount. Without this the React commit order
+        // (setAttribute -> appendChild) leaves the access slots empty
+        // even though _attributes carries them.
         if (typeof __replayAriaAttributes__ === "function") {
             __replayAriaAttributes__(child);
         }
-        // pulp #1926 — rect / line / circle SVG primitives. React/JSX
-        // commits setAttribute() before appendChild(), so geometry and
+        // Rect / line / circle SVG primitives. React/JSX commits
+        // setAttribute() before appendChild(), so geometry and
         // fill/stroke land on _attributes before the bridge sees the
         // native id. Flush them now that the native widget exists.
         if (typeof __replaySvgRectAttributes__ === "function") {
@@ -99,29 +96,26 @@ if (!Element.prototype.appendChild ||
         if (typeof __replaySvgCircleAttributes__ === "function") {
             __replaySvgCircleAttributes__(child);
         }
-        // pulp #1899 — replay SvgPath attributes (d / stroke /
-        // stroke-width / fill / viewBox-from-parent) for `<path>`
-        // elements. React commits these via setAttribute BEFORE the
-        // appendChild that materializes the native widget, so the
-        // SvgPathWidget is empty until this replay runs.
+        // Replay SvgPath attributes (d / stroke / stroke-width / fill /
+        // viewBox-from-parent) for `<path>` elements. React commits
+        // these via setAttribute BEFORE the appendChild that materializes
+        // the native widget, so the SvgPathWidget is empty until this
+        // replay runs.
         if (typeof __replaySvgPathAttributes__ === "function") {
             __replaySvgPathAttributes__(child);
         }
         child.style._flushAll();
         child._reapplyStylesheets();
 
-        // pulp jsx-instrument-import (2026-05-17) — auto-register
-        // native click + pointer events on EVERY appended element so
-        // React 17+'s root-delegated event system actually receives
-        // events. React attaches a single delegate listener to the
-        // root container; individual JSX elements never call
-        // addEventListener('click', fn), so pre-fix registerClick(id)
-        // / registerPointer(id) was never invoked and native NSEvents
-        // never reached the JS bubble chain. The shim's _dispatchEvent
-        // implements proper capture/bubble through _parentElement,
-        // so once native click/pointer fires `on(id, 'click')` we
-        // synthesize a DOM Event, dispatch on the target child Element,
-        // and the existing bubble walk delivers to React's root.
+        // Auto-register native click + pointer events on EVERY appended
+        // element so React 17+'s root-delegated event system receives
+        // events. React attaches a single delegate listener to the root
+        // container; individual JSX elements never call addEventListener
+        // ('click', fn). The shim's _dispatchEvent implements proper
+        // capture/bubble through _parentElement, so once native
+        // click/pointer fires `on(id, 'click')` we synthesize a DOM Event,
+        // dispatch on the target child Element, and the existing bubble
+        // walk delivers to React's root.
         //
         // Idempotent via _autoEventsRegistered flag.
         if (!child._autoEventsRegistered) {
@@ -182,11 +176,11 @@ if (!Element.prototype.appendChild ||
                 });
             }
         }
-        // pulp #1323 — `<style>` elements receive CSS via either direct
-        // textContent assignment or child Text nodes (React's reconciler
-        // takes the second path). When a Text-bearing child lands under a
-        // `<style>` parent, route the aggregated text through the CSS
-        // translator so `:hover` rules get registered.
+        // `<style>` elements receive CSS via either direct textContent
+        // assignment or child Text nodes; React's reconciler takes the
+        // second path. When a Text-bearing child lands under a `<style>`
+        // parent, route the aggregated text through the CSS translator so
+        // `:hover` rules get registered.
         if ((this.tagName === "STYLE" || this._isStyleElement)
                 && typeof _processStyleElement === "function") {
             var aggregated = "";
@@ -218,8 +212,8 @@ if (!Element.prototype.appendChild ||
 
     Element.prototype.insertBefore = function(newChild, refChild) {
         if (!refChild) return this.appendChild(newChild);
-        // DocumentFragment flatten (pulp #468 Codex P1): each child of
-        // the fragment is inserted at the ref position individually.
+        // DocumentFragment flatten: each child of the fragment is inserted
+        // at the ref position individually.
         if (newChild._isDocumentFragment) {
             var kids = newChild._children.slice(0);
             newChild._children.length = 0;
@@ -235,15 +229,15 @@ if (!Element.prototype.appendChild ||
         __domAppend(this._id, newChild._id, newChild.tagName.toLowerCase());
         newChild._nativeCreated = true;
         if (newChild._textContent) setText(newChild._id, newChild._textContent);
-        // pulp #1147 / Wave 3 html.2 — same pre-mount attribute replay
-        // path as appendChild, including ARIA attributes.
+        // Same pre-mount attribute replay path as appendChild, including
+        // ARIA attributes.
         if (typeof __replayMediaAttributes__ === "function") {
             __replayMediaAttributes__(newChild);
         }
         if (typeof __replayAriaAttributes__ === "function") {
             __replayAriaAttributes__(newChild);
         }
-        // pulp #1926 — see appendChild for rationale.
+        // See appendChild for the SVG primitive replay rationale.
         if (typeof __replaySvgRectAttributes__ === "function") {
             __replaySvgRectAttributes__(newChild);
         }
@@ -253,7 +247,7 @@ if (!Element.prototype.appendChild ||
         if (typeof __replaySvgCircleAttributes__ === "function") {
             __replaySvgCircleAttributes__(newChild);
         }
-        // pulp #1899 — see appendChild for rationale.
+        // See appendChild for the SvgPath replay rationale.
         if (typeof __replaySvgPathAttributes__ === "function") {
             __replaySvgPathAttributes__(newChild);
         }

--- a/core/view/js/web-compat-observers.js
+++ b/core/view/js/web-compat-observers.js
@@ -8,8 +8,8 @@
 // real Intersection / Mutation / Resize / Performance reporting against our
 // virtual DOM.
 //
-// See pulp #468 (gap matrix) for the full list and the per-API call counts
-// against react-dom.development.js.
+// The browser-API gap matrix tracks the full list and the per-API call
+// counts against react-dom.development.js.
 
 (function () {
     function NoOpObserver() {

--- a/core/view/js/web-compat-scheduler.js
+++ b/core/view/js/web-compat-scheduler.js
@@ -5,16 +5,15 @@
 // prefers `MessageChannel` for cross-task fan-out so it can yield back to
 // the host between renders. When MessageChannel is missing it falls back to
 // `setTimeout(0)` — still functional, just less granular. For the import-
-// time first-commit harvest (pulp #468) we don't need real concurrency,
+// time first-commit harvest we don't need real concurrency,
 // only the constructor plus port wiring so React's feature-detect resolves
 // to its preferred path.
 //
-// pulp #915 — animation-frame and timer globals are now registered here
+// animation-frame and timer globals are now registered here
 // (driven by the underscored `__requestFrame__` / `__scheduleTimer__`
 // natives that WidgetBridge::register_api installs) so consumer bundles
-// don't need a JS shim that re-aliases `__requestFrame__` ⇄
-// `requestAnimationFrame`. The deletion of spectr's ~80-line shim.js
-// hangs off this slot.
+// don't need a JS shim that re-aliases `__requestFrame__` to
+// `requestAnimationFrame`.
 //
 // This shim is intentionally thin: the message queue is drained on the
 // next microtask via `Promise.resolve().then`. That keeps the scheduling
@@ -43,7 +42,7 @@
         };
     }
 
-    // ── requestAnimationFrame / cancelAnimationFrame (pulp #915) ─────────
+    // ── requestAnimationFrame / cancelAnimationFrame ─────────
     // Wraps the native __requestFrame__ id-allocator + __frameCallbacks__
     // table that WidgetBridge installs in its preamble. Standard names go
     // on globalThis directly so consumers don't need a shim.
@@ -62,7 +61,7 @@
         };
     }
 
-    // ── setTimeout / clearTimeout / setInterval / clearInterval (#915) ───
+    // ── setTimeout / clearTimeout / setInterval / clearInterval ──────────
     // Driven by the native deadline tracker (__scheduleTimer__) so the
     // frame loop fires positive-delay timers without the consumer having
     // to chain rAF ticks. setTimeout(fn, 0) bypasses native scheduling
@@ -105,7 +104,7 @@
         globalThis.clearInterval = globalThis.clearTimeout;
     }
 
-    // ── performance.now() (pulp #915) ────────────────────────────────────
+    // ── performance.now() ────────────────────────────────────
     // Bundled-React frameworks read `performance.now` at module-eval
     // time; without it the bundle ReferenceErrors before the bridge has
     // a chance to install the legacy window.performance shim.
@@ -189,7 +188,7 @@
     // checks `window.postMessage` specifically — and in this runtime
     // `window` is a distinct object created in web-compat-document.js, so
     // assigning on globalThis alone doesn't cover the check. Mirror onto
-    // both. (pulp #468 Codex P2.)
+    // both.
     if (typeof globalThis.postMessage !== "function") {
         globalThis.postMessage = function () {};
     }
@@ -202,11 +201,10 @@
     // Real browser frames give nested windows a `parent` that points at the
     // embedding frame; standalone top-level windows have `window.parent ===
     // window`. Imported React designs commonly call
-    // `window.parent.postMessage(...)` for cross-frame messaging (4 sites
-    // in Spectr's edit-mode bridge alone); without a self-reference, the
-    // property access throws TypeError and the calling effect is silently
-    // dead. We're always a top-level window in this runtime, so the
-    // self-reference is spec-correct.
+    // `window.parent.postMessage(...)` for cross-frame messaging; without
+    // a self-reference, the property access throws TypeError and the calling
+    // effect is silently dead. We're always a top-level window in this
+    // runtime, so the self-reference is spec-correct.
     if (typeof globalThis.window === "object" && globalThis.window !== null
             && typeof globalThis.window.parent === "undefined") {
         globalThis.window.parent = globalThis.window;
@@ -334,7 +332,7 @@
         globalThis.URLSearchParams = URLSearchParams;
     }
 
-    // ── Mirror standard names onto `window` (pulp #915) ──────────────────
+    // ── Mirror standard names onto `window` ──────────────────
     // web-compat-document.js installs a `window` object before this file
     // runs and pre-populates it with its own requestAnimationFrame /
     // cancelAnimationFrame closures. React's scheduler reads

--- a/core/view/js/web-compat-style-decl-helpers.js
+++ b/core/view/js/web-compat-style-decl-helpers.js
@@ -1,12 +1,11 @@
 // ═══════════════════════════════════════════════════════════════════════════════
-// CSSStyleDeclaration helpers (P5-5 first cut — extracted from web-compat-style-decl.js)
+// CSSStyleDeclaration helpers extracted from web-compat-style-decl.js
 // ═══════════════════════════════════════════════════════════════════════════════
 //
-// Three orthogonal pieces that the U-2 export map calls out as the
-// natural seam:
+// Four orthogonal pieces live at this seam:
 //
 //   1. `_cssToFlex(v)` — CSS-keyword → Yoga-flex-value translator. Used
-//      by the layout property switch inside the big `_applyProperty` body.
+//      by the layout property switch in `_applyLayoutProp`.
 //   2. `__cssProperties__` — exhaustive list of camelCase CSS property
 //      names that get the getter/setter reflection.
 //   3. The IIFE that walks `__cssProperties__` and defines a
@@ -32,9 +31,8 @@ function _cssToFlex(v) {
     return v; // center, stretch pass through
 }
 
-// Define style property getters/setters via Proxy-like approach
-// Since QuickJS supports Proxy, use it for the style object
-// But for safety and compatibility, we use defineProperty on the prototype
+// QuickJS supports Proxy, but for safety and compatibility we use
+// defineProperty on the prototype for style property getters/setters.
 var __cssProperties__ = [
     "display", "flexDirection", "flexWrap", "flexGrow", "flexShrink", "flexBasis", "flex",
     "flexFlow", "justifyContent", "alignItems", "alignSelf", "alignContent", "order",
@@ -44,10 +42,10 @@ var __cssProperties__ = [
     "aspectRatio", "boxSizing",
     "margin", "marginTop", "marginRight", "marginBottom", "marginLeft",
     "marginInline", "marginBlock",
-    // pulp #1434 A4 Bundle 3 — CSS logical-edge longhands.
+    // CSS logical-edge longhands.
     "marginInlineStart", "marginInlineEnd", "marginBlockStart", "marginBlockEnd",
     "paddingInlineStart", "paddingInlineEnd", "paddingBlockStart", "paddingBlockEnd",
-    // pulp #1434 batch 4 — React Native shorthand aliases.
+    // React Native shorthand aliases.
     "marginHorizontal", "marginVertical",
     "padding", "paddingTop", "paddingRight", "paddingBottom", "paddingLeft",
     "paddingInline", "paddingBlock",
@@ -55,7 +53,7 @@ var __cssProperties__ = [
     "backgroundColor", "color",
     "fontSize", "fontWeight", "fontStyle", "fontFamily", "letterSpacing", "lineHeight",
     "textAlign", "textTransform",
-    // pulp #1434 (batch 3) — text-decoration shorthand + 3 longhands.
+    // Text-decoration shorthand plus longhands.
     "textDecoration", "textDecorationLine", "textDecorationColor", "textDecorationStyle",
     "textOverflow", "textShadow",
     "whiteSpace", "wordBreak", "overflowWrap", "wordWrap",
@@ -66,25 +64,25 @@ var __cssProperties__ = [
     "borderTopLeftRadius", "borderTopRightRadius", "borderBottomLeftRadius", "borderBottomRightRadius",
     "outline", "outlineWidth", "outlineColor", "outlineOffset", "outlineStyle",
     "opacity", "overflow", "cursor", "visibility",
-    // pulp #1434 A4 Bundle 4 — overflow per-axis (axis-tied gotcha).
+    // Overflow per-axis; keep axis-tied semantics explicit.
     "overflowX", "overflowY",
     "userSelect", "pointerEvents",
     "transform", "transformOrigin",
     "transition", "transitionDuration",
     "animation", "animationName", "animationDuration", "animationTimingFunction",
     "animationDelay", "animationIterationCount", "animationDirection", "animationFillMode",
-    // pulp #1434 A4 Bundle 2 — animation-play-state.
+    // Animation play-state.
     "animationPlayState",
     "position", "top", "right", "bottom", "left", "zIndex", "inset",
     "boxShadow", "filter", "backdropFilter", "background", "backgroundImage",
     "backgroundSize", "backgroundPosition", "backgroundRepeat",
-    // pulp #1517 — background sub-props (mostly noop / partial in pulp's
-    // layout model; see _applyProperty for the per-prop semantics).
+    // Background sub-props; most are no-op or partial in Pulp's layout
+    // model. See _applyProperty for the per-prop semantics.
     "backgroundAttachment", "backgroundClip", "backgroundOrigin",
     "gridTemplateColumns", "gridTemplateRows", "gridColumn", "gridRow",
     "lineClamp", "webkitLineClamp",
-    // pulp #1434 A4 Bundles 5–7 closure — text rendering tail, isolation,
-    // clip/mask cluster, direction, resize, fontVariant.
+    // Text rendering tail, isolation, clip/mask cluster, direction,
+    // resize, and fontVariant.
     "textIndent", "verticalAlign", "writingMode",
     "scrollBehavior", "scrollMargin", "scrollPadding", "scrollSnapType",
     "isolation", "mixBlendMode", "clipPath", "mask", "maskImage", "direction",
@@ -112,14 +110,12 @@ CSSStyleDeclaration.prototype.setProperty = function(name, value) {
     // --custom-property -> set as theme token
     if (name.indexOf("--") === 0) {
         var tokenName = name.slice(2);
-        // pulp #1918 (Codex review) — custom-property storage spans
-        // three theme slots: dimensions (motion), colors, strings.
-        // When a var() is reassigned from one value-type to another
-        // (e.g. `--my-var: "red"` → `--my-var: 12px`) the OLD slot
-        // would otherwise retain a stale token, and the React-side
-        // resolver checks strings BEFORE motion — so the stale string
-        // would shadow the new length. Conservatively clear every
-        // non-active slot up front, then write the new value.
+        // Custom-property storage spans three theme slots: dimensions
+        // (motion), colors, and strings. When a var() is reassigned from
+        // one value-type to another (e.g. `--my-var: "red"` →
+        // `--my-var: 12px`) the old slot would otherwise retain a stale
+        // token, and the React-side resolver checks strings before
+        // motion. Clear every non-active slot before writing the new value.
         if (typeof setStringToken === 'function') setStringToken(tokenName, "");
         if (typeof setMotionToken === 'function') setMotionToken(tokenName, 0);
         var parsed = resolveCSSLength(value);
@@ -132,12 +128,12 @@ CSSStyleDeclaration.prototype.setProperty = function(name, value) {
                 // Use applyTokenDiff for color tokens
                 applyTokenDiff('{"colors":{"' + tokenName + '":"' + color + '"}}');
             } else if (typeof setStringToken === 'function') {
-                // pulp #1899 (gap #3) — string-valued custom property
-                // (e.g. `--mono: "JetBrains Mono"`). Store on
-                // theme.strings so resolveVar() on the React side and
-                // getPropertyValue() below can read it back. Without
-                // this, fontFamily-shaped custom properties were
-                // silently dropped at setProperty time.
+                // String-valued custom property (e.g. `--mono:
+                // "JetBrains Mono"`). Store on theme.strings so
+                // resolveVar() on the React side and getPropertyValue()
+                // below can read it back. Without this, fontFamily-shaped
+                // custom properties were silently dropped at setProperty
+                // time.
                 setStringToken(tokenName, String(value));
             }
         }
@@ -151,10 +147,10 @@ CSSStyleDeclaration.prototype.setProperty = function(name, value) {
 CSSStyleDeclaration.prototype.getPropertyValue = function(name) {
     if (name.indexOf("--") === 0) {
         var tokenName = name.slice(2);
-        // pulp #1899 (gap #3) — prefer the string-token map for
-        // values that weren't parseable as length / color at set time
-        // (e.g. font families). Fall back to the motion-token value
-        // otherwise to preserve legacy numeric token reads.
+        // Prefer the string-token map for values that weren't parseable
+        // as length / color at set time (e.g. font families). Fall back
+        // to the motion-token value otherwise to preserve legacy numeric
+        // token reads.
         if (typeof getStringToken === 'function') {
             var s = getStringToken(tokenName);
             if (s) return s;

--- a/core/view/js/web-compat-style-decl-misc.js
+++ b/core/view/js/web-compat-style-decl-misc.js
@@ -1,5 +1,5 @@
 // ═══════════════════════════════════════════════════════════════════════════════
-// CSSStyleDeclaration — misc domain handler (P5-5 split of _applyProperty)
+// CSSStyleDeclaration — misc domain handler split from _applyProperty
 // ═══════════════════════════════════════════════════════════════════════════════
 //
 // Handles the interaction / scroll / 3D-OOS CSS properties that don't
@@ -64,7 +64,7 @@ function _applyMiscProp(decl, id, key, resolved, value) {
             // intentional no-op — see compat.json css/writingMode.
             return true;
 
-        // pulp #1737 RN-OOS-fixup (audit 2026-05-11) — CSS scroll-behavior +
+        // CSS scroll-behavior +
         // overscroll-behavior route to View slots that ScrollView reads.
         // Other scroll* properties (scrollMargin / scrollPadding /
         // scrollSnapType) remain catalog wontfix — they require a scroll-

--- a/core/view/js/web-compat-style-decl-paint.js
+++ b/core/view/js/web-compat-style-decl-paint.js
@@ -1,5 +1,5 @@
 // ═══════════════════════════════════════════════════════════════════════════════
-// CSSStyleDeclaration — paint domain handler (P5-5 split of _applyProperty)
+// CSSStyleDeclaration — paint domain handler split from _applyProperty
 // ═══════════════════════════════════════════════════════════════════════════════
 //
 // Handles the paint-surface CSS properties: colors, borders, opacity,
@@ -9,9 +9,9 @@
 // claimed the key, false otherwise. Each `case` body is byte-identical
 // to the matching arm of the pre-split `_applyProperty` switch.
 //
-// `decl` carries the CSSStyleDeclaration `this`; the scrollBehavior /
-// isolation cases read `decl.__pulpId__`. Embed order: loaded AFTER
-// web-compat-style-decl.js (the dispatcher).
+// `decl` carries the CSSStyleDeclaration `this`; the isolation case reads
+// `decl.__pulpId__`. Embed order: loaded AFTER web-compat-style-decl.js
+// (the dispatcher).
 
 function _applyPaintProp(decl, id, key, resolved, value) {
     switch (key) {
@@ -27,8 +27,7 @@ function _applyPaintProp(decl, id, key, resolved, value) {
             return true;
         }
 
-        // Border
-        // pulp #1027 (audit PR #1166 finding #4) — these used to lower onto
+        // Border attributes used to lower onto
         // the unified `setBorder(id, color, width, radius)` which clobbers
         // ALL three slots on every call. Setting `borderRadius` then
         // `borderColor` would silently drop the radius back to 0. The
@@ -37,12 +36,12 @@ function _applyPaintProp(decl, id, key, resolved, value) {
         // routing to them preserves the unset siblings — matching CSS
         // semantics.
         case "borderRadius": {
-            // pulp Wave 2 css.2 — accept `%` values. Pulp's setBorderRadius
-            // is scalar (no percent unit on the View slot), so we treat
+            // Accept `%` values. Pulp's setBorderRadius is scalar (no
+            // percent unit on the View slot), so we treat
             // the percent value as a px-equivalent best-effort: 50% on a
             // 200x100 box would historically be 100/50px, but we don't
-            // have the box size here. The catalog flips %/elliptical to
-            // `partial` honest. Users wanting a circle should use a
+            // have the box size here. The catalog marks %/elliptical
+            // support as `partial` to stay honest. Users wanting a circle should use a
             // numeric radius >= half their min(width, height).
             var br = resolveCSSLength(resolved);
             if (br) setBorderRadius(id, br.value);
@@ -67,14 +66,13 @@ function _applyPaintProp(decl, id, key, resolved, value) {
             return true;
         }
         case "borderWidth": {
-            // pulp Wave 2 css.2 — keyword expansion for `thin` / `medium` /
+            // Keyword expansion for `thin` / `medium` /
             // `thick` (CSS Backgrounds & Borders L3 named widths). Browser
             // defaults vary slightly but the canonical values are 1 / 3 /
             // 5px (Chromium / WebKit ship 1 / 3 / 5; Firefox uses 1 / 3 /
-            // 5 too). We pick 1 / 2 / 4 to match the original Wave 2 plan
-            // — slightly thinner than browsers but a reasonable visual
-            // ladder for our 1x DPI default. Authors who want exact
-            // browser parity can pass numeric px values.
+            // 5 too). We pick 1 / 2 / 4 — slightly thinner than browsers
+            // but a reasonable visual ladder for our 1x DPI default.
+            // Authors who want exact browser parity can pass numeric px values.
             var bwResolved = String(resolved).trim().toLowerCase();
             if (bwResolved === "thin")   { setBorderWidth(id, 1); return true; }
             if (bwResolved === "medium") { setBorderWidth(id, 2); return true; }
@@ -83,8 +81,8 @@ function _applyPaintProp(decl, id, key, resolved, value) {
             if (bw) setBorderWidth(id, bw.value);
             return true;
         }
-        // pulp #1434 Triage #10 — borderStyle keyword passes verbatim to
-        // setBorderStyle. The bridge maps to View::BorderStyle. Skia
+        // borderStyle keyword passes verbatim to setBorderStyle. The
+        // bridge maps to View::BorderStyle. Skia
         // installs SkDashPathEffect for dashed/dotted; other named
         // styles currently degrade to solid (paint-side gap).
         case "borderStyle": {
@@ -105,8 +103,8 @@ function _applyPaintProp(decl, id, key, resolved, value) {
             }
             return true;
         }
-        // pulp #1027 (audit PR #1166 finding #4) — per-side flat props
-        // (RN parity). Route to setBorderTop/Right/Bottom/Left{Color,Width}
+        // Per-side flat props (RN parity). Route to
+        // setBorderTop/Right/Bottom/Left{Color,Width}
         // which preserve the OTHER attribute on the View (see
         // applyBorderSide in widget_bridge.cpp). Calling setBorderSide
         // with a placeholder 0/"" for the unset slot would clobber it.
@@ -196,7 +194,7 @@ function _applyPaintProp(decl, id, key, resolved, value) {
             setFilter(id, resolved);
             return true;
 
-        // pulp #1434 (batch 3) — backdrop-filter route. The bridge
+        // backdrop-filter route. The bridge
         // setter is numeric (`setBackdropFilter(id, blur_px)`), so we
         // parse a `blur(Npx)` substring out of the CSS value. This
         // matches what `setFilter` already does on the bridge side
@@ -219,7 +217,7 @@ function _applyPaintProp(decl, id, key, resolved, value) {
             return true;
         }
 
-        // pulp #1515 — CSS `clip-path` cluster. The bridge only honors
+        // CSS `clip-path` cluster. The bridge only honors
         // the `path("...")` form (Skia parses via SkPath::FromSVGString
         // and installs the clip on paint). URL refs (`url(#id)`) and
         // named shape forms (`circle()`, `inset()`, `polygon()`,
@@ -244,7 +242,7 @@ function _applyPaintProp(decl, id, key, resolved, value) {
             return true;
         }
 
-        // pulp #1515 — CSS `mask-image`. Storage-only today; the
+        // CSS `mask-image`. Storage-only today; the
         // paint pipeline does not yet composite a shader mask onto a
         // saveLayer. Forwarding the value through to the bridge keeps
         // the slot round-trippable so harness tests can assert the
@@ -258,7 +256,7 @@ function _applyPaintProp(decl, id, key, resolved, value) {
             return true;
         }
 
-        // pulp #1515 followup — `mask-size` pairs with mask-image.
+        // `mask-size` pairs with mask-image.
         // Storage-only today; consumed by the future paint slice that
         // wires the mask shader onto the saveLayer.
         case "maskSize": {
@@ -297,7 +295,7 @@ function _applyPaintProp(decl, id, key, resolved, value) {
             return true;
         }
 
-        // pulp #1515 — CSS `mask` shorthand. Parse the image
+        // CSS `mask` shorthand. Parse the image
         // sub-property out (it's the only longhand we support today)
         // and forward both the shorthand verbatim (so View::mask()
         // round-trips) and the extracted image to setMaskImage.
@@ -338,7 +336,7 @@ function _applyPaintProp(decl, id, key, resolved, value) {
             return true;
         }
 
-        // pulp #1517 — background sub-props.
+        // background sub-props.
         // - backgroundAttachment: only `scroll` is the conformant default in
         //   pulp's non-scrolling layout model. `fixed` / `local` need a
         //   scroll-context coupling we don't model — accept verbatim and
@@ -371,9 +369,9 @@ function _applyPaintProp(decl, id, key, resolved, value) {
             return true;
 
         // outline: "2px solid blue" — fan-out to the per-attribute
-        // bridge fns introduced in pulp #1519 (setOutlineColor /
-        // setOutlineStyle / setOutlineWidth). Falls back to legacy
-        // setOutline if the new ones aren't registered (older bridge).
+        // bridge fns (setOutlineColor / setOutlineStyle / setOutlineWidth).
+        // Falls back to legacy setOutline if the new ones aren't registered
+        // (older bridge).
         case "outline": {
             var op = resolved.match(/([\d.]+)px\s+(\w+)\s+(.+)/);
             if (op) {
@@ -404,7 +402,7 @@ function _applyPaintProp(decl, id, key, resolved, value) {
             }
             return true;
         }
-        // pulp #1519 — outline-offset / outline-style now have dedicated
+        // outline-offset / outline-style now have dedicated
         // bridge setters. Outline doesn't take Yoga layout space, so the
         // CSS path mirrors borderStyle keyword set verbatim.
         case "outlineOffset": {
@@ -440,14 +438,14 @@ function _applyPaintProp(decl, id, key, resolved, value) {
             return true;
 
         // mix-blend-mode — already wired via setMixBlendMode bridge fn
-        // (#1549). Mirroring the RN surface so CSS authors get the same
+        // Mirroring the RN surface so CSS authors get the same
         // 16-keyword set.
         case "mixBlendMode":
             if (typeof setMixBlendMode === "function") setMixBlendMode(id, resolved);
             return true;
 
-        // pulp #1737 RN-OOS-fixup (final round) — CSS isolation honest
-        // CSS-subset flip. Pulp's per-View save_layer_with_blend model
+        // CSS `isolation` honest CSS-subset flip. Pulp's per-View
+        // save_layer_with_blend model
         // is structurally isolated by default (each blended View has
         // its own composition layer; z-index is paint-order scoped to
         // siblings within a parent), so the keyword round-trips to a

--- a/core/view/js/web-compat-style-decl-transform.js
+++ b/core/view/js/web-compat-style-decl-transform.js
@@ -1,5 +1,5 @@
 // ═══════════════════════════════════════════════════════════════════════════════
-// CSSStyleDeclaration — transform domain handler (P5-5 split of _applyProperty)
+// CSSStyleDeclaration — transform domain handler split from _applyProperty
 // ═══════════════════════════════════════════════════════════════════════════════
 //
 // Handles the transform / transition / animation CSS properties.
@@ -12,7 +12,7 @@ function _applyTransformProp(decl, id, key, resolved, value) {
     switch (key) {
         // Transform
         case "transform": {
-            // pulp #1434 Triage #9 — full CSS transform-function fan-out.
+            // full CSS transform-function fan-out.
             // Walk-once accumulator (mirrors the @pulp/react prop-applier
             // walker) so the within-string order produces a single set
             // of consolidated bridge calls instead of multiple
@@ -25,8 +25,8 @@ function _applyTransformProp(decl, id, key, resolved, value) {
             //   • rotateX / rotateY — pulp's 2D View has no 3D rotation
             //     storage; rotateZ aliases to setRotation.
             //   • matrix3d / perspective — ditto, no 3D model.
-            //   • matrix(a b c d tx ty) — 2D affine. Per Codex P1 audit,
-            //     dispatched directly to setTransform(id, a, b, c, d, e, f)
+            //   • matrix(a b c d tx ty) — 2D affine. Dispatched directly
+            //     to setTransform(id, a, b, c, d, e, f)
             //     to preserve all 6 components verbatim. The earlier
             //     decomposition to translate+uniform-scale+rotate dropped
             //     the c/d skew components on rotation matrices like
@@ -108,7 +108,7 @@ function _applyTransformProp(decl, id, key, resolved, value) {
             return true;
         }
 
-        // Transition (pulp #1434 Phase A2-1) — pass the full shorthand
+        // Transition — pass the full shorthand
         // string to the bridge, which parses it into a list of
         // TransitionSpecs (one per comma-separated entry; supports
         // duration / delay / easing / property + cubic-bezier + steps).
@@ -179,7 +179,7 @@ function _applyTransformProp(decl, id, key, resolved, value) {
         case "animationFillMode":
             if (typeof setAnimation === "function") setAnimation(id, "fill", resolved);
             return true;
-        // pulp #1434 A4 Bundle 2 — animation-play-state. Forwards the
+        // animation-play-state. Forwards the
         // CSS keyword (`running` | `paused`) through the existing
         // setAnimation control-token ABI so the bridge can route it to
         // the staged_animation slot. The full pause/resume of the

--- a/core/view/js/web-compat-style-decl-typography.js
+++ b/core/view/js/web-compat-style-decl-typography.js
@@ -1,5 +1,5 @@
 // ═══════════════════════════════════════════════════════════════════════════════
-// CSSStyleDeclaration — typography domain handler (P5-5 split of _applyProperty)
+// CSSStyleDeclaration — typography domain handler split from _applyProperty
 // ═══════════════════════════════════════════════════════════════════════════════
 //
 // Handles the text / font CSS properties: font-size / weight / style /
@@ -14,7 +14,7 @@
 function _applyTypographyProp(decl, id, key, resolved, value) {
     switch (key) {
         case "fontSize": {
-            // pulp Wave 2 css.2 — relative-unit & keyword expansion.
+            // Font-size relative-unit and keyword expansion.
             //   • em/rem/%   → resolve against parent / root font-size.
             //                  We don't have a real cascade context here
             //                  (the CSS shim is per-element with no
@@ -50,8 +50,8 @@ function _applyTypographyProp(decl, id, key, resolved, value) {
             return true;
         }
         case "fontWeight":
-            // pulp #1434 (batch 3) — translate CSS keyword forms to
-            // numeric weight before reaching the bridge. Numeric values
+            // Translate CSS keyword forms to numeric weight before
+            // reaching the bridge. Numeric values
             // ("400", "500") still flow through unchanged. The previous
             // `parseInt` path returned NaN for keywords, which fell back
             // to the `|| 400` default — silently mapping `"bold"` to
@@ -74,8 +74,8 @@ function _applyTypographyProp(decl, id, key, resolved, value) {
             setFontWeight(id, fwNumeric);
             return true;
         case "fontStyle":
-            // pulp Wave 2 css.4 — `oblique` (and `oblique <angle>`) aliases
-            // to `italic`. Skia distinguishes italic-vs-oblique only when
+            // `oblique` (and `oblique <angle>`) aliases to `italic`.
+            // Skia distinguishes italic-vs-oblique only when
             // the font has a slant (`slnt`) variation axis, which most
             // bundled fonts don't. The previous default-case behavior
             // forwarded `oblique` verbatim, which the bridge silently
@@ -88,7 +88,7 @@ function _applyTypographyProp(decl, id, key, resolved, value) {
             }
             return true;
         case "letterSpacing": {
-            // pulp Wave 2 css.2 — `normal` keyword + `em` unit.
+            // Letter-spacing `normal` keyword + `em` unit.
             //   • normal → 0 (CSS spec — no extra spacing)
             //   • em     → resolved against the same default font-size as
             //              fontSize above (14px).
@@ -107,7 +107,7 @@ function _applyTypographyProp(decl, id, key, resolved, value) {
             return true;
         }
         case "lineHeight": {
-            // pulp Wave 2 css.2 — accept three additional value forms:
+            // Accept three additional line-height value forms:
             //   • unitless multiplier ("1.5") → multiply by font-size
             //     (CSS spec — most common form). Pulp's Label expects a
             //     line-height in *pixels*; we resolve the multiplier
@@ -149,13 +149,12 @@ function _applyTypographyProp(decl, id, key, resolved, value) {
         case "textDecoration":
             setTextDecoration(id, resolved);
             return true;
-        // pulp #1434 (batch 3) — text-decoration longhands. CSS exposes
+        // text-decoration longhands. CSS exposes
         // the shorthand `text-decoration` plus three independent
         // longhands: `-line` / `-color` / `-style`. Routing each to its
         // own bridge setter (instead of coalescing into a shorthand
-        // string) means a previously-set sibling longhand is preserved
-        // — matching the per-attribute border-color/width fix from PR
-        // #1166 finding #4. Same pattern, same reasoning.
+        // string) means a previously-set sibling longhand is preserved.
+        // Same pattern and reasoning as the per-side border setters.
         case "textDecorationLine":
             // Reuse the shorthand setter — same line keyword surface
             // (underline / line-through / overline / none).
@@ -175,7 +174,7 @@ function _applyTypographyProp(decl, id, key, resolved, value) {
             setTextOverflow(id, resolved);
             return true;
 
-        // pulp #1514 — list-style cluster. Pulp doesn't model
+        // list-style cluster. Pulp doesn't model
         // <li>/<ul>/<ol> semantics; the bridge stores the values
         // verbatim. Marker glyph rendering is deferred — flipping
         // the catalog from `missing` to `partial` documents the
@@ -191,7 +190,7 @@ function _applyTypographyProp(decl, id, key, resolved, value) {
             var lsTokens = String(resolved).trim().split(/\s+/);
             var lsTypes = {
                 "none": 1, "disc": 1, "circle": 1, "square": 1, "decimal": 1,
-                // Counter-style keywords (pulp #1514). Storage-only on the
+                // Counter-style keywords. Storage-only on the
                 // bridge today; the shorthand parser still needs to route
                 // them to setListStyleType so the View round-trips honestly.
                 "decimal-leading-zero": 1,
@@ -264,23 +263,16 @@ function _applyTypographyProp(decl, id, key, resolved, value) {
             return true;
         }
 
-        // font-family — pulp #1151, font v2 Slice 1.1.a
+        // font-family fallback stack.
         // CSS font-family is a comma-separated fallback list, e.g.
         //   font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
         //
-        // Pre-Slice 1.1.a: the bridge split the list and passed only
-        // the FIRST family to setFontFamily. The remaining fallback
-        // names never reached the C++ side, so an author who wrote
-        // `'IBM Plex Mono', monospace` lost the `monospace` safety net
-        // and saw silent tofu when IBM Plex Mono wasn't installed.
-        //
-        // Post-Slice 1.1.a: pass the entire raw comma-list to
-        // setFontFamily verbatim. The C++ side (skia_canvas /
-        // text_shaper / sdf_atlas, now all routed through
-        // FontResolver) splits the list once and walks it cascade-style
-        // — registered → bundled → platform per family in order,
-        // emitting a FallbackTrace for every step. The full intent of
-        // the author's CSS font-family stack reaches the resolver.
+        // Pass the entire raw comma-list to setFontFamily verbatim. The
+        // C++ side (skia_canvas / text_shaper / sdf_atlas, now all routed
+        // through FontResolver) splits the list once and walks it
+        // cascade-style — registered → bundled → platform per family in
+        // order, emitting a FallbackTrace for every step. The full intent
+        // of the author's CSS font-family stack reaches the resolver.
         //
         // No JS-side trimming or quote-stripping is necessary anymore;
         // the resolver handles both. Passing the raw string preserves

--- a/core/view/js/web-compat-style-decl.js
+++ b/core/view/js/web-compat-style-decl.js
@@ -5,7 +5,7 @@
 function CSSStyleDeclaration(el) {
     this._el = el;
     this._props = {};
-    // pulp #1148 (slice b) — auto-overlay heuristic state. Tracks whether
+    // auto-overlay heuristic state. Tracks whether
     // we've called `claimOverlay` for this element via the CSS-shape
     // detector so we can release exactly once on the inverse transition
     // (position -> static/relative, z-index -> below threshold,
@@ -16,7 +16,7 @@ function CSSStyleDeclaration(el) {
     this._autoOverlayClaimed = false;
 }
 
-// pulp #1148 (slice b) — z-index threshold above which an absolutely
+// z-index threshold above which an absolutely
 // positioned element is treated as a popover/overlay candidate. Web
 // authors typically use values like 1000 / 9999 for popovers and 1-3
 // for stacking-context shuffles within layouts; 10 is comfortably
@@ -26,7 +26,7 @@ function CSSStyleDeclaration(el) {
 // must NOT auto-claim because a claim hijacks click routing).
 var _PULP_AUTO_OVERLAY_Z_INDEX_THRESHOLD = 10;
 
-// pulp #1148 (slice b) — re-evaluate the auto-overlay heuristic for
+// re-evaluate the auto-overlay heuristic for
 // this element. Called whenever `position`, `zIndex`, or the
 // `data-overlay` hint changes. Conservative by design: opt-in only
 // when the CSS shape strongly signals a popover (position:absolute +
@@ -76,8 +76,8 @@ CSSStyleDeclaration.prototype._flushAll = function() {
 
 // Apply a single CSS property to the bridge.
 //
-// P5-5 — the former monolithic per-property `switch` is split into
-// per-domain handler modules (web-compat-style-decl-layout / -paint /
+// The former monolithic per-property `switch` is split into per-domain
+// handler modules (web-compat-style-decl-layout / -paint /
 // -typography / -transform / -misc), mirroring the @pulp/react
 // prop-applier split. `_applyProperty` below is now a thin dispatcher
 // that calls each `_applyXProp` handler in sequence until one claims


### PR DESCRIPTION
## Summary
- clean stale issue/PR/wave/Codex breadcrumbs from the web-compat JS preludes
- preserve durable rationale for CSS parsing, DOM shims, selectors, DOMMatrix, WebGPU mocks, scheduler/observer shims, and CSSStyleDeclaration handlers
- fix review-found misleading/dangling comments while keeping the batch comment-only

## Validation
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py --mode=report --all $(git diff --name-only)`
- `python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`
- `python3 tools/scripts/docs_sync_check.py --base origin/main --mode=report`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`
- `python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce`
- `python3 tools/scripts/hotspot_size_guard.py --base origin/main --config tools/scripts/hotspot_size_guard.json --mode=report`
- full local pre-push content gate before message-only trailer amend: `10410/10410` CTest passed, 0 failures; diff coverage OK
- multiple RepoPrompt/rp-cli adversarial reviews; accepted findings fixed
- `autoreview --mode local --reviewers codex,claude` clean on rerun

## Notes
- Comment-only batch; tip commit carries `Skill-Update` and `Compat-Update` skip trailers for engine/CSS mapping gates.
- Final push used `PULP_SKIP_PREPUSH=1` only after the message-only trailer amend; the content tree already passed the full local pre-push test gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned and modernized comments across the web‑compat JS preludes to remove stale breadcrumbs and clarify intent. This is comment-only; no runtime or API changes.

- **Refactors**
  - Removed stale issue/PR/wave/Codex breadcrumbs and fixed misleading/dangling notes across `css-parser.js`, DOM ops, document/selectors, DOMMatrix helper, WebGPU mock, scheduler/observers, and style-decl modules.
  - Rewrote comments to be spec-focused and clear, preserving durable rationale for CSS color/length parsing, selector matching, DOMMatrix semantics, WebGPU behavior, timers/observers, and CSSStyleDeclaration handlers.
  - Clarified embed order and behavior notes where relevant; no functional changes or interface updates.

<sup>Written for commit e6cc5ac6f0e0150e017f747b6b50ee0b06bab8ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

