### PR TITLE
docs(test): trim gpu comment provenance breadcrumbs

### DIFF
--- a/test/test_gpu_compute.cpp
+++ b/test/test_gpu_compute.cpp
@@ -232,15 +232,14 @@ TEST_CASE("GpuCompute benchmark magnitude", "[render][gpu][compute][benchmark]")
     REQUIRE(results.size() == sizes.size());
 }
 
-// ── Slice 1 acceptance: staging buffer pool reuse ───────────────────────────
+// ── Staging buffer pool reuse ───────────────────────────────────────────────
 //
-// Before Slice 1 landed, compute_magnitude() created a fresh wgpu::Buffer on
-// every call — steady-state GPU memory kept climbing because Dawn can't
-// immediately reclaim backing storage on release, and the bench harness
-// reveals this as an allocator-churn hotspot. With the StagingBufferPool,
-// buffers of the same size/usage are recycled; 1000 iterations should reach
-// steady state after the first 2–3 calls and produce a flat allocation
-// profile. See planning/zero-copy-slice-1-design-2026-04-20.md.
+// Without the pool, compute_magnitude() created a fresh wgpu::Buffer on every
+// call — steady-state GPU memory kept climbing because Dawn can't immediately
+// reclaim backing storage on release, and the bench harness reveals this as an
+// allocator-churn hotspot. With the StagingBufferPool, buffers of the same
+// size/usage are recycled; 1000 iterations should reach steady state after the
+// first 2–3 calls and produce a flat allocation profile.
 //
 // Verifies:
 // - No correctness regression under sustained hot-loop usage
