### PR TITLE
feat(host): route sidechain edges on the canonical executor path

### DIFF
--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -139,8 +139,9 @@ predictable output, no MIDI.
   auxes, surround, or multi-output products.
 - **Canonical-executor routing (opt-in, default OFF).** An eligible graph —
   nodes only AudioInput / AudioOutput / Gain / Plugin (every Plugin node must
-  carry a LIVE slot), connections only plain audio (feedforward or one-block
-  feedback; no MIDI / automation / audio-rate-mod / sidechain) — can be driven
+  carry a LIVE slot), connections only audio (feedforward, one-block feedback,
+  or sidechain — a sidechain edge routes as plain audio into a higher input port
+  of the destination plugin; no MIDI / automation / audio-rate-mod) — can be driven
   through the canonical `GraphRuntimeExecutor` instead of the legacy walk via
   `set_canonical_executor_routing_enabled(true)`. Output is bit-identical to the
   legacy walk (`signal_graph_executor_routing.{hpp,cpp}` translates the graph;

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.238.0",
+      "version": "0.239.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.238.0"
+  "version": "0.239.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.238.0",
+  "version": "0.239.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.475.0
+    VERSION 0.476.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/host/include/pulp/host/signal_graph_executor_routing.hpp
+++ b/core/host/include/pulp/host/signal_graph_executor_routing.hpp
@@ -67,8 +67,9 @@ struct SignalGraphExecutorRouting {
 //     output region is pinned persistent so a plugin that does not fully write
 //     matches SignalGraph's persistent per-node buffer; a reported latency is
 //     fine — its delay compensation is replicated on the routed path);
-//   - connections only plain audio (feedforward or feedback; no MIDI,
-//     automation, audio-rate-modulation, or sidechain).
+//   - connections only audio (feedforward, feedback, or sidechain — a sidechain
+//     edge routes as plain audio into a higher input port of the destination
+//     plugin; no MIDI, automation, or audio-rate-modulation).
 // No prepared check.
 bool signal_graph_topology_executor_eligible(std::span<const GraphNode> nodes,
                                               std::span<const Connection> connections);

--- a/core/host/src/signal_graph_executor_routing.cpp
+++ b/core/host/src/signal_graph_executor_routing.cpp
@@ -126,10 +126,14 @@ bool node_eligible(const GraphNode& node) noexcept {
 }
 
 bool connection_eligible(const Connection& c) noexcept {
-    // Plain audio only; feedback is fine (the executor handles one-block
-    // feedback). MIDI / automation / audio-rate-mod / sidechain keep the
-    // legacy walk.
-    return !c.midi && !c.automation && !c.audio_rate_modulation && !c.sidechain;
+    // Audio edges only. Feedback is fine (the executor handles one-block
+    // feedback). Sidechain is fine: SignalGraph routes a sidechain edge as a
+    // plain audio edge into a higher input port of the destination plugin (the
+    // plugin's input_ports count already includes its sidechain ports, and the
+    // single concatenated input bus carries them), and it participates in PDC
+    // exactly like any audio edge — all of which the routed gather reproduces.
+    // MIDI / automation / audio-rate-mod still keep the legacy walk.
+    return !c.midi && !c.automation && !c.audio_rate_modulation;
 }
 
 } // namespace

--- a/test/test_signal_graph_executor_parity.cpp
+++ b/test/test_signal_graph_executor_parity.cpp
@@ -513,7 +513,7 @@ PluginInfo test_plugin_info(int in_ch, int out_ch) {
 //                      current block), so the same instance can drive both walks.
 class DeterministicPlugin final : public PluginSlot {
 public:
-    enum class Mode { kFull, kPartialCh1Gated };
+    enum class Mode { kFull, kPartialCh1Gated, kSidechainMix };
     DeterministicPlugin(Mode mode, float scale, int in_ch, int out_ch, int latency = 0)
         : mode_(mode), scale_(scale), latency_(latency),
           info_(test_plugin_info(in_ch, out_ch)) {}
@@ -529,6 +529,24 @@ public:
                  const pulp::host::ParameterEventQueue&,
                  int n) override {
         const std::size_t chs = out.num_channels();
+        if (mode_ == Mode::kSidechainMix) {
+            // out[c] = main[c] * scale + sidechain[c], where the sidechain
+            // channels are the input channels just past the main channels (a
+            // plugin exposing `chs` main + `chs` sidechain inputs). Reading the
+            // sidechain channels makes a sidechain-routing or PDC-delay bug
+            // surface as an output divergence.
+            for (std::size_t c = 0; c < chs; ++c) {
+                float* o = out.channel_ptr(c);
+                const float* m = c < in.num_channels() ? in.channel_ptr(c) : nullptr;
+                const std::size_t sc = c + chs;
+                const float* s = sc < in.num_channels() ? in.channel_ptr(sc) : nullptr;
+                for (int k = 0; k < n; ++k) {
+                    const auto i = static_cast<std::size_t>(k);
+                    o[i] = (m ? m[i] * scale_ : 0.0f) + (s ? s[i] : 0.0f);
+                }
+            }
+            return;
+        }
         const bool gate_open = in.num_samples() > 0 && in.num_channels() > 0 &&
                                in.channel_ptr(0)[0] > 0.0f;
         for (std::size_t c = 0; c < chs; ++c) {
@@ -897,5 +915,86 @@ TEST_CASE("SignalGraph::process PDC executor path does not allocate on the audio
         pulp::test::RtAllocationProbe probe;
         g.process(ov, iv, kFrames);
         REQUIRE_FALSE(probe.saw_allocation());
+    }
+}
+
+TEST_CASE("Translated routing matches SignalGraph: sidechain edges",
+          "[host][graph][executor][routing][parity][plugin][sidechain]") {
+    // A plugin with 2 main + 2 sidechain input ports reads its sidechain
+    // channels (out = main*scale + sidechain). The sidechain source is a
+    // separately-scaled copy of the input so main != sidechain. The routed
+    // gather must fill the plugin's higher input ports from the sidechain edges
+    // exactly as SignalGraph does.
+    SignalGraph g;
+    const auto in = g.add_input_node(2, "In");
+    const auto sc = g.add_gain_node("SCGain");
+    const auto p = g.add_plugin_node(
+        std::make_unique<DeterministicPlugin>(
+            DeterministicPlugin::Mode::kSidechainMix, 0.5f, /*in_ch=*/4, /*out_ch=*/2),
+        4, 2, "MixP");
+    const auto out = g.add_output_node(2, "Out");
+    for (int c = 0; c < 2; ++c) {
+        REQUIRE(g.connect(in, c, p, c));                       // main inputs
+        REQUIRE(g.connect(in, c, sc, c));                      // feed the sc source
+        REQUIRE(g.connect_sidechain(sc, c, p, c + 2));         // sidechain inputs
+        REQUIRE(g.connect(p, c, out, c));
+    }
+    REQUIRE(g.set_node_gain(sc, 0.75f));
+    REQUIRE(g.prepare(kSr, kFrames));
+    REQUIRE(signal_graph_executor_eligible(g));
+    SignalGraphExecutorRouting routing;
+    REQUIRE(build_signal_graph_executor_routing(g, routing));
+    REQUIRE(routing.valid);
+    pulp::format::GraphRuntimeExecutor exec;
+    for (int blk = 0; blk < 4; ++blk) {
+        const std::vector<std::vector<float>> input{
+            ramp(kFrames, 0.8f + 0.02f * static_cast<float>(blk)),
+            ramp(kFrames, 0.6f - 0.02f * static_cast<float>(blk))};
+        INFO("block " << blk);
+        expect_equal(run_legacy(g, kFrames, input, 2),
+                     run_routed(exec, routing, kFrames, input, 2));
+    }
+}
+
+TEST_CASE("Translated routing matches SignalGraph: sidechain edge with PDC delay",
+          "[host][graph][executor][routing][parity][plugin][sidechain][pdc]") {
+    // The main path runs through a latency-reporting plugin, so the plugin
+    // mixing in the sidechain sees its main inputs at latency 64 and its
+    // sidechain inputs (a plain gain path) at latency 0 — the sidechain edges
+    // must be PDC-delayed by 64 to time-align. Exercises PDC on sidechain edges;
+    // requires block-for-block parity (the delay ring carries state).
+    SignalGraph g;
+    const auto in = g.add_input_node(2, "In");
+    const auto latP = g.add_plugin_node(
+        std::make_unique<DeterministicPlugin>(
+            DeterministicPlugin::Mode::kFull, 0.5f, 2, 2, /*latency=*/64),
+        2, 2, "LatP");
+    const auto sc = g.add_gain_node("SCGain");
+    const auto mixP = g.add_plugin_node(
+        std::make_unique<DeterministicPlugin>(
+            DeterministicPlugin::Mode::kSidechainMix, 1.0f, /*in_ch=*/4, /*out_ch=*/2),
+        4, 2, "MixP");
+    const auto out = g.add_output_node(2, "Out");
+    for (int c = 0; c < 2; ++c) {
+        REQUIRE(g.connect(in, c, latP, c));
+        REQUIRE(g.connect(latP, c, mixP, c));                  // main (latency 64)
+        REQUIRE(g.connect(in, c, sc, c));
+        REQUIRE(g.connect_sidechain(sc, c, mixP, c + 2));      // sidechain (latency 0)
+        REQUIRE(g.connect(mixP, c, out, c));
+    }
+    REQUIRE(g.set_node_gain(sc, 0.75f));
+    REQUIRE(g.prepare(kSr, kFrames));
+    REQUIRE(signal_graph_executor_eligible(g));
+    SignalGraphExecutorRouting routing;
+    REQUIRE(build_signal_graph_executor_routing(g, routing));
+    REQUIRE(routing.valid);
+    pulp::format::GraphRuntimeExecutor exec;
+    for (int blk = 0; blk < 8; ++blk) {
+        const std::vector<std::vector<float>> input{
+            ramp(kFrames, 0.7f + 0.03f * static_cast<float>(blk)),
+            ramp(kFrames, 0.5f + 0.02f * static_cast<float>(blk))};
+        INFO("block " << blk);
+        expect_equal(run_legacy(g, kFrames, input, 2),
+                     run_routed(exec, routing, kFrames, input, 2));
     }
 }


### PR DESCRIPTION
Makes sidechain connections eligible for the opt-in (default-OFF) canonical-executor routing path. Phase 4 slice 4f-3d.

A SignalGraph sidechain edge is structurally a plain audio edge into a higher input port of the destination plugin:
- `connect_sidechain` requires the plugin to already expose the input port, so the node's `input_ports` count includes its sidechain ports.
- Both the legacy walk and the executor present the plugin a **single concatenated Main input bus** (`in_ch = num_input_ports`); there is no separate Sidechain bus in the SignalGraph plugin path.
- Sidechain participates in PDC exactly like any audio edge (legacy `compute_latencies_for_` does not skip it; the executor assignment keys delay on `!feedback && !event`).

So the routed gather already reproduces sidechain routing — this slice just drops the `!c.sidechain` exclusion from the executor-routing eligibility check.

## Tests (bit-exact vs SignalGraph)
- **Sidechain parity**: a plugin reading its sidechain channels (`out = main*0.5 + sidechain`), fed a distinctly-scaled sidechain signal, across blocks — distinguishes correct higher-port routing from a misroute or a dropped sidechain.
- **Sidechain + PDC parity**: the main arm runs through a latency-64 plugin, so the sidechain edge is delay-compensated by 64; bit-exact across 8 blocks (the delay ring carries state).

Default-OFF; legacy walk stays the fallback + oracle. Adversarially reviewed: no MUST-FIX / SHOULD-FIX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables routing of sidechain edges on the opt‑in canonical executor path, matching SignalGraph’s single-bus input model and preserving PDC. Default stays OFF.

- **New Features**
  - Allows sidechain connections by removing the `!c.sidechain` exclusion; treated as plain audio into higher input ports. MIDI/automation/audio‑rate‑mod remain excluded; one-block feedback still supported.
  - Adds parity tests: sidechain mix and sidechain + PDC (64‑sample latency) to verify bit‑exact output across blocks.
  - Updates docs/comments to describe sidechain behavior and bumps versions (`project 0.476.0`, `plugin 0.239.0`).

<sup>Written for commit 7f727dc5ccc66e3a5651438b0bdc7bab32c8b9ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

