### PR TITLE
docs(import): trim comment provenance breadcrumbs

### DIFF
--- a/tools/import-design/CMakeLists.txt
+++ b/tools/import-design/CMakeLists.txt
@@ -1,13 +1,13 @@
 # pulp-import-design — design file import tool
 # Translates Figma/Stitch/v0/Pencil designs to Pulp web-compat JS.
-# pulp #1031 adds the versioned detect-only surface (import_detect.cpp);
-# the detector is intentionally self-contained so it can be linked into
-# the test target without dragging the full pulp::view pipeline along.
+# The versioned detect-only surface is intentionally self-contained so it can
+# be linked into the test target without dragging the full pulp::view pipeline
+# along.
 add_executable(pulp-import-design
     pulp_import_design.cpp
     import_detect.cpp
     # miniz lets the CLI auto-unpack .pulp.zip exports from the Figma
-    # plugin (issue #47). Compiled here rather than pulled from
+    # plugin. Compiled here rather than pulled from
     # pulp::runtime because that target's miniz include dirs are PRIVATE
     # and pulp::view doesn't re-export them.
     ${CMAKE_SOURCE_DIR}/external/miniz/miniz.c
@@ -32,11 +32,10 @@ add_executable(pulp-svg-probe svg_probe.cpp)
 target_include_directories(pulp-svg-probe PRIVATE ${CMAKE_SOURCE_DIR})
 target_link_libraries(pulp-svg-probe PRIVATE pulp::view pulp::state pulp::platform)
 
-# Link-order fix for libskia.a → fontconfig on Linux+GNU ld (#1986
-# follow-up): re-mention fontconfig AFTER pulp::view's transitive
-# skia::skia so the linker resolves SkFontMgr_New_FontConfig's Fc*
-# references. Caused v0.100.0 release-cli linux-x64 to fail; was
-# already in place for pulp-cli.
+# Link-order fix for libskia.a → fontconfig on Linux+GNU ld: re-mention
+# fontconfig AFTER pulp::view's transitive skia::skia so the linker resolves
+# SkFontMgr_New_FontConfig's Fc* references. Caused v0.100.0 release-cli
+# linux-x64 to fail; was already in place for pulp-cli.
 include(${CMAKE_SOURCE_DIR}/tools/cmake/PulpLinkFontconfig.cmake)
 pulp_link_fontconfig_after_skia(pulp-import-design)
 pulp_link_fontconfig_after_skia(pulp-design-import-bench)

--- a/tools/import-design/fidelity_diff.py
+++ b/tools/import-design/fidelity_diff.py
@@ -1829,8 +1829,8 @@ def _has_track_stroke_above_thumb(crop: "Image.Image", bg: RGB) -> bool:
     a hair darker/equal to the panel interior, with a faint low-sat edge). Both
     are "the dark housing track above the thumb" and both should count, so the
     test accepts a low-saturation pixel that is meaningfully distinct from the
