### PR TITLE
docs(ci): trim workflow provenance comments

### DIFF
--- a/.github/workflows/install-consumer-smoke.yml
+++ b/.github/workflows/install-consumer-smoke.yml
@@ -1,7 +1,7 @@
 name: Install consumer smoke
 
-# Pulp #2087 piggyback. Catches the class of bug where in-tree builds
-# work but installed-SDK consumers break — the original symptom: an
+# Catches the class of bug where in-tree builds work but installed-SDK
+# consumers break - for example, an
 # `include(${CMAKE_SOURCE_DIR}/tools/cmake/PulpLinkFontconfig.cmake)`
 # inside PulpUtils.cmake resolved to the *consumer's* source tree
 # during `find_package(Pulp)`, blocking every downstream Linux/Android
@@ -109,10 +109,10 @@ jobs:
           PREFIX="${RUNNER_TEMP}/pulp-install"
           cmake --install build --prefix "$PREFIX" --config Release
           ls -la "$PREFIX"/lib/cmake/Pulp/
-          # The piggyback fix: PulpLinkFontconfig.cmake MUST ship alongside
-          # PulpUtils.cmake. Pre-fix this file was missing and consumers
-          # blew up at configure-time with a CMAKE_SOURCE_DIR path that
-          # resolved to their own source tree.
+          # PulpLinkFontconfig.cmake MUST ship alongside PulpUtils.cmake.
+          # If this helper is missing, consumers fail at configure time
+          # with a CMAKE_SOURCE_DIR path that resolves to their own
+          # source tree.
           test -f "$PREFIX/lib/cmake/Pulp/PulpLinkFontconfig.cmake"
           test -f "$PREFIX/lib/cmake/Pulp/PulpUtils.cmake"
         shell: bash
@@ -124,12 +124,11 @@ jobs:
           rm -rf "$CONSUMER"
           mkdir -p "$CONSUMER/src"
           # Minimal consumer: actually invoke `pulp_add_plugin(...)` so
-          # `_pulp_add_standalone` runs, which is the function body where
-          # the #2087 piggyback bug lived (an include of
-          # PulpLinkFontconfig.cmake via the wrong CMake path variable).
+          # `_pulp_add_standalone` runs, which is the function body that
+          # includes PulpLinkFontconfig.cmake and therefore exercises the
+          # install-tree path variables.
           # A pure find_package + target-existence check leaves that path
-          # untested — and that's exactly the gap Codex P2 flagged on
-          # PR #2091 (consumer smoke would have passed on a broken SDK).
+          # untested and would pass even when the installed SDK is broken.
           #
           # The plugin source file is intentionally trivial: this is a
           # configure-time smoke (not a build-time smoke), so we only
@@ -156,11 +155,11 @@ jobs:
               message(FATAL_ERROR "find_package(Pulp) did not expose Pulp::view")
           endif()
           # ACTUALLY invoke pulp_add_plugin so _pulp_add_standalone runs.
