### PR TITLE
feat(host): per-connection PDC in the canonical executor routing path

### DIFF
--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -150,7 +150,12 @@ predictable output, no MIDI.
   stale tail across blocks that SignalGraph's per-node buffer does — the reason a
   Plugin node needs a live slot to be eligible (a null-slot placeholder would
   take the legacy pass-through-or-zero branch, which the executor does not
-  reproduce). MIDI / automation / sidechain graphs stay on the legacy walk.
+  reproduce). A latency-reporting plugin IS eligible: the routed gather applies
+  the same per-connection plug-in delay compensation as the legacy walk
+  (per-node latency is propagated through the topology in the buffer assignment,
+  and each feedforward connection that needs it gets a delay ring sized in the
+  `GraphRuntimeBufferPool`), so fan-in paths of differing latency time-align
+  identically. MIDI / automation / sidechain graphs stay on the legacy walk.
 - `connect()` returns `false` on cycle — always check. `would_create_cycle`
   lets you preview without mutating.
 - `processing_order()` is recomputed each call; cache it in the audio

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.237.0",
+      "version": "0.238.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.237.0"
+  "version": "0.238.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.237.0",
+  "version": "0.238.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.474.0
+    VERSION 0.475.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/audio/include/pulp/audio/rt_safety_contract.hpp
+++ b/core/audio/include/pulp/audio/rt_safety_contract.hpp
@@ -605,9 +605,10 @@ inline constexpr std::array kCoreRuntimeRtSafetyContracts{
         true,
         "audio thread over a prepared snapshot + pre-sized GraphRuntimeBufferPool",
         "Routes inter-node audio through caller-allocated scratch slots: "
-        "gather/scatter and the one-block feedback capture are bounded fills and "
-        "copies, no allocation or lock. The snapshot's buffer assignment and the "
-        "pool are built off the callback; pool.fits() must hold for the block."),
+        "gather/scatter, the one-block feedback capture, and the per-connection "
+        "delay-compensation rings are bounded fills and copies, no allocation or "
+        "lock. The snapshot's buffer assignment and the pool (slots + delay "
+        "rings) are built off the callback; pool.fits() must hold for the block."),
 };
 
 [[nodiscard]] constexpr std::span<const RtSafetyContract>

--- a/core/format/include/pulp/format/graph_runtime_executor.hpp
+++ b/core/format/include/pulp/format/graph_runtime_executor.hpp
@@ -165,6 +165,15 @@ public:
     // Zero-fills, so the first block (and any feedback edge) reads silence.
     // Returns false on allocation failure or zero max_frames with slots.
     bool reset(std::uint32_t slot_count, std::uint32_t max_frames);
+
+    // Off-RT: as above, plus per-connection plug-in-delay-compensation rings.
+    // `connection_delay_samples` is the snapshot assignment's per-connection
+    // delay (0 = no ring). Each delayed connection gets a contiguous ring of
+    // (delay + max_frames) floats and a persisted write position, zero-filled so
+    // the leading delay reads silence. The 2-arg reset is equivalent to passing
+    // an all-zero / empty span. Returns false on allocation failure.
+    bool reset(std::uint32_t slot_count, std::uint32_t max_frames,
+               std::span<const std::uint32_t> connection_delay_samples);
     void clear() noexcept;
 
     std::uint32_t slot_count() const noexcept { return slot_count_; }
@@ -180,15 +189,63 @@ public:
         return storage_.data() + static_cast<std::size_t>(index) * max_frames_;
     }
 
-    // True when the pool can back `snapshot`'s routing for a block of `frames`.
+    // A per-connection plug-in-delay-compensation ring: a contiguous float
+    // buffer of `size` (= delay + max_frames) with a persisted write position the
+    // executor advances by the block's frame count. `data == nullptr` when the
+    // connection needs no delay.
+    struct DelayRing {
+        float* data = nullptr;
+        std::uint32_t size = 0;
+        std::uint32_t delay = 0;
+        int* write_pos = nullptr;
+    };
+
+    // RT-safe: the delay ring for connection `index`, or an empty ring (data ==
+    // nullptr) when the connection has no delay or the pool carries no rings.
+    DelayRing delay_ring(std::uint32_t index) noexcept {
+        if (index >= ring_.size()) return {};
+        RingSlot& r = ring_[index];
+        if (r.size == 0) return {};
+        return DelayRing{ring_storage_.data() + r.offset, r.size, r.delay, &r.write_pos};
+    }
+
+    // True when the pool can back `snapshot`'s routing for a block of `frames`:
+    // enough mono slots, a large-enough max_frames, and — if the snapshot needs
+    // PDC — a delay-ring layout matching its connection count (so a pool sized
+    // without rings falls back to the legacy walk rather than routing without
+    // delay compensation and diverging). This validates ring COUNT, not each
+    // ring's size; the invariant that the rings were sized from THIS snapshot's
+    // per-connection delays is held by construction — reset() the pool from the
+    // same buffer_assignment that built the snapshot (both travel as one
+    // CompiledGraph). Pairing a pool with a same-connection-count-but-different-
+    // delays snapshot is not a supported call sequence.
     bool fits(const GraphRuntimeSnapshot& snapshot, std::uint32_t frames) const noexcept {
-        return slot_count_ >= snapshot.buffer_slot_count() && frames <= max_frames_;
+        if (slot_count_ < snapshot.buffer_slot_count() || frames > max_frames_) {
+            return false;
+        }
+        const auto& assignment = snapshot.buffer_assignment();
+        if (assignment.has_delay &&
+            ring_.size() != snapshot.plan().connections.size()) {
+            return false;
+        }
+        return true;
     }
 
 private:
