### PR TITLE
feat(host): route MIDI edges on the canonical executor path

### DIFF
--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -139,9 +139,10 @@ predictable output, no MIDI.
   auxes, surround, or multi-output products.
 - **Canonical-executor routing (opt-in, default OFF).** An eligible graph —
   nodes only AudioInput / AudioOutput / Gain / Plugin (every Plugin node must
-  carry a LIVE slot), connections only audio (feedforward, one-block feedback,
-  or sidechain — a sidechain edge routes as plain audio into a higher input port
-  of the destination plugin; no MIDI / automation / audio-rate-mod) — can be driven
+  carry a LIVE slot) / MidiInput / MidiOutput, connections audio (feedforward,
+  one-block feedback, or sidechain — a sidechain edge routes as plain audio into
+  a higher input port of the destination plugin) or MIDI (connect_midi event
+  edges; no automation / audio-rate-mod) — can be driven
   through the canonical `GraphRuntimeExecutor` instead of the legacy walk via
   `set_canonical_executor_routing_enabled(true)`. Output is bit-identical to the
   legacy walk (`signal_graph_executor_routing.{hpp,cpp}` translates the graph;
@@ -156,7 +157,10 @@ predictable output, no MIDI.
   (per-node latency is propagated through the topology in the buffer assignment,
   and each feedforward connection that needs it gets a delay ring sized in the
   `GraphRuntimeBufferPool`), so fan-in paths of differing latency time-align
-  identically. MIDI / automation / sidechain graphs stay on the legacy walk.
+  identically. MIDI edges route through per-node MIDI scratch buffers owned by
+  the executor (`GraphRuntimeMidiScratch`); SignalGraph bridges its MIDI
+  mailboxes (inject_midi / extract_midi) around the routed call. Automation /
+  audio-rate-mod graphs stay on the legacy walk.
 - `connect()` returns `false` on cycle — always check. `would_create_cycle`
   lets you preview without mutating.
 - `processing_order()` is recomputed each call; cache it in the audio

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.239.0",
+      "version": "0.240.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.239.0"
+  "version": "0.240.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.239.0",
+  "version": "0.240.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.476.0
+    VERSION 0.477.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/graph_runtime_executor.hpp
+++ b/core/format/include/pulp/format/graph_runtime_executor.hpp
@@ -5,11 +5,14 @@
 #include <pulp/graph/graph_runtime_buffer_assignment.hpp>
 #include <pulp/graph/graph_runtime_plan.hpp>
 #include <pulp/graph/graph_runtime_queue.hpp>
+#include <pulp/midi/buffer.hpp>
+#include <pulp/midi/ump_buffer.hpp>
 
 #include <array>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <span>
 #include <vector>
 
@@ -53,6 +56,14 @@ struct GraphRuntimeNodeProcessContext {
     // `node_outputs` (its assigned scratch slots). Channels are mono slots.
     audio::BufferView<const float> node_inputs;
     audio::BufferView<float> node_outputs;
+    // Per-node MIDI (non-null only on the routing path when the call supplies a
+    // GraphRuntimeMidiScratch). `node_midi_in` holds the events gathered from
+    // this node's inbound event connections (the executor fills it before the
+    // binding runs); a binding that emits MIDI writes `node_midi_out` (clearing
+    // it first). Null when the graph carries no MIDI — a binding then falls back
+    // to its own scratch.
+    midi::MidiBuffer* node_midi_in = nullptr;
+    midi::MidiBuffer* node_midi_out = nullptr;
 };
 
 using GraphRuntimeNodeProcessFn = bool (*)(
@@ -248,6 +259,70 @@ private:
     std::vector<RingSlot> ring_;
 };
 
+/// Pre-allocated per-node MIDI buffers backing the routing path's event edges.
+///
+/// One `in`/`out` MidiBuffer pair per plan node (indexed by dense node index),
+/// each with an attached UmpBuffer and reserved to a fixed realtime capacity so
+/// add()/sysex append never allocate on the audio thread. The executor clears a
+/// node's `in` and gathers its inbound event connections into it before the
+/// node runs; a MIDI-emitting binding writes the node's `out`. A node's `out`
+/// also serves as the source other nodes gather from, so it persists for the
+/// block. The caller (host) bridges MidiInput/MidiOutput system nodes to its own
+/// mailboxes around process_routed by writing/reading these buffers directly.
+///
+/// Slots are heap-stable (each pair is a unique_ptr) because a MidiBuffer holds
+/// a pointer to its attached UmpBuffer; a reallocating vector would dangle it.
+class GraphRuntimeMidiScratch {
+public:
+    // Off-RT: (re)allocate `node_count` in/out buffer pairs, each reserved to the
+    // fixed realtime capacities. Returns false on allocation failure.
+    bool reset(std::uint32_t node_count);
+    void clear() noexcept;
+
+    std::uint32_t node_count() const noexcept { return node_count_; }
+
+    // RT-safe: this node's gathered MIDI input / produced MIDI output buffer, or
+    // nullptr if the node index is out of range.
+    midi::MidiBuffer* in(std::uint32_t node_index) noexcept {
+        return node_index < node_count_ ? &slots_[node_index]->in_buffer : nullptr;
+    }
+    midi::MidiBuffer* out(std::uint32_t node_index) noexcept {
+        return node_index < node_count_ ? &slots_[node_index]->out_buffer : nullptr;
+    }
+
+    // Per-node incompleteness flags (a buffer dropped events, or carried an
+    // upstream drop). Tracked so the host egress can report the same incomplete
+    // state through extract_midi() that the legacy walk does.
+    bool in_incomplete(std::uint32_t node_index) const noexcept {
+        return node_index < node_count_ && slots_[node_index]->in_incomplete;
+    }
+    void set_in_incomplete(std::uint32_t node_index, bool v) noexcept {
+        if (node_index < node_count_) slots_[node_index]->in_incomplete = v;
+    }
+    bool out_incomplete(std::uint32_t node_index) const noexcept {
+        return node_index < node_count_ && slots_[node_index]->out_incomplete;
+    }
+    void set_out_incomplete(std::uint32_t node_index, bool v) noexcept {
+        if (node_index < node_count_) slots_[node_index]->out_incomplete = v;
+    }
+
+    bool fits(std::uint32_t node_count) const noexcept {
+        return node_count_ >= node_count;
+    }
+
+private:
+    struct Slot {
+        midi::MidiBuffer in_buffer;
+        midi::UmpBuffer in_ump;
+        midi::MidiBuffer out_buffer;
+        midi::UmpBuffer out_ump;
+        bool in_incomplete = false;
+        bool out_incomplete = false;
+    };
+    std::vector<std::unique_ptr<Slot>> slots_;
+    std::uint32_t node_count_ = 0;
+};
+
 class GraphRuntimeExecutor {
 public:
     static constexpr std::size_t kMaxInlineCommandCapacity = 256;
@@ -315,10 +390,17 @@ public:
     // output is captured into that slot for the next block (matching
     // host::SignalGraph's feedback_prev). The pool's zero-init gives the first
     // block silent feedback.
+    // When `midi` is non-null it must fit() the snapshot's node count: the
+    // executor clears each node's MIDI input, gathers its inbound event
+    // connections into it, and exposes the per-node in/out buffers to bindings
+    // via the process context. MidiInput/MidiOutput system nodes carry no audio
+    // and no binding; the caller pre-fills a MidiInput node's `out` and drains a
+    // MidiOutput node's `in` around this call. Pass null for audio-only graphs.
     GraphRuntimeExecutorResult process_routed(
         ProcessBlock& block,
         const GraphRuntimeSnapshot& snapshot,
         GraphRuntimeBufferPool& pool,
+        GraphRuntimeMidiScratch* midi = nullptr,
         std::span<const graph::GraphTimedCommand> commands = {},
         std::span<GraphRuntimeCommandDecision> command_results = {},
         GraphRuntimeCommandHandler command_handler = {},

--- a/core/format/src/graph_runtime_executor.cpp
+++ b/core/format/src/graph_runtime_executor.cpp
@@ -116,6 +116,81 @@ void gather_node_inputs(const graph::GraphRuntimePlan& plan,
     }
 }
 
+// Clear a MIDI buffer's events, sysex, and attached UMP — the full reset the
+// host walk applies before gathering a node's inbound MIDI.
+void clear_routed_midi(midi::MidiBuffer& block) noexcept {
+    block.clear();
+    block.clear_sysex();
+    if (auto* ump = block.ump()) ump->clear();
+}
+
+// True if a buffer dropped any event / sysex / UMP message (capacity limit hit),
+// matching the host walk's drop check.
+bool routed_midi_has_drops(const midi::MidiBuffer& block) noexcept {
+    if (block.dropped_event_count() > 0 || block.dropped_sysex_count() > 0) return true;
+    const auto* ump = block.ump();
+    return ump != nullptr && ump->dropped_event_count() > 0;
+}
+
+// Append every event / sysex / UMP message from `src` to `dst`, the same
+// whole-buffer copy the host walk uses to gather an inbound MIDI edge. Returns
+// false if `src` already carried a drop or an add() dropped here (the
+// incompleteness the host propagates downstream). RT-safe when both buffers are
+// reserved (add() respects the realtime capacity limit).
+bool copy_routed_midi(const midi::MidiBuffer& src, midi::MidiBuffer& dst) noexcept {
+    bool copied_all = !routed_midi_has_drops(src);
+    for (const auto& ev : src) {
+        if (!dst.add(ev)) copied_all = false;
+    }
+    for (const auto& sx : src.sysex()) {
+        if (sx.data.empty()) {
+            if (!dst.add_sysex({}, sx.sample_offset, sx.timestamp)) copied_all = false;
+        } else if (!dst.add_sysex_copy(sx.data.data(), sx.data.size(), sx.sample_offset,
+                                       sx.timestamp)) {
+            copied_all = false;
+        }
+    }
+    const auto* src_ump = src.ump();
+    auto* dst_ump = dst.ump();
+    if (src_ump != nullptr && dst_ump != nullptr) {
+        for (const auto& ev : *src_ump) {
+            if (!dst_ump->add(ev)) copied_all = false;
+        }
+    } else if (src_ump != nullptr && !src_ump->empty()) {
+        copied_all = false;
+    }
+    return copied_all;
+}
+
+// Clear this node's gathered MIDI input, then append every inbound event
+// connection's source MIDI output into it (whole-buffer copy, summed in inbound
+// order). Topological order guarantees each source's output is final this block.
+// The node's MIDI output is left untouched — a MIDI-emitting binding fills it,
+// and a MidiInput system node's output is supplied by the host before the walk.
+void gather_node_midi(const graph::GraphRuntimePlan& plan,
+                      GraphRuntimeMidiScratch& midi,
+                      const graph::GraphRuntimeNodePlan& node,
+                      std::uint32_t node_index) noexcept {
+    midi::MidiBuffer* in = midi.in(node_index);
+    if (in == nullptr) return;
+    clear_routed_midi(*in);
+    bool incomplete = false;
+    for (std::uint32_t c = 0; c < node.inbound_connection_count; ++c) {
+        const auto conn_index =
+            plan.inbound_connection_indices[node.first_inbound_connection + c];
+        const auto& conn = plan.connections[conn_index];
+        if (!conn.event) continue;
+        const midi::MidiBuffer* src = midi.out(conn.source_index);
+        if (src == nullptr) continue;
+        // A source whose output was incomplete, or a copy that drops here,
+        // marks this node's input incomplete (matching the host walk's
+        // node-to-node incompleteness propagation).
+        if (midi.out_incomplete(conn.source_index)) incomplete = true;
+        if (!copy_routed_midi(*src, *in)) incomplete = true;
+    }
+    midi.set_in_incomplete(node_index, incomplete);
+}
+
 // After all nodes run, capture each feedback edge's current source output into
 // its previous-block slot for the next block (the source's output slot is final
 // once the block's walk completes). One-block delay, matching SignalGraph.
@@ -170,7 +245,47 @@ void copy_io_bus(graph::GraphRuntimeNodeKind kind,
     }
 }
 
+// Fixed realtime MIDI capacities for the routed per-node scratch buffers. Match
+// the host graph's per-node MIDI block storage so the routed path never drops an
+// event the legacy walk would have kept.
+constexpr std::size_t kRoutedMidiEventCapacity = 1024;
+constexpr std::size_t kRoutedMidiSysexCapacity = 128;
+constexpr std::size_t kRoutedMidiSysexPayloadCapacity = 4096;
+
 } // namespace