-          # This is the configure-time path where #2087 piggyback's
-          # PulpLinkFontconfig.cmake include lived; a pure target-check
-          # would silently miss the regression. CLAP-only formats keeps
-          # the workflow runner light and works on linux + macos without
-          # extra SDK dependencies.
+          # This is the configure-time path where the
+          # PulpLinkFontconfig.cmake include runs; a pure target-check
+          # would silently miss the regression. CLAP-only formats keeps the
+          # workflow runner light and works on linux + macos without extra
+          # SDK dependencies.
           pulp_add_plugin(PulpConsumerSmoke
               PLUGIN_NAME "PulpConsumerSmoke"
               MANUFACTURER "PulpSmoke"
@@ -180,9 +179,8 @@ jobs:
       - name: Verify CMake config files don't reach into Pulp's source tree
         # Defense in depth: grep the installed CMake config files for
         # any ${CMAKE_SOURCE_DIR}/tools/cmake/... or similar
-        # Pulp-internal path. That pattern was the #2087 piggyback bug —
-        # the include resolved to the *consumer's* source tree, not
-        # Pulp's, at consume-time.
+        # Pulp-internal path. That pattern resolves to the *consumer's*
+        # source tree, not Pulp's, at consume-time.
         #
         # Intentional ${CMAKE_SOURCE_DIR} uses (the consumer's own
         # android/, external/skia-build/ etc. — i.e., paths the consumer
@@ -193,13 +191,13 @@ jobs:
           PREFIX="${RUNNER_TEMP}/pulp-install"
           # Patterns that indicate a Pulp-internal path that no consumer
           # has any reason to own. If a future commit adds one of these,
-          # the same class of bug as #2087 has reappeared.
+          # the installed SDK is leaking source-tree assumptions again.
           set +e
           bad=$(grep -nE '\$\{CMAKE_SOURCE_DIR\}/tools/(cmake|scripts)/|\$\{CMAKE_SOURCE_DIR\}/core/' \
                   "$PREFIX"/lib/cmake/Pulp/*.cmake 2>/dev/null)
           set -e
           if [ -n "$bad" ]; then
-            echo "::error::Installed CMake config files reach into Pulp's source tree via CMAKE_SOURCE_DIR — will resolve to consumer's source tree, not Pulp's. Class of bug as #2087 piggyback."
+            echo "::error::Installed CMake config files reach into Pulp's source tree via CMAKE_SOURCE_DIR — will resolve to consumer's source tree, not Pulp's."
             echo "$bad"
             echo
             echo "Fix: inside a function body, use CMAKE_CURRENT_FUNCTION_LIST_DIR. At top level of a config file, use CMAKE_CURRENT_LIST_DIR. See tools/cmake/PulpUtils.cmake's _pulp_add_standalone for the pattern."

--- a/.github/workflows/macos-cross-advisory.yml
+++ b/.github/workflows/macos-cross-advisory.yml
@@ -27,15 +27,14 @@ name: macOS Cross (advisory)
 #  - Validate signatures.
 #
 # These steps require either licensed Apple inputs (SDK) or a real Mac
-# (`codesign`, AU registration, `auval`). Promotion to a full advisory
-# build job (Phase 5 step 3 in the plan) is gated on standing up a
+# (`codesign`, AU registration, `auval`). Promotion to a real cross-build
+# job is gated on standing up a
 # self-hosted Linux runner that already has the private SDK and
 # osxcross prefix on disk. When that runner exists, add a second
 # `cross-build` job that calls into the private infra repo's scripts;
 # do not inline the bootstrap here.
 #
 # Plan: planning/2026-05-24-linux-hosted-macos-arm64-cross-lane.md
-# Phase: 5 — CI and artifact publication (scaffold step).
 
 on:
   pull_request:
@@ -124,7 +123,7 @@ jobs:
           an osxcross prefix, which live in a private infra repo and
           on the private Linux host.
 
-          Promotion path (planning/2026-05-24-linux-hosted-macos-arm64-cross-lane.md):
+          Promotion path:
           1. **(this job)** scaffold check, advisory.
           2. Self-hosted Linux runner with pinned osxcross + private
              SDK calls into the private infra scripts.

--- a/.github/workflows/ruleset-drift-check.yml
+++ b/.github/workflows/ruleset-drift-check.yml
@@ -1,8 +1,8 @@
 name: Ruleset Drift Check
 
-# Issue #462. Detects drift between the checked-in branch-protection intent
-# (.github/rulesets/main-protection.json) and the live ruleset configured on
-# GitHub. Keeps the UI and the repo honest.
+# Detects drift between the checked-in branch-protection intent
+# (.github/rulesets/main-protection.json) and the live ruleset configured
+# on GitHub. Keeps the UI and the repo honest.
 #
 # Behavior:
 #   - On pull requests that touch .github/rulesets/** or this workflow:

--- a/tools/scripts/host_pump_lint.py
+++ b/tools/scripts/host_pump_lint.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""host_pump_lint.py — guard against the pulp-internal #71 foot-gun.
+"""host_pump_lint.py — guard against the host idle-pump foot-gun.
 
 Every live-host main.cpp (examples/design-tool, examples/ui-preview, future
 hosts) must drive BOTH halves of the WidgetBridge idle pump on every tick:
@@ -11,8 +11,8 @@ Calling only the first half silently freezes every imported app's polling
 state path: setInterval(fn, N) returns a valid id but `fn` never fires. The
 underlying chart/canvas (which paints from a separate ref store) keeps
 updating, but every React label that reads polled state stays frozen.
-See scripted_ui.cpp:67-81 for the contract documentation; see PR #1957
-follow-up commit for the concrete regression.
+The contract is documented next to the bridge implementation in
+scripted_ui.cpp.
 
 This lint scans every examples/*/main.cpp (and other host main files we
 extend the map to) and flags any call to poll_async_results() whose
@@ -99,9 +99,9 @@ def main() -> int:
         print(
             "\nFix: add `bridge->service_frame_callbacks();` immediately after "
             "the `poll_async_results()` call in the same handler block.\n"
-            "Background: pulp-internal #71. Without the second half, every "
-            "imported app's setTimeout/setInterval queues forever and any "
-            "polling-driven React state freezes.\n"
+            "Background: without the second half, every imported app's "
+            "setTimeout/setInterval queues forever and any polling-driven "
+            "React state freezes.\n"
             "Genuine one-shot CLI exemption: append "
             f'`// {SKIP_MARKER} — <reason>` to the line.',
             file=sys.stderr,

--- a/tools/scripts/test_compat_sync_check.py
+++ b/tools/scripts/test_compat_sync_check.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for compat_sync_check.py (#1029).
+"""Tests for compat_sync_check.py.
 
 Two layers:
     1. Unit-style — pure-Python evaluation of compute_findings,
@@ -477,8 +477,7 @@ class IntegrationTests(unittest.TestCase):
         self.assertEqual(code, 0)
 
     def test_empty_section_tolerance_smoke(self) -> None:
-        """Critical: an empty compat.json section must NOT false-
-        positive while #1027 is still open."""
+        """Critical: an empty compat.json section must NOT false-positive."""
         # Touch widget_bridge.cpp (wildcard prefix → expands to all
         # KNOWN_PREFIXES). The compat-json requirement should pass
         # for every prefix because all sections are empty stubs. The
@@ -541,10 +540,10 @@ if __name__ == "__main__":
     unittest.main(verbosity=2)
 
     def test_unknown_kind_in_map_raises_at_load(self) -> None:
-        # pulp #1171 (Codex P2 on #1068) — a typo'd `kind` like "tests"
-        # used to be silently dropped, leaving CI green while a required
-        # compat-artifact gate was effectively disabled. The fix raises
-        # at config-load time so the misconfiguration fails loudly.
+        # A typo'd `kind` like "tests" used to be silently dropped, leaving
+        # CI green while a required compat-artifact gate was effectively
+        # disabled. The fix raises at config-load time so the
+        # misconfiguration fails loudly.
         cfg = self.tmp / "tools/scripts/compat_path_map.json"
         data = json.loads(cfg.read_text())
         data["paths"].setdefault("core/view/src/scroll_view.cpp", []).append(


### PR DESCRIPTION
## Summary
- trim stale issue/PR/Codex/phase breadcrumbs from selected CI workflow comments
- keep the current installed-SDK, ruleset drift, macOS cross-lane, host pump, and compat-sync invariants intact
- add Skill-Update trailer because CI workflow changes are comment-only and do not change CI behavior

## Validation
- RepoPrompt/rp-cli selection: focused on install-consumer-smoke, macos-cross-advisory, ruleset-drift-check, host_pump_lint, and test_compat_sync_check
- rg stale-marker scan on touched files
- git diff --check
- python3 YAML parse for touched workflows
- actionlint on touched workflows
- python3 -m py_compile tools/scripts/host_pump_lint.py tools/scripts/test_compat_sync_check.py
- python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD
- tools/scripts/gates.sh refs/remotes/origin/main
- python3 -m unittest tools.scripts.test_compat_sync_check.IntegrationTests.test_empty_section_tolerance_smoke
- local diff-cover/pre-push full run: 10418/10418 tests passed, diff coverage OK; second push used PULP_SKIP_DIFF_COVER=1 only to avoid duplicating that run
- autoreview --mode local --reviewers codex,claude: clean
- autoreview --mode commit --commit HEAD --reviewers codex,claude: clean after retrying a transient Claude 529

## Notes
- yamllint is not installed locally.
- Broader dense CI workflows (build.yml, auto-release.yml, workflow-lint.yml) are intentionally deferred to a separate CI-focused cleanup batch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed stale issue/PR breadcrumbs and tightened wording in CI workflow comments and script docstrings to reduce noise. No CI behavior or logic changed.

- **Refactors**
  - Workflows (`install-consumer-smoke.yml`, `macos-cross-advisory.yml`, `ruleset-drift-check.yml`): removed provenance references and clarified intent while keeping installed-SDK, ruleset drift, and macOS cross-lane checks intact.
  - Scripts (`tools/scripts/host_pump_lint.py`, `tools/scripts/test_compat_sync_check.py`): simplified docstrings and messages to remove internal IDs and clarify guidance.

<sup>Written for commit c6f9416ba74399c0d56e9197b8a3558c18b8e2b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

