### PR TITLE
docs(source): clean remaining provenance comment labels

### DIFF
--- a/core/midi/include/pulp/midi/android_midi_fifo.hpp
+++ b/core/midi/include/pulp/midi/android_midi_fifo.hpp
@@ -8,9 +8,8 @@
 // block, converting the monotonic nanosecond timestamp into a sample
 // offset within the current block.
 //
-// This is an INTERNAL Phase-1 API. External consumers should use
-// `pulp::midi::android::drain_into(MidiBuffer&, ...)` from the audio
-// thread.
+// This is an internal bridge API. External consumers should use
+// `pulp::midi::android::drain_into(MidiBuffer&, ...)` from the audio thread.
 
 #if defined(__ANDROID__)
 

--- a/core/render/platform/android/gpu_surface_android_internal.hpp
+++ b/core/render/platform/android/gpu_surface_android_internal.hpp
@@ -1,14 +1,13 @@
 // gpu_surface_android_internal.hpp — PRIVATE shared declarations for the
 // Android GPU-surface translation units.
 //
-// Created in the P8-1 refactor that split the JNI `extern "C"` bridge out
-// of gpu_surface_android.cpp into gpu_surface_android_jni.cpp. The JNI
-// layer is a thin forwarder: every export calls one of the `android_*`
-// entry points below (already external-linkage free functions in
-// gpu_surface_android.cpp) — except nativeOnTouchCancel, which clears the
-// shared touch-capture pointer directly. That one global (g_captured_view)
-// is the only file-local static promoted to external linkage for the
-// split; all paint/lifecycle state stays private to gpu_surface_android.cpp.
+// Shared by gpu_surface_android.cpp and gpu_surface_android_jni.cpp. This
+// header declares the render entry points that the JNI bridge calls after any
+// Java-boundary work it owns, such as GlobalRef management, ANativeWindow
+// conversion, drag-backend registration, and drop-path marshalling.
+// nativeOnTouchCancel clears the shared touch-capture pointer directly; that
+// pointer (g_captured_view) is the only cross-TU state exposed here. All paint
+// and lifecycle state stays private to gpu_surface_android.cpp.
 //
 // PRIVATE: lives under core/render/platform/android/, not the public
 // include tree. Not part of the installed SDK surface — do not reference

--- a/core/render/platform/android/gpu_surface_android_jni.cpp
+++ b/core/render/platform/android/gpu_surface_android_jni.cpp
@@ -1,12 +1,14 @@
 // gpu_surface_android_jni.cpp — JNI `extern "C"` bridge for the Android
 // GPU surface.
 //
-// Relocated from gpu_surface_android.cpp in the P8-1 refactor. Every
-// JNIEXPORT below is a thin forwarder onto the `android_*` entry points
-// declared in gpu_surface_android_internal.hpp (defined in
-// gpu_surface_android.cpp). The exports stay welded together in their own
-// TU because they share the Kotlin-facing `Java_com_pulp_render_*` symbol
-// surface and the same exception-bridging contract.
+// Owns the Kotlin-facing `Java_com_pulp_render_*` symbol surface for the GPU
+// host. Simple setters and touch down/move/up events forward directly to the
+// `android_*` entry points declared in gpu_surface_android_internal.hpp;
+// nativeOnTouchCancel clears capture state directly. Surface creation,
+// destruction, and file drops also manage JNI references, drag backend state,
+// and Java-array marshalling at this boundary. Lifecycle exports bridge C++
+// exceptions to Java; nativeOnDrop logs instead of throwing, and trivial
+// setters/touch forwarders rely on their callees to stay non-throwing.
 
 #if defined(__ANDROID__)
 

