### PR TITLE
docs(test): clean test provenance comment breadcrumbs

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4203,13 +4203,12 @@ target_compile_definitions(pulp-test-canvas PRIVATE
     "PULP_TEST_FONT_PATH=\"${CMAKE_SOURCE_DIR}/external/fonts/Inter-Regular.ttf\"")
 catch_discover_tests(pulp-test-canvas)
 
-# Canvas CG-paths tests (P5-2 follow-up — extracted from test_canvas.cpp,
-# 2026-05). Apple-only TU covering pulp #943 / #933 concat_transform,
-# pulp #1322 Canvas2D path API (fill + curves + stroke + gradients),
-# fill_rect / fill_path with active gradient, pulp #1368 save/restore
-# tracking, and pulp #1322 BlendMode every-value round-trip. Companion
-# to test_canvas_cg_gradients.cpp; the non-Apple parts stay in
-# test_canvas.cpp.
+# Canvas CG-paths tests. Apple-only TU covering pulp #943 / #933
+# concat_transform, pulp #1322 Canvas2D path API (fill + curves +
+# stroke + gradients), fill_rect / fill_path with active gradient,
+# pulp #1368 save/restore tracking, and pulp #1322 BlendMode
+# every-value round-trip. Companion to test_canvas_cg_gradients.cpp;
+# the non-Apple parts stay in test_canvas.cpp.
 add_executable(pulp-test-canvas-cg-paths test_canvas_cg_paths.cpp)
 target_link_libraries(pulp-test-canvas-cg-paths PRIVATE pulp::canvas Catch2::Catch2WithMain)
 if(APPLE)
@@ -4217,11 +4216,10 @@ if(APPLE)
 endif()
 catch_discover_tests(pulp-test-canvas-cg-paths)
 
-# Canvas font tests (P5-2 first cut — extracted from test_canvas.cpp).
-# Covers pulp #932 (bundled-font registration via match_bundled_typeface)
-# + pulp #1150 (public register_font(path) API). Shares the
-# PULP_TEST_FONT_PATH compile def so test fixtures find the bundled
-# Inter-Regular.ttf regardless of CWD.
+# Canvas font tests. Covers pulp #932 (bundled-font registration via
+# match_bundled_typeface) + pulp #1150 (public register_font(path)
+# API). Shares the PULP_TEST_FONT_PATH compile def so test fixtures find
+# the bundled Inter-Regular.ttf regardless of CWD.
 add_executable(pulp-test-canvas-fonts test_canvas_fonts.cpp)
 target_link_libraries(pulp-test-canvas-fonts PRIVATE pulp::canvas Catch2::Catch2WithMain)
 # pulp::canvas exports PULP_HAS_SKIA=1 as a PUBLIC compile def when Skia
@@ -4240,11 +4238,11 @@ target_compile_definitions(pulp-test-canvas-fonts PRIVATE
     "PULP_TEST_VARIABLE_FONT_PATH=\"${CMAKE_SOURCE_DIR}/external/fonts/FunnelDisplay-VariableFont_wght.ttf\"")
 catch_discover_tests(pulp-test-canvas-fonts)
 
-# CG-degraded gradient + pattern cluster (P5-2 follow-up — extracted from
-# test_canvas.cpp). Apple-only TU: every TEST_CASE drives CoreGraphics
-# directly to prove the CoreGraphicsCanvas fallback honours the canvas2d
-# spec (pulp #1524) — conic / two-circle radial / pattern + gradient-
-# anchored fill/stroke text + line-dash CG paths.
+# CG-degraded gradient + pattern cluster. Apple-only TU: every
+# TEST_CASE drives CoreGraphics directly to prove the CoreGraphicsCanvas
+# fallback honours the canvas2d spec (pulp #1524) — conic / two-circle
+# radial / pattern + gradient-anchored fill/stroke text + line-dash CG
+# paths.
 add_executable(pulp-test-canvas-cg-gradients test_canvas_cg_gradients.cpp)
 target_link_libraries(pulp-test-canvas-cg-gradients PRIVATE pulp::canvas Catch2::Catch2WithMain)
 if(PULP_HAS_SKIA)