+
+bool GraphRuntimeMidiScratch::reset(std::uint32_t node_count) {
+    clear();
+    try {
+        slots_.reserve(node_count);
+        for (std::uint32_t i = 0; i < node_count; ++i) {
+            auto slot = std::make_unique<Slot>();
+            slot->in_buffer.reserve(kRoutedMidiEventCapacity, kRoutedMidiSysexCapacity,
+                                    kRoutedMidiSysexPayloadCapacity);
+            slot->in_buffer.set_realtime_capacity_limit(true);
+            slot->in_ump.reserve(kRoutedMidiEventCapacity);
+            slot->in_ump.set_realtime_capacity_limit(true);
+            slot->in_buffer.attach_ump(&slot->in_ump);
+            slot->out_buffer.reserve(kRoutedMidiEventCapacity, kRoutedMidiSysexCapacity,
+                                     kRoutedMidiSysexPayloadCapacity);
+            slot->out_buffer.set_realtime_capacity_limit(true);
+            slot->out_ump.reserve(kRoutedMidiEventCapacity);
+            slot->out_ump.set_realtime_capacity_limit(true);
+            slot->out_buffer.attach_ump(&slot->out_ump);
+            slots_.push_back(std::move(slot));
+        }
+    } catch (...) {
+        clear();
+        return false;
+    }
+    node_count_ = node_count;
+    return true;
+}
+
+void GraphRuntimeMidiScratch::clear() noexcept {
+    slots_.clear();
+    node_count_ = 0;
+}
 
 bool GraphRuntimeBufferPool::reset(std::uint32_t slot_count, std::uint32_t max_frames) {
     return reset(slot_count, max_frames, {});
@@ -385,6 +500,7 @@ GraphRuntimeExecutorResult GraphRuntimeExecutor::process_routed(
     ProcessBlock& block,
     const GraphRuntimeSnapshot& snapshot,
     GraphRuntimeBufferPool& pool,
+    GraphRuntimeMidiScratch* midi,
     std::span<const graph::GraphTimedCommand> commands,
     std::span<GraphRuntimeCommandDecision> command_results,
     GraphRuntimeCommandHandler command_handler,
@@ -398,6 +514,14 @@ GraphRuntimeExecutorResult GraphRuntimeExecutor::process_routed(
     const auto frames = block.frame_count;
 
     if (!pool.fits(snapshot, frames)) {
+        GraphRuntimeExecutorResult fail;
+        fail.error = GraphRuntimeExecutorErrorCode::BufferPoolTooSmall;
+        return fail;
+    }
+    // A MIDI scratch, when supplied, must cover every node so the gather can
+    // index any node's in/out buffer; an undersized one fails closed rather than
+    // routing MIDI past the end of the scratch.
+    if (midi != nullptr && !midi->fits(plan.node_count())) {
         GraphRuntimeExecutorResult fail;
         fail.error = GraphRuntimeExecutorErrorCode::BufferPoolTooSmall;
         return fail;
@@ -438,6 +562,9 @@ GraphRuntimeExecutorResult GraphRuntimeExecutor::process_routed(
         }
 
         gather_node_inputs(plan, assignment, pool, node, slots, frames);
+        if (midi != nullptr) {
+            gather_node_midi(plan, *midi, node, node_index);
+        }
 
         if (node.kind == graph::GraphRuntimeNodeKind::AudioInput ||
             node.kind == graph::GraphRuntimeNodeKind::AudioOutput) {
@@ -480,11 +607,24 @@ GraphRuntimeExecutorResult GraphRuntimeExecutor::process_routed(
                 in_ptrs.data(), node.input_ports, frames);
             context.node_outputs = audio::BufferView<float>(
                 out_ptrs.data(), node.output_ports, frames);
+            if (midi != nullptr) {
+                context.node_midi_in = midi->in(node_index);
+                context.node_midi_out = midi->out(node_index);
+            }
             if (!binding.process(block, context, binding.user_data)) {
                 result.error = GraphRuntimeExecutorErrorCode::NodeProcessorFailed;
                 result.failed_node_index = node_index;
                 node_failures_.fetch_add(1, std::memory_order_relaxed);
                 return result;
+            }
+            // A MIDI-emitting binding's output is incomplete if its gathered
+            // input was, or if the binding itself dropped output events —
+            // matching the host walk's per-node midi_out_incomplete.
+            if (midi != nullptr && context.node_midi_out != nullptr) {
+                midi->set_out_incomplete(
+                    node_index,
+                    midi->in_incomplete(node_index) ||
+                        routed_midi_has_drops(*context.node_midi_out));
             }
         }
 

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -677,6 +677,22 @@ private:
         // themselves live in `plugins` above (same cg lifetime).
         std::vector<PluginBindingContext> routing_plugin_ctx;
         PluginRoutingScratch routing_plugin_scratch;
+        // Per-node MIDI buffers for the routed path's event edges, owned
+        // per-snapshot like exec_pool. Empty (node_count 0) for graphs with no
+        // MIDI. The routed dispatch bridges the SignalGraph MIDI mailboxes to
+        // these buffers around process_routed: a MidiInput node's mailbox is read
+        // into its scratch output before the walk, and a MidiOutput node's
+        // gathered scratch input is published to its mailbox after. `routing_midi_io`
+        // lists those system nodes by (dense plan index, NodeId) so the bridge
+        // avoids a per-block NodeId lookup.
+        format::GraphRuntimeMidiScratch routing_midi;
+        // `pending_seq` is audio-thread scratch: the mailbox sequence a MidiInput
+        // would consume this block, captured during the ingress pre-fill and
+        // committed to midi_input_sequence_seen only after the routed dispatch
+        // succeeds (so a fallback to the legacy walk re-consumes the same block).
+        struct RoutedMidiNode { std::uint32_t plan_index; NodeId id; std::uint64_t pending_seq = 0; };
+        std::vector<RoutedMidiNode> routing_midi_inputs;
+        std::vector<RoutedMidiNode> routing_midi_outputs;
     };
 
     std::vector<GraphNode> nodes_;

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -1176,6 +1176,31 @@ SignalGraph::compile_(double sample_rate, int max_block_size) {
                 static_cast<std::uint32_t>(max_block_size),
                 cg->routing_snapshot.buffer_assignment().connection_delay_samples);
         }
+        // Per-snapshot MIDI scratch + the MidiInput/MidiOutput node index lists
+        // the routed dispatch bridges to the mailboxes. Built only when the
+        // routed plan carries MIDI nodes, so audio-only graphs allocate none.
+        cg->routing_midi_inputs.clear();
+        cg->routing_midi_outputs.clear();
+        if (cg->routing_valid) {
+            const auto& plan = cg->routing_snapshot.plan();
+            bool plan_has_midi = false;
+            for (std::uint32_t i = 0; i < plan.nodes.size(); ++i) {
+                const auto kind = plan.nodes[i].kind;
+                if (kind == graph::GraphRuntimeNodeKind::MidiInput) {
+                    cg->routing_midi_inputs.push_back({i, plan.nodes[i].id});
+                    plan_has_midi = true;
+                } else if (kind == graph::GraphRuntimeNodeKind::MidiOutput) {
+                    cg->routing_midi_outputs.push_back({i, plan.nodes[i].id});
+                    plan_has_midi = true;
+                } else if (plan.nodes[i].event_input_ports > 0 ||
+                           plan.nodes[i].event_output_ports > 0) {
+                    plan_has_midi = true;  // a plugin carrying MIDI edges
+                }
+            }
+            if (plan_has_midi) {
+                cg->routing_valid = cg->routing_midi.reset(plan.node_count());
+            }
+        }
     }
     return cg;
 }
