### PR TITLE
feat(host): route sparse parameter automation on the canonical executor path

### DIFF
--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -141,8 +141,9 @@ predictable output, no MIDI.
   nodes only AudioInput / AudioOutput / Gain / Plugin (every Plugin node must
   carry a LIVE slot) / MidiInput / MidiOutput, connections audio (feedforward,
   one-block feedback, or sidechain — a sidechain edge routes as plain audio into
-  a higher input port of the destination plugin) or MIDI (connect_midi event
-  edges; no automation / audio-rate-mod) — can be driven
+  a higher input port of the destination plugin), MIDI (connect_midi event
+  edges), or SPARSE parameter automation (connect_automation; dense audio-rate
+  modulation still keeps the legacy walk) — can be driven
   through the canonical `GraphRuntimeExecutor` instead of the legacy walk via
   `set_canonical_executor_routing_enabled(true)`. Output is bit-identical to the
   legacy walk (`signal_graph_executor_routing.{hpp,cpp}` translates the graph;
@@ -159,8 +160,13 @@ predictable output, no MIDI.
   `GraphRuntimeBufferPool`), so fan-in paths of differing latency time-align
   identically. MIDI edges route through per-node MIDI scratch buffers owned by
   the executor (`GraphRuntimeMidiScratch`); SignalGraph bridges its MIDI
-  mailboxes (inject_midi / extract_midi) around the routed call. Automation /
-  audio-rate-mod graphs stay on the legacy walk.
+  mailboxes (inject_midi / extract_midi) around the routed call. Sparse parameter
+  automation routes through a `GraphRuntimeAutomationScratch` (per-node parameter
+  event queue + per-connection slew state): the executor samples each source at
+  the block edges, maps/slews/mixes per the connection's resolved bounds, and
+  builds the plugin's parameter events — bit-identical to the walk. A node
+  automating more than `kMaxParamsPerNode` (64) distinct parameters is kept on
+  the legacy walk. Dense audio-rate modulation still stays on the legacy walk.
 - `connect()` returns `false` on cycle — always check. `would_create_cycle`
   lets you preview without mutating.
 - `processing_order()` is recomputed each call; cache it in the audio

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.240.0",
+      "version": "0.241.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.240.0"
+  "version": "0.241.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.240.0",
+  "version": "0.241.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.478.0
+    VERSION 0.479.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/graph_runtime_executor.hpp
+++ b/core/format/include/pulp/format/graph_runtime_executor.hpp
@@ -7,6 +7,7 @@
 #include <pulp/graph/graph_runtime_queue.hpp>
 #include <pulp/midi/buffer.hpp>
 #include <pulp/midi/ump_buffer.hpp>
+#include <pulp/state/parameter_event_queue.hpp>
 
 #include <array>
 #include <atomic>
@@ -64,6 +65,12 @@ struct GraphRuntimeNodeProcessContext {
     // to its own scratch.
     midi::MidiBuffer* node_midi_in = nullptr;
     midi::MidiBuffer* node_midi_out = nullptr;
+    // Per-node parameter automation events (non-null only on the routing path
+    // when the call supplies a GraphRuntimeAutomationScratch). The executor fills
+    // it from this node's inbound automation connections before the binding runs;
+    // a plugin binding passes it to PluginSlot::process. Null when the graph
+    // carries no automation — a binding then uses an empty queue.
+    state::ParameterEventQueue* node_param_events = nullptr;
 };
 
 using GraphRuntimeNodeProcessFn = bool (*)(
@@ -323,6 +330,56 @@ private:
     std::uint32_t node_count_ = 0;
 };
 