-    panel bg in EITHER luma direction (not just lighter). pulp #3191 follow-up:
-    keying only on "lighter than bg + 12" missed the dark recessed slot that the
+    panel bg in EITHER luma direction (not just lighter): keying only on
+    "lighter than bg + 12" missed the dark recessed slot that the
     captured Pulp fader/meter draws (track ≈ panel interior luma)."""
     crop = crop.convert("RGBA")
     w, h = crop.size

--- a/tools/import-design/figma_rest_export.py
+++ b/tools/import-design/figma_rest_export.py
@@ -377,7 +377,7 @@ def widget_kind_from_name(name):
     if has("spectrum"): return "spectrum"
     return None
 
-# ── Faithful-vector import (Plan B / B4) ────────────────────────────────────
+# ── Faithful-vector import ──────────────────────────────────────────────────
 # Geometry auto-detect of knobs in an exported frame SVG, ported verbatim from
 # the vector-knob PoC (examples/vector-knob parse_frame_knobs) and the C++
 # DesignFrameView convention. A knob DOME is a gradient-filled <circle>
@@ -556,7 +556,7 @@ def walk(n, parent, z, ctx):
     tiny = bb.get("width", 0) < 1 and bb.get("height", 0) < 1
     captured = False
     wkind = widget_kind_from_name(n.get("name", ""))
-    # Codex #3234 P2: only promote LEAF-ish nodes. A CONTAINER whose name merely
+    # Only promote LEAF-ish nodes. A CONTAINER whose name merely
     # contains a widget word (e.g. "Knob Row", "Fader Bank") must NOT be promoted
     # to a leaf widget — that would drop its children (the real knobs inside).
     # Mirrors the importer's detect_node_audio_widget has_child_containers rule.
@@ -631,8 +631,8 @@ def resolve_token(explicit):
 
 def parse_url(url):
     # https://figma.com/design/<KEY>/<name>?node-id=<a-b>  (node-id uses '-'; API uses ':')
-    # Codex #3225 P2: copied URLs commonly percent-encode the separator
-    # (node-id=3%3A42, or %2D); unquote first so the regex still matches.
+    # Copied URLs commonly percent-encode the separator (node-id=3%3A42, or
+    # %2D); unquote first so the regex still matches.
     import urllib.parse
     url = urllib.parse.unquote(url)
     m = re.search(r"/(?:design|file)/([A-Za-z0-9]+)", url)
@@ -647,8 +647,8 @@ def fetch_nodes(file_key, node_id, token):
         token=token, what="file nodes")
 
 def resolve_image_fills(file_key, refs, token, out_dir):
-    """Codex #3225 P2: resolve IMAGE-fill imageRefs into real assets. The image
-    fill on a node references a file image by `imageRef`; the file-images
+    """Resolve IMAGE-fill imageRefs into real assets. The image fill on a node
+    references a file image by `imageRef`; the file-images
     endpoint maps each ref to a (temporary) download URL. Download → assets/
     (sha256-named, like node captures) → return (manifest_entries, {ref: rel_path})
     so the caller can rewrite each node's `background_image: "pending:<ref>"` into
@@ -805,7 +805,7 @@ def parse_panel_bounds(svg):
 def detect_overlay_controls(figma_root, root_abs, panel_origin):
     """Detect NATIVE-OVERLAY controls (search/dropdown/tabs) from the Figma node
     tree by name/structure — source metadata, more reliable than SVG glyphs
-    (Codex review). Node coords are mapped into SVG space:
+    Node coords are mapped into SVG space:
       svg = (node_abs - root_abs) + panel_origin
     because the node tree is frame-local while the SVG export adds the drop-shadow
     margin (so the panel sits at panel_origin, not 0,0). text_field (search) +
@@ -1159,8 +1159,8 @@ def build_argparser():
     ap.add_argument("--token", help="Figma PAT (else $FIGMA_TOKEN or ~/.config/pulp/figma-token)")
     ap.add_argument("--no-assets", action="store_true", help="skip /images PNG capture (geometry+style only)")
     ap.add_argument("--node-json", help="use a pre-fetched /v1/.../nodes JSON instead of calling REST")
-    # Faithful-vector is the DEFAULT import lane (Plan B): it captures the frame's
-    # own SVG and renders it pixel-faithfully via DesignFrameView, overlaying the
+    # Faithful-vector is the DEFAULT import lane: it captures the frame's own
+    # SVG and renders it pixel-faithfully via DesignFrameView, overlaying the
     # auto-detected INTERACTIVE controls (knobs, search field, dropdowns, steppers,
     # tab groups). Without it the importer emits a flat, STATIC node tree with no
     # live widgets — which is almost never what a plugin UI wants — so it is opt-OUT
@@ -1207,8 +1207,8 @@ def main():
         asset_manifest_entries = export_assets(file_key, ctx.asset_ids, token, out_dir)
         print(f"  captured {len(asset_manifest_entries)} PNGs")
     # Resolve IMAGE-fill imageRefs → real assets, rewrite the dangling pending:
-    # markers (Codex #3225 P2). Even with --no-assets/--node-json we strip the
-    # pending: placeholders so the envelope never carries a dead reference.
+    # markers. Even with --no-assets/--node-json we strip the pending:
+    # placeholders so the envelope never carries a dead reference.
     if ctx.image_fills:
         ref_to_rel = {}
         if not args.no_assets and token:

--- a/tools/import-design/import_detect.cpp
+++ b/tools/import-design/import_detect.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 //
-// pulp #1031 — implementation of the versioned import detector.
+// Implementation of the versioned import detector.
 
 #include "import_detect.hpp"
 

--- a/tools/import-design/import_detect.hpp
+++ b/tools/import-design/import_detect.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 //
-// pulp #1031 — three-layer versioned detection for `pulp import-design`.
+// Three-layer versioned detection for `pulp import-design`.
 //
 // Detects the (source, format-version, parser-version) tuple of an
 // external design export by walking a file or directory and matching

