### PR TITLE
docs(ci): trim workflow comment breadcrumbs

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -69,8 +69,8 @@ jobs:
               echo "skip=1" >> "$GITHUB_OUTPUT"
               exit 0
           fi
-          # pulp #1308 follow-up — honor `Version-Bump: skip reason="..."`
-          # the same way `Release: skip` is honored. Authors use this
+          # Honor `Version-Bump: skip reason="..."` the same way
+          # `Release: skip` is honored. Authors use this
           # trailer for fix/feat changes that genuinely don't bump the
           # SDK or plugin (e.g. JS-only changes to packages/pulp-react/
           # which versions independently via npm, or docs fixups
@@ -94,9 +94,9 @@ jobs:
           # in version_bump_check.py). Mirrors the same matching shape
           # as `_range_has_version_bump_skip_trailer()` in
           # tools/scripts/version_bump_check.py — including the
-          # requirement that the reason be NON-EMPTY (Codex P2 on the
-          # original #1310 fix; the earlier regex allowed bare
-          # `reason=` with no value, but the Python gate rejects it).
+          # requirement that the reason be NON-EMPTY. The Python gate
+          # rejects bare `reason=` with no value; this shell guard must
+          # stay in lockstep.
           # If the two layers disagreed on validity, an author could
           # write `reason=""` that passes here but fails at PR time
           # (or vice-versa) — making the bypass inconsistent.
@@ -132,8 +132,8 @@ jobs:
           #    squash-merge in quick succession and a queued run is
           #    cancelled (see 2026-04-19 cascade: v0.23.0 lost).
           #
-          # 2. Latest existing tag. #498 switched to this; fixed the
-          #    self-heal case but broke TWO other cases (Codex review):
+          # 2. Latest existing tag. This fixed the self-heal case but
+          #    broke TWO other cases:
           #
           #    a. `Release: skip` trailer — if a bump merges WITH the
           #       trailer, latest-tag stays at the older version. Next
@@ -181,11 +181,11 @@ jobs:
           # "eq", or "lt". Empty strings behave like "missing" — treat
           # as "lt" so HEAD always wins over nothing.
           #
