### PR TITLE
docs(font): refresh text test comments

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1528,29 +1528,28 @@ pulp_add_test_suite(pulp-test-image-codecs-extended LIBRARIES pulp::canvas)
 # pass-through stub.
 pulp_add_test_suite(pulp-test-bidi-text LIBRARIES pulp::canvas)
 
-# pulp #2163 / font v2 Slice 2.7 — FontScope memory-budget eviction.
+# FontScope memory-budget eviction.
 pulp_add_test_suite(pulp-test-font-scope-budget LIBRARIES pulp::canvas)
 
-# pulp #2163 / font v2 Slice 2.8 — TTF/OTF structural sanitizer.
+# TTF/OTF structural sanitizer.
 # Gated on PULP_HAS_SKIA: the non-Skia stub in font_registry_stubs.cpp
 # accepts any non-empty buffer, so the rejection cases false-negative.
-# (Codex review on PR #2177, P2.)
 if(PULP_HAS_SKIA)
     pulp_add_test_suite(pulp-test-font-security LIBRARIES pulp::canvas)
 endif()
 
-# pulp #2163 / font v2 Slice 2.3 — variable axis wiring.
+# Variable axis wiring.
 # Gated on PULP_HAS_SKIA: FontResolver::resolve_family_list returns
 # NotFound when Skia is absent, so the has_typeface() assertions
-# false-negative. (Codex review on PR #2180, P1.)
+# false-negative.
 if(PULP_HAS_SKIA)
     pulp_add_test_suite(pulp-test-font-variable-axes LIBRARIES pulp::canvas)
 endif()
 
-# pulp #2163 / font v2 Slice 3.6 — UAX #29-lite cluster_step.
+# UAX #29-lite cluster_step.
 pulp_add_test_suite(pulp-test-cluster-step LIBRARIES pulp::canvas)
 
-# pulp #2163 / font v2 Slice 2.4 — locale-aware word + line breaking.
+# Locale-aware word + line breaking.
 # The surface always links: when ICU's <unicode/brkiter.h> is on the
 # include path the assertions exercise the real UAX #14 path against
 # the SkUnicode_icu symbols bundled in libskia.a; otherwise the
@@ -1558,7 +1557,7 @@ pulp_add_test_suite(pulp-test-cluster-step LIBRARIES pulp::canvas)
 # English-only expectations still hold.
 pulp_add_test_suite(pulp-test-font-locale-shaping LIBRARIES pulp::canvas)
 
-# pulp #2163 / font v2 Slice 3.2 — AA / hinting / subpixel policy centralization.
+# AA / hinting / subpixel policy centralization.
 add_executable(pulp-test-font-aa-hinting test_font_aa_hinting.cpp)
 target_link_libraries(pulp-test-font-aa-hinting PRIVATE pulp::canvas Catch2::Catch2WithMain)
 if(PULP_HAS_SKIA)
@@ -1566,24 +1565,24 @@ if(PULP_HAS_SKIA)
 endif()
 catch_discover_tests(pulp-test-font-aa-hinting)
 
-# pulp #2163 / font v2 Slice 2.2 — FontFlightRecorder + JSON drain.
+# FontFlightRecorder + JSON drain.
 add_executable(pulp-test-font-flight-recorder test_font_flight_recorder.cpp)
 target_link_libraries(pulp-test-font-flight-recorder PRIVATE pulp::canvas Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-font-flight-recorder)
 
-# pulp #2163 / font v2 Slice 3.3 — variable-font axis-animation LRU cache.
+# Variable-font axis-animation LRU cache.
 add_executable(pulp-test-font-axis-animation test_font_axis_animation.cpp)
 target_link_libraries(pulp-test-font-axis-animation PRIVATE pulp::canvas Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-font-axis-animation)
 
-# pulp #2163 / font v2 Slice 3.7 — parallel shaping via TextRunPlanner::shape_batch.
+# Parallel shaping via TextRunPlanner::shape_batch.
 add_executable(pulp-test-text-run-planner-parallel test_text_run_planner_parallel.cpp)
 target_link_libraries(pulp-test-text-run-planner-parallel PRIVATE pulp::canvas Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-text-run-planner-parallel)
 
