### PR TITLE
feat(host): route dense audio-rate parameter modulation on the canonical executor

### DIFF
--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -142,8 +142,8 @@ predictable output, no MIDI.
   carry a LIVE slot) / MidiInput / MidiOutput, connections audio (feedforward,
   one-block feedback, or sidechain — a sidechain edge routes as plain audio into
   a higher input port of the destination plugin), MIDI (connect_midi event
-  edges), or SPARSE parameter automation (connect_automation; dense audio-rate
-  modulation still keeps the legacy walk) — can be driven
+  edges), or parameter automation — sparse (connect_automation, two control
+  points) and dense (connect_audio_rate_modulation, per-sample) — can be driven
   through the canonical `GraphRuntimeExecutor` instead of the legacy walk via
   `set_canonical_executor_routing_enabled(true)`. Output is bit-identical to the
   legacy walk (`signal_graph_executor_routing.{hpp,cpp}` translates the graph;
@@ -160,13 +160,16 @@ predictable output, no MIDI.
   `GraphRuntimeBufferPool`), so fan-in paths of differing latency time-align
   identically. MIDI edges route through per-node MIDI scratch buffers owned by
   the executor (`GraphRuntimeMidiScratch`); SignalGraph bridges its MIDI
-  mailboxes (inject_midi / extract_midi) around the routed call. Sparse parameter
+  mailboxes (inject_midi / extract_midi) around the routed call. Parameter
   automation routes through a `GraphRuntimeAutomationScratch` (per-node parameter
-  event queue + per-connection slew state): the executor samples each source at
-  the block edges, maps/slews/mixes per the connection's resolved bounds, and
-  builds the plugin's parameter events — bit-identical to the walk. A node
-  automating more than `kMaxParamsPerNode` (64) distinct parameters is kept on
-  the legacy walk. Dense audio-rate modulation still stays on the legacy walk.
+  event queue + per-connection slew state + per-node dense buffers): sparse edges
+  sample the source at the block edges, map/slew/mix per the connection's
+  resolved bounds, and emit two control points; dense audio-rate edges map every
+  sample (through the same per-connection PDC delay ring as audio), mix into a
+  per-node buffer, and emit one event per sample — both bit-identical to the walk
+  and built into the same per-node event queue. A node exceeding
+  `kMaxParamsPerNode` (64) distinct sparse OR dense params is kept on the legacy
+  walk.
 - `connect()` returns `false` on cycle — always check. `would_create_cycle`
   lets you preview without mutating.
 - `processing_order()` is recomputed each call; cache it in the audio

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.241.0",
+      "version": "0.242.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.241.0"
+  "version": "0.242.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.241.0",
+  "version": "0.242.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.479.0
+    VERSION 0.480.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/graph_runtime_executor.hpp
+++ b/core/format/include/pulp/format/graph_runtime_executor.hpp
@@ -345,19 +345,22 @@ public:
     // routed, since the gather would otherwise silently drop the overflow.
     static constexpr std::uint32_t kMaxParamsPerNode = 64;
 
-    // Off-RT: allocate `node_count` event queues and `connection_count` slew
-    // states (zero-initialized, un-primed). Returns false on allocation failure.
-    bool reset(std::uint32_t node_count, std::uint32_t connection_count);
+    // Off-RT: allocate per-node event queues + per-connection slew state, and —
+    // for each node — a max_frames accumulation buffer per distinct DENSE
+    // (audio-rate) automation parameter it receives (precomputed from the plan in
+    // first-seen connection order). Returns false on allocation failure.
+    bool reset(const graph::GraphRuntimePlan& plan, std::uint32_t max_frames);
     void clear() noexcept;
 
     std::uint32_t node_count() const noexcept { return node_count_; }
     std::uint32_t connection_count() const noexcept { return connection_count_; }
+    std::uint32_t max_frames() const noexcept { return max_frames_; }
 
     state::ParameterEventQueue* events(std::uint32_t node_index) noexcept {
         return node_index < node_count_ ? events_[node_index].get() : nullptr;
     }
-    // Persisted per-connection slew state (RT-mutable). last() is the previous
-    // block's post-slew value; primed() guards the first-block snap.
+    // Persisted per-connection slew state (RT-mutable, sparse). last() is the
+    // previous block's post-slew value; primed() guards the first-block snap.
     float& slew_last(std::uint32_t conn_index) noexcept { return slew_last_[conn_index]; }
     bool slew_primed(std::uint32_t conn_index) const noexcept {
         return slew_primed_[conn_index] != 0;
@@ -366,18 +369,42 @@ public:
         slew_primed_[conn_index] = v ? 1 : 0;
     }
 
