### PR TITLE
docs(import-ir): clean stale comments and fix HostBench test path

### DIFF
--- a/examples/host-bench-plugin/CMakeLists.txt
+++ b/examples/host-bench-plugin/CMakeLists.txt
@@ -12,6 +12,8 @@ if(PULP_BUILD_TESTS)
         PRIVATE pulp::format Catch2::Catch2WithMain)
     target_include_directories(pulp-host-bench-test
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    target_compile_definitions(pulp-host-bench-test
+        PRIVATE PULP_HOST_BENCH_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
     catch_discover_tests(pulp-host-bench-test)
 endif()
 

--- a/examples/host-bench-plugin/test_host_bench.cpp
+++ b/examples/host-bench-plugin/test_host_bench.cpp
@@ -21,6 +21,10 @@
 #  include <unistd.h>
 #endif
 
+#ifndef PULP_HOST_BENCH_SOURCE_DIR
+#  error "PULP_HOST_BENCH_SOURCE_DIR must be defined by the host-bench test target"
+#endif
+
 using namespace pulp;
 using namespace pulp::examples;
 
@@ -110,7 +114,7 @@ struct BenchFixture {
 }  // namespace
 
 TEST_CASE("HostBench AU v2 package matches MIDI descriptor", "[bench][au]") {
-    const auto source_dir = std::filesystem::path(__FILE__).parent_path();
+    const auto source_dir = std::filesystem::path(PULP_HOST_BENCH_SOURCE_DIR);
 
     std::ifstream cmake_file(source_dir / "CMakeLists.txt");
     REQUIRE(cmake_file.good());

--- a/packages/pulp-import-ir/README.md
+++ b/packages/pulp-import-ir/README.md
@@ -25,7 +25,7 @@ src/
 ├── lower-via-prop-applier.ts — IR → JSX-equivalent tree (consumed by @pulp/react)
 ├── adapters/
 │   └── claude-design-html/
-│       └── lower.ts         — first-spike adapter
+│       └── lower.ts         — Claude Design HTML adapter
 └── index.ts                 — public API
 ```
 
@@ -43,4 +43,4 @@ See `docs/guides/import-ir.md` for the full guide.
 
 ## License
 
-MIT — pulp #1486 spike.
+MIT.

--- a/packages/pulp-import-ir/package.json
+++ b/packages/pulp-import-ir/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pulp/import-ir",
   "version": "0.0.1",
-  "description": "Pulp design-import IR — typed intermediate representation that survives reimport. Adapters lower source formats (Figma / Mitosis / HTML / etc.) into IRNode trees keyed by stable_anchor_id; tweaks layer survives source regeneration. Phase 1 spike — Claude Design HTML adapter + 5-scenario harness (closes pulp #1486 phase 1).",
+  "description": "Pulp design-import IR — typed intermediate representation that survives reimport. Adapters lower source formats (Figma / Mitosis / HTML / etc.) into IRNode trees keyed by stable_anchor_id; tweaks layer survives source regeneration. Includes the Claude Design HTML adapter and scenario harness.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/pulp-import-ir/src/adapters/claude-design-html/lower.ts
+++ b/packages/pulp-import-ir/src/adapters/claude-design-html/lower.ts
@@ -1,12 +1,11 @@
-// pulp #1486 — Claude Design HTML adapter (Phase 1 spike target).
+// Claude Design HTML adapter.
 //
 // Lowers a Claude-Design-style HTML payload (a single document or a
-// fragment) into an IRNode tree. Uses content-hash anchors per §4.4.
+// fragment) into an IRNode tree. Uses content-hash anchors.
 //
-// First-spike scope: structural translation + the most common style
-// properties. Anything not yet typed is preserved verbatim under
-// `raw_source.outerHtml` so a future Pulp version can re-walk the
-// source without a re-import.
+// Handles structural translation and common inline-style properties.
+// Anything not yet typed is preserved verbatim under `raw_source.outerHtml`
+// so callers can re-walk the original source without a re-import.
 
 import type {
     IRNode,
@@ -38,12 +37,10 @@ interface BuildNode extends PreAnchorIRNode {
 /**
  * Lower a Claude Design HTML string (or fragment) into an IRNode tree.
  *
- * The payload is parsed via a small DOM-like walker that the Phase 1
- * spike implements without depending on a full HTML parser — Claude
- * Design output is well-formed enough that a regex-driven walker
- * suffices for the first spike. A real implementation would lean on
- * `parse5` or `htmlparser2`; that lands when we move to a real
- * parser-driven adapter (Phase 2).
+ * The payload is parsed via a small DOM-like walker without depending on a
+ * full HTML parser. Claude Design output is well-formed enough for the
+ * current regex-driven walker; broader malformed HTML support should use
+ * a parser such as `parse5` or `htmlparser2`.
  */
 export async function lowerClaudeDesignHtml(
     rawHtml: string,
@@ -100,15 +97,14 @@ function materialize(
 
 // ── HTML parser ───────────────────────────────────────────────────────
 //
-// Phase 1: a regex-driven walker over a small subset of HTML that
-// covers what Claude Design generates. We accept:
+// Regex-driven walker over the subset of HTML that Claude Design generates.
+// We accept:
 //   <tag attr="..." style="...">…</tag>
 //   <tag />            — self-closing
 //   text runs between tags
 //
 // We do NOT yet handle: DOCTYPE, comments, CDATA, scripts, attributes
-// without quotes, malformed nesting (assumes well-formed). Phase 2
-// swaps to parse5.
+// without quotes, or malformed nesting. This path assumes well-formed input.
 
 interface ParsedTag {
     tagName: string;
@@ -123,7 +119,7 @@ const ATTR = /([a-zA-Z-]+)="([^"]*)"/g;
 
 function parseHtmlToBuildNode(html: string, preserveRawSource: boolean): BuildNode {
     // If the input has multiple roots, wrap them in an implicit View
-    // (the spec's "fragment becomes a synthetic root" pattern).
+    // so fragments become a synthetic root.
     // We try to find a single outer tag first; if that consumes the
     // whole input, use it as the root, otherwise wrap.
     const trimmed = html.trim();
@@ -176,9 +172,8 @@ function buildFromTag(
         );
     }
 
-    // Find the matching close-tag. Phase 1 simplification: assumes
-    // well-formed, no same-tag nesting that would confuse us. (Phase 2
-    // uses parse5 and this concern goes away.)
+    // Find the matching close-tag. This assumes well-formed input with no
+    // same-tag nesting that would confuse the lightweight walker.
     const closeTag = `</${tagName}>`;
     const closeIdx = findMatchingCloseTag(src, contentStart, tagName);
     if (closeIdx < 0) {
@@ -506,7 +501,7 @@ function extractLayout(
         out.overflow = overflow as TypedLayout['overflow'];
         any = true;
     }
-    void attrs; // reserved for future data-* layout extensions
+    void attrs; // reserved for data-* layout extensions
     return any ? out : undefined;
 }
 

--- a/packages/pulp-import-ir/src/anchors.ts
+++ b/packages/pulp-import-ir/src/anchors.ts
@@ -1,14 +1,14 @@
-// pulp #1486 — stable_anchor_id strategies (§4 of the spec).
+// stable_anchor_id strategies.
 //
 // Three strategies:
 //   • content-hash — used by Claude Design HTML / Stitch / generic HTML.
-//                     Hash over (tag, role, normalized text, depth).
+//                     Hash over (tag, role, normalized text, depth, sibling discriminator).
 //   • path        — used by RN file exports / hand-edited code.
-//                    `Frame[2]/Section[0]/Button#0` w/ tiebreak.
+//                    `Tag[idx]/Tag[idx]/...`, e.g. `Frame[0]/Button[1]`.
 //   • adapter     — used by Figma / Pencil / Mitosis (sources with native IDs).
 //
-// Phase 1 spike: content-hash + path (adapter strategy is a thin
-// passthrough that the adapter populates during lower()).
+// content-hash + path are implemented here; adapter strategy is a thin
+// passthrough that the adapter populates during lower().
 
 import type { IRNode, AnchorStrategy } from './types.js';
 
@@ -19,7 +19,7 @@ import type { IRNode, AnchorStrategy } from './types.js';
 //
 // We re-implement here rather than vendor — the algorithm is ~30 lines
 // and the upstream surface is liable to change in ways unrelated to
-// Pulp's needs (per CLAUDE.md "pattern lift, no vendoring").
+// Pulp's needs.
 export function hashCodeAsString(input: unknown): string {
     const str = stableStringify(input);
     // FNV-1a 32-bit. Fast, stable, low collision rate at the scale we
@@ -224,7 +224,7 @@ function countSiblingTags(
     return counter;
 }
 
-// Default per-source strategy, per §4.4 of the spec.
+// Default per-source strategy.
 export const DEFAULT_ANCHOR_STRATEGY: Record<string, AnchorStrategy> = {
     'figma-mcp': 'adapter',
     'figma-zip': 'adapter',

--- a/packages/pulp-import-ir/src/diff.ts
+++ b/packages/pulp-import-ir/src/diff.ts
@@ -1,7 +1,7 @@
-// pulp #1486 — Drift diff (§7 of the spec).
+// Drift diff.
 //
 // Compares two IR trees produced by the SAME adapter and emits a flat
-// list of Drift entries keyed by stable_anchor_id. Phase 1 supports:
+// list of Drift entries keyed by stable_anchor_id. Supported kinds:
 //   - added / removed / changed / reordered
 //   - orphaned-tweak (carried over from applyTweaks's meta.orphaned_tweaks)
 //
@@ -135,6 +135,6 @@ function shallowEqual(a: unknown, b: unknown): boolean {
     if (a == null || b == null) return false;
     if (typeof a !== typeof b) return false;
     // For arrays / objects we go deep via JSON — values in the IR are
-    // either primitives or POJOs; this is a fine spike-quality check.
+    // either primitives or POJOs.
     return JSON.stringify(a) === JSON.stringify(b);
 }

--- a/packages/pulp-import-ir/src/index.ts
+++ b/packages/pulp-import-ir/src/index.ts
@@ -1,10 +1,9 @@
-// pulp #1486 — public surface for @pulp/import-ir.
+// Public surface for @pulp/import-ir.
 //
-// Phase 1 spike: types + content-hash anchors + Claude Design HTML
-// adapter + tweaks layer + JSX-like tree map. CLI integration
-// (`pulp import design path/x.html`) lives downstream; this package
-// stays renderer-agnostic so adapters (Figma MCP, Pencil, Mitosis, …)
-// can land independently against the same IR contract.
+// Exposes the typed IR, content-hash anchors, Claude Design HTML adapter,
+// tweaks layer, diffing, and JSX-like tree map. The package stays
+// renderer-agnostic so adapters (Figma MCP, Pencil, Mitosis, etc.) can
+// share the same IR contract.
 
 export * from './types.js';
 export {

--- a/packages/pulp-import-ir/src/lower-via-prop-applier.ts
+++ b/packages/pulp-import-ir/src/lower-via-prop-applier.ts
@@ -1,14 +1,10 @@
-// pulp #1486 — IR → JSX-equivalent intrinsics → @pulp/react prop-applier
-// dispatch (§10 Q7 of the spec, user-locked decision: duplicative-but-safe
-// route through the well-tested code path).
+// IR → JSX-equivalent intrinsics → @pulp/react prop-applier dispatch.
 //
-// Phase 1 spike: this is the SKELETON. The real wiring lives in the
-// CLI's `pulp import design` flow and uses @pulp/react's React
-// renderer. This file isolates the IR → React-tree translation so
-// downstream consumers (CLI / tests) don't have to know the IR shape.
+// This file isolates the IR → React-tree translation so renderers and tests
+// can consume a stable JSX-like tree without depending on the raw IR shape.
 //
 // The translation is a pure tree map: each IRNode becomes a `{ tag,
-// props, children }` shape that a downstream renderer can feed into
+// props, children }` shape that a renderer can feed into
 // `React.createElement` (or any equivalent tree-builder). Returning a
 // concrete JSX-equivalent shape rather than React elements lets the
 // IR package stay decoupled from a specific React version.
@@ -38,8 +34,8 @@ export interface JSXLikeNode {
  *   - text leaf content becomes the `text` prop on Label / Button.
  *   - children recurse.
  *   - meta.role becomes a data-pulp-role marker on the props map for
- *     diagnostics; non-mappable IR fields ride through unchanged so a
- *     future renderer iteration can pick them up.
+ *     diagnostics; non-mappable IR fields ride through unchanged for
+ *     renderer-specific handling.
  */
 export function toJSXLikeTree(node: IRNode): JSXLikeNode {
     const props: Record<string, unknown> = {};

--- a/packages/pulp-import-ir/src/tweaks.ts
+++ b/packages/pulp-import-ir/src/tweaks.ts
@@ -1,4 +1,4 @@
-// pulp #1486 — Tweaks layer (§7, §8 of the spec).
+// Tweaks layer.
 //
 // Reads `pulp-tweaks.json` from disk, applies dev overrides on top of
 // a freshly-lowered IRNode tree. Pure functions — no side effects.
@@ -68,12 +68,12 @@ function applyTweakValue(node: IRNode, tweak: TweakValue): IRNode {
 
 /**
  * Set a dotted-path field on an IRNode without mutating the original.
- * Phase 1 supports flat paths into typed top-level fields:
+ * Supports flat paths into typed top-level fields:
  *   'paint.backgroundColor'
  *   'text.fontSize'
  *   'layout.padding'
  *   'meta.role'
- * `null` value clears the field (deletion semantics per §8.3).
+ * `null` value clears the field.
  */
 export function setByDottedPath(node: IRNode, path: string, value: unknown): IRNode {
     const segments = path.split('.');
@@ -100,10 +100,10 @@ export function setByDottedPath(node: IRNode, path: string, value: unknown): IRN
     } as IRNode;
 }
 
-// ── File I/O — narrow API surface for the spike ──────────────────────
+// ── File I/O ─────────────────────────────────────────────────────────
 //
-// Phase 1 keeps fs access optional so the IR core stays browser-loadable.
-// CLI integration (pulp import design ...) will inject the fs hook.
+// fs access stays optional so the IR core remains browser-loadable. Callers
+// inject the fs hook when they need disk-backed tweaks.
 
 export interface TweaksIO {
     readTweaks(filePath: string): Promise<TweaksFile | null>;

--- a/packages/pulp-import-ir/src/types.ts
+++ b/packages/pulp-import-ir/src/types.ts
@@ -1,16 +1,12 @@
-// pulp #1486 — Pulp design-import IR (Phase 1 spike).
+// Pulp design-import IR.
 //
 // IRNode is the typed intermediate representation that survives source
 // re-import. Adapters lower source formats (Figma / Mitosis / Claude
 // Design HTML / etc.) into IRNode trees keyed by `stable_anchor_id`;
 // the tweaks layer (`pulp-tweaks.json`) is keyed by the same anchors,
 // so dev overrides survive when the designer regenerates the source.
-//
-// Spec: /tmp/pulp-ir-spec-spike.md (sub-agent #25 draft).
-// Phase 1: types + Claude Design HTML adapter (content-hash anchors)
-// + tweaks read/write + 5-scenario harness.
 
-// ── Value types (§1.1, §2.1) ──────────────────────────────────────────
+// ── Value types ───────────────────────────────────────────────────────
 
 export type TokenRef = `{${string}}`;
 
@@ -28,7 +24,7 @@ export type Color = string | TokenRef;
 export type Pixels = number | TokenRef;
 export type NumberRef = number | TokenRef;
 
-// ── TypedLayout (§1.2) ────────────────────────────────────────────────
+// ── TypedLayout ───────────────────────────────────────────────────────
 
 export interface TypedLayout {
     display?: 'flex' | 'none' | 'contents' | 'block' | 'inline-flex' | string;
@@ -90,7 +86,7 @@ export interface TypedLayout {
     overflowY?: 'visible' | 'hidden' | 'scroll' | 'auto';
 }
 
-// ── TypedPaint (§2.2) ─────────────────────────────────────────────────
+// ── TypedPaint ────────────────────────────────────────────────────────
 
 export interface Gradient {
     type: 'linear' | 'radial' | 'conic';
@@ -171,7 +167,7 @@ export interface TypedPaint {
     cursor?: 'default' | 'pointer' | 'text' | 'crosshair' | 'grab' | 'grabbing' | 'not-allowed';
 }
 
-// ── TypedText (§3) ────────────────────────────────────────────────────
+// ── TypedText ─────────────────────────────────────────────────────────
 
 export interface TypedText {
     fontFamily?: string | TokenRef;
@@ -198,7 +194,7 @@ export interface TypedText {
     text?: string;
 }
 
-// ── raw_source (§5) ──────────────────────────────────────────────────
+// ── raw_source ────────────────────────────────────────────────────────
 
 export type SourceFormat =
     | { kind: 'figma-reconstruction'; spec: unknown }
@@ -212,7 +208,7 @@ export type SourceFormat =
     | { kind: 'rn-file'; jsxText: string }
     | { kind: 'unknown'; payload: unknown };
 
-// ── provenance (§6) ──────────────────────────────────────────────────
+// ── provenance ────────────────────────────────────────────────────────
 
 export interface IRProvenance {
     adapter: string;
@@ -228,7 +224,7 @@ export interface IRProvenance {
     source_commit?: string;
 }
 
-// ── confidence (§7.2) ────────────────────────────────────────────────
+// ── confidence ────────────────────────────────────────────────────────
 
 export type Confidence = 'PASS' | 'DIVERGE' | 'NOT_IMPL';
 
@@ -272,7 +268,7 @@ export interface IRNode {
     confidence: Confidence;
 }
 
-// ── Adapter contract (§7) ────────────────────────────────────────────
+// ── Adapter contract ─────────────────────────────────────────────────
 
 export type AnchorStrategy = 'adapter' | 'content-hash' | 'path';
 
@@ -303,7 +299,7 @@ export interface SourceAdapter<R = unknown> {
     applyTweaks(node: IRNode, tweaks: TweaksFile): IRNode;
 }
 
-// ── Tweaks layer (§8) ────────────────────────────────────────────────
+// ── Tweaks layer ─────────────────────────────────────────────────────
 
 export interface TweaksFile {
     $schema?: string;
@@ -319,7 +315,7 @@ export type TweakValue = {
     [path: string]: unknown;
 };
 
-// ── DTCG token tree (§10 Q3 — post-lowering resolution) ──────────────
+// ── DTCG token tree ──────────────────────────────────────────────────
 
 export interface DTCGTokenTree {
     /** Recursive token map. Leaves carry `$value` per DTCG spec. */

--- a/packages/pulp-import-ir/test/anchors.test.ts
+++ b/packages/pulp-import-ir/test/anchors.test.ts
@@ -1,4 +1,4 @@
-// pulp #1486 — anchor strategy unit tests.
+// Anchor strategy unit tests.
 
 import { describe, it, expect } from 'vitest';
 import { hashCodeAsString, generateAnchorId, assignAnchors } from '../src/anchors.js';
@@ -139,14 +139,12 @@ describe('assignAnchors', () => {
         expect(childAnchors[2]).toBe('View[0]/Button[2]');
     });
 
-    // pulp #1499 follow-up — Codex P1: duplicate-sibling content-hash
-    // collision. Two siblings with identical {tag, role, text} (and
-    // therefore identical depth) used to produce the same anchor,
-    // which silently broke tweak routing and made `diff()` lossy.
+    // Duplicate siblings with identical {tag, role, text} and depth need
+    // distinct content-hash anchors so tweak routing and diff() remain lossless.
     // The discriminator is the Nth occurrence of the same signature
     // among earlier siblings — stable across re-imports of the same
     // source HTML, distinct for each duplicate.
-    it('content-hash disambiguates duplicate siblings (#1499 follow-up)', () => {
+    it('content-hash disambiguates duplicate siblings', () => {
         const root = {
             tag: 'View',
             children: [

--- a/packages/pulp-import-ir/test/build-output.test.ts
+++ b/packages/pulp-import-ir/test/build-output.test.ts
@@ -1,12 +1,8 @@
-// pulp #1499 follow-up — Codex P2: the package's `exports` map points
-// `import` to `./dist/index.mjs`, but the original `build` script only
-// ran `tsc` (which emits `.js`, not `.mjs`). Consumers importing
-// @pulp/import-ir through package exports failed at runtime with a
-// missing-module error.
+// The package's `exports` map points `import` to `./dist/index.mjs`, so
+// the build must emit an ESM bundle alongside tsc's CommonJS-shaped output.
 //
-// The fix extends the build script to also produce dist/index.mjs via
-// esbuild. This test guards against the build script regressing — if
-// dist/index.mjs disappears, downstream ESM consumers break silently
+// This test guards against the build script regressing — if
+// dist/index.mjs disappears, ESM consumers break silently
 // at runtime.
 //
 // The test runs after `pnpm build`. CI invokes `pnpm build && pnpm
@@ -21,7 +17,7 @@ const distMjs = resolve(__dirname, '..', 'dist', 'index.mjs');
 const distJs = resolve(__dirname, '..', 'dist', 'index.js');
 const distDts = resolve(__dirname, '..', 'dist', 'index.d.ts');
 
-describe('@pulp/import-ir build output (#1499 follow-up)', () => {
+describe('@pulp/import-ir build output', () => {
     it('emits dist/index.mjs that the package exports map references', () => {
         expect(existsSync(distMjs)).toBe(true);
         const st = statSync(distMjs);

--- a/packages/pulp-import-ir/test/diff.test.ts
+++ b/packages/pulp-import-ir/test/diff.test.ts
@@ -1,4 +1,4 @@
-// pulp #1486 — diff() unit tests.
+// diff() unit tests.
 
 import { describe, it, expect } from 'vitest';
 import { diff } from '../src/diff.js';

--- a/packages/pulp-import-ir/test/lower.test.ts
+++ b/packages/pulp-import-ir/test/lower.test.ts
@@ -1,21 +1,16 @@
-// pulp #1499 follow-up — Codex P1: lowerClaudeDesignHtml infinite loop
-// when `preserveRawSource: false`. parseFragment used to compute parser
-// advance from `node.rawHtml.length`, but `makeNode` deliberately
-// stores `rawHtml: ''` in non-preserve mode; consumed length became 0
-// and the cursor never moved on tag-shaped input. The fix tracks the
-// consumed outer-tag length independently of whether `rawHtml` is
-// retained on the BuildNode.
+// lowerClaudeDesignHtml must track consumed outer-tag length independently
+// of whether `rawHtml` is retained on the BuildNode. In non-preserve mode
+// `makeNode` stores `rawHtml: ''`, so parser progress cannot depend on
+// `node.rawHtml.length`.
 
 import { describe, it, expect } from 'vitest';
 import { lowerClaudeDesignHtml } from '../src/adapters/claude-design-html/lower.js';
 
-describe('lowerClaudeDesignHtml — preserveRawSource: false (#1499 follow-up)', () => {
+describe('lowerClaudeDesignHtml — preserveRawSource: false', () => {
     it('terminates on a multi-child fragment without preserving raw source', async () => {
-        // The pre-fix behavior was an infinite loop on this exact
-        // shape (root wraps multiple <div>s and parseFragment walks
-        // them one at a time). If this regresses, vitest's
-        // per-test timeout will fail the suite hard rather than
-        // hanging indefinitely.
+        // This shape can hang if parser progress is tied to retained rawHtml.
+        // If it regresses, vitest's per-test timeout fails the suite hard
+        // rather than hanging indefinitely.
         const html = `<div><span>one</span><span>two</span></div>`;
         const ir = await Promise.race([
             lowerClaudeDesignHtml(html, { preserveRawSource: false }),
@@ -30,10 +25,9 @@ describe('lowerClaudeDesignHtml — preserveRawSource: false (#1499 follow-up)',
 
     it('terminates on a multi-root fragment when raw source is dropped', async () => {
         // Multi-root path: the synthetic-wrapper-View case forces
-        // parseFragment to drive the loop directly, which is the
-        // surface the original infinite-loop bug bit on. We use
-        // different opening and closing tags so matchSingleOuterTag
-        // does NOT collapse the input into a single root.
+        // parseFragment to drive the loop directly. We use different
+        // opening and closing tags so matchSingleOuterTag does NOT collapse
+        // the input into a single root.
         const html = `<header>a</header><section>b</section><footer>c</footer>`;
         const ir = await Promise.race([
             lowerClaudeDesignHtml(html, { preserveRawSource: false }),

--- a/packages/pulp-import-ir/test/scenarios/scenarios.test.ts
+++ b/packages/pulp-import-ir/test/scenarios/scenarios.test.ts
@@ -1,4 +1,4 @@
-// pulp #1486 — 5-scenario validation harness (§4 of the spec).
+// 5-scenario validation harness.
 //
 //   S1 Pure regen, no source change                  → tweaks survive
 //   S2 Designer changed colors, structure preserved  → tweaks survive
@@ -6,9 +6,8 @@
 //   S4 Designer deleted a tweaked section            → drift flags orphaned tweak
 //   S5 Designer reordered sections                   → content-hash strategy survives
 //
-// Acceptance for the Phase 1 spike: 4 of 5 pass. (S5 with content-hash
-// is expected to pass because the hash is depth+text-driven, not
-// path-driven.)
+// S5 with content-hash is expected to pass because the hash is
+// depth+text-driven, not path-driven.
 
 import { describe, it, expect } from 'vitest';
 import {
@@ -20,7 +19,7 @@ import {
     type IRNode,
 } from '../../src/index.js';
 
-// Minimal HTML fixtures. Phase 1's adapter handles inline `style`
+// Minimal HTML fixtures. The adapter handles inline `style`
 // attributes — these fixtures exercise the typed paint / text fields.
 const HOMEPAGE_V1 = `
 <div>
@@ -223,7 +222,7 @@ describe('S5 — Designer reordered sections', () => {
 
 // ── Acceptance summary ───────────────────────────────────────────────
 
-describe('Phase 1 acceptance — 4-of-5 scenarios pass', () => {
+describe('scenario harness smoke', () => {
     it('all five scenarios run without throwing', async () => {
         // Smoke check the harness itself: every scenario completes.
         await lowerClaudeDesignHtml(HOMEPAGE_V1);

--- a/packages/pulp-import-ir/test/tweaks.test.ts
+++ b/packages/pulp-import-ir/test/tweaks.test.ts
@@ -1,4 +1,4 @@
-// pulp #1486 — tweaks layer unit tests.
+// Tweaks layer unit tests.
 
 import { describe, it, expect } from 'vitest';
 import {


### PR DESCRIPTION
## Summary
- remove stale issue/spec/phase/spike breadcrumbs from `@pulp/import-ir` docs, headers, and test labels
- preserve durable adapter/source-format rationale while tightening comments to current behavior
- correct the anchor strategy header so it matches the implemented sibling discriminator and path-anchor format
- fix the HostBench AU v2 descriptor test to read package source files from the configured source directory instead of relying on CI-dependent `__FILE__` expansion

## Validation
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py --mode=report --all packages/pulp-import-ir`
- stale-token scan over `packages/pulp-import-ir` for issue/spec/phase/spike breadcrumbs: no hits
- `npm run build` in `packages/pulp-import-ir`
- `npm test` in `packages/pulp-import-ir` (40 tests)
- `cmake --build build-hostbench-ci-fix --target pulp-host-bench-test -j$(sysctl -n hw.ncpu)`
- `./build-hostbench-ci-fix/examples/host-bench-plugin/pulp-host-bench-test "HostBench AU v2 package matches MIDI descriptor"`
- `python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`
- `python3 tools/scripts/docs_sync_check.py --base origin/main --mode=report`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`
- `python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report --enforce`
- `python3 tools/scripts/hotspot_size_guard.py --base origin/main --config tools/scripts/hotspot_size_guard.json --mode=report`
- RepoPrompt adversarial review; accepted/fixed findings in `anchors.ts`, `types.ts`, and the HostBench macro guard
- `$HOME/.agents/skills/autoreview/scripts/autoreview --mode local --reviewers codex,claude` (clean)
- pre-push gates clean

Note: local `npm install --no-package-lock` reported existing dependency audit findings in this package dependency set; this PR does not change dependency ranges.