### PR TITLE
docs(font): refresh rendering test comments

### DIFF
--- a/test/test_cluster_step.cpp
+++ b/test/test_cluster_step.cpp
@@ -1,4 +1,4 @@
-// test_cluster_step.cpp — Pulp #2163, font v2 Slice 3.6.
+// test_cluster_step.cpp — UTF-8 grapheme cluster stepping.
 //
 // UAX #29-lite cluster_step behavior: emoji ZWJ family steps as one,
 // regional-indicator flag pairs step as one, Devanagari virama

--- a/test/test_font_aa_hinting.cpp
+++ b/test/test_font_aa_hinting.cpp
@@ -1,4 +1,4 @@
-// test_font_aa_hinting.cpp — Pulp #2163, font v2 Slice 3.2.
+// test_font_aa_hinting.cpp — anti-aliasing and hinting mode propagation.
 //
 // Verifies that FontOptions.aa_mode / .hinting_mode are propagated by
 // FontResolver onto the returned ResolvedFont, and that the helper
@@ -24,11 +24,9 @@ using namespace pulp::canvas;
 
 #ifdef PULP_HAS_SKIA
 
-// pulp #2163 — review-sweep update: `Default` / `PlatformDefault`
-// no longer hard-map to a specific Skia enum (Codex P2 review on
-// PR #2186). They resolve to `std::nullopt`, signalling "caller
-// preserves the existing per-context heuristic". Explicit modes
-// still resolve to the fixed enum.
+// Regression note from PR #2186: `Default` / `PlatformDefault` resolve
+// to `std::nullopt`, signalling "caller preserves the existing
+// per-context heuristic". Explicit modes still resolve to the fixed enum.
 
 TEST_CASE("AA mode: Default returns nullopt (caller decides)", "[font][aa][issue-2163]") {
     REQUIRE(sk_edging_for(AntiAliasMode::Default) == std::nullopt);

--- a/test/test_font_axis_animation.cpp
+++ b/test/test_font_axis_animation.cpp
@@ -1,4 +1,4 @@
-// test_font_axis_animation.cpp — Pulp #2163, font v2 Slice 3.3.
+// test_font_axis_animation.cpp — variable-font animation cache eviction.
 //
 // Variable-font animation cache eviction. 60fps `wght` interpolation
 // produces 60 distinct FontOptions hashes per second per family.

--- a/test/test_font_color_mode.cpp
+++ b/test/test_font_color_mode.cpp
@@ -1,4 +1,4 @@
-// test_font_color_mode.cpp — Pulp #2163, font v2 Slice 3.1.
+// test_font_color_mode.cpp — color-font mode resolution.
 //
 // ResolvedFont::supports_color_font / color_font_active behavior.
 // Tests the predicates against the bundled non-color Inter face,
@@ -99,8 +99,8 @@ TEST_CASE("ColorFont: no typeface => supports_color_font is false",
     REQUIRE_FALSE(r.color_font_active());
 }
 
-// pulp #2243 follow-up (Codex review P2): the explicit ColorFontMode
-// values (Bitmap / COLR / SVG) request a SPECIFIC color format. The
+// Regression for pulp #2243: the explicit ColorFontMode values
+// (Bitmap / COLR / SVG) request a SPECIFIC color format. The
 // pre-fix `color_font_active()` returned true for any of those modes
 // whenever `supports_color_font()` returned true — i.e. it treated
 // every explicit mode like Auto, silently accepting "I have CBDT" as

--- a/test/test_font_locale_shaping.cpp
+++ b/test/test_font_locale_shaping.cpp
@@ -1,4 +1,4 @@
-// test_font_locale_shaping.cpp — Pulp #2163, font v2 Slice 2.4.
+// test_font_locale_shaping.cpp — locale-aware text segmentation.
 //
 // Locale-aware word + line break surface. When ICU's public headers
 // are on the include path (`__has_include(<unicode/brkiter.h>)`), the
@@ -109,8 +109,8 @@ TEST_CASE("word_break_step: backward from end yields offset < end", "[font][loca
     REQUIRE(out < s.size());
 }
 
-// pulp #2249 follow-up (Codex review P2): byte offsets that land
-// strictly inside a multi-byte UTF-8 scalar must be mapped to the
+// Regression for pulp #2249: byte offsets that land strictly inside
+// a multi-byte UTF-8 scalar must be mapped to the
 // FLOOR UTF-16 index (the scalar that contains the offset), not the
 // next scalar's start. With the pre-fix `lower_bound` mapping a
 // mid-codepoint cursor jumped *past* the codepoint, and the off-by-
@@ -143,9 +143,9 @@ TEST_CASE("word_break_step: mid-codepoint cursor rounds down to cluster boundary
     }
 }
 