@@ -4265,11 +4263,10 @@ if(PULP_HAS_SKIA)
 endif()
 catch_discover_tests(pulp-test-canvas-filter-chain)
 
-# Canvas arcs / path-primitive Skia rasterization fixtures (P5-2
-# follow-up — extracted from test_canvas.cpp). pulp #1521 native
-# arc / arcTo / ellipse / roundRect cluster: RecordingCanvas captures
-# of native primitives + Skia rasterization fixtures (full / half
-# circle arc matches reference SkPath::arcTo, arc_to collinear
+# Canvas arcs / path-primitive Skia rasterization fixtures. pulp #1521
+# native arc / arcTo / ellipse / roundRect cluster: RecordingCanvas
+# captures of native primitives + Skia rasterization fixtures (full /
+# half circle arc matches reference SkPath::arcTo, arc_to collinear
 # lineTos, round_rect 4-corner radii, ellipse rotation contour
 # continuity).
 add_executable(pulp-test-canvas-arcs test_canvas_arcs.cpp)
@@ -4592,9 +4589,8 @@ if(PULP_ENABLE_GPU AND NOT ANDROID AND NOT IOS)
     catch_discover_tests(pulp-test-inspector
         PROPERTIES ENVIRONMENT "PULP_INSPECTOR_NO_LAUNCH=1")
 
-    # Inspector test split (Phase-5 oversized-test-file refactor): four
-    # concern-scoped sibling TUs carved verbatim out of test_inspector.cpp
-    # — GPU pass attribution, source-jump, drift/reconcile, atlas viewer.
+    # Inspector sibling TUs: GPU pass attribution, source-jump,
+    # drift/reconcile, and atlas viewer.
     # Each mirrors pulp-test-inspector's exact registration (own executable
     # + catch_discover_tests, same libraries, same NO_LAUNCH env guard).
     add_executable(pulp-test-inspector-gpu-passes test_inspector_gpu_passes.cpp)
@@ -4635,9 +4631,8 @@ if(PULP_ENABLE_GPU AND NOT ANDROID AND NOT IOS)
             PROPERTIES ENVIRONMENT "PULP_INSPECTOR_NO_LAUNCH=1")
     endif()
 
