### PR TITLE
docs(view): trim source provenance comments

### DIFF
--- a/core/view/include/pulp/view/component_dragger.hpp
+++ b/core/view/include/pulp/view/component_dragger.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
 /// @file component_dragger.hpp
-/// ComponentDragger — drag-to-move helper for any View
-/// (closes the gap-doc P2 row "Drag & drop ComponentDragger utility").
+/// ComponentDragger — drag-to-move helper for any View.
 ///
 /// A `ComponentDragger` adds "click and drag to move me within my parent"
 /// behavior to any `View`. It is intentionally a free helper (not a mixin)

--- a/core/view/include/pulp/view/musical_typing.hpp
+++ b/core/view/include/pulp/view/musical_typing.hpp
@@ -12,7 +12,7 @@
 ///   k=C(+12) o=C# l=D  p=D#
 /// `z` / `x` shift the base octave down / up.
 ///
-/// Design notes (aligned with a Codex review + JUCE/PlunderTube study):
+/// Design notes (JUCE/PlunderTube study):
 ///   - Rejects Cmd/Ctrl/Alt/Meta chords so host menu shortcuts (Cmd+S …) still
 ///     work — `handle_key` returns false for them and for unmapped keys, so the
 ///     caller falls through to the host.

--- a/core/view/include/pulp/view/preferences_panel.hpp
+++ b/core/view/include/pulp/view/preferences_panel.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
 /// @file preferences_panel.hpp
-/// PreferencesPanel — sidebar-of-pages container for app preferences
-/// (closes the gap-doc P3 row "PreferencesPanel").
+/// PreferencesPanel — sidebar-of-pages container for app preferences.
 ///
 /// `PreferencesPanel` is a `View` subclass that hosts a sidebar of named
 /// "pages". Each page is a (title, icon, content) tuple; the panel

--- a/core/view/include/pulp/view/tooltip_window.hpp
+++ b/core/view/include/pulp/view/tooltip_window.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
 /// @file tooltip_window.hpp
-/// TooltipWindow — transient floating tooltip near the cursor
-/// (closes the gap-doc P2 row "TooltipWindow").
+/// TooltipWindow — transient floating tooltip near the cursor.
 ///
 /// A `TooltipWindow` is a tiny stateful holder that drives a tooltip
 /// "popup" near a pointer:

--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -1273,7 +1273,7 @@ static void install_app_menu(NSString* appName) {
     }
 }
 