-// pulp #2249 follow-up (Codex review P2): malformed UTF-8 lead bytes
-// whose continuation bytes don't match `0b10xxxxxx` must be advanced
-// by exactly 1 byte (matching ICU's U+FFFD substitution length). A
+// Regression for pulp #2249: malformed UTF-8 lead bytes whose
+// continuation bytes don't match `0b10xxxxxx` must be advanced by
+// exactly 1 byte (matching ICU's U+FFFD substitution length). A
 // pre-fix `utf8_scalar_len` that accepted `0xC2 0x41` as a 2-byte
 // scalar desynced the bridge: build_bridge advanced 2, ICU advanced
 // 1, and subsequent byte→UTF-16 lookups returned wrong offsets.

--- a/test/test_font_rendering_goldens.cpp
+++ b/test/test_font_rendering_goldens.cpp
@@ -1,4 +1,4 @@
-// test_font_rendering_goldens.cpp — Font v2 Slice 3.4
+// test_font_rendering_goldens.cpp — cross-backend font rendering goldens.
 // (Cross-backend rendering goldens).
 //
 // Captures a small, fast, deterministic golden hash of three
@@ -42,8 +42,8 @@
 //     the same process must produce *bit-identical* pixels.
 //     If that ever fails, it's a render-pipeline non-determinism
 //     bug (e.g. uninitialised glyph-cache state, racy lazy init)
-//     and not a golden-file issue. Per the Slice 3.4 brief:
-//     STOP and escalate to codex-consult.
+//     and not a golden-file issue. Stop and escalate to codex-consult
+//     rather than relaxing the golden.
 //
 //  5. On mismatch we dump the actual bitmap to a stable path
 //     so a developer can eyeball the diff. We bypass
