### PR TITLE
chore(harness): trim stale provenance labels

### DIFF
--- a/tools/harness/adapters/canvas2d.py
+++ b/tools/harness/adapters/canvas2d.py
@@ -59,7 +59,7 @@ NOT_IMPL_MARKERS = (
 # explanations of supported features (e.g. "no bridge round-trip" describing
 # a JS-only synchronous read like getTransform). When mapsTo contains both a
 # NOT_IMPL marker and one of these benign-context phrases, the marker hit is
-# treated as a false positive. See pulp #1615.
+# treated as a false positive.
 NOT_IMPL_MARKER_BENIGN_CONTEXT = (
     "no bridge round-trip",
     "no bridge round trip",
@@ -113,11 +113,11 @@ class Canvas2dAdapter(AdapterBase):
                 "core/view/src/widget_bridge/canvas2d_api.cpp",
             )
         )
-        # P5-6 + P5-6 follow-up extracted prelude content out of the original
-        # web-compat-canvas.js into sibling files (matrix helper, image API,
-        # native-GPU helpers). The shim text the adapter reasons about is the
-        # union of all three so prototype methods + ctx attributes that moved
-        # don't get mis-classified as NOT-IMPL.
+        # Prelude content lives in sibling files alongside the original
+        # web-compat-canvas.js (matrix helper, image API, native-GPU helpers).
+        # The shim text the adapter reasons about is the union of the parent
+        # file and its three siblings, so prototype methods + ctx attributes
+        # that moved don't get mis-classified as NOT-IMPL.
         self._shim_text = "\n".join(
             self._read(f"core/view/js/{name}")
             for name in (
@@ -216,10 +216,10 @@ class Canvas2dAdapter(AdapterBase):
         if not maps_to:
             return True
         m = maps_to.lower()
-        # Skip any NOT_IMPL marker hit when the mapsTo also contains one
-        # of the benign-context phrases (pulp #1615 — `getTransform` mentions
-        # "no bridge round-trip" to explain a synchronous JS-only read; that
-        # must not be misread as "no bridge").
+        # Skip any NOT_IMPL marker hit when the mapsTo also contains one of
+        # the benign-context phrases: `getTransform` mentions "no bridge
+        # round-trip" to explain a synchronous JS-only read; that must not be
+        # misread as "no bridge".
         if any(benign in m for benign in NOT_IMPL_MARKER_BENIGN_CONTEXT):
             return False
         return any(marker in m for marker in NOT_IMPL_MARKERS)

--- a/tools/harness/adapters/css.py
+++ b/tools/harness/adapters/css.py
@@ -1,4 +1,4 @@
-"""CSS surface adapter — week 1 deliverable (pulp #1392, second of 5 surfaces).
+"""CSS surface adapter.
 
 Mirrors the three-layer classifier introduced by the yoga adapter:
 
@@ -98,12 +98,12 @@ class CssAdapter(AdapterBase):
         super().__init__(repo_root)
         self._oracle = self._load_oracle()
         # The wired set is parsed from the CSS shim's `_applyProperty`
-        # surface. P5-5 split the former monolithic switch into per-domain
-        # handler modules (web-compat-style-decl-{layout,paint,typography,
-        # transform,misc}.js) with a thin dispatcher in the parent file,
-        # so the `case "X":` arms are now spread across all six files.
-        # Concatenate them before scanning so every wired property is
-        # still seen — adapter init is the only time we read the files.
+        # surface. The switch is split into per-domain handler modules
+        # (web-compat-style-decl-{layout,paint,typography,transform,misc}.js)
+        # with a thin dispatcher in the parent file, so the `case "X":` arms
+        # are now spread across all six files. Concatenate them before
+        # scanning so every wired property is still seen — adapter init is the
+        # only time we read the files.
         self._js_text = "\n".join(
             self._read(rel)
             for rel in (
@@ -162,12 +162,11 @@ class CssAdapter(AdapterBase):
     def _extract_wired_cases(js_text: str) -> set[str]:
         """Return every `case "X":` key in the CSS shim's apply surface.
 
-        After the P5-5 split the `_applyProperty` switch lives in five
-        per-domain handler modules (layout / paint / typography /
-        transform / misc). `__init__` concatenates those modules plus the
-        dispatcher file into `js_text`; every `case "X":` token belongs to
-        one of the domain switches, so scanning the joined text is
-        unambiguous.
+        The `_applyProperty` switch lives in five per-domain handler modules
+        (layout / paint / typography / transform / misc). `__init__`
+        concatenates those modules plus the dispatcher file into `js_text`;
+        every `case "X":` token belongs to one of the domain switches, so
+        scanning the joined text is unambiguous.
         """
         if not js_text:
             return set()

--- a/tools/harness/adapters/html.py
+++ b/tools/harness/adapters/html.py
@@ -1,4 +1,4 @@
-"""HTML surface adapter — week 1 deliverable (one of five).
+"""HTML surface adapter.
 
 Classifies each `html/*` entry in compat.json against three layers of
 evidence:
@@ -20,9 +20,9 @@ evidence:
 The verdict is PASS / DIVERGE / NO-OP / NOT-IMPL / OOS — see
 `tools/harness/status.py` for the full taxonomy.
 
-Like the yoga adapter, this is a static-evidence classifier. The Week-3+
-upgrade path replaces the oracle table with a `jsdom`-driven trace
-comparator (see `tools/harness/oracles/html/README.md`).
+Like the yoga adapter, this is a static-evidence classifier. A future upgrade
+path replaces the oracle table with a `jsdom`-driven trace comparator (see
+`tools/harness/oracles/html/README.md`).
 """
 
 from __future__ import annotations
@@ -78,20 +78,18 @@ class HtmlAdapter(AdapterBase):
         # second pass after element.js loads), and the legacy
         # web-compat.js bundle (still hosts a few entries). Concatenate
         # them once so the prototype-evidence regex sees the full surface.
-        # P5-7 follow-up (PR #2337) extracted Element.prototype's Event +
+        # web-compat-element-events.js hosts Element.prototype's Event +
         # Pointer-capture methods (addEventListener / removeEventListener /
         # dispatchEvent / setPointerCapture / releasePointerCapture /
-        # hasPointerCapture + the synthetic event payloads) into
-        # web-compat-element-events.js. Without it in the union, the
-        # `html/Element_setPointerCapture` oracle false-classifies as
-        # NOT_IMPL (Codex P2 on PR #2337 — same class as #2253's
-        # canvas2d adapter gap fixed by #2317).
+        # hasPointerCapture + synthetic event payloads). It must stay in the
+        # union or `html/Element_setPointerCapture` and related entries
+        # false-classify as NOT_IMPL.
         #
         # The legacy web-compat.js bundle was further split: the CSS
-        # selector engine moved to web-compat-selector.js and the Phase 9
-        # runtime API shims moved to web-compat-runtime-apis.js. Both
-        # siblings join the union so the prototype/selector evidence
-        # regexes still see the full surface after the split.
+        # selector engine moved to web-compat-selector.js and the runtime API
+        # shims moved to web-compat-runtime-apis.js. Both siblings join the
+        # union so the prototype/selector evidence regexes still see the full
+        # surface after the split.
         self._element_js = "\n".join(
             self._read(p)
             for p in (

--- a/tools/harness/adapters/rn.py
+++ b/tools/harness/adapters/rn.py
@@ -1,4 +1,4 @@
-"""RN ViewStyle surface adapter — week 1 deliverable (third of 5).
+"""RN ViewStyle surface adapter.
 
 Classifies each `rn/*` entry in compat.json against three layers of evidence:
 
@@ -70,11 +70,11 @@ class RnAdapter(AdapterBase):
     def __init__(self, repo_root: Path):
         super().__init__(repo_root)
         self._oracle = self._load_oracle()
-        # P5-NEW-A split the former monolithic prop-applier switch into a
-        # thin dispatcher plus per-domain modules. Concatenate all of them
-        # before extracting `case 'X':` arms so the RN harness sees the live
-        # JSX bridge surface instead of only the handful of type-dispatched
-        # cases that remain in prop-applier.ts.
+        # The prop-applier switch is split into a thin dispatcher plus
+        # per-domain modules. Concatenate all of them before extracting
+        # `case 'X':` arms so the RN harness sees the live JSX bridge surface
+        # instead of only the handful of type-dispatched cases that remain in
+        # prop-applier.ts.
         self._prop_applier_text = "\n".join(
             self._read(rel)
             for rel in (

--- a/tools/harness/adapters/yoga.py
+++ b/tools/harness/adapters/yoga.py
@@ -1,4 +1,4 @@
-"""Yoga surface adapter — week 1 deliverable.
+"""Yoga surface adapter.
 
 Classifies each `yoga/*` entry in compat.json against three layers of evidence:
 
@@ -158,8 +158,7 @@ class YogaAdapter(AdapterBase):
     # The Yoga oracle stores bare CSS-style tokens (`flex`, `none`,
     # `row-reverse`). Naive string equality between the two surfaces
     # mis-classifies annotated catalog entries as NOT-IMPL even when the
-    # adapter found a binding, inflating the drift count (Codex P1 on
-    # PR #1395, tracked as #1413).
+    # adapter found a binding, inflating the drift count.
     #
     # Normalize by stripping a single trailing parenthetical group plus any
     # surrounding whitespace. Apply on BOTH sides so the contract is
@@ -278,7 +277,7 @@ class YogaAdapter(AdapterBase):
         # 4. Compare supportedValues vs the oracle's enum value set.
         #    Normalize annotated values like "flex (implicit)" -> "flex" on
         #    BOTH sides so the comparison is robust to either surface
-        #    growing parenthetical context. (Codex P1 on PR #1395 / #1413.)
+        #    growing parenthetical context.
         if kind == "enum" and oracle_values:
             sup = self._normalize_enum_values(entry.supported_values)
             unsup = self._normalize_enum_values(entry.unsupported_values)

--- a/tools/harness/tests/test_canvas2d_adapter_shim_files.py
+++ b/tools/harness/tests/test_canvas2d_adapter_shim_files.py
@@ -1,12 +1,11 @@
-"""Regression test for the Canvas2dAdapter shim-file union (post-P5-6 split).
+"""Regression test for the Canvas2dAdapter shim-file union.
 
-Pulp #2253 (P5-6 follow-up) extracted `measureText` / `drawImage` /
-`setLineDash` / `getLineDash` / `getImageData` / `putImageData` out of
-`web-compat-canvas.js` into a sibling prelude `web-compat-canvas-image.js`,
-and `_PulpCanvasMatrix` into `web-compat-canvas-matrix.js`. The harness
-adapter previously read only `web-compat-canvas.js`, so the canvas2d
-compat verifier mis-classified the six extracted APIs as `NOT-IMPL`
-(Codex P1 on PR #2253).
+`measureText` / `drawImage` / `setLineDash` / `getLineDash` /
+`getImageData` / `putImageData` live in the sibling prelude
+`web-compat-canvas-image.js`, and `_PulpCanvasMatrix` lives in
+`web-compat-canvas-matrix.js`. The adapter must read those files alongside
+`web-compat-canvas.js`, or the canvas2d compat verifier mis-classifies those
+APIs as `NOT-IMPL`.
 
 This test pins the contract that the adapter's shim text is the *union*
 of the parent file + its sibling preludes — if a future split moves a

--- a/tools/harness/tests/test_html_adapter_element_events_union.py
+++ b/tools/harness/tests/test_html_adapter_element_events_union.py
@@ -1,18 +1,15 @@
-"""Regression test for the HtmlAdapter element-shim union (post-P5-7 split).
+"""Regression test for the HtmlAdapter element-shim union.
 
-Pulp #2337 extracted Element.prototype's Event + Pointer-capture methods
-(addEventListener / removeEventListener / dispatchEvent /
-setPointerCapture / releasePointerCapture) out of
-`web-compat-element.js` into a sibling prelude
-`web-compat-element-events.js`. The harness `HtmlAdapter` previously
-unioned only the parent file + web-compat-dom-ops.js + the legacy
-web-compat.js bundle, so the `html/Element_setPointerCapture` oracle
-would false-classify as NOT_IMPL after the split (Codex P2 on #2337).
+Element.prototype's Event + Pointer-capture methods (addEventListener /
+removeEventListener / dispatchEvent / setPointerCapture /
+releasePointerCapture) live in the sibling prelude
+`web-compat-element-events.js`. The harness `HtmlAdapter` must union the
+element prelude files, or the `html/Element_setPointerCapture` oracle
+false-classifies as NOT_IMPL.
 
 This test pins the contract that the adapter's element-shim text is
-the *union* of the four prelude files — if a future split moves a
-prototype method into another file that isn't in the union, this
-fails loudly. Mirrors the canvas2d-adapter regression test from #2317.
+the *union* of the prelude files — if a future split moves a prototype method
+into another file that isn't in the union, this fails loudly.
 """
 
 from __future__ import annotations

--- a/tools/harness/tests/test_validate_test_ref.py
+++ b/tools/harness/tests/test_validate_test_ref.py
@@ -1,4 +1,4 @@
-"""Tests for the test-reference validator (pulp #1737).
+"""Tests for the test-reference validator.
 
 Verifies that `_validate_test_ref()` correctly accepts/rejects each form
 of catalog test reference:
@@ -169,9 +169,11 @@ class ValidateTestRefTests(unittest.TestCase):
         self.assertTrue(ok)
 
     def test_unit_prefix_with_missing_path_rejected(self) -> None:
-        """pulp #1737 followup (Codex P2 on #1768): typed refs that
-        look like file paths get existence-checked. Pre-fix any string
-        starting with `unit:` auto-passed."""
+        """Typed refs that look like file paths get existence-checked.
+
+        Any string starting with `unit:` used to auto-pass, so this keeps the
+        path-shaped form honest.
+        """
         ok, reason = _validate_test_ref(
             self.repo, "unit:test/missing.cpp"
         )

--- a/tools/harness/verifier.py
+++ b/tools/harness/verifier.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Catalog verifier orchestrator — pulp #1391, refactored P9-3.
+"""Catalog verifier orchestrator.
 
 Walks `compat.json`, dispatches each entry to its surface adapter, and
 aggregates the results into a coverage matrix.
@@ -16,10 +16,9 @@ Their public symbols are re-imported here so existing
 ``from tools.harness.verifier import ...`` call sites (CLI, adapter
 tests, the harness test suite) keep working unchanged.
 
-Adapter auto-discovery (the import-time `@register_adapter` side effect,
-pulp #1401) deliberately stays in this module — see ``_discover_adapters``
-below — because that side effect must fire when ``verifier.py`` is
-imported.
+Adapter auto-discovery (the import-time `@register_adapter` side effect)
+deliberately stays in this module — see ``_discover_adapters`` below —
+because that side effect must fire when ``verifier.py`` is imported.
 
 Outputs:
 * `build/harness-coverage-<sha>.json`     machine-readable
@@ -86,7 +85,7 @@ KNOWN_SURFACES = ["yoga", "css", "rn", "html", "canvas2d", "imports"]
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Adapter auto-discovery (pulp #1401)
+# Adapter auto-discovery
 #
 # Each adapter module under ``tools/harness/adapters/`` is imported in
 # alphabetical order. The :func:`tools.harness.adapters.base.register_adapter`
@@ -95,8 +94,8 @@ KNOWN_SURFACES = ["yoga", "css", "rn", "html", "canvas2d", "imports"]
 # with anything that imported the symbol from the old hand-rolled registry.
 #
 # A broken adapter module (raises on import) is logged and skipped; it does
-# not crash the verifier or other surfaces. This is the property covered by
-# the issue's "verifier still works when one adapter throws on import" test.
+# not crash the verifier or other surfaces. The harness test suite covers this
+# degraded-import behavior.
 # ─────────────────────────────────────────────────────────────────────────────
 
 
@@ -326,7 +325,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     elif args.surface:
         surfaces = list(args.surface)
     else:
-        # Default: yoga only this week — same as `--surface=yoga`.
+        # Default: yoga — same as `--surface=yoga`.
         surfaces = ["yoga"]
 
     for s in surfaces:

--- a/tools/harness/verify_report.py
+++ b/tools/harness/verify_report.py
@@ -1,19 +1,18 @@
 #!/usr/bin/env python3
-"""Coverage-matrix report renderer (roadmap P9-3).
+"""Coverage-matrix report renderer.
 
-Extracted from ``verifier.py`` as a focused validator-report module.
-Turns the per-surface :class:`~tools.harness.adapters.base.Result` lists
-into the two artefacts the harness publishes:
+Focused validator-report module for the harness coverage matrix. Turns the
+per-surface :class:`~tools.harness.adapters.base.Result` lists into the two
+artefacts the harness publishes:
 
 * :func:`render_markdown` — the human-readable coverage matrix mirrored to
   ``build/harness-coverage.md`` and ``docs/reports/harness-coverage.md``.
 * :func:`render_json`     — the machine-readable
   ``build/harness-coverage-<sha>.json`` payload.
 
-This is a pure mechanical move — the code is byte-identical to the
-``verifier.py`` original. ``verifier.py`` re-imports both functions so
-existing ``from tools.harness.verifier import render_json`` (etc.) call
-sites keep working unchanged.
+``verifier.py`` re-imports both functions so existing
+``from tools.harness.verifier import render_json`` (etc.) call sites keep
+working unchanged.
 """
 
 from __future__ import annotations

--- a/tools/harness/visual/check_skia_pin.py
+++ b/tools/harness/visual/check_skia_pin.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Lint: the visual-harness Dockerfile must match the canonical Skia pin.
 
-Roadmap P9-4. The visual harness builds a deterministic raster image inside
+The visual harness builds a deterministic raster image inside
 ``ci/visual-harness.Dockerfile``, which downloads a pinned ``linux/amd64`` Skia
 archive via ``ARG`` lines. The canonical, machine-readable Skia pin lives in
 ``tools/deps/manifest.json`` under the ``Skia`` dependency's ``determinism``

--- a/tools/harness/visual/runner.py
+++ b/tools/harness/visual/runner.py
@@ -435,10 +435,9 @@ def main(argv: Optional[list[str]] = None) -> int:
         print("error: pass --all OR --entry, not both", file=sys.stderr)
         return 2
 
-    # Codex P2 on PR #1598 — `--all` was previously redundant: omitting
-    # `--entry` ALSO returned every fixture, so `--generate` could
-    # silently rewrite all goldens for a surface without an explicit
-    # opt-in. Tighten the contract:
+    # `--all` was previously redundant: omitting `--entry` ALSO returned every
+    # fixture, so `--generate` could silently rewrite all goldens for a surface
+    # without an explicit opt-in. Tighten the contract:
     #
     #   --generate REQUIRES --all OR --entry. Bulk golden rewrites
     #     are now explicit; a forgotten `--entry` no longer triggers
@@ -453,7 +452,7 @@ def main(argv: Optional[list[str]] = None) -> int:
             "error: --generate requires either --all (regenerate every "
             "fixture for the selected surface) or --entry NAME [--entry NAME ...]"
             " (regenerate the listed fixtures). Refusing to silently "
-            "rewrite every golden — Codex P2 on PR #1598.",
+            "rewrite every golden.",
             file=sys.stderr,
         )
         return 2

--- a/tools/harness/visual/tests/test_check_skia_pin.py
+++ b/tools/harness/visual/tests/test_check_skia_pin.py
@@ -1,4 +1,4 @@
-"""Tests for the visual-harness Dockerfile / manifest Skia-pin lint (P9-4)."""
+"""Tests for the visual-harness Dockerfile / manifest Skia-pin lint."""
 
 from __future__ import annotations
 

--- a/tools/harness/visual/tests/test_runner.py
+++ b/tools/harness/visual/tests/test_runner.py
@@ -471,9 +471,9 @@ class RunnerTests(unittest.TestCase):
                 runner.generate(binary, root, "canvas2d", [bad])
 
     def test_generate_requires_explicit_all_or_entry(self) -> None:
-        # Codex P2 on PR #1598 — `--generate` without `--all` or
-        # `--entry` previously regenerated every golden silently.
-        # Now require an explicit opt-in to bulk rewrites.
+        # `--generate` without `--all` or `--entry` previously regenerated
+        # every golden silently. Now require an explicit opt-in to bulk
+        # rewrites.
         buf = io.StringIO()
         with redirect_stderr(buf):
             rc = runner.main(["--generate", "--surface", "yoga"])
@@ -481,6 +481,7 @@ class RunnerTests(unittest.TestCase):
         self.assertIn("--generate requires", buf.getvalue())
         self.assertIn("--all", buf.getvalue())
         self.assertIn("--entry", buf.getvalue())
+        self.assertIn("rewrite every golden.", buf.getvalue())
 
     def test_verify_with_all_emits_deprecation_warning(self) -> None:
         # `--all` is redundant with `--verify` (omitting --entry already


### PR DESCRIPTION
## Summary
- Trim stale roadmap/PR/Codex provenance from harness adapter/verifier docstrings and comments while preserving behavioral rationale.
- Remove the same stale provenance from the visual-runner `--generate` error text and assert the cleaned wording.
- Keep this as one batched harness cleanup PR instead of per-file comment hygiene PRs.

## Validation
- RepoPrompt classification review over selected harness files.
- RepoPrompt final diff/content review; accepted findings fixed.
- `rg` provenance scan over touched files: clean.
- `git diff --check`.
- `python3 -m py_compile` for touched Python files.
- AST comparison vs `origin/main` for docstring/comment-only files after stripping docstrings: clean; runner output change covered by focused test.
- `python3 -m unittest tools.harness.tests.test_canvas2d_adapter_shim_files tools.harness.tests.test_html_adapter_element_events_union tools.harness.tests.test_validate_test_ref tools.harness.visual.tests.test_check_skia_pin tools.harness.visual.tests.test_runner` (70 tests OK).
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base refs/remotes/origin/main --head HEAD`.
- `tools/scripts/gates.sh`.
- `$HOME/.agents/skills/autoreview/scripts/autoreview --mode local --reviewers codex,claude` (panel clean).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed stale roadmap/PR/Codex provenance from harness comments and docstrings while keeping rationale intact, and cleaned the visual runner `--generate` error message. No logic changes; only message text and tests updated.

- **Refactors**
  - Removed provenance labels from adapters (`canvas2d`, `css`, `html`, `rn`, `yoga`), `verifier`, `verify_report`, visual harness lint/runner, and related tests.
  - Preserved behavioral explanations; AST checks confirm comment-only changes.
  - Simplified the visual runner `--generate` error text (no provenance mention) and updated tests to assert the new wording.

<sup>Written for commit 8628ed9aefe2e305f987e5cb0e0bcdb100aacd43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

