### PR TITLE
docs(audio): refresh observability comments

### DIFF
--- a/core/audio/include/pulp/audio/audio_probe_json.hpp
+++ b/core/audio/include/pulp/audio/audio_probe_json.hpp
@@ -34,7 +34,8 @@ std::string_view audio_probe_stage_name(AudioProbeStage stage);
 /// offline Audio Doctor artifacts). The object always carries:
 ///   stage, sample_rate, block_size, channel_count, sequence_number,
 ///   peak_max, rms_max, peak_dbfs, rms_dbfs, clip_count, nan_inf_count,
-///   clipped_blocks, nan_blocks, silence_run_blocks, callbacks.
+///   clipped_blocks, nan_blocks, silence_run_blocks, callbacks, underruns,
+///   device_xruns, cpu_overloads.
 /// `peak_dbfs` / `rms_dbfs` are `null` when the corresponding linear value is 0.
 std::string audio_probe_snapshot_to_json(const AudioProbeSnapshot& snapshot,
                                          const AudioStats& stats,

--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -185,10 +185,11 @@ bool StandaloneApp::start() {
 #if PULP_ENABLE_AUDIO_PROBES
     // Prepare the realtime output-boundary probe BEFORE the audio callback
     // starts. This is the only place it allocates. Probe-enabled standalone
-    // builds keep a small last-N channel-0 ring so the developer Audio
-    // Inspector can paint a live waveform whether it was opened from
-    // PULP_AUDIO_INSPECTOR at launch or toggled later by command. The ring is
-    // sized to the panel's display capacity so one UI tick fills the trace.
+    // builds keep a small last-N multichannel ring so the developer Audio
+    // Inspector can paint a live waveform (channel 0 drives the Signal trace)
+    // whether it was opened from PULP_AUDIO_INSPECTOR at launch or toggled
+    // later by command. The ring is sized to the panel's display capacity so
+    // one UI tick fills the trace.
     audio::AudioProbe::CaptureConfig probe_capture;
     constexpr int kMaxScopeWindowSamples = 16384;
     const int scope_capture_frames = config_.audio_scope_json_path.empty()

--- a/core/view/include/pulp/view/audio_inspector_panel.hpp
+++ b/core/view/include/pulp/view/audio_inspector_panel.hpp
@@ -6,8 +6,8 @@
 /// balance, and a device/runtime summary.
 ///
 /// This panel owns its OWN state model. It consumes the shared probe schema
-/// (`pulp::audio::AudioProbeSnapshot` + `AudioStats`) and `MultiChannelMeter`
-/// L/R match, and is deliberately NOT coupled to the layout inspector's
+/// (`pulp::audio::AudioProbeSnapshot` + `AudioStats`) and is deliberately NOT
+/// coupled to the layout inspector's
 /// view-tree / property internals. The window shell
 /// (`AudioInspectorWindow`) polls a probe once per UI tick and pushes the
 /// copied snapshot in via `update()`; the panel never touches the realtime

--- a/test/support/audio_doctor.cpp
+++ b/test/support/audio_doctor.cpp
@@ -1,6 +1,6 @@
-// audio_doctor.cpp — scenario-driven Audio Doctor wiring (harness Phase 7,
-// slice 1). Synthesizes the stimulus, drives the processor through
-// RenderScenario, then delegates all spectral math to the buffer-level
+// audio_doctor.cpp — scenario-driven Audio Doctor wiring. Synthesizes the
+// stimulus, drives the processor through RenderScenario, then delegates all
+// spectral math to the buffer-level
 // analyzers in pulp-audio-analysis (audio_spectrum.cpp). The per-analyzer
 // determinism contracts live in audio_spectrum.hpp.
 

--- a/test/support/audio_doctor.hpp
+++ b/test/support/audio_doctor.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
 /// @file audio_doctor.hpp
-/// Scenario-driven offline "Audio Doctor" analyzers (harness Phase 7, slice 1).
+/// Scenario-driven offline "Audio Doctor" analyzers.
 ///
 /// The Doctor is the top harness layer: it sits ABOVE scenarios and drives a
 /// processor through `RenderScenario`, then runs the buffer-level spectrum
 /// analyzers in `pulp-audio-analysis` (audio_spectrum.hpp) over the rendered
 /// output to answer the "is this DSP behaving correctly?" questions an
 /// interactive analyzer answers visually — magnitude/frequency response and
-/// harmonic distortion in this slice.
+/// harmonic distortion.
 ///
 /// This header owns only the scenario wiring (stimulus synthesis + render);
 /// the windowing/FFT/THD/response math lives in `audio_spectrum.hpp` so the

--- a/test/test_audio_doctor.cpp
+++ b/test/test_audio_doctor.cpp
@@ -1,5 +1,5 @@
-// test_audio_doctor.cpp — offline Audio Doctor analyzers (harness Phase 7,
-// slice 1): magnitude/frequency response and THD/THD+N.
+// test_audio_doctor.cpp — offline Audio Doctor analyzers:
+// magnitude/frequency response and THD/THD+N.
 //
 // ── Analyzer Determinism Contract (uniform across this file) ───────────────
 // All renders are deterministic: sine/impulse stimulus (no seed, no clock),

--- a/test/test_audio_inspector_window.cpp
+++ b/test/test_audio_inspector_window.cpp
@@ -1,9 +1,8 @@
 // test_audio_inspector_window.cpp — headless coverage for the developer
-// Audio Inspector tool window (Phase 6 of the audio observability harness,
-// planning/2026-06-09-audio-inspector-separate-tool-window-proposal.md).
+// Audio Inspector tool window.
 //
 // The window is a SIBLING of the layout InspectorWindow, not a tab in it. It
-// owns its own state model and consumes the Phase 5 RT probe schema. These
+// owns its own state model and consumes the RT probe schema. These
 // tests drive a REAL AudioProbe as the synthetic source (the production data
 // path — analyze_output() publishes snapshots, the window reads latest()), and
 // assert on state, not pixels:

--- a/test/test_audio_probe.cpp
+++ b/test/test_audio_probe.cpp
@@ -1,4 +1,4 @@
-// test_audio_probe.cpp — Phase 5 RT-probe acceptance.
+// test_audio_probe.cpp — RT-probe acceptance.
 //
 // GATE 2: an allocation-counting test (RtAllocationProbe) asserting ZERO
 // allocations across N analyze_output() calls after prepare(). Plus correctness

--- a/test/test_standalone_audio_inspector.cpp
+++ b/test/test_standalone_audio_inspector.cpp
@@ -1,6 +1,5 @@
 // test_standalone_audio_inspector.cpp — the standalone-host wiring proof for
-// the developer Audio Inspector (audio observability harness Phase 6,
-// planning/2026-06-09-audio-inspector-separate-tool-window-proposal.md).
+// the developer Audio Inspector.
 //
 // The window tests in test_audio_inspector_window.cpp prove the window in
 // isolation. This file proves the SEAM the standalone host owns: the exact


### PR DESCRIPTION
## Summary

Batch audio-observability comment hygiene in one PR:

- remove stale harness phase/slice/planning provenance from Audio Doctor, Audio Inspector, standalone Audio Inspector, and AudioProbe test headers
- preserve behavior-bearing contracts: RT safety gate, Audio Doctor determinism/layering, Audio Inspector probe schema, standalone-host seam proof, test names/tags, and issue anchors
- fix nearby stale comment drift found during review: AudioProbe JSON documented fields now list all always-emitted counters, the Audio Inspector panel header no longer cites `MultiChannelMeter` as the L/R source, and standalone probe capture wording reflects the multichannel ring

## Review

- RepoPrompt pre-edit classification: safe/protect/defer over the audio observability cluster
- RepoPrompt post-edit review: no over-deletion; caught the JSON field-list doc drift
- RepoPrompt final review: confirmed JSON doc/serializer/golden alignment; flagged the panel and standalone capture wording, both fixed before commit
- `autoreview --mode local --reviewers codex,claude`: clean
- `autoreview --mode branch --base origin/main --reviewers codex,claude`: clean

## Validation

- comment-only diff verifier: passed
- `git diff --check origin/main...HEAD`: passed
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base refs/remotes/origin/main --head HEAD`: passed
- `tools/scripts/gates.sh refs/remotes/origin/main --pr-title "docs(audio): refresh observability comments"`: passed
- no focused build/test run; this is comment-only


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshed audio observability comments across Audio Doctor, Audio Inspector (panel + standalone), AudioProbe, and tests to remove stale harness/phase references and correct wording with no behavior changes. AudioProbe JSON docs now list underruns, device_xruns, and cpu_overloads; clarified that standalone scope uses a multichannel ring and removed the `MultiChannelMeter` L/R reference from the panel header.

<sup>Written for commit a8e0892203e111125626db3c264705bd0f7e4870. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

