### PR TITLE
docs(react): clean stale comment breadcrumbs

### DIFF
--- a/packages/pulp-react/README.md
+++ b/packages/pulp-react/README.md
@@ -6,9 +6,11 @@ Same architectural pattern as [Ink](https://github.com/vadimdemedes/ink) (termin
 
 ## Status
 
-**v0** — design validated by Codex consult + RepoPrompt review on 2026-04-25 (pulp #772). Source scaffolded; needs build + smoke test + draft PR. See spectr #26 (live tracker) for what's done.
+`@pulp/react` is the in-tree React host for Pulp view trees. It supports the
+core intrinsic widgets, Yoga layout props, bridge-backed visual props, keyboard
+shortcuts, and mock-bridge tests used by the package build lane.
 
-## Install (after first publish)
+## Install
 
 ```bash
 npm install @pulp/react
@@ -25,7 +27,7 @@ function App({ analyzerData }) {
   return (
     <View flexGrow={1} background="#0a0e14">
       <Row gap={10} paddingLeft={20} paddingRight={20} alignItems="center" height={44}>
-        <Label textColor="#ffffff">SPECTR</Label>
+        <Label textColor="#ffffff">ANALYZER</Label>
         <Button>LIVE</Button>
         <Button>PRECISION</Button>
       </Row>
@@ -90,7 +92,7 @@ Text (Label/Button/TextEditor): `text`, `textColor`, `textAlign`.
 - Mutation mode (Ink/R3F pattern), `isPrimaryRenderer: true`
 - `shouldSetTextContent` selectively for `Label` / `Button` / `TextEditor` so `<Label>hello</Label>` lowers to `setText(id, "hello")` instead of a child node
 - Ink-style scheduler: `supportsMicrotasks: true` + `queueMicrotask`
-- Concurrent mode: deferred for v0 (synchronous rendering only)
+- Synchronous rendering only; concurrent mode is not enabled
 - Single commit-time layout flush owned by `resetAfterCommit` (calls `layout()` once per React commit)
 
 ## Testing
@@ -110,9 +112,6 @@ bridge.uninstall();
 
 ## References
 
-- [pulp #772](https://github.com/danielraffel/pulp/issues/772) — design + validation
-- [spectr #25](https://github.com/danielraffel/spectr/issues/25) — Spectr master roadmap (first consumer)
-- [spectr #26](https://github.com/danielraffel/spectr/issues/26) — live progress tracker
 - Reference implementations: `ink/src/reconciler.ts`, `react-three-fiber/packages/fiber/src/core/reconciler.tsx`, `react-native-skia/packages/skia/src/sksg/HostConfig.ts`
 
 ## License

--- a/packages/pulp-react/src/prop-applier-internal.ts
+++ b/packages/pulp-react/src/prop-applier-internal.ts
@@ -37,9 +37,8 @@ export function call(name: string, ...args: unknown[]): void {
 // bypasses that — it forwards the raw `style.fontFamily` value straight
 // into `setFontFamily`. The string "var(--mono)" then reached Skia's
 // font matcher as a literal family name, returned no match, and fell
-// through to a proportional sans (visible as the Spectr top-bar "faint
-// label" symptom — labels rendered in the wrong typeface AND in a layer
-// that degraded the LCD AA, compounding the faintness).
+// through to a proportional sans. Labels rendered in the wrong typeface,
+// and the fallback layer degraded LCD antialiasing.
 //
 // Resolution tiers (first hit wins):
 //   1. `globalThis.__pulpCssVars[name]` — developer-set runtime

--- a/packages/pulp-react/src/prop-applier-layout.ts
+++ b/packages/pulp-react/src/prop-applier-layout.ts
@@ -245,8 +245,7 @@ export function applyLayoutProp(
         // of 0 / NaN / undefined clears the slot on the bridge side.
         case 'aspectRatio':     call('setFlex', id, 'aspect_ratio', value as number); return true;
 
-        // `display: 'flex' | 'none'`. RN exports + Figma / v0 /
-        // Claude Design HTML routinely emit
+        // `display: 'flex' | 'none'`. RN and design-tool exports routinely emit
         // `style={{ display: 'flex' }}` (the implicit default in pulp,
         // but the prop-applier shouldn't drop it as unknown) or
         // `style={{ display: 'none' }}` to hide a subtree. The same
@@ -277,9 +276,9 @@ export function applyLayoutProp(
                 // JSX silently collapses every flex container to a
                 // vertical stack on import.
                 if (props) {
-                    // `direction` is a third flex-direction alias in
-                    // this prop-applier
-                    // (see the `case 'direction'` block above: a value
+                    // `direction` is the third flex-axis spelling after
+                    // `flexDirection` and `flex-direction` in this
+                    // prop-applier (see the `case 'direction'` block above: a value
                     // of 'row' / 'column' / 'row-reverse' / 'column-reverse'
                     // routes to setFlex(direction); writing-direction
                     // keywords like 'ltr' / 'rtl' / 'inherit' / 'auto'
@@ -452,9 +451,8 @@ export function applyLayoutProp(
         // top/right/bottom/left accept either a number ('50' -> px) or
         // a percent string ('50%' -> percent of parent), mirroring the
         // width/height percent behavior for View positional fields.
-        // Figma absolute-positioned overlays, v0.dev hero anchors, and
-        // Claude Design sticky elements all emit
-        // `top:'50%'` etc. routinely; without percent forwarding the
+        // Design-tool absolute overlays, hero anchors, and sticky elements
+        // routinely emit `top:'50%'` etc.; without percent forwarding the
         // layout collapses to numeric 0 silently. The bridge inspects
         // arg index 1 as a string, detects the '%' suffix, and routes to
         // Yoga's YGNodeStyleSetPositionPercent path via View::top_unit_.

--- a/packages/pulp-react/src/prop-applier-paint.ts
+++ b/packages/pulp-react/src/prop-applier-paint.ts
@@ -162,7 +162,8 @@ export function applyPaintProp(
         //     `local` are noop (pulp doesn't model scroll contexts).
         //   • `backgroundClip` — `text` is the interesting variant
         //     (paint-time SkBlendMode::kSrcIn against text glyphs);
-        //     deferred to a future PR. Other values noop on solid bg.
+        //     not implemented in the current paint path. Other values noop
+        //     on solid bg.
         //   • `backgroundOrigin` — relevant only for repeating gradients;
         //     noop today.
         case 'backgroundAttachment': call('setBackgroundAttachment', id, value as string); return true;
@@ -410,12 +411,10 @@ export function applyPaintProp(
         // gradient backgrounds).
         case 'backgroundRepeat': call('setBackgroundRepeat', id, value as string); return true;
 
-        // RN iOS-legacy box-shadow longhands. Modern RN code uses
-        // `boxShadow` (CSS
-        // shorthand) which Pulp fully supports, but upstream RN still
-        // accepts shadowColor / shadowOffset / shadowOpacity /
-        // shadowRadius as cross-platform-ish style props (originally
-        // iOS-only, but Pulp implements them cross-platform via the
+        // React Native box-shadow longhands. Modern RN code uses
+        // `boxShadow` (CSS shorthand) which Pulp fully supports, but RN
+        // still accepts shadowColor / shadowOffset / shadowOpacity /
+        // shadowRadius as style props. Pulp implements them via the
         // unified BoxShadow struct on View). Each per-attribute setter
         // writes ONE slot of View::shadow_ in isolation so a JSX diff
         // that touches one prop doesn't clobber the others.

--- a/packages/pulp-react/src/prop-applier.ts
+++ b/packages/pulp-react/src/prop-applier.ts
@@ -24,8 +24,8 @@ import { applyEventProp } from './prop-applier-events.js';
 // in prop-applier-internal.ts so every domain shares one logging
 // counter.
 //
-// Bridge globals are still looked up through globalThis at call time
-// so the mock-bridge install path picks them up (see host-config.ts).
+// The optional logging hook is looked up through globalThis at call time.
+// Bridge setters dispatch through `call()` in prop-applier-internal.ts.
 type AnyFn = (...args: unknown[]) => unknown;
 const g = globalThis as unknown as Record<string, AnyFn | undefined>;
 
@@ -127,11 +127,10 @@ function applyEventHandler(id: string, key: string, value: unknown): void {
     // Also arm the pointer dispatch path for mouse events. Do not do
     // this for onClick: that is the W3C click-on-release semantic and
     // routes through on_click.
-    // Imported JSX bundles (Chainer's knobs/faders/XY pad) install
-    // onMouseDown / onMouseMove / onMouseUp handlers that need to fire on
-    // press, not release. Without this pre-fix, hit_test returns the
-    // widget with has_pointer=no and the bridge's pointer event lambda
-    // never fires for mouse* event types.
+    // Imported JSX bundles install onMouseDown / onMouseMove / onMouseUp
+    // handlers that need to fire on press, not release. Without this,
+    // hit_test returns the widget with has_pointer=no and the bridge's
+    // pointer event lambda never fires for mouse* event types.
     if (eventName === 'mousedown' || eventName === 'mouseup' ||
         eventName === 'mousemove') {
         call('registerPointer', id);
@@ -304,8 +303,8 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
 
 // ── normalizeHostProps ───────────────────────────────────────────────
 //
-// Imported React apps (Claude/Stitch/Figma/v0 bundles loaded via
-// @pulp/react/runtime-import) use HTML-style JSX:
+// Imported React apps (design-tool or runtime-import bundles) use
+// HTML-style JSX:
 //   <div style={{ width: 100, color: 'red' }} className="card">
 // This flattens that to the shape applyAllProps/applyChangedProps
 // expect (flat `width: 100, color: 'red'` props).

--- a/packages/pulp-react/src/shortcuts.ts
+++ b/packages/pulp-react/src/shortcuts.ts
@@ -187,7 +187,7 @@ function ensureDispatcher(parsed: ParsedShortcut): void {
 /// unregister fn. Useful for non-React call sites (the import-design
 /// runtime injection path) and as the primitive `useShortcut` builds
 /// on. `source` is a free-form label that appears in clash warnings —
-/// pass something the user can grep for (`'spectr-mode-switch'`, the
+/// pass something the user can grep for (`'settings-mode-switch'`, the
 /// component's display name, etc.).
 export function registerShortcut(
     spec: string,

--- a/packages/pulp-react/src/types.ts
+++ b/packages/pulp-react/src/types.ts
@@ -309,7 +309,7 @@ export interface StyleProps {
     /// `'none'` / `null` / `undefined` clears the slot.
     boxShadow?: BoxShadow | string | null;
     /// RN-style transform array. An array of single-property objects is
-    /// common in Figma / v0.dev / Claude Design exports. Wired ops:
+    /// common in design-tool exports. Wired ops:
     ///   • `translateX`, `translateY` — number, px
     ///   • `rotate`, `rotateZ` — `'45deg'` / `'1rad'` / numeric (deg)
     ///   • `scale` — uniform scalar

--- a/packages/pulp-react/test/build-output-externals.test.ts
+++ b/packages/pulp-react/test/build-output-externals.test.ts
@@ -1,9 +1,9 @@
 // Regression test for the React-dispatcher-null crash.
 //
 // Root cause: when @pulp/react was published with React (and friends)
-// inlined inside dist/index.mjs, downstream consumers (esbuild bundling
-// Spectr's editor.js) ended up with TWO copies of React in the final
-// IIFE — one inside the pre-bundled @pulp/react.mjs and one resolved
+// inlined inside dist/index.mjs, downstream consumers using esbuild ended
+// up with TWO copies of React in the final IIFE — one inside the
+// pre-bundled @pulp/react.mjs and one resolved
 // from the consumer's npm-installed `react` package via host-shims.
 //
 // React 18's dispatcher lives on a per-React-module singleton
@@ -23,7 +23,7 @@
 // This test guards the build output: if any of the four packages get
 // inlined back into the bundle (because someone removed an
 // `--external:` flag from the build script), the test fails before
-// the regression hits Spectr.
+// the regression reaches downstream plugins.
 
 import { describe, it, expect } from 'vitest';
 import { readFileSync, statSync } from 'node:fs';
@@ -35,8 +35,7 @@ describe('@pulp/react build output', () => {
   it('dist/index.mjs exists and is small (no React inlined)', () => {
     const st = statSync(distMjs);
     // After externalizing react / react-reconciler / scheduler the bundle
-    // is ~106 KB (was ~27 KB pre-shortcuts; the rest is prop-applier +
-    // host-config + intrinsics surface that accumulated over time).
+    // is ~106 KB for the prop-applier, host-config, and intrinsic surface.
     // If anyone re-inlines react it jumps to ~950 KB. A 130 KB ceiling
     // keeps a wide gap from a React-inlined bundle while leaving room
     // for the non-React surface to keep growing.

--- a/packages/pulp-react/test/host-config-array-children-text.test.ts
+++ b/packages/pulp-react/test/host-config-array-children-text.test.ts
@@ -46,7 +46,7 @@ describe('host-config commitUpdate — array children on TEXT_BEARING', () => {
     });
 
     it('emits setText when [number, string] array changes value', () => {
-        // Mirrors Spectr's <button>{bandsCount}{" bands ▾"}</button>.
+        // Mirrors a button that combines a dynamic count and a static label.
         const inst = makeButton('bands_trigger', [32, ' bands ▾']);
         commitUpdate!(
             inst, null, 'button',

--- a/packages/pulp-react/test/prop-applier-color-alias.test.ts
+++ b/packages/pulp-react/test/prop-applier-color-alias.test.ts
@@ -1,9 +1,7 @@
 // CSS-canonical `color` must fan out to the same setTextColor bridge
 // call as the RN-canonical `textColor`. JSX styles authored by every
-// HTML/Tailwind/Stitch/Figma export use `color` — the dispatch case
-// was missing the alias, so 39 occurrences in Spectr's editor.html
-// silently dropped at the prop-applier and no text picked up the
-// authored colour.
+// HTML/Tailwind/design-tool export use `color`; without the alias those
+// props silently drop at the prop-applier and text keeps the default colour.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';

--- a/packages/pulp-react/test/prop-applier-dimensions-auto.test.ts
+++ b/packages/pulp-react/test/prop-applier-dimensions-auto.test.ts
@@ -2,10 +2,9 @@
 // verbatim to the bridge so Yoga's YGNodeStyleSetWidthAuto /
 // SetHeightAuto path is reached.
 //
-// Figma auto-layout "hug contents" frames, v0.dev intrinsic-sizing
-// cards, and Claude Design responsive containers all emit `width:
-// 'auto'` / `height: 'auto'`. Before this batch the bridge had no
-// 'auto' branch on setFlex(width|height); strings reached `(float)val`
+// Auto-layout frames, intrinsic-sizing cards, and responsive containers
+// routinely emit `width: 'auto'` / `height: 'auto'`. Before this batch
+// the bridge had no 'auto' branch on setFlex(width|height); strings reached `(float)val`
 // = NaN/0 and the node was effectively pinned to 0×0. The TS surface
 // already types width/height as `number | string`, so this test only
 // exercises the 'auto' string path through the existing code shape.

--- a/packages/pulp-react/test/prop-applier-disappearing-style.test.ts
+++ b/packages/pulp-react/test/prop-applier-disappearing-style.test.ts
@@ -4,9 +4,8 @@
 // the corresponding bridge state instead of leaving the previous visual
 // value painted.
 //
-// This bites the conditional-spread idiom that Spectr's Settings Manager
-// Preset chips, PatternRow rows, and most imported designs (Stitch / v0
-// / Figma) use:
+// This bites the conditional-spread idiom that preset chips, pattern rows,
+// and imported designs use:
 //
 //   style={{ ...base, ...(active ? activeStyle : {}) }}
 //
@@ -131,7 +130,7 @@ describe('@pulp/react prop-applier — disappearing style keys', () => {
     });
 
     it('conditional-spread true → false: active-only background + border clear', () => {
-        // Mirrors Spectr Settings Manager Preset chip:
+        // Mirrors an active/inactive preset chip:
         //   style={{ ...base, ...(active ? activeStyle : {}) }}
         // Active state set background + borderColor; inactive drops them.
         const baseProps = { padding: 8, borderRadius: 4 };

--- a/packages/pulp-react/test/prop-applier-display.test.ts
+++ b/packages/pulp-react/test/prop-applier-display.test.ts
@@ -1,7 +1,7 @@
 // Verify the @pulp/react prop-applier dispatches
 // `display: 'flex' | 'none'` to the right setVisible call.
 //
-// RN exports + Figma / v0.dev / Claude Design HTML routinely emit
+// RN and design-tool exports routinely emit
 // `style={{ display: 'flex' }}` (the implicit default in pulp, but
 // the prop-applier shouldn't drop it as unknown) or `display: 'none'`
 // to hide a subtree. This test guards the RN-flavored JSX path so RN

--- a/packages/pulp-react/test/prop-applier-fontweight.test.ts
+++ b/packages/pulp-react/test/prop-applier-fontweight.test.ts
@@ -5,9 +5,8 @@
 // Raw Number(...) coercion would turn keyword weights into NaN before
 // the bridge's defensive default maps them back to 400. This translation
 // must stay aligned with compat.json (`css/fontWeight`) and the JS CSS
-// shim (`web-compat-style-decl.js`) so design-tool exports (Figma,
-// Stitch, v0, Claude Design) and React-Native style objects produce the
-// same Label::font_weight() result.
+// shim (`web-compat-style-decl.js`) so design-tool exports and React-Native
+// style objects produce the same Label::font_weight() result.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyChangedProps } from '../src/prop-applier.js';

--- a/packages/pulp-react/test/prop-applier-pointer.test.ts
+++ b/packages/pulp-react/test/prop-applier-pointer.test.ts
@@ -4,9 +4,8 @@
 //
 // Without registerPointer, the bridge keeps the JS listener in its dispatch
 // table but the View's on_pointer_event callback is never armed by the
-// native side, so clicks never fire the React handler. Spectr's FilterBank
-// band drag was the canonical repro — see spectr #32 + import-design
-// SKILL.md gotcha #8.
+// native side, so clicks never fire the React handler. Canvas band-drag
+// handlers with wheel zoom are the representative regression shape.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createMockBridge, type MockBridge } from '../src/bridge.js';
@@ -77,8 +76,8 @@ describe('@pulp/react prop-applier — pointer registration', () => {
     });
 
     it('calls both registerPointer and registerWheel when both pointer + wheel handlers present', () => {
-        // Spectr FilterBank shape: onPointerDown for band drag + onWheel
-        // for zoom. Both lambdas must be wired since each filters on
+        // Canvas band-drag shape: onPointerDown for drag + onWheel for zoom.
+        // Both lambdas must be wired since each filters on
         // me.is_wheel inversely.
         applyAllProps(instance('canvas2', 'Canvas', {
             onPointerDown: () => {},
@@ -177,7 +176,7 @@ describe('@pulp/react prop-applier — pointer registration', () => {
     });
 
     it('arms registerPointer + registerHover when both pointer and hover handlers present', () => {
-        // Spectr FilterBank wrap shape: hover-driven cursor + drag-driven gain
+        // Canvas interaction wrapper shape: hover-driven cursor + drag-driven gain
         // edits both attached to the same widget.
         applyAllProps(instance('wrap', 'View', {
             onPointerDown: () => {},

--- a/packages/pulp-react/test/prop-applier-var-resolve.test.ts
+++ b/packages/pulp-react/test/prop-applier-var-resolve.test.ts
@@ -92,8 +92,7 @@ describe('React prop forwarding for var() token resolution', () => {
         const calls = callsOf('setFontFamily');
         expect(calls).toHaveLength(1);
         // The fallback is the literal string after the comma, trimmed.
-        // Quoted strings keep their quotes — Skia's font matcher strips
-        // them (issue-932 commit list test).
+        // Quoted strings keep their quotes; Skia's font matcher strips them.
         expect(calls[0].args[1]).toBe('"SF Mono"');
     });
 

--- a/packages/pulp-react/test/shortcuts.test.ts
+++ b/packages/pulp-react/test/shortcuts.test.ts
@@ -31,7 +31,7 @@ describe('parseShortcut', () => {
         expect(r.canonical).toBe('s');
     });
 
-    it('parses cmd+, (Spectr settings chord)', () => {
+    it('parses cmd+, (settings chord)', () => {
         const r = parseShortcut('cmd+,');
         expect(r.keyCode).toBe(','.charCodeAt(0));
         expect(r.modMask).toBe(MOD_CMD);

--- a/packages/pulp-react/test/smoke.test.ts
+++ b/packages/pulp-react/test/smoke.test.ts
@@ -20,7 +20,7 @@ describe('@pulp/react smoke', () => {
   it('exposes the core intrinsic components', () => {
     // Spot-check a representative slice of the intrinsic surface that the
     // bridge contract is built around. If any of these disappear, downstream
-    // plugin code (Spectr et al.) breaks.
+    // plugin code breaks.
     expect(typeof pulpReact.View).toBe('function');
     expect(typeof pulpReact.Row).toBe('function');
     expect(typeof pulpReact.Col).toBe('function');

--- a/packages/pulp-react/vitest.config.ts
+++ b/packages/pulp-react/vitest.config.ts
@@ -1,15 +1,12 @@
 import { defineConfig } from 'vitest/config';
 
-// Vitest v8 coverage wired for pulp #1886 Phase 1 (measure-only).
-// The native diff-coverage gate runs against a Cobertura XML, so v8
-// provider + cobertura reporter keeps the JS/TS lane shape-compatible
-// with the existing aggregation in tools/scripts/coverage_tier_check.py
-// without changing the gate semantics. `text` keeps a human-readable
-// summary in CI logs.
+// Vitest v8 coverage emits Cobertura XML for the native diff-coverage
+// aggregation in tools/scripts/coverage_tier_check.py. `text` keeps a
+// human-readable summary in CI logs.
 //
-// Phase 1: no thresholds; the workflow uploads the artifact and Codecov
-// flag `pulp-react`, nothing fails. Phase 2 will layer per-tier
-// enforcement once a baseline is established.
+// Thresholds intentionally live outside this package config; the workflow
+// uploads the `pulp-react` artifact and Codecov flag, while repository-level
+// gates decide whether a coverage result is enforceable.
 export default defineConfig({
   test: {
     include: ['test/**/*.test.ts'],


### PR DESCRIPTION
## Summary
- Rewrites @pulp/react README status/install notes to describe current package behavior instead of old scaffold/live-tracker state.
- Replaces consumer-specific and workflow-era comments in the React prop-applier/tests with durable compatibility and regression rationale.
- Keeps behavior/API comments intact while removing stale issue/PR/tool/phase breadcrumbs from the package area.

## Validation
- RepoPrompt adversarial comment-hygiene review over selected @pulp/react files.
- RepoPrompt final diff review; accepted stale prop-applier header finding and applied follow-up cleanup.
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py --mode=report --all packages/pulp-react`
- `npm ci` in `packages/pulp-react` (reported existing npm audit findings; no dependency changes made)
- `npm test -- --run` in `packages/pulp-react` (50 files / 540 tests)
- `npm run build` in `packages/pulp-react`
- `python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`
- `python3 tools/scripts/docs_sync_check.py --base origin/main --mode=report`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`
- `python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce`
- `python3 tools/scripts/hotspot_size_guard.py --base origin/main --config tools/scripts/hotspot_size_guard.json --mode=report`
- `/Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode local --reviewers codex,claude` (clean, 0 findings)
- pre-push hook gates clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `@pulp/react` README and code/test comments to reflect current behavior and remove stale, consumer-specific breadcrumbs. No runtime or API changes; wording now uses neutral “design‑tool” terminology, updates install/status notes, and keeps behavior/API rationale intact.

<sup>Written for commit 10c96d30d3b6250c7dbd768cf2fb18dbda180552. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

