### PR TITLE
test(view): trim stale provenance comments

### DIFF
--- a/test/test_fft_backends.cpp
+++ b/test/test_fft_backends.cpp
@@ -72,7 +72,7 @@ void unset_env_var(const char* name) {
 
 }  // namespace
 
-// Regression: Codex PR #3021 review — MKL DftiSetValue is a variadic API.
+// Regression: MKL DftiSetValue is a variadic API.
 // Calling it through a fixed-signature `fn_set_f` reinterpret_cast was UB
 // on most ABIs (varargs uses different register/stack slots than typed args)
 // and would silently mis-pass the backward-scale float on platforms where

--- a/test/test_gui_components.cpp
+++ b/test/test_gui_components.cpp
@@ -974,7 +974,7 @@ TEST_CASE("TextButton paint truncates long labels with U+2026 when text-overflow
     REQUIRE(canvas.measure_text(drawn) <= 80.0f - 16.0f);
 }
 
-// pulp #1407 (Codex post-merge sweep) — a TextButton narrower than its
+// A TextButton narrower than its
 // 2 × 8 px horizontal padding budget collapses the available text-box
 // to ≤ 0. Without the non-positive guard inside truncate_to_width, the
 // helper would short-circuit to the full string and visibly leak the
@@ -1095,7 +1095,7 @@ TEST_CASE("ShapeButton reports hover and pressed states to draw callback",
     REQUIRE(saw_hover);
     REQUIRE(saw_pressed);
 
-    // pulp #1171 (Codex P2 on #1069) — verify hover state actually
+    // Verify hover state actually
     // resets after on_mouse_leave(). The previous version pre-set
     // saw_hover=true and only OR'd new values into it, so a regression
     // where leave failed to clear hover would not be caught.

--- a/test/test_layout_w3c.cpp
+++ b/test/test_layout_w3c.cpp
@@ -203,7 +203,7 @@ TEST_CASE("View: overflow default is visible (CSS default, pulp #972)", "[view][
 }
 
 // ═══════════════════════════════════════════════════════════════════
-// Phase 13.1: margin
+// margin
 // ═══════════════════════════════════════════════════════════════════
 
 TEST_CASE("Layout: margin adds space around child", "[layout][w3c][margin]") {
@@ -238,7 +238,7 @@ TEST_CASE("Layout: per-side margin overrides uniform", "[layout][w3c][margin]") 
 }
 
 // ═══════════════════════════════════════════════════════════════════
-// Phase 13.1: align-self
+// align-self
 // ═══════════════════════════════════════════════════════════════════
 
 TEST_CASE("Layout: align-self center overrides parent stretch", "[layout][w3c][align-self]") {
@@ -277,7 +277,7 @@ TEST_CASE("Layout: align-self auto inherits parent", "[layout][w3c][align-self]"
 }
 
 // ═══════════════════════════════════════════════════════════════════
-// Phase 13.1: flex-basis
+// flex-basis
 // ═══════════════════════════════════════════════════════════════════
 
 TEST_CASE("Layout: flex-basis overrides preferred width", "[layout][w3c][flex-basis]") {
@@ -295,7 +295,7 @@ TEST_CASE("Layout: flex-basis overrides preferred width", "[layout][w3c][flex-ba
 }
 
 // ═══════════════════════════════════════════════════════════════════
-// Phase 13.1: order
+// order
 // ═══════════════════════════════════════════════════════════════════
 
 TEST_CASE("Layout: order changes rendering sequence", "[layout][w3c][order]") {
@@ -316,7 +316,7 @@ TEST_CASE("Layout: order changes rendering sequence", "[layout][w3c][order]") {
 }
 
 // ═══════════════════════════════════════════════════════════════════
-// Phase 13.1: directional gap
+// directional gap
 // ═══════════════════════════════════════════════════════════════════
 
 TEST_CASE("Layout: column_gap for row direction", "[layout][w3c][gap]") {
@@ -337,7 +337,7 @@ TEST_CASE("Layout: column_gap for row direction", "[layout][w3c][gap]") {
 }
 
 // ═══════════════════════════════════════════════════════════════════
-// Phase 13.1: intrinsic sizing with Label
+// intrinsic sizing with Label
 // ═══════════════════════════════════════════════════════════════════
 
 TEST_CASE("Layout: Label intrinsic height in column", "[layout][w3c][intrinsic]") {

--- a/test/test_mac_perform_key_equivalent.mm
+++ b/test/test_mac_perform_key_equivalent.mm
@@ -16,7 +16,7 @@
 //  3. Asserts the on_global_key callback fired AND received the
 //     (key=',', mods=kModCmd) event the lambda forwards into the bridge.
 //
-// Audio-observability Phase 4 sharpened the contract: the override now
+// The override now
 // HONORS consumption. A chord the root hook claims (on_global_key returns
 // true — e.g. CommandRegistry::dispatch_key_event found a handler) returns
 // YES and is NOT also fanned out to the script global-key dispatcher (no

--- a/test/test_render_loop.cpp
+++ b/test/test_render_loop.cpp
@@ -156,7 +156,7 @@ TEST_CASE("RenderLoop timer backend can restart with a new callback",
     REQUIRE(second.load(std::memory_order_relaxed) == 1);
 }
 
-// ── Slice 16 — VBlank-locked safe-repaint additions ─────────────────────
+// ── VBlank-locked safe-repaint additions ───────────────────────────────
 
 TEST_CASE("RenderLoop factory selects the timer backend under force-timer",
           "[render][loop][vblank][slice-16]") {
@@ -211,7 +211,7 @@ TEST_CASE("render_loop_backend_name covers every backend",
 
 TEST_CASE("DwmBackendTracker latches to the timer fallback once a vblank wait fails",
           "[render][loop][vblank][slice-16][issue-2580]") {
-    // Codex P2 #2580: the Windows loop sleeps on a ~60 Hz timer when
+    // The Windows loop sleeps on a ~60 Hz timer when
     // DwmFlush() fails, but backend() must then stop claiming dwm_flush so
     // render_loop_backend_is_vsync() callers can detect the fallback.
     DwmBackendTracker tracker;

--- a/test/test_text_shaper.cpp
+++ b/test/test_text_shaper.cpp
@@ -120,7 +120,7 @@ TEST_CASE("TextShaper layout_with_lines max_lines=1 materializes the full string
     REQUIRE(nowrap.lines[0].text.find("delta") != std::string::npos);
 }
 
-// pulp #1410 (Codex pre-merge sweep) — CSS `white-space: nowrap`
+// pulp #1410 — CSS `white-space: nowrap`
 // collapses hard line breaks into a single space, both in the
 // materialized line text and in the width sum. Otherwise an input
 // like "alpha\nbeta" would measure as alpha + beta with no inter-word
@@ -548,7 +548,7 @@ TEST_CASE("TextShaper BreakMode::normal default-arg matches the no-arg overload"
 TEST_CASE("TextShaper BreakMode preserves remnant when the over-wide segment is followed by more text",
           "[canvas][text_shaper][issue-1737]") {
     TextShaper shaper;
-    // Codex P1 on PR #1795: when break_word splits an over-wide segment
+    // When break_word splits an over-wide segment
     // mid-segment AND that segment is NOT the last one, the remainder
     // characters were silently dropped. The fix emits the remnant as
     // its own line unconditionally so materialization downstream sees

--- a/test/test_view.cpp
+++ b/test/test_view.cpp
@@ -456,7 +456,7 @@ TEST_CASE("View pointer capture hover and inspector hooks cover edge paths",
     // No painting root supplied → hook receives nullptr (legacy/headless path).
     REQUIRE(last_painting_root == nullptr);
 
-    // WYSIWYG P2e: paint_overlays forwards the painting root to the hook so it
+    // paint_overlays forwards the painting root to the hook so it
     // can gate which root the inspector overlay paints into.
     View probe_root;
     View::set_inspector_paint_hook(
@@ -471,7 +471,7 @@ TEST_CASE("View pointer capture hover and inspector hooks cover edge paths",
     View::set_inspector_paint_hook({});
 }
 
-// WYSIWYG P4 FIX 1 — the mouse / cursor / text inspector hooks now carry the
+// The mouse / cursor / text inspector hooks now carry the
 // event's root View so the installed hook can gate to the inspected canvas
 // root (mirroring the paint-hook root-gate above). This proves the call
 // forwards the root and that an installed gate dispatches only when the event
@@ -1088,7 +1088,7 @@ TEST_CASE("View per-corner radii setters flip has_corner_radii",
     REQUIRE_THAT(v.corner_radius_br(), WithinAbs(2.0f,  1e-5f));
 }
 
-// pulp #1171 (#1044) — uniform set_border_radius() followed
+// pulp #1171 — uniform set_border_radius() followed
 // by a single per-corner override must NOT zero the other three corners.
 // Previously: set_border_radius(10); set_corner_radius_tl(2);
 // rendered as {2, 0, 0, 0}, silently discarding the uniform 10.
@@ -1448,7 +1448,7 @@ TEST_CASE("LiveConstantEditor toggles visibility and ignores header drags",
     REQUIRE(registry.get("phase3.live.editor") == Catch::Approx(5.0f));
 }
 
-// Phase 3d (inspector roadmap) — per-component paint timing.
+// Per-component paint timing.
 // View::paint_all() now records nanoseconds spent inside paint() (self)
 // and the recursive children walk (with_children) so the inspector can
 // show per-view cost without adding new instrumentation per query.

--- a/test/test_widgets_label.cpp
+++ b/test/test_widgets_label.cpp
@@ -251,7 +251,7 @@ TEST_CASE("Label intrinsic_height counts explicit newlines on multi_line labels"
 
 TEST_CASE("Label intrinsic_height ignores a trailing newline (no phantom line)",
           "[view][widget][internal-74][issue-1969]") {
-    // PR #1969 Codex P2 — a string ending with `\n` used to count an
+    // A string ending with `\n` used to count an
     // extra line in the `\n`-count loop ("Title\n" → 2). But
     // Label::paint()'s split-and-emit loop stops once `pos ==
     // display_text.size()`, so it draws exactly one line. Yoga was

--- a/test/test_winrt_midi.cpp
+++ b/test/test_winrt_midi.cpp
@@ -157,7 +157,7 @@ TEST_CASE("WinRT MIDI: sysex7 reassembly framed to F0..F7 for delivery",
 
 TEST_CASE("WinRT MIDI: per-group sysex7 reassembly keeps interleaved streams separate",
           "[midi][ump][sysex][winrt][pr3781]") {
-    // Codex #3781 P2: SysEx7 reassembly is per-stream state, and UMP SysEx7
+    // SysEx7 reassembly is per-stream state, and UMP SysEx7
     // streams can interleave across the 16 UMP groups. The backend keeps one
     // reassembler per group so a Start on group 1 cannot reset/corrupt an
     // in-flight stream on group 0 — which a single shared reassembler would.


### PR DESCRIPTION
## Summary
- Trim stale roadmap/Codex/PR provenance from UI/view-related test comments.
- Preserve all Catch2 `TEST_CASE` names, tags, user-visible strings, issue anchors with active regression rationale, and product/spec grouping comments.
- Keep this as one batched test-comment cleanup PR rather than per-file PRs.

## Validation
- RepoPrompt classification review over selected UI/view test files.
- RepoPrompt diff/content review; accepted findings fixed.
- Changed-line verifier: all changed lines are `//` comments.
- `git diff --check`.
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base refs/remotes/origin/main --head HEAD`.
- `tools/scripts/gates.sh`.
- `$HOME/.agents/skills/autoreview/scripts/autoreview --mode local --reviewers codex,claude` (panel clean).

## Preserved intentionally
- Catch2 names/tags such as `[codex-p2]`, `[slice-16]`, `[pr3781]`, and regression-title suffixes because they affect test reporting/filtering.
- Current issue-anchored rationale where the issue number explains a non-obvious behavior contract.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove stale Codex/roadmap provenance from UI/view test comments to reduce noise. No code or behavior changes.

- **Refactors**
  - Touched only `//` comments across view, layout, text shaper, render loop, widgets, MIDI, and mac tests.
  - Preserved all Catch2 test names, tags (e.g., `[slice-16]`, `[pr3781]`), and active issue-anchored rationale.
  - Verified comment-only changes with repo gates and linters.

<sup>Written for commit 206f785434292af33119876471f55cdd5404c54f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