@@ -1492,8 +1517,66 @@ void SignalGraph::process(audio::BufferView<float>& output,
             block.sample_rate = cg->sample_rate;
             block.frame_count = static_cast<std::uint32_t>(num_samples);
             block.buses = &buses;
+
+            const bool has_midi = cg->routing_midi.node_count() > 0;
+            // Bridge MIDI ingress: copy each MidiInput node's freshly-injected
+            // mailbox snapshot into its routed MIDI-output buffer (the same
+            // unseen-sequence dedup the legacy walk applies), so the executor's
+            // MIDI gather sees it. The executor never touches a node's MIDI
+            // output, so this pre-fill survives the walk. The consumed sequence
+            // is captured in `pending_seq` and committed to
+            // midi_input_sequence_seen only after the dispatch succeeds — a
+            // fallback to the legacy walk must re-consume the same block.
+            if (has_midi) {
+                for (auto& mi : cg->routing_midi_inputs) {
+                    mi.pending_seq = 0;
+                    midi::MidiBuffer* out_buf = cg->routing_midi.out(mi.plan_index);
+                    if (out_buf == nullptr) continue;
+                    clear_midi_block(*out_buf);
+                    cg->routing_midi.set_out_incomplete(mi.plan_index, false);
+                    auto rt_it = cg->runtime.find(mi.id);
+                    if (rt_it == cg->runtime.end() || !rt_it->second.midi_input_mailbox) {
+                        continue;
+                    }
+                    const auto& injected = rt_it->second.midi_input_mailbox->published.read();
+                    if (injected.sequence != 0 &&
+                        injected.sequence != rt_it->second.midi_input_sequence_seen) {
+                        cg->routing_midi.set_out_incomplete(
+                            mi.plan_index, !injected.copy_to_midi(*out_buf));
+                        mi.pending_seq = injected.sequence;
+                    }
+                }
+            }
+
             if (block.validate() &&
-                executor_.process_routed(block, cg->routing_snapshot, cg->exec_pool).ok()) {
+                executor_.process_routed(
+                    block, cg->routing_snapshot, cg->exec_pool,
+                    has_midi ? &cg->routing_midi : nullptr).ok()) {
+                if (has_midi) {
+                    // Commit the consumed mailbox sequences now that routing
+                    // succeeded.
+                    for (const auto& mi : cg->routing_midi_inputs) {
+                        if (mi.pending_seq == 0) continue;
+                        auto rt_it = cg->runtime.find(mi.id);
+                        if (rt_it != cg->runtime.end()) {
+                            rt_it->second.midi_input_sequence_seen = mi.pending_seq;
+                        }
+                    }
+                    // Bridge MIDI egress: publish each MidiOutput node's gathered
+                    // routed MIDI-input buffer to its mailbox for extract_midi(),
+                    // carrying the same incompleteness the legacy walk reports.
+                    for (const auto& mo : cg->routing_midi_outputs) {
+                        midi::MidiBuffer* in_buf = cg->routing_midi.in(mo.plan_index);
+                        auto rt_it = cg->runtime.find(mo.id);
+                        if (in_buf == nullptr || rt_it == cg->runtime.end() ||
+                            !rt_it->second.midi_output_mailbox) {
+                            continue;
+                        }
+                        cg->midi_publish_scratch.set_from_midi(
+                            *in_buf, 0, cg->routing_midi.in_incomplete(mo.plan_index));
+                        rt_it->second.midi_output_mailbox->write(cg->midi_publish_scratch);
+                    }
+                }
                 return;
             }
         }