--- a/core/signal/include/pulp/signal/convolver.hpp
+++ b/core/signal/include/pulp/signal/convolver.hpp
@@ -66,13 +66,12 @@ public:
     bool try_swap_ir(ConvolverIrSwapper& swapper) {
         // Gate the swap on retire-ring capacity FIRST so the audio
         // thread never has to free the displaced IR inline if the
-        // ring is saturated (Codex P1 on #2881 — single-slot retired_
-        // would let the audio thread deallocate when 2+ swaps
-        // happened between drain_old() calls). Refusing the swap
-        // when the ring is full is RT-safe: pending stays in the
-        // swapper for the next try_swap_ir attempt; in-flight state_
-        // continues uninterrupted; worker thread catches up on its
-        // next drain tick.
+        // ring is saturated. A single retired slot would let the audio
+        // thread deallocate when 2+ swaps happened between drain_old()
+        // calls. Refusing the swap when the ring is full is RT-safe:
+        // pending stays in the swapper for the next try_swap_ir attempt;
+        // in-flight state_ continues uninterrupted; worker thread catches
+        // up on its next drain tick.
         if (state_ && !swapper.has_retire_capacity()) {
             return false;
         }

--- a/core/view/src/design_tokens.cpp
+++ b/core/view/src/design_tokens.cpp
@@ -1,5 +1,5 @@
-// design_tokens.cpp — design-token import/export, extracted from
-// design_import.cpp in the 2026-05 Phase 6 (A3) refactor.
+// design_tokens.cpp — design-token import/export extracted from
+// design_import.cpp.
 //
 // The design-token surface converts between Pulp's Theme and the three
 // external token formats Pulp interoperates with:

--- a/tools/build-api-docs.sh
+++ b/tools/build-api-docs.sh
@@ -4,7 +4,7 @@
 #
 # Injects the current SDK version from CMakeLists.txt (`project(Pulp VERSION x.y.z)`)
 # as Doxygen's PROJECT_NUMBER so `/api/` always shows the right version instead
-# of the stale literal baked into docs/doxygen/Doxyfile. (#577 PR 4.)
+# of the stale literal baked into docs/doxygen/Doxyfile.
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

- Cleans stale provenance labels from remaining reviewed source-comment candidates in MIDI, Android render JNI, signal convolution, design tokens, and API-doc generation.
- Preserves behavioral guidance around Android JNI boundaries, touch cancellation, surface lifecycle ownership, MIDI FIFO internal API guidance, convolver retire-ring RT safety, token parsing, and API-doc target selection.
- Defers `core/view/include/pulp/view/design_import.hpp` P7 labels pending wider reference review, because RepoPrompt classified that public header as needing broader grep/context before rewriting.

## Files

- `core/midi/include/pulp/midi/android_midi_fifo.hpp`
- `core/render/platform/android/gpu_surface_android_internal.hpp`
- `core/render/platform/android/gpu_surface_android_jni.cpp`
- `core/signal/include/pulp/signal/convolver.hpp`
- `core/view/src/design_tokens.cpp`
- `tools/build-api-docs.sh`

## Validation

- `git diff --check origin/main...HEAD`
- stale-marker scan over edited files for removed labels and overbroad review phrases
- comment-only diff verifier
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base refs/remotes/origin/main --head HEAD`
- `tools/scripts/gates.sh refs/remotes/origin/main --pr-title 'docs(source): clean remaining provenance comment labels'`
- RepoPrompt Oracle classification and diff review
- `autoreview --mode local --reviewers codex,claude` clean after addressing review findings

## Notes

- Added `Skill-Update: skip skill=android` trailer because the Android files only changed provenance comment wording; no Android workflow or agent guidance changed.
- A first push attempt started the local diff-coverage build/test path and reached test 1492/10410 after compiling; it was interrupted because skill-sync had already failed before the trailer was added. The final push used `PULP_SKIP_DIFF_COVER=1` after the targeted gates passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned stale provenance labels in source comments across MIDI, Android GPU surface JNI bridge, convolver, design tokens, and the API-doc build script. Clarifies JNI boundary ownership and RT-safety notes; no code or API behavior changed.

- **Refactors**
  - Android GPU surface: clarified JNI vs render responsibilities; noted `nativeOnTouchCancel` capture handling and exception-bridging behavior.
  - Audio pipeline: tightened RT-safety comments in `PartitionedConvolver`; marked Android MIDI FIFO as an internal bridge and pointed callers to `pulp::midi::android::drain_into`.
  - Docs and tokens: trimmed refactor-era notes in `design_tokens.cpp` and `tools/build-api-docs.sh`.
  - Deferred: `core/view/include/pulp/view/design_import.hpp` pending broader review.

<sup>Written for commit 6532e7dd07d44148ed5662d3d2dbe3c82c736121. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

