### PR TITLE
docs(test): trim canvas comment provenance breadcrumbs

### DIFF
--- a/test/test_canvas.cpp
+++ b/test/test_canvas.cpp
@@ -79,8 +79,8 @@ TEST_CASE("RecordingCanvas text", "[canvas]") {
     REQUIRE(w > 0);
 }
 
-// Regression test for #75: text draws inside nested clip/translate
-// contexts should still emit exactly one fill_text command per call.
+// Text drawn inside nested clip/translate contexts should still emit exactly
+// one fill_text command per call.
 // The Skia path uses SkTextBlob with explicit per-glyph advances
 // instead of SkShaper::shape(), which prevented ghost/double rendering
 // in the widget paint pipeline. This test guards against a regression
@@ -117,13 +117,10 @@ TEST_CASE("Canvas text in nested clip contexts -- no duplication (#75)",
     REQUIRE(canvas.count(DrawCommand::Type::clip_rect) == 3);
 }
 
-// pulp #1737 — direct unit tests for the new draw_image_*_rect overrides.
-// The integration test [issue-1737] in test_widget_bridge.cpp exercises
-// draw_image_from_file_rect end-to-end via the JS bridge, but codecov's
-// patch-coverage measurement reported 0% on the new lines anyway (the
-// widget-bridge test goes through too many dispatch layers for the
-// per-line attribution). Direct calls on RecordingCanvas pin the new
-// behavior to specific test cases that codecov measures unambiguously.
+// Direct unit tests for the draw_image_*_rect overrides. The integration test
+// in test_widget_bridge.cpp exercises draw_image_from_file_rect end-to-end via
+// the JS bridge; direct calls on RecordingCanvas pin the source/destination
+// rectangle behavior without the bridge dispatch layers.
 TEST_CASE("RecordingCanvas::draw_image_from_file_rect captures src + dst rect",
           "[canvas][issue-1737][issue-916]") {
     RecordingCanvas canvas;
@@ -899,10 +896,10 @@ TEST_CASE("Canvas base fallbacks delegate through recording backend",
 }
 
 #ifdef PULP_HAS_SKIA
-// Issue-897 P1 follow-up: ctx.setTransform must compose onto the parent
-// View's transform, not overwrite it. Without this, a CanvasWidget at
-// non-zero offset would have its translation wiped the moment JS calls
-// ctx.setTransform(scale, 0, 0, scale, 0, 0) for devicePixelRatio scaling.
+// ctx.setTransform must compose onto the parent View's transform, not overwrite
+// it. Without this, a CanvasWidget at non-zero offset would have its translation
+// wiped the moment JS calls ctx.setTransform(scale, 0, 0, scale, 0, 0) for
+// devicePixelRatio scaling.
 TEST_CASE("SkiaCanvas::set_transform composes onto captured paint baseline",
           "[canvas][skia][issue-897]") {
     SkImageInfo info = SkImageInfo::Make(200, 200, kN32_SkColorType,
@@ -1058,7 +1055,7 @@ TEST_CASE("SkiaCanvas::set_line_dash applies an SkDashPathEffect on stroke",
 #endif  // PULP_HAS_SKIA
 
 
-// ── pulp #929 — Canvas::clear_rect default + CoreGraphics override ──────────
+// ── Canvas::clear_rect default + CoreGraphics override ─────────────────────
 
 namespace {
 
@@ -1171,7 +1168,7 @@ TEST_CASE("CoreGraphicsCanvas::clear_rect zeroes destination pixels",
 }
 #endif  // __APPLE__
 
-// ── pulp #1737 — CSS font-variant → SkShaper Feature plumbing ─────────────
+// ── CSS font-variant → SkShaper Feature plumbing ──────────────────────────
 // Regression coverage for the SkShaper 8-arg shape() overload that the
 // fontVariant slice routes through. The legacy 6-arg shape() ignores the
 // caller's feature array entirely (HarfBuzz applies only the on-by-default
@@ -1258,7 +1255,7 @@ TEST_CASE("Canvas::make_font_feature_tag packs OpenType four-char tags",
 }
 #endif // PULP_HAS_SKIA
 
-// ── pulp #1806 — fill_current_path / stroke_current_path preserve the scratch path ──
+// ── fill_current_path / stroke_current_path preserve the scratch path ──────
 // Canvas2D spec: ctx.fill() and ctx.stroke() do NOT consume the path. A
 // subsequent stroke() after fill() must paint the outlined version of
 // the filled shape. Previously path_builder_->detach() emptied the
@@ -1316,13 +1313,12 @@ TEST_CASE("pulp #1806 — begin_path resets between fill+stroke pairs",
 }
 
 #ifdef PULP_HAS_SKIA
-// pulp #1899 (gap #3) — SkiaCanvas tracks every currently-open
-// save_layer whose layer-paint alpha is < 1. Text paint paths
-// (fill_text / stroke_text) consult `inside_non_opaque_layer()` at
-// paint time and select greyscale AA over LCD subpixel AA, so glyphs
-// stay legible inside CSS-opacity layers (browser parity). This test
-// asserts the stack state transitions across the four save_layer
-// entry points + plain save + restore + restore_to_count.
+// SkiaCanvas tracks every currently-open save_layer whose layer-paint alpha is
+// < 1. Text paint paths (fill_text / stroke_text) consult
+// `inside_non_opaque_layer()` at paint time and select greyscale AA over LCD
+// subpixel AA, so glyphs stay legible inside CSS-opacity layers (browser
+// parity). This test asserts the stack state transitions across the four
+// save_layer entry points + plain save + restore + restore_to_count.
 TEST_CASE("SkiaCanvas tracks non-opaque layers for text edging "
           "(pulp #1899 gap #3)", "[canvas][skia][issue-1899]") {
     SkImageInfo info = SkImageInfo::Make(64, 64, kN32_SkColorType,
@@ -1397,13 +1393,13 @@ TEST_CASE("SkiaCanvas tracks non-opaque layers for text edging "
     }
 }
 
-// pulp #1899 (gap #3) — end-to-end: render the same glyph twice into
-// the same surface, once inside save_layer(opacity = 0.5) and once
-// outside, and verify the inside-layer pixels show no LCD subpixel
-// pattern. LCD AA produces unequal R / G / B coverage at glyph edges;
-// greyscale AA writes equal R / G / B. Scanning a few rows where the
-// glyph should have an edge and asserting "max channel difference == 0"
-// for the inside-layer block is the simplest cross-platform probe.
+// End-to-end: render the same glyph twice into the same surface, once inside
+// save_layer(opacity = 0.5) and once outside, and verify the inside-layer
+// pixels show no LCD subpixel pattern. LCD AA produces unequal R / G / B
+// coverage at glyph edges; greyscale AA writes equal R / G / B. Scanning a few
+// rows where the glyph should have an edge and asserting
+// "max channel difference == 0" for the inside-layer block is the simplest
+// cross-platform probe.
 TEST_CASE("SkiaCanvas text inside opacity layer uses greyscale AA "
           "(pulp #1899 gap #3)", "[canvas][skia][issue-1899]") {
     // Two side-by-side surfaces — one painted with an opacity layer,

--- a/test/test_canvas_cg_gradients.cpp
+++ b/test/test_canvas_cg_gradients.cpp
@@ -1,10 +1,9 @@
-// Canvas — CoreGraphics gradient + pattern fixtures (pulp #1524 cluster).
+// Canvas — CoreGraphics gradient + pattern fixtures.
 //
-// Extracted from test/test_canvas.cpp as part of P5-2 to keep individual
-// fixture TUs under the maintainability threshold. The cluster is
-// Apple-only because every test path drives CoreGraphics directly to
-// prove the CoreGraphicsCanvas fallback honours the canvas2d gradient
-// + pattern spec (no degradations).
+// Extracted from test/test_canvas.cpp to keep individual fixture TUs under the
+// maintainability threshold. The cluster is Apple-only because every test path
+// drives CoreGraphics directly to prove the CoreGraphicsCanvas fallback honours
+// the canvas2d gradient + pattern spec (no degradations).
 
 #ifdef __APPLE__
 
@@ -22,7 +21,7 @@
 
 using namespace pulp::canvas;
 
-// ── pulp #1524 — CG-degraded gradient/pattern cluster ────────────────────────
+// ── CG-degraded gradient/pattern cluster ────────────────────────────────────
 //
 // Promotes 3 DIVERGE entries → PASS on the CoreGraphics fallback path:
 //   * canvas2d/createConicGradient     — software-rasterised CGImage sweep
@@ -61,7 +60,7 @@ CGContextRef cg_make_bitmap(int w, int h, std::vector<uint8_t>& pixels) {
 }
 } // namespace
 
-// pulp #1524 — `createConicGradient` on CG must produce angle-varying colour
+// `createConicGradient` on CG must produce angle-varying colour
 // instead of the pre-#1524 first-stop solid fallback. We fill a 64x64 square
 // with a 4-stop conic spanning red / green / blue / red and sample the four
 // cardinal directions from the centre. Each cardinal must hit a different
@@ -108,7 +107,7 @@ TEST_CASE("CoreGraphicsCanvas createConicGradient sweeps angle through stops",
     REQUIRE(west[3]  == 255);
 }
 
-// pulp #1524 — `createRadialGradient` two-circle form must honour the inner
+// `createRadialGradient` two-circle form must honour the inner
 // circle. Pre-#1524 the JS shim dropped (x0,y0,r0) and forwarded only the
 // outer circle, so a gradient with an *offset* inner circle painted as if
 // inner_centre==outer_centre — visually the same as a single-circle radial.
@@ -159,7 +158,7 @@ TEST_CASE("CoreGraphicsCanvas radial two-circle form honours inner circle",
     REQUIRE(near_inner[3] == 255);
 }
 
-// pulp #1524 — `createPattern` on CG must install a real CGPattern instead
+// `createPattern` on CG must install a real CGPattern instead
 // of falling back to the active solid colour. A 1x2 image (red top half,
 // blue bottom half) tiled with `repeat` should produce alternating red/blue
 // horizontal bands when filled across a tall rectangle. Pre-#1524 the
@@ -262,7 +261,7 @@ TEST_CASE("CoreGraphicsCanvas set_fill_pattern installs a real CGPattern",
     REQUIRE(green_count == 0);
 }
 
-// pulp #1524 — `set_fill_pattern("")` clears any active pattern back to the
+// `set_fill_pattern("")` clears any active pattern back to the
 // solid fill colour. Mirrors clear_fill_gradient's reset semantics so a JS
 // fillStyle string assignment after a pattern fillStyle reverts cleanly.
 TEST_CASE("CoreGraphicsCanvas set_fill_pattern clears on empty src",
@@ -289,8 +288,8 @@ TEST_CASE("CoreGraphicsCanvas set_fill_pattern clears on empty src",
     REQUIRE(pixels[2] == 0);    // B
 }
 
-// pulp #1666 — CoreGraphicsCanvas::fill_text must honour an active fill
-// gradient. Pre-fix, fill_text used kCGTextFill with apply_fill_color()
+// CoreGraphicsCanvas::fill_text must honour an active fill gradient. Pre-fix,
+// fill_text used kCGTextFill with apply_fill_color()
 // which routed solid `fill_color_` into the glyphs and silently dropped
 // the gradient set via set_fill_gradient_linear. Post-fix, fill_text
 // switches to kCGTextClip on the glyph fills then paints the active
@@ -354,8 +353,8 @@ TEST_CASE("CoreGraphicsCanvas::fill_text honours active fill gradient",
     REQUIRE(any_glyph_with_dominant_channel(W - 16, W, /*b*/2, /*r*/0));
 }
 
-// pulp #1666 — CoreGraphicsCanvas stroke ops must honour an active
-// stroke gradient set via set_stroke_gradient_linear. Pre-fix, every
+// CoreGraphicsCanvas stroke ops must honour an active stroke gradient set via
+// set_stroke_gradient_linear. Pre-fix, every
 // stroke_* method called apply_stroke_color() which routed solid
 // `stroke_color_` and silently dropped the gradient. Post-fix, stroke
 // methods short-circuit to stroke_with_active_paint() which clips to
@@ -415,8 +414,8 @@ TEST_CASE("CoreGraphicsCanvas::stroke_rect honours active stroke gradient",
     REQUIRE(any_stroked_with_channel(W - 16, W - 4, /*b*/2, /*r*/0));
 }
 
-// pulp #1747 (P1 Codex review on #1736) — stroke_text gradient endpoints
-// must be evaluated in canvas space, NOT in text-local space. Pre-fix
+// stroke_text gradient endpoints must be evaluated in canvas space, NOT in
+// text-local space. Pre-fix
 // stroke_text mutated the CTM (translate(draw_x, y) + scale(1, -1)) and
 // then called stroke_with_active_paint(), so the gradient was sampled
 // in text-local coords: same createLinearGradient stops produced
@@ -518,7 +517,7 @@ TEST_CASE("CoreGraphicsCanvas::stroke_text gradient is canvas-space anchored",
     REQUIRE(br > 30); REQUIRE(bb > 30);
 }
 
-// pulp #1898 — CoreGraphicsCanvas::set_line_dash must produce visible gaps.
+// CoreGraphicsCanvas::set_line_dash must produce visible gaps.
 //
 // Background. The base Canvas virtual is a no-op `(void)`, so before this
 // override Spectr's 0 dB rail (and ~5 other dashed-stroke callsites) drew
@@ -601,9 +600,8 @@ TEST_CASE("CoreGraphicsCanvas::set_line_dash produces gaps in stroke",
     REQUIRE(first_gap_empty >= 3);
 }
 
-// pulp #1898 — clearing the dash (empty intervals) must restore solid strokes
-// on subsequent draws. Mirrors the JS bridge contract: ctx.setLineDash([])
-// reverts to solid.
+// Clearing the dash (empty intervals) must restore solid strokes on subsequent
+// draws. Mirrors the JS bridge contract: ctx.setLineDash([]) reverts to solid.
 TEST_CASE("CoreGraphicsCanvas::set_line_dash clears back to solid",
           "[canvas][cg][issue-1898]") {
     constexpr int W = 32;

--- a/test/test_canvas_cg_paths.cpp
+++ b/test/test_canvas_cg_paths.cpp
@@ -1,11 +1,11 @@
 // CoreGraphicsCanvas — Canvas2D path + transform + gradient + blend +
 // save/restore tests. Apple-only TU (`#ifdef __APPLE__`). Covers:
 //
-//   * pulp #943 / #933 concat_transform (translates + scales)
-//   * pulp #1322 Canvas2D path API (fill + quad/cubic + stroke + gradients)
-//   * pulp #1322 fill_rect / fill_path honoring linear gradient state
-//   * pulp #1368 save_count / restore_to_count
-//   * pulp #1322 set_blend_mode (BlendMode enum every value round-trip
+//   * concat_transform (translates + scales)
+//   * Canvas2D path API (fill + quad/cubic + stroke + gradients)
+//   * fill_rect / fill_path honoring linear gradient state
+//   * save_count / restore_to_count
+//   * set_blend_mode (BlendMode enum every value round-trip
 //     through to_cg_blend)
 //
 // Companion to test_canvas_cg_gradients.cpp, which covers the other
@@ -33,8 +33,8 @@ using namespace pulp::canvas;
 
 #ifdef __APPLE__
 
-// pulp #943 (#933 P1) — CoreGraphicsCanvas::concat_transform must compose the
-// supplied affine onto the current CTM rather than no-op (the default in the
+// CoreGraphicsCanvas::concat_transform must compose the supplied affine onto
+// the current CTM rather than no-op (the default in the
 // base Canvas virtual). Without the override, View::paint_all() routes
 // JS-supplied setTransform(...) through Canvas::concat_transform and the
 // transform silently disappears on Apple CPU paint paths.
@@ -108,10 +108,9 @@ TEST_CASE("CoreGraphicsCanvas::concat_transform translates draw position",
     REQUIRE(red_pixels >= 16);  // at least the 4x4 footprint
 }
 
-// pulp #943 (#933 P1) — verify a non-translation affine (scale + translate)
-// composes correctly, not just pure translations. This catches a regression
-// where someone implements concat_transform as CGContextTranslateCTM(e, f)
-// and ignores a/b/c/d.
+// Verify a non-translation affine (scale + translate) composes correctly, not
+// just pure translations. This catches a regression where someone implements
+// concat_transform as CGContextTranslateCTM(e, f) and ignores a/b/c/d.
 TEST_CASE("CoreGraphicsCanvas::concat_transform scales + translates",
           "[canvas][cg][issue-943-933]") {
     constexpr int W = 64;
@@ -161,8 +160,8 @@ TEST_CASE("CoreGraphicsCanvas::concat_transform scales + translates",
     REQUIRE(reference == via_concat);
 }
 
-// pulp #1322 — CoreGraphicsCanvas must implement Canvas2D-style path
-// building. The base Canvas defaults are no-ops, so a JS bundle that drives
+// CoreGraphicsCanvas must implement Canvas2D-style path building. The base
+// Canvas defaults are no-ops, so a JS bundle that drives
 // draw via beginPath/moveTo/lineTo/closePath/fillPath silently produced
 // nothing on the CPU paint path used by Pulp's standalone host
 // (run_with_editor(use_gpu=false)), even though the bridge dutifully
@@ -214,8 +213,8 @@ TEST_CASE("CoreGraphicsCanvas Canvas2D path API fills (issue 1322)",
     REQUIRE(red_pixels >= 16);  // diamond covers ~64 pixels at this size
 }
 
-// pulp #1322 — beziers (quadTo, cubicTo) must also accumulate into the
-// Canvas2D path. Same shape coverage check as the diamond test.
+// Beziers (quadTo, cubicTo) must also accumulate into the Canvas2D path. Same
+// shape coverage check as the diamond test.
 TEST_CASE("CoreGraphicsCanvas Canvas2D path quad/cubic curves fill (issue 1322)",
           "[canvas][cg][issue-1322]") {
     constexpr int W = 32;
@@ -254,9 +253,9 @@ TEST_CASE("CoreGraphicsCanvas Canvas2D path quad/cubic curves fill (issue 1322)"
     REQUIRE(blue_pixels >= 16);
 }
 
-// pulp #1322 — Canvas2D path stroke must hit the destination too. Spectr
-// also draws spectrum traces via beginPath/moveTo/lineTo*N/strokePath, and
-// stroke_current_path was a no-op on CG before this fix.
+// Canvas2D path stroke must hit the destination too. Spectr also draws spectrum
+// traces via beginPath/moveTo/lineTo*N/strokePath, and stroke_current_path was
+// a no-op on CG before this fix.
 TEST_CASE("CoreGraphicsCanvas Canvas2D path stroke draws (issue 1322)",
           "[canvas][cg][issue-1322]") {
     constexpr int W = 32;
@@ -294,10 +293,10 @@ TEST_CASE("CoreGraphicsCanvas Canvas2D path stroke draws (issue 1322)",
     REQUIRE(green_pixels >= 24);  // a 28-pixel-wide line at width=2
 }
 
-// pulp #1322 — set_fill_gradient_linear must paint a real gradient on CG;
-// the base Canvas fallback collapses to "set fill color = colors[0]" which
-// produces a single colour fill (Spectr's spectrum bg is gradient-driven).
-// Verify that two different colors actually appear in the output bitmap.
+// set_fill_gradient_linear must paint a real gradient on CG; the base Canvas
+// fallback collapses to "set fill color = colors[0]" which produces a single
+// colour fill (Spectr's spectrum bg is gradient-driven). Verify that two
+// different colors actually appear in the output bitmap.
 TEST_CASE("CoreGraphicsCanvas linear gradient paints multiple colors (issue 1322)",
           "[canvas][cg][issue-1322]") {
     constexpr int W = 64;
@@ -336,12 +335,12 @@ TEST_CASE("CoreGraphicsCanvas linear gradient paints multiple colors (issue 1322
     REQUIRE(saw_blue_dominant);
 }
 
-// pulp #1359 — fill_rect already routes the active gradient through
-// fill_with_active_paint(), but fill_path / fill_circle / fill_rounded_rect
+// fill_rect already routes the active gradient through fill_with_active_paint(),
+// but fill_path / fill_circle / fill_rounded_rect
 // silently dropped the gradient and fell back to apply_fill_color(). This
-// is the direct CG parallel of pulp #1350/#1353 on the Skia side. Spectr's
-// CPU-mode FilterBank backplate is the canonical repro — it paints solid
-// white instead of the dark-gradient backplate without this fix.
+// is the direct CG parallel of the Skia-side gradient fixes for #1350/#1353.
+// Spectr's CPU-mode FilterBank backplate is the canonical repro — it paints
+// solid white instead of the dark-gradient backplate without this fix.
 //
 // Verify a 64x8 rect filled with a red→green linear gradient produces a
 // red-dominant left endpoint and a green-dominant right endpoint.
@@ -391,9 +390,9 @@ TEST_CASE("CoreGraphicsCanvas::fill_rect honors active linear gradient",
     REQUIRE(rg > rr);
 }
 
-// pulp #1359 — same test for fill_path. Build a triangle path and verify
-// at least two pixels inside the rendered triangle differ in color, proving
-// the gradient was actually painted (not a single solid colour).
+// Same test for fill_path. Build a triangle path and verify at least two pixels
+// inside the rendered triangle differ in color, proving the gradient was
+// actually painted (not a single solid colour).
 TEST_CASE("CoreGraphicsCanvas::fill_path honors active linear gradient",
           "[canvas][cg][gradient][issue-1359]") {
     constexpr int W = 64;
@@ -451,8 +450,8 @@ TEST_CASE("CoreGraphicsCanvas::fill_path honors active linear gradient",
     REQUIRE(green_dominant > 0);
 }
 
-// pulp #1368 — CoreGraphicsCanvas tracks save_count() and supports
-// restore_to_count() for the CanvasWidget::paint defensive bracket.
+// CoreGraphicsCanvas tracks save_count() and supports restore_to_count() for
+// the CanvasWidget::paint defensive bracket.
 TEST_CASE("CoreGraphicsCanvas tracks save_count and restore_to_count",
           "[canvas][cg][issue-1368]") {
     constexpr int W = 16;
@@ -493,8 +492,8 @@ TEST_CASE("CoreGraphicsCanvas tracks save_count and restore_to_count",
     CGContextRelease(ctx);
 }
 
-// pulp #1371 — CoreGraphicsCanvas::set_blend_mode was a silent no-op (the
-// base Canvas virtual default `(void)mode;`). Skia honored every CSS
+// CoreGraphicsCanvas::set_blend_mode was a silent no-op (the base Canvas
+// virtual default `(void)mode;`). Skia honored every CSS
 // globalCompositeOperation; CG dropped them all and forced SrcOver. The
 // canonical repro is Spectr's filterbank: `ctx.globalCompositeOperation =
 // 'lighter'` paints a vivid blue→green→red rainbow gradient additively over
@@ -672,10 +671,9 @@ TEST_CASE("CoreGraphicsCanvas::set_blend_mode honors all BlendMode values",
     }
 }
 
-// pulp #1371 — exhaustively exercise every BlendMode enum case in the new
-// switch so the diff-cover gate sees each branch run. The earlier test
-// proves end-to-end pixel correctness on a handful of representative ops;
-// this one is structural — every enum value must round-trip through
+// Exhaustively exercise every BlendMode enum case in the switch. The earlier
+// test proves end-to-end pixel correctness on a handful of representative ops;
+// this one is structural: every enum value must round-trip through
 // `CoreGraphicsCanvas::set_blend_mode → to_cg_blend(...)` and reach CG.
 //
 // We don't assert per-channel pixel formulas for every mode (CG's edge
@@ -759,11 +757,11 @@ TEST_CASE("CoreGraphicsCanvas::set_blend_mode every enum value round-trips throu
 
 #endif  // __APPLE__
 
-// pulp #1368 — Canvas's default save_count() / restore_to_count() impls
-// are no-op fallbacks for backends that don't implement an introspectable
-// save stack. CanvasWidget's defensive bracket relies on the contract that
-// these are safe to call on any Canvas. Exercise the defaults via a
-// minimal Canvas subclass that doesn't override either method.
+// Canvas's default save_count() / restore_to_count() impls are no-op fallbacks
+// for backends that don't implement an introspectable save stack. CanvasWidget's
+// defensive bracket relies on the contract that these are safe to call on any
+// Canvas. Exercise the defaults via a minimal Canvas subclass that doesn't
+// override either method.
 namespace {
 
 class MinimalCanvas final : public pulp::canvas::Canvas {

--- a/test/test_canvas_widget.cpp
+++ b/test/test_canvas_widget.cpp
@@ -99,11 +99,10 @@ TEST_CASE("CanvasWidget: clear command fills background", "[canvas_widget]") {
     REQUIRE(rc.commands().size() > 0);
 }
 
-// Issue-897 P1 follow-up: CanvasWidget::paint() must snapshot the inbound
-// device matrix at entry so JS-driven setTransform() composes onto the
-// parent View transform instead of overwriting it. Without this baseline
-// the SkiaCanvas backend's setTransform would wipe the parent translation
-// applied by View::paint_all.
+// CanvasWidget::paint() must snapshot the inbound device matrix at entry so
+// JS-driven setTransform() composes onto the parent View transform instead of
+// overwriting it. Without this baseline the SkiaCanvas backend's setTransform
+// would wipe the parent translation applied by View::paint_all.
 TEST_CASE("CanvasWidget::paint captures paint baseline transform at entry",
           "[canvas_widget][issue-897]") {
     RecordingCanvas rc;
@@ -139,7 +138,7 @@ TEST_CASE("CanvasWidget::paint baseline capture is idempotent and ordered",
     REQUIRE_FALSE(rc.commands().empty());
 }
 
-// ── pulp #929 — Canvas widget transparent default + clearRect semantics ──
+// ── Canvas widget transparent default + clearRect semantics ────────────────
 
 // Empty-command paint must not introduce a full-bounds fill that would
 // hide the parent's painted surface. Asserting against RecordingCanvas
@@ -172,8 +171,8 @@ TEST_CASE("CanvasWidget::paint with no JS draw commands does not pre-fill bounds
 
 // JS-issued clearRect should produce a single clear_rect command, not a
 // SrcOver fill that is a no-op. RecordingCanvas captures the dedicated
-// DrawCommand::Type::clear_rect introduced in pulp #929 so this is a
-// straightforward identity assertion.
+// DrawCommand::Type::clear_rect, giving this a straightforward identity
+// assertion.
 TEST_CASE("CanvasWidget::paint translates clearRect into a real clear_rect command",
           "[canvas_widget][issue-929]") {
     RecordingCanvas rc;
@@ -208,8 +207,8 @@ TEST_CASE("CanvasWidget::paint translates clearRect into a real clear_rect comma
     }
 }
 
-// pulp #949 — backend-independent guard for the FilterBank regression. A
-// parent View with a background paints its bg, then a CanvasWidget child
+// Backend-independent guard for the FilterBank regression. A parent View with a
+// background paints its bg, then a CanvasWidget child
 // with a clearRect+fillRect pair runs. The recorded command sequence must
 // be:
 //   1. parent's bg fill_rect (covering parent's local bounds)
@@ -277,8 +276,8 @@ TEST_CASE("CanvasWidget::paint_all under parent View emits correct command order
 
 #ifdef PULP_HAS_SKIA
 
-// Pixel + sample_pixel moved to the shared canvas_pixel_probe.hpp in the
-// pulp #2462 fix (was duplicated here and in test_canvas2d_shim.cpp).
+// Pixel + sample_pixel live in the shared canvas_pixel_probe.hpp instead of
+// being duplicated here and in test_canvas2d_shim.cpp.
 #include "canvas_pixel_probe.hpp"
 using pulp::canvas_test::Pixel;
 using pulp::canvas_test::sample_pixel;
@@ -348,11 +347,11 @@ TEST_CASE("CanvasWidget partial fillRect leaves untouched pixels transparent",
 
 TEST_CASE("CanvasWidget clearRect zeros its own backing store, not the parent",
           "[canvas_widget][skia][issue-929][issue-1368]") {
-    // pulp #1368 contract update: each CanvasWidget paints into its own
-    // save_layer-backed offscreen so JS-driven clearRect (kClear blend)
-    // can only zero THIS canvas's backing store. The parent surface is
-    // untouched by the clear; on layer restore the empty layer composites
-    // back as a no-op SrcOver and the parent pixels survive.
+    // Each CanvasWidget paints into its own save_layer-backed offscreen so
+    // JS-driven clearRect (kClear blend) can only zero THIS canvas's backing
+    // store. The parent surface is untouched by the clear; on layer restore the
+    // empty layer composites back as a no-op SrcOver and the parent pixels
+    // survive.
     //
     // Pre-#1368, clearRect was emitted directly on the inbound parent
     // surface, so it nuked sibling-painted pixels. The check we now want:
@@ -392,8 +391,8 @@ TEST_CASE("CanvasWidget clearRect zeros its own backing store, not the parent",
     REQUIRE(px.b == 255);
 }
 
-// pulp #949 — FilterBank-style repro: a parent View paints a dark navy
-// background, then a CanvasWidget child paints into the same surface using
+// FilterBank-style repro: a parent View paints a dark navy background, then a
+// CanvasWidget child paints into the same surface using
 // the v0.57.0 sequence (clearRect → fillStyle = gradient → fillRect →
 // path-based fillPath). The regression Spectr saw was that the canvas
 // content never appeared on top of the parent's bg even though 1600+
@@ -454,9 +453,9 @@ TEST_CASE("CanvasWidget content paints over parent View bg via paint_all",
     REQUIRE(px.b == 255);
 }
 
-// pulp #949 — same scenario but the parent has overflow:visible and an
-// additional sibling. Verifies the canvas widget's draws still land on
-// top, and the parent's bg outside the child's bounds is preserved.
+// Same scenario but the parent has overflow:visible and an additional sibling.
+// Verifies the canvas widget's draws still land on top, and the parent's bg
+// outside the child's bounds is preserved.
 TEST_CASE("CanvasWidget draws on top of sibling-painted parent surface",
           "[canvas_widget][skia][issue-949]") {
     SkImageInfo info = SkImageInfo::Make(80, 60, kRGBA_8888_SkColorType,
@@ -512,8 +511,8 @@ TEST_CASE("CanvasWidget draws on top of sibling-painted parent surface",
 
 #endif  // PULP_HAS_SKIA
 
-// pulp #964 / #967 — Spectr's FilterBank scenario, asserted at the
-// command-stream level so the test runs without Skia.
+// Spectr's FilterBank scenario, asserted at the command-stream level so the
+// test runs without Skia.
 //
 // A parent View has a green setBackground() applied. It contains two
 // empty CanvasWidget children that occupy the full bounds and have
@@ -582,8 +581,8 @@ TEST_CASE("FilterBank repro: empty canvas children don't paint opaque white",
     REQUIRE(full_bounds_fills == 1);
 }
 
-// pulp #967 — A bare View with no setBackground() must emit zero
-// fill_rect commands of any kind. HTML <div> default is transparent.
+// A bare View with no setBackground() must emit zero fill_rect commands of any
+// kind. HTML <div> default is transparent.
 TEST_CASE("Bare View with no setBackground emits no background fill",
           "[view][issue-967]") {
     RecordingCanvas rc;
@@ -601,7 +600,7 @@ TEST_CASE("Bare View with no setBackground emits no background fill",
     REQUIRE(fill_rect_count == 0);
 }
 
-// ── pulp #968 — canvasRect must honour active fillStyle when no color arg ──
+// ── canvasRect must honour active fillStyle when no color arg ──────────────
 //
 // The Canvas2D `ctx.fillRect(x,y,w,h)` API has no color argument — it paints
 // with whatever `ctx.fillStyle` (a CSS color OR a CanvasGradient) was set
@@ -816,7 +815,7 @@ TEST_CASE("CanvasWidget stroke_rect with use_active_style preserves prior set_st
     REQUIRE(is_green);
 }
 
-// ── pulp #964 — `ctx.fillRect()` from web-compat-canvas.js must reach the bridge ──
+// ── `ctx.fillRect()` from web-compat-canvas.js must reach the bridge ───────
 //
 // Pre-#964, `core/view/js/web-compat-canvas.js` defined
 //   CanvasRenderingContext2D.prototype.fillRect = function(x, y, w, h) {
@@ -941,7 +940,7 @@ TEST_CASE("WidgetBridge: HTML5 ctx.fillRect via web-compat shim reaches the brid
     REQUIRE(saw_green_full_fill);
 }
 
-// ── pulp #1368 — CanvasWidget::paint balances save/restore across frames ──
+// ── CanvasWidget::paint balances save/restore across frames ────────────────
 //
 // Spectr's filterbank uses two `<canvas>` widgets in identical configuration.
 // One paints visibly, the other doesn't. The visible one (overlay sibling)
@@ -1068,7 +1067,7 @@ TEST_CASE("CanvasWidget::paint nested under a parent save still balances",
     REQUIRE(rc.save_count() == depth_at_root);
 }
 
-// ── pulp #1368 — per-canvas backing-store isolation via save_layer ─────
+// ── Per-canvas backing-store isolation via save_layer ──────────────────────
 //
 // Root cause beyond the save/restore depth defense above: JS-driven
 // `clearRect` lowers to a kClear blend (SkBlendMode::kClear /
@@ -1220,8 +1219,8 @@ TEST_CASE("Two sibling CanvasWidgets each open their own backing store",
 
 #ifdef PULP_HAS_SKIA
 
-// pulp #1368 — visual sibling isolation. Two CanvasWidgets paint
-// against a shared parent surface; sibling-2 starts its frame with
+// Visual sibling isolation. Two CanvasWidgets paint against a shared parent
+// surface; sibling-2 starts its frame with
 // clearRect over its full bounds. Pre-fix, the clearRect zeroed the
 // shared parent texels and erased sibling-1's pixels. Post-fix, each
 // canvas paints into its own save_layer-backed offscreen so kClear
@@ -1277,7 +1276,7 @@ TEST_CASE("Sibling CanvasWidget clearRect does not erase prior sibling's pixels"
     REQUIRE(px.b == 0);
 }
 
-// pulp #1368 — destination-out compositing must also be contained.
+// Destination-out compositing must also be contained.
 // `globalCompositeOperation = "destination-out"` punches alpha holes
 // in the destination. Without per-canvas isolation, sibling-2's
 // destination-out fill would punch a hole through sibling-1's pixels
@@ -1340,7 +1339,7 @@ TEST_CASE("Sibling CanvasWidget destination-out does not punch holes in siblings
     REQUIRE(px.b == 0);
 }
 
-// pulp #1368 — single-canvas paints should not change output. The
+// Single-canvas paints should not change output. The
 // per-canvas layer must be visually equivalent to direct-on-parent
 // painting for an isolated canvas; the layer's existence is a
 // correctness fix for the multi-canvas case, not a behaviour change
@@ -1401,7 +1400,7 @@ TEST_CASE("Single CanvasWidget paint is pixel-equivalent with the layer wrap",
 }
 
 #endif  // PULP_HAS_SKIA
-// ── pulp #1368 round 2 — current_transform() snapshot for paint diagnostics ──
+// ── current_transform() snapshot for paint diagnostics ─────────────────────
 //
 // The Spectr filterbank repro shows pr_1's first-instruction `fillRect(50,50,…)`
 // landing in the title-bar region above the canvas. Either bounds_.y is wrong
@@ -1470,7 +1469,7 @@ TEST_CASE("RecordingCanvas::current_transform composes translate + scale",
     REQUIRE(t.f == 20.0f);
 }
 
-// ── pulp #1368 round 2 — env-gated paint trace: coverage exercise ───────────
+// ── Env-gated paint trace: coverage exercise ───────────────────────────────
 //
 // PULP_LOG_CANVAS_PAINT=1 is the diagnostic switch Spectr uses to capture
 // per-frame bounds + CTM + cmd_total + per-type summary. The fprintf+map
@@ -1668,7 +1667,7 @@ TEST_CASE("CanvasWidget::paint logging path is silent when env unset or empty",
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// pulp #1387 gap #2 — NaN / Infinity defense at add_command boundary
+// NaN / Infinity defense at add_command boundary
 // ─────────────────────────────────────────────────────────────────────
 //
 // Spectr's filterbank reproduced this: an off-screen drag computed a
@@ -1735,19 +1734,14 @@ TEST_CASE("CanvasWidget paint dispatches set_filter to the canvas",
     REQUIRE(observed_string == "blur(5px) sepia(60%)");
 }
 
-// ── pulp #1739 codecov backfill — 9-arg drawImage paint-replay coverage ──
+// ── 9-arg drawImage paint-replay coverage ─────────────────────────────────
 //
-// PR #1739 wired the canvas2d/drawImage sprite-sheet form
-// (drawImage(img, sx,sy,sw,sh, dx,dy,dw,dh)) end-to-end through the JS
-// shim → WidgetBridge → CanvasWidget::paint() → Canvas::draw_image_*_rect.
-// The end-to-end test in test_widget_bridge.cpp [issue-1737] passes, but
-// codecov reported 0% patch coverage on the new lines because the bridge
-// → JS-shim → widget-paint dispatch chain was too indirect for per-line
-// attribution. These focused tests construct the CanvasDrawCmd directly
-// and call CanvasWidget::paint() against a RecordingCanvas — codecov
-// can attribute the `has_source_rect` branch in canvas_widget.cpp and
-// the `draw_image_from_file_rect` recording in recording_canvas.cpp
-// unambiguously to these test cases.
+// The canvas2d/drawImage sprite-sheet form (drawImage(img, sx,sy,sw,sh,
+// dx,dy,dw,dh)) routes end-to-end through the JS shim → WidgetBridge →
+// CanvasWidget::paint() → Canvas::draw_image_*_rect. These focused tests
+// construct the CanvasDrawCmd directly and call CanvasWidget::paint() against a
+// RecordingCanvas to pin the `has_source_rect` and draw_image_from_file_rect
+// branches without the full bridge dispatch chain.
 
 // 9-arg form: `has_source_rect=true` routes through the `_rect` overload
 // so x2/y2/x3/y3 (sx,sy,sw,sh) ride alongside x/y/w/h (dx,dy,dw,dh) to

--- a/test/test_widget_bridge_canvas2d.cpp
+++ b/test/test_widget_bridge_canvas2d.cpp
@@ -1,11 +1,11 @@
 // WidgetBridge Canvas2D tests covering the bridge surface end-to-end through
 // CanvasWidget::paint:
 //
-//   - canvasSetTransform / canvasClip / canvasGlobalCompositeOperation
-//     (issue-896): the bridge records a CanvasDrawCmd, paint() replays it
+//   - canvasSetTransform / canvasClip / canvasGlobalCompositeOperation:
+//     the bridge records a CanvasDrawCmd, paint() replays it
 //   - canvasMeasureText / canvasSetLineDash / canvasDrawImage /
 //     canvasGetImageData / canvasPutImageData (issue-916)
-//   - pulp #1899 / #1901 — 4-arg canvasFillText preserves prior state
+//   - 4-arg canvasFillText preserves prior state
 //
 // Tests share fixtures with the smaller WidgetBridge surface clusters.
 
@@ -304,9 +304,9 @@ TEST_CASE("WidgetBridge direct Canvas2D gap APIs replay expected canvas commands
 }
 
 // ───────────────────────────────────────────────────────────────────────────
-// pulp #899 — WidgetBridge auto-wires repaint_callback_ to the root view's
-// host invalidator so JS-driven UI changes (and rAF callbacks) actually
-// schedule a paint when the View owns its own bridge.
+// WidgetBridge auto-wires repaint_callback_ to the root view's host invalidator
+// so JS-driven UI changes (and rAF callbacks) actually schedule a paint when
+// the View owns its own bridge.
 // ───────────────────────────────────────────────────────────────────────────
 
 namespace {
@@ -475,11 +475,10 @@ TEST_CASE("View::request_repaint reaches host through propagated descendants (is
 }
 
 // ───────────────────────────────────────────────────────────────────────────
-// pulp #921 — __requestFrame__ must call request_repaint() so that
-// requestAnimationFrame() actually drives the host paint loop. Without
-// this wiring, JS-side rAF callbacks accumulate in pending_frame_ids_
-// but the host never schedules the paint that drains them — Spectr's
-// FilterBank canvas stays blank.
+// __requestFrame__ must call request_repaint() so that requestAnimationFrame()
+// actually drives the host paint loop. Without this wiring, JS-side rAF
+// callbacks accumulate in pending_frame_ids_ but the host never schedules the
+// paint that drains them — Spectr's FilterBank canvas stays blank.
 // ───────────────────────────────────────────────────────────────────────────
 
 TEST_CASE("WidgetBridge requestAnimationFrame triggers a host repaint (issue 921)",
@@ -599,8 +598,7 @@ TEST_CASE("WidgetBridge requestAnimationFrame chain keeps requesting paints (iss
 // These five CanvasRenderingContext2D bridge functions close the gap
 // list in issue-916. The first three are the user-priority items
 // (Spectr FilterBank text alignment + footer icon rendering); the last
-// two are P2 follow-ups but ship together to land the surface in one
-// pass.
+// two ship together to land the surface in one pass.
 
 TEST_CASE("WidgetBridge canvasMeasureText returns full TextMetrics object",
           "[view][bridge][canvas][issue-916]") {
@@ -800,8 +798,8 @@ TEST_CASE("WidgetBridge canvasDrawImage records draw_image with src + dst rect",
     REQUIRE(drawIndex >= 0);
 }
 
-// pulp #1737 — drawImage(img, sx,sy,sw,sh, dx,dy,dw,dh) sprite-sheet
-// slicing form. Pre-fix, the JS shim accepted the 9-arg signature but
+// drawImage(img, sx,sy,sw,sh, dx,dy,dw,dh) sprite-sheet slicing form.
+// Pre-fix, the JS shim accepted the 9-arg signature but
 // silently dropped the source rect — only the dst rect made it across
 // the bridge, so a sprite-sheet `drawImage(strip, 32,0,32,32, 0,0,32,32)`
 // drew the entire strip scaled into the 32×32 dst tile. Post-fix, the
@@ -862,15 +860,10 @@ TEST_CASE("WidgetBridge canvasDrawImage 9-arg form plumbs source rect end-to-end
     REQUIRE(drawIndex >= 0);
 }
 
-// pulp #1739 codecov backfill — focused unit test for the bridge-side
-// 9-arg drawImage plumbing. The end-to-end test above (#1737) exercises
-// the same path through the JS shim, but codecov's per-line attribution
-// reported 0% on widget_bridge.cpp lines 7045-7051 (the `args.numArgs
-// >= 10` branch that sets has_source_rect + stashes sx,sy,sw,sh in
-// x2,y2,x3,y3). This test invokes canvasDrawImage directly via JS to
-// pin the bridge plumbing to a tight Catch2 fixture so codecov measures
-// it. Asserts target the CanvasDrawCmd state right at the
-// JS-→-bridge boundary (read back via CanvasWidget::commands()).
+// Focused unit test for the bridge-side 9-arg drawImage plumbing. The
+// end-to-end test above exercises the same path through the JS shim; this test
+// invokes canvasDrawImage directly via JS and asserts the CanvasDrawCmd state
+// right at the JS-→-bridge boundary (read back via CanvasWidget::commands()).
 TEST_CASE("WidgetBridge canvasDrawImage 10-arg call sets has_source_rect on the recorded cmd",
           "[view][bridge][canvas][issue-1739][canvas2d][coverage]") {
     ScriptEngine engine;
@@ -882,8 +875,8 @@ TEST_CASE("WidgetBridge canvasDrawImage 10-arg call sets has_source_rect on the 
 
     // Drive canvasDrawImage directly with the 10-arg shape so the
     // `args.numArgs >= 10` branch in widget_bridge.cpp fires. Using the
-    // raw bridge function (not the JS shim) keeps the call site tightly
-    // bound to the lines under test for codecov line-attribution.
+    // raw bridge function (not the JS shim) keeps the call site tightly bound
+    // to the branch under test.
     bridge.load_script(R"(
         var c = document.createElement('canvas');
         c.id = 'bridge-9arg-canvas';
@@ -905,8 +898,8 @@ TEST_CASE("WidgetBridge canvasDrawImage 10-arg call sets has_source_rect on the 
 
     // CanvasWidget::commands() exposes the recorded cmd queue (read-only).
     // We assert directly on the CanvasDrawCmd to pin the bridge's
-    // x2/y2/x3/y3 + has_source_rect writes — no paint-replay layer in
-    // between for codecov to lose track of.
+    // x2/y2/x3/y3 + has_source_rect writes without an intervening paint-replay
+    // layer.
     const auto& cmds = canvas->commands();
     REQUIRE(cmds.size() == 1);
     const auto& cmd = cmds.front();
@@ -967,15 +960,14 @@ TEST_CASE("WidgetBridge canvasDrawImage 6-arg call leaves has_source_rect=false"
     REQUIRE_THAT(cmd.y3, WithinAbs(0.0f, 1e-5f));
 }
 
-// ── pulp #1899 / #1901 review — 4-arg canvasFillText preserves prior state ──
+// ── 4-arg canvasFillText preserves prior state ─────────────────────────────
 //
 // The original 4-arg shim (#1899) unconditionally injected a `set_font`
 // (system-ui 14px) ahead of every fillText cmd AND overwrote
 // `cmd.color` to white. That stomped any prior `fillStyle = "..."` or
-// `font = "..."` set by the caller. Codex flagged both as P1 on
-// PR #1901. The fix gates each default on whether any prior fill-style
-// / font-state cmd has been recorded on the canvas; if so, we propagate
-// that state into the fill_text cmd rather than reset to defaults.
+// `font = "..."` set by the caller. The fix gates each default on whether any
+// prior fill-style / font-state cmd has been recorded on the canvas; if so, we
+// propagate that state into the fill_text cmd rather than reset to defaults.
 
 TEST_CASE("WidgetBridge 4-arg canvasFillText preserves prior fillStyle color",
           "[view][bridge][canvas][issue-1901][canvas2d][coverage]") {
@@ -1114,12 +1106,11 @@ TEST_CASE("WidgetBridge canvasPutImageData records pixel buffer for paint replay
     REQUIRE(writeIndex >= 0);
 }
 
-// pulp #1737 — putImageData(imageData, dx, dy, dirtyX, dirtyY, dirtyW,
-// dirtyH) sub-rect form. Pre-fix the JS shim accepted the 7-arg
-// signature but silently dropped dirtyX/Y/W/H and wrote the entire
-// ImageData. Per HTML5 spec only the (dirtyX, dirtyY)→(dirtyX+dirtyW,
-// dirtyY+dirtyH) sub-rect of the source ImageData is written, at
-// destination top-left (dx + dirtyX, dy + dirtyY).
+// putImageData(imageData, dx, dy, dirtyX, dirtyY, dirtyW, dirtyH) sub-rect
+// form. Pre-fix the JS shim accepted the 7-arg signature but silently dropped
+// dirtyX/Y/W/H and wrote the entire ImageData. Per HTML5 spec only the
+// (dirtyX, dirtyY)→(dirtyX+dirtyW, dirtyY+dirtyH) sub-rect of the source
+// ImageData is written, at destination top-left (dx + dirtyX, dy + dirtyY).
 //
 // Test drives a 4×4 ImageData with a recognisable colour pattern and
 // asks the shim to write only the 2×2 bottom-right sub-rect at
@@ -1202,11 +1193,10 @@ TEST_CASE("WidgetBridge canvasPutImageData 7-arg sub-rect slices on the JS side"
     REQUIRE(writeIndex >= 0);
 }
 
-// pulp #1737 — putImageData with an empty dirty rect (e.g. dirtyW <= 0
-// after clamping) is a no-op per HTML5 spec. Pre-fix the JS shim
-// dropped the dirty args entirely, so an empty dirty rect would still
-// blast the whole ImageData onto the canvas. Post-fix the shim
-// recognises the empty case and bails before encoding/sending.
+// putImageData with an empty dirty rect (e.g. dirtyW <= 0 after clamping) is a
+// no-op per HTML5 spec. Pre-fix the JS shim dropped the dirty args entirely, so
+// an empty dirty rect would still blast the whole ImageData onto the canvas.
+// Post-fix the shim recognises the empty case and bails before encoding/sending.
 TEST_CASE("WidgetBridge canvasPutImageData 7-arg empty dirty rect is a no-op",
           "[view][bridge][canvas][issue-916][issue-1737]") {
     ScriptEngine engine;


### PR DESCRIPTION
## Summary
- Trim stale provenance/issue/phase/review/codecov breadcrumbs from canvas and CanvasWidget test comments.
- Preserve failure-mode rationale for nested text clipping, drawImage rectangles, setTransform baseline composition, font-feature plumbing, scratch path preservation, opacity-layer text AA, CoreGraphics fallback behavior, backing-store isolation, FilterBank regressions, rAF repaint wiring, and putImageData dirty rects.
- Leave test names, Catch tags, INFO/SUCCEED strings, JS snippets, and numeric assertions untouched.

## Validation
- RepoPrompt/rp-cli window 95 classified the canvas/WidgetBridge candidate files before edits.
- RepoPrompt diff review with the actual git diff confirmed every changed line was a comment and no test names/tags/non-comment strings changed; its actionable grammar finding was fixed.
- Mechanical comment-only diff parser passed.
- `git diff --check`
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD`
- `tools/scripts/gates.sh refs/remotes/origin/main`
- pre-push gates clean.

## Adversarial review
- First Codex+Claude autoreview found a duplicated clearRect comment phrase; fixed.
- Rerun: `$HOME/.agents/skills/autoreview/scripts/autoreview --mode local --reviewers codex,claude --base origin/main` returned `autoreview panel clean: no accepted/actionable findings reported`; Claude and Codex each reported 0 findings.

## Deferred intentionally
- `test/test_widget_bridge_canvas2d_wave2.cpp` `#1638` baseline-corruption stub region is left untouched. RepoPrompt classified it as manual-review territory because comments, skipped test names/tags, and SUCCEED strings are coupled to justify deliberately stubbed tests.
- Codex-review provenance was intentionally removed where it was only reviewer/provenance breadcrumb, while useful cross-links such as the Skia-side `#1350/#1353` gradient parallel were preserved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed stale provenance/review/codecov breadcrumbs from Canvas and CanvasWidget test comments to reduce noise and clarify intent. Preserved useful rationale notes; no test logic, names, tags, or assertions changed.

- **Refactors**
  - Comment-only edits across canvas/CG/WidgetBridge test files.
  - Removed breadcrumb noise; tightened and normalized comments while keeping key rationale (e.g., drawImage src/dst rects, gradient handling, setTransform composition, opacity-layer text AA).
  - Verified via diff and repo gates that only comments changed.

<sup>Written for commit 922c1d6ca9d4bb1042715208ebc22acad9af383a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

