### PR TITLE
docs(source): clean layout geometry comment breadcrumbs

### DIFF
--- a/core/view/include/pulp/view/geometry.hpp
+++ b/core/view/include/pulp/view/geometry.hpp
@@ -59,34 +59,26 @@ struct Rect {
 // Layout mode
 enum class LayoutMode { flex, grid };
 
-// Flex layout direction.
-// pulp #1434 (rn batch B) — added row_reverse / column_reverse so RN
-// exports that emit `flexDirection: 'row-reverse' | 'column-reverse'`
-// route to YGFlexDirectionRowReverse / ColumnReverse instead of falling
-// through to YGFlexDirectionColumn.
+// Flex layout direction. row_reverse / column_reverse route
+// `flexDirection: 'row-reverse' | 'column-reverse'` to
+// YGFlexDirectionRowReverse / ColumnReverse.
 enum class FlexDirection { row, column, row_reverse, column_reverse };
 
-/// pulp #1434 Triage #14 — flex-wrap tri-state. Yoga has YGWrapNoWrap /
-/// YGWrapWrap / YGWrapWrapReverse natively. Before this slice, the
-/// FlexStyle field was a bool, so the wrap-reverse case was
-/// inexpressible — `flex-wrap: wrap-reverse` silently fell through
-/// to plain wrap.
+/// Flex-wrap tri-state. Yoga has YGWrapNoWrap / YGWrapWrap /
+/// YGWrapWrapReverse natively, so `flex-wrap: wrap-reverse` is distinct
+/// from plain wrap.
 enum class FlexWrap { no_wrap, wrap, wrap_reverse };
 
-/// pulp #1516 — CSS `box-sizing`. Yoga 3.x has `YGNodeStyleSetBoxSizing`
-/// which natively honors the spec: with `border-box`, the declared
-/// width/height includes padding + border (the inner content area
-/// shrinks); with `content-box` (CSS default), padding + border are
-/// outside the declared dimensions. Web designs almost universally
-/// reset `* { box-sizing: border-box }`, so this matters more than
-/// the +1 catalog entry suggests — many imports only lay out
-/// correctly under border-box.
+/// CSS `box-sizing`. Yoga 3.x has `YGNodeStyleSetBoxSizing` which natively
+/// honors the spec: with `border-box`, the declared width/height includes
+/// padding + border (the inner content area shrinks); with `content-box`
+/// (CSS default), padding + border are outside the declared dimensions.
+/// Many imports only lay out correctly under border-box because web designs
+/// commonly reset `* { box-sizing: border-box }`.
 enum class BoxSizing { content_box, border_box };
 
 // Flex alignment (auto_ = inherit from parent's align_items).
-// pulp #1434 (rn batch B) — added `baseline`. Yoga has YGAlignBaseline
-// natively; before this batch, RN exports emitting
-// `alignItems: 'baseline'` silently fell through to stretch.
+// `baseline` maps to YGAlignBaseline.
 enum class FlexAlign { start, center, end, stretch, auto_, baseline };
 
 /// Justify content modes (main axis space distribution)
@@ -167,13 +159,12 @@ struct FlexStyle {
     FlexAlign align_items = FlexAlign::stretch;
     FlexAlign align_self = FlexAlign::auto_;  ///< Override parent's align_items for this child
 
-    /// pulp #1434 (sub-agent #12 follow-up) — align-content is the
-    /// CSS / Yoga multi-line flex cross-axis distribution control.
-    /// Yoga supports it natively via YGNodeStyleSetAlignContent; the
-    /// only gap was a missing FlexStyle field + setter wiring. Default
-    /// matches Yoga's default (FlexStart) — note this differs from
-    /// CSS's `normal`/`stretch` defaults but matches Yoga / RN. The
-    /// usual `space-between`/`space-around`/`space-evenly` /
+    /// align-content is the CSS / Yoga multi-line flex cross-axis
+    /// distribution control. Yoga supports it natively via
+    /// YGNodeStyleSetAlignContent. Default matches Yoga's default
+    /// (FlexStart) — note this differs from CSS's `normal`/`stretch`
+    /// defaults but matches Yoga / RN. The usual
+    /// `space-between`/`space-around`/`space-evenly` /
     /// `flex-start`/`flex-end`/`center`/`stretch` values all map to
     /// the existing FlexAlign enum + the FlexJustify space-* values
     /// via `to_yg_align_content` in yoga_layout.cpp.
@@ -216,15 +207,15 @@ struct FlexStyle {
     float max_width = 0;        ///< 0 = no maximum
     float max_height = 0;       ///< 0 = no maximum
 
-    /// Viewport-relative dimension overrides. When set (unit != px with value 0),
-    /// these are resolved before layout and override the corresponding float fields.
+    /// Viewport-relative dimension overrides. Non-default units or non-zero
+    /// values are resolved before layout and override the corresponding float
+    /// fields.
     /// Yoga's native percent / auto APIs are dispatched on these in
     /// `yoga_layout.cpp::apply_flex_style` when `unit != px`.
-    /// pulp #1434 (rn batch C) — added `dim_max_width` / `dim_max_height` /
-    /// `dim_flex_basis` so percent and `auto` strings on max-* and flex-basis
+    /// `resolve_dimensions()` resolves preferred/min dimensions for the local
+    /// scalar fields; max-* and flex-basis stay as Dimension values so they can
     /// reach Yoga's `YGNodeStyleSet{MaxWidth,MaxHeight,FlexBasis}Percent` and
-    /// `YGNodeStyleSetFlexBasisAuto` instead of being truncated to plain
-    /// floats. min_* already had Dimension fields from earlier work.
+    /// `YGNodeStyleSetFlexBasisAuto` instead of being truncated to plain floats.
     Dimension dim_width;
     Dimension dim_height;
     Dimension dim_min_width;
@@ -233,10 +224,8 @@ struct FlexStyle {
     Dimension dim_max_height;
     Dimension dim_flex_basis;
 
-    /// pulp #1434 (cross-surface mega-batch) — per-edge margin / padding
-    /// accept percent strings (and `auto` for margin only). Mirrors the
-    /// width/height (#1426) and top/right/bottom/left (#1451) percent
-    /// patterns. yoga_layout.cpp dispatches on `dim_*.unit` to
+    /// Per-edge margin / padding accept percent strings (and `auto` for
+    /// margin only). yoga_layout.cpp dispatches on `dim_*.unit` to
     /// `YGNodeStyleSetMargin{Percent,Auto}` /
     /// `YGNodeStyleSetPaddingPercent` for the non-px paths. Yoga's
     /// padding does not support `auto` (only margin does — see Yoga
@@ -250,12 +239,12 @@ struct FlexStyle {
     Dimension dim_padding_bottom;
     Dimension dim_padding_left;
 
-    /// pulp #1542 — yoga logical-edge fan-out. CSS / RN logical edges
-    /// (`marginStart` / `marginEnd` / `paddingStart` / `paddingEnd` /
-    /// `start` / `end`) flip with the writing direction: in LTR, `start`
-    /// is the left edge; in RTL, `start` is the right edge. Yoga
-    /// resolves this natively via `YGEdgeStart` / `YGEdgeEnd` once the
-    /// node's writing direction is set (see `writing_direction` below).
+    /// Yoga logical-edge fan-out. CSS / RN logical edges (`marginStart` /
+    /// `marginEnd` / `paddingStart` / `paddingEnd` / `start` / `end`) flip
+    /// with the writing direction: in LTR, `start` is the left edge; in RTL,
+    /// `start` is the right edge. Yoga resolves this natively via
+    /// `YGEdgeStart` / `YGEdgeEnd` once the node's writing direction is set
+    /// (see `writing_direction` below).
     /// yoga_layout.cpp dispatches on `dim_*.unit`:
     ///   • px      → YGNodeStyleSetMargin/Padding/Position(YGEdgeStart|End)
     ///   • percent → YGNodeStyleSetMargin/Padding/PositionPercent(...)
@@ -271,8 +260,8 @@ struct FlexStyle {
     Dimension dim_start;
     Dimension dim_end;
 
-    /// pulp #1542 — node writing direction. Controls how Yoga resolves
-    /// `YGEdgeStart` / `YGEdgeEnd` (and how it lays out row-axis
+    /// Node writing direction. Controls how Yoga resolves `YGEdgeStart` /
+    /// `YGEdgeEnd` (and how it lays out row-axis
     /// children when no explicit start/end edge is set). Defaults to
     /// `inherit` so the layout root's direction propagates down. The
     /// bridge accepts the `direction_writing` sub-key on `setFlex`
@@ -296,21 +285,15 @@ struct FlexStyle {
             min_height = dim_min_height.resolve(parent_h, viewport_w, viewport_h, dpi);
     }
 
-    /// pulp #1434 Triage #14 — tri-state wrap. CSS / RN allow
-    /// `wrap-reverse` (overflows wrap UP instead of DOWN, or RIGHT
-    /// instead of LEFT depending on flex-direction). Yoga has
-    /// YGWrapWrapReverse for this; previously flex_wrap was a bool
-    /// expressible only as wrap / no-wrap. Bridge accepts numeric (0/1
-    /// for backward compat) and the CSS keyword strings ("wrap" /
-    /// "wrap-reverse" / "nowrap" / "no-wrap").
+    /// Tri-state wrap. CSS / RN allow `wrap-reverse` (overflows wrap UP
+    /// instead of DOWN, or RIGHT instead of LEFT depending on flex-direction).
+    /// Yoga has YGWrapWrapReverse for this. Bridge accepts numeric (0/1 for
+    /// backward compat) and the CSS keyword strings ("wrap" / "wrap-reverse" /
+    /// "nowrap" / "no-wrap").
     FlexWrap flex_wrap = FlexWrap::no_wrap;
-    /// pulp #1516 — CSS `box-sizing`. Default is `border_box` to match
-    /// Yoga 3.x's own default AND pulp's prior implicit behavior (no
-    /// existing fixture / consumer was prepared for content-box layout
-    /// math, even though that's the CSS spec default). Web designs
-    /// almost universally reset to `border-box` via
-    /// `* { box-sizing: border-box }`, so this matches what consumers
-    /// pasting JSX from Figma / v0 / Claude Design HTML expect.
+    /// CSS `box-sizing`. Default is `border_box` to match Yoga 3.x's own
+    /// default and the web-import convention that most pasted JSX already
+    /// assumes via `* { box-sizing: border-box }`.
     /// Setting `content-box` opts in to CSS-spec behavior:
     /// `width = 100; padding = 10` → outer width = 120 instead of 100.
     BoxSizing box_sizing = BoxSizing::border_box;
@@ -318,9 +301,8 @@ struct FlexStyle {
 
     /// Aspect ratio (width / height). When set, Yoga sizes the cross axis
     /// to match `main_axis / aspect_ratio` (or the inverse, depending on
-    /// which dimension is constrained). pulp #1434 — RN exports use
-    /// `aspectRatio` for image cards / video tiles; Figma exports for
-    /// fixed-ratio frames; v0/Claude Design generate it for hero images.
+    /// which dimension is constrained). Imports use `aspectRatio` for image
+    /// cards, video tiles, fixed-ratio frames, and hero images.
     /// std::optional distinguishes "unset" from a literal 0 value (which
     /// would be invalid anyway, but the optional makes the intent explicit
     /// at the dispatcher boundary). Accepts plain numbers (1.5),
@@ -334,8 +316,7 @@ struct FlexStyle {
     float margin_b() const { return margin_bottom >= 0 ? margin_bottom : margin; }
     float margin_l() const { return margin_left >= 0 ? margin_left : margin; }
 
-    // Helper: resolve directional gap.
-    // pulp #1434 (rn batch B) — row_reverse counts as a row-axis
+    // Helper: resolve directional gap. row_reverse counts as a row-axis
     // container; the visual reversal doesn't change which gap edge
     // (column-gap) sits between siblings.
     float effective_gap(FlexDirection dir) const {
@@ -364,7 +345,7 @@ struct GridTrack {
 
 /// Grid layout properties (CSS Grid Level 1 subset).
 ///
-/// pulp #1434 Phase A2-2 extends the existing infrastructure with:
+/// Supports:
 ///   • grid-auto-columns / grid-auto-rows  — implicit-track sizing
 ///   • grid-auto-flow                       — row / column / dense
 ///   • grid-template-areas                  — named-area string parser
@@ -374,13 +355,13 @@ struct GridStyle {
     std::vector<GridTrack> template_columns;  ///< grid-template-columns
     std::vector<GridTrack> template_rows;     ///< grid-template-rows
 
-    /// pulp #1434 Phase A2-2 — implicit-track sizing for auto-placed
-    /// items that overflow the explicit grid. CSS spec: a single
-    /// track template that's repeated for every implicit row/column.
+    /// Implicit-track sizing for auto-placed items that overflow the explicit
+    /// grid. CSS spec: a single track template that's repeated for every
+    /// implicit row/column.
     GridTrack auto_columns = GridTrack::auto_size();
     GridTrack auto_rows    = GridTrack::auto_size();
 
-    /// pulp #1434 Phase A2-2 — auto-flow direction.
+    /// Auto-flow direction.
     enum class AutoFlow {
         row,           ///< default; fill rows left-to-right then wrap
         column,        ///< fill columns top-to-bottom then wrap
@@ -392,8 +373,8 @@ struct GridStyle {
     float column_gap = 0;                     ///< grid-column-gap
     float row_gap = 0;                        ///< grid-row-gap
 
-    /// pulp #1434 Phase A2-2 — named-area grid. Each entry is
-    /// `{name, col_start, col_end, row_start, row_end}` (1-based,
+    /// Named-area grid. Each entry is `{name, col_start, col_end,
+    /// row_start, row_end}` (1-based,
     /// matching CSS line-numbering). Populated by
     /// `parse_template_areas("'h h h' 'm c c' 'f f f'")`. The
     /// per-child `grid_area` field below references one of these
@@ -412,17 +393,17 @@ struct GridStyle {
     int grid_column_end = 0;    ///< 0 = span 1
     int grid_row_start = 0;
     int grid_row_end = 0;
-    /// pulp #1434 Phase A2-2 — `grid-area: header` references the
-    /// parent's NamedArea by name. Empty string means "no named-area
-    /// reference; use the explicit start/end fields above."
+    /// `grid-area: header` references the parent's NamedArea by name.
+    /// Empty string means "no named-area reference; use the explicit
+    /// start/end fields above."
     std::string grid_area_name;
 
     /// Parse "1fr 2fr auto 100px" into track list. `depth` bounds recursion
     /// into nested `repeat(...)` bodies from untrusted design-tool input.
     static std::vector<GridTrack> parse_template(const std::string& tmpl, int depth = 0);
 
-    /// pulp #1434 Phase A2-2 — parse the CSS named-area grid string
-    /// (e.g. `"'h h h' 'm c c' 'f f f'"`) into the NamedArea list.
+    /// Parse the CSS named-area grid string (e.g.
+    /// `"'h h h' 'm c c' 'f f f'"`) into the NamedArea list.
     /// Each row is wrapped in single quotes; cells within a row are
     /// space-separated. Cells that share a name across adjacent rows
     /// or columns merge into a single rectangular area. `'.'` is the

--- a/core/view/include/pulp/view/layout_snapshot.hpp
+++ b/core/view/include/pulp/view/layout_snapshot.hpp
@@ -35,7 +35,7 @@ std::string dump_layout_tree(
     const View& root,
     const LayoutTreeSnapshotOptions& options = {});
 
-/// Compare two dump_layout_tree() JSON strings with the Phase 2 oracle rules:
+/// Compare two dump_layout_tree() JSON strings with the layout oracle rules:
 /// node kind/id/visibility/z-order/overflow must match exactly, numeric layout
 /// bounds must match exactly by default, and text-box dimensions allow a small
 /// tolerance for text measurement. Golden-file callers that compare snapshots

--- a/core/view/js/web-compat.js
+++ b/core/view/js/web-compat.js
@@ -428,18 +428,16 @@ Element.prototype.setAttribute = function(name, value) {
     else if (name.indexOf("data-") === 0) {
         this._dataset[_camelCase(name.slice(5))] = value;
     }
-    // pulp #2163 — font v2 Slice 2.5. The HTML `dir` attribute
-    // (`<div dir="rtl">…</div>`) parallels the CSS `direction: rtl`
-    // path (web-compat-style-decl.js → setDirection). Both routes
-    // land on View::WritingDirection which Yoga consumes for
-    // container child-order flip + the shaper consumes for bidi
-    // base direction. Values: "ltr" | "rtl" | "auto" (CSS spec).
+    // The HTML `dir` attribute (`<div dir="rtl">…</div>`) parallels the CSS
+    // `direction: rtl` path (web-compat-style-decl.js -> setDirection). Both
+    // routes land on View::WritingDirection, which Yoga consumes for container
+    // child-order flip and the shaper consumes for bidi base direction. Values:
+    // "ltr" | "rtl" | "auto" (CSS spec).
     else if (name === "dir" && typeof setDirection !== "undefined") {
-        // Codex review on PR #2181 (P2): the CSS `direction` path
-        // forwards every value to the bridge and lets it coerce
-        // unknowns to `auto_`. Mirror that here so dynamic updates
-        // from `dir="rtl"` to an unsupported value reset to default
-        // rather than leaving the previous bidi/layout state stuck.
+        // Match the CSS `direction` path: forward every value to the bridge and
+        // let it coerce unknowns to `auto_`. That lets dynamic updates from
+        // `dir="rtl"` to an unsupported value reset to default rather than
+        // leaving the previous bidi/layout state stuck.
         setDirection(this._id, String(value).toLowerCase());
     }
 };
@@ -1101,10 +1099,9 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         // Display / flex direction
         case "display":
             if (resolved === "none") { setVisible(id, false); }
-            // pulp #1420 — inline-block ≡ block, inline-flex ≡ flex in pulp's
-            // non-text-flowing layout (matches RN + CSS formatting-context
-            // semantics where there is no inline flow). 4 of these were
-            // silently dropped by Spectr today.
+            // inline-block ≡ block and inline-flex ≡ flex in Pulp's
+            // non-text-flowing layout. That matches the RN-style bridge where
+            // there is no inline formatting context to preserve.
             else if (resolved === "flex" || resolved === "block" ||
                      resolved === "inline-block" || resolved === "inline-flex") {
                 setVisible(id, true);
@@ -1112,9 +1109,9 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             else if (resolved === "grid") { /* grid mode set via gridTemplateColumns */ }
             break;
         case "flexDirection":
-            // pulp #1434 (rn batch B) — forward all four CSS values
-            // verbatim so the bridge can route to YGFlexDirectionRow /
-            // RowReverse / Column / ColumnReverse.
+            // Forward reverse/row keywords verbatim and map CSS `column` to the
+            // bridge shorthand `col`; the bridge routes these to
+            // YGFlexDirectionRow / RowReverse / Column / ColumnReverse.
             setFlex(id, "direction",
                 resolved === "row" ? "row" :
                 resolved === "row-reverse" ? "row-reverse" :
@@ -1122,8 +1119,8 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
                 "col");
             break;
         case "flexWrap":
-            // pulp #1434 Triage #14 — forward keyword verbatim so the
-            // bridge can route wrap-reverse through YGWrapWrapReverse.
+            // Forward keyword values verbatim so the bridge can route
+            // wrap-reverse through YGWrapWrapReverse.
             setFlex(id, "flex_wrap", resolved);
             break;
         case "flexGrow":
@@ -1172,8 +1169,8 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             break;
         }
 
-        // Dimensions — pulp #1423 forwards percent values verbatim so
-        // the bridge can route to Yoga's percent API.
+        // Dimensions forward percent values verbatim so the bridge can route
+        // to Yoga's percent API.
         case "width": {
             var w = parseCSSLength(resolved);
             if (!w) break;
@@ -1407,8 +1404,8 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         case "position":
             setPosition(id, resolved);
             break;
-        // pulp #1434 batch 6 — top/right/bottom/left forward percent
-        // values verbatim so the bridge can route to Yoga's percent API.
+        // top/right/bottom/left forward percent values verbatim so the bridge
+        // can route to Yoga's percent API.
         case "top": {
             var tv = parseCSSLength(resolved); if (!tv) break;
             if (tv.unit === "%") setTop(id, tv.value + "%"); else setTop(id, tv.value);
@@ -1435,7 +1432,8 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             setZIndex(id, parseInt(resolved) || 0);
             break;
 
-        // Box shadow: "2px 4px 8px rgba(0,0,0,0.3)" or "inset 2px 4px 8px ..." (issue-925)
+        // Box shadow: "2px 4px 8px rgba(0,0,0,0.3)" or
+        // "inset 2px 4px 8px ...".
         case "boxShadow": {
             if (resolved === "none" || resolved === "" || resolved == null) {
                 if (typeof clearBoxShadow === "function") clearBoxShadow(id);
@@ -1551,11 +1549,9 @@ CSSStyleDeclaration.prototype.setProperty = function(name, value) {
     // --custom-property -> set as theme token
     if (name.indexOf("--") === 0) {
         var tokenName = name.slice(2);
-        // pulp #1918 (Codex review) — clear every non-active slot
-        // first so a var() reassignment that changes the value type
-        // (string ↔ length ↔ color) doesn't leave a stale token in
-        // one of the other slots. See the matching fix and rationale
-        // in web-compat-style-decl.js.
+        // Clear the non-color token slots first so a var() reassignment between
+        // string and length values doesn't leave a stale token in the other
+        // slot. See the matching rationale in web-compat-style-decl.js.
         if (typeof setStringToken === 'function') setStringToken(tokenName, "");
         if (typeof setMotionToken === 'function') setMotionToken(tokenName, 0);
         var parsed = parseCSSLength(value);
@@ -1568,9 +1564,8 @@ CSSStyleDeclaration.prototype.setProperty = function(name, value) {
                 // Use applyTokenDiff for color tokens
                 applyTokenDiff('{"colors":{"' + tokenName + '":"' + color + '"}}');
             } else if (typeof setStringToken === 'function') {
-                // pulp #1899 (gap #3) — string-valued custom property
-                // (font family / arbitrary string). Mirrors
-                // web-compat-style-decl.js.
+                // String-valued custom property (font family / arbitrary
+                // string). Mirrors web-compat-style-decl.js.
                 setStringToken(tokenName, String(value));
             }
         }
@@ -1584,8 +1579,7 @@ CSSStyleDeclaration.prototype.setProperty = function(name, value) {
 CSSStyleDeclaration.prototype.getPropertyValue = function(name) {
     if (name.indexOf("--") === 0) {
         var tokenName = name.slice(2);
-        // pulp #1899 (gap #3) — string-token round-trip; mirrors
-        // web-compat-style-decl.js.
+        // String-token round-trip; mirrors web-compat-style-decl.js.
         if (typeof getStringToken === 'function') {
             var s = getStringToken(tokenName);
             if (s) return s;
@@ -1942,4 +1936,3 @@ var window = {
     // window.onerror
     onerror: null
 };
-

--- a/core/view/src/view.cpp
+++ b/core/view/src/view.cpp
@@ -601,14 +601,14 @@ void View::paint_all(canvas::Canvas& canvas) {
         }
     }
 
-    // Focus ring — only show on text input widgets, not sliders/toggles/meters
-    // Matches CSS :focus-visible behavior (keyboard focus on text inputs)
+    // No generic focus ring is painted here; text-capable widgets provide
+    // their own focus affordance.
     if (has_focus_ && focusable_ &&
         access_role_ != AccessRole::slider &&
         access_role_ != AccessRole::toggle &&
         access_role_ != AccessRole::meter) {
-        // TextEditor handles its own focus border, so skip the generic ring
-        // for views that paint their own focus state
+        // Intentionally empty: TextEditor handles its own focus border, so
+        // skip the generic ring.
     }
 
     // End compositing layer (restore pops the saveLayer, compositing the subtree)
@@ -686,6 +686,7 @@ void View::simulate_drag(Point start, Point end, int steps) {
     if (pulp::view::motion::input_recording_enabled()) {
         const std::string id = target ? target->id() : std::string();
         std::vector<std::pair<std::string, double>> coords;
+        // Recorded coordinates are keyed fields; insertion order is not semantic.
         coords.emplace_back("end_x",   static_cast<double>(end.x));
         coords.emplace_back("end_y",   static_cast<double>(end.y));
         coords.emplace_back("start_x", static_cast<double>(start.x));
@@ -1257,9 +1258,8 @@ std::vector<GridTrack> GridStyle::parse_template(const std::string& tmpl, int de
     }
     if (!token.empty()) tokens.push_back(token);
 
-    // Parse a numeric prefix without throwing; std::stof on a non-numeric
-    // token (e.g. the CSS initial value `none`) used to throw out of
-    // WidgetBridge::load_script. Returns false for unparseable tokens.
+    // Parse a numeric prefix without throwing. Non-numeric tokens (e.g. the
+    // CSS initial value `none`) are skipped instead of propagating an exception.
     auto try_parse = [](const std::string& s, float& out) -> bool {
         try {
             size_t consumed = 0;
@@ -1466,7 +1466,7 @@ static void layout_grid(View& parent) {
         if (t.type == GridTrack::Type::fr && total_fr_w > 0) {
             col_widths[static_cast<size_t>(i)] = remaining_w * (t.value / total_fr_w);
         } else if (t.type == GridTrack::Type::auto_) {
-            // Auto: share remaining equally among auto tracks
+            // Auto: share remaining width using the current total column count.
             col_widths[static_cast<size_t>(i)] = remaining_w / std::max(1.0f, static_cast<float>(num_cols));
         }
     }

--- a/core/view/src/widget_bridge/layout_api.cpp
+++ b/core/view/src/widget_bridge/layout_api.cpp
@@ -116,8 +116,9 @@ void WidgetBridge::register_layout_flex_api() {
         if (!v) return choc::value::Value();
         auto& f = v->flex();
         auto val = args.get<double>(2, 0);
-        // Slider/drag jitter diagnostic. When PULP_DEBUG_FLEX_THRASH=1, log
-        // every setFlex call so per-frame style churn during a drag is visible.
+        // Slider/drag jitter diagnostic. When PULP_DEBUG_FLEX_THRASH is set to
+        // any value, log every setFlex call so per-frame style churn during a
+        // drag is visible.
         // The getenv result is cached on first call and only emits when enabled.
         static const bool flex_thrash_log = std::getenv("PULP_DEBUG_FLEX_THRASH") != nullptr;
         if (flex_thrash_log) {
@@ -139,10 +140,10 @@ void WidgetBridge::register_layout_flex_api() {
         else if (key == "gap") f.gap = (float)val;
         else if (key == "padding") f.padding = (float)val;
         // Per-edge padding accepts either a number ("10" -> px) or a
-        // percentage string ("5%" -> percent of parent main-axis size). Yoga
-        // padding does not support "auto", so unrecognized strings fall
-        // through to the px path with the parsed numeric value, or 0 on total
-        // parse failure. Mirrors width/height/min/max patterns.
+        // percentage string ("5%" -> percent of the parent's width / inline
+        // size). Yoga padding does not support "auto", so unrecognized strings
+        // fall through to the px path with the parsed numeric value, or 0 on
+        // total parse failure. Mirrors width/height/min/max patterns.
         else if (key == "padding_top") {
             auto sval = args.get<std::string>(2, "");
             if (!sval.empty() && sval.back() == '%') {
@@ -336,10 +337,11 @@ void WidgetBridge::register_layout_flex_api() {
                 f.dim_max_height.unit = pulp::view::DimensionUnit::px;
             }
         }
-        // Aspect ratio is the width/height ratio. A value <= 0 or NaN clears
-        // the slot, matching CSS `aspect-ratio: auto`; a finite positive value
-        // pins it. The CSS shim parses both `1.5` and `16/9` before reaching
-        // here, and @pulp/react accepts `aspectRatio` directly as a number.
+        // Aspect ratio is the width/height ratio. Any non-finite or
+        // non-positive value clears the slot, matching CSS `aspect-ratio: auto`;
+        // a finite positive value pins it. The CSS shim parses both `1.5` and
+        // `16/9` before reaching here, and @pulp/react accepts `aspectRatio`
+        // directly as a number.
         else if (key == "aspect_ratio" || key == "aspectRatio") {
             if (val > 0.0 && std::isfinite(val)) f.aspect_ratio = (float)val;
             else f.aspect_ratio.reset();
@@ -347,10 +349,10 @@ void WidgetBridge::register_layout_flex_api() {
         // Margin
         else if (key == "margin") f.margin = (float)val;
         // Per-edge margin accepts a number ("10" -> px), a percentage string
-        // ("5%" -> percent of parent main-axis size), or "auto" for Yoga's
-        // YGNodeStyleSetMarginAuto path. Yoga supports `auto` on margin only,
-        // not padding. yoga_layout.cpp dispatches on dim_margin_*.unit; the
-        // legacy float field uses -1 as a sentinel so uniform `margin`
+        // ("5%" -> percent of the parent's width / inline size), or "auto" for
+        // Yoga's YGNodeStyleSetMarginAuto path. Yoga supports `auto` on margin
+        // only, not padding. yoga_layout.cpp dispatches on dim_margin_*.unit;
+        // the legacy float field uses -1 as a sentinel so uniform `margin`
         // consumers keep working.
         else if (key == "margin_top") {
             auto sval = args.get<std::string>(2, "");
@@ -702,8 +704,9 @@ void WidgetBridge::register_layout_box_model_api() {
     // CSS box-sizing keyword. Yoga's `YGNodeStyleSetBoxSizing` honors the spec,
     // so record the enum on FlexStyle and let `build_yoga_subtree` route it
     // through.
-    // Default `content-box` matches the CSS spec; web designs typically
-    // reset to `border-box` via `* { box-sizing: border-box }`.
+    // The unset FlexStyle default is `border-box` to match Yoga/imported web
+    // layout convention; this setter maps absent or unknown keywords to
+    // `content-box`, the CSS-spec keyword default.
     register_bridge_function(api, "setBoxSizing", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto kw = args.get<std::string>(1, "content-box");
@@ -725,7 +728,7 @@ void WidgetBridge::register_layout_box_model_api() {
 void WidgetBridge::register_layout_position_api() {
     BridgeApiContext api{engine_};
 
-    // setPosition(id, "static"/"relative"/"absolute"/"fixed") — CSS position
+    // setPosition(id, "static"/"relative"/"absolute"/"fixed"/"sticky") — CSS position
     // Instrument under PULP_DEBUG_FLEX_THRASH so we can see whether JSX
     // `position: "absolute"` reaches the bridge. When runtime React imports
     // miss this path, inline absolute children render at the wrong place.


### PR DESCRIPTION
## Summary

- remove stale issue/phase/batch breadcrumbs from layout geometry comments
- tighten current Yoga/CSS/grid/layout notes in `geometry.hpp`, `layout_api.cpp`, and `view.cpp`
- clean matching web-compat layout shim comments for display, flex direction/wrap, percent dimensions, offsets, `dir`, box-shadow, and CSS custom-property token handling

This is comment-only; no behavior changes intended.

## Validation

- Read `CLAUDE.md`
- RepoPrompt/rp-cli review on the selected layout/web-compat files; fixed all findings
- `git diff --check`
- targeted stale-marker scan on touched files
- comment-only changed-line check against `origin/main`
- `python3 tools/scripts/docs_noise_lint.py --mode=report --all`
- `tools/scripts/gates.sh origin/main`
- pre-push gates with `PULP_VIA_SHIPYARD=1 PULP_SKIP_DIFF_COVER=1`
- `/Users/danielraffel/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --reviewers codex,claude`
  - result: clean, 0 Codex findings, 0 Claude findings

## Queue note

Held this branch until the obsolete #4444 pull_request runs were canceled after #4444 merged. The remaining #4444 jobs are post-merge main push follow-ups.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale issue/phase/batch breadcrumbs from layout comments and clarified Yoga/CSS/Grid behavior across `geometry.hpp`, `layout_api.cpp`, `view.cpp`, `layout_snapshot.hpp`, and `web-compat.js`. Comment-only; clarifies display/flex direction and wrap, percent dimensions and offsets, logical start/end and `dir`, box-shadow, custom-property tokens, aspect-ratio, and box-sizing, with no behavior changes.

<sup>Written for commit 05dc2bc62d05fd15f9920b6d2401f29b896667bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