-          # #501 shipped this with the Python body at column 1, which
-          # broke the YAML `run: |` block scalar (any line less-indented
-          # than the block ends the scalar). GitHub rejected the workflow
-          # file with "workflow file issue" on every push since — every
-          # auto-release run silently failed, so v0.23.1 never tagged.
+          # Keep the Python body inside a heredoc. A prior inline body at
+          # column 1 broke the YAML `run: |` block scalar (any line
+          # less-indented than the block ends the scalar), so GitHub
+          # rejected the workflow file with "workflow file issue" before
+          # any jobs could run.
           # Fix: use a heredoc that python3 reads from stdin so script
           # indentation is divorced from YAML indentation.
           semver_cmp() {
@@ -212,8 +212,8 @@ jobs:
           # NB: `git tag --list … | head -1` SIGPIPEs the tag walk (exit 141)
           # under `set -o pipefail` once the tag set is large enough that
           # `--sort` is still streaming when `head` closes the pipe — which is
-          # exactly what wedged every auto-release on 2026-06-08 after the day's
-          # version bumps grew the tag list. `for-each-ref --count=1` returns a
+          # exactly what wedges auto-release once the tag list grows large
+          # enough. `for-each-ref --count=1` returns a
           # single ref with no pipe, so there is no reader to close early.
           latest_sdk_tag=$(git for-each-ref --sort=-version:refname --format='%(refname:short)' --count=1 'refs/tags/v[0-9]*')
           latest_plugin_tag=$(git for-each-ref --sort=-version:refname --format='%(refname:short)' --count=1 'refs/tags/plugin-v[0-9]*')
@@ -223,14 +223,12 @@ jobs:
           plugin_tag=$(extract_json_version "${latest_plugin_tag:-HEAD~1}" .claude-plugin/plugin.json || true)
           plugin_after=$(extract_json_version HEAD .claude-plugin/plugin.json || true)
 
-          # #513 fix — trailer-aware bump detection. Walk history from
-          # HEAD backward to find the commit that set a given version
-          # file to its current value. If that bump commit carries
-          # `Release: skip`, the skip is sticky (permanent for that
-          # bumped value) and no future push re-evaluates it. Prior
-          # logic tried to approximate this using event.before and
-          # broke the self-heal case (v0.23.1 recovery on 2026-04-20
-          # showed the pattern).
+          # Trailer-aware bump detection. Walk history from HEAD backward
+          # to find the commit that set a given version file to its
+          # current value. If that bump commit carries `Release: skip`,
+          # the skip is sticky for that bumped value and no future push
+          # re-evaluates it. Approximating this with event.before breaks
+          # self-heal after cancelled intermediate release runs.
           find_bump_commit() {
               local file="$1"
               local extract="$2"
@@ -374,8 +372,7 @@ jobs:
       # release. The intent: if v0.101.7 is mid-build and we just tagged
       # v0.102.0, v0.101.7's artifacts are obsolete — users will only
       # ever install v0.102.0. Saves github-hosted macos-15 minutes and
-      # gets the latest release to users faster (see #2075 + the 2026-05-15
-      # v0.101.x saga that motivated this step).
+      # gets the latest release to users faster.
       #
       # Two opt-outs:
       #   1. vars.PULP_RELEASE_MODE=land-all — repo-wide disable
@@ -384,7 +381,7 @@ jobs:
       #
       # Cancelling sign-and-release.yml is important: it runs on the same
       # tag push and can resurrect a draft release after release-cli is
-      # cancelled (codex flagged this footgun in #2075).
+      # cancelled.
       #
       # Semver via stdlib regex, not packaging.version (PEP 440 ≠ SemVer)
       # and not `sort -V` (Pulp pre-release suffixes would be a future
@@ -438,16 +435,15 @@ jobs:
                   return None
               return r.stdout
 
-          # The 2026-05-18 starvation incident (pulp #2226 / this fix):
-          # the original supersede policy "cancel any tag strictly older
+          # The original supersede policy "cancel any tag strictly older
           # than NEW_TAG" cascaded when main moved faster than
           # release-cli.yml could finish. Every new tag cancelled the
           # previous tag's release-cli, and itself got cancelled by the
-          # NEXT tag, leaving 10 SDK versions (v0.111.0 → v0.115.0)
-          # tagged-but-never-published. No watchdog caught it because
-          # release-cli was `cancelled` (not `failure`), draft was
-          # deleted (so draft-stuck didn't fire), and tag existed (so
-          # cadence-check was happy).
+          # next tag, leaving SDK versions tagged-but-never-published.
+          # No watchdog caught it because release-cli was `cancelled`
+          # (not `failure`), the draft was deleted before the draft-stuck
+          # watchdog could fire, and the tag existed so cadence-check was
+          # satisfied.
           #
           # New policy: never cancel any tag ≥ the LATEST PUBLISHED
           # release. We only supersede builds that we already know are
@@ -585,11 +581,10 @@ jobs:
           echo "Tip subject: ${subject}"
 
           # Bail early for non-fix/feat — the no-tag outcome is correct
-          # for those. B1 (2026-05): classification now shells out to
+          # for those. Classification shells out to
           # `version_bump_check.py classify-subject` so the regex has a
-          # single source of truth. Previous inline-Python heredoc copied
-          # _FIX_FEAT_TITLE_RE verbatim and could silently drift; the
-          # lock-step risk was documented but not enforced.
+          # single source of truth instead of an inline copy that can
+          # silently drift.
           if ! python3 tools/scripts/version_bump_check.py classify-subject "$subject"; then
               echo "Tip is not a fix:/feat: — no-tag outcome is expected. Done."
               exit 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,11 +89,10 @@ jobs:
           WORKFLOW_DISPATCH_MACOS_SELECTOR: ${{ inputs.macos_runner_selector_json || '' }}
           LOCAL_MACOS_RUNS_ON_JSON: ${{ vars.PULP_LOCAL_MACOS_RUNS_ON_JSON || '' }}
           # BUSY threshold for macOS overflow. With one local runner,
-          # BUSY >= 1 would overflow as soon as any job is in flight —
-          # Codex flagged that as too aggressive (planning doc Step 2).
+          # BUSY >= 1 would overflow as soon as any job is in flight.
           # Default 2 means "local is fully saturated AND new work is
-          # coming"; when Plan A's 2nd local runner is added, bump to
-          # match the new capacity.
+          # coming"; if local runner capacity changes, keep this in
+          # lockstep with that capacity.
           LOCAL_MAC_OVERFLOW_THRESHOLD: ${{ vars.PULP_LOCAL_MAC_OVERFLOW_THRESHOLD || '2' }}
           # The runner label the overflow logic queries for `busy`. Must
           # match the label PULP_LOCAL_MACOS_RUNS_ON_JSON targets.
@@ -108,7 +107,7 @@ jobs:
           # NOTE: an *empty* variable value cannot disable overflow —
           # GitHub treats unset and empty identically and the `||` default
           # below re-fills it — so "local-only" is the explicit off
-          # switch, not emptiness (Codex P2 on #2451).
+          # switch, not emptiness.
           OVERFLOW_MACOS_RUNS_ON_JSON: ${{ vars.PULP_OVERFLOW_BUILD_MACOS_RUNS_ON_JSON || '["macos-15"]' }}
           # gh CLI auth for the overflow-busy-count probe.
           GH_TOKEN: ${{ github.token }}
@@ -155,19 +154,17 @@ jobs:
           #
           # Implementation note: `gh api .../actions/runners` requires
           # repo `Administration: Read` scope, which the default workflow
-          # GITHUB_TOKEN does not have. The first cut of this probe used
-          # that endpoint and fell back to BUSY=0 on every run — overflow
-          # never engaged (pulp #1935 post-merge finding). The second cut
-          # (pulp #1942) used `actions/runs?status=in_progress|queued`
-          # filtered to Build-and-Test runs as a proxy for "local Mac
-          # saturated" — but that over-counts: if 20 BAT runs are queued
-          # ALL routing to macos-15 (overflow), local sits idle yet the
-          # probe still reports BUSY=20 and routes the new PR to overflow
-          # too. Local participation drops to zero during deep queues
-          # (user feedback, pulp task #24).
+          # GITHUB_TOKEN does not have; falling back to BUSY=0 on that
+          # endpoint failure silently disables overflow. Counting
+          # Build-and-Test runs via `actions/runs?status=in_progress|queued`
+          # also over-counts:
+          # if many BAT runs are queued and all are already routing to
+          # macos-15 overflow, local sits idle yet the probe still reads
+          # as saturated and routes new PRs to overflow too. Local
+          # participation then drops to zero during deep queues.
           #
-          # This probe (pulp #2467 class) counts only the macOS legs
-          # ACTUALLY OCCUPYING a local M1 right now: a Build-and-Test
+          # This probe counts only the macOS legs ACTUALLY OCCUPYING a
+          # local M1 right now: a Build-and-Test
           # macOS job whose `status == "in_progress"` AND whose `labels`
           # include the local self-hosted label. Everything else counts
           # as 0:
@@ -178,15 +175,13 @@ jobs:
           #     not yet registered (matrix not expanded) or is still
           #     `queued` is NOT occupying an M1 — count 0.
           #
-          # The earlier cut (pulp #1942) enumerated in_progress + queued
-          # runs and PESSIMISTICALLY counted a not-yet-registered macOS
-          # job as local-busy. During a deep Actions queue (~250 runs)
-          # that over-counts catastrophically: hundreds of undispatched
+          # Counting in_progress + queued runs pessimistically treats
+          # not-yet-registered macOS jobs as local-busy. During a deep
+          # Actions queue that over-counts catastrophically: undispatched
           # queued runs all read as "local-busy", BUSY blows past the
-          # threshold, EVERY new macOS leg routes to github-hosted
-          # overflow, and the local M1 runners sit 100% idle while macOS
-          # work — the CI long-pole — starves on the contended
-          # github-hosted pool. Merges stalled ~80 minutes on 2026-05-20.
+          # threshold, every new macOS leg routes to github-hosted
+          # overflow, and the local M1 runners sit idle while macOS work
+          # starves on the contended github-hosted pool.
           #
           # The fix deliberately INVERTS the old pessimism: an
           # unregistered / queued / API-blip macOS job counts 0, not 1.
@@ -528,7 +523,7 @@ jobs:
       # Keep the ordinary build matrix out of sanitizer-owned build dirs so
       # cached CMake flags such as -fsanitize=address cannot bleed into it.
       PULP_BUILD_DIR: build-${{ matrix.key }}
-      # ── ccache correctness overrides (pulp #3504 follow-up) ──────────────
+      # ── ccache correctness overrides ─────────────────────────────────────
       # The self-hosted macOS runners' service env (~/actions-runner-*/.env)
       # sets CCACHE_DEPEND=true with the default compiler_check=mtime on a
       # ccache shared across all three runners. Depend mode skips the
@@ -537,8 +532,8 @@ jobs:
       # object gets served and corrupts unrelated TUs at once — observed as a
       # pure function (resolve_checkpoint_url) returning "" and other
       # change-unrelated tests failing on every PR while clean local Debug AND
-      # Release builds pass. #3504's build-dir guard does not touch ccache, so
-      # it cannot fix this. Force the safe path here (job env overrides the
+      # Release builds pass. Build-dir guards do not touch ccache, so force
+      # the safe path here (job env overrides the
       # runner-service .env for these steps):
       #   - compiler_check=content → key the compiler by content, not mtime;
       #     this also changes the cache-key namespace, so the existing
@@ -583,9 +578,9 @@ jobs:
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
-          # libfontconfig1-dev added in #1970: chrome/m144 Skia exposes
-          # fontconfig symbols (`FcInitLoadConfigAndFonts` et al.) that
-          # earlier Skia releases hid. Without the dev package,
+          # chrome/m144 Skia exposes fontconfig symbols
+          # (`FcInitLoadConfigAndFonts` et al.) that earlier Skia releases
+          # hid. Without the dev package,
           # `pkg_check_modules(FONTCONFIG fontconfig)` in
           # core/canvas/CMakeLists.txt comes up empty and the Linux link
           # step fails. Mirrors the matching fix in release-cli.yml.
@@ -613,7 +608,7 @@ jobs:
             wayland-protocols \
             ccache
 
-      # ── Namespace cache (per Namespace team telemetry, 2026-05-19) ──
+      # ── Namespace cache ─────────────────────────────────────────────────
       # Namespace cache volumes persist across runs on the same workspace,
       # cutting brew-install latency and ccache miss rates substantially.
       # Detection: Namespace selectors land in matrix.runs_on_json as
@@ -621,20 +616,19 @@ jobs:
       # vars.PULP_NAMESPACE_BUILD_*_RUNS_ON_JSON form configured today)
       # OR direct machine labels like "nscloud-macos-tahoe-arm64-6x14"
       # (documented in docs/guides/local-ci.md as an alternative).
-      # Codex P2 on #2399 flagged that a single "namespace" substring
-      # missed the nscloud-* form, so we check both prefixes.
+      # A single "namespace" substring misses the nscloud-* form, so we
+      # check both prefixes.
       #
-      # macOS-only restriction (fix-up to #2399 + #2402): the action
-      # hard-errors when run on a Namespace profile without cache
-      # volumes configured (observed on the Windows Namespace lane in
-      # PR #2376 — "nscloud-cache-action requires a cache volume to
-      # be configured"). Cache volumes are only configured for the
+      # macOS-only restriction: the action hard-errors when run on a
+      # Namespace profile without cache volumes configured
+      # ("nscloud-cache-action requires a cache volume to be configured").
+      # Cache volumes are only configured for the
       # macOS profile, and the cached paths here (brew, ~/Library/…)
       # are macOS-specific anyway. Windows uses choco + a different
       # ccache path, so it doesn't benefit from this step regardless.
       #
       # No-op on self-hosted Mac (already keeps caches on local disk)
-      # and github-hosted runners (have actions/cache via #420).
+      # and github-hosted runners (have actions/cache).
       - name: Namespace cache (brew + ccache + Pulp FetchContent)
         if: runner.os == 'macOS' && (contains(matrix.runs_on_json, 'namespace') || contains(matrix.runs_on_json, 'nscloud'))
         uses: namespacelabs/nscloud-cache-action@v1
@@ -648,8 +642,7 @@ jobs:
       # Without this `brew update`, any subsequent `brew install` fails
       # fast with: "You have disabled automatic updates and have not
       # updated today. Do not report this issue until you've run
-      # `brew update` and tried again." (PR #2399 — unblocks #2367,
-      # #2374, #2378, #2388 which all wedged on this on 2026-05-19.)
+      # `brew update` and tried again."
       # Local self-hosted Macs already keep brew warm between runs, but
       # `brew update --quiet` is idempotent and cheap there; cheap
       # enough to run unconditionally on every macOS leg.
@@ -862,7 +855,7 @@ jobs:
           fi
           exclude='STFT|VisualizationBridge|Clipboard|Toolbar add items'
           if [ "${RUNNER_OS}" = "macOS" ]; then
-            # macOS self-hosted required gate stability, 2026-05-20:
+            # macOS self-hosted required gate stability:
             # these tests currently fail only on the local runner image
             # and block unrelated PRs behind the serialized macOS queue.
             # Keep them visible on Linux/Windows and in dedicated fixes.
@@ -877,16 +870,14 @@ jobs:
             exclude="${exclude}|mac harness scroll event carries non-zero deltas through PulpView"
             exclude="${exclude}|mac harness right-click reaches PulpView::rightMouseDown"
             exclude="${exclude}|pulp-mcp-launcher"
-            # NOTE: "CoreAudio render sine wave" + "StandaloneApp::apply_config"
-            # were temporarily excluded here on 2026-06-04 (full-suite-only 120s
-            # hang on the local runner). Root cause: CoreAudio teardown blocks on
-            # the RT I/O thread, which was CPU-starved under -j8. Fixed properly
-            # via a PROCESSORS reservation on the device-opening suites in
-            # test/CMakeLists.txt, so they are re-enabled here.
+            # CoreAudio/StandaloneApp device-opening suites rely on the
+            # PROCESSORS reservation in test/CMakeLists.txt to avoid
+            # RT-thread starvation under -j8; keep that reservation if
+            # those suites stay enabled here.
           fi
           if [ "${RUNNER_OS}" = "Linux" ]; then
-            # Linux ARM64 PR runner, 2026-06-19: Skia is present, but the
-            # headless VM exposes an incompatible Vulkan device
+            # Linux ARM64 PR runner: Skia is present, but the headless VM
+            # exposes an incompatible Vulkan device
             # (/dev/dri/renderD128 -> VK_ERROR_INCOMPATIBLE_DRIVER) and no
             # DISPLAY. That makes visual/golden assertions fail as runner
             # capability checks, not as product regressions. Keep the rest of
@@ -912,8 +903,8 @@ jobs:
         # On a SELF-HOSTED runner the test step's log is not retrievable via
         # `gh run view --log` (you get only "Process completed with exit code
         # 8") and check-run annotations are empty — so a failing test is
-        # invisible remotely (see #3392; cost ~hours on 2026-06-03). ctest's own
-        # result logs name it: dump them into the job summary so the failing
+        # invisible remotely. ctest's own result logs name it: dump them into
+        # the job summary so the failing
         # test(s) + assertions show in the GitHub UI without host access.
         if: failure() && runner.os != 'Windows'
         shell: bash
@@ -955,7 +946,7 @@ jobs:
         # ensures the code page applies to the cmd subshell that
         # spawns test binaries — a plain bash `chcp.com 65001` ran
         # at the outer shell level but didn't propagate to ctest's
-        # children on Namespace Windows (observed on #702).
+        # children on Namespace Windows.
         # Shipyard v0.38.0's UTF-8 prelude only covers commands
         # Shipyard dispatches via ssh-windows; GH Actions ctest
         # calls don't go through that path.
@@ -1004,20 +995,16 @@ jobs:
 
   # ── Windows MSVC release-path PR gate ────────────────────────────────────
   #
-  # The main `build-and-test` matrix above runs Windows via Namespace with a
-  # configure that differs from release-cli.yml's. Result: MSVC-specific
-  # errors (protected-member strictness, WIN32_LEAN_AND_MEAN / COM header
-  # interactions, etc.) only surface AFTER a tag is pushed, when
-  # release-cli.yml builds on a GitHub-hosted windows-latest runner. That's
-  # how v0.15.0 / v0.16.0 / v0.17.0 shipped broken release pipelines —
-  # wasapi_device.cpp and accessibility_win.cpp both hit MSVC errors that
-  # the PR gate didn't catch.
+  # The main `build-and-test` matrix uses a test-oriented Windows configure
+  # that differs from release-cli.yml's release configure. Without a matching
+  # release-path gate, MSVC-specific errors (protected-member strictness,
+  # WIN32_LEAN_AND_MEAN / COM header interactions, etc.) surface only AFTER a
+  # tag is pushed, when release-cli.yml builds on windows-latest.
   #
   # This job mirrors release-cli.yml's CLI-build configure on windows-latest
   # for every PR so MSVC errors block merge instead of silently failing at
   # tag-push time. Build-only; no test step — release-cli.yml doesn't run
-  # tests either, and the main matrix above already covers Windows tests on
-  # Namespace.
+  # tests either, and the main matrix above already covers Windows tests.
   windows-msvc-release-gate:
     needs: classify
     if: needs.classify.outputs.native_build_required == 'true'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -707,11 +707,9 @@ jobs:
           }
           size=$(wc -c < "$xml")
           echo "coverage.cobertura.xml size: ${size} bytes"
-          # A2 first cut: assertion logic extracted to
-          # tools/scripts/verify_cobertura_xml.py so the inline-Python
-          # heredoc isn't duplicated across the native + Python lanes
-          # (and stays unit-testable). #605 contract preserved
-          # verbatim — non-empty file + lines-valid > 0.
+          # Shared verifier keeps the native + Python lanes on the same
+          # non-empty file + lines-valid > 0 contract without duplicating
+          # inline Python.
           python3 tools/scripts/verify_cobertura_xml.py "$xml" \
             --label "coverage.cobertura.xml" \
             --hint "llvm-cov / lcov_cobertura filtered out every source file — check scripts/run_coverage.sh's COVERAGE_IGNORE_REGEX and -object list against the actual profraw source paths."
@@ -729,7 +727,7 @@ jobs:
             echo "::error::Python tools coverage likely failed — check the 'Run Python tools coverage' step above."
             exit 1
           }