@@ -286,8 +286,8 @@ TEST_CASE("font v2 Slice 3.4 — golden Inter 14px CJK 日本語 on raster",
     // case so this test stays a useful guard on the platforms
     // that DO have a CJK fallback.
     //
-    // pulp #2261 follow-up (Codex review P1): use a DETERMINISTIC
-    // probe instead of the post-render `opaque_pixels < 20`
+    // Regression for pulp #2261: use a DETERMINISTIC probe instead
+    // of the post-render `opaque_pixels < 20`
     // threshold. The threshold approach is unsound because Skia's
     // `fill_text` paints the `.notdef` glyph (tofu boxes) when no
     // CJK face is found — those tofu pixels easily exceed 20,

--- a/test/test_font_rendering_goldens_d3d.cpp
+++ b/test/test_font_rendering_goldens_d3d.cpp
@@ -1,4 +1,4 @@
-// test_font_rendering_goldens_d3d.cpp — Font v2 Slice 3.4
+// test_font_rendering_goldens_d3d.cpp — D3D12 font rendering golden scaffold.
 // (Cross-backend rendering goldens — Skia GPU Direct3D 12 lane, SCAFFOLD).
 //
 // Sibling of `test_font_rendering_goldens.cpp` (Skia raster),
@@ -16,7 +16,7 @@
 //   * The Skia GPU backend on D3D12 (Graphite-D3D / GrD3DBackend,
 //     depending on Skia point release) produces text rasters in the
 //     same neighbourhood as the raster, Metal, and Vulkan lanes for
-//     the three Slice 3.4 reference strings (`"Hello"` / Inter / 14 px,
+//     the three golden reference strings (`"Hello"` / Inter / 14 px,
 //     `"日本語"` / Inter / 14 px CJK fallback, `"Hello world"` /
 //     JetBrains Mono / 12 px).
 //   * The D3D12 pipeline is deterministic in-process — same surface,
@@ -57,8 +57,8 @@
 //     runner. There is no Windows runner in the required gate set.
 //   * The GitHub-hosted Windows runner is advisory, not required, and
 //     does not currently have Skia-with-D3D linked.
-//   * Adding a Windows D3D runner is tracked separately (Slice 3.4
-//     follow-up work). Until that lane exists, building this TU
+//   * Adding a Windows D3D runner is tracked as future D3D golden-lane
+//     work. Until that lane exists, building this TU
 //     against D3D symbols would only burn CI roundtrips on
 //     "couldn't find <d3d12.h>" failures.
 //

--- a/test/test_font_rendering_goldens_gpu.cpp
+++ b/test/test_font_rendering_goldens_gpu.cpp
@@ -1,4 +1,4 @@
-// test_font_rendering_goldens_gpu.cpp — Font v2 Slice 3.4
+// test_font_rendering_goldens_gpu.cpp — Skia GPU font rendering goldens.
 // (Cross-backend rendering goldens — Skia GPU lane).
 //
 // Sibling of `test_font_rendering_goldens.cpp`. That file pins the
@@ -537,7 +537,7 @@ TEST_CASE("font v2 Slice 3.4 — GPU rendering goldens require Skia on macOS",
     //  1. Skia not linked (Namespace macOS overflow runner, Linux/Win CI).
     //  2. Skia linked but not on Apple — Dawn-on-Metal is the only
     //     headless GPU lane wired up today; Vulkan + D3D paths are
-    //     deferred (Slice 3.4 follow-up).
+    //     deferred until those lanes exist.
     SUCCEED("Skia GPU goldens are gated on PULP_HAS_SKIA && APPLE.");
 }
 

--- a/test/test_font_rendering_goldens_vulkan.cpp
+++ b/test/test_font_rendering_goldens_vulkan.cpp
@@ -1,4 +1,4 @@
-// test_font_rendering_goldens_vulkan.cpp — Font v2 Slice 3.4
+// test_font_rendering_goldens_vulkan.cpp — Vulkan font rendering golden scaffold.
 // (Cross-backend rendering goldens — Skia GPU Vulkan lane, SCAFFOLD).
 //
 // Sibling of `test_font_rendering_goldens.cpp` (Skia raster) and
@@ -15,7 +15,7 @@
 //   * The Skia GPU backend on Vulkan (Graphite-Vk / GrVkBackend
 //     depending on Skia point release) produces text rasters in the
 //     same neighbourhood as the raster and Metal lanes for the three
-//     Slice 3.4 reference strings (`"Hello"` / Inter / 14 px,
+//     golden reference strings (`"Hello"` / Inter / 14 px,
 //     `"日本語"` / Inter / 14 px CJK fallback, `"Hello world"` /
 //     JetBrains Mono / 12 px).
 //   * The Vulkan pipeline is deterministic in-process — same surface,
@@ -61,8 +61,8 @@
 //     gate set.
 //   * The GitHub-hosted Linux runner is advisory, not required, and
 //     does not currently have Skia-with-Vulkan linked.
-//   * Adding a Vulkan runner is tracked separately (Slice 3.4
-//     follow-up work). Until that lane exists, building this TU
+//   * Adding a Vulkan runner is tracked as future Vulkan golden-lane
+//     work. Until that lane exists, building this TU
 //     against Vulkan symbols would only burn CI roundtrips on
 //     "couldn't find <vulkan/vulkan.h>" failures.
 //

--- a/test/test_font_scope_budget.cpp
+++ b/test/test_font_scope_budget.cpp
@@ -1,4 +1,4 @@
-// test_font_scope_budget.cpp — Pulp #2163, font v2 Slice 2.7.
+// test_font_scope_budget.cpp — FontScope cache budget enforcement.
 //
 // Verifies that FontScope::set_memory_budget triggers a
 // prune-to-budget operation that evicts the resolver cache so

--- a/test/test_font_security.cpp
+++ b/test/test_font_security.cpp
@@ -1,4 +1,4 @@
-// test_font_security.cpp — Pulp #2163, font v2 Slice 2.8.
+// test_font_security.cpp — font-byte validation and rejection paths.
 //
 // Verifies validate_font_bytes rejects structurally malformed TTF/OTF
 // inputs without crashing, and accepts a known-good bundled font.

--- a/test/test_font_variable_axes.cpp
+++ b/test/test_font_variable_axes.cpp
@@ -1,4 +1,4 @@
-// test_font_variable_axes.cpp — Pulp #2163, font v2 Slice 2.3.
+// test_font_variable_axes.cpp — variable-font axis resolution.
 //
 // Verifies that FontOptions.variation_axes flows through the
 // FontResolver into SkTypeface::makeClone(SkFontArguments). Bundled

--- a/test/test_font_woff2.cpp
+++ b/test/test_font_woff2.cpp
@@ -1,4 +1,4 @@
-// test_font_woff2.cpp — Pulp #2163, font v2 Slice 3.5.
+// test_font_woff2.cpp — WOFF2 structural rejection and decoder probing.
 //
 // Exercises the structural-rejection contract of
 // `pulp::canvas::register_font_woff2(...)` and the
@@ -9,7 +9,7 @@
 //
 // Building a real .woff2 fixture would require an actual encoder,
 // which Pulp does not ship. We test the structural surface only —
-// that's the point of Slice 3.5: even when full decompression is
+// that's the point of this contract: even when full decompression is
 // unavailable, callers can still reliably distinguish "this isn't a
 // WOFF2 file" from "this is a WOFF2 file but the build can't process
 // it" through `woff2_decoder_available()`.

--- a/test/test_text_accessibility_linux.cpp
+++ b/test/test_text_accessibility_linux.cpp
@@ -1,4 +1,4 @@
-// Linux AccessKit TextAccessibilityNode backend tests (font v2 Slice 2.6).
+// Linux AccessKit TextAccessibilityNode backend tests.
 //
 // Compile-gated on Linux (excluding Android, which uses a different
 // platform-a11y path via TalkBack). The Pulp CI matrix currently runs
@@ -38,8 +38,8 @@ TEST_CASE("TextAccessibilityNode linux backend: skipped (non-Linux host)",
 // platform/linux/text_accessibility_linux.cpp. Returns the integer value
 // of the accesskit::Role enumerator that the eventual real backend will
 // pass to AccessKit's C API. Keeping the mapping pinned in a test
-// means the follow-up PR that flips the stub to a live backend cannot
-// silently drift the role contract.
+// means a future live-backend replacement cannot silently drift the
+// role contract.
 extern "C" int pulp_text_accessibility_role_linux(int pulp_role);
 
 TEST_CASE("TextAccessibilityNode linux backend reports 'linux-accesskit-stub'",

--- a/test/test_text_accessibility_macos.mm
+++ b/test/test_text_accessibility_macos.mm
@@ -1,4 +1,4 @@
-// macOS NSAccessibility backend for TextAccessibilityNode (font v2 Slice 2.6).
+// macOS NSAccessibility backend for TextAccessibilityNode.
 //
 // Verifies the platform overlay defined in
 // core/view/platform/mac/text_accessibility_macos.mm. The cross-platform
@@ -225,9 +225,8 @@ TEST_CASE("macOS text-a11y: PulpPluginView::accessibilityChildren surfaces "
 
         // The merged children array must contain a node whose label
         // matches the registered text. Pre-fix, the AX tree ignored the
-        // text registry entirely and Codex's P1 review (#2307) flagged
-        // that VoiceOver could never reach painted text registered
-        // through the scaffold.
+        // text registry entirely (#2307), so VoiceOver could never
+        // reach painted text registered through the scaffold.
         BOOL found = NO;
         for (id child in children) {
             if ([child respondsToSelector:@selector(accessibilityLabel)]) {

--- a/test/test_text_accessibility_windows.cpp
+++ b/test/test_text_accessibility_windows.cpp
@@ -1,4 +1,4 @@
-// Windows UIA TextAccessibilityNode backend tests (font v2 Slice 2.6).
+// Windows UIA TextAccessibilityNode backend tests.
 //
 // Compile-gated on _WIN32. The Pulp CI matrix doesn't currently exercise
 // the Windows lane on every PR (macOS is the only required gate), so

--- a/test/test_text_run_planner_icu.cpp
+++ b/test/test_text_run_planner_icu.cpp
@@ -1,4 +1,4 @@
-// test_text_run_planner_icu.cpp — Pulp #2163, font v2 Slice 1.2.a finish.
+// test_text_run_planner_icu.cpp — ICU-backed text-run planning.
 //
 // Real ICU bidi + script run iterators. Verifies that
 // `TextRunPlanner::shape` emits multiple `ShapedRun`s on bidi /
@@ -122,7 +122,7 @@ TEST_CASE("planner — script split for Hello 日本語 world",
 #endif
 }
 
-// ── Single-run bidi: pure-RTL Hebrew keeps RTL level (Codex review on #2311) ─
+// ── Regression for #2311: pure-RTL Hebrew keeps RTL level ───────────────
 //
 // `"שלום"` is one bidi run AND one script run. SkShaper iterators report
 // `atEnd()` true after the first consume(), but `currentLevel()` still
@@ -149,7 +149,7 @@ TEST_CASE("planner — single-run RTL preserves bidi level after atEnd",
 #endif
 }
 
-// ── Single-run script: pure CJK keeps Hani tag after atEnd (Codex review on #2311) ─
+// ── Regression for #2311: pure CJK keeps Hani tag after atEnd ───────────
 //
 // `"日本語"` is one script run. After consume() the script iterator's
 // `atEnd()` returns true, but `currentScript()` still reports 'Hani'
@@ -181,7 +181,7 @@ TEST_CASE("planner — single-run CJK preserves script tag after atEnd",
 //
 // `"क्ष"` decomposes as ka (U+0915) + virama (U+094D) + ssa (U+0937).
 // UAX #29 says: virama joins the following consonant into one extended
-// grapheme cluster. cluster_step (Slice 3.6) already implements this;
+// grapheme cluster. cluster_step already implements this;
 // the planner must surface it in `ShapedText::clusters`.
 TEST_CASE("planner — Devanagari virama: क्ष is one cluster",
           "[font][planner][cluster][issue-2163]") {
@@ -256,7 +256,7 @@ TEST_CASE("planner — combining mark é is one cluster",
 // Every UTF-16 surface (JS, IME, macOS / Windows a11y) needs UTF-16
 // code-unit offsets. Every cluster surface (TextEditor caret motion,
 // IME composition, selection) needs `byte_to_cluster`. Both are
-// populated by Slice 1.2.a finish.
+// populated by the ICU shaping path.
 TEST_CASE("planner — UnicodeIndexMap utf16_offsets + byte_to_cluster",
           "[font][planner][index-map][issue-2163]") {
     SECTION("BMP-only Latin: utf16_offsets parallel scalar_offsets") {


### PR DESCRIPTION
## Summary
- refresh stale `font v2 Slice` and review-provenance comments across the remaining font/text rendering tests
- preserve behavior-bearing issue anchors for #2243, #2249, #2261, #2307, and PR #2186 where they explain current regression contracts
- leave test names/tags untouched to avoid metadata churn

## Validation
- RepoPrompt classification pass over the selected font/text test files
- RepoPrompt diff review found three preservation issues; all were fixed before commit
- mechanical verifier: changed lines are comment-only
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base refs/remotes/origin/main --head HEAD`
- `tools/scripts/gates.sh refs/remotes/origin/main --pr-title 'docs(font): refresh rendering test comments'`
- `~/.agents/skills/autoreview/scripts/autoreview --mode local --reviewers codex,claude`
- `~/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --reviewers codex,claude`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh and clarify comments across font and text rendering tests to better describe intent and current regression contracts. Removed stale “font v2 Slice” wording and preserved anchors for #2243, #2249, #2261, #2307 and PR #2186; tests and behavior are unchanged.

- **Refactors**
  - Updated file headers and comments for clarity (e.g., cluster stepping, color-font modes, ICU planner).
  - Converted review notes into concise regression callouts, including #2311 where relevant.
  - Left test names and tags unchanged to avoid metadata churn.

<sup>Written for commit a97e7dc4a2aa49951fe65c35c331ff3958956b35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

