### PR TITLE
docs(tools,test): trim stale provenance comments

### DIFF
--- a/test/test_partial_rendering_poc.cpp
+++ b/test/test_partial_rendering_poc.cpp
@@ -47,10 +47,10 @@ TEST_CASE("partial-rendering POC: clear() resets dirty state and advances frame 
 
 TEST_CASE("partial-rendering POC: single request_repaint(rect) → union equals that rect, no full repaint",
           "[render][partial-render]") {
-    // This is the per-View / per-widget invalidation path the follow-up partial-rendering slice
-    // will plumb through. The the host wiring still calls
-    // invalidate_all(), but the tracker contract must support the
-    // rect path so the follow-up partial-rendering slice doesn't require a tracker API change.
+    // This is the per-View / per-widget invalidation path used by
+    // partial repaint callers. Host wiring may still choose
+    // invalidate_all(), but the tracker contract must keep the rect
+    // path stable so callers do not need a tracker API change.
     DirtyTracker dt;
     dt.clear();  // start clean
 
@@ -93,12 +93,11 @@ TEST_CASE("partial-rendering POC: two disjoint invalidations coalesce to boundin
 
 TEST_CASE("partial-rendering POC: invalidate_all() always wins, matching the pump-driver path",
           "[render][partial-render]") {
-    // Codex review correction 2: animation / FrameClock pump drivers
-    // call tracker_.invalidate_all() because they mutate visual state
-    // without going through request_repaint(). This test pins that
-    // contract: invalidate_all() must override and clear any pending
-    // partial rects so the the follow-up partial-rendering slice clip would degrade to full-screen
-    // (which is safe; better than missing pixels).
+    // Animation / FrameClock pump drivers call tracker_.invalidate_all()
+    // because they mutate visual state without going through
+    // request_repaint(). This test pins that contract: invalidate_all()
+    // must override and clear any pending partial rects so clipping
+    // degrades to full-screen, which is safe and avoids missed pixels.
     DirtyTracker dt;
     dt.clear();
     dt.set_viewport(800, 600);
@@ -115,9 +114,9 @@ TEST_CASE("partial-rendering POC: invalidate_all() always wins, matching the pum
 
 TEST_CASE("partial-rendering POC: area threshold escalates partial → full when many rects accumulate",
           "[render][partial-render]") {
-    // The host pushes one invalidate_all per repaint() today, so the
-    // area-threshold escalation is mostly a the follow-up partial-rendering slice concern. Test it
-    // here anyway so the contract doesn't quietly drift.
+    // The host pushes one invalidate_all per repaint() today, so
+    // area-threshold escalation mostly protects partial repaint callers.
+    // Test it here anyway so the contract does not quietly drift.
     DirtyTracker dt;
     dt.clear();
     dt.set_viewport(100, 100);  // tiny viewport, 60% = 6000 sq px

--- a/tools/scripts/install.sh
+++ b/tools/scripts/install.sh
@@ -112,12 +112,10 @@ if [ -x "${INSTALL_DIR}/pulp-mcp" ]; then
     info "Installed: pulp-mcp (Claude Code plugin MCP server)"
 fi
 
-# #2087: Pulp users running `curl install.sh | sh` historically ended
-# up with a fresh CLI but no SDK. Any project then built against
-# whatever stale ~/.pulp/sdk/<old>/ they had — sometimes months behind
-# — silently missing every framework fix in between (Spectr was the
-# visible victim). Auto-install the latest SDK matching the CLI's own
-# version so install.sh leaves the user with a coherent CLI+SDK pair.
+# The installer must leave curl-installed users with a coherent CLI+SDK
+# pair. Without the matching SDK install, existing projects can build
+# against an old ~/.pulp/sdk/<old>/ and silently miss framework fixes
+# even though the CLI itself updated successfully.
 #
 # Failure mode: SDK install can fail on a transient network error.
 # Don't fail the whole install — the CLI is still usable; the user can

--- a/tools/scripts/sign-notarize-auv3-mac.sh
+++ b/tools/scripts/sign-notarize-auv3-mac.sh
@@ -71,7 +71,7 @@ echo "   .appex     = $APPEX"
 echo "   .framework = $FRAMEWORK"
 echo "   cert       = $APP_CERT"
 
-# Default entitlements — match the templates shipped with Phase 3.5.
+# Entitlement paths are opt-in; empty values sign without an entitlements file.
 APPEX_ENTITLEMENTS="${APPEX_ENTITLEMENTS:-}"
 HOST_ENTITLEMENTS="${HOST_ENTITLEMENTS:-}"
 

--- a/tools/scripts/test_version_bump_check_extra.py
+++ b/tools/scripts/test_version_bump_check_extra.py
@@ -53,11 +53,11 @@ class VersionFileIoTests(unittest.TestCase):
             self.assertIsNone(vbc.read_version(repo, vbc.VersionFile("missing", "json_field", "version")))
 
     def test_json_path_kind_walks_nested_arrays_and_objects(self) -> None:
-        # pulp #1962-followup — marketplace.json has both a top-level
-        # `.version` and a nested `.plugins[0].version`. The Claude Code
-        # marketplace reads the nested one, so plugin bumps must update
-        # both. Cover read + write + the missing-segment fallthrough that
-        # keeps the gate advisory rather than crashing on shape drift.
+        # marketplace.json has both a top-level `.version` and a nested
+        # `.plugins[0].version`. The Claude Code marketplace reads the
+        # nested one, so plugin bumps must update both. Cover read + write
+        # + the missing-segment fallthrough that keeps the gate advisory
+        # rather than crashing on shape drift.
         with tempfile.TemporaryDirectory() as td:
             repo = pathlib.Path(td)
             (repo / "marketplace.json").write_text(
@@ -88,11 +88,11 @@ class VersionFileIoTests(unittest.TestCase):
             self.assertFalse(vbc.write_version(repo, empty, "9.9.9"))
 
     def test_marketplace_plugins_version_stays_in_sync_with_top_level(self) -> None:
-        # pulp #1962-followup — assert versioning.json registers BOTH the
-        # top-level marketplace.json `.version` AND the nested
-        # `.plugins[0].version` for the plugin surface. If a future
-        # refactor drops the nested entry, Claude Code's marketplace
-        # silently ships a stale plugin version and we never notice.
+        # Assert versioning.json registers BOTH the top-level
+        # marketplace.json `.version` AND the nested `.plugins[0].version`
+        # for the plugin surface. If a future refactor drops the nested
+        # entry, Claude Code's marketplace silently ships a stale plugin
+        # version and we never notice.
         repo = pathlib.Path(vbc.__file__).resolve().parents[2]
         cfg_path = repo / "tools/scripts/versioning.json"
         cfg = json.loads(cfg_path.read_text())

--- a/tools/scripts/version_consistency_check.py
+++ b/tools/scripts/version_consistency_check.py
@@ -6,8 +6,8 @@ and a plugin version in `.claude-plugin/plugin.json` + `marketplace.json`.
 CHANGELOG.md carries the same SDK version in its newest `## [X.Y.Z]` heading
 once the release lands. If a PR's CHANGELOG entry advertises a version that
 isn't reflected in CMakeLists.txt, the next auto-release tag won't fire and
-the entry sits orphaned (which is what triggered Codex P2 on PR #2331:
-CHANGELOG said `[0.138.0]` while CMakeLists was still at `0.137.1`).
+the entry sits orphaned; for example, CHANGELOG `[0.138.0]` with
+CMakeLists VERSION `0.137.1` would never produce the advertised tag.
 
 This script reads all four files and verifies:
   1. CMakeLists.txt's `project(Pulp VERSION X.Y.Z)` line is present.
@@ -41,9 +41,8 @@ def read_plugin_versions() -> tuple[str, str, str]:
     marketplace.json::plugins[0].version). The marketplace top-level
     `version` and the nested `plugins[0].version` BOTH exist in
     Pulp's manifest — the version-bump tooling and cmd_version.cpp
-    each consume one, so they must agree. Codex P2 on PR #2341
-    flagged the gap where this script only read the top-level and
-    a future bump could leave `plugins[0].version` stale."""
+    each consume one, so they must agree. Reading only the top-level
+    value would let a future bump leave `plugins[0].version` stale."""
     plugin = json.loads(
         (REPO_ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
     )
@@ -101,9 +100,8 @@ def main() -> int:
                 f"CHANGELOG top entry [{changelog_version}] advertises a version"
                 f" higher than CMakeLists VERSION {cmake_version}. auto-release tags"
                 " from CMakeLists VERSION, so the CHANGELOG entry would sit orphaned"
-                " until the next legit bump. This is the drift Codex P2 on #2331"
-                " flagged: a 'chore: bump versions' commit that silently no-op'd on"
-                " CMakeLists and only mutated CHANGELOG."
+                " until the next legitimate bump. This catches a bump commit that"
+                " silently no-ops on CMakeLists and only mutates CHANGELOG."
             )
         # cmake_version > changelog_version is the post-bump pre-regen window;
         # no failure — the auto-release-bot CHANGELOG regen will close it.


### PR DESCRIPTION
## Summary

- refresh partial-rendering DirtyTracker comments so they describe the current contract instead of old follow-up/review provenance
- trim stale issue/phase breadcrumbs from installer, AUv3 signing, and version metadata comments
- preserve the useful rationale around SDK pairing, entitlement behavior, marketplace nested version sync, and CHANGELOG/CMake drift

## Validation

- RepoPrompt/rp-cli: created rooted context for this worktree and selected all edited files; Oracle review failed twice with provider 500, so final review used autoreview panel instead
- `rg -n -C 1 'follow-up partial-rendering slice|The the host wiring|the the follow-up|a the follow-up|Phase 3\.5|#2087|#1962-followup|Codex P[0-9]|Codex review correction' ...` clean for edited files
- `git diff --check`
- comment/docstring-only heuristic over the edited diff
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD`
- `tools/scripts/gates.sh refs/remotes/origin/main`
- `python3 -m unittest tools.scripts.test_version_bump_check_extra.VersionFileIoTests.test_json_path_kind_walks_nested_arrays_and_objects tools.scripts.test_version_bump_check_extra.VersionFileIoTests.test_marketplace_plugins_version_stays_in_sync_with_top_level`
- `$HOME/.agents/skills/autoreview/scripts/autoreview --mode local --reviewers codex,claude` clean
- `$HOME/.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD --reviewers codex,claude` clean
- direct push pre-push gates passed; local diff-cover/full build intentionally skipped because `/Volumes/Workshop` is at 100% capacity with ~4.6 GiB free and the previous Shipyard path failed with `No space left on device`

Known pre-existing validation note:

- `python3 tools/scripts/test_version_bump_check_extra.py` fails the same way from the `origin/main` copy of that file on this machine: `test_apply_bumps_ignores_none_and_patch_verdicts` expects `already_bumped` not to be called. This patch changes only comments/docstrings in that file; the focused touched tests above pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed stale provenance comments across tests and tooling to match current contracts and remove outdated issue breadcrumbs. Clarifies SDK pairing in the installer, AUv3 entitlements behavior, and versioning gate rationale; no functional changes.

- **Refactors**
  - DirtyTracker partial-rendering tests: refreshed comments to reflect current invalidate_all/rect behavior and area-threshold intent.
  - `tools/scripts/install.sh`: clarified auto-install of matching SDK to keep CLI+SDK in sync and non-fatal handling of SDK install failures.
  - `tools/scripts/sign-notarize-auv3-mac.sh`: clarified that entitlements are opt-in; empty values sign without an entitlements file.
  - `tools/scripts/test_version_bump_check_extra.py` and `tools/scripts/version_consistency_check.py`: clarified marketplace nested version sync and CHANGELOG/CMake drift checks.

<sup>Written for commit 3be9875300e4b29a8b6778e5939f238618309325. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

