### PR TITLE
feat(graph): carry parameter-automation metadata on graph connections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.477.0
+    VERSION 0.478.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/src/graph_runtime_executor.cpp
+++ b/core/format/src/graph_runtime_executor.cpp
@@ -82,7 +82,8 @@ void gather_node_inputs(const graph::GraphRuntimePlan& plan,
         const auto conn_index =
             plan.inbound_connection_indices[node.first_inbound_connection + c];
         const auto& conn = plan.connections[conn_index];
-        if (conn.event) continue;
+        // Event (MIDI) and automation edges carry no audio into an input port.
+        if (conn.event || conn.is_automation) continue;
         float* dst = pool.slot_data(slots.input_base + conn.dest_port);
         if (dst == nullptr) continue;
         if (conn.feedback) {

--- a/core/graph/include/pulp/graph/graph_runtime_plan.hpp
+++ b/core/graph/include/pulp/graph/graph_runtime_plan.hpp
@@ -49,6 +49,25 @@ struct GraphRuntimeNodeSpec {
     std::uint32_t latency_samples = 0;
 };
 
+// Parameter automation carried on a connection: the source audio output drives
+// the destination plugin's parameter `param_id` instead of an audio/event port.
+// `audio_rate` selects dense per-sample modulation; otherwise sparse two-point
+// (sample 0 + sample N-1). All values the realtime automation gather needs —
+// the source→param range map, the per-source slew time, the mix mode, and the
+// resolved parameter bounds — are carried here so the gather never calls into
+// the plugin on the audio thread. Meaningful only when `GraphRuntimeConnection*
+// ::automation` is true.
+struct GraphRuntimeAutomationSpec {
+    std::uint32_t param_id = 0;
+    float range_lo = 0.0f;        // plain-parameter domain the source maps into
+    float range_hi = 1.0f;
+    float smoothing_ms = 0.0f;    // per-source linear slew time (sparse only)
+    bool mix_add = false;         // false = Replace, true = Add (then clamp)
+    bool audio_rate = false;      // true = dense per-sample, false = sparse 2-point
+    float bounds_lo = 0.0f;       // resolved parameter bounds (Add-mix clamp)
+    float bounds_hi = 1.0f;
+};
+
 struct GraphRuntimeConnectionSpec {
     NodeId source_node = 0;
     PortIndex source_port = 0;
@@ -56,6 +75,11 @@ struct GraphRuntimeConnectionSpec {
     PortIndex dest_port = 0;
     bool feedback = false;
     bool event = false;
+    // True if this connection drives a parameter rather than an audio/event
+    // port; `automation` then carries the mapping. Automation connections still
+    // order the graph (source before dest) but carry no audio/MIDI payload.
+    bool is_automation = false;
+    GraphRuntimeAutomationSpec automation;
 };
 
 struct GraphRuntimeNodePlan {
@@ -82,6 +106,9 @@ struct GraphRuntimeConnectionPlan {
     PortIndex dest_port = 0;
     bool feedback = false;
     bool event = false;
+    // Carried from GraphRuntimeConnectionSpec; see those fields.
+    bool is_automation = false;
+    GraphRuntimeAutomationSpec automation;
 };
 
 struct GraphRuntimePlan {

--- a/core/graph/src/graph_runtime_buffer_assignment.cpp
+++ b/core/graph/src/graph_runtime_buffer_assignment.cpp
@@ -100,6 +100,9 @@ GraphRuntimeBufferAssignment build_graph_runtime_buffer_assignment(
             last_use[n] = plan.nodes[n].persistent_output ? pinned : pos[n];
         }
         // Connection plans store dense node indices in source_index/dest_index.
+        // An automation source's audio output IS read (sampled for the parameter
+        // value) at the destination's position, so it extends source liveness
+        // like an audio feedforward edge — but event (MIDI) edges carry no audio.
         for (const auto& conn : plan.connections) {
             if (conn.event) continue;
             if (conn.feedback) {
@@ -175,7 +178,10 @@ GraphRuntimeBufferAssignment build_graph_runtime_buffer_assignment(
                 const auto ci = plan.inbound_connection_indices[
                     node.first_inbound_connection + c];
                 const auto& conn = plan.connections[ci];
-                if (conn.feedback || conn.event) continue;
+                // Feedback, event (MIDI), and sparse-automation edges do not
+                // carry latency-aligned audio into an input port, so they don't
+                // contribute to a node's input latency (matching the host walk).
+                if (conn.feedback || conn.event || conn.is_automation) continue;
                 max_upstream = std::max(max_upstream, output_latency[conn.source_index]);
             }
             input_latency[node_index] = max_upstream;
@@ -183,7 +189,7 @@ GraphRuntimeBufferAssignment build_graph_runtime_buffer_assignment(
         }
         for (std::size_t i = 0; i < plan.connections.size(); ++i) {
             const auto& conn = plan.connections[i];
-            if (conn.feedback || conn.event) continue;
+            if (conn.feedback || conn.event || conn.is_automation) continue;
             const std::uint32_t dst_in = input_latency[conn.dest_index];
             const std::uint32_t src_out = output_latency[conn.source_index];
             const std::uint32_t want = dst_in > src_out ? dst_in - src_out : 0;

--- a/core/graph/src/graph_runtime_plan.cpp
+++ b/core/graph/src/graph_runtime_plan.cpp
@@ -170,15 +170,21 @@ GraphRuntimePlanResult build_graph_runtime_plan(
                                 ? "graph event connection source port is out of range"
                                 : "graph connection source port is out of range");
             }
-            const auto& dest = result.plan.nodes[dest_index];
-            const auto dest_ports = spec.event ? dest.event_input_ports
-                                               : dest.input_ports;
-            if (spec.dest_port >= dest_ports) {
-                return fail(GraphRuntimePlanErrorCode::DestinationPortOutOfRange, i,
-                            spec.dest_node,
-                            spec.event
-                                ? "graph event connection destination port is out of range"
-                                : "graph connection destination port is out of range");
+            // An automation connection targets a destination PARAMETER, not an
+            // audio/event input port (its dest_port is a conventional 0), so the
+            // input-port range check does not apply. Its source IS an audio
+            // output port, so the source check above still holds.
+            if (!spec.is_automation) {
+                const auto& dest = result.plan.nodes[dest_index];
+                const auto dest_ports = spec.event ? dest.event_input_ports
+                                                   : dest.input_ports;
+                if (spec.dest_port >= dest_ports) {
+                    return fail(GraphRuntimePlanErrorCode::DestinationPortOutOfRange, i,
+                                spec.dest_node,
+                                spec.event
+                                    ? "graph event connection destination port is out of range"
+                                    : "graph connection destination port is out of range");
+                }
             }
 
             result.plan.connections.push_back({
@@ -188,6 +194,8 @@ GraphRuntimePlanResult build_graph_runtime_plan(
                 spec.dest_port,
                 spec.feedback,
                 spec.event,
+                spec.is_automation,
+                spec.automation,
             });
             ++outbound_counts[source_index];
             ++inbound_counts[dest_index];

--- a/test/test_graph_runtime_plan.cpp
+++ b/test/test_graph_runtime_plan.cpp
@@ -282,3 +282,75 @@ TEST_CASE("GraphRuntimePlan accepts empty graphs as valid no-op plans",
     REQUIRE(result.plan.connection_count() == 0);
     REQUIRE(result.plan.processing_order_indices.empty());
 }
+
+TEST_CASE("GraphRuntimePlan carries parameter-automation metadata",
+          "[graph][graph-runtime][plan][automation]") {
+    using namespace pulp::graph;
+    // in(0->2) -> plugin(2->2); plus an automation edge in:0 -> plugin param 42.
+    const std::array nodes = {
+        node(1, 0, 2, GraphRuntimeNodeKind::AudioInput),
+        node(2, 2, 2),
+    };
+    GraphRuntimeConnectionSpec audio = connect(1, 0, 2, 0);
+    GraphRuntimeConnectionSpec autom{};
+    autom.source_node = 1;
+    autom.source_port = 1;
+    autom.dest_node = 2;
+    autom.dest_port = 0;  // conventional; a parameter target, not an audio port
+    autom.is_automation = true;
+    autom.automation = GraphRuntimeAutomationSpec{
+        /*param_id=*/42, /*range_lo=*/-1.0f, /*range_hi=*/1.0f,
+        /*smoothing_ms=*/25.0f, /*mix_add=*/true, /*audio_rate=*/false,
+        /*bounds_lo=*/-2.0f, /*bounds_hi=*/2.0f};
+    const std::array conns = {audio, autom};
+
+    const auto result = build_graph_runtime_plan(nodes, conns);
+    REQUIRE(result.ok());
+    REQUIRE(result.plan.connections.size() == 2);
+
+    // The audio edge is unchanged; the automation edge carries its full spec.
+    const auto& a = result.plan.connections[1];
+    CHECK(a.is_automation);
+    CHECK_FALSE(a.event);
+    CHECK_FALSE(a.feedback);
+    CHECK(a.automation.param_id == 42u);
+    CHECK(a.automation.range_lo == -1.0f);
+    CHECK(a.automation.range_hi == 1.0f);
+    CHECK(a.automation.smoothing_ms == 25.0f);
+    CHECK(a.automation.mix_add);
+    CHECK_FALSE(a.automation.audio_rate);
+    CHECK(a.automation.bounds_lo == -2.0f);
+    CHECK(a.automation.bounds_hi == 2.0f);
+
+    // Automation still orders the graph: source (in) before dest (plugin).
+    REQUIRE(result.plan.processing_order_indices.size() == 2);
+    CHECK(result.plan.processing_order_indices[0] == 0);
+    CHECK(result.plan.processing_order_indices[1] == 1);
+}
+
+TEST_CASE("GraphRuntimePlan skips the input-port check for automation edges",
+          "[graph][graph-runtime][plan][automation]") {
+    using namespace pulp::graph;
+    // The destination plugin has ZERO audio input ports; an automation edge to
+    // its parameter must still be accepted (dest_port targets a parameter, not
+    // an audio input), whereas a plain audio edge to it would be rejected.
+    const std::array nodes = {
+        node(1, 0, 2, GraphRuntimeNodeKind::AudioInput),
+        node(2, 0, 2),  // 0 audio inputs
+    };
+    GraphRuntimeConnectionSpec autom{};
+    autom.source_node = 1;
+    autom.source_port = 0;
+    autom.dest_node = 2;
+    autom.dest_port = 0;
+    autom.is_automation = true;
+    autom.automation.param_id = 7;
+    const std::array ok_conns = {autom};
+    CHECK(build_graph_runtime_plan(nodes, ok_conns).ok());
+
+    // A plain audio edge to the same (absent) input port 0 is rejected.
+    const std::array bad_conns = {connect(1, 0, 2, 0)};
+    const auto bad = build_graph_runtime_plan(nodes, bad_conns);
+    CHECK_FALSE(bad.ok());
+    CHECK(bad.error.code == GraphRuntimePlanErrorCode::DestinationPortOutOfRange);
+}


### PR DESCRIPTION
Substrate for routing parameter automation on the canonical executor. Phase 4 slice 4f-3f-1 (the gather + eligibility lands in 4f-3f-2).

A graph connection can mark itself `is_automation` and carry a `GraphRuntimeAutomationSpec` — parameter id, source→param range map, per-source slew time, mix mode (Replace/Add), `audio_rate` flag, and **resolved parameter bounds** — so a future realtime automation gather needs no plugin call on the audio thread.

- The plan builder carries these through. Because an automation edge targets a destination **parameter**, not an audio input port, the input-port range check is skipped for it (its source is still a real audio output port, so the source check holds), while it still orders the graph (source before dest).
- Automation edges are excluded from audio-input gather, latency propagation, and per-connection delay (matching the legacy walk), but still extend their source's audio-output liveness (the value is sampled from it).

No routing behavior change: automation connections remain **ineligible** until the gather lands (carried-but-ungathered would diverge), so this is consumed by unit tests — metadata round-trip, the input-port-check skip (accepts an automation edge to a 0-audio-input plugin; rejects a plain audio edge there), and topological ordering. Audio-only and MIDI plans are byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds parameter-automation metadata to graph connections so the executor can route automation without plugin calls on the audio thread. Introduces `is_automation` edges that target parameters, adjust planning/latency rules, and keep current routing unchanged.

- New Features
  - Add `is_automation` and `automation` to connection spec/plan, carrying `param_id`, source→param range, `smoothing_ms`, mix mode (Replace/Add), `audio_rate`, and resolved bounds.
  - Plan builder passes automation metadata through and skips destination input-port checks for automation edges; edges still order the graph.
  - Executor input gather ignores automation edges; buffer assignment excludes them from latency/delay but extends source liveness.
  - No behavior change yet: automation edges remain ineligible until the gather lands; tests cover metadata round-trip, port-check skip on 0-input plugins, and topological ordering.

<sup>Written for commit 7fad5651ff23905f64f6a27a9fa25ec63cff6f89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

