### PR TITLE
feat(graph): off-RT plan levelization for static multicore scheduling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.480.0
+    VERSION 0.481.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/graph/CMakeLists.txt
+++ b/core/graph/CMakeLists.txt
@@ -10,6 +10,7 @@ target_include_directories(pulp-graph
 target_sources(pulp-graph PRIVATE
     src/graph_runtime_plan.cpp
     src/graph_runtime_buffer_assignment.cpp
+    src/graph_runtime_levelization.cpp
 )
 
 target_link_libraries(pulp-graph

--- a/core/graph/include/pulp/graph/graph_runtime_levelization.hpp
+++ b/core/graph/include/pulp/graph/graph_runtime_levelization.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <pulp/graph/graph_runtime_plan.hpp>
+
+#include <cstdint>
+#include <vector>
+
+namespace pulp::graph {
+
+// Off-RT levelization of a GraphRuntimePlan for static multicore scheduling.
+//
+// A node's LEVEL is the length of its longest dependency chain: 0 for a node
+// with no feedforward dependencies, otherwise one more than the maximum level of
+// any node it depends on through a non-feedback connection (audio, event, or
+// automation — every edge that requires the source to run before the dest).
+// Feedback connections are excluded (they read the previous block, like the
+// topological sort), so they never raise a level or create a cycle.
+//
+// Nodes sharing a level are mutually independent — no dependency path connects
+// them — so a parallel executor can run them concurrently, synchronizing only at
+// level boundaries. This is the static schedule masterwork §6.1 precomputes at
+// plan time; the serial executor ignores it (its processing order already
+// respects dependencies), and a future parallel executor consumes it behind the
+// canonical seam.
+struct GraphRuntimeLevelization {
+    // Per dense node index (matches GraphRuntimePlan::nodes order): the node's
+    // level.
+    std::vector<std::uint32_t> node_level;
+    // Number of distinct levels (0 for an empty plan).
+    std::uint32_t level_count = 0;
+    // CSR grouping of node indices by level: the nodes at level L are
+    // level_nodes[level_offsets[L] .. level_offsets[L + 1]). level_offsets has
+    // level_count + 1 entries; level_nodes has one entry per node.
+    std::vector<std::uint32_t> level_offsets;
+    std::vector<std::uint32_t> level_nodes;
+    bool ok = false;
+};
+
+// Compute the levelization for `plan`. Returns ok=false only on allocation
+// failure or a malformed plan (processing order not covering every node); an
+// empty plan yields ok=true with level_count=0.
+GraphRuntimeLevelization build_graph_runtime_levelization(const GraphRuntimePlan& plan);
+
+} // namespace pulp::graph

--- a/core/graph/src/graph_runtime_levelization.cpp
+++ b/core/graph/src/graph_runtime_levelization.cpp
@@ -1,0 +1,68 @@
+#include <pulp/graph/graph_runtime_levelization.hpp>
+
+#include <algorithm>
+#include <vector>
+
+namespace pulp::graph {
+
+GraphRuntimeLevelization build_graph_runtime_levelization(const GraphRuntimePlan& plan) {
+    GraphRuntimeLevelization result;
+    const std::size_t node_count = plan.nodes.size();
+
+    // A malformed plan whose processing order does not cover every node can't be
+    // levelled deterministically (a source might be visited after its consumer).
+    if (plan.processing_order_indices.size() != node_count) {
+        return result;  // ok = false
+    }
+
+    try {
+        result.node_level.assign(node_count, 0);
+
+        // Walk in topological order so every non-feedback source's level is final
+        // before any consumer reads it. level[dest] = max(level[dest],
+        // level[source] + 1) over each non-feedback inbound edge.
+        std::uint32_t max_level = 0;
+        for (const auto node_index : plan.processing_order_indices) {
+            if (node_index >= node_count) return result;  // ok = false
+            const auto& node = plan.nodes[node_index];
+            std::uint32_t level = 0;
+            for (std::uint32_t c = 0; c < node.inbound_connection_count; ++c) {
+                const auto ci =
+                    plan.inbound_connection_indices[node.first_inbound_connection + c];
+                const auto& conn = plan.connections[ci];
+                if (conn.feedback) continue;  // reads previous block; no ordering
+                level = std::max(level, result.node_level[conn.source_index] + 1);
+            }
+            result.node_level[node_index] = level;
+            max_level = std::max(max_level, level);
+        }
+
+        result.level_count = node_count == 0 ? 0 : max_level + 1;
+
+        // CSR grouping by level: counting sort over node_level.
+        result.level_offsets.assign(result.level_count + 1, 0);
+        result.level_nodes.assign(node_count, 0);
+        for (std::size_t n = 0; n < node_count; ++n) {
+            ++result.level_offsets[result.node_level[n] + 1];
+        }
+        for (std::uint32_t l = 0; l < result.level_count; ++l) {
+            result.level_offsets[l + 1] += result.level_offsets[l];
+        }
+        // Place nodes in ascending node-index order within each level (stable,
+        // deterministic) using a per-level write cursor seeded from the offsets.
+        std::vector<std::uint32_t> cursor(result.level_offsets.begin(),
+                                          result.level_offsets.end());
+        for (std::uint32_t n = 0; n < node_count; ++n) {
+            const std::uint32_t level = result.node_level[n];
+            result.level_nodes[cursor[level]++] = n;
+        }
+    } catch (...) {
+        result = {};
+        return result;  // ok = false
+    }
+
+    result.ok = true;
+    return result;
+}
+
+} // namespace pulp::graph

--- a/test/cmake/sampler_runtime_tests.cmake
+++ b/test/cmake/sampler_runtime_tests.cmake
@@ -44,6 +44,8 @@ pulp_add_test_suite(pulp-test-graph-executor-parity
     LIBRARIES pulp::host pulp::format pulp::graph)
 # Off-RT scratch-slot buffer-assignment layout + reuse.
 pulp_add_test_suite(pulp-test-graph-runtime-buffer-assignment LIBRARIES pulp::graph)
+# Off-RT levelization (parallel-schedule levels) for static multicore.
+pulp_add_test_suite(pulp-test-graph-runtime-levelization LIBRARIES pulp::graph)
 # Executor routing path moves audio between nodes (chain/diamond/feedback/
 # multi-output parity vs SignalGraph) and is allocation-free on the RT thread.
 pulp_add_test_suite(pulp-test-graph-executor-routing

--- a/test/test_graph_runtime_levelization.cpp
+++ b/test/test_graph_runtime_levelization.cpp
@@ -1,0 +1,184 @@
+// Unit coverage for the off-RT levelization pass that a future static-multicore
+// executor consumes: each node's parallel LEVEL (longest dependency chain) and a
+// CSR grouping of nodes by level. These assert the core invariants — every
+// non-feedback edge runs strictly lower->higher level, feedback edges never
+// raise a level, same-level nodes are independent, and the CSR grouping is a
+// consistent partition of all nodes.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/graph/graph_runtime_levelization.hpp>
+#include <pulp/graph/graph_runtime_plan.hpp>
+
+#include <array>
+#include <vector>
+
+namespace {
+
+using pulp::graph::GraphRuntimeConnectionSpec;
+using pulp::graph::GraphRuntimeLevelization;
+using pulp::graph::GraphRuntimeNodeKind;
+using pulp::graph::GraphRuntimeNodeSpec;
+using pulp::graph::GraphRuntimePlan;
+using pulp::graph::build_graph_runtime_levelization;
+using pulp::graph::build_graph_runtime_plan;
+
+GraphRuntimeNodeSpec node(pulp::graph::NodeId id, std::uint32_t in, std::uint32_t out,
+                          GraphRuntimeNodeKind kind = GraphRuntimeNodeKind::Processor) {
+    return {id, kind, in, out};
+}
+
+// Map a NodeId to its dense plan index.
+std::uint32_t index_of(const GraphRuntimePlan& plan, pulp::graph::NodeId id) {
+    for (std::uint32_t i = 0; i < plan.nodes.size(); ++i) {
+        if (plan.nodes[i].id == id) return i;
+    }
+    return 0xFFFFFFFFu;
+}
+
+// Assert the invariants every valid levelization must satisfy.
+void check_invariants(const GraphRuntimePlan& plan, const GraphRuntimeLevelization& lv) {
+    REQUIRE(lv.ok);
+    REQUIRE(lv.node_level.size() == plan.nodes.size());
+    // Every non-feedback connection goes strictly lower -> higher level; feedback
+    // edges are unconstrained.
+    for (const auto& c : plan.connections) {
+        if (c.feedback) continue;
+        CHECK(lv.node_level[c.source_index] < lv.node_level[c.dest_index]);
+    }
+    // CSR grouping is a partition: offsets monotonic, total == node count, and
+    // every node appears exactly once at its own level.
+    REQUIRE(lv.level_offsets.size() == lv.level_count + 1);
+    CHECK(lv.level_offsets.front() == 0);
+    CHECK(lv.level_offsets.back() == plan.nodes.size());
+    CHECK(lv.level_nodes.size() == plan.nodes.size());
+    std::vector<int> seen(plan.nodes.size(), 0);
+    for (std::uint32_t l = 0; l < lv.level_count; ++l) {
+        CHECK(lv.level_offsets[l] <= lv.level_offsets[l + 1]);
+        for (std::uint32_t k = lv.level_offsets[l]; k < lv.level_offsets[l + 1]; ++k) {
+            const std::uint32_t n = lv.level_nodes[k];
+            REQUIRE(n < plan.nodes.size());
+            CHECK(lv.node_level[n] == l);
+            ++seen[n];
+        }
+    }
+    for (const auto s : seen) CHECK(s == 1);
+}
+
+} // namespace
+
+TEST_CASE("Levelization: a linear chain assigns one node per ascending level",
+          "[graph][levelization]") {
+    // in(0->2) -> g1 -> g2 -> out
+    const std::array nodes = {
+        node(1, 0, 2, GraphRuntimeNodeKind::AudioInput),
+        node(2, 2, 2),
+        node(3, 2, 2),
+        node(4, 2, 0, GraphRuntimeNodeKind::AudioOutput),
+    };
+    const std::array conns = {
+        GraphRuntimeConnectionSpec{1, 0, 2, 0}, GraphRuntimeConnectionSpec{1, 1, 2, 1},
+        GraphRuntimeConnectionSpec{2, 0, 3, 0}, GraphRuntimeConnectionSpec{2, 1, 3, 1},
+        GraphRuntimeConnectionSpec{3, 0, 4, 0}, GraphRuntimeConnectionSpec{3, 1, 4, 1},
+    };
+    const auto plan = build_graph_runtime_plan(nodes, conns);
+    REQUIRE(plan.ok());
+    const auto lv = build_graph_runtime_levelization(plan.plan);
+    check_invariants(plan.plan, lv);
+    CHECK(lv.level_count == 4);
+    CHECK(lv.node_level[index_of(plan.plan, 1)] == 0);
+    CHECK(lv.node_level[index_of(plan.plan, 2)] == 1);
+    CHECK(lv.node_level[index_of(plan.plan, 3)] == 2);
+    CHECK(lv.node_level[index_of(plan.plan, 4)] == 3);
+    // Each level holds exactly one node.
+    for (std::uint32_t l = 0; l < lv.level_count; ++l) {
+        CHECK(lv.level_offsets[l + 1] - lv.level_offsets[l] == 1);
+    }
+}
+
+TEST_CASE("Levelization: a diamond's parallel arms share a level",
+          "[graph][levelization]") {
+    // in -> {g1, g2} -> out. g1 and g2 are independent -> same level (1).
+    const std::array nodes = {
+        node(1, 0, 1, GraphRuntimeNodeKind::AudioInput),
+        node(2, 1, 1),
+        node(3, 1, 1),
+        node(4, 1, 0, GraphRuntimeNodeKind::AudioOutput),
+    };
+    const std::array conns = {
+        GraphRuntimeConnectionSpec{1, 0, 2, 0},
+        GraphRuntimeConnectionSpec{1, 0, 3, 0},
+        GraphRuntimeConnectionSpec{2, 0, 4, 0},
+        GraphRuntimeConnectionSpec{3, 0, 4, 0},
+    };
+    const auto plan = build_graph_runtime_plan(nodes, conns);
+    REQUIRE(plan.ok());
+    const auto lv = build_graph_runtime_levelization(plan.plan);
+    check_invariants(plan.plan, lv);
+    CHECK(lv.level_count == 3);
+    CHECK(lv.node_level[index_of(plan.plan, 1)] == 0);
+    CHECK(lv.node_level[index_of(plan.plan, 2)] == 1);
+    CHECK(lv.node_level[index_of(plan.plan, 3)] == 1);  // shares level with g2
+    CHECK(lv.node_level[index_of(plan.plan, 4)] == 2);
+    // Level 1 holds both parallel arms.
+    CHECK(lv.level_offsets[2] - lv.level_offsets[1] == 2);
+}
+
+TEST_CASE("Levelization: an unbalanced fan-in takes the longest path",
+          "[graph][levelization]") {
+    // in -> a -> b -> out, and in -> out directly. `out` depends on both b
+    // (level 2) and in (level 0), so out is level 3 (longest chain wins).
+    const std::array nodes = {
+        node(1, 0, 1, GraphRuntimeNodeKind::AudioInput),
+        node(2, 1, 1),
+        node(3, 1, 1),
+        node(4, 1, 0, GraphRuntimeNodeKind::AudioOutput),
+    };
+    const std::array conns = {
+        GraphRuntimeConnectionSpec{1, 0, 2, 0},  // in -> a
+        GraphRuntimeConnectionSpec{2, 0, 3, 0},  // a -> b
+        GraphRuntimeConnectionSpec{3, 0, 4, 0},  // b -> out
+        GraphRuntimeConnectionSpec{1, 0, 4, 0},  // in -> out (short path)
+    };
+    const auto plan = build_graph_runtime_plan(nodes, conns);
+    REQUIRE(plan.ok());
+    const auto lv = build_graph_runtime_levelization(plan.plan);
+    check_invariants(plan.plan, lv);
+    CHECK(lv.node_level[index_of(plan.plan, 4)] == 3);
+}
+
+TEST_CASE("Levelization: a feedback edge does not raise a level",
+          "[graph][levelization]") {
+    // in -> a -> out, plus a feedback edge a -> a. The feedback edge reads the
+    // previous block, so it must not affect a's level (would otherwise be a
+    // self-cycle). a stays level 1.
+    const std::array nodes = {
+        node(1, 0, 1, GraphRuntimeNodeKind::AudioInput),
+        node(2, 1, 1),
+        node(3, 1, 0, GraphRuntimeNodeKind::AudioOutput),
+    };
+    const std::array conns = {
+        GraphRuntimeConnectionSpec{1, 0, 2, 0},
+        GraphRuntimeConnectionSpec{2, 0, 3, 0},
+        GraphRuntimeConnectionSpec{2, 0, 2, 0, /*feedback=*/true},
+    };
+    const auto plan = build_graph_runtime_plan(nodes, conns);
+    REQUIRE(plan.ok());
+    const auto lv = build_graph_runtime_levelization(plan.plan);
+    check_invariants(plan.plan, lv);
+    CHECK(lv.node_level[index_of(plan.plan, 2)] == 1);
+    CHECK(lv.level_count == 3);
+}
+
+TEST_CASE("Levelization: an empty plan is a valid zero-level schedule",
+          "[graph][levelization]") {
+    const auto plan = build_graph_runtime_plan({}, {});
+    REQUIRE(plan.ok());
+    const auto lv = build_graph_runtime_levelization(plan.plan);
+    REQUIRE(lv.ok);
+    CHECK(lv.level_count == 0);
+    CHECK(lv.node_level.empty());
+    CHECK(lv.level_nodes.empty());
+    REQUIRE(lv.level_offsets.size() == 1);
+    CHECK(lv.level_offsets[0] == 0);
+}


### PR DESCRIPTION
First Phase-5 substrate slice. Adds `build_graph_runtime_levelization(plan)` — a pure off-RT pass that assigns each node a parallel **level** (0 for sources; otherwise one more than the max level of any node it depends on through a non-feedback connection) and a CSR grouping of nodes by level.

Per masterwork §6.1, static multicore starts by precomputing the schedule off-RT in `core/graph`. Same-level nodes are mutually independent and parallelizable; feedback edges are excluded (they read the previous block, so they never raise a level or create a cycle). **No execution change** — the serial executor's processing order already respects dependencies; the future levelized-multicore executor consumes this behind the canonical seam (default-OFF). Consumed by unit tests now (substrate-first, mirroring 4a).

## Tests
linear chain (one node per ascending level), diamond (parallel arms share a level), unbalanced fan-in (longest path wins), feedback edge (does not raise a level), empty plan (zero-level schedule); plus partition invariants — every non-feedback edge runs strictly lower→higher level, and the CSR grouping places every node exactly once at its own level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an off-RT levelization pass to precompute parallel execution levels and a CSR grouping for static multicore scheduling. No runtime behavior changes; the serial executor is unchanged and tests consume the new pass.

- **New Features**
  - Added `build_graph_runtime_levelization(plan)` to assign each node a level (longest non-feedback path) and build CSR groups by level.
  - Ignores feedback edges; nodes at the same level are independent and parallelizable. Stable node order within each level.
  - Integrated into `pulp-graph`; bumped project version to 0.481.0.

<sup>Written for commit 872b6a77391914708bf3903e3d4c7cd539a2cf80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