-    bool fits(std::uint32_t node_count, std::uint32_t connection_count) const noexcept {
-        return node_count_ >= node_count && connection_count_ >= connection_count;
+    // Per-node DENSE (audio-rate) parameter accumulation buffers. A node receives
+    // `dense_param_count(n)` distinct audio-rate parameters; dense_param_id(n,i)
+    // is the i-th and dense_buffer(n,i) its max_frames accumulation region.
+    std::uint32_t dense_param_count(std::uint32_t node_index) const noexcept {
+        return node_index < node_count_ ? node_dense_count_[node_index] : 0;
+    }
+    std::uint32_t dense_param_id(std::uint32_t node_index, std::uint32_t i) const noexcept {
+        return dense_params_[node_dense_first_[node_index] + i].param_id;
+    }
+    float* dense_buffer(std::uint32_t node_index, std::uint32_t i) noexcept {
+        return dense_storage_.data() + dense_params_[node_dense_first_[node_index] + i].offset;
+    }
+
+    bool fits(std::uint32_t node_count, std::uint32_t connection_count,
+              std::uint32_t frames) const noexcept {
+        return node_count_ >= node_count && connection_count_ >= connection_count &&
+               frames <= max_frames_;
     }
 
 private:
+    struct DenseParam {
+        std::uint32_t param_id = 0;
+        std::uint32_t offset = 0;  // into dense_storage_ (floats)
+    };
     // ParameterEventQueue is large and non-copyable; hold it via unique_ptr so a
     // reallocating vector never needs to move/copy it.
     std::vector<std::unique_ptr<state::ParameterEventQueue>> events_;  // per node
     std::vector<float> slew_last_;                    // per connection
     std::vector<std::uint8_t> slew_primed_;           // per connection
+    std::vector<DenseParam> dense_params_;            // flattened per-node
+    std::vector<std::uint32_t> node_dense_first_;     // per node: index into dense_params_
+    std::vector<std::uint32_t> node_dense_count_;     // per node
+    std::vector<float> dense_storage_;                // total dense params × max_frames
     std::uint32_t node_count_ = 0;
     std::uint32_t connection_count_ = 0;
+    std::uint32_t max_frames_ = 0;
 };
 
 class GraphRuntimeExecutor {

--- a/core/format/src/graph_runtime_executor.cpp
+++ b/core/format/src/graph_runtime_executor.cpp
@@ -308,6 +308,75 @@ void gather_node_automation(const graph::GraphRuntimePlan& plan,
         if (!queue->push({accum[pi].param_id, 0, v0, 0})) break;
         if (last > 0 && !queue->push({accum[pi].param_id, last, vN, 0})) break;
     }
+
+    // Dense (audio-rate) modulation: per-sample map (with the same per-connection
+    // PDC delay ring as audio) accumulated per parameter, emitting one event per
+    // sample. Pushed after the sparse control points into the SAME queue (a final
+    // stable sort orders them by sample offset), matching the host walk's
+    // audio-rate path.
+    const std::uint32_t dense_count = automation.dense_param_count(node_index);
+    std::array<bool, kMaxAutomatedParamsPerNode> dense_replace{};
+    std::array<bool, kMaxAutomatedParamsPerNode> dense_add{};
+    std::array<float, kMaxAutomatedParamsPerNode> dense_lo{};
+    std::array<float, kMaxAutomatedParamsPerNode> dense_hi{};
+    for (std::uint32_t i = 0; i < dense_count; ++i) {
+        std::fill_n(automation.dense_buffer(node_index, i), frames, 0.0f);
+    }
+    for (std::uint32_t c = 0; c < node.inbound_connection_count; ++c) {
+        const auto conn_index =
+            plan.inbound_connection_indices[node.first_inbound_connection + c];
+        const auto& conn = plan.connections[conn_index];
+        if (!conn.is_automation || !conn.automation.audio_rate) continue;
+        std::uint32_t pi = 0;
+        for (; pi < dense_count; ++pi) {
+            if (automation.dense_param_id(node_index, pi) == conn.automation.param_id) break;
+        }
+        if (pi == dense_count) continue;
+        const auto& src_slots = assignment.nodes[conn.source_index];
+        const float* src = pool.slot_data(src_slots.output_base + conn.source_port);
+        if (src == nullptr) continue;
+        const auto& a = conn.automation;
+        dense_lo[pi] = a.bounds_lo;
+        dense_hi[pi] = a.bounds_hi;
+        float* dst = automation.dense_buffer(node_index, pi);
+        const auto ring = pool.delay_ring(conn_index);
+        if (ring.data == nullptr || ring.delay == 0) {
+            for (std::uint32_t f = 0; f < frames; ++f) {
+                const float v = a.range_lo +
+                    std::clamp(src[f], 0.0f, 1.0f) * (a.range_hi - a.range_lo);
+                if (a.mix_add) { dst[f] += v; dense_add[pi] = true; }
+                else { dst[f] = v; dense_replace[pi] = true; }
+            }
+        } else {
+            const int ring_size = static_cast<int>(ring.size);
+            const int delay = static_cast<int>(ring.delay);
+            int wp = *ring.write_pos;
+            int rp = wp - delay;
+            if (rp < 0) rp += ring_size;
+            for (std::uint32_t f = 0; f < frames; ++f) {
+                ring.data[wp] = src[f];
+                const float v = a.range_lo +
+                    std::clamp(ring.data[rp], 0.0f, 1.0f) * (a.range_hi - a.range_lo);
+                if (a.mix_add) { dst[f] += v; dense_add[pi] = true; }
+                else { dst[f] = v; dense_replace[pi] = true; }
+                if (++wp == ring_size) wp = 0;
+                if (++rp == ring_size) rp = 0;
+            }
+            *ring.write_pos = wp;
+        }
+    }
+    for (std::uint32_t i = 0; i < dense_count; ++i) {
+        if (!dense_replace[i] && !dense_add[i]) continue;
+        const std::uint32_t pid = automation.dense_param_id(node_index, i);
+        const float* vals = automation.dense_buffer(node_index, i);
+        const float lo = std::min(dense_lo[i], dense_hi[i]);
+        const float hi = std::max(dense_lo[i], dense_hi[i]);
+        for (std::uint32_t f = 0; f < frames; ++f) {
+            float v = vals[f];
+            if (dense_add[i]) v = std::clamp(v, lo, hi);
+            if (!queue->push({pid, static_cast<std::int32_t>(f), v, 0})) break;
+        }
+    }
     queue->sort();
 }
 