-// ── Trackpad gestures (P4: pinch/rotate) ───────────────────────────
+// ── Trackpad gestures (pinch/rotate) ───────────────────────────────
 
 - (void)magnifyWithEvent:(NSEvent*)event {
     if (!self.rootView) return;

--- a/core/view/platform/mac/window_host_mac_geometry.mm
+++ b/core/view/platform/mac/window_host_mac_geometry.mm
@@ -1,7 +1,7 @@
 // window_host_mac_geometry.mm — geometry, coordinate, and event-
 // translation helpers extracted from window_host_mac.mm.
 //
-// R2-5 refactor: these are free functions / former file-local statics
+// These are free functions / former file-local statics
 // that do NOT touch PulpView ivars or any Obj-C instance state — pure
 // coordinate math, NSEvent→Pulp event translation, View tree walks, and
 // NSWindow / NSView configuration. The PulpView @implementation block,

--- a/core/view/platform/win/webview2_backend.cpp
+++ b/core/view/platform/win/webview2_backend.cpp
@@ -4,7 +4,7 @@
 // which on Windows talks to Microsoft Edge WebView2 (via the
 // `Microsoft.Web.WebView2.Loader` COM shim distributed with the Edge
 // runtime). CHOC handles the heavy lifting — this translation unit
-// exists so the gap-doc audit can confirm:
+// exists to confirm:
 //
 //   1. The WebView2 runtime is locatable at process start (so the build
 //      isn't silently emitting CHOC code that will fail to instantiate),
@@ -23,14 +23,14 @@
 //     channel, not as part of the Windows SDK, so vendor-pinned headers
 //     would add a needless build dependency.
 //
-// What's *not* in this file (deferred follow-up):
+// What's *not* in this file:
 //   * Full WebView2 environment setup (`CreateCoreWebView2Environment`,
 //     `ICoreWebView2Controller2`, the per-user data folder convention).
 //     CHOC already takes that path inside `choc::ui::WebView`; this
 //     module just confirms the loader DLL is reachable.
 //   * Custom-scheme / `WebResourceRequested` interception. CHOC's
 //     `customSchemeURI` + `fetchResource` already cover the
-//     `ResourceProvider`-style intercept use case for the gap-doc row.
+//     `ResourceProvider`-style intercept use case.
 
 #include <pulp/view/web_view.hpp>
 

--- a/core/view/src/design_frame_view.cpp
+++ b/core/view/src/design_frame_view.cpp
@@ -534,7 +534,7 @@ View* DesignFrameView::overlay_widget(int i) const {
 void DesignFrameView::layout_children() {
     // Position each native overlay over its element's rect, mapped through the
     // SAME panel transform paint() uses, so the widget tracks the design exactly
-    // as the window scales (Codex: layout_children is the hook hosts/screenshots
+    // as the window scales (layout_children is the hook hosts/screenshots
     // call before paint; set_bounds only fires on_resized).
     const auto t = panel_transform(local_bounds());
     if (t.scale <= 0) return;

--- a/core/view/src/web_view.cpp
+++ b/core/view/src/web_view.cpp
@@ -1,6 +1,6 @@
 // WebView embedding implementation
 // Wraps CHOC's native WebView layer (WKWebView / WebView2 / WebKitGTK) and
-// adds a small structured bridge on top for Pulp's Phase 7 interop needs.
+// adds a small structured bridge on top for Pulp's interop needs.
 
 #include <pulp/view/web_view.hpp>
 #include <pulp/view/asset_manager.hpp>

--- a/core/view/src/widget_bridge/platform_services_api.cpp
+++ b/core/view/src/widget_bridge/platform_services_api.cpp
@@ -128,7 +128,7 @@ void WidgetBridge::register_platform_services_dialog_api() {
 void WidgetBridge::register_platform_services_clipboard_api() {
     BridgeApiContext api{engine_};
 
-    // P1: Clipboard - read/write text via platform::Clipboard
+    // Clipboard - read/write text via platform::Clipboard
     register_bridge_function(api, "readClipboard", [](choc::javascript::ArgumentList) {
         auto text = platform::Clipboard::get_text();
         return choc::value::createString(text.value_or(""));

--- a/core/view/src/widget_bridge/storage_assets_api.cpp
+++ b/core/view/src/widget_bridge/storage_assets_api.cpp
@@ -198,7 +198,7 @@ std::string base64_encode_blob(const std::vector<uint8_t>& data) {
 void WidgetBridge::register_storage_key_value_api() {
     BridgeApiContext api{engine_};
 
-    // P2: localStorage equivalent - file-based key-value in plugin data dir.
+    // localStorage equivalent - file-based key-value in plugin data dir.
     register_bridge_function(api, "storageGetItem", [](choc::javascript::ArgumentList args) {
         auto key = args.get<std::string>(0, "");
         if (key.empty()) return choc::value::createString("");
@@ -270,8 +270,8 @@ void WidgetBridge::register_font_assets_api() {
     // registerFont(family, path) - register a bundled .ttf/.otf with the text
     // renderer under `family`, so set_font() / Label font_family resolve to the
     // shipped face instead of a same-named system font (or a generic fallback).
-    // figma-import #43b: codegen emits these from the envelope's
-    // font_family_assets before any setFontFamily.
+    // Codegen emits these from the envelope's font_family_assets before any
+    // setFontFamily.
     register_bridge_function(api, "registerFont", [](choc::javascript::ArgumentList args) {
         auto family = args.get<std::string>(0, "");
         auto path = args.get<std::string>(1, "");

--- a/core/view/src/widgets/visualizers.cpp
+++ b/core/view/src/widgets/visualizers.cpp
@@ -128,8 +128,7 @@ void ImageView::paint(canvas::Canvas& canvas) {
         const std::string& fit = object_fit();
 
         // Default `fill` (CSS spec): stretch to the box, full src.
-        // Same applies when `object-fit` is unset or unknown — the
-        // pre-#1737 behaviour.
+        // Same applies when `object-fit` is unset or unknown.
         if (fit.empty() || fit == "fill") {
             return {dst, src};
         }


### PR DESCRIPTION
## Summary
- Trim workflow/provenance wording from core/view comments without changing behavior.
- Keep concrete rationale, platform quirks, issue anchors, license-lineage notes, and regression evidence.
- Preserve the `c29fa49f` macOS pointer and drag-drop follow-up anchor after adversarial review adjudication.

## Review
- RepoPrompt/rp-cli classification pass over `core/view` comment-hygiene candidates.
- RepoPrompt second pass on remaining hits: no additional safe edits.
- Diff-backed adversarial review was adjudicated; concrete anchors were restored where useful.
- `autoreview --mode local --reviewers codex,claude`: clean, 0 accepted/actionable findings.

## Validation
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD`
- `tools/scripts/gates.sh refs/remotes/origin/main`
- Comment-only guard over C++/ObjC++ diff lines
- Pre-push `local_diff_cover.sh`: 10,418 tests passed, 0 failed; diff coverage OK (no covered code lines in diff)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed workflow/provenance and audit references from comments across `core/view` while keeping design rationale and concrete anchors. No behavior changes.

- **Refactors**
  - Removed gap-doc notes, priority/phase markers, issue refs, and review provenance from headers and sources.
  - Preserved useful anchors and notes (e.g., macOS pointer/drag-drop follow-up).
  - Tightened wording across mac host/geometry, Windows WebView2 backend, widget-bridge clipboard/storage/font comments, and nearby view modules (`design_frame_view`, `web_view`, visualizers).

<sup>Written for commit 29b5f6d8ecf749db283f91af14550de27792478b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