--- a/core/host/src/signal_graph_executor_routing.cpp
+++ b/core/host/src/signal_graph_executor_routing.cpp
@@ -92,9 +92,21 @@ bool plugin_binding(fmt::ProcessBlock&,
         fmt::ProcessBusBufferSet<float>{std::span(output_buses)},
     };
 
-    pctx->scratch->midi_out.clear();
-    pctx->slot->process(buffers, pctx->scratch->midi_in, pctx->scratch->midi_out,
-                        pctx->scratch->param_events, num_samples);
+    // Use the executor's per-node MIDI buffers when the routed call supplies
+    // them (a MIDI graph): node_midi_in carries the events gathered from this
+    // plugin's inbound MIDI edges, and node_midi_out is the buffer downstream
+    // nodes gather from. Fall back to the empty shared scratch for audio-only
+    // graphs (no MIDI routing). Clear the output fully before the plugin fills
+    // it, matching SignalGraph's per-node clear.
+    midi::MidiBuffer& midi_in =
+        ctx.node_midi_in != nullptr ? *ctx.node_midi_in : pctx->scratch->midi_in;
+    midi::MidiBuffer& midi_out =
+        ctx.node_midi_out != nullptr ? *ctx.node_midi_out : pctx->scratch->midi_out;
+    midi_out.clear();
+    midi_out.clear_sysex();
+    if (auto* ump = midi_out.ump()) ump->clear();
+    pctx->slot->process(buffers, midi_in, midi_out, pctx->scratch->param_events,
+                        num_samples);
     return true;
 }
 
@@ -102,6 +114,8 @@ gr::GraphRuntimeNodeKind map_kind(NodeType type) noexcept {
     switch (type) {
         case NodeType::AudioInput: return gr::GraphRuntimeNodeKind::AudioInput;
         case NodeType::AudioOutput: return gr::GraphRuntimeNodeKind::AudioOutput;
+        case NodeType::MidiInput: return gr::GraphRuntimeNodeKind::MidiInput;
+        case NodeType::MidiOutput: return gr::GraphRuntimeNodeKind::MidiOutput;
         default: return gr::GraphRuntimeNodeKind::Processor;  // Gain / Plugin
     }
 }
@@ -111,6 +125,11 @@ bool node_eligible(const GraphNode& node) noexcept {
         case NodeType::AudioInput:
         case NodeType::AudioOutput:
         case NodeType::Gain:
+        // MidiInput / MidiOutput carry no audio and run as no-op nodes on the
+        // routed path; the host bridges their mailboxes around process_routed,
+        // and the executor's MIDI gather routes events between them and plugins.
+        case NodeType::MidiInput:
+        case NodeType::MidiOutput:
             return true;
         case NodeType::Plugin:
             // A Plugin node only routes bit-exactly when its slot is live (the
@@ -126,14 +145,15 @@ bool node_eligible(const GraphNode& node) noexcept {
 }
 
 bool connection_eligible(const Connection& c) noexcept {
-    // Audio edges only. Feedback is fine (the executor handles one-block
+    // Audio and MIDI edges. Feedback is fine (the executor handles one-block
     // feedback). Sidechain is fine: SignalGraph routes a sidechain edge as a
     // plain audio edge into a higher input port of the destination plugin (the
     // plugin's input_ports count already includes its sidechain ports, and the
     // single concatenated input bus carries them), and it participates in PDC
-    // exactly like any audio edge — all of which the routed gather reproduces.
-    // MIDI / automation / audio-rate-mod still keep the legacy walk.
-    return !c.midi && !c.automation && !c.audio_rate_modulation;
+    // exactly like any audio edge. MIDI edges are carried as event connections
+    // and routed by the executor's MIDI gather. Automation / audio-rate-mod
+    // still keep the legacy walk.
+    return !c.automation && !c.audio_rate_modulation;
 }
 
 } // namespace