+/// Pre-allocated scratch backing the routing path's parameter-automation edges.
+///
+/// Per node: one ParameterEventQueue (the automation events handed to the
+/// plugin). Per connection: the persisted per-source slew state (last delivered
+/// value + primed flag) a sparse automation edge ramps from across blocks. Both
+/// are sized off-RT from the snapshot; the executor's automation gather fills a
+/// node's queue from its inbound automation connections before the node runs.
+class GraphRuntimeAutomationScratch {
+public:
+    // Upper bound on distinct automated parameters per node — the size of the
+    // gather's on-stack accumulator. A graph automating more than this on any one
+    // node must be rejected by the caller (kept on the legacy walk) rather than
+    // routed, since the gather would otherwise silently drop the overflow.
+    static constexpr std::uint32_t kMaxParamsPerNode = 64;
+
+    // Off-RT: allocate `node_count` event queues and `connection_count` slew
+    // states (zero-initialized, un-primed). Returns false on allocation failure.
+    bool reset(std::uint32_t node_count, std::uint32_t connection_count);
+    void clear() noexcept;
+
+    std::uint32_t node_count() const noexcept { return node_count_; }
+    std::uint32_t connection_count() const noexcept { return connection_count_; }
+
+    state::ParameterEventQueue* events(std::uint32_t node_index) noexcept {
+        return node_index < node_count_ ? events_[node_index].get() : nullptr;
+    }
+    // Persisted per-connection slew state (RT-mutable). last() is the previous
+    // block's post-slew value; primed() guards the first-block snap.
+    float& slew_last(std::uint32_t conn_index) noexcept { return slew_last_[conn_index]; }
+    bool slew_primed(std::uint32_t conn_index) const noexcept {
+        return slew_primed_[conn_index] != 0;
+    }
+    void set_slew_primed(std::uint32_t conn_index, bool v) noexcept {
+        slew_primed_[conn_index] = v ? 1 : 0;
+    }
+
+    bool fits(std::uint32_t node_count, std::uint32_t connection_count) const noexcept {
+        return node_count_ >= node_count && connection_count_ >= connection_count;
+    }
+
+private:
+    // ParameterEventQueue is large and non-copyable; hold it via unique_ptr so a
+    // reallocating vector never needs to move/copy it.
+    std::vector<std::unique_ptr<state::ParameterEventQueue>> events_;  // per node
+    std::vector<float> slew_last_;                    // per connection
+    std::vector<std::uint8_t> slew_primed_;           // per connection
+    std::uint32_t node_count_ = 0;
+    std::uint32_t connection_count_ = 0;
+};
+
 class GraphRuntimeExecutor {
 public:
     static constexpr std::size_t kMaxInlineCommandCapacity = 256;
@@ -401,6 +458,7 @@ public:
         const GraphRuntimeSnapshot& snapshot,
         GraphRuntimeBufferPool& pool,
         GraphRuntimeMidiScratch* midi = nullptr,
+        GraphRuntimeAutomationScratch* automation = nullptr,
         std::span<const graph::GraphTimedCommand> commands = {},
         std::span<GraphRuntimeCommandDecision> command_results = {},
         GraphRuntimeCommandHandler command_handler = {},

--- a/core/format/src/graph_runtime_executor.cpp
+++ b/core/format/src/graph_runtime_executor.cpp
@@ -192,6 +192,125 @@ void gather_node_midi(const graph::GraphRuntimePlan& plan,
     midi.set_in_incomplete(node_index, incomplete);
 }
 
+// Upper bound on distinct automated parameters per node for the on-stack
+// accumulator. The caller (eligibility check) rejects any graph that exceeds
+// this on a node and keeps it on the legacy walk, so the `continue` below is
+// a defense-in-depth backstop, never hit for an eligible graph.
+constexpr std::uint32_t kMaxAutomatedParamsPerNode =
+    GraphRuntimeAutomationScratch::kMaxParamsPerNode;
+
+// Build this node's parameter-automation events from its inbound SPARSE
+// automation connections (audio-rate edges are handled elsewhere). Each edge
+// samples its source's audio output at sample 0 and N-1, maps into the
+// parameter range, applies per-source linear slew (state persisted in the
+// scratch), accumulates per parameter by mix mode, then emits two control points
+// per touched parameter — replicating the host walk's sparse-automation math.
+void gather_node_automation(const graph::GraphRuntimePlan& plan,
+                            const graph::GraphRuntimeBufferAssignment& assignment,
+                            GraphRuntimeBufferPool& pool,
+                            GraphRuntimeAutomationScratch& automation,
+                            const graph::GraphRuntimeNodePlan& node,
+                            std::uint32_t node_index,
+                            std::uint32_t frames,
+                            double sample_rate) noexcept {
+    state::ParameterEventQueue* queue = automation.events(node_index);
+    if (queue == nullptr) return;
+    queue->clear();
+    const int last = static_cast<int>(frames) - 1;
+
+    struct Accum {
+        std::uint32_t param_id;
+        float v0;
+        float vN;
+        float lo;
+        float hi;
+        bool has_add;
+    };
+    std::array<Accum, kMaxAutomatedParamsPerNode> accum{};
+    std::uint32_t param_count = 0;
+
+    for (std::uint32_t c = 0; c < node.inbound_connection_count; ++c) {
+        const auto conn_index =
+            plan.inbound_connection_indices[node.first_inbound_connection + c];
+        const auto& conn = plan.connections[conn_index];
+        if (!conn.is_automation || conn.automation.audio_rate) continue;
+        const auto& src_slots = assignment.nodes[conn.source_index];
+        const float* src = pool.slot_data(src_slots.output_base + conn.source_port);
+        if (src == nullptr) continue;
+        const auto& a = conn.automation;
+        const float s0 = std::clamp(src[0], 0.0f, 1.0f);
+        const float sN = std::clamp(src[last < 0 ? 0 : last], 0.0f, 1.0f);
+        float m0 = a.range_lo + s0 * (a.range_hi - a.range_lo);
+        float mN = a.range_lo + sN * (a.range_hi - a.range_lo);
+
+        if (a.smoothing_ms > 0.0f && sample_rate > 0.0) {
+            const float range = std::abs(a.range_hi - a.range_lo);
+            const double slew_samples =
+                static_cast<double>(a.smoothing_ms) * 0.001 * sample_rate;
+            const float max_step =
+                slew_samples > 0.0 ? (range / static_cast<float>(slew_samples)) : range;
+            if (!automation.slew_primed(conn_index)) {
+                automation.slew_last(conn_index) = m0;
+                automation.set_slew_primed(conn_index, true);
+            }
+            auto ramp_to = [max_step](float from, float target) {
+                const float delta = target - from;
+                if (delta > max_step) return from + max_step;
+                if (delta < -max_step) return from - max_step;
+                return target;
+            };
+            const float new_v0 = ramp_to(automation.slew_last(conn_index), m0);
+            float new_vN = new_v0;
+            if (last > 0) {
+                const float max_block_step = max_step * static_cast<float>(last);
+                const float delta = mN - new_v0;
+                if (delta > max_block_step) {
+                    new_vN = new_v0 + max_block_step;
+                } else if (delta < -max_block_step) {
+                    new_vN = new_v0 - max_block_step;
+                } else {
+                    new_vN = mN;
+                }
+            }
+            automation.slew_last(conn_index) = new_vN;
+            m0 = new_v0;
+            mN = new_vN;
+        }
+
+        std::uint32_t pi = 0;
+        for (; pi < param_count; ++pi) {
+            if (accum[pi].param_id == a.param_id) break;
+        }
+        if (pi == param_count) {
+            if (param_count >= kMaxAutomatedParamsPerNode) continue;
+            accum[pi] = Accum{a.param_id, 0.0f, 0.0f, a.bounds_lo, a.bounds_hi, false};
+            ++param_count;
+        }
+        if (a.mix_add) {
+            accum[pi].v0 += m0;
+            accum[pi].vN += mN;
+            accum[pi].has_add = true;
+        } else {
+            accum[pi].v0 = m0;
+            accum[pi].vN = mN;
+        }
+    }
+
+    for (std::uint32_t pi = 0; pi < param_count; ++pi) {
+        float v0 = accum[pi].v0;
+        float vN = accum[pi].vN;
+        if (accum[pi].has_add) {
+            const float lo = std::min(accum[pi].lo, accum[pi].hi);
+            const float hi = std::max(accum[pi].lo, accum[pi].hi);
+            v0 = std::clamp(v0, lo, hi);
+            vN = std::clamp(vN, lo, hi);
+        }
+        if (!queue->push({accum[pi].param_id, 0, v0, 0})) break;
+        if (last > 0 && !queue->push({accum[pi].param_id, last, vN, 0})) break;
+    }
+    queue->sort();
+}
+
 // After all nodes run, capture each feedback edge's current source output into
 // its previous-block slot for the next block (the source's output slot is final
 // once the block's walk completes). One-block delay, matching SignalGraph.
@@ -286,6 +405,33 @@ bool GraphRuntimeMidiScratch::reset(std::uint32_t node_count) {
 void GraphRuntimeMidiScratch::clear() noexcept {
     slots_.clear();
     node_count_ = 0;
+}
+
+bool GraphRuntimeAutomationScratch::reset(std::uint32_t node_count,
+                                          std::uint32_t connection_count) {
+    clear();
+    try {
+        events_.reserve(node_count);
+        for (std::uint32_t i = 0; i < node_count; ++i) {
+            events_.push_back(std::make_unique<state::ParameterEventQueue>());
+        }
+        slew_last_.assign(connection_count, 0.0f);
+        slew_primed_.assign(connection_count, 0);
+    } catch (...) {
+        clear();
+        return false;
+    }
+    node_count_ = node_count;
+    connection_count_ = connection_count;
+    return true;
+}
+
+void GraphRuntimeAutomationScratch::clear() noexcept {
+    events_.clear();
+    slew_last_.clear();
+    slew_primed_.clear();
+    node_count_ = 0;
+    connection_count_ = 0;
 }
 
 bool GraphRuntimeBufferPool::reset(std::uint32_t slot_count, std::uint32_t max_frames) {
@@ -502,6 +648,7 @@ GraphRuntimeExecutorResult GraphRuntimeExecutor::process_routed(
     const GraphRuntimeSnapshot& snapshot,
     GraphRuntimeBufferPool& pool,
     GraphRuntimeMidiScratch* midi,
+    GraphRuntimeAutomationScratch* automation,
     std::span<const graph::GraphTimedCommand> commands,
     std::span<GraphRuntimeCommandDecision> command_results,
     GraphRuntimeCommandHandler command_handler,
@@ -515,6 +662,14 @@ GraphRuntimeExecutorResult GraphRuntimeExecutor::process_routed(
     const auto frames = block.frame_count;
 
     if (!pool.fits(snapshot, frames)) {
+        GraphRuntimeExecutorResult fail;
+        fail.error = GraphRuntimeExecutorErrorCode::BufferPoolTooSmall;
+        return fail;
+    }
+    // An automation scratch, when supplied, must cover every node + connection so
+    // the gather can index any node's queue and any connection's slew state.
+    if (automation != nullptr &&
+        !automation->fits(plan.node_count(), plan.connection_count())) {
         GraphRuntimeExecutorResult fail;
         fail.error = GraphRuntimeExecutorErrorCode::BufferPoolTooSmall;
         return fail;
@@ -566,6 +721,10 @@ GraphRuntimeExecutorResult GraphRuntimeExecutor::process_routed(
         if (midi != nullptr) {
             gather_node_midi(plan, *midi, node, node_index);
         }
+        if (automation != nullptr) {
+            gather_node_automation(plan, assignment, pool, *automation, node,
+                                   node_index, frames, block.sample_rate);
+        }
 
         if (node.kind == graph::GraphRuntimeNodeKind::AudioInput ||
             node.kind == graph::GraphRuntimeNodeKind::AudioOutput) {
@@ -611,6 +770,9 @@ GraphRuntimeExecutorResult GraphRuntimeExecutor::process_routed(
             if (midi != nullptr) {
                 context.node_midi_in = midi->in(node_index);
                 context.node_midi_out = midi->out(node_index);
+            }
+            if (automation != nullptr) {
+                context.node_param_events = automation->events(node_index);
             }
             if (!binding.process(block, context, binding.user_data)) {
                 result.error = GraphRuntimeExecutorErrorCode::NodeProcessorFailed;

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -693,6 +693,10 @@ private:
         struct RoutedMidiNode { std::uint32_t plan_index; NodeId id; std::uint64_t pending_seq = 0; };
         std::vector<RoutedMidiNode> routing_midi_inputs;
         std::vector<RoutedMidiNode> routing_midi_outputs;
+        // Per-node parameter-event queues + per-connection slew state for routed
+        // sparse automation, owned per-snapshot like exec_pool. Empty (node_count
+        // 0) for graphs with no sparse automation.
+        format::GraphRuntimeAutomationScratch routing_automation;
     };
 
     std::vector<GraphNode> nodes_;

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -1200,6 +1200,17 @@ SignalGraph::compile_(double sample_rate, int max_block_size) {
             if (plan_has_midi) {
                 cg->routing_valid = cg->routing_midi.reset(plan.node_count());
             }
+            // Per-snapshot sparse-automation scratch, built only when the routed
+            // plan carries automation connections (audio-only / MIDI graphs
+            // allocate none).
+            bool plan_has_automation = false;
+            for (const auto& conn : plan.connections) {
+                if (conn.is_automation) { plan_has_automation = true; break; }
+            }
+            if (cg->routing_valid && plan_has_automation) {
+                cg->routing_valid = cg->routing_automation.reset(
+                    plan.node_count(), plan.connection_count());
+            }
         }
     }
     return cg;
@@ -1548,10 +1559,12 @@ void SignalGraph::process(audio::BufferView<float>& output,
                 }
             }
 
+            const bool has_automation = cg->routing_automation.node_count() > 0;
             if (block.validate() &&
                 executor_.process_routed(
                     block, cg->routing_snapshot, cg->exec_pool,
-                    has_midi ? &cg->routing_midi : nullptr).ok()) {
+                    has_midi ? &cg->routing_midi : nullptr,
+                    has_automation ? &cg->routing_automation : nullptr).ok()) {
                 if (has_midi) {
                     // Commit the consumed mailbox sequences now that routing
                     // succeeded.

--- a/core/host/src/signal_graph_executor_routing.cpp
+++ b/core/host/src/signal_graph_executor_routing.cpp
@@ -105,8 +105,12 @@ bool plugin_binding(fmt::ProcessBlock&,
     midi_out.clear();
     midi_out.clear_sysex();
     if (auto* ump = midi_out.ump()) ump->clear();
-    pctx->slot->process(buffers, midi_in, midi_out, pctx->scratch->param_events,
-                        num_samples);
+    // Use the executor's per-node parameter-automation events when supplied (an
+    // automation graph); the empty shared scratch queue otherwise.
+    state::ParameterEventQueue& param_events =
+        ctx.node_param_events != nullptr ? *ctx.node_param_events
+                                         : pctx->scratch->param_events;
+    pctx->slot->process(buffers, midi_in, midi_out, param_events, num_samples);
     return true;
 }
 
@@ -145,15 +149,15 @@ bool node_eligible(const GraphNode& node) noexcept {
 }
 
 bool connection_eligible(const Connection& c) noexcept {
-    // Audio and MIDI edges. Feedback is fine (the executor handles one-block
-    // feedback). Sidechain is fine: SignalGraph routes a sidechain edge as a
-    // plain audio edge into a higher input port of the destination plugin (the
-    // plugin's input_ports count already includes its sidechain ports, and the
-    // single concatenated input bus carries them), and it participates in PDC
-    // exactly like any audio edge. MIDI edges are carried as event connections
-    // and routed by the executor's MIDI gather. Automation / audio-rate-mod
-    // still keep the legacy walk.
-    return !c.automation && !c.audio_rate_modulation;
+    // Audio, MIDI, and SPARSE parameter-automation edges. Feedback is fine (the
+    // executor handles one-block feedback). Sidechain is fine: SignalGraph routes
+    // a sidechain edge as a plain audio edge into a higher input port of the
+    // destination plugin and it participates in PDC like any audio edge. MIDI
+    // edges are carried as event connections. Sparse automation (`automation` &&
+    // !`audio_rate_modulation`) is carried as an automation connection and built
+    // into the plugin's parameter-event queue by the executor's automation
+    // gather. Dense audio-rate modulation still keeps the legacy walk.
+    return !c.audio_rate_modulation;
 }
 
 } // namespace
@@ -165,6 +169,27 @@ bool signal_graph_topology_executor_eligible(std::span<const GraphNode> nodes,
     }
     for (const auto& c : connections) {
         if (!connection_eligible(c)) return false;
+    }
+    // The executor's automation gather accumulates distinct automated parameters
+    // per node in a fixed on-stack array (kMaxParamsPerNode); a node automating
+    // more than that would silently drop the overflow. Keep such a graph on the
+    // legacy walk (fail closed) rather than route it and diverge.
+    std::vector<std::pair<NodeId, std::vector<std::uint32_t>>> per_dest;
+    for (const auto& c : connections) {
+        if (!c.automation || c.audio_rate_modulation) continue;  // sparse only
+        auto it = std::find_if(per_dest.begin(), per_dest.end(),
+                               [&](const auto& e) { return e.first == c.dest_node; });
+        if (it == per_dest.end()) {
+            per_dest.push_back({c.dest_node, {c.automation_param_id}});
+            continue;
+        }
+        auto& ids = it->second;
+        if (std::find(ids.begin(), ids.end(), c.automation_param_id) == ids.end()) {
+            ids.push_back(c.automation_param_id);
+            if (ids.size() > fmt::GraphRuntimeAutomationScratch::kMaxParamsPerNode) {
+                return false;
+            }
+        }
     }
     return true;
 }
@@ -249,10 +274,38 @@ bool build_executor_snapshot(std::span<const GraphNode> nodes,
     std::vector<gr::GraphRuntimeConnectionSpec> conn_specs;
     conn_specs.reserve(connections.size());
     for (const auto& c : connections) {
-        conn_specs.push_back(gr::GraphRuntimeConnectionSpec{
+        gr::GraphRuntimeConnectionSpec spec{
             c.source_node, c.source_port, c.dest_node, c.dest_port,
             c.feedback, /*event=*/c.midi,
-        });
+        };
+        // A sparse parameter-automation edge becomes an automation connection
+        // carrying its mapping. Resolve the destination plugin's parameter bounds
+        // OFF the audio thread (so the realtime gather's Add-mix clamp matches the
+        // legacy walk's bounds_for_param without a plugin call). Dense audio-rate
+        // edges stay on the legacy walk (connection_eligible rejects them).
+        if (c.automation && !c.audio_rate_modulation) {
+            spec.is_automation = true;
+            spec.automation.param_id = c.automation_param_id;
+            spec.automation.range_lo = c.automation_range_lo;
+            spec.automation.range_hi = c.automation_range_hi;
+            spec.automation.smoothing_ms = c.automation_smoothing_ms;
+            spec.automation.mix_add = c.automation_mix == AutomationMix::Add;
+            spec.automation.audio_rate = false;
+            // Default bounds to the mapped range, then refine to the plugin's
+            // declared parameter bounds if resolvable (matching bounds_for_param).
+            spec.automation.bounds_lo = c.automation_range_lo;
+            spec.automation.bounds_hi = c.automation_range_hi;
+            PluginSlot* dest_slot = plugin_for ? plugin_for(c.dest_node) : nullptr;
+            if (dest_slot != nullptr) {
+                for (const auto& p : dest_slot->parameters()) {
+                    if (p.id != c.automation_param_id) continue;
+                    spec.automation.bounds_lo = p.min_value;
+                    spec.automation.bounds_hi = p.max_value;
+                    break;
+                }
+            }
+        }
+        conn_specs.push_back(spec);
     }
 
     auto plan = gr::build_graph_runtime_plan(node_specs, conn_specs);

--- a/test/test_signal_graph_executor_parity.cpp
+++ b/test/test_signal_graph_executor_parity.cpp
@@ -678,6 +678,130 @@ pulp::midi::MidiBuffer make_injected_midi(int seed) {
     return buf;
 }
 
+// Plugin with one automatable parameter (id 1, bounds [0,2]) that applies it as
+// a per-sample gain ramp from the block's first control point to its last:
+// out[c][i] = in[c][i] * lerp(v0, vN, i/last). Reading the parameter events makes
+// any automation gather divergence (mapping, slew, mix, clamp, ordering) show up
+// as an audio-output difference.
+class AutomatedGainPlugin final : public PluginSlot {
+public:
+    explicit AutomatedGainPlugin(int channels)
+        : info_(test_plugin_info(channels, channels)) {}
+
+    const PluginInfo& info() const override { return info_; }
+    bool is_loaded() const override { return true; }
+    bool prepare(double, int) override { return true; }
+    void release() override {}
+    void process(pulp::audio::BufferView<float>& out,
+                 const pulp::audio::BufferView<const float>& in,
+                 const pulp::midi::MidiBuffer&,
+                 pulp::midi::MidiBuffer&,
+                 const pulp::host::ParameterEventQueue& params,
+                 int n) override {
+        const int last = n - 1;
+        float v0 = 1.0f;
+        float vN = 1.0f;
+        for (const auto& ev : params) {
+            if (ev.param_id != 1) continue;
+            if (ev.sample_offset == 0) v0 = ev.value;
+            if (ev.sample_offset == last) vN = ev.value;
+        }
+        const std::size_t chs = out.num_channels();
+        for (std::size_t c = 0; c < chs; ++c) {
+            float* o = out.channel_ptr(c);
+            const float* i = c < in.num_channels() ? in.channel_ptr(c) : nullptr;
+            for (int s = 0; s < n; ++s) {
+                const float t = last > 0 ? static_cast<float>(s) / static_cast<float>(last) : 0.0f;
+                const float gain = v0 + (vN - v0) * t;
+                o[static_cast<std::size_t>(s)] =
+                    (i ? i[static_cast<std::size_t>(s)] : 0.0f) * gain;
+            }
+        }
+    }
+    std::vector<pulp::host::HostParamInfo> parameters() const override {
+        pulp::host::HostParamInfo p;
+        p.id = 1;
+        p.name = "Gain";
+        p.min_value = 0.0f;
+        p.max_value = 2.0f;
+        p.default_value = 1.0f;
+        p.flags.automatable = true;
+        // A second, audio-rate-capable parameter for dense-modulation coverage.
+        pulp::host::HostParamInfo p2;
+        p2.id = 2;
+        p2.name = "AudioRateGain";
+        p2.min_value = 0.0f;
+        p2.max_value = 2.0f;
+        p2.default_value = 1.0f;
+        p2.flags.automatable = true;
+        p2.flags.modulatable = true;
+        p2.rate = pulp::state::ParamRate::AudioRate;
+        return {p, p2};
+    }
+    float get_parameter(uint32_t) const override { return 1.0f; }
+    void set_parameter(uint32_t, float) override {}
+    void set_bypass(bool) override {}
+    bool is_bypassed() const override { return false; }
+    std::vector<uint8_t> save_state() const override { return {}; }
+    bool restore_state(const std::vector<uint8_t>&) override { return true; }
+    int latency_samples() const override { return 0; }
+    int tail_samples() const override { return 0; }
+    bool has_editor() const override { return false; }
+    void* create_editor_view() override { return nullptr; }
+    void destroy_editor_view() override {}
+
+private:
+    PluginInfo info_;
+};
+
+// Plugin exposing `num_params` automatable parameters (ids 1..num_params), for
+// the per-node automated-parameter cap. Audio passes through unchanged.
+class ManyParamPlugin final : public PluginSlot {
+public:
+    ManyParamPlugin(int num_params, int channels)
+        : num_params_(num_params), info_(test_plugin_info(channels, channels)) {}
+    const PluginInfo& info() const override { return info_; }
+    bool is_loaded() const override { return true; }
+    bool prepare(double, int) override { return true; }
+    void release() override {}
+    void process(pulp::audio::BufferView<float>& out,
+                 const pulp::audio::BufferView<const float>& in,
+                 const pulp::midi::MidiBuffer&, pulp::midi::MidiBuffer&,
+                 const pulp::host::ParameterEventQueue&, int n) override {
+        const std::size_t chs = std::min(out.num_channels(), in.num_channels());
+        for (std::size_t c = 0; c < chs; ++c) {
+            std::copy_n(in.channel_ptr(c), n, out.channel_ptr(c));
+        }
+    }
+    std::vector<pulp::host::HostParamInfo> parameters() const override {
+        std::vector<pulp::host::HostParamInfo> ps;
+        for (int i = 0; i < num_params_; ++i) {
+            pulp::host::HostParamInfo p;
+            p.id = static_cast<uint32_t>(i + 1);
+            p.min_value = 0.0f;
+            p.max_value = 1.0f;
+            p.flags.automatable = true;
+            ps.push_back(p);
+        }
+        return ps;
+    }
+    float get_parameter(uint32_t) const override { return 0.0f; }
+    void set_parameter(uint32_t, float) override {}
+    void set_bypass(bool) override {}
+    bool is_bypassed() const override { return false; }
+    std::vector<uint8_t> save_state() const override { return {}; }
+    bool restore_state(const std::vector<uint8_t>&) override { return true; }
+    int latency_samples() const override { return 0; }
+    int tail_samples() const override { return 0; }
+    bool has_editor() const override { return false; }
+    void* create_editor_view() override { return nullptr; }
+    void destroy_editor_view() override {}
+
+private:
+    int num_params_;
+    PluginInfo info_;
+};
+
 } // namespace
 
 TEST_CASE("Translated routing matches SignalGraph: input -> plugin -> output",
@@ -1305,4 +1429,227 @@ TEST_CASE("SignalGraph::process MIDI executor path does not allocate on the audi
     pulp::midi::MidiBuffer drained;
     drained.reserve(64, 8, 256);
     static_cast<void>(g.extract_midi(mo, drained));
+}
+
+TEST_CASE("SignalGraph::process automation matches legacy: single sparse edge",
+          "[host][graph][executor][routing][parity][automation]") {
+    // in:0 drives the plugin's gain parameter (range [0,2]); the plugin applies
+    // it to the audio. The routed automation gather must build the same two
+    // control points the legacy walk does, so the audio output matches.
+    auto build = [](SignalGraph& g, bool route) {
+        const auto in = g.add_input_node(2, "In");
+        const auto p = g.add_plugin_node(std::make_unique<AutomatedGainPlugin>(2), 2, 2, "P");
+        const auto out = g.add_output_node(2, "Out");
+        for (int c = 0; c < 2; ++c) {
+            REQUIRE(g.connect(in, c, p, c));
+            REQUIRE(g.connect(p, c, out, c));
+        }
+        REQUIRE(g.connect_automation(in, 0, p, 1, 0.0f, 2.0f, 0.0f,
+                                     pulp::host::AutomationMix::Replace));
+        g.set_canonical_executor_routing_enabled(route);
+        REQUIRE(g.prepare(kSr, kFrames));
+    };
+    SignalGraph legacy, routed;
+    build(legacy, false);
+    build(routed, true);
+    REQUIRE(signal_graph_executor_eligible(routed));
+    for (int blk = 0; blk < 4; ++blk) {
+        const std::vector<std::vector<float>> input{
+            ramp(kFrames, 0.6f + 0.05f * static_cast<float>(blk)),
+            ramp(kFrames, 0.4f + 0.03f * static_cast<float>(blk))};
+        INFO("block " << blk);
+        expect_equal(run_legacy(legacy, kFrames, input, 2),
+                     run_legacy(routed, kFrames, input, 2));
+    }
+}
+
+TEST_CASE("SignalGraph::process automation matches legacy: per-source slew across blocks",
+          "[host][graph][executor][routing][parity][automation]") {
+    // A non-zero smoothing time engages the per-source slew, whose state persists
+    // across blocks. Drive several blocks with changing source values and require
+    // block-for-block parity so the slew state is exercised.
+    auto build = [](SignalGraph& g, bool route) {
+        const auto in = g.add_input_node(2, "In");
+        const auto p = g.add_plugin_node(std::make_unique<AutomatedGainPlugin>(2), 2, 2, "P");
+        const auto out = g.add_output_node(2, "Out");
+        for (int c = 0; c < 2; ++c) {
+            REQUIRE(g.connect(in, c, p, c));
+            REQUIRE(g.connect(p, c, out, c));
+        }
+        REQUIRE(g.connect_automation(in, 0, p, 1, 0.0f, 2.0f, /*smoothing_ms=*/5.0f,
+                                     pulp::host::AutomationMix::Replace));
+        g.set_canonical_executor_routing_enabled(route);
+        REQUIRE(g.prepare(kSr, kFrames));
+    };
+    SignalGraph legacy, routed;
+    build(legacy, false);
+    build(routed, true);
+    REQUIRE(signal_graph_executor_eligible(routed));
+    for (int blk = 0; blk < 8; ++blk) {
+        // Alternate the source level hard so the slew must ramp, not snap.
+        const float lvl = (blk % 2 == 0) ? 0.1f : 0.9f;
+        std::vector<float> a(static_cast<std::size_t>(kFrames), lvl);
+        std::vector<float> b = ramp(kFrames, 0.5f);
+        const std::vector<std::vector<float>> input{a, b};
+        INFO("block " << blk);
+        expect_equal(run_legacy(legacy, kFrames, input, 2),
+                     run_legacy(routed, kFrames, input, 2));
+    }
+}
+
+TEST_CASE("SignalGraph::process automation matches legacy: two-source Add mix",
+          "[host][graph][executor][routing][parity][automation]") {
+    // Two automation sources (in:0, in:1) sum into the same parameter with Add
+    // mix; the accumulate order + bounds clamp must match the legacy walk.
+    auto build = [](SignalGraph& g, bool route) {
+        const auto in = g.add_input_node(2, "In");
+        const auto p = g.add_plugin_node(std::make_unique<AutomatedGainPlugin>(2), 2, 2, "P");
+        const auto out = g.add_output_node(2, "Out");
+        for (int c = 0; c < 2; ++c) {
+            REQUIRE(g.connect(in, c, p, c));
+            REQUIRE(g.connect(p, c, out, c));
+        }
+        REQUIRE(g.connect_automation(in, 0, p, 1, 0.0f, 1.5f, 0.0f,
+                                     pulp::host::AutomationMix::Add));
+        REQUIRE(g.connect_automation(in, 1, p, 1, 0.0f, 1.5f, 0.0f,
+                                     pulp::host::AutomationMix::Add));
+        g.set_canonical_executor_routing_enabled(route);
+        REQUIRE(g.prepare(kSr, kFrames));
+    };
+    SignalGraph legacy, routed;
+    build(legacy, false);
+    build(routed, true);
+    REQUIRE(signal_graph_executor_eligible(routed));
+    for (int blk = 0; blk < 4; ++blk) {
+        const std::vector<std::vector<float>> input{
+            ramp(kFrames, 0.7f + 0.04f * static_cast<float>(blk)),
+            ramp(kFrames, 0.8f - 0.05f * static_cast<float>(blk))};
+        INFO("block " << blk);
+        expect_equal(run_legacy(legacy, kFrames, input, 2),
+                     run_legacy(routed, kFrames, input, 2));
+    }
+}
+
+TEST_CASE("SignalGraph::process opt-in falls back to legacy for dense audio-rate automation",
+          "[host][graph][executor][routing][automation]") {
+    // Dense audio-rate modulation is not yet routed; an eligible-looking graph
+    // with an audio-rate edge must stay ineligible and fall back to the walk.
+    SignalGraph g;
+    const auto in = g.add_input_node(2, "In");
+    const auto p = g.add_plugin_node(std::make_unique<AutomatedGainPlugin>(2), 2, 2, "P");
+    const auto out = g.add_output_node(2, "Out");
+    for (int c = 0; c < 2; ++c) {
+        REQUIRE(g.connect(in, c, p, c));
+        REQUIRE(g.connect(p, c, out, c));
+    }
+    REQUIRE(g.connect_audio_rate_modulation(in, 0, p, 2, 0.0f, 2.0f, 0.0f,
+                                            pulp::host::AutomationMix::Replace));
+    REQUIRE(g.prepare(kSr, kFrames));
+    CHECK_FALSE(signal_graph_executor_eligible(g));
+}
+
+TEST_CASE("SignalGraph::process automation executor path does not allocate on the audio thread",
+          "[host][graph][executor][routing][rt-safety][automation]") {
+    SignalGraph g;
+    const auto in = g.add_input_node(2, "In");
+    const auto p = g.add_plugin_node(std::make_unique<AutomatedGainPlugin>(2), 2, 2, "P");
+    const auto out = g.add_output_node(2, "Out");
+    for (int c = 0; c < 2; ++c) {
+        REQUIRE(g.connect(in, c, p, c));
+        REQUIRE(g.connect(p, c, out, c));
+    }
+    REQUIRE(g.connect_automation(in, 0, p, 1, 0.0f, 2.0f, /*smoothing_ms=*/5.0f,
+                                 pulp::host::AutomationMix::Replace));
+    g.set_canonical_executor_routing_enabled(true);
+    REQUIRE(g.prepare(kSr, kFrames));
+    REQUIRE(signal_graph_executor_eligible(g));
+
+    const auto l = ramp(kFrames, 0.8f), r = ramp(kFrames, 0.6f);
+    std::vector<float> li = l, ri = r;
+    std::vector<float> lo(kFrames, 0.0f), ro(kFrames, 0.0f);
+    std::array<const float*, 2> ic{li.data(), ri.data()};
+    std::array<float*, 2> oc{lo.data(), ro.data()};
+    pulp::audio::BufferView<const float> iv(ic.data(), 2, kFrames);
+    pulp::audio::BufferView<float> ov(oc.data(), 2, kFrames);
+
+    g.process(ov, iv, kFrames);  // warm-up outside the probe
+    {
+        pulp::test::RtAllocationProbe probe;
+        g.process(ov, iv, kFrames);
+        REQUIRE_FALSE(probe.saw_allocation());
+    }
+}
+
+TEST_CASE("SignalGraph::process opt-in falls back to legacy past the per-node automation cap",
+          "[host][graph][executor][routing][automation]") {
+    // A node automating more distinct parameters than the gather's on-stack
+    // accumulator holds must stay ineligible (kept on the legacy walk) rather
+    // than route and silently drop the overflow.
+    constexpr int kOverCap =
+        static_cast<int>(pulp::format::GraphRuntimeAutomationScratch::kMaxParamsPerNode) + 1;
+    SignalGraph g;
+    const auto in = g.add_input_node(2, "In");
+    const auto p = g.add_plugin_node(std::make_unique<ManyParamPlugin>(kOverCap, 2), 2, 2, "P");
+    const auto out = g.add_output_node(2, "Out");
+    for (int c = 0; c < 2; ++c) {
+        REQUIRE(g.connect(in, c, p, c));
+        REQUIRE(g.connect(p, c, out, c));
+    }
+    for (int i = 0; i < kOverCap; ++i) {
+        REQUIRE(g.connect_automation(in, 0, p, static_cast<uint32_t>(i + 1), 0.0f, 1.0f, 0.0f,
+                                     pulp::host::AutomationMix::Add));
+    }
+    REQUIRE(g.prepare(kSr, kFrames));
+    CHECK_FALSE(signal_graph_executor_eligible(g));
+
+    // Exactly at the cap is still eligible.
+    SignalGraph at_cap;
+    const auto in2 = at_cap.add_input_node(2, "In");
+    const auto p2 = at_cap.add_plugin_node(
+        std::make_unique<ManyParamPlugin>(kOverCap - 1, 2), 2, 2, "P");
+    const auto out2 = at_cap.add_output_node(2, "Out");
+    for (int c = 0; c < 2; ++c) {
+        REQUIRE(at_cap.connect(in2, c, p2, c));
+        REQUIRE(at_cap.connect(p2, c, out2, c));
+    }
+    for (int i = 0; i < kOverCap - 1; ++i) {
+        REQUIRE(at_cap.connect_automation(in2, 0, p2, static_cast<uint32_t>(i + 1), 0.0f, 1.0f,
+                                          0.0f, pulp::host::AutomationMix::Add));
+    }
+    REQUIRE(at_cap.prepare(kSr, kFrames));
+    CHECK(signal_graph_executor_eligible(at_cap));
+}
+
+TEST_CASE("SignalGraph::process automation matches legacy: source also drives audio",
+          "[host][graph][executor][routing][parity][automation]") {
+    // A plugin's audio output both feeds a downstream plugin's audio input AND
+    // drives its gain parameter. The source's output slot must stay live for the
+    // automation gather to read it, and the routed output must match the walk.
+    auto build = [](SignalGraph& g, bool route) {
+        const auto in = g.add_input_node(2, "In");
+        const auto a = g.add_plugin_node(std::make_unique<AutomatedGainPlugin>(2), 2, 2, "A");
+        const auto b = g.add_plugin_node(std::make_unique<AutomatedGainPlugin>(2), 2, 2, "B");
+        const auto out = g.add_output_node(2, "Out");
+        for (int c = 0; c < 2; ++c) {
+            REQUIRE(g.connect(in, c, a, c));
+            REQUIRE(g.connect(a, c, b, c));   // A's audio -> B's audio
+            REQUIRE(g.connect(b, c, out, c));
+        }
+        REQUIRE(g.connect_automation(a, 0, b, 1, 0.0f, 2.0f, 0.0f,  // A:0 -> B's gain param
+                                     pulp::host::AutomationMix::Replace));
+        g.set_canonical_executor_routing_enabled(route);
+        REQUIRE(g.prepare(kSr, kFrames));
+    };
+    SignalGraph legacy, routed;
+    build(legacy, false);
+    build(routed, true);
+    REQUIRE(signal_graph_executor_eligible(routed));
+    for (int blk = 0; blk < 4; ++blk) {
+        const std::vector<std::vector<float>> input{
+            ramp(kFrames, 0.6f + 0.04f * static_cast<float>(blk)),
+            ramp(kFrames, 0.5f + 0.03f * static_cast<float>(blk))};
+        INFO("block " << blk);
+        expect_equal(run_legacy(legacy, kFrames, input, 2),
+                     run_legacy(routed, kFrames, input, 2));
+    }
 }


### PR DESCRIPTION
Sparse two-point parameter automation (`connect_automation`) now routes on the opt-in (default-OFF) canonical-executor path, bit-identical to the legacy walk. Phase 4 slice 4f-3f-2 (dense audio-rate is 4f-3f-3).

## What
- `GraphRuntimeExecutor` owns a `GraphRuntimeAutomationScratch`: a per-node `ParameterEventQueue` (heap-stable `unique_ptr` — the queue is non-copyable) plus per-connection slew state persisted across blocks. `process_routed` takes it as an optional arg; a gather pass runs before each node's binding, and the plugin binding passes the node's queue.
- `gather_node_automation` replicates the legacy sparse math exactly: read the source audio output at sample 0 and N-1, clamp/map into the parameter range, apply per-source linear slew, accumulate per parameter by mix mode (Replace / Add-then-clamp) in connection order, emit two control points per touched parameter, sort.
- Parameter bounds are resolved **off the audio thread** at translation from `plugin->parameters()` (matching `bounds_for_param`), carried on the connection spec — the realtime gather makes no plugin call.
- A node automating more than `kMaxParamsPerNode` (64) distinct parameters is kept **ineligible** (fail closed to the legacy walk) rather than routed with a silently-dropped overflow.
- Dense audio-rate modulation stays on the legacy walk (still ineligible).

## Tests (bit-exact vs SignalGraph, RT no-alloc, TSan-clean)
single sparse edge; per-source slew across blocks (cross-block state); two-source Add-mix (accumulate order + clamp); a source that also drives audio (source-slot liveness); the per-node cap fallback (over-cap ineligible / at-cap eligible); dense audio-rate fallback.

Default-OFF; legacy walk stays the fallback + oracle. Adversarially reviewed: one MUST-FIX (the 64-param cap was a silent drop) — fixed to fail-closed with a test; the slew/map/mix/bounds/ordering math was verified bit-exact field-for-field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in routing of sparse parameter automation to the canonical executor path, bit-identical to the legacy walk and with no audio-thread allocations. Dense audio‑rate modulation remains on the legacy path.

- **New Features**
  - Routes `connect_automation` edges via the executor using `GraphRuntimeAutomationScratch` (per-node `ParameterEventQueue` + per-connection slew state).
  - Builds per-node parameter events with a gather that mirrors the legacy math: sample 0/N-1, map/clamp, per-source linear slew, accumulate by mix mode, emit two points, sort.
  - Resolves parameter bounds off-RT at snapshot translation and stores them on the connection; the RT gather makes no plugin calls.
  - Adds an eligibility guard: nodes automating >64 distinct params stay on the legacy path; dense audio-rate modulation also stays on the legacy path.
  - Extends `process_routed` to accept an optional automation scratch and passes per-node queues to plugin bindings via `node_param_events`.
  - Opt-in (default OFF); legacy remains the fallback and parity oracle, with tests confirming bit-exact output and RT no-alloc.

- **Dependencies**
  - Bumped versions: `.claude-plugin` to `0.241.0`; project `CMakeLists.txt` to `0.479.0`.

<sup>Written for commit 97c0182699c35bac736f3d7234fb6facede03bf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