-          # A2 first cut: shared verifier (see native lane above).
+          # Shared verifier, same contract as the native lane above.
           python3 tools/scripts/verify_cobertura_xml.py "$xml" \
             --label "coverage.python.xml" \
             --hint "coverage.py did not record any executable tools/scripts lines."

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -1,14 +1,13 @@
 name: IWYU advisory
 
-# include-what-you-use advisory gate for issue #594.
+# include-what-you-use advisory gate.
 #
 # Transitive-include bugs (code that uses std::X but only picks up
 # X's header transitively) keep reaching main because Apple Clang's
-# libc++ tolerates the miss while Linux Clang + MSVC reject. Three
-# incidents on 2026-04-21 (#540, <atomic>, #593) triggered this
-# gate. The coverage-build gate catches the same bug class later in
-# the matrix; this workflow catches it earlier, at IWYU-analysis time,
-# before it reaches the cross-platform matrix.
+# libc++ tolerates the miss while Linux Clang + MSVC reject. The
+# coverage-build gate catches the same bug class later in the matrix;
+# this workflow catches it earlier, at IWYU-analysis time, before it
+# reaches the cross-platform matrix.
 #
 # Still advisory: continue-on-error is true, PR diffs get inline
 # annotations, and merges are not blocked. Flip to blocking only after

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -3,8 +3,7 @@ name: Workflow lint
 # Layer 1 of the release-watchdog triad (docs/guides/release-watchdog.md):
 # catch bad `.github/workflows/*.yml` before merge. Uses agent-agnostic
 # tooling (yamllint, actionlint, `python3 -c yaml.safe_load`) so any
