### PR TITLE
fix(ios): nest AUv3 example bundle id under host app

### DIFF
--- a/.agents/skills/ios/SKILL.md
+++ b/.agents/skills/ios/SKILL.md
@@ -441,7 +441,7 @@ The required frameworks (`AVFoundation`, `CoreBluetooth`,
 ```cmake
 pulp_add_ios_auv3(
     NAME               PulpSineSynth
-    BUNDLE_ID          com.pulp.examples.sinesynth
+    BUNDLE_ID          com.pulp.examples.sinesynth.host.PulpSineSynth
     MANUFACTURER       Pulp
     MANUFACTURER_CODE  Pulp        # exactly 4 characters
     SUBTYPE_CODE       PsSn        # exactly 4 characters

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.228.0",
+      "version": "0.228.1",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.228.0"
+  "version": "0.228.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.228.0",
+  "version": "0.228.1",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/docs/getting-started/ios-deployment.md
+++ b/docs/getting-started/ios-deployment.md
@@ -45,7 +45,7 @@ source ~/.config/pulp/secrets/notary.env
 # examples/ios-auv3-synth/CMakeLists.txt
 pulp_add_ios_auv3(
     NAME            PulpSineSynth
-    BUNDLE_ID       com.pulp.examples.sinesynth
+    BUNDLE_ID       com.pulp.examples.sinesynth.host.PulpSineSynth
     MANUFACTURER    Pulp
     MANUFACTURER_CODE  Pulp
     SUBTYPE_CODE    PsSn
@@ -151,7 +151,7 @@ cmake --build build-ios-device \
 
 > **Provisioning profile gotcha**: Automatic signing requires the
 > bundle identifier (`com.pulp.examples.sinesynth.host` and its
-> `.appex` sibling `com.pulp.examples.sinesynth`) to already exist
+> `.appex` child `com.pulp.examples.sinesynth.host.PulpSineSynth.appex`) to already exist
 > in [Apple Developer → Identifiers](https://developer.apple.com/account/resources/identifiers/list).
 > If Xcode reports "No matching profiles found", open the generated
 > `Pulp.xcodeproj` once in Xcode and let it register the IDs.

--- a/examples/ios-auv3-synth/CMakeLists.txt
+++ b/examples/ios-auv3-synth/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 # helper in tools/cmake/PulpUtils.cmake.
 pulp_add_ios_auv3(
     NAME            PulpSineSynth
-    BUNDLE_ID       com.pulp.examples.sinesynth
+    BUNDLE_ID       com.pulp.examples.sinesynth.host.PulpSineSynth
     MANUFACTURER    Pulp
     MANUFACTURER_CODE  Pulp
     SUBTYPE_CODE    PsSn

--- a/examples/ios-auv3-synth/src/sine_synth.cpp
+++ b/examples/ios-auv3-synth/src/sine_synth.cpp
@@ -15,7 +15,7 @@ PluginDescriptor SineSynth::descriptor() const {
     PluginDescriptor d;
     d.name = "Pulp Sine Synth";
     d.manufacturer = "Pulp";
-    d.bundle_id = "com.pulp.examples.sinesynth";
+    d.bundle_id = "com.pulp.examples.sinesynth.host.PulpSineSynth";
     d.version = "0.1.0";
     d.category = PluginCategory::Instrument;
     d.accepts_midi = true;

--- a/test/cmake/test_ios_auv3_configure.sh
+++ b/test/cmake/test_ios_auv3_configure.sh
@@ -152,6 +152,12 @@ if [[ "${PULP_IOS_AUV3_SMOKE_BUILD:-1}" == "1" ]]; then
         echo "FAIL: Info.plist missing from built .appex"
         exit 1
     fi
+    if [[ "$(/usr/bin/plutil -extract CFBundleIdentifier raw -o - "${appex_path}/Info.plist" 2>/dev/null)" \
+            != "com.pulp.examples.sinesynth.host.PulpSineSynth.appex" ]]; then
+        echo "FAIL: Info.plist CFBundleIdentifier is not nested under the HostApp id"
+        /usr/bin/plutil -p "${appex_path}/Info.plist" >&2
+        exit 1
+    fi
     if ! /usr/bin/plutil -p "${appex_path}/Info.plist" | grep -q 'com.apple.AudioUnit-UI'; then
         echo "FAIL: Info.plist NSExtension does not declare com.apple.AudioUnit-UI"
         /usr/bin/plutil -p "${appex_path}/Info.plist" >&2


### PR DESCRIPTION
## Summary

Fix the iOS AUv3 example after #4592's containment guard by making the example extension id a strict child of its HostApp id.

- sets the example AUv3 CMake `BUNDLE_ID` to `com.pulp.examples.sinesynth.host.PulpSineSynth`
- aligns the sample processor descriptor and iOS docs/skill snippets
- adds a smoke assertion for the generated `.appex` `CFBundleIdentifier`

## Why

`origin/main` was failing `cmake-ios-auv3-configure` and `cmake-ios-hostapp-links` because the new guard rejects the old example id `com.pulp.examples.sinesynth` under HostApp id `com.pulp.examples.sinesynth.host`.

Generated-output evidence from a temp iOS Xcode build:

- `PulpSineSynth.appex/Info.plist` `CFBundleIdentifier`: `com.pulp.examples.sinesynth.host.PulpSineSynth.appex`
- `NSExtension.NSExtensionAttributes.AudioComponentBundle`: `com.pulp.examples.sinesynth.host.PulpSineSynth.appex`

## Validation

- RepoPrompt selected/reviewed the iOS example, CMake guard, docs, and tests: clean
- `git diff --check`
- `test/cmake/test_ios_hostapp_bundle_guard.sh /Volumes/Workshop/Code/pulp-wt-ios-auv3-example-bundle-id-fix`
- `PULP_IOS_AUV3_SMOKE_BUILD=0 test/cmake/test_ios_auv3_configure.sh /Volumes/Workshop/Code/pulp-wt-ios-auv3-example-bundle-id-fix`
- `test/cmake/test_ios_hostapp_links.sh /Volumes/Workshop/Code/pulp-wt-ios-auv3-example-bundle-id-fix`
- `test/cmake/test_ios_auv3_configure.sh /Volumes/Workshop/Code/pulp-wt-ios-auv3-example-bundle-id-fix`
- `tools/scripts/gates.sh refs/remotes/origin/main`
- Codex+Claude autoreview panel with generated-plist evidence: clean, no accepted/actionable findings
- pre-push gates: clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Nests the iOS AUv3 example bundle ID under the HostApp so it passes the new containment guard and builds cleanly. Updates docs, snippets, and tests to the new ID.

- **Bug Fixes**
  - Set example AUv3 `BUNDLE_ID` to `com.pulp.examples.sinesynth.host.PulpSineSynth`.
  - Updated plugin descriptor and iOS docs/skill snippets.
  - Added a build test asserting `.appex` `CFBundleIdentifier` is `com.pulp.examples.sinesynth.host.PulpSineSynth.appex`.

- **Dependencies**
  - Bumped plugin metadata version to `0.228.1` in `.claude-plugin` configs.

<sup>Written for commit 20011f181ff6ef4762433536fec42b43e2d186ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

