### PR TITLE
docs(source): clean Priority B source comment breadcrumbs

### DIFF
--- a/core/canvas/src/msdf_atlas.cpp
+++ b/core/canvas/src/msdf_atlas.cpp
@@ -7,11 +7,11 @@
 // where single-channel SDF rounds them off.
 //
 // This is *not* Chlumsky's shape-decomposition algorithm (which emits
-// provably-orthogonal channels per edge); a follow-up pass that vendors
-// the `msdfgen` library (MIT) will replace `generate_msdf_tile()` with
-// its output. The current generator is strong enough to exercise the
-// MSDF sampler shader, demonstrate sharper corners than plain SDF on
-// simple primitives, and validate the atlas packing + test pipeline.
+// provably-orthogonal channels per edge). An msdfgen-backed implementation
+// can replace `generate_msdf_tile()` with true per-edge channel output; the
+// current generator is strong enough to exercise the MSDF sampler shader,
+// demonstrate sharper corners than plain SDF on simple primitives, and
+// validate the atlas packing + test pipeline.
 
 #include <pulp/canvas/msdf_atlas.hpp>
 

--- a/core/format/include/pulp/format/processor.hpp
+++ b/core/format/include/pulp/format/processor.hpp
@@ -627,12 +627,14 @@ public:
     /// state/sync-strategy guidance for cache invalidation.
     ///
     /// Wiring:
-    ///   iOS       — PulpAudioSessionBridge routes didReceiveMemoryWarning
-    ///               into the running processor.
-    ///   macOS     — no-op today; host apps can still invoke manually to
-    ///               test plugin behaviour.
-    ///   Android   — ComponentCallbacks2.onTrimMemory (future slice).
-    ///   Windows   — CreateMemoryResourceNotification (future slice).
+    ///   iOS       — the platform layer receives didReceiveMemoryWarning;
+    ///               routing that signal into processors is host-owned.
+    ///   macOS     — the platform layer observes DISPATCH_MEMORYPRESSURE;
+    ///               routing that signal into processors is host-owned.
+    ///   Android   — the platform layer receives ComponentCallbacks2.onTrimMemory;
+    ///               routing that signal into processors is host-owned.
+    ///   Windows   — the platform layer samples GlobalMemoryStatusEx(); routing
+    ///               that signal into processors is host-owned.
     virtual void on_memory_pressure(MemoryPressure /*level*/) {}
 
     /// Latency in samples introduced by this processor (default 0).

--- a/core/signal/include/pulp/signal/offline_stretch.hpp
+++ b/core/signal/include/pulp/signal/offline_stretch.hpp
@@ -56,10 +56,9 @@ enum class StretchTransientMode { phase_reset, verbatim_relocate };
 ///                   Natural, time != pitch. Best for tonal/melodic/sustained.
 ///   varispeed     — pitch+time LINKED (pure resample) + speed-scaled tape head EQ.
 ///                   Tape character, NO stretch artifacts. Pitch follows tempo.
-///   phase_vocoder — clean + verbatim transient relocation for extra punch.
-///                   SCAFFOLD: relocation seam handling is not solved yet, so this
-///                   currently renders as `clean` (see relocate_transients).
-///   granular      — grain/stutter texture. SCAFFOLD: not implemented, renders clean.
+///   phase_vocoder — reserved for clean + verbatim transient relocation; currently
+///                   renders as `clean` until seam handling passes the quality gate.
+///   granular      — reserved for grain/stutter texture; currently renders as `clean`.
 enum class StretchCharacter { clean, varispeed, phase_vocoder, granular };
 
 /// Whole-input render options.
@@ -68,7 +67,7 @@ struct OfflineStretchOptions {
     /// pitch_semitones (pitch is linked to time_ratio); the others honor it.
     StretchCharacter character = StretchCharacter::clean;
     /// Cross-engine: graft verbatim transients onto the stretched output for punch.
-    /// SCAFFOLD — the seam-clean implementation is future work; currently a no-op.
+    /// Current limitation: seam-clean relocation is not enabled yet, so this is a no-op.
     bool relocate_transients = false;
     double time_ratio = 1.0;        ///< output duration / input duration
     double pitch_semitones = 0.0;   ///< fractional allowed
@@ -290,9 +289,9 @@ public:
 
         // Character-mode dispatch. `varispeed` is pitch+time-linked (tape): a pure
         // resample + a speed-scaled head EQ, no phase-vocoder artifacts. The
-        // `phase_vocoder` and `granular` characters are scaffolds — they fall
+        // `phase_vocoder` and `granular` characters are reserved modes that fall
         // through to the clean spectral path for now (relocate_transients is a
-        // documented no-op until the seam-clean relocation lands).
+        // documented no-op until seam-clean relocation is enabled).
         if (opts.character == StretchCharacter::varispeed)
             return varispeed_render(in, in_frames, out, out_frames, opts.time_ratio);
 

--- a/core/view/include/pulp/view/design_export.hpp
+++ b/core/view/include/pulp/view/design_export.hpp
@@ -76,8 +76,8 @@ public:
 //      back into DESIGN.md.
 //
 // This API is intentionally gated until anchor-stable IDs and 3-way merge
-// semantics are available. Until then, the function below throws
-// `std::logic_error("export_designmd is gated on pulp #1307")`.
+// semantics are available. Until then, the function below throws a
+// reimport-safe design-loop gate error instead of writing partial output.
 
 struct DesignMdProseHints {
     // Optional verbatim prose for each canonical section (Overview,

--- a/core/view/src/design_export.cpp
+++ b/core/view/src/design_export.cpp
@@ -197,10 +197,10 @@ std::string DesignExport::to_wgsl_uniforms(const Theme& theme, const std::string
     return ss.str();
 }
 
-// ── Phase 3 (gated on pulp #1307) ───────────────────────────────────────
+// ── DESIGN.md emitter ───────────────────────────────────────────────────
 //
 // DESIGN.md emitter — fills in once anchor-stable IDs + 3-way merge
-// semantics from #1307 land. Until then the signature is fixed so
+// semantics are available. Until then the signature is fixed so
 // callers can wire against it; the body throws so misuse surfaces
 // at the call site rather than silently writing an empty file.
 


### PR DESCRIPTION
## Summary

- Clean stale source-comment breadcrumbs across the Priority B comment-hygiene areas: MSDF atlas, Processor memory-pressure notes, OfflineStretch reserved modes, and DESIGN.md emitter comments.
- Keep behavior unchanged and preserve the existing user-visible `export_designmd` gated error string.
- Leave already-clean/obsolete rows untouched after live scan showed their targeted markers were gone on current `origin/main`.

## Validation

- `git diff --check origin/main..HEAD`
- Added-line scan: comment-only
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD`
- `tools/scripts/gates.sh origin/main`
- Pre-push full local diff-coverage run: `10410/10410` CTest tests passed, diff-cover OK
- Claude review: Clean
- autoreview: clean, no accepted/actionable findings


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned stale source-comment breadcrumbs in the MSDF atlas, processor memory-pressure wiring docs, offline stretch reserved modes, and DESIGN.md emitter comments. No functional changes; the `export_designmd` gate/error string remains unchanged.

<sup>Written for commit a8168ee89a5a19ce2049073a0e34bbb35003a7ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

