### PR TITLE
docs(canvas): refresh shim comment status

### DIFF
--- a/test/test_canvas2d_shim_late.cpp
+++ b/test/test_canvas2d_shim_late.cpp
@@ -79,15 +79,14 @@ struct ScriptedBridge {
 
 // ── pulp #1525 — fillText / strokeText maxWidth + glyph cluster handling ──
 //
-// Promotion target: 2 DIVERGE → PASS for canvas2d/fillText and
-// canvas2d/strokeText. Pre-#1525 the JS shim accepted `maxWidth` as a
-// 4th arg but discarded it (`void maxWidth;`) and `strokeText` re-routed
-// through `fillText` with the strokeStyle as the fill colour — visually
-// approximate but spec-incompatible (no real outlined glyphs, no
-// horizontal squeeze).
+// The catalog marks canvas2d/fillText and canvas2d/strokeText as supported.
+// Pre-#1525 the JS shim accepted `maxWidth` as a 4th arg but discarded it
+// (`void maxWidth;`) and `strokeText` re-routed through `fillText` with the
+// strokeStyle as the fill colour — visually approximate but spec-incompatible
+// (no real outlined glyphs, no horizontal squeeze).
 //
-// These tests cover the full JS → bridge → CanvasDrawCmd surface so the
-// catalog can flip from `partial` to `supported`.
+// These tests cover the full JS → bridge → CanvasDrawCmd surface that backs
+// the supported catalog entries.
 
 TEST_CASE("Canvas2D fillText threads maxWidth through to bridge",
           "[view][canvas2d][issue-1525]") {
@@ -517,10 +516,9 @@ TEST_CASE("Canvas2D roundRect shim accepts {x,y} elliptical corner",
 
 // ── pulp #1520 — Canvas2D ctx.direction / ctx.filter ────────────────────
 //
-// canvas2d/direction and canvas2d/filter were the last two NOT-IMPL
-// entries in compat.json's canvas2d catalog. This block flips them to
-// `partial` by routing the JS shim through the bridge and into Skia's
-// SkShaper / SkImageFilter chain. The tests below exercise:
+// canvas2d/direction and canvas2d/filter are supported by routing the JS shim
+// through the bridge and into Skia's SkShaper / SkImageFilter chain. The tests
+// below exercise:
 //   * round-trip getter/setter on the JS shim
 //   * defensive coercion of unknown direction strings
 //   * sticky flush of direction setter before fillText

--- a/test/test_canvas_widget_shadow.cpp
+++ b/test/test_canvas_widget_shadow.cpp
@@ -236,10 +236,3 @@ TEST_CASE("SkiaCanvas skips shadow when fully transparent or zero",
     REQUIRE(px.b == 255);
 }
 #endif  // PULP_HAS_SKIA
-
-// ── pulp #1520 — Canvas2D ctx.direction / ctx.filter dispatch ────────────
-//
-// Asserts that the CanvasWidget paint loop forwards the new
-// `set_direction` / `set_filter` commands through to the underlying
-// canvas (here, RecordingCanvas) so the JS shim's setter intent reaches
-// the active backend on every frame.

--- a/test/test_widget_bridge_svg.cpp
+++ b/test/test_widget_bridge_svg.cpp
@@ -629,8 +629,8 @@ TEST_CASE("CSSStyleDeclaration translates whiteSpace to setWhiteSpace bridge cal
 }
 
 // pulp #1423 — `width: '100%'` and `height: '100%'` propagate through the
-// CSS translator and bridge to Yoga's percent API. Spectr uses the
-// `width:'100%'` form at spectr-editor-extracted.js:2377 and :3414.
+// CSS translator and bridge to Yoga's percent API. Spectr's generated editor
+// bundle uses the `width:'100%'` form.
 TEST_CASE("CSS width/height percent strings propagate to Yoga via setFlex",
           "[view][bridge][css][issue-1423]") {
     ScriptEngine engine;


### PR DESCRIPTION
## Summary

- Refreshes Canvas2D shim comments to match the current `compat/canvas2d.json` supported status for `fillText`, `strokeText`, `direction`, and `filter`.
- Removes a dead orphan footer from `test_canvas_widget_shadow.cpp`; the actual direction/filter dispatch coverage lives in the bridge-fns test cluster.
- Replaces brittle exact Spectr generated-bundle line references with source-name-level wording.

## Files

- `test/test_canvas2d_shim_late.cpp`
- `test/test_canvas_widget_shadow.cpp`
- `test/test_widget_bridge_svg.cpp`

## Validation

- Read-only subagent audit of Canvas2D catalog comments and orphan footer
- Read-only subagent audit of Spectr generated-bundle line references
- RepoPrompt workspace `51` review with `compat/canvas2d.json` and sibling tests selected
- `git diff --check origin/main...HEAD`
- stale-phrase scan over edited files
- comment-only diff verifier
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base refs/remotes/origin/main --head HEAD`
- `tools/scripts/gates.sh refs/remotes/origin/main --pr-title 'docs(canvas): refresh shim comment status'`
- `autoreview --mode local --reviewers codex,claude` clean

## Notes

- The JSON catalog is treated as authoritative for this comment cleanup. A separate public docs drift remains: `docs/reference/compat/canvas2d.md` still describes `direction`/`filter` as partial while `compat/canvas2d.json` marks them supported.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes Canvas2D test comments to match `compat/canvas2d.json`, marking `fillText`, `strokeText`, `direction`, and `filter` as supported. Cleans up tests by removing a dead footer and replacing brittle Spectr generated-bundle line refs with source-level wording; no runtime behavior changes.

<sup>Written for commit 1bdc87cf08198bd10507a991cbe84e436220f66c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