@@ -173,6 +193,23 @@ bool build_executor_snapshot(std::span<const GraphNode> nodes,
     }
     plugin_ctx.reserve(plugin_count);
 
+    // Whether this graph carries any MIDI. Only then do nodes declare event
+    // ports (one in + one out, port 0 — connect_midi routes the whole per-node
+    // MIDI stream on port 0), so an audio-only graph's plan is byte-identical to
+    // before MIDI support and never inflates the total-port budget.
+    bool has_midi = false;
+    for (const auto& node : nodes) {
+        if (node.type == NodeType::MidiInput || node.type == NodeType::MidiOutput) {
+            has_midi = true;
+            break;
+        }
+    }
+    if (!has_midi) {
+        for (const auto& c : connections) {
+            if (c.midi) { has_midi = true; break; }
+        }
+    }
+
     // Node specs in nodes() order; the plan resolves connections by NodeId, so
     // bindings just need to match plan.nodes order (== spec order). Plugin output
     // regions are pinned persistent so a non-full-writing plugin keeps its stale
@@ -186,6 +223,10 @@ bool build_executor_snapshot(std::span<const GraphNode> nodes,
             static_cast<std::uint32_t>(std::max(0, node.num_input_ports)),
             static_cast<std::uint32_t>(std::max(0, node.num_output_ports)),
         };
+        if (has_midi) {
+            spec.event_input_ports = 1;
+            spec.event_output_ports = 1;
+        }
         spec.persistent_output = node.type == NodeType::Plugin;
         // Carry the node's reported latency so the buffer assignment can derive
         // per-connection delay compensation. Resolve it from the SAME slot the