-# contributor or agent — Claude, Codex, a human — can run the same
-# checks locally.
+# contributor or agent can run the same checks locally.
 #
 # Motivating incident: #501 shipped an auto-release.yml with Python
 # code at column 1 nested inside a YAML `run: |` block whose indent


### PR DESCRIPTION
## Summary
- trims stale provenance, issue-wave, and agent-review breadcrumbs from long-lived workflow comments
- keeps the current invariants in place for macOS overflow routing, ccache safety, release tagging/supersede behavior, coverage gates, IWYU advisory behavior, and workflow linting
- leaves non-comment behavior unchanged; every changed diff line is a YAML comment

## Scope
- `.github/workflows/build.yml`
- `.github/workflows/auto-release.yml`
- `.github/workflows/coverage.yml`
- `.github/workflows/iwyu.yml`
- `.github/workflows/workflow-lint.yml`

Deferred intentionally: `tools/shipyard.toml`, `.github/workflows/pulp-react-build.yml`, `.github/actions/retry/action.yml`, and `templates-smoke.yml` because those comments were either current operational rationale or not comments.

## Review
- RepoPrompt/rp-cli selection covered the workflow/config batch.
- RepoPrompt direct diff review initially caught lost PROCESSORS/watchdog/endpoint context; the patch restored evergreen invariant text.
- Final RepoPrompt direct diff review: clean, no actionable correctness or invariant findings.
- Autoreview panel with Codex + Claude: clean, no accepted/actionable findings.

