### PR TITLE
docs(source): clean widget bridge comment breadcrumbs

### DIFF
--- a/core/view/src/widget_bridge/accessibility_api.cpp
+++ b/core/view/src/widget_bridge/accessibility_api.cpp
@@ -21,8 +21,8 @@ void WidgetBridge::register_accessibility_api() {
     // NSAccessibility bridge in core/view/platform/mac/accessibility_mac.mm
     // and the cross-platform AccessibilityTree snapshot in
     // accessibility_tree.cpp). Linux AT-SPI / Windows UIA platform
-    // routing remains a separate concern (#217): the bridge entry point
-    // is platform-agnostic; JS-side authors can rely on the same surface
+    // routing remains a platform concern: the bridge entry point is
+    // platform-agnostic; JS-side authors can rely on the same surface
     // on every platform and the storage round-trips through getAttribute
     // either way.
     //
@@ -78,11 +78,10 @@ void WidgetBridge::register_accessibility_api() {
         return choc::value::Value();
     });
 
-    // pulp #1737 - ARIA state attributes (aria-pressed / aria-checked /
-    // aria-disabled / aria-hidden). Tri-state per ARIA 1.2: `true` /
+    // ARIA state attributes (aria-pressed / aria-checked / aria-disabled /
+    // aria-hidden). Tri-state per ARIA 1.2: `true` /
     // `false` / `mixed` / unset. We store the raw string the JS shim
