### PR TITLE
docs(native): clean Rust fixture provenance comments

### DIFF
--- a/test/fixtures/native-components/gain-rust-core/Cargo.toml
+++ b/test/fixtures/native-components/gain-rust-core/Cargo.toml
@@ -1,5 +1,5 @@
-# Real Rust DSP core (a stereo gain) for the Phase 2b end-to-end proof: a native
-# Rust core that actually processes audio through the C ABI, driven by the C++
+# Real Rust DSP core (a stereo gain) for the end-to-end proof: a native Rust core
+# that actually processes audio through the C ABI, driven by the C++
 # NativeCoreProcessor adapter. TEST FIXTURE — built only under
 # PULP_BUILD_NATIVE_COMPONENT_RUST_TESTS (default OFF).
 [package]

--- a/test/fixtures/native-components/gain-rust-core/src/lib.rs
+++ b/test/fixtures/native-components/gain-rust-core/src/lib.rs
@@ -1,6 +1,6 @@
 //! A real Rust stereo-gain DSP core implementing the Pulp native-component C
 //! ABI, used to prove end-to-end native audio through the C++
-//! NativeCoreProcessor adapter (Phase 2b). TEST FIXTURE ONLY.
+//! NativeCoreProcessor adapter. TEST FIXTURE ONLY.
 //!
 //! Hand-mirrors the `#[repr(C)]` structs it reads in `process()` (audio buses,
 //! the parameter-event view, the process bundle) plus the descriptor/param/

--- a/test/fixtures/native-components/node-rust/src/lib.rs
+++ b/test/fixtures/native-components/node-rust/src/lib.rs
@@ -1,6 +1,6 @@
 //! A Rust custom node implementing the public `pulp_node_v1` C ABI, used to
-//! prove a C node and a Rust node load through the SAME contract (Phase 6).
-//! TEST FIXTURE ONLY. Hand-mirrors the `#[repr(C)]` structs from
+//! prove a C node and a Rust node load through the SAME contract. TEST FIXTURE
+//! ONLY. Hand-mirrors the `#[repr(C)]` structs from
 //! core/native-components/include/pulp/native_components/pulp_node_v1.h.
 
 #![allow(non_camel_case_types)]

--- a/test/fixtures/native-components/node_pack_test_module.cpp
+++ b/test/fixtures/native-components/node_pack_test_module.cpp
@@ -1,6 +1,6 @@
 // A minimal pulp_node_v1 node built as a loadable MODULE (.dylib/.so/.dll) for
-// the Phase 7 node-pack loader test. Exports pulp_node_v1_entry with default
-// visibility so dlsym/GetProcAddress can resolve it.
+// the node-pack loader test. Exports pulp_node_v1_entry with default visibility
+// so dlsym/GetProcAddress can resolve it.
 
 #if defined(_WIN32)
 #define PULP_NODE_V1_EXPORT __declspec(dllexport)

--- a/test/fixtures/native-components/noop-rust-core/Cargo.toml
+++ b/test/fixtures/native-components/noop-rust-core/Cargo.toml
@@ -1,4 +1,4 @@
-# Reference no-op native DSP core for the opt-in Phase 1 Rust lane.
+# Reference no-op native DSP core for the opt-in Rust lane.
 #
 # This is a TEST FIXTURE, not a shipped crate. It proves the canonical C ABI
 # (core/native-components/include/pulp/native_components/native_core.h) links and

--- a/test/fixtures/native-components/noop-rust-core/src/lib.rs
+++ b/test/fixtures/native-components/noop-rust-core/src/lib.rs
@@ -184,8 +184,8 @@ extern "C" fn suspend(inst: *mut c_void) -> i32 {
     PULP_NATIVE_OK
 }
 extern "C" fn reset(_inst: *mut c_void) {}
-// No-op process: passthrough is a Phase 2 concern (golden audio). Here we only
-// prove the call links and dispatches RT-safely (no alloc/log/panic).
+// No-op process: passthrough/golden-audio is out of scope for this fixture.
+// Here we only prove the call links and dispatches RT-safely (no alloc/log/panic).
 extern "C" fn process(_inst: *mut c_void, _io: *const c_void) -> i32 {
     PULP_NATIVE_OK
 }

--- a/test/native_components/reference_processor.hpp
+++ b/test/native_components/reference_processor.hpp
@@ -1,11 +1,9 @@
-// Cross-format parity-harness SKELETON.
+// Cross-format parity harness support.
 //
-// Phase 1 ships the shape only: a reference-processor concept plus the
-// event-case matrix the future harness will run identically across VST3 / AU /
-// CLAP / LV2 (Phase 3 fills in per-format execution). It exists now so the
-// Phase 2 prototype is written against a stable fixture surface and the
-// Phase 2->3 ordering hazard is removed. There is intentionally NO format
-// execution here yet.
+// Reference-processor concept plus the event-case matrix the future harness
+// will run identically across VST3 / AU / CLAP / LV2. This keeps fixture
+// identity stable before per-format execution exists. There is intentionally NO
+// format execution here yet.
 #pragma once
 
 #include <cstdint>
