### PR TITLE
chore(source): batch comment hygiene and benchmark cleanup

### DIFF
--- a/core/audio/platform/linux/alsa_device.cpp
+++ b/core/audio/platform/linux/alsa_device.cpp
@@ -305,7 +305,7 @@ namespace {
 // Probe an ALSA device for its real per-direction channel maximum by
 // briefly opening it in non-blocking mode and reading hw_params. Falls
 // back to 0 if the device can't be probed (busy, missing, no support
-// for that direction). #20 — replaces the hardcoded `2` placeholder.
+// for that direction), instead of reporting a placeholder channel count.
 unsigned probe_max_channels(const std::string& id, snd_pcm_stream_t stream) {
     snd_pcm_t* pcm = nullptr;
     if (snd_pcm_open(&pcm, id.c_str(), stream, SND_PCM_NONBLOCK) < 0) {

--- a/core/canvas/src/svg.cpp
+++ b/core/canvas/src/svg.cpp
@@ -89,9 +89,9 @@ void SvgImage::render(Canvas& canvas, float x, float y, float w, float h) const 
     canvas.translate(x, y);
     canvas.scale(scale, scale);
 
-    // pulp #72 — render fills + cubic Bezier curves via Canvas's path API
-    // instead of approximating each path as straight lines between control
-    // handles. The previous implementation:
+    // Render fills and cubic Bezier curves via Canvas's path API instead
+    // of approximating each path as straight lines between control handles.
+    // The previous implementation:
     //   for (i = 0; i < npts - 1; i += 3)
     //       stroke_line(pts[i*2], pts[i*2+1], pts[(i+3)*2], pts[(i+3)*2+1])
     // had two latent bugs that surfaced as "preset preview blank":
@@ -149,10 +149,9 @@ void SvgImage::render(Canvas& canvas, float x, float y, float w, float h) const 
         }
 
         if (has_fill) {
-            // Codex review on PR #2011 — honor `fill-rule="evenodd"`
-            // so SVGs with cutouts/holes (a common preset-thumbnail
-            // pattern) render correctly. nanosvg exposes the rule on
-            // the shape; default in SVG is nonzero.
+            // Honor `fill-rule="evenodd"` so SVGs with cutouts or holes
+            // (a common preset-thumbnail pattern) render correctly. nanosvg
+            // exposes the rule on the shape; default in SVG is nonzero.
             FillRule rule = (shape->fillRule == NSVG_FILLRULE_EVENODD)
                 ? FillRule::evenodd
                 : FillRule::nonzero;

--- a/examples/design-tool/design-tool-chat.js
+++ b/examples/design-tool/design-tool-chat.js
@@ -1,4 +1,4 @@
-// Issue 2: image upload via file dialog
+// Image upload via file dialog
 var uploadedImagePath = "";
 var uploadedImageName = "";
 var REFERENCE_IMAGE_EXTENSIONS = "png;jpg;jpeg;gif;webp;bmp;tif;tiff;heic;heif";
@@ -202,7 +202,7 @@ function buildChatControlsAndToast() {
         updateChatInputSizing(text);
     });
 
-    // #49: Send button with proper icon sizing
+    // Send button with proper icon sizing
     createCol("send-btn", "chat-input-row");
     setFlex("send-btn", "width", 32);
     setFlex("send-btn", "height", 32);
@@ -219,7 +219,7 @@ function buildChatControlsAndToast() {
     setFlex("send-cancel-icon", "height", 14);
     setPointerEvents("send-cancel-icon", "none");
     setVisible("send-cancel-icon", false);
-    // Issue 3: hover state for send button
+    // Hover state for send button
     registerHover("send-btn");
     on("send-btn", "mouseenter", function() {
         if (chatRequestPending) {
@@ -252,7 +252,7 @@ function buildChatControlsAndToast() {
     createLabel("status-schema", "pulp-theme/v1", "status-bar");
 
     // ═══════════════════════════════════════════════════════════════════
-    // D7: Toast notification system
+    // Toast notification system
     // ═══════════════════════════════════════════════════════════════════
     createCol("toast-overlay", "");
     setPosition("toast-overlay", "absolute");
@@ -459,7 +459,7 @@ styleStatusSchema();
 // ═══════════════════════════════════════════════════════════════════
 // Inspector: Cmd+click detection
 // ═══════════════════════════════════════════════════════════════════
-// Issue 6: Cmd+click inspector with chat context scoping
+// Cmd+click inspector with chat context scoping
 var inspectedComponent = null;
 
 function clearInspectedComponent() {
@@ -591,7 +591,7 @@ wireInspectorAndGlobalKeys();
 // Chat logic
 // ═══════════════════════════════════════════════════════════════════
 
-// Issue 8: Track cumulative chat height for proper scroll sizing
+// Track cumulative chat height for proper scroll sizing
 var chatTotalHeight = 62; // welcome + hint + gap baseline
 var chatTypingVisible = false;
 var chatTypingPhase = 0;
@@ -720,16 +720,16 @@ function addChatMessage(role, text) {
     var hasRestore = (role === "assistant");
     chatHistory.push({ role: role, text: text });
 
-    // Issue 8: Better height estimation — wider chars-per-line for 230px width
+    // Better height estimation: wider chars-per-line for 230px width
     var charsPerLine = 25;
     var lineCount = Math.max(1, Math.ceil(text.length / charsPerLine));
     var msgHeight = 16 + lineCount * 16 + (hasRestore ? 24 : 0) + 20;
 
     createCol(id, "chat-thread");
     setFlex(id, "height", msgHeight);
-    setFlex(id, "flex_shrink", 0);  // Issue 8: prevent squishing
+    setFlex(id, "flex_shrink", 0);  // Prevent squishing
     setFlex(id, "padding", 10);
-    setFlex(id, "padding_right", 16);  // Issue 8: clear scrollbar
+    setFlex(id, "padding_right", 16);  // Clear scrollbar
     setFlex(id, "gap", 4);
     setBorder(id, APP_BORDER, 1, 8);
     if (role === "user") {
@@ -766,7 +766,7 @@ function addChatMessage(role, text) {
         })(snapshot, restoreId);
     }
 
-    // Issue 1: multi-line label for wrapping
+    // Multi-line label for wrapping
     createLabel(id + "-text", text, id);
     setFontSize(id + "-text", 12);
     setFlex(id + "-text", "flex_grow", 1);
@@ -1998,8 +1998,7 @@ wireChatInputAndPresetSelector();
 // ═══════════════════════════════════════════════════════════════════
 // Export/Import buttons
 // ═══════════════════════════════════════════════════════════════════
-// D4: Multi-format export
-// #57: expanded export formats including W3C tokens and style preset payloads
+// Multi-format export, including W3C tokens and style preset payloads
 var exportFormats = ["JSON", "CSS Vars", "OKLCH", "C++ Header", "C++ Palette", "W3C Tokens", "Style Preset"];
 var activeExportFormat = 0;
 var exportPopupOpen = false;

--- a/examples/design-tool/design-tool-palette.js
+++ b/examples/design-tool/design-tool-palette.js
@@ -1028,7 +1028,7 @@ function buildOppositeModeButton() {
 }
 buildOppositeModeButton();
 
-// #60: Save/Load palette buttons
+// Save/Load palette buttons
 function serializePaletteConfiguration() {
     return JSON.stringify({
         title: getText("theme-name-label"),

--- a/examples/design-tool/design-tool-popup.js
+++ b/examples/design-tool/design-tool-popup.js
@@ -1,6 +1,6 @@
 
 // ═══════════════════════════════════════════════════════════════════
-// D1: Token Palette Picker Popup
+// Token Palette Picker Popup
 // ═══════════════════════════════════════════════════════════════════
 var TOKEN_POPUP_W = 280;
 
@@ -158,7 +158,7 @@ function buildTokenPopupControls() {
         closeTokenPopup();
     });
 
-    // #62: Token alpha (opacity) fader
+    // Token alpha (opacity) fader
     createRow("tp-alpha-row", "token-popup");
     setFlex("tp-alpha-row", "height", 20);
     setFlex("tp-alpha-row", "gap", 6);
@@ -242,7 +242,7 @@ function buildTokenPopupCustomToggle() {
 }
 buildTokenPopupCustomToggle();
 
-// D2: Gamut triangle canvas — rendered as grid of colored rectangles
+// Gamut triangle canvas, rendered as grid of colored rectangles
 var GAMUT_W = 50;  // columns (lightness steps)
 var GAMUT_H = 30;  // rows (chroma steps)
 var GAMUT_MAX_C = 0.4;
@@ -594,7 +594,7 @@ function updatePopupState(tokenName) {
     setValue("tp-alpha-fdr", hexAlpha(hex));
     setText("tp-alpha-val", hexAlpha(hex).toFixed(1));
     setOpacity("tp-token-modified", isTokenModified(tokenName) ? 1.0 : 0.0);
-    // D2: Sync HCL faders and gamut triangle
+    // Sync HCL faders and gamut triangle
     if (tpCustomOpen) {
         var oklch = OklchEngine.hexToOklch(hex);
         updateTokenPopupCustomUi(oklch, oklch.H, true, true);
@@ -715,7 +715,7 @@ function wireAccentHueAndSelectors() {
     createCol("center-panel", "main-area");
     setFlex("center-panel", "flex_grow", 1);
     setFlex("center-panel", "flex_shrink", 1);
-    setFlex("center-panel", "min_width", 420);  // Issue 5: prevent scrollbar behind content
+    setFlex("center-panel", "min_width", 420);  // Prevent scrollbar behind content
     setFlex("center-panel", "padding", 16);
     setFlex("center-panel", "gap", 8);
     setBackground("center-panel", APP_BG);

--- a/examples/design-tool/design-tool-preview.js
+++ b/examples/design-tool/design-tool-preview.js
@@ -326,7 +326,7 @@ function buildPreviewWaveformAndMeters() {
 }
 buildPreviewWaveformAndMeters();
 
-// D3: Card grid matching HTML reference — Empty, Loading, Ready (OK badge), Error (! badge)
+// Card grid matching HTML reference: Empty, Loading, Ready (OK badge), Error (! badge)
 var cardDefs = [
     { id: "card-1", label: "Empty", bg: APP_PANEL, border: APP_BORDER, badge: null },
     { id: "card-2", label: "Loading", bg: APP_PANEL, border: APP_BORDER, badge: null, loading: true },
@@ -926,8 +926,7 @@ function buildRightPanelChat() {
     setFlex("model-top-row", "align_items", "center");
     setFlex("model-top-row", "justify_content", "space-between");
 
-    // #51: Context badge with accent styling
-    // Chat context badge
+    // Chat context badge with accent styling
     createRow("context-badge", "model-top-row");
     setFlex("context-badge", "height", 22);
     setFlex("context-badge", "width", 136);
@@ -1063,8 +1062,7 @@ function buildRightPanelChat() {
     setFlex("chat-input-row", "flex_shrink", 0);
     setFlex("chat-input-row", "gap", 6);
 
-    // Upload button with hover state (Issue 3)
-    // #49: Upload button with proper icon sizing
+    // Upload button with hover state and proper icon sizing
     createCol("upload-btn", "chat-input-row");
     setFlex("upload-btn", "width", 32);
     setFlex("upload-btn", "height", 32);

--- a/examples/design-tool/design-tool-toolbar.js
+++ b/examples/design-tool/design-tool-toolbar.js
@@ -118,7 +118,7 @@ function buildToolbarStatePills() {
                 }
                 activeState = idx;
                 setText("status-text", "State: " + stateNames[idx]);
-                // #50: Apply state overrides to preview components
+                // Apply state overrides to preview components
                 applyStateToPreview(idx);
             });
         })(sp);
@@ -126,7 +126,7 @@ function buildToolbarStatePills() {
 }
 buildToolbarStatePills();
 
-// #50: Apply state overrides to preview components
+// Apply state overrides to preview components
 function applyStateToPreview(stateIdx) {
     // 0=Default, 1=Hover, 2=Focus, 3=Disabled, 4=Error
     // Reset all to default first
@@ -317,7 +317,7 @@ function buildToolbarActionsAndLeftPanelControls() {
     setBorder("left-panel", APP_BORDER, 1, 0);
     setScrollContentSize("left-panel", 310, 900);
 
-    // Issue 9: Color System section matching HTML reference
+    // Color System section matching HTML reference
     createCol("color-section", "left-panel");
     setFlex("color-section", "padding", 10);
     setFlex("color-section", "padding_right", 18);
@@ -330,7 +330,7 @@ function buildToolbarActionsAndLeftPanelControls() {
     setTextColor("cs-title", APP_ACCENT);
     setFlex("cs-title", "height", 14);
 
-    // #55: Template selector row
+    // Template selector row
     createRow("template-row", "color-section");
     setFlex("template-row", "height", 22);
     setFlex("template-row", "gap", 6);
@@ -347,7 +347,7 @@ function buildToolbarActionsAndLeftPanelControls() {
     setFlex("template-selector", "flex_grow", 1);
     setFlex("template-selector", "height", 22);
     setSelected("template-selector", 0);
-    // #56: ? info button
+    // Template info button
     createLabel("template-help", "?", "template-row");
     setFontSize("template-help", 10);
     setTextColor("template-help", APP_TEXT_DIM);
@@ -434,7 +434,7 @@ function buildToolbarActionsAndLeftPanelControls() {
         showHelpModal("Mode", "Dark mode maps lighter shades to text and surfaces over dark backgrounds. Light mode inverts the relationship so semantic ramps still read correctly.");
     });
 
-    // Issue 9: 5 palette rows — each with base color dot + name + 11-shade mini ramp
+    // Five palette rows, each with base color dot + name + 11-shade mini ramp
     // (shade ramps are built dynamically by buildShadeRamps below)
 
     // Hue fader (compact)
@@ -494,7 +494,7 @@ function buildToolbarActionsAndLeftPanelControls() {
 buildToolbarActionsAndLeftPanelControls();
 
 // Token groups
-// D5: Expanded token registry (50+ semantic tokens matching HTML reference)
+// Expanded token registry (50+ semantic tokens matching HTML reference)
 var tokenGroups = [
     { name: "Background", tokens: ["bg.primary", "bg.secondary", "bg.surface", "bg.elevated"] },
     { name: "Text", tokens: ["text.primary", "text.secondary", "text.disabled", "text.link"] },
@@ -653,7 +653,7 @@ function buildTokenList() {
         setFlex(gid, "padding_top", 4);
         setFlex(gid, "gap", 2);
 
-        // D7: Styled group headers — uppercase, accent colored
+        // Styled group headers: uppercase, accent colored
         createLabel(gid + "-title", group.name, gid);
         setFontSize(gid + "-title", 9);
         setTextColor(gid + "-title", APP_ACCENT);
@@ -707,7 +707,7 @@ function buildTokenList() {
             setTextColor(resetId + "-lbl", APP_TEXT_DIM);
             setPointerEvents(resetId + "-lbl", "none");
 
-            // D1: hex input field
+            // Hex input field
             var hexId = tid + "-hex";
             createTextEditor(hexId, tid);
             setPlaceholder(hexId, "#000000");
@@ -718,14 +718,14 @@ function buildTokenList() {
             setFlex(hexId, "height", 20);
             setFontSize(hexId, 10);
 
-            // D7: hover highlight on token row
+            // Hover highlight on token row
             registerHover(tid);
             (function(rowId) {
                 on(rowId, 'mouseenter', function() { setBackground(rowId, '#ffffff08'); });
                 on(rowId, 'mouseleave', function() { setBackground(rowId, 'transparent'); });
             })(tid);
 
-            // D1: click swatch → open token popup
+            // Click swatch to open token popup
             registerClick(swatchId);
             (function(tokenName, sid, gi, ti) {
                 on(sid, 'click', function() {
@@ -739,7 +739,7 @@ function buildTokenList() {
                 });
             })(group.tokens[t], resetId);
 
-            // D1: hex input → apply on Enter
+            // Hex input applies on Enter
             (function(tokenName, hid) {
                 on(hid, 'return', function(text) {
                     var hex = text.trim();

--- a/examples/threejs-native-demo/main.cpp
+++ b/examples/threejs-native-demo/main.cpp
@@ -1530,20 +1530,19 @@ std::vector<uint8_t> capture_demo_offscreen_png(DemoEnvironment& env,
 
 #ifdef PULP_BENCHMARK
 
-// ── Zero-copy benchmark mode (Slice 0.5 of #516) ────────────────────────────
+// ── Zero-copy benchmark mode ────────────────────────────────────────────────
 //
 // Drives the *real* JS→GPU upload path: Three.js BufferGeometry +
 // BufferAttribute(Float32Array, 3), with `needsUpdate = true` per
 // frame so the vertex buffer is re-uploaded via queue.WriteBuffer.
-// This exercises the upload code touched in #535 (the same code path
-// a real JS-scripted plugin UI would use), not the C++-driven
-// VisualizationBridge path. Headless: no WindowHost, offscreen Dawn
-// surface only. Emits JSON with the Slice 0 schema plus the new
-// Slice 0.5 fields (base64_decode_us, gpu_buffer_upload_count,
-// gpu_buffer_bytes_resident_peak).
+// This exercises the same upload code path a real JS-scripted plugin UI
+// would use, not the C++-driven VisualizationBridge path. Headless: no
+// WindowHost, offscreen Dawn surface only. Emits JSON with the benchmark
+// schema fields base64_decode_us, gpu_buffer_upload_count, and
+// gpu_buffer_bytes_resident_peak.
 //
-// MB-fraction is computed exactly as requested by the re-evaluation
-// plan: (base64_decode_us + gpu_upload_us) / frame_budget_us.
+// MB-fraction is computed as:
+//   (base64_decode_us + gpu_upload_us) / frame_budget_us.
 
 struct ParticleBenchmarkConfig {
     bool enabled = false;
@@ -1569,11 +1568,10 @@ std::string current_iso8601_utc_threejs() {
 }
 
 std::string current_short_sha_threejs() {
-    // Codex 2026-04-21 review on #541: MSVC's CRT exposes the pipe
-    // helpers as `_popen` / `_pclose`; bare `popen` / `pclose` are
-    // POSIX spellings that don't link on Windows. Mirror the pattern
-    // already used in tools/mcp/pulp_mcp.cpp so `PULP_BENCHMARK`-enabled
-    // Windows builds don't fail to link.
+    // MSVC's CRT exposes the pipe helpers as `_popen` / `_pclose`;
+    // bare `popen` / `pclose` are POSIX spellings that don't link on
+    // Windows. Mirror the pattern already used in tools/mcp/pulp_mcp.cpp
+    // so `PULP_BENCHMARK`-enabled Windows builds don't fail to link.
 #if defined(_WIN32)
     std::FILE* pipe = _popen("git rev-parse --short HEAD 2>NUL", "r");
 #else
@@ -1752,7 +1750,7 @@ std::string make_particle_benchmark_harness() {
 int run_particle_benchmark(const ParticleBenchmarkConfig& cfg) {
     using namespace pulp::view;
 
-    std::cout << "Pulp zero-copy particle benchmark (Slice 0.5)\n"
+    std::cout << "Pulp zero-copy particle benchmark\n"
               << "  widget:         " << cfg.widget << "\n"
               << "  particle count: " << cfg.particle_count << "\n"
               << "  seconds:        " << cfg.seconds << "\n"
@@ -1764,15 +1762,14 @@ int run_particle_benchmark(const ParticleBenchmarkConfig& cfg) {
         return 2;
     }
 
-    // Codex 2026-04-21 review on #541: this harness is particle-only for
-    // the Slice 0.5 re-eval. `--widget=<anything-else>` used to silently
-    // run the particle workload while writing the user-supplied label
-    // into the output JSON, which corrupts benchmark comparisons. Reject
-    // any unsupported value up front so baselines stay honest.
+    // This harness is particle-only. `--widget=<anything-else>` used to
+    // silently run the particle workload while writing the user-supplied
+    // label into the output JSON, which corrupts benchmark comparisons.
+    // Reject any unsupported value up front so baselines stay honest.
     if (cfg.widget != "particles") {
         std::cerr << "Unsupported --widget=\"" << cfg.widget
                   << "\"; only 'particles' is implemented in this lane.\n"
-                  << "Add a real harness before re-enabling. (Codex #541)\n";
+                  << "Add a real harness before re-enabling.\n";
         return 2;
     }
 
@@ -1783,42 +1780,6 @@ int run_particle_benchmark(const ParticleBenchmarkConfig& cfg) {
 
     const int width = 820;
     const int height = 560;
-    const auto gltf_box_url = mode == DemoMode::gltf_box ? ensure_gltf_box_asset_url() : std::string();
-
-    if (capture_path) {
-        DemoEnvironment env(static_cast<float>(width), static_cast<float>(height));
-        env.initialize_offscreen_gpu(static_cast<float>(width), static_cast<float>(height));
-        if (!env.has_native_gpu()) {
-            std::cerr << "Native Dawn adapter unavailable on this host/backend\n";
-            return 1;
-        }
-
-        if (mode != DemoMode::cube && mode != DemoMode::gltf_box) {
-            env.enable_audio_source(mode == DemoMode::reverb);
-        }
-
-        std::string error;
-        if (!load_demo(env, width, height, mode, error, particle_count, gltf_box_url)) {
-            std::cerr << error << "\n";
-            return 1;
-        }
-
-        prime_demo_frames(env, mode == DemoMode::cube ? 4 : 10);
-        env.root.layout_children();
-        std::cout << "Three.js native demo ready (" << demo_mode_name(mode) << "): "
-                  << eval_string(env.engine, "JSON.stringify(globalThis.__pulpThreeDemoState)") << "\n";
-
-        std::string capture_error;
-        const auto png = capture_demo_offscreen_png(env, width, height, capture_error);
-        if (png.empty()) {
-            std::cerr << (capture_error.empty() ? "Demo capture failed" : capture_error) << "\n";
-            return 1;
-        }
-        write_binary_file(*capture_path, png);
-        std::cout << "Captured demo frame: " << capture_path->string() << "\n";
-        return 0;
-    }
-
     DemoEnvironment env(static_cast<float>(width), static_cast<float>(height));
     env.initialize_offscreen_gpu(static_cast<float>(width), static_cast<float>(height));
     if (!env.has_native_gpu()) {
@@ -1864,7 +1825,7 @@ int run_particle_benchmark(const ParticleBenchmarkConfig& cfg) {
             "String(__pulpBenchLastResult)");
         const auto last = std::string(probe.getWithDefault<std::string_view>("?"));
         if (last != "true") {
-            std::cerr << "Benchmark harm-up upload returned '" << last
+            std::cerr << "Benchmark warm-up upload returned '" << last
                       << "' — native bridge rejected the draw payload.\n"
                       << "Build was likely configured without PULP_HAS_SKIA "
                       << "(check CMake: SKIA_DIR must point to a complete Skia tree).\n";
@@ -1928,7 +1889,7 @@ int run_particle_benchmark(const ParticleBenchmarkConfig& cfg) {
     per_upload_us.addMember("bytes_avg",
                             snap.cpu_to_gpu_bytes_total / u);
 
-    // MB-fraction per the re-evaluation plan:
+    // MB-fraction:
     //   (base64_decode_us + gpu_upload_us) / frame_budget_us
     // where the us values are per-frame averages.
     const double per_frame_decode_us = snap.base64_decode_total_us / n;
@@ -2002,7 +1963,7 @@ bool load_demo(DemoEnvironment& env, int width, int height, DemoMode mode,
     // frame clock (normally driven by the windowed NSTimer/run_event_loop) never
     // ticks, so any rAF registered by three.webgpu.js / OrbitControls during the
     // `await renderer.init()` chain never fires and the module promise stays
-    // pending. Fixes #542.
+    // pending.
     for (int i = 0; i < 1024; ++i) {
         env.advance_sources(1.0f / 60.0f);
         if (env.bridge) env.bridge->service_frame_callbacks();
@@ -2022,9 +1983,8 @@ bool load_demo(DemoEnvironment& env, int width, int height, DemoMode mode,
     // `service_frame_callbacks()` here — rAF self-rearms, so draining
     // frames would render 64 real frames of animation before `load_demo`
     // returns, skewing initial capture state (frame counter, scene age).
-    // Codex 2026-04-21 review on #553. The hang itself is fixed by the
-    // bounded service_frame_callbacks pump above (#542), not by this
-    // drain.
+    // The hang itself is fixed by the bounded service_frame_callbacks pump
+    // above, not by this drain.
     for (int i = 0; i < 64; ++i) {
         env.engine.pump_message_loop();
     }
@@ -2050,7 +2010,7 @@ bool load_demo(DemoEnvironment& env, int width, int height, DemoMode mode,
 
 // Emit a machine-parseable identity block proving exactly which JS runtime and
 // GPU adapter this binary is actually running on. Used by the strict provider-
-// identity CTest and the #30 A/B report. Brings up a real V8 ScriptEngine and a
+// identity CTest and provider report. Brings up a real V8 ScriptEngine and a
 // real offscreen Dawn surface so every field is observed, not assumed.
 int print_engine_identity(int width, int height) {
     const bool has_v8 = is_engine_available(JsEngineType::v8);

--- a/ship/include/pulp/ship/appcast.hpp
+++ b/ship/include/pulp/ship/appcast.hpp
@@ -60,10 +60,9 @@ struct KeyPair {
 // Returns std::nullopt when signing is unavailable OR when inputs are
 // invalid (unreadable file, malformed key). Callers MUST treat nullopt
 // as a hard failure and refuse to produce an unsigned appcast. Returning
-// an empty string silently was the #295 P0 bug — it looked like a
-// successful sign to the CLI but emitted `edSignature=""` into the
-// appcast, which Sparkle then parsed as "not signed yet" while operators
-// believed they had shipped a signed update.
+// an empty string silently looks like a successful sign to the CLI but
+// emits `edSignature=""` into the appcast, which Sparkle then parses as
+// "not signed yet" while operators believe they shipped a signed update.
 std::optional<std::string> sign_file_ed25519(const std::string& file_path,
                                              const std::string& private_key_b64);
 

--- a/ship/platform/win/codesign_win.cpp
+++ b/ship/platform/win/codesign_win.cpp
@@ -41,8 +41,8 @@ bool codesign(const std::string& path, const std::string& identity,
               const std::string& entitlements) {
     (void)entitlements; // Not used on Windows
     // Reject an empty identity (or path) up front. `signtool sign /n ""` can
-    // otherwise latch onto an unintended cert or appear to no-op "successfully"
-    // — the #295 lesson: never emit an unusable/empty signature silently.
+    // otherwise latch onto an unintended cert or appear to no-op "successfully";
+    // never emit an unusable or empty signature silently.
     if (identity.empty() || path.empty()) return false;
 
     std::string cmd = "signtool sign /n \"" + identity + "\" /t http://timestamp.digicert.com"

--- a/ship/src/appcast.cpp
+++ b/ship/src/appcast.cpp
@@ -183,11 +183,10 @@ int compare_versions(const std::string& a, const std::string& b) {
 //   - unreadable file
 //   - private key that decodes to neither 32 nor 64 bytes
 //   - any signing-call failure
-// Callers MUST treat nullopt as a hard failure (#295). Earlier
-// behaviour wrote an empty `edSignature=""` into the appcast and
-// logged success — Sparkle then parsed the unsigned release as
-// "not signed yet" while operators believed they had shipped a
-// signed update. Tracking issue is the same #295.
+// Callers MUST treat nullopt as a hard failure. Earlier behaviour wrote
+// an empty `edSignature=""` into the appcast and logged success; Sparkle
+// then parsed the unsigned release as "not signed yet" while operators
+// believed they had shipped a signed update.
 
 namespace {
 

--- a/tools/screenshot/pulp_screenshot.cpp
+++ b/tools/screenshot/pulp_screenshot.cpp
@@ -18,7 +18,7 @@
 using namespace pulp::view;
 using namespace pulp::state;
 
-// pulp #1899 — viewport reconciliation for runtime-imported content.
+// Viewport reconciliation for runtime-imported content.
 //
 // Imports (Spectr, v0.dev, Stitch, Figma exports) routinely ship a
 // top-level container with literal-CSS hardcoded dimensions that
@@ -120,10 +120,7 @@ static ScreenshotCliOptions parse_options(int argc, char* argv[]) {
     // `--scale` arguments, which throw on malformed input. Without this
     // pre-scan, a command like `pulp-screenshot --width foo --help`
     // would throw before reaching the help check and exit non-zero
-    // instead of printing usage with exit code 0. Regression:
-    // #2956 / Codex comment 3304939247 (resurfaced after #2957's
-    // partial fix moved the flag-set into the loop without breaking
-    // out of it).
+    // instead of printing usage with exit code 0.
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
         if (arg == "--help" || arg == "-h") {
@@ -151,12 +148,11 @@ static ScreenshotCliOptions parse_options(int argc, char* argv[]) {
 }
 
 static bool normalize_backend(ScreenshotCliOptions& options) {
-    // pulp #1919 (Codex P2) — only default to Skia when the build
-    // actually compiled it in. Otherwise the CLI would report
-    // `backend=skia` while silently producing CoreGraphics output.
-    // We defer the warning until after argument parsing so that an
-    // explicit `--backend coregraphics` doesn't print a spurious
-    // "falling back" line.
+    // Only default to Skia when the build actually compiled it in.
+    // Otherwise the CLI would report `backend=skia` while silently
+    // producing CoreGraphics output. We defer the warning until after
+    // argument parsing so that an explicit `--backend coregraphics`
+    // doesn't print a spurious "falling back" line.
 #ifdef PULP_HAS_SKIA
     constexpr bool kHasSkia = true;
 #else
@@ -410,13 +406,12 @@ int main(int argc, char* argv[]) {
     auto options = parse_options(argc, argv);
     if (options.help) { print_usage(); return 0; }
 
-    // pulp #1919 (Codex P2) — refuse a silent downgrade. If the caller
-    // explicitly asked for Skia but Skia isn't compiled in, fail loudly
-    // with exit code 2 so CI / harness diffs catch the mismatch instead
-    // of comparing CoreGraphics output against a Skia baseline.
-    // TODO: pin in #1919 test — add CLI-shellout test covering both the
-    // "no PULP_HAS_SKIA, default" warning path and the explicit-skia
-    // exit-code-2 error path.
+    // Refuse a silent downgrade. If the caller explicitly asked for Skia
+    // but Skia isn't compiled in, fail loudly with exit code 2 so CI and
+    // harness diffs catch the mismatch instead of comparing CoreGraphics
+    // output against a Skia baseline.
+    // TODO: add CLI-shellout coverage for both the default warning path
+    // when Skia is absent and the explicit-skia exit-code-2 error path.
     if (!normalize_backend(options)) return 2;
 
     ScreenshotBackend backend = ScreenshotBackend::skia;
@@ -451,8 +446,8 @@ int main(int argc, char* argv[]) {
     else if (options.theme_name == "pro_audio") root.set_theme(Theme::pro_audio());
     else root.set_theme(Theme::dark());
 
-    // pulp #1899 — apply --width/--height to the root's bounds BEFORE
-    // any script runs. Without this, root.local_bounds() is (0,0,0,0)
+    // Apply --width/--height to the root's bounds BEFORE any script runs.
+    // Without this, root.local_bounds() is (0,0,0,0)
     // when yoga_layout reads it; YGNodeStyleSetWidth/Height(root) then
     // gets 0, and every position:absolute + inset:0 child computes to
     // 0×0 — blanking any chain of absolute-positioned containers (the
@@ -472,8 +467,8 @@ int main(int argc, char* argv[]) {
     ScriptEngine engine;
     WidgetBridge bridge(engine, root, store);
 
-    // pulp #1899 — install runtime-import handlers so React-imported
-    // trees (Spectr's editor.js et al.) can register & drain useEffect /
+    // Install runtime-import handlers so React-imported trees (Spectr's
+    // editor.js et al.) can register & drain useEffect /
     // requestAnimationFrame / setTimeout callbacks. These are registered
     // conditionally because plain createKnob / createFader scripts don't
     // need them. Always install in pulp-screenshot since the tool's
@@ -509,20 +504,19 @@ int main(int argc, char* argv[]) {
         }
         bridge.load_script(code);
 
-        // pulp #1899 — after React mount, reconcile any oversize
-        // absolute descendants with the viewport so bottom-anchored
-        // content lands within the captured frame. No-op when content
-        // fits. Walks the entire subtree, not just direct children of
-        // root_, because runtime-import adapters (Spectr's dom-adapter
-        // at tsx:440-441) propagate the hardcoded oversize through
-        // multiple intermediate wrappers.
+        // After React mount, reconcile any oversize absolute descendants
+        // with the viewport so bottom-anchored content lands within the
+        // captured frame. No-op when content fits. Walks the entire
+        // subtree, not just direct children of root_, because
+        // runtime-import adapters (Spectr's dom-adapter at tsx:440-441)
+        // propagate the hardcoded oversize through multiple wrappers.
         pulp::view::reconcile_oversize_absolute_subtree(root, options.width, options.height);
     }
 
-    // pulp #1899 — drain React's useEffect callbacks, requestAnimationFrame
-    // queue, and setTimeout/setInterval timers BEFORE rendering. Without
-    // this, headless captures of React-imported trees show only what
-    // mounts synchronously — any drawing that lives inside useEffect
+    // Drain React's useEffect callbacks, requestAnimationFrame queue, and
+    // setTimeout/setInterval timers BEFORE rendering. Without this,
+    // headless captures of React-imported trees show only what mounts
+    // synchronously — any drawing that lives inside useEffect
     // (canvas paint, dB axis labels, frequency labels, grid lines) never
     // runs because the underlying message loop doesn't tick between
     // script-load and render. Spectr's editor uses this pattern for


### PR DESCRIPTION
## Summary
- batch source comment-hygiene cleanup across audio/canvas/design-tool/ship/screenshot/threejs demo files
- preserve technical rationale while removing stale issue/PR/Codex/date/process breadcrumbs
- clean the Three.js benchmark banner/error text and remove a benchmark-only capture block that referenced out-of-scope symbols under `PULP_BENCHMARK`

## Validation
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py --mode=report --all`
- `tools/scripts/gates.sh origin/main`
- targeted stale-breadcrumb `rg` scan over touched files
- `cmake -S . -B build-comment-hygiene-bench-tests -DPULP_BENCHMARK=ON -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=ON -DPULP_FETCHCONTENT_UPDATES_DISCONNECTED=ON`
- `cmake --build build-comment-hygiene-bench-tests --target pulp-threejs-native-demo -j8`
- RepoPrompt adversarial review: Clean
- `autoreview --mode local --reviewers codex,claude`: clean, 0 findings

## Shipyard note
Normal `shipyard pr --skip-target ubuntu --skip-target windows` was attempted twice after local gates passed. Both attempts hung before PR creation in `shipyard::pr::push_branch` (confirmed with `sample`, no PR or ship-state entry was created). The branch was pushed directly with `PULP_SKIP_DIFF_COVER=1` so the fast pre-push gates still ran; this PR is the documented manual fallback for that Shipyard tool failure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch comment cleanup across audio/canvas/design-tool/ship/screenshot to remove stale issue/PR references while keeping technical rationale. Simplifies the Three.js native benchmark by deleting a broken PNG-capture path behind `PULP_BENCHMARK` and tightening logs/errors.

- **Bug Fixes**
  - Three.js native benchmark (`PULP_BENCHMARK`): removed out-of-scope PNG capture path; cleaned banner/error text; fixed "warm-up" typo; kept particle-only harness guard.
  - General: pruned breadcrumbs and clarified comments in ALSA probe, SVG fill rules, design-tool UI, appcast/codesign, and screenshot CLI; no logic changes.

<sup>Written for commit 532d469acf8856d3608132b56fe50dc125e42f68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