-    // hands us so platform AT bridges (NSAccessibility today; AT-SPI /
-    // UIA when those land per pulp #217) can read it back verbatim.
+    // hands us so platform AT bridges can read it back verbatim.
     // Single bridge fn rather than four; `attr` selects the slot.
     register_bridge_function(api, "setAccessibilityState",
                              [this](choc::javascript::ArgumentList args) {

--- a/core/view/src/widget_bridge/animation_api.cpp
+++ b/core/view/src/widget_bridge/animation_api.cpp
@@ -72,10 +72,9 @@ void WidgetBridge::register_animation_style_api() {
         return choc::value::Value();
     });
 
-    // pulp #1434 Phase A2-1 - setTransition(id, "opacity 200ms ease, transform 300ms").
-    // Parses the full CSS shorthand into View::transitions_. PR 2 of
-    // the ladder will hook the prop-applier dispatcher to consult
-    // these specs when a property changes. PR 1 ships parser + storage.
+    // setTransition(id, "opacity 200ms ease, transform 300ms").
+    // Parses the full CSS shorthand into View::transitions_ so property
+    // application can consult the parsed transition specs when values change.
     register_bridge_function(api, "setTransition", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto css = args.get<std::string>(1, "");
@@ -171,8 +170,8 @@ void WidgetBridge::register_animation_style_api() {
     // Applied at View paint time as a concat onto the current canvas matrix
     // so it composes with parent transforms and child Views inherit it.
     // Layout (Yoga + hit-test) sees the un-transformed bounds: paint-only.
-    // Issue-930. Companion to canvasSetTransform from PR #897 (issue-896),
-    // but applied to the View's painting frame rather than a Canvas2D context.
+    // Companion to canvasSetTransform, but applied to the View's painting
+    // frame rather than a Canvas2D context.
     register_bridge_function(api, "setTransform", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto a = static_cast<float>(args.get<double>(1, 1.0));
@@ -188,7 +187,7 @@ void WidgetBridge::register_animation_style_api() {
 
     // clearTransform(id) - drop the affine matrix; the View reverts to its
     // CSS-transform scalars (translate/rotate/scale) only. Mirrors removing
-    // the inline `transform` property in CSS. Issue-930.
+    // the inline `transform` property in CSS.
     register_bridge_function(api, "clearTransform", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto* v = id.empty() ? &root_ : widget(id);
@@ -206,16 +205,14 @@ void WidgetBridge::register_animation_style_api() {
         return choc::value::Value();
     });
 
-    // pulp #1434 Phase A2-1 - defineKeyframes(name, stops_json_string).
+    // defineKeyframes(name, stops_json_string).
     // Stops are JSON-encoded for bridge simplicity:
     //   defineKeyframes('fade', JSON.stringify([
     //     { offset: 0,   properties: { opacity: '0' } },
     //     { offset: 1.0, properties: { opacity: '1' } },
     //   ]));
     // The CSS shim's @keyframes parser produces this shape directly.
-    // Populates the application-wide registry. PR 4 wires the registry
-    // into setAnimation playback; PR 1 ships parser + storage so the
-    // registry is consultable today.
+    // Populates the application-wide registry consulted by setAnimation.
     register_bridge_function(api, "defineKeyframes", [this](choc::javascript::ArgumentList args) {
         auto name = args.get<std::string>(0, "");
         auto stops_json = args.get<std::string>(1, "[]");
@@ -252,7 +249,7 @@ void WidgetBridge::register_animation_style_api() {
         return choc::value::Value();
     });
 
-    // pulp #1434 Phase A2-1 - setAnimation supports two ABIs.
+    // setAnimation supports two ABIs.
     //
     //   Positional (new, @pulp/react direct callers):
     //     setAnimation(id, animation_name, duration, iterations, direction)
@@ -270,10 +267,10 @@ void WidgetBridge::register_animation_style_api() {
     // the legacy path; otherwise treat as positional. The legacy path
     // accumulates state in View::staged_animation(); when `name` arrives
     // and resolves against the keyframes registry, we seed entries into
-    // active_animations() using the staged values. Codex audit on pulp
-    // #1508 caught the original handler dropping every web-compat call
-    // because "name"/"duration"/etc. were being treated as the
-    // animation_name token (registry lookup always missed).
+    // active_animations() using the staged values. Keep the token
+    // dispatch ahead of the positional path; otherwise web-compat
+    // longhand calls such as "name" / "duration" are mistaken for
+    // animation names and the keyframe registry lookup misses.
     register_bridge_function(api, "setAnimation", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto arg1 = args.get<std::string>(1, "");
@@ -330,9 +327,8 @@ void WidgetBridge::register_animation_style_api() {
             } else if (arg1 == "fill") {
                 staged.fill_mode = args.get<std::string>(2, "");
             } else if (arg1 == "play_state") {
-                // pulp #1434 A4 Bundle 2 - animation-play-state.
-                // Storage-only today; the playback driver pause/resume
-                // is the follow-up. Mirror to View's storage slot so
+                // Storage-only today; the playback driver does not pause or
+                // resume active animations yet. Mirror to View's storage slot so
                 // round-trip queries work without poking into the
                 // staged struct.
                 v->set_animation_play_state(args.get<std::string>(2, "running"));
@@ -343,13 +339,13 @@ void WidgetBridge::register_animation_style_api() {
         // Positional dispatch (new ABI).
         const auto& anim_name = arg1;
         auto duration = static_cast<float>(args.get<double>(2, 0.0));
-        (void)args.get<double>(3, 1.0);  // iterations, PR 4
-        (void)args.get<std::string>(4, "normal");  // direction, PR 4
+        (void)args.get<double>(3, 1.0);  // iterations, not driven by playback yet
+        (void)args.get<std::string>(4, "normal");  // direction, not driven by playback yet
         const auto* block = css_keyframes_registry_.find(anim_name);
         if (!block || block->stops.empty()) return choc::value::Value();
-        // Seed one Animation per property the first stop touches. PR 2
-        // specializes the value type per property and drives the
-        // tween via the frame clock.
+        // Seed one Animation per property the first stop touches. Playback
+        // currently records the parsed property and timing state; property-
+        // specific value interpolation remains owned by the frame driver.
         const auto& first = block->stops.front();
         for (const auto& [prop, _val] : first.properties) {
             CssAnimation a{};
@@ -374,10 +370,7 @@ void WidgetBridge::register_animation_style_api() {
     });
 
     // setSkew(id, x_deg, y_deg) - CSS transform: skewX() / skewY().
-    // pulp #1434 Triage #9 (transform fan-out) - View::set_skew has
-    // existed since the 2D View slot was added; this surface just
-    // had not been registered as a JS bridge fn until now. The CSS
-    // shim's parseTransform dispatches each axis independently
+    // The CSS shim's parseTransform dispatches each axis independently
     // (skewX(alpha) -> setSkew(id, alpha, 0); skewY(beta) -> setSkew(id, 0, beta));
     // when both appear in the same transform string the second
     // call's arg-pattern preserves the axis the first call set

--- a/core/view/src/widget_bridge/border_box_api.cpp
+++ b/core/view/src/widget_bridge/border_box_api.cpp
@@ -61,9 +61,9 @@ void WidgetBridge::register_widget_border_box_api(std::function<canvas::Color(co
         return choc::value::Value();
     });
 
-    // pulp #1026 — Standalone border setters (RN parity). The shorthand
-    // setBorder(id, color, width, radius) is convenient for atomic style
-    // application but @pulp/react's prop-applier needs per-attribute
+    // Standalone border setters for RN parity. The shorthand setBorder(id,
+    // color, width, radius) is convenient for atomic style application, but
+    // @pulp/react's prop-applier needs per-attribute
     // setters so individual JSX style props (`borderColor`, `borderWidth`,
     // `borderRadius`) can update without recomputing the others.
     //
@@ -85,12 +85,11 @@ void WidgetBridge::register_widget_border_box_api(std::function<canvas::Color(co
         return choc::value::Value();
     });
 
-    // setBorderStyle(id, "solid"|"dashed"|"dotted"|...) — pulp #1434
-    // Triage #10. Maps the CSS border-style keyword to View::BorderStyle.
+    // setBorderStyle(id, "solid"|"dashed"|"dotted"|...) maps the CSS
+    // border-style keyword to View::BorderStyle.
     // Skia paint installs the dashed / dotted SkDashPathEffect at stroke
-    // time; double / groove / ridge / inset / outset currently degrade
-    // to solid (paint-side gap, tracked for follow-up). none / hidden
-    // short-circuit the stroke entirely.
+    // time; double / groove / ridge / inset / outset currently degrade to
+    // solid. none / hidden short-circuit the stroke entirely.
     register_bridge_function(api, "setBorderStyle", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto s = args.get<std::string>(1, "solid");

--- a/core/view/src/widget_bridge/border_radius_api.cpp
+++ b/core/view/src/widget_bridge/border_radius_api.cpp
@@ -15,8 +15,8 @@ void WidgetBridge::register_widget_border_radius_api() {
     // setters (setBorderTopLeftRadius / TopRight / BottomLeft / BottomRight)
     // override individual corners on top of the uniform value.
     //
-    // pulp #1663 - accepts either a number (px) or a string with % suffix
-    // (e.g. "50%"). Percent values are stored separately and resolved at
+    // Accepts either a number (px) or a string with % suffix (e.g. "50%").
+    // Percent values are stored separately and resolved at
     // paint time as `pct * 0.01 * min(width, height)` so the radius
     // tracks the View's actual bounds.
     auto parseRadiusArg = [](choc::javascript::ArgumentList& args, int idx) -> std::pair<float, float> {
@@ -42,13 +42,13 @@ void WidgetBridge::register_widget_border_radius_api() {
         return choc::value::Value();
     });
 
-    // pulp #1026 - Per-corner border-radius shorthands (RN parity).
-    // Equivalent to `setCornerRadius(id, "TopLeft", r)` but matches the
+    // Per-corner border-radius shorthands for RN parity. Equivalent to
+    // `setCornerRadius(id, "TopLeft", r)` but matches the
     // RN style-prop name 1:1 so @pulp/react's prop-applier can bind them
     // without a translation layer. Sets the `has_corner_radii_` flag on
     // the View; paint_all() then routes background/border through the
-    // per-corner path builder rather than fill_rounded_rect.
-    // pulp #1663 - same %-string handling as setBorderRadius.
+    // per-corner path builder rather than fill_rounded_rect. Uses the same
+    // %-string handling as setBorderRadius.
     register_bridge_function(api, "setBorderTopLeftRadius", [this, parseRadiusArg](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto [px, pct] = parseRadiusArg(args, 1);

--- a/core/view/src/widget_bridge/border_side_api.cpp
+++ b/core/view/src/widget_bridge/border_side_api.cpp
@@ -14,8 +14,8 @@ void WidgetBridge::register_widget_border_side_api(std::function<canvas::Color(c
     BridgeApiContext api{engine_};
     auto parseHexColor = std::move(parse_color);
 
-    // pulp #1026 - Per-side border color/width shorthands (RN parity).
-    // RN exposes `borderTopColor`, `borderTopWidth`, etc. as separate
+    // Per-side border color/width shorthands for RN parity. RN exposes
+    // `borderTopColor`, `borderTopWidth`, etc. as separate
     // style props; pulp's existing `setBorderSide(id, side, width, color)`
     // sets both at once which is awkward for a prop-by-prop applier. The
     // setBorderTop/Right/Bottom/Left{Color,Width} setters route through
@@ -25,15 +25,15 @@ void WidgetBridge::register_widget_border_side_api(std::function<canvas::Color(c
                               std::optional<canvas::Color> color,
                               std::optional<float> width) {
         if (!v) return;
-        // pulp #1026 - preserve the unrelated attribute when a per-side
-        // setter is called for only color OR only width, matching how
-        // RN's JSX prop-applier emits property updates one at a time.
-        // pulp #1566 - route through the split color-only / width-only
-        // setters so that `setBorderTopColor` does NOT mark the per-edge
-        // WIDTH as explicitly set (which would let a stale 0 override
-        // the uniform `borderWidth` shorthand). Symmetrically,
-        // `setBorderTopWidth(0)` MUST mark the edge as explicitly set so
-        // it overrides the shorthand on that edge per CSS / RN semantics.
+        // Preserve the unrelated attribute when a per-side setter is called
+        // for only color OR only width, matching how RN's JSX prop-applier
+        // emits property updates one at a time. Route through the split
+        // color-only / width-only setters so that `setBorderTopColor` does
+        // NOT mark the per-edge WIDTH as explicitly set (which would let a
+        // stale 0 override the uniform `borderWidth` shorthand).
+        // Symmetrically, `setBorderTopWidth(0)` MUST mark the edge as
+        // explicitly set so it overrides the shorthand on that edge per
+        // CSS / RN semantics.
         if (color.has_value()) {
             if (side == "top")         v->set_border_top_color(*color);
             else if (side == "right")  v->set_border_right_color(*color);

--- a/core/view/src/widget_bridge/dom_api.cpp
+++ b/core/view/src/widget_bridge/dom_api.cpp
@@ -55,8 +55,8 @@ void WidgetBridge::register_dom_api() {
         }
         // Create the appropriate widget type based on HTML tag.
         //
-        // pulp #1147 - this fast-path bypasses the JS-side `_ensureNative`
-        // for performance + QuickJS stack reasons, but it MUST mirror the
+        // This fast-path bypasses the JS-side `_ensureNative` for performance
+        // and QuickJS stack reasons, but it MUST mirror the
         // tag->widget mapping in `web-compat-element.js` or web-compat
         // semantics drift between the createElement+appendChild path and
         // the React-style commit path that goes through here.
@@ -75,8 +75,8 @@ void WidgetBridge::register_dom_api() {
             });
             child = std::move(canvas);
         } else if (tag == "rect") {
-            // pulp #1926 - SVG primitives other than <path>. Spectr's
-            // bottom-toolbar mini-icons (segmented mode toggles, analyzer
+            // SVG primitives other than <path>. Spectr's bottom-toolbar
+            // mini-icons (segmented mode toggles, analyzer
             // pills) emit lowercase <rect> / <line> / <circle> inside the
             // parent <svg>. Without this routing they fall through to the
             // unknown-tag default and paint nothing.
@@ -88,15 +88,15 @@ void WidgetBridge::register_dom_api() {
             l->set_id(childId);
             child = std::move(l);
         } else if (tag == "circle") {
-            // pulp #1926 - no dedicated SvgCircleWidget; map to SvgPath
-            // and synthesize a `d` arc in JS (web-compat-element.js
+            // No dedicated SvgCircleWidget; map to SvgPath and synthesize a
+            // `d` arc in JS (web-compat-element.js
             // __replaySvgCircleAttributes__) from cx/cy/r.
             auto svg = std::make_unique<SvgPathWidget>();
             svg->set_id(childId);
             child = std::move(svg);
         } else if (tag == "path") {
-            // pulp #1899 - mirror the JS-side _ensureNative routing:
-            // `<path>` (typically inside an `<svg>`) materializes as the
+            // Mirror the JS-side _ensureNative routing: `<path>` (typically
+            // inside an `<svg>`) materializes as the
             // SvgPathWidget so the d / stroke / stroke-width / fill /
             // viewBox attribute replay actually paints. Without this
             // branch the React/JSX commit path (which goes through
@@ -106,12 +106,11 @@ void WidgetBridge::register_dom_api() {
             svg->set_id(childId);
             child = std::move(svg);
         } else if (tag == "input") {
-            // pulp #1899 - `<input>` needs the JS-side `_type` to pick a
-            // widget. JS callers pass it through the optional 4th `hint`
+            // `<input>` needs the JS-side `_type` to pick a widget.
+            // JS callers pass it through the optional 4th `hint`
             // arg ("range:horizontal", "range:vertical", "checkbox", "text").
             // Without a hint, fall back to a plain View so the element
-            // still receives child/style ops (matches pre-2026-05-17
-            // behavior for unhinted inputs).
+            // still receives child/style ops.
             auto hint = args.get<std::string>(3, "");
             if (hint == "range:horizontal" || hint == "range:vertical") {
                 auto fader = std::make_unique<Fader>();
@@ -125,11 +124,9 @@ void WidgetBridge::register_dom_api() {
                 cb->set_id(childId);
                 child = std::move(cb);
             } else if (hint == "text") {
-                // pulp jsx-instrument-import (2026-05-17) - plain text
-                // `<input>` (and text-like subtypes: search / email / url
+                // Plain text `<input>` (and text-like subtypes: search / email / url
                 // / tel / password) materialize as a TextEditor so they
-                // accept keyboard input. Pre-fix, Chainer's preset-name
-                // field landed as a non-editable View; per Codex review.
+                // accept keyboard input instead of becoming a non-editable View.
                 auto te = std::make_unique<TextEditor>();
                 te->set_id(childId);
                 child = std::move(te);
@@ -139,8 +136,8 @@ void WidgetBridge::register_dom_api() {
                 child = std::move(v);
             }
         } else if (auto widget_for_tag = make_widget_for_tag(tag, childId)) {
-            // pulp 2026-06-08 (routing-parity sweep) - route lowercase
-            // `@pulp/react` widget intrinsics (knob/fader/toggle/combo/
+            // Route lowercase `@pulp/react` widget intrinsics
+            // (knob/fader/toggle/combo/
             // checkbox/spectrum/waveform/meter/xypad/listbox/icon, plus the
             // select/progress/img HTML aliases) to native widgets here in the
             // React-commit fast path. `<Knob>` etc. lower to lowercase DOM
@@ -159,8 +156,8 @@ void WidgetBridge::register_dom_api() {
             if (tag == "div" || tag == "section" || tag == "article" || tag == "aside" ||
                 tag == "header" || tag == "footer" || tag == "nav" || tag == "main")
                 v->flex().direction = FlexDirection::column;
-            // pulp #1147 - <svg> is a layout-leaf media element. Default
-            // direction stays column so child <path>/<g> attaches; the
+            // <svg> is a layout-leaf media element. Default direction stays
+            // column so child <path>/<g> attaches; the
             // presentational width/height attributes are replayed via
             // setFlex() on the JS side (see web-compat-element.js
             // setAttribute() path).

--- a/core/view/src/widget_bridge/list_style_api.cpp
+++ b/core/view/src/widget_bridge/list_style_api.cpp
@@ -10,23 +10,19 @@ namespace pulp::view {
 void WidgetBridge::register_list_style_api() {
     BridgeApiContext api{engine_};
 
-    // pulp #1514 - list-style cluster (listStyle / listStyleType /
-    // listStyleImage / listStylePosition). Pulp doesn't model
-    // <li>/<ul>/<ol> semantics, so the bridge stores the values
-    // verbatim on the View so a later paint pass (or a future
-    // semantic-list surface) can honor them. Marker glyph rendering
-    // is the follow-up; this PR flips the catalog out of `missing`
-    // by wiring the round-trip + JS shorthand parsing.
+    // list-style cluster (listStyle / listStyleType / listStyleImage /
+    // listStylePosition). Pulp doesn't model <li>/<ul>/<ol> semantics, so
+    // the bridge stores the values verbatim on the View for round-trip and
+    // future marker rendering.
     //
     // setListStyleType(id, "disc"|"circle"|"square"|"decimal"|"none"
     //                       |"decimal-leading-zero"|"lower-roman"|"upper-roman"
     //                       |"lower-alpha"|"upper-alpha"|"lower-latin"|"upper-latin"
     //                       |"lower-greek"|"armenian"|"georgian").
     //
-    // The counter-style keywords (lower-roman, etc.) are stored verbatim
-    // on the View::ListStyleType enum today; paint-side glyph rendering
-    // is the follow-up (pulp #1514). Unknown keywords fall back to `disc`
-    // to match the longstanding default.
+    // The counter-style keywords (lower-roman, etc.) are stored on the
+    // View::ListStyleType enum; marker glyph rendering is not wired yet.
+    // Unknown keywords fall back to `disc` to match the longstanding default.
     register_bridge_function(api, "setListStyleType", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto s = args.get<std::string>(1, "disc");

--- a/core/view/src/widget_bridge/outline_api.cpp
+++ b/core/view/src/widget_bridge/outline_api.cpp
@@ -14,8 +14,8 @@ void WidgetBridge::register_widget_outline_api(std::function<canvas::Color(const
     BridgeApiContext api{engine_};
     auto parseHexColor = std::move(parse_color);
 
-    // pulp #1519 - CSS / RN outline cluster. Outline is paint-time only:
-    // it does NOT take up Yoga layout space (parent never reserves room
+    // CSS / RN outline cluster. Outline is paint-time only: it does NOT
+    // take up Yoga layout space (parent never reserves room
     // for it). Each setter mutates one slot in isolation so a JSX prop
     // diff that touches only `outlineColor` doesn't clobber `outlineWidth`.
     // Skia paint inflates the box by (offset + width/2) and strokes with
@@ -26,7 +26,7 @@ void WidgetBridge::register_widget_outline_api(std::function<canvas::Color(const
     // setOutlineColor(id, hex) - accepts the same color forms as
     // setBackground / setBorderColor (#hex / rgb() / named), plus the
     // CSS `currentColor` keyword which resolves to the View's text
-    // color via the inheritable cascade (#1710).
+    // color via the inheritable cascade.
     register_bridge_function(api, "setOutlineColor", [this, parseHexColor](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto hex = args.get<std::string>(1, "");
@@ -34,13 +34,12 @@ void WidgetBridge::register_widget_outline_api(std::function<canvas::Color(const
         if (!v || hex.empty()) return choc::value::Value();
         // CSS `currentColor`: resolve to the element's own computed text
         // color first, then the inheritable cascade, then theme fallback.
-        // Order matters - pulp #1728 Codex P2: a Label that set its own
-        // `color` via setTextColor stores it in `Label::text_color_`
-        // (`has_own_text_color_=true`) and does NOT touch the inheritable
-        // slot, so `inheritable_text_color()` would skip the Label and
-        // climb to the parent's inheritable color. CSS semantics: an
-        // element's own `color` always wins over inheritance for that
-        // element's `currentColor`.
+        // Order matters: a Label that set its own `color` via setTextColor
+        // stores it in `Label::text_color_` (`has_own_text_color_=true`) and
+        // does NOT touch the inheritable slot, so `inheritable_text_color()`
+        // would skip the Label and climb to the parent's inheritable color.
+        // CSS semantics: an element's own `color` always wins over
+        // inheritance for that element's `currentColor`.
         std::string lower;
         lower.reserve(hex.size());
         for (char c : hex) lower += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));

--- a/core/view/src/widget_bridge/runtime_api.cpp
+++ b/core/view/src/widget_bridge/runtime_api.cpp
@@ -14,8 +14,6 @@
 namespace pulp::view {
 
 void WidgetBridge::register_runtime_api() {
-    // Phase 9: Runtime API gap closure.
-
     // __requestFrame__ - requestAnimationFrame implementation.
     // JS side stores callbacks in __frameCallbacks__ map, passes ID to C++.
     // C++ stores pending IDs and invokes them on next frame via __invokeFrame__.
@@ -29,8 +27,8 @@ void WidgetBridge::register_runtime_api() {
             "  var fn = __frameCallbacks__[id];"
             "  if (fn) { delete __frameCallbacks__[id]; fn(); }"
             "}"
-            // pulp #915 - timer registry for native setTimeout / setInterval.
-            // Callbacks live in JS (CHOC's NativeFunction can't carry JSValue
+            // Timer registry for native setTimeout / setInterval. Callbacks
+            // live in JS (CHOC's NativeFunction can't carry JSValue
             // arguments); native side tracks deadlines + repeat semantics
             // and pings these helpers when a timer expires.
             "var __timerCallbacks__ = Object.create(null);"
@@ -53,8 +51,8 @@ void WidgetBridge::register_runtime_api() {
         auto id = args.get<int>(0, 0);
         if (id > 0) {
             pending_frame_ids_.push_back(id);
-            // pulp #921 - signal the host so the next paint runs and
-            // service_frame_callbacks() drains the queue. Without this,
+            // Signal the host so the next paint runs and service_frame_callbacks()
+            // drains the queue. Without this,
             // requestAnimationFrame queues a callback but never asks the
             // host for a frame, so the canvas never repaints.
             request_repaint();
@@ -75,8 +73,7 @@ void WidgetBridge::register_runtime_api() {
         if (ids.empty()) {
             return choc::value::Value();
         }
-        // Phase 9: invoke each callback under its own ambient
-        // provenance. The script identity (set via
+        // Invoke each callback under its own ambient provenance. The script identity (set via
         // `load_script(code, script_id)` / `set_active_script_id`) is
         // prefixed onto the callback id so a published value emitted
         // from inside an rAF body inherits source_id =
@@ -105,8 +102,7 @@ void WidgetBridge::register_runtime_api() {
         return choc::value::Value();
     });
 
-    // Phase 9: motion observability - JS-side bridge for the publish
-    // channel + ambient provenance slot.
+    // JS-side bridge for the motion publish channel and ambient provenance slot.
     //
     // Exposes:
     //   motion.publishValue(viewName, metricName, value)
@@ -171,8 +167,8 @@ void WidgetBridge::register_runtime_api() {
         "void 0;"
     );
 
-    // pulp #915 - native setTimeout / setInterval scheduling. JS-side
-    // setTimeout/setInterval generate the id and stash the callback in
+    // Native setTimeout / setInterval scheduling. JS-side setTimeout/setInterval
+    // generate the id and stash the callback in
     // __timerCallbacks__; native tracks (id, deadline, repeat, interval)
     // so service_frame_callbacks() can fire expired timers without a
     // consumer-side shim.
@@ -245,7 +241,7 @@ void WidgetBridge::register_runtime_api() {
         return choc::value::Value();
     });
 
-    // P0: performance.now() - high-resolution monotonic time in milliseconds.
+    // performance.now() - high-resolution monotonic time in milliseconds.
     register_bridge_function(api, "__performanceNow__", [](choc::javascript::ArgumentList) {
         static auto start = std::chrono::steady_clock::now();
         auto now = std::chrono::steady_clock::now();

--- a/core/view/src/widget_bridge/style_cursor_api.cpp
+++ b/core/view/src/widget_bridge/style_cursor_api.cpp
@@ -16,16 +16,14 @@ void WidgetBridge::register_widget_style_cursor_direction_api() {
         auto c = args.get<std::string>(1, "default");
         auto* v = id.empty() ? &root_ : widget(id);
         if (!v) return choc::value::Value();
-        // pulp #1434 Triage #7 - cursor enum fan-out. Map the full CSS
-        // cursor keyword set to the View::CursorStyle slots that exist
+        // Map the CSS cursor keyword set to the View::CursorStyle slots that exist
         // today (4 base + 7 resize + invisible + multi-directional = 12
         // distinct visuals). Where multiple CSS keywords map to the
         // same visual (n/s/e/w-resize all map to the axis-aligned
         // resize cursor), we collapse to the closest existing slot.
         //
-        // pulp #1550 Tier-4 macOS partial 2026-05-12 - added dedicated
-        // slots for `alias` / `copy` / `zoom-in` / `zoom-out` /
-        // `context-menu` (5 keywords with real NSCursor backings on
+        // Dedicated slots for `alias` / `copy` / `zoom-in` / `zoom-out` /
+        // `context-menu` use real NSCursor backings on
         // macOS - see core/view/platform/mac/window_host_mac.mm).
         // `wait` / `help` / `progress` / `cell` stay routed to default
         // because macOS has no native cursor for them - listed in
@@ -57,7 +55,7 @@ void WidgetBridge::register_widget_style_cursor_direction_api() {
         else if (c == "move" || c == "all-scroll") {
             v->set_cursor(CS::multi_directional_resize);
         }
-        // pulp #1550 - 5 CSS cursor keywords with macOS NSCursor backings.
+        // CSS cursor keywords with macOS NSCursor backings.
         else if (c == "alias")           v->set_cursor(CS::alias);
         else if (c == "copy")            v->set_cursor(CS::copy);
         else if (c == "zoom-in")         v->set_cursor(CS::zoom_in);
@@ -67,13 +65,12 @@ void WidgetBridge::register_widget_style_cursor_direction_api() {
         return choc::value::Value();
     });
 
-    // pulp #1434 Phase A2-3 - writing direction. Maps the CSS keyword
-    // to View::WritingDirection. Yoga's flow honors direction for
+    // setDirection(id, "ltr"|"rtl"|"auto") maps the CSS keyword to
+    // View::WritingDirection. Yoga's flow honors direction for
     // flexDirection 'row' (which visually reverses under RTL); Skia's
     // paragraph_style.setTextDirection picks up the same value at
     // shape time. Logical-edge mapping in the @pulp/react prop-applier
-    // currently stays LTR-only (per #1497 fast-path note); a future
-    // slice will make it direction-aware via a shared resolver.
+    // currently stays LTR-only.
     register_bridge_function(api, "setDirection", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto d = args.get<std::string>(1, "ltr");

--- a/core/view/src/widget_bridge/style_effects_api.cpp
+++ b/core/view/src/widget_bridge/style_effects_api.cpp
@@ -17,11 +17,10 @@ void WidgetBridge::register_widget_style_filter_clip_api(
     auto parseColor = std::move(parse_color);
 
     // setFilter(id, "blur(4px) brightness(0.8) saturate(1.2) drop-shadow(...)")
-    //   - pulp #1434 Phase A2-4 CSS filter chain. Walks the function
-    //   sequence and builds View::FilterOp entries; the View paint
-    //   path passes the chain to canvas.save_layer_with_filters which
-    //   composes via SkImageFilters on the Skia backend (CG falls
-    //   through to blur-only for now).
+    // Walks the function sequence and builds View::FilterOp entries; the
+    // View paint path passes the chain to canvas.save_layer_with_filters,
+    // which composes via SkImageFilters on the Skia backend (CG falls
+    // through to blur-only for now).
     register_bridge_function(api, "setFilter", [this, parseColor](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto filter_str = args.get<std::string>(1, "");
@@ -141,8 +140,8 @@ void WidgetBridge::register_widget_style_filter_clip_api(
     });
 
     // setBackdropFilter(id, blur_px) - CSS `backdrop-filter: blur(Npx)` for
-    // frosted-glass overlays / modal backgrounds (issue-926). Numeric
-    // overload to keep the bridge cheap; string-form CSS parsing stays in
+    // frosted-glass overlays / modal backgrounds. Numeric overload keeps
+    // the bridge cheap; string-form CSS parsing stays in
     // setFilter.
     register_bridge_function(api, "setBackdropFilter",
         [this](choc::javascript::ArgumentList args) {
@@ -153,14 +152,11 @@ void WidgetBridge::register_widget_style_filter_clip_api(
             return choc::value::Value();
         });
 
-    // setClipPath(id, value) - CSS `clip-path` (pulp #1515). The paint
-    // side feeds the stored slot to `Canvas::clip_path_svg` which calls
-    // `SkPath::FromSVGString` - that parser only accepts raw SVG path
-    // "d" data, so we must unwrap `path("...")` here and explicitly
-    // skip shapes / URL refs that the paint side cannot honor (they
-    // remain documented as deferred). Forwarding the verbatim value
-    // produced silent paint failures on every non-path() form (Codex
-    // #1616 P1 on #1540).
+    // setClipPath(id, value) - CSS `clip-path`. The paint side feeds the
+    // stored slot to `Canvas::clip_path_svg` which calls
+    // `SkPath::FromSVGString`; that parser only accepts raw SVG path "d"
+    // data. Unwrap `path("...")` here and explicitly skip shapes / URL
+    // refs the paint side cannot honor.
     register_bridge_function(api, "setClipPath",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
@@ -177,8 +173,7 @@ void WidgetBridge::register_widget_style_filter_clip_api(
             // CSS keywords (`none`, `path(...)`, `circle(...)`, etc.) are
             // case-insensitive per spec. Build a lowercased copy of the
             // prefix-bearing portion for comparison; preserve the original
-            // case for the SVG path "d" data inside path("...") (Codex
-            // #1616 P2 on #1540 follow-up #1698).
+            // case for the SVG path "d" data inside path("...").
             std::string t_lower = t;
             for (auto& c : t_lower) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
             if (t_lower.empty() || t_lower == "none") {
@@ -209,10 +204,10 @@ void WidgetBridge::register_widget_style_filter_clip_api(
 void WidgetBridge::register_widget_style_blend_api() {
     BridgeApiContext api{engine_};
 
-    // pulp #1549 - setMixBlendMode(id, "multiply") for CSS / RN
-    // `mix-blend-mode`. Maps the W3C blend-mode keyword set to the
-    // canvas BlendMode enum so the View paint path can pass it
-    // straight into `save_layer_with_blend()` at compositing time.
+    // setMixBlendMode(id, "multiply") for CSS / RN `mix-blend-mode`.
+    // Maps the W3C blend-mode keyword set to the canvas BlendMode enum
+    // so the View paint path can pass it straight into
+    // `save_layer_with_blend()` at compositing time.
     // The keyword set mirrors the W3C separable + non-separable blend
     // modes (the same 16 values RN's New Architecture surface accepts;
     // see tools/harness/oracles/rn/rn-viewstyle.json::mixBlendMode).
@@ -243,8 +238,8 @@ void WidgetBridge::register_widget_style_blend_api() {
             else if (kw == "saturation")  mode = BM::saturation;
             else if (kw == "color")       mode = BM::color;
             else if (kw == "luminosity")  mode = BM::luminosity;
-            // pulp Wave 2 css.9 - `plus-lighter` and `plus-darker` are CSS
-            // Compositing & Blending Level 2 keywords. Both map to
+            // `plus-lighter` and `plus-darker` are CSS Compositing &
+            // Blending Level 2 keywords. Both map to
             // `SkBlendMode::kPlus` (additive) at the Skia layer (see
             // canvas.hpp::BlendMode::lighter, index 26). `plus-darker` is
             // technically a multiplicative variant in the W3C draft but

--- a/core/view/src/widget_bridge/style_rn_compat_api.cpp
+++ b/core/view/src/widget_bridge/style_rn_compat_api.cpp
@@ -15,8 +15,7 @@ void WidgetBridge::register_widget_style_rn_compat_api(
     BridgeApiContext api{engine_};
     auto parseHexColor = std::move(parse_color);
 
-    // pulp #1737 RN-OOS-fixup (audit 2026-05-11) — RN iOS-legacy
-    // shadow{Color,Offset,Opacity,Radius} per-attribute setters for
+    // RN iOS-legacy shadow{Color,Offset,Opacity,Radius} per-attribute setters for
     // box-shadow. Mirrors the textShadow* pattern above so a JSX prop
     // diff that touches one prop doesn't clobber the others. Modern
     // RN code uses `boxShadow` (CSS shorthand) — Pulp fully supports
@@ -58,8 +57,7 @@ void WidgetBridge::register_widget_style_rn_compat_api(
             return choc::value::Value();
         });
 
-    // pulp #1737 RN-OOS-fixup (audit 2026-05-11, final sweep) — RN's
-    // `includeFontPadding` is an Android-only legacy prop. Android's
+    // RN's `includeFontPadding` is an Android-only legacy prop. Android's
     // TextView paints extra vertical padding around text glyphs;
     // setting `includeFontPadding: false` removes it. Pulp's text-
     // shaping pipeline (Skia/SkParagraph) uses tight baseline-relative
@@ -74,10 +72,9 @@ void WidgetBridge::register_widget_style_rn_compat_api(
     //
     // Bridge fn stores the keyword on a View slot purely for round-
     // trip (element.style / style.X reading the value back). This
-    // mirrors the overscroll-behavior pattern (PR #1805): all keywords
-    // accepted, single consistent behavior produced, honest catalog
-    // claim of "supported as a CSS-spec subset where Pulp's behavior
-    // matches the dominant author intent".
+    // mirrors the overscroll-behavior pattern: all keywords accepted,
+    // single consistent behavior produced, and the catalog can report a
+    // CSS-spec subset where Pulp's behavior matches the dominant author intent.
     register_bridge_function(api, "setIncludeFontPadding",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
@@ -89,7 +86,7 @@ void WidgetBridge::register_widget_style_rn_compat_api(
             return choc::value::Value();
         });
 
-    // pulp #1737 RN-OOS-fixup (#1812) — RN's `borderCurve` corner shape.
+    // RN's `borderCurve` corner shape.
     // `circular` (default) keeps the standard quarter-circle rounded
     // corner; `continuous` switches View::paint_all to the iOS-style
     // squircle approximation (super-ellipse path with extension factor
@@ -108,11 +105,10 @@ void WidgetBridge::register_widget_style_rn_compat_api(
             return choc::value::Value();
         });
 
-    // pulp #1737 RN-OOS-fixup (final round) — CSS `isolation` + RN
-    // `isolation` honest CSS-subset flip. Pulp's per-View render model
+    // CSS `isolation` + RN `isolation` subset. Pulp's per-View render model
     // is structurally isolated by default: each View with mix-blend-mode
-    // opens its own save_layer_with_blend composition (PR #1549) and
-    // composites back to its parent normally — there's no
+    // opens its own save_layer_with_blend composition and composites
+    // back to its parent normally — there's no
     // "cross-stacking-context blend leakage" that CSS isolation: isolate
     // is designed to prevent. Similarly, z-index is paint-order scoped
     // to siblings within a parent, so a child's z-index can't promote
@@ -124,8 +120,7 @@ void WidgetBridge::register_widget_style_rn_compat_api(
     // reads (el.style.isolation === "isolate"). Paint has no special
     // case because Pulp's existing per-View layering already provides
     // the isolation contract. Same CSS-subset pattern as
-    // overscrollBehavior, includeFontPadding, scrollBehavior from
-    // earlier this session.
+    // overscrollBehavior, includeFontPadding, and scrollBehavior.
     register_bridge_function(api, "setIsolation",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
@@ -135,8 +130,7 @@ void WidgetBridge::register_widget_style_rn_compat_api(
             return choc::value::Value();
         });
 
-    // pulp #1737 RN-OOS-fixup (audit 2026-05-11) — RN's `elevation` is
-    // Android-only Material elevation (0–24dp). Pulp catalogs boxShadow
+    // RN's `elevation` is Android-only Material elevation (0–24dp). Pulp catalogs boxShadow
     // as the cross-platform equivalent; this shim translates elevation
     // to a single-shadow approximation of the Material dual-shadow
     // spec so consumers shipping unchanged RN-Android styles get a
@@ -174,8 +168,7 @@ void WidgetBridge::register_widget_style_rn_compat_api(
             return choc::value::Value();
         });
 
-    // pulp #1737 RN-OOS-fixup (audit 2026-05-11) — CSS scroll-behavior +
-    // overscroll-behavior. Stored on the View slot; ScrollView reads
+    // CSS scroll-behavior + overscroll-behavior. Stored on the View slot; ScrollView reads
     // scroll_behavior_ in scroll_by (auto → instant, else smooth) and
     // overscroll_behavior_ via the existing clamp_scroll_targets path
     // (Pulp already clamps at content bounds and doesn't scroll-chain

--- a/core/view/src/widget_bridge/style_storage_api.cpp
+++ b/core/view/src/widget_bridge/style_storage_api.cpp
@@ -12,10 +12,9 @@ void WidgetBridge::register_widget_style_background_repeat_api() {
 
     // setBackgroundRepeat(id, kw) - CSS background-repeat keyword. Storage-
     // only on the View (no-op for solid-color backgrounds, which is the
-    // only currently rendered case). Future paint work for
-    // `background-image: url(...)` / repeating gradients consults the
-    // stored slot; setting the keyword today makes the round-trip work
-    // and lets authors express intent without dropping the prop silently.
+    // only currently rendered case). Keeping the slot makes the round-trip
+    // work for imported styles and gives future raster / gradient
+    // background paint code an explicit repeat keyword to consume.
     // Accepts: `repeat` / `repeat-x` / `repeat-y` / `no-repeat` /
     // `space` / `round`. Unknown / empty resets to "" (paint defaults to
     // CSS initial `repeat`).
@@ -31,11 +30,10 @@ void WidgetBridge::register_widget_style_background_repeat_api() {
 void WidgetBridge::register_widget_style_mask_object_api() {
     BridgeApiContext api{engine_};
 
-    // setMaskImage(id, value) - CSS `mask-image` (pulp #1515).
-    // Storage-only today; the saveLayer + SkBlendMode::kDstIn shader
-    // composite is a follow-up paint slice. The slot round-trips
-    // through View::mask_image() so harness tests can assert the
-    // bridge accepted the value.
+    // setMaskImage(id, value) - CSS `mask-image`.
+    // The bridge stores the value on the View; mask-capable paint backends
+    // consume the slot, while fallback backends still round-trip it through
+    // View::mask_image().
     register_bridge_function(api, "setMaskImage",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
@@ -45,10 +43,10 @@ void WidgetBridge::register_widget_style_mask_object_api() {
             return choc::value::Value();
         });
 
-    // setMask(id, shorthand) - CSS `mask` shorthand (pulp #1515).
+    // setMask(id, shorthand) - CSS `mask` shorthand.
     // Stores the verbatim shorthand on the View; the JS shim
     // (web-compat-style-decl.js) is responsible for fanning out into
-    // the maskImage longhand. Storage-only today.
+    // the maskImage longhand.
     register_bridge_function(api, "setMask",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
@@ -58,9 +56,8 @@ void WidgetBridge::register_widget_style_mask_object_api() {
             return choc::value::Value();
         });
 
-    // setMaskSize(id, value) - CSS `mask-size`, pairs with mask-image
-    // (pulp #1515 followup). Storage-only; consumed by the same
-    // future paint slice that wires the mask shader.
+    // setMaskSize(id, value) - CSS `mask-size`, stored with mask-image for
+    // paint paths that can apply a mask.
     register_bridge_function(api, "setMaskSize",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
@@ -85,9 +82,9 @@ void WidgetBridge::register_widget_style_mask_object_api() {
             return choc::value::Value();
         });
 
-    // setObjectFit(id, value) - CSS `object-fit`. Storage-only today;
-    // the ImageView paint slice that consumes this needs access to
-    // the decoded image's natural size (planned follow-up).
+    // setObjectFit(id, value) - CSS `object-fit`. The bridge stores the
+    // keyword; visualizer/image-like paint paths consume it when mapping
+    // source content into their bounds.
     register_bridge_function(api, "setObjectFit",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
@@ -97,8 +94,8 @@ void WidgetBridge::register_widget_style_mask_object_api() {
             return choc::value::Value();
         });
 
-    // setObjectPosition(id, value) - CSS `object-position`. Pairs
-    // with object-fit. Storage-only today.
+    // setObjectPosition(id, value) - CSS `object-position`. Stored with
+    // object-fit for paint paths that align content inside the destination rect.
     register_bridge_function(api, "setObjectPosition",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
@@ -112,11 +109,10 @@ void WidgetBridge::register_widget_style_mask_object_api() {
 void WidgetBridge::register_widget_style_background_subproperty_api() {
     BridgeApiContext api{engine_};
 
-    // pulp #1517 - background sub-property setters. Storage-only today;
-    // see View::set_background_{attachment,clip,origin}() doc for the
-    // partial-vs-noop semantics. Wiring them here unblocks the JS shim
-    // path and lets the catalog honestly report `noop` / `partial`
-    // instead of `missing`.
+    // Background sub-property setters. See
+    // View::set_background_{attachment,clip,origin}() for the
+    // partial-vs-noop semantics; wiring them here lets the JS shim path
+    // round-trip these keywords instead of dropping them.
     register_bridge_function(api, "setBackgroundAttachment",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
@@ -142,15 +138,10 @@ void WidgetBridge::register_widget_style_background_subproperty_api() {
             return choc::value::Value();
         });
 
-    // Wave 5 css.5 - setBackgroundPosition / setBackgroundSize. The JS
-    // shim (web-compat-style-decl.js cases backgroundPosition /
-    // backgroundSize) was already calling these as `typeof set... ===
-    // "function"` guards; without a registered bridge fn the calls were
-    // silent no-ops and the catalog claim of `supported` was a fiction.
-    // Storage-only landing here makes the round-trip honest (JS -> bridge
-    // -> View slot -> get_attribute pulls it back) and unblocks a future
-    // raster background-image paint slice - see View::set_background_*
-    // doc for the architectural caveat.
+    // setBackgroundPosition / setBackgroundSize. The JS shim calls these
+    // behind `typeof set... === "function"` guards; registering the bridge
+    // functions makes the round-trip explicit (JS -> bridge -> View slot ->
+    // get_attribute) while raster background-image paint remains deferred.
     register_bridge_function(api, "setBackgroundPosition",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");

--- a/core/view/src/widget_bridge/style_visibility_api.cpp
+++ b/core/view/src/widget_bridge/style_visibility_api.cpp
@@ -23,16 +23,15 @@ void WidgetBridge::register_widget_style_visibility_api() {
 void WidgetBridge::register_widget_style_interaction_api() {
     BridgeApiContext api{engine_};
 
-    // setPointerEvents(id, "none"|"auto") - CSS pointer-events: skip in hit_test
-    // pulp #1026 - RN-shaped 4-valued pointerEvents:
+    // setPointerEvents(id, "none"|"auto") - CSS pointer-events: skip in hit_test.
+    // RN-shaped 4-valued pointerEvents:
     //   "auto"     - default, this view + children intercept events.
     //   "none"     - neither this view nor descendants intercept events.
     //   "box-only" - this view intercepts; children do NOT.
     //   "box-none" - this view does NOT intercept; children do.
-    // Pre-#1026 the bridge only honored auto / none and routed through
-    // set_hit_testable(); we keep that mapping for the binary cases for
-    // back-compat with existing scripts and additionally route the new
-    // four-valued enum via View::set_pointer_events().
+    // Keep set_hit_testable() in sync for the binary cases for back-compat
+    // with existing scripts, and route the four-valued enum via
+    // View::set_pointer_events().
     register_bridge_function(api, "setPointerEvents", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto mode = args.get<std::string>(1, "auto");
@@ -54,11 +53,9 @@ void WidgetBridge::register_widget_style_interaction_api() {
         return choc::value::Value();
     });
 
-    // pulp #1026 - RN backfaceVisibility ("visible"|"hidden"). Stored on
-    // the View for plumbing parity with @pulp/react. The flag is consumed
-    // by the paint path only when a 3D transform with negative Z is
-    // active; pulp's transform model is currently 2D-affine, so this is
-    // a no-op for painting today and reserved for future 3D support.
+    // RN backfaceVisibility ("visible"|"hidden"). Stored on the View for
+    // plumbing parity with @pulp/react. Pulp's transform model is currently
+    // 2D-affine, so this is a no-op for painting today.
     register_bridge_function(api, "setBackfaceVisibility", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto mode = args.get<std::string>(1, "visible");
@@ -83,20 +80,20 @@ void WidgetBridge::register_widget_style_interaction_api() {
 
     // setWhiteSpace(id, "normal"|"nowrap"|"pre"|"pre-wrap")
     //
-    // pulp #1410 - sets a generic `View::white_space_nowrap()` flag so
-    // ANY widget with a textual surface (Button, custom text-bearing
+    // Sets a generic `View::white_space_nowrap()` flag so ANY widget with a
+    // textual surface (Button, custom text-bearing
     // views, future TextEditor surfaces) and `TextShaper` consumers can
     // observe nowrap without dynamic_casting to Label. The original
     // Label::set_multi_line side-effect stays in lock-step so existing
-    // single-line Label paint paths (incl. #1407 ellipsis truncation)
+    // single-line Label paint paths, including ellipsis truncation,
     // keep working when only one of the flags is set.
     register_bridge_function(api, "setWhiteSpace", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto ws = args.get<std::string>(1, "normal");
         auto* v = id.empty() ? &root_ : widget(id);
         if (!v) return choc::value::Value();
-        // pulp #1737 - map keyword to View::WhiteSpaceMode enum.
-        // The set_white_space_mode setter also maintains the legacy
+        // Map keyword to View::WhiteSpaceMode enum. The set_white_space_mode
+        // setter also maintains the legacy
         // white_space_nowrap_ bool (true for nowrap + pre) so existing
         // consumers of white_space_nowrap() keep working.
         using M = View::WhiteSpaceMode;
@@ -108,8 +105,7 @@ void WidgetBridge::register_widget_style_interaction_api() {
         else if (ws == "break-spaces")  mode = M::break_spaces;
         // Unknown keyword falls back to normal (per CSS forward-compat).
         v->set_white_space_mode(mode);
-        // pulp #1737 (Codex P1 followup on #1786): Label.multi_line
-        // is TRUE for all modes except `nowrap`. Originally `pre`
+        // Label.multi_line is TRUE for all modes except `nowrap`. Originally `pre`
         // mapped to multi_line=false to match the CSS spec's
         // "no-soft-wrap" semantic, but Pulp's Label only emits hard
         // line breaks via the multi_line splitting path - single-line
@@ -122,7 +118,7 @@ void WidgetBridge::register_widget_style_interaction_api() {
         // the spec-critical "preserve newlines" by keeping
         // multi_line=true for `pre`. Long lines overflow horizontally
         // - a degraded but spec-correct behaviour. Soft-wrap
-        // suppression for `pre` is a Label-side follow-up.
+        // suppression for `pre` is not wired yet.
         if (auto* l = dynamic_cast<Label*>(widget(id))) {
             const bool wraps = (mode != M::nowrap);
             l->set_multi_line(wraps);
@@ -131,10 +127,8 @@ void WidgetBridge::register_widget_style_interaction_api() {
     });
 
     // setUserSelect(id, "auto"|"none"|"text"|"all"|"contain") - CSS
-    // user-select. Tier-2 follow-up to #1656 (which walked the catalog
-    // claim back to partial because this stub was a literal no-op).
-    // Now stores the keyword on View::user_select_ so widgets that
-    // participate in selection can read it. Unknown keywords map to
+    // user-select. Stores the keyword on View::user_select_ so widgets
+    // that participate in selection can read it. Unknown keywords map to
     // the spec default (auto).
     register_bridge_function(api, "setUserSelect", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");

--- a/core/view/src/widget_bridge/style_visual_api.cpp
+++ b/core/view/src/widget_bridge/style_visual_api.cpp
@@ -24,10 +24,10 @@ void WidgetBridge::register_widget_style_shadow_api(
     std::function<canvas::Color(const std::string&)> parse_color) {
     BridgeApiContext api{engine_};
 
-    // pulp #1026 - RN-shaped shadow primitive. RN's View style-prop names
-    // are { shadowColor, shadowOffset: {x,y}, shadowOpacity, shadowRadius }
-    // and do not carry spread or inset. Lower these onto the existing pulp
-    // #925 box-shadow primitive while leaving setBoxShadow unchanged.
+    // RN-shaped shadow primitive. RN's View style-prop names are
+    // { shadowColor, shadowOffset: {x,y}, shadowOpacity, shadowRadius } and
+    // do not carry spread or inset. Lower these onto the existing box-shadow
+    // primitive while leaving setBoxShadow unchanged.
     register_bridge_function(api, "setShadow", [this, parse_color](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto hex = args.get<std::string>(1, "#000000ff");

--- a/core/view/src/widget_bridge/svg_api.cpp
+++ b/core/view/src/widget_bridge/svg_api.cpp
@@ -17,8 +17,8 @@ void WidgetBridge::register_svg_api(std::function<canvas::Color(const std::strin
     BridgeApiContext api{engine_};
     auto parseHexColor = std::move(parse_color);
 
-    // pulp #965 - SvgPathWidget bridge. Mirrors the API surface of
-    // CanvasWidget but for inline <svg><path> icons. JS registers the
+    // SvgPathWidget bridge. Mirrors the API surface of CanvasWidget but for
+    // inline <svg><path> icons. JS registers the
     // widget and pushes its path-data + paint attributes; the native
     // widget parses path-data once on set_path() and replays as Canvas2D
     // path commands inside paint().
@@ -51,11 +51,10 @@ void WidgetBridge::register_svg_api(std::function<canvas::Color(const std::strin
         return choc::value::Value();
     });
 
-    // pulp #1416 - setSvgFill / setSvgStroke / setSvgStrokeWidth are
-    // polymorphic across all SVG-primitive widgets so JSX consumers see
-    // a uniform fill/stroke surface. SvgPathWidget is the legacy path
-    // (#965 / #994); SvgRectWidget and SvgLineWidget mirror the API with
-    // the same hex / "none" / strokeWidth semantics.
+    // setSvgFill / setSvgStroke / setSvgStrokeWidth are polymorphic across
+    // all SVG-primitive widgets so JSX consumers see a uniform fill/stroke
+    // surface. SvgRectWidget and SvgLineWidget mirror the path API with the
+    // same hex / "none" / strokeWidth semantics.
     register_bridge_function(api, "setSvgFill", [this, parseHexColor](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto hex = args.get<std::string>(1, "");
@@ -63,10 +62,9 @@ void WidgetBridge::register_svg_api(std::function<canvas::Color(const std::strin
         if (auto* w = dynamic_cast<SvgPathWidget*>(widget(id))) {
             if (clear) w->clear_fill();
             else       w->set_fill_color(parseHexColor(hex));
-            // pulp #932 / #1737 PR-4 - solid color path wins over any
-            // previous gradient. Clear the gradient slot so a later
-            // re-render with a solid fill doesn't accidentally pick
-            // up a stale linear-gradient string.
+            // Solid color path wins over any previous gradient. Clear the
+            // gradient slot so a later re-render with a solid fill doesn't
+            // accidentally pick up a stale linear-gradient string.
             w->clear_fill_gradient();
         } else if (auto* r = dynamic_cast<SvgRectWidget*>(widget(id))) {
             if (clear) r->clear_fill();
@@ -77,8 +75,8 @@ void WidgetBridge::register_svg_api(std::function<canvas::Color(const std::strin
         return choc::value::Value();
     });
 
-    // pulp #932 / #1737 PR-4 - gradient-fill bridge fn for SvgPathWidget.
-    // Accepts a CSS linear-gradient string verbatim; the widget parses
+    // Gradient-fill bridge fn for SvgPathWidget. Accepts a CSS
+    // linear-gradient string verbatim; the widget parses
     // it at paint time. Intended JSX usage: `<SvgLinearGradient id="g"
     // stops={...}>` + `<SvgPath fill="url(#g)" .../>`; prop-applier
     // resolves the gradient JSX to a CSS string and calls this fn.
@@ -95,8 +93,8 @@ void WidgetBridge::register_svg_api(std::function<canvas::Color(const std::strin
         return choc::value::Value();
     });
 
-    // pulp #3656 - fill-rule (nonzero | evenodd) for SvgPathWidget.
-    // JUCE's SVGGraphicsContext lowers a stroked ellipse to a compound
+    // fill-rule (nonzero | evenodd) for SvgPathWidget. Some importers lower
+    // a stroked ellipse to a compound
     // annular `M…Z M…Z` fill that only renders the ring's hole under
     // even-odd winding; surfacing the prop lets a captured editor ship
     // those paths verbatim. SvgPath-only - SvgRect / SvgLine have no
@@ -142,8 +140,8 @@ void WidgetBridge::register_svg_api(std::function<canvas::Color(const std::strin
         return choc::value::Value();
     });
 
-    // pulp #1416 - SvgRectWidget bridge. Mirrors createSvgPath /
-    // setSvgPath. Geometry is local to the widget origin (not
+    // SvgRectWidget bridge. Mirrors createSvgPath / setSvgPath. Geometry is
+    // local to the widget origin (not
     // bounds()-translated). x/y default to 0, w/h default to 0 so an
     // unset rect is invisible by default.
     register_bridge_function(api, "createSvgRect", [this](choc::javascript::ArgumentList args) {
@@ -169,8 +167,8 @@ void WidgetBridge::register_svg_api(std::function<canvas::Color(const std::strin
         return choc::value::Value();
     });
 
-    // pulp #1416 - SvgLineWidget bridge. Mirrors createSvgPath /
-    // setSvgRect. Endpoints are local to the widget origin.
+    // SvgLineWidget bridge. Mirrors createSvgPath / setSvgRect. Endpoints
+    // are local to the widget origin.
     register_bridge_function(api, "createSvgLine", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto pid = args.get<std::string>(1, "");

--- a/core/view/src/widget_bridge/tokens_api.cpp
+++ b/core/view/src/widget_bridge/tokens_api.cpp
@@ -31,17 +31,15 @@ void WidgetBridge::register_tokens_api(std::function<canvas::Color(const std::st
         return choc::value::createFloat64(d.value_or(0.0f));
     });
 
-    // pulp #1899 (gap #3) - string-valued theme-token lookup.
-    // setStringToken(name, value) / getStringToken(name) parallel the
+    // String-valued theme-token lookup. setStringToken(name, value) /
+    // getStringToken(name) parallel the
     // motion-token / color-token APIs but back onto `theme.strings`
     // (the same map that already stores design-system font names
     // imported via Stitch / W3C tokens - see design_import.cpp). The
     // React-side prop-applier consults this to resolve `var(--mono)`
-    // in `fontFamily` / `color` / `borderColor` etc. before forwarding
-    // to setFontFamily / setTextColor - without this, Skia's font
-    // matcher received the literal string "var(--mono)" as a family
-    // name and fell through to a proportional sans, which is visible
-    // as the Spectr top-bar "faint label" symptom from #1899.
+    // in `fontFamily` / `color` / `borderColor` etc. before forwarding to
+    // setFontFamily / setTextColor; otherwise Skia's font matcher receives
+    // the literal string "var(--mono)" as a family name.
     register_bridge_function(api, "setStringToken", [this](choc::javascript::ArgumentList args) {
         auto name = args.get<std::string>(0, "");
         auto value = args.get<std::string>(1, "");

--- a/core/view/src/widget_bridge/typography_api.cpp
+++ b/core/view/src/widget_bridge/typography_api.cpp
@@ -14,20 +14,16 @@ namespace pulp::view {
 void WidgetBridge::register_widget_typography_api() {
     BridgeApiContext api{engine_};
 
-    // pulp #927: setFontFamily(id, family) was called from web-compat JS
-    // but had no C++ binding, so the call became a silent no-op. Now wires
-    // through to Label::set_font_family() and Label::paint() honors it via
+    // setFontFamily(id, family) wires web-compat font-family declarations
+    // through to Label::set_font_family(); Label::paint() honors it via
     // canvas.set_font_full().
     register_bridge_function(api, "setFontFamily", [this](choc::javascript::ArgumentList args) {
         auto* v = widget(args.get<std::string>(0, ""));
         auto family = args.get<std::string>(1, "");
         if (!v) return choc::value::Value();
-        // pulp #1737 (#932 followup): pass the comma-separated CSS
-        // family list verbatim so the SkiaCanvas typeface resolver
+        // Pass the comma-separated CSS family list verbatim so the SkiaCanvas typeface resolver
         // (skia_canvas.cpp:get_cached_typeface) can walk the fallback
-        // chain. Pre-fix the bridge stripped to the first family,
-        // dropping the rest. Now the resolver tries each family in
-        // order through registered, bundled, and SkFontMgr sources.
+        // chain through registered, bundled, and SkFontMgr sources.
         //
         // Storage layer accepts the raw comma-list; the resolver
         // splits it at paint time. Single-family inputs (no comma)
@@ -36,15 +32,14 @@ void WidgetBridge::register_widget_typography_api() {
         if (auto* l = dynamic_cast<Label*>(v)) {
             l->set_font_family(family);
         } else {
-            // pulp #1434 Phase A2-5: inheritable cascade. Mirrors the
-            // setFontWeight / setLetterSpacing pattern so a container
+            // Mirrors the setFontWeight / setLetterSpacing pattern so a container
             // View's font-family flows down to descendant Labels.
             v->set_inheritable_font_family(family);
         }
         return choc::value::Value();
     });
 
-    // issue-969: typography setters cascade. Label gets its own value;
+    // Typography setters cascade. Label gets its own value;
     // any other View (Panel, Box, container) stores the value on the
     // View's inheritable_* slot so descendant Labels pick it up. Do not
     // silently no-op on container Views; that was the dom-adapter
@@ -85,7 +80,7 @@ void WidgetBridge::register_widget_typography_api() {
         auto* v = widget(args.get<std::string>(0, ""));
         auto a = args.get<std::string>(1, "left");
         if (!v) return choc::value::Value();
-        // pulp #1434: accept all six CSS / RN textAlign values:
+        // Accept all six CSS / RN textAlign values:
         //   "left"/"start"     -> LabelAlign::left         (0)
         //   "center"           -> LabelAlign::center       (1)
         //   "right"/"end"      -> LabelAlign::right        (2)
@@ -103,8 +98,8 @@ void WidgetBridge::register_widget_typography_api() {
         if (auto* l = dynamic_cast<Label*>(v)) {
             l->set_text_align(label_a);
         } else {
-            // issue-969: container Views store the alignment in the
-            // inheritable slot for descendant Labels. Encoding extends
+            // Container Views store the alignment in the inheritable slot for
+            // descendant Labels. Encoding extends
             // 0..5 to cover auto / justify / match-parent.
             v->set_inheritable_text_align(aligned);
         }
@@ -129,8 +124,8 @@ void WidgetBridge::register_widget_typography_api() {
         } else if (auto* e = dynamic_cast<TextEditor*>(v)) {
             e->set_font_size(size);
         } else {
-            // issue-969: container Views store the size for descendant
-            // Labels via the inheritable slot.
+            // Container Views store the size for descendant Labels via the
+            // inheritable slot.
             v->set_inheritable_font_size(size);
         }
         return choc::value::Value();
@@ -147,7 +142,7 @@ void WidgetBridge::register_widget_typography_color_api(std::function<canvas::Co
         auto* v = widget(id);
         if (!v || hex.empty()) return choc::value::Value();
         auto color = parseHexColor(hex);
-        // issue-969: CSS-style cascade.
+        // CSS-style cascade.
         // - On a Label: set the Label's own explicit text_color, which
         //   wins over inheritance and theme tokens.
         // - On a container View: store the color on the inheritable
@@ -161,7 +156,7 @@ void WidgetBridge::register_widget_typography_color_api(std::function<canvas::Co
         // Keep the theme-token fallback in sync so widgets that resolve
         // through resolve_color("text.primary") (e.g. Knob/ToggleButton)
         // also pick up the override on their own subtree; preserves the
-        // pre-#969 behavior for those widgets.
+        // legacy behavior for those widgets.
         auto theme = v->theme();
         theme.colors["text.primary"] = color;
         v->set_theme(theme);
@@ -199,8 +194,7 @@ void WidgetBridge::register_widget_typography_decoration_api(std::function<canva
         return choc::value::Value();
     });
 
-    // pulp #1434 (batch 3) - text-decoration longhands. CSS shorthand
-    // text-decoration historically routed through setTextDecoration
+    // Text-decoration longhands. CSS shorthand text-decoration routes through setTextDecoration
     // above (line keyword only). The longhand triplet
     // text-decoration-line / -color / -style reaches each setter
     // independently so authors can build the decoration up piece-by-piece
@@ -267,7 +261,7 @@ void WidgetBridge::register_widget_typography_extended_api() {
     BridgeApiContext api{engine_};
 
     // setTextIndent(id, px) - CSS text-indent. Storage-only today;
-    // SkParagraph::setTextIndent integration is the paint-side follow-up.
+    // SkParagraph::setTextIndent integration is not wired yet.
     register_bridge_function(api, "setTextIndent",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");
@@ -321,7 +315,7 @@ void WidgetBridge::register_widget_typography_extended_api() {
         });
 
     // RN textShadow* per-attribute setters. Storage-only; SkPaint shadow
-    // integration is the deferred paint-time slice.
+    // integration is not wired yet.
     register_bridge_function(api, "setTextShadowColor",
         [this](choc::javascript::ArgumentList args) {
             auto id = args.get<std::string>(0, "");

--- a/core/view/src/widget_bridge/widget_value_controls_api.cpp
+++ b/core/view/src/widget_bridge/widget_value_controls_api.cpp
@@ -13,8 +13,8 @@ void WidgetBridge::register_widget_value_controls_api() {
 
     // setValue(id, value) -> set widget value
     // For Knob / Fader / Toggle this is normalised 0..1.
-    // For RangeSlider (issue-966) it's the raw value in [min,max]; the
-    // widget clamps + quantises against its own configured range.
+    // For RangeSlider it's the raw value in [min,max]; the widget clamps
+    // and quantises against its own configured range.
     register_bridge_function(api, "setValue", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto value = args.get<double>(1, 0);
@@ -62,7 +62,7 @@ void WidgetBridge::register_widget_value_controls_api() {
         return choc::value::createFloat64(0);
     });
 
-    // -- pulp issue-966: RangeSlider configuration setters -----------------
+    // RangeSlider configuration setters.
     // setMin/setMax/setStep mirror the HTMLInputElement attributes
     // `min`, `max`, `step`. Each one re-applies the widget's clamp +
     // quantisation pipeline so out-of-range values stay consistent.
@@ -91,8 +91,8 @@ void WidgetBridge::register_widget_value_controls_api() {
     });
 
     // setOrientation(id, "horizontal" | "vertical")
-    // Currently only RangeSlider (issue-966); future widgets that need
-    // an orientation can extend this dynamic_cast chain.
+    // RangeSlider and Fader consume this today; future widgets that need an
+    // orientation can extend this dynamic_cast chain.
     register_bridge_function(api, "setOrientation", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto orient = args.get<std::string>(1, "horizontal");


### PR DESCRIPTION
## Summary
- clean stale provenance/phase/PR breadcrumbs from WidgetBridge registrar comments
- preserve current compatibility notes for animation dispatch, SVG routing, RN/CSS style subsets, accessibility state, and storage/paint boundaries
- keep the batch scoped to WidgetBridge source comments with no behavior changes

## Review
- RepoPrompt/rp-cli adversarial review found one wording issue in style_storage_api.cpp; fixed by clarifying bridge storage vs downstream paint consumption
- autoreview panel: codex + claude clean, no accepted/actionable findings

## Validation
- git diff --check
- python3 tools/scripts/docs_noise_lint.py --mode=report --all
- tools/scripts/gates.sh origin/main
- pre-push gates via PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1 git push

## Notes
Comment hygiene only; compat skip trailers document unchanged html/css/rn WidgetBridge API behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned stale provenance/phase/PR breadcrumbs across `WidgetBridge` source comments and clarified wording around storage vs. paint boundaries. Preserves existing compatibility notes (animation dispatch, SVG routing, RN/CSS style subsets, accessibility state) with no code or behavior changes.

<sup>Written for commit 9b5d6429267016cb48dd169e3afefccad2f06649. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