@@ -407,9 +476,11 @@ void GraphRuntimeMidiScratch::clear() noexcept {
     node_count_ = 0;
 }
 
-bool GraphRuntimeAutomationScratch::reset(std::uint32_t node_count,
-                                          std::uint32_t connection_count) {
+bool GraphRuntimeAutomationScratch::reset(const graph::GraphRuntimePlan& plan,
+                                          std::uint32_t max_frames) {
     clear();
+    const std::uint32_t node_count = plan.node_count();
+    const std::uint32_t connection_count = plan.connection_count();
     try {
         events_.reserve(node_count);
         for (std::uint32_t i = 0; i < node_count; ++i) {
@@ -417,12 +488,44 @@ bool GraphRuntimeAutomationScratch::reset(std::uint32_t node_count,
         }
         slew_last_.assign(connection_count, 0.0f);
         slew_primed_.assign(connection_count, 0);
+
+        // Per-node dense (audio-rate) parameter layout: each node's distinct
+        // audio-rate param ids in first-seen inbound-connection order, each given
+        // a max_frames accumulation region (matching the host walk's per-node
+        // audio_rate_param_data).
+        node_dense_first_.assign(node_count, 0);
+        node_dense_count_.assign(node_count, 0);
+        std::uint32_t total_dense = 0;
+        for (std::uint32_t n = 0; n < node_count; ++n) {
+            const auto& node = plan.nodes[n];
+            node_dense_first_[n] = static_cast<std::uint32_t>(dense_params_.size());
+            for (std::uint32_t c = 0; c < node.inbound_connection_count; ++c) {
+                const auto ci =
+                    plan.inbound_connection_indices[node.first_inbound_connection + c];
+                const auto& conn = plan.connections[ci];
+                if (!conn.is_automation || !conn.automation.audio_rate) continue;
+                bool seen = false;
+                for (std::uint32_t k = 0; k < node_dense_count_[n]; ++k) {
+                    if (dense_params_[node_dense_first_[n] + k].param_id ==
+                        conn.automation.param_id) {
+                        seen = true;
+                        break;
+                    }
+                }
+                if (seen) continue;
+                dense_params_.push_back({conn.automation.param_id, total_dense * max_frames});
+                ++node_dense_count_[n];
+                ++total_dense;
+            }
+        }
+        dense_storage_.assign(static_cast<std::size_t>(total_dense) * max_frames, 0.0f);
     } catch (...) {
         clear();
         return false;
     }
     node_count_ = node_count;
     connection_count_ = connection_count;
+    max_frames_ = max_frames;
     return true;
 }
 
@@ -430,8 +533,13 @@ void GraphRuntimeAutomationScratch::clear() noexcept {
     events_.clear();
     slew_last_.clear();
     slew_primed_.clear();
+    dense_params_.clear();
+    node_dense_first_.clear();
+    node_dense_count_.clear();
+    dense_storage_.clear();
     node_count_ = 0;
     connection_count_ = 0;
+    max_frames_ = 0;
 }
 
 bool GraphRuntimeBufferPool::reset(std::uint32_t slot_count, std::uint32_t max_frames) {
@@ -669,7 +777,7 @@ GraphRuntimeExecutorResult GraphRuntimeExecutor::process_routed(
     // An automation scratch, when supplied, must cover every node + connection so
     // the gather can index any node's queue and any connection's slew state.
     if (automation != nullptr &&
-        !automation->fits(plan.node_count(), plan.connection_count())) {
+        !automation->fits(plan.node_count(), plan.connection_count(), frames)) {
         GraphRuntimeExecutorResult fail;
         fail.error = GraphRuntimeExecutorErrorCode::BufferPoolTooSmall;
         return fail;

--- a/core/graph/src/graph_runtime_buffer_assignment.cpp
+++ b/core/graph/src/graph_runtime_buffer_assignment.cpp
@@ -178,10 +178,16 @@ GraphRuntimeBufferAssignment build_graph_runtime_buffer_assignment(
                 const auto ci = plan.inbound_connection_indices[
                     node.first_inbound_connection + c];
                 const auto& conn = plan.connections[ci];
-                // Feedback, event (MIDI), and sparse-automation edges do not
-                // carry latency-aligned audio into an input port, so they don't
-                // contribute to a node's input latency (matching the host walk).
-                if (conn.feedback || conn.event || conn.is_automation) continue;
+                // Feedback, event (MIDI), and SPARSE-automation edges carry no
+                // latency-aligned audio, so they don't contribute to a node's
+                // input latency. DENSE audio-rate modulation edges DO participate
+                // in latency + per-connection delay (their source is sampled per
+                // block-position and time-aligned like audio) — matching the host
+                // walk, which only skips feedback/midi/sparse-automation.
+                if (conn.feedback || conn.event ||
+                    (conn.is_automation && !conn.automation.audio_rate)) {
+                    continue;
+                }
                 max_upstream = std::max(max_upstream, output_latency[conn.source_index]);
             }
             input_latency[node_index] = max_upstream;
@@ -189,7 +195,10 @@ GraphRuntimeBufferAssignment build_graph_runtime_buffer_assignment(
         }
         for (std::size_t i = 0; i < plan.connections.size(); ++i) {
             const auto& conn = plan.connections[i];
-            if (conn.feedback || conn.event || conn.is_automation) continue;
+            if (conn.feedback || conn.event ||
+                (conn.is_automation && !conn.automation.audio_rate)) {
+                continue;
+            }
             const std::uint32_t dst_in = input_latency[conn.dest_index];
             const std::uint32_t src_out = output_latency[conn.source_index];
             const std::uint32_t want = dst_in > src_out ? dst_in - src_out : 0;

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -1207,9 +1207,9 @@ SignalGraph::compile_(double sample_rate, int max_block_size) {
             for (const auto& conn : plan.connections) {
                 if (conn.is_automation) { plan_has_automation = true; break; }
             }
-            if (cg->routing_valid && plan_has_automation) {
+            if (cg->routing_valid && plan_has_automation && max_block_size > 0) {
                 cg->routing_valid = cg->routing_automation.reset(
-                    plan.node_count(), plan.connection_count());
+                    plan, static_cast<std::uint32_t>(max_block_size));
             }
         }
     }

--- a/core/host/src/signal_graph_executor_routing.cpp
+++ b/core/host/src/signal_graph_executor_routing.cpp
@@ -148,16 +148,12 @@ bool node_eligible(const GraphNode& node) noexcept {
     }
 }
 
-bool connection_eligible(const Connection& c) noexcept {
-    // Audio, MIDI, and SPARSE parameter-automation edges. Feedback is fine (the
-    // executor handles one-block feedback). Sidechain is fine: SignalGraph routes
-    // a sidechain edge as a plain audio edge into a higher input port of the
-    // destination plugin and it participates in PDC like any audio edge. MIDI
-    // edges are carried as event connections. Sparse automation (`automation` &&
-    // !`audio_rate_modulation`) is carried as an automation connection and built
-    // into the plugin's parameter-event queue by the executor's automation
-    // gather. Dense audio-rate modulation still keeps the legacy walk.
-    return !c.audio_rate_modulation;
+bool connection_eligible(const Connection& /*c*/) noexcept {
+    // Every connection kind is now routed: plain audio (feedforward, feedback,
+    // sidechain) with PDC; MIDI event edges; sparse parameter automation
+    // (two-point) and dense audio-rate modulation (per-sample) — both built into
+    // the plugin's parameter-event queue by the executor's automation gather.
+    return true;
 }
 
 } // namespace
@@ -171,26 +167,34 @@ bool signal_graph_topology_executor_eligible(std::span<const GraphNode> nodes,
         if (!connection_eligible(c)) return false;
     }
     // The executor's automation gather accumulates distinct automated parameters
-    // per node in a fixed on-stack array (kMaxParamsPerNode); a node automating
-    // more than that would silently drop the overflow. Keep such a graph on the
-    // legacy walk (fail closed) rather than route it and diverge.
-    std::vector<std::pair<NodeId, std::vector<std::uint32_t>>> per_dest;
-    for (const auto& c : connections) {
-        if (!c.automation || c.audio_rate_modulation) continue;  // sparse only
-        auto it = std::find_if(per_dest.begin(), per_dest.end(),
-                               [&](const auto& e) { return e.first == c.dest_node; });
-        if (it == per_dest.end()) {
-            per_dest.push_back({c.dest_node, {c.automation_param_id}});
-            continue;
-        }
-        auto& ids = it->second;
-        if (std::find(ids.begin(), ids.end(), c.automation_param_id) == ids.end()) {
-            ids.push_back(c.automation_param_id);
-            if (ids.size() > fmt::GraphRuntimeAutomationScratch::kMaxParamsPerNode) {
-                return false;
+    // per node in fixed on-stack arrays (kMaxParamsPerNode) — one for sparse
+    // two-point automation, one for dense audio-rate. A node automating more than
+    // that on EITHER axis would silently drop the overflow, so keep such a graph
+    // on the legacy walk (fail closed). Count sparse and dense distinct params
+    // per node separately.
+    const auto over_cap = [&](bool dense) {
+        std::vector<std::pair<NodeId, std::vector<std::uint32_t>>> per_dest;
+        for (const auto& c : connections) {
+            const bool is_dense = c.audio_rate_modulation;
+            const bool is_sparse = c.automation && !c.audio_rate_modulation;
+            if (dense ? !is_dense : !is_sparse) continue;
+            auto it = std::find_if(per_dest.begin(), per_dest.end(),
+                                   [&](const auto& e) { return e.first == c.dest_node; });
+            if (it == per_dest.end()) {
+                per_dest.push_back({c.dest_node, {c.automation_param_id}});
+                continue;
+            }
+            auto& ids = it->second;
+            if (std::find(ids.begin(), ids.end(), c.automation_param_id) == ids.end()) {
+                ids.push_back(c.automation_param_id);
+                if (ids.size() > fmt::GraphRuntimeAutomationScratch::kMaxParamsPerNode) {
+                    return true;
+                }
             }
         }
-    }
+        return false;
+    };
+    if (over_cap(/*dense=*/false) || over_cap(/*dense=*/true)) return false;
     return true;
 }
 
@@ -278,19 +282,19 @@ bool build_executor_snapshot(std::span<const GraphNode> nodes,
             c.source_node, c.source_port, c.dest_node, c.dest_port,
             c.feedback, /*event=*/c.midi,
         };
-        // A sparse parameter-automation edge becomes an automation connection
+        // A parameter-automation edge — sparse two-point (`automation`) or dense
+        // audio-rate (`audio_rate_modulation`) — becomes an automation connection
         // carrying its mapping. Resolve the destination plugin's parameter bounds
         // OFF the audio thread (so the realtime gather's Add-mix clamp matches the
-        // legacy walk's bounds_for_param without a plugin call). Dense audio-rate
-        // edges stay on the legacy walk (connection_eligible rejects them).
-        if (c.automation && !c.audio_rate_modulation) {
+        // legacy walk's bounds_for_param without a plugin call).
+        if (c.automation || c.audio_rate_modulation) {
             spec.is_automation = true;
             spec.automation.param_id = c.automation_param_id;
             spec.automation.range_lo = c.automation_range_lo;
             spec.automation.range_hi = c.automation_range_hi;
             spec.automation.smoothing_ms = c.automation_smoothing_ms;
             spec.automation.mix_add = c.automation_mix == AutomationMix::Add;
-            spec.automation.audio_rate = false;
+            spec.automation.audio_rate = c.audio_rate_modulation;
             // Default bounds to the mapped range, then refine to the plugin's
             // declared parameter bounds if resolvable (matching bounds_for_param).
             spec.automation.bounds_lo = c.automation_range_lo;

--- a/test/test_signal_graph_executor_parity.cpp
+++ b/test/test_signal_graph_executor_parity.cpp
@@ -699,12 +699,20 @@ public:
                  const pulp::host::ParameterEventQueue& params,
                  int n) override {
         const int last = n - 1;
+        // Param 1 (sparse / control-rate): linear gain ramp v0 -> vN.
         float v0 = 1.0f;
         float vN = 1.0f;
+        // Param 2 (dense / audio-rate): per-sample gain, default 1 where unset.
+        std::array<float, 4096> g2;
+        for (int s = 0; s < n && s < 4096; ++s) g2[static_cast<std::size_t>(s)] = 1.0f;
         for (const auto& ev : params) {
-            if (ev.param_id != 1) continue;
-            if (ev.sample_offset == 0) v0 = ev.value;
-            if (ev.sample_offset == last) vN = ev.value;
+            if (ev.param_id == 1) {
+                if (ev.sample_offset == 0) v0 = ev.value;
+                if (ev.sample_offset == last) vN = ev.value;
+            } else if (ev.param_id == 2 && ev.sample_offset >= 0 &&
+                       ev.sample_offset < n && ev.sample_offset < 4096) {
+                g2[static_cast<std::size_t>(ev.sample_offset)] = ev.value;
+            }
         }
         const std::size_t chs = out.num_channels();
         for (std::size_t c = 0; c < chs; ++c) {
@@ -712,7 +720,7 @@ public:
             const float* i = c < in.num_channels() ? in.channel_ptr(c) : nullptr;
             for (int s = 0; s < n; ++s) {
                 const float t = last > 0 ? static_cast<float>(s) / static_cast<float>(last) : 0.0f;
-                const float gain = v0 + (vN - v0) * t;
+                const float gain = (v0 + (vN - v0) * t) * g2[static_cast<std::size_t>(s)];
                 o[static_cast<std::size_t>(s)] =
                     (i ? i[static_cast<std::size_t>(s)] : 0.0f) * gain;
             }
@@ -781,6 +789,8 @@ public:
             p.min_value = 0.0f;
             p.max_value = 1.0f;
             p.flags.automatable = true;
+            p.flags.modulatable = true;
+            p.rate = pulp::state::ParamRate::AudioRate;  // also dense-modulatable
             ps.push_back(p);
         }
         return ps;
@@ -1530,22 +1540,75 @@ TEST_CASE("SignalGraph::process automation matches legacy: two-source Add mix",
     }
 }
 
-TEST_CASE("SignalGraph::process opt-in falls back to legacy for dense audio-rate automation",
-          "[host][graph][executor][routing][automation]") {
-    // Dense audio-rate modulation is not yet routed; an eligible-looking graph
-    // with an audio-rate edge must stay ineligible and fall back to the walk.
-    SignalGraph g;
-    const auto in = g.add_input_node(2, "In");
-    const auto p = g.add_plugin_node(std::make_unique<AutomatedGainPlugin>(2), 2, 2, "P");
-    const auto out = g.add_output_node(2, "Out");
-    for (int c = 0; c < 2; ++c) {
-        REQUIRE(g.connect(in, c, p, c));
-        REQUIRE(g.connect(p, c, out, c));
+TEST_CASE("SignalGraph::process automation matches legacy: dense audio-rate modulation",
+          "[host][graph][executor][routing][parity][automation]") {
+    // in:0 drives the plugin's audio-rate parameter (id 2) per sample; the plugin
+    // applies it sample-by-sample. The routed dense gather must build the same
+    // per-sample parameter events the legacy walk does.
+    auto build = [](SignalGraph& g, bool route) {
+        const auto in = g.add_input_node(2, "In");
+        const auto p = g.add_plugin_node(std::make_unique<AutomatedGainPlugin>(2), 2, 2, "P");
+        const auto out = g.add_output_node(2, "Out");
+        for (int c = 0; c < 2; ++c) {
+            REQUIRE(g.connect(in, c, p, c));
+            REQUIRE(g.connect(p, c, out, c));
+        }
+        REQUIRE(g.connect_audio_rate_modulation(in, 0, p, 2, 0.0f, 2.0f, 0.0f,
+                                                pulp::host::AutomationMix::Replace));
+        g.set_canonical_executor_routing_enabled(route);
+        REQUIRE(g.prepare(kSr, kFrames));
+    };
+    SignalGraph legacy, routed;
+    build(legacy, false);
+    build(routed, true);
+    REQUIRE(signal_graph_executor_eligible(routed));
+    for (int blk = 0; blk < 4; ++blk) {
+        const std::vector<std::vector<float>> input{
+            ramp(kFrames, 0.6f + 0.05f * static_cast<float>(blk)),
+            ramp(kFrames, 0.4f + 0.03f * static_cast<float>(blk))};
+        INFO("block " << blk);
+        expect_equal(run_legacy(legacy, kFrames, input, 2),
+                     run_legacy(routed, kFrames, input, 2));
     }
-    REQUIRE(g.connect_audio_rate_modulation(in, 0, p, 2, 0.0f, 2.0f, 0.0f,
-                                            pulp::host::AutomationMix::Replace));
-    REQUIRE(g.prepare(kSr, kFrames));
-    CHECK_FALSE(signal_graph_executor_eligible(g));
+}
+
+TEST_CASE("SignalGraph::process automation matches legacy: dense audio-rate with PDC delay",
+          "[host][graph][executor][routing][parity][automation][pdc]") {
+    // The dense modulation source runs through a latency-64 plugin, so the
+    // audio-rate edge into the mixing plugin is PDC-delayed by 64. Drive several
+    // blocks (the delay ring carries state) and require block-for-block parity.
+    auto build = [](SignalGraph& g, bool route) {
+        const auto in = g.add_input_node(2, "In");
+        const auto latP = g.add_plugin_node(
+            std::make_unique<DeterministicPlugin>(
+                DeterministicPlugin::Mode::kFull, 1.0f, 2, 2, /*latency=*/64),
+            2, 2, "LatP");
+        const auto p = g.add_plugin_node(std::make_unique<AutomatedGainPlugin>(2), 2, 2, "P");
+        const auto out = g.add_output_node(2, "Out");
+        for (int c = 0; c < 2; ++c) {
+            REQUIRE(g.connect(in, c, latP, c));
+            REQUIRE(g.connect(latP, c, p, c));  // main audio (latency 64)
+            REQUIRE(g.connect(p, c, out, c));
+        }
+        // Dense modulation from the plain (0-latency) input -> p's audio-rate
+        // param; p.input_latency=64, so this edge is delay-compensated by 64.
+        REQUIRE(g.connect_audio_rate_modulation(in, 0, p, 2, 0.0f, 2.0f, 0.0f,
+                                                pulp::host::AutomationMix::Replace));
+        g.set_canonical_executor_routing_enabled(route);
+        REQUIRE(g.prepare(kSr, kFrames));
+    };
+    SignalGraph legacy, routed;
+    build(legacy, false);
+    build(routed, true);
+    REQUIRE(signal_graph_executor_eligible(routed));
+    for (int blk = 0; blk < 8; ++blk) {
+        const std::vector<std::vector<float>> input{
+            ramp(kFrames, 0.7f + 0.02f * static_cast<float>(blk)),
+            ramp(kFrames, 0.5f + 0.02f * static_cast<float>(blk))};
+        INFO("block " << blk);
+        expect_equal(run_legacy(legacy, kFrames, input, 2),
+                     run_legacy(routed, kFrames, input, 2));
+    }
 }
 
 TEST_CASE("SignalGraph::process automation executor path does not allocate on the audio thread",
@@ -1560,6 +1623,9 @@ TEST_CASE("SignalGraph::process automation executor path does not allocate on th
     }
     REQUIRE(g.connect_automation(in, 0, p, 1, 0.0f, 2.0f, /*smoothing_ms=*/5.0f,
                                  pulp::host::AutomationMix::Replace));
+    // Also a dense audio-rate edge so the probe covers the per-sample gather.
+    REQUIRE(g.connect_audio_rate_modulation(in, 1, p, 2, 0.0f, 2.0f, 0.0f,
+                                            pulp::host::AutomationMix::Replace));
     g.set_canonical_executor_routing_enabled(true);
     REQUIRE(g.prepare(kSr, kFrames));
     REQUIRE(signal_graph_executor_eligible(g));
@@ -1648,6 +1714,67 @@ TEST_CASE("SignalGraph::process automation matches legacy: source also drives au
         const std::vector<std::vector<float>> input{
             ramp(kFrames, 0.6f + 0.04f * static_cast<float>(blk)),
             ramp(kFrames, 0.5f + 0.03f * static_cast<float>(blk))};
+        INFO("block " << blk);
+        expect_equal(run_legacy(legacy, kFrames, input, 2),
+                     run_legacy(routed, kFrames, input, 2));
+    }
+}
+
+TEST_CASE("SignalGraph::process opt-in falls back to legacy past the per-node dense automation cap",
+          "[host][graph][executor][routing][automation]") {
+    // The dense gather's per-param accumulators are also a fixed on-stack array;
+    // a node receiving more distinct audio-rate params than the cap must stay on
+    // the legacy walk.
+    constexpr int kOverCap =
+        static_cast<int>(pulp::format::GraphRuntimeAutomationScratch::kMaxParamsPerNode) + 1;
+    SignalGraph g;
+    const auto in = g.add_input_node(2, "In");
+    const auto p = g.add_plugin_node(std::make_unique<ManyParamPlugin>(kOverCap, 2), 2, 2, "P");
+    const auto out = g.add_output_node(2, "Out");
+    for (int c = 0; c < 2; ++c) {
+        REQUIRE(g.connect(in, c, p, c));
+        REQUIRE(g.connect(p, c, out, c));
+    }
+    for (int i = 0; i < kOverCap; ++i) {
+        REQUIRE(g.connect_audio_rate_modulation(in, 0, p, static_cast<uint32_t>(i + 1),
+                                                0.0f, 1.0f, 0.0f,
+                                                pulp::host::AutomationMix::Add));
+    }
+    // Prepare with a tiny block so the per-sample events (kOverCap * block) fit
+    // the parameter-event-queue capacity (1024) — otherwise prepare rejects the
+    // graph before eligibility is queried. With a prepared graph, the per-node
+    // dense param cap is the gate that keeps it on the legacy walk.
+    REQUIRE(g.prepare(kSr, /*max_block=*/8));
+    CHECK_FALSE(signal_graph_executor_eligible(g));
+}
+
+TEST_CASE("SignalGraph::process automation matches legacy: dense Replace + Add on one param",
+          "[host][graph][executor][routing][parity][automation]") {
+    // Two dense edges into the same audio-rate parameter — one Replace, one Add —
+    // so the per-sample accumulate order + bounds clamp must match the walk.
+    auto build = [](SignalGraph& g, bool route) {
+        const auto in = g.add_input_node(2, "In");
+        const auto p = g.add_plugin_node(std::make_unique<AutomatedGainPlugin>(2), 2, 2, "P");
+        const auto out = g.add_output_node(2, "Out");
+        for (int c = 0; c < 2; ++c) {
+            REQUIRE(g.connect(in, c, p, c));
+            REQUIRE(g.connect(p, c, out, c));
+        }
+        REQUIRE(g.connect_audio_rate_modulation(in, 0, p, 2, 0.0f, 1.2f, 0.0f,
+                                                pulp::host::AutomationMix::Replace));
+        REQUIRE(g.connect_audio_rate_modulation(in, 1, p, 2, 0.0f, 1.2f, 0.0f,
+                                                pulp::host::AutomationMix::Add));
+        g.set_canonical_executor_routing_enabled(route);
+        REQUIRE(g.prepare(kSr, kFrames));
+    };
+    SignalGraph legacy, routed;
+    build(legacy, false);
+    build(routed, true);
+    REQUIRE(signal_graph_executor_eligible(routed));
+    for (int blk = 0; blk < 4; ++blk) {
+        const std::vector<std::vector<float>> input{
+            ramp(kFrames, 0.7f + 0.03f * static_cast<float>(blk)),
+            ramp(kFrames, 0.6f - 0.02f * static_cast<float>(blk))};
         INFO("block " << blk);
         expect_equal(run_legacy(legacy, kFrames, input, 2),
                      run_legacy(routed, kFrames, input, 2));


### PR DESCRIPTION
Dense audio-rate modulation (`connect_audio_rate_modulation`) now routes on the opt-in (default-OFF) canonical-executor path, bit-identical to the legacy walk. With this, **every** SignalGraph connection kind routes: audio (PDC / sidechain / feedback), MIDI, and parameter automation (sparse + dense). Phase 4 slice 4f-3f-3 — completes 4f-3f.

## What
- `GraphRuntimeAutomationScratch` gains per-node dense parameter buffers, precomputed from the plan (distinct audio-rate param ids per node in first-seen connection order, each a `max_frames` region); `reset()` now takes the plan + max_frames.
- `gather_node_automation`'s dense pass maps each audio-rate source **per sample** through the **same per-connection PDC delay ring as audio** (reusing 4f-3c), accumulates per parameter by mix mode into the node's dense buffer, then emits one event per sample — pushed after the sparse control points into the same per-node `ParameterEventQueue`, with a single final stable sort. Matches the legacy audio-rate path exactly.
- The buffer assignment now keeps dense edges in latency propagation + per-connection delay (the legacy includes audio-rate in both); only sparse automation is skipped.
- `connection_eligible` admits every connection kind. The per-node param cap (fail closed to the legacy walk) now covers sparse **and** dense distinct params.

## Tests (bit-exact vs SignalGraph, RT no-alloc, TSan-clean)
dense audio-rate parity (no-PDC + PDC-delayed across blocks); dense Replace+Add on one param; dense+sparse no-alloc; dense per-node cap fallback (realizable at a tiny block where per-sample events still fit the 1024 queue capacity).

Default-OFF; legacy walk stays the fallback + oracle. Adversarially reviewed: no MUST-FIX (dense ring / latency / map / mix / ordering verified bit-exact); applied both SHOULD-FIX test additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route dense audio-rate parameter modulation through the opt-in canonical executor, matching the legacy walk bit-for-bit. All SignalGraph connection kinds now route: audio (PDC, sidechain, feedback), MIDI, and parameter automation (sparse and dense).

- New Features
  - `GraphRuntimeAutomationScratch`: adds per-node dense param buffers; `reset(plan, max_frames)`; dense buffer/query helpers.
  - `gather_node_automation`: per-sample mapping via the same PDC delay ring as audio; accumulate by mix mode; emit one event per sample; merged with sparse events and stable-sorted.
  - Buffer assignment: dense edges participate in latency propagation and per-connection delay; sparse automation is skipped.
  - Routing eligibility: accept all connection kinds; per-node param cap now covers sparse and dense distinct params; `fits(..., frames)` guard added.
  - Host compile: build automation scratch from the plan when routing is valid and `max_block_size > 0`.

- Dependencies
  - Bump `.claude-plugin` version to `0.242.0` and project version to `0.480.0`.

<sup>Written for commit bfd5e01b3b1cd597ebb2ad4d2bb16675999a8e8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