@@ -203,13 +244,14 @@ bool build_executor_snapshot(std::span<const GraphNode> nodes,
 
     // Connection specs in connections() order, so a dest port's inbound edges
     // are summed in the SAME order SignalGraph accumulates them (float add is
-    // non-associative). Feedback flag carried through.
+    // non-associative). Feedback flag carried through; a MIDI edge becomes an
+    // event connection the executor routes via its MIDI gather.
     std::vector<gr::GraphRuntimeConnectionSpec> conn_specs;
     conn_specs.reserve(connections.size());
     for (const auto& c : connections) {
         conn_specs.push_back(gr::GraphRuntimeConnectionSpec{
             c.source_node, c.source_port, c.dest_node, c.dest_port,
-            c.feedback, /*event=*/false,
+            c.feedback, /*event=*/c.midi,
         });
     }
 
@@ -244,7 +286,11 @@ bool build_executor_snapshot(std::span<const GraphNode> nodes,
             plugin_ctx.push_back(PluginBindingContext{slot, &scratch});
             bindings.push_back(fmt::GraphRuntimeNodeBinding{
                 id, plugin_binding, &plugin_ctx.back(), /*required=*/true});
-        } else {  // AudioInput / AudioOutput — executor kind dispatch
+        } else {  // AudioInput / AudioOutput / MidiInput / MidiOutput — null
+            // binding: AudioInput/AudioOutput are executor kind dispatch, and
+            // MidiInput/MidiOutput run as no-op nodes (the executor's MIDI gather
+            // fills a MidiOutput's input; the host pre-fills a MidiInput's output
+            // and drains a MidiOutput's input around process_routed).
             bindings.push_back(fmt::GraphRuntimeNodeBinding{
                 id, nullptr, nullptr, /*required=*/false});
         }

--- a/test/test_signal_graph_executor_parity.cpp
+++ b/test/test_signal_graph_executor_parity.cpp
@@ -277,19 +277,19 @@ TEST_CASE("SignalGraph::process opt-in executor path matches the legacy walk",
 
 TEST_CASE("SignalGraph::process opt-in falls back to legacy for ineligible graphs",
           "[host][graph][executor][routing]") {
-    // A stray MIDI node makes the graph ineligible; with the opt-in ON, process()
-    // must fall back to the legacy walk and still produce in*gain.
+    // A stray Custom node makes the graph ineligible; with the opt-in ON,
+    // process() must fall back to the legacy walk and still produce in*gain.
     SignalGraph g;
     const auto in = g.add_input_node(1, "In");
     const auto a = g.add_gain_node("A");
     const auto out = g.add_output_node(1, "Out");
-    (void)g.add_midi_input_node("MIDI In");  // ineligible node type present
+    (void)g.add_unresolved_custom_node("test.custom", 1, 1, 1, "Custom");  // ineligible type
     REQUIRE(g.connect(in, 0, a, 0));
     REQUIRE(g.connect(a, 0, out, 0));
     REQUIRE(g.set_node_gain(a, 0.5f));
     g.set_canonical_executor_routing_enabled(true);
     REQUIRE(g.prepare(kSr, kFrames));
-    CHECK_FALSE(signal_graph_executor_eligible(g));  // MIDI node disqualifies
+    CHECK_FALSE(signal_graph_executor_eligible(g));  // Custom node disqualifies
 
     const auto x = ramp(kFrames, 0.8f);
     std::vector<float> xi = x, yo(kFrames, 0.0f);
@@ -453,13 +453,15 @@ TEST_CASE("Executor eligibility rejects unprepared and non-eligible graphs",
     CHECK_FALSE(build_signal_graph_executor_routing(unprepared, routing));
     CHECK_FALSE(routing.valid);
 
-    // A MIDI node is outside the eligible subset even when prepared.
-    SignalGraph midi;
-    const auto min = midi.add_midi_input_node("MIDI In");
-    const auto mout = midi.add_midi_output_node("MIDI Out");
-    REQUIRE(midi.connect_midi(min, mout));
-    REQUIRE(midi.prepare(kSr, kFrames));
-    CHECK_FALSE(signal_graph_executor_eligible(midi));
+    // A Custom node is outside the eligible subset even when prepared.
+    SignalGraph custom;
+    const auto cin = custom.add_input_node(1, "In");
+    const auto cnode = custom.add_unresolved_custom_node("test.custom", 1, 1, 1, "Custom");
+    const auto cout = custom.add_output_node(1, "Out");
+    REQUIRE(custom.connect(cin, 0, cnode, 0));
+    REQUIRE(custom.connect(cnode, 0, cout, 0));
+    REQUIRE(custom.prepare(kSr, kFrames));
+    CHECK_FALSE(signal_graph_executor_eligible(custom));
 }
 
 TEST_CASE("Executor routing build fails closed for oversized otherwise-eligible graphs",
@@ -580,6 +582,101 @@ private:
     int latency_;
     PluginInfo info_;
 };
+
+// Deterministic MIDI plugin: passes audio through (full write) and emits a copy
+// of each inbound note transposed by `transpose_` semitones (other messages pass
+// through). The transpose makes the plugin's MIDI output distinct from its input
+// so a bug that routed the wrong buffer would surface.
+class MidiTransposePlugin final : public PluginSlot {
+public:
+    MidiTransposePlugin(int transpose, int in_ch, int out_ch)
+        : transpose_(transpose), info_(test_plugin_info(in_ch, out_ch)) {}
+
+    const PluginInfo& info() const override { return info_; }
+    bool is_loaded() const override { return true; }
+    bool prepare(double, int) override { return true; }
+    void release() override {}
+    void process(pulp::audio::BufferView<float>& out,
+                 const pulp::audio::BufferView<const float>& in,
+                 const pulp::midi::MidiBuffer& midi_in,
+                 pulp::midi::MidiBuffer& midi_out,
+                 const pulp::host::ParameterEventQueue&,
+                 int n) override {
+        const std::size_t chs = out.num_channels();
+        for (std::size_t c = 0; c < chs; ++c) {
+            float* o = out.channel_ptr(c);
+            const float* i = c < in.num_channels() ? in.channel_ptr(c) : nullptr;
+            for (int s = 0; s < n; ++s) {
+                o[static_cast<std::size_t>(s)] = i ? i[static_cast<std::size_t>(s)] : 0.0f;
+            }
+        }
+        for (const auto& ev : midi_in) {
+            const auto ch = static_cast<uint8_t>(ev.data()[0] & 0x0F);
+            const auto note = static_cast<uint8_t>((ev.data()[1] + transpose_) & 0x7F);
+            if (ev.is_note_on()) {
+                midi_out.add(pulp::midi::MidiEvent::note_on(ch, note, ev.data()[2]));
+            } else if (ev.is_note_off()) {
+                midi_out.add(pulp::midi::MidiEvent::note_off(ch, note, ev.data()[2]));
+            } else {
+                midi_out.add(ev);
+            }
+        }
+    }
+    std::vector<pulp::host::HostParamInfo> parameters() const override { return {}; }
+    float get_parameter(uint32_t) const override { return 0.0f; }
+    void set_parameter(uint32_t, float) override {}
+    void set_bypass(bool) override {}
+    bool is_bypassed() const override { return false; }
+    std::vector<uint8_t> save_state() const override { return {}; }
+    bool restore_state(const std::vector<uint8_t>&) override { return true; }
+    int latency_samples() const override { return 0; }
+    int tail_samples() const override { return 0; }
+    bool has_editor() const override { return false; }
+    void* create_editor_view() override { return nullptr; }
+    void destroy_editor_view() override {}
+
+private:
+    int transpose_;
+    PluginInfo info_;
+};
+
+// A comparable snapshot of a MIDI buffer's events (3 status/data bytes + size +
+// offset), in buffer order, for bit-exact comparison between the two walks.
+struct MidiEvtKey {
+    std::array<uint8_t, 3> bytes{};
+    std::uint32_t size = 0;
+    int32_t offset = 0;
+    bool operator==(const MidiEvtKey& o) const {
+        return bytes == o.bytes && size == o.size && offset == o.offset;
+    }
+};
+
+std::vector<MidiEvtKey> collect_midi(const pulp::midi::MidiBuffer& buf) {
+    std::vector<MidiEvtKey> out;
+    for (const auto& ev : buf) {
+        MidiEvtKey k;
+        k.size = ev.size();
+        for (std::uint32_t i = 0; i < ev.size() && i < 3; ++i) k.bytes[i] = ev.data()[i];
+        k.offset = ev.sample_offset;
+        out.push_back(k);
+    }
+    return out;
+}
+
+void expect_midi_equal(const std::vector<MidiEvtKey>& a,
+                       const std::vector<MidiEvtKey>& b) {
+    REQUIRE(a.size() == b.size());
+    for (std::size_t i = 0; i < a.size(); ++i) REQUIRE(a[i] == b[i]);
+}
+
+pulp::midi::MidiBuffer make_injected_midi(int seed) {
+    pulp::midi::MidiBuffer buf;
+    buf.reserve(64, 8, 256);
+    buf.add(pulp::midi::MidiEvent::note_on(0, static_cast<uint8_t>(60 + seed), 100));
+    buf.add(pulp::midi::MidiEvent::cc(0, 7, static_cast<uint8_t>(64 + seed)));
+    buf.add(pulp::midi::MidiEvent::note_off(0, static_cast<uint8_t>(60 + seed), 0));
+    return buf;
+}
 
 } // namespace
 
@@ -997,4 +1094,215 @@ TEST_CASE("Translated routing matches SignalGraph: sidechain edge with PDC delay
         expect_equal(run_legacy(g, kFrames, input, 2),
                      run_routed(exec, routing, kFrames, input, 2));
     }
+}
+
+namespace {
+
+// Drive one block with a 1-channel silent audio bus (graphs whose only purpose
+// is MIDI routing still need a valid block; the audio bus is unused).
+void process_silent_block(SignalGraph& g) {
+    std::vector<float> in(static_cast<std::size_t>(kFrames), 0.0f);
+    std::vector<float> out(static_cast<std::size_t>(kFrames), 0.0f);
+    std::array<const float*, 1> ic{in.data()};
+    std::array<float*, 1> oc{out.data()};
+    pulp::audio::BufferView<const float> iv(ic.data(), 1, kFrames);
+    pulp::audio::BufferView<float> ov(oc.data(), 1, kFrames);
+    g.process(ov, iv, kFrames);
+}
+
+std::vector<MidiEvtKey> extract_collected(const SignalGraph& g, pulp::host::NodeId out_node) {
+    pulp::midi::MidiBuffer buf;
+    buf.reserve(64, 8, 256);
+    REQUIRE(const_cast<SignalGraph&>(g).extract_midi(out_node, buf));
+    return collect_midi(buf);
+}
+
+} // namespace
+
+TEST_CASE("SignalGraph::process MIDI routing matches legacy: MidiInput -> MidiOutput",
+          "[host][graph][executor][routing][parity][midi]") {
+    // Pure MIDI edge routing: injected events flow MidiInput -> MidiOutput with
+    // no plugin. The routed path's MIDI gather must deliver the same events to
+    // the output mailbox that the legacy walk does.
+    auto build = [](SignalGraph& g, bool route) {
+        const auto mi = g.add_midi_input_node("MIDI In");
+        const auto mo = g.add_midi_output_node("MIDI Out");
+        REQUIRE(g.connect_midi(mi, mo));
+        g.set_canonical_executor_routing_enabled(route);
+        REQUIRE(g.prepare(kSr, kFrames));
+        return std::pair<pulp::host::NodeId, pulp::host::NodeId>{mi, mo};
+    };
+    SignalGraph legacy, routed;
+    const auto [lmi, lmo] = build(legacy, false);
+    const auto [rmi, rmo] = build(routed, true);
+    REQUIRE(signal_graph_executor_eligible(routed));
+
+    for (int blk = 0; blk < 4; ++blk) {
+        const auto inj = make_injected_midi(blk);
+        REQUIRE(legacy.inject_midi(lmi, inj));
+        REQUIRE(routed.inject_midi(rmi, inj));
+        process_silent_block(legacy);
+        process_silent_block(routed);
+        INFO("block " << blk);
+        expect_midi_equal(extract_collected(legacy, lmo), extract_collected(routed, rmo));
+    }
+}
+
+TEST_CASE("SignalGraph::process MIDI routing matches legacy: overflow reports incomplete",
+          "[host][graph][executor][routing][parity][midi]") {
+    // Injecting more events than the per-node MIDI capacity (1024) overflows the
+    // mailbox snapshot; both walks must deliver the same truncated events AND
+    // report the same incomplete status through extract_midi()'s return value.
+    auto build = [](SignalGraph& g, bool route) {
+        const auto mi = g.add_midi_input_node("MIDI In");
+        const auto mo = g.add_midi_output_node("MIDI Out");
+        REQUIRE(g.connect_midi(mi, mo));
+        g.set_canonical_executor_routing_enabled(route);
+        REQUIRE(g.prepare(kSr, kFrames));
+        return std::pair<pulp::host::NodeId, pulp::host::NodeId>{mi, mo};
+    };
+    SignalGraph legacy, routed;
+    const auto [lmi, lmo] = build(legacy, false);
+    const auto [rmi, rmo] = build(routed, true);
+    REQUIRE(signal_graph_executor_eligible(routed));
+
+    pulp::midi::MidiBuffer flood;
+    flood.reserve(4096, 8, 256);
+    for (int i = 0; i < 2000; ++i) {
+        flood.add(pulp::midi::MidiEvent::note_on(0, static_cast<uint8_t>(i & 0x7F), 100));
+    }
+    // inject_midi returns false when the flood overflows the mailbox, but still
+    // publishes the truncated + incomplete snapshot; both paths see the same.
+    CHECK(legacy.inject_midi(lmi, flood) == routed.inject_midi(rmi, flood));
+    process_silent_block(legacy);
+    process_silent_block(routed);
+
+    pulp::midi::MidiBuffer legacy_out, routed_out;
+    legacy_out.reserve(4096, 8, 256);
+    routed_out.reserve(4096, 8, 256);
+    const bool legacy_complete = legacy.extract_midi(lmo, legacy_out);
+    const bool routed_complete = routed.extract_midi(rmo, routed_out);
+    CHECK(legacy_complete == routed_complete);   // both incomplete under overflow
+    expect_midi_equal(collect_midi(legacy_out), collect_midi(routed_out));
+}
+
+TEST_CASE("SignalGraph::process MIDI routing matches legacy: MidiInput -> plugin -> MidiOutput",
+          "[host][graph][executor][routing][parity][midi][plugin]") {
+    // Audio and MIDI through one plugin: audio in -> plugin -> out, and
+    // MIDI in -> plugin (transpose +7) -> MIDI out. Both the audio output and
+    // the transposed MIDI at the sink must match the legacy walk block-for-block.
+    struct Ids { pulp::host::NodeId mi, mo; };
+    auto build = [](SignalGraph& g, bool route) {
+        const auto in = g.add_input_node(2, "In");
+        const auto p = g.add_plugin_node(
+            std::make_unique<MidiTransposePlugin>(7, 2, 2), 2, 2, "P");
+        const auto out = g.add_output_node(2, "Out");
+        const auto mi = g.add_midi_input_node("MIDI In");
+        const auto mo = g.add_midi_output_node("MIDI Out");
+        for (int c = 0; c < 2; ++c) {
+            REQUIRE(g.connect(in, c, p, c));
+            REQUIRE(g.connect(p, c, out, c));
+        }
+        REQUIRE(g.connect_midi(mi, p));
+        REQUIRE(g.connect_midi(p, mo));
+        g.set_canonical_executor_routing_enabled(route);
+        REQUIRE(g.prepare(kSr, kFrames));
+        return Ids{mi, mo};
+    };
+    SignalGraph legacy, routed;
+    const auto lids = build(legacy, false);
+    const auto rids = build(routed, true);
+    REQUIRE(signal_graph_executor_eligible(routed));
+
+    for (int blk = 0; blk < 4; ++blk) {
+        const auto inj = make_injected_midi(blk);
+        REQUIRE(legacy.inject_midi(lids.mi, inj));
+        REQUIRE(routed.inject_midi(rids.mi, inj));
+
+        const auto x = ramp(kFrames, 0.7f + 0.05f * static_cast<float>(blk));
+        const auto y = ramp(kFrames, 0.5f - 0.03f * static_cast<float>(blk));
+        const std::vector<std::vector<float>> input{x, y};
+        INFO("block " << blk);
+        // run_legacy drives g.process(); the routed graph dispatches through the
+        // executor (routing enabled), the other through the legacy walk.
+        expect_equal(run_legacy(legacy, kFrames, input, 2),
+                     run_legacy(routed, kFrames, input, 2));
+        expect_midi_equal(extract_collected(legacy, lids.mo),
+                          extract_collected(routed, rids.mo));
+    }
+}
+
+TEST_CASE("SignalGraph::process MIDI routing matches legacy: plugin -> plugin MIDI chain",
+          "[host][graph][executor][routing][parity][midi][plugin]") {
+    // MIDI flows through two plugins in series (transpose +5 then +3); the
+    // executor's MIDI gather must carry each plugin's MIDI output into the next.
+    struct Ids { pulp::host::NodeId mi, mo; };
+    auto build = [](SignalGraph& g, bool route) {
+        const auto p1 = g.add_plugin_node(
+            std::make_unique<MidiTransposePlugin>(5, 0, 0), 0, 0, "P1");
+        const auto p2 = g.add_plugin_node(
+            std::make_unique<MidiTransposePlugin>(3, 0, 0), 0, 0, "P2");
+        const auto mi = g.add_midi_input_node("MIDI In");
+        const auto mo = g.add_midi_output_node("MIDI Out");
+        REQUIRE(g.connect_midi(mi, p1));
+        REQUIRE(g.connect_midi(p1, p2));
+        REQUIRE(g.connect_midi(p2, mo));
+        g.set_canonical_executor_routing_enabled(route);
+        REQUIRE(g.prepare(kSr, kFrames));
+        return Ids{mi, mo};
+    };
+    SignalGraph legacy, routed;
+    const auto lids = build(legacy, false);
+    const auto rids = build(routed, true);
+    REQUIRE(signal_graph_executor_eligible(routed));
+
+    for (int blk = 0; blk < 4; ++blk) {
+        const auto inj = make_injected_midi(blk);
+        REQUIRE(legacy.inject_midi(lids.mi, inj));
+        REQUIRE(routed.inject_midi(rids.mi, inj));
+        process_silent_block(legacy);
+        process_silent_block(routed);
+        INFO("block " << blk);
+        expect_midi_equal(extract_collected(legacy, lids.mo),
+                          extract_collected(routed, rids.mo));
+    }
+}
+
+TEST_CASE("SignalGraph::process MIDI executor path does not allocate on the audio thread",
+          "[host][graph][executor][routing][rt-safety][midi]") {
+    SignalGraph g;
+    const auto p = g.add_plugin_node(
+        std::make_unique<MidiTransposePlugin>(7, 0, 0), 0, 0, "P");
+    const auto mi = g.add_midi_input_node("MIDI In");
+    const auto mo = g.add_midi_output_node("MIDI Out");
+    REQUIRE(g.connect_midi(mi, p));
+    REQUIRE(g.connect_midi(p, mo));
+    g.set_canonical_executor_routing_enabled(true);
+    REQUIRE(g.prepare(kSr, kFrames));
+    REQUIRE(signal_graph_executor_eligible(g));
+
+    // Pre-allocate the audio bus OUTSIDE the probe (the graph is MIDI-only; the
+    // 1-channel bus is unused but process() needs a valid block).
+    std::vector<float> in(static_cast<std::size_t>(kFrames), 0.0f);
+    std::vector<float> out(static_cast<std::size_t>(kFrames), 0.0f);
+    std::array<const float*, 1> ic{in.data()};
+    std::array<float*, 1> oc{out.data()};
+    pulp::audio::BufferView<const float> iv(ic.data(), 1, kFrames);
+    pulp::audio::BufferView<float> ov(oc.data(), 1, kFrames);
+
+    // Warm up the routed event path (mailbox read, gather, plugin emit, publish)
+    // outside the probe, then inject immediately before the probed block so it
+    // actually carries events (process() clears the MIDI input each block).
+    REQUIRE(g.inject_midi(mi, make_injected_midi(1)));
+    g.process(ov, iv, kFrames);
+    REQUIRE(g.inject_midi(mi, make_injected_midi(2)));
+    {
+        pulp::test::RtAllocationProbe probe;
+        g.process(ov, iv, kFrames);
+        REQUIRE_FALSE(probe.saw_allocation());
+    }
+
+    pulp::midi::MidiBuffer drained;
+    drained.reserve(64, 8, 256);
+    static_cast<void>(g.extract_midi(mo, drained));
 }


### PR DESCRIPTION
Enables MIDI graphs (MidiInput / MidiOutput nodes, `connect_midi` event edges, plugin MIDI in/out) on the opt-in (default-OFF) canonical-executor routing path, bit-identical to the legacy walk. Phase 4 slice 4f-3e.

## What
- `GraphRuntimeExecutor` owns per-node MIDI scratch (`GraphRuntimeMidiScratch` — in/out `MidiBuffer`s reserved RT-safe, attached UMP) and gathers each node's inbound event connections into its MIDI input before the node runs; the plugin binding reads `node_midi_in` and writes `node_midi_out`. `process_routed` takes an optional MIDI scratch (null for audio-only graphs).
- `MidiInput` / `MidiOutput` are null-binding no-op nodes. SignalGraph bridges its MIDI mailboxes around `process_routed`: it pre-fills each `MidiInput`'s scratch output from its mailbox (legacy unseen-sequence dedup) and publishes each `MidiOutput`'s gathered scratch input to its mailbox after.
- Incompleteness (event/sysex/UMP drops) propagates node-to-node and surfaces through `extract_midi` exactly as the legacy walk does.
- The consumed mailbox sequence is committed only after the routed dispatch succeeds, so a fallback to the legacy walk re-consumes the same block.
- Event ports are declared (and the MIDI scratch built) only for graphs that carry MIDI, so audio-only plans stay byte-identical.

## Tests (bit-exact vs SignalGraph, RT no-alloc, TSan-clean)
- `MidiInput → MidiOutput` direct; `MidiInput → plugin(transpose +7) → MidiOutput` with audio passthrough; `plugin → plugin` MIDI chain; mailbox-overflow incomplete-parity (both walks report the same `extract_midi` status + truncated events); routed MIDI no-alloc trap.
- TSan-clean on the MIDI + re-prepare-while-rendering concurrency hammer.

Default-OFF; legacy walk stays the fallback + oracle. Adversarially reviewed: no MUST-FIX; applied both SHOULD-FIX correctness fixes (incomplete-flag egress propagation + deferred mailbox-sequence commit), each with a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables MIDI routing on the opt-in canonical executor path (default OFF) with bit-identical behavior to the legacy walk. Adds per-node RT-safe MIDI buffers and routes `connect_midi` edges through the executor while bridging MIDI mailboxes in `SignalGraph`.

- **New Features**
  - `GraphRuntimeExecutor`: per-node MIDI scratch with attached UMP; gathers inbound event edges; exposes `node_midi_in`/`node_midi_out`; `process_routed` accepts optional MIDI scratch.
  - Supports `MidiInput`/`MidiOutput` as no-op nodes; host pre-fills/egresses mailboxes; commits consumed sequences only after success; propagates incompleteness exactly like legacy.
  - Executor routing now allows MIDI event connections; audio-only plans remain byte-identical and allocate no RT memory; plugin binding uses executor MIDI buffers when present.
  - Docs updated to reflect MIDI support on the canonical path; extensive parity tests added (direct, plugin chain, overflow, RT no-alloc).

- **Dependencies**
  - Bump `CMake` project to `0.477.0`.
  - Bump `.claude-plugin` manifests to `0.240.0`.

<sup>Written for commit c74b5bf425979790f1d2af52fa1c743854abf767. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

