### PR TITLE
docs(view): clean bridge provenance comments

### DIFF
--- a/core/view/platform/mac/window_host_mac_capture.h
+++ b/core/view/platform/mac/window_host_mac_capture.h
@@ -1,11 +1,11 @@
 // window_host_mac_capture.h — private forward declarations for the PNG /
 // capture helpers used by window_host_mac.mm.
 //
-// The implementations live in window_host_mac_capture.mm. Only consumed by
-// window_host_mac.mm — not part of the public SDK surface.
+// The implementations live in window_host_mac_capture.mm. This header is only
+// consumed by window_host_mac.mm and is not part of the public SDK surface.
 //
-// Only free functions that don't touch PulpView ivars are extracted. The
-// PulpView @implementation block and its ivars stay in window_host_mac.mm.
+// Only free functions that don't touch PulpView ivars live here. The PulpView
+// @implementation block and its ivars stay in window_host_mac.mm.
 
 #pragma once
 

--- a/core/view/platform/mac/window_host_mac_capture.mm
+++ b/core/view/platform/mac/window_host_mac_capture.mm
@@ -1,8 +1,8 @@
 // window_host_mac_capture.mm — PNG / capture helpers for the macOS
-// window host. Extracted from window_host_mac.mm.
+// window host.
 //
-// Only free functions that don't touch PulpView ivars are extracted;
-// PulpView's @implementation and ivars stay in window_host_mac.mm.
+// Only free functions that don't touch PulpView ivars live here; PulpView's
+// @implementation and ivars stay in window_host_mac.mm.
 
 #include "window_host_mac_capture.h"
 

--- a/core/view/src/design_ir_json.cpp
+++ b/core/view/src/design_ir_json.cpp
@@ -1,11 +1,9 @@
 // design_ir_json.cpp — DesignIR JSON serialize / deserialize band.
 //
-// Relocation-only split from design_import.cpp: the JSON helpers,
-// serialize_design_ir, and parse_design_ir_json moved here unchanged. Four helpers
-// (parse_ir_node, parse_ir_tokens, make_import_diagnostic,
-// is_asset_reference_key) are promoted from static to external linkage
-// because the asset pipeline / source parsers that remain in
-// design_import.cpp call them; their declarations live in
+// JSON helpers, serialize_design_ir, and parse_design_ir_json live here. Four
+// helpers (parse_ir_node, parse_ir_tokens, make_import_diagnostic,
+// is_asset_reference_key) have external linkage because the asset pipeline /
+// source parsers in design_import.cpp call them; their declarations live in
 // design_import_internal.hpp. promote_interactive_frames stays defined in
 // design_import.cpp and is declared in that same header.
 