-    # P11-5 (#2647): three more concern-scoped sibling TUs carved verbatim out
-    # of test_inspector.cpp to bring the 3,126-line parent under the 2,000-line
-    # target (now 1,859). Same registration as pulp-test-inspector.
+    # Additional inspector sibling TUs (#2647). Same registration as
+    # pulp-test-inspector.
     add_executable(pulp-test-inspector-domains test_inspector_domains.cpp)
     target_link_libraries(pulp-test-inspector-domains PRIVATE pulp::view pulp::inspect pulp::state Catch2::Catch2WithMain)
     catch_discover_tests(pulp-test-inspector-domains
@@ -4696,43 +4691,39 @@ pulp_add_test_suite(pulp-test-widget-bridge-api-contracts
 pulp_add_test_suite(pulp-test-widget-bridge-no-gpu-gates
     COMPILE_DEFINITIONS PULP_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 
-# Widget bridge — runtime-import handlers (pulp #468 follow-up).
-# Split out of test_widget_bridge.cpp in the Phase 5 P5-1 first cut so
-# the 14k-line god-test file shrinks toward per-surface modules.
+# Widget bridge — runtime-import handlers (pulp #468).
 pulp_add_test_suite(pulp-test-widget-bridge-runtime-import LIBRARIES pulp::view)
 
-# Widget bridge — Canvas2D surface (P5-1 continuation).
-# Covers canvasSetTransform / canvasClip / canvasGlobalCompositeOperation
-# (issue-896), canvasMeasureText / canvasSetLineDash / canvasDrawImage /
+# Widget bridge — Canvas2D surface. Covers canvasSetTransform /
+# canvasClip / canvasGlobalCompositeOperation (issue-896),
+# canvasMeasureText / canvasSetLineDash / canvasDrawImage /
 # canvasGetImageData / canvasPutImageData (issue-916), and pulp #1899 /
 # #1901 4-arg canvasFillText prior-state preservation.
 pulp_add_test_suite(pulp-test-widget-bridge-canvas2d LIBRARIES pulp::view)
 
-# Widget bridge — Yoga layer (P5-1 follow-up). Three coherent clusters:
-# (1) pulp #1434 rn-batch-C dimension percent strings (width/height +
-# min/max via Yoga's percent API), (2) pulp #1545 flexBasis%
-# promotion (basis "NN%" + "flex 1 1 NN%" decomposition), (3) pulp
-# #1434 rn-batch-B yoga value-aliasing (flexDirection /
-# justifyContent / alignItems / alignSelf / order / flexWrap value
-# translations).
+# Widget bridge — Yoga layer. Three coherent clusters: (1) pulp #1434
+# dimension percent strings (width/height + min/max via Yoga's percent
+# API), (2) pulp #1545 flexBasis% promotion (basis "NN%" +
+# "flex 1 1 NN%" decomposition), (3) pulp #1434 yoga value-aliasing
+# (flexDirection / justifyContent / alignItems / alignSelf / order /
+# flexWrap value translations).
 pulp_add_test_suite(pulp-test-widget-bridge-yoga LIBRARIES pulp::view)
 
-# Widget bridge — Canvas2D Wave 2 cheap-wiring surface (P5-1 follow-up).
+# Widget bridge — Canvas2D Wave 2 cheap-wiring surface.
 # Covers canvas2d/fill + canvas2d/clip evenodd, canvas2d/roundRect
 # 4-corner radii, canvas2d/ellipse rotation, canvas2d/strokeText
 # dedicated-command routing — the five Wave 2 partial → supported
 # compat.json entries.
 pulp_add_test_suite(pulp-test-widget-bridge-canvas2d-wave2 LIBRARIES pulp::view)
 
-# Widget bridge — yoga logical-edge fan-out + A4 OOS pins (P5-1
-# follow-up). pulp #1542 yoga logical-edge (marginInline/Block +
-# paddingInline/Block + inset shorthand) + pulp #1434 A4 Bundles 2-7
-# css NOT-IMPL closure catalog hygiene.
+# Widget bridge — yoga logical-edge fan-out + A4 OOS pins. pulp #1542
+# yoga logical-edge (marginInline/Block + paddingInline/Block + inset
+# shorthand) + pulp #1434 CSS NOT-IMPL closure catalog hygiene.
 pulp_add_test_suite(pulp-test-widget-bridge-yoga-a4-oos LIBRARIES pulp::view)
 
-# Widget bridge — Wave 2 cheap-wiring (P5-1 follow-up). Bundles the
-# Wave 2 canvas2d cheap wiring (DIVERGE → PASS) + Wave 2 css value-
-# coverage wiring entries from compat.json's Wave 2 cleanup pass.
+# Widget bridge — Wave 2 cheap-wiring. Bundles the Canvas2D cheap
+# wiring (DIVERGE → PASS) + CSS value-coverage wiring entries from
+# compat.json's Wave 2 cleanup pass.
 pulp_add_test_suite(pulp-test-widget-bridge-wave2-cheap LIBRARIES pulp::view)
 
 # Widget bridge — RN style-prop bridge primitives (P5-1 follow-up,

--- a/test/test_canvas2d_shim_late.cpp
+++ b/test/test_canvas2d_shim_late.cpp
@@ -1,14 +1,11 @@
-// test_canvas2d_shim_late.cpp — extracted from test_canvas2d_shim.cpp
-// in the 2026-05 Phase 5 (P5-2 follow-up) refactor.
-//
-// Post-Wave-2 Canvas2D shim coverage. Each cluster pins runtime path
-// for entries that landed under specific issues:
+// Canvas2D shim coverage. Each cluster pins runtime paths for entries
+// that landed under specific issues:
 //
 //   * #1525 — fillText / strokeText maxWidth + glyph cluster handling
 //   * #1521 — arc-as-path cluster (DIVERGE → PASS)
 //   * #1520 — ctx.direction / ctx.filter
 //   * #1526 — catalog hygiene round-trip for already-supported properties
-//   * Wave 4 c2d cleanup — lineDashOffset re-flushes on assignment
+//   * lineDashOffset re-flushes on assignment
 //   * #1527 — getTransform / resetTransform + isPointInPath / isPointInStroke
 
 #include <catch2/catch_test_macros.hpp>
@@ -35,10 +32,8 @@ using namespace pulp::view;
 using namespace pulp::state;
 
 // Local copies of run_in_bridge + ScriptedBridge — file-static in the
-// parent test_canvas2d_shim.cpp. Duplicated here per the extracted-TU
-// pattern. Updating one without the other is a documented gotcha; this
-// is the same trade-off the canvas2d-wave2 + svg + other widget-bridge
-// splits already accept.
+// parent test_canvas2d_shim.cpp. Updating one without the other is a
+// documented gotcha.
 namespace {
 
 std::string run_in_bridge(const std::string& js) {
@@ -776,13 +771,11 @@ TEST_CASE("Canvas2D direction + filter cache invalidates on save/restore",
 //
 // Ten entries — globalAlpha, lineCap, lineJoin, lineDashOffset,
 // textAlign, textBaseline, globalCompositeOperation, quadraticCurveTo,
-// bezierCurveTo, arc — were cataloged in PR #1366 / wired in PR #1348 /
-// fanned out across #1480 (line cap/join paint plumbing) and the pre-
-// existing FilterBank repro suite. Their bridge-side coverage is split
-// across the issue-964 cases above, but no single test exercises the
-// 10-as-a-set as the catalog claims. This test pins each one's full
-// round-trip through the JS shim → bridge → CanvasWidget command stream
-// so a regression in any of them surfaces directly under [issue-1526].
+// bezierCurveTo, arc — have bridge-side coverage split across the
+// issue-964 cases above, but no single test exercises the 10-as-a-set
+// as the catalog claims. This test pins each one's full round-trip
+// through the JS shim → bridge → CanvasWidget command stream so a
+// regression in any of them surfaces directly under [issue-1526].
 TEST_CASE("Canvas2D shim flushes the 10-entry catalog set to the bridge",
           "[view][canvas2d][issue-1526]") {
     ScriptedBridge env;
@@ -969,17 +962,17 @@ TEST_CASE("Canvas2D shim getter round-trip for the 10-entry catalog set",
         "methods-ok");
 }
 
-// ── Wave 4 c2d cleanup — lineDashOffset re-flushes on assignment ─────────
+// ── lineDashOffset re-flushes on assignment ─────────────────────────────
 //
 // HTML5 spec: ctx.lineDashOffset is a sticky phase property; assigning to
 // it must shift the dash phase on subsequent strokes without requiring a
-// redundant setLineDash call. Pre-Wave-4 the field was tracked locally
-// but only sent on the next setLineDash, so phase mutations between
-// draws were silently dropped.
+// redundant setLineDash call. The field used to be tracked locally but
+// only sent on the next setLineDash, so phase mutations between draws
+// were silently dropped.
 //
-// Wave 4 converted lineDashOffset to an Object.defineProperty getter/
-// setter pair: the setter re-pushes the active dash pattern via
-// canvasSetLineDash with the new phase. Verify that:
+// lineDashOffset now uses an Object.defineProperty getter/setter pair:
+// the setter re-pushes the active dash pattern via canvasSetLineDash
+// with the new phase. Verify that:
 //   1. The default (lineDashOffset=0) reads back as 0.
 //   2. Assigning a new value with a pattern in place re-pushes
 //      canvasSetLineDash with the new phase.

--- a/test/test_canvas_arcs.cpp
+++ b/test/test_canvas_arcs.cpp
@@ -1,6 +1,3 @@
-// test_canvas_arcs.cpp — extracted from test_canvas.cpp in the
-// 2026-05 Phase 5 (P5-2 follow-up) refactor.
-//
 // pulp #1521 — native arc / arcTo / ellipse / roundRect cluster.
 //
 // Two contiguous sub-clusters under the same arc/path-primitive

--- a/test/test_canvas_cg_paths.cpp
+++ b/test/test_canvas_cg_paths.cpp
@@ -1,6 +1,3 @@
-// test_canvas_cg_paths.cpp — extracted from test_canvas.cpp in the
-// 2026-05 Phase 5 P5-2 follow-up refactor.
-//
 // CoreGraphicsCanvas — Canvas2D path + transform + gradient + blend +
 // save/restore tests. Apple-only TU (`#ifdef __APPLE__`). Covers:
 //
@@ -11,10 +8,9 @@
 //   * pulp #1322 set_blend_mode (BlendMode enum every value round-trip
 //     through to_cg_blend)
 //
-// Companion to test_canvas_cg_gradients.cpp (PR #2247) which covers the
-// other Apple-only CG paths (conic, radial, pattern, line-dash, gradient-
-// anchored text). The previously bundled CG tests stay in test_canvas.cpp
-// for the non-Apple paths.
+// Companion to test_canvas_cg_gradients.cpp, which covers the other
+// Apple-only CG paths (conic, radial, pattern, line-dash, gradient-
+// anchored text). Non-Apple paths stay in test_canvas.cpp.
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>

--- a/test/test_canvas_fonts.cpp
+++ b/test/test_canvas_fonts.cpp
@@ -1,14 +1,9 @@
-// test_canvas_fonts.cpp — extracted from test_canvas.cpp in the 2026-05
-// Phase 5 (P5-2 first cut) refactor. Covers two font-related test
-// clusters that share Skia font-manager fixtures:
+// Font tests that share Skia font-manager fixtures:
 //
 //   - pulp #932 — bundled-font (Inter-Regular, JetBrainsMono-Regular)
 //     registration with SkFontMgr + bundled_blobs() table.
 //   - pulp #1150 — public `register_font(path)` API + the SkFontMgr
 //     fallback chain through match_bundled_typeface.
-//
-// Test set is byte-equivalent to the in-place section it replaces;
-// only the TU boundary moved.
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>

--- a/test/test_canvas_widget_shadow.cpp
+++ b/test/test_canvas_widget_shadow.cpp
@@ -1,6 +1,3 @@
-// test_canvas_widget_shadow.cpp — extracted from test_canvas_widget.cpp
-// in the 2026-05 Phase 5 P5-3 follow-up refactor.
-//
 // CanvasWidget + SkiaCanvas Canvas2D shadow-state cluster. Pins:
 //
 //   * CanvasWidget replays sticky Canvas2D shadow setters before each
@@ -152,9 +149,7 @@ TEST_CASE("CanvasWidget shadow setters can be cleared mid-stream",
 
 #ifdef PULP_HAS_SKIA
 
-// Shared raster-pixel probe. This file was extracted from
-// test_canvas_widget.cpp in the Phase 5 P5-3 split (#2418) but never
-// carried sample_pixel — the loose end pulp #2462 tracked.
+// Shared raster-pixel probe for the Skia pixel-readback tests below.
 #include "canvas_pixel_probe.hpp"
 using pulp::canvas_test::Pixel;
 using pulp::canvas_test::sample_pixel;
@@ -248,4 +243,3 @@ TEST_CASE("SkiaCanvas skips shadow when fully transparent or zero",
 // `set_direction` / `set_filter` commands through to the underlying
 // canvas (here, RecordingCanvas) so the JS shim's setter intent reaches
 // the active backend on every frame.
-

--- a/test/test_cli_shellout_helpers.hpp
+++ b/test/test_cli_shellout_helpers.hpp
@@ -1,13 +1,11 @@
-// test_cli_shellout_helpers.hpp — shared helpers for the test_cli_shellout
-// suite and its sibling TUs extracted in the Phase 5 P5-4 refactor.
+// Shared helpers for the test_cli_shellout suite and its sibling TUs.
 //
 // Per CLAUDE.md: shell-out CLI tests assert exit code + stderr content
 // against the built binary. These helpers wrap the platform-specific
 // env-var / process / path plumbing every shell-out test repeats.
 //
 // Helpers are header-inline so each translation unit can include this
-// without ODR issues. They were previously living in an anonymous
-// namespace inside test_cli_shellout.cpp.
+// without ODR issues.
 
 #pragma once
 

--- a/test/test_cli_shellout_lifecycle.cpp
+++ b/test/test_cli_shellout_lifecycle.cpp
@@ -1,14 +1,10 @@
-// test_cli_shellout_lifecycle.cpp — extracted from test_cli_shellout.cpp
-// in the 2026-05 Phase 5 P5-4 follow-up refactor.
-//
 // CLI lifecycle-command shell-out tests — pulp doctor, pulp dev,
 // pulp design, pulp sdk, pulp upgrade. All five commands sit in the
 // "lifecycle / diagnostics" surface of the CLI: they help users
 // inspect and maintain their dev environment rather than building or
-// shipping a plugin. Bundling them keeps the parent TU under the
-// < 2,000-line P5-4 target while preserving their shared shell-out
-// contract (PULP_HOME tmpdir + binary_exists guard + ProcessResult
-// stdout/exit_code assertions).
+// shipping a plugin. They share the shell-out contract: PULP_HOME
+// tmpdir, binary_exists guard, and ProcessResult stdout/exit_code
+// assertions.
 
 #include "test_cli_shellout_helpers.hpp"
 

--- a/test/test_cli_shellout_loop.cpp
+++ b/test/test_cli_shellout_loop.cpp
@@ -1,6 +1,3 @@
-// test_cli_shellout_loop.cpp — extracted from test_cli_shellout.cpp
-// in the 2026-05 Phase 5 P5-4 refactor.
-//
 // `pulp loop` shell-out tests. Covers the surface that
 // doesn't depend on a live watch loop (the watch-loop interactions are
 // tested by `pulp dev`'s harness):

--- a/test/test_cli_shellout_pr.cpp
+++ b/test/test_cli_shellout_pr.cpp
@@ -1,8 +1,4 @@
-// test_cli_shellout_pr.cpp — extracted from test_cli_shellout.cpp in
-// the 2026-05 Phase 5 P5-4 follow-up refactor.
-//
-// `pulp pr` shell-out tests — 11 TEST_CASEs spread across two contiguous
-// clusters in the parent TU. Covers:
+// `pulp pr` shell-out tests. Covers:
 //
 //   * pr.workflow validation (manual / github / shipyard delegation)
 //   * Shipyard binary pin handling

--- a/test/test_cli_shellout_scan_projects.cpp
+++ b/test/test_cli_shellout_scan_projects.cpp
@@ -1,6 +1,3 @@
-// test_cli_shellout_scan_projects.cpp — extracted from test_cli_shellout.cpp
-// in the 2026-05 Phase 5 P5-4 refactor.
-//
 // `pulp projects list` and `pulp scan` shell-out tests:
 //
 //   * `pulp projects list --json` emits valid JSON for empty + non-empty

--- a/test/test_design_import_react_runtime.cpp
+++ b/test/test_design_import_react_runtime.cpp
@@ -1,11 +1,7 @@
-// test_design_import_react_runtime.cpp — extracted from test_design_import.cpp
-// in the 2026-05 Phase 5 (P5-3 follow-up) refactor.
-//
 // React-runtime parser cluster — TSX/runtime React bundle parsers for
 // every supported design-tool source. All four parsers share a
 // consistent contract: parse fixture, materialize via host React shim,
-// accept sanitized TSX, reject out-of-matrix surfaces. Originally lived
-// across ~830 contiguous lines in test_design_import.cpp.
+// accept sanitized TSX, reject out-of-matrix surfaces.
 //
 // Covered:
 //   * parse_v0_tsx + parse_v0_dev_react           (v0.dev)

--- a/test/test_widget_bridge_html_aria.cpp
+++ b/test/test_widget_bridge_html_aria.cpp
@@ -1,7 +1,4 @@
-// test_widget_bridge_html_aria.cpp — extracted from test_widget_bridge.cpp
-// in the 2026-05 Phase 5 (P5-1 follow-up) refactor.
-//
-// Wave 3 html bundle — two coherent compat surfaces:
+// HTML compatibility bundle — two coherent surfaces:
 //
 //   1. ARIA attribute routing (#1476 / html.2). aria-label and role
 //      attributes flow through the html-compat shim into View's
@@ -40,11 +37,11 @@ using namespace pulp::view;
 using namespace pulp::state;
 using Catch::Matchers::WithinAbs;
 
-// ── pulp Wave 3 html bundle (ARIA + querySelector) ─────────────────────
+// ── HTML bundle (ARIA + querySelector) ──────────────────────────────────
 //
-// Wave 3 html.2 / #1476: aria-label / role attributes flow through the
+// pulp #1476: aria-label / role attributes flow through the
 // html-compat shim into View::access_label_ / View::access_role_ slots
-// that the macOS NSAccessibility bridge already consumes.  Wave 3 html.3:
+// that the macOS NSAccessibility bridge already consumes.
 // document.querySelector accepts attribute selectors, compound selectors,
 // and descendant / child combinators in addition to the previously
 // supported tag/.class/#id forms.

--- a/test/test_widget_bridge_svg.cpp
+++ b/test/test_widget_bridge_svg.cpp
@@ -1,6 +1,3 @@
-// test_widget_bridge_svg.cpp — extracted from test_widget_bridge.cpp
-// in the 2026-05 Phase 5 (P5-1 follow-up) refactor.
-//
 // SVG widget JS-bridge integration, three coherent compat surfaces:
 //
 //   1. pulp #965 — SvgPathWidget JS bridge integration.
@@ -870,4 +867,3 @@ TEST_CASE("WidgetBridge SvgPath compound multi-subpath parses every segment",
     REQUIRE(moves == 10);
     REQUIRE(lines == 10);
 }
-

--- a/tools/scripts/hotspot_size_guard.json
+++ b/tools/scripts/hotspot_size_guard.json
@@ -32,8 +32,8 @@
     },
     {
       "path": "test/CMakeLists.txt",
-      "max_loc": 6151,
-      "note": "shared test registration hotspot"
+      "max_loc": 6142,
+      "note": "shared test registration hotspot; lowered after comment-hygiene cleanup"
     },
     {
       "path": "test/test_design_import_codegen.cpp",


### PR DESCRIPTION
## Summary
- remove stale Phase/P5/Wave/split provenance from test comments and test registration comments
- preserve current test rationale: platform guards, issue contracts, PULP_HAS_SKIA propagation, ODR/header-inline notes, duplicated helper sync warnings, and NO_LAUNCH safety notes
- lower the test/CMakeLists.txt hotspot ceiling from 6151 to 6142 after the comment shrink

## Validation
- RepoPrompt pre-edit review and post-edit review
- RepoPrompt subagent read-only audit for preserve/remove guidance
- changed-line guard for comment-only test/CMake edits
- python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD
- git diff --check origin/main
- tools/scripts/gates.sh origin/main
- autoreview --mode local --reviewers codex,claude (clean, final diff)

Skill-Update: skip skill=ci reason="hotspot ceiling reduction only"


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up stale provenance breadcrumbs in test comments and CMake test registrations while keeping actionable rationale. Reduced the `test/CMakeLists.txt` hotspot ceiling after the shrink; no test logic or behavior changed.

- **Refactors**
  - Removed Phase/Wave/split history notes and redundant extraction comments across test files.
  - Preserved rationale: platform guards, issue links, `PULP_HAS_SKIA` propagation, ODR/header-inline notes, helper sync warnings, and `NO_LAUNCH` safety notes.
  - Lowered `tools/scripts/hotspot_size_guard.json` limit for `test/CMakeLists.txt` from 6151 to 6142.

<sup>Written for commit de8f4cf643f6a3777d885009e44b4fb60910d0fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