@@ -14,9 +12,9 @@
 namespace pulp::native_components::test {
 
 // The matrix of behaviours a single reference processor must exhibit identically
-// across every format. Phase 3's harness asserts each case; a format that
-// genuinely cannot represent a case records `Unsupported` (an explicit skip),
-// never a silent pass.
+// across every format. The harness asserts each case; a format that genuinely
+// cannot represent a case records `Unsupported` (an explicit skip), never a
+// silent pass.
 enum class EventCase : std::uint8_t {
     Effect,            // stereo in/out, no MIDI
     InstrumentMidi,    // MIDI in -> audio out
@@ -45,8 +43,8 @@ struct ReferenceProcessorSpec {
     EventCase primary_case;
 };
 
-// The set of reference processors the full harness will eventually drive. Phase
-// 1 declares them; Phase 3 wires the per-format runners.
+// The set of reference processors the full harness will eventually drive.
+// Per-format runners are wired separately.
 inline constexpr ReferenceProcessorSpec kReferenceProcessors[] = {
     {"ref.gain", "Reference Gain", EventCase::Effect},
     {"ref.synth", "Reference Synth", EventCase::InstrumentMidi},

--- a/test/native_components/rt_intercept_test_support.cpp
+++ b/test/native_components/rt_intercept_test_support.cpp
@@ -15,8 +15,8 @@
 // The trap itself allocates nothing, locks nothing, and only writes a fixed
 // message with write(2) before aborting — safe to call from anywhere,
 // including a death-test child. macOS + Linux are the primary enforcement
-// platforms (per the Phase 1 design); both honour a strong global
-// operator-new override and a Rust #[global_allocator] in this executable.
+// platforms; both honour a strong global operator-new override and a Rust
+// #[global_allocator] in this executable.
 
 #include "rt_test_scope.hpp"
 #include "../harness/rt_allocation_probe.hpp"

--- a/test/test_pulp_node_v1_rust.cpp
+++ b/test/test_pulp_node_v1_rust.cpp
@@ -1,7 +1,7 @@
-// Phase 6 cross-language proof (opt-in, PULP_BUILD_NATIVE_COMPONENT_RUST_TESTS):
-// a Rust node implementing pulp_node_v1 loads through the SAME contract the
-// always-built C node uses (test_pulp_node_v1.cpp). Proves the public node ABI
-// is genuinely language-neutral.
+// Opt-in cross-language proof (PULP_BUILD_NATIVE_COMPONENT_RUST_TESTS): a Rust
+// node implementing pulp_node_v1 loads through the SAME contract the always-built
+// C node uses (test_pulp_node_v1.cpp). Proves the public node ABI is genuinely
+// language-neutral.
 
 #include <pulp/native_components/pulp_node_v1.h>
 #include <pulp/native_components/pulp_node_v1.hpp>

--- a/test/test_rust_dsp_ffi.cpp
+++ b/test/test_rust_dsp_ffi.cpp
@@ -119,7 +119,7 @@ TEST_CASE("C++ allocation inside a no-alloc scope also traps (death test)",
 
 TEST_CASE("parity-harness skeleton exposes the reference matrix",
           "[rust-dsp][parity]") {
-    // Phase 1 only declares the matrix; Phase 3 wires per-format execution.
+    // This only declares the matrix; per-format execution is wired separately.
     REQUIRE(std::size(test::kReferenceProcessors) == 3);
     REQUIRE(test::kReferenceProcessors[0].primary_case == test::EventCase::Effect);
 }

--- a/test/test_rust_dsp_processor.cpp
+++ b/test/test_rust_dsp_processor.cpp
@@ -1,7 +1,7 @@
-// Phase 2b end-to-end proof (opt-in, PULP_BUILD_NATIVE_COMPONENT_RUST_TESTS):
-// a REAL Rust DSP core (a stereo gain) driven through the C++
-// NativeCoreProcessor adapter. 1b proved Rust <-> C ABI; 2a proved the adapter
-// <-> Processor seam with a C++ core; this joins them with real Rust audio.
+// Opt-in Rust DSP proof (PULP_BUILD_NATIVE_COMPONENT_RUST_TESTS): a REAL Rust
+// DSP core (a stereo gain) driven through the C++ NativeCoreProcessor adapter.
+// This joins the Rust <-> C ABI with the adapter <-> Processor seam using real
+// Rust audio.
 
 #include <pulp/format/native_core_processor.hpp>
 


### PR DESCRIPTION
## Summary
- clean stale phase/prototype breadcrumbs from the native/Rust fixture comments
- preserve ABI decision anchors, RT/no-alloc invariants, stable fixture IDs, and current unsupported-format semantics
- keep this as one consolidated native/Rust comment-hygiene batch

## Validation
- git diff --check origin/main...HEAD
- stale-marker scan over edited native/Rust files
- comment-only diff verifier
- python3 tools/scripts/docs_noise_lint.py --mode=report --base refs/remotes/origin/main --head HEAD
- cargo metadata for noop/gain/node Rust fixture manifests
- tools/scripts/gates.sh refs/remotes/origin/main --pr-title "docs(native): clean Rust fixture provenance comments"
- RepoPrompt Oracle review: Clean
- autoreview --mode branch --base origin/main --reviewers codex,claude: clean

## Note
A focused opt-in Release build of the native Rust test targets succeeded, but the pre-existing `pulp-test-rust-dsp-ffi` C++ allocation death test still exits normally instead of trapping on this machine. The Rust allocation death test passes; this PR does not change test code or runtime behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned stale phase/prototype breadcrumbs from Rust native fixture and test comments to improve clarity while keeping ABI anchors and RT invariants intact. Comment-only cleanup; no behavior changes.

- **Refactors**
  - Removed outdated phase markers in `gain-rust-core`, `noop-rust-core`, `node-rust`, and related C++ tests.
  - Clarified reference harness and node-pack comments; preserved ABI decision anchors, RT/no-alloc notes, stable fixture IDs, and unsupported-format semantics.

<sup>Written for commit 86f76af87eb8f71c57d31a42dede69a0c1c2cdad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

