### PR TITLE
docs(source): clean web-compat JS comment breadcrumbs

### DIFF
--- a/core/view/js/import-runtime.js
+++ b/core/view/js/import-runtime.js
@@ -1,5 +1,5 @@
 // import-runtime.js — DOM construction + walker for the
-// `--execute-bundle` Claude Design import lane (pulp #468).
+// `--execute-bundle` Claude Design import lane.
 //
 // Two responsibilities, both gated behind the `__pulpImportRuntime__`
 // global so they don't pollute the runtime when the harness isn't in

--- a/core/view/js/web-compat-document.js
+++ b/core/view/js/web-compat-document.js
@@ -173,7 +173,7 @@ function _setupPseudoHover(el, props) {
 // suffixed with a single `:hover` / `:focus` / `:active` pseudo-class,
 // comma-separated selector lists, and `prop: value;` declarations.
 //
-// Out of scope for this slice (deferred follow-ups):
+// Out of scope for this conservative CSS-text parser:
 //   - Descendant / child / sibling combinators in the CSS-text input
 //     (the underlying matcher supports them via `_parseSelector` but
 //     bringing them through the text parser opens a larger correctness

--- a/core/view/js/web-compat-element-events.js
+++ b/core/view/js/web-compat-element-events.js
@@ -1,5 +1,5 @@
 // ═══════════════════════════════════════════════════════════════════════════════
-// Events + Pointer-capture (P5-7 follow-up — extracted from web-compat-element.js)
+// Events + Pointer-capture support extracted from web-compat-element.js
 // ═══════════════════════════════════════════════════════════════════════════════
 //
 // Two coherent subsurfaces of the DOM Event surface:
@@ -351,11 +351,10 @@ function _dispatchEvent(target, event) {
     var el = target._parentElement;
     while (el) { path.unshift(el); el = el._parentElement; }
 
-    // pulp jsx-instrument-import diag 2026-05-17 — log every dispatch
-    // path for pointer/click/mouse events so we can see if the bubble
-    // chain reaches __root__ where React-DOM delegate is registered.
-    // Gated by globalThis.__pulpDebugDispatch__ to keep silent in
-    // normal runs.
+    // Debug-only dispatch logging for pointer/click/mouse events. Shows whether
+    // the bubble chain reaches __root__ where the React-DOM delegate is
+    // registered. Gated by globalThis.__pulpDebugDispatch__ to keep normal runs
+    // silent.
     if (globalThis.__pulpDebugDispatch__ && /^(click|mousedown|mouseup|pointerdown|pointerup)$/.test(event.type)) {
         var pathIds = path.map(function (e) { return e._id; }).join(">");
         var rootListeners = (__eventListeners__["__root__"]

--- a/core/view/js/web-compat-runtime-apis.js
+++ b/core/view/js/web-compat-runtime-apis.js
@@ -1,4 +1,4 @@
-// web-compat-runtime-apis.js — Phase 9 runtime API shims
+// web-compat-runtime-apis.js — runtime API shims
 //
 // Extracted verbatim from the legacy web-compat.js bundle. Provides the
 // browser runtime globals: performance, navigator.clipboard, localStorage /
@@ -9,7 +9,7 @@
 // (tools/harness/adapters/html.py).
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// Phase 9: Runtime APIs
+// Runtime APIs
 // ═══════════════════════════════════════════════════════════════════════════════
 
 // performance.now() — high-resolution monotonic time

--- a/core/view/js/web-compat-style-decl-paint.js
+++ b/core/view/js/web-compat-style-decl-paint.js
@@ -164,7 +164,8 @@ function _applyPaintProp(decl, id, key, resolved, value) {
             setOpacity(id, parseFloat(resolved) || 0);
             return true;
 
-        // Box shadow: "2px 4px 8px rgba(0,0,0,0.3)" or "inset 2px 4px 8px ..." (issue-925)
+        // Box shadow: "2px 4px 8px rgba(0,0,0,0.3)" or
+        // "inset 2px 4px 8px ...".
         case "boxShadow": {
             if (resolved === "none" || resolved === "" || resolved == null) {
                 if (typeof clearBoxShadow === "function") clearBoxShadow(id);
@@ -242,12 +243,10 @@ function _applyPaintProp(decl, id, key, resolved, value) {
             return true;
         }
 
-        // CSS `mask-image`. Storage-only today; the
-        // paint pipeline does not yet composite a shader mask onto a
-        // saveLayer. Forwarding the value through to the bridge keeps
-        // the slot round-trippable so harness tests can assert the
-        // shim accepts the value, and so a future paint slice can
-        // honor it without a JS-side change.
+        // CSS `mask-image`. The bridge stores the value on the View;
+        // mask-capable paint backends consume supported forms (currently
+        // `url(...)` and `linear-gradient(...)`) and fall back to no-mask
+        // painting for unsupported or unparseable forms.
         case "maskImage": {
             if (typeof setMaskImage !== "function") return true;
             var miv = String(resolved).trim();
@@ -256,9 +255,8 @@ function _applyPaintProp(decl, id, key, resolved, value) {
             return true;
         }
 
-        // `mask-size` pairs with mask-image.
-        // Storage-only today; consumed by the future paint slice that
-        // wires the mask shader onto the saveLayer.
+        // `mask-size` pairs with mask-image and is consumed by mask-capable
+        // paint backends when the mask image resolves to a shader.
         case "maskSize": {
             if (typeof setMaskSize !== "function") return true;
             setMaskSize(id, String(resolved).trim());
@@ -279,8 +277,8 @@ function _applyPaintProp(decl, id, key, resolved, value) {
         }
 
         // CSS `object-fit` — controls fitting of <img> intrinsic
-        // size into its layout box. Storage-only today; ImageView
-        // paint-time consumption needs natural-size access (follow-up).
+        // size into its layout box. Image-like paint paths consume it
+        // when mapping source content into their bounds.
         case "objectFit": {
             if (typeof setObjectFit !== "function") return true;
             setObjectFit(id, String(resolved).trim());
@@ -288,7 +286,8 @@ function _applyPaintProp(decl, id, key, resolved, value) {
         }
 
         // CSS `object-position` — alignment of object-fit residual
-        // space. Pairs with object-fit. Storage-only today.
+        // space. Pairs with object-fit; image-like paint paths consume it
+        // to offset fitted content within the destination rect.
         case "objectPosition": {
             if (typeof setObjectPosition !== "function") return true;
             setObjectPosition(id, String(resolved).trim());
@@ -299,9 +298,10 @@ function _applyPaintProp(decl, id, key, resolved, value) {
         // sub-property out (it's the only longhand we support today)
         // and forward both the shorthand verbatim (so View::mask()
         // round-trips) and the extracted image to setMaskImage.
-        // The remaining longhands (mode / repeat / position / size /
-        // origin / clip / composite) are deferred — the saveLayer +
-        // SkBlendMode::kDstIn paint slice is the follow-up.
+        // The remaining shorthand longhands (mode / repeat / position /
+        // size / origin / clip / composite) are not fanned out of the
+        // shorthand yet; unsupported image forms are stored but fall
+        // back to no-mask painting.
         case "mask": {
             if (typeof setMask === "function") {
                 setMask(id, String(resolved));
@@ -315,8 +315,8 @@ function _applyPaintProp(decl, id, key, resolved, value) {
                     // radial-gradient(...) substring out and treat the
                     // rest as deferred sub-properties. Solid-color
                     // masks (`mask: black`) flow through verbatim too;
-                    // the bridge stores the value but doesn't paint it
-                    // yet.
+                    // unsupported forms are stored but fall back to
+                    // no-mask painting.
                     var imgm = mv.match(/(url\([^)]*\)|(?:linear|radial|conic)-gradient\([^)]*\))/);
                     setMaskImage(id, imgm ? imgm[1] : mv);
                 }

--- a/core/view/js/web-compat-style-decl-transform.js
+++ b/core/view/js/web-compat-style-decl-transform.js
@@ -72,9 +72,9 @@ function _applyTransformProp(decl, id, key, resolved, value) {
                         f: t.args[5] !== undefined ? t.args[5] : 0,
                     };
                 }
-                // rotateX / rotateY / matrix3d / perspective: 2D View has
-                // no 3D rotation storage; silently dropped. Tracked for
-                // a follow-up issue (3D model on View).
+                // rotateX / rotateY / matrix3d / perspective: the 2D View
+                // transform surface has no 3D rotation storage, so these are
+                // silently dropped.
             }
             if (matrixCall && typeof setTransform !== "undefined") {
                 // Full-matrix path — 6-component bridge call. Skips the
@@ -182,10 +182,9 @@ function _applyTransformProp(decl, id, key, resolved, value) {
         // animation-play-state. Forwards the
         // CSS keyword (`running` | `paused`) through the existing
         // setAnimation control-token ABI so the bridge can route it to
-        // the staged_animation slot. The full pause/resume of the
-        // active_animations playback driver is the follow-up; storing
-        // the keyword today is enough for the catalog to claim partial
-        // and for round-trip validation.
+        // the staged_animation slot. The active_animations playback driver
+        // does not consume it yet; storing the keyword keeps the value
+        // round-trippable for validation.
         case "animationPlayState":
             if (typeof setAnimation === "function") setAnimation(id, "play_state", resolved);
             return true;

--- a/core/view/js/web-compat-style-decl-typography.js
+++ b/core/view/js/web-compat-style-decl-typography.js
@@ -283,8 +283,8 @@ function _applyTypographyProp(decl, id, key, resolved, value) {
             }
             return true;
 
-        // text-indent — first-line indent. Storage-only; SkParagraph
-        // setTextIndent integration is the follow-up.
+        // text-indent — first-line indent. Storage-only; the SkParagraph paint
+        // path does not consume setTextIndent yet.
         case "textIndent": {
             var ti = resolveCSSLength(resolved);
             if (ti && typeof setTextIndent === "function") setTextIndent(id, ti.value);


### PR DESCRIPTION
## Summary
- Clean stale planning/provenance breadcrumbs from web-compat JS comments.
- Update mask/object-fit/object-position comments to match current paint behavior.
- Keep this slice comment-only across the web-compat JS area.

## Validation
- RepoPrompt adversarial review: CLEAN after object-position correction.
- `python3 tools/scripts/docs_noise_lint.py --mode=report --all`
- `tools/scripts/gates.sh origin/main`
- `autoreview --mode branch --base origin/main --reviewers codex,claude`
- Pre-push full local diff coverage: 10,410 tests passed, 0 failed; expected visual/android skips; diff coverage OK.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up and clarifies comments across web-compat JS modules to reflect current paint behavior and remove stale breadcrumbs. No runtime or API changes.

- **Refactors**
  - Shortened headers and removed phase/planning notes in `import-runtime.js` and runtime APIs.
  - Clarified event dispatch debug logging; gated by `__pulpDebugDispatch__`.
  - Updated paint comments for `mask-image`, `mask-size`, and `mask` shorthand to describe backend consumption and fallbacks.
  - Updated `object-fit` and `object-position` notes to reflect consumption by image paint paths.
  - Clarified transform docs (3D calls dropped on 2D View) and `animationPlayState` as stored-only; marked `text-indent` as stored-only.

<sup>Written for commit a00735017c2ef9a1b31717bbc9d31ebf4001e597. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

