### PR TITLE
feat(format): persistent fork-join worker pool for the levelized parallel executor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.481.0
+    VERSION 0.482.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/CMakeLists.txt
+++ b/core/format/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(pulp-format PRIVATE
     src/offline_sample_bounce.cpp
     src/offline_sample_slot_bounce.cpp
     src/graph_runtime_executor.cpp
+    src/graph_runtime_worker_pool.cpp
     src/plugin_state_io.cpp
     src/processor_block_adapter.cpp
     src/processor_node_adapter.cpp

--- a/core/format/include/pulp/format/graph_runtime_worker_pool.hpp
+++ b/core/format/include/pulp/format/graph_runtime_worker_pool.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <thread>
+#include <vector>
+
+namespace pulp::format {
+
+/// Persistent fork-join worker pool for the levelized parallel graph executor.
+///
+/// Threads are spawned once at start() (off the audio thread) and parked on a
+/// bounded atomic until run() publishes a batch. run() executes `task_count`
+/// tasks across the pool's threads PLUS the calling (audio) thread, then returns
+/// when every task has completed — no allocation, no lock, no condition variable
+/// in run(). It is the persistent-worker / epoch-publish / bounded-atomic
+/// pattern (masterwork §6.1): the audio callback owns the fork-join, workers
+/// never allocate or steal.
+///
+/// Tasks are claimed cooperatively via an atomic cursor, so a task is a small
+/// index the caller maps to a unit of work (e.g. a node in the current level).
+/// The same pool is reused across blocks. Idle workers spin with a yield-backoff
+/// (a refinement to OS-park / device-workgroup join is left to a later slice).
+///
+/// Lifetime: start()/stop() are control-thread only. run() is audio-thread only
+/// and must not overlap a stop(). A run_fn must be RT-safe (no alloc/lock) — the
+/// pool only provides the fork-join, not RT-safety of the work itself.
+class GraphRuntimeWorkerPool {
+public:
+    using TaskFn = void (*)(void* context, std::uint32_t task_index) noexcept;
+
+    GraphRuntimeWorkerPool() = default;
+    ~GraphRuntimeWorkerPool();
+
+    GraphRuntimeWorkerPool(const GraphRuntimeWorkerPool&) = delete;
+    GraphRuntimeWorkerPool& operator=(const GraphRuntimeWorkerPool&) = delete;
+
+    // Off-RT: spawn `worker_count` total participants (worker_count - 1 threads;
+    // the caller of run() is the worker_count-th). worker_count <= 1 means run()
+    // executes everything inline on the caller with no threads. Re-start() after
+    // stop(). Returns false on an invalid count or thread-spawn failure.
+    bool start(std::uint32_t worker_count);
+
+    // Off-RT: signal and join all worker threads. Idempotent.
+    void stop() noexcept;
+
+    std::uint32_t worker_count() const noexcept { return worker_count_; }
+    bool running() const noexcept { return running_.load(std::memory_order_acquire); }
+
+    // RT-safe: run `fn(context, i)` for every i in [0, task_count) exactly once,
+    // distributed across the pool threads and the calling thread, and return only
+    // after all have completed. Allocation-free and lock-free. With no worker
+    // threads (worker_count <= 1) it simply runs them inline on the caller.
+    void run(std::uint32_t task_count, TaskFn fn, void* context) noexcept;
+
+private:
+    void worker_loop(std::uint32_t worker_index) noexcept;
+    // Run this worker's STATIC contiguous task range for the current batch and
+    // add its size to the completion counter. Static partitioning (no shared
+    // claim cursor) means a lagging worker can never re-claim tasks after run()
+    // publishes the next batch — run() returns only once completed_ == task_count
+    // (every worker's add is done), so the next batch's counter reset is safe.
+    void run_range(std::uint32_t worker_index) noexcept;
+
+    std::vector<std::thread> threads_;
+    std::uint32_t worker_count_ = 0;
+
+    // Published batch (valid for the current epoch). Written by run() before the
+    // epoch bump (release), read by workers after observing the new epoch
+    // (acquire).
+    TaskFn fn_ = nullptr;
+    void* context_ = nullptr;
+    std::uint32_t task_count_ = 0;
+
+    // Epoch a worker waits on; bumped by run() to publish a batch. stop() bumps
+    // it with `stopping_` set so workers exit.
+    std::atomic<std::uint64_t> epoch_{0};
+    std::atomic<bool> stopping_{false};
+    std::atomic<bool> running_{false};
+
+    // MONOTONIC count of tasks completed across all batches (each worker adds its
+    // range size with release; the caller acquire-waits until it reaches the
+    // batch target). Never reset — a reset would race a lagging worker's add from
+    // the previous batch. 64-bit so it never wraps in a long session.
+    std::atomic<std::uint64_t> completed_{0};
+    // The value of completed_ before the current batch (caller-only scratch, so
+    // the per-batch target is completed_base_ + task_count_).
+    std::uint64_t completed_base_ = 0;
+
+    // Debug-only guard asserting run() is never called re-entrantly / from two
+    // threads at once — the load-bearing invariant the lock-free barrier relies
+    // on. Compiled out (and never touched) in release builds.
+    std::atomic<bool> in_run_{false};
+};
+
+} // namespace pulp::format

--- a/core/format/src/graph_runtime_worker_pool.cpp
+++ b/core/format/src/graph_runtime_worker_pool.cpp
@@ -1,0 +1,148 @@
+#include <pulp/format/graph_runtime_worker_pool.hpp>
+
+#include <cassert>
+
+namespace pulp::format {
+namespace {
+
+// Even static split of [0, count) across `workers` participants: participant w
+// owns [w*count/workers, (w+1)*count/workers). Balanced to within one task.
+struct Range {
+    std::uint32_t begin;
+    std::uint32_t end;
+};
+Range range_for(std::uint32_t worker_index, std::uint32_t workers,
+                std::uint32_t count) noexcept {
+    const std::uint64_t c = count;
+    const std::uint32_t begin =
+        static_cast<std::uint32_t>(c * worker_index / workers);
+    const std::uint32_t end =
+        static_cast<std::uint32_t>(c * (worker_index + 1) / workers);
+    return {begin, end};
+}
+
+} // namespace
+
+GraphRuntimeWorkerPool::~GraphRuntimeWorkerPool() { stop(); }
+
+bool GraphRuntimeWorkerPool::start(std::uint32_t worker_count) {
+    stop();
+    if (worker_count == 0) return false;
+    worker_count_ = worker_count;
+    stopping_.store(false, std::memory_order_release);
+    epoch_.store(0, std::memory_order_release);
+    completed_.store(0, std::memory_order_release);
+    completed_base_ = 0;
+    // worker_count includes the run() caller as participant 0; spawn the rest.
+    if (worker_count_ <= 1) {
+        running_.store(true, std::memory_order_release);
+        return true;
+    }
+    try {
+        threads_.reserve(worker_count_ - 1);
+        for (std::uint32_t w = 1; w < worker_count_; ++w) {
+            threads_.emplace_back([this, w] { worker_loop(w); });
+        }
+    } catch (...) {
+        stop();
+        return false;
+    }
+    running_.store(true, std::memory_order_release);
+    return true;
+}
+
+void GraphRuntimeWorkerPool::stop() noexcept {
+    if (!threads_.empty()) {
+        // Park-loop workers re-check stopping_ each iteration, so setting it is
+        // enough to release them; bump the epoch too so a worker blocked on the
+        // epoch wait observes a change immediately.
+        stopping_.store(true, std::memory_order_release);
+        epoch_.fetch_add(1, std::memory_order_release);
+        for (auto& t : threads_) {
+            if (t.joinable()) t.join();
+        }
+        threads_.clear();
+    }
+    worker_count_ = 0;
+    running_.store(false, std::memory_order_release);
+}
+
+void GraphRuntimeWorkerPool::run(std::uint32_t task_count, TaskFn fn,
+                                 void* context) noexcept {
+    if (task_count == 0 || fn == nullptr) return;
+    // No worker threads: run everything inline on the caller.
+    if (worker_count_ <= 1 || threads_.empty()) {
+        for (std::uint32_t i = 0; i < task_count; ++i) fn(context, i);
+        return;
+    }
+
+    // run() must not overlap another run() (the lock-free barrier's correctness
+    // depends on serialized batches); enforce it loudly in debug builds.
+    assert(!in_run_.exchange(true, std::memory_order_relaxed) &&
+           "GraphRuntimeWorkerPool::run() is not re-entrant and must not run concurrently");
+
+    // Publish the batch, then release it to the parked workers via the epoch.
+    // completed_ is monotonic: this batch is done when it reaches base + count.
+    const std::uint64_t target = completed_base_ + task_count;
+    fn_ = fn;
+    context_ = context;
+    task_count_ = task_count;
+    epoch_.fetch_add(1, std::memory_order_release);
+
+    // The caller is participant 0.
+    run_range(0);
+
+    // Spin until every participant has added its range (all task writes are then
+    // visible via the completed_ acquire/release barrier).
+    // `< target` (not `!=`): completed_ reaches target exactly, but a `<` guard
+    // can never deadlock the spin if the count ever overshoots.
+    std::uint32_t spins = 0;
+    while (completed_.load(std::memory_order_acquire) < target) {
+        if (++spins < 1024) {
+#if defined(__x86_64__) || defined(_M_X64)
+            __builtin_ia32_pause();
+#elif defined(__aarch64__)
+            __asm__ __volatile__("yield");
+#endif
+        } else {
+            std::this_thread::yield();
+            spins = 0;
+        }
+    }
+    completed_base_ = target;
+    assert((in_run_.store(false, std::memory_order_relaxed), true));
+}
+
+void GraphRuntimeWorkerPool::run_range(std::uint32_t worker_index) noexcept {
+    const Range r = range_for(worker_index, worker_count_, task_count_);
+    for (std::uint32_t i = r.begin; i < r.end; ++i) {
+        fn_(context_, i);
+    }
+    completed_.fetch_add(r.end - r.begin, std::memory_order_acq_rel);
+}
+
+void GraphRuntimeWorkerPool::worker_loop(std::uint32_t worker_index) noexcept {
+    std::uint64_t local_epoch = 0;
+    for (;;) {
+        std::uint32_t spins = 0;
+        std::uint64_t e;
+        while ((e = epoch_.load(std::memory_order_acquire)) == local_epoch) {
+            if (stopping_.load(std::memory_order_acquire)) return;
+            if (++spins < 1024) {
+#if defined(__x86_64__) || defined(_M_X64)
+                __builtin_ia32_pause();
+#elif defined(__aarch64__)
+                __asm__ __volatile__("yield");
+#endif
+            } else {
+                std::this_thread::yield();
+                spins = 0;
+            }
+        }
+        local_epoch = e;
+        if (stopping_.load(std::memory_order_acquire)) return;
+        run_range(worker_index);
+    }
+}
+
+} // namespace pulp::format

--- a/test/cmake/sampler_runtime_tests.cmake
+++ b/test/cmake/sampler_runtime_tests.cmake
@@ -46,6 +46,10 @@ pulp_add_test_suite(pulp-test-graph-executor-parity
 pulp_add_test_suite(pulp-test-graph-runtime-buffer-assignment LIBRARIES pulp::graph)
 # Off-RT levelization (parallel-schedule levels) for static multicore.
 pulp_add_test_suite(pulp-test-graph-runtime-levelization LIBRARIES pulp::graph)
+# Persistent fork-join worker pool for the levelized parallel executor.
+pulp_add_test_suite(pulp-test-graph-runtime-worker-pool
+    SOURCES test_graph_runtime_worker_pool.cpp harness/rt_allocation_probe.cpp
+    LIBRARIES pulp::format)
 # Executor routing path moves audio between nodes (chain/diamond/feedback/
 # multi-output parity vs SignalGraph) and is allocation-free on the RT thread.
 pulp_add_test_suite(pulp-test-graph-executor-routing

--- a/test/test_graph_runtime_worker_pool.cpp
+++ b/test/test_graph_runtime_worker_pool.cpp
@@ -1,0 +1,148 @@
+// Coverage for the persistent fork-join worker pool the levelized parallel
+// executor uses. Verifies every task in a batch runs exactly once, results are
+// visible to the caller after run() returns, batches reuse the pool without
+// races (run under TSan in CI), and the inline (no-thread) path works.
+
+#include "harness/rt_allocation_probe.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/format/graph_runtime_worker_pool.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <numeric>
+#include <vector>
+
+namespace {
+
+using pulp::format::GraphRuntimeWorkerPool;
+
+struct SquareCtx {
+    std::vector<std::uint32_t> out;
+    std::atomic<std::uint32_t> runs{0};
+};
+
+// Each task writes its own slot (disjoint — the executor's model) and bumps a
+// shared run counter so a double-run or missed-run is detectable.
+void square_task(void* ctx, std::uint32_t i) noexcept {
+    auto* c = static_cast<SquareCtx*>(ctx);
+    c->out[i] = i * i;
+    c->runs.fetch_add(1, std::memory_order_relaxed);
+}
+
+} // namespace
+
+TEST_CASE("WorkerPool runs every task in a batch exactly once",
+          "[format][worker-pool]") {
+    for (std::uint32_t workers : {1u, 2u, 4u, 8u}) {
+        GraphRuntimeWorkerPool pool;
+        REQUIRE(pool.start(workers));
+        REQUIRE(pool.worker_count() == workers);
+
+        constexpr std::uint32_t kTasks = 1000;
+        SquareCtx ctx;
+        ctx.out.assign(kTasks, 0xFFFFFFFFu);
+        pool.run(kTasks, square_task, &ctx);
+
+        CHECK(ctx.runs.load() == kTasks);  // each task ran exactly once
+        for (std::uint32_t i = 0; i < kTasks; ++i) {
+            CHECK(ctx.out[i] == i * i);  // results visible after run() returns
+        }
+        pool.stop();
+    }
+}
+
+TEST_CASE("WorkerPool reuses the pool across many batches without races",
+          "[format][worker-pool]") {
+    GraphRuntimeWorkerPool pool;
+    REQUIRE(pool.start(4));
+    // Smaller and larger batches, including counts below the worker count and
+    // odd counts that produce uneven static ranges.
+    for (std::uint32_t batch = 0; batch < 200; ++batch) {
+        const std::uint32_t kTasks = (batch % 7) + 1 + (batch % 13) * 9;
+        SquareCtx ctx;
+        ctx.out.assign(kTasks, 0xFFFFFFFFu);
+        pool.run(kTasks, square_task, &ctx);
+        REQUIRE(ctx.runs.load() == kTasks);
+        for (std::uint32_t i = 0; i < kTasks; ++i) REQUIRE(ctx.out[i] == i * i);
+    }
+    pool.stop();
+}
+
+TEST_CASE("WorkerPool with a single participant runs inline",
+          "[format][worker-pool]") {
+    GraphRuntimeWorkerPool pool;
+    REQUIRE(pool.start(1));  // caller is the only participant; no threads
+    SquareCtx ctx;
+    ctx.out.assign(64, 0);
+    pool.run(64, square_task, &ctx);
+    CHECK(ctx.runs.load() == 64);
+    for (std::uint32_t i = 0; i < 64; ++i) CHECK(ctx.out[i] == i * i);
+    pool.stop();
+}
+
+TEST_CASE("WorkerPool run() is allocation-free on the calling thread",
+          "[format][worker-pool][rt-safety]") {
+    GraphRuntimeWorkerPool pool;
+    REQUIRE(pool.start(4));
+    SquareCtx ctx;
+    ctx.out.assign(256, 0);
+    pool.run(256, square_task, &ctx);  // warm up the threads outside the probe
+    {
+        pulp::test::RtAllocationProbe probe;
+        pool.run(256, square_task, &ctx);
+        CHECK_FALSE(probe.saw_allocation());
+    }
+    pool.stop();
+}
+
+TEST_CASE("WorkerPool run() with zero tasks is a no-op",
+          "[format][worker-pool]") {
+    GraphRuntimeWorkerPool pool;
+    REQUIRE(pool.start(4));
+    SquareCtx ctx;
+    ctx.out.assign(4, 7);
+    pool.run(0, square_task, &ctx);
+    CHECK(ctx.runs.load() == 0);
+    pool.stop();
+}
+
+TEST_CASE("WorkerPool oversubscribes more workers than cores",
+          "[format][worker-pool]") {
+    // Far more participants than hardware cores stresses the yield-backoff slow
+    // path and oversubscription, where a lost wakeup or starvation would surface.
+    GraphRuntimeWorkerPool pool;
+    REQUIRE(pool.start(64));
+    for (std::uint32_t batch = 0; batch < 20; ++batch) {
+        SquareCtx ctx;
+        ctx.out.assign(500, 0xFFFFFFFFu);
+        pool.run(500, square_task, &ctx);
+        REQUIRE(ctx.runs.load() == 500);
+        for (std::uint32_t i = 0; i < 500; ++i) REQUIRE(ctx.out[i] == i * i);
+    }
+    pool.stop();
+}
+
+TEST_CASE("WorkerPool restarts cleanly after stop",
+          "[format][worker-pool]") {
+    GraphRuntimeWorkerPool pool;
+    for (int cycle = 0; cycle < 3; ++cycle) {
+        REQUIRE(pool.start(4));
+        SquareCtx ctx;
+        ctx.out.assign(300, 0xFFFFFFFFu);
+        pool.run(300, square_task, &ctx);
+        CHECK(ctx.runs.load() == 300);
+        for (std::uint32_t i = 0; i < 300; ++i) CHECK(ctx.out[i] == i * i);
+        pool.stop();
+    }
+}
+
+TEST_CASE("WorkerPool stop is idempotent",
+          "[format][worker-pool]") {
+    GraphRuntimeWorkerPool pool;
+    REQUIRE(pool.start(4));
+    pool.stop();
+    pool.stop();  // second stop is a no-op, not a crash
+    CHECK_FALSE(pool.running());
+}


### PR DESCRIPTION
Phase-5 slice 5b-2. Adds `GraphRuntimeWorkerPool` — the persistent-worker / epoch-publish / bounded-atomic fork-join the static-multicore graph executor will use (masterwork §6.1).

## What
- `start(N)` spawns N-1 threads off the audio thread; `run(task_count, fn, ctx)` wakes the parked workers via a release epoch bump, runs the batch across the workers **plus the calling (audio) thread** via a static contiguous range partition, and returns once every participant has completed — **no allocation, no lock, no condition variable** in `run()`. Idle workers spin with a yield-backoff (OS-park / device-workgroup join is a later refinement, flagged in the header).
- Completion is a **monotonic 64-bit counter** compared against a cumulative per-batch target, not a per-batch reset. An earlier reset-to-zero draft raced a lagging worker's add from the prior batch (**caught by TSan**); the monotonic counter removes the reset entirely. The barrier's acquire load synchronizes with every participant's release add (a release sequence over the RMW chain), so all task writes are visible after `run()` returns.

**Not yet wired to any executor** — standalone primitive (default-OFF by absence of a caller), consumed by tests. 5b-3 wires it into `process_parallel`.

## Tests (TSan-clean, 5×+)
exactly-once across worker counts; visibility after return; 200-batch reuse with uneven/odd/below-worker-count sizes; inline single-participant path; **64-worker oversubscription**; restart-after-stop; idempotent stop; `run()` no-alloc probe; zero-task no-op. A debug-only re-entrancy assert enforces the serialized-`run()` invariant.

Adversarially reviewed (concurrency-focused): no MUST-FIX; the release-sequence memory-ordering core was verified correct. Applied all SHOULD-FIX (debug re-entrancy guard, defensive `>=` spin, oversubscription/restart/idempotency tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a persistent fork-join worker pool for the levelized parallel graph executor. Batches run across worker threads plus the calling audio thread with no allocation or locks in `run()`, improving RT safety and preparing for multicore processing.

- **New Features**
  - Added `GraphRuntimeWorkerPool` with `start(N)`, `run(task_count, fn, ctx)`, and `stop()`.
  - Static range split across workers + caller; inline path when N ≤ 1.
  - Monotonic 64-bit completion counter with acquire/release barrier for visibility on return.
  - Yield-backoff when idle; restart supported; stop is idempotent.
  - Not yet wired to the executor; tests cover exactly-once, reuse across batches, oversubscription, RT no-alloc, and zero-task no-op.

<sup>Written for commit 791739150d2a0d9aaf1824ae6ddd7048a98fc1ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/pulp/pull/4801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