## Validation
- `python3` comment-only diff detector: passed
- `git diff --check`: passed
- PyYAML parse for touched workflows: passed
- `actionlint -shellcheck= -pyflakes= .github/workflows/build.yml .github/workflows/coverage.yml .github/workflows/auto-release.yml .github/workflows/iwyu.yml .github/workflows/workflow-lint.yml`: passed
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD`: passed
- `tools/scripts/gates.sh refs/remotes/origin/main`: passed
- `python3 tools/scripts/test_resolve_provider_busy_probe.py`: passed, 11 tests
- `python3 tools/scripts/test_release_workflow_test_step.py`: passed, 21 tests
- `python3 tools/scripts/test_workflow_build_dirs.py`: passed, 8 tests
- `python3 tools/scripts/test_iwyu_annotate.py`: passed, 16 tests
- `python3 tools/scripts/test_coverage_tier_check.py`: passed, 46 tests

Note: plain `actionlint` still reports the pre-existing shellcheck SC2129 in `auto-release.yml`; the passing command matches the repo's workflow-lint configuration by disabling shellcheck/pyflakes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up long-lived comments in CI workflows by removing stale provenance and review breadcrumbs. No behavior changes; all edits are comment-only and keep existing invariants for macOS overflow routing, ccache safety, release tagging/supersede logic, coverage gates, IWYU advisory, and workflow linting.

- **Refactors**
  - Trimmed and clarified comments; behavior unchanged.
  - Updated: `.github/workflows/build.yml`, `.github/workflows/auto-release.yml`, `.github/workflows/coverage.yml`, `.github/workflows/iwyu.yml`, `.github/workflows/workflow-lint.yml`.

<sup>Written for commit 67b229c710e2d9a013c7c301deb8e1a88f8bd7de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

