### PR TITLE
docs(runtime): trim source provenance comments

### DIFF
--- a/core/events/platform/mac/user_notifications_backend.mm
+++ b/core/events/platform/mac/user_notifications_backend.mm
@@ -11,7 +11,7 @@
 // up the macOS path without per-call wiring. Plugin sandboxes that
 // cannot use UserNotifications (older AU hosts) still work because
 // the framework calls themselves no-op when the host process is not
-// authorized; the gap-doc row stays "local-only" until remote shipping.
+// authorized.
 
 #include <pulp/events/push_notifications.hpp>
 

--- a/core/format/include/pulp/format/remote_view_session.hpp
+++ b/core/format/include/pulp/format/remote_view_session.hpp
@@ -28,8 +28,8 @@ namespace pulp::format {
 class RemoteViewSession {
 public:
     /// Role this session drives in the owning bridge — always
-    /// `ViewRole::Remote` in the current MVP; reserved for future
-    /// differentiation between different remote renderers.
+    /// `ViewRole::Remote`; reserved for future differentiation between
+    /// different remote renderers.
     ViewRole role() const { return ViewRole::Remote; }
 
     /// URL (or descriptive label) this session was opened against.

--- a/core/format/src/host_quirks.cpp
+++ b/core/format/src/host_quirks.cpp
@@ -96,20 +96,14 @@ static_assert(count_quirk_fields() == 37,
 
 namespace {
 
-// Per-host quirk-population helpers. Extracted per-host modules under
-// `core/format/include/pulp/format/host_quirks/<host>.hpp` expose an
-// inline `host_quirks::apply_<host>(HostQuirks&, HostVersion)` that
-// the dispatch table below routes to. Hosts without a dedicated header
-// still live here as private helpers until the next batch extracts
-// them. License-hygiene: every flag flipped here (or in a per-host
-// header) must be backed by a host vendor doc + a reproducer Pulp
-// issue. See the catalog at
+// Per-host quirk-population helpers. Hosts without a dedicated header
+// live here as private helpers until they are extracted. License-hygiene:
+// every flag flipped here (or in a per-host header) must be backed by a
+// host vendor doc + a reproducer Pulp issue. See the catalog at
 // `planning/2026-05-24-daw-host-quirks-inheritance.md`.
 
 void apply_reaper_quirks(HostQuirks& q, HostVersion v) {
-    // Main 6 REAPER rows (15 + R1-R4 + R6) — extracted to the per-host
-    // header so REAPER-specific lessons live in one place. Adapter
-    // surface unchanged; this is a pure header refactor for item 5.8.
+    // Main 6 REAPER rows (15 + R1-R4 + R6).
     host_quirks::apply_reaper(q, v);
     // Layer the iPlug2-audit keyboard-only-space lesson on top via the
     // separate factory so its LessonOnly tier can evolve independently
@@ -124,10 +118,9 @@ void apply_reaper_quirks(HostQuirks& q, HostVersion v) {
 }
 
 void apply_pro_tools_quirks(HostQuirks& q, HostVersion v) {
-    // Main 3 AAX rows (16-18) — extracted to the per-host header for
-    // item 5.9 (opt-in lane gated on Avid SDK at the adapter level;
-    // the quirk dispatch itself is unconditional so filtering behaves
-    // identically across builds).
+    // Main 3 AAX rows (16-18). Adapter use is gated on the
+    // developer-supplied Avid SDK; the quirk dispatch itself is
+    // unconditional so filtering behaves identically across builds.
     host_quirks::apply_pro_tools(q, v);
     // Pro Tools' AAX wrapper does not surface a reliable vendor version
     // through the AAX spec, so version-gated decisions for this host

--- a/core/format/src/remote_view_session.cpp
+++ b/core/format/src/remote_view_session.cpp
@@ -84,9 +84,9 @@ void RemoteViewSession::install_handlers_(Processor& processor) {
             return runtime::JsonRpcResult::ok(os.str());
         });
 
-    // view.input: forwarded input event. Current MVP just logs;
-    // wiring into the bridge's primary view input dispatch is a
-    // follow-up (requires synthetic input API on View).
+    // view.input: forwarded input event. Currently just logs; wiring
+    // into the bridge's primary view input dispatch requires a
+    // synthetic input API on View.
     peer_->on_notification("view.input",
         [](std::string_view payload) {
             runtime::log_debug("RemoteViewSession: view.input {}", std::string{payload});
@@ -155,7 +155,7 @@ std::optional<float> RemoteViewSession::get_parameter(uint32_t id) {
         });
     // Spin briefly — the test harness uses synchronous message loopback
     // so the reply is usually immediate. Real WebSocket use should
-    // switch to an async accessor; kept synchronous for MVP.
+    // switch to an async accessor; kept synchronous for now.
     for (int i = 0; i < 100 && !done; ++i) std::this_thread::sleep_for(std::chrono::milliseconds(1));
     return result;
 }

--- a/core/runtime/include/pulp/runtime/mac_address.hpp
+++ b/core/runtime/include/pulp/runtime/mac_address.hpp
@@ -3,10 +3,8 @@
 /// @file mac_address.hpp
 /// MAC address parsing, formatting, and validation utility.
 ///
-/// Closes the gap-doc Runtime row "MACAddress" (the IPAddress side
-/// already shipped via `pulp/runtime/ip_address.hpp`). Pure parser +
-/// formatter — no platform calls, no allocation in the common path.
-/// Headless-friendly, RT-safe to copy/compare.
+/// Pure parser + formatter — no platform calls, no allocation in the
+/// common path. Headless-friendly, RT-safe to copy/compare.
 
 #include <array>
 #include <cstdint>

--- a/core/runtime/include/pulp/runtime/result.hpp
+++ b/core/runtime/include/pulp/runtime/result.hpp
@@ -3,12 +3,10 @@
 /// @file result.hpp
 /// `Result<T, E>` — success / failure union for fallible operations.
 ///
-/// Closes the gap-doc Runtime row "Result" (currently `std::optional`
-/// throughout — drops the error context). This header is a
-/// dependency-free placeholder until `std::expected` (C++23) is
-/// available across all target toolchains. The shape is intentionally
-/// API-compatible with `std::expected` so callers can migrate
-/// mechanically (`Ok` / `Err` map to `T` / `unexpected<E>`).
+/// Dependency-free placeholder until `std::expected` (C++23) is available
+/// across all target toolchains. The shape is intentionally API-compatible
+/// with `std::expected` so callers can migrate mechanically (`Ok` / `Err`
+/// map to `T` / `unexpected<E>`).
 ///
 /// Why not just adopt `std::expected` today? Pulp's stable toolchain
 /// matrix still includes platforms whose stdlib lacks `<expected>` (or

--- a/core/runtime/include/pulp/runtime/url.hpp
+++ b/core/runtime/include/pulp/runtime/url.hpp
@@ -3,11 +3,9 @@
 /// @file url.hpp
 /// Minimal URL parser + builder utility.
 ///
-/// Closes the gap-doc Runtime row "URL parser class". Pulp already has
-/// `http_*` and `http_download` for transport — this header just adds
-/// the structural parse/build that callers need for query-string
-/// manipulation, scheme dispatch, and round-tripping a URL through
-/// state.
+/// Transport already lives in `http_*` and `http_download`; this header
+/// adds the structural parse/build that callers need for query-string
+/// manipulation, scheme dispatch, and round-tripping a URL through state.
 ///
 /// Scope:
 ///   - Parses the common URL grammar — `scheme://[user[:pass]@]host


### PR DESCRIPTION
## Summary
- trim stale provenance/roadmap breadcrumbs from runtime utility comments, remote view session notes, local notification backend notes, and host-quirks implementation comments
- preserve active behavioral contracts: RT/no-allocation MAC helpers, `std::expected` migration rationale, URL boundary semantics, local-only notification behavior, remote view limitations, and host-quirks evidence/licensing constraints
- explicitly defer `host-quirks.json` and the host quirks public header because RepoPrompt classified those comments as tooling/provenance-contract sensitive

## Review and validation
- RepoPrompt/rp-cli exact-snippet analysis used to classify safe edits vs deferred host-quirks items
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD`
- `tools/scripts/gates.sh refs/remotes/origin/main`
- comment-only added-line guard over C++/ObjC++ diffs
- `autoreview --mode branch --base origin/main --reviewers codex,claude` clean: 0 accepted/actionable findings
- pre-push local diff coverage: full coverage build and 10,418/10,418 tests passed; diff-cover reported no covered lines in diff and passed threshold

## Deferred follow-up
- `core/format/host-quirks.json` `_comment`: defer until the provenance/staleness tooling contract is audited
- `core/format/include/pulp/format/host_quirks.hpp`: defer to a focused pass that separates live validation-tier/evidence contracts from removable planning-history text


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed stale provenance/roadmap comments across runtime and format modules while keeping existing behavioral contracts and rationale intact. No functional changes—comment-only cleanup to improve readability.

- **Refactors**
  - Removed planning breadcrumbs in: `remote_view_session.{hpp,cpp}`, `user_notifications_backend.mm`, `mac_address.hpp`, `result.hpp`, `url.hpp`, and `host_quirks.cpp`.
  - Preserved key contracts (RT/no-allocation MAC helpers, `std::expected` migration rationale, URL boundary semantics, remote view limitations).
  - Deferred edits for `core/format/host-quirks.json` and the public `host_quirks.hpp` header for a dedicated follow-up.

<sup>Written for commit 25b887275a7d46d3896a67d500949599d17c3664. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