@@ -281,7 +280,7 @@ TEST_CASE("GpuCompute magnitude hot loop reuses pool buffers",
     // ceiling instead of tripping the sentinel, and the flake window widens on a
     // slow/virtualized overflow runner. 5 * 100 = 500 submits → ~240 ms/call
     // ceiling, comfortably above the 100 ms sentinel. (Was 5 * 1000 = 5000 →
-    // ~24 ms ceiling, below the sentinel — see #3411 review r3352262249.)
+    // ~24 ms ceiling, below the sentinel — see #3411.)
     constexpr int kBatches = 5;
     constexpr int kItersPerBatch = 100;
     std::vector<double> per_call_us_samples;

--- a/test/test_gpu_compute_pool.cpp
+++ b/test/test_gpu_compute_pool.cpp
@@ -1,7 +1,4 @@
-// test_gpu_compute_pool.cpp — unit tests for the staging buffer pool
-// introduced in Slice 1 of the zero-copy ralph loop.
-//
-// Design reference: planning/zero-copy-slice-1-design-2026-04-20.md
+// test_gpu_compute_pool.cpp — unit tests for the staging buffer pool.
 //
 // Tests live here (not in test_gpu_compute.cpp) because they exercise
 // the pool in isolation using a real Dawn device obtained from
@@ -307,13 +304,12 @@ TEST_CASE("StagingBufferPool clear() drops all tracked buffers",
 
 TEST_CASE("StagingBufferPool::discard drops in_flight slot without recycling",
           "[render][gpu][pool][codex-560]") {
-    // Codex 2026-04-21 wave 2 P1 on #560: on MapAsync timeout the
-    // caller cannot hand the buffer back via release() (the GPU may
-    // still be mapping it) but must drop the pool's reference so
-    // subsequent acquires don't grow in_flight_ without bound. This
-    // test hammers that path: 32 discarded buffers must leave both
-    // free_count() and in_flight_count() bounded; without discard()
-    // in_flight_count() would grow linearly.
+    // On MapAsync timeout, the caller cannot hand the buffer back via
+    // release() (the GPU may still be mapping it) but must drop the
+    // pool's reference so subsequent acquires don't grow in_flight_
+    // without bound. This test hammers that path: 32 discarded buffers
+    // must leave both free_count() and in_flight_count() bounded;
+    // without discard(), in_flight_count() would grow linearly.
     auto env = make_dawn_env();
     if (!env.valid()) {
         WARN("no Dawn device available; skipping");

--- a/test/test_gpu_timestamps.cpp
+++ b/test/test_gpu_timestamps.cpp
@@ -1,4 +1,4 @@
-// Phase 6.5 — Dawn GPU timestamp queries.
+// Dawn GPU timestamp queries.
 //
 // These tests cover the *pure* resolution layer of `gpu_timestamps.hpp`:
 // the nanosecond-tick -> millisecond conversion, the `decode_resolved_
@@ -10,7 +10,7 @@
 // `decode_resolved_ticks` is the seam `GpuTimestamps::resolve()` uses to
 // turn a mapped Dawn readback buffer into ticks — covering it here is
 // what proves `read_back()` surfaces populated, correctly-converted
-// numbers rather than the empty vector the Phase 6.5 P1 review flagged.
+// numbers rather than the empty vector returned by the earlier path.
 //
 // Live-device smoke (a real `wgpu::QuerySet` resolved against Metal/
 // Vulkan via `resolve()`) is deferred to CI's GPU matrix; the math and
@@ -94,12 +94,12 @@ TEST_CASE("timestamp_pair_to_ms treats an equal pair as zero duration",
 
 // ── decode_resolved_ticks — mapped-buffer byte decode ───────────────────────
 //
-// This is the seam the Phase 6.5 P1 review flagged: before this layer
-// existed, `GpuTimestamps::read_back()` returned an internal vector that
-// nothing ever populated, so GPU timings never surfaced even when the
-// device supported `timestamp-query`. `resolve()` now decodes the
-// mapped readback buffer through `decode_resolved_ticks`; these cases
-// pin that decode against the byte layout a real mapped buffer carries.
+// Before this layer existed, `GpuTimestamps::read_back()` returned an
+// internal vector that nothing ever populated, so GPU timings never
+// surfaced even when the device supported `timestamp-query`. `resolve()`
+// now decodes the mapped readback buffer through `decode_resolved_ticks`;
+// these cases pin that decode against the byte layout a real mapped
+// buffer carries.
 
 TEST_CASE("decode_resolved_ticks decodes a mapped timestamp buffer",
           "[render][gpu-timestamps]") {

--- a/test/test_skia_surface.cpp
+++ b/test/test_skia_surface.cpp
@@ -183,10 +183,9 @@ TEST_CASE("SkiaSurface null without Skia", "[render][skia]") {
 // ---------------------------------------------------------------------------
 // SkPicture (.skp) serialization on the Graphite backend
 //
-// Phase 6.4 spike (inspector roadmap): the planned "capture Skia frame"
-// feature wants to write a `.skp` artifact that the Skia team's own
-// `skiadebugger` can replay. Pulp renders through the Graphite backend
-// (skgpu::graphite::Context) — `.skp` / SkPicture is the legacy
+// The frame-capture path writes a `.skp` artifact that the Skia team's
+// own `skiadebugger` can replay. Pulp renders through the Graphite
+// backend (skgpu::graphite::Context) — `.skp` / SkPicture is the legacy
 // SkPicture serialization format, so we must verify the two compose.
 //
 // Verdict from these tests: `SkPicture` is backend-independent. An
@@ -196,8 +195,8 @@ TEST_CASE("SkiaSurface null without Skia", "[render][skia]") {
 // process is running. The single caveat is documented in SkPicture.h: the
 // default serializer encodes embedded `SkImage`s as nullptr unless the
 // caller supplies `SkSerialProcs::fImageProc`. That is format policy, not a
-// Graphite limitation — Phase 6.4 must set fImageProc to capture frames
-// that embed images. These tests pin both facts.
+// Graphite limitation: callers must set fImageProc to capture frames that
+// embed images. These tests pin both facts.
 // ---------------------------------------------------------------------------
 #ifdef PULP_HAS_SKIA
 
@@ -286,7 +285,7 @@ TEST_CASE("SkPicture round-trips through an SkStream", "[render][skia][skp]") {
     sk_sp<SkPicture> picture = record_vector_scene();
     REQUIRE(picture != nullptr);
 
-    // serialize(SkWStream*) is the path Phase 6.4 will use to write a file.
+    // serialize(SkWStream*) is the file-write path.
     SkDynamicMemoryWStream out;
     picture->serialize(&out);
     REQUIRE(out.bytesWritten() > 0);
@@ -302,11 +301,10 @@ TEST_CASE("SkPicture round-trips through an SkStream", "[render][skia][skp]") {
 }
 
 TEST_CASE("SkPicture serialization is independent of any GPU context", "[render][skia][skp]") {
-    // The whole point of the Phase 6.4 spike: prove SkPicture works without
-    // — and regardless of — a live Graphite context. A picture recorded and
-    // serialized with no GPU context whatsoever still round-trips, which is
-    // exactly why it is safe on the Graphite backend (Graphite never touches
-    // the SkPicture pipeline).
+    // SkPicture must work without — and regardless of — a live Graphite
+    // context. A picture recorded and serialized with no GPU context
+    // whatsoever still round-trips, which is exactly why it is safe on the
+    // Graphite backend (Graphite never touches the SkPicture pipeline).
     sk_sp<SkPicture> picture = record_vector_scene();
     sk_sp<SkData> blob = picture->serialize();
     REQUIRE(blob != nullptr);
@@ -320,10 +318,10 @@ TEST_CASE("SkPicture serialization is independent of any GPU context", "[render]
 TEST_CASE("SkPicture with embedded image needs fImageProc to round-trip pixels",
           "[render][skia][skp]") {
     // SkPicture.h documents: "The default behavior for serializing SkImages
-    // is to encode a nullptr." This is the one real caveat for Phase 6.4 —
-    // a captured frame that embeds images must supply SkSerialProcs so the
-    // image survives the round trip. This test pins that contract so the
-    // Phase 6.4 implementation does not silently ship null-image captures.
+    // is to encode a nullptr." A captured frame that embeds images must
+    // supply SkSerialProcs so the image survives the round trip. This test
+    // pins that contract so frame capture does not silently ship null-image
+    // captures.
 
     // A tiny raster image (the kind a real frame would embed; Graphite frames
     // upload raster sources, so this mirrors the captured-frame case).
@@ -390,14 +388,14 @@ TEST_CASE("SkPicture with embedded image needs fImageProc to round-trip pixels",
 #endif  // PULP_HAS_SKIA
 
 // ---------------------------------------------------------------------------
-// SkpFrameCapture — Phase 6.4 `.skp` frame-capture API (core/render)
+// SkpFrameCapture — `.skp` frame-capture API (core/render)
 //
 // These exercise the public capture surface in
 // core/render/include/pulp/render/skp_capture.hpp: record a frame's
 // draw ops through the capture's pulp::canvas::Canvas, serialize a
 // `.skp` artifact, and prove the round trip — including the load-bearing
-// embedded-image-pixel assertion the spike pinned (cullRect equality
-// alone is insufficient). The capture path is GPU-backend-agnostic and
+// embedded-image-pixel assertion (cullRect equality alone is insufficient).
+// The capture path is GPU-backend-agnostic and
 // needs no live GPU context, so these run on the CI matrix even without
 // a GPU adapter.
 // ---------------------------------------------------------------------------
@@ -499,8 +497,8 @@ TEST_CASE("SkpFrameCapture writes a loadable .skp file", "[render][skia][skp]") 
 
 TEST_CASE("SkpFrameCapture preserves embedded-image pixels via fImageProc",
           "[render][skia][skp]") {
-    // The load-bearing Phase 6.4 assertion: a frame that embeds an image
-    // must survive the .skp round trip with its pixels intact.
+    // A frame that embeds an image must survive the .skp round trip with its
+    // pixels intact.
     // SkpFrameCapture sets SkSerialProcs::fImageProc (PNG encode); if it
     // did not, the embedded image would deserialize to null and the
     // replay would be blank. Replay + pixel-sample is what proves the
@@ -612,11 +610,11 @@ TEST_CASE("SkiaCanvas fill-rule punches an even-odd hole in compound paths",
 
 TEST_CASE("SkpFrameCapture round-trips a GPU-texture-backed embedded image",
           "[render][skia][skp]") {
-    // Codex P1: SkPicture::serialize()'s image proc must not silently drop
-    // GPU-texture-backed embedded images. SkpFrameCapture rasterizes them
-    // via the Graphite Context threaded through the capture, so a frame
-    // that embeds a GPU image survives the .skp round trip with pixels
-    // intact. Requires a live GPU adapter — skips cleanly without one.
+    // SkPicture::serialize()'s image proc must not silently drop GPU-texture-
+    // backed embedded images. SkpFrameCapture rasterizes them via the
+    // Graphite Context threaded through the capture, so a frame that embeds
+    // a GPU image survives the .skp round trip with pixels intact. Requires
+    // a live GPU adapter — skips cleanly without one.
     auto gpu = GpuSurface::create_dawn();
     if (!gpu) return;
     GpuSurface::Config gpu_config{};
@@ -678,10 +676,9 @@ TEST_CASE("SkpFrameCapture round-trips a GPU-texture-backed embedded image",
 
 TEST_CASE("SkpFrameCapture writes atomically — a failed write leaves no file",
           "[render][skia][skp]") {
-    // Codex P2: the .skp must never land half-written and must never
-    // clobber a previously-valid capture. The write goes to a sibling
-    // <dest>.tmp and is renamed onto the destination only on full
-    // success.
+    // The .skp must never land half-written and must never clobber a
+    // previously-valid capture. The write goes to a sibling <dest>.tmp
+    // and is renamed onto the destination only on full success.
 
     SECTION("failed write does not create the destination file") {
         // A path inside a directory that does not exist: opening the

--- a/test/test_texture_atlas.cpp
+++ b/test/test_texture_atlas.cpp
@@ -436,9 +436,8 @@ TEST_CASE("BufferPool caps retained buffers at max_pool_size - issue-646",
     REQUIRE(drained == 32);
 }
 
-// ── Phase 6.2 — atlas introspection accessors ───────────────────────────────
+// ── Atlas introspection accessors ───────────────────────────────────────────
 //
-// Spec: planning/2026-05-19-inspector-phase6-gpu-perf-spike.md § Phase 6.2.
 // The inspector's texture-atlas viewer reads per-atlas dimensions and a
 // shelf-packer occupancy estimate. These tests pin the read-only accessors
 // added to AtlasPacker / ImageAtlas / GlyphAtlas / GradientAtlas / PathAtlas.
@@ -538,7 +537,7 @@ TEST_CASE("GradientAtlas exposes row capacity and occupancy - phase6.2",
     REQUIRE(ga.occupancy() == Catch::Approx(0.5f));  // 256 / 512.
 }
 
-// ── Phase 6.2 — AtlasInventory aggregator ───────────────────────────────────
+// ── AtlasInventory aggregator ───────────────────────────────────────────────
 
 TEST_CASE("AtlasInventory starts empty - phase6.2",
           "[render][atlas][phase6.2]") {


### PR DESCRIPTION
## Summary

Trim stale provenance/workflow breadcrumbs from GPU/Skia/texture test comments while preserving the comments that explain current behavior and failure modes.

Files:
- `test/test_gpu_compute.cpp`
- `test/test_gpu_compute_pool.cpp`
- `test/test_gpu_timestamps.cpp`
- `test/test_texture_atlas.cpp`
- `test/test_skia_surface.cpp`

What changed:
- Removed stale `Slice` / `Phase` / `Codex P1/P2` / review-id wording from long-lived comments.
- Removed planning-document path references from source comments.
- Reworded the surrounding comments as present-tense rationale.

Preserved intentionally:
- Catch2 test names/selectors, including `[codex-560]`, `[phase6.2]`, `[issue-3656]`, and related tags.
- Current allocator-churn, MapAsync-timeout/discard, timestamp decode, Dawn/SkPicture/fImageProc, atomic-write, fill-rule, atlas-capacity, and issue-anchor rationale.
- All executable code, assertions, test strings, and user-visible output.

## Review / validation

- RepoPrompt/rp-cli classification over the five selected files.
- Mechanical comment-only diff verifier: clean.
- Focused stale-breadcrumb scan: clean except protected `[codex-560]` selector.
- `git diff --check`: clean.
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main --head HEAD`: clean.
- `tools/scripts/gates.sh refs/remotes/origin/main`: clean.
- RepoPrompt actual-diff review: CLEAN.
- Codex+Claude autoreview: clean, 0 accepted/actionable findings.
- After `origin/main` advanced, rebased onto `a2371e3118113c6d33158283aa6b8f7ad03e8734` and reran the comment-only verifier, `git diff --check`, `docs_noise_lint`, and `gates.sh` successfully.

No build/test binary run: the patch is mechanically comment-only and the repo gates/reviews found no code-risk issue.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed stale provenance breadcrumbs from GPU/Skia/atlas test comments and rewrote them as brief, current rationale. No code changes; tests, tags, and outputs are unchanged.

- **Refactors**
  - Removed outdated `Slice`/`Phase`/`Codex P1/P2` wording and planning-doc paths across `test_gpu_compute.cpp`, `test_gpu_compute_pool.cpp`, `test_gpu_timestamps.cpp`, `test_texture_atlas.cpp`, and `test_skia_surface.cpp`.
  - Rephrased comments to explain present behavior (e.g., staging buffer pool reuse, MapAsync timeout/discard, timestamp decode, SkPicture capture, atlas accessors).
  - Kept all Catch2 selectors and tags (e.g., `[codex-560]`, `[phase6.2]`, `[issue-3656]`) and all executable code/outputs intact.

<sup>Written for commit 10bd9cafb9a35e361cadcbb9659f6524d439ca2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

