### PR TITLE
docs(view): trim source roadmap comments

### DIFF
--- a/core/signal/include/pulp/signal/fft_backend.hpp
+++ b/core/signal/include/pulp/signal/fft_backend.hpp
@@ -4,12 +4,11 @@
 //
 // Backends:
 //   - vdsp     : Apple Accelerate.framework (always available on Apple)
-//   - kissfft  : built-in radix-2 fallback (always available, header-only)
-//                pulp-doc: "kissfft" is the historical name in the gap-doc
-//                multi-engine FFT row; our shipping fallback is the hand-rolled
-//                radix-2 Cooley-Tukey in pulp::signal::Fft, exposed under this
-//                stable alias so callers don't have to track implementation
-//                changes.
+//   - kissfft  : built-in radix-2 fallback (always available, header-only).
+//                The public backend name stays stable even though the shipping
+//                implementation is the hand-rolled radix-2 Cooley-Tukey in
+//                pulp::signal::Fft, so callers do not have to track
+//                implementation changes.
 //   - fftw3   : libfftw3f loaded via dlopen at runtime (optional)
 //   - mkl     : Intel MKL libmkl_rt loaded via dlopen at runtime (optional)
 //

--- a/core/view/include/pulp/view/component_dragger.hpp
+++ b/core/view/include/pulp/view/component_dragger.hpp
@@ -30,9 +30,9 @@
 /// the dragged view's bounds; tests can call `start_dragging` /
 /// `drag_view` directly without simulating real mouse events.
 ///
-/// License-lineage note: the name is Pulp-native per the gap-doc rule —
-/// the behavior mirrors a well-trodden idiom across UI toolkits, but the
-/// implementation here is independent.
+/// License-lineage note: the name is Pulp-native. The behavior mirrors a
+/// well-trodden idiom across UI toolkits, but the implementation here is
+/// independent.
 
 #include <algorithm>
 #include <pulp/view/geometry.hpp>

