### PR TITLE
docs(source): clean figma plugin comment breadcrumbs

### DIFF
--- a/tools/figma-plugin/src/assets.ts
+++ b/tools/figma-plugin/src/assets.ts
@@ -4,15 +4,17 @@
 //   - For image fills: Figma exposes a stable `imageHash`. Multiple nodes can
 //     reference the same hash. We cache by imageHash → bytes once.
 //   - For VECTOR / BOOLEAN_OPERATION / shape nodes: call exportAsync(SVG_STRING).
-//     There's no built-in dedup key, so we compute sha256(bytes) ourselves.
-//   - Each emitted asset gets a stable `asset_id` keyed by content_hash (sha256
-//     hex of the bytes). Nodes reference assets via `asset_ref = asset_id`.
+//     There's no built-in dedup key, so we compute content_hash from the bytes.
+//   - Each emitted asset gets a stable `asset_id` keyed by content_hash. Nodes
+//     reference assets via `asset_ref = asset_id`.
 //
-// The crypto subtle API is available in Figma's plugin sandbox (modern V8).
+// content_hash uses SHA-256 when the Figma sandbox exposes crypto.subtle, with
+// a deterministic FNV-1a fallback for older/sandboxed runtimes. The hash is for
+// deduplication, not cryptographic integrity.
 
 export interface AssetEntry {
   asset_id: string;
-  content_hash: string;       // sha256 hex
+  content_hash: string;
   bytes: Uint8Array;          // raw bytes, fed to ZIP packager in UI
   mime: string;
   width?: number;
@@ -130,11 +132,9 @@ export class AssetCache {
 
 // ── crypto + format helpers ──────────────────────────────────────────────
 
-// Figma's plugin sandbox doesn't reliably expose crypto.subtle either, so we
-// use a fast non-cryptographic hash (FNV-1a 64-bit, encoded as 16 hex chars)
-// for content-addressable dedupe. Collisions are theoretically possible but
-// vanishingly rare within a single export and acceptable here — we're hashing
-// for de-duplication, not cryptographic integrity.
+// Prefer SHA-256 when crypto.subtle is available; fall back to a fast
+// non-cryptographic FNV-1a 64-bit hash (encoded as 16 hex chars) for
+// content-addressable dedupe in runtimes without WebCrypto.
 export async function sha256Hex(bytes: Uint8Array): Promise<string> {
   try {
     if (typeof crypto !== "undefined" && crypto.subtle && typeof crypto.subtle.digest === "function") {
@@ -184,7 +184,7 @@ function peekImageSize(bytes: Uint8Array, mime: string): { w: number; h: number 
     const h = (bytes[20] << 24) | (bytes[21] << 16) | (bytes[22] << 8) | bytes[23];
     return { w: w >>> 0, h: h >>> 0 };
   }
-  // JPEG / GIF / WebP size parsing skipped — slice-2 plugin doesn't need exact pixel dims.
+  // JPEG / GIF / WebP size parsing skipped — importer only needs exact PNG dims.
   return undefined;
 }
 

--- a/tools/figma-plugin/src/code.ts
+++ b/tools/figma-plugin/src/code.ts
@@ -17,10 +17,10 @@ const LIBRARY_MANIFEST: LibraryManifestSnapshot = {
 
 let knownFileKey: string | null = null;
 
-/// #43c — sandbox-side store of user-dropped TTF/OTF bytes, keyed by
-/// (family, style). Survives across export attempts within a single
-/// plugin session so the user can drop, preview, export, drop more,
-/// re-export. Discarded when the plugin closes.
+/// Sandbox-side store of user-dropped TTF/OTF bytes, keyed by (family, style).
+/// Survives across export attempts within a single plugin session so the user
+/// can drop, preview, export, drop more, re-export. Discarded when the plugin
+/// closes.
 const userFonts = new UserFontCache();
 
 figma.showUI(__html__, { width: 360, height: 540, themeColors: true });
@@ -117,8 +117,8 @@ async function handleExport(): Promise<void> {
   // Hand the assets to the UI as { content_hash, mime, bytes } records.
   // Bytes are transferred as plain arrays to keep postMessage compatibility;
   // the UI converts back to Uint8Array for the zip writer. The user-font
-  // entries (#43c) ride in the same bundle list — the UI doesn't need to
-  // distinguish them; the zip writer picks the file extension from mime.
+  // entries ride in the same bundle list — the UI doesn't need to distinguish
+  // them; the zip writer picks the file extension from mime.
   const assetBundles = [
     ...result.assets.entries().map((a) => ({
       content_hash: a.content_hash,
@@ -150,12 +150,11 @@ async function handleExport(): Promise<void> {
   });
 }
 
-/// #43c — walk the current selection, collect the unique (family, style,
-/// weight?, italic?) tuples referenced by text nodes, and reply with a
-/// `fonts-detected` message annotated with which entries already have
-/// user-supplied bytes in the cache. The same logic the export path
-/// uses (collectFontFamilyAssets) — invoked early so the UI can render
-/// drop zones before the user commits to a full export.
+/// Walk the current selection, collect the unique (family, style, weight?,
+/// italic?) tuples referenced by text nodes, and reply with a `fonts-detected`
+/// message annotated with which entries already have user-supplied bytes in the
+/// cache. Invoked early so the UI can render drop zones before the user commits
+/// to a full export.
 async function handleScanFonts(): Promise<void> {
   const sel = figma.currentPage.selection;
   if (sel.length === 0) {
@@ -173,9 +172,9 @@ async function handleScanFonts(): Promise<void> {
   reply({ type: "fonts-detected", fonts });
 }
 
-/// #43c — user dropped a TTF/OTF onto the UI. Store in the cache and
-/// ack with the asset_id so the UI can flip the row state. The cache
-/// survives until plugin close.
+/// User dropped a TTF/OTF onto the UI. Store it in the cache and ack with the
+/// asset_id so the UI can flip the row state. The cache survives until plugin
+/// close.
 async function handleUserFont(msg: {
   family: string;
   style: string;

--- a/tools/figma-plugin/src/extract-model.ts
+++ b/tools/figma-plugin/src/extract-model.ts
@@ -1,8 +1,8 @@
-// In-memory model produced by extract.ts (Phase 2a) and consumed by
-// serialize.ts (Phase 2b) + the future Phase 3 recognizer.
+// In-memory model produced by extract.ts and consumed by serialize.ts and the
+// library-widget recognizer.
 //
 // Field names mirror the JSON envelope in schema/figma-plugin-export-v1.json so
-// the Phase 2b serializer is mostly a passthrough.
+// the serializer is mostly a passthrough.
 
 import type { InteractiveElement } from "./faithful-vector";
 
@@ -10,7 +10,7 @@ export type AudioWidgetKind = "knob" | "fader" | "meter" | "xy_pad" | "waveform"
 
 export interface ExtractedFigmaNode {
   // Identity
-  type: string;             // "frame" | "text" | "image" | "vector" | (after Phase 3) audio widget kinds
+  type: string;             // "frame" | "text" | "image" | "vector" | audio widget kinds
   figma_type: string;       // raw SceneNode.type (FRAME, RECTANGLE, INSTANCE, ...)
   name: string;
   figma_node_id: string;
@@ -32,11 +32,11 @@ export interface ExtractedFigmaNode {
   // Text
   content?: string;
 
-  // Image / vector — populated in slice 2
+  // Image / vector assets
   exported_asset?: { content_hash: string; mime: string; bytes_size: number };
   asset_ref?: string;       // reference into AssetCache; serialized as node.asset_ref
 
-  // Faithful-vector import (Plan B / B4b). When set, the node renders its own
+  // Faithful-vector import. When set, the node renders its own
   // SVG export via DesignFrameView with the interactive overlays below, instead
   // of the widget-recognition rebuild. Mirrors the canonical IR keys the C++
   // parser reads (design_ir_json.cpp::parse_ir_node).
@@ -44,7 +44,7 @@ export interface ExtractedFigmaNode {
   svg_asset_id?: string;                       // → asset_manifest entry (image/svg+xml)
   interactive_elements?: InteractiveElement[];
 
-  // Component / instance metadata — populated when walking INSTANCE nodes (slice 2)
+  // Component / instance metadata — populated when walking INSTANCE nodes
   component_key?: string;
   component_set_name?: string;
   main_component_id?: string;
@@ -53,24 +53,23 @@ export interface ExtractedFigmaNode {
   component_properties?: Record<string, { type: string; value: string | number | boolean }>;
   variant_properties?: Record<string, string>;
 
-  // Library awareness (Phase 3)
+  // Library awareness
   library_widget_kind?: AudioWidgetKind;
   library_version?: string;
 
-  // Structured audio-widget properties (Phase 3). Populated when a Pulp
-  // library widget is recognised; carried into the JSON envelope at the
-  // node root so design_import.cpp::parse_ir_node maps them onto
-  // IRNode.audio_label / audio_min / audio_max / audio_default and the
-  // attributes map (units, binding).
+  // Structured audio-widget properties. Populated when a Pulp library widget is
+  // recognised; carried into the JSON envelope at the node root so
+  // design_import.cpp::parse_ir_node maps them onto IRNode.audio_label /
+  // audio_min / audio_max / audio_default and the attributes map.
   audio_label?: string;
   audio_min?: number;
   audio_max?: number;
   audio_default?: number;
   audio_units?: string;
   audio_binding?: string;
-  // Phase 5 — XYPad carries a Y-axis binding alongside the primary
-  // `binding` (which holds the X-axis route). Lands in IRNode.attributes.binding_y.
-  // Populated only for `Pulp / XYPad` library instances.
+  // XYPad carries a Y-axis binding alongside the primary `binding` (which holds
+  // the X-axis route). Lands in IRNode.attributes.binding_y. Populated only for
+  // `Pulp / XYPad` library instances.
   audio_binding_y?: string;
 
   children: ExtractedFigmaNode[];

--- a/tools/figma-plugin/src/extract-pure.ts
+++ b/tools/figma-plugin/src/extract-pure.ts
@@ -1,22 +1,17 @@
-// Pure, host-neutral helpers split out of `extract.ts` (P2 — see
-// planning/figma-import-coordination-log.md 22:50Z roadmap).
+// Pure, host-neutral helpers shared by the UI plugin and headless extractor.
 //
 // Every function here operates on types only (SceneNode shape, RGBA,
 // Paint, GradientPaint, FrameNode axis enums) — no `await
 // figma.X.Async()`, no `getBytesAsync`, no `exportAsync`. Anything
 // pulling bytes through the Figma Plugin API stays in `extract.ts`.
 //
-// **Why split this out:** the extractor has two real consumers — the
-// UI plugin (`code.ts`) and the headless bundle (`headless.ts`) — and
-// a structural neighbour, Agent A's Python REST port at
-// `tools/import-design/figma_rest_export.py`, which mirrors these
-// helpers field-for-field. Co-locating the pure logic makes drift
-// between the two language ports visible in one file and reduces the
-// surface area future provider abstractions (`NodeProvider`,
-// `AssetProvider`, etc.) have to thread through.
-//
-// **No behaviour change.** Functions kept verbatim; only `export`
-// added so `extract.ts` can re-import them.
+// The extractor has two real consumers — the UI plugin (`code.ts`) and the
+// headless bundle (`headless.ts`) — plus a structural neighbour, the Python REST
+// port at `tools/import-design/figma_rest_export.py`, which mirrors these
+// helpers field-for-field. Co-locating the pure logic makes drift between the
+// language ports visible in one file and reduces the surface area future
+// provider abstractions (`NodeProvider`, `AssetProvider`, etc.) have to thread
+// through.
 
 import type { ExtractedFigmaNode, ExtractedLayout } from "./extract-model";
 import type { AudioWidgetKind } from "./extract-model";
@@ -75,7 +70,7 @@ export function mapNodeType(n: SceneNode): string {
       return "frame";
     case "COMPONENT":
     case "COMPONENT_SET":
-      return "frame"; // Phase 3 will promote recognized instances to widget kinds
+      return "frame"; // recognized instances are promoted to widget kinds later
     case "INSTANCE":
       return "frame"; // ditto
     case "TEXT":
@@ -213,8 +208,7 @@ export function isPureVectorIllustration(node: SceneNode): boolean {
 // ──────────────────────────────────────────────────────────────────────────
 // Font catalogue — walks the post-extraction IR (not the Figma scene),
 // so it's already host-neutral and operates only on ExtractedFigmaNode
-// trees. Emitted as the envelope's top-level `font_family_assets` per
-// #43a-rev.
+// trees. Emitted as the envelope's top-level `font_family_assets`.
 
 export function collectFontFamilyAssets(roots: ExtractedFigmaNode[]): FontFamilyAsset[] {
   const seen = new Map<string, FontFamilyAsset>();

--- a/tools/figma-plugin/src/extract.ts
+++ b/tools/figma-plugin/src/extract.ts
@@ -1,15 +1,10 @@
-// Phase 2a — Figma scene walker.
+// Figma scene walker.
 //
 // Walks a Figma selection and produces an `ExtractedFigmaNode` tree matching the
 // shape declared in schema/figma-plugin-export-v1.json. This is the in-memory
-// model that downstream phases consume:
-//   - Phase 2b serializes it to JSON
-//   - Phase 3 mutates it to swap library-component frames into widget nodes
-//
-// SLICE 1 of Phase 2a (this file): geometry, frames + auto-layout, text +
-// dominant typography, basic style (fills as flat color or linear gradient,
-// strokes, corner radius, opacity, blend mode), and recursive children.
-// Images / vectors / instance-component-key lookup defer to slice 2.
+// model serialized to JSON and consumed by the design importer. It captures
+// geometry, frames + auto-layout, text + dominant typography, style, recursive
+// children, assets, vector exports, and library component metadata.
 
 import type {
   ExtractedFigmaNode,
@@ -31,8 +26,6 @@ import {
   widgetKindByNamePrefix,
   LIBRARY_VERSION,
 } from "./library-registry";
-// P2 — pure, host-neutral helpers split for clarity + maintainability.
-// Behaviour-unchanged from when these lived inline here.
 import {
   paintToColor,
   rgbaToCss,
@@ -55,9 +48,9 @@ export interface ExtractOptions {
   includeHidden?: boolean;
   /// Max nodes before the walker bails out with a diagnostic (perf safety).
   maxNodes?: number;
-  /// Faithful-vector lane (Plan B / B4b): export each top-level frame's own
-  /// SVG and render it pixel-faithfully via DesignFrameView, with knobs
-  /// auto-detected from the SVG. Off by default (the widget-recognition lane).
+  /// Export each top-level frame's own SVG and render it pixel-faithfully via
+  /// DesignFrameView, with knobs auto-detected from the SVG. Off by default
+  /// for the widget-recognition lane.
   faithfulVector?: boolean;
 }
 
@@ -69,16 +62,16 @@ export interface ExtractResult {
   nodeCount: number;
   /// True if maxNodes was hit and the result is incomplete.
   truncated: boolean;
-  /// Captured assets (slice 2). Empty when no fills/vectors were exported.
+  /// Captured image/vector assets. Empty when no fills/vectors were exported.
   assets: AssetCache;
   /// Captured design tokens from Figma variables.
   tokens: ExtractedTokens;
   /// Deduplicated list of every font family/style/weight tuple referenced
   /// by text nodes in the extracted tree. Drives Pulp's runtime font
-  /// resolution (#43a-rev / #43b). Note: Figma's plugin API does NOT
+  /// resolution. Note: Figma's plugin API does NOT
   /// expose font binaries — `asset_id` stays empty for plain captures;
   /// it's populated only when the user supplies a TTF via the drag-drop
-  /// escape hatch (#43c, follow-up).
+  /// escape hatch.
   font_family_assets: FontFamilyAsset[];
 }
 
@@ -97,7 +90,7 @@ export interface FontFamilyAsset {
   /// variants without re-parsing the style string.
   italic?: boolean;
   /// Set only when the user supplied a TTF/OTF via the drag-drop escape
-  /// hatch (#43c, follow-up). Points into the envelope's
+  /// hatch. Points into the envelope's
   /// `asset_manifest` so the runtime can locate the bundled font file.
   asset_id?: string;
 }
@@ -164,8 +157,8 @@ export async function extractScene(
 /// Order is stable: families appear in first-encounter order, styles
 /// within a family in first-encounter order. That stability matters for
 /// snapshot tests that compare envelope output.
-// `collectFontFamilyAssets` moved to ./extract-pure.ts (P2). Behaviour-identical;
-// imported above. Kept the call site in `extractScene` unchanged.
+// Font-family collection stays in extract-pure.ts so this file stays focused on
+// async Figma API calls and tree assembly.
 
 // ──────────────────────────────────────────────────────────────────────────
 // Internal walker
@@ -266,24 +259,23 @@ async function walk(
     extractTextStyle(node as TextNode, ex.style, ctx);
   }
 
-  // INSTANCE: capture component metadata so Phase 3 can recognize Pulp library widgets.
+  // INSTANCE: capture component metadata so Pulp library widgets can be recognized.
   if (node.type === "INSTANCE") {
     await captureInstanceMetadata(node as InstanceNode, ex, ctx);
 
-    // Phase 3 — Pulp Library component recognition.
+    // Pulp Library component recognition.
     //
     // Recognition order:
     //   1. Authoritative key-based match: ex.component_key matches a
     //      Pulp-library component_set_key from library-manifest.json.
-    //      This is the canonical Phase 3 path — designs that pulled in
+    //      This is the canonical path — designs that pulled in
     //      the published Pulp library hit this regardless of layer name.
     //   2. Name-prefix fallback: name starts with a manifest-registered
     //      prefix (e.g. "Pulp / Knob"). Lets designs use the convention
     //      without depending on the published library file.
     //   3. Permissive name match: the broader audioWidgetKindFromName()
     //      heuristic ("knob" / "fader" / "meter" appearing anywhere in
-    //      the name) — preserves pre-Phase-3 behaviour for sprite-strip
-    //      detection on ad-hoc designs.
+    //      the name) — preserves sprite-strip detection on ad-hoc designs.
     //
     // The first match wins. When a library or prefix match fires we
     // also stamp ex.library_version so the importer can tell apart
@@ -340,7 +332,7 @@ async function walk(
     }
   }
 
-  // Vector-like nodes → SVG asset export (Phase 2a slice 2).
+  // Vector-like nodes → exported asset.
   const isVectorLike =
     node.type === "VECTOR" ||
     node.type === "BOOLEAN_OPERATION" ||
@@ -406,8 +398,6 @@ async function walk(
 
 // ──────────────────────────────────────────────────────────────────────────
 // Type mapping
-
-// `mapNodeType` moved to ./extract-pure.ts (P2). Behaviour-identical.
 
 // ──────────────────────────────────────────────────────────────────────────
 // Geometry
@@ -511,12 +501,12 @@ function extractStyle(n: SceneNode, ctx: WalkCtx): ExtractedStyle {
       } else if (first.type === "GRADIENT_LINEAR") {
         s.background_gradient = gradientToCss(first as GradientPaint);
       } else if (first.type === "IMAGE") {
-        // Slice 2: extract image fill bytes via Figma's imageHash, cache by sha256.
+        // Extract image fill bytes via Figma's imageHash, cache by sha256.
         const imgHash = (first as ImagePaint).imageHash;
         if (imgHash) {
           // Schedule asset capture; rejoined via a microtask so we don't block this synchronous walk.
           // Note: extractStyle is synchronous; the caller will retroactively call
-          // captureImageFill via the deferred path. For slice 2, we mark with a placeholder
+          // captureImageFill via the deferred path. Mark with a placeholder
           // and use a side-channel — but the simpler thing is to make extractStyle async-aware.
           // SEE: image fills are wired via captureImageFillsForNode after style extraction.
           s.background_image = `pending:${imgHash}`;
@@ -591,8 +581,8 @@ function extractStyle(n: SceneNode, ctx: WalkCtx): ExtractedStyle {
 }
 
 function extractTextStyle(t: TextNode, s: ExtractedStyle, ctx: WalkCtx): void {
-  // Read the "first character" style as the dominant style. Per-range
-  // emission is a follow-up.
+  // Read the "first character" style as the dominant style; range-specific
+  // emission is not wired through this envelope yet.
   const charLen = t.characters.length;
   if (charLen === 0) return;
   if (typeof t.fontSize === "number") s.font_size = t.fontSize;
@@ -629,9 +619,9 @@ function extractTextStyle(t: TextNode, s: ExtractedStyle, ctx: WalkCtx): void {
       delete s.background_color;
     }
   }
-  // Per-range note for follow-up
+  // Detect once range-specific font capture is wired.
   if (charLen > 0) {
-    const hasMultiRangeFonts = false; // TODO slice 2: scan getRangeFontName
+    const hasMultiRangeFonts = false; // TODO: scan getRangeFontName
     if (hasMultiRangeFonts) {
       pushDiag(ctx, "info", "text-ranges-flattened", "capture_partial",
         "Mixed font ranges in text node flattened to dominant style.");
@@ -671,10 +661,6 @@ function extractLayout(n: SceneNode, ctx: WalkCtx): ExtractedLayout {
   return l;
 }
 
-// `mapPrimaryAxisAlign`, `mapCounterAxisAlign`, `mapAxisSize`, `paintToColor`,
-// `rgbaToCss`, `hex2`, `gradientToCss`, `gradientFallbackFlat` all moved to
-// ./extract-pure.ts (P2). Behaviour-identical.
-
 // ──────────────────────────────────────────────────────────────────────────
 // Diagnostic helpers
 
@@ -688,11 +674,11 @@ function pushDiag(
   ctx.diagnostics.push({ severity, code, kind, message, path: pathOf(ctx) });
 }
 
-// Faithful-vector capture (Plan B / B4b): export the frame's own SVG, register
-// it as an image/svg+xml asset, and attach the render-mode + auto-detected
-// interactive knobs the C++ DesignFrameView consumes. A capture failure leaves
-// the node on the normal widget-recognition lane (diagnostic only) — the import
-// degrades, it never blanks.
+// Faithful-vector capture: export the frame's own SVG, register it as an
+// image/svg+xml asset, and attach the render-mode + auto-detected interactive
+// knobs the C++ DesignFrameView consumes. A capture failure leaves the node on
+// the normal widget-recognition lane (diagnostic only) — the import degrades, it
+// never blanks.
 async function applyFaithfulVector(
   node: ExtractedFigmaNode,
   sceneNode: SceneNode,
@@ -713,11 +699,10 @@ async function applyFaithfulVector(
     // (search/dropdown/stepper/tabs), mapped into the SVG's panel space — kept in
     // lockstep with the REST lane (figma_rest_export.py).
     const knobs = parseFrameKnobs(svg);
-    // P7 import report: knobs are GEOMETRY-detected (dome+needle in the SVG),
-    // with no node name — stamp them as affordance-resolved (rung 2) so the
-    // import report lists EVERY control, not just the overlays (which
-    // detectOverlayControls stamps itself). A geometric knob's bounds are its
-    // hit circle, so it is square by construction → no conflict, full confidence.
+    // Knobs are geometry-detected (dome+needle in the SVG), with no node name.
+    // Stamp them as affordance-resolved so the import report lists every
+    // control, not just the overlays. A geometric knob's bounds are its hit
+    // circle, so it is square by construction: no conflict, full confidence.
     for (let ki = 0; ki < knobs.length; ki++) {
       const k = knobs[ki];
       const d = 2 * (k.hit_radius || 0);
@@ -742,10 +727,10 @@ function pathOf(ctx: WalkCtx): string {
   return ctx.pathStack.join("");
 }
 
-/// Phase 3 — read the structured audio-widget properties (label, min,
-/// max, value, units, binding) off `ex.component_properties` and stamp
-/// them onto `ex.audio_*` fields so the serializer can emit them at the
-/// IR node root for design_import.cpp::parse_ir_node to consume.
+/// Read the structured audio-widget properties (label, min, max, value, units,
+/// binding) off `ex.component_properties` and stamp them onto `ex.audio_*`
+/// fields so the serializer can emit them at the IR node root for
+/// design_import.cpp::parse_ir_node to consume.
 ///
 /// componentProperties keys carry a "#<unique-id>" suffix (e.g.
 /// "binding#01:02"); we match on the prefix before the "#".
@@ -785,20 +770,14 @@ function extractAudioPropsFromComponentProperties(
   if (units !== undefined && units.length > 0) ex.audio_units = units;
   const binding = getRawString("binding");
   if (binding !== undefined && binding.length > 0) ex.audio_binding = binding;
-  // Phase 5: XYPad has a second binding for the Y axis. Only the XYPad
-  // library variant defines this property; other widgets fall through.
+  // XYPad has a second binding for the Y axis. Only the XYPad library variant
+  // defines this property; other widgets fall through.
   const binding_y = getRawString("binding_y");
   if (binding_y !== undefined && binding_y.length > 0) ex.audio_binding_y = binding_y;
 }
 
-/// Detect audio widget kind from an instance's main-component name. Used
-/// to flatten widget instances to a PNG skin (Track A2). Patterns match
-/// Pulp's IR-side detect_audio_widget() (core/view/src/design_import.cpp).
-// `audioWidgetKindFromName` and `isPureVectorIllustration` moved to
-// ./extract-pure.ts (P2). Behaviour-identical.
-
 // ──────────────────────────────────────────────────────────────────────────
-// Instance metadata capture (Phase 2a slice 2)
+// Instance metadata capture
 
 async function captureInstanceMetadata(
   inst: InstanceNode,

--- a/tools/figma-plugin/src/faithful-vector.ts
+++ b/tools/figma-plugin/src/faithful-vector.ts
@@ -1,4 +1,4 @@
-// Faithful-vector import (Plan B / B4b) — geometry auto-detect of knobs in an
+// Faithful-vector import: geometry auto-detect of knobs in an
 // exported frame SVG, ported from the vector-knob PoC and the C++ DesignFrameView
 // convention (kept in lockstep with tools/import-design/figma_rest_export.py's
 // parse_frame_knobs). A knob DOME is a gradient-filled <circle> (fill="url(",
@@ -11,8 +11,8 @@
 // decode) — the Figma plugin sandbox tsconfig targets an older lib without
 // String.matchAll / includes / spread-of-typed-array.
 
-// P7-F2: the resolution self-check that records each control's provenance +
-// catches name/geometry conflicts. (Type-only the other direction, so no cycle.)
+// The resolution self-check records each control's provenance and catches
+// name/geometry conflicts. Type-only the other direction, so no cycle.
 import { assessResolution } from "./resolve-control";
 
 // The interactive-overlay kinds the schema (figma-plugin-export-v1.json
@@ -60,14 +60,13 @@ export interface InteractiveElement {
   text?: string;           // value_label: initial readout string
   value_left_align?: boolean;  // value_label: left-align the readout
   default_value_y?: number;    // xy_pad: initial normalized Y (0=top)
-  // P7 import report (resolution provenance) — carried so a low-confidence or
-  // conflicted control is visible at the host materialize boundary, not just in
-  // the TS importer. The resolution LOGIC that fills these is P7-F2.
+  // Resolution provenance — carried so a low-confidence or conflicted control is
+  // visible at the host materialize boundary, not just in the TS importer.
   resolution_rung?: number;        // which ladder rung resolved this (0=unset..5=inert)
   confidence_score?: number;       // 0..1; 1.0 = unset/legacy
   conflict_signals?: string[];     // cross-signal conflicts (empty = none)
   verification_pass?: boolean;     // render verification passed (default true)
-  // custom (P7 Tier-3 registered control)
+  // Registered custom control.
   factory_id?: string;             // the registered native-overlay factory id
   custom_props?: string;           // opaque props handed to the factory (e.g. JSON)
 }
@@ -270,8 +269,8 @@ export function detectOverlayControls(
   const subtreeEnd = new Map<OverlayNode, number>();
   const occluders: Array<[number, number, number, number, number]> = [];
   let _counter = 0;
-  // node id -> name, so the P7 post-pass can read the name signal for each
-  // emitted control (which only carries its source_node_id).
+  // node id -> name, so the post-pass can read the name signal for each emitted
+  // control (which only carries its source_node_id).
   const nodeNameById: { [id: string]: string } = {};
   function scan(n: OverlayNode): number {
     const idx = _counter++;
@@ -470,16 +469,16 @@ export function detectOverlayControls(
       return;  // leaf overlay
     }
 
-    // ── swap / action / xy_pad / value_label (P1b) ───────────────────────────
+    // ── swap / action / xy_pad / value_label ────────────────────────────────
     // Whole-word name-gated, and run AFTER the tuned dropdown/stepper/tab_group/
     // text_field detectors in this visit() so they always win — these only claim
     // a node the others left unclaimed, and only on an explicit name token, so a
     // generic design never sprouts spurious overlays. (Knob detection is a
     // separate geometry pass, parseFrameKnobs, not part of this precedence.) The
-    // full node-tree signals
-    // (prototype reactions for swap, value patterns for value_label, a command
-    // vocabulary for action) land with P2's unified resolver; this is the
-    // name-driven floor that proves the producer can emit each kind.
+    // Full node-tree signals (prototype reactions for swap, value patterns for
+    // value_label, a command vocabulary for action) belong in the unified
+    // resolver; this is the name-driven floor that proves the producer can emit
+    // each kind.
     if (bb) {
       const named = detectNamedControl(n, name, ntype, toSvg(bb));
       if (named) { out.push(named); return; }
@@ -490,7 +489,7 @@ export function detectOverlayControls(
 
   visit(root, null);
 
-  // ── P7-F2 resolution self-check ──────────────────────────────────────────
+  // ── Resolution self-check ────────────────────────────────────────────────
   // Stamp each emitted control with its resolution provenance (rung / confidence
   // / conflicts / verification). assessResolution cross-checks the name signal
   // against the node's geometry, so a control whose name and shape disagree
@@ -515,7 +514,7 @@ function hasWord(s: string, w: string): boolean {
   return new RegExp("(^|[^a-z0-9])" + w + "([^a-z0-9]|$)").test(s);
 }
 
-// Name-driven detection for the P1b kinds. `rect` is the node's SVG-space box.
+// Name-driven detection for overlay kinds. `rect` is the node's SVG-space box.
 function detectNamedControl(
   n: OverlayNode, name: string, ntype: string,
   rect: [number, number, number, number],
@@ -548,7 +547,7 @@ function detectNamedControl(
   // value_label: a TEXT node DELIBERATELY named a readout. Gated on explicit
   // markers ("readout" / "value_label"), NOT the bare word "value"/"display" —
   // those are far too common on STATIC text layers to flip into a live overlay.
-  // (Richer content-pattern detection rides P2's unified resolver.)
+  // Richer content-pattern detection belongs in the unified resolver.
   if (ntype === "TEXT" &&
       (hasWord(name, "readout") || name.indexOf("value_label") !== -1 ||
        name.indexOf("value-label") !== -1 || name.indexOf("valuelabel") !== -1)) {

--- a/tools/figma-plugin/src/headless.ts
+++ b/tools/figma-plugin/src/headless.ts
@@ -44,10 +44,10 @@ const LIBRARY_MANIFEST: LibraryManifestSnapshot = {
 };
 
 declare const TARGET_NODE_ID: string | undefined;
-// Faithful-vector lane (Plan B / B4b) — the DEFAULT. Each top-level frame
-// exports its own SVG and renders via DesignFrameView with auto-detected
-// INTERACTIVE overlays, instead of the legacy widget-recognition rebuild. The
-// injected prelude sets FAITHFUL_VECTOR = false to opt out (legacy flat tree).
+// Faithful-vector lane: the default. Each top-level frame exports its own SVG
+// and renders via DesignFrameView with auto-detected interactive overlays,
+// instead of the legacy widget-recognition rebuild. The injected prelude sets
+// FAITHFUL_VECTOR = false to opt out (legacy flat tree).
 declare const FAITHFUL_VECTOR: boolean | undefined;
 
 interface HeadlessAssetBundle {
@@ -105,10 +105,10 @@ async function run(): Promise<HeadlessResult> {
     figma.fileKey ??
     `local-${encodeURIComponent(figma.root.name).slice(0, 32)}`;
 
-  // The published plugin supports drag-drop user fonts (#43c); the headless
-  // path has no UI, so the cache is always empty. We pass an empty cache
-  // so the serializer's metadata-only path runs (matches the byte shape
-  // of an "Export to Pulp" with no user fonts supplied).
+  // The published plugin supports drag-drop user fonts; the headless path has no
+  // UI, so the cache is always empty. We pass an empty cache so the serializer's
+  // metadata-only path runs (matches the byte shape of an "Export to Pulp" with
+  // no user fonts supplied).
   const userFonts = new UserFontCache();
 
   const envelope = serializeExport(result.roots, result.diagnostics, {

--- a/tools/figma-plugin/src/library-registry.ts
+++ b/tools/figma-plugin/src/library-registry.ts
@@ -1,4 +1,4 @@
-// library-registry.ts — Phase 3 (planning/2026-05-28-pulp-figma-plugin-strategy.md §8)
+// Pulp Figma library registry.
 //
 // Loads tools/figma-plugin/library-manifest.json at build time and exposes
 // typed lookups for:
@@ -91,7 +91,7 @@ export function entryForKind(
   return widgetEntries.find((e) => e.kind === kind);
 }
 
-// ── Custom-control resolution (P8 — the package-fragment merge) ──────────────
+// ── Custom-control resolution ───────────────────────────────────────────────
 // A shared package (registry-schema `design_controls`) maps a Figma identity to
 // the `factory_id` its pulp::view::View registers (register_design_control_
 // factory). The importer MERGES the installed packages' fragments into one list

--- a/tools/figma-plugin/src/resolve-control.ts
+++ b/tools/figma-plugin/src/resolve-control.ts
@@ -1,15 +1,15 @@
-// P7-F2 — control-resolution self-check for the faithful-vector lane.
+// Control-resolution self-check for the faithful-vector lane.
 //
 // The original stumble was a slider/button silently materialized as a `knob`:
 // a MISSING VERIFICATION LOOP, not just a missing kind. This module computes the
 // control kind from INDEPENDENT signals and cross-checks them, so a mismatch is
 // CAUGHT (lowered confidence + a recorded conflict) instead of silently shipped.
-// It fills the P7 import-report fields (resolution_rung / confidence_score /
+// It fills the import-report fields (resolution_rung / confidence_score /
 // conflict_signals / verification_pass) the F0 chain carries to the host.
 //
-// Signals available in THIS lane: geometry/affordance (node bounds) and
-// name/token (the node name). Component identity is the P2/extract.ts lane; when
-// it lands it slots in as rung 1 ahead of these.
+// Signals available in this lane: geometry/affordance (node bounds) and
+// name/token (the node name). Component identity slots in as rung 1 ahead of
+// these when available.
 //
 // ES5-conservative (the Figma plugin sandbox tsconfig targets an older lib).
 

--- a/tools/figma-plugin/src/serialize.ts
+++ b/tools/figma-plugin/src/serialize.ts
@@ -1,4 +1,4 @@
-// Phase 2b — serialize an extracted scene into the v1 JSON envelope declared in
+// Serialize an extracted scene into the v1 JSON envelope declared in
 // schema/figma-plugin-export-v1.json. This is mostly a passthrough since the
 // extractor's in-memory model already mirrors the envelope shape; the
 // serializer's job is to add the envelope-level fields (format_version,
@@ -18,16 +18,16 @@ export interface SerializeContext {
   libraryManifest?: LibraryManifestSnapshot;
   assets: AssetCache;
   tokens: ExtractedTokens;
-  /// Deduplicated font catalogue produced by extractScene (#43a-rev).
+  /// Deduplicated font catalogue produced by extractScene.
   /// Empty array → no text nodes in the selection (or no font names
   /// captured). Emitted at envelope root as `font_family_assets`.
   fontFamilyAssets?: FontFamilyAsset[];
-  /// #43c — user-supplied font bytes captured via the drag-drop UI.
+  /// User-supplied font bytes captured via the drag-drop UI.
   /// When present, every `font_family_assets` entry whose (family, style)
   /// matches a cache entry gets `asset_id` stamped, and the bytes flow
   /// through the asset_manifest into the `.pulp.zip`. Optional — empty
   /// or undefined cache is a no-op (the envelope still emits the
-  /// metadata-only catalogue per #43a-rev).
+  /// metadata-only catalogue).
   userFonts?: UserFontCache;
 }
 
@@ -42,7 +42,7 @@ export function serializeExport(
   diagnostics: ExtractedDiagnostic[],
   ctx: SerializeContext,
 ): unknown {
-  // #43c orphan-font check — if the user dropped a TTF/OTF for
+  // Orphan-font check: if the user dropped a TTF/OTF for
   // (family, style) tuples that don't appear in font_family_assets
   // (drop happened before scan, or selection changed before export),
   // the bytes still ride in asset_manifest but no catalogue entry
@@ -115,7 +115,7 @@ export function serializeExport(
           width: a.width,
           height: a.height,
         })),
-        // #43c — user-supplied fonts ride alongside the image / vector
+        // User-supplied fonts ride alongside the image / vector
         // assets in the same manifest. The local_path always ends in
         // .ttf / .otf so the zip writer and downstream consumers can
         // pick them out by extension without re-sniffing the mime.
@@ -129,12 +129,12 @@ export function serializeExport(
         })),
       ],
     },
-    // #43a-rev: top-level font catalogue. Each entry holds the family
+    // Top-level font catalogue. Each entry holds the family
     // name + style + (optional) weight + (optional) italic flag for every
     // font referenced by text nodes. `asset_id` is populated only by the
-    // drag-drop escape hatch (#43c) for user-supplied TTF bundling — the
+    // drag-drop escape hatch for user-supplied TTF bundling — the
     // Figma plugin API does not expose font binaries directly. Runtime
-    // (Agent A's #43b) consumes via Skia's SkFontMgr system-font matcher
+    // consumer uses via Skia's SkFontMgr system-font matcher
     // with the bundled OFL set as fallback.
     font_family_assets: stampUserFonts(ctx.fontFamilyAssets ?? [], ctx.userFonts),
     diagnostics: diagnostics.map(toEnvelopeDiagnostic),
@@ -163,10 +163,10 @@ function extOfFontMime(mime: string): string {
   }
 }
 
-/// #43c — for every font_family_assets entry, if the user has
+/// For every font_family_assets entry, if the user has
 /// supplied a matching (family, style) cache entry, stamp it with
 /// the cached asset_id. Pure function; the original list is preserved
-/// otherwise so the metadata-only catalogue from #43a-rev is unchanged
+/// otherwise so the metadata-only catalogue is unchanged
 /// when no user fonts are present.
 function stampUserFonts(
   fonts: FontFamilyAsset[],
@@ -189,7 +189,7 @@ function toEnvelopeNode(n: ExtractedFigmaNode): unknown {
   if (n.content !== undefined) out.content = n.content;
   if (n.asset_ref) out.asset_ref = n.asset_ref;
 
-  // Faithful-vector (Plan B / B4b) — emit the render-mode + SVG asset + typed
+  // Faithful-vector: emit the render-mode + SVG asset + typed
   // interactive overlays the C++ materializer consumes (parse_ir_node already
   // reads these keys). Only present on a faithful_svg node.
   if (n.render_mode) out.render_mode = n.render_mode;
@@ -198,7 +198,7 @@ function toEnvelopeNode(n: ExtractedFigmaNode): unknown {
     out.interactive_elements = n.interactive_elements;
   }
 
-  // Phase 3 — emit audio-widget metadata at the IR node root. The C++
+  // Emit audio-widget metadata at the IR node root. The C++
   // parser (design_ir_json.cpp::parse_ir_node) reads:
   //   audio_widget  → IRNode.audio_widget enum
   //   label         → IRNode.audio_label
@@ -215,10 +215,9 @@ function toEnvelopeNode(n: ExtractedFigmaNode): unknown {
     const attrs: Record<string, string> = {};
     if (n.audio_units !== undefined) attrs.units = n.audio_units;
     if (n.audio_binding !== undefined) attrs.binding = n.audio_binding;
-    // Phase 5: XYPad carries a second-axis binding alongside the primary
-    // `binding`. Lands in IRNode.attributes.binding_y; codegen consumes
-    // when the audio_widget="xy_pad" branch is wired up to route two
-    // parameter targets (see planning/2026-05-30-figma-import-fidelity-coordination.md).
+    // XYPad carries a second-axis binding alongside the primary `binding`.
+    // Lands in IRNode.attributes.binding_y; codegen consumes it when
+    // audio_widget="xy_pad" routes two parameter targets.
     if (n.audio_binding_y !== undefined) attrs.binding_y = n.audio_binding_y;
     out.attributes = attrs;
   }

--- a/tools/figma-plugin/src/types.ts
+++ b/tools/figma-plugin/src/types.ts
@@ -5,9 +5,8 @@ export type PulpFigmaUIMessage =
   | { type: "report-file-key"; fileKey: string | null }
   | { type: "get-selection-summary" }
   | { type: "export" }
-  /// #43c — user dragged a TTF/OTF onto the plugin UI to satisfy a
-  /// non-system font. `bytes` is the raw font file as a number[]
-  /// (postMessage-safe transit).
+  /// User dragged a TTF/OTF onto the plugin UI to satisfy a non-system font.
+  /// `bytes` is the raw font file as a number[] (postMessage-safe transit).
   | {
       type: "user-font";
       family: string;
@@ -15,9 +14,8 @@ export type PulpFigmaUIMessage =
       bytes: number[];
       filename: string;
     }
-  /// #43c — UI asks the sandbox to scan the current selection's text
-  /// nodes and report back the unique font tuples so it can render
-  /// per-family drop zones.
+  /// UI asks the sandbox to scan the current selection's text nodes and report
+  /// back the unique font tuples so it can render per-family drop zones.
   | { type: "scan-fonts" }
   | { type: "close" };
 
@@ -43,15 +41,13 @@ export type PulpSandboxMessage =
   | { type: "pong"; figmaVersion: string; editorType: string; documentName: string }
   | { type: "selection-summary"; count: number; names: string[]; firstTypeIfAny: string | null }
   | { type: "progress"; stage: "extracting" | "serializing"; message: string }
-  /// #43c — sandbox responds to scan-fonts with the unique
-  /// (family, style, weight?, italic?) tuples referenced by the
-  /// current selection's text nodes, plus a flag for which are
-  /// already bundled via a user drop.
+  /// Sandbox responds to scan-fonts with the unique (family, style, weight?,
+  /// italic?) tuples referenced by the current selection's text nodes, plus a
+  /// flag for which are already bundled via a user drop.
   | { type: "fonts-detected"; fonts: FontFamilyAssetSummary[] }
-  /// #43c — sandbox acknowledges a user-font upload. The UI uses this
-  /// to flip the row to "✓ bundled" state. `asset_id` is the
-  /// content-hashed handle the envelope will carry on the matching
-  /// font_family_assets entry.
+  /// Sandbox acknowledges a user-font upload. The UI uses this to flip the row
+  /// to "✓ bundled" state. `asset_id` is the content-hashed handle the envelope
+  /// will carry on the matching font_family_assets entry.
   | { type: "user-font-staged"; family: string; style: string; asset_id: string }
   | {
       type: "export-result";

--- a/tools/figma-plugin/src/ui.ts
+++ b/tools/figma-plugin/src/ui.ts
@@ -70,8 +70,8 @@ function extOfMime(m: string): string {
     case "image/gif": return "gif";
     case "image/webp": return "webp";
     case "image/svg+xml": return "svg";
-    // #43c — user-supplied font assets ride alongside image assets in
-    // the same bundle list; the zip writer needs to recognise them.
+    // User-supplied font assets ride alongside image assets in the same bundle
+    // list; the zip writer needs to recognise them.
     case "font/ttf": return "ttf";
     case "font/otf": return "otf";
     case "font/woff": return "woff";
@@ -80,10 +80,9 @@ function extOfMime(m: string): string {
   }
 }
 
-// #43c — font drop-zone state. `bundled` reflects sandbox confirmation
-// (we asked for a stage and got back `user-font-staged`); the row
-// turns green when this fires. Keyed by the same `family|style` tuple
-// the sandbox uses.
+// Font drop-zone state. `bundled` reflects sandbox confirmation (we asked for a
+// stage and got back `user-font-staged`); the row turns green when this fires.
+// Keyed by the same `family|style` tuple the sandbox uses.
 const bundledFonts = new Set<string>();
 const fontKey = (family: string, style: string): string => `${family}|${style}`;
 

--- a/tools/figma-plugin/src/user-fonts.ts
+++ b/tools/figma-plugin/src/user-fonts.ts
@@ -1,11 +1,11 @@
-// #43c — User-supplied font cache for the drag-drop escape hatch.
+// User-supplied font cache for the drag-drop escape hatch.
 //
 // The Figma plugin API intentionally does not expose font byte access (see
-// #43a-rev redesign note). Users with non-system fonts (custom foundry
-// faces, restricted-license families like Clash Grotesk) supply the
-// `.ttf` / `.otf` file via a drag-drop zone in the plugin UI. The UI
-// reads bytes via FileReader and forwards them to the sandbox; this
-// module is the sandbox-side store.
+// the runtime font-catalogue contract). Users with non-system fonts (custom
+// foundry faces, restricted-license families like Clash Grotesk) supply the
+// `.ttf` / `.otf` file via a drag-drop zone in the plugin UI. The UI reads
+// bytes via FileReader and forwards them to the sandbox; this module is the
+// sandbox-side store.
 //
 // Storage shape: keyed by `family|style` (the same tuple
 // `font_family_assets` entries are deduped on), value carries the

--- a/tools/figma-plugin/test/audio-widget-name.test.ts
+++ b/tools/figma-plugin/test/audio-widget-name.test.ts
@@ -1,7 +1,7 @@
-// P2 resolver unification — audioWidgetKindFromName must match WHOLE WORDS, not
-// substrings, in lockstep with the C++ detect_audio_widget (design_import.cpp)
-// and the Python widget_kind_from_name. The old substring match produced the
-// false positives this pins shut.
+// audioWidgetKindFromName must match whole words, not substrings, in lockstep
+// with the C++ detect_audio_widget (design_import.cpp) and the Python
+// widget_kind_from_name. The old substring match produced the false positives
+// this pins shut.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";

--- a/tools/figma-plugin/test/faithful-vector.test.ts
+++ b/tools/figma-plugin/test/faithful-vector.test.ts
@@ -1,8 +1,8 @@
-// Plan B / B4b: the faithful-vector lane for the Figma plugin. Exercises the
-// geometry knob auto-detector + the sandbox-safe SVG byte decode, and asserts
-// serialize.ts emits the render_mode / svg_asset_id / interactive_elements the
-// C++ materializer (DesignFrameView) consumes. Kept in lockstep with the REST
-// lane (tools/import-design/figma_rest_export.py + test_figma_rest_export.py).
+// Faithful-vector lane for the Figma plugin. Exercises the geometry knob
+// auto-detector + sandbox-safe SVG byte decode, and asserts serialize.ts emits
+// the render_mode / svg_asset_id / interactive_elements the C++ materializer
+// (DesignFrameView) consumes. Kept in lockstep with the REST lane
+// (tools/import-design/figma_rest_export.py + test_figma_rest_export.py).
 
 import { test } from "node:test";
 import assert from "node:assert/strict";

--- a/tools/figma-plugin/test/library-registry.test.ts
+++ b/tools/figma-plugin/test/library-registry.test.ts
@@ -73,7 +73,7 @@ test("entryForKind + LIBRARY_VERSION are wired from the manifest", () => {
   assert.equal(knob.name_prefix, "Pulp / Knob");
 });
 
-// ── P8: custom-control resolution from merged package fragments ──────────────
+// ── Custom-control resolution from merged package fragments ─────────────────
 const dcEntries: DesignControlEntry[] = [
   { factory_id: "acme.spinner", component_set_key: "1:2abc", name_prefix: "Acme / Spinner" },
   { factory_id: "acme.xy", name_prefix: "Acme / XY" },

--- a/tools/figma-plugin/test/resolve-control.test.ts
+++ b/tools/figma-plugin/test/resolve-control.test.ts
@@ -1,5 +1,5 @@
-// P7-F2 — the control-resolution self-check. These tests pin the loop that would
-// have CAUGHT the original silent-knob stumble.
+// Control-resolution self-check. These tests pin the loop that would have caught
+// the original silent-knob stumble.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -37,9 +37,9 @@ test("shapeClass classifies bounds into square vs stretched", () => {
 });
 
 test("THE STUMBLE: a node named 'knob' with slider geometry is CAUGHT as a conflict", () => {
-  // The exact failure mode P7 exists to prevent: the importer resolved a knob (by
-  // name), but the bounds are a wide track. assessResolution must flag it and drop
-  // confidence — NOT silently ship a knob.
+  // Exact failure mode: the importer resolved a knob by name, but the bounds are
+  // a wide track. assessResolution must flag it and drop confidence, not silently
+  // ship a knob.
   const r = assessResolution("knob", "Filter Knob", { w: 220, h: 22 });
   assert.ok(r.conflict_signals.length >= 1, "a conflict must be recorded");
   assert.ok(r.conflict_signals.some((c) => c.indexOf("knob") !== -1 && c.indexOf("stretched") !== -1),

--- a/tools/figma-plugin/test/serialize.test.ts
+++ b/tools/figma-plugin/test/serialize.test.ts
@@ -240,12 +240,11 @@ test("serialized knob validates against figma-plugin-export-v1 schema", () => {
 });
 
 // ---------------------------------------------------------------------------
-// P1a — the interactive_element schema must accept every kind the producers
-// already emit (the pre-existing drift: a knob-only enum + additionalProperties
-// :false rejected the overlay overlays that faithful-vector.ts / figma_rest_
-// export.py emit) PLUS the newly-added fader/toggle. Validates element objects
-// directly against $defs.interactive_element, including the per-kind required-
-// field segmentation (knob → cx/cy/hit_radius; overlays → x/y/w/h).
+// The interactive_element schema must accept every kind the producers emit. This
+// catches drift where the schema rejects overlay elements that faithful-vector.ts
+// / figma_rest_export.py emit. Validates element objects directly against
+// $defs.interactive_element, including the per-kind required-field segmentation
+// (knob -> cx/cy/hit_radius; overlays -> x/y/w/h).
 // ---------------------------------------------------------------------------
 
 function ieErrors(el: any): string[] {
@@ -314,13 +313,12 @@ test("interactive_element schema enforces per-kind required fields (P1a)", () =>
 });
 
 // ---------------------------------------------------------------------------
-// #43c — user-supplied font bundling. When a UserFontCache carries a TTF
-// for a (family, style) tuple matching a font_family_assets entry, the
-// serializer must:
+// User-supplied font bundling. When a UserFontCache carries a TTF for a (family,
+// style) tuple matching a font_family_assets entry, the serializer must:
 //   1. Stamp the entry with the cache's `asset_id`.
 //   2. Add a corresponding entry to `asset_manifest.assets` so the zip
 //      writer packages the bytes as `assets/<hash>.ttf`.
-//   3. Leave NON-matching entries untouched (metadata-only per #43a-rev).
+//   3. Leave NON-matching entries untouched (metadata-only).
 // ---------------------------------------------------------------------------
 
 import { UserFontCache } from "../src/user-fonts";
@@ -362,7 +360,7 @@ test("serializeExport stamps user-supplied font asset_id (#43c)", async () => {
     `local_path should end in .ttf, got ${fontAssets[0].local_path}`,
   );
 
-  // 3 — the metadata-only path (#43a-rev) still works when no cache is given.
+  // The metadata-only path still works when no cache is given.
   const noCacheOut = serializeExport([knobNode()], [], ctx({
     fontFamilyAssets,
   })) as Record<string, any>;
@@ -396,10 +394,9 @@ test("UserFontCache sniffs SFNT magic for font/ttf vs font/otf (#43c)", async ()
 });
 
 // ---------------------------------------------------------------------------
-// #43c follow-up — input validation hardening (filed after self-review).
-// Pulp's "no silent failures" rule: drag-drop UX gaps that let an empty /
-// corrupt blob into the asset cache get caught here, not at runtime three
-// systems away.
+// User-font input validation hardening. Pulp's "no silent failures" rule:
+// drag-drop UX gaps that let an empty / corrupt blob into the asset cache get
+// caught here, not at runtime three systems away.
 // ---------------------------------------------------------------------------
 
 test("UserFontCache rejects 0-byte drops (#43c hardening)", async () => {
@@ -489,4 +486,3 @@ test("serializeExport does NOT emit userfont-orphan when every cached font is re
     "no orphan diagnostic when every cached font matches a catalogue entry",
   );
 });
-


### PR DESCRIPTION
## Summary
- clean stale phase/slice/issue breadcrumbs across the Figma plugin extractor, serializer, faithful-vector, font, and related tests
- keep current schema/runtime caveats while rewording comments around assets, font bundling, library recognition, and control resolution
- fix a stale hash comment so it correctly documents SHA-256 with FNV fallback

## Validation
- RepoPrompt pre-edit review selected tools/figma-plugin as the next coherent batch
- RepoPrompt post-edit review found the stale assets hash comment; fixed in this PR
- comment-only changed-line guard
- python3 tools/scripts/docs_noise_lint.py --mode=report tools/figma-plugin/src tools/figma-plugin/test
- git diff --check origin/main
- npm run typecheck (tools/figma-plugin)
- npm test (tools/figma-plugin, 60 tests)
- tools/scripts/gates.sh origin/main
- autoreview --mode local --reviewers codex,claude: clean


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans and modernizes source comments across the Figma plugin extractor, serializer, faithful‑vector path, font handling, and tests. Clarifies the content_hash algorithm (SHA‑256 with deterministic FNV‑1a fallback) and removes stale phase/issue breadcrumbs; no behavior changes.

- **Refactors**
  - Unifies wording around assets, font bundling, library recognition, and control resolution.
  - Updates comments to reflect current schema/runtime and drops outdated “Phase”/issue refs.
  - Aligns test comments with current behavior and schema fields.

<sup>Written for commit b4a7149e1b17260fb3d92d9b4854d0b200572bfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