+    // Per-connection delay-ring layout (parallel to the plan's connections; empty
+    // when the pool was reset without delays). size == 0 means no ring.
+    struct RingSlot {
+        std::uint32_t offset = 0;  // into ring_storage_
+        std::uint32_t size = 0;    // delay + max_frames; 0 = no ring
+        std::uint32_t delay = 0;
+        int write_pos = 0;         // persisted RT state, advanced per block
+    };
+
     std::vector<float> storage_;
     std::uint32_t slot_count_ = 0;
     std::uint32_t max_frames_ = 0;
+    std::vector<float> ring_storage_;
+    std::vector<RingSlot> ring_;
 };
 
 class GraphRuntimeExecutor {

--- a/core/format/src/graph_runtime_executor.cpp
+++ b/core/format/src/graph_runtime_executor.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <span>
 #include <utility>
 
 namespace pulp::format {
@@ -61,11 +62,11 @@ graph::GraphEvent command_event(const graph::GraphTimedCommand& command,
 // captured source output), matching SignalGraph's one-block feedback_prev. Event
 // edges carry no audio and are skipped.
 //
-// Feedforward edges are summed with no plug-in delay compensation. SignalGraph
-// applies a per-connection PDC ring when a node reports latency
-// (signal_graph.cpp); the executor needs the same before it can route
-// latency-reporting graphs. Routing parity holds today because the routed
-// graphs report zero latency.
+// A feedforward edge whose source is less latent than the destination's
+// most-latent input is delayed through a per-connection ring (sized by the
+// snapshot's buffer assignment, stored in the pool) so fan-in paths time-align,
+// matching the host graph's per-connection delay lines. Edges with zero delay
+// take the plain sum path.
 void gather_node_inputs(const graph::GraphRuntimePlan& plan,
                         const graph::GraphRuntimeBufferAssignment& assignment,
                         GraphRuntimeBufferPool& pool,
@@ -82,16 +83,36 @@ void gather_node_inputs(const graph::GraphRuntimePlan& plan,
             plan.inbound_connection_indices[node.first_inbound_connection + c];
         const auto& conn = plan.connections[conn_index];
         if (conn.event) continue;
-        const float* src = nullptr;
-        if (conn.feedback) {
-            src = pool.slot_data(assignment.feedback_prev_slot[conn_index]);
-        } else {
-            const auto& src_slots = assignment.nodes[conn.source_index];
-            src = pool.slot_data(src_slots.output_base + conn.source_port);
-        }
         float* dst = pool.slot_data(slots.input_base + conn.dest_port);
-        if (src == nullptr || dst == nullptr) continue;
-        for (std::uint32_t f = 0; f < frames; ++f) dst[f] += src[f];
+        if (dst == nullptr) continue;
+        if (conn.feedback) {
+            const float* src = pool.slot_data(assignment.feedback_prev_slot[conn_index]);
+            if (src == nullptr) continue;
+            for (std::uint32_t f = 0; f < frames; ++f) dst[f] += src[f];
+            continue;
+        }
+        const auto& src_slots = assignment.nodes[conn.source_index];
+        const float* src = pool.slot_data(src_slots.output_base + conn.source_port);
+        if (src == nullptr) continue;
+        const auto ring = pool.delay_ring(conn_index);
+        if (ring.data == nullptr || ring.delay == 0) {
+            for (std::uint32_t f = 0; f < frames; ++f) dst[f] += src[f];
+        } else {
+            // Per-connection delay line: write the current sample at the write
+            // head, read the sample `delay` positions behind it, accumulate.
+            const int ring_size = static_cast<int>(ring.size);
+            const int delay = static_cast<int>(ring.delay);
+            int wp = *ring.write_pos;
+            int rp = wp - delay;
+            if (rp < 0) rp += ring_size;
+            for (std::uint32_t f = 0; f < frames; ++f) {
+                ring.data[wp] = src[f];
+                dst[f] += ring.data[rp];
+                if (++wp == ring_size) wp = 0;
+                if (++rp == ring_size) rp = 0;
+            }
+            *ring.write_pos = wp;
+        }
     }
 }
 
@@ -152,9 +173,44 @@ void copy_io_bus(graph::GraphRuntimeNodeKind kind,
 } // namespace
 
 bool GraphRuntimeBufferPool::reset(std::uint32_t slot_count, std::uint32_t max_frames) {
+    return reset(slot_count, max_frames, {});
+}
+
+bool GraphRuntimeBufferPool::reset(std::uint32_t slot_count, std::uint32_t max_frames,
+                                   std::span<const std::uint32_t> connection_delay_samples) {
     if (slot_count > 0 && max_frames == 0) return false;
     try {
         storage_.assign(static_cast<std::size_t>(slot_count) * max_frames, 0.0f);
+
+        // Lay out one contiguous ring per delayed connection in ring_storage_.
+        // A delay of D needs D + max_frames floats (the legacy per-connection
+        // delay line), zero-filled so the leading D samples read silence.
+        std::vector<RingSlot> rings;
+        std::size_t total_ring_floats = 0;
+        if (!connection_delay_samples.empty()) {
+            rings.assign(connection_delay_samples.size(), RingSlot{});
+            for (std::size_t i = 0; i < connection_delay_samples.size(); ++i) {
+                const std::uint32_t delay = connection_delay_samples[i];
+                if (delay == 0) continue;
+                const std::uint32_t size = delay + max_frames;
+                // Fail closed rather than truncate the 32-bit ring offset: a
+                // truncated offset would index out of ring_storage_ on the RT
+                // gather. Off-RT, so the bound check is free.
+                if (total_ring_floats > 0xFFFFFFFFull - size) {
+                    clear();
+                    return false;
+                }
+                rings[i].offset = static_cast<std::uint32_t>(total_ring_floats);
+                rings[i].size = size;
+                rings[i].delay = delay;
+                rings[i].write_pos = 0;
+                total_ring_floats += size;
+            }
+        }
+        std::vector<float> ring_storage(total_ring_floats, 0.0f);
+
+        ring_ = std::move(rings);
+        ring_storage_ = std::move(ring_storage);
     } catch (...) {
         clear();
         return false;
@@ -168,6 +224,8 @@ void GraphRuntimeBufferPool::clear() noexcept {
     storage_.clear();
     slot_count_ = 0;
     max_frames_ = 0;
+    ring_storage_.clear();
+    ring_.clear();
 }
 
 bool GraphRuntimeSnapshot::reset(

--- a/core/graph/include/pulp/graph/graph_runtime_buffer_assignment.hpp
+++ b/core/graph/include/pulp/graph/graph_runtime_buffer_assignment.hpp
@@ -53,6 +53,20 @@ struct GraphRuntimeBufferAssignment {
     std::vector<std::uint32_t> feedback_prev_slot;
     // True if the plan has any feedback connection.
     bool has_feedback = false;
+    // Indexed by connection index (matches GraphRuntimePlan::connections). For a
+    // feedforward audio connection, the number of samples its source output must
+    // be delayed so it time-aligns with the destination's most-latent input —
+    // plug-in delay compensation. Derived by propagating per-node
+    // latency_samples through the topology (input_latency = max upstream
+    // output_latency; output_latency = input_latency + this node's
+    // latency_samples) and taking dst.input_latency - src.output_latency. 0 for
+    // connections that need no delay and for every feedback/event connection.
+    // The backing delay ring (sized delay + max_frames, with a persisted write
+    // position) lives in the GraphRuntimeBufferPool, which knows max_frames; the
+    // assignment carries only the per-connection sample counts.
+    std::vector<std::uint32_t> connection_delay_samples;
+    // True if any connection needs a non-zero delay.
+    bool has_delay = false;
     bool ok = false;
 };
 

--- a/core/graph/include/pulp/graph/graph_runtime_plan.hpp
+++ b/core/graph/include/pulp/graph/graph_runtime_plan.hpp
@@ -41,6 +41,12 @@ struct GraphRuntimeNodeSpec {
     // slot reuse would otherwise hand it a different node's stale data.
     // Meaningful only for nodes with output_ports > 0; a no-op otherwise.
     bool persistent_output = false;
+    // Latency this node ADDS to its own signal path, in samples (e.g. a hosted
+    // plugin's reported processing latency). The buffer assignment propagates it
+    // through the topology to derive per-connection delay compensation so that
+    // fan-in paths of differing latency time-align. Zero for nodes that add no
+    // latency (audio I/O, gain).
+    std::uint32_t latency_samples = 0;
 };
 
 struct GraphRuntimeConnectionSpec {
@@ -61,6 +67,8 @@ struct GraphRuntimeNodePlan {
     std::uint32_t event_output_ports = 0;
     // Carried from GraphRuntimeNodeSpec::persistent_output; see that field.
     bool persistent_output = false;
+    // Carried from GraphRuntimeNodeSpec::latency_samples; see that field.
+    std::uint32_t latency_samples = 0;
     std::uint32_t first_inbound_connection = 0;
     std::uint32_t inbound_connection_count = 0;
     std::uint32_t first_outbound_connection = 0;

--- a/core/graph/src/graph_runtime_buffer_assignment.cpp
+++ b/core/graph/src/graph_runtime_buffer_assignment.cpp
@@ -61,6 +61,7 @@ GraphRuntimeBufferAssignment build_graph_runtime_buffer_assignment(
     try {
         assignment.nodes.resize(node_count);
         assignment.feedback_prev_slot.assign(plan.connections.size(), kGraphRuntimeNoSlot);
+        assignment.connection_delay_samples.assign(plan.connections.size(), 0);
     } catch (...) {
         assignment = {};
         assignment.ok = false;
@@ -153,6 +154,42 @@ GraphRuntimeBufferAssignment build_graph_runtime_buffer_assignment(
             }
         }
         assignment.slot_count = cursor;
+    } catch (...) {
+        assignment = {};
+        assignment.ok = false;
+        return assignment;
+    }
+
+    // Plug-in delay compensation. Propagate each node's added latency through the
+    // topology in processing order (every source resolves before its consumers),
+    // then derive each feedforward connection's required delay so fan-in paths of
+    // differing latency time-align — matching the host graph's per-connection
+    // delay lines. Feedback and event connections carry no delay.
+    try {
+        std::vector<std::uint32_t> input_latency(node_count, 0);
+        std::vector<std::uint32_t> output_latency(node_count, 0);
+        for (const auto node_index : plan.processing_order_indices) {
+            const auto& node = plan.nodes[node_index];
+            std::uint32_t max_upstream = 0;
+            for (std::uint32_t c = 0; c < node.inbound_connection_count; ++c) {
+                const auto ci = plan.inbound_connection_indices[
+                    node.first_inbound_connection + c];
+                const auto& conn = plan.connections[ci];
+                if (conn.feedback || conn.event) continue;
+                max_upstream = std::max(max_upstream, output_latency[conn.source_index]);
+            }
+            input_latency[node_index] = max_upstream;
+            output_latency[node_index] = max_upstream + node.latency_samples;
+        }
+        for (std::size_t i = 0; i < plan.connections.size(); ++i) {
+            const auto& conn = plan.connections[i];
+            if (conn.feedback || conn.event) continue;
+            const std::uint32_t dst_in = input_latency[conn.dest_index];
+            const std::uint32_t src_out = output_latency[conn.source_index];
+            const std::uint32_t want = dst_in > src_out ? dst_in - src_out : 0;
+            assignment.connection_delay_samples[i] = want;
+            if (want > 0) assignment.has_delay = true;
+        }
     } catch (...) {
         assignment = {};
         assignment.ok = false;

--- a/core/graph/src/graph_runtime_plan.cpp
+++ b/core/graph/src/graph_runtime_plan.cpp
@@ -122,6 +122,7 @@ GraphRuntimePlanResult build_graph_runtime_plan(
                 spec.event_input_ports,
                 spec.event_output_ports,
                 spec.persistent_output,
+                spec.latency_samples,
                 0,
                 0,
                 0,

--- a/core/host/include/pulp/host/signal_graph_executor_routing.hpp
+++ b/core/host/include/pulp/host/signal_graph_executor_routing.hpp
@@ -65,7 +65,8 @@ struct SignalGraphExecutorRouting {
 //   - nodes only AudioInput / AudioOutput / Gain (fixed 2-in/2-out, always
 //     fully writes) / Plugin (every Plugin node must carry a live slot; its
 //     output region is pinned persistent so a plugin that does not fully write
-//     matches SignalGraph's persistent per-node buffer);
+//     matches SignalGraph's persistent per-node buffer; a reported latency is
+//     fine — its delay compensation is replicated on the routed path);
 //   - connections only plain audio (feedforward or feedback; no MIDI,
 //     automation, audio-rate-modulation, or sidechain).
 // No prepared check.

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -1173,7 +1173,8 @@ SignalGraph::compile_(double sample_rate, int max_block_size) {
         if (cg->routing_valid && max_block_size > 0) {
             cg->routing_valid = cg->exec_pool.reset(
                 cg->routing_snapshot.buffer_slot_count(),
-                static_cast<std::uint32_t>(max_block_size));
+                static_cast<std::uint32_t>(max_block_size),
+                cg->routing_snapshot.buffer_assignment().connection_delay_samples);
         }
     }
     return cg;

--- a/core/host/src/signal_graph_executor_routing.cpp
+++ b/core/host/src/signal_graph_executor_routing.cpp
@@ -115,12 +115,11 @@ bool node_eligible(const GraphNode& node) noexcept {
         case NodeType::Plugin:
             // A Plugin node only routes bit-exactly when its slot is live (the
             // binding invokes it; a missing/placeholder slot would take
-            // SignalGraph's pass-through-or-zero branch instead) AND reports zero
-            // latency: the executor's gather has no per-connection PDC delay yet,
-            // so a latency-reporting plugin — which the legacy walk delay-
-            // compensates — would diverge. Such graphs stay on the legacy walk
-            // until executor PDC lands.
-            return node.plugin != nullptr && node.plugin->latency_samples() == 0;
+            // SignalGraph's pass-through-or-zero branch instead). A reported
+            // latency is fine: the executor's gather applies the same
+            // per-connection delay compensation as the legacy walk, derived from
+            // the node's latency_samples carried into the plan.
+            return node.plugin != nullptr;
         default:
             return false;
     }
@@ -184,6 +183,17 @@ bool build_executor_snapshot(std::span<const GraphNode> nodes,
             static_cast<std::uint32_t>(std::max(0, node.num_output_ports)),
         };
         spec.persistent_output = node.type == NodeType::Plugin;
+        // Carry the node's reported latency so the buffer assignment can derive
+        // per-connection delay compensation. Resolve it from the SAME slot the
+        // legacy walk's latency pass uses (plugin_for == the compiled snapshot's
+        // plugins) so the propagated delays match exactly.
+        if (node.type == NodeType::Plugin) {
+            PluginSlot* slot = plugin_for ? plugin_for(node.id) : nullptr;
+            if (slot != nullptr) {
+                spec.latency_samples =
+                    static_cast<std::uint32_t>(std::max(0, slot->latency_samples()));
+            }
+        }
         node_specs.push_back(spec);
     }
 
@@ -260,7 +270,8 @@ bool build_signal_graph_executor_routing(const SignalGraph& graph,
     const int max_block = graph.prepared_max_block_size();
     if (max_block <= 0) return false;
     if (!out.pool.reset(out.snapshot.buffer_slot_count(),
-                        static_cast<std::uint32_t>(max_block))) {
+                        static_cast<std::uint32_t>(max_block),
+                        out.snapshot.buffer_assignment().connection_delay_samples)) {
         return false;
     }
 

--- a/test/test_graph_runtime_buffer_assignment.cpp
+++ b/test/test_graph_runtime_buffer_assignment.cpp
@@ -256,3 +256,60 @@ TEST_CASE("Persistent-output and feedback pinning coexist without slot collision
         }
     }
 }
+
+TEST_CASE("Buffer assignment propagates latency into per-connection delays",
+          "[graph][buffer-assignment][pdc]") {
+    // Diamond: AudioInput -> {plugin(latency 64), gain} -> AudioOutput. The gain
+    // arm is less latent than the plugin arm, so its edges to the output must be
+    // delayed by 64 to time-align the fan-in; every other edge needs no delay.
+    const std::array nodes = {
+        GraphRuntimeNodeSpec{1, GraphRuntimeNodeKind::AudioInput, 0, 2},
+        GraphRuntimeNodeSpec{2, GraphRuntimeNodeKind::Processor, 2, 2, 0, 0, true, 64},
+        GraphRuntimeNodeSpec{3, GraphRuntimeNodeKind::Processor, 2, 2},
+        GraphRuntimeNodeSpec{4, GraphRuntimeNodeKind::AudioOutput, 2, 0},
+    };
+    const std::array conns = {
+        GraphRuntimeConnectionSpec{1, 0, 2, 0},  // in -> plugin
+        GraphRuntimeConnectionSpec{1, 1, 2, 1},
+        GraphRuntimeConnectionSpec{1, 0, 3, 0},  // in -> gain
+        GraphRuntimeConnectionSpec{1, 1, 3, 1},
+        GraphRuntimeConnectionSpec{2, 0, 4, 0},  // plugin -> out
+        GraphRuntimeConnectionSpec{2, 1, 4, 1},
+        GraphRuntimeConnectionSpec{3, 0, 4, 0},  // gain -> out (delayed)
+        GraphRuntimeConnectionSpec{3, 1, 4, 1},
+    };
+    const auto plan = build_graph_runtime_plan(nodes, conns);
+    REQUIRE(plan.ok());
+    const auto a = build_graph_runtime_buffer_assignment(plan.plan);
+    check_invariants(plan.plan, a);
+
+    REQUIRE(a.has_delay);
+    REQUIRE(a.connection_delay_samples.size() == plan.plan.connections.size());
+    // Dense indices: gain == node index 2, output == node index 3.
+    for (std::size_t i = 0; i < plan.plan.connections.size(); ++i) {
+        const auto& c = plan.plan.connections[i];
+        const bool gain_to_out = c.source_index == 2 && c.dest_index == 3;
+        CHECK(a.connection_delay_samples[i] == (gain_to_out ? 64u : 0u));
+    }
+}
+
+TEST_CASE("Buffer assignment reports no delay when no node adds latency",
+          "[graph][buffer-assignment][pdc]") {
+    const std::array nodes = {
+        GraphRuntimeNodeSpec{1, GraphRuntimeNodeKind::AudioInput, 0, 2},
+        GraphRuntimeNodeSpec{2, GraphRuntimeNodeKind::Processor, 2, 2},
+        GraphRuntimeNodeSpec{3, GraphRuntimeNodeKind::AudioOutput, 2, 0},
+    };
+    const std::array conns = {
+        GraphRuntimeConnectionSpec{1, 0, 2, 0},
+        GraphRuntimeConnectionSpec{1, 1, 2, 1},
+        GraphRuntimeConnectionSpec{2, 0, 3, 0},
+        GraphRuntimeConnectionSpec{2, 1, 3, 1},
+    };
+    const auto plan = build_graph_runtime_plan(nodes, conns);
+    REQUIRE(plan.ok());
+    const auto a = build_graph_runtime_buffer_assignment(plan.plan);
+    check_invariants(plan.plan, a);
+    CHECK_FALSE(a.has_delay);
+    for (const auto d : a.connection_delay_samples) CHECK(d == 0u);
+}

--- a/test/test_signal_graph_executor_parity.cpp
+++ b/test/test_signal_graph_executor_parity.cpp
@@ -736,11 +736,12 @@ TEST_CASE("SignalGraph::process plugin executor path does not allocate on the au
     }
 }
 
-TEST_CASE("Executor eligibility rejects a latency-reporting plugin",
-          "[host][graph][executor][routing][eligibility][plugin]") {
-    // The executor's gather has no per-connection PDC delay; the legacy walk
-    // delay-compensates a latency-reporting plugin, so such a graph must stay on
-    // the legacy walk (ineligible) rather than route and diverge silently.
+TEST_CASE("Translated routing matches SignalGraph: latency-reporting plugin in a chain",
+          "[host][graph][executor][routing][parity][plugin][pdc]") {
+    // A latency-reporting plugin is now eligible: the routed gather applies the
+    // same per-connection delay compensation as the legacy walk. In a pure chain
+    // every path is equally latent, so no connection is delayed — but the graph
+    // must still be eligible and route bit-exactly across blocks.
     SignalGraph g;
     const auto in = g.add_input_node(2, "In");
     const auto p = g.add_plugin_node(
@@ -753,8 +754,148 @@ TEST_CASE("Executor eligibility rejects a latency-reporting plugin",
         REQUIRE(g.connect(p, c, out, c));
     }
     REQUIRE(g.prepare(kSr, kFrames));
-    REQUIRE_FALSE(signal_graph_executor_eligible(g));
+    REQUIRE(signal_graph_executor_eligible(g));
     SignalGraphExecutorRouting routing;
-    REQUIRE_FALSE(build_signal_graph_executor_routing(g, routing));
-    REQUIRE_FALSE(routing.valid);
+    REQUIRE(build_signal_graph_executor_routing(g, routing));
+    REQUIRE(routing.valid);
+    pulp::format::GraphRuntimeExecutor exec;
+    for (int blk = 0; blk < 4; ++blk) {
+        const std::vector<std::vector<float>> input{
+            ramp(kFrames, 0.8f + 0.01f * static_cast<float>(blk)),
+            ramp(kFrames, 0.6f - 0.01f * static_cast<float>(blk))};
+        INFO("block " << blk);
+        expect_equal(run_legacy(g, kFrames, input, 2),
+                     run_routed(exec, routing, kFrames, input, 2));
+    }
+}
+
+namespace {
+
+// A diamond where one arm carries a latency-reporting plugin and the other a
+// plain gain. The plain arm must be delay-compensated to time-align with the
+// plugin arm at the output fan-in, exercising the per-connection delay ring.
+// Driven over several blocks (the ring carries state across blocks) and required
+// to match SignalGraph's own walk block-for-block. Parameterized on the reported
+// latency so both sub-block and supra-block delays are covered.
+void run_latency_diamond_parity(int latency) {
+    SignalGraph g;
+    const auto in = g.add_input_node(2, "In");
+    const auto p = g.add_plugin_node(
+        std::make_unique<DeterministicPlugin>(
+            DeterministicPlugin::Mode::kFull, 0.5f, 2, 2, latency),
+        2, 2, "LatencyP");
+    const auto gain = g.add_gain_node("G");
+    const auto out = g.add_output_node(2, "Out");
+    for (int c = 0; c < 2; ++c) {
+        REQUIRE(g.connect(in, c, p, c));      // latent arm
+        REQUIRE(g.connect(in, c, gain, c));   // plain arm (must be delayed)
+        REQUIRE(g.connect(p, c, out, c));
+        REQUIRE(g.connect(gain, c, out, c));  // fan-in sum at the output
+    }
+    REQUIRE(g.set_node_gain(gain, 0.75f));
+    REQUIRE(g.prepare(kSr, kFrames));
+    REQUIRE(signal_graph_executor_eligible(g));
+    SignalGraphExecutorRouting routing;
+    REQUIRE(build_signal_graph_executor_routing(g, routing));
+    REQUIRE(routing.valid);
+    pulp::format::GraphRuntimeExecutor exec;
+    for (int blk = 0; blk < 8; ++blk) {
+        const std::vector<std::vector<float>> input{
+            ramp(kFrames, 0.7f + 0.03f * static_cast<float>(blk)),
+            ramp(kFrames, 0.5f + 0.02f * static_cast<float>(blk))};
+        INFO("latency " << latency << " block " << blk);
+        expect_equal(run_legacy(g, kFrames, input, 2),
+                     run_routed(exec, routing, kFrames, input, 2));
+    }
+}
+
+}  // namespace
+
+TEST_CASE("Translated routing matches SignalGraph: latency diamond, sub-block delay",
+          "[host][graph][executor][routing][parity][plugin][pdc]") {
+    run_latency_diamond_parity(/*latency=*/64);  // < kFrames (128)
+}
+
+TEST_CASE("Translated routing matches SignalGraph: latency diamond, supra-block delay",
+          "[host][graph][executor][routing][parity][plugin][pdc]") {
+    run_latency_diamond_parity(/*latency=*/200);  // > kFrames (128): ring wraps
+}
+
+TEST_CASE("Translated routing matches SignalGraph: latency diamond, mixed block sizes",
+          "[host][graph][executor][routing][parity][plugin][pdc]") {
+    // The ring is sized delay + max_frames precisely so a runtime block shorter
+    // than the prepared maximum still wraps correctly. Prepare at kFrames but
+    // drive blocks of varying length (including sub-max), requiring block-for-
+    // block equality so the shorter-block ring advance is exercised.
+    SignalGraph g;
+    const auto in = g.add_input_node(2, "In");
+    const auto p = g.add_plugin_node(
+        std::make_unique<DeterministicPlugin>(
+            DeterministicPlugin::Mode::kFull, 0.5f, 2, 2, /*latency=*/96),
+        2, 2, "LatencyP");
+    const auto gain = g.add_gain_node("G");
+    const auto out = g.add_output_node(2, "Out");
+    for (int c = 0; c < 2; ++c) {
+        REQUIRE(g.connect(in, c, p, c));
+        REQUIRE(g.connect(in, c, gain, c));
+        REQUIRE(g.connect(p, c, out, c));
+        REQUIRE(g.connect(gain, c, out, c));
+    }
+    REQUIRE(g.set_node_gain(gain, 0.75f));
+    REQUIRE(g.prepare(kSr, kFrames));  // max_block = kFrames (128)
+    REQUIRE(signal_graph_executor_eligible(g));
+    SignalGraphExecutorRouting routing;
+    REQUIRE(build_signal_graph_executor_routing(g, routing));
+    REQUIRE(routing.valid);
+    pulp::format::GraphRuntimeExecutor exec;
+    const std::array<int, 6> block_sizes{64, 128, 32, 100, 64, 17};
+    for (std::size_t b = 0; b < block_sizes.size(); ++b) {
+        const int frames = block_sizes[b];
+        const std::vector<std::vector<float>> input{
+            ramp(frames, 0.7f + 0.05f * static_cast<float>(b)),
+            ramp(frames, 0.5f + 0.04f * static_cast<float>(b))};
+        INFO("block " << b << " frames " << frames);
+        expect_equal(run_legacy(g, frames, input, 2),
+                     run_routed(exec, routing, frames, input, 2));
+    }
+}
+
+TEST_CASE("SignalGraph::process PDC executor path does not allocate on the audio thread",
+          "[host][graph][executor][routing][rt-safety][plugin][pdc]") {
+    // The per-connection delay ring is sized at prepare(); the gather only does
+    // bounded index arithmetic and copies over it. Exercise the delayed-edge
+    // branch (a latency diamond) under the allocation probe.
+    SignalGraph g;
+    const auto in = g.add_input_node(2, "In");
+    const auto p = g.add_plugin_node(
+        std::make_unique<DeterministicPlugin>(
+            DeterministicPlugin::Mode::kFull, 0.5f, 2, 2, /*latency=*/200),
+        2, 2, "LatencyP");
+    const auto gain = g.add_gain_node("G");
+    const auto out = g.add_output_node(2, "Out");
+    for (int c = 0; c < 2; ++c) {
+        REQUIRE(g.connect(in, c, p, c));
+        REQUIRE(g.connect(in, c, gain, c));
+        REQUIRE(g.connect(p, c, out, c));
+        REQUIRE(g.connect(gain, c, out, c));
+    }
+    REQUIRE(g.set_node_gain(gain, 0.75f));
+    g.set_canonical_executor_routing_enabled(true);
+    REQUIRE(g.prepare(kSr, kFrames));
+    REQUIRE(signal_graph_executor_eligible(g));
+
+    const auto l = ramp(kFrames, 0.8f), r = ramp(kFrames, 0.6f);
+    std::vector<float> li = l, ri = r;
+    std::vector<float> lo(kFrames, 0.0f), ro(kFrames, 0.0f);
+    std::array<const float*, 2> ic{li.data(), ri.data()};
+    std::array<float*, 2> oc{lo.data(), ro.data()};
+    pulp::audio::BufferView<const float> iv(ic.data(), 2, kFrames);
+    pulp::audio::BufferView<float> ov(oc.data(), 2, kFrames);
+
+    g.process(ov, iv, kFrames);  // warm-up outside the probe
+    {
+        pulp::test::RtAllocationProbe probe;
+        g.process(ov, iv, kFrames);
+        REQUIRE_FALSE(probe.saw_allocation());
+    }
 }


### PR DESCRIPTION
Replicates SignalGraph's per-connection plug-in delay compensation on the canonical `GraphRuntimeExecutor` routing path, so **latency-reporting plugins** become eligible for the opt-in (default-OFF) executor route. Phase 4 slice 4f-3c.

## What
- `GraphRuntimeNodeSpec`/`NodePlan` carry a `latency_samples` field; the SignalGraph translation sets it from the same plugin slot the legacy latency pass uses.
- `build_graph_runtime_buffer_assignment` propagates per-node latency through the processing order and derives each feedforward connection's delay (`dst.input_latency - src.output_latency`), matching `compute_latencies_for_`.
- `GraphRuntimeBufferPool` gains per-connection delay rings (`delay + max_frames`, with a persisted write position) laid out off-RT in a new 3-arg `reset()`. `gather_node_inputs` routes a delayed edge through the ring with arithmetic identical to the legacy delay line; zero-delay edges keep the plain sum path.
- `fits()` rejects a ringless pool backing a PDC snapshot, so a mis-sized pool falls back to the legacy walk rather than routing without delay compensation.
- Plugin eligibility no longer requires zero latency.

## Tests (bit-exact vs SignalGraph, RT no-alloc, TSan-clean)
- Assignment latency-propagation unit tests (diamond → delayed arm == latency; no-latency → no delay).
- SignalGraph parity: latency plugin in a chain; latency diamond at sub-block (64), supra-block (200, ring wraps), and mixed block sizes (64/128/32/100/64/17) across blocks.
- PDC routed no-alloc trap; TSan 5× on the PDC + re-prepare-while-rendering concurrency hammer.

Default-OFF (`set_canonical_executor_routing_enabled`); the legacy walk stays the fallback + oracle. Adversarially reviewed (no MUST-FIX; applied the uint32 ring-offset fail-closed guard, the `fits()` invariant comment, and the mixed-block parity test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-connection plug-in delay compensation to the canonical `GraphRuntimeExecutor`, enabling latency-reporting plugins to use the executor routing path with bit-for-bit parity to SignalGraph. Default OFF; remains RT-safe and falls back to the legacy walk if the pool isn’t sized for PDC.

- New Features
  - Nodes carry `latency_samples`; the SignalGraph translation sets it from the plugin slot.
  - Buffer assignment propagates latencies and computes per-connection `connection_delay_samples`.
  - `GraphRuntimeBufferPool` adds a 3-arg `reset(slot_count, max_frames, connection_delay_samples)` that lays out per-connection delay rings (`delay + max_frames`) with a persisted write head, plus a `delay_ring()` accessor.
  - `fits()` validates slot/max_frames and ring presence/count so a ringless pool cleanly falls back.
  - `gather_node_inputs` routes delayed edges through the rings; zero-delay edges follow the plain sum path.
  - Executor eligibility no longer requires zero plugin latency.

<sup>Written for commit 5ca007f7507d1dc61b194aba5f8309b932ca75a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