--- a/core/view/include/pulp/view/design_frame_view.hpp
+++ b/core/view/include/pulp/view/design_frame_view.hpp
@@ -11,8 +11,7 @@ namespace pulp::view {
 // One interactive element overlaid on a faithfully-rendered design frame. The
 // element list is TYPED and supplied by the importer (source-side semantics) —
 // DesignFrameView does NOT guess from the SVG. Bounds/coords are in the SVG's own
-// coordinate space. (Per the Plan-B review: real behavior comes from source
-// metadata, not SVG structure.)
+// coordinate space. Real behavior comes from source metadata, not SVG structure.
 struct DesignFrameElement {
     // `knob` is SVG-patch (rotates its needle path in the SVG). `text_field` /
     // `dropdown` / `tab_group` / `stepper` are NATIVE-OVERLAY: an opaque child
@@ -44,8 +43,8 @@ struct DesignFrameElement {
     // [x,y,w,h] moves the puck element (needle_d) to follow — `value` is the X
     // position (0→left, 1→right), `value_y` the Y (0→top, 1→bottom). cx/cy = the
     // puck's baked center.
-    // `custom` is a registered native control (P7 Tier-3): the overlay is built
-    // by a factory looked up under `factory_id` in the design-control registry
+    // `custom` is a registered native control: the overlay is built by a factory
+    // looked up under `factory_id` in the design-control registry
     // (register_design_control_factory). If no factory is registered the element
     // renders inert (the baked SVG underneath always shows) and the importer
     // diagnoses it — a custom control never blanks or silently mis-renders.
@@ -130,12 +129,11 @@ struct DesignFrameElement {
     std::string source_node_id;
 };
 
-// ── Custom-control factory registry (P7 Tier-3) ──────────────────────────────
-// The "one piece neither glint nor reflex provides": a runtime name→View table
-// so a design's genuinely-novel control resolves to a registered native view
-// instead of a silent-knob. A host (or a shared package — P8) registers a factory
-// under an id; the importer emits a Kind::custom element carrying that id; the
-// DesignFrameView builds the overlay by looking the factory up.
+// ── Custom-control factory registry ──────────────────────────────────────────
+// Runtime name→View table for genuinely novel controls in imported designs. A
+// host or shared package registers a factory under an id; the importer emits a
+// Kind::custom element carrying that id; DesignFrameView builds the overlay by
+// looking the factory up.
 
 // Geometry + opaque props handed to a custom-control factory so it can build and
 // bind its View. Panel coordinates (the same space DesignFrameView positions
@@ -198,10 +196,9 @@ bool suppress_svg_glyph_at(std::string& svg, float x, float y, float w, float h)
 // typed element list. This is the faithful-vector design-import lane's view: the
 // importer materializes one of these per imported frame.
 //
-// B1 scope: render + crop + interactive knobs (drag to turn). Each drag patches
-// only the dragged knob's needle in the SVG and repaints. The SVG is currently
-// re-rendered per repaint (SkSVGDOM rebuilds the DOM each draw_svg call) — fine
-// at interactive rates here, but a parsed-DOM cache is a planned optimization.
+// Each drag patches only the dragged knob's needle in the SVG and repaints. The
+// SVG is currently re-rendered per repaint (SkSVGDOM rebuilds the DOM each
+// draw_svg call), which is acceptable at interactive rates for this view.
 class DesignFrameView : public View {
 public:
     // `svg` is the full SVG document. The panel (the design body the window
@@ -399,7 +396,8 @@ private:
 // control drawn opaque over the design's tab strip (so it replaces the baked
 // tabs + highlight). Clicking a slot selects it and moves the highlight — the
 // "regular selection state" a static SVG can't provide. Styling approximates the
-// design's dark strip; pixel-exact theming is a follow-up.
+// design's dark strip; it is intentionally an approximation rather than
+// pixel-exact theming.
 class DesignTabGroup : public View {
 public:
     DesignTabGroup(std::vector<std::string> labels, int selected);

--- a/core/view/include/pulp/view/design_import.hpp
+++ b/core/view/include/pulp/view/design_import.hpp
@@ -41,10 +41,10 @@ class TextEditor;
 class XYPad;
 class WaveformView;
 
-// ── P7 import report ─────────────────────────────────────────────────────────
-// Surfaces the per-control resolution provenance the IR carries (P7-F0/F2) so a
-// low-confidence or conflicted control is SEEN at import time — in the CLI and as
-// a machine-readable JSON a CI gate can threshold — instead of discovered later.
+// ── Import report ────────────────────────────────────────────────────────────
+// Surfaces the per-control resolution provenance the IR carries so a
+// low-confidence or conflicted control is SEEN at import time — in the CLI and
+// as machine-readable JSON a CI gate can threshold — instead of discovered later.
 struct ImportReportEntry {
     std::string source_node_id;       ///< Figma node id (empty if unknown)
     std::string kind;                 ///< resolved interactive-element kind
@@ -74,16 +74,16 @@ ImportReport collect_import_report(const IRNode& root,
 std::string import_report_to_json(const ImportReport& report);
 std::string import_report_to_text(const ImportReport& report);
 
-// P7 render-placement verification (the structural half of the render-golden
-// gate). Walks the IR and flags interactive overlays that cannot render where
+// Render-placement verification. Walks the IR and flags interactive overlays
+// that cannot render where
 // they claim to: a degenerate extent (no hit radius and a zero-area box), or a
 // box that falls entirely outside the node's own render region [0,0,frame_w,
 // frame_h] (when the frame size is known, >0). A flagged control gets
 // verification_pass=false plus a recorded conflict, so collect_import_report
 // surfaces it and --fail-on-unresolved can gate on it. Mutates `root` in place;
 // returns the number of controls newly flagged. frame_w/h <= 0 means "unknown"
-// (skip the bounds half, keep the degenerate-extent check). The full pixel-level
-// golden diff is the render-path follow-up; this is the geometry-level check.
+// (skip the bounds half, keep the degenerate-extent check). This is a
+// geometry-level check, not a pixel diff.
 int apply_placement_verification(IRNode& root, float frame_w = 0.0f, float frame_h = 0.0f);
 
 struct NativeMaterializeOptions {

--- a/core/view/include/pulp/view/drag_drop.hpp
+++ b/core/view/include/pulp/view/drag_drop.hpp
@@ -64,10 +64,9 @@ public:
 // SEPARATE CONCERN from DropReceiver above. This is the platform-side
 // registration layer: register_drop_target() tells a native OS view (today only
 // the macOS NSView path in drag_drop_mac.mm) to advertise dragged types. It does
-// NOT route into the Pulp view tree. When macOS NSDraggingDestination delivery
-// is wired, this layer will feed the dispatch_* functions below and converge
-// with DropReceiver (tracked in the drag-drop hardening follow-up). New code
-// should implement DropReceiver, not DropTarget.
+// NOT route into the Pulp view tree. The dispatch_* functions below are the
+// convergence point for native delivery and DropReceiver. New code should
+// implement DropReceiver, not DropTarget.
 class DropTarget {
 public:
     virtual ~DropTarget() = default;

--- a/core/view/include/pulp/view/preferences_panel.hpp
+++ b/core/view/include/pulp/view/preferences_panel.hpp
@@ -24,7 +24,7 @@
 /// Headless-friendly: pages register `View` content but `PreferencesPanel`
 /// never paints in tests — it just owns the registry + active-index state.
 ///
-/// License-lineage note: the name is Pulp-native per the gap-doc rule.
+/// License-lineage note: the name is Pulp-native.
 
 #include <algorithm>
 #include <functional>

--- a/core/view/include/pulp/view/tooltip_window.hpp
+++ b/core/view/include/pulp/view/tooltip_window.hpp
@@ -27,7 +27,7 @@
 /// related is driven by `tick(dt)`, so unit tests can drain timers
 /// without sleeping.
 ///
-/// License-lineage note: the name is Pulp-native per the gap-doc rule.
+/// License-lineage note: the name is Pulp-native.
 
 #include <algorithm>
 #include <functional>

--- a/core/view/include/pulp/view/web_view.hpp
+++ b/core/view/include/pulp/view/web_view.hpp
@@ -132,9 +132,8 @@ WebViewOptions::FetchResource make_webview_directory_resource_fetcher(
 ///   * `"none"`        — `PULP_BUILD_WEBVIEW=OFF` or no runtime backend
 ///                       resolved on this OS at process start.
 ///
-/// Useful for the gap-doc audit (which backends actually wire up on the
-/// platforms Pulp ships to) and for callers that need to surface a clear
-/// "no embedded browser available on this OS" message.
+/// Useful for callers that need to surface a clear "no embedded browser
+/// available on this OS" message.
 std::string detect_webview_backend();
 
 /// Returns true if the host process has a usable WebView backend.

--- a/core/view/include/pulp/view/widget_skin_derive.hpp
+++ b/core/view/include/pulp/view/widget_skin_derive.hpp
@@ -9,14 +9,14 @@ namespace pulp::view {
 /// Derives native-widget skin styling from a captured design asset (a flat
 /// PNG exported by a design tool such as the Figma plugin).
 ///
-/// Rationale (Pulp issue #3191): the figma-plugin export ships a single flat
-/// PNG per recognised widget — a fader baked at its captured value, a meter
-/// baked at its captured level. Skinning the native widget with that image
-/// verbatim would FREEZE the control (the thumb / fill couldn't move). Instead
-/// we *sample* the captured pixels to recover the underlying style (track /
-/// fill / thumb colours for a fader; the gradient stops for a meter) and hand
-/// those to the widget, which redraws them procedurally — value-driven, so the
-/// thumb still moves with set_value() and the fill still tracks set_level().
+/// Rationale: the figma-plugin export ships a single flat PNG per recognised
+/// widget — a fader baked at its captured value, a meter baked at its captured
+/// level. Skinning the native widget with that image verbatim would FREEZE the
+/// control (the thumb / fill couldn't move). Instead we *sample* the captured
+/// pixels to recover the underlying style (track / fill / thumb colours for a
+/// fader; the gradient stops for a meter) and hand those to the widget, which
+/// redraws them procedurally — value-driven, so the thumb still moves with
+/// set_value() and the fill still tracks set_level().
 ///
 /// This is a GENERALIZABLE importer rule: it reads the design data (the actual
 /// exported pixels) and derives style. It hardcodes no per-instance colours,
@@ -42,7 +42,7 @@ struct FaderSkin {
     // around the dark channel above the thumb). Recovered as the brightest
     // low-saturation column pixel found on a track row, when it is meaningfully
     // lighter than the track fill itself. Lets the skinned fader stroke the
-    // track so it doesn't read as a flat dark slab. pulp #3192.
+    // track so it doesn't read as a flat dark slab.
     canvas::Color track_border_color{};
     bool has_track = false;
     bool has_fill = false;
@@ -52,7 +52,7 @@ struct FaderSkin {
     // Horizontal extents recovered from the captured art, in ASSET PIXELS
     // (the importer divides by the asset scale to get logical px). The track
     // is the thin low-saturation central column at a non-thumb row; the thumb
-    // is the widest opaque row (the silver slab). pulp #3191 width fix.
+    // is the widest opaque row (the silver slab).
     float track_width_px = 0.0f;
     float thumb_width_px = 0.0f;
     bool has_track_width = false;
@@ -61,14 +61,14 @@ struct FaderSkin {
     // in ASSET PIXELS. The captured PNG bakes the value-stack text below the
     // control, so the node's declared height spans control+labels; using it
     // verbatim stretches the fader to ~2× its real height. This is the real
-    // control extent. pulp #3191 follow-up.
+    // control extent.
     float housing_height_px = 0.0f;
     bool has_housing_height = false;
     // Normalised thumb position recovered from the capture (0 = bottom, 1 =
     // top), i.e. where the design actually drew the thumb. An audio fader's
     // value→position map is non-linear (a taper), so a linear (value-min)/(max-
     // min) seed lands the thumb in the wrong place; seeding from the captured
-    // position reproduces the design. pulp #3191.
+    // position reproduces the design.
     float thumb_position = 0.0f;
     bool has_thumb_position = false;
     bool any() const { return has_track || has_fill || has_thumb || has_thumb_border; }
@@ -84,7 +84,6 @@ struct MeterSkin {
     // Horizontal extent of the coloured bar, in ASSET PIXELS (the importer
     // divides by the asset scale to get logical px). Recovered from the bar's
     // own vertical region so faint label glyphs below it don't widen it.
-    // pulp #3191 width fix.
     float bar_width_px = 0.0f;
     bool has_bar_width = false;
     // Height of the meter housing (the tallest opaque run — the dark channel +
@@ -92,20 +91,19 @@ struct MeterSkin {
     // the value-stack text below the control, so the declared height spans
     // control+labels; using it verbatim stretches the meter to ~2× its real
     // height (and doubles the absolute fill). This is the real control extent.
-    // pulp #3191 follow-up.
     float housing_height_px = 0.0f;
     bool has_housing_height = false;
     // Fraction of the housing's cross-axis width occupied by the coloured fill
     // (colored-bar width / full housing width, 0..1). The captured meter recesses
     // a narrow coloured bar inside a wider dark housing slot; this ratio lets the
     // skinned meter reproduce that inset instead of painting edge-to-edge. 1.0
-    // when the fill spans the full housing. pulp #3191 follow-up.
+    // when the fill spans the full housing.
     float bar_fill_ratio = 1.0f;
     bool has_bar_fill_ratio = false;
     // Normalised fill level recovered from the capture (0 = empty, 1 = full):
     // the height of the contiguous saturated fill from the bottom of the bar.
     // Like the fader, a meter's dB→position map is non-linear, so seed the
-    // initial level from where the capture actually filled to. pulp #3191.
+    // initial level from where the capture actually filled to.
     float fill_level = 0.0f;
     bool has_fill_level = false;
     bool valid() const { return gradient.size() >= 2; }

--- a/core/view/platform/linux/webkitgtk_backend.cpp
+++ b/core/view/platform/linux/webkitgtk_backend.cpp
@@ -4,10 +4,9 @@
 // which on Linux uses WebKitGTK (`libwebkit2gtk-4.1.so.0`) plus GTK 3.
 // CHOC handles instantiation; this translation unit exists so:
 //
-//   1. The gap-doc audit can confirm WebKitGTK is actually resolvable at
-//      runtime on the user's distro (Ubuntu 22.04+, Fedora 38+, etc.
-//      ship 4.1 by default; some long-tail distros still carry only the
-//      legacy 4.0 ABI).
+//   1. The runtime probe can confirm WebKitGTK is actually resolvable on the
+//      user's distro (Ubuntu 22.04+, Fedora 38+, etc. ship 4.1 by default;
+//      some long-tail distros still carry only the legacy 4.0 ABI).
 //   2. `pulp::view::detect_webview_backend()` returns a stable identifier
 //      callers can use to surface a clear "WebKitGTK 4.1 not installed"
 //      message instead of crashing inside CHOC.
@@ -32,8 +31,8 @@ namespace {
 
 // Probe-once cache. We try the modern 4.1 ABI first (current stable),
 // then fall back to the legacy 4.0 ABI for older LTS distros. Either
-// works behind CHOC's WebKitGTK adapter — the gap-doc row only cares
-// that *some* WebKitGTK is reachable.
+// works behind CHOC's WebKitGTK adapter; callers only need to know that *some*
+// WebKitGTK ABI is reachable.
 struct WebKitGtkProbe {
     bool available = false;
     const char* soname = nullptr;

--- a/core/view/src/design_frame_view.cpp
+++ b/core/view/src/design_frame_view.cpp
@@ -16,7 +16,7 @@
 
 namespace pulp::view {
 
-// ── Custom-control factory registry (P7 Tier-3) ──────────────────────────────
+// ── Custom-control factory registry ──────────────────────────────────────────
 // UI-thread-only (see the header contract), so a plain function-local static map
 // with no locking is correct: registration at startup and lookup at overlay
 // build both run on the UI thread.
@@ -388,11 +388,10 @@ void DesignFrameView::build_overlays() {
             stepper->on_select = [this, i](int idx) { notify_choice(i, idx); };
             widget = std::move(stepper);
         } else if (e.kind == DesignFrameElement::Kind::custom) {
-            // P7 Tier-3: a registered native control. Build the overlay via the
-            // factory looked up under factory_id. If none is registered the
-            // element stays inert — the baked SVG underneath still renders, so a
-            // custom control never blanks (the importer diagnosed the gap at
-            // materialize time). UI-thread-only, matching the registry contract.
+            // Registered native control. Build the overlay via the factory
+            // looked up under factory_id. If none is registered the element stays
+            // inert — the baked SVG underneath still renders, so a custom control
+            // never blanks. UI-thread-only, matching the registry contract.
             auto& reg = design_control_registry();
             const auto it = reg.find(e.factory_id);
             if (it != reg.end() && it->second) {

--- a/core/view/src/design_import_native_common.cpp
+++ b/core/view/src/design_import_native_common.cpp
@@ -951,7 +951,7 @@ std::string asset_uri(const IRAssetRef& asset) {
     return {};
 }
 
-// ── Faithful-vector import (Plan B): resolve an SVG asset to its document text ─
+// ── Faithful-vector import: resolve an SVG asset to its document text ─────────
 // Percent-decode a `data:` payload (`%3C` → `<`, `+` stays literal in data URIs).
 std::string svg_percent_decode(std::string_view in) {
     std::string out;
@@ -1034,7 +1034,7 @@ std::vector<DesignFrameElement> to_frame_elements(
         el.text = e.text;
         el.value_left_align = e.value_left_align;
         el.value_y = e.default_value_y;
-        // custom (P7 Tier-3) — the factory id + opaque props.
+        // custom native control — the factory id + opaque props.
         el.factory_id = e.factory_id;
         el.custom_props = e.custom_props;
         // Carry the design-source node id to the live element so the inspector's
@@ -1068,9 +1068,9 @@ std::unique_ptr<View> make_faithful_svg_frame(const IRNode& node,
             asset_id.empty() ? std::optional<std::string>("svg_asset_id") : std::nullopt));
         return nullptr;
     }
-    // P7 Tier-3: a custom control whose factory isn't registered renders inert
-    // (the baked SVG underneath still shows). Diagnose it so the gap is SEEN and
-    // never becomes a silent knob.
+    // A custom control whose factory isn't registered renders inert (the baked
+    // SVG underneath still shows). Diagnose it so the gap is SEEN and never
+    // becomes a silent knob.
     for (const auto& ie : node.interactive_elements) {
         if (ie.kind != InteractiveElementKind::custom) continue;
         if (ie.factory_id.empty() || !has_design_control_factory(ie.factory_id)) {
@@ -1747,10 +1747,10 @@ std::unique_ptr<View> materialize_node(const IRNode& node,
                                        std::string_view path,
                                        std::optional<LayoutDirection> parent_direction,
                                        std::vector<ImportDiagnostic>& diagnostics) {
-    // Faithful-vector lane (Plan B): render this node's own SVG export via
-    // DesignFrameView and overlay native interaction from the typed element
-    // list. Falls through to normal materialization (with a diagnostic) if the
-    // SVG asset can't be resolved, so a bad asset degrades rather than blanks.
+    // Faithful-vector lane: render this node's own SVG export via DesignFrameView
+    // and overlay native interaction from the typed element list. Falls through
+    // to normal materialization (with a diagnostic) if the SVG asset can't be
+    // resolved, so a bad asset degrades rather than blanks.
     if (node.render_mode == NodeRenderMode::faithful_svg) {
         if (auto frame = make_faithful_svg_frame(node, manifest, path, diagnostics))
             return frame;

--- a/core/view/src/widget_bridge/svg_api.cpp
+++ b/core/view/src/widget_bridge/svg_api.cpp
@@ -88,8 +88,8 @@ void WidgetBridge::register_svg_api(std::function<canvas::Color(const std::strin
             if (value.empty()) w->clear_fill_gradient();
             else               w->set_fill_gradient(std::move(value));
         }
-        // SvgRect / SvgLine - gradient fills follow up; bridge fn is a
-        // no-op for those widget types so consumers don't crash.
+        // SvgRect / SvgLine gradient fills are intentionally a no-op for those
+        // widget types so consumers don't crash.
         return choc::value::Value();
     });
 

--- a/core/view/src/widget_skin_derive.cpp
+++ b/core/view/src/widget_skin_derive.cpp
@@ -97,8 +97,8 @@ FaderSkin derive_fader_skin(const SkinImage& img) {
         out.track_color = to_color(low_sat[low_sat.size() / 6].second);
         out.has_track = true;
 
-        // Track outline (pulp #3192): the captured empty track is a dark
-        // channel that the design draws with a slightly lighter edge so it
+        // Track outline: the captured empty track is a dark channel that the
+        // design draws with a slightly lighter edge so it
         // doesn't read as a flat slab. We first try to RECOVER that edge by
         // scanning across a representative dark track row for the brightest
         // low-saturation pixel and comparing it to the fill at the row centre —
@@ -188,7 +188,7 @@ FaderSkin derive_fader_skin(const SkinImage& img) {
     // deepest stop and over-saturates the derived colour vs the fill's dominant
     // mid tone. Collect the saturated rows (sat > 40) and take the MEDIAN by
     // saturation so the derived colour is the dominant mid blue — matching the
-    // reference palette the harness compares against. pulp #3191 colour fix.
+    // reference palette the harness compares against.
     {
         std::vector<RGB> colored;
         for (auto& r : rows)
@@ -201,7 +201,7 @@ FaderSkin derive_fader_skin(const SkinImage& img) {
         }
     }
 
-    // ── Horizontal widths (pulp #3191) ───────────────────────────────────────
+    // ── Horizontal widths ───────────────────────────────────────────────────
     // Thumb width: the widest opaque row in the art region (the silver slab).
     // Track width: the opaque width at rows away from the thumb (the thin
     // track/fill column). Measured outward from cx so disjoint glyphs never
@@ -236,7 +236,7 @@ FaderSkin derive_fader_skin(const SkinImage& img) {
     }
 
     // Housing height = the control art region (track + thumb), excluding the
-    // value-stack text the design tool bakes below it. pulp #3191 follow-up.
+    // value-stack text the design tool bakes below it.
     if (bottom > top) {
         out.housing_height_px = static_cast<float>(bottom - top);
         out.has_housing_height = true;
@@ -283,7 +283,7 @@ MeterSkin derive_meter_skin(const SkinImage& img, int stop_count) {
 
     // How far the captured gradient filled the bar (0 = empty, 1 = full) — seed
     // the imported meter's initial level from this rather than a linear dB→
-    // position map. pulp #3191.
+    // position map.
     if (bottom > top + 1) {
         out.fill_level = std::clamp(
             static_cast<float>(fill_h) / static_cast<float>(bottom - top), 0.0f, 1.0f);
@@ -301,7 +301,7 @@ MeterSkin derive_meter_skin(const SkinImage& img, int stop_count) {
         out.gradient.push_back(to_color(pixel(img, cx, y)));
     }
 
-    // ── Bar / housing widths (pulp #3191) ─────────────────────────────────────
+    // ── Bar / housing widths ─────────────────────────────────────────────────
     // The captured art has TWO widths: the dark HOUSING slot (the full opaque
     // run in [top, bottom)) and the narrower COLOURED bar recessed inside it
     // (the saturated fill in [fill_top, fill_bottom]). The widget box should be
@@ -349,8 +349,7 @@ MeterSkin derive_meter_skin(const SkinImage& img, int stop_count) {
         }
     }
     // Housing height = the control art region (dark channel + coloured fill),
-    // excluding the value-stack text the design tool bakes below it. pulp #3191
-    // follow-up.
+    // excluding the value-stack text the design tool bakes below it.
     if (bottom > top) {
         out.housing_height_px = static_cast<float>(bottom - top);
         out.has_housing_height = true;

--- a/core/view/src/widgets/visualizers.cpp
+++ b/core/view/src/widgets/visualizers.cpp
@@ -1,5 +1,5 @@
-// Visualizer widget implementations split from widgets.cpp. Public
-// declarations stay in core/view/include/pulp/view/widgets.hpp.
+// Visualizer widget implementations. Public declarations stay in
+// core/view/include/pulp/view/widgets.hpp.
 
 #include <pulp/view/widgets.hpp>
 #include <pulp/view/animation.hpp>
@@ -381,10 +381,7 @@ void Meter::paint(canvas::Canvas& canvas) {
         // So sample the gradient across the FILL region (0 at the fill bottom,
         // 1 at the fill top) rather than against absolute meter height. That
         // makes the fill top read warm/red — matching the capture — while the
-        // fill still reveals more of the SAME ramp as the level moves. pulp
-        // #3191 follow-up: previously `pos` was keyed off absolute meter height,
-        // so a partial fill only ever exposed the lower (green→yellow) stops and
-        // the warm top was clipped away above the fill.
+        // fill still reveals more of the SAME ramp as the level moves.
         //
         // Horizontal inset is derived from the captured bar-vs-housing ratio so
         // the colored bar reads as a narrower fill recessed inside the darker


### PR DESCRIPTION
## Summary
- trim stale roadmap, issue, and follow-up breadcrumbs from view/design-import/widget-skin/WebView/drag-drop/FFT source comments
- preserve current rationale and behavioral constraints where the comments still document live invariants
- keep this as one batched source-comment hygiene PR instead of per-file PRs

## Validation
- RepoPrompt Oracle classification pass over WebView/design-import/FFT/component comments
- RepoPrompt Oracle classification pass over widget-skin/drag-drop/SVG/visualizer comments
- stale-marker scan over touched files: clean
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD`
- comment-only guard over C++/header diff
- `tools/scripts/gates.sh refs/remotes/origin/main`
- `autoreview --mode local --reviewers codex,claude`: clean
- direct pre-push: mapped-path checks accepted comment-only skip trailers; pre-push gates clean
- interrupted overbroad local full-test pre-push run at 1,598/10,418 after all completed tests passed; GitHub CI is the merge gate


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed stale roadmap and internal issue breadcrumbs from source comments across view/design-import/WebView/drag-drop/FFT/widget-skin, while keeping concise rationale where it documents live behavior. No functional changes; comment-only hygiene to reduce noise and improve readability.

<sup>Written for commit fc1b899063e1e45a8e296c069787863c889dc427. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