-# pulp #2163 / font v2 Slice 1.2.a finish — real ICU bidi + script run
-# iterators. Verifies multi-run shaping on bidi / script boundaries and
-# UAX #29 cluster grouping (ZWJ, regional-indicator-pair, virama,
+# Real ICU bidi + script run iterators. Verifies multi-run shaping on
+# bidi / script boundaries plus UAX #29 cluster grouping (ZWJ,
+# regional-indicator-pair, virama,
 # combining marks). Cluster-grouping cases run on every build; the
 # bidi / script cases auto-skip under non-Skia builds via SUCCEED.
 #
@@ -1598,19 +1597,19 @@ if(PULP_HAS_SKIA)
 endif()
 catch_discover_tests(pulp-test-text-run-planner-icu)
 
-# pulp #2163 / font v2 Slice 2.1 — async font lifecycle (register_font_url).
+# Async font lifecycle (register_font_url).
 add_executable(pulp-test-font-async-lifecycle test_font_async_lifecycle.cpp)
 target_link_libraries(pulp-test-font-async-lifecycle PRIVATE pulp::canvas Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-font-async-lifecycle)
 
-# pulp #2163 / font v2 Slice 3.5 — WOFF2 runtime decoding (security-gated).
+# WOFF2 runtime decoding (security-gated).
 # Structural rejection + decoder-availability probe; no Skia link
 # required because the negative paths are universal.
 add_executable(pulp-test-font-woff2 test_font_woff2.cpp)
 target_link_libraries(pulp-test-font-woff2 PRIVATE pulp::canvas Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-font-woff2)
 
-# pulp #2163 / font v2 Slice 3.1 — color-font predicate on ResolvedFont.
+# Color-font predicate on ResolvedFont.
 # Gated on PULP_HAS_SKIA — the predicate returns false without a real
 # typeface so the resolver-bound assertions can't fire on non-Skia.
 if(PULP_HAS_SKIA)
@@ -1624,19 +1623,19 @@ add_executable(pulp-test-font-options test_font_options.cpp)
 target_link_libraries(pulp-test-font-options PRIVATE pulp::canvas Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-font-options)
 
-# pulp #2163 — font v2 Slice 1.3 measurement-paint parity harness.
+# Measurement-paint parity harness.
 # Asserts TextShaper predictions match Skia's measured advance within
 # 0.5px for a hand-picked sample set representative of CHAIN INFO /
-# CROSSOVER bugs. Full multilingual torture corpus (test/text_corpus/
+# CROSSOVER bugs. The full multilingual corpus (test/text_corpus/
 # corpus.json) loader + per-TextAnchor bbox assertions land alongside
-# the JSON parser link in a follow-up.
+# a future JSON parser link.
 if(PULP_HAS_SKIA)
     add_executable(pulp-test-parity test_parity.cpp)
     target_link_libraries(pulp-test-parity PRIVATE pulp::canvas Catch2::Catch2WithMain skia::skia)
     catch_discover_tests(pulp-test-parity)
 endif()
 
-# Font v2 Slice 3.4 — cross-backend rendering goldens.
+# Cross-backend font rendering goldens.
 # Catches font-cascade / hinting / AA regressions in the Skia
 # raster path before they land. Uses a structural digest (width,
 # height, opaque-pixel count, darkness sum) with ±5% tolerance
@@ -1655,7 +1654,7 @@ if(PULP_HAS_SKIA)
     catch_discover_tests(pulp-test-font-rendering-goldens)
 endif()
 
-# Font v2 Slice 3.4 — Skia GPU lane (Dawn → Metal on macOS-arm64).
+# Skia GPU font rendering lane (Dawn → Metal on macOS-arm64).
 # Sibling of `pulp-test-font-rendering-goldens` (raster). Same
 # three strings, same structural digest, ±15% tolerance to absorb
 # Graphite/Metal subpixel + AA drift. Gated at compile time on
@@ -1711,7 +1710,7 @@ if(PULP_HAS_SKIA AND APPLE AND PULP_ENABLE_GPU)
     endif()
 endif()
 
-# Font v2 Slice 3.4 — Skia GPU Vulkan lane (SCAFFOLD).
+# Skia GPU Vulkan font rendering lane (scaffold).
 # Sibling of `pulp-test-font-rendering-goldens-gpu` (Metal). The Vulkan
 # lane is intentionally OFF by default: there is no Vulkan-capable
 # runner in Pulp's required gate set today, so building this target