--- a/tools/import-design/montage.py
+++ b/tools/import-design/montage.py
@@ -83,8 +83,8 @@ def build_montage(panels, out_path, labels=True, columns=1, title_height=36,
 
 def _parse_panel(spec):
     # "path:Label" → (label, path). Split on the FIRST ':' so a label that itself
-    # contains colons survives (Codex #3237: "x.png:1. Figma: source" must keep
-    # "1. Figma: source" as the label, not truncate at the last colon). Fall back
+    # contains colons survives ("x.png:1. Figma: source" must keep "1. Figma:
+    # source" as the label, not truncate at the last colon). Fall back
     # to treating the whole spec as a path when the head isn't an existing file
     # (bare path, or a path with no label).
     if os.path.exists(spec):                      # whole spec is a real path → no label

--- a/tools/import-design/pulp_import_design.cpp
+++ b/tools/import-design/pulp_import_design.cpp
@@ -50,7 +50,7 @@ using namespace pulp::state;
 
 namespace {
 
-// ── Minimal PNG → RGBA8 decoder (pulp #3191) ────────────────────────────────
+// ── Minimal PNG → RGBA8 decoder ─────────────────────────────────────────────
 // AssetManager::decode_png only stores raw bytes + IHDR dims (the real decode
 // happens in the Skia renderer, which isn't linked in the GPU-off importer
 // build). For the fader/meter skin sampler we need actual pixels, so decode
@@ -844,7 +844,7 @@ SwiftOutputPaths resolve_swift_output_paths(const std::string& output_file) {
     // Theme artifact + type are derived per-view (`<RootView>Theme`) so two
     // SwiftUI imports never clobber a shared PulpTheme.swift on disk nor emit a
     // duplicate `enum PulpTheme` / dynamic-color symbol when compiled into one
-    // Swift target (Codex review). The theme file (<RootView>Theme.swift) is
+    // Swift target. The theme file (<RootView>Theme.swift) is
     // always distinct from the view (<RootView>.swift), so no path collision.
     paths.theme_type_name = paths.root_view_name + "Theme";
     paths.theme = paths.view.parent_path() / (paths.root_view_name + "Theme.swift");
@@ -981,7 +981,7 @@ static std::string read_file(const std::string& path) {
     return ss.str();
 }
 
-// ── .pulp.zip auto-unpack (issue #47) ──────────────────────────────────
+// ── .pulp.zip auto-unpack ───────────────────────────────────────────────
 //
 // The Pulp Figma plugin's "Export to Pulp" button emits a `.pulp.zip` that
 // contains scene.pulp.json + assets/*.png. Asking users to manually unzip
@@ -1677,8 +1677,8 @@ int main(int argc, char* argv[]) {
     // Per-node override: a Figma node name ending in `@sprite` or
     // `@silver` overrides the global default for THAT knob only.
     bool use_silver_knobs = true;    // figma-plugin default; sprite via --knob-style=sprite
-    bool skin_faders = true;         // pulp #3191; plain via --fader-style=default
-    bool skin_meters = true;         // pulp #3191; plain via --meter-style=default
+    bool skin_faders = true;         // plain via --fader-style=default
+    bool skin_meters = true;         // plain via --meter-style=default
     bool debug_json = false;         // --debug: output JSON report with all metrics
     std::string debug_output;        // --debug-output: path for JSON report
     int render_width = 340;
@@ -1692,25 +1692,25 @@ int main(int argc, char* argv[]) {
     pulp::view::ScreenshotBackend screenshot_backend =
         pulp::view::ScreenshotBackend::skia;
     std::string bridge_output = "bridge_handlers.cpp";  // claude scaffold output
-    bool bridge_output_explicit = false;                 // pulp friction-fix #4
+    bool bridge_output_explicit = false;                 // bridge output was set explicitly
     bool emit_bridge_scaffold = true;                    // default on for --from claude
-    bool execute_bundle = false;                         // pulp #468 native-runtime path
-    std::string classnames_output = "classnames.json";   // pulp #1035 — claude classname map
-    bool classnames_output_explicit = false;             // pulp friction-fix #4
+    bool execute_bundle = false;                         // native-runtime path
+    std::string classnames_output = "classnames.json";   // claude classname map
+    bool classnames_output_explicit = false;             // classname output was set explicitly
     bool emit_classnames = true;                          // default on for --from claude
-    // pulp #2116 V2 — keyboard shortcuts auto-imported from source.
+    // Keyboard shortcuts are auto-imported from source.
     // Default-on; opt out with --no-import-shortcuts.
     std::string shortcuts_output = "shortcuts.json";
     bool shortcuts_output_explicit = false;
     bool import_shortcuts = true;
-    // Phase A defaults — auto-bind platform conventions (Cmd+, → Settings,
+    // Auto-bind platform conventions (Cmd+, → Settings,
     // etc.) when the source has a high-confidence component match. Default-on;
     // `--no-default-shortcuts` opts out without affecting the source-extracted
     // path above.
     bool default_shortcuts = true;
-    bool output_explicit = false;                         // pulp friction-fix #4
-    bool tokens_file_explicit = false;                    // pulp friction-fix #4
-    // pulp #1031 — versioned detect surface
+    bool output_explicit = false;                         // output path was set explicitly
+    bool tokens_file_explicit = false;                    // tokens file was set explicitly
+    // Versioned detect surface.
     bool detect_only = false;
     bool report_new_format = false;
     std::string input_directory;                          // --directory: alternative to --file
@@ -1947,7 +1947,7 @@ int main(int argc, char* argv[]) {
 
     // --format css-variables emits a CSS file, so its sidecar defaults to
     // theme.css rather than tokens.json (the W3C default). The leaf name also
-    // feeds the friction-fix #4 anchoring below.
+    // feeds the sidecar anchoring below.
     const char* tokens_default_leaf =
         (export_format == "css-variables") ? "theme.css" : "tokens.json";
     if (export_format == "css-variables" && !tokens_file_explicit)
@@ -1964,8 +1964,8 @@ int main(int argc, char* argv[]) {
         return 2;
     }
 
-    // pulp friction-fix #4 — when the user passes --output <dir>/ui.js,
-    // anchor the sidecar files (bridge_handlers.cpp, classnames.json,
+    // When the user passes --output <dir>/ui.js, anchor the sidecar files
+    // (bridge_handlers.cpp, classnames.json,
     // tokens.json) to the same directory so they don't scatter to cwd.
     // Only applies when the sidecar flag wasn't given explicitly.
     if (output_explicit) {
@@ -2020,7 +2020,7 @@ int main(int argc, char* argv[]) {
         return 0;
     }
 
-    // ── pulp #1031 — versioned detect-only path ─────────────────────────
+    // ── Versioned detect-only path ──────────────────────────────────────
     // Runs against compat.json without invoking the source parsers.
     if (detect_only) {
         namespace det = pulp::import_detect;
@@ -2250,8 +2250,8 @@ int main(int argc, char* argv[]) {
         } else {
             switch (*source) {
                 case DesignSource::figma:
-                    // Guardrail (pulp #41 follow-up): a Figma-plugin export
-                    // envelope passed to `--from figma` would otherwise be fed
+                    // Guardrail: a Figma-plugin export envelope passed to
+                    // `--from figma` would otherwise be fed
                     // to parse_figma_json, which finds none of its structure and
                     // silently yields an empty root-only import. Auto-route to
                     // the plugin parser and tell the user once.
@@ -2592,7 +2592,7 @@ int main(int argc, char* argv[]) {
     opts.skin_faders = skin_faders;
     opts.skin_meters = skin_meters;
 
-    // pulp #2116 V2 — auto-import keyboard shortcuts from the source.
+    // Auto-import keyboard shortcuts from the source.
     // Default-on. Source-agnostic helper: the extractor takes a raw
     // TSX/JS/HTML string and regex-scans for `e.key === '…'` patterns,
     // so all source types (claude, v0, figma code blobs, stitch inline
@@ -2603,15 +2603,15 @@ int main(int argc, char* argv[]) {
     if (import_shortcuts) {
         detected_shortcuts = extract_keyboard_shortcuts(content, input_file);
 
-        // Phase A defaults — only fire when the developer's React source
-        // has a high-confidence match. `apply_default_shortcuts` lowers
+        // Default shortcuts only fire when the developer's React source has a
+        // high-confidence match. `apply_default_shortcuts` lowers
         // accepted DefaultShortcutCandidates into the same DetectedShortcut
         // form so they ride V2's codegen path with no fork. Suppressed
         // chord-by-chord against `detected_shortcuts` so an extracted
         // binding always wins.
         //
-        // Codex P2 on #2128: the import CLI runs at build time, but the
-        // generated ui.js ships to many platforms (mac standalone, win
+        // The import CLI runs at build time, but the generated ui.js ships to
+        // many platforms (mac standalone, win
         // standalone, plugin hosts on either). Emit BOTH macOS and
         // Win/Linux variants — at runtime only the chord matching the
         // physical key press fires its registerShortcut entry, so the
@@ -2768,7 +2768,7 @@ int main(int argc, char* argv[]) {
                             }
                         }
 
-                        // pulp #3191 — derive a value-driven skin for recognised
+                        // Derive a value-driven skin for recognised
                         // faders/meters by SAMPLING the captured PNG (not baking
                         // it). The widget then redraws the recovered colours /
                         // gradient procedurally so the thumb/level still move
@@ -2803,7 +2803,7 @@ int main(int argc, char* argv[]) {
                                     // exports at 2× but we derive it from the
                                     // data rather than assume, so a re-scaled
                                     // export still maps art px → logical px.
-                                    // pulp #3191 width fix.
+                                    // Derive the asset scale from the captured width.
                                     float node_w = n.style.width.value_or(0.0f);
                                     float asset_scale =
                                         (node_w > 0.0f && img.width > 0)
@@ -3041,7 +3041,7 @@ int main(int argc, char* argv[]) {
         std::cout << ")\n";
     }
 
-    // Bridge handler scaffold for Claude Design imports (pulp #709).
+    // Bridge handler scaffold for Claude Design imports.
     // Only emitted for --from claude; other sources keep their existing
     // output shape unchanged.
     if (*source == DesignSource::claude && emit_bridge_scaffold) {
@@ -3052,7 +3052,7 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    // Classnames artifact for Claude Design imports (pulp #1035).
+    // Classnames artifact for Claude Design imports.
     // Spectr's `tools/extract-html-bundle/extract.mjs` emits the same
     // map by hand; pulling it into the CLI lets `@pulp/css-adapt`
     // consume the file directly without a separate Node-side pass.
@@ -3069,8 +3069,8 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    // pulp #2116 V2 — shortcuts manifest alongside classnames. Mirror
-    // shape so a reviewer can audit what the auto-import will bind. The
+    // Shortcuts manifest alongside classnames. Mirror shape so a reviewer can
+    // audit what the auto-import will bind. The
     // generated ui.js already contains the matching registerShortcut(...)
     // calls; this file is for human/CI audit.
     if (import_shortcuts && !detected_shortcuts.empty()) {
@@ -3095,8 +3095,8 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    // Phase A — diagnostic dump of the defaults scan alongside the bound
-    // manifest. Writes even when no defaults fired, so a reviewer can see
+    // Diagnostic dump of the defaults scan alongside the bound manifest.
+    // Writes even when no defaults fired, so a reviewer can see
     // *why* (collisions, low confidence). Mirror naming convention.
     if (import_shortcuts && default_shortcuts &&
         (!default_scan.accepted.empty() || !default_scan.collisions.empty())) {
@@ -3114,8 +3114,8 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    // pulp friction-fix #3 — native-react detection (heuristic shared
-    // with the lib so tests can exercise it directly; see
+    // Native-react detection (heuristic shared with the lib so tests can
+    // exercise it directly; see
     // design_import.hpp::looks_like_bundler_entry). When the static
     // parser produces only a handful of elements AND the HTML looks
     // like a JS-bundler entry, the user almost certainly wanted to run

--- a/tools/import-validation/check_label_coverage.sh
+++ b/tools/import-validation/check_label_coverage.sh
@@ -53,8 +53,8 @@ while IFS= read -r expected; do
   if grep -Fxq "$expected" "$captured"; then
     hit=$((hit + 1))
   elif [[ ${#expected} -ge 4 ]] && grep -Fq "$expected" "$captured"; then
-    # Codex P1 follow-up on PR #1847: limit the substring fallback to
-    # labels of >= 4 characters. Short labels like "A" / "B" / "?" /
+    # Limit the substring fallback to labels of >= 4 characters. Short labels
+    # like "A" / "B" / "?" /
     # "⋯" would otherwise match as substrings inside unrelated longer
     # labels ("▸ A", "BANDS", etc), inflating coverage and letting
     # missing controls slip past the 70% gate. Exact-match path

--- a/tools/import-validation/diff_against_reference_regions.py
+++ b/tools/import-validation/diff_against_reference_regions.py
@@ -9,9 +9,6 @@ the canvas happens to match. This script computes a per-region score so
 the harness can fail on the FIRST broken region rather than averaging
 everything into one number.
 
-Codex review of planning/spectr-validated-runtime-import-product-spec.md
-flagged this as a hard-gate requirement (2026-05-12).
-
 Regions are defined as percent-of-window rects, so they scale across
 different output sizes (the reference may be 2640x1620, the native render
 1213x812 — the same region maps proportionally to each).

--- a/tools/import-validation/semantic_probes.sh
+++ b/tools/import-validation/semantic_probes.sh
@@ -36,7 +36,7 @@
 #       columns) must have non-trivial pixel content above the near-black
 #       threshold. A blank canvas with intact chrome can pass an overall
 #       histogram diff because the chrome dominates the histogram. Probe 3
-#       calls diff_against_reference_regions.py (PR #1871) and inspects
+#       calls diff_against_reference_regions.py and inspects
 #       central_canvas.blank_candidate — fails if the canvas region is
 #       blank.
 #
@@ -61,8 +61,8 @@
 #   --require-trace
 #                 Treat missing __pulpRuntimeTrace__ lines as a hard FAIL
 #                 even when the log file exists. Default is to WARN — the
-#                 trace globals are still being wired into Spectr's bridge
-#                 (see spectr #TBD) so we don't want to block harness
+#                 trace globals are still being wired into Spectr's bridge,
+#                 so we don't want to block harness
 #                 adoption on instrumentation that doesn't ship yet.
 #   --json        Emit a single JSON object summarizing all probes
 #                 (overall_passed + per-probe verdicts). Default is
@@ -232,7 +232,7 @@ run_probe_2() {
 
 # ── Probe 3: central canvas region is non-blank ──────────────────────────
 #
-# Uses diff_against_reference_regions.py (PR #1871). Reads its --json
+# Uses diff_against_reference_regions.py. Reads its --json
 # output and asserts central_canvas.blank_candidate == false. We do not
 # require the region to *pass* the per-region threshold here — that's the
 # pixel-diff harness's job. We only require that *something* painted into


### PR DESCRIPTION
## Summary
- Trim stale provenance/issue/phase/review breadcrumbs from import-design and import-validation comments/docstrings.
- Preserve current rationale for detector isolation, miniz/private includes, fontconfig link order, widget skin sampling, ZIP auto-unpack, Figma-plugin guardrails, shortcut import/default behavior, sidecar anchoring, and Spectr semantic probes.
- Leave user-visible strings, README prose, and test contract docstrings unchanged.

## Validation
- RepoPrompt/rp-cli window 94 classified the selected import-design/import-validation files before edits.
- `python3 -m py_compile tools/import-design/fidelity_diff.py tools/import-design/montage.py tools/import-design/figma_rest_export.py tools/import-validation/diff_against_reference_regions.py`
- `bash -n tools/import-validation/check_label_coverage.sh tools/import-validation/semantic_probes.sh`
- `python3 tools/import-validation/test_diff_against_reference_regions.py`
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD`
- `git diff --check`
- `tools/scripts/gates.sh refs/remotes/origin/main`
- pre-push gates clean; skill-sync bypass trailer is present because this is comment-only and does not change import-design behavior/workflow.

## Adversarial review
- `$HOME/.agents/skills/autoreview/scripts/autoreview --mode local --reviewers codex,claude --base origin/main` with a comment-hygiene prompt returned `autoreview panel clean: no accepted/actionable findings reported`; Claude and Codex each reported 0 findings.

## Deferred intentionally
- CLI help/output strings still contain `Plan B`, `pulp #1035`, and `Phase A` wording.
- `tools/import-validation/README.md`, `tools/import-validation/test_diff_against_reference_regions.py`, and `tools/import-design/jsx-runtime/README.md` keep docs/test-contract references.
- `import_detect.hpp` stale `compat-schema-version: "0.2"` wording was deferred as a possible correctness/doc-contract issue, not comment hygiene.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up stale provenance/issue breadcrumbs in comments and docstrings across `tools/import-design` and `tools/import-validation`, keeping current technical rationale. No runtime, build, or user-visible changes.

<sup>Written for commit 1b3b6c2dc4468c0957a0cc6611e0a6162eff96a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

