### PR TITLE
fix(inspect): keep unavailable MCP wrappers honest

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -147,6 +147,10 @@ the tool takes arguments:
   as separate flags; a bare `{...}` token is ignored. Read-only tools that take
   no args sidestep this, so don't copy their dispatch shape for a tool that
   carries a payload.
+- **Do not wrap inspector error text as media.** Protocol-reserved methods that
+  are not wired yet (for example screenshot/evaluate surfaces waiting on
+  WindowHost or ScriptEngine references) should return ordinary text/error
+  content through MCP until the inspector method returns a real payload.
 - **Mutating tools must go through a typed inspector method** (e.g.
   `State.setParameter`) with validation + gesture wrapping in
   `StateInspector`/`DomainHandler` — never via `Runtime.evaluate`. Cover the

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.230.5",
+      "version": "0.231.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.230.5"
+  "version": "0.231.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.230.5",
+  "version": "0.231.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/.claude/commands/inspect.md
+++ b/.claude/commands/inspect.md
@@ -10,8 +10,12 @@ widget state, layout, and runtime diagnostics.
 ./build/pulp inspect
 ./build/pulp inspect --port 49152
 ./build/pulp inspect --command DOM.getDocument
-./build/pulp inspect --command Capture.screenshot --output shot.json
+./build/pulp inspect --command State.getParameters
 ```
+
+`Runtime.evaluate`, `Capture.screenshot`, and `Capture.screenshotNode`
+currently return explicit unavailable errors until script-engine and
+host-capture wiring lands.
 
 The inspector exposes:
 - View hierarchy with bounds, flex properties, and styles

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.466.2
+    VERSION 0.466.3
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/docs/agent-integrations.md
+++ b/docs/agent-integrations.md
@@ -53,8 +53,11 @@ The plugin extends Claude Code with:
   the CLI.
 - **MCP server**: Claude can call build/test/inspect tools as MCP
   tool calls instead of shell-and-parse. Highest value for the
-  inspector tools (`pulp_inspect_dom`, `pulp_inspect_evaluate`,
+  inspector tools (`pulp_inspect_dom`, `pulp_inspect_params`,
   etc.) which wrap the running-plugin inspector socket protocol.
+  `pulp_inspect_evaluate` and `pulp_inspect_screenshot` currently
+  return explicit unavailable errors until script-engine and
+  host-capture wiring lands.
 - **Setup hook**: when a Claude Code session starts in a project that
   has the plugin installed but `pulp` is not on PATH, prints a
   one-time install banner. Informational, never blocks the session.

--- a/docs/guides/claude-code-plugin.md
+++ b/docs/guides/claude-code-plugin.md
@@ -98,7 +98,7 @@ clients) can drive them in one turn instead of multiple shell calls.
 |---|---|
 | Build / test / status | `pulp_build`, `pulp_test`, `pulp_status`, `pulp_validate`, `pulp_create`, `pulp_docs_check`, `pulp_docs_search` |
 | UI rendering + interaction | `pulp_screenshot` (render JS UI to PNG), `pulp_simulate_click`, `pulp_get_view_tree` |
-| Live plugin inspection (inspector protocol) | `pulp_inspect_dom`, `pulp_inspect_params`, `pulp_inspect_set_param` (gesture-wrapped numeric param write), `pulp_inspect_screenshot`, `pulp_inspect_evaluate` (JS expr), `pulp_inspect_performance`, `pulp_inspect_audio` |
+| Live plugin inspection (inspector protocol) | `pulp_inspect_dom`, `pulp_inspect_params`, `pulp_inspect_set_param` (gesture-wrapped numeric param write), `pulp_inspect_screenshot` (currently returns the inspector unavailable error until host-capture wiring lands), `pulp_inspect_evaluate` (currently returns the inspector unavailable error until ScriptEngine wiring lands), `pulp_inspect_performance`, `pulp_inspect_audio` |
 | Audio model / WAV-first excerpt-find / live probe/scope JSON | `pulp_audio_model_list`, `pulp_audio_model_status`, `pulp_audio_model_activate`, `pulp_audio_excerpt_find`, `pulp_audio_read_bundle`, `pulp_audio_probe_json`, `pulp_audio_scope` |
 | Kit manifests | `pulp_kit`, `pulp_kit_search`, `pulp_kit_validate`, `pulp_kit_inspect`, `pulp_kit_plan`, `pulp_kit_verify`, `pulp_kit_apply`, `pulp_kit_remove`, `pulp_kit_pack`, `pulp_kit_publish_check`, `pulp_kit_init` |
 | Content packs | `pulp_content`, `pulp_content_validate`, `pulp_content_preview`, `pulp_content_install`, `pulp_content_update`, `pulp_content_list`, `pulp_content_rescan`, `pulp_content_remove`, `pulp_content_reveal` |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1146,7 +1146,7 @@ directory.
 pulp inspect
 pulp inspect --port 49152
 pulp inspect --command DOM.getDocument
-pulp inspect --command Capture.screenshot --output shot.json
+pulp inspect --command State.getParameters
 ```
 
 Options:
@@ -1156,6 +1156,11 @@ Options:
 - `--command METHOD` - send one inspector command and print the response
 - `--params JSON` - JSON params for `--command`
 - `--output FILE` - write a one-shot command response to a file
+
+`Runtime.evaluate`, `Capture.screenshot`, and `Capture.screenshotNode` are
+reserved inspector protocol methods, but currently return explicit unavailable
+errors until script-engine and host-capture references are wired into the
+inspector domain.
 
 ### tweaks
 

--- a/test/test_mcp_server.cpp
+++ b/test/test_mcp_server.cpp
@@ -1662,6 +1662,36 @@ TEST_CASE("MCP wrapper tools route to the correct handler arm (project-root gate
     }
 }
 
+TEST_CASE("MCP inspect screenshot and evaluate wrappers preserve unavailable text",
+          "[mcp][tools][inspect][coverage]") {
+#if defined(_WIN32)
+    SKIP("POSIX fake script assertions are only used on non-Windows");
+#else
+    TempDir project;
+    std::filesystem::create_directories(project.path / "core");
+    std::ofstream(project.path / "CMakeLists.txt") << "project(FakePulp VERSION 1.2.3)\n";
+    make_fake_pulp_cli(project.path);
+
+    ScopedCurrentPath cwd(project.path);
+
+    auto evaluate = handle_request(tool_call(
+        "50", "pulp_inspect_evaluate",
+        R"JSON({"expression":"window.title + ' ok'"})JSON"));
+    require_contains(evaluate, R"JSON("id":50)JSON");
+    require_contains(evaluate, "fake-pulp [inspect] [--command] [Runtime.evaluate] [--params]");
+    require_contains(evaluate, R"JSON([{\"expression\":\"window.title + ' ok'\"}])JSON");
+    REQUIRE(evaluate.find(R"JSON([Runtime.evaluate] [{\"expression\")JSON")
+            == std::string::npos);
+
+    auto screenshot = handle_request(tool_call("51", "pulp_inspect_screenshot"));
+    require_contains(screenshot, R"JSON("id":51)JSON");
+    require_contains(screenshot, R"JSON("type":"text")JSON");
+    require_contains(screenshot, "fake-pulp [inspect] [--command] [Capture.screenshot]");
+    REQUIRE(screenshot.find(R"JSON("type":"image")JSON") == std::string::npos);
+    REQUIRE(screenshot.find(R"JSON("mimeType":"image/png")JSON") == std::string::npos);
+#endif
+}
+
 TEST_CASE("MCP validate only passes --all for the explicit all flag",
           "[mcp][tools][validate][coverage]") {
 #if defined(_WIN32)

--- a/tools/cli/cmd_inspect.cpp
+++ b/tools/cli/cmd_inspect.cpp
@@ -162,8 +162,11 @@ int cmd_inspect(const std::vector<std::string>& args) {
             std::cout << "Examples:\n";
             std::cout << "  pulp inspect                              # Interactive REPL\n";
             std::cout << "  pulp inspect --command DOM.getDocument     # One-shot query\n";
-            std::cout << "  pulp inspect --command Capture.screenshot --output shot.png\n";
+            std::cout << "  pulp inspect --command State.getParameters # Parameter snapshot\n";
             std::cout << "  pulp inspect --host 192.168.1.42          # Remote debugging\n";
+            std::cout << "\n";
+            std::cout << "Note: Runtime.evaluate and Capture.screenshot currently report unavailable\n";
+            std::cout << "until script-engine and host-capture wiring lands.\n";
             return 0;
         }
         if (args[i] == "--host") {

--- a/tools/mcp/pulp_mcp.cpp
+++ b/tools/mcp/pulp_mcp.cpp
@@ -128,8 +128,8 @@ static std::string tools_list_json() {
     out += R"JSON({"name":"pulp_inspect_dom","description":"Get the view tree of a running plugin's UI via the inspector protocol","inputSchema":{"type":"object","properties":{}}},)JSON";
     out += R"JSON({"name":"pulp_inspect_params","description":"Get all parameter info and current values from a running plugin","inputSchema":{"type":"object","properties":{}}},)JSON";
     out += R"JSON({"name":"pulp_inspect_set_param","description":"Set a parameter value on a running plugin (standalone host) via the inspector. Wraps the write in a host gesture so DAW undo/automation grouping behaves like a user edit. Numeric parameters only; errors on an unknown parameter id. Note: the inspector is wired into the standalone host, not plugin formats loaded in a third-party DAW.","inputSchema":{"type":"object","required":["id","value"],"properties":{"id":{"type":"integer","description":"Parameter id (from pulp_inspect_params)"},"value":{"type":"number","description":"New value (raw, or a 0..1 position when normalized=true)"},"normalized":{"type":"boolean","description":"Treat value as a 0..1 normalized position (default false)"}}}},)JSON";
-    out += R"JSON({"name":"pulp_inspect_screenshot","description":"Capture a screenshot from a running plugin via the inspector","inputSchema":{"type":"object","properties":{}}},)JSON";
-    out += R"JSON({"name":"pulp_inspect_evaluate","description":"Evaluate a JS expression in a running plugin's script engine","inputSchema":{"type":"object","properties":{"expression":{"type":"string","description":"JS expression to evaluate"}}}},)JSON";
+    out += R"JSON({"name":"pulp_inspect_screenshot","description":"Request an inspector screenshot. Currently returns the inspector unavailable error until WindowHost capture wiring lands.","inputSchema":{"type":"object","properties":{}}},)JSON";
+    out += R"JSON({"name":"pulp_inspect_evaluate","description":"Request Runtime.evaluate in a running plugin. Currently returns the inspector unavailable error until ScriptEngine wiring lands.","inputSchema":{"type":"object","properties":{"expression":{"type":"string","description":"JS expression to evaluate"}}}},)JSON";
     out += R"JSON({"name":"pulp_inspect_performance","description":"Get render performance metrics from a running plugin","inputSchema":{"type":"object","properties":{}}},)JSON";
     out += R"JSON({"name":"pulp_inspect_audio","description":"Get audio configuration from a running plugin via Audio.getConfig","inputSchema":{"type":"object","properties":{}}},)JSON";
     out += R"JSON({"name":"pulp_motion_start_trace","description":"Start a motion trace via the inspector Motion.startTrace protocol. Attaches one or more metric probes (geometry / scroll-geometry) on a target view and begins streaming Motion.sample events. Enables tracing on the Coordinator if it is currently off. Returns the assigned trace_id.","inputSchema":{"type":"object","required":["view_name","metrics"],"properties":{"view_name":{"type":"string","description":"Human-readable trace name attached to all emitted events"},"fps":{"type":"integer","description":"Target sample rate in frames per second (default 15)"},"metrics":{"type":"array","description":"Metric probes. Each item is {kind:'geometry'|'scroll-geometry', name, node_id, properties?, space?, source?}.","items":{"type":"object","required":["kind"],"properties":{"kind":{"type":"string","enum":["geometry","scroll-geometry","scrollGeometry"]},"name":{"type":"string"},"node_id":{"type":"string"},"properties":{"type":"array","items":{"type":"string"}},"space":{"type":"string"},"source":{"type":"string"}}}}}}},)JSON";
@@ -445,7 +445,10 @@ static std::string handle_request_raw(const std::string& json) {
             else if (name == "pulp_inspect_evaluate") {
                 inspector_method = "Runtime.evaluate";
                 auto expr = extract_string(args_json, "expression");
-                if (!expr.empty()) inspector_params = " {\"expression\":" + json_string(expr) + "}";
+                if (!expr.empty()) {
+                    auto params_json = std::string("{\"expression\":") + json_string(expr) + "}";
+                    inspector_params = " --params " + shell_quote(params_json);
+                }
             }
             else if (name == "pulp_inspect_performance") inspector_method = "Performance.getMetrics";
             else if (name == "pulp_inspect_audio")   inspector_method = "Audio.getConfig";
@@ -456,12 +459,7 @@ static std::string handle_request_raw(const std::string& json) {
             } else {
                 auto cli = (root / "build" / "tools" / "cli" / "pulp").string();
                 auto output = exec(cli + " inspect --command " + inspector_method + inspector_params + " 2>&1");
-                if (name == "pulp_inspect_screenshot") {
-                    // Screenshot returns base64 PNG — escape for safe JSON embedding
-                    result = "{\"content\":[{\"type\":\"image\",\"data\":" + json_string(output) + ",\"mimeType\":\"image/png\"}]}";
-                } else {
-                    result = "{\"content\":[{\"type\":\"text\",\"text\":" + json_string(output) + "}]}";
-                }
+                result = "{\"content\":[{\"type\":\"text\",\"text\":" + json_string(output) + "}]}";
             }
         }
         else return json_error(id, -32601, "Unknown tool: " + name);


### PR DESCRIPTION
## Summary

- Mark inspector MCP screenshot/evaluate wrappers as currently unavailable until WindowHost/ScriptEngine wiring exists.
- Fix `pulp_inspect_evaluate` MCP wrapper argument construction to pass inspector params through `--params` instead of appending bare JSON.
- Keep screenshot/evaluate unavailable/error responses as MCP text rather than pretending screenshot failures are image payloads.
- Update inspect docs, Claude command docs, agent integration docs, and cli-maintenance guidance.
- Add MCP regression coverage for unavailable inspect screenshot/evaluate wrappers.

## Validation

- `git diff --check`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target pulp-test-mcp-server pulp-test-cli-shellout --parallel 8`
- `./build/test/pulp-test-mcp-server "MCP inspect screenshot and evaluate wrappers preserve unavailable text"`
- `./build/test/pulp-test-cli-shellout "pulp inspect help and no-discovery paths are deterministic"`
- `./build/test/pulp-test-mcp-server`
- `python3 tools/scripts/cli_sync_check.py`
- `python3 tools/scripts/check_cli_mcp_parity.py --mode=report`
- `python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main`
- `python3 tools/scripts/version_bump_check.py --mode=report --base origin/main`
- `python3 tools/scripts/docs_noise_lint.py --mode=report --base origin/main`
- `python3 tools/docs_generate.py check`
- `tools/check-docs.sh`
- Pre-push hook completed cleanly after full CTest: `10449/10449` passed, expected skips only, diff coverage `100%` on `tools/mcp/pulp_mcp.cpp`.

## Notes

- `shipyard pr` could not create the PR because local `gh auth status` reports the default personal token is invalid. The branch was pushed over SSH after the pre-push hook completed cleanly, and this PR was opened through the GitHub connector.
- Local QEMU Windows runner is healthy and idle with `queued=0`; current Shipyard `windows` target is the old unreachable `ssh-windows` target, and the repo PR profile treats authoritative Windows as GitHub-hosted x64. The local QEMU runner is an ARM64 smoke lane, not a substitute for required x64 PR validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks the inspector screenshot/evaluate MCP wrappers as unavailable and fixes `pulp_inspect_evaluate` arg passing to avoid bogus payloads and confusion. Updates docs/help to reflect the current inspector status and adds regression tests.

- **Bug Fixes**
  - `pulp_inspect_screenshot` and `pulp_inspect_evaluate` now return clear unavailable text until WindowHost/ScriptEngine wiring exists; no fake `image/png` payloads.
  - `Runtime.evaluate` params are passed via `--params` (properly quoted) instead of appending bare JSON.
  - CLI help and docs updated to show `State.getParameters` example and note unavailable inspector methods.
  - Added MCP tests to verify `--params` flow and text responses for unavailable methods.
  - Version bumps: framework `0.466.3`, plugin `0.231.0`.

<sup>Written for commit 86c35779afcaca027d7dfe292475d506d0a50cbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