@@ -1721,10 +1720,10 @@ endif()
 # Tolerance for the raster↔Vulkan cross-backend probe is ±20 % —
 # see the test header for the rationale.
 option(PULP_VULKAN_AVAILABLE
-    "Build the Skia GPU Vulkan rendering-goldens scaffold (font v2 \
-Slice 3.4 follow-up). Requires Skia built with skia_use_vulkan=true \
-and a working Vulkan ICD on the host. OFF on every Pulp CI lane \
-today; flip ON when a Vulkan-capable runner exists."
+    "Build the Skia GPU Vulkan rendering-goldens scaffold. Requires \
+Skia built with skia_use_vulkan=true and a working Vulkan ICD on the \
+host. OFF on every Pulp CI lane today; flip ON when a Vulkan-capable \
+runner exists."
     OFF)
 if(PULP_HAS_SKIA AND (UNIX AND NOT APPLE OR WIN32) AND PULP_VULKAN_AVAILABLE)
     add_executable(pulp-test-font-rendering-goldens-vulkan
@@ -1739,7 +1738,7 @@ if(PULP_HAS_SKIA AND (UNIX AND NOT APPLE OR WIN32) AND PULP_VULKAN_AVAILABLE)
     catch_discover_tests(pulp-test-font-rendering-goldens-vulkan)
 endif()
 
-# Font v2 Slice 3.4 — Skia GPU Direct3D 12 lane (SCAFFOLD).
+# Skia GPU Direct3D 12 font rendering lane (scaffold).
 # Sibling of `pulp-test-font-rendering-goldens-gpu` (Metal). The D3D
 # lane is intentionally OFF by default: there is no Windows D3D
 # runner in Pulp's required gate set today, so building this target
@@ -1749,10 +1748,9 @@ endif()
 # raster↔D3D cross-backend probe is ±20 % — see the test header for
 # the rationale.
 option(PULP_D3D_AVAILABLE
-    "Build the Skia GPU Direct3D 12 rendering-goldens scaffold \
-(font v2 Slice 3.4 follow-up). Requires Skia built with \
-skia_use_direct3d=true on Windows. OFF on every Pulp CI lane \
-today; flip ON when a Windows D3D runner exists."
+    "Build the Skia GPU Direct3D 12 rendering-goldens scaffold. \
+Requires Skia built with skia_use_direct3d=true on Windows. OFF on \
+every Pulp CI lane today; flip ON when a Windows D3D runner exists."
     OFF)
 if(PULP_HAS_SKIA AND WIN32 AND PULP_D3D_AVAILABLE)
     add_executable(pulp-test-font-rendering-goldens-d3d

--- a/test/test_font_async_lifecycle.cpp
+++ b/test/test_font_async_lifecycle.cpp
@@ -1,4 +1,4 @@
-// test_font_async_lifecycle.cpp — Pulp #2163, font v2 Slice 2.1.
+// test_font_async_lifecycle.cpp — async font URL lifecycle coverage.
 //
 // Verifies register_font_url(...) returns a future that resolves to
 // the expected FontState for each URL scheme:
@@ -29,10 +29,10 @@ using namespace std::chrono_literals;
 
 namespace {
 
-// Write a bundled Inter blob to a temp file we can hand to
-// register_font_url. We could call into the bundled-font table
-// directly, but a real on-disk round-trip exercises the actual
-// register_font_file path the future dispatches to.
+// Write readable-but-invalid bytes to a temp file so register_font_url
+// exercises the file-input failure path. Skia builds reach the async
+// register_font_file worker; non-Skia builds return the ready Failed
+// stub result.
 std::string write_temp_dummy_font_bytes() {
     auto tmp = std::filesystem::temp_directory_path() / "pulp_font_async_test.ttf";
     std::ofstream f(tmp, std::ios::binary);
@@ -125,12 +125,11 @@ TEST_CASE("register_font_url: unsupported schemes are treated as plain paths",
     REQUIRE(fut.get() == FontState::Failed);
 }
 
-// pulp #2308 follow-up (Codex review P2): the detached worker calls
-// register_font_file(), which can throw — for example, a vector
-// allocation backed by `tellg()` on a huge sparse file. An exception
-// escaping a detached `std::thread` calls `std::terminate` and kills
-// the host process. The contract callers were sold is "drop the
-// future and you get a Failed result, never a crash."
+// Detached workers call register_font_file(), which can throw — for
+// example, a vector allocation backed by `tellg()` on a huge sparse
+// file. An exception escaping a detached `std::thread` calls
+// `std::terminate` and kills the host process. The public contract is
+// "drop the future and you get a Failed result, never a crash."
 //
 // This test creates a sparse file with a 10 TiB logical size on
 // filesystems that support it (APFS, ext4, NTFS sparse). When
@@ -176,15 +175,9 @@ TEST_CASE("register_font_url: detached worker survives allocation throw",
     fs::remove(tmp, ec);
 }
 
-// pulp #2246 follow-up (Codex review P1): the docstring on
-// register_font_url promises "the future is safe to detach", but the
-// pre-fix implementation used `std::async(std::launch::async, ...)`
-// whose returned future's destructor BLOCKS the caller until the
-// task completes if dropped without `.get()` / `.wait()`. That made
-// the docstring a lie. Verify the post-fix behavior: scheduling a
-// long-running registration and then dropping the future must NOT
-// block the caller — the test must complete promptly even though
-// the worker thread is still running in the background.
+// register_font_url promises "the future is safe to detach". Verify
+// that scheduling a registration and then dropping the future does not
+// block the caller; the worker may still be running in the background.
 TEST_CASE("register_font_url: dropping the future does not block the caller",
           "[font][async][issue-2246]") {
     namespace fs = std::filesystem;

--- a/test/test_font_flight_recorder.cpp
+++ b/test/test_font_flight_recorder.cpp
@@ -1,4 +1,4 @@
-// test_font_flight_recorder.cpp — Pulp #2163, font v2 Slice 2.2.
+// test_font_flight_recorder.cpp — font fallback trace recorder coverage.
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -33,7 +33,7 @@ TEST_CASE("FlightRecorder: record + drain round-trip", "[font][diagnostics]") {
     REQUIRE(r.size() == 0u);
     REQUIRE(out[0].requested_family == "Inter");
     REQUIRE(out[1].requested_family == "JetBrains Mono");
-    REQUIRE(out[0].sequence < out[1].sequence);  // monotonic
+    REQUIRE(out[0].sequence < out[1].sequence);
 }
 
 TEST_CASE("FlightRecorder: capacity overflow drops oldest", "[font][diagnostics]") {
@@ -44,14 +44,15 @@ TEST_CASE("FlightRecorder: capacity overflow drops oldest", "[font][diagnostics]
     r.record_fallback({"a", "a", 0u, 0u, 0u});
     r.record_fallback({"b", "b", 0u, 0u, 0u});
     r.record_fallback({"c", "c", 0u, 0u, 0u});
-    r.record_fallback({"d", "d", 0u, 0u, 0u});  // pushes 'a' off
+    // Over capacity: the oldest record should be dropped.
+    r.record_fallback({"d", "d", 0u, 0u, 0u});
 
     auto out = r.snapshot();
     REQUIRE(out.size() == 3u);
     REQUIRE(out[0].requested_family == "b");
     REQUIRE(out[2].requested_family == "d");
 
-    r.set_capacity(1024);  // restore default
+    r.set_capacity(1024);
     r.clear();
 }
 

--- a/test/test_parity.cpp
+++ b/test/test_parity.cpp
@@ -1,4 +1,4 @@
-// test_parity.cpp — Pulp #2163 follow-up, font v2 Slice 1.3.
+// test_parity.cpp — font measurement/paint parity.
 //
 // Measurement-paint parity harness. Asserts that
 // `TextShaper::prepare(text, family, size).total_width()` matches
@@ -9,14 +9,12 @@
 // asserts the architectural invariant the v2 plan calls "the
 // killer" gap: measure equals paint, every frame, every script.
 //
-// V1 (this commit): width parity only, hand-picked sample set
+// Current coverage is width parity over a hand-picked sample set
 // representative of the CHAIN INFO / CROSSOVER / MID-SIDE-WIDTH
-// bugs that drove the v2 plan. The full multilingual torture
-// corpus (60 entries in test/text_corpus/corpus.json) loader +
-// per-TextAnchor bbox assertions arrive in the next iteration of
-// this file once we have a JSON parser linked into the test
-// target. This MVP proves the parity property is testable and
-// guards the regressions Slice 1.3 was specifically created for.
+// regressions that drove this harness. The fuller 60-entry multilingual
+// corpus lives in test/text_corpus/corpus.json; wiring that loader and
+// per-TextAnchor bbox assertions needs a JSON parser linked into this
+// test target.
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/test/test_text_accessibility.cpp
+++ b/test/test_text_accessibility.cpp
@@ -1,10 +1,9 @@
-// Cross-platform text-accessibility scaffold (font v2 Slice 2.6).
+// Cross-platform text-accessibility registry and backend contract.
 //
 // Validates the default no-op backend: a process-local registry that
-// stores TextAccessibilityNode entries keyed by id. The platform
-// overlays (NSAccessibility, UIA, AccessKit) will replace
-// accessibility_backend_name() and the register/unregister symbols in
-// a follow-up slice; this test pins down the cross-platform surface.
+// stores TextAccessibilityNode entries keyed by id. Platform overlays
+// expose backend-specific accessibility_backend_name() values while the
+// registry surface stays shared.
 
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/view/text_accessibility.hpp>
@@ -142,17 +141,13 @@ TEST_CASE("TextAccessibilityNode: backend probe is stable across calls",
     const auto second = accessibility_backend_name();
     REQUIRE(first == second);
     // Per-platform overlays replace the default "none" symbol at link
-    // time. macOS ships the NSAccessibility overlay ("macos-ax",
-    // font v2 Slice 2.6); Windows ships the UIA overlay
-    // ("windows-uia", Slice 2.6 follow-up via PR #2326); Linux ships
-    // the AccessKit stub ("linux-accesskit-stub", same PR). iOS and
-    // any not-yet-overlaid platform still ride the default ("none").
+    // time. macOS ships the NSAccessibility overlay ("macos-ax"),
+    // Windows ships the UIA overlay ("windows-uia"), and Linux ships
+    // the AccessKit stub ("linux-accesskit-stub"). iOS and any
+    // not-yet-overlaid platform still ride the default ("none").
     // The probe value therefore depends on the platform link line,
     // but it must be one of the recognized backend identifiers.
     //
-    // Address for Codex P2 on PR #2326: Linux + Windows lanes
-    // previously failed this assertion because the test still
-    // hardcoded `first == "none"`.
 #if defined(__APPLE__) && !TARGET_OS_IPHONE
     REQUIRE(first == "macos-ax");
 #elif defined(_WIN32)

--- a/tools/scripts/hotspot_size_guard.json
+++ b/tools/scripts/hotspot_size_guard.json
@@ -32,7 +32,7 @@
     },
     {
       "path": "test/CMakeLists.txt",
-      "max_loc": 6133,
+      "max_loc": 6131,
       "note": "shared test registration hotspot; lowered after comment-hygiene cleanup"
     },
     {


### PR DESCRIPTION
## Summary
- refresh stale roadmap/PR/slice wording in font and text test comments
- preserve useful behavioral notes around async font registration, sparse-file crash coverage, parity corpus breadth, and flight recorder overflow behavior
- lower the `test/CMakeLists.txt` hotspot guard ceiling because the cleanup shrank that tracked file

## Validation
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base refs/remotes/origin/main --head HEAD`
- `tools/scripts/gates.sh refs/remotes/origin/main --pr-title 'docs(font): refresh text test comments'`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPULP_BUILD_EXAMPLES=OFF`
- `cmake --build build --target pulp-test-font-async-lifecycle pulp-test-font-flight-recorder pulp-test-parity pulp-test-text-accessibility -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-font-async-lifecycle`
- `./build/test/pulp-test-font-flight-recorder`
- `./build/test/pulp-test-text-accessibility`
- `./build/test/pulp-test-parity`

Note: broad `ctest -R` also matched `_NOT_BUILT` sentinel entries, so the built test executables above were run directly.

## Reviews
- RepoPrompt review of test-file changes: clean after restoring useful notes
- RepoPrompt CMake-only review: clean
- Subagent adversarial review found an async-font wording overclaim; fixed before PR
- `autoreview --mode local --reviewers codex,claude`: clean after hotspot guard update


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up and modernized comments in font/text tests and `test/CMakeLists.txt`, removing stale roadmap references and clarifying intent. Kept key behavior notes (async font URL lifecycle, sparse-file crash case, parity corpus scope, flight recorder overflow) and lowered the `test/CMakeLists.txt` hotspot LOC guard in `tools/scripts/hotspot_size_guard.json` to reflect the shrink.

<sup>Written for commit 373d99bb723c764beb321b07a0c6da93f832c79f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