@@ -61,8 +59,7 @@ static const char* render_mode_id(NodeRenderMode m) {
 // Maps a wire `kind` string to an InteractiveElementKind. Unknown ids fall back
 // to `knob` for forward-compat, but set `*recognized = false` so the caller can
 // diagnose a genuinely-unknown kind instead of silently shipping a wrong knob.
-// (P7 grows this into the full resolution ladder; here we just stop being
-// silent.) `recognized` may be null.
+// `recognized` may be null.
 static InteractiveElementKind interactive_kind_from_id(const std::string& s,
                                                        bool* recognized = nullptr) {
     if (recognized) *recognized = true;
@@ -568,10 +565,8 @@ void normalize_figma_plugin_binding(IRNode& node) {
 }
 
 // ── parse_ir_node post-passes ────────────────────────────────────────────
-// These ran as inline blocks at the tail of parse_ir_node; pulled out into
-// named functions so each rule reads as one testable unit. Behavior is
-// unchanged from the inline versions (the shadow snap now reads the parsed
-// IRBoxShadow layers instead of re-parsing the raw CSS string each time).
+// Named post-parse rules. The shadow snap reads parsed IRBoxShadow layers
+// instead of re-parsing the raw CSS string each time.
 
 // Shadow-driven sibling snap. When a frame has a downward drop shadow and an
 // absolutely-positioned sibling sits just below it with a small gap, the gap
@@ -836,8 +831,7 @@ IRNode parse_ir_node(const choc::value::ValueView& obj) {
             el.kind = interactive_kind_from_id(kind_str, &kind_recognized);
             if (!kind_recognized) {
                 // Don't silently materialize an unknown control as a working
-                // knob — surface it so the import isn't quietly wrong. The full
-                // ordered ladder + import report lands in P7; this is the floor.
+                // knob — surface it so the import isn't quietly wrong.
                 pulp::runtime::log_warn(
                     "design-import: unknown interactive_element kind '{}' "
                     "(node {}); falling back to knob render",
@@ -868,11 +862,11 @@ IRNode parse_ir_node(const choc::value::ValueView& obj) {
             el.text = get_string(e, "text");
             el.value_left_align = get_bool(e, "value_left_align");
             el.default_value_y = get_float(e, "default_value_y", 0.5f);
-            // P7 import report (resolution provenance).
+            // Import report (resolution provenance).
             el.resolution_rung = static_cast<int>(get_float(e, "resolution_rung", 0.0f));
             el.confidence_score = get_float(e, "confidence_score", 1.0f);
             el.verification_pass = get_bool(e, "verification_pass", true);
-            // custom (P7 Tier-3) — registered native control.
+            // custom — registered native control.
             el.factory_id = get_string(e, "factory_id");
             el.custom_props = get_string(e, "custom_props");
             if (e.hasObjectMember("conflict_signals") && e["conflict_signals"].isArray()) {
@@ -1834,7 +1828,7 @@ static void write_ir_node_json(std::ostringstream& out, const IRNode& node,
             if (el.value_left_align) { write_key(out, ef, "value_left_align"); out << "true"; }
             if (el.kind == InteractiveElementKind::xy_pad)
                 write_float_member(out, ef, "default_value_y", el.default_value_y);
-            // P7 import report — emitted only when the ladder set them (lean otherwise).
+            // Import report fields — emitted only when set (lean otherwise).
             if (el.resolution_rung != 0)
                 write_int_member(out, ef, "resolution_rung", el.resolution_rung);
             if (el.confidence_score != 1.0f)
@@ -2182,7 +2176,7 @@ DesignIR parse_design_ir_json(const std::string& json) {
     return ir;
 }
 
-// ── P7 import report ─────────────────────────────────────────────────────────
+// ── import report ────────────────────────────────────────────────────────────
 static void collect_report_visit(const IRNode& node, ImportReport& report,
                                  float low_confidence_threshold) {
     for (const auto& e : node.interactive_elements) {
@@ -2208,7 +2202,7 @@ ImportReport collect_import_report(const IRNode& root, float low_confidence_thre
     return report;
 }
 
-// P7 render-placement verification (structural half of the render-golden gate).
+// Render-placement verification (structural half of the render-golden gate).
 static int verify_placement_visit(IRNode& node, float fw, float fh) {
     int flagged = 0;
     for (auto& e : node.interactive_elements) {

--- a/test/test_canvas2d_shim_late.cpp
+++ b/test/test_canvas2d_shim_late.cpp
@@ -295,14 +295,10 @@ TEST_CASE("Canvas2D fillText with maxWidth horizontally squeezes raster output",
     REQUIRE(rightmost <= 5 + 60 + 6);
 }
 
-// Codex P2 (PR #1555): SkiaCanvas::stroke_text built its stroke paint
-// via make_stroke_paint() but never called apply_stroke_state(), so
-// ctx.lineJoin / ctx.lineCap / ctx.miterLimit / ctx.strokeStyle pattern
-// shaders were silently dropped on strokeText only — every other stroke
-// primitive honoured them. This test renders a heavy-stroke glyph twice
-// against identical surfaces, once with the default (miter) line join
-// and once with LineJoin::round, and asserts the rasters differ. With
-// the apply_stroke_state call missing, both paths would resolve to the
+// SkiaCanvas::stroke_text must apply sticky stroke state. The test renders a
+// heavy-stroke glyph twice against identical surfaces, once with the default
+// (miter) line join and once with LineJoin::round, and asserts the rasters
+// differ. If stroke_text skips apply_stroke_state(), both paths resolve to the
 // same default-join SkPaint and produce identical pixels.
 TEST_CASE("SkiaCanvas::stroke_text honors sticky line_join state",
           "[canvas][skia][issue-1525-fix]") {
@@ -772,8 +768,8 @@ TEST_CASE("Canvas2D direction + filter cache invalidates on save/restore",
 // Ten entries — globalAlpha, lineCap, lineJoin, lineDashOffset,
 // textAlign, textBaseline, globalCompositeOperation, quadraticCurveTo,
 // bezierCurveTo, arc — have bridge-side coverage split across the
-// issue-964 cases above, but no single test exercises the 10-as-a-set
-// as the catalog claims. This test pins each one's full round-trip
+// issue-964 cases in test_canvas2d_shim.cpp, but no single test exercises the
+// 10-as-a-set as the catalog claims. This test pins each one's full round-trip
 // through the JS shim → bridge → CanvasWidget command stream so a
 // regression in any of them surfaces directly under [issue-1526].
 TEST_CASE("Canvas2D shim flushes the 10-entry catalog set to the bridge",
@@ -1388,10 +1384,8 @@ TEST_CASE("Canvas2D getTransform DOMMatrix scaleSelf + isIdentity recompute",
 
 TEST_CASE("Canvas2D getTransform DOMMatrix rotateSelf takes degrees [issue-1730]",
           "[view][canvas2d][issue-1527][issue-1730][dommatrix-mutators]") {
-    // Codex P1 on #1730: rotateSelf() input is DEGREES per the
-    // DOMMatrix spec (https://drafts.fxtf.org/geometry/#dom-dommatrix-rotateself).
-    // Previously this test passed Math.PI/2 and expected a 90deg
-    // rotation — that documented the BUG. Now we pass 90 (degrees).
+    // rotateSelf() input is DEGREES per the DOMMatrix spec:
+    // https://drafts.fxtf.org/geometry/#dom-dommatrix-rotateself
     auto result = run_in_bridge(R"(
         var c = document.createElement('canvas');
         c.id = 'probe'; document.body.appendChild(c);
@@ -1426,7 +1420,7 @@ TEST_CASE("Canvas2D DOMMatrix rotateSelf(180) flips signs [issue-1730]",
 
 TEST_CASE("Canvas2D DOMMatrix rotateSelf() omitted arg defaults to 0 [issue-1730]",
           "[view][canvas2d][issue-1730][dommatrix-mutators]") {
-    // Codex P1 on #1730: omitted angle defaults to 0 — must not be NaN.
+    // Omitted angle defaults to 0 — must not be NaN.
     auto result = run_in_bridge(R"(
         var c = document.createElement('canvas');
         c.id = 'probe'; document.body.appendChild(c);
@@ -1440,8 +1434,8 @@ TEST_CASE("Canvas2D DOMMatrix rotateSelf() omitted arg defaults to 0 [issue-1730
 
 TEST_CASE("Canvas2D DOMMatrix scaleSelf() omitted args default to identity [issue-1730]",
           "[view][canvas2d][issue-1730][dommatrix-mutators]") {
-    // Codex P2 on #1730: spec says scaleX defaults to 1 when omitted,
-    // scaleY defaults to scaleX when omitted. Was producing NaN before.
+    // Per spec, scaleX defaults to 1 when omitted and scaleY defaults to
+    // scaleX when omitted.
     auto result = run_in_bridge(R"(
         var c = document.createElement('canvas');
         c.id = 'probe'; document.body.appendChild(c);
@@ -1476,11 +1470,9 @@ TEST_CASE("Canvas2D getTransform DOMMatrix translateSelf affine compose",
 
 TEST_CASE("Canvas2D DOMMatrix singular inverse: all 16 components are NaN [issue-1730]",
           "[view][canvas2d][issue-1730][dommatrix-mutators]") {
-    // Codex P2 follow-up on #1754: spec says ALL 16 matrix components
-    // become NaN for a non-invertible inverse. Constructor only NaN'd
-    // the 2D aliases; m13/m14/m23/m24/m31..m34/m43/m44 stayed at
-    // constructor-default identity. toFloat32Array/toFloat64Array
-    // would return mixed finite/NaN, violating the contract.
+    // Per spec, ALL 16 matrix components become NaN for a non-invertible
+    // inverse. toFloat32Array/toFloat64Array must not return a mixed
+    // finite/NaN matrix.
     auto result = run_in_bridge(R"(
         var c = document.createElement('canvas');
         c.id = 'probe'; document.body.appendChild(c);
@@ -1499,9 +1491,8 @@ TEST_CASE("Canvas2D DOMMatrix singular inverse: all 16 components are NaN [issue
 
 TEST_CASE("Canvas2D DOMMatrix toJSON honors actual is2D [issue-1730]",
           "[view][canvas2d][issue-1730][dommatrix-mutators]") {
-    // Codex P2 follow-up on #1754: toJSON used to hardcode is2D=true;
-    // a singular-inverse result has is2D=false but JSON serialization
-    // would lose the inversion-failure indicator.
+    // A singular-inverse result has is2D=false; JSON serialization must keep
+    // that inversion-failure indicator.
     auto result = run_in_bridge(R"(
         var c = document.createElement('canvas');
         c.id = 'probe'; document.body.appendChild(c);
@@ -1520,11 +1511,9 @@ TEST_CASE("Canvas2D DOMMatrix toJSON honors actual is2D [issue-1730]",
 
 TEST_CASE("Canvas2D DOMMatrix inverse round-trips identity; singular yields NaN matrix [issue-1730]",
           "[view][canvas2d][issue-1527][issue-1730][dommatrix-mutators]") {
-    // Codex P1 on #1730: per spec
-    // (https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-inverse),
-    // a non-invertible matrix produces a matrix with NaN components and
-    // is2D=false. It does NOT throw. The previous test asserted "throws
-    // TypeError" — that was documenting the BUG.
+    // Per spec, a non-invertible matrix produces a matrix with NaN components
+    // and is2D=false. It does NOT throw:
+    // https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-inverse
     auto result = run_in_bridge(R"(
         var c = document.createElement('canvas');
         c.id = 'probe'; document.body.appendChild(c);

--- a/test/test_cli_shellout_pr.cpp
+++ b/test/test_cli_shellout_pr.cpp
@@ -306,7 +306,7 @@ TEST_CASE("pulp pr delegates to shipyard with forwarded arguments",
     // Report the version the pulp CLI's skew check expects (tools/shipyard.toml
     // pin), stripped of the leading 'v' since that's what `shipyard --version`
     // emits in practice. Reading dynamically keeps the test honest across pin
-    // bumps — the old hardcoded "0.46.0" broke on the v0.56.2 bump.
+    // bumps.
     std::string version = pinned_shipyard_version_for_test();
     if (!version.empty() && version[0] == 'v') version.erase(0, 1);
     {

--- a/test/test_widget_bridge_svg.cpp
+++ b/test/test_widget_bridge_svg.cpp
@@ -1,10 +1,13 @@
-// SVG widget JS-bridge integration, three coherent compat surfaces:
+// WidgetBridge integration coverage for SVG widgets, Canvas2D shims, and CSS
+// style translation:
 //
 //   1. pulp #965 — SvgPathWidget JS bridge integration.
 //   2. pulp #1416 — SvgRectWidget + SvgLineWidget JS bridge integration.
 //   3. Compound-path SVG icons (Spectr PEAK / AVG / BOTH / OFF) —
 //      regression-pins the parser's enumeration of every M and L across
 //      disjoint subpaths, separate from the main #965 cluster.
+//   4. Canvas2D and CSS style shims used by bridge-created widgets
+//      (#968, #1410, #1423, #1434, #1737).
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
@@ -555,9 +558,8 @@ TEST_CASE("WidgetBridge setWhiteSpace routes all 6 CSS keywords to WhiteSpaceMod
         bool expected_multi_line;
         bool expected_nowrap_bool;
     } cases[] = {
-        // pulp #1737 (Codex P1 followup on #1786): `pre` keeps
-        // multi_line=true so newlines render. The spec's "no-soft-
-        // wrap" semantic for `pre` is a Label-side follow-up;
+        // For pulp #1737, `pre` keeps multi_line=true so newlines render. The
+        // spec's "no-soft-wrap" semantic for `pre` is a Label-side follow-up;
         // newline preservation is the spec-critical part.
         {"normal",       M::normal,       true,  false},
         {"nowrap",       M::nowrap,       false, true },
@@ -580,11 +582,8 @@ TEST_CASE("WidgetBridge setWhiteSpace routes all 6 CSS keywords to WhiteSpaceMod
     REQUIRE(label->white_space_mode() == M::normal);
     REQUIRE(label->multi_line());
 
-    // pulp #1737 (Codex P2 followup on #1786): the legacy
-    // set_white_space_nowrap() setter MUST keep the WhiteSpaceMode
-    // enum in sync. Pre-fix, the legacy setter only touched the bool
-    // and left the enum stale (still `normal` after a `set_white_space_nowrap(true)`
-    // call), violating the stated backward-compat contract.
+    // The legacy set_white_space_nowrap() setter MUST keep the WhiteSpaceMode
+    // enum in sync with the bool for backward compatibility.
     label->set_white_space_nowrap(true);
     REQUIRE(label->white_space_mode() == M::nowrap);
     REQUIRE(label->white_space_nowrap());

--- a/tools/scripts/hotspot_size_guard.json
+++ b/tools/scripts/hotspot_size_guard.json
@@ -97,7 +97,7 @@
     },
     {
       "path": "core/view/src/design_ir_json.cpp",
-      "max_loc": 2295,
+      "max_loc": 2289,
       "note": "DesignIR serialization contract hotspot; lowered after comment-hygiene cleanup"
     },
     {


### PR DESCRIPTION
## Summary

- Cleans stale provenance/workflow wording from view/design-import JSON comments, macOS capture helper headers, Canvas2D/WidgetBridge regression comments, and `pulp pr` shell-out test guidance.
- Preserves behavior-critical rationale: DesignIR external-linkage helpers, import-report fields, render-placement verification, PulpView/capture helper ownership, DOMMatrix spec contracts, stroke-text sticky state, white-space compatibility, and Shipyard pin handling.
- Updates `tools/scripts/hotspot_size_guard.json` to lower the `design_ir_json.cpp` ceiling from `2295` to `2289` after the comment cleanup shrank the hotspot.

## Files

- `core/view/src/design_ir_json.cpp`
- `core/view/platform/mac/window_host_mac_capture.h`
- `core/view/platform/mac/window_host_mac_capture.mm`
- `test/test_canvas2d_shim_late.cpp`
- `test/test_widget_bridge_svg.cpp`
- `test/test_cli_shellout_pr.cpp`
- `tools/scripts/hotspot_size_guard.json`

## Validation

- RepoPrompt workspace `50` classification over the remaining view/test candidate set
- RepoPrompt diff/comment-state review; fixed the two accepted findings before PR
- `git diff --check origin/main...HEAD`
- stale-label scan over edited files
- comment-only verifier allowing only the required hotspot ceiling metadata update
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base refs/remotes/origin/main --head HEAD`
- `tools/scripts/gates.sh refs/remotes/origin/main --pr-title 'docs(view): clean bridge provenance comments'`
- `autoreview --mode local --reviewers codex,claude` clean on the final diff

## Notes

- Commit carries `Skill-Update: skip skill=ci` because `hotspot_size_guard.json` changed only to lower a file-size ceiling after comment cleanup; no CI workflow or agent guidance changed.
- Deferred items from RepoPrompt are intentionally untouched: Canvas2D catalog-state claims that need `compat.json`, Spectr exact line references that need source validation, and the orphan-looking shadow-file header that needs sibling TU review.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans stale provenance/process wording across view and test comments and clarifies helper ownership and DesignIR JSON rationale. No behavior changes.

- **Refactors**
  - Clarified `window_host_mac_capture` docs: only free functions not touching `PulpView` live here; `@implementation` stays in `window_host_mac.mm`.
  - Removed legacy “P7/Codex” and process notes while keeping behavior-critical rationale (DesignIR external-linkage helpers and import-report fields, render-placement verification, Canvas2D stroke state, DOMMatrix contracts, white-space handling, and Shipyard pin guidance).
  - Lowered `core/view/src/design_ir_json.cpp` hotspot ceiling in `tools/scripts/hotspot_size_guard.json` from 2295 to 2289 after comment shrink.

<sup>Written for commit ff0ac9e13e416455c28aa363dd5633fc0b01fedb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

